### PR TITLE
[Vertical Tabs] Add multi value flag support for vertical tab expand delay

### DIFF
--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -11,7 +11,6 @@
 #include "brave/browser/brave_features_internal_names.h"
 #include "brave/browser/ui/brave_ui_features.h"
 #include "brave/browser/ui/tabs/features.h"
-#include "brave/browser/ui/views/tabs/switches.h"
 #include "brave/browser/updater/buildflags.h"
 #include "brave/components/ai_chat/core/common/features.h"
 #include "brave/components/ai_rewriter/common/buildflags/buildflags.h"
@@ -75,6 +74,7 @@
 #include "brave/browser/android/safe_browsing/features.h"
 #include "brave/browser/android/youtube_script_injector/features.h"
 #else
+#include "brave/browser/ui/views/tabs/switches.h"
 #include "brave/components/commander/common/features.h"
 #include "brave/components/commands/common/features.h"
 #endif

--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -11,6 +11,7 @@
 #include "brave/browser/brave_features_internal_names.h"
 #include "brave/browser/ui/brave_ui_features.h"
 #include "brave/browser/ui/tabs/features.h"
+#include "brave/browser/ui/views/tabs/switches.h"
 #include "brave/browser/updater/buildflags.h"
 #include "brave/components/ai_chat/core/common/features.h"
 #include "brave/components/ai_rewriter/common/buildflags/buildflags.h"
@@ -338,6 +339,18 @@ const char* const kBraveSyncImplLink[1] = {"https://github.com/brave/go-sync"};
 #endif  // BUILDFLAG(IS_ANDROID)
 
 #if !BUILDFLAG(IS_ANDROID)
+constexpr flags_ui::FeatureEntry::Choice kVerticalTabExpandDelayChoices[] = {
+    {"default", "", ""},
+    {"0ms", tabs::switches::kVerticalTabExpandDelaySwitch, "0"},
+    {"50ms", tabs::switches::kVerticalTabExpandDelaySwitch, "50"},
+    {"100ms", tabs::switches::kVerticalTabExpandDelaySwitch, "100"},
+    {"150ms", tabs::switches::kVerticalTabExpandDelaySwitch, "150"},
+    {"200ms", tabs::switches::kVerticalTabExpandDelaySwitch, "200"},
+    {"250ms", tabs::switches::kVerticalTabExpandDelaySwitch, "250"},
+    {"300ms", tabs::switches::kVerticalTabExpandDelaySwitch, "300"},
+    {"400ms", tabs::switches::kVerticalTabExpandDelaySwitch, "400"},
+};
+
 #define BRAVE_TABS_FEATURE_ENTRIES                                             \
   EXPAND_FEATURE_ENTRIES(                                                      \
       {                                                                        \
@@ -374,6 +387,13 @@ const char* const kBraveSyncImplLink[1] = {"https://github.com/brave/go-sync"};
           "Hides the vertical tab strip when collapsed",                       \
           kOsWin | kOsMac | kOsLinux,                                          \
           FEATURE_VALUE_TYPE(tabs::features::kBraveVerticalTabHideCompletely), \
+      },                                                                       \
+      {                                                                        \
+          "brave-vertical-tab-expand-delay",                                   \
+          "Brave Vertical Tab Expand Delay",                                   \
+          "Delay before expanding the vertical tab strip when hovering",       \
+          kOsWin | kOsMac | kOsLinux,                                          \
+          MULTI_VALUE_TYPE(kVerticalTabExpandDelayChoices),                    \
       },                                                                       \
       {                                                                        \
           kSplitViewFeatureInternalName,                                       \
@@ -1086,7 +1106,7 @@ namespace {
   static_assert(
       std::initializer_list<FeatureEntry>{BRAVE_ABOUT_FLAGS_FEATURE_ENTRIES}
           .size());
-}
+}  // namespace
 
 }  // namespace
 }  // namespace flags_ui

--- a/browser/ui/views/tabs/switches.h
+++ b/browser/ui/views/tabs/switches.h
@@ -12,6 +12,12 @@ namespace tabs::switches {
 // useful when vertical tab strip causes browser to crash on start up.
 inline constexpr char kDisableVerticalTabsSwitch[] = "disable-vertical-tabs";
 
+// This switch should be followed by a number in milliseconds, which
+// specifies the delay before expanding the vertical tab strip when hovering
+// over it.
+inline constexpr char kVerticalTabExpandDelaySwitch[] =
+    "vertical-tab-expand-delay";
+
 }  // namespace tabs::switches
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_TABS_SWITCHES_H_


### PR DESCRIPTION
As a part of user requests, we're going to experiment with a delay
before expanding the vertical tab strip when hovering over it.
We'd like to figure out the best delay value through this experiment,
also providing users with the ability to customize it.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/41184

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
