### PR TITLE
[Sync] Cherry-pick of upstream commit to revert CHECKs back to DCHECKs

### DIFF
--- a/patches/components-sync-model-processor_entity.cc.patch
+++ b/patches/components-sync-model-processor_entity.cc.patch
@@ -1,0 +1,151 @@
+diff --git a/components/sync/model/processor_entity.cc b/components/sync/model/processor_entity.cc
+index dc299bb3424c1da9fa4657a0729bef579e970603..fe3eb7cf008169c1c5d974ad7296589ce7e71ee1 100644
+--- a/components/sync/model/processor_entity.cc
++++ b/components/sync/model/processor_entity.cc
+@@ -33,7 +33,7 @@ bool MetadataIsValid(const sync_pb::EntityMetadata& metadata) {
+ }
+ 
+ std::string HashSpecifics(const sync_pb::EntitySpecifics& specifics) {
+-  CHECK_GT(specifics.ByteSizeLong(), 0u, base::NotFatalUntil::M141);
++  DCHECK_GT(specifics.ByteSizeLong(), 0u);
+   return base::Base64Encode(
+       base::SHA1HashString(specifics.SerializeAsString()));
+ }
+@@ -64,7 +64,7 @@ std::unique_ptr<ProcessorEntity> ProcessorEntity::CreateNew(
+ std::unique_ptr<ProcessorEntity> ProcessorEntity::CreateFromMetadata(
+     const std::string& storage_key,
+     sync_pb::EntityMetadata metadata) {
+-  CHECK(!storage_key.empty(), base::NotFatalUntil::M141);
++  DCHECK(!storage_key.empty());
+   if (!MetadataIsValid(metadata)) {
+     return nullptr;
+   }
+@@ -83,8 +83,8 @@ ProcessorEntity::ProcessorEntity(const std::string& storage_key,
+ ProcessorEntity::~ProcessorEntity() = default;
+ 
+ void ProcessorEntity::SetStorageKey(const std::string& storage_key) {
+-  CHECK(storage_key_.empty(), base::NotFatalUntil::M141);
+-  CHECK(!storage_key.empty(), base::NotFatalUntil::M141);
++  DCHECK(storage_key_.empty());
++  DCHECK(!storage_key.empty());
+   storage_key_ = storage_key;
+ }
+ 
+@@ -93,7 +93,7 @@ void ProcessorEntity::ClearStorageKey() {
+ }
+ 
+ void ProcessorEntity::SetCommitData(std::unique_ptr<EntityData> data) {
+-  CHECK(data);
++  DCHECK(data);
+   // Update data's fields from metadata.
+   data->client_tag_hash =
+       ClientTagHash::FromHashed(metadata_.client_tag_hash());
+@@ -104,7 +104,7 @@ void ProcessorEntity::SetCommitData(std::unique_ptr<EntityData> data) {
+   data->modification_time = ProtoTimeToTime(metadata_.modification_time());
+ 
+   commit_data_ = std::move(data);
+-  CHECK(HasCommitData());
++  DCHECK(HasCommitData());
+ }
+ 
+ bool ProcessorEntity::HasCommitData() const {
+@@ -120,23 +120,20 @@ bool ProcessorEntity::MatchesData(const EntityData& data) const {
+   }
+   // Do not check for unique position changes explicitly because they are
+   // supposed to be in specifics.
+-  CHECK_GT(data.specifics.ByteSizeLong(), 0u, base::NotFatalUntil::M141);
+-  return HashSpecifics(data.specifics) == metadata_.specifics_hash();
++  return MatchesSpecificsHash(data.specifics);
+ }
+ 
+ bool ProcessorEntity::MatchesOwnBaseData() const {
+-  // The `base_specifics_hash` is only set if the entity is unsynced.
+-  CHECK(IsUnsynced(), base::NotFatalUntil::M141);
++  DCHECK(IsUnsynced());
+   if (metadata_.is_deleted()) {
+     return false;
+   }
+-  CHECK(!metadata_.specifics_hash().empty(), base::NotFatalUntil::M141);
++  DCHECK(!metadata_.specifics_hash().empty());
+   return metadata_.specifics_hash() == metadata_.base_specifics_hash();
+ }
+ 
+ bool ProcessorEntity::MatchesBaseData(const EntityData& data) const {
+-  // The `base_specifics_hash` is only set if the entity is unsynced.
+-  CHECK(IsUnsynced(), base::NotFatalUntil::M141);
++  DCHECK(IsUnsynced());
+   if (data.is_deleted() || metadata_.base_specifics_hash().empty()) {
+     return false;
+   }
+@@ -165,18 +162,17 @@ bool ProcessorEntity::IsVersionAlreadyKnown(int64_t update_version) const {
+ 
+ void ProcessorEntity::RecordIgnoredRemoteUpdate(
+     const UpdateResponseData& update) {
+-  CHECK(metadata_.server_id().empty() ||
+-            metadata_.server_id() == update.entity.id,
+-        base::NotFatalUntil::M141);
++  DCHECK(metadata_.server_id().empty() ||
++         metadata_.server_id() == update.entity.id);
+   metadata_.set_server_id(update.entity.id);
+   metadata_.set_server_version(update.response_version);
+   // Either these already matched, acked was just bumped to squash a pending
+   // commit and this should follow, or the pending commit needs to be requeued.
+   commit_requested_sequence_number_ = metadata_.acked_sequence_number();
+-  // If a local change was made while the server assigned a new id to the
+-  // entity, update the id in cached commit data.
++  // If local change was made while server assigned a new id to the entity,
++  // update id in cached commit data.
+   if (HasCommitData() && commit_data_->id != metadata_.server_id()) {
+-    CHECK(commit_data_->id.empty(), base::NotFatalUntil::M141);
++    DCHECK(commit_data_->id.empty());
+     commit_data_->id = metadata_.server_id();
+   }
+ }
+@@ -185,7 +181,7 @@ void ProcessorEntity::RecordAcceptedRemoteUpdate(
+     const UpdateResponseData& update,
+     sync_pb::EntitySpecifics trimmed_specifics,
+     std::optional<sync_pb::UniquePosition> unique_position) {
+-  CHECK(!IsUnsynced(), base::NotFatalUntil::M141);
++  DCHECK(!IsUnsynced());
+   RecordIgnoredRemoteUpdate(update);
+   metadata_.set_is_deleted(update.entity.is_deleted());
+   metadata_.set_modification_time(
+@@ -234,6 +230,8 @@ void ProcessorEntity::RecordLocalUpdate(
+     std::unique_ptr<EntityData> data,
+     sync_pb::EntitySpecifics trimmed_specifics,
+     std::optional<sync_pb::UniquePosition> unique_position) {
++  DCHECK(!metadata_.client_tag_hash().empty());
++
+   // Update metadata fields from updated data.
+   base::Time modification_time = !data->modification_time.is_null()
+                                      ? data->modification_time
+@@ -318,11 +316,10 @@ bool ProcessorEntity::RecordLocalDeletion(const DeletionOrigin& origin) {
+ 
+ void ProcessorEntity::InitializeCommitRequestData(CommitRequestData* request) {
+   if (!metadata_.is_deleted()) {
+-    CHECK(HasCommitData(), base::NotFatalUntil::M141);
+-    CHECK_EQ(commit_data_->client_tag_hash.value(), metadata_.client_tag_hash(),
+-             base::NotFatalUntil::M141);
+-    CHECK_EQ(commit_data_->id, metadata_.server_id(),
+-             base::NotFatalUntil::M141);
++    DCHECK(HasCommitData());
++    DCHECK_EQ(commit_data_->client_tag_hash.value(),
++              metadata_.client_tag_hash());
++    DCHECK_EQ(commit_data_->id, metadata_.server_id());
+     request->entity = std::move(commit_data_);
+   } else {
+     // Make an EntityData with empty specifics to indicate deletion. This is
+@@ -406,6 +403,13 @@ size_t ProcessorEntity::EstimateMemoryUsage() const {
+   return memory_usage;
+ }
+ 
++bool ProcessorEntity::MatchesSpecificsHash(
++    const sync_pb::EntitySpecifics& specifics) const {
++  DCHECK(!metadata_.is_deleted());
++  DCHECK_GT(specifics.ByteSizeLong(), 0u);
++  return HashSpecifics(specifics) == metadata_.specifics_hash();
++}
++
+ void ProcessorEntity::UpdateSpecificsHash(
+     const sync_pb::EntitySpecifics& specifics) {
+   if (specifics.ByteSizeLong() > 0) {

--- a/patches/components-sync-model-processor_entity.h.patch
+++ b/patches/components-sync-model-processor_entity.h.patch
@@ -1,0 +1,66 @@
+diff --git a/components/sync/model/processor_entity.h b/components/sync/model/processor_entity.h
+index 007b5387726e3f90cb5c92070ca29bcc1db5c832..4410fc931b1c8551d013f40d6ad665ee81a53ff3 100644
+--- a/components/sync/model/processor_entity.h
++++ b/components/sync/model/processor_entity.h
+@@ -44,9 +44,8 @@ class ProcessorEntity {
+       const std::string& server_id,
+       base::Time creation_time);
+ 
+-  // Construct an instance representing an item loaded from storage on init. The
+-  // passed-in `storage_key` must not be empty. May return nullptr if the
+-  // passed-in `metadata` is invalid.
++  // Construct an instance representing an item loaded from storage on init. May
++  // return nullptr if the passed-in `metadata` is invalid.
+   static std::unique_ptr<ProcessorEntity> CreateFromMetadata(
+       const std::string& storage_key,
+       sync_pb::EntityMetadata metadata);
+@@ -108,9 +107,8 @@ class ProcessorEntity {
+   // previously committed to server and tombstone should be sent.
+   bool RecordLocalDeletion(const DeletionOrigin& origin);
+ 
+-  // Initializes a message representing this item's uncommitted state. Assumes
+-  // that the message is forwarded to the sync engine for committing, i.e.
+-  // clears local commit data.
++  // Initializes a message representing this item's uncommitted state
++  // and assumes that it is forwarded to the sync engine for committing.
+   void InitializeCommitRequestData(CommitRequestData* request);
+ 
+   // Receives a successful commit response.
+@@ -137,21 +135,20 @@ class ProcessorEntity {
+   void ClearStorageKey();
+ 
+   // Takes the passed commit data updates its fields with values from metadata
+-  // and caches it in the instance. `data` must not be null.
++  // and caches it in the instance.
+   void SetCommitData(std::unique_ptr<EntityData> data);
+ 
+-  // Checks if the instance has cached commit data.
++  // Check if the instance has cached commit data.
+   bool HasCommitData() const;
+ 
+-  // Checks whether `data` matches the stored specifics hash.
++  // Check whether `data` matches the stored specifics hash.
+   bool MatchesData(const EntityData& data) const;
+ 
+-  // Checks whether the current metadata matches the stored base specifics hash.
+-  // Must only be called if `IsUnsynced()` is true.
++  // Check whether the current metadata of an unsynced entity matches the stored
++  // base specifics hash.
+   bool MatchesOwnBaseData() const;
+ 
+-  // Check whether `data` matches the stored base specifics hash. Must only be
+-  // called if `IsUnsynced()` is true.
++  // Check whether `data` matches the stored base specifics hash.
+   bool MatchesBaseData(const EntityData& data) const;
+ 
+   // Increment sequence number in the metadata. This will also update the
+@@ -167,6 +164,9 @@ class ProcessorEntity {
+   ProcessorEntity(const std::string& storage_key,
+                   sync_pb::EntityMetadata metadata);
+ 
++  // Check whether `specifics` matches the stored specifics_hash.
++  bool MatchesSpecificsHash(const sync_pb::EntitySpecifics& specifics) const;
++
+   // Updates hash string for EntitySpecifics in the metadata.
+   void UpdateSpecificsHash(const sync_pb::EntitySpecifics& specifics);
+ 


### PR DESCRIPTION
This is cherry-pick of upstream's commit `35b700af4f3e058dbb7b84346e4d293408d09736`

The `CHECK(<expr>, base::NotFatalUntil::M141)` causes thousands reports at backtrace, https://share.backtrace.io/api/share/W5WX1724ibAkwmqujo2ep0 . It looks like the issue is not completely solved at the upstream.
Reverting here through patch for the case if the next minor `cr137` bump will not have the commit. At the upstream it was landed on `137.0.7151.79`.

Chromium commit
https://source.chromium.org/chromium/chromium/src/+/35b700af4f3e058dbb7b84346e4d293408d09736
```
[M137] Revert "Sync ProcessorEntity: Upgrade remaining DCHECKs"
...
```

Resolves https://github.com/brave/brave-browser/issues/46539


<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
