### PR TITLE
[ads] Support fonts for RichNTT

### DIFF
--- a/components/ntp_background_images/browser/ntp_sponsored_rich_media_source.cc
+++ b/components/ntp_background_images/browser/ntp_sponsored_rich_media_source.cc
@@ -94,6 +94,8 @@ std::string NTPSponsoredRichMediaSource::GetContentSecurityPolicy(
       return "script-src 'self';";
     case network::mojom::CSPDirectiveName::StyleSrc:
       return "style-src 'self';";
+    case network::mojom::CSPDirectiveName::FontSrc:
+      return "font-src 'self';";
     case network::mojom::CSPDirectiveName::ImgSrc:
       return "img-src 'self';";
     case network::mojom::CSPDirectiveName::MediaSrc:

--- a/components/ntp_background_images/browser/ntp_sponsored_rich_media_source_unittest.cc
+++ b/components/ntp_background_images/browser/ntp_sponsored_rich_media_source_unittest.cc
@@ -130,7 +130,7 @@ TEST_F(NTPSponsoredRichMediaSourceTest,
 }
 
 TEST_F(NTPSponsoredRichMediaSourceTest,
-       DoNotStartDataRequestIfContentIsOutsideOfSandbox3) {
+       DoNotStartDataRequestIfContentIsOutsideOfSandbox) {
   EXPECT_THAT(StartDataRequest(
                   GURL("chrome-untrusted://new-tab-takeover/restricted.jpg")),
               ::testing::IsEmpty());
@@ -211,6 +211,12 @@ TEST_F(NTPSponsoredRichMediaSourceTest, GetContentSecurityPolicy) {
 
       case network::mojom::CSPDirectiveName::StyleSrc: {
         EXPECT_EQ("style-src 'self';",
+                  url_data_source()->GetContentSecurityPolicy(directive));
+        break;
+      }
+
+      case network::mojom::CSPDirectiveName::FontSrc: {
+        EXPECT_EQ("font-src 'self';",
                   url_data_source()->GetContentSecurityPolicy(directive));
         break;
       }


### PR DESCRIPTION
Add an explicit font-src 'self' directive to the Rich NTT Content Security Policy. This will allow fonts bundled as part of the assets to load from the same origin and improve the appearance of Rich NTT based on advertiser requirements.

Verify that bundled fonts are rendering correctly in Rich NTT content.

Once merged, I will upload an NTT to staging that uses bundled fonts for testing.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/47323

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
