### PR TITLE
[ubsan] Fix UaF on `BraveTabContainer`'s observer

### DIFF
--- a/browser/ui/views/tabs/brave_tab_container.cc
+++ b/browser/ui/views/tabs/brave_tab_container.cc
@@ -704,6 +704,10 @@ void BraveTabContainer::OnSwapTabsInTile(const TabTile& tile) {
   UpdateTabsBorderInTile(tile);
 }
 
+void BraveTabContainer::OnWillDeleteBrowserData() {
+  split_view_data_observation_.Reset();
+}
+
 gfx::Rect BraveTabContainer::GetDropBounds(int drop_index,
                                            bool drop_before,
                                            bool drop_in_group,

--- a/browser/ui/views/tabs/brave_tab_container.h
+++ b/browser/ui/views/tabs/brave_tab_container.h
@@ -68,6 +68,7 @@ class BraveTabContainer : public TabContainerImpl,
   void OnTileTabs(const TabTile& tile) override;
   void OnDidBreakTile(const TabTile& tile) override;
   void OnSwapTabsInTile(const TabTile& tile) override;
+  void OnWillDeleteBrowserData() override;
 
  private:
   class DropArrow {


### PR DESCRIPTION
The observer is for `SplitViewBrowserData`, which is a browser window
feature and goes out of scope when the browser windows is being torn
down.

This change unregisters the scoped observation as the object is being
disposed of.

Resolves https://github.com/brave/brave-browser/issues/47750
