### PR TITLE
[IWYU] Fixing logging inclusions pt.5

### DIFF
--- a/browser/permissions/connect_account_android.cc
+++ b/browser/permissions/connect_account_android.cc
@@ -6,6 +6,7 @@
 #include "base/android/jni_android.h"
 #include "base/android/jni_array.h"
 #include "base/android/jni_string.h"
+#include "base/check.h"
 #include "base/functional/callback.h"
 #include "brave/components/brave_wallet/browser/permission_utils.h"
 #include "brave/components/brave_wallet/common/brave_wallet.mojom-shared.h"

--- a/browser/permissions/mock_permission_lifetime_prompt_factory.cc
+++ b/browser/permissions/mock_permission_lifetime_prompt_factory.cc
@@ -7,6 +7,7 @@
 
 #include <vector>
 
+#include "base/check.h"
 #include "base/containers/contains.h"
 #include "base/functional/bind.h"
 #include "base/memory/ptr_util.h"

--- a/browser/permissions/permission_lifetime_manager_browsertest.cc
+++ b/browser/permissions/permission_lifetime_manager_browsertest.cc
@@ -10,6 +10,7 @@
 
 #include "base/command_line.h"
 #include "base/json/json_file_value_serializer.h"
+#include "base/notreached.h"
 #include "base/path_service.h"
 #include "base/run_loop.h"
 #include "base/strings/string_util.h"

--- a/browser/permissions/permission_origin_lifetime_monitor_impl.cc
+++ b/browser/permissions/permission_origin_lifetime_monitor_impl.cc
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include "base/check.h"
 #include "brave/browser/ephemeral_storage/ephemeral_storage_service_factory.h"
 #include "brave/components/brave_wallet/browser/permission_utils.h"
 #include "brave/components/ephemeral_storage/ephemeral_storage_service.h"

--- a/browser/playlist/playlist_data_source.cc
+++ b/browser/playlist/playlist_data_source.cc
@@ -11,6 +11,8 @@
 #include <utility>
 #include <vector>
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "base/containers/heap_array.h"
 #include "base/files/file.h"
 #include "base/files/file_path.h"

--- a/browser/playlist/playlist_service_factory.cc
+++ b/browser/playlist/playlist_service_factory.cc
@@ -11,7 +11,10 @@
 #include <utility>
 #include <vector>
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "base/feature_list.h"
+#include "base/logging.h"
 #include "base/no_destructor.h"
 #include "base/task/thread_pool.h"
 #include "brave/browser/brave_stats/first_run_util.h"

--- a/browser/playlist/test/playlist_media_discovery_browsertests.cc
+++ b/browser/playlist/test/playlist_media_discovery_browsertests.cc
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 
+#include "base/logging.h"
 #include "base/test/bind.h"
 #include "base/test/mock_callback.h"
 #include "base/test/scoped_feature_list.h"

--- a/browser/playlist/test/playlist_service_unittest.cc
+++ b/browser/playlist/test/playlist_service_unittest.cc
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 
+#include "base/check.h"
 #include "base/files/file_util.h"
 #include "base/files/scoped_temp_dir.h"
 #include "base/run_loop.h"

--- a/browser/ui/omnibox/brave_omnibox_client_impl.cc
+++ b/browser/ui/omnibox/brave_omnibox_client_impl.cc
@@ -7,6 +7,7 @@
 
 #include <string>
 
+#include "base/check.h"
 #include "base/check_is_test.h"
 #include "brave/browser/autocomplete/brave_autocomplete_scheme_classifier.h"
 #include "brave/browser/misc_metrics/profile_misc_metrics_service.h"

--- a/browser/ui/side_panel/ai_chat/ai_chat_side_panel_utils.cc
+++ b/browser/ui/side_panel/ai_chat/ai_chat_side_panel_utils.cc
@@ -5,6 +5,7 @@
 
 #include "brave/browser/ui/side_panel/ai_chat/ai_chat_side_panel_utils.h"
 
+#include "base/notimplemented.h"
 #include "chrome/browser/ui/browser_finder.h"
 
 namespace ai_chat {

--- a/browser/ui/views/omnibox/brave_omnibox_result_view.cc
+++ b/browser/ui/views/omnibox/brave_omnibox_result_view.cc
@@ -7,6 +7,7 @@
 
 #include <memory>
 
+#include "base/check.h"
 #include "base/time/time.h"
 #include "brave/browser/ui/color/brave_color_id.h"
 #include "brave/browser/ui/views/omnibox/brave_omnibox_popup_view_views.h"

--- a/browser/ui/views/omnibox/brave_search_conversion_promotion_view.cc
+++ b/browser/ui/views/omnibox/brave_search_conversion_promotion_view.cc
@@ -7,7 +7,9 @@
 
 #include <utility>
 
-#include "base/logging.h"
+#include "base/check.h"
+#include "base/check_op.h"
+#include "base/notreached.h"
 #include "brave/browser/ui/color/brave_color_id.h"
 #include "brave/browser/ui/views/omnibox/brave_omnibox_popup_view_views.h"
 #include "brave/browser/ui/views/omnibox/brave_omnibox_result_view.h"

--- a/browser/ui/views/playlist/playlist_action_dialogs.cc
+++ b/browser/ui/views/playlist/playlist_action_dialogs.cc
@@ -10,6 +10,10 @@
 #include <utility>
 #include <variant>
 
+#include "base/check.h"
+#include "base/check_op.h"
+#include "base/logging.h"
+#include "base/notreached.h"
 #include "base/strings/stringprintf.h"
 #include "brave/browser/playlist/playlist_service_factory.h"
 #include "brave/browser/ui/color/brave_color_id.h"

--- a/browser/ui/views/playlist/playlist_action_dialogs.h
+++ b/browser/ui/views/playlist/playlist_action_dialogs.h
@@ -12,6 +12,7 @@
 #include <variant>
 #include <vector>
 
+#include "base/check.h"
 #include "brave/browser/ui/views/playlist/selectable_list_view.h"
 #include "brave/components/playlist/browser/playlist_tab_helper_observer.h"
 #include "brave/components/playlist/common/mojom/playlist.mojom.h"

--- a/browser/ui/views/playlist/playlist_add_bubble_view.cc
+++ b/browser/ui/views/playlist/playlist_add_bubble_view.cc
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include "base/check.h"
 #include "base/functional/bind.h"
 #include "base/functional/callback.h"
 #include "base/location.h"

--- a/browser/ui/views/playlist/playlist_bubble_view.cc
+++ b/browser/ui/views/playlist/playlist_bubble_view.cc
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include "base/check.h"
 #include "brave/browser/ui/views/playlist/playlist_action_icon_view.h"
 #include "brave/components/playlist/browser/playlist_tab_helper.h"
 #include "ui/base/metadata/metadata_impl_macros.h"

--- a/browser/ui/views/playlist/playlist_bubbles_controller.cc
+++ b/browser/ui/views/playlist/playlist_bubbles_controller.cc
@@ -7,8 +7,8 @@
 
 #include <vector>
 
+#include "base/check.h"
 #include "base/memory/ptr_util.h"
-#include "base/notreached.h"
 #include "brave/browser/ui/views/playlist/playlist_action_icon_view.h"
 #include "brave/browser/ui/views/playlist/playlist_add_bubble_view.h"
 #include "brave/browser/ui/views/playlist/playlist_edit_bubble_view.h"

--- a/browser/ui/views/playlist/playlist_edit_bubble_view.cc
+++ b/browser/ui/views/playlist/playlist_edit_bubble_view.cc
@@ -10,6 +10,7 @@
 #include <string>
 #include <utility>
 
+#include "base/check.h"
 #include "base/functional/bind.h"
 #include "base/functional/callback.h"
 #include "base/memory/weak_ptr.h"

--- a/browser/ui/views/playlist/selectable_list_view.h
+++ b/browser/ui/views/playlist/selectable_list_view.h
@@ -11,6 +11,8 @@
 #include <string>
 #include <vector>
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "base/containers/flat_set.h"
 #include "brave/browser/ui/views/playlist/thumbnail_provider.h"
 #include "brave/components/playlist/browser/playlist_constants.h"

--- a/browser/ui/views/playlist/thumbnail_provider.cc
+++ b/browser/ui/views/playlist/thumbnail_provider.cc
@@ -9,10 +9,12 @@
 #include <memory>
 #include <utility>
 
+#include "base/check.h"
 #include "base/containers/flat_map.h"
 #include "base/containers/lru_cache.h"
 #include "base/files/file_path.h"
 #include "base/files/file_util.h"
+#include "base/logging.h"
 #include "base/no_destructor.h"
 #include "base/task/thread_pool.h"
 #include "base/task/thread_pool/thread_pool_instance.h"

--- a/browser/ui/views/side_panel/brave_bookmarks_side_panel_view.cc
+++ b/browser/ui/views/side_panel/brave_bookmarks_side_panel_view.cc
@@ -7,6 +7,7 @@
 
 #include <memory>
 
+#include "base/check_op.h"
 #include "base/memory/raw_ref.h"
 #include "brave/browser/ui/color/brave_color_id.h"
 #include "brave/components/vector_icons/vector_icons.h"

--- a/browser/ui/views/side_panel/brave_side_panel.cc
+++ b/browser/ui/views/side_panel/brave_side_panel.cc
@@ -10,6 +10,7 @@
 #include <utility>
 
 #include "base/check_is_test.h"
+#include "base/check_op.h"
 #include "base/functional/bind.h"
 #include "brave/browser/ui/brave_browser.h"
 #include "brave/browser/ui/color/brave_color_id.h"

--- a/browser/ui/views/side_panel/brave_side_panel_coordinator.cc
+++ b/browser/ui/views/side_panel/brave_side_panel_coordinator.cc
@@ -9,8 +9,10 @@
 #include <string>
 #include <utility>
 
+#include "base/check.h"
 #include "base/debug/crash_logging.h"
 #include "base/debug/dump_without_crashing.h"
+#include "base/logging.h"
 #include "brave/browser/ui/sidebar/sidebar_service_factory.h"
 #include "brave/browser/ui/sidebar/sidebar_utils.h"
 #include "brave/browser/ui/views/frame/brave_browser_view.h"

--- a/browser/ui/views/side_panel/brave_side_panel_resize_widget.cc
+++ b/browser/ui/views/side_panel/brave_side_panel_resize_widget.cc
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include "base/check.h"
 #include "brave/browser/ui/views/frame/brave_browser_view.h"
 #include "brave/browser/ui/views/side_panel/brave_side_panel.h"
 #include "build/build_config.h"

--- a/browser/ui/views/side_panel/brave_side_panel_utils.cc
+++ b/browser/ui/views/side_panel/brave_side_panel_utils.cc
@@ -3,6 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include "base/check.h"
 #include "brave/browser/ai_chat/ai_chat_urls.h"
 #include "brave/browser/ui/webui/ai_chat/ai_chat_ui.h"
 #include "brave/components/ai_chat/core/browser/utils.h"

--- a/browser/ui/views/side_panel/playlist/playlist_contents_wrapper.cc
+++ b/browser/ui/views/side_panel/playlist/playlist_contents_wrapper.cc
@@ -7,6 +7,8 @@
 
 #include <utility>
 
+#include "base/check.h"
+#include "base/logging.h"
 #include "brave/browser/ui/views/side_panel/playlist/playlist_side_panel_coordinator.h"
 #include "chrome/browser/picture_in_picture/picture_in_picture_window_manager.h"
 #include "chrome/browser/ui/exclusive_access/exclusive_access_manager.h"

--- a/browser/ui/views/side_panel/playlist/playlist_side_panel_coordinator.cc
+++ b/browser/ui/views/side_panel/playlist/playlist_side_panel_coordinator.cc
@@ -7,6 +7,7 @@
 
 #include <memory>
 
+#include "base/check.h"
 #include "base/check_is_test.h"
 #include "base/functional/callback.h"
 #include "brave/browser/ui/sidebar/sidebar_controller.h"

--- a/components/brave_search/browser/backup_results_allowed_urls.cc
+++ b/components/brave_search/browser/backup_results_allowed_urls.cc
@@ -10,7 +10,6 @@
 #include <vector>
 
 #include "base/containers/fixed_flat_set.h"
-#include "base/logging.h"
 #include "base/strings/string_split.h"
 #include "net/base/registry_controlled_domains/registry_controlled_domain.h"
 #include "url/url_constants.h"

--- a/components/brave_search/renderer/brave_search_default_js_handler.cc
+++ b/components/brave_search/renderer/brave_search_default_js_handler.cc
@@ -8,6 +8,7 @@
 #include <tuple>
 #include <utility>
 
+#include "base/check.h"
 #include "base/no_destructor.h"
 #include "base/strings/utf_string_conversions.h"
 #include "content/public/renderer/render_frame.h"

--- a/components/brave_search/renderer/brave_search_service_worker_holder.cc
+++ b/components/brave_search/renderer/brave_search_service_worker_holder.cc
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "base/auto_reset.h"
+#include "base/check.h"
 #include "base/threading/thread_checker.h"
 #include "brave/components/brave_search/common/brave_search_utils.h"
 #include "brave/components/brave_search/renderer/brave_search_fallback_js_handler.h"

--- a/components/brave_sync/brave_sync_prefs.cc
+++ b/components/brave_sync/brave_sync_prefs.cc
@@ -8,6 +8,7 @@
 #include <utility>
 
 #include "base/base64.h"
+#include "base/check.h"
 #include "base/files/file_path.h"
 #include "base/logging.h"
 #include "base/strings/strcat.h"

--- a/components/brave_sync/brave_sync_prefs_unittest.cc
+++ b/components/brave_sync/brave_sync_prefs_unittest.cc
@@ -8,7 +8,6 @@
 #include <memory>
 
 #include "base/base64.h"
-#include "base/logging.h"
 #include "base/test/gtest_util.h"
 #include "base/test/task_environment.h"
 #include "build/build_config.h"

--- a/components/brave_sync/crypto/crypto.cc
+++ b/components/brave_sync/crypto/crypto.cc
@@ -7,6 +7,8 @@
 
 #include <cmath>
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "base/logging.h"
 #include "brave/third_party/bip39wally-core-native/include/wally_bip39.h"
 #include "brave/vendor/bat-native-tweetnacl/tweetnacl.h"

--- a/components/brave_sync/network_time_helper.cc
+++ b/components/brave_sync/network_time_helper.cc
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include "base/logging.h"
 #include "base/no_destructor.h"
 #include "base/sequence_checker.h"
 #include "base/task/single_thread_task_runner.h"

--- a/components/brave_sync/qr_code_validator.cc
+++ b/components/brave_sync/qr_code_validator.cc
@@ -9,8 +9,8 @@
 #include <string_view>
 #include <vector>
 
+#include "base/check.h"
 #include "base/logging.h"
-#include "base/notreached.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/string_split.h"
 #include "base/strings/string_util.h"

--- a/components/brave_sync/qr_code_validator_unittest.cc
+++ b/components/brave_sync/qr_code_validator_unittest.cc
@@ -8,7 +8,6 @@
 #include <memory>
 #include <string>
 
-#include "base/logging.h"
 #include "base/strings/stringize_macros.h"
 #include "base/time/time_override.h"
 #include "brave/components/brave_sync/qr_code_data.h"

--- a/components/brave_sync/sync_service_impl_helper.cc
+++ b/components/brave_sync/sync_service_impl_helper.cc
@@ -8,6 +8,7 @@
 #include <string>
 #include <utility>
 
+#include "base/check.h"
 #include "brave/components/sync/service/brave_sync_service_impl.h"
 #include "components/sync_device_info/device_info_sync_service.h"
 #include "components/sync_device_info/device_info_tracker.h"

--- a/components/brave_sync/time_limited_words.cc
+++ b/components/brave_sync/time_limited_words.cc
@@ -9,6 +9,8 @@
 #include <string>
 #include <vector>
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "base/compiler_specific.h"
 #include "base/containers/span.h"
 #include "base/logging.h"

--- a/components/content_settings/core/browser/brave_content_settings_pref_provider.cc
+++ b/components/content_settings/core/browser/brave_content_settings_pref_provider.cc
@@ -9,7 +9,9 @@
 #include <memory>
 #include <utility>
 
+#include "base/check.h"
 #include "base/check_deref.h"
+#include "base/check_op.h"
 #include "base/containers/contains.h"
 #include "base/functional/bind.h"
 #include "base/json/values_util.h"

--- a/components/content_settings/core/browser/brave_content_settings_pref_provider_unittest.cc
+++ b/components/content_settings/core/browser/brave_content_settings_pref_provider_unittest.cc
@@ -10,6 +10,7 @@
 #include <string_view>
 #include <utility>
 
+#include "base/check.h"
 #include "base/json/values_util.h"
 #include "base/memory/raw_ptr.h"
 #include "base/strings/string_number_conversions.h"

--- a/components/content_settings/core/browser/brave_content_settings_utils.cc
+++ b/components/content_settings/core/browser/brave_content_settings_utils.cc
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <optional>
 
+#include "base/check.h"
 #include "base/containers/contains.h"
 #include "base/no_destructor.h"
 #include "base/notreached.h"

--- a/components/content_settings/core/browser/remote_list_provider.cc
+++ b/components/content_settings/core/browser/remote_list_provider.cc
@@ -8,6 +8,7 @@
 #include <memory>
 #include <vector>
 
+#include "base/check.h"
 #include "brave/components/webcompat/content/browser/webcompat_exceptions_service.h"
 #include "components/content_settings/core/browser/content_settings_rule.h"
 

--- a/components/content_settings/core/common/content_settings_util.cc
+++ b/components/content_settings/core/common/content_settings_util.cc
@@ -5,6 +5,7 @@
 
 #include "brave/components/content_settings/core/common/content_settings_util.h"
 
+#include "base/check.h"
 #include "base/strings/strcat.h"
 #include "net/base/registry_controlled_domains/registry_controlled_domain.h"
 #include "url/gurl.h"

--- a/components/content_settings/renderer/brave_content_settings_agent_impl.cc
+++ b/components/content_settings/renderer/brave_content_settings_agent_impl.cc
@@ -11,11 +11,13 @@
 #include <utility>
 #include <vector>
 
+#include "base/check.h"
 #include "base/containers/contains.h"
 #include "base/debug/crash_logging.h"
 #include "base/debug/dump_without_crashing.h"
 #include "base/feature_list.h"
 #include "base/functional/callback_helpers.h"
+#include "base/logging.h"
 #include "base/strings/utf_string_conversions.h"
 #include "brave/components/brave_shields/core/common/brave_shield_utils.h"
 #include "brave/components/brave_shields/core/common/features.h"

--- a/components/cosmetic_filters/browser/cosmetic_filters_resources.cc
+++ b/components/cosmetic_filters/browser/cosmetic_filters_resources.cc
@@ -9,6 +9,7 @@
 #include <optional>
 #include <utility>
 
+#include "base/check.h"
 #include "base/feature_list.h"
 #include "base/json/json_reader.h"
 #include "base/strings/string_util.h"

--- a/components/cosmetic_filters/renderer/cosmetic_filters_js_handler.cc
+++ b/components/cosmetic_filters/renderer/cosmetic_filters_js_handler.cc
@@ -8,6 +8,7 @@
 #include <optional>
 #include <utility>
 
+#include "base/check.h"
 #include "base/feature_list.h"
 #include "base/functional/bind.h"
 #include "base/json/json_writer.h"

--- a/components/cosmetic_filters/renderer/cosmetic_filters_js_render_frame_observer.cc
+++ b/components/cosmetic_filters/renderer/cosmetic_filters_js_render_frame_observer.cc
@@ -9,6 +9,7 @@
 #include <optional>
 #include <utility>
 
+#include "base/check_op.h"
 #include "base/feature_list.h"
 #include "base/functional/bind.h"
 #include "brave/components/brave_shields/core/common/features.h"

--- a/components/decentralized_dns/content/decentralized_dns_interstitial_controller_client.cc
+++ b/components/decentralized_dns/content/decentralized_dns_interstitial_controller_client.cc
@@ -5,6 +5,7 @@
 
 #include "brave/components/decentralized_dns/content/decentralized_dns_interstitial_controller_client.h"
 
+#include "base/check.h"
 #include "base/notreached.h"
 #include "brave/components/decentralized_dns/core/constants.h"
 #include "brave/components/decentralized_dns/core/pref_names.h"

--- a/components/decentralized_dns/content/decentralized_dns_opt_in_page.cc
+++ b/components/decentralized_dns/content/decentralized_dns_opt_in_page.cc
@@ -9,6 +9,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/check.h"
 #include "base/notreached.h"
 #include "base/strings/strcat.h"
 #include "base/strings/string_number_conversions.h"

--- a/components/decentralized_dns/content/ens_offchain_lookup_interstitial_controller_client.cc
+++ b/components/decentralized_dns/content/ens_offchain_lookup_interstitial_controller_client.cc
@@ -5,6 +5,7 @@
 
 #include "brave/components/decentralized_dns/content/ens_offchain_lookup_interstitial_controller_client.h"
 
+#include "base/check.h"
 #include "brave/components/decentralized_dns/core/constants.h"
 #include "brave/components/decentralized_dns/core/pref_names.h"
 #include "brave/components/decentralized_dns/core/utils.h"

--- a/components/decentralized_dns/content/ens_offchain_lookup_opt_in_page.cc
+++ b/components/decentralized_dns/content/ens_offchain_lookup_opt_in_page.cc
@@ -9,6 +9,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/check.h"
 #include "base/notreached.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/string_util.h"

--- a/components/ntp_background_images/browser/brave_ntp_custom_background_service.cc
+++ b/components/ntp_background_images/browser/brave_ntp_custom_background_service.cc
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include "base/check.h"
 #include "base/files/file_path.h"
 #include "brave/components/ntp_background_images/browser/url_constants.h"
 #include "url/gurl.h"

--- a/components/ntp_background_images/browser/ntp_background_images_data.cc
+++ b/components/ntp_background_images/browser/ntp_background_images_data.cc
@@ -7,6 +7,7 @@
 
 #include <optional>
 
+#include "base/check.h"
 #include "base/json/json_reader.h"
 #include "base/logging.h"
 #include "base/strings/stringprintf.h"

--- a/components/ntp_background_images/browser/ntp_background_images_service.cc
+++ b/components/ntp_background_images/browser/ntp_background_images_service.cc
@@ -8,6 +8,8 @@
 #include <memory>
 #include <utility>
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "base/command_line.h"
 #include "base/feature_list.h"
 #include "base/files/file_path.h"
@@ -15,6 +17,7 @@
 #include "base/functional/bind.h"
 #include "base/i18n/time_formatting.h"
 #include "base/json/json_reader.h"
+#include "base/logging.h"
 #include "base/path_service.h"
 #include "base/strings/stringprintf.h"
 #include "base/task/thread_pool.h"

--- a/components/ntp_background_images/browser/ntp_custom_images_source.cc
+++ b/components/ntp_background_images/browser/ntp_custom_images_source.cc
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include "base/check.h"
 #include "base/files/file_path.h"
 #include "base/files/file_util.h"
 #include "base/functional/bind.h"

--- a/components/ntp_background_images/browser/ntp_p3a_util.cc
+++ b/components/ntp_background_images/browser/ntp_p3a_util.cc
@@ -5,6 +5,7 @@
 
 #include "brave/components/ntp_background_images/browser/ntp_p3a_util.h"
 
+#include "base/check.h"
 #include "base/metrics/histogram_macros.h"
 #include "brave/components/ntp_background_images/common/pref_names.h"
 #include "components/prefs/pref_service.h"

--- a/components/ntp_background_images/browser/ntp_sponsored_images_data.cc
+++ b/components/ntp_background_images/browser/ntp_sponsored_images_data.cc
@@ -5,6 +5,7 @@
 
 #include "brave/components/ntp_background_images/browser/ntp_sponsored_images_data.h"
 
+#include "base/check.h"
 #include "base/files/file_path.h"
 #include "base/logging.h"
 #include "base/strings/string_util.h"

--- a/components/ntp_background_images/browser/view_counter_model.cc
+++ b/components/ntp_background_images/browser/view_counter_model.cc
@@ -8,6 +8,7 @@
 #include <algorithm>
 
 #include "base/check.h"
+#include "base/check_op.h"
 #include "base/rand_util.h"
 #include "brave/components/ntp_background_images/browser/features.h"
 #include "components/prefs/pref_service.h"

--- a/components/ntp_background_images/browser/view_counter_service.cc
+++ b/components/ntp_background_images/browser/view_counter_service.cc
@@ -11,6 +11,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/check.h"
 #include "base/check_is_test.h"
 #include "base/functional/bind.h"
 #include "base/functional/callback_helpers.h"

--- a/components/omnibox/browser/brave_history_quick_provider_unittest.cc
+++ b/components/omnibox/browser/brave_history_quick_provider_unittest.cc
@@ -14,6 +14,7 @@
 #include <string>
 #include <vector>
 
+#include "base/check.h"
 #include "base/memory/raw_ptr.h"
 #include "base/run_loop.h"
 #include "base/test/task_environment.h"

--- a/components/omnibox/browser/brave_history_url_provider_unittest.cc
+++ b/components/omnibox/browser/brave_history_url_provider_unittest.cc
@@ -12,6 +12,7 @@
 #include <string_view>
 #include <utility>
 
+#include "base/check.h"
 #include "base/run_loop.h"
 #include "base/test/task_environment.h"
 #include "base/time/time.h"

--- a/components/omnibox/browser/brave_local_history_zero_suggest_provider_unittest.cc
+++ b/components/omnibox/browser/brave_local_history_zero_suggest_provider_unittest.cc
@@ -11,6 +11,7 @@
 #include <string_view>
 #include <utility>
 
+#include "base/check.h"
 #include "base/memory/ref_counted.h"
 #include "base/run_loop.h"
 #include "base/strings/utf_string_conversions.h"

--- a/components/omnibox/browser/brave_search_provider.cc
+++ b/components/omnibox/browser/brave_search_provider.cc
@@ -5,6 +5,7 @@
 
 #include "brave/components/omnibox/browser/brave_search_provider.h"
 
+#include "base/logging.h"
 #include "base/metrics/histogram_macros.h"
 #include "base/time/time.h"
 #include "brave/components/omnibox/browser/brave_omnibox_prefs.h"

--- a/components/omnibox/browser/brave_search_provider_unittest.cc
+++ b/components/omnibox/browser/brave_search_provider_unittest.cc
@@ -11,6 +11,7 @@
 #include <memory>
 #include <string>
 
+#include "base/check.h"
 #include "base/compiler_specific.h"
 #include "base/memory/raw_ptr.h"
 #include "base/memory/scoped_refptr.h"

--- a/components/omnibox/browser/commander_action.cc
+++ b/components/omnibox/browser/commander_action.cc
@@ -5,6 +5,8 @@
 
 #include "brave/components/omnibox/browser/commander_action.h"
 
+#include "base/check.h"
+
 namespace commander {
 
 CommanderAction::CommanderAction(uint32_t command_index, uint32_t result_set_id)

--- a/components/omnibox/browser/commander_provider.cc
+++ b/components/omnibox/browser/commander_provider.cc
@@ -8,6 +8,7 @@
 #include <string>
 #include <utility>
 
+#include "base/check.h"
 #include "base/memory/scoped_refptr.h"
 #include "base/strings/strcat.h"
 #include "brave/components/commander/browser/commander_frontend_delegate.h"

--- a/components/omnibox/browser/commander_provider_unittest.cc
+++ b/components/omnibox/browser/commander_provider_unittest.cc
@@ -12,7 +12,7 @@
 #include <vector>
 
 #include "base/memory/scoped_refptr.h"
-#include "base/notreached.h"
+#include "base/notimplemented.h"
 #include "base/observer_list.h"
 #include "base/strings/strcat.h"
 #include "base/test/scoped_feature_list.h"

--- a/components/omnibox/browser/leo_provider.cc
+++ b/components/omnibox/browser/leo_provider.cc
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include "base/check.h"
 #include "base/strings/string_split.h"
 #include "brave/components/ai_chat/core/common/features.h"
 #include "brave/components/omnibox/browser/leo_action.h"

--- a/components/omnibox/browser/promotion_utils.cc
+++ b/components/omnibox/browser/promotion_utils.cc
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 
+#include "base/check.h"
 #include "base/strings/string_number_conversions.h"
 #include "brave/components/brave_search_conversion/types.h"
 #include "brave/components/brave_search_conversion/utils.h"

--- a/components/omnibox/browser/search_suggestions/query_check_utils.cc
+++ b/components/omnibox/browser/search_suggestions/query_check_utils.cc
@@ -9,6 +9,7 @@
 #include <string>
 #include <vector>
 
+#include "base/check.h"
 #include "base/compiler_specific.h"
 #include "base/no_destructor.h"
 #include "base/notreached.h"

--- a/components/password_manager/core/browser/import/csv_safari_password.cc
+++ b/components/password_manager/core/browser/import/csv_safari_password.cc
@@ -8,7 +8,6 @@
 #include <string_view>
 #include <utility>
 
-#include "base/check_op.h"
 #include "base/strings/string_util.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/time/time.h"

--- a/components/password_manager/core/browser/import/csv_safari_password_iterator.h
+++ b/components/password_manager/core/browser/import/csv_safari_password_iterator.h
@@ -12,6 +12,7 @@
 #include <optional>
 #include <string_view>
 
+#include "base/check.h"
 #include "base/memory/raw_ptr.h"
 #include "brave/components/password_manager/core/browser/import/csv_safari_password.h"
 

--- a/components/password_manager/core/browser/import/csv_safari_password_sequence.cc
+++ b/components/password_manager/core/browser/import/csv_safari_password_sequence.cc
@@ -10,6 +10,8 @@
 #include <string_view>
 #include <utility>
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "base/containers/fixed_flat_map.h"
 #include "base/containers/flat_set.h"
 #include "base/not_fatal_until.h"

--- a/components/password_manager/core/browser/import/safari_password_importer.cc
+++ b/components/password_manager/core/browser/import/safari_password_importer.cc
@@ -11,11 +11,14 @@
 #include <utility>
 
 #include "base/barrier_closure.h"
+#include "base/check.h"
+#include "base/check_op.h"
 #include "base/files/file_util.h"
 #include "base/functional/bind.h"
 #include "base/location.h"
 #include "base/metrics/histogram_functions.h"
 #include "base/metrics/histogram_macros.h"
+#include "base/notreached.h"
 #include "base/strings/string_util.h"
 #include "base/task/thread_pool.h"
 #include "base/types/expected.h"

--- a/components/password_manager/services/csv_password/public/mojom/csv_safari_password_parser_traits.cc
+++ b/components/password_manager/services/csv_password/public/mojom/csv_safari_password_parser_traits.cc
@@ -5,6 +5,8 @@
 
 #include "brave/components/password_manager/services/csv_password/public/mojom/csv_safari_password_parser_traits.h"
 
+#include "base/check.h"
+#include "base/notreached.h"
 #include "url/mojom/url_gurl_mojom_traits.h"
 
 namespace mojo {

--- a/components/permissions/contexts/brave_wallet_permission_context.cc
+++ b/components/permissions/contexts/brave_wallet_permission_context.cc
@@ -8,6 +8,7 @@
 #include <optional>
 #include <utility>
 
+#include "base/check.h"
 #include "base/strings/string_util.h"
 #include "brave/components/brave_wallet/browser/permission_utils.h"
 #include "brave/components/permissions/permission_lifetime_utils.h"

--- a/components/permissions/permission_expiration_key.cc
+++ b/components/permissions/permission_expiration_key.cc
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include "base/check.h"
 #include "base/strings/string_number_conversions.h"
 
 namespace permissions {

--- a/components/permissions/permission_lifetime_manager.cc
+++ b/components/permissions/permission_lifetime_manager.cc
@@ -9,6 +9,7 @@
 #include <utility>
 
 #include "base/auto_reset.h"
+#include "base/check.h"
 #include "base/containers/contains.h"
 #include "base/logging.h"
 #include "base/metrics/histogram_functions.h"

--- a/components/permissions/permission_lifetime_utils.cc
+++ b/components/permissions/permission_lifetime_utils.cc
@@ -10,7 +10,10 @@
 #include <string>
 #include <utility>
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "base/command_line.h"
+#include "base/logging.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/stringprintf.h"
 #include "base/strings/utf_string_conversions.h"

--- a/components/playlist/browser/media_detector_component_manager.cc
+++ b/components/playlist/browser/media_detector_component_manager.cc
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include "base/check.h"
 #include "base/containers/flat_set.h"
 #include "base/files/file_path.h"
 #include "base/files/file_util.h"

--- a/components/playlist/browser/playlist_background_web_contents_helper.cc
+++ b/components/playlist/browser/playlist_background_web_contents_helper.cc
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include "base/check.h"
 #include "base/logging.h"
 #include "brave/components/playlist/browser/playlist_service.h"
 #include "brave/components/playlist/common/mojom/playlist.mojom.h"

--- a/components/playlist/browser/playlist_background_web_contentses.cc
+++ b/components/playlist/browser/playlist_background_web_contentses.cc
@@ -8,6 +8,7 @@
 #include <string>
 #include <utility>
 
+#include "base/check.h"
 #include "base/containers/flat_set.h"
 #include "base/feature_list.h"
 #include "base/functional/bind.h"

--- a/components/playlist/browser/playlist_background_web_contentses.h
+++ b/components/playlist/browser/playlist_background_web_contentses.h
@@ -10,6 +10,7 @@
 #include <memory>
 #include <vector>
 
+#include "base/check.h"
 #include "base/containers/unique_ptr_adapters.h"
 #include "base/gtest_prod_util.h"
 #include "base/memory/weak_ptr.h"

--- a/components/playlist/browser/playlist_media_file_download_manager.cc
+++ b/components/playlist/browser/playlist_media_file_download_manager.cc
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include "base/check.h"
 #include "base/files/file_path.h"
 #include "base/logging.h"
 #include "base/task/sequenced_task_runner.h"

--- a/components/playlist/browser/playlist_media_file_downloader.cc
+++ b/components/playlist/browser/playlist_media_file_downloader.cc
@@ -9,8 +9,12 @@
 #include <string_view>
 #include <utility>
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "base/files/file_util.h"
 #include "base/functional/bind.h"
+#include "base/logging.h"
+#include "base/notreached.h"
 #include "base/task/thread_pool.h"
 #include "base/uuid.h"
 #include "brave/components/playlist/browser/mime_util.h"

--- a/components/playlist/browser/playlist_p3a.cc
+++ b/components/playlist/browser/playlist_p3a.cc
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include "base/check.h"
 #include "base/functional/bind.h"
 #include "base/location.h"
 #include "brave/components/p3a_utils/bucket.h"

--- a/components/playlist/browser/playlist_service.cc
+++ b/components/playlist/browser/playlist_service.cc
@@ -9,13 +9,17 @@
 #include <algorithm>
 #include <utility>
 
+#include "base/check.h"
 #include "base/check_is_test.h"
+#include "base/check_op.h"
 #include "base/containers/flat_set.h"
+#include "base/dcheck_is_on.h"
 #include "base/files/file_enumerator.h"
 #include "base/files/file_util.h"
 #include "base/functional/bind.h"
 #include "base/functional/callback_helpers.h"
 #include "base/json/values_util.h"
+#include "base/logging.h"
 #include "base/strings/strcat.h"
 #include "base/strings/string_split.h"
 #include "base/task/thread_pool.h"

--- a/components/playlist/browser/playlist_tab_helper.cc
+++ b/components/playlist/browser/playlist_tab_helper.cc
@@ -8,7 +8,10 @@
 #include <algorithm>
 #include <utility>
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "base/functional/bind.h"
+#include "base/logging.h"
 #include "base/strings/utf_string_conversions.h"
 #include "brave/components/playlist/browser/playlist_constants.h"
 #include "brave/components/playlist/browser/playlist_media_handler.h"

--- a/components/playlist/browser/playlist_thumbnail_downloader.cc
+++ b/components/playlist/browser/playlist_thumbnail_downloader.cc
@@ -7,7 +7,9 @@
 
 #include <utility>
 
+#include "base/check.h"
 #include "base/files/file_util.h"
+#include "base/logging.h"
 #include "base/task/thread_pool.h"
 #include "content/public/browser/browser_context.h"
 #include "content/public/browser/storage_partition.h"

--- a/components/playlist/browser/type_converter.cc
+++ b/components/playlist/browser/type_converter.cc
@@ -10,6 +10,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/check.h"
 #include "base/containers/contains.h"
 #include "base/json/values_util.h"
 #include "brave/components/playlist/browser/playlist_constants.h"

--- a/components/playlist/common/features.cc
+++ b/components/playlist/common/features.cc
@@ -5,7 +5,6 @@
 
 #include "brave/components/playlist/common/features.h"
 
-#include "base/dcheck_is_on.h"
 #include "base/feature_list.h"
 
 namespace playlist::features {

--- a/components/playlist/renderer/playlist_render_frame_observer.cc
+++ b/components/playlist/renderer/playlist_render_frame_observer.cc
@@ -7,8 +7,10 @@
 
 #include <utility>
 
+#include "base/check.h"
 #include "base/functional/bind.h"
 #include "base/functional/callback.h"
+#include "base/logging.h"
 #include "base/values.h"
 #include "brave/components/playlist/common/playlist_render_frame_observer_helper.h"
 #include "brave/gin/converter_specializations.h"


### PR DESCRIPTION
This change is one of many fixing inclusion for the following files:

 - `base/notimplemented.h`
 - `base/notreached.h`
 - `base/check.h`
 - `base/dcheck_is_on.h`
 - `base/check_deref.h`
 - `base/check_op.h`
 - `base/logging/log_severity.h`
 - `base/logging.h`

This change is a mechanical change done with the following script:
https://github.com/brave/brave-browser/issues/46707#issuecomment-2960116515

Resolves https://github.com/brave/brave-browser/issues/46707
