### PR TITLE
Update nala dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@brave/brave-ui": "0.40.6",
-        "@brave/leo": "github:brave/leo#26f873510cbedb9649a518a627c9e0e464540ca6",
+        "@brave/leo": "github:brave/leo#99f624799f6247f1b915e37f360028051746ead537981c7",
         "@brave/leo-sf-symbols": "github:brave/leo-sf-symbols#8685eec0851afa96d23dd424cd152854476e585d",
         "@brave/wallet-standard-brave": "0.0.16",
         "@dnd-kit/core": "6.0.5",
@@ -22170,7 +22170,7 @@
     "@brave/leo": {
       "version": "git+ssh://git@github.com/brave/leo.git#26f873510cbedb9649a518a627c9e0e464540ca6",
       "integrity": "sha512-ccw1H/GkTbpA9UuHoauxEpbVn+/6gbZPK008vnQJ330ve6Ou8Wx3417jQqXQJ+rrc5f4wr3LeoctCj1tdGL9Ig==",
-      "from": "@brave/leo@github:brave/leo#26f873510cbedb9649a518a627c9e0e464540ca6",
+      "from": "@brave/leo@github:brave/leo#99f624799f6247f1b915e37f360028051746ead537981c7",
       "requires": {
         "@storybook/test": "8.6.14",
         "svelte": "4.2.20",

--- a/package.json
+++ b/package.json
@@ -186,7 +186,7 @@
   },
   "dependencies": {
     "@brave/brave-ui": "0.40.6",
-    "@brave/leo": "github:brave/leo#26f873510cbedb9649a518a627c9e0e464540ca6",
+    "@brave/leo": "github:brave/leo#99f624799f6247f1b915e37f360028051746ead537981c7",
     "@brave/leo-sf-symbols": "github:brave/leo-sf-symbols#8685eec0851afa96d23dd424cd152854476e585d",
     "@brave/wallet-standard-brave": "0.0.16",
     "@dnd-kit/core": "6.0.5",


### PR DESCRIPTION
https://github.com/brave/leo/compare/26f873510cbedb9649a518a627c9e0e464540ca6...99f6247f1b915e37f360028051746ead537981c7

- [Tooltip]: Configurable delay before opening
- chore(deps): update dependency prettier to v3.6.0
- chore(deps): update dependency prettier to v3.6.1
- [Icons]: Update icons from Figma
