### PR TITLE
Fixed crash when swaps in split tabs with `SideBySide`

### DIFF
--- a/browser/ui/views/frame/brave_browser_view.cc
+++ b/browser/ui/views/frame/brave_browser_view.cc
@@ -10,7 +10,6 @@
 #include <map>
 #include <memory>
 #include <optional>
-#include <utility>
 #include <vector>
 
 #include "base/containers/contains.h"
@@ -36,6 +35,7 @@
 #include "brave/browser/ui/views/brave_shields/cookie_list_opt_in_bubble_host.h"
 #include "brave/browser/ui/views/frame/brave_contents_layout_manager.h"
 #include "brave/browser/ui/views/frame/brave_contents_view_util.h"
+#include "brave/browser/ui/views/frame/split_view/brave_multi_contents_view.h"
 #include "brave/browser/ui/views/frame/vertical_tab_strip_region_view.h"
 #include "brave/browser/ui/views/frame/vertical_tab_strip_widget_delegate_view.h"
 #include "brave/browser/ui/views/location_bar/brave_location_bar_view.h"
@@ -808,12 +808,30 @@ void BraveBrowserView::ShowSplitView() {
   BrowserView::ShowSplitView();
 
   UpdateContentsSeparatorVisibility();
+  GetBraveMultiContentsView()->UpdateSecondaryLocationBar();
 }
 
 void BraveBrowserView::HideSplitView() {
   BrowserView::HideSplitView();
 
   UpdateContentsSeparatorVisibility();
+}
+
+void BraveBrowserView::UpdateActiveSplitView() {
+  BrowserView::UpdateActiveSplitView();
+  GetBraveMultiContentsView()->UpdateSecondaryLocationBar();
+}
+
+void BraveBrowserView::OnSplitTabContentsUpdated(
+    split_tabs::SplitTabId split_id,
+    std::vector<std::pair<tabs::TabInterface*, int>> prev_tabs,
+    std::vector<std::pair<tabs::TabInterface*, int>> new_tabs) {
+  BrowserView::OnSplitTabContentsUpdated(split_id, prev_tabs, new_tabs);
+  GetBraveMultiContentsView()->UpdateSecondaryLocationBar();
+}
+
+BraveMultiContentsView* BraveBrowserView::GetBraveMultiContentsView() const {
+  return BraveMultiContentsView::From(multi_contents_view_);
 }
 
 bool BraveBrowserView::ShouldShowWindowTitle() const {

--- a/browser/ui/views/frame/brave_browser_view.h
+++ b/browser/ui/views/frame/brave_browser_view.h
@@ -9,6 +9,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "base/gtest_prod_util.h"
@@ -59,6 +60,7 @@ class Widget;
 
 class BraveBrowser;
 class BraveHelpBubbleHostView;
+class BraveMultiContentsView;
 class ContentsLayoutManager;
 class SidebarContainerView;
 class SidePanelEntry;
@@ -184,6 +186,12 @@ class BraveBrowserView : public BrowserView,
   void GetAccessiblePanes(std::vector<views::View*>* panes) override;
   void ShowSplitView() override;
   void HideSplitView() override;
+  void UpdateActiveSplitView() override;
+
+  void OnSplitTabContentsUpdated(
+      split_tabs::SplitTabId split_id,
+      std::vector<std::pair<tabs::TabInterface*, int>> prev_tabs,
+      std::vector<std::pair<tabs::TabInterface*, int>> new_tabs) override;
 
   void StopTabCycling();
   void UpdateSearchTabsButtonState();
@@ -206,7 +214,7 @@ class BraveBrowserView : public BrowserView,
 #endif
 
   void UpdateSideBarHorizontalAlignment();
-
+  BraveMultiContentsView* GetBraveMultiContentsView() const;
   views::View* contents_separator_for_testing() const {
     return contents_separator_;
   }

--- a/browser/ui/views/frame/split_view/brave_multi_contents_view.cc
+++ b/browser/ui/views/frame/split_view/brave_multi_contents_view.cc
@@ -24,6 +24,12 @@ namespace {
 constexpr auto kSpacingBetweenContentsWebViews = 4;
 }  // namespace
 
+// static
+BraveMultiContentsView* BraveMultiContentsView::From(MultiContentsView* view) {
+  CHECK(view);
+  return static_cast<BraveMultiContentsView*>(view);
+}
+
 BraveMultiContentsView::BraveMultiContentsView(
     BrowserView* browser_view,
     WebContentsFocusedCallback inactive_contents_focused_callback,
@@ -109,12 +115,6 @@ void BraveMultiContentsView::Layout(PassKey) {
   contents_container_views_[1]->SetBoundsRect(end_rect);
 }
 
-void BraveMultiContentsView::SetActiveIndex(int index) {
-  MultiContentsView::SetActiveIndex(index);
-
-  UpdateSecondaryLocationBar();
-}
-
 float BraveMultiContentsView::GetCornerRadius() const {
   return BraveBrowser::ShouldUseBraveWebViewRoundedCorners(
              browser_view_->browser())
@@ -142,7 +142,7 @@ void BraveMultiContentsView::UpdateSecondaryLocationBar() {
   // as it's attached to inactive contents view.
   int inactive_index = active_index_ == 0 ? 1 : 0;
   secondary_location_bar_->SetWebContents(
-      GetInactiveContentsView()->GetWebContents());
+      GetInactiveContentsView()->web_contents());
   secondary_location_bar_->SetParentWebView(
       contents_container_views_[inactive_index]);
 

--- a/browser/ui/views/frame/split_view/brave_multi_contents_view.h
+++ b/browser/ui/views/frame/split_view/brave_multi_contents_view.h
@@ -27,11 +27,15 @@ class BraveMultiContentsView : public MultiContentsView,
  public:
   static constexpr int kBorderThickness = 2;
 
+  static BraveMultiContentsView* From(MultiContentsView* view);
+
   BraveMultiContentsView(
       BrowserView* browser_view,
       WebContentsFocusedCallback inactive_contents_focused_callback,
       WebContentsResizeCallback contents_resize_callback);
   ~BraveMultiContentsView() override;
+
+  void UpdateSecondaryLocationBar();
 
  private:
   friend class SplitViewLocationBarBrowserTest;
@@ -42,13 +46,11 @@ class BraveMultiContentsView : public MultiContentsView,
   // MultiContentsView:
   void UpdateContentsBorder() override;
   void Layout(PassKey) override;
-  void SetActiveIndex(int index) override;
 
   // SplitViewSeparatorDelegate:
   void OnDoubleClicked() override;
 
   float GetCornerRadius() const;
-  void UpdateSecondaryLocationBar();
 
   std::vector<ContentsContainerView*> contents_container_views_for_testing()
       const {

--- a/browser/ui/views/split_view/split_view_browsertest.cc
+++ b/browser/ui/views/split_view/split_view_browsertest.cc
@@ -252,12 +252,15 @@ IN_PROC_BROWSER_TEST_F(SideBySideEnabledBrowserTest, SelectTabTest) {
             insets + gfx::Insets::TLBR(0, 0, 4, 0));
 
   // Check active tab is not changed after swap.
+  // Active tab index is changed after swap.
   auto* tab_strip_model = browser()->tab_strip_model();
   EXPECT_EQ(5, tab_strip_model->active_index());
   auto split_id = tab_strip_model->GetSplitForTab(4);
   ASSERT_TRUE(split_id);
   tab_strip_model->SwapTabsInSplit(split_id.value());
   EXPECT_EQ(4, tab_strip_model->active_index());
+  tab_strip_model->SwapTabsInSplit(split_id.value());
+  EXPECT_EQ(5, tab_strip_model->active_index());
 }
 
 class SplitViewBrowserTest : public InProcessBrowserTest {

--- a/browser/ui/views/split_view/split_view_browsertest.cc
+++ b/browser/ui/views/split_view/split_view_browsertest.cc
@@ -250,6 +250,14 @@ IN_PROC_BROWSER_TEST_F(SideBySideEnabledBrowserTest, SelectTabTest) {
             insets + gfx::Insets::TLBR(4, 0, 0, 0));
   EXPECT_EQ(tab_strip()->tab_at(5)->GetBorder()->GetInsets(),
             insets + gfx::Insets::TLBR(0, 0, 4, 0));
+
+  // Check active tab is not changed after swap.
+  auto* tab_strip_model = browser()->tab_strip_model();
+  EXPECT_EQ(5, tab_strip_model->active_index());
+  auto split_id = tab_strip_model->GetSplitForTab(4);
+  ASSERT_TRUE(split_id);
+  tab_strip_model->SwapTabsInSplit(split_id.value());
+  EXPECT_EQ(4, tab_strip_model->active_index());
 }
 
 class SplitViewBrowserTest : public InProcessBrowserTest {

--- a/chromium_src/chrome/browser/ui/views/frame/browser_view.h
+++ b/chromium_src/chrome/browser/ui/views/frame/browser_view.h
@@ -52,9 +52,11 @@
 #define LoadAccelerators virtual LoadAccelerators
 #define ShowSplitView virtual ShowSplitView
 #define HideSplitView virtual HideSplitView
+#define UpdateActiveSplitView virtual UpdateActiveSplitView
 
 #include "src/chrome/browser/ui/views/frame/browser_view.h"  // IWYU pragma: export
 
+#undef UpdateActiveSplitView
 #undef HideSplitView
 #undef ShowSplitView
 #undef LoadAccelerators

--- a/chromium_src/chrome/browser/ui/views/frame/multi_contents_view.h
+++ b/chromium_src/chrome/browser/ui/views/frame/multi_contents_view.h
@@ -15,15 +15,12 @@ class ResizeArea;
   friend class BraveMultiContentsView; \
   virtual void UpdateContentsBorder
 
-#define SetActiveIndex virtual SetActiveIndex
-
 // Changed to base class as we want to point to our views::ResizeArea subclass.
 #define MultiContentsResizeArea views::ResizeArea
 
 #include "src/chrome/browser/ui/views/frame/multi_contents_view.h"  // IWYU pragma: export
 
 #undef MultiContentsResizeArea
-#undef SetActiveIndex
 #undef UpdateContentsBorder
 
 #endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_FRAME_MULTI_CONTENTS_VIEW_H_


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/46588

Crash happened because SecurityStateTabHelper was null for inactive tab in split tabs.
It should not be null because split view location bar fetches tab's current security status indirectly via ChromeLocationBarModelDelegate.

So far, BraveMultiContentsView calls UpdateSecondaryLocationBar() whenever SetActiveIndex()
is called. If SetActiveIndex() is called after proper WebContents are set on both inactive/active
web view in split tabs, there is no crash. However, SetActiveIndex() could be called if one of them is cleared state.
At BrowserView::OnSplitTabContentsUpdated(), that can happen.
So, WebView::GetWebContents() created another WebContents accidently and that created WebContents doesn't have
SecurityStateTabHelper. To prevent creating it, calling `GetWebContents()` is replaced with `web_contents()`.

To fix this, called UpdateSecondaryLocationBar() after proper WebContents are set on inactive/active webview in split tabs.

TEST=`SideBySideEnabledBrowserTest.SelectTabTest`

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
