### PR TITLE
[Rewards] Add support for card banners

### DIFF
--- a/components/brave_rewards/core/engine/endpoints/brave/get_ui_cards.cc
+++ b/components/brave_rewards/core/engine/endpoints/brave/get_ui_cards.cc
@@ -72,6 +72,18 @@ std::optional<std::vector<mojom::UICardPtr>> ReadResponseBody(
       if (auto order = dict.FindInt("order")) {
         card->order = *order;
       }
+      if (auto* banner_dict = dict.FindDict("banner")) {
+        auto banner = mojom::UICardBanner::New();
+        if (auto* image = banner_dict->FindString("image")) {
+          banner->image = *image;
+        }
+        if (auto* url = banner_dict->FindString("url")) {
+          banner->url = *url;
+        }
+        if (!banner->url.empty() && !banner->image.empty()) {
+          card->banner = std::move(banner);
+        }
+      }
       if (auto* list = dict.FindList("items")) {
         card->items = ReadItemList(*list);
       }

--- a/components/brave_rewards/core/engine/endpoints/brave/get_ui_cards_unittest.cc
+++ b/components/brave_rewards/core/engine/endpoints/brave/get_ui_cards_unittest.cc
@@ -43,6 +43,10 @@ TEST_F(RewardsGetUICardsTest, ExpectedResponse) {
       "title": "$card-title",
       "section": "explore",
       "order": 1,
+      "banner": {
+        "image": "$banner-image",
+        "url": "$banner-url"
+      },
       "items": [{
         "title": "$title",
         "description": "$description",
@@ -71,6 +75,9 @@ TEST_F(RewardsGetUICardsTest, ExpectedResponse) {
   EXPECT_EQ(promo_card->title, "$card-title");
   EXPECT_EQ(promo_card->section, "explore");
   EXPECT_EQ(promo_card->order, 1);
+  ASSERT_TRUE(promo_card->banner);
+  EXPECT_EQ(promo_card->banner->image, "$banner-image");
+  EXPECT_EQ(promo_card->banner->url, "$banner-url");
   ASSERT_EQ(promo_card->items.size(), static_cast<size_t>(1));
   EXPECT_EQ(promo_card->items[0]->title, "$title");
   EXPECT_EQ(promo_card->items[0]->description, "$description");

--- a/components/brave_rewards/core/mojom/rewards.mojom
+++ b/components/brave_rewards/core/mojom/rewards.mojom
@@ -362,10 +362,16 @@ struct UICardItem {
   string thumbnail;
 };
 
+struct UICardBanner {
+  string url;
+  string image;
+};
+
 struct UICard {
   string name;
   string title;
   string section;
   int32 order;
+  UICardBanner? banner;
   array<UICardItem> items;
 };

--- a/components/brave_rewards/resources/rewards_page/components/explore/card_item_view.tsx
+++ b/components/brave_rewards/resources/rewards_page/components/explore/card_item_view.tsx
@@ -7,30 +7,7 @@ import * as React from 'react'
 
 import { UICardItem } from '../../lib/app_state'
 import { NewTabLink } from '../../../shared/components/new_tab_link'
-
-function sanitizeURL(url: string) {
-  try {
-    return new URL(url).protocol === 'https:' ? url : ''
-  } catch {
-    return ''
-  }
-}
-
-function faviconURL(item: UICardItem) {
-  return `chrome://favicon2/?size=64&pageUrl=${encodeURIComponent(item.url)}`
-}
-
-function thumbnailURL(url: string) {
-  url = sanitizeURL(url)
-  try {
-    if (/(^|\.)brave(software)?\.com$/i.test(new URL(url).hostname)) {
-      return `chrome://rewards-image/${url}`
-    }
-    return ''
-  } catch {
-    return ''
-  }
-}
+import { sanitizeURL, faviconURL, cardImageURL } from './card_urls'
 
 interface Props {
   item: UICardItem
@@ -38,14 +15,14 @@ interface Props {
 
 export function CardItemView(props: Props) {
   const { item } = props
-  const thumbnail = thumbnailURL(item.thumbnail)
+  const thumbnail = cardImageURL(item.thumbnail)
   return (
     <NewTabLink href={sanitizeURL(item.url)}>
       <span className='thumbnail'>
         {
           thumbnail
             ? <img src={thumbnail} />
-            : <img className='favicon' src={faviconURL(item)} />
+            : <img className='favicon' src={faviconURL(item.url)} />
         }
       </span>
       <span className='item-info'>

--- a/components/brave_rewards/resources/rewards_page/components/explore/card_urls.ts
+++ b/components/brave_rewards/resources/rewards_page/components/explore/card_urls.ts
@@ -1,0 +1,28 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+export function sanitizeURL(url: string) {
+  try {
+    return new URL(url).protocol === 'https:' ? url : ''
+  } catch {
+    return ''
+  }
+}
+
+export function faviconURL(url: string) {
+  return `chrome://favicon2/?size=64&pageUrl=${encodeURIComponent(url)}`
+}
+
+export function cardImageURL(url: string) {
+  url = sanitizeURL(url)
+  try {
+    if (/(^|\.)brave(software)?\.com$/i.test(new URL(url).hostname)) {
+      return `chrome://rewards-image/${url}`
+    }
+    return ''
+  } catch {
+    return ''
+  }
+}

--- a/components/brave_rewards/resources/rewards_page/components/explore/card_view.style.ts
+++ b/components/brave_rewards/resources/rewards_page/components/explore/card_view.style.ts
@@ -29,6 +29,21 @@ export const style = scoped.css`
     }
   }
 
+  .banner {
+    display: flex;
+    border-radius: 12px;
+    overflow: hidden;
+
+    img {
+      width: 100%;
+      height: auto;
+    }
+  }
+
+  section:empty {
+    display: none;
+  }
+
   section a {
     display: flex;
     gap: 16px;

--- a/components/brave_rewards/resources/rewards_page/components/explore/card_view.tsx
+++ b/components/brave_rewards/resources/rewards_page/components/explore/card_view.tsx
@@ -8,6 +8,8 @@ import * as React from 'react'
 import { useLocaleContext } from '../../lib/locale_strings'
 import { UICard } from '../../lib/app_state'
 import { CardItemView } from './card_item_view'
+import { NewTabLink } from '../../../shared/components/new_tab_link'
+import { sanitizeURL, cardImageURL } from './card_urls'
 
 import { style } from './card_view.style'
 
@@ -35,6 +37,12 @@ export function CardView(props: Props) {
   return (
     <div className='content-card' data-css-scope={style.scope}>
       <h4>{cardTitle()}</h4>
+      {
+        card.banner &&
+          <NewTabLink className='banner' href={sanitizeURL(card.banner.url)}>
+            <img src={cardImageURL(card.banner.image)} />
+          </NewTabLink>
+      }
       <section>
         {card.items.map((item, i) => <CardItemView key={i} item={item} />)}
       </section>

--- a/components/brave_rewards/resources/rewards_page/components/home/home_view.tsx
+++ b/components/brave_rewards/resources/rewards_page/components/home/home_view.tsx
@@ -12,6 +12,7 @@ import { EarningCard } from './earning_card'
 import { PayoutAccountCard } from './payout_account_card'
 import { BenefitsCard } from './benefits_card'
 import { RecurringContributionCard } from './recurring_contribution_card'
+import { TopPromoCard } from './top_promo_card'
 
 import { style } from './home_view.style'
 
@@ -41,6 +42,7 @@ export function HomeView() {
   return (
     <div data-css-scope={style.scope}>
       <ContributeCard />
+      <TopPromoCard />
       <EarningCard />
       <PayoutAccountCard />
       <BenefitsCard />

--- a/components/brave_rewards/resources/rewards_page/components/home/top_promo_card.tsx
+++ b/components/brave_rewards/resources/rewards_page/components/home/top_promo_card.tsx
@@ -1,0 +1,27 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import * as React from 'react'
+
+import { useAppState } from '../../lib/app_model_context'
+import { CardView } from '../explore/card_view'
+
+export function TopPromoCard() {
+  const cards = useAppState((state) => state.cards)
+  const isBubble = useAppState((state) => state.embedder.isBubble)
+
+  if (!cards || !isBubble) {
+    return null
+  }
+
+  const promoCards = cards.filter((card) => card.section === 'top')
+  if (promoCards.length === 0) {
+    return null
+  }
+
+  return promoCards.map((card) => (
+    <CardView key={card.name} card={card} />
+  ))
+}

--- a/components/brave_rewards/resources/rewards_page/lib/app_state.ts
+++ b/components/brave_rewards/resources/rewards_page/lib/app_state.ts
@@ -134,11 +134,17 @@ export interface UICardItem {
   thumbnail: string
 }
 
+export interface UICardBanner {
+  image: string
+  url: string
+}
+
 export interface UICard {
   name: string
   title: string
   section: string
   order: number
+  banner: UICardBanner | null | undefined
   items: UICardItem[]
 }
 

--- a/components/brave_rewards/resources/rewards_page/stories/storybook_model.ts
+++ b/components/brave_rewards/resources/rewards_page/stories/storybook_model.ts
@@ -135,6 +135,7 @@ export function createModel(): AppModel {
         title: '',
         order: 0,
         section: '',
+        banner: null,
         items: [
           {
             title: 'Brave meetup in Toronto!',
@@ -149,6 +150,7 @@ export function createModel(): AppModel {
         title: '',
         order: 0,
         section: '',
+        banner: null,
         items: [
           {
             title: 'Brave Embroidered Crop Top',
@@ -163,6 +165,7 @@ export function createModel(): AppModel {
         title: 'Ledger Hardware Wallet',
         order: 0,
         section: '',
+        banner: null,
         items: [
           {
             title: 'Secure Your Crypto with Ledger Nano',
@@ -171,6 +174,17 @@ export function createModel(): AppModel {
             thumbnail: ''
           }
         ]
+      },
+      {
+        name: 'top-banner-card',
+        title: 'Top Banner',
+        section: 'top',
+        order: 0,
+        banner: {
+          image: '',
+          url: ''
+        },
+        items: []
       }
     ]
   })


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/45607

<img width="408" alt="Screenshot 2025-05-16 at 8 50 33 AM" src="https://github.com/user-attachments/assets/5f6ad5fe-943d-45d4-ad7e-204fe48c6a94" />

### Test steps

With a Rewards-enabled profile using the staging environment:

* Open the Rewards panel
* Ensure that any cards that have a "banner" field are displayed with a banner (below the card header and above the card items, if any) and in the correct position.

Currently, in staging, the following cards have banners:

* "The Gardening Card" (top slot)
* "The Outdoor Living Card" (explore section)

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
