### PR TITLE
[AI Chat]: Update Send Button Styles

### DIFF
--- a/components/ai_chat/resources/page/components/attachment_button_menu/index.tsx
+++ b/components/ai_chat/resources/page/components/attachment_button_menu/index.tsx
@@ -38,7 +38,10 @@ export default function AttachmentButtonMenu(props: Props) {
   return (
     <>
       <ButtonMenu>
-        <div slot='anchor-content'>
+        <div
+          slot='anchor-content'
+          className={styles.anchor}
+        >
           <Button
             fab
             kind='plain-faint'

--- a/components/ai_chat/resources/page/components/attachment_button_menu/style.module.scss
+++ b/components/ai_chat/resources/page/components/attachment_button_menu/style.module.scss
@@ -27,3 +27,7 @@
 .buttonIcon {
   --leo-icon-size: 20px;
 }
+
+.anchor {
+  display: flex;
+}

--- a/components/ai_chat/resources/page/components/input_box/index.test.tsx
+++ b/components/ai_chat/resources/page/components/input_box/index.test.tsx
@@ -29,10 +29,13 @@ const defaultContext: InputBoxProps['context'] = {
   shouldDisableUserInput: false,
   shouldSendPageContents: true,
   submitInputTextToAPI: () => {},
-  updateShouldSendPageContents: () => {},
   uploadImage: () => {},
   associatedContentInfo: [],
-  handleVoiceRecognition: () => {}
+  handleVoiceRecognition: () => {},
+  isUploadingFiles: false,
+  disassociateContent: () => {},
+  associateDefaultContent: () => {},
+  getPluralString: () => Promise.resolve('')
 }
 
 describe('input box', () => {
@@ -127,5 +130,50 @@ describe('input box', () => {
     expect(
       container.querySelector('img[src*="//favicon2"]')
     ).not.toBeInTheDocument()
+  })
+
+  it('send button is disabled when the input text is empty', () => {
+    const { container } = render(
+      <InputBox
+        context={{
+          ...defaultContext,
+          inputText: ''
+        }}
+        conversationStarted={false}
+      />
+    )
+
+    const sendButton = container.querySelector('.sendButtonDisabled')
+    expect(sendButton).toBeInTheDocument()
+    expect(sendButton).toHaveClass('sendButtonDisabled')
+  })
+
+  it('send button is enabled when the input text is not empty', () => {
+    const { container } = render(
+      <InputBox
+        context={{
+          ...defaultContext,
+          inputText: 'test'
+        }}
+        conversationStarted={false}
+      />
+    )
+
+    const sendButton = container.querySelector('.button')
+    expect(sendButton).toBeInTheDocument()
+    expect(sendButton).not.toHaveClass('sendButtonDisabled')
+  })
+
+  it('streaming button is shown while generating', () => {
+    const { container } = render(
+      <InputBox
+        context={{ ...defaultContext, isGenerating: true }}
+        conversationStarted={false}
+      />
+    )
+
+    const streamingButton = container.querySelector('.streamingButton')
+    expect(streamingButton).toBeInTheDocument()
+    expect(streamingButton).toHaveClass('streamingButton')
   })
 })

--- a/components/ai_chat/resources/page/components/input_box/index.tsx
+++ b/components/ai_chat/resources/page/components/input_box/index.tsx
@@ -140,6 +140,8 @@ function InputBox(props: InputBoxProps) {
   const showPageAttachments = props.context.associatedContentInfo.length > 0
     && props.context.shouldSendPageContents
     && !props.conversationStarted
+  const isSendButtonDisabled =
+    props.context.shouldDisableUserInput || props.context.inputText === ''
 
   return (
     <form className={styles.form}>
@@ -252,21 +254,31 @@ function InputBox(props: InputBoxProps) {
           {props.context.isGenerating ? (
             <Button
               fab
-              kind='plain-faint'
+              kind='filled'
+              className={classnames({
+                [styles.button]: true,
+                [styles.streamingButton]: true
+              })}
               onClick={handleStopGenerating}
               title={getLocale(S.CHAT_UI_STOP_GENERATION_BUTTON_LABEL)}
             >
-              <Icon name='stop-circle' />
+              <Icon name='stop-circle' className={styles.streamingIcon} />
             </Button>
           ) : (
             <Button
               fab
-              kind='plain-faint'
+              kind='filled'
+              className={classnames({
+                [styles.button]: true,
+                [styles.sendButtonDisabled]: isSendButtonDisabled
+              })}
               onClick={handleSubmit}
-              disabled={props.context.shouldDisableUserInput}
+              disabled={isSendButtonDisabled}
               title={getLocale(S.CHAT_UI_SEND_CHAT_BUTTON_LABEL)}
             >
-              <Icon name='send' />
+              <Icon className={classnames({
+                [styles.sendIconDisabled]: isSendButtonDisabled
+              })} name='arrow-up' />
             </Button>
           )}
         </div>

--- a/components/ai_chat/resources/page/components/input_box/style.module.scss
+++ b/components/ai_chat/resources/page/components/input_box/style.module.scss
@@ -108,7 +108,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: var(--leo-spacing-m) var(--leo-spacing-xl) 10px;
+  padding: 0 var(--leo-spacing-m) var(--leo-spacing-m) var(--leo-spacing-xl);
 }
 
 .tools {
@@ -137,4 +137,30 @@
 .attachmentWrapperScrollStyles {
   padding: var(--leo-spacing-m);
   border-bottom: 1px solid var(--leo-color-divider-subtle);
+}
+
+.button {
+  --leo-button-radius: var(--leo-radius-full);
+  --leo-button-padding: var(--leo-spacing-m);
+}
+
+
+.sendButtonDisabled {
+  --leo-button-color: var(--leo-color-button-disabled);
+}
+
+.sendIconDisabled {
+  // Not able to use --leo-icon-color in .sendButtonDisabled class
+  // because it gets overridden by the button component's default styles.
+  --leo-icon-color: var(--leo-color-icon-disabled);
+}
+
+.streamingButton {
+  --leo-button-color:
+    color-mix(in srgb, var(--leo-color-button-background) 5%, transparent);
+}
+
+.streamingIcon {
+  // Same is applied to the icon in the .streamingButton class.
+  --leo-icon-color: var(--leo-color-icon-interactive);
 }

--- a/ui/webui/resources/BUILD.gn
+++ b/ui/webui/resources/BUILD.gn
@@ -168,6 +168,7 @@ leo_icons = [
   "arrow-small-right.svg",
   "arrow-small-up.svg",
   "arrow-undo.svg",
+  "arrow-up.svg",
   "arrow-up-and-down.svg",
   "attachment.svg",
   "autoplay-off.svg",


### PR DESCRIPTION
## Description 

Updates the `Send` button `Icon` and styling to the latest designs.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/46904>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

## Test Plan:
1. Open `Leo AI` to start a new chat
2. The `Send` button should now have an `Arrow Up` icon
3. The `Send` button should now be `32px` by `32px`
4. The `Send` Button should be `disabled` if the input field is empty
5. Ask a question, the `Send` button should change to the `Stop` streaming button.

Before:

![image](https://github.com/user-attachments/assets/dbc65ff4-0bff-467d-bd45-fcc39c544ad1) | ![image](https://github.com/user-attachments/assets/d81ff427-ea8b-4851-bb24-3c41ed44aa02) | ![image](https://github.com/user-attachments/assets/e745e806-0275-412c-98b1-34f0d95e31ee)
--|--|--

After:

![image](https://github.com/user-attachments/assets/f7899df3-ab9b-4dd6-9b04-3d8d30b0bf57) | ![image](https://github.com/user-attachments/assets/44290b1b-f885-4d10-86f2-6b6d6db882ff) | ![image](https://github.com/user-attachments/assets/94257f09-153b-4c2c-a57d-2cdb4dc65557)
--|--|--

