### PR TITLE
[ads] Followup: Add condition matcher virtual prefs for advertisers, campaigns, creative sets, and creative instances #45662 (uplift to 1.81.x)

### DIFF
--- a/components/brave_ads/core/internal/user_engagement/ad_events/ad_events_database_table.cc
+++ b/components/brave_ads/core/internal/user_engagement/ad_events/ad_events_database_table.cc
@@ -466,8 +466,7 @@ void AdEvents::GetVirtualPrefs(const base::flat_set<std::string>& ids,
               OR advertiser_id IN ($1)
           )
           WHERE id IS NOT NULL
-          GROUP BY id, confirmation_type;
-        )",
+          GROUP BY id, confirmation_type;)",
       {base::JoinString(quoted_ids, ", ")}, nullptr);
   mojom_db_action->bind_column_types = {
       mojom::DBBindColumnType::kString,  // id


### PR DESCRIPTION
Uplift of #29929
Resolves https://github.com/brave/brave-browser/issues/47424

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.