### PR TITLE
QSE is shown twice in the scroll view after searching in multiple tabs (uplift to 1.81.x)

### DIFF
--- a/browser/quick_search_engines/android/java/src/org/chromium/brave/browser/quick_search_engines/utils/QuickSearchEnginesUtil.java
+++ b/browser/quick_search_engines/android/java/src/org/chromium/brave/browser/quick_search_engines/utils/QuickSearchEnginesUtil.java
@@ -29,6 +29,8 @@ import org.chromium.net.NetworkTrafficAnnotationTag;
 import org.chromium.url.GURL;
 
 import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -200,6 +202,28 @@ public class QuickSearchEnginesUtil {
         }
         // Remove default search engine from quick search options
         removeDefaultSearchEngine(searchEnginesMap, defaultSearchEngine);
+        // Remove models that have equal short names in a similar
+        // way as we do in Search engines settings inside
+        // BraveBaseSearchEngineAdapter.sortAndFilterUnnecessaryTemplateUrl
+        filterUnnecessaryModels(searchEnginesMap);
+    }
+
+    /**
+     * Filters out models that have equal short names
+     *
+     * @param searchEnginesMap Map of search engine keywords to their QuickSearchEnginesModel
+     */
+    private static void filterUnnecessaryModels(
+            Map<String, QuickSearchEnginesModel> searchEnginesMap) {
+        final Iterator<Map.Entry<String, QuickSearchEnginesModel>> iter =
+                searchEnginesMap.entrySet().iterator();
+        final HashSet<String> valueSet = new HashSet<>();
+        while (iter.hasNext()) {
+            final Map.Entry<String, QuickSearchEnginesModel> next = iter.next();
+            if (!valueSet.add(next.getValue().getShortName())) {
+                iter.remove();
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
Uplift of #29791
Resolves https://github.com/brave/brave-browser/issues/46886

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.