### PR TITLE
[CodeHealth] Removing use of `NoDestructor` in `brave/browser/net`

### DIFF
--- a/browser/net/brave_network_delegate_base_unittest.cc
+++ b/browser/net/brave_network_delegate_base_unittest.cc
@@ -16,8 +16,8 @@
 #include "net/url_request/url_request_test_util.h"
 #include "url/gurl.h"
 
+using brave::kTrackableSecurityHeaders;
 using brave::RemoveTrackableSecurityHeadersForThirdParty;
-using brave::TrackableSecurityHeaders;
 using net::HttpResponseHeaders;
 
 
@@ -68,7 +68,7 @@ TEST_F(BraveNetworkDelegateBaseTest, RemoveTrackableSecurityHeaders) {
   RemoveTrackableSecurityHeadersForThirdParty(request_url,
                                               url::Origin::Create(tab_url),
                                               nullptr, &headers);
-  for (auto header : *TrackableSecurityHeaders()) {
+  for (auto header : kTrackableSecurityHeaders) {
     EXPECT_FALSE(headers->HasHeader(std::string(header)));
   }
   EXPECT_TRUE(headers->HasHeader(kAcceptLanguageHeader));
@@ -86,7 +86,7 @@ TEST_F(BraveNetworkDelegateBaseTest, RemoveTrackableSecurityHeadersMixedCase) {
   RemoveTrackableSecurityHeadersForThirdParty(request_url,
                                               url::Origin::Create(tab_url),
                                               nullptr, &headers);
-  for (auto header : *TrackableSecurityHeaders()) {
+  for (auto header : kTrackableSecurityHeaders) {
     EXPECT_FALSE(headers->HasHeader(std::string(header)));
   }
   EXPECT_TRUE(headers->HasHeader(kAcceptLanguageHeader));
@@ -104,7 +104,7 @@ TEST_F(BraveNetworkDelegateBaseTest, RetainTrackableSecurityHeaders) {
   RemoveTrackableSecurityHeadersForThirdParty(request_url,
                                               url::Origin::Create(tab_url),
                                               nullptr, &headers);
-  for (auto header : *TrackableSecurityHeaders()) {
+  for (auto header : kTrackableSecurityHeaders) {
     EXPECT_TRUE(headers->HasHeader(std::string(header)));
   }
   EXPECT_TRUE(headers->HasHeader(kAcceptLanguageHeader));

--- a/browser/net/brave_stp_util.cc
+++ b/browser/net/brave_stp_util.cc
@@ -13,14 +13,6 @@
 
 namespace brave {
 
-base::flat_set<std::string_view>* TrackableSecurityHeaders() {
-  static base::NoDestructor<base::flat_set<std::string_view>>
-      kTrackableSecurityHeaders(base::flat_set<std::string_view>{
-          "Strict-Transport-Security", "Expect-CT", "Public-Key-Pins",
-          "Public-Key-Pins-Report-Only"});
-  return kTrackableSecurityHeaders.get();
-}
-
 void RemoveTrackableSecurityHeadersForThirdParty(
     const GURL& request_url, const url::Origin& top_frame_origin,
     const net::HttpResponseHeaders* original_response_headers,
@@ -39,7 +31,7 @@ void RemoveTrackableSecurityHeadersForThirdParty(
     *override_response_headers =
         new net::HttpResponseHeaders(original_response_headers->raw_headers());
   }
-  for (auto header : *TrackableSecurityHeaders()) {
+  for (auto header : kTrackableSecurityHeaders) {
     (*override_response_headers)->RemoveHeader(std::string(header));
   }
 }

--- a/browser/net/brave_stp_util.h
+++ b/browser/net/brave_stp_util.h
@@ -6,16 +6,19 @@
 #ifndef BRAVE_BROWSER_NET_BRAVE_STP_UTIL_H_
 #define BRAVE_BROWSER_NET_BRAVE_STP_UTIL_H_
 
+#include <array>
 #include <string_view>
 
-#include "base/containers/flat_set.h"
 #include "net/http/http_response_headers.h"
 #include "url/gurl.h"
 #include "url/origin.h"
 
 namespace brave {
 
-base::flat_set<std::string_view>* TrackableSecurityHeaders();
+inline constexpr auto kTrackableSecurityHeaders =
+    std::to_array<std::string_view>({"Strict-Transport-Security", "Expect-CT",
+                                     "Public-Key-Pins",
+                                     "Public-Key-Pins-Report-Only"});
 
 void RemoveTrackableSecurityHeadersForThirdParty(
     const GURL& request_url, const url::Origin& top_frame_origin,


### PR DESCRIPTION
This PR converts the `flat_set` that was being created as `NoDestructor` to a simple `array` that is `constexpr`.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/46644

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
