### PR TITLE
[CodeHealth] `PRESUBMIT` check for `nogncheck`

### DIFF
--- a/PRESUBMIT.py
+++ b/PRESUBMIT.py
@@ -350,9 +350,20 @@ _BANNED_CPP_FUNCTIONS += (
          'you must inject into the main world, consider using '
          'script_injector::ScriptInjector::RequestAsyncExecuteScript(...) '
          'instead. This is a warning only for existing usages, new usages are '
-         'strictly banned.'),
+         'strictly banned.', ),
         treat_as_error=False,
-    ))
+    ),
+    BanRule(
+        pattern=r'//\s*nogncheck(\s|$)',
+        explanation=
+        ('Avoid suppressing gn checks with `nogncheck` comments, and only do '
+         'it if it is absolutely necessary. Make sure that this is not the '
+         'case that the exclusion for the inclusion line has in the C++ source '
+         'has a mismatch with what is being included/excluded in the gn file.',
+         ),
+        treat_as_error=False,
+    ),
+)
 
 
 # Extend BanRule exclude lists with Brave-specific paths.


### PR DESCRIPTION
This PR adds a presubmit check for `nogncheck` uses, to make sure we are
using this lint suppresion label in places where appropriate. In
particular, the need for this check has come up due to the wrong
assumption that `gn` somehow lacked the ability to understand `#ifdef`
conditionals for header inclusions, when in fact, the issue with `gn`
checks in such cases is that there is a buildflag for a certain
exclusion, but the same exclusion has also to be applied in gn files.

Resolves https://github.com/brave/brave-browser/issues/47269
