### PR TITLE
Fixed unhandled chrome.send for getLeoIconVisibility. (uplift to 1.80.x)

### DIFF
--- a/browser/ui/webui/brave_settings_ui.cc
+++ b/browser/ui/webui/brave_settings_ui.cc
@@ -52,6 +52,7 @@
 #include "content/public/browser/web_ui_data_source.h"
 #include "content/public/common/content_features.h"
 #include "extensions/buildflags/buildflags.h"
+#include "mojo/public/cpp/bindings/self_owned_receiver.h"
 #include "net/base/features.h"
 
 #if BUILDFLAG(ENABLE_PIN_SHORTCUT)

--- a/browser/ui/webui/brave_settings_ui.cc
+++ b/browser/ui/webui/brave_settings_ui.cc
@@ -11,6 +11,7 @@
 
 #include "base/compiler_specific.h"
 #include "base/feature_list.h"
+#include "brave/browser/ai_chat/ai_chat_settings_helper.h"
 #include "brave/browser/brave_rewards/rewards_util.h"
 #include "brave/browser/brave_wallet/brave_wallet_context_utils.h"
 #include "brave/browser/ntp_background/view_counter_service_factory.h"
@@ -95,6 +96,9 @@ BraveSettingsUI::BraveSettingsUI(content::WebUI* web_ui) : SettingsUI(web_ui) {
   web_ui->AddMessageHandler(std::make_unique<BraveSyncHandler>());
   web_ui->AddMessageHandler(std::make_unique<BraveWalletHandler>());
   web_ui->AddMessageHandler(std::make_unique<BraveAdBlockHandler>());
+  web_ui->AddMessageHandler(
+      std::make_unique<settings::BraveLeoAssistantHandler>());
+
 #if BUILDFLAG(ENABLE_TOR)
   web_ui->AddMessageHandler(std::make_unique<BraveTorHandler>());
 #endif
@@ -212,11 +216,9 @@ void BraveSettingsUI::BindInterface(
 void BraveSettingsUI::BindInterface(
     mojo::PendingReceiver<ai_chat::mojom::AIChatSettingsHelper>
         pending_receiver) {
-  auto assistant_handler = std::make_unique<settings::BraveLeoAssistantHandler>(
-      std::make_unique<ai_chat::AIChatSettingsHelper>(
-          web_ui()->GetWebContents()->GetBrowserContext()));
-  assistant_handler->BindInterface(std::move(pending_receiver));
-  web_ui()->AddMessageHandler(std::move(assistant_handler));
+  auto helper = std::make_unique<ai_chat::AIChatSettingsHelper>(
+      web_ui()->GetWebContents()->GetBrowserContext());
+  mojo::MakeSelfOwnedReceiver(std::move(helper), std::move(pending_receiver));
 }
 
 void BraveSettingsUI::BindInterface(

--- a/browser/ui/webui/settings/brave_settings_leo_assistant_handler.cc
+++ b/browser/ui/webui/settings/brave_settings_leo_assistant_handler.cc
@@ -6,25 +6,18 @@
 #include "brave/browser/ui/webui/settings/brave_settings_leo_assistant_handler.h"
 
 #include <algorithm>
-#include <utility>
 #include <vector>
 
 #include "base/containers/contains.h"
 #include "brave/browser/ai_chat/ai_chat_service_factory.h"
-#include "brave/browser/brave_browser_process.h"
-#include "brave/browser/misc_metrics/process_misc_metrics.h"
 #include "brave/browser/ui/sidebar/sidebar_service_factory.h"
-#include "brave/components/ai_chat/core/browser/ai_chat_metrics.h"
 #include "brave/components/ai_chat/core/browser/ai_chat_service.h"
 #include "brave/components/ai_chat/core/browser/model_validator.h"
 #include "brave/components/ai_chat/core/browser/utils.h"
 #include "brave/components/ai_chat/core/common/features.h"
-#include "brave/components/ai_chat/core/common/pref_names.h"
 #include "brave/components/sidebar/browser/sidebar_item.h"
 #include "brave/components/sidebar/browser/sidebar_service.h"
-#include "chrome/browser/browser_process.h"
 #include "chrome/browser/profiles/profile.h"
-#include "components/prefs/pref_service.h"
 #include "content/public/browser/web_contents.h"
 
 namespace {
@@ -66,10 +59,7 @@ bool HideLeoAssistantIconIfNot(sidebar::SidebarService* sidebar_service) {
 
 namespace settings {
 
-BraveLeoAssistantHandler::BraveLeoAssistantHandler(
-    std::unique_ptr<ai_chat::AIChatSettingsHelper> settings_helper) {
-  settings_helper_ = std::move(settings_helper);
-}
+BraveLeoAssistantHandler::BraveLeoAssistantHandler() = default;
 
 BraveLeoAssistantHandler::~BraveLeoAssistantHandler() = default;
 
@@ -196,13 +186,6 @@ void BraveLeoAssistantHandler::HandleResetLeoData(
   }
 
   AllowJavascript();
-}
-
-void BraveLeoAssistantHandler::BindInterface(
-    mojo::PendingReceiver<ai_chat::mojom::AIChatSettingsHelper>
-        pending_receiver) {
-  DCHECK(settings_helper_);
-  settings_helper_->BindInterface(std::move(pending_receiver));
 }
 
 }  // namespace settings

--- a/browser/ui/webui/settings/brave_settings_leo_assistant_handler.h
+++ b/browser/ui/webui/settings/brave_settings_leo_assistant_handler.h
@@ -6,11 +6,8 @@
 #ifndef BRAVE_BROWSER_UI_WEBUI_SETTINGS_BRAVE_SETTINGS_LEO_ASSISTANT_HANDLER_H_
 #define BRAVE_BROWSER_UI_WEBUI_SETTINGS_BRAVE_SETTINGS_LEO_ASSISTANT_HANDLER_H_
 
-#include <memory>
-
 #include "base/memory/raw_ptr.h"
 #include "base/scoped_observation.h"
-#include "brave/browser/ai_chat/ai_chat_settings_helper.h"
 #include "brave/components/sidebar/browser/sidebar_service.h"
 #include "chrome/browser/ui/webui/settings/settings_page_ui_handler.h"
 
@@ -21,15 +18,11 @@ namespace settings {
 class BraveLeoAssistantHandler : public settings::SettingsPageUIHandler,
                                  public sidebar::SidebarService::Observer {
  public:
-  explicit BraveLeoAssistantHandler(
-      std::unique_ptr<ai_chat::AIChatSettingsHelper> settings_helper);
+  BraveLeoAssistantHandler();
   ~BraveLeoAssistantHandler() override;
 
   BraveLeoAssistantHandler(const BraveLeoAssistantHandler&) = delete;
   BraveLeoAssistantHandler& operator=(const BraveLeoAssistantHandler&) = delete;
-
-  void BindInterface(mojo::PendingReceiver<ai_chat::mojom::AIChatSettingsHelper>
-                         pending_receiver);
 
  private:
   // SettingsPageUIHandler overrides:
@@ -52,7 +45,6 @@ class BraveLeoAssistantHandler : public settings::SettingsPageUIHandler,
   base::ScopedObservation<sidebar::SidebarService,
                           sidebar::SidebarService::Observer>
       sidebar_service_observer_{this};
-  std::unique_ptr<ai_chat::AIChatSettingsHelper> settings_helper_;
 };
 
 }  // namespace settings


### PR DESCRIPTION
Uplift of #30006
Resolves https://github.com/brave/brave-browser/issues/47553

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.