### PR TITLE
[CodeHealth] Make known chain maps `constexpr` in `network_manager.cc`

### DIFF
--- a/browser/brave_wallet/brave_wallet_service_unittest.cc
+++ b/browser/brave_wallet/brave_wallet_service_unittest.cc
@@ -1994,13 +1994,13 @@ TEST_F(BraveWalletServiceUnitTest, MigrateEip1559ForCustomNetworks) {
               "0xe708": true
             })"));
 
-  EXPECT_FALSE(*network_manager_->IsEip1559Chain("0x4e454152"));
-  EXPECT_TRUE(*network_manager_->IsEip1559Chain("0x1"));
-  EXPECT_TRUE(*network_manager_->IsEip1559Chain("0xe708"));
-  EXPECT_FALSE(*network_manager_->IsEip1559Chain(mojom::kLocalhostChainId));
+  EXPECT_FALSE(network_manager_->IsEip1559Chain("0x4e454152"));
+  EXPECT_TRUE(network_manager_->IsEip1559Chain("0x1"));
+  EXPECT_TRUE(network_manager_->IsEip1559Chain("0xe708"));
+  EXPECT_FALSE(network_manager_->IsEip1559Chain(mojom::kLocalhostChainId));
 
   // solana does not get into this list.
-  EXPECT_FALSE(network_manager_->IsEip1559Chain("0x66").has_value());
+  EXPECT_FALSE(network_manager_->IsEip1559Chain("0x66"));
 
   EXPECT_TRUE(
       GetPrefs()->GetBoolean(kBraveWalletEip1559ForCustomNetworksMigrated));

--- a/components/brave_wallet/browser/BUILD.gn
+++ b/components/brave_wallet/browser/BUILD.gn
@@ -442,6 +442,11 @@ source_set("utils") {
     "//third_party/boringssl",
     "//ui/base",
     "//url",
+
+    # TODO(https://github.com/brave/brave-browser/issues/46940): Remove this
+    # dependency to version_info once crash dumps have been collected for
+    # MakeChainIdLowerCase.
+    "//base/version_info:version_info",
   ]
 
   public_deps = [ "//brave/components/brave_wallet/common" ]

--- a/components/brave_wallet/browser/eth_tx_manager.cc
+++ b/components/brave_wallet/browser/eth_tx_manager.cc
@@ -168,9 +168,7 @@ void EthTxManager::AddUnapprovedEvmTransaction(
       mojom::TxData::New("", "", params->gas_limit, params->to, params->value,
                          params->data, false, std::nullopt);
 
-  if (!json_rpc_service_->network_manager()
-           ->IsEip1559Chain(params->chain_id)
-           .value_or(false)) {
+  if (!json_rpc_service_->network_manager()->IsEip1559Chain(params->chain_id)) {
     AddUnapprovedTransaction(params->chain_id, std::move(tx_data), params->from,
                              std::move(origin_val), std::move(callback));
   } else {

--- a/components/brave_wallet/browser/eth_tx_manager_unittest.cc
+++ b/components/brave_wallet/browser/eth_tx_manager_unittest.cc
@@ -522,7 +522,7 @@ TEST_F(EthTxManagerUnitTest, AddUnapprovedEvmTransaction) {
         mojom::kMainnetChainId, from(),
         "0xbe862ad9abfe6f22bcb087716c7d89a26051f74c", "0x016345785d8a0000",
         "0x0974", data_);
-    EXPECT_TRUE(*network_manager_->IsEip1559Chain(params->chain_id));
+    EXPECT_TRUE(network_manager_->IsEip1559Chain(params->chain_id));
 
     bool callback_called = false;
     std::string tx_meta_id;
@@ -546,7 +546,7 @@ TEST_F(EthTxManagerUnitTest, AddUnapprovedEvmTransaction) {
         mojom::kBnbSmartChainMainnetChainId, from(),
         "0xbe862ad9abfe6f22bcb087716c7d89a26051f74c", "0x016345785d8a0000",
         "0x0974", data_);
-    EXPECT_FALSE(*network_manager_->IsEip1559Chain(params->chain_id));
+    EXPECT_FALSE(network_manager_->IsEip1559Chain(params->chain_id));
 
     bool callback_called = false;
     std::string tx_meta_id;
@@ -569,8 +569,7 @@ TEST_F(EthTxManagerUnitTest, AddUnapprovedEvmTransaction) {
     auto params = mojom::NewEvmTransactionParams::New(
         "0x1234", from(), "0xbe862ad9abfe6f22bcb087716c7d89a26051f74c",
         "0x016345785d8a0000", "0x0974", data_);
-    EXPECT_FALSE(
-        network_manager_->IsEip1559Chain(params->chain_id).has_value());
+    EXPECT_FALSE(network_manager_->IsEip1559Chain(params->chain_id));
 
     bool callback_called = false;
     std::string tx_meta_id;

--- a/components/brave_wallet/browser/ethereum_provider_impl.cc
+++ b/components/brave_wallet/browser/ethereum_provider_impl.cc
@@ -296,9 +296,8 @@ void EthereumProviderImpl::SendOrSignTransactionInternal(
   if (!account_id) {
     return;
   }
-  const bool is_eip_1559_network = brave_wallet_service_->network_manager()
-                                       ->IsEip1559Chain(chain->chain_id)
-                                       .value_or(false);
+  const bool is_eip_1559_network =
+      brave_wallet_service_->network_manager()->IsEip1559Chain(chain->chain_id);
   if (is_eip_1559_network && ShouldCreate1559Tx(*tx_data_1559)) {
     // Set chain_id to current chain_id.
     tx_data_1559->chain_id = chain->chain_id;

--- a/components/brave_wallet/browser/json_rpc_service_unittest.cc
+++ b/components/brave_wallet/browser/json_rpc_service_unittest.cc
@@ -820,7 +820,7 @@ class JsonRpcServiceUnitTest : public testing::Test {
   }
 
   bool GetIsEip1559FromPrefs(const std::string& chain_id) {
-    return network_manager_->IsEip1559Chain(chain_id).value_or(false);
+    return network_manager_->IsEip1559Chain(chain_id);
   }
 
   void SetEthTokenInfoInterceptor(const GURL& network_url,

--- a/components/brave_wallet/browser/network_manager.h
+++ b/components/brave_wallet/browser/network_manager.h
@@ -52,7 +52,7 @@ class NetworkManager {
   GURL GetNetworkURL(mojom::CoinType coin,
                      const std::optional<url::Origin>& origin);
 
-  std::optional<bool> IsEip1559Chain(std::string_view chain_id);
+  bool IsEip1559Chain(std::string_view chain_id);
   void SetEip1559ForCustomChain(std::string_view chain_id,
                                 std::optional<bool> is_eip1559);
 

--- a/components/brave_wallet/browser/network_manager_unittest.cc
+++ b/components/brave_wallet/browser/network_manager_unittest.cc
@@ -600,7 +600,7 @@ TEST_F(NetworkManagerUnitTest, Eip1559Chain) {
       {mojom::kNeonEVMMainnetChainId, false},
       {mojom::kLocalhostChainId, false}};
   for (auto& [chain_id, value] : known_states) {
-    EXPECT_EQ(network_manager()->IsEip1559Chain(chain_id).value(), value);
+    EXPECT_EQ(network_manager()->IsEip1559Chain(chain_id), value);
   }
 
   // Custom chain.
@@ -608,24 +608,24 @@ TEST_F(NetworkManagerUnitTest, Eip1559Chain) {
   EXPECT_FALSE(network_manager()->IsEip1559Chain(custom_chain_id));
 
   network_manager()->SetEip1559ForCustomChain(custom_chain_id, true);
-  EXPECT_TRUE(*network_manager()->IsEip1559Chain(custom_chain_id));
+  EXPECT_TRUE(network_manager()->IsEip1559Chain(custom_chain_id));
   EXPECT_EQ(*dict().FindBool(custom_chain_id), true);
 
   network_manager()->SetEip1559ForCustomChain(
       base::ToUpperASCII(custom_chain_id), false);
   EXPECT_FALSE(
-      *network_manager()->IsEip1559Chain(base::ToUpperASCII(custom_chain_id)));
+      network_manager()->IsEip1559Chain(base::ToUpperASCII(custom_chain_id)));
   EXPECT_EQ(*dict().FindBool(custom_chain_id), false);
 
   network_manager()->SetEip1559ForCustomChain(custom_chain_id, std::nullopt);
-  EXPECT_FALSE(network_manager()->IsEip1559Chain(custom_chain_id).has_value());
+  EXPECT_FALSE(network_manager()->IsEip1559Chain(custom_chain_id));
   EXPECT_EQ(dict().FindBool(custom_chain_id), std::nullopt);
 
   // Custom chain overriding known one.
   network_manager()->SetEip1559ForCustomChain(mojom::kPolygonMainnetChainId,
                                               false);
   EXPECT_FALSE(
-      *network_manager()->IsEip1559Chain(mojom::kPolygonMainnetChainId));
+      network_manager()->IsEip1559Chain(mojom::kPolygonMainnetChainId));
   EXPECT_EQ(*dict().FindBool(mojom::kPolygonMainnetChainId), false);
 
   network_manager()->SetEip1559ForCustomChain(mojom::kPolygonMainnetChainId,
@@ -761,12 +761,12 @@ TEST_F(NetworkManagerUnitTest, RemoveCustomNetworkRemovesEip1559) {
 
   network_manager()->AddCustomNetwork(chain);
 
-  EXPECT_FALSE(network_manager()->IsEip1559Chain(chain.chain_id).has_value());
+  EXPECT_FALSE(network_manager()->IsEip1559Chain(chain.chain_id));
   network_manager()->SetEip1559ForCustomChain(chain.chain_id, true);
-  EXPECT_TRUE(*network_manager()->IsEip1559Chain(chain.chain_id));
+  EXPECT_TRUE(network_manager()->IsEip1559Chain(chain.chain_id));
 
   network_manager()->RemoveCustomNetwork(chain.chain_id, mojom::CoinType::ETH);
-  EXPECT_FALSE(network_manager()->IsEip1559Chain(chain.chain_id).has_value());
+  EXPECT_FALSE(network_manager()->IsEip1559Chain(chain.chain_id));
 }
 
 TEST_F(NetworkManagerUnitTest, HiddenNetworks) {


### PR DESCRIPTION
This PR migrates two `NoDestructor` maps to `constexpr`, as that's
perfectly fine to use. Uses of `GetChainSubdomains` were dealing with an
`optional<bool>`, which this function drops for a `bool`, as this is
much simpler and for the use in question was functionally the same.

Resolves https://github.com/brave/brave-browser/issues/46873
