### PR TITLE
[explainers]: Update WebUI overriding explainer with a link to strings and note that storybook strings are automatic now.

### DIFF
--- a/docs/webui_overriding.md
+++ b/docs/webui_overriding.md
@@ -176,3 +176,9 @@ the upstream build for that WebUI.
 
 See `//brave/browser/resources/settings/BUILD.gn` and
 `//brave/browser/resources/settings/settings.gni` for how to get this setup.
+
+## Strings
+
+When using translated strings you should follow the guidance in the
+[webui strings explainer](./webui_strings_explainer.md) to reduce boilerplate
+and ensure we catch misspelt strings.

--- a/docs/webui_strings_explainer.md
+++ b/docs/webui_strings_explainer.md
@@ -92,5 +92,4 @@ Afterwards everything should work the same as it does in our UIs.
 
 ## Storybook
 
-We're looking into generating Storybook strings too, but that will be done as a
-followup.
+Storybook will automatically have the generated strings available.


### PR DESCRIPTION
Updates the `webui_overriding` explainer to link to the strings explainer
Also updates the Storybook section in the strings explainer to note that its automatic now.