### PR TITLE
[cr139] Use `NavigationThrottleRegistry` with throttles

### DIFF
--- a/browser/ai_chat/ai_chat_throttle_unittest.cc
+++ b/browser/ai_chat/ai_chat_throttle_unittest.cc
@@ -15,6 +15,7 @@
 #include "chrome/test/base/testing_profile_manager.h"
 #include "content/public/test/browser_task_environment.h"
 #include "content/public/test/mock_navigation_handle.h"
+#include "content/public/test/mock_navigation_throttle_registry.h"
 #include "content/public/test/test_renderer_host.h"
 #include "content/public/test/web_contents_tester.h"
 #include "testing/gtest/include/gtest/gtest.h"
@@ -86,9 +87,10 @@ TEST_P(AIChatThrottleUnitTest, CancelNavigationFromTab) {
       ui::PageTransition::PAGE_TRANSITION_TYPED);
 
   test_handle.set_page_transition(transition);
+  content::MockNavigationThrottleRegistry registry(&test_handle);
 
   std::unique_ptr<AIChatThrottle> throttle =
-      AIChatThrottle::MaybeCreateThrottleFor(&test_handle);
+      AIChatThrottle::MaybeCreateThrottleFor(registry);
 
 #if !BUILDFLAG(IS_ANDROID)
   if (IsAIChatHistoryEnabled()) {
@@ -113,9 +115,10 @@ TEST_P(AIChatThrottleUnitTest, CancelNavigationToFrame) {
       ui::PageTransition::PAGE_TRANSITION_TYPED);
 
   test_handle.set_page_transition(transition);
+  content::MockNavigationThrottleRegistry registry(&test_handle);
 
   std::unique_ptr<AIChatThrottle> throttle =
-      AIChatThrottle::MaybeCreateThrottleFor(&test_handle);
+      AIChatThrottle::MaybeCreateThrottleFor(registry);
 #if !BUILDFLAG(IS_ANDROID)
   EXPECT_EQ(content::NavigationThrottle::CANCEL_AND_IGNORE,
             throttle->WillStartRequest().action());
@@ -138,9 +141,10 @@ TEST_P(AIChatThrottleUnitTest, AllowNavigationFromPanel) {
 #endif
 
   test_handle.set_page_transition(transition);
+  content::MockNavigationThrottleRegistry registry(&test_handle);
 
   std::unique_ptr<AIChatThrottle> throttle =
-      AIChatThrottle::MaybeCreateThrottleFor(&test_handle);
+      AIChatThrottle::MaybeCreateThrottleFor(registry);
   EXPECT_EQ(throttle.get(), nullptr);
 }
 

--- a/browser/brave_content_browser_client.cc
+++ b/browser/brave_content_browser_client.cc
@@ -1150,40 +1150,38 @@ void BraveContentBrowserClient::CreateThrottlesForNavigation(
 
   registry.MaybeAddThrottle(
       brave_rewards::RewardsProtocolNavigationThrottle::MaybeCreateThrottleFor(
-          &navigation_handle));
+          registry));
 
 #if !BUILDFLAG(IS_ANDROID)
   registry.MaybeAddThrottle(
-      NewTabShowsNavigationThrottle::MaybeCreateThrottleFor(
-          &navigation_handle));
+      NewTabShowsNavigationThrottle::MaybeCreateThrottleFor(registry));
 #endif
 
 #if BUILDFLAG(ENABLE_BRAVE_WEBTORRENT)
   registry.AddThrottle(
       std::make_unique<extensions::BraveWebTorrentNavigationThrottle>(
-          &navigation_handle));
+          registry));
 #endif
 
 #if BUILDFLAG(ENABLE_TOR)
   registry.MaybeAddThrottle(tor::TorNavigationThrottle::MaybeCreateThrottleFor(
-      &navigation_handle, context->IsTor()));
+      registry, context->IsTor()));
   registry.MaybeAddThrottle(
       tor::OnionLocationNavigationThrottle::MaybeCreateThrottleFor(
-          &navigation_handle, TorProfileServiceFactory::IsTorDisabled(context),
+          registry, TorProfileServiceFactory::IsTorDisabled(context),
           context->IsTor()));
 #endif
 
   registry.MaybeAddThrottle(
       decentralized_dns::DecentralizedDnsNavigationThrottle::
-          MaybeCreateThrottleFor(&navigation_handle,
-                                 user_prefs::UserPrefs::Get(context),
+          MaybeCreateThrottleFor(registry, user_prefs::UserPrefs::Get(context),
                                  g_browser_process->local_state(),
                                  g_browser_process->GetApplicationLocale()));
 
   // Debounce
   registry.MaybeAddThrottle(
       debounce::DebounceNavigationThrottle::MaybeCreateThrottleFor(
-          &navigation_handle,
+          registry,
           debounce::DebounceServiceFactory::GetForBrowserContext(context)));
 
   // The HostContentSettingsMap might be null for some irregular profiles, e.g.
@@ -1193,7 +1191,7 @@ void BraveContentBrowserClient::CreateThrottlesForNavigation(
   if (host_content_settings_map) {
     registry.MaybeAddThrottle(
         brave_shields::DomainBlockNavigationThrottle::MaybeCreateThrottleFor(
-            &navigation_handle, g_brave_browser_process->ad_block_service(),
+            registry, g_brave_browser_process->ad_block_service(),
             g_brave_browser_process->ad_block_service()
                 ->custom_filters_provider(),
             EphemeralStorageServiceFactory::GetForContext(context),
@@ -1205,7 +1203,7 @@ void BraveContentBrowserClient::CreateThrottlesForNavigation(
   // Request Off-The-Record
   registry.MaybeAddThrottle(
       request_otr::RequestOTRNavigationThrottle::MaybeCreateThrottleFor(
-          &navigation_handle,
+          registry,
           request_otr::RequestOTRServiceFactory::GetForBrowserContext(context),
           EphemeralStorageServiceFactory::GetForContext(context),
           Profile::FromBrowserContext(context)->GetPrefs(),
@@ -1214,20 +1212,20 @@ void BraveContentBrowserClient::CreateThrottlesForNavigation(
 
   if (Profile::FromBrowserContext(context)->IsRegularProfile()) {
     registry.MaybeAddThrottle(
-        ai_chat::AIChatThrottle::MaybeCreateThrottleFor(&navigation_handle));
+        ai_chat::AIChatThrottle::MaybeCreateThrottleFor(registry));
   }
 
 #if !BUILDFLAG(IS_ANDROID)
   registry.MaybeAddThrottle(
       ai_chat::AIChatBraveSearchThrottle::MaybeCreateThrottleFor(
-          base::BindOnce(&ai_chat::OpenAIChatForTab), &navigation_handle,
+          base::BindOnce(&ai_chat::OpenAIChatForTab), registry,
           ai_chat::AIChatServiceFactory::GetForBrowserContext(context),
           user_prefs::UserPrefs::Get(context)));
 #endif
 
   registry.MaybeAddThrottle(
       brave_search::BackupResultsNavigationThrottle::MaybeCreateThrottleFor(
-          &navigation_handle));
+          registry));
 }
 
 bool PreventDarkModeFingerprinting(WebContents* web_contents,

--- a/browser/brave_search/backup_results_navigation_throttle.cc
+++ b/browser/brave_search/backup_results_navigation_throttle.cc
@@ -16,20 +16,21 @@ namespace brave_search {
 
 std::unique_ptr<BackupResultsNavigationThrottle>
 BackupResultsNavigationThrottle::MaybeCreateThrottleFor(
-    content::NavigationHandle* navigation_handle) {
-  auto* context = navigation_handle->GetWebContents()->GetBrowserContext();
+    content::NavigationThrottleRegistry& registry) {
+  auto* context =
+      registry.GetNavigationHandle().GetWebContents()->GetBrowserContext();
   auto* profile = Profile::FromBrowserContext(context);
   if (!profile->IsOffTheRecord() ||
       !profile->GetOTRProfileID().IsSearchBackupResults()) {
     return nullptr;
   }
 
-  return std::make_unique<BackupResultsNavigationThrottle>(navigation_handle);
+  return std::make_unique<BackupResultsNavigationThrottle>(registry);
 }
 
 BackupResultsNavigationThrottle::BackupResultsNavigationThrottle(
-    content::NavigationHandle* navigation_handle)
-    : NavigationThrottle(navigation_handle) {}
+    content::NavigationThrottleRegistry& registry)
+    : NavigationThrottle(registry) {}
 BackupResultsNavigationThrottle::~BackupResultsNavigationThrottle() = default;
 
 content::NavigationThrottle::ThrottleCheckResult

--- a/browser/brave_search/backup_results_navigation_throttle.h
+++ b/browser/brave_search/backup_results_navigation_throttle.h
@@ -10,16 +10,12 @@
 
 #include "content/public/browser/navigation_throttle.h"
 
-namespace content {
-class NavigationHandle;
-}  // namespace content
-
 namespace brave_search {
 
 class BackupResultsNavigationThrottle : public content::NavigationThrottle {
  public:
   explicit BackupResultsNavigationThrottle(
-      content::NavigationHandle* navigation_handle);
+      content::NavigationThrottleRegistry& registry);
   ~BackupResultsNavigationThrottle() override;
 
   BackupResultsNavigationThrottle(const BackupResultsNavigationThrottle&) =
@@ -28,7 +24,7 @@ class BackupResultsNavigationThrottle : public content::NavigationThrottle {
       const BackupResultsNavigationThrottle&) = delete;
 
   static std::unique_ptr<BackupResultsNavigationThrottle>
-  MaybeCreateThrottleFor(content::NavigationHandle* navigation_handle);
+  MaybeCreateThrottleFor(content::NavigationThrottleRegistry& registry);
 
  private:
   // content::NavigationThrottle overrides:

--- a/browser/new_tab/new_tab_shows_navigation_throttle.cc
+++ b/browser/new_tab/new_tab_shows_navigation_throttle.cc
@@ -20,19 +20,20 @@
 // static
 std::unique_ptr<NewTabShowsNavigationThrottle>
 NewTabShowsNavigationThrottle::MaybeCreateThrottleFor(
-    content::NavigationHandle* navigation_handle) {
-  auto* context = navigation_handle->GetWebContents()->GetBrowserContext();
+    content::NavigationThrottleRegistry& registry) {
+  auto& navigation_handle = registry.GetNavigationHandle();
+  auto* context = navigation_handle.GetWebContents()->GetBrowserContext();
   if (!Profile::FromBrowserContext(context)->IsRegularProfile() ||
-      !NewTabUI::IsNewTab(navigation_handle->GetURL())) {
+      !NewTabUI::IsNewTab(navigation_handle.GetURL())) {
     return nullptr;
   }
 
-  return std::make_unique<NewTabShowsNavigationThrottle>(navigation_handle);
+  return std::make_unique<NewTabShowsNavigationThrottle>(registry);
 }
 
 NewTabShowsNavigationThrottle::NewTabShowsNavigationThrottle(
-    content::NavigationHandle* navigation_handle)
-    : NavigationThrottle(navigation_handle) {}
+    content::NavigationThrottleRegistry& registry)
+    : NavigationThrottle(registry) {}
 NewTabShowsNavigationThrottle::~NewTabShowsNavigationThrottle() = default;
 
 content::NavigationThrottle::ThrottleCheckResult

--- a/browser/new_tab/new_tab_shows_navigation_throttle.h
+++ b/browser/new_tab/new_tab_shows_navigation_throttle.h
@@ -15,7 +15,7 @@
 class NewTabShowsNavigationThrottle : public content::NavigationThrottle {
  public:
   explicit NewTabShowsNavigationThrottle(
-      content::NavigationHandle* navigation_handle);
+      content::NavigationThrottleRegistry& registry);
   ~NewTabShowsNavigationThrottle() override;
 
   NewTabShowsNavigationThrottle(const NewTabShowsNavigationThrottle&) = delete;
@@ -23,7 +23,7 @@ class NewTabShowsNavigationThrottle : public content::NavigationThrottle {
       const NewTabShowsNavigationThrottle&) = delete;
 
   static std::unique_ptr<NewTabShowsNavigationThrottle> MaybeCreateThrottleFor(
-      content::NavigationHandle* navigation_handle);
+      content::NavigationThrottleRegistry& registry);
 
  private:
   // content::NavigationThrottle overrides:

--- a/browser/tor/test/tor_navigation_throttle_unittest.cc
+++ b/browser/tor/test/tor_navigation_throttle_unittest.cc
@@ -3,6 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include "brave/components/tor/tor_navigation_throttle.h"
+
 #include <memory>
 #include <utility>
 
@@ -10,7 +12,6 @@
 #include "brave/browser/tor/tor_profile_manager.h"
 #include "brave/browser/tor/tor_profile_service_factory.h"
 #include "brave/components/tor/mock_tor_launcher_factory.h"
-#include "brave/components/tor/tor_navigation_throttle.h"
 #include "brave/components/tor/tor_profile_service.h"
 #include "chrome/test/base/testing_browser_process.h"
 #include "chrome/test/base/testing_profile.h"
@@ -18,6 +19,7 @@
 #include "content/public/browser/navigation_handle.h"
 #include "content/public/test/browser_task_environment.h"
 #include "content/public/test/mock_navigation_handle.h"
+#include "content/public/test/mock_navigation_throttle_registry.h"
 #include "content/public/test/test_renderer_host.h"
 #include "content/public/test/web_contents_tester.h"
 #include "testing/gtest/include/gtest/gtest.h"
@@ -81,15 +83,17 @@ class TorNavigationThrottleUnitTest : public testing::Test {
 // Tests TorNavigationThrottle::MaybeCreateThrottleFor with tor enabled/disabled
 TEST_F(TorNavigationThrottleUnitTest, Instantiation) {
   content::MockNavigationHandle test_handle(tor_web_contents());
+  content::MockNavigationThrottleRegistry registry(&test_handle);
   std::unique_ptr<TorNavigationThrottle> throttle =
       TorNavigationThrottle::MaybeCreateThrottleFor(
-          &test_handle, tor_web_contents()->GetBrowserContext()->IsTor());
+          registry, tor_web_contents()->GetBrowserContext()->IsTor());
   EXPECT_TRUE(throttle != nullptr);
 
   content::MockNavigationHandle test_handle2(web_contents());
+  content::MockNavigationThrottleRegistry registry2(&test_handle2);
   std::unique_ptr<TorNavigationThrottle> throttle2 =
       TorNavigationThrottle::MaybeCreateThrottleFor(
-          &test_handle2, web_contents()->GetBrowserContext()->IsTor());
+          registry2, web_contents()->GetBrowserContext()->IsTor());
   EXPECT_TRUE(throttle2 == nullptr);
 }
 
@@ -98,9 +102,10 @@ TEST_F(TorNavigationThrottleUnitTest, WhitelistedScheme) {
   EXPECT_CALL(*GetTorLauncherFactory(), IsTorConnected)
       .WillRepeatedly(testing::Return(true));
   content::MockNavigationHandle test_handle(tor_web_contents());
+  content::MockNavigationThrottleRegistry registry(&test_handle);
   std::unique_ptr<TorNavigationThrottle> throttle =
       TorNavigationThrottle::MaybeCreateThrottleFor(
-          &test_handle, *GetTorLauncherFactory(),
+          registry, *GetTorLauncherFactory(),
           tor_web_contents()->GetBrowserContext()->IsTor());
   GURL url("http://www.example.com");
   test_handle.set_url(url);
@@ -136,9 +141,10 @@ TEST_F(TorNavigationThrottleUnitTest, BlockedScheme) {
   EXPECT_CALL(*GetTorLauncherFactory(), IsTorConnected)
       .WillRepeatedly(testing::Return(true));
   content::MockNavigationHandle test_handle(tor_web_contents());
+  content::MockNavigationThrottleRegistry registry(&test_handle);
   std::unique_ptr<TorNavigationThrottle> throttle =
       TorNavigationThrottle::MaybeCreateThrottleFor(
-          &test_handle, *GetTorLauncherFactory(),
+          registry, *GetTorLauncherFactory(),
           tor_web_contents()->GetBrowserContext()->IsTor());
   GURL url("ftp://ftp.example.com");
   test_handle.set_url(url);
@@ -164,9 +170,10 @@ TEST_F(TorNavigationThrottleUnitTest, DeferUntilTorProcessLaunched) {
   EXPECT_CALL(*GetTorLauncherFactory(), IsTorConnected)
       .WillRepeatedly(testing::Return(false));
   content::MockNavigationHandle test_handle(tor_web_contents());
+  content::MockNavigationThrottleRegistry registry(&test_handle);
   std::unique_ptr<TorNavigationThrottle> throttle =
       TorNavigationThrottle::MaybeCreateThrottleFor(
-          &test_handle, *GetTorLauncherFactory(),
+          registry, *GetTorLauncherFactory(),
           tor_web_contents()->GetBrowserContext()->IsTor());
   bool was_navigation_resumed = false;
   throttle->set_resume_callback_for_testing(

--- a/components/ai_chat/content/browser/ai_chat_brave_search_throttle.cc
+++ b/components/ai_chat/content/browser/ai_chat_brave_search_throttle.cc
@@ -36,10 +36,10 @@ namespace ai_chat {
 std::unique_ptr<AIChatBraveSearchThrottle>
 AIChatBraveSearchThrottle::MaybeCreateThrottleFor(
     base::OnceCallback<void(content::WebContents*)> open_leo_delegate,
-    content::NavigationHandle* navigation_handle,
+    content::NavigationThrottleRegistry& registry,
     AIChatService* ai_chat_service,
     PrefService* pref_service) {
-  auto* web_contents = navigation_handle->GetWebContents();
+  auto* web_contents = registry.GetNavigationHandle().GetWebContents();
   if (!web_contents) {
     return nullptr;
   }
@@ -47,19 +47,20 @@ AIChatBraveSearchThrottle::MaybeCreateThrottleFor(
   if (!open_leo_delegate || !ai_chat_service ||
       !IsAIChatEnabled(pref_service) ||
       !features::IsOpenAIChatFromBraveSearchEnabled() ||
-      !IsOpenAIChatButtonFromBraveSearchURL(navigation_handle->GetURL())) {
+      !IsOpenAIChatButtonFromBraveSearchURL(
+          registry.GetNavigationHandle().GetURL())) {
     return nullptr;
   }
 
   return std::make_unique<AIChatBraveSearchThrottle>(
-      std::move(open_leo_delegate), navigation_handle, ai_chat_service);
+      std::move(open_leo_delegate), registry, ai_chat_service);
 }
 
 AIChatBraveSearchThrottle::AIChatBraveSearchThrottle(
     base::OnceCallback<void(content::WebContents*)> open_leo_delegate,
-    content::NavigationHandle* handle,
+    content::NavigationThrottleRegistry& registry,
     AIChatService* ai_chat_service)
-    : content::NavigationThrottle(handle),
+    : content::NavigationThrottle(registry),
       open_ai_chat_delegate_(std::move(open_leo_delegate)),
       ai_chat_service_(ai_chat_service) {
   CHECK(open_ai_chat_delegate_);

--- a/components/ai_chat/content/browser/ai_chat_brave_search_throttle.h
+++ b/components/ai_chat/content/browser/ai_chat_brave_search_throttle.h
@@ -25,7 +25,6 @@ enum class PermissionStatus : int32_t;
 
 namespace content {
 class WebContents;
-class NavigationHandle;
 }
 
 class PrefService;
@@ -50,13 +49,13 @@ class AIChatBraveSearchThrottle : public content::NavigationThrottle {
  public:
   AIChatBraveSearchThrottle(
       base::OnceCallback<void(content::WebContents*)> open_leo_delegate,
-      content::NavigationHandle* handle,
+      content::NavigationThrottleRegistry& registry,
       AIChatService* ai_chat_service);
   ~AIChatBraveSearchThrottle() override;
 
   static std::unique_ptr<AIChatBraveSearchThrottle> MaybeCreateThrottleFor(
       base::OnceCallback<void(content::WebContents*)> open_leo_delegate,
-      content::NavigationHandle* navigation_handle,
+      content::NavigationThrottleRegistry& registry,
       AIChatService* ai_chat_service,
       PrefService* pref_service);
 

--- a/components/ai_chat/content/browser/ai_chat_throttle.cc
+++ b/components/ai_chat/content/browser/ai_chat_throttle.cc
@@ -24,17 +24,18 @@ namespace ai_chat {
 
 // static
 std::unique_ptr<AIChatThrottle> AIChatThrottle::MaybeCreateThrottleFor(
-    content::NavigationHandle* navigation_handle) {
+    content::NavigationThrottleRegistry& registry) {
   // The throttle's only purpose is to deny navigation in a Tab.
 
   // The AI Chat WebUI won't be enabled if the feature or policy is disabled
   // (this is not checking a user preference).
+  content::NavigationHandle& navigation_handle = registry.GetNavigationHandle();
   if (!ai_chat::IsAIChatEnabled(user_prefs::UserPrefs::Get(
-          navigation_handle->GetWebContents()->GetBrowserContext()))) {
+          navigation_handle.GetWebContents()->GetBrowserContext()))) {
     return nullptr;
   }
 
-  const GURL& url = navigation_handle->GetURL();
+  const GURL& url = navigation_handle.GetURL();
 
   bool is_main_page_url = url.SchemeIs(content::kChromeUIScheme) &&
                           url.host_piece() == kAIChatUIHost;
@@ -59,18 +60,18 @@ std::unique_ptr<AIChatThrottle> AIChatThrottle::MaybeCreateThrottleFor(
 #if BUILDFLAG(IS_ANDROID)
   return nullptr;
 #else
-  ui::PageTransition transition = navigation_handle->GetPageTransition();
+  ui::PageTransition transition = navigation_handle.GetPageTransition();
   if (!ui::PageTransitionTypeIncludingQualifiersIs(
           ui::PageTransitionGetQualifier(transition),
           ui::PageTransition::PAGE_TRANSITION_FROM_ADDRESS_BAR)) {
     return nullptr;
   }
-  return std::make_unique<AIChatThrottle>(navigation_handle);
+  return std::make_unique<AIChatThrottle>(registry);
 #endif  // BUILDFLAG(IS_ANDROID)
 }
 
-AIChatThrottle::AIChatThrottle(content::NavigationHandle* handle)
-    : content::NavigationThrottle(handle) {}
+AIChatThrottle::AIChatThrottle(content::NavigationThrottleRegistry& registry)
+    : content::NavigationThrottle(registry) {}
 
 AIChatThrottle::~AIChatThrottle() {}
 

--- a/components/ai_chat/content/browser/ai_chat_throttle.h
+++ b/components/ai_chat/content/browser/ai_chat_throttle.h
@@ -10,20 +10,16 @@
 
 #include "content/public/browser/navigation_throttle.h"
 
-namespace content {
-class NavigationHandle;
-}  // namespace content
-
 namespace ai_chat {
 
 // Prevents navigation to certain AI Chat URLs
 class AIChatThrottle : public content::NavigationThrottle {
  public:
-  explicit AIChatThrottle(content::NavigationHandle* handle);
+  explicit AIChatThrottle(content::NavigationThrottleRegistry& registry);
   ~AIChatThrottle() override;
 
   static std::unique_ptr<AIChatThrottle> MaybeCreateThrottleFor(
-      content::NavigationHandle* navigation_handle);
+      content::NavigationThrottleRegistry& registry);
 
   // content::NavigationThrottle:
   // ThrottleCheckResult WillProcessResponse() override;

--- a/components/brave_rewards/content/rewards_protocol_navigation_throttle.cc
+++ b/components/brave_rewards/content/rewards_protocol_navigation_throttle.cc
@@ -42,21 +42,19 @@ namespace brave_rewards {
 // static
 std::unique_ptr<RewardsProtocolNavigationThrottle>
 RewardsProtocolNavigationThrottle::MaybeCreateThrottleFor(
-    content::NavigationHandle* navigation_handle) {
+    content::NavigationThrottleRegistry& registry) {
   auto* pref_service = user_prefs::UserPrefs::Get(
-      navigation_handle->GetWebContents()->GetBrowserContext());
+      registry.GetNavigationHandle().GetWebContents()->GetBrowserContext());
   if (!pref_service->GetBoolean(brave_rewards::prefs::kEnabled)) {
     return nullptr;
   }
 
-  return std::make_unique<RewardsProtocolNavigationThrottle>(navigation_handle);
+  return std::make_unique<RewardsProtocolNavigationThrottle>(registry);
 }
 
 RewardsProtocolNavigationThrottle::RewardsProtocolNavigationThrottle(
-    NavigationHandle* handle)
-    : NavigationThrottle(handle) {
-  CHECK(handle);
-}
+    content::NavigationThrottleRegistry& registry)
+    : NavigationThrottle(registry) {}
 
 RewardsProtocolNavigationThrottle::~RewardsProtocolNavigationThrottle() =
     default;

--- a/components/brave_rewards/content/rewards_protocol_navigation_throttle.h
+++ b/components/brave_rewards/content/rewards_protocol_navigation_throttle.h
@@ -10,15 +10,12 @@
 
 #include "content/public/browser/navigation_throttle.h"
 
-namespace content {
-class NavigationHandle;
-}  // namespace content
-
 namespace brave_rewards {
 
 class RewardsProtocolNavigationThrottle : public content::NavigationThrottle {
  public:
-  explicit RewardsProtocolNavigationThrottle(content::NavigationHandle* handle);
+  explicit RewardsProtocolNavigationThrottle(
+      content::NavigationThrottleRegistry& registry);
   ~RewardsProtocolNavigationThrottle() override;
 
   RewardsProtocolNavigationThrottle(const RewardsProtocolNavigationThrottle&) =
@@ -27,7 +24,7 @@ class RewardsProtocolNavigationThrottle : public content::NavigationThrottle {
       const RewardsProtocolNavigationThrottle&) = delete;
 
   static std::unique_ptr<RewardsProtocolNavigationThrottle>
-  MaybeCreateThrottleFor(content::NavigationHandle* handle);
+  MaybeCreateThrottleFor(content::NavigationThrottleRegistry& registry);
 
   // Implements content::NavigationThrottle.
   ThrottleCheckResult WillStartRequest() override;

--- a/components/brave_shields/content/browser/domain_block_navigation_throttle.cc
+++ b/components/brave_shields/content/browser/domain_block_navigation_throttle.cc
@@ -100,7 +100,7 @@ namespace brave_shields {
 // static
 std::unique_ptr<DomainBlockNavigationThrottle>
 DomainBlockNavigationThrottle::MaybeCreateThrottleFor(
-    content::NavigationHandle* navigation_handle,
+    content::NavigationThrottleRegistry& registry,
     AdBlockService* ad_block_service,
     AdBlockCustomFiltersProvider* ad_block_custom_filters_provider,
     ephemeral_storage::EphemeralStorageService* ephemeral_storage_service,
@@ -114,22 +114,22 @@ DomainBlockNavigationThrottle::MaybeCreateThrottleFor(
     return nullptr;
   }
   // Don't block subframes.
-  if (!navigation_handle->IsInMainFrame()) {
+  if (!registry.GetNavigationHandle().IsInMainFrame()) {
     return nullptr;
   }
   return std::make_unique<DomainBlockNavigationThrottle>(
-      navigation_handle, ad_block_service, ad_block_custom_filters_provider,
+      registry, ad_block_service, ad_block_custom_filters_provider,
       ephemeral_storage_service, content_settings, locale);
 }
 
 DomainBlockNavigationThrottle::DomainBlockNavigationThrottle(
-    content::NavigationHandle* navigation_handle,
+    content::NavigationThrottleRegistry& registry,
     AdBlockService* ad_block_service,
     AdBlockCustomFiltersProvider* ad_block_custom_filters_provider,
     ephemeral_storage::EphemeralStorageService* ephemeral_storage_service,
     HostContentSettingsMap* content_settings,
     const std::string& locale)
-    : content::NavigationThrottle(navigation_handle),
+    : content::NavigationThrottle(registry),
       ad_block_service_(ad_block_service),
       ad_block_custom_filters_provider_(ad_block_custom_filters_provider),
       ephemeral_storage_service_(ephemeral_storage_service),

--- a/components/brave_shields/content/browser/domain_block_navigation_throttle.h
+++ b/components/brave_shields/content/browser/domain_block_navigation_throttle.h
@@ -19,10 +19,6 @@
 
 class HostContentSettingsMap;
 
-namespace content {
-class NavigationHandle;
-}  // namespace content
-
 namespace ephemeral_storage {
 class EphemeralStorageService;
 }  // namespace ephemeral_storage
@@ -36,7 +32,7 @@ class DomainBlockNavigationThrottle : public content::NavigationThrottle {
  public:
   struct BlockResult;
   explicit DomainBlockNavigationThrottle(
-      content::NavigationHandle* navigation_handle,
+      content::NavigationThrottleRegistry& registry,
       AdBlockService* ad_block_service,
       AdBlockCustomFiltersProvider* ad_block_custom_filters_provider,
       ephemeral_storage::EphemeralStorageService* ephemeral_storage_service,
@@ -49,7 +45,7 @@ class DomainBlockNavigationThrottle : public content::NavigationThrottle {
       const DomainBlockNavigationThrottle&) = delete;
 
   static std::unique_ptr<DomainBlockNavigationThrottle> MaybeCreateThrottleFor(
-      content::NavigationHandle* navigation_handle,
+      content::NavigationThrottleRegistry& registry,
       AdBlockService* ad_block_service,
       AdBlockCustomFiltersProvider* ad_block_custom_filters_provider,
       ephemeral_storage::EphemeralStorageService* ephemeral_storage_service,

--- a/components/debounce/content/browser/debounce_navigation_throttle.cc
+++ b/components/debounce/content/browser/debounce_navigation_throttle.cc
@@ -87,7 +87,7 @@ void ClearRedirectChain(NavigationHandle* navigation_handle) {
 // static
 std::unique_ptr<DebounceNavigationThrottle>
 DebounceNavigationThrottle::MaybeCreateThrottleFor(
-    NavigationHandle* navigation_handle,
+    content::NavigationThrottleRegistry& registry,
     DebounceService* debounce_service) {
   // If debouncing is disabled in brave://flags, debounce service will
   // never be created (will be null) so we won't create the throttle
@@ -100,14 +100,14 @@ DebounceNavigationThrottle::MaybeCreateThrottleFor(
     return nullptr;
   }
 
-  return std::make_unique<DebounceNavigationThrottle>(navigation_handle,
+  return std::make_unique<DebounceNavigationThrottle>(registry,
                                                       *debounce_service);
 }
 
 DebounceNavigationThrottle::DebounceNavigationThrottle(
-    NavigationHandle* handle,
+    content::NavigationThrottleRegistry& registry,
     DebounceService& debounce_service)
-    : NavigationThrottle(handle), debounce_service_(debounce_service) {}
+    : NavigationThrottle(registry), debounce_service_(debounce_service) {}
 
 DebounceNavigationThrottle::~DebounceNavigationThrottle() = default;
 

--- a/components/debounce/content/browser/debounce_navigation_throttle.h
+++ b/components/debounce/content/browser/debounce_navigation_throttle.h
@@ -11,18 +11,15 @@
 #include "base/memory/raw_ref.h"
 #include "content/public/browser/navigation_throttle.h"
 
-namespace content {
-class NavigationHandle;
-}
-
 namespace debounce {
 
 class DebounceService;
 
 class DebounceNavigationThrottle : public content::NavigationThrottle {
  public:
-  explicit DebounceNavigationThrottle(content::NavigationHandle* handle,
-                                      DebounceService& debounce_service);
+  explicit DebounceNavigationThrottle(
+      content::NavigationThrottleRegistry& registry,
+      DebounceService& debounce_service);
   ~DebounceNavigationThrottle() override;
 
   DebounceNavigationThrottle(const DebounceNavigationThrottle&) = delete;
@@ -30,7 +27,7 @@ class DebounceNavigationThrottle : public content::NavigationThrottle {
       delete;
 
   static std::unique_ptr<DebounceNavigationThrottle> MaybeCreateThrottleFor(
-      content::NavigationHandle* handle,
+      content::NavigationThrottleRegistry& registry,
       DebounceService* debounce_service);
 
   // Implements content::NavigationThrottle.

--- a/components/decentralized_dns/content/decentralized_dns_navigation_throttle.cc
+++ b/components/decentralized_dns/content/decentralized_dns_navigation_throttle.cc
@@ -27,30 +27,31 @@ namespace decentralized_dns {
 // static
 std::unique_ptr<DecentralizedDnsNavigationThrottle>
 DecentralizedDnsNavigationThrottle::MaybeCreateThrottleFor(
-    content::NavigationHandle* navigation_handle,
+    content::NavigationThrottleRegistry& registry,
     PrefService* user_prefs,
     PrefService* local_state,
     const std::string& locale) {
+  content::NavigationHandle& navigation_handle = registry.GetNavigationHandle();
   content::BrowserContext* context =
-      navigation_handle->GetWebContents()->GetBrowserContext();
+      navigation_handle.GetWebContents()->GetBrowserContext();
   if (context->IsOffTheRecord()) {
     return nullptr;
   }
 
-  if (!navigation_handle->IsInMainFrame()) {
+  if (!navigation_handle.IsInMainFrame()) {
     return nullptr;
   }
 
   return std::make_unique<DecentralizedDnsNavigationThrottle>(
-      navigation_handle, user_prefs, local_state, locale);
+      registry, user_prefs, local_state, locale);
 }
 
 DecentralizedDnsNavigationThrottle::DecentralizedDnsNavigationThrottle(
-    content::NavigationHandle* navigation_handle,
+    content::NavigationThrottleRegistry& registry,
     PrefService* user_prefs,
     PrefService* local_state,
     const std::string& locale)
-    : content::NavigationThrottle(navigation_handle),
+    : content::NavigationThrottle(registry),
       user_prefs_(user_prefs),
       local_state_(local_state),
       locale_(locale) {}

--- a/components/decentralized_dns/content/decentralized_dns_navigation_throttle.h
+++ b/components/decentralized_dns/content/decentralized_dns_navigation_throttle.h
@@ -12,10 +12,6 @@
 #include "base/memory/weak_ptr.h"
 #include "content/public/browser/navigation_throttle.h"
 
-namespace content {
-class NavigationHandle;
-}  // namespace content
-
 class PrefService;
 
 namespace decentralized_dns {
@@ -23,7 +19,7 @@ namespace decentralized_dns {
 class DecentralizedDnsNavigationThrottle : public content::NavigationThrottle {
  public:
   explicit DecentralizedDnsNavigationThrottle(
-      content::NavigationHandle* navigation_handle,
+      content::NavigationThrottleRegistry& registry,
       PrefService* user_prefs,
       PrefService* local_state,
       const std::string& locale);
@@ -35,7 +31,7 @@ class DecentralizedDnsNavigationThrottle : public content::NavigationThrottle {
       const DecentralizedDnsNavigationThrottle&) = delete;
 
   static std::unique_ptr<DecentralizedDnsNavigationThrottle>
-  MaybeCreateThrottleFor(content::NavigationHandle* navigation_handle,
+  MaybeCreateThrottleFor(content::NavigationThrottleRegistry& registry,
                          PrefService* user_prefs,
                          PrefService* local_state,
                          const std::string& locale);

--- a/components/request_otr/browser/request_otr_navigation_throttle.cc
+++ b/components/request_otr/browser/request_otr_navigation_throttle.cc
@@ -35,7 +35,7 @@ namespace request_otr {
 // static
 std::unique_ptr<RequestOTRNavigationThrottle>
 RequestOTRNavigationThrottle::MaybeCreateThrottleFor(
-    content::NavigationHandle* navigation_handle,
+    content::NavigationThrottleRegistry& registry,
     RequestOTRService* request_otr_service,
     ephemeral_storage::EphemeralStorageService* ephemeral_storage_service,
     PrefService* pref_service,
@@ -56,15 +56,16 @@ RequestOTRNavigationThrottle::MaybeCreateThrottleFor(
   }
 
   // If this is the system profile, then we don't need the throttle.
+  content::NavigationHandle& navigation_handle = registry.GetNavigationHandle();
   if (profile_metrics::GetBrowserProfileType(
-          navigation_handle->GetWebContents()->GetBrowserContext()) ==
+          navigation_handle.GetWebContents()->GetBrowserContext()) ==
       profile_metrics::BrowserProfileType::kSystem) {
     return nullptr;
   }
   DCHECK(ephemeral_storage_service);
 
   // Don't block subframes.
-  if (!navigation_handle->IsInMainFrame()) {
+  if (!navigation_handle.IsInMainFrame()) {
     return nullptr;
   }
 
@@ -76,17 +77,17 @@ RequestOTRNavigationThrottle::MaybeCreateThrottleFor(
   }
 
   return std::make_unique<RequestOTRNavigationThrottle>(
-      navigation_handle, request_otr_service, ephemeral_storage_service,
-      pref_service, locale);
+      registry, request_otr_service, ephemeral_storage_service, pref_service,
+      locale);
 }
 
 RequestOTRNavigationThrottle::RequestOTRNavigationThrottle(
-    content::NavigationHandle* navigation_handle,
+    content::NavigationThrottleRegistry& registry,
     RequestOTRService* request_otr_service,
     ephemeral_storage::EphemeralStorageService* ephemeral_storage_service,
     PrefService* pref_service,
     const std::string& locale)
-    : content::NavigationThrottle(navigation_handle),
+    : content::NavigationThrottle(registry),
       request_otr_service_(request_otr_service),
       ephemeral_storage_service_(ephemeral_storage_service),
       pref_service_(pref_service),

--- a/components/request_otr/browser/request_otr_navigation_throttle.h
+++ b/components/request_otr/browser/request_otr_navigation_throttle.h
@@ -18,10 +18,6 @@
 
 class PrefService;
 
-namespace content {
-class NavigationHandle;
-}  // namespace content
-
 namespace ephemeral_storage {
 class EphemeralStorageService;
 }  // namespace ephemeral_storage
@@ -33,7 +29,7 @@ class RequestOTRService;
 class RequestOTRNavigationThrottle : public content::NavigationThrottle {
  public:
   explicit RequestOTRNavigationThrottle(
-      content::NavigationHandle* navigation_handle,
+      content::NavigationThrottleRegistry& registry,
       RequestOTRService* request_otr_service,
       ephemeral_storage::EphemeralStorageService* ephemeral_storage_service,
       PrefService* pref_service,
@@ -45,7 +41,7 @@ class RequestOTRNavigationThrottle : public content::NavigationThrottle {
       delete;
 
   static std::unique_ptr<RequestOTRNavigationThrottle> MaybeCreateThrottleFor(
-      content::NavigationHandle* navigation_handle,
+      content::NavigationThrottleRegistry& registry,
       RequestOTRService* request_otr_service,
       ephemeral_storage::EphemeralStorageService* ephemeral_storage_service,
       PrefService* pref_service,

--- a/components/tor/onion_location_navigation_throttle.cc
+++ b/components/tor/onion_location_navigation_throttle.cc
@@ -41,21 +41,20 @@ bool GetOnionLocation(const net::HttpResponseHeaders* headers,
 // static
 std::unique_ptr<OnionLocationNavigationThrottle>
 OnionLocationNavigationThrottle::MaybeCreateThrottleFor(
-    content::NavigationHandle* navigation_handle,
+    content::NavigationThrottleRegistry& registry,
     bool is_tor_disabled,
     bool is_tor_profile) {
-  if (is_tor_disabled || !navigation_handle->IsInMainFrame()) {
+  if (is_tor_disabled || !registry.GetNavigationHandle().IsInMainFrame()) {
     return nullptr;
   }
-  return std::make_unique<OnionLocationNavigationThrottle>(navigation_handle,
+  return std::make_unique<OnionLocationNavigationThrottle>(registry,
                                                            is_tor_profile);
 }
 
 OnionLocationNavigationThrottle::OnionLocationNavigationThrottle(
-    content::NavigationHandle* navigation_handle,
+    content::NavigationThrottleRegistry& registry,
     bool is_tor_profile)
-    : content::NavigationThrottle(navigation_handle),
-      is_tor_profile_(is_tor_profile) {}
+    : content::NavigationThrottle(registry), is_tor_profile_(is_tor_profile) {}
 
 OnionLocationNavigationThrottle::~OnionLocationNavigationThrottle() = default;
 

--- a/components/tor/onion_location_navigation_throttle.h
+++ b/components/tor/onion_location_navigation_throttle.h
@@ -13,7 +13,6 @@
 class GURL;
 
 namespace content {
-class NavigationHandle;
 class WebContents;
 }  // namespace content
 
@@ -22,11 +21,11 @@ namespace tor {
 class OnionLocationNavigationThrottle : public content::NavigationThrottle {
  public:
   static std::unique_ptr<OnionLocationNavigationThrottle>
-  MaybeCreateThrottleFor(content::NavigationHandle* navigation_handle,
+  MaybeCreateThrottleFor(content::NavigationThrottleRegistry& registry,
                          bool is_tor_disabled,
                          bool is_tor_profile);
   explicit OnionLocationNavigationThrottle(
-      content::NavigationHandle* navigation_handle,
+      content::NavigationThrottleRegistry& registry,
       bool is_tor_profile);
   ~OnionLocationNavigationThrottle() override;
 

--- a/components/tor/tor_navigation_throttle.cc
+++ b/components/tor/tor_navigation_throttle.cc
@@ -20,36 +20,36 @@ bool TorNavigationThrottle::skip_wait_for_tor_connected_for_testing_ = false;
 // static
 std::unique_ptr<TorNavigationThrottle>
 TorNavigationThrottle::MaybeCreateThrottleFor(
-    content::NavigationHandle* navigation_handle,
+    content::NavigationThrottleRegistry& registry,
     bool is_tor_profile) {
   if (!is_tor_profile)
     return nullptr;
-  return std::make_unique<TorNavigationThrottle>(navigation_handle);
+  return std::make_unique<TorNavigationThrottle>(registry);
 }
 
 // static
 std::unique_ptr<TorNavigationThrottle>
 TorNavigationThrottle::MaybeCreateThrottleFor(
-    content::NavigationHandle* navigation_handle,
+    content::NavigationThrottleRegistry& registry,
     TorLauncherFactory& tor_launcher_factory,
     bool is_tor_profile) {
   if (!is_tor_profile)
     return nullptr;
-  return std::make_unique<TorNavigationThrottle>(navigation_handle,
+  return std::make_unique<TorNavigationThrottle>(registry,
                                                  tor_launcher_factory);
 }
 
 TorNavigationThrottle::TorNavigationThrottle(
-    content::NavigationHandle* navigation_handle)
-    : content::NavigationThrottle(navigation_handle),
+    content::NavigationThrottleRegistry& registry)
+    : content::NavigationThrottle(registry),
       tor_launcher_factory_(*TorLauncherFactory::GetInstance()) {
   tor_launcher_factory_->AddObserver(this);
 }
 
 TorNavigationThrottle::TorNavigationThrottle(
-    content::NavigationHandle* navigation_handle,
+    content::NavigationThrottleRegistry& registry,
     TorLauncherFactory& tor_launcher_factory)
-    : content::NavigationThrottle(navigation_handle),
+    : content::NavigationThrottle(registry),
       tor_launcher_factory_(tor_launcher_factory) {
   tor_launcher_factory_->AddObserver(this);
 }

--- a/components/tor/tor_navigation_throttle.h
+++ b/components/tor/tor_navigation_throttle.h
@@ -13,10 +13,6 @@
 #include "brave/components/tor/tor_launcher_observer.h"
 #include "content/public/browser/navigation_throttle.h"
 
-namespace content {
-class NavigationHandle;
-}  // namespace content
-
 class TorLauncherFactory;
 
 namespace tor {
@@ -25,15 +21,15 @@ class TorNavigationThrottle : public content::NavigationThrottle,
                               public TorLauncherObserver {
  public:
   static std::unique_ptr<TorNavigationThrottle> MaybeCreateThrottleFor(
-      content::NavigationHandle* navigation_handle,
+      content::NavigationThrottleRegistry& registry,
       bool is_tor_profile);
   // For tests to use its own McokTorLauncherFactory
   static std::unique_ptr<TorNavigationThrottle> MaybeCreateThrottleFor(
-      content::NavigationHandle* navigation_handle,
+      content::NavigationThrottleRegistry& registry,
       TorLauncherFactory& tor_launcher_factory,
       bool is_tor_profile);
-  explicit TorNavigationThrottle(content::NavigationHandle* navigation_handle);
-  TorNavigationThrottle(content::NavigationHandle* navigation_handle,
+  explicit TorNavigationThrottle(content::NavigationThrottleRegistry& registry);
+  TorNavigationThrottle(content::NavigationThrottleRegistry& registry,
                         TorLauncherFactory& tor_launcher_factory);
   TorNavigationThrottle(const TorNavigationThrottle&) = delete;
   TorNavigationThrottle& operator=(const TorNavigationThrottle&) = delete;


### PR DESCRIPTION
Chromium has deleted the `NavigationThrottle` constructor taking a
`NavigationHandle` instance. This change migrates all our throttles to
use the `NavigationThrottleRegistry` constructor.

Chromium changes:
https://chromium.googlesource.com/chromium/src/+/74e6ef30ecad7b1e2b91c475cb757c79c194ee8e

commit 74e6ef30ecad7b1e2b91c475cb757c79c194ee8e
Author: Takashi Toyoshima <toyoshim@chromium.org>
Date:   Fri Jun 6 04:28:41 2025 -0700

    NavigationThrottleRunner2: Remove the legacy NavigationThrottle ctor

    This is the last CL to migrate remaining all throttles that call the
    legacy ctor.

    Now the MockNavigationThrottleRegistry needs to outlive throttles
    that are created with the mock

    To avoid tricky lifetime management on the
    MockNavigationThrottleRegistry working with the real NavigationRequest,
    now the mock takes a weak pointer. This helps to avoid dangling pointer
    false alerts on testing failure request cases where it's difficult to
    delete relevant objects in the right order.

    Bug: 412524375
    Change-Id: Ib29fa828584f1020ce51d9fdd87a48f90493c5c6
    Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/6595332
    Commit-Queue: Takashi Toyoshima <toyoshim@chromium.org>
    Reviewed-by: Victor Vianna <victorvianna@google.com>
    Reviewed-by: Sylvain Defresne <sdefresne@chromium.org>
    Reviewed-by: Alex Moshchuk <alexmos@chromium.org>
    Cr-Commit-Position: refs/heads/main@{#1470463}

Resolves https://github.com/brave/brave-browser/issues/46794
