### PR TITLE
[IWYU] Fixing logging inclusions `//browser/ui/views`

### DIFF
--- a/browser/ui/views/bookmarks/brave_bookmark_context_menu.cc
+++ b/browser/ui/views/bookmarks/brave_bookmark_context_menu.cc
@@ -7,6 +7,7 @@
 
 #include <vector>
 
+#include "base/check.h"
 #include "brave/browser/ui/toolbar/brave_bookmark_context_menu_controller.h"
 #include "chrome/app/chrome_command_ids.h"
 #include "chrome/browser/ui/views/bookmarks/bookmark_context_menu.h"

--- a/browser/ui/views/brave_first_run_dialog.cc
+++ b/browser/ui/views/brave_first_run_dialog.cc
@@ -8,6 +8,7 @@
 #include <memory>
 #include <utility>
 
+#include "base/check.h"
 #include "base/functional/bind.h"
 #include "base/memory/scoped_refptr.h"
 #include "base/run_loop.h"

--- a/browser/ui/views/brave_help_bubble/brave_help_bubble_delegate_view.cc
+++ b/browser/ui/views/brave_help_bubble/brave_help_bubble_delegate_view.cc
@@ -8,6 +8,7 @@
 #include <array>
 #include <utility>
 
+#include "base/check.h"
 #include "base/strings/utf_string_conversions.h"
 #include "components/grit/brave_components_strings.h"
 #include "ui/base/l10n/l10n_util.h"

--- a/browser/ui/views/brave_help_bubble/brave_help_bubble_host_view.cc
+++ b/browser/ui/views/brave_help_bubble/brave_help_bubble_host_view.cc
@@ -5,6 +5,7 @@
 
 #include "brave/browser/ui/views/brave_help_bubble/brave_help_bubble_host_view.h"
 
+#include "base/check.h"
 #include "cc/paint/paint_shader.h"
 #include "extensions/common/constants.h"
 #include "third_party/skia/include/core/SkColor.h"

--- a/browser/ui/views/brave_javascript_tab_modal_dialog_view_views.cc
+++ b/browser/ui/views/brave_javascript_tab_modal_dialog_view_views.cc
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include "base/check.h"
 #include "base/functional/bind.h"
 #include "base/types/to_address.h"
 #include "brave/browser/ui/tabs/split_view_browser_data.h"

--- a/browser/ui/views/brave_news/brave_news_action_icon_view.cc
+++ b/browser/ui/views/brave_news/brave_news_action_icon_view.cc
@@ -9,6 +9,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/check.h"
 #include "base/functional/bind.h"
 #include "base/functional/callback_forward.h"
 #include "brave/browser/brave_news/brave_news_tab_helper.h"

--- a/browser/ui/views/brave_news/brave_news_bubble_controller.cc
+++ b/browser/ui/views/brave_news/brave_news_bubble_controller.cc
@@ -7,6 +7,7 @@
 
 #include <vector>
 
+#include "base/check.h"
 #include "base/memory/ptr_util.h"
 #include "brave/browser/ui/views/brave_news/brave_news_action_icon_view.h"
 #include "brave/browser/ui/views/brave_news/brave_news_bubble_view.h"

--- a/browser/ui/views/brave_news/brave_news_bubble_view.cc
+++ b/browser/ui/views/brave_news/brave_news_bubble_view.cc
@@ -8,6 +8,7 @@
 #include <memory>
 #include <vector>
 
+#include "base/check.h"
 #include "base/memory/weak_ptr.h"
 #include "base/scoped_observation.h"
 #include "base/strings/utf_string_conversions.h"

--- a/browser/ui/views/brave_news/brave_news_feed_item_view.cc
+++ b/browser/ui/views/brave_news/brave_news_feed_item_view.cc
@@ -8,6 +8,7 @@
 #include <memory>
 #include <vector>
 
+#include "base/check.h"
 #include "base/strings/utf_string_conversions.h"
 #include "brave/components/vector_icons/vector_icons.h"
 #include "components/grit/brave_components_strings.h"

--- a/browser/ui/views/brave_player/brave_player_action_icon_view.cc
+++ b/browser/ui/views/brave_player/brave_player_action_icon_view.cc
@@ -8,6 +8,8 @@
 #include <memory>
 #include <string>
 
+#include "base/check.h"
+#include "base/notreached.h"
 #include "base/strings/strcat.h"
 #include "brave/browser/ui/color/brave_color_id.h"
 #include "brave/components/brave_player/common/buildflags/buildflags.h"

--- a/browser/ui/views/brave_shields/cookie_list_opt_in_bubble_host.cc
+++ b/browser/ui/views/brave_shields/cookie_list_opt_in_bubble_host.cc
@@ -8,6 +8,7 @@
 #include <memory>
 #include <optional>
 
+#include "base/check.h"
 #include "base/feature_list.h"
 #include "base/metrics/histogram_functions.h"
 #include "brave/browser/brave_browser_process.h"

--- a/browser/ui/views/brave_tab_search_bubble_host.cc
+++ b/browser/ui/views/brave_tab_search_bubble_host.cc
@@ -5,6 +5,8 @@
 
 #include "brave/browser/ui/views/brave_tab_search_bubble_host.h"
 
+#include "base/check.h"
+#include "base/dcheck_is_on.h"
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 #include "chrome/browser/ui/layout_constants.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"

--- a/browser/ui/views/brave_tooltips/brave_tooltip_popup.cc
+++ b/browser/ui/views/brave_tooltips/brave_tooltip_popup.cc
@@ -8,6 +8,7 @@
 #include <map>
 #include <utility>
 
+#include "base/check.h"
 #include "base/time/time.h"
 #include "brave/browser/ui/brave_tooltips/bounds_util.h"
 #include "brave/grit/brave_generated_resources.h"

--- a/browser/ui/views/brave_tooltips/brave_tooltip_popup_handler.cc
+++ b/browser/ui/views/brave_tooltips/brave_tooltip_popup_handler.cc
@@ -8,6 +8,7 @@
 #include <map>
 #include <string>
 
+#include "base/check.h"
 #include "brave/browser/ui/brave_tooltips/brave_tooltip.h"
 #include "brave/browser/ui/views/brave_tooltips/brave_tooltip_popup.h"
 

--- a/browser/ui/views/brave_tooltips/brave_tooltip_view.cc
+++ b/browser/ui/views/brave_tooltips/brave_tooltip_view.cc
@@ -8,6 +8,7 @@
 #include <memory>
 #include <string>
 
+#include "base/check.h"
 #include "brave/app/vector_icons/vector_icons.h"
 #include "brave/browser/ui/brave_tooltips/bounds_util.h"
 #include "brave/browser/ui/views/brave_tooltips/brave_tooltip_popup.h"

--- a/browser/ui/views/commands/default_accelerators_mac.mm
+++ b/browser/ui/views/commands/default_accelerators_mac.mm
@@ -6,9 +6,11 @@
 #include "brave/browser/ui/views/commands/default_accelerators_mac.h"
 
 #import <Cocoa/Cocoa.h>
+
 #include <optional>
 
 #include "base/check.h"
+#include "base/check_op.h"
 #include "base/containers/contains.h"
 #include "base/containers/flat_map.h"
 #include "base/logging.h"

--- a/browser/ui/views/dialog_footnote_utils.cc
+++ b/browser/ui/views/dialog_footnote_utils.cc
@@ -7,6 +7,8 @@
 
 #include <utility>
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "base/functional/bind.h"
 #include "base/strings/string_util.h"
 #include "chrome/browser/ui/browser.h"

--- a/browser/ui/views/extensions/brave_extension_menu_item_view.cc
+++ b/browser/ui/views/extensions/brave_extension_menu_item_view.cc
@@ -8,6 +8,7 @@
 #include <string>
 #include <utility>
 
+#include "base/check.h"
 #include "brave/browser/ui/color/brave_color_id.h"
 #include "brave/components/vector_icons/vector_icons.h"
 #include "chrome/browser/ui/toolbar/toolbar_action_view_controller.h"

--- a/browser/ui/views/extensions/brave_extensions_menu_main_page_view.cc
+++ b/browser/ui/views/extensions/brave_extensions_menu_main_page_view.cc
@@ -5,6 +5,8 @@
 
 #include "brave/browser/ui/views/extensions/brave_extensions_menu_main_page_view.h"
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "brave/browser/ui/color/brave_color_id.h"
 #include "brave/components/vector_icons/vector_icons.h"
 #include "chrome/browser/ui/browser.h"

--- a/browser/ui/views/frame/brave_browser_frame_view_linux_native.cc
+++ b/browser/ui/views/frame/brave_browser_frame_view_linux_native.cc
@@ -8,6 +8,8 @@
 #include <numeric>
 #include <string>
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "base/notreached.h"
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 #include "brave/browser/ui/views/toolbar/brave_toolbar_view.h"

--- a/browser/ui/views/frame/brave_browser_frame_view_win.cc
+++ b/browser/ui/views/frame/brave_browser_frame_view_win.cc
@@ -5,6 +5,7 @@
 
 #include "brave/browser/ui/views/frame/brave_browser_frame_view_win.h"
 
+#include "base/check.h"
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
 #include "brave/browser/ui/views/frame/brave_non_client_hit_test_helper.h"
 #include "brave/browser/ui/views/frame/brave_window_frame_graphic.h"

--- a/browser/ui/views/frame/brave_browser_view.cc
+++ b/browser/ui/views/frame/brave_browser_view.cc
@@ -12,6 +12,7 @@
 #include <optional>
 #include <vector>
 
+#include "base/check.h"
 #include "base/containers/contains.h"
 #include "base/feature_list.h"
 #include "base/functional/bind.h"

--- a/browser/ui/views/frame/brave_browser_view_layout.cc
+++ b/browser/ui/views/frame/brave_browser_view_layout.cc
@@ -9,6 +9,7 @@
 #include <limits>
 #include <utility>
 
+#include "base/check.h"
 #include "brave/browser/ui/brave_browser.h"
 #include "brave/browser/ui/views/frame/brave_contents_view_util.h"
 #include "brave/browser/ui/views/sidebar/sidebar_container_view.h"

--- a/browser/ui/views/frame/brave_contents_layout_manager.cc
+++ b/browser/ui/views/frame/brave_contents_layout_manager.cc
@@ -5,6 +5,7 @@
 
 #include "brave/browser/ui/views/frame/brave_contents_layout_manager.h"
 
+#include "base/check.h"
 #include "ui/views/view.h"
 
 // static

--- a/browser/ui/views/frame/brave_contents_view_util.cc
+++ b/browser/ui/views/frame/brave_contents_view_util.cc
@@ -5,6 +5,7 @@
 
 #include "brave/browser/ui/views/frame/brave_contents_view_util.h"
 
+#include "base/check.h"
 #include "brave/browser/ui/brave_browser.h"
 #include "chrome/browser/ui/browser.h"
 #include "ui/compositor/layer.h"

--- a/browser/ui/views/frame/brave_non_client_hit_test_helper.cc
+++ b/browser/ui/views/frame/brave_non_client_hit_test_helper.cc
@@ -5,6 +5,7 @@
 
 #include "brave/browser/ui/views/frame/brave_non_client_hit_test_helper.h"
 
+#include "base/check_op.h"
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
 #include "chrome/browser/ui/views/toolbar/toolbar_view.h"

--- a/browser/ui/views/frame/brave_opaque_browser_frame_view.cc
+++ b/browser/ui/views/frame/brave_opaque_browser_frame_view.cc
@@ -7,6 +7,7 @@
 
 #include <memory>
 
+#include "base/check.h"
 #include "brave/browser/ui/views/frame/brave_non_client_hit_test_helper.h"
 #include "brave/browser/ui/views/frame/brave_window_frame_graphic.h"
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"

--- a/browser/ui/views/frame/brave_system_menu_model_builder_browsertest.cc
+++ b/browser/ui/views/frame/brave_system_menu_model_builder_browsertest.cc
@@ -3,6 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include "base/check.h"
 #include "brave/app/brave_command_ids.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
 #include "chrome/test/base/in_process_browser_test.h"

--- a/browser/ui/views/frame/split_view/brave_multi_contents_view.cc
+++ b/browser/ui/views/frame/split_view/brave_multi_contents_view.cc
@@ -5,6 +5,7 @@
 
 #include "brave/browser/ui/views/frame/split_view/brave_multi_contents_view.h"
 
+#include "base/check.h"
 #include "brave/browser/ui/brave_browser.h"
 #include "brave/browser/ui/color/brave_color_id.h"
 #include "brave/browser/ui/views/frame/brave_contents_view_util.h"

--- a/browser/ui/views/frame/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.cc
@@ -11,6 +11,9 @@
 #include <utility>
 #include <vector>
 
+#include "base/check.h"
+#include "base/check_op.h"
+#include "base/dcheck_is_on.h"
 #include "base/functional/bind.h"
 #include "base/strings/string_split.h"
 #include "brave/app/vector_icons/vector_icons.h"

--- a/browser/ui/views/frame/vertical_tab_strip_region_view_mac.mm
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view_mac.mm
@@ -7,6 +7,7 @@
 
 #import <Cocoa/Cocoa.h>
 
+#include "base/check.h"
 #include "chrome/app/chrome_command_ids.h"
 
 static_assert(__OBJC__);

--- a/browser/ui/views/frame/vertical_tab_strip_root_view.cc
+++ b/browser/ui/views/frame/vertical_tab_strip_root_view.cc
@@ -5,6 +5,7 @@
 
 #include "brave/browser/ui/views/frame/vertical_tab_strip_root_view.h"
 
+#include "base/check.h"
 #include "chrome/browser/ui/views/frame/browser_root_view.h"
 #include "ui/base/metadata/metadata_impl_macros.h"
 #include "ui/views/view_utils.h"

--- a/browser/ui/views/infobars/brave_confirm_infobar.cc
+++ b/browser/ui/views/infobars/brave_confirm_infobar.cc
@@ -9,6 +9,7 @@
 #include <utility>
 
 #include "base/functional/bind.h"
+#include "base/notreached.h"
 #include "build/build_config.h"
 #include "chrome/browser/ui/views/chrome_layout_provider.h"
 #include "ui/base/metadata/metadata_impl_macros.h"

--- a/browser/ui/views/infobars/brave_infobar_container_view.cc
+++ b/browser/ui/views/infobars/brave_infobar_container_view.cc
@@ -7,6 +7,7 @@
 
 #include <memory>
 
+#include "base/check.h"
 #include "ui/base/metadata/metadata_impl_macros.h"
 
 BraveInfoBarContainerView::BraveInfoBarContainerView(

--- a/browser/ui/views/infobars/brave_sync_account_deleted_infobar.cc
+++ b/browser/ui/views/infobars/brave_sync_account_deleted_infobar.cc
@@ -9,6 +9,7 @@
 #include <memory>
 #include <utility>
 
+#include "base/check.h"
 #include "build/build_config.h"
 #include "chrome/browser/ui/views/chrome_layout_provider.h"
 #include "ui/views/controls/button/md_text_button.h"

--- a/browser/ui/views/location_bar/brave_location_bar_view.cc
+++ b/browser/ui/views/location_bar/brave_location_bar_view.cc
@@ -8,6 +8,7 @@
 #include <optional>
 #include <utility>
 
+#include "base/check.h"
 #include "base/containers/contains.h"
 #include "base/feature_list.h"
 #include "brave/app/vector_icons/vector_icons.h"

--- a/browser/ui/views/location_bar/brave_search_conversion/promotion_button_controller.cc
+++ b/browser/ui/views/location_bar/brave_search_conversion/promotion_button_controller.cc
@@ -5,6 +5,7 @@
 
 #include "brave/browser/ui/views/location_bar/brave_search_conversion/promotion_button_controller.h"
 
+#include "base/check.h"
 #include "base/functional/bind.h"
 #include "brave/browser/ui/views/location_bar/brave_search_conversion/promotion_button_view.h"
 #include "brave/components/brave_search_conversion/features.h"

--- a/browser/ui/views/obsolete_system_confirm_dialog_view.cc
+++ b/browser/ui/views/obsolete_system_confirm_dialog_view.cc
@@ -9,7 +9,6 @@
 #include <utility>
 
 #include "base/functional/callback.h"
-#include "base/notreached.h"
 #include "brave/grit/brave_generated_resources.h"
 #include "build/build_config.h"
 #include "chrome/browser/ui/browser.h"

--- a/browser/ui/views/overlay/brave_video_overlay_window_views.cc
+++ b/browser/ui/views/overlay/brave_video_overlay_window_views.cc
@@ -9,6 +9,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/check.h"
 #include "base/strings/strcat.h"
 #include "base/strings/stringprintf.h"
 #include "base/strings/utf_string_conversions.h"

--- a/browser/ui/views/page_action/wayback_machine_state_manager.cc
+++ b/browser/ui/views/page_action/wayback_machine_state_manager.cc
@@ -7,6 +7,7 @@
 
 #include <optional>
 
+#include "base/check.h"
 #include "base/functional/bind.h"
 #include "brave/browser/ui/views/page_action/wayback_machine_action_icon_view.h"
 #include "brave/components/brave_wayback_machine/brave_wayback_machine_tab_helper.h"

--- a/browser/ui/views/permission_bubble/brave_wallet_permission_prompt_impl.cc
+++ b/browser/ui/views/permission_bubble/brave_wallet_permission_prompt_impl.cc
@@ -7,6 +7,7 @@
 
 #include <optional>
 
+#include "base/check.h"
 #include "brave/browser/brave_wallet/brave_wallet_tab_helper.h"
 #include "components/permissions/permission_uma_util.h"
 

--- a/browser/ui/views/profiles/brave_avatar_toolbar_button.cc
+++ b/browser/ui/views/profiles/brave_avatar_toolbar_button.cc
@@ -10,6 +10,7 @@
 #include <string>
 #include <utility>
 
+#include "base/check.h"
 #include "base/strings/string_number_conversions.h"
 #include "brave/app/vector_icons/vector_icons.h"
 #include "brave/browser/ui/color/color_palette.h"

--- a/browser/ui/views/profiles/brave_incognito_menu_view.cc
+++ b/browser/ui/views/profiles/brave_incognito_menu_view.cc
@@ -9,6 +9,7 @@
 #include <optional>
 #include <utility>
 
+#include "base/check.h"
 #include "brave/components/tor/buildflags/buildflags.h"
 #include "brave/grit/brave_generated_resources.h"
 #include "chrome/app/vector_icons/vector_icons.h"

--- a/browser/ui/views/profiles/brave_profile_menu_view_browsertest.cc
+++ b/browser/ui/views/profiles/brave_profile_menu_view_browsertest.cc
@@ -3,6 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include "base/logging.h"
 #include "build/build_config.h"
 #include "chrome/browser/browser_process.h"
 #include "chrome/browser/profiles/profile.h"

--- a/browser/ui/views/sidebar/sidebar_add_item_bubble_delegate_view.cc
+++ b/browser/ui/views/sidebar/sidebar_add_item_bubble_delegate_view.cc
@@ -8,6 +8,7 @@
 #include <memory>
 #include <utility>
 
+#include "base/check.h"
 #include "base/memory/raw_ptr.h"
 #include "base/strings/utf_string_conversions.h"
 #include "brave/browser/ui/brave_browser.h"

--- a/browser/ui/views/sidebar/sidebar_container_view.cc
+++ b/browser/ui/views/sidebar/sidebar_container_view.cc
@@ -10,7 +10,9 @@
 #include <optional>
 #include <utility>
 
+#include "base/check.h"
 #include "base/functional/bind.h"
+#include "base/logging.h"
 #include "base/time/time.h"
 #include "brave/browser/ui/brave_browser.h"
 #include "brave/browser/ui/color/brave_color_id.h"

--- a/browser/ui/views/sidebar/sidebar_control_view.cc
+++ b/browser/ui/views/sidebar/sidebar_control_view.cc
@@ -5,6 +5,7 @@
 
 #include "brave/browser/ui/views/sidebar/sidebar_control_view.h"
 
+#include "base/check.h"
 #include "brave/app/brave_command_ids.h"
 #include "brave/browser/ui/brave_browser.h"
 #include "brave/browser/ui/color/brave_color_id.h"

--- a/browser/ui/views/sidebar/sidebar_edit_item_bubble_delegate_view.cc
+++ b/browser/ui/views/sidebar/sidebar_edit_item_bubble_delegate_view.cc
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include "base/check.h"
 #include "base/functional/bind.h"
 #include "base/strings/utf_string_conversions.h"
 #include "brave/browser/ui/brave_browser.h"

--- a/browser/ui/views/sidebar/sidebar_item_view.cc
+++ b/browser/ui/views/sidebar/sidebar_item_view.cc
@@ -5,6 +5,7 @@
 
 #include "brave/browser/ui/views/sidebar/sidebar_item_view.h"
 
+#include "base/check.h"
 #include "brave/browser/ui/color/brave_color_id.h"
 #include "brave/grit/brave_theme_resources.h"
 #include "chrome/browser/ui/views/event_utils.h"

--- a/browser/ui/views/sidebar/sidebar_items_contents_view.cc
+++ b/browser/ui/views/sidebar/sidebar_items_contents_view.cc
@@ -8,7 +8,9 @@
 #include <optional>
 #include <string>
 
+#include "base/check.h"
 #include "base/check_is_test.h"
+#include "base/check_op.h"
 #include "base/functional/bind.h"
 #include "base/functional/callback.h"
 #include "base/i18n/case_conversion.h"

--- a/browser/ui/views/sidebar/sidebar_items_scroll_view.cc
+++ b/browser/ui/views/sidebar/sidebar_items_scroll_view.cc
@@ -8,6 +8,7 @@
 #include <optional>
 #include <string>
 
+#include "base/check.h"
 #include "base/functional/bind.h"
 #include "base/time/time.h"
 #include "brave/app/vector_icons/vector_icons.h"

--- a/browser/ui/views/sidebar/sidebar_show_options_event_detect_widget.cc
+++ b/browser/ui/views/sidebar/sidebar_show_options_event_detect_widget.cc
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include "base/check.h"
 #include "base/memory/raw_ref.h"
 #include "brave/app/vector_icons/vector_icons.h"
 #include "brave/browser/ui/views/frame/brave_browser_view.h"

--- a/browser/ui/views/speedreader/reader_mode_bubble.cc
+++ b/browser/ui/views/speedreader/reader_mode_bubble.cc
@@ -9,6 +9,8 @@
 #include <string>
 #include <utility>
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "brave/browser/speedreader/speedreader_service_factory.h"
 #include "brave/browser/speedreader/speedreader_tab_helper.h"
 #include "brave/components/speedreader/speedreader_service.h"

--- a/browser/ui/views/speedreader/reader_mode_toolbar_view.cc
+++ b/browser/ui/views/speedreader/reader_mode_toolbar_view.cc
@@ -7,6 +7,7 @@
 
 #include <memory>
 
+#include "base/check_op.h"
 #include "base/memory/raw_ptr.h"
 #include "brave/browser/ui/brave_browser.h"
 #include "brave/browser/ui/views/frame/brave_contents_view_util.h"

--- a/browser/ui/views/split_view/split_view.cc
+++ b/browser/ui/views/split_view/split_view.cc
@@ -7,6 +7,8 @@
 
 #include <utility>
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "base/types/to_address.h"
 #include "brave/browser/ui/brave_browser.h"
 #include "brave/browser/ui/color/brave_color_id.h"

--- a/browser/ui/views/split_view/split_view_layout_manager.cc
+++ b/browser/ui/views/split_view/split_view_layout_manager.cc
@@ -5,6 +5,7 @@
 
 #include "brave/browser/ui/views/split_view/split_view_layout_manager.h"
 
+#include "base/check.h"
 #include "base/feature_list.h"
 #include "brave/browser/ui/tabs/features.h"
 #include "brave/browser/ui/views/split_view/split_view_separator.h"

--- a/browser/ui/views/split_view/split_view_location_bar.cc
+++ b/browser/ui/views/split_view/split_view_location_bar.cc
@@ -10,6 +10,7 @@
 #include <optional>
 #include <utility>
 
+#include "base/check.h"
 #include "base/check_is_test.h"
 #include "base/functional/bind.h"
 #include "brave/browser/ui/color/brave_color_id.h"

--- a/browser/ui/views/split_view/split_view_separator.cc
+++ b/browser/ui/views/split_view/split_view_separator.cc
@@ -8,6 +8,7 @@
 #include <memory>
 #include <utility>
 
+#include "base/check.h"
 #include "base/functional/bind.h"
 #include "base/time/time.h"
 #include "brave/browser/ui/color/brave_color_id.h"

--- a/browser/ui/views/tabs/brave_compound_tab_container.cc
+++ b/browser/ui/views/tabs/brave_compound_tab_container.cc
@@ -11,6 +11,8 @@
 #include <utility>
 #include <vector>
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "brave/browser/ui/color/brave_color_id.h"
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
 #include "brave/browser/ui/tabs/features.h"

--- a/browser/ui/views/tabs/brave_tab.cc
+++ b/browser/ui/views/tabs/brave_tab.cc
@@ -9,6 +9,7 @@
 #include <optional>
 #include <utility>
 
+#include "base/check.h"
 #include "brave/browser/ui/tabs/brave_tab_layout_constants.h"
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
 #include "brave/browser/ui/tabs/features.h"

--- a/browser/ui/views/tabs/brave_tab_container.cc
+++ b/browser/ui/views/tabs/brave_tab_container.cc
@@ -10,7 +10,9 @@
 #include <optional>
 #include <utility>
 
+#include "base/check.h"
 #include "base/check_is_test.h"
+#include "base/check_op.h"
 #include "base/containers/flat_map.h"
 #include "base/feature_list.h"
 #include "brave/browser/ui/color/brave_color_id.h"

--- a/browser/ui/views/tabs/brave_tab_context_menu_contents.cc
+++ b/browser/ui/views/tabs/brave_tab_context_menu_contents.cc
@@ -12,8 +12,8 @@
 #include <utility>
 #include <vector>
 
+#include "base/check.h"
 #include "base/functional/bind.h"
-#include "base/notimplemented.h"
 #include "base/notreached.h"
 #include "brave/browser/ui/browser_commands.h"
 #include "brave/browser/ui/tabs/brave_tab_menu_model.h"

--- a/browser/ui/views/tabs/brave_tab_group_header.cc
+++ b/browser/ui/views/tabs/brave_tab_group_header.cc
@@ -7,6 +7,7 @@
 
 #include <optional>
 
+#include "base/check.h"
 #include "brave/browser/ui/color/brave_color_id.h"
 #include "brave/browser/ui/tabs/brave_tab_layout_constants.h"
 #include "brave/browser/ui/tabs/features.h"

--- a/browser/ui/views/tabs/brave_tab_strip.cc
+++ b/browser/ui/views/tabs/brave_tab_strip.cc
@@ -10,6 +10,8 @@
 #include <utility>
 #include <vector>
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "brave/browser/themes/brave_dark_mode_utils.h"
 #include "brave/browser/ui/color/brave_color_id.h"
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"

--- a/browser/ui/views/tabs/brave_tab_strip_layout_helper.cc
+++ b/browser/ui/views/tabs/brave_tab_strip_layout_helper.cc
@@ -8,6 +8,8 @@
 #include <limits>
 #include <optional>
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "brave/browser/ui/tabs/brave_tab_layout_constants.h"
 #include "brave/browser/ui/tabs/features.h"
 #include "brave/browser/ui/views/tabs/brave_tab_group_header.h"

--- a/browser/ui/views/tabs/brave_tab_style_views.inc.cc
+++ b/browser/ui/views/tabs/brave_tab_style_views.inc.cc
@@ -6,6 +6,9 @@
 // This file must be included inside tab_style_views.cc as classes here are
 // depending on what's defined in anonymous namespace of tab_style_views.cc
 
+#include "base/check.h"
+#include "base/dcheck_is_on.h"
+#include "base/logging.h"
 #include "brave/browser/ui/tabs/split_view_browser_data.h"
 #include "brave/ui/color/nala/nala_color_id.h"
 #include "chrome/browser/ui/browser_window/public/browser_window_features.h"

--- a/browser/ui/views/tabs/dragging/dragging_tabs_session.cc
+++ b/browser/ui/views/tabs/dragging/dragging_tabs_session.cc
@@ -5,6 +5,7 @@
 
 #include "brave/browser/ui/views/tabs/dragging/dragging_tabs_session.h"
 
+#include "base/check.h"
 #include "chrome/browser/ui/views/tabs/dragging/drag_session_data.h"
 #include "chrome/browser/ui/views/tabs/dragging/tab_drag_context.h"
 #include "ui/gfx/geometry/point.h"

--- a/browser/ui/views/tabs/dragging/tab_drag_controller.cc
+++ b/browser/ui/views/tabs/dragging/tab_drag_controller.cc
@@ -10,6 +10,8 @@
 #include <set>
 #include <utility>
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "base/feature_list.h"
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
 #include "brave/browser/ui/tabs/features.h"

--- a/browser/ui/views/tabs/shared_pinned_tab_dummy_view_views.cc
+++ b/browser/ui/views/tabs/shared_pinned_tab_dummy_view_views.cc
@@ -7,6 +7,7 @@
 
 #include <memory>
 
+#include "base/check.h"
 #include "base/functional/bind.h"
 #include "brave/browser/ui/color/brave_color_id.h"
 #include "brave/browser/ui/tabs/shared_pinned_tab_dummy_view.h"

--- a/browser/ui/views/tabs/vertical_tab_strip_browsertest.cc
+++ b/browser/ui/views/tabs/vertical_tab_strip_browsertest.cc
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 
+#include "base/logging.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/test/bind.h"
 #include "base/test/run_until.h"

--- a/browser/ui/views/tabs/vertical_tab_utils.cc
+++ b/browser/ui/views/tabs/vertical_tab_utils.cc
@@ -5,6 +5,7 @@
 
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 
+#include "base/check.h"
 #include "base/check_is_test.h"
 #include "base/command_line.h"
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"

--- a/browser/ui/views/text_recognition_dialog_tracker.cc
+++ b/browser/ui/views/text_recognition_dialog_tracker.cc
@@ -5,6 +5,9 @@
 
 #include "brave/browser/ui/views/text_recognition_dialog_tracker.h"
 
+#include "base/check.h"
+#include "base/check_op.h"
+
 TextRecognitionDialogTracker::TextRecognitionDialogTracker(
     content::WebContents* web_contents)
     : content::WebContentsUserData<TextRecognitionDialogTracker>(

--- a/browser/ui/views/text_recognition_dialog_view.cc
+++ b/browser/ui/views/text_recognition_dialog_view.cc
@@ -9,6 +9,7 @@
 #include <optional>
 #include <utility>
 
+#include "base/check.h"
 #include "base/functional/bind.h"
 #include "base/strings/string_util.h"
 #include "base/strings/utf_string_conversions.h"

--- a/browser/ui/views/toolbar/brave_app_menu.cc
+++ b/browser/ui/views/toolbar/brave_app_menu.cc
@@ -7,9 +7,12 @@
 
 #include <memory>
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "base/debug/crash_logging.h"
 #include "base/debug/dump_without_crashing.h"
 #include "base/functional/bind.h"
+#include "base/logging.h"
 #include "base/scoped_observation.h"
 #include "brave/app/brave_command_ids.h"
 #include "brave/browser/brave_browser_process.h"

--- a/browser/ui/views/toolbar/brave_toolbar_view.cc
+++ b/browser/ui/views/toolbar/brave_toolbar_view.cc
@@ -9,6 +9,8 @@
 #include <memory>
 #include <utility>
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "base/functional/bind.h"
 #include "brave/app/brave_command_ids.h"
 #include "brave/browser/ai_chat/ai_chat_utils.h"

--- a/browser/ui/views/toolbar/brave_toolbar_view_browsertest.cc
+++ b/browser/ui/views/toolbar/brave_toolbar_view_browsertest.cc
@@ -5,6 +5,7 @@
 
 #include "brave/browser/ui/views/toolbar/brave_toolbar_view.h"
 
+#include "base/check.h"
 #include "base/functional/callback_helpers.h"
 #include "base/memory/raw_ptr.h"
 #include "base/test/scoped_feature_list.h"

--- a/browser/ui/views/toolbar/brave_vpn_button.cc
+++ b/browser/ui/views/toolbar/brave_vpn_button.cc
@@ -8,8 +8,8 @@
 #include <optional>
 #include <utility>
 
+#include "base/check.h"
 #include "base/memory/raw_ptr.h"
-#include "base/notreached.h"
 #include "brave/app/brave_command_ids.h"
 #include "brave/app/vector_icons/vector_icons.h"
 #include "brave/browser/brave_vpn/brave_vpn_service_factory.h"

--- a/browser/ui/views/toolbar/brave_vpn_panel_controller.cc
+++ b/browser/ui/views/toolbar/brave_vpn_panel_controller.cc
@@ -7,6 +7,7 @@
 
 #include <string>
 
+#include "base/check.h"
 #include "brave/browser/ui/views/frame/brave_browser_view.h"
 #include "brave/components/constants/webui_url_constants.h"
 #include "chrome/browser/profiles/profile.h"

--- a/browser/ui/views/toolbar/brave_vpn_status_label.cc
+++ b/browser/ui/views/toolbar/brave_vpn_status_label.cc
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include "base/check.h"
 #include "brave/browser/brave_vpn/brave_vpn_service_factory.h"
 #include "brave/browser/ui/color/brave_color_id.h"
 #include "brave/components/brave_vpn/browser/brave_vpn_service.h"

--- a/browser/ui/views/toolbar/brave_vpn_toggle_button.cc
+++ b/browser/ui/views/toolbar/brave_vpn_toggle_button.cc
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include "base/check.h"
 #include "base/functional/bind.h"
 #include "brave/browser/brave_vpn/brave_vpn_service_factory.h"
 #include "brave/components/brave_vpn/browser/brave_vpn_service.h"

--- a/browser/ui/views/toolbar/wallet_button.cc
+++ b/browser/ui/views/toolbar/wallet_button.cc
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <utility>
 
+#include "base/check.h"
 #include "base/strings/string_number_conversions.h"
 #include "brave/browser/brave_wallet/brave_wallet_tab_helper.h"
 #include "brave/browser/ui/brave_icon_with_badge_image_source.h"

--- a/browser/ui/views/view_shadow.cc
+++ b/browser/ui/views/view_shadow.cc
@@ -9,6 +9,8 @@
 #include <memory>
 #include <tuple>
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "ui/compositor/layer.h"
 #include "ui/compositor/paint_recorder.h"
 #include "ui/gfx/skia_paint_util.h"

--- a/browser/ui/views/wallet_bubble_focus_observer.cc
+++ b/browser/ui/views/wallet_bubble_focus_observer.cc
@@ -5,6 +5,7 @@
 
 #include "brave/browser/ui/views/wallet_bubble_focus_observer.h"
 
+#include "base/check.h"
 #include "chrome/browser/ui/views/bubble/webui_bubble_dialog_view.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
 #include "ui/views/controls/webview/webview.h"

--- a/browser/ui/views/wayback_machine_bubble_view.cc
+++ b/browser/ui/views/wayback_machine_bubble_view.cc
@@ -10,6 +10,7 @@
 #include <string>
 #include <utility>
 
+#include "base/check.h"
 #include "base/functional/bind.h"
 #include "brave/browser/ui/views/page_action/wayback_machine_action_icon_view.h"
 #include "brave/components/brave_wayback_machine/brave_wayback_machine_tab_helper.h"

--- a/chromium_src/chrome/browser/ui/autofill/autofill_context_menu_manager.cc
+++ b/chromium_src/chrome/browser/ui/autofill/autofill_context_menu_manager.cc
@@ -5,6 +5,8 @@
 
 #include "chrome/browser/ui/autofill/autofill_context_menu_manager.h"
 
+#include "base/check_op.h"
+
 #define AppendItems AppendItems_ChromiumImpl
 #include "src/chrome/browser/ui/autofill/autofill_context_menu_manager.cc"
 #undef AppendItems

--- a/chromium_src/chrome/browser/ui/browser_commands.cc
+++ b/chromium_src/chrome/browser/ui/browser_commands.cc
@@ -5,6 +5,7 @@
 
 #include "brave/browser/ui/browser_commands.h"
 
+#include "base/check.h"
 #include "brave/components/commander/common/buildflags/buildflags.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser_commands.h"

--- a/chromium_src/chrome/browser/ui/startup/infobar_utils.cc
+++ b/chromium_src/chrome/browser/ui/startup/infobar_utils.cc
@@ -3,6 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include "base/check.h"
 #include "brave/browser/infobars/dev_channel_deprecation_infobar_delegate.h"
 #include "brave/browser/ui/startup/brave_obsolete_system_infobar_delegate.h"
 #include "build/build_config.h"

--- a/chromium_src/chrome/browser/ui/startup/startup_browser_creator.cc
+++ b/chromium_src/chrome/browser/ui/startup/startup_browser_creator.cc
@@ -4,6 +4,8 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "chrome/browser/ui/startup/startup_browser_creator.h"
+
+#include "base/logging.h"
 #include "brave/components/constants/brave_switches.h"
 #include "brave/components/tor/buildflags/buildflags.h"
 #include "chrome/browser/ui/startup/startup_browser_creator_impl.h"

--- a/chromium_src/chrome/browser/ui/tabs/recent_tabs_sub_menu_model.cc
+++ b/chromium_src/chrome/browser/ui/tabs/recent_tabs_sub_menu_model.cc
@@ -3,6 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include "base/check.h"
 #include "chrome/browser/ui/singleton_tabs.h"
 #include "components/sync_sessions/open_tabs_ui_delegate.h"
 #include "ui/base/l10n/l10n_util.h"

--- a/chromium_src/chrome/browser/ui/tabs/tab_renderer_data.cc
+++ b/chromium_src/chrome/browser/ui/tabs/tab_renderer_data.cc
@@ -5,6 +5,8 @@
 
 #include "chrome/browser/ui/tabs/tab_renderer_data.h"
 
+#include "base/check.h"
+
 #define FromTabInModel FromTabInModel_ChromiumImpl
 #include "src/chrome/browser/ui/tabs/tab_renderer_data.cc"
 #undef FromTabInModel

--- a/chromium_src/chrome/browser/ui/test/test_browser_ui.cc
+++ b/chromium_src/chrome/browser/ui/test/test_browser_ui.cc
@@ -5,6 +5,7 @@
 
 #include "chrome/browser/ui/test/test_browser_ui.h"
 
+#include "base/logging.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 // A workaround for Brave CIs.

--- a/chromium_src/chrome/browser/ui/views/bookmarks/bookmark_bar_view.cc
+++ b/chromium_src/chrome/browser/ui/views/bookmarks/bookmark_bar_view.cc
@@ -3,6 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "brave/browser/ui/brave_view_ids.h"
 #include "brave/browser/ui/views/bookmarks/bookmark_bar_instructions_view.h"
 #include "brave/browser/ui/views/bookmarks/brave_bookmark_context_menu.h"

--- a/chromium_src/chrome/browser/ui/views/frame/browser_desktop_window_tree_host_win.cc
+++ b/chromium_src/chrome/browser/ui/views/frame/browser_desktop_window_tree_host_win.cc
@@ -7,6 +7,7 @@
 
 #include <dwmapi.h>
 
+#include "base/check.h"
 #include "base/feature_list.h"
 #include "base/win/windows_types.h"
 #include "brave/browser/ui/brave_ui_features.h"

--- a/chromium_src/chrome/browser/ui/views/frame/browser_frame_view_layout_linux.cc
+++ b/chromium_src/chrome/browser/ui/views/frame/browser_frame_view_layout_linux.cc
@@ -5,7 +5,9 @@
 
 #include "src/chrome/browser/ui/views/frame/browser_frame_view_layout_linux.cc"
 
+#include "base/check.h"
 #include "base/check_is_test.h"
+#include "base/check_op.h"
 #include "brave/browser/ui/tabs/features.h"
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"

--- a/chromium_src/chrome/browser/ui/views/frame/browser_view.cc
+++ b/chromium_src/chrome/browser/ui/views/frame/browser_view.cc
@@ -7,6 +7,8 @@
 // therefore avoid undef before use.
 #include "chrome/browser/ui/views/frame/browser_view.h"
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "brave/browser/ui/views/brave_tab_search_bubble_host.h"
 #include "brave/browser/ui/views/frame/brave_browser_view_layout.h"
 #include "brave/browser/ui/views/frame/brave_tab_strip_region_view.h"

--- a/chromium_src/chrome/browser/ui/views/omnibox/rounded_omnibox_results_frame.cc
+++ b/chromium_src/chrome/browser/ui/views/omnibox/rounded_omnibox_results_frame.cc
@@ -3,6 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include "base/check_op.h"
 #include "ui/views/layout/layout_provider.h"
 
 // Set our radius value directly as kOmniboxExpandedRadius is mapped to

--- a/chromium_src/chrome/browser/ui/views/permissions/chip/permission_dashboard_controller.cc
+++ b/chromium_src/chrome/browser/ui/views/permissions/chip/permission_dashboard_controller.cc
@@ -5,6 +5,7 @@
 
 #include "chrome/browser/ui/views/permissions/chip/permission_dashboard_controller.h"
 
+#include "base/check.h"
 #include "brave/grit/brave_generated_resources.h"
 #include "chrome/browser/ui/views/permissions/chip/permission_chip_view.h"
 #include "components/content_settings/browser/page_specific_content_settings.h"

--- a/chromium_src/chrome/browser/ui/views/permissions/permission_prompt_bubble_base_view.cc
+++ b/chromium_src/chrome/browser/ui/views/permissions/permission_prompt_bubble_base_view.cc
@@ -7,6 +7,8 @@
 
 #include <vector>
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "base/feature_list.h"
 #include "base/memory/raw_ptr.h"
 #include "base/memory/raw_ref.h"

--- a/chromium_src/chrome/browser/ui/views/permissions/permission_prompt_factory.cc
+++ b/chromium_src/chrome/browser/ui/views/permissions/permission_prompt_factory.cc
@@ -3,6 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include "base/logging.h"
 #include "chrome/browser/ui/permission_bubble/permission_prompt.h"
 #include "components/permissions/request_type.h"
 

--- a/chromium_src/chrome/browser/ui/views/tabs/tab_group_editor_bubble_view.cc
+++ b/chromium_src/chrome/browser/ui/views/tabs/tab_group_editor_bubble_view.cc
@@ -5,6 +5,7 @@
 
 #include "chrome/browser/ui/views/tabs/tab_group_editor_bubble_view.h"
 
+#include "base/check.h"
 #include "chrome/app/vector_icons/vector_icons.h"
 #include "chrome/browser/ui/views/data_sharing/data_sharing_bubble_controller.h"
 #include "chrome/browser/user_education/user_education_service.h"

--- a/chromium_src/chrome/browser/ui/views/tabs/tab_icon.cc
+++ b/chromium_src/chrome/browser/ui/views/tabs/tab_icon.cc
@@ -3,6 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include "base/check.h"
 #include "chrome/browser/ui/color/chrome_color_id.h"
 #include "ui/color/color_provider.h"
 #include "ui/views/cascading_property.h"

--- a/chromium_src/chrome/browser/ui/views/tabs/tab_strip_layout_helper.cc
+++ b/chromium_src/chrome/browser/ui/views/tabs/tab_strip_layout_helper.cc
@@ -5,6 +5,7 @@
 
 #include "chrome/browser/ui/views/tabs/tab_strip_layout_helper.h"
 
+#include "base/check.h"
 #include "brave/browser/ui/views/tabs/brave_tab_strip.h"
 
 #define CalculateTabBounds                                                     \

--- a/chromium_src/chrome/browser/ui/views/toolbar/toolbar_button.cc
+++ b/chromium_src/chrome/browser/ui/views/toolbar/toolbar_button.cc
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include "base/check.h"
 #include "brave/browser/ui/color/brave_color_id.h"
 #include "ui/views/controls/highlight_path_generator.h"
 

--- a/chromium_src/chrome/browser/ui/views/web_apps/web_app_views_utils.cc
+++ b/chromium_src/chrome/browser/ui/views/web_apps/web_app_views_utils.cc
@@ -5,6 +5,7 @@
 
 #include "chrome/browser/ui/views/web_apps/web_app_views_utils.h"
 
+#include "base/check.h"
 #include "brave/browser/ui/brave_scheme_utils.h"
 
 #define CreateOriginLabelFromStartUrl CreateOriginLabelFromStartUrl_ChromiumImpl

--- a/chromium_src/chrome/browser/ui/webui/current_channel_logo.cc
+++ b/chromium_src/chrome/browser/ui/webui/current_channel_logo.cc
@@ -5,6 +5,8 @@
 
 #define CurrentChannelLogoResourceId CurrentChannelLogoResourceId_Unused
 #include "src/chrome/browser/ui/webui/current_channel_logo.cc"
+
+#include "base/notreached.h"
 #undef CurrentChannelLogoResourceId
 
 namespace webui {

--- a/chromium_src/chrome/browser/ui/webui/help/version_updater_mac.mm
+++ b/chromium_src/chrome/browser/ui/webui/help/version_updater_mac.mm
@@ -8,8 +8,11 @@
 #include <memory>
 
 #include "base/apple/foundation_util.h"
+#include "base/logging.h"
 #include "base/memory/ptr_util.h"
 #include "base/memory/raw_ptr.h"
+#include "base/notimplemented.h"
+#include "base/notreached.h"
 #include "base/strings/escape.h"
 #include "base/strings/stringprintf.h"
 #include "base/strings/sys_string_conversions.h"


### PR DESCRIPTION
This change is one of many fixing inclusion for the following files:

    - `base/notimplemented.h`
    - `base/notreached.h`
    - `base/check.h`
    - `base/dcheck_is_on.h`
    - `base/check_deref.h`
    - `base/check_op.h`
    - `base/logging/log_severity.h`
    - `base/logging.h`

This change is a mechanical change done with the following script:
https://github.com/brave/brave-browser/issues/46707#issuecomment-2960116515

Resolves https://github.com/brave/brave-browser/issues/46707
