### PR TITLE
Revert "[cr137] Disables Brave browser tests failing on Windows CI. (uplift to 1.80.x)

### DIFF
--- a/browser/extensions/brave_extension_provider_browsertest.cc
+++ b/browser/extensions/brave_extension_provider_browsertest.cc
@@ -18,16 +18,7 @@
 #include "content/public/test/browser_test.h"
 #include "content/public/test/browser_test_utils.h"
 
-// Since Chromium 137 all these tests fail ONLY on Windows CI (not locally).
-// TODO(https://github.com/brave/brave-browser/issues/45944)
-#if BUILDFLAG(IS_WIN)
-#define MAYBE_BraveExtensionProviderTest DISABLED_BraveExtensionProviderTest
-#else
-#define MAYBE_BraveExtensionProviderTest BraveExtensionProviderTest
-#endif  // BUILDFLAG(IS_WIN)
-
-class MAYBE_BraveExtensionProviderTest
-    : public extensions::ExtensionFunctionalTest {
+class BraveExtensionProviderTest : public extensions::ExtensionFunctionalTest {
  public:
   void SetUpOnMainThread() override {
     extensions::ExtensionFunctionalTest::SetUpOnMainThread();
@@ -38,7 +29,7 @@ namespace extensions {
 
 // Load an extension page with an ad image, and make sure it is NOT blocked.
 // It would otherwise be blocked though if it wasn't an extension.
-IN_PROC_BROWSER_TEST_F(MAYBE_BraveExtensionProviderTest,
+IN_PROC_BROWSER_TEST_F(BraveExtensionProviderTest,
                        AdsNotBlockedByDefaultBlockerInExtension) {
   base::FilePath test_data_dir;
   GetTestDataDir(&test_data_dir);
@@ -60,8 +51,7 @@ IN_PROC_BROWSER_TEST_F(MAYBE_BraveExtensionProviderTest,
   EXPECT_EQ(browser()->profile()->GetPrefs()->GetUint64(kAdsBlocked), 0ULL);
 }
 
-IN_PROC_BROWSER_TEST_F(MAYBE_BraveExtensionProviderTest,
-                       ExtensionsCanGetCookies) {
+IN_PROC_BROWSER_TEST_F(BraveExtensionProviderTest, ExtensionsCanGetCookies) {
   base::FilePath test_data_dir;
   GetTestDataDir(&test_data_dir);
   scoped_refptr<const extensions::Extension> extension =
@@ -80,8 +70,7 @@ IN_PROC_BROWSER_TEST_F(MAYBE_BraveExtensionProviderTest,
             content::EvalJs(contents, "canGetCookie('test', 'http://a.com')"));
 }
 
-IN_PROC_BROWSER_TEST_F(MAYBE_BraveExtensionProviderTest,
-                       ExtensionsCanSetCookies) {
+IN_PROC_BROWSER_TEST_F(BraveExtensionProviderTest, ExtensionsCanSetCookies) {
   base::FilePath test_data_dir;
   GetTestDataDir(&test_data_dir);
   scoped_refptr<const extensions::Extension> extension =

--- a/browser/extensions/extension_system_browsertest.cc
+++ b/browser/extensions/extension_system_browsertest.cc
@@ -81,17 +81,8 @@ IN_PROC_BROWSER_TEST_F(ExtensionSystemBrowserTest,
   NavigateAndExpectErrorPage(GURL("https://b.com/simple.html"), true);
 }
 
-// Since Chromium 137 this test fails ONLY on Windows CI (not locally).
-// TODO(https://github.com/brave/brave-browser/issues/45944)
-#if BUILDFLAG(IS_WIN)
-#define MAYBE_DeclarativeNetRequestWorksAfterRestart \
-  DISABLED_DeclarativeNetRequestWorksAfterRestart
-#else
-#define MAYBE_DeclarativeNetRequestWorksAfterRestart \
-  DeclarativeNetRequestWorksAfterRestart
-#endif  // BUILDFLAG(IS_WIN)
 IN_PROC_BROWSER_TEST_F(ExtensionSystemBrowserTest,
-                       MAYBE_DeclarativeNetRequestWorksAfterRestart) {
+                       DeclarativeNetRequestWorksAfterRestart) {
   // After a browser restart the extensions should work as expected.
   NavigateAndExpectErrorPage(GURL("https://a.com/simple.html"), false);
   NavigateAndExpectErrorPage(GURL("https://b.com/simple.html"), true);

--- a/browser/ui/webui/new_tab_page/brave_new_tab_ui_browsertest.cc
+++ b/browser/ui/webui/new_tab_page/brave_new_tab_ui_browsertest.cc
@@ -122,15 +122,7 @@ IN_PROC_BROWSER_TEST_F(BraveNewTabUIBrowserTest, BraveNewTabIsDefault) {
 
 // This test simply loads an extension that sets a newtab override.
 // It checks to make sure the newtab override is used as the newtab page.
-// Since Chromium 137 this test fails ONLY on Windows CI (not locally).
-// TODO(https://github.com/brave/brave-browser/issues/45944)
-#if BUILDFLAG(IS_WIN)
-#define MAYBE_NewTabPageLocationOverride DISABLED_NewTabPageLocationOverride
-#else
-#define MAYBE_NewTabPageLocationOverride NewTabPageLocationOverride
-#endif  // BUILDFLAG(IS_WIN)
-IN_PROC_BROWSER_TEST_F(BraveNewTabUIBrowserTest,
-                       MAYBE_NewTabPageLocationOverride) {
+IN_PROC_BROWSER_TEST_F(BraveNewTabUIBrowserTest, NewTabPageLocationOverride) {
   base::FilePath test_data_dir;
   GetTestDataDir(&test_data_dir);
   InstallExtensionSilently(extension_service(),


### PR DESCRIPTION
Uplift of #29283
Resolves https://github.com/brave/brave-browser/issues/45944

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.