### PR TITLE
fix(iOS): Meld opt-in screen isn't shown when wallet is reset (uplift to 1.81.x)

### DIFF
--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/SettingsStore.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/SettingsStore.swift
@@ -169,6 +169,8 @@ public class SettingsStore: ObservableObject, WalletObserverStore {
     Preferences.Wallet.nonSelectedNetworksFilter.reset()
     // onboarding
     Preferences.Wallet.isOnboardingCompleted.reset()
+    // meld
+    Preferences.Wallet.meldAPIAgreementShownAndAgreed.reset()
 
     Task { @MainActor in
       await WalletUserAssetGroup.removeAllGroup()


### PR DESCRIPTION
Uplift of #30052
Resolves https://github.com/brave/brave-browser/issues/47633

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.