### PR TITLE
[Android] Reverted width code for shields menu (uplift to 1.81.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/shields/BraveShieldsHandler.java
+++ b/android/java/org/chromium/chrome/browser/shields/BraveShieldsHandler.java
@@ -21,7 +21,6 @@ import android.text.SpannableString;
 import android.text.method.LinkMovementMethod;
 import android.text.method.ScrollingMovementMethod;
 import android.text.style.StyleSpan;
-import android.view.ContextThemeWrapper;
 import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.Surface;
@@ -259,7 +258,6 @@ public class BraveShieldsHandler implements BraveRewardsHelper.LargeIconReadyCal
             anchorView = mHardwareButtonMenuAnchor;
         }
 
-        ContextThemeWrapper wrapper = new ContextThemeWrapper(mContext, R.style.OverflowMenuThemeOverlay);
         Point pt = new Point();
         ((Activity)mContext).getWindowManager().getDefaultDisplay().getSize(pt);
         // Get the height and width of the display.
@@ -295,12 +293,6 @@ public class BraveShieldsHandler implements BraveRewardsHelper.LargeIconReadyCal
         PopupWindow popupWindow = new PopupWindow(mPopupView, width, height, focusable);
         popupWindow.setBackgroundDrawable(new ColorDrawable(Color.WHITE));
         popupWindow.setElevation(20);
-        Rect bgPadding = new Rect();
-        int popupWidth =
-                wrapper.getResources().getDimensionPixelSize(R.dimen.menu_width)
-                        + bgPadding.left
-                        + bgPadding.right;
-        popupWindow.setWidth(popupWidth);
         // Set the location of the window on the screen
         mAnchorView = anchorView;
         if (BottomToolbarConfiguration.isToolbarBottomAnchored()) {


### PR DESCRIPTION
Uplift of #30160
Resolves https://github.com/brave/brave-browser/issues/47790

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.