### PR TITLE
Try to fix crash from brave infobar multiline support (uplift to 1.81.x)

### DIFF
--- a/browser/ui/views/infobars/brave_confirm_infobar.cc
+++ b/browser/ui/views/infobars/brave_confirm_infobar.cc
@@ -212,7 +212,11 @@ void BraveConfirmInfoBar::MaybeLayoutMultiLineLabelAndLink() {
   const int target_height = std::max(
       max_height,
       ChromeLayoutProvider::Get()->GetDistanceMetric(DISTANCE_INFOBAR_HEIGHT));
-  SetTargetHeight(target_height);
+
+  // Don't call SetTargetHeight() as it causes another nested layout pass inside
+  // the layout. Instead, just set the target height and update the computed
+  // height.
+  BraveSetTargetHeight(target_height);
 }
 
 void BraveConfirmInfoBar::CheckboxPressed() {

--- a/chromium_src/components/infobars/core/infobar.cc
+++ b/chromium_src/components/infobars/core/infobar.cc
@@ -1,0 +1,15 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "src/components/infobars/core/infobar.cc"
+
+namespace infobars {
+
+void InfoBar::BraveSetTargetHeight(int height) {
+  target_height_ = height;
+  height_ = animation_.CurrentValueBetween(0, target_height_);
+}
+
+}  // namespace infobars

--- a/chromium_src/components/infobars/core/infobar.h
+++ b/chromium_src/components/infobars/core/infobar.h
@@ -1,0 +1,19 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_COMPONENTS_INFOBARS_CORE_INFOBAR_H_
+#define BRAVE_CHROMIUM_SRC_COMPONENTS_INFOBARS_CORE_INFOBAR_H_
+
+// BraveSetTargetHeight() sets the target height and computed height w/o
+// triggering a layout pass.
+#define SetTargetHeight             \
+  BraveSetTargetHeight(int height); \
+  void SetTargetHeight
+
+#include "src/components/infobars/core/infobar.h"  // IWYU pragma: export
+
+#undef SetTargetHeight
+
+#endif  // BRAVE_CHROMIUM_SRC_COMPONENTS_INFOBARS_CORE_INFOBAR_H_


### PR DESCRIPTION
Uplift of #29988
fix https://github.com/brave/brave-browser/issues/47504

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.