### PR TITLE
[iOS] Add safety check when fetching the current user agent type (uplift to 1.80.x)

### DIFF
--- a/ios/web_view/internal/cwv_web_view_extras.mm
+++ b/ios/web_view/internal/cwv_web_view_extras.mm
@@ -62,9 +62,12 @@ const CWVUserAgentType CWVUserAgentTypeDesktop =
 }
 
 - (CWVUserAgentType)currentItemUserAgentType {
-  return static_cast<CWVUserAgentType>(self.webState->GetNavigationManager()
-                                           ->GetVisibleItem()
-                                           ->GetUserAgentType());
+  web::NavigationItem* visibleItem =
+      self.webState->GetNavigationManager()->GetVisibleItem();
+  if (!visibleItem) {
+    return CWVUserAgentTypeNone;
+  }
+  return static_cast<CWVUserAgentType>(visibleItem->GetUserAgentType());
 }
 
 - (void)reloadWithUserAgentType:(CWVUserAgentType)userAgentType {


### PR DESCRIPTION
Uplift of #29276
Resolves https://github.com/brave/brave-browser/issues/46403

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.