### PR TITLE
fix(privacy): Procedural filters applying on mutated elements on iOS

### DIFF
--- a/components/cosmetic_filters/resources/data/content_cosmetic_ios.js
+++ b/components/cosmetic_filters/resources/data/content_cosmetic_ios.js
@@ -829,7 +829,7 @@ import { applyCompiledSelector, compileProceduralSelector } from './procedural_f
    * polling mechanism
    */
   const scheduleQueuePump = (hide1pContent, genericHide) => {
-    if (!genericHide) {
+    if (!genericHide || CC.hasProceduralActions) {
       if (args.firstSelectorsPollingDelayMs === undefined) {
         startPollingSelectors()
       } else {

--- a/components/cosmetic_filters/resources/data/content_cosmetic_ios.js
+++ b/components/cosmetic_filters/resources/data/content_cosmetic_ios.js
@@ -1228,6 +1228,8 @@ import { applyCompiledSelector, compileProceduralSelector } from './procedural_f
         }
       }
     }
+    // update stylesheet for procedural actions
+    setRulesOnStylesheetThrottled();
   };
 
   const waitForBody = () => {

--- a/ios/brave-ios/Tests/ClientTests/Resources/html/index.html
+++ b/ios/brave-ios/Tests/ClientTests/Resources/html/index.html
@@ -126,7 +126,14 @@
       div.textContent = `First local frame body: ${window.sval}`;
       localFrame.contentDocument.body.appendChild(div);
     }
-      
+
+    const addElementForProceduralFilter = () => {
+      const div = document.createElement('div');
+      div.id = "test-delayed-has-text";
+      div.innerText = 'Please hide me';
+      document.body.appendChild(div);
+    }
+
     const onload = () => {
       const localFrame = document.createElement('iframe');
       localFrame.id = 'local-iframe';
@@ -142,6 +149,7 @@
       
       setTimeout(displaySvalInBody, 100);
       setTimeout(displaySvalInLocalFrame, 200);
+      setTimeout(addElementForProceduralFilter, 500);
     };
     window.onload = onload;
     </script>

--- a/ios/brave-ios/Tests/ClientTests/Resources/scripts/cosmetic-filter-tests.js
+++ b/ios/brave-ios/Tests/ClientTests/Resources/scripts/cosmetic-filter-tests.js
@@ -24,7 +24,8 @@
       'upwardSelector': results.upwardSelector,
       'localFrameElement': results.localFrameElement,
       'hasTextDisplayIsNone': results.hasTextDisplayIsNone,
-      'hasDisplayIsNone': results.hasDisplayIsNone
+      'hasDisplayIsNone': results.hasDisplayIsNone,
+      'delayedHasTextHidden': results.delayedHasTextHidden
     })
   }
 
@@ -45,7 +46,8 @@
       upwardSelector: false,
       localFrameElement: false,
       hasTextDisplayIsNone: false,
-      hasDisplayIsNone: false
+      hasDisplayIsNone: false,
+      delayedHasTextHidden: false
     }
 
     elements.forEach((node) => {
@@ -86,6 +88,11 @@
       if (node.id === 'test-has-text') {
         const nodeDisplay = window.getComputedStyle(node).display
         results.hasTextDisplayIsNone = nodeDisplay === 'none'
+      }
+
+      if (node.id === 'test-delayed-has-text') {
+        const nodeDisplay = window.getComputedStyle(node).display
+        results.delayedHasTextHidden = nodeDisplay === 'none'
       }
 
       if (node.id === 'test-has') {


### PR DESCRIPTION
The `scheduleQueuePump` function in the iOS cosmetic filtering script missed including a check for `CC.hasProceduralActions` to trigger the creation of the mutation observer. This aligns the script with desktop implementation: https://github.com/brave/brave-core/blob/7bb0e7931cabbe5aba4f2a67808cf33048de3ef9/components/cosmetic_filters/resources/data/content_cosmetic.ts#L689-L694

Resolves https://github.com/brave/brave-browser/issues/46046

### Testplan

1. Add `stephenheaps.github.io##custom:has-text(open in app)` to custom filters
2. Visit https://stephenheaps.github.io/procedural-filters/dynamic.html
3. `open in app` text / element should be hidden


Before | After
--|--
![Visible](https://github.com/user-attachments/assets/03e37567-242f-49c0-8d1e-c1d69b5bacdf) | ![Hidden](https://github.com/user-attachments/assets/13a02a64-5528-40a5-a1c8-3d8ccf4c6be1)
