### PR TITLE
[Dropdown]: Make web3 settings dropdown widths consistent (uplift to 1.79.x)

### DIFF
--- a/browser/resources/settings/brave_wallet_page/brave_wallet_page.html
+++ b/browser/resources/settings/brave_wallet_page/brave_wallet_page.html
@@ -20,12 +20,6 @@
     .reset-transaction-info {
       cursor: pointer;
     }
-    settings-dropdown-menu.wide-drop-down {
-      --md-select-width: 260px;
-    }
-    settings-dropdown-menu.narrow-drop-down {
-      --md-select-width: 100px;
-    }
 
   #needsRestart {
     background-color: #fff;
@@ -74,7 +68,6 @@
   <div class="settings-box first">
     <div class="start">$i18n{defaultEthereumWalletDesc}</div>
     <settings-dropdown-menu id="defaultEthereumWalletType"
-                            class="wide-drop-down"
                             pref="{{prefs.brave.wallet.default_wallet2}}"
                             menu-options="[[ethereum_provider_options_]]">
     </settings-dropdown-menu>
@@ -82,7 +75,6 @@
   <div class="settings-box">
     <div class="start">$i18n{defaultSolanaWalletDesc}</div>
     <settings-dropdown-menu id="defaultSolanaWalletType"
-                            class="wide-drop-down"
                             pref="{{prefs.brave.wallet.default_solana_wallet}}"
                             menu-options="[[solana_provider_options_]]">
     </settings-dropdown-menu>
@@ -90,7 +82,6 @@
   <div class="settings-box">
     <div class="start">$i18n{defaultBaseCurrencyDesc}</div>
     <settings-dropdown-menu id="defaultBaseCurrencyType"
-                            class="narrow-drop-down"
                             pref="{{prefs.brave.wallet.default_base_currency}}"
                             menu-options="[[currency_list_]]">
     </settings-dropdown-menu>
@@ -98,7 +89,6 @@
   <div class="settings-box">
     <div class="start">$i18n{defaultBaseCryptocurrencyDesc}</div>
     <settings-dropdown-menu id="defaultBaseCryptocurrencyType"
-                            class="narrow-drop-down"
                             pref="{{prefs.brave.wallet.default_base_cryptocurrency}}"
                             menu-options="[[cryptocurrency_list_]]">
     </settings-dropdown-menu>
@@ -106,7 +96,6 @@
   <div class="settings-box" hidden="[[!isTransactionSimulationsFeatureEnabled]]">
     <div class="start">$i18nRaw{transactionSimulationDesc}</div>
       <settings-dropdown-menu id="transactionSimulationOptInStatus"
-        class="narrow-drop-down"
         pref="{{prefs.brave.wallet.transaction_simulation_opt_in_status}}"
         menu-options="[[transaction_simulation_opt_in_options_]]">
     </settings-dropdown-menu>


### PR DESCRIPTION
Uplift of #28931
Resolves https://github.com/brave/brave-browser/issues/45814

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.