### PR TITLE
Android infobars are rendered incorrectly with gesture navigation

### DIFF
--- a/android/brave_java_sources.gni
+++ b/android/brave_java_sources.gni
@@ -227,6 +227,7 @@ brave_java_sources = [
   "../../brave/android/java/org/chromium/chrome/browser/homepage/settings/BraveRadioButtonGroupHomepagePreference.java",
   "../../brave/android/java/org/chromium/chrome/browser/homepage/settings/BraveRadioButtonGroupHomepagePreferenceDummySuper.java",
   "../../brave/android/java/org/chromium/chrome/browser/identity_disc/BraveIdentityDiscController.java",
+  "../../brave/android/java/org/chromium/chrome/browser/infobar/BraveInfoBarContainerView.java",
   "../../brave/android/java/org/chromium/chrome/browser/infobar/BraveInfoBarIdentifier.java",
   "../../brave/android/java/org/chromium/chrome/browser/informers/BraveSyncAccountDeletedInformer.java",
   "../../brave/android/java/org/chromium/chrome/browser/language/settings/BraveLanguageSettings.java",

--- a/android/java/apk_for_test.flags
+++ b/android/java/apk_for_test.flags
@@ -993,3 +993,12 @@
 -keep class org.chromium.chrome.browser.tab_group_sync.BraveStartupHelper {
     *** handleUnsavedLocalTabGroups(...);
 }
+
+-keep class org.chromium.chrome.browser.infobar.InfoBarContainerView {
+    <init>(...);
+    *** mEdgeToEdgeSupplier;
+}
+
+-keep class org.chromium.chrome.browser.infobar.BraveInfoBarContainerView {
+    <init>(...);
+}

--- a/android/java/org/chromium/chrome/browser/infobar/BraveInfoBarContainerView.java
+++ b/android/java/org/chromium/chrome/browser/infobar/BraveInfoBarContainerView.java
@@ -1,0 +1,74 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.chromium.chrome.browser.infobar;
+
+import android.content.Context;
+import android.view.View;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import org.chromium.base.supplier.ObservableSupplier;
+import org.chromium.chrome.browser.browser_controls.BrowserControlsStateProvider;
+import org.chromium.chrome.browser.ui.edge_to_edge.EdgeToEdgeController;
+import org.chromium.components.infobars.InfoBar;
+import org.chromium.components.infobars.InfoBarLayout;
+import org.chromium.components.infobars.R;
+
+public class BraveInfoBarContainerView extends InfoBarContainerView {
+    // To be deleted in bytecode and super field to be used
+    @Nullable private ObservableSupplier<EdgeToEdgeController> mEdgeToEdgeSupplier;
+
+    BraveInfoBarContainerView(
+            @NonNull Context context,
+            @NonNull ContainerViewObserver containerViewObserver,
+            @Nullable BrowserControlsStateProvider browserControlsStateProvider,
+            @Nullable ObservableSupplier<EdgeToEdgeController> edgeToEdgeSupplier,
+            boolean isTablet) {
+        super(
+                context,
+                containerViewObserver,
+                browserControlsStateProvider,
+                edgeToEdgeSupplier,
+                isTablet);
+    }
+
+    @Override
+    void addInfoBar(InfoBar infoBar) {
+        super.addInfoBar(infoBar);
+
+        int infoBarIdentifier = (int) infoBar.getInfoBarIdentifier();
+        if (infoBarIdentifier != BraveInfoBarIdentifier.NEW_TAB_TAKEOVER_INFOBAR_DELEGATE
+                && infoBarIdentifier
+                        != BraveInfoBarIdentifier.SEARCH_RESULT_AD_CLICKED_INFOBAR_DELEGATE) {
+            return;
+        }
+        boolean drawEdgeToEdge =
+                mEdgeToEdgeSupplier != null
+                        && mEdgeToEdgeSupplier.get() != null
+                        && mEdgeToEdgeSupplier.get().isDrawingToEdge();
+        View infoBarView = infoBar.getView();
+        if (!drawEdgeToEdge || !(infoBarView instanceof InfoBarLayout)) {
+            return;
+        }
+
+        InfoBarLayout layout = (InfoBarLayout) infoBarView;
+        TextView messageTexView = layout.getMessageTextView();
+        // Adding extra padding at the bottom when edge to edge
+        // is active.
+        // See https://github.com/brave/brave-browser/issues/46513
+        // for more info.
+        messageTexView.setPadding(
+                messageTexView.getPaddingLeft(),
+                messageTexView.getPaddingTop(),
+                messageTexView.getPaddingRight(),
+                messageTexView.getPaddingBottom()
+                        + messageTexView
+                                .getResources()
+                                .getDimensionPixelOffset(R.dimen.infobar_padding));
+    }
+}

--- a/android/java/org/chromium/chrome/browser/infobar/BraveInfoBarIdentifier.java
+++ b/android/java/org/chromium/chrome/browser/infobar/BraveInfoBarIdentifier.java
@@ -18,6 +18,7 @@ import java.lang.annotation.RetentionPolicy;
     BraveInfoBarIdentifier.SYNC_CANNOT_RUN_INFOBAR,
     BraveInfoBarIdentifier.WEB_DISCOVERY_INFOBAR_DELEGATE,
     BraveInfoBarIdentifier.BRAVE_SYNC_ACCOUNT_DELETED_INFOBAR,
+    BraveInfoBarIdentifier.SEARCH_RESULT_AD_CLICKED_INFOBAR_DELEGATE,
     BraveInfoBarIdentifier.NEW_TAB_TAKEOVER_INFOBAR_DELEGATE
 })
 @Retention(RetentionPolicy.SOURCE)
@@ -30,5 +31,6 @@ public @interface BraveInfoBarIdentifier {
     int SYNC_CANNOT_RUN_INFOBAR = 505;
     int WEB_DISCOVERY_INFOBAR_DELEGATE = 506;
     int BRAVE_SYNC_ACCOUNT_DELETED_INFOBAR = 507;
+    int SEARCH_RESULT_AD_CLICKED_INFOBAR_DELEGATE = 510;
     int NEW_TAB_TAKEOVER_INFOBAR_DELEGATE = 511;
 }

--- a/android/javatests/org/chromium/chrome/browser/BytecodeTest.java
+++ b/android/javatests/org/chromium/chrome/browser/BytecodeTest.java
@@ -80,6 +80,7 @@ import org.chromium.chrome.browser.fullscreen.BrowserControlsManager;
 import org.chromium.chrome.browser.fullscreen.FullscreenManager;
 import org.chromium.chrome.browser.homepage.settings.BraveRadioButtonGroupHomepagePreference;
 import org.chromium.chrome.browser.hub.ResourceButtonData;
+import org.chromium.chrome.browser.infobar.InfoBarContainerView;
 import org.chromium.chrome.browser.keyboard_accessory.ManualFillingComponentSupplier;
 import org.chromium.chrome.browser.layouts.LayoutManager;
 import org.chromium.chrome.browser.lifecycle.ActivityLifecycleDispatcher;
@@ -1942,6 +1943,15 @@ public class BytecodeTest {
                         ObservableSupplier.class,
                         boolean.class,
                         MultiWindowModeStateDispatcher.class));
+        Assert.assertTrue(
+                constructorsMatch(
+                        "org/chromium/chrome/browser/infobar/InfoBarContainerView",
+                        "org/chromium/chrome/browser/infobar/BraveInfoBarContainerView",
+                        Context.class,
+                        InfoBarContainerView.ContainerViewObserver.class,
+                        BrowserControlsStateProvider.class,
+                        ObservableSupplier.class,
+                        boolean.class));
     }
 
     @Test
@@ -2365,6 +2375,10 @@ public class BytecodeTest {
                 fieldExists(
                         "org/chromium/chrome/browser/contextmenu/ChromeContextMenuPopulator",
                         "mParams"));
+        Assert.assertTrue(
+                fieldExists(
+                        "org/chromium/chrome/browser/infobar/InfoBarContainerView",
+                        "mEdgeToEdgeSupplier"));
     }
 
     @Test

--- a/build/android/bytecode/BUILD.gn
+++ b/build/android/bytecode/BUILD.gn
@@ -62,6 +62,7 @@ java_binary("java_bytecode_rewriter") {
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveHubManagerImplClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveIdentityDiscControllerClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveIncognitoTabSwitcherPaneClassAdapter.java",
+    "//brave/build/android/bytecode/java/org/brave/bytecode/BraveInfoBarContainerViewClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveIntentHandlerClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveLaunchIntentDispatcherClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveLauncherActivityClassAdapter.java",

--- a/build/android/bytecode/java/org/brave/bytecode/BraveClassAdapter.java
+++ b/build/android/bytecode/java/org/brave/bytecode/BraveClassAdapter.java
@@ -59,6 +59,7 @@ public class BraveClassAdapter {
         chain = new BraveHubManagerImplClassAdapter(chain);
         chain = new BraveIdentityDiscControllerClassAdapter(chain);
         chain = new BraveIncognitoTabSwitcherPaneClassAdapter(chain);
+        chain = new BraveInfoBarContainerViewClassAdapter(chain);
         chain = new BraveIntentHandlerClassAdapter(chain);
         chain = new BraveLauncherActivityClassAdapter(chain);
         chain = new BraveLaunchIntentDispatcherClassAdapter(chain);

--- a/build/android/bytecode/java/org/brave/bytecode/BraveInfoBarContainerViewClassAdapter.java
+++ b/build/android/bytecode/java/org/brave/bytecode/BraveInfoBarContainerViewClassAdapter.java
@@ -1,0 +1,24 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.brave.bytecode;
+
+import org.objectweb.asm.ClassVisitor;
+
+public class BraveInfoBarContainerViewClassAdapter extends BraveClassVisitor {
+    static String sInfoBarContainerViewClassName =
+            "org/chromium/chrome/browser/infobar/InfoBarContainerView";
+
+    static String sBraveInfoBarContainerViewClassName =
+            "org/chromium/chrome/browser/infobar/BraveInfoBarContainerView";
+
+    public BraveInfoBarContainerViewClassAdapter(ClassVisitor visitor) {
+        super(visitor);
+
+        deleteField(sBraveInfoBarContainerViewClassName, "mEdgeToEdgeSupplier");
+        makeProtectedField(sInfoBarContainerViewClassName, "mEdgeToEdgeSupplier");
+        redirectConstructor(sInfoBarContainerViewClassName, sBraveInfoBarContainerViewClassName);
+    }
+}

--- a/chromium_presubmit_config.json5
+++ b/chromium_presubmit_config.json5
@@ -185,6 +185,7 @@
       "android/java/org/chromium/chrome/browser/customtabs/FullScreenCustomTabActivity.java",
       "android/java/org/chromium/chrome/browser/customtabs/FullScreenCustomTabRootUiCoordinator.java",
       "android/java/org/chromium/chrome/browser/firstrun/WelcomeOnboardingActivity.java",
+      "android/java/org/chromium/chrome/browser/infobar/BraveInfoBarContainerView.java",
       "android/java/org/chromium/chrome/browser/settings/AppearancePreferences.java",
       "android/java/org/chromium/chrome/browser/settings/BraveNewsPreferencesDetails.java",
       "android/java/org/chromium/chrome/browser/settings/BraveNewsPreferencesV2.java",

--- a/patches/chrome-android-java-src-org-chromium-chrome-browser-infobar-InfoBarContainerView.java.patch
+++ b/patches/chrome-android-java-src-org-chromium-chrome-browser-infobar-InfoBarContainerView.java.patch
@@ -1,0 +1,20 @@
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/infobar/InfoBarContainerView.java b/chrome/android/java/src/org/chromium/chrome/browser/infobar/InfoBarContainerView.java
+index 169e9e64cc462f6b2b53c3558978adc7f6e4a3ea..5fa1d99cfc5d22c286856585dd1a13017983f108 100644
+--- a/chrome/android/java/src/org/chromium/chrome/browser/infobar/InfoBarContainerView.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/infobar/InfoBarContainerView.java
+@@ -83,6 +83,7 @@ public class InfoBarContainerView extends SwipableOverlayView
+      * @param isTablet Whether this view is displayed on tablet or not.
+      * @deprecated Please use the constructor with the EdgeToEdgeSupplier.
+      */
++    /*
+     @Deprecated
+     InfoBarContainerView(
+             @NonNull Context context,
+@@ -91,6 +92,7 @@ public class InfoBarContainerView extends SwipableOverlayView
+             boolean isTablet) {
+         this(context, containerViewObserver, browserControlsStateProvider, null, isTablet);
+     }
++     */
+ 
+     /**
+      * @param context The {@link Context} that this view is attached to.


### PR DESCRIPTION
Ads info bar cut at the bottom when gesture navigation is enabled on device. Adds extra padding in such cases.
Resolves: https://github.com/brave/brave-browser/issues/46513

Test plan:

1. Enable gesture navigation on device.
2. Make sure the info bar isn't cut at the bottom.

![Screenshot_20250619-134618](https://github.com/user-attachments/assets/7cc82159-c649-4189-b6db-ffdc24ff98a5)

![Screenshot_20250620-125717](https://github.com/user-attachments/assets/e498bcbd-0740-4cd6-863a-5ce5a1611b23)
