### PR TITLE
[iOS] - Fix translate button showing on pages with invalid languages (uplift to 1.79.x)

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Brave Translate/BraveTranslateSession.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Brave Translate/BraveTranslateSession.swift
@@ -47,7 +47,9 @@ class BraveTranslateSession {
     }
 
     guard let sourceLanguage = source.languageCode?.identifier,
-      let targetLanguage = target.languageCode?.identifier
+      let targetLanguage = target.languageCode?.identifier,
+      Locale.availableIdentifiers.contains(sourceLanguage),
+      Locale.availableIdentifiers.contains(targetLanguage)
     else {
       return false
     }

--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/BraveTranslateScriptHandler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/BraveTranslateScriptHandler.swift
@@ -256,7 +256,9 @@ class BraveTranslateScriptLanguageDetectionHandler: NSObject, TabContentScript {
         from: JSONSerialization.data(withJSONObject: body, options: .fragmentsAllowed)
       )
 
-      if message.hasNoTranslate {
+      // The page cannot be translated because it has "noTranslate" flag set,
+      // Or because the detected language code isn't valid.
+      if message.hasNoTranslate || !Locale.availableIdentifiers.contains(message.htmlLang) {
         translateHelper.currentLanguageInfo.pageLanguage = nil
       } else {
         translateHelper.currentLanguageInfo.pageLanguage =


### PR DESCRIPTION
Uplift of #28899
Resolves https://github.com/brave/brave-browser/issues/45779

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.