### PR TITLE
[IWYU] Fixing logging inclusions for Wallet

### DIFF
--- a/browser/brave_wallet/android/wallet_native_utils_android.cc
+++ b/browser/brave_wallet/android/wallet_native_utils_android.cc
@@ -5,7 +5,7 @@
 
 #include "base/android/jni_android.h"
 #include "base/android/jni_string.h"
-#include "base/logging.h"
+#include "base/check.h"
 #include "brave/browser/brave_wallet/brave_wallet_service_factory.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_service.h"
 #include "brave/components/decentralized_dns/core/utils.h"

--- a/browser/brave_wallet/brave_wallet_ethereum_chain_browsertest.cc
+++ b/browser/brave_wallet/brave_wallet_ethereum_chain_browsertest.cc
@@ -6,6 +6,7 @@
 #include <memory>
 #include <optional>
 
+#include "base/notreached.h"
 #include "base/path_service.h"
 #include "base/test/bind.h"
 #include "base/test/scoped_feature_list.h"

--- a/browser/brave_wallet/brave_wallet_policy_browsertest.cc
+++ b/browser/brave_wallet/brave_wallet_policy_browsertest.cc
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 
+#include "base/check.h"
 #include "brave/app/brave_command_ids.h"
 #include "brave/browser/brave_wallet/brave_wallet_context_utils.h"
 #include "brave/browser/brave_wallet/brave_wallet_service_factory.h"

--- a/browser/brave_wallet/brave_wallet_provider_delegate_impl.cc
+++ b/browser/brave_wallet/brave_wallet_provider_delegate_impl.cc
@@ -10,6 +10,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/check.h"
 #include "base/functional/bind.h"
 #include "base/strings/string_util.h"
 #include "brave/browser/brave_wallet/brave_wallet_provider_delegate_impl_helper.h"

--- a/browser/brave_wallet/brave_wallet_provider_delegate_impl_helper.cc
+++ b/browser/brave_wallet/brave_wallet_provider_delegate_impl_helper.cc
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include "base/notreached.h"
 #include "brave/browser/brave_wallet/brave_wallet_tab_helper.h"
 #include "brave/browser/ui/brave_pages.h"
 #include "chrome/browser/ui/browser_finder.h"

--- a/browser/brave_wallet/brave_wallet_provider_delegate_impl_helper_android.cc
+++ b/browser/brave_wallet/brave_wallet_provider_delegate_impl_helper_android.cc
@@ -8,7 +8,6 @@
 #include "base/android/callback_android.h"
 #include "base/android/jni_android.h"
 #include "base/android/jni_string.h"
-#include "base/notreached.h"
 #include "brave/browser/brave_wallet/brave_wallet_tab_helper.h"
 #include "brave/components/brave_wallet/common/brave_wallet.mojom.h"
 #include "chrome/android/chrome_jni_headers/BraveWalletProviderDelegateImplHelper_jni.h"

--- a/browser/brave_wallet/brave_wallet_service_delegate_impl.cc
+++ b/browser/brave_wallet/brave_wallet_service_delegate_impl.cc
@@ -8,6 +8,7 @@
 #include <optional>
 #include <utility>
 
+#include "base/check.h"
 #include "base/types/expected.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_utils.h"
 #include "brave/components/brave_wallet/browser/permission_utils.h"

--- a/browser/brave_wallet/brave_wallet_service_delegate_impl_android.cc
+++ b/browser/brave_wallet/brave_wallet_service_delegate_impl_android.cc
@@ -10,6 +10,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/check_op.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_utils.h"
 #include "brave/components/brave_wallet/browser/permission_utils.h"
 #include "brave/components/permissions/contexts/brave_wallet_permission_context.h"

--- a/browser/brave_wallet/brave_wallet_tab_helper.cc
+++ b/browser/brave_wallet/brave_wallet_tab_helper.cc
@@ -9,6 +9,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/check.h"
 #include "brave/browser/brave_wallet/brave_wallet_provider_delegate_impl.h"
 #include "brave/browser/brave_wallet/brave_wallet_service_factory.h"
 #include "brave/components/brave_wallet/browser/ethereum_provider_impl.h"

--- a/browser/brave_wallet/eth_allowance_manager_unittest.cc
+++ b/browser/brave_wallet/eth_allowance_manager_unittest.cc
@@ -11,6 +11,7 @@
 #include <string_view>
 #include <utility>
 
+#include "base/check.h"
 #include "base/memory/raw_ptr.h"
 #include "base/strings/string_util.h"
 #include "base/test/bind.h"

--- a/browser/brave_wallet/external_wallets_importer.cc
+++ b/browser/brave_wallet/external_wallets_importer.cc
@@ -11,8 +11,11 @@
 #include <vector>
 
 #include "base/base64.h"
+#include "base/check.h"
 #include "base/functional/bind.h"
 #include "base/json/json_reader.h"
+#include "base/logging.h"
+#include "base/notreached.h"
 #include "base/strings/utf_string_conversion_utils.h"
 #include "base/task/bind_post_task.h"
 #include "base/task/sequenced_task_runner.h"

--- a/browser/brave_wallet/notifications/wallet_notification_service.cc
+++ b/browser/brave_wallet/notifications/wallet_notification_service.cc
@@ -8,6 +8,7 @@
 #include <memory>
 #include <string>
 
+#include "base/logging.h"
 #include "base/strings/utf_string_conversions.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_service.h"
 #include "brave/components/brave_wallet/browser/tx_service.h"

--- a/browser/brave_wallet/solana_provider_impl_unittest.cc
+++ b/browser/brave_wallet/solana_provider_impl_unittest.cc
@@ -9,6 +9,7 @@
 #include <optional>
 #include <vector>
 
+#include "base/check.h"
 #include "base/json/json_reader.h"
 #include "base/memory/raw_ptr.h"
 #include "base/test/bind.h"

--- a/browser/ui/webui/brave_wallet/android/android_wallet_page_handler.cc
+++ b/browser/ui/webui/brave_wallet/android/android_wallet_page_handler.cc
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include "base/check.h"
 #include "brave/browser/brave_wallet/brave_wallet_provider_delegate_impl_helper.h"
 
 AndroidWalletPageHandler::AndroidWalletPageHandler(

--- a/browser/ui/webui/brave_wallet/android/android_wallet_page_ui.cc
+++ b/browser/ui/webui/brave_wallet/android/android_wallet_page_ui.cc
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include "base/check.h"
 #include "base/command_line.h"
 #include "base/strings/string_util.h"
 #include "brave/browser/brave_wallet/asset_ratio_service_factory.h"

--- a/browser/ui/webui/brave_wallet/page_handler/wallet_page_handler.cc
+++ b/browser/ui/webui/brave_wallet/page_handler/wallet_page_handler.cc
@@ -7,6 +7,8 @@
 
 #include <utility>
 
+#include "base/notreached.h"
+
 #if defined(TOOLKIT_VIEWS)
 #include "brave/browser/ui/browser_commands.h"
 #include "chrome/browser/ui/browser_finder.h"

--- a/browser/ui/webui/brave_wallet/panel_handler/wallet_panel_handler.cc
+++ b/browser/ui/webui/brave_wallet/panel_handler/wallet_panel_handler.cc
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include "base/check.h"
 #include "base/functional/callback.h"
 #include "brave/browser/brave_wallet/brave_wallet_tab_helper.h"
 #include "brave/components/brave_wallet/browser/permission_utils.h"

--- a/browser/ui/webui/brave_wallet/wallet_page_ui.cc
+++ b/browser/ui/webui/brave_wallet/wallet_page_ui.cc
@@ -8,6 +8,7 @@
 #include <string>
 #include <utility>
 
+#include "base/check.h"
 #include "base/command_line.h"
 #include "base/files/file_path.h"
 #include "brave/browser/brave_wallet/asset_ratio_service_factory.h"

--- a/browser/ui/webui/brave_wallet/wallet_panel_ui.cc
+++ b/browser/ui/webui/brave_wallet/wallet_panel_ui.cc
@@ -8,6 +8,7 @@
 #include <string>
 #include <utility>
 
+#include "base/check.h"
 #include "base/command_line.h"
 #include "base/strings/strcat.h"
 #include "base/strings/string_util.h"

--- a/components/brave_wallet/browser/account_discovery_manager.cc
+++ b/components/brave_wallet/browser/account_discovery_manager.cc
@@ -5,8 +5,10 @@
 
 #include "brave/components/brave_wallet/browser/account_discovery_manager.h"
 
+#include "base/check.h"
 #include "base/check_is_test.h"
 #include "base/functional/bind.h"
+#include "base/notreached.h"
 #include "base/strings/strcat.h"
 #include "base/strings/string_number_conversions.h"
 #include "brave/components/brave_wallet/browser/bitcoin/bitcoin_wallet_service.h"

--- a/components/brave_wallet/browser/account_resolver_delegate_impl.cc
+++ b/components/brave_wallet/browser/account_resolver_delegate_impl.cc
@@ -5,6 +5,7 @@
 
 #include "brave/components/brave_wallet/browser/account_resolver_delegate_impl.h"
 
+#include "base/check.h"
 #include "base/strings/string_util.h"
 
 namespace brave_wallet {

--- a/components/brave_wallet/browser/android_page_appearing_browsertest.cc
+++ b/components/brave_wallet/browser/android_page_appearing_browsertest.cc
@@ -7,7 +7,9 @@
 #include <optional>
 #include <string_view>
 
+#include "base/check.h"
 #include "base/files/scoped_temp_dir.h"
+#include "base/logging.h"
 #include "base/strings/pattern.h"
 #include "base/strings/strcat.h"
 #include "base/strings/string_util.h"

--- a/components/brave_wallet/browser/asset_ratio_response_parser.cc
+++ b/components/brave_wallet/browser/asset_ratio_response_parser.cc
@@ -5,6 +5,7 @@
 
 #include "brave/components/brave_wallet/browser/asset_ratio_response_parser.h"
 
+#include "base/check.h"
 #include "base/logging.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/stringprintf.h"

--- a/components/brave_wallet/browser/bitcoin/bitcoin_base_keyring.cc
+++ b/components/brave_wallet/browser/bitcoin/bitcoin_base_keyring.cc
@@ -5,6 +5,7 @@
 
 #include "brave/components/brave_wallet/browser/bitcoin/bitcoin_base_keyring.h"
 
+#include "base/check.h"
 #include "brave/components/brave_wallet/common/common_utils.h"
 
 namespace brave_wallet {

--- a/components/brave_wallet/browser/bitcoin/bitcoin_hd_keyring.cc
+++ b/components/brave_wallet/browser/bitcoin/bitcoin_hd_keyring.cc
@@ -11,7 +11,6 @@
 
 #include "base/check.h"
 #include "base/containers/span.h"
-#include "base/notimplemented.h"
 #include "brave/components/brave_wallet/browser/internal/hd_key_common.h"
 #include "brave/components/brave_wallet/common/bitcoin_utils.h"
 #include "brave/components/brave_wallet/common/common_utils.h"

--- a/components/brave_wallet/browser/bitcoin/bitcoin_knapsack_solver.cc
+++ b/components/brave_wallet/browser/bitcoin/bitcoin_knapsack_solver.cc
@@ -8,6 +8,8 @@
 #include <algorithm>
 #include <utility>
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "base/rand_util.h"
 #include "base/types/expected.h"
 #include "brave/components/brave_wallet/browser/bitcoin/bitcoin_serializer.h"

--- a/components/brave_wallet/browser/bitcoin/bitcoin_max_send_solver.cc
+++ b/components/brave_wallet/browser/bitcoin/bitcoin_max_send_solver.cc
@@ -7,6 +7,8 @@
 
 #include <utility>
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "base/types/expected.h"
 #include "brave/components/brave_wallet/browser/bitcoin/bitcoin_serializer.h"
 #include "brave/components/brave_wallet/common/bitcoin_utils.h"

--- a/components/brave_wallet/browser/bitcoin/bitcoin_rpc.cc
+++ b/components/brave_wallet/browser/bitcoin/bitcoin_rpc.cc
@@ -9,6 +9,7 @@
 #include <optional>
 
 #include "base/check.h"
+#include "base/check_op.h"
 #include "base/functional/bind.h"
 #include "base/strings/strcat.h"
 #include "base/strings/string_number_conversions.h"

--- a/components/brave_wallet/browser/bitcoin/bitcoin_serializer.cc
+++ b/components/brave_wallet/browser/bitcoin/bitcoin_serializer.cc
@@ -8,6 +8,9 @@
 #include <optional>
 #include <utility>
 
+#include "base/check.h"
+#include "base/check_op.h"
+#include "base/notreached.h"
 #include "brave/components/brave_wallet/common/bitcoin_utils.h"
 #include "brave/components/brave_wallet/common/btc_like_serializer_stream.h"
 #include "brave/components/brave_wallet/common/hash_utils.h"

--- a/components/brave_wallet/browser/bitcoin/bitcoin_test_utils.cc
+++ b/components/brave_wallet/browser/bitcoin/bitcoin_test_utils.cc
@@ -10,6 +10,7 @@
 #include <optional>
 #include <string>
 
+#include "base/notreached.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/string_split.h"
 #include "base/test/values_test_util.h"

--- a/components/brave_wallet/browser/bitcoin/bitcoin_transaction.cc
+++ b/components/brave_wallet/browser/bitcoin/bitcoin_transaction.cc
@@ -11,6 +11,8 @@
 #include <utility>
 #include <vector>
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "base/rand_util.h"
 #include "base/strings/string_number_conversions.h"
 #include "brave/components/brave_wallet/common/bitcoin_utils.h"

--- a/components/brave_wallet/browser/bitcoin/bitcoin_tx_manager.cc
+++ b/components/brave_wallet/browser/bitcoin/bitcoin_tx_manager.cc
@@ -11,7 +11,10 @@
 #include <string>
 #include <utility>
 
+#include "base/check.h"
 #include "base/functional/bind.h"
+#include "base/logging.h"
+#include "base/notimplemented.h"
 #include "base/notreached.h"
 #include "brave/components/brave_wallet/browser/bitcoin/bitcoin_block_tracker.h"
 #include "brave/components/brave_wallet/browser/bitcoin/bitcoin_transaction.h"

--- a/components/brave_wallet/browser/bitcoin/bitcoin_tx_meta.cc
+++ b/components/brave_wallet/browser/bitcoin/bitcoin_tx_meta.cc
@@ -9,6 +9,7 @@
 #include <string>
 #include <vector>
 
+#include "base/check_op.h"
 #include "base/strings/string_number_conversions.h"
 #include "brave/components/brave_wallet/browser/bitcoin/bitcoin_transaction.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_utils.h"

--- a/components/brave_wallet/browser/blockchain_list_parser.cc
+++ b/components/brave_wallet/browser/blockchain_list_parser.cc
@@ -10,6 +10,7 @@
 #include <tuple>
 #include <utility>
 
+#include "base/check.h"
 #include "base/json/json_reader.h"
 #include "base/logging.h"
 #include "base/strings/strcat.h"

--- a/components/brave_wallet/browser/blockchain_registry.cc
+++ b/components/brave_wallet/browser/blockchain_registry.cc
@@ -11,6 +11,7 @@
 
 #include "base/containers/flat_set.h"
 #include "base/files/file_path.h"
+#include "base/logging.h"
 #include "base/no_destructor.h"
 #include "base/strings/string_util.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_constants.h"

--- a/components/brave_wallet/browser/brave_wallet_p3a.cc
+++ b/components/brave_wallet/browser/brave_wallet_p3a.cc
@@ -10,7 +10,10 @@
 #include <string>
 #include <utility>
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "base/command_line.h"
+#include "base/logging.h"
 #include "base/metrics/histogram_functions.h"
 #include "base/metrics/histogram_macros.h"
 #include "base/notreached.h"

--- a/components/brave_wallet/browser/brave_wallet_prefs.cc
+++ b/components/brave_wallet/browser/brave_wallet_prefs.cc
@@ -9,6 +9,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/check.h"
 #include "base/values.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_constants.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_service.h"

--- a/components/brave_wallet/browser/brave_wallet_service.cc
+++ b/components/brave_wallet/browser/brave_wallet_service.cc
@@ -11,7 +11,10 @@
 #include <optional>
 #include <vector>
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "base/containers/contains.h"
+#include "base/logging.h"
 #include "base/notreached.h"
 #include "base/strings/string_util.h"
 #include "base/values.h"

--- a/components/brave_wallet/browser/brave_wallet_service_delegate.cc
+++ b/components/brave_wallet/browser/brave_wallet_service_delegate.cc
@@ -9,6 +9,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/notimplemented.h"
 #include "base/types/expected.h"
 
 namespace brave_wallet {

--- a/components/brave_wallet/browser/brave_wallet_utils.cc
+++ b/components/brave_wallet/browser/brave_wallet_utils.cc
@@ -11,6 +11,7 @@
 #include <utility>
 
 #include "base/check.h"
+#include "base/check_op.h"
 #include "base/containers/span.h"
 #include "base/notreached.h"
 #include "base/strings/strcat.h"

--- a/components/brave_wallet/browser/cardano/cardano_create_transaction_task.cc
+++ b/components/brave_wallet/browser/cardano/cardano_create_transaction_task.cc
@@ -11,6 +11,8 @@
 #include <utility>
 #include <vector>
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "base/functional/bind.h"
 #include "base/memory/scoped_refptr.h"
 #include "base/task/bind_post_task.h"

--- a/components/brave_wallet/browser/cardano/cardano_knapsack_solver.cc
+++ b/components/brave_wallet/browser/cardano/cardano_knapsack_solver.cc
@@ -8,6 +8,8 @@
 #include <algorithm>
 #include <utility>
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "base/numerics/clamped_math.h"
 #include "base/rand_util.h"
 #include "base/types/expected.h"

--- a/components/brave_wallet/browser/cardano/cardano_max_send_solver.cc
+++ b/components/brave_wallet/browser/cardano/cardano_max_send_solver.cc
@@ -8,6 +8,8 @@
 #include <algorithm>
 #include <utility>
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "base/numerics/clamped_math.h"
 #include "base/rand_util.h"
 #include "base/types/expected.h"

--- a/components/brave_wallet/browser/cardano/cardano_rpc.cc
+++ b/components/brave_wallet/browser/cardano/cardano_rpc.cc
@@ -12,6 +12,7 @@
 
 #include "base/check.h"
 #include "base/check_is_test.h"
+#include "base/check_op.h"
 #include "base/command_line.h"
 #include "base/containers/span.h"
 #include "base/functional/bind.h"

--- a/components/brave_wallet/browser/cardano/cardano_serializer.cc
+++ b/components/brave_wallet/browser/cardano/cardano_serializer.cc
@@ -10,6 +10,7 @@
 #include <optional>
 #include <utility>
 
+#include "base/check.h"
 #include "brave/components/brave_wallet/browser/cardano/cardano_transaction.h"
 #include "brave/components/brave_wallet/common/hash_utils.h"
 #include "components/cbor/values.h"

--- a/components/brave_wallet/browser/cardano/cardano_test_utils.cc
+++ b/components/brave_wallet/browser/cardano/cardano_test_utils.cc
@@ -14,6 +14,7 @@
 
 #include "base/containers/extend.h"
 #include "base/json/json_writer.h"
+#include "base/notreached.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/string_split.h"
 #include "base/values.h"

--- a/components/brave_wallet/browser/cardano/cardano_transaction.cc
+++ b/components/brave_wallet/browser/cardano/cardano_transaction.cc
@@ -11,6 +11,8 @@
 #include <utility>
 #include <vector>
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "base/numerics/clamped_math.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/types/optional_util.h"

--- a/components/brave_wallet/browser/cardano/cardano_tx_manager.cc
+++ b/components/brave_wallet/browser/cardano/cardano_tx_manager.cc
@@ -12,6 +12,7 @@
 #include <utility>
 
 #include "base/functional/bind.h"
+#include "base/notimplemented.h"
 #include "base/notreached.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_utils.h"
 #include "brave/components/brave_wallet/browser/cardano/cardano_block_tracker.h"

--- a/components/brave_wallet/browser/cardano/cardano_tx_meta.cc
+++ b/components/brave_wallet/browser/cardano/cardano_tx_meta.cc
@@ -9,6 +9,7 @@
 #include <string>
 #include <vector>
 
+#include "base/check_op.h"
 #include "base/strings/string_number_conversions.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_utils.h"
 #include "brave/components/brave_wallet/browser/cardano/cardano_transaction.h"

--- a/components/brave_wallet/browser/cardano/cardano_wallet_service.cc
+++ b/components/brave_wallet/browser/cardano/cardano_wallet_service.cc
@@ -13,6 +13,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/check.h"
 #include "base/notreached.h"
 #include "base/types/expected.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_utils.h"

--- a/components/brave_wallet/browser/eip1559_transaction.cc
+++ b/components/brave_wallet/browser/eip1559_transaction.cc
@@ -9,6 +9,7 @@
 #include <optional>
 #include <utility>
 
+#include "base/check.h"
 #include "base/containers/extend.h"
 #include "base/values.h"
 #include "brave/components/brave_wallet/browser/rlp_encode.h"

--- a/components/brave_wallet/browser/eip2930_transaction.cc
+++ b/components/brave_wallet/browser/eip2930_transaction.cc
@@ -8,6 +8,7 @@
 #include <optional>
 #include <utility>
 
+#include "base/check.h"
 #include "base/containers/extend.h"
 #include "base/values.h"
 #include "brave/components/brave_wallet/browser/rlp_encode.h"

--- a/components/brave_wallet/browser/ens_resolver_task.cc
+++ b/components/brave_wallet/browser/ens_resolver_task.cc
@@ -10,6 +10,8 @@
 #include <optional>
 #include <utility>
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "base/compiler_specific.h"
 #include "base/containers/contains.h"
 #include "base/json/json_writer.h"

--- a/components/brave_wallet/browser/ens_resolver_task.h
+++ b/components/brave_wallet/browser/ens_resolver_task.h
@@ -12,6 +12,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/check.h"
 #include "base/functional/callback_forward.h"
 #include "base/memory/weak_ptr.h"
 #include "base/notreached.h"

--- a/components/brave_wallet/browser/eth_abi_decoder.cc
+++ b/components/brave_wallet/browser/eth_abi_decoder.cc
@@ -13,6 +13,7 @@
 #include "base/containers/span.h"
 #include "base/containers/span_reader.h"
 #include "base/memory/raw_span.h"
+#include "base/notreached.h"
 #include "base/strings/strcat.h"
 #include "base/strings/string_number_conversions.h"
 #include "brave/components/brave_wallet/common/eth_abi_utils.h"

--- a/components/brave_wallet/browser/eth_allowance_manager.cc
+++ b/components/brave_wallet/browser/eth_allowance_manager.cc
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <utility>
 
+#include "base/check.h"
 #include "base/no_destructor.h"
 #include "base/strings/string_util.h"
 #include "brave/components/brave_wallet/browser/blockchain_registry.h"

--- a/components/brave_wallet/browser/eth_data_builder.cc
+++ b/components/brave_wallet/browser/eth_data_builder.cc
@@ -10,9 +10,9 @@
 #include <optional>
 
 #include "base/check.h"
+#include "base/check_op.h"
 #include "base/containers/fixed_flat_map.h"
 #include "base/containers/span.h"
-#include "base/logging.h"
 #include "base/notreached.h"
 #include "base/strings/strcat.h"
 #include "base/strings/string_util.h"

--- a/components/brave_wallet/browser/eth_data_parser.cc
+++ b/components/brave_wallet/browser/eth_data_parser.cc
@@ -10,6 +10,7 @@
 #include <tuple>
 #include <utility>
 
+#include "base/check_op.h"
 #include "base/strings/strcat.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_constants.h"
 #include "brave/components/brave_wallet/browser/eth_abi_decoder.h"

--- a/components/brave_wallet/browser/eth_logs_tracker.cc
+++ b/components/brave_wallet/browser/eth_logs_tracker.cc
@@ -8,6 +8,9 @@
 #include <string>
 #include <utility>
 
+#include "base/check.h"
+#include "base/logging.h"
+
 namespace brave_wallet {
 
 EthLogsTracker::EthLogsTracker(JsonRpcService* json_rpc_service)

--- a/components/brave_wallet/browser/eth_nonce_tracker.cc
+++ b/components/brave_wallet/browser/eth_nonce_tracker.cc
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <utility>
 
+#include "base/check.h"
 #include "base/functional/bind.h"
 #include "brave/components/brave_wallet/browser/eth_tx_meta.h"
 #include "brave/components/brave_wallet/browser/json_rpc_service.h"

--- a/components/brave_wallet/browser/eth_pending_tx_tracker.cc
+++ b/components/brave_wallet/browser/eth_pending_tx_tracker.cc
@@ -9,6 +9,7 @@
 #include <optional>
 #include <utility>
 
+#include "base/check.h"
 #include "brave/components/brave_wallet/browser/eth_nonce_tracker.h"
 #include "brave/components/brave_wallet/browser/eth_tx_meta.h"
 #include "brave/components/brave_wallet/browser/json_rpc_service.h"

--- a/components/brave_wallet/browser/eth_response_parser.cc
+++ b/components/brave_wallet/browser/eth_response_parser.cc
@@ -9,6 +9,7 @@
 #include <tuple>
 #include <utility>
 
+#include "base/check.h"
 #include "base/strings/string_number_conversions.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_utils.h"
 #include "brave/components/brave_wallet/browser/eth_abi_decoder.h"

--- a/components/brave_wallet/browser/eth_transaction.cc
+++ b/components/brave_wallet/browser/eth_transaction.cc
@@ -9,6 +9,7 @@
 #include <utility>
 
 #include "base/base64.h"
+#include "base/check.h"
 #include "base/containers/to_vector.h"
 #include "base/logging.h"
 #include "base/values.h"

--- a/components/brave_wallet/browser/eth_tx_manager.cc
+++ b/components/brave_wallet/browser/eth_tx_manager.cc
@@ -13,6 +13,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/check.h"
 #include "base/functional/bind.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/string_util.h"

--- a/components/brave_wallet/browser/eth_tx_manager_unittest.cc
+++ b/components/brave_wallet/browser/eth_tx_manager_unittest.cc
@@ -15,6 +15,7 @@
 
 #include "base/files/scoped_temp_dir.h"
 #include "base/functional/callback_helpers.h"
+#include "base/logging.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/string_util.h"
 #include "base/task/sequenced_task_runner.h"

--- a/components/brave_wallet/browser/eth_tx_meta.cc
+++ b/components/brave_wallet/browser/eth_tx_meta.cc
@@ -9,6 +9,7 @@
 #include <string>
 #include <vector>
 
+#include "base/check_op.h"
 #include "base/logging.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_constants.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_utils.h"

--- a/components/brave_wallet/browser/ethereum_provider_impl.cc
+++ b/components/brave_wallet/browser/ethereum_provider_impl.cc
@@ -12,10 +12,12 @@
 #include <utility>
 #include <vector>
 
+#include "base/check.h"
 #include "base/containers/contains.h"
 #include "base/containers/to_vector.h"
 #include "base/json/json_reader.h"
 #include "base/json/json_writer.h"
+#include "base/notreached.h"
 #include "base/strings/strcat.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/string_util.h"

--- a/components/brave_wallet/browser/fil_block_tracker.cc
+++ b/components/brave_wallet/browser/fil_block_tracker.cc
@@ -10,6 +10,7 @@
 
 #include "base/containers/contains.h"
 #include "base/functional/bind.h"
+#include "base/logging.h"
 #include "brave/components/brave_wallet/browser/json_rpc_service.h"
 
 namespace brave_wallet {

--- a/components/brave_wallet/browser/fil_nonce_tracker.cc
+++ b/components/brave_wallet/browser/fil_nonce_tracker.cc
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <utility>
 
+#include "base/check.h"
 #include "brave/components/brave_wallet/browser/fil_tx_meta.h"
 #include "brave/components/brave_wallet/browser/json_rpc_service.h"
 #include "brave/components/brave_wallet/browser/tx_state_manager.h"

--- a/components/brave_wallet/browser/fil_transaction.cc
+++ b/components/brave_wallet/browser/fil_transaction.cc
@@ -12,6 +12,7 @@
 #include <utility>
 
 #include "base/base64.h"
+#include "base/check.h"
 #include "base/containers/adapters.h"
 #include "base/containers/span.h"
 #include "base/json/json_reader.h"

--- a/components/brave_wallet/browser/fil_tx_manager.cc
+++ b/components/brave_wallet/browser/fil_tx_manager.cc
@@ -11,7 +11,10 @@
 #include <string>
 #include <utility>
 
-#include "base/notreached.h"
+#include "base/check.h"
+#include "base/check_op.h"
+#include "base/logging.h"
+#include "base/notimplemented.h"
 #include "brave/components/brave_wallet/browser/account_resolver_delegate.h"
 #include "brave/components/brave_wallet/browser/fil_block_tracker.h"
 #include "brave/components/brave_wallet/browser/fil_nonce_tracker.h"

--- a/components/brave_wallet/browser/fil_tx_meta.cc
+++ b/components/brave_wallet/browser/fil_tx_meta.cc
@@ -8,6 +8,7 @@
 #include <string>
 #include <vector>
 
+#include "base/check_op.h"
 #include "base/values.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_utils.h"
 #include "brave/components/brave_wallet/browser/fil_transaction.h"

--- a/components/brave_wallet/browser/filecoin_keyring.cc
+++ b/components/brave_wallet/browser/filecoin_keyring.cc
@@ -10,10 +10,12 @@
 #include <vector>
 
 #include "base/base64.h"
+#include "base/check.h"
 #include "base/containers/contains.h"
 #include "base/containers/span_rust.h"
 #include "base/containers/to_vector.h"
 #include "base/json/json_reader.h"
+#include "base/logging.h"
 #include "base/notreached.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/string_util.h"

--- a/components/brave_wallet/browser/internal/hd_key_ed25519.cc
+++ b/components/brave_wallet/browser/internal/hd_key_ed25519.cc
@@ -8,7 +8,7 @@
 #include <memory>
 #include <utility>
 
-#include "base/check.h"
+#include "base/check_op.h"
 #include "base/containers/span.h"
 #include "base/containers/span_writer.h"
 #include "base/containers/to_vector.h"

--- a/components/brave_wallet/browser/internal/hd_key_ed25519_slip23.cc
+++ b/components/brave_wallet/browser/internal/hd_key_ed25519_slip23.cc
@@ -11,6 +11,7 @@
 #include <utility>
 
 #include "base/check.h"
+#include "base/check_op.h"
 #include "base/containers/span.h"
 #include "base/containers/span_writer.h"
 #include "crypto/hmac.h"

--- a/components/brave_wallet/browser/internal/orchard_storage/orchard_storage.cc
+++ b/components/brave_wallet/browser/internal/orchard_storage/orchard_storage.cc
@@ -11,6 +11,7 @@
 #include <string>
 #include <utility>
 
+#include "base/check.h"
 #include "base/containers/to_vector.h"
 #include "base/files/file_util.h"
 #include "base/threading/scoped_blocking_call.h"

--- a/components/brave_wallet/browser/internal/orchard_storage/orchard_storage.h
+++ b/components/brave_wallet/browser/internal/orchard_storage/orchard_storage.h
@@ -11,6 +11,7 @@
 #include <string>
 #include <vector>
 
+#include "base/check.h"
 #include "base/containers/span.h"
 #include "base/files/file_path.h"
 #include "base/sequence_checker.h"

--- a/components/brave_wallet/browser/internal/orchard_sync_state.cc
+++ b/components/brave_wallet/browser/internal/orchard_sync_state.cc
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <utility>
 
+#include "base/check.h"
 #include "base/check_is_test.h"
 #include "base/containers/extend.h"
 #include "base/types/expected_macros.h"

--- a/components/brave_wallet/browser/json_rpc_response_parser.h
+++ b/components/brave_wallet/browser/json_rpc_response_parser.h
@@ -10,8 +10,8 @@
 #include <string>
 #include <vector>
 
+#include "base/check.h"
 #include "base/json/json_reader.h"
-#include "base/logging.h"
 #include "base/values.h"
 #include "brave/components/brave_wallet/browser/json_rpc_responses.h"
 #include "brave/components/brave_wallet/common/brave_wallet.mojom.h"

--- a/components/brave_wallet/browser/json_rpc_service_unittest.cc
+++ b/components/brave_wallet/browser/json_rpc_service_unittest.cc
@@ -16,6 +16,7 @@
 #include <vector>
 
 #include "base/base64.h"
+#include "base/check.h"
 #include "base/containers/span.h"
 #include "base/containers/span_writer.h"
 #include "base/functional/bind.h"

--- a/components/brave_wallet/browser/keyring_service.cc
+++ b/components/brave_wallet/browser/keyring_service.cc
@@ -12,6 +12,7 @@
 #include <utility>
 
 #include "base/base64.h"
+#include "base/check.h"
 #include "base/check_is_test.h"
 #include "base/check_op.h"
 #include "base/command_line.h"

--- a/components/brave_wallet/browser/keyring_service_migrations.cc
+++ b/components/brave_wallet/browser/keyring_service_migrations.cc
@@ -12,7 +12,7 @@
 #include <vector>
 
 #include "base/base64.h"
-#include "base/check_op.h"
+#include "base/check.h"
 #include "base/containers/span.h"
 #include "base/notreached.h"
 #include "base/strings/string_number_conversions.h"

--- a/components/brave_wallet/browser/keyring_service_prefs.cc
+++ b/components/brave_wallet/browser/keyring_service_prefs.cc
@@ -9,6 +9,8 @@
 #include <utility>
 #include <vector>
 
+#include "base/check.h"
+#include "base/notreached.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/values.h"
 #include "brave/components/brave_wallet/browser/pref_names.h"

--- a/components/brave_wallet/browser/keyring_service_unittest.cc
+++ b/components/brave_wallet/browser/keyring_service_unittest.cc
@@ -11,6 +11,7 @@
 #include <utility>
 
 #include "base/base64.h"
+#include "base/check.h"
 #include "base/containers/span.h"
 #include "base/files/scoped_temp_dir.h"
 #include "base/functional/callback_helpers.h"

--- a/components/brave_wallet/browser/meld_integration_response_parser.cc
+++ b/components/brave_wallet/browser/meld_integration_response_parser.cc
@@ -10,6 +10,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/logging.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/types/expected.h"
 #include "brave/components/brave_wallet/browser/meld_integration_responses.h"

--- a/components/brave_wallet/browser/meld_integration_service.cc
+++ b/components/brave_wallet/browser/meld_integration_service.cc
@@ -12,11 +12,11 @@
 #include <utility>
 #include <vector>
 
+#include "base/check.h"
 #include "base/containers/flat_map.h"
 #include "base/environment.h"
 #include "base/functional/bind.h"
 #include "base/json/json_writer.h"
-#include "base/logging.h"
 #include "base/no_destructor.h"
 #include "base/task/thread_pool.h"
 #include "base/values.h"

--- a/components/brave_wallet/browser/network_manager.cc
+++ b/components/brave_wallet/browser/network_manager.cc
@@ -11,6 +11,7 @@
 
 #include "base/check.h"
 #include "base/check_is_test.h"
+#include "base/check_op.h"
 #include "base/command_line.h"
 #include "base/containers/contains.h"
 #include "base/containers/extend.h"

--- a/components/brave_wallet/browser/nft_metadata_fetcher.cc
+++ b/components/brave_wallet/browser/nft_metadata_fetcher.cc
@@ -12,6 +12,7 @@
 #include "base/base64.h"
 #include "base/containers/span.h"
 #include "base/json/json_writer.h"
+#include "base/logging.h"
 #include "base/numerics/byte_conversions.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_utils.h"
 #include "brave/components/brave_wallet/browser/eth_response_parser.h"

--- a/components/brave_wallet/browser/password_encryptor.cc
+++ b/components/brave_wallet/browser/password_encryptor.cc
@@ -9,6 +9,7 @@
 #include <utility>
 
 #include "base/base64.h"
+#include "base/check.h"
 #include "base/containers/span.h"
 #include "base/no_destructor.h"
 #include "crypto/aead.h"

--- a/components/brave_wallet/browser/permission_utils.cc
+++ b/components/brave_wallet/browser/permission_utils.cc
@@ -8,6 +8,7 @@
 #include <optional>
 #include <string_view>
 
+#include "base/check.h"
 #include "base/no_destructor.h"
 #include "base/strings/strcat.h"
 #include "base/strings/string_util.h"

--- a/components/brave_wallet/browser/simple_hash_client.cc
+++ b/components/brave_wallet/browser/simple_hash_client.cc
@@ -9,6 +9,7 @@
 #include <optional>
 #include <utility>
 
+#include "base/check_op.h"
 #include "base/containers/map_util.h"
 #include "base/containers/to_vector.h"
 #include "base/no_destructor.h"

--- a/components/brave_wallet/browser/simulation_request_helper.cc
+++ b/components/brave_wallet/browser/simulation_request_helper.cc
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "base/base64.h"
+#include "base/check.h"
 #include "base/values.h"
 #include "brave/components/brave_wallet/browser/json_rpc_requests_helper.h"
 #include "brave/components/brave_wallet/browser/solana_transaction.h"

--- a/components/brave_wallet/browser/simulation_service.cc
+++ b/components/brave_wallet/browser/simulation_service.cc
@@ -7,6 +7,7 @@
 #include <optional>
 #include <utility>
 
+#include "base/check.h"
 #include "base/no_destructor.h"
 #include "base/strings/stringprintf.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_constants.h"

--- a/components/brave_wallet/browser/siwe_message_parser.cc
+++ b/components/brave_wallet/browser/siwe_message_parser.cc
@@ -10,6 +10,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/check.h"
 #include "base/containers/contains.h"
 #include "base/strings/strcat.h"
 #include "base/strings/string_number_conversions.h"

--- a/components/brave_wallet/browser/sns_resolver_task.cc
+++ b/components/brave_wallet/browser/sns_resolver_task.cc
@@ -12,6 +12,8 @@
 #include <vector>
 
 #include "base/base64.h"
+#include "base/check.h"
+#include "base/check_op.h"
 #include "base/containers/span.h"
 #include "base/memory/raw_span.h"
 #include "base/no_destructor.h"

--- a/components/brave_wallet/browser/sns_resolver_task.h
+++ b/components/brave_wallet/browser/sns_resolver_task.h
@@ -12,6 +12,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/check.h"
 #include "base/memory/weak_ptr.h"
 #include "base/notreached.h"
 #include "brave/components/api_request_helper/api_request_helper.h"

--- a/components/brave_wallet/browser/solana_compiled_instruction.cc
+++ b/components/brave_wallet/browser/solana_compiled_instruction.cc
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <optional>
 
+#include "base/check.h"
 #include "brave/components/brave_wallet/browser/solana_instruction.h"
 #include "brave/components/brave_wallet/browser/solana_message_address_table_lookup.h"
 #include "brave/components/brave_wallet/common/solana_address.h"

--- a/components/brave_wallet/browser/solana_instruction.cc
+++ b/components/brave_wallet/browser/solana_instruction.cc
@@ -12,7 +12,6 @@
 #include <utility>
 
 #include "base/base64.h"
-#include "base/check.h"
 #include "base/containers/span.h"
 #include "base/values.h"
 #include "brave/components/brave_wallet/browser/solana_compiled_instruction.h"

--- a/components/brave_wallet/browser/solana_instruction_builder.cc
+++ b/components/brave_wallet/browser/solana_instruction_builder.cc
@@ -8,6 +8,7 @@
 #include <optional>
 #include <utility>
 
+#include "base/check.h"
 #include "base/containers/span.h"
 #include "base/containers/span_writer.h"
 #include "base/numerics/safe_conversions.h"

--- a/components/brave_wallet/browser/solana_instruction_data_decoder.cc
+++ b/components/brave_wallet/browser/solana_instruction_data_decoder.cc
@@ -9,6 +9,7 @@
 #include <tuple>
 #include <utility>
 
+#include "base/check.h"
 #include "base/containers/flat_map.h"
 #include "base/containers/span.h"
 #include "base/no_destructor.h"

--- a/components/brave_wallet/browser/solana_message_address_table_lookup.cc
+++ b/components/brave_wallet/browser/solana_message_address_table_lookup.cc
@@ -8,6 +8,7 @@
 #include <optional>
 
 #include "base/base64.h"
+#include "base/check.h"
 #include "brave/components/brave_wallet/common/brave_wallet_constants.h"
 #include "brave/components/brave_wallet/common/solana_utils.h"
 

--- a/components/brave_wallet/browser/solana_provider_impl.cc
+++ b/components/brave_wallet/browser/solana_provider_impl.cc
@@ -9,6 +9,8 @@
 #include <optional>
 #include <vector>
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "base/containers/flat_map.h"
 #include "base/notreached.h"
 #include "base/strings/strcat.h"

--- a/components/brave_wallet/browser/solana_requests.cc
+++ b/components/brave_wallet/browser/solana_requests.cc
@@ -8,6 +8,7 @@
 #include <optional>
 #include <utility>
 
+#include "base/check.h"
 #include "base/strings/string_number_conversions.h"
 #include "brave/components/brave_wallet/browser/json_rpc_requests_helper.h"
 #include "brave/components/brave_wallet/common/solana_utils.h"

--- a/components/brave_wallet/browser/solana_response_parser.cc
+++ b/components/brave_wallet/browser/solana_response_parser.cc
@@ -10,6 +10,7 @@
 #include <utility>
 
 #include "base/base64.h"
+#include "base/check.h"
 #include "base/json/json_writer.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/values.h"

--- a/components/brave_wallet/browser/solana_tx_manager.cc
+++ b/components/brave_wallet/browser/solana_tx_manager.cc
@@ -14,7 +14,9 @@
 
 #include "base/barrier_callback.h"
 #include "base/base64.h"
-#include "base/notreached.h"
+#include "base/check.h"
+#include "base/logging.h"
+#include "base/notimplemented.h"
 #include "brave/components/brave_wallet/browser/account_resolver_delegate.h"
 #include "brave/components/brave_wallet/browser/blockchain_registry.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_constants.h"

--- a/components/brave_wallet/browser/solana_tx_meta.cc
+++ b/components/brave_wallet/browser/solana_tx_meta.cc
@@ -9,6 +9,7 @@
 #include <string>
 #include <vector>
 
+#include "base/check_op.h"
 #include "base/values.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_utils.h"
 

--- a/components/brave_wallet/browser/swap_request_helper.cc
+++ b/components/brave_wallet/browser/swap_request_helper.cc
@@ -10,6 +10,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/notreached.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/stringprintf.h"
 #include "base/values.h"

--- a/components/brave_wallet/browser/test_utils.cc
+++ b/components/brave_wallet/browser/test_utils.cc
@@ -8,6 +8,7 @@
 #include <memory>
 #include <utility>
 
+#include "base/check.h"
 #include "base/containers/contains.h"
 #include "base/files/scoped_temp_dir.h"
 #include "base/memory/raw_ref.h"

--- a/components/brave_wallet/browser/tx_manager.cc
+++ b/components/brave_wallet/browser/tx_manager.cc
@@ -10,7 +10,6 @@
 #include <utility>
 #include <vector>
 
-#include "base/check.h"
 #include "base/containers/to_vector.h"
 #include "base/logging.h"
 #include "brave/components/brave_wallet/browser/block_tracker.h"

--- a/components/brave_wallet/browser/tx_meta.cc
+++ b/components/brave_wallet/browser/tx_meta.cc
@@ -5,6 +5,7 @@
 
 #include "brave/components/brave_wallet/browser/tx_meta.h"
 
+#include "base/check.h"
 #include "base/json/values_util.h"
 #include "base/uuid.h"
 #include "base/values.h"

--- a/components/brave_wallet/browser/tx_service.cc
+++ b/components/brave_wallet/browser/tx_service.cc
@@ -8,7 +8,9 @@
 #include <optional>
 #include <utility>
 
+#include "base/check.h"
 #include "base/check_is_test.h"
+#include "base/check_op.h"
 #include "base/notreached.h"
 #include "brave/components/brave_wallet/browser/account_resolver_delegate_impl.h"
 #include "brave/components/brave_wallet/browser/bitcoin/bitcoin_tx_manager.h"

--- a/components/brave_wallet/browser/tx_state_manager.cc
+++ b/components/brave_wallet/browser/tx_state_manager.cc
@@ -8,6 +8,8 @@
 #include <optional>
 #include <utility>
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "base/json/values_util.h"
 #include "base/values.h"
 #include "brave/components/brave_wallet/browser/account_resolver_delegate.h"

--- a/components/brave_wallet/browser/tx_storage_delegate_impl.cc
+++ b/components/brave_wallet/browser/tx_storage_delegate_impl.cc
@@ -8,6 +8,7 @@
 #include <optional>
 #include <utility>
 
+#include "base/check.h"
 #include "base/files/file_path.h"
 #include "base/functional/bind.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_utils.h"

--- a/components/brave_wallet/browser/unstoppable_domains_multichain_calls.cc
+++ b/components/brave_wallet/browser/unstoppable_domains_multichain_calls.cc
@@ -9,6 +9,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/check.h"
 #include "url/gurl.h"
 
 namespace brave_wallet::unstoppable_domains {

--- a/components/brave_wallet/browser/wallet_data_files_installer.cc
+++ b/components/brave_wallet/browser/wallet_data_files_installer.cc
@@ -11,10 +11,10 @@
 #include <utility>
 #include <vector>
 
+#include "base/check.h"
 #include "base/compiler_specific.h"
 #include "base/containers/to_vector.h"
 #include "base/functional/bind.h"
-#include "base/logging.h"
 #include "base/values.h"
 #include "brave/components/brave_component_updater/browser/brave_on_demand_updater.h"
 #include "brave/components/brave_wallet/browser/blockchain_registry.h"

--- a/components/brave_wallet/browser/zcash/rust/cxx_orchard_shard_tree_delegate.cc
+++ b/components/brave_wallet/browser/zcash/rust/cxx_orchard_shard_tree_delegate.cc
@@ -9,6 +9,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/check_op.h"
 #include "brave/components/brave_wallet/browser/internal/orchard_storage/orchard_storage.h"
 #include "brave/components/brave_wallet/browser/zcash/rust/lib.rs.h"
 #include "brave/components/brave_wallet/common/zcash_utils.h"

--- a/components/brave_wallet/browser/zcash/rust/orchard_unauthorized_bundle_impl.cc
+++ b/components/brave_wallet/browser/zcash/rust/orchard_unauthorized_bundle_impl.cc
@@ -10,7 +10,6 @@
 #include <vector>
 
 #include "base/check_is_test.h"
-#include "base/logging.h"
 #include "base/memory/ptr_util.h"
 #include "brave/components/brave_wallet/browser/zcash/rust/orchard_authorized_bundle_impl.h"
 

--- a/components/brave_wallet/browser/zcash/zcash_auto_sync_manager.cc
+++ b/components/brave_wallet/browser/zcash/zcash_auto_sync_manager.cc
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include "base/check.h"
 #include "brave/components/brave_wallet/browser/zcash/zcash_wallet_service.h"
 
 namespace brave_wallet {

--- a/components/brave_wallet/browser/zcash/zcash_blocks_batch_scan_task.cc
+++ b/components/brave_wallet/browser/zcash/zcash_blocks_batch_scan_task.cc
@@ -10,6 +10,8 @@
 #include <utility>
 #include <vector>
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "base/containers/extend.h"
 #include "base/strings/string_number_conversions.h"
 #include "brave/components/brave_wallet/browser/zcash/zcash_wallet_service.h"

--- a/components/brave_wallet/browser/zcash/zcash_complete_transaction_task.cc
+++ b/components/brave_wallet/browser/zcash/zcash_complete_transaction_task.cc
@@ -8,6 +8,8 @@
 #include <utility>
 #include <vector>
 
+#include "base/check.h"
+#include "base/logging.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/task/thread_pool.h"
 #include "brave/components/brave_wallet/browser/keyring_service.h"

--- a/components/brave_wallet/browser/zcash/zcash_create_orchard_to_orchard_transaction_task.cc
+++ b/components/brave_wallet/browser/zcash/zcash_create_orchard_to_orchard_transaction_task.cc
@@ -8,6 +8,7 @@
 #include <utility>
 #include <variant>
 
+#include "base/check.h"
 #include "base/numerics/checked_math.h"
 #include "brave/components/brave_wallet/common/brave_wallet.mojom.h"
 #include "components/grit/brave_components_strings.h"

--- a/components/brave_wallet/browser/zcash/zcash_create_transparent_to_orchard_transaction_task.cc
+++ b/components/brave_wallet/browser/zcash/zcash_create_transparent_to_orchard_transaction_task.cc
@@ -7,6 +7,8 @@
 
 #include <variant>
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "brave/components/brave_wallet/browser/zcash/zcash_serializer.h"
 #include "brave/components/brave_wallet/browser/zcash/zcash_transaction_utils.h"
 #include "brave/components/brave_wallet/common/common_utils.h"

--- a/components/brave_wallet/browser/zcash/zcash_create_transparent_transaction_task.cc
+++ b/components/brave_wallet/browser/zcash/zcash_create_transparent_transaction_task.cc
@@ -7,6 +7,8 @@
 
 #include <utility>
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "base/containers/extend.h"
 #include "brave/components/brave_wallet/browser/zcash/zcash_transaction_utils.h"
 #include "brave/components/brave_wallet/common/zcash_utils.h"

--- a/components/brave_wallet/browser/zcash/zcash_discover_next_unused_zcash_address_task.cc
+++ b/components/brave_wallet/browser/zcash/zcash_discover_next_unused_zcash_address_task.cc
@@ -8,6 +8,7 @@
 #include <string>
 #include <utility>
 
+#include "base/check.h"
 #include "brave/components/brave_wallet/common/common_utils.h"
 #include "brave/components/brave_wallet/common/zcash_utils.h"
 #include "components/grit/brave_components_strings.h"

--- a/components/brave_wallet/browser/zcash/zcash_get_zcash_chain_tip_status_task.cc
+++ b/components/brave_wallet/browser/zcash/zcash_get_zcash_chain_tip_status_task.cc
@@ -8,6 +8,8 @@
 #include <utility>
 #include <variant>
 
+#include "base/check.h"
+
 namespace brave_wallet {
 
 ZCashGetZCashChainTipStatusTask::ZCashGetZCashChainTipStatusTask(

--- a/components/brave_wallet/browser/zcash/zcash_resolve_balance_task.cc
+++ b/components/brave_wallet/browser/zcash/zcash_resolve_balance_task.cc
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include "base/check.h"
 #include "brave/components/brave_wallet/common/common_utils.h"
 #include "components/grit/brave_components_strings.h"
 #include "ui/base/l10n/l10n_util.h"

--- a/components/brave_wallet/browser/zcash/zcash_resolve_transaction_status_task.cc
+++ b/components/brave_wallet/browser/zcash/zcash_resolve_transaction_status_task.cc
@@ -8,6 +8,7 @@
 #include <utility>
 #include <variant>
 
+#include "base/check.h"
 #include "brave/components/brave_wallet/browser/zcash/zcash_tx_meta.h"
 
 namespace brave_wallet {

--- a/components/brave_wallet/browser/zcash/zcash_rpc.cc
+++ b/components/brave_wallet/browser/zcash/zcash_rpc.cc
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include "base/check.h"
 #include "base/functional/bind.h"
 #include "base/strings/string_number_conversions.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_utils.h"

--- a/components/brave_wallet/browser/zcash/zcash_scan_blocks_task.cc
+++ b/components/brave_wallet/browser/zcash/zcash_scan_blocks_task.cc
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <utility>
 
+#include "base/check.h"
 #include "brave/components/brave_wallet/browser/zcash/zcash_wallet_service.h"
 
 namespace brave_wallet {

--- a/components/brave_wallet/browser/zcash/zcash_scan_blocks_task_unittest.cc
+++ b/components/brave_wallet/browser/zcash/zcash_scan_blocks_task_unittest.cc
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "base/files/scoped_temp_dir.h"
+#include "base/notreached.h"
 #include "base/task/thread_pool.h"
 #include "base/test/bind.h"
 #include "base/test/mock_callback.h"

--- a/components/brave_wallet/browser/zcash/zcash_serializer.cc
+++ b/components/brave_wallet/browser/zcash/zcash_serializer.cc
@@ -9,6 +9,8 @@
 #include <string>
 #include <utility>
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "base/containers/span.h"
 #include "base/containers/span_writer.h"
 #include "brave/components/brave_wallet/common/btc_like_serializer_stream.h"

--- a/components/brave_wallet/browser/zcash/zcash_shield_sync_service.cc
+++ b/components/brave_wallet/browser/zcash/zcash_shield_sync_service.cc
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <utility>
 
+#include "base/check.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/task/thread_pool.h"
 #include "brave/components/brave_wallet/browser/zcash/zcash_scan_blocks_task.h"

--- a/components/brave_wallet/browser/zcash/zcash_tx_manager.cc
+++ b/components/brave_wallet/browser/zcash/zcash_tx_manager.cc
@@ -13,6 +13,8 @@
 #include <vector>
 
 #include "base/functional/bind.h"
+#include "base/logging.h"
+#include "base/notimplemented.h"
 #include "base/notreached.h"
 #include "brave/components/brave_wallet/browser/zcash/zcash_block_tracker.h"
 #include "brave/components/brave_wallet/browser/zcash/zcash_transaction.h"

--- a/components/brave_wallet/browser/zcash/zcash_tx_meta.cc
+++ b/components/brave_wallet/browser/zcash/zcash_tx_meta.cc
@@ -9,6 +9,8 @@
 #include <string>
 #include <vector>
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_utils.h"
 #include "brave/components/brave_wallet/browser/zcash/zcash_transaction.h"
 #include "brave/components/brave_wallet/common/zcash_utils.h"

--- a/components/brave_wallet/browser/zcash/zcash_verify_chain_state_task.cc
+++ b/components/brave_wallet/browser/zcash/zcash_verify_chain_state_task.cc
@@ -9,6 +9,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/check.h"
 #include "brave/components/brave_wallet/browser/zcash/zcash_wallet_service.h"
 
 namespace brave_wallet {

--- a/components/brave_wallet/browser/zcash/zcash_wallet_service.cc
+++ b/components/brave_wallet/browser/zcash/zcash_wallet_service.cc
@@ -10,6 +10,7 @@
 #include <utility>
 
 #include "base/barrier_callback.h"
+#include "base/check.h"
 #include "base/check_is_test.h"
 #include "base/containers/span.h"
 #include "base/task/thread_pool.h"

--- a/components/brave_wallet/common/bitcoin_utils.cc
+++ b/components/brave_wallet/common/bitcoin_utils.cc
@@ -9,6 +9,7 @@
 #include <optional>
 #include <utility>
 
+#include "base/check_op.h"
 #include "base/strings/string_util.h"
 #include "brave/components/brave_wallet/common/bech32.h"
 #include "brave/components/brave_wallet/common/hash_utils.h"

--- a/components/brave_wallet/common/brave_wallet_response_helpers.cc
+++ b/components/brave_wallet/common/brave_wallet_response_helpers.cc
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include "base/check.h"
 #include "base/json/json_reader.h"
 #include "base/json/json_writer.h"
 #include "base/strings/string_number_conversions.h"

--- a/components/brave_wallet/common/cardano_address.cc
+++ b/components/brave_wallet/common/cardano_address.cc
@@ -8,6 +8,8 @@
 #include <optional>
 #include <utility>
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "base/containers/span_writer.h"
 #include "brave/components/brave_wallet/common/bech32.h"
 

--- a/components/brave_wallet/common/common_utils.cc
+++ b/components/brave_wallet/common/common_utils.cc
@@ -7,6 +7,9 @@
 
 #include <utility>
 
+#include "base/check.h"
+#include "base/check_op.h"
+#include "base/dcheck_is_on.h"
 #include "base/feature_list.h"
 #include "base/notreached.h"
 #include "base/strings/string_number_conversions.h"

--- a/components/brave_wallet/common/encoding_utils.cc
+++ b/components/brave_wallet/common/encoding_utils.cc
@@ -7,6 +7,8 @@
 
 #include <utility>
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "base/containers/span.h"
 #include "base/containers/span_writer.h"
 #include "brave/components/brave_wallet/common/hash_utils.h"

--- a/components/brave_wallet/common/eth_request_helper.cc
+++ b/components/brave_wallet/common/eth_request_helper.cc
@@ -12,6 +12,7 @@
 #include <utility>
 
 #include "base/base64.h"
+#include "base/check.h"
 #include "base/compiler_specific.h"
 #include "base/containers/to_vector.h"
 #include "base/json/json_reader.h"

--- a/components/brave_wallet/common/eth_sign_typed_data_helper.cc
+++ b/components/brave_wallet/common/eth_sign_typed_data_helper.cc
@@ -10,6 +10,7 @@
 #include <string_view>
 #include <utility>
 
+#include "base/check.h"
 #include "base/containers/extend.h"
 #include "base/containers/span.h"
 #include "base/logging.h"

--- a/components/brave_wallet/common/fil_address.cc
+++ b/components/brave_wallet/common/fil_address.cc
@@ -7,8 +7,10 @@
 
 #include <optional>
 
+#include "base/check.h"
 #include "base/containers/extend.h"
 #include "base/containers/to_vector.h"
+#include "base/notreached.h"
 #include "base/strings/string_util.h"
 #include "brave/components/brave_wallet/common/brave_wallet.mojom.h"
 #include "brave/components/brave_wallet/common/eth_address.h"

--- a/components/brave_wallet/common/hash_utils.cc
+++ b/components/brave_wallet/common/hash_utils.cc
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <array>
 
+#include "base/check_op.h"
 #include "base/containers/adapters.h"
 #include "base/containers/span.h"
 #include "base/strings/string_split.h"

--- a/components/brave_wallet/common/hex_utils.cc
+++ b/components/brave_wallet/common/hex_utils.cc
@@ -7,6 +7,8 @@
 
 #include <optional>
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "base/strings/strcat.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/string_util.h"

--- a/components/brave_wallet/common/solana_address.cc
+++ b/components/brave_wallet/common/solana_address.cc
@@ -8,6 +8,7 @@
 #include <optional>
 #include <utility>
 
+#include "base/check.h"
 #include "brave/components/brave_wallet/common/brave_wallet_constants.h"
 #include "brave/components/brave_wallet/common/encoding_utils.h"
 #include "brave/components/brave_wallet/common/solana_utils.h"

--- a/components/brave_wallet/common/string_utils_unittest.cc
+++ b/components/brave_wallet/common/string_utils_unittest.cc
@@ -7,7 +7,6 @@
 
 #include <limits>
 
-#include "base/logging.h"
 #include "testing/gmock/include/gmock/gmock.h"
 #include "testing/gtest/include/gtest/gtest.h"
 

--- a/components/brave_wallet/common/test_utils.h
+++ b/components/brave_wallet/common/test_utils.h
@@ -10,6 +10,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/check.h"
 #include "base/strings/string_number_conversions.h"
 #include "brave/components/brave_wallet/common/brave_wallet.mojom.h"
 #include "testing/gmock/include/gmock/gmock-matchers.h"

--- a/components/brave_wallet/common/value_conversion_utils.cc
+++ b/components/brave_wallet/common/value_conversion_utils.cc
@@ -10,6 +10,8 @@
 #include <utility>
 #include <vector>
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "base/containers/contains.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/string_util.h"

--- a/components/brave_wallet/renderer/js_ethereum_provider.cc
+++ b/components/brave_wallet/renderer/js_ethereum_provider.cc
@@ -10,6 +10,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/check.h"
 #include "base/json/json_writer.h"
 #include "base/no_destructor.h"
 #include "base/strings/utf_string_conversions.h"

--- a/components/brave_wallet/renderer/js_solana_provider.cc
+++ b/components/brave_wallet/renderer/js_solana_provider.cc
@@ -9,7 +9,9 @@
 #include <tuple>
 #include <utility>
 
+#include "base/check.h"
 #include "base/no_destructor.h"
+#include "base/notreached.h"
 #include "brave/components/brave_wallet/common/brave_wallet_constants.h"
 #include "brave/components/brave_wallet/common/brave_wallet_response_helpers.h"
 #include "brave/components/brave_wallet/common/encoding_utils.h"

--- a/components/brave_wallet/renderer/v8_helper.cc
+++ b/components/brave_wallet/renderer/v8_helper.cc
@@ -8,6 +8,7 @@
 #include <string_view>
 #include <utility>
 
+#include "base/check.h"
 #include "brave/components/safe_builtins/renderer/safe_builtins_helpers.h"
 #include "gin/converter.h"
 #include "third_party/blink/public/web/web_local_frame.h"


### PR DESCRIPTION
This change is one of many fixing inclusion for the following files:

 - `base/notimplemented.h`
 - `base/notreached.h`
 - `base/check.h`
 - `base/dcheck_is_on.h`
 - `base/check_deref.h`
 - `base/check_op.h`
 - `base/logging/log_severity.h`
 - `base/logging.h`

This change is a mechanical change done with the following script:
https://github.com/brave/brave-browser/issues/46707#issuecomment-2960116515

Resolves https://github.com/brave/brave-browser/issues/46707
