### PR TITLE
Load NTP when creating split view with active tab

### DIFF
--- a/browser/ui/views/split_view/split_view_location_bar_browsertest.cc
+++ b/browser/ui/views/split_view/split_view_location_bar_browsertest.cc
@@ -134,14 +134,6 @@ IN_PROC_BROWSER_TEST_P(SplitViewLocationBarBrowserTest,
             tab_strip_model().GetWebContentsAt(0)->GetVisibleURL().spec());
   ASSERT_EQ(u"about:blank", split_view_location_bar().url_->GetText());
 
-  // For now upstream's another page is loaded when split view is created
-  // with active tab. So, loaded newtab to use below url check.
-  if (IsSideBySideEnabled()) {
-    ASSERT_TRUE(ui_test_utils::NavigateToURLWithDisposition(
-        browser(), GURL("chrome://newtab/"), WindowOpenDisposition::CURRENT_TAB,
-        ui_test_utils::BROWSER_TEST_WAIT_FOR_LOAD_STOP));
-  }
-
   // When activating another tab in split view,
   tab_strip_model().ActivateTabAt(0);
 

--- a/chromium_src/chrome/browser/ui/browser_commands.cc
+++ b/chromium_src/chrome/browser/ui/browser_commands.cc
@@ -8,10 +8,13 @@
 #include "brave/components/commander/common/buildflags/buildflags.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser_commands.h"
+#include "chrome/common/webui_url_constants.h"
 
 #define ReloadBypassingCache ReloadBypassingCache_ChromiumImpl
 #define GetReadingListModel GetReadingListModel_ChromiumImpl
+#define kChromeUISplitViewNewTabPageURL kChromeUINewTabURL
 #include "src/chrome/browser/ui/browser_commands.cc"
+#undef kChromeUISplitViewNewTabPageURL
 #undef ReloadBypassingCache
 #undef GetReadingListModel
 


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/46191

Uptream loads split view specific page when createing another tab.
We want to load NTP instead.

TEST=SplitViewLocationBarBrowserTest.URLShouldBeUpdated_WhenActiveTabChanges

1. launch browser with --enable-features=SideBySide
2. Select "Add tab to split view" from active tab's context menu
3. Check NTP is loaded in newly created tab


https://github.com/user-attachments/assets/e8b0d75b-ce2e-41bd-93cc-6867764b9640


<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
