### PR TITLE
[msan] Fix uninitialised reads for `Orchard*` structs (uplift to 1.80.x)

### DIFF
--- a/components/brave_wallet/common/zcash_utils.h
+++ b/components/brave_wallet/common/zcash_utils.h
@@ -98,7 +98,7 @@ struct DecodedZCashTransparentAddress {
 
 struct OrchardOutput {
   uint32_t value = 0;
-  OrchardAddrRawPart addr;
+  OrchardAddrRawPart addr{};
   std::optional<OrchardMemo> memo;
 
   bool operator==(const OrchardOutput& other) const = default;
@@ -111,7 +111,7 @@ struct OrchardOutput {
 struct OrchardNoteSpend {
   // Block id where spent nullifier was met.
   uint32_t block_id = 0;
-  std::array<uint8_t, kOrchardNullifierSize> nullifier;
+  std::array<uint8_t, kOrchardNullifierSize> nullifier{};
 
   bool operator==(const OrchardNoteSpend& other) const = default;
 };
@@ -121,13 +121,13 @@ struct OrchardNoteSpend {
 // in the Orchard commitment tree, amount and data required
 // for costructing zk-proof for spending.
 struct OrchardNote {
-  OrchardAddrRawPart addr;
+  OrchardAddrRawPart addr{};
   uint32_t block_id = 0;
-  OrchardNullifier nullifier;
+  OrchardNullifier nullifier{};
   uint32_t amount = 0;
   uint32_t orchard_commitment_tree_position = 0;
-  OrchardRho rho;
-  OrchardRseed seed;
+  OrchardRho rho{};
+  OrchardRseed seed{};
 
   bool operator==(const OrchardNote& other) const = default;
   base::Value::Dict ToValue() const;
@@ -166,8 +166,8 @@ struct OrchardSpendsBundle {
   ~OrchardSpendsBundle();
   OrchardSpendsBundle(const OrchardSpendsBundle& other);
 
-  OrchardSpendingKey sk;
-  OrchardFullViewKey fvk;
+  OrchardSpendingKey sk{};
+  OrchardFullViewKey fvk{};
   std::vector<OrchardInput> inputs;
 };
 


### PR DESCRIPTION
Uplift of #30195
Resolves https://github.com/brave/brave-browser/issues/47823

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.