### PR TITLE
fix(iOS): fix incorrect color/theme being used for Favorites & the omnibox dropdown

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserColors.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserColors.swift
@@ -47,6 +47,11 @@ protocol BrowserColors {
   // MARK: - TabBar
   var tabBarTabBackground: UIColor { get }
   var tabBarTabActiveBackground: UIColor { get }
+
+  // MARK: - Favorites/Search View Controller
+  var favoritesAndSearchScreenBackground: UIColor { get }
+  var favoritesAndSearchScreenSectionBackground: UIColor { get }
+  var favoritesAndSearchScreenSectionGroupBackground: UIColor { get }
 }
 
 extension BrowserColors where Self == StandardBrowserColors {
@@ -144,6 +149,18 @@ struct StandardBrowserColors: BrowserColors {
   var tabBarTabActiveBackground: UIColor {
     .init(light: .primitiveNeutral98, dark: .primitiveNeutral10)
   }
+
+  var favoritesAndSearchScreenBackground: UIColor {
+    .init(light: .primitiveNeutral95, dark: .primitiveNeutral0)
+  }
+
+  var favoritesAndSearchScreenSectionBackground: UIColor {
+    .init(braveSystemName: .materialThin)
+  }
+
+  var favoritesAndSearchScreenSectionGroupBackground: UIColor {
+    self.containerBackground
+  }
 }
 
 /// The set of browser colors specific to private mode
@@ -230,6 +247,18 @@ struct PrivateModeBrowserColors: BrowserColors {
 
   var tabBarTabActiveBackground: UIColor {
     .init(braveSystemName: .primitivePrivateWindow10)
+  }
+
+  var favoritesAndSearchScreenBackground: UIColor {
+    .init(light: .primitivePrivateWindow25, dark: .primitivePrivateWindow5)
+  }
+
+  var favoritesAndSearchScreenSectionBackground: UIColor {
+    .init(light: .primitivePrivateWindow40, dark: .primitivePrivateWindow15)
+  }
+
+  var favoritesAndSearchScreenSectionGroupBackground: UIColor {
+    .init(light: .primitivePrivateWindow50, dark: .primitivePrivateWindow25)
   }
 }
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Favorites/Views/Cells/FavoritesCollectionViewCell.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Favorites/Views/Cells/FavoritesCollectionViewCell.swift
@@ -16,6 +16,12 @@ class FavoritesCollectionViewCell: UICollectionViewCell, CollectionViewReusable 
 
   let textLabel = UILabel()
 
+  var isPrivateBrowsing: Bool = false {
+    didSet {
+      setTheme()
+    }
+  }
+
   override var isHighlighted: Bool {
     didSet {
       UIView.animate(
@@ -58,9 +64,10 @@ class FavoritesCollectionViewCell: UICollectionViewCell, CollectionViewReusable 
   private func setTheme() {
     imageContainer.do {
       $0.layer.cornerRadius = 12.0
-      $0.layer.borderWidth = 0.5
+      $0.layer.borderWidth = isPrivateBrowsing ? 0 : 0.5
       $0.layer.cornerCurve = .continuous
-      $0.layer.borderColor = UIColor(braveSystemName: .dividerSubtle).cgColor
+      $0.layer.borderColor = isPrivateBrowsing ? nil : UIColor(braveSystemName: .dividerSubtle).cgColor
+      $0.backgroundColor = isPrivateBrowsing ? UIColor(braveSystemName: .containerBackground) : nil
     }
 
     textLabel.do {
@@ -79,6 +86,7 @@ class FavoritesCollectionViewCell: UICollectionViewCell, CollectionViewReusable 
       )
       $0.font = font
       $0.lineBreakMode = NSLineBreakMode.byTruncatingTail
+      $0.textColor = isPrivateBrowsing ? .white : UIColor(braveSystemName: .textSecondary)
     }
   }
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Favorites/Views/Cells/FavoritesCollectionViewCell.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Favorites/Views/Cells/FavoritesCollectionViewCell.swift
@@ -66,7 +66,8 @@ class FavoritesCollectionViewCell: UICollectionViewCell, CollectionViewReusable 
       $0.layer.cornerRadius = 12.0
       $0.layer.borderWidth = isPrivateBrowsing ? 0 : 0.5
       $0.layer.cornerCurve = .continuous
-      $0.layer.borderColor = isPrivateBrowsing ? nil : UIColor(braveSystemName: .dividerSubtle).cgColor
+      $0.layer.borderColor =
+        isPrivateBrowsing ? nil : UIColor(braveSystemName: .dividerSubtle).cgColor
       $0.backgroundColor = isPrivateBrowsing ? UIColor(braveSystemName: .containerBackground) : nil
     }
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Favorites/Views/SupplementaryViews/FavoritesHeaderView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Favorites/Views/SupplementaryViews/FavoritesHeaderView.swift
@@ -8,7 +8,13 @@ import Shared
 import UIKit
 
 class FavoritesHeaderView: UICollectionReusableView {
-  let label = UILabel()
+  private let label = UILabel()
+
+  var isPrivateBrowsing: Bool = false {
+    didSet {
+      setTheme()
+    }
+  }
 
   override init(frame: CGRect) {
     super.init(frame: frame)
@@ -34,7 +40,7 @@ class FavoritesHeaderView: UICollectionReusableView {
   private func setTheme() {
     label.do {
       $0.text = Strings.recentSearchFavorites
-      $0.textColor = UIColor(braveSystemName: .textPrimary)
+      $0.textColor = isPrivateBrowsing ? .white : UIColor(braveSystemName: .textPrimary)
 
       var sizeCategory = UIApplication.shared.preferredContentSizeCategory
       if sizeCategory.isAccessibilityCategory {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Favorites/Views/SupplementaryViews/FavoritesRecentSearchFooterView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Favorites/Views/SupplementaryViews/FavoritesRecentSearchFooterView.swift
@@ -8,7 +8,13 @@ import Shared
 import UIKit
 
 class FavoritesRecentSearchFooterView: UICollectionReusableView {
-  let label = UILabel()
+  private let label = UILabel()
+
+  var isPrivateBrowsing: Bool = false {
+    didSet {
+      setTheme()
+    }
+  }
 
   override init(frame: CGRect) {
     super.init(frame: frame)
@@ -35,7 +41,7 @@ class FavoritesRecentSearchFooterView: UICollectionReusableView {
   private func setTheme() {
     label.do {
       $0.text = Strings.recentShowMore
-      $0.textColor = UIColor(braveSystemName: .textInteractive)
+      $0.textColor = isPrivateBrowsing ? .white : UIColor(braveSystemName: .textInteractive)
 
       var sizeCategory = UIApplication.shared.preferredContentSizeCategory
       if sizeCategory.isAccessibilityCategory {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Favorites/Views/SupplementaryViews/FavoritesSectionBackgroundView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Favorites/Views/SupplementaryViews/FavoritesSectionBackgroundView.swift
@@ -20,9 +20,9 @@ class FavoritesSectionBackgroundLayoutAttribute: UICollectionViewLayoutAttribute
 
   override func isEqual(_ object: Any?) -> Bool {
     guard let other = object as? FavoritesSectionBackgroundLayoutAttribute else { return false }
-    return super.isEqual(object) &&
-      backgroundColour == other.backgroundColour &&
-      groupBackgroundColour == other.groupBackgroundColour
+
+    return super.isEqual(object) && backgroundColour.rgba == other.backgroundColour.rgba
+      && groupBackgroundColour.rgba == other.groupBackgroundColour.rgba
   }
 }
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Favorites/Views/SupplementaryViews/FavoritesSectionBackgroundView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Favorites/Views/SupplementaryViews/FavoritesSectionBackgroundView.swift
@@ -7,6 +7,25 @@ import BraveUI
 import Shared
 import UIKit
 
+class FavoritesSectionBackgroundLayoutAttribute: UICollectionViewLayoutAttributes {
+  var backgroundColour = UIColor(braveSystemName: .materialThin)
+  var groupBackgroundColour = UIColor(braveSystemName: .containerBackground)
+
+  override func copy(with zone: NSZone? = nil) -> Any {
+    let copy = super.copy(with: zone) as! FavoritesSectionBackgroundLayoutAttribute
+    copy.backgroundColour = self.backgroundColour
+    copy.groupBackgroundColour = self.groupBackgroundColour
+    return copy
+  }
+
+  override func isEqual(_ object: Any?) -> Bool {
+    guard let other = object as? FavoritesSectionBackgroundLayoutAttribute else { return false }
+    return super.isEqual(object) &&
+      backgroundColour == other.backgroundColour &&
+      groupBackgroundColour == other.groupBackgroundColour
+  }
+}
+
 class FavoritesSectionBackgroundView: UICollectionReusableView {
 
   let sectionGroupBackground = UIView()
@@ -35,5 +54,15 @@ class FavoritesSectionBackgroundView: UICollectionReusableView {
   @available(*, unavailable)
   required init(coder: NSCoder) {
     fatalError()
+  }
+
+  override func apply(_ layoutAttributes: UICollectionViewLayoutAttributes) {
+    super.apply(layoutAttributes)
+
+    guard let customAttrs = layoutAttributes as? FavoritesSectionBackgroundLayoutAttribute else {
+      return
+    }
+    self.backgroundColor = customAttrs.backgroundColour
+    self.sectionGroupBackground.backgroundColor = customAttrs.groupBackgroundColour
   }
 }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/SearchViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/SearchViewController.swift
@@ -1077,21 +1077,25 @@ extension SearchViewController: UICollectionViewDelegate, UICollectionViewDataSo
         return header
       }
     } else if kind == UICollectionView.elementKindSectionFooter {
-      let footer =
+      if let footer =
         collectionView
         .dequeueReusableSupplementaryView(
           ofKind: kind,
           withReuseIdentifier: SupplementaryViewReuseIdentifier.inYourDeviceSectionFooterIdentifer,
           for: indexPath
-        )
-      let tapGesture = UITapGestureRecognizer(
-        target: self,
-        action: #selector(onShowMorePressed)
-      )
-      footer.addGestureRecognizer(tapGesture)
-      footer.isUserInteractionEnabled = true
+        ) as? FavoritesRecentSearchFooterView
+      {
+        footer.isPrivateBrowsing = dataSource.isPrivate
 
-      return footer
+        let tapGesture = UITapGestureRecognizer(
+          target: self,
+          action: #selector(onShowMorePressed)
+        )
+        footer.addGestureRecognizer(tapGesture)
+        footer.isUserInteractionEnabled = true
+
+        return footer
+      }
     }
     return
       collectionView

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/Views/Cells/SearchFindInPageCell.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/Views/Cells/SearchFindInPageCell.swift
@@ -39,6 +39,12 @@ class SearchFindInPageCell: UICollectionViewCell, CollectionViewReusable {
     }
   }
 
+  var isPrivateBrowsing: Bool = false {
+    didSet {
+      setTheme()
+    }
+  }
+
   override init(frame: CGRect) {
     super.init(frame: frame)
 
@@ -73,12 +79,12 @@ class SearchFindInPageCell: UICollectionViewCell, CollectionViewReusable {
     updateTitleTheme()
 
     searchImageView.do {
-      $0.tintColor = UIColor(braveSystemName: .iconDefault)
+      $0.tintColor = isPrivateBrowsing ? .white : UIColor(braveSystemName: .iconDefault)
     }
   }
 
   private func updateTitleTheme() {
-    titleLabel.textColor = UIColor(braveSystemName: .textPrimary)
+    titleLabel.textColor = isPrivateBrowsing ? .white : UIColor(braveSystemName: .textPrimary)
     titleLabel.lineBreakMode = .byTruncatingTail
 
     var sizeCategory = UIApplication.shared.preferredContentSizeCategory
@@ -101,7 +107,7 @@ class SearchFindInPageCell: UICollectionViewCell, CollectionViewReusable {
       string: Strings.findInPageFormat,
       attributes: [
         .font: boldFont,
-        .foregroundColor: UIColor(braveSystemName: .textTertiary),
+        .foregroundColor: isPrivateBrowsing ? .white : UIColor(braveSystemName: .textTertiary),
       ]
     )
     attString.append(
@@ -109,7 +115,7 @@ class SearchFindInPageCell: UICollectionViewCell, CollectionViewReusable {
         string: "\"\(title)\"",
         attributes: [
           .font: regularFont,
-          .foregroundColor: UIColor(braveSystemName: .textPrimary),
+          .foregroundColor: isPrivateBrowsing ? .white : UIColor(braveSystemName: .textPrimary),
         ]
       )
     )

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/Views/Cells/SearchOnYourDeviceCell.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/Views/Cells/SearchOnYourDeviceCell.swift
@@ -92,6 +92,12 @@ class SearchOnYourDeviceCell: UICollectionViewCell, CollectionViewReusable {
     }
   }
 
+  var isPrivateBrowsing: Bool = false {
+    didSet {
+      setTheme()
+    }
+  }
+
   override init(frame: CGRect) {
     super.init(frame: frame)
 
@@ -154,7 +160,7 @@ class SearchOnYourDeviceCell: UICollectionViewCell, CollectionViewReusable {
     let traitCollection = UITraitCollection(preferredContentSizeCategory: sizeCategory)
 
     titleLabel.do {
-      $0.textColor = UIColor(braveSystemName: .textPrimary)
+      $0.textColor = isPrivateBrowsing ? .white : UIColor(braveSystemName: .textPrimary)
       $0.lineBreakMode = .byTruncatingTail
 
       let font = UIFont.preferredFont(
@@ -166,7 +172,7 @@ class SearchOnYourDeviceCell: UICollectionViewCell, CollectionViewReusable {
     }
 
     subtitleLabel.do {
-      $0.textColor = UIColor(braveSystemName: .textSecondary)
+      $0.textColor = isPrivateBrowsing ? .white : UIColor(braveSystemName: .textSecondary)
       $0.lineBreakMode = .byTruncatingTail
 
       let font = UIFont.preferredFont(
@@ -179,11 +185,11 @@ class SearchOnYourDeviceCell: UICollectionViewCell, CollectionViewReusable {
 
     badgeImageView.do {
       $0.contentMode = .scaleAspectFit
-      $0.tintColor = UIColor(braveSystemName: .iconSecondary)
+      $0.tintColor = isPrivateBrowsing ? .white : UIColor(braveSystemName: .iconSecondary)
     }
   }
 
-  func setSite(_ site: Site, isPrivateBrowsing: Bool) {
+  func setSite(_ site: Site) {
     siteImageView.loadFavicon(
       for: site.tileURL,
       isPrivateBrowsing: isPrivateBrowsing
@@ -200,7 +206,7 @@ class SearchOnYourDeviceCell: UICollectionViewCell, CollectionViewReusable {
           string: Strings.searchSuggestionOpenTabActionTitle,
           attributes: [
             .font: DynamicFontHelper.defaultHelper.smallSizeBoldWeightAS,
-            .foregroundColor: UIColor(braveSystemName: .textSecondary),
+            .foregroundColor: isPrivateBrowsing ? .white : UIColor(braveSystemName: .textSecondary),
           ]
         )
       )
@@ -209,7 +215,7 @@ class SearchOnYourDeviceCell: UICollectionViewCell, CollectionViewReusable {
           string: " · \(site.url)",
           attributes: [
             .font: DynamicFontHelper.defaultHelper.smallSizeRegularWeightAS,
-            .foregroundColor: UIColor(braveSystemName: .textSecondary),
+            .foregroundColor: isPrivateBrowsing ? .white : UIColor(braveSystemName: .textSecondary),
           ]
         )
       )
@@ -250,7 +256,7 @@ class SearchOnYourDeviceCell: UICollectionViewCell, CollectionViewReusable {
         string: Strings.searchSuggestionOpenPlaylistActionTitle,
         attributes: [
           .font: DynamicFontHelper.defaultHelper.smallSizeBoldWeightAS,
-          .foregroundColor: UIColor(braveSystemName: .textSecondary),
+          .foregroundColor: isPrivateBrowsing ? .white : UIColor(braveSystemName: .textSecondary),
         ]
       )
     )
@@ -260,7 +266,7 @@ class SearchOnYourDeviceCell: UICollectionViewCell, CollectionViewReusable {
           string: " · \(Duration.seconds(item.duration).formatted(.timestamp))",
           attributes: [
             .font: DynamicFontHelper.defaultHelper.smallSizeRegularWeightAS,
-            .foregroundColor: UIColor(braveSystemName: .textSecondary),
+            .foregroundColor: isPrivateBrowsing ? .white : UIColor(braveSystemName: .textSecondary),
           ]
         )
       )

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/Views/Cells/SearchSuggestionCell.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/Views/Cells/SearchSuggestionCell.swift
@@ -21,7 +21,6 @@ class SearchSuggestionCell: UICollectionViewCell, CollectionViewReusable {
   private let searchImageView = UIImageView().then {
     $0.image = UIImage(braveSystemNamed: "leo.search")!.template
     $0.contentMode = .scaleAspectFit
-    $0.tintColor = UIColor(braveSystemName: .iconDefault)
   }
 
   private let titleLabel = UILabel().then {
@@ -44,6 +43,12 @@ class SearchSuggestionCell: UICollectionViewCell, CollectionViewReusable {
           self.contentView.alpha = self.isHighlighted ? 0.5 : 1.0
         }
       )
+    }
+  }
+
+  var isPrivateBrowsing: Bool = false {
+    didSet {
+      setTheme()
     }
   }
 
@@ -89,8 +94,10 @@ class SearchSuggestionCell: UICollectionViewCell, CollectionViewReusable {
   }
 
   private func setTheme() {
+    searchImageView.tintColor = isPrivateBrowsing ? .white : UIColor(braveSystemName: .iconDefault)
+
     titleLabel.do {
-      $0.textColor = UIColor(braveSystemName: .textPrimary)
+      $0.textColor = isPrivateBrowsing ? .white : UIColor(braveSystemName: .textPrimary)
       $0.lineBreakMode = .byTruncatingMiddle
 
       var sizeCategory = UIApplication.shared.preferredContentSizeCategory
@@ -111,7 +118,7 @@ class SearchSuggestionCell: UICollectionViewCell, CollectionViewReusable {
         UIImage(braveSystemNamed: "leo.arrow.diagonal-up-left")?.template,
         for: .normal
       )
-      $0.tintColor = UIColor(braveSystemName: .iconInteractive)
+      $0.tintColor = isPrivateBrowsing ? .white : UIColor(braveSystemName: .iconInteractive)
     }
   }
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/Views/SupplementaryViews/SearchSectionBackground.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/Views/SupplementaryViews/SearchSectionBackground.swift
@@ -7,6 +7,25 @@ import BraveUI
 import Shared
 import UIKit
 
+class SearchSectionBackgroundLayoutAttribute: UICollectionViewLayoutAttributes {
+  var backgroundColour = UIColor(braveSystemName: .materialThin)
+  var groupBackgroundColour = UIColor(braveSystemName: .containerBackground)
+
+  override func copy(with zone: NSZone? = nil) -> Any {
+    let copy = super.copy(with: zone) as! SearchSectionBackgroundLayoutAttribute
+    copy.backgroundColour = self.backgroundColour
+    copy.groupBackgroundColour = self.groupBackgroundColour
+    return copy
+  }
+
+  override func isEqual(_ object: Any?) -> Bool {
+    guard let other = object as? SearchSectionBackgroundLayoutAttribute else { return false }
+    return super.isEqual(object)
+      && backgroundColour == other.backgroundColour
+      && groupBackgroundColour == other.groupBackgroundColour
+  }
+}
+
 class SearchSectionBackgroundView: UICollectionReusableView {
 
   let sectionGroupBackground = UIView()
@@ -33,5 +52,15 @@ class SearchSectionBackgroundView: UICollectionReusableView {
   @available(*, unavailable)
   required init(coder: NSCoder) {
     fatalError()
+  }
+
+  override func apply(_ layoutAttributes: UICollectionViewLayoutAttributes) {
+    super.apply(layoutAttributes)
+
+    guard let customAttrs = layoutAttributes as? SearchSectionBackgroundLayoutAttribute else {
+      return
+    }
+    self.backgroundColor = customAttrs.backgroundColour
+    self.sectionGroupBackground.backgroundColor = customAttrs.groupBackgroundColour
   }
 }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/Views/SupplementaryViews/SearchSectionBackground.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/Views/SupplementaryViews/SearchSectionBackground.swift
@@ -21,8 +21,8 @@ class SearchSectionBackgroundLayoutAttribute: UICollectionViewLayoutAttributes {
   override func isEqual(_ object: Any?) -> Bool {
     guard let other = object as? SearchSectionBackgroundLayoutAttribute else { return false }
     return super.isEqual(object)
-      && backgroundColour == other.backgroundColour
-      && groupBackgroundColour == other.groupBackgroundColour
+      && backgroundColour.rgba == other.backgroundColour.rgba
+      && groupBackgroundColour.rgba == other.groupBackgroundColour.rgba
   }
 }
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/Views/SupplementaryViews/SearchSectionHeaderView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/Views/SupplementaryViews/SearchSectionHeaderView.swift
@@ -10,6 +10,12 @@ import UIKit
 class SearchSectionHeaderView: UICollectionReusableView, CollectionViewReusable {
   private let label = UILabel()
 
+  var isPrivateBrowsing: Bool = false {
+    didSet {
+      setTheme()
+    }
+  }
+
   override init(frame: CGRect) {
     super.init(frame: frame)
 
@@ -33,7 +39,7 @@ class SearchSectionHeaderView: UICollectionReusableView, CollectionViewReusable 
 
   private func setTheme() {
     label.do {
-      $0.textColor = UIColor(braveSystemName: .textPrimary)
+      $0.textColor = isPrivateBrowsing ? .white : UIColor(braveSystemName: .textPrimary)
 
       var sizeCategory = UIApplication.shared.preferredContentSizeCategory
       if sizeCategory.isAccessibilityCategory {

--- a/ios/brave-ios/Sources/BraveShared/Extensions/UIColorExtensions.swift
+++ b/ios/brave-ios/Sources/BraveShared/Extensions/UIColorExtensions.swift
@@ -47,4 +47,18 @@ extension UIColor {
       alpha: a
     )
   }
+
+  public static func == (l: UIColor, r: UIColor) -> Bool {
+    var r1: CGFloat = 0
+    var g1: CGFloat = 0
+    var b1: CGFloat = 0
+    var a1: CGFloat = 0
+    l.getRed(&r1, green: &g1, blue: &b1, alpha: &a1)
+    var r2: CGFloat = 0
+    var g2: CGFloat = 0
+    var b2: CGFloat = 0
+    var a2: CGFloat = 0
+    r.getRed(&r2, green: &g2, blue: &b2, alpha: &a2)
+    return r1 == r2 && g1 == g2 && b1 == b2 && a1 == a2
+  }
 }

--- a/ios/brave-ios/Sources/BraveShared/Extensions/UIColorExtensions.swift
+++ b/ios/brave-ios/Sources/BraveShared/Extensions/UIColorExtensions.swift
@@ -47,18 +47,4 @@ extension UIColor {
       alpha: a
     )
   }
-
-  public static func == (l: UIColor, r: UIColor) -> Bool {
-    var r1: CGFloat = 0
-    var g1: CGFloat = 0
-    var b1: CGFloat = 0
-    var a1: CGFloat = 0
-    l.getRed(&r1, green: &g1, blue: &b1, alpha: &a1)
-    var r2: CGFloat = 0
-    var g2: CGFloat = 0
-    var b2: CGFloat = 0
-    var a2: CGFloat = 0
-    r.getRed(&r2, green: &g2, blue: &b2, alpha: &a2)
-    return r1 == r2 && g1 == g2 && b1 == b2 && a1 == a2
-  }
 }


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/46710

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

## Test Plan

 &nbsp; | Standard mode |  Private mode
--- | --- | ---
Light | ![Simulator Screenshot - iPhone 16 Pro - 2025-07-07 at 16 57 52](https://github.com/user-attachments/assets/f6e2788a-f5be-422f-88c4-6954b5f2a55a) ![Simulator Screenshot - iPhone 16 Pro - 2025-07-07 at 16 58 01](https://github.com/user-attachments/assets/fdeb2ad5-a0d2-4df7-9060-81daf7ca5460) | ![Simulator Screenshot - iPhone 16 Pro - 2025-07-07 at 17 03 24](https://github.com/user-attachments/assets/6c2c1b43-5399-4273-b785-7653e4af3991) ![Simulator Screenshot - iPhone 16 Pro - 2025-07-07 at 17 03 34](https://github.com/user-attachments/assets/89dee718-087a-4e04-90cf-45b5d35dd341)
Dark | ![Simulator Screenshot - iPhone 16 Pro - 2025-07-07 at 17 07 49](https://github.com/user-attachments/assets/e6b8fd91-09f5-4d62-a4f5-8e299b364612) ![Simulator Screenshot - iPhone 16 Pro - 2025-07-07 at 17 07 52](https://github.com/user-attachments/assets/4d343651-dc76-4219-aa64-9fc783057321) | ![Simulator Screenshot - iPhone 16 Pro - 2025-07-07 at 17 06 45](https://github.com/user-attachments/assets/4420c853-2350-432f-87a2-ad9a752cd92c) ![Simulator Screenshot - iPhone 16 Pro - 2025-07-07 at 17 06 49](https://github.com/user-attachments/assets/068674e8-642f-4c9e-a9bf-943b30562283)

**Note:** We also rounded the QSE icon corners to match the LEO button in the QSE list 