### PR TITLE
[iOS] Fix `WebKitTabState.callAsyncJavaScript` function signature (uplift to 1.79.x)

### DIFF
--- a/ios/brave-ios/Sources/Web/WebKit/WebKitTabState.swift
+++ b/ios/brave-ios/Sources/Web/WebKit/WebKitTabState.swift
@@ -537,7 +537,7 @@ class WebKitTabState: TabState, TabStateImpl {
     _ functionBody: String,
     arguments: [String: Any],
     in frame: WKFrameInfo?,
-    in contentWorld: WKContentWorld
+    contentWorld: WKContentWorld
   ) async throws -> Any? {
     try await webView?.callAsyncJavaScript(
       functionBody,


### PR DESCRIPTION
Uplift of #28945
Resolves https://github.com/brave/brave-browser/issues/45864

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.