### PR TITLE
[iOS] Always add shuffle & repeat buttons to CarPlay now playing screen

### DIFF
--- a/ios/brave-ios/Sources/PlaylistUI/CarPlayController.swift
+++ b/ios/brave-ios/Sources/PlaylistUI/CarPlayController.swift
@@ -45,6 +45,17 @@ public class CarPlayController {
         animated: true,
         completion: nil
       )
+
+      let nowPlaying = CPNowPlayingTemplate.shared
+      let shuffleButton = CPNowPlayingShuffleButton { [weak self] _ in
+        self?.player.isShuffleEnabled.toggle()
+      }
+      shuffleButton.isSelected = player.isShuffleEnabled
+      let repeatButton = CPNowPlayingRepeatButton { [weak self] _ in
+        self?.player.repeatMode.cycle()
+      }
+      repeatButton.isSelected = player.repeatMode != .none
+      nowPlaying.updateNowPlayingButtons([shuffleButton, repeatButton])
     }
 
     fetchResultsDelegate.contentDidChange = { [weak self] in
@@ -172,15 +183,6 @@ public class CarPlayController {
     }
     let nowPlaying = CPNowPlayingTemplate.shared
     if interface.topTemplate != nowPlaying {
-      let shuffleButton = CPNowPlayingShuffleButton { [weak self] _ in
-        self?.player.isShuffleEnabled.toggle()
-      }
-      shuffleButton.isSelected = player.isShuffleEnabled
-      let repeatButton = CPNowPlayingRepeatButton { [weak self] _ in
-        self?.player.repeatMode.cycle()
-      }
-      repeatButton.isSelected = player.repeatMode != .none
-      nowPlaying.updateNowPlayingButtons([shuffleButton, repeatButton])
       interface.pushTemplate(nowPlaying, animated: true, completion: nil)
     }
   }


### PR DESCRIPTION
This change ensures we add the shuffle & repeat mode buttons to the `CPNowPlayingTemplate` when setting up the CarPlay templates rather than set them when tapping on an item in the users playlist

### Test Plan

1. Prefix: Add items to playlist
2. Start playing an item on your phone
3. Open Brave in CarPlay (either in a car or via CarPlay simulator)
4. Tap on the Now Playing icon in the toolbar (top right, looks like a play button)
5. Verify shuffle & repeat mode buttons are visible on now playing screen
6. Tap back and traverse a folder and tap on a saved item 
7. Verify shuffle & repeat mode buttons are visible on now playing screen

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/46262

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
