### PR TITLE
[iOS] Fix crash on iOS 16 when downloading a file

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabDownloadDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabDownloadDelegate.swift
@@ -185,7 +185,7 @@ extension BrowserViewController: TabDownloadDelegate {
     suggestedFileName: String
   ) async -> Bool {
     // Only download if there is a valid host
-    let host = download.originalURL?.host() ?? ""
+    let host = download.originalURL?.host ?? ""
 
     // Never present the download alert on a tab that isn't visible
     guard tab === tabManager.selectedTab


### PR DESCRIPTION
There is a bug in Swift/iOS 16 where the `host(percentEncoded:)` and `path(percentEncoded:)` methods on `URL` will crash

Resolves https://github.com/brave/brave-browser/issues/46682

### Test Case
Prefix: iOS 16.0-16.3 only
- Tap a link that would trigger a download prompt and ensure it doesnt crash when the alert is presented and that you can download the file