### PR TITLE
fix(wallet): Change the logic to detect if asset for purchase using meld integration is available

### DIFF
--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
@@ -126,16 +126,18 @@ struct AssetDetailView: View {
   @ViewBuilder private func coinMarketInfoView(_ coinMarket: BraveWallet.CoinMarket) -> some View {
     VStack(spacing: 16) {
       HStack(alignment: .top, spacing: 40) {
-        if assetDetailStore.isBuySupported {
+        if assetDetailStore.meldCryptoCurrency != nil {
           PortfolioHeaderButton(style: .buy) {
-            let destination = WalletActionDestination(
-              kind: .buy,
-              initialToken: assetDetailStore.assetDetailToken
-            )
-            if assetDetailStore.allAccountsForToken.isEmpty {
-              onAccountCreationNeeded(destination)
-            } else {
-              walletActionDestination = destination
+            Task { @MainActor in
+              let destination = WalletActionDestination(
+                kind: .buy,
+                initialToken: assetDetailStore.assetDetailToken
+              )
+              if await assetDetailStore.accountCreationNeededForBuy() {
+                onAccountCreationNeeded(destination)
+              } else {
+                walletActionDestination = destination
+              }
             }
           }
         }
@@ -233,16 +235,18 @@ struct AssetDetailView: View {
 
   @ViewBuilder var actionButtonsContainer: some View {
     HStack(alignment: .top, spacing: 40) {
-      if assetDetailStore.isBuySupported {
+      if assetDetailStore.meldCryptoCurrency != nil {
         PortfolioHeaderButton(style: .buy) {
-          let destination = WalletActionDestination(
-            kind: .buy,
-            initialToken: assetDetailStore.assetDetailToken
-          )
-          if assetDetailStore.allAccountsForToken.isEmpty {
-            onAccountCreationNeeded(destination)
-          } else {
-            walletActionDestination = destination
+          Task { @MainActor in
+            let destination = WalletActionDestination(
+              kind: .buy,
+              initialToken: assetDetailStore.assetDetailToken
+            )
+            if await assetDetailStore.accountCreationNeededForBuy() {
+              onAccountCreationNeeded(destination)
+            } else {
+              walletActionDestination = destination
+            }
           }
         }
       }

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
@@ -126,7 +126,7 @@ struct AssetDetailView: View {
   @ViewBuilder private func coinMarketInfoView(_ coinMarket: BraveWallet.CoinMarket) -> some View {
     VStack(spacing: 16) {
       HStack(alignment: .top, spacing: 40) {
-        if assetDetailStore.meldCryptoCurrency != nil {
+        if assetDetailStore.isBuySupported {
           PortfolioHeaderButton(style: .buy) {
             Task { @MainActor in
               let destination = WalletActionDestination(
@@ -235,7 +235,7 @@ struct AssetDetailView: View {
 
   @ViewBuilder var actionButtonsContainer: some View {
     HStack(alignment: .top, spacing: 40) {
-      if assetDetailStore.meldCryptoCurrency != nil {
+      if assetDetailStore.isBuySupported {
         PortfolioHeaderButton(style: .buy) {
           Task { @MainActor in
             let destination = WalletActionDestination(

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/AssetDetailStore.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/AssetDetailStore.swift
@@ -73,6 +73,10 @@ class AssetDetailStore: ObservableObject, WalletObserverStore {
       .reduce(0, +)
   }
 
+  var isBuySupported: Bool {
+    meldCryptoCurrency != nil
+  }
+
   private let assetRatioService: BraveWalletAssetRatioService
   private let keyringService: BraveWalletKeyringService
   private let walletService: BraveWalletBraveWalletService
@@ -585,8 +589,7 @@ class AssetDetailStore: ObservableObject, WalletObserverStore {
     guard let meldCryptoCurrency else {
       return false
     }
-    let allAccounts = await keyringService.allAccounts().accounts
-    return !allAccounts.contains { $0.coin == meldCryptoCurrency.coin }
+    return await !keyringService.isAccountAvailable(for: meldCryptoCurrency.coin)
   }
 
   /// Should be called after dismissing create account. Returns true if an account was created

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/AssetDetailStore.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/AssetDetailStore.swift
@@ -50,7 +50,6 @@ class AssetDetailStore: ObservableObject, WalletObserverStore {
   @Published private(set) var isLoadingAccountBalances: Bool = false
   @Published private(set) var nonZeroBalanceAccounts: [AccountAssetViewModel] = []
   @Published private(set) var transactionSections: [TransactionSection] = []
-  @Published private(set) var isBuySupported: Bool = false
   @Published private(set) var isSendSupported: Bool = false
   @Published private(set) var isSwapSupported: Bool = false
   @Published private(set) var currencyCode: String = CurrencyCode.usd.code {
@@ -63,6 +62,8 @@ class AssetDetailStore: ObservableObject, WalletObserverStore {
     }
   }
   @Published private(set) var network: BraveWallet.NetworkInfo?
+  /// For buy option
+  @Published private(set) var meldCryptoCurrency: BraveWallet.MeldCryptoCurrency?
 
   let currencyFormatter: NumberFormatter = .usdCurrencyFormatter
 
@@ -118,6 +119,8 @@ class AssetDetailStore: ObservableObject, WalletObserverStore {
   }
 
   // All account info that has the same coin type as this asset's
+  // This should only be used for asset from token registry
+  // Token from market does not guarantee the correct coin type.
   var allAccountsForToken: [BraveWallet.AccountInfo] = []
   private var depositableTokens: [BraveWallet.BlockchainToken] = []
 
@@ -213,7 +216,9 @@ class AssetDetailStore: ObservableObject, WalletObserverStore {
           allNetworks.first(where: { $0.coin == token.coin && $0.chainId == token.chainId })
           ?? selectedNetwork
         self.network = network
-        self.isBuySupported = await self.isBuyButtonSupported(in: network, for: token)
+        let (matchedCryptoCurrency, _) =
+          await meldIntegrationService.convertToMeldCryptoCurrency(for: assetDetailToken)
+        self.meldCryptoCurrency = matchedCryptoCurrency
         self.isSendSupported = true
         self.isSwapSupported = await swapService.isSwapSupported(chainId: token.chainId)
 
@@ -346,7 +351,9 @@ class AssetDetailStore: ObservableObject, WalletObserverStore {
           .flatMap(\.tokens)
         self.depositableTokens = allUserTokens + allBlockchainTokens
 
-        self.isBuySupported = await isBuyButtonSupported(in: nil, for: assetDetailToken)
+        let (matchedCryptoCurrency, _) =
+          await meldIntegrationService.convertToMeldCryptoCurrency(for: assetDetailToken)
+        self.meldCryptoCurrency = matchedCryptoCurrency
 
         // fetch accounts if this coinMarket is depositable
         if let depositableToken = convertCoinMarketToDepositableToken(symbol: coinMarket.symbol) {
@@ -368,41 +375,6 @@ class AssetDetailStore: ObservableObject, WalletObserverStore {
         self.transactionSections = []
       }
     }
-  }
-
-  @MainActor private func isBuyButtonSupported(
-    in network: BraveWallet.NetworkInfo?,
-    for token: BraveWallet.BlockchainToken
-  ) async -> Bool {
-    if let network,
-      network.isNativeAsset(token)
-    {
-      return true
-    }
-    let (allMeldSupportedTokens, _) = await meldIntegrationService.cryptoCurrencies(
-      filter: .init(
-        countries: nil,
-        fiatCurrencies: nil,
-        cryptoCurrencies: nil,
-        cryptoChains: network?.chainId,
-        serviceProviders: nil,
-        paymentMethodTypes: nil,
-        statuses: nil
-      )
-    )
-    guard let allMeldSupportedTokens else {
-      return false
-    }
-    return allMeldSupportedTokens.contains(where: {
-      if let contractAddress = $0.contractAddress,
-        let chainId = $0.chainId
-      {
-        return contractAddress.caseInsensitiveCompare(token.contractAddress) == .orderedSame
-          && chainId.caseInsensitiveCompare(token.chainId) == .orderedSame
-      } else {
-        return $0.displaySymbol.caseInsensitiveCompare(token.symbol) == .orderedSame
-      }
-    })
   }
 
   func convertCoinMarketToDepositableToken(symbol: String) -> BraveWallet.BlockchainToken? {
@@ -607,6 +579,14 @@ class AssetDetailStore: ObservableObject, WalletObserverStore {
   func closeTransactionDetailsStore() {
     self.transactionDetailsStore?.tearDown()
     self.transactionDetailsStore = nil
+  }
+
+  @MainActor func accountCreationNeededForBuy() async -> Bool {
+    guard let meldCryptoCurrency else {
+      return false
+    }
+    let allAccounts = await keyringService.allAccounts().accounts
+    return !allAccounts.contains { $0.coin == meldCryptoCurrency.coin }
   }
 
   /// Should be called after dismissing create account. Returns true if an account was created

--- a/ios/brave-ios/Sources/BraveWallet/Extensions/MeldIntegrationServiceExtensions.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Extensions/MeldIntegrationServiceExtensions.swift
@@ -1,0 +1,63 @@
+// Copyright 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import BraveCore
+
+extension BraveWalletMeldIntegrationService {
+  /// - Parameters:
+  ///     - token: A `BraveWallet.BlockchainToken` from token registry that we want to convert from
+  ///
+  /// - Returns: A  tuple of `BraveWallet.MeldCryptoCurrency` and a list of BraveWallet.MeldCryptoCurrency.
+  /// The first value of the tuple would be the meld supported crypto currency if we found one, otherwise it would be nil.
+  /// The second value of the tuple would be all meld supported crypto currencies with a default filter and the given
+  /// network info if it fetches without an error, otherwise it would be nil
+  func convertToMeldCryptoCurrency(
+    for token: BraveWallet.BlockchainToken
+  ) async -> (BraveWallet.MeldCryptoCurrency?, [BraveWallet.MeldCryptoCurrency]?) {
+    let (allMeldSupportedTokens, _) = await cryptoCurrencies(
+      filter: .init(
+        countries: nil,
+        fiatCurrencies: nil,
+        cryptoCurrencies: nil,
+        cryptoChains: WalletConstants.supportedChainsForMeld.joined(separator: ","),
+        serviceProviders: nil,
+        paymentMethodTypes: nil,
+        statuses: nil
+      )
+    )
+    guard let allMeldSupportedTokens else {
+      return (nil, nil)
+    }
+
+    if token.contractAddress.isEmpty,
+      let foundNativeToken = allMeldSupportedTokens.first(where: {
+        if let cryptoChainId = $0.chainId {
+          return cryptoChainId.caseInsensitiveCompare(token.chainId) == .orderedSame
+            && $0.displaySymbol.caseInsensitiveCompare(token.symbol) == .orderedSame
+        }
+        return false
+      })
+    {
+      return (foundNativeToken, allMeldSupportedTokens)
+    } else if let foundTokenByContractAddress = allMeldSupportedTokens.first(where: {
+      if let cryptoContractAddress = $0.contractAddress,
+        let cryptoChainId = $0.chainId
+      {
+        return cryptoContractAddress.caseInsensitiveCompare(
+          token.contractAddress
+        ) == .orderedSame
+          && cryptoChainId.caseInsensitiveCompare(token.chainId) == .orderedSame
+      }
+      return false
+    }) {
+      return (foundTokenByContractAddress, allMeldSupportedTokens)
+    } else if let foundTokenBySymbol = allMeldSupportedTokens.first(where: {
+      $0.displaySymbol.caseInsensitiveCompare(token.symbol) == .orderedSame
+    }) {
+      return (foundTokenBySymbol, allMeldSupportedTokens)
+    }
+    return (nil, allMeldSupportedTokens)
+  }
+}

--- a/ios/brave-ios/Tests/BraveWalletTests/AssetDetailStoreTests.swift
+++ b/ios/brave-ios/Tests/BraveWalletTests/AssetDetailStoreTests.swift
@@ -262,6 +262,7 @@ class AssetDetailStoreTests: XCTestCase {
 
     store.update()
     wait(for: [assetDetailException], timeout: 1)
+    XCTAssertTrue(store.isBuySupported)
   }
 
   func testUpdateWithBlockchainTokenBitcoin() {
@@ -474,6 +475,7 @@ class AssetDetailStoreTests: XCTestCase {
 
     store.update()
     wait(for: [assetDetailException], timeout: 1)
+    XCTAssertFalse(store.isBuySupported)
   }
 
   func testUpdateWithCoinMarket() {
@@ -659,6 +661,7 @@ class AssetDetailStoreTests: XCTestCase {
 
     store.update()
     wait(for: [assetDetailBitcoinException], timeout: 1)
+    XCTAssertFalse(store.isBuySupported)
     cancellables.removeAll()
 
     // setup store
@@ -778,5 +781,6 @@ class AssetDetailStoreTests: XCTestCase {
 
     store.update()
     wait(for: [assetDetailNonBitcoinException], timeout: 1)
+    XCTAssertTrue(store.isBuySupported)
   }
 }

--- a/ios/brave-ios/Tests/BraveWalletTests/AssetDetailStoreTests.swift
+++ b/ios/brave-ios/Tests/BraveWalletTests/AssetDetailStoreTests.swift
@@ -149,11 +149,11 @@ class AssetDetailStoreTests: XCTestCase {
         XCTAssertEqual(network, .mockMainnet)
       }
       .store(in: &cancellables)
-    store.$isBuySupported
+    store.$meldCryptoCurrency
       .dropFirst()
       .sink {
         defer { assetDetailException.fulfill() }
-        XCTAssertTrue($0)
+        XCTAssertNotNil($0)
       }
       .store(in: &cancellables)
     store.$isSendSupported
@@ -378,11 +378,11 @@ class AssetDetailStoreTests: XCTestCase {
         XCTAssertEqual(network, .mockBitcoinMainnet)
       }
       .store(in: &cancellables)
-    store.$isBuySupported
+    store.$meldCryptoCurrency
       .dropFirst()
       .sink {
         defer { assetDetailException.fulfill() }
-        XCTAssertTrue($0)
+        XCTAssertNil($0)
       }
       .store(in: &cancellables)
     store.$isSendSupported
@@ -567,11 +567,11 @@ class AssetDetailStoreTests: XCTestCase {
 
     let assetDetailBitcoinException = expectation(description: "update-coinMarket-bitcoin")
     assetDetailBitcoinException.expectedFulfillmentCount = 10
-    store.$isBuySupported
+    store.$meldCryptoCurrency
       .dropFirst()
       .sink {
         defer { assetDetailBitcoinException.fulfill() }
-        XCTAssertFalse($0)
+        XCTAssertNil($0)
       }
       .store(in: &cancellables)
     store.$isSendSupported
@@ -680,11 +680,11 @@ class AssetDetailStoreTests: XCTestCase {
     )
     let assetDetailNonBitcoinException = expectation(description: "update-coinMarket-non-bitcoin")
     assetDetailNonBitcoinException.expectedFulfillmentCount = 10
-    store.$isBuySupported
+    store.$meldCryptoCurrency
       .dropFirst()
       .sink {
         defer { assetDetailNonBitcoinException.fulfill() }
-        XCTAssertTrue($0)
+        XCTAssertNotNil($0)
       }
       .store(in: &cancellables)
     store.$isSendSupported


### PR DESCRIPTION
1. first check if it's native asset further comparing chain id and symbol
2. then fall back to comparing contract address and chain id
3. last fall back to comparing symbol this logic is aligned with desktop.

Also fix unnecessary account creation prompt by tapping buy button in asset detail screen.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/47635

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

## Test Plan
1. open wallet and go to portfolio
2. pick any asset in portfolio and go to it's details screen 
3. tap buy button if it's available 
5. observe buy screen will show up with no error pops up
6. go to market tab 
7. repeat step 2 to step 4
8. stay in market tab
9. tap Litecoin to go to details screen
10. tap buy button 
11. observe buy screen will show up with no account creation pops up
