### PR TITLE
Cherry-pick of crash fix for page-info bubble (uplift to 1.79.x)

### DIFF
--- a/patches/chrome-browser-ui-views-page_info-permission_toggle_row_view.cc.patch
+++ b/patches/chrome-browser-ui-views-page_info-permission_toggle_row_view.cc.patch
@@ -1,0 +1,16 @@
+diff --git a/chrome/browser/ui/views/page_info/permission_toggle_row_view.cc b/chrome/browser/ui/views/page_info/permission_toggle_row_view.cc
+index f78df0c4dec9629ab7efff7a488eb24657201e92..341ae3ddf2bc2b885c5aed3243cd76f4fac0fa4f 100644
+--- a/chrome/browser/ui/views/page_info/permission_toggle_row_view.cc
++++ b/chrome/browser/ui/views/page_info/permission_toggle_row_view.cc
+@@ -253,7 +253,10 @@ void PermissionToggleRowView::InitForUserSource(
+       auto spacer_view = std::make_unique<views::View>();
+       spacer_view->SetPreferredSize(gfx::Size(icon_size, icon_size));
+       spacer_view_ = row_view_->AddControl(std::move(spacer_view));
+-    } else {
++    } else if (toggle_button_) {
++      // toggle_button_ could be uninitialized if this row represents
++      // 'CAPTURED_SURFACE_CONTROL' permission type and that permission type
++      // is not found in `DoesSupportTemporaryGrants`.
+       toggle_button_->SetProperty(
+           views::kMarginsKey, gfx::Insets::TLBR(0, icon_label_spacing, 0, 0));
+     }


### PR DESCRIPTION
Uplift of #29468
Fixes https://github.com/brave/brave-browser/issues/46566

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.