### PR TITLE
Set Web view for AI chat side panel to focus on show (#30179) (uplift to 1.81.x).

### DIFF
--- a/browser/ui/views/side_panel/brave_side_panel_utils.cc
+++ b/browser/ui/views/side_panel/brave_side_panel_utils.cc
@@ -4,6 +4,7 @@
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #include "base/check.h"
+#include "base/functional/bind.h"
 #include "brave/browser/ai_chat/ai_chat_urls.h"
 #include "brave/browser/ui/webui/ai_chat/ai_chat_ui.h"
 #include "brave/components/ai_chat/core/browser/utils.h"
@@ -12,8 +13,8 @@
 #include "chrome/browser/ui/views/side_panel/side_panel_web_ui_view.h"
 #include "components/grit/brave_components_strings.h"
 #include "components/user_prefs/user_prefs.h"
-#include "ui/base/l10n/l10n_util.h"
 #include "ui/base/metadata/metadata_impl_macros.h"
+#include "ui/views/widget/widget.h"
 
 using SidePanelWebUIViewT_AIChatUI = SidePanelWebUIViewT<AIChatUI>;
 BEGIN_TEMPLATE_METADATA(SidePanelWebUIViewT_AIChatUI, SidePanelWebUIViewT)
@@ -21,17 +22,54 @@ END_METADATA
 
 namespace {
 
+// A custom web view to set focus correctly when the side panel is shown.
+class AIChatSidePanelWebView : public SidePanelWebUIViewT<AIChatUI> {
+ public:
+  AIChatSidePanelWebView(
+      SidePanelEntryScope& scope,
+      std::unique_ptr<WebUIContentsWrapperT<AIChatUI>> contents_wrapper)
+      : SidePanelWebUIViewT<AIChatUI>(
+            scope,
+            base::BindRepeating(&AIChatSidePanelWebView::OnShow,
+                                base::Unretained(this)),
+            base::RepeatingClosure(),
+            std::move(contents_wrapper)) {}
+
+  ~AIChatSidePanelWebView() override = default;
+
+ private:
+  // This callback is invoked multiple times, so we need to ensure that
+  // focus is set only once with `should_focus_`.
+  void OnShow() {
+    if (!should_focus_) {
+      return;
+    }
+
+    if (IsFocusable()) {
+      auto* widget = GetWidget();
+      CHECK(widget);
+      // There's a bug in focus handling. We should clear focus before setting
+      // side panel focused. Otherwise, focus won't be forwarded to the
+      // web contents properly.
+      widget->GetFocusManager()->ClearFocus();
+      RequestFocus();
+      should_focus_ = false;
+    }
+  }
+
+  bool should_focus_ = true;
+};
+
 std::unique_ptr<views::View> CreateAIChatSidePanelWebView(
     base::WeakPtr<Profile> profile,
     SidePanelEntryScope& scope) {
   CHECK(profile);
 
-  auto web_view = std::make_unique<SidePanelWebUIViewT<AIChatUI>>(
-      scope, base::RepeatingClosure(), base::RepeatingClosure(),
-      std::make_unique<WebUIContentsWrapperT<AIChatUI>>(
-          ai_chat::TabAssociatedConversationUrl(), profile.get(),
-          IDS_SIDEBAR_CHAT_SUMMARIZER_ITEM_TITLE,
-          /*esc_closes_ui=*/false));
+  auto web_view = std::make_unique<AIChatSidePanelWebView>(
+      scope, std::make_unique<WebUIContentsWrapperT<AIChatUI>>(
+                 ai_chat::TabAssociatedConversationUrl(), profile.get(),
+                 IDS_SIDEBAR_CHAT_SUMMARIZER_ITEM_TITLE,
+                 /*esc_closes_ui=*/false));
   web_view->ShowUI();
   return web_view;
 }


### PR DESCRIPTION
This PR sets focus to the AI chat side panel web view when it is shown. This is done to ensure that the user can immediately interact with the chat interface without needing to manually focus on it.

Technical Details:
- Modified `brave_side_panel_utils.cc` to include focus handling logic.
- Added a check to clear focus before requesting it, addressing a bug in focus handling.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/47796
Uplift from https://github.com/brave/brave-core/pull/30179

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
