### PR TITLE
[iOS] Remove small animation when showing/hiding the NTP

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -1569,22 +1569,9 @@ public class BrowserViewController: UIViewController {
         $0.edges.equalTo(pageOverlayLayoutGuide)
       }
       ntpController.view.layoutIfNeeded()
-      ntpController.view.alpha = 0
 
-      // We have to run this animation, even if the view is already showing because there may be a hide animation running
-      // and we want to be sure to override its results.
-      let animator = UIViewPropertyAnimator(
-        duration: 0.2,
-        curve: .easeInOut,
-        animations: {
-          ntpController.view.alpha = 1
-        }
-      )
-      animator.addCompletion { _ in
-        self.webViewContainer.accessibilityElementsHidden = true
-        UIAccessibility.post(notification: .screenChanged, argument: nil)
-      }
-      animator.startAnimation()
+      self.webViewContainer.accessibilityElementsHidden = true
+      UIAccessibility.post(notification: .screenChanged, argument: nil)
     }
   }
 
@@ -1593,36 +1580,26 @@ public class BrowserViewController: UIViewController {
   fileprivate func hideActiveNewTabPageController(_ isReaderModeURL: Bool = false) {
     guard let controller = activeNewTabPageViewController else { return }
 
-    let animator = UIViewPropertyAnimator(
-      duration: 0.2,
-      curve: .easeInOut,
-      animations: {
-        controller.view.alpha = 0.0
-      }
-    )
-    animator.addCompletion { _ in
-      controller.willMove(toParent: nil)
-      controller.view.removeFromSuperview()
-      controller.removeFromParent()
-      controller.view.alpha = 1
-      self.webViewContainer.accessibilityElementsHidden = false
-      UIAccessibility.post(notification: .screenChanged, argument: nil)
+    controller.willMove(toParent: nil)
+    controller.view.removeFromSuperview()
+    controller.removeFromParent()
+    controller.view.alpha = 1
+    self.webViewContainer.accessibilityElementsHidden = false
+    UIAccessibility.post(notification: .screenChanged, argument: nil)
 
-      // Refresh the reading view toolbar since the article record may have changed
-      if let tab = self.tabManager.selectedTab,
-        let readerMode = tab.browserData?.getContentScript(
-          name: ReaderModeScriptHandler.scriptName
-        )
-          as? ReaderModeScriptHandler,
-        readerMode.state == .active,
-        isReaderModeURL,
-        let state = tab.playlistItemState
-      {
-        self.showReaderModeBar(animated: false)
-        self.updatePlaylistURLBar(tab: tab, state: state, item: tab.playlistItem)
-      }
+    // Refresh the reading view toolbar since the article record may have changed
+    if let tab = self.tabManager.selectedTab,
+      let readerMode = tab.browserData?.getContentScript(
+        name: ReaderModeScriptHandler.scriptName
+      )
+        as? ReaderModeScriptHandler,
+      readerMode.state == .active,
+      isReaderModeURL,
+      let state = tab.playlistItemState
+    {
+      self.showReaderModeBar(animated: false)
+      self.updatePlaylistURLBar(tab: tab, state: state, item: tab.playlistItem)
     }
-    animator.startAnimation()
   }
 
   func updateInContentHomePanel(_ url: URL?) {


### PR DESCRIPTION
This change removes the animation which could cause odd glitches such as flashing the NTP's background color when deleting tabs, animating the tab tray, etc. In the future this could possibly be re-added when NTPs are added directly to a TabState's view hierarchy instead of BVCs

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/47026

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
