### PR TITLE
[IWYU] Fixing logging inclusions pt.10

### DIFF
--- a/chromium_src/base/feature_list.cc
+++ b/chromium_src/base/feature_list.cc
@@ -8,11 +8,12 @@
 #include <algorithm>
 #include <optional>
 
+#include "base/check.h"
 #include "base/check_op.h"
 #include "base/containers/flat_map.h"
 #include "base/containers/flat_set.h"
+#include "base/dcheck_is_on.h"
 #include "base/feature_override.h"
-#include "base/logging.h"
 #include "base/no_destructor.h"
 
 namespace base {

--- a/chromium_src/base/logging/rust_log_integration.cc
+++ b/chromium_src/base/logging/rust_log_integration.cc
@@ -5,6 +5,8 @@
 
 #include "base/logging/rust_log_integration.h"
 
+#include "base/logging.h"
+
 #define print_rust_log print_rust_log_chromium_impl
 #include "src/base/logging/rust_log_integration.cc"
 #undef print_rust_log

--- a/chromium_src/chrome/browser/autocomplete/chrome_autocomplete_provider_client.cc
+++ b/chromium_src/chrome/browser/autocomplete/chrome_autocomplete_provider_client.cc
@@ -5,6 +5,7 @@
 
 #include "src/chrome/browser/autocomplete/chrome_autocomplete_provider_client.cc"
 
+#include "base/check.h"
 #include "brave/browser/ai_chat/ai_chat_service_factory.h"
 #include "brave/browser/ai_chat/ai_chat_urls.h"
 #include "brave/components/ai_chat/content/browser/ai_chat_tab_helper.h"

--- a/chromium_src/chrome/browser/bookmarks/android/bookmark_bridge.cc
+++ b/chromium_src/chrome/browser/bookmarks/android/bookmark_bridge.cc
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include "base/check.h"
 #include "base/task/thread_pool.h"
 #include "base/threading/thread.h"
 #include "chrome/browser/bookmarks/bookmark_html_writer.h"

--- a/chromium_src/chrome/browser/download/bubble/download_display_controller.cc
+++ b/chromium_src/chrome/browser/download/bubble/download_display_controller.cc
@@ -7,8 +7,10 @@
 
 #define DownloadDisplayController DownloadDisplayControllerChromium
 
+#include "base/check.h"
 #include "chrome/browser/download/bubble/download_bubble_display_info.h"
 #include "chrome/browser/ui/web_applications/app_browser_controller.h"
+
 #include "src/chrome/browser/download/bubble/download_display_controller.cc"
 
 #undef DownloadDisplayController

--- a/chromium_src/chrome/browser/download/download_file_picker.cc
+++ b/chromium_src/chrome/browser/download/download_file_picker.cc
@@ -5,6 +5,7 @@
 
 #include <string>
 
+#include "base/check.h"
 #include "components/download/public/common/download_item.h"
 #include "content/public/browser/render_frame_host.h"
 #include "content/public/browser/web_contents.h"

--- a/chromium_src/chrome/browser/download/download_ui_controller.cc
+++ b/chromium_src/chrome/browser/download/download_ui_controller.cc
@@ -3,6 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include "base/check_op.h"
 #include "chrome/browser/download/bubble/download_bubble_prefs.h"
 #include "chrome/browser/download/download_stats.h"
 #include "chrome/common/pref_names.h"

--- a/chromium_src/chrome/browser/extensions/api/identity/identity_get_auth_token_function.cc
+++ b/chromium_src/chrome/browser/extensions/api/identity/identity_get_auth_token_function.cc
@@ -3,9 +3,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include "chrome/browser/extensions/api/identity/identity_get_auth_token_function.h"
+
 #include <optional>
 
-#include "chrome/browser/extensions/api/identity/identity_get_auth_token_function.h"
+#include "base/check.h"
 #include "chrome/browser/extensions/api/identity/identity_token_cache.h"
 #include "google_apis/google_api_keys.h"
 

--- a/chromium_src/chrome/browser/importer/importer_list.cc
+++ b/chromium_src/chrome/browser/importer/importer_list.cc
@@ -5,6 +5,7 @@
 
 #include "chrome/browser/importer/importer_list.h"
 
+#include "base/check.h"
 #include "base/files/file_path.h"
 #include "base/strings/strcat.h"
 #include "base/strings/utf_string_conversions.h"

--- a/chromium_src/chrome/browser/media/router/media_router_feature.cc
+++ b/chromium_src/chrome/browser/media/router/media_router_feature.cc
@@ -5,6 +5,7 @@
 
 #include "chrome/browser/media/router/media_router_feature.h"
 
+#include "base/check.h"
 #include "build/build_config.h"
 #include "content/public/browser/browser_context.h"
 

--- a/chromium_src/chrome/browser/net/proxy_config_monitor.cc
+++ b/chromium_src/chrome/browser/net/proxy_config_monitor.cc
@@ -5,6 +5,7 @@
 
 #include <memory>
 
+#include "base/check.h"
 #include "brave/components/tor/buildflags/buildflags.h"
 #include "chrome/browser/profiles/profile.h"
 

--- a/chromium_src/chrome/browser/prefs/browser_prefs.cc
+++ b/chromium_src/chrome/browser/prefs/browser_prefs.cc
@@ -3,6 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include "base/check.h"
 #include "brave/browser/brave_local_state_prefs.h"
 #include "brave/browser/brave_profile_prefs.h"
 #include "brave/browser/brave_rewards/rewards_prefs_util.h"

--- a/chromium_src/chrome/browser/profiles/delete_profile_helper.cc
+++ b/chromium_src/chrome/browser/profiles/delete_profile_helper.cc
@@ -5,15 +5,12 @@
 
 #include <string_view>
 
+#include "base/logging.h"
 #include "brave/components/sync/service/brave_sync_service_impl.h"
-#include "chrome/browser/sync/sync_service_factory.h"
-#include "components/sync/service/sync_user_settings.h"
-
-// Include to prevent redefining HasPrimaryAccount method at the header
-#include "components/signin/public/identity_manager/identity_manager.h"
-
-// Include to prevent redefining IdentityManager method at the header
 #include "chrome/browser/signin/identity_manager_factory.h"
+#include "chrome/browser/sync/sync_service_factory.h"
+#include "components/signin/public/identity_manager/identity_manager.h"
+#include "components/sync/service/sync_user_settings.h"
 
 class Profile;
 

--- a/chromium_src/chrome/browser/profiles/profile_attributes_entry.cc
+++ b/chromium_src/chrome/browser/profiles/profile_attributes_entry.cc
@@ -5,6 +5,7 @@
 
 #include "chrome/browser/profiles/profile_attributes_entry.h"
 
+#include "base/check.h"
 #include "chrome/browser/profiles/profile_avatar_icon_util.h"
 
 void ProfileAttributesEntry::BraveMigrateObsoleteProfileAttributes() {

--- a/chromium_src/chrome/browser/profiles/profile_avatar_icon_util.cc
+++ b/chromium_src/chrome/browser/profiles/profile_avatar_icon_util.cc
@@ -7,6 +7,7 @@
 
 #include <array>
 
+#include "base/check_op.h"
 #include "base/values.h"
 #include "brave/app/vector_icons/vector_icons.h"
 #include "brave/grit/brave_generated_resources.h"

--- a/chromium_src/chrome/browser/renderer_context_menu/render_view_context_menu.cc
+++ b/chromium_src/chrome/browser/renderer_context_menu/render_view_context_menu.cc
@@ -7,9 +7,11 @@
 
 #include <optional>
 
+#include "base/check.h"
 #include "base/containers/fixed_flat_map.h"
 #include "base/containers/fixed_flat_set.h"
 #include "base/feature_list.h"
+#include "base/logging.h"
 #include "brave/browser/autocomplete/brave_autocomplete_scheme_classifier.h"
 #include "brave/browser/brave_shields/brave_shields_tab_helper.h"
 #include "brave/browser/cosmetic_filters/cosmetic_filters_tab_helper.h"

--- a/chromium_src/chrome/browser/shell_integration.cc
+++ b/chromium_src/chrome/browser/shell_integration.cc
@@ -3,6 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include "base/notreached.h"
 #include "build/build_config.h"
 #include "ui/base/l10n/l10n_util.h"
 

--- a/chromium_src/chrome/browser/web_applications/os_integration/mac/apps_folder_support.mm
+++ b/chromium_src/chrome/browser/web_applications/os_integration/mac/apps_folder_support.mm
@@ -3,9 +3,11 @@
   * License, v. 2.0. If a copy of the MPL was not distributed with this file,
   * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-namespace base {
-class FilePath;
-}  // namespace base
+#include "base/notreached.h"
+
+ namespace base {
+ class FilePath;
+ }  // namespace base
 
 namespace {
 base::FilePath GetLocalizableBraveAppShortcutsSubdirName();

--- a/chromium_src/chrome/common/media/cdm_host_file_path.cc
+++ b/chromium_src/chrome/common/media/cdm_host_file_path.cc
@@ -7,7 +7,6 @@
 
 #include "base/files/file_path.h"
 #include "base/files/file_util.h"
-#include "base/logging.h"
 #include "base/path_service.h"
 #include "base/stl_util.h"
 #include "build/branding_buildflags.h"

--- a/chromium_src/chrome/installer/setup/brave_behaviors.cc
+++ b/chromium_src/chrome/installer/setup/brave_behaviors.cc
@@ -3,13 +3,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#include "chrome/installer/setup/brand_behaviors.h"
-
 #include <string_view>
 
+#include "base/check_op.h"
+#include "base/dcheck_is_on.h"
 #include "base/strings/strcat.h"
 #include "base/strings/stringprintf.h"
 #include "base/strings/utf_string_conversions.h"
+#include "chrome/installer/setup/brand_behaviors.h"
 
 #define DoPostUninstallOperations DoPostUninstallOperations_UNUSED
 #include "src/chrome/installer/setup/google_chrome_behaviors.cc"

--- a/chromium_src/chrome/renderer/media/chrome_key_systems.cc
+++ b/chromium_src/chrome/renderer/media/chrome_key_systems.cc
@@ -3,6 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include "base/check.h"
 #include "third_party/widevine/cdm/buildflags.h"
 
 #if !BUILDFLAG(ENABLE_WIDEVINE)

--- a/chromium_src/chrome/renderer/worker_content_settings_client.cc
+++ b/chromium_src/chrome/renderer/worker_content_settings_client.cc
@@ -7,8 +7,10 @@
 
 #include <optional>
 
+#include "base/check.h"
 #include "base/debug/crash_logging.h"
 #include "base/debug/dump_without_crashing.h"
+#include "base/logging.h"
 #include "brave/components/brave_shields/core/common/brave_shield_utils.h"
 #include "brave/components/content_settings/renderer/brave_content_settings_agent_impl.h"
 #include "components/content_settings/renderer/content_settings_agent_impl.h"

--- a/chromium_src/chrome/test/base/chrome_test_suite.cc
+++ b/chromium_src/chrome/test/base/chrome_test_suite.cc
@@ -8,6 +8,9 @@
 #include <algorithm>
 #include <string_view>
 
+#include "base/check.h"
+#include "base/dcheck_is_on.h"
+#include "base/logging.h"
 #include "base/strings/string_util.h"
 
 #define ChromeTestSuite ChromeTestSuite_ChromiumImpl

--- a/chromium_src/components/component_updater/component_installer.cc
+++ b/chromium_src/components/component_updater/component_installer.cc
@@ -5,6 +5,8 @@
 
 #include "components/component_updater/component_installer.h"
 
+#include "base/check.h"
+#include "base/logging.h"
 #include "build/build_config.h"
 
 #define Register Register_ChromiumImpl

--- a/chromium_src/components/content_settings/core/browser/content_settings_utils.cc
+++ b/chromium_src/components/content_settings/core/browser/content_settings_utils.cc
@@ -7,6 +7,8 @@
 
 #include <iostream>
 
+#include "base/check.h"
+
 #define GetRendererContentSettingRules \
   GetRendererContentSettingRules_ChromiumImpl
 

--- a/chromium_src/components/content_settings/core/browser/cookie_settings.cc
+++ b/chromium_src/components/content_settings/core/browser/cookie_settings.cc
@@ -3,9 +3,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include "components/content_settings/core/browser/cookie_settings.h"
+
 #include <optional>
 
-#include "components/content_settings/core/browser/cookie_settings.h"
+#include "base/check.h"
 #include "net/base/features.h"
 #include "net/base/url_util.h"
 

--- a/chromium_src/components/content_settings/core/common/content_settings.cc
+++ b/chromium_src/components/content_settings/core/common/content_settings.cc
@@ -7,6 +7,8 @@
 
 #include <vector>
 
+#include "base/check.h"
+
 #define RendererContentSettingRules RendererContentSettingRules_ChromiumImpl
 
 #include "src/components/content_settings/core/common/content_settings.cc"

--- a/chromium_src/components/content_settings/core/common/cookie_settings_base.cc
+++ b/chromium_src/components/content_settings/core/common/cookie_settings_base.cc
@@ -8,6 +8,7 @@
 #include <optional>
 
 #include "base/auto_reset.h"
+#include "base/check.h"
 #include "base/compiler_specific.h"
 #include "base/feature_list.h"
 #include "base/no_destructor.h"

--- a/chromium_src/components/crx_file/crx_creator.cc
+++ b/chromium_src/components/crx_file/crx_creator.cc
@@ -5,6 +5,8 @@
 
 #include "components/crx_file/crx_creator.h"
 
+#include "base/check.h"
+
 namespace crx_file {
 
 class CrxFileHeader;

--- a/chromium_src/components/history/core/browser/url_database.cc
+++ b/chromium_src/components/history/core/browser/url_database.cc
@@ -3,6 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
+#include "base/check.h"
 #include "base/time/time.h"
 #include "components/history/core/browser/features.h"
 

--- a/chromium_src/components/omnibox/browser/autocomplete_controller.cc
+++ b/chromium_src/components/omnibox/browser/autocomplete_controller.cc
@@ -9,6 +9,7 @@
 #include <memory>
 #include <vector>
 
+#include "base/check.h"
 #include "base/memory/scoped_refptr.h"
 #include "brave/components/ai_chat/core/browser/utils.h"
 #include "brave/components/ai_chat/core/common/features.h"

--- a/chromium_src/components/os_crypt/sync/key_storage_linux.cc
+++ b/chromium_src/components/os_crypt/sync/key_storage_linux.cc
@@ -5,6 +5,8 @@
 
 #include "components/os_crypt/sync/key_storage_linux.h"
 
+#include "base/logging.h"
+
 #define BRAVE_KEY_STORAGE_LINUX                             \
   const char KeyStorageLinux::kFolderName[] = "Brave Keys"; \
   const char KeyStorageLinux::kKey[] = "Brave Safe Storage";

--- a/chromium_src/components/permissions/android/permission_prompt/permission_dialog_delegate.cc
+++ b/chromium_src/components/permissions/android/permission_prompt/permission_dialog_delegate.cc
@@ -8,6 +8,9 @@
       JNIEnv* env, const base::android::JavaRef<jobject>& obj); \
   virtual void CreateJavaDelegate
 #include "components/permissions/android/permission_prompt/permission_dialog_delegate.h"
+
+#include "base/check.h"
+#include "base/notreached.h"
 #undef CreateJavaDelegate
 
 #include "base/android/jni_array.h"

--- a/chromium_src/components/permissions/permission_context_base.cc
+++ b/chromium_src/components/permissions/permission_context_base.cc
@@ -4,6 +4,8 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "components/permissions/permission_context_base.h"
+
+#include "base/check.h"
 #include "components/permissions/permissions_client.h"
 
 #define PermissionContextBase PermissionContextBase_ChromiumImpl

--- a/chromium_src/components/permissions/permission_request.cc
+++ b/chromium_src/components/permissions/permission_request.cc
@@ -8,8 +8,10 @@
 #include <optional>
 #include <vector>
 
+#include "base/check.h"
 #include "base/containers/contains.h"
 #include "base/containers/fixed_flat_set.h"
+#include "base/notreached.h"
 #include "build/build_config.h"
 #include "components/grit/brave_components_strings.h"
 #include "components/strings/grit/components_strings.h"

--- a/chromium_src/components/permissions/permission_request_manager.cc
+++ b/chromium_src/components/permissions/permission_request_manager.cc
@@ -5,6 +5,7 @@
 
 #include <string>
 
+#include "base/check.h"
 #include "base/containers/contains.h"
 #include "brave/components/brave_wallet/browser/permission_utils.h"
 

--- a/chromium_src/components/regional_capabilities/regional_capabilities_utils.cc
+++ b/chromium_src/components/regional_capabilities/regional_capabilities_utils.cc
@@ -5,6 +5,8 @@
 
 #include "components/regional_capabilities/regional_capabilities_utils.h"
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "base/containers/fixed_flat_map.h"
 #include "base/containers/flat_map.h"
 #include "base/containers/span.h"

--- a/chromium_src/components/remote_cocoa/app_shim/native_widget_ns_window_bridge.mm
+++ b/chromium_src/components/remote_cocoa/app_shim/native_widget_ns_window_bridge.mm
@@ -3,9 +3,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#include "skia/ext/skia_utils_mac.h"
-
 #include "src/components/remote_cocoa/app_shim/native_widget_ns_window_bridge.mm"
+
+#include "base/check.h"
+#include "base/logging.h"
+#include "skia/ext/skia_utils_mac.h"
 
 namespace {
 NSColor* g_brave_title_color = nil;

--- a/chromium_src/components/search_engines/util.cc
+++ b/chromium_src/components/search_engines/util.cc
@@ -5,7 +5,6 @@
 
 #include <algorithm>
 
-#include "base/check_deref.h"
 #include "base/containers/adapters.h"
 
 #define GetSearchProvidersUsingKeywordResult \

--- a/chromium_src/components/sync/engine/sync_scheduler_impl.cc
+++ b/chromium_src/components/sync/engine/sync_scheduler_impl.cc
@@ -7,7 +7,9 @@
   HandleBraveConfigurationFailure(model_neutral_state);
 
 #include "src/components/sync/engine/sync_scheduler_impl.cc"
+
 #include "base/functional/callback_forward.h"
+#include "base/logging.h"
 
 #undef BRAVE_SYNC_SCHEDULER_IMPL_HANDLE_FAILURE
 

--- a/chromium_src/components/sync/service/glue/sync_engine_impl.cc
+++ b/chromium_src/components/sync/service/glue/sync_engine_impl.cc
@@ -5,6 +5,7 @@
 
 #include "src/components/sync/service/glue/sync_engine_impl.cc"
 
+#include "base/check.h"
 #include "base/task/bind_post_task.h"
 
 namespace syncer {

--- a/chromium_src/components/sync/service/sync_internals_util.cc
+++ b/chromium_src/components/sync/service/sync_internals_util.cc
@@ -5,6 +5,7 @@
 
 #include "components/sync/service/sync_internals_util.h"
 
+#include "base/check_op.h"
 #include "brave/components/sync/service/brave_sync_service_impl.h"
 #include "components/os_crypt/sync/os_crypt.h"
 

--- a/chromium_src/components/sync/service/sync_service_impl.cc
+++ b/chromium_src/components/sync/service/sync_service_impl.cc
@@ -3,6 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include "base/logging.h"
 #include "brave/components/brave_sync/brave_sync_prefs.h"
 #include "brave/components/sync/service/brave_sync_auth_manager.h"
 #include "brave/components/sync/service/brave_sync_stopped_reporter.h"

--- a/chromium_src/components/sync_device_info/device_info_sync_bridge.cc
+++ b/chromium_src/components/sync_device_info/device_info_sync_bridge.cc
@@ -5,6 +5,7 @@
 
 #include "components/sync_device_info/device_info_sync_bridge.h"
 
+#include "base/logging.h"
 #include "brave/components/sync_device_info/brave_device_info.h"
 #include "components/sync/base/deletion_origin.h"
 

--- a/chromium_src/components/update_client/update_checker.cc
+++ b/chromium_src/components/update_client/update_checker.cc
@@ -8,6 +8,8 @@
 #include <algorithm>
 #include <optional>
 
+#include "base/check.h"
+#include "base/logging.h"
 #include "components/update_client/update_client.h"
 
 #include "src/components/update_client/update_checker.cc"

--- a/chromium_src/components/update_client/update_client.cc
+++ b/chromium_src/components/update_client/update_client.cc
@@ -5,6 +5,8 @@
 
 #include "components/update_client/update_client.h"
 
+#include "base/logging.h"
+
 #define UpdateClientFactory UpdateClientFactory_ChromiumImpl
 #include "src/components/update_client/update_client.cc"
 #undef UpdateClientFactory

--- a/chromium_src/components/variations/variations_seed_store.cc
+++ b/chromium_src/components/variations/variations_seed_store.cc
@@ -6,6 +6,7 @@
 #include "components/variations/variations_seed_store.h"
 
 #include "base/check_is_test.h"
+#include "base/check_op.h"
 #include "crypto/signature_verifier.h"
 
 namespace variations {

--- a/chromium_src/components/webui/flags/flags_state.cc
+++ b/chromium_src/components/webui/flags/flags_state.cc
@@ -8,6 +8,8 @@
 #include <algorithm>
 #include <string_view>
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "base/strings/strcat.h"
 
 #include "src/components/webui/flags/flags_state.cc"

--- a/chromium_src/content/browser/browser_context.cc
+++ b/chromium_src/content/browser/browser_context.cc
@@ -3,9 +3,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include "content/public/browser/browser_context.h"
+
 #include <optional>
 #include <string>
 
+#include "base/check.h"
 #include "base/memory/ref_counted.h"
 #include "content/browser/blob_storage/chrome_blob_storage_context.h"
 #include "content/browser/dom_storage/dom_storage_context_wrapper.h"
@@ -13,7 +16,6 @@
 #include "content/browser/renderer_host/navigation_controller_impl.h"
 #include "content/browser/renderer_host/render_view_host_delegate.h"
 #include "content/browser/site_instance_impl.h"
-#include "content/public/browser/browser_context.h"
 #include "content/public/browser/render_view_host.h"
 #include "content/public/browser/session_storage_namespace.h"
 #include "content/public/browser/storage_partition.h"

--- a/chromium_src/content/browser/picture_in_picture/video_picture_in_picture_window_controller_impl.cc
+++ b/chromium_src/content/browser/picture_in_picture/video_picture_in_picture_window_controller_impl.cc
@@ -3,6 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include "base/check.h"
 #include "content/public/browser/overlay_window.h"
 #include "third_party/blink/public/mojom/mediasession/media_session.mojom.h"
 

--- a/chromium_src/content/browser/renderer_host/render_frame_host_impl.cc
+++ b/chromium_src/content/browser/renderer_host/render_frame_host_impl.cc
@@ -5,6 +5,9 @@
 
 #include "content/browser/renderer_host/render_frame_host_impl.h"
 
+#include "base/check.h"
+#include "base/logging.h"
+
 #define BRAVE_RENDER_FRAME_HOST_IMPL_COMPUTE_ISOLATION_INFO_INTERNAL \
   SetEphemeralStorageToken(top_frame_origin);
 

--- a/chromium_src/content/browser/webui/shared_resources_data_source.cc
+++ b/chromium_src/content/browser/webui/shared_resources_data_source.cc
@@ -6,6 +6,7 @@
 #include <string>
 #include <vector>
 
+#include "base/check.h"
 #include "base/functional/bind.h"
 #include "base/memory/ref_counted_memory.h"
 #include "base/no_destructor.h"

--- a/chromium_src/crypto/kdf.h
+++ b/chromium_src/crypto/kdf.h
@@ -6,6 +6,8 @@
 #ifndef BRAVE_CHROMIUM_SRC_CRYPTO_KDF_H_
 #define BRAVE_CHROMIUM_SRC_CRYPTO_KDF_H_
 
+#include "base/check_op.h"
+
 #include "src/crypto/kdf.h"  // IWYU pragma: export
 
 namespace crypto::kdf {

--- a/chromium_src/net/cookies/cookie_options.cc
+++ b/chromium_src/net/cookies/cookie_options.cc
@@ -3,10 +3,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include "net/cookies/cookie_options.h"
+
 #include <optional>
 
+#include "base/check.h"
 #include "net/cookies/cookie_access_delegate.h"
-#include "net/cookies/cookie_options.h"
 
 #define CookieOptions CookieOptions_ChromiumImpl
 #include "src/net/cookies/cookie_options.cc"

--- a/chromium_src/net/http/transport_security_state.cc
+++ b/chromium_src/net/http/transport_security_state.cc
@@ -7,6 +7,7 @@
 
 #include <optional>
 
+#include "base/check.h"
 #include "base/strings/strcat.h"
 #include "build/build_config.h"
 #include "net/base/network_anonymization_key.h"

--- a/chromium_src/net/socket/socks5_client_socket.cc
+++ b/chromium_src/net/socket/socks5_client_socket.cc
@@ -23,6 +23,10 @@
   next_state_ = STATE_AUTH;
 
 #include "src/net/socket/socks5_client_socket.cc"
+
+#include "base/check.h"
+#include "base/check_op.h"
+#include "base/notreached.h"
 #undef BRAVE_SOCKS5_CLIENT_SOCKET_DO_GREET_READ_COMPLETE_2
 #undef BRAVE_SOCKS5_CLIENT_SOCKET_DO_GREET_READ_COMPLETE_1
 #undef BRAVE_SOCKS5_CLIENT_SOCKET_DO_GREET_WRITE

--- a/chromium_src/third_party/blink/common/origin_trials/origin_trials.cc
+++ b/chromium_src/third_party/blink/common/origin_trials/origin_trials.cc
@@ -7,6 +7,7 @@
 
 #include <string_view>
 
+#include "base/check.h"
 #include "base/containers/fixed_flat_set.h"
 
 namespace blink::origin_trials {

--- a/chromium_src/third_party/blink/renderer/bindings/core/v8/referrer_script_info.cc
+++ b/chromium_src/third_party/blink/renderer/bindings/core/v8/referrer_script_info.cc
@@ -5,6 +5,8 @@
 
 #include "third_party/blink/renderer/bindings/core/v8/referrer_script_info.h"
 
+#include "base/check_op.h"
+
 #if BUILDFLAG(ENABLE_BRAVE_PAGE_GRAPH)
 #define FromV8HostDefinedOptions FromV8HostDefinedOptions_ChromiumImpl
 #define ToV8HostDefinedOptions ToV8HostDefinedOptions_ChromiumImpl

--- a/chromium_src/third_party/blink/renderer/core/clipboard/system_clipboard.cc
+++ b/chromium_src/third_party/blink/renderer/core/clipboard/system_clipboard.cc
@@ -3,9 +3,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-#include "third_party/blink/renderer/core/clipboard/system_clipboard.h"
-
 #include "src/third_party/blink/renderer/core/clipboard/system_clipboard.cc"
+
+#include "base/check.h"
+#include "third_party/blink/renderer/core/clipboard/system_clipboard.h"
 
 namespace blink {
 

--- a/chromium_src/third_party/blink/renderer/core/dom/events/event_listener_map.cc
+++ b/chromium_src/third_party/blink/renderer/core/dom/events/event_listener_map.cc
@@ -5,6 +5,8 @@
 
 #include "src/third_party/blink/renderer/core/dom/events/event_listener_map.cc"
 
+#include "base/check.h"
+
 #if BUILDFLAG(ENABLE_BRAVE_PAGE_GRAPH)
 #include "third_party/blink/renderer/core/probe/core_probes.h"
 

--- a/chromium_src/third_party/blink/renderer/core/execution_context/navigator_base.cc
+++ b/chromium_src/third_party/blink/renderer/core/execution_context/navigator_base.cc
@@ -6,6 +6,7 @@
 #include "third_party/blink/renderer/core/execution_context/navigator_base.h"
 
 #include "base/compiler_specific.h"
+#include "base/notreached.h"
 #include "base/system/sys_info.h"
 #include "brave/third_party/blink/renderer/core/farbling/brave_session_cache.h"
 #include "third_party/blink/renderer/core/execution_context/execution_context.h"

--- a/chromium_src/third_party/blink/renderer/core/frame/local_frame.cc
+++ b/chromium_src/third_party/blink/renderer/core/frame/local_frame.cc
@@ -5,6 +5,7 @@
 
 #include "third_party/blink/renderer/core/frame/local_frame.h"
 
+#include "base/check.h"
 #include "brave/components/brave_page_graph/common/buildflags.h"
 #include "skia/ext/skia_utils_base.h"
 #include "third_party/blink/renderer/core/core_probe_sink.h"

--- a/chromium_src/third_party/blink/renderer/core/workers/shared_worker_content_settings_proxy.cc
+++ b/chromium_src/third_party/blink/renderer/core/workers/shared_worker_content_settings_proxy.cc
@@ -5,6 +5,7 @@
 
 #include "src/third_party/blink/renderer/core/workers/shared_worker_content_settings_proxy.cc"
 
+#include "base/check.h"
 #include "brave/components/brave_shields/core/common/shields_settings.mojom-blink.h"
 #include "mojo/public/cpp/bindings/string_traits_wtf.h"
 

--- a/chromium_src/third_party/blink/renderer/modules/encryptedmedia/navigator_request_media_key_system_access.cc
+++ b/chromium_src/third_party/blink/renderer/modules/encryptedmedia/navigator_request_media_key_system_access.cc
@@ -19,6 +19,8 @@ void MaybeOnWidevineRequest(MediaKeySystemAccessInitializer* initializer,
   MaybeOnWidevineRequest(initializer, window->GetFrame());
 
 #include "src/third_party/blink/renderer/modules/encryptedmedia/navigator_request_media_key_system_access.cc"
+
+#include "base/check.h"
 #undef BRAVE_NAVIGATOR_REQUEST_MEDIA_KEY_SYSTEM_ACCESS
 
 #include "brave/components/brave_drm/brave_drm.mojom-blink.h"

--- a/chromium_src/third_party/blink/renderer/modules/geolocation/geolocation.cc
+++ b/chromium_src/third_party/blink/renderer/modules/geolocation/geolocation.cc
@@ -3,6 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include "base/check.h"
 #include "build/build_config.h"
 #include "mojo/public/cpp/bindings/associated_remote.h"
 #include "services/device/public/mojom/geolocation.mojom-blink.h"

--- a/chromium_src/third_party/blink/renderer/modules/plugins/dom_plugin_array.cc
+++ b/chromium_src/third_party/blink/renderer/modules/plugins/dom_plugin_array.cc
@@ -5,7 +5,9 @@
 
 #include "third_party/blink/renderer/modules/plugins/dom_plugin_array.h"
 
+#include "base/check_op.h"
 #include "base/compiler_specific.h"
+#include "base/notreached.h"
 #include "base/types/cxx23_to_underlying.h"
 #include "brave/third_party/blink/renderer/core/farbling/brave_session_cache.h"
 #include "third_party/blink/renderer/core/frame/local_dom_window.h"

--- a/chromium_src/third_party/blink/renderer/modules/service_worker/service_worker_content_settings_proxy.cc
+++ b/chromium_src/third_party/blink/renderer/modules/service_worker/service_worker_content_settings_proxy.cc
@@ -5,6 +5,7 @@
 
 #include "src/third_party/blink/renderer/modules/service_worker/service_worker_content_settings_proxy.cc"
 
+#include "base/check.h"
 #include "brave/components/brave_shields/core/common/shields_settings.mojom-blink.h"
 #include "mojo/public/cpp/bindings/string_traits_wtf.h"
 

--- a/chromium_src/third_party/blink/renderer/modules/storage/storage_area.cc
+++ b/chromium_src/third_party/blink/renderer/modules/storage/storage_area.cc
@@ -5,6 +5,7 @@
 
 #include "src/third_party/blink/renderer/modules/storage/storage_area.cc"
 
+#include "base/check.h"
 #include "brave/third_party/blink/renderer/core/brave_page_graph/blink_probe_types.h"
 
 namespace blink {

--- a/chromium_src/third_party/blink/renderer/modules/webgl/webgl2_rendering_context_base.cc
+++ b/chromium_src/third_party/blink/renderer/modules/webgl/webgl2_rendering_context_base.cc
@@ -4,10 +4,12 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "third_party/blink/renderer/modules/webgl/webgl2_rendering_context_base.h"
-#include "brave/third_party/blink/renderer/core/farbling/brave_session_cache.h"
-#include "third_party/blink/renderer/bindings/modules/v8/webgl_any.h"
 
 #include <algorithm>
+
+#include "base/notreached.h"
+#include "brave/third_party/blink/renderer/core/farbling/brave_session_cache.h"
+#include "third_party/blink/renderer/bindings/modules/v8/webgl_any.h"
 
 using blink::ExecutionContext;
 using blink::ScriptState;

--- a/chromium_src/third_party/blink/renderer/platform/fonts/font_fallback_list.cc
+++ b/chromium_src/third_party/blink/renderer/platform/fonts/font_fallback_list.cc
@@ -5,6 +5,7 @@
 
 #include "third_party/blink/renderer/platform/fonts/font_fallback_list.h"
 
+#include "base/check.h"
 #include "base/no_destructor.h"
 #include "third_party/blink/renderer/platform/fonts/font_selector.h"
 #include "third_party/blink/renderer/platform/wtf/text/atomic_string.h"

--- a/chromium_src/third_party/blink/renderer/platform/weborigin/security_origin.h
+++ b/chromium_src/third_party/blink/renderer/platform/weborigin/security_origin.h
@@ -19,6 +19,8 @@
   }                                                                      \
   bool SerializesAsNull
 
+#include "base/check.h"
+
 #include "src/third_party/blink/renderer/platform/weborigin/security_origin.h"  // IWYU pragma: export
 
 #undef SerializesAsNull

--- a/chromium_src/ui/accessibility/platform/ax_platform_node_cocoa.mm
+++ b/chromium_src/ui/accessibility/platform/ax_platform_node_cocoa.mm
@@ -5,6 +5,7 @@
 
 #include "base/debug/alias.h"
 #include "base/debug/dump_without_crashing.h"
+#include "base/logging.h"
 
 // Assumed to be a temporary fix for
 // https://github.com/brave/brave-browser/issues/13778

--- a/chromium_src/ui/views/controls/button/md_text_button.cc
+++ b/chromium_src/ui/views/controls/button/md_text_button.cc
@@ -8,6 +8,7 @@
 #include <optional>
 #include <tuple>
 
+#include "base/check.h"
 #include "base/containers/flat_map.h"
 #include "base/no_destructor.h"
 #include "base/notreached.h"

--- a/chromium_src/ui/views/controls/focus_ring.cc
+++ b/chromium_src/ui/views/controls/focus_ring.cc
@@ -3,6 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // you can obtain one at http://mozilla.org/MPL/2.0/.
 
+#include "base/check.h"
 #include "ui/color/color_id.h"
 #include "ui/color/color_provider.h"
 #include "ui/gfx/color_palette.h"

--- a/chromium_src/ui/views/widget/native_widget_mac.mm
+++ b/chromium_src/ui/views/widget/native_widget_mac.mm
@@ -5,6 +5,8 @@
 
 #include "src/ui/views/widget/native_widget_mac.mm"
 
+#include "base/check.h"
+
 namespace views {
 
 void NativeWidgetMac::SetWindowTitleVisibility(bool visible) {

--- a/chromium_src/ui/views/window/dialog_client_view.cc
+++ b/chromium_src/ui/views/window/dialog_client_view.cc
@@ -3,9 +3,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // you can obtain one at http://mozilla.org/MPL/2.0/.
 
-#include "ui/views/layout/box_layout.h"
-
 #include "src/ui/views/window/dialog_client_view.cc"
+
+#include "base/check.h"
+#include "ui/views/layout/box_layout.h"
 
 namespace views {
 

--- a/third_party/blink/renderer/core/brave_page_graph/graph_item/edge/graph_edge.cc
+++ b/third_party/blink/renderer/core/brave_page_graph/graph_item/edge/graph_edge.cc
@@ -7,6 +7,7 @@
 
 #include <string>
 
+#include "base/check.h"
 #include "base/strings/string_number_conversions.h"
 #include "brave/third_party/blink/renderer/core/brave_page_graph/graph_item/graph_item.h"
 #include "brave/third_party/blink/renderer/core/brave_page_graph/graph_item/node/graph_node.h"

--- a/third_party/blink/renderer/core/brave_page_graph/graph_item/edge/js/edge_js_call.cc
+++ b/third_party/blink/renderer/core/brave_page_graph/graph_item/edge/js/edge_js_call.cc
@@ -5,6 +5,7 @@
 
 #include "brave/third_party/blink/renderer/core/brave_page_graph/graph_item/edge/js/edge_js_call.h"
 
+#include "base/check.h"
 #include "brave/third_party/blink/renderer/core/brave_page_graph/graph_item/node/actor/node_script.h"
 #include "brave/third_party/blink/renderer/core/brave_page_graph/graph_item/node/js/node_js.h"
 #include "brave/third_party/blink/renderer/core/brave_page_graph/graphml.h"

--- a/third_party/blink/renderer/core/brave_page_graph/graph_item/edge/js/edge_js_result.cc
+++ b/third_party/blink/renderer/core/brave_page_graph/graph_item/edge/js/edge_js_result.cc
@@ -5,6 +5,7 @@
 
 #include "brave/third_party/blink/renderer/core/brave_page_graph/graph_item/edge/js/edge_js_result.h"
 
+#include "base/check.h"
 #include "brave/third_party/blink/renderer/core/brave_page_graph/graph_item/node/actor/node_script.h"
 #include "brave/third_party/blink/renderer/core/brave_page_graph/graph_item/node/js/node_js.h"
 #include "brave/third_party/blink/renderer/core/brave_page_graph/graphml.h"

--- a/third_party/blink/renderer/core/brave_page_graph/graph_item/edge/node/edge_node_insert.cc
+++ b/third_party/blink/renderer/core/brave_page_graph/graph_item/edge/node/edge_node_insert.cc
@@ -8,6 +8,7 @@
 #include <sstream>
 #include <string>
 
+#include "base/check.h"
 #include "brave/third_party/blink/renderer/core/brave_page_graph/graph_item/node/actor/node_actor.h"
 #include "brave/third_party/blink/renderer/core/brave_page_graph/graph_item/node/html/node_html.h"
 #include "brave/third_party/blink/renderer/core/brave_page_graph/graph_item/node/html/node_html_element.h"

--- a/third_party/blink/renderer/core/brave_page_graph/graph_item/node/html/node_html.cc
+++ b/third_party/blink/renderer/core/brave_page_graph/graph_item/node/html/node_html.cc
@@ -5,6 +5,7 @@
 
 #include "brave/third_party/blink/renderer/core/brave_page_graph/graph_item/node/html/node_html.h"
 
+#include "base/check.h"
 #include "brave/third_party/blink/renderer/core/brave_page_graph/graph_item/edge/node/edge_node_delete.h"
 #include "brave/third_party/blink/renderer/core/brave_page_graph/graphml.h"
 #include "third_party/blink/renderer/core/dom/dom_node_ids.h"

--- a/third_party/blink/renderer/core/brave_page_graph/graph_item/node/html/node_html_element.cc
+++ b/third_party/blink/renderer/core/brave_page_graph/graph_item/node/html/node_html_element.cc
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <sstream>
 
+#include "base/check_op.h"
 #include "brave/third_party/blink/renderer/core/brave_page_graph/graph_item/edge/attribute/edge_attribute_delete.h"
 #include "brave/third_party/blink/renderer/core/brave_page_graph/graph_item/edge/attribute/edge_attribute_set.h"
 #include "brave/third_party/blink/renderer/core/brave_page_graph/graph_item/edge/edge_document.h"

--- a/third_party/blink/renderer/core/brave_page_graph/graphml.cc
+++ b/third_party/blink/renderer/core/brave_page_graph/graphml.cc
@@ -11,6 +11,7 @@
 #include <string>
 #include <string_view>
 
+#include "base/check.h"
 #include "base/no_destructor.h"
 #include "base/strings/string_number_conversions.h"
 #include "brave/third_party/blink/renderer/core/brave_page_graph/libxml_utils.h"

--- a/third_party/blink/renderer/core/brave_page_graph/libxml_utils.cc
+++ b/third_party/blink/renderer/core/brave_page_graph/libxml_utils.cc
@@ -10,6 +10,7 @@
 #include <string>
 #include <string_view>
 
+#include "base/check.h"
 #include "base/numerics/safe_conversions.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/string_util.h"

--- a/third_party/blink/renderer/core/brave_page_graph/page_graph.cc
+++ b/third_party/blink/renderer/core/brave_page_graph/page_graph.cc
@@ -23,10 +23,11 @@
 #include <vector>
 
 #include "base/base64.h"
-#include "base/dcheck_is_on.h"
+#include "base/check.h"
 #include "base/debug/dump_without_crashing.h"
 #include "base/debug/stack_trace.h"
 #include "base/json/json_string_value_serializer.h"
+#include "base/logging.h"
 #include "base/no_destructor.h"
 #include "base/notreached.h"
 #include "base/strings/string_number_conversions.h"

--- a/third_party/blink/renderer/core/brave_page_graph/requests/request_tracker.cc
+++ b/third_party/blink/renderer/core/brave_page_graph/requests/request_tracker.cc
@@ -9,6 +9,8 @@
 #include <string>
 #include <utility>
 
+#include "base/check.h"
+#include "base/check_op.h"
 #include "base/containers/contains.h"
 #include "base/memory/scoped_refptr.h"
 #include "brave/third_party/blink/renderer/core/brave_page_graph/graph_item/edge/request/edge_request_start.h"

--- a/third_party/blink/renderer/core/brave_page_graph/requests/tracked_request.cc
+++ b/third_party/blink/renderer/core/brave_page_graph/requests/tracked_request.cc
@@ -5,6 +5,7 @@
 
 #include "brave/third_party/blink/renderer/core/brave_page_graph/requests/tracked_request.h"
 
+#include "base/check.h"
 #include "brave/third_party/blink/renderer/core/brave_page_graph/graph_item/edge/request/edge_request_complete.h"
 #include "brave/third_party/blink/renderer/core/brave_page_graph/graph_item/edge/request/edge_request_error.h"
 #include "brave/third_party/blink/renderer/core/brave_page_graph/graph_item/edge/request/edge_request_redirect.h"

--- a/third_party/blink/renderer/core/brave_page_graph/scripts/script_tracker.cc
+++ b/third_party/blink/renderer/core/brave_page_graph/scripts/script_tracker.cc
@@ -7,8 +7,10 @@
 
 #include <utility>
 
+#include "base/check.h"
 #include "base/debug/alias.h"
 #include "base/no_destructor.h"
+#include "base/notreached.h"
 #include "brave/third_party/blink/renderer/core/brave_page_graph/graph_item/node/actor/node_script_local.h"
 #include "brave/third_party/blink/renderer/core/brave_page_graph/page_graph_context.h"
 #include "brave/third_party/blink/renderer/core/brave_page_graph/types.h"

--- a/third_party/blink/renderer/core/farbling/brave_session_cache.cc
+++ b/third_party/blink/renderer/core/farbling/brave_session_cache.cc
@@ -7,11 +7,13 @@
 
 #include <string_view>
 
+#include "base/check.h"
 #include "base/compiler_specific.h"
 #include "base/debug/alias.h"
 #include "base/debug/dump_without_crashing.h"
 #include "base/feature_list.h"
 #include "base/hash/hash.h"
+#include "base/notreached.h"
 #include "base/numerics/byte_conversions.h"
 #include "base/numerics/safe_conversions.h"
 #include "brave/third_party/blink/renderer/brave_farbling_constants.h"

--- a/third_party/blink/renderer/core/resource_pool_limiter/resource_pool_limiter.cc
+++ b/third_party/blink/renderer/core/resource_pool_limiter/resource_pool_limiter.cc
@@ -5,6 +5,7 @@
 
 #include "brave/third_party/blink/renderer/core/resource_pool_limiter/resource_pool_limiter.h"
 
+#include "base/check.h"
 #include "base/notreached.h"
 #include "third_party/blink/renderer/core/execution_context/security_context.h"
 #include "third_party/blink/renderer/core/frame/local_dom_window.h"


### PR DESCRIPTION
This change is one of many fixing inclusion for the following files:

    - `base/notimplemented.h`
    - `base/notreached.h`
    - `base/check.h`
    - `base/dcheck_is_on.h`
    - `base/check_deref.h`
    - `base/check_op.h`
    - `base/logging/log_severity.h`
    - `base/logging.h`

This change is a mechanical change done with the following script:
https://github.com/brave/brave-browser/issues/46707#issuecomment-2960116515

Resolves https://github.com/brave/brave-browser/issues/46707
