### PR TITLE
[iOS] Replace animation APIs used to present NTP (uplift to 1.80.x)

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -1537,21 +1537,22 @@ public class BrowserViewController: UIViewController {
         $0.edges.equalTo(pageOverlayLayoutGuide)
       }
       ntpController.view.layoutIfNeeded()
+      ntpController.view.alpha = 0
 
       // We have to run this animation, even if the view is already showing because there may be a hide animation running
       // and we want to be sure to override its results.
-      UIView.animate(
-        withDuration: 0.2,
+      let animator = UIViewPropertyAnimator(
+        duration: 0.2,
+        curve: .easeInOut,
         animations: {
           ntpController.view.alpha = 1
-        },
-        completion: { finished in
-          if finished {
-            self.webViewContainer.accessibilityElementsHidden = true
-            UIAccessibility.post(notification: .screenChanged, argument: nil)
-          }
         }
       )
+      animator.addCompletion { _ in
+        self.webViewContainer.accessibilityElementsHidden = true
+        UIAccessibility.post(notification: .screenChanged, argument: nil)
+      }
+      animator.startAnimation()
     }
   }
 
@@ -1560,33 +1561,36 @@ public class BrowserViewController: UIViewController {
   fileprivate func hideActiveNewTabPageController(_ isReaderModeURL: Bool = false) {
     guard let controller = activeNewTabPageViewController else { return }
 
-    UIView.animate(
-      withDuration: 0.2,
+    let animator = UIViewPropertyAnimator(
+      duration: 0.2,
+      curve: .easeInOut,
       animations: {
         controller.view.alpha = 0.0
-      },
-      completion: { finished in
-        controller.willMove(toParent: nil)
-        controller.view.removeFromSuperview()
-        controller.removeFromParent()
-        self.webViewContainer.accessibilityElementsHidden = false
-        UIAccessibility.post(notification: .screenChanged, argument: nil)
-
-        // Refresh the reading view toolbar since the article record may have changed
-        if let tab = self.tabManager.selectedTab,
-          let readerMode = tab.browserData?.getContentScript(
-            name: ReaderModeScriptHandler.scriptName
-          )
-            as? ReaderModeScriptHandler,
-          readerMode.state == .active,
-          isReaderModeURL,
-          let state = tab.playlistItemState
-        {
-          self.showReaderModeBar(animated: false)
-          self.updatePlaylistURLBar(tab: tab, state: state, item: tab.playlistItem)
-        }
       }
     )
+    animator.addCompletion { _ in
+      controller.willMove(toParent: nil)
+      controller.view.removeFromSuperview()
+      controller.removeFromParent()
+      controller.view.alpha = 1
+      self.webViewContainer.accessibilityElementsHidden = false
+      UIAccessibility.post(notification: .screenChanged, argument: nil)
+
+      // Refresh the reading view toolbar since the article record may have changed
+      if let tab = self.tabManager.selectedTab,
+        let readerMode = tab.browserData?.getContentScript(
+          name: ReaderModeScriptHandler.scriptName
+        )
+          as? ReaderModeScriptHandler,
+        readerMode.state == .active,
+        isReaderModeURL,
+        let state = tab.playlistItemState
+      {
+        self.showReaderModeBar(animated: false)
+        self.updatePlaylistURLBar(tab: tab, state: state, item: tab.playlistItem)
+      }
+    }
+    animator.startAnimation()
   }
 
   func updateInContentHomePanel(_ url: URL?) {


### PR DESCRIPTION
Uplift of #29265
Resolves https://github.com/brave/brave-browser/issues/46379

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.