### PR TITLE
[AI Chat]: Citation UI Improvements

### DIFF
--- a/components/ai_chat/resources/untrusted_conversation_frame/components/assistant_response/index.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/assistant_response/index.tsx
@@ -13,6 +13,9 @@ import { useUntrustedConversationContext } from '../../untrusted_conversation_co
 import MarkdownRenderer from '../markdown_renderer'
 import WebSourcesEvent from './web_sources_event'
 import styles from './style.module.scss'
+import {
+  removeReasoning //
+} from '../conversation_entries/conversation_entries_utils'
 
 function SearchSummary (props: { searchQueries: string[] }) {
   const context = useUntrustedConversationContext()
@@ -64,12 +67,12 @@ function AssistantEvent(props: {
                            `[${index + 1}]: ${url}`).join('\n') + '\n\n'
         : '';
 
-    // Replaces 2 consecutive citations with a separator so that
-    // they will both render as links.
-    const completion =
-      event.completionEvent.completion.replace(/(\[\d+\])(?=\[\d+\])/g,
-                                               '$1\u200B')
-    const fullText = `${numberedLinks}${completion}`;
+    // Replaces 2 consecutive citations with a separator and also
+    // adds a space before the citation and the text.
+     const completion =
+       event.completionEvent.completion.replace(/(\w|\S)\[(\d+)\]/g, '$1 [$2]')
+
+    const fullText = `${numberedLinks}${removeReasoning(completion)}`;
 
     return (
       <MarkdownRenderer
@@ -127,8 +130,10 @@ export default function AssistantResponse(props: {
   {
     !props.isEntryInProgress &&
     <>
-      {searchQueriesEvent && <SearchSummary searchQueries={searchQueriesEvent.searchQueries} />}
       {sourcesEvent && <WebSourcesEvent sources={sourcesEvent.sources} />}
+      {searchQueriesEvent &&
+        <SearchSummary searchQueries={searchQueriesEvent.searchQueries} />
+      }
     </>
   }
   </>)

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/assistant_response/style.module.scss
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/assistant_response/style.module.scss
@@ -17,7 +17,7 @@
 
 .searchSummary {
   --leo-icon-size: 18px;
-  margin-top: var(--leo-spacing-m);
+  margin-top: var(--leo-spacing-xl);
   display: flex;
   flex-direction: row;
   gap: 6px;

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/assistant_response/web_sources_event.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/assistant_response/web_sources_event.tsx
@@ -14,7 +14,10 @@ import styles from './web_sources_event.module.scss'
 
 const UNEXPANDED_SOURCES_COUNT = 4;
 
-function WebSource (props: { source: mojom.WebSource }) {
+function WebSource (props: {
+    source: mojom.WebSource,
+    citationNumber: number
+  }) {
   const context = useUntrustedConversationContext()
 
   const { source } = props
@@ -33,7 +36,7 @@ function WebSource (props: { source: mojom.WebSource }) {
     <li>
       <a href={source.url.url} title={source.title} onClick={(e) => handleOpenSource(e, source)}>
         <img src={faviconSrc} />
-        {host}
+        {props.citationNumber} - {host}
       </a>
     </li>
   )
@@ -49,7 +52,13 @@ export default function WebSourcesEvent (props: { sources: mojom.WebSource[] }) 
     <div className={styles.sources}>
       <h4>{getLocale('sources')}</h4>
       <ul>
-        {unhiddenSources.map(source => <WebSource key={source.url.url} source={source} />)}
+        {unhiddenSources.map((source, index) =>
+          <WebSource
+            key={source.url.url}
+            source={source}
+            citationNumber={index + 1}
+          />
+        )}
         {!isExpanded && hiddenSources.length > 0 && (
           <li>
             <button name='expand' onClick={() => setIsExpanded(true)}>
@@ -58,7 +67,13 @@ export default function WebSourcesEvent (props: { sources: mojom.WebSource[] }) 
             </button>
           </li>
         )}
-        {isExpanded && hiddenSources.map(source => <WebSource key={source.url.url} source={source} />)}
+        {isExpanded && hiddenSources.map((source, index) =>
+          <WebSource
+            key={source.url.url}
+            source={source}
+            citationNumber={index + UNEXPANDED_SOURCES_COUNT + 1}
+          />
+        )}
       </ul>
     </div>
   )

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/conversation_entries/conversation_entries_utils.test.ts
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/conversation_entries/conversation_entries_utils.test.ts
@@ -3,7 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import { getReasoningText } from './conversation_entries_utils'
+import { getReasoningText, removeReasoning } from './conversation_entries_utils'
 
 describe('getReasoningText', () => {
   it('Should extract reasoning text between start and end tags', () => {
@@ -30,5 +30,32 @@ describe('getReasoningText', () => {
   it('Should handle removing white space around reasoning text', () => {
     const input = '<think> Reasoning text here. </think>'
     expect(getReasoningText(input)).toBe('Reasoning text here.')
+  })
+})
+
+describe('removeReasoning', () => {
+  it('Should remove reasoning text between start and end tags', () => {
+    const input = '<think>Reasoning text here.</think> Rest of the text.'
+    expect(removeReasoning(input)).toBe(' Rest of the text.')
+  })
+
+  it('Should not fail if there is an empty string', () => {
+    const input = ''
+    expect(removeReasoning(input)).toBe('')
+  })
+
+  it('Should not fail if there is no reasoning text', () => {
+    const input = 'Rest of the text.'
+    expect(removeReasoning(input)).toBe('Rest of the text.')
+  })
+
+  it('should not fail if there is not ending tag', () => {
+    const input = '<think>Reasoning text here.'
+    expect(removeReasoning(input)).toBe('<think>Reasoning text here.')
+  })
+
+  it('should not fail if there is not starting tag', () => {
+    const input = 'Reasoning text here.</think>'
+    expect(removeReasoning(input)).toBe('Reasoning text here.</think>')
   })
 })

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/conversation_entries/conversation_entries_utils.ts
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/conversation_entries/conversation_entries_utils.ts
@@ -48,3 +48,9 @@ export const getReasoningText = (text: string) => {
 
   return result.trim()
 }
+
+export const removeReasoning = (text: string) => {
+  return text.includes('<think>') && text.includes('</think>')
+    ? text.split('</think>')[1]
+    : text
+}

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/markdown_renderer/index.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/markdown_renderer/index.tsx
@@ -7,7 +7,7 @@ import * as React from 'react'
 import Markdown from 'react-markdown'
 import type { Root, Element as HastElement } from 'hast'
 import { Url } from 'gen/url/mojom/url.mojom.m.js'
-
+import Label from '@brave/leo/react/label'
 import { visit } from 'unist-util-visit'
 
 import styles from './style.module.scss'
@@ -15,10 +15,6 @@ import CaretSVG from '../svg/caret'
 import {
   useUntrustedConversationContext //
 } from '../../untrusted_conversation_context'
-
-const removeReasoning = (text: string) => {
-  return text.includes('<think>') ? text.split('</think>')[1] : text
-}
 
 const CodeBlock = React.lazy(async () => ({
   default: (await import('../code_block')).default.Block
@@ -115,14 +111,31 @@ export function RenderLink(props: RenderLinkProps) {
 
   const isCitation = typeof children === 'string' && /^\d+$/.test(children)
 
+  if (isCitation) {
+    return (
+      <Label>
+        <a
+          // While we preventDefault, we still need to pass the href
+          // here so we can continue to show link previews.
+          href={href}
+          className={styles.citation}
+          onClick={(e) => {
+            e.preventDefault()
+            handleLinkClicked()
+          }}
+        >
+          {children}
+        </a>
+      </Label>
+    )
+  }
+
   return (
     <a
       // While we preventDefault, we still need to pass the href
       // here so we can continue to show link previews.
       href={href}
-      className={`${styles.conversationLink}${
-        isCitation ? ` ${styles.citation}` : ''
-      }`}
+      className={styles.conversationLink}
       onClick={(e) => {
         e.preventDefault()
         handleLinkClicked()
@@ -169,7 +182,7 @@ export default function MarkdownRenderer(mainProps: MarkdownRendererProps) {
         // if the component is allowed to show the text cursor.
         rehypePlugins={mainProps.shouldShowTextCursor ? [plugin] : undefined}
         unwrapDisallowed={true}
-        children={removeReasoning(mainProps.text)}
+        children={mainProps.text}
         components={{
           p: (props) => (
             <CursorDecorator

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/markdown_renderer/render_link.test.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/markdown_renderer/render_link.test.tsx
@@ -39,9 +39,20 @@ test('Test RenderLink component with citations.', async () => {
       allowedLinks={['https://brave.com']}
     />
   )
-  expect(screen.getByText('1')).toBeInTheDocument()
-  expect(screen.getByText('1').tagName).toBe('A')
-  expect(screen.getByText('1').className).toBe('conversationLink citation')
+
+  // Make sure the label is visible
+  const label = document.querySelector<HTMLDivElement>('leo-label')
+  expect(label).toBeInTheDocument()
+  expect(label).toBeVisible()
+  expect(label).toHaveTextContent('1')
+
+  // Make sure the citation is visible
+  const citation = document.querySelector<HTMLAnchorElement>('.citation')
+  expect(citation).toBeInTheDocument()
+  expect(citation).toBeVisible()
+  expect(citation).toHaveTextContent('1')
+  expect(citation?.tagName).toBe('A')
+  expect(citation?.className).toBe('citation')
 })
 
 test('Test RenderLink component with disableLinkRestrictions.', async () => {

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/markdown_renderer/style.module.scss
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/markdown_renderer/style.module.scss
@@ -83,30 +83,15 @@
 
 .conversationLink {
   cursor: pointer;
-  background: none;
-  border: none;
-  margin: 0px;
-  padding: 0px;
   text-decoration: underline;
   color: var(--leo-color-text-primary);
   &:hover {
     color: var(--leo-color-text-interactive);
   }
+}
 
-  &.citation {
-    font-size: 0.75em;
-    vertical-align: super;
-    text-decoration: none;
-    color: var(--leo-color-text-secondary); /* make it more subtle */
-    margin-left: 0.15em;
-
-    &:first-child {
-      margin-left: 0; /* don't add space to the first one */
-    }
-
-    &:hover {
-      text-decoration: underline;
-      color: var(--leo-color-text-interactive);
-    }
-  }
+.citation {
+  cursor: pointer;
+  text-decoration: none;
+  color: var(--leo-color-text-secondary);
 }


### PR DESCRIPTION
## Description 

Improvements to the `Citation` UI
- Citation numbers in the response are now wrapped in a `Label`
- Web sources will now display the citation number next to the host
- Web sources will now be listed above the search summary.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/45761>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

## Test Plan:

1. Start a new conversation with `Leo AI` that would return `Citations` for example ('What races has Brian Bondy participated in?`)
2. Once there is a response, test that the citation `Number` url matches the `Number` of a websource
3. Ensure that `Sources` is listed above `Search` summary

Before:

![Screenshot 59](https://github.com/user-attachments/assets/dcbaf3f4-63cf-4d18-bc42-53ec9d7bc9f7)

After:

![Screenshot 60](https://github.com/user-attachments/assets/b1ade0ed-3e9d-4c84-9104-fc464758cbaf)
