### PR TITLE
[Rewards] Handle engine pref access when disconnected on startup

### DIFF
--- a/components/brave_rewards/core/engine/util/rewards_prefs.cc
+++ b/components/brave_rewards/core/engine/util/rewards_prefs.cc
@@ -22,7 +22,7 @@ void RewardsPrefs::SetBoolean(std::string_view path, bool value) {
 }
 
 bool RewardsPrefs::GetBoolean(std::string_view path) {
-  return GetValue(path).GetBool();
+  return GetValue(path).GetIfBool().value_or(false);
 }
 
 void RewardsPrefs::SetInteger(std::string_view path, int value) {
@@ -30,7 +30,7 @@ void RewardsPrefs::SetInteger(std::string_view path, int value) {
 }
 
 int RewardsPrefs::GetInteger(std::string_view path) {
-  return GetValue(path).GetInt();
+  return GetValue(path).GetIfInt().value_or(0);
 }
 
 void RewardsPrefs::SetDouble(std::string_view path, double value) {
@@ -38,7 +38,7 @@ void RewardsPrefs::SetDouble(std::string_view path, double value) {
 }
 
 double RewardsPrefs::GetDouble(std::string_view path) {
-  return GetValue(path).GetDouble();
+  return GetValue(path).GetIfDouble().value_or(0);
 }
 
 void RewardsPrefs::SetString(std::string_view path, std::string_view value) {
@@ -46,7 +46,9 @@ void RewardsPrefs::SetString(std::string_view path, std::string_view value) {
 }
 
 const std::string& RewardsPrefs::GetString(std::string_view path) {
-  return GetValue(path).GetString();
+  static constexpr std::string default_value = "";
+  auto* string_value = GetValue(path).GetIfString();
+  return string_value ? *string_value : default_value;
 }
 
 void RewardsPrefs::Set(std::string_view path, const base::Value& value) {
@@ -69,7 +71,9 @@ void RewardsPrefs::SetDict(std::string_view path, base::Value::Dict dict) {
 }
 
 const base::Value::Dict& RewardsPrefs::GetDict(std::string_view path) {
-  return GetValue(path).GetDict();
+  static const base::Value::Dict default_value;
+  auto* dict = GetValue(path).GetIfDict();
+  return dict ? *dict : default_value;
 }
 
 void RewardsPrefs::SetInt64(std::string_view path, int64_t value) {


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/46948

If the rewards engine client is disconnected during shutdown, a call to retrieve a pref value may fail. With this change, a default value of the correct type will be returned instead of crashing.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
