### PR TITLE
[Vertical Tabs] Add multi value flag for vertical tab collapse delay

### DIFF
--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -351,6 +351,18 @@ constexpr flags_ui::FeatureEntry::Choice kVerticalTabExpandDelayChoices[] = {
     {"400ms", tabs::switches::kVerticalTabExpandDelaySwitch, "400"},
 };
 
+constexpr flags_ui::FeatureEntry::Choice kVerticalTabCollapseDelayChoices[] = {
+    {"default", "", ""},
+    {"0ms", tabs::switches::kVerticalTabCollapseDelaySwitch, "0"},
+    {"50ms", tabs::switches::kVerticalTabCollapseDelaySwitch, "50"},
+    {"100ms", tabs::switches::kVerticalTabCollapseDelaySwitch, "100"},
+    {"150ms", tabs::switches::kVerticalTabCollapseDelaySwitch, "150"},
+    {"200ms", tabs::switches::kVerticalTabCollapseDelaySwitch, "200"},
+    {"250ms", tabs::switches::kVerticalTabCollapseDelaySwitch, "250"},
+    {"300ms", tabs::switches::kVerticalTabCollapseDelaySwitch, "300"},
+    {"400ms", tabs::switches::kVerticalTabCollapseDelaySwitch, "400"},
+};
+
 #define BRAVE_TABS_FEATURE_ENTRIES                                             \
   EXPAND_FEATURE_ENTRIES(                                                      \
       {                                                                        \
@@ -394,6 +406,13 @@ constexpr flags_ui::FeatureEntry::Choice kVerticalTabExpandDelayChoices[] = {
           "Delay before expanding the vertical tab strip when hovering",       \
           kOsWin | kOsMac | kOsLinux,                                          \
           MULTI_VALUE_TYPE(kVerticalTabExpandDelayChoices),                    \
+      },                                                                       \
+      {                                                                        \
+          "brave-vertical-tab-collapse-delay",                                 \
+          "Brave Vertical Tab Collapse Delay",                                 \
+          "Delay before collapsing the vertical tab strip when mouse exits",   \
+          kOsWin | kOsMac | kOsLinux,                                          \
+          MULTI_VALUE_TYPE(kVerticalTabCollapseDelayChoices),                  \
       },                                                                       \
       {                                                                        \
           kSplitViewFeatureInternalName,                                       \

--- a/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.cc
@@ -679,6 +679,7 @@ void VerticalTabStripRegionView::SetState(State state) {
   }
 
   mouse_enter_timer_.Stop();
+  mouse_exit_timer_.Stop();
 
   last_state_ = std::exchange(state_, state);
   resize_area_->SetEnabled(state == State::kExpanded);
@@ -925,7 +926,7 @@ void VerticalTabStripRegionView::OnMouseExited() {
 
   mouse_enter_timer_.Stop();
   if (state_ == State::kFloating) {
-    SetState(State::kCollapsed);
+    ScheduleCollapseTimer();
   }
 }
 
@@ -943,6 +944,7 @@ void VerticalTabStripRegionView::OnMouseEntered() {
     return;
   }
 
+  mouse_exit_timer_.Stop();
   ScheduleFloatingModeTimer();
 }
 
@@ -1297,6 +1299,47 @@ void VerticalTabStripRegionView::ScheduleFloatingModeTimer() {
         base::BindOnce(&VerticalTabStripRegionView::SetState,
                        base::Unretained(this), State::kFloating));
   }
+}
+
+void VerticalTabStripRegionView::ScheduleCollapseTimer() {
+  if (state_ != State::kFloating) {
+    return;
+  }
+
+  if (mouse_exit_timer_.IsRunning()) {
+    return;
+  }
+
+  auto get_collapse_delay = []() {
+    constexpr int kDefaultDelay = 0;
+    auto* cmd_line = base::CommandLine::ForCurrentProcess();
+    if (!cmd_line->HasSwitch(tabs::switches::kVerticalTabCollapseDelaySwitch)) {
+      return kDefaultDelay;
+    }
+
+    auto delay_string = cmd_line->GetSwitchValueASCII(
+        tabs::switches::kVerticalTabCollapseDelaySwitch);
+
+    int override_delay = 0;
+    if (delay_string.empty() ||
+        !base::StringToInt(delay_string, &override_delay)) {
+      return kDefaultDelay;
+    }
+
+    return override_delay;
+  };
+
+  const auto delay = get_collapse_delay();
+  if (delay == 0) {
+    // If the delay is 0, we should collapse immediately.
+    SetState(State::kCollapsed);
+    return;
+  }
+
+  mouse_exit_timer_.Start(
+      FROM_HERE, base::Milliseconds(delay),
+      base::BindOnce(&VerticalTabStripRegionView::SetState,
+                     base::Unretained(this), State::kCollapsed));
 }
 
 #if !BUILDFLAG(IS_MAC)

--- a/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.h
+++ b/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.h
@@ -159,6 +159,7 @@ class VerticalTabStripRegionView : public views::View,
   bool IsFloatingVerticalTabsEnabled() const;
   bool IsFloatingEnabledForBrowserFullscreen() const;
   void ScheduleFloatingModeTimer();
+  void ScheduleCollapseTimer();
   void OnMouseExited();
   void OnMouseEntered();
   void OnMousePressedInTree();
@@ -214,6 +215,7 @@ class VerticalTabStripRegionView : public views::View,
   int expanded_width_ = 220;
 
   base::OneShotTimer mouse_enter_timer_;
+  base::OneShotTimer mouse_exit_timer_;
 
   bool mouse_events_for_test_ = false;
 

--- a/browser/ui/views/tabs/switches.h
+++ b/browser/ui/views/tabs/switches.h
@@ -18,6 +18,12 @@ inline constexpr char kDisableVerticalTabsSwitch[] = "disable-vertical-tabs";
 inline constexpr char kVerticalTabExpandDelaySwitch[] =
     "vertical-tab-expand-delay";
 
+// This switch should be followed by a number in milliseconds, which
+// specifies the delay before collapsing the vertical tab strip when the mouse
+// exits the tab strip in floating mode.
+inline constexpr char kVerticalTabCollapseDelaySwitch[] =
+    "vertical-tab-collapse-delay";
+
 }  // namespace tabs::switches
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_TABS_SWITCHES_H_


### PR DESCRIPTION
We need to explore the possibility of adding a delay before collapsing the vertical tab strip when the mouse exits the tab strip in floating mode. This will help prevent accidental collapses when users are interacting with the tabs.

This change introduces a new flag with multiple predefined milliseconds values for the collapse delay, similar to the existing expand delay flag.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/47489

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
