### PR TITLE
[iOS] Ensure playlist web loaders inject adblock/shields (uplift to 1.78.x)

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Playlist/Managers & Cache/PlaylistCacheLoader.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Playlist/Managers & Cache/PlaylistCacheLoader.swift
@@ -25,7 +25,6 @@ class LivePlaylistWebLoaderFactory: PlaylistWebLoaderFactory {
 
 class LivePlaylistWebLoader: UIView, PlaylistWebLoader {
   fileprivate static var pageLoadTimeout = 300.0
-  private var pendingRequests = [String: URLRequest]()
 
   private let tab = Tab(
     configuration: WKWebViewConfiguration().then {
@@ -90,6 +89,7 @@ class LivePlaylistWebLoader: UIView, PlaylistWebLoader {
       browserViewController.tab(tab, didCreateWebView: webContentView)
 
       tab.addObserver(self)
+      tab.addPolicyDecider(self)
       tab.browserData?.replaceContentScript(
         PlaylistWebLoaderContentHelper(self),
         name: PlaylistWebLoaderContentHelper.scriptName,
@@ -278,5 +278,88 @@ extension LivePlaylistWebLoader: TabObserver {
     if error.userInfo["_WKRecoveryAttempterErrorKey"] == nil {
       self.handler?(nil)
     }
+  }
+}
+
+extension LivePlaylistWebLoader: TabPolicyDecider {
+  func tab(
+    _ tab: Tab,
+    shouldAllowRequest request: URLRequest,
+    requestInfo: WebRequestInfo
+  ) async -> WebPolicyDecision {
+    guard let requestURL = request.url else {
+      return .cancel
+    }
+
+    // Add logic that powers adblock into the playlist loader, this is mostly copied from
+    // BVC+TabPolicyDecider with the only difference being we force shields on and don't use
+    // persistent Domain lookups.
+
+    if let mainDocumentURL = request.mainDocumentURL {
+      if mainDocumentURL != tab.currentPageData?.mainFrameURL {
+        tab.currentPageData = PageData(mainFrameURL: mainDocumentURL)
+      }
+
+      let domainForMainFrame = Domain.getOrCreate(forUrl: mainDocumentURL, persistent: false)
+
+      if !requestInfo.isNewWindow {
+        tab.currentPageData?.addSubframeURL(
+          forRequestURL: requestURL,
+          isForMainFrame: requestInfo.isMainFrame
+        )
+        let scriptTypes =
+          await tab.currentPageData?.makeUserScriptTypes(
+            domain: domainForMainFrame,
+            isDeAmpEnabled: false
+          ) ?? []
+        tab.browserData?.setCustomUserScript(scripts: scriptTypes)
+      }
+    }
+
+    if ["http", "https", "data", "blob", "file"].contains(requestURL.scheme) {
+      if requestInfo.isMainFrame,
+        let etldP1 = requestURL.baseDomain,
+        tab.proceedAnywaysDomainList?.contains(etldP1) == false
+      {
+        let domain = Domain.getOrCreate(forUrl: requestURL, persistent: false)
+
+        let shouldBlock = await AdBlockGroupsManager.shared.shouldBlock(
+          requestURL: requestURL,
+          sourceURL: requestURL,
+          resourceType: .document,
+          domain: domain
+        )
+
+        if shouldBlock, let url = requestURL.encodeEmbeddedInternalURL(for: .blocked) {
+          let request = PrivilegedRequest(url: url) as URLRequest
+          tab.loadRequest(request)
+          return .cancel
+        }
+      }
+
+      if let mainDocumentURL = request.mainDocumentURL,
+        mainDocumentURL.schemelessAbsoluteString == requestURL.schemelessAbsoluteString,
+        requestInfo.isMainFrame
+      {
+        let domainForShields = Domain.getOrCreate(
+          forUrl: mainDocumentURL,
+          persistent: !false
+        )
+
+        // Force adblocking on
+        domainForShields.shield_allOff = 0
+        domainForShields.domainBlockAdsAndTrackingLevel = .standard
+
+        let ruleLists = await AdBlockGroupsManager.shared.ruleLists(for: domainForShields)
+        tab.contentBlocker?.set(ruleLists: ruleLists)
+      }
+
+      // Cookie Blocking code below
+      tab.browserData?.setScript(
+        script: .cookieBlocking,
+        enabled: Preferences.Privacy.blockAllCookies.value
+      )
+    }
+    return .allow
   }
 }


### PR DESCRIPTION
Uplift of #29002
Resolves https://github.com/brave/brave-browser/issues/45933

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.