### PR TITLE
Fix Android browser crash on startup after upgrade to cr136 (uplift to 1.79.x)

### DIFF
--- a/patches/components-webui-flags-flags_state.cc.patch
+++ b/patches/components-webui-flags-flags_state.cc.patch
@@ -1,0 +1,27 @@
+diff --git a/components/webui/flags/flags_state.cc b/components/webui/flags/flags_state.cc
+index d7b4c069962eec7a007f68f506f50c2a2e744c47..9680fa109340b7db445180195be8bca3d3ee074e 100644
+--- a/components/webui/flags/flags_state.cc
++++ b/components/webui/flags/flags_state.cc
+@@ -1129,6 +1129,8 @@ void FlagsState::SetFlags(
+     std::string feature_internal_name = flag.substr(0, at_index);
+     const flags_ui::FeatureEntry* entry =
+         FindFeatureEntryByName(feature_internal_name);
++    // Since this flag is currently enabled, we know for sure that we can find
++    // its feature entry using its internal name.
+     CHECK(entry);
+ 
+     if (entry->type == FeatureEntry::FEATURE_VALUE ||
+@@ -1186,7 +1188,12 @@ void FlagsState::SetFlags(
+       std::string feature_internal_name = flag.substr(0, at_index);
+       const flags_ui::FeatureEntry* entry =
+           FindFeatureEntryByName(feature_internal_name);
+-      CHECK(entry);
++      // Since this flag is enabled previously but not enabled right now, it is
++      // possible that we have removed this flag from the codebase. Therefore,
++      // if we cannot find the feature entry, we just move on.
++      if (entry == nullptr) {
++        continue;
++      }
+ 
+       if (entry->type == FeatureEntry::FEATURE_VALUE ||
+           entry->type == FeatureEntry::FEATURE_WITH_PARAMS_VALUE) {


### PR DESCRIPTION
Uplift of #28921
Resolves https://github.com/brave/brave-browser/issues/45816

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.