### PR TITLE
[iOS] Reset `javaScriptEnabled` preference correctly between navigations (uplift to 1.79.x)

### DIFF
--- a/chromium_src/ios/web/navigation/crw_wk_navigation_handler.mm
+++ b/chromium_src/ios/web/navigation/crw_wk_navigation_handler.mm
@@ -40,6 +40,20 @@ bool ShouldBlockJavaScript(web::WebState* webState, NSURLRequest* request);
           // Only ever update it to false
           preferences.allowsContentJavaScript = false;
         }
+
+        if (@available(iOS 18, *)) {
+        } else {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+          // In prior versions of iOS,
+          // `WKWebpagePreferences.allowsContentJavaScript` does not work
+          // correctly in all cases:
+          // https://github.com/brave/brave-ios/issues/8585
+          webView.configuration.preferences.javaScriptEnabled =
+              preferences.allowsContentJavaScript;
+#pragma clang diagnostic pop
+        }
+
         if (policy == WKNavigationActionPolicyAllow) {
           // Check if we want to explicitly block universal links
           bool forceBlockUniversalLinks = brave::ShouldBlockUniversalLinks(

--- a/ios/brave-ios/Sources/Web/WebKit/TabWKNavigationHandler.swift
+++ b/ios/brave-ios/Sources/Web/WebKit/TabWKNavigationHandler.swift
@@ -116,17 +116,13 @@ class TabWKNavigationHandler: NSObject, WKNavigationDelegate {
       if let delegate = tab.delegate,
         delegate.tab(tab, shouldBlockJavaScriptForRequest: navigationAction.request)
       {
-        // Due to a bug in iOS WKWebpagePreferences.allowsContentJavaScript does NOT work!
-        // https://github.com/brave/brave-ios/issues/8585
-        //
-        // However, the deprecated API WKWebViewConfiguration.preferences.javaScriptEnabled DOES work!
-        // Even though `configuration` is @NSCopying, somehow this actually updates the preferences LIVE!!
-        // This follows the same behaviour as Safari
-        //
-        // - Brandon T.
-        //
         preferences.allowsContentJavaScript = false
-        webView.configuration.preferences.javaScriptEnabled = false
+      }
+
+      if #unavailable(iOS 18.0) {
+        // In prior versions of iOS, `WKWebpagePreferences.allowsContentJavaScript` does not work
+        // correctly in all cases: https://github.com/brave/brave-ios/issues/8585
+        webView.configuration.preferences.javaScriptEnabled = preferences.allowsContentJavaScript
       }
 
       // Downloads


### PR DESCRIPTION
Uplift of #29129
Resolves https://github.com/brave/brave-browser/issues/46155

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.