### PR TITLE
fix(privacy): Re-compile engines from cached combined rules when failing to deserialize cached engine on iOS

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/Debug/AdBlock/AdBlockDebugView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/Debug/AdBlock/AdBlockDebugView.swift
@@ -279,10 +279,17 @@ private struct CorruptCacheSectionView: View {
       // if file doesn't exist, we can't corrupt it.
       return false
     }
+    guard let content = await AsyncFileManager.default.contents(atPath: cachedDATFile.path),
+      var corruptedData = UUID().uuidString.data(using: .utf8)
+    else {
+      return false
+    }
+    // prefix UUID string to existing data to corrupt it
+    corruptedData.append(content)
     // remove the cached DAT file
     try? await AsyncFileManager.default.removeItem(atPath: cachedDATFile.path)
-    // 'corrupt' by replacing with empty file
-    await AsyncFileManager.default.createFile(atPath: cachedDATFile.path, contents: Data())
+    // 'corrupt' by replacing with corrupted data format
+    await AsyncFileManager.default.createFile(atPath: cachedDATFile.path, contents: corruptedData)
 
     return true
   }

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/Debug/AdBlock/AdBlockDebugView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/Debug/AdBlock/AdBlockDebugView.swift
@@ -3,6 +3,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import BraveShared
+import Strings
 import SwiftUI
 import WebKit
 
@@ -10,6 +12,7 @@ struct AdBlockDebugView: View {
   var body: some View {
     Form {
       CompileContentBlockersSectionView()
+      CorruptCacheSectionView()
     }
   }
 }
@@ -181,5 +184,106 @@ private struct CompileContentBlockersSectionView: View {
         where: { $0.setting.uuid == uuid }
       )?.setting.externalURL.lastPathComponent ?? uuid
     }
+  }
+}
+
+private struct CorruptCacheSectionView: View {
+  enum CacheResult: Error, Identifiable {
+    case success
+    case noCache
+    case failedStandard
+    case failedAggressive
+
+    var id: String {
+      return message
+    }
+
+    var title: String {
+      switch self {
+      case .success:
+        return "Success"
+      case .noCache, .failedStandard, .failedAggressive:
+        return "Failure"
+      }
+    }
+
+    var message: String {
+      switch self {
+      case .success:
+        return "Successfully corrupted adblock cache."
+      case .noCache:
+        return "Cache unavailable."
+      case .failedStandard:
+        return "Failed to corrupt standard cache."
+      case .failedAggressive:
+        return "Failed to corrupt aggressive cache."
+      }
+    }
+  }
+  @State private var corruptCacheResult: CacheResult?
+
+  var body: some View {
+    Section {
+      Button(action: corruptAdblockDATCache) {
+        Text("Corrupt Adblock Engine DAT Caches")
+      }
+    }
+    .alert(item: $corruptCacheResult) { corruptCacheResult in
+      Alert(
+        title: Text(corruptCacheResult.title),
+        message: Text(corruptCacheResult.message),
+        dismissButton: .default(Text(Strings.OKString))
+      )
+    }
+  }
+
+  private func corruptAdblockDATCache() {
+    Task {
+      guard
+        let folderURL = try? AsyncFileManager.default.url(
+          for: .cachesDirectory,
+          in: .userDomainMask
+        )
+      else {
+        self.corruptCacheResult = .noCache
+        return
+      }
+
+      let standardCacheFolderURL =
+        folderURL
+        .appendingPathComponent("engines", conformingTo: .folder)
+        .appendingPathComponent("standard", conformingTo: .folder)
+      if await !corruptListDATFile(in: standardCacheFolderURL) {
+        self.corruptCacheResult = .failedStandard
+        return
+      }
+
+      let aggressiveCacheFolderURL =
+        folderURL
+        .appendingPathComponent("engines", conformingTo: .folder)
+        .appendingPathComponent("aggressive", conformingTo: .folder)
+      if await !corruptListDATFile(in: aggressiveCacheFolderURL) {
+        self.corruptCacheResult = .failedAggressive
+        return
+      }
+      return self.corruptCacheResult = .success
+    }
+  }
+
+  private func corruptListDATFile(in directory: URL) async -> Bool {
+    guard await AsyncFileManager.default.fileExists(atPath: directory.path) else {
+      return false
+    }
+    let cachedDATFile = directory.appendingPathComponent("list.dat", conformingTo: .data)
+    guard await AsyncFileManager.default.fileExists(atPath: cachedDATFile.path) else {
+      // if file doesn't exist, we can't corrupt it.
+      return false
+    }
+    // remove the cached DAT file
+    try? await AsyncFileManager.default.removeItem(atPath: cachedDATFile.path)
+    // 'corrupt' by replacing with empty file
+    await AsyncFileManager.default.createFile(atPath: cachedDATFile.path, contents: Data())
+
+    return true
   }
 }

--- a/ios/brave-ios/Sources/Brave/WebFilters/AdBlock/AdBlockGroupsManager.swift
+++ b/ios/brave-ios/Sources/Brave/WebFilters/AdBlock/AdBlockGroupsManager.swift
@@ -146,21 +146,7 @@ import os
   /// will load from legacy storage (using text files) if the dat file is unavailable.
   private func loadEngineFromCache(for engineType: GroupedAdBlockEngine.EngineType) async {
     let manager = getManager(for: engineType)
-
-    if await !manager.loadFromCache(resourcesInfo: self.resourcesInfo) {
-      // This migration will add ~24s on an iPhone 8 (~8s on an iPhone 14)
-      // Even though its a one time thing, let's skip it.
-      // We never waited for the aggressive engines to be ready before anyways
-      guard engineType == .standard else { return }
-      for fileInfo in sourceProvider.legacyCacheFiles(for: engineType) {
-        manager.add(fileInfo: fileInfo)
-      }
-
-      await manager.compileAvailableEnginesIfNeeded(
-        for: sourceProvider.enabledSources,
-        resourcesInfo: self.resourcesInfo
-      )
-    }
+    await manager.loadFromCache(resourcesInfo: self.resourcesInfo)
   }
 
   /// Inform this manager of updates to the resources so our engines can be updated

--- a/ios/brave-ios/Sources/Brave/WebFilters/AdBlock/GroupedAdBlockEngine.swift
+++ b/ios/brave-ios/Sources/Brave/WebFilters/AdBlock/GroupedAdBlockEngine.swift
@@ -85,7 +85,13 @@ public actor GroupedAdBlockEngine {
   public struct FilterListGroup: Hashable, Equatable {
     let infos: [FilterListInfo]
     let localFileURL: URL
-    let fileType: GroupedAdBlockEngine.FileType
+    var fileType: GroupedAdBlockEngine.FileType {
+      if localFileURL.lastPathComponent.hasSuffix(".txt") {
+        return .text
+      } else {
+        return .data
+      }
+    }
 
     public func makeDebugDescription(for engineType: GroupedAdBlockEngine.EngineType) -> String {
       return infos.enumerated()

--- a/ios/brave-ios/Tests/ClientTests/Web Filters/GroupedAdBlockEngineTests.swift
+++ b/ios/brave-ios/Tests/ClientTests/Web Filters/GroupedAdBlockEngineTests.swift
@@ -75,8 +75,7 @@ final class GroupedAdBlockEngineTests: XCTestCase {
       engine: engine!,
       group: GroupedAdBlockEngine.FilterListGroup(
         infos: [filterListInfo],
-        localFileURL: localFileURL,
-        fileType: .text
+        localFileURL: localFileURL
       ),
       type: .standard
     )
@@ -107,8 +106,7 @@ final class GroupedAdBlockEngineTests: XCTestCase {
     )
     let group = GroupedAdBlockEngine.FilterListGroup(
       infos: [textFilterListInfo],
-      localFileURL: localFileURL,
-      fileType: .text
+      localFileURL: localFileURL
     )
 
     let expectation = expectation(description: "Compiled engine resources")
@@ -187,8 +185,7 @@ final class GroupedAdBlockEngineTests: XCTestCase {
 
       let group = GroupedAdBlockEngine.FilterListGroup(
         infos: [filterListInfo],
-        localFileURL: sampleFilterListURL,
-        fileType: .text
+        localFileURL: sampleFilterListURL
       )
 
       do {

--- a/ios/browser/api/brave_shields/adblock_engine.mm
+++ b/ios/browser/api/brave_shields/adblock_engine.mm
@@ -105,6 +105,7 @@ class AdblockEngineBox final {
         *error =
             [[self class] adblockErrorForKind:adblock::ResultKind::AdblockError
                                       message:"Failed to deserialize data"];
+        return nil;
       }
     }
   }

--- a/ios/browser/api/brave_shields/adblock_engine.mm
+++ b/ios/browser/api/brave_shields/adblock_engine.mm
@@ -91,7 +91,13 @@ class AdblockEngineBox final {
         if (error) {
           *error = [[self class] adblockErrorForKind:result.result_kind
                                              message:result.error_message];
+        } else {
+          *error = [[self class]
+              adblockErrorForKind:adblock::ResultKind::AdblockError
+                          message:
+                              "Unknown error initializing engine with rules"];
         }
+        return nil;
       }
     }
   }


### PR DESCRIPTION
- This change only affects the flow where we fail to deserialize the `AdblockEngine` using the serialized `list.dat` from our cache.
    - When this occurs for the standard engine, we will use instead re-compile the `AdblockEngine` from the cached combined rule lists stored at `/Caches/engines/<engine_type>/list.txt` (we [combine rule lists](https://github.com/brave/brave-core/blob/ba5ae78a6cb09645b5825b00157ee1046a9ae403/ios/brave-ios/Sources/Brave/WebFilters/AdBlock/AdBlockEngineManager.swift#L374-L398) and cache them), then re-caches the engine to the serialized DAT format.
- This recompile comes with a small one-time performance hit (~1.2s to compile from plaintext during startup vs ~0.6s to compile from DAT on iPhone XS w/ A12 Bionic), as compiling the adblock engine from plaintext is slower than loading from serialized data file.
- Adds a adblock debug option to 'corrupt' this cache by writing empty data file to the cache location, which causes us to fail to deserialize the engine on next launch.

Resolves https://github.com/brave/brave-browser/issues/46545

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

1. In the QA menu / developer options menu, open the `AdBlock Debugger` section, then tap `Corrupt Adblock Engine DAT Caches`
2. After successful alert, restart the app (if a developer, restart with debugger attached to view console logs)
3. (Developers only) On launch you should see `Set <engine_type> (txt)` in console logs to indicate the engine being compiled from txt
4. Verify adblock engine is working as expected (ex visit a website and confirm >0 items in shields panel)
5. Restart the app
6. (Developers only) On launch you should see `Set <engine_type> (dat)` in console logs to indicate the engine being loaded from cached DAT again
7. Verify adblock engine is working as expected (ex visit a website and confirm >0 items in shields panel)