### PR TITLE
[ads] Add condition matcher virtual pref for survey panelists

### DIFF
--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -197,6 +197,7 @@ AdsServiceImpl::AdsServiceImpl(
       prefs_(prefs),
       local_state_(local_state),
       virtual_pref_provider_(std::make_unique<VirtualPrefProvider>(
+          prefs_,
           local_state_,
           std::move(virtual_pref_provider_delegate))),
       url_loader_(std::move(url_loader)),

--- a/components/brave_ads/core/browser/service/BUILD.gn
+++ b/components/brave_ads/core/browser/service/BUILD.gn
@@ -20,6 +20,7 @@ source_set("service") {
     "//base",
     "//brave/components/brave_ads/core/mojom",
     "//brave/components/brave_ads/core/public:headers",
+    "//brave/components/ntp_background_images/common",
     "//brave/components/services/bat_ads/public/interfaces",
     "//components/keyed_service/core",
     "//components/prefs",

--- a/components/brave_ads/core/browser/service/virtual_pref_provider.cc
+++ b/components/brave_ads/core/browser/service/virtual_pref_provider.cc
@@ -12,6 +12,7 @@
 #include "base/version_info/version_info.h"
 #include "brave/components/brave_ads/core/browser/service/virtual_pref_provider_util.h"
 #include "brave/components/brave_ads/core/public/common/locale/locale_util.h"
+#include "brave/components/ntp_background_images/common/pref_names.h"
 #include "brave/components/skus/browser/pref_names.h"
 #include "components/prefs/pref_service.h"
 
@@ -85,6 +86,8 @@ base::Value::Dict ParseSkuOrders(const base::Value::Dict& dict) {
 }
 
 base::Value::Dict GetSkus(PrefService* local_state) {
+  CHECK(local_state);
+
   base::Value::Dict skus;
 
   if (!local_state->FindPreference(skus::prefs::kSkusState)) {
@@ -118,11 +121,20 @@ base::Value::Dict GetSkus(PrefService* local_state) {
   return skus;
 }
 
+bool IsSurveyPanelist(PrefService* prefs) {
+  CHECK(prefs);
+
+  return prefs->GetBoolean(
+      ntp_background_images::prefs::kNewTabPageSponsoredImagesSurveyPanelist);
+}
+
 }  // namespace
 
-VirtualPrefProvider::VirtualPrefProvider(PrefService* local_state,
+VirtualPrefProvider::VirtualPrefProvider(PrefService* prefs,
+                                         PrefService* local_state,
                                          std::unique_ptr<Delegate> delegate)
-    : local_state_(local_state), delegate_(std::move(delegate)) {
+    : prefs_(prefs), local_state_(local_state), delegate_(std::move(delegate)) {
+  CHECK(prefs_);
   CHECK(local_state_);
   CHECK(delegate_);
 }
@@ -146,6 +158,7 @@ base::Value::Dict VirtualPrefProvider::GetPrefs() const {
                                   .Set("region", CurrentCountryCode()))
                .Set("is_mobile_platform", IsMobilePlatform())
                .Set("name", version_info::GetOSType()))
+      .Set("[virtual]:is_survey_panelist", IsSurveyPanelist(prefs_))
       .Set("[virtual]:search_engine",
            base::Value::Dict().Set("default_name",
                                    delegate_->GetDefaultSearchEngineName()))

--- a/components/brave_ads/core/browser/service/virtual_pref_provider.h
+++ b/components/brave_ads/core/browser/service/virtual_pref_provider.h
@@ -27,7 +27,8 @@ class VirtualPrefProvider final {
     virtual std::string GetDefaultSearchEngineName() const = 0;
   };
 
-  VirtualPrefProvider(PrefService* local_state,
+  VirtualPrefProvider(PrefService* prefs,
+                      PrefService* local_state,
                       std::unique_ptr<Delegate> delegate);
 
   VirtualPrefProvider(const VirtualPrefProvider&) = delete;
@@ -38,6 +39,7 @@ class VirtualPrefProvider final {
   base::Value::Dict GetPrefs() const;
 
  private:
+  const raw_ptr<PrefService> prefs_;        // Not owned.
   const raw_ptr<PrefService> local_state_;  // Not owned.
 
   const std::unique_ptr<Delegate> delegate_;

--- a/ios/browser/api/ads/brave_ads.mm
+++ b/ios/browser/api/ads/brave_ads.mm
@@ -160,7 +160,7 @@ constexpr NSString* kAdsResourceComponentMetadataVersion = @".v1";
     ProfileIOS* profile = [self getLastUsedProfile];
     CHECK(profile);
     virtualPrefProvider = std::make_unique<brave_ads::VirtualPrefProvider>(
-        self.localStatePrefService,
+        self.profilePrefService, self.localStatePrefService,
         std::make_unique<brave_ads::VirtualPrefProviderDelegateIOS>(*profile));
   }
   return self;


### PR DESCRIPTION
Support `[virtual]:is_survey_panelist` for SmartNTT matching to deliver pre/post-survey new tab takeovers to users opted in via brave://settings/surveyPanelist

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/46500

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
