### PR TITLE
Bypass Brave hosted extensions verification on install. (uplift to 1.81.x)

### DIFF
--- a/app/brave_settings_strings.grdp
+++ b/app/brave_settings_strings.grdp
@@ -1269,7 +1269,7 @@
     The following Manifest V2 extensions will be removed from the Chrome Web Store, but are still supported in Brave. Toggle to download and install, or to uninstall.
   </message>
   <message name="IDS_SETTINGS_MANAGE_EXTENSIONS_V2_WARN" desc="The warning message in v2 extensions in settings.">
-    Brave does not review or verify the content, security, or behavior of these Manifest V2 extensions. Please see each extension's official page for help. Read Brave's plans for Manifest V2 <ph name="BEGIN_LINK">&lt;a target="_blank" rel="noreferrer" href="$1"&gt;</ph>here<ph name="END_LINK">&lt;/a&gt;</ph>.
+    Brave hosts these Manifest V2 extensions on Brave servers, but does not review or verify their content, security, or behavior. Please see each extension's official page for help. Read Brave's plans for Manifest V2 <ph name="BEGIN_LINK">&lt;a target="_blank" rel="noreferrer" href="$1"&gt;</ph>here<ph name="END_LINK">&lt;/a&gt;</ph>.
   </message>
   <message name="IDS_SETTINGS_MANAGE_EXTENSIONS_V2_TOAST_CONFIRM" desc="The label of the error toast button in settings">
     Close

--- a/browser/extensions/manifest_v2/BUILD.gn
+++ b/browser/extensions/manifest_v2/BUILD.gn
@@ -21,8 +21,23 @@ source_set("manifest_v2") {
     "//components/update_client",
     "//content/public/browser",
     "//extensions/browser",
-    "//extensions/common:common",
+    "//extensions/common",
     "//net/traffic_annotation",
     "//services/network/public/cpp",
+  ]
+}
+
+source_set("unit_tests") {
+  testonly = true
+
+  sources = [ "brave_extensions_manifest_v2_unittest.cc" ]
+
+  deps = [
+    ":manifest_v2",
+    "//chrome/browser/extensions",
+    "//chrome/test:test_support",
+    "//extensions:test_support",
+    "//testing/gmock",
+    "//testing/gtest",
   ]
 }

--- a/browser/extensions/manifest_v2/brave_extensions_manifest_v2_installer.cc
+++ b/browser/extensions/manifest_v2/brave_extensions_manifest_v2_installer.cc
@@ -35,10 +35,6 @@ namespace extensions_mv2 {
 
 namespace {
 
-bool IsKnownMV2Extension(const extensions::ExtensionId& id) {
-  return kPreconfiguredManifestV2Extensions.contains(id);
-}
-
 GURL GetUpdaterExtensionDownloadUrl(
     const extensions::ExtensionId& extenion_id) {
   const std::string params[] = {base::JoinString({"id", extenion_id}, "="),
@@ -98,6 +94,10 @@ GURL GetCrxDownloadUrl(const base::Value::Dict& update_manifest,
 }
 
 }  // namespace
+
+bool IsKnownMV2Extension(const extensions::ExtensionId& id) {
+  return kPreconfiguredManifestV2Extensions.contains(id);
+}
 
 ExtensionManifestV2Installer::ExtensionManifestV2Installer(
     const std::string& extension_id,

--- a/browser/extensions/manifest_v2/brave_extensions_manifest_v2_installer.h
+++ b/browser/extensions/manifest_v2/brave_extensions_manifest_v2_installer.h
@@ -43,6 +43,8 @@ inline constexpr auto kPreconfiguredManifestV2Extensions =
                                                  kUBlockId,
                                              });
 
+bool IsKnownMV2Extension(const extensions::ExtensionId& id);
+
 class ExtensionManifestV2Installer {
  public:
   ExtensionManifestV2Installer(

--- a/browser/extensions/manifest_v2/brave_extensions_manifest_v2_unittest.cc
+++ b/browser/extensions/manifest_v2/brave_extensions_manifest_v2_unittest.cc
@@ -1,0 +1,98 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/browser/extensions/manifest_v2/brave_extensions_manifest_v2_installer.h"
+#include "chrome/browser/extensions/extension_management.h"
+#include "chrome/browser/extensions/extension_service_test_base.h"
+#include "chrome/browser/extensions/install_signer.h"
+#include "chrome/browser/extensions/install_verifier.h"
+#include "chrome/browser/extensions/mv2_deprecation_impact_checker.h"
+#include "chrome/browser/extensions/mv2_experiment_stage.h"
+#include "extensions/browser/extension_prefs.h"
+#include "extensions/common/extension_builder.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+struct BraveExtensionsManifestV2Test
+    : public extensions::ExtensionServiceTestBase {
+ public:
+  void SetUp() override {
+    extensions::ExtensionServiceTestBase::SetUp();
+
+    InitializeExtensionService(ExtensionServiceInitParams());
+  }
+
+  void InitVerifier() {
+    extensions::InstallSignature signature = {};
+    auto dict = signature.ToDict();
+    extensions::ExtensionPrefs::Get(profile())->SetInstallSignature(&dict);
+    extensions::InstallVerifier::Get(profile())->Init();
+  }
+
+ private:
+  extensions::ScopedInstallVerifierBypassForTest force_install_verification_{
+      extensions::ScopedInstallVerifierBypassForTest::kForceOn};
+};
+
+TEST_F(BraveExtensionsManifestV2Test, CheckInstallVerifier) {
+  struct {
+    const char* extension_id;
+    bool expected_must_remain_disabled;
+    extensions::disable_reason::DisableReason expected_reason;
+  } test_cases[] = {{extensions_mv2::kNoScriptId, false,
+                     extensions::disable_reason::DISABLE_NONE},
+                    {"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", true,
+                     extensions::disable_reason::DISABLE_NOT_VERIFIED}};
+
+  InitVerifier();
+
+  for (const auto& test : test_cases) {
+    SCOPED_TRACE(::testing::Message() << test.extension_id);
+
+    auto extension =
+        extensions::ExtensionBuilder("test")
+            .SetID(test.extension_id)
+            .AddFlags(extensions::Extension::FROM_WEBSTORE)
+            .SetLocation(extensions::mojom::ManifestLocation::kExternalPolicy)
+            .Build();
+
+    auto* install_verifier = extensions::InstallVerifier::Get(profile());
+
+    auto disable_reason = extensions::disable_reason::DISABLE_NONE;
+    EXPECT_EQ(
+        test.expected_must_remain_disabled,
+        install_verifier->MustRemainDisabled(extension.get(), &disable_reason));
+    EXPECT_EQ(test.expected_reason, disable_reason);
+  }
+}
+
+class BraveExtensionsManifestV2DeprecationTest
+    : public BraveExtensionsManifestV2Test,
+      public ::testing::WithParamInterface<extensions::MV2ExperimentStage> {};
+
+INSTANTIATE_TEST_SUITE_P(
+    ,
+    BraveExtensionsManifestV2DeprecationTest,
+    ::testing::Values(extensions::MV2ExperimentStage::kNone,
+                      extensions::MV2ExperimentStage::kDisableWithReEnable,
+                      extensions::MV2ExperimentStage::kUnsupported,
+                      extensions::MV2ExperimentStage::kWarning));
+
+TEST_P(BraveExtensionsManifestV2DeprecationTest,
+       KnownMV2ExtensionsNotDeprecated) {
+  extensions::MV2DeprecationImpactChecker checker(
+      GetParam(),
+      extensions::ExtensionManagementFactory::GetForBrowserContext(profile()));
+
+  for (const auto& known_mv2 :
+       extensions_mv2::kPreconfiguredManifestV2Extensions) {
+    auto extension =
+        extensions::ExtensionBuilder("test")
+            .SetID(std::string(known_mv2))
+            .AddFlags(extensions::Extension::FROM_WEBSTORE)
+            .SetLocation(extensions::mojom::ManifestLocation::kExternalPolicy)
+            .Build();
+    EXPECT_FALSE(checker.IsExtensionAffected(*extension.get()));
+  }
+}

--- a/browser/misc_metrics/extension_metrics.cc
+++ b/browser/misc_metrics/extension_metrics.cc
@@ -78,8 +78,7 @@ void ExtensionMetrics::OnExtensionLoaded(
   }
 
   // Check if this is a pre-configured Manifest V2 extension
-  if (extensions_mv2::kPreconfiguredManifestV2Extensions.contains(
-          extension->id())) {
+  if (extensions_mv2::IsKnownMV2Extension(extension->id())) {
     select_manifest_v2_extensions_loaded_.insert(extension->id());
   }
 
@@ -100,8 +99,7 @@ void ExtensionMetrics::OnExtensionUninstalled(
   }
 
   // Check if this is a pre-configured Manifest V2 extension
-  if (extensions_mv2::kPreconfiguredManifestV2Extensions.contains(
-          extension->id())) {
+  if (extensions_mv2::IsKnownMV2Extension(extension->id())) {
     select_manifest_v2_extensions_loaded_.erase(extension->id());
   }
 

--- a/browser/ui/webui/settings/brave_extensions_manifest_v2_browsertest.cc
+++ b/browser/ui/webui/settings/brave_extensions_manifest_v2_browsertest.cc
@@ -14,6 +14,7 @@
 #include "chrome/browser/extensions/chrome_content_verifier_delegate.h"
 #include "chrome/browser/extensions/crx_installer.h"
 #include "chrome/browser/extensions/extension_service.h"
+#include "chrome/browser/extensions/install_verifier.h"
 #include "chrome/browser/ui/browser.h"
 #include "chrome/test/base/in_process_browser_test.h"
 #include "chrome/test/base/ui_test_utils.h"
@@ -269,6 +270,9 @@ class BraveExtensionsManifestV2InstallerBrowserTest
 
 IN_PROC_BROWSER_TEST_F(BraveExtensionsManifestV2InstallerBrowserTest,
                        InstallExtension) {
+  extensions::ScopedInstallVerifierBypassForTest scoped_install_verifier{
+      extensions::ScopedInstallVerifierBypassForTest::kForceOn};
+
   ASSERT_TRUE(ui_test_utils::NavigateToURL(
       browser(), GURL("brave://settings/extensions/v2")));
   auto* web_contents = browser()->tab_strip_model()->GetActiveWebContents();
@@ -290,6 +294,9 @@ IN_PROC_BROWSER_TEST_F(BraveExtensionsManifestV2InstallerBrowserTest,
 
 IN_PROC_BROWSER_TEST_F(BraveExtensionsManifestV2InstallerBrowserTest,
                        InstallCancelExtension) {
+  extensions::ScopedInstallVerifierBypassForTest scoped_install_verifier{
+      extensions::ScopedInstallVerifierBypassForTest::kForceOn};
+
   ASSERT_TRUE(ui_test_utils::NavigateToURL(
       browser(), GURL("brave://settings/extensions/v2")));
   auto* web_contents = browser()->tab_strip_model()->GetActiveWebContents();

--- a/chromium_src/chrome/browser/extensions/install_verifier.cc
+++ b/chromium_src/chrome/browser/extensions/install_verifier.cc
@@ -43,12 +43,22 @@
 // All above headers copied from original install_verifier.cc are
 // included to prevent below GOOGLE_CHROME_BUILD affect them.
 
+#include "brave/browser/extensions/manifest_v2/brave_extensions_manifest_v2_installer.h"
+
 // `VerifyStatus::ENFORCE` is only defaulted for google chrome.
 #if defined(OFFICIAL_BUILD)
 #undef BUILDFLAG_INTERNAL_GOOGLE_CHROME_BRANDING
 #define BUILDFLAG_INTERNAL_GOOGLE_CHROME_BRANDING() (1)
 #endif
+
+#define IsUnpackedLocation(...)      \
+  IsUnpackedLocation(__VA_ARGS__) || \
+      extensions_mv2::IsKnownMV2Extension(extension->id())
+
 #include "src/chrome/browser/extensions/install_verifier.cc"
+
 #if defined(OFFICIAL_BUILD)
 #undef BUILDFLAG_INTERNAL_GOOGLE_CHROME_BRANDING
 #endif
+
+#undef IsUnpackedLocation

--- a/chromium_src/chrome/browser/extensions/mv2_deprecation_impact_checker.cc
+++ b/chromium_src/chrome/browser/extensions/mv2_deprecation_impact_checker.cc
@@ -1,0 +1,14 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "base/containers/contains.h"
+#include "brave/browser/extensions/manifest_v2/brave_extensions_manifest_v2_installer.h"
+
+#define Contains(...) \
+  Contains(__VA_ARGS__) || extensions_mv2::IsKnownMV2Extension(extension_id)
+
+#include "src/chrome/browser/extensions/mv2_deprecation_impact_checker.cc"
+
+#undef Contains

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -559,6 +559,7 @@ test("brave_unit_tests") {
 
     deps += [
       "//brave/browser/extensions",
+      "//brave/browser/extensions/manifest_v2:unit_tests",
       "//brave/browser/importer:unit_tests",
       "//brave/common/importer",
       "//chrome/browser/extensions",


### PR DESCRIPTION
Uplift of #29559
Resolves https://github.com/brave/brave-browser/issues/46824
Resolves https://github.com/brave/brave-browser/issues/46919
Resolves https://github.com/brave/brave-browser/issues/46917
Resolves https://github.com/brave/brave-browser/issues/46921

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.