### PR TITLE
[Android] Prevent cleaning of tab groups without sync id

### DIFF
--- a/android/java/apk_for_test.flags
+++ b/android/java/apk_for_test.flags
@@ -978,6 +978,10 @@
 
 -keep class org.chromium.chrome.browser.homepage.settings.BraveRadioButtonGroupHomepagePreference
 
+-keep class org.chromium.chrome.browser.tab_group_sync.StartupHelper {
+    *** handleUnsavedLocalTabGroups(...);
+}
+
 -keep class org.chromium.chrome.browser.tab_group_sync.BraveStartupHelper {
     *** handleUnsavedLocalTabGroups(...);
 }

--- a/android/java/apk_for_test.flags
+++ b/android/java/apk_for_test.flags
@@ -977,3 +977,7 @@
 }
 
 -keep class org.chromium.chrome.browser.homepage.settings.BraveRadioButtonGroupHomepagePreference
+
+-keep class org.chromium.chrome.browser.tab_group_sync.BraveStartupHelper {
+    *** handleUnsavedLocalTabGroups(...);
+}

--- a/android/java/proguard.flags
+++ b/android/java/proguard.flags
@@ -102,3 +102,6 @@
     *** dismissActivityIfNeeded(...);
 }
 
+-keep class org.chromium.chrome.browser.tab_group_sync.StartupHelper {
+    *** handleUnsavedLocalTabGroups(...);
+}

--- a/android/java/proguard.flags
+++ b/android/java/proguard.flags
@@ -101,7 +101,3 @@
 -keep class org.chromium.chrome.browser.media.FullscreenVideoPictureInPictureController {
     *** dismissActivityIfNeeded(...);
 }
-
--keep class org.chromium.chrome.browser.tab_group_sync.StartupHelper {
-    *** handleUnsavedLocalTabGroups(...);
-}

--- a/android/javatests/org/chromium/chrome/browser/BytecodeTest.java
+++ b/android/javatests/org/chromium/chrome/browser/BytecodeTest.java
@@ -413,6 +413,7 @@ public class BytecodeTest {
         Assert.assertTrue(
                 classExists(
                         "org/chromium/chrome/browser/quickactionsearchwidget/BraveQuickActionSearchWidgetProvider")); // presubmit: ignore-long-line
+        Assert.assertTrue(classExists("org/chromium/chrome/browser/tab_group_sync/StartupHelper"));
     }
 
     @Test
@@ -959,6 +960,12 @@ public class BytecodeTest {
                         "getChromeNtpRadioButton",
                         MethodModifier.REGULAR,
                         RadioButtonWithDescription.class));
+        Assert.assertTrue(
+                methodExists(
+                        "org/chromium/chrome/browser/tab_group_sync/StartupHelper",
+                        "handleUnsavedLocalTabGroups",
+                        MethodModifier.REGULAR,
+                        void.class));
     }
 
     @Test
@@ -2485,6 +2492,10 @@ public class BytecodeTest {
                 checkSuperName(
                         "org/chromium/chrome/browser/homepage/settings/BraveRadioButtonGroupHomepagePreference", // presubmit: ignore-long-line
                         "org/chromium/chrome/browser/homepage/settings/RadioButtonGroupHomepagePreference")); // presubmit: ignore-long-line
+        Assert.assertTrue(
+                checkSuperName(
+                        "org/chromium/chrome/browser/tab_group_sync/StartupHelper",
+                        "org/chromium/chrome/browser/tab_group_sync/BraveStartupHelper"));
     }
 
     @Test

--- a/browser/tab_group_sync/BUILD.gn
+++ b/browser/tab_group_sync/BUILD.gn
@@ -1,0 +1,12 @@
+# Copyright (c) 2025 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import("//build/config/android/rules.gni")
+
+android_library("java") {
+  sources = [ "android/java/src/org/chromium/chrome/browser/tab_group_sync/BraveStartupHelper.java" ]
+
+  deps = [ "//chrome/browser/tab_group_sync:java" ]
+}

--- a/browser/tab_group_sync/android/java/src/org/chromium/chrome/browser/tab_group_sync/BraveStartupHelper.java
+++ b/browser/tab_group_sync/android/java/src/org/chromium/chrome/browser/tab_group_sync/BraveStartupHelper.java
@@ -1,0 +1,17 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.chromium.chrome.browser.tab_group_sync;
+
+import org.chromium.build.annotations.NullMarked;
+
+@NullMarked
+public class BraveStartupHelper {
+
+    // Replace StartupHelper.handleUnsavedLocalTabGroups with empty implementation.
+    // The reason for this - otherwise groups created with `Open tabs in current group` option
+    // are wiped after app restart.
+    public void handleUnsavedLocalTabGroups() {}
+}

--- a/build/android/bytecode/BUILD.gn
+++ b/build/android/bytecode/BUILD.gn
@@ -110,6 +110,7 @@ java_binary("java_bytecode_rewriter") {
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveSiteSettingsCategoryClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveSiteSettingsDelegateClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveSiteSettingsPreferencesBaseClassAdapter.java",
+    "//brave/build/android/bytecode/java/org/brave/bytecode/BraveStartupHelperClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveStatusBarColorControllerClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveStatusMediatorClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveStrictPreferenceKeyCheckerClassAdapter.java",

--- a/build/android/bytecode/bytecode_rewriter.gni
+++ b/build/android/bytecode/bytecode_rewriter.gni
@@ -40,6 +40,7 @@ brave_bytecode_jars = [
   "obj/chrome/browser/site_settings/android/java.javac.jar",
   "obj/chrome/browser/tabmodel/java.javac.jar",
   "obj/chrome/browser/customtabs/java.javac.jar",
+  "obj/chrome/browser/tab_group_sync/java.javac.jar",
   "obj/chrome/browser/tab_ui/android/java.javac.jar",
   "obj/chrome/browser/ui/android/appmenu/internal/java.javac.jar",
   "obj/chrome/browser/ui/android/logo/java.javac.jar",

--- a/build/android/bytecode/java/org/brave/bytecode/BraveClassAdapter.java
+++ b/build/android/bytecode/java/org/brave/bytecode/BraveClassAdapter.java
@@ -105,6 +105,7 @@ public class BraveClassAdapter {
         chain = new BraveSiteSettingsCategoryClassAdapter(chain);
         chain = new BraveSiteSettingsDelegateClassAdapter(chain);
         chain = new BraveSiteSettingsPreferencesBaseClassAdapter(chain);
+        chain = new BraveStartupHelperClassAdapter(chain);
         chain = new BraveStatusBarColorControllerClassAdapter(chain);
         chain = new BraveStatusMediatorClassAdapter(chain);
         chain = new BraveStrictPreferenceKeyCheckerClassAdapter(chain);

--- a/build/android/bytecode/java/org/brave/bytecode/BraveStartupHelperClassAdapter.java
+++ b/build/android/bytecode/java/org/brave/bytecode/BraveStartupHelperClassAdapter.java
@@ -1,0 +1,25 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.brave.bytecode;
+
+import org.objectweb.asm.ClassVisitor;
+
+public class BraveStartupHelperClassAdapter extends BraveClassVisitor {
+    static String sStartupHelperClassName =
+            "org/chromium/chrome/browser/tab_group_sync/StartupHelper";
+    static String sBraveStartupHelperClassName =
+            "org/chromium/chrome/browser/tab_group_sync/BraveStartupHelper";
+
+    public BraveStartupHelperClassAdapter(ClassVisitor visitor) {
+        super(visitor);
+
+        changeSuperName(sStartupHelperClassName, sBraveStartupHelperClassName);
+        changeMethodOwner(
+                sStartupHelperClassName,
+                "handleUnsavedLocalTabGroups",
+                sBraveStartupHelperClassName);
+    }
+}

--- a/build/android/config.gni
+++ b/build/android/config.gni
@@ -27,6 +27,7 @@ brave_chrome_java_deps = [
   "//brave/browser/notifications/android:java",
   "//brave/browser/quick_search_engines/android:java",
   "//brave/browser/safe_browsing/android/java/src/org/chromium/chrome/browser/safe_browsing/settings:java",
+  "//brave/browser/tab_group_sync:java",
   "//brave/browser/tabmodel/android:java",
   "//brave/browser/ui/android/logo:java",
   "//brave/browser/ui/android/omnibox:java",


### PR DESCRIPTION
This PR replaces upstream's `StartupHelper.handleUnsavedLocalTabGroups` with empty implementation to avoid wipe groups created with `Open tabs in current group` after app restart.

After DM discussion with @samartnik created follow-up https://github.com/brave/brave-browser/issues/46309  

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/45549

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
