### PR TITLE
[Android] Prevent cleaning of tab groups without sync id (uplift to 1.80.x)

### DIFF
--- a/android/java/apk_for_test.flags
+++ b/android/java/apk_for_test.flags
@@ -977,3 +977,11 @@
 }
 
 -keep class org.chromium.chrome.browser.homepage.settings.BraveRadioButtonGroupHomepagePreference
+
+-keep class org.chromium.chrome.browser.tab_group_sync.StartupHelper {
+    *** handleUnsavedLocalTabGroups(...);
+}
+
+-keep class org.chromium.chrome.browser.tab_group_sync.BraveStartupHelper {
+    *** handleUnsavedLocalTabGroups(...);
+}

--- a/android/java/proguard.flags
+++ b/android/java/proguard.flags
@@ -101,4 +101,3 @@
 -keep class org.chromium.chrome.browser.media.FullscreenVideoPictureInPictureController {
     *** dismissActivityIfNeeded(...);
 }
-

--- a/android/javatests/org/chromium/chrome/browser/BytecodeTest.java
+++ b/android/javatests/org/chromium/chrome/browser/BytecodeTest.java
@@ -413,6 +413,7 @@ public class BytecodeTest {
         Assert.assertTrue(
                 classExists(
                         "org/chromium/chrome/browser/quickactionsearchwidget/BraveQuickActionSearchWidgetProvider")); // presubmit: ignore-long-line
+        Assert.assertTrue(classExists("org/chromium/chrome/browser/tab_group_sync/StartupHelper"));
     }
 
     @Test
@@ -959,6 +960,12 @@ public class BytecodeTest {
                         "getChromeNtpRadioButton",
                         MethodModifier.REGULAR,
                         RadioButtonWithDescription.class));
+        Assert.assertTrue(
+                methodExists(
+                        "org/chromium/chrome/browser/tab_group_sync/StartupHelper",
+                        "handleUnsavedLocalTabGroups",
+                        MethodModifier.REGULAR,
+                        void.class));
     }
 
     @Test
@@ -2485,6 +2492,10 @@ public class BytecodeTest {
                 checkSuperName(
                         "org/chromium/chrome/browser/homepage/settings/BraveRadioButtonGroupHomepagePreference", // presubmit: ignore-long-line
                         "org/chromium/chrome/browser/homepage/settings/RadioButtonGroupHomepagePreference")); // presubmit: ignore-long-line
+        Assert.assertTrue(
+                checkSuperName(
+                        "org/chromium/chrome/browser/tab_group_sync/StartupHelper",
+                        "org/chromium/chrome/browser/tab_group_sync/BraveStartupHelper"));
     }
 
     @Test

--- a/browser/tab_group_sync/BUILD.gn
+++ b/browser/tab_group_sync/BUILD.gn
@@ -1,0 +1,12 @@
+# Copyright (c) 2025 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import("//build/config/android/rules.gni")
+
+android_library("java") {
+  sources = [ "android/java/src/org/chromium/chrome/browser/tab_group_sync/BraveStartupHelper.java" ]
+
+  deps = [ "//chrome/browser/tab_group_sync:java" ]
+}

--- a/browser/tab_group_sync/android/java/src/org/chromium/chrome/browser/tab_group_sync/BraveStartupHelper.java
+++ b/browser/tab_group_sync/android/java/src/org/chromium/chrome/browser/tab_group_sync/BraveStartupHelper.java
@@ -1,0 +1,17 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.chromium.chrome.browser.tab_group_sync;
+
+import org.chromium.build.annotations.NullMarked;
+
+@NullMarked
+public class BraveStartupHelper {
+
+    // Replace StartupHelper.handleUnsavedLocalTabGroups with empty implementation.
+    // The reason for this - otherwise groups created with `Open tabs in current group` option
+    // are wiped after app restart.
+    public void handleUnsavedLocalTabGroups() {}
+}

--- a/build/android/bytecode/BUILD.gn
+++ b/build/android/bytecode/BUILD.gn
@@ -110,6 +110,7 @@ java_binary("java_bytecode_rewriter") {
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveSiteSettingsCategoryClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveSiteSettingsDelegateClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveSiteSettingsPreferencesBaseClassAdapter.java",
+    "//brave/build/android/bytecode/java/org/brave/bytecode/BraveStartupHelperClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveStatusBarColorControllerClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveStatusMediatorClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveStrictPreferenceKeyCheckerClassAdapter.java",

--- a/build/android/bytecode/bytecode_rewriter.gni
+++ b/build/android/bytecode/bytecode_rewriter.gni
@@ -40,6 +40,7 @@ brave_bytecode_jars = [
   "obj/chrome/browser/site_settings/android/java.javac.jar",
   "obj/chrome/browser/tabmodel/java.javac.jar",
   "obj/chrome/browser/customtabs/java.javac.jar",
+  "obj/chrome/browser/tab_group_sync/java.javac.jar",
   "obj/chrome/browser/tab_ui/android/java.javac.jar",
   "obj/chrome/browser/ui/android/appmenu/internal/java.javac.jar",
   "obj/chrome/browser/ui/android/logo/java.javac.jar",

--- a/build/android/bytecode/java/org/brave/bytecode/BraveClassAdapter.java
+++ b/build/android/bytecode/java/org/brave/bytecode/BraveClassAdapter.java
@@ -105,6 +105,7 @@ public class BraveClassAdapter {
         chain = new BraveSiteSettingsCategoryClassAdapter(chain);
         chain = new BraveSiteSettingsDelegateClassAdapter(chain);
         chain = new BraveSiteSettingsPreferencesBaseClassAdapter(chain);
+        chain = new BraveStartupHelperClassAdapter(chain);
         chain = new BraveStatusBarColorControllerClassAdapter(chain);
         chain = new BraveStatusMediatorClassAdapter(chain);
         chain = new BraveStrictPreferenceKeyCheckerClassAdapter(chain);

--- a/build/android/bytecode/java/org/brave/bytecode/BraveStartupHelperClassAdapter.java
+++ b/build/android/bytecode/java/org/brave/bytecode/BraveStartupHelperClassAdapter.java
@@ -1,0 +1,25 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.brave.bytecode;
+
+import org.objectweb.asm.ClassVisitor;
+
+public class BraveStartupHelperClassAdapter extends BraveClassVisitor {
+    static String sStartupHelperClassName =
+            "org/chromium/chrome/browser/tab_group_sync/StartupHelper";
+    static String sBraveStartupHelperClassName =
+            "org/chromium/chrome/browser/tab_group_sync/BraveStartupHelper";
+
+    public BraveStartupHelperClassAdapter(ClassVisitor visitor) {
+        super(visitor);
+
+        changeSuperName(sStartupHelperClassName, sBraveStartupHelperClassName);
+        changeMethodOwner(
+                sStartupHelperClassName,
+                "handleUnsavedLocalTabGroups",
+                sBraveStartupHelperClassName);
+    }
+}

--- a/build/android/config.gni
+++ b/build/android/config.gni
@@ -27,6 +27,7 @@ brave_chrome_java_deps = [
   "//brave/browser/notifications/android:java",
   "//brave/browser/quick_search_engines/android:java",
   "//brave/browser/safe_browsing/android/java/src/org/chromium/chrome/browser/safe_browsing/settings:java",
+  "//brave/browser/tab_group_sync:java",
   "//brave/browser/tabmodel/android:java",
   "//brave/browser/ui/android/logo:java",
   "//brave/browser/ui/android/omnibox:java",


### PR DESCRIPTION
Uplift of #29201
Resolves https://github.com/brave/brave-browser/issues/45549

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.