### PR TITLE
[json64] Make `base_unittests` a default test suite

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -49,7 +49,10 @@ declare_args() {
 # buildable in all platforms in a single build run.
 group("all") {
   testonly = true
-  deps = [ "//brave" ]
+  deps = [
+    "//base:base_unittests",
+    "//brave",
+  ]
 
   if (!is_android && !is_ios) {
     deps += [

--- a/build/commands/lib/test.js
+++ b/build/commands/lib/test.js
@@ -24,6 +24,7 @@ const getTestBinary = (suite) => {
 
 const getChromiumUnitTestsSuites = () => {
   return [
+    'base_unittests',
     'components_unittests',
     'content_unittests',
     'net_unittests',

--- a/test/filters/base_unittests-windows.filter
+++ b/test/filters/base_unittests-windows.filter
@@ -1,0 +1,15 @@
+# Copyright (c) 2025 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+##
+## Upstream tests to disable
+##
+## When adding a new filter to this list, please include a short description of
+## why the filter is required and create an associated tracking issue.
+##
+
+# `PathService.Get` fails in CI with `DIR_ONE_DRIVE`, as the Windows install
+# flavour in our infra does not produce this path.
+-PathServiceTest.Get

--- a/test/filters/base_unittests.filter
+++ b/test/filters/base_unittests.filter
@@ -1,0 +1,15 @@
+# Copyright (c) 2025 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+##
+## Upstream tests to disable
+##
+## When adding a new filter to this list, please include a short description of
+## why the filter is required and create an associated tracking issue.
+##
+
+# rust logs severity has been tamed in brave, as crates were spamming CI with
+# logs.
+-RustLogIntegrationTest.CheckAllSeverity


### PR DESCRIPTION
This change adds `base_unittests` to the list of default suits to be
built and run with brave. This is being done so we have full test
coverage over the default code paths
`base::Value`/`JSONReader`/`JSONWriter`, as these classes are having
overrides added to them to support 64bit numbers, but we have to make
sure we are not breaking the default behaviour.

Resolves https://github.com/brave/brave-browser/issues/47643
