### PR TITLE
Update TabContainer layout before adding groups

### DIFF
--- a/browser/ui/views/tabs/vertical_tab_strip_browsertest.cc
+++ b/browser/ui/views/tabs/vertical_tab_strip_browsertest.cc
@@ -983,26 +983,25 @@ IN_PROC_BROWSER_TEST_F(VerticalTabStripDragAndDropBrowserTest,
       GetCenterPointInScreen(GetTabAt(browser(), 0));
   point_out_of_tabstrip.set_x(point_out_of_tabstrip.x() +
                               2 * GetTabAt(browser(), 0)->width());
-  MoveMouseTo(point_out_of_tabstrip, base::BindLambdaForTesting([&]() {
-                // Creating new browser during drag-and-drop will create
-                // a nested run loop. So we should do things within callback.
-                auto* browser_list = BrowserList::GetInstance();
-                EXPECT_EQ(2,
-                          std::ranges::count_if(*browser_list, [&](Browser* b) {
-                            return b->profile() == browser()->profile();
-                          }));
-                auto* new_browser = browser_list->GetLastActive();
-                auto* browser_view =
-                    BrowserView::GetBrowserViewForBrowser(new_browser);
-                auto* tab = browser_view->tabstrip()->tab_at(0);
-                ASSERT_TRUE(tab);
-                // During the tab detaching, mouse should be over the dragged
-                // tab.
-                EXPECT_TRUE(tab->IsMouseHovered());
-                EXPECT_TRUE(tab->dragging());
-                ReleaseMouse();
-                new_browser->window()->Close();
-              }));
+  MoveMouseTo(
+      point_out_of_tabstrip, base::BindLambdaForTesting([&]() {
+        // Creating new browser during drag-and-drop will create
+        // a nested run loop. So we should do things within callback.
+        auto* browser_list = BrowserList::GetInstance();
+        EXPECT_EQ(2, std::ranges::count_if(*browser_list, [&](Browser* b) {
+                    return b->profile() == browser()->profile();
+                  }));
+        auto* new_browser = browser_list->GetLastActive();
+        auto* browser_view = BrowserView::GetBrowserViewForBrowser(new_browser);
+        auto* tab = browser_view->tabstrip()->tab_at(0);
+        ASSERT_TRUE(tab);
+        // During the tab detaching, mouse should be over the dragged
+        // tab.
+        EXPECT_TRUE(tab->IsMouseHovered());
+        EXPECT_TRUE(tab->dragging());
+        ReleaseMouse();
+        new_browser->window()->Close();
+      }));
 }
 
 #if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_LINUX)
@@ -1075,6 +1074,16 @@ IN_PROC_BROWSER_TEST_F(VerticalTabStripWithScrollableTabBrowserTest, Sanity) {
   // https://github.com/brave/brave-browser/issues/28877
   ToggleVerticalTabStrip();
   Browser::Create(Browser::CreateParams(browser()->profile(), true));
+}
+
+IN_PROC_BROWSER_TEST_F(VerticalTabStripWithScrollableTabBrowserTest,
+                       ToggleWithGroups) {
+  // Make sure browser works with both vertical tab and scrollable tab strip
+  // even with groups.
+  // https://github.com/brave/brave-browser/issues/46615
+  AddTabToNewGroup(browser(), 0);
+  ToggleVerticalTabStrip();  // To vertical tab strip
+  ToggleVerticalTabStrip();  // To horizontal tab strip
 }
 
 // * Non-type argument of 'float' or 'double' for template is unsupported


### PR DESCRIPTION
As adding groups needs the TabContainer to be in a valid state, 
especially state related to available width, we need to ensure 
that the TabContainer is updated before we add groups to it.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/46615

TEST=VerticalTabStripWithScrollableTabBrowserTest.ToggleWithGroups

### MANUAL TEST:
#### Steps to verify
* Turn on brave://flags/#scrollable-tabstrip feature flag
* Create a tab group
* Toggle tabs orientation to vertical and then back to horizontal

#### Expected behavior
There should be no crash

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
