### PR TITLE
Fixes Brave News subscription lists are empty on Android (uplift to 1.80.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/ntp/BraveNewTabPageLayout.java
+++ b/android/java/org/chromium/chrome/browser/ntp/BraveNewTabPageLayout.java
@@ -847,7 +847,7 @@ public class BraveNewTabPageLayout extends NewTabPageLayout
         mNtpAdapter.setImageCreditAlpha(1f);
         mNtpAdapter.setDisplayNewsFeed(mIsDisplayNewsFeed);
 
-        if (isOptin && mBraveNewsController != null && BraveNewsUtils.getLocale() == null) {
+        if (isOptin && mBraveNewsController != null && BraveNewsUtils.getLocale().isEmpty()) {
             BraveNewsUtils.getBraveNewsSettingsData(mBraveNewsController, null, null);
         }
     }

--- a/android/java/org/chromium/chrome/browser/settings/BraveNewsPreferencesV2.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveNewsPreferencesV2.java
@@ -150,7 +150,7 @@ public class BraveNewsPreferencesV2 extends BravePreferenceFragment
             }
         }
 
-        if (BraveNewsUtils.getLocale() != null
+        if (!BraveNewsUtils.getLocale().isEmpty()
                 && BraveNewsUtils.getSuggestionsPublisherList().size() > 0) {
             mIsSuggestionAvailable = true;
         }
@@ -164,7 +164,7 @@ public class BraveNewsPreferencesV2 extends BravePreferenceFragment
     public void onResume() {
         super.onResume();
 
-        if (BraveNewsUtils.getLocale() != null && mSwitchShowNews.isChecked()) {
+        if (!BraveNewsUtils.getLocale().isEmpty() && mSwitchShowNews.isChecked()) {
             updateFollowerCount();
 
             if (!mIsSuggestionAvailable) {
@@ -236,7 +236,7 @@ public class BraveNewsPreferencesV2 extends BravePreferenceFragment
             if (BraveNewsUtils.getChannelIcons().size() == 0) {
                 BraveNewsUtils.setChannelIcons();
             }
-            if (BraveNewsUtils.getLocale() == null && mBraveNewsController != null) {
+            if (BraveNewsUtils.getLocale().isEmpty() && mBraveNewsController != null) {
                 BraveNewsUtils.getBraveNewsSettingsData(mBraveNewsController, this, null);
             } else {
                 mTvSearch.setVisibility(View.VISIBLE);


### PR DESCRIPTION
Uplift of #29528
Resolves https://github.com/brave/brave-browser/issues/46714

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.