### PR TITLE
[CodeHealth] Avoid unnecessary `EXPECT_STREQ` uses

### DIFF
--- a/browser/brave_content_browser_client_browsertest.cc
+++ b/browser/brave_content_browser_client_browsertest.cc
@@ -168,22 +168,17 @@ IN_PROC_BROWSER_TEST_F(BraveContentBrowserClientTest, CanLoadChromeURL) {
           ui_test_utils::NavigateToURL(browser(), GURL(scheme + page + "/")));
       ASSERT_TRUE(WaitForLoadStop(contents));
 
-      EXPECT_STREQ(base::UTF16ToUTF8(
-                       browser()->location_bar_model()->GetFormattedFullURL())
-                       .c_str(),
-                   ("brave://" + page).c_str());
-      EXPECT_STREQ(contents->GetController()
-                       .GetLastCommittedEntry()
-                       ->GetVirtualURL()
-                       .spec()
-                       .c_str(),
-                   ("chrome://" + page + "/").c_str());
-      EXPECT_STREQ(contents->GetController()
-                       .GetLastCommittedEntry()
-                       ->GetURL()
-                       .spec()
-                       .c_str(),
-                   ("chrome://" + page + "/").c_str());
+      EXPECT_EQ(base::UTF16ToUTF8(
+                    browser()->location_bar_model()->GetFormattedFullURL()),
+                ("brave://" + page));
+      EXPECT_EQ(contents->GetController()
+                    .GetLastCommittedEntry()
+                    ->GetVirtualURL()
+                    .spec(),
+                ("chrome://" + page + "/"));
+      EXPECT_EQ(
+          contents->GetController().GetLastCommittedEntry()->GetURL().spec(),
+          ("chrome://" + page + "/"));
     }
   }
 }
@@ -206,22 +201,17 @@ IN_PROC_BROWSER_TEST_F(BraveContentBrowserClientTest, CanLoadCustomBravePages) {
           ui_test_utils::NavigateToURL(browser(), GURL(scheme + page + "/")));
       ASSERT_TRUE(WaitForLoadStop(contents));
 
-      EXPECT_STREQ(base::UTF16ToUTF8(
-                       browser()->location_bar_model()->GetFormattedFullURL())
-                       .c_str(),
-                   ("brave://" + page).c_str());
-      EXPECT_STREQ(contents->GetController()
-                       .GetLastCommittedEntry()
-                       ->GetVirtualURL()
-                       .spec()
-                       .c_str(),
-                   ("chrome://" + page + "/").c_str());
-      EXPECT_STREQ(contents->GetController()
-                       .GetLastCommittedEntry()
-                       ->GetURL()
-                       .spec()
-                       .c_str(),
-                   ("chrome://" + page + "/").c_str());
+      EXPECT_EQ(base::UTF16ToUTF8(
+                    browser()->location_bar_model()->GetFormattedFullURL()),
+                ("brave://" + page));
+      EXPECT_EQ(contents->GetController()
+                    .GetLastCommittedEntry()
+                    ->GetVirtualURL()
+                    .spec(),
+                ("chrome://" + page + "/"));
+      EXPECT_EQ(
+          contents->GetController().GetLastCommittedEntry()->GetURL().spec(),
+          ("chrome://" + page + "/"));
     }
   }
 }
@@ -239,22 +229,17 @@ IN_PROC_BROWSER_TEST_F(BraveContentBrowserClientTest, CanLoadAboutHost) {
         ui_test_utils::NavigateToURL(browser(), GURL(scheme + "about/")));
     ASSERT_TRUE(WaitForLoadStop(contents));
 
-    EXPECT_STREQ(base::UTF16ToUTF8(
-                     browser()->location_bar_model()->GetFormattedFullURL())
-                     .c_str(),
-                 "brave://about");
-    EXPECT_STREQ(contents->GetController()
-                     .GetLastCommittedEntry()
-                     ->GetVirtualURL()
-                     .spec()
-                     .c_str(),
-                 "chrome://about/");
-    EXPECT_STREQ(contents->GetController()
-                     .GetLastCommittedEntry()
-                     ->GetURL()
-                     .spec()
-                     .c_str(),
-                 "chrome://chrome-urls/");
+    EXPECT_EQ(base::UTF16ToUTF8(
+                  browser()->location_bar_model()->GetFormattedFullURL()),
+              "brave://about");
+    EXPECT_EQ(contents->GetController()
+                  .GetLastCommittedEntry()
+                  ->GetVirtualURL()
+                  .spec(),
+              "chrome://about/");
+    EXPECT_EQ(
+        contents->GetController().GetLastCommittedEntry()->GetURL().spec(),
+        "chrome://chrome-urls/");
   }
 }
 IN_PROC_BROWSER_TEST_F(BraveContentBrowserClientTest, RewriteChromeSync) {
@@ -270,10 +255,9 @@ IN_PROC_BROWSER_TEST_F(BraveContentBrowserClientTest, RewriteChromeSync) {
                                     GURL(scheme + chrome::kBraveUISyncHost),
                                     GURL("chrome://sync"));
 
-    EXPECT_STREQ(base::UTF16ToUTF8(
-                     browser()->location_bar_model()->GetFormattedFullURL())
-                     .c_str(),
-                 "brave://sync");
+    EXPECT_EQ(base::UTF16ToUTF8(
+                  browser()->location_bar_model()->GetFormattedFullURL()),
+              "brave://sync");
     EXPECT_EQ(
         contents->GetController().GetLastCommittedEntry()->GetVirtualURL(),
         GURL("chrome://sync"));
@@ -293,10 +277,9 @@ IN_PROC_BROWSER_TEST_F(BraveContentBrowserClientTest, RewriteAdblock) {
         browser()->tab_strip_model()->GetActiveWebContents();
     NavigateToURLAndWaitForRewrites(contents, GURL(scheme + "adblock"),
                                     GURL("chrome://settings/shields/filters"));
-    EXPECT_STREQ(base::UTF16ToUTF8(
-                     browser()->location_bar_model()->GetFormattedFullURL())
-                     .c_str(),
-                 "brave://settings/shields/filters");
+    EXPECT_EQ(base::UTF16ToUTF8(
+                  browser()->location_bar_model()->GetFormattedFullURL()),
+              "brave://settings/shields/filters");
     EXPECT_EQ(browser()->location_bar_model()->GetURL(),
               GURL("chrome://settings/shields/filters"));
     EXPECT_EQ(
@@ -313,12 +296,11 @@ IN_PROC_BROWSER_TEST_F(BraveContentBrowserClientTest, RewriteMagnetURLURLBar) {
 
   ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), magnet_url()));
   ASSERT_TRUE(WaitForLoadStop(contents));
-  EXPECT_STREQ(contents->GetLastCommittedURL().spec().c_str(),
-               magnet_url().spec().c_str())
+  EXPECT_EQ(contents->GetLastCommittedURL().spec(), magnet_url().spec())
       << "URL visible to users should stay as the magnet URL";
   content::NavigationEntry* entry =
       contents->GetController().GetLastCommittedEntry();
-  EXPECT_STREQ(entry->GetURL().spec().c_str(), extension_url().spec().c_str())
+  EXPECT_EQ(entry->GetURL().spec(), extension_url().spec())
       << "Real URL should be extension URL";
 }
 
@@ -334,12 +316,11 @@ IN_PROC_BROWSER_TEST_F(BraveContentBrowserClientTest, RewriteMagnetURLLink) {
   base::RunLoop().RunUntilIdle();
   ASSERT_TRUE(WaitForLoadStop(contents));
 
-  EXPECT_STREQ(contents->GetLastCommittedURL().spec().c_str(),
-               magnet_url().spec().c_str())
+  EXPECT_EQ(contents->GetLastCommittedURL().spec(), magnet_url().spec())
       << "URL visible to users should stay as the magnet URL";
   content::NavigationEntry* entry =
       contents->GetController().GetLastCommittedEntry();
-  EXPECT_STREQ(entry->GetURL().spec().c_str(), extension_url().spec().c_str())
+  EXPECT_EQ(entry->GetURL().spec(), extension_url().spec())
       << "Real URL should be extension URL";
 }
 
@@ -373,8 +354,7 @@ IN_PROC_BROWSER_TEST_F(BraveContentBrowserClientTest,
       << "URL visible to users should stay as the torrent URL";
   content::NavigationEntry* entry =
       contents->GetController().GetLastCommittedEntry();
-  EXPECT_STREQ(entry->GetURL().spec().c_str(),
-               torrent_extension_url().spec().c_str())
+  EXPECT_EQ(entry->GetURL().spec(), torrent_extension_url().spec())
       << "Real URL should be extension URL";
 }
 
@@ -435,13 +415,13 @@ IN_PROC_BROWSER_TEST_F(BraveContentBrowserClientTest,
   ASSERT_TRUE(ui_test_utils::NavigateToURL(
       browser(), torrent_invalid_query_extension_url()));
   ASSERT_TRUE(WaitForLoadStop(contents));
-  EXPECT_STREQ(contents->GetLastCommittedURL().spec().c_str(),
-               torrent_invalid_query_extension_url().spec().c_str())
+  EXPECT_EQ(contents->GetLastCommittedURL().spec(),
+            torrent_invalid_query_extension_url().spec())
       << "URL visible to users should stay as extension URL for invalid query";
   content::NavigationEntry* entry =
       contents->GetController().GetLastCommittedEntry();
-  EXPECT_STREQ(entry->GetURL().spec().c_str(),
-               torrent_invalid_query_extension_url().spec().c_str())
+  EXPECT_EQ(entry->GetURL().spec(),
+            torrent_invalid_query_extension_url().spec())
       << "Real URL should be extension URL";
 }
 
@@ -481,10 +461,10 @@ IN_PROC_BROWSER_TEST_F(BraveContentBrowserClientTest,
       browser()->tab_strip_model()->GetActiveWebContents();
   ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), magnet_url()));
   ASSERT_TRUE(WaitForLoadStop(contents));
-  EXPECT_STREQ(contents->GetLastCommittedURL().spec().c_str(), "about:blank");
+  EXPECT_EQ(contents->GetLastCommittedURL().spec(), "about:blank");
   content::NavigationEntry* entry =
       contents->GetController().GetLastCommittedEntry();
-  EXPECT_STREQ(entry->GetURL().spec().c_str(), "about:blank");
+  EXPECT_EQ(entry->GetURL().spec(), "about:blank");
 }
 
 IN_PROC_BROWSER_TEST_F(BraveContentBrowserClientTest,
@@ -511,12 +491,10 @@ IN_PROC_BROWSER_TEST_F(BraveContentBrowserClientTest,
   base::RunLoop().RunUntilIdle();
   ASSERT_TRUE(WaitForLoadStop(contents));
 
-  EXPECT_STREQ(contents->GetLastCommittedURL().spec().c_str(),
-               magnet_html_url().spec().c_str());
+  EXPECT_EQ(contents->GetLastCommittedURL().spec(), magnet_html_url().spec());
   content::NavigationEntry* entry =
       contents->GetController().GetLastCommittedEntry();
-  EXPECT_STREQ(entry->GetURL().spec().c_str(),
-               magnet_html_url().spec().c_str());
+  EXPECT_EQ(entry->GetURL().spec(), magnet_html_url().spec());
 }
 
 IN_PROC_BROWSER_TEST_F(BraveContentBrowserClientTest,
@@ -538,13 +516,12 @@ IN_PROC_BROWSER_TEST_F(BraveContentBrowserClientTest,
   ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), torrent_extension_url()));
   WaitForLoadStop(contents);
 
-  EXPECT_STREQ(contents->GetLastCommittedURL().spec().c_str(),
-               torrent_extension_url().spec().c_str())
+  EXPECT_EQ(contents->GetLastCommittedURL().spec(),
+            torrent_extension_url().spec())
       << "No changes on the visible URL";
   content::NavigationEntry* entry =
       contents->GetController().GetLastCommittedEntry();
-  EXPECT_STREQ(entry->GetURL().spec().c_str(),
-               torrent_extension_url().spec().c_str())
+  EXPECT_EQ(entry->GetURL().spec(), torrent_extension_url().spec())
       << "No changes on the real URL";
 }
 #endif  // BUILDFLAG(ENABLE_BRAVE_WEBTORRENT)

--- a/browser/brave_scheme_load_browsertest.cc
+++ b/browser/brave_scheme_load_browsertest.cc
@@ -90,10 +90,9 @@ class BraveSchemeLoadBrowserTest : public InProcessBrowserTest,
                       ->GetController()
                       .GetLastCommittedEntry();
     EXPECT_EQ(entry->GetPageType(), content::PageType::PAGE_TYPE_ERROR);
-    EXPECT_STREQ("about:blank",
-                 base::UTF16ToUTF8(
-                     browser()->location_bar_model()->GetFormattedFullURL())
-                     .c_str());
+    EXPECT_EQ("about:blank",
+              base::UTF16ToUTF8(
+                  browser()->location_bar_model()->GetFormattedFullURL()));
     EXPECT_EQ(1, browser()->tab_strip_model()->count());
   }
 
@@ -124,9 +123,8 @@ class BraveSchemeLoadBrowserTest : public InProcessBrowserTest,
 
     browser()->tab_strip_model()->RemoveObserver(this);
 
-    EXPECT_STREQ(url.c_str(),
-                 base::UTF16ToUTF8(browser()->location_bar_model()
-                      ->GetFormattedFullURL()).c_str());
+    EXPECT_EQ(url, base::UTF16ToUTF8(
+                       browser()->location_bar_model()->GetFormattedFullURL()));
     EXPECT_EQ(2, browser()->tab_strip_model()->count());
     // Private window stays as initial state.
     EXPECT_EQ("about:blank",
@@ -153,10 +151,9 @@ class BraveSchemeLoadBrowserTest : public InProcessBrowserTest,
                       ->GetController()
                       .GetLastCommittedEntry();
     EXPECT_EQ(entry->GetPageType(), content::PageType::PAGE_TYPE_ERROR);
-    EXPECT_STREQ("about:blank",
-                 base::UTF16ToUTF8(
-                     browser()->location_bar_model()->GetFormattedFullURL())
-                     .c_str());
+    EXPECT_EQ("about:blank",
+              base::UTF16ToUTF8(
+                  browser()->location_bar_model()->GetFormattedFullURL()));
     EXPECT_EQ(1, browser()->tab_strip_model()->count());
   }
 

--- a/browser/brave_stats/brave_stats_updater_browsertest.cc
+++ b/browser/brave_stats/brave_stats_updater_browsertest.cc
@@ -175,7 +175,7 @@ IN_PROC_BROWSER_TEST_F(BraveStatsUpdaterBrowserTest,
   WaitForStandardStatsUpdatedCallback();
 
   // Dummy URL confirms no request was triggered
-  EXPECT_STREQ(GetUpdateURL().host().c_str(), "no-thanks.invalid");
+  EXPECT_EQ(GetUpdateURL().host(), "no-thanks.invalid");
 
   // No prefs should be updated
   EXPECT_FALSE(g_browser_process->local_state()->GetBoolean(kFirstCheckMade));
@@ -199,11 +199,11 @@ IN_PROC_BROWSER_TEST_F(BraveStatsUpdaterBrowserTest,
   // Verify that daily parameter is true
   std::string query_value;
   EXPECT_TRUE(net::GetValueForKeyInQuery(update_url, "daily", &query_value));
-  EXPECT_STREQ(query_value.c_str(), "true");
+  EXPECT_EQ(query_value, "true");
 
   // Verify that there is no referral code
   EXPECT_TRUE(net::GetValueForKeyInQuery(update_url, "ref", &query_value));
-  EXPECT_STREQ(query_value.c_str(), "BRV001");
+  EXPECT_EQ(query_value, "BRV001");
 }
 
 // TODO(bridiver) - convert to a unit test
@@ -226,11 +226,11 @@ IN_PROC_BROWSER_TEST_F(BraveStatsUpdaterBrowserTest,
   // Verify that daily parameter is true
   std::string query_value;
   EXPECT_TRUE(net::GetValueForKeyInQuery(update_url, "daily", &query_value));
-  EXPECT_STREQ(query_value.c_str(), "true");
+  EXPECT_EQ(query_value, "true");
 
   // Verify that there is no referral code
   EXPECT_TRUE(net::GetValueForKeyInQuery(update_url, "ref", &query_value));
-  EXPECT_STREQ(query_value.c_str(), "BRV001");
+  EXPECT_EQ(query_value, "BRV001");
 }
 
 class BraveStatsUpdaterReferralCodeBrowserTest
@@ -275,9 +275,9 @@ IN_PROC_BROWSER_TEST_F(BraveStatsUpdaterReferralCodeBrowserTest,
   // Verify that daily parameter is true
   std::string query_value;
   EXPECT_TRUE(net::GetValueForKeyInQuery(update_url, "daily", &query_value));
-  EXPECT_STREQ(query_value.c_str(), "true");
+  EXPECT_EQ(query_value, "true");
 
   // Verify that the expected referral code is present
   EXPECT_TRUE(net::GetValueForKeyInQuery(update_url, "ref", &query_value));
-  EXPECT_STREQ(query_value.c_str(), referral_code().c_str());
+  EXPECT_EQ(query_value, referral_code());
 }

--- a/browser/download/brave_download_item_model_unittest.cc
+++ b/browser/download/brave_download_item_model_unittest.cc
@@ -111,9 +111,8 @@ TEST_F(BraveDownloadItemModelTest, GetOriginUrlText) {
     EXPECT_CALL(item(), GetURL())
         .WillRepeatedly(ReturnRefOfCopy(GURL(test_case.url)));
     bool is_secure = false;
-    EXPECT_STREQ(
-        test_case.expected_text,
-        base::UTF16ToUTF8(model().GetOriginURLText(&is_secure)).c_str());
+    EXPECT_EQ(test_case.expected_text,
+              base::UTF16ToUTF8(model().GetOriginURLText(&is_secure)));
     EXPECT_EQ(is_secure, test_case.expected_is_secure) << test_case.url;
     Mock::VerifyAndClearExpectations(&item());
   }
@@ -147,6 +146,5 @@ TEST_F(BraveDownloadItemModelTest, NoDownloadItem) {
   DownloadUIModel model;
   BraveDownloadItemModel brave_model(&model);
   bool is_secure = false;
-  EXPECT_STREQ(
-      "", base::UTF16ToUTF8(brave_model.GetOriginURLText(&is_secure)).c_str());
+  EXPECT_EQ("", base::UTF16ToUTF8(brave_model.GetOriginURLText(&is_secure)));
 }

--- a/browser/playlist/test/mime_util_unittest.cc
+++ b/browser/playlist/test/mime_util_unittest.cc
@@ -12,10 +12,9 @@
 
 TEST(PlaylistMimeUtilUnitTest, GetFileExtensionForMimetype) {
   auto compare_result = [](const auto& mimetype, const auto& extension) {
-    EXPECT_STREQ(playlist::mime_util::GetFileExtensionForMimetype(mimetype)
-                     .value()
-                     .c_str(),
-                 extension);
+    EXPECT_EQ(
+        playlist::mime_util::GetFileExtensionForMimetype(mimetype).value(),
+        extension);
   };
 
   compare_result("application/ogg", FILE_PATH_LITERAL("ogx"));
@@ -48,10 +47,9 @@ TEST(PlaylistMimeUtilUnitTest, GetFileExtensionForMimetype) {
 
 TEST(PlaylistMimeUtilUnitTest, GetMimeTypeForFileExtension) {
   auto compare_result = [](const auto& extension, const auto& mimetype) {
-    EXPECT_STREQ(playlist::mime_util::GetMimeTypeForFileExtension(extension)
-                     .value()
-                     .c_str(),
-                 mimetype);
+    EXPECT_EQ(
+        playlist::mime_util::GetMimeTypeForFileExtension(extension).value(),
+        mimetype);
   };
 
   compare_result(FILE_PATH_LITERAL("m3u8"), "application/x-mpegurl");

--- a/browser/test/os_crypt/keychain_password_mac_browsertest.mm
+++ b/browser/test/os_crypt/keychain_password_mac_browsertest.mm
@@ -58,10 +58,8 @@ IN_PROC_BROWSER_TEST_P(BraveKeychainPasswordTest, ServiceAndAccountName) {
     base::CommandLine::ForCurrentProcess()->AppendSwitch(
         test_data.switch_to_append);
   }
-  EXPECT_STREQ(KeychainPassword::GetServiceName().c_str(),
-               test_data.service_name);
-  EXPECT_STREQ(KeychainPassword::GetAccountName().c_str(),
-               test_data.account_name);
+  EXPECT_EQ(KeychainPassword::GetServiceName(), test_data.service_name);
+  EXPECT_EQ(KeychainPassword::GetAccountName(), test_data.account_name);
 }
 
 INSTANTIATE_TEST_SUITE_P(/*no prefix*/,

--- a/browser/ui/webui/welcome_page/brave_welcome_ui_browsertest.cc
+++ b/browser/ui/webui/welcome_page/brave_welcome_ui_browsertest.cc
@@ -56,12 +56,11 @@ IN_PROC_BROWSER_TEST_F(BraveWelcomeUIBrowserTest, PRE_StartupURLTest) {
   content::WebContents* web_contents = tab_strip->GetWebContentsAt(0);
   content::TestNavigationObserver observer(web_contents, 1);
   observer.Wait();
-  EXPECT_STREQ("chrome://welcome/", tab_strip->GetWebContentsAt(0)
-                                        ->GetController()
-                                        .GetLastCommittedEntry()
-                                        ->GetVirtualURL()
-                                        .possibly_invalid_spec()
-                                        .c_str());
+  EXPECT_EQ("chrome://welcome/", tab_strip->GetWebContentsAt(0)
+                                     ->GetController()
+                                     .GetLastCommittedEntry()
+                                     ->GetVirtualURL()
+                                     .possibly_invalid_spec());
 }
 
 // Check wheter startup url is not welcome ui at second run.

--- a/components/ai_chat/core/browser/engine/conversation_api_client_unittest.cc
+++ b/components/ai_chat/core/browser/engine/conversation_api_client_unittest.cc
@@ -311,8 +311,8 @@ TEST_F(ConversationAPIUnitTest, PerformRequest_PremiumHeaders) {
         EXPECT_NE(headers.find("x-brave-key"), headers.end());
 
         // Verify input body contains input events in expected json format
-        EXPECT_STREQ(GetEventsJson(body).c_str(),
-                     FormatComparableEventsJson(expected_events_body).c_str());
+        EXPECT_EQ(GetEventsJson(body),
+                  FormatComparableEventsJson(expected_events_body));
 
         // Verify body contains the language
         auto [system_language, selected_language] = GetLanguage(body);
@@ -524,8 +524,8 @@ TEST_F(ConversationAPIUnitTest, PerformRequest_NonPremium) {
         EXPECT_NE(headers.find("x-brave-key"), headers.end());
 
         // Verify body contains events in expected json format
-        EXPECT_STREQ(GetEventsJson(body).c_str(),
-                     FormatComparableEventsJson(expected_events_body).c_str());
+        EXPECT_EQ(GetEventsJson(body),
+                  FormatComparableEventsJson(expected_events_body));
 
         // Verify body contains the language
         auto [system_language, selected_language] = GetLanguage(body);

--- a/components/ai_chat/core/browser/engine/engine_consumer_conversation_api_unittest.cc
+++ b/components/ai_chat/core/browser/engine/engine_consumer_conversation_api_unittest.cc
@@ -200,8 +200,8 @@ TEST_F(EngineConsumerConversationAPIUnitTest, GenerateEvents_BasicMessage) {
         EXPECT_EQ(conversation[0].type, ConversationAPIClient::PageText);
         EXPECT_EQ(conversation[1].role, mojom::CharacterType::HUMAN);
         // Match entire structure
-        EXPECT_STREQ(mock_api_client->GetEventsJson(conversation).c_str(),
-                     FormatComparableEventsJson(expected_events).c_str());
+        EXPECT_EQ(mock_api_client->GetEventsJson(conversation),
+                  FormatComparableEventsJson(expected_events));
         auto completion_event =
             mojom::ConversationEntryEvent::NewCompletionEvent(
                 mojom::CompletionEvent::New(""));
@@ -246,8 +246,8 @@ TEST_F(EngineConsumerConversationAPIUnitTest, GenerateEvents_WithSelectedText) {
         EXPECT_EQ(conversation[1].type, ConversationAPIClient::PageExcerpt);
         EXPECT_EQ(conversation[2].role, mojom::CharacterType::HUMAN);
         // Match entire structure
-        EXPECT_STREQ(mock_api_client->GetEventsJson(conversation).c_str(),
-                     FormatComparableEventsJson(expected_events).c_str());
+        EXPECT_EQ(mock_api_client->GetEventsJson(conversation),
+                  FormatComparableEventsJson(expected_events));
         auto completion_event =
             mojom::ConversationEntryEvent::NewCompletionEvent(
                 mojom::CompletionEvent::New(""));
@@ -315,8 +315,8 @@ TEST_F(EngineConsumerConversationAPIUnitTest,
         EXPECT_EQ(conversation[3].role, mojom::CharacterType::ASSISTANT);
         EXPECT_EQ(conversation[4].role, mojom::CharacterType::HUMAN);
         // Match entire JSON
-        EXPECT_STREQ(mock_api_client->GetEventsJson(conversation).c_str(),
-                     FormatComparableEventsJson(expected_events).c_str());
+        EXPECT_EQ(mock_api_client->GetEventsJson(conversation),
+                  FormatComparableEventsJson(expected_events));
         auto completion_event =
             mojom::ConversationEntryEvent::NewCompletionEvent(
                 mojom::CompletionEvent::New(""));
@@ -345,8 +345,8 @@ TEST_F(EngineConsumerConversationAPIUnitTest, GenerateEvents_Rewrite) {
                     EngineConsumer::GenerationCompletedCallback callback,
                     const std::optional<std::string>& model_name) {
         EXPECT_EQ(conversation.size(), 2u);
-        EXPECT_STREQ(mock_api_client->GetEventsJson(conversation).c_str(),
-                     FormatComparableEventsJson(expected_events).c_str());
+        EXPECT_EQ(mock_api_client->GetEventsJson(conversation),
+                  FormatComparableEventsJson(expected_events));
         auto completion_event =
             mojom::ConversationEntryEvent::NewCompletionEvent(
                 mojom::CompletionEvent::New(""));
@@ -428,8 +428,8 @@ TEST_F(EngineConsumerConversationAPIUnitTest, GenerateEvents_ModifyReply) {
         EXPECT_EQ(conversation[2].role, mojom::CharacterType::ASSISTANT);
         EXPECT_EQ(conversation[3].role, mojom::CharacterType::HUMAN);
         // Match entire JSON
-        EXPECT_STREQ(mock_api_client->GetEventsJson(conversation).c_str(),
-                     FormatComparableEventsJson(expected_events).c_str());
+        EXPECT_EQ(mock_api_client->GetEventsJson(conversation),
+                  FormatComparableEventsJson(expected_events));
         auto completion_event =
             mojom::ConversationEntryEvent::NewCompletionEvent(
                 mojom::CompletionEvent::New(""));
@@ -493,8 +493,8 @@ TEST_F(EngineConsumerConversationAPIUnitTest, GenerateEvents_SummarizePage) {
                     EngineConsumer::GenerationCompletedCallback callback,
                     const std::optional<std::string>& model_name) {
         // Match entire structure to ensure the generated JSON is correct
-        EXPECT_STREQ(mock_api_client->GetEventsJson(conversation).c_str(),
-                     FormatComparableEventsJson(expected_events).c_str());
+        EXPECT_EQ(mock_api_client->GetEventsJson(conversation),
+                  FormatComparableEventsJson(expected_events));
         auto completion_event =
             mojom::ConversationEntryEvent::NewCompletionEvent(
                 mojom::CompletionEvent::New(""));
@@ -609,8 +609,8 @@ TEST_F(EngineConsumerConversationAPIUnitTest, GetSuggestedTopics) {
                     EngineConsumer::GenerationCompletedCallback callback,
                     const std::optional<std::string>& model_name) {
         EXPECT_EQ(conversation.size(), 1u);
-        EXPECT_STREQ(mock_api_client->GetEventsJson(conversation).c_str(),
-                     FormatComparableEventsJson(expected_events1).c_str());
+        EXPECT_EQ(mock_api_client->GetEventsJson(conversation),
+                  FormatComparableEventsJson(expected_events1));
         auto completion_event =
             mojom::ConversationEntryEvent::NewCompletionEvent(
                 mojom::CompletionEvent::New(
@@ -625,8 +625,8 @@ TEST_F(EngineConsumerConversationAPIUnitTest, GetSuggestedTopics) {
                     EngineConsumer::GenerationCompletedCallback callback,
                     const std::optional<std::string>& model_name) {
         EXPECT_EQ(conversation.size(), 1u);
-        EXPECT_STREQ(mock_api_client->GetEventsJson(conversation).c_str(),
-                     FormatComparableEventsJson(expected_events2).c_str());
+        EXPECT_EQ(mock_api_client->GetEventsJson(conversation),
+                  FormatComparableEventsJson(expected_events2));
         auto completion_event =
             mojom::ConversationEntryEvent::NewCompletionEvent(
                 mojom::CompletionEvent::New(
@@ -641,8 +641,8 @@ TEST_F(EngineConsumerConversationAPIUnitTest, GetSuggestedTopics) {
                     EngineConsumer::GenerationCompletedCallback callback,
                     const std::optional<std::string>& model_name) {
         EXPECT_EQ(conversation.size(), 1u);
-        EXPECT_STREQ(mock_api_client->GetEventsJson(conversation).c_str(),
-                     FormatComparableEventsJson(expected_events3).c_str());
+        EXPECT_EQ(mock_api_client->GetEventsJson(conversation),
+                  FormatComparableEventsJson(expected_events3));
         auto completion_event =
             mojom::ConversationEntryEvent::NewCompletionEvent(
                 mojom::CompletionEvent::New(
@@ -674,8 +674,8 @@ TEST_F(EngineConsumerConversationAPIUnitTest, GetSuggestedTopics) {
                     EngineConsumer::GenerationCompletedCallback callback,
                     const std::optional<std::string>& model_name) {
         EXPECT_EQ(conversation.size(), 1u);
-        EXPECT_STREQ(mock_api_client->GetEventsJson(conversation).c_str(),
-                     FormatComparableEventsJson(expected_events1).c_str());
+        EXPECT_EQ(mock_api_client->GetEventsJson(conversation),
+                  FormatComparableEventsJson(expected_events1));
         auto completion_event =
             mojom::ConversationEntryEvent::NewCompletionEvent(
                 mojom::CompletionEvent::New(
@@ -690,8 +690,8 @@ TEST_F(EngineConsumerConversationAPIUnitTest, GetSuggestedTopics) {
                     EngineConsumer::GenerationCompletedCallback callback,
                     const std::optional<std::string>& model_name) {
         EXPECT_EQ(conversation.size(), 1u);
-        EXPECT_STREQ(mock_api_client->GetEventsJson(conversation).c_str(),
-                     FormatComparableEventsJson(expected_events2).c_str());
+        EXPECT_EQ(mock_api_client->GetEventsJson(conversation),
+                  FormatComparableEventsJson(expected_events2));
         std::move(callback).Run(
             base::unexpected(mojom::APIError::RateLimitReached));
       });
@@ -712,8 +712,8 @@ TEST_F(EngineConsumerConversationAPIUnitTest, GetSuggestedTopics) {
                     EngineConsumer::GenerationCompletedCallback callback,
                     const std::optional<std::string>& model_name) {
         EXPECT_EQ(conversation.size(), 1u);
-        EXPECT_STREQ(mock_api_client->GetEventsJson(conversation).c_str(),
-                     FormatComparableEventsJson(expected_events1).c_str());
+        EXPECT_EQ(mock_api_client->GetEventsJson(conversation),
+                  FormatComparableEventsJson(expected_events1));
         auto completion_event =
             mojom::ConversationEntryEvent::NewCompletionEvent(
                 mojom::CompletionEvent::New(
@@ -728,8 +728,8 @@ TEST_F(EngineConsumerConversationAPIUnitTest, GetSuggestedTopics) {
                     EngineConsumer::GenerationCompletedCallback callback,
                     const std::optional<std::string>& model_name) {
         EXPECT_EQ(conversation.size(), 1u);
-        EXPECT_STREQ(mock_api_client->GetEventsJson(conversation).c_str(),
-                     FormatComparableEventsJson(expected_events2).c_str());
+        EXPECT_EQ(mock_api_client->GetEventsJson(conversation),
+                  FormatComparableEventsJson(expected_events2));
         auto completion_event =
             mojom::ConversationEntryEvent::NewCompletionEvent(
                 mojom::CompletionEvent::New(
@@ -744,8 +744,8 @@ TEST_F(EngineConsumerConversationAPIUnitTest, GetSuggestedTopics) {
                     EngineConsumer::GenerationCompletedCallback callback,
                     const std::optional<std::string>& model_name) {
         EXPECT_EQ(conversation.size(), 1u);
-        EXPECT_STREQ(mock_api_client->GetEventsJson(conversation).c_str(),
-                     FormatComparableEventsJson(expected_events3).c_str());
+        EXPECT_EQ(mock_api_client->GetEventsJson(conversation),
+                  FormatComparableEventsJson(expected_events3));
         std::move(callback).Run(
             base::unexpected(mojom::APIError::RateLimitReached));
       });
@@ -769,8 +769,8 @@ TEST_F(EngineConsumerConversationAPIUnitTest, GetSuggestedTopics) {
                     EngineConsumer::GenerationCompletedCallback callback,
                     const std::optional<std::string>& model_name) {
         EXPECT_EQ(conversation.size(), 1u);
-        EXPECT_STREQ(mock_api_client->GetEventsJson(conversation).c_str(),
-                     FormatComparableEventsJson(expected_events1).c_str());
+        EXPECT_EQ(mock_api_client->GetEventsJson(conversation),
+                  FormatComparableEventsJson(expected_events1));
         auto completion_event =
             mojom::ConversationEntryEvent::NewCompletionEvent(
                 mojom::CompletionEvent::New(
@@ -785,8 +785,8 @@ TEST_F(EngineConsumerConversationAPIUnitTest, GetSuggestedTopics) {
                     EngineConsumer::GenerationCompletedCallback callback,
                     const std::optional<std::string>& model_name) {
         EXPECT_EQ(conversation.size(), 1u);
-        EXPECT_STREQ(mock_api_client->GetEventsJson(conversation).c_str(),
-                     FormatComparableEventsJson(expected_events2).c_str());
+        EXPECT_EQ(mock_api_client->GetEventsJson(conversation),
+                  FormatComparableEventsJson(expected_events2));
         auto completion_event =
             mojom::ConversationEntryEvent::NewCompletionEvent(
                 mojom::CompletionEvent::New("not well structured"));
@@ -799,10 +799,9 @@ TEST_F(EngineConsumerConversationAPIUnitTest, GetSuggestedTopics) {
                     EngineConsumer::GenerationCompletedCallback callback,
                     const std::optional<std::string>& model_name) {
         EXPECT_EQ(conversation.size(), 1u);
-        EXPECT_STREQ(mock_api_client->GetEventsJson(conversation).c_str(),
-                     FormatComparableEventsJson(
-                         expected_events3_skipped_invalid_response)
-                         .c_str());
+        EXPECT_EQ(mock_api_client->GetEventsJson(conversation),
+                  FormatComparableEventsJson(
+                      expected_events3_skipped_invalid_response));
         auto completion_event =
             mojom::ConversationEntryEvent::NewCompletionEvent(
                 mojom::CompletionEvent::New(
@@ -830,8 +829,8 @@ TEST_F(EngineConsumerConversationAPIUnitTest, GetSuggestedTopics) {
                     EngineConsumer::GenerationCompletedCallback callback,
                     const std::optional<std::string>& model_name) {
         EXPECT_EQ(conversation.size(), 1u);
-        EXPECT_STREQ(mock_api_client->GetEventsJson(conversation).c_str(),
-                     FormatComparableEventsJson(expected_events1).c_str());
+        EXPECT_EQ(mock_api_client->GetEventsJson(conversation),
+                  FormatComparableEventsJson(expected_events1));
         auto completion_event =
             mojom::ConversationEntryEvent::NewCompletionEvent(
                 mojom::CompletionEvent::New(
@@ -846,8 +845,8 @@ TEST_F(EngineConsumerConversationAPIUnitTest, GetSuggestedTopics) {
                     EngineConsumer::GenerationCompletedCallback callback,
                     const std::optional<std::string>& model_name) {
         EXPECT_EQ(conversation.size(), 1u);
-        EXPECT_STREQ(mock_api_client->GetEventsJson(conversation).c_str(),
-                     FormatComparableEventsJson(expected_events2).c_str());
+        EXPECT_EQ(mock_api_client->GetEventsJson(conversation),
+                  FormatComparableEventsJson(expected_events2));
         auto completion_event =
             mojom::ConversationEntryEvent::NewCompletionEvent(
                 mojom::CompletionEvent::New(
@@ -862,8 +861,8 @@ TEST_F(EngineConsumerConversationAPIUnitTest, GetSuggestedTopics) {
                     EngineConsumer::GenerationCompletedCallback callback,
                     const std::optional<std::string>& model_name) {
         EXPECT_EQ(conversation.size(), 1u);
-        EXPECT_STREQ(mock_api_client->GetEventsJson(conversation).c_str(),
-                     FormatComparableEventsJson(expected_events3).c_str());
+        EXPECT_EQ(mock_api_client->GetEventsJson(conversation),
+                  FormatComparableEventsJson(expected_events3));
         auto completion_event =
             mojom::ConversationEntryEvent::NewCompletionEvent(
                 mojom::CompletionEvent::New(
@@ -930,8 +929,8 @@ TEST_F(EngineConsumerConversationAPIUnitTest,
                     EngineConsumer::GenerationCompletedCallback callback,
                     const std::optional<std::string>& model_name) {
         EXPECT_EQ(conversation.size(), 1u);
-        EXPECT_STREQ(mock_api_client->GetEventsJson(conversation).c_str(),
-                     FormatComparableEventsJson(expected_events).c_str());
+        EXPECT_EQ(mock_api_client->GetEventsJson(conversation),
+                  FormatComparableEventsJson(expected_events));
         auto completion_event =
             mojom::ConversationEntryEvent::NewCompletionEvent(
                 mojom::CompletionEvent::New(
@@ -982,8 +981,8 @@ TEST_F(EngineConsumerConversationAPIUnitTest, GetFocusTabs) {
                     EngineConsumer::GenerationCompletedCallback callback,
                     const std::optional<std::string>& model_name) {
         EXPECT_EQ(conversation.size(), 1u);
-        EXPECT_STREQ(mock_api_client->GetEventsJson(conversation).c_str(),
-                     FormatComparableEventsJson(expected_events1).c_str());
+        EXPECT_EQ(mock_api_client->GetEventsJson(conversation),
+                  FormatComparableEventsJson(expected_events1));
         auto completion_event =
             mojom::ConversationEntryEvent::NewCompletionEvent(
                 mojom::CompletionEvent::New(
@@ -997,8 +996,8 @@ TEST_F(EngineConsumerConversationAPIUnitTest, GetFocusTabs) {
                     EngineConsumer::GenerationCompletedCallback callback,
                     const std::optional<std::string>& model_name) {
         EXPECT_EQ(conversation.size(), 1u);
-        EXPECT_STREQ(mock_api_client->GetEventsJson(conversation).c_str(),
-                     FormatComparableEventsJson(expected_events2).c_str());
+        EXPECT_EQ(mock_api_client->GetEventsJson(conversation),
+                  FormatComparableEventsJson(expected_events2));
         auto completion_event =
             mojom::ConversationEntryEvent::NewCompletionEvent(
                 mojom::CompletionEvent::New(
@@ -1040,8 +1039,8 @@ TEST_F(EngineConsumerConversationAPIUnitTest, GetFocusTabs) {
                     EngineConsumer::GenerationCompletedCallback callback,
                     const std::optional<std::string>& model_name) {
         EXPECT_EQ(conversation.size(), 1u);
-        EXPECT_STREQ(mock_api_client->GetEventsJson(conversation).c_str(),
-                     FormatComparableEventsJson(expected_events1).c_str());
+        EXPECT_EQ(mock_api_client->GetEventsJson(conversation),
+                  FormatComparableEventsJson(expected_events1));
         auto completion_event =
             mojom::ConversationEntryEvent::NewCompletionEvent(
                 mojom::CompletionEvent::New(
@@ -1055,8 +1054,8 @@ TEST_F(EngineConsumerConversationAPIUnitTest, GetFocusTabs) {
                     EngineConsumer::GenerationCompletedCallback callback,
                     const std::optional<std::string>& model_name) {
         EXPECT_EQ(conversation.size(), 1u);
-        EXPECT_STREQ(mock_api_client->GetEventsJson(conversation).c_str(),
-                     FormatComparableEventsJson(expected_events2).c_str());
+        EXPECT_EQ(mock_api_client->GetEventsJson(conversation),
+                  FormatComparableEventsJson(expected_events2));
         auto completion_event =
             mojom::ConversationEntryEvent::NewCompletionEvent(
                 mojom::CompletionEvent::New(
@@ -1260,8 +1259,8 @@ TEST_F(EngineConsumerConversationAPIUnitTest, GenerateQuestionSuggestions) {
                       EngineConsumer::GenerationCompletedCallback callback,
                       const std::optional<std::string>& model_name) {
           EXPECT_EQ(conversation.size(), 2u);
-          EXPECT_STREQ(mock_api_client->GetEventsJson(conversation).c_str(),
-                       FormatComparableEventsJson(expected_events).c_str());
+          EXPECT_EQ(mock_api_client->GetEventsJson(conversation),
+                    FormatComparableEventsJson(expected_events));
           auto completion_event =
               mojom::ConversationEntryEvent::NewCompletionEvent(
                   mojom::CompletionEvent::New("question1|question2|question3"));

--- a/components/ai_chat/core/browser/engine/engine_consumer_oai_unittest.cc
+++ b/components/ai_chat/core/browser/engine/engine_consumer_oai_unittest.cc
@@ -195,24 +195,24 @@ TEST_F(EngineConsumerOAIUnitTest, GenerateQuestionSuggestions) {
       false, page_content, "",
       base::BindLambdaForTesting(
           [](EngineConsumer::SuggestedQuestionResult result) {
-            EXPECT_STREQ(result.value()[0].c_str(), "Question 1");
-            EXPECT_STREQ(result.value()[1].c_str(), "Question 2");
+            EXPECT_EQ(result.value()[0], "Question 1");
+            EXPECT_EQ(result.value()[1], "Question 2");
           }));
 
   engine_->GenerateQuestionSuggestions(
       false, page_content, "",
       base::BindLambdaForTesting(
           [](EngineConsumer::SuggestedQuestionResult result) {
-            EXPECT_STREQ(result.value()[0].c_str(), "Question 1");
-            EXPECT_STREQ(result.value()[1].c_str(), "Question 2");
+            EXPECT_EQ(result.value()[0], "Question 1");
+            EXPECT_EQ(result.value()[1], "Question 2");
           }));
 
   engine_->GenerateQuestionSuggestions(
       false, page_content, "",
       base::BindLambdaForTesting(
           [&run_loop](EngineConsumer::SuggestedQuestionResult result) {
-            EXPECT_STREQ(result.value()[0].c_str(), "Question 1");
-            EXPECT_STREQ(result.value()[1].c_str(), "Question 2");
+            EXPECT_EQ(result.value()[0], "Question 1");
+            EXPECT_EQ(result.value()[1], "Question 2");
             run_loop.Quit();
           }));
 

--- a/components/ai_chat/core/browser/engine/oai_api_client_unittest.cc
+++ b/components/ai_chat/core/browser/engine/oai_api_client_unittest.cc
@@ -160,9 +160,8 @@ TEST_F(OAIAPIUnitTest, PerformRequest) {
         EXPECT_EQ(url, model_options->endpoint);
         EXPECT_EQ(headers.contains("Authorization"), true);
         EXPECT_EQ(method, net::HttpRequestHeaders::kPostMethod);
-        EXPECT_STREQ(
-            GetMessagesJson(body).c_str(),
-            FormatComparableEventsJson(expected_conversation_body).c_str());
+        EXPECT_EQ(GetMessagesJson(body),
+                  FormatComparableEventsJson(expected_conversation_body));
 
         auto chunk = base::test::ParseJson(server_chunk);
         data_received_callback.Run(base::ok(std::move(chunk)));


### PR DESCRIPTION
This PR removes a lot of unnecessary uses of `EXPECT_STREQ` combined with calls to `c_str()`, and converts  these comparisons simply to `std::string` comparisons using `EXPECT_EQ`. This is functionally the same, but it is arguably easier to read in general.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/46600

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
