### PR TITLE
Adds feature flag for Brave Account.

### DIFF
--- a/browser/brave_content_browser_client.cc
+++ b/browser/brave_content_browser_client.cc
@@ -59,6 +59,7 @@
 #include "brave/components/ai_chat/core/common/mojom/untrusted_frame.mojom.h"
 #include "brave/components/ai_rewriter/common/buildflags/buildflags.h"
 #include "brave/components/body_sniffer/body_sniffer_throttle.h"
+#include "brave/components/brave_account/features.h"
 #include "brave/components/brave_education/buildflags.h"
 #include "brave/components/brave_rewards/content/rewards_protocol_navigation_throttle.h"
 #include "brave/components/brave_search/browser/backup_results_service.h"
@@ -645,8 +646,10 @@ void BraveContentBrowserClient::RegisterWebUIInterfaceBrokers(
       .Add<new_tab_takeover::mojom::NewTabTakeover>();
 #endif  // !BUILDFLAG(IS_ANDROID)
 
-  registry.ForWebUI<BraveAccountUI>()
-      .Add<password_strength_meter::mojom::PasswordStrengthMeter>();
+  if (brave_account::features::IsBraveAccountEnabled()) {
+    registry.ForWebUI<BraveAccountUI>()
+        .Add<password_strength_meter::mojom::PasswordStrengthMeter>();
+  }
 }
 
 std::optional<base::UnguessableToken>
@@ -843,8 +846,11 @@ void BraveContentBrowserClient::RegisterBrowserInterfaceBindersForFrame(
     content::RegisterWebUIControllerInterfaceBinder<
         commands::mojom::CommandsService, BraveSettingsUI>(map);
   }
-  content::RegisterWebUIControllerInterfaceBinder<
-      brave_account::mojom::BraveAccountSettingsHandler, BraveSettingsUI>(map);
+  if (brave_account::features::IsBraveAccountEnabled()) {
+    content::RegisterWebUIControllerInterfaceBinder<
+        brave_account::mojom::BraveAccountSettingsHandler, BraveSettingsUI>(
+        map);
+  }
 #endif
 
   auto* prefs =

--- a/browser/resources/settings/getting_started_page/brave_account_row.html.ts
+++ b/browser/resources/settings/getting_started_page/brave_account_row.html.ts
@@ -5,10 +5,11 @@
 
 import { html } from '//resources/lit/v3_0/lit.rollup.js'
 
+import { loadTimeData } from '//resources/js/load_time_data.js'
 import { SettingsBraveAccountRow } from './brave_account_row.js'
 
 export function getHtml(this: SettingsBraveAccountRow) {
-  return html`<!--_html_template_start_-->
+  return html`
     <div class="row">
       <div class="circle">
         <leo-icon name="social-brave-release-favicon-fullheight-color">
@@ -18,22 +19,21 @@ export function getHtml(this: SettingsBraveAccountRow) {
         <div class="title">
           ${this.signedIn
             ? 'John Doe'
-            : '$i18n{braveAccountRowTitle}'}
+            : loadTimeData.getString('braveAccountRowTitle')}
         </div>
         <div class="description">
           ${this.signedIn
             ? 'johndoe@gmail.com'
-            : '$i18n{braveAccountRowDescription}'}
+            : loadTimeData.getString('braveAccountRowDescription')}
         </div>
       </div>
       <leo-button kind=${this.signedIn ? 'outline' : 'filled'}
                   size="small"
                   @click=${this.onButtonClicked}>
         ${this.signedIn
-          ? '$i18n{braveAccountManageAccountButtonLabel}'
-          : '$i18n{braveAccountGetStartedButtonLabel}'
+          ? loadTimeData.getString('braveAccountManageAccountButtonLabel')
+          : loadTimeData.getString('braveAccountGetStartedButtonLabel')
         }
       </leo-button>
-    </div>
-  <!--_html_template_end_-->`
+    </div>`
 }

--- a/browser/resources/settings/getting_started_page/getting_started.html
+++ b/browser/resources/settings/getting_started_page/getting_started.html
@@ -1,5 +1,8 @@
 <style include="settings-shared md-select">
 </style>
+<template is="dom-if" if="[[isBraveAccountEnabled_]]">
+  <settings-brave-account-row></settings-brave-account-row>
+</template>
 <settings-people-page prefs="{{prefs}}"
   page-visibility="[[pageVisibility]]">
 </settings-people-page>

--- a/browser/resources/settings/getting_started_page/getting_started.ts
+++ b/browser/resources/settings/getting_started_page/getting_started.ts
@@ -4,7 +4,9 @@
 // you can obtain one at https://mozilla.org/MPL/2.0/.
 
 import {PolymerElement} from 'chrome://resources/polymer/v3_0/polymer/polymer_bundled.min.js'
+import {loadTimeData} from 'chrome://resources/js/load_time_data.js'
 
+import './brave_account_row.js'
 import '../people_page/people_page.js'
 import '../settings_page/settings_animated_pages.js'
 import '../default_browser_page/default_browser_page.js'
@@ -24,6 +26,17 @@ export class BraveSettingsGettingStarted extends PolymerElement {
   static get template() {
     return getTemplate()
   }
+
+  static get properties() {
+    return {
+      isBraveAccountEnabled_: {
+        type: Boolean,
+        value: () => loadTimeData.getBoolean('isBraveAccountEnabled'),
+      },
+    }
+  }
+
+  declare private isBraveAccountEnabled_: boolean
 }
 
 customElements.define(BraveSettingsGettingStarted.is, BraveSettingsGettingStarted);

--- a/browser/sources.gni
+++ b/browser/sources.gni
@@ -151,6 +151,7 @@ brave_chrome_browser_deps = [
   "//brave/components/ai_chat/core/common/mojom",
   "//brave/components/ai_rewriter/common/buildflags",
   "//brave/components/body_sniffer",
+  "//brave/components/brave_account:features",
   "//brave/components/brave_adaptive_captcha",
   "//brave/components/brave_ads/browser",
   "//brave/components/brave_ads/core",

--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -311,6 +311,7 @@ source_set("ui") {
       "//brave/browser/ui/sidebar",
       "//brave/browser/ui/tabs:split_view",
       "//brave/common",
+      "//brave/components/brave_account:features",
       "//brave/components/brave_account/mojom",
       "//brave/components/constants",
       "//brave/components/email_aliases:features",

--- a/browser/ui/webui/brave_account/BUILD.gn
+++ b/browser/ui/webui/brave_account/BUILD.gn
@@ -12,6 +12,7 @@ source_set("brave_account") {
   deps = [
     "//base",
     "//brave/components/brave_account",
+    "//brave/components/brave_account:features",
     "//brave/components/constants",
     "//chrome/browser/profiles",
     "//chrome/browser/ui/webui",

--- a/browser/ui/webui/brave_account/brave_account_ui.cc
+++ b/browser/ui/webui/brave_account/brave_account_ui.cc
@@ -5,6 +5,7 @@
 
 #include "brave/browser/ui/webui/brave_account/brave_account_ui.h"
 
+#include "base/check.h"
 #include "base/functional/bind.h"
 #include "brave/components/brave_account/features.h"
 #include "brave/components/constants/webui_url_constants.h"
@@ -20,9 +21,6 @@ BraveAccountUI::BraveAccountUI(content::WebUI* web_ui)
 WEB_UI_CONTROLLER_TYPE_IMPL(BraveAccountUI)
 
 BraveAccountUIConfig::BraveAccountUIConfig()
-    : DefaultWebUIConfig(content::kChromeUIScheme, kBraveAccountHost) {}
-
-bool BraveAccountUIConfig::IsWebUIEnabled(
-    content::BrowserContext* browser_context) {
-  return brave_account::features::IsBraveAccountEnabled();
+    : DefaultWebUIConfig(content::kChromeUIScheme, kBraveAccountHost) {
+  CHECK(brave_account::features::IsBraveAccountEnabled());
 }

--- a/browser/ui/webui/brave_account/brave_account_ui.cc
+++ b/browser/ui/webui/brave_account/brave_account_ui.cc
@@ -6,6 +6,7 @@
 #include "brave/browser/ui/webui/brave_account/brave_account_ui.h"
 
 #include "base/functional/bind.h"
+#include "brave/components/brave_account/features.h"
 #include "brave/components/constants/webui_url_constants.h"
 #include "chrome/browser/profiles/profile.h"
 #include "content/public/common/url_constants.h"
@@ -23,5 +24,5 @@ BraveAccountUIConfig::BraveAccountUIConfig()
 
 bool BraveAccountUIConfig::IsWebUIEnabled(
     content::BrowserContext* browser_context) {
-  return false;
+  return brave_account::features::IsBraveAccountEnabled();
 }

--- a/browser/ui/webui/brave_account/brave_account_ui.h
+++ b/browser/ui/webui/brave_account/brave_account_ui.h
@@ -13,7 +13,6 @@
 #include "content/public/browser/webui_config.h"
 
 namespace content {
-class BrowserContext;
 class WebUI;
 }  // namespace content
 
@@ -30,9 +29,6 @@ class BraveAccountUIConfig
     : public content::DefaultWebUIConfig<BraveAccountUI> {
  public:
   BraveAccountUIConfig();
-
-  // content::WebUIConfig:
-  bool IsWebUIEnabled(content::BrowserContext* browser_context) override;
 };
 
 #endif  // BRAVE_BROWSER_UI_WEBUI_BRAVE_ACCOUNT_BRAVE_ACCOUNT_UI_H_

--- a/browser/ui/webui/brave_settings_ui.cc
+++ b/browser/ui/webui/brave_settings_ui.cc
@@ -31,6 +31,7 @@
 #include "brave/browser/ui/webui/settings/default_brave_shields_handler.h"
 #include "brave/components/ai_chat/core/browser/utils.h"
 #include "brave/components/ai_chat/core/common/features.h"
+#include "brave/components/brave_account/features.h"
 #include "brave/components/brave_vpn/common/buildflags/buildflags.h"
 #include "brave/components/brave_vpn/common/features.h"
 #include "brave/components/brave_wallet/common/common_utils.h"
@@ -215,6 +216,8 @@ void BraveSettingsUI::AddResources(content::WebUIDataSource* html_source,
       "isContainersEnabled",
       base::FeatureList::IsEnabled(containers::features::kContainers));
 #endif
+  html_source->AddBoolean("isBraveAccountEnabled",
+                          brave_account::features::IsBraveAccountEnabled());
 }
 
 // static

--- a/browser/ui/webui/settings/brave_settings_localized_strings_provider.cc
+++ b/browser/ui/webui/settings/brave_settings_localized_strings_provider.cc
@@ -12,6 +12,7 @@
 #include "brave/browser/ui/webui/brave_settings_ui.h"
 #include "brave/browser/ui/webui/settings/brave_privacy_handler.h"
 #include "brave/components/ai_chat/core/browser/model_validator.h"
+#include "brave/components/brave_account/features.h"
 #include "brave/components/brave_news/common/pref_names.h"
 #include "brave/components/brave_rewards/core/pref_names.h"
 #include "brave/components/brave_shields/core/common/features.h"
@@ -156,15 +157,6 @@ void BraveAddCommonStrings(content::WebUIDataSource* html_source,
       {"siteSettingsLocalhostAccessAllowExceptions",
        IDS_SETTINGS_SITE_SETTINGS_LOCALHOST_ACCESS_ALLOW_EXCEPTIONS},
       {"braveGetStartedTitle", IDS_SETTINGS_BRAVE_GET_STARTED_TITLE},
-      // <Brave Account Row>
-      {"braveAccountRowTitle", IDS_SETTINGS_BRAVE_ACCOUNT_ROW_TITLE},
-      {"braveAccountRowDescription",
-       IDS_SETTINGS_BRAVE_ACCOUNT_ROW_DESCRIPTION},
-      {"braveAccountGetStartedButtonLabel",
-       IDS_SETTINGS_BRAVE_ACCOUNT_GET_STARTED_BUTTON_LABEL},
-      {"braveAccountManageAccountButtonLabel",
-       IDS_SETTINGS_BRAVE_ACCOUNT_MANAGE_ACCOUNT_BUTTON_LABEL},
-      // </Brave Account Row>
       {"siteSettingsShields", IDS_SETTINGS_SITE_SETTINGS_SHIELDS},
       {"siteSettingsShieldsStatus", IDS_SETTINGS_SITE_SETTINGS_SHIELDS_STATUS},
       {"siteSettingsShieldsUp", IDS_SETTINGS_SITE_SETTINGS_SHIELDS_UP},
@@ -1102,6 +1094,24 @@ void BraveAddEmailAliasesStrings(content::WebUIDataSource* html_source) {
   html_source->AddLocalizedStrings(localized_strings);
 }
 
+void BraveAddBraveAccountStrings(content::WebUIDataSource* html_source) {
+  if (!brave_account::features::IsBraveAccountEnabled()) {
+    return;
+  }
+
+  webui::LocalizedString localized_strings[] = {
+      {"braveAccountRowTitle", IDS_SETTINGS_BRAVE_ACCOUNT_ROW_TITLE},
+      {"braveAccountRowDescription",
+       IDS_SETTINGS_BRAVE_ACCOUNT_ROW_DESCRIPTION},
+      {"braveAccountGetStartedButtonLabel",
+       IDS_SETTINGS_BRAVE_ACCOUNT_GET_STARTED_BUTTON_LABEL},
+      {"braveAccountManageAccountButtonLabel",
+       IDS_SETTINGS_BRAVE_ACCOUNT_MANAGE_ACCOUNT_BUTTON_LABEL},
+  };
+
+  html_source->AddLocalizedStrings(localized_strings);
+}
+
 }  // namespace
 
 void BraveAddLocalizedStrings(content::WebUIDataSource* html_source,
@@ -1112,6 +1122,7 @@ void BraveAddLocalizedStrings(content::WebUIDataSource* html_source,
   BravePrivacyHandler::AddLoadTimeData(html_source, profile);
   BraveAddSyncStrings(html_source);
   BraveAddEmailAliasesStrings(html_source);
+  BraveAddBraveAccountStrings(html_source);
 
   // Load time data for brave://settings/extensions
   html_source->AddBoolean(

--- a/browser/ui/webui/sources.gni
+++ b/browser/ui/webui/sources.gni
@@ -13,6 +13,7 @@ brave_browser_ui_webui_configs_deps = [
   "//base",
   "//brave/brave_domains",
   "//brave/browser/ui",
+  "//brave/components/brave_account:features",
   "//brave/components/brave_education:buildflags",
   "//brave/components/brave_private_cdn",
   "//brave/components/brave_shields/content/browser",

--- a/chromium_src/chrome/browser/ui/webui/DEPS
+++ b/chromium_src/chrome/browser/ui/webui/DEPS
@@ -3,6 +3,7 @@ include_rules = [
   "+brave/components/webui",
   "+brave/components/version_info",
   "+brave/components/ai_chat/core/common",
+  "+brave/components/brave_account/features.h",
   "+brave/components/brave_vpn/common",
   "+brave/components/playlist/common",
   "+brave/components/brave_private_cdn",

--- a/chromium_src/chrome/browser/ui/webui/chrome_web_ui_configs.cc
+++ b/chromium_src/chrome/browser/ui/webui/chrome_web_ui_configs.cc
@@ -6,7 +6,9 @@
 #include "chrome/browser/ui/webui/chrome_web_ui_configs.h"
 
 #include "brave/browser/ui/webui/ai_chat/ai_chat_ui.h"
+#include "brave/browser/ui/webui/brave_account/brave_account_ui.h"
 #include "brave/components/ai_chat/core/common/features.h"
+#include "brave/components/brave_account/features.h"
 #include "brave/components/brave_education/buildflags.h"
 #include "content/public/browser/webui_config_map.h"
 
@@ -28,7 +30,6 @@
 #include "brave/browser/ui/webui/new_tab_takeover/android/new_tab_takeover_ui_config.h"
 #endif  // !BUILDFLAG(IS_ANDROID)
 
-#include "brave/browser/ui/webui/brave_account/brave_account_ui.h"
 #include "brave/browser/ui/webui/brave_adblock_internals_ui.h"
 #include "brave/browser/ui/webui/brave_adblock_ui.h"
 
@@ -86,12 +87,15 @@ void RegisterChromeWebUIConfigs() {
 #else   // !BUILDFLAG(IS_ANDROID)
   map.AddWebUIConfig(std::make_unique<NewTabTakeoverUIConfig>());
 #endif  // !BUILDFLAG(IS_ANDROID)
-  map.AddWebUIConfig(std::make_unique<BraveAccountUIConfig>());
   map.AddWebUIConfig(std::make_unique<BraveAdblockUIConfig>());
   map.AddWebUIConfig(std::make_unique<BraveAdblockInternalsUIConfig>());
 
   if (ai_chat::features::IsAIChatEnabled()) {
     map.AddWebUIConfig(std::make_unique<AIChatUIConfig>());
+  }
+
+  if (brave_account::features::IsBraveAccountEnabled()) {
+    map.AddWebUIConfig(std::make_unique<BraveAccountUIConfig>());
   }
 
 #if BUILDFLAG(ENABLE_BRAVE_EDUCATION)

--- a/components/brave_account/BUILD.gn
+++ b/components/brave_account/BUILD.gn
@@ -19,3 +19,12 @@ source_set("brave_account") {
     "//ui/base",
   ]
 }
+
+source_set("features") {
+  sources = [
+    "features.cc",
+    "features.h",
+  ]
+
+  deps = [ "//base" ]
+}

--- a/components/brave_account/BUILD.gn
+++ b/components/brave_account/BUILD.gn
@@ -8,6 +8,7 @@ source_set("brave_account") {
 
   deps = [
     "//base",
+    "//brave/components/brave_account:features",
     "//brave/components/brave_account/resources",
     "//brave/components/constants",
     "//brave/components/password_strength_meter",

--- a/components/brave_account/brave_account_ui_base.h
+++ b/components/brave_account/brave_account_ui_base.h
@@ -8,9 +8,11 @@
 
 #include <utility>
 
+#include "base/check.h"
 #include "base/containers/span.h"
 #include "base/functional/callback_forward.h"
 #include "base/functional/callback_helpers.h"
+#include "brave/components/brave_account/features.h"
 #include "brave/components/brave_account/resources/grit/brave_account_resources.h"
 #include "brave/components/brave_account/resources/grit/brave_account_resources_map.h"
 #include "brave/components/constants/webui_url_constants.h"
@@ -39,6 +41,8 @@ class BraveAccountUIBase {
       base::OnceCallback<
           void(WebUIDataSource*, base::span<const webui::ResourcePath>, int)>
           setup_webui_data_source = base::DoNothing()) {
+    CHECK(brave_account::features::IsBraveAccountEnabled());
+
     auto* source = WebUIDataSource::CreateAndAdd(profile, kBraveAccountHost);
     std::move(setup_webui_data_source)
         .Run(source, kBraveAccountResources,

--- a/components/brave_account/features.cc
+++ b/components/brave_account/features.cc
@@ -7,12 +7,10 @@
 
 namespace brave_account::features {
 
-BASE_FEATURE(kEnableBraveAccount,
-             "BraveAccount",
-             base::FEATURE_DISABLED_BY_DEFAULT);
+BASE_FEATURE(kBraveAccount, "BraveAccount", base::FEATURE_DISABLED_BY_DEFAULT);
 
 bool IsBraveAccountEnabled() {
-  return base::FeatureList::IsEnabled(kEnableBraveAccount);
+  return base::FeatureList::IsEnabled(kBraveAccount);
 }
 
 }  // namespace brave_account::features

--- a/components/brave_account/features.cc
+++ b/components/brave_account/features.cc
@@ -1,0 +1,18 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_account/features.h"
+
+namespace brave_account::features {
+
+BASE_FEATURE(kEnableBraveAccount,
+             "BraveAccount",
+             base::FEATURE_DISABLED_BY_DEFAULT);
+
+bool IsBraveAccountEnabled() {
+  return base::FeatureList::IsEnabled(kEnableBraveAccount);
+}
+
+}  // namespace brave_account::features

--- a/components/brave_account/features.h
+++ b/components/brave_account/features.h
@@ -1,0 +1,19 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_ACCOUNT_FEATURES_H_
+#define BRAVE_COMPONENTS_BRAVE_ACCOUNT_FEATURES_H_
+
+#include "base/feature_list.h"
+
+namespace brave_account::features {
+
+BASE_DECLARE_FEATURE(kEnableBraveAccount);
+
+bool IsBraveAccountEnabled();
+
+}  // namespace brave_account::features
+
+#endif  // BRAVE_COMPONENTS_BRAVE_ACCOUNT_FEATURES_H_

--- a/components/brave_account/features.h
+++ b/components/brave_account/features.h
@@ -10,7 +10,7 @@
 
 namespace brave_account::features {
 
-BASE_DECLARE_FEATURE(kEnableBraveAccount);
+BASE_DECLARE_FEATURE(kBraveAccount);
 
 bool IsBraveAccountEnabled();
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ToolbarDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ToolbarDelegate.swift
@@ -341,6 +341,7 @@ extension BrowserViewController: TopToolbarDelegate {
       "ads-internals",
       "credits",
       "sync-internals",
+      "account",
     ]
     guard let host = url.host, supportedPages.contains(host) else {
       return false

--- a/ios/browser/api/features/BUILD.gn
+++ b/ios/browser/api/features/BUILD.gn
@@ -12,6 +12,7 @@ source_set("features") {
   deps = [
     "//base",
     "//brave/components/ai_chat/core/common:common",
+    "//brave/components/brave_account:features",
     "//brave/components/brave_component_updater/browser:browser",
     "//brave/components/brave_news/common:common",
     "//brave/components/brave_rewards/core:features",

--- a/ios/browser/api/features/DEPS
+++ b/ios/browser/api/features/DEPS
@@ -1,5 +1,6 @@
 include_rules = [
   "+brave/components/ai_chat/core/common/features.h",
+  "+brave/components/brave_account/features.h",
   "+brave/components/brave_component_updater/browser/features.h",
   "+brave/components/brave_news/common/features.h",
   "+brave/components/brave_rewards/core/features.h",

--- a/ios/browser/api/features/features.h
+++ b/ios/browser/api/features/features.h
@@ -67,6 +67,7 @@ OBJC_EXPORT
     Feature* kCosmeticFilteringExtraPerfMetrics;
 @property(class, nonatomic, readonly) Feature* kCosmeticFilteringJsPerformance;
 @property(class, nonatomic, readonly) Feature* kCosmeticFilteringSyncLoad;
+@property(class, nonatomic, readonly) Feature* kEnableBraveAccount;
 @property(class, nonatomic, readonly, nullable) Feature* kGeminiFeature;
 @property(class, nonatomic, readonly) Feature* kNTP;
 @property(class, nonatomic, readonly) Feature* kNativeBraveWalletFeature;

--- a/ios/browser/api/features/features.h
+++ b/ios/browser/api/features/features.h
@@ -67,7 +67,7 @@ OBJC_EXPORT
     Feature* kCosmeticFilteringExtraPerfMetrics;
 @property(class, nonatomic, readonly) Feature* kCosmeticFilteringJsPerformance;
 @property(class, nonatomic, readonly) Feature* kCosmeticFilteringSyncLoad;
-@property(class, nonatomic, readonly) Feature* kEnableBraveAccount;
+@property(class, nonatomic, readonly) Feature* kBraveAccount;
 @property(class, nonatomic, readonly, nullable) Feature* kGeminiFeature;
 @property(class, nonatomic, readonly) Feature* kNTP;
 @property(class, nonatomic, readonly) Feature* kNativeBraveWalletFeature;

--- a/ios/browser/api/features/features.mm
+++ b/ios/browser/api/features/features.mm
@@ -8,6 +8,7 @@
 #include "base/memory/raw_ptr.h"
 #include "base/strings/sys_string_conversions.h"
 #include "brave/components/ai_chat/core/common/features.h"
+#include "brave/components/brave_account/features.h"
 #include "brave/components/brave_component_updater/browser/features.h"
 #include "brave/components/brave_news/common/features.h"
 #include "brave/components/brave_rewards/core/features.h"
@@ -270,6 +271,11 @@
 + (Feature*)kCosmeticFilteringSyncLoad {
   return [[Feature alloc]
       initWithFeature:&brave_shields::features::kCosmeticFilteringSyncLoad];
+}
+
++ (Feature*)kEnableBraveAccount {
+  return [[Feature alloc]
+      initWithFeature:&brave_account::features::kEnableBraveAccount];
 }
 
 #if BUILDFLAG(ENABLE_GEMINI_WALLET)

--- a/ios/browser/api/features/features.mm
+++ b/ios/browser/api/features/features.mm
@@ -273,9 +273,9 @@
       initWithFeature:&brave_shields::features::kCosmeticFilteringSyncLoad];
 }
 
-+ (Feature*)kEnableBraveAccount {
-  return [[Feature alloc]
-      initWithFeature:&brave_account::features::kEnableBraveAccount];
++ (Feature*)kBraveAccount {
+  return
+      [[Feature alloc] initWithFeature:&brave_account::features::kBraveAccount];
 }
 
 #if BUILDFLAG(ENABLE_GEMINI_WALLET)

--- a/ios/browser/ui/webui/BUILD.gn
+++ b/ios/browser/ui/webui/BUILD.gn
@@ -17,6 +17,7 @@ source_set("webui") {
 
   deps = [
     "//base",
+    "//brave/components/brave_account:features",
     "//brave/components/constants",
     "//brave/components/webui",
     "//brave/ios/browser/ui/webui:data_sources",

--- a/ios/browser/ui/webui/DEPS
+++ b/ios/browser/ui/webui/DEPS
@@ -1,4 +1,5 @@
 include_rules = [
+  "+brave/components/brave_account/features.h",
   "+brave/components/constants",
   "+brave/components/webui",
   "+ios/web/webui",

--- a/ios/browser/ui/webui/brave_web_ui_controller_factory.mm
+++ b/ios/browser/ui/webui/brave_web_ui_controller_factory.mm
@@ -10,6 +10,7 @@
 #include "base/feature_list.h"
 #include "base/memory/ptr_util.h"
 #include "base/no_destructor.h"
+#include "brave/components/brave_account/features.h"
 #include "brave/components/constants/pref_names.h"
 #include "brave/components/constants/url_constants.h"
 #include "brave/components/constants/webui_url_constants.h"
@@ -65,7 +66,8 @@ WebUIIOSFactoryFunction GetWebUIIOSFactoryFunction(const GURL& url) {
 
   if (url_host == kAdsInternalsHost) {
     return &NewWebUIIOS<AdsInternalsUI>;
-  } else if (url_host == kBraveAccountHost) {
+  } else if (url_host == kBraveAccountHost &&
+             brave_account::features::IsBraveAccountEnabled()) {
     return &NewWebUIIOS<BraveAccountUI>;
   } else if (url_host == kSkusInternalsHost) {
     return &NewWebUIIOS<SkusInternalsUI>;


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/47085.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

## Test 1 (across all platforms: desktop, Android, and iOS):
### Ensure the Brave Account feature flag is hidden from the `brave://flags` UI.

**Steps:**
1. launch Brave normally (no flags)
2. navigate to `brave://flags`
3. search for `Brave Account`
4. no entries related to Brave Account should be shown

---

## Test 2 (across all platforms: desktop, Android, and iOS):
### Ensure `brave://account` does not load the Brave Account UI when the feature is not enabled.

**Steps:**
1. launch Brave normally (no flags)
2. navigate to `brave://account`
3. the Brave Account UI must not load (an error page should be shown)

---

## Test 3 (across all platforms: desktop, Android, and iOS):
### Verify that enabling Brave Account via `--enable-features=BraveAccount` allows access to the Brave Account UI.

**Steps:**
1. launch Brave using the `--enable-features=BraveAccount` flag
2. navigate to `brave://account`
3. the Brave Account UI should load successfully