### PR TITLE
[SideBySide] Updated pinned split tabs position in vertical tabs

### DIFF
--- a/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.h
+++ b/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.h
@@ -134,6 +134,8 @@ class VerticalTabStripRegionView : public views::View,
   FRIEND_TEST_ALL_PREFIXES(VerticalTabStripBrowserTest, ExpandedWidth);
   FRIEND_TEST_ALL_PREFIXES(VerticalTabStripBrowserTest,
                            LayoutAfterFirstTabCreation);
+  FRIEND_TEST_ALL_PREFIXES(SideBySideEnabledBrowserTest,
+                           PinnedSplitTabsLayoutInVerticalTabTest);
 
   FullscreenController* GetFullscreenController() const;
   bool IsTabFullscreen() const;

--- a/browser/ui/views/split_view/BUILD.gn
+++ b/browser/ui/views/split_view/BUILD.gn
@@ -39,6 +39,7 @@ source_set("browser_tests") {
     "//base",
     "//brave/browser/ui/tabs:split_view",
     "//brave/browser/ui/views/frame/split_view",
+    "//brave/browser/ui/views/frame/vertical_tabs",
     "//brave/browser/ui/views/split_view",
     "//chrome/browser/ui",
     "//chrome/browser/ui:ui_features",

--- a/browser/ui/views/split_view/split_view_browsertest.cc
+++ b/browser/ui/views/split_view/split_view_browsertest.cc
@@ -17,6 +17,8 @@
 #include "brave/browser/ui/views/brave_javascript_tab_modal_dialog_view_views.h"
 #include "brave/browser/ui/views/frame/brave_browser_view.h"
 #include "brave/browser/ui/views/frame/split_view/brave_multi_contents_view.h"
+#include "brave/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.h"
+#include "brave/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_widget_delegate_view.h"
 #include "brave/browser/ui/views/split_view/split_view_layout_manager.h"
 #include "brave/browser/ui/views/split_view/split_view_separator.h"
 #include "chrome/browser/profiles/profile.h"
@@ -124,6 +126,62 @@ class SideBySideEnabledBrowserTest : public InProcessBrowserTest {
  private:
   base::test::ScopedFeatureList scoped_features_;
 };
+
+IN_PROC_BROWSER_TEST_F(SideBySideEnabledBrowserTest,
+                       PinnedSplitTabsLayoutInVerticalTabTest) {
+  ToggleVerticalTabStrip();
+
+  // Create enough pinned tabs including split tabs.
+  chrome::AddTabAt(browser(), GURL(), -1, /*foreground*/ true);
+  chrome::PinTab(browser());
+  chrome::AddTabAt(browser(), GURL(), -1, /*foreground*/ true);
+  chrome::PinTab(browser());
+
+  chrome::AddTabAt(browser(), GURL(), -1, /*foreground*/ true);
+  chrome::NewSplitTab(browser());
+  chrome::PinTab(browser());
+
+  chrome::AddTabAt(browser(), GURL(), -1, /*foreground*/ true);
+  chrome::PinTab(browser());
+
+  chrome::AddTabAt(browser(), GURL(), -1, /*foreground*/ true);
+  chrome::NewSplitTab(browser());
+  chrome::PinTab(browser());
+
+  tab_strip()->StopAnimating(/* layout= */ true);
+  auto* widget_delegate_view =
+      brave_browser_view()->vertical_tab_strip_widget_delegate_view();
+  ASSERT_TRUE(widget_delegate_view);
+
+  auto* region_view = widget_delegate_view->vertical_tab_strip_region_view();
+  ASSERT_TRUE(region_view);
+  ASSERT_EQ(VerticalTabStripRegionView::State::kExpanded, region_view->state());
+
+  auto check_split_tabs_has_same_y_position = [&]() {
+    auto* model = browser()->tab_strip_model();
+    const int tab_count = model->count();
+    for (int i = 0; i < tab_count; i++) {
+      auto* tab = tab_strip()->tab_at(i);
+      if (tab_count != (i + 1) && tab->split().has_value() &&
+          tab->split() == tab_strip()->tab_at(i + 1)->split()) {
+        // Check each split tab has same y-position.
+        EXPECT_EQ(tab->y(), tab_strip()->tab_at(i + 1)->y());
+      }
+    }
+  };
+
+  // check_split_tabs_has_same_y_position();
+  const auto initial_width = region_view->expanded_width_;
+  while (region_view->expanded_width_ >= (initial_width / 2)) {
+    check_split_tabs_has_same_y_position();
+    region_view->SetExpandedWidth(region_view->expanded_width_ - 20);
+  }
+
+  while (region_view->expanded_width_ < initial_width) {
+    check_split_tabs_has_same_y_position();
+    region_view->SetExpandedWidth(region_view->expanded_width_ + 20);
+  }
+}
 
 IN_PROC_BROWSER_TEST_F(SideBySideEnabledBrowserTest,
                        BraveMultiContentsViewTest) {

--- a/browser/ui/views/split_view/split_view_browsertest.cc
+++ b/browser/ui/views/split_view/split_view_browsertest.cc
@@ -170,7 +170,6 @@ IN_PROC_BROWSER_TEST_F(SideBySideEnabledBrowserTest,
     }
   };
 
-  // check_split_tabs_has_same_y_position();
   const auto initial_width = region_view->expanded_width_;
   while (region_view->expanded_width_ >= (initial_width / 2)) {
     check_split_tabs_has_same_y_position();


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/47338

Whenever each tabs in same split tab are positioned in different line due to the lack of available width,
their background was painted for wrong region because we calculate split tab's background rect by using
left tab's origin and right tab's bottom right. Fixed by locating two tabs always in the same horizontal line.

TEST=SideBySideEnabledBrowserTest.PinnedSplitTabsLayoutInVerticalTabTest

Manual test:
1. Launch Brave with `--enable-features=SideBySide`
2. Turn on vertical tabs
3. Create many pinned tabs and pinned split tabs
4. Resize vertical tab and check two tabs of same split tabs are always located in the same horizontal line


https://github.com/user-attachments/assets/3e0b0e77-dfc1-44a9-b7de-adaaaf5012a0



<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
