### PR TITLE
No ddns nav throttle for subframes (uplift to 1.80.x)

### DIFF
--- a/browser/brave_content_browser_client.cc
+++ b/browser/brave_content_browser_client.cc
@@ -1228,10 +1228,11 @@ BraveContentBrowserClient::CreateThrottlesForNavigation(
 #endif
 
   std::unique_ptr<content::NavigationThrottle>
-      decentralized_dns_navigation_throttle =
-          decentralized_dns::DecentralizedDnsNavigationThrottle::
-              MaybeCreateThrottleFor(handle, g_browser_process->local_state(),
-                                     g_browser_process->GetApplicationLocale());
+      decentralized_dns_navigation_throttle = decentralized_dns::
+          DecentralizedDnsNavigationThrottle::MaybeCreateThrottleFor(
+              handle, user_prefs::UserPrefs::Get(context),
+              g_browser_process->local_state(),
+              g_browser_process->GetApplicationLocale());
   if (decentralized_dns_navigation_throttle) {
     throttles.push_back(std::move(decentralized_dns_navigation_throttle));
   }

--- a/components/decentralized_dns/content/decentralized_dns_navigation_throttle.cc
+++ b/components/decentralized_dns/content/decentralized_dns_navigation_throttle.cc
@@ -28,6 +28,7 @@ namespace decentralized_dns {
 std::unique_ptr<DecentralizedDnsNavigationThrottle>
 DecentralizedDnsNavigationThrottle::MaybeCreateThrottleFor(
     content::NavigationHandle* navigation_handle,
+    PrefService* user_prefs,
     PrefService* local_state,
     const std::string& locale) {
   content::BrowserContext* context =
@@ -36,17 +37,21 @@ DecentralizedDnsNavigationThrottle::MaybeCreateThrottleFor(
     return nullptr;
   }
 
+  if (!navigation_handle->IsInMainFrame()) {
+    return nullptr;
+  }
+
   return std::make_unique<DecentralizedDnsNavigationThrottle>(
-      navigation_handle, local_state, locale);
+      navigation_handle, user_prefs, local_state, locale);
 }
 
 DecentralizedDnsNavigationThrottle::DecentralizedDnsNavigationThrottle(
     content::NavigationHandle* navigation_handle,
+    PrefService* user_prefs,
     PrefService* local_state,
     const std::string& locale)
     : content::NavigationThrottle(navigation_handle),
-      user_prefs_(user_prefs::UserPrefs::Get(
-          navigation_handle->GetWebContents()->GetBrowserContext())),
+      user_prefs_(user_prefs),
       local_state_(local_state),
       locale_(locale) {}
 

--- a/components/decentralized_dns/content/decentralized_dns_navigation_throttle.h
+++ b/components/decentralized_dns/content/decentralized_dns_navigation_throttle.h
@@ -24,6 +24,7 @@ class DecentralizedDnsNavigationThrottle : public content::NavigationThrottle {
  public:
   explicit DecentralizedDnsNavigationThrottle(
       content::NavigationHandle* navigation_handle,
+      PrefService* user_prefs,
       PrefService* local_state,
       const std::string& locale);
   ~DecentralizedDnsNavigationThrottle() override;
@@ -35,6 +36,7 @@ class DecentralizedDnsNavigationThrottle : public content::NavigationThrottle {
 
   static std::unique_ptr<DecentralizedDnsNavigationThrottle>
   MaybeCreateThrottleFor(content::NavigationHandle* navigation_handle,
+                         PrefService* user_prefs,
                          PrefService* local_state,
                          const std::string& locale);
 


### PR DESCRIPTION
Uplift of #29392
Resolves https://github.com/brave/brave-browser/issues/46703

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.