### PR TITLE
[ads] Fix stuck Ads initialization on browser start

### DIFF
--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -208,7 +208,7 @@ AdsServiceImpl::AdsServiceImpl(
           std::make_unique<NewTabPageAdPrefetcher>(/*ads_service=*/*this)),
       bat_ads_service_factory_(std::move(bat_ads_service_factory)),
       file_task_runner_(base::ThreadPool::CreateSequencedTaskRunner(
-          {base::MayBlock(), base::TaskPriority::BEST_EFFORT,
+          {base::MayBlock(), base::TaskPriority::USER_VISIBLE,
            base::TaskShutdownBehavior::BLOCK_SHUTDOWN})),
       ads_service_path_(profile_path.AppendASCII("ads_service")),
       bat_ads_client_associated_receiver_(this) {
@@ -366,6 +366,8 @@ void AdsServiceImpl::MaybeStartBatAdsService() {
 void AdsServiceImpl::StartBatAdsService() {
   CHECK(!IsBatAdsServiceBound());
 
+  VLOG(6) << "Starting Bat Ads Service";
+
   bat_ads_service_remote_ = bat_ads_service_factory_->Launch();
   bat_ads_service_remote_.set_disconnect_handler(base::BindOnce(
       &AdsServiceImpl::DisconnectHandler, weak_ptr_factory_.GetWeakPtr()));
@@ -431,6 +433,7 @@ void AdsServiceImpl::InitializeBasePathDirectoryCallback(
     VLOG(0) << "Failed to initialize " << ads_service_path_ << " directory";
     return ShutdownAdsService();
   }
+  VLOG(6) << "Successfully initialized base path directory";
 
   Initialize(current_start_number);
 }
@@ -455,6 +458,7 @@ void AdsServiceImpl::InitializeRewardsWalletCallback(
   if (!ShouldProceedInitialization(current_start_number)) {
     return;
   }
+  VLOG(6) << "Successfully retrieved rewards wallet info";
 
   if (!bat_ads_associated_remote_.is_bound()) {
     return;

--- a/components/brave_ads/core/internal/database/database_manager.cc
+++ b/components/brave_ads/core/internal/database/database_manager.cc
@@ -27,7 +27,7 @@ namespace brave_ads {
 
 DatabaseManager::DatabaseManager(const base::FilePath& path)
     : database_task_runner_(base::ThreadPool::CreateSequencedTaskRunner(
-          {base::MayBlock(), base::TaskPriority::BEST_EFFORT,
+          {base::MayBlock(), base::TaskPriority::USER_VISIBLE,
            base::TaskShutdownBehavior::BLOCK_SHUTDOWN})),
       database_(base::SequenceBound<Database>(database_task_runner_, path)) {}
 


### PR DESCRIPTION
The PR changes the Brave Ads background task runner priority from BEST_EFFORT to USER_VISIBLE, which is more appropriate as the outcome of these tasks can can affect UI, for example by displaying an NTT.

It also fixes an issue where Ads initialization could get stuck during browser startup on macOS, introduced by the Chromium 133 version upgrade.

More info about Ads initialization stuck. 
It was noticed that ads are stuck in initialization on browser start.
To find the reason we got traces on browser start within 10 seconds with command line:
```
/Applications/Brave\ Browser.app/Contents/MacOS/Brave\ Browser --args --enable-logging=stderr --vmodule="*/brave_rewards/*"=6,"*/brave_ads/*"=6,"*/bat_ads/*"=6,"*/variations/*"=6,"*/ntp_background_images/*"=6 --trace-startup --trace-startup-file=broken_start.json --trace-startup-duration=10 --enable-features=ShouldAlwaysRunBraveAdsService
```

During trace analysis, it was found that Ads initialization was getting stuck inside the `AdsServiceImpl::BatAdsServiceCreatedCallback` function, specifically during the `file_task_runner_->PostTaskAndReplyWithResult` call:
https://github.com/brave/brave-core/blob/master/components/brave_ads/browser/ads_service_impl.cc#L418.

Here is screenshot of `AdsServiceImpl::BatAdsServiceCreatedCallback` call trace for browser `v1.75.171` (chromium 132) https://github.com/brave/brave-browser/releases/tag/v1.75.171:
<img width="300" alt="image" src="https://github.com/user-attachments/assets/42825941-c326-4151-ad22-21d7d668c8cd" />

Here is screenshot of  `AdsServiceImpl::BatAdsServiceCreatedCallback` call trace for browser `v1.75.172` (chromium 133) https://github.com/brave/brave-browser/releases/tag/v1.75.172:
<img width="300" alt="image" src="https://github.com/user-attachments/assets/0b50972b-b206-49c3-ac82-ab062a31a195" />

It is seen that the last post task (`file_task_runner_->PostTaskAndReplyWithResult`) is not being executed with browser `v1.75.172` (chromium 133).

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/47021

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
