### PR TITLE
Temporarily remove a CHECK() which causes a crash during autofill prompt

### DIFF
--- a/patches/components-autofill-core-browser-data_quality-addresses-profile_requirement_utils.cc.patch
+++ b/patches/components-autofill-core-browser-data_quality-addresses-profile_requirement_utils.cc.patch
@@ -1,0 +1,13 @@
+diff --git a/components/autofill/core/browser/data_quality/addresses/profile_requirement_utils.cc b/components/autofill/core/browser/data_quality/addresses/profile_requirement_utils.cc
+index 6d4e5f7db77605c228b259663a2485f49fd826a4..5150a085715eac8c17e20893a586d8050a8e4970 100644
+--- a/components/autofill/core/browser/data_quality/addresses/profile_requirement_utils.cc
++++ b/components/autofill/core/browser/data_quality/addresses/profile_requirement_utils.cc
+@@ -36,7 +36,7 @@ constexpr AddressImportRequirement kMinimumAddressRequirementViolations[] = {
+ std::vector<autofill_metrics::AddressProfileImportRequirementMetric>
+ ValidateProfileImportRequirements(const AutofillProfile& profile,
+                                   LogBuffer* import_log_buffer) {
+-  CHECK(profile.HasInfo(ADDRESS_HOME_COUNTRY));
++  if (!profile.HasInfo(ADDRESS_HOME_COUNTRY)) return {}; // NOTE(bsclifton): disabled with https://github.com/brave/brave-browser/issues/45546
+ 
+   std::vector<AddressImportRequirement> address_import_requirements;
+   // Validates the `profile` by testing that it has information for at least one


### PR DESCRIPTION
Happens for folks who have `English (World)` set as the locale.

See https://issues.chromium.org/issues/414842437 for more info

Fixes https://github.com/brave/brave-browser/issues/45546

