### PR TITLE
[iOS] Remove view hierarchy adjustment for backgrounded tab snapshots

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -2166,20 +2166,10 @@ public class BrowserViewController: UIViewController {
       // VoiceOver will sometimes be stuck on the element, not allowing user to move
       // forward/backward. Strange, but LayoutChanged fixes that.
       UIAccessibility.post(notification: .layoutChanged, argument: nil)
+    }
 
-      DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(500)) {
-        self.screenshotHelper.takeScreenshot(tab)
-      }
-    } else if tab.isWebViewCreated {
-      // To Screenshot a tab that is hidden we must add the webView,
-      // then wait enough time for the webview to render.
-      view.insertSubview(tab.view, at: 0)
-      DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(500)) {
-        self.screenshotHelper.takeScreenshot(tab)
-        if tab.view.superview == self.view {
-          tab.view.removeFromSuperview()
-        }
-      }
+    DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(500)) {
+      self.screenshotHelper.takeScreenshot(tab)
     }
   }
 


### PR DESCRIPTION
This removes the code that adds a web view to the view hierarchy in order to make a snapshot as this is no longer necessary and should fix a hang that is caused by when a web view changes windows

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/46503

### Test Case

Verify with Use Chromium Web Embedder feature flag on and off:
- Load a page such a wikipedia
- Tap a link near the bottom of the page and _immediately_ add a new tab/switch tabs
- Wait for backgrounded tab page to load (dependent on internet, likely ~1s)
- Tap the tab tray and verify tab snapshot was updated to the new page for the backgrounded tab

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
