### PR TITLE
Fix #45840: Adjust brave version regex for translations (uplift to 1.79.x)

### DIFF
--- a/browser/resources/settings/brave_overrides/about_page.ts
+++ b/browser/resources/settings/brave_overrides/about_page.ts
@@ -26,8 +26,7 @@ RegisterStyleOverride(
 
 const extractVersions = (versionElement: Element) => {
   const [ _, braveVersion, chromiumVersion, build ] = versionElement
-    .innerHTML
-    .match(/^Version\s([\d+\.?]+)\sChromium:\s([\d+\.?]+)\s(.*)$/) ?? []
+    .textContent?.match(/(\d+\.\d+(?:\.\d+)*)\D+(\d+\.\d+(?:\.\d+)*)(.*)/) ?? []
 
   return { braveVersion, build, chromiumVersion }
 }


### PR DESCRIPTION
Uplift of #29047
Resolves https://github.com/brave/brave-browser/issues/45840

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.