### PR TITLE
chore(wallet): Add isAndroid Selector

### DIFF
--- a/components/brave_wallet_ui/common/selectors/ui-selectors.ts
+++ b/components/brave_wallet_ui/common/selectors/ui-selectors.ts
@@ -11,6 +11,7 @@ type State = { ui: UIState }
 export const selectedPendingTransactionId = ({ ui }: State) =>
   ui.selectedPendingTransactionId
 export const isPanel = ({ ui }: State) => ui.isPanel
+export const isAndroid = ({ ui }: State) => ui.isAndroid
 
 // unsafe
 export const transactionProviderErrorRegistry = ({ ui }: State) =>

--- a/components/brave_wallet_ui/common/slices/ui.slice.ts
+++ b/components/brave_wallet_ui/common/slices/ui.slice.ts
@@ -13,6 +13,7 @@ export const defaultUIState: UIState = {
   selectedPendingTransactionId: undefined,
   transactionProviderErrorRegistry: {},
   isPanel: false,
+  isAndroid: false,
 }
 
 // slice

--- a/components/brave_wallet_ui/components/desktop/account-list-item/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/account-list-item/index.tsx
@@ -28,7 +28,6 @@ import {
 } from '../../../utils/rewards_utils'
 import { getLocale } from '../../../../common/locale'
 import { getEntitiesListFromEntityState } from '../../../utils/entities.utils'
-import { loadTimeData } from '../../../../common/loadTimeData'
 
 // hooks
 import { useOnClickOutside } from '../../../common/hooks/useOnClickOutside'
@@ -127,7 +126,7 @@ export const AccountListItem = ({
 
   // selectors
   const isPanel = useSafeUISelector(UISelectors.isPanel)
-  const isAndroid = loadTimeData.getBoolean('isAndroid') || false
+  const isAndroid = useSafeUISelector(UISelectors.isAndroid)
 
   // redux
   const isZCashShieldedTransactionsEnabled = useSafeWalletSelector(

--- a/components/brave_wallet_ui/components/desktop/lock-screen/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/lock-screen/index.tsx
@@ -15,7 +15,6 @@ import {
 import { WalletRoutes } from '../../../constants/types'
 
 // Utils
-import { loadTimeData } from '../../../../common/loadTimeData'
 import { getLocale } from '../../../../common/locale'
 import { openWalletRouteTab } from '../../../utils/routes-utils'
 import { UISelectors } from '../../../common/selectors'
@@ -44,6 +43,7 @@ import { VerticalSpace, Row, Text } from '../../shared/style'
 export const LockScreen = () => {
   // redux
   const isPanel = useSafeUISelector(UISelectors.isPanel)
+  const isAndroid = useSafeUISelector(UISelectors.isAndroid)
 
   // routing
   const history = useHistory()
@@ -107,8 +107,6 @@ export const LockScreen = () => {
       getWalletAPIProxy().pageHandler?.unlockWalletUI()
     }
   }
-
-  const isAndroid = loadTimeData.getBoolean('isAndroid') || false
 
   // render
   if (isAndroid) {

--- a/components/brave_wallet_ui/components/desktop/popup-modals/confirm-password-modal/remove-account-modal.tsx
+++ b/components/brave_wallet_ui/components/desktop/popup-modals/confirm-password-modal/remove-account-modal.tsx
@@ -15,7 +15,6 @@ import {
 } from '../../../../page/reducers/accounts-tab-reducer'
 
 // utils
-import { loadTimeData } from '../../../../../common/loadTimeData'
 import { getLocale } from '../../../../../common/locale'
 import { BraveWallet } from '../../../../constants/types'
 import { UISelectors } from '../../../../common/selectors'
@@ -42,7 +41,7 @@ export const RemoveAccountModal = () => {
   const dispatch = useDispatch()
 
   const isPanel = useSafeUISelector(UISelectors.isPanel)
-  const isMobile = loadTimeData.getBoolean('isAndroid') || false
+  const isAndroid = useSafeUISelector(UISelectors.isAndroid)
 
   // accounts tab state
   const accountToRemove = useSelector(
@@ -174,7 +173,7 @@ export const RemoveAccountModal = () => {
           </Row>
         </Column>
 
-        {isMobile || isPanel ? (
+        {isAndroid || isPanel ? (
           <Row gap='4px'>
             <LeoSquaredButton
               onClick={() =>

--- a/components/brave_wallet_ui/components/desktop/popup-modals/enable-nft-discovery-modal/enable-nft-discovery-modal.tsx
+++ b/components/brave_wallet_ui/components/desktop/popup-modals/enable-nft-discovery-modal/enable-nft-discovery-modal.tsx
@@ -12,7 +12,6 @@ import { UISelectors } from '../../../../common/selectors'
 
 // utils
 import { getLocale, formatLocale } from '$web-common/locale'
-import { loadTimeData } from '../../../../../common/loadTimeData'
 
 // components
 import { PopupModal } from '../../popup-modals/index'
@@ -54,7 +53,7 @@ const enableNftAutoDiscovery = formatLocale(
 export const EnableNftDiscoveryModal = ({ onConfirm, onCancel }: Props) => {
   // Selectors
   const isPanel = useSafeUISelector(UISelectors.isPanel)
-  const isAndroid = loadTimeData.getBoolean('isAndroid') || false
+  const isAndroid = useSafeUISelector(UISelectors.isAndroid)
 
   return (
     <PopupModal

--- a/components/brave_wallet_ui/components/desktop/views/accounts/account.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/accounts/account.tsx
@@ -55,7 +55,6 @@ import {
   selectAllVisibleUserAssetsFromQueryResult, //
 } from '../../../../common/slices/entities/blockchain-token.entity'
 import { getAssetIdKey, isTokenWatchOnly } from '../../../../utils/asset-utils'
-import { loadTimeData } from '../../../../../common/loadTimeData'
 
 // Styled Components
 import {
@@ -167,7 +166,7 @@ export const Account = () => {
     WalletSelectors.isZCashShieldedTransactionsEnabled,
   )
   const isPanel = useSafeUISelector(UISelectors.isPanel)
-  const isAndroid = loadTimeData.getBoolean('isAndroid') || false
+  const isAndroid = useSafeUISelector(UISelectors.isAndroid)
   // mutations
   const [startShieldSync] = useStartShieldSyncMutation()
   const [stopShieldSync] = useStopShieldSyncMutation()

--- a/components/brave_wallet_ui/components/desktop/views/banners/banners.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/banners/banners.tsx
@@ -10,7 +10,6 @@ import { useHistory } from 'react-router-dom'
 import getWalletPageApiProxy from '../../../../page/wallet_page_api_proxy'
 
 // Utils
-import { loadTimeData } from '../../../../../common/loadTimeData'
 import { getLocale } from '../../../../../common/locale'
 import { openWalletSettings } from '../../../../utils/routes-utils'
 
@@ -33,6 +32,7 @@ import {
 export const Banners = () => {
   // Selectors
   const isPanel = useSafeUISelector(UISelectors.isPanel)
+  const isAndroid = useSafeUISelector(UISelectors.isAndroid)
 
   // Queries
   const {
@@ -58,9 +58,6 @@ export const Banners = () => {
 
   // routing
   const history = useHistory()
-
-  // Computed
-  const isAndroid = loadTimeData.getBoolean('isAndroid') || false
 
   const isCheckingWallets =
     isCheckingInstalledExtensions

--- a/components/brave_wallet_ui/components/desktop/views/portfolio/portfolio-overview.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/portfolio-overview.tsx
@@ -59,7 +59,6 @@ import {
   getStoredPortfolioTimeframe, //
 } from '../../../../utils/local-storage-utils'
 import { makePortfolioAssetRoute } from '../../../../utils/routes-utils'
-import { loadTimeData } from '../../../../../common/loadTimeData'
 
 // Options
 import {
@@ -135,8 +134,6 @@ import {
 } from '../../../../common/slices/entities/blockchain-token.entity'
 
 export const PortfolioOverview = () => {
-  const isAndroid = loadTimeData.getBoolean('isAndroid') || false
-
   // routing
   const history = useHistory()
   const location = useLocation()
@@ -146,6 +143,7 @@ export const PortfolioOverview = () => {
 
   // UI Selectors (safe)
   const isPanel = useSafeUISelector(UISelectors.isPanel)
+  const isAndroid = useSafeUISelector(UISelectors.isAndroid)
 
   // custom hooks
   const {

--- a/components/brave_wallet_ui/components/desktop/wallet-menus/accounts-menu.tsx
+++ b/components/brave_wallet_ui/components/desktop/wallet-menus/accounts-menu.tsx
@@ -5,7 +5,12 @@
 
 import * as React from 'react'
 import { useHistory } from 'react-router'
-import { loadTimeData } from '../../../../common/loadTimeData'
+
+// Selectors
+import {
+  useSafeUISelector, //
+} from '../../../common/hooks/use-safe-selector'
+import { UISelectors } from '../../../common/selectors'
 
 // Options
 import { CreateAccountOptions } from '../../../options/nav-options'
@@ -25,7 +30,9 @@ export const AccountsMenu = () => {
   // routing
   const history = useHistory()
 
-  const isAndroid = loadTimeData.getBoolean('isAndroid') || false
+  // Selectors
+  const isAndroid = useSafeUISelector(UISelectors.isAndroid)
+
   return (
     <StyledWrapper yPosition={42}>
       {CreateAccountOptions.filter(

--- a/components/brave_wallet_ui/components/desktop/wallet-page-wrapper/wallet-page-wrapper.tsx
+++ b/components/brave_wallet_ui/components/desktop/wallet-page-wrapper/wallet-page-wrapper.tsx
@@ -43,8 +43,6 @@ import {
   ConnectionBackgroundColor,
 } from './wallet-page-wrapper.style'
 
-import { loadTimeData } from '../../../../common/loadTimeData'
-
 export interface Props {
   wrapContentInBox?: boolean
   noPadding?: boolean
@@ -82,12 +80,11 @@ export const WalletPageWrapper = (props: Props) => {
     isConnection,
   } = props
 
-  const isAndroid = loadTimeData.getBoolean('isAndroid') || false
-
   // Wallet Selectors (safe)
   const isWalletCreated = useSafeWalletSelector(WalletSelectors.isWalletCreated)
   const isWalletLocked = useSafeWalletSelector(WalletSelectors.isWalletLocked)
   const isPanel = useSafeUISelector(UISelectors.isPanel)
+  const isAndroid = useSafeUISelector(UISelectors.isAndroid)
 
   // State
   const [headerShadowOpacity, setHeaderShadowOpacity] =

--- a/components/brave_wallet_ui/constants/types.ts
+++ b/components/brave_wallet_ui/constants/types.ts
@@ -197,6 +197,7 @@ export interface UIState {
   selectedPendingTransactionId?: string | undefined
   transactionProviderErrorRegistry: TransactionProviderErrorRegistry
   isPanel: boolean
+  isAndroid: boolean
 }
 
 export interface WalletState {

--- a/components/brave_wallet_ui/page/screens/android-buy/android/fund-wallet.tsx
+++ b/components/brave_wallet_ui/page/screens/android-buy/android/fund-wallet.tsx
@@ -41,7 +41,7 @@ export function AndroidFundWalletApp() {
           dark={walletDarkTheme}
           light={walletLightTheme}
         >
-          <FundWalletScreen isAndroid={true} />
+          <FundWalletScreen />
         </BraveCoreThemeProvider>
       </BrowserRouter>
     </Provider>

--- a/components/brave_wallet_ui/page/screens/fund-wallet/android/deposit-funds.tsx
+++ b/components/brave_wallet_ui/page/screens/fund-wallet/android/deposit-funds.tsx
@@ -40,7 +40,7 @@ export function AndroidDepositApp() {
           dark={walletDarkTheme}
           light={walletLightTheme}
         >
-          <DepositFundsScreen isAndroid={true} />
+          <DepositFundsScreen />
         </BraveCoreThemeProvider>
       </BrowserRouter>
     </Provider>

--- a/components/brave_wallet_ui/page/screens/fund-wallet/deposit-funds.tsx
+++ b/components/brave_wallet_ui/page/screens/fund-wallet/deposit-funds.tsx
@@ -129,17 +129,16 @@ const zcashAddressOptions: zcashAddressOptionType[] = [
   },
 ]
 
-interface Props {
-  isAndroid?: boolean
-}
-
 interface Params {
   assetId: string
 }
 
-export const DepositFundsScreen = ({ isAndroid }: Props) => {
+export const DepositFundsScreen = () => {
   // routing
   const history = useHistory()
+
+  // Selectors
+  const isAndroid = useSafeUISelector(UISelectors.isAndroid)
 
   // render
   return (

--- a/components/brave_wallet_ui/page/screens/fund-wallet/fund-wallet.tsx
+++ b/components/brave_wallet_ui/page/screens/fund-wallet/fund-wallet.tsx
@@ -101,14 +101,11 @@ import {
 } from '../../../utils/routes-utils'
 import { networkSupportsAccount } from '../../../utils/network-utils'
 
-interface Props {
-  isAndroid?: boolean
-}
 interface Params {
   assetId: string
 }
 
-export const FundWalletScreen = ({ isAndroid }: Props) => {
+export const FundWalletScreen = () => {
   // render
   return (
     <Switch>
@@ -116,14 +113,14 @@ export const FundWalletScreen = ({ isAndroid }: Props) => {
         path={WalletRoutes.FundWalletPurchaseOptionsPage}
         exact
       >
-        <PurchaseOptionSelection isAndroid={isAndroid} />
+        <PurchaseOptionSelection />
       </Route>
 
       <Route
         path={WalletRoutes.FundWalletPage}
         exact
       >
-        <AssetSelection isAndroid={isAndroid} />
+        <AssetSelection />
       </Route>
 
       <Redirect to={WalletRoutes.FundWalletPage} />
@@ -131,7 +128,10 @@ export const FundWalletScreen = ({ isAndroid }: Props) => {
   )
 }
 
-function AssetSelection({ isAndroid }: Props) {
+function AssetSelection() {
+  // Selectors
+  const isAndroid = useSafeUISelector(UISelectors.isAndroid)
+
   // routing
   const history = useHistory()
   const { assetId: selectedOnRampAssetId } = useParams<Params>()
@@ -444,7 +444,10 @@ function AssetSelection({ isAndroid }: Props) {
   )
 }
 
-function PurchaseOptionSelection({ isAndroid }: Props) {
+function PurchaseOptionSelection() {
+  // Selectors
+  const isAndroid = useSafeUISelector(UISelectors.isAndroid)
+
   // routing
   const history = useHistory()
   const { assetId: selectedOnRampAssetId } = useParams<Params>()

--- a/components/brave_wallet_ui/page/screens/fund-wallet/fund_wallet_v2.tsx
+++ b/components/brave_wallet_ui/page/screens/fund-wallet/fund_wallet_v2.tsx
@@ -63,11 +63,7 @@ import {
 import { Column, Row, Text } from '../../../components/shared/style'
 import { SearchInput } from './components/shared/style'
 
-interface Props {
-  isAndroid?: boolean
-}
-
-export const FundWalletScreen = ({ isAndroid }: Props) => {
+export const FundWalletScreen = () => {
   // State
   const [isCurrencyDialogOpen, setIsCurrencyDialogOpen] = React.useState(false)
   const [isAssetDialogOpen, setIsAssetDialogOpen] = React.useState(false)
@@ -113,6 +109,7 @@ export const FundWalletScreen = ({ isAndroid }: Props) => {
 
   // Redux
   const isPanel = useSafeUISelector(UISelectors.isPanel)
+  const isAndroid = useSafeUISelector(UISelectors.isAndroid)
 
   // Computed
   const selectedCountry = countries?.find(

--- a/components/brave_wallet_ui/page/screens/send/android/send.tsx
+++ b/components/brave_wallet_ui/page/screens/send/android/send.tsx
@@ -39,7 +39,7 @@ export function AndroidSendApp() {
         >
           <Switch>
             <Route>
-              <SendScreen isAndroid={true} />
+              <SendScreen />
             </Route>
           </Switch>
         </BraveCoreThemeProvider>

--- a/components/brave_wallet_ui/page/screens/send/send_screen/send_screen.tsx
+++ b/components/brave_wallet_ui/page/screens/send/send_screen/send_screen.tsx
@@ -99,13 +99,7 @@ import {
 } from '../../composer_ui/select_address_button/select_address_button'
 import { AddMemo } from '../components/add_memo/add_memo'
 
-interface Props {
-  isAndroid?: boolean
-}
-
-export const SendScreen = React.memo((props: Props) => {
-  const { isAndroid = false } = props
-
+export const SendScreen = React.memo(() => {
   // routing
   const query = useQuery()
   const history = useHistory()
@@ -138,6 +132,7 @@ export const SendScreen = React.memo((props: Props) => {
 
   // Selectors
   const isPanel = useSafeUISelector(UISelectors.isPanel)
+  const isAndroid = useSafeUISelector(UISelectors.isAndroid)
   const isZCashShieldedTransactionsEnabled = useSafeWalletSelector(
     WalletSelectors.isZCashShieldedTransactionsEnabled,
   )

--- a/components/brave_wallet_ui/page/store.ts
+++ b/components/brave_wallet_ui/page/store.ts
@@ -16,7 +16,7 @@ import { walletApi } from '../common/slices/api.slice'
 import walletReducer from '../common/slices/wallet.slice'
 import accountsTabReducer from './reducers/accounts-tab-reducer'
 import pageReducer from './reducers/page_reducer'
-import uiReducer from '../common/slices/ui.slice'
+import { uiReducer, defaultUIState } from '../common/slices/ui.slice'
 
 // utils
 import {
@@ -26,6 +26,7 @@ import {
   makeKeyringServiceObserver,
   makeTxServiceObserver,
 } from '../common/wallet_api_proxy_observers'
+import { loadTimeData } from '../../common/loadTimeData'
 
 export const store = configureStore({
   reducer: {
@@ -34,6 +35,12 @@ export const store = configureStore({
     accountsTab: accountsTabReducer,
     ui: uiReducer,
     [walletApi.reducerPath]: walletApi.reducer,
+  },
+  preloadedState: {
+    ui: {
+      ...defaultUIState,
+      isAndroid: loadTimeData.getBoolean('isAndroid') || false,
+    },
   },
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware({

--- a/components/brave_wallet_ui/stories/mock-data/mock-ui-state.ts
+++ b/components/brave_wallet_ui/stories/mock-data/mock-ui-state.ts
@@ -9,5 +9,6 @@ import { mockedErc20ApprovalTransaction } from './mock-transaction-info'
 export const mockUiState: UIState = {
   transactionProviderErrorRegistry: {},
   selectedPendingTransactionId: mockedErc20ApprovalTransaction.id,
-  isPanel: false
+  isPanel: false,
+  isAndroid: false
 }


### PR DESCRIPTION
## Description 

Adds a `isAndroid` selector to the `Wallet` UI and replaces all instances where we were calling `loadTimeDat.getBoolean('isAndroid')` with `useSafeUISelector(UISelectors.isAndroid)`.

This will allow for better `Testing` and more efficient Android `WebUI` development since we can now have a single
point of truth to use.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/46285>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

## Test Plan:

Android `WebUI` should continue to work as expected.