### PR TITLE
PageGraph: Add additional items to track

### DIFF
--- a/chromium_src/third_party/blink/renderer/bindings/scripts/bind_gen/interface.py
+++ b/chromium_src/third_party/blink/renderer/bindings/scripts/bind_gen/interface.py
@@ -25,9 +25,8 @@ _IS_OBSERVABLE_ARRAY_SETTER = "pg_is_observable_array_setter"
 
 # Allowed WebAPIs to track.
 _PAGE_GRAPH_TRACKED_ITEMS = {
-    "OffscreenCanvasRenderingContext2D": {
-        "measureText",
-    },
+    "AudioContext": {"*"},
+    "BaseAudioContext": {"*"},
     "CanvasRenderingContext2D": {
         "measureText",
     },
@@ -35,41 +34,48 @@ _PAGE_GRAPH_TRACKED_ITEMS = {
         "cookie",
         "referrer",
     },
+    "DynamicsCompressorNode": {"*"},
+    "Geolocation": {"*"},
     "HTMLCanvasElement": {
         "getContext",
         "toBlob",
         "toDataURL",
     },
-    "Geolocation": {"*"},
     "Location": {"*"},
     "MediaDevices": {"*"},
     "Navigator": {"*"},
+    "OfflineAudioContext": {"*"},
+    "OffscreenCanvasRenderingContext2D": {
+        "measureText",
+    },
+    "OscillatorNode": {"*"},
     "Performance": {"*"},
-    "PerformanceObserver": {"*"},
     "PerformanceNavigation": {"*"},
+    "PerformanceObserver": {"*"},
     "PerformanceTiming": {"*"},
     "Screen": {"*"},
     "Storage": {"*"},
-    "Window": {
-        "performance",
-        "fetch",
-        "setTimeout",
-        "setInterval",
-        "clearTimeout",
-        "clearInterval",
-    },
-    "WorkerGlobalScope": {
-        "performance",
-        "fetch",
+    "WebGL2RenderingContext": {
+        "getExtension",
+        "getParameter",
     },
     "WebGLRenderingContext": {
         "getExtension",
         "getParameter",
         "getShaderPrecisionFormat",
     },
-    "WebGL2RenderingContext": {
-        "getExtension",
-        "getParameter",
+    "Window": {
+        "clearInterval",
+        "clearTimeout",
+        "fetch",
+        "matchMedia",
+        "performance",
+        "setInterval",
+        "setTimeout",
+    },
+    "WorkerGlobalScope": {
+        "fetch",
+        "performance",
     },
     "XMLHttpRequest": {"*"},
     "XMLHttpRequestEventTarget": {"*"},


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/47395

This commit adds Web API used in [fingerprintjs](https://github.com/fingerprintjs/fingerprintjs/tree/master/src/sources) to the default list of tracked items. It does not cover all instrumented APIs, for example `ApplePaySession` ([here](https://github.com/fingerprintjs/fingerprintjs/blob/master/src/sources/apple_pay.ts)) is ignored due to its very specific scope, but it covers a substantial portion of the commonly used ones. Many relevant items were already tracked in the existing default list.

