### PR TITLE
[IWYU] Fixing logging inclusions for Ads

### DIFF
--- a/browser/brave_ads/ad_units/notification_ad/notification_ad_platform_bridge.cc
+++ b/browser/brave_ads/ad_units/notification_ad/notification_ad_platform_bridge.cc
@@ -5,6 +5,7 @@
 
 #include "brave/browser/brave_ads/ad_units/notification_ad/notification_ad_platform_bridge.h"
 
+#include "base/check.h"
 #include "base/memory/raw_ref.h"
 #include "base/memory/scoped_refptr.h"
 #include "brave/browser/brave_ads/ads_service_factory.h"

--- a/browser/brave_ads/ads_service_delegate.cc
+++ b/browser/brave_ads/ads_service_delegate.cc
@@ -7,7 +7,6 @@
 
 #include <utility>
 
-#include "base/check_deref.h"
 #include "brave/browser/brave_ads/ad_units/notification_ad/notification_ad_platform_bridge.h"
 #include "brave/browser/brave_ads/application_state/notification_helper/notification_helper.h"
 #include "brave/browser/ui/brave_ads/notification_ad.h"

--- a/browser/brave_ads/ads_service_factory.cc
+++ b/browser/brave_ads/ads_service_factory.cc
@@ -8,6 +8,7 @@
 #include <memory>
 #include <utility>
 
+#include "base/check.h"
 #include "base/no_destructor.h"
 #include "brave/browser/brave_adaptive_captcha/brave_adaptive_captcha_service_factory.h"
 #include "brave/browser/brave_ads/ad_units/notification_ad/notification_ad_platform_bridge.h"

--- a/browser/brave_ads/application_state/background_helper/background_helper_mac.mm
+++ b/browser/brave_ads/application_state/background_helper/background_helper_mac.mm
@@ -9,7 +9,6 @@
 
 #include "base/apple/foundation_util.h"
 #include "base/apple/osstatus_logging.h"
-#include "base/logging.h"
 #include "base/mac/mac_util.h"
 #include "base/memory/raw_ptr.h"
 

--- a/browser/brave_ads/creatives/search_result_ad/creative_search_result_ad_clicked_infobar_delegate.cc
+++ b/browser/brave_ads/creatives/search_result_ad/creative_search_result_ad_clicked_infobar_delegate.cc
@@ -8,6 +8,7 @@
 #include <memory>
 #include <utility>
 
+#include "base/check.h"
 #include "brave/components/brave_ads/core/public/prefs/pref_names.h"
 #include "brave/grit/brave_generated_resources.h"
 #include "build/build_config.h"

--- a/browser/ui/brave_ads/notification_ad.h
+++ b/browser/ui/brave_ads/notification_ad.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <utility>
 
+#include "base/check.h"
 #include "base/memory/scoped_refptr.h"
 #include "brave/browser/ui/brave_ads/notification_ad_delegate.h"
 

--- a/browser/ui/views/brave_ads/bounds_util.cc
+++ b/browser/ui/views/brave_ads/bounds_util.cc
@@ -5,6 +5,7 @@
 
 #include "brave/browser/ui/views/brave_ads/bounds_util.h"
 
+#include "base/check.h"
 #include "brave/components/brave_ads/browser/ad_units/notification_ad/custom_notification_ad_feature.h"
 #include "ui/display/screen.h"
 #include "ui/gfx/geometry/rect.h"

--- a/browser/ui/views/brave_ads/notification_ad_background_painter.cc
+++ b/browser/ui/views/brave_ads/notification_ad_background_painter.cc
@@ -5,6 +5,7 @@
 
 #include "brave/browser/ui/views/brave_ads/notification_ad_background_painter.h"
 
+#include "base/check.h"
 #include "third_party/skia/include/core/SkPath.h"
 #include "ui/gfx/canvas.h"
 #include "ui/gfx/geometry/rect.h"

--- a/browser/ui/views/brave_ads/notification_ad_control_buttons_view.cc
+++ b/browser/ui/views/brave_ads/notification_ad_control_buttons_view.cc
@@ -7,6 +7,7 @@
 
 #include <memory>
 
+#include "base/check.h"
 #include "base/functional/bind.h"
 #include "brave/app/vector_icons/vector_icons.h"
 #include "brave/browser/ui/views/brave_ads/notification_ad_view.h"

--- a/browser/ui/views/brave_ads/notification_ad_header_view.cc
+++ b/browser/ui/views/brave_ads/notification_ad_header_view.cc
@@ -5,6 +5,7 @@
 
 #include "brave/browser/ui/views/brave_ads/notification_ad_header_view.h"
 
+#include "base/check.h"
 #include "brave/browser/ui/views/brave_ads/insets_util.h"
 #include "brave/browser/ui/views/brave_ads/spacer_view.h"
 #include "ui/base/metadata/metadata_impl_macros.h"

--- a/browser/ui/views/brave_ads/notification_ad_popup.cc
+++ b/browser/ui/views/brave_ads/notification_ad_popup.cc
@@ -7,7 +7,9 @@
 
 #include <string>
 
+#include "base/check.h"
 #include "base/check_is_test.h"
+#include "base/check_op.h"
 #include "base/time/time.h"
 #include "brave/browser/ui/brave_ads/notification_ad_delegate.h"
 #include "brave/browser/ui/views/brave_ads/bounds_util.h"

--- a/browser/ui/views/brave_ads/notification_ad_popup_collection.cc
+++ b/browser/ui/views/brave_ads/notification_ad_popup_collection.cc
@@ -7,6 +7,8 @@
 
 #include <map>
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "brave/browser/ui/views/brave_ads/notification_ad_popup.h"
 
 namespace brave_ads {

--- a/browser/ui/views/brave_ads/notification_ad_popup_handler.cc
+++ b/browser/ui/views/brave_ads/notification_ad_popup_handler.cc
@@ -5,6 +5,7 @@
 
 #include "brave/browser/ui/brave_ads/notification_ad_popup_handler.h"
 
+#include "base/check.h"
 #include "brave/browser/ui/brave_ads/notification_ad.h"
 #include "brave/browser/ui/brave_ads/notification_ad_delegate.h"
 #include "brave/browser/ui/views/brave_ads/notification_ad_popup.h"

--- a/browser/ui/views/brave_ads/notification_ad_popup_widget.cc
+++ b/browser/ui/views/brave_ads/notification_ad_popup_widget.cc
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include "base/check.h"
 #include "brave/components/brave_ads/browser/ad_units/notification_ad/custom_notification_ad_feature.h"
 #include "build/build_config.h"
 #include "ui/gfx/geometry/rect.h"

--- a/browser/ui/views/brave_ads/padded_image_button.cc
+++ b/browser/ui/views/brave_ads/padded_image_button.cc
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <utility>
 
+#include "base/check.h"
 #include "third_party/skia/include/core/SkColor.h"
 #include "ui/base/metadata/metadata_impl_macros.h"
 #include "ui/color/color_provider.h"

--- a/browser/ui/views/brave_ads/text_notification_ad_view.cc
+++ b/browser/ui/views/brave_ads/text_notification_ad_view.cc
@@ -8,6 +8,7 @@
 #include <memory>
 #include <utility>
 
+#include "base/check.h"
 #include "brave/browser/ui/brave_ads/notification_ad.h"
 #include "brave/browser/ui/views/brave_ads/insets_util.h"
 #include "brave/browser/ui/views/brave_ads/notification_ad_control_buttons_view.h"

--- a/components/brave_ads/browser/analytics/p2a/p2a.cc
+++ b/components/brave_ads/browser/analytics/p2a/p2a.cc
@@ -9,6 +9,7 @@
 #include <limits>
 #include <string>
 
+#include "base/check.h"
 #include "base/logging.h"
 #include "base/metrics/histogram_functions.h"
 #include "base/strings/strcat.h"

--- a/components/brave_ads/browser/component_updater/resource_component.cc
+++ b/components/brave_ads/browser/component_updater/resource_component.cc
@@ -5,6 +5,7 @@
 
 #include "brave/components/brave_ads/browser/component_updater/resource_component.h"
 
+#include "base/check.h"
 #include "base/files/file_path.h"
 #include "base/files/file_util.h"
 #include "base/functional/bind.h"

--- a/components/brave_ads/browser/component_updater/resource_component_registrar.cc
+++ b/components/brave_ads/browser/component_updater/resource_component_registrar.cc
@@ -5,6 +5,7 @@
 
 #include "brave/components/brave_ads/browser/component_updater/resource_component_registrar.h"
 
+#include "base/check.h"
 #include "base/files/file_path.h"
 #include "base/logging.h"
 #include "base/strings/string_util.h"

--- a/components/brave_ads/content/browser/creatives/search_result_ad/creative_search_result_ad_handler.cc
+++ b/components/brave_ads/content/browser/creatives/search_result_ad/creative_search_result_ad_handler.cc
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include "base/check.h"
 #include "base/functional/bind.h"
 #include "base/functional/callback_helpers.h"
 #include "base/memory/ptr_util.h"

--- a/components/brave_ads/core/internal/account/account.cc
+++ b/components/brave_ads/core/internal/account/account.cc
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include "base/check.h"
 #include "base/check_op.h"
 #include "base/functional/bind.h"
 #include "brave/components/brave_ads/core/internal/account/account_util.h"

--- a/components/brave_ads/core/internal/account/confirmations/confirmations.cc
+++ b/components/brave_ads/core/internal/account/confirmations/confirmations.cc
@@ -8,6 +8,7 @@
 #include <optional>
 #include <utility>
 
+#include "base/check.h"
 #include "base/time/time.h"
 #include "brave/components/brave_ads/core/internal/account/confirmations/confirmation_info.h"
 #include "brave/components/brave_ads/core/internal/account/confirmations/non_reward/non_reward_confirmation_util.h"

--- a/components/brave_ads/core/internal/account/confirmations/confirmations.h
+++ b/components/brave_ads/core/internal/account/confirmations/confirmations.h
@@ -6,6 +6,7 @@
 #ifndef BRAVE_COMPONENTS_BRAVE_ADS_CORE_INTERNAL_ACCOUNT_CONFIRMATIONS_CONFIRMATIONS_H_
 #define BRAVE_COMPONENTS_BRAVE_ADS_CORE_INTERNAL_ACCOUNT_CONFIRMATIONS_CONFIRMATIONS_H_
 
+#include "base/check_op.h"
 #include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
 #include "base/values.h"

--- a/components/brave_ads/core/internal/account/confirmations/confirmations_util.cc
+++ b/components/brave_ads/core/internal/account/confirmations/confirmations_util.cc
@@ -9,6 +9,7 @@
 #include <string>
 
 #include "base/base64url.h"
+#include "base/check.h"
 #include "base/json/json_reader.h"
 #include "brave/components/brave_ads/core/internal/account/confirmations/confirmation_info.h"
 #include "brave/components/brave_ads/core/internal/account/confirmations/payload/confirmation_payload_json_writer.h"

--- a/components/brave_ads/core/internal/account/confirmations/non_reward/non_reward_confirmation_test_util.cc
+++ b/components/brave_ads/core/internal/account/confirmations/non_reward/non_reward_confirmation_test_util.cc
@@ -5,6 +5,7 @@
 
 #include "brave/components/brave_ads/core/internal/account/confirmations/non_reward/non_reward_confirmation_test_util.h"
 
+#include "base/check.h"
 #include "brave/components/brave_ads/core/internal/account/confirmations/confirmation_info.h"
 #include "brave/components/brave_ads/core/internal/account/confirmations/non_reward/non_reward_confirmation_util.h"
 #include "brave/components/brave_ads/core/internal/account/confirmations/reward/reward_confirmation_util.h"

--- a/components/brave_ads/core/internal/account/confirmations/payload/reward_confirmation_payload_util.cc
+++ b/components/brave_ads/core/internal/account/confirmations/payload/reward_confirmation_payload_util.cc
@@ -8,6 +8,7 @@
 #include <optional>
 #include <string>
 
+#include "base/check.h"
 #include "brave/components/brave_ads/core/internal/account/confirmations/reward/reward_info.h"
 
 namespace brave_ads {

--- a/components/brave_ads/core/internal/account/confirmations/queue/confirmation_queue.h
+++ b/components/brave_ads/core/internal/account/confirmations/queue/confirmation_queue.h
@@ -6,6 +6,7 @@
 #ifndef BRAVE_COMPONENTS_BRAVE_ADS_CORE_INTERNAL_ACCOUNT_CONFIRMATIONS_QUEUE_CONFIRMATION_QUEUE_H_
 #define BRAVE_COMPONENTS_BRAVE_ADS_CORE_INTERNAL_ACCOUNT_CONFIRMATIONS_QUEUE_CONFIRMATION_QUEUE_H_
 
+#include "base/check_op.h"
 #include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
 #include "brave/components/brave_ads/core/internal/account/confirmations/queue/confirmation_queue_database_table.h"

--- a/components/brave_ads/core/internal/account/issuers/issuers.cc
+++ b/components/brave_ads/core/internal/account/issuers/issuers.cc
@@ -8,6 +8,7 @@
 #include <optional>
 #include <utility>
 
+#include "base/check.h"
 #include "base/functional/bind.h"
 #include "base/location.h"
 #include "base/time/time.h"

--- a/components/brave_ads/core/internal/account/statement/next_payment_date_util.cc
+++ b/components/brave_ads/core/internal/account/statement/next_payment_date_util.cc
@@ -5,6 +5,7 @@
 
 #include "brave/components/brave_ads/core/internal/account/statement/next_payment_date_util.h"
 
+#include "base/check.h"
 #include "base/time/time.h"
 #include "brave/components/brave_ads/core/internal/account/statement/statement_feature.h"
 #include "brave/components/brave_ads/core/internal/account/transactions/reconciled_transactions_util.h"

--- a/components/brave_ads/core/internal/account/tokens/confirmation_tokens/confirmation_tokens_test_util.cc
+++ b/components/brave_ads/core/internal/account/tokens/confirmation_tokens/confirmation_tokens_test_util.cc
@@ -3,13 +3,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include "brave/components/brave_ads/core/internal/account/tokens/confirmation_tokens/confirmation_tokens_test_util.h"
+
 #include <optional>
 #include <string>
 #include <vector>
 
+#include "base/check.h"
 #include "base/check_op.h"
 #include "brave/components/brave_ads/core/internal/account/tokens/confirmation_tokens/confirmation_tokens.h"
-#include "brave/components/brave_ads/core/internal/account/tokens/confirmation_tokens/confirmation_tokens_test_util.h"
 #include "brave/components/brave_ads/core/internal/account/tokens/confirmation_tokens/confirmation_tokens_util.h"
 #include "brave/components/brave_ads/core/internal/account/wallet/wallet_info.h"
 #include "brave/components/brave_ads/core/internal/account/wallet/wallet_test_util.h"

--- a/components/brave_ads/core/internal/account/tokens/payment_tokens/payment_tokens_test_util.cc
+++ b/components/brave_ads/core/internal/account/tokens/payment_tokens/payment_tokens_test_util.cc
@@ -8,6 +8,7 @@
 #include <string>
 #include <vector>
 
+#include "base/check.h"
 #include "base/check_op.h"
 #include "brave/components/brave_ads/core/internal/account/tokens/payment_tokens/payment_tokens.h"
 #include "brave/components/brave_ads/core/internal/account/transactions/transaction_test_constants.h"

--- a/components/brave_ads/core/internal/account/tokens/token_generator_test_util.cc
+++ b/components/brave_ads/core/internal/account/tokens/token_generator_test_util.cc
@@ -8,6 +8,7 @@
 #include <string>
 #include <vector>
 
+#include "base/check.h"
 #include "base/check_op.h"
 #include "base/no_destructor.h"
 #include "brave/components/brave_ads/core/internal/account/tokens/token_generator_mock.h"

--- a/components/brave_ads/core/internal/account/transactions/transactions.cc
+++ b/components/brave_ads/core/internal/account/transactions/transactions.cc
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include "base/check.h"
 #include "base/check_op.h"
 #include "base/functional/bind.h"
 #include "base/time/time.h"

--- a/components/brave_ads/core/internal/account/user_rewards/user_rewards.cc
+++ b/components/brave_ads/core/internal/account/user_rewards/user_rewards.cc
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include "base/check.h"
 #include "base/functional/bind.h"
 #include "brave/components/brave_ads/core/internal/account/issuers/issuers.h"
 #include "brave/components/brave_ads/core/internal/account/issuers/issuers_info.h"

--- a/components/brave_ads/core/internal/account/utility/redeem_payment_tokens/redeem_payment_tokens.cc
+++ b/components/brave_ads/core/internal/account/utility/redeem_payment_tokens/redeem_payment_tokens.cc
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include "base/check.h"
 #include "base/functional/bind.h"
 #include "base/location.h"
 #include "base/time/time.h"

--- a/components/brave_ads/core/internal/account/utility/refill_confirmation_tokens/refill_confirmation_tokens.cc
+++ b/components/brave_ads/core/internal/account/utility/refill_confirmation_tokens/refill_confirmation_tokens.cc
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include "base/check.h"
 #include "base/functional/bind.h"
 #include "base/json/json_reader.h"
 #include "base/location.h"

--- a/components/brave_ads/core/internal/account/wallet/wallet_util.cc
+++ b/components/brave_ads/core/internal/account/wallet/wallet_util.cc
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "base/base64.h"
+#include "base/check.h"
 #include "brave/components/brave_ads/core/internal/account/wallet/wallet_info.h"
 #include "brave/components/brave_ads/core/internal/common/crypto/crypto_util.h"
 #include "brave/components/brave_ads/core/internal/common/crypto/key_pair_info.h"

--- a/components/brave_ads/core/internal/ad_units/ad_handler.cc
+++ b/components/brave_ads/core/internal/ad_units/ad_handler.cc
@@ -8,6 +8,7 @@
 #include <optional>
 #include <utility>
 
+#include "base/check.h"
 #include "brave/components/brave_ads/core/internal/account/deposits/deposit_util.h"
 #include "brave/components/brave_ads/core/internal/account/user_data/fixed/conversion_user_data.h"
 #include "brave/components/brave_ads/core/internal/account/user_data/fixed/page_land_user_data.h"

--- a/components/brave_ads/core/internal/ad_units/inline_content_ad/inline_content_ad_handler.cc
+++ b/components/brave_ads/core/internal/ad_units/inline_content_ad/inline_content_ad_handler.cc
@@ -7,7 +7,7 @@
 
 #include <utility>
 
-#include "base/check.h"
+#include "base/check_op.h"
 #include "base/strings/string_util.h"
 #include "brave/components/brave_ads/core/internal/account/deposits/deposit_util.h"
 #include "brave/components/brave_ads/core/internal/analytics/p2a/opportunities/p2a_opportunity.h"

--- a/components/brave_ads/core/internal/ad_units/notification_ad/notification_ad_handler.cc
+++ b/components/brave_ads/core/internal/ad_units/notification_ad/notification_ad_handler.cc
@@ -7,7 +7,7 @@
 
 #include <utility>
 
-#include "base/check.h"
+#include "base/check_op.h"
 #include "base/time/time.h"
 #include "brave/components/brave_ads/core/internal/account/deposits/deposit_util.h"
 #include "brave/components/brave_ads/core/internal/ad_units/notification_ad/notification_ad_handler_util.h"

--- a/components/brave_ads/core/internal/ad_units/promoted_content_ad/promoted_content_ad_handler.cc
+++ b/components/brave_ads/core/internal/ad_units/promoted_content_ad/promoted_content_ad_handler.cc
@@ -7,7 +7,7 @@
 
 #include <utility>
 
-#include "base/check.h"
+#include "base/check_op.h"
 #include "brave/components/brave_ads/core/internal/account/deposits/deposit_util.h"
 #include "brave/components/brave_ads/core/internal/ad_units/promoted_content_ad/promoted_content_ad_info.h"
 #include "brave/components/brave_ads/core/internal/common/logging_util.h"

--- a/components/brave_ads/core/internal/ad_units/search_result_ad/search_result_ad_handler.cc
+++ b/components/brave_ads/core/internal/ad_units/search_result_ad/search_result_ad_handler.cc
@@ -9,6 +9,7 @@
 
 #include "base/check.h"
 #include "base/check_is_test.h"
+#include "base/check_op.h"
 #include "base/functional/bind.h"
 #include "base/functional/callback_helpers.h"
 #include "brave/components/brave_ads/core/internal/account/deposits/deposit_util.h"

--- a/components/brave_ads/core/internal/ads_client/ads_client_notifier.cc
+++ b/components/brave_ads/core/internal/ads_client/ads_client_notifier.cc
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <memory>
 
+#include "base/check.h"
 #include "base/functional/bind.h"
 #include "brave/components/brave_ads/core/public/ads_client/ads_client_notifier_observer.h"
 #include "brave/components/brave_ads/core/public/common/functional/once_closure_task_queue.h"

--- a/components/brave_ads/core/internal/ads_client/ads_client_notifier_for_testing.cc
+++ b/components/brave_ads/core/internal/ads_client/ads_client_notifier_for_testing.cc
@@ -5,6 +5,7 @@
 
 #include "brave/components/brave_ads/core/internal/ads_client/ads_client_notifier_for_testing.h"
 
+#include "base/check.h"
 #include "base/check_op.h"
 #include "brave/components/brave_ads/core/public/ads_client/ads_client_notifier_observer.h"
 #include "url/gurl.h"

--- a/components/brave_ads/core/internal/analytics/p2a/opportunities/p2a_opportunity_util.cc
+++ b/components/brave_ads/core/internal/analytics/p2a/opportunities/p2a_opportunity_util.cc
@@ -8,6 +8,7 @@
 #include <optional>
 
 #include "base/check.h"
+#include "base/check_op.h"
 #include "base/strings/string_util.h"
 #include "brave/components/brave_ads/core/internal/common/strings/string_strip_util.h"
 #include "brave/components/brave_ads/core/internal/segments/segment_util.h"

--- a/components/brave_ads/core/internal/catalog/catalog_url_request.cc
+++ b/components/brave_ads/core/internal/catalog/catalog_url_request.cc
@@ -8,6 +8,7 @@
 #include <optional>
 #include <utility>
 
+#include "base/check.h"
 #include "base/functional/bind.h"
 #include "base/location.h"
 #include "base/time/time.h"

--- a/components/brave_ads/core/internal/common/crypto/crypto_util.cc
+++ b/components/brave_ads/core/internal/common/crypto/crypto_util.cc
@@ -14,6 +14,7 @@
 #include <iterator>
 
 #include "base/base64.h"
+#include "base/check.h"
 #include "brave/components/brave_ads/core/internal/common/crypto/key_pair_info.h"
 #include "crypto/random.h"
 #include "third_party/boringssl/src/include/openssl/curve25519.h"

--- a/components/brave_ads/core/internal/common/database/database_column_util.cc
+++ b/components/brave_ads/core/internal/common/database/database_column_util.cc
@@ -8,6 +8,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/check.h"
 #include "base/check_op.h"
 #include "base/strings/string_util.h"
 #include "brave/components/brave_ads/core/mojom/brave_ads.mojom.h"

--- a/components/brave_ads/core/internal/common/database/database_table_util.cc
+++ b/components/brave_ads/core/internal/common/database/database_table_util.cc
@@ -5,6 +5,7 @@
 
 #include "brave/components/brave_ads/core/internal/common/database/database_table_util.h"
 
+#include "base/check.h"
 #include "base/check_op.h"
 #include "base/strings/string_util.h"
 #include "brave/components/brave_ads/core/internal/common/database/database_transaction_util.h"

--- a/components/brave_ads/core/internal/common/database/database_transaction_util.cc
+++ b/components/brave_ads/core/internal/common/database/database_transaction_util.cc
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <utility>
 
+#include "base/check.h"
 #include "base/functional/bind.h"
 #include "base/strings/string_util.h"
 #include "base/trace_event/trace_event.h"

--- a/components/brave_ads/core/internal/common/functional/once_closure_task_queue.cc
+++ b/components/brave_ads/core/internal/common/functional/once_closure_task_queue.cc
@@ -7,6 +7,8 @@
 
 #include <utility>
 
+#include "base/check.h"
+
 namespace brave_ads {
 
 OnceClosureTaskQueue::OnceClosureTaskQueue() = default;

--- a/components/brave_ads/core/internal/common/logging_util.h
+++ b/components/brave_ads/core/internal/common/logging_util.h
@@ -8,6 +8,7 @@
 
 #include <sstream>  // IWYU pragma: keep
 
+#include "base/logging.h"
 #include "brave/components/brave_ads/core/internal/common/logging_util_internal.h"  // IWYU pragma: keep
 
 namespace brave_ads {

--- a/components/brave_ads/core/internal/common/subdivision/subdivision.cc
+++ b/components/brave_ads/core/internal/common/subdivision/subdivision.cc
@@ -7,6 +7,7 @@
 
 #include <optional>
 
+#include "base/check.h"
 #include "brave/components/brave_ads/core/internal/ads_client/ads_client_util.h"
 #include "brave/components/brave_ads/core/internal/common/logging_util.h"
 #include "brave/components/brave_ads/core/internal/common/subdivision/subdivision_util.h"

--- a/components/brave_ads/core/internal/common/subdivision/url_request/subdivision_url_request.cc
+++ b/components/brave_ads/core/internal/common/subdivision/url_request/subdivision_url_request.cc
@@ -8,6 +8,7 @@
 #include <optional>
 #include <utility>
 
+#include "base/check.h"
 #include "base/location.h"
 #include "base/time/time.h"
 #include "brave/components/brave_ads/core/internal/ads_client/ads_client_util.h"

--- a/components/brave_ads/core/internal/common/test/internal/tag_parser_test_util_internal.cc
+++ b/components/brave_ads/core/internal/common/test/internal/tag_parser_test_util_internal.cc
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "base/check.h"
+#include "base/check_op.h"
 #include "base/i18n/time_formatting.h"
 #include "base/notreached.h"
 #include "base/strings/string_number_conversions.h"

--- a/components/brave_ads/core/internal/common/test/internal/url_response_test_util_internal.cc
+++ b/components/brave_ads/core/internal/common/test/internal/url_response_test_util_internal.cc
@@ -9,6 +9,7 @@
 #include <string>
 #include <vector>
 
+#include "base/check.h"
 #include "base/check_op.h"
 #include "base/containers/flat_map.h"
 #include "base/files/file_path.h"

--- a/components/brave_ads/core/internal/common/test/local_state_pref_registry_test_util.cc
+++ b/components/brave_ads/core/internal/common/test/local_state_pref_registry_test_util.cc
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include "base/check.h"
 #include "base/json/values_util.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/time/time.h"

--- a/components/brave_ads/core/internal/common/test/local_state_pref_value_test_util.cc
+++ b/components/brave_ads/core/internal/common/test/local_state_pref_value_test_util.cc
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include "base/check.h"
 #include "base/json/values_util.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/time/time.h"

--- a/components/brave_ads/core/internal/common/test/mock_test_util.cc
+++ b/components/brave_ads/core/internal/common/test/mock_test_util.cc
@@ -10,6 +10,7 @@
 #include <string>
 #include <utility>
 
+#include "base/check.h"
 #include "base/check_op.h"
 #include "base/notreached.h"
 #include "base/types/cxx23_to_underlying.h"

--- a/components/brave_ads/core/internal/common/test/profile_pref_registry_test_util.cc
+++ b/components/brave_ads/core/internal/common/test/profile_pref_registry_test_util.cc
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include "base/check.h"
 #include "base/json/values_util.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/time/time.h"

--- a/components/brave_ads/core/internal/common/test/profile_pref_value_test_util.cc
+++ b/components/brave_ads/core/internal/common/test/profile_pref_value_test_util.cc
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include "base/check.h"
 #include "base/json/values_util.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/time/time.h"

--- a/components/brave_ads/core/internal/common/test/time_test_util.cc
+++ b/components/brave_ads/core/internal/common/test/time_test_util.cc
@@ -8,6 +8,7 @@
 #include <ctime>
 
 #include "base/check.h"
+#include "base/check_op.h"
 #include "base/i18n/time_formatting.h"
 #include "base/time/time.h"
 

--- a/components/brave_ads/core/internal/common/url/url_util.cc
+++ b/components/brave_ads/core/internal/common/url/url_util.cc
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 
+#include "base/check.h"
 #include "base/strings/pattern.h"
 #include "base/strings/string_util.h"
 #include "brave/components/brave_ads/core/internal/common/url/url_util_internal.h"

--- a/components/brave_ads/core/internal/common/url/url_util_internal.cc
+++ b/components/brave_ads/core/internal/common/url/url_util_internal.cc
@@ -7,6 +7,7 @@
 
 #include <string>
 
+#include "base/check.h"
 #include "base/containers/contains.h"
 #include "net/base/registry_controlled_domains/registry_controlled_domain.h"
 #include "net/base/url_util.h"

--- a/components/brave_ads/core/internal/database/database_manager.cc
+++ b/components/brave_ads/core/internal/database/database_manager.cc
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include "base/check.h"
 #include "base/check_op.h"
 #include "base/debug/dump_without_crashing.h"
 #include "base/functional/bind.h"

--- a/components/brave_ads/core/internal/deprecated/confirmations/confirmation_state_manager.h
+++ b/components/brave_ads/core/internal/deprecated/confirmations/confirmation_state_manager.h
@@ -9,6 +9,7 @@
 #include <optional>
 #include <string>
 
+#include "base/check.h"
 #include "base/memory/weak_ptr.h"
 #include "base/values.h"
 #include "brave/components/brave_ads/core/internal/account/tokens/confirmation_tokens/confirmation_tokens.h"

--- a/components/brave_ads/core/internal/history/ad_history_builder_util.cc
+++ b/components/brave_ads/core/internal/history/ad_history_builder_util.cc
@@ -5,6 +5,7 @@
 
 #include "brave/components/brave_ads/core/internal/history/ad_history_builder_util.h"
 
+#include "base/check.h"
 #include "base/time/time.h"
 #include "brave/components/brave_ads/core/mojom/brave_ads.mojom.h"
 #include "brave/components/brave_ads/core/public/ad_units/ad_info.h"

--- a/components/brave_ads/core/internal/history/ad_history_manager.cc
+++ b/components/brave_ads/core/internal/history/ad_history_manager.cc
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include "base/check.h"
 #include "base/functional/bind.h"
 #include "base/time/time.h"
 #include "brave/components/brave_ads/core/internal/ad_units/promoted_content_ad/promoted_content_ad_info.h"

--- a/components/brave_ads/core/internal/legacy_migration/database/database_migration.cc
+++ b/components/brave_ads/core/internal/legacy_migration/database/database_migration.cc
@@ -8,6 +8,7 @@
 #include <utility>
 
 #include "base/check.h"
+#include "base/check_op.h"
 #include "base/location.h"
 #include "brave/components/brave_ads/core/internal/account/confirmations/queue/confirmation_queue_database_table.h"
 #include "brave/components/brave_ads/core/internal/account/deposits/deposits_database_table.h"

--- a/components/brave_ads/core/internal/ml/data/vector_data.cc
+++ b/components/brave_ads/core/internal/ml/data/vector_data.cc
@@ -13,6 +13,7 @@
 #include <numeric>
 #include <utility>
 
+#include "base/check.h"
 #include "base/check_op.h"
 
 namespace brave_ads::ml {

--- a/components/brave_ads/core/internal/ml/pipeline/text_processing/text_processing.cc
+++ b/components/brave_ads/core/internal/ml/pipeline/text_processing/text_processing.cc
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <utility>
 
+#include "base/check.h"
 #include "base/files/file.h"
 #include "brave/components/brave_ads/core/internal/common/strings/string_strip_util.h"
 #include "brave/components/brave_ads/core/internal/ml/data/text_data.h"

--- a/components/brave_ads/core/internal/serving/eligible_ads/exclusion_rules/daypart_exclusion_rule_test_util.cc
+++ b/components/brave_ads/core/internal/serving/eligible_ads/exclusion_rules/daypart_exclusion_rule_test_util.cc
@@ -3,8 +3,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-#include "base/time/time.h"
 #include "brave/components/brave_ads/core/internal/serving/eligible_ads/exclusion_rules/daypart_exclusion_rule_test_util.h"
+
+#include "base/check.h"
+#include "base/time/time.h"
 
 namespace brave_ads::test {
 

--- a/components/brave_ads/core/internal/serving/eligible_ads/exclusion_rules/exclusion_rule_util.cc
+++ b/components/brave_ads/core/internal/serving/eligible_ads/exclusion_rules/exclusion_rule_util.cc
@@ -5,6 +5,7 @@
 
 #include "brave/components/brave_ads/core/internal/serving/eligible_ads/exclusion_rules/exclusion_rule_util.h"
 
+#include "base/check.h"
 #include "base/time/time.h"
 #include "brave/components/brave_ads/core/internal/common/algorithm/count_if_until_util.h"
 #include "brave/components/brave_ads/core/internal/creatives/creative_ad_info.h"

--- a/components/brave_ads/core/internal/serving/prediction/model_based/creative_ad_model_based_predictor.h
+++ b/components/brave_ads/core/internal/serving/prediction/model_based/creative_ad_model_based_predictor.h
@@ -9,6 +9,7 @@
 #include <optional>
 #include <vector>
 
+#include "base/check.h"
 #include "brave/components/brave_ads/core/internal/serving/prediction/model_based/creative_ad_model_based_predictor_info.h"
 #include "brave/components/brave_ads/core/internal/serving/prediction/model_based/creative_ad_model_based_predictor_util.h"
 #include "brave/components/brave_ads/core/internal/serving/prediction/model_based/sampling/creative_ad_model_based_predictor_sampling.h"

--- a/components/brave_ads/core/internal/serving/targeting/condition_matcher/prefs/internal/condition_matcher_pref_util_internal.cc
+++ b/components/brave_ads/core/internal/serving/targeting/condition_matcher/prefs/internal/condition_matcher_pref_util_internal.cc
@@ -8,7 +8,6 @@
 #include <utility>
 #include <vector>
 
-#include "base/check.h"
 #include "base/notreached.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/string_split.h"

--- a/components/brave_ads/core/internal/targeting/geographical/subdivision/subdivision_targeting.cc
+++ b/components/brave_ads/core/internal/targeting/geographical/subdivision/subdivision_targeting.cc
@@ -5,6 +5,7 @@
 
 #include "brave/components/brave_ads/core/internal/targeting/geographical/subdivision/subdivision_targeting.h"
 
+#include "base/check.h"
 #include "brave/components/brave_ads/core/internal/ads_client/ads_client_util.h"
 #include "brave/components/brave_ads/core/internal/common/logging_util.h"
 #include "brave/components/brave_ads/core/internal/common/subdivision/subdivision_util.h"

--- a/components/brave_ads/core/internal/user_engagement/conversions/types/verifiable_conversion/envelope/verifiable_conversion_envelope_test_util.cc
+++ b/components/brave_ads/core/internal/user_engagement/conversions/types/verifiable_conversion/envelope/verifiable_conversion_envelope_test_util.cc
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "base/base64.h"
+#include "base/check.h"
 #include "brave/components/brave_ads/core/internal/common/crypto/crypto_util.h"
 #include "brave/components/brave_ads/core/internal/user_engagement/conversions/types/verifiable_conversion/envelope/verifiable_conversion_envelope_info.h"
 #include "tweetnacl.h"  // NOLINT

--- a/components/brave_ads/core/internal/user_engagement/site_visit/site_visit.cc
+++ b/components/brave_ads/core/internal/user_engagement/site_visit/site_visit.cc
@@ -5,6 +5,7 @@
 
 #include "brave/components/brave_ads/core/internal/user_engagement/site_visit/site_visit.h"
 
+#include "base/check.h"
 #include "base/functional/bind.h"
 #include "base/location.h"
 #include "base/time/time.h"


### PR DESCRIPTION
This change is one of many fixing inclusion for the following files:

 - `base/notimplemented.h`
 - `base/notreached.h`
 - `base/check.h`
 - `base/dcheck_is_on.h`
 - `base/check_deref.h`
 - `base/check_op.h`
 - `base/logging/log_severity.h`
 - `base/logging.h`

This change is a mechanical change done with the following script:
https://github.com/brave/brave-browser/issues/46707#issuecomment-2960116515

Resolves https://github.com/brave/brave-browser/issues/46707
