### PR TITLE
Fixed wrong split tab insets when pin state is changed

### DIFF
--- a/browser/ui/views/split_view/split_view_browsertest.cc
+++ b/browser/ui/views/split_view/split_view_browsertest.cc
@@ -257,56 +257,6 @@ IN_PROC_BROWSER_TEST_F(SideBySideEnabledBrowserTest, SelectTabTest) {
   EXPECT_EQ(3, tab_strip()->GetActiveIndex());
   EXPECT_FALSE(tab_strip()->tab_at(2)->IsActive());
   EXPECT_TRUE(tab_strip()->tab_at(3)->IsActive());
-
-  // Check split tab's border insets to test split tabs related apis in
-  // BraveVerticalTabStyle. Its insets is different with normal tabs. Also
-  // different between first and second split tab in vertical tab mode.
-  ToggleVerticalTabStrip();
-
-  // Create new tab at 4.
-  chrome::AddTabAt(browser(), GURL(), -1, /*foreground*/ true);
-  EXPECT_EQ(4, tab_strip()->GetActiveIndex());
-
-  // Get base insets.
-  const auto insets = tab_strip()->tab_at(4)->tab_style()->GetContentsInsets();
-
-  // Check normal tab's border insets.
-  EXPECT_EQ(tab_strip()->tab_at(4)->GetBorder()->GetInsets(), insets);
-
-  // Create split tabs with tab at 4 and new tab at 5.
-  chrome::NewSplitTab(browser());
-
-  // Check split tab's first & second tabs' insets are different.
-  // value 4 here is copied from |kPaddingForVerticalTabInTile| in
-  // brave_tab_style_views.inc.cc.
-  EXPECT_EQ(tab_strip()->tab_at(4)->GetBorder()->GetInsets(),
-            insets + gfx::Insets::TLBR(4, 0, 0, 0));
-  EXPECT_EQ(tab_strip()->tab_at(5)->GetBorder()->GetInsets(),
-            insets + gfx::Insets::TLBR(0, 0, 4, 0));
-
-  // Check active tab is not changed after swap.
-  // Active tab index is changed after swap.
-  auto* tab_strip_model = browser()->tab_strip_model();
-  EXPECT_EQ(5, tab_strip_model->active_index());
-  auto split_id = tab_strip_model->GetSplitForTab(4);
-  ASSERT_TRUE(split_id);
-  tab_strip_model->ReverseTabsInSplit(split_id.value());
-  EXPECT_EQ(4, tab_strip_model->active_index());
-
-  // Check split tabs have proper insets after swap
-  EXPECT_EQ(tab_strip()->tab_at(4)->GetBorder()->GetInsets(),
-            insets + gfx::Insets::TLBR(4, 0, 0, 0));
-  EXPECT_EQ(tab_strip()->tab_at(5)->GetBorder()->GetInsets(),
-            insets + gfx::Insets::TLBR(0, 0, 4, 0));
-
-  tab_strip_model->ReverseTabsInSplit(split_id.value());
-  EXPECT_EQ(5, tab_strip_model->active_index());
-
-  ToggleVerticalTabStrip();
-  EXPECT_NE(tab_strip()->tab_at(4)->GetBorder()->GetInsets(),
-            insets + gfx::Insets::TLBR(4, 0, 0, 0));
-  EXPECT_NE(tab_strip()->tab_at(5)->GetBorder()->GetInsets(),
-            insets + gfx::Insets::TLBR(0, 0, 4, 0));
 }
 
 class SplitViewWithTabDialogBrowserTest
@@ -374,6 +324,18 @@ class SplitViewWithTabDialogBrowserTest
     return IsSplitWebContents(GetWebContentsAt(index));
   }
 
+  void SwapActiveSplitTab() {
+    if (IsSideBySideEnabled()) {
+      auto* tab_strip_model = browser()->tab_strip_model();
+      auto split_id =
+          tab_strip_model->GetSplitForTab(tab_strip_model->active_index());
+      ASSERT_TRUE(split_id);
+      tab_strip_model->ReverseTabsInSplit(split_id.value());
+    } else {
+      brave::SwapTabsInTile(browser());
+    }
+  }
+
   bool IsSplitWebContents(content::WebContents* web_contents) {
     auto tab_handle =
         tabs::TabInterface::GetFromContents(web_contents)->GetHandle();
@@ -400,6 +362,86 @@ class SplitViewWithTabDialogBrowserTest
   base::test::ScopedFeatureList scoped_features_;
 };
 
+IN_PROC_BROWSER_TEST_P(SplitViewWithTabDialogBrowserTest, SplitTabInsetsTest) {
+  brave::ToggleVerticalTabStrip(browser());
+
+  auto* tab_strip_model = browser()->tab_strip_model();
+  tab_strip_model->SetTabPinned(0, true);
+  chrome::AddTabAt(browser(), GURL(), -1, /*foreground*/ true);
+  chrome::AddTabAt(browser(), GURL(), -1, /*foreground*/ true);
+  NewSplitTab();
+  EXPECT_EQ(3, tab_strip_model->active_index());
+  EXPECT_FALSE(IsSplitTabAt(0));
+  EXPECT_FALSE(IsSplitTabAt(1));
+  EXPECT_TRUE(IsSplitTabAt(2));
+  EXPECT_TRUE(IsSplitTabAt(3));
+  EXPECT_TRUE(tab_strip_model->IsTabPinned(0));
+  EXPECT_FALSE(tab_strip_model->IsTabPinned(1));
+  EXPECT_FALSE(tab_strip_model->IsTabPinned(2));
+  EXPECT_FALSE(tab_strip_model->IsTabPinned(3));
+
+  // Get normal tab's border insets.
+  const auto insets = tab_strip()->tab_at(1)->GetBorder()->GetInsets();
+
+  // Check split tab's first & second tabs' insets are different.
+  // value 4 here is copied from |kPaddingForVerticalTabInTile| in
+  // brave_tab_style_views.inc.cc.
+  EXPECT_EQ(tab_strip()->tab_at(2)->GetBorder()->GetInsets(),
+            insets + gfx::Insets::TLBR(4, 0, 0, 0));
+  EXPECT_EQ(tab_strip()->tab_at(3)->GetBorder()->GetInsets(),
+            insets + gfx::Insets::TLBR(0, 0, 4, 0));
+
+  SwapActiveSplitTab();
+  EXPECT_EQ(2, tab_strip()->GetActiveIndex());
+
+  // Check split tabs have proper insets after swap
+  EXPECT_EQ(tab_strip()->tab_at(2)->GetBorder()->GetInsets(),
+            insets + gfx::Insets::TLBR(4, 0, 0, 0));
+  EXPECT_EQ(tab_strip()->tab_at(3)->GetBorder()->GetInsets(),
+            insets + gfx::Insets::TLBR(0, 0, 4, 0));
+
+  // Check pinned split tabs have same insets with other pinned tab
+  chrome::PinTab(browser());
+  ASSERT_TRUE(base::test::RunUntil([&]() {
+    return tab_strip_model->IsTabPinned(1) && tab_strip_model->IsTabPinned(2);
+  }));
+
+  EXPECT_FALSE(IsSplitTabAt(0));
+  EXPECT_TRUE(IsSplitTabAt(1));
+  EXPECT_TRUE(IsSplitTabAt(2));
+  EXPECT_FALSE(IsSplitTabAt(3));
+  EXPECT_TRUE(tab_strip_model->IsTabPinned(0));
+  EXPECT_TRUE(tab_strip_model->IsTabPinned(1));
+  EXPECT_TRUE(tab_strip_model->IsTabPinned(2));
+  EXPECT_FALSE(tab_strip_model->IsTabPinned(3));
+
+  EXPECT_EQ(tab_strip()->tab_at(0)->GetBorder()->GetInsets(),
+            tab_strip()->tab_at(1)->GetBorder()->GetInsets());
+  EXPECT_EQ(tab_strip()->tab_at(0)->GetBorder()->GetInsets(),
+            tab_strip()->tab_at(2)->GetBorder()->GetInsets());
+
+  tab_strip_model->ActivateTabAt(3);
+  NewSplitTab();
+  EXPECT_TRUE(IsSplitTabAt(3));
+  EXPECT_TRUE(IsSplitTabAt(4));
+
+  // vertical tab off.
+  brave::ToggleVerticalTabStrip(browser());
+
+  chrome::AddTabAt(browser(), GURL(), -1, /*foreground*/ true);
+  EXPECT_EQ(5, tab_strip()->GetActiveIndex());
+  NewSplitTab();
+  EXPECT_TRUE(IsSplitTabAt(5));
+  EXPECT_TRUE(IsSplitTabAt(6));
+
+  // Check split tabs(at 3, 4) created at vertical tab and split tabs(5, 6)
+  // created at horizontal tab have same insets.
+  EXPECT_EQ(tab_strip()->tab_at(3)->GetBorder()->GetInsets(),
+            tab_strip()->tab_at(5)->GetBorder()->GetInsets());
+  EXPECT_EQ(tab_strip()->tab_at(4)->GetBorder()->GetInsets(),
+            tab_strip()->tab_at(6)->GetBorder()->GetInsets());
+}
+
 // Check split view works with pinned tabs.
 IN_PROC_BROWSER_TEST_P(SplitViewWithTabDialogBrowserTest,
                        SplitViewWithPinnedTabTest) {
@@ -419,20 +461,6 @@ IN_PROC_BROWSER_TEST_P(SplitViewWithTabDialogBrowserTest,
 
   // Pin active tab(split tab at 4).
   chrome::PinTab(browser());
-
-  // Check pinned split tabs have same insets with pin tabs.
-  EXPECT_FALSE(IsSplitTabAt(0));
-  EXPECT_TRUE(IsSplitTabAt(1));
-  EXPECT_TRUE(IsSplitTabAt(2));
-  EXPECT_TRUE(tab_strip_model->IsTabPinned(0));
-
-  const auto insets = tab_strip()->tab_at(0)->GetBorder()->GetInsets();
-  ASSERT_TRUE(base::test::RunUntil([&]() {
-    return tab_strip_model->IsTabPinned(1) && tab_strip_model->IsTabPinned(2);
-  }));
-
-  EXPECT_EQ(insets, tab_strip()->tab_at(1)->GetBorder()->GetInsets());
-  EXPECT_EQ(insets, tab_strip()->tab_at(2)->GetBorder()->GetInsets());
 }
 
 IN_PROC_BROWSER_TEST_P(SplitViewWithTabDialogBrowserTest,
@@ -840,48 +868,6 @@ IN_PROC_BROWSER_TEST_F(SplitViewBrowserTest,
   // Then, the secondary web view should show up
   ASSERT_TRUE(base::test::RunUntil(
       [&]() { return secondary_contents_container().GetVisible(); }));
-
-  // Check split tab's border insets to test split tabs related apis in
-  // BraveVerticalTabStyle. Its insets is different with normal tabs. Also
-  // different between first and second split tab in vertical tab mode.
-  ToggleVerticalTabStrip();
-
-  // Create new tab at 3.
-  chrome::AddTabAt(browser(), GURL(), -1, /*foreground*/ true);
-  EXPECT_EQ(3, tab_strip().GetActiveIndex());
-
-  // Get base insets.
-  const auto insets = tab_strip().tab_at(3)->tab_style()->GetContentsInsets();
-
-  // Check normal tab's border insets.
-  EXPECT_EQ(tab_strip().tab_at(3)->GetBorder()->GetInsets(), insets);
-
-  // Create split tabs with tab at 3 and new tab at 4.
-  brave::NewSplitViewForTab(browser());
-  EXPECT_EQ(4, tab_strip().GetActiveIndex());
-
-  // Check split tab's first & second tabs' insets are different.
-  // value 4 here is copied from |kPaddingForVerticalTabInTile| in
-  // brave_tab_style_views.inc.cc.
-  EXPECT_EQ(tab_strip().tab_at(3)->GetBorder()->GetInsets(),
-            insets + gfx::Insets::TLBR(4, 0, 0, 0));
-  EXPECT_EQ(tab_strip().tab_at(4)->GetBorder()->GetInsets(),
-            insets + gfx::Insets::TLBR(0, 0, 4, 0));
-
-  brave::SwapTabsInTile(browser());
-  EXPECT_EQ(3, tab_strip().GetActiveIndex());
-
-  // Check split tabs have proper insets after swap
-  EXPECT_EQ(tab_strip().tab_at(3)->GetBorder()->GetInsets(),
-            insets + gfx::Insets::TLBR(4, 0, 0, 0));
-  EXPECT_EQ(tab_strip().tab_at(4)->GetBorder()->GetInsets(),
-            insets + gfx::Insets::TLBR(0, 0, 4, 0));
-
-  ToggleVerticalTabStrip();
-  EXPECT_NE(tab_strip().tab_at(3)->GetBorder()->GetInsets(),
-            insets + gfx::Insets::TLBR(4, 0, 0, 0));
-  EXPECT_NE(tab_strip().tab_at(4)->GetBorder()->GetInsets(),
-            insets + gfx::Insets::TLBR(0, 0, 4, 0));
 }
 
 IN_PROC_BROWSER_TEST_F(SplitViewBrowserTest,

--- a/browser/ui/views/tabs/brave_compound_tab_container.cc
+++ b/browser/ui/views/tabs/brave_compound_tab_container.cc
@@ -228,6 +228,8 @@ void BraveCompoundTabContainer::TransferTabBetweenContainers(
   }
 
   if (layout_dirty) {
+    // Tab could have different insets per containers(ex, split tabs).
+    tab->UpdateInsets();
     DeprecatedLayoutImmediately();
   }
 }

--- a/browser/ui/views/tabs/brave_tab_container.cc
+++ b/browser/ui/views/tabs/brave_tab_container.cc
@@ -297,6 +297,13 @@ void BraveTabContainer::UpdateLayoutOrientation() {
       tabs::utils::ShouldShowVerticalTabs(tab_slot_controller_->GetBrowser()));
   layout_helper_->set_tab_strip(
       static_cast<TabStrip*>(base::to_address(tab_slot_controller_)));
+
+  // Tab could have different insets per orientation(ex, split tabs).
+  const int tab_count = GetTabCount();
+  for (int i = 0; i < tab_count; ++i) {
+    GetTabAtModelIndex(i)->UpdateInsets();
+  }
+
   InvalidateLayout();
 }
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/47364

Updated tab's insets when tab is transferred or vertical tabs mode changed because
pinned state and vertical tabs mode affects split tab's insets.

TEST=SplitViewWithTabDialogBrowserTest.SplitTabInsetsTest

Manual test:

1. Turn on vertical tabs
2. Create some pinned tabs
3. Create non pinned tabs and create split views with it
4. Pin split tabs
5. Check pinned split tab's icon aligned well

https://github.com/user-attachments/assets/3d95b0a6-67f8-4f28-89e5-478acef7387c



<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
