### PR TITLE
Patch `FullscreenHtmlApiHandlerBase` to fix PIP

### DIFF
--- a/patches/chrome-android-java-src-org-chromium-chrome-browser-fullscreen-FullscreenHtmlApiHandlerBase.java.patch
+++ b/patches/chrome-android-java-src-org-chromium-chrome-browser-fullscreen-FullscreenHtmlApiHandlerBase.java.patch
@@ -1,7 +1,16 @@
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/fullscreen/FullscreenHtmlApiHandlerBase.java b/chrome/android/java/src/org/chromium/chrome/browser/fullscreen/FullscreenHtmlApiHandlerBase.java
-index a326a5b1e637afefe28214e83ac43b0614bacada..6c6329e43acef8b67f3341c47c0b3ca00e6d172c 100644
+index a326a5b1e637afefe28214e83ac43b0614bacada..93cd521a06cfe929558ee3bdcd569329866fb953 100644
 --- a/chrome/android/java/src/org/chromium/chrome/browser/fullscreen/FullscreenHtmlApiHandlerBase.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/fullscreen/FullscreenHtmlApiHandlerBase.java
+@@ -237,7 +237,7 @@ public abstract class FullscreenHtmlApiHandlerBase
+         @Override
+         public void onMultiWindowModeChanged(boolean isInMultiWindowMode) {
+             if (mTab != null && !mIsInMultiWindowMode && isInMultiWindowMode) {
+-                onExitFullscreen(mTab);
++                if (!mActivity.isInPictureInPictureMode()) onExitFullscreen(mTab);
+             }
+             mIsInMultiWindowMode = isInMultiWindowMode;
+         }
 @@ -300,6 +300,7 @@ public abstract class FullscreenHtmlApiHandlerBase
  
                      @Override


### PR DESCRIPTION
## Resolves https://github.com/brave/brave-browser/issues/46128

Patches `FullscreenHtmlApiHandlerBase` class to resolve an issue affecting PIP after the latest Chromium update.
Because the fix modifies the non-static inner class `FullscreenMultiWindowModeObserver` it's not possible to rely on bytecode manipulation methods like `redirectConstructor` as non-static inner classes hold a reference to their outer class making them hard to extend.


<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

## Test Plan:
- Open Brave Browser and navigate to youtube.com
- Search for a random video and play it
- Tap on the fullscreen icon within the YT player
- Navigate to the home screen using the swiping gestures or Android navigation bar
- Observe the activity playing the video entering into picture in picture mode
- Lock the screen
- Observe the audio keeps playing
- Unlock the screen
- Observe the activity is still correctly playing the video in picture in picture mode
