### PR TITLE
[ads] Fixes Creatives in a campaign fail to serve when the first creative's condition matcher fails (uplift to 1.79.x)

### DIFF
--- a/components/brave_ads/core/internal/creatives/new_tab_page_ads/creative_new_tab_page_ads_util.cc
+++ b/components/brave_ads/core/internal/creatives/new_tab_page_ads/creative_new_tab_page_ads_util.cc
@@ -154,15 +154,12 @@ void ParseAndSaveNewTabPageAds(base::Value::Dict dict,
       continue;
     }
 
-    CreativeNewTabPageAdInfo creative_ad;
-
     const std::string* const campaign_id =
         campaign_dict->FindString(kCampaignIdKey);
     if (!campaign_id) {
       BLOG(0, "Campaign ID is required, skipping campaign");
       continue;
     }
-    creative_ad.campaign_id = *campaign_id;
 
     const std::string* const advertiser_id =
         campaign_dict->FindString(kCampaignAdvertiserIdKey);
@@ -170,40 +167,41 @@ void ParseAndSaveNewTabPageAds(base::Value::Dict dict,
       BLOG(0, "Advertiser ID is required, skipping campaign");
       continue;
     }
-    creative_ad.advertiser_id = *advertiser_id;
 
+    base::Time start_at;
     if (const std::string* const value =
             campaign_dict->FindString(kCampaignStartAtKey)) {
       // Start at is optional.
-      if (!base::Time::FromUTCString(value->c_str(), &creative_ad.start_at)) {
+      if (!base::Time::FromUTCString(value->c_str(), &start_at)) {
         BLOG(0, "Failed to parse campaign start at, skipping campaign");
         continue;
       }
     } else {
       // Default to starting immediately.
-      creative_ad.start_at = base::Time::Now();
+      start_at = base::Time::Now();
     }
 
+    base::Time end_at;
     if (const std::string* const value =
             campaign_dict->FindString(kCampaignEndAtKey)) {
       // End at is optional.
-      if (!base::Time::FromUTCString(value->c_str(), &creative_ad.end_at)) {
+      if (!base::Time::FromUTCString(value->c_str(), &end_at)) {
         BLOG(0, "Failed to parse campaign end at, skipping campaign");
         continue;
       }
     } else {
       // Default to running indefinitely.
-      creative_ad.end_at = base::Time::Max();
+      end_at = base::Time::Max();
     }
 
-    creative_ad.daily_cap =
+    const int daily_cap =
         campaign_dict->FindInt(kCampaignDailyCapKey).value_or(0);
 
-    creative_ad.priority =
+    const int priority =
         campaign_dict->FindInt(kCampaignPriorityKey).value_or(10);
 
-    creative_ad.pass_through_rate =
-        campaign_dict->FindInt(kCampaignPassThroughRateKey).value_or(1.0);
+    const double pass_through_rate =
+        campaign_dict->FindDouble(kCampaignPassThroughRateKey).value_or(1.0);
 
     // Geo targets.
     const base::Value::List* const geo_target_list =
@@ -223,7 +221,6 @@ void ParseAndSaveNewTabPageAds(base::Value::Dict dict,
 
       geo_targets.insert(*geo_target);
     }
-    creative_ad.geo_targets = geo_targets;
 
     // Dayparts.
     CreativeDaypartSet dayparts;
@@ -261,7 +258,6 @@ void ParseAndSaveNewTabPageAds(base::Value::Dict dict,
       CreativeDaypartInfo daypart;
       dayparts.insert(daypart);
     }
-    creative_ad.dayparts = dayparts;
 
     // Creative sets.
     const base::Value::List* const creative_set_list =
@@ -278,6 +274,17 @@ void ParseAndSaveNewTabPageAds(base::Value::Dict dict,
         BLOG(0, "Malformed creative set, skipping creative set");
         continue;
       }
+
+      CreativeNewTabPageAdInfo creative_ad;
+      creative_ad.campaign_id = *campaign_id;
+      creative_ad.advertiser_id = *advertiser_id;
+      creative_ad.start_at = start_at;
+      creative_ad.end_at = end_at;
+      creative_ad.daily_cap = daily_cap;
+      creative_ad.priority = priority;
+      creative_ad.pass_through_rate = pass_through_rate;
+      creative_ad.geo_targets = geo_targets;
+      creative_ad.dayparts = dayparts;
 
       // Creative set.
       const std::string* const creative_set_id =
@@ -464,6 +471,7 @@ void ParseAndSaveNewTabPageAds(base::Value::Dict dict,
             creative_dict->FindList(kCreativeConditionMatchersKey);
         if (condition_matcher_list) {
           // Condition matchers are optional.
+          ConditionMatcherMap condition_matchers;
           for (const auto& condition_matcher_value : *condition_matcher_list) {
             const base::Value::Dict* const condition_matcher_dict =
                 condition_matcher_value.GetIfDict();
@@ -489,8 +497,10 @@ void ParseAndSaveNewTabPageAds(base::Value::Dict dict,
               continue;
             }
 
-            creative_ad.condition_matchers.emplace(*pref_path, *condition);
+            condition_matchers.emplace(*pref_path, *condition);
           }
+
+          creative_ad.condition_matchers = condition_matchers;
         }
 
         for (const auto& segment : segments) {

--- a/components/brave_ads/core/internal/creatives/new_tab_page_ads/creative_new_tab_page_ads_util_unittest.cc
+++ b/components/brave_ads/core/internal/creatives/new_tab_page_ads/creative_new_tab_page_ads_util_unittest.cc
@@ -13,16 +13,157 @@
 #include "base/test/values_test_util.h"
 #include "base/values.h"
 #include "brave/components/brave_ads/core/internal/common/test/test_base.h"
+#include "brave/components/brave_ads/core/internal/common/test/time_test_util.h"
+#include "brave/components/brave_ads/core/internal/creatives/new_tab_page_ads/creative_new_tab_page_ad_info.h"
+#include "brave/components/brave_ads/core/internal/creatives/new_tab_page_ads/creative_new_tab_page_ads_database_table.h"
+#include "brave/components/brave_ads/core/internal/segments/segment_alias.h"
+#include "brave/components/brave_ads/core/internal/segments/segment_constants.h"
 #include "brave/components/brave_ads/core/public/ads_callback.h"
 
 // npm run test -- brave_unit_tests --filter=BraveAds*
 
 namespace brave_ads {
 
+namespace {
+
+CreativeNewTabPageAdList BuildCreativeNewTabPageAds() {
+  CreativeNewTabPageAdList creative_ads;
+
+  {
+    CreativeNewTabPageAdInfo creative_ad;
+    creative_ad.campaign_id = "65933e82-6b21-440b-9956-c0f675ca7435";
+    creative_ad.advertiser_id = "496b045a-195e-441f-b439-07bac083450f";
+    creative_ad.start_at = test::TimeFromString("2025-01-01T00:00:00Z");
+    creative_ad.end_at = test::TimeFromString("2025-12-31T23:59:59Z");
+    creative_ad.daily_cap = 20;
+    creative_ad.priority = 10;
+    creative_ad.pass_through_rate = 1;
+    creative_ad.geo_targets = {"US"};
+    creative_ad.dayparts = {{{"012", 0, 1439}, {"3456", 0, 1439}}};
+    creative_ad.creative_set_id = "34ab06be-c9ed-4104-9ce0-9e639f4ad272";
+    creative_ad.creative_instance_id = "aa0b561e-9eed-4aaa-8999-5627bc6b14fd";
+    creative_ad.wallpaper_type = CreativeNewTabPageAdWallpaperType::kRichMedia;
+    creative_ad.company_name = "Rich Media NTT Creative 1";
+    creative_ad.alt = "Some rich content 1";
+    creative_ad.target_url = GURL("https://brave.com/1");
+    creative_ad.condition_matchers = {
+        {/*pref_path*/ "uninstall_metrics.installation_date2",
+         /*condition*/ "[T<]:7"},
+        {/*pref_path*/ "[virtual]:operating_system|locale|language",
+         /*condition*/ "en"}};
+    creative_ad.segment = kUntargetedSegment;
+    creative_ad.split_test_group = "Group A";
+    creative_ad.per_day = 15;
+    creative_ad.per_week = 120;
+    creative_ad.per_month = 580;
+    creative_ad.total_max = 980;
+    creative_ad.value = 0.05;
+    creative_ads.push_back(creative_ad);
+  }
+
+  {
+    CreativeNewTabPageAdInfo creative_ad;
+    creative_ad.campaign_id = "65933e82-6b21-440b-9956-c0f675ca7435";
+    creative_ad.advertiser_id = "496b045a-195e-441f-b439-07bac083450f";
+    creative_ad.start_at = test::TimeFromString("2025-01-01T00:00:00Z");
+    creative_ad.end_at = test::TimeFromString("2025-12-31T23:59:59Z");
+    creative_ad.daily_cap = 20;
+    creative_ad.priority = 10;
+    creative_ad.pass_through_rate = 1;
+    creative_ad.geo_targets = {"US"};
+    creative_ad.dayparts = {{{"012", 0, 1439}, {"3456", 0, 1439}}};
+    creative_ad.creative_set_id = "34ab06be-c9ed-4104-9ce0-9e639f4ad272";
+    creative_ad.creative_instance_id = "143148ee-bd08-41f2-a8e0-fd8516e02975";
+    creative_ad.wallpaper_type = CreativeNewTabPageAdWallpaperType::kImage;
+    creative_ad.company_name = "Image NTT Creative 1";
+    creative_ad.alt = "Some content 1";
+    creative_ad.target_url = GURL("https://basicattentiontoken.org/1");
+    creative_ad.condition_matchers = {
+        {/*pref_path*/ "[virtual]:browser|version",
+         /*condition*/ R"RE2(^\d+\.\d+\.(?:[0-6]?\d|7[0-7])\.\d+$)RE2"}};
+    creative_ad.segment = kUntargetedSegment;
+    creative_ad.split_test_group = "Group A";
+    creative_ad.per_day = 15;
+    creative_ad.per_week = 120;
+    creative_ad.per_month = 580;
+    creative_ad.total_max = 980;
+    creative_ad.value = 0.05;
+    creative_ads.push_back(creative_ad);
+  }
+
+  {
+    CreativeNewTabPageAdInfo creative_ad;
+    creative_ad.creative_instance_id = "5c2cf7fa-fc3f-4b1e-939a-7ac9fd2a128a";
+    creative_ad.creative_set_id = "0c2f239c-1230-43f9-8759-9b17532c2749";
+    creative_ad.campaign_id = "5a5e9915-128e-41af-9d56-b7c0db1ba6fa";
+    creative_ad.advertiser_id = "496b045a-195e-441f-b439-07bac083450f";
+    creative_ad.start_at = test::TimeFromString("2025-03-01T00:00:00Z");
+    creative_ad.end_at = test::TimeFromString("2025-09-31T23:59:59Z");
+    creative_ad.daily_cap = 10;
+    creative_ad.priority = 20;
+    creative_ad.pass_through_rate = 0.5;
+    creative_ad.per_day = 20;
+    creative_ad.per_week = 140;
+    creative_ad.per_month = 560;
+    creative_ad.total_max = 1000;
+    creative_ad.value = 0.1;
+    creative_ad.segment = kUntargetedSegment;
+    creative_ad.split_test_group = "Group B";
+    creative_ad.condition_matchers = {
+        {/*pref_path*/ "uninstall_metrics.installation_date2",
+         /*condition*/ "[T<]:3"},
+        {/*pref_path*/ "[virtual]:operating_system|locale|language",
+         /*condition*/ "fr"}};
+    creative_ad.dayparts = {{{"012", 0, 719}, {"3456", 720, 1439}}};
+    creative_ad.geo_targets = {"KY"};
+    creative_ad.wallpaper_type = CreativeNewTabPageAdWallpaperType::kRichMedia;
+    creative_ad.company_name = "Rich Media NTT Creative 2";
+    creative_ad.alt = "Some rich content 2";
+    creative_ad.target_url = GURL("https://brave.com/2");
+    creative_ads.push_back(creative_ad);
+  }
+
+  {
+    CreativeNewTabPageAdInfo creative_ad;
+    creative_ad.campaign_id = "5a5e9915-128e-41af-9d56-b7c0db1ba6fa";
+    creative_ad.advertiser_id = "496b045a-195e-441f-b439-07bac083450f";
+    creative_ad.start_at = test::TimeFromString("2025-03-01T00:00:00Z");
+    creative_ad.end_at = test::TimeFromString("2025-09-31T23:59:59Z");
+    creative_ad.daily_cap = 10;
+    creative_ad.priority = 20;
+    creative_ad.pass_through_rate = 0.5;
+    creative_ad.geo_targets = {"KY"};
+    creative_ad.dayparts = {{{"012", 0, 719}, {"3456", 720, 1439}}};
+    creative_ad.creative_set_id = "0c2f239c-1230-43f9-8759-9b17532c2749";
+    creative_ad.creative_instance_id = "ec585946-7755-4ba1-8666-a65be845e1fd";
+    creative_ad.wallpaper_type = CreativeNewTabPageAdWallpaperType::kImage;
+    creative_ad.company_name = "Image NTT Creative 2";
+    creative_ad.alt = "Some content 2";
+    creative_ad.target_url = GURL("https://basicattentiontoken.org/2");
+    creative_ad.condition_matchers = {
+        {/*pref_path*/ "[virtual]:browser|version",
+         /*condition*/ R"RE2(^\d+\.\d+\.(?:7[8-9]|[89]\d|\d{3,})\.\d+$)RE2"}};
+    creative_ad.segment = kUntargetedSegment;
+    creative_ad.split_test_group = "Group B";
+    creative_ad.per_day = 20;
+    creative_ad.per_week = 140;
+    creative_ad.per_month = 560;
+    creative_ad.total_max = 1000;
+    creative_ad.value = 0.1;
+    creative_ads.push_back(creative_ad);
+  }
+
+  return creative_ads;
+}
+
+}  // namespace
+
 class BraveAdsCreativeNewTabPageAdsUtilTest : public test::TestBase {};
 
 TEST_F(BraveAdsCreativeNewTabPageAdsUtilTest, ParseAndSaveAds) {
   // Arrange
+  AdvanceClockTo(test::TimeFromString("4 July 2025"));
+
   base::Value::Dict dict = base::test::ParseJsonDict(R"JSON(
       {
         "schemaVersion": 2,
@@ -57,35 +198,137 @@ TEST_F(BraveAdsCreativeNewTabPageAdsUtilTest, ParseAndSaveAds) {
                 "creatives": [
                   {
                     "creativeInstanceId": "aa0b561e-9eed-4aaa-8999-5627bc6b14fd",
-                    "companyName": "Rich Media NTT Creative",
-                    "alt": "Some rich content",
-                    "targetUrl": "https://brave.com",
+                    "companyName": "Rich Media NTT Creative 1",
+                    "alt": "Some rich content 1",
+                    "targetUrl": "https://brave.com/1",
                     "conditionMatchers": [
                       {
                         "condition": "[T<]:7",
                         "prefPath": "uninstall_metrics.installation_date2"
+                      },
+                      {
+                        "condition": "en",
+                        "prefPath": "[virtual]:operating_system|locale|language"
                       }
                     ],
                     "wallpaper": {
                       "type": "richMedia",
-                      "relativeUrl": "aa0b561e-9eed-4aaa-8999-5627bc6b14fd/index.html"
+                      "relativeUrl": "689fcd95-c77c-4574-9615-ab8cf1995735/index.html"
                     }
                   },
                   {
                     "creativeInstanceId": "143148ee-bd08-41f2-a8e0-fd8516e02975",
-                    "companyName": "Image NTT Creative",
-                    "alt": "Some content",
-                    "targetUrl": "https://basicattentiontoken.org",
+                    "companyName": "Image NTT Creative 1",
+                    "alt": "Some content 1",
+                    "targetUrl": "https://basicattentiontoken.org/1",
+                    "conditionMatchers": [
+                      {
+                        "condition": "^\\d+\\.\\d+\\.(?:[0-6]?\\d|7[0-7])\\.\\d+$",
+                        "prefPath": "[virtual]:browser|version"
+                      }
+                    ],
                     "wallpaper": {
                       "type": "image",
-                      "relativeUrl": "143148ee-bd08-41f2-a8e0-fd8516e02975/background.jpg",
+                      "relativeUrl": "f4c33efb-1605-4b2a-8980-4d41d25b36ff/background.jpg",
                       "focalPoint": {
                         "x": 25,
                         "y": 50
                       },
                       "button": {
                         "image": {
-                          "relativeUrl": "143148ee-bd08-41f2-a8e0-fd8516e02975/button.png"
+                          "relativeUrl": "eee468e8-d56f-4d59-9b51-03e1b1069fb3/button.png"
+                        }
+                      }
+                    }
+                  }
+                ],
+                "conversions": [
+                  {
+                    "observationWindow": 7,
+                    "urlPattern": "https://www.brave.com/1/*"
+                  }
+                ],
+                "segments": [
+                  "untargeted"
+                ],
+                "splitTestGroup": "Group A",
+                "perDay": 15,
+                "perWeek": 120,
+                "perMonth": 580,
+                "totalMax": 980,
+                "value": "0.05"
+              }
+            ]
+          },
+          {
+            "version": 1,
+            "campaignId": "5a5e9915-128e-41af-9d56-b7c0db1ba6fa",
+            "advertiserId": "496b045a-195e-441f-b439-07bac083450f",
+            "startAt": "2025-03-01T00:00:00Z",
+            "endAt": "2025-09-31T23:59:59Z",
+            "dailyCap": 10,
+            "priority": 20,
+            "ptr": 0.5,
+            "geoTargets": [
+              "KY"
+            ],
+            "dayParts": [
+              {
+                "daysOfWeek": "012",
+                "startMinute": 0,
+                "endMinute": 719
+              },
+              {
+                "daysOfWeek": "3456",
+                "startMinute": 720,
+                "endMinute": 1439
+              }
+            ],
+            "creativeSets": [
+              {
+                "creativeSetId": "0c2f239c-1230-43f9-8759-9b17532c2749",
+                "creatives": [
+                  {
+                    "creativeInstanceId": "5c2cf7fa-fc3f-4b1e-939a-7ac9fd2a128a",
+                    "companyName": "Rich Media NTT Creative 2",
+                    "alt": "Some rich content 2",
+                    "targetUrl": "https://brave.com/2",
+                    "conditionMatchers": [
+                      {
+                        "condition": "[T<]:3",
+                        "prefPath": "uninstall_metrics.installation_date2"
+                      },
+                      {
+                        "condition": "fr",
+                        "prefPath": "[virtual]:operating_system|locale|language"
+                      }
+                    ],
+                    "wallpaper": {
+                      "type": "richMedia",
+                      "relativeUrl": "748eafb6-c96f-4a54-87dc-a39c2718c45e/index.html"
+                    }
+                  },
+                  {
+                    "creativeInstanceId": "ec585946-7755-4ba1-8666-a65be845e1fd",
+                    "companyName": "Image NTT Creative 2",
+                    "alt": "Some content 2",
+                    "targetUrl": "https://basicattentiontoken.org/2",
+                    "conditionMatchers": [
+                      {
+                        "condition": "^\\d+\\.\\d+\\.(?:7[8-9]|[89]\\d|\\d{3,})\\.\\d+$",
+                        "prefPath": "[virtual]:browser|version"
+                      }
+                    ],
+                    "wallpaper": {
+                      "type": "image",
+                      "relativeUrl": "b12b0568-6894-42c8-abf8-4997dabb6c95/background.jpg",
+                      "focalPoint": {
+                        "x": 25,
+                        "y": 50
+                      },
+                      "button": {
+                        "image": {
+                          "relativeUrl": "b12b0568-6894-42c8-abf8-4997dabb6c95/button.png"
                         }
                       }
                     }
@@ -94,13 +337,13 @@ TEST_F(BraveAdsCreativeNewTabPageAdsUtilTest, ParseAndSaveAds) {
                 "conversions": [
                   {
                     "observationWindow": 30,
-                    "urlPattern": "https://www.brave.com/*"
+                    "urlPattern": "https://www.brave.com/2/*"
                   }
                 ],
                 "segments": [
-                  "technology & computing"
+                  "untargeted"
                 ],
-                "splitTestGroup": "Group A",
+                "splitTestGroup": "Group B",
                 "perDay": 20,
                 "perWeek": 140,
                 "perMonth": 560,
@@ -112,12 +355,27 @@ TEST_F(BraveAdsCreativeNewTabPageAdsUtilTest, ParseAndSaveAds) {
         ]
       })JSON");
 
-  // Act & Assert
-  base::MockCallback<ResultCallback> callback;
+  // Act
+  {
+    base::MockCallback<ResultCallback> callback;
+    base::RunLoop run_loop;
+    EXPECT_CALL(callback, Run(/*success=*/true))
+        .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
+    ParseAndSaveNewTabPageAds(std::move(dict), callback.Get());
+    run_loop.Run();
+  }
+
+  // Assert
+  base::MockCallback<database::table::GetCreativeNewTabPageAdsCallback>
+      callback;
   base::RunLoop run_loop;
-  EXPECT_CALL(callback, Run(/*success=*/true))
+  EXPECT_CALL(
+      callback,
+      Run(/*success=*/true, SegmentList{kUntargetedSegment},
+          ::testing::UnorderedElementsAreArray(BuildCreativeNewTabPageAds())))
       .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
-  ParseAndSaveNewTabPageAds(std::move(dict), callback.Get());
+  database::table::CreativeNewTabPageAds database_table;
+  database_table.GetForActiveCampaigns(callback.Get());
   run_loop.Run();
 }
 


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/29141
Resolves https://github.com/brave/brave-browser/issues/46204

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
-  [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.