### PR TITLE
Fix prettier config path

### DIFF
--- a/build/commands/scripts/format.js
+++ b/build/commands/scripts/format.js
@@ -140,6 +140,7 @@ const runPrettier = async (files, dryRun) => {
     const content = await fs.readFile(file, { encoding: 'utf-8' })
     const formatted = await prettier.format(content, {
       ...options,
+      filepath: file,
       parser: fileInfo.inferredParser,
     })
     if (content !== formatted) {

--- a/build/commands/scripts/format.js
+++ b/build/commands/scripts/format.js
@@ -119,6 +119,41 @@ const runFormat = async (options = {}) => {
   }
 }
 
+const runPrettierForFile = async (file, dryRun, options, ignorePath) => {
+  const fileInfo = await prettier.getFileInfo(file, {
+    ignorePath: ignorePath,
+    withNodeModules: false,
+  })
+
+  if (fileInfo.ignored || !fileInfo.inferredParser) {
+    return null
+  }
+
+  const content = await fs.readFile(file, { encoding: 'utf-8' })
+  const formatted = await prettier.format(content, {
+    ...options,
+    filepath: file,
+    parser: fileInfo.inferredParser,
+  })
+  if (content !== formatted) {
+    if (dryRun) {
+      // Use `echo <formatted> | git diff --no-index <file> -` to show diff
+      const diffResult = spawnSync('git', ['diff', '--no-index', file, '-'], {
+        stdio: 'pipe',
+        input: formatted,
+      })
+      if (diffResult.status === 1) {
+        // Differences were found
+        return convertDiff(diffResult.stdout.toString(), file)
+      } else {
+        return `Can't show diff for ${file}:\n ${formatOutput(diffResult)}`
+      }
+    } else {
+      await fs.writeFile(file, formatted)
+    }
+  }
+  return null
+}
 const runPrettier = async (files, dryRun) => {
   const options = require(path.join(config.braveCoreDir, '.prettierrc'))
   const ignorePath = path.join(config.braveCoreDir, '.prettierignore')
@@ -128,39 +163,13 @@ const runPrettier = async (files, dryRun) => {
 
   const prettierIssues = []
   for (const file of files) {
-    const fileInfo = await prettier.getFileInfo(file, {
-      ignorePath: ignorePath,
-      withNodeModules: false,
-    })
-
-    if (fileInfo.ignored || !fileInfo.inferredParser) {
-      continue
-    }
-
-    const content = await fs.readFile(file, { encoding: 'utf-8' })
-    const formatted = await prettier.format(content, {
-      ...options,
-      filepath: file,
-      parser: fileInfo.inferredParser,
-    })
-    if (content !== formatted) {
-      if (dryRun) {
-        // Use `echo <formatted> | git diff --no-index <file> -` to show diff
-        const diffResult = spawnSync('git', ['diff', '--no-index', file, '-'], {
-          stdio: 'pipe',
-          input: formatted,
-        })
-        if (diffResult.status === 1) {
-          // Differences were found
-          prettierIssues.push(convertDiff(diffResult.stdout.toString(), file))
-        } else {
-          prettierIssues.push(
-            `Can't show diff for ${file}:\n ${formatOutput(diffResult)}`,
-          )
-        }
-      } else {
-        await fs.writeFile(file, formatted)
+    try {
+      const issue = await runPrettierForFile(file, dryRun, options, ignorePath)
+      if (issue) {
+        prettierIssues.push(issue)
       }
+    } catch (e) {
+      prettierIssues.push(`Can't format ${file}:\n ${e}`)
     }
   }
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/46361

The PR:
* fixes incorrect formatting of `*.ts` files by adding `filepath` to the format options. It turned out that passing just a parser isn't enough (fixes the linked issue).
* wraps prettier calls to try-catch. For malformed files they could return errors. 


<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
