### PR TITLE
Fix flaky Android browser tests (uplift to 1.78.x)

### DIFF
--- a/chromium_src/build/android/pylib/gtest/gtest_test_instance.py
+++ b/chromium_src/build/android/pylib/gtest/gtest_test_instance.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2025 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""A inline part of gtest_test_instance.py"""
+
+BRAVE_BROWSER_TEST_SUITES = [
+    'brave_browser_tests',
+]
+
+# Add Brave items to Chromium BROWSER_TEST_SUITES:
+# pylint: disable=used-before-assignment
+BROWSER_TEST_SUITES = BROWSER_TEST_SUITES + BRAVE_BROWSER_TEST_SUITES

--- a/patches/build-android-pylib-gtest-gtest_test_instance.py.patch
+++ b/patches/build-android-pylib-gtest-gtest_test_instance.py.patch
@@ -1,0 +1,9 @@
+diff --git a/build/android/pylib/gtest/gtest_test_instance.py b/build/android/pylib/gtest/gtest_test_instance.py
+index e4b76b321e4e1e4b630c37e779221bb9f0068c21..a68aa14a96334a4912839471962c639c6166d646 100644
+--- a/build/android/pylib/gtest/gtest_test_instance.py
++++ b/build/android/pylib/gtest/gtest_test_instance.py
+@@ -668,3 +668,4 @@ class GtestTestInstance(test_instance.TestInstance):
+   #override
+   def TearDown(self):
+     """Do nothing."""
++from brave_chromium_utils import inline_chromium_src_override; inline_chromium_src_override(globals(), locals())


### PR DESCRIPTION
Uplift of #28976
Resolves https://github.com/brave/brave-browser/issues/45913

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.