### PR TITLE
style(wallet): Fix Arrow Icon on Buy Screen Android

### DIFF
--- a/components/brave_wallet_ui/page/screens/fund-wallet/components/buy_quote/buy_quote.style.ts
+++ b/components/brave_wallet_ui/page/screens/fund-wallet/components/buy_quote/buy_quote.style.ts
@@ -24,6 +24,8 @@ export const StyledWrapper = styled.div<{ isOpen?: boolean }>`
     ${(p) => (p.isOpen ? color.button.background : color.divider.subtle)};
   background-color: ${color.container.background};
   width: 100%;
+  box-sizing: border-box;
+  overflow: hidden;
 `
 
 export const ProviderName = styled.p`

--- a/components/brave_wallet_ui/page/screens/fund-wallet/components/buy_quote/buy_quote.test.tsx
+++ b/components/brave_wallet_ui/page/screens/fund-wallet/components/buy_quote/buy_quote.test.tsx
@@ -1,0 +1,61 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import * as React from 'react'
+import { render, screen } from '@testing-library/react'
+
+// Mock Data
+import {
+  mockMeldCryptoQuotes,
+  mockServiceProviders
+} from '../../../../../common/constants/mocks'
+
+// Components
+import { BuyQuote } from './buy_quote'
+
+describe('buy quote option', () => {
+  it('renders buy quote option and handles click', () => {
+    const clickHandler = jest.fn()
+    const { container } = render(
+      <BuyQuote
+        quote={mockMeldCryptoQuotes[0]}
+        serviceProviders={mockServiceProviders}
+        isCreatingWidget={false}
+        isBestOption={true}
+        isOpenOverride={true}
+        onBuy={clickHandler}
+      />
+    )
+
+    // Test Text
+    expect(screen.getByText('Transak')).toBeInTheDocument()
+    expect(screen.getByText('braveWalletBestOption')).toBeInTheDocument()
+
+    // Test Styles
+    const styledWrapper = container.querySelector(
+      '[data-key="buy-quote-wrapper"]'
+    )
+    expect(styledWrapper).toBeInTheDocument()
+    expect(styledWrapper).toHaveStyle({
+      boxSizing: 'border-box',
+      overflow: 'hidden'
+    })
+
+    // Test Carat Icon
+    const caratIcon = container.querySelector('leo-icon[name="carat-down"]')
+    expect(caratIcon).toBeInTheDocument()
+    expect(caratIcon).toBeVisible()
+    expect(caratIcon).toHaveAttribute('name', 'carat-down')
+
+    // Test Buy Button Click
+    const buyButton: any = document.querySelector('leo-button')
+    expect(buyButton).toBeInTheDocument()
+    expect(buyButton).toBeVisible()
+
+    // Button is a leo-button, we we trigger the click from the shadowRoot
+    buyButton?.shadowRoot?.querySelector('button').click()
+    expect(clickHandler).toHaveBeenCalledWith(mockMeldCryptoQuotes[0])
+  })
+})

--- a/components/brave_wallet_ui/page/screens/fund-wallet/components/buy_quote/buy_quote.tsx
+++ b/components/brave_wallet_ui/page/screens/fund-wallet/components/buy_quote/buy_quote.tsx
@@ -109,7 +109,10 @@ export const BuyQuote = ({
     : quoteServiceProvider?.logoImages?.lightShortUrl
 
   return (
-    <StyledWrapper isOpen={isOpen}>
+    <StyledWrapper
+      isOpen={isOpen}
+      data-key='buy-quote-wrapper'
+    >
       <Row
         justifyContent='space-between'
         width='100%'
@@ -134,23 +137,31 @@ export const BuyQuote = ({
           gap='8px'
           justifyContent='flex-end'
         >
-          {isBestOption ? (
-            <BestOptionLabel>
-              <div slot='icon-before'>
-                <Icon name='thumb-up' />
-              </div>
-              {getLocale('braveWalletBestOption')}
-            </BestOptionLabel>
-          ) : null}
-          <PaymentMethodsWrapper>
-            {isDeditCardSupported ? <PaymentMethodIcon name='bank' /> : null}
-            {isCreditCardSupported ? (
-              <PaymentMethodIcon name='credit-card' />
+          <Row
+            width='unset'
+            gap='8px'
+            justifyContent='flex-end'
+            flexWrap='wrap'
+          >
+            {isBestOption ? (
+              <BestOptionLabel>
+                <div slot='icon-before'>
+                  <Icon name='thumb-up' />
+                </div>
+                {getLocale('braveWalletBestOption')}
+              </BestOptionLabel>
             ) : null}
-          </PaymentMethodsWrapper>
+            <PaymentMethodsWrapper>
+              {isDeditCardSupported ? <PaymentMethodIcon name='bank' /> : null}
+              {isCreditCardSupported ? (
+                <PaymentMethodIcon name='credit-card' />
+              ) : null}
+            </PaymentMethodsWrapper>
+          </Row>
           <CaratIcon
             isOpen={isOpen}
             name='carat-down'
+            data-key='carat-icon'
           />
         </Row>
       </Row>


### PR DESCRIPTION
## Description 

Fixes a bug where the `Arrow` icon was being pushed outside of the `Buy Quote` option container on Android devices

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/44413>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

## Test Plan:

1. Open the `Wallet` and navigate to the `Buy` tab on an `Android` phone.
2. Wait for some `Quotes` to fetch
3. The `Arrow` icon should not be pushed outside of the `Buy Quote` option container

Before:

![Screenshot 20](https://github.com/user-attachments/assets/5acacd66-3d2e-4572-b69e-36e0d3eef6f8)

After:

![Screenshot 19](https://github.com/user-attachments/assets/3bcb6371-59ec-4192-aecd-7443a8fb8ca3)
