### PR TITLE
Fix flaky Android browser tests

### DIFF
--- a/chromium_src/build/android/pylib/gtest/gtest_test_instance.py
+++ b/chromium_src/build/android/pylib/gtest/gtest_test_instance.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2025 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""A inline part of gtest_test_instance.py"""
+
+BRAVE_BROWSER_TEST_SUITES = [
+    'brave_browser_tests',
+]
+
+# Add Brave items to Chromium BROWSER_TEST_SUITES:
+# pylint: disable=used-before-assignment
+BROWSER_TEST_SUITES = BROWSER_TEST_SUITES + BRAVE_BROWSER_TEST_SUITES

--- a/patches/build-android-pylib-gtest-gtest_test_instance.py.patch
+++ b/patches/build-android-pylib-gtest-gtest_test_instance.py.patch
@@ -1,12 +1,9 @@
 diff --git a/build/android/pylib/gtest/gtest_test_instance.py b/build/android/pylib/gtest/gtest_test_instance.py
-index e4b76b321e4e1e4b630c37e779221bb9f0068c21..aa93f34c4892fc2da675d1ae6542cc226a3baa83 100644
+index e4b76b321e4e1e4b630c37e779221bb9f0068c21..a68aa14a96334a4912839471962c639c6166d646 100644
 --- a/build/android/pylib/gtest/gtest_test_instance.py
 +++ b/build/android/pylib/gtest/gtest_test_instance.py
-@@ -27,6 +27,7 @@ with host_paths.SysPath(host_paths.BUILD_UTIL_PATH):
- BROWSER_TEST_SUITES = [
-     'android_browsertests',
-     'android_sync_integration_tests',
-+    'brave_browser_tests',
-     'components_browsertests',
-     'content_browsertests',
-     'weblayer_browsertests',
+@@ -668,3 +668,4 @@ class GtestTestInstance(test_instance.TestInstance):
+   #override
+   def TearDown(self):
+     """Do nothing."""
++from brave_chromium_utils import inline_chromium_src_override; inline_chromium_src_override(globals(), locals())

--- a/patches/build-android-pylib-gtest-gtest_test_instance.py.patch
+++ b/patches/build-android-pylib-gtest-gtest_test_instance.py.patch
@@ -1,0 +1,12 @@
+diff --git a/build/android/pylib/gtest/gtest_test_instance.py b/build/android/pylib/gtest/gtest_test_instance.py
+index e4b76b321e4e1e4b630c37e779221bb9f0068c21..aa93f34c4892fc2da675d1ae6542cc226a3baa83 100644
+--- a/build/android/pylib/gtest/gtest_test_instance.py
++++ b/build/android/pylib/gtest/gtest_test_instance.py
+@@ -27,6 +27,7 @@ with host_paths.SysPath(host_paths.BUILD_UTIL_PATH):
+ BROWSER_TEST_SUITES = [
+     'android_browsertests',
+     'android_sync_integration_tests',
++    'brave_browser_tests',
+     'components_browsertests',
+     'content_browsertests',
+     'weblayer_browsertests',


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/45913

It turns out that browser test requires to run in a separate process and it wasn't so for us on Android.
The  crash happened at [this place](https://source.chromium.org/chromium/chromium/src/+/main:content/public/test/browser_test_base.cc;l=262;drc=1379ddb0f0535ff846ce0fbad8ee49af303140c4?q=content%2Fpublic%2Ftest%2Fbrowser_test_base.cc&ss=chromium%2Fchromium%2Fsrc)

```

BrowserTestBase::BrowserTestBase() {
  CHECK(!g_instance_already_created)
      << "Each browser test should be run in a new process. If you are adding "
         "a new browser test suite that runs on Android, please add it to "
         "//build/android/pylib/gtest/gtest_test_instance.py.";
  g_instance_already_created = true;
```
but script did retry and in some cases all tests eventually succeeded and in some - they didn't.

This error message was hidden at logcat and was not obvious when we were looking into CI result.
It describes well what should be done to fix it.

Local run of the command `npm run test -- brave_browser_tests Release  --target_os=android --target_arch=x86  --android_test_emulator_name=android_30_google_atd_x86  --filter=AdBlockServiceTest.*` gave me this

Before fix| After fix
--|--
![image](https://github.com/user-attachments/assets/bba99957-029c-40d7-bb54-a9322de87a3a)|![image](https://github.com/user-attachments/assets/0cba4a8e-3aa2-4272-a35e-c6fe4f26f68e)

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
