### PR TITLE
[iOS] Block Leo from opening using shortcut button while private browsing (uplift to 1.80.x)

### DIFF
--- a/ios/brave-ios/Sources/AIChat/AIChatStrings.swift
+++ b/ios/brave-ios/Sources/AIChat/AIChatStrings.swift
@@ -1108,5 +1108,23 @@ extension Strings {
       comment:
         "The message that shows in an alert, to let the user know the 'Leo' feature is disabled, and explains how to re-enable the feature."
     )
+    public static let leoDisabledPrivateBrowsingMessageTitle = NSLocalizedString(
+      "aichat.leoDisabledPrivateBrowsingMessageTitle",
+      tableName: "BraveLeo",
+      bundle: .module,
+      value:
+        "Leo Not Available",
+      comment:
+        "The title that shows in an alert when the Leo/AI-Chat is disabled due to the user being in private browsing mode."
+    )
+    public static let leoDisabledPrivateBrowsingMessageDescription = NSLocalizedString(
+      "aichat.leoDisabledPrivateBrowsingMessageDescription",
+      tableName: "BraveLeo",
+      bundle: .module,
+      value:
+        "Leo is currently not available in Private Browsing Mode. To use Leo, please exit Private Browsing Mode and try again.",
+      comment:
+        "The message that shows in an alert, to let the user know the 'Leo' feature is disabled in private browsing mode."
+    )
   }
 }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -3280,7 +3280,19 @@ extension BrowserViewController {
         message: Strings.AIChat.leoDisabledMessageDescription,
         preferredStyle: .alert
       )
-      let action = UIAlertAction(title: Strings.OKString, style: .default)
+      let action = UIAlertAction(title: Strings.OBErrorOkay, style: .default)
+      alert.addAction(action)
+      present(alert, animated: true)
+      return
+    }
+
+    if privateBrowsingManager.isPrivateBrowsing {
+      let alert = UIAlertController(
+        title: Strings.AIChat.leoDisabledPrivateBrowsingMessageTitle,
+        message: Strings.AIChat.leoDisabledPrivateBrowsingMessageDescription,
+        preferredStyle: .alert
+      )
+      let action = UIAlertAction(title: Strings.OBErrorOkay, style: .default)
       alert.addAction(action)
       present(alert, animated: true)
       return


### PR DESCRIPTION
Uplift of #29395
Resolves https://github.com/brave/brave-browser/issues/46423

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.