### PR TITLE
Add admin policy for Web Discovery

### DIFF
--- a/browser/DEPS
+++ b/browser/DEPS
@@ -68,6 +68,7 @@ include_rules += [
   "-brave/components/speedreader/renderer",
   "+brave/components/web_discovery/browser",
   "+brave/components/web_discovery/buildflags",
+  "+brave/components/web_discovery/common",
   "+brave/components/webcompat/content/browser",
   "+brave/components/webcompat/core/common",
   "+brave/components/brave_vpn/browser",

--- a/browser/brave_profile_prefs.cc
+++ b/browser/brave_profile_prefs.cc
@@ -449,6 +449,7 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
 
 #if BUILDFLAG(ENABLE_EXTENSIONS) || BUILDFLAG(ENABLE_WEB_DISCOVERY_NATIVE)
   registry->RegisterBooleanPref(kWebDiscoveryEnabled, false);
+  registry->RegisterBooleanPref(kWebDiscoveryDisabledByPolicy, false);
   registry->RegisterDictionaryPref(kWebDiscoveryCTAState);
 #endif
 

--- a/browser/extensions/BUILD.gn
+++ b/browser/extensions/BUILD.gn
@@ -25,6 +25,7 @@ source_set("component_loader") {
     "//base",
     "//brave/components/brave_component_updater/browser",
     "//brave/components/brave_extension:static_resources",
+    "//brave/components/web_discovery/common:util",
     "//chrome/browser:browser_process",
     "//chrome/browser/extensions",
     "//chrome/browser/profiles:profile",
@@ -33,6 +34,10 @@ source_set("component_loader") {
     "//extensions/browser",
     "//extensions/common",
   ]
+
+  if (enable_web_discovery_native) {
+    deps += [ "//brave/components/web_discovery/common" ]
+  }
 }
 
 # This is split out from extensions and the rest of brave_prefs_util because it
@@ -133,6 +138,7 @@ source_set("extensions") {
     "//brave/components/sidebar/browser",
     "//brave/components/tor/buildflags",
     "//brave/components/web_discovery/buildflags",
+    "//brave/components/web_discovery/common:util",
     "//brave/components/webcompat_reporter/common",
     "//chrome/browser:browser_process",
     "//chrome/browser:browser_public_dependencies",

--- a/browser/extensions/api/settings_private/brave_prefs_util.cc
+++ b/browser/extensions/api/settings_private/brave_prefs_util.cc
@@ -193,6 +193,8 @@ const PrefsUtil::TypedPrefMap& BravePrefsUtil::GetAllowlistedKeys() {
 #if BUILDFLAG(ENABLE_EXTENSIONS) || BUILDFLAG(ENABLE_WEB_DISCOVERY_NATIVE)
   // Web discovery prefs
   (*s_brave_allowlist)[kWebDiscoveryEnabled] = settings_api::PrefType::kBoolean;
+  (*s_brave_allowlist)[kWebDiscoveryDisabledByPolicy] =
+      settings_api::PrefType::kBoolean;
 #endif
   // Clear browsing data on exit prefs.
   (*s_brave_allowlist)[browsing_data::prefs::kDeleteBrowsingHistoryOnExit] =

--- a/browser/extensions/api/web_discovery_api.h
+++ b/browser/extensions/api/web_discovery_api.h
@@ -26,14 +26,14 @@ class WebDiscoveryRetrieveBackupResultsFunction : public ExtensionFunction {
       std::optional<brave_search::BackupResultsService::BackupResults> results);
 };
 
-class WebDiscoveryIsWebDiscoveryNativeEnabledFunction
+class WebDiscoveryIsWebDiscoveryExtensionEnabledFunction
     : public ExtensionFunction {
  public:
-  DECLARE_EXTENSION_FUNCTION("webDiscovery.isWebDiscoveryNativeEnabled",
+  DECLARE_EXTENSION_FUNCTION("webDiscovery.isWebDiscoveryExtensionEnabled",
                              UNKNOWN)
 
  protected:
-  ~WebDiscoveryIsWebDiscoveryNativeEnabledFunction() override;
+  ~WebDiscoveryIsWebDiscoveryExtensionEnabledFunction() override;
 
   ResponseAction Run() override;
 };

--- a/browser/policy/brave_simple_policy_map.h
+++ b/browser/policy/brave_simple_policy_map.h
@@ -75,6 +75,8 @@ inline constexpr PolicyToPreferenceMapEntry kBraveSimplePolicyMap[] = {
      base::Value::Type::BOOLEAN},
     {policy::key::kBraveStatsPingDisabled, kStatsReportingDisabledByPolicy,
      base::Value::Type::BOOLEAN},
+    {policy::key::kBraveWebDiscoveryDisabled, kWebDiscoveryDisabledByPolicy,
+     base::Value::Type::BOOLEAN},
 #if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_MAC) || BUILDFLAG(IS_LINUX)
     {policy::key::kBraveNewsDisabled,
      brave_news::prefs::kBraveNewsDisabledByPolicy, base::Value::Type::BOOLEAN},

--- a/browser/resources/settings/brave_search_engines_page/brave_search_engines_page.html
+++ b/browser/resources/settings/brave_search_engines_page/brave_search_engines_page.html
@@ -71,15 +71,17 @@
       sub-label="$i18n{searchSuggestDesc}">
   </settings-toggle-button>
 </template>
-<if expr="enable_extensions or enable_web_discovery_native">
-<settings-toggle-button id="webDiscoveryEnabledExtension"
-    class="cr-row"
-    pref="{{prefs.brave.web_discovery_enabled}}"
-    label="$i18n{braveWebDiscoveryLabel}"
-    sub-label="$i18n{braveWebDiscoverySubLabel}"
-    learn-more-url="$i18n{webDiscoveryLearnMoreURL}">
-</settings-toggle-button>
-</if>
+<template is="dom-if" if="[[!prefs.brave.web_discovery_disabled_by_policy.value]]">
+  <if expr="enable_extensions or enable_web_discovery_native">
+    <settings-toggle-button id="webDiscoveryEnabledExtension"
+        class="cr-row"
+        pref="{{prefs.brave.web_discovery_enabled}}"
+        label="$i18n{braveWebDiscoveryLabel}"
+        sub-label="$i18n{braveWebDiscoverySubLabel}"
+        learn-more-url="$i18n{webDiscoveryLearnMoreURL}">
+    </settings-toggle-button>
+  </if>
+</template>
 <settings-toggle-button id="otherSearchEnginesEnabled"
     class="cr-row"
     pref="{{prefs.brave.other_search_engines_enabled}}"

--- a/browser/resources/settings/brave_search_engines_page/brave_search_engines_page.ts
+++ b/browser/resources/settings/brave_search_engines_page/brave_search_engines_page.ts
@@ -16,9 +16,10 @@ import {BraveSearchEnginesPageBrowserProxyImpl} from './brave_search_engines_pag
 import {getTemplate} from './brave_search_engines_page.html.js'
 import type {CrToastElement} from 'chrome://resources/cr_elements/cr_toast/cr_toast.js'
 import type {SearchEngine} from '../search_engines_page/search_engines_browser_proxy.js'
+import {PrefsMixin} from '/shared/settings/prefs/prefs_mixin.js'
 
 const BraveSearchEnginesPageBase =
-  WebUiListenerMixin(I18nMixin(RouteObserverMixin(PolymerElement)))
+  WebUiListenerMixin(PrefsMixin(I18nMixin(RouteObserverMixin(PolymerElement))))
 
 class BraveSearchEnginesPage extends BraveSearchEnginesPageBase {
   static get is() {

--- a/browser/search_engines/search_engine_tracker.cc
+++ b/browser/search_engines/search_engine_tracker.cc
@@ -17,6 +17,7 @@
 #include "brave/components/brave_search_conversion/p3a.h"
 #include "brave/components/brave_search_conversion/utils.h"
 #include "brave/components/constants/pref_names.h"
+#include "brave/components/web_discovery/common/util.h"
 #include "chrome/browser/browser_process.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/search_engines/template_url_service_factory.h"
@@ -238,7 +239,7 @@ void SearchEngineTracker::OnTemplateURLServiceChanged() {
 
 #if BUILDFLAG(ENABLE_EXTENSIONS) || BUILDFLAG(ENABLE_WEB_DISCOVERY_NATIVE)
 void SearchEngineTracker::RecordWebDiscoveryEnabledP3A() {
-  bool enabled = profile_prefs_->GetBoolean(kWebDiscoveryEnabled);
+  bool enabled = web_discovery::IsWebDiscoveryEnabled(*profile_prefs_);
   UMA_HISTOGRAM_BOOLEAN(kWebDiscoveryEnabledMetric, enabled);
   UMA_HISTOGRAM_BOOLEAN(
       kWebDiscoveryAndAdsMetric,

--- a/browser/search_engines/sources.gni
+++ b/browser/search_engines/sources.gni
@@ -16,6 +16,7 @@ brave_browser_search_engines_deps = [
   "//base",
   "//brave/components/brave_search_conversion",
   "//brave/components/time_period_storage",
+  "//brave/components/web_discovery/common:util",
   "//chrome/browser/profiles:profile",
   "//components/keyed_service/content",
   "//components/keyed_service/core",

--- a/browser/ui/webui/welcome_page/welcome_dom_handler.cc
+++ b/browser/ui/webui/welcome_page/welcome_dom_handler.cc
@@ -196,6 +196,10 @@ void WelcomeDOMHandler::HandleEnableWebDiscovery(
     const base::Value::List& args) {
   DCHECK(profile_);
 #if BUILDFLAG(ENABLE_EXTENSIONS) || BUILDFLAG(ENABLE_WEB_DISCOVERY_NATIVE)
+  // Don't allow enabling web discovery if it's disabled by policy
+  if (profile_->GetPrefs()->GetBoolean(kWebDiscoveryDisabledByPolicy)) {
+    return;
+  }
   profile_->GetPrefs()->SetBoolean(kWebDiscoveryEnabled, true);
 #endif
 }

--- a/browser/web_discovery/sources.gni
+++ b/browser/web_discovery/sources.gni
@@ -23,6 +23,7 @@ if (enable_extensions || enable_web_discovery_native) {
     "//brave/common",
     "//brave/components/constants",
     "//brave/components/search_engines",
+    "//brave/components/web_discovery/common:util",
     "//chrome/browser/profiles",
     "//chrome/browser/ui",
     "//components/infobars/content",

--- a/browser/web_discovery/web_discovery_cta_util.cc
+++ b/browser/web_discovery/web_discovery_cta_util.cc
@@ -14,6 +14,7 @@
 #include "brave/components/constants/pref_names.h"
 #include "brave/components/constants/url_constants.h"
 #include "brave/components/search_engines/brave_prepopulated_engines.h"
+#include "brave/components/web_discovery/common/util.h"
 #include "components/prefs/pref_service.h"
 #include "components/prefs/scoped_user_pref_update.h"
 #include "components/search_engines/template_url.h"
@@ -86,8 +87,9 @@ bool ShouldShowWebDiscoveryInfoBar(TemplateURLService* service,
                                    PrefService* prefs,
                                    const WebDiscoveryCTAState& state,
                                    base::Clock* test_clock) {
-  if (prefs->GetBoolean(kWebDiscoveryEnabled))
+  if (web_discovery::IsWebDiscoveryEnabled(*prefs)) {
     return false;
+  }
 
   if (!service || !IsBraveSearchDefault(service))
     return false;

--- a/common/extensions/api/web_discovery.json
+++ b/common/extensions/api/web_discovery.json
@@ -42,9 +42,9 @@
         }
       },
       {
-        "name": "isWebDiscoveryNativeEnabled",
+        "name": "isWebDiscoveryExtensionEnabled",
         "type": "function",
-        "description": "Returns true if Web Discovery native feature is active",
+        "description": "Returns true if Web Discovery extension should be active",
         "parameters": [],
         "returns_async": {
           "name": "callback",

--- a/components/constants/pref_names.h
+++ b/components/constants/pref_names.h
@@ -97,6 +97,9 @@ inline constexpr char kDefaultBrowserPromptEnabled[] =
 
 #if BUILDFLAG(ENABLE_EXTENSIONS) || BUILDFLAG(ENABLE_WEB_DISCOVERY_NATIVE)
 inline constexpr char kWebDiscoveryEnabled[] = "brave.web_discovery_enabled";
+// Used to enable/disable web discovery via a policy.
+inline constexpr char kWebDiscoveryDisabledByPolicy[] =
+    "brave.web_discovery_disabled_by_policy";
 #endif
 inline constexpr char kWebDiscoveryCTAState[] = "brave.web_discovery.cta_state";
 inline constexpr char kDontAskEnableWebDiscovery[] =

--- a/components/definitions/chromel.d.ts
+++ b/components/definitions/chromel.d.ts
@@ -240,6 +240,6 @@ declare namespace chrome.test {
 }
 
 declare namespace chrome.webDiscovery {
-  type WebDiscoveryNativeEnabledCallback = (enabled: boolean) => void
-  const isWebDiscoveryNativeEnabled: (callback: WebDiscoveryNativeEnabledCallback) => void
+  type WebDiscoveryExtensionEnabledCallback = (enabled: boolean) => void
+  const isWebDiscoveryExtensionEnabled: (callback: WebDiscoveryExtensionEnabledCallback) => void
 }

--- a/components/policy/resources/templates/policy_definitions/BraveSoftware/BraveWebDiscoveryDisabled.yaml
+++ b/components/policy/resources/templates/policy_definitions/BraveSoftware/BraveWebDiscoveryDisabled.yaml
@@ -1,0 +1,39 @@
+caption: Disable Web Discovery
+default: null
+desc: |-
+  Disable Web Discovery in Brave.
+
+  Web Discovery is an opt-in feature that helps improve Brave's search index in a privacy-preserving way.
+
+  If this policy is set to true, Web Discovery will always be disabled and all related UI elements will be hidden.
+
+  If this policy is set to false, Web Discovery will be disabled by default.
+
+  If you set this policy, users cannot change or override it.
+
+  If this policy is left unset, Web Discovery will be disabled by default (subject to user preferences).
+example_value: true
+features:
+  can_be_mandatory: true
+  can_be_recommended: false
+  dynamic_refresh: false
+  per_profile: true
+items:
+- caption: Allow the user to decide (disabled by default)
+  value: false
+- caption: Disable Web Discovery functionality
+  value: true
+- caption: Allow the user to decide (disabled by default)
+  value: null
+owners:
+- bbondy@brave.com
+- clifton@brave.com
+- dandries@brave.com
+schema:
+  type: boolean
+supported_on:
+- chrome.*:138-
+future_on:
+- android
+tags: []
+type: main 

--- a/components/policy/resources/templates/policy_definitions/brave_policies.gni
+++ b/components/policy/resources/templates/policy_definitions/brave_policies.gni
@@ -16,6 +16,7 @@ _brave_policies = [
   "BraveSoftware/BraveSyncUrl.yaml",
   "BraveSoftware/BraveTalkDisabled.yaml",
   "BraveSoftware/BraveVPNDisabled.yaml",
+  "BraveSoftware/BraveWebDiscoveryDisabled.yaml",
   "BraveSoftware/BraveWalletDisabled.yaml",
   "BraveSoftware/BraveWaybackMachineDisabled.yaml",
   "BraveSoftware/IPFSEnabled.yaml",

--- a/components/web_discovery/browser/BUILD.gn
+++ b/components/web_discovery/browser/BUILD.gn
@@ -15,7 +15,10 @@ static_library("browser") {
   deps = [
     ":internal",
     "//base",
+    "//brave/components/constants",
+    "//brave/components/web_discovery/common",
     "//brave/components/web_discovery/common:mojom",
+    "//brave/components/web_discovery/common:util",
     "//components/keyed_service/core",
     "//components/prefs",
     "//services/network/public/cpp",
@@ -100,12 +103,15 @@ source_set("unit_tests") {
     "request_queue_unittest.cc",
     "server_config_loader_unittest.cc",
     "signature_basename_unittest.cc",
+    "web_discovery_service_unittest.cc",
   ]
   deps = [
     ":browser",
     ":internal",
     "//base/test:test_support",
+    "//brave/components/brave_search/browser",
     "//brave/components/constants",
+    "//brave/components/web_discovery/common",
     "//components/prefs:test_support",
     "//crypto",
     "//services/network:test_support",

--- a/components/web_discovery/browser/util.cc
+++ b/components/web_discovery/browser/util.cc
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include "base/command_line.h"
 #include "base/strings/stringprintf.h"
 #include "base/strings/utf_string_conversions.h"
 #include "brave/brave_domains/service_domains.h"

--- a/components/web_discovery/browser/web_discovery_service.cc
+++ b/components/web_discovery/browser/web_discovery_service.cc
@@ -11,11 +11,12 @@
 #include "base/functional/bind.h"
 #include "base/logging.h"
 #include "base/strings/stringprintf.h"
+#include "brave/components/constants/pref_names.h"
 #include "brave/components/web_discovery/browser/content_scraper.h"
 #include "brave/components/web_discovery/browser/payload_generator.h"
-#include "brave/components/web_discovery/browser/pref_names.h"
 #include "brave/components/web_discovery/browser/privacy_guard.h"
 #include "brave/components/web_discovery/browser/server_config_loader.h"
+#include "brave/components/web_discovery/common/util.h"
 #include "components/prefs/pref_registry_simple.h"
 #include "components/prefs/pref_service.h"
 #include "components/prefs/scoped_user_pref_update.h"
@@ -45,8 +46,12 @@ WebDiscoveryService::WebDiscoveryService(
       kWebDiscoveryEnabled,
       base::BindRepeating(&WebDiscoveryService::OnEnabledChange,
                           base::Unretained(this)));
+  pref_change_registrar_.Add(
+      kWebDiscoveryDisabledByPolicy,
+      base::BindRepeating(&WebDiscoveryService::OnEnabledChange,
+                          base::Unretained(this)));
 
-  if (profile_prefs_->GetBoolean(kWebDiscoveryEnabled)) {
+  if (IsWebDiscoveryEnabled()) {
     Start();
   }
 }
@@ -107,8 +112,12 @@ void WebDiscoveryService::ClearPrefs() {
   profile_prefs_->ClearPref(kPageCounts);
 }
 
+bool WebDiscoveryService::IsWebDiscoveryEnabled() const {
+  return web_discovery::IsWebDiscoveryEnabled(*profile_prefs_);
+}
+
 void WebDiscoveryService::OnEnabledChange() {
-  if (profile_prefs_->GetBoolean(kWebDiscoveryEnabled)) {
+  if (IsWebDiscoveryEnabled()) {
     Start();
   } else {
     Stop();

--- a/components/web_discovery/browser/web_discovery_service.h
+++ b/components/web_discovery/browser/web_discovery_service.h
@@ -68,9 +68,24 @@ class WebDiscoveryService : public KeyedService {
       mojo::Remote<mojom::DocumentExtractor> document_extractor);
 
  private:
+  friend class WebDiscoveryServiceTest;
+  FRIEND_TEST_ALL_PREFIXES(WebDiscoveryServiceTest, ServiceStartsWhenEnabled);
+  FRIEND_TEST_ALL_PREFIXES(WebDiscoveryServiceTest,
+                           ServiceDoesNotStartWhenDisabled);
+  FRIEND_TEST_ALL_PREFIXES(WebDiscoveryServiceTest,
+                           ServiceDoesNotStartWhenDisabledByPolicy);
+  FRIEND_TEST_ALL_PREFIXES(WebDiscoveryServiceTest,
+                           ServiceRestartsWhenReEnabled);
+  FRIEND_TEST_ALL_PREFIXES(WebDiscoveryServiceTest,
+                           ServiceStopsOnDisabledPrefChange);
+  FRIEND_TEST_ALL_PREFIXES(WebDiscoveryServiceTest,
+                           ServiceStopsOnPolicyDisabledPrefChange);
+
   void Start();
   void Stop();
   void ClearPrefs();
+
+  bool IsWebDiscoveryEnabled() const;
 
   void OnEnabledChange();
 

--- a/components/web_discovery/browser/web_discovery_service_unittest.cc
+++ b/components/web_discovery/browser/web_discovery_service_unittest.cc
@@ -1,0 +1,148 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/web_discovery/browser/web_discovery_service.h"
+
+#include <memory>
+
+#include "base/files/scoped_temp_dir.h"
+#include "base/memory/weak_ptr.h"
+#include "base/test/task_environment.h"
+#include "brave/components/brave_search/browser/backup_results_service.h"
+#include "brave/components/constants/pref_names.h"
+#include "components/prefs/pref_registry_simple.h"
+#include "components/prefs/testing_pref_service.h"
+#include "services/network/public/cpp/weak_wrapper_shared_url_loader_factory.h"
+#include "services/network/test/test_url_loader_factory.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace web_discovery {
+
+class WebDiscoveryServiceTest : public testing::Test {
+ private:
+  class MockBackupResultsService : public brave_search::BackupResultsService {
+   public:
+    MockBackupResultsService() = default;
+    ~MockBackupResultsService() override = default;
+
+    // Override virtual methods with empty implementations
+    void FetchBackupResults(const GURL& url,
+                            std::optional<net::HttpRequestHeaders> headers,
+                            BackupResultsCallback callback) override {}
+
+    bool HandleWebContentsStartRequest(const content::WebContents* web_contents,
+                                       const GURL& url) override {
+      return true;
+    }
+
+    base::WeakPtr<BackupResultsService> GetWeakPtr() override {
+      return nullptr;
+    }
+  };
+
+ public:
+  WebDiscoveryServiceTest()
+      : task_environment_(base::test::TaskEnvironment::TimeSource::MOCK_TIME),
+        shared_url_loader_factory_(
+            base::MakeRefCounted<network::WeakWrapperSharedURLLoaderFactory>(
+                &url_loader_factory_)) {}
+  ~WebDiscoveryServiceTest() override = default;
+
+  void SetUp() override {
+    WebDiscoveryService::RegisterLocalStatePrefs(local_state_.registry());
+    WebDiscoveryService::RegisterProfilePrefs(profile_prefs_.registry());
+    profile_prefs_.registry()->RegisterBooleanPref(kWebDiscoveryEnabled, false);
+    profile_prefs_.registry()->RegisterBooleanPref(
+        kWebDiscoveryDisabledByPolicy, false);
+
+    ASSERT_TRUE(temp_dir_.CreateUniqueTempDir());
+  }
+
+ protected:
+  void CreateService() {
+    service_ = std::make_unique<WebDiscoveryService>(
+        &local_state_, &profile_prefs_, temp_dir_.GetPath(),
+        shared_url_loader_factory_, &backup_results_service_);
+  }
+
+  // Check if service is active (has both components)
+  bool IsActive() const {
+    return service_->server_config_loader_ != nullptr &&
+           service_->credential_manager_ != nullptr;
+  }
+
+  base::test::TaskEnvironment task_environment_;
+  TestingPrefServiceSimple local_state_;
+  TestingPrefServiceSimple profile_prefs_;
+
+  network::TestURLLoaderFactory url_loader_factory_;
+  scoped_refptr<network::SharedURLLoaderFactory> shared_url_loader_factory_;
+
+  base::ScopedTempDir temp_dir_;
+  MockBackupResultsService backup_results_service_;
+  std::unique_ptr<WebDiscoveryService> service_;
+};
+
+TEST_F(WebDiscoveryServiceTest, ServiceStartsWhenEnabled) {
+  profile_prefs_.SetBoolean(kWebDiscoveryEnabled, true);
+  profile_prefs_.SetBoolean(kWebDiscoveryDisabledByPolicy, false);
+
+  CreateService();
+
+  EXPECT_TRUE(IsActive());
+}
+
+TEST_F(WebDiscoveryServiceTest, ServiceDoesNotStartWhenDisabled) {
+  // Test disabled via enabled pref
+  profile_prefs_.SetBoolean(kWebDiscoveryEnabled, false);
+  profile_prefs_.SetBoolean(kWebDiscoveryDisabledByPolicy, false);
+  CreateService();
+  EXPECT_FALSE(IsActive());
+
+  // Test disabled via policy pref
+  profile_prefs_.SetBoolean(kWebDiscoveryEnabled, true);
+  profile_prefs_.SetBoolean(kWebDiscoveryDisabledByPolicy, true);
+  CreateService();
+  EXPECT_FALSE(IsActive());
+
+  // Test both disabled
+  profile_prefs_.SetBoolean(kWebDiscoveryEnabled, false);
+  profile_prefs_.SetBoolean(kWebDiscoveryDisabledByPolicy, true);
+  CreateService();
+  EXPECT_FALSE(IsActive());
+}
+
+TEST_F(WebDiscoveryServiceTest, ServiceTogglesOnPrefChange) {
+  // Start disabled
+  profile_prefs_.SetBoolean(kWebDiscoveryEnabled, false);
+  CreateService();
+  EXPECT_FALSE(IsActive());
+
+  // Enable
+  profile_prefs_.SetBoolean(kWebDiscoveryEnabled, true);
+  EXPECT_TRUE(IsActive());
+
+  // Disable again
+  profile_prefs_.SetBoolean(kWebDiscoveryEnabled, false);
+  EXPECT_FALSE(IsActive());
+
+  // Enable again
+  profile_prefs_.SetBoolean(kWebDiscoveryEnabled, true);
+  EXPECT_TRUE(IsActive());
+}
+
+TEST_F(WebDiscoveryServiceTest, ServiceDoesNotToggleWhenDisabledByPolicy) {
+  // Start with policy disabled
+  profile_prefs_.SetBoolean(kWebDiscoveryDisabledByPolicy, true);
+  profile_prefs_.SetBoolean(kWebDiscoveryEnabled, false);
+  CreateService();
+  EXPECT_FALSE(IsActive());
+
+  // Try to enable via user pref - should remain inactive due to policy
+  profile_prefs_.SetBoolean(kWebDiscoveryEnabled, true);
+  EXPECT_FALSE(IsActive());
+}
+
+}  // namespace web_discovery

--- a/components/web_discovery/common/BUILD.gn
+++ b/components/web_discovery/common/BUILD.gn
@@ -6,9 +6,9 @@
 import("//brave/components/web_discovery/buildflags/buildflags.gni")
 import("//mojo/public/tools/bindings/mojom.gni")
 
-assert(enable_web_discovery_native)
-
 static_library("common") {
+  assert(enable_web_discovery_native)
+
   sources = [
     "features.cc",
     "features.h",
@@ -21,6 +21,20 @@ static_library("common") {
 }
 
 mojom("mojom") {
+  assert(enable_web_discovery_native)
+
   sources = [ "web_discovery.mojom" ]
   deps = [ "//mojo/public/mojom/base" ]
+}
+
+static_library("util") {
+  sources = [
+    "util.cc",
+    "util.h",
+  ]
+
+  deps = [
+    "//brave/components/constants",
+    "//components/prefs",
+  ]
 }

--- a/components/web_discovery/common/DEPS
+++ b/components/web_discovery/common/DEPS
@@ -1,0 +1,3 @@
+include_rules = [
+  "+components/prefs",
+]

--- a/components/web_discovery/common/util.cc
+++ b/components/web_discovery/common/util.cc
@@ -1,0 +1,18 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/web_discovery/common/util.h"
+
+#include "brave/components/constants/pref_names.h"
+#include "components/prefs/pref_service.h"
+
+namespace web_discovery {
+
+bool IsWebDiscoveryEnabled(PrefService& pref_service) {
+  return pref_service.GetBoolean(kWebDiscoveryEnabled) &&
+         !pref_service.GetBoolean(kWebDiscoveryDisabledByPolicy);
+}
+
+}  // namespace web_discovery

--- a/components/web_discovery/common/util.h
+++ b/components/web_discovery/common/util.h
@@ -1,0 +1,19 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_WEB_DISCOVERY_COMMON_UTIL_H_
+#define BRAVE_COMPONENTS_WEB_DISCOVERY_COMMON_UTIL_H_
+
+class PrefService;
+
+namespace web_discovery {
+
+// Returns true if web discovery is enabled by user preference and not
+// disabled by policy.
+bool IsWebDiscoveryEnabled(PrefService& profile_prefs);
+
+}  // namespace web_discovery
+
+#endif  // BRAVE_COMPONENTS_WEB_DISCOVERY_COMMON_UTIL_H_


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/47579

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

## Test plan

See the [support doc](https://support.brave.app/hc/en-us/articles/360039248271-Group-Policy) and the [Chromium doc](https://source.chromium.org/chromium/chromium/src/+/main:docs/enterprise/policies.md) for more info on enabling policies.

Configure a MITM proxy for these tests.

Unset the policy, start the browser with a fresh profile, enable Web Discovery. Make some Google queries, visit some web pages, wait five minutes. Ensure a request was sent to `collector.wdp.brave.com` or `patterns.wdp.brave.com`.

Enable the `BraveWebDiscoveryDisabled` policy. Start the browser with the same profile. Make some Google queries, visit some web pages, wait five minutes. Ensure a request was NOT sent to the hosts above. Ensure that the Web Discovery setting is not available in the settings UI.

Test again with the `BraveWebDiscoveryNative` feature enabled and a fresh profile.
