### PR TITLE
[iOS] Use chromium prefs to determine sync enabled status

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -377,13 +377,19 @@ public class BrowserViewController: UIViewController {
       }
     )
 
+    // Update the preference based on the underlying Chromium prefs
+    // Remove this when the pref is deleted: https://github.com/brave/brave-browser/issues/47487
+    Preferences.Chromium.syncEnabled.value = profileController.syncAPI.isInSyncGroup
+
     // Observer watching state change in sync chain
     syncServiceStateListener = profileController.syncAPI.addServiceStateObserver { [weak self] in
       guard let self = self else { return }
-      // Observe Sync State in order to determine if the sync chain is deleted
-      // from another device - Clean local sync chain
-      if self.profileController.syncAPI.shouldLeaveSyncGroup {
-        self.profileController.syncAPI.leaveSyncGroup()
+      DispatchQueue.main.async {
+        // Observe Sync State in order to determine if the sync chain is deleted
+        // from another device - Clean local sync chain
+        if self.profileController.syncAPI.shouldLeaveSyncGroup {
+          self.profileController.syncAPI.leaveSyncGroup()
+        }
       }
     }
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Tabs/TabTray/TabTrayController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Tabs/TabTray/TabTrayController.swift
@@ -250,9 +250,11 @@ class TabTrayController: AuthenticationController {
     syncServicStateListener = braveCore.syncAPI.addServiceStateObserver { [weak self] in
       guard let self = self else { return }
 
-      if self.braveCore.syncAPI.shouldLeaveSyncGroup {
-        self.tabSyncView.do {
-          $0.updateSyncStatusPanel(for: self.emptyPanelState)
+      DispatchQueue.main.async {
+        if self.braveCore.syncAPI.shouldLeaveSyncGroup {
+          self.tabSyncView.do {
+            $0.updateSyncStatusPanel(for: self.emptyPanelState)
+          }
         }
       }
     }

--- a/ios/brave-ios/Sources/Brave/Frontend/Sync/BraveCore/BraveSyncAPIExtensions.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Sync/BraveCore/BraveSyncAPIExtensions.swift
@@ -28,10 +28,6 @@ extension BraveSyncAPI {
 
   public static let seedByteLength = 32
 
-  public var isInSyncGroup: Bool {
-    return Preferences.Chromium.syncEnabled.value
-  }
-
   /// Property that determines if the local sync chain should be resetted
   var shouldLeaveSyncGroup: Bool {
     guard isInSyncGroup else {

--- a/ios/browser/api/sync/brave_sync_api.h
+++ b/ios/browser/api/sync/brave_sync_api.h
@@ -75,6 +75,7 @@ OBJC_EXPORT
 @property(nonatomic, readonly) bool isInitialSyncFeatureSetupComplete;
 @property(nonatomic) bool isSyncAccountDeletedNoticePending;
 @property(nonatomic, readonly) bool isFailedDecryptSeedNoticeDismissed;
+@property(readonly) bool isInSyncGroup;
 
 - (instancetype)init NS_UNAVAILABLE;
 

--- a/ios/browser/api/sync/brave_sync_api.mm
+++ b/ios/browser/api/sync/brave_sync_api.mm
@@ -179,6 +179,13 @@ BraveSyncAPIWordsValidationStatus const
   _profile = nullptr;
 }
 
+- (bool)isInSyncGroup {
+  auto* service = static_cast<syncer::SyncServiceImpl*>(
+      SyncServiceFactory::GetForProfile(_profile));
+  return service->GetSyncAccountStateForPrefs() !=
+         syncer::SyncPrefs::SyncAccountState::kNotSignedIn;
+}
+
 - (bool)canSyncFeatureStart {
   return _worker->CanSyncFeatureStart();
 }


### PR DESCRIPTION
This change ensures that the `isInSyncGroup` now relies on the underlying Chromium preference so that the states dont fall out of sync. This change does not explicitly remove the preferences to keep changes minimal but will further be improved in brave/brave-browser#47487

Resolves https://github.com/brave/brave-browser/issues/47375

### Test Case

Unfortunately there are no steps to reproduce the crash itself without corrupting local data manually, so this test case is mostly verifying sync working correctly

- Join a sync chain
- Test syncing of all data types (bookmarks, passwords, open tabs, history)
- Force close & relaunch app
- Leave the sync chain from sync settings
- Force close & relaunch app
- Join the sync chain again
- From another device on the chain, remove the device
- Ensure that sync disables on the device
- Force close & relaunch app

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
