### PR TITLE
[Vertical Tabs] Add feature flag to hide vertical tab strip completely when collapsed

### DIFF
--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -338,42 +338,49 @@ const char* const kBraveSyncImplLink[1] = {"https://github.com/brave/go-sync"};
 #endif  // BUILDFLAG(IS_ANDROID)
 
 #if !BUILDFLAG(IS_ANDROID)
-#define BRAVE_TABS_FEATURE_ENTRIES                                         \
-  EXPAND_FEATURE_ENTRIES(                                                  \
-      {                                                                    \
-          "brave-shared-pinned-tabs",                                      \
-          "Shared pinned tab",                                             \
-          "Pinned tabs are shared across windows",                         \
-          kOsWin | kOsMac | kOsLinux,                                      \
-          FEATURE_VALUE_TYPE(tabs::features::kBraveSharedPinnedTabs),      \
-      },                                                                   \
-      {                                                                    \
-          "brave-horizontal-tabs-update",                                  \
-          "Updated horizontal tabs design",                                \
-          "Updates the look and feel or horizontal tabs",                  \
-          kOsWin | kOsMac | kOsLinux,                                      \
-          FEATURE_VALUE_TYPE(tabs::features::kBraveHorizontalTabsUpdate),  \
-      },                                                                   \
-      {                                                                    \
-          "brave-compact-horizontal-tabs",                                 \
-          "Compact horizontal tabs design",                                \
-          "Reduces the height of horizontal tabs",                         \
-          kOsWin | kOsMac | kOsLinux,                                      \
-          FEATURE_VALUE_TYPE(tabs::features::kBraveCompactHorizontalTabs), \
-      },                                                                   \
-      {                                                                    \
-          "brave-vertical-tab-scroll-bar",                                 \
-          "Show scroll bar on vertical tab strip",                         \
-          "Shows scroll bar on vertical tab strip when it overflows",      \
-          kOsWin | kOsMac | kOsLinux,                                      \
-          FEATURE_VALUE_TYPE(tabs::features::kBraveVerticalTabScrollBar),  \
-      },                                                                   \
-      {                                                                    \
-          kSplitViewFeatureInternalName,                                   \
-          "Enable split view",                                             \
-          "Enables split view",                                            \
-          kOsWin | kOsMac | kOsLinux,                                      \
-          FEATURE_VALUE_TYPE(tabs::features::kBraveSplitView),             \
+#define BRAVE_TABS_FEATURE_ENTRIES                                             \
+  EXPAND_FEATURE_ENTRIES(                                                      \
+      {                                                                        \
+          "brave-shared-pinned-tabs",                                          \
+          "Shared pinned tab",                                                 \
+          "Pinned tabs are shared across windows",                             \
+          kOsWin | kOsMac | kOsLinux,                                          \
+          FEATURE_VALUE_TYPE(tabs::features::kBraveSharedPinnedTabs),          \
+      },                                                                       \
+      {                                                                        \
+          "brave-horizontal-tabs-update",                                      \
+          "Updated horizontal tabs design",                                    \
+          "Updates the look and feel or horizontal tabs",                      \
+          kOsWin | kOsMac | kOsLinux,                                          \
+          FEATURE_VALUE_TYPE(tabs::features::kBraveHorizontalTabsUpdate),      \
+      },                                                                       \
+      {                                                                        \
+          "brave-compact-horizontal-tabs",                                     \
+          "Compact horizontal tabs design",                                    \
+          "Reduces the height of horizontal tabs",                             \
+          kOsWin | kOsMac | kOsLinux,                                          \
+          FEATURE_VALUE_TYPE(tabs::features::kBraveCompactHorizontalTabs),     \
+      },                                                                       \
+      {                                                                        \
+          "brave-vertical-tab-scroll-bar",                                     \
+          "Show scroll bar on vertical tab strip",                             \
+          "Shows scroll bar on vertical tab strip when it overflows",          \
+          kOsWin | kOsMac | kOsLinux,                                          \
+          FEATURE_VALUE_TYPE(tabs::features::kBraveVerticalTabScrollBar),      \
+      },                                                                       \
+      {                                                                        \
+          "brave-vertical-tab-hide-completely",                                \
+          "Brave Vertical Tab Hide Completely",                                \
+          "Hides the vertical tab strip when collapsed",                       \
+          kOsWin | kOsMac | kOsLinux,                                          \
+          FEATURE_VALUE_TYPE(tabs::features::kBraveVerticalTabHideCompletely), \
+      },                                                                       \
+      {                                                                        \
+          kSplitViewFeatureInternalName,                                       \
+          "Enable split view",                                                 \
+          "Enables split view",                                                \
+          kOsWin | kOsMac | kOsLinux,                                          \
+          FEATURE_VALUE_TYPE(tabs::features::kBraveSplitView),                 \
       })
 #else
 #define BRAVE_TABS_FEATURE_ENTRIES

--- a/browser/ui/tabs/features.cc
+++ b/browser/ui/tabs/features.cc
@@ -31,6 +31,10 @@ BASE_FEATURE(kBraveVerticalTabScrollBar,
              "BraveVerticalTabScrollBar",
              base::FEATURE_DISABLED_BY_DEFAULT);
 
+BASE_FEATURE(kBraveVerticalTabHideCompletely,
+             "BraveVerticalTabHideCompletely",
+             base::FEATURE_DISABLED_BY_DEFAULT);
+
 BASE_FEATURE(kBraveSplitView,
              "BraveSplitView",
              base::FEATURE_ENABLED_BY_DEFAULT);

--- a/browser/ui/tabs/features.h
+++ b/browser/ui/tabs/features.h
@@ -23,6 +23,8 @@ BASE_DECLARE_FEATURE(kBraveCompactHorizontalTabs);
 
 BASE_DECLARE_FEATURE(kBraveVerticalTabScrollBar);
 
+BASE_DECLARE_FEATURE(kBraveVerticalTabHideCompletely);
+
 BASE_DECLARE_FEATURE(kBraveSplitView);
 
 bool HorizontalTabsUpdateEnabled();

--- a/browser/ui/views/frame/brave_browser_view.h
+++ b/browser/ui/views/frame/brave_browser_view.h
@@ -166,6 +166,7 @@ class BraveBrowserView : public BrowserView,
   FRIEND_TEST_ALL_PREFIXES(VerticalTabStripBrowserTest, ExpandedWidth);
   FRIEND_TEST_ALL_PREFIXES(SideBySideEnabledBrowserTest,
                            BraveMultiContentsViewTest);
+  FRIEND_TEST_ALL_PREFIXES(VerticalTabStripHideCompletelyTest, GetMinimumWidth);
 
   static void SetDownloadConfirmReturnForTesting(bool allow);
 

--- a/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_browsertest.cc
+++ b/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_browsertest.cc
@@ -1178,3 +1178,33 @@ IN_PROC_BROWSER_TEST_F(VerticalTabStripScrollBarFlagTest, MigrationTest) {
   EXPECT_FALSE(pref->IsDefaultValue());
   EXPECT_TRUE(prefs->GetBoolean(brave_tabs::kVerticalTabsShowScrollbar));
 }
+
+class VerticalTabStripHideCompletelyTest : public VerticalTabStripBrowserTest {
+ public:
+  VerticalTabStripHideCompletelyTest()
+      : feature_list_(tabs::features::kBraveVerticalTabHideCompletely) {}
+
+  ~VerticalTabStripHideCompletelyTest() override = default;
+
+ private:
+  base::test::ScopedFeatureList feature_list_;
+};
+
+IN_PROC_BROWSER_TEST_F(VerticalTabStripHideCompletelyTest, GetMinimumWidth) {
+  // Given vertical tab strip is enabled and collapsed with the flag is on
+  ToggleVerticalTabStrip();
+  auto* widget_delegate_view =
+      browser_view()->vertical_tab_strip_widget_delegate_view_.get();
+  ASSERT_TRUE(widget_delegate_view);
+
+  auto* region_view = widget_delegate_view->vertical_tab_strip_region_view();
+  ASSERT_TRUE(region_view);
+
+  region_view->ToggleState();
+  ASSERT_EQ(VerticalTabStripRegionView::State::kCollapsed,
+            region_view->state());
+
+  // The minimum width of the region view should be 4px, which is narrower than
+  // it used to be.
+  EXPECT_EQ(4, region_view->GetMinimumSize().width());
+}

--- a/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.cc
@@ -1354,12 +1354,6 @@ gfx::Size VerticalTabStripRegionView::GetPreferredSizeForState(
     return {};
   }
 
-  if (IsFloatingEnabledForBrowserFullscreen() && state_ == State::kCollapsed) {
-    // In this case, vertical tab strip should be invisible but show up when
-    // mouse hovers.
-    return {2, View::CalculatePreferredSize({}).height()};
-  }
-
   return {GetPreferredWidthForState(state, include_border, ignore_animation),
           View::CalculatePreferredSize({}).height()};
 }
@@ -1373,8 +1367,17 @@ int VerticalTabStripRegionView::GetPreferredWidthForState(
   };
 
   auto calculate_collapsed_width = [&]() {
+    if (IsFloatingEnabledForBrowserFullscreen()) {
+      // In this case, vertical tab strip should be invisible but show up when
+      // mouse hovers.
+      // there's no border visible, so 2px is enough.
+      return 2;
+    }
+
     if (base::FeatureList::IsEnabled(
             tabs::features::kBraveVerticalTabHideCompletely)) {
+      // Typical window frame border is 8px, so we can use 4px as vertical tab
+      // space only takes inner 4px.
       return 4;
     }
 

--- a/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.cc
@@ -14,12 +14,14 @@
 #include "base/check.h"
 #include "base/check_op.h"
 #include "base/dcheck_is_on.h"
+#include "base/feature_list.h"
 #include "base/functional/bind.h"
 #include "base/strings/string_split.h"
 #include "brave/app/vector_icons/vector_icons.h"
 #include "brave/browser/ui/brave_browser.h"
 #include "brave/browser/ui/color/brave_color_id.h"
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
+#include "brave/browser/ui/tabs/features.h"
 #include "brave/browser/ui/views/brave_tab_search_bubble_host.h"
 #include "brave/browser/ui/views/frame/brave_contents_view_util.h"
 #include "brave/browser/ui/views/tabs/brave_new_tab_button.h"
@@ -1132,8 +1134,17 @@ void VerticalTabStripRegionView::OnBoundsChanged(
 
 #if DCHECK_IS_ON()
   DCHECK(GetWidget());
+  // In this mode,vertical tab strip takes a little width, such as 4px, and
+  // when mouse is hovered, it expands to the full width.
+  const bool is_hot_corner =
+      IsBrowserFullscren() ||
+      (base::FeatureList::IsEnabled(
+           tabs::features::kBraveVerticalTabHideCompletely) &&
+       state_ == State::kCollapsed);
+
+  // Checks if the width is in valid range when it's visible.
   if (auto width = GetContentsBounds().width();
-      width && !IsBrowserFullscren() && GetWidget()->IsVisible()) {
+      width && !is_hot_corner && GetWidget()->IsVisible()) {
     CHECK_GE(
         width,
         tabs::kVerticalTabMinWidth + tabs::kMarginForVerticalTabContainers * 2 -
@@ -1362,6 +1373,11 @@ int VerticalTabStripRegionView::GetPreferredWidthForState(
   };
 
   auto calculate_collapsed_width = [&]() {
+    if (base::FeatureList::IsEnabled(
+            tabs::features::kBraveVerticalTabHideCompletely)) {
+      return 4;
+    }
+
     return tabs::kVerticalTabMinWidth +
            tabs::kMarginForVerticalTabContainers * 2 +
            (include_border ? GetInsets().width() : 0);
@@ -1394,7 +1410,9 @@ VerticalTabStripRegionView::GetTabStripScrollContainer() {
 
 bool VerticalTabStripRegionView::IsFloatingVerticalTabsEnabled() const {
   return IsFloatingEnabledForBrowserFullscreen() ||
-         tabs::utils::IsFloatingVerticalTabsEnabled(browser_);
+         tabs::utils::IsFloatingVerticalTabsEnabled(browser_) ||
+         base::FeatureList::IsEnabled(
+             tabs::features::kBraveVerticalTabHideCompletely);
 }
 
 bool VerticalTabStripRegionView::IsFloatingEnabledForBrowserFullscreen() const {

--- a/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.cc
@@ -1075,9 +1075,6 @@ void VerticalTabStripRegionView::OnMouseExited() {
   mouse_enter_timer_.Stop();
   if (state_ == State::kFloating) {
     SetState(State::kCollapsed);
-    if (IsFloatingEnabledForBrowserFullscreen()) {
-      SetVisible(false);
-    }
   }
 }
 
@@ -1211,6 +1208,11 @@ void VerticalTabStripRegionView::AnimationProgressed(
 void VerticalTabStripRegionView::AnimationEnded(
     const gfx::Animation* animation) {
   PreferredSizeChanged();
+
+  if (IsFloatingEnabledForBrowserFullscreen() && state_ == State::kCollapsed) {
+    // When the animation ends, we should hide the vertical tab strip.
+    SetVisible(false);
+  }
 }
 
 void VerticalTabStripRegionView::UpdateNewTabButtonVisibility() {


### PR DESCRIPTION
When a new feature flag is enabled, the vertical tab strip will be
completely hidden when it is collapsed, rather than just showing 
a narrow strip. This allows users to have a cleaner interface when
they prefer not to see the vertical tab strip at all.

This is implemented by adding a new feature flag for it, 
`kBraveVerticalTabsHideWhenCollapsed`, and making minimum width of
vertical tab strip tab strip region view have 4px when it's collapsed.

4px is needed for users to expand the vertical tab strip again by
hovering over the collapsed area.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/42052

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
