### PR TITLE
[CodeHealth] Simplify/modernise `eth_requests.h` funcs

### DIFF
--- a/components/brave_wallet/browser/brave_wallet_utils.cc
+++ b/components/brave_wallet/browser/brave_wallet_utils.cc
@@ -44,18 +44,6 @@ namespace brave_wallet {
 
 namespace {
 
-const base::flat_map<std::string_view, std::string_view>
-    kUnstoppableDomainsProxyReaderContractAddressMap = {
-        // https://github.com/unstoppabledomains/uns/blob/abd9e12409094dd6ea8611ebffdade8db49c4b56/uns-config.json#L76
-        {brave_wallet::mojom::kMainnetChainId,
-         "0x578853aa776Eef10CeE6c4dd2B5862bdcE767A8B"},
-        // https://github.com/unstoppabledomains/uns/blob/abd9e12409094dd6ea8611ebffdade8db49c4b56/uns-config.json#L221
-        {brave_wallet::mojom::kPolygonMainnetChainId,
-         "0x91EDd8708062bd4233f4Dd0FCE15A7cb4d500091"},
-        // https://github.com/unstoppabledomains/uns/blob/abd9e12409094dd6ea8611ebffdade8db49c4b56/uns-config.json#L545
-        {brave_wallet::mojom::kBaseMainnetChainId,
-         "0x78c4b414e1abdf0de267deda01dffd4cd0817a16"}};
-
 constexpr const char kEnsRegistryContractAddress[] =
     "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e";
 
@@ -455,16 +443,6 @@ void SetDefaultBaseCryptocurrency(PrefService* prefs,
 
 std::string GetDefaultBaseCryptocurrency(PrefService* prefs) {
   return prefs->GetString(kDefaultBaseCryptocurrency);
-}
-
-std::string_view GetUnstoppableDomainsProxyReaderContractAddress(
-    std::string_view chain_id) {
-  std::string chain_id_lower = base::ToLowerASCII(chain_id);
-  if (kUnstoppableDomainsProxyReaderContractAddressMap.contains(
-          chain_id_lower)) {
-    return kUnstoppableDomainsProxyReaderContractAddressMap.at(chain_id_lower);
-  }
-  return "";
 }
 
 std::string GetEnsRegistryContractAddress(std::string_view chain_id) {

--- a/components/brave_wallet/browser/brave_wallet_utils.h
+++ b/components/brave_wallet/browser/brave_wallet_utils.h
@@ -65,8 +65,6 @@ void SetDefaultBaseCryptocurrency(PrefService* prefs,
                                   std::string_view cryptocurrency);
 std::string GetDefaultBaseCryptocurrency(PrefService* prefs);
 
-std::string_view GetUnstoppableDomainsProxyReaderContractAddress(
-    std::string_view chain_id);
 std::string GetEnsRegistryContractAddress(std::string_view chain_id);
 
 mojom::BlockchainTokenPtr GetUserAsset(PrefService* prefs,

--- a/components/brave_wallet/browser/ens_resolver_task.cc
+++ b/components/brave_wallet/browser/ens_resolver_task.cc
@@ -287,7 +287,7 @@ void EnsResolverTask::FetchEnsResolver() {
 
   std::string call_data = ens::Resolver(resolver_domain_);
 
-  RequestInternal(eth::eth_call(contract_address, call_data),
+  RequestInternal(eth::GetCallPayload(contract_address, call_data),
                   base::BindOnce(&EnsResolverTask::OnFetchEnsResolverDone,
                                  weak_ptr_factory_.GetWeakPtr()));
 }
@@ -333,7 +333,7 @@ void EnsResolverTask::FetchEnsip10Support() {
   // https://docs.ens.domains/ens-improvement-proposals/ensip-10-wildcard-resolution#specification
   auto call = erc165::SupportsInterface(kResolveBytesBytesSelector);
 
-  RequestInternal(eth::eth_call(resolver_address_.ToHex(), ToHex(call)),
+  RequestInternal(eth::GetCallPayload(resolver_address_.ToHex(), ToHex(call)),
                   base::BindOnce(&EnsResolverTask::OnFetchEnsip10SupportDone,
                                  weak_ptr_factory_.GetWeakPtr()));
 }
@@ -369,9 +369,10 @@ void EnsResolverTask::FetchEnsRecord() {
     return;
   }
 
-  RequestInternal(eth::eth_call(resolver_address_.ToHex(), ToHex(ens_call_)),
-                  base::BindOnce(&EnsResolverTask::OnFetchEnsRecordDone,
-                                 weak_ptr_factory_.GetWeakPtr()));
+  RequestInternal(
+      eth::GetCallPayload(resolver_address_.ToHex(), ToHex(ens_call_)),
+      base::BindOnce(&EnsResolverTask::OnFetchEnsRecordDone,
+                     weak_ptr_factory_.GetWeakPtr()));
 }
 
 void EnsResolverTask::OnFetchEnsRecordDone(
@@ -420,7 +421,7 @@ void EnsResolverTask::FetchWithEnsip10Resolve() {
                               .EncodeWithSelector(kResolveBytesBytesSelector);
 
   RequestInternal(
-      eth::eth_call(resolver_address_.ToHex(), ToHex(ens_resolve_call)),
+      eth::GetCallPayload(resolver_address_.ToHex(), ToHex(ens_resolve_call)),
       base::BindOnce(&EnsResolverTask::OnFetchWithEnsip10ResolveDone,
                      weak_ptr_factory_.GetWeakPtr()));
 }
@@ -563,10 +564,10 @@ void EnsResolverTask::FetchOffchainCallback() {
   DCHECK(offchain_callback_call_);
   DCHECK(!task_result_);
 
-  RequestInternal(
-      eth::eth_call(resolver_address_.ToHex(), ToHex(*offchain_callback_call_)),
-      base::BindOnce(&EnsResolverTask::OnFetchOffchainCallbackDone,
-                     weak_ptr_factory_.GetWeakPtr()));
+  RequestInternal(eth::GetCallPayload(resolver_address_.ToHex(),
+                                      ToHex(*offchain_callback_call_)),
+                  base::BindOnce(&EnsResolverTask::OnFetchOffchainCallbackDone,
+                                 weak_ptr_factory_.GetWeakPtr()));
 }
 
 void EnsResolverTask::OnFetchOffchainCallbackDone(

--- a/components/brave_wallet/browser/eth_requests.cc
+++ b/components/brave_wallet/browser/eth_requests.cc
@@ -7,26 +7,27 @@
 
 #include <utility>
 
+#include "brave/components/brave_wallet/browser/brave_wallet_constants.h"
 #include "brave/components/brave_wallet/browser/json_rpc_requests_helper.h"
 #include "brave/components/brave_wallet/common/hex_utils.h"
 
 namespace brave_wallet::eth {
 
-std::string eth_chainId() {
+std::string GetChainIdPayload() {
   return GetJsonRpcString("eth_chainId");
 }
 
-std::string eth_gasPrice() {
+std::string GetGasPricePayload() {
   return GetJsonRpcString("eth_gasPrice");
 }
 
-std::string eth_blockNumber() {
+std::string GetBlockNumberPayload() {
   return GetJsonRpcString("eth_blockNumber");
 }
 
-std::string eth_feeHistory(const std::string& num_blocks,
-                           const std::string& head,
-                           const std::vector<double>& reward_percentiles) {
+std::string GetFeeHistoryPayload(std::string_view num_blocks,
+                                 std::string_view head,
+                                 base::span<const double> reward_percentiles) {
   base::Value::List percentile_values;
   for (double reward_percentile : reward_percentiles) {
     percentile_values.Append(base::Value(reward_percentile));
@@ -41,22 +42,22 @@ std::string eth_feeHistory(const std::string& num_blocks,
   return GetJSON(dictionary);
 }
 
-std::string eth_getBalance(const std::string& address,
-                           const std::string& quantity_tag) {
+std::string GetBalancePayload(std::string_view address,
+                              std::string_view quantity_tag) {
   return GetJsonRpcString("eth_getBalance", address, quantity_tag);
 }
 
-std::string eth_getTransactionCount(const std::string& address,
-                                    const std::string& quantity_tag) {
+std::string GetTransactionCountPayload(std::string_view address,
+                                       std::string_view quantity_tag) {
   return GetJsonRpcString("eth_getTransactionCount", address, quantity_tag);
 }
 
-std::string eth_getCode(const std::string& address,
-                        const std::string& quantity_tag) {
+std::string GetCodePayload(std::string_view address,
+                           std::string_view quantity_tag) {
   return GetJsonRpcString("eth_getCode", address, quantity_tag);
 }
 
-std::string eth_sendRawTransaction(const std::string& raw_transaction) {
+std::string GetSendRawTransactionPayload(std::string_view raw_transaction) {
   base::Value::List params;
   params.Append(base::Value(raw_transaction));
   base::Value::Dict dictionary =
@@ -64,38 +65,25 @@ std::string eth_sendRawTransaction(const std::string& raw_transaction) {
   return GetJSON(dictionary);
 }
 
-std::string eth_call(const std::string& from_address,
-                     const std::string& to_address,
-                     const std::string& gas,
-                     const std::string& gas_price,
-                     const std::string& val,
-                     const std::string& data,
-                     const std::string& quantity_tag) {
-  base::Value::List params;
+std::string GetCallPayload(std::string_view to_address, std::string_view data) {
   base::Value::Dict transaction;
-  AddKeyIfNotEmpty(&transaction, "data", data);
-  AddKeyIfNotEmpty(&transaction, "from", from_address);
-  AddKeyIfNotEmpty(&transaction, "gas", gas);
-  AddKeyIfNotEmpty(&transaction, "gasPrice", gas_price);
-  transaction.Set("to", base::Value(to_address));
-  AddKeyIfNotEmpty(&transaction, "value", val);
+  transaction.Set("data", data);
+  transaction.Set("to", to_address);
+
+  base::Value::List params;
   params.Append(std::move(transaction));
-  params.Append(std::move(quantity_tag));
+  params.Append(kEthereumBlockTagLatest);
   base::Value::Dict dictionary =
       GetJsonRpcDictionary("eth_call", std::move(params));
   return GetJSON(dictionary);
 }
 
-std::string eth_call(const std::string& to_address, const std::string& data) {
-  return eth::eth_call("", to_address, "", "", "", data, "latest");
-}
-
-std::string eth_estimateGas(const std::string& from_address,
-                            const std::string& to_address,
-                            const std::string& gas,
-                            const std::string& gas_price,
-                            const std::string& val,
-                            const std::string& data) {
+std::string GetEstimateGasPayload(std::string_view from_address,
+                                  std::string_view to_address,
+                                  std::string_view gas,
+                                  std::string_view gas_price,
+                                  std::string_view val,
+                                  std::string_view data) {
   base::Value::List params;
   base::Value::Dict transaction;
   AddKeyIfNotEmpty(&transaction, "data", data);
@@ -110,7 +98,7 @@ std::string eth_estimateGas(const std::string& from_address,
   return GetJSON(dictionary);
 }
 
-std::string eth_getBlockByHash(const std::string& block_hash,
+std::string eth_getBlockByHash(std::string_view block_hash,
                                bool full_transaction_object) {
   base::Value::List params;
   params.Append(base::Value(block_hash));
@@ -120,8 +108,8 @@ std::string eth_getBlockByHash(const std::string& block_hash,
   return GetJSON(dictionary);
 }
 
-std::string eth_getBlockByNumber(const std::string& quantity_tag,
-                                 bool full_transaction_object) {
+std::string GetBlockByNumberPayload(std::string_view quantity_tag,
+                                    bool full_transaction_object) {
   base::Value::List params;
   params.Append(base::Value(quantity_tag));
   params.Append(base::Value(full_transaction_object));
@@ -130,11 +118,11 @@ std::string eth_getBlockByNumber(const std::string& quantity_tag,
   return GetJSON(dictionary);
 }
 
-std::string eth_getTransactionReceipt(const std::string& transaction_hash) {
+std::string GetTransactionReceiptPayload(std::string_view transaction_hash) {
   return GetJsonRpcString("eth_getTransactionReceipt", transaction_hash);
 }
 
-std::string eth_getLogs(base::Value::Dict filter_options) {
+std::string GetLogsPayload(base::Value::Dict filter_options) {
   base::Value::List params;
   params.Append(std::move(filter_options));
   base::Value::Dict dictionary =

--- a/components/brave_wallet/browser/eth_requests.h
+++ b/components/brave_wallet/browser/eth_requests.h
@@ -6,45 +6,40 @@
 #ifndef BRAVE_COMPONENTS_BRAVE_WALLET_BROWSER_ETH_REQUESTS_H_
 #define BRAVE_COMPONENTS_BRAVE_WALLET_BROWSER_ETH_REQUESTS_H_
 
+#include <optional>
 #include <string>
-#include <vector>
+#include <string_view>
 
+#include "base/containers/span.h"
 #include "base/values.h"
 
 namespace brave_wallet::eth {
 
 // Request chainId for a network.
-std::string eth_chainId();
+std::string GetChainIdPayload();
 // Returns the current price per gas in wei.
-std::string eth_gasPrice();
+std::string GetGasPricePayload();
 // Returns the number of most recent block.
-std::string eth_blockNumber();
+std::string GetBlockNumberPayload();
 // Returns the fee history.
-std::string eth_feeHistory(const std::string& num_blocks,
-                           const std::string& head,
-                           const std::vector<double>& reward_percentiles);
+std::string GetFeeHistoryPayload(std::string_view num_blocks,
+                                 std::string_view head,
+                                 base::span<const double> reward_percentiles);
 // Returns the balance of the account of given address.
-std::string eth_getBalance(const std::string& address,
-                           const std::string& quantity_tag);
+std::string GetBalancePayload(std::string_view address,
+                              std::string_view quantity_tag);
 // Returns the number of transactions sent from an address.
-std::string eth_getTransactionCount(const std::string& address,
-                                    const std::string& quantity_tag);
+std::string GetTransactionCountPayload(std::string_view address,
+                                       std::string_view quantity_tag);
 // Returns code at a given address.
-std::string eth_getCode(const std::string& address,
-                        const std::string& quantity_tag);
+std::string GetCodePayload(std::string_view address,
+                           std::string_view quantity_tag);
 // Creates new message call transaction or a contract creation for signed
 // transactions.
-std::string eth_sendRawTransaction(const std::string& raw_transaction);
+std::string GetSendRawTransactionPayload(std::string_view raw_transaction);
 // Executes a new message call immediately without creating a transaction on the
 // block chain.
-std::string eth_call(const std::string& from_address,
-                     const std::string& to_address,
-                     const std::string& gas,
-                     const std::string& gas_price,
-                     const std::string& value,
-                     const std::string& data,
-                     const std::string& quantity_tag);
-std::string eth_call(const std::string& to_address, const std::string& data);
+std::string GetCallPayload(std::string_view to_address, std::string_view data);
 // Generates and returns an estimate of how much gas is necessary to allow the
 // transaction to complete. The transaction will not be added to the blockchain.
 // Note that the estimate may be significantly more than the amount of gas
@@ -55,19 +50,19 @@ std::string eth_call(const std::string& to_address, const std::string& data);
 // QUANTITY|TAG, however the official specs in github.com/ethereum/eth1.0-specs
 // do not. Therefore to support chains that follow the official specs, we do not
 // allow specifying this parameter.
-std::string eth_estimateGas(const std::string& from_address,
-                            const std::string& to_address,
-                            const std::string& gas,
-                            const std::string& gas_price,
-                            const std::string& value,
-                            const std::string& data);
+std::string GetEstimateGasPayload(std::string_view from_address,
+                                  std::string_view to_address,
+                                  std::string_view gas,
+                                  std::string_view gas_price,
+                                  std::string_view value,
+                                  std::string_view data);
 // Returns information about a block by block number.
-std::string eth_getBlockByNumber(const std::string& quantity_tag,
-                                 bool full_transaction_object);
+std::string GetBlockByNumberPayload(std::string_view quantity_tag,
+                                    bool full_transaction_object);
 // Returns the receipt of a transaction by transaction hash.
-std::string eth_getTransactionReceipt(const std::string& transaction_hash);
+std::string GetTransactionReceiptPayload(std::string_view transaction_hash);
 // Returns an array of all logs matching a given filter object.
-std::string eth_getLogs(base::Value::Dict filter_options);
+std::string GetLogsPayload(base::Value::Dict filter_options);
 
 }  // namespace brave_wallet::eth
 

--- a/components/brave_wallet/browser/eth_requests_unittest.cc
+++ b/components/brave_wallet/browser/eth_requests_unittest.cc
@@ -12,90 +12,83 @@
 
 namespace brave_wallet::eth {
 
-TEST(EthRequestUnitTest, eth_gasPrice) {
-  ASSERT_EQ(eth_gasPrice(),
+TEST(EthRequestUnitTest, GetGasPricePayload) {
+  ASSERT_EQ(GetGasPricePayload(),
             R"({"id":1,"jsonrpc":"2.0","method":"eth_gasPrice","params":[]})");
 }
 
-TEST(EthRequestUnitTest, eth_blockNumber) {
+TEST(EthRequestUnitTest, GetBlockNumberPayload) {
   ASSERT_EQ(
-      eth_blockNumber(),
+      GetBlockNumberPayload(),
       R"({"id":1,"jsonrpc":"2.0","method":"eth_blockNumber","params":[]})");
 }
 
-TEST(EthRequestUnitTest, eth_feeHistory) {
+TEST(EthRequestUnitTest, GetFeeHistoryPayload) {
   ASSERT_EQ(
-      eth_feeHistory("0x28", "latest", std::vector<double>{20, 50, 80}),
+      GetFeeHistoryPayload("0x28", "latest", std::vector<double>{20, 50, 80}),
       R"({"id":1,"jsonrpc":"2.0","method":"eth_feeHistory","params":["0x28","latest",[20.0,50.0,80.0]]})");
 }
 
-TEST(EthRequestUnitTest, eth_getBalance) {
+TEST(EthRequestUnitTest, GetBalancePayload) {
   ASSERT_EQ(
-      eth_getBalance("0x407d73d8a49eeb85d32cf465507dd71d507100c1", "latest"),
+      GetBalancePayload("0x407d73d8a49eeb85d32cf465507dd71d507100c1", "latest"),
       R"({"id":1,"jsonrpc":"2.0","method":"eth_getBalance","params":["0x407d73d8a49eeb85d32cf465507dd71d507100c1","latest"]})");  // NOLINT
 }
 
-TEST(EthRequestUnitTest, eth_getTransactionCount) {
+TEST(EthRequestUnitTest, GetTransactionCountPayload) {
   ASSERT_EQ(
-      eth_getTransactionCount("0x407d73d8a49eeb85d32cf465507dd71d507100c1",
-                              "latest"),
+      GetTransactionCountPayload("0x407d73d8a49eeb85d32cf465507dd71d507100c1",
+                                 "latest"),
       R"({"id":1,"jsonrpc":"2.0","method":"eth_getTransactionCount","params":["0x407d73d8a49eeb85d32cf465507dd71d507100c1","latest"]})");  // NOLINT
 }
 
-TEST(EthRequestUnitTest, eth_getCode) {
+TEST(EthRequestUnitTest, GetCodePayload) {
   ASSERT_EQ(
-      eth_getCode("0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b", "0x2"),
+      GetCodePayload("0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b", "0x2"),
       R"({"id":1,"jsonrpc":"2.0","method":"eth_getCode","params":["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b","0x2"]})");  // NOLINT
 }
 
-TEST(EthRequestUnitTest, eth_sendRawTransaction) {
+TEST(EthRequestUnitTest, GetSendRawTransactionPayload) {
   ASSERT_EQ(
-      eth_sendRawTransaction("0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb97087"
-                             "0f072445675058bb8eb970870f072445675"),
+      GetSendRawTransactionPayload(
+          "0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb97087"
+          "0f072445675058bb8eb970870f072445675"),
       R"({"id":1,"jsonrpc":"2.0","method":"eth_sendRawTransaction","params":["0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675"]})");  // NOLINT
 }
 
-TEST(EthRequestUnitTest, eth_call) {
+TEST(EthRequestUnitTest, GetCallPayload) {
   ASSERT_EQ(
-      eth_call("0xb60e8dd61c5d32be8058bb8eb970870f07233155",
-               "0xd46e8dd67c5d32be8058bb8eb970870f07244567", "0x76c0",
-               "0x9184e72a000", "0x9184e72a",
-               "0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058"
-               "bb8eb970870f072445675",
-               "latest"),
-      R"({"id":1,"jsonrpc":"2.0","method":"eth_call","params":[{"data":"0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675","from":"0xb60e8dd61c5d32be8058bb8eb970870f07233155","gas":"0x76c0","gasPrice":"0x9184e72a000","to":"0xd46e8dd67c5d32be8058bb8eb970870f07244567","value":"0x9184e72a"},"latest"]})");  // NOLINT
-
-  ASSERT_EQ(
-      eth_call(
+      GetCallPayload(
           "0xd46e8dd67c5d32be8058bb8eb970870f07244567",
           "0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058"),
       R"({"id":1,"jsonrpc":"2.0","method":"eth_call","params":[{"data":"0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058","to":"0xd46e8dd67c5d32be8058bb8eb970870f07244567"},"latest"]})");  // NOLINT
 }
 
-TEST(EthRequestUnitTest, eth_estimateGas) {
+TEST(EthRequestUnitTest, GetEstimateGasPayload) {
   ASSERT_EQ(
-      eth_estimateGas("0xb60e8dd61c5d32be8058bb8eb970870f07233155",
-                      "0xd46e8dd67c5d32be8058bb8eb970870f07244567", "0x76c0",
-                      "0x9184e72a000", "0x9184e72a",
-                      "0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f07244"
-                      "5675058bb8eb970870f072445675"),
+      GetEstimateGasPayload(
+          "0xb60e8dd61c5d32be8058bb8eb970870f07233155",
+          "0xd46e8dd67c5d32be8058bb8eb970870f07244567", "0x76c0",
+          "0x9184e72a000", "0x9184e72a",
+          "0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f07244"
+          "5675058bb8eb970870f072445675"),
       R"({"id":1,"jsonrpc":"2.0","method":"eth_estimateGas","params":[{"data":"0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675","from":"0xb60e8dd61c5d32be8058bb8eb970870f07233155","gas":"0x76c0","gasPrice":"0x9184e72a000","to":"0xd46e8dd67c5d32be8058bb8eb970870f07244567","value":"0x9184e72a"}]})");  // NOLINT
 }
 
-TEST(EthRequestUnitTest, eth_getBlockByNumber) {
+TEST(EthRequestUnitTest, GetBlockByNumberPayload) {
   ASSERT_EQ(
-      eth_getBlockByNumber("0x1b4", true),
+      GetBlockByNumberPayload("0x1b4", true),
       R"({"id":1,"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x1b4",true]})");  // NOLINT
 }
 
-TEST(EthRequestUnitTest, eth_getTransactionReceipt) {
+TEST(EthRequestUnitTest, GetTransactionReceiptPayload) {
   ASSERT_EQ(
-      eth_getTransactionReceipt(
+      GetTransactionReceiptPayload(
           "0xb903239f8543d04b5dc1ba6579132b143087c68db1b2168786408fcbce568238"),
       R"({"id":1,"jsonrpc":"2.0","method":"eth_getTransactionReceipt","params":["0xb903239f8543d04b5dc1ba6579132b143087c68db1b2168786408fcbce568238"]})");  // NOLINT
 }
 
-TEST(EthRequestUnitTest, eth_getLogs) {
+TEST(EthRequestUnitTest, GetLogsPayload) {
   base::Value::List topics;
   topics.Append(
       "0x000000000000000000000000a94f5374fce5edbc8e2a8697c15331677e6ebf0b");
@@ -118,7 +111,7 @@ TEST(EthRequestUnitTest, eth_getLogs) {
       "blockhash",
       "0xb903239f8543d04b5dc1ba6579132b143087c68db1b2168786408fcbce568238");
   ASSERT_EQ(
-      eth_getLogs(std::move(filtering)),
+      GetLogsPayload(std::move(filtering)),
       R"({"id":1,"jsonrpc":"2.0","method":"eth_getLogs","params":[{"address":["0x8888f1f195afa192cfee860698584c030f4c9db1"],"blockhash":"0xb903239f8543d04b5dc1ba6579132b143087c68db1b2168786408fcbce568238","fromBlock":"0x1","toBlock":"0x2","topics":["0x000000000000000000000000a94f5374fce5edbc8e2a8697c15331677e6ebf0b",["0x000000000000000000000000a94f5374fce5edbc8e2a8697c15331677e6ebf0b","0x0000000000000000000000000aff3454fce5edbc8cca8697c15331677e6ebccc"]]}]})");  // NOLINT
 }
 

--- a/components/brave_wallet/browser/json_rpc_service.cc
+++ b/components/brave_wallet/browser/json_rpc_service.cc
@@ -6,6 +6,7 @@
 #include "brave/components/brave_wallet/browser/json_rpc_service.h"
 
 #include <algorithm>
+#include <array>
 #include <memory>
 #include <optional>
 #include <utility>
@@ -16,6 +17,7 @@
 #include "base/check.h"
 #include "base/check_is_test.h"
 #include "base/containers/extend.h"
+#include "base/containers/fixed_flat_map.h"
 #include "base/containers/flat_set.h"
 #include "base/containers/map_util.h"
 #include "base/functional/bind.h"
@@ -148,6 +150,18 @@ constexpr char kUDPattern[] =
     "mumu|nft|nibi|npc|onchain|pastor|podcast|pog|polygon|privacy|propykeys|"
     "pudgy|quantum|rad|raiin|secret|smobler|south|stepn|tball|tea|tribe|u|ubu|"
     "unstoppable|wallet|wifi|witg|wrkx|x|xec|xmr|zil)";
+
+constexpr auto kUnstoppableDomainsProxyReaderContractAddresses =
+    base::MakeFixedFlatMap<std::string_view, std::string_view>(
+        {// https://github.com/unstoppabledomains/uns/blob/abd9e12409094dd6ea8611ebffdade8db49c4b56/uns-config.json#L76
+         {brave_wallet::mojom::kMainnetChainId,
+          "0x578853aa776Eef10CeE6c4dd2B5862bdcE767A8B"},
+         // https://github.com/unstoppabledomains/uns/blob/abd9e12409094dd6ea8611ebffdade8db49c4b56/uns-config.json#L221
+         {brave_wallet::mojom::kPolygonMainnetChainId,
+          "0x91EDd8708062bd4233f4Dd0FCE15A7cb4d500091"},
+         // https://github.com/unstoppabledomains/uns/blob/abd9e12409094dd6ea8611ebffdade8db49c4b56/uns-config.json#L545
+         {brave_wallet::mojom::kBaseMainnetChainId,
+          "0x78c4b414e1abdf0de267deda01dffd4cd0817a16"}});
 
 net::NetworkTrafficAnnotationTag GetNetworkTrafficAnnotationTag() {
   return net::DefineNetworkTrafficAnnotation("json_rpc_service", R"(
@@ -504,7 +518,7 @@ void JsonRpcService::AddChain(mojom::NetworkInfoPtr chain,
   auto result = base::BindOnce(&JsonRpcService::OnEthChainIdValidated,
                                weak_ptr_factory_.GetWeakPtr(), std::move(chain),
                                url, std::move(callback));
-  RequestInternal(eth::eth_chainId(), true, url, std::move(result));
+  RequestInternal(eth::GetChainIdPayload(), true, url, std::move(result));
 }
 
 void JsonRpcService::OnEthChainIdValidated(
@@ -572,7 +586,7 @@ void JsonRpcService::AddEthereumChainRequestCompleted(
 
   auto result = base::BindOnce(&JsonRpcService::OnEthChainIdValidatedForOrigin,
                                weak_ptr_factory_.GetWeakPtr(), chain_id, url);
-  RequestInternal(eth::eth_chainId(), true, url, std::move(result));
+  RequestInternal(eth::GetChainIdPayload(), true, url, std::move(result));
 }
 
 void JsonRpcService::OnEthChainIdValidatedForOrigin(
@@ -758,7 +772,7 @@ void JsonRpcService::GetBlockNumber(const std::string& chain_id,
   auto internal_callback =
       base::BindOnce(&JsonRpcService::OnGetBlockNumber,
                      weak_ptr_factory_.GetWeakPtr(), std::move(callback));
-  RequestInternal(eth::eth_blockNumber(), true,
+  RequestInternal(eth::GetBlockNumberPayload(), true,
                   GetNetworkURL(chain_id, mojom::CoinType::ETH),
                   std::move(internal_callback));
 }
@@ -778,7 +792,7 @@ void JsonRpcService::GetCode(const std::string& address,
   auto internal_callback =
       base::BindOnce(&JsonRpcService::OnGetCode, weak_ptr_factory_.GetWeakPtr(),
                      std::move(callback));
-  RequestInternal(eth::eth_getCode(address, "latest"), true, network_url,
+  RequestInternal(eth::GetCodePayload(address, "latest"), true, network_url,
                   std::move(internal_callback));
 }
 
@@ -838,11 +852,13 @@ void JsonRpcService::GetFeeHistory(const std::string& chain_id,
   auto conversion_callback =
       base::BindOnce(&ConvertAllNumbersToString, "/result");
 
-  RequestInternal(eth::eth_feeHistory("0x28",  // blockCount = 40
-                                      kEthereumBlockTagLatest,
-                                      std::vector<double>{20, 50, 80}),
-                  true, GetNetworkURL(chain_id, mojom::CoinType::ETH),
-                  std::move(internal_callback), std::move(conversion_callback));
+  static constexpr auto kRewardPercentiles =
+      std::to_array<double>({20, 50, 80});
+  RequestInternal(
+      eth::GetFeeHistoryPayload("0x28",  // blockCount = 40
+                                kEthereumBlockTagLatest, kRewardPercentiles),
+      true, GetNetworkURL(chain_id, mojom::CoinType::ETH),
+      std::move(internal_callback), std::move(conversion_callback));
 }
 
 void JsonRpcService::OnGetFeeHistory(GetFeeHistoryCallback callback,
@@ -892,8 +908,8 @@ void JsonRpcService::GetBalance(const std::string& address,
     auto internal_callback =
         base::BindOnce(&JsonRpcService::OnEthGetBalance,
                        weak_ptr_factory_.GetWeakPtr(), std::move(callback));
-    RequestInternal(eth::eth_getBalance(address, kEthereumBlockTagLatest), true,
-                    network_url, std::move(internal_callback));
+    RequestInternal(eth::GetBalancePayload(address, kEthereumBlockTagLatest),
+                    true, network_url, std::move(internal_callback));
     return;
   }
 
@@ -1048,7 +1064,7 @@ void JsonRpcService::GetEthTransactionCount(const std::string& chain_id,
                      weak_ptr_factory_.GetWeakPtr(), std::move(callback));
 
   RequestInternal(
-      eth::eth_getTransactionCount(address, kEthereumBlockTagLatest), true,
+      eth::GetTransactionCountPayload(address, kEthereumBlockTagLatest), true,
       network_url, std::move(internal_callback));
 }
 
@@ -1104,7 +1120,7 @@ void JsonRpcService::GetTransactionReceipt(const std::string& chain_id,
   auto internal_callback =
       base::BindOnce(&JsonRpcService::OnGetTransactionReceipt,
                      weak_ptr_factory_.GetWeakPtr(), std::move(callback));
-  RequestInternal(eth::eth_getTransactionReceipt(tx_hash), true,
+  RequestInternal(eth::GetTransactionReceiptPayload(tx_hash), true,
                   GetNetworkURL(chain_id, mojom::CoinType::ETH),
                   std::move(internal_callback));
 }
@@ -1138,7 +1154,7 @@ void JsonRpcService::SendRawTransaction(const std::string& chain_id,
   auto internal_callback =
       base::BindOnce(&JsonRpcService::OnSendRawTransaction,
                      weak_ptr_factory_.GetWeakPtr(), std::move(callback));
-  RequestInternal(eth::eth_sendRawTransaction(signed_tx), true,
+  RequestInternal(eth::GetSendRawTransactionPayload(signed_tx), true,
                   GetNetworkURL(chain_id, mojom::CoinType::ETH),
                   std::move(internal_callback));
 }
@@ -1182,9 +1198,8 @@ void JsonRpcService::GetERC20TokenBalance(
   auto internal_callback =
       base::BindOnce(&JsonRpcService::OnGetERC20TokenBalance,
                      weak_ptr_factory_.GetWeakPtr(), std::move(callback));
-  RequestInternal(
-      eth::eth_call("", contract, "", "", "", data, kEthereumBlockTagLatest),
-      true, network_url, std::move(internal_callback));
+  RequestInternal(eth::GetCallPayload(contract, data), true, network_url,
+                  std::move(internal_callback));
 }
 
 void JsonRpcService::OnGetERC20TokenBalance(
@@ -1257,9 +1272,8 @@ void JsonRpcService::GetERC20TokenAllowance(
   auto internal_callback =
       base::BindOnce(&JsonRpcService::OnGetERC20TokenAllowance,
                      weak_ptr_factory_.GetWeakPtr(), std::move(callback));
-  RequestInternal(eth::eth_call("", contract_address, "", "", "", data,
-                                kEthereumBlockTagLatest),
-                  true, GetNetworkURL(chain_id, mojom::CoinType::ETH),
+  RequestInternal(eth::GetCallPayload(contract_address, data), true,
+                  GetNetworkURL(chain_id, mojom::CoinType::ETH),
                   std::move(internal_callback));
 }
 
@@ -1362,7 +1376,7 @@ void JsonRpcService::ProcessNextERC20Batch(
       &JsonRpcService::OnGetERC20TokenBalances, weak_ptr_factory_.GetWeakPtr(),
       std::move(token_addresses), std::move(batch_callback));
 
-  RequestInternal(eth::eth_call(scanner_address, calldata.value()), true,
+  RequestInternal(eth::GetCallPayload(scanner_address, calldata.value()), true,
                   network_url, std::move(internal_callback));
 }
 
@@ -1759,15 +1773,13 @@ void JsonRpcService::UnstoppableDomainsResolveDns(
   }
 
   ud_resolve_dns_calls_.AddCallback(domain, std::move(callback));
-  for (const auto& chain_id : ud_resolve_dns_calls_.GetChains()) {
-    auto internal_callback =
-        base::BindOnce(&JsonRpcService::OnUnstoppableDomainsResolveDns,
-                       weak_ptr_factory_.GetWeakPtr(), domain, chain_id);
-    auto eth_call = eth::eth_call(
-        "",
-        std::string(GetUnstoppableDomainsProxyReaderContractAddress(chain_id)),
-        "", "", "", *data, kEthereumBlockTagLatest);
-    RequestInternal(std::move(eth_call), true,
+  for (const auto [chain_id, address] :
+       kUnstoppableDomainsProxyReaderContractAddresses) {
+    auto internal_callback = base::BindOnce(
+        &JsonRpcService::OnUnstoppableDomainsResolveDns,
+        weak_ptr_factory_.GetWeakPtr(), domain, std::string(chain_id));
+
+    RequestInternal(eth::GetCallPayload(address, *data), true,
                     NetworkManager::GetUnstoppableDomainsRpcUrl(chain_id),
                     std::move(internal_callback));
   }
@@ -1833,14 +1845,12 @@ void JsonRpcService::UnstoppableDomainsGetWalletAddr(
       domain, token->coin, token->symbol, token->chain_id);
 
   ud_get_eth_addr_calls_.AddCallback(key, std::move(callback));
-  for (const auto& chain_id : ud_get_eth_addr_calls_.GetChains()) {
-    auto internal_callback =
-        base::BindOnce(&JsonRpcService::OnUnstoppableDomainsGetWalletAddr,
-                       weak_ptr_factory_.GetWeakPtr(), key, chain_id);
-    auto eth_call = eth::eth_call(
-        std::string(GetUnstoppableDomainsProxyReaderContractAddress(chain_id)),
-        ToHex(call_data));
-    RequestInternal(std::move(eth_call), true,
+  for (const auto [chain_id, address] :
+       kUnstoppableDomainsProxyReaderContractAddresses) {
+    auto internal_callback = base::BindOnce(
+        &JsonRpcService::OnUnstoppableDomainsGetWalletAddr,
+        weak_ptr_factory_.GetWeakPtr(), key, std::string(chain_id));
+    RequestInternal(eth::GetCallPayload(address, ToHex(call_data)), true,
                     NetworkManager::GetUnstoppableDomainsRpcUrl(chain_id),
                     std::move(internal_callback));
   }
@@ -1943,8 +1953,8 @@ void JsonRpcService::GetEstimateGas(const std::string& chain_id,
   auto internal_callback =
       base::BindOnce(&JsonRpcService::OnGetEstimateGas,
                      weak_ptr_factory_.GetWeakPtr(), std::move(callback));
-  RequestInternal(eth::eth_estimateGas(from_address, to_address, gas, gas_price,
-                                       value, data),
+  RequestInternal(eth::GetEstimateGasPayload(from_address, to_address, gas,
+                                             gas_price, value, data),
                   true, GetNetworkURL(chain_id, mojom::CoinType::ETH),
                   std::move(internal_callback));
 }
@@ -1982,7 +1992,7 @@ void JsonRpcService::GetGasPrice(const std::string& chain_id,
   auto internal_callback =
       base::BindOnce(&JsonRpcService::OnGetGasPrice,
                      weak_ptr_factory_.GetWeakPtr(), std::move(callback));
-  RequestInternal(eth::eth_gasPrice(), true,
+  RequestInternal(eth::GetGasPricePayload(), true,
                   GetNetworkURL(chain_id, mojom::CoinType::ETH),
                   std::move(internal_callback));
 }
@@ -2019,7 +2029,7 @@ void JsonRpcService::GetBaseFeePerGas(const std::string& chain_id,
   auto internal_callback =
       base::BindOnce(&JsonRpcService::OnGetBaseFeePerGas,
                      weak_ptr_factory_.GetWeakPtr(), std::move(callback));
-  RequestInternal(eth::eth_getBlockByNumber(kEthereumBlockTagLatest, false),
+  RequestInternal(eth::GetBlockByNumberPayload(kEthereumBlockTagLatest, false),
                   true, GetNetworkURL(chain_id, mojom::CoinType::ETH),
                   std::move(internal_callback));
 }
@@ -2058,7 +2068,7 @@ void JsonRpcService::GetBlockByNumber(const std::string& chain_id,
   auto internal_callback =
       base::BindOnce(&JsonRpcService::OnGetBlockByNumber,
                      weak_ptr_factory_.GetWeakPtr(), std::move(callback));
-  RequestInternal(eth::eth_getBlockByNumber(block_number, false), true,
+  RequestInternal(eth::GetBlockByNumberPayload(block_number, false), true,
                   GetNetworkURL(chain_id, mojom::CoinType::ETH),
                   std::move(internal_callback));
 }
@@ -2135,9 +2145,8 @@ void JsonRpcService::GetERC721OwnerOf(const std::string& contract,
   auto internal_callback =
       base::BindOnce(&JsonRpcService::OnGetERC721OwnerOf,
                      weak_ptr_factory_.GetWeakPtr(), std::move(callback));
-  RequestInternal(
-      eth::eth_call("", contract, "", "", "", data, kEthereumBlockTagLatest),
-      true, network_url, std::move(internal_callback));
+  RequestInternal(eth::GetCallPayload(contract, data), true, network_url,
+                  std::move(internal_callback));
 }
 
 void JsonRpcService::OnGetERC721OwnerOf(GetERC721OwnerOfCallback callback,
@@ -2274,8 +2283,7 @@ void JsonRpcService::GetEthTokenUri(const std::string& chain_id,
       base::BindOnce(&JsonRpcService::OnGetEthTokenUri,
                      weak_ptr_factory_.GetWeakPtr(), std::move(callback));
 
-  RequestInternal(eth::eth_call("", contract_address, "", "", "",
-                                function_signature, kEthereumBlockTagLatest),
+  RequestInternal(eth::GetCallPayload(contract_address, function_signature),
                   true, network_url, std::move(internal_callback));
 }
 
@@ -2343,9 +2351,8 @@ void JsonRpcService::GetERC1155TokenBalance(
   auto internal_callback =
       base::BindOnce(&JsonRpcService::OnEthGetBalance,
                      weak_ptr_factory_.GetWeakPtr(), std::move(callback));
-  RequestInternal(eth::eth_call("", contract_address, "", "", "", data,
-                                kEthereumBlockTagLatest),
-                  true, network_url, std::move(internal_callback));
+  RequestInternal(eth::GetCallPayload(contract_address, data), true,
+                  network_url, std::move(internal_callback));
 }
 
 void JsonRpcService::EthGetLogs(const std::string& chain_id,
@@ -2362,7 +2369,7 @@ void JsonRpcService::EthGetLogs(const std::string& chain_id,
   auto internal_callback =
       base::BindOnce(&JsonRpcService::OnEthGetLogs,
                      weak_ptr_factory_.GetWeakPtr(), std::move(callback));
-  RequestInternal(eth::eth_getLogs(std::move(filter_options)), true,
+  RequestInternal(eth::GetLogsPayload(std::move(filter_options)), true,
                   network_url, std::move(internal_callback));
 }
 
@@ -2411,9 +2418,8 @@ void JsonRpcService::GetSupportsInterface(
   auto internal_callback =
       base::BindOnce(&JsonRpcService::OnGetSupportsInterface,
                      weak_ptr_factory_.GetWeakPtr(), std::move(callback));
-  RequestInternal(eth::eth_call("", contract_address, "", "", "", data,
-                                kEthereumBlockTagLatest),
-                  true, network_url, std::move(internal_callback));
+  RequestInternal(eth::GetCallPayload(contract_address, data), true,
+                  network_url, std::move(internal_callback));
 }
 
 void JsonRpcService::OnGetSupportsInterface(
@@ -2614,8 +2620,8 @@ void JsonRpcService::GetEthTokenSymbol(
   auto internal_callback =
       base::BindOnce(&JsonRpcService::OnGetEthTokenSymbol,
                      weak_ptr_factory_.GetWeakPtr(), std::move(callback));
-  RequestInternal(eth::eth_call(contract_address, data), true, network_url,
-                  std::move(internal_callback));
+  RequestInternal(eth::GetCallPayload(contract_address, data), true,
+                  network_url, std::move(internal_callback));
 }
 
 void JsonRpcService::OnGetEthTokenSymbol(
@@ -2655,8 +2661,8 @@ void JsonRpcService::GetEthTokenDecimals(
   auto internal_callback =
       base::BindOnce(&JsonRpcService::OnGetEthTokenDecimals,
                      weak_ptr_factory_.GetWeakPtr(), std::move(callback));
-  RequestInternal(eth::eth_call(contract_address, data), true, network_url,
-                  std::move(internal_callback));
+  RequestInternal(eth::GetCallPayload(contract_address, data), true,
+                  network_url, std::move(internal_callback));
 }
 
 void JsonRpcService::OnGetEthTokenDecimals(
@@ -2705,8 +2711,8 @@ void JsonRpcService::GetEthTokenName(const std::string& contract_address,
   auto internal_callback =
       base::BindOnce(&JsonRpcService::OnGetEthTokenName,
                      weak_ptr_factory_.GetWeakPtr(), std::move(callback));
-  RequestInternal(eth::eth_call(contract_address, data), true, network_url,
-                  std::move(internal_callback));
+  RequestInternal(eth::GetCallPayload(contract_address, data), true,
+                  network_url, std::move(internal_callback));
 }
 
 void JsonRpcService::OnGetEthTokenName(GetEthTokenStringResultCallback callback,
@@ -3707,6 +3713,16 @@ void JsonRpcService::FetchSolCompressedNftProofData(
     SimpleHashClient::FetchSolCompressedNftProofDataCallback callback) {
   simple_hash_client_->FetchSolCompressedNftProofData(token_address,
                                                       std::move(callback));
+}
+
+// static
+std::string_view
+JsonRpcService::GetUnstoppableDomainsProxyReaderContractAddressForTesting(
+    std::string_view coin) {
+  auto* address =
+      base::FindOrNull(kUnstoppableDomainsProxyReaderContractAddresses, coin);
+  CHECK(address);
+  return *address;
 }
 
 }  // namespace brave_wallet

--- a/components/brave_wallet/browser/json_rpc_service.h
+++ b/components/brave_wallet/browser/json_rpc_service.h
@@ -573,6 +573,10 @@ class JsonRpcService : public mojom::JsonRpcService {
 
   NetworkManager* network_manager() { return network_manager_; }
 
+  static std::string_view
+  GetUnstoppableDomainsProxyReaderContractAddressForTesting(
+      std::string_view coin);
+
  private:
   void FireNetworkChanged(mojom::CoinType coin,
                           const std::string& chain_id,

--- a/components/brave_wallet/browser/json_rpc_service_unittest.cc
+++ b/components/brave_wallet/browser/json_rpc_service_unittest.cc
@@ -3206,27 +3206,33 @@ class UnstoppableDomainsUnitTest : public JsonRpcServiceUnitTest {
     JsonRpcServiceUnitTest::SetUp();
     eth_mainnet_endpoint_handler_ = std::make_unique<JsonRpcEndpointHandler>(
         NetworkManager::GetUnstoppableDomainsRpcUrl(mojom::kMainnetChainId));
-    eth_mainnet_getmany_call_handler_ = std::make_unique<UDGetManyCallHandler>(
-        EthAddress::FromHex(GetUnstoppableDomainsProxyReaderContractAddress(
-            mojom::kMainnetChainId)));
+    eth_mainnet_getmany_call_handler_ =
+        std::make_unique<UDGetManyCallHandler>(EthAddress::FromHex(
+            JsonRpcService::
+                GetUnstoppableDomainsProxyReaderContractAddressForTesting(
+                    mojom::kMainnetChainId)));
     eth_mainnet_endpoint_handler_->AddEthCallHandler(
         eth_mainnet_getmany_call_handler_.get());
 
     polygon_endpoint_handler_ = std::make_unique<JsonRpcEndpointHandler>(
         NetworkManager::GetUnstoppableDomainsRpcUrl(
             mojom::kPolygonMainnetChainId));
-    polygon_getmany_call_handler_ = std::make_unique<UDGetManyCallHandler>(
-        EthAddress::FromHex(GetUnstoppableDomainsProxyReaderContractAddress(
-            mojom::kPolygonMainnetChainId)));
+    polygon_getmany_call_handler_ =
+        std::make_unique<UDGetManyCallHandler>(EthAddress::FromHex(
+            JsonRpcService::
+                GetUnstoppableDomainsProxyReaderContractAddressForTesting(
+                    mojom::kPolygonMainnetChainId)));
     polygon_endpoint_handler_->AddEthCallHandler(
         polygon_getmany_call_handler_.get());
 
     base_endpoint_handler_ = std::make_unique<JsonRpcEndpointHandler>(
         NetworkManager::GetUnstoppableDomainsRpcUrl(
             mojom::kBaseMainnetChainId));
-    base_getmany_call_handler_ = std::make_unique<UDGetManyCallHandler>(
-        EthAddress::FromHex(GetUnstoppableDomainsProxyReaderContractAddress(
-            mojom::kBaseMainnetChainId)));
+    base_getmany_call_handler_ =
+        std::make_unique<UDGetManyCallHandler>(EthAddress::FromHex(
+            JsonRpcService::
+                GetUnstoppableDomainsProxyReaderContractAddressForTesting(
+                    mojom::kBaseMainnetChainId)));
     base_endpoint_handler_->AddEthCallHandler(base_getmany_call_handler_.get());
 
     url_loader_factory_.SetInterceptor(base::BindRepeating(

--- a/components/brave_wallet/browser/unstoppable_domains_multichain_calls.cc
+++ b/components/brave_wallet/browser/unstoppable_domains_multichain_calls.cc
@@ -94,13 +94,6 @@ bool MultichainCall<ResultType>::MaybeResolveCallbacks() {
 }
 
 template <class KeyType, class ResultType>
-std::vector<std::string> MultichainCalls<KeyType, ResultType>::GetChains()
-    const {
-  return {mojom::kPolygonMainnetChainId, mojom::kBaseMainnetChainId,
-          mojom::kMainnetChainId};
-}
-
-template <class KeyType, class ResultType>
 bool MultichainCalls<KeyType, ResultType>::HasCall(const KeyType& key) {
   return calls_.count(key) > 0;
 }

--- a/components/brave_wallet/browser/unstoppable_domains_multichain_calls.h
+++ b/components/brave_wallet/browser/unstoppable_domains_multichain_calls.h
@@ -64,8 +64,6 @@ class MultichainCalls {
   MultichainCalls() = default;
   ~MultichainCalls() = default;
 
-  std::vector<std::string> GetChains() const;
-
   bool HasCall(const KeyType& key);
   void AddCallback(const KeyType& key, CallbackType callback);
   void SetNoResult(const KeyType& key, const std::string& chain_id);


### PR DESCRIPTION
This PR touches on the functions in `eth_requests.h` and adjacent code
for them. We are doing a few things:

 - Passing `std::string_view` rather than `const std::string&`.
 - Correcting the naming convention for these function.
 - Using `std::optional` where possible to signal presence, rather than
   `""`.

Additionally, this PR does away with
`GetUnstoppableDomainsProxyReaderContractAddress` and the map behind it.
There are few gains with this change around this function. First, we are
now using a `constexpr` set, and avoiding the string allocations that
were taking place. Second, the places where this data set was being used
have been reviewed, and the conversion to lower case is not needed
anymore, which removes the extra allocation for that.

Finally, `MultichainCalls::GetChains` is also being removed. The style
guide specifies that member functions must have some relation to the
data of a class, which wasn't the case here. Additonally, the vector
allocation is really not necessary for this case. This function was
being used only by `JsonRpcService`, and the set returned by `GetChains`
was at this moment a duplication of the keys of
`kUnstoppableDomainsProxyReaderContractAddresses`. This PR moves all
this code to be a discreet implementation detail of `JsonRpcService`, to
simplify further the association of this data. However, a static testing
function has been made available through `JsonRpcService` for testing
code.

Resolves https://github.com/brave/brave-browser/issues/47794
