### PR TITLE
fix(iOS): add a placeholder for no pending tx in confirmation screen.

### DIFF
--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Transaction Confirmations/TransactionConfirmationView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Transaction Confirmations/TransactionConfirmationView.swift
@@ -53,7 +53,7 @@ struct TransactionConfirmationView: View {
   }
 
   @ViewBuilder private var containerView: some View {
-    if confirmationStore.unapprovedTxs.count == 0 {
+    if confirmationStore.unapprovedTxs.isEmpty {
       VStack {
         Spacer()
         Image(braveSystemName: "leo.info.outline")
@@ -83,7 +83,7 @@ struct TransactionConfirmationView: View {
         isShowingAdvancedSettings: $isShowingAdvancedSettings,
         isTxSubmitting: $confirmationStore.isTxSubmitting,
         onDismiss: {
-          if confirmationStore.unapprovedTxs.count == 0 {
+          if confirmationStore.unapprovedTxs.isEmpty {
             onDismiss()
           }
           // update activeTransactionId

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Transaction Confirmations/TransactionConfirmationView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Transaction Confirmations/TransactionConfirmationView.swift
@@ -53,21 +53,44 @@ struct TransactionConfirmationView: View {
   }
 
   @ViewBuilder private var containerView: some View {
-    PendingTransactionView(
-      confirmationStore: confirmationStore,
-      networkStore: networkStore,
-      keyringStore: keyringStore,
-      isShowingGas: $isShowingGas,
-      isShowingAdvancedSettings: $isShowingAdvancedSettings,
-      isTxSubmitting: $confirmationStore.isTxSubmitting,
-      onDismiss: {
-        if confirmationStore.unapprovedTxs.count == 0 {
-          onDismiss()
-        }
-        // update activeTransactionId
-        confirmationStore.updateActiveTxIdAfterSignedClosed()
+    if confirmationStore.unapprovedTxs.count == 0 {
+      VStack {
+        Spacer()
+        Image(braveSystemName: "leo.info.outline")
+          .resizable()
+          .frame(width: 28, height: 28)
+          .padding(16)
+          .background(
+            Color.white.clipShape(.circle)
+          )
+        Text(Strings.Wallet.txConfirmationNoMorePendingTitle)
+          .font(.title3.weight(.semibold))
+          .foregroundColor(Color(braveSystemName: .textPrimary))
+          .padding(.top, 24)
+          .padding(.bottom, 12)
+        Text(Strings.Wallet.txStatusSubmittedDisclosure)
+          .font(.subheadline)
+          .foregroundColor(Color(braveSystemName: .textTertiary))
+        Spacer()
       }
-    )
+      .frame(maxWidth: .infinity)
+    } else {
+      PendingTransactionView(
+        confirmationStore: confirmationStore,
+        networkStore: networkStore,
+        keyringStore: keyringStore,
+        isShowingGas: $isShowingGas,
+        isShowingAdvancedSettings: $isShowingAdvancedSettings,
+        isTxSubmitting: $confirmationStore.isTxSubmitting,
+        onDismiss: {
+          if confirmationStore.unapprovedTxs.count == 0 {
+            onDismiss()
+          }
+          // update activeTransactionId
+          confirmationStore.updateActiveTxIdAfterSignedClosed()
+        }
+      )
+    }
   }
 
   var body: some View {

--- a/ios/brave-ios/Sources/BraveWallet/WalletStrings.swift
+++ b/ios/brave-ios/Sources/BraveWallet/WalletStrings.swift
@@ -5886,5 +5886,13 @@ extension Strings {
       comment:
         "The text in the disclosure view in transaction status screen."
     )
+    public static let txConfirmationNoMorePendingTitle = NSLocalizedString(
+      "wallet.txStatusSubmittedDisclosure",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value:  "No more pending transactions",
+      comment:
+        "The title displays in confirmation screen when there is no more pending transaction."
+    )
   }
 }


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/43878

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

## Test Plan
1. open wallet 
2. make a send tx
3. confirm this tx 
4. observe tx status shows up 
5. close tx status screen 
6. observe confirmation screen change to a placeholder saying there is no pending tx and dismiss itself automatically 
![Untitled](https://github.com/user-attachments/assets/bb45fd08-e6bd-4e00-8e0e-c7101d05525a)


