### PR TITLE
[Customize Chrome Panel]Add close button to "Customize Chrome" side panel

### DIFF
--- a/browser/ui/webui/side_panel/customize_chrome/BUILD.gn
+++ b/browser/ui/webui/side_panel/customize_chrome/BUILD.gn
@@ -1,0 +1,17 @@
+# Copyright (c) 2025 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+source_set("browser_tests") {
+  testonly = true
+  defines = [ "HAS_OUT_OF_PROC_TEST_RUNNER" ]
+
+  sources = [ "customize_chrome_browsertest.cc" ]
+
+  deps = [
+    "//chrome/browser/ui/browser_window",
+    "//chrome/test:test_support",
+    "//chrome/test:test_support_ui",
+  ]
+}

--- a/browser/ui/webui/side_panel/customize_chrome/customize_chrome_browsertest.cc
+++ b/browser/ui/webui/side_panel/customize_chrome/customize_chrome_browsertest.cc
@@ -1,0 +1,95 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "base/test/bind.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/browser_window/public/browser_window_features.h"
+#include "chrome/browser/ui/customize_chrome/side_panel_controller.h"
+#include "chrome/browser/ui/tabs/public/tab_features.h"
+#include "chrome/browser/ui/views/side_panel/side_panel_ui.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "chrome/test/base/ui_test_utils.h"
+#include "components/tabs/public/tab_interface.h"
+#include "content/public/browser/web_contents.h"
+#include "content/public/test/browser_test.h"
+#include "content/public/test/browser_test_utils.h"
+
+class CustomizeChromeSidePanelBrowserTest : public InProcessBrowserTest {
+ protected:
+  // Returns the CustomizeChromeTabHelper associated with the tab
+  customize_chrome::SidePanelController* GetSidePanelController(
+      Browser* browser) {
+    return browser->GetActiveTabInterface()
+        ->GetTabFeatures()
+        ->customize_chrome_side_panel_controller();
+  }
+
+  SidePanelUI* GetSidePanelUI(Browser* browser) {
+    return browser->browser_window_features()->side_panel_ui();
+  }
+
+  content::WebContents* GetCustomizeChromeWebContents() {
+    return GetSidePanelUI(browser())->GetWebContentsForTest(
+        SidePanelEntryId::kCustomizeChrome);
+  }
+
+  void WaitUntil(base::RepeatingCallback<bool()> condition) {
+    if (condition.Run()) {
+      return;
+    }
+
+    base::RepeatingTimer scheduler;
+    scheduler.Start(FROM_HERE, base::Milliseconds(100),
+                    base::BindLambdaForTesting([this, &condition] {
+                      if (condition.Run()) {
+                        run_loop_->Quit();
+                      }
+                    }));
+    RunLoop();
+  }
+
+  void RunLoop() {
+    run_loop_ = std::make_unique<base::RunLoop>();
+    run_loop_->Run();
+  }
+
+ private:
+  std::unique_ptr<base::RunLoop> run_loop_;
+};
+
+IN_PROC_BROWSER_TEST_F(CustomizeChromeSidePanelBrowserTest, CloseButton) {
+  // Given that customize chrome side panel is available,
+  auto* customize_chrome_side_panel_controller =
+      GetSidePanelController(browser());
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(),
+                                           GURL(chrome::kChromeUINewTabURL)));
+  ASSERT_TRUE(customize_chrome_side_panel_controller
+                  ->IsCustomizeChromeEntryAvailable());
+
+  // When the side panel is opened,
+  customize_chrome_side_panel_controller->OpenSidePanel(
+      SidePanelOpenTrigger::kAppMenu, CustomizeChromeSection::kAppearance);
+  ASSERT_TRUE(
+      customize_chrome_side_panel_controller->IsCustomizeChromeEntryShowing());
+  content::WebContents* web_contents = GetCustomizeChromeWebContents();
+  ASSERT_TRUE(web_contents);
+
+  WaitUntil(
+      base::BindLambdaForTesting([&]() { return !web_contents->IsLoading(); }));
+
+  // clicking the close button should close the side panel.
+  // And the render frame will be deleted, so the returned result will be false.
+  EXPECT_FALSE(content::ExecJs(web_contents,
+                               R"-js-(
+      document.querySelector("body > customize-chrome-app")
+          .shadowRoot.querySelector("#closeButton")
+          .shadowRoot.querySelector("#closeButton").click();)-js-"));
+
+  // Double check that the side panel is closed.
+  WaitUntil(base::BindLambdaForTesting([&]() {
+    return !customize_chrome_side_panel_controller
+                ->IsCustomizeChromeEntryShowing();
+  }));
+}

--- a/chromium_src/chrome/browser/resources/side_panel/customize_chrome/app.html.ts.lit_mangler.ts
+++ b/chromium_src/chrome/browser/resources/side_panel/customize_chrome/app.html.ts.lit_mangler.ts
@@ -42,3 +42,21 @@ mangle(
   (template) =>
     template.text.includes('id="toolbar-customization-inner-heading"'),
 )
+
+// Insert a close button into the sp-heading element.
+mangle(
+  (element: DocumentFragment) => {
+    // Remove the "Choose which icons to show on the toolbar" text.
+    const el = element.querySelector('sp-heading')
+    if (!el) {
+      throw new Error('[Customize Chrome] sp-heading is gone.')
+    }
+
+    el.insertAdjacentHTML(
+      'afterbegin',
+      /* html */ `
+      <close-panel-button id="closeButton" iron-icon="close" slot="buttons"/>`,
+    )
+  },
+  (template) => template.text.includes('sp-heading'),
+)

--- a/chromium_src/chrome/browser/resources/side_panel/customize_chrome/app.html.ts.lit_mangler.ts
+++ b/chromium_src/chrome/browser/resources/side_panel/customize_chrome/app.html.ts.lit_mangler.ts
@@ -46,7 +46,6 @@ mangle(
 // Insert a close button into the sp-heading element.
 mangle(
   (element: DocumentFragment) => {
-    // Remove the "Choose which icons to show on the toolbar" text.
     const el = element.querySelector('sp-heading')
     if (!el) {
       throw new Error('[Customize Chrome] sp-heading is gone.')

--- a/chromium_src/chrome/browser/resources/side_panel/customize_chrome/app.ts
+++ b/chromium_src/chrome/browser/resources/side_panel/customize_chrome/app.ts
@@ -9,7 +9,7 @@ import { CrLitElement, html } from '//resources/lit/v3_0/lit.rollup.js';
 
 export * from './app-chromium.js'
 
-export class ClosePanelButton extends CrLitElement {
+class ClosePanelButton extends CrLitElement {
   static get is() {
     return 'close-panel-button'
   }

--- a/chromium_src/chrome/browser/resources/side_panel/customize_chrome/app.ts
+++ b/chromium_src/chrome/browser/resources/side_panel/customize_chrome/app.ts
@@ -1,0 +1,38 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { CustomizeChromeApiProxy } from './customize_chrome_api_proxy.js'
+
+import { CrLitElement, html } from '//resources/lit/v3_0/lit.rollup.js';
+
+export * from './app-chromium.js'
+
+export class ClosePanelButton extends CrLitElement {
+  static get is() {
+    return 'close-panel-button'
+  }
+
+  override render() {
+    return html`
+      <cr-icon-button
+        id="closeButton"
+        iron-icon="close"
+        @click=${this.onClosePanel}
+      ></cr-icon-button>
+    `
+  }
+
+  private onClosePanel() {
+    CustomizeChromeApiProxy.getInstance().handler.closePanel()
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'close-panel-button': ClosePanelButton
+  }
+}
+
+customElements.define(ClosePanelButton.is, ClosePanelButton)

--- a/chromium_src/chrome/browser/resources/side_panel/customize_chrome/customize_toolbar/toolbar.html.ts.lit_mangler.ts
+++ b/chromium_src/chrome/browser/resources/side_panel/customize_chrome/customize_toolbar/toolbar.html.ts.lit_mangler.ts
@@ -107,3 +107,21 @@ mangle(
     lastEl.insertAdjacentElement('afterend', resetButton)
   } /* omit selector to access the top level node */,
 )
+
+// Insert close button to the sp-heading element
+mangle(
+  (element: DocumentFragment) => {
+    // Remove the "Choose which icons to show on the toolbar" text.
+    const el = element.querySelector('sp-heading')
+    if (!el) {
+      throw new Error('[Customize Chrome > Toolbar] sp-heading is gone.')
+    }
+
+    el.insertAdjacentHTML(
+      'afterbegin',
+      /* html */ `
+        <close-panel-button id="closeButton" iron-icon="close" slot="buttons" />`,
+    )
+  },
+  (template) => template.text.includes('sp-heading'),
+)

--- a/chromium_src/chrome/browser/resources/side_panel/customize_chrome/customize_toolbar/toolbar.html.ts.lit_mangler.ts
+++ b/chromium_src/chrome/browser/resources/side_panel/customize_chrome/customize_toolbar/toolbar.html.ts.lit_mangler.ts
@@ -111,7 +111,6 @@ mangle(
 // Insert close button to the sp-heading element
 mangle(
   (element: DocumentFragment) => {
-    // Remove the "Choose which icons to show on the toolbar" text.
     const el = element.querySelector('sp-heading')
     if (!el) {
       throw new Error('[Customize Chrome > Toolbar] sp-heading is gone.')

--- a/chromium_src/chrome/browser/ui/views/side_panel/customize_chrome/side_panel_controller_views.cc
+++ b/chromium_src/chrome/browser/ui/views/side_panel/customize_chrome/side_panel_controller_views.cc
@@ -1,0 +1,24 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "chrome/browser/ui/views/side_panel/customize_chrome/side_panel_controller_views.h"
+
+#include "chrome/browser/ui/views/side_panel/side_panel_web_ui_view.h"
+#include "chrome/browser/ui/webui/side_panel/customize_chrome/customize_chrome_ui.h"
+
+// Inside SidePanelControllerViews::CreateCustomizeChromeWebView()
+#define ShowUI()                                                           \
+  ShowUI();                                                                \
+  auto customize_chrome_ui = customize_chrome_web_view->contents_wrapper() \
+                                 ->GetWebUIController()                    \
+                                 ->GetWeakPtr();                           \
+  CHECK(customize_chrome_ui);                                              \
+  customize_chrome_ui->SetClosePanelCallback(                              \
+      base::BindRepeating(&SidePanelControllerViews::CloseSidePanel,       \
+                          weak_ptr_factory_.GetWeakPtr()));
+
+#include "src/chrome/browser/ui/views/side_panel/customize_chrome/side_panel_controller_views.cc"
+
+#undef ShowUI

--- a/chromium_src/chrome/browser/ui/views/side_panel/customize_chrome/side_panel_controller_views.h
+++ b/chromium_src/chrome/browser/ui/views/side_panel/customize_chrome/side_panel_controller_views.h
@@ -1,0 +1,21 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_SIDE_PANEL_CUSTOMIZE_CHROME_SIDE_PANEL_CONTROLLER_VIEWS_H_
+#define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_SIDE_PANEL_CUSTOMIZE_CHROME_SIDE_PANEL_CONTROLLER_VIEWS_H_
+
+#include "base/memory/weak_ptr.h"
+
+#define will_discard_contents_callback_subscription_                 \
+  will_discard_contents_callback_subscription_;                      \
+  base::WeakPtrFactory<SidePanelControllerViews> weak_ptr_factory_ { \
+    this                                                             \
+  }
+
+#include "src/chrome/browser/ui/views/side_panel/customize_chrome/side_panel_controller_views.h"  // IWYU pragma: export
+
+#undef will_discard_contents_callback_subscription_
+
+#endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_SIDE_PANEL_CUSTOMIZE_CHROME_SIDE_PANEL_CONTROLLER_VIEWS_H_

--- a/chromium_src/chrome/browser/ui/webui/side_panel/customize_chrome/customize_chrome.mojom
+++ b/chromium_src/chrome/browser/ui/webui/side_panel/customize_chrome/customize_chrome.mojom
@@ -1,0 +1,12 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+module side_panel.mojom;
+
+[BraveExtend]
+interface CustomizeChromePageHandler {
+  // Closes the customize chrome side pane
+  ClosePanel();
+};

--- a/chromium_src/chrome/browser/ui/webui/side_panel/customize_chrome/customize_chrome_page_handler.cc
+++ b/chromium_src/chrome/browser/ui/webui/side_panel/customize_chrome/customize_chrome_page_handler.cc
@@ -5,8 +5,12 @@
 
 #include "src/chrome/browser/ui/webui/side_panel/customize_chrome/customize_chrome_page_handler.cc"
 
+#include "chrome/browser/ui/webui/side_panel/customize_chrome/customize_chrome_ui.h"
+
 void CustomizeChromePageHandler::ClosePanel() {
-  if (close_panel_callback_) {
-    close_panel_callback_.Run();
-  }
+  CHECK(customize_chrome_ui_)
+      << "CustomizeChromeUI must be set on its creation.";
+  auto close_panel = customize_chrome_ui_->close_panel_callback();
+  CHECK(close_panel);
+  close_panel.Run();
 }

--- a/chromium_src/chrome/browser/ui/webui/side_panel/customize_chrome/customize_chrome_page_handler.cc
+++ b/chromium_src/chrome/browser/ui/webui/side_panel/customize_chrome/customize_chrome_page_handler.cc
@@ -1,0 +1,12 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "src/chrome/browser/ui/webui/side_panel/customize_chrome/customize_chrome_page_handler.cc"
+
+void CustomizeChromePageHandler::ClosePanel() {
+  if (close_panel_callback_) {
+    close_panel_callback_.Run();
+  }
+}

--- a/chromium_src/chrome/browser/ui/webui/side_panel/customize_chrome/customize_chrome_page_handler.h
+++ b/chromium_src/chrome/browser/ui/webui/side_panel/customize_chrome/customize_chrome_page_handler.h
@@ -8,16 +8,19 @@
 
 #include "chrome/browser/ui/webui/side_panel/customize_chrome/customize_chrome.mojom.h"
 
-#define UpdateNtpManagedByName                                                 \
-  UpdateNtpManagedByName() override;                                           \
-  void set_close_panel_callback(base::RepeatingClosure close_panel_callback) { \
-    close_panel_callback_ = std::move(close_panel_callback);                   \
-  }                                                                            \
-                                                                               \
- private:                                                                      \
-  base::RepeatingClosure close_panel_callback_;                                \
-                                                                               \
- public:                                                                       \
+class CustomizeChromeUI;
+
+#define UpdateNtpManagedByName                                       \
+  UpdateNtpManagedByName() override;                                 \
+  void set_customize_chrome_ui(                                      \
+      const base::WeakPtr<CustomizeChromeUI>& customize_chrome_ui) { \
+    customize_chrome_ui_ = std::move(customize_chrome_ui);           \
+  }                                                                  \
+                                                                     \
+ private:                                                            \
+  base::WeakPtr<CustomizeChromeUI> customize_chrome_ui_;             \
+                                                                     \
+ public:                                                             \
   void ClosePanel
 
 #include "src/chrome/browser/ui/webui/side_panel/customize_chrome/customize_chrome_page_handler.h"  // IWYU pragma: export

--- a/chromium_src/chrome/browser/ui/webui/side_panel/customize_chrome/customize_chrome_page_handler.h
+++ b/chromium_src/chrome/browser/ui/webui/side_panel/customize_chrome/customize_chrome_page_handler.h
@@ -1,0 +1,27 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_WEBUI_SIDE_PANEL_CUSTOMIZE_CHROME_CUSTOMIZE_CHROME_PAGE_HANDLER_H_
+#define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_WEBUI_SIDE_PANEL_CUSTOMIZE_CHROME_CUSTOMIZE_CHROME_PAGE_HANDLER_H_
+
+#include "chrome/browser/ui/webui/side_panel/customize_chrome/customize_chrome.mojom.h"
+
+#define UpdateNtpManagedByName                                                 \
+  UpdateNtpManagedByName() override;                                           \
+  void set_close_panel_callback(base::RepeatingClosure close_panel_callback) { \
+    close_panel_callback_ = std::move(close_panel_callback);                   \
+  }                                                                            \
+                                                                               \
+ private:                                                                      \
+  base::RepeatingClosure close_panel_callback_;                                \
+                                                                               \
+ public:                                                                       \
+  void ClosePanel
+
+#include "src/chrome/browser/ui/webui/side_panel/customize_chrome/customize_chrome_page_handler.h"  // IWYU pragma: export
+
+#undef UpdateNtpManagedByName
+
+#endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_WEBUI_SIDE_PANEL_CUSTOMIZE_CHROME_CUSTOMIZE_CHROME_PAGE_HANDLER_H_

--- a/chromium_src/chrome/browser/ui/webui/side_panel/customize_chrome/customize_chrome_ui.cc
+++ b/chromium_src/chrome/browser/ui/webui/side_panel/customize_chrome/customize_chrome_ui.cc
@@ -25,16 +25,11 @@ void CustomizeChromeUI::CreatePageHandler(
   CreatePageHandlerChromium(std::move(pending_page),
                             std::move(pending_page_handler));
   CHECK(customize_chrome_page_handler_);
-  customize_chrome_page_handler_->set_close_panel_callback(
-      close_panel_callback_);
+  customize_chrome_page_handler_->set_customize_chrome_ui(
+      weak_ptr_factory_.GetWeakPtr());
 }
 
 void CustomizeChromeUI::SetClosePanelCallback(
     base::RepeatingClosure close_panel_callback) {
   close_panel_callback_ = std::move(close_panel_callback);
-  if (customize_chrome_page_handler_) {
-    // Do not std::move() callback as handler may be created after this call
-    customize_chrome_page_handler_->set_close_panel_callback(
-        close_panel_callback);
-  }
 }

--- a/chromium_src/chrome/browser/ui/webui/side_panel/customize_chrome/customize_chrome_ui.cc
+++ b/chromium_src/chrome/browser/ui/webui/side_panel/customize_chrome/customize_chrome_ui.cc
@@ -3,13 +3,38 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
+#include "chrome/browser/ui/webui/side_panel/customize_chrome/customize_chrome_ui.h"
+
 #include "content/public/browser/web_ui_data_source.h"
 
 #define AddLocalizedStrings(...)                               \
   AddLocalizedStrings(__VA_ARGS__);                            \
   source->AddLocalizedString("braveCustomizeMenuToolbarLabel", \
                              IDS_BRAVE_CUSTOMIZE_MENU_TOOLBAR_LABEL)
+#define CreatePageHandler CreatePageHandlerChromium
 
 #include "src/chrome/browser/ui/webui/side_panel/customize_chrome/customize_chrome_ui.cc"
 
+#undef CreatePageHandler
 #undef AddLocalizedStrings
+
+void CustomizeChromeUI::CreatePageHandler(
+    mojo::PendingRemote<side_panel::mojom::CustomizeChromePage> pending_page,
+    mojo::PendingReceiver<side_panel::mojom::CustomizeChromePageHandler>
+        pending_page_handler) {
+  CreatePageHandlerChromium(std::move(pending_page),
+                            std::move(pending_page_handler));
+  CHECK(customize_chrome_page_handler_);
+  customize_chrome_page_handler_->set_close_panel_callback(
+      close_panel_callback_);
+}
+
+void CustomizeChromeUI::SetClosePanelCallback(
+    base::RepeatingClosure close_panel_callback) {
+  close_panel_callback_ = std::move(close_panel_callback);
+  if (customize_chrome_page_handler_) {
+    // Do not std::move() callback as handler may be created after this call
+    customize_chrome_page_handler_->set_close_panel_callback(
+        close_panel_callback);
+  }
+}

--- a/chromium_src/chrome/browser/ui/webui/side_panel/customize_chrome/customize_chrome_ui.h
+++ b/chromium_src/chrome/browser/ui/webui/side_panel/customize_chrome/customize_chrome_ui.h
@@ -12,6 +12,9 @@
 #define AttachedTabStateUpdated                                            \
   AttachedTabStateUpdated_Unused();                                        \
   void SetClosePanelCallback(base::RepeatingClosure close_panel_callback); \
+  base::RepeatingClosure close_panel_callback() const {                    \
+    return close_panel_callback_;                                          \
+  }                                                                        \
                                                                            \
  private:                                                                  \
   base::RepeatingClosure close_panel_callback_;                            \

--- a/chromium_src/chrome/browser/ui/webui/side_panel/customize_chrome/customize_chrome_ui.h
+++ b/chromium_src/chrome/browser/ui/webui/side_panel/customize_chrome/customize_chrome_ui.h
@@ -1,0 +1,35 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_WEBUI_SIDE_PANEL_CUSTOMIZE_CHROME_CUSTOMIZE_CHROME_UI_H_
+#define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_WEBUI_SIDE_PANEL_CUSTOMIZE_CHROME_CUSTOMIZE_CHROME_UI_H_
+
+#include "base/functional/callback_forward.h"
+#include "chrome/browser/ui/webui/side_panel/customize_chrome/customize_chrome.mojom.h"
+
+#define AttachedTabStateUpdated                                            \
+  AttachedTabStateUpdated_Unused();                                        \
+  void SetClosePanelCallback(base::RepeatingClosure close_panel_callback); \
+                                                                           \
+ private:                                                                  \
+  base::RepeatingClosure close_panel_callback_;                            \
+                                                                           \
+ public:                                                                   \
+  void AttachedTabStateUpdated
+
+#define CreatePageHandler                                                  \
+  CreatePageHandlerChromium(                                               \
+      mojo::PendingRemote<side_panel::mojom::CustomizeChromePage>          \
+          pending_page,                                                    \
+      mojo::PendingReceiver<side_panel::mojom::CustomizeChromePageHandler> \
+          pending_page_handler);                                           \
+  void CreatePageHandler
+
+#include "src/chrome/browser/ui/webui/side_panel/customize_chrome/customize_chrome_ui.h"  // IWYU pragma: export
+
+#undef CreatePageHandler
+#undef AttachedTabStateUpdated
+
+#endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_WEBUI_SIDE_PANEL_CUSTOMIZE_CHROME_CUSTOMIZE_CHROME_UI_H_

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -1150,6 +1150,7 @@ test("brave_browser_tests") {
       "//brave/browser/ui/geolocation:browser_tests",
       "//brave/browser/ui/tabs:split_view",
       "//brave/browser/ui/toolbar:brave_app_menu_browser_tests",
+      "//brave/browser/ui/webui/side_panel/customize_chrome:browser_tests",
       "//brave/browser/ui/webui/tab_search:browser_tests",
       "//brave/browser/ui/whats_new:browser_test",
       "//brave/browser/url_sanitizer:browser_tests",

--- a/tools/chromium_src/lit_mangler/__snapshots__/mangle.test.ts.snap
+++ b/tools/chromium_src/lit_mangler/__snapshots__/mangle.test.ts.snap
@@ -60,7 +60,7 @@ exports[`mangled files should have up to date snapshots ./chromium_src/chrome/br
 "===================================================================
 --- ../chrome/browser/resources/side_panel/customize_chrome/app.html.ts
 +++ gen/chrome/browser/resources/side_panel/customize_chrome/preprocessed/app.html.ts
-@@ -4,31 +4,23 @@
+@@ -4,31 +4,24 @@
  
  export function getHtml(this: AppElement) {
    // clang-format off
@@ -73,6 +73,7 @@ exports[`mangled files should have up to date snapshots ./chromium_src/chrome/br
      <div id=\\"appearance\\" class=\\"section sp-card\\">
 -      <sp-heading hide-back-button>
 +      <sp-heading hide-back-button=\\"\\">
++      <close-panel-button id=\\"closeButton\\" iron-icon=\\"close\\" slot=\\"buttons\\"></close-panel-button>
          <h2 slot=\\"heading\\">$i18n{appearanceHeader}</h2>
        </sp-heading>
 -      <customize-chrome-appearance @edit-theme-click=\\"\${this.onEditThemeClick_}\\"
@@ -99,7 +100,7 @@ exports[`mangled files should have up to date snapshots ./chromium_src/chrome/br
       \${this.isSourceTabFirstPartyNtp_() ? html\`<hr class=\\"sp-cards-separator\\">
      <div id=\\"shortcuts\\" class=\\"section sp-card\\">
        <sp-heading hide-back-button>
-@@ -98,10 +90,9 @@
+@@ -98,10 +91,9 @@
      <customize-chrome-wallpaper-search @back-click=\\"\${this.onBackClick_}\\"
          page-name=\\"wallpaper-search\\" id=\\"wallpaperSearchPage\\">
      </customize-chrome-wallpaper-search>
@@ -230,7 +231,7 @@ exports[`mangled files should have up to date snapshots ./chromium_src/chrome/br
 "===================================================================
 --- ../chrome/browser/resources/side_panel/customize_chrome/customize_toolbar/toolbar.html.ts
 +++ gen/chrome/browser/resources/side_panel/customize_chrome/preprocessed/customize_toolbar/toolbar.html.ts
-@@ -4,26 +4,21 @@
+@@ -4,26 +4,22 @@
  
  export function getHtml(this: ToolbarElement) {
    return html\`<!--_html_template_start_-->
@@ -239,6 +240,7 @@ exports[`mangled files should have up to date snapshots ./chromium_src/chrome/br
 -      back-button-aria-label=\\"$i18n{backButton}\\"
 -      back-button-title=\\"$i18n{backButton}\\">
 +  <sp-heading id=\\"heading\\" @back-button-click=\\"\${this.onBackClick_}\\" back-button-aria-label=\\"$i18n{backButton}\\" back-button-title=\\"$i18n{backButton}\\">
++        <close-panel-button id=\\"closeButton\\" iron-icon=\\"close\\" slot=\\"buttons\\"></close-panel-button>
      <h2 slot=\\"heading\\">$i18n{toolbarHeader}</h2>
    </sp-heading>
 -  <div id=\\"miniToolbarBackground\\">
@@ -267,7 +269,7 @@ exports[`mangled files should have up to date snapshots ./chromium_src/chrome/br
  <div class=\\"sp-card\\" id=\\"pinningSelectionCard\\">
    \${
        this.categories_.map(
-@@ -71,14 +66,12 @@
+@@ -71,14 +67,12 @@
                categoryIndex !== this.categories_.length - 1 ?
                    html\`<hr class=\\"sp-hr\\">\` :
                    ''}


### PR DESCRIPTION
According to the design spec, the "Customize Chrome" side panel 
should have a close button in the top right corner.

This PR reuses SidePanelController::ClosePanel(), which upstream 
code already has, to implement the close button functionality.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/46894

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
