### PR TITLE
Fix `matches-path` and `matches-media` fast path in procedural filter script (uplift to 1.80.x)

### DIFF
--- a/browser/brave_shields/ad_block_service_browsertest.cc
+++ b/browser/brave_shields/ad_block_service_browsertest.cc
@@ -2825,8 +2825,8 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, ProceduralFilterMatchesPath) {
   UpdateAdBlockInstanceWithRules(
       "a.com##section .positive-string-case "
       "p.odd:matches-path(cosmetic_filtering.html)\n"
-      "a.com##section .positive-regex-case "
-      "p.odd:matches-path(/c[aeiou]smetic\\_[a-z]{9}/)\n"
+      "a.com##:matches-path(/c[aeiou]smetic\\_[a-z]{9}/) section "
+      ".positive-regex-case p.odd\n"
       "a.com##section .negative-case:matches-path(/some-other-page.html)");
 
   GURL tab_url =

--- a/components/cosmetic_filters/resources/data/procedural_filters.ts
+++ b/components/cosmetic_filters/resources/data/procedural_filters.ts
@@ -580,7 +580,7 @@ const applyCompiledSelector = (selector: CompiledProceduralSelector,
       // Note that unless we've taken the if-true branch above, then
       // the nodesToConsider array will still have all the elements
       // it started with.
-      break
+      continue
     }
 
     let newNodesToConsider: HTMLElement[] = []


### PR DESCRIPTION
Uplift of #29173
Resolves https://github.com/brave/brave-browser/issues/46220

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.