### PR TITLE
Fixes incorrect initialization of secondary_contents_scrim_view in SplitView. (uplift to 1.81.x)

### DIFF
--- a/browser/ui/views/split_view/split_view.cc
+++ b/browser/ui/views/split_view/split_view.cc
@@ -101,7 +101,7 @@ SplitView::SplitView(Browser& browser,
 
   secondary_devtools_web_view_ = secondary_contents_container_->AddChildView(
       std::make_unique<views::WebView>(browser_->profile()));
-  secondary_contents_scrim_view_ = secondary_contents_container_->AddChildView(
+  secondary_devtools_scrim_view_ = secondary_contents_container_->AddChildView(
       std::make_unique<ScrimView>());
   secondary_contents_web_view_ = secondary_contents_container_->AddChildView(
       std::make_unique<ActivatableContentsWebView>(browser_->profile()));
@@ -126,7 +126,7 @@ SplitView::SplitView(Browser& browser,
 
   secondary_contents_container_->SetLayoutManager(
       std::make_unique<BraveContentsLayoutManager>(
-          secondary_devtools_web_view_, secondary_contents_scrim_view_,
+          secondary_devtools_web_view_, secondary_devtools_scrim_view_,
           secondary_contents_web_view_, secondary_lens_overlay_view_,
           secondary_contents_scrim_view_, /*border_view*/ nullptr,
           /*watermark_view*/ nullptr, secondary_reader_mode_toolbar_));


### PR DESCRIPTION
Uplift of #29928
Resolves https://github.com/brave/brave-browser/issues/47423

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.