### PR TITLE
[iOS] Pass correct main frame info when using Chromium web views

### DIFF
--- a/ios/brave-ios/Sources/Web/Chromium/TabCWVNavigationHandler.swift
+++ b/ios/brave-ios/Sources/Web/Chromium/TabCWVNavigationHandler.swift
@@ -72,7 +72,7 @@ class TabCWVNavigationHandler: NSObject, BraveWebViewNavigationDelegate {
 
   public func webView(
     _ webView: CWVWebView,
-    decidePolicyFor navigationAction: CWVNavigationAction,
+    decidePolicyFor navigationAction: BraveNavigationAction,
     decisionHandler: @escaping (CWVNavigationActionPolicy) -> Void
   ) {
     guard let tab else { return }
@@ -97,7 +97,7 @@ class TabCWVNavigationHandler: NSObject, BraveWebViewNavigationDelegate {
         navigationAction.request,
         requestInfo: .init(
           navigationType: navigationType,
-          isMainFrame: navigationAction.navigationType.isMainFrame,
+          isMainFrame: navigationAction.isTargetFrameMain,
           isNewWindow: navigationAction.navigationType == .newWindow,
           isUserInitiated: navigationAction.isUserInitiated
         )

--- a/ios/browser/api/web_view/brave_web_view.h
+++ b/ios/browser/api/web_view/brave_web_view.h
@@ -11,12 +11,30 @@
 #import <WebKit/WebKit.h>
 
 #import "cwv_export.h"               // NOLINT
+#import "cwv_navigation_action.h"    // NOLINT
 #import "cwv_navigation_delegate.h"  // NOLINT
 #import "cwv_ui_delegate.h"          // NOLINT
 #import "cwv_web_view.h"             // NOLINT
 #import "cwv_web_view_extras.h"      // NOLINT
 
 NS_ASSUME_NONNULL_BEGIN
+
+CWV_EXPORT
+@interface BraveNavigationAction : CWVNavigationAction
+/// YES if the navigation target frame is the main frame.
+@property(nonatomic, readonly, getter=isTargetFrameMain) BOOL targetFrameIsMain;
+/// YES if the navigation target frame is cross-origin with respect to the the
+/// navigation source frame.
+@property(nonatomic, readonly, getter=isTargetFrameCrossOrigin)
+    BOOL targetFrameIsCrossOrigin;
+/// YES if the navigation target frame is in another window and is cross-origin
+/// with respect to the the navigation source frame.
+@property(nonatomic, readonly, getter=isTargetWindowCrossOrigin)
+    BOOL targetWindowIsCrossOrigin;
+/// YES if there was a recent user interaction with the web view (not
+/// necessarily on the page).
+@property(nonatomic, readonly) BOOL hasTappedRecently;
+@end
 
 /// Additional navigation delegate methods that extend functionality of
 /// CWVWebView
@@ -44,6 +62,15 @@ CWV_EXPORT
 /// Notifies the delegate that a server redirect occured. At the point when this
 /// is called, the url will already be updated.
 - (void)webViewDidRedirectNavigation:(CWVWebView*)webView;
+// An alternative to -[id<CWVNavigationDelegate>
+// webView:decidePolicyForNavigationAction:decisionHandler:] which provides
+// additional request info found in WebPolicyDecider
+- (void)webView:(CWVWebView*)webView
+    decidePolicyForBraveNavigationAction:
+        (BraveNavigationAction*)navigationAction
+                         decisionHandler:(void (^)(CWVNavigationActionPolicy))
+                                             decisionHandler;
+
 @end
 
 CWV_EXPORT

--- a/ios/browser/api/web_view/brave_web_view.mm
+++ b/ios/browser/api/web_view/brave_web_view.mm
@@ -7,18 +7,113 @@
 
 #include "base/notreached.h"
 #include "ios/chrome/browser/tabs/model/tab_helper_util.h"
+#include "ios/web/public/navigation/web_state_policy_decider.h"
 #include "ios/web/public/web_state.h"
+#include "ios/web_view/internal/cwv_navigation_action_internal.h"
+#include "ios/web_view/internal/cwv_navigation_type_internal.h"
 #include "ios/web_view/internal/cwv_web_view_internal.h"
 
+@interface BraveNavigationAction ()
+- (instancetype)initWithRequest:(NSURLRequest*)request
+                    requestInfo:
+                        (web::WebStatePolicyDecider::RequestInfo)requestInfo;
+@end
+
+namespace {
+
+class BraveWebViewWebStatePolicyDecider : public web::WebStatePolicyDecider {
+ public:
+  BraveWebViewWebStatePolicyDecider(web::WebState* web_state,
+                                    BraveWebView* web_view)
+      : web::WebStatePolicyDecider(web_state), web_view_(web_view) {}
+
+  // web::WebStatePolicyDecider overrides:
+  void ShouldAllowRequest(
+      NSURLRequest* request,
+      web::WebStatePolicyDecider::RequestInfo request_info,
+      web::WebStatePolicyDecider::PolicyDecisionCallback callback) override {
+    id<BraveWebViewNavigationDelegate> delegate = web_view_.navigationDelegate;
+    if ([delegate respondsToSelector:@selector
+                  (webView:
+                      decidePolicyForBraveNavigationAction:decisionHandler:)]) {
+      BraveNavigationAction* navigationAction =
+          [[BraveNavigationAction alloc] initWithRequest:request
+                                             requestInfo:request_info];
+
+      __block web::WebStatePolicyDecider::PolicyDecisionCallback
+          block_callback = std::move(callback);
+      [delegate webView:web_view_
+          decidePolicyForBraveNavigationAction:navigationAction
+                               decisionHandler:^(
+                                   CWVNavigationActionPolicy policy) {
+                                 switch (policy) {
+                                   case CWVNavigationActionPolicyCancel:
+                                     std::move(block_callback)
+                                         .Run(web::WebStatePolicyDecider::
+                                                  PolicyDecision::Cancel());
+                                     break;
+                                   case CWVNavigationActionPolicyAllow:
+                                     std::move(block_callback)
+                                         .Run(web::WebStatePolicyDecider::
+                                                  PolicyDecision::Allow());
+                                     break;
+                                 }
+                               }];
+      return;
+    }
+    std::move(callback).Run(
+        web::WebStatePolicyDecider::PolicyDecision::Allow());
+  }
+
+ private:
+  // Delegates to |delegate| property of this web view.
+  __weak BraveWebView* web_view_ = nil;
+};
+
+}  // namespace
+
+@implementation BraveNavigationAction
+- (instancetype)initWithRequest:(NSURLRequest*)request
+                    requestInfo:
+                        (web::WebStatePolicyDecider::RequestInfo)requestInfo {
+  if ((self = [super initWithRequest:request
+                       userInitiated:requestInfo.is_user_initiated
+                      navigationType:CWVNavigationTypeFromPageTransition(
+                                         requestInfo.transition_type)])) {
+    _targetFrameIsMain = requestInfo.target_frame_is_main;
+    _targetFrameIsCrossOrigin = requestInfo.target_frame_is_cross_origin;
+    _targetWindowIsCrossOrigin = requestInfo.target_window_is_cross_origin;
+    _hasTappedRecently = requestInfo.user_tapped_recently;
+  }
+  return self;
+}
+@end
+
 @interface CWVWebView ()
+- (void)resetWebStateWithCoder:(NSCoder*)coder
+               WKConfiguration:(WKWebViewConfiguration*)wkConfiguration
+                createdWebView:(WKWebView**)createdWebView;
 - (void)attachSecurityInterstitialHelpersToWebStateIfNecessary;
 - (void)updateCurrentURLs;
 @end
 
-@implementation BraveWebView
+@implementation BraveWebView {
+  std::unique_ptr<BraveWebViewWebStatePolicyDecider> _webStatePolicyDecider;
+}
 
 // These are shadowed CWVWebView properties
 @dynamic navigationDelegate, UIDelegate;
+
+- (void)resetWebStateWithCoder:(NSCoder*)coder
+               WKConfiguration:(WKWebViewConfiguration*)wkConfiguration
+                createdWebView:(WKWebView**)createdWebView {
+  [super resetWebStateWithCoder:coder
+                WKConfiguration:wkConfiguration
+                 createdWebView:createdWebView];
+
+  _webStatePolicyDecider =
+      std::make_unique<BraveWebViewWebStatePolicyDecider>(self.webState, self);
+}
 
 - (void)attachSecurityInterstitialHelpersToWebStateIfNecessary {
   [super attachSecurityInterstitialHelpersToWebStateIfNecessary];


### PR DESCRIPTION
This change introduces a `CWVNavigationAction` subclass and new delegate method specific to `BraveWebView` that provides the correct info from `web::WebStatePolicyDecider::RequestInfo` for determining if the navigation was done on the main frame which fixes things such as aggressive shields showing interstitials for blocked subframe navigations.

Resolves https://github.com/brave/brave-browser/issues/46239

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
