### PR TITLE
feat(wallet): Address Actions Menu

### DIFF
--- a/components/brave_wallet_ui/components/desktop/asset-group-container/asset-group-container.style.ts
+++ b/components/brave_wallet_ui/components/desktop/asset-group-container/asset-group-container.style.ts
@@ -15,29 +15,25 @@ export const StyledWrapper = styled(Column)<{ isCollapsed: boolean }>`
       p.isCollapsed ? leo.color.container.highlight : leo.color.divider.subtle};
   border-radius: 12px;
   margin-bottom: 16px;
-  overflow: ${(p) => (p.isCollapsed ? 'hidden' : 'visible')};
   &:last-child {
     margin-bottom: 0px;
   }
 `
 
-export const CollapseButton = styled(WalletButton)`
+export const CollapsedWrapper = styled.div<{
+  isCollapsed?: boolean
+}>`
   display: flex;
   align-items: center;
   justify-content: space-between;
   flex-direction: row;
-  cursor: pointer;
   outline: none;
   background: none;
   border: none;
-  padding: 12px;
   margin: 0px;
   width: 100%;
-  border-radius: 11px 11px 0px 0px;
+  border-radius: ${(p) => (p.isCollapsed ? '11px' : '11px 11px 0px 0px')};
   background-color: ${leo.color.container.highlight};
-  :disabled {
-    cursor: default;
-  }
 `
 
 export const CollapseIcon = styled(Icon)<{
@@ -53,6 +49,7 @@ export const CollapseIcon = styled(Icon)<{
 `
 
 export const AccountDescriptionWrapper = styled(Row)`
+  height: 100%;
   align-items: center;
   justify-content: flex-start;
   @media screen and (max-width: ${layoutPanelWidth}px) {
@@ -93,4 +90,63 @@ export const WarningIcon = styled(Icon).attrs({
 })`
   --leo-icon-size: 20px;
   color: ${leo.color.systemfeedback.warningIcon};
+`
+
+export const ClickArea = styled(WalletButton)`
+  flex: 1;
+  cursor: pointer;
+  display: flex;
+  flex-direction: row;
+  background: none;
+  border: none;
+  margin: 0;
+  padding: 0;
+  :disabled {
+    cursor: default;
+  }
+`
+
+export const AccountIconClickArea = styled(ClickArea)`
+  height: 100%;
+  padding: 12px 0px 12px 12px;
+`
+
+export const AccountNameClickArea = styled(ClickArea)<{
+  hasAddress?: boolean
+}>`
+  height: 100%;
+  align-items: center;
+  @media screen and (max-width: ${layoutPanelWidth}px) {
+    align-items: ${(p) => (p.hasAddress ? 'flex-end' : 'center')};
+    height: unset;
+  }
+`
+
+export const BalanceClickArea = styled(ClickArea)`
+  height: 100%;
+  padding-right: 12px;
+  justify-content: flex-end;
+`
+
+export const AddressArea = styled(Row)`
+  height: 100%;
+  justify-content: flex-start;
+  @media screen and (max-width: ${layoutPanelWidth}px) {
+    flex: 1;
+    align-items: flex-start;
+    height: unset;
+    width: 100%;
+  }
+`
+
+export const EmptyClickArea = styled(ClickArea)`
+  display: none;
+  @media screen and (max-width: ${layoutPanelWidth}px) {
+    display: flex;
+    height: 100%;
+  }
+`
+
+export const NetworkAndExternalProviderClickArea = styled(ClickArea)`
+  padding: 12px 0px 12px 12px;
 `

--- a/components/brave_wallet_ui/components/desktop/asset-group-container/asset-group-container.tsx
+++ b/components/brave_wallet_ui/components/desktop/asset-group-container/asset-group-container.tsx
@@ -56,11 +56,14 @@ import {
 import {
   ZCashSyncModal, //
 } from '../popup-modals/zcash_sync_modal/zcash_sync_modal'
+import {
+  AddressActionsMenu, //
+} from '../wallet-menus/address_actions_menu'
 
 // Styled Components
 import {
   StyledWrapper,
-  CollapseButton,
+  CollapsedWrapper,
   CollapseIcon,
   AccountDescriptionWrapper,
   RewardsProviderContainer,
@@ -68,6 +71,12 @@ import {
   InfoBar,
   InfoText,
   WarningIcon,
+  BalanceClickArea,
+  AccountIconClickArea,
+  AccountNameClickArea,
+  AddressArea,
+  NetworkAndExternalProviderClickArea,
+  EmptyClickArea,
 } from './asset-group-container.style'
 import {
   Row,
@@ -228,12 +237,12 @@ export const AssetGroupContainer = (props: Props) => {
       fullWidth={true}
       isCollapsed={isSkeleton || isCollapsed}
     >
-      <CollapseButton
-        onClick={onToggleCollapsed}
-        disabled={isDisabled}
-      >
+      <CollapsedWrapper isCollapsed={isSkeleton || isCollapsed}>
         {isSkeleton && (
-          <Row width='unset'>
+          <Row
+            width='unset'
+            padding='12px'
+          >
             <LoadingSkeleton
               width={24}
               height={24}
@@ -247,111 +256,150 @@ export const AssetGroupContainer = (props: Props) => {
           </Row>
         )}
         {externalProvider && !isSkeleton && (
-          <Row width='unset'>
-            {network && (
+          <NetworkAndExternalProviderClickArea
+            onClick={onToggleCollapsed}
+            disabled={isDisabled}
+          >
+            <Row width='unset'>
+              {network && (
+                <CreateNetworkIcon
+                  network={network}
+                  marginRight={16}
+                  size='huge'
+                />
+              )}
+              {account && (
+                <CreateAccountIcon
+                  size='medium'
+                  externalProvider={externalProvider}
+                  marginRight={16}
+                />
+              )}
+              <RewardsProviderContainer>
+                <RewardsText
+                  textSize='14px'
+                  isBold={true}
+                  textColor='primary'
+                  textAlign='left'
+                >
+                  {externalRewardsDescription}
+                </RewardsText>
+                <BraveRewardsIndicator>
+                  {getLocale('braveWalletBraveRewardsTitle')}
+                </BraveRewardsIndicator>
+              </RewardsProviderContainer>
+            </Row>
+          </NetworkAndExternalProviderClickArea>
+        )}
+
+        {network && !externalProvider && !isSkeleton && (
+          <NetworkAndExternalProviderClickArea
+            onClick={onToggleCollapsed}
+            disabled={isDisabled}
+          >
+            <Row width='unset'>
               <CreateNetworkIcon
                 network={network}
                 marginRight={16}
                 size='huge'
               />
-            )}
-            {account && (
-              <CreateAccountIcon
-                size='medium'
-                externalProvider={externalProvider}
-                marginRight={16}
-              />
-            )}
-            <RewardsProviderContainer>
-              <RewardsText
+              <Text
                 textSize='14px'
                 isBold={true}
                 textColor='primary'
                 textAlign='left'
               >
-                {externalRewardsDescription}
-              </RewardsText>
-              <BraveRewardsIndicator>
-                {getLocale('braveWalletBraveRewardsTitle')}
-              </BraveRewardsIndicator>
-            </RewardsProviderContainer>
-          </Row>
-        )}
-
-        {network && !externalProvider && !isSkeleton && (
-          <Row width='unset'>
-            <CreateNetworkIcon
-              network={network}
-              marginRight={16}
-              size='huge'
-            />
-            <Text
-              textSize='14px'
-              isBold={true}
-              textColor='primary'
-              textAlign='left'
-            >
-              {network.chainName}
-            </Text>
-          </Row>
+                {network.chainName}
+              </Text>
+            </Row>
+          </NetworkAndExternalProviderClickArea>
         )}
 
         {account && !externalProvider && !isSkeleton && (
-          <Row width='unset'>
-            <CreateAccountIcon
-              size='medium'
-              account={account}
-              marginRight={16}
-            />
+          <Row
+            width='unset'
+            height='100%'
+          >
+            <AccountIconClickArea
+              onClick={onToggleCollapsed}
+              disabled={isDisabled}
+            >
+              <CreateAccountIcon
+                size='medium'
+                account={account}
+                marginRight={16}
+              />
+            </AccountIconClickArea>
             <AccountDescriptionWrapper width='unset'>
-              <Text
-                textSize='14px'
-                isBold={true}
-                textColor='primary'
-                textAlign='left'
+              <AccountNameClickArea
+                onClick={onToggleCollapsed}
+                disabled={isDisabled}
+                hasAddress={account.address !== ''}
               >
-                {account.name}
-              </Text>
-              <HorizontalSpace space='8px' />
-              <Text
-                textSize='12px'
-                isBold={false}
-                textColor='secondary'
-              >
-                {reduceAddress(account.address)}
-              </Text>
+                <Text
+                  textSize='14px'
+                  isBold={true}
+                  textColor='primary'
+                  textAlign='left'
+                >
+                  {account.name}
+                </Text>
+                <HorizontalSpace space='8px' />
+              </AccountNameClickArea>
+              {account.address !== '' && (
+                <AddressArea width='unset'>
+                  <AddressActionsMenu account={account}>
+                    <Text
+                      textSize='12px'
+                      isBold={false}
+                      textColor='secondary'
+                    >
+                      {reduceAddress(account.address)}
+                    </Text>
+                  </AddressActionsMenu>
+                  <EmptyClickArea
+                    onClick={onToggleCollapsed}
+                    disabled={isDisabled}
+                  />
+                </AddressArea>
+              )}
             </AccountDescriptionWrapper>
           </Row>
         )}
 
-        <Row width='unset'>
-          {balance !== '' && !hideBalance ? (
-            <Text
-              textSize='14px'
-              isBold={true}
-              textColor='primary'
-            >
-              {hidePortfolioBalances ? '******' : balance}
-            </Text>
-          ) : (
-            <>
-              {!hideBalance && (
-                <LoadingSkeleton
-                  width={60}
-                  height={14}
-                />
-              )}
-            </>
-          )}
+        <BalanceClickArea
+          onClick={onToggleCollapsed}
+          disabled={isDisabled}
+        >
+          <Row width='unset'>
+            {balance !== '' && !hideBalance ? (
+              <Text
+                textSize='14px'
+                isBold={true}
+                textColor='primary'
+              >
+                {hidePortfolioBalances ? '******' : balance}
+              </Text>
+            ) : (
+              <>
+                {!hideBalance && (
+                  <LoadingSkeleton
+                    width={60}
+                    height={14}
+                  />
+                )}
+              </>
+            )}
 
-          {!isDisabled && (
-            <CollapseIcon
-              isCollapsed={isCollapsed}
-              name='carat-down'
-            />
-          )}
-        </Row>
-      </CollapseButton>
+            {!isDisabled && (
+              <CollapseIcon
+                isCollapsed={isCollapsed}
+                name='carat-down'
+              />
+            )}
+          </Row>
+        </BalanceClickArea>
+      </CollapsedWrapper>
 
       {!isCollapsed && !isDisabled && (
         <Column fullWidth={true}>

--- a/components/brave_wallet_ui/components/desktop/popup-modals/view_on_block_explorer_modal/view_on_block_explorer_modal.tsx
+++ b/components/brave_wallet_ui/components/desktop/popup-modals/view_on_block_explorer_modal/view_on_block_explorer_modal.tsx
@@ -38,81 +38,84 @@ interface Props {
   onClose: () => void
 }
 
-export const ViewOnBlockExplorerModal = (props: Props) => {
-  const { account, onClose } = props
+export const ViewOnBlockExplorerModal = React.forwardRef<HTMLDivElement, Props>(
+  (props: Props, forwardedRef) => {
+    const { account, onClose } = props
 
-  // Queries
-  const { data: visibleNetworks = [] } = useGetVisibleNetworksQuery()
+    // Queries
+    const { data: visibleNetworks = [] } = useGetVisibleNetworksQuery()
 
-  // Memos
-  const networksByAccountCoinType = React.useMemo(() => {
-    return visibleNetworks.filter(
-      (network) => network.coin === account.accountId.coin,
-    )
-  }, [visibleNetworks, account])
+    // Memos
+    const networksByAccountCoinType = React.useMemo(() => {
+      return visibleNetworks.filter(
+        (network) => network.coin === account.accountId.coin,
+      )
+    }, [visibleNetworks, account])
 
-  return (
-    <PopupModal
-      title={getLocale('braveWalletTransactionExplorer')}
-      onClose={onClose}
-      width='520px'
-    >
-      <StyledWrapper
-        fullWidth={true}
-        fullHeight={true}
-        alignItems='flex-start'
-        justifyContent='flex-start'
-        padding='0px 16px 16px 16px'
+    return (
+      <PopupModal
+        title={getLocale('braveWalletTransactionExplorer')}
+        onClose={onClose}
+        width='520px'
+        ref={forwardedRef}
       >
-        <AccountInfoRow
+        <StyledWrapper
+          fullWidth={true}
+          fullHeight={true}
+          alignItems='flex-start'
           justifyContent='flex-start'
-          marginBottom={16}
+          padding='0px 16px 16px 16px'
         >
-          <CreateAccountIcon
-            account={account}
-            size='huge'
-            marginRight={16}
-          />
-          <Column alignItems='flex-start'>
+          <AccountInfoRow
+            justifyContent='flex-start'
+            marginBottom={16}
+          >
+            <CreateAccountIcon
+              account={account}
+              size='huge'
+              marginRight={16}
+            />
+            <Column alignItems='flex-start'>
+              <Text
+                isBold={true}
+                textColor='primary'
+                textSize='14px'
+              >
+                {account.name}
+              </Text>
+              <AddressText
+                isBold={false}
+                textColor='secondary'
+                textSize='12px'
+                textAlign='left'
+              >
+                {account.address}
+              </AddressText>
+            </Column>
+          </AccountInfoRow>
+          <Row
+            padding='16px'
+            justifyContent='flex-start'
+          >
             <Text
               isBold={true}
               textColor='primary'
               textSize='14px'
             >
-              {account.name}
+              {getLocale('braveWalletViewAddressOn')}
             </Text>
-            <AddressText
-              isBold={false}
-              textColor='secondary'
-              textSize='12px'
-              textAlign='left'
-            >
-              {account.address}
-            </AddressText>
-          </Column>
-        </AccountInfoRow>
-        <Row
-          padding='16px'
-          justifyContent='flex-start'
-        >
-          <Text
-            isBold={true}
-            textColor='primary'
-            textSize='14px'
-          >
-            {getLocale('braveWalletViewAddressOn')}
-          </Text>
-        </Row>
-        <ScrollableColumn>
-          {networksByAccountCoinType.map((network) => (
-            <NetworkButton
-              key={getNetworkId(network)}
-              network={network}
-              address={account.accountId.address}
-            />
-          ))}
-        </ScrollableColumn>
-      </StyledWrapper>
-    </PopupModal>
-  )
-}
+          </Row>
+          <ScrollableColumn>
+            {networksByAccountCoinType.map((network) => (
+              <NetworkButton
+                key={getNetworkId(network)}
+                network={network}
+                address={account.accountId.address}
+              />
+            ))}
+          </ScrollableColumn>
+        </StyledWrapper>
+      </PopupModal>
+    )
+  },
+)

--- a/components/brave_wallet_ui/components/desktop/wallet-menus/address_actions_menu.style.ts
+++ b/components/brave_wallet_ui/components/desktop/wallet-menus/address_actions_menu.style.ts
@@ -1,0 +1,32 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import styled from 'styled-components'
+
+// Shared Styles
+import {
+  layoutPanelWidth, //
+} from '../wallet-page-wrapper/wallet-page-wrapper.style'
+
+export const MenuWrapper = styled.div`
+  flex: 1;
+  position: relative;
+  display: flex;
+  height: 100%;
+`
+
+export const Button = styled.button`
+  flex: 1;
+  display: flex;
+  border: none;
+  background: none;
+  cursor: pointer;
+  padding: 0;
+  margin: 0;
+  align-items: center;
+  @media screen and (max-width: ${layoutPanelWidth}px) {
+    align-items: flex-start;
+  }
+`

--- a/components/brave_wallet_ui/components/desktop/wallet-menus/address_actions_menu.tsx
+++ b/components/brave_wallet_ui/components/desktop/wallet-menus/address_actions_menu.tsx
@@ -1,0 +1,159 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import * as React from 'react'
+import { showAlert } from '@brave/leo/react/alertCenter'
+
+// Types
+import { BraveWallet } from '../../../constants/types'
+
+// Utils
+import { getLocale } from '../../../../common/locale'
+import { copyToClipboard } from '../../../utils/copy-to-clipboard'
+
+// Selectors
+import {
+  useSafeUISelector, //
+} from '../../../common/hooks/use-safe-selector'
+import { UISelectors } from '../../../common/selectors'
+
+// Hooks
+import {
+  useOnClickOutside, //
+} from '../../../common/hooks/useOnClickOutside'
+
+// Components
+import {
+  DepositModal, //
+} from '../popup-modals/account-settings-modal/account-settings-modal'
+import {
+  ViewOnBlockExplorerModal, //
+} from '../popup-modals/view_on_block_explorer_modal/view_on_block_explorer_modal'
+import { PopupModal } from '../popup-modals'
+
+// Styled Components
+import {
+  StyledWrapper,
+  PopupButton,
+  PopupButtonText,
+  ButtonIcon,
+} from './wellet-menus.style'
+import { MenuWrapper, Button } from './address_actions_menu.style'
+import { VerticalDivider, Column } from '../../shared/style'
+
+export interface Props {
+  account: BraveWallet.AccountInfo
+  children?: React.ReactNode
+}
+
+export const AddressActionsMenu = (props: Props) => {
+  const { account, children } = props
+
+  const isPanel = useSafeUISelector(UISelectors.isPanel)
+  const isAndroid = useSafeUISelector(UISelectors.isAndroid)
+
+  // State
+  const [showMenu, setShowMenu] = React.useState(false)
+  const [showDepositModal, setShowDepositModal] = React.useState(false)
+  const [showViewOnExplorerModal, setShowViewOnExplorerModal] =
+    React.useState(false)
+
+  // Refs
+  const menuRef = React.useRef<HTMLDivElement>(null)
+  const depositModalRef = React.useRef<HTMLDivElement>(null)
+  const viewOnExplorerModalRef = React.useRef<HTMLDivElement>(null)
+
+  // Hooks
+  useOnClickOutside(menuRef, () => setShowMenu(false), showMenu)
+  useOnClickOutside(
+    depositModalRef,
+    () => setShowDepositModal(false),
+    showDepositModal,
+  )
+  useOnClickOutside(
+    viewOnExplorerModalRef,
+    () => setShowViewOnExplorerModal(false),
+    showViewOnExplorerModal,
+  )
+
+  const handleCopyAddress = () => {
+    setShowMenu(false)
+    copyToClipboard(account.address)
+    showAlert({
+      type: 'success',
+      content: getLocale('braveWalletButtonCopied'),
+      actions: [],
+    })
+  }
+
+  return (
+    <>
+      <MenuWrapper ref={menuRef}>
+        <Button onClick={() => setShowMenu((prev) => !prev)}>{children}</Button>
+        {showMenu && (
+          <StyledWrapper
+            yPosition={isPanel || isAndroid ? 26 : 46}
+            left={0}
+          >
+            <PopupButton onClick={handleCopyAddress}>
+              <ButtonIcon name='copy' />
+              <PopupButtonText>
+                {getLocale('braveWalletButtonCopy')}
+              </PopupButtonText>
+            </PopupButton>
+            <PopupButton
+              onClick={() => {
+                setShowDepositModal(true)
+                setShowMenu(false)
+              }}
+            >
+              <ButtonIcon name='qr-code-alternative' />
+              <PopupButtonText>
+                {getLocale('braveWalletDepositCryptoButton')}
+              </PopupButtonText>
+            </PopupButton>
+            <PopupButton
+              onClick={() => {
+                setShowViewOnExplorerModal(true)
+                setShowMenu(false)
+              }}
+            >
+              <ButtonIcon name='web3-blockexplorer' />
+              <PopupButtonText>
+                {getLocale('braveWalletPortfolioViewOnExplorerMenuLabel')}
+              </PopupButtonText>
+            </PopupButton>
+          </StyledWrapper>
+        )}
+      </MenuWrapper>
+      {showDepositModal && (
+        <PopupModal
+          title={getLocale('braveWalletDepositCryptoButton')}
+          onClose={() => setShowDepositModal(false)}
+          ref={depositModalRef}
+        >
+          <VerticalDivider />
+          <Column
+            fullHeight={true}
+            fullWidth={true}
+            justifyContent='flex-start'
+            padding='20px 15px'
+          >
+            <DepositModal selectedAccount={account} />
+          </Column>
+        </PopupModal>
+      )}
+      {showViewOnExplorerModal && (
+        <ViewOnBlockExplorerModal
+          account={account}
+          onClose={() => setShowViewOnExplorerModal(false)}
+          ref={viewOnExplorerModalRef}
+        />
+      )}
+    </>
+  )
+}
+
+export default AddressActionsMenu

--- a/components/brave_wallet_ui/components/desktop/wallet-menus/wellet-menus.style.ts
+++ b/components/brave_wallet_ui/components/desktop/wallet-menus/wellet-menus.style.ts
@@ -20,6 +20,7 @@ import {
 export const StyledWrapper = styled.div<{
   yPosition?: number
   right?: number
+  left?: number
   padding?: string
 }>`
   display: flex;
@@ -33,7 +34,24 @@ export const StyledWrapper = styled.div<{
   box-shadow: 0px 1px 4px rgba(0, 0, 0, 0.25);
   position: absolute;
   top: ${(p) => (p.yPosition !== undefined ? p.yPosition : 35)}px;
-  right: ${(p) => (p.right !== undefined ? p.right : 0)}px;
+  right: ${(p) => {
+    if (p.left !== undefined) {
+      return 'unset'
+    }
+    if (p.right !== undefined) {
+      return `${p.right}px`
+    }
+    return '0px'
+  }};
+  left: ${(p) => {
+    if (p.right !== undefined) {
+      return 'unset'
+    }
+    if (p.left !== undefined) {
+      return `${p.left}px`
+    }
+    return 'unset'
+  }};
   z-index: 20;
 `
 

--- a/components/brave_wallet_ui/page/container.tsx
+++ b/components/brave_wallet_ui/page/container.tsx
@@ -41,6 +41,7 @@ import 'emptykit.css'
 import {
   FullScreenWrapper,
   SimplePageWrapper,
+  AlertCenter,
 } from './screens/page-screen.styles'
 
 // components
@@ -172,6 +173,7 @@ export const Container = () => {
 
   return (
     <>
+      <AlertCenter position='top-center' />
       <Switch>
         <ProtectedRoute
           path={WalletRoutes.Onboarding}

--- a/components/brave_wallet_ui/page/screens/page-screen.styles.ts
+++ b/components/brave_wallet_ui/page/screens/page-screen.styles.ts
@@ -5,6 +5,11 @@
 
 import styled from 'styled-components'
 import * as leo from '@brave/leo/tokens/css/variables'
+import LeoAlertCenter from '@brave/leo/react/alertCenter'
+
+export const AlertCenter = styled(LeoAlertCenter)`
+  --leo-alert-center-width: 200px;
+`
 
 export const SimplePageWrapper = styled.div`
   display: flex;

--- a/components/brave_wallet_ui/stories/wallet-concept.tsx
+++ b/components/brave_wallet_ui/stories/wallet-concept.tsx
@@ -7,6 +7,11 @@ import * as React from 'react'
 import './locale'
 import WalletPageStory from './wrappers/wallet-page-story-wrapper'
 import Container from '../page/container'
+import {
+  mockAccount,
+  mockNativeBalanceRegistry,
+  mockTokenBalanceRegistry,
+} from '../common/constants/mocks'
 
 type StorybookWalletConceptArgs = {
   isPanel: boolean
@@ -53,6 +58,11 @@ export const _DesktopWalletConcept = {
         }}
         uiStateOverride={{
           isPanel: isPanel,
+        }}
+        apiOverrides={{
+          selectedAccountId: mockAccount.accountId,
+          nativeBalanceRegistry: mockNativeBalanceRegistry,
+          tokenBalanceRegistry: mockTokenBalanceRegistry,
         }}
       >
         <Container />

--- a/ui/webui/resources/BUILD.gn
+++ b/ui/webui/resources/BUILD.gn
@@ -355,6 +355,7 @@ leo_icons = [
   "protocol-handler-off.svg",
   "protocol-handler.svg",
   "qr-code.svg",
+  "qr-code-alternative.svg",
   "qwant-color.svg",
   "radio-checked.svg",
   "radio-unchecked.svg",


### PR DESCRIPTION
## Description 

Introduces a new `Address Actions` menu, to be used throughout the `Wallet` everywhere we display an address.
Rolling out on the `Portfolio` screen first and will follow up by adding everywhere else in the `Wallet`

Menu option:
- Copy
- Deposit (Will display the deposit `QR Code` modal)
- View on block explorer (Will display the `View on Block Explorer` modal)

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/47019>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

## Test Plan:
1. Open the `Wallet` and navigate to the `Portfolio` screen
2. Group your assets by `Account`
3. Now click on the `Address` for one of you accounts
4. You should see the new `Address Actions` menu
5. Test all options
6. `Copy` should copy the address to your `Clipboard` and display a `Copied!` alert
7. `Deposit` should open the deposit `QR Code` modal
8. `View on block explorer` should open the `View on Block Explorer` modal.

![Screenshot 32](https://github.com/user-attachments/assets/26f845a8-facf-417a-a758-573243da4e5f)

https://github.com/user-attachments/assets/07c0aa25-83e4-41bb-8662-fde8f3b53173
