### PR TITLE
[ads] Always allow ad serving permission when Rewards wallet is not connected

### DIFF
--- a/components/brave_ads/core/internal/ad_units/new_tab_page_ad/new_tab_page_ad_test.cc
+++ b/components/brave_ads/core/internal/ad_units/new_tab_page_ad/new_tab_page_ad_test.cc
@@ -155,6 +155,25 @@ TEST_F(BraveAdsNewTabPageAdIntegrationTest, ServeAd) {
 }
 
 TEST_F(BraveAdsNewTabPageAdIntegrationTest,
+       AlwaysServeAdIfUserHasJoinedBraveRewardsAndNotConnectedWallet) {
+  // Arrange
+  const base::test::ScopedFeatureList scoped_feature_list(
+      {kNewTabPageAdServingFeature});
+
+  test::DisconnectExternalBraveRewardsWallet();
+
+  MockCreativeNewTabPageAds();
+
+  // Act & Assert
+  base::MockCallback<MaybeServeNewTabPageAdCallback> callback;
+  base::RunLoop run_loop;
+  EXPECT_CALL(callback, Run(/*ad=*/::testing::Ne(std::nullopt)))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
+  GetAds().MaybeServeNewTabPageAd(callback.Get());
+  run_loop.Run();
+}
+
+TEST_F(BraveAdsNewTabPageAdIntegrationTest,
        DoNotServeAdIfPermissionRulesAreDenied) {
   // Arrange
   const base::test::ScopedFeatureList scoped_feature_list(

--- a/components/brave_ads/core/internal/serving/permission_rules/new_tab_page_ads/new_tab_page_ad_permission_rules.cc
+++ b/components/brave_ads/core/internal/serving/permission_rules/new_tab_page_ads/new_tab_page_ad_permission_rules.cc
@@ -24,7 +24,7 @@ bool NewTabPageAdPermissionRules::HasPermission(const AdEventList& ad_events) {
   TRACE_EVENT(kTraceEventCategory,
               "NewTabPageAdPermissionRules::HasPermission");
 
-  if (!UserHasJoinedBraveRewards()) {
+  if (!UserHasJoinedBraveRewardsAndConnectedWallet()) {
     // If the user has not joined Brave Rewards, always grant permission.
     return true;
   }

--- a/components/brave_ads/core/internal/serving/permission_rules/user_activity_permission_rule.cc
+++ b/components/brave_ads/core/internal/serving/permission_rules/user_activity_permission_rule.cc
@@ -13,7 +13,9 @@
 namespace brave_ads {
 
 bool HasUserActivityPermission() {
-  if (!UserHasJoinedBraveRewards()) {
+  if (!UserHasJoinedBraveRewardsAndConnectedWallet()) {
+    // Allow ads if the user has not joined Brave Rewards and connected a
+    // wallet.
     return true;
   }
 

--- a/components/brave_ads/core/internal/serving/permission_rules/user_activity_permission_rule_unittest.cc
+++ b/components/brave_ads/core/internal/serving/permission_rules/user_activity_permission_rule_unittest.cc
@@ -50,8 +50,21 @@ TEST_F(BraveAdsUserActivityPermissionRuleTest,
   EXPECT_TRUE(HasUserActivityPermission());
 }
 
+TEST_F(
+    BraveAdsUserActivityPermissionRuleTest,
+    ShouldAllowIfUserHasJoinedBraveRewardsAndNotConnectedWalletAndUserActivityScoreIsLessThanThreshold) {
+  // Arrange
+  test::DisconnectExternalBraveRewardsWallet();
+
+  UserActivityManager::GetInstance().RecordEvent(
+      UserActivityEventType::kOpenedNewTab);
+
+  // Act & Assert
+  EXPECT_TRUE(HasUserActivityPermission());
+}
+
 TEST_F(BraveAdsUserActivityPermissionRuleTest,
-       ShouldAllowIfUserActivityScoreIsGreaterThanTheThreshold) {
+       ShouldAllowIfUserActivityScoreIsGreaterThanThreshold) {
   // Arrange
   UserActivityManager::GetInstance().RecordEvent(
       UserActivityEventType::kOpenedNewTab);
@@ -65,7 +78,7 @@ TEST_F(BraveAdsUserActivityPermissionRuleTest,
 }
 
 TEST_F(BraveAdsUserActivityPermissionRuleTest,
-       ShouldNotAllowIfUserActivityScoreIsLessThanTheThreshold) {
+       ShouldNotAllowIfUserActivityScoreIsLessThanThreshold) {
   // Arrange
   UserActivityManager::GetInstance().RecordEvent(
       UserActivityEventType::kOpenedNewTab);


### PR DESCRIPTION
This change ensures that ad serving permission is always granted when the Rewards wallet is not connected. Previously, ad delivery could be blocked in these cases if the wallet status was disconnected, preventing ads from being shown.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/47397

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
