### PR TITLE
upgrade action/labeler to v5

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,41 +1,53 @@
 CI/run-audit-deps:
-- DEPS
-- package.json
-- package-lock.json
-- script/audit_deps.py
-- "**/Cargo.toml"
-- "**/Cargo.lock"
+  - changed-files:
+    - any-glob-to-any-file:
+      - DEPS
+      - package.json
+      - package-lock.json
+      - script/audit_deps.py
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
 
 CI/run-network-audit:
-- browser/net/*
-- chromium_src/net/**/*
-- chromium_src/**/*features.cc
-- patches/chrome-VERSION.patch
+  - changed-files:
+    - any-glob-to-any-file:
+      - browser/net/*
+      - chromium_src/net/**/*
+      - chromium_src/**/*features.cc
+      - patches/chrome-VERSION.patch
 
 CI/run-upstream-tests:
-- browser/about_flags.cc
-- chromium_src/**/*features.cc
+  - changed-files:
+    - any-glob-to-any-file:
+      - browser/about_flags.cc
+      - chromium_src/**/*features.cc
 
 CI/storybook-url:
-- "**/*.ts"
-- "**/*.tsx"
-- "**/*.svelte"
-- "**/*.css"
-- "**/*.scss"
+  - changed-files:
+    - any-glob-to-any-file:
+      - "**/*.ts"
+      - "**/*.tsx"
+      - "**/*.svelte"
+      - "**/*.css"
+      - "**/*.scss"
 
 feature/web3/wallet:
-- android/java/org/chromium/chrome/browser/app/domain/**/*
-- android/java/org/chromium/chrome/browser/crypto_wallet/**/*
-- browser/brave_wallet/android/**/*
-- browser/resources/settings/brave_wallet_page/**/*
-- browser/ui/brave_wallet/**/*
-- browser/ui/webui/brave_wallet/**/*
-- components/brave_wallet/**/*
-- components/brave_wallet_ui/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - android/java/org/chromium/chrome/browser/app/domain/**/*
+      - android/java/org/chromium/chrome/browser/crypto_wallet/**/*
+      - browser/brave_wallet/android/**/*
+      - browser/resources/settings/brave_wallet_page/**/*
+      - browser/ui/brave_wallet/**/*
+      - browser/ui/webui/brave_wallet/**/*
+      - components/brave_wallet/**/*
+      - components/brave_wallet_ui/**/*
 
 feature/web3/wallet/core:
-- browser/brave_wallet/android/**/*
-- browser/resources/settings/brave_wallet_page/**/*
-- browser/ui/brave_wallet/**/*
-- browser/ui/webui/brave_wallet/**/*
-- components/brave_wallet/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - browser/brave_wallet/android/**/*
+      - browser/resources/settings/brave_wallet_page/**/*
+      - browser/ui/brave_wallet/**/*
+      - browser/ui/webui/brave_wallet/**/*
+      - components/brave_wallet/**/*

--- a/.github/workflows/assign-labels.yml
+++ b/.github/workflows/assign-labels.yml
@@ -12,11 +12,8 @@ jobs:
     name: Assign labels
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@ac9175f8a1f3625fd0d4fb234536d26811351594 # v4.3.0
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        # Workaround for https://github.com/actions/labeler/issues/104
-        # Explained at https://github.com/wesnoth/wesnoth/commit/958c82d0867568057caaf58356502ec8c87d8366
-        # Should continue working https://github.com/actions/labeler/pull/113#issuecomment-865404272
-        # The above are not fixed in v4.3.0, which is currently the last v4 before v5
-        sync-labels: ""
+        sync-labels: true


### PR DESCRIPTION
Upgrades gha/labeler to V5. 
Needed to implement more sophisticated PR labeling logic.

docs:
https://github.com/actions/labeler?tab=readme-ov-file#match-object


This is descoped version of this [PR](https://github.com/brave/brave-core/pull/29606) that introduces an only-docs label