### PR TITLE
[iOS] Add private tabs settings access inside of the new tab tray UI

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Tabs/TabGrid/TabGridPrivateTabsSettingsView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Tabs/TabGrid/TabGridPrivateTabsSettingsView.swift
@@ -1,0 +1,125 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import BraveStrings
+import LocalAuthentication
+import Preferences
+import Strings
+import SwiftUI
+
+struct TabGridPrivateTabsSettings: View {
+  var viewModel: TabGridViewModel
+
+  @State private var context: LAContext = .init()
+  @Environment(\.dismiss) private var dismiss
+  @ObservedObject private var persistentPrivateBrowsing = Preferences.Privacy
+    .persistentPrivateBrowsing
+  @ObservedObject private var privateBrowsingLock = Preferences.Privacy.privateBrowsingLock
+
+  private var authenticationKind: LABiometryType? {
+    if context.canEvaluatePolicy(.deviceOwnerAuthentication, error: nil) {
+      return context.biometryType
+    }
+    return nil
+  }
+
+  private var privateBrowsingLockBinding: Binding<Bool> {
+    .init {
+      privateBrowsingLock.value
+    } set: { newValue in
+      // Avoiding the use of WindowProtection on purpose in this contxt because its being used
+      // to control private mode in general inside of the tab tray and we really only need to it
+      // flip a pref here, not control the visibility of the window.
+      if !newValue, context.canEvaluatePolicy(.deviceOwnerAuthentication, error: nil) {
+        context.evaluatePolicy(
+          .deviceOwnerAuthentication,
+          localizedReason: Strings.authenticationLoginsTouchReason
+        ) { success, _ in
+          DispatchQueue.main.async { [self] in
+            privateBrowsingLock.value = !success
+          }
+        }
+      } else {
+        privateBrowsingLock.value = newValue
+      }
+    }
+  }
+
+  var body: some View {
+    NavigationStack {
+      Form {
+        Toggle(isOn: $persistentPrivateBrowsing.value) {
+          Label {
+            Text(Strings.TabsSettings.persistentPrivateBrowsingTitle)
+              .foregroundStyle(Color(braveSystemName: .textPrimary))
+            Text(Strings.TabsSettings.persistentPrivateBrowsingDescription)
+              .foregroundStyle(Color(braveSystemName: .textTertiary))
+              .font(.footnote)
+          } icon: {
+            Image(braveSystemName: "leo.browser.mobile-tabs")
+              .foregroundStyle(Color(braveSystemName: .iconDefault))
+          }
+        }
+        .tint(Color.accentColor)
+        .listRowBackground(Color(uiColor: .secondaryBraveGroupedBackground))
+        if let authenticationKind {
+          Toggle(isOn: privateBrowsingLockBinding) {
+            Label {
+              let (title, body) =
+                switch authenticationKind {
+                case .faceID:
+                  (
+                    Strings.TabsSettings.privateBrowsingLockTitleFaceID,
+                    Strings.TabsSettings.privateBrowsingLockDescriptionFaceID
+                  )
+                case .touchID:
+                  (
+                    Strings.TabsSettings.privateBrowsingLockTitleTouchID,
+                    Strings.TabsSettings.privateBrowsingLockDescriptionTouchID
+                  )
+                default:
+                  (
+                    Strings.TabsSettings.privateBrowsingLockTitlePinCode,
+                    Strings.TabsSettings.privateBrowsingLockDescriptionPinCode
+                  )
+                }
+              Text(title)
+                .foregroundStyle(Color(braveSystemName: .textPrimary))
+              Text(body)
+                .foregroundStyle(Color(braveSystemName: .textTertiary))
+                .font(.footnote)
+            } icon: {
+              Group {
+                switch authenticationKind {
+                case .faceID:
+                  Image(braveSystemName: "leo.face.id")
+                case .touchID:
+                  Image(braveSystemName: "leo.biometric.login")
+                default:
+                  Image(braveSystemName: "leo.lock")
+                }
+              }
+              .foregroundStyle(Color(braveSystemName: .iconDefault))
+            }
+          }
+          .tint(Color.accentColor)
+          .listRowBackground(Color(uiColor: .secondaryBraveGroupedBackground))
+        }
+      }
+      .scrollContentBackground(.hidden)
+      .background(Color(uiColor: .braveGroupedBackground))
+      .navigationTitle(Strings.TabGrid.privateTabsSettingsTitle)
+      .navigationBarTitleDisplayMode(.inline)
+      .toolbar {
+        ToolbarItemGroup(placement: .confirmationAction) {
+          Button(Strings.done) {
+            dismiss()
+          }
+          .foregroundStyle(Color(braveSystemName: .textPrimary))
+        }
+      }
+    }
+  }
+}

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Tabs/TabGrid/TabGridView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Tabs/TabGrid/TabGridView.swift
@@ -56,9 +56,12 @@ struct TabGridView: View {
   @Environment(\.colorScheme) private var colorScheme
   @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
+  @ObservedObject private var privateBrowsingOnly = Preferences.Privacy.privateBrowsingOnly
+
   private enum DestinationSheet: Int, Identifiable, Hashable {
     case syncedTabs
     case history
+    case privateTabsSettings
 
     var id: Int {
       rawValue
@@ -203,6 +206,11 @@ struct TabGridView: View {
         if let historyModel = viewModel.historyModel {
           HistoryView(model: historyModel)
         }
+      case .privateTabsSettings:
+        TabGridPrivateTabsSettings(viewModel: viewModel)
+          .presentationDetents([.medium])
+          .colorScheme(.dark)
+          .preferredColorScheme(.dark)
       }
     }
     .alert(
@@ -342,6 +350,15 @@ struct TabGridView: View {
           viewModel.closeAllTabs()
         } label: {
           Label(Strings.TabGrid.closeAllTabsButtonTitle, braveSystemImage: "leo.close")
+        }
+        if viewModel.isPrivateBrowsing && !privateBrowsingOnly.value {
+          Section {
+            Button {
+              destinationSheet = .privateTabsSettings
+            } label: {
+              Label(Strings.TabGrid.privateTabsSettingsTitle, braveSystemImage: "leo.settings")
+            }
+          }
         }
       } label: {
         Text(Strings.TabGrid.moreMenuButtonTitle)

--- a/ios/brave-ios/Sources/BraveStrings/BraveStrings.swift
+++ b/ios/brave-ios/Sources/BraveStrings/BraveStrings.swift
@@ -1269,6 +1269,13 @@ extension Strings {
       value: "Close All Tabs",
       comment: "A button title which when tapped will close all of the open tabs for the user"
     )
+    public static let privateTabsSettingsTitle = NSLocalizedString(
+      "tabGrid.privateTabsSettingsTitle",
+      tableName: "BraveShared",
+      bundle: .module,
+      value: "Private Tabs Settings",
+      comment: "A button title which when tapped will present settings for private tabs"
+    )
     public static let moreMenuButtonTitle = NSLocalizedString(
       "tabGrid.moreMenuButtonTitle",
       tableName: "BraveShared",
@@ -6454,6 +6461,30 @@ extension Strings {
         bundle: .module,
         value: "Require Face ID",
         comment: ""
+      )
+    public static let privateBrowsingLockDescriptionFaceID =
+      NSLocalizedString(
+        "tabs.settings.privateBrowsingLockDescriptionFaceID",
+        tableName: "BraveShared",
+        bundle: .module,
+        value: "Require Face ID to access your private tabs.",
+        comment: "Describes the preference that locks the users private tabs behind their device biometrics"
+      )
+    public static let privateBrowsingLockDescriptionTouchID =
+      NSLocalizedString(
+        "tabs.settings.privateBrowsingLockDescriptionTouchID",
+        tableName: "BraveShared",
+        bundle: .module,
+        value: "Require Touch ID to access your private tabs.",
+        comment: "Describes the preference that locks the users private tabs behind their device biometrics"
+      )
+    public static let privateBrowsingLockDescriptionPinCode =
+      NSLocalizedString(
+        "tabs.settings.privateBrowsingLockDescriptionPinCode",
+        tableName: "BraveShared",
+        bundle: .module,
+        value: "Require your device PIN to access your private tabs.",
+        comment: "Describes the preference that locks the users private tabs behind their device PIN"
       )
     public static let privateBrowsingLockTitleTouchID =
       NSLocalizedString(


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/47751

### Test Case

- Tap "More" in regular browsing, verify that "Private Tabs Settings" is not visible
- Enter Private browsing mode and verify that "Private Tabs Settings" is now accessible in the "More" menu
- In private tabs settings verify the preferences work correctly like they would if you enabled them in Settings
  - When disabling Private Browsing Lock, verify you are required to authenticate with your device PIN or biometrics before it turn soff
  - When disabling persistent private tabs, ensure tabs remain accessible while you're still Private Browsing, and only are removed after leaving private browsing mode (or force killing the app)

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
