### PR TITLE
[iOS] Use correct suspension value for invalid language metrics answer (uplift to 1.81.x)

### DIFF
--- a/ios/brave-ios/Sources/Growth/LanguageMetrics.swift
+++ b/ios/brave-ios/Sources/Growth/LanguageMetrics.swift
@@ -206,7 +206,7 @@ public class LanguageMetrics {
   ]
 
   static func answerForLangaugeCode(_ languageCode: String?) -> Int {
-    let suspendedMetricValue = Int.max - 1
+    let suspendedMetricValue = Int(Int32.max - 1)
     guard let languageCode = languageCode,
       case let primaryLanguage = languageSynonyms[languageCode, default: languageCode],
       let answer = acceptedLanguages.firstIndex(of: primaryLanguage)

--- a/ios/brave-ios/Tests/GrowthTests/LangaugeMetricsTests.swift
+++ b/ios/brave-ios/Tests/GrowthTests/LangaugeMetricsTests.swift
@@ -10,7 +10,7 @@ import XCTest
 
 class LanguageMetricsTests: XCTestCase {
   func testInvalidLanguageCodes() {
-    let expectedValue = Int.max - 1
+    let expectedValue = Int(Int32.max - 1)
     XCTAssertEqual(LanguageMetrics.answerForLangaugeCode(nil), expectedValue)
     XCTAssertEqual(LanguageMetrics.answerForLangaugeCode("notalangugage"), expectedValue)
   }


### PR DESCRIPTION
Uplift of #30136
Resolves https://github.com/brave/brave-browser/issues/47755

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.