### PR TITLE
[iOS] Ensure toolbar item visibility is updated correctly when animating

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
@@ -803,29 +803,24 @@ class TopToolbarView: UIView, ToolbarProtocol {
   }
 
   private func updateViewsForOverlayModeAndToolbarChanges() {
-    // UIStackView bug:
-    // Don't set `isHidden` to the same value on a view that adjusts layout of a UIStackView
-    // inside of a UIView.animate() block, otherwise on occasion the view will render but
-    // `isHidden` will still be true
-    if cancelButton.isHidden == inOverlayMode {
-      cancelButton.isHidden = !inOverlayMode
-    }
-    backButton.isHidden = toolbarIsShowing || inOverlayMode
-    forwardButton.isHidden = toolbarIsShowing || inOverlayMode
-    shareButton.isHidden = toolbarIsShowing || inOverlayMode
-    trailingItemsStackView.isHidden = toolbarIsShowing || inOverlayMode
-    locationView.contentView.isHidden = inOverlayMode
-    shieldsRewardsStack.isHidden = inOverlayMode
+    cancelButton.stackViewAnimationSafeIsHidden = !inOverlayMode
+    backButton.stackViewAnimationSafeIsHidden = toolbarIsShowing || inOverlayMode
+    forwardButton.stackViewAnimationSafeIsHidden = toolbarIsShowing || inOverlayMode
+    shareButton.stackViewAnimationSafeIsHidden = toolbarIsShowing || inOverlayMode
+    trailingItemsStackView.stackViewAnimationSafeIsHidden = toolbarIsShowing || inOverlayMode
+    locationView.contentView.stackViewAnimationSafeIsHidden = inOverlayMode
+    shieldsRewardsStack.stackViewAnimationSafeIsHidden = inOverlayMode
 
     let selectedShortcut: WidgetShortcut? = Preferences.General.toolbarShortcutButton.value.flatMap(
       WidgetShortcut.init
     )
-    shortcutButton.isHidden = selectedShortcut != nil ? inOverlayMode : true
+    shortcutButton.stackViewAnimationSafeIsHidden = selectedShortcut != nil ? inOverlayMode : true
     if let selectedShortcut {
       shortcutButton.setImage(selectedShortcut.image, for: .normal)
       shortcutButton.accessibilityLabel = selectedShortcut.displayString
     }
-    leadingItemsStackView.isHidden = leadingItemsStackView.arrangedSubviews.allSatisfy(\.isHidden)
+    leadingItemsStackView.stackViewAnimationSafeIsHidden = leadingItemsStackView.arrangedSubviews
+      .allSatisfy(\.isHidden)
   }
 
   private func animateToOverlayState(overlayMode overlay: Bool, didCancel cancel: Bool = false) {
@@ -1074,5 +1069,20 @@ extension TopToolbarView: UIDragInteractionDelegate {
 
   func dragInteraction(_ interaction: UIDragInteraction, sessionWillBegin session: UIDragSession) {
     delegate?.topToolbarDidBeginDragInteraction(self)
+  }
+}
+
+extension UIView {
+  // UIStackView bug:
+  // Don't set `isHidden` to the same value on a view that adjusts layout of a UIStackView
+  // inside of a UIView.animate() block, otherwise on occasion the view will render but
+  // `isHidden` will still be true
+  fileprivate var stackViewAnimationSafeIsHidden: Bool {
+    get { isHidden }
+    set {
+      if isHidden != newValue {
+        isHidden = newValue
+      }
+    }
   }
 }


### PR DESCRIPTION
This change ensures that the `isHidden` property is updated only if the value has changed to avoid a `UIStackView` bug where the view's hidden value will not update correctly and either layout or render incorrectly when done in an animation block

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/46226

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
