### PR TITLE
[AI Chat]: Display Loading Spinner After Submission

### DIFF
--- a/components/ai_chat/resources/untrusted_conversation_frame/components/conversation_entries/index.test.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/conversation_entries/index.test.tsx
@@ -11,11 +11,19 @@ import { useUntrustedConversationContext }
   from '../../untrusted_conversation_context'
 import ConversationEntries from '.'
 
-const assistantResponseMock = jest.fn(() => <div />)
+interface AssistantResponseProps {
+  entry: Mojom.ConversationTurn
+  isEntryInProgress: boolean
+  allowedLinks: string[]
+  isLeoModel: boolean
+}
+
+const assistantResponseMock =
+  jest.fn((props: AssistantResponseProps) => <div />)
 
 jest.mock('../assistant_response', () => ({
   __esModule: true,
-  default: (props: any) => {
+  default: (props: AssistantResponseProps) => {
     assistantResponseMock(props)
     return <div />
   }
@@ -72,5 +80,68 @@ describe('ConversationEntries allowedLinks per response', () => {
     expect(assistantResponseMock).toHaveBeenCalledTimes(2)
     expect(assistantResponseMock.mock.calls[0][0].allowedLinks).toEqual(['https://a.com'])
     expect(assistantResponseMock.mock.calls[1][0].allowedLinks).toEqual(['https://b.com'])
+  })
+})
+
+describe('ConversationEntries loading spinner', () => {
+  const turn1 = {
+    uuid: '1',
+    characterType: Mojom.CharacterType.HUMAN,
+    actionType: Mojom.ActionType.UNSPECIFIED,
+    text: 'Human turn',
+    prompt: undefined,
+    selectedText: undefined,
+    events: [],
+    createdTime: { internalValue: BigInt(Date.now() * 1000) },
+    edits: undefined,
+    uploadedFiles: undefined,
+    fromBraveSearchSERP: false,
+    modelKey: undefined
+  }
+
+  const turn2 = {
+    ...turn1,
+    uuid: '2',
+    characterType: Mojom.CharacterType.ASSISTANT,
+    text: 'Assistant response',
+    events: [{
+      completionEvent: { completion: 'Assistant response' },
+      searchQueriesEvent: undefined,
+      searchStatusEvent: undefined,
+      sourcesEvent: undefined,
+      selectedLanguageEvent: undefined,
+      contentReceiptEvent: undefined,
+      conversationTitleEvent: undefined
+    }]
+  }
+
+  const setupContext = (history: Mojom.ConversationTurn[]) => {
+    assistantResponseMock.mockClear()
+    ;(useUntrustedConversationContext as jest.Mock).mockReturnValue({
+      conversationHistory: history,
+      isGenerating: true,
+      isMobile: false,
+      isLeoModel: true,
+      allModels: [],
+      canSubmitUserEntries: true,
+      conversationHandler: null,
+      trimmedTokens: 0,
+      totalTokens: 100,
+      contentUsedPercentage: 100
+    })
+    const { container } = render(<ConversationEntries />)
+    const loadingSpinner = container.querySelector('leo-progressring')
+    return loadingSpinner
+  }
+
+  it('shows loading spinner when human turn is'
+    + 'submitted and isGenerating is true', () => {
+    const loadingSpinner = setupContext([turn1])
+    expect(loadingSpinner).toBeInTheDocument()
+  })
+
+  it('does not show loading spinner when completion event is present', () => {
+    const loadingSpinner = setupContext([turn1, turn2])
+    expect(loadingSpinner).not.toBeInTheDocument()
   })
 })

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/conversation_entries/index.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/conversation_entries/index.tsx
@@ -4,6 +4,7 @@
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import * as React from 'react'
+import ProgressRing from '@brave/leo/react/progressRing'
 import classnames from '$web-common/classnames'
 import { getLocale } from '$web-common/locale'
 import useLongPress from '$web-common/useLongPress'
@@ -69,6 +70,8 @@ function ConversationEntries() {
           const isEntryInProgress =
             isLastEntry && isAIAssistant && conversationContext.isGenerating
           const isHuman = turn.characterType === Mojom.CharacterType.HUMAN
+          const isGeneratingResponse =
+            isHuman && isLastEntry && conversationContext.isGenerating
           const showLongPageContentInfo =
             id === 1 &&
             isAIAssistant &&
@@ -227,6 +230,9 @@ function ConversationEntries() {
                       onCopyTextClicked={handleCopyText}
                     />
                   )}
+                {isGeneratingResponse && (
+                  <div className={styles.loading}><ProgressRing /></div>
+                )}
               </div>
             </div>
           )

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/conversation_entries/style.module.scss
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/conversation_entries/style.module.scss
@@ -86,3 +86,16 @@
   overflow-y: auto;
   gap: var(--leo-spacing-s);
 }
+
+.loading {
+  display: flex;
+  justify-content: flex-start;
+  width: 100%;
+  // Added padding to the top to avoid layout shift between this
+  // loading spinner and the "Improving answer with Brave Search…"
+  // loading spinner.
+  padding-top: 10px;
+  --leo-progressring-color: var(--leo-color-icon-interactive);
+  --leo-progressring-size: 15px;
+  --leo-icon-size: 20px;
+}


### PR DESCRIPTION
## Description 

Will now display a `Loading Spinner` immediately upon user submission.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/46671>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

## Test Plan:
1. Start a conversation with `Leo AI`
2. You should see a `Loading Spinner` immediately upon submitting your turn.
3. The `Loading Spinner` should go away after `Assistant Response`

https://github.com/user-attachments/assets/64202da6-7f1e-4189-ba7f-e0cd6d970640
