### PR TITLE
fix(iOS): fix wrong QSE launched if Leo is disabled. (uplift to 1.79.x)

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/SearchViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/SearchViewController.swift
@@ -704,7 +704,7 @@ public class SearchViewController: UIViewController, LoaderListener {
       return
     }
 
-    let offset = dataSource.isPrivate ? 0 : 1  // offset for the Leo button
+    let offset = dataSource.isAIChatAvailable ? 1 : 0  // offset for the Leo button
     let engine = dataSource.quickSearchEngines[index - offset]
     let localSearchQuery = dataSource.searchQuery.lowercased()
     guard let url = engine.searchURLForQuery(localSearchQuery) else {


### PR DESCRIPTION
Uplift of #29338
Resolves https://github.com/brave/brave-browser/issues/46421

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.