### PR TITLE
Fixed brave shiels panel in incognito.

### DIFF
--- a/browser/brave_shields/BUILD.gn
+++ b/browser/brave_shields/BUILD.gn
@@ -1,0 +1,29 @@
+# Copyright (c) 2025 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import("//testing/test.gni")
+
+source_set("unit_tests") {
+  testonly = true
+
+  sources = []
+
+  deps = [
+    "//brave/components/brave_shields/content/browser",
+    "//brave/components/brave_shields/core/browser",
+    "//brave/components/brave_shields/core/common",
+    "//chrome/test:test_support",
+    "//testing/gtest",
+  ]
+
+  if (!is_android) {
+    sources += [ "brave_shields_util_profiles_unittest.cc" ]
+
+    deps += [
+      "//chrome/browser",
+      "//chrome/browser/content_settings:content_settings_factory",
+    ]
+  }
+}

--- a/browser/brave_shields/ad_block_service_browsertest.cc
+++ b/browser/brave_shields/ad_block_service_browsertest.cc
@@ -680,7 +680,7 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, SubFrameShieldsOff) {
                          )"));
   content::RunAllTasksUntilIdle();
   EXPECT_EQ(profile()->GetPrefs()->GetUint64(kAdsBlocked), 0ULL);
-  brave_shields::ResetBraveShieldsEnabled(content_settings(), url);
+  brave_shields::SetBraveShieldsEnabled(content_settings(), true, url);
 }
 
 // Requests made by a service worker should be blocked as well.

--- a/browser/brave_shields/brave_shields_tab_helper.cc
+++ b/browser/brave_shields/brave_shields_tab_helper.cc
@@ -178,13 +178,8 @@ bool BraveShieldsTabHelper::GetBraveShieldsEnabled() {
 
 void BraveShieldsTabHelper::SetBraveShieldsEnabled(bool is_enabled) {
   auto* map = GetHostContentSettingsMap(web_contents());
-  if (map->GetDefaultContentSetting(ContentSettingsType::BRAVE_SHIELDS,
-                                    nullptr) == is_enabled) {
-    brave_shields::ResetBraveShieldsEnabled(map, GetCurrentSiteURL());
-  } else {
-    brave_shields::SetBraveShieldsEnabled(map, is_enabled, GetCurrentSiteURL(),
-                                          g_browser_process->local_state());
-  }
+  brave_shields::SetBraveShieldsEnabled(map, is_enabled, GetCurrentSiteURL(),
+                                        g_browser_process->local_state());
   ReloadWebContents();
 }
 

--- a/browser/brave_shields/brave_shields_util_profiles_unittest.cc
+++ b/browser/brave_shields/brave_shields_util_profiles_unittest.cc
@@ -1,0 +1,212 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/components/brave_shields/content/browser/brave_shields_util.h"
+#include "chrome/browser/content_settings/cookie_settings_factory.h"
+#include "chrome/browser/content_settings/host_content_settings_map_factory.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/test/base/testing_browser_process.h"
+#include "chrome/test/base/testing_profile.h"
+#include "chrome/test/base/testing_profile_manager.h"
+#include "components/content_settings/core/browser/cookie_settings.h"
+#include "components/content_settings/core/browser/host_content_settings_map.h"
+#include "content/public/test/browser_task_environment.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "url/gurl.h"
+
+namespace {
+
+using ScopedIncognitoProfile =
+    std::unique_ptr<Profile, decltype([](Profile* p) {
+                      ASSERT_TRUE(!!p->IsOffTheRecord());
+                      p->GetOriginalProfile()->DestroyOffTheRecordProfile(p);
+                    })>;
+
+testing::Message& operator<<(testing::Message& m,
+                             brave_shields::ControlType c) {
+  return m << brave_shields::ControlTypeToString(c);
+}
+
+}  // namespace
+
+namespace brave_shields {
+
+class BraveShieldsUtilProfilesTest : public testing::Test {
+ public:
+  BraveShieldsUtilProfilesTest()
+      : local_state_(TestingBrowserProcess::GetGlobal()) {}
+  ~BraveShieldsUtilProfilesTest() override = default;
+
+  TestingProfile* regular_profile() { return &profile_; }
+  ScopedIncognitoProfile incognito_profile() {
+    return ScopedIncognitoProfile(regular_profile()->GetOffTheRecordProfile(
+        Profile::OTRProfileID::PrimaryID(),
+        /*create_if_needed=*/true));
+  }
+
+  HostContentSettingsMap* hcsm(Profile* profile) {
+    return HostContentSettingsMapFactory::GetForProfile(profile);
+  }
+
+  HostContentSettingsMap* hcsm(ScopedIncognitoProfile& profile) {
+    return hcsm(profile.get());
+  }
+
+  const GURL test_url{"https://example.com"};
+
+  template <typename ValueT, typename SetFn, typename GetFn>
+  void RunTest(base::span<const std::pair<ValueT, ValueT>> cases,
+               SetFn setter,
+               GetFn getter) {
+    testing::Message issues;
+    for (const auto& [value, expect] : cases) {
+      setter(hcsm(regular_profile()), value);
+      const auto get = getter(hcsm(regular_profile()));
+      if (expect != get) {
+        issues << "Regular profile: Set " << value << " Get " << get
+               << " Expected " << expect << "\n";
+      }
+
+      auto incognito = incognito_profile();
+      // Now change value for incognito and expect that values are not depended
+      // on the regular profile.
+      for (const auto& [ivalue, iexpect] : cases) {
+        setter(hcsm(incognito), ivalue);
+        const auto iget = getter(hcsm(incognito));
+        if (iexpect != iget) {
+          issues << "Incognito profile: Set " << ivalue << " Get " << iget
+                 << " Expected " << iexpect << " Regular profile value "
+                 << value << "\n";
+        }
+      }
+    }
+    const auto message = issues.GetString();
+    EXPECT_TRUE(message.empty()) << message;
+  }
+
+ private:
+  content::BrowserTaskEnvironment task_environment_;
+  TestingProfile profile_;
+  ScopedTestingLocalState local_state_;
+};
+
+TEST_F(BraveShieldsUtilProfilesTest, SetBraveShieldsEnabled) {
+  constexpr std::pair<bool, bool> kExpects[] = {{true, true}, {false, false}};
+
+  auto set = [this](HostContentSettingsMap* map, bool value) {
+    SetBraveShieldsEnabled(map, value, test_url);
+  };
+  auto get = [this](HostContentSettingsMap* map) {
+    return GetBraveShieldsEnabled(map, test_url);
+  };
+
+  RunTest<bool>(kExpects, std::move(set), std::move(get));
+}
+
+TEST_F(BraveShieldsUtilProfilesTest, SetAdControlType) {
+  constexpr std::pair<ControlType, ControlType> kExpects[] = {{ALLOW, ALLOW},
+                                                              {BLOCK, BLOCK}};
+
+  auto set = [this](HostContentSettingsMap* map, ControlType value) {
+    SetAdControlType(map, value, test_url);
+  };
+  auto get = [this](HostContentSettingsMap* map) {
+    return GetAdControlType(map, test_url);
+  };
+
+  RunTest<ControlType>(kExpects, std::move(set), std::move(get));
+}
+
+TEST_F(BraveShieldsUtilProfilesTest, SetCosmeticFilteringControlType) {
+  constexpr std::pair<ControlType, ControlType> kExpects[] = {
+      {ALLOW, ALLOW}, {BLOCK, BLOCK}, {BLOCK_THIRD_PARTY, BLOCK_THIRD_PARTY}};
+
+  auto set = [this](HostContentSettingsMap* map, ControlType value) {
+    SetCosmeticFilteringControlType(map, value, test_url);
+  };
+  auto get = [this](HostContentSettingsMap* map) {
+    return GetCosmeticFilteringControlType(map, test_url);
+  };
+
+  RunTest<ControlType>(kExpects, std::move(set), std::move(get));
+}
+
+TEST_F(BraveShieldsUtilProfilesTest, SetCookieControlType) {
+  constexpr std::pair<ControlType, ControlType> kExpects[] = {
+      {ALLOW, ALLOW}, {BLOCK, BLOCK}, {BLOCK_THIRD_PARTY, BLOCK_THIRD_PARTY}};
+
+  auto set = [this](HostContentSettingsMap* map, ControlType value) {
+    SetCookieControlType(map, regular_profile()->GetPrefs(), value, test_url);
+  };
+
+  auto cookie_settings =
+      CookieSettingsFactory::GetForProfile(regular_profile());
+
+  auto get = [this, cookie_settings](HostContentSettingsMap* map) {
+    return GetCookieControlType(map, cookie_settings.get(), test_url);
+  };
+
+  RunTest<ControlType>(kExpects, std::move(set), std::move(get));
+}
+
+TEST_F(BraveShieldsUtilProfilesTest, SetFingerprintingControlType) {
+  constexpr std::pair<ControlType, ControlType> kExpects[] = {
+      {ALLOW, ALLOW},
+      {BLOCK, DEFAULT},
+      {BLOCK_THIRD_PARTY, DEFAULT},
+      {DEFAULT, DEFAULT}};
+
+  auto set = [this](HostContentSettingsMap* map, ControlType value) {
+    SetFingerprintingControlType(map, value, test_url);
+  };
+  auto get = [this](HostContentSettingsMap* map) {
+    return GetFingerprintingControlType(map, test_url);
+  };
+
+  RunTest<ControlType>(kExpects, std::move(set), std::move(get));
+}
+
+TEST_F(BraveShieldsUtilProfilesTest, SetHttpsUpgradeControlType) {
+  constexpr std::pair<ControlType, ControlType> kExpects[] = {
+      {ALLOW, ALLOW}, {BLOCK, BLOCK}, {BLOCK_THIRD_PARTY, BLOCK_THIRD_PARTY}};
+
+  auto set = [this](HostContentSettingsMap* map, ControlType value) {
+    SetHttpsUpgradeControlType(map, value, test_url);
+  };
+  auto get = [this](HostContentSettingsMap* map) {
+    return GetHttpsUpgradeControlType(map, test_url);
+  };
+
+  RunTest<ControlType>(kExpects, std::move(set), std::move(get));
+}
+
+TEST_F(BraveShieldsUtilProfilesTest, SetNoScriptControlType) {
+  constexpr std::pair<ControlType, ControlType> kExpects[] = {
+      {ALLOW, ALLOW}, {BLOCK, BLOCK}, {DEFAULT, BLOCK}};
+
+  auto set = [this](HostContentSettingsMap* map, ControlType value) {
+    SetNoScriptControlType(map, value, test_url);
+  };
+  auto get = [this](HostContentSettingsMap* map) {
+    return GetNoScriptControlType(map, test_url);
+  };
+
+  RunTest<ControlType>(kExpects, std::move(set), std::move(get));
+}
+
+TEST_F(BraveShieldsUtilProfilesTest, SetForgetFirstPartyStorageEnabled) {
+  constexpr std::pair<bool, bool> kExpects[] = {{true, true}, {false, false}};
+
+  auto set = [this](HostContentSettingsMap* map, bool value) {
+    SetForgetFirstPartyStorageEnabled(map, value, test_url);
+  };
+  auto get = [this](HostContentSettingsMap* map) {
+    return GetForgetFirstPartyStorageEnabled(map, test_url);
+  };
+
+  RunTest<bool>(kExpects, std::move(set), std::move(get));
+}
+
+}  // namespace brave_shields

--- a/browser/brave_shields/domain_block_page_browsertest.cc
+++ b/browser/brave_shields/domain_block_page_browsertest.cc
@@ -28,7 +28,6 @@
 #include "url/gurl.h"
 
 using brave_shields::ControlType;
-using brave_shields::ResetBraveShieldsEnabled;
 using brave_shields::SetBraveShieldsEnabled;
 using brave_shields::SetCosmeticFilteringControlType;
 using brave_shields::features::kBraveDomainBlock;

--- a/components/brave_shields/content/browser/brave_shields_util.cc
+++ b/components/brave_shields/content/browser/brave_shields_util.cc
@@ -246,7 +246,9 @@ void SetBraveShieldsEnabled(HostContentSettingsMap* map,
         primary_pattern, ContentSettingsPattern::Wildcard(),
         ContentSettingsType::BRAVE_SHIELDS, setting);
 
-    RecordShieldsToggled(local_state);
+    if (!map->IsOffTheRecord()) {
+      RecordShieldsToggled(local_state);
+    }
   } else {
     map->SetContentSettingCustomScope(
         primary_pattern, ContentSettingsPattern::Wildcard(),

--- a/components/brave_shields/content/browser/brave_shields_util.cc
+++ b/components/brave_shields/content/browser/brave_shields_util.cc
@@ -237,29 +237,21 @@ void SetBraveShieldsEnabled(HostContentSettingsMap* map,
     return;
   }
 
-  map->SetContentSettingCustomScope(
-      primary_pattern, ContentSettingsPattern::Wildcard(),
-      ContentSettingsType::BRAVE_SHIELDS,
-      // this is 'allow_brave_shields' so 'enable' == 'allow'
-      enable ? CONTENT_SETTING_ALLOW : CONTENT_SETTING_BLOCK);
+  // this is 'allow_brave_shields' so 'enable' == 'allow'
+  const auto setting = enable ? CONTENT_SETTING_ALLOW : CONTENT_SETTING_BLOCK;
+  if (map->IsOffTheRecord() ||
+      setting != map->GetDefaultContentSetting(
+                     ContentSettingsType::BRAVE_SHIELDS, nullptr)) {
+    map->SetContentSettingCustomScope(
+        primary_pattern, ContentSettingsPattern::Wildcard(),
+        ContentSettingsType::BRAVE_SHIELDS, setting);
 
-  RecordShieldsToggled(local_state);
-}
-
-void ResetBraveShieldsEnabled(HostContentSettingsMap* map, const GURL& url) {
-  if (url.is_valid() && !url.SchemeIsHTTPOrHTTPS()) {
-    return;
+    RecordShieldsToggled(local_state);
+  } else {
+    map->SetContentSettingCustomScope(
+        primary_pattern, ContentSettingsPattern::Wildcard(),
+        ContentSettingsType::BRAVE_SHIELDS, CONTENT_SETTING_DEFAULT);
   }
-
-  auto primary_pattern = GetPatternFromURL(url);
-
-  if (!primary_pattern.IsValid()) {
-    return;
-  }
-
-  map->SetContentSettingCustomScope(
-      primary_pattern, ContentSettingsPattern::Wildcard(),
-      ContentSettingsType::BRAVE_SHIELDS, CONTENT_SETTING_DEFAULT);
 }
 
 bool GetBraveShieldsEnabled(HostContentSettingsMap* map, const GURL& url) {
@@ -283,7 +275,8 @@ void SetAdControlType(HostContentSettingsMap* map,
                       ControlType type,
                       const GURL& url,
                       PrefService* local_state) {
-  DCHECK(type != ControlType::BLOCK_THIRD_PARTY);
+  DCHECK_NE(type, ControlType::BLOCK_THIRD_PARTY);
+  DCHECK_NE(type, ControlType::DEFAULT);
   auto primary_pattern = GetPatternFromURL(url);
 
   if (!primary_pattern.IsValid()) {
@@ -319,6 +312,7 @@ void SetCosmeticFilteringControlType(HostContentSettingsMap* map,
                                      const GURL& url,
                                      PrefService* local_state,
                                      PrefService* profile_state) {
+  DCHECK_NE(type, ControlType::DEFAULT);
   auto primary_pattern = GetPatternFromURL(url);
 
   if (!primary_pattern.IsValid()) {
@@ -682,6 +676,7 @@ void SetHttpsUpgradeControlType(HostContentSettingsMap* map,
                                 ControlType type,
                                 const GURL& url,
                                 PrefService* local_state) {
+  DCHECK_NE(type, ControlType::DEFAULT);
   if (!url.SchemeIsHTTPOrHTTPS() && !url.is_empty()) {
     return;
   }
@@ -786,7 +781,7 @@ void SetNoScriptControlType(HostContentSettingsMap* map,
                             ControlType type,
                             const GURL& url,
                             PrefService* local_state) {
-  DCHECK(type != ControlType::BLOCK_THIRD_PARTY);
+  DCHECK_NE(type, ControlType::BLOCK_THIRD_PARTY);
   auto primary_pattern = GetPatternFromURL(url);
 
   if (!primary_pattern.IsValid()) {

--- a/components/brave_shields/content/browser/brave_shields_util.h
+++ b/components/brave_shields/content/browser/brave_shields_util.h
@@ -58,8 +58,6 @@ void SetBraveShieldsEnabled(HostContentSettingsMap* map,
                             bool enable,
                             const GURL& url,
                             PrefService* local_state = nullptr);
-// reset to the default value
-void ResetBraveShieldsEnabled(HostContentSettingsMap* map, const GURL& url);
 bool GetBraveShieldsEnabled(HostContentSettingsMap* map, const GURL& url);
 
 void SetAdControlType(HostContentSettingsMap* map,

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -162,6 +162,7 @@ test("brave_unit_tests") {
     "//brave/browser/autocomplete:unit_tests",
     "//brave/browser/brave_ads",
     "//brave/browser/brave_ads/device_id:unit_tests",
+    "//brave/browser/brave_shields:unit_tests",
     "//brave/browser/brave_stats:unit_tests",
     "//brave/browser/brave_wallet",
     "//brave/browser/brave_wallet:unit_tests",


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/46186

There were two functions, `SetBraveShieldsEnabled` and `ResetBraveShieldsEnabled`. The second function set `CONTENT_SETTING_DEFAULT` for the content settings when shields were enabled on the page, while `SetBraveShieldsEnabled` would set `CONTENT_SETTING_ALLOW` in the same case. I've merged the logic of `ResetBraveShieldsEnabled` into `SetBraveShieldsEnabled`.

Now:
1. `SetBraveShieldsEnabled` sets `CONTENT_SETTING_DEFAULT` when the user enables shields on the page in a regular profile
2. `SetBraveShieldsEnabled` sets `CONTENT_SETTING_ALLOW` when the user enables shields on the page in an off-the-record profile, because `BRAVE_SHIELDS` content settings are registered to inherit values from the regular profile. Without explicitly setting `ALLOW` in off-the-record profiles, the getter would fall back to the regular profile's settings, which cause incorrect behavior described in the issue.

Other functions were also checked for similar issues. In cases where a problem arises, it has been confirmed that such a state cannot be reached from the UI, and `DCHECK`s have been added for values that are unused (and should not be used).