### PR TITLE
Disable FileSystemAccessSymbolicLinkCheck for Windows (uplift to 1.81.x)

### DIFF
--- a/patches/chrome-browser-file_system_access-file_system_access_features.cc.patch
+++ b/patches/chrome-browser-file_system_access-file_system_access_features.cc.patch
@@ -1,0 +1,18 @@
+diff --git a/chrome/browser/file_system_access/file_system_access_features.cc b/chrome/browser/file_system_access/file_system_access_features.cc
+index 3ff46cd7524f12454db43d9ae7558f0e1aba086d..a15a8d710ae94036ebfcac8e1d159b5d387653b2 100644
+--- a/chrome/browser/file_system_access/file_system_access_features.cc
++++ b/chrome/browser/file_system_access/file_system_access_features.cc
+@@ -21,6 +21,12 @@ BASE_FEATURE(kFileSystemAccessPersistentPermissions,
+ // resolves any symbolic link.
+ BASE_FEATURE(kFileSystemAccessSymbolicLinkCheck,
+              "FileSystemAccessSymbolicLinkCheck",
+-             base::FEATURE_ENABLED_BY_DEFAULT);
++// TODO(crbug.com/428455312): Enable for Windows
++#if BUILDFLAG(IS_WIN)
++             base::FEATURE_DISABLED_BY_DEFAULT
++#else
++             base::FEATURE_ENABLED_BY_DEFAULT
++#endif
++);
+ 
+ }  // namespace features


### PR DESCRIPTION
Uplift of #29858
Resolves https://github.com/brave/brave-browser/issues/47295

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.