### PR TITLE
[IWYU] Fix includes for `base/gtest_prod_util.h`

### DIFF
--- a/browser/brave_vpn/win/brave_vpn_wireguard_service/status_tray/status_tray_runner.h
+++ b/browser/brave_vpn/win/brave_vpn_wireguard_service/status_tray/status_tray_runner.h
@@ -11,6 +11,7 @@
 #include <string>
 #include <utility>
 
+#include "base/gtest_prod_util.h"
 #include "base/memory/weak_ptr.h"
 #include "base/no_destructor.h"
 #include "base/win/registry.h"

--- a/browser/onboarding/onboarding_tab_helper.h
+++ b/browser/onboarding/onboarding_tab_helper.h
@@ -10,6 +10,7 @@
 #include <string>
 
 #include "base/functional/callback_forward.h"
+#include "base/gtest_prod_util.h"
 #include "base/time/time.h"
 #include "content/public/browser/web_contents_observer.h"
 #include "content/public/browser/web_contents_user_data.h"

--- a/browser/playlist/test/playlist_service_unittest.cc
+++ b/browser/playlist/test/playlist_service_unittest.cc
@@ -10,6 +10,7 @@
 #include "base/check.h"
 #include "base/files/file_util.h"
 #include "base/files/scoped_temp_dir.h"
+#include "base/gtest_prod_util.h"
 #include "base/run_loop.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/test/bind.h"

--- a/browser/ui/tabs/split_view_browser_data.h
+++ b/browser/ui/tabs/split_view_browser_data.h
@@ -13,6 +13,7 @@
 
 #include "base/functional/callback_forward.h"
 #include "base/functional/callback_helpers.h"
+#include "base/gtest_prod_util.h"
 #include "base/memory/weak_ptr.h"
 #include "base/observer_list.h"
 #include "chrome/browser/ui/tabs/tab_model.h"

--- a/browser/ui/toolbar/brave_vpn_menu_model.h
+++ b/browser/ui/toolbar/brave_vpn_menu_model.h
@@ -8,6 +8,7 @@
 
 #include <optional>
 
+#include "base/gtest_prod_util.h"
 #include "base/memory/raw_ptr.h"
 #include "ui/menus/simple_menu_model.h"
 

--- a/browser/ui/views/omnibox/brave_omnibox_view_views.h
+++ b/browser/ui/views/omnibox/brave_omnibox_view_views.h
@@ -8,6 +8,7 @@
 
 #include <optional>
 
+#include "base/gtest_prod_util.h"
 #include "chrome/browser/ui/views/omnibox/omnibox_view_views.h"
 #include "ui/base/metadata/metadata_header_macros.h"
 

--- a/browser/ui/views/page_action/wayback_machine_action_icon_view.h
+++ b/browser/ui/views/page_action/wayback_machine_action_icon_view.h
@@ -6,6 +6,7 @@
 #ifndef BRAVE_BROWSER_UI_VIEWS_PAGE_ACTION_WAYBACK_MACHINE_ACTION_ICON_VIEW_H_
 #define BRAVE_BROWSER_UI_VIEWS_PAGE_ACTION_WAYBACK_MACHINE_ACTION_ICON_VIEW_H_
 
+#include "base/gtest_prod_util.h"
 #include "base/memory/raw_ref.h"
 #include "brave/browser/ui/views/page_action/wayback_machine_state_manager.h"
 #include "chrome/browser/ui/views/page_action/page_action_icon_view.h"

--- a/browser/ui/views/split_view/split_view.h
+++ b/browser/ui/views/split_view/split_view.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <vector>
 
+#include "base/gtest_prod_util.h"
 #include "base/memory/raw_ptr.h"
 #include "base/memory/raw_ref.h"
 #include "base/types/pass_key.h"

--- a/browser/ui/views/split_view/split_view_location_bar.h
+++ b/browser/ui/views/split_view/split_view_location_bar.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <string>
 
+#include "base/gtest_prod_util.h"
 #include "base/memory/weak_ptr.h"
 #include "base/scoped_observation.h"
 #include "components/prefs/pref_member.h"

--- a/browser/ui/views/split_view/split_view_separator.h
+++ b/browser/ui/views/split_view/split_view_separator.h
@@ -8,6 +8,7 @@
 
 #include <memory>
 
+#include "base/gtest_prod_util.h"
 #include "base/memory/raw_ptr.h"
 #include "base/scoped_observation.h"
 #include "brave/browser/ui/views/split_view/split_view_separator_delegate.h"

--- a/browser/ui/views/tabs/brave_compound_tab_container.h
+++ b/browser/ui/views/tabs/brave_compound_tab_container.h
@@ -8,7 +8,9 @@
 
 #include <memory>
 #include <optional>
+#include <vector>
 
+#include "base/gtest_prod_util.h"
 #include "chrome/browser/ui/views/tabs/compound_tab_container.h"
 
 namespace views {

--- a/browser/ui/views/toolbar/ai_chat_button.h
+++ b/browser/ui/views/toolbar/ai_chat_button.h
@@ -8,6 +8,7 @@
 
 #include <memory>
 
+#include "base/gtest_prod_util.h"
 #include "base/memory/raw_ref.h"
 #include "chrome/browser/ui/views/toolbar/toolbar_button.h"
 #include "ui/base/metadata/metadata_header_macros.h"

--- a/browser/ui/views/toolbar/brave_toolbar_view.h
+++ b/browser/ui/views/toolbar/brave_toolbar_view.h
@@ -6,6 +6,7 @@
 #ifndef BRAVE_BROWSER_UI_VIEWS_TOOLBAR_BRAVE_TOOLBAR_VIEW_H_
 #define BRAVE_BROWSER_UI_VIEWS_TOOLBAR_BRAVE_TOOLBAR_VIEW_H_
 
+#include "base/gtest_prod_util.h"
 #include "base/memory/raw_ptr.h"
 #include "base/scoped_observation.h"
 #include "brave/components/brave_vpn/common/buildflags/buildflags.h"

--- a/chromium_src/chrome/browser/metrics/chrome_metrics_service_client_unittest.cc
+++ b/chromium_src/chrome/browser/metrics/chrome_metrics_service_client_unittest.cc
@@ -3,7 +3,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-#include "base/gtest_prod_util.h"
 
 // Disable the original tests we're going to override.
 #define TestRegisterUKMProviders DISABLED_TestRegisterUKMProviders

--- a/chromium_src/chrome/browser/ui/views/side_panel/side_panel_coordinator.h
+++ b/chromium_src/chrome/browser/ui/views/side_panel/side_panel_coordinator.h
@@ -9,7 +9,6 @@
 // Moved all header includes of upstream side_panel_coordinator.h to apply
 // final define only to side_panel_coordinator.h as the final keyword is very
 // commonly used from many places.
-#include "base/gtest_prod_util.h"
 #include "base/memory/raw_ptr.h"
 #include "base/observer_list.h"
 #include "base/scoped_multi_source_observation.h"

--- a/chromium_src/ui/views/controls/button/md_text_button.h
+++ b/chromium_src/ui/views/controls/button/md_text_button.h
@@ -6,6 +6,7 @@
 #ifndef BRAVE_CHROMIUM_SRC_UI_VIEWS_CONTROLS_BUTTON_MD_TEXT_BUTTON_H_
 #define BRAVE_CHROMIUM_SRC_UI_VIEWS_CONTROLS_BUTTON_MD_TEXT_BUTTON_H_
 
+#include "base/gtest_prod_util.h"
 #include "third_party/skia/include/core/SkColor.h"
 #include "ui/gfx/vector_icon_types.h"
 #include "ui/views/controls/button/label_button.h"

--- a/components/ai_chat/core/browser/ai_chat_service.h
+++ b/components/ai_chat/core/browser/ai_chat_service.h
@@ -20,7 +20,6 @@
 #include "base/callback_list.h"
 #include "base/functional/callback.h"
 #include "base/functional/callback_helpers.h"
-#include "base/gtest_prod_util.h"
 #include "base/memory/raw_ptr.h"
 #include "base/memory/scoped_refptr.h"
 #include "base/memory/weak_ptr.h"

--- a/components/brave_rewards/core/engine/contribution/contribution.h
+++ b/components/brave_rewards/core/engine/contribution/contribution.h
@@ -15,7 +15,6 @@
 #include <vector>
 
 #include "base/functional/callback_forward.h"
-#include "base/gtest_prod_util.h"
 #include "base/memory/raw_ref.h"
 #include "base/memory/weak_ptr.h"
 #include "base/time/time.h"

--- a/components/brave_user_agent/browser/brave_user_agent_exceptions.h
+++ b/components/brave_user_agent/browser/brave_user_agent_exceptions.h
@@ -11,6 +11,7 @@
 #include <string>
 
 #include "base/files/file_path.h"
+#include "base/gtest_prod_util.h"
 #include "base/memory/singleton.h"
 #include "base/memory/weak_ptr.h"
 #include "url/gurl.h"

--- a/components/brave_vpn/browser/connection/brave_vpn_connection_manager.h
+++ b/components/brave_vpn/browser/connection/brave_vpn_connection_manager.h
@@ -11,6 +11,7 @@
 #include <utility>
 
 #include "base/functional/callback_forward.h"
+#include "base/gtest_prod_util.h"
 #include "base/memory/raw_ptr.h"
 #include "base/memory/scoped_refptr.h"
 #include "base/memory/weak_ptr.h"

--- a/components/brave_vpn/browser/connection/connection_api_impl.h
+++ b/components/brave_vpn/browser/connection/connection_api_impl.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <string>
 
+#include "base/gtest_prod_util.h"
 #include "base/memory/raw_ref.h"
 #include "base/memory/scoped_refptr.h"
 #include "base/values.h"

--- a/components/brave_vpn/browser/connection/ikev2/connection_api_impl_sim.h
+++ b/components/brave_vpn/browser/connection/ikev2/connection_api_impl_sim.h
@@ -9,7 +9,6 @@
 #include <optional>
 #include <string>
 
-#include "base/gtest_prod_util.h"
 #include "base/memory/weak_ptr.h"
 #include "brave/components/brave_vpn/browser/connection/brave_vpn_connection_info.h"
 #include "brave/components/brave_vpn/browser/connection/ikev2/system_vpn_connection_api_impl_base.h"

--- a/components/brave_vpn/browser/connection/ikev2/system_vpn_connection_api_impl_base.h
+++ b/components/brave_vpn/browser/connection/ikev2/system_vpn_connection_api_impl_base.h
@@ -8,6 +8,7 @@
 
 #include <string>
 
+#include "base/gtest_prod_util.h"
 #include "brave/components/brave_vpn/browser/connection/brave_vpn_connection_info.h"
 #include "brave/components/brave_vpn/browser/connection/connection_api_impl.h"
 #include "brave/components/brave_vpn/common/mojom/brave_vpn.mojom.h"

--- a/components/brave_wallet/browser/asset_ratio_service.h
+++ b/components/brave_wallet/browser/asset_ratio_service.h
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "base/functional/callback.h"
+#include "base/gtest_prod_util.h"
 #include "base/memory/weak_ptr.h"
 #include "brave/components/api_request_helper/api_request_helper.h"
 #include "brave/components/brave_wallet/common/brave_wallet.mojom.h"

--- a/components/brave_wallet/browser/bitcoin/bitcoin_tx_manager.h
+++ b/components/brave_wallet/browser/bitcoin/bitcoin_tx_manager.h
@@ -10,6 +10,7 @@
 #include <optional>
 #include <string>
 
+#include "base/gtest_prod_util.h"
 #include "base/memory/raw_ref.h"
 #include "base/scoped_observation.h"
 #include "brave/components/brave_wallet/browser/bitcoin/bitcoin_block_tracker.h"

--- a/components/brave_wallet/browser/brave_wallet_p3a.h
+++ b/components/brave_wallet/browser/brave_wallet_p3a.h
@@ -8,6 +8,7 @@
 
 #include <optional>
 
+#include "base/gtest_prod_util.h"
 #include "base/memory/raw_ptr.h"
 #include "brave/components/brave_wallet/browser/keyring_service_observer_base.h"
 #include "brave/components/brave_wallet/common/brave_wallet.mojom.h"

--- a/components/brave_wallet/browser/cardano/cardano_tx_manager.h
+++ b/components/brave_wallet/browser/cardano/cardano_tx_manager.h
@@ -10,6 +10,7 @@
 #include <optional>
 #include <string>
 
+#include "base/gtest_prod_util.h"
 #include "base/memory/raw_ref.h"
 #include "base/scoped_observation.h"
 #include "brave/components/brave_wallet/browser/cardano/cardano_block_tracker.h"

--- a/components/brave_wallet/browser/eth_allowance_manager.h
+++ b/components/brave_wallet/browser/eth_allowance_manager.h
@@ -12,6 +12,7 @@
 #include <tuple>
 #include <vector>
 
+#include "base/gtest_prod_util.h"
 #include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
 #include "brave/components/brave_wallet/common/brave_wallet.mojom.h"

--- a/components/brave_wallet/browser/ethereum_keyring.h
+++ b/components/brave_wallet/browser/ethereum_keyring.h
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "base/containers/span.h"
+#include "base/gtest_prod_util.h"
 #include "brave/components/brave_wallet/browser/secp256k1_hd_keyring.h"
 #include "brave/components/brave_wallet/common/brave_wallet_types.h"
 

--- a/components/brave_wallet/browser/solana_keyring.h
+++ b/components/brave_wallet/browser/solana_keyring.h
@@ -13,6 +13,7 @@
 
 #include "base/containers/flat_map.h"
 #include "base/containers/span.h"
+#include "base/gtest_prod_util.h"
 #include "brave/components/brave_wallet/browser/internal/hd_key_ed25519.h"
 #include "brave/components/brave_wallet/common/brave_wallet.mojom.h"
 

--- a/components/brave_wallet/browser/zcash/zcash_serializer.h
+++ b/components/brave_wallet/browser/zcash/zcash_serializer.h
@@ -10,6 +10,7 @@
 #include <string>
 #include <vector>
 
+#include "base/gtest_prod_util.h"
 #include "brave/components/brave_wallet/browser/keyring_service.h"
 #include "brave/components/brave_wallet/browser/zcash/zcash_keyring.h"
 #include "brave/components/brave_wallet/browser/zcash/zcash_transaction.h"

--- a/components/brave_wallet/browser/zcash/zcash_shield_sync_service.h
+++ b/components/brave_wallet/browser/zcash/zcash_shield_sync_service.h
@@ -11,6 +11,7 @@
 #include <string>
 #include <vector>
 
+#include "base/gtest_prod_util.h"
 #include "base/types/expected.h"
 #include "brave/components/brave_wallet/browser/internal/orchard_block_scanner.h"
 #include "brave/components/brave_wallet/browser/internal/orchard_sync_state.h"

--- a/components/brave_wayback_machine/wayback_machine_url_fetcher.h
+++ b/components/brave_wayback_machine/wayback_machine_url_fetcher.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <string>
 
+#include "base/gtest_prod_util.h"
 #include "base/memory/raw_ptr.h"
 #include "base/memory/scoped_refptr.h"
 #include "brave/components/api_request_helper/api_request_helper.h"

--- a/components/p3a/p3a_service.h
+++ b/components/p3a/p3a_service.h
@@ -14,6 +14,7 @@
 
 #include "base/callback_list.h"
 #include "base/containers/flat_map.h"
+#include "base/gtest_prod_util.h"
 #include "base/memory/raw_ref.h"
 #include "base/memory/ref_counted.h"
 #include "base/metrics/histogram_base.h"

--- a/components/playlist/browser/media_detector_component_manager.h
+++ b/components/playlist/browser/media_detector_component_manager.h
@@ -10,6 +10,7 @@
 
 #include "base/containers/flat_map.h"
 #include "base/files/file_path.h"
+#include "base/gtest_prod_util.h"
 #include "base/memory/weak_ptr.h"
 #include "base/observer_list.h"
 #include "net/base/schemeful_site.h"

--- a/components/playlist/browser/playlist_streaming.h
+++ b/components/playlist/browser/playlist_streaming.h
@@ -11,7 +11,6 @@
 
 #include "base/containers/flat_map.h"
 #include "base/files/file_path.h"
-#include "base/gtest_prod_util.h"
 #include "base/memory/scoped_refptr.h"
 #include "brave/components/api_request_helper/api_request_helper.h"
 


### PR DESCRIPTION
This is a mechanical fix to correct the inclusions for
`base/gtest_prod_util.h` across the codebase. Details about the script
used can be found in the issue description.

Resolves https://github.com/brave/brave-browser/issues/47053
