### PR TITLE
Disable `SplitView` feature when upstream's `SideBySide` is enabled

### DIFF
--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -1425,7 +1425,10 @@ source_set("brave_tab_features") {
     "tabs/features.cc",
     "tabs/features.h",
   ]
-  deps = [ "//base" ]
+  deps = [
+    "//base",
+    "//chrome/browser/ui:ui_features",
+  ]
 }
 
 source_set("brave_rewards_source") {

--- a/browser/ui/brave_browser_command_controller.cc
+++ b/browser/ui/brave_browser_command_controller.cc
@@ -132,8 +132,8 @@ void BraveBrowserCommandController::OnTabStripModelChanged(
   UpdateCommandsForSend();
   UpdateCommandsForPin();
 
-  if (base::FeatureList::IsEnabled(tabs::features::kBraveSplitView) &&
-      browser_->is_type_normal() && selection.active_tab_changed()) {
+  if (tabs::features::SplitViewEnabled() && browser_->is_type_normal() &&
+      selection.active_tab_changed()) {
     UpdateCommandForSplitView();
   }
 }

--- a/browser/ui/brave_browser_command_controller.cc
+++ b/browser/ui/brave_browser_command_controller.cc
@@ -132,7 +132,7 @@ void BraveBrowserCommandController::OnTabStripModelChanged(
   UpdateCommandsForSend();
   UpdateCommandsForPin();
 
-  if (tabs::features::SplitViewEnabled() && browser_->is_type_normal() &&
+  if (tabs::features::IsBraveSplitViewEnabled() && browser_->is_type_normal() &&
       selection.active_tab_changed()) {
     UpdateCommandForSplitView();
   }

--- a/browser/ui/browser_window/browser_window_features.cc
+++ b/browser/ui/browser_window/browser_window_features.cc
@@ -53,7 +53,7 @@ BraveVPNController* BrowserWindowFeatures::brave_vpn_controller() {
 void BrowserWindowFeatures::Init(BrowserWindowInterface* browser) {
   BrowserWindowFeatures_ChromiumImpl::Init(browser);
 
-  if (base::FeatureList::IsEnabled(tabs::features::kBraveSplitView)) {
+  if (tabs::features::SplitViewEnabled()) {
     split_view_browser_data_ = std::make_unique<SplitViewBrowserData>(browser);
   }
 }

--- a/browser/ui/browser_window/browser_window_features.cc
+++ b/browser/ui/browser_window/browser_window_features.cc
@@ -53,7 +53,7 @@ BraveVPNController* BrowserWindowFeatures::brave_vpn_controller() {
 void BrowserWindowFeatures::Init(BrowserWindowInterface* browser) {
   BrowserWindowFeatures_ChromiumImpl::Init(browser);
 
-  if (tabs::features::SplitViewEnabled()) {
+  if (tabs::features::IsBraveSplitViewEnabled()) {
     split_view_browser_data_ = std::make_unique<SplitViewBrowserData>(browser);
   }
 }

--- a/browser/ui/tabs/brave_tab_menu_model.cc
+++ b/browser/ui/tabs/brave_tab_menu_model.cc
@@ -122,7 +122,7 @@ void BraveTabMenuModel::Build(Browser* browser,
                            CommandCloseDuplicateTabs,
                            IDS_TAB_CXMENU_CLOSE_DUPLICATE_TABS);
 
-  if (base::FeatureList::IsEnabled(tabs::features::kBraveSplitView)) {
+  if (tabs::features::SplitViewEnabled()) {
     BuildItemsForSplitView(browser, tab_strip_model, indices);
     return;
   }

--- a/browser/ui/tabs/brave_tab_menu_model.cc
+++ b/browser/ui/tabs/brave_tab_menu_model.cc
@@ -122,7 +122,7 @@ void BraveTabMenuModel::Build(Browser* browser,
                            CommandCloseDuplicateTabs,
                            IDS_TAB_CXMENU_CLOSE_DUPLICATE_TABS);
 
-  if (tabs::features::SplitViewEnabled()) {
+  if (tabs::features::IsBraveSplitViewEnabled()) {
     BuildItemsForSplitView(browser, tab_strip_model, indices);
     return;
   }

--- a/browser/ui/tabs/features.cc
+++ b/browser/ui/tabs/features.cc
@@ -39,7 +39,7 @@ bool HorizontalTabsUpdateEnabled() {
   return base::FeatureList::IsEnabled(kBraveHorizontalTabsUpdate);
 }
 
-bool SplitViewEnabled() {
+bool IsBraveSplitViewEnabled() {
   if (!base::FeatureList::IsEnabled(tabs::features::kBraveSplitView)) {
     return false;
   }

--- a/browser/ui/tabs/features.cc
+++ b/browser/ui/tabs/features.cc
@@ -5,6 +5,8 @@
 
 #include "brave/browser/ui/tabs/features.h"
 
+#include "chrome/browser/ui/ui_features.h"
+
 namespace tabs::features {
 
 #if BUILDFLAG(IS_LINUX)
@@ -35,6 +37,17 @@ BASE_FEATURE(kBraveSplitView,
 
 bool HorizontalTabsUpdateEnabled() {
   return base::FeatureList::IsEnabled(kBraveHorizontalTabsUpdate);
+}
+
+bool SplitViewEnabled() {
+  if (!base::FeatureList::IsEnabled(tabs::features::kBraveSplitView)) {
+    return false;
+  }
+
+  // Brave can't use both features together.
+  // We'll migrate our SplitView feature onto upstream's SideBySide
+  // feature.
+  return !base::FeatureList::IsEnabled(::features::kSideBySide);
 }
 
 }  // namespace tabs::features

--- a/browser/ui/tabs/features.h
+++ b/browser/ui/tabs/features.h
@@ -26,6 +26,7 @@ BASE_DECLARE_FEATURE(kBraveVerticalTabScrollBar);
 BASE_DECLARE_FEATURE(kBraveSplitView);
 
 bool HorizontalTabsUpdateEnabled();
+bool SplitViewEnabled();
 
 }  // namespace tabs::features
 

--- a/browser/ui/tabs/features.h
+++ b/browser/ui/tabs/features.h
@@ -26,7 +26,7 @@ BASE_DECLARE_FEATURE(kBraveVerticalTabScrollBar);
 BASE_DECLARE_FEATURE(kBraveSplitView);
 
 bool HorizontalTabsUpdateEnabled();
-bool SplitViewEnabled();
+bool IsBraveSplitViewEnabled();
 
 }  // namespace tabs::features
 

--- a/browser/ui/tabs/split_view_browser_data.cc
+++ b/browser/ui/tabs/split_view_browser_data.cc
@@ -26,7 +26,7 @@ SplitViewBrowserData::SplitViewBrowserData(
     : tab_strip_model_adapter_(std::make_unique<SplitViewTabStripModelAdapter>(
           *this,
           browser_window_interface->GetTabStripModel())) {
-  CHECK(base::FeatureList::IsEnabled(tabs::features::kBraveSplitView));
+  CHECK(tabs::features::SplitViewEnabled());
 }
 
 SplitViewBrowserData::~SplitViewBrowserData() {

--- a/browser/ui/tabs/split_view_browser_data.cc
+++ b/browser/ui/tabs/split_view_browser_data.cc
@@ -26,7 +26,7 @@ SplitViewBrowserData::SplitViewBrowserData(
     : tab_strip_model_adapter_(std::make_unique<SplitViewTabStripModelAdapter>(
           *this,
           browser_window_interface->GetTabStripModel())) {
-  CHECK(tabs::features::SplitViewEnabled());
+  CHECK(tabs::features::IsBraveSplitViewEnabled());
 }
 
 SplitViewBrowserData::~SplitViewBrowserData() {

--- a/browser/ui/tabs/split_view_tab_strip_model_adapter.cc
+++ b/browser/ui/tabs/split_view_tab_strip_model_adapter.cc
@@ -22,7 +22,7 @@ SplitViewTabStripModelAdapter::SplitViewTabStripModelAdapter(
     SplitViewBrowserData& split_view_browser_data,
     TabStripModel* model)
     : split_view_browser_data_(split_view_browser_data), model_(*model) {
-  CHECK(tabs::features::SplitViewEnabled());
+  CHECK(tabs::features::IsBraveSplitViewEnabled());
 
   model_->AddObserver(this);
 }

--- a/browser/ui/tabs/split_view_tab_strip_model_adapter.cc
+++ b/browser/ui/tabs/split_view_tab_strip_model_adapter.cc
@@ -22,7 +22,7 @@ SplitViewTabStripModelAdapter::SplitViewTabStripModelAdapter(
     SplitViewBrowserData& split_view_browser_data,
     TabStripModel* model)
     : split_view_browser_data_(split_view_browser_data), model_(*model) {
-  CHECK(base::FeatureList::IsEnabled(tabs::features::kBraveSplitView));
+  CHECK(tabs::features::SplitViewEnabled());
 
   model_->AddObserver(this);
 }

--- a/browser/ui/views/frame/brave_browser_view.cc
+++ b/browser/ui/views/frame/brave_browser_view.cc
@@ -311,8 +311,7 @@ BraveBrowserView::BraveBrowserView(std::unique_ptr<Browser> browser)
                             base::Unretained(this)));
   }
 
-  if (base::FeatureList::IsEnabled(tabs::features::kBraveSplitView) &&
-      browser_->is_type_normal()) {
+  if (tabs::features::SplitViewEnabled() && browser_->is_type_normal()) {
     split_view_ =
         contents_container_->parent()->AddChildView(std::make_unique<SplitView>(
             *browser_, contents_container_, contents_web_view_));

--- a/browser/ui/views/frame/brave_browser_view.cc
+++ b/browser/ui/views/frame/brave_browser_view.cc
@@ -311,7 +311,7 @@ BraveBrowserView::BraveBrowserView(std::unique_ptr<Browser> browser)
                             base::Unretained(this)));
   }
 
-  if (tabs::features::SplitViewEnabled() && browser_->is_type_normal()) {
+  if (tabs::features::IsBraveSplitViewEnabled() && browser_->is_type_normal()) {
     split_view_ =
         contents_container_->parent()->AddChildView(std::make_unique<SplitView>(
             *browser_, contents_container_, contents_web_view_));

--- a/browser/ui/views/split_view/split_view.cc
+++ b/browser/ui/views/split_view/split_view.cc
@@ -87,7 +87,7 @@ SplitView::SplitView(Browser& browser,
     : browser_(browser),
       contents_container_(contents_container),
       contents_web_view_(contents_web_view) {
-  CHECK(base::FeatureList::IsEnabled(tabs::features::kBraveSplitView));
+  CHECK(tabs::features::SplitViewEnabled());
 
   // Re-parent the |contents_container| to this view.
   AddChildView(

--- a/browser/ui/views/split_view/split_view.cc
+++ b/browser/ui/views/split_view/split_view.cc
@@ -87,7 +87,7 @@ SplitView::SplitView(Browser& browser,
     : browser_(browser),
       contents_container_(contents_container),
       contents_web_view_(contents_web_view) {
-  CHECK(tabs::features::SplitViewEnabled());
+  CHECK(tabs::features::IsBraveSplitViewEnabled());
 
   // Re-parent the |contents_container| to this view.
   AddChildView(

--- a/browser/ui/views/split_view/split_view_browsertest.cc
+++ b/browser/ui/views/split_view/split_view_browsertest.cc
@@ -68,7 +68,7 @@ IN_PROC_BROWSER_TEST_F(SideBySideEnabledBrowserTest, LaunchTest) {
                     ->multi_contents_view_for_testing());
 
   // Check SplitView feature is not enabled.
-  EXPECT_FALSE(tabs::features::SplitViewEnabled());
+  EXPECT_FALSE(tabs::features::IsBraveSplitViewEnabled());
   auto* split_view_data = browser()->GetFeatures().split_view_browser_data();
   EXPECT_FALSE(!!split_view_data);
 }

--- a/browser/ui/views/split_view/split_view_browsertest.cc
+++ b/browser/ui/views/split_view/split_view_browsertest.cc
@@ -53,10 +53,8 @@ IN_PROC_BROWSER_TEST_F(SplitViewDisabledBrowserTest,
 class SideBySideEnabledBrowserTest : public InProcessBrowserTest {
  public:
   SideBySideEnabledBrowserTest() {
-    // Can't enable SideBySide and our SplitView features together.
     scoped_features_.InitWithFeatures(
-        /*enabled_features*/ {features::kSideBySide},
-        /*disabled_features*/ {tabs::features::kBraveSplitView});
+        /*enabled_features*/ {features::kSideBySide}, {});
   }
   ~SideBySideEnabledBrowserTest() override = default;
 
@@ -68,6 +66,11 @@ class SideBySideEnabledBrowserTest : public InProcessBrowserTest {
 IN_PROC_BROWSER_TEST_F(SideBySideEnabledBrowserTest, LaunchTest) {
   EXPECT_TRUE(!!BrowserView::GetBrowserViewForBrowser(browser())
                     ->multi_contents_view_for_testing());
+
+  // Check SplitView feature is not enabled.
+  EXPECT_FALSE(tabs::features::SplitViewEnabled());
+  auto* split_view_data = browser()->GetFeatures().split_view_browser_data();
+  EXPECT_FALSE(!!split_view_data);
 }
 
 class SplitViewBrowserTest : public InProcessBrowserTest {

--- a/browser/ui/views/split_view/split_view_layout_manager.cc
+++ b/browser/ui/views/split_view/split_view_layout_manager.cc
@@ -38,7 +38,7 @@ SplitViewLayoutManager::SplitViewLayoutManager(
     : contents_container_(contents_container),
       secondary_contents_container_(secondary_contents_container),
       split_view_separator_(split_view_separator) {
-  CHECK(base::FeatureList::IsEnabled(tabs::features::kBraveSplitView));
+  CHECK(tabs::features::SplitViewEnabled());
   split_view_separator_->set_delegate(this);
 }
 

--- a/browser/ui/views/split_view/split_view_layout_manager.cc
+++ b/browser/ui/views/split_view/split_view_layout_manager.cc
@@ -38,7 +38,7 @@ SplitViewLayoutManager::SplitViewLayoutManager(
     : contents_container_(contents_container),
       secondary_contents_container_(secondary_contents_container),
       split_view_separator_(split_view_separator) {
-  CHECK(tabs::features::SplitViewEnabled());
+  CHECK(tabs::features::IsBraveSplitViewEnabled());
   split_view_separator_->set_delegate(this);
 }
 

--- a/chromium_src/chrome/browser/renderer_context_menu/render_view_context_menu.cc
+++ b/chromium_src/chrome/browser/renderer_context_menu/render_view_context_menu.cc
@@ -343,7 +343,7 @@ void OnRewriteSuggestionCompleted(
 
 bool CanOpenSplitViewForWebContents(
     base::WeakPtr<content::WebContents> web_contents) {
-  if (!tabs::features::SplitViewEnabled()) {
+  if (!tabs::features::IsBraveSplitViewEnabled()) {
     return false;
   }
 

--- a/chromium_src/chrome/browser/renderer_context_menu/render_view_context_menu.cc
+++ b/chromium_src/chrome/browser/renderer_context_menu/render_view_context_menu.cc
@@ -343,7 +343,7 @@ void OnRewriteSuggestionCompleted(
 
 bool CanOpenSplitViewForWebContents(
     base::WeakPtr<content::WebContents> web_contents) {
-  if (!base::FeatureList::IsEnabled(tabs::features::kBraveSplitView)) {
+  if (!tabs::features::SplitViewEnabled()) {
     return false;
   }
 

--- a/test/filters/browser_tests.filter
+++ b/test/filters/browser_tests.filter
@@ -2143,15 +2143,6 @@
 -All/OpticalCharacterRecognizerTest.PerformOCR_Simple/OCR_Enabled_Library_Available
 -MainContentExtractionTest.RequestWithContent
 
-# These tests fail because we disable kSideBySide
--MultiContentsViewBrowserTest.*
--TabStripModelBrowserTest.CommandAddToSplit
--TabStripModelBrowserTest.CommandOrganizeTabs
--TabStripModelBrowserTest.CommandRemoveSplit
--TabStripModelBrowserTest.DetachWebContentsAtForInsertion
--TabStripModelBrowserTest.OnTabGroupAdded
--TabStripModelBrowserTest.OnTabGroupWillBeRemoved
-
 # These tests fail because we disable MV2 deprecation and disablement
 -ManifestV2ExperimentManagerBrowserTest.*
 -ManifestV2ExperimentWithLegacyExtensionSupportTest.*


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/46089

This PR introduced `tab::features::IsBraveSplitViewEnabled()` and simply replace `base::FeatureList::IsEnabled(tabs::features::kBraveSplitView)` with it.
`tab::features::IsBraveSplitViewEnabled()` always gives false if `SideBySide` is enabled.

Some upstream tests were failed because both features are enabled.
In that situation, Brave can't run. All filtered upstream tests are added again.
We'll migrate our SplitView UX onto upstream's SideBySide feature.

TEST=`SideBySideEnabledBrowserTest.*`

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
