### PR TITLE
[iOS] Replace captive portal tab helper

### DIFF
--- a/chromium_src/ios/chrome/browser/ssl/model/ios_captive_portal_blocking_page.mm
+++ b/chromium_src/ios/chrome/browser/ssl/model/ios_captive_portal_blocking_page.mm
@@ -1,0 +1,60 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "base/check.h"
+#include "base/memory/raw_ptr.h"
+#include "ios/chrome/browser/ssl/model/captive_portal_tab_helper.h"
+#include "ios/chrome/browser/web/model/web_navigation_util.h"
+#include "ios/web/public/lazy_web_state_user_data.h"
+#include "ios/web/public/navigation/navigation_manager.h"
+#include "ios/web/public/web_state.h"
+#include "ios/web/public/web_state_observer.h"
+
+// A custom captive portal tab helper that instead just loads the landing URL
+// directly into the current WebState instead of attempting to open it in a new
+// tab since we dont use WebStateList & its insertion agent on iOS
+class BraveCaptivePortalTabHelper
+    : public web::LazyWebStateUserData<BraveCaptivePortalTabHelper>,
+      web::WebStateObserver {
+ public:
+  BraveCaptivePortalTabHelper(const BraveCaptivePortalTabHelper&) = delete;
+  BraveCaptivePortalTabHelper& operator=(const BraveCaptivePortalTabHelper&) =
+      delete;
+
+  ~BraveCaptivePortalTabHelper() override {
+    if (web_state_) {
+      web_state_->RemoveObserver(this);
+    }
+  }
+
+  // Displays the Captive Portal Login page at `landing_url`.
+  void DisplayCaptivePortalLoginPage(GURL landing_url) {
+    if (!web_state_) {
+      return;
+    }
+    web_state_->GetNavigationManager()->LoadURLWithParams(
+        web_navigation_util::CreateWebLoadParams(
+            landing_url, ui::PAGE_TRANSITION_TYPED, nullptr));
+  }
+
+  // WebObserver
+  void WebStateDestroyed(web::WebState* web_state) override {
+    DCHECK_EQ(web_state_, web_state);
+    web_state_->RemoveObserver(this);
+    web_state_ = nullptr;
+  }
+
+ private:
+  friend class web::LazyWebStateUserData<BraveCaptivePortalTabHelper>;
+  BraveCaptivePortalTabHelper(web::WebState* web_state)
+      : web_state_(web_state) {
+    web_state_->AddObserver(this);
+  }
+  raw_ptr<web::WebState> web_state_ = nullptr;
+};
+
+#define CaptivePortalTabHelper BraveCaptivePortalTabHelper
+#include "src/ios/chrome/browser/ssl/model/ios_captive_portal_blocking_page.mm"
+#undef CaptivePortalTabHelper


### PR DESCRIPTION
This change replaces the Chromium CaptivePortalTabHelper with our own, since we do not use `WebStateList` and therefore will crash since we dont have an insertion agent for the tab helper to insert a new tab. The replacement tab helper loads the landing page into the current web state

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/46872

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
