### PR TITLE
Print node error correctly on launch via presubmit.

### DIFF
--- a/PRESUBMIT.py
+++ b/PRESUBMIT.py
@@ -45,10 +45,10 @@ def CheckLeoVariables(input_api, output_api):
             brave_node.PathInNodeModules('@brave', 'leo', 'src', 'scripts',
                                          'audit-tokens.js')
         ]
-        brave_node.RunNode(parts)
+        brave_node.RunNode(parts, include_command_in_error=False)
         return []
     except RuntimeError as err:
-        return [output_api.PresubmitError(err.args[1])]
+        return [output_api.PresubmitError(str(err))]
 
 
 # Check and fix formatting issues (supports --fix).
@@ -60,13 +60,13 @@ def CheckPatchFormatted(input_api, output_api):
     if not input_api.PRESUBMIT_FIX:
         cmd.append('--dry-run')
     try:
-        brave_node.RunNode(cmd)
+        brave_node.RunNode(cmd, include_command_in_error=False)
         return []
     except RuntimeError as err:
         return [
             output_api.PresubmitError(
                 f'The code requires formatting. '
-                f'Please run: npm run presubmit -- --fix.\n\n{err.args[1]}')
+                f'Please run: npm run presubmit -- --fix.\n\n{err}')
         ]
 
 

--- a/script/brave_node.py
+++ b/script/brave_node.py
@@ -15,7 +15,7 @@ def PathInNodeModules(*args):
     return os.path.join(NODE_MODULES, *args)
 
 
-def RunNode(cmd_parts):
+def RunNode(cmd_parts, include_command_in_error=True):
     cmd = ['node'] + cmd_parts
     process = subprocess.Popen(cmd,
                                cwd=os.getcwd(),
@@ -26,8 +26,8 @@ def RunNode(cmd_parts):
 
     if process.returncode != 0:
         err = stderr if len(stderr) > 0 else stdout
-        raise RuntimeError('Command \'%s\' failed\n%s' % (' '.join(cmd), err),
-                           err)
+        raise RuntimeError(f"Command '{' '.join(cmd)}' failed\n{err}"
+                           if include_command_in_error else err)
 
     return stdout
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Fix `RuntimeError` to string conversion in upstream eslint runner. Adding a new argument to `RuntimeError` breaks `str(err)` call.

Resolves https://github.com/brave/brave-browser/issues/47522

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
