### PR TITLE
[iOS] Disable insecure form warnings when using Chromium web views (uplift to 1.80.x)

### DIFF
--- a/ios/browser/web/brave_web_client.h
+++ b/ios/browser/web/brave_web_client.h
@@ -37,6 +37,8 @@ class BraveWebClient : public ChromeWebClient {
   void PostBrowserURLRewriterCreation(
       web::BrowserURLRewriter* rewriter) override;
 
+  bool IsInsecureFormWarningEnabled(
+      web::BrowserState* browser_state) const override;
   void BuildEditMenu(web::WebState* web_state,
                      id<UIMenuBuilder>) const override;
 

--- a/ios/browser/web/brave_web_client.mm
+++ b/ios/browser/web/brave_web_client.mm
@@ -99,6 +99,12 @@ void BraveWebClient::SetLegacyUserAgent(const std::string& user_agent) {
   legacy_user_agent_ = user_agent;
 }
 
+bool BraveWebClient::IsInsecureFormWarningEnabled(
+    web::BrowserState* browser_state) const {
+  // TODO: Remove when brave/brave-browser#46667 is implemented
+  return false;
+}
+
 void BraveWebClient::BuildEditMenu(web::WebState* web_state,
                                    id<UIMenuBuilder> builder) const {
   BraveWebView* webView =


### PR DESCRIPTION
Uplift of #29459
Resolves https://github.com/brave/brave-browser/issues/46668

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.