### PR TITLE
Increase reporting cutoff for date of activation/install P3A attributes (uplift to 1.80.x)

### DIFF
--- a/components/p3a/p3a_message.cc
+++ b/components/p3a/p3a_message.cc
@@ -73,7 +73,7 @@ constexpr auto kNotableCountries = base::MakeFixedFlatSet<std::string_view>(
     {"US", "FR", "PH", "GB", "IN", "DE", "BR", "CA", "IT", "ES",
      "NL", "MX", "AU", "RU", "JP", "PL", "ID", "KR", "AR", "AT"});
 
-constexpr base::TimeDelta kDateOmissionThreshold = base::Days(30);
+constexpr base::TimeDelta kDateOmissionThreshold = base::Days(31);
 
 std::string FormatUTCDateFromExploded(const base::Time::Exploded& exploded) {
   return base::StringPrintf("%d-%02d-%02d", exploded.year, exploded.month,


### PR DESCRIPTION
Uplift of #29424
Resolves https://github.com/brave/brave-browser/issues/46608

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.