### PR TITLE
Add conditional host check in binding handlers

### DIFF
--- a/browser/brave_content_browser_client.cc
+++ b/browser/brave_content_browser_client.cc
@@ -386,7 +386,7 @@ void BindBraveSearchFallbackHost(
 void BindBraveSearchDefaultHost(
     content::RenderFrameHost* const frame_host,
     mojo::PendingReceiver<brave_search::mojom::BraveSearchDefault> receiver) {
-  const GURL frame_host_url = frame_host->GetLastCommittedURL();
+  const GURL& frame_host_url = frame_host->GetLastCommittedURL();
   if (!brave_search::IsAllowedHost(frame_host_url)) {
     return;
   }
@@ -412,14 +412,15 @@ void BindBraveSearchDefaultHost(
 void BindIAPSubscription(
     content::RenderFrameHost* const frame_host,
     mojo::PendingReceiver<ai_chat::mojom::IAPSubscription> receiver) {
-  const GURL frame_host_url = frame_host->GetLastCommittedURL();
-  if (skus::IsSafeOrigin(frame_host_url)) {
-    auto* context = frame_host->GetBrowserContext();
-    auto* profile = Profile::FromBrowserContext(context);
-    mojo::MakeSelfOwnedReceiver(
-        std::make_unique<ai_chat::AIChatIAPSubscription>(profile->GetPrefs()),
-        std::move(receiver));
+  const GURL& frame_host_url = frame_host->GetLastCommittedURL();
+  if (!skus::IsSafeOrigin(frame_host_url)) {
+    return;
   }
+  auto* context = frame_host->GetBrowserContext();
+  auto* profile = Profile::FromBrowserContext(context);
+  mojo::MakeSelfOwnedReceiver(
+      std::make_unique<ai_chat::AIChatIAPSubscription>(profile->GetPrefs()),
+      std::move(receiver));
 }
 #endif
 
@@ -427,22 +428,24 @@ void BindIAPSubscription(
 void MaybeBindBraveVpnImpl(
     content::RenderFrameHost* const frame_host,
     mojo::PendingReceiver<brave_vpn::mojom::ServiceHandler> receiver) {
-  const GURL frame_host_url = frame_host->GetLastCommittedURL();
-  if (skus::IsSafeOrigin(frame_host_url)) {
-    auto* context = frame_host->GetBrowserContext();
-    brave_vpn::BraveVpnServiceFactory::BindForContext(context,
-                                                      std::move(receiver));
+  const GURL& frame_host_url = frame_host->GetLastCommittedURL();
+  if (!skus::IsSafeOrigin(frame_host_url)) {
+    return;
   }
+  auto* context = frame_host->GetBrowserContext();
+  brave_vpn::BraveVpnServiceFactory::BindForContext(context,
+                                                    std::move(receiver));
 }
 #endif
 void MaybeBindSkusSdkImpl(
     content::RenderFrameHost* const frame_host,
     mojo::PendingReceiver<skus::mojom::SkusService> receiver) {
-  const GURL frame_host_url = frame_host->GetLastCommittedURL();
-  if (skus::IsSafeOrigin(frame_host_url)) {
-    auto* context = frame_host->GetBrowserContext();
-    skus::SkusServiceFactory::BindForContext(context, std::move(receiver));
+  const GURL& frame_host_url = frame_host->GetLastCommittedURL();
+  if (!skus::IsSafeOrigin(frame_host_url)) {
+    return;
   }
+  auto* context = frame_host->GetBrowserContext();
+  skus::SkusServiceFactory::BindForContext(context, std::move(receiver));
 }
 
 }  // namespace

--- a/browser/brave_content_browser_client.cc
+++ b/browser/brave_content_browser_client.cc
@@ -386,6 +386,10 @@ void BindBraveSearchFallbackHost(
 void BindBraveSearchDefaultHost(
     content::RenderFrameHost* const frame_host,
     mojo::PendingReceiver<brave_search::mojom::BraveSearchDefault> receiver) {
+  const GURL frame_host_url = frame_host->GetLastCommittedURL();
+  if (!brave_search::IsAllowedHost(frame_host_url)) {
+    return;
+  }
   auto* context = frame_host->GetBrowserContext();
   auto* profile = Profile::FromBrowserContext(context);
   if (profile->IsRegularProfile()) {
@@ -420,16 +424,22 @@ void BindIAPSubscription(
 void MaybeBindBraveVpnImpl(
     content::RenderFrameHost* const frame_host,
     mojo::PendingReceiver<brave_vpn::mojom::ServiceHandler> receiver) {
-  auto* context = frame_host->GetBrowserContext();
-  brave_vpn::BraveVpnServiceFactory::BindForContext(context,
-                                                    std::move(receiver));
+  const GURL frame_host_url = frame_host->GetLastCommittedURL();
+  if (skus::IsSafeOrigin(frame_host_url)) {
+    auto* context = frame_host->GetBrowserContext();
+    brave_vpn::BraveVpnServiceFactory::BindForContext(context,
+                                                      std::move(receiver));
+  }
 }
 #endif
 void MaybeBindSkusSdkImpl(
     content::RenderFrameHost* const frame_host,
     mojo::PendingReceiver<skus::mojom::SkusService> receiver) {
-  auto* context = frame_host->GetBrowserContext();
-  skus::SkusServiceFactory::BindForContext(context, std::move(receiver));
+  const GURL frame_host_url = frame_host->GetLastCommittedURL();
+  if (skus::IsSafeOrigin(frame_host_url)) {
+    auto* context = frame_host->GetBrowserContext();
+    skus::SkusServiceFactory::BindForContext(context, std::move(receiver));
+  }
 }
 
 }  // namespace

--- a/browser/brave_content_browser_client.cc
+++ b/browser/brave_content_browser_client.cc
@@ -412,11 +412,14 @@ void BindBraveSearchDefaultHost(
 void BindIAPSubscription(
     content::RenderFrameHost* const frame_host,
     mojo::PendingReceiver<ai_chat::mojom::IAPSubscription> receiver) {
-  auto* context = frame_host->GetBrowserContext();
-  auto* profile = Profile::FromBrowserContext(context);
-  mojo::MakeSelfOwnedReceiver(
-      std::make_unique<ai_chat::AIChatIAPSubscription>(profile->GetPrefs()),
-      std::move(receiver));
+  const GURL frame_host_url = frame_host->GetLastCommittedURL();
+  if (skus::IsSafeOrigin(frame_host_url)) {
+    auto* context = frame_host->GetBrowserContext();
+    auto* profile = Profile::FromBrowserContext(context);
+    mojo::MakeSelfOwnedReceiver(
+        std::make_unique<ai_chat::AIChatIAPSubscription>(profile->GetPrefs()),
+        std::move(receiver));
+  }
 }
 #endif
 


### PR DESCRIPTION
## Description
Covers SKUs / VPN / Search

Does NOT cover:
- [`BindBraveSearchFallbackHost`](https://github.com/brave/brave-core/blob/df5bd689d4b9b9e32d50d6d118f6688f00fadd03/browser/brave_content_browser_client.cc#L368-L383) which has `content::RenderProcessHost*` - invoked from [`BraveContentBrowserClient::ExposeInterfacesToRenderer`](https://github.com/brave/brave-core/blob/df5bd689d4b9b9e32d50d6d118f6688f00fadd03/browser/brave_content_browser_client.cc#L759-L768)

Fixes https://github.com/brave/brave-browser/issues/46181
Fixes https://github.com/brave/brave-browser/issues/46394

## Test plan
See https://github.com/brave/brave-browser/issues/46181
