### PR TITLE
Revert "Force load of dev_ui_resources.pak on universal apk (#28870)" (uplift to 1.78.x)

### DIFF
--- a/chromium_src/ui/base/resource/resource_bundle_android.cc
+++ b/chromium_src/ui/base/resource/resource_bundle_android.cc
@@ -10,36 +10,16 @@ namespace ui {
 namespace {
 
 int g_brave_resources_pack_fd = -1;
-int g_dev_ui_resources_pack_fd = -1;
-
 base::MemoryMappedFile::Region g_brave_resources_pack_region;
-base::MemoryMappedFile::Region g_dev_ui_resources_pack_region;
 }
 
-void BraveLoadAdditionalAndroidPackFiles() {
-  base::FilePath disk_file_path;
-
-  // brave_100_percent.pak is excluded now from the Android build because
-  // its resources are not used
-  if (LoadFromApkOrFile("assets/brave_resources.pak", &disk_file_path,
+void BraveLoadMainAndroidPackFile(const char* path_within_apk,
+                                  const base::FilePath& disk_file_path) {
+  if (LoadFromApkOrFile(path_within_apk, &disk_file_path,
                         &g_brave_resources_pack_fd,
                         &g_brave_resources_pack_region)) {
     ResourceBundle::GetSharedInstance().AddDataPackFromFileRegion(
         base::File(g_brave_resources_pack_fd), g_brave_resources_pack_region,
-        ui::kScaleFactorNone);
-  }
-
-  // dev_ui_resources.pak is required only for the case when the universal
-  // apk was generated from aab, with --android_aab_to_apk build key.
-  // For the aab bundle dev_ui_resources.pak is placed into a separate module,
-  // dev_ui-master.apk and with --android_aab_to_apk it goes into
-  // Bravearm64Universal.apk as-is, so we need to force load. The regular apk
-  // has dev-ui resources merged into resources.pak.
-  if (LoadFromApkOrFile("assets/dev_ui_resources.pak", &disk_file_path,
-                        &g_dev_ui_resources_pack_fd,
-                        &g_dev_ui_resources_pack_region)) {
-    ResourceBundle::GetSharedInstance().AddDataPackFromFileRegion(
-        base::File(g_dev_ui_resources_pack_fd), g_dev_ui_resources_pack_region,
         ui::kScaleFactorNone);
   }
 }

--- a/chromium_src/ui/base/resource/resource_bundle_android.h
+++ b/chromium_src/ui/base/resource/resource_bundle_android.h
@@ -11,7 +11,8 @@
 namespace ui {
 
 COMPONENT_EXPORT(UI_BASE)
-void BraveLoadAdditionalAndroidPackFiles();
+void BraveLoadMainAndroidPackFile(const char* path_within_apk,
+                                  const base::FilePath& disk_file_path);
 }
 
 #endif  // BRAVE_CHROMIUM_SRC_UI_BASE_RESOURCE_RESOURCE_BUNDLE_ANDROID_H_

--- a/common/resource_bundle_helper.cc
+++ b/common/resource_bundle_helper.cc
@@ -66,7 +66,10 @@ namespace brave {
 
 void InitializeResourceBundle() {
 #if BUILDFLAG(IS_ANDROID)
-  ui::BraveLoadAdditionalAndroidPackFiles();
+  ui::BraveLoadMainAndroidPackFile("assets/brave_resources.pak",
+                                   base::FilePath());
+  // brave_100_percent.pak is excluded now from the Android build because
+  // its resources are not used
 #else
   auto& rb = ui::ResourceBundle::GetSharedInstance();
   rb.AddDataPackFromPath(GetResourcesPakFilePath(), ui::kScaleFactorNone);


### PR DESCRIPTION
Uplift of #29013
Resolves https://github.com/brave/brave-browser/issues/45969

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.