### PR TITLE
feat(wallet): Add Shield Account Alert to Account Details

### DIFF
--- a/components/brave_wallet/browser/brave_wallet_constants.h
+++ b/components/brave_wallet/browser/brave_wallet_constants.h
@@ -1627,6 +1627,8 @@ inline constexpr webui::LocalizedString kLocalizedStrings[] = {
     {"braveWalletSwitchToShieldedAccount",
      IDS_BRAVE_WALLET_SWITCH_TO_SHIELDED_ACCOUNT},
     {"braveWalletShieldAccount", IDS_BRAVE_WALLET_SHIELD_ACCOUNT},
+    {"braveWalletShieldAccountAlertDescription",
+     IDS_BRAVE_WALLET_SHIELD_ACCOUNT_ALERT_DESCRIPTION},
     {"braveWalletAccountNotShieldedDescription",
      IDS_BRAVE_WALLET_ACCOUNT_NOT_SHIELDED_DESCRIPTION},
     {"braveWalletAccountShieldedDescription",

--- a/components/brave_wallet_ui/components/desktop/views/accounts/account.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/accounts/account.tsx
@@ -103,6 +103,7 @@ import {
   ViewOnBlockExplorerModal, //
 } from '../../popup-modals/view_on_block_explorer_modal/view_on_block_explorer_modal'
 import { ZCashSyncModal } from '../../popup-modals/zcash_sync_modal/zcash_sync_modal'
+import { ShieldAccountAlert } from './shield_account_alert/shield_account_alert'
 
 // options
 import { AccountDetailsOptions } from '../../../../options/nav-options'
@@ -122,6 +123,7 @@ import {
   useStopShieldSyncMutation,
   useGetZCashBalanceQuery,
   useClearChainTipStatusCacheMutation,
+  useGetIsShieldingAvailableQuery,
 } from '../../../../common/slices/api.slice'
 import {
   querySubscriptionOptions60s, //
@@ -244,6 +246,16 @@ export const Account = () => {
       : skipToken,
   )
 
+  const zcashAccountIds = accounts
+    .filter((account) => account.accountId.coin === BraveWallet.CoinType.ZEC)
+    .map((account) => account.accountId)
+
+  const { data: isShieldingAvailable } = useGetIsShieldingAvailableQuery(
+    isZCashShieldedTransactionsEnabled && zcashAccountIds
+      ? zcashAccountIds
+      : skipToken,
+  )
+
   // state
   const [showAddNftModal, setShowAddNftModal] = React.useState<boolean>(false)
   const [showViewOnBlockExplorerModal, setShowViewOnBlockExplorerModal] =
@@ -264,6 +276,13 @@ export const Account = () => {
 
   const enableSyncButton =
     !isAccountSyncing && showSyncWarning && blocksBehind > 0
+
+  const canShieldAccount =
+    isZCashShieldedTransactionsEnabled
+    && selectedAccount?.accountId.coin === BraveWallet.CoinType.ZEC
+    && isShieldingAvailable
+    && zcashAccountInfo
+    && !zcashAccountInfo.accountShieldBirthday
 
   // custom hooks & memos
   const scrollIntoView = useScrollIntoView()
@@ -682,6 +701,7 @@ export const Account = () => {
           </SyncAlert>
         </SyncAlertWrapper>
       )}
+      {canShieldAccount && <ShieldAccountAlert account={selectedAccount} />}
       <ControlsWrapper fullWidth={true}>
         <SegmentedControl navOptions={routeOptions} />
       </ControlsWrapper>

--- a/components/brave_wallet_ui/components/desktop/views/accounts/shield_account_alert/shield_account_alert.style.ts
+++ b/components/brave_wallet_ui/components/desktop/views/accounts/shield_account_alert/shield_account_alert.style.ts
@@ -1,0 +1,24 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import styled from 'styled-components'
+import LeoAlert from '@brave/leo/react/alert'
+
+// Shared Styles
+import { Row } from '../../../../shared/style'
+import { layoutPanelWidth } from '../../../wallet-page-wrapper/wallet-page-wrapper.style'
+
+export const Wrapper = styled(Row)`
+  padding: 0px 32px;
+  margin: 0px 0px 32px 0px;
+  @media screen and (max-width: ${layoutPanelWidth}px) {
+    padding: 16px 16px 0px 16px;
+    margin: 0px;
+  }
+`
+
+export const Alert = styled(LeoAlert)`
+  width: 100%;
+`

--- a/components/brave_wallet_ui/components/desktop/views/accounts/shield_account_alert/shield_account_alert.test.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/accounts/shield_account_alert/shield_account_alert.test.tsx
@@ -1,0 +1,67 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import * as React from 'react'
+import { render, act, waitFor } from '@testing-library/react'
+
+// Utils
+import {
+  // eslint-disable-next-line import/no-named-default
+  default as BraveCoreThemeProvider,
+} from '../../../../../../common/BraveCoreThemeProvider'
+import { createMockStore } from '../../../../../utils/test-utils'
+
+// Components
+import { ShieldAccountAlert } from './shield_account_alert'
+
+// Mocks
+import { mockZecAccount } from '../../../../../common/constants/mocks'
+import { Provider } from 'react-redux'
+
+describe('ShieldAccountAlert', () => {
+  it('should render', async () => {
+    const store = createMockStore({})
+    const { container } = render(
+      <Provider store={store}>
+        <BraveCoreThemeProvider>
+          <ShieldAccountAlert account={mockZecAccount} />
+        </BraveCoreThemeProvider>
+      </Provider>,
+    )
+
+    // Check if the shield account alert is rendered
+    expect(container).toBeInTheDocument()
+    expect(container).toHaveTextContent('braveWalletShieldAccount')
+    expect(container).toHaveTextContent(
+      'braveWalletShieldAccountAlertDescription',
+    )
+
+    // Check if the shield account alert button is rendered
+    const shieldAccountAlertButton: any = document.querySelector('leo-button')
+    expect(shieldAccountAlertButton).toBeInTheDocument()
+    expect(shieldAccountAlertButton?.textContent).toBe(
+      'braveWalletShieldAccount',
+    )
+
+    // Check if the shield account alert button is clickable and opens the modal
+    act(() => {
+      shieldAccountAlertButton?.shadowRoot?.querySelector('button').click()
+    })
+
+    await waitFor(() => {
+      expect(container).toHaveTextContent('braveWalletSwitchToShieldedAccount')
+      expect(container).toHaveTextContent(
+        'braveWalletAccountNotShieldedDescription',
+      )
+      expect(container).toHaveTextContent(
+        'braveWalletAccountShieldedDescription',
+      )
+      expect(container).toHaveTextContent(
+        'braveWalletAdvancedTransactionSettings',
+      )
+      expect(container).toHaveTextContent('braveWalletShieldAccount')
+    })
+  })
+})

--- a/components/brave_wallet_ui/components/desktop/views/accounts/shield_account_alert/shield_account_alert.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/accounts/shield_account_alert/shield_account_alert.tsx
@@ -1,0 +1,108 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import * as React from 'react'
+import Button from '@brave/leo/react/button'
+import Icon from '@brave/leo/react/icon'
+
+// Types
+import { BraveWallet } from '../../../../../constants/types'
+
+// Safe Selectors
+import {
+  useSafeUISelector, //
+} from '../../../../../common/hooks/use-safe-selector'
+import { UISelectors } from '../../../../../common/selectors'
+
+// Components
+import {
+  ShieldZCashAccountModal, //
+} from '../../../popup-modals/shield_zcash_account/shield_zcash_account'
+
+// Utils
+import { getLocale } from '../../../../../../common/locale'
+
+// Styled Components
+import { Wrapper, Alert } from './shield_account_alert.style'
+import { Row, Column, Text } from '../../../../shared/style'
+
+export interface Props {
+  account: BraveWallet.AccountInfo
+}
+
+export function ShieldAccountAlert(props: Props) {
+  const { account } = props
+
+  // State
+  const [showShieldAccountModal, setShowShieldAccountModal] =
+    React.useState<boolean>(false)
+
+  // Safe Selectors
+  const isPanel = useSafeUISelector(UISelectors.isPanel)
+  const isAndroid = useSafeUISelector(UISelectors.isAndroid)
+  const isPanelOrAndroid = isPanel || isAndroid
+
+  return (
+    <>
+      <Wrapper>
+        <Alert type='info'>
+          <Row justifyContent='space-between'>
+            <Column alignItems='flex-start'>
+              <Text
+                textColor='info'
+                isBold={true}
+                textSize='16px'
+              >
+                {getLocale('braveWalletShieldAccount')}
+              </Text>
+              {getLocale('braveWalletShieldAccountAlertDescription')}
+            </Column>
+            {!isPanelOrAndroid && (
+              <div>
+                <Button
+                  onClick={() => {
+                    setShowShieldAccountModal(true)
+                  }}
+                >
+                  <Icon
+                    name='shield-done'
+                    slot='icon-before'
+                  />
+                  {getLocale('braveWalletShieldAccount')}
+                </Button>
+              </div>
+            )}
+          </Row>
+          {isPanelOrAndroid && (
+            <div slot='actions'>
+              <Button
+                size='small'
+                onClick={() => {
+                  setShowShieldAccountModal(true)
+                }}
+              >
+                <Icon
+                  name='shield-done'
+                  slot='icon-before'
+                />
+                {getLocale('braveWalletShieldAccount')}
+              </Button>
+            </div>
+          )}
+        </Alert>
+      </Wrapper>
+      {showShieldAccountModal && (
+        <ShieldZCashAccountModal
+          account={account}
+          onClose={() => {
+            setShowShieldAccountModal(false)
+          }}
+        />
+      )}
+    </>
+  )
+}
+
+export default ShieldAccountAlert

--- a/components/brave_wallet_ui/stories/locale.ts
+++ b/components/brave_wallet_ui/stories/locale.ts
@@ -1517,6 +1517,8 @@ provideStrings({
   // ZCash
   braveWalletSwitchToShieldedAccount: 'Switch to a shielded account',
   braveWalletShieldAccount: 'Shield account',
+  braveWalletShieldAccountAlertDescription:
+    'Enable shielding to enhance transaction privacy.',
   braveWalletAccountNotShieldedDescription:
     'Currently this account supports transparent transactions which means they are visible to everyone on the blockchain.',
   braveWalletAccountShieldedDescription:

--- a/components/resources/wallet_strings.grdp
+++ b/components/resources/wallet_strings.grdp
@@ -1159,6 +1159,7 @@
   <message name="IDS_BRAVE_WALLET_VERIFIED" desc="Verified label">Verified by DappRadar</message>
   <message name="IDS_BRAVE_WALLET_SWITCH_TO_SHIELDED_ACCOUNT" desc="Switch to a shielded account button text">Switch to a shielded account</message>
   <message name="IDS_BRAVE_WALLET_SHIELD_ACCOUNT" desc="Shield account button text">Shield account</message>
+  <message name="IDS_BRAVE_WALLET_SHIELD_ACCOUNT_ALERT_DESCRIPTION" desc="Shield account alert description">Enable shielding to enhance transaction privacy.</message>
   <message name="IDS_BRAVE_WALLET_ACCOUNT_NOT_SHIELDED_DESCRIPTION" desc="ZCash account not shielded description.">Currently this account supports transparent transactions which means they are visible to everyone on the blockchain.</message>
   <message name="IDS_BRAVE_WALLET_ACCOUNT_SHIELDED_DESCRIPTION" desc="ZCash account shielded description">Upgrading to a shielded account means that these transactions hide the sender, receiver and amount details.</message>
   <message name="IDS_BRAVE_WALLET_SHIELDED" desc="Shielded label">Shielded</message>


### PR DESCRIPTION
## Description 

Will now display a `Shield Account` alert on the `Account Details` screen if you are able to shield a `Zcash` account

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/46598>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

## Test Plan:

1. Create a brand new profile and wallet
2. Navigate to the `Accounts` screen and open you `Zcash` account details
3. You should see the `Shield Account` alert at the top of the page
4. Click `Shield Account` and the `Shield Account Modal` should popup
5. Shield your account and the `Modal` and `Alert` should both disapear
6. Ensure that your account did indeed `Shield`

![Screenshot 64](https://github.com/user-attachments/assets/6250a2d9-c9ce-413e-89a3-931f61b52310)

https://github.com/user-attachments/assets/96f33420-4eaf-4af8-91fc-b8c2e9e2075b
