### PR TITLE
style(wallet): Fix Search Icon Being Cut Off

### DIFF
--- a/components/brave_wallet_ui/components/shared/search-bar/index.tsx
+++ b/components/brave_wallet_ui/components/shared/search-bar/index.tsx
@@ -38,6 +38,7 @@ export const SearchBar = (props: Props) => {
         name='search'
       />
       <SearchInput
+        data-key='search-input'
         autoFocus={autoFocus}
         value={value}
         placeholder={placeholder}

--- a/components/brave_wallet_ui/components/shared/search-bar/search_bar.test.tsx
+++ b/components/brave_wallet_ui/components/shared/search-bar/search_bar.test.tsx
@@ -1,0 +1,37 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import * as React from 'react'
+import { render } from '@testing-library/react'
+import { SearchBar } from '.'
+
+describe('wallet search bar', () => {
+  it('renders search bar with search icon and search input', () => {
+    const { container } = render(
+      <SearchBar
+        placeholder='Search'
+        value='test'
+        action={() => {}}
+        isV2={true}
+      />
+    )
+
+    // Test search input
+    const searchInput = container.querySelector('[data-key="search-input"]')
+    expect(searchInput).toBeInTheDocument()
+    expect(searchInput).toBeVisible()
+    expect(searchInput).toHaveAttribute('placeholder', 'Search')
+    expect(searchInput).toHaveValue('test')
+    // This is to ensure that the search icon does not get
+    // pushed out of view to the left.
+    expect(searchInput).toHaveStyle({ minWidth: '0px' })
+
+    // Test search icon
+    const searchIcon = container.querySelector('leo-icon')
+    expect(searchIcon).toBeInTheDocument()
+    expect(searchIcon).toBeVisible()
+    expect(searchIcon).toHaveAttribute('name', 'search')
+  })
+})

--- a/components/brave_wallet_ui/components/shared/search-bar/style.ts
+++ b/components/brave_wallet_ui/components/shared/search-bar/style.ts
@@ -38,6 +38,7 @@ export const SearchInput = styled.input<{
 }>`
   flex: 1;
   height: 100%;
+  min-width: 0px;
   outline: none;
   background-image: none;
   background-color: var(--background-color);


### PR DESCRIPTION
## Description 

Fixes a bug where the `Search Icon` was being cut off on the `Explorer` tab on `Android` devices.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/44950>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

## Test Plan:

1. Open the `Wallet` and navigate to the `Explorer` tab on an `Android` phone.
2. The `Search` icon should not be cut off.

Before:

![Screenshot 16](https://github.com/user-attachments/assets/ed2060c2-c604-4eab-86e1-7d4c9c5551c5)

After:

![Screenshot 17](https://github.com/user-attachments/assets/da348be7-95a3-4c00-ac1e-755dc5087527)

