### PR TITLE
[iOS] Fix missing toggle switch for 'Always request desktop mode' pref (uplift to 1.80.x)

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/SettingsViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/SettingsViewController.swift
@@ -533,6 +533,7 @@ class SettingsViewController: TableViewController {
         Row(
           text: Strings.alwaysRequestDesktopSite,
           image: UIImage(braveSystemNamed: "leo.window.cursor"),
+          accessory: .view(defaultPageModeSwitch),
           cellClass: MultilineSubtitleCell.self
         )
       )


### PR DESCRIPTION
Uplift of #29391
Resolves https://github.com/brave/brave-browser/issues/46484

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.