### PR TITLE
Ensure that bookmarks default to bookmarks bar folder

### DIFF
--- a/browser/brave_app_controller_mac_browsertest.mm
+++ b/browser/brave_app_controller_mac_browsertest.mm
@@ -222,32 +222,22 @@ IN_PROC_BROWSER_TEST_F(BraveAppControllerBrowserTest,
   [[normal_window_submenu delegate] menuNeedsUpdate:normal_window_submenu];
 
   // Total 5 items - basic 3 items (Bookmark Manager, Bookmark This Tab... and
-  // Bookmark All Tabs..), separator, and "Other Bookmarks" (which contains the
-  // new bookmark item).
+  // Bookmark All Tabs..), separator, and "Bookmarks" (which contains the new
+  // bookmark item).
   EXPECT_EQ(5, [normal_window_submenu numberOfItems]);
-  EXPECT_TRUE([[normal_window_submenu itemAtIndex:4] hasSubmenu]);
-  NSMenu* other_bookmarks_submenu =
-      [[normal_window_submenu itemAtIndex:4] submenu];
-  // The "Other Bookmarks" menu is lazy loaded
-  EXPECT_EQ([other_bookmarks_submenu numberOfItems], 0);
-  [ac bookmarkMenuBridge]->UpdateNonRootMenu(
-      other_bookmarks_submenu, BookmarkParentFolder::OtherFolder());
-  EXPECT_EQ([other_bookmarks_submenu numberOfItems], 1);
-  EXPECT_EQ(std::u16string(kPersistBookmarkTitle),
-            base::SysNSStringToUTF16(
-                [[other_bookmarks_submenu itemAtIndex:0] title]));
+  EXPECT_EQ(
+      std::u16string(kPersistBookmarkTitle),
+      base::SysNSStringToUTF16([[normal_window_submenu itemAtIndex:4] title]));
 
   // Create private browser and check bookmark menubar has same items.
   auto* private_browser = CreateIncognitoBrowser(browser()->profile());
   [ac setLastProfile:private_browser->profile()];
   NSMenu* private_browser_submenu = [ac bookmarkMenuBridge]->BookmarkMenu();
   [[private_browser_submenu delegate] menuNeedsUpdate:private_browser_submenu];
-  NSMenu* private_other_bookmarks_submenu =
-      [[private_browser_submenu itemAtIndex:4] submenu];
-  EXPECT_EQ([private_other_bookmarks_submenu numberOfItems], 1);
+  EXPECT_EQ(5, [private_browser_submenu numberOfItems]);
   EXPECT_EQ(std::u16string(kPersistBookmarkTitle),
             base::SysNSStringToUTF16(
-                [[private_other_bookmarks_submenu itemAtIndex:0] title]));
+                [[private_browser_submenu itemAtIndex:4] title]));
 
   // Close private browser and check bookmark menubar still has same items.
   chrome::CloseWindow(private_browser);
@@ -256,10 +246,9 @@ IN_PROC_BROWSER_TEST_F(BraveAppControllerBrowserTest,
   [ac setLastProfile:browser()->profile()];
   [[normal_window_submenu delegate] menuNeedsUpdate:normal_window_submenu];
   EXPECT_EQ(5, [normal_window_submenu numberOfItems]);
-  EXPECT_EQ([other_bookmarks_submenu numberOfItems], 1);
-  EXPECT_EQ(std::u16string(kPersistBookmarkTitle),
-            base::SysNSStringToUTF16(
-                [[other_bookmarks_submenu itemAtIndex:0] title]));
+  EXPECT_EQ(
+      std::u16string(kPersistBookmarkTitle),
+      base::SysNSStringToUTF16([[normal_window_submenu itemAtIndex:4] title]));
 }
 
 #if BUILDFLAG(ENABLE_TOR)

--- a/chromium_src/components/bookmarks/browser/bookmark_utils.cc
+++ b/chromium_src/components/bookmarks/browser/bookmark_utils.cc
@@ -1,0 +1,22 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include <algorithm>
+
+#include "components/bookmarks/browser/bookmark_node.h"
+
+// Restores simplified modification date comparison to avoid changing the
+// default bookmark save location to "Other bookmarks" (`more_recently_modified`
+// is mentioned at the end in order to avoid an unused variable warning)
+#define stable_sort(NODES, COMPARATOR)                              \
+  stable_sort(NODES, [](const bookmarks::BookmarkNode* n1,          \
+                        const bookmarks::BookmarkNode* n2) {        \
+    return n1->date_folder_modified() > n2->date_folder_modified(); \
+  });                                                               \
+  more_recently_modified;
+
+#include "src/components/bookmarks/browser/bookmark_utils.cc"
+
+#undef stable_sort

--- a/test/filters/browser_tests.filter
+++ b/test/filters/browser_tests.filter
@@ -2237,6 +2237,11 @@
 -TabStripComboButtonBrowserTest.BuildsComboButton
 -TabStripComboButtonBrowserTest.SeparatorVisibility
 
+# These tests fail because we default to saving bookmarks in the "Bookmarks"
+# folder, not in "Other bookmarks"
+-BookmarkBrowsertest.BookmarkCurrentTab_WithAccountNodes
+-BookmarkBrowsertest.BookmarkCurrentTab_WithoutAccountNodes
+
 # Tests below this point have not been diagnosed or had issues created yet.
 -_/WebrtcLoggingPrivateApiStartEventLoggingTestPolicyEnabled.*
 -AdsPageLoadMetricsObserverBrowserTest.*


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/47069

Upstream has made a change to the default save location for bookmarks: when there are no account bookmarks and the user hasn't modified their bookmarks yet, the "Other bookmarks" folder should be the default save location. We want bookmarks to continue going to the "Bookmarks" folder instead, so we are reverting to the previous comparison that only used the folder modified date.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
