### PR TITLE
[iOS] Remove Playlist badge that would appear on the browser menu button

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Playlist.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Playlist.swift
@@ -99,13 +99,6 @@ extension BrowserViewController: PlaylistScriptHandlerDelegate,
           browser.topToolbar.updatePlaylistButtonState(
             shouldShowPlaylistURLBarButton ? .addToPlaylist : .none
           )
-          if Preferences.Playlist.enablePlaylistMenuBadge.value {
-            browser.topToolbar.menuButton.addBadge(.playlist, animated: true)
-            browser.toolbar?.menuButton.addBadge(.playlist, animated: true)
-          } else {
-            browser.topToolbar.menuButton.removeBadge(.playlist, animated: true)
-            browser.toolbar?.menuButton.removeBadge(.playlist, animated: true)
-          }
         case .existingItem:
           browser.topToolbar.updatePlaylistButtonState(
             shouldShowPlaylistURLBarButton ? .addedToPlaylist(item) : .none

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -487,7 +487,6 @@ public class BrowserViewController: UIViewController {
     Preferences.Privacy.blockAllCookies.observe(from: self)
     Preferences.Rewards.hideRewardsIcon.observe(from: self)
     Preferences.Rewards.rewardsToggledOnce.observe(from: self)
-    Preferences.Playlist.enablePlaylistMenuBadge.observe(from: self)
     Preferences.Playlist.enablePlaylistURLBarButton.observe(from: self)
     Preferences.Playlist.syncSharedFoldersAutomatically.observe(from: self)
     Preferences.NewTabPage.backgroundMediaTypeRaw.observe(from: self)
@@ -2970,8 +2969,7 @@ extension BrowserViewController: PreferencesObserver {
           for: $0
         )
       }
-    case Preferences.Playlist.enablePlaylistMenuBadge.key,
-      Preferences.Playlist.enablePlaylistURLBarButton.key:
+    case Preferences.Playlist.enablePlaylistURLBarButton.key:
       let selectedTab = tabManager.selectedTab
       updatePlaylistURLBar(
         tab: selectedTab,

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/PlaylistSettingsViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/PlaylistSettingsViewController.swift
@@ -74,15 +74,6 @@ class PlaylistSettingsViewController: TableViewController {
       Section(
         rows: [
           .boolRow(
-            title: Strings.PlayList.menuBadgeOptionTitle,
-            option: Preferences.Playlist.enablePlaylistMenuBadge
-          )
-        ],
-        footer: .title(Strings.PlayList.menuBadgeOptionFooterText)
-      ),
-      Section(
-        rows: [
-          .boolRow(
             title: Strings.PlayList.playlistLongPressSettingsOptionTitle,
             option: Preferences.Playlist.enableLongPressAddToPlaylist
           )

--- a/ios/brave-ios/Sources/BraveStrings/BraveStrings.swift
+++ b/ios/brave-ios/Sources/BraveStrings/BraveStrings.swift
@@ -5068,25 +5068,6 @@ extension Strings {
           "Button Title of the ActionSheet/Alert Button when sharing a playlist item from the Swipe-Action"
       )
 
-    public static let menuBadgeOptionTitle =
-      NSLocalizedString(
-        "playlist.menuBadgeOptionTitle",
-        tableName: "BraveShared",
-        bundle: .module,
-        value: "Show Menu Notification Badge",
-        comment: "Title for playlist menu badge option"
-      )
-
-    public static let menuBadgeOptionFooterText =
-      NSLocalizedString(
-        "playlist.menuBadgeOptionFooterText",
-        tableName: "BraveShared",
-        bundle: .module,
-        value:
-          "When enabled, a badge will be displayed on the main menu icon, indicating media on the page may be added to Brave Playlist.",
-        comment: "Description footer for playlist menu badge option"
-      )
-
     public static let playlistLongPressSettingsOptionTitle =
       NSLocalizedString(
         "playlist.playlistLongPressSettingsOptionTitle",

--- a/ios/brave-ios/Sources/Playlist/PlaylistPreferences.swift
+++ b/ios/brave-ios/Sources/Playlist/PlaylistPreferences.swift
@@ -55,9 +55,6 @@ extension Preferences {
     /// The option to disable long-press-to-add-to-playlist gesture.
     public static let enableLongPressAddToPlaylist =
       Option<Bool>(key: "playlist.longPressAddToPlaylist", default: true)
-    /// The option to enable or disable the 3-dot menu badge for playlist
-    public static let enablePlaylistMenuBadge =
-      Option<Bool>(key: "playlist.enablePlaylistMenuBadge", default: true)
     /// The option to enable or disable the URL-Bar button for playlist
     public static let enablePlaylistURLBarButton =
       Option<Bool>(key: "playlist.enablePlaylistURLBarButton", default: true)


### PR DESCRIPTION
Add to playlist is no longer a focal point on the new menu design when available, so this badge didn't make any sense anymore

Resolves https://github.com/brave/brave-browser/issues/47525

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
