### PR TITLE
[CodeHealth] Remove uses of `SpawnedTestServer`

### DIFF
--- a/browser/brave_shields/ad_block_service_browsertest.h
+++ b/browser/brave_shields/ad_block_service_browsertest.h
@@ -16,7 +16,6 @@
 #include "brave/components/brave_shields/content/test/test_filters_provider.h"
 #include "chrome/test/base/platform_browser_test.h"
 #include "content/public/test/content_mock_cert_verifier.h"
-#include "net/test/spawned_test_server/spawned_test_server.h"
 
 class HostContentSettingsMap;
 

--- a/browser/brave_shields/websockets_pool_limit_browsertest.cc
+++ b/browser/brave_shields/websockets_pool_limit_browsertest.cc
@@ -20,7 +20,8 @@
 #include "content/public/test/content_mock_cert_verifier.h"
 #include "extensions/buildflags/buildflags.h"
 #include "net/dns/mock_host_resolver.h"
-#include "net/test/spawned_test_server/spawned_test_server.h"
+#include "net/test/embedded_test_server/embedded_test_server.h"
+#include "net/test/embedded_test_server/install_default_websocket_handlers.h"
 #include "net/test/test_data_directory.h"
 #include "third_party/blink/public/common/features.h"
 #include "url/gurl.h"
@@ -108,11 +109,13 @@ class WebSocketsPoolLimitBrowserTest : public InProcessBrowserTest {
     content::SetupCrossSiteRedirector(&https_server_);
     ASSERT_TRUE(https_server_.Start());
 
-    ws_server_ = std::make_unique<net::SpawnedTestServer>(
-        net::SpawnedTestServer::TYPE_WSS, net::GetWebSocketTestDataDirectory());
+    ws_server_ = std::make_unique<net::EmbeddedTestServer>(
+        net::EmbeddedTestServer::TYPE_HTTPS);
+    net::test_server::InstallDefaultWebSocketHandlers(ws_server_.get());
     ASSERT_TRUE(ws_server_->Start());
 
-    ws_url_ = ws_server_->GetURL("a.com", "echo-with-no-extension");
+    ws_url_ = net::test_server::GetWebSocketURL(*ws_server_, "a.com",
+                                                "/echo-with-no-extension");
   }
 
   void SetUpCommandLine(base::CommandLine* command_line) override {
@@ -179,8 +182,7 @@ class WebSocketsPoolLimitBrowserTest : public InProcessBrowserTest {
                        std::string_view script_template,
                        int count) {
     for (int i = 0; i < count; ++i) {
-      EXPECT_EQ("close",
-                content::EvalJs(rfh, content::JsReplace(script_template, i)));
+      EXPECT_TRUE(content::ExecJs(rfh, content::JsReplace(script_template, i)));
     }
   }
 
@@ -195,7 +197,7 @@ class WebSocketsPoolLimitBrowserTest : public InProcessBrowserTest {
   content::ContentMockCertVerifier mock_cert_verifier_;
   net::test_server::EmbeddedTestServer https_server_{
       net::test_server::EmbeddedTestServer::TYPE_HTTPS};
-  std::unique_ptr<net::SpawnedTestServer> ws_server_;
+  std::unique_ptr<net::EmbeddedTestServer> ws_server_;
   GURL ws_url_;
 
  private:

--- a/browser/permissions/localhost_access_permission_browsertest.cc
+++ b/browser/permissions/localhost_access_permission_browsertest.cc
@@ -35,7 +35,8 @@
 #include "content/public/test/content_mock_cert_verifier.h"
 #include "content/public/test/test_navigation_observer.h"
 #include "net/dns/mock_host_resolver.h"
-#include "net/test/spawned_test_server/spawned_test_server.h"
+#include "net/test/embedded_test_server/embedded_test_server.h"
+#include "net/test/embedded_test_server/install_default_websocket_handlers.h"
 #include "net/test/test_data_directory.h"
 #include "url/gurl.h"
 
@@ -367,10 +368,11 @@ IN_PROC_BROWSER_TEST_F(LocalhostAccessBrowserTest, NoPermissionPrompt) {
 // Test that WebSocket connections to localhost are blocked/allowed.
 IN_PROC_BROWSER_TEST_F(LocalhostAccessBrowserTest, WebSocket) {
   // Start a WebSocket server.
-  auto ws_server = std::make_unique<net::SpawnedTestServer>(
-      net::SpawnedTestServer::TYPE_WSS, net::GetWebSocketTestDataDirectory());
-  ASSERT_TRUE(ws_server->Start());
-  auto ws_url = ws_server->GetURL("localhost", "echo-with-no-extension");
+  net::EmbeddedTestServer ws_server(net::EmbeddedTestServer::TYPE_HTTPS);
+  net::test_server::InstallDefaultWebSocketHandlers(&ws_server);
+  ASSERT_TRUE(ws_server.Start());
+  auto ws_url = net::test_server::GetWebSocketURL(ws_server, "localhost",
+                                                  "/echo-with-no-extension");
   // Script to connect to ws server.
   std::string ws_open_script_template = R"(
     new Promise(resolve => {


### PR DESCRIPTION
This test class relies on python, and has been deprecated. There's active work in getting it deleted eventually. This PR fixes all the places where `SpawnedTestServer` was being used, to make use of the `net::EmbeddedTestServer` equivalent.

Resolves https://github.com/brave/brave-browser/issues/45577
