### PR TITLE
[plaster] Add `chrome/app/BUILD.gn` 🩹

### DIFF
--- a/rewrite/chrome/app/BUILD.gn.toml
+++ b/rewrite/chrome/app/BUILD.gn.toml
@@ -1,0 +1,13 @@
+# Copyright (c) 2025 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+# This substitution matches with the `grit_strings("generated_resources")`
+# block, and adds our line just as the last line before the block closes.
+[[substitution]]
+description = "Adding brave_generated_resources_grit to Chromium's resources."
+re_pattern = '(grit_strings\("generated_resources"\)\s*\{.*?)(\n\})'
+replace = '''\1
+  deps = [ "//brave/app:brave_generated_resources_grit" ]\2'''
+re_flags = "DOTALL"


### PR DESCRIPTION
This change adds a  🩹 for the patching we do in `chrome/app/BUILD.gn`.
The output is the same as the patch we already have in place, so nothing
changes there. This particular plaster is meant to be flexible, so to
not break by the lines around changing. It is designed to add the line
just at the end of the block, regardless of what may have changed around
it.

```
grit_strings("generated_resources") {
  ...
  ...
  ...
  deps = [ "//brave/app:brave_generated_resources_grit" ]
}
```

Resolves https://github.com/brave/brave-browser/issues/47088
