### PR TITLE
Activate clicked tab of split view with SideBySide feature

### DIFF
--- a/browser/ui/views/tabs/brave_browser_tab_strip_controller.cc
+++ b/browser/ui/views/tabs/brave_browser_tab_strip_controller.cc
@@ -43,3 +43,11 @@ void BraveBrowserTabStripController::ShowContextMenuForTab(
       std::make_unique<BraveTabContextMenuContents>(tab, this, *tab_index);
   context_menu_contents_->RunMenuAt(p, source_type);
 }
+
+int BraveBrowserTabStripController::GetIndexOfLastFocusedTabInSplit(
+    int model_index) {
+  // To use original |model_index| value always instead of updating it.
+  // We want to activate clicked tab. But upstream activates the most recently
+  // focused tab in the split when selecting a split tab.
+  return model_index;
+}

--- a/browser/ui/views/tabs/brave_browser_tab_strip_controller.h
+++ b/browser/ui/views/tabs/brave_browser_tab_strip_controller.h
@@ -31,6 +31,7 @@ class BraveBrowserTabStripController : public BrowserTabStripController {
   void ShowContextMenuForTab(Tab* tab,
                              const gfx::Point& p,
                              ui::mojom::MenuSourceType source_type) override;
+  int GetIndexOfLastFocusedTabInSplit(int model_index) override;
 
  private:
   // If non-NULL it means we're showing a menu for the tab.

--- a/chromium_src/chrome/browser/ui/views/tabs/browser_tab_strip_controller.h
+++ b/chromium_src/chrome/browser/ui/views/tabs/browser_tab_strip_controller.h
@@ -11,8 +11,11 @@
   friend class BraveBrowserTabStripController; \
   void CloseContextMenuForTesting
 
+#define GetIndexOfLastFocusedTabInSplit virtual GetIndexOfLastFocusedTabInSplit
+
 #include "src/chrome/browser/ui/views/tabs/browser_tab_strip_controller.h"  // IWYU pragma: export
 
+#undef GetIndexOfLastFocusedTabInSplit
 #undef CloseContextMenuForTesting
 
 #endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_TABS_BROWSER_TAB_STRIP_CONTROLLER_H_


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/46365

When any tab in split tab is clicked, activated tab is the last activated tab in split tab not a clicked tab.
But, we want to activate clicked tab.

TEST=SideBySideEnabledBrowserTest.SelectTabTest

1. Launch browser with `--enable-features=SideBySide`
2. Create several tabs and create split view from any tab's context menu
3. Activate first tab in split view and activate any non split tab
4. Activate second tab in split view and check second tab is activated

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
