### PR TITLE
Allow Mac app to quit when an update is available

### DIFF
--- a/browser/mac/sparkle_glue.mm
+++ b/browser/mac/sparkle_glue.mm
@@ -5,9 +5,10 @@
 
 #import "brave/browser/mac/sparkle_glue.h"
 
-#include <string>
 #include <sys/mount.h>
 #include <sys/stat.h>
+
+#include <string>
 
 #include "base/apple/bundle_locations.h"
 #include "base/apple/foundation_util.h"
@@ -21,6 +22,7 @@
 #include "brave/browser/update_util.h"
 #include "brave/common/brave_channel_info.h"
 #include "brave/components/constants/brave_switches.h"
+#include "chrome/browser/app_controller_mac.h"
 #include "chrome/common/channel_info.h"
 #include "chrome/common/chrome_constants.h"
 
@@ -391,6 +393,15 @@ std::string GetDescriptionFromAppcastItem(id item) {
              GetDescriptionFromAppcastItem(item);
 
   _updateWillBeInstalledOnQuit = YES;
+
+  // Updates roll out orders of magnitude slower on macOS than on other
+  // platforms. The current hypothesis is that the reason for this is the
+  // following: Updates require a relaunch to be applied. On other platforms,
+  // closing the last browser window terminates the application. But on macOS,
+  // the app keeps running by default. This prevents it from being updated.
+  // In an attempt to fix the problem, we therefore allow the application to
+  // terminate when an update is ready to be installed:
+  app_controller_mac::AllowApplicationToTerminate();
 
   [self determineUpdateStatusAsync];
 }


### PR DESCRIPTION
The motivation is that this should make updates roll out (/take effect) faster.

Resolves https://github.com/brave/brave-browser/issues/45426.

# Test Plan

1. Follow the usual steps to test automatic updates, until the step where you relaunch the browser to install the new version.
2. Close each browser window individually. (Do NOT press Cmd+Q or select _Quit_ from the main menu.)
3. Start the browser.

After step 2., the browser should no longer be running. After step 3., it should be at the new version.