### PR TITLE
[json64] Fix broken header guard

### DIFF
--- a/chromium_src/check_chromium_src_config.json5
+++ b/chromium_src/check_chromium_src_config.json5
@@ -43,6 +43,7 @@
         "components/variations/service/field_trial_unittest.cc",
         "net/base/brave_proxy_string_util_unittest.cc",
         "net/cookies/brave_canonical_cookie_unittest.cc",
+        "third_party/rust/serde_json_lenient/v0_2/wrapper/large_integers.rs",
         "v8/include/DO NOT PUT FILES HERE",
         "ui/views/controls/button/md_text_button_constants_unittest.cc"
     ],

--- a/chromium_src/third_party/rust/serde_json_lenient/v0_2/wrapper/functions.h
+++ b/chromium_src/third_party/rust/serde_json_lenient/v0_2/wrapper/functions.h
@@ -3,8 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-#ifndef BRAVE_CHROMIUM_SRC_THIRD_PARTY_RUST_SERDE_JSON_LENIENT_V0_2_WRAPPER_SERDE_JSON_LENIENT_H_
-#define BRAVE_CHROMIUM_SRC_THIRD_PARTY_RUST_SERDE_JSON_LENIENT_V0_2_WRAPPER_SERDE_JSON_LENIENT_H_
+#ifndef BRAVE_CHROMIUM_SRC_THIRD_PARTY_RUST_SERDE_JSON_LENIENT_V0_2_WRAPPER_FUNCTIONS_H_
+#define BRAVE_CHROMIUM_SRC_THIRD_PARTY_RUST_SERDE_JSON_LENIENT_V0_2_WRAPPER_FUNCTIONS_H_
 
 #include <stdint.h>
 
@@ -34,4 +34,4 @@ void dict_set_i64(Dict& ctx, rust::Str key, int64_t val);
 void dict_set_u64(Dict& ctx, rust::Str key, uint64_t val);
 }  // namespace serde_json_lenient
 
-#endif  // BRAVE_CHROMIUM_SRC_THIRD_PARTY_RUST_SERDE_JSON_LENIENT_V0_2_WRAPPER_SERDE_JSON_LENIENT_H_
+#endif  // BRAVE_CHROMIUM_SRC_THIRD_PARTY_RUST_SERDE_JSON_LENIENT_V0_2_WRAPPER_FUNCTIONS_H_


### PR DESCRIPTION
This header guard started failing recently. Maybe something changed
since M139, but it is not very clear what happened. This change corrects
the presubmit warning with the expected value.

This should have been caught by the presubmit, but for some reason no warning was emitted. A fix for the presubmit has been submitted separately. For details see:
https://github.com/brave/brave-core/pull/30105
