### PR TITLE
[iOS] Replace strict cast in Chromium's GetAnyKeyWindow (uplift to 1.80.x)

### DIFF
--- a/chromium_src/ios/web/common/uikit_ui_util.mm
+++ b/chromium_src/ios/web/common/uikit_ui_util.mm
@@ -1,4 +1,4 @@
-/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
@@ -8,5 +8,5 @@
 // Replaces the strict cast to a standard cast since its possible for Brave to
 // have a non-window scene thanks to the CarPlay support
 #define ObjCCastStrict ObjCCast
-#include "src/ui/display/ios/screen_ios.mm"
+#include "src/ios/web/common/uikit_ui_util.mm"
 #undef ObjCCastStrict


### PR DESCRIPTION
Uplift of #29594
Resolves https://github.com/brave/brave-browser/issues/46883

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.