### PR TITLE
Fixes position of automatically remove permissions on Android

### DIFF
--- a/android/javatests/BUILD.gn
+++ b/android/javatests/BUILD.gn
@@ -8,20 +8,45 @@ import("//build/config/android/rules.gni")
 
 testonly = true
 
+# Contain all source code that is used by tests in a different package.
+android_library("brave_test_java_helper") {
+  sources = [ "//chrome/android/javatests/src/org/chromium/chrome/browser/site_settings/SiteSettingsTestUtils.java" ]
+  public_deps = [
+    "//base:base_java_test_support",
+    "//chrome/android:chrome_java",
+    "//chrome/browser/flags:java",
+    "//chrome/browser/profiles/android:java",
+    "//chrome/browser/settings:factory_java",
+    "//chrome/browser/settings:test_support_java",
+    "//chrome/test/android:chrome_java_test_support_common",
+    "//components/browser_ui/settings/android:java",
+    "//components/browser_ui/site_settings/android:constants_java",
+    "//components/browser_ui/site_settings/android:java",
+    "//components/browser_ui/site_settings/android:java_resources",
+    "//components/browser_ui/widget/android:java",
+    "//components/browser_ui/widget/android:test_support_java",
+    "//components/browsing_data/core:java",
+    "//components/content_settings/android:content_settings_enums_java",
+    "//components/content_settings/android:java",
+    "//third_party/androidx:androidx_fragment_fragment_java",
+    "//third_party/androidx:androidx_preference_preference_java",
+    "//third_party/androidx:androidx_test_core_java",
+    "//third_party/androidx:androidx_test_monitor_java",
+    "//third_party/androidx:androidx_test_runner_java__classes",
+    "//third_party/junit:junit",
+  ]
+}
+
 android_library("brave_test_java_org.chromium.chrome.browser.download") {
   sources =
       [ "org/chromium/chrome/browser/download/BraveDownloadSettingsTest.java" ]
 
-  deps = [
-    "//base:base_java_test_support",
-    "//chrome/android:chrome_java",
-    "//chrome/browser/flags:java",
-    "//chrome/browser/settings:test_support_java",
-    "//chrome/test/android:chrome_java_test_support_common",
-    "//components/browser_ui/settings/android:java",
-    "//third_party/androidx:androidx_fragment_fragment_java",
-    "//third_party/androidx:androidx_preference_preference_java",
-    "//third_party/androidx:androidx_test_runner_java__classes",
-    "//third_party/junit:junit",
-  ]
+  deps = [ ":brave_test_java_helper" ]
+}
+
+android_library("brave_test_java_org.chromium.chrome.browser.site_settings") {
+  sources =
+      [ "org/chromium/chrome/browser/site_settings/BraveSiteSettingsTest.java" ]
+
+  deps = [ ":brave_test_java_helper" ]
 }

--- a/android/javatests/org/chromium/chrome/browser/site_settings/BraveSiteSettingsTest.java
+++ b/android/javatests/org/chromium/chrome/browser/site_settings/BraveSiteSettingsTest.java
@@ -1,0 +1,52 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.chromium.chrome.browser.site_settings;
+
+import androidx.preference.Preference;
+import androidx.test.filters.SmallTest;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.chromium.base.test.util.Batch;
+import org.chromium.base.test.util.Feature;
+import org.chromium.chrome.browser.settings.SettingsActivity;
+import org.chromium.chrome.test.ChromeJUnit4ClassRunner;
+import org.chromium.components.browser_ui.site_settings.SiteSettings;
+
+@Batch(Batch.PER_CLASS)
+@RunWith(ChromeJUnit4ClassRunner.class)
+public class BraveSiteSettingsTest {
+    private static final String DIVIDER_KEY = "divider";
+    private static final String PERMISSION_AUTOREVOCATION_KEY = "permission_autorevocation";
+    private static final String SOLANA_CONNECTED_SITES_KEY = "solana_connected_sites";
+
+    /**
+     * Tests an order of PERMISSION_AUTOREVOCATION_KEY. It has to be at the bottom, right after
+     * SOLANA_CONNECTED_SITES_KEY
+     */
+    @Test
+    @SmallTest
+    @Feature({"Preferences"})
+    public void testSiteSettingsMenuPermissionAutorevocationOrder() {
+        final SettingsActivity settingsActivity = SiteSettingsTestUtils.startSiteSettingsMenu("");
+        SiteSettings siteSettings = (SiteSettings) settingsActivity.getMainFragment();
+        Assert.assertNotNull(siteSettings);
+        Preference prefDivider = siteSettings.findPreference(DIVIDER_KEY);
+        Assert.assertNotNull(prefDivider);
+        Preference prefPermissionAutorevocation =
+                siteSettings.findPreference(PERMISSION_AUTOREVOCATION_KEY);
+        Assert.assertNotNull(prefPermissionAutorevocation);
+        Preference prefSolanaConnectedSites =
+                siteSettings.findPreference(SOLANA_CONNECTED_SITES_KEY);
+        Assert.assertNotNull(prefSolanaConnectedSites);
+        Assert.assertEquals(prefSolanaConnectedSites.getOrder(), prefDivider.getOrder() - 1);
+        Assert.assertEquals(
+                prefSolanaConnectedSites.getOrder(), prefPermissionAutorevocation.getOrder() - 2);
+        settingsActivity.finish();
+    }
+}

--- a/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/BraveSiteSettingsPreferencesBase.java
+++ b/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/BraveSiteSettingsPreferencesBase.java
@@ -17,6 +17,9 @@ public class BraveSiteSettingsPreferencesBase extends BaseSiteSettingsFragment {
     private static final String ADS_KEY = "ads";
     private static final String BACKGROUND_SYNC_KEY = "background_sync";
     private static final String IDLE_DETECTION = "idle_detection";
+    private static final String DIVIDER_KEY = "divider";
+    private static final String PERMISSION_AUTOREVOCATION_KEY = "permission_autorevocation";
+    private static final String SOLANA_CONNECTED_SITES_KEY = "solana_connected_sites";
 
     private final HashMap<String, Preference> mRemovedPreferences = new HashMap<>();
 
@@ -63,5 +66,23 @@ public class BraveSiteSettingsPreferencesBase extends BaseSiteSettingsFragment {
         removePreferenceIfPresent(IDLE_DETECTION);
         removePreferenceIfPresent(ADS_KEY);
         removePreferenceIfPresent(BACKGROUND_SYNC_KEY);
+
+        // We want to place these Settings at the bottom.
+        // See https://github.com/brave/brave-browser/issues/46547
+        // for the context
+        Preference prefDivider = getPreferenceScreen().findPreference(DIVIDER_KEY);
+        Preference prefPermissionAutorevocation =
+                getPreferenceScreen().findPreference(PERMISSION_AUTOREVOCATION_KEY);
+        assert prefDivider != null && prefPermissionAutorevocation != null
+                : "Remove the order adjustment if the prefs are removed from upstream";
+        if (prefDivider != null && prefPermissionAutorevocation != null) {
+            Preference prefSolanaConnectedSites =
+                    getPreferenceScreen().findPreference(SOLANA_CONNECTED_SITES_KEY);
+            assert prefSolanaConnectedSites != null
+                    : "Adjust if needed for the last pref in the site settings screen";
+            int solanaConnectedSitesOrder = prefSolanaConnectedSites.getOrder();
+            prefDivider.setOrder(solanaConnectedSitesOrder + 1);
+            prefPermissionAutorevocation.setOrder(solanaConnectedSitesOrder + 2);
+        }
     }
 }

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -1274,6 +1274,7 @@ if (is_android) {
       "//base:base_java_test_support",
       "//base:base_shared_preferences_java",
       "//brave/android/javatests:brave_test_java_org.chromium.chrome.browser.download",
+      "//brave/android/javatests:brave_test_java_org.chromium.chrome.browser.site_settings",
       "//brave/components/brave_wallet/common:mojom_java",
       "//brave/components/safe_browsing/android:brave_safe_browsing_java",
       "//cc:cc_java",


### PR DESCRIPTION
We should move the Automatically remove permissions permission/setting under Site settings to the bottom like Chrome does rather than putting it between the other settings.

Resolves: https://github.com/brave/brave-browser/issues/46547

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
