### PR TITLE
Update chromium_src include logic to allow `<>` includes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ vendor/omaha/
 .gclient_*
 .tags*
 .cipd
-/.clang-format
+/chromium_src/.clang-format
 /.idea/
 /components/brave_new_tab_ui/data/LICENSE
 /components/brave_wallet/browser/zcash/rust/librustzcash/src/

--- a/DEPS
+++ b/DEPS
@@ -158,10 +158,20 @@ hooks = [
     'action': ['python3', 'build/apple/download_swift_format.py', '510.1.0', '0ddbb486640cde862fa311dc0f7387e6c5171bdcc0ee0c89bc9a1f8a75e8bfaf']
   },
   {
-    # Generate .clang-format.
-    'name': 'generate_clang_format',
+    # Chromium_src files require custom formatting to correctly sort includes
+    # that reference original files.
+    'name': 'generate_chromium_src_clang_format',
     'pattern': '.',
-    'action': ['vpython3', 'build/util/generate_clang_format.py', '../.clang-format', '.clang-format']
+    'action': ['vpython3', 'tools/chromium_src/generate_clang_format.py',
+               '../.clang-format', 'chromium_src/.clang-format'],
+  },
+  {
+    # We only need a custom .clang-format in chromium_src. It was previously
+    # generated in the root of brave/, so we remove it now. This hook can be
+    # removed after 08/2025.
+    'name': 'remove_stale_clang_format',
+    'pattern': '.',
+    'action': ['python3', '../tools/remove_stale_files.py', '.clang-format']
   },
   {
     'name': 'update_midl_files',

--- a/build/BUILD.gn
+++ b/build/BUILD.gn
@@ -6,11 +6,16 @@
 import("//brave/build/config.gni")
 
 config("brave_chromium_src_support") {
-  # Add max priority "//brave/chromium_src" include search path to be able to
-  # redirect Chromium #include into our file if it exists.
-  # For example, to override //base/macros.h, the overriden file must be
-  # placed at //brave/chromium_src/base/macros.h.
-  include_dirs = [ "//brave/chromium_src" ]
+  # Add "//brave/chromium_src" to the quoted include search path using -iquote.
+  # This allows all source files to point to Brave overrides via #include "...",
+  # while the overrides themselves can reference original Chromium files with
+  # #include <...>.
+  cflags = []
+  if (is_win) {
+    # Clang-cl doesn't know -iquote. Prepend -Xclang to make it work.
+    cflags += [ "-Xclang" ]
+  }
+  cflags += [ "-iquote" + rebase_path("//brave/chromium_src", root_build_dir) ]
 
   # Add lowest priority "//.." include search path to be able to include original
   # Chromium files using "src/" prefix.
@@ -18,7 +23,7 @@ config("brave_chromium_src_support") {
   # because it should have the lowest priority to not break compile steps when a
   # path clash is possible: //base/macros.h vs //third_party/v8/src/base/macros.h.
   relative_root_dir = rebase_path("//..", root_build_dir)
-  cflags = [ "-I${relative_root_dir}" ]
+  cflags += [ "-I${relative_root_dir}" ]
 }
 
 # Config to support //base build without redirect_cc to build redirect_cc itself.

--- a/chromium_src/base/check_is_test.cc
+++ b/chromium_src/base/check_is_test.cc
@@ -5,7 +5,7 @@
 
 #include "base/check_is_test.h"
 
-#include "src/base/check_is_test.cc"
+#include <base/check_is_test.cc>
 
 namespace {
 bool g_this_is_a_brave_test = false;

--- a/chromium_src/base/check_is_test.h
+++ b/chromium_src/base/check_is_test.h
@@ -6,9 +6,9 @@
 #ifndef BRAVE_CHROMIUM_SRC_BASE_CHECK_IS_TEST_H_
 #define BRAVE_CHROMIUM_SRC_BASE_CHECK_IS_TEST_H_
 
-#include "base/gtest_prod_util.h"
-
 #include <base/check_is_test.h>  // IWYU pragma: export
+
+#include "base/gtest_prod_util.h"
 
 namespace variations {
 class PublicKeyWrapper;

--- a/chromium_src/base/check_is_test.h
+++ b/chromium_src/base/check_is_test.h
@@ -8,7 +8,7 @@
 
 #include "base/gtest_prod_util.h"
 
-#include "src/base/check_is_test.h"  // IWYU pragma: export
+#include <base/check_is_test.h>  // IWYU pragma: export
 
 namespace variations {
 class PublicKeyWrapper;

--- a/chromium_src/base/debug/alias.h
+++ b/chromium_src/base/debug/alias.h
@@ -6,13 +6,13 @@
 #ifndef BRAVE_CHROMIUM_SRC_BASE_DEBUG_ALIAS_H_
 #define BRAVE_CHROMIUM_SRC_BASE_DEBUG_ALIAS_H_
 
+#include <base/debug/alias.h>  // IWYU pragma: export
+
 #include <algorithm>
 
 #include "base/containers/span.h"
 #include "base/memory/raw_ptr_exclusion.h"
 #include "base/memory/stack_allocated.h"
-
-#include <base/debug/alias.h>  // IWYU pragma: export
 
 namespace base::debug {
 

--- a/chromium_src/base/debug/alias.h
+++ b/chromium_src/base/debug/alias.h
@@ -12,7 +12,7 @@
 #include "base/memory/raw_ptr_exclusion.h"
 #include "base/memory/stack_allocated.h"
 
-#include "src/base/debug/alias.h"  // IWYU pragma: export
+#include <base/debug/alias.h>  // IWYU pragma: export
 
 namespace base::debug {
 

--- a/chromium_src/base/feature_list.cc
+++ b/chromium_src/base/feature_list.cc
@@ -137,7 +137,7 @@ FeatureState FeatureList::GetCompileTimeFeatureState(const Feature& feature) {
 #define IsFeatureOverridden IsFeatureOverridden_ChromiumImpl
 #define GetStateIfOverridden GetStateIfOverridden_ChromiumImpl
 
-#include "src/base/feature_list.cc"
+#include <base/feature_list.cc>
 
 #undef GetStateIfOverridden
 #undef IsFeatureOverridden

--- a/chromium_src/base/feature_list.h
+++ b/chromium_src/base/feature_list.h
@@ -15,7 +15,7 @@
   GetStateIfOverridden_ChromiumImpl(const Feature& feature); \
   static std::optional<bool> GetStateIfOverridden
 
-#include "src/base/feature_list.h"  // IWYU pragma: export
+#include <base/feature_list.h>  // IWYU pragma: export
 
 #undef IsFeatureOverridden
 #undef GetStateIfOverridden

--- a/chromium_src/base/features.cc
+++ b/chromium_src/base/features.cc
@@ -3,9 +3,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-#include <base/features.cc>
-
 #include "base/feature_override.h"
+
+#include <base/features.cc>
 
 namespace base::features {
 

--- a/chromium_src/base/features.cc
+++ b/chromium_src/base/features.cc
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-#include "src/base/features.cc"
+#include <base/features.cc>
 
 #include "base/feature_override.h"
 

--- a/chromium_src/base/logging/rust_log_integration.cc
+++ b/chromium_src/base/logging/rust_log_integration.cc
@@ -8,7 +8,7 @@
 #include "base/logging.h"
 
 #define print_rust_log print_rust_log_chromium_impl
-#include "src/base/logging/rust_log_integration.cc"
+#include <base/logging/rust_log_integration.cc>
 #undef print_rust_log
 
 namespace logging {

--- a/chromium_src/base/metrics/histogram_functions.h
+++ b/chromium_src/base/metrics/histogram_functions.h
@@ -15,7 +15,7 @@
 #define BRAVE_HISTOGRAM_FUNCTIONS_UMA_HISTOGRAM_ENUMERATION \
   if (static_cast<intmax_t>(sample) >= 0)
 
-#include "src/base/metrics/histogram_functions.h"  // IWYU pragma: export
+#include <base/metrics/histogram_functions.h>  // IWYU pragma: export
 
 #undef BRAVE_HISTOGRAM_FUNCTIONS_UMA_HISTOGRAM_ENUMERATION
 

--- a/chromium_src/base/test/launcher/test_launcher.cc
+++ b/chromium_src/base/test/launcher/test_launcher.cc
@@ -10,7 +10,7 @@
 #define TestLauncher TestLauncher_ChromiumImpl
 #define AddTestResult(...) AddTestResult(OnTestResult(__VA_ARGS__));
 
-#include "src/base/test/launcher/test_launcher.cc"
+#include <base/test/launcher/test_launcher.cc>
 
 #undef TestLauncher
 #undef AddTestResult

--- a/chromium_src/base/test/launcher/test_launcher.h
+++ b/chromium_src/base/test/launcher/test_launcher.h
@@ -23,7 +23,7 @@ using TestLauncher_BraveImpl = TestLauncher;
   virtual void OnTestFinished
 #define MaybeSaveSummaryAsJSON virtual MaybeSaveSummaryAsJSON
 
-#include "src/base/test/launcher/test_launcher.h"  // IWYU pragma: export
+#include <base/test/launcher/test_launcher.h>  // IWYU pragma: export
 
 #undef TestLauncher
 #undef OnTestFinished

--- a/chromium_src/base/test/launcher/test_results_tracker.cc
+++ b/chromium_src/base/test/launcher/test_results_tracker.cc
@@ -13,6 +13,6 @@
           testsuite_name.c_str(), result.GetTestName().c_str(), \
           result.output_snippet.c_str());
 
-#include "src/base/test/launcher/test_results_tracker.cc"
+#include <base/test/launcher/test_results_tracker.cc>
 
 #undef TEST_RESULTS_TRACKER_ADD_FAILURE_DETAILS

--- a/chromium_src/base/test/scoped_feature_list.cc
+++ b/chromium_src/base/test/scoped_feature_list.cc
@@ -5,7 +5,7 @@
 
 #include "base/test/scoped_feature_list.h"
 
-#include "src/base/test/scoped_feature_list.cc"
+#include <base/test/scoped_feature_list.cc>
 
 namespace base::test {
 

--- a/chromium_src/base/test/scoped_feature_list.h
+++ b/chromium_src/base/test/scoped_feature_list.h
@@ -11,7 +11,7 @@
                              __VA_ARGS__);                         \
   void InitWithFeatures(__VA_ARGS__)
 
-#include "src/base/test/scoped_feature_list.h"  // IWYU pragma: export
+#include <base/test/scoped_feature_list.h>  // IWYU pragma: export
 
 #undef InitWithFeatures
 

--- a/chromium_src/base/threading/thread_restrictions.h
+++ b/chromium_src/base/threading/thread_restrictions.h
@@ -15,7 +15,7 @@ class ProcessLauncher;
   friend class ::BraveBrowsingDataRemoverDelegate; \
   friend class brave::ProcessLauncher;
 
-#include "src/base/threading/thread_restrictions.h"  // IWYU pragma: export
+#include <base/threading/thread_restrictions.h>  // IWYU pragma: export
 
 #undef BRAVE_SCOPED_ALLOW_BASE_SYNC_PRIMITIVES_H
 

--- a/chromium_src/base/trace_event/builtin_categories.h
+++ b/chromium_src/base/trace_event/builtin_categories.h
@@ -19,7 +19,7 @@
   perfetto::Category("brave"), perfetto::Category("brave.adblock"), \
       perfetto::Category("brave.ads"),
 
-#include "src/base/trace_event/builtin_categories.h"  // IWYU pragma: export
+#include <base/trace_event/builtin_categories.h>  // IWYU pragma: export
 
 #undef BRAVE_INTERNAL_TRACE_LIST_BUILTIN_CATEGORIES
 

--- a/chromium_src/base/trace_event/memory_infra_background_allowlist.cc
+++ b/chromium_src/base/trace_event/memory_infra_background_allowlist.cc
@@ -7,7 +7,7 @@
 
 #define IsMemoryAllocatorDumpNameInAllowlist \
   IsMemoryAllocatorDumpNameInAllowlist_ChromiumImpl
-#include "src/base/trace_event/memory_infra_background_allowlist.cc"
+#include <base/trace_event/memory_infra_background_allowlist.cc>
 #undef IsMemoryAllocatorDumpNameInAllowlist
 
 namespace base::trace_event {

--- a/chromium_src/base/version_info/channel.h
+++ b/chromium_src/base/version_info/channel.h
@@ -10,7 +10,7 @@
 
 #define GetChannelString GetChannelString_ChromiumImpl
 
-#include "src/base/version_info/channel.h"  // IWYU pragma: export
+#include <base/version_info/channel.h>  // IWYU pragma: export
 #undef GetChannelString
 
 namespace version_info {

--- a/chromium_src/tools/clang/pylib/clang/compile_db.py
+++ b/chromium_src/tools/clang/pylib/clang/compile_db.py
@@ -48,8 +48,8 @@ def ProcessCompileDatabase(original_function,
 def _FilterFlags(original_function, command, additional_filtered_flags):
     flags = original_function(command, additional_filtered_flags)
     flags_to_restore = [
-        # Clangd 15+ is required, VSCode extension includes it.
         ' -Xclang -fexperimental-max-bitint-width=256',
+        ' -Xclang -iquote../../brave/chromium_src',
     ]
 
     for flag_to_restore in flags_to_restore:

--- a/tools/chromium_src/check_chromium_src.py
+++ b/tools/chromium_src/check_chromium_src.py
@@ -165,7 +165,7 @@ class ChromiumSrcOverridesChecker:
 
     def do_check_includes(self, override_filepath, original_is_in_gen):
         """
-        Checks if |override_filepath| uses relative includes and also checks
+        Checks if |override_filepath| uses relative includes and also checks <>,
         src/ and ../gen-prefixed includes for naming consistency between the
         original and the override.
         """
@@ -175,7 +175,7 @@ class ChromiumSrcOverridesChecker:
             display_override_filepath = os.path.join('chromium_src',
                                                      override_filepath)
             override_filename = os.path.basename(override_filepath)
-            regexp = r'^#include "src/(.*)"'
+            regexp = r'^#include (?:"src/(.*)"|<(.*\.(?:c|cc|cpp|m|mm))>)'
             gen_regexp = r'^#include "\.\./gen/(.*)"'
             rel_regexp = rf'^#include "(\.\./.*{override_filename})"'
 
@@ -183,23 +183,25 @@ class ChromiumSrcOverridesChecker:
                 # Check src/-prefixed includes
                 line_match = re.search(regexp, line)
                 if line_match:
+                    line_match_path = line_match.group(1) or line_match.group(
+                        2)
                     if original_is_in_gen:
                         self.AddError(
                             f"  {display_override_filepath} overrides a " +
-                            "generated source file, but uses a src/-prefixed " +
-                            "include.\n  A ../gen/-prefixed include should " +
-                            "be used instead.")
-                    elif line_match.group(1) != normalized_override_filepath:
+                            "generated source file, but does not use a " +
+                            "../gen/-prefixed include.\n  A ../gen/-prefixed "
+                            + "include should be used instead.")
+                    elif line_match_path != normalized_override_filepath:
                         # Check for v8 overrides, they can have includes
                         # starting with src.
                         if normalized_override_filepath.startswith("v8/src"):
                             continue
                         self.AddError(
                             f"  {display_override_filepath} uses a " +
-                            "src/-prefixed include that doesn't point to " +
-                            "the expected file:\n" + f"  Include: {line}" +
-                            "  Expected include target: src/" +
-                            f"{normalized_override_filepath}")
+                            "src/-prefixed or <> include that doesn't point " +
+                            "to the expected file:\n" + f"  Include: {line}" +
+                            "  Expected include target: <" +
+                            f"{normalized_override_filepath}>")
                     continue
 
                 # Check ..gen/-prefixed includes

--- a/tools/chromium_src/check_chromium_src.py
+++ b/tools/chromium_src/check_chromium_src.py
@@ -211,8 +211,8 @@ class ChromiumSrcOverridesChecker:
                             f"  {display_override_filepath} uses a " +
                             "src/-prefixed or <> include that doesn't point " +
                             "to the expected file:\n" + f"  Include: {line}" +
-                            "  Expected include target: <" +
-                            f"{normalized_override_filepath}>")
+                            "  Expected include target: src/" +
+                            f"{normalized_override_filepath}")
                     continue
 
                 # Check ..gen/-prefixed includes

--- a/tools/chromium_src/generate_clang_format.py
+++ b/tools/chromium_src/generate_clang_format.py
@@ -42,6 +42,14 @@ def add_chromium_src_include_categories_rule(data):
     # wildcard rule.
     include_categories.insert(wildcard_rule_idx, chromium_src_rule)
 
+    # Put original source file #include last.
+    lowest_rule_priority = max(rule['Priority'] for rule in include_categories)
+    chromium_src_source_rule = {
+        'Regex': r'^<.*\.(c|cc|cpp|m|mm)>',
+        'Priority': lowest_rule_priority + 1,
+    }
+    include_categories.insert(0, chromium_src_source_rule)
+
 
 def load_clang_format(path):
     with open(path, 'r') as file:

--- a/tools/chromium_src/generate_clang_format.py
+++ b/tools/chromium_src/generate_clang_format.py
@@ -42,12 +42,17 @@ def add_chromium_src_include_categories_rule(data):
     # wildcard rule.
     include_categories.insert(wildcard_rule_idx, chromium_src_rule)
 
-    # Put original source file #include last.
+    # Add a new category for original source file #include statements. This
+    # category will put those includes after all other includes by default.
+    # However it still be possible to rearrange them by having a #define or a
+    # comment or anything else before the #include statement.
     lowest_rule_priority = max(rule['Priority'] for rule in include_categories)
     chromium_src_source_rule = {
         'Regex': r'^<.*\.(c|cc|cpp|m|mm)>',
         'Priority': lowest_rule_priority + 1,
     }
+    # The rule is placed at the beginning of the list to match interesting files
+    # first. Otherwise, the wildcard rule will match them.
     include_categories.insert(0, chromium_src_source_rule)
 
 

--- a/tools/redirect_cc/redirect_cc.cc
+++ b/tools/redirect_cc/redirect_cc.cc
@@ -27,7 +27,8 @@
 #include "base/environment.h"
 #endif  // defined(REDIRECT_CC_AS_REWRAPPER)
 
-const base::FilePath::StringViewType kIncludeFlag = FILE_PATH_LITERAL("-I");
+const base::FilePath::StringViewType kIncludeQuotedFlag =
+    FILE_PATH_LITERAL("-iquote");
 const base::FilePath::StringViewType kBraveChromiumSrc =
     FILE_PATH_LITERAL("brave/chromium_src");
 const base::FilePath::StringViewType kGen = FILE_PATH_LITERAL("gen");
@@ -93,9 +94,9 @@ class RedirectCC {
     // Find directories to work with first.
     for (const auto* arg : args_.subspan(first_compiler_arg_idx)) {
       base::FilePath::StringViewType arg_piece(arg);
-      if (arg_piece.starts_with(kIncludeFlag) &&
+      if (arg_piece.starts_with(kIncludeQuotedFlag) &&
           arg_piece.ends_with(kBraveChromiumSrc)) {
-        arg_piece.remove_prefix(kIncludeFlag.size());
+        arg_piece.remove_prefix(kIncludeQuotedFlag.size());
         brave_chromium_src_dir = base::FilePath::StringType(arg_piece);
         arg_piece.remove_suffix(kBraveChromiumSrc.size());
         chromium_src_dir_with_slash = base::FilePath::StringType(arg_piece);


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
### Summary
This change updates how `brave/chromium_src` overrides can reference original files: it adds ability to use `#include <...>` along with `#include "src/..."`. This is enabled by replacing `-I../../brave/chromium_src` with `-iquote../../brave_chromium_src`, which adds an include search path only for `#include "..."` directives.

### Details
With this approach, other files in the build tree can reference `brave/chromium_src` overrides using `#include "..."`, while the overrides themselves can reference original Chromium files using `#include <...>`. Since Chromium uses `#include "..."` for all in-tree files, we can leverage this convention and configure our overrides so that we can drop support for `#include "src/"` later by removing `-I../../..` and making `rbe_exec_root` modification obsolete (the main goal).

Resolves https://github.com/brave/brave-browser/issues/46979

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
