### PR TITLE
[AI Chat]: Filter Out Citations With Missing Sources

### DIFF
--- a/components/ai_chat/resources/untrusted_conversation_frame/components/assistant_response/index.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/assistant_response/index.tsx
@@ -14,7 +14,8 @@ import MarkdownRenderer from '../markdown_renderer'
 import WebSourcesEvent from './web_sources_event'
 import styles from './style.module.scss'
 import {
-  removeReasoning //
+  removeReasoning,
+  removeCitationsWithMissingLinks
 } from '../conversation_entries/conversation_entries_utils'
 
 function SearchSummary (props: { searchQueries: string[] }) {
@@ -67,10 +68,18 @@ function AssistantEvent(props: {
                            `[${index + 1}]: ${url}`).join('\n') + '\n\n'
         : '';
 
+    // Remove citations with missing links
+    const filteredOutCitationsWithMissingLinks =
+      removeCitationsWithMissingLinks(
+        event.completionEvent.completion,
+        allowedLinks
+      )
+
     // Replaces 2 consecutive citations with a separator and also
     // adds a space before the citation and the text.
-     const completion =
-       event.completionEvent.completion.replace(/(\w|\S)\[(\d+)\]/g, '$1 [$2]')
+    const completion =
+      filteredOutCitationsWithMissingLinks
+        .replace(/(\w|\S)\[(\d+)\]/g, '$1 [$2]')
 
     const fullText = `${numberedLinks}${removeReasoning(completion)}`;
 

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/conversation_entries/conversation_entries_utils.test.ts
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/conversation_entries/conversation_entries_utils.test.ts
@@ -3,7 +3,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import { getReasoningText, removeReasoning } from './conversation_entries_utils'
+import {
+  getReasoningText,
+  removeReasoning,
+  removeCitationsWithMissingLinks,
+} from './conversation_entries_utils'
 
 describe('getReasoningText', () => {
   it('Should extract reasoning text between start and end tags', () => {
@@ -57,5 +61,18 @@ describe('removeReasoning', () => {
   it('should not fail if there is not starting tag', () => {
     const input = 'Reasoning text here.</think>'
     expect(removeReasoning(input)).toBe('Reasoning text here.</think>')
+  })
+})
+
+describe('removeCitationsWithMissingLinks', () => {
+  it('should remove citations with missing links', () => {
+    const input = 'Citation [1] and [2] thats it[3].'
+    const citationLinks = [
+      'https://example.com/link1',
+      'https://example.com/link2',
+    ]
+    expect(removeCitationsWithMissingLinks(input, citationLinks)).toBe(
+      'Citation [1] and [2] thats it.',
+    )
   })
 })

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/conversation_entries/conversation_entries_utils.ts
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/conversation_entries/conversation_entries_utils.ts
@@ -54,3 +54,14 @@ export const removeReasoning = (text: string) => {
     ? text.split('</think>')[1]
     : text
 }
+
+export const removeCitationsWithMissingLinks = (
+  text: string,
+  citationLinks: string[],
+) => {
+  return text.replace(/\[(\d+)\]/g, (match, citationNumber) => {
+    // Convert to 0-based index
+    const index = parseInt(citationNumber) - 1
+    return index >= 0 && index < citationLinks.length ? match : ''
+  })
+}


### PR DESCRIPTION
## Description 

Fixes a bug where `Citation` brackets were being displayed even though there were no corresponding sources.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/47484>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

## Test Plan:
1. Start a conversation with `Leo AI` and ask it a question where `citations` would be returned
2. Now edit the `AI` response and add `citation` brackets to the answer that have no corresponding source.
3. Those `citation` brackets should not be displayed

Before:

<img width="727" height="668" alt="Screenshot 67" src="https://github.com/user-attachments/assets/bff9f650-c1bd-46f7-b463-36f8ae3c5c57" />

After:

<img width="717" height="638" alt="Screenshot 66" src="https://github.com/user-attachments/assets/5eb22524-28bb-449f-a0c5-3a9642cdac99" />
