### PR TITLE
Fixed crash from clicking private/tor window's profile avatar button

### DIFF
--- a/app/feature_defaults_unittest.cc
+++ b/app/feature_defaults_unittest.cc
@@ -242,6 +242,7 @@ TEST(FeatureDefaultsTest, DisabledFeatures) {
       &segmentation_platform::features::kSegmentationPlatformTimeDelaySampling,
       &shared_highlighting::kSharedHighlightingManager,
       &subresource_filter::kAdTagging,
+      &switches::kEnableImprovedGuestProfileMenu,
       &switches::kSyncEnableBookmarksInTransportMode,
       &syncer::kSyncAutofillLoyaltyCard,
 #if !BUILDFLAG(IS_ANDROID)

--- a/browser/ui/views/toolbar/brave_toolbar_view_browsertest.cc
+++ b/browser/ui/views/toolbar/brave_toolbar_view_browsertest.cc
@@ -399,6 +399,16 @@ IN_PROC_BROWSER_TEST_F(BraveToolbarViewTest,
   EXPECT_EQ(gfx::Size(avatar_size, avatar_size), avatar->size());
 }
 
+// Check no crash when clicking private window's avatar button.
+IN_PROC_BROWSER_TEST_F(BraveToolbarViewTest, ClickAvatarButtonTest) {
+  auto* incognito_browser = CreateIncognitoBrowser(browser()->profile());
+  auto* avatar_button = BrowserView::GetBrowserViewForBrowser(incognito_browser)
+                            ->toolbar_button_provider()
+                            ->GetAvatarToolbarButton();
+  EXPECT_TRUE(avatar_button->GetVisible());
+  avatar_button->button_controller()->NotifyClick();
+}
+
 IN_PROC_BROWSER_TEST_F(BraveToolbarViewTest,
                        BookmarkButtonCanBeToggledWithPref) {
   auto* prefs = browser()->profile()->GetPrefs();

--- a/chromium_src/components/signin/public/base/signin_switches.cc
+++ b/chromium_src/components/signin/public/base/signin_switches.cc
@@ -10,6 +10,7 @@
 namespace switches {
 
 OVERRIDE_FEATURE_DEFAULT_STATES({{
+    {kEnableImprovedGuestProfileMenu, base::FEATURE_DISABLED_BY_DEFAULT},
     {kSyncEnableBookmarksInTransportMode, base::FEATURE_DISABLED_BY_DEFAULT},
 }});
 


### PR DESCRIPTION
In cr138, `kEnableImprovedGuestProfileMenu` is enabled by default but we're not ready to enable it.
We call `SetProfileIdentityInfo()` always from `BraveIncognitoMenuView` but upstream doesn't allow to call it
when `kEnableImprovedGuestProfileMenu` is enabled.
Fixed disabling it by default. As this feature is deleted and already handled in cr139 branch,
we don't need another f/u for enabling it by default in the future.

TEST=BraveToolbarViewTest.ClickAvatarButtonTest

1. Launch brave and open private window
2. Click private window's profile avatar button
3. Check no crash

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/47073

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
