### PR TITLE
Crash in ShieldsPanelDataHandler::AreAnyBlockedElementsPresent (uplift to 1.79.x)

### DIFF
--- a/browser/ui/webui/brave_shields/shields_panel_data_handler.cc
+++ b/browser/ui/webui/brave_shields/shields_panel_data_handler.cc
@@ -186,16 +186,24 @@ void ShieldsPanelDataHandler::OpenWebCompatWindow() {
 
 void ShieldsPanelDataHandler::AreAnyBlockedElementsPresent(
     AreAnyBlockedElementsPresentCallback callback) {
+  if (!active_shields_data_controller_) {
+    return;
+  }
+
   std::move(callback).Run(
       g_brave_browser_process->ad_block_service()->AreAnyBlockedElementsPresent(
           active_shields_data_controller_->web_contents()->GetURL().host()));
 }
 
 void ShieldsPanelDataHandler::ResetBlockedElements() {
+  webui_controller_->embedder()->CloseUI();
+
+  if (!active_shields_data_controller_) {
+    return;
+  }
+
   g_brave_browser_process->ad_block_service()->ResetCosmeticFilter(
       active_shields_data_controller_->web_contents()->GetURL().host());
-
-  webui_controller_->embedder()->CloseUI();
 
   active_shields_data_controller_->web_contents()->GetController().Reload(
       content::ReloadType::NORMAL, true);


### PR DESCRIPTION
Uplift of #29127
Resolves https://github.com/brave/brave-browser/issues/46172

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.