### PR TITLE
[CodeHealth] Remove unused `string` statics in `LocalDataFilesService`

### DIFF
--- a/components/brave_component_updater/browser/BUILD.gn
+++ b/components/brave_component_updater/browser/BUILD.gn
@@ -36,6 +36,8 @@ component("browser") {
     "//components/update_client",
     "//crypto",
   ]
+
+  configs += [ "//build/config/compiler:wexit_time_destructors" ]
 }
 
 source_set("test_support") {

--- a/components/brave_component_updater/browser/local_data_files_service.cc
+++ b/components/brave_component_updater/browser/local_data_files_service.cc
@@ -11,12 +11,6 @@ using brave_component_updater::BraveComponent;
 
 namespace brave_component_updater {
 
-std::string LocalDataFilesService::g_local_data_files_component_id_(
-    kLocalDataFilesComponentId);
-std::string LocalDataFilesService::
-g_local_data_files_component_base64_public_key_(
-    kLocalDataFilesComponentBase64PublicKey);
-
 LocalDataFilesService::LocalDataFilesService(BraveComponent::Delegate* delegate)
   : BraveComponent(delegate),
     initialized_(false) {}
@@ -29,9 +23,8 @@ LocalDataFilesService::~LocalDataFilesService() {
 bool LocalDataFilesService::Start() {
   if (initialized_)
     return true;
-  Register(kLocalDataFilesComponentName,
-           g_local_data_files_component_id_,
-           g_local_data_files_component_base64_public_key_);
+  Register(kLocalDataFilesComponentName, kLocalDataFilesComponentId,
+           kLocalDataFilesComponentBase64PublicKey);
   initialized_ = true;
   return true;
 }
@@ -50,14 +43,6 @@ void LocalDataFilesService::AddObserver(LocalDataFilesObserver* observer) {
 
 void LocalDataFilesService::RemoveObserver(LocalDataFilesObserver* observer) {
   observers_.RemoveObserver(observer);
-}
-
-// static
-void LocalDataFilesService::SetComponentIdAndBase64PublicKeyForTest(
-    const std::string& component_id,
-    const std::string& component_base64_public_key) {
-  g_local_data_files_component_id_ = component_id;
-  g_local_data_files_component_base64_public_key_ = component_base64_public_key;
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/components/brave_component_updater/browser/local_data_files_service.h
+++ b/components/brave_component_updater/browser/local_data_files_service.h
@@ -45,10 +45,6 @@ class COMPONENT_EXPORT(BRAVE_COMPONENT_UPDATER) LocalDataFilesService
   void AddObserver(LocalDataFilesObserver* observer);
   void RemoveObserver(LocalDataFilesObserver* observer);
 
-  static void SetComponentIdAndBase64PublicKeyForTest(
-      const std::string& component_id,
-      const std::string& component_base64_public_key);
-
  protected:
   void OnComponentReady(const std::string& component_id,
       const base::FilePath& install_dir,


### PR DESCRIPTION
This PR removes the static fields in `LocalDataFilesService` which are
`std::string` globals specifically added to this class to provide custom
testing hooks. These globals are never used, and the function setting
custom values for these static strings is never called.

This change removes these unnecessary values, and enables
`-Wexit-time-destructors` for this target to prevent back sliding.

Resolves https://github.com/brave/brave-browser/issues/47342
