### PR TITLE
Fix update relaunch nudge on macOS (uplift to 1.79.x)

### DIFF
--- a/build/commands/lib/config.js
+++ b/build/commands/lib/config.js
@@ -425,7 +425,7 @@ Config.prototype.buildArgs = function () {
     enable_updater: this.isOfficialBuild(),
     // Disable "Can't update Brave" notification on macOS until we have switched
     // to Omaha 4 and have background updates:
-    enable_update_notifications: this.isOfficialBuild() && this.getTargetOS() !== 'mac',
+    enable_update_notifications: this.isOfficialBuild(),
     brave_services_production_domain: this.braveServicesProductionDomain,
     brave_services_staging_domain: this.braveServicesStagingDomain,
     brave_services_dev_domain: this.braveServicesDevDomain,

--- a/chromium_src/chrome/browser/upgrade_detector/upgrade_detector_impl.cc
+++ b/chromium_src/chrome/browser/upgrade_detector/upgrade_detector_impl.cc
@@ -1,0 +1,30 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "build/build_config.h"
+
+// When the current build is more than several weeks old, upstream takes this as
+// a sign that automatic updates are broken and shows a prominent "Can't update
+// - please reinstall" notification. This makes sense for upstream, which uses
+// Omaha 4 with background updates on macOS. But we still use Sparkle, which
+// only updates while the browser is running and requires a relaunch to install
+// new versions. In this case, the "reinstall" prompt is very confusing,
+// especially because it is likely that Brave is just downloading an update in
+// the background. To work around this, we disable outdated build detection
+// until we also have background updates on macOS.
+#if BUILDFLAG(IS_MAC)
+#include "brave/browser/mac_features.h"
+
+#define BRAVE_UPGRADE_DETECTOR_IMPL_START_OUTDATED_BUILD_DETECTOR \
+  if (!brave::ShouldUseOmaha4()) {                                \
+    return;                                                       \
+  }
+#else
+#define BRAVE_UPGRADE_DETECTOR_IMPL_START_OUTDATED_BUILD_DETECTOR
+#endif
+
+#include "src/chrome/browser/upgrade_detector/upgrade_detector_impl.cc"
+
+#undef BRAVE_UPGRADE_DETECTOR_IMPL_START_OUTDATED_BUILD_DETECTOR

--- a/patches/chrome-browser-upgrade_detector-upgrade_detector_impl.cc.patch
+++ b/patches/chrome-browser-upgrade_detector-upgrade_detector_impl.cc.patch
@@ -1,0 +1,12 @@
+diff --git a/chrome/browser/upgrade_detector/upgrade_detector_impl.cc b/chrome/browser/upgrade_detector/upgrade_detector_impl.cc
+index a372c42fe5755b9328b25ca09efca7297a0db57e..3436b446e1bd1515543472bf2644a9c03eccdd62 100644
+--- a/chrome/browser/upgrade_detector/upgrade_detector_impl.cc
++++ b/chrome/browser/upgrade_detector/upgrade_detector_impl.cc
+@@ -214,6 +214,7 @@ void UpgradeDetectorImpl::DoCalculateThresholds() {
+ 
+ void UpgradeDetectorImpl::StartOutdatedBuildDetector() {
+   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
++  BRAVE_UPGRADE_DETECTOR_IMPL_START_OUTDATED_BUILD_DETECTOR
+   static BASE_FEATURE(kOutdatedBuildDetector, "OutdatedBuildDetector",
+                       base::FEATURE_ENABLED_BY_DEFAULT);
+ 


### PR DESCRIPTION
Uplift of #28991
Resolves https://github.com/brave/brave-browser/issues/45802

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.