### PR TITLE
[iOS] Remove displayed popover tracking & representation on rotation

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ReaderMode.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ReaderMode.swift
@@ -92,26 +92,16 @@ extension BrowserViewController: ReaderModeBarViewDelegate {
     )
     readerModeStyleViewController.delegate = self
     readerModeStyleViewController.modalPresentationStyle = .popover
+    readerModeStyleViewController.presentationController?.delegate = self
 
-    let setupPopover = { [unowned self, weak readerModeStyleViewController] in
-
-      if let popoverPresentationController = readerModeStyleViewController?
-        .popoverPresentationController
-      {
-        popoverPresentationController.backgroundColor = .white
-        popoverPresentationController.delegate = self
-        popoverPresentationController.sourceView = view
-        popoverPresentationController.sourceRect =
-          CGRect(x: view.bounds.width / 2, y: UIConstants.toolbarHeight / 2, width: 0, height: 0)
-        popoverPresentationController.permittedArrowDirections = .up
-      }
-    }
-
-    setupPopover()
-
-    if readerModeStyleViewController.popoverPresentationController != nil {
-      displayedPopoverController = readerModeStyleViewController
-      updateDisplayedPopoverProperties = setupPopover
+    if let popoverPresentationController = readerModeStyleViewController
+      .popoverPresentationController
+    {
+      popoverPresentationController.backgroundColor = .white
+      popoverPresentationController.sourceView = view
+      popoverPresentationController.sourceRect =
+        CGRect(x: view.bounds.width / 2, y: UIConstants.toolbarHeight / 2, width: 0, height: 0)
+      popoverPresentationController.permittedArrowDirections = .up
     }
 
     present(readerModeStyleViewController, animated: true, completion: nil)

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ShareActivity.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ShareActivity.swift
@@ -236,13 +236,13 @@ extension BrowserViewController {
                       activityItems: [url],
                       applicationActivities: nil
                     )
+                    pdfActivityController.presentationController?.delegate = self
                     if let popoverPresentationController = pdfActivityController
                       .popoverPresentationController
                     {
                       popoverPresentationController.sourceView = sourceView
                       popoverPresentationController.sourceRect = sourceRect
                       popoverPresentationController.permittedArrowDirections = arrowDirection
-                      popoverPresentationController.delegate = self
                     }
                     self.present(pdfActivityController, animated: true)
                   } catch {
@@ -360,11 +360,11 @@ extension BrowserViewController {
       self?.cleanUpCreateActivity()
     }
 
+    controller.presentationController?.delegate = self
     if let popoverPresentationController = controller.popoverPresentationController {
       popoverPresentationController.sourceView = sourceView
       popoverPresentationController.sourceRect = sourceRect
       popoverPresentationController.permittedArrowDirections = arrowDirection
-      popoverPresentationController.delegate = self
     }
 
     present(controller, animated: true, completion: nil)
@@ -373,11 +373,5 @@ extension BrowserViewController {
   private func cleanUpCreateActivity() {
     // After dismissing, check to see if there were any prompts we queued up
     showQueuedAlertIfAvailable()
-
-    // Usually the popover delegate would handle nil'ing out the references we have to it
-    // on the BVC when displaying as a popover but the delegate method doesn't seem to be
-    // invoked on iOS 10. See Bug 1297768 for additional details.
-    displayedPopoverController = nil
-    updateDisplayedPopoverProperties = nil
   }
 }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ToolbarDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ToolbarDelegate.swift
@@ -386,7 +386,6 @@ extension BrowserViewController: TopToolbarDelegate {
   }
 
   func topToolbarDidBeginDragInteraction(_ topToolbar: TopToolbarView) {
-    dismissVisibleMenus()
   }
 
   func topToolbarDidTapBraveShieldsButton(_ topToolbar: TopToolbarView) {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -166,10 +166,6 @@ public class BrowserViewController: UIViewController {
 
   var customSearchBarButtonItemGroup: UIBarButtonItemGroup?
 
-  // popover rotation handling
-  var displayedPopoverController: UIViewController?
-  var updateDisplayedPopoverProperties: (() -> Void)?
-
   public let windowId: UUID
   let profile: Profile
   let attributionManager: AttributionManager
@@ -441,14 +437,8 @@ public class BrowserViewController: UIViewController {
   ) {
     super.viewWillTransition(to: size, with: coordinator)
 
-    dismissVisibleMenus()
-
     coordinator.animate(
       alongsideTransition: { context in
-        if let popover = self.displayedPopoverController {
-          self.updateDisplayedPopoverProperties?()
-          self.present(popover, animated: true, completion: nil)
-        }
         #if canImport(BraveTalk)
         self.braveTalkJitsiCoordinator.resetPictureInPictureBounds(.init(size: size))
         #endif
@@ -713,7 +703,6 @@ public class BrowserViewController: UIViewController {
       updateToolbarStateForTraitCollection(newCollection, withTransitionCoordinator: coordinator)
     }
 
-    displayedPopoverController?.dismiss(animated: true, completion: nil)
     coordinator.animate(
       alongsideTransition: { context in
         if self.isViewLoaded {
@@ -723,21 +712,6 @@ public class BrowserViewController: UIViewController {
         }
       }
     )
-  }
-
-  func dismissVisibleMenus() {
-    displayedPopoverController?.dismiss(animated: true)
-  }
-
-  @objc func sceneDidEnterBackgroundNotification(_ notification: NSNotification) {
-    guard let scene = notification.object as? UIScene, scene == currentScene else {
-      return
-    }
-
-    displayedPopoverController?.dismiss(animated: false) {
-      self.updateDisplayedPopoverProperties = nil
-      self.displayedPopoverController = nil
-    }
   }
 
   @objc func appWillTerminateNotification() {
@@ -768,12 +742,6 @@ public class BrowserViewController: UIViewController {
     }
 
     tabManager.saveAllTabs()
-
-    // Dismiss any popovers that might be visible
-    displayedPopoverController?.dismiss(animated: false) {
-      self.updateDisplayedPopoverProperties = nil
-      self.displayedPopoverController = nil
-    }
 
     // If we are displaying a private tab, hide any elements in the tab that we wouldn't want shown
     // when the app is in the home switcher
@@ -914,12 +882,6 @@ public class BrowserViewController: UIViewController {
         self,
         selector: #selector(sceneDidBecomeActiveNotification(_:)),
         name: UIScene.didActivateNotification,
-        object: nil
-      )
-      $0.addObserver(
-        self,
-        selector: #selector(sceneDidEnterBackgroundNotification),
-        name: UIScene.didEnterBackgroundNotification,
         object: nil
       )
       $0.addObserver(
@@ -2641,15 +2603,6 @@ extension BrowserViewController: SearchViewControllerDelegate {
 }
 
 // MARK: - UIPopoverPresentationControllerDelegate
-
-extension BrowserViewController: UIPopoverPresentationControllerDelegate {
-  public func popoverPresentationControllerDidDismissPopover(
-    _ popoverPresentationController: UIPopoverPresentationController
-  ) {
-    displayedPopoverController = nil
-    updateDisplayedPopoverProperties = nil
-  }
-}
 
 extension BrowserViewController: UIAdaptivePresentationControllerDelegate {
   // Returning None here makes sure that the Popover is actually presented as a Popover and


### PR DESCRIPTION
This change removes "visible popover" tracking that was being used only for reader mode which fixes a bug where the reader mode popover would continuously reappear whenever the window transitioned to a new size

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/47272

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
