### PR TITLE
Temporarily remove a CHECK() which causes a crash during autofill prompt (uplift to 1.79.x)

### DIFF
--- a/patches/components-autofill-core-browser-data_quality-addresses-profile_requirement_utils.cc.patch
+++ b/patches/components-autofill-core-browser-data_quality-addresses-profile_requirement_utils.cc.patch
@@ -1,0 +1,13 @@
+diff --git a/components/autofill/core/browser/data_quality/addresses/profile_requirement_utils.cc b/components/autofill/core/browser/data_quality/addresses/profile_requirement_utils.cc
+index 6d4e5f7db77605c228b259663a2485f49fd826a4..5150a085715eac8c17e20893a586d8050a8e4970 100644
+--- a/components/autofill/core/browser/data_quality/addresses/profile_requirement_utils.cc
++++ b/components/autofill/core/browser/data_quality/addresses/profile_requirement_utils.cc
+@@ -36,7 +36,7 @@ constexpr AddressImportRequirement kMinimumAddressRequirementViolations[] = {
+ std::vector<autofill_metrics::AddressProfileImportRequirementMetric>
+ ValidateProfileImportRequirements(const AutofillProfile& profile,
+                                   LogBuffer* import_log_buffer) {
+-  CHECK(profile.HasInfo(ADDRESS_HOME_COUNTRY));
++  if (!profile.HasInfo(ADDRESS_HOME_COUNTRY)) return {}; // NOTE(bsclifton): disabled with https://github.com/brave/brave-browser/issues/45546
+ 
+   std::vector<AddressImportRequirement> address_import_requirements;
+   // Validates the `profile` by testing that it has information for at least one


### PR DESCRIPTION
Uplift of #29356
Fixes https://github.com/brave/brave-browser/issues/45546

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.