### PR TITLE
Revert "[bedrock] `PlaylistSidePanelCoordinator` as a browser window feature"

### DIFF
--- a/browser/playlist/test/playlist_browsertest.cc
+++ b/browser/playlist/test/playlist_browsertest.cc
@@ -98,7 +98,6 @@ class PlaylistBrowserTest : public PlatformBrowserTest {
 
   void ActivatePlaylistSidePanel() {
     auto* sidebar_controller = browser()->GetFeatures().sidebar_controller();
-    ASSERT_TRUE(sidebar_controller);
     sidebar_controller->ActivatePanelItem(
         sidebar::SidebarItem::BuiltInItemType::kPlaylist);
   }
@@ -108,12 +107,11 @@ class PlaylistBrowserTest : public PlatformBrowserTest {
 
     // Wrap routine with lambda as ASSERT_FOO has return type internally.
     ([&]() {
-      auto* coordinator =
-          browser()->GetFeatures().playlist_side_panel_coordinator();
+      auto* coordinator = PlaylistSidePanelCoordinator::FromBrowser(browser());
       ASSERT_TRUE(coordinator);
 
       auto* contents_wrapper = coordinator->contents_wrapper();
-      ASSERT_TRUE(contents_wrapper);
+      ASSERT_TRUE(coordinator);
 
       contents = contents_wrapper->web_contents();
       ASSERT_TRUE(contents);
@@ -183,8 +181,7 @@ IN_PROC_BROWSER_TEST_F(PlaylistBrowserTest, PanelToggleTestWhilePlaying) {
   ASSERT_TRUE(
       base::test::RunUntil([&]() { return panel_ui->IsSidePanelShowing(); }));
 
-  auto* coordinator =
-      browser()->GetFeatures().playlist_side_panel_coordinator();
+  auto* coordinator = PlaylistSidePanelCoordinator::FromBrowser(browser());
   ASSERT_TRUE(coordinator);
   coordinator->is_audible_for_testing_ = true;
 

--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -1330,6 +1330,8 @@ source_set("ui") {
       "views/side_panel/playlist/playlist_contents_wrapper.h",
       "views/side_panel/playlist/playlist_side_panel_coordinator.cc",
       "views/side_panel/playlist/playlist_side_panel_coordinator.h",
+      "views/side_panel/playlist/playlist_side_panel_web_view.cc",
+      "views/side_panel/playlist/playlist_side_panel_web_view.h",
       "webui/playlist_active_tab_tracker.cc",
       "webui/playlist_active_tab_tracker.h",
       "webui/playlist_ui.cc",

--- a/browser/ui/browser_window/browser_window_features.cc
+++ b/browser/ui/browser_window/browser_window_features.cc
@@ -14,11 +14,9 @@
 #include "brave/browser/ui/sidebar/sidebar_utils.h"
 #include "brave/browser/ui/tabs/features.h"
 #include "brave/browser/ui/tabs/split_view_browser_data.h"
-#include "brave/browser/ui/views/side_panel/playlist/playlist_side_panel_coordinator.h"
 #include "brave/components/brave_vpn/common/buildflags/buildflags.h"
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/browser_window/public/browser_window_interface.h"
-#include "chrome/browser/ui/views/frame/browser_view.h"
 
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
 #include "brave/browser/ui/brave_vpn/brave_vpn_controller.h"
@@ -70,21 +68,21 @@ void BrowserWindowFeatures::Init(BrowserWindowInterface* browser) {
 
 void BrowserWindowFeatures::InitPostBrowserViewConstruction(
     BrowserView* browser_view) {
-  if (sidebar::CanUseSidebar(browser_view->browser())) {
-    sidebar_controller_ = std::make_unique<sidebar::SidebarController>(
-        browser_view->browser(), browser_view->GetProfile());
-    playlist_side_panel_coordinator_ =
-        std::make_unique<PlaylistSidePanelCoordinator>(
-            browser_view->browser(), sidebar_controller_.get(),
-            browser_view->GetProfile());
-  }
+  BrowserWindowFeatures_ChromiumImpl::InitPostBrowserViewConstruction(
+      browser_view);
 
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
   brave_vpn_controller_ = std::make_unique<BraveVPNController>(browser_view);
 #endif
+}
 
-  BrowserWindowFeatures_ChromiumImpl::InitPostBrowserViewConstruction(
-      browser_view);
+void BrowserWindowFeatures::InitPostWindowConstruction(Browser* browser) {
+  BrowserWindowFeatures_ChromiumImpl::InitPostWindowConstruction(browser);
+
+  if (sidebar::CanUseSidebar(browser)) {
+    sidebar_controller_ = std::make_unique<sidebar::SidebarController>(
+        browser, browser->profile());
+  }
 }
 
 void BrowserWindowFeatures::TearDownPreBrowserViewDestruction() {
@@ -94,7 +92,5 @@ void BrowserWindowFeatures::TearDownPreBrowserViewDestruction() {
 #endif
   if (sidebar_controller_) {
     sidebar_controller_->TearDownPreBrowserWindowDestruction();
-
-    playlist_side_panel_coordinator_.reset();
   }
 }

--- a/browser/ui/browser_window/public/browser_window_features.h
+++ b/browser/ui/browser_window/public/browser_window_features.h
@@ -10,7 +10,6 @@
 
 class BraveVPNController;
 class SplitViewBrowserData;
-class PlaylistSidePanelCoordinator;
 
 namespace brave_rewards {
 class RewardsPanelCoordinator;
@@ -35,6 +34,7 @@ class BrowserWindowFeatures : public BrowserWindowFeatures_ChromiumImpl {
   // BrowserWindowFeatures_ChromiumImpl:
   void Init(BrowserWindowInterface* browser) override;
   void InitPostBrowserViewConstruction(BrowserView* browser_view) override;
+  void InitPostWindowConstruction(Browser* browser) override;
   void TearDownPreBrowserViewDestruction() override;
 
   sidebar::SidebarController* sidebar_controller() {
@@ -48,10 +48,6 @@ class BrowserWindowFeatures : public BrowserWindowFeatures_ChromiumImpl {
     return split_view_browser_data_.get();
   }
 
-  PlaylistSidePanelCoordinator* playlist_side_panel_coordinator() {
-    return playlist_side_panel_coordinator_.get();
-  }
-
  protected:
   BrowserWindowFeatures();
 
@@ -61,8 +57,6 @@ class BrowserWindowFeatures : public BrowserWindowFeatures_ChromiumImpl {
   std::unique_ptr<SplitViewBrowserData> split_view_browser_data_;
   std::unique_ptr<brave_rewards::RewardsPanelCoordinator>
       rewards_panel_coordinator_;
-  std::unique_ptr<PlaylistSidePanelCoordinator>
-      playlist_side_panel_coordinator_;
 };
 
 #endif  // BRAVE_BROWSER_UI_BROWSER_WINDOW_PUBLIC_BROWSER_WINDOW_FEATURES_H_

--- a/browser/ui/views/playlist/playlist_edit_bubble_view.cc
+++ b/browser/ui/views/playlist/playlist_edit_bubble_view.cc
@@ -23,7 +23,6 @@
 #include "brave/components/playlist/browser/playlist_tab_helper.h"
 #include "brave/components/vector_icons/vector_icons.h"
 #include "chrome/browser/ui/browser_finder.h"
-#include "chrome/browser/ui/browser_window/public/browser_window_features.h"
 #include "chrome/grit/generated_resources.h"
 #include "ui/base/l10n/l10n_util.h"
 #include "ui/base/metadata/metadata_impl_macros.h"
@@ -187,7 +186,7 @@ void PlaylistEditBubbleView::OpenInPlaylist() {
   const std::string& item_id = saved_items.front()->id;
 
   auto* side_panel_coordinator =
-      browser_->GetFeatures().playlist_side_panel_coordinator();
+      PlaylistSidePanelCoordinator::FromBrowser(browser_);
   CHECK(side_panel_coordinator);
   side_panel_coordinator->ActivatePanel();
 

--- a/browser/ui/views/side_panel/playlist/playlist_contents_wrapper.cc
+++ b/browser/ui/views/side_panel/playlist/playlist_contents_wrapper.cc
@@ -16,7 +16,6 @@
 #include "chrome/browser/ui/exclusive_access/fullscreen_within_tab_helper.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
 #include "chrome/browser/ui/views/side_panel/side_panel_ui.h"
-#include "chrome/browser/ui/views/side_panel/side_panel_web_ui_view.h"
 #include "third_party/blink/public/mojom/frame/fullscreen.mojom.h"
 #include "ui/views/widget/widget.h"
 
@@ -61,7 +60,9 @@ void PlaylistContentsWrapper::EnterFullscreenModeForTab(
   fullscreen_display_id_ = options.display_id;
   if (was_browser_fullscreen_) {
     // In case it was in fullscreen for browser, we should trigger layout here.
-    coordinator_->side_panel_web_view()->InvalidateLayout();
+    auto side_panel_web_view = coordinator_->side_panel_web_view();
+    DCHECK(side_panel_web_view);
+    side_panel_web_view->InvalidateLayout();
   } else {
     widget->SetFullscreen(true, fullscreen_display_id_);
   }
@@ -162,5 +163,7 @@ void PlaylistContentsWrapper::OnExitFullscreen() {
   fullscreen_observation_.Reset();
   fullscreen_display_id_ = display::kInvalidDisplayId;
 
-  coordinator_->side_panel_web_view()->InvalidateLayout();
+  auto side_panel_web_view = coordinator_->side_panel_web_view();
+  DCHECK(side_panel_web_view);
+  side_panel_web_view->InvalidateLayout();
 }

--- a/browser/ui/views/side_panel/playlist/playlist_side_panel_web_view.cc
+++ b/browser/ui/views/side_panel/playlist/playlist_side_panel_web_view.cc
@@ -1,0 +1,22 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/views/side_panel/playlist/playlist_side_panel_web_view.h"
+
+PlaylistSidePanelWebView::PlaylistSidePanelWebView(
+    Browser* browser,
+    SidePanelEntryScope& scope,
+    base::RepeatingClosure close_cb,
+    WebUIContentsWrapper* contents_wrapper)
+    : SidePanelWebUIView(scope,
+                         /* on_show_cb = */ base::RepeatingClosure(),
+                         close_cb,
+                         contents_wrapper) {}
+
+PlaylistSidePanelWebView::~PlaylistSidePanelWebView() = default;
+
+base::WeakPtr<PlaylistSidePanelWebView> PlaylistSidePanelWebView::GetWeakPtr() {
+  return weak_ptr_factory_.GetWeakPtr();
+}

--- a/browser/ui/views/side_panel/playlist/playlist_side_panel_web_view.h
+++ b/browser/ui/views/side_panel/playlist/playlist_side_panel_web_view.h
@@ -1,0 +1,33 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_VIEWS_SIDE_PANEL_PLAYLIST_PLAYLIST_SIDE_PANEL_WEB_VIEW_H_
+#define BRAVE_BROWSER_UI_VIEWS_SIDE_PANEL_PLAYLIST_PLAYLIST_SIDE_PANEL_WEB_VIEW_H_
+
+class Browser;
+class WebUIContentsWrapper;
+class SidePanelEntryScope;
+
+#include "base/functional/callback_forward.h"
+#include "brave/browser/ui/webui/playlist_ui.h"
+#include "chrome/browser/ui/views/side_panel/side_panel_web_ui_view.h"
+
+class PlaylistSidePanelWebView : public SidePanelWebUIView {
+ public:
+  PlaylistSidePanelWebView(Browser* browser,
+                           SidePanelEntryScope& scope,
+                           base::RepeatingClosure close_cb,
+                           WebUIContentsWrapper* contents_wrapper);
+  PlaylistSidePanelWebView(const PlaylistSidePanelWebView&) = delete;
+  PlaylistSidePanelWebView& operator=(const PlaylistSidePanelWebView&) = delete;
+  ~PlaylistSidePanelWebView() override;
+
+  base::WeakPtr<PlaylistSidePanelWebView> GetWeakPtr();
+
+ private:
+  base::WeakPtrFactory<PlaylistSidePanelWebView> weak_ptr_factory_{this};
+};
+
+#endif  // BRAVE_BROWSER_UI_VIEWS_SIDE_PANEL_PLAYLIST_PLAYLIST_SIDE_PANEL_WEB_VIEW_H_

--- a/browser/ui/views/sidebar/sidebar_container_view.cc
+++ b/browser/ui/views/sidebar/sidebar_container_view.cc
@@ -202,9 +202,8 @@ bool SidebarContainerView::IsFullscreenForCurrentEntry() const {
 
   // TODO(sko) Do we have a more general way to get WebContents of the active
   // entry?
-  auto* web_view = browser_->GetFeatures()
-                       .playlist_side_panel_coordinator()
-                       ->side_panel_web_view();
+  auto web_view = PlaylistSidePanelCoordinator::FromBrowser(browser_)
+                      ->side_panel_web_view();
   if (!web_view) {
     return false;
   }

--- a/chromium_src/chrome/browser/ui/views/side_panel/side_panel_util.cc
+++ b/chromium_src/chrome/browser/ui/views/side_panel/side_panel_util.cc
@@ -17,9 +17,7 @@ void SidePanelUtil::PopulateGlobalEntries(Browser* browser,
   PopulateGlobalEntries_ChromiumImpl(browser, global_registry);
 
   if (base::FeatureList::IsEnabled(playlist::features::kPlaylist)) {
-    auto* playlist_coordinator =
-        browser->GetFeatures().playlist_side_panel_coordinator();
-    CHECK(playlist_coordinator);
-    playlist_coordinator->CreateAndRegisterEntry(global_registry);
+    PlaylistSidePanelCoordinator::GetOrCreateForBrowser(browser)
+        ->CreateAndRegisterEntry(global_registry);
   }
 }


### PR DESCRIPTION
Reverts brave/brave-core#30031

Crash happened when pwa launched.

See https://bravesoftware.slack.com/archives/C7VLGSR55/p1752619959658379 