### PR TITLE
[Customize Chrome Panel] Migrate toolbar customization from settings page to Customize Chrome side panel

### DIFF
--- a/browser/resources/settings/brave_appearance_page/toolbar.html
+++ b/browser/resources/settings/brave_appearance_page/toolbar.html
@@ -58,13 +58,6 @@
     label="$i18n{appearanceSettingsShowBraveNewsButtonLabel}">
   </settings-toggle-button>
 </template>
-<template is="dom-if" if="[[showLeoAssistant_()]]">
-  <settings-toggle-button
-    class="cr-row"
-    pref="{{prefs.brave.ai_chat.show_toolbar_button}}"
-    label="$i18n{appearanceSettingsShowLeoButtonLabel}">
-  </settings-toggle-button>
-</template>
 <template is="dom-if" if="[[isBraveRewardsSupported_()]]">
   <settings-toggle-button
     class="cr-row"
@@ -72,28 +65,6 @@
     pref="{{prefs.brave.rewards.show_brave_rewards_button_in_location_bar}}">
   </settings-toggle-button>
 </template>
-<template is="dom-if" if="[[isNativeWalletEnabled_]]" restamp>
-  <settings-toggle-button id="showBraveWalletIconOnToolbar"
-    class="cr-row"
-    pref="{{prefs.brave.wallet.show_wallet_icon_on_toolbar}}"
-    label="$i18n{showBravewalletIconOnToolbar}">
-  </settings-toggle-button>
-</template>
-<settings-toggle-button
-  class="cr-row"
-  pref="{{prefs.brave.show_side_panel_button}}"
-  label="$i18n{appearanceSettingsShowSidebarButton}">
-</settings-toggle-button>
-<if expr="enable_brave_vpn_wireguard">
-  <template is="dom-if" if="[[showBraveVPNOption_()]]">
-    <settings-toggle-button
-      pref="{{prefs.brave.brave_vpn.show_button}}"
-      class="cr-row"
-      label="$i18n{showBraveVPNButton}"
-      sub-label="$i18n{showBraveVPNButtonSubLabel}">
-    </settings-toggle-button>
-  </template>
-</if>
 <settings-toggle-button
   id="autocomplete-suggestion-sources"
   class="cr-row"

--- a/browser/resources/settings/brave_overrides/appearance_page.ts
+++ b/browser/resources/settings/brave_overrides/appearance_page.ts
@@ -61,13 +61,6 @@ RegisterPolymerTemplateModifications({
       }
     }
 
-    const customizeToolbar = templateContent.getElementById('customizeToolbar')
-    if (!customizeToolbar) {
-        console.error(`[Settings] Couldn't find #customizeToolbar`)
-    } else {
-        customizeToolbar.setAttribute('hidden', 'true')
-    }
-
     // Super-referral
     // W/o super referral, we don't need to themes link option with themes sub
     // page.

--- a/chromium_src/chrome/browser/resources/side_panel/customize_chrome/customize_toolbar/toolbar.html.ts.lit_mangler.ts
+++ b/chromium_src/chrome/browser/resources/side_panel/customize_chrome/customize_toolbar/toolbar.html.ts.lit_mangler.ts
@@ -147,3 +147,16 @@ mangle(
   },
   (template) => template.text.includes('sp-heading'),
 )
+
+// Hide back button
+mangle(
+  (element: DocumentFragment) => {
+    const el = element.querySelector('sp-heading')
+    if (!el) {
+      throw new Error('[Customize Chrome > Toolbar] sp-heading is gone.')
+    }
+
+    el.setAttribute('hide-back-button', 'true')
+  },
+  (template) => template.text.includes('sp-heading'),
+)

--- a/tools/chromium_src/lit_mangler/__snapshots__/mangle.test.ts.snap
+++ b/tools/chromium_src/lit_mangler/__snapshots__/mangle.test.ts.snap
@@ -333,7 +333,7 @@ exports[`mangled files should have up to date snapshots ./chromium_src/chrome/br
 -      back-button-aria-label=\\"$i18n{backButton}\\"
 -      back-button-title=\\"$i18n{backButton}\\">
 -    <h2 slot=\\"heading\\">$i18n{toolbarHeader}</h2>
-+  <sp-heading id=\\"heading\\" @back-button-click=\\"\${this.onBackClick_}\\" back-button-aria-label=\\"$i18n{backButton}\\" back-button-title=\\"$i18n{backButton}\\">
++  <sp-heading id=\\"heading\\" @back-button-click=\\"\${this.onBackClick_}\\" back-button-aria-label=\\"$i18n{backButton}\\" back-button-title=\\"$i18n{backButton}\\" hide-back-button=\\"true\\">
 +        <close-panel-button id=\\"closeButton\\" iron-icon=\\"close\\" slot=\\"buttons\\"></close-panel-button>
 +    <h2 slot=\\"heading\\"><leo-icon name=\\"window-edit\\"></leo-icon>$i18n{toolbarHeader}</h2>
    </sp-heading>


### PR DESCRIPTION
In favor of 'Customize Chrome' side panel, we're moving toggle
items from the settings page to the side panel. This commit removes
the toolbar customization toggles from the settings page and
resurrect link button to open the side panel.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/47628

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
