### PR TITLE
Move Background YouTube play preference into appropriate section

### DIFF
--- a/android/java/org/chromium/chrome/browser/settings/MediaPreferences.java
+++ b/android/java/org/chromium/chrome/browser/settings/MediaPreferences.java
@@ -31,7 +31,8 @@ import org.chromium.mojo.system.MojoException;
 public class MediaPreferences extends BravePreferenceFragment
         implements ConnectionErrorHandler, Preference.OnPreferenceChangeListener {
     public static final String PREF_WIDEVINE_ENABLED = "widevine_enabled";
-    public static final String PREF_BACKGROUND_VIDEO_PLAYBACK = "background_video_playback";
+    public static final String PREF_BACKGROUND_YOUTUBE_VIDEO_PLAYBACK =
+            "background_youtube_video_playback";
     public static final String PLAY_YT_VIDEO_IN_BROWSER_KEY = "play_yt_video_in_browser";
     private static final String PREF_HIDE_YOUTUBE_RECOMMENDED_CONTENT =
             "hide_youtube_recommended_content";
@@ -72,14 +73,15 @@ public class MediaPreferences extends BravePreferenceFragment
             enableWidevinePref.setOnPreferenceChangeListener(this);
         }
 
-        ChromeSwitchPreference backgroundVideoPlaybackPref =
-                (ChromeSwitchPreference) findPreference(PREF_BACKGROUND_VIDEO_PLAYBACK);
-        if (backgroundVideoPlaybackPref != null) {
-            backgroundVideoPlaybackPref.setOnPreferenceChangeListener(this);
+        ChromeSwitchPreference backgroundYouTubeVideoPlaybackPref =
+                findPreference(PREF_BACKGROUND_YOUTUBE_VIDEO_PLAYBACK);
+        if (backgroundYouTubeVideoPlaybackPref != null) {
+            backgroundYouTubeVideoPlaybackPref.setOnPreferenceChangeListener(this);
             boolean enabled =
                     ChromeFeatureList.isEnabled(BraveFeatureList.BRAVE_BACKGROUND_VIDEO_PLAYBACK)
-                    || BravePrefServiceBridge.getInstance().getBackgroundVideoPlaybackEnabled();
-            backgroundVideoPlaybackPref.setChecked(enabled);
+                            || BravePrefServiceBridge.getInstance()
+                                    .getBackgroundVideoPlaybackEnabled();
+            backgroundYouTubeVideoPlaybackPref.setChecked(enabled);
         }
 
         ChromeSwitchPreference openYoutubeLinksBravePref =
@@ -142,7 +144,7 @@ public class MediaPreferences extends BravePreferenceFragment
                             BravePref.WIDEVINE_ENABLED,
                             !BraveLocalState.get().getBoolean(BravePref.WIDEVINE_ENABLED));
             shouldRelaunch = true;
-        } else if (PREF_BACKGROUND_VIDEO_PLAYBACK.equals(key)) {
+        } else if (PREF_BACKGROUND_YOUTUBE_VIDEO_PLAYBACK.equals(key)) {
             BraveFeatureUtil.enableFeature(
                     BraveFeatureList.BRAVE_BACKGROUND_VIDEO_PLAYBACK_INTERNAL,
                     (boolean) newValue,

--- a/android/java/res/xml/media_preferences.xml
+++ b/android/java/res/xml/media_preferences.xml
@@ -13,16 +13,16 @@
             android:key="widevine_enabled"
             android:title="@string/prefs_enable_widevine_title"
             android:summary="@string/prefs_enable_widevine_summary" />
-        <org.chromium.components.browser_ui.settings.ChromeSwitchPreference
-            android:key="background_video_playback"
-            android:defaultValue="false"
-            android:title="@string/prefs_background_video_playback"
-            android:summary="@string/prefs_background_video_playback_on" />
     </PreferenceCategory>
 
     <PreferenceCategory
         android:key="youtube_section"
         android:title="@string/youtube">
+        <org.chromium.components.browser_ui.settings.ChromeSwitchPreference
+            android:key="background_youtube_video_playback"
+            android:defaultValue="false"
+            android:title="@string/prefs_background_youtube_video_playback"
+            android:summary="@string/prefs_background_youtube_video_playback_description" />
         <org.chromium.components.browser_ui.settings.ChromeSwitchPreference
             android:key="play_yt_video_in_browser"
             android:title="@string/prefs_open_youtube_links_brave" />

--- a/browser/ui/android/strings/android_brave_strings.grd
+++ b/browser/ui/android/strings/android_brave_strings.grd
@@ -820,14 +820,14 @@ This file contains all "about" strings.  It is set to NOT be translated, in tran
       <message name="IDS_PREFS_SECTION_CLEAR_DATA" desc="Title for Clear private data automatically section in the privacy preferences screen">
         Clear browsing data
       </message>
-      <message name="IDS_PREFS_BACKGROUND_VIDEO_PLAYBACK" desc="Title for background video playback preference in controls section">
-        Background play
+      <message name="IDS_PREFS_BACKGROUND_YOUTUBE_VIDEO_PLAYBACK" desc="Title for background YouTube video playback preference in controls section">
+        Background YouTube play
       </message>
       <message name="IDS_PREFS_CLOSING_ALL_TABS_CLOSES_BRAVE" desc="Title for closing all tabs closes brave in controls section">
         Closing all tabs closes Brave
       </message>
-      <message name="IDS_PREFS_BACKGROUND_VIDEO_PLAYBACK_ON" desc="Text for background video playback is on">
-        Allows audio to play when you switch to another tab in Brave or another app or your device screen is off.
+      <message name="IDS_PREFS_BACKGROUND_YOUTUBE_VIDEO_PLAYBACK_DESCRIPTION" desc="Description for background YouTube video playback preference in controls section">
+        Allows YouTube videos to play when you switch to another tab in Brave or another app or your device screen is off.
       </message>
       <message name="IDS_PREFS_OPEN_YOUTUBE_LINKS_BRAVE" desc="Text for open youtube links in brave">
         Open YouTube links in Brave


### PR DESCRIPTION
## Resolves https://github.com/brave/brave-browser/issues/46265

This PR moves Background YouTube play preference into the appropriate YouTube section as the feature refers to YouTube videos only, and also slightly improves preference description.

<img width="528" alt="Screenshot_2025-05-22_at_3_10_02 PM" src="https://github.com/user-attachments/assets/2b3a0284-4797-4565-a8b6-403494cb4f3d" />


<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

## Test Plan

- Navigate to Settings > Media
- Observe the Background YouTube play preference is approprately placed into YouTube section
