### PR TITLE
[build-commands] Allow `gn` to set `.env` value defaults

### DIFF
--- a/build/commands/lib/config.js
+++ b/build/commands/lib/config.js
@@ -162,99 +162,96 @@ const Config = function () {
   this.targetEnvironment = getEnvConfig(['target_environment'])
   this.gypTargetArch = 'x64'
   this.targetAndroidBase = 'classic'
-  this.braveServicesProductionDomain =
-    getEnvConfig(['brave_services_production_domain']) || ''
-  this.braveServicesStagingDomain =
-    getEnvConfig(['brave_services_staging_domain']) || ''
-  this.braveServicesDevDomain =
-    getEnvConfig(['brave_services_dev_domain']) || ''
-  this.braveGoogleApiKey =
-    getEnvConfig(['brave_google_api_key'])
-    || 'AIzaSyAREPLACEWITHYOUROWNGOOGLEAPIKEY2Q'
-  this.googleApiEndpoint =
-    getEnvConfig(['brave_google_api_endpoint'])
-    || 'https://www.googleapis.com/geolocation/v1/geolocate?key='
-  this.googleDefaultClientId = getEnvConfig(['google_default_client_id']) || ''
-  this.googleDefaultClientSecret =
-    getEnvConfig(['google_default_client_secret']) || ''
-  this.infuraProjectId = getEnvConfig(['brave_infura_project_id']) || ''
-  this.sardineClientId = getEnvConfig(['sardine_client_id']) || ''
-  this.sardineClientSecret = getEnvConfig(['sardine_client_secret']) || ''
-  this.bitFlyerProductionClientId =
-    getEnvConfig(['bitflyer_production_client_id']) || ''
-  this.bitFlyerProductionClientSecret =
-    getEnvConfig(['bitflyer_production_client_secret']) || ''
-  this.bitFlyerProductionFeeAddress =
-    getEnvConfig(['bitflyer_production_fee_address']) || ''
-  this.bitFlyerProductionUrl = getEnvConfig(['bitflyer_production_url']) || ''
-  this.bitFlyerSandboxClientId =
-    getEnvConfig(['bitflyer_sandbox_client_id']) || ''
-  this.bitFlyerSandboxClientSecret =
-    getEnvConfig(['bitflyer_sandbox_client_secret']) || ''
-  this.bitFlyerSandboxFeeAddress =
-    getEnvConfig(['bitflyer_sandbox_fee_address']) || ''
-  this.bitFlyerSandboxUrl = getEnvConfig(['bitflyer_sandbox_url']) || ''
-  this.geminiProductionApiUrl =
-    getEnvConfig(['gemini_production_api_url']) || ''
-  this.geminiProductionClientId =
-    getEnvConfig(['gemini_production_client_id']) || ''
-  this.geminiProductionClientSecret =
-    getEnvConfig(['gemini_production_client_secret']) || ''
-  this.geminiProductionFeeAddress =
-    getEnvConfig(['gemini_production_fee_address']) || ''
-  this.geminiProductionOauthUrl =
-    getEnvConfig(['gemini_production_oauth_url']) || ''
-  this.geminiSandboxApiUrl = getEnvConfig(['gemini_sandbox_api_url']) || ''
-  this.geminiSandboxClientId = getEnvConfig(['gemini_sandbox_client_id']) || ''
-  this.geminiSandboxClientSecret =
-    getEnvConfig(['gemini_sandbox_client_secret']) || ''
-  this.geminiSandboxFeeAddress =
-    getEnvConfig(['gemini_sandbox_fee_address']) || ''
-  this.geminiSandboxOauthUrl = getEnvConfig(['gemini_sandbox_oauth_url']) || ''
-  this.upholdProductionApiUrl =
-    getEnvConfig(['uphold_production_api_url']) || ''
-  this.upholdProductionClientId =
-    getEnvConfig(['uphold_production_client_id']) || ''
-  this.upholdProductionClientSecret =
-    getEnvConfig(['uphold_production_client_secret']) || ''
-  this.upholdProductionFeeAddress =
-    getEnvConfig(['uphold_production_fee_address']) || ''
-  this.upholdProductionOauthUrl =
-    getEnvConfig(['uphold_production_oauth_url']) || ''
-  this.upholdSandboxApiUrl = getEnvConfig(['uphold_sandbox_api_url']) || ''
-  this.upholdSandboxClientId = getEnvConfig(['uphold_sandbox_client_id']) || ''
-  this.upholdSandboxClientSecret =
-    getEnvConfig(['uphold_sandbox_client_secret']) || ''
-  this.upholdSandboxFeeAddress =
-    getEnvConfig(['uphold_sandbox_fee_address']) || ''
-  this.upholdSandboxOauthUrl = getEnvConfig(['uphold_sandbox_oauth_url']) || ''
-  this.zebPayProductionApiUrl =
-    getEnvConfig(['zebpay_production_api_url']) || ''
-  this.zebPayProductionClientId =
-    getEnvConfig(['zebpay_production_client_id']) || ''
-  this.zebPayProductionClientSecret =
-    getEnvConfig(['zebpay_production_client_secret']) || ''
-  this.zebPayProductionOauthUrl =
-    getEnvConfig(['zebpay_production_oauth_url']) || ''
-  this.zebPaySandboxApiUrl = getEnvConfig(['zebpay_sandbox_api_url']) || ''
-  this.zebPaySandboxClientId = getEnvConfig(['zebpay_sandbox_client_id']) || ''
-  this.zebPaySandboxClientSecret =
-    getEnvConfig(['zebpay_sandbox_client_secret']) || ''
-  this.zebPaySandboxOauthUrl = getEnvConfig(['zebpay_sandbox_oauth_url']) || ''
-  this.braveSyncEndpoint = getEnvConfig(['brave_sync_endpoint']) || ''
-  this.safeBrowsingApiEndpoint =
-    getEnvConfig(['safebrowsing_api_endpoint']) || ''
-  this.updaterProdEndpoint = getEnvConfig(['updater_prod_endpoint']) || ''
-  this.updaterDevEndpoint = getEnvConfig(['updater_dev_endpoint']) || ''
-  this.webcompatReportApiEndpoint =
-    getEnvConfig(['webcompat_report_api_endpoint'])
-    || 'https://webcompat.brave.com/1/webcompat'
-  this.rewardsGrantDevEndpoint =
-    getEnvConfig(['rewards_grant_dev_endpoint']) || ''
-  this.rewardsGrantStagingEndpoint =
-    getEnvConfig(['rewards_grant_staging_endpoint']) || ''
-  this.rewardsGrantProdEndpoint =
-    getEnvConfig(['rewards_grant_prod_endpoint']) || ''
+  this.braveServicesProductionDomain = getEnvConfig([
+    'brave_services_production_domain',
+  ])
+  this.braveServicesStagingDomain = getEnvConfig([
+    'brave_services_staging_domain',
+  ])
+  this.braveServicesDevDomain = getEnvConfig(['brave_services_dev_domain'])
+  this.braveGoogleApiKey = getEnvConfig(['brave_google_api_key'])
+  this.googleApiEndpoint = getEnvConfig(['brave_google_api_endpoint'])
+  this.googleDefaultClientId = getEnvConfig(['google_default_client_id'])
+  this.googleDefaultClientSecret = getEnvConfig([
+    'google_default_client_secret',
+  ])
+  this.infuraProjectId = getEnvConfig(['brave_infura_project_id'])
+  this.sardineClientId = getEnvConfig(['sardine_client_id'])
+  this.sardineClientSecret = getEnvConfig(['sardine_client_secret'])
+  this.bitFlyerProductionClientId = getEnvConfig([
+    'bitflyer_production_client_id',
+  ])
+  this.bitFlyerProductionClientSecret = getEnvConfig([
+    'bitflyer_production_client_secret',
+  ])
+  this.bitFlyerProductionFeeAddress = getEnvConfig([
+    'bitflyer_production_fee_address',
+  ])
+  this.bitFlyerProductionUrl = getEnvConfig(['bitflyer_production_url'])
+  this.bitFlyerSandboxClientId = getEnvConfig(['bitflyer_sandbox_client_id'])
+  this.bitFlyerSandboxClientSecret = getEnvConfig([
+    'bitflyer_sandbox_client_secret',
+  ])
+  this.bitFlyerSandboxFeeAddress = getEnvConfig([
+    'bitflyer_sandbox_fee_address',
+  ])
+  this.bitFlyerSandboxUrl = getEnvConfig(['bitflyer_sandbox_url'])
+  this.geminiProductionApiUrl = getEnvConfig(['gemini_production_api_url'])
+  this.geminiProductionClientId = getEnvConfig(['gemini_production_client_id'])
+  this.geminiProductionClientSecret = getEnvConfig([
+    'gemini_production_client_secret',
+  ])
+  this.geminiProductionFeeAddress = getEnvConfig([
+    'gemini_production_fee_address',
+  ])
+  this.geminiProductionOauthUrl = getEnvConfig(['gemini_production_oauth_url'])
+  this.geminiSandboxApiUrl = getEnvConfig(['gemini_sandbox_api_url'])
+  this.geminiSandboxClientId = getEnvConfig(['gemini_sandbox_client_id'])
+  this.geminiSandboxClientSecret = getEnvConfig([
+    'gemini_sandbox_client_secret',
+  ])
+  this.geminiSandboxFeeAddress = getEnvConfig(['gemini_sandbox_fee_address'])
+  this.geminiSandboxOauthUrl = getEnvConfig(['gemini_sandbox_oauth_url'])
+  this.upholdProductionApiUrl = getEnvConfig(['uphold_production_api_url'])
+  this.upholdProductionClientId = getEnvConfig(['uphold_production_client_id'])
+  this.upholdProductionClientSecret = getEnvConfig([
+    'uphold_production_client_secret',
+  ])
+  this.upholdProductionFeeAddress = getEnvConfig([
+    'uphold_production_fee_address',
+  ])
+  this.upholdProductionOauthUrl = getEnvConfig(['uphold_production_oauth_url'])
+  this.upholdSandboxApiUrl = getEnvConfig(['uphold_sandbox_api_url'])
+  this.upholdSandboxClientId = getEnvConfig(['uphold_sandbox_client_id'])
+  this.upholdSandboxClientSecret = getEnvConfig([
+    'uphold_sandbox_client_secret',
+  ])
+  this.upholdSandboxFeeAddress = getEnvConfig(['uphold_sandbox_fee_address'])
+  this.upholdSandboxOauthUrl = getEnvConfig(['uphold_sandbox_oauth_url'])
+  this.zebPayProductionApiUrl = getEnvConfig(['zebpay_production_api_url'])
+  this.zebPayProductionClientId = getEnvConfig(['zebpay_production_client_id'])
+  this.zebPayProductionClientSecret = getEnvConfig([
+    'zebpay_production_client_secret',
+  ])
+  this.zebPayProductionOauthUrl = getEnvConfig(['zebpay_production_oauth_url'])
+  this.zebPaySandboxApiUrl = getEnvConfig(['zebpay_sandbox_api_url'])
+  this.zebPaySandboxClientId = getEnvConfig(['zebpay_sandbox_client_id'])
+  this.zebPaySandboxClientSecret = getEnvConfig([
+    'zebpay_sandbox_client_secret',
+  ])
+  this.zebPaySandboxOauthUrl = getEnvConfig(['zebpay_sandbox_oauth_url'])
+  this.braveSyncEndpoint = getEnvConfig(['brave_sync_endpoint'])
+  this.safeBrowsingApiEndpoint = getEnvConfig(['safebrowsing_api_endpoint'])
+  this.updaterProdEndpoint = getEnvConfig(['updater_prod_endpoint'])
+  this.updaterDevEndpoint = getEnvConfig(['updater_dev_endpoint'])
+  this.webcompatReportApiEndpoint = getEnvConfig([
+    'webcompat_report_api_endpoint',
+  ])
+  this.rewardsGrantDevEndpoint = getEnvConfig(['rewards_grant_dev_endpoint'])
+  this.rewardsGrantStagingEndpoint = getEnvConfig([
+    'rewards_grant_staging_endpoint',
+  ])
+  this.rewardsGrantProdEndpoint = getEnvConfig(['rewards_grant_prod_endpoint'])
   this.ignorePatchVersionNumber =
     !this.isBraveReleaseBuild()
     && getEnvConfig(['ignore_patch_version_number'], !this.isCI)
@@ -267,13 +264,11 @@ const Config = function () {
   this.mac_installer_signing_identifier =
     getEnvConfig(['mac_installer_signing_identifier']) || ''
   this.mac_signing_keychain = getEnvConfig(['mac_signing_keychain']) || 'login'
-  this.sparkleDSAPrivateKeyFile =
-    getEnvConfig(['sparkle_dsa_private_key_file']) || ''
-  this.sparkleEdDSAPrivateKey =
-    getEnvConfig(['sparkle_eddsa_private_key']) || ''
-  this.sparkleEdDSAPublicKey = getEnvConfig(['sparkle_eddsa_public_key']) || ''
-  this.notary_user = getEnvConfig(['notary_user']) || ''
-  this.notary_password = getEnvConfig(['notary_password']) || ''
+  this.sparkleDSAPrivateKeyFile = getEnvConfig(['sparkle_dsa_private_key_file'])
+  this.sparkleEdDSAPrivateKey = getEnvConfig(['sparkle_eddsa_private_key'])
+  this.sparkleEdDSAPublicKey = getEnvConfig(['sparkle_eddsa_public_key'])
+  this.notary_user = getEnvConfig(['notary_user'])
+  this.notary_password = getEnvConfig(['notary_password'])
   this.channel = 'development'
   this.git_cache_path = getEnvConfig(['git_cache_path'])
   this.sccache = getEnvConfig(['sccache'])
@@ -303,10 +298,12 @@ const Config = function () {
   this.extraGnArgs = {}
   this.extraGnGenOpts = getEnvConfig(['brave_extra_gn_gen_opts']) || ''
   this.extraNinjaOpts = []
-  this.braveAndroidSafeBrowsingApiKey =
-    getEnvConfig(['brave_safebrowsing_api_key']) || ''
-  this.braveAndroidDeveloperOptionsCode =
-    getEnvConfig(['brave_android_developer_options_code']) || ''
+  this.braveAndroidSafeBrowsingApiKey = getEnvConfig([
+    'brave_safebrowsing_api_key',
+  ])
+  this.braveAndroidDeveloperOptionsCode = getEnvConfig([
+    'brave_android_developer_options_code',
+  ])
   this.braveAndroidKeystorePath = getEnvConfig(['brave_android_keystore_path'])
   this.braveAndroidKeystoreName = getEnvConfig(['brave_android_keystore_name'])
   this.braveAndroidKeystorePassword = getEnvConfig([
@@ -315,19 +312,19 @@ const Config = function () {
   this.braveAndroidKeyPassword = getEnvConfig(['brave_android_key_password'])
   this.braveAndroidPkcs11Provider = ''
   this.braveAndroidPkcs11Alias = ''
-  this.braveVariationsServerUrl =
-    getEnvConfig(['brave_variations_server_url']) || ''
+  this.braveVariationsServerUrl = getEnvConfig(['brave_variations_server_url'])
   this.nativeRedirectCCDir = path.join(this.srcDir, 'out', 'redirect_cc')
   this.useRemoteExec = getEnvConfig(['use_remoteexec']) || false
   this.offline = getEnvConfig(['offline']) || false
   this.use_libfuzzer = false
   this.androidAabToApk = false
   this.useBraveHermeticToolchain = this.rbeService.includes('.brave.com:')
-  this.brave_services_key_id = getEnvConfig(['brave_services_key_id']) || ''
-  this.service_key_aichat = getEnvConfig(['service_key_aichat']) || ''
-  this.braveIOSDeveloperOptionsCode =
-    getEnvConfig(['brave_ios_developer_options_code']) || ''
-  this.service_key_stt = getEnvConfig(['service_key_stt']) || ''
+  this.brave_services_key_id = getEnvConfig(['brave_services_key_id'])
+  this.service_key_aichat = getEnvConfig(['service_key_aichat'])
+  this.braveIOSDeveloperOptionsCode = getEnvConfig([
+    'brave_ios_developer_options_code',
+  ])
+  this.service_key_stt = getEnvConfig(['service_key_stt'])
   this.skip_download_rust_toolchain_aux =
     getEnvConfig(['skip_download_rust_toolchain_aux']) || false
 }

--- a/build/commands/lib/util.js
+++ b/build/commands/lib/util.js
@@ -1328,15 +1328,18 @@ const util = {
     const generatedArgsContent = [
       '# Do not edit, any changes will be lost on next build.',
       '# To customize build args, use args.gn in the same directory.\n',
-      ...Object.entries(buildArgs).map(([arg, val]) => {
-        assert(typeof arg === 'string')
-        assert(val !== undefined)
-        if (val === null) {
-          // Output only arg, it may be a comment or an import statement.
-          return arg
-        }
-        return `${arg}=${JSON.stringify(val)}`
-      }),
+      ...Object.entries(buildArgs)
+        // undefined values filtered out to allow gn to use default values in
+        // the absence of an .env key.
+        .filter(([_, val]) => val !== undefined)
+        .map(([arg, val]) => {
+          assert(typeof arg === 'string')
+          if (val === null) {
+            // Output only arg, it may be a comment or an import statement.
+            return arg
+          }
+          return `${arg}=${JSON.stringify(val)}`
+        }),
     ].join('\n')
 
     // Write the generated arguments to the args_generated.gni file. The file

--- a/components/geolocation/BUILD.gn
+++ b/components/geolocation/BUILD.gn
@@ -6,8 +6,9 @@
 import("//build/buildflag_header.gni")
 
 declare_args() {
-  brave_google_api_key = ""
-  brave_google_api_endpoint = ""
+  brave_google_api_key = "AIzaSyAREPLACEWITHYOUROWNGOOGLEAPIKEY2Q"
+  brave_google_api_endpoint =
+      "https://www.googleapis.com/geolocation/v1/geolocate?key="
 }
 
 buildflag_header("geolocation") {


### PR DESCRIPTION
This PR changes the way we are reading values from `.env` to allow
absent keys to pass `undefined` forward, and being ignored when
generating gn args, as opposed to have our build commands providing a
default in the absence of the key. This change will allow defaults to be
stored in `.gn` files, rather than always being overwritten by our build
command.

Improper default overwritting is what caused the crash relating to these
two PRs:

https://github.com/brave/brave-core/pull/28463
https://github.com/brave/brave-core/pull/29891
