### PR TITLE
Fixed crash when creating split view with SideBySide

### DIFF
--- a/browser/ui/views/split_view/split_view_browsertest.cc
+++ b/browser/ui/views/split_view/split_view_browsertest.cc
@@ -379,6 +379,23 @@ class SplitViewWithTabDialogBrowserTest
   base::test::ScopedFeatureList scoped_features_;
 };
 
+// Check split view works with pinned tabs.
+IN_PROC_BROWSER_TEST_P(SplitViewWithTabDialogBrowserTest,
+                       SplitViewWithPinnedTabTest) {
+  auto* tab_strip_model = browser()->tab_strip_model();
+  tab_strip_model->SetTabPinned(0, true);
+  chrome::AddTabAt(browser(), GURL(), -1, /*foreground*/ true);
+  EXPECT_EQ(1, tab_strip_model->active_index());
+  NewSplitTab();
+  EXPECT_EQ(2, tab_strip_model->active_index());
+
+  brave::ToggleVerticalTabStrip(browser());
+  chrome::AddTabAt(browser(), GURL(), -1, /*foreground*/ true);
+  EXPECT_EQ(3, tab_strip_model->active_index());
+  NewSplitTab();
+  EXPECT_EQ(4, tab_strip_model->active_index());
+}
+
 IN_PROC_BROWSER_TEST_P(SplitViewWithTabDialogBrowserTest,
                        BookmarksBarVisibilityTest) {
   auto* prefs = browser()->profile()->GetPrefs();

--- a/browser/ui/views/tabs/brave_tab_container.h
+++ b/browser/ui/views/tabs/brave_tab_container.h
@@ -55,6 +55,7 @@ class BraveTabContainer : public TabContainerImpl,
   void Layout(PassKey) override;
   void OnSplitCreated(const std::vector<int>& indices) override;
   void OnSplitRemoved(const std::vector<int>& indices) override;
+  void OnSplitContentsChanged(const std::vector<int>& indices) override;
 
   // BrowserRootView::DropTarget
   std::optional<BrowserRootView::DropIndex> GetDropIndex(


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/47109

Passed tab indices to `TabContainer::OnSplitCreated()` is TabStripModel's index not the each tab container's.
Because of that, that value should be adjusted by checking pinned tab existence.
Otherwise, that index could be invalid one in unpinned tab container.

TEST=`SplitViewWithTabDialogBrowserTest.SplitViewWithPinnedTabTest`
Manual test:
1. Launch Brave with `--enable-features=SideBySide`
2. Changed to vertical tab
3. Create pinned tab
4. Create another new tab and create split view
5. Check no crash

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
