### PR TITLE
[SideBySide] Fixed crash when pinning split tabs in vertical tabs

### DIFF
--- a/browser/ui/views/split_view/split_view_browsertest.cc
+++ b/browser/ui/views/split_view/split_view_browsertest.cc
@@ -357,6 +357,10 @@ class SplitViewWithTabDialogBrowserTest
 
   bool IsSideBySideEnabled() const { return GetParam(); }
 
+  bool IsSplitTabAt(int index) {
+    return IsSplitWebContents(GetWebContentsAt(index));
+  }
+
   bool IsSplitWebContents(content::WebContents* web_contents) {
     auto tab_handle =
         tabs::TabInterface::GetFromContents(web_contents)->GetHandle();
@@ -394,6 +398,10 @@ IN_PROC_BROWSER_TEST_P(SplitViewWithTabDialogBrowserTest,
   EXPECT_EQ(3, tab_strip_model->active_index());
   NewSplitTab();
   EXPECT_EQ(4, tab_strip_model->active_index());
+  EXPECT_TRUE(IsSplitTabAt(4));
+
+  // Pin active tab(split tab at 4).
+  chrome::PinTab(browser());
 }
 
 IN_PROC_BROWSER_TEST_P(SplitViewWithTabDialogBrowserTest,

--- a/chromium_src/chrome/browser/ui/views/tabs/compound_tab_container.h
+++ b/chromium_src/chrome/browser/ui/views/tabs/compound_tab_container.h
@@ -6,12 +6,19 @@
 #ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_TABS_COMPOUND_TAB_CONTAINER_H_
 #define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_TABS_COMPOUND_TAB_CONTAINER_H_
 
+// Moved to public to call from PinnedTabContainerController.
 #define NumPinnedTabs                     \
   NumPinnedTabs_Unused() {                \
     return {};                            \
   }                                       \
   friend class BraveCompoundTabContainer; \
-  int NumPinnedTabs
+                                          \
+ public:                                  \
+  int NumPinnedTabs() const;              \
+                                          \
+ private:                                 \
+  int Unused
+
 #define TransferTabBetweenContainers virtual TransferTabBetweenContainers
 #define GetUnpinnedContainerIdealLeadingX \
   virtual GetUnpinnedContainerIdealLeadingX

--- a/patches/chrome-browser-ui-views-tabs-compound_tab_container.cc.patch
+++ b/patches/chrome-browser-ui-views-tabs-compound_tab_container.cc.patch
@@ -1,0 +1,13 @@
+diff --git a/chrome/browser/ui/views/tabs/compound_tab_container.cc b/chrome/browser/ui/views/tabs/compound_tab_container.cc
+index e655cb3c2c7e221ef25f419648f8ca9b1d3256ee..0b215a930d7ba05a8c44cf79caee11c7f08202b9 100644
+--- a/chrome/browser/ui/views/tabs/compound_tab_container.cc
++++ b/chrome/browser/ui/views/tabs/compound_tab_container.cc
+@@ -52,7 +52,7 @@ class PinnedTabContainerController final : public TabContainerController {
+   }
+ 
+   int NumPinnedTabsInModel() const override {
+-    return base_controller_->NumPinnedTabsInModel();
++    return compound_tab_container_->NumPinnedTabs();
+   }
+ 
+   void OnDropIndexUpdate(const std::optional<int> index,


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/47261

Crashed because `PinnedTabContainerController::NumPinnedTabsInModel()` gives wrong answer when pinning split tabs.
It should give its model's pinned tabs count instead of TabStripModel's pinned tabs count.
When split tabs is pinned, each tabs are set as pinned in TabStripModel and notifies this changes.
And each tab is transferred from unpinned tab container to pinned tab container.
When first(left) split tab is transfered, only first split tab is added to pinned tab container.
In this time, pinned tab container's tab count and TabStripModel's pinned tabs cound are different
because second(right) split tab is not yet moved to pinned tabs container.
So PinnedTabContainerController::NumPinnedTabsInModel() should give its current pinned tab.

This is chromium's bug as chromium test doesn't cover about CompoundTabContainer well.

In this PR, new patch file is added but can't avoid because that class is declared/defined
in anon namespace and referenced in this file. And modified method(NumPinnedTabsInModel()) is called in this same file.

TEST=SplitViewWithTabDialogBrowserTest.SplitViewWithPinnedTabTest

Manual test:
1. Open Brave with `--enable-features=SideBySide`
2. Turn on vertical tab
3. Create split view and try to pin it
4. No crash

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
