### PR TITLE
Revert "Allow Mac app to quit when an update is available" (uplift to 1.80.x)

### DIFF
--- a/browser/mac/sparkle_glue.mm
+++ b/browser/mac/sparkle_glue.mm
@@ -5,10 +5,9 @@
 
 #import "brave/browser/mac/sparkle_glue.h"
 
+#include <string>
 #include <sys/mount.h>
 #include <sys/stat.h>
-
-#include <string>
 
 #include "base/apple/bundle_locations.h"
 #include "base/apple/foundation_util.h"
@@ -22,7 +21,6 @@
 #include "brave/browser/update_util.h"
 #include "brave/common/brave_channel_info.h"
 #include "brave/components/constants/brave_switches.h"
-#include "chrome/browser/app_controller_mac.h"
 #include "chrome/common/channel_info.h"
 #include "chrome/common/chrome_constants.h"
 
@@ -393,15 +391,6 @@ std::string GetDescriptionFromAppcastItem(id item) {
              GetDescriptionFromAppcastItem(item);
 
   _updateWillBeInstalledOnQuit = YES;
-
-  // Updates roll out orders of magnitude slower on macOS than on other
-  // platforms. The current hypothesis is that the reason for this is the
-  // following: Updates require a relaunch to be applied. On other platforms,
-  // closing the last browser window terminates the application. But on macOS,
-  // the app keeps running by default. This prevents it from being updated.
-  // In an attempt to fix the problem, we therefore allow the application to
-  // terminate when an update is ready to be installed:
-  app_controller_mac::AllowApplicationToTerminate();
 
   [self determineUpdateStatusAsync];
 }

--- a/browser/mac/sparkle_glue.mm
+++ b/browser/mac/sparkle_glue.mm
@@ -5,9 +5,10 @@
 
 #import "brave/browser/mac/sparkle_glue.h"
 
-#include <string>
 #include <sys/mount.h>
 #include <sys/stat.h>
+
+#include <string>
 
 #include "base/apple/bundle_locations.h"
 #include "base/apple/foundation_util.h"


### PR DESCRIPTION
Uplift of #29202

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.