### PR TITLE
Revert "[cr139] Use `NavigationThrottleRegistry` with throttles"

### DIFF
--- a/browser/ai_chat/ai_chat_throttle_unittest.cc
+++ b/browser/ai_chat/ai_chat_throttle_unittest.cc
@@ -15,7 +15,6 @@
 #include "chrome/test/base/testing_profile_manager.h"
 #include "content/public/test/browser_task_environment.h"
 #include "content/public/test/mock_navigation_handle.h"
-#include "content/public/test/mock_navigation_throttle_registry.h"
 #include "content/public/test/test_renderer_host.h"
 #include "content/public/test/web_contents_tester.h"
 #include "testing/gtest/include/gtest/gtest.h"
@@ -87,10 +86,9 @@ TEST_P(AIChatThrottleUnitTest, CancelNavigationFromTab) {
       ui::PageTransition::PAGE_TRANSITION_TYPED);
 
   test_handle.set_page_transition(transition);
-  content::MockNavigationThrottleRegistry registry(&test_handle);
 
   std::unique_ptr<AIChatThrottle> throttle =
-      AIChatThrottle::MaybeCreateThrottleFor(registry);
+      AIChatThrottle::MaybeCreateThrottleFor(&test_handle);
 
 #if !BUILDFLAG(IS_ANDROID)
   if (IsAIChatHistoryEnabled()) {
@@ -115,10 +113,9 @@ TEST_P(AIChatThrottleUnitTest, CancelNavigationToFrame) {
       ui::PageTransition::PAGE_TRANSITION_TYPED);
 
   test_handle.set_page_transition(transition);
-  content::MockNavigationThrottleRegistry registry(&test_handle);
 
   std::unique_ptr<AIChatThrottle> throttle =
-      AIChatThrottle::MaybeCreateThrottleFor(registry);
+      AIChatThrottle::MaybeCreateThrottleFor(&test_handle);
 #if !BUILDFLAG(IS_ANDROID)
   EXPECT_EQ(content::NavigationThrottle::CANCEL_AND_IGNORE,
             throttle->WillStartRequest().action());
@@ -141,10 +138,9 @@ TEST_P(AIChatThrottleUnitTest, AllowNavigationFromPanel) {
 #endif
 
   test_handle.set_page_transition(transition);
-  content::MockNavigationThrottleRegistry registry(&test_handle);
 
   std::unique_ptr<AIChatThrottle> throttle =
-      AIChatThrottle::MaybeCreateThrottleFor(registry);
+      AIChatThrottle::MaybeCreateThrottleFor(&test_handle);
   EXPECT_EQ(throttle.get(), nullptr);
 }
 

--- a/browser/brave_content_browser_client.cc
+++ b/browser/brave_content_browser_client.cc
@@ -1150,38 +1150,40 @@ void BraveContentBrowserClient::CreateThrottlesForNavigation(
 
   registry.MaybeAddThrottle(
       brave_rewards::RewardsProtocolNavigationThrottle::MaybeCreateThrottleFor(
-          registry));
+          &navigation_handle));
 
 #if !BUILDFLAG(IS_ANDROID)
   registry.MaybeAddThrottle(
-      NewTabShowsNavigationThrottle::MaybeCreateThrottleFor(registry));
+      NewTabShowsNavigationThrottle::MaybeCreateThrottleFor(
+          &navigation_handle));
 #endif
 
 #if BUILDFLAG(ENABLE_BRAVE_WEBTORRENT)
   registry.AddThrottle(
       std::make_unique<extensions::BraveWebTorrentNavigationThrottle>(
-          registry));
+          &navigation_handle));
 #endif
 
 #if BUILDFLAG(ENABLE_TOR)
   registry.MaybeAddThrottle(tor::TorNavigationThrottle::MaybeCreateThrottleFor(
-      registry, context->IsTor()));
+      &navigation_handle, context->IsTor()));
   registry.MaybeAddThrottle(
       tor::OnionLocationNavigationThrottle::MaybeCreateThrottleFor(
-          registry, TorProfileServiceFactory::IsTorDisabled(context),
+          &navigation_handle, TorProfileServiceFactory::IsTorDisabled(context),
           context->IsTor()));
 #endif
 
   registry.MaybeAddThrottle(
       decentralized_dns::DecentralizedDnsNavigationThrottle::
-          MaybeCreateThrottleFor(registry, user_prefs::UserPrefs::Get(context),
+          MaybeCreateThrottleFor(&navigation_handle,
+                                 user_prefs::UserPrefs::Get(context),
                                  g_browser_process->local_state(),
                                  g_browser_process->GetApplicationLocale()));
 
   // Debounce
   registry.MaybeAddThrottle(
       debounce::DebounceNavigationThrottle::MaybeCreateThrottleFor(
-          registry,
+          &navigation_handle,
           debounce::DebounceServiceFactory::GetForBrowserContext(context)));
 
   // The HostContentSettingsMap might be null for some irregular profiles, e.g.
@@ -1191,7 +1193,7 @@ void BraveContentBrowserClient::CreateThrottlesForNavigation(
   if (host_content_settings_map) {
     registry.MaybeAddThrottle(
         brave_shields::DomainBlockNavigationThrottle::MaybeCreateThrottleFor(
-            registry, g_brave_browser_process->ad_block_service(),
+            &navigation_handle, g_brave_browser_process->ad_block_service(),
             g_brave_browser_process->ad_block_service()
                 ->custom_filters_provider(),
             EphemeralStorageServiceFactory::GetForContext(context),
@@ -1203,7 +1205,7 @@ void BraveContentBrowserClient::CreateThrottlesForNavigation(
   // Request Off-The-Record
   registry.MaybeAddThrottle(
       request_otr::RequestOTRNavigationThrottle::MaybeCreateThrottleFor(
-          registry,
+          &navigation_handle,
           request_otr::RequestOTRServiceFactory::GetForBrowserContext(context),
           EphemeralStorageServiceFactory::GetForContext(context),
           Profile::FromBrowserContext(context)->GetPrefs(),
@@ -1212,20 +1214,20 @@ void BraveContentBrowserClient::CreateThrottlesForNavigation(
 
   if (Profile::FromBrowserContext(context)->IsRegularProfile()) {
     registry.MaybeAddThrottle(
-        ai_chat::AIChatThrottle::MaybeCreateThrottleFor(registry));
+        ai_chat::AIChatThrottle::MaybeCreateThrottleFor(&navigation_handle));
   }
 
 #if !BUILDFLAG(IS_ANDROID)
   registry.MaybeAddThrottle(
       ai_chat::AIChatBraveSearchThrottle::MaybeCreateThrottleFor(
-          base::BindOnce(&ai_chat::OpenAIChatForTab), registry,
+          base::BindOnce(&ai_chat::OpenAIChatForTab), &navigation_handle,
           ai_chat::AIChatServiceFactory::GetForBrowserContext(context),
           user_prefs::UserPrefs::Get(context)));
 #endif
 
   registry.MaybeAddThrottle(
       brave_search::BackupResultsNavigationThrottle::MaybeCreateThrottleFor(
-          registry));
+          &navigation_handle));
 }
 
 bool PreventDarkModeFingerprinting(WebContents* web_contents,

--- a/browser/brave_search/backup_results_navigation_throttle.cc
+++ b/browser/brave_search/backup_results_navigation_throttle.cc
@@ -16,21 +16,20 @@ namespace brave_search {
 
 std::unique_ptr<BackupResultsNavigationThrottle>
 BackupResultsNavigationThrottle::MaybeCreateThrottleFor(
-    content::NavigationThrottleRegistry& registry) {
-  auto* context =
-      registry.GetNavigationHandle().GetWebContents()->GetBrowserContext();
+    content::NavigationHandle* navigation_handle) {
+  auto* context = navigation_handle->GetWebContents()->GetBrowserContext();
   auto* profile = Profile::FromBrowserContext(context);
   if (!profile->IsOffTheRecord() ||
       !profile->GetOTRProfileID().IsSearchBackupResults()) {
     return nullptr;
   }
 
-  return std::make_unique<BackupResultsNavigationThrottle>(registry);
+  return std::make_unique<BackupResultsNavigationThrottle>(navigation_handle);
 }
 
 BackupResultsNavigationThrottle::BackupResultsNavigationThrottle(
-    content::NavigationThrottleRegistry& registry)
-    : NavigationThrottle(registry) {}
+    content::NavigationHandle* navigation_handle)
+    : NavigationThrottle(navigation_handle) {}
 BackupResultsNavigationThrottle::~BackupResultsNavigationThrottle() = default;
 
 content::NavigationThrottle::ThrottleCheckResult

--- a/browser/brave_search/backup_results_navigation_throttle.h
+++ b/browser/brave_search/backup_results_navigation_throttle.h
@@ -10,12 +10,16 @@
 
 #include "content/public/browser/navigation_throttle.h"
 
+namespace content {
+class NavigationHandle;
+}  // namespace content
+
 namespace brave_search {
 
 class BackupResultsNavigationThrottle : public content::NavigationThrottle {
  public:
   explicit BackupResultsNavigationThrottle(
-      content::NavigationThrottleRegistry& registry);
+      content::NavigationHandle* navigation_handle);
   ~BackupResultsNavigationThrottle() override;
 
   BackupResultsNavigationThrottle(const BackupResultsNavigationThrottle&) =
@@ -24,7 +28,7 @@ class BackupResultsNavigationThrottle : public content::NavigationThrottle {
       const BackupResultsNavigationThrottle&) = delete;
 
   static std::unique_ptr<BackupResultsNavigationThrottle>
-  MaybeCreateThrottleFor(content::NavigationThrottleRegistry& registry);
+  MaybeCreateThrottleFor(content::NavigationHandle* navigation_handle);
 
  private:
   // content::NavigationThrottle overrides:

--- a/browser/new_tab/new_tab_shows_navigation_throttle.cc
+++ b/browser/new_tab/new_tab_shows_navigation_throttle.cc
@@ -20,20 +20,19 @@
 // static
 std::unique_ptr<NewTabShowsNavigationThrottle>
 NewTabShowsNavigationThrottle::MaybeCreateThrottleFor(
-    content::NavigationThrottleRegistry& registry) {
-  auto& navigation_handle = registry.GetNavigationHandle();
-  auto* context = navigation_handle.GetWebContents()->GetBrowserContext();
+    content::NavigationHandle* navigation_handle) {
+  auto* context = navigation_handle->GetWebContents()->GetBrowserContext();
   if (!Profile::FromBrowserContext(context)->IsRegularProfile() ||
-      !NewTabUI::IsNewTab(navigation_handle.GetURL())) {
+      !NewTabUI::IsNewTab(navigation_handle->GetURL())) {
     return nullptr;
   }
 
-  return std::make_unique<NewTabShowsNavigationThrottle>(registry);
+  return std::make_unique<NewTabShowsNavigationThrottle>(navigation_handle);
 }
 
 NewTabShowsNavigationThrottle::NewTabShowsNavigationThrottle(
-    content::NavigationThrottleRegistry& registry)
-    : NavigationThrottle(registry) {}
+    content::NavigationHandle* navigation_handle)
+    : NavigationThrottle(navigation_handle) {}
 NewTabShowsNavigationThrottle::~NewTabShowsNavigationThrottle() = default;
 
 content::NavigationThrottle::ThrottleCheckResult

--- a/browser/new_tab/new_tab_shows_navigation_throttle.h
+++ b/browser/new_tab/new_tab_shows_navigation_throttle.h
@@ -15,7 +15,7 @@
 class NewTabShowsNavigationThrottle : public content::NavigationThrottle {
  public:
   explicit NewTabShowsNavigationThrottle(
-      content::NavigationThrottleRegistry& registry);
+      content::NavigationHandle* navigation_handle);
   ~NewTabShowsNavigationThrottle() override;
 
   NewTabShowsNavigationThrottle(const NewTabShowsNavigationThrottle&) = delete;
@@ -23,7 +23,7 @@ class NewTabShowsNavigationThrottle : public content::NavigationThrottle {
       const NewTabShowsNavigationThrottle&) = delete;
 
   static std::unique_ptr<NewTabShowsNavigationThrottle> MaybeCreateThrottleFor(
-      content::NavigationThrottleRegistry& registry);
+      content::NavigationHandle* navigation_handle);
 
  private:
   // content::NavigationThrottle overrides:

--- a/browser/tor/test/tor_navigation_throttle_unittest.cc
+++ b/browser/tor/test/tor_navigation_throttle_unittest.cc
@@ -3,6 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include "brave/components/tor/tor_navigation_throttle.h"
+
 #include <memory>
 #include <utility>
 
@@ -10,7 +12,6 @@
 #include "brave/browser/tor/tor_profile_manager.h"
 #include "brave/browser/tor/tor_profile_service_factory.h"
 #include "brave/components/tor/mock_tor_launcher_factory.h"
-#include "brave/components/tor/tor_navigation_throttle.h"
 #include "brave/components/tor/tor_profile_service.h"
 #include "chrome/test/base/testing_browser_process.h"
 #include "chrome/test/base/testing_profile.h"

--- a/components/ai_chat/content/browser/ai_chat_brave_search_throttle.cc
+++ b/components/ai_chat/content/browser/ai_chat_brave_search_throttle.cc
@@ -36,10 +36,10 @@ namespace ai_chat {
 std::unique_ptr<AIChatBraveSearchThrottle>
 AIChatBraveSearchThrottle::MaybeCreateThrottleFor(
     base::OnceCallback<void(content::WebContents*)> open_leo_delegate,
-    content::NavigationThrottleRegistry& registry,
+    content::NavigationHandle* navigation_handle,
     AIChatService* ai_chat_service,
     PrefService* pref_service) {
-  auto* web_contents = registry.GetNavigationHandle().GetWebContents();
+  auto* web_contents = navigation_handle->GetWebContents();
   if (!web_contents) {
     return nullptr;
   }
@@ -47,20 +47,19 @@ AIChatBraveSearchThrottle::MaybeCreateThrottleFor(
   if (!open_leo_delegate || !ai_chat_service ||
       !IsAIChatEnabled(pref_service) ||
       !features::IsOpenAIChatFromBraveSearchEnabled() ||
-      !IsOpenAIChatButtonFromBraveSearchURL(
-          registry.GetNavigationHandle().GetURL())) {
+      !IsOpenAIChatButtonFromBraveSearchURL(navigation_handle->GetURL())) {
     return nullptr;
   }
 
   return std::make_unique<AIChatBraveSearchThrottle>(
-      std::move(open_leo_delegate), registry, ai_chat_service);
+      std::move(open_leo_delegate), navigation_handle, ai_chat_service);
 }
 
 AIChatBraveSearchThrottle::AIChatBraveSearchThrottle(
     base::OnceCallback<void(content::WebContents*)> open_leo_delegate,
-    content::NavigationThrottleRegistry& registry,
+    content::NavigationHandle* handle,
     AIChatService* ai_chat_service)
-    : content::NavigationThrottle(registry),
+    : content::NavigationThrottle(handle),
       open_ai_chat_delegate_(std::move(open_leo_delegate)),
       ai_chat_service_(ai_chat_service) {
   CHECK(open_ai_chat_delegate_);

--- a/components/ai_chat/content/browser/ai_chat_brave_search_throttle.h
+++ b/components/ai_chat/content/browser/ai_chat_brave_search_throttle.h
@@ -25,6 +25,7 @@ enum class PermissionStatus : int32_t;
 
 namespace content {
 class WebContents;
+class NavigationHandle;
 }
 
 class PrefService;
@@ -49,13 +50,13 @@ class AIChatBraveSearchThrottle : public content::NavigationThrottle {
  public:
   AIChatBraveSearchThrottle(
       base::OnceCallback<void(content::WebContents*)> open_leo_delegate,
-      content::NavigationThrottleRegistry& registry,
+      content::NavigationHandle* handle,
       AIChatService* ai_chat_service);
   ~AIChatBraveSearchThrottle() override;
 
   static std::unique_ptr<AIChatBraveSearchThrottle> MaybeCreateThrottleFor(
       base::OnceCallback<void(content::WebContents*)> open_leo_delegate,
-      content::NavigationThrottleRegistry& registry,
+      content::NavigationHandle* navigation_handle,
       AIChatService* ai_chat_service,
       PrefService* pref_service);
 

--- a/components/ai_chat/content/browser/ai_chat_throttle.cc
+++ b/components/ai_chat/content/browser/ai_chat_throttle.cc
@@ -24,18 +24,17 @@ namespace ai_chat {
 
 // static
 std::unique_ptr<AIChatThrottle> AIChatThrottle::MaybeCreateThrottleFor(
-    content::NavigationThrottleRegistry& registry) {
+    content::NavigationHandle* navigation_handle) {
   // The throttle's only purpose is to deny navigation in a Tab.
 
   // The AI Chat WebUI won't be enabled if the feature or policy is disabled
   // (this is not checking a user preference).
-  content::NavigationHandle& navigation_handle = registry.GetNavigationHandle();
   if (!ai_chat::IsAIChatEnabled(user_prefs::UserPrefs::Get(
-          navigation_handle.GetWebContents()->GetBrowserContext()))) {
+          navigation_handle->GetWebContents()->GetBrowserContext()))) {
     return nullptr;
   }
 
-  const GURL& url = navigation_handle.GetURL();
+  const GURL& url = navigation_handle->GetURL();
 
   bool is_main_page_url = url.SchemeIs(content::kChromeUIScheme) &&
                           url.host_piece() == kAIChatUIHost;
@@ -60,18 +59,18 @@ std::unique_ptr<AIChatThrottle> AIChatThrottle::MaybeCreateThrottleFor(
 #if BUILDFLAG(IS_ANDROID)
   return nullptr;
 #else
-  ui::PageTransition transition = navigation_handle.GetPageTransition();
+  ui::PageTransition transition = navigation_handle->GetPageTransition();
   if (!ui::PageTransitionTypeIncludingQualifiersIs(
           ui::PageTransitionGetQualifier(transition),
           ui::PageTransition::PAGE_TRANSITION_FROM_ADDRESS_BAR)) {
     return nullptr;
   }
-  return std::make_unique<AIChatThrottle>(registry);
+  return std::make_unique<AIChatThrottle>(navigation_handle);
 #endif  // BUILDFLAG(IS_ANDROID)
 }
 
-AIChatThrottle::AIChatThrottle(content::NavigationThrottleRegistry& registry)
-    : content::NavigationThrottle(registry) {}
+AIChatThrottle::AIChatThrottle(content::NavigationHandle* handle)
+    : content::NavigationThrottle(handle) {}
 
 AIChatThrottle::~AIChatThrottle() {}
 

--- a/components/ai_chat/content/browser/ai_chat_throttle.h
+++ b/components/ai_chat/content/browser/ai_chat_throttle.h
@@ -10,16 +10,20 @@
 
 #include "content/public/browser/navigation_throttle.h"
 
+namespace content {
+class NavigationHandle;
+}  // namespace content
+
 namespace ai_chat {
 
 // Prevents navigation to certain AI Chat URLs
 class AIChatThrottle : public content::NavigationThrottle {
  public:
-  explicit AIChatThrottle(content::NavigationThrottleRegistry& registry);
+  explicit AIChatThrottle(content::NavigationHandle* handle);
   ~AIChatThrottle() override;
 
   static std::unique_ptr<AIChatThrottle> MaybeCreateThrottleFor(
-      content::NavigationThrottleRegistry& registry);
+      content::NavigationHandle* navigation_handle);
 
   // content::NavigationThrottle:
   // ThrottleCheckResult WillProcessResponse() override;

--- a/components/brave_rewards/content/rewards_protocol_navigation_throttle.cc
+++ b/components/brave_rewards/content/rewards_protocol_navigation_throttle.cc
@@ -42,19 +42,21 @@ namespace brave_rewards {
 // static
 std::unique_ptr<RewardsProtocolNavigationThrottle>
 RewardsProtocolNavigationThrottle::MaybeCreateThrottleFor(
-    content::NavigationThrottleRegistry& registry) {
+    content::NavigationHandle* navigation_handle) {
   auto* pref_service = user_prefs::UserPrefs::Get(
-      registry.GetNavigationHandle().GetWebContents()->GetBrowserContext());
+      navigation_handle->GetWebContents()->GetBrowserContext());
   if (!pref_service->GetBoolean(brave_rewards::prefs::kEnabled)) {
     return nullptr;
   }
 
-  return std::make_unique<RewardsProtocolNavigationThrottle>(registry);
+  return std::make_unique<RewardsProtocolNavigationThrottle>(navigation_handle);
 }
 
 RewardsProtocolNavigationThrottle::RewardsProtocolNavigationThrottle(
-    content::NavigationThrottleRegistry& registry)
-    : NavigationThrottle(registry) {}
+    NavigationHandle* handle)
+    : NavigationThrottle(handle) {
+  CHECK(handle);
+}
 
 RewardsProtocolNavigationThrottle::~RewardsProtocolNavigationThrottle() =
     default;

--- a/components/brave_rewards/content/rewards_protocol_navigation_throttle.h
+++ b/components/brave_rewards/content/rewards_protocol_navigation_throttle.h
@@ -10,12 +10,15 @@
 
 #include "content/public/browser/navigation_throttle.h"
 
+namespace content {
+class NavigationHandle;
+}  // namespace content
+
 namespace brave_rewards {
 
 class RewardsProtocolNavigationThrottle : public content::NavigationThrottle {
  public:
-  explicit RewardsProtocolNavigationThrottle(
-      content::NavigationThrottleRegistry& registry);
+  explicit RewardsProtocolNavigationThrottle(content::NavigationHandle* handle);
   ~RewardsProtocolNavigationThrottle() override;
 
   RewardsProtocolNavigationThrottle(const RewardsProtocolNavigationThrottle&) =
@@ -24,7 +27,7 @@ class RewardsProtocolNavigationThrottle : public content::NavigationThrottle {
       const RewardsProtocolNavigationThrottle&) = delete;
 
   static std::unique_ptr<RewardsProtocolNavigationThrottle>
-  MaybeCreateThrottleFor(content::NavigationThrottleRegistry& registry);
+  MaybeCreateThrottleFor(content::NavigationHandle* handle);
 
   // Implements content::NavigationThrottle.
   ThrottleCheckResult WillStartRequest() override;

--- a/components/brave_shields/content/browser/domain_block_navigation_throttle.cc
+++ b/components/brave_shields/content/browser/domain_block_navigation_throttle.cc
@@ -100,7 +100,7 @@ namespace brave_shields {
 // static
 std::unique_ptr<DomainBlockNavigationThrottle>
 DomainBlockNavigationThrottle::MaybeCreateThrottleFor(
-    content::NavigationThrottleRegistry& registry,
+    content::NavigationHandle* navigation_handle,
     AdBlockService* ad_block_service,
     AdBlockCustomFiltersProvider* ad_block_custom_filters_provider,
     ephemeral_storage::EphemeralStorageService* ephemeral_storage_service,
@@ -114,22 +114,22 @@ DomainBlockNavigationThrottle::MaybeCreateThrottleFor(
     return nullptr;
   }
   // Don't block subframes.
-  if (!registry.GetNavigationHandle().IsInMainFrame()) {
+  if (!navigation_handle->IsInMainFrame()) {
     return nullptr;
   }
   return std::make_unique<DomainBlockNavigationThrottle>(
-      registry, ad_block_service, ad_block_custom_filters_provider,
+      navigation_handle, ad_block_service, ad_block_custom_filters_provider,
       ephemeral_storage_service, content_settings, locale);
 }
 
 DomainBlockNavigationThrottle::DomainBlockNavigationThrottle(
-    content::NavigationThrottleRegistry& registry,
+    content::NavigationHandle* navigation_handle,
     AdBlockService* ad_block_service,
     AdBlockCustomFiltersProvider* ad_block_custom_filters_provider,
     ephemeral_storage::EphemeralStorageService* ephemeral_storage_service,
     HostContentSettingsMap* content_settings,
     const std::string& locale)
-    : content::NavigationThrottle(registry),
+    : content::NavigationThrottle(navigation_handle),
       ad_block_service_(ad_block_service),
       ad_block_custom_filters_provider_(ad_block_custom_filters_provider),
       ephemeral_storage_service_(ephemeral_storage_service),

--- a/components/brave_shields/content/browser/domain_block_navigation_throttle.h
+++ b/components/brave_shields/content/browser/domain_block_navigation_throttle.h
@@ -19,6 +19,10 @@
 
 class HostContentSettingsMap;
 
+namespace content {
+class NavigationHandle;
+}  // namespace content
+
 namespace ephemeral_storage {
 class EphemeralStorageService;
 }  // namespace ephemeral_storage
@@ -32,7 +36,7 @@ class DomainBlockNavigationThrottle : public content::NavigationThrottle {
  public:
   struct BlockResult;
   explicit DomainBlockNavigationThrottle(
-      content::NavigationThrottleRegistry& registry,
+      content::NavigationHandle* navigation_handle,
       AdBlockService* ad_block_service,
       AdBlockCustomFiltersProvider* ad_block_custom_filters_provider,
       ephemeral_storage::EphemeralStorageService* ephemeral_storage_service,
@@ -45,7 +49,7 @@ class DomainBlockNavigationThrottle : public content::NavigationThrottle {
       const DomainBlockNavigationThrottle&) = delete;
 
   static std::unique_ptr<DomainBlockNavigationThrottle> MaybeCreateThrottleFor(
-      content::NavigationThrottleRegistry& registry,
+      content::NavigationHandle* navigation_handle,
       AdBlockService* ad_block_service,
       AdBlockCustomFiltersProvider* ad_block_custom_filters_provider,
       ephemeral_storage::EphemeralStorageService* ephemeral_storage_service,

--- a/components/debounce/content/browser/debounce_navigation_throttle.cc
+++ b/components/debounce/content/browser/debounce_navigation_throttle.cc
@@ -87,7 +87,7 @@ void ClearRedirectChain(NavigationHandle* navigation_handle) {
 // static
 std::unique_ptr<DebounceNavigationThrottle>
 DebounceNavigationThrottle::MaybeCreateThrottleFor(
-    content::NavigationThrottleRegistry& registry,
+    NavigationHandle* navigation_handle,
     DebounceService* debounce_service) {
   // If debouncing is disabled in brave://flags, debounce service will
   // never be created (will be null) so we won't create the throttle
@@ -100,14 +100,14 @@ DebounceNavigationThrottle::MaybeCreateThrottleFor(
     return nullptr;
   }
 
-  return std::make_unique<DebounceNavigationThrottle>(registry,
+  return std::make_unique<DebounceNavigationThrottle>(navigation_handle,
                                                       *debounce_service);
 }
 
 DebounceNavigationThrottle::DebounceNavigationThrottle(
-    content::NavigationThrottleRegistry& registry,
+    NavigationHandle* handle,
     DebounceService& debounce_service)
-    : NavigationThrottle(registry), debounce_service_(debounce_service) {}
+    : NavigationThrottle(handle), debounce_service_(debounce_service) {}
 
 DebounceNavigationThrottle::~DebounceNavigationThrottle() = default;
 

--- a/components/debounce/content/browser/debounce_navigation_throttle.h
+++ b/components/debounce/content/browser/debounce_navigation_throttle.h
@@ -11,15 +11,18 @@
 #include "base/memory/raw_ref.h"
 #include "content/public/browser/navigation_throttle.h"
 
+namespace content {
+class NavigationHandle;
+}
+
 namespace debounce {
 
 class DebounceService;
 
 class DebounceNavigationThrottle : public content::NavigationThrottle {
  public:
-  explicit DebounceNavigationThrottle(
-      content::NavigationThrottleRegistry& registry,
-      DebounceService& debounce_service);
+  explicit DebounceNavigationThrottle(content::NavigationHandle* handle,
+                                      DebounceService& debounce_service);
   ~DebounceNavigationThrottle() override;
 
   DebounceNavigationThrottle(const DebounceNavigationThrottle&) = delete;
@@ -27,7 +30,7 @@ class DebounceNavigationThrottle : public content::NavigationThrottle {
       delete;
 
   static std::unique_ptr<DebounceNavigationThrottle> MaybeCreateThrottleFor(
-      content::NavigationThrottleRegistry& registry,
+      content::NavigationHandle* handle,
       DebounceService* debounce_service);
 
   // Implements content::NavigationThrottle.

--- a/components/decentralized_dns/content/decentralized_dns_navigation_throttle.cc
+++ b/components/decentralized_dns/content/decentralized_dns_navigation_throttle.cc
@@ -27,31 +27,30 @@ namespace decentralized_dns {
 // static
 std::unique_ptr<DecentralizedDnsNavigationThrottle>
 DecentralizedDnsNavigationThrottle::MaybeCreateThrottleFor(
-    content::NavigationThrottleRegistry& registry,
+    content::NavigationHandle* navigation_handle,
     PrefService* user_prefs,
     PrefService* local_state,
     const std::string& locale) {
-  content::NavigationHandle& navigation_handle = registry.GetNavigationHandle();
   content::BrowserContext* context =
-      navigation_handle.GetWebContents()->GetBrowserContext();
+      navigation_handle->GetWebContents()->GetBrowserContext();
   if (context->IsOffTheRecord()) {
     return nullptr;
   }
 
-  if (!navigation_handle.IsInMainFrame()) {
+  if (!navigation_handle->IsInMainFrame()) {
     return nullptr;
   }
 
   return std::make_unique<DecentralizedDnsNavigationThrottle>(
-      registry, user_prefs, local_state, locale);
+      navigation_handle, user_prefs, local_state, locale);
 }
 
 DecentralizedDnsNavigationThrottle::DecentralizedDnsNavigationThrottle(
-    content::NavigationThrottleRegistry& registry,
+    content::NavigationHandle* navigation_handle,
     PrefService* user_prefs,
     PrefService* local_state,
     const std::string& locale)
-    : content::NavigationThrottle(registry),
+    : content::NavigationThrottle(navigation_handle),
       user_prefs_(user_prefs),
       local_state_(local_state),
       locale_(locale) {}

--- a/components/decentralized_dns/content/decentralized_dns_navigation_throttle.h
+++ b/components/decentralized_dns/content/decentralized_dns_navigation_throttle.h
@@ -12,6 +12,10 @@
 #include "base/memory/weak_ptr.h"
 #include "content/public/browser/navigation_throttle.h"
 
+namespace content {
+class NavigationHandle;
+}  // namespace content
+
 class PrefService;
 
 namespace decentralized_dns {
@@ -19,7 +23,7 @@ namespace decentralized_dns {
 class DecentralizedDnsNavigationThrottle : public content::NavigationThrottle {
  public:
   explicit DecentralizedDnsNavigationThrottle(
-      content::NavigationThrottleRegistry& registry,
+      content::NavigationHandle* navigation_handle,
       PrefService* user_prefs,
       PrefService* local_state,
       const std::string& locale);
@@ -31,7 +35,7 @@ class DecentralizedDnsNavigationThrottle : public content::NavigationThrottle {
       const DecentralizedDnsNavigationThrottle&) = delete;
 
   static std::unique_ptr<DecentralizedDnsNavigationThrottle>
-  MaybeCreateThrottleFor(content::NavigationThrottleRegistry& registry,
+  MaybeCreateThrottleFor(content::NavigationHandle* navigation_handle,
                          PrefService* user_prefs,
                          PrefService* local_state,
                          const std::string& locale);

--- a/components/request_otr/browser/request_otr_navigation_throttle.cc
+++ b/components/request_otr/browser/request_otr_navigation_throttle.cc
@@ -35,7 +35,7 @@ namespace request_otr {
 // static
 std::unique_ptr<RequestOTRNavigationThrottle>
 RequestOTRNavigationThrottle::MaybeCreateThrottleFor(
-    content::NavigationThrottleRegistry& registry,
+    content::NavigationHandle* navigation_handle,
     RequestOTRService* request_otr_service,
     ephemeral_storage::EphemeralStorageService* ephemeral_storage_service,
     PrefService* pref_service,
@@ -56,16 +56,15 @@ RequestOTRNavigationThrottle::MaybeCreateThrottleFor(
   }
 
   // If this is the system profile, then we don't need the throttle.
-  content::NavigationHandle& navigation_handle = registry.GetNavigationHandle();
   if (profile_metrics::GetBrowserProfileType(
-          navigation_handle.GetWebContents()->GetBrowserContext()) ==
+          navigation_handle->GetWebContents()->GetBrowserContext()) ==
       profile_metrics::BrowserProfileType::kSystem) {
     return nullptr;
   }
   DCHECK(ephemeral_storage_service);
 
   // Don't block subframes.
-  if (!navigation_handle.IsInMainFrame()) {
+  if (!navigation_handle->IsInMainFrame()) {
     return nullptr;
   }
 
@@ -77,17 +76,17 @@ RequestOTRNavigationThrottle::MaybeCreateThrottleFor(
   }
 
   return std::make_unique<RequestOTRNavigationThrottle>(
-      registry, request_otr_service, ephemeral_storage_service, pref_service,
-      locale);
+      navigation_handle, request_otr_service, ephemeral_storage_service,
+      pref_service, locale);
 }
 
 RequestOTRNavigationThrottle::RequestOTRNavigationThrottle(
-    content::NavigationThrottleRegistry& registry,
+    content::NavigationHandle* navigation_handle,
     RequestOTRService* request_otr_service,
     ephemeral_storage::EphemeralStorageService* ephemeral_storage_service,
     PrefService* pref_service,
     const std::string& locale)
-    : content::NavigationThrottle(registry),
+    : content::NavigationThrottle(navigation_handle),
       request_otr_service_(request_otr_service),
       ephemeral_storage_service_(ephemeral_storage_service),
       pref_service_(pref_service),

--- a/components/request_otr/browser/request_otr_navigation_throttle.h
+++ b/components/request_otr/browser/request_otr_navigation_throttle.h
@@ -18,6 +18,10 @@
 
 class PrefService;
 
+namespace content {
+class NavigationHandle;
+}  // namespace content
+
 namespace ephemeral_storage {
 class EphemeralStorageService;
 }  // namespace ephemeral_storage
@@ -29,7 +33,7 @@ class RequestOTRService;
 class RequestOTRNavigationThrottle : public content::NavigationThrottle {
  public:
   explicit RequestOTRNavigationThrottle(
-      content::NavigationThrottleRegistry& registry,
+      content::NavigationHandle* navigation_handle,
       RequestOTRService* request_otr_service,
       ephemeral_storage::EphemeralStorageService* ephemeral_storage_service,
       PrefService* pref_service,
@@ -41,7 +45,7 @@ class RequestOTRNavigationThrottle : public content::NavigationThrottle {
       delete;
 
   static std::unique_ptr<RequestOTRNavigationThrottle> MaybeCreateThrottleFor(
-      content::NavigationThrottleRegistry& registry,
+      content::NavigationHandle* navigation_handle,
       RequestOTRService* request_otr_service,
       ephemeral_storage::EphemeralStorageService* ephemeral_storage_service,
       PrefService* pref_service,

--- a/components/tor/onion_location_navigation_throttle.cc
+++ b/components/tor/onion_location_navigation_throttle.cc
@@ -41,20 +41,21 @@ bool GetOnionLocation(const net::HttpResponseHeaders* headers,
 // static
 std::unique_ptr<OnionLocationNavigationThrottle>
 OnionLocationNavigationThrottle::MaybeCreateThrottleFor(
-    content::NavigationThrottleRegistry& registry,
+    content::NavigationHandle* navigation_handle,
     bool is_tor_disabled,
     bool is_tor_profile) {
-  if (is_tor_disabled || !registry.GetNavigationHandle().IsInMainFrame()) {
+  if (is_tor_disabled || !navigation_handle->IsInMainFrame()) {
     return nullptr;
   }
-  return std::make_unique<OnionLocationNavigationThrottle>(registry,
+  return std::make_unique<OnionLocationNavigationThrottle>(navigation_handle,
                                                            is_tor_profile);
 }
 
 OnionLocationNavigationThrottle::OnionLocationNavigationThrottle(
-    content::NavigationThrottleRegistry& registry,
+    content::NavigationHandle* navigation_handle,
     bool is_tor_profile)
-    : content::NavigationThrottle(registry), is_tor_profile_(is_tor_profile) {}
+    : content::NavigationThrottle(navigation_handle),
+      is_tor_profile_(is_tor_profile) {}
 
 OnionLocationNavigationThrottle::~OnionLocationNavigationThrottle() = default;
 

--- a/components/tor/onion_location_navigation_throttle.h
+++ b/components/tor/onion_location_navigation_throttle.h
@@ -13,6 +13,7 @@
 class GURL;
 
 namespace content {
+class NavigationHandle;
 class WebContents;
 }  // namespace content
 
@@ -21,11 +22,11 @@ namespace tor {
 class OnionLocationNavigationThrottle : public content::NavigationThrottle {
  public:
   static std::unique_ptr<OnionLocationNavigationThrottle>
-  MaybeCreateThrottleFor(content::NavigationThrottleRegistry& registry,
+  MaybeCreateThrottleFor(content::NavigationHandle* navigation_handle,
                          bool is_tor_disabled,
                          bool is_tor_profile);
   explicit OnionLocationNavigationThrottle(
-      content::NavigationThrottleRegistry& registry,
+      content::NavigationHandle* navigation_handle,
       bool is_tor_profile);
   ~OnionLocationNavigationThrottle() override;
 

--- a/components/tor/tor_navigation_throttle.cc
+++ b/components/tor/tor_navigation_throttle.cc
@@ -20,36 +20,36 @@ bool TorNavigationThrottle::skip_wait_for_tor_connected_for_testing_ = false;
 // static
 std::unique_ptr<TorNavigationThrottle>
 TorNavigationThrottle::MaybeCreateThrottleFor(
-    content::NavigationThrottleRegistry& registry,
+    content::NavigationHandle* navigation_handle,
     bool is_tor_profile) {
   if (!is_tor_profile)
     return nullptr;
-  return std::make_unique<TorNavigationThrottle>(registry);
+  return std::make_unique<TorNavigationThrottle>(navigation_handle);
 }
 
 // static
 std::unique_ptr<TorNavigationThrottle>
 TorNavigationThrottle::MaybeCreateThrottleFor(
-    content::NavigationThrottleRegistry& registry,
+    content::NavigationHandle* navigation_handle,
     TorLauncherFactory& tor_launcher_factory,
     bool is_tor_profile) {
   if (!is_tor_profile)
     return nullptr;
-  return std::make_unique<TorNavigationThrottle>(registry,
+  return std::make_unique<TorNavigationThrottle>(navigation_handle,
                                                  tor_launcher_factory);
 }
 
 TorNavigationThrottle::TorNavigationThrottle(
-    content::NavigationThrottleRegistry& registry)
-    : content::NavigationThrottle(registry),
+    content::NavigationHandle* navigation_handle)
+    : content::NavigationThrottle(navigation_handle),
       tor_launcher_factory_(*TorLauncherFactory::GetInstance()) {
   tor_launcher_factory_->AddObserver(this);
 }
 
 TorNavigationThrottle::TorNavigationThrottle(
-    content::NavigationThrottleRegistry& registry,
+    content::NavigationHandle* navigation_handle,
     TorLauncherFactory& tor_launcher_factory)
-    : content::NavigationThrottle(registry),
+    : content::NavigationThrottle(navigation_handle),
       tor_launcher_factory_(tor_launcher_factory) {
   tor_launcher_factory_->AddObserver(this);
 }

--- a/components/tor/tor_navigation_throttle.h
+++ b/components/tor/tor_navigation_throttle.h
@@ -13,6 +13,10 @@
 #include "brave/components/tor/tor_launcher_observer.h"
 #include "content/public/browser/navigation_throttle.h"
 
+namespace content {
+class NavigationHandle;
+}  // namespace content
+
 class TorLauncherFactory;
 
 namespace tor {
@@ -21,15 +25,15 @@ class TorNavigationThrottle : public content::NavigationThrottle,
                               public TorLauncherObserver {
  public:
   static std::unique_ptr<TorNavigationThrottle> MaybeCreateThrottleFor(
-      content::NavigationThrottleRegistry& registry,
+      content::NavigationHandle* navigation_handle,
       bool is_tor_profile);
   // For tests to use its own McokTorLauncherFactory
   static std::unique_ptr<TorNavigationThrottle> MaybeCreateThrottleFor(
-      content::NavigationThrottleRegistry& registry,
+      content::NavigationHandle* navigation_handle,
       TorLauncherFactory& tor_launcher_factory,
       bool is_tor_profile);
-  explicit TorNavigationThrottle(content::NavigationThrottleRegistry& registry);
-  TorNavigationThrottle(content::NavigationThrottleRegistry& registry,
+  explicit TorNavigationThrottle(content::NavigationHandle* navigation_handle);
+  TorNavigationThrottle(content::NavigationHandle* navigation_handle,
                         TorLauncherFactory& tor_launcher_factory);
   TorNavigationThrottle(const TorNavigationThrottle&) = delete;
   TorNavigationThrottle& operator=(const TorNavigationThrottle&) = delete;


### PR DESCRIPTION
This reverts commit 00ef89cfc3db05257b6c9c6e1b1704fe83d5e644.

There have been network audit failures that may be due to this PR:

https://ci.brave.com/job/brave-browser-build-linux-x64-asan/1776/testReport/junit/(root)/BraveNetworkAuditSearchAdTest/linux_x64___audit_network___SearchAdTest/
https://ci.brave.com/job/brave-browser-build-linux-x64-asan/1776/testReport/junit/(root)/BraveNetworkAuditTest/linux_x64___audit_network___BasicTests/
https://ci.brave.com/job/brave-browser-build-linux-x64-asan/1776/testReport/junit/(root)/BraveRewardsNetworkAuditTest/linux_x64___audit_network___BasicTests/
