### PR TITLE
fix(privacy): Fix alternative strategy for mutation observation not executing procedural filters on iOS

### DIFF
--- a/ios/brave-ios/Tests/ClientTests/Resources/html/index.html
+++ b/ios/brave-ios/Tests/ClientTests/Resources/html/index.html
@@ -127,9 +127,9 @@
       localFrame.contentDocument.body.appendChild(div);
     }
 
-    const addElementForProceduralFilter = () => {
+    const addElementForProceduralFilter = (id) => {
       const div = document.createElement('div');
-      div.id = "test-delayed-has-text";
+      div.id = id;
       div.innerText = 'Please hide me';
       document.body.appendChild(div);
     }
@@ -154,6 +154,18 @@
       childNode2.appendChild(span);
 
       root.appendChild(rootElement);
+    }
+    
+    // Create an element with inflated mutation score to at least `switchToSelectorsPollingThreshold`
+    // value to so mutationScore triggers alternative mutation strategy (polling) in `content_cosmetic_ios`
+    const triggerAltMutationObservationStrategy = () => {
+      const div = document.createElement('div')
+      for (let i = 0; i < 2000; i++) {
+        const span = document.createElement('span');
+        span.setAttribute('id', 'span-id-' + i);
+        div.appendChild(span)
+      }
+      document.body.appendChild(div);
     }
 
     const onload = () => {

--- a/ios/brave-ios/Tests/ClientTests/Resources/scripts/cosmetic-filter-tests.js
+++ b/ios/brave-ios/Tests/ClientTests/Resources/scripts/cosmetic-filter-tests.js
@@ -27,6 +27,7 @@
       'hasDisplayIsNone': results.hasDisplayIsNone,
       'delayedHasTextHidden': results.delayedHasTextHidden,
       'delayedChildHasTextHidden': results.delayedChildHasTextHidden,
+      'altMutationStrategyHidden': results.altMutationStrategyHidden
     })
   }
 
@@ -49,7 +50,8 @@
       hasTextDisplayIsNone: false,
       hasDisplayIsNone: false,
       delayedHasTextHidden: false,
-      delayedChildHasTextHidden: []
+      delayedChildHasTextHidden: [],
+      altMutationStrategyHidden: false
     }
 
     elements.forEach((node) => {
@@ -95,6 +97,11 @@
       if (node.id === 'test-delayed-has-text') {
         const nodeDisplay = window.getComputedStyle(node).display
         results.delayedHasTextHidden = nodeDisplay === 'none'
+      }
+
+      if (node.id === 'test-alt-mutation-observation-strategy') {
+        const nodeDisplay = window.getComputedStyle(node).display
+        results.altMutationStrategyHidden = nodeDisplay === 'none'
       }
 
       if (node.id === 'test-has') {


### PR DESCRIPTION
- Fixes alternative strategy for mutation observation not executing procedural actions on iOS

Resolves https://github.com/brave/brave-browser/issues/46358

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

### Testplan

1. Add `stephenheaps.github.io###view-in-app-banner-id:has-text(View in App)` to custom filter rules
2. Visit https://stephenheaps.github.io/procedural-filters/mutation-observation-alt-strategy.html
3. Verify `View in App` text is hidden