### PR TITLE
threads through --no-history flag enabling faster cloning using gclient 

### DIFF
--- a/build/commands/lib/syncUtils.js
+++ b/build/commands/lib/syncUtils.js
@@ -117,6 +117,7 @@ function syncChromium(program) {
   const deleteUnusedDeps = program.delete_unused_deps
   const gclientWithoutRevision = program.with_issue_44921
 
+
   const requiredChromiumRef = config.getProjectRef('chrome')
   let args = ['sync', '--nohooks', '--reset', '--upstream']
 
@@ -132,6 +133,10 @@ function syncChromium(program) {
 
   if (syncWithForce) {
     args.push('--force')
+  }
+
+  if (program.history == false) {
+    args.push('--no-history');
   }
 
   const latestSyncInfoFilePath = path.join(

--- a/build/commands/scripts/sync.js
+++ b/build/commands/scripts/sync.js
@@ -26,6 +26,7 @@ program
   )
   .option('--init', 'initialize all dependencies')
   .option('--force', 'force reset all projects to origin/ref')
+  .option('--no-history', 'performs a shallow clone') // NOTE: sets program.history = false
   .option('--fetch_all', 'fetch all tags and branch heads')
   .option(
     '-C, --sync_chromium [arg]',
@@ -51,6 +52,10 @@ function syncBrave(program) {
 
   if (program.delete_unused_deps) {
     args.push('-D')
+  }
+
+  if (program.history == false) {
+    args.push('--no-history');
   }
 
   util.runGClient(


### PR DESCRIPTION
Resolves: https://github.com/brave/brave-browser/issues/6444

threads through --no-history flag enabling faster cloning using gclient.

GClient currently clones a total of 230 repositories with their complete history.

We can speed up this process by passing --no-history flag to gclient.
This PR is just an enablement and doesn't change the default behaviour.

My local test conclude a reduction of downloaded data from 99GB -> 23GB.
