### PR TITLE
[IWYU] Fix includes for utf conversion functions

### DIFF
--- a/brave_domains/service_domains_unittest.cc
+++ b/brave_domains/service_domains_unittest.cc
@@ -11,7 +11,6 @@
 #include "base/debug/debugging_buildflags.h"
 #include "base/files/file_path.h"
 #include "base/strings/strcat.h"
-#include "base/strings/utf_string_conversions.h"
 #include "brave/brave_domains/buildflags.h"
 #include "build/build_config.h"
 #include "testing/gmock/include/gmock/gmock.h"

--- a/browser/android/youtube_script_injector/youtube_script_injector_tab_helper.cc
+++ b/browser/android/youtube_script_injector/youtube_script_injector_tab_helper.cc
@@ -5,7 +5,6 @@
 
 #include "brave/browser/android/youtube_script_injector/youtube_script_injector_tab_helper.h"
 
-#include "base/strings/utf_string_conversions.h"
 #include "brave/browser/android/youtube_script_injector/features.h"
 #include "brave/components/brave_shields/content/browser/brave_shields_util.h"
 #include "brave/components/constants/pref_names.h"

--- a/browser/brave_shields/brave_shields_tab_helper.cc
+++ b/browser/brave_shields/brave_shields_tab_helper.cc
@@ -8,6 +8,7 @@
 #include <string>
 #include <utility>
 
+#include "base/i18n/number_formatting.h"
 #include "base/metrics/histogram_macros.h"
 #include "base/notreached.h"
 #include "base/strings/utf_string_conversions.h"

--- a/browser/brave_vpn/win/brave_vpn_helper/brave_vpn_helper_crash_reporter_client.cc
+++ b/browser/brave_vpn/win/brave_vpn_helper/brave_vpn_helper_crash_reporter_client.cc
@@ -12,7 +12,6 @@
 #include "base/file_version_info.h"
 #include "base/notreached.h"
 #include "base/strings/string_util.h"
-#include "base/strings/utf_string_conversions.h"
 #include "brave/browser/brave_vpn/win/brave_vpn_helper/brave_vpn_helper_constants.h"
 #include "brave/browser/brave_vpn/win/brave_vpn_helper/brave_vpn_helper_utils.h"
 #include "chrome/install_static/install_util.h"

--- a/browser/brave_vpn/win/brave_vpn_helper/main.cc
+++ b/browser/brave_vpn/win/brave_vpn_helper/main.cc
@@ -11,7 +11,6 @@
 #include "base/files/file_path.h"
 #include "base/logging.h"
 #include "base/process/memory.h"
-#include "base/strings/utf_string_conversions.h"
 #include "base/win/process_startup_helper.h"
 #include "brave/browser/brave_vpn/win/brave_vpn_helper/brave_vpn_helper_constants.h"
 #include "brave/browser/brave_vpn/win/brave_vpn_helper/brave_vpn_helper_crash_reporter_client.h"

--- a/browser/extensions/brave_extension_provider_browsertest.cc
+++ b/browser/extensions/brave_extension_provider_browsertest.cc
@@ -4,7 +4,6 @@
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #include "base/path_service.h"
-#include "base/strings/utf_string_conversions.h"
 #include "base/test/thread_test_helper.h"
 #include "brave/browser/extensions/brave_extension_functional_test.h"
 #include "brave/components/constants/brave_paths.h"

--- a/browser/farbling/brave_navigator_useragent_farbling_browsertest.cc
+++ b/browser/farbling/brave_navigator_useragent_farbling_browsertest.cc
@@ -9,7 +9,6 @@
 #include "base/path_service.h"
 #include "base/strings/strcat.h"
 #include "base/strings/stringprintf.h"
-#include "base/strings/utf_string_conversions.h"
 #include "base/test/thread_test_helper.h"
 #include "base/version.h"
 #include "brave/browser/extensions/brave_base_local_data_files_browsertest.h"

--- a/browser/playlist/playlist_data_source.cc
+++ b/browser/playlist/playlist_data_source.cc
@@ -25,7 +25,6 @@
 #include "base/notreached.h"
 #include "base/strings/escape.h"
 #include "base/strings/string_split.h"
-#include "base/strings/utf_string_conversions.h"
 #include "base/task/thread_pool.h"
 #include "brave/components/playlist/browser/mime_util.h"
 #include "brave/components/playlist/browser/playlist_service.h"

--- a/browser/profiles/brave_profile_manager_browsertest.cc
+++ b/browser/profiles/brave_profile_manager_browsertest.cc
@@ -6,7 +6,6 @@
 #include <vector>
 
 #include "base/functional/callback_helpers.h"
-#include "base/strings/utf_string_conversions.h"
 #include "brave/browser/brave_ads/ads_service_factory.h"
 #include "brave/browser/brave_rewards/rewards_service_factory.h"
 #include "brave/components/constants/pref_names.h"

--- a/browser/tor/test/tor_profile_manager_browsertest.cc
+++ b/browser/tor/test/tor_profile_manager_browsertest.cc
@@ -7,7 +7,6 @@
 
 #include "base/path_service.h"
 #include "base/process/launch.h"
-#include "base/strings/utf_string_conversions.h"
 #include "base/test/bind.h"
 #include "base/threading/thread_restrictions.h"
 #include "brave/browser/brave_ads/ads_service_factory.h"

--- a/browser/ui/ai_chat/ai_chat_tab_helper_unittest.cc
+++ b/browser/ui/ai_chat/ai_chat_tab_helper_unittest.cc
@@ -9,6 +9,7 @@
 #include <string>
 
 #include "base/strings/stringprintf.h"
+#include "base/strings/utf_string_conversions.h"
 #include "base/test/gmock_callback_support.h"
 #include "base/test/mock_callback.h"
 #include "base/test/test_future.h"

--- a/browser/ui/commander/open_url_command_source.cc
+++ b/browser/ui/commander/open_url_command_source.cc
@@ -15,7 +15,6 @@
 #include <vector>
 
 #include "base/i18n/case_conversion.h"
-#include "base/strings/utf_string_conversions.h"
 #include "brave/browser/ui/commander/fuzzy_finder.h"
 #include "build/branding_buildflags.h"
 #include "chrome/browser/ui/browser.h"

--- a/browser/ui/toolbar/brave_app_menu_model.cc
+++ b/browser/ui/toolbar/brave_app_menu_model.cc
@@ -13,7 +13,6 @@
 #include "base/check_op.h"
 #include "base/memory/raw_ptr.h"
 #include "base/notreached.h"
-#include "base/strings/utf_string_conversions.h"
 #include "brave/app/brave_command_ids.h"
 #include "brave/browser/ui/toolbar/app_menu_icons.h"
 #include "brave/components/commander/common/buildflags/buildflags.h"

--- a/browser/ui/toolbar/brave_location_bar_model_delegate.cc
+++ b/browser/ui/toolbar/brave_location_bar_model_delegate.cc
@@ -7,7 +7,6 @@
 
 #include "base/check.h"
 #include "base/feature_list.h"
-#include "base/strings/utf_string_conversions.h"
 #include "brave/browser/ui/brave_scheme_utils.h"
 #include "brave/browser/ui/tabs/features.h"
 #include "brave/components/constants/url_constants.h"

--- a/browser/ui/views/bookmarks/bookmark_bar_instructions_view.cc
+++ b/browser/ui/views/bookmarks/bookmark_bar_instructions_view.cc
@@ -7,7 +7,6 @@
 
 #include <algorithm>
 
-#include "base/strings/utf_string_conversions.h"
 #include "brave/browser/ui/brave_view_ids.h"
 #include "brave/browser/ui/color/brave_color_id.h"
 #include "brave/browser/ui/color/color_palette.h"

--- a/browser/ui/views/brave_news/brave_news_bubble_view.cc
+++ b/browser/ui/views/brave_news/brave_news_bubble_view.cc
@@ -11,7 +11,6 @@
 #include "base/check.h"
 #include "base/memory/weak_ptr.h"
 #include "base/scoped_observation.h"
-#include "base/strings/utf_string_conversions.h"
 #include "brave/browser/brave_news/brave_news_tab_helper.h"
 #include "brave/browser/themes/brave_dark_mode_utils.h"
 #include "brave/browser/ui/views/brave_news/brave_news_bubble_controller.h"

--- a/browser/ui/views/omnibox/brave_omnibox_view_views_browsertest.cc
+++ b/browser/ui/views/omnibox/brave_omnibox_view_views_browsertest.cc
@@ -5,6 +5,7 @@
 
 #include "brave/browser/ui/views/omnibox/brave_omnibox_view_views.h"
 
+#include "base/strings/utf_string_conversions.h"
 #include "brave/browser/brave_browser_features.h"
 #include "brave/browser/url_sanitizer/url_sanitizer_service_factory.h"
 #include "brave/components/url_sanitizer/browser/url_sanitizer_service.h"

--- a/browser/ui/views/omnibox/omnibox_autocomplete_browsertest.cc
+++ b/browser/ui/views/omnibox/omnibox_autocomplete_browsertest.cc
@@ -3,7 +3,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#include "base/strings/utf_string_conversions.h"
 #include "brave/components/constants/pref_names.h"
 #include "brave/components/omnibox/browser/brave_omnibox_prefs.h"
 #include "chrome/browser/profiles/profile.h"

--- a/browser/ui/views/playlist/playlist_action_dialogs.cc
+++ b/browser/ui/views/playlist/playlist_action_dialogs.cc
@@ -15,6 +15,7 @@
 #include "base/logging.h"
 #include "base/notreached.h"
 #include "base/strings/stringprintf.h"
+#include "base/strings/utf_string_conversions.h"
 #include "brave/browser/playlist/playlist_service_factory.h"
 #include "brave/browser/ui/color/brave_color_id.h"
 #include "brave/browser/ui/playlist/playlist_browser_finder.h"

--- a/browser/ui/views/rounded_separator.cc
+++ b/browser/ui/views/rounded_separator.cc
@@ -7,7 +7,6 @@
 
 #include <algorithm>
 
-#include "base/strings/utf_string_conversions.h"
 #include "chrome/grit/generated_resources.h"
 #include "ui/accessibility/ax_enums.mojom.h"
 #include "ui/accessibility/ax_node_data.h"

--- a/browser/ui/views/split_view/split_view_location_bar_browsertest.cc
+++ b/browser/ui/views/split_view/split_view_location_bar_browsertest.cc
@@ -9,7 +9,6 @@
 #include <utility>
 
 #include "base/run_loop.h"
-#include "base/strings/utf_string_conversions.h"
 #include "base/test/bind.h"
 #include "base/timer/timer.h"
 #include "brave/browser/ui/browser_commands.h"

--- a/browser/ui/views/toolbar/bookmark_button.cc
+++ b/browser/ui/views/toolbar/bookmark_button.cc
@@ -7,7 +7,6 @@
 
 #include <utility>
 
-#include "base/strings/utf_string_conversions.h"
 #include "chrome/app/chrome_command_ids.h"
 #include "chrome/browser/ui/color/chrome_color_id.h"
 #include "chrome/browser/ui/view_ids.h"

--- a/browser/ui/webui/brave_webui_source.cc
+++ b/browser/ui/webui/brave_webui_source.cc
@@ -11,7 +11,6 @@
 #include "base/containers/flat_map.h"
 #include "base/containers/span.h"
 #include "base/logging.h"
-#include "base/strings/utf_string_conversions.h"
 #include "brave/components/constants/url_constants.h"
 #include "brave/components/tor/buildflags/buildflags.h"
 #include "brave/components/webui/webui_resources.h"

--- a/browser/ui/webui/settings/brave_default_extensions_handler.cc
+++ b/browser/ui/webui/settings/brave_default_extensions_handler.cc
@@ -10,7 +10,6 @@
 
 #include "base/check_op.h"
 #include "base/functional/bind.h"
-#include "base/strings/utf_string_conversions.h"
 #include "base/values.h"
 #include "brave/browser/brave_wallet/brave_wallet_service_factory.h"
 #include "brave/browser/extensions/brave_component_loader.h"

--- a/browser/ui/webui/settings/brave_import_bulk_data_handler.cc
+++ b/browser/ui/webui/settings/brave_import_bulk_data_handler.cc
@@ -19,7 +19,6 @@
 #include "base/functional/bind.h"
 #include "base/json/json_reader.h"
 #include "base/rand_util.h"
-#include "base/strings/utf_string_conversions.h"
 #include "chrome/browser/browser_process.h"
 #include "chrome/browser/profiles/profile_attributes_entry.h"
 #include "chrome/browser/profiles/profile_attributes_storage.h"

--- a/chromium_src/chrome/browser/autocomplete/chrome_autocomplete_provider_client.cc
+++ b/chromium_src/chrome/browser/autocomplete/chrome_autocomplete_provider_client.cc
@@ -6,6 +6,7 @@
 #include "src/chrome/browser/autocomplete/chrome_autocomplete_provider_client.cc"
 
 #include "base/check.h"
+#include "base/strings/utf_string_conversions.h"
 #include "brave/browser/ai_chat/ai_chat_service_factory.h"
 #include "brave/browser/ai_chat/ai_chat_urls.h"
 #include "brave/components/ai_chat/content/browser/ai_chat_tab_helper.h"

--- a/chromium_src/chrome/browser/renderer_context_menu/render_view_context_menu.cc
+++ b/chromium_src/chrome/browser/renderer_context_menu/render_view_context_menu.cc
@@ -12,6 +12,7 @@
 #include "base/containers/fixed_flat_set.h"
 #include "base/feature_list.h"
 #include "base/logging.h"
+#include "base/strings/utf_string_conversions.h"
 #include "brave/browser/autocomplete/brave_autocomplete_scheme_classifier.h"
 #include "brave/browser/brave_shields/brave_shields_tab_helper.h"
 #include "brave/browser/cosmetic_filters/cosmetic_filters_tab_helper.h"

--- a/chromium_src/chrome/browser/ui/views/tabs/tab_hover_card_bubble_view.cc
+++ b/chromium_src/chrome/browser/ui/views/tabs/tab_hover_card_bubble_view.cc
@@ -8,7 +8,6 @@
 #include <string>
 
 #include "base/strings/strcat.h"
-#include "base/strings/utf_string_conversions.h"
 #include "brave/browser/ui/brave_scheme_utils.h"
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
 #include "chrome/browser/profiles/profile.h"

--- a/chromium_src/chrome/browser/ui/views/tabs/tab_hover_card_bubble_view_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/views/tabs/tab_hover_card_bubble_view_browsertest.cc
@@ -3,7 +3,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#include "base/strings/utf_string_conversions.h"
 #include "brave/browser/ui/views/tabs/brave_tab_hover_card_controller.h"
 #include "build/build_config.h"
 #include "chrome/app/chrome_command_ids.h"

--- a/chromium_src/chrome/common/channel_info_win.cc
+++ b/chromium_src/chrome/common/channel_info_win.cc
@@ -6,7 +6,6 @@
 #include "chrome/common/channel_info.h"
 
 #include "base/debug/profiler.h"
-#include "base/strings/utf_string_conversions.h"
 #include "build/branding_buildflags.h"
 
 // All above headers copied from original channel_info_win.cc are included to

--- a/chromium_src/components/omnibox/browser/search_suggestion_parser.cc
+++ b/chromium_src/components/omnibox/browser/search_suggestion_parser.cc
@@ -7,7 +7,6 @@
 
 #include <string>
 
-#include "base/strings/utf_string_conversions.h"
 #include "brave/components/omnibox/browser/brave_search_suggestion_parser.h"
 #include "components/omnibox/browser/autocomplete_match_type.h"
 #include "third_party/omnibox_proto/types.pb.h"

--- a/chromium_src/components/password_manager/core/browser/ui/weak_check_utility_unittest.cc
+++ b/chromium_src/components/password_manager/core/browser/ui/weak_check_utility_unittest.cc
@@ -8,6 +8,8 @@
 #include <string>
 #include <utility>
 
+#include "base/strings/utf_string_conversions.h"
+
 namespace password_manager {
 
 using ParamType = std::pair<std::string,  // password

--- a/chromium_src/components/viz/service/gl/gpu_service_impl.cc
+++ b/chromium_src/components/viz/service/gl/gpu_service_impl.cc
@@ -5,6 +5,8 @@
 
 #include "components/viz/service/gl/gpu_service_impl.h"
 
+#include "base/strings/utf_string_conversions.h"
+
 #define InitializeWithHost InitializeWithHost_ChromiumImpl
 
 #include "src/components/viz/service/gl/gpu_service_impl.cc"

--- a/components/ai_chat/core/browser/ai_chat_service_unittest.cc
+++ b/components/ai_chat/core/browser/ai_chat_service_unittest.cc
@@ -26,6 +26,7 @@
 #include "base/run_loop.h"
 #include "base/scoped_observation.h"
 #include "base/strings/stringprintf.h"
+#include "base/strings/utf_string_conversions.h"
 #include "base/task/sequenced_task_runner.h"
 #include "base/task/thread_pool.h"
 #include "base/test/bind.h"

--- a/components/brave_search/renderer/brave_search_default_js_handler.cc
+++ b/components/brave_search/renderer/brave_search_default_js_handler.cc
@@ -10,7 +10,6 @@
 
 #include "base/check.h"
 #include "base/no_destructor.h"
-#include "base/strings/utf_string_conversions.h"
 #include "content/public/renderer/render_frame.h"
 #include "gin/arguments.h"
 #include "gin/function_template.h"

--- a/components/brave_search/renderer/brave_search_fallback_js_handler.cc
+++ b/components/brave_search/renderer/brave_search_fallback_js_handler.cc
@@ -9,7 +9,6 @@
 #include <utility>
 
 #include "base/no_destructor.h"
-#include "base/strings/utf_string_conversions.h"
 #include "content/public/renderer/render_frame.h"
 #include "gin/arguments.h"
 #include "gin/function_template.h"

--- a/components/brave_vpn/common/wireguard/wireguard_utils.cc
+++ b/components/brave_vpn/common/wireguard/wireguard_utils.cc
@@ -16,7 +16,6 @@
 #include "base/compiler_specific.h"
 #include "base/logging.h"
 #include "base/strings/string_util.h"
-#include "base/strings/utf_string_conversions.h"
 #include "crypto/openssl_util.h"
 #include "net/base/ip_address.h"
 #include "net/base/url_util.h"

--- a/components/brave_wallet/browser/swap_response_parser_unittest.cc
+++ b/components/brave_wallet/browser/swap_response_parser_unittest.cc
@@ -9,7 +9,6 @@
 
 #include "base/i18n/time_formatting.h"
 #include "base/json/json_reader.h"
-#include "base/strings/utf_string_conversions.h"
 #include "base/test/values_test_util.h"
 #include "brave/components/brave_wallet/browser/json_rpc_requests_helper.h"
 #include "brave/components/brave_wallet/browser/swap_response_parser.h"

--- a/components/brave_wallet/renderer/js_ethereum_provider.cc
+++ b/components/brave_wallet/renderer/js_ethereum_provider.cc
@@ -15,7 +15,6 @@
 #include "base/json/json_writer.h"
 #include "base/no_destructor.h"
 #include "base/strings/string_number_conversions.h"
-#include "base/strings/utf_string_conversions.h"
 #include "base/uuid.h"
 #include "brave/components/brave_wallet/common/eth_request_helper.h"
 #include "brave/components/brave_wallet/common/hex_utils.h"

--- a/components/decentralized_dns/content/ens_offchain_lookup_opt_in_page.cc
+++ b/components/decentralized_dns/content/ens_offchain_lookup_opt_in_page.cc
@@ -13,7 +13,6 @@
 #include "base/notreached.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/string_util.h"
-#include "base/strings/utf_string_conversions.h"
 #include "base/values.h"
 #include "brave/components/decentralized_dns/content/ens_offchain_lookup_interstitial_controller_client.h"
 #include "brave/components/decentralized_dns/core/utils.h"

--- a/components/omnibox/browser/brave_history_url_provider_unittest.cc
+++ b/components/omnibox/browser/brave_history_url_provider_unittest.cc
@@ -14,6 +14,7 @@
 
 #include "base/check.h"
 #include "base/run_loop.h"
+#include "base/strings/utf_string_conversions.h"
 #include "base/test/task_environment.h"
 #include "base/time/time.h"
 #include "brave/components/omnibox/browser/brave_omnibox_prefs.h"

--- a/components/omnibox/browser/brave_shortcuts_provider_unittest.cc
+++ b/components/omnibox/browser/brave_shortcuts_provider_unittest.cc
@@ -11,6 +11,7 @@
 
 #include "base/files/file_path.h"
 #include "base/memory/scoped_refptr.h"
+#include "base/strings/utf_string_conversions.h"
 #include "base/test/task_environment.h"
 #include "base/time/time.h"
 #include "brave/components/omnibox/browser/brave_fake_autocomplete_provider_client.h"

--- a/components/password_manager/core/browser/import/csv_safari_password.cc
+++ b/components/password_manager/core/browser/import/csv_safari_password.cc
@@ -9,7 +9,6 @@
 #include <utility>
 
 #include "base/strings/string_util.h"
-#include "base/strings/utf_string_conversions.h"
 #include "base/time/time.h"
 #include "components/affiliations/core/browser/affiliation_utils.h"
 #include "components/password_manager/core/browser/form_parsing/form_data_parser.h"

--- a/components/password_manager/core/browser/import/safari_password_importer.cc
+++ b/components/password_manager/core/browser/import/safari_password_importer.cc
@@ -20,6 +20,7 @@
 #include "base/metrics/histogram_macros.h"
 #include "base/notreached.h"
 #include "base/strings/string_util.h"
+#include "base/strings/utf_string_conversions.h"
 #include "base/task/thread_pool.h"
 #include "base/types/expected.h"
 #include "base/types/expected_macros.h"

--- a/components/playlist/browser/playlist_tab_helper.cc
+++ b/components/playlist/browser/playlist_tab_helper.cc
@@ -12,7 +12,6 @@
 #include "base/check_op.h"
 #include "base/functional/bind.h"
 #include "base/logging.h"
-#include "base/strings/utf_string_conversions.h"
 #include "brave/components/playlist/browser/playlist_constants.h"
 #include "brave/components/playlist/browser/playlist_media_handler.h"
 #include "brave/components/playlist/browser/playlist_service.h"

--- a/components/skus/browser/skus_url_loader_impl.cc
+++ b/components/skus/browser/skus_url_loader_impl.cc
@@ -10,7 +10,6 @@
 
 #include "base/logging.h"
 #include "base/strings/string_split.h"
-#include "base/strings/utf_string_conversions.h"
 #include "brave/components/skus/browser/rs/cxx/src/lib.rs.h"
 #include "brave/components/skus/common/skus_sdk.mojom.h"
 #include "net/base/load_flags.h"

--- a/components/skus/renderer/skus_js_handler.cc
+++ b/components/skus/renderer/skus_js_handler.cc
@@ -14,7 +14,6 @@
 #include "base/functional/callback_helpers.h"
 #include "base/json/json_reader.h"
 #include "base/no_destructor.h"
-#include "base/strings/utf_string_conversions.h"
 #include "content/public/renderer/render_frame.h"
 #include "content/public/renderer/v8_value_converter.h"
 #include "gin/arguments.h"

--- a/components/webui/webui_resources.cc
+++ b/components/webui/webui_resources.cc
@@ -9,7 +9,6 @@
 
 #include "base/containers/flat_map.h"
 #include "base/no_destructor.h"
-#include "base/strings/utf_string_conversions.h"
 #include "brave/components/brave_vpn/common/buildflags/buildflags.h"
 #include "brave/components/constants/url_constants.h"
 #include "brave/components/tor/buildflags/buildflags.h"

--- a/ios/browser/api/bookmarks/importer/bookmarks_importer.mm
+++ b/ios/browser/api/bookmarks/importer/bookmarks_importer.mm
@@ -16,7 +16,6 @@
 #include "base/notreached.h"
 #include "base/path_service.h"
 #include "base/strings/string_number_conversions.h"
-#include "base/strings/utf_string_conversions.h"
 #include "brave/ios/browser/api/bookmarks/importer/imported_bookmark_entry.h"
 #include "components/bookmarks/browser/bookmark_model.h"
 #include "components/bookmarks/browser/bookmark_node.h"

--- a/ios/browser/api/history/history_driver_ios.mm
+++ b/ios/browser/api/history/history_driver_ios.mm
@@ -8,7 +8,6 @@
 #import <utility>
 
 #import "base/check.h"
-#import "base/strings/utf_string_conversions.h"
 #import "components/browsing_data/core/history_notice_utils.h"
 #import "ios/chrome/browser/history/model/history_utils.h"
 

--- a/ios/browser/api/omnibox/autocomplete_classifier.mm
+++ b/ios/browser/api/omnibox/autocomplete_classifier.mm
@@ -7,7 +7,6 @@
 
 #include "base/notreached.h"
 #include "base/strings/sys_string_conversions.h"
-#include "base/strings/utf_string_conversions.h"
 #include "components/omnibox/browser/autocomplete_classifier.h"
 #include "components/omnibox/browser/autocomplete_match.h"
 #include "components/prefs/pref_service.h"

--- a/ios/browser/api/unzip/unzip.mm
+++ b/ios/browser/api/unzip/unzip.mm
@@ -11,7 +11,6 @@
 #include "base/functional/callback_helpers.h"
 #include "base/strings/string_split.h"
 #include "base/strings/sys_string_conversions.h"
-#include "base/strings/utf_string_conversions.h"
 #include "base/task/sequenced_task_runner.h"
 #include "base/task/thread_pool.h"
 #include "components/services/unzip/in_process_unzipper.h"  // nogncheck

--- a/ios/browser/api/webcompat_reporter/webcompat_reporter_service_delegate.mm
+++ b/ios/browser/api/webcompat_reporter/webcompat_reporter_service_delegate.mm
@@ -5,7 +5,6 @@
 
 #include "brave/ios/browser/api/webcompat_reporter/webcompat_reporter_service_delegate.h"
 
-#include "base/strings/utf_string_conversions.h"
 #include "brave/components/webcompat_reporter/browser/webcompat_reporter_utils.h"
 #include "components/component_updater/component_updater_service.h"
 

--- a/ios/browser/ui/webui/brave_web_ui_ios_data_source.mm
+++ b/ios/browser/ui/webui/brave_web_ui_ios_data_source.mm
@@ -12,7 +12,6 @@
 #include "base/memory/ref_counted_memory.h"
 #include "base/strings/strcat.h"
 #include "base/strings/string_util.h"
-#include "base/strings/utf_string_conversions.h"
 #include "brave/ios/browser/ui/webui/brave_url_data_source_ios.h"
 #include "ios/chrome/browser/shared/model/url/chrome_url_constants.h"
 #include "ios/components/webui/web_ui_url_constants.h"

--- a/ios/browser/ui/webui/brave_webui_utils.mm
+++ b/ios/browser/ui/webui/brave_webui_utils.mm
@@ -9,7 +9,6 @@
 #include <vector>
 
 #include "base/containers/flat_map.h"
-#include "base/strings/utf_string_conversions.h"
 #include "brave/components/constants/url_constants.h"
 #include "brave/components/webui/webui_resources.h"
 #include "brave/ios/browser/ui/webui/brave_web_ui_ios_data_source.h"

--- a/ios/browser/ui/webui/skus/skus_internals_ui.mm
+++ b/ios/browser/ui/webui/skus/skus_internals_ui.mm
@@ -16,7 +16,6 @@
 #include "base/json/json_writer.h"
 #include "base/notimplemented.h"
 #include "base/strings/sys_string_conversions.h"
-#include "base/strings/utf_string_conversions.h"
 #include "base/task/thread_pool.h"
 #include "brave/components/constants/webui_url_constants.h"
 #include "brave/components/skus/browser/pref_names.h"

--- a/renderer/test/subresource_web_bundles_browsertest.cc
+++ b/renderer/test/subresource_web_bundles_browsertest.cc
@@ -5,7 +5,6 @@
 
 #include "base/strings/strcat.h"
 #include "base/strings/string_util.h"
-#include "base/strings/utf_string_conversions.h"
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/tabs/tab_strip_model.h"
 #include "chrome/test/base/in_process_browser_test.h"

--- a/utility/importer/brave_profile_import_impl.cc
+++ b/utility/importer/brave_profile_import_impl.cc
@@ -14,7 +14,6 @@
 #include "base/location.h"
 #include "base/memory/ref_counted.h"
 #include "base/notreached.h"
-#include "base/strings/utf_string_conversions.h"
 #include "base/task/single_thread_task_runner.h"
 #include "base/threading/thread.h"
 #include "brave/utility/importer/brave_external_process_importer_bridge.h"


### PR DESCRIPTION
This PR does IWYU for the following files:

 - base/strings/utf_string_conversions.h
 - base/i18n/number_formatting.h

This is a mechanical change, and for more details, check the issue
description.

Resolves https://github.com/brave/brave-browser/issues/47060
