### PR TITLE
[AI Chat]: Conversation Padding for Panel and Android

### DIFF
--- a/components/ai_chat/resources/page/components/main/index.tsx
+++ b/components/ai_chat/resources/page/components/main/index.tsx
@@ -185,7 +185,11 @@ function Main() {
   })
 
   return (
-    <main className={styles.main} ref={setMainElement}>
+    <main className={classnames({
+      [styles.main]: true,
+      [styles.mainPanel]: !aiChatContext.isStandalone,
+      [styles.mainMobile]: aiChatContext.isMobile
+    })} ref={setMainElement}>
       {isConversationListOpen && !aiChatContext.isStandalone && (
         <div className={styles.conversationsList}>
           <div

--- a/components/ai_chat/resources/page/components/main/style.module.scss
+++ b/components/ai_chat/resources/page/components/main/style.module.scss
@@ -4,7 +4,7 @@
 // you can obtain one at https://mozilla.org/MPL/2.0/.
 
 .main {
-  --conversation-content-margin: var(--leo-spacing-2xl);
+  --conversation-content-margin: var(--leo-spacing-5xl);
   --conversation-content-max-width: calc(680px + calc(var(--conversation-content-margin) * 2));
 
   display: flex;
@@ -13,6 +13,14 @@
   height: 100%;
   position: relative;
   overflow: hidden;
+}
+
+.mainPanel {
+  --conversation-content-margin: var(--leo-spacing-2xl);
+}
+
+.mainMobile {
+  --conversation-content-margin: var(--leo-spacing-xl);
 }
 
 .attachmentsDialog {
@@ -90,8 +98,7 @@
   max-width: var(--conversation-content-max-width);
   // Adjust padding to account for scrollbar width so content lines up with
   // input area which is outside of the scroller.
-  padding:
-    0 calc(var(--conversation-content-margin) - var(--scrollbar-width) / 2) 0 calc(var(--conversation-content-margin) + var(--scrollbar-width) / 2);
+  padding: 0 calc(var(--conversation-content-margin) - var(--scrollbar-width) / 2) 0 var(--conversation-content-margin);
 
   // Hide until content is ready
   opacity: 0;

--- a/components/ai_chat/resources/page/components/model_intro/style.module.scss
+++ b/components/ai_chat/resources/page/components/model_intro/style.module.scss
@@ -1,5 +1,5 @@
 .modelInfo {
-  margin: var(--leo-spacing-2xl) var(--leo-spacing-2xl) 0 var(--leo-spacing-2xl);
+  margin-top: var(--leo-spacing-2xl);
   display: flex;
   flex-direction: column;
   gap: var(--leo-spacing-m);

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/conversation_entries/style.module.scss
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/conversation_entries/style.module.scss
@@ -10,7 +10,7 @@
   gap: var(--leo-spacing-xl);
   font: var(--leo-font-large-regular);
   color: var(--leo-color-text-primary);
-  padding: var(--leo-spacing-2xl) var(--leo-spacing-2xl) 0 var(--leo-spacing-2xl);
+  padding-top: var(--leo-spacing-2xl);
 }
 
 .turnContainerMobile {


### PR DESCRIPTION
## Description 

Fixes the padding `gutters` for conversations in the `Panel` and `Android`

- Desktop should have `48px` left padding and `45px` right padding (-3px to compensate for 3px sidebar)
- Panel should have '24px` left padding and `21px` right padding (-3px to compensate for 3px sidebar)
- Android should have `16px` left padding and `13px` right padding (-3px to compensate for 3px sidebar)

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/45766>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

## Test Plan:
1. Open `Leo AI` on `Desktop` full page view and inspect that the `Padding` is correct
2. Open `Leo AI` in the sidebar `Panel` and inspect that the `Padding` is correct
3. Open `Leo AI` on an `Android` device and inspect that the `Padding` is correct

Panel Before:

![Screenshot 40](https://github.com/user-attachments/assets/158713e1-cfd9-442d-ae6a-b4b1c34c587e)

Panel After:

![Screenshot 39](https://github.com/user-attachments/assets/a9dd8ad1-3de9-4b4c-9a2d-7bba64225b9c)
