### PR TITLE
[iOS] Remove private mode association from SessionWindow

### DIFF
--- a/ios/brave-ios/App/iOS/Delegates/AppDelegate.swift
+++ b/ios/brave-ios/App/iOS/Delegates/AppDelegate.swift
@@ -491,12 +491,12 @@ extension AppDelegate {
     // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
 
     sceneSessions.forEach { session in
-      if let windowIdString = BrowserState.getWindowInfo(from: session).windowId,
+      if let windowIdString = BrowserState.getWindowId(from: session),
         let windowId = UUID(uuidString: windowIdString)
       {
         SessionWindow.delete(windowId: windowId)
       } else if let userActivity = session.scene?.userActivity,
-        let windowIdString = BrowserState.getWindowInfo(from: userActivity).windowId,
+        let windowIdString = BrowserState.getNewWindowInfo(from: userActivity).windowId,
         let windowId = UUID(uuidString: windowIdString)
       {
         SessionWindow.delete(windowId: windowId)

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -745,7 +745,6 @@ public class BrowserViewController: UIViewController {
 
   @objc func appWillTerminateNotification() {
     tabManager.saveAllTabs()
-    tabManager.removePrivateWindows()
   }
 
   @objc private func tappedCollapsedURLBar() {
@@ -1284,35 +1283,6 @@ public class BrowserViewController: UIViewController {
       show(toast: toast, afterWaiting: ButtonToastUX.toastDelay)
     }
     showQueuedAlertIfAvailable()
-
-    let isPrivateBrowsing = SessionWindow.from(windowId: windowId)?.isPrivate == true
-    var userActivity = view.window?.windowScene?.userActivity
-
-    if let userActivity = userActivity {
-      BrowserState.setWindowInfo(
-        for: userActivity,
-        windowId: windowId.uuidString,
-        isPrivate: isPrivateBrowsing
-      )
-    } else {
-      userActivity = BrowserState.userActivity(
-        for: windowId.uuidString,
-        isPrivate: isPrivateBrowsing
-      )
-    }
-
-    if let scene = view.window?.windowScene {
-      scene.userActivity = userActivity
-      BrowserState.setWindowInfo(
-        for: scene.session,
-        windowId: windowId.uuidString,
-        isPrivate: isPrivateBrowsing
-      )
-    }
-
-    for session in UIApplication.shared.openSessions {
-      UIApplication.shared.requestSceneSessionRefresh(session)
-    }
   }
 
   /// Whether or not to show the playlist onboarding callout this session
@@ -1336,8 +1306,6 @@ public class BrowserViewController: UIViewController {
   override public func viewWillDisappear(_ animated: Bool) {
     screenshotHelper.viewIsVisible = false
     super.viewWillDisappear(animated)
-
-    view.window?.windowScene?.userActivity = nil
   }
 
   /// A layout guide defining where the favorites and NTP overlay are placed
@@ -1990,8 +1958,7 @@ public class BrowserViewController: UIViewController {
   }
 
   func openInNewWindow(url: URL?, isPrivate: Bool) {
-    let activity = BrowserState.userActivity(
-      for: UUID().uuidString,
+    let activity = BrowserState.newWindowUserActivity(
       isPrivate: isPrivate,
       openURL: url
     )

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/TabManager.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/TabManager.swift
@@ -695,15 +695,6 @@ class TabManager: NSObject {
     }
   }
 
-  func removePrivateWindows() {
-    if Preferences.Privacy.privateBrowsingOnly.value
-      || (privateBrowsingManager.isPrivateBrowsing
-        && !Preferences.Privacy.persistentPrivateBrowsing.value)
-    {
-      SessionWindow.deleteAllWindows(privateOnly: true)
-    }
-  }
-
   func saveAllTabs() {
     if Preferences.Privacy.privateBrowsingOnly.value
       || (privateBrowsingManager.isPrivateBrowsing

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Tabs/TabTray/TabTrayController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Tabs/TabTray/TabTrayController.swift
@@ -879,6 +879,10 @@ class TabTrayController: AuthenticationController {
     } else {
       tabTrayView.hidePrivateModeInfo()
 
+      if tabManager.tabsForCurrentMode.isEmpty {
+        tabManager.addTabAndSelect(isPrivate: false)
+      }
+
       // When you go back from private mode, a previous current tab is selected
       // Reloding the collection view in order to mark the selecte the tab
       let normalModeTabSelected =

--- a/ios/brave-ios/Sources/Brave/Migration/Migration.swift
+++ b/ios/brave-ios/Sources/Brave/Migration/Migration.swift
@@ -109,7 +109,7 @@ public class Migration {
     }
 
     let windowIds = UIApplication.shared.openSessions
-      .compactMap({ BrowserState.getWindowInfo(from: $0).windowId })
+      .compactMap({ BrowserState.getWindowId(from: $0) })
       .filter({ $0 != activeWindow.windowId.uuidString })
 
     let zombieTabs =

--- a/ios/brave-ios/Sources/Data/models/Model.xcdatamodeld/.xccurrentversion
+++ b/ios/brave-ios/Sources/Data/models/Model.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>Model33.xcdatamodel</string>
+	<string>Model34.xcdatamodel</string>
 </dict>
 </plist>

--- a/ios/brave-ios/Sources/Data/models/Model.xcdatamodeld/Model34.xcdatamodel/contents
+++ b/ios/brave-ios/Sources/Data/models/Model.xcdatamodeld/Model34.xcdatamodel/contents
@@ -1,0 +1,233 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23788.4" systemVersion="24E263" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="BlockedResource" representedClassName="Data.BlockedResource" syncable="YES">
+        <attribute name="domain" optional="YES" attributeType="String"/>
+        <attribute name="faviconUrl" optional="YES" attributeType="String"/>
+        <attribute name="host" optional="YES" attributeType="String"/>
+        <attribute name="timestamp" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <fetchIndex name="byHost">
+            <fetchIndexElement property="host" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <fetchIndex name="byDomain">
+            <fetchIndexElement property="domain" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="Bookmark" representedClassName="Data.Favorite" syncable="YES">
+        <attribute name="created" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="customTitle" optional="YES" attributeType="String"/>
+        <attribute name="isFavorite" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="isFolder" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="lastVisited" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="order" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="syncDisplayUUID" optional="YES" attributeType="String"/>
+        <attribute name="syncOrder" optional="YES" attributeType="String"/>
+        <attribute name="syncParentDisplayUUID" optional="YES" attributeType="String"/>
+        <attribute name="tags" optional="YES" attributeType="Transformable"/>
+        <attribute name="title" optional="YES" attributeType="String"/>
+        <attribute name="url" optional="YES" attributeType="String"/>
+        <attribute name="visits" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="domain" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Domain" inverseName="bookmarks" inverseEntity="Domain"/>
+        <fetchIndex name="byLastVisitedIndex">
+            <fetchIndexElement property="lastVisited" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <fetchIndex name="byUrlIndex">
+            <fetchIndexElement property="url" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <fetchIndex name="byVisitsIndex">
+            <fetchIndexElement property="visits" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="BraveVPNAlert" representedClassName="Data.BraveVPNAlert" syncable="YES">
+        <attribute name="action" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="category" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="host" optional="YES" attributeType="String"/>
+        <attribute name="message" optional="YES" attributeType="String"/>
+        <attribute name="timestamp" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="title" optional="YES" attributeType="String"/>
+        <attribute name="uuid" optional="YES" attributeType="String"/>
+        <fetchIndex name="byUUID">
+            <fetchIndexElement property="uuid" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="uuid"/>
+            </uniquenessConstraint>
+            <uniquenessConstraint>
+                <constraint value="timestamp"/>
+                <constraint value="host"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="CustomFilterListSetting" representedClassName="Data.CustomFilterListSetting" syncable="YES">
+        <attribute name="externalURL" optional="YES" attributeType="URI"/>
+        <attribute name="isEnabled" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="uuid" optional="YES" attributeType="String"/>
+    </entity>
+    <entity name="DataSaved" representedClassName="Data.DataSaved" syncable="YES">
+        <attribute name="amount" optional="YES" attributeType="String"/>
+        <attribute name="savedUrl" optional="YES" attributeType="String"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="savedUrl"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="Domain" representedClassName="Data.Domain" syncable="YES">
+        <attribute name="blockedFromTopSites" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="shield_adblockAndTp" optional="YES" attributeType="Boolean" usesScalarValueType="NO"/>
+        <attribute name="shield_allOff" optional="YES" attributeType="Boolean" usesScalarValueType="NO"/>
+        <attribute name="shield_blockAdsAndTrackingLevel" optional="YES" attributeType="String"/>
+        <attribute name="shield_fpProtection" optional="YES" attributeType="Boolean" usesScalarValueType="NO"/>
+        <attribute name="shield_httpse" optional="YES" attributeType="Boolean" usesScalarValueType="NO"/>
+        <attribute name="shield_noScript" optional="YES" attributeType="Boolean" usesScalarValueType="NO"/>
+        <attribute name="shield_safeBrowsing" optional="YES" attributeType="Boolean" usesScalarValueType="NO"/>
+        <attribute name="shield_shredLevel" optional="YES" attributeType="String"/>
+        <attribute name="topsite" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="url" optional="YES" attributeType="String"/>
+        <attribute name="visits" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="wallet_permittedAccounts" optional="YES" attributeType="String"/>
+        <attribute name="wallet_solanaPermittedAcccounts" optional="YES" attributeType="String"/>
+        <attribute name="zoom_level" optional="YES" attributeType="Double" usesScalarValueType="NO"/>
+        <relationship name="bookmarks" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Bookmark" inverseName="domain" inverseEntity="Bookmark"/>
+        <fetchIndex name="byBlockedFromTopSitesIndex">
+            <fetchIndexElement property="blockedFromTopSites" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <fetchIndex name="byUrlIndex">
+            <fetchIndexElement property="url" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <fetchIndex name="byVisitsIndex">
+            <fetchIndexElement property="visits" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="FeedSourceOverride" representedClassName="Data.FeedSourceOverride" syncable="YES">
+        <attribute name="enabled" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="publisherID" attributeType="String"/>
+        <fetchIndex name="byPublisherID">
+            <fetchIndexElement property="publisherID" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="publisherID"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="FilterListSetting" representedClassName="Data.FilterListSetting" syncable="YES">
+        <attribute name="componentId" optional="YES" attributeType="String"/>
+        <attribute name="folderPath" optional="YES" attributeType="String"/>
+        <attribute name="isAlwaysAggressive" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="isDefaultEnabled" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="isEnabled" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="isHidden" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="order" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="uuid" attributeType="String"/>
+    </entity>
+    <entity name="PlaylistFolder" representedClassName="Data.PlaylistFolder" syncable="YES">
+        <attribute name="creatorLink" optional="YES" attributeType="String"/>
+        <attribute name="creatorName" optional="YES" attributeType="String"/>
+        <attribute name="dateAdded" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="order" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="sharedFolderETag" optional="YES" attributeType="String"/>
+        <attribute name="sharedFolderId" optional="YES" attributeType="String"/>
+        <attribute name="sharedFolderUrl" optional="YES" attributeType="String"/>
+        <attribute name="title" attributeType="String"/>
+        <attribute name="uuid" attributeType="String"/>
+        <relationship name="playlistItems" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="PlaylistItem" inverseName="playlistFolder" inverseEntity="PlaylistItem"/>
+    </entity>
+    <entity name="PlaylistItem" representedClassName="Data.PlaylistItem" syncable="YES">
+        <attribute name="cachedData" optional="YES" attributeType="Binary"/>
+        <attribute name="dateAdded" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="duration" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="lastPlayedOffset" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="mediaSrc" attributeType="String"/>
+        <attribute name="mimeType" attributeType="String"/>
+        <attribute name="name" attributeType="String"/>
+        <attribute name="order" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="pageSrc" attributeType="String"/>
+        <attribute name="pageTitle" optional="YES" attributeType="String"/>
+        <attribute name="uuid" optional="YES" attributeType="String"/>
+        <relationship name="playlistFolder" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="PlaylistFolder" inverseName="playlistItems" inverseEntity="PlaylistFolder"/>
+    </entity>
+    <entity name="RecentlyClosed" representedClassName="Data.RecentlyClosed" syncable="YES">
+        <attribute name="dateAdded" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="historyIndex" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="historyList" optional="YES" attributeType="Transformable"/>
+        <attribute name="interactionState" optional="YES" attributeType="Binary"/>
+        <attribute name="title" optional="YES" attributeType="String"/>
+        <attribute name="url" attributeType="String"/>
+    </entity>
+    <entity name="RecentSearch" representedClassName="Data.RecentSearch" syncable="YES">
+        <attribute name="dateAdded" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="searchType" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="text" optional="YES" attributeType="String"/>
+        <attribute name="websiteUrl" optional="YES" attributeType="String"/>
+    </entity>
+    <entity name="RSSFeedSource" representedClassName="Data.RSSFeedSource" syncable="YES">
+        <attribute name="feedUrl" attributeType="String"/>
+        <attribute name="title" optional="YES" attributeType="String"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="feedUrl"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="SessionTab" representedClassName="Data.SessionTab" syncable="YES">
+        <attribute name="index" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="interactionState" attributeType="Binary"/>
+        <attribute name="isPrivate" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="isSelected" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="lastUpdated" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="screenshotData" attributeType="Binary"/>
+        <attribute name="tabId" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="title" attributeType="String"/>
+        <attribute name="url" optional="YES" attributeType="URI"/>
+        <relationship name="sessionTabGroup" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SessionTabGroup" inverseName="sessionTabs" inverseEntity="SessionTabGroup"/>
+        <relationship name="sessionWindow" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SessionWindow" inverseName="sessionTabs" inverseEntity="SessionWindow"/>
+    </entity>
+    <entity name="SessionTabGroup" representedClassName="Data.SessionTabGroup" syncable="YES">
+        <attribute name="groupId" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="index" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="title" attributeType="String"/>
+        <relationship name="sessionTabs" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="SessionTab" inverseName="sessionTabGroup" inverseEntity="SessionTab"/>
+        <relationship name="sessionWindow" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SessionWindow" inverseName="sessionTabGroups" inverseEntity="SessionWindow"/>
+    </entity>
+    <entity name="SessionWindow" representedClassName="Data.SessionWindow" syncable="YES">
+        <attribute name="index" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="isSelected" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="windowId" attributeType="UUID" usesScalarValueType="NO"/>
+        <relationship name="sessionTabGroups" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="SessionTabGroup" inverseName="sessionWindow" inverseEntity="SessionTabGroup"/>
+        <relationship name="sessionTabs" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="SessionTab" inverseName="sessionWindow" inverseEntity="SessionTab"/>
+    </entity>
+    <entity name="WalletUserAsset" representedClassName="Data.WalletUserAsset" syncable="YES">
+        <attribute name="chainId" optional="YES" attributeType="String"/>
+        <attribute name="coin" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="coingeckoId" optional="YES" attributeType="String"/>
+        <attribute name="contractAddress" optional="YES" attributeType="String"/>
+        <attribute name="decimals" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="isCompressed" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="isDeletedByUser" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="isERC20" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="isERC721" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="isERC1155" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="isNFT" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="isSpam" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="logo" optional="YES" attributeType="String"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="splTokenProgram" optional="YES" attributeType="Integer 16" usesScalarValueType="YES"/>
+        <attribute name="symbol" optional="YES" attributeType="String"/>
+        <attribute name="tokenId" optional="YES" attributeType="String"/>
+        <attribute name="visible" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <relationship name="walletUserAssetGroup" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="WalletUserAssetGroup" inverseName="walletUserAssets" inverseEntity="WalletUserAssetGroup"/>
+    </entity>
+    <entity name="WalletUserAssetBalance" representedClassName="Data.WalletUserAssetBalance" syncable="YES">
+        <attribute name="accountAddress" optional="YES" attributeType="String"/>
+        <attribute name="balance" optional="YES" attributeType="String"/>
+        <attribute name="chainId" optional="YES" attributeType="String"/>
+        <attribute name="contractAddress" optional="YES" attributeType="String"/>
+        <attribute name="symbol" optional="YES" attributeType="String"/>
+        <attribute name="tokenId" optional="YES" attributeType="String"/>
+    </entity>
+    <entity name="WalletUserAssetGroup" representedClassName="Data.WalletUserAssetGroup" syncable="YES">
+        <attribute name="groupId" optional="YES" attributeType="String"/>
+        <relationship name="walletUserAssets" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="WalletUserAsset" inverseName="walletUserAssetGroup" inverseEntity="WalletUserAsset"/>
+    </entity>
+</model>

--- a/ios/brave-ios/Sources/Data/models/SessionWindow.swift
+++ b/ios/brave-ios/Sources/Data/models/SessionWindow.swift
@@ -10,7 +10,6 @@ import os.log
 
 public final class SessionWindow: NSManagedObject, CRUD {
   @NSManaged public var index: Int32
-  @NSManaged private(set) public var isPrivate: Bool
   @NSManaged public var isSelected: Bool
   @NSManaged private(set) public var windowId: UUID
 
@@ -35,7 +34,6 @@ public final class SessionWindow: NSManagedObject, CRUD {
   public init(
     context: NSManagedObjectContext,
     index: Int32,
-    isPrivate: Bool,
     isSelected: Bool
   ) {
     guard let entity = NSEntityDescription.entity(forEntityName: "SessionWindow", in: context)
@@ -47,7 +45,6 @@ public final class SessionWindow: NSManagedObject, CRUD {
     self.sessionTabs = Set()
     self.sessionTabGroups = Set()
     self.index = index
-    self.isPrivate = isPrivate
     self.isSelected = isSelected
     self.windowId = UUID()
   }
@@ -84,7 +81,6 @@ extension SessionWindow {
       _ = SessionWindow(
         context: context,
         index: index,
-        isPrivate: isPrivate,
         isSelected: isSelected
       )
 
@@ -98,7 +94,7 @@ extension SessionWindow {
     }
   }
 
-  public static func createWindow(isPrivate: Bool, isSelected: Bool, uuid: UUID) {
+  public static func createWindow(isSelected: Bool, uuid: UUID) {
     DataController.performOnMainContext { context in
       if let sessionWindow = SessionWindow.from(windowId: uuid, in: context) {
         Self.all().forEach {
@@ -113,7 +109,6 @@ extension SessionWindow {
       let window = SessionWindow(
         context: context,
         index: Int32(count),
-        isPrivate: isPrivate,
         isSelected: isSelected
       )
       window.windowId = uuid
@@ -163,31 +158,6 @@ extension SessionWindow {
       }
 
       sessionWindow.delete(context: .existing(context))
-    }
-  }
-
-  public static func deleteAllWindows(privateOnly: Bool) {
-    DataController.perform { context in
-      guard
-        let sessionWindows = SessionWindow.all(
-          where: NSPredicate(format: "isPrivate == %@", NSNumber(value: privateOnly)),
-          context: context
-        )
-      else {
-        return
-      }
-
-      sessionWindows.forEach { sessionWindow in
-        sessionWindow.sessionTabs?.forEach {
-          $0.delete(context: .existing(context))
-        }
-
-        sessionWindow.sessionTabGroups?.forEach {
-          $0.delete(context: .existing(context))
-        }
-
-        sessionWindow.delete(context: .existing(context))
-      }
     }
   }
 }

--- a/ios/brave-ios/Tests/ClientTests/TabManagerTests.swift
+++ b/ios/brave-ios/Tests/ClientTests/TabManagerTests.swift
@@ -769,7 +769,7 @@ open class MockTabManagerDelegate: TabManagerDelegate {
       forNotification: NSNotification.Name.NSManagedObjectContextDidSave,
       object: nil
     )
-    SessionWindow.createWindow(isPrivate: false, isSelected: true, uuid: testWindowId)
+    SessionWindow.createWindow(isSelected: true, uuid: testWindowId)
     wait(for: [windowCreateExpectation], timeout: 5)
 
     delegate.expect([willAdd, didAdd])
@@ -812,7 +812,7 @@ open class MockTabManagerDelegate: TabManagerDelegate {
       forNotification: .NSManagedObjectContextDidSave,
       object: nil
     )
-    SessionWindow.createWindow(isPrivate: false, isSelected: true, uuid: testWindowId)
+    SessionWindow.createWindow(isSelected: true, uuid: testWindowId)
     wait(for: [windowCreateExpectation], timeout: 5)
 
     delegate.expect([willAdd, didAdd, willAdd, didAdd])


### PR DESCRIPTION
This change includes a number of changes surrounding how we deal with multi-windowing on iPad:
1. `SessionWindow.isPrivate` field removed since the concept of a window to only be able to access a single type of data does not exist on iOS
2. Sessions are always restored in regular mode (unless PBO mode is enabled) instead of relying on the stored scene session data
3. `NSUserActivity`'s stored within the window scene are now are only used to associate window ID's with the scene and only user activities used to create new windows are contain URL & isPrivate keys.

Resolves https://github.com/brave/brave-browser/issues/45827

### Test Plan:

Prefix: All tests on iPad
- Ensure tab restoration works correctly
- Ensure opening a new window (and new private window) by long pressing a link works as usual
- Test restoring a window in both regular mode, private mode and PBO mode. Unless PBO is enabled, window should restore in regular mode
- Test persistent private tabs when enabled are still available even if the window restores in regular mode
- Test STR from issue to ensure app cant get stuck in private mode
- Upgrade from a device stuck in private mode using STR in issue and ensure that it now launches in regular mode again