### PR TITLE
Show tab hover state only on hovered split tab with SideBySide

### DIFF
--- a/browser/ui/views/split_view/split_view_browsertest.cc
+++ b/browser/ui/views/split_view/split_view_browsertest.cc
@@ -7,7 +7,6 @@
 
 #include <utility>
 
-#include "base/task/current_thread.h"
 #include "base/test/run_until.h"
 #include "brave/browser/brave_browser_features.h"
 #include "brave/browser/ui/browser_commands.h"
@@ -58,12 +57,6 @@ namespace {
 ui::MouseEvent GetDummyEvent() {
   return ui::MouseEvent(ui::EventType::kMousePressed, gfx::PointF(),
                         gfx::PointF(), base::TimeTicks::Now(), 0, 0);
-}
-
-void RunUntilIdle() {
-  DCHECK(base::CurrentThread::Get());
-  base::RunLoop loop;
-  loop.RunUntilIdle();
 }
 }  // namespace
 
@@ -240,8 +233,9 @@ IN_PROC_BROWSER_TEST_F(SideBySideEnabledBrowserTest, SelectTabTest) {
   EXPECT_EQ(hovered_split_tab->split(), not_hovered_split_tab->split());
   hovered_split_tab->controller()->ShowHover(hovered_split_tab,
                                              TabStyle::ShowHoverStyle::kSubtle);
-  RunUntilIdle();
-  EXPECT_NE(hovered_split_tab->tab_style_views()->GetHoverAnimationValue(), 0);
+  ASSERT_TRUE(base::test::RunUntil([&]() {
+    return hovered_split_tab->tab_style_views()->GetHoverAnimationValue() != 0;
+  }));
   EXPECT_EQ(not_hovered_split_tab->tab_style_views()->GetHoverAnimationValue(),
             0);
 

--- a/browser/ui/views/tabs/brave_tab_strip.cc
+++ b/browser/ui/views/tabs/brave_tab_strip.cc
@@ -127,6 +127,17 @@ bool BraveTabStrip::ShouldDrawStrokes() const {
   return contrast_ratio < kBraveMinimumContrastRatioForOutlines;
 }
 
+void BraveTabStrip::ShowHover(Tab* tab, TabStyle::ShowHoverStyle style) {
+  // Chromium asks hover style to all split tabs but we only set hover style
+  // to hovered tab.
+  tab->ShowHover(style);
+}
+
+void BraveTabStrip::HideHover(Tab* tab, TabStyle::HideHoverStyle style) {
+  // See the comment of ShowHover().
+  tab->HideHover(style);
+}
+
 void BraveTabStrip::UpdateHoverCard(Tab* tab, HoverCardUpdateType update_type) {
   if (brave_tabs::AreTooltipsEnabled(controller_->GetProfile()->GetPrefs())) {
     return;

--- a/browser/ui/views/tabs/brave_tab_strip.h
+++ b/browser/ui/views/tabs/brave_tab_strip.h
@@ -27,6 +27,8 @@ class BraveTabStrip : public TabStrip {
   TabTiledState GetTiledStateForTab(int index) const;
 
   // TabStrip:
+  void ShowHover(Tab* tab, TabStyle::ShowHoverStyle style) override;
+  void HideHover(Tab* tab, TabStyle::HideHoverStyle style) override;
   void UpdateHoverCard(Tab* tab, HoverCardUpdateType update_type) override;
   void MaybeStartDrag(
       TabSlotView* source,


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/47126

Chromium set hovered state when any tab in split tabs is hovered.
But we only want hover effect only on hovered tab in split tab.

TEST=SideBySideEnabledBrowserTest.SelectTabTest

Manual test:
1. Open Brave with `--enable-features=SideBySide`
2. Open split tabs
3. Hover on tab in split tab
4. Check only that hovered tab has hover effect

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
