### PR TITLE
Prevent crash from VerticalTabSearchButton duing the destruction (uplift to 1.80.x)

### DIFF
--- a/browser/ui/views/frame/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.cc
@@ -179,6 +179,28 @@ class VerticalTabSearchButton : public BraveTabSearchButton {
     SetBackground(nullptr);
   }
 
+  void UpdateBackground() override {
+    // Copied comment from BraveTabStrip::GetCustomBackgroundId() as
+    // this method overriding has same purpose.
+    // When vertical tab strip mode is enabled, the tab strip could be
+    // reattached to the original parent during destruction. In this case, theme
+    // changing could occur. But unfortunately, some of native widget's
+    // implementation doesn't check the validity of pointer, which causes crash.
+    // e.g. DesktopNativeWidgetAura's many methods desktop_tree_host without
+    //      checking it's validity.
+    // In order to avoid accessing invalid pointer, filters here.
+
+    // TabStripControlButton::UpdateBackground() tries to access theme provider
+    // by calling BrowserTabStripController::GetCustomBackgroundId() and
+    // crash could happen there.
+    if (auto* widget = GetWidget();
+        !widget || widget->IsClosed() || !widget->native_widget()) {
+      return;
+    }
+
+    return BraveTabSearchButton::UpdateBackground();
+  }
+
   void OnThemeChanged() override {
     BraveTabSearchButton::OnThemeChanged();
     ConfigureInkDropForToolbar(this);

--- a/chromium_src/chrome/browser/ui/views/tabs/tab_strip_control_button.h
+++ b/chromium_src/chrome/browser/ui/views/tabs/tab_strip_control_button.h
@@ -9,9 +9,18 @@
 #define TabStripControlButton TabStripControlButton_ChromiumImpl
 #define UpdateInkDrop virtual UpdateInkDrop
 #define GetForegroundColor virtual GetForegroundColor
+#define UpdateBackground           \
+  UpdateBackground_UnUsed() {}     \
+                                   \
+ protected:                        \
+  virtual void UpdateBackground(); \
+                                   \
+ private:                          \
+  void UnUsed
 
 #include "src/chrome/browser/ui/views/tabs/tab_strip_control_button.h"  // IWYU pragma: export
 
+#undef UpdateBackground
 #undef GetForegroundColor
 #undef UpdateInkDrop
 #undef TabStripControlButton


### PR DESCRIPTION
Uplift of #29645
Resolves https://github.com/brave/brave-browser/issues/46066

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.