### PR TITLE
[IWYU] Fixing logging inclusions `//browser/ui`

### DIFF
--- a/browser/ui/ai_chat/utils.cc
+++ b/browser/ui/ai_chat/utils.cc
@@ -5,6 +5,7 @@
 
 #include "brave/browser/ui/ai_chat/utils.h"
 
+#include "base/check.h"
 #include "chrome/browser/ui/browser_window/public/browser_window_features.h"
 #include "chrome/browser/ui/browser_window/public/browser_window_interface.h"
 #include "chrome/browser/ui/views/side_panel/side_panel_coordinator.h"

--- a/browser/ui/ai_rewriter/ai_rewriter_dialog_delegate.cc
+++ b/browser/ui/ai_rewriter/ai_rewriter_dialog_delegate.cc
@@ -10,6 +10,7 @@
 #include <string>
 #include <utility>
 
+#include "base/check.h"
 #include "base/functional/bind.h"
 #include "base/json/json_writer.h"
 #include "base/memory/ptr_util.h"

--- a/browser/ui/brave_browser.cc
+++ b/browser/ui/brave_browser.cc
@@ -9,6 +9,7 @@
 #include <optional>
 #include <utility>
 
+#include "base/check.h"
 #include "base/check_is_test.h"
 #include "base/feature_list.h"
 #include "base/functional/bind.h"

--- a/browser/ui/brave_browser_command_controller.cc
+++ b/browser/ui/brave_browser_command_controller.cc
@@ -7,9 +7,12 @@
 
 #include <optional>
 
+#include "base/check.h"
 #include "base/check_is_test.h"
 #include "base/containers/fixed_flat_set.h"
 #include "base/feature_list.h"
+#include "base/logging.h"
+#include "base/notreached.h"
 #include "base/types/to_address.h"
 #include "brave/app/brave_command_ids.h"
 #include "brave/browser/ai_chat/ai_chat_utils.h"

--- a/browser/ui/brave_browser_command_controller_browsertest.cc
+++ b/browser/ui/brave_browser_command_controller_browsertest.cc
@@ -8,6 +8,7 @@
 #include <memory>
 #include <optional>
 
+#include "base/check.h"
 #include "base/functional/callback_helpers.h"
 #include "base/test/run_until.h"
 #include "base/test/scoped_feature_list.h"

--- a/browser/ui/brave_file_select_utils.cc
+++ b/browser/ui/brave_file_select_utils.cc
@@ -8,6 +8,7 @@
 #include <array>
 #include <unordered_map>
 
+#include "base/check.h"
 #include "base/i18n/rtl.h"
 #include "base/no_destructor.h"
 #include "brave/grit/brave_generated_resources.h"

--- a/browser/ui/brave_icon_with_badge_image_source.cc
+++ b/browser/ui/brave_icon_with_badge_image_source.cc
@@ -9,6 +9,7 @@
 #include <optional>
 #include <utility>
 
+#include "base/logging.h"
 #include "base/strings/utf_string_conversions.h"
 #include "cc/paint/paint_flags.h"
 #include "chrome/grit/theme_resources.h"

--- a/browser/ui/brave_pages.cc
+++ b/browser/ui/brave_pages.cc
@@ -5,6 +5,7 @@
 
 #include "brave/browser/ui/brave_pages.h"
 
+#include "base/check.h"
 #include "base/strings/strcat.h"
 #include "brave/browser/ui/webui/webcompat_reporter/webcompat_reporter_dialog.h"
 #include "brave/components/ai_chat/core/common/features.h"

--- a/browser/ui/brave_tooltips/bounds_util.cc
+++ b/browser/ui/brave_tooltips/bounds_util.cc
@@ -5,6 +5,7 @@
 
 #include "brave/browser/ui/brave_tooltips/bounds_util.h"
 
+#include "base/check.h"
 #include "ui/display/screen.h"
 #include "ui/gfx/geometry/rect.h"
 

--- a/browser/ui/brave_tooltips/brave_tooltip.h
+++ b/browser/ui/brave_tooltips/brave_tooltip.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <utility>
 
+#include "base/check.h"
 #include "base/memory/ref_counted.h"
 #include "base/memory/weak_ptr.h"
 #include "brave/browser/ui/brave_tooltips/brave_tooltip_attributes.h"

--- a/browser/ui/browser_commands.cc
+++ b/browser/ui/browser_commands.cc
@@ -13,10 +13,14 @@
 #include <utility>
 #include <vector>
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "base/feature_list.h"
 #include "base/functional/callback_helpers.h"
 #include "base/i18n/file_util_icu.h"
 #include "base/i18n/time_formatting.h"
+#include "base/logging.h"
+#include "base/notreached.h"
 #include "base/path_service.h"
 #include "base/strings/utf_string_conversions.h"
 #include "brave/app/brave_command_ids.h"

--- a/browser/ui/color/brave_color_mixer.cc
+++ b/browser/ui/color/brave_color_mixer.cc
@@ -5,7 +5,6 @@
 
 #include "brave/browser/ui/color/brave_color_mixer.h"
 
-#include "base/notreached.h"
 #include "base/numerics/safe_conversions.h"
 #include "brave/browser/themes/brave_dark_mode_utils.h"
 #include "brave/browser/ui/color/brave_color_id.h"

--- a/browser/ui/color/material_brave_color_mixer.cc
+++ b/browser/ui/color/material_brave_color_mixer.cc
@@ -5,6 +5,7 @@
 
 #include "brave/browser/ui/color/material_brave_color_mixer.h"
 
+#include "base/check.h"
 #include "chrome/browser/ui/color/chrome_color_id.h"
 #include "ui/color/color_provider.h"
 #include "ui/color/color_recipe.h"

--- a/browser/ui/commander/bookmark_command_source.cc
+++ b/browser/ui/commander/bookmark_command_source.cc
@@ -15,6 +15,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/check.h"
 #include "brave/browser/ui/commander/fuzzy_finder.h"
 #include "chrome/browser/bookmarks/bookmark_model_factory.h"
 #include "chrome/browser/profiles/profile.h"

--- a/browser/ui/commander/commander_service.cc
+++ b/browser/ui/commander/commander_service.cc
@@ -15,6 +15,7 @@
 #include <variant>
 #include <vector>
 
+#include "base/check.h"
 #include "base/functional/bind.h"
 #include "base/functional/callback_forward.h"
 #include "base/location.h"

--- a/browser/ui/commander/entity_match.cc
+++ b/browser/ui/commander/entity_match.cc
@@ -12,6 +12,7 @@
 
 #include <utility>
 
+#include "base/check.h"
 #include "brave/browser/ui/commander/fuzzy_finder.h"
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/browser_list.h"

--- a/browser/ui/commander/fuzzy_finder.cc
+++ b/browser/ui/commander/fuzzy_finder.cc
@@ -12,6 +12,8 @@
 
 #include <algorithm>
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "base/containers/span.h"
 #include "base/i18n/case_conversion.h"
 #include "base/i18n/char_iterator.h"

--- a/browser/ui/commander/tab_command_source.cc
+++ b/browser/ui/commander/tab_command_source.cc
@@ -17,6 +17,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/check.h"
 #include "base/functional/bind.h"
 #include "base/strings/utf_string_conversions.h"
 #include "brave/app/command_utils.h"

--- a/browser/ui/commands/accelerator_service_factory.cc
+++ b/browser/ui/commands/accelerator_service_factory.cc
@@ -8,6 +8,7 @@
 #include <memory>
 #include <utility>
 
+#include "base/check.h"
 #include "base/no_destructor.h"
 #include "brave/browser/ui/brave_browser_window.h"
 #include "brave/browser/ui/commands/accelerator_service.h"

--- a/browser/ui/content_settings/brave_autoplay_content_setting_bubble_model.cc
+++ b/browser/ui/content_settings/brave_autoplay_content_setting_bubble_model.cc
@@ -8,6 +8,7 @@
 #include <memory>
 #include <string>
 
+#include "base/check.h"
 #include "base/strings/utf_string_conversions.h"
 #include "brave/browser/ui/brave_browser_content_setting_bubble_model_delegate.h"
 #include "brave/grit/brave_generated_resources.h"

--- a/browser/ui/sidebar/sidebar_browsertest.cc
+++ b/browser/ui/sidebar/sidebar_browsertest.cc
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <optional>
 
+#include "base/check.h"
 #include "base/functional/bind.h"
 #include "base/memory/weak_ptr.h"
 #include "base/run_loop.h"

--- a/browser/ui/sidebar/sidebar_controller.cc
+++ b/browser/ui/sidebar/sidebar_controller.cc
@@ -8,6 +8,7 @@
 #include <optional>
 #include <vector>
 
+#include "base/check.h"
 #include "base/check_op.h"
 #include "brave/browser/ui/sidebar/sidebar.h"
 #include "brave/browser/ui/sidebar/sidebar_model.h"

--- a/browser/ui/sidebar/sidebar_model.cc
+++ b/browser/ui/sidebar/sidebar_model.cc
@@ -10,7 +10,7 @@
 #include <string>
 #include <utility>
 
-#include "base/logging.h"
+#include "base/check.h"
 #include "base/time/time.h"
 #include "brave/browser/ui/sidebar/sidebar_service_factory.h"
 #include "brave/components/sidebar/browser/sidebar_item.h"

--- a/browser/ui/sidebar/sidebar_utils.cc
+++ b/browser/ui/sidebar/sidebar_utils.cc
@@ -7,8 +7,10 @@
 
 #include <optional>
 
+#include "base/check.h"
 #include "base/check_is_test.h"
 #include "base/command_line.h"
+#include "base/notreached.h"
 #include "brave/browser/ui/sidebar/sidebar_controller.h"
 #include "brave/browser/ui/sidebar/sidebar_model.h"
 #include "brave/browser/ui/sidebar/sidebar_service_factory.h"

--- a/browser/ui/tabs/brave_tab_menu_model.cc
+++ b/browser/ui/tabs/brave_tab_menu_model.cc
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <vector>
 
+#include "base/check.h"
 #include "base/feature_list.h"
 #include "brave/browser/ui/browser_commands.h"
 #include "brave/browser/ui/tabs/brave_tab_strip_model.h"

--- a/browser/ui/tabs/shared_pinned_tab_service.cc
+++ b/browser/ui/tabs/shared_pinned_tab_service.cc
@@ -8,8 +8,11 @@
 #include <algorithm>
 #include <utility>
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "base/functional/bind.h"
 #include "base/functional/callback_forward.h"
+#include "base/logging.h"
 #include "base/notreached.h"
 #include "brave/browser/ui/brave_browser_window.h"
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"

--- a/browser/ui/tabs/split_view_browser_data.cc
+++ b/browser/ui/tabs/split_view_browser_data.cc
@@ -7,7 +7,9 @@
 
 #include <algorithm>
 
+#include "base/check.h"
 #include "base/check_is_test.h"
+#include "base/check_op.h"
 #include "base/containers/contains.h"
 #include "base/functional/callback_helpers.h"
 #include "base/notreached.h"

--- a/browser/ui/tabs/split_view_tab_strip_model_adapter.cc
+++ b/browser/ui/tabs/split_view_tab_strip_model_adapter.cc
@@ -8,6 +8,8 @@
 #include <algorithm>
 
 #include "base/auto_reset.h"
+#include "base/check.h"
+#include "base/check_op.h"
 #include "base/compiler_specific.h"
 #include "base/memory/weak_ptr.h"
 #include "base/task/sequenced_task_runner.h"

--- a/browser/ui/tabs/tab_features.cc
+++ b/browser/ui/tabs/tab_features.cc
@@ -8,6 +8,7 @@
 #include <memory>
 #include <utility>
 
+#include "base/check.h"
 #include "base/memory/ptr_util.h"
 #include "base/no_destructor.h"
 #include "brave/browser/ai_chat/ai_chat_utils.h"

--- a/browser/ui/tabs/test/split_view_browser_data_browsertest.cc
+++ b/browser/ui/tabs/test/split_view_browser_data_browsertest.cc
@@ -7,6 +7,7 @@
 
 #include <memory>
 
+#include "base/check.h"
 #include "base/test/scoped_feature_list.h"
 #include "brave/browser/ui/tabs/features.h"
 #include "chrome/browser/profiles/profile.h"

--- a/browser/ui/tabs/test/split_view_tab_strip_model_adapter_browsertest.cc
+++ b/browser/ui/tabs/test/split_view_tab_strip_model_adapter_browsertest.cc
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include "base/check.h"
 #include "base/run_loop.h"
 #include "brave/browser/ui/tabs/features.h"
 #include "brave/browser/ui/tabs/split_view_browser_data.h"

--- a/browser/ui/toolbar/brave_app_menu_model.cc
+++ b/browser/ui/toolbar/brave_app_menu_model.cc
@@ -9,6 +9,8 @@
 #include <optional>
 #include <string>
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "base/memory/raw_ptr.h"
 #include "base/notreached.h"
 #include "base/strings/utf_string_conversions.h"

--- a/browser/ui/toolbar/brave_app_menu_model_browsertest.cc
+++ b/browser/ui/toolbar/brave_app_menu_model_browsertest.cc
@@ -9,6 +9,7 @@
 #include <optional>
 #include <vector>
 
+#include "base/check.h"
 #include "base/containers/contains.h"
 #include "base/functional/callback_helpers.h"
 #include "base/test/scoped_feature_list.h"

--- a/browser/ui/toolbar/brave_location_bar_model_delegate.cc
+++ b/browser/ui/toolbar/brave_location_bar_model_delegate.cc
@@ -5,6 +5,7 @@
 
 #include "brave/browser/ui/toolbar/brave_location_bar_model_delegate.h"
 
+#include "base/check.h"
 #include "base/feature_list.h"
 #include "base/strings/utf_string_conversions.h"
 #include "brave/browser/ui/brave_scheme_utils.h"

--- a/browser/ui/wallet_bubble_manager_delegate_impl.cc
+++ b/browser/ui/wallet_bubble_manager_delegate_impl.cc
@@ -10,6 +10,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/check.h"
 #include "base/memory/raw_ptr.h"
 #include "brave/browser/ui/views/frame/brave_browser_view.h"
 #include "brave/browser/ui/views/wallet_bubble_focus_observer.h"

--- a/browser/ui/webui/ai_chat/ai_chat_ui.cc
+++ b/browser/ui/webui/ai_chat/ai_chat_ui.cc
@@ -9,6 +9,8 @@
 #include <memory>
 #include <utility>
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "base/strings/stringprintf.h"
 #include "brave/browser/ai_chat/ai_chat_service_factory.h"
 #include "brave/browser/ai_chat/tab_tracker_service_factory.h"

--- a/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
+++ b/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
@@ -10,6 +10,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/check.h"
 #include "base/functional/bind.h"
 #include "base/functional/callback_forward.h"
 #include "brave/browser/ai_chat/ai_chat_service_factory.h"

--- a/browser/ui/webui/ai_chat/ai_chat_ui_page_handler_browsertest.cc
+++ b/browser/ui/webui/ai_chat/ai_chat_ui_page_handler_browsertest.cc
@@ -5,6 +5,7 @@
 
 #include "brave/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.h"
 
+#include "base/check.h"
 #include "base/path_service.h"
 #include "base/run_loop.h"
 #include "base/strings/strcat.h"

--- a/browser/ui/webui/ai_chat/ai_chat_untrusted_conversation_ui.cc
+++ b/browser/ui/webui/ai_chat/ai_chat_untrusted_conversation_ui.cc
@@ -8,6 +8,8 @@
 #include <string>
 #include <utility>
 
+#include "base/check.h"
+#include "base/logging.h"
 #include "base/strings/escape.h"
 #include "base/strings/stringprintf.h"
 #include "brave/browser/ai_chat/ai_chat_service_factory.h"

--- a/browser/ui/webui/ai_rewriter/ai_rewriter_ui.cc
+++ b/browser/ui/webui/ai_rewriter/ai_rewriter_ui.cc
@@ -8,6 +8,7 @@
 #include <string>
 #include <utility>
 
+#include "base/check.h"
 #include "base/functional/bind.h"
 #include "base/memory/weak_ptr.h"
 #include "base/notimplemented.h"

--- a/browser/ui/webui/brave_adblock_internals_ui.cc
+++ b/browser/ui/webui/brave_adblock_internals_ui.cc
@@ -11,6 +11,8 @@
 #include <utility>
 #include <vector>
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "base/functional/bind.h"
 #include "base/process/process.h"
 #include "base/strings/string_number_conversions.h"

--- a/browser/ui/webui/brave_adblock_ui.cc
+++ b/browser/ui/webui/brave_adblock_ui.cc
@@ -9,6 +9,8 @@
 #include <string>
 #include <utility>
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "base/scoped_observation.h"
 #include "base/values.h"
 #include "brave/browser/brave_browser_process.h"

--- a/browser/ui/webui/brave_education/brave_education_page_delegate_desktop.cc
+++ b/browser/ui/webui/brave_education/brave_education_page_delegate_desktop.cc
@@ -5,6 +5,7 @@
 
 #include "brave/browser/ui/webui/brave_education/brave_education_page_delegate_desktop.h"
 
+#include "base/check.h"
 #include "brave/browser/ui/brave_rewards/rewards_panel_coordinator.h"
 #include "brave/browser/ui/brave_vpn/brave_vpn_controller.h"
 #include "brave/components/brave_vpn/common/buildflags/buildflags.h"

--- a/browser/ui/webui/brave_education/brave_education_page_ui.cc
+++ b/browser/ui/webui/brave_education/brave_education_page_ui.cc
@@ -11,6 +11,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/check.h"
 #include "brave/browser/ui/webui/brave_browser_command/brave_browser_command_handler.h"
 #include "brave/browser/ui/webui/brave_education/brave_education_handler.h"
 #include "brave/browser/ui/webui/brave_education/brave_education_page_delegate_desktop.h"

--- a/browser/ui/webui/brave_education/brave_education_server_checker.cc
+++ b/browser/ui/webui/brave_education/brave_education_server_checker.cc
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include "base/check.h"
 #include "base/strings/string_split.h"
 #include "components/language/core/browser/pref_names.h"
 #include "components/prefs/pref_service.h"

--- a/browser/ui/webui/brave_new_tab_page_refresh/background_facade.cc
+++ b/browser/ui/webui/brave_new_tab_page_refresh/background_facade.cc
@@ -8,6 +8,7 @@
 #include <utility>
 
 #include "base/barrier_callback.h"
+#include "base/check.h"
 #include "base/containers/contains.h"
 #include "brave/browser/ntp_background/custom_background_file_manager.h"
 #include "brave/browser/ntp_background/ntp_background_prefs.h"

--- a/browser/ui/webui/brave_new_tab_page_refresh/new_tab_page_handler.cc
+++ b/browser/ui/webui/brave_new_tab_page_refresh/new_tab_page_handler.cc
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include "base/check.h"
 #include "base/strings/utf_string_conversions.h"
 #include "brave/browser/ntp_background/new_tab_takeover_infobar_delegate.h"
 #include "brave/browser/ui/webui/brave_new_tab_page_refresh/background_facade.h"

--- a/browser/ui/webui/brave_new_tab_page_refresh/top_sites_facade.cc
+++ b/browser/ui/webui/brave_new_tab_page_refresh/top_sites_facade.cc
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include "base/check.h"
 #include "base/strings/utf_string_conversions.h"
 #include "chrome/browser/ui/webui/new_tab_page/ntp_pref_names.h"
 #include "components/ntp_tiles/constants.h"

--- a/browser/ui/webui/brave_news_internals/brave_news_internals_ui.cc
+++ b/browser/ui/webui/brave_news_internals/brave_news_internals_ui.cc
@@ -8,6 +8,7 @@
 #include <string>
 #include <utility>
 
+#include "base/check.h"
 #include "brave/browser/ui/webui/brave_webui_source.h"
 #include "brave/components/brave_news/browser/brave_news_controller.h"
 #include "brave/components/brave_news/browser/resources/grit/brave_news_internals_generated_map.h"

--- a/browser/ui/webui/brave_shields/cookie_list_opt_in_page_handler.cc
+++ b/browser/ui/webui/brave_shields/cookie_list_opt_in_page_handler.cc
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include "base/check.h"
 #include "base/metrics/histogram_functions.h"
 #include "brave/browser/brave_browser_process.h"
 #include "brave/components/brave_shields/content/browser/ad_block_service.h"

--- a/browser/ui/webui/brave_shields/cookie_list_opt_in_ui.cc
+++ b/browser/ui/webui/brave_shields/cookie_list_opt_in_ui.cc
@@ -8,6 +8,7 @@
 #include <memory>
 #include <utility>
 
+#include "base/check.h"
 #include "base/feature_list.h"
 #include "brave/browser/ui/webui/brave_shields/cookie_list_opt_in_page_handler.h"
 #include "brave/components/brave_shields/core/common/features.h"

--- a/browser/ui/webui/brave_shields/shields_panel_data_handler.cc
+++ b/browser/ui/webui/brave_shields/shields_panel_data_handler.cc
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include "base/check.h"
 #include "brave/browser/brave_browser_process.h"
 #include "brave/browser/ui/webui/webcompat_reporter/webcompat_reporter_dialog.h"
 #include "brave/components/brave_shields/content/browser/ad_block_service.h"

--- a/browser/ui/webui/brave_shields/shields_panel_handler.cc
+++ b/browser/ui/webui/brave_shields/shields_panel_handler.cc
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include "base/check.h"
 #include "brave/browser/ui/brave_browser_window.h"
 #include "brave/components/brave_shields/content/browser/brave_shields_p3a.h"
 #include "brave/components/constants/pref_names.h"

--- a/browser/ui/webui/brave_shields/shields_panel_ui.cc
+++ b/browser/ui/webui/brave_shields/shields_panel_ui.cc
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include "base/check.h"
 #include "brave/browser/ui/brave_browser_window.h"
 #include "brave/components/brave_shields/content/browser/brave_shields_util.h"
 #include "brave/components/brave_shields/core/common/brave_shield_localized_strings.h"

--- a/browser/ui/webui/brave_vpn/vpn_panel_handler.cc
+++ b/browser/ui/webui/brave_vpn/vpn_panel_handler.cc
@@ -4,11 +4,12 @@
 // you can obtain one at http://mozilla.org/MPL/2.0/.
 
 #include "brave/browser/ui/webui/brave_vpn/vpn_panel_handler.h"
-#include "brave/browser/ui/webui/brave_vpn/vpn_panel_ui.h"
 
 #include <utility>
 
+#include "base/check.h"
 #include "brave/browser/brave_vpn/brave_vpn_service_factory.h"
+#include "brave/browser/ui/webui/brave_vpn/vpn_panel_ui.h"
 #include "brave/components/brave_vpn/browser/brave_vpn_service.h"
 #include "brave/components/brave_vpn/common/brave_vpn_constants.h"
 #include "brave/components/brave_vpn/common/brave_vpn_utils.h"

--- a/browser/ui/webui/brave_vpn/vpn_panel_ui.cc
+++ b/browser/ui/webui/brave_vpn/vpn_panel_ui.cc
@@ -9,6 +9,7 @@
 #include <string>
 #include <utility>
 
+#include "base/check.h"
 #include "base/functional/bind.h"
 #include "brave/browser/brave_vpn/brave_vpn_service_factory.h"
 #include "brave/browser/brave_vpn/vpn_utils.h"

--- a/browser/ui/webui/brave_web_ui_controller_factory.cc
+++ b/browser/ui/webui/brave_web_ui_controller_factory.cc
@@ -8,6 +8,7 @@
 #include <memory>
 #include <string>
 
+#include "base/check.h"
 #include "base/feature_list.h"
 #include "base/memory/ptr_util.h"
 #include "base/no_destructor.h"

--- a/browser/ui/webui/brave_webui_source.cc
+++ b/browser/ui/webui/brave_webui_source.cc
@@ -10,6 +10,7 @@
 
 #include "base/containers/flat_map.h"
 #include "base/containers/span.h"
+#include "base/logging.h"
 #include "base/strings/utf_string_conversions.h"
 #include "brave/components/constants/url_constants.h"
 #include "brave/components/tor/buildflags/buildflags.h"

--- a/browser/ui/webui/new_tab_page/brave_new_tab_message_handler.cc
+++ b/browser/ui/webui/new_tab_page/brave_new_tab_message_handler.cc
@@ -10,8 +10,10 @@
 #include <string>
 #include <utility>
 
+#include "base/check.h"
 #include "base/functional/bind.h"
 #include "base/json/values_util.h"
+#include "base/logging.h"
 #include "base/memory/weak_ptr.h"
 #include "base/threading/thread_restrictions.h"
 #include "base/values.h"

--- a/browser/ui/webui/new_tab_page/brave_new_tab_page_handler.cc
+++ b/browser/ui/webui/new_tab_page/brave_new_tab_page_handler.cc
@@ -9,8 +9,10 @@
 #include <optional>
 #include <utility>
 
+#include "base/check.h"
 #include "base/files/file_path.h"
 #include "base/functional/bind.h"
+#include "base/logging.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/values.h"
 #include "brave/browser/brave_browser_process.h"

--- a/browser/ui/webui/new_tab_page/top_sites_message_handler.cc
+++ b/browser/ui/webui/new_tab_page/top_sites_message_handler.cc
@@ -10,6 +10,7 @@
 #include <string>
 #include <utility>
 
+#include "base/check.h"
 #include "base/i18n/rtl.h"
 #include "base/strings/utf_string_conversions.h"
 #include "brave/browser/ntp_background/view_counter_service_factory.h"

--- a/browser/ui/webui/playlist_active_tab_tracker.cc
+++ b/browser/ui/webui/playlist_active_tab_tracker.cc
@@ -5,6 +5,9 @@
 
 #include "brave/browser/ui/webui/playlist_active_tab_tracker.h"
 
+#include <vector>
+
+#include "base/check.h"
 #include "brave/browser/ui/playlist/playlist_browser_finder.h"
 #include "brave/components/playlist/browser/playlist_tab_helper.h"
 #include "chrome/browser/ui/browser.h"

--- a/browser/ui/webui/playlist_ui.cc
+++ b/browser/ui/webui/playlist_ui.cc
@@ -8,6 +8,7 @@
 #include <memory>
 #include <utility>
 
+#include "base/check.h"
 #include "base/feature_list.h"
 #include "base/functional/bind.h"
 #include "base/strings/strcat.h"

--- a/browser/ui/webui/private_new_tab_page/brave_private_new_tab_page_browsertest.cc
+++ b/browser/ui/webui/private_new_tab_page/brave_private_new_tab_page_browsertest.cc
@@ -1,10 +1,11 @@
-/* Copyright 2022 The Brave Authors. All rights reserved.
+/* Copyright 2022 <year> The Brave Authors. All rights reserved.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
- * You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #include <memory>
 
+#include "base/check.h"
 #include "base/run_loop.h"
 #include "brave/browser/extensions/brave_extension_functional_test.h"
 #include "brave/browser/ui/browser_commands.h"

--- a/browser/ui/webui/private_new_tab_page/brave_private_new_tab_page_handler.cc
+++ b/browser/ui/webui/private_new_tab_page/brave_private_new_tab_page_handler.cc
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include "base/check.h"
 #include "base/functional/bind.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/time/time.h"

--- a/browser/ui/webui/settings/brave_adblock_handler.cc
+++ b/browser/ui/webui/settings/brave_adblock_handler.cc
@@ -8,6 +8,8 @@
 #include <string>
 #include <utility>
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "base/feature_list.h"
 #include "base/functional/bind.h"
 #include "base/json/values_util.h"

--- a/browser/ui/webui/settings/brave_appearance_handler.cc
+++ b/browser/ui/webui/settings/brave_appearance_handler.cc
@@ -5,6 +5,8 @@
 
 #include "brave/browser/ui/webui/settings/brave_appearance_handler.h"
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "base/functional/bind.h"
 #include "base/metrics/histogram_macros.h"
 #include "brave/browser/new_tab/new_tab_shows_options.h"

--- a/browser/ui/webui/settings/brave_clear_browsing_data_handler.cc
+++ b/browser/ui/webui/settings/brave_clear_browsing_data_handler.cc
@@ -5,6 +5,8 @@
 
 #include "brave/browser/ui/webui/settings/brave_clear_browsing_data_handler.h"
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "base/functional/bind.h"
 #include "base/functional/callback_helpers.h"
 #include "brave/browser/brave_ads/ads_service_factory.h"

--- a/browser/ui/webui/settings/brave_default_extensions_handler.cc
+++ b/browser/ui/webui/settings/brave_default_extensions_handler.cc
@@ -8,6 +8,7 @@
 #include <memory>
 #include <string>
 
+#include "base/check_op.h"
 #include "base/functional/bind.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/values.h"

--- a/browser/ui/webui/settings/brave_extensions_manifest_v2_handler.cc
+++ b/browser/ui/webui/settings/brave_extensions_manifest_v2_handler.cc
@@ -10,6 +10,8 @@
 #include <string>
 #include <utility>
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "brave/browser/extensions/manifest_v2/brave_extensions_manifest_v2_installer.h"
 #include "brave/grit/brave_generated_resources.h"
 #include "chrome/browser/extensions/webstore_install_with_prompt.h"

--- a/browser/ui/webui/settings/brave_import_bulk_data_handler.cc
+++ b/browser/ui/webui/settings/brave_import_bulk_data_handler.cc
@@ -12,6 +12,8 @@
 #include <utility>
 #include <vector>
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "base/files/file_path.h"
 #include "base/files/file_util.h"
 #include "base/functional/bind.h"

--- a/browser/ui/webui/settings/brave_import_data_handler.cc
+++ b/browser/ui/webui/settings/brave_import_data_handler.cc
@@ -9,6 +9,8 @@
 #include <string>
 #include <utility>
 
+#include "base/check.h"
+#include "base/logging.h"
 #include "brave/browser/importer/brave_external_process_importer_host.h"
 #include "chrome/browser/importer/importer_list.h"
 #include "chrome/browser/importer/profile_writer.h"

--- a/browser/ui/webui/settings/brave_importer_observer.cc
+++ b/browser/ui/webui/settings/brave_importer_observer.cc
@@ -7,7 +7,7 @@
 
 #include <utility>
 
-#include "base/logging.h"
+#include "base/check.h"
 #include "chrome/browser/importer/external_process_importer_host.h"
 
 BraveImporterObserver::BraveImporterObserver(

--- a/browser/ui/webui/settings/brave_importer_observer_unittest.cc
+++ b/browser/ui/webui/settings/brave_importer_observer_unittest.cc
@@ -8,7 +8,6 @@
 #include <memory>
 #include <utility>
 
-#include "base/logging.h"
 #include "base/test/bind.h"
 #include "base/test/values_test_util.h"
 #include "brave/browser/importer/brave_external_process_importer_host.h"

--- a/browser/ui/webui/settings/brave_privacy_handler.cc
+++ b/browser/ui/webui/settings/brave_privacy_handler.cc
@@ -5,6 +5,8 @@
 
 #include "brave/browser/ui/webui/settings/brave_privacy_handler.h"
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "base/functional/bind.h"
 #include "base/values.h"
 #include "brave/components/ai_chat/core/browser/utils.h"

--- a/browser/ui/webui/settings/brave_search_engines_handler.cc
+++ b/browser/ui/webui/settings/brave_search_engines_handler.cc
@@ -8,6 +8,8 @@
 #include <string>
 #include <utility>
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "base/functional/bind.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/values.h"

--- a/browser/ui/webui/settings/brave_settings_leo_assistant_handler.cc
+++ b/browser/ui/webui/settings/brave_settings_leo_assistant_handler.cc
@@ -9,6 +9,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/check.h"
 #include "base/containers/contains.h"
 #include "brave/browser/ai_chat/ai_chat_service_factory.h"
 #include "brave/browser/brave_browser_process.h"

--- a/browser/ui/webui/settings/brave_site_settings_handler.cc
+++ b/browser/ui/webui/settings/brave_site_settings_handler.cc
@@ -7,6 +7,7 @@
 
 #include <string>
 
+#include "base/check_op.h"
 #include "base/values.h"
 #include "brave/components/brave_shields/content/browser/brave_shields_util.h"
 #include "chrome/browser/content_settings/host_content_settings_map_factory.h"

--- a/browser/ui/webui/settings/brave_sync_handler.cc
+++ b/browser/ui/webui/settings/brave_sync_handler.cc
@@ -10,7 +10,11 @@
 #include <utility>
 #include <vector>
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "base/functional/bind.h"
+#include "base/logging.h"
+#include "base/notreached.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/types/cxx23_to_underlying.h"
 #include "brave/components/brave_sync/brave_sync_prefs.h"

--- a/browser/ui/webui/settings/brave_tor_handler.cc
+++ b/browser/ui/webui/settings/brave_tor_handler.cc
@@ -12,6 +12,8 @@
 #include <vector>
 
 #include "base/base64.h"
+#include "base/check.h"
+#include "base/check_op.h"
 #include "base/functional/bind.h"
 #include "base/functional/callback.h"
 #include "base/json/json_writer.h"

--- a/browser/ui/webui/settings/brave_tor_snowflake_extension_handler.cc
+++ b/browser/ui/webui/settings/brave_tor_snowflake_extension_handler.cc
@@ -8,6 +8,8 @@
 #include <memory>
 #include <string>
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "base/memory/scoped_refptr.h"
 #include "brave/components/tor/pref_names.h"
 #include "chrome/browser/browser_process.h"

--- a/browser/ui/webui/settings/brave_vpn/brave_vpn_handler.cc
+++ b/browser/ui/webui/settings/brave_vpn/brave_vpn_handler.cc
@@ -7,6 +7,7 @@
 
 #include <memory>
 
+#include "base/check.h"
 #include "base/command_line.h"
 #include "base/files/file_path.h"
 #include "base/path_service.h"

--- a/browser/ui/webui/settings/brave_wallet_handler.cc
+++ b/browser/ui/webui/settings/brave_wallet_handler.cc
@@ -10,8 +10,9 @@
 #include <utility>
 #include <vector>
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "base/functional/bind.h"
-#include "base/notreached.h"
 #include "base/values.h"
 #include "brave/browser/brave_wallet/brave_wallet_service_factory.h"
 #include "brave/components/brave_wallet/browser/blockchain_registry.h"

--- a/browser/ui/webui/settings/default_brave_shields_handler.cc
+++ b/browser/ui/webui/settings/default_brave_shields_handler.cc
@@ -7,6 +7,8 @@
 
 #include <utility>
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "base/functional/bind.h"
 #include "base/values.h"
 #include "brave/browser/webcompat_reporter/webcompat_reporter_service_factory.h"

--- a/browser/ui/webui/settings/pin_shortcut_handler.cc
+++ b/browser/ui/webui/settings/pin_shortcut_handler.cc
@@ -5,6 +5,7 @@
 
 #include "brave/browser/ui/webui/settings/pin_shortcut_handler.h"
 
+#include "base/check.h"
 #include "base/functional/bind.h"
 #include "brave/browser/brave_shell_integration.h"
 #include "chrome/browser/profiles/profile.h"

--- a/browser/ui/webui/skus_internals_ui.cc
+++ b/browser/ui/webui/skus_internals_ui.cc
@@ -9,11 +9,13 @@
 #include <string_view>
 #include <utility>
 
+#include "base/check.h"
 #include "base/files/file_util.h"
 #include "base/functional/bind.h"
 #include "base/json/json_reader.h"
 #include "base/json/json_writer.h"
-#include "base/notreached.h"
+#include "base/logging.h"
+#include "base/notimplemented.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/task/thread_pool.h"
 #include "brave/browser/brave_browser_process.h"

--- a/browser/ui/webui/speedreader/speedreader_toolbar_data_handler_impl.cc
+++ b/browser/ui/webui/speedreader/speedreader_toolbar_data_handler_impl.cc
@@ -8,6 +8,7 @@
 #include <memory>
 #include <utility>
 
+#include "base/check.h"
 #include "brave/browser/brave_browser_features.h"
 #include "brave/browser/speedreader/speedreader_service_factory.h"
 #include "brave/browser/speedreader/speedreader_tab_helper.h"

--- a/browser/ui/webui/tor_internals_ui.cc
+++ b/browser/ui/webui/tor_internals_ui.cc
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include "base/check_op.h"
 #include "brave/browser/ui/webui/brave_webui_source.h"
 #include "brave/components/tor/resources/grit/tor_internals_generated_map.h"
 #include "brave/components/tor/resources/grit/tor_resources.h"

--- a/browser/ui/webui/webcompat_reporter/webcompat_reporter_dialog.cc
+++ b/browser/ui/webui/webcompat_reporter/webcompat_reporter_dialog.cc
@@ -12,7 +12,9 @@
 #include <utility>
 #include <vector>
 
+#include "base/check.h"
 #include "base/json/json_writer.h"
+#include "base/notreached.h"
 #include "base/values.h"
 #include "brave/browser/brave_shields/brave_shields_tab_helper.h"
 #include "brave/browser/webcompat_reporter/webcompat_reporter_service_factory.h"

--- a/browser/ui/webui/webcompat_reporter/webcompat_reporter_ui.cc
+++ b/browser/ui/webui/webcompat_reporter/webcompat_reporter_ui.cc
@@ -12,8 +12,11 @@
 #include <vector>
 
 #include "base/base64.h"
+#include "base/check.h"
+#include "base/check_op.h"
 #include "base/debug/dump_without_crashing.h"
 #include "base/functional/bind.h"
+#include "base/logging.h"
 #include "base/metrics/histogram_macros.h"
 #include "base/task/sequenced_task_runner.h"
 #include "base/task/thread_pool.h"

--- a/browser/ui/webui/welcome_page/brave_welcome_ui.cc
+++ b/browser/ui/webui/welcome_page/brave_welcome_ui.cc
@@ -9,6 +9,7 @@
 #include <memory>
 #include <string>
 
+#include "base/check.h"
 #include "base/feature_list.h"
 #include "base/memory/raw_ptr.h"
 #include "base/task/single_thread_task_runner.h"

--- a/browser/ui/webui/welcome_page/welcome_dom_handler.cc
+++ b/browser/ui/webui/welcome_page/welcome_dom_handler.cc
@@ -7,6 +7,8 @@
 
 #include <algorithm>
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "base/feature_list.h"
 #include "base/metrics/histogram_macros.h"
 #include "base/strings/string_util.h"

--- a/browser/ui/whats_new/whats_new_util.cc
+++ b/browser/ui/whats_new/whats_new_util.cc
@@ -10,7 +10,11 @@
 #include <optional>
 #include <string>
 
+#include "base/check.h"
+#include "base/check_op.h"
+#include "base/logging.h"
 #include "base/metrics/field_trial_params.h"
+#include "base/notreached.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/stringprintf.h"
 #include "base/version.h"

--- a/browser/ui/window_closing_confirm_browsertest.cc
+++ b/browser/ui/window_closing_confirm_browsertest.cc
@@ -3,6 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include "base/check.h"
 #include "base/functional/bind.h"
 #include "base/run_loop.h"
 #include "brave/browser/ui/brave_browser.h"


### PR DESCRIPTION
This change is one of many fixing inclusion for the following files:

    - `base/notimplemented.h`
    - `base/notreached.h`
    - `base/check.h`
    - `base/dcheck_is_on.h`
    - `base/check_deref.h`
    - `base/check_op.h`
    - `base/logging/log_severity.h`
    - `base/logging.h`

This change is a mechanical change done with the following script:
https://github.com/brave/brave-browser/issues/46707#issuecomment-2960116515

Resolves https://github.com/brave/brave-browser/issues/46707
