### PR TITLE
Located tab modal dialog at the center of split tab in `SideBySide`

### DIFF
--- a/browser/ui/views/frame/brave_browser_view.h
+++ b/browser/ui/views/frame/brave_browser_view.h
@@ -142,6 +142,8 @@ class BraveBrowserView : public BrowserView,
   // commands::AcceleratorService:
   void OnAcceleratorsChanged(const commands::Accelerators& changed) override;
 
+  BraveMultiContentsView* GetBraveMultiContentsView() const;
+
   SidebarContainerView* sidebar_container_view() {
     return sidebar_container_view_;
   }
@@ -214,7 +216,6 @@ class BraveBrowserView : public BrowserView,
 #endif
 
   void UpdateSideBarHorizontalAlignment();
-  BraveMultiContentsView* GetBraveMultiContentsView() const;
   views::View* contents_separator_for_testing() const {
     return contents_separator_;
   }

--- a/browser/ui/views/frame/split_view/brave_multi_contents_view.cc
+++ b/browser/ui/views/frame/split_view/brave_multi_contents_view.cc
@@ -8,6 +8,7 @@
 #include "base/check.h"
 #include "brave/browser/ui/brave_browser.h"
 #include "brave/browser/ui/color/brave_color_id.h"
+#include "brave/browser/ui/views/frame/brave_browser_view.h"
 #include "brave/browser/ui/views/frame/brave_contents_view_util.h"
 #include "brave/browser/ui/views/split_view/split_view_location_bar.h"
 #include "brave/browser/ui/views/split_view/split_view_separator.h"
@@ -116,6 +117,8 @@ void BraveMultiContentsView::Layout(PassKey) {
   contents_container_views_[0]->SetBoundsRect(start_rect);
   resize_area_->SetBoundsRect(resize_rect);
   contents_container_views_[1]->SetBoundsRect(end_rect);
+
+  BraveBrowserView::From(browser_view_)->NotifyDialogPositionRequiresUpdate();
 }
 
 float BraveMultiContentsView::GetCornerRadius() const {

--- a/browser/ui/views/split_view/split_view_browsertest.cc
+++ b/browser/ui/views/split_view/split_view_browsertest.cc
@@ -384,6 +384,13 @@ IN_PROC_BROWSER_TEST_P(
     return web_view_bounds.CenterPoint().x() == dialog_bounds.CenterPoint().x();
   }));
 #else
+  // On macOS, this check is flaky. It seems widget position is not updated
+  // immediately. So, used loop like above on macOS.
+  // Why not using above checking in loop on all platform?
+  // Above checking in loop causes another weird |Widget::native_widget_|
+  // invalidation in the loop on other platforms(win/linux). Not sure why.
+  // Fortunately, below checking works well. So, testing differently on macOS
+  // and others.
   const auto dialog_bounds = widget->GetWindowBoundsInScreen();
   auto web_view_bounds = GetContentsWebView()->GetLocalBounds();
   views::View::ConvertRectToScreen(GetContentsWebView(), &web_view_bounds);

--- a/browser/ui/views/split_view/split_view_browsertest.cc
+++ b/browser/ui/views/split_view/split_view_browsertest.cc
@@ -376,12 +376,19 @@ IN_PROC_BROWSER_TEST_P(
   auto* widget = dialog->GetWidget();
   ASSERT_TRUE(widget);
 
+#if BUILDFLAG(IS_MAC)
+  ASSERT_TRUE(base::test::RunUntil([&]() {
+    const auto dialog_bounds = widget->GetWindowBoundsInScreen();
+    auto web_view_bounds = GetContentsWebView()->GetLocalBounds();
+    views::View::ConvertRectToScreen(GetContentsWebView(), &web_view_bounds);
+    return web_view_bounds.CenterPoint().x() == dialog_bounds.CenterPoint().x();
+  }));
+#else
   const auto dialog_bounds = widget->GetWindowBoundsInScreen();
-
   auto web_view_bounds = GetContentsWebView()->GetLocalBounds();
   views::View::ConvertRectToScreen(GetContentsWebView(), &web_view_bounds);
-
   EXPECT_EQ(web_view_bounds.CenterPoint().x(), dialog_bounds.CenterPoint().x());
+#endif
 }
 
 // This test can be flaky depending on the screen size. Our macOS CI doesn't


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/47077

Tab modal dialog should be centered in its tab instead of browser window when `SideBySide` is enabled.
Reused existing code of our split view for centering split view.

TEST=SplitViewWithTabDialogBrowserTest.JavascriptTabModalDialogView_DialogShouldBeCenteredToRelatedWebView

1. Launch Brave with `--enable-features=SideBySide`
2. Create split view
3. Load https://frozzipies.github.io/5sec.html in any split tab
4. Click `Test alert` and check alert dialog is centered in the tab

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
