### PR TITLE
[AI Chat]: Fix Small and Cut Button Menus

### DIFF
--- a/components/ai_chat/resources/page/chat_ui.tsx
+++ b/components/ai_chat/resources/page/chat_ui.tsx
@@ -96,13 +96,22 @@ function ConversationEntries(props: ConversationEntriesProps) {
       // Use the first height change to notify that the iframe has rendered,
       // in lieu of an actual "has rendered the conversation entries" event
       // which, if we get any bugs with this and need to add complexity, might
-      // be simpler to implement excplicitly, from child -> parent.
+      // be simpler to implement explicitly, from child -> parent.
       if (!hasNotifiedContentReady.current && height > 0) {
         hasNotifiedContentReady.current = true
         props.onIsContentReady(true)
       }
       if (iframeRef.current) {
-        iframeRef.current.style.height = height + 'px'
+        // Additional height is added here to address the issue where the
+        // button menu's get cut off when the conversation is short since
+        // they cant be rendered outside of the iframe.
+        // See https://github.com/brave/brave-browser/issues/46042
+        const additionalHeight = Math.max(0, 500 - height)
+        document.body.style.setProperty(
+          '--iframe-additional-margin-for-menus',
+          additionalHeight + 'px'
+        )
+        iframeRef.current.style.height = (height + additionalHeight) + 'px'
         props.onHeightChanged()
       }
     }

--- a/components/ai_chat/resources/page/components/main/index.tsx
+++ b/components/ai_chat/resources/page/components/main/index.tsx
@@ -242,7 +242,10 @@ function Main() {
                   </div>
                 )}
 
-                <div ref={scrollAnchor}>
+                <div
+                  className={styles.aichatIframeContainer}
+                  ref={scrollAnchor}
+                >
                   {!!conversationContext.conversationUuid &&
                     <aiChatContext.conversationEntriesComponent
                       onIsContentReady={setIsContentReady}

--- a/components/ai_chat/resources/page/components/main/style.module.scss
+++ b/components/ai_chat/resources/page/components/main/style.module.scss
@@ -229,3 +229,10 @@
 .feedbackForm {
   padding: 0 16px;
 }
+
+.aichatIframeContainer {
+  // Negative margin to account for the additional height
+  // added to the iframe.
+  // See https://github.com/brave/brave-browser/issues/46042
+  margin-bottom: calc(-1 * var(--iframe-additional-margin-for-menus));
+}


### PR DESCRIPTION
## Description 

Fixes a couple bugs where when a conversation is really small. The edit human message menu would get cut off and the regenerate answer menu would be supper small.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/46042>
Resolves <https://github.com/brave/brave-browser/issues/46741>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->


Before:

![image](https://github.com/user-attachments/assets/d370e6d6-b0f3-47d8-8546-fc20f996328b) | ![image](https://github.com/user-attachments/assets/8d219794-aa8d-49b2-944e-4f7b4aea165e)
--|--

After:

![image](https://github.com/user-attachments/assets/32b408a5-e4b1-4e0e-b373-a5e435f9f50a) | ![image](https://github.com/user-attachments/assets/8bd5f62d-d8cd-4820-a1b8-b9cfc39136d2)
--|--
