### PR TITLE
Disabled scrim views

### DIFF
--- a/app/feature_defaults_unittest.cc
+++ b/app/feature_defaults_unittest.cc
@@ -162,6 +162,8 @@ TEST(FeatureDefaultsTest, DisabledFeatures) {
       &features::kReportPakFileIntegrity,
 #endif
       &features::kSCTAuditing,
+      &features::kScrimForBrowserWindowModal,
+      &features::KScrimForTabModal,
       &features::kServiceWorkerAutoPreload,
       &features::kSideBySide,
       &features::kTabHoverCardImages,

--- a/browser/ui/views/frame/BUILD.gn
+++ b/browser/ui/views/frame/BUILD.gn
@@ -1,0 +1,23 @@
+# Copyright (c) 2025 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+source_set("browser_tests") {
+  testonly = true
+  defines = [ "HAS_OUT_OF_PROC_TEST_RUNNER" ]
+
+  sources =
+      [ "//brave/browser/ui/views/frame/brave_browser_view_browsertest.cc" ]
+
+  deps = [
+    "//base",
+    "//chrome/browser",
+    "//chrome/browser/ui",
+    "//chrome/browser/ui/browser_window",
+    "//chrome/test:test_support",
+    "//chrome/test:test_support_ui",
+    "//content/test:test_support",
+    "//ui/views",
+  ]
+}

--- a/browser/ui/views/frame/brave_browser_view_browsertest.cc
+++ b/browser/ui/views/frame/brave_browser_view_browsertest.cc
@@ -1,0 +1,100 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/views/frame/brave_browser_view.h"
+
+#include <string>
+
+#include "build/build_config.h"
+#include "chrome/browser/ui/tab_modal_confirm_dialog.h"
+#include "chrome/browser/ui/tabs/tab_strip_model.h"
+#include "chrome/browser/ui/tabs/tab_strip_user_gesture_details.h"
+#include "chrome/browser/ui/test/test_browser_ui.h"
+#include "chrome/browser/ui/views/frame/browser_view.h"
+#include "chrome/browser/ui/views/frame/scrim_view.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "content/public/browser/web_contents.h"
+#include "content/public/test/browser_test.h"
+#include "content/public/test/browser_test_utils.h"
+#include "ui/views/widget/widget.h"
+#include "ui/views/widget/widget_delegate.h"
+
+namespace {
+class TestTabModalConfirmDialogDelegate : public TabModalConfirmDialogDelegate {
+ public:
+  explicit TestTabModalConfirmDialogDelegate(content::WebContents* contents)
+      : TabModalConfirmDialogDelegate(contents) {}
+
+  TestTabModalConfirmDialogDelegate(const TestTabModalConfirmDialogDelegate&) =
+      delete;
+  TestTabModalConfirmDialogDelegate& operator=(
+      const TestTabModalConfirmDialogDelegate&) = delete;
+
+  std::u16string GetTitle() override { return std::u16string(u"Dialog Title"); }
+  std::u16string GetDialogMessage() override { return std::u16string(); }
+};
+}  // namespace
+
+class BraveBrowserViewTest : public InProcessBrowserTest {
+ public:
+  BraveBrowserViewTest() = default;
+  ~BraveBrowserViewTest() override = default;
+
+  BraveBrowserViewTest(const BraveBrowserViewTest&) = delete;
+  BraveBrowserViewTest& operator=(const BraveBrowserViewTest&) = delete;
+
+ protected:
+  BrowserView* browser_view() {
+    return BrowserView::GetBrowserViewForBrowser(browser());
+  }
+};
+
+// Tests that a content area scrim is still disabled when a tab modal dialog is
+// active.
+IN_PROC_BROWSER_TEST_F(BraveBrowserViewTest, ScrimForTabModalDisabledTest) {
+  content::WebContents* contents = browser_view()->GetActiveWebContents();
+  auto delegate = std::make_unique<TestTabModalConfirmDialogDelegate>(contents);
+
+  // Check scrim view is always not visible.
+  TabModalConfirmDialog::Create(std::move(delegate), contents);
+  EXPECT_FALSE(browser_view()->contents_scrim_view()->GetVisible());
+
+  ASSERT_TRUE(
+      AddTabAtIndex(1, GURL(url::kAboutBlankURL), ui::PAGE_TRANSITION_LINK));
+  EXPECT_FALSE(browser_view()->contents_scrim_view()->GetVisible());
+
+  browser()->tab_strip_model()->ActivateTabAt(
+      0, TabStripUserGestureDetails(
+             TabStripUserGestureDetails::GestureType::kMouse));
+  EXPECT_FALSE(browser_view()->contents_scrim_view()->GetVisible());
+}
+
+// MacOS does not need views window scrim. We use sheet to show window modals
+// (-[NSWindow beginSheet:]), which natively draws a scrim since macOS 11.
+// Tests that a scrim is still disabled when a window modal dialog is active.
+#if !BUILDFLAG(IS_MAC)
+IN_PROC_BROWSER_TEST_F(BraveBrowserViewTest,
+                       ScrimForBrowserWindowModalDisabledTest) {
+  auto child_widget_delegate = std::make_unique<views::WidgetDelegate>();
+  auto child_widget = std::make_unique<views::Widget>();
+  child_widget_delegate->SetModalType(ui::mojom::ModalType::kWindow);
+  views::Widget::InitParams params(
+      views::Widget::InitParams::CLIENT_OWNS_WIDGET,
+      views::Widget::InitParams::TYPE_WINDOW);
+  params.delegate = child_widget_delegate.get();
+  params.parent = browser_view()->GetWidget()->GetNativeView();
+  child_widget->Init(std::move(params));
+
+  // Check scrim view is always not visible.
+  child_widget->Show();
+  EXPECT_FALSE(browser_view()->window_scrim_view()->GetVisible());
+  child_widget->Hide();
+  EXPECT_FALSE(browser_view()->window_scrim_view()->GetVisible());
+  child_widget->Show();
+  EXPECT_FALSE(browser_view()->window_scrim_view()->GetVisible());
+  child_widget.reset();
+  EXPECT_FALSE(browser_view()->window_scrim_view()->GetVisible());
+}
+#endif  // !BUILDFLAG(IS_MAC)

--- a/chromium_src/chrome/browser/ui/ui_features.cc
+++ b/chromium_src/chrome/browser/ui/ui_features.cc
@@ -13,6 +13,10 @@ OVERRIDE_FEATURE_DEFAULT_STATES({{
 #if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_MAC) || BUILDFLAG(IS_LINUX)
     {kFewerUpdateConfirmations, base::FEATURE_DISABLED_BY_DEFAULT},
 #endif
+    // TODO(https://github.com/brave/brave-browser/issues/46337): Re-enable
+    // scrim views if needed.
+    {kScrimForBrowserWindowModal, base::FEATURE_DISABLED_BY_DEFAULT},
+    {KScrimForTabModal, base::FEATURE_DISABLED_BY_DEFAULT},
     {kSideBySide, base::FEATURE_DISABLED_BY_DEFAULT},
     {kTabHoverCardImages, base::FEATURE_DISABLED_BY_DEFAULT},
 }});

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -1117,6 +1117,7 @@ test("brave_browser_tests") {
     deps += [
       "//brave/browser/ui/sidebar:browser_tests",
       "//brave/browser/ui/views/brave_ads:browser_tests",
+      "//brave/browser/ui/views/frame:browser_tests",
       "//brave/browser/ui/views/location_bar:browser_tests",
       "//brave/browser/ui/views/split_view:browser_tests",
       "//brave/browser/ui/views/tabs:browser_tests",


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/46264

We're not ready to use it. Disable it first and add additional scrim views to our widget controls as a f/u.

TEST=`BraveBrowserViewTest.ScrimForTabModalDisabledTest`,
`BraveBrowserViewTest.ScrimForBrowserWindowModalDisabledTest`,
 `FeatureDefaultsTest.DisabledFeatures`

1. Launch browser and add multiple tabs
2. Click window close button and check there is no grayed area after launching window closing dialog
3. Enable split view or vertical tab and check same with above step 2.

![Screenshot 2025-05-26 112204](https://github.com/user-attachments/assets/dc5d8549-89e5-4227-bb53-667d6c0d1e98)
![Screenshot 2025-05-26 112223](https://github.com/user-attachments/assets/1e6740af-85b1-4695-9906-974affc0516c)
![Screenshot 2025-05-26 112250](https://github.com/user-attachments/assets/00a88856-c37c-482c-a217-7bae94b3c28b)


<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
