### PR TITLE
[iOS] Select child tabs created by the DOM immediately

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabDownloadDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabDownloadDelegate.swift
@@ -4,7 +4,9 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import BraveShared
+import BraveStrings
 import Foundation
+import OSLog
 import PassKit
 import SafariServices
 import Shared
@@ -19,7 +21,7 @@ extension UTType {
 
 extension BrowserViewController: TabDownloadDelegate {
   public func tab(_ tab: some TabState, didCreateDownload download: Download) {
-    guard tab.browserData?.isTabVisible() == true else {
+    guard tab.isVisible else {
       download.cancel()
       return
     }
@@ -105,17 +107,18 @@ extension BrowserViewController: TabDownloadDelegate {
     guard let destinationURL = download.destinationURL, error == nil else {
       downloadQueue.download(download, didCompleteWithError: error)
 
+      if let error, (error as NSError).code == URLError.cancelled.rawValue {
+        // If the download was cancelled then we can ignore the error
+        return
+      }
+
       // display an error
       let alertController = UIAlertController(
-        title: Strings.unableToAddPassErrorTitle,
-        message: Strings.unableToAddPassErrorMessage,
+        title: Strings.unableToDownloadFileErrorTitle,
+        message: Strings.unableToDownloadFileErrorMessage,
         preferredStyle: .alert
       )
-      alertController.addAction(
-        UIAlertAction(title: Strings.unableToAddPassErrorDismiss, style: .cancel) { (action) in
-          // Do nothing.
-        }
-      )
+      alertController.addAction(UIAlertAction(title: Strings.OKString, style: .cancel) { _ in })
       present(alertController, animated: true, completion: nil)
 
       return

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabObserver.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabObserver.swift
@@ -16,6 +16,10 @@ extension BrowserViewController: TabObserver {
   public func tabDidCreateWebView(_ tab: some TabState) {
     tab.view.frame = webViewContainer.frame
 
+    if tab.isVisible, let scrollView = tab.webViewProxy?.scrollView {
+      toolbarVisibilityViewModel.beginObservingScrollView(scrollView)
+    }
+
     var injectedScripts: [TabContentScript] = [
       ReaderModeScriptHandler(),
       ErrorPageHelper(certStore: profile.certStore),

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/TabManager.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/TabManager.swift
@@ -357,7 +357,7 @@ class TabManager: NSObject {
       preserveScreenshot(for: previousTab)
     }
 
-    if let t = selectedTab, !t.isWebViewCreated {
+    if let t = selectedTab, !t.isWebViewCreated, t.opener == nil {
       selectedTab?.createWebView()
       restoreTab(t)
     }
@@ -374,7 +374,9 @@ class TabManager: NSObject {
     }
 
     UIImpactFeedbackGenerator(style: .light).vibrate()
-    selectedTab?.createWebView()
+    if tab?.opener == nil {
+      selectedTab?.createWebView()
+    }
 
     if let selectedTab = selectedTab,
       selectedTab.visibleURL == nil
@@ -643,7 +645,9 @@ class TabManager: NSObject {
       while insertIndex < allTabs.count && allTabs[insertIndex].isDescendentOf(parent) {
         insertIndex += 1
       }
-      tab.opener = parent
+      if isPopup {
+        tab.opener = parent
+      }
       allTabs.insert(tab, at: insertIndex)
     }
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/ToolbarVisibilityViewModel.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/ToolbarVisibilityViewModel.swift
@@ -296,6 +296,10 @@ import UIKit
   ///
   /// If you need to control the delegate yourself, consider calling actions yourself instead
   func beginObservingScrollView(_ scrollView: UIScrollView) {
+    if scrollViewObservation != nil {
+      // Already observing
+      return
+    }
     scrollView.panGestureRecognizer.addTarget(self, action: #selector(pannedScrollView(_:)))
     scrollViewObservation = scrollView.observe(
       \.contentSize,

--- a/ios/brave-ios/Sources/BraveStrings/BraveStrings.swift
+++ b/ios/brave-ios/Sources/BraveStrings/BraveStrings.swift
@@ -9322,6 +9322,18 @@ extension Strings {
 
 extension Strings {
   // Errors
+  public static let unableToDownloadFileErrorTitle = NSLocalizedString(
+    "UnableToDownloadFileErrorTitle",
+    bundle: .module,
+    value: "Failed to Download File",
+    comment: "A title shown when a file fails to download for some reason"
+  )
+  public static let unableToDownloadFileErrorMessage = NSLocalizedString(
+    "UnableToDownloadFileErrorMessage",
+    bundle: .module,
+    value: "An error occurred while downloading the file. Please try again later.",
+    comment: "A message shown when a file fails to download for some reason"
+  )
   public static let unsupportedInstrumentMessage = NSLocalizedString(
     "unsupportedInstrumentMessage",
     tableName: "BraveShared",


### PR DESCRIPTION
This change removes the delay before selecting a tab that is created by the DOM (via `window.open` or `target=_blank`) and ensures that `opener` on the `TabState` is only set for these types of DOM-created tabs. A side effect of this is that a web view is no longer guaranteed to be created when a tab is selected, so scroll view observation must also be done in `tabDidCreateWebView`. This change also updates the copy for a failed download to not display Apple Wallet Passes failure messages.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/46323

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
