### PR TITLE
Ensure that shields p3a is not reported for incognito profiles.

### DIFF
--- a/browser/brave_browser_main_extra_parts.cc
+++ b/browser/brave_browser_main_extra_parts.cc
@@ -44,8 +44,8 @@ void RecordInitialP3AValues() {
       g_browser_process->local_state());
 #endif  // !BUILDFLAG(IS_ANDROID)
 
-  brave_shields::MaybeRecordShieldsUsageP3A(brave_shields::kNeverClicked,
-                                            g_browser_process->local_state());
+  P3A(brave_shields::NotIncognito()) << MaybeRecordShieldsUsageP3A(
+      brave_shields::kNeverClicked, g_browser_process->local_state());
 
   // Record crash reporting status stats.
   const bool crash_reports_enabled = g_browser_process->local_state()->

--- a/browser/misc_metrics/profile_misc_metrics_service_factory.cc
+++ b/browser/misc_metrics/profile_misc_metrics_service_factory.cc
@@ -68,9 +68,10 @@ ProfileMiscMetricsServiceFactory::BuildServiceInstanceForBrowserContext(
 content::BrowserContext*
 ProfileMiscMetricsServiceFactory::GetBrowserContextToUse(
     content::BrowserContext* context) const {
-  if (context->IsOffTheRecord()) {
+  /*
+    if (context->IsOffTheRecord()) {
     return nullptr;
-  }
+  }*/
   return context;
 }
 

--- a/browser/profiles/brave_profile_manager.cc
+++ b/browser/profiles/brave_profile_manager.cc
@@ -93,7 +93,7 @@ void RecordInitialP3AValues(Profile* profile) {
   }
   ntp_background_images::RecordSponsoredImagesEnabledP3A(profile->GetPrefs());
   if (profile->IsRegularProfile()) {
-    brave_shields::MaybeRecordInitialShieldsSettings(
+    P3A(profile) << brave_shields::MaybeRecordInitialShieldsSettings(
         profile->GetPrefs(),
         HostContentSettingsMapFactory::GetForProfile(profile));
   }

--- a/browser/ui/webui/brave_shields/shields_panel_handler.cc
+++ b/browser/ui/webui/brave_shields/shields_panel_handler.cc
@@ -34,7 +34,7 @@ void ShieldsPanelHandler::ShowUI() {
   if (embedder) {
     embedder->ShowUI();
   }
-  brave_shields::MaybeRecordShieldsUsageP3A(
+  P3A(profile_.get()) << MaybeRecordShieldsUsageP3A(
       brave_shields::ShieldsIconUsage::kClicked,
       g_browser_process->local_state());
 }

--- a/components/brave_shields/content/browser/BUILD.gn
+++ b/components/brave_shields/content/browser/BUILD.gn
@@ -36,6 +36,7 @@ static_library("browser") {
     "brave_farbling_service.h",
     "brave_shields_p3a.cc",
     "brave_shields_p3a.h",
+    "brave_shields_p3a_utils.h",
     "brave_shields_util.cc",
     "brave_shields_util.h",
     "cookie_list_opt_in_service.cc",

--- a/components/brave_shields/content/browser/brave_shields_p3a.cc
+++ b/components/brave_shields/content/browser/brave_shields_p3a.cc
@@ -154,25 +154,36 @@ int DomainCountRelativeToGlobalSetting(PrefService* profile_prefs,
 
 }  // namespace
 
-void MaybeRecordShieldsUsageP3A(ShieldsIconUsage usage,
-                                PrefService* local_state) {
+P3A_FUNC RecordShieldsToggled(PrefService* local_state) {
+  return MaybeRecordShieldsUsageP3A(kShutOffShields, local_state);
+}
+
+P3A_FUNC RecordShieldsSettingChanged(PrefService* local_state) {
+  return MaybeRecordShieldsUsageP3A(kChangedPerSiteShields, local_state);
+}
+
+P3A_FUNC MaybeRecordShieldsUsageP3A(ShieldsIconUsage usage,
+                                    PrefService* local_state) {
   p3a::RecordValueIfGreater<ShieldsIconUsage>(usage, kUsageStatusHistogramName,
                                               kUsagePrefName, local_state);
+  return {};
 }
 
-void RecordShieldsAdsSetting(ControlType setting) {
+P3A_FUNC RecordShieldsAdsSetting(ControlType setting) {
   RecordShieldsLevelSetting(kAdsSettingHistogramName, setting);
+  return {};
 }
 
-void RecordShieldsFingerprintSetting(ControlType setting) {
+P3A_FUNC RecordShieldsFingerprintSetting(ControlType setting) {
   RecordShieldsLevelSetting(kFingerprintSettingHistogramName, setting);
+  return {};
 }
 
-void RecordShieldsDomainSettingCounts(PrefService* profile_prefs,
-                                      bool is_fingerprint,
-                                      ControlType global_setting) {
+P3A_FUNC RecordShieldsDomainSettingCounts(PrefService* profile_prefs,
+                                          bool is_fingerprint,
+                                          ControlType global_setting) {
   if (profile_prefs == nullptr) {
-    return;
+    return {};
   }
   const char* above_hg_name = is_fingerprint
                                   ? kDomainFPSettingsAboveHistogramName
@@ -200,15 +211,16 @@ void RecordShieldsDomainSettingCounts(PrefService* profile_prefs,
     p3a_utils::RecordToHistogramBucket(below_hg_name, kDomainCountBuckets,
                                        below_total);
   }
+  return {};
 }
 
-void RecordShieldsDomainSettingCountsWithChange(PrefService* profile_prefs,
-                                                bool is_fingerprint,
-                                                ControlType global_setting,
-                                                ControlType* prev_setting,
-                                                ControlType new_setting) {
+P3A_FUNC RecordShieldsDomainSettingCountsWithChange(PrefService* profile_prefs,
+                                                    bool is_fingerprint,
+                                                    ControlType global_setting,
+                                                    ControlType* prev_setting,
+                                                    ControlType new_setting) {
   if (profile_prefs == nullptr) {
-    return;
+    return {};
   }
   if (prev_setting != nullptr) {
     UpdateDomainSettingCount(profile_prefs, is_fingerprint, *prev_setting, -1);
@@ -221,11 +233,11 @@ void RecordShieldsDomainSettingCountsWithChange(PrefService* profile_prefs,
   VLOG(1) << "BraveShieldsP3A: Increasing new setting count: new_setting="
           << new_setting << " is_fp=" << is_fingerprint << " count="
           << GetDomainSettingCount(profile_prefs, is_fingerprint, new_setting);
-  RecordShieldsDomainSettingCounts(profile_prefs, is_fingerprint,
-                                   global_setting);
+  return RecordShieldsDomainSettingCounts(profile_prefs, is_fingerprint,
+                                          global_setting);
 }
 
-void RecordForgetFirstPartySetting(HostContentSettingsMap* map) {
+P3A_FUNC RecordForgetFirstPartySetting(HostContentSettingsMap* map) {
   ContentSetting global_setting = map->GetContentSetting(
       {}, {}, ContentSettingsType::BRAVE_REMEMBER_1P_STORAGE);
   auto per_site_settings = map->GetSettingsForOneType(
@@ -247,20 +259,21 @@ void RecordForgetFirstPartySetting(HostContentSettingsMap* map) {
     answer = 3;
   }
   UMA_HISTOGRAM_EXACT_LINEAR(kForgetFirstPartyHistogramName, answer, 4);
+  return {};
 }
 
-void MaybeRecordInitialShieldsSettings(PrefService* profile_prefs,
-                                       HostContentSettingsMap* map) {
+P3A_FUNC MaybeRecordInitialShieldsSettings(PrefService* profile_prefs,
+                                           HostContentSettingsMap* map) {
   if (profile_prefs->GetInteger(kFirstReportedRevisionPrefName) >=
       kCurrentReportRevision) {
-    return;
+    return {};
   }
   VLOG(1) << "BraveShieldsP3A: Starting initial report for profile";
 
   ControlType global_ads_setting = GetCosmeticFilteringControlType(map, GURL());
   ControlType global_fp_setting = GetFingerprintingControlType(map, GURL());
-  RecordShieldsAdsSetting(global_ads_setting);
-  RecordShieldsFingerprintSetting(global_fp_setting);
+  P3A(map) << RecordShieldsAdsSetting(global_ads_setting)
+           << RecordShieldsFingerprintSetting(global_fp_setting);
 
   // Since internal setting counts don't exist, we will
   // count ads & fp settings for all domains by processing the content settings.
@@ -295,12 +308,15 @@ void MaybeRecordInitialShieldsSettings(PrefService* profile_prefs,
   UpdateDomainSettingCount(profile_prefs, false, ControlType::BLOCK,
                            ads_counts.aggressive);
 
-  RecordShieldsDomainSettingCounts(profile_prefs, false, global_ads_setting);
-  RecordShieldsDomainSettingCounts(profile_prefs, true, global_fp_setting);
-  RecordForgetFirstPartySetting(map);
+  P3A(map) << RecordShieldsDomainSettingCounts(profile_prefs, false,
+                                               global_ads_setting)
+           << RecordShieldsDomainSettingCounts(profile_prefs, true,
+                                               global_fp_setting)
+           << RecordForgetFirstPartySetting(map);
 
   profile_prefs->SetInteger(kFirstReportedRevisionPrefName,
                             kCurrentReportRevision);
+  return {};
 }
 
 void RegisterShieldsP3ALocalPrefs(PrefRegistrySimple* local_state) {
@@ -319,11 +335,11 @@ void RegisterShieldsP3AProfilePrefs(PrefRegistrySimple* registry) {
 
 void RegisterShieldsP3AProfilePrefsForMigration(PrefRegistrySimple* registry) {
   // Added 03/2024
-  registry->RegisterBooleanPref(kFirstReportedPrefName, false);
+  registry->RegisterBooleanPref(kDeprecatedFirstReportedPrefName, false);
 }
 
 void MigrateObsoleteProfilePrefs(PrefService* profile_prefs) {
-  profile_prefs->ClearPref(kFirstReportedPrefName);
+  profile_prefs->ClearPref(kDeprecatedFirstReportedPrefName);
 }
 
 }  // namespace brave_shields

--- a/components/brave_shields/content/browser/brave_shields_p3a.h
+++ b/components/brave_shields/content/browser/brave_shields_p3a.h
@@ -6,6 +6,7 @@
 #ifndef BRAVE_COMPONENTS_BRAVE_SHIELDS_CONTENT_BROWSER_BRAVE_SHIELDS_P3A_H_
 #define BRAVE_COMPONENTS_BRAVE_SHIELDS_CONTENT_BROWSER_BRAVE_SHIELDS_P3A_H_
 
+#include "brave/components/brave_shields/content/browser/brave_shields_p3a_utils.h"
 #include "brave/components/brave_shields/content/browser/brave_shields_util.h"
 
 class PrefRegistrySimple;
@@ -15,7 +16,7 @@ class HostContentSettingsMap;
 namespace brave_shields {
 
 inline constexpr char kUsagePrefName[] = "brave_shields.p3a_usage";
-inline constexpr char kFirstReportedPrefName[] =
+inline constexpr char kDeprecatedFirstReportedPrefName[] =
     "brave_shields.p3a_first_reported_v2";  // DEPRECATED
 inline constexpr char kFirstReportedRevisionPrefName[] =
     "brave_shields.p3a_first_reported_revision";
@@ -58,37 +59,40 @@ enum ShieldsIconUsage {
   kSize,
 };
 
+P3A_FUNC RecordShieldsToggled(PrefService* local_state);
+
+P3A_FUNC RecordShieldsSettingChanged(PrefService* local_state);
+
 // We save latest value to local state and compare new values with it.
 // The idea is to write to a histogram only the highest value (e.g. we are
 // not interested in |kClicked| event if the user already turned off shields.
-// Sine P3A sends only latest written values, these is enough for our current
+// Since P3A sends only latest written values, these is enough for our current
 // goals.
-void MaybeRecordShieldsUsageP3A(ShieldsIconUsage usage,
-                                PrefService* local_state);
+P3A_FUNC MaybeRecordShieldsUsageP3A(ShieldsIconUsage usage,
+                                    PrefService* local_state);
 
 // Records to global ads setting histogram: Brave.Shields.AdBlockSetting
-void RecordShieldsAdsSetting(ControlType setting);
+P3A_FUNC RecordShieldsAdsSetting(ControlType setting);
 
 // Records to global FP setting histogram: Brave.Shields.FingerprintBlockSetting
-void RecordShieldsFingerprintSetting(ControlType setting);
+P3A_FUNC RecordShieldsFingerprintSetting(ControlType setting);
 
 // To be called when the global setting changes.
 // Will update domain setting count histograms.
-void RecordShieldsDomainSettingCounts(PrefService* profile_prefs,
-                                      bool is_fingerprint,
-                                      ControlType global_setting);
-
+P3A_FUNC RecordShieldsDomainSettingCounts(PrefService* profile_prefs,
+                                          bool is_fingerprint,
+                                          ControlType global_setting);
 // To be called when a domain setting changes.
 // Will update internal pref counts and update domain setting count histograms.
-void RecordShieldsDomainSettingCountsWithChange(PrefService* profile_prefs,
-                                                bool is_fingerprint,
-                                                ControlType global_setting,
-                                                ControlType* prev_setting,
-                                                ControlType new_setting);
+P3A_FUNC RecordShieldsDomainSettingCountsWithChange(PrefService* profile_prefs,
+                                                    bool is_fingerprint,
+                                                    ControlType global_setting,
+                                                    ControlType* prev_setting,
+                                                    ControlType new_setting);
 
 // Records global "forget me when I close this site" setting,
 // and any per-site exceptions.
-void RecordForgetFirstPartySetting(HostContentSettingsMap* map);
+P3A_FUNC RecordForgetFirstPartySetting(HostContentSettingsMap* map);
 
 void RegisterShieldsP3ALocalPrefs(PrefRegistrySimple* local_state);
 
@@ -98,8 +102,8 @@ void MigrateObsoleteProfilePrefs(PrefService* profile_prefs);
 
 // To be called at initialization. Will count all domain settings and
 // record to all histograms, if executed for the first time.
-void MaybeRecordInitialShieldsSettings(PrefService* profile_prefs,
-                                       HostContentSettingsMap* map);
+P3A_FUNC MaybeRecordInitialShieldsSettings(PrefService* profile_prefs,
+                                           HostContentSettingsMap* map);
 
 }  // namespace brave_shields
 

--- a/components/brave_shields/content/browser/brave_shields_p3a_utils.h
+++ b/components/brave_shields/content/browser/brave_shields_p3a_utils.h
@@ -1,0 +1,84 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_COMPONENTS_BRAVE_SHIELDS_CONTENT_BROWSER_BRAVE_SHIELDS_P3A_UTILS_H_
+#define BRAVE_COMPONENTS_BRAVE_SHIELDS_CONTENT_BROWSER_BRAVE_SHIELDS_P3A_UTILS_H_
+
+#include "base/check.h"
+
+namespace brave_shields {
+// This code implements a lazy evaluation pattern for P3A logging calls with
+// several key features:
+//
+// * Incognito Mode Handling - The P3AContextCheck ensures analytics are only
+//   recorded in non-incognito contexts by verifying IsOffTheRecord().
+//
+// * Lazy Evaluation - The P3A_LAZY_CALLS macro prevents unnecessary evaluation
+//   of logging parameters when P3A is disabled for the current context.
+//
+// * Usage Enforcement - The P3AResult class, marked with [[nodiscard]], along
+//   with its used_ flag, ensures logging calls are properly handled within
+//   the context check.
+//
+// * The P3A() macro provides a clean interface that automatically handles
+//   all context checking logic.
+//
+// * The P3A_FUNC macro marks the target function to be used for reporting P3A
+//   metrics. The marked functions can't be called outside the context checking.
+
+// Only use this if you can't acquire context. Make sure to use it in
+// non-incognito mode.
+struct NotIncognito {
+  bool IsOffTheRecord() const { return false; }
+};
+
+struct P3AContextCheck {
+  template <typename Context>
+  static bool From(const Context context) {
+    if constexpr (std::is_pointer_v<Context>) {
+      if (!context || context->IsOffTheRecord()) {
+        return false;
+      }
+    } else {
+      if (context.IsOffTheRecord()) {
+        return false;
+      }
+    }
+    return true;
+  }
+};
+
+class P3AResult {
+ public:
+  ~P3AResult() { CHECK(used_); }
+
+ private:
+  friend struct P3ACallStream;
+  bool used_ = false;
+};
+
+struct P3ACallStream {
+  struct Voidify {
+    void operator&(P3ACallStream&) {}
+  };
+
+  P3ACallStream& operator<<(P3AResult&& r) {
+    r.used_ = true;
+    return *this;
+  }
+};
+
+#define P3A_LAZY_CALLS(stream, is_enabled) \
+  !(is_enabled) ? (void)0 : ::brave_shields::P3ACallStream::Voidify() & (stream)
+
+#define P3A(context)                               \
+  P3A_LAZY_CALLS(::brave_shields::P3ACallStream(), \
+                 ::brave_shields::P3AContextCheck::From(context))
+
+#define P3A_FUNC [[nodiscard]] ::brave_shields::P3AResult
+
+}  // namespace brave_shields
+
+#endif  // BRAVE_COMPONENTS_BRAVE_SHIELDS_CONTENT_BROWSER_BRAVE_SHIELDS_P3A_UTILS_H_

--- a/components/brave_shields/content/browser/brave_shields_util.cc
+++ b/components/brave_shields/content/browser/brave_shields_util.cc
@@ -46,16 +46,6 @@ uint32_t g_stable_farbling_tokens_seed = 0;
 
 namespace {
 
-void RecordShieldsToggled(PrefService* local_state) {
-  ::brave_shields::MaybeRecordShieldsUsageP3A(::brave_shields::kShutOffShields,
-                                              local_state);
-}
-
-void RecordShieldsSettingChanged(PrefService* local_state) {
-  ::brave_shields::MaybeRecordShieldsUsageP3A(
-      ::brave_shields::kChangedPerSiteShields, local_state);
-}
-
 ContentSetting GetDefaultAllowFromControlType(ControlType type) {
   if (type == ControlType::DEFAULT) {
     return CONTENT_SETTING_DEFAULT;
@@ -246,9 +236,7 @@ void SetBraveShieldsEnabled(HostContentSettingsMap* map,
         primary_pattern, ContentSettingsPattern::Wildcard(),
         ContentSettingsType::BRAVE_SHIELDS, setting);
 
-    if (!map->IsOffTheRecord()) {
-      RecordShieldsToggled(local_state);
-    }
+    P3A(map) << RecordShieldsToggled(local_state);
   } else {
     map->SetContentSettingCustomScope(
         primary_pattern, ContentSettingsPattern::Wildcard(),
@@ -293,7 +281,7 @@ void SetAdControlType(HostContentSettingsMap* map,
                                     ContentSettingsPattern::Wildcard(),
                                     ContentSettingsType::BRAVE_TRACKERS,
                                     GetDefaultBlockFromControlType(type));
-  RecordShieldsSettingChanged(local_state);
+  P3A(map) << RecordShieldsSettingChanged(local_state);
 }
 
 ControlType GetAdControlType(HostContentSettingsMap* map, const GURL& url) {
@@ -340,21 +328,18 @@ void SetCosmeticFilteringControlType(HostContentSettingsMap* map,
       ContentSettingsType::BRAVE_COSMETIC_FILTERING,
       GetDefaultAllowFromControlType(type));
 
-  if (!map->IsOffTheRecord()) {
-    // Only report to P3A if not a guest/incognito profile
-    RecordShieldsSettingChanged(local_state);
-    if (url.is_empty()) {
-      // If global setting changed, report global setting and recalulate
-      // domain specific setting counts
-      RecordShieldsAdsSetting(type);
-      RecordShieldsDomainSettingCounts(profile_state, false, type);
-    } else {
-      // If domain specific setting changed, recalculate counts
-      ControlType global_setting = GetCosmeticFilteringControlType(map, GURL());
-      RecordShieldsDomainSettingCountsWithChange(
-          profile_state, false, global_setting,
-          was_default ? nullptr : &prev_setting, type);
-    }
+  P3A(map) << RecordShieldsSettingChanged(local_state);
+  if (url.is_empty()) {
+    // If global setting changed, report global setting and recalulate
+    // domain specific setting counts
+    P3A(map) << RecordShieldsAdsSetting(type)
+             << RecordShieldsDomainSettingCounts(profile_state, false, type);
+  } else {
+    // If domain specific setting changed, recalculate counts
+    ControlType global_setting = GetCosmeticFilteringControlType(map, GURL());
+    P3A(map) << RecordShieldsDomainSettingCountsWithChange(
+        profile_state, false, global_setting,
+        was_default ? nullptr : &prev_setting, type);
   }
 }
 
@@ -477,7 +462,7 @@ void SetCookieControlType(HostContentSettingsMap* map,
     return;
   }
 
-  RecordShieldsSettingChanged(local_state);
+  P3A(map) << RecordShieldsSettingChanged(local_state);
 
   if (patterns.host_pattern == ContentSettingsPattern::Wildcard()) {
     // Default settings.
@@ -618,21 +603,18 @@ void SetFingerprintingControlType(HostContentSettingsMap* map,
   map->SetContentSettingCustomScope(
       primary_pattern, ContentSettingsPattern::Wildcard(),
       ContentSettingsType::BRAVE_FINGERPRINTING_V2, content_setting);
-  if (!map->IsOffTheRecord()) {
-    // Only report to P3A if not a guest/incognito profile
-    RecordShieldsSettingChanged(local_state);
-    if (url.is_empty()) {
-      // If global setting changed, report global setting and recalulate
-      // domain specific setting counts
-      RecordShieldsFingerprintSetting(type);
-      RecordShieldsDomainSettingCounts(profile_state, true, type);
-    } else {
-      // If domain specific setting changed, recalculate counts
-      ControlType global_setting = GetFingerprintingControlType(map, GURL());
-      RecordShieldsDomainSettingCountsWithChange(
-          profile_state, true, global_setting,
-          was_default ? nullptr : &prev_setting, type);
-    }
+  P3A(map) << RecordShieldsSettingChanged(local_state);
+  if (url.is_empty()) {
+    // If global setting changed, report global setting and recalulate
+    // domain specific setting counts
+    P3A(map) << RecordShieldsFingerprintSetting(type)
+             << RecordShieldsDomainSettingCounts(profile_state, true, type);
+  } else {
+    // If domain specific setting changed, recalculate counts
+    ControlType global_setting = GetFingerprintingControlType(map, GURL());
+    P3A(map) << RecordShieldsDomainSettingCountsWithChange(
+        profile_state, true, global_setting,
+        was_default ? nullptr : &prev_setting, type);
   }
 }
 
@@ -715,7 +697,7 @@ void SetHttpsUpgradeControlType(HostContentSettingsMap* map,
         secure_url, GURL(), ContentSettingsType::HTTP_ALLOWED, base::Value());
   }
 
-  RecordShieldsSettingChanged(local_state);
+  P3A(map) << RecordShieldsSettingChanged(local_state);
 }
 
 ControlType GetHttpsUpgradeControlType(HostContentSettingsMap* map,
@@ -795,7 +777,7 @@ void SetNoScriptControlType(HostContentSettingsMap* map,
       ContentSettingsType::JAVASCRIPT,
       type == ControlType::ALLOW ? CONTENT_SETTING_ALLOW
                                  : CONTENT_SETTING_BLOCK);
-  RecordShieldsSettingChanged(local_state);
+  P3A(map) << RecordShieldsSettingChanged(local_state);
 }
 
 ControlType GetNoScriptControlType(HostContentSettingsMap* map,
@@ -821,8 +803,8 @@ void SetForgetFirstPartyStorageEnabled(HostContentSettingsMap* map,
       primary_pattern, ContentSettingsPattern::Wildcard(),
       ContentSettingsType::BRAVE_REMEMBER_1P_STORAGE,
       is_enabled ? CONTENT_SETTING_BLOCK : CONTENT_SETTING_ALLOW);
-  RecordShieldsSettingChanged(local_state);
-  RecordForgetFirstPartySetting(map);
+  P3A(map) << RecordShieldsSettingChanged(local_state)
+           << RecordForgetFirstPartySetting(map);
 }
 
 bool GetForgetFirstPartyStorageEnabled(HostContentSettingsMap* map,
@@ -901,7 +883,7 @@ void SetWebcompatEnabled(HostContentSettingsMap* map,
   map->SetContentSettingCustomScope(primary_pattern,
                                     ContentSettingsPattern::Wildcard(),
                                     webcompat_settings_type, setting);
-  RecordShieldsSettingChanged(local_state);
+  P3A(map) << RecordShieldsSettingChanged(local_state);
 }
 
 bool IsWebcompatEnabled(HostContentSettingsMap* map,

--- a/components/brave_shields/content/test/brave_shields_p3a_unittest.cc
+++ b/components/brave_shields/content/test/brave_shields_p3a_unittest.cc
@@ -3,11 +3,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
+#include "brave/components/brave_shields/content/browser/brave_shields_p3a.h"
+
 #include <memory>
 
 #include "base/test/metrics/histogram_tester.h"
 #include "base/test/scoped_feature_list.h"
-#include "brave/components/brave_shields/content/browser/brave_shields_p3a.h"
 #include "brave/components/brave_shields/content/browser/brave_shields_util.h"
 #include "brave/components/brave_shields/core/common/features.h"
 #include "chrome/browser/content_settings/host_content_settings_map_factory.h"
@@ -82,7 +83,8 @@ TEST_F(BraveShieldsP3ATest, RecordDomainAdBlockCounts) {
                                   GURL("https://brave.com"));
 
   // Test initial count
-  MaybeRecordInitialShieldsSettings(GetProfile()->GetPrefs(), map);
+  P3A(GetProfile()) << MaybeRecordInitialShieldsSettings(
+      GetProfile()->GetPrefs(), map);
   histogram_tester_->ExpectBucketCount(kDomainAdsSettingsAboveHistogramName, 1,
                                        1);
   histogram_tester_->ExpectBucketCount(kDomainAdsSettingsBelowHistogramName, 0,
@@ -147,7 +149,8 @@ TEST_F(BraveShieldsP3ATest, RecordDomainFingerprintBlockCounts) {
                                GURL("https://brave.com"));
 
   // Test initial count
-  MaybeRecordInitialShieldsSettings(GetProfile()->GetPrefs(), map);
+  P3A(GetProfile()) << MaybeRecordInitialShieldsSettings(
+      GetProfile()->GetPrefs(), map);
   histogram_tester_->ExpectBucketCount(kDomainFPSettingsAboveHistogramName, 1,
                                        1);
   histogram_tester_->ExpectBucketCount(kDomainFPSettingsBelowHistogramName, 0,


### PR DESCRIPTION
### Background  
As we now know, we do not want to process OTR profile data in P3A. Previously, this requirement did not exist, and as a legacy, there are still P3A calls originating from OTR contexts.  

### Possible Solutions  
We can approach this issue in a few ways:  

1. **Manual Approach**  
   - Locate all P3A calls manually.  
   - Determine if they are executed in an OTR context.  
   - If they are, add a conditional check:  
     ```cpp  
     if (!OTR) RecordP3A(...);  
     ```  
     Alternatively, modify `RecordP3A` to include a parameter and validate the context internally.  

2. **Automated Approach**  
   - Annotate relevant functions (e.g., `RecordP3A`) with a marker like `P3A_FUNC`:  
     ```cpp  
     P3A_FUNC RecordP3A(...);  
     ```  
   - This will intentionally break the build wherever these functions are used.  
   - At each call site, enforce context validation by modifying the call to:  
     ```cpp  
     P3A(context_to_check) << RecordP3A(...);  
     ```  

### Implementation in This PR  
This PR implements **Solution #2** for the Shields component. However, we could move `brave_shields_p3a_utils.h` to the P3A component level, allowing iterative validation and fixes for other components if needed.

Lets discuss it