### PR TITLE
[CodeHealth] Use `web3_provider_constants.h` only for shared const values

### DIFF
--- a/components/brave_wallet/browser/ethereum_provider_impl.cc
+++ b/components/brave_wallet/browser/ethereum_provider_impl.cc
@@ -38,7 +38,6 @@
 #include "brave/components/brave_wallet/common/eth_sign_typed_data_helper.h"
 #include "brave/components/brave_wallet/common/hex_utils.h"
 #include "brave/components/brave_wallet/common/value_conversion_utils.h"
-#include "brave/components/brave_wallet/common/web3_provider_constants.h"
 #include "components/content_settings/core/browser/host_content_settings_map.h"
 #include "components/grit/brave_components_strings.h"
 #include "crypto/random.h"
@@ -48,6 +47,33 @@
 namespace brave_wallet {
 
 namespace {
+
+constexpr char kEthAccounts[] = "eth_accounts";
+constexpr char kEthCoinbase[] = "eth_coinbase";
+constexpr char kEthRequestAccounts[] = "eth_requestAccounts";
+constexpr char kEthSendTransaction[] = "eth_sendTransaction";
+constexpr char kEthSignTransaction[] = "eth_signTransaction";
+constexpr char kEthSendRawTransaction[] = "eth_sendRawTransaction";
+constexpr char kEthSign[] = "eth_sign";
+constexpr char kPersonalSign[] = "personal_sign";
+constexpr char kPersonalEcRecover[] = "personal_ecRecover";
+constexpr char kEthGetEncryptionPublicKey[] = "eth_getEncryptionPublicKey";
+constexpr char kEthDecrypt[] = "eth_decrypt";
+constexpr char kWalletWatchAsset[] = "wallet_watchAsset";
+constexpr char kMetamaskWatchAsset[] = "metamask_watchAsset";
+constexpr char kWeb3ClientVersion[] = "web3_clientVersion";
+constexpr char kEthSubscribe[] = "eth_subscribe";
+constexpr char kEthSubscribeNewHeads[] = "newHeads";
+constexpr char kEthSubscribeLogs[] = "logs";
+constexpr char kEthUnsubscribe[] = "eth_unsubscribe";
+
+constexpr char kEthSignTypedDataV3[] = "eth_signTypedData_v3";
+constexpr char kEthSignTypedDataV4[] = "eth_signTypedData_v4";
+constexpr char kAddEthereumChainMethod[] = "wallet_addEthereumChain";
+constexpr char kSwitchEthereumChainMethod[] = "wallet_switchEthereumChain";
+constexpr char kRequestPermissionsMethod[] = "wallet_requestPermissions";
+constexpr char kGetPermissionsMethod[] = "wallet_getPermissions";
+constexpr char kParams[] = "params";
 
 void RejectInvalidParams(base::Value id,
                          mojom::EthereumProvider::RequestCallback callback) {
@@ -177,7 +203,7 @@ void EthereumProviderImpl::AddEthereumChain(const std::string& json_payload,
   }
   const auto& root = *json_value;
 
-  const auto* params = root.FindList(brave_wallet::kParams);
+  const auto* params = root.FindList(kParams);
   if (!params || params->empty()) {
     return RejectInvalidParams(std::move(id), std::move(callback));
   }

--- a/components/brave_wallet/browser/json_rpc_requests_helper.cc
+++ b/components/brave_wallet/browser/json_rpc_requests_helper.cc
@@ -16,13 +16,16 @@
 #include "brave/components/brave_wallet/browser/brave_wallet_constants.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_utils.h"
 #include "brave/components/brave_wallet/common/eth_request_helper.h"
-#include "brave/components/brave_wallet/common/web3_provider_constants.h"
 #include "brave/components/constants/brave_services_key.h"
 #include "net/http/http_util.h"
 
 namespace brave_wallet {
 
 namespace {
+
+constexpr char kEthGetBlockByNumber[] = "eth_getBlockByNumber";
+constexpr char kEthBlockNumber[] = "eth_blockNumber";
+
 std::optional<std::string> EthGetBlockByNumberParamsForCache(
     const base::Value::List& params_list) {
   std::string cleaned_params;

--- a/components/brave_wallet/browser/solana_provider_impl.cc
+++ b/components/brave_wallet/browser/solana_provider_impl.cc
@@ -28,7 +28,6 @@
 #include "brave/components/brave_wallet/common/brave_wallet_constants.h"
 #include "brave/components/brave_wallet/common/encoding_utils.h"
 #include "brave/components/brave_wallet/common/solana_utils.h"
-#include "brave/components/brave_wallet/common/web3_provider_constants.h"
 #include "components/grit/brave_components_strings.h"
 #include "ui/base/l10n/l10n_util.h"
 
@@ -43,6 +42,13 @@ constexpr char kMessage[] = "message";
 constexpr char kPublicKey[] = "publicKey";
 constexpr char kSignature[] = "signature";
 constexpr char kOptions[] = "options";
+
+constexpr char kSolanaConnect[] = "connect";
+constexpr char kSolanaDisconnect[] = "disconnect";
+constexpr char kSolanaSignMessage[] = "signMessage";
+constexpr char kSolanaSignTransaction[] = "signTransaction";
+constexpr char kSolanaSignAndSendTransaction[] = "signAndSendTransaction";
+constexpr char kSolanaSignAllTransactions[] = "signAllTransactions";
 
 }  // namespace
 
@@ -668,17 +674,17 @@ void SolanaProviderImpl::Request(base::Value::Dict arg,
   base::Value::Dict* params = arg.FindDict("params");
 
   // params is optional for connect and disconnect doesn't need it
-  if (!params && (*method == solana::kSignTransaction ||
-                  *method == solana::kSignAndSendTransaction ||
-                  *method == solana::kSignAllTransactions ||
-                  *method == solana::kSignMessage)) {
+  if (!params && (*method == kSolanaSignTransaction ||
+                  *method == kSolanaSignAndSendTransaction ||
+                  *method == kSolanaSignAllTransactions ||
+                  *method == kSolanaSignMessage)) {
     std::move(callback).Run(mojom::SolanaProviderError::kParsingError,
                             l10n_util::GetStringUTF8(IDS_WALLET_PARSING_ERROR),
                             base::Value::Dict());
     return;
   }
 
-  if (*method == solana::kConnect) {
+  if (*method == kSolanaConnect) {
     std::optional<base::Value::Dict> option = std::nullopt;
     if (params) {
       option = std::move(*params);
@@ -686,11 +692,11 @@ void SolanaProviderImpl::Request(base::Value::Dict arg,
     Connect(std::move(option),
             base::BindOnce(&SolanaProviderImpl::OnRequestConnect,
                            weak_factory_.GetWeakPtr(), std::move(callback)));
-  } else if (*method == solana::kDisconnect) {
+  } else if (*method == kSolanaDisconnect) {
     Disconnect();
     std::move(callback).Run(mojom::SolanaProviderError::kSuccess, "",
                             base::Value::Dict());
-  } else if (*method == solana::kSignTransaction) {
+  } else if (*method == kSolanaSignTransaction) {
     const std::string* message = params->FindString(kMessage);
     if (!message) {
       std::move(callback).Run(
@@ -704,7 +710,7 @@ void SolanaProviderImpl::Request(base::Value::Dict arg,
             *message, std::vector<mojom::SignaturePubkeyPairPtr>()),
         base::BindOnce(&SolanaProviderImpl::OnRequestSignTransaction,
                        weak_factory_.GetWeakPtr(), std::move(callback)));
-  } else if (*method == solana::kSignAndSendTransaction) {
+  } else if (*method == kSolanaSignAndSendTransaction) {
     const std::string* message = params->FindString(kMessage);
     if (!message) {
       std::move(callback).Run(
@@ -722,7 +728,7 @@ void SolanaProviderImpl::Request(base::Value::Dict arg,
         mojom::SolanaSignTransactionParam::New(
             *message, std::vector<mojom::SignaturePubkeyPairPtr>()),
         std::move(options), std::move(callback));
-  } else if (*method == solana::kSignAllTransactions) {
+  } else if (*method == kSolanaSignAllTransactions) {
     const base::Value::List* messages = params->FindList(kMessage);
     if (!messages) {
       std::move(callback).Run(
@@ -745,7 +751,7 @@ void SolanaProviderImpl::Request(base::Value::Dict arg,
         std::move(sign_params),
         base::BindOnce(&SolanaProviderImpl::OnRequestSignAllTransactions,
                        weak_factory_.GetWeakPtr(), std::move(callback)));
-  } else if (*method == solana::kSignMessage) {
+  } else if (*method == kSolanaSignMessage) {
     const auto* message = params->FindBlob(kMessage);
     if (!message) {
       std::move(callback).Run(

--- a/components/brave_wallet/common/eth_request_helper.cc
+++ b/components/brave_wallet/common/eth_request_helper.cc
@@ -25,10 +25,13 @@
 #include "brave/components/brave_wallet/common/eth_requests.h"
 #include "brave/components/brave_wallet/common/hex_utils.h"
 #include "brave/components/brave_wallet/common/json_rpc_requests.h"
-#include "brave/components/brave_wallet/common/web3_provider_constants.h"
 #include "url/gurl.h"
 
 namespace {
+
+constexpr char kId[] = "id";
+constexpr char kMethod[] = "method";
+constexpr char kParams[] = "params";
 
 std::optional<base::Value::List> GetParamsList(std::string_view json) {
   auto json_value =
@@ -39,7 +42,7 @@ std::optional<base::Value::List> GetParamsList(std::string_view json) {
   }
 
   auto& value = *json_value;
-  auto* params = value.FindListByDottedPath(brave_wallet::kParams);
+  auto* params = value.FindListByDottedPath(kParams);
   if (!params) {
     return std::nullopt;
   }
@@ -64,7 +67,7 @@ std::optional<base::Value::Dict> GetParamsDict(std::string_view json) {
   if (!json_value) {
     return std::nullopt;
   }
-  auto* value = json_value->FindDict(brave_wallet::kParams);
+  auto* value = json_value->FindDict(kParams);
   if (!value) {
     return std::nullopt;
   }

--- a/components/brave_wallet/common/web3_provider_constants.h
+++ b/components/brave_wallet/common/web3_provider_constants.h
@@ -11,55 +11,6 @@ namespace brave_wallet {
 inline constexpr char kConnectEvent[] = "connect";
 inline constexpr char kDisconnectEvent[] = "disconnect";
 
-namespace ethereum {
-inline constexpr char kChainChangedEvent[] = "chainChanged";
-inline constexpr char kAccountsChangedEvent[] = "accountsChanged";
-inline constexpr char kMessageEvent[] = "message";
-}  // namespace ethereum
-
-namespace solana {
-inline constexpr char kAccountChangedEvent[] = "accountChanged";
-inline constexpr char kConnect[] = "connect";
-inline constexpr char kDisconnect[] = "disconnect";
-inline constexpr char kSignTransaction[] = "signTransaction";
-inline constexpr char kSignAndSendTransaction[] = "signAndSendTransaction";
-inline constexpr char kSignAllTransactions[] = "signAllTransactions";
-inline constexpr char kSignMessage[] = "signMessage";
-}  // namespace solana
-
-inline constexpr char kEthAccounts[] = "eth_accounts";
-inline constexpr char kEthCoinbase[] = "eth_coinbase";
-inline constexpr char kEthRequestAccounts[] = "eth_requestAccounts";
-inline constexpr char kEthSendTransaction[] = "eth_sendTransaction";
-inline constexpr char kEthSignTransaction[] = "eth_signTransaction";
-inline constexpr char kEthSendRawTransaction[] = "eth_sendRawTransaction";
-inline constexpr char kEthGetBlockByNumber[] = "eth_getBlockByNumber";
-inline constexpr char kEthBlockNumber[] = "eth_blockNumber";
-inline constexpr char kEthSign[] = "eth_sign";
-inline constexpr char kPersonalSign[] = "personal_sign";
-inline constexpr char kPersonalEcRecover[] = "personal_ecRecover";
-inline constexpr char kEthGetEncryptionPublicKey[] =
-    "eth_getEncryptionPublicKey";
-inline constexpr char kEthDecrypt[] = "eth_decrypt";
-inline constexpr char kWalletWatchAsset[] = "wallet_watchAsset";
-inline constexpr char kMetamaskWatchAsset[] = "metamask_watchAsset";
-inline constexpr char kWeb3ClientVersion[] = "web3_clientVersion";
-inline constexpr char kEthSubscribe[] = "eth_subscribe";
-inline constexpr char kEthUnsubscribe[] = "eth_unsubscribe";
-inline constexpr char kEthSubscribeNewHeads[] = "newHeads";
-inline constexpr char kEthSubscribeLogs[] = "logs";
-
-inline constexpr char kEthSignTypedDataV3[] = "eth_signTypedData_v3";
-inline constexpr char kEthSignTypedDataV4[] = "eth_signTypedData_v4";
-inline constexpr char kId[] = "id";
-inline constexpr char kMethod[] = "method";
-inline constexpr char kParams[] = "params";
-inline constexpr char kAddEthereumChainMethod[] = "wallet_addEthereumChain";
-inline constexpr char kSwitchEthereumChainMethod[] =
-    "wallet_switchEthereumChain";
-inline constexpr char kRequestPermissionsMethod[] = "wallet_requestPermissions";
-inline constexpr char kGetPermissionsMethod[] = "wallet_getPermissions";
-
 }  // namespace brave_wallet
 
 #endif  // BRAVE_COMPONENTS_BRAVE_WALLET_COMMON_WEB3_PROVIDER_CONSTANTS_H_

--- a/components/brave_wallet/renderer/js_ethereum_provider.cc
+++ b/components/brave_wallet/renderer/js_ethereum_provider.cc
@@ -68,6 +68,10 @@ constexpr char kIsMetaMask[] = "isMetaMask";
 constexpr char kMetaMask[] = "_metamask";
 constexpr char kIsUnlocked[] = "isUnlocked";
 
+constexpr char kEthereumChainChangedEvent[] = "chainChanged";
+constexpr char kEthereumAccountsChangedEvent[] = "accountsChanged";
+constexpr char kEthereumMessageEvent[] = "message";
+
 }  // namespace
 
 namespace brave_wallet {
@@ -647,7 +651,7 @@ void JSEthereumProvider::ChainChangedEvent(const std::string& chain_id) {
     return;
   }
 
-  FireEvent(ethereum::kChainChangedEvent, base::Value(chain_id));
+  FireEvent(kEthereumChainChangedEvent, base::Value(chain_id));
   chain_id_ = chain_id;
 }
 
@@ -661,7 +665,7 @@ void JSEthereumProvider::AccountsChangedEvent(
   if (accounts.size() > 0) {
     first_allowed_account_ = accounts[0];
   }
-  FireEvent(ethereum::kAccountsChangedEvent, event_args);
+  FireEvent(kEthereumAccountsChangedEvent, event_args);
 }
 
 void JSEthereumProvider::MessageEvent(const std::string& subscription_id,
@@ -672,7 +676,7 @@ void JSEthereumProvider::MessageEvent(const std::string& subscription_id,
   data.Set("result", std::move(result));
   event_args.Set("type", "eth_subscription");
   event_args.Set("data", std::move(data));
-  FireEvent(ethereum::kMessageEvent, event_args);
+  FireEvent(kEthereumMessageEvent, event_args);
 }
 
 void JSEthereumProvider::OnProviderRequested() {

--- a/components/brave_wallet/renderer/js_solana_provider.cc
+++ b/components/brave_wallet/renderer/js_solana_provider.cc
@@ -89,6 +89,8 @@ constexpr char kSolanaProxyHandlerScript[] = R"((function() {
   return handler;
 })())";
 
+constexpr char kSolanaAccountChangedEvent[] = "accountChanged";
+
 }  // namespace
 
 JSSolanaProvider::JSSolanaProvider(content::RenderFrame* render_frame)
@@ -229,7 +231,7 @@ void JSSolanaProvider::AccountChangedEvent(
     v8::Local<v8::Value> v8_public_key = CreatePublicKey(context, *account);
     args.push_back(std::move(v8_public_key));
   }
-  FireEvent(solana::kAccountChangedEvent, std::move(args));
+  FireEvent(kSolanaAccountChangedEvent, std::move(args));
 }
 
 void JSSolanaProvider::DisconnectEvent() {


### PR DESCRIPTION
This PR removes a good number of constants declared in
`components/brave_wallet/common/web3_provider_constants.h`, as these
constants are only used once in a single source, so it makes sense to
keep them close to where they are used.

Resolves https://github.com/brave/brave-browser/issues/47372
