### PR TITLE
[ads] Support fonts for RichNTT (uplift to 1.80.x)

### DIFF
--- a/components/ntp_background_images/browser/ntp_sponsored_rich_media_source.cc
+++ b/components/ntp_background_images/browser/ntp_sponsored_rich_media_source.cc
@@ -94,6 +94,8 @@ std::string NTPSponsoredRichMediaSource::GetContentSecurityPolicy(
       return "script-src 'self';";
     case network::mojom::CSPDirectiveName::StyleSrc:
       return "style-src 'self';";
+    case network::mojom::CSPDirectiveName::FontSrc:
+      return "font-src 'self';";
     case network::mojom::CSPDirectiveName::ImgSrc:
       return "img-src 'self';";
     case network::mojom::CSPDirectiveName::MediaSrc:

--- a/components/ntp_background_images/browser/ntp_sponsored_rich_media_source_unittest.cc
+++ b/components/ntp_background_images/browser/ntp_sponsored_rich_media_source_unittest.cc
@@ -129,7 +129,7 @@ TEST_F(NTPSponsoredRichMediaSourceTest,
 }
 
 TEST_F(NTPSponsoredRichMediaSourceTest,
-       DoNotStartDataRequestIfContentIsOutsideOfSandbox3) {
+       DoNotStartDataRequestIfContentIsOutsideOfSandbox) {
   EXPECT_THAT(StartDataRequest(
                   GURL("chrome-untrusted://new-tab-takeover/restricted.jpg")),
               ::testing::IsEmpty());
@@ -210,6 +210,12 @@ TEST_F(NTPSponsoredRichMediaSourceTest, GetContentSecurityPolicy) {
 
       case network::mojom::CSPDirectiveName::StyleSrc: {
         EXPECT_EQ("style-src 'self';",
+                  url_data_source()->GetContentSecurityPolicy(directive));
+        break;
+      }
+
+      case network::mojom::CSPDirectiveName::FontSrc: {
+        EXPECT_EQ("font-src 'self';",
                   url_data_source()->GetContentSecurityPolicy(directive));
         break;
       }


### PR DESCRIPTION
Uplift of #29890
Resolves https://github.com/brave/brave-browser/issues/47323

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.