### PR TITLE
[CodeHealth] Remove uses of `base::StringPrintf` pt.2

### DIFF
--- a/components/ai_chat/content/browser/ai_chat_tab_helper.cc
+++ b/components/ai_chat/content/browser/ai_chat_tab_helper.cc
@@ -384,7 +384,7 @@ void AIChatTabHelper::OnScreenshotsCaptured(
     for (auto& screenshot : result.value()) {
       size_t screenshot_size = screenshot.size();
       screenshots.push_back(mojom::UploadedFile::New(
-          base::StringPrintf("fullscreenshot_%i.png", screenshot_index++),
+          absl::StrFormat("fullscreenshot_%i.png", screenshot_index++),
           screenshot_size, std::move(screenshot),
           mojom::UploadedFileType::kScreenshot));
     }

--- a/components/ai_chat/content/browser/full_screenshotter.cc
+++ b/components/ai_chat/content/browser/full_screenshotter.cc
@@ -90,8 +90,8 @@ void FullScreenshotter::OnScreenshotCaptured(
   if (status != PaintPreviewBaseService::CaptureStatus::kOk ||
       !result->capture_success) {
     std::move(callback).Run(base::unexpected(
-        base::StringPrintf("Failed to capture a screenshot (CaptureStatus=%d)",
-                           static_cast<int>(status))));
+        absl::StrFormat("Failed to capture a screenshot (CaptureStatus=%d)",
+                        static_cast<int>(status))));
     return;
   }
 
@@ -224,8 +224,8 @@ void FullScreenshotter::OnBitmapReceived(
       bitmap.empty()) {
     std::move(pending->callback)
         .Run(base::unexpected(
-            base::StringPrintf("Failed to get bitmap (BitmapStatus=%d)",
-                               static_cast<int>(status))));
+            absl::StrFormat("Failed to get bitmap (BitmapStatus=%d)",
+                            static_cast<int>(status))));
     return;
   }
 

--- a/components/ai_chat/content/browser/page_content_fetcher.cc
+++ b/components/ai_chat/content/browser/page_content_fetcher.cc
@@ -255,9 +255,9 @@ class PageContentFetcherInternal {
       const auto& config = data->content->get_youtube_inner_tube_config();
       DVLOG(1) << "Making InnerTube API request for video " << config->video_id;
 
-      auto url = GURL(base::StringPrintf(
-          "https://www.youtube.com/youtubei/v1/player?key=%s",
-          base::EscapeQueryParamValue(config->api_key, true).c_str()));
+      auto url = GURL(
+          absl::StrFormat("https://www.youtube.com/youtubei/v1/player?key=%s",
+                          base::EscapeQueryParamValue(config->api_key, true)));
       auto new_invalidation_token = url.spec();
       if (new_invalidation_token == invalidation_token) {
         VLOG(2) << "Not fetching content since invalidation token matches: "

--- a/components/ai_chat/content/browser/page_content_fetcher_unittest.cc
+++ b/components/ai_chat/content/browser/page_content_fetcher_unittest.cc
@@ -168,8 +168,7 @@ class PageContentFetcherTest : public content::RenderViewHostTestHarness {
 
   // Helper method to create a YouTube InnerTube API response
   std::string CreateInnerTubeResponse(const std::string& base_url) {
-    base::Value response =
-        base::test::ParseJson(base::StringPrintf(R"({
+    base::Value response = base::test::ParseJson(absl::StrFormat(R"({
       "captions": {
         "playerCaptionsTracklistRenderer": {
           "captionTracks": [
@@ -182,7 +181,7 @@ class PageContentFetcherTest : public content::RenderViewHostTestHarness {
         }
       }
     })",
-                                                 base_url.c_str()));
+                                                                 base_url));
 
     std::string response_str;
     base::JSONWriter::Write(response, &response_str);
@@ -284,8 +283,7 @@ TEST_F(PageContentFetcherTest, YouTubeInnerTubeAPISuccess) {
 
   // Verify the request body
   ASSERT_EQ(request_bodies.size(), 1u);
-  base::Value expected_body =
-      base::test::ParseJson(base::StringPrintf(R"({
+  base::Value expected_body = base::test::ParseJson(absl::StrFormat(R"({
     "videoId": "%s",
     "context": {
       "client": {
@@ -294,7 +292,7 @@ TEST_F(PageContentFetcherTest, YouTubeInnerTubeAPISuccess) {
       }
     }
   })",
-                                               video_id.c_str()));
+                                                                    video_id));
 
   std::string expected_body_str;
   base::JSONWriter::Write(expected_body, &expected_body_str);

--- a/components/ai_chat/core/browser/ai_chat_credential_manager_unittest.cc
+++ b/components/ai_chat/core/browser/ai_chat_credential_manager_unittest.cc
@@ -134,7 +134,7 @@ std::string formatSkusStateValue(const base::Time start_time,
     base::Time incremented_time = shifted_start_time + base::Days(i);
     base::Time::Exploded exploded;
     incremented_time.UTCExplode(&exploded);
-    std::string formatted_time = base::StringPrintf(
+    std::string formatted_time = absl::StrFormat(
         "%04d-%02d-%02dT%02d:%02d:%02d", exploded.year, exploded.month,
         exploded.day_of_month, exploded.hour, exploded.minute, exploded.second);
 

--- a/components/ai_chat/core/browser/ai_chat_database_unittest.cc
+++ b/components/ai_chat/core/browser/ai_chat_database_unittest.cc
@@ -89,8 +89,7 @@ INSTANTIATE_TEST_SUITE_P(
     // and no tables are missing or different.
     ::testing::Bool(),
     [](const testing::TestParamInfo<AIChatDatabaseTest::ParamType>& info) {
-      return base::StringPrintf("DropTablesFirst_%s",
-                                info.param ? "Yes" : "No");
+      return absl::StrFormat("DropTablesFirst_%s", info.param ? "Yes" : "No");
     });
 
 // Functions tested:
@@ -1011,7 +1010,7 @@ class AIChatDatabaseMigrationTest : public testing::Test,
     base::test::TestFuture<os_crypt_async::Encryptor> future;
     os_crypt_->GetInstance(future.GetCallback());
     CreateDatabase(
-        base::StringPrintf("aichat_database_dump_version_%d.sql", version()));
+        absl::StrFormat("aichat_database_dump_version_%d.sql", version()));
     db_ = std::make_unique<AIChatDatabase>(db_file_path(), future.Take());
   }
 
@@ -1073,8 +1072,8 @@ INSTANTIATE_TEST_SUITE_P(
     testing::Range(kLowestSupportedDatabaseVersion, kCurrentDatabaseVersion),
     [](const testing::TestParamInfo<AIChatDatabaseMigrationTest::ParamType>&
            info) {
-      return base::StringPrintf("From_v%d_to_v%d", info.param,
-                                kCurrentDatabaseVersion);
+      return absl::StrFormat("From_v%d_to_v%d", info.param,
+                             kCurrentDatabaseVersion);
     });
 
 // Tests the migration of the database from version() to kCurrentVersionNumber

--- a/components/ai_chat/core/browser/ai_chat_service_unittest.cc
+++ b/components/ai_chat/core/browser/ai_chat_service_unittest.cc
@@ -402,8 +402,7 @@ INSTANTIATE_TEST_SUITE_P(
     AIChatServiceUnitTest,
     ::testing::Bool(),
     [](const testing::TestParamInfo<AIChatServiceUnitTest::ParamType>& info) {
-      return base::StringPrintf("History%s",
-                                info.param ? "Enabled" : "Disabled");
+      return absl::StrFormat("History%s", info.param ? "Enabled" : "Disabled");
     });
 
 TEST_P(AIChatServiceUnitTest, ConversationLifecycle_NoMessages) {

--- a/components/brave_adaptive_captcha/brave_adaptive_captcha_service.cc
+++ b/components/brave_adaptive_captcha/brave_adaptive_captcha_service.cc
@@ -23,8 +23,8 @@ std::string GetScheduledCaptchaUrl(const std::string& payment_id,
   DCHECK(!payment_id.empty());
   DCHECK(!captcha_id.empty());
 
-  const std::string path = base::StringPrintf(
-      "/v3/captcha/%s/%s", payment_id.c_str(), captcha_id.c_str());
+  const std::string path =
+      absl::StrFormat("/v3/captcha/%s/%s", payment_id, captcha_id);
   return brave_adaptive_captcha::ServerUtil::GetInstance()->GetServerUrl(path);
 }
 

--- a/components/brave_adaptive_captcha/get_adaptive_captcha_challenge.cc
+++ b/components/brave_adaptive_captcha/get_adaptive_captcha_challenge.cc
@@ -28,7 +28,7 @@ GetAdaptiveCaptchaChallenge::~GetAdaptiveCaptchaChallenge() = default;
 
 std::string GetAdaptiveCaptchaChallenge::GetUrl(const std::string& payment_id) {
   const std::string path =
-      base::StringPrintf("/v3/captcha/challenge/%s", payment_id.c_str());
+      absl::StrFormat("/v3/captcha/challenge/%s", payment_id);
   return ServerUtil::GetInstance()->GetServerUrl(path);
 }
 

--- a/components/brave_ads/core/internal/account/issuers/url_request/issuers_url_request_builder_util.cc
+++ b/components/brave_ads/core/internal/account/issuers/url_request/issuers_url_request_builder_util.cc
@@ -11,7 +11,7 @@
 namespace brave_ads {
 
 std::string BuildIssuersUrlPath() {
-  return base::StringPrintf("/v%d/issuers", kIssuersServerVersion);
+  return absl::StrFormat("/v%d/issuers", kIssuersServerVersion);
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/account/utility/redeem_confirmation/non_reward/url_request_builders/create_non_reward_confirmation_url_request_builder_util.cc
+++ b/components/brave_ads/core/internal/account/utility/redeem_confirmation/non_reward/url_request_builders/create_non_reward_confirmation_url_request_builder_util.cc
@@ -18,8 +18,8 @@ std::string BuildCreateNonRewardConfirmationUrlPath(
     const std::string& transaction_id) {
   CHECK(!transaction_id.empty());
 
-  return base::StringPrintf("/v%d/confirmation/%s", kConfirmationServerVersion,
-                            transaction_id.c_str());
+  return absl::StrFormat("/v%d/confirmation/%s", kConfirmationServerVersion,
+                         transaction_id);
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/account/utility/redeem_confirmation/reward/url_request_builders/create_reward_confirmation_url_request_builder_util.cc
+++ b/components/brave_ads/core/internal/account/utility/redeem_confirmation/reward/url_request_builders/create_reward_confirmation_url_request_builder_util.cc
@@ -17,9 +17,8 @@ std::string BuildCreateRewardConfirmationUrlPath(
   CHECK(!transaction_id.empty());
   CHECK(!credential_base64url.empty());
 
-  return base::StringPrintf("/v%d/confirmation/%s/%s", kTokensServerVersion,
-                            transaction_id.c_str(),
-                            credential_base64url.c_str());
+  return absl::StrFormat("/v%d/confirmation/%s/%s", kTokensServerVersion,
+                         transaction_id, credential_base64url);
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/account/utility/redeem_confirmation/reward/url_request_builders/fetch_payment_token_url_request_builder_util.cc
+++ b/components/brave_ads/core/internal/account/utility/redeem_confirmation/reward/url_request_builders/fetch_payment_token_url_request_builder_util.cc
@@ -11,8 +11,8 @@
 namespace brave_ads {
 
 std::string BuildFetchPaymentTokenUrlPath(const std::string& transaction_id) {
-  return base::StringPrintf("/v%d/confirmation/%s/paymentToken",
-                            kTokensServerVersion, transaction_id.c_str());
+  return absl::StrFormat("/v%d/confirmation/%s/paymentToken",
+                         kTokensServerVersion, transaction_id);
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/account/utility/redeem_payment_tokens/url_request_builders/redeem_payment_tokens_url_request_builder_util.cc
+++ b/components/brave_ads/core/internal/account/utility/redeem_payment_tokens/url_request_builders/redeem_payment_tokens_url_request_builder_util.cc
@@ -14,8 +14,8 @@ namespace brave_ads {
 std::string BuildRedeemPaymentTokensUrlPath(const std::string& payment_id) {
   CHECK(!payment_id.empty());
 
-  return base::StringPrintf("/v%d/confirmation/payment/%s",
-                            kTokensServerVersion, payment_id.c_str());
+  return absl::StrFormat("/v%d/confirmation/payment/%s", kTokensServerVersion,
+                         payment_id);
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/account/utility/refill_confirmation_tokens/url_requests/get_signed_tokens/get_signed_tokens_url_request_builder_util.cc
+++ b/components/brave_ads/core/internal/account/utility/refill_confirmation_tokens/url_requests/get_signed_tokens/get_signed_tokens_url_request_builder_util.cc
@@ -16,9 +16,8 @@ std::string BuildGetSignedTokensUrlPath(const std::string& payment_id,
   CHECK(!payment_id.empty());
   CHECK(!nonce.empty());
 
-  return base::StringPrintf("/v%d/confirmation/token/%s?nonce=%s",
-                            kTokensServerVersion, payment_id.c_str(),
-                            nonce.c_str());
+  return absl::StrFormat("/v%d/confirmation/token/%s?nonce=%s",
+                         kTokensServerVersion, payment_id, nonce);
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/account/utility/refill_confirmation_tokens/url_requests/request_signed_tokens/request_signed_tokens_url_request_builder_util.cc
+++ b/components/brave_ads/core/internal/account/utility/refill_confirmation_tokens/url_requests/request_signed_tokens/request_signed_tokens_url_request_builder_util.cc
@@ -14,8 +14,8 @@ namespace brave_ads {
 std::string BuildRequestSignedTokensUrlPath(const std::string& payment_id) {
   CHECK(!payment_id.empty());
 
-  return base::StringPrintf("/v%d/confirmation/token/%s", kTokensServerVersion,
-                            payment_id.c_str());
+  return absl::StrFormat("/v%d/confirmation/token/%s", kTokensServerVersion,
+                         payment_id);
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/catalog/catalog_url_request_builder_util.cc
+++ b/components/brave_ads/core/internal/catalog/catalog_url_request_builder_util.cc
@@ -11,7 +11,7 @@
 namespace brave_ads {
 
 std::string BuildCatalogUrlPath() {
-  return base::StringPrintf("/v%d/catalog", kCatalogVersion);
+  return absl::StrFormat("/v%d/catalog", kCatalogVersion);
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/common/net/http/http_status_code_util.cc
+++ b/components/brave_ads/core/internal/common/net/http/http_status_code_util.cc
@@ -36,7 +36,7 @@ std::optional<std::string> HttpStatusCodeClassToString(
     return std::nullopt;
   }
 
-  return base::StringPrintf("%dxx", http_status_code_class);
+  return absl::StrFormat("%dxx", http_status_code_class);
 }
 
 }  // namespace

--- a/components/brave_ads/core/internal/common/net/http/http_status_code_util_unittest.cc
+++ b/components/brave_ads/core/internal/common/net/http/http_status_code_util_unittest.cc
@@ -50,7 +50,7 @@ TEST(BraveAdsHttpStatusCodeUtilTest, HttpStatusCodeToString) {
     if (kAllowedHttpStatusCodes.contains(i)) {
       EXPECT_EQ(base::NumberToString(i), http_status_code);
     } else {
-      EXPECT_EQ(base::StringPrintf("%dxx", /*http_status_code_class*/ i / 100),
+      EXPECT_EQ(absl::StrFormat("%dxx", /*http_status_code_class*/ i / 100),
                 http_status_code);
     }
   }

--- a/components/brave_ads/core/internal/common/subdivision/url_request/subdivision_url_request_builder_util.cc
+++ b/components/brave_ads/core/internal/common/subdivision/url_request/subdivision_url_request_builder_util.cc
@@ -11,7 +11,7 @@
 namespace brave_ads {
 
 std::string BuildSubdivisionUrlPath() {
-  return base::StringPrintf("/v%d/getstate", kSubdivisionServerVersion);
+  return absl::StrFormat("/v%d/getstate", kSubdivisionServerVersion);
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/common/time/time_util.cc
+++ b/components/brave_ads/core/internal/common/time/time_util.cc
@@ -67,9 +67,8 @@ std::string TimeToPrivacyPreservingIso8601(base::Time time) {
   base::Time::Exploded exploded;
   time.UTCExplode(&exploded);
 
-  return base::StringPrintf("%04d-%02d-%02dT%02d:00:00.000Z", exploded.year,
-                            exploded.month, exploded.day_of_month,
-                            exploded.hour);
+  return absl::StrFormat("%04d-%02d-%02dT%02d:00:00.000Z", exploded.year,
+                         exploded.month, exploded.day_of_month, exploded.hour);
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/common/url/url_response_string_util.cc
+++ b/components/brave_ads/core/internal/common/url/url_response_string_util.cc
@@ -36,11 +36,11 @@ std::string HeadersToString(
 
 std::string UrlResponseToString(
     const mojom::UrlResponseInfo& mojom_url_response) {
-  return base::StringPrintf(
+  return absl::StrFormat(
       "URL Response:\n  URL: %s\n  Response "
       "Status Code: %d\n  Response: %s",
-      mojom_url_response.url.spec().c_str(), mojom_url_response.status_code,
-      mojom_url_response.body.c_str());
+      mojom_url_response.url.spec(), mojom_url_response.status_code,
+      mojom_url_response.body);
 }
 
 std::string UrlResponseHeadersToString(

--- a/components/brave_ads/core/internal/legacy_migration/database/database_migration_for_non_rewards_unittest.cc
+++ b/components/brave_ads/core/internal/legacy_migration/database/database_migration_for_non_rewards_unittest.cc
@@ -20,8 +20,8 @@ namespace {
 constexpr int kFreshInstallDatabaseVersion = 0;
 
 std::string TestParamToString(::testing::TestParamInfo<int> test_param) {
-  return base::StringPrintf("%d_to_%d", test_param.param,
-                            database::kVersionNumber);
+  return absl::StrFormat("%d_to_%d", test_param.param,
+                         database::kVersionNumber);
 }
 
 }  // namespace
@@ -48,8 +48,8 @@ class BraveAdsDatabaseMigrationForNonRewardsTest
   static int GetSchemaVersion() { return GetParam(); }
 
   static std::string DatabasePathForSchemaVersion() {
-    return base::StringPrintf("database/migration/database_schema_%d.sqlite",
-                              GetSchemaVersion());
+    return absl::StrFormat("database/migration/database_schema_%d.sqlite",
+                           GetSchemaVersion());
   }
 
   static bool IsTestingFreshInstall() {

--- a/components/brave_ads/core/internal/legacy_migration/database/database_migration_unittest.cc
+++ b/components/brave_ads/core/internal/legacy_migration/database/database_migration_unittest.cc
@@ -19,8 +19,8 @@ namespace {
 constexpr int kFreshInstallDatabaseVersion = 0;
 
 std::string TestParamToString(::testing::TestParamInfo<int> test_param) {
-  return base::StringPrintf("%d_to_%d", test_param.param,
-                            database::kVersionNumber);
+  return absl::StrFormat("%d_to_%d", test_param.param,
+                         database::kVersionNumber);
 }
 
 }  // namespace
@@ -44,8 +44,8 @@ class BraveAdsDatabaseMigrationTest : public test::TestBase,
   static int GetSchemaVersion() { return GetParam(); }
 
   static std::string DatabasePathForSchemaVersion() {
-    return base::StringPrintf("database/migration/database_schema_%d.sqlite",
-                              GetSchemaVersion());
+    return absl::StrFormat("database/migration/database_schema_%d.sqlite",
+                           GetSchemaVersion());
   }
 
   static bool IsTestingFreshInstall() {

--- a/components/brave_rewards/content/diagnostic_log.cc
+++ b/components/brave_rewards/content/diagnostic_log.cc
@@ -41,7 +41,7 @@ std::string GetLogVerboseLevelName(int verbose_level) {
     }
 
     default: {
-      verbose_level_name = base::StringPrintf("VERBOSE%d", verbose_level);
+      verbose_level_name = absl::StrFormat("VERBOSE%d", verbose_level);
       break;
     }
   }
@@ -335,9 +335,9 @@ void DiagnosticLog::Write(const std::string& log_entry,
   const base::FilePath file_path = base::FilePath().AppendASCII(file);
   const std::string filename = file_path.BaseName().MaybeAsASCII();
 
-  const std::string formatted_log_entry = base::StringPrintf(
-      "[%s:%s:%s(%d)] %s\n", formatted_time.c_str(), verbose_level_name.c_str(),
-      filename.c_str(), line, log_entry.c_str());
+  const std::string formatted_log_entry =
+      absl::StrFormat("[%s:%s:%s(%d)] %s\n", formatted_time, verbose_level_name,
+                      filename, line, log_entry);
 
   Write(formatted_log_entry, std::move(callback));
 }

--- a/components/brave_rewards/content/rewards_notification_service_impl.cc
+++ b/components/brave_rewards/content/rewards_notification_service_impl.cc
@@ -17,7 +17,6 @@
 #include "base/logging.h"
 #include "base/rand_util.h"
 #include "base/strings/string_number_conversions.h"
-#include "base/strings/stringprintf.h"
 #include "base/time/time.h"
 #include "base/values.h"
 #include "brave/components/brave_rewards/core/pref_names.h"
@@ -134,8 +133,8 @@ RewardsNotificationServiceImpl::GetAllNotifications() const {
 
 RewardsNotificationServiceImpl::RewardsNotificationID
 RewardsNotificationServiceImpl::GenerateRewardsNotificationID() const {
-  return base::StringPrintf(
-      "%d", base::RandInt(0, std::numeric_limits<int32_t>::max()));
+  return base::NumberToString(
+      base::RandInt(0, std::numeric_limits<int32_t>::max()));
 }
 
 RewardsNotificationServiceImpl::RewardsNotificationTimestamp

--- a/components/brave_rewards/core/engine/database/database_activity_info.cc
+++ b/components/brave_rewards/core/engine/database/database_activity_info.cc
@@ -59,7 +59,7 @@ std::string GenerateActivityFilterQuery(const int start,
   }
 
   if (!filter->non_verified) {
-    const std::string status = base::StringPrintf(
+    const std::string status = absl::StrFormat(
         " AND spi.status != %1d AND spi.address != ''",
         base::to_underlying(mojom::PublisherStatus::NOT_VERIFIED));
     query += status;
@@ -138,9 +138,9 @@ void DatabaseActivityInfo::NormalizeList(
   }
   std::string main_query;
   for (const auto& info : list) {
-    main_query += base::StringPrintf(
+    main_query += absl::StrFormat(
         "UPDATE %s SET percent = %d, weight = %f WHERE publisher_id = '%s';",
-        kTableName, info->percent, info->weight, info->id.c_str());
+        kTableName, info->percent, info->weight, info->id);
   }
 
   if (main_query.empty()) {
@@ -185,7 +185,7 @@ void DatabaseActivityInfo::InsertOrUpdate(mojom::PublisherInfoPtr info,
   }
 
   auto transaction = mojom::DBTransaction::New();
-  const std::string query = base::StringPrintf(
+  const std::string query = absl::StrFormat(
       "INSERT OR REPLACE INTO %s "
       "(publisher_id, duration, score, percent, "
       "weight, reconcile_stamp, visits) "
@@ -223,7 +223,7 @@ void DatabaseActivityInfo::GetRecordsList(
 
   auto transaction = mojom::DBTransaction::New();
 
-  std::string query = base::StringPrintf(
+  std::string query = absl::StrFormat(
       "SELECT ai.publisher_id, ai.duration, ai.score, "
       "ai.percent, ai.weight, spi.status, spi.updated_at, pi.excluded, "
       "pi.name, pi.url, pi.provider, "
@@ -311,7 +311,7 @@ void DatabaseActivityInfo::DeleteRecord(const std::string& publisher_key,
 
   auto transaction = mojom::DBTransaction::New();
 
-  const std::string query = base::StringPrintf(
+  const std::string query = absl::StrFormat(
       "DELETE FROM %s WHERE publisher_id = ? AND reconcile_stamp = ?",
       kTableName);
 
@@ -333,7 +333,7 @@ void DatabaseActivityInfo::GetPublishersVisitedCount(
     base::OnceCallback<void(int)> callback) {
   auto transaction = mojom::DBTransaction::New();
 
-  std::string query = base::StringPrintf(
+  std::string query = absl::StrFormat(
       "SELECT COUNT(DISTINCT ai.publisher_id) "
       "FROM %s AS ai INNER JOIN server_publisher_info AS spi "
       "ON spi.publisher_key = ai.publisher_id "

--- a/components/brave_rewards/core/engine/database/database_balance_report.cc
+++ b/components/brave_rewards/core/engine/database/database_balance_report.cc
@@ -21,7 +21,7 @@ namespace {
 constexpr char kTableName[] = "balance_report_info";
 
 std::string GetBalanceReportId(mojom::ActivityMonth month, int year) {
-  return base::StringPrintf("%u_%u", year, base::to_underlying(month));
+  return absl::StrFormat("%u_%u", year, base::to_underlying(month));
 }
 
 std::string GetTypeColumn(mojom::ReportType type) {
@@ -63,7 +63,7 @@ void DatabaseBalanceReport::InsertOrUpdate(mojom::BalanceReportInfoPtr info,
 
   auto transaction = mojom::DBTransaction::New();
 
-  const std::string query = base::StringPrintf(
+  const std::string query = absl::StrFormat(
       "INSERT OR REPLACE INTO %s "
       "(balance_report_id, grants_ugp, grants_ads, auto_contribute, "
       "tip_recurring, tip) "
@@ -99,7 +99,7 @@ void DatabaseBalanceReport::InsertOrUpdateList(
 
   auto transaction = mojom::DBTransaction::New();
 
-  const std::string query = base::StringPrintf(
+  const std::string query = absl::StrFormat(
       "INSERT OR REPLACE INTO %s "
       "(balance_report_id, grants_ugp, grants_ads, auto_contribute, "
       "tip_recurring, tip) "
@@ -141,7 +141,7 @@ void DatabaseBalanceReport::SetAmount(mojom::ActivityMonth month,
 
   const std::string id = GetBalanceReportId(month, year);
 
-  const std::string insert_query = base::StringPrintf(
+  const std::string insert_query = absl::StrFormat(
       "INSERT OR IGNORE INTO %s "
       "(balance_report_id, grants_ugp, grants_ads, auto_contribute, "
       "tip_recurring, tip) "
@@ -154,9 +154,9 @@ void DatabaseBalanceReport::SetAmount(mojom::ActivityMonth month,
   BindString(command.get(), 0, id);
   transaction->commands.push_back(std::move(command));
 
-  const std::string update_query = base::StringPrintf(
-      "UPDATE %s SET %s = %s + ? WHERE balance_report_id = ?", kTableName,
-      GetTypeColumn(type).c_str(), GetTypeColumn(type).c_str());
+  const std::string update_query =
+      absl::StrFormat("UPDATE %s SET %s = %s + ? WHERE balance_report_id = ?",
+                      kTableName, GetTypeColumn(type), GetTypeColumn(type));
 
   command = mojom::DBCommand::New();
   command->type = mojom::DBCommand::Type::RUN;
@@ -183,7 +183,7 @@ void DatabaseBalanceReport::GetRecord(
   auto transaction = mojom::DBTransaction::New();
 
   // when new month starts we need to insert blank values
-  const std::string insert_query = base::StringPrintf(
+  const std::string insert_query = absl::StrFormat(
       "INSERT OR IGNORE INTO %s "
       "(balance_report_id, grants_ugp, grants_ads, auto_contribute, "
       "tip_recurring, tip) "
@@ -196,7 +196,7 @@ void DatabaseBalanceReport::GetRecord(
   BindString(command.get(), 0, GetBalanceReportId(month, year));
   transaction->commands.push_back(std::move(command));
 
-  const std::string select_query = base::StringPrintf(
+  const std::string select_query = absl::StrFormat(
       "SELECT balance_report_id, grants_ugp, grants_ads, "
       "auto_contribute, tip_recurring, tip "
       "FROM %s WHERE balance_report_id = ?",
@@ -254,7 +254,7 @@ void DatabaseBalanceReport::GetAllRecords(
     GetBalanceReportListCallback callback) {
   auto transaction = mojom::DBTransaction::New();
 
-  const std::string query = base::StringPrintf(
+  const std::string query = absl::StrFormat(
       "SELECT balance_report_id, grants_ugp, grants_ads, "
       "auto_contribute, tip_recurring, tip "
       "FROM %s",
@@ -310,7 +310,7 @@ void DatabaseBalanceReport::OnGetAllRecords(
 void DatabaseBalanceReport::DeleteAllRecords(ResultCallback callback) {
   auto transaction = mojom::DBTransaction::New();
 
-  const std::string query = base::StringPrintf("DELETE FROM %s", kTableName);
+  const std::string query = absl::StrFormat("DELETE FROM %s", kTableName);
 
   auto command = mojom::DBCommand::New();
   command->type = mojom::DBCommand::Type::EXECUTE;

--- a/components/brave_rewards/core/engine/database/database_contribution_info.cc
+++ b/components/brave_rewards/core/engine/database/database_contribution_info.cc
@@ -45,7 +45,7 @@ void DatabaseContributionInfo::InsertOrUpdate(mojom::ContributionInfoPtr info,
 
   auto transaction = mojom::DBTransaction::New();
 
-  const std::string query = base::StringPrintf(
+  const std::string query = absl::StrFormat(
       "INSERT OR REPLACE INTO %s "
       "(contribution_id, amount, type, step, retry_count, created_at, "
       "processor) "
@@ -77,7 +77,7 @@ void DatabaseContributionInfo::GetRecord(const std::string& contribution_id,
                                          GetContributionInfoCallback callback) {
   auto transaction = mojom::DBTransaction::New();
 
-  const std::string query = base::StringPrintf(
+  const std::string query = absl::StrFormat(
       "SELECT ci.contribution_id, ci.amount, ci.type, ci.step, ci.retry_count, "
       "ci.processor, ci.created_at "
       "FROM %s as ci "
@@ -159,7 +159,7 @@ void DatabaseContributionInfo::GetAllRecords(
     ContributionInfoListCallback callback) {
   auto transaction = mojom::DBTransaction::New();
 
-  const std::string query = base::StringPrintf(
+  const std::string query = absl::StrFormat(
       "SELECT ci.contribution_id, ci.amount, ci.type, ci.step, ci.retry_count,"
       "ci.processor, ci.created_at "
       "FROM %s as ci ",
@@ -196,7 +196,7 @@ void DatabaseContributionInfo::GetOneTimeTips(const mojom::ActivityMonth month,
 
   auto transaction = mojom::DBTransaction::New();
 
-  const std::string query = base::StringPrintf(
+  const std::string query = absl::StrFormat(
       "SELECT pi.publisher_id, pi.name, pi.url, pi.favIcon, "
       "ci.amount, ci.created_at, spi.status, spi.updated_at, pi.provider "
       "FROM %s as ci "
@@ -215,7 +215,7 @@ void DatabaseContributionInfo::GetOneTimeTips(const mojom::ActivityMonth month,
   command->command = query;
 
   const std::string formatted_month =
-      base::StringPrintf("%02d", base::to_underlying(month));
+      absl::StrFormat("%02d", base::to_underlying(month));
 
   BindString(command.get(), 0, formatted_month);
   BindString(command.get(), 1, base::NumberToString(year));
@@ -299,7 +299,7 @@ void DatabaseContributionInfo::GetNotCompletedRecords(
 
   transaction->commands.push_back(std::move(revive_command));
 
-  const std::string query = base::StringPrintf(
+  const std::string query = absl::StrFormat(
       "SELECT ci.contribution_id, ci.amount, ci.type, ci.step, ci.retry_count, "
       "ci.processor, ci.created_at "
       "FROM %s as ci WHERE ci.step > 0",
@@ -393,7 +393,7 @@ void DatabaseContributionInfo::UpdateStep(const std::string& contribution_id,
 
   auto transaction = mojom::DBTransaction::New();
 
-  const std::string query = base::StringPrintf(
+  const std::string query = absl::StrFormat(
       "UPDATE %s SET step=?, retry_count=0 WHERE contribution_id = ?",
       kTableName);
 
@@ -424,7 +424,7 @@ void DatabaseContributionInfo::UpdateStepAndCount(
 
   auto transaction = mojom::DBTransaction::New();
 
-  const std::string query = base::StringPrintf(
+  const std::string query = absl::StrFormat(
       "UPDATE %s SET step=?, retry_count=? WHERE contribution_id = ?;",
       kTableName);
 
@@ -454,7 +454,7 @@ void DatabaseContributionInfo::UpdateContributedAmount(
 void DatabaseContributionInfo::FinishAllInProgressRecords(
     ResultCallback callback) {
   auto transaction = mojom::DBTransaction::New();
-  const std::string query = base::StringPrintf(
+  const std::string query = absl::StrFormat(
       "UPDATE %s SET step = ?, retry_count = 0 WHERE step >= 0", kTableName);
 
   auto command = mojom::DBCommand::New();

--- a/components/brave_rewards/core/engine/database/database_contribution_info_publishers.cc
+++ b/components/brave_rewards/core/engine/database/database_contribution_info_publishers.cc
@@ -38,7 +38,7 @@ void DatabaseContributionInfoPublishers::InsertOrUpdate(
     return;
   }
 
-  const std::string query = base::StringPrintf(
+  const std::string query = absl::StrFormat(
       "INSERT OR REPLACE INTO %s "
       "(contribution_id, publisher_key, total_amount, contributed_amount) "
       "VALUES (?, ?, ?, ?)",
@@ -68,10 +68,10 @@ void DatabaseContributionInfoPublishers::GetRecordByContributionList(
 
   auto transaction = mojom::DBTransaction::New();
 
-  const std::string query = base::StringPrintf(
+  const std::string query = absl::StrFormat(
       "SELECT contribution_id, publisher_key, total_amount, contributed_amount "
       "FROM %s WHERE contribution_id IN (%s)",
-      kTableName, GenerateStringInCase(contribution_ids).c_str());
+      kTableName, GenerateStringInCase(contribution_ids));
 
   auto command = mojom::DBCommand::New();
   command->type = mojom::DBCommand::Type::READ;
@@ -128,7 +128,7 @@ void DatabaseContributionInfoPublishers::GetContributionPublisherPairList(
 
   auto transaction = mojom::DBTransaction::New();
 
-  const std::string query = base::StringPrintf(
+  const std::string query = absl::StrFormat(
       "SELECT cip.contribution_id, cip.publisher_key, cip.total_amount, "
       "pi.name, pi.url, pi.favIcon, spi.status, spi.updated_at, pi.provider "
       "FROM %s as cip "
@@ -136,7 +136,7 @@ void DatabaseContributionInfoPublishers::GetContributionPublisherPairList(
       "LEFT JOIN server_publisher_info AS spi "
       "ON spi.publisher_key = cip.publisher_key "
       "WHERE cip.contribution_id IN (%s)",
-      kTableName, GenerateStringInCase(contribution_ids).c_str());
+      kTableName, GenerateStringInCase(contribution_ids));
 
   auto command = mojom::DBCommand::New();
   command->type = mojom::DBCommand::Type::READ;
@@ -206,7 +206,7 @@ void DatabaseContributionInfoPublishers::UpdateContributedAmount(
 
   auto transaction = mojom::DBTransaction::New();
 
-  const std::string query = base::StringPrintf(
+  const std::string query = absl::StrFormat(
       "UPDATE %s SET contributed_amount="
       "(SELECT total_amount WHERE contribution_id = ? AND publisher_key = ?) "
       "WHERE contribution_id = ? AND publisher_key = ?;",

--- a/components/brave_rewards/core/engine/database/database_contribution_queue.cc
+++ b/components/brave_rewards/core/engine/database/database_contribution_queue.cc
@@ -44,7 +44,7 @@ void DatabaseContributionQueue::InsertOrUpdate(mojom::ContributionQueuePtr info,
 
   auto transaction = mojom::DBTransaction::New();
 
-  const std::string query = base::StringPrintf(
+  const std::string query = absl::StrFormat(
       "INSERT OR REPLACE INTO %s (contribution_queue_id, type, amount, "
       "partial) "
       "VALUES (?, ?, ?, ?)",
@@ -89,7 +89,7 @@ void DatabaseContributionQueue::GetFirstRecord(
     GetFirstContributionQueueCallback callback) {
   auto transaction = mojom::DBTransaction::New();
 
-  const std::string query = base::StringPrintf(
+  const std::string query = absl::StrFormat(
       "SELECT contribution_queue_id, type, amount, partial "
       "FROM %s WHERE completed_at = 0 "
       "ORDER BY created_at ASC LIMIT 1",
@@ -165,7 +165,7 @@ void DatabaseContributionQueue::MarkRecordAsComplete(const std::string& id,
 
   auto transaction = mojom::DBTransaction::New();
 
-  const std::string query = base::StringPrintf(
+  const std::string query = absl::StrFormat(
       "UPDATE %s SET completed_at = ? WHERE contribution_queue_id = ?",
       kTableName);
 

--- a/components/brave_rewards/core/engine/database/database_contribution_queue_publishers.cc
+++ b/components/brave_rewards/core/engine/database/database_contribution_queue_publishers.cc
@@ -40,7 +40,7 @@ void DatabaseContributionQueuePublishers::InsertOrUpdate(
 
   auto transaction = mojom::DBTransaction::New();
 
-  const std::string query = base::StringPrintf(
+  const std::string query = absl::StrFormat(
       "INSERT OR REPLACE INTO %s "
       "(contribution_queue_id, publisher_key, amount_percent) VALUES (?, ?, ?)",
       kTableName);
@@ -73,7 +73,7 @@ void DatabaseContributionQueuePublishers::GetRecordsByQueueId(
 
   auto transaction = mojom::DBTransaction::New();
 
-  const std::string query = base::StringPrintf(
+  const std::string query = absl::StrFormat(
       "SELECT publisher_key, amount_percent "
       "FROM %s WHERE contribution_queue_id = ?",
       kTableName);

--- a/components/brave_rewards/core/engine/database/database_creds_batch.cc
+++ b/components/brave_rewards/core/engine/database/database_creds_batch.cc
@@ -35,7 +35,7 @@ void DatabaseCredsBatch::InsertOrUpdate(mojom::CredsBatchPtr creds,
 
   auto transaction = mojom::DBTransaction::New();
 
-  const std::string query = base::StringPrintf(
+  const std::string query = absl::StrFormat(
       "INSERT OR REPLACE INTO %s "
       "(creds_id, trigger_id, trigger_type, creds, blinded_creds, "
       "signed_creds, public_key, batch_proof, status) "
@@ -70,7 +70,7 @@ void DatabaseCredsBatch::GetRecordByTrigger(
   DCHECK(!trigger_id.empty());
   auto transaction = mojom::DBTransaction::New();
 
-  const std::string query = base::StringPrintf(
+  const std::string query = absl::StrFormat(
       "SELECT creds_id, trigger_id, trigger_type, creds, blinded_creds, "
       "signed_creds, public_key, batch_proof, status FROM %s "
       "WHERE trigger_id = ? AND trigger_type = ?",
@@ -144,7 +144,7 @@ void DatabaseCredsBatch::SaveSignedCreds(mojom::CredsBatchPtr creds,
 
   auto transaction = mojom::DBTransaction::New();
 
-  const std::string query = base::StringPrintf(
+  const std::string query = absl::StrFormat(
       "UPDATE %s SET signed_creds = ?, public_key = ?, batch_proof = ?, "
       "status = ? WHERE trigger_id = ? AND trigger_type = ?",
       kTableName);
@@ -170,7 +170,7 @@ void DatabaseCredsBatch::SaveSignedCreds(mojom::CredsBatchPtr creds,
 void DatabaseCredsBatch::GetAllRecords(GetCredsBatchListCallback callback) {
   auto transaction = mojom::DBTransaction::New();
 
-  const std::string query = base::StringPrintf(
+  const std::string query = absl::StrFormat(
       "SELECT creds_id, trigger_id, trigger_type, creds, blinded_creds, "
       "signed_creds, public_key, batch_proof, status FROM %s",
       kTableName);
@@ -239,7 +239,7 @@ void DatabaseCredsBatch::UpdateStatus(const std::string& trigger_id,
 
   auto transaction = mojom::DBTransaction::New();
 
-  const std::string query = base::StringPrintf(
+  const std::string query = absl::StrFormat(
       "UPDATE %s SET status = ? WHERE trigger_id = ? AND trigger_type = ?",
       kTableName);
 
@@ -271,9 +271,9 @@ void DatabaseCredsBatch::UpdateRecordsStatus(
 
   auto transaction = mojom::DBTransaction::New();
 
-  const std::string query = base::StringPrintf(
+  const std::string query = absl::StrFormat(
       "UPDATE %s SET status = ? WHERE trigger_id IN (%s) AND trigger_type = ?",
-      kTableName, GenerateStringInCase(trigger_ids).c_str());
+      kTableName, GenerateStringInCase(trigger_ids));
 
   auto command = mojom::DBCommand::New();
   command->type = mojom::DBCommand::Type::RUN;
@@ -294,11 +294,11 @@ void DatabaseCredsBatch::GetRecordsByTriggers(
     GetCredsBatchListCallback callback) {
   auto transaction = mojom::DBTransaction::New();
 
-  const std::string query = base::StringPrintf(
+  const std::string query = absl::StrFormat(
       "SELECT creds_id, trigger_id, trigger_type, creds, blinded_creds, "
       "signed_creds, public_key, batch_proof, status FROM %s "
       "WHERE trigger_id IN (%s)",
-      kTableName, GenerateStringInCase(trigger_ids).c_str());
+      kTableName, GenerateStringInCase(trigger_ids));
 
   auto command = mojom::DBCommand::New();
   command->type = mojom::DBCommand::Type::READ;

--- a/components/brave_rewards/core/engine/database/database_event_log.cc
+++ b/components/brave_rewards/core/engine/database/database_event_log.cc
@@ -37,7 +37,7 @@ void DatabaseEventLog::Insert(const std::string& key,
 
   auto transaction = mojom::DBTransaction::New();
 
-  const std::string query = base::StringPrintf(
+  const std::string query = absl::StrFormat(
       "INSERT INTO %s (event_log_id, key, value, created_at) "
       "VALUES (?, ?, ?, ?)",
       kTableName);
@@ -69,17 +69,16 @@ void DatabaseEventLog::InsertRecords(
 
   auto transaction = mojom::DBTransaction::New();
   auto time = util::GetCurrentTimeStamp();
-  const std::string base_query = base::StringPrintf(
+  const std::string base_query = absl::StrFormat(
       "INSERT INTO %s (event_log_id, key, value, created_at) VALUES ",
       kTableName);
 
   std::string query = base_query;
   for (const auto& record : records) {
-    query += base::StringPrintf(
-        R"(('%s','%s','%s',%u),)",
-        base::Uuid::GenerateRandomV4().AsLowercaseString().c_str(),
-        record.first.c_str(), record.second.c_str(),
-        static_cast<uint32_t>(time));
+    query += absl::StrFormat(R"(('%s','%s','%s',%u),)",
+                             base::Uuid::GenerateRandomV4().AsLowercaseString(),
+                             record.first, record.second,
+                             static_cast<uint32_t>(time));
   }
 
   query.pop_back();
@@ -97,7 +96,7 @@ void DatabaseEventLog::InsertRecords(
 void DatabaseEventLog::GetLastRecords(GetEventLogsCallback callback) {
   auto transaction = mojom::DBTransaction::New();
 
-  const std::string query = base::StringPrintf(
+  const std::string query = absl::StrFormat(
       "SELECT event_log_id, key, value, created_at "
       "FROM %s ORDER BY created_at DESC, ROWID DESC LIMIT 2000",
       kTableName);

--- a/components/brave_rewards/core/engine/database/database_external_transactions.cc
+++ b/components/brave_rewards/core/engine/database/database_external_transactions.cc
@@ -33,7 +33,7 @@ void DatabaseExternalTransactions::Insert(
 
   auto command = mojom::DBCommand::New();
   command->type = mojom::DBCommand::Type::RUN;
-  command->command = base::StringPrintf(
+  command->command = absl::StrFormat(
       R"(
         INSERT INTO %s (transaction_id, contribution_id, destination, amount)
         VALUES(?, ?, ?, ?)
@@ -69,7 +69,7 @@ void DatabaseExternalTransactions::GetTransaction(
     GetExternalTransactionCallback callback) {
   auto command = mojom::DBCommand::New();
   command->type = mojom::DBCommand::Type::READ;
-  command->command = base::StringPrintf(
+  command->command = absl::StrFormat(
       R"(
         SELECT transaction_id, contribution_id, destination, amount
         FROM %s

--- a/components/brave_rewards/core/engine/database/database_media_publisher_info.cc
+++ b/components/brave_rewards/core/engine/database/database_media_publisher_info.cc
@@ -38,7 +38,7 @@ void DatabaseMediaPublisherInfo::InsertOrUpdate(
 
   auto transaction = mojom::DBTransaction::New();
 
-  const std::string query = base::StringPrintf(
+  const std::string query = absl::StrFormat(
       "INSERT OR REPLACE INTO %s (media_key, publisher_id) VALUES (?, ?)",
       kTableName);
 
@@ -65,7 +65,7 @@ void DatabaseMediaPublisherInfo::GetRecord(const std::string& media_key,
 
   auto transaction = mojom::DBTransaction::New();
 
-  const std::string query = base::StringPrintf(
+  const std::string query = absl::StrFormat(
       "SELECT pi.publisher_id, pi.name, pi.url, pi.favIcon, "
       "pi.provider, spi.status, spi.updated_at, pi.excluded "
       "FROM %s as mpi "

--- a/components/brave_rewards/core/engine/database/database_migration.cc
+++ b/components/brave_rewards/core/engine/database/database_migration.cc
@@ -206,7 +206,7 @@ void DatabaseMigration::RunDBTransactionCallback(
     if (migrated_version >= 29) {
       engine_->database()->SaveEventLog(
           log::kDatabaseMigrated,
-          base::StringPrintf("%d->%d", start_version - 1, migrated_version));
+          absl::StrFormat("%d->%d", start_version - 1, migrated_version));
     }
 
     return std::move(callback).Run(mojom::Result::OK);

--- a/components/brave_rewards/core/engine/database/database_migration_unittest.cc
+++ b/components/brave_rewards/core/engine/database/database_migration_unittest.cc
@@ -85,7 +85,7 @@ class RewardsDatabaseMigrationTest : public RewardsEngineTest {
 
   void InitializeDatabaseAtVersion(int version) {
     base::FilePath path = GetTestDataPath().AppendASCII(
-        base::StringPrintf("publisher_info_db_v%d.sql", version));
+        absl::StrFormat("publisher_info_db_v%d.sql", version));
 
     std::string init_script;
     ASSERT_TRUE(base::ReadFileToString(path, &init_script));
@@ -93,8 +93,7 @@ class RewardsDatabaseMigrationTest : public RewardsEngineTest {
   }
 
   int CountTableRows(const std::string& table) {
-    const std::string sql =
-        base::StringPrintf("SELECT COUNT(*) FROM %s", table.c_str());
+    const std::string sql = absl::StrFormat("SELECT COUNT(*) FROM %s", table);
     sql::Statement s(GetDB()->GetUniqueStatement(sql));
     return s.Step() ? static_cast<int>(s.ColumnInt64(0)) : -1;
   }

--- a/components/brave_rewards/core/engine/database/database_publisher_info.cc
+++ b/components/brave_rewards/core/engine/database/database_publisher_info.cc
@@ -39,7 +39,7 @@ void DatabasePublisherInfo::InsertOrUpdate(mojom::PublisherInfoPtr info,
 
   auto transaction = mojom::DBTransaction::New();
 
-  const std::string query = base::StringPrintf(
+  const std::string query = absl::StrFormat(
       "INSERT OR REPLACE INTO %s "
       "(publisher_id, excluded, name, url, provider, favIcon) "
       "VALUES (?, ?, ?, ?, ?, "
@@ -63,7 +63,7 @@ void DatabasePublisherInfo::InsertOrUpdate(mojom::PublisherInfoPtr info,
 
   std::string favicon = info->favicon_url;
   if (!favicon.empty() && !info->provider.empty()) {
-    const std::string query_icon = base::StringPrintf(
+    const std::string query_icon = absl::StrFormat(
         "UPDATE %s SET favIcon = ? WHERE publisher_id = ?;", kTableName);
 
     auto command_icon = mojom::DBCommand::New();
@@ -95,7 +95,7 @@ void DatabasePublisherInfo::GetRecord(const std::string& publisher_key,
 
   auto transaction = mojom::DBTransaction::New();
 
-  const std::string query = base::StringPrintf(
+  const std::string query = absl::StrFormat(
       "SELECT pi.publisher_id, pi.name, pi.url, pi.favIcon, pi.provider, "
       "spi.status, spi.updated_at, pi.excluded "
       "FROM %s as pi "
@@ -167,7 +167,7 @@ void DatabasePublisherInfo::GetPanelRecord(
 
   auto transaction = mojom::DBTransaction::New();
 
-  const std::string query = base::StringPrintf(
+  const std::string query = absl::StrFormat(
       "SELECT pi.publisher_id, pi.name, pi.url, pi.favIcon, "
       "pi.provider, spi.status, pi.excluded, "
       "("
@@ -237,8 +237,8 @@ void DatabasePublisherInfo::OnGetPanelRecord(
 
 void DatabasePublisherInfo::RestorePublishers(ResultCallback callback) {
   auto transaction = mojom::DBTransaction::New();
-  const std::string query = base::StringPrintf(
-      "UPDATE %s SET excluded=? WHERE excluded=?", kTableName);
+  const std::string query =
+      absl::StrFormat("UPDATE %s SET excluded=? WHERE excluded=?", kTableName);
 
   auto command = mojom::DBCommand::New();
   command->type = mojom::DBCommand::Type::RUN;
@@ -271,7 +271,7 @@ void DatabasePublisherInfo::OnRestorePublishers(
 
 void DatabasePublisherInfo::GetExcludedList(GetExcludedListCallback callback) {
   auto transaction = mojom::DBTransaction::New();
-  const std::string query = base::StringPrintf(
+  const std::string query = absl::StrFormat(
       "SELECT pi.publisher_id, spi.status, pi.name,"
       "pi.favicon, pi.url, pi.provider "
       "FROM %s as pi "

--- a/components/brave_rewards/core/engine/database/database_recurring_tip.cc
+++ b/components/brave_rewards/core/engine/database/database_recurring_tip.cc
@@ -49,7 +49,7 @@ void DatabaseRecurringTip::InsertOrUpdate(mojom::RecurringTipPtr info,
 
   auto transaction = mojom::DBTransaction::New();
 
-  const std::string query = base::StringPrintf(
+  const std::string query = absl::StrFormat(
       "INSERT OR REPLACE INTO %s "
       "(publisher_id, amount, added_date) "
       "VALUES (?, ?, ?)",
@@ -90,7 +90,7 @@ void DatabaseRecurringTip::InsertOrUpdate(
 
   auto command = mojom::DBCommand::New();
   command->type = mojom::DBCommand::Type::RUN;
-  command->command = base::StringPrintf(
+  command->command = absl::StrFormat(
       "INSERT OR REPLACE INTO %s "
       "(publisher_id, amount, added_date, next_contribution_at) "
       "VALUES (?, ?, ?, ?)",
@@ -116,7 +116,7 @@ void DatabaseRecurringTip::InsertOrUpdate(
 void DatabaseRecurringTip::AdvanceMonthlyContributionDates(
     const std::vector<std::string>& publisher_ids,
     base::OnceCallback<void(bool)> callback) {
-  const std::string query = base::StringPrintf(
+  const std::string query = absl::StrFormat(
       "UPDATE %s SET next_contribution_at = ? WHERE publisher_id = ?",
       kTableName);
 
@@ -151,7 +151,7 @@ void DatabaseRecurringTip::GetNextMonthlyContributionTime(
 
   auto command = mojom::DBCommand::New();
   command->type = mojom::DBCommand::Type::RUN;
-  command->command = base::StringPrintf(
+  command->command = absl::StrFormat(
       "UPDATE %s SET next_contribution_at = ? "
       "WHERE next_contribution_at IS NULL",
       kTableName);
@@ -160,8 +160,8 @@ void DatabaseRecurringTip::GetNextMonthlyContributionTime(
 
   command = mojom::DBCommand::New();
   command->type = mojom::DBCommand::Type::READ;
-  command->command = base::StringPrintf(
-      "SELECT MIN(next_contribution_at) FROM %s", kTableName);
+  command->command =
+      absl::StrFormat("SELECT MIN(next_contribution_at) FROM %s", kTableName);
   command->record_bindings = {mojom::DBCommand::RecordBindingType::INT64_TYPE};
   transaction->commands.push_back(std::move(command));
 
@@ -195,7 +195,7 @@ void DatabaseRecurringTip::GetNextMonthlyContributionTime(
 void DatabaseRecurringTip::GetAllRecords(GetRecurringTipsCallback callback) {
   auto transaction = mojom::DBTransaction::New();
 
-  const std::string query = base::StringPrintf(
+  const std::string query = absl::StrFormat(
       "SELECT pi.publisher_id, pi.name, pi.url, pi.favIcon, "
       "rd.amount, rd.next_contribution_at, spi.status, spi.updated_at, "
       "pi.provider "
@@ -275,7 +275,7 @@ void DatabaseRecurringTip::DeleteRecord(const std::string& publisher_key,
   auto transaction = mojom::DBTransaction::New();
 
   const std::string query =
-      base::StringPrintf("DELETE FROM %s WHERE publisher_id = ?", kTableName);
+      absl::StrFormat("DELETE FROM %s WHERE publisher_id = ?", kTableName);
 
   auto command = mojom::DBCommand::New();
   command->type = mojom::DBCommand::Type::RUN;

--- a/components/brave_rewards/core/engine/database/database_server_publisher_banner.cc
+++ b/components/brave_rewards/core/engine/database/database_server_publisher_banner.cc
@@ -42,7 +42,7 @@ void DatabaseServerPublisherBanner::InsertOrUpdate(
 
   auto command = mojom::DBCommand::New();
   command->type = mojom::DBCommand::Type::RUN;
-  command->command = base::StringPrintf(
+  command->command = absl::StrFormat(
       "INSERT OR REPLACE INTO %s "
       "(publisher_key, title, description, background, logo, web3_url) "
       "VALUES (?, ?, ?, ?, ?, ?)",
@@ -71,8 +71,8 @@ void DatabaseServerPublisherBanner::DeleteRecords(
   auto command = mojom::DBCommand::New();
   command->type = mojom::DBCommand::Type::RUN;
   command->command =
-      base::StringPrintf("DELETE FROM %s WHERE publisher_key IN (%s)",
-                         kTableName, publisher_key_list.c_str());
+      absl::StrFormat("DELETE FROM %s WHERE publisher_key IN (%s)", kTableName,
+                      publisher_key_list);
 
   transaction->commands.push_back(std::move(command));
 
@@ -88,7 +88,7 @@ void DatabaseServerPublisherBanner::GetRecord(
     return;
   }
   auto transaction = mojom::DBTransaction::New();
-  const std::string query = base::StringPrintf(
+  const std::string query = absl::StrFormat(
       "SELECT title, description, background, logo, web3_url "
       "FROM %s "
       "WHERE publisher_key=?",

--- a/components/brave_rewards/core/engine/database/database_server_publisher_info.cc
+++ b/components/brave_rewards/core/engine/database/database_server_publisher_info.cc
@@ -39,7 +39,7 @@ void DatabaseServerPublisherInfo::InsertOrUpdate(
 
   auto command = mojom::DBCommand::New();
   command->type = mojom::DBCommand::Type::RUN;
-  command->command = base::StringPrintf(
+  command->command = absl::StrFormat(
       "INSERT OR REPLACE INTO %s "
       "(publisher_key, status, address, updated_at) "
       "VALUES (?, ?, ?, ?)",
@@ -80,7 +80,7 @@ void DatabaseServerPublisherInfo::OnGetRecordBanner(
     GetServerPublisherInfoCallback callback,
     mojom::PublisherBannerPtr banner) {
   auto transaction = mojom::DBTransaction::New();
-  const std::string query = base::StringPrintf(
+  const std::string query = absl::StrFormat(
       "SELECT status, address, updated_at "
       "FROM %s WHERE publisher_key=?",
       kTableName);
@@ -149,7 +149,7 @@ void DatabaseServerPublisherInfo::DeleteExpiredRecords(
   // Get a list of publisher keys that are older than |max_age_seconds|.
   auto command = mojom::DBCommand::New();
   command->type = mojom::DBCommand::Type::READ;
-  command->command = base::StringPrintf(
+  command->command = absl::StrFormat(
       "SELECT publisher_key FROM %s WHERE updated_at < ?", kTableName);
   BindInt64(command.get(), 0, cutoff);
 
@@ -195,8 +195,8 @@ void DatabaseServerPublisherInfo::OnExpiredRecordsSelected(
   auto command = mojom::DBCommand::New();
   command->type = mojom::DBCommand::Type::RUN;
   command->command =
-      base::StringPrintf("DELETE FROM %s WHERE publisher_key IN (%s)",
-                         kTableName, publisher_key_list.c_str());
+      absl::StrFormat("DELETE FROM %s WHERE publisher_key IN (%s)", kTableName,
+                      publisher_key_list);
 
   transaction->commands.push_back(std::move(command));
 

--- a/components/brave_rewards/core/engine/database/database_server_publisher_links.cc
+++ b/components/brave_rewards/core/engine/database/database_server_publisher_links.cc
@@ -42,7 +42,7 @@ void DatabaseServerPublisherLinks::InsertOrUpdate(
 
     auto command = mojom::DBCommand::New();
     command->type = mojom::DBCommand::Type::RUN;
-    command->command = base::StringPrintf(
+    command->command = absl::StrFormat(
         "INSERT OR REPLACE INTO %s (publisher_key, provider, link) "
         "VALUES (?, ?, ?)",
         kTableName);
@@ -66,8 +66,8 @@ void DatabaseServerPublisherLinks::DeleteRecords(
   auto command = mojom::DBCommand::New();
   command->type = mojom::DBCommand::Type::RUN;
   command->command =
-      base::StringPrintf("DELETE FROM %s WHERE publisher_key IN (%s)",
-                         kTableName, publisher_key_list.c_str());
+      absl::StrFormat("DELETE FROM %s WHERE publisher_key IN (%s)", kTableName,
+                      publisher_key_list);
 
   transaction->commands.push_back(std::move(command));
 }
@@ -82,7 +82,7 @@ void DatabaseServerPublisherLinks::GetRecord(
   }
 
   auto transaction = mojom::DBTransaction::New();
-  const std::string query = base::StringPrintf(
+  const std::string query = absl::StrFormat(
       "SELECT provider, link FROM %s WHERE publisher_key=?", kTableName);
 
   auto command = mojom::DBCommand::New();

--- a/components/brave_rewards/core/engine/database/database_sku_order.cc
+++ b/components/brave_rewards/core/engine/database/database_sku_order.cc
@@ -35,7 +35,7 @@ void DatabaseSKUOrder::InsertOrUpdate(mojom::SKUOrderPtr order,
 
   auto transaction = mojom::DBTransaction::New();
 
-  const std::string query = base::StringPrintf(
+  const std::string query = absl::StrFormat(
       "INSERT OR REPLACE INTO %s "
       "(order_id, total_amount, merchant_id, location, status, "
       "contribution_id) "
@@ -73,7 +73,7 @@ void DatabaseSKUOrder::UpdateStatus(const std::string& order_id,
 
   auto transaction = mojom::DBTransaction::New();
 
-  const std::string query = base::StringPrintf(
+  const std::string query = absl::StrFormat(
       "UPDATE %s SET status = ? WHERE order_id = ?", kTableName);
 
   auto command = mojom::DBCommand::New();
@@ -100,7 +100,7 @@ void DatabaseSKUOrder::GetRecord(const std::string& order_id,
 
   auto transaction = mojom::DBTransaction::New();
 
-  const std::string query = base::StringPrintf(
+  const std::string query = absl::StrFormat(
       "SELECT order_id, total_amount, merchant_id, location, status, "
       "contribution_id, created_at FROM %s WHERE order_id = ?",
       kTableName);
@@ -183,7 +183,7 @@ void DatabaseSKUOrder::GetRecordByContributionId(
   }
   auto transaction = mojom::DBTransaction::New();
 
-  const std::string query = base::StringPrintf(
+  const std::string query = absl::StrFormat(
       "SELECT order_id, total_amount, merchant_id, location, status, "
       "contribution_id, created_at FROM %s WHERE contribution_id = ?",
       kTableName);
@@ -223,7 +223,7 @@ void DatabaseSKUOrder::SaveContributionIdForSKUOrder(
 
   auto transaction = mojom::DBTransaction::New();
 
-  const std::string query = base::StringPrintf(
+  const std::string query = absl::StrFormat(
       "UPDATE %s SET contribution_id = ? WHERE order_id = ?", kTableName);
 
   auto command = mojom::DBCommand::New();

--- a/components/brave_rewards/core/engine/database/database_sku_order_items.cc
+++ b/components/brave_rewards/core/engine/database/database_sku_order_items.cc
@@ -35,7 +35,7 @@ void DatabaseSKUOrderItems::InsertOrUpdateList(
     return;
   }
 
-  const std::string query = base::StringPrintf(
+  const std::string query = absl::StrFormat(
       "INSERT OR REPLACE INTO %s "
       "(order_item_id, order_id, sku, quantity, price, name, description, "
       "type, expires_at) "
@@ -72,7 +72,7 @@ void DatabaseSKUOrderItems::GetRecordsByOrderId(
 
   auto transaction = mojom::DBTransaction::New();
 
-  const std::string query = base::StringPrintf(
+  const std::string query = absl::StrFormat(
       "SELECT order_item_id, order_id, sku, quantity, price, name, "
       "description, type, expires_at FROM %s WHERE order_id = ?",
       kTableName);

--- a/components/brave_rewards/core/engine/database/database_sku_transaction.cc
+++ b/components/brave_rewards/core/engine/database/database_sku_transaction.cc
@@ -36,7 +36,7 @@ void DatabaseSKUTransaction::InsertOrUpdate(
 
   auto db_transaction = mojom::DBTransaction::New();
 
-  const std::string query = base::StringPrintf(
+  const std::string query = absl::StrFormat(
       "INSERT OR REPLACE INTO %s "
       "(transaction_id, order_id, external_transaction_id, type, amount, "
       "status) "
@@ -72,7 +72,7 @@ void DatabaseSKUTransaction::SaveExternalTransaction(
     return;
   }
 
-  const std::string query = base::StringPrintf(
+  const std::string query = absl::StrFormat(
       "UPDATE %s SET "
       "external_transaction_id = ?, status = ? WHERE transaction_id = ?",
       kTableName);
@@ -105,7 +105,7 @@ void DatabaseSKUTransaction::GetRecordByOrderId(
   }
   auto transaction = mojom::DBTransaction::New();
 
-  const std::string query = base::StringPrintf(
+  const std::string query = absl::StrFormat(
       "SELECT transaction_id, order_id, external_transaction_id, amount, type, "
       "status FROM %s WHERE order_id = ?",
       kTableName);

--- a/components/brave_rewards/core/engine/database/database_unblinded_token.cc
+++ b/components/brave_rewards/core/engine/database/database_unblinded_token.cc
@@ -41,7 +41,7 @@ void DatabaseUnblindedToken::InsertOrUpdateList(
 
   auto transaction = mojom::DBTransaction::New();
 
-  const std::string query = base::StringPrintf(
+  const std::string query = absl::StrFormat(
       "INSERT OR IGNORE INTO %s "
       "(token_id, token_value, public_key, value, creds_id, expires_at) "
       "VALUES (?, ?, ?, ?, ?, ?)",
@@ -104,7 +104,7 @@ void DatabaseUnblindedToken::GetSpendableRecords(
     GetUnblindedTokenListCallback callback) {
   auto command = mojom::DBCommand::New();
   command->type = mojom::DBCommand::Type::READ;
-  command->command = base::StringPrintf(
+  command->command = absl::StrFormat(
       R"(
     SELECT
       ut.token_id,
@@ -150,10 +150,10 @@ void DatabaseUnblindedToken::MarkRecordListAsSpent(
 
   auto transaction = mojom::DBTransaction::New();
 
-  const std::string query = base::StringPrintf(
+  const std::string query = absl::StrFormat(
       "UPDATE %s SET redeemed_at = ?, redeem_id = ?, redeem_type = ? "
       "WHERE token_id IN (%s)",
-      kTableName, GenerateStringInCase(ids).c_str());
+      kTableName, GenerateStringInCase(ids));
 
   auto command = mojom::DBCommand::New();
   command->type = mojom::DBCommand::Type::RUN;
@@ -184,13 +184,13 @@ void DatabaseUnblindedToken::MarkRecordListAsReserved(
 
   const std::string id_values = GenerateStringInCase(ids);
 
-  std::string query = base::StringPrintf(
+  std::string query = absl::StrFormat(
       "UPDATE %s SET redeem_id = ?, reserved_at = ? "
       "WHERE ( "
       "SELECT COUNT(*) FROM %s "
       "WHERE reserved_at = 0 AND redeemed_at = 0 AND token_id IN (%s) "
       ") = ? AND token_id IN (%s)",
-      kTableName, kTableName, id_values.c_str(), id_values.c_str());
+      kTableName, kTableName, id_values, id_values);
 
   auto command = mojom::DBCommand::New();
   command->type = mojom::DBCommand::Type::RUN;
@@ -216,10 +216,10 @@ void DatabaseUnblindedToken::MarkRecordListAsReserved(
 
   transaction->commands.push_back(std::move(command));
 
-  query = base::StringPrintf(
+  query = absl::StrFormat(
       "SELECT token_id FROM %s "
       "WHERE reserved_at != 0 AND token_id IN (%s)",
-      kTableName, id_values.c_str());
+      kTableName, id_values);
 
   command = mojom::DBCommand::New();
   command->type = mojom::DBCommand::Type::READ;
@@ -264,7 +264,7 @@ void DatabaseUnblindedToken::MarkRecordListAsSpendable(
 
   auto transaction = mojom::DBTransaction::New();
 
-  const std::string query = base::StringPrintf(
+  const std::string query = absl::StrFormat(
       "UPDATE %s SET redeem_id = '', reserved_at = 0 "
       "WHERE redeem_id = ? AND redeemed_at = 0",
       kTableName);
@@ -293,7 +293,7 @@ void DatabaseUnblindedToken::GetReservedRecordList(
 
   auto transaction = mojom::DBTransaction::New();
 
-  const std::string query = base::StringPrintf(
+  const std::string query = absl::StrFormat(
       "SELECT ut.token_id, ut.token_value, ut.public_key, ut.value, "
       "ut.creds_id, ut.expires_at FROM %s as ut "
       "WHERE ut.redeem_id = ? AND ut.redeemed_at = 0 AND ut.reserved_at != 0",
@@ -337,14 +337,14 @@ void DatabaseUnblindedToken::GetSpendableRecordListByBatchTypes(
 
   auto transaction = mojom::DBTransaction::New();
 
-  const std::string query = base::StringPrintf(
+  const std::string query = absl::StrFormat(
       "SELECT ut.token_id, ut.token_value, ut.public_key, ut.value, "
       "ut.creds_id, ut.expires_at FROM %s as ut "
       "LEFT JOIN creds_batch as cb ON cb.creds_id = ut.creds_id "
       "WHERE ut.redeemed_at = 0 AND "
       "(ut.expires_at > strftime('%%s','now') OR ut.expires_at = 0) AND "
       "(cb.trigger_type IN (%s) OR ut.creds_id IS NULL)",
-      kTableName, base::JoinString(in_case, ",").c_str());
+      kTableName, base::JoinString(in_case, ","));
 
   auto command = mojom::DBCommand::New();
   command->type = mojom::DBCommand::Type::READ;

--- a/components/brave_rewards/core/engine/database/database_util.cc
+++ b/components/brave_rewards/core/engine/database/database_util.cc
@@ -175,9 +175,7 @@ std::string GenerateStringInCase(const std::vector<std::string>& items) {
     return "";
   }
 
-  const std::string items_join = base::JoinString(items, "', '");
-
-  return base::StringPrintf("'%s'", items_join.c_str());
+  return absl::StrFormat("'%s'", base::JoinString(items, "', '"));
 }
 
 mojom::PublisherStatus PublisherStatusFromInt(int value) {

--- a/components/brave_rewards/core/engine/endpoints/brave/post_connect_bitflyer.cc
+++ b/components/brave_rewards/core/engine/endpoints/brave/post_connect_bitflyer.cc
@@ -39,7 +39,7 @@ std::optional<std::string> PostConnectBitflyer::Content() const {
 }
 
 std::string PostConnectBitflyer::Path(base::cstring_view payment_id) const {
-  return base::StringPrintf("/v3/wallet/bitflyer/%s/claim", payment_id.c_str());
+  return absl::StrFormat("/v3/wallet/bitflyer/%s/claim", payment_id);
 }
 
 }  // namespace brave_rewards::internal::endpoints

--- a/components/brave_rewards/core/engine/endpoints/brave/post_connect_gemini.cc
+++ b/components/brave_rewards/core/engine/endpoints/brave/post_connect_gemini.cc
@@ -48,7 +48,7 @@ std::optional<std::string> PostConnectGemini::Content() const {
 }
 
 std::string PostConnectGemini::Path(base::cstring_view payment_id) const {
-  return base::StringPrintf("/v3/wallet/gemini/%s/claim", payment_id.c_str());
+  return absl::StrFormat("/v3/wallet/gemini/%s/claim", payment_id);
 }
 
 }  // namespace brave_rewards::internal::endpoints

--- a/components/brave_rewards/core/engine/endpoints/brave/post_connect_uphold.cc
+++ b/components/brave_rewards/core/engine/endpoints/brave/post_connect_uphold.cc
@@ -104,7 +104,7 @@ std::optional<std::vector<std::string>> PostConnectUphold::Headers(
 }
 
 std::string PostConnectUphold::Path(base::cstring_view payment_id) const {
-  return base::StringPrintf("/v3/wallet/uphold/%s/claim", payment_id.c_str());
+  return absl::StrFormat("/v3/wallet/uphold/%s/claim", payment_id);
 }
 
 }  // namespace brave_rewards::internal::endpoints

--- a/components/brave_rewards/core/engine/endpoints/brave/post_connect_zebpay.cc
+++ b/components/brave_rewards/core/engine/endpoints/brave/post_connect_zebpay.cc
@@ -39,7 +39,7 @@ std::optional<std::string> PostConnectZebPay::Content() const {
 }
 
 std::string PostConnectZebPay::Path(base::cstring_view payment_id) const {
-  return base::StringPrintf("/v3/wallet/zebpay/%s/claim", payment_id.c_str());
+  return absl::StrFormat("/v3/wallet/zebpay/%s/claim", payment_id);
 }
 
 }  // namespace brave_rewards::internal::endpoints

--- a/components/brave_rewards/core/engine/endpoints/common/post_connect_unittest.cc
+++ b/components/brave_rewards/core/engine/endpoints/common/post_connect_unittest.cc
@@ -33,7 +33,7 @@ class PostConnectMock final : public endpoints::PostConnect {
 
  private:
   std::string Path(base::cstring_view payment_id) const override {
-    return base::StringPrintf("/v3/wallet/mock/%s/claim", payment_id.c_str());
+    return absl::StrFormat("/v3/wallet/mock/%s/claim", payment_id);
   }
 };
 

--- a/components/brave_rewards/core/engine/publisher/publisher.cc
+++ b/components/brave_rewards/core/engine/publisher/publisher.cc
@@ -821,15 +821,14 @@ std::string Publisher::GetShareURL(
   // with the supplied comment; otherwise, just tweet the comment.
   std::string share_url;
   if (tweet_id != args.end() && !tweet_id->second.empty()) {
-    const std::string quoted_tweet_url =
-        base::StringPrintf("https://twitter.com/%s/status/%s",
-                           name->second.c_str(), tweet_id->second.c_str());
-    share_url = base::StringPrintf(
-        "https://twitter.com/intent/tweet?text=%s&url=%s",
-        comment_with_hashtag.c_str(), quoted_tweet_url.c_str());
+    const std::string quoted_tweet_url = absl::StrFormat(
+        "https://twitter.com/%s/status/%s", name->second, tweet_id->second);
+    share_url =
+        absl::StrFormat("https://twitter.com/intent/tweet?text=%s&url=%s",
+                        comment_with_hashtag, quoted_tweet_url);
   } else {
-    share_url = base::StringPrintf("https://twitter.com/intent/tweet?text=%s",
-                                   comment_with_hashtag.c_str());
+    share_url = absl::StrFormat("https://twitter.com/intent/tweet?text=%s",
+                                comment_with_hashtag);
   }
 
   return share_url;


### PR DESCRIPTION
This PR has additional replacements for `base::StringPrintf` with the
underlying abseil implementation `absl::StrFormat`.

This is mostly a mechanical change.

Resolves https://github.com/brave/brave-browser/issues/47799
