### PR TITLE
[cr138 follow up] Disable invalidation features. (uplift to 1.80.x)

### DIFF
--- a/app/BUILD.gn
+++ b/app/BUILD.gn
@@ -122,6 +122,7 @@ source_set("unit_tests") {
     "//chrome/browser",
     "//chrome/browser/devtools",
     "//chrome/browser/enterprise/connectors/analysis:features",
+    "//chrome/browser/policy:policy_util",
     "//chrome/browser/ui",
     "//chrome/browser/ui:ui_features",
     "//chrome/common/privacy_budget",

--- a/app/feature_defaults_unittest.cc
+++ b/app/feature_defaults_unittest.cc
@@ -11,6 +11,7 @@
 #include "chrome/browser/browser_features.h"
 #include "chrome/browser/devtools/features.h"
 #include "chrome/browser/history_embeddings/history_embeddings_utils.h"
+#include "chrome/browser/policy/policy_util.h"
 #include "chrome/browser/preloading/preloading_features.h"
 #include "chrome/browser/ui/ui_features.h"
 #include "chrome/common/chrome_features.h"
@@ -226,6 +227,10 @@ TEST(FeatureDefaultsTest, DisabledFeatures) {
       &permissions::features::kPermissionPredictionsV2,
       &permissions::features::kShowRelatedWebsiteSetsPermissionGrants,
       &plus_addresses::features::kPlusAddressesEnabled,
+      &policy::kDevicePolicyInvalidationWithDirectMessagesEnabled,
+      &policy::kDeviceLocalAccountPolicyInvalidationWithDirectMessagesEnabled,
+      &policy::kCbcmPolicyInvalidationWithDirectMessagesEnabled,
+      &policy::kUserPolicyInvalidationWithDirectMessagesEnabled,
       &privacy_sandbox::kEnforcePrivacySandboxAttestations,
       &privacy_sandbox::kFingerprintingProtectionUx,
       &privacy_sandbox::kOverridePrivacySandboxSettingsLocalTesting,

--- a/browser/net/brave_network_audit_allowed_lists.h
+++ b/browser/net/brave_network_audit_allowed_lists.h
@@ -77,9 +77,6 @@ inline constexpr auto kAllowedUrlPrefixes = std::to_array<std::string_view>({
     "https://safebrowsing.brave.com/",
     "https://static.brave.com/",
     "https://static1.brave.com/",
-
-    // Temporary allow GCM (push messaging) endpoint
-    "https://android.clients.google.com/",
 });
 
 }  // namespace brave

--- a/chromium_src/chrome/browser/policy/policy_util.cc
+++ b/chromium_src/chrome/browser/policy/policy_util.cc
@@ -1,0 +1,23 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "src/chrome/browser/policy/policy_util.cc"
+
+#include "base/feature_override.h"
+
+namespace policy {
+
+OVERRIDE_FEATURE_DEFAULT_STATES({{
+    {kDevicePolicyInvalidationWithDirectMessagesEnabled,
+     base::FEATURE_DISABLED_BY_DEFAULT},
+    {kDeviceLocalAccountPolicyInvalidationWithDirectMessagesEnabled,
+     base::FEATURE_DISABLED_BY_DEFAULT},
+    {kCbcmPolicyInvalidationWithDirectMessagesEnabled,
+     base::FEATURE_DISABLED_BY_DEFAULT},
+    {kUserPolicyInvalidationWithDirectMessagesEnabled,
+     base::FEATURE_DISABLED_BY_DEFAULT},
+}});
+
+}  // namespace policy


### PR DESCRIPTION
Uplift of #29621
Resolves https://github.com/brave/brave-browser/issues/46912
Resolves https://github.com/brave/brave-browser/issues/46813
Resolves https://github.com/brave/brave-browser/issues/46814
Resolves https://github.com/brave/brave-browser/issues/46815

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.