### PR TITLE
[ads] Fixes Clear Brave Ads data in brave://settings/clearBrowserData does not work (uplift to 1.79.x)

### DIFF
--- a/browser/resources/settings/brave_clear_browsing_data_dialog/brave_clear_browsing_data_dialog_behavior.ts
+++ b/browser/resources/settings/brave_clear_browsing_data_dialog/brave_clear_browsing_data_dialog_behavior.ts
@@ -24,7 +24,7 @@ import {
 export class BraveSettingsClearBrowsingDataDialogElement
 extends SettingsClearBrowsingDataDialogElement {
   declare braveRewardsEnabled_: boolean
-  onClearBraveAdsDataClickHandler_: ((e: Event) => void) = () => {}
+  declare onClearBraveAdsDataClickHandler_: ((e: Event) => void)
 
   private clearDataBrowserProxy_: BraveClearBrowsingDataDialogBrowserProxy =
     BraveClearBrowsingDataDialogBrowserProxyImpl.getInstance()
@@ -41,6 +41,10 @@ extends SettingsClearBrowsingDataDialogElement {
       braveRewardsEnabled_: {
         type: Boolean,
         value: false,
+      },
+      onClearBraveAdsDataClickHandler_: {
+        type: Function,
+        value: () => {},
       },
     }
   }


### PR DESCRIPTION
Uplift of #29107
Resolves https://github.com/brave/brave-browser/issues/46132

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.