### PR TITLE
[CodeHealth] Remove `NoDestructor` use in `md_text_buttons.h`

### DIFF
--- a/chromium_src/check_chromium_src_config.json5
+++ b/chromium_src/check_chromium_src_config.json5
@@ -44,6 +44,7 @@
         "net/base/brave_proxy_string_util_unittest.cc",
         "net/cookies/brave_canonical_cookie_unittest.cc",
         "v8/include/DO NOT PUT FILES HERE",
+        "ui/views/controls/button/md_text_button_constants_unittest.cc"
     ],
 
     // These symbols found in associated paths will be ignored.

--- a/chromium_src/ui/views/controls/button/md_text_button.h
+++ b/chromium_src/ui/views/controls/button/md_text_button.h
@@ -29,6 +29,24 @@
 #undef MdTextButton
 
 namespace views {
+
+namespace internal {
+
+// These colours are snapshots of specific alpha blends, to be able to use them
+// in a constexpr context. Check
+// chromium_src/ui/views/controls/button/md_text_button_constants_unittest.cc
+// for the recipes.
+inline constexpr SkColor kColorButtonBackgroundBlack = 4281478842u;
+inline constexpr SkColor kColorButtonBackgroundWhite = 4284834285u;
+inline constexpr SkColor kColorDividerInteractiveBlack = 2234792601u;
+inline constexpr SkColor kColorTextInteractiveBlack = 4281478842u;
+inline constexpr SkColor kColorDividerInteractiveWhite = 2241240571u;
+inline constexpr SkColor kColorTextInteractiveDarkWhite = 4288063487u;
+inline constexpr SkColor kColorTextSecondaryBlack = 4281482820u;
+inline constexpr SkColor kColorTextSecondaryDarkWhite = 4292994535u;
+
+}  // namespace internal
+
 // Make visual changes to MdTextButton in line with Brave visual style:
 //  - More rounded rectangle (for regular border, focus ring and ink drop)
 //  - Different hover text and boder color for non-prominent button

--- a/chromium_src/ui/views/controls/button/md_text_button_constants_unittest.cc
+++ b/chromium_src/ui/views/controls/button/md_text_button_constants_unittest.cc
@@ -1,0 +1,49 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "testing/gtest/include/gtest/gtest.h"
+#include "ui/gfx/color_palette.h"
+#include "ui/gfx/color_utils.h"
+#include "ui/views/controls/button/md_text_button.h"
+
+TEST(MdTextButtonConstantsTest, ExpectedAlphaBlendConstants) {
+  // This test verifies that the constants used in the MdTextButton internally
+  // match the expected alpha blend results. In case these test fails, it
+  // indicates that the values in `gfx` potentially changed, and the constants
+  // in `views` need to be updated accordingly, based on the new alpha blend
+  // results emitted by the test failure.
+  EXPECT_EQ(
+      color_utils::AlphaBlend(SK_ColorBLACK, gfx::kColorButtonBackground, 0.2f),
+      views::internal::kColorButtonBackgroundBlack)
+      << "kColorButtonBackgroundBlack needs to be updated.";
+  EXPECT_EQ(
+      color_utils::AlphaBlend(SK_ColorWHITE, gfx::kColorButtonBackground, 0.2f),
+      views::internal::kColorButtonBackgroundWhite)
+      << "kColorButtonBackgroundWhite needs to be updated.";
+  EXPECT_EQ(color_utils::AlphaBlend(SK_ColorBLACK,
+                                    gfx::kColorDividerInteractive, 0.2f),
+            views::internal::kColorDividerInteractiveBlack)
+      << "kColorDividerInteractiveBlack needs to be updated.";
+  EXPECT_EQ(
+      color_utils::AlphaBlend(SK_ColorBLACK, gfx::kColorTextInteractive, 0.2f),
+      views::internal::kColorTextInteractiveBlack)
+      << "kColorTextInteractiveBlack needs to be updated.";
+  EXPECT_EQ(color_utils::AlphaBlend(SK_ColorWHITE,
+                                    gfx::kColorDividerInteractive, 0.2f),
+            views::internal::kColorDividerInteractiveWhite)
+      << "kColorDividerInteractiveWhite needs to be updated.";
+  EXPECT_EQ(color_utils::AlphaBlend(SK_ColorWHITE,
+                                    gfx::kColorTextInteractiveDark, 0.2f),
+            views::internal::kColorTextInteractiveDarkWhite)
+      << "kColorTextInteractiveDarkWhite needs to be updated.";
+  EXPECT_EQ(
+      color_utils::AlphaBlend(SK_ColorBLACK, gfx::kColorTextSecondary, 0.2f),
+      views::internal::kColorTextSecondaryBlack)
+      << "kColorTextSecondaryBlack needs to be updated.";
+  EXPECT_EQ(color_utils::AlphaBlend(SK_ColorWHITE, gfx::kColorTextSecondaryDark,
+                                    0.2f),
+            views::internal::kColorTextSecondaryDarkWhite)
+      << "kColorTextSecondaryDarkWhite needs to be updated.";
+}

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -427,6 +427,7 @@ test("brave_unit_tests") {
       "//brave/chromium_src/chrome/browser/devtools/url_constants_unittest.cc",
       "//brave/chromium_src/chrome/browser/profiles/profile_avatar_icon_util_unittest.cc",
       "//brave/chromium_src/components/update_client/request_sender_unittest.cc",
+      "//brave/chromium_src/ui/views/controls/button/md_text_button_constants_unittest.cc",
       "//chrome/browser/push_messaging/push_messaging_app_identifier_unittest.cc",
       "//chrome/browser/push_messaging/push_messaging_notification_manager_unittest.cc",
       "//chrome/browser/push_messaging/push_messaging_service_unittest.cc",


### PR DESCRIPTION
This PR removes the use of `NoDestructor` for this particular map with button themes. The data itself is `constexpr`-compatible already, however some of the values are produced through calls to `color_utils::AlphaBlend`, which cannot be used in a `constexpr` context. To correct this, this PR creates a couple of constants to store the result of the `AlphaBlend` call.

This PR also adds a test to make sure that the result of the `AlphaBlend` call is kept consistent, and that some failure is produced whenever a value slides.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/46863

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
