### PR TITLE
[json64] Adding hooks to `serde_json_lenient`'s visitor

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -6,6 +6,7 @@
 import(
     "//brave/browser/brave_vpn/win/brave_vpn_wireguard_service/allowlist.gni")
 import("//brave/build/config.gni")
+import("//brave/build/redirect_cc.gni")
 import("//brave/components/brave_vpn/common/buildflags/buildflags.gni")
 import("//brave/tools/crates/config.gni")
 import("//build/config/locales.gni")

--- a/build/BUILD.gn
+++ b/build/BUILD.gn
@@ -4,6 +4,7 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import("//brave/build/config.gni")
+import("//brave/build/redirect_cc.gni")
 import("//build/config/compiler/compiler.gni")
 
 config("brave_chromium_src_support") {

--- a/build/config.gni
+++ b/build/config.gni
@@ -45,7 +45,6 @@ declare_args() {
 
   # Enables brave/tools/redirect_cc target, replaces brave/chromium_src
   # overrides with empty ones to make //base buildable for redirect_cc.
-  is_redirect_cc_build = false
   android_aab_to_apk = false
 }
 

--- a/build/redirect_cc.gni
+++ b/build/redirect_cc.gni
@@ -1,0 +1,11 @@
+# Copyright (c) 2025 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+declare_args() {
+  # This flag indicates that this is a redirect_cc build.
+  # A redirect_cc build is a special, as it cannot make use of the
+  # `chromium_src` override mechanism that is available to a normal brave build.
+  is_redirect_cc_build = false
+}

--- a/chromium_src/base/json/json_reader.cc
+++ b/chromium_src/base/json/json_reader.cc
@@ -1,0 +1,35 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "src/base/json/json_reader.cc"
+
+#include "base/notimplemented.h"
+#include "third_party/rust/serde_json_lenient/v0_2/wrapper/lib.rs.h"
+
+namespace serde_json_lenient {
+
+// TODO(https://github.com/brave/brave-browser/issues/47120): These methods are
+// not implemented for now, but their purpose is to eventually hook up the
+// the `serde_json_lenient` to `base::Value`, and let us store binary blobs
+// whenever dealing with 64bit integers that cannot be represented in
+// `base::Value`.
+
+void list_append_i64(base::Value::List& ctx, int64_t val) {
+  NOTIMPLEMENTED();
+}
+
+void list_append_u64(base::Value::List& ctx, uint64_t val) {
+  NOTIMPLEMENTED();
+}
+
+void dict_set_i64(base::Value::Dict& ctx, rust::Str key, int64_t val) {
+  NOTIMPLEMENTED();
+}
+
+void dict_set_u64(base::Value::Dict& ctx, rust::Str key, uint64_t val) {
+  NOTIMPLEMENTED();
+}
+
+}  // namespace serde_json_lenient

--- a/chromium_src/third_party/rust/serde_json_lenient/v0_2/wrapper/DEPS
+++ b/chromium_src/third_party/rust/serde_json_lenient/v0_2/wrapper/DEPS
@@ -1,0 +1,8 @@
+# Copyright (c) 2025 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+include_rules = [
+  "+brave/components/json/buildflags/buildflags.h",
+]

--- a/chromium_src/third_party/rust/serde_json_lenient/v0_2/wrapper/functions.h
+++ b/chromium_src/third_party/rust/serde_json_lenient/v0_2/wrapper/functions.h
@@ -1,0 +1,37 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_THIRD_PARTY_RUST_SERDE_JSON_LENIENT_V0_2_WRAPPER_SERDE_JSON_LENIENT_H_
+#define BRAVE_CHROMIUM_SRC_THIRD_PARTY_RUST_SERDE_JSON_LENIENT_V0_2_WRAPPER_SERDE_JSON_LENIENT_H_
+
+#include <stdint.h>
+
+#include "brave/components/json/buildflags/buildflags.h"
+#include "third_party/rust/cxx/v1/cxx.h"
+
+// We only disable 64-bit integer support when building redirect_cc, which means
+// that `chromium_src` shadow inclusions like the one below do not work, and
+// therefore we have to cancel it, that both header and override file are being
+// added by the visitor.
+#if BUILDFLAG(ENABLE_JSON_64BIT_INT_SUPPORT)
+#include "src/third_party/rust/serde_json_lenient/v0_2/wrapper/functions.h"  // IWYU pragma: export
+#endif
+
+namespace base {
+class DictValue;
+class ListValue;
+}  // namespace base
+
+namespace serde_json_lenient {
+using Dict = base::DictValue;
+using List = base::ListValue;
+
+void list_append_i64(List& ctx, int64_t val);
+void list_append_u64(List& ctx, uint64_t val);
+void dict_set_i64(Dict& ctx, rust::Str key, int64_t val);
+void dict_set_u64(Dict& ctx, rust::Str key, uint64_t val);
+}  // namespace serde_json_lenient
+
+#endif  // BRAVE_CHROMIUM_SRC_THIRD_PARTY_RUST_SERDE_JSON_LENIENT_V0_2_WRAPPER_SERDE_JSON_LENIENT_H_

--- a/chromium_src/third_party/rust/serde_json_lenient/v0_2/wrapper/large_integers.rs
+++ b/chromium_src/third_party/rust/serde_json_lenient/v0_2/wrapper/large_integers.rs
@@ -1,0 +1,70 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#![allow(dead_code)]
+
+/// This source provides extra C++ bindings which are used to handle 64bit
+/// integers over base::Value types.
+#[cxx::bridge(namespace=serde_json_lenient)]
+mod ffi {
+    unsafe extern "C++" {
+        include!("brave/chromium_src/third_party/rust/serde_json_lenient/v0_2/wrapper/functions.h");
+
+        type Dict = crate::Dict;
+        type List = crate::List;
+
+        fn list_append_i64(ctx: Pin<&mut List>, val: i64);
+        fn list_append_u64(ctx: Pin<&mut List>, val: u64);
+        fn dict_set_i64(ctx: Pin<&mut Dict>, key: &str, val: i64);
+        fn dict_set_u64(ctx: Pin<&mut Dict>, key: &str, val: u64);
+    }
+}
+
+#[cfg(feature = "json_64bit_int_support")]
+pub use ffi::*;
+
+use crate::visitor::DeserializationTarget;
+
+/// The customisation point to provide custom handling for i64 base::Value.
+pub fn handle_large_i64<E: serde::de::Error>(
+    _aggregate: DeserializationTarget,
+    _value: i64,
+) -> Result<(), E> {
+    #[cfg(feature = "json_64bit_int_support")]
+    {
+        match _aggregate {
+            DeserializationTarget::List { ctx } => list_append_i64(ctx, _value),
+            DeserializationTarget::Dict { ctx, key } => dict_set_i64(ctx, key, _value),
+        }
+        Ok(())
+    }
+    #[cfg(not(feature = "json_64bit_int_support"))]
+    {
+        unreachable!(
+            "handle_large_i64 should not be called without the 'json_64bit_int_support' feature"
+        );
+    }
+}
+
+/// The customisation point to provide custom handling for u64 base::Value.
+pub fn handle_large_u64<E: serde::de::Error>(
+    _aggregate: DeserializationTarget,
+    _value: u64,
+) -> Result<(), E> {
+    #[cfg(feature = "json_64bit_int_support")]
+    {
+        match _aggregate {
+            DeserializationTarget::List { ctx } => list_append_u64(ctx, _value),
+            DeserializationTarget::Dict { ctx, key } => dict_set_u64(ctx, key, _value),
+        }
+        Ok(())
+    }
+    #[cfg(not(feature = "json_64bit_int_support"))]
+    {
+        unreachable!(
+            "handle_large_u64 should not be called without the 'json_64bit_int_support' feature"
+        );
+    }
+}

--- a/components/BUILD.gn
+++ b/components/BUILD.gn
@@ -20,6 +20,7 @@ test("brave_components_unittests") {
     "//brave/components/api_request_helper:unit_tests",
     "//brave/components/brave_wallet/browser:unit_tests",
     "//brave/components/brave_wallet/common:unit_tests",
+    "//brave/components/json:unit_tests",
     "//components/test:run_all_unittests",
   ]
 

--- a/components/json/BUILD.gn
+++ b/components/json/BUILD.gn
@@ -20,9 +20,10 @@ component("json") {
   ]
 }
 
-source_set("brave_json_unit_tests") {
+source_set("unit_tests") {
   testonly = true
-  sources = [ "//brave/components/json/json_parser_unittest.cc" ]
+  sources = [ "json_parser_unittest.cc" ]
+
   deps = [
     "//base",
     "//base/test:test_support",

--- a/components/json/buildflags/BUILD.gn
+++ b/components/json/buildflags/BUILD.gn
@@ -1,0 +1,12 @@
+# Copyright (c) 2025 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import("//brave/components/json/buildflags/features.gni")
+import("//build/buildflag_header.gni")
+
+buildflag_header("buildflags") {
+  header = "buildflags.h"
+  flags = [ "ENABLE_JSON_64BIT_INT_SUPPORT=$enable_json_64bit_int_support" ]
+}

--- a/components/json/buildflags/features.gni
+++ b/components/json/buildflags/features.gni
@@ -1,0 +1,10 @@
+# Copyright (c) 2025 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import("//brave/build/redirect_cc.gni")
+
+declare_args() {
+  enable_json_64bit_int_support = !is_redirect_cc_build
+}

--- a/patches/third_party-rust-serde_json_lenient-v0_2-wrapper-BUILD.gn.patch
+++ b/patches/third_party-rust-serde_json_lenient-v0_2-wrapper-BUILD.gn.patch
@@ -1,0 +1,12 @@
+diff --git a/third_party/rust/serde_json_lenient/v0_2/wrapper/BUILD.gn b/third_party/rust/serde_json_lenient/v0_2/wrapper/BUILD.gn
+index c1642f6b2d12e9aa0cb4661f6c4b9581e2ad4650..46eed9552f2489fd35c07348db7c5c8b9c06b90f 100644
+--- a/third_party/rust/serde_json_lenient/v0_2/wrapper/BUILD.gn
++++ b/third_party/rust/serde_json_lenient/v0_2/wrapper/BUILD.gn
+@@ -19,6 +19,7 @@ rust_static_library("wrapper") {
+     "//third_party/rust/serde/v1:lib",
+     "//third_party/rust/serde_json_lenient/v0_2:lib",
+   ]
++  import("//brave/components/json/buildflags/features.gni") public_deps += [ "//brave/components/json/buildflags" ] if (enable_json_64bit_int_support) { features = [ "json_64bit_int_support" ] } sources += [ "//brave/chromium_src/third_party/rust/serde_json_lenient/v0_2/wrapper/large_integers.rs" ] cxx_bindings += [ "//brave/chromium_src/third_party/rust/serde_json_lenient/v0_2/wrapper/large_integers.rs" ]
+ }
+ 
+ source_set("wrapper_functions") {

--- a/patches/third_party-rust-serde_json_lenient-v0_2-wrapper-lib.rs.patch
+++ b/patches/third_party-rust-serde_json_lenient-v0_2-wrapper-lib.rs.patch
@@ -1,0 +1,30 @@
+diff --git a/third_party/rust/serde_json_lenient/v0_2/wrapper/lib.rs b/third_party/rust/serde_json_lenient/v0_2/wrapper/lib.rs
+index c5e39138b1d25c8a534e97b9f79eeee5b8fba33b..bd61d4f60f5abff19b84dbe350f9110bdcef3c31 100644
+--- a/third_party/rust/serde_json_lenient/v0_2/wrapper/lib.rs
++++ b/third_party/rust/serde_json_lenient/v0_2/wrapper/lib.rs
+@@ -3,6 +3,7 @@
+ // found in the LICENSE file.
+ 
+ mod visitor;
++#[path = "../../../../../brave/chromium_src/third_party/rust/serde_json_lenient/v0_2/wrapper/large_integers.rs"] mod large_integers;
+ 
+ use crate::visitor::ValueVisitor;
+ 
+@@ -79,6 +80,8 @@ mod ffi {
+         /// The maximum recursion depth to walk while parsing nested JSON
+         /// objects. JSON beyond the specified depth will be ignored.
+         max_depth: usize,
++        /// Allows 64-bit integers rather than trying to fit than as double.
++        allow_64bit_numbers: bool,
+     }
+ }
+ 
+@@ -122,7 +125,7 @@ pub fn decode_json(
+ 
+     let target = visitor::DeserializationTarget::List { ctx };
+ 
+-    let result = deserializer.deserialize_any(ValueVisitor::new(target, options.max_depth));
++    let result = deserializer.deserialize_any(ValueVisitor::new(target, options.max_depth, options.allow_64bit_numbers));
+     match result.and(deserializer.end()) {
+         Ok(()) => true,
+         Err(err) => {

--- a/patches/third_party-rust-serde_json_lenient-v0_2-wrapper-visitor.rs.patch
+++ b/patches/third_party-rust-serde_json_lenient-v0_2-wrapper-visitor.rs.patch
@@ -1,0 +1,73 @@
+diff --git a/third_party/rust/serde_json_lenient/v0_2/wrapper/visitor.rs b/third_party/rust/serde_json_lenient/v0_2/wrapper/visitor.rs
+index c8f0c444c21fa229d9b87bcb26fb8390d6a025ac..9ee3500a8ea92833253b9c1decd8a5d96785a8ec 100644
+--- a/third_party/rust/serde_json_lenient/v0_2/wrapper/visitor.rs
++++ b/third_party/rust/serde_json_lenient/v0_2/wrapper/visitor.rs
+@@ -3,6 +3,7 @@
+ // found in the LICENSE file.
+ 
+ use crate::{ffi, Dict, List};
++use crate::large_integers::{handle_large_i64, handle_large_u64};
+ use serde::de::{DeserializeSeed, Deserializer, Error, MapAccess, SeqAccess, Visitor};
+ use std::borrow::Cow;
+ use std::convert::TryFrom;
+@@ -74,15 +75,17 @@ impl<'de> DeserializeSeed<'de> for CowStrVisitor {
+ pub struct ValueVisitor<'c, 'k> {
+     aggregate: DeserializationTarget<'c, 'k>,
+     recursion_depth_check: RecursionDepthCheck,
++    allow_64bit_numbers: bool,
+ }
+ 
+ impl<'c, 'k> ValueVisitor<'c, 'k> {
+-    pub fn new(target: DeserializationTarget<'c, 'k>, max_depth: usize) -> Self {
++    pub fn new(target: DeserializationTarget<'c, 'k>, max_depth: usize, allow_64bit_numbers: bool) -> Self {
+         Self {
+             aggregate: target,
+             // The `max_depth` includes the top level of the JSON input, which is where parsing
+             // starts. We subtract 1 to count the top level now.
+             recursion_depth_check: RecursionDepthCheck(max_depth - 1),
++            allow_64bit_numbers: allow_64bit_numbers,
+         }
+     }
+ }
+@@ -121,7 +124,11 @@ impl<'de> Visitor<'de> for ValueVisitor<'_, '_> {
+         // JSONReaderTest.LargerIntIsLossy for a related test.
+         match i32::try_from(value) {
+             Ok(value) => self.visit_i32(value),
+-            Err(_) => self.visit_f64(value as f64),
++            Err(_) => if !self.allow_64bit_numbers {
++                self.visit_f64(value as f64)
++            } else {
++                handle_large_i64(self.aggregate, value)
++            }
+         }
+     }
+ 
+@@ -129,7 +136,11 @@ impl<'de> Visitor<'de> for ValueVisitor<'_, '_> {
+         // See visit_i64 comment.
+         match i32::try_from(value) {
+             Ok(value) => self.visit_i32(value),
+-            Err(_) => self.visit_f64(value as f64),
++            Err(_) => if !self.allow_64bit_numbers {
++                self.visit_f64(value as f64)
++            } else {
++                handle_large_u64(self.aggregate, value)
++            }
+         }
+     }
+ 
+@@ -175,6 +186,7 @@ impl<'de> Visitor<'de> for ValueVisitor<'_, '_> {
+             access.next_value_seed(ValueVisitor {
+                 aggregate: DeserializationTarget::Dict { ctx: inner_ctx.as_mut(), key },
+                 recursion_depth_check: self.recursion_depth_check.recurse()?,
++                allow_64bit_numbers: self.allow_64bit_numbers,
+             })?;
+         }
+         Ok(())
+@@ -193,6 +205,7 @@ impl<'de> Visitor<'de> for ValueVisitor<'_, '_> {
+         while let Some(_) = access.next_element_seed(ValueVisitor {
+             aggregate: DeserializationTarget::List { ctx: inner_ctx.as_mut() },
+             recursion_depth_check: self.recursion_depth_check.recurse()?,
++            allow_64bit_numbers: self.allow_64bit_numbers,
+         })? {}
+         Ok(())
+     }

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -247,7 +247,6 @@ test("brave_unit_tests") {
     "//brave/components/history/core/browser:unit_tests",
     "//brave/components/history/core/browser/sync:unit_tests",
     "//brave/components/ipfs/test:brave_ipfs_unit_tests",
-    "//brave/components/json:brave_json_unit_tests",
     "//brave/components/l10n/common",
     "//brave/components/l10n/common:test_support",
     "//brave/components/l10n/common:unit_tests",


### PR DESCRIPTION
This PR is the first of a couple of changes to allow us to parse, and carry over JSON content 64bit integer representation. This is currently not possible, as Chromium's `base::Value` only support a range of integer values that is valid to be represented JS.

This work aims to store integer values outside the allowed boundaries as binary data into `base::Value`. This will be done through customisations to `base::JSONReader`, and `base::JSONWriter`. Additionally, most of the complexity will hopefully be hidden away by code generators in the json-schema-compiler.

This first PR adds hooks into the visitor for `serde_json_lenient` that will allow us to provide the special conversions to binary blob data for large 64bit values that fall outside of what can be represented as double without loss.

This PR is also introducing a build flag, namely,
`enable_json_64bit_int_support`, to allow us to have some compile time control over to switch this feature off. This is necessary, as `redirect_cc` cannot build `//brave/chromium_src` files the same way a normal Brave build does, and therefore it is necessary to be able to switch of these customisations in that mode.

Resolves https://github.com/brave/brave-browser/issues/47119

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
