### PR TITLE
[ubsan] Fix uninitialised read by `FullScreenshotter`

### DIFF
--- a/components/ai_chat/content/browser/full_screenshotter.cc
+++ b/components/ai_chat/content/browser/full_screenshotter.cc
@@ -68,6 +68,7 @@ void FullScreenshotter::CaptureScreenshots(
   capture_params.web_contents = web_contents;
   capture_params.persistence =
       paint_preview::RecordingPersistence::kMemoryBuffer;
+  capture_params.capture_links = false;
   CapturePaintPreview(
       capture_params,
       base::BindOnce(&FullScreenshotter::OnScreenshotCaptured,


### PR DESCRIPTION
In `FullScreenshotter::CaptureScreenshots` an instance of
`CaptureParams` is created and passed into `CapturePaintPreview`.
Unfortunately, `CaptureParams::capture_links` is uninitialised, which
leads to an uninitialised read of this field inside `CaptureParams`.

This PR fixes this Undefined Behaviour case, by initialising the field
to a default.

Resolves https://github.com/brave/brave-browser/issues/47737
