### PR TITLE
[cr139] `NavigationThrottleRegistry::MaybeAddThrottle` removed

### DIFF
--- a/browser/ai_chat/ai_chat_throttle_unittest.cc
+++ b/browser/ai_chat/ai_chat_throttle_unittest.cc
@@ -87,21 +87,22 @@ TEST_P(AIChatThrottleUnitTest, CancelNavigationFromTab) {
       ui::PageTransition::PAGE_TRANSITION_TYPED);
 
   test_handle.set_page_transition(transition);
-  content::MockNavigationThrottleRegistry registry(&test_handle);
+  content::MockNavigationThrottleRegistry registry(
+      &test_handle,
+      content::MockNavigationThrottleRegistry::RegistrationMode::kHold);
 
-  std::unique_ptr<AIChatThrottle> throttle =
-      AIChatThrottle::MaybeCreateThrottleFor(registry);
+  AIChatThrottle::MaybeCreateAndAdd(registry);
 
 #if !BUILDFLAG(IS_ANDROID)
   if (IsAIChatHistoryEnabled()) {
-    EXPECT_EQ(throttle.get(), nullptr);
+    EXPECT_TRUE(registry.throttles().empty());
   } else {
-    EXPECT_NE(throttle.get(), nullptr);
+    ASSERT_FALSE(registry.throttles().empty());
     EXPECT_EQ(content::NavigationThrottle::CANCEL_AND_IGNORE,
-              throttle->WillStartRequest().action());
+              registry.throttles().back()->WillStartRequest().action());
   }
 #else
-  EXPECT_EQ(throttle.get(), nullptr);
+  EXPECT_TRUE(registry.throttles().empty());
 #endif
 }
 
@@ -115,15 +116,17 @@ TEST_P(AIChatThrottleUnitTest, CancelNavigationToFrame) {
       ui::PageTransition::PAGE_TRANSITION_TYPED);
 
   test_handle.set_page_transition(transition);
-  content::MockNavigationThrottleRegistry registry(&test_handle);
+  content::MockNavigationThrottleRegistry registry(
+      &test_handle,
+      content::MockNavigationThrottleRegistry::RegistrationMode::kHold);
 
-  std::unique_ptr<AIChatThrottle> throttle =
-      AIChatThrottle::MaybeCreateThrottleFor(registry);
+  AIChatThrottle::MaybeCreateAndAdd(registry);
 #if !BUILDFLAG(IS_ANDROID)
+  ASSERT_FALSE(registry.throttles().empty());
   EXPECT_EQ(content::NavigationThrottle::CANCEL_AND_IGNORE,
-            throttle->WillStartRequest().action());
+            registry.throttles().back()->WillStartRequest().action());
 #else
-  EXPECT_EQ(throttle.get(), nullptr);
+  EXPECT_TRUE(registry.throttles().empty());
 #endif
 }
 
@@ -141,11 +144,12 @@ TEST_P(AIChatThrottleUnitTest, AllowNavigationFromPanel) {
 #endif
 
   test_handle.set_page_transition(transition);
-  content::MockNavigationThrottleRegistry registry(&test_handle);
+  content::MockNavigationThrottleRegistry registry(
+      &test_handle,
+      content::MockNavigationThrottleRegistry::RegistrationMode::kHold);
 
-  std::unique_ptr<AIChatThrottle> throttle =
-      AIChatThrottle::MaybeCreateThrottleFor(registry);
-  EXPECT_EQ(throttle.get(), nullptr);
+  AIChatThrottle::MaybeCreateAndAdd(registry);
+  EXPECT_TRUE(registry.throttles().empty());
 }
 
 }  // namespace ai_chat

--- a/browser/brave_content_browser_client.cc
+++ b/browser/brave_content_browser_client.cc
@@ -1146,9 +1146,7 @@ void BraveContentBrowserClient::CreateThrottlesForNavigation(
     content::NavigationThrottleRegistry& registry) {
   // inserting the navigation throttle at the fist position before any java
   // navigation happens
-  registry.MaybeAddThrottle(
-      brave_rewards::RewardsProtocolNavigationThrottle::MaybeCreateThrottleFor(
-          registry));
+  brave_rewards::RewardsProtocolNavigationThrottle::MaybeCreateAndAdd(registry);
 
   ChromeContentBrowserClient::CreateThrottlesForNavigation(registry);
 
@@ -1156,8 +1154,7 @@ void BraveContentBrowserClient::CreateThrottlesForNavigation(
   content::BrowserContext* context =
       navigation_handle.GetWebContents()->GetBrowserContext();
 #if !BUILDFLAG(IS_ANDROID)
-  registry.MaybeAddThrottle(
-      NewTabShowsNavigationThrottle::MaybeCreateThrottleFor(registry));
+  NewTabShowsNavigationThrottle::MaybeCreateAndAdd(registry);
 #endif
 
 #if BUILDFLAG(ENABLE_BRAVE_WEBTORRENT)
@@ -1167,68 +1164,56 @@ void BraveContentBrowserClient::CreateThrottlesForNavigation(
 #endif
 
 #if BUILDFLAG(ENABLE_TOR)
-  registry.MaybeAddThrottle(tor::TorNavigationThrottle::MaybeCreateThrottleFor(
-      registry, context->IsTor()));
-  registry.MaybeAddThrottle(
-      tor::OnionLocationNavigationThrottle::MaybeCreateThrottleFor(
-          registry, TorProfileServiceFactory::IsTorDisabled(context),
-          context->IsTor()));
+  tor::TorNavigationThrottle::MaybeCreateAndAdd(registry, context->IsTor());
+  tor::OnionLocationNavigationThrottle::MaybeCreateAndAdd(
+      registry, TorProfileServiceFactory::IsTorDisabled(context),
+      context->IsTor());
 #endif
 
-  registry.MaybeAddThrottle(
-      decentralized_dns::DecentralizedDnsNavigationThrottle::
-          MaybeCreateThrottleFor(registry, user_prefs::UserPrefs::Get(context),
-                                 g_browser_process->local_state(),
-                                 g_browser_process->GetApplicationLocale()));
+  decentralized_dns::DecentralizedDnsNavigationThrottle::MaybeCreateAndAdd(
+      registry, user_prefs::UserPrefs::Get(context),
+      g_browser_process->local_state(),
+      g_browser_process->GetApplicationLocale());
 
   // Debounce
-  registry.MaybeAddThrottle(
-      debounce::DebounceNavigationThrottle::MaybeCreateThrottleFor(
-          registry,
-          debounce::DebounceServiceFactory::GetForBrowserContext(context)));
+  debounce::DebounceNavigationThrottle::MaybeCreateAndAdd(
+      registry,
+      debounce::DebounceServiceFactory::GetForBrowserContext(context));
 
   // The HostContentSettingsMap might be null for some irregular profiles, e.g.
   // the System Profile.
   auto* host_content_settings_map =
       HostContentSettingsMapFactory::GetForProfile(context);
   if (host_content_settings_map) {
-    registry.MaybeAddThrottle(
-        brave_shields::DomainBlockNavigationThrottle::MaybeCreateThrottleFor(
-            registry, g_brave_browser_process->ad_block_service(),
-            g_brave_browser_process->ad_block_service()
-                ->custom_filters_provider(),
-            EphemeralStorageServiceFactory::GetForContext(context),
-            host_content_settings_map,
-            g_browser_process->GetApplicationLocale()));
+    brave_shields::DomainBlockNavigationThrottle::MaybeCreateAndAdd(
+        registry, g_brave_browser_process->ad_block_service(),
+        g_brave_browser_process->ad_block_service()->custom_filters_provider(),
+        EphemeralStorageServiceFactory::GetForContext(context),
+        host_content_settings_map, g_browser_process->GetApplicationLocale());
   }
 
 #if BUILDFLAG(ENABLE_REQUEST_OTR)
   // Request Off-The-Record
-  registry.MaybeAddThrottle(
-      request_otr::RequestOTRNavigationThrottle::MaybeCreateThrottleFor(
-          registry,
-          request_otr::RequestOTRServiceFactory::GetForBrowserContext(context),
-          EphemeralStorageServiceFactory::GetForContext(context),
-          Profile::FromBrowserContext(context)->GetPrefs(),
-          g_browser_process->GetApplicationLocale()));
+  request_otr::RequestOTRNavigationThrottle::MaybeCreateAndAdd(
+      registry,
+      request_otr::RequestOTRServiceFactory::GetForBrowserContext(context),
+      EphemeralStorageServiceFactory::GetForContext(context),
+      Profile::FromBrowserContext(context)->GetPrefs(),
+      g_browser_process->GetApplicationLocale());
 #endif
 
   if (Profile::FromBrowserContext(context)->IsRegularProfile()) {
-    registry.MaybeAddThrottle(
-        ai_chat::AIChatThrottle::MaybeCreateThrottleFor(registry));
+    ai_chat::AIChatThrottle::MaybeCreateAndAdd(registry);
   }
 
 #if !BUILDFLAG(IS_ANDROID)
-  registry.MaybeAddThrottle(
-      ai_chat::AIChatBraveSearchThrottle::MaybeCreateThrottleFor(
-          base::BindOnce(&ai_chat::OpenAIChatForTab), registry,
-          ai_chat::AIChatServiceFactory::GetForBrowserContext(context),
-          user_prefs::UserPrefs::Get(context)));
+  ai_chat::AIChatBraveSearchThrottle::MaybeCreateAndAdd(
+      base::BindOnce(&ai_chat::OpenAIChatForTab), registry,
+      ai_chat::AIChatServiceFactory::GetForBrowserContext(context),
+      user_prefs::UserPrefs::Get(context));
 #endif
 
-  registry.MaybeAddThrottle(
-      brave_search::BackupResultsNavigationThrottle::MaybeCreateThrottleFor(
-          registry));
+  brave_search::BackupResultsNavigationThrottle::MaybeCreateAndAdd(registry);
 }
 
 bool PreventDarkModeFingerprinting(WebContents* web_contents,

--- a/browser/brave_search/backup_results_navigation_throttle.cc
+++ b/browser/brave_search/backup_results_navigation_throttle.cc
@@ -14,18 +14,19 @@
 
 namespace brave_search {
 
-std::unique_ptr<BackupResultsNavigationThrottle>
-BackupResultsNavigationThrottle::MaybeCreateThrottleFor(
+// static
+void BackupResultsNavigationThrottle::MaybeCreateAndAdd(
     content::NavigationThrottleRegistry& registry) {
   auto* context =
       registry.GetNavigationHandle().GetWebContents()->GetBrowserContext();
   auto* profile = Profile::FromBrowserContext(context);
   if (!profile->IsOffTheRecord() ||
       !profile->GetOTRProfileID().IsSearchBackupResults()) {
-    return nullptr;
+    return;
   }
 
-  return std::make_unique<BackupResultsNavigationThrottle>(registry);
+  registry.AddThrottle(
+      std::make_unique<BackupResultsNavigationThrottle>(registry));
 }
 
 BackupResultsNavigationThrottle::BackupResultsNavigationThrottle(

--- a/browser/brave_search/backup_results_navigation_throttle.h
+++ b/browser/brave_search/backup_results_navigation_throttle.h
@@ -6,8 +6,6 @@
 #ifndef BRAVE_BROWSER_BRAVE_SEARCH_BACKUP_RESULTS_NAVIGATION_THROTTLE_H_
 #define BRAVE_BROWSER_BRAVE_SEARCH_BACKUP_RESULTS_NAVIGATION_THROTTLE_H_
 
-#include <memory>
-
 #include "content/public/browser/navigation_throttle.h"
 
 namespace brave_search {
@@ -23,8 +21,7 @@ class BackupResultsNavigationThrottle : public content::NavigationThrottle {
   BackupResultsNavigationThrottle& operator=(
       const BackupResultsNavigationThrottle&) = delete;
 
-  static std::unique_ptr<BackupResultsNavigationThrottle>
-  MaybeCreateThrottleFor(content::NavigationThrottleRegistry& registry);
+  static void MaybeCreateAndAdd(content::NavigationThrottleRegistry& registry);
 
  private:
   // content::NavigationThrottle overrides:

--- a/browser/new_tab/new_tab_shows_navigation_throttle.cc
+++ b/browser/new_tab/new_tab_shows_navigation_throttle.cc
@@ -18,17 +18,17 @@
 #include "content/public/browser/web_contents.h"
 
 // static
-std::unique_ptr<NewTabShowsNavigationThrottle>
-NewTabShowsNavigationThrottle::MaybeCreateThrottleFor(
+void NewTabShowsNavigationThrottle::MaybeCreateAndAdd(
     content::NavigationThrottleRegistry& registry) {
   auto& navigation_handle = registry.GetNavigationHandle();
   auto* context = navigation_handle.GetWebContents()->GetBrowserContext();
   if (!Profile::FromBrowserContext(context)->IsRegularProfile() ||
       !NewTabUI::IsNewTab(navigation_handle.GetURL())) {
-    return nullptr;
+    return;
   }
 
-  return std::make_unique<NewTabShowsNavigationThrottle>(registry);
+  registry.AddThrottle(
+      std::make_unique<NewTabShowsNavigationThrottle>(registry));
 }
 
 NewTabShowsNavigationThrottle::NewTabShowsNavigationThrottle(

--- a/browser/new_tab/new_tab_shows_navigation_throttle.h
+++ b/browser/new_tab/new_tab_shows_navigation_throttle.h
@@ -6,8 +6,6 @@
 #ifndef BRAVE_BROWSER_NEW_TAB_NEW_TAB_SHOWS_NAVIGATION_THROTTLE_H_
 #define BRAVE_BROWSER_NEW_TAB_NEW_TAB_SHOWS_NAVIGATION_THROTTLE_H_
 
-#include <memory>
-
 #include "base/memory/weak_ptr.h"
 #include "content/public/browser/navigation_throttle.h"
 #include "url/gurl.h"
@@ -22,8 +20,7 @@ class NewTabShowsNavigationThrottle : public content::NavigationThrottle {
   NewTabShowsNavigationThrottle& operator=(
       const NewTabShowsNavigationThrottle&) = delete;
 
-  static std::unique_ptr<NewTabShowsNavigationThrottle> MaybeCreateThrottleFor(
-      content::NavigationThrottleRegistry& registry);
+  static void MaybeCreateAndAdd(content::NavigationThrottleRegistry& registry);
 
  private:
   // content::NavigationThrottle overrides:

--- a/components/ai_chat/content/browser/ai_chat_brave_search_throttle.cc
+++ b/components/ai_chat/content/browser/ai_chat_brave_search_throttle.cc
@@ -33,15 +33,14 @@ class RenderFrameHost;
 namespace ai_chat {
 
 // static
-std::unique_ptr<AIChatBraveSearchThrottle>
-AIChatBraveSearchThrottle::MaybeCreateThrottleFor(
+void AIChatBraveSearchThrottle::MaybeCreateAndAdd(
     base::OnceCallback<void(content::WebContents*)> open_leo_delegate,
     content::NavigationThrottleRegistry& registry,
     AIChatService* ai_chat_service,
     PrefService* pref_service) {
   auto* web_contents = registry.GetNavigationHandle().GetWebContents();
   if (!web_contents) {
-    return nullptr;
+    return;
   }
 
   if (!open_leo_delegate || !ai_chat_service ||
@@ -49,11 +48,11 @@ AIChatBraveSearchThrottle::MaybeCreateThrottleFor(
       !features::IsOpenAIChatFromBraveSearchEnabled() ||
       !IsOpenAIChatButtonFromBraveSearchURL(
           registry.GetNavigationHandle().GetURL())) {
-    return nullptr;
+    return;
   }
 
-  return std::make_unique<AIChatBraveSearchThrottle>(
-      std::move(open_leo_delegate), registry, ai_chat_service);
+  registry.AddThrottle(std::make_unique<AIChatBraveSearchThrottle>(
+      std::move(open_leo_delegate), registry, ai_chat_service));
 }
 
 AIChatBraveSearchThrottle::AIChatBraveSearchThrottle(

--- a/components/ai_chat/content/browser/ai_chat_brave_search_throttle.h
+++ b/components/ai_chat/content/browser/ai_chat_brave_search_throttle.h
@@ -6,16 +6,13 @@
 #ifndef BRAVE_COMPONENTS_AI_CHAT_CONTENT_BROWSER_AI_CHAT_BRAVE_SEARCH_THROTTLE_H_
 #define BRAVE_COMPONENTS_AI_CHAT_CONTENT_BROWSER_AI_CHAT_BRAVE_SEARCH_THROTTLE_H_
 
-#include <memory>
 #include <optional>
 #include <string>
 
 #include "base/functional/callback.h"
 #include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
-#include "brave/components/ai_chat/core/browser/ai_chat_service.h"
 #include "content/public/browser/navigation_throttle.h"
-#include "content/public/browser/permission_result.h"
 
 namespace blink {
 namespace mojom {
@@ -53,7 +50,7 @@ class AIChatBraveSearchThrottle : public content::NavigationThrottle {
       AIChatService* ai_chat_service);
   ~AIChatBraveSearchThrottle() override;
 
-  static std::unique_ptr<AIChatBraveSearchThrottle> MaybeCreateThrottleFor(
+  static void MaybeCreateAndAdd(
       base::OnceCallback<void(content::WebContents*)> open_leo_delegate,
       content::NavigationThrottleRegistry& registry,
       AIChatService* ai_chat_service,

--- a/components/ai_chat/content/browser/ai_chat_throttle.cc
+++ b/components/ai_chat/content/browser/ai_chat_throttle.cc
@@ -23,7 +23,7 @@
 namespace ai_chat {
 
 // static
-std::unique_ptr<AIChatThrottle> AIChatThrottle::MaybeCreateThrottleFor(
+void AIChatThrottle::MaybeCreateAndAdd(
     content::NavigationThrottleRegistry& registry) {
   // The throttle's only purpose is to deny navigation in a Tab.
 
@@ -32,7 +32,7 @@ std::unique_ptr<AIChatThrottle> AIChatThrottle::MaybeCreateThrottleFor(
   content::NavigationHandle& navigation_handle = registry.GetNavigationHandle();
   if (!ai_chat::IsAIChatEnabled(user_prefs::UserPrefs::Get(
           navigation_handle.GetWebContents()->GetBrowserContext()))) {
-    return nullptr;
+    return;
   }
 
   const GURL& url = navigation_handle.GetURL();
@@ -43,7 +43,7 @@ std::unique_ptr<AIChatThrottle> AIChatThrottle::MaybeCreateThrottleFor(
   // We allow main page navigation only if the full-page feature is enabled
   // via the AIChatHistory feature flag.
   if (is_main_page_url && features::IsAIChatHistoryEnabled()) {
-    return nullptr;
+    return;
   }
 
   bool is_ai_chat_frame =
@@ -52,21 +52,21 @@ std::unique_ptr<AIChatThrottle> AIChatThrottle::MaybeCreateThrottleFor(
 
   // We need this throttle to work only for AI Chat related URLs
   if (!is_main_page_url && !is_ai_chat_frame) {
-    return nullptr;
+    return;
   }
 
 // On Android, we only have full page chat, so we always allow loading. On
 // desktop we just disallow PAGE_TRANSITION_FROM_ADDRESS_BAR.
 #if BUILDFLAG(IS_ANDROID)
-  return nullptr;
+  return;
 #else
   ui::PageTransition transition = navigation_handle.GetPageTransition();
   if (!ui::PageTransitionTypeIncludingQualifiersIs(
           ui::PageTransitionGetQualifier(transition),
           ui::PageTransition::PAGE_TRANSITION_FROM_ADDRESS_BAR)) {
-    return nullptr;
+    return;
   }
-  return std::make_unique<AIChatThrottle>(registry);
+  registry.AddThrottle(std::make_unique<AIChatThrottle>(registry));
 #endif  // BUILDFLAG(IS_ANDROID)
 }
 

--- a/components/ai_chat/content/browser/ai_chat_throttle.h
+++ b/components/ai_chat/content/browser/ai_chat_throttle.h
@@ -6,8 +6,6 @@
 #ifndef BRAVE_COMPONENTS_AI_CHAT_CONTENT_BROWSER_AI_CHAT_THROTTLE_H_
 #define BRAVE_COMPONENTS_AI_CHAT_CONTENT_BROWSER_AI_CHAT_THROTTLE_H_
 
-#include <memory>
-
 #include "content/public/browser/navigation_throttle.h"
 
 namespace ai_chat {
@@ -18,8 +16,7 @@ class AIChatThrottle : public content::NavigationThrottle {
   explicit AIChatThrottle(content::NavigationThrottleRegistry& registry);
   ~AIChatThrottle() override;
 
-  static std::unique_ptr<AIChatThrottle> MaybeCreateThrottleFor(
-      content::NavigationThrottleRegistry& registry);
+  static void MaybeCreateAndAdd(content::NavigationThrottleRegistry& registry);
 
   // content::NavigationThrottle:
   // ThrottleCheckResult WillProcessResponse() override;

--- a/components/brave_rewards/content/rewards_protocol_navigation_throttle.cc
+++ b/components/brave_rewards/content/rewards_protocol_navigation_throttle.cc
@@ -40,16 +40,16 @@ using content::WebContents;
 namespace brave_rewards {
 
 // static
-std::unique_ptr<RewardsProtocolNavigationThrottle>
-RewardsProtocolNavigationThrottle::MaybeCreateThrottleFor(
+void RewardsProtocolNavigationThrottle::MaybeCreateAndAdd(
     content::NavigationThrottleRegistry& registry) {
   auto* pref_service = user_prefs::UserPrefs::Get(
       registry.GetNavigationHandle().GetWebContents()->GetBrowserContext());
   if (!pref_service->GetBoolean(brave_rewards::prefs::kEnabled)) {
-    return nullptr;
+    return;
   }
 
-  return std::make_unique<RewardsProtocolNavigationThrottle>(registry);
+  registry.AddThrottle(
+      std::make_unique<RewardsProtocolNavigationThrottle>(registry));
 }
 
 RewardsProtocolNavigationThrottle::RewardsProtocolNavigationThrottle(

--- a/components/brave_rewards/content/rewards_protocol_navigation_throttle.h
+++ b/components/brave_rewards/content/rewards_protocol_navigation_throttle.h
@@ -6,8 +6,6 @@
 #ifndef BRAVE_COMPONENTS_BRAVE_REWARDS_CONTENT_REWARDS_PROTOCOL_NAVIGATION_THROTTLE_H_
 #define BRAVE_COMPONENTS_BRAVE_REWARDS_CONTENT_REWARDS_PROTOCOL_NAVIGATION_THROTTLE_H_
 
-#include <memory>
-
 #include "content/public/browser/navigation_throttle.h"
 
 namespace brave_rewards {
@@ -23,8 +21,7 @@ class RewardsProtocolNavigationThrottle : public content::NavigationThrottle {
   RewardsProtocolNavigationThrottle& operator=(
       const RewardsProtocolNavigationThrottle&) = delete;
 
-  static std::unique_ptr<RewardsProtocolNavigationThrottle>
-  MaybeCreateThrottleFor(content::NavigationThrottleRegistry& registry);
+  static void MaybeCreateAndAdd(content::NavigationThrottleRegistry& registry);
 
   // Implements content::NavigationThrottle.
   ThrottleCheckResult WillStartRequest() override;

--- a/components/brave_shields/content/browser/domain_block_navigation_throttle.cc
+++ b/components/brave_shields/content/browser/domain_block_navigation_throttle.cc
@@ -34,6 +34,7 @@
 #include "content/public/browser/web_contents.h"
 #include "content/public/browser/web_contents_user_data.h"
 #include "net/base/net_errors.h"
+#include "url/gurl.h"
 
 namespace brave_shields {
 
@@ -98,8 +99,7 @@ ShouldBlockDomainOnTaskRunner(brave_shields::AdBlockService* ad_block_service,
 namespace brave_shields {
 
 // static
-std::unique_ptr<DomainBlockNavigationThrottle>
-DomainBlockNavigationThrottle::MaybeCreateThrottleFor(
+void DomainBlockNavigationThrottle::MaybeCreateAndAdd(
     content::NavigationThrottleRegistry& registry,
     AdBlockService* ad_block_service,
     AdBlockCustomFiltersProvider* ad_block_custom_filters_provider,
@@ -107,19 +107,19 @@ DomainBlockNavigationThrottle::MaybeCreateThrottleFor(
     HostContentSettingsMap* content_settings,
     const std::string& locale) {
   if (!ad_block_service || !ad_block_custom_filters_provider) {
-    return nullptr;
+    return;
   }
   if (!base::FeatureList::IsEnabled(
           brave_shields::features::kBraveDomainBlock)) {
-    return nullptr;
+    return;
   }
   // Don't block subframes.
   if (!registry.GetNavigationHandle().IsInMainFrame()) {
-    return nullptr;
+    return;
   }
-  return std::make_unique<DomainBlockNavigationThrottle>(
+  registry.AddThrottle(std::make_unique<DomainBlockNavigationThrottle>(
       registry, ad_block_service, ad_block_custom_filters_provider,
-      ephemeral_storage_service, content_settings, locale);
+      ephemeral_storage_service, content_settings, locale));
 }
 
 DomainBlockNavigationThrottle::DomainBlockNavigationThrottle(

--- a/components/brave_shields/content/browser/domain_block_navigation_throttle.h
+++ b/components/brave_shields/content/browser/domain_block_navigation_throttle.h
@@ -6,18 +6,15 @@
 #ifndef BRAVE_COMPONENTS_BRAVE_SHIELDS_CONTENT_BROWSER_DOMAIN_BLOCK_NAVIGATION_THROTTLE_H_
 #define BRAVE_COMPONENTS_BRAVE_SHIELDS_CONTENT_BROWSER_DOMAIN_BLOCK_NAVIGATION_THROTTLE_H_
 
-#include <memory>
 #include <string>
-#include <utility>
-#include <vector>
 
 #include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
 #include "brave/components/brave_shields/content/browser/brave_shields_util.h"
 #include "content/public/browser/navigation_throttle.h"
-#include "url/gurl.h"
 
 class HostContentSettingsMap;
+class GURL;
 
 namespace ephemeral_storage {
 class EphemeralStorageService;
@@ -44,7 +41,7 @@ class DomainBlockNavigationThrottle : public content::NavigationThrottle {
   DomainBlockNavigationThrottle& operator=(
       const DomainBlockNavigationThrottle&) = delete;
 
-  static std::unique_ptr<DomainBlockNavigationThrottle> MaybeCreateThrottleFor(
+  static void MaybeCreateAndAdd(
       content::NavigationThrottleRegistry& registry,
       AdBlockService* ad_block_service,
       AdBlockCustomFiltersProvider* ad_block_custom_filters_provider,

--- a/components/debounce/content/browser/debounce_navigation_throttle.cc
+++ b/components/debounce/content/browser/debounce_navigation_throttle.cc
@@ -85,23 +85,22 @@ void ClearRedirectChain(NavigationHandle* navigation_handle) {
 }  // namespace
 
 // static
-std::unique_ptr<DebounceNavigationThrottle>
-DebounceNavigationThrottle::MaybeCreateThrottleFor(
+void DebounceNavigationThrottle::MaybeCreateAndAdd(
     content::NavigationThrottleRegistry& registry,
     DebounceService* debounce_service) {
   // If debouncing is disabled in brave://flags, debounce service will
   // never be created (will be null) so we won't create the throttle
   // either. Caller must nullcheck this.
   if (!debounce_service) {
-    return nullptr;
+    return;
   }
 
   if (!debounce_service->IsEnabled()) {
-    return nullptr;
+    return;
   }
 
-  return std::make_unique<DebounceNavigationThrottle>(registry,
-                                                      *debounce_service);
+  registry.AddThrottle(std::make_unique<DebounceNavigationThrottle>(
+      registry, *debounce_service));
 }
 
 DebounceNavigationThrottle::DebounceNavigationThrottle(

--- a/components/debounce/content/browser/debounce_navigation_throttle.h
+++ b/components/debounce/content/browser/debounce_navigation_throttle.h
@@ -6,8 +6,6 @@
 #ifndef BRAVE_COMPONENTS_DEBOUNCE_CONTENT_BROWSER_DEBOUNCE_NAVIGATION_THROTTLE_H_
 #define BRAVE_COMPONENTS_DEBOUNCE_CONTENT_BROWSER_DEBOUNCE_NAVIGATION_THROTTLE_H_
 
-#include <memory>
-
 #include "base/memory/raw_ref.h"
 #include "content/public/browser/navigation_throttle.h"
 
@@ -26,9 +24,8 @@ class DebounceNavigationThrottle : public content::NavigationThrottle {
   DebounceNavigationThrottle& operator=(const DebounceNavigationThrottle&) =
       delete;
 
-  static std::unique_ptr<DebounceNavigationThrottle> MaybeCreateThrottleFor(
-      content::NavigationThrottleRegistry& registry,
-      DebounceService* debounce_service);
+  static void MaybeCreateAndAdd(content::NavigationThrottleRegistry& registry,
+                                DebounceService* debounce_service);
 
   // Implements content::NavigationThrottle.
   ThrottleCheckResult WillStartRequest() override;

--- a/components/decentralized_dns/content/decentralized_dns_navigation_throttle.cc
+++ b/components/decentralized_dns/content/decentralized_dns_navigation_throttle.cc
@@ -25,8 +25,7 @@
 namespace decentralized_dns {
 
 // static
-std::unique_ptr<DecentralizedDnsNavigationThrottle>
-DecentralizedDnsNavigationThrottle::MaybeCreateThrottleFor(
+void DecentralizedDnsNavigationThrottle::MaybeCreateAndAdd(
     content::NavigationThrottleRegistry& registry,
     PrefService* user_prefs,
     PrefService* local_state,
@@ -35,15 +34,15 @@ DecentralizedDnsNavigationThrottle::MaybeCreateThrottleFor(
   content::BrowserContext* context =
       navigation_handle.GetWebContents()->GetBrowserContext();
   if (context->IsOffTheRecord()) {
-    return nullptr;
+    return;
   }
 
   if (!navigation_handle.IsInMainFrame()) {
-    return nullptr;
+    return;
   }
 
-  return std::make_unique<DecentralizedDnsNavigationThrottle>(
-      registry, user_prefs, local_state, locale);
+  registry.AddThrottle(std::make_unique<DecentralizedDnsNavigationThrottle>(
+      registry, user_prefs, local_state, locale));
 }
 
 DecentralizedDnsNavigationThrottle::DecentralizedDnsNavigationThrottle(

--- a/components/decentralized_dns/content/decentralized_dns_navigation_throttle.h
+++ b/components/decentralized_dns/content/decentralized_dns_navigation_throttle.h
@@ -6,7 +6,6 @@
 #ifndef BRAVE_COMPONENTS_DECENTRALIZED_DNS_CONTENT_DECENTRALIZED_DNS_NAVIGATION_THROTTLE_H_
 #define BRAVE_COMPONENTS_DECENTRALIZED_DNS_CONTENT_DECENTRALIZED_DNS_NAVIGATION_THROTTLE_H_
 
-#include <memory>
 #include <string>
 
 #include "base/memory/weak_ptr.h"
@@ -30,11 +29,10 @@ class DecentralizedDnsNavigationThrottle : public content::NavigationThrottle {
   DecentralizedDnsNavigationThrottle& operator=(
       const DecentralizedDnsNavigationThrottle&) = delete;
 
-  static std::unique_ptr<DecentralizedDnsNavigationThrottle>
-  MaybeCreateThrottleFor(content::NavigationThrottleRegistry& registry,
-                         PrefService* user_prefs,
-                         PrefService* local_state,
-                         const std::string& locale);
+  static void MaybeCreateAndAdd(content::NavigationThrottleRegistry& registry,
+                                PrefService* user_prefs,
+                                PrefService* local_state,
+                                const std::string& locale);
 
   // content::NavigationThrottle implementation:
   ThrottleCheckResult WillStartRequest() override;

--- a/components/request_otr/browser/request_otr_navigation_throttle.h
+++ b/components/request_otr/browser/request_otr_navigation_throttle.h
@@ -6,17 +6,15 @@
 #ifndef BRAVE_COMPONENTS_REQUEST_OTR_BROWSER_REQUEST_OTR_NAVIGATION_THROTTLE_H_
 #define BRAVE_COMPONENTS_REQUEST_OTR_BROWSER_REQUEST_OTR_NAVIGATION_THROTTLE_H_
 
-#include <memory>
 #include <string>
-#include <vector>
 
 #include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
 #include "brave/components/brave_shields/content/browser/brave_shields_util.h"
 #include "content/public/browser/navigation_throttle.h"
-#include "url/gurl.h"
 
 class PrefService;
+class GURL;
 
 namespace ephemeral_storage {
 class EphemeralStorageService;
@@ -40,7 +38,7 @@ class RequestOTRNavigationThrottle : public content::NavigationThrottle {
   RequestOTRNavigationThrottle& operator=(const RequestOTRNavigationThrottle&) =
       delete;
 
-  static std::unique_ptr<RequestOTRNavigationThrottle> MaybeCreateThrottleFor(
+  static void MaybeCreateAndAdd(
       content::NavigationThrottleRegistry& registry,
       RequestOTRService* request_otr_service,
       ephemeral_storage::EphemeralStorageService* ephemeral_storage_service,

--- a/components/tor/onion_location_navigation_throttle.cc
+++ b/components/tor/onion_location_navigation_throttle.cc
@@ -39,16 +39,15 @@ bool GetOnionLocation(const net::HttpResponseHeaders* headers,
 }  // namespace
 
 // static
-std::unique_ptr<OnionLocationNavigationThrottle>
-OnionLocationNavigationThrottle::MaybeCreateThrottleFor(
+void OnionLocationNavigationThrottle::MaybeCreateAndAdd(
     content::NavigationThrottleRegistry& registry,
     bool is_tor_disabled,
     bool is_tor_profile) {
   if (is_tor_disabled || !registry.GetNavigationHandle().IsInMainFrame()) {
-    return nullptr;
+    return;
   }
-  return std::make_unique<OnionLocationNavigationThrottle>(registry,
-                                                           is_tor_profile);
+  registry.AddThrottle(std::make_unique<OnionLocationNavigationThrottle>(
+      registry, is_tor_profile));
 }
 
 OnionLocationNavigationThrottle::OnionLocationNavigationThrottle(

--- a/components/tor/onion_location_navigation_throttle.h
+++ b/components/tor/onion_location_navigation_throttle.h
@@ -6,8 +6,6 @@
 #ifndef BRAVE_COMPONENTS_TOR_ONION_LOCATION_NAVIGATION_THROTTLE_H_
 #define BRAVE_COMPONENTS_TOR_ONION_LOCATION_NAVIGATION_THROTTLE_H_
 
-#include <memory>
-
 #include "content/public/browser/navigation_throttle.h"
 
 class GURL;
@@ -20,10 +18,9 @@ namespace tor {
 
 class OnionLocationNavigationThrottle : public content::NavigationThrottle {
  public:
-  static std::unique_ptr<OnionLocationNavigationThrottle>
-  MaybeCreateThrottleFor(content::NavigationThrottleRegistry& registry,
-                         bool is_tor_disabled,
-                         bool is_tor_profile);
+  static void MaybeCreateAndAdd(content::NavigationThrottleRegistry& registry,
+                                bool is_tor_disabled,
+                                bool is_tor_profile);
   explicit OnionLocationNavigationThrottle(
       content::NavigationThrottleRegistry& registry,
       bool is_tor_profile);

--- a/components/tor/tor_navigation_throttle.cc
+++ b/components/tor/tor_navigation_throttle.cc
@@ -18,25 +18,23 @@ namespace tor {
 bool TorNavigationThrottle::skip_wait_for_tor_connected_for_testing_ = false;
 
 // static
-std::unique_ptr<TorNavigationThrottle>
-TorNavigationThrottle::MaybeCreateThrottleFor(
+void TorNavigationThrottle::MaybeCreateAndAdd(
     content::NavigationThrottleRegistry& registry,
     bool is_tor_profile) {
   if (!is_tor_profile)
-    return nullptr;
-  return std::make_unique<TorNavigationThrottle>(registry);
+    return;
+  registry.AddThrottle(std::make_unique<TorNavigationThrottle>(registry));
 }
 
 // static
-std::unique_ptr<TorNavigationThrottle>
-TorNavigationThrottle::MaybeCreateThrottleFor(
+void TorNavigationThrottle::MaybeCreateAndAdd(
     content::NavigationThrottleRegistry& registry,
     TorLauncherFactory& tor_launcher_factory,
     bool is_tor_profile) {
   if (!is_tor_profile)
-    return nullptr;
-  return std::make_unique<TorNavigationThrottle>(registry,
-                                                 tor_launcher_factory);
+    return;
+  registry.AddThrottle(
+      std::make_unique<TorNavigationThrottle>(registry, tor_launcher_factory));
 }
 
 TorNavigationThrottle::TorNavigationThrottle(

--- a/components/tor/tor_navigation_throttle.h
+++ b/components/tor/tor_navigation_throttle.h
@@ -6,8 +6,6 @@
 #ifndef BRAVE_COMPONENTS_TOR_TOR_NAVIGATION_THROTTLE_H_
 #define BRAVE_COMPONENTS_TOR_TOR_NAVIGATION_THROTTLE_H_
 
-#include <memory>
-
 #include "base/gtest_prod_util.h"
 #include "base/memory/raw_ref.h"
 #include "brave/components/tor/tor_launcher_observer.h"
@@ -20,14 +18,12 @@ namespace tor {
 class TorNavigationThrottle : public content::NavigationThrottle,
                               public TorLauncherObserver {
  public:
-  static std::unique_ptr<TorNavigationThrottle> MaybeCreateThrottleFor(
-      content::NavigationThrottleRegistry& registry,
-      bool is_tor_profile);
+  static void MaybeCreateAndAdd(content::NavigationThrottleRegistry& registry,
+                                bool is_tor_profile);
   // For tests to use its own McokTorLauncherFactory
-  static std::unique_ptr<TorNavigationThrottle> MaybeCreateThrottleFor(
-      content::NavigationThrottleRegistry& registry,
-      TorLauncherFactory& tor_launcher_factory,
-      bool is_tor_profile);
+  static void MaybeCreateAndAdd(content::NavigationThrottleRegistry& registry,
+                                TorLauncherFactory& tor_launcher_factory,
+                                bool is_tor_profile);
   explicit TorNavigationThrottle(content::NavigationThrottleRegistry& registry);
   TorNavigationThrottle(content::NavigationThrottleRegistry& registry,
                         TorLauncherFactory& tor_launcher_factory);


### PR DESCRIPTION
This is an overall improvement on how the registry manages these
throttles, but it ends up touching a lot of places, and the way all
throttles are instantiated.

Chromium changes:
https://chromium.googlesource.com/chromium/src/+/b1629ea692c8614cb272bd693571aa887de92c6c
https://chromium.googlesource.com/chromium/src/+/79566dfffd2c4d74aea54bcff1b3957bbeb1342d
https://chromium.googlesource.com/chromium/src/+/eca5027cdfc38625db8ac467fd5b4bf703befa6b

```
commit b1629ea692c8614cb272bd693571aa887de92c6c
Author: Takashi Toyoshima <toyoshim@chromium.org>
Date:   Mon Jun 9 22:58:01 2025 -0700

    NavigationThrottleRunner2: Remove MaybeAddThrottle

    Now all callers pass a valid NavigationThrottle instance to add their
    throttles to the registry as now the registration is done by the end
    users, and they know if they need to register a throttle or not.

    Bug: 412524375
    Change-Id: I9144fd327fb21be5362157ee84a267012796f2dd
    Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/6628079
    Reviewed-by: Alex Moshchuk <alexmos@chromium.org>
    Commit-Queue: Takashi Toyoshima <toyoshim@chromium.org>
    Cr-Commit-Position: refs/heads/main@{#1471602}

commit 79566dfffd2c4d74aea54bcff1b3957bbeb1342d
Author: Takashi Toyoshima <toyoshim@chromium.org>
Date:   Thu May 15 08:05:50 2025 -0700

    NavigationThrottleRunner2: NavigationThrottle migration for chrome 1

    This is a follow-up of crrev.com/c/6510776, and applies the same ctor
    migration to the former half of throttles used in
    ChromeContentBrowserClient.

    Bug: 412524375
    Change-Id: I834478c8d1dfd117527546ae0a5bbd12aa46c361
    Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/6536175
    Reviewed-by: Colin Blundell <blundell@chromium.org>
    Commit-Queue: Takashi Toyoshima <toyoshim@chromium.org>
    Reviewed-by: Devlin Cronin <rdevlin.cronin@chromium.org>
    Reviewed-by: David Roger <droger@chromium.org>
    Cr-Commit-Position: refs/heads/main@{#1460728}

commit eca5027cdfc38625db8ac467fd5b4bf703befa6b
Author: Takashi Toyoshima <toyoshim@chromium.org>
Date:   Tue May 27 22:12:22 2025 -0700

    NavigationThrottleRunner2: NavigationThrottle ctor migration //content 2

    This patch migrates former half remaining throttles that are
    registered in the content::NavigationThrottleRunner, but haven't
    migrated to use the new constructor yet.

    Bug: 412524375
    Change-Id: I1fc5c9e4efe368d539751aeda0c324321c9ff30d
    Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/6585462
    Commit-Queue: Takashi Toyoshima <toyoshim@chromium.org>
    Reviewed-by: Alex Moshchuk <alexmos@chromium.org>
    Cr-Commit-Position: refs/heads/main@{#1466303}
```

Resolves https://github.com/brave/brave-browser/issues/46902
