### PR TITLE
Remove obsolete comment

### DIFF
--- a/build/commands/lib/config.js
+++ b/build/commands/lib/config.js
@@ -501,8 +501,6 @@ Config.prototype.buildArgs = function () {
     use_siso: false,
     use_libfuzzer: this.use_libfuzzer,
     enable_updater: this.isOfficialBuild(),
-    // Disable "Can't update Brave" notification on macOS until we have switched
-    // to Omaha 4 and have background updates:
     enable_update_notifications: this.isOfficialBuild(),
     brave_services_production_domain: this.braveServicesProductionDomain,
     brave_services_staging_domain: this.braveServicesStagingDomain,


### PR DESCRIPTION
It was added in https://github.com/brave/brave-core/pull/28351. This was reverted in https://github.com/brave/brave-core/pull/28991. But the comment was forgotten.

Pure dev concern. No QA required.