### PR TITLE
[iOS] - Fix Playlist unable to save Japanese videos offline

### DIFF
--- a/ios/brave-ios/Sources/Playlist/PlaylistDownloadManager.swift
+++ b/ios/brave-ios/Sources/Playlist/PlaylistDownloadManager.swift
@@ -413,7 +413,7 @@ private class PlaylistHLSDownloadManager: NSObject, AVAssetDownloadDelegate {
   func urlSession(
     _ session: URLSession,
     assetDownloadTask: AVAssetDownloadTask,
-    didFinishDownloadingTo location: URL
+    willDownloadTo location: URL
   ) {
     pendingDownloadTasks[assetDownloadTask] = location
   }
@@ -531,7 +531,8 @@ private class PlaylistHLSDownloadManager: NSObject, AVAssetDownloadDelegate {
     // so we must synchonously move the file to a temporary directory first before processing it
     // on a different thread since the Task will execute after this method returns
     let assetUrl = FileManager.default.temporaryDirectory
-      .appending(component: "\(asset.id)-\(temporaryUrl.lastPathComponent)")
+      .appending(component: asset.id).appendingPathExtension(temporaryUrl.pathExtension)
+
     try? FileManager.default.moveItem(at: temporaryUrl, to: assetUrl)
 
     @Sendable func cleanupAndFailDownload(location: URL?, error: Error) async {
@@ -920,7 +921,7 @@ private class PlaylistFileDownloadManager: NSObject, URLSessionDownloadDelegate 
       // so we must synchonously move the file to a temporary directory first before processing it
       // on a different thread since the Task will execute after this method returns
       let temporaryLocation = FileManager.default.temporaryDirectory
-        .appending(component: location.lastPathComponent)
+        .appending(component: asset.id).appendingPathExtension(location.pathExtension)
       try? FileManager.default.moveItem(at: location, to: temporaryLocation)
       Task {
         // Couldn't determine file type so we assume mp4 which is the most widely used container.


### PR DESCRIPTION
## Summary
- Fix playlist unable to download Japanese titled files or save them to disk due to double percent encoding.

## Test
1. Turn on Japanese VPN (such as NordVPN or BraveVPN)
2. When connected to a Japanese server, visit: https://sp.nicovideo.jp/watch/sm21036288 or https://sp.nicovideo.jp/watch/sm44980829
3. Add the video to playlist via the 3 dot menu
4. Long-Press to save offline
5. Video should save offline

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves: https://github.com/brave/brave-browser/issues/46236
Follow-Up of: https://github.com/brave/brave-browser/issues/42764

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
