### PR TITLE
Handle ReaderModeToolbar with SideBySide

### DIFF
--- a/browser/ui/views/frame/brave_browser_view.cc
+++ b/browser/ui/views/frame/brave_browser_view.cc
@@ -33,6 +33,7 @@
 #include "brave/browser/ui/views/brave_help_bubble/brave_help_bubble_host_view.h"
 #include "brave/browser/ui/views/frame/brave_contents_layout_manager.h"
 #include "brave/browser/ui/views/frame/brave_contents_view_util.h"
+#include "brave/browser/ui/views/frame/split_view/brave_contents_container_view.h"
 #include "brave/browser/ui/views/frame/split_view/brave_multi_contents_view.h"
 #include "brave/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.h"
 #include "brave/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_widget_delegate_view.h"
@@ -230,21 +231,18 @@ BraveBrowserView::BraveBrowserView(std::unique_ptr<Browser> browser)
   const bool use_rounded_corners =
       BraveBrowser::ShouldUseBraveWebViewRoundedCorners(browser_.get());
 #if BUILDFLAG(ENABLE_SPEEDREADER)
-  reader_mode_toolbar_ =
-      contents_container_->AddChildView(std::make_unique<ReaderModeToolbarView>(
-          browser_->profile(), use_rounded_corners));
-
-  views::View* contents_view = contents_web_view_;
-  // MultiContentsView is contents view with SideBySide feature.
-  if (base::FeatureList::IsEnabled(features::kSideBySide)) {
-    contents_view = multi_contents_view_;
+  // When SideBySide is enabled, each ContentsContainerView in MultiContentsView
+  // own ReaderModeToolbarView.
+  if (!base::FeatureList::IsEnabled(features::kSideBySide)) {
+    reader_mode_toolbar_ = contents_container_->AddChildView(
+        std::make_unique<ReaderModeToolbarView>(browser_->profile(),
+                                                use_rounded_corners));
+    contents_container_->SetLayoutManager(
+        std::make_unique<BraveContentsLayoutManager>(
+            devtools_web_view(), devtools_scrim_view(), contents_web_view_,
+            lens_overlay_view_, contents_scrim_view(), /*border_view*/ nullptr,
+            watermark_view_.get(), reader_mode_toolbar_));
   }
-  CHECK(contents_view);
-  contents_container_->SetLayoutManager(
-      std::make_unique<BraveContentsLayoutManager>(
-          devtools_web_view(), devtools_scrim_view(), contents_view,
-          lens_overlay_view_, contents_scrim_view(), /*border_view*/ nullptr,
-          watermark_view_.get(), reader_mode_toolbar_));
 #endif
 
   if (use_rounded_corners) {
@@ -453,6 +451,15 @@ void BraveBrowserView::SetStarredState(bool is_starred) {
 }
 
 #if BUILDFLAG(ENABLE_SPEEDREADER)
+ReaderModeToolbarView* BraveBrowserView::reader_mode_toolbar() {
+  if (base::FeatureList::IsEnabled(features::kSideBySide)) {
+    return GetBraveMultiContentsView()
+        ->GetActiveContentsContainerView()
+        ->reader_mode_toolbar();
+  }
+
+  return reader_mode_toolbar_;
+}
 
 speedreader::SpeedreaderBubbleView* BraveBrowserView::ShowSpeedreaderBubble(
     speedreader::SpeedreaderTabHelper* tab_helper,
@@ -465,7 +472,7 @@ speedreader::SpeedreaderBubbleView* BraveBrowserView::ShowSpeedreaderBubble(
       arrow = views::BubbleBorder::TOP_RIGHT;
       break;
     case speedreader::SpeedreaderBubbleLocation::kToolbar:
-      anchor = reader_mode_toolbar_->toolbar();
+      anchor = reader_mode_toolbar()->toolbar();
       arrow = views::BubbleBorder::TOP_LEFT;
       break;
   }
@@ -489,8 +496,18 @@ void BraveBrowserView::UpdateReaderModeToolbar() {
     }
     return false;
   };
-  reader_mode_toolbar_->SetVisible(
+  reader_mode_toolbar()->SetVisible(
       is_distilled(browser()->tab_strip_model()->GetActiveWebContents()));
+
+  if (base::FeatureList::IsEnabled(features::kSideBySide)) {
+    // Need to update inactive split tabs' reader mode toolbar because
+    // it's also visible.
+    auto* contents_container =
+        GetBraveMultiContentsView()->GetInactiveContentsContainerView();
+    auto* reader_mode_toolbar = contents_container->reader_mode_toolbar();
+    reader_mode_toolbar->SetVisible(
+        is_distilled(contents_container->GetContentsView()->web_contents()));
+  }
 }
 #endif  // BUILDFLAG(ENABLE_SPEEDREADER)
 

--- a/browser/ui/views/frame/brave_browser_view.h
+++ b/browser/ui/views/frame/brave_browser_view.h
@@ -104,7 +104,8 @@ class BraveBrowserView : public BrowserView,
   views::View* GetAnchorViewForBraveVPNPanel();
   gfx::Rect GetShieldsBubbleRect() override;
 #if BUILDFLAG(ENABLE_SPEEDREADER)
-  ReaderModeToolbarView* reader_mode_toolbar() { return reader_mode_toolbar_; }
+  // Give active tab's reader mode toolbar.
+  ReaderModeToolbarView* reader_mode_toolbar();
   speedreader::SpeedreaderBubbleView* ShowSpeedreaderBubble(
       speedreader::SpeedreaderTabHelper* tab_helper,
       speedreader::SpeedreaderBubbleLocation location) override;

--- a/browser/ui/views/frame/split_view/brave_contents_container_view.h
+++ b/browser/ui/views/frame/split_view/brave_contents_container_view.h
@@ -7,13 +7,25 @@
 #define BRAVE_BROWSER_UI_VIEWS_FRAME_SPLIT_VIEW_BRAVE_CONTENTS_CONTAINER_VIEW_H_
 
 #include "base/gtest_prod_util.h"
+#include "base/memory/raw_ptr.h"
 #include "base/memory/raw_ref.h"
+#include "brave/components/speedreader/common/buildflags/buildflags.h"
 #include "chrome/browser/ui/views/frame/contents_container_view.h"
 #include "ui/base/metadata/metadata_header_macros.h"
 
-class BraveContentsContainerView : public ContentsContainerView {
+#if BUILDFLAG(ENABLE_SPEEDREADER)
+#include "brave/browser/ui/views/speedreader/reader_mode_toolbar_view.h"
+#endif
+
+class BraveContentsContainerView :
+#if BUILDFLAG(ENABLE_SPEEDREADER)
+    public ReaderModeToolbarView::Delegate,
+#endif
+    public ContentsContainerView {
   METADATA_HEADER(BraveContentsContainerView, ContentsContainerView)
  public:
+  static BraveContentsContainerView* From(ContentsContainerView* view);
+
   explicit BraveContentsContainerView(BrowserView* browser_view);
   ~BraveContentsContainerView() override;
 
@@ -21,6 +33,16 @@ class BraveContentsContainerView : public ContentsContainerView {
   void UpdateBorderAndOverlay(bool is_in_split,
                               bool is_active,
                               bool show_scrim) override;
+  views::ProposedLayout CalculateProposedLayout(
+      const views::SizeBounds& size_bounds) const override;
+  void ChildVisibilityChanged(views::View* child) override;
+
+#if BUILDFLAG(ENABLE_SPEEDREADER)
+  // ReaderModeToolbarView::Delegate:
+  void OnReaderModeToolbarActivate(ReaderModeToolbarView* toolbar) override;
+
+  ReaderModeToolbarView* reader_mode_toolbar() { return reader_mode_toolbar_; }
+#endif
 
  private:
   FRIEND_TEST_ALL_PREFIXES(SideBySideEnabledBrowserTest,
@@ -31,6 +53,10 @@ class BraveContentsContainerView : public ContentsContainerView {
   float GetCornerRadius(bool for_border) const;
 
   raw_ref<BrowserView> browser_view_;
+
+#if BUILDFLAG(ENABLE_SPEEDREADER)
+  raw_ptr<ReaderModeToolbarView> reader_mode_toolbar_ = nullptr;
+#endif
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_FRAME_SPLIT_VIEW_BRAVE_CONTENTS_CONTAINER_VIEW_H_

--- a/browser/ui/views/frame/split_view/brave_multi_contents_view.cc
+++ b/browser/ui/views/frame/split_view/brave_multi_contents_view.cc
@@ -9,6 +9,7 @@
 
 #include "base/check.h"
 #include "brave/browser/ui/views/frame/brave_browser_view.h"
+#include "brave/browser/ui/views/frame/split_view/brave_contents_container_view.h"
 #include "brave/browser/ui/views/split_view/split_view_location_bar.h"
 #include "brave/browser/ui/views/split_view/split_view_separator.h"
 #include "chrome/browser/profiles/profile.h"
@@ -87,6 +88,18 @@ void BraveMultiContentsView::UpdateSecondaryLocationBar() {
   auto* separator = static_cast<SplitViewSeparator*>(resize_area_);
   CHECK(separator);
   separator->ShowMenuButtonWidget();
+}
+
+BraveContentsContainerView*
+BraveMultiContentsView::GetActiveContentsContainerView() {
+  return BraveContentsContainerView::From(
+      contents_container_views_[active_index_]);
+}
+
+BraveContentsContainerView*
+BraveMultiContentsView::GetInactiveContentsContainerView() {
+  return BraveContentsContainerView::From(
+      contents_container_views_[GetInactiveIndex()]);
 }
 
 BEGIN_METADATA(BraveMultiContentsView)

--- a/browser/ui/views/frame/split_view/brave_multi_contents_view.h
+++ b/browser/ui/views/frame/split_view/brave_multi_contents_view.h
@@ -19,6 +19,7 @@ class Widget;
 }  // namespace views
 
 class SplitViewLocationBar;
+class BraveContentsContainerView;
 
 class BraveMultiContentsView : public MultiContentsView,
                                public SplitViewSeparatorDelegate {
@@ -33,9 +34,13 @@ class BraveMultiContentsView : public MultiContentsView,
 
   void UpdateSecondaryLocationBar();
 
+  BraveContentsContainerView* GetActiveContentsContainerView();
+  BraveContentsContainerView* GetInactiveContentsContainerView();
+
  private:
   friend class SplitViewLocationBarBrowserTest;
   friend class SideBySideEnabledBrowserTest;
+  friend class SpeedReaderWithSplitViewBrowserTest;
   FRIEND_TEST_ALL_PREFIXES(SideBySideEnabledBrowserTest,
                            BraveMultiContentsViewTest);
 

--- a/browser/ui/views/split_view/split_view.h
+++ b/browser/ui/views/split_view/split_view.h
@@ -9,7 +9,6 @@
 #include <memory>
 #include <vector>
 
-#include "base/gtest_prod_util.h"
 #include "base/memory/raw_ptr.h"
 #include "base/memory/raw_ref.h"
 #include "base/types/pass_key.h"
@@ -136,7 +135,7 @@ class SplitView : public views::View,
  private:
   friend class SplitViewBrowserTest;
   friend class SplitViewLocationBarBrowserTest;
-  FRIEND_TEST_ALL_PREFIXES(SpeedReaderBrowserTest, SplitView);
+  friend class SpeedReaderWithSplitViewBrowserTest;
 
   tabs::TabHandle GetActiveTabHandle() const;
   bool IsActiveWebContentsTiled(const TabTile& tile) const;

--- a/chromium_src/chrome/browser/ui/views/frame/contents_container_view.h
+++ b/chromium_src/chrome/browser/ui/views/frame/contents_container_view.h
@@ -6,7 +6,10 @@
 #ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_FRAME_CONTENTS_CONTAINER_VIEW_H_
 #define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_FRAME_CONTENTS_CONTAINER_VIEW_H_
 
-#define UpdateBorderAndOverlay virtual UpdateBorderAndOverlay
+#define UpdateBorderAndOverlay             \
+  UnUsed() {}                              \
+  friend class BraveContentsContainerView; \
+  virtual void UpdateBorderAndOverlay
 
 #include <chrome/browser/ui/views/frame/contents_container_view.h>  // IWYU pragma: export
 

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -1066,6 +1066,7 @@ test("brave_browser_tests") {
   if (enable_speedreader && toolkit_views) {
     sources += [ "//brave/browser/speedreader/speedreader_browsertest.cc" ]
     deps += [
+      "//brave/browser/ui/views/frame/split_view/",
       "//brave/browser/ui/views/split_view/",
       "//brave/components/ai_chat/core/common",
       "//brave/components/speedreader",


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/46491

When `SideBySide` is enabled, `BraveMultiContentsView` owns each contents views(`BraveContentsContainerView`).
`BraveContentsContainerView` covers whole each split view area and it controls split view activation border.
So, `ReaderModeToolbarView` also should be included in `BraveContentsContainerView`.
As this is same behaviour with our split view implementation, existing test case can verify this PR's change.

TEST=`SpeedReaderWithSplitViewBrowserTest.*`

Manual test
1. Launch Brave with `--enable-features=SideBySide`
2. Test any speed reader features with split views

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
