### PR TITLE
Fixes Brave News subscription lists are empty on Android

### DIFF
--- a/android/java/org/chromium/chrome/browser/ntp/BraveNewTabPageLayout.java
+++ b/android/java/org/chromium/chrome/browser/ntp/BraveNewTabPageLayout.java
@@ -847,7 +847,7 @@ public class BraveNewTabPageLayout extends NewTabPageLayout
         mNtpAdapter.setImageCreditAlpha(1f);
         mNtpAdapter.setDisplayNewsFeed(mIsDisplayNewsFeed);
 
-        if (isOptin && mBraveNewsController != null && BraveNewsUtils.getLocale() == null) {
+        if (isOptin && mBraveNewsController != null && BraveNewsUtils.getLocale().isEmpty()) {
             BraveNewsUtils.getBraveNewsSettingsData(mBraveNewsController, null, null);
         }
     }

--- a/android/java/org/chromium/chrome/browser/settings/BraveNewsPreferencesV2.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveNewsPreferencesV2.java
@@ -150,7 +150,7 @@ public class BraveNewsPreferencesV2 extends BravePreferenceFragment
             }
         }
 
-        if (BraveNewsUtils.getLocale() != null
+        if (!BraveNewsUtils.getLocale().isEmpty()
                 && BraveNewsUtils.getSuggestionsPublisherList().size() > 0) {
             mIsSuggestionAvailable = true;
         }
@@ -164,7 +164,7 @@ public class BraveNewsPreferencesV2 extends BravePreferenceFragment
     public void onResume() {
         super.onResume();
 
-        if (BraveNewsUtils.getLocale() != null && mSwitchShowNews.isChecked()) {
+        if (!BraveNewsUtils.getLocale().isEmpty() && mSwitchShowNews.isChecked()) {
             updateFollowerCount();
 
             if (!mIsSuggestionAvailable) {
@@ -236,7 +236,7 @@ public class BraveNewsPreferencesV2 extends BravePreferenceFragment
             if (BraveNewsUtils.getChannelIcons().size() == 0) {
                 BraveNewsUtils.setChannelIcons();
             }
-            if (BraveNewsUtils.getLocale() == null && mBraveNewsController != null) {
+            if (BraveNewsUtils.getLocale().isEmpty() && mBraveNewsController != null) {
                 BraveNewsUtils.getBraveNewsSettingsData(mBraveNewsController, this, null);
             } else {
                 mTvSearch.setVisibility(View.VISIBLE);


### PR DESCRIPTION
This is a regression fix that was introduced in
https://github.com/brave/brave-browser/issues/45645. It fixes Brave News subscription lists are empty before relaunching Brave. The reason is because `@NullMarked` was applied to `BraveNewsUtils` and the function started to return an empty string instead of `null`.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves: https://github.com/brave/brave-browser/issues/46714

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
