### PR TITLE
[iOS] Add standalone Synced Tabs UI

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ToolbarDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ToolbarDelegate.swift
@@ -28,7 +28,7 @@ import os.log
 
 extension BrowserViewController: TopToolbarDelegate {
 
-  func showTabTray(isExternallyPresented: Bool = false) {
+  func showTabTray() {
     if tabManager.tabsForCurrentMode.isEmpty {
       return
     }
@@ -44,7 +44,6 @@ extension BrowserViewController: TopToolbarDelegate {
     isTabTrayActive = true
 
     let tabTrayController = TabTrayController(
-      isExternallyPresented: isExternallyPresented,
       tabManager: tabManager,
       braveCore: profileController,
       windowProtection: windowProtection
@@ -56,12 +55,10 @@ extension BrowserViewController: TopToolbarDelegate {
     container.delegate = self
 
     if !UIAccessibility.isReduceMotionEnabled {
-      if !isExternallyPresented {
-        container.transitioningDelegate = tabTrayController
-      }
+      container.transitioningDelegate = tabTrayController
       container.modalPresentationStyle = .fullScreen
     }
-    present(container, animated: !isExternallyPresented)
+    present(container, animated: true)
   }
 
   func topToolbarDidPressReload(_ topToolbar: TopToolbarView) {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/BrowserNavigationHelper.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/BrowserNavigationHelper.swift
@@ -6,6 +6,7 @@
 import BraveShared
 import BraveVPN
 import Foundation
+import Preferences
 import Shared
 import SwiftUI
 import UIKit
@@ -58,6 +59,35 @@ class BrowserNavigationHelper {
     vc.toolbarUrlActionsDelegate = bvc
 
     open(vc, doneButton: DoneButton(style: .done, position: .right))
+  }
+
+  func openSyncedTabsList() {
+    guard let bvc = bvc else { return }
+    let controller = UIHostingController(
+      rootView: SyncedTabsView(
+        openTabs: bvc.profileController.openTabsAPI,
+        urlActionHandler: bvc,
+        openSyncSettings: { [unowned bvc] in
+          let controller: UIViewController
+          if Preferences.Chromium.syncEnabled.value {
+            controller = SyncSettingsTableViewController(
+              isModallyPresented: true,
+              braveCoreMain: bvc.profileController,
+              windowProtection: bvc.windowProtection
+            )
+          } else {
+            controller = SyncWelcomeViewController(
+              braveCore: bvc.profileController,
+              windowProtection: bvc.windowProtection,
+              isModallyPresented: true
+            )
+          }
+          let container = UINavigationController(rootViewController: controller)
+          bvc.presentedViewController?.present(container, animated: true)
+        }
+      )
+    )
+    bvc.present(controller, animated: true)
   }
 
   func openDownloads(_ completion: @escaping (Bool) -> Void) {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/TabManager.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/TabManager.swift
@@ -132,8 +132,8 @@ class TabManager: NSObject {
     self.privateBrowsingManager = privateBrowsingManager
     super.init()
 
-    Preferences.Shields.blockImages.observe(from: self)
     Preferences.General.nightModeEnabled.observe(from: self)
+    Preferences.Chromium.syncOpenTabsEnabled.observe(from: self)
 
     domainFrc.delegate = self
     do {
@@ -1531,6 +1531,10 @@ extension TabManager: PreferencesObserver {
         tabManager: self,
         enabled: Preferences.General.nightModeEnabled.value
       )
+    case Preferences.Chromium.syncOpenTabsEnabled.key:
+      if Preferences.Chromium.syncOpenTabsEnabled.value {
+        addRegularTabsToSyncChain()
+      }
     default:
       break
     }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Tabs/Synced/SyncedTabsView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Tabs/Synced/SyncedTabsView.swift
@@ -1,0 +1,470 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import BraveCore
+import BraveShared
+import BraveStrings
+import BraveUI
+import DesignSystem
+import Favicon
+import Preferences
+import Shared
+import Strings
+import SwiftUI
+
+protocol OpenTabsModel {
+  func getSyncedSessions() -> [OpenDistantSession]
+  func add(_ observer: any OpenTabsSessionStateObserver) -> OpenTabsSessionStateListener
+}
+
+extension BraveOpenTabsAPI: OpenTabsModel {}
+
+/// Wraps a BraveOpenTabsAPI instance in an observable model
+@Observable
+@MainActor private class SyncedOpenTabsModel {
+  private let openTabs: any OpenTabsModel
+  @ObservationIgnored
+  private var listener: OpenTabsSessionStateListener?
+
+  private(set) var sessions: [OpenDistantSession] = []
+
+  init(openTabs: any OpenTabsModel) {
+    self.openTabs = openTabs
+    self.listener = openTabs.add(
+      OpenTabsStateObserver { [weak self] state in
+        self?.update()
+      }
+    )
+    update()
+  }
+
+  private func update() {
+    sessions = openTabs.getSyncedSessions()
+  }
+}
+
+struct SyncedTabsView: View {
+  var urlActionHandler: ToolbarUrlActionsDelegate?
+  var openSyncSettings: () -> Void
+
+  private var model: SyncedOpenTabsModel
+  @State private var searchQuery: String = ""
+  @ObservedObject private var syncOpenTabsEnabled = Preferences.Chromium.syncOpenTabsEnabled
+  @ObservedObject private var syncEnabled = Preferences.Chromium.syncEnabled
+  @Environment(\.dismiss) private var dismiss
+
+  init(
+    openTabs: OpenTabsModel,
+    urlActionHandler: ToolbarUrlActionsDelegate? = nil,
+    openSyncSettings: @escaping () -> Void = {}
+  ) {
+    self.model = .init(openTabs: openTabs)
+    self.urlActionHandler = urlActionHandler
+    self.openSyncSettings = openSyncSettings
+  }
+
+  private var filteredSessions: [OpenDistantSession] {
+    if searchQuery.isEmpty {
+      return model.sessions
+    } else {
+      return model.sessions.compactMap { session in
+        let matchingTabs = session.tabs.filter { tab in
+          tab.url.absoluteString.localizedCaseInsensitiveContains(searchQuery)
+            || tab.title?.localizedCaseInsensitiveContains(searchQuery) == true
+        }
+        if matchingTabs.isEmpty {
+          return nil
+        }
+        let session = session.copy() as! OpenDistantSession
+        session.tabs = matchingTabs
+        return session
+      }
+    }
+  }
+
+  var body: some View {
+    NavigationStack {
+      let sessions = filteredSessions
+      List {
+        ForEach(sessions, id: \.sessionTag) { session in
+          Section {
+            SessionDisclosureGroup(session: session) { tab in
+              Button {
+                urlActionHandler?.openInNewTab(tab.url, isPrivate: false)
+                dismiss()
+              } label: {
+                SessionTab(tab: tab)
+                  .padding(.horizontal, 16)
+                  .padding(.vertical, 12)
+              }
+              .contextMenu {
+                Section {
+                  Button {
+                    urlActionHandler?.openInNewTab(tab.url, isPrivate: false)
+                    dismiss()
+                  } label: {
+                    Label(Strings.openNewTabButtonTitle, systemImage: "plus.square.on.square")
+                  }
+                }
+                Section {
+                  Button {
+                    urlActionHandler?.copy(tab.url)
+                  } label: {
+                    Label(Strings.copyLinkActionTitle, braveSystemImage: "leo.copy")
+                  }
+                  Button {
+                    urlActionHandler?.share(tab.url)
+                  } label: {
+                    Label(Strings.shareLinkActionTitle, braveSystemImage: "leo.share.macos")
+                  }
+                }
+              }
+            }
+          } header: {
+            if session.sessionTag == sessions.first?.sessionTag {
+              // This is unfortunately needed to ensure there's proper padding at the top of the list
+              // most likely due to using UIAppearance defaults across the app to manage the navigation
+              // bar appearance
+              Color.clear
+            }
+          }
+        }
+        if !sessions.isEmpty {
+          Section {
+            Button {
+
+            } label: {
+              Text("Add New Device")
+            }
+          }
+        }
+      }
+      .scrollContentBackground(.hidden)
+      .background(Color(uiColor: .braveGroupedBackground))
+      .overlay {
+        Group {
+          if !syncEnabled.value {
+            SyncDisabledView(action: openSyncSettings)
+          } else if !syncOpenTabsEnabled.value {
+            OpenTabSyncDisabled(action: openSyncSettings)
+          } else if !searchQuery.isEmpty && sessions.isEmpty {
+            Text(Strings.noSearchResultsfound)
+          } else if sessions.isEmpty {
+            NoSessionTabsView()
+          }
+        }
+        .transition(.opacity.animation(.default))
+      }
+      .navigationTitle(Strings.OpenTabs.openTabsOnOtherDevices)
+      .navigationBarTitleDisplayMode(.inline)
+      .searchable(text: $searchQuery, prompt: Strings.OpenTabs.tabTrayOpenTabSearchBarTitle)
+      .animation(.default, value: sessions)
+      .toolbar {
+        ToolbarItemGroup(placement: .topBarLeading) {
+          Button {
+            dismiss()
+          } label: {
+            Label(Strings.close, braveSystemImage: "leo.close")
+          }
+        }
+        ToolbarItemGroup(placement: .topBarTrailing) {
+          Button {
+            openSyncSettings()
+          } label: {
+            Label(Strings.Sync.settingsTitle, braveSystemImage: "leo.settings")
+          }
+        }
+      }
+    }
+  }
+}
+
+private struct SessionDisclosureGroup<Content: View>: View {
+  var session: OpenDistantSession
+  @ViewBuilder var content: (OpenDistantTab) -> Content
+
+  @State private var isCollapsed: Bool = false
+
+  var body: some View {
+    Group {
+      Button {
+        withAnimation {
+          isCollapsed.toggle()
+        }
+      } label: {
+        Label {
+          HStack {
+            VStack(alignment: .leading) {
+              if let name = session.name {
+                Text(name)
+                  .font(.callout.weight(.semibold))
+                  .foregroundStyle(Color(braveSystemName: .textPrimary))
+              }
+              if let modifiedTime = session.modifiedTime {
+                Text(modifiedTime, format: .relative(presentation: .named, unitsStyle: .wide))
+                  .font(.footnote)
+                  .foregroundStyle(Color(braveSystemName: .textTertiary))
+              }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            Spacer()
+            Image(braveSystemName: "leo.carat.up")
+              .rotationEffect(.degrees(isCollapsed ? 180 : 0))
+              .foregroundStyle(Color(braveSystemName: .iconDefault))
+          }
+        } icon: {
+          Image(braveSystemName: session.deviceFormFactor.braveSystemImageName)
+            .font(.subheadline)
+            .foregroundStyle(Color(braveSystemName: .iconDefault))
+            .padding(6)
+            .background(
+              Color(braveSystemName: .containerDisabled),
+              in: .rect(cornerRadius: 8, style: .continuous)
+            )
+        }
+        .padding()
+      }
+      .alignmentGuide(HorizontalAlignment.listRowSeparatorLeading) { dimension in
+        dimension[.leading]
+      }
+      .listRowInsets(.zero)
+      .listRowBackground(Color(uiColor: .secondaryBraveGroupedBackground))
+      if !isCollapsed {
+        ForEach(session.tabs, id: \.tabId) { tab in
+          content(tab)
+            .listRowBackground(Color(uiColor: .secondaryBraveGroupedBackground))
+            .listRowInsets(.zero)
+        }
+      }
+    }
+  }
+}
+
+private struct SessionTab: View {
+  var tab: OpenDistantTab
+
+  var body: some View {
+    Label {
+      VStack {
+        if let title = tab.title, !title.isEmpty {
+          Text(title)
+            .lineLimit(1)
+            .truncationMode(.tail)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .fixedSize(horizontal: false, vertical: true)
+            .foregroundStyle(Color(braveSystemName: .textPrimary))
+        }
+
+        URLElidedText(
+          text: URLFormatter.formatURLOrigin(
+            forDisplayOmitSchemePathAndTrivialSubdomains: tab.url.strippingBlobURLAuth
+              .absoluteString
+          )
+        )
+        .font(.footnote)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .fixedSize(horizontal: false, vertical: true)
+        .foregroundStyle(Color(braveSystemName: .textTertiary))
+      }
+    } icon: {
+      FaviconImage(url: tab.url, isPrivateBrowsing: false)
+        .frame(width: 20, height: 20)
+        .padding(6)
+        .overlay(
+          ContainerRelativeShape()
+            .strokeBorder(Color(braveSystemName: .dividerSubtle), lineWidth: 1.0)
+        )
+        .containerShape(RoundedRectangle(cornerRadius: 8.0, style: .continuous))
+    }
+  }
+}
+
+private struct NoSessionTabsView: View {
+  var body: some View {
+    ContentUnavailableView {
+      Label {
+        Text(Strings.OpenTabs.openTabsNoSyncedTabsTitle)
+          .foregroundStyle(Color(braveSystemName: .textSecondary))
+          .font(.title3)
+      } icon: {
+        Image(braveSystemName: "leo.product.sync")
+          .foregroundStyle(Color(braveSystemName: .iconSecondary))
+      }
+    } description: {
+      Text(Strings.OpenTabs.openTabsYourTabsAppearHere)
+        .foregroundStyle(Color(braveSystemName: .textTertiary))
+        .font(.callout)
+    }
+  }
+}
+
+private struct SyncDisabledView: View {
+  var action: () -> Void
+
+  var body: some View {
+    ContentUnavailableView {
+      Label {
+        Text(Strings.OpenTabs.noSyncSessionPlaceHolderViewTitle)
+          .foregroundStyle(Color(braveSystemName: .textSecondary))
+          .font(.title3)
+      } icon: {
+        Image(braveSystemName: "leo.product.sync")
+          .foregroundStyle(Color(braveSystemName: .iconSecondary))
+      }
+    } description: {
+      Text(Strings.OpenTabs.noSyncChainPlaceHolderViewDescription)
+        .foregroundStyle(Color(braveSystemName: .textTertiary))
+        .font(.callout)
+    } actions: {
+      Button {
+        action()
+      } label: {
+        Text(Strings.OpenTabs.syncChainStartButtonTitle)
+      }
+      .buttonStyle(BraveFilledButtonStyle(size: .normal))
+    }
+  }
+}
+
+private struct OpenTabSyncDisabled: View {
+  var action: () -> Void
+
+  var body: some View {
+    ContentUnavailableView {
+      Label {
+        Text(Strings.OpenTabs.noSyncSessionPlaceHolderViewTitle)
+          .foregroundStyle(Color(braveSystemName: .textSecondary))
+          .font(.title3)
+      } icon: {
+        Image(braveSystemName: "leo.product.sync")
+          .foregroundStyle(Color(braveSystemName: .iconSecondary))
+      }
+    } description: {
+      Text(Strings.OpenTabs.enableOpenTabsPlaceHolderViewDescription)
+        .foregroundStyle(Color(braveSystemName: .textTertiary))
+        .font(.callout)
+    } actions: {
+      VStack(spacing: 24) {
+        Button {
+          action()
+        } label: {
+          Text(Strings.OpenTabs.tabSyncEnableButtonTitle)
+        }
+        .buttonStyle(BraveFilledButtonStyle(size: .normal))
+        Text(Strings.OpenTabs.noSyncSessionPlaceHolderViewAdditionalDescription)
+          .foregroundStyle(Color(braveSystemName: .textTertiary))
+          .font(.footnote)
+      }
+    }
+  }
+}
+
+extension SyncDeviceFormFactor {
+  fileprivate var braveSystemImageName: String {
+    switch self {
+    case .phone, .tablet:
+      return "leo.smartphone.tablet-portrait"
+    case .desktop:
+      return "leo.laptop"
+    default:
+      return "leo.smartphone.laptop"
+    }
+  }
+}
+
+#if DEBUG
+
+private struct MockOpenTabsModel: OpenTabsModel {
+  var sessions: [OpenDistantSession] = []
+  func getSyncedSessions() -> [OpenDistantSession] {
+    return sessions
+  }
+  func add(_ observer: any OpenTabsSessionStateObserver) -> OpenTabsSessionStateListener {
+    class MockListener: NSObject, OpenTabsSessionStateListener {
+      func destroy() {}
+    }
+    return MockListener()
+  }
+}
+
+extension OpenDistantSession {
+  fileprivate convenience init(
+    name: String,
+    dateCreated: Date = .now,
+    deviceFormFactor: SyncDeviceFormFactor,
+    tabs: [OpenDistantTab]
+  ) {
+    self.init(
+      name: name,
+      sessionTag: UUID().uuidString,
+      dateCreated: dateCreated,
+      deviceFormFactor: deviceFormFactor
+    )
+    self.tabs = tabs
+  }
+}
+
+#Preview("Sync Disabled") {
+  SyncedTabsView(openTabs: MockOpenTabsModel())
+    .onAppear {
+      Preferences.Chromium.syncEnabled.value = false
+      Preferences.Chromium.syncOpenTabsEnabled.value = false
+    }
+}
+
+#Preview("Open Tabs Sync Disabled") {
+  SyncedTabsView(openTabs: MockOpenTabsModel())
+    .onAppear {
+      Preferences.Chromium.syncEnabled.value = true
+      Preferences.Chromium.syncOpenTabsEnabled.value = false
+    }
+}
+
+#Preview("No Synced Sessions") {
+  SyncedTabsView(openTabs: MockOpenTabsModel())
+    .onAppear {
+      Preferences.Chromium.syncEnabled.value = true
+      Preferences.Chromium.syncOpenTabsEnabled.value = true
+    }
+}
+
+#Preview("Synced Sessions") {
+  SyncedTabsView(
+    openTabs: MockOpenTabsModel(
+      sessions: [
+        .init(
+          name: "iPhone",
+          deviceFormFactor: .phone,
+          tabs: [
+            .init(
+              url: URL(string: "https://brave.com")!,
+              title: "Brave",
+              tabId: 1,
+              sessionTag: "brave"
+            )
+          ]
+        ),
+        .init(
+          name: "Mac",
+          deviceFormFactor: .desktop,
+          tabs: [
+            .init(
+              url: URL(string: "https://brave.com")!,
+              title: "Brave",
+              tabId: 1,
+              sessionTag: "brave2"
+            )
+          ]
+        ),
+      ]
+    )
+  )
+  .onAppear {
+    Preferences.Chromium.syncEnabled.value = true
+    Preferences.Chromium.syncOpenTabsEnabled.value = true
+  }
+}
+
+#endif

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Tabs/TabTray/TabTrayController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Tabs/TabTray/TabTrayController.swift
@@ -110,8 +110,7 @@ class TabTrayController: AuthenticationController {
   var isTabTrayBeingSearched = false
   var tabTraySearchQuery: String?
   var tabTrayMode: TabTrayMode = .local
-  // The tab tray is presented by an action outside the application like shortcuts
-  private var isExternallyPresented: Bool
+
   private var privateModeCancellable: AnyCancellable?
   private var initialScrollCompleted = false
   private var localAuthObservers = Set<AnyCancellable>()
@@ -216,12 +215,10 @@ class TabTrayController: AuthenticationController {
   // MARK: Lifecycle
 
   init(
-    isExternallyPresented: Bool = false,
     tabManager: TabManager,
     braveCore: BraveProfileController,
     windowProtection: WindowProtection?
   ) {
-    self.isExternallyPresented = isExternallyPresented
     self.tabManager = tabManager
     self.braveCore = braveCore
 
@@ -386,16 +383,6 @@ class TabTrayController: AuthenticationController {
         name: UIScene.didActivateNotification,
         object: nil
       )
-    }
-  }
-
-  override func viewDidAppear(_ animated: Bool) {
-    super.viewDidAppear(animated)
-
-    // Navigate tabs from other devices
-    if isExternallyPresented {
-      tabTypeSelector.selectedSegmentIndex = 1
-      tabTypeSelector.sendActions(for: UIControl.Event.valueChanged)
     }
   }
 
@@ -925,7 +912,6 @@ class TabTrayController: AuthenticationController {
       openInsideSettingsNavigation(
         with: SyncWelcomeViewController(
           braveCore: braveCore,
-          tabManager: tabManager,
           windowProtection: windowProtection,
           isModallyPresented: true
         )
@@ -939,7 +925,6 @@ class TabTrayController: AuthenticationController {
       let syncSettingsScreen = SyncSettingsTableViewController(
         isModallyPresented: true,
         braveCoreMain: braveCore,
-        tabManager: tabManager,
         windowProtection: windowProtection
       )
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/SettingsViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/SettingsViewController.swift
@@ -480,7 +480,6 @@ class SettingsViewController: TableViewController {
 
               let syncSettingsViewController = SyncSettingsTableViewController(
                 braveCoreMain: braveCore,
-                tabManager: tabManager,
                 windowProtection: windowProtection
               )
 
@@ -489,7 +488,6 @@ class SettingsViewController: TableViewController {
             } else {
               let syncWelcomeViewController = SyncWelcomeViewController(
                 braveCore: braveCore,
-                tabManager: tabManager,
                 windowProtection: windowProtection
               )
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Sync/SyncSettingsTableViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Sync/SyncSettingsTableViewController.swift
@@ -59,7 +59,6 @@ class SyncSettingsTableViewController: SyncViewController, UITableViewDelegate,
   private let braveCoreMain: BraveProfileController
   private let syncAPI: BraveSyncAPI
   private let syncProfileService: BraveSyncProfileServiceIOS
-  private let tabManager: TabManager
 
   private var syncDeviceObserver: AnyObject?
   private var syncServiceObserver: AnyObject?
@@ -91,14 +90,12 @@ class SyncSettingsTableViewController: SyncViewController, UITableViewDelegate,
   init(
     isModallyPresented: Bool = false,
     braveCoreMain: BraveProfileController,
-    tabManager: TabManager,
     windowProtection: WindowProtection?
   ) {
     self.isModallyPresented = isModallyPresented
     self.braveCoreMain = braveCoreMain
     self.syncAPI = braveCoreMain.syncAPI
     self.syncProfileService = braveCoreMain.syncProfileService
-    self.tabManager = tabManager
 
     // Local Authentication (Biometric - Pincode) needed only for actions
     // Enabling - disabling password sync and add new device
@@ -154,7 +151,7 @@ class SyncSettingsTableViewController: SyncViewController, UITableViewDelegate,
     }
 
     navigationItem.rightBarButtonItem = UIBarButtonItem(
-      image: UIImage(systemName: "gearshape"),
+      image: UIImage(braveSystemNamed: "leo.settings"),
       style: .plain,
       target: self,
       action: #selector(onSyncInternalsTapped)
@@ -319,11 +316,6 @@ class SyncSettingsTableViewController: SyncViewController, UITableViewDelegate,
         Preferences.Chromium.syncPasswordsEnabled.value = !toggleExistingStatus
       case .openTabs:
         Preferences.Chromium.syncOpenTabsEnabled.value = !toggleExistingStatus
-
-        // Sync Regular Tabs when open tabs are enabled
-        if Preferences.Chromium.syncOpenTabsEnabled.value {
-          tabManager.addRegularTabsToSyncChain()
-        }
       }
 
       syncAPI.enableSyncTypes(syncProfileService: syncProfileService)

--- a/ios/brave-ios/Sources/Brave/Frontend/Sync/SyncWelcomeViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Sync/SyncWelcomeViewController.swift
@@ -6,6 +6,7 @@ import BraveCore
 import BraveShared
 import BraveUI
 import Data
+import DesignSystem
 import Preferences
 import Shared
 import UIKit
@@ -79,7 +80,6 @@ class SyncWelcomeViewController: SyncViewController {
 
   private var syncServiceObserver: AnyObject?
   private var syncDeviceInfoObserver: AnyObject?
-  private let tabManager: TabManager
 
   lazy var mainStackView: UIStackView = {
     let stackView = UIStackView()
@@ -167,17 +167,17 @@ class SyncWelcomeViewController: SyncViewController {
   private let braveCore: BraveProfileController
   private let syncAPI: BraveSyncAPI
   private let syncProfileServices: BraveSyncProfileServiceIOS
+  private var isModallyPresented = false
 
   init(
     braveCore: BraveProfileController,
-    tabManager: TabManager,
     windowProtection: WindowProtection?,
     isModallyPresented: Bool = false
   ) {
     self.braveCore = braveCore
     self.syncAPI = braveCore.syncAPI
     self.syncProfileServices = braveCore.syncProfileService
-    self.tabManager = tabManager
+    self.isModallyPresented = isModallyPresented
 
     super.init(windowProtection: windowProtection, isModallyPresented: isModallyPresented)
   }
@@ -223,14 +223,26 @@ class SyncWelcomeViewController: SyncViewController {
     mainStackView.addArrangedSubview(buttonsStackView)
 
     navigationItem.rightBarButtonItem = UIBarButtonItem(
-      image: UIImage(systemName: "gearshape"),
+      image: UIImage(braveSystemNamed: "leo.settings"),
       style: .plain,
       target: self,
       action: #selector(onSyncInternalsAction)
     )
+
+    if isModallyPresented {
+      navigationItem.leftBarButtonItem = UIBarButtonItem(
+        barButtonSystemItem: .done,
+        target: self,
+        action: #selector(doneTapped)
+      )
+    }
   }
 
   // MARK: Actions
+
+  @objc private func doneTapped() {
+    dismiss(animated: true)
+  }
 
   @objc
   private func newToSyncAction() {
@@ -334,7 +346,6 @@ class SyncWelcomeViewController: SyncViewController {
     let syncSettingsVC = SyncSettingsTableViewController(
       isModallyPresented: true,
       braveCoreMain: braveCore,
-      tabManager: tabManager,
       windowProtection: windowProtection
     )
 

--- a/ios/brave-ios/Sources/Brave/Shortcuts/ActivityShortcutManager.swift
+++ b/ios/brave-ios/Sources/Brave/Shortcuts/ActivityShortcutManager.swift
@@ -226,7 +226,7 @@ public class ActivityShortcutManager: NSObject {
       }
     case .openSyncedTabs:
       bvc.popToBVC()
-      bvc.showTabTray(isExternallyPresented: true)
+      bvc.navigationHelper.openSyncedTabsList()
     }
   }
 

--- a/ios/brave-ios/Sources/BraveStrings/BraveStrings.swift
+++ b/ios/brave-ios/Sources/BraveStrings/BraveStrings.swift
@@ -7265,6 +7265,30 @@ extension Strings {
         value: "Hide for now",
         comment: "The title for the action to hide open session with all tabs"
       )
+    public static let openTabsNoSyncedTabsTitle =
+      NSLocalizedString(
+        "opentabs.openTabsNoSyncedTabsTitle",
+        tableName: "BraveShared",
+        bundle: .module,
+        value: "No Synced Tabs",
+        comment: "A title shown when there are no synced open tabs to show in the list"
+      )
+    public static let openTabsYourTabsAppearHere =
+      NSLocalizedString(
+        "opentabs.openTabsYourTabsAppearHere",
+        tableName: "BraveShared",
+        bundle: .module,
+        value: "Your synced tabs appear here",
+        comment: "A description shown when there are no synced open tabs to show in the list"
+      )
+    public static let openTabsOnOtherDevices =
+      NSLocalizedString(
+        "opentabs.openTabsOnOtherDevices",
+        tableName: "BraveShared",
+        bundle: .module,
+        value: "Tabs on Other Devices",
+        comment: "The title shown on the screen that shows tabs synced from other devices"
+      )
   }
 }
 

--- a/ios/brave-ios/Sources/Favicon/FaviconImage.swift
+++ b/ios/brave-ios/Sources/Favicon/FaviconImage.swift
@@ -35,6 +35,9 @@ public struct FaviconImage: View {
       .resizable()
       .aspectRatio(contentMode: .fit)
       .task(id: url) {
+        if ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] != nil {
+          return
+        }
         faviconLoader.load(url: url, isPrivateBrowsing: isPrivateBrowsing)
       }
   }

--- a/ios/browser/api/opentabs/brave_opentabs_api.mm
+++ b/ios/browser/api/opentabs/brave_opentabs_api.mm
@@ -74,6 +74,10 @@ SyncDeviceFormFactor const SyncDeviceFormFactorTablet =
 
 #pragma mark - IOSOpenDistantSession
 
+@interface IOSOpenDistantSession ()
+@property(nonatomic) NSMutableArray* mTabs;
+@end
+
 @implementation IOSOpenDistantSession
 
 - (instancetype)initWithName:(nullable NSString*)name
@@ -100,10 +104,18 @@ SyncDeviceFormFactor const SyncDeviceFormFactorTablet =
     openDistantSession.sessionTag = [self.sessionTag copy];
     openDistantSession.modifiedTime = [self.modifiedTime copy];
     openDistantSession.deviceFormFactor = self.deviceFormFactor;
-    openDistantSession.tabs = [self.tabs copy];
+    openDistantSession.tabs = [self.mTabs copy];
   }
 
   return openDistantSession;
+}
+
+- (NSArray<IOSOpenDistantTab*>*)tabs {
+  return [self.mTabs copy];
+}
+
+- (void)setTabs:(NSArray<IOSOpenDistantTab*>*)tabs {
+  self.mTabs = [tabs mutableCopy];
 }
 
 - (void)updateOpenDistantSessionModified:(NSDate*)modifiedTime {
@@ -141,7 +153,7 @@ SyncDeviceFormFactor const SyncDeviceFormFactorTablet =
               title:base::SysUTF8ToNSString(tab_title)
               tabId:session_tab.tab_id.id()
          sessionTag:base::SysUTF8ToNSString(session_tag)];
-    [(NSMutableArray*)_tabs addObject:distant_tab];
+    [self.mTabs addObject:distant_tab];
   }
 }
 


### PR DESCRIPTION
This change adds a new component to display synced tabs. It currently only is visible when presenting synced tabs from Shortcuts.app, but will be used in the future tab tray redesign

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/46478

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
