### PR TITLE
Fix update relaunch nudge on macOS

### DIFF
--- a/build/commands/lib/config.js
+++ b/build/commands/lib/config.js
@@ -428,7 +428,7 @@ Config.prototype.buildArgs = function () {
     enable_updater: this.isOfficialBuild(),
     // Disable "Can't update Brave" notification on macOS until we have switched
     // to Omaha 4 and have background updates:
-    enable_update_notifications: this.isOfficialBuild() && this.getTargetOS() !== 'mac',
+    enable_update_notifications: this.isOfficialBuild(),
     brave_services_production_domain: this.braveServicesProductionDomain,
     brave_services_staging_domain: this.braveServicesStagingDomain,
     brave_services_dev_domain: this.braveServicesDevDomain,

--- a/chromium_src/chrome/browser/upgrade_detector/upgrade_detector_impl.cc
+++ b/chromium_src/chrome/browser/upgrade_detector/upgrade_detector_impl.cc
@@ -3,7 +3,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-#include "base/feature_list.h"
 #include "brave/browser/mac_features.h"
 #include "chrome/browser/buildflags.h"
 

--- a/chromium_src/chrome/browser/upgrade_detector/upgrade_detector_impl.cc
+++ b/chromium_src/chrome/browser/upgrade_detector/upgrade_detector_impl.cc
@@ -1,0 +1,27 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "base/feature_list.h"
+#include "chrome/browser/buildflags.h"
+
+#if BUILDFLAG(IS_MAC)
+// When the current build is more than several weeks old, upstream takes this as
+// a sign that automatic updates are broken and shows a prominent "Can't update
+// - please reinstall" notification. This makes sense for upstream, which uses
+// Omaha 4 with background updates on macOS. But we still use Sparkle, which
+// only updates while the browser is running and requires a relaunch to install
+// new versions. In this case, the "reinstall" prompt is very confusing,
+// especially because it is likely that Brave is just downloading an update in
+// the background. To work around this until we also have background updates on
+// macOS, we disable the outdated build detection feature. The easiest way to do
+// this here is as follows:
+#define FEATURE_ENABLED_BY_DEFAULT FEATURE_DISABLED_BY_DEFAULT
+#endif
+
+#include "src/chrome/browser/upgrade_detector/upgrade_detector_impl.cc"
+
+#if BUILDFLAG(IS_MAC)
+#undef FEATURE_ENABLED_BY_DEFAULT
+#endif

--- a/chromium_src/chrome/browser/upgrade_detector/upgrade_detector_impl.cc
+++ b/chromium_src/chrome/browser/upgrade_detector/upgrade_detector_impl.cc
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-#include "chrome/browser/buildflags.h"
+#include "build/build_config.h"
 
 // When the current build is more than several weeks old, upstream takes this as
 // a sign that automatic updates are broken and shows a prominent "Can't update

--- a/chromium_src/chrome/browser/upgrade_detector/upgrade_detector_impl.cc
+++ b/chromium_src/chrome/browser/upgrade_detector/upgrade_detector_impl.cc
@@ -4,24 +4,37 @@
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #include "base/feature_list.h"
+#include "brave/browser/mac_features.h"
 #include "chrome/browser/buildflags.h"
 
 #if BUILDFLAG(IS_MAC)
-// When the current build is more than several weeks old, upstream takes this as
-// a sign that automatic updates are broken and shows a prominent "Can't update
-// - please reinstall" notification. This makes sense for upstream, which uses
-// Omaha 4 with background updates on macOS. But we still use Sparkle, which
-// only updates while the browser is running and requires a relaunch to install
-// new versions. In this case, the "reinstall" prompt is very confusing,
-// especially because it is likely that Brave is just downloading an update in
-// the background. To work around this until we also have background updates on
-// macOS, we disable the outdated build detection feature. The easiest way to do
-// this here is as follows:
-#define FEATURE_ENABLED_BY_DEFAULT FEATURE_DISABLED_BY_DEFAULT
+namespace base {
+class FeatureList_BraveImpl : public FeatureList {
+ public:
+  static bool IsEnabled(const Feature& feature) {
+    if (!brave::ShouldUseOmaha4() &&
+        strcmp(feature.name, "OutdatedBuildDetector") == 0) {
+      // When the current build is more than several weeks old, upstream takes
+      // this as a sign that automatic updates are broken and shows a prominent
+      // "Can't update - please reinstall" notification. This makes sense for
+      // upstream, which uses Omaha 4 with background updates on macOS. But we
+      // still use Sparkle, which only updates while the browser is running and
+      // requires a relaunch to install new versions. In this case, the
+      // "reinstall" prompt is very confusing, especially because it is likely
+      // that Brave is just downloading an update in the background. To work
+      // around this, we disable the outdated build detection feature until we
+      // also have background updates on macOS.
+      return false;
+    }
+    return FeatureList::IsEnabled(feature);
+  }
+};
+}  // namespace base
+#define FeatureList FeatureList_BraveImpl
 #endif
 
 #include "src/chrome/browser/upgrade_detector/upgrade_detector_impl.cc"
 
 #if BUILDFLAG(IS_MAC)
-#undef FEATURE_ENABLED_BY_DEFAULT
+#undef FeatureList
 #endif

--- a/chromium_src/chrome/browser/upgrade_detector/upgrade_detector_impl.cc
+++ b/chromium_src/chrome/browser/upgrade_detector/upgrade_detector_impl.cc
@@ -3,7 +3,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-#include "brave/browser/mac_features.h"
 #include "chrome/browser/buildflags.h"
 
 // When the current build is more than several weeks old, upstream takes this as
@@ -16,6 +15,8 @@
 // the background. To work around this, we disable outdated build detection
 // until we also have background updates on macOS.
 #if BUILDFLAG(IS_MAC)
+#include "brave/browser/mac_features.h"
+
 #define BRAVE_UPGRADE_DETECTOR_IMPL_START_OUTDATED_BUILD_DETECTOR \
   if (!brave::ShouldUseOmaha4()) {                                \
     return;                                                       \

--- a/patches/chrome-browser-upgrade_detector-upgrade_detector_impl.cc.patch
+++ b/patches/chrome-browser-upgrade_detector-upgrade_detector_impl.cc.patch
@@ -1,0 +1,12 @@
+diff --git a/chrome/browser/upgrade_detector/upgrade_detector_impl.cc b/chrome/browser/upgrade_detector/upgrade_detector_impl.cc
+index a372c42fe5755b9328b25ca09efca7297a0db57e..3436b446e1bd1515543472bf2644a9c03eccdd62 100644
+--- a/chrome/browser/upgrade_detector/upgrade_detector_impl.cc
++++ b/chrome/browser/upgrade_detector/upgrade_detector_impl.cc
+@@ -214,6 +214,7 @@ void UpgradeDetectorImpl::DoCalculateThresholds() {
+ 
+ void UpgradeDetectorImpl::StartOutdatedBuildDetector() {
+   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
++  BRAVE_UPGRADE_DETECTOR_IMPL_START_OUTDATED_BUILD_DETECTOR
+   static BASE_FEATURE(kOutdatedBuildDetector, "OutdatedBuildDetector",
+                       base::FEATURE_ENABLED_BY_DEFAULT);
+ 


### PR DESCRIPTION
My PR https://github.com/brave/brave-core/pull/28351 tried to remove the confusing "Can't update Brave" popup:

![image](https://github.com/user-attachments/assets/94b5bd84-5906-4ec3-a968-7e0979e2ac9d)

This popup gets shown by upstream when it detects that the browser build is more than 8 weeks old. It makes little sense for us because we don't have background updates: At the moment, updates only take place while the browser is running. In most cases, users are running outdated builds when either 1) they haven't started Brave in a long time or 2) they haven't re-launched Brave in a long time. In both cases, a "Brave can't update - please reinstall" message is wrong and confusing. My PR therefore tried to remove the popup.

Unfortunately, my PR went too far and caused https://github.com/brave/brave-browser/issues/45802. That is, when an update is ready to be installed, we want the hamburger menu to change color and nudge the user to relaunch the browser to install the new version. My PR removed this functionality as well. This present PR now adds the functionality back while still avoiding the "Can't update Brave" popup.

Resolves https://github.com/brave/brave-browser/issues/45802.

# Test Plan

To test that the relaunch nudge appears in the hamburger menu, you can follow [these steps](https://github.com/brave/brave-browser/issues/37427#issuecomment-2815934740).

To test that this PR does not regress on https://github.com/brave/brave-browser/issues/37427, you can launch Brave with command line flag `"--simulate-outdated=Tue, 15 Nov 1994 12:45:26 GMT"` (with the quotation marks `"`). This should NOT bring up the "Can't update Brave" popup, even when waiting for several seconds.