### PR TITLE
[iOS] Add browser menu quick action count customization

### DIFF
--- a/ios/brave-ios/Sources/BrowserMenu/BrowserMenuPreferences.swift
+++ b/ios/brave-ios/Sources/BrowserMenu/BrowserMenuPreferences.swift
@@ -16,5 +16,8 @@ extension Preferences {
 
     // maps `Action.Identifier.id` to the user defined rankings
     static let actionRanks: Option<[String: Double]> = .init(key: "menu.action-ranks", default: [:])
+
+    /// The number of quick actions that are displayed on the menu
+    static let numberOfQuickActions: Option<Int> = .init(key: "menu.quick-action-count", default: 4)
   }
 }

--- a/ios/brave-ios/Sources/BrowserMenu/BrowserMenuStrings.swift
+++ b/ios/brave-ios/Sources/BrowserMenu/BrowserMenuStrings.swift
@@ -65,6 +65,35 @@ extension Strings {
       value: "Show All…",
       comment: "A button title that when taps shows all actions that are hidden by default"
     )
+    public static let quickActionDividerTitle = NSLocalizedString(
+      "BrowserMenu.quickActionDividerTitle",
+      bundle: .module,
+      value: "Items on top will show on the main area",
+      comment:
+        "A row in the menu action customization list that divides which items are placed in a grid and which are placed in a list."
+    )
+    public static let resetToDefault = NSLocalizedString(
+      "BrowserMenu.resetToDefault",
+      bundle: .module,
+      value: "Reset to Default",
+      comment:
+        "A button title that when taps shows a confirmation dialog to reset the menu back to its default state"
+    )
+    public static let resetButtonTitle = NSLocalizedString(
+      "BrowserMenu.resetButtonTitle",
+      bundle: .module,
+      value: "Reset",
+      comment:
+        "A button title that when taps shows a confirmation dialog to reset the menu back to its default state"
+    )
+    public static let resetToDefaultDialogMessage = NSLocalizedString(
+      "BrowserMenu.resetToDefaultDialogMessage",
+      bundle: .module,
+      value:
+        "By resetting to default, you'll lose any customizations you've made in Brave. This action cannot be undone. Are you sure you want to proceed?",
+      comment:
+        "A message presented in a confirmation dialog explaining the destructive action of resetting the menu to its default state"
+    )
   }
 
   /// Action titles that are different when shown in the new menu design

--- a/ios/brave-ios/Sources/BrowserMenu/CustomizeMenuView.swift
+++ b/ios/brave-ios/Sources/BrowserMenu/CustomizeMenuView.swift
@@ -5,6 +5,7 @@
 
 import BraveUI
 import DesignSystem
+import Preferences
 import Strings
 import SwiftUI
 
@@ -13,34 +14,100 @@ struct CustomizeMenuView: View {
 
   @Environment(\.dismiss) private var dismiss
 
+  @ObservedObject private var numberOfQuickActions = Preferences.BrowserMenu.numberOfQuickActions
+  @State private var isResetDialogPresented = false
+
+  private enum VisibleRow: Identifiable {
+    case action(Action)
+    case quickActionCountDivider
+
+    var id: String {
+      switch self {
+      case .action(let action): return action.id.id
+      case .quickActionCountDivider: return "count-divider"
+      }
+    }
+  }
+
+  private var visibleRows: [VisibleRow] {
+    var rows = model.visibleActions.map(VisibleRow.action)
+    if rows.count > numberOfQuickActions.value {
+      rows.insert(.quickActionCountDivider, at: numberOfQuickActions.value)
+    } else {
+      rows.append(.quickActionCountDivider)
+    }
+    return rows
+  }
+
+  private func moveRow(from source: IndexSet, to destinationOffset: Int) {
+    // Let SwiftUI do the heavy lifting for actually reordering
+    var newVisibleRows = visibleRows
+    newVisibleRows.move(fromOffsets: source, toOffset: destinationOffset)
+
+    // Update the number of quick actions based on the new location of the divider
+    let previousNumberOfQuickActions = numberOfQuickActions.value
+    if let quickActionCountDividerIndex = newVisibleRows.firstIndex(where: { element in
+      if case .quickActionCountDivider = element {
+        return true
+      }
+      return false
+    }) {
+      numberOfQuickActions.value = quickActionCountDividerIndex
+      // Remove the divider from the data source so that we can calculate a destination index
+      // without it
+      newVisibleRows.remove(at: quickActionCountDividerIndex)
+    }
+
+    guard let sourceIndex = source.first,
+      // Adjust the source index if it was previously passed the divider
+      case let adjustedSourceIndex = sourceIndex > previousNumberOfQuickActions
+        ? sourceIndex - 1 : sourceIndex,
+      let action = model.visibleActions[safe: adjustedSourceIndex],
+      let destinationIndex = newVisibleRows.firstIndex(where: {
+        $0.id == action.id.id
+      }),
+      adjustedSourceIndex != destinationIndex
+    else { return }
+
+    model.reorderVisibleAction(action, to: destinationIndex)
+  }
+
   var body: some View {
     NavigationStack {
       List {
         Section {
-          ForEach(model.visibleActions) { action in
-            let id = action.id
-            HStack {
-              Button {
-                withAnimation {
-                  model.updateActionVisibility(action, visibility: .hidden)
+          ForEach(visibleRows) { visibleRow in
+            switch visibleRow {
+            case .action(let action):
+              let id = action.id
+              HStack {
+                Button {
+                  withAnimation {
+                    model.updateActionVisibility(action, visibility: .hidden)
+                  }
+                } label: {
+                  Image(systemName: "minus.circle.fill")
+                    .imageScale(.large)
                 }
-              } label: {
-                Image(systemName: "minus.circle.fill")
-                  .imageScale(.large)
+                .buttonStyle(.plain)
+                .foregroundStyle(.red)
+                Label {
+                  Text(id.defaultTitle)
+                } icon: {
+                  Image(braveSystemName: id.defaultImage)
+                    .foregroundStyle(Color(braveSystemName: .iconDefault))
+                }
               }
-              .buttonStyle(.plain)
-              .foregroundStyle(.red)
-              Label {
-                Text(id.defaultTitle)
-              } icon: {
-                Image(braveSystemName: id.defaultImage)
-                  .foregroundStyle(Color(braveSystemName: .iconDefault))
-              }
+              .id("Visible-\(id.id)")
+            case .quickActionCountDivider:
+              Text(Strings.BrowserMenu.quickActionDividerTitle)
+                .font(.caption)
+                .textCase(.uppercase)
+                .foregroundStyle(Color(braveSystemName: .textTertiary))
             }
-            .id("Visible-\(id.id)")
           }
           .onMove { source, destination in
-            model.moveVisibleActions(fromOffsets: source, toOffset: destination)
+            moveRow(from: source, to: destination)
           }
           .listRowBackground(Color(.secondaryBraveGroupedBackground))
         } header: {
@@ -73,6 +140,16 @@ struct CustomizeMenuView: View {
         } header: {
           Text(Strings.BrowserMenu.hiddenActionsTitle)
         }
+
+        Section {
+          Button(role: .destructive) {
+            isResetDialogPresented = true
+          } label: {
+            Text(Strings.BrowserMenu.resetToDefault)
+              .frame(maxWidth: .infinity)
+          }
+          .listRowBackground(Color(.secondaryBraveGroupedBackground))
+        }
       }
       .scrollContentBackground(.hidden)
       .background(Color(.braveGroupedBackground))
@@ -88,6 +165,22 @@ struct CustomizeMenuView: View {
       }
       .navigationBarTitleDisplayMode(.inline)
       .navigationTitle(Strings.BrowserMenu.customizeTitle)
+      .confirmationDialog(
+        Strings.BrowserMenu.resetToDefault,
+        isPresented: $isResetDialogPresented,
+        titleVisibility: .visible
+      ) {
+        Button(role: .destructive) {
+          withAnimation {
+            numberOfQuickActions.reset()
+            model.resetToDefault()
+          }
+        } label: {
+          Text(Strings.BrowserMenu.resetButtonTitle)
+        }
+      } message: {
+        Text(Strings.BrowserMenu.resetToDefaultDialogMessage)
+      }
     }
   }
 }


### PR DESCRIPTION
This change introduces the ability to customize how many items appear as quick actions (grid buttons) in the browser menu, with more than 4 creating multiple rows of grid items. It also introduces a new "Reset to Default" button at the bottom of the customize screen to allow users to reset back to the stock menu.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/47625

### Test Case

- Reorder matrix testing:
  - Reorder adjacent items 
  - Reorder items across the quick action divider
  - Reorder items to extremes (first/last spot destination)
  - Reorder the quick action divider itself
- Verify setting the quick action divider to the first spot shows no quick actions (only listed items)
- Verify setting the quick action divider to the last spot shows no listed items ("Show All…" will still add listed items)

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
