### PR TITLE
Add tear down for `BrowserWindowFeatures` controllers

### DIFF
--- a/browser/ui/browser_window/browser_window_features.cc
+++ b/browser/ui/browser_window/browser_window_features.cc
@@ -84,3 +84,13 @@ void BrowserWindowFeatures::InitPostWindowConstruction(Browser* browser) {
         browser, browser->profile());
   }
 }
+
+void BrowserWindowFeatures::TearDownPreBrowserViewDestruction() {
+  BrowserWindowFeatures_ChromiumImpl::TearDownPreBrowserViewDestruction();
+#if BUILDFLAG(ENABLE_BRAVE_VPN)
+  brave_vpn_controller_.reset();
+#endif
+  if (sidebar_controller_) {
+    sidebar_controller_->TearDownPreBrowserWindowDestruction();
+  }
+}

--- a/browser/ui/browser_window/public/browser_window_features.h
+++ b/browser/ui/browser_window/public/browser_window_features.h
@@ -35,6 +35,7 @@ class BrowserWindowFeatures : public BrowserWindowFeatures_ChromiumImpl {
   void Init(BrowserWindowInterface* browser) override;
   void InitPostBrowserViewConstruction(BrowserView* browser_view) override;
   void InitPostWindowConstruction(Browser* browser) override;
+  void TearDownPreBrowserViewDestruction() override;
 
   sidebar::SidebarController* sidebar_controller() {
     return sidebar_controller_.get();

--- a/browser/ui/sidebar/sidebar_controller.cc
+++ b/browser/ui/sidebar/sidebar_controller.cc
@@ -87,6 +87,11 @@ bool SidebarController::DoesBrowserHaveOpenedTabForItem(
   return false;
 }
 
+void SidebarController::TearDownPreBrowserWindowDestruction() {
+  sidebar_service_observed_.Reset();
+  sidebar_ = nullptr;
+}
+
 void SidebarController::ActivateItemAt(std::optional<size_t> index,
                                        WindowOpenDisposition disposition) {
   // disengaged means there is no active item.

--- a/browser/ui/sidebar/sidebar_controller.h
+++ b/browser/ui/sidebar/sidebar_controller.h
@@ -71,6 +71,8 @@ class SidebarController : public SidebarService::Observer {
   bool IsActiveIndex(std::optional<size_t> index) const;
   bool DoesBrowserHaveOpenedTabForItem(const SidebarItem& item) const;
 
+  void TearDownPreBrowserWindowDestruction();
+
   void SetSidebar(Sidebar* sidebar);
   Sidebar* sidebar() const { return sidebar_; }
   SidebarModel* model() const { return sidebar_model_.get(); }
@@ -93,7 +95,7 @@ class SidebarController : public SidebarService::Observer {
   raw_ptr<TabStripModel> tab_strip_model_ = nullptr;
   raw_ptr<Profile> profile_ = nullptr;
   raw_ptr<Browser> browser_ = nullptr;
-  raw_ptr<Sidebar, DanglingUntriaged> sidebar_ = nullptr;
+  raw_ptr<Sidebar> sidebar_ = nullptr;
 
   std::unique_ptr<SidebarModel> sidebar_model_;
   base::ScopedObservation<SidebarService, SidebarService::Observer>

--- a/chromium_src/chrome/browser/ui/browser_window/public/browser_window_features.h
+++ b/chromium_src/chrome/browser/ui/browser_window/public/browser_window_features.h
@@ -14,6 +14,8 @@
 #define Init virtual Init
 #define InitPostBrowserViewConstruction virtual InitPostBrowserViewConstruction
 #define InitPostWindowConstruction virtual InitPostWindowConstruction
+#define TearDownPreBrowserViewDestruction \
+  virtual TearDownPreBrowserViewDestruction
 
 #include "src/chrome/browser/ui/browser_window/public/browser_window_features.h"  // IWYU pragma: export
 
@@ -21,6 +23,7 @@
 #undef InitPostBrowserViewConstruction
 #undef Init
 #undef BrowserWindowFeatures
+#undef TearDownPreBrowserViewDestruction
 
 #include "brave/browser/ui/browser_window/public/browser_window_features.h"
 


### PR DESCRIPTION
This PR adds an override for
`BrowserWindowFeatures::TearDownPreBrowserViewDestruction`. This
override allows disposing of controllers that require `BrowserView`
before `BrowserView` itself is destroyed. This method can also be used
to do particular tear down of certain controllers, like stopping
observers, etc.

Resolves https://github.com/brave/brave-browser/issues/47516
