### PR TITLE
[iOS] Restore correct tab ordering when opening links in new tabs

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/TabDescendentHelper.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/TabDescendentHelper.swift
@@ -1,0 +1,28 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Web
+
+extension TabDataValues {
+  private struct ParentHelperKey: TabDataKey {
+    static var defaultValue: (any TabState)?
+  }
+
+  /// The tab that a user opened the current tab from. Use this to improve ordering of tabs in the
+  /// tab tray & tab bar.
+  ///
+  /// - note: This is different than `opener` which is used when the tab is opened by the web page
+  var parent: (any TabState)? {
+    get { self[ParentHelperKey.self] }
+    set { self[ParentHelperKey.self] = newValue }
+  }
+}
+
+extension TabState {
+  func isDescendentOf(_ ancestor: any TabState) -> Bool {
+    return sequence(first: opener) { $0?.opener }.contains { $0 === ancestor }
+      || sequence(first: data.parent) { $0?.data.parent }.contains { $0 === ancestor }
+  }
+}

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/TabManager.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/TabManager.swift
@@ -644,6 +644,8 @@ class TabManager: NSObject {
       }
       if isPopup {
         tab.opener = parent
+      } else {
+        tab.parent = parent
       }
       allTabs.insert(tab, at: insertIndex)
     }

--- a/ios/brave-ios/Sources/Web/TabState.swift
+++ b/ios/brave-ios/Sources/Web/TabState.swift
@@ -345,12 +345,6 @@ extension TabState {
   }
 }
 
-extension TabState {
-  public func isDescendentOf(_ ancestor: any TabState) -> Bool {
-    return sequence(first: opener) { $0?.opener }.contains { $0 === ancestor }
-  }
-}
-
 /// A basic proxy over the underlying web view that may be displaying web content
 public protocol WebViewProxy {
   var scrollView: UIScrollView? { get }


### PR DESCRIPTION
This adds back the parent-child relationship for user-driven new tabs so that the ordering of said tabs matches 1.78, which would add new tabs to the end of the chain instead of right after the tab which the user opened the link from

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/47020

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
