### PR TITLE
[iOS] Purge restoration data the first launch using Chromium web views (uplift to 1.81.x)

### DIFF
--- a/ios/brave-ios/App/iOS/Delegates/AppState.swift
+++ b/ios/brave-ios/App/iOS/Delegates/AppState.swift
@@ -55,9 +55,15 @@ public class AppState {
           Migration.migrateLostTabsActiveWindow()
 
           let useChromiumWebViews = FeatureList.kUseChromiumWebViews.enabled
+          var purgeSessionData =
+            useChromiumWebViews && !Preferences.Chromium.invalidatedRestorationOnUpgrade.value
           if let value = Preferences.Chromium.lastWebViewsFlagState.value,
             value != useChromiumWebViews
           {
+            purgeSessionData = true
+          }
+          if purgeSessionData {
+            Preferences.Chromium.invalidatedRestorationOnUpgrade.value = true
             SessionTab.purgeSessionData()
           }
 

--- a/ios/brave-ios/Sources/Preferences/GlobalPreferences.swift
+++ b/ios/brave-ios/Sources/Preferences/GlobalPreferences.swift
@@ -259,6 +259,12 @@ extension Preferences {
       key: "chromium.last.webviewsflagstate",
       default: nil
     )
+    /// Whether or not we've invalidated session restoration data the first time the user is
+    /// upgraded to use Chromium web views
+    public static let invalidatedRestorationOnUpgrade = Option<Bool>(
+      key: "chromium.invalidated-restoration-on-upgrade",
+      default: false
+    )
     /// Sync Device Restoration Token
     public static let hasSyncDeviceRestorationToken = Option<Bool>(
       key: "chromium.sync.hasSyncDeviceRestorationToken",


### PR DESCRIPTION
Uplift of #29639
Resolves https://github.com/brave/brave-browser/issues/46965

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.