### PR TITLE
Show mini urlbar in `BraveMultiContentsView`

### DIFF
--- a/browser/ui/views/frame/split_view/BUILD.gn
+++ b/browser/ui/views/frame/split_view/BUILD.gn
@@ -10,6 +10,8 @@ source_set("split_view") {
   ]
 
   deps = [
+    "//brave/browser/ui/views/split_view",
+    "//chrome/browser/profiles:profile",
     "//chrome/browser/ui/color:mixers",
     "//ui/base/metadata",
     "//ui/compositor",

--- a/browser/ui/views/frame/split_view/brave_multi_contents_view.cc
+++ b/browser/ui/views/frame/split_view/brave_multi_contents_view.cc
@@ -104,11 +104,9 @@ float BraveMultiContentsView::GetCornerRadius() const {
 }
 
 void BraveMultiContentsView::UpdateSecondaryLocationBar() {
-  int inactive_index = active_index_ == 0 ? 1 : 0;
   if (!secondary_location_bar_) {
     secondary_location_bar_ = std::make_unique<SplitViewLocationBar>(
-        browser_view_->browser()->profile()->GetPrefs(),
-        contents_container_views_[inactive_index]);
+        browser_view_->browser()->profile()->GetPrefs());
     secondary_location_bar_widget_ = std::make_unique<views::Widget>();
 
     secondary_location_bar_widget_->Init(
@@ -118,6 +116,7 @@ void BraveMultiContentsView::UpdateSecondaryLocationBar() {
 
   // Inactive web contents/view should be set to secondary location bar
   // as it's attached to inactive contents view.
+  int inactive_index = active_index_ == 0 ? 1 : 0;
   secondary_location_bar_->SetWebContents(
       GetInactiveContentsView()->GetWebContents());
   secondary_location_bar_->SetParentWebView(

--- a/browser/ui/views/frame/split_view/brave_multi_contents_view.cc
+++ b/browser/ui/views/frame/split_view/brave_multi_contents_view.cc
@@ -8,6 +8,8 @@
 #include "brave/browser/ui/brave_browser.h"
 #include "brave/browser/ui/color/brave_color_id.h"
 #include "brave/browser/ui/views/frame/brave_contents_view_util.h"
+#include "brave/browser/ui/views/split_view/split_view_location_bar.h"
+#include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
 #include "chrome/browser/ui/views/frame/contents_web_view.h"
 #include "chrome/browser/ui/views/frame/multi_contents_resize_area.h"
@@ -15,6 +17,15 @@
 #include "ui/color/color_provider.h"
 #include "ui/compositor/layer.h"
 #include "ui/views/border.h"
+#include "ui/views/widget/widget.h"
+
+BraveMultiContentsView::BraveMultiContentsView(
+    BrowserView* browser_view,
+    WebContentsFocusedCallback inactive_contents_focused_callback,
+    WebContentsResizeCallback contents_resize_callback)
+    : MultiContentsView(browser_view,
+                        inactive_contents_focused_callback,
+                        contents_resize_callback) {}
 
 BraveMultiContentsView::~BraveMultiContentsView() = default;
 
@@ -79,11 +90,38 @@ void BraveMultiContentsView::Layout(PassKey) {
   contents_container_views_[1]->SetBoundsRect(end_rect);
 }
 
+void BraveMultiContentsView::SetActiveIndex(int index) {
+  MultiContentsView::SetActiveIndex(index);
+
+  UpdateSecondaryLocationBar();
+}
+
 float BraveMultiContentsView::GetCornerRadius() const {
   return BraveBrowser::ShouldUseBraveWebViewRoundedCorners(
              browser_view_->browser())
              ? BraveContentsViewUtil::kBorderRadius + kBorderThickness
              : 0;
+}
+
+void BraveMultiContentsView::UpdateSecondaryLocationBar() {
+  int inactive_index = active_index_ == 0 ? 1 : 0;
+  if (!secondary_location_bar_) {
+    secondary_location_bar_ = std::make_unique<SplitViewLocationBar>(
+        browser_view_->browser()->profile()->GetPrefs(),
+        contents_container_views_[inactive_index]);
+    secondary_location_bar_widget_ = std::make_unique<views::Widget>();
+
+    secondary_location_bar_widget_->Init(
+        SplitViewLocationBar::GetWidgetInitParams(
+            GetWidget()->GetNativeView(), secondary_location_bar_.get()));
+  }
+
+  // Inactive web contents/view should be set to secondary location bar
+  // as it's attached to inactive contents view.
+  secondary_location_bar_->SetWebContents(
+      GetInactiveContentsView()->GetWebContents());
+  secondary_location_bar_->SetParentWebView(
+      contents_container_views_[inactive_index]);
 }
 
 BEGIN_METADATA(BraveMultiContentsView)

--- a/browser/ui/views/frame/split_view/brave_multi_contents_view.h
+++ b/browser/ui/views/frame/split_view/brave_multi_contents_view.h
@@ -6,11 +6,18 @@
 #ifndef BRAVE_BROWSER_UI_VIEWS_FRAME_SPLIT_VIEW_BRAVE_MULTI_CONTENTS_VIEW_H_
 #define BRAVE_BROWSER_UI_VIEWS_FRAME_SPLIT_VIEW_BRAVE_MULTI_CONTENTS_VIEW_H_
 
+#include <memory>
 #include <vector>
 
 #include "base/gtest_prod_util.h"
 #include "chrome/browser/ui/views/frame/multi_contents_view.h"
 #include "ui/base/metadata/metadata_header_macros.h"
+
+namespace views {
+class Widget;
+}  // namespace views
+
+class SplitViewLocationBar;
 
 class BraveMultiContentsView : public MultiContentsView {
   METADATA_HEADER(BraveMultiContentsView, MultiContentsView)
@@ -18,7 +25,10 @@ class BraveMultiContentsView : public MultiContentsView {
  public:
   static constexpr int kBorderThickness = 2;
 
-  using MultiContentsView::MultiContentsView;
+  BraveMultiContentsView(
+      BrowserView* browser_view,
+      WebContentsFocusedCallback inactive_contents_focused_callback,
+      WebContentsResizeCallback contents_resize_callback);
   ~BraveMultiContentsView() override;
 
  private:
@@ -28,13 +38,18 @@ class BraveMultiContentsView : public MultiContentsView {
   // MultiContentsView:
   void UpdateContentsBorder() override;
   void Layout(PassKey) override;
+  void SetActiveIndex(int index) override;
 
   float GetCornerRadius() const;
+  void UpdateSecondaryLocationBar();
 
   std::vector<ContentsContainerView*> contents_container_views_for_testing()
       const {
     return contents_container_views_;
   }
+
+  std::unique_ptr<SplitViewLocationBar> secondary_location_bar_;
+  std::unique_ptr<views::Widget> secondary_location_bar_widget_;
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_FRAME_SPLIT_VIEW_BRAVE_MULTI_CONTENTS_VIEW_H_

--- a/browser/ui/views/frame/split_view/brave_multi_contents_view.h
+++ b/browser/ui/views/frame/split_view/brave_multi_contents_view.h
@@ -32,6 +32,7 @@ class BraveMultiContentsView : public MultiContentsView {
   ~BraveMultiContentsView() override;
 
  private:
+  friend class SplitViewLocationBarBrowserTest;
   FRIEND_TEST_ALL_PREFIXES(SideBySideEnabledBrowserTest,
                            BraveMultiContentsViewTest);
 

--- a/browser/ui/views/split_view/split_view.cc
+++ b/browser/ui/views/split_view/split_view.cc
@@ -259,8 +259,9 @@ void SplitView::Layout(PassKey key) {
 void SplitView::AddedToWidget() {
   widget_observation_.Observe(GetWidget());
 
-  secondary_location_bar_ = std::make_unique<SplitViewLocationBar>(
-      browser_->profile()->GetPrefs(), secondary_contents_container_);
+  secondary_location_bar_ =
+      std::make_unique<SplitViewLocationBar>(browser_->profile()->GetPrefs());
+  secondary_location_bar_->SetParentWebView(secondary_contents_container_);
   secondary_location_bar_widget_ = std::make_unique<views::Widget>();
 
   secondary_location_bar_widget_->Init(

--- a/browser/ui/views/split_view/split_view.cc
+++ b/browser/ui/views/split_view/split_view.cc
@@ -260,7 +260,7 @@ void SplitView::AddedToWidget() {
   widget_observation_.Observe(GetWidget());
 
   secondary_location_bar_ = std::make_unique<SplitViewLocationBar>(
-      browser_->profile()->GetPrefs(), this);
+      browser_->profile()->GetPrefs(), secondary_contents_container_);
   secondary_location_bar_widget_ = std::make_unique<views::Widget>();
 
   secondary_location_bar_widget_->Init(

--- a/browser/ui/views/split_view/split_view_location_bar.cc
+++ b/browser/ui/views/split_view/split_view_location_bar.cc
@@ -134,6 +134,18 @@ void SplitViewLocationBar::SetWebContents(content::WebContents* new_contents) {
   UpdateURLAndIcon();
 }
 
+void SplitViewLocationBar::SetParentWebView(views::View* parent_web_view) {
+  if (view_observation_.GetSource() == parent_web_view) {
+    return;
+  }
+
+  view_observation_.Reset();
+  view_observation_.Observe(parent_web_view);
+
+  UpdateVisibility();
+  UpdateBounds();
+}
+
 void SplitViewLocationBar::AddedToWidget() {
   WidgetDelegateView::AddedToWidget();
   UpdateVisibility();

--- a/browser/ui/views/split_view/split_view_location_bar.cc
+++ b/browser/ui/views/split_view/split_view_location_bar.cc
@@ -35,8 +35,7 @@
 #include "ui/views/view_class_properties.h"
 #include "ui/views/widget/widget_delegate.h"
 
-SplitViewLocationBar::SplitViewLocationBar(PrefService* prefs,
-                                           views::View* parent_web_view)
+SplitViewLocationBar::SplitViewLocationBar(PrefService* prefs)
     : prefs_(prefs),
       location_bar_model_delegate_(
           std::make_unique<SplitViewLocationBarModelDelegate>()),
@@ -44,12 +43,6 @@ SplitViewLocationBar::SplitViewLocationBar(PrefService* prefs,
           location_bar_model_delegate_.get(),
           content::kMaxURLDisplayChars)) {
   set_owned_by_client(OwnedByClientPassKey());
-
-  if (parent_web_view) {
-    view_observation_.Observe(parent_web_view);
-  } else {
-    CHECK_IS_TEST();
-  }
 
   constexpr auto kChildSpacing = 8;
   views::Builder<SplitViewLocationBar>(this)
@@ -142,8 +135,10 @@ void SplitViewLocationBar::SetParentWebView(views::View* parent_web_view) {
   view_observation_.Reset();
   view_observation_.Observe(parent_web_view);
 
-  UpdateVisibility();
-  UpdateBounds();
+  if (GetWidget()) {
+    UpdateVisibility();
+    UpdateBounds();
+  }
 }
 
 void SplitViewLocationBar::AddedToWidget() {

--- a/browser/ui/views/split_view/split_view_location_bar.cc
+++ b/browser/ui/views/split_view/split_view_location_bar.cc
@@ -36,9 +36,8 @@
 #include "ui/views/widget/widget_delegate.h"
 
 SplitViewLocationBar::SplitViewLocationBar(PrefService* prefs,
-                                           SplitView* split_view)
+                                           views::View* parent_web_view)
     : prefs_(prefs),
-      split_view_(split_view),
       location_bar_model_delegate_(
           std::make_unique<SplitViewLocationBarModelDelegate>()),
       location_bar_model_(std::make_unique<LocationBarModelImpl>(
@@ -46,8 +45,8 @@ SplitViewLocationBar::SplitViewLocationBar(PrefService* prefs,
           content::kMaxURLDisplayChars)) {
   set_owned_by_client(OwnedByClientPassKey());
 
-  if (split_view_) {
-    view_observation_.Observe(split_view_->secondary_contents_container());
+  if (parent_web_view) {
+    view_observation_.Observe(parent_web_view);
   } else {
     CHECK_IS_TEST();
   }

--- a/browser/ui/views/split_view/split_view_location_bar.h
+++ b/browser/ui/views/split_view/split_view_location_bar.h
@@ -25,7 +25,6 @@ class Label;
 class ImageView;
 }  // namespace views
 
-class SplitView;
 class SplitViewLocationBarModelDelegate;
 class PrefService;
 class LocationBarModel;
@@ -39,7 +38,7 @@ class SplitViewLocationBar : public views::WidgetDelegateView,
   METADATA_HEADER(SplitViewLocationBar, views::WidgetDelegateView)
 
  public:
-  SplitViewLocationBar(PrefService* prefs, SplitView* split_view);
+  SplitViewLocationBar(PrefService* prefs, views::View* parent_web_view);
   ~SplitViewLocationBar() override;
 
   static views::Widget::InitParams GetWidgetInitParams(
@@ -92,7 +91,6 @@ class SplitViewLocationBar : public views::WidgetDelegateView,
   SkPath GetBorderPath(bool close);
 
   raw_ptr<PrefService> prefs_ = nullptr;
-  raw_ptr<SplitView> split_view_ = nullptr;
 
   std::unique_ptr<SplitViewLocationBarModelDelegate>
       location_bar_model_delegate_;

--- a/browser/ui/views/split_view/split_view_location_bar.h
+++ b/browser/ui/views/split_view/split_view_location_bar.h
@@ -38,7 +38,7 @@ class SplitViewLocationBar : public views::WidgetDelegateView,
   METADATA_HEADER(SplitViewLocationBar, views::WidgetDelegateView)
 
  public:
-  SplitViewLocationBar(PrefService* prefs, views::View* parent_web_view);
+  explicit SplitViewLocationBar(PrefService* prefs);
   ~SplitViewLocationBar() override;
 
   static views::Widget::InitParams GetWidgetInitParams(

--- a/browser/ui/views/split_view/split_view_location_bar.h
+++ b/browser/ui/views/split_view/split_view_location_bar.h
@@ -45,6 +45,7 @@ class SplitViewLocationBar : public views::WidgetDelegateView,
       gfx::NativeView parent_native_view,
       views::WidgetDelegateView* delegate);
 
+  void SetParentWebView(views::View* parent_web_view);
   void SetWebContents(content::WebContents* web_contents);
 
   // views::WidgetDelegateView:

--- a/browser/ui/views/split_view/split_view_location_bar_unittest.cc
+++ b/browser/ui/views/split_view/split_view_location_bar_unittest.cc
@@ -93,7 +93,7 @@ class SplitViewLocationBarUnitTest : public testing::Test {
 
   // testing::Test
   void SetUp() override {
-    location_bar_ = std::make_unique<SplitViewLocationBar>(nullptr, nullptr);
+    location_bar_ = std::make_unique<SplitViewLocationBar>(nullptr);
     location_bar_->location_bar_model_ =
         std::make_unique<LocationBarModelImpl>(&delegate_, 1024);
   }

--- a/chromium_src/chrome/browser/ui/views/frame/multi_contents_view.h
+++ b/chromium_src/chrome/browser/ui/views/frame/multi_contents_view.h
@@ -11,8 +11,11 @@
   friend class BraveMultiContentsView; \
   virtual void UpdateContentsBorder
 
+#define SetActiveIndex virtual SetActiveIndex
+
 #include "src/chrome/browser/ui/views/frame/multi_contents_view.h"  // IWYU pragma: export
 
+#undef SetActiveIndex
 #undef UpdateContentsBorder
 
 #endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_FRAME_MULTI_CONTENTS_VIEW_H_


### PR DESCRIPTION
Show mini urlbar in BraveMultiContentsView

fix https://github.com/brave/brave-browser/issues/46161

TEST=`SplitViewLocationBarBrowserTest.*`

1. launch browser with --enable-features=SideBySide
2. Select Add tab to split view from tab's context menu
3. Check mini urlbar is displayed on the inactive tab's contents

![image](https://github.com/user-attachments/assets/2379b3e8-a20d-4bb0-9c6e-391100cfa2b9)

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
