### PR TITLE
Disable PartitionAllocShadowMetadata (uplift to 1.80.x)

### DIFF
--- a/patches/base-allocator-partition_alloc_features.cc.patch
+++ b/patches/base-allocator-partition_alloc_features.cc.patch
@@ -1,0 +1,13 @@
+diff --git a/base/allocator/partition_alloc_features.cc b/base/allocator/partition_alloc_features.cc
+index 240c8266a3205a79c541c7897b0f05ea049fcaf1..6478ff45bfb757bec5d212e73c91ea5e1a53323f 100644
+--- a/base/allocator/partition_alloc_features.cc
++++ b/base/allocator/partition_alloc_features.cc
+@@ -490,7 +490,7 @@ BASE_FEATURE(kPartitionAllocAdjustSizeWhenInForeground,
+ BASE_FEATURE(kPartitionAllocShadowMetadata,
+              "PartitionAllocShadowMetadata",
+ #if BUILDFLAG(IS_LINUX)
+-             FEATURE_ENABLED_BY_DEFAULT);
++             FEATURE_DISABLED_BY_DEFAULT);  // Brave: crbug.com/40238514
+ #else
+              FEATURE_DISABLED_BY_DEFAULT);
+ #endif


### PR DESCRIPTION
Uplift of #30170
Resolves https://github.com/brave/brave-browser/issues/47801

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.