### PR TITLE
[msan] Fix uninitialised read for `TestLocationBarModelDelegate`

### DIFF
--- a/browser/ui/views/split_view/split_view_location_bar_unittest.cc
+++ b/browser/ui/views/split_view/split_view_location_bar_unittest.cc
@@ -65,7 +65,8 @@ class TestLocationBarModelDelegate : public LocationBarModelDelegate {
 
  private:
   GURL url_;
-  security_state::SecurityLevel security_level_;
+  security_state::SecurityLevel security_level_{
+      security_state::SecurityLevel::NONE};
   net::CertStatus cert_status_ = 0;
   bool should_prevent_elision_ = false;
 };


### PR DESCRIPTION
This class' field, `security_level_`, is an enum value, and as it was
being left uninitialised, in certain cases, there were opportunities for
uninitialised reads, which is Undefined Behaviour.

Resolves https://github.com/brave/brave-browser/issues/47815
