### PR TITLE
[ads] Fix New Tab Takeover infobar text truncation (uplift to 1.80)

### DIFF
--- a/browser/ntp_background/BUILD.gn
+++ b/browser/ntp_background/BUILD.gn
@@ -27,6 +27,7 @@ source_set("ntp_background") {
     "//brave/components/brave_ads/core/public:headers",
     "//brave/components/brave_rewards/core",
     "//brave/components/constants",
+    "//brave/components/infobars/core",
     "//brave/components/ntp_background_images/browser",
     "//brave/components/ntp_background_images/buildflags",
     "//brave/components/ntp_background_images/common",

--- a/browser/ntp_background/DEPS
+++ b/browser/ntp_background/DEPS
@@ -1,4 +1,5 @@
 include_rules = [
   "+brave/components/brave_ads/core/browser/service",
   "+brave/components/brave_ads/core/mojom",
+  "+brave/components/infobars/core/brave_confirm_infobar_delegate.h",
 ]

--- a/browser/ntp_background/new_tab_takeover_infobar_delegate.h
+++ b/browser/ntp_background/new_tab_takeover_infobar_delegate.h
@@ -6,18 +6,28 @@
 #ifndef BRAVE_BROWSER_NTP_BACKGROUND_NEW_TAB_TAKEOVER_INFOBAR_DELEGATE_H_
 #define BRAVE_BROWSER_NTP_BACKGROUND_NEW_TAB_TAKEOVER_INFOBAR_DELEGATE_H_
 
+#include <string>
+#include <vector>
+
 #include "base/memory/raw_ptr.h"
-#include "components/infobars/core/confirm_infobar_delegate.h"
+#include "brave/components/infobars/core/brave_confirm_infobar_delegate.h"
+#include "components/infobars/core/infobar_delegate.h"
 
 class PrefService;
+class GURL;
+enum class WindowOpenDisposition;
 
 namespace content {
 class WebContents;
 }  // namespace content
 
+namespace ui {
+class ImageModel;
+}  // namespace ui
+
 namespace ntp_background_images {
 
-class NewTabTakeoverInfoBarDelegate : public ConfirmInfoBarDelegate {
+class NewTabTakeoverInfoBarDelegate : public BraveConfirmInfoBarDelegate {
  public:
   explicit NewTabTakeoverInfoBarDelegate(PrefService* prefs);
 
@@ -41,6 +51,10 @@ class NewTabTakeoverInfoBarDelegate : public ConfirmInfoBarDelegate {
   GURL GetLinkURL() const override;
   bool LinkClicked(WindowOpenDisposition disposition) override;
   void InfoBarDismissed() override;
+
+  // BraveConfirmInfoBarDelegate:
+  std::vector<int> GetButtonsOrder() const override;
+  bool ShouldSupportMultiLine() const override;
 
  private:
   const raw_ptr<PrefService> prefs_;

--- a/browser/ui/views/infobars/brave_confirm_infobar.h
+++ b/browser/ui/views/infobars/brave_confirm_infobar.h
@@ -42,6 +42,8 @@ class BraveConfirmInfoBar : public InfoBarView {
   // InfoBarView:
   int GetContentMinimumWidth() const override;
 
+  void MaybeLayoutMultiLineLabelAndLink();
+
   void OkButtonPressed();
   void CancelButtonPressed();
   void ExtraButtonPressed();

--- a/components/infobars/core/brave_confirm_infobar_delegate.cc
+++ b/components/infobars/core/brave_confirm_infobar_delegate.cc
@@ -45,3 +45,12 @@ bool BraveConfirmInfoBarDelegate::InterceptClosing() {
 bool BraveConfirmInfoBarDelegate::ExtraButtonPressed() {
   return true;
 }
+
+bool BraveConfirmInfoBarDelegate::ShouldSupportMultiLine() const {
+  return false;
+}
+
+size_t BraveConfirmInfoBarDelegate::GetMaxLines() const {
+  // Return 0 to indicate that there is no limit on the number of lines.
+  return 0;
+}

--- a/components/infobars/core/brave_confirm_infobar_delegate.h
+++ b/components/infobars/core/brave_confirm_infobar_delegate.h
@@ -6,6 +6,7 @@
 #ifndef BRAVE_COMPONENTS_INFOBARS_CORE_BRAVE_CONFIRM_INFOBAR_DELEGATE_H_
 #define BRAVE_COMPONENTS_INFOBARS_CORE_BRAVE_CONFIRM_INFOBAR_DELEGATE_H_
 
+#include <cstddef>
 #include <string>
 #include <vector>
 
@@ -28,6 +29,8 @@ class BraveConfirmInfoBarDelegate : public ConfirmInfoBarDelegate {
   virtual std::vector<int> GetButtonsOrder() const;
   virtual bool IsProminent(int id) const;
   virtual bool ExtraButtonPressed();
+  virtual bool ShouldSupportMultiLine() const;
+  virtual size_t GetMaxLines() const;
 
   int GetButtons() const override;
 


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/29507
Resolves https://github.com/brave/brave-browser/issues/46507

Uplift of https://github.com/brave/brave-core/pull/29516
Resolves https://github.com/brave/brave-browser/issues/46755

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.