### PR TITLE
Enable prettier for build/

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,32 +1,7 @@
-# Ignored files identified within .gitignore:
-/vendor/*
-/components/brave_new_tab_ui/data/LICENSE
-/components/brave_webtorrent/extension/out/
-/components/brave_rewards/resources/extension/brave_rewards/out/
-/components/third_party/adblock/LICENSE
-/components/third_party/local_data/LICENSE
-/dist/
-/out/
-node_modules/
-/third_party/
-.vs/
-.vscode/
-.npmrc
-.env
-cmake-build-debug/
-coverage/
-/build/rustup/
-venv/
-.storybook-out
-
-# Ignore version control files
-**/.git
-**/.svn
-**/.hg
-
-# Ignore node_modules
-**/node_modules
-
+# Don't add paths that are already ignored in .gitignore:
+# npm run format/presubmit does it automatically.
+# For manual run use :
+# npx prettier --ignore-path .prettierignore --ignore-path .gitignore .
 
 # Ignore HTML Files - incompatable with presubmit rules
 *.html
@@ -48,9 +23,7 @@ venv/
 /installer
 /ios
 /mojo
-/mojo/brave_ast_patcher
 /net
-/node_modules
 /patches
 /renderer
 /resources
@@ -64,8 +37,8 @@ venv/
 /utility
 /v8
 /vector_icons
-/vendor
 /win_build_output
+/.storybook/
 
 # Ignore github .yml files:
 .github/**/*.yml
@@ -78,6 +51,8 @@ README.md
 # Ignored top-level files:
 .clang-tidy
 chromium_presubmit_config.json5
+jest.config.js
+snapcraft.yaml
 
 # Ignored minified javascript
 components/brave_wallet/resources/solana_web3_script.js
@@ -122,9 +97,3 @@ components/brave_wallet/resources/solana_web3_script.js
 /components/test/
 /components/translate/
 /components/variations/
-
-# Ignore other files
-.eslintrc.js
-/.storybook/
-jest.config.js
-snapcraft.yaml

--- a/.prettierignore
+++ b/.prettierignore
@@ -81,3 +81,50 @@ chromium_presubmit_config.json5
 
 # Ignored minified javascript
 components/brave_wallet/resources/solana_web3_script.js
+
+# Ignore components folders with a lot of formatting issues
+/components/ai_chat/
+/components/ai_rewriter/
+/components/brave_new_tab_ui/
+/components/brave_rewards/
+/components/brave_wallet_ui/
+/components/brave_shields/
+/components/brave_vpn/
+/components/brave_news/
+/components/web-components/
+/components/brave_welcome_ui/
+/components/brave_adblock_ui/
+/components/brave_ads/
+/components/brave_extension/
+/components/brave_perf_predictor/
+/components/brave_private_new_tab_ui/
+/components/policy/resources/templates/
+/components/playlist/
+/components/speedreader/
+/components/brave_webtorrent/
+/components/common/
+/components/cosmetic_filters/
+/components/definitions/
+/components/new_tab_takeover/
+/components/skus/
+/components/tor/
+/components/webcompat_reporter/
+/components/webpack/
+/components/browser_ui/
+/components/decentralized_dns/
+/components/embedder_support/
+/components/flags_ui/
+/components/permissions/
+/components/request_otr/
+/components/safe_browsing/
+/components/security_interstitials/
+/components/signin/
+/components/test/
+/components/translate/
+/components/variations/
+
+# Ignore other files
+.eslintrc.js
+/.storybook/
+jest.config.js
+snapcraft.yaml

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -28,5 +28,13 @@ module.exports = {
   'vueIndentScriptAndStyle': false,
   'jsxBracketSameLine': false,
   'singleAttributePerLine': true,
-  'overrides': undefined
+  'overrides': [
+    {
+      // Allow longer lines in this file until we properly format it
+      files: 'build/commands/lib/utils.js',
+      options: {
+        printWidth: 160
+      }
+    }
+  ]
 }

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -28,13 +28,4 @@ module.exports = {
   'vueIndentScriptAndStyle': false,
   'jsxBracketSameLine': false,
   'singleAttributePerLine': true,
-  'overrides': [
-    {
-      // Allow longer lines in this file until we properly format it
-      files: 'build/commands/lib/utils.js',
-      options: {
-        printWidth: 160
-      }
-    }
-  ]
 }

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -27,5 +27,5 @@ module.exports = {
   'useTabs': false,
   'vueIndentScriptAndStyle': false,
   'jsxBracketSameLine': false,
-  'singleAttributePerLine': true,
+  'singleAttributePerLine': true
 }

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -26,6 +26,6 @@ module.exports = {
   'requirePragma': false,
   'useTabs': false,
   'vueIndentScriptAndStyle': false,
-  'jsxBracketSameLine': false,
+  'bracketSameLine': false,
   'singleAttributePerLine': true
 }

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -19,7 +19,6 @@ module.exports = {
   'htmlWhitespaceSensitivity': 'css',
   'insertPragma': false,
   'plugins': [],
-  'pluginSearchDirs': false,
   'printWidth': 80,
   'proseWrap': 'always',
   'rangeEnd': Infinity,

--- a/PRESUBMIT.py
+++ b/PRESUBMIT.py
@@ -61,8 +61,9 @@ def CheckPatchFormatted(input_api, output_api):
         return []
     except RuntimeError as err:
         return [
-            f'The code requires formatting. '
-            f'Please run: npm run presubmit -- --fix.\n\n{err.args[1]}'
+            output_api.PresubmitError(
+                f'The code requires formatting. '
+                f'Please run: npm run presubmit -- --fix.\n\n{err.args[1]}')
         ]
 
 

--- a/PRESUBMIT.py
+++ b/PRESUBMIT.py
@@ -54,8 +54,7 @@ def CheckLeoVariables(input_api, output_api):
 # Check and fix formatting issues (supports --fix).
 def CheckPatchFormatted(input_api, output_api):
     cmd = [
-        'build/commands/scripts/commands.js',
-        'format',
+        'build/commands/scripts/format.js',
     ]
     if not input_api.PRESUBMIT_FIX:
         cmd.append('--diff')

--- a/PRESUBMIT.py
+++ b/PRESUBMIT.py
@@ -61,8 +61,8 @@ def CheckPatchFormatted(input_api, output_api):
         return []
     except RuntimeError as err:
         return [
-            output_api.PresubmitError(
-                err.args[1] + '\nPlease run: npm run presubmit -- --fix.')
+            f'The code requires formatting. '
+            f'Please run: npm run presubmit -- --fix.\n\n{err.args[1]}'
         ]
 
 

--- a/PRESUBMIT.py
+++ b/PRESUBMIT.py
@@ -53,7 +53,10 @@ def CheckLeoVariables(input_api, output_api):
 
 # Check and fix formatting issues (supports --fix).
 def CheckPatchFormatted(input_api, output_api):
-    cmd = ['build/commands/scripts/format.js', '--presubmit']
+    cmd = [
+        brave_chromium_utils.wspath(
+            '//brave/build/commands/scripts/format.js'), '--presubmit'
+    ]
     if not input_api.PRESUBMIT_FIX:
         cmd.append('--dry-run')
     try:

--- a/PRESUBMIT.py
+++ b/PRESUBMIT.py
@@ -53,93 +53,20 @@ def CheckLeoVariables(input_api, output_api):
 
 # Check and fix formatting issues (supports --fix).
 def CheckPatchFormatted(input_api, output_api):
-    # Use git cl format to format supported files with Chromium formatters.
-    git_cl_format_cmd = [
-        '-C',
-        input_api.change.RepositoryRoot(),
-        'cl',
+    cmd = [
+        'build/commands/scripts/commands.js',
         'format',
-        '--presubmit',
     ]
-
-    # Keep in sync with `npm run format` command.
-    git_cl_format_cmd.extend([
-        '--python',
-        '--no-rust-fmt',
-    ])
-
-    # Make sure the passed --upstream branch is applied to git cl format.
-    if input_api.change.UpstreamBranch():
-        git_cl_format_cmd.extend(
-            ['--upstream', input_api.change.UpstreamBranch()])
-
-    # Do a dry run if --fix was not passed.
     if not input_api.PRESUBMIT_FIX:
-        git_cl_format_cmd.append('--dry-run')
-
-    # Pass a path where the current PRESUBMIT.py file is located.
-    git_cl_format_cmd.append(input_api.PresubmitLocalPath())
-
-    with brave_chromium_utils.sys_path("//brave/vendor/depot_tools"):
-        import git_cl
-
-    # Run git cl format and get return code.
-    git_cl_format_code, _ = git_cl.RunGitWithCode(git_cl_format_cmd)
-    if git_cl_format_code not in (0, 2):
+        cmd.append('--diff')
+    try:
+        brave_node.RunNode(cmd)
+        return []
+    except RuntimeError as err:
         return [
             output_api.PresubmitError(
-                f'Presubmit format check has failed, return code: {git_cl_format_code}'
-            )
+                err.args[1] + '\nPlease run: npm run presubmit -- --fix.')
         ]
-
-    is_format_required = git_cl_format_code == 2
-
-    if not is_format_required or input_api.PRESUBMIT_FIX:
-        # Use Prettier to format other file types.
-        files_to_check = (
-            # Enable when files will be formatted.
-            # r'.+\.js$',
-            # r'.+\.ts$',
-            # r'.+\.tsx$',
-        )
-        files_to_skip = input_api.DEFAULT_FILES_TO_SKIP
-
-        file_filter = lambda f: input_api.FilterSourceFile(
-            f, files_to_check=files_to_check, files_to_skip=files_to_skip)
-        affected_files = input_api.AffectedFiles(file_filter=file_filter,
-                                                 include_deletes=False)
-        files_to_format = [f.AbsoluteLocalPath() for f in affected_files]
-
-        node_args = [
-            brave_node.PathInNodeModules('prettier', 'bin-prettier'),
-            '--write' if input_api.PRESUBMIT_FIX else '--check',
-        ]
-
-        files_per_command = 25 if input_api.is_windows else 1000
-        for i in range(0, len(files_to_format), files_per_command):
-            args = node_args + files_to_format[i:i + files_per_command]
-            try:
-                brave_node.RunNode(args)
-            except RuntimeError as err:
-                if 'Forgot to run Prettier?' in str(err):
-                    is_format_required = True
-                    break
-                # Raise on unexpected output. Could be node or prettier issues.
-                raise
-
-    if is_format_required:
-        if input_api.PRESUBMIT_FIX:
-            raise RuntimeError('--fix was passed, but format has failed')
-        short_path = input_api.basename(input_api.change.RepositoryRoot())
-        git_cl_format_cmd.remove('--dry-run')
-        git_cl_format_cmd.append('--diff')
-        _, diff_output = git_cl.RunGitWithCode(git_cl_format_cmd)
-        return [
-            output_api.PresubmitError(
-                f'The {short_path} directory requires source formatting. '
-                f'Please run: npm run presubmit -- --fix.\n\n{diff_output}')
-        ]
-    return []
 
 
 # Check and fix ESLint issues (supports --fix).

--- a/PRESUBMIT.py
+++ b/PRESUBMIT.py
@@ -53,11 +53,9 @@ def CheckLeoVariables(input_api, output_api):
 
 # Check and fix formatting issues (supports --fix).
 def CheckPatchFormatted(input_api, output_api):
-    cmd = [
-        'build/commands/scripts/format.js',
-    ]
+    cmd = ['build/commands/scripts/format.js', '--presubmit']
     if not input_api.PRESUBMIT_FIX:
-        cmd.append('--diff')
+        cmd.append('--dry-run')
     try:
         brave_node.RunNode(cmd)
         return []

--- a/build/commands/lib/format.js
+++ b/build/commands/lib/format.js
@@ -1,0 +1,96 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+const path = require('path')
+const fs = require('fs-extra')
+const prettier = require('prettier')
+const config = require('./config')
+const util = require('./util')
+
+
+const mergeWithDefault = (options) => {
+  return Object.assign({}, config.defaultOptions, options)
+}
+
+// A function that formats the code in the current diff with base branch.
+// It uses git cl format and prettier, then aggregates the results.
+const runFormat = async (options = {}) => {
+  if (!options.base) {
+    options.base = 'origin/master'
+  }
+  let cmdOptions = config.defaultOptions
+  cmdOptions.cwd = config.braveCoreDir
+  cmdOptions = mergeWithDefault(cmdOptions)
+  cmd = 'git'
+  args = ['cl', 'format', '--upstream=' + options.base]
+
+  args.push('--python')
+  args.push('--no-rust-fmt')
+
+  if (options.full)
+    args.push('--full')
+  if (options.diff)
+    args.push('--diff')
+
+  const clFormatResult = util
+    .run(cmd, args, {
+      ...cmdOptions,
+      stdio: 'pipe'
+    })
+    .stdout.toString()
+
+  const changedFiles = util.getChangedFiles(options)
+  const prettierResult = await runPrettier(changedFiles, options.diff)
+
+  if (options.diff) {
+    let result = true
+    if (clFormatResult != '') {
+      console.error(clFormatResult)
+      console.error('git cl format failed')
+      result = false
+    }
+
+    if (prettierResult.length > 0) {
+      console.error(prettierResult.join('\n'))
+      console.error('Prettier check failed')
+      result = false
+    }
+
+    process.exit(result ? 0 : 1)
+  }
+}
+
+const runPrettier = async (files, diff) => {
+  const result = []
+  const options = require(path.join(config.braveCoreDir, '.prettierrc'))
+  for (const file of files) {
+    const fileInfo = await prettier.getFileInfo(file, {
+      ignorePath: path.join(config.braveCoreDir, '.prettierignore'),
+      withNodeModules: false
+    })
+
+    if (fileInfo.ignored || !fileInfo.inferredParser) {
+      continue
+    }
+
+    const content = fs.readFileSync(file, { encoding: 'utf-8' })
+    const formatted = await prettier.format(content, {
+      ...options,
+      parser: fileInfo.inferredParser
+    })
+    if (diff) {
+      if (content !== formatted) {
+        result.push(`${file} is not formatted`)
+      }
+    } else {
+      fs.writeFileSync(file, formatted)
+    }
+  }
+  return result
+}
+
+module.exports = {
+  runFormat,
+}

--- a/build/commands/lib/format.js
+++ b/build/commands/lib/format.js
@@ -46,7 +46,7 @@ const runFormat = async (options = {}) => {
 
   if (options.diff) {
     let result = true
-    if (clFormatResult != '') {
+    if (clFormatResult !== '') {
       console.error(clFormatResult)
       console.error('git cl format failed')
       result = false

--- a/build/commands/lib/util.js
+++ b/build/commands/lib/util.js
@@ -20,6 +20,65 @@ const ActionGuard = require('./actionGuard')
 // Do not limit the number of listeners to avoid warnings from EventEmitter.
 process.setMaxListeners(0);
 
+// Mapping for copying Brave's Android resource into chromium folder.
+// prettier-ignore
+const getCopyAndroidResourceMapping = () => {
+  const androidTranslateResSource = path.join(config.braveCoreDir, 'components', 'translate','content' , 'android', 'java', 'res')
+  const androidTranslateResDest = path.join(config.srcDir, 'components', 'translate','content' , 'android', 'java', 'res')
+  const androidIconSource = path.join(braveAppDir, 'theme', 'brave', 'android', androidIconSet)
+  const androidIconDest = path.join(config.srcDir, 'chrome', 'android', 'java', 'res_chromium')
+  const androidIconBaseSource = path.join(braveAppDir, 'theme', 'brave', 'android', androidIconSet + '_base')
+  const androidIconBaseDest = path.join(config.srcDir, 'chrome', 'android', 'java', 'res_chromium_base')
+  const androidResSource = path.join(config.braveCoreDir, 'android', 'java', 'res')
+  const androidResDest = path.join(config.srcDir, 'chrome', 'android', 'java', 'res')
+  const androidResTemplateSource = path.join(config.braveCoreDir, 'android', 'java', 'res_template')
+  const androidResTemplateDest = path.join(config.srcDir, 'chrome', 'android', 'java', 'res_template')
+  const androidContentPublicResSource = path.join(config.braveCoreDir, 'content', 'public', 'android', 'java', 'res')
+  const androidContentPublicResDest = path.join(config.srcDir, 'content', 'public', 'android', 'java', 'res')
+  const androidTouchtoFillResSource = path.join(config.braveCoreDir, 'browser', 'touch_to_fill', 'password_manager', 'android', 'internal', 'java', 'res')
+  const androidTouchtoFillResDest = path.join(config.srcDir, 'chrome', 'browser', 'touch_to_fill', 'password_manager', 'android', 'internal', 'java', 'res')
+  const androidToolbarResSource = path.join(config.braveCoreDir, 'browser', 'ui', 'android', 'toolbar', 'java', 'res')
+  const androidToolbarResDest = path.join(config.srcDir, 'chrome', 'browser', 'ui', 'android', 'toolbar', 'java', 'res')
+  const androidComponentsWidgetResSource = path.join(config.braveCoreDir, 'components', 'browser_ui', 'widget', 'android', 'java', 'res')
+  const androidComponentsWidgetResDest = path.join(config.srcDir, 'components', 'browser_ui', 'widget', 'android', 'java', 'res')
+  const androidComponentsStylesResSource = path.join(config.braveCoreDir, 'components', 'browser_ui', 'styles', 'android', 'java', 'res')
+  const androidComponentsStylesResDest = path.join(config.srcDir, 'components', 'browser_ui', 'styles', 'android', 'java', 'res')
+  const androidSafeBrowsingResSource = path.join(config.braveCoreDir, 'browser', 'safe_browsing', 'android', 'java', 'res')
+  const androidSafeBrowsingResDest = path.join(config.srcDir, 'chrome', 'browser', 'safe_browsing', 'android', 'java', 'res')
+  const androidDownloadInternalResSource = path.join(config.braveCoreDir, 'browser', 'download', 'internal', 'android', 'java', 'res')
+  const androidDownloadInternalResDest = path.join(config.srcDir, 'chrome', 'browser', 'download', 'internal', 'android', 'java', 'res')
+  const androidFeaturesTabUiResSource = path.join(config.braveCoreDir, 'android', 'features', 'tab_ui', 'java', 'res')
+  const androidFeaturesTabUiDest = path.join(config.srcDir, 'chrome', 'android', 'features', 'tab_ui', 'java', 'res')
+  const androidComponentsOmniboxResSource = path.join(config.braveCoreDir, 'components', 'omnibox', 'browser', 'android', 'java', 'res')
+  const androidComponentsOmniboxResDest = path.join(config.srcDir, 'components', 'omnibox', 'browser', 'android', 'java', 'res')
+  const androidBrowserUiOmniboxResSource = path.join(config.braveCoreDir, 'browser', 'ui', 'android', 'omnibox', 'java', 'brave_res')
+  const androidBrowserUiOmniboxResDest = path.join(config.srcDir, 'chrome', 'browser', 'ui', 'android', 'omnibox', 'java', 'res')
+  const androidBrowserPrivateResSource = path.join(config.braveCoreDir, 'browser', 'incognito', 'android', 'java', 'res')
+  const androidBrowserPrivateResDest = path.join(config.srcDir, 'chrome', 'browser', 'incognito', 'android', 'java', 'res')
+  const androidBrowserHubInternalResSource = path.join(config.braveCoreDir, 'browser', 'hub', 'internal', 'android', 'res')
+  const androidBrowserHubInternalResDest = path.join(config.srcDir, 'chrome', 'browser', 'hub', 'internal', 'android', 'res')
+
+  return {
+    [androidTranslateResSource]: [androidTranslateResDest],
+    [androidIconSource]: [androidIconDest],
+    [androidIconBaseSource]: [androidIconBaseDest],
+    [androidResSource]: [androidResDest],
+    [androidResTemplateSource]: [androidResTemplateDest],
+    [androidContentPublicResSource]: [androidContentPublicResDest],
+    [androidTouchtoFillResSource]: [androidTouchtoFillResDest],
+    [androidToolbarResSource]: [androidToolbarResDest],
+    [androidComponentsWidgetResSource]: [androidComponentsWidgetResDest],
+    [androidComponentsStylesResSource]: [androidComponentsStylesResDest],
+    [androidSafeBrowsingResSource]: [androidSafeBrowsingResDest],
+    [androidDownloadInternalResSource]: [androidDownloadInternalResDest],
+    [androidFeaturesTabUiResSource]: [androidFeaturesTabUiDest],
+    [androidComponentsOmniboxResSource]: [androidComponentsOmniboxResDest],
+    [androidBrowserUiOmniboxResSource]: [androidBrowserUiOmniboxResDest],
+    [androidBrowserPrivateResSource]: [androidBrowserPrivateResDest],
+    [androidBrowserHubInternalResSource]: [androidBrowserHubInternalResDest]
+  }
+}
+
 async function applyPatches(printPatchFailuresInJson) {
   const GitPatcher = require('./gitPatcher')
   Log.progressStart('apply patches')
@@ -272,6 +331,7 @@ const util = {
     return md5.digest('hex')
   },
 
+  // prettier-ignore
   updateBranding: () => {
     Log.progressStart('update branding')
     const chromeComponentsDir = path.join(config.srcDir, 'components')
@@ -450,64 +510,8 @@ const util = {
         androidIconSet = 'res_brave_nightly'
       }
 
-      const androidTranslateResSource = path.join(config.braveCoreDir, 'components', 'translate','content' , 'android', 'java', 'res')
-      const androidTranslateResDest = path.join(config.srcDir, 'components', 'translate','content' , 'android', 'java', 'res')
-      const androidIconSource = path.join(braveAppDir, 'theme', 'brave', 'android', androidIconSet)
-      const androidIconDest = path.join(config.srcDir, 'chrome', 'android', 'java', 'res_chromium')
-      const androidIconBaseSource = path.join(braveAppDir, 'theme', 'brave', 'android', androidIconSet + '_base')
-      const androidIconBaseDest = path.join(config.srcDir, 'chrome', 'android', 'java', 'res_chromium_base')
-      const androidResSource = path.join(config.braveCoreDir, 'android', 'java', 'res')
-      const androidResDest = path.join(config.srcDir, 'chrome', 'android', 'java', 'res')
-      const androidResTemplateSource = path.join(config.braveCoreDir, 'android', 'java', 'res_template')
-      const androidResTemplateDest = path.join(config.srcDir, 'chrome', 'android', 'java', 'res_template')
-      const androidContentPublicResSource = path.join(config.braveCoreDir, 'content', 'public', 'android', 'java', 'res')
-      const androidContentPublicResDest = path.join(config.srcDir, 'content', 'public', 'android', 'java', 'res')
-      const androidTouchtoFillResSource = path.join(config.braveCoreDir, 'browser', 'touch_to_fill', 'password_manager', 'android', 'internal', 'java', 'res')
-      const androidTouchtoFillResDest = path.join(config.srcDir, 'chrome', 'browser', 'touch_to_fill', 'password_manager', 'android', 'internal', 'java', 'res')
-      const androidToolbarResSource = path.join(config.braveCoreDir, 'browser', 'ui', 'android', 'toolbar', 'java', 'res')
-      const androidToolbarResDest = path.join(config.srcDir, 'chrome', 'browser', 'ui', 'android', 'toolbar', 'java', 'res')
-      const androidComponentsWidgetResSource = path.join(config.braveCoreDir, 'components', 'browser_ui', 'widget', 'android', 'java', 'res')
-      const androidComponentsWidgetResDest = path.join(config.srcDir, 'components', 'browser_ui', 'widget', 'android', 'java', 'res')
-      const androidComponentsStylesResSource = path.join(config.braveCoreDir, 'components', 'browser_ui', 'styles', 'android', 'java', 'res')
-      const androidComponentsStylesResDest = path.join(config.srcDir, 'components', 'browser_ui', 'styles', 'android', 'java', 'res')
-      const androidSafeBrowsingResSource = path.join(config.braveCoreDir, 'browser', 'safe_browsing', 'android', 'java', 'res')
-      const androidSafeBrowsingResDest = path.join(config.srcDir, 'chrome', 'browser', 'safe_browsing', 'android', 'java', 'res')
-      const androidDownloadInternalResSource = path.join(config.braveCoreDir, 'browser', 'download', 'internal', 'android', 'java', 'res')
-      const androidDownloadInternalResDest = path.join(config.srcDir, 'chrome', 'browser', 'download', 'internal', 'android', 'java', 'res')
-      const androidFeaturesTabUiResSource = path.join(config.braveCoreDir, 'android', 'features', 'tab_ui', 'java', 'res')
-      const androidFeaturesTabUiDest = path.join(config.srcDir, 'chrome', 'android', 'features', 'tab_ui', 'java', 'res')
-      const androidComponentsOmniboxResSource = path.join(config.braveCoreDir, 'components', 'omnibox', 'browser', 'android', 'java', 'res')
-      const androidComponentsOmniboxResDest = path.join(config.srcDir, 'components', 'omnibox', 'browser', 'android', 'java', 'res')
-      const androidBrowserUiOmniboxResSource = path.join(config.braveCoreDir, 'browser', 'ui', 'android', 'omnibox', 'java', 'brave_res')
-      const androidBrowserUiOmniboxResDest = path.join(config.srcDir, 'chrome', 'browser', 'ui', 'android', 'omnibox', 'java', 'res')
-      const androidBrowserPrivateResSource = path.join(config.braveCoreDir, 'browser', 'incognito', 'android', 'java', 'res')
-      const androidBrowserPrivateResDest = path.join(config.srcDir, 'chrome', 'browser', 'incognito', 'android', 'java', 'res')
-      const androidBrowserHubInternalResSource = path.join(config.braveCoreDir, 'browser', 'hub', 'internal', 'android', 'res')
-      const androidBrowserHubInternalResDest = path.join(config.srcDir, 'chrome', 'browser', 'hub', 'internal', 'android', 'res')
-
-      // Mapping for copying Brave's Android resource into chromium folder.
-      const copyAndroidResourceMapping = {
-        [androidTranslateResSource]: [androidTranslateResDest],
-        [androidIconSource]: [androidIconDest],
-        [androidIconBaseSource]: [androidIconBaseDest],
-        [androidResSource]: [androidResDest],
-        [androidResTemplateSource]: [androidResTemplateDest],
-        [androidContentPublicResSource]: [androidContentPublicResDest],
-        [androidTouchtoFillResSource]: [androidTouchtoFillResDest],
-        [androidToolbarResSource]: [androidToolbarResDest],
-        [androidComponentsWidgetResSource]: [androidComponentsWidgetResDest],
-        [androidComponentsStylesResSource]: [androidComponentsStylesResDest],
-        [androidSafeBrowsingResSource]: [androidSafeBrowsingResDest],
-        [androidDownloadInternalResSource]: [androidDownloadInternalResDest],
-        [androidFeaturesTabUiResSource]: [androidFeaturesTabUiDest],
-        [androidComponentsOmniboxResSource]: [androidComponentsOmniboxResDest],
-        [androidBrowserUiOmniboxResSource]: [androidBrowserUiOmniboxResDest],
-        [androidBrowserPrivateResSource]: [androidBrowserPrivateResDest],
-        [androidBrowserHubInternalResSource]: [androidBrowserHubInternalResDest]
-      }
-
       console.log('copy Android app icons and app resources')
-      Object.entries(copyAndroidResourceMapping).map(([sourcePath, destPaths]) => {
+      Object.entries(getCopyAndroidResourceMapping()).map(([sourcePath, destPaths]) => {
         let androidSourceFiles = []
         if (fs.statSync(sourcePath).isDirectory()) {
           androidSourceFiles = util.walkSync(sourcePath)

--- a/build/commands/lib/util.js
+++ b/build/commands/lib/util.js
@@ -16,7 +16,6 @@ const assert = require('assert')
 const updateChromeVersion = require('./updateChromeVersion')
 const updateUnsafeBuffersPaths = require('./updateUnsafeBuffersPaths.js')
 const ActionGuard = require('./actionGuard')
-const prettier = require('prettier')
 
 // Do not limit the number of listeners to avoid warnings from EventEmitter.
 process.setMaxListeners(0);

--- a/build/commands/lib/util.js
+++ b/build/commands/lib/util.js
@@ -20,10 +20,6 @@ const ActionGuard = require('./actionGuard')
 // Do not limit the number of listeners to avoid warnings from EventEmitter.
 process.setMaxListeners(0);
 
-const mergeWithDefault = (options) => {
-  return Object.assign({}, config.defaultOptions, options)
-}
-
 async function applyPatches(printPatchFailuresInJson) {
   const GitPatcher = require('./gitPatcher')
   Log.progressStart('apply patches')
@@ -618,6 +614,10 @@ const util = {
     }
   },
 
+  mergeWithDefault: (options) => {
+    return Object.assign({}, config.defaultOptions, options)
+  },
+
   buildNativeRedirectCC: async () => {
     // Expected path to redirect_cc.
     const redirectCC = path.join(config.nativeRedirectCCDir, util.appendExeIfWin32('redirect_cc'))
@@ -643,7 +643,7 @@ const util = {
     util.runGnGen(config.nativeRedirectCCDir, buildArgs, [
       '--root-target=//brave/tools/redirect_cc'
     ])
-    await util.buildTargets(['brave/tools/redirect_cc'], mergeWithDefault({outputDir: config.nativeRedirectCCDir}))
+    await util.buildTargets(['brave/tools/redirect_cc'], util.mergeWithDefault({outputDir: config.nativeRedirectCCDir}))
     Log.progressFinish('build redirect_cc')
   },
 
@@ -821,12 +821,10 @@ const util = {
 
   // Get the files that have been changed in the current diff with base branch.
   getChangedFiles: (options = {}) => {
-    const base = options.base || 'origin/master'
-
     const upstreamCommit = util.runGit(config.braveCoreDir, [
       'merge-base',
       'HEAD',
-      base
+      options.base
     ])
 
     return util.runGit(config.braveCoreDir, [
@@ -847,7 +845,7 @@ const util = {
         config.braveCoreDir, ['config', '--unset-all', 'gerrit.host'], true)
     let cmdOptions = config.defaultOptions
     cmdOptions.cwd = config.braveCoreDir
-    cmdOptions = mergeWithDefault(cmdOptions)
+    cmdOptions = util.mergeWithDefault(cmdOptions)
     cmd = 'git'
     // --upload mode is similar to `git cl upload`. Non-upload mode covers less
     // checks.
@@ -886,7 +884,7 @@ const util = {
       args.push('--verbose')
     }
     options.cwd = options.cwd || config.rootDir
-    options = mergeWithDefault(options)
+    options = util.mergeWithDefault(options)
     options.env.GCLIENT_FILE = gClientFile
     util.run('gclient', args, options)
   },

--- a/build/commands/lib/util.js
+++ b/build/commands/lib/util.js
@@ -20,65 +20,6 @@ const ActionGuard = require('./actionGuard')
 // Do not limit the number of listeners to avoid warnings from EventEmitter.
 process.setMaxListeners(0);
 
-// Mapping for copying Brave's Android resource into chromium folder.
-// prettier-ignore
-const getCopyAndroidResourceMapping = () => {
-  const androidTranslateResSource = path.join(config.braveCoreDir, 'components', 'translate','content' , 'android', 'java', 'res')
-  const androidTranslateResDest = path.join(config.srcDir, 'components', 'translate','content' , 'android', 'java', 'res')
-  const androidIconSource = path.join(braveAppDir, 'theme', 'brave', 'android', androidIconSet)
-  const androidIconDest = path.join(config.srcDir, 'chrome', 'android', 'java', 'res_chromium')
-  const androidIconBaseSource = path.join(braveAppDir, 'theme', 'brave', 'android', androidIconSet + '_base')
-  const androidIconBaseDest = path.join(config.srcDir, 'chrome', 'android', 'java', 'res_chromium_base')
-  const androidResSource = path.join(config.braveCoreDir, 'android', 'java', 'res')
-  const androidResDest = path.join(config.srcDir, 'chrome', 'android', 'java', 'res')
-  const androidResTemplateSource = path.join(config.braveCoreDir, 'android', 'java', 'res_template')
-  const androidResTemplateDest = path.join(config.srcDir, 'chrome', 'android', 'java', 'res_template')
-  const androidContentPublicResSource = path.join(config.braveCoreDir, 'content', 'public', 'android', 'java', 'res')
-  const androidContentPublicResDest = path.join(config.srcDir, 'content', 'public', 'android', 'java', 'res')
-  const androidTouchtoFillResSource = path.join(config.braveCoreDir, 'browser', 'touch_to_fill', 'password_manager', 'android', 'internal', 'java', 'res')
-  const androidTouchtoFillResDest = path.join(config.srcDir, 'chrome', 'browser', 'touch_to_fill', 'password_manager', 'android', 'internal', 'java', 'res')
-  const androidToolbarResSource = path.join(config.braveCoreDir, 'browser', 'ui', 'android', 'toolbar', 'java', 'res')
-  const androidToolbarResDest = path.join(config.srcDir, 'chrome', 'browser', 'ui', 'android', 'toolbar', 'java', 'res')
-  const androidComponentsWidgetResSource = path.join(config.braveCoreDir, 'components', 'browser_ui', 'widget', 'android', 'java', 'res')
-  const androidComponentsWidgetResDest = path.join(config.srcDir, 'components', 'browser_ui', 'widget', 'android', 'java', 'res')
-  const androidComponentsStylesResSource = path.join(config.braveCoreDir, 'components', 'browser_ui', 'styles', 'android', 'java', 'res')
-  const androidComponentsStylesResDest = path.join(config.srcDir, 'components', 'browser_ui', 'styles', 'android', 'java', 'res')
-  const androidSafeBrowsingResSource = path.join(config.braveCoreDir, 'browser', 'safe_browsing', 'android', 'java', 'res')
-  const androidSafeBrowsingResDest = path.join(config.srcDir, 'chrome', 'browser', 'safe_browsing', 'android', 'java', 'res')
-  const androidDownloadInternalResSource = path.join(config.braveCoreDir, 'browser', 'download', 'internal', 'android', 'java', 'res')
-  const androidDownloadInternalResDest = path.join(config.srcDir, 'chrome', 'browser', 'download', 'internal', 'android', 'java', 'res')
-  const androidFeaturesTabUiResSource = path.join(config.braveCoreDir, 'android', 'features', 'tab_ui', 'java', 'res')
-  const androidFeaturesTabUiDest = path.join(config.srcDir, 'chrome', 'android', 'features', 'tab_ui', 'java', 'res')
-  const androidComponentsOmniboxResSource = path.join(config.braveCoreDir, 'components', 'omnibox', 'browser', 'android', 'java', 'res')
-  const androidComponentsOmniboxResDest = path.join(config.srcDir, 'components', 'omnibox', 'browser', 'android', 'java', 'res')
-  const androidBrowserUiOmniboxResSource = path.join(config.braveCoreDir, 'browser', 'ui', 'android', 'omnibox', 'java', 'brave_res')
-  const androidBrowserUiOmniboxResDest = path.join(config.srcDir, 'chrome', 'browser', 'ui', 'android', 'omnibox', 'java', 'res')
-  const androidBrowserPrivateResSource = path.join(config.braveCoreDir, 'browser', 'incognito', 'android', 'java', 'res')
-  const androidBrowserPrivateResDest = path.join(config.srcDir, 'chrome', 'browser', 'incognito', 'android', 'java', 'res')
-  const androidBrowserHubInternalResSource = path.join(config.braveCoreDir, 'browser', 'hub', 'internal', 'android', 'res')
-  const androidBrowserHubInternalResDest = path.join(config.srcDir, 'chrome', 'browser', 'hub', 'internal', 'android', 'res')
-
-  return {
-    [androidTranslateResSource]: [androidTranslateResDest],
-    [androidIconSource]: [androidIconDest],
-    [androidIconBaseSource]: [androidIconBaseDest],
-    [androidResSource]: [androidResDest],
-    [androidResTemplateSource]: [androidResTemplateDest],
-    [androidContentPublicResSource]: [androidContentPublicResDest],
-    [androidTouchtoFillResSource]: [androidTouchtoFillResDest],
-    [androidToolbarResSource]: [androidToolbarResDest],
-    [androidComponentsWidgetResSource]: [androidComponentsWidgetResDest],
-    [androidComponentsStylesResSource]: [androidComponentsStylesResDest],
-    [androidSafeBrowsingResSource]: [androidSafeBrowsingResDest],
-    [androidDownloadInternalResSource]: [androidDownloadInternalResDest],
-    [androidFeaturesTabUiResSource]: [androidFeaturesTabUiDest],
-    [androidComponentsOmniboxResSource]: [androidComponentsOmniboxResDest],
-    [androidBrowserUiOmniboxResSource]: [androidBrowserUiOmniboxResDest],
-    [androidBrowserPrivateResSource]: [androidBrowserPrivateResDest],
-    [androidBrowserHubInternalResSource]: [androidBrowserHubInternalResDest]
-  }
-}
-
 async function applyPatches(printPatchFailuresInJson) {
   const GitPatcher = require('./gitPatcher')
   Log.progressStart('apply patches')
@@ -331,7 +272,6 @@ const util = {
     return md5.digest('hex')
   },
 
-  // prettier-ignore
   updateBranding: () => {
     Log.progressStart('update branding')
     const chromeComponentsDir = path.join(config.srcDir, 'components')
@@ -510,8 +450,64 @@ const util = {
         androidIconSet = 'res_brave_nightly'
       }
 
+      const androidTranslateResSource = path.join(config.braveCoreDir, 'components', 'translate','content' , 'android', 'java', 'res')
+      const androidTranslateResDest = path.join(config.srcDir, 'components', 'translate','content' , 'android', 'java', 'res')
+      const androidIconSource = path.join(braveAppDir, 'theme', 'brave', 'android', androidIconSet)
+      const androidIconDest = path.join(config.srcDir, 'chrome', 'android', 'java', 'res_chromium')
+      const androidIconBaseSource = path.join(braveAppDir, 'theme', 'brave', 'android', androidIconSet + '_base')
+      const androidIconBaseDest = path.join(config.srcDir, 'chrome', 'android', 'java', 'res_chromium_base')
+      const androidResSource = path.join(config.braveCoreDir, 'android', 'java', 'res')
+      const androidResDest = path.join(config.srcDir, 'chrome', 'android', 'java', 'res')
+      const androidResTemplateSource = path.join(config.braveCoreDir, 'android', 'java', 'res_template')
+      const androidResTemplateDest = path.join(config.srcDir, 'chrome', 'android', 'java', 'res_template')
+      const androidContentPublicResSource = path.join(config.braveCoreDir, 'content', 'public', 'android', 'java', 'res')
+      const androidContentPublicResDest = path.join(config.srcDir, 'content', 'public', 'android', 'java', 'res')
+      const androidTouchtoFillResSource = path.join(config.braveCoreDir, 'browser', 'touch_to_fill', 'password_manager', 'android', 'internal', 'java', 'res')
+      const androidTouchtoFillResDest = path.join(config.srcDir, 'chrome', 'browser', 'touch_to_fill', 'password_manager', 'android', 'internal', 'java', 'res')
+      const androidToolbarResSource = path.join(config.braveCoreDir, 'browser', 'ui', 'android', 'toolbar', 'java', 'res')
+      const androidToolbarResDest = path.join(config.srcDir, 'chrome', 'browser', 'ui', 'android', 'toolbar', 'java', 'res')
+      const androidComponentsWidgetResSource = path.join(config.braveCoreDir, 'components', 'browser_ui', 'widget', 'android', 'java', 'res')
+      const androidComponentsWidgetResDest = path.join(config.srcDir, 'components', 'browser_ui', 'widget', 'android', 'java', 'res')
+      const androidComponentsStylesResSource = path.join(config.braveCoreDir, 'components', 'browser_ui', 'styles', 'android', 'java', 'res')
+      const androidComponentsStylesResDest = path.join(config.srcDir, 'components', 'browser_ui', 'styles', 'android', 'java', 'res')
+      const androidSafeBrowsingResSource = path.join(config.braveCoreDir, 'browser', 'safe_browsing', 'android', 'java', 'res')
+      const androidSafeBrowsingResDest = path.join(config.srcDir, 'chrome', 'browser', 'safe_browsing', 'android', 'java', 'res')
+      const androidDownloadInternalResSource = path.join(config.braveCoreDir, 'browser', 'download', 'internal', 'android', 'java', 'res')
+      const androidDownloadInternalResDest = path.join(config.srcDir, 'chrome', 'browser', 'download', 'internal', 'android', 'java', 'res')
+      const androidFeaturesTabUiResSource = path.join(config.braveCoreDir, 'android', 'features', 'tab_ui', 'java', 'res')
+      const androidFeaturesTabUiDest = path.join(config.srcDir, 'chrome', 'android', 'features', 'tab_ui', 'java', 'res')
+      const androidComponentsOmniboxResSource = path.join(config.braveCoreDir, 'components', 'omnibox', 'browser', 'android', 'java', 'res')
+      const androidComponentsOmniboxResDest = path.join(config.srcDir, 'components', 'omnibox', 'browser', 'android', 'java', 'res')
+      const androidBrowserUiOmniboxResSource = path.join(config.braveCoreDir, 'browser', 'ui', 'android', 'omnibox', 'java', 'brave_res')
+      const androidBrowserUiOmniboxResDest = path.join(config.srcDir, 'chrome', 'browser', 'ui', 'android', 'omnibox', 'java', 'res')
+      const androidBrowserPrivateResSource = path.join(config.braveCoreDir, 'browser', 'incognito', 'android', 'java', 'res')
+      const androidBrowserPrivateResDest = path.join(config.srcDir, 'chrome', 'browser', 'incognito', 'android', 'java', 'res')
+      const androidBrowserHubInternalResSource = path.join(config.braveCoreDir, 'browser', 'hub', 'internal', 'android', 'res')
+      const androidBrowserHubInternalResDest = path.join(config.srcDir, 'chrome', 'browser', 'hub', 'internal', 'android', 'res')
+
+      // Mapping for copying Brave's Android resource into chromium folder.
+      const copyAndroidResourceMapping = {
+        [androidTranslateResSource]: [androidTranslateResDest],
+        [androidIconSource]: [androidIconDest],
+        [androidIconBaseSource]: [androidIconBaseDest],
+        [androidResSource]: [androidResDest],
+        [androidResTemplateSource]: [androidResTemplateDest],
+        [androidContentPublicResSource]: [androidContentPublicResDest],
+        [androidTouchtoFillResSource]: [androidTouchtoFillResDest],
+        [androidToolbarResSource]: [androidToolbarResDest],
+        [androidComponentsWidgetResSource]: [androidComponentsWidgetResDest],
+        [androidComponentsStylesResSource]: [androidComponentsStylesResDest],
+        [androidSafeBrowsingResSource]: [androidSafeBrowsingResDest],
+        [androidDownloadInternalResSource]: [androidDownloadInternalResDest],
+        [androidFeaturesTabUiResSource]: [androidFeaturesTabUiDest],
+        [androidComponentsOmniboxResSource]: [androidComponentsOmniboxResDest],
+        [androidBrowserUiOmniboxResSource]: [androidBrowserUiOmniboxResDest],
+        [androidBrowserPrivateResSource]: [androidBrowserPrivateResDest],
+        [androidBrowserHubInternalResSource]: [androidBrowserHubInternalResDest]
+      }
+
       console.log('copy Android app icons and app resources')
-      Object.entries(getCopyAndroidResourceMapping()).map(([sourcePath, destPaths]) => {
+      Object.entries(copyAndroidResourceMapping).map(([sourcePath, destPaths]) => {
         let androidSourceFiles = []
         if (fs.statSync(sourcePath).isDirectory()) {
           androidSourceFiles = util.walkSync(sourcePath)

--- a/build/commands/lib/util.js
+++ b/build/commands/lib/util.js
@@ -824,14 +824,14 @@ const util = {
   },
 
   // Get the files that have been changed in the current diff with base branch.
-  getChangedFiles: (options = {}) => {
-    const upstreamCommit = util.runGit(config.braveCoreDir, [
+  getChangedFiles: (repoDir, base) => {
+    const upstreamCommit = util.runGit(repoDir, [
       'merge-base',
       'HEAD',
-      options.base
+      base
     ])
 
-    return util.runGit(config.braveCoreDir, [
+    return util.runGit(repoDir, [
       'diff',
       '--name-only',
       '--diff-filter=d',

--- a/build/commands/scripts/commands.js
+++ b/build/commands/scripts/commands.js
@@ -10,6 +10,7 @@ const program = require('commander');
 const path = require('path')
 const fs = require('fs-extra')
 const config = require('../lib/config')
+const format = require('../lib/format')
 const util = require('../lib/util')
 const build = require('../lib/build')
 const buildChromiumRelease = require('../lib/buildChromiumRelease')
@@ -255,7 +256,7 @@ program
   .option('--base <base branch>', 'set the destination branch for the PR')
   .option('--full', 'format all lines in changed files instead of only the changed lines')
   .option('--diff', 'print diff to stdout rather than modifying files')
-  .action(util.format)
+  .action(format.runFormat)
 
 program
   .command('mass_rename')

--- a/build/commands/scripts/commands.js
+++ b/build/commands/scripts/commands.js
@@ -10,7 +10,6 @@ const program = require('commander');
 const path = require('path')
 const fs = require('fs-extra')
 const config = require('../lib/config')
-const format = require('../lib/format')
 const util = require('../lib/util')
 const build = require('../lib/build')
 const buildChromiumRelease = require('../lib/buildChromiumRelease')
@@ -250,13 +249,6 @@ program
   .option('--fix', 'try to fix found issues automatically')
   .option('--json <output>', 'An output file for a JSON report')
   .action(util.presubmit)
-
-program
-  .command('format')
-  .option('--base <base branch>', 'set the destination branch for the PR')
-  .option('--full', 'format all lines in changed files instead of only the changed lines')
-  .option('--diff', 'print diff to stdout rather than modifying files')
-  .action(format.runFormat)
 
 program
   .command('mass_rename')

--- a/build/commands/scripts/format.js
+++ b/build/commands/scripts/format.js
@@ -13,10 +13,10 @@ const util = require('../lib/util')
 
 program
   .description(
-    'Format changed code with git cl format and prettifier.\n' +
+    'Format changed code with git cl format and prettier.\n' +
       'The changed code is the difference between the current files on disk\n' +
       'and the base branch (origin/master by default).\n' +
-      'This script is also called as part of presubmit checks'
+      'This script is also called as part of presubmit checks.'
   )
   .option('--base <base branch>', 'set the destination branch for the PR')
   .option(
@@ -69,7 +69,7 @@ const runFormat = async (options = {}) => {
       errors.push(
         diffResult.stdout.toString() + '\n' + 'git cl format checks failed'
       )
-    } else if (clFormatResult.status != 0) {
+    } else if (clFormatResult.status !== 0) {
       console.error('Fatal: git cl format internal error')
       process.exit(1)
     }

--- a/build/commands/scripts/format.js
+++ b/build/commands/scripts/format.js
@@ -60,7 +60,7 @@ const runFormat = async (options = {}) => {
       ...cmdOptions,
       continueOnFail: true
     })
-    if (clFormatResult.status == 2) {
+    if (clFormatResult.status === 2) {
       // format issues found. Run git cl format with --diff to print the diff
       const diffResult = util.run(cmd, [...args, '--diff'], {
         ...cmdOptions,

--- a/build/commands/scripts/format.js
+++ b/build/commands/scripts/format.js
@@ -80,7 +80,9 @@ const runFormat = async (options = {}) => {
   }
 
   if (options.dryRun) {
-    args.push('--diff', '--dry-run')
+    // `--dry-run` alone only generates a non-zero exit code on format issues.
+    // `--diff` is required to get the actual change in stdout.
+    args.push('--dry-run', '--diff')
   }
 
   let errors = []

--- a/build/commands/scripts/format.js
+++ b/build/commands/scripts/format.js
@@ -11,10 +11,6 @@ const program = require('commander')
 const config = require('../lib/config')
 const util = require('../lib/util')
 
-const mergeWithDefault = (options) => {
-  return Object.assign({}, config.defaultOptions, options)
-}
-
 // A function that formats the code in the current diff with base branch.
 // It uses git cl format and prettier, then aggregates the results.
 const runFormat = async (options = {}) => {
@@ -23,7 +19,7 @@ const runFormat = async (options = {}) => {
   }
   let cmdOptions = config.defaultOptions
   cmdOptions.cwd = config.braveCoreDir
-  cmdOptions = mergeWithDefault(cmdOptions)
+  cmdOptions = util.mergeWithDefault(cmdOptions)
   cmd = 'git'
   args = ['cl', 'format', '--upstream=' + options.base]
 

--- a/build/commands/scripts/format.js
+++ b/build/commands/scripts/format.js
@@ -7,6 +7,7 @@ const path = require('path')
 const fs = require('fs-extra')
 const prettier = require('prettier')
 const program = require('commander')
+const { spawnSync } = require('child_process')
 
 const config = require('../lib/config')
 const util = require('../lib/util')
@@ -118,7 +119,7 @@ const runPrettier = async (files, dryRun) => {
     if (content !== formatted) {
       if (dryRun) {
         // Use `echo <formatted> | git diff --no-index <file> -` to show diff
-        const diffResult = util.runProcess('git', ['diff', '--no-index', file, '-'], {
+        const diffResult = spawnSync('git', ['diff', '--no-index', file, '-'], {
           stdio: 'pipe',
           input: formatted,
         })

--- a/build/commands/scripts/format.js
+++ b/build/commands/scripts/format.js
@@ -11,6 +11,16 @@ const program = require('commander')
 const config = require('../lib/config')
 const util = require('../lib/util')
 
+program
+  .option('--base <base branch>', 'set the destination branch for the PR')
+  .option(
+    '--full',
+    'format all lines in changed files instead of only the changed lines'
+  )
+  .option('--diff', 'print diff to stdout rather than modifying files')
+  .parse(process.argv)
+
+
 // A function that formats the code in the current diff with base branch.
 // It uses git cl format and prettier, then aggregates the results.
 const runFormat = async (options = {}) => {
@@ -97,13 +107,4 @@ const runPrettier = async (files, diff) => {
   return result
 }
 
-program
-  .option('--base <base branch>', 'set the destination branch for the PR')
-  .option(
-    '--full',
-    'format all lines in changed files instead of only the changed lines'
-  )
-  .option('--diff', 'print diff to stdout rather than modifying files')
-  .action(runFormat)
-
-program.parse(process.argv)
+runFormat(program.opts())

--- a/package-lock.json
+++ b/package-lock.json
@@ -123,7 +123,7 @@
         "mz": "2.7.0",
         "os-browserify": "0.3.0",
         "path-browserify": "1.0.1",
-        "prettier": "2.8.8",
+        "prettier": "3.5.3",
         "process": "0.11.10",
         "querystring-es3": "0.2.1",
         "react": "18.2.0",
@@ -17946,15 +17946,16 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
       "devOptional": true,
+      "license": "MIT",
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
@@ -35990,9 +35991,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
       "devOptional": true
     },
     "prettier-bytes": {

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "mz": "2.7.0",
     "os-browserify": "0.3.0",
     "path-browserify": "1.0.1",
-    "prettier": "2.8.8",
+    "prettier": "3.5.3",
     "process": "0.11.10",
     "querystring-es3": "0.2.1",
     "react": "18.2.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "pull_l10n": "node ./build/commands/scripts/commands.js pull_l10n",
     "chromium_rebase_l10n": "node ./build/commands/scripts/commands.js chromium_rebase_l10n",
     "presubmit": "node ./build/commands/scripts/commands.js presubmit",
-    "format": "node ./build/commands/scripts/commands.js format",
+    "format": "node ./build/commands/scripts/format.js",
     "mass_rename": "node ./build/commands/scripts/commands.js mass_rename",
     "docs": "node ./build/commands/scripts/commands.js docs",
     "test": "node ./build/commands/scripts/commands.js test",


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves
The PR prepares for enforcing format rules for build/**/*.js files. IT
* makes `npm run format` a single entry point to check/fix format
* replaces the current code in `PRESUBMIT.py` to call `npm run format`
* updates prettier to `3.5.3`

The diff we're going to apply:
https://github.com/brave/brave-core/commit/e8d11e70fccabeac81aee7816b128589f5290499


<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
