### PR TITLE
[iOS] Set explicit ButtonStyle to avoid duplicated accessibility outlines

### DIFF
--- a/ios/brave-ios/Sources/BrowserMenu/BrowserMenu.swift
+++ b/ios/brave-ios/Sources/BrowserMenu/BrowserMenu.swift
@@ -105,6 +105,7 @@ public struct BrowserMenu: View {
                 .padding(.horizontal, 12)
                 .background(Color(braveSystemName: .iosBrowserContainerHighlightIos), in: .capsule)
             }
+            .buttonStyle(.plain)
           }
           .foregroundStyle(Color(braveSystemName: .textTertiary))
           QuickActionsView(actions: quickActions) { $action in


### PR DESCRIPTION
### Description

This PR resolves [#46014](https://github.com/brave/brave-browser/issues/46014) by explicitly setting `ButtonStyle` for buttons which already have a defined visual appearance. Without this, iOS draws duplicated accessibility outlines when "Button Shapes" is enabled in Accessibility settings.

### Changes

- Explicitly applied `.plain` (BrowserMenu - EditButton)

### Steps to Test

1. Go to Settings > Accessibility > Display & Text Size
2. Enable “Button Shapes”
3. Launch the app and verify that buttons like “Edit” no longer have duplicated outlines

### Issue

Fixes: brave/brave-browser#46014