### PR TITLE
[NTP Next] Introduce a short delay before rendering the news feed

### DIFF
--- a/browser/resources/brave_new_tab_page_refresh/components/news/news_feed.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/news/news_feed.tsx
@@ -14,11 +14,19 @@ import { style } from './news_feed.style'
 
 export function NewsFeed() {
   const braveNews = useBraveNews()
+  const [shouldRenderNews, setShouldRenderNews] = React.useState(false)
+
+  React.useEffect(() => {
+    setTimeout(() => setShouldRenderNews(true), 1000)
+  }, [])
+
   return <>
     {
       braveNews.isShowOnNTPPrefEnabled &&
         <div data-css-scope={style.scope}>
-          {braveNews.isOptInPrefEnabled ? <NewsPage /> : <OptIn />}
+          {braveNews.isOptInPrefEnabled
+            ? shouldRenderNews && <NewsPage />
+            : <OptIn />}
         </div>
     }
     {braveNews.customizePage && <CustomizeModal />}


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/46868

On the existing NTP, there is a 1.7 second delay before the news feed is rendered (see the `isPromptingBraveNews` component state). This change introduces a similar delay to the new NTP (reduced to 1 second) which additionally fixes the issue with scroll restoration after navigating back from a news article.

**Additional Notes:**

Without the delay, the "scroll news to top" effect in `brave_news/browser/resources/Page.tsx` is run twice: once on initial render and once when the "load feed" effect is run in `useFeedV2`. The second call occurs after the scroll restoration effect runs, essentially cancelling the scroll restoration.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
