### PR TITLE
[Android] Prevent bottom controls bitmap capture in tab switcher mode

### DIFF
--- a/android/java/org/chromium/chrome/browser/toolbar/bottom/BottomToolbarCoordinator.java
+++ b/android/java/org/chromium/chrome/browser/toolbar/bottom/BottomToolbarCoordinator.java
@@ -81,6 +81,7 @@ class BottomToolbarCoordinator implements View.OnLongClickListener {
     private final LocationBarModel mLocationBarModel;
     private final HomepageManager mHomepageManager;
     private final BookmarkManagerOpener mBookmarkManagerOpener;
+    private boolean mIsInTabSwitcherMode;
 
     private final Context mContext = ContextUtils.getApplicationContext();
 
@@ -199,7 +200,7 @@ class BottomToolbarCoordinator implements View.OnLongClickListener {
                         @Override
                         public void onStartedShowing(@LayoutType int layoutType) {
                             if (layoutType != LayoutType.TAB_SWITCHER) return;
-
+                            mIsInTabSwitcherMode = true;
                             BrowsingModeBottomToolbarCoordinator browsingModeCoordinator =
                                     (BrowsingModeBottomToolbarCoordinator) mBrowsingModeCoordinator;
                             browsingModeCoordinator.getSearchAccelerator().setVisibility(View.GONE);
@@ -230,7 +231,7 @@ class BottomToolbarCoordinator implements View.OnLongClickListener {
                         @Override
                         public void onStartedHiding(@LayoutType int layoutType) {
                             if (layoutType != LayoutType.TAB_SWITCHER) return;
-
+                            mIsInTabSwitcherMode = false;
                             BrowsingModeBottomToolbarCoordinator browsingModeCoordinator =
                                     (BrowsingModeBottomToolbarCoordinator) mBrowsingModeCoordinator;
                             browsingModeCoordinator
@@ -381,5 +382,9 @@ class BottomToolbarCoordinator implements View.OnLongClickListener {
             mHomeButton.setImageDrawable(
                     ContextCompat.getDrawable(mContext, R.drawable.btn_toolbar_home));
         }
+    }
+
+    public boolean isInTabSwitcherMode() {
+        return mIsInTabSwitcherMode;
     }
 }

--- a/android/java/org/chromium/chrome/browser/toolbar/bottom/BraveBottomControlsCoordinator.java
+++ b/android/java/org/chromium/chrome/browser/toolbar/bottom/BraveBottomControlsCoordinator.java
@@ -186,4 +186,8 @@ public class BraveBottomControlsCoordinator extends BottomControlsCoordinator {
         assert false : "Make sure mMediator is properly patched in bytecode.";
         return null;
     }
+
+    public boolean isInTabSwitcherMode() {
+        return mBottomToolbarCoordinator != null && mBottomToolbarCoordinator.isInTabSwitcherMode();
+    }
 }

--- a/android/java/org/chromium/chrome/browser/toolbar/bottom/BraveScrollingBottomViewResourceFrameLayout.java
+++ b/android/java/org/chromium/chrome/browser/toolbar/bottom/BraveScrollingBottomViewResourceFrameLayout.java
@@ -155,6 +155,8 @@ public class BraveScrollingBottomViewResourceFrameLayout
 
     @SuppressLint("VisibleForTests")
     public void triggerBitmapCapture(boolean dropCachedBitmap) {
+        if (isInTabSwitcherMode()) return;
+
         synchronized (mCallbackController) {
             if (dropCachedBitmap) {
                 getResourceAdapter().dropCachedBitmap();
@@ -163,5 +165,11 @@ public class BraveScrollingBottomViewResourceFrameLayout
                 getResourceAdapter().triggerBitmapCapture();
             }
         }
+    }
+
+    private boolean isInTabSwitcherMode() {
+        BraveBottomControlsCoordinator bottomControlsCoordinator = braveBottomControlsCoordinator();
+        if (bottomControlsCoordinator == null) return false;
+        return bottomControlsCoordinator.isInTabSwitcherMode();
     }
 }


### PR DESCRIPTION
This is a cherry-pick of 
https://github.com/brave/brave-core/commit/0c18a9c937bcb82d94a63427853f09db896b1dfb
Issue and fix were found by @samartnik during work on `cr139`

```
[cr139][Android] Prevent bottom controls bitmap capture in tab switcher mode
I didn't find exact upstream change, but in cr139 it started glitching and show tab switcher's bitmap on scoll.
We need to capture bitmap only for web page srolling animation and thus no need to capture it in tab switcher mode.
```
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/46901

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
