### PR TITLE
Fixed asan failure during the SplitView dtor

### DIFF
--- a/browser/ui/brave_browser_command_controller.cc
+++ b/browser/ui/brave_browser_command_controller.cc
@@ -470,9 +470,10 @@ void BraveBrowserCommandController::UpdateCommandsForPin() {
 }
 
 void BraveBrowserCommandController::UpdateCommandForSplitView() {
-  if (!split_view_browser_data_observation_.IsObserving()) {
-    split_view_browser_data_observation_.Observe(
-        browser_->GetFeatures().split_view_browser_data());
+  if (auto* data = browser_->GetFeatures().split_view_browser_data()) {
+    if (!split_view_browser_data_observation_.IsObserving()) {
+      split_view_browser_data_observation_.Observe(data);
+    }
   }
 
   UpdateCommandEnabled(IDC_NEW_SPLIT_VIEW, brave::CanOpenNewSplitViewForTab(

--- a/browser/ui/browser_window/browser_window_features.cc
+++ b/browser/ui/browser_window/browser_window_features.cc
@@ -86,6 +86,12 @@ void BrowserWindowFeatures::InitPostWindowConstruction(Browser* browser) {
 }
 
 void BrowserWindowFeatures::TearDownPreBrowserWindowDestruction() {
+  // SplitView depends on some browser window features(ex, fullscreen
+  // controller) that destroyed via
+  // BrowserWindowFeatures_ChromiumImpl::TearDownPreBrowserWindowDestruction().
+  // So we need to reset it before they're gone.
+  split_view_browser_data_.reset();
+
   BrowserWindowFeatures_ChromiumImpl::TearDownPreBrowserWindowDestruction();
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
   brave_vpn_controller_.reset();

--- a/browser/ui/browser_window/public/browser_window_features.h
+++ b/browser/ui/browser_window/public/browser_window_features.h
@@ -44,6 +44,10 @@ class BrowserWindowFeatures : public BrowserWindowFeatures_ChromiumImpl {
     return rewards_panel_coordinator_.get();
   }
   BraveVPNController* brave_vpn_controller();
+
+  // Checks this is not null before using it always because this is reset
+  // at the very early stage of browser window destruction. That means this
+  // could be null when most of UI is live.
   SplitViewBrowserData* split_view_browser_data() {
     return split_view_browser_data_.get();
   }

--- a/browser/ui/views/brave_javascript_tab_modal_dialog_view_views.cc
+++ b/browser/ui/views/brave_javascript_tab_modal_dialog_view_views.cc
@@ -149,7 +149,9 @@ gfx::Point BraveJavaScriptTabModalDialogViewViews::
   if (tabs::features::IsBraveSplitViewEnabled()) {
     auto* split_view_browser_data =
         browser->GetFeatures().split_view_browser_data();
-    CHECK(split_view_browser_data);
+    if (!split_view_browser_data) {
+      return bounds.origin();
+    }
 
     auto tile = split_view_browser_data->GetTile(tab_handle);
     if (!tile) {

--- a/browser/ui/views/split_view/split_view.h
+++ b/browser/ui/views/split_view/split_view.h
@@ -123,6 +123,7 @@ class SplitView : public views::View,
   void OnTileTabs(const TabTile& tile) override;
   void OnDidBreakTile(const TabTile& tile) override;
   void OnSwapTabsInTile(const TabTile& tile) override;
+  void OnWillDeleteBrowserData() override;
 
   // views::WidgetObserver:
   void OnWidgetDestroying(views::Widget* widget) override;


### PR DESCRIPTION
fix https://github.com/brave/internal/issues/1337

SplitView observes FullscreenController but it's destroyed before than SplitView destruction.
It's lifecycle is changed in upstream(cr139). BrowserWindowFeatures tears down exclusive acceess manager that owns fullscreen controller at the start of BrowserView dtor.
As SplitView is FullscreenControllerObser, it should be cleaned up before fullscreen controller is gone.

As this PR destroys SplitViewBrowserData at the start of BrowserView dtor, added its null check at all places.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
