### PR TITLE
Replace failed text fallback with auto screenshots

### DIFF
--- a/browser/ai_chat/ai_chat_ui_browsertest.cc
+++ b/browser/ai_chat/ai_chat_ui_browsertest.cc
@@ -299,31 +299,6 @@ IN_PROC_BROWSER_TEST_F(AIChatUIBrowserTest, ExtractionPrintDialog) {
                               "window.print();");
   print_preview_observer.WaitUntilPreviewIsReady();
 }
-
-// Disable flaky test on ASAN windows 64-bit
-// https://github.com/brave/brave-browser/issues/37969
-#if BUILDFLAG(IS_WIN) && defined(ADDRESS_SANITIZER) && defined(ARCH_CPU_64_BITS)
-#define MAYBE_PrintPreviewFallback DISABLED_PrintPreviewFallback
-#else
-#define MAYBE_PrintPreviewFallback PrintPreviewFallback
-#endif  // BUILDFLAG(IS_WIN) && defined(ADDRESS_SANITIZER) &&
-        // defined(ARCH_CPU_64_BITS)
-IN_PROC_BROWSER_TEST_F(AIChatUIBrowserTest, MAYBE_PrintPreviewFallback) {
-  NavigateURL(https_server_.GetURL("a.com", "/text_in_image.pdf"), false);
-  ASSERT_TRUE(
-      pdf_extension_test_util::EnsurePDFHasLoaded(GetActiveWebContents()));
-  FetchPageContent(
-      FROM_HERE, "This is the way.\n\nI have spoken.\nWherever I Go, He Goes.");
-
-  NavigateURL(https_server_.GetURL("a.com", "/canvas.html"), false);
-  FetchPageContent(FROM_HERE, "this is the way");
-
-  // Does not fall back when there is regular DOM content
-  NavigateURL(
-      https_server_.GetURL("a.com", "/long_canvas_with_dom_content.html"),
-      false);
-  FetchPageContent(FROM_HERE, "Or maybe not.");
-}
 #endif  // BUILDFLAG(ENABLE_TEXT_RECOGNITION) && BUILDFLAG(ENABLE_PRINT_PREVIEW)
 
 IN_PROC_BROWSER_TEST_F(AIChatUIBrowserTest, PrintPreviewDisabled) {

--- a/components/ai_chat/content/browser/ai_chat_tab_helper.cc
+++ b/components/ai_chat/content/browser/ai_chat_tab_helper.cc
@@ -174,20 +174,11 @@ void AIChatTabHelper::OnFetchPageContentComplete(
     std::string invalidation_token) {
   base::TrimWhitespaceASCII(content, base::TRIM_ALL, &content);
   // If content is empty, and page was not loaded yet, wait for page load.
-  // Once page load is complete, try again. If it's still empty, fallback
-  // to print preview extraction.
-  if (content.empty() && !is_video) {
-    // When page isn't loaded yet, wait until DidFinishLoad
-    DVLOG(1) << __func__ << " empty content, will attempt fallback";
-    if (MaybePrintPreviewExtract(callback)) {
-      return;
-    } else if (!is_page_loaded_) {
-      DVLOG(1) << "page was not loaded yet, will try again after load";
-      SetPendingGetContentCallback(std::move(callback));
-      return;
-    }
-    // When print preview extraction isn't available, return empty content
-    DVLOG(1) << "no fallback available";
+  // Once page load is complete, try again.
+  if (content.empty() && !is_video && !is_page_loaded_) {
+    DVLOG(1) << "page was not loaded yet, will try again after load";
+    SetPendingGetContentCallback(std::move(callback));
+    return;
   }
   std::move(callback).Run(std::move(content), is_video,
                           std::move(invalidation_token));

--- a/components/ai_chat/core/browser/conversation_handler.h
+++ b/components/ai_chat/core/browser/conversation_handler.h
@@ -318,6 +318,10 @@ class ConversationHandler : public mojom::ConversationHandler,
 
   void OnGeneratePageContentComplete(GetAllContentCallback callback,
                                      bool content_changed);
+  void OnScreenshotsTaken(
+      GetAllContentCallback callback,
+      std::optional<std::vector<mojom::UploadedFilePtr>> screenshots);
+
   void OnEngineCompletionDataReceived(
       EngineConsumer::GenerationResultData result);
   void OnEngineCompletionComplete(EngineConsumer::GenerationResult result);
@@ -350,6 +354,10 @@ class ConversationHandler : public mojom::ConversationHandler,
   // Instead, we build a list from all the available tool sources, given
   // the current conversation state.
   std::vector<base::WeakPtr<Tool>> GetTools();
+
+  // Helper method to switch to vision model if needed
+  void MaybeSwitchToVisionModel(
+      const std::optional<std::vector<mojom::UploadedFilePtr>>& uploaded_files);
 
   std::unique_ptr<AssociatedContentManager> associated_content_manager_;
 

--- a/components/ai_chat/core/browser/conversation_handler_unittest.cc
+++ b/components/ai_chat/core/browser/conversation_handler_unittest.cc
@@ -44,6 +44,7 @@
 #include "brave/components/ai_chat/core/browser/tools/tool_utils.h"
 #include "brave/components/ai_chat/core/browser/types.h"
 #include "brave/components/ai_chat/core/browser/utils.h"
+#include "brave/components/ai_chat/core/common/constants.h"
 #include "brave/components/ai_chat/core/common/features.h"
 #include "brave/components/ai_chat/core/common/mojom/ai_chat.mojom.h"
 #include "brave/components/ai_chat/core/common/pref_names.h"
@@ -3302,6 +3303,12 @@ class ConversationHandlerUnitTest_AutoScreenshot
 // empty/whitespace-only
 TEST_P(ConversationHandlerUnitTest_AutoScreenshot,
        AutoScreenshotOnEmptyContent) {
+#if BUILDFLAG(IS_IOS)
+  // Set a vision support model to prevent model switching
+  // Remove this model switch once iOS set automatic as default
+  model_service_->SetDefaultModelKeyWithoutValidationForTesting(
+      kClaudeHaikuModelKey);
+#endif
   const EmptyContentTestData& test_data = GetParam();
 
   // Mock associated content to return the test content
@@ -3459,6 +3466,12 @@ TEST_F(ConversationHandlerUnitTest, NoScreenshotWhenScreenshotsAlreadyExist) {
 
 // Test that screenshots are appended to existing uploaded files
 TEST_F(ConversationHandlerUnitTest, ScreenshotsAppendToExistingFiles) {
+#if BUILDFLAG(IS_IOS)
+  // Set a vision support model to prevent model switching
+  // Remove this model switch once iOS set automatic as default
+  model_service_->SetDefaultModelKeyWithoutValidationForTesting(
+      kClaudeHaikuModelKey);
+#endif
   // Mock associated content to return empty text content
   EXPECT_CALL(*associated_content_, GetTextContent)
       .WillRepeatedly(testing::Return(""));

--- a/components/ai_chat/core/browser/conversation_handler_unittest.cc
+++ b/components/ai_chat/core/browser/conversation_handler_unittest.cc
@@ -34,6 +34,7 @@
 #include "brave/components/ai_chat/core/browser/ai_chat_credential_manager.h"
 #include "brave/components/ai_chat/core/browser/ai_chat_service.h"
 #include "brave/components/ai_chat/core/browser/associated_archive_content.h"
+#include "brave/components/ai_chat/core/browser/associated_content_delegate.h"
 #include "brave/components/ai_chat/core/browser/associated_content_manager.h"
 #include "brave/components/ai_chat/core/browser/engine/mock_engine_consumer.h"
 #include "brave/components/ai_chat/core/browser/mock_conversation_handler_observer.h"
@@ -2499,6 +2500,7 @@ TEST_F(ConversationHandlerUnitTest, RateMessage) {
 
 TEST_F(ConversationHandlerUnitTest,
        SubmitHumanConversationEntry_NoNewEntrySubmitHuman) {
+  conversation_handler_->associated_content_manager()->ClearContent();
   // Tests what happens when the engine returns a success but there was no new
   // entry. We should avoid re-adding the most recent entry.
 
@@ -2543,6 +2545,7 @@ TEST_F(ConversationHandlerUnitTest,
 
 TEST_F(ConversationHandlerUnitTest,
        SubmitHumanConversationEntry_NoNewEntryToolUse) {
+  conversation_handler_->associated_content_manager()->ClearContent();
   // Tests what happens when the engine returns a success but there was no new
   // entry after a tool use response.
   MockEngineConsumer* engine = static_cast<MockEngineConsumer*>(
@@ -2651,6 +2654,7 @@ TEST_F(ConversationHandlerUnitTest,
 }
 
 TEST_F(ConversationHandlerUnitTest, ToolUseEvents_PartialEventsGetCombined) {
+  conversation_handler_->associated_content_manager()->ClearContent();
   MockEngineConsumer* engine = static_cast<MockEngineConsumer*>(
       conversation_handler_->GetEngineForTesting());
 
@@ -2728,6 +2732,7 @@ TEST_F(ConversationHandlerUnitTest, ToolUseEvents_PartialEventsGetCombined) {
 }
 
 TEST_F(ConversationHandlerUnitTest, ToolUseEvents_CorrectToolCalled) {
+  conversation_handler_->associated_content_manager()->ClearContent();
   // Setup multiple tools with only 1 being called
   auto tool1 =
       std::make_unique<NiceMock<MockTool>>("weather_tool", "Get weather");
@@ -2878,6 +2883,7 @@ TEST_F(ConversationHandlerUnitTest, ToolUseEvents_CorrectToolCalled) {
 }
 
 TEST_F(ConversationHandlerUnitTest, ToolUseEvents_MultipleToolsCalled) {
+  conversation_handler_->associated_content_manager()->ClearContent();
   MockEngineConsumer* engine = static_cast<MockEngineConsumer*>(
       conversation_handler_->GetEngineForTesting());
 
@@ -3017,6 +3023,7 @@ TEST_F(ConversationHandlerUnitTest, ToolUseEvents_MultipleToolsCalled) {
 
 TEST_F(ConversationHandlerUnitTest,
        ToolUseEvents_RequiresUserInteractionBeforeHandling) {
+  conversation_handler_->associated_content_manager()->ClearContent();
   MockEngineConsumer* engine = static_cast<MockEngineConsumer*>(
       conversation_handler_->GetEngineForTesting());
 
@@ -3117,6 +3124,7 @@ TEST_F(ConversationHandlerUnitTest,
 }
 
 TEST_F(ConversationHandlerUnitTest, ToolUseEvents_MultipleToolIterations) {
+  conversation_handler_->associated_content_manager()->ClearContent();
   MockEngineConsumer* engine = static_cast<MockEngineConsumer*>(
       conversation_handler_->GetEngineForTesting());
 
@@ -3270,6 +3278,354 @@ TEST_F(ConversationHandlerUnitTest, ToolUseEvents_MultipleToolIterations) {
 
   // Final response should be present
   EXPECT_EQ(history.back()->text, "Final response after tools");
+}
+
+struct EmptyContentTestData {
+  std::string name;
+  std::string content;
+};
+
+class ConversationHandlerUnitTest_AutoScreenshot
+    : public ConversationHandlerUnitTest,
+      public testing::WithParamInterface<EmptyContentTestData> {
+ public:
+  static std::vector<EmptyContentTestData> GetTestCases() {
+    return {
+        {"EmptyString", ""},
+        {"StandardWhitespace", "   \t\n\r  "},
+        {"MixedWhitespace", "\n\t \r\n  \t\r  "},
+    };
+  }
+};
+
+// Test that screenshots are automatically taken when page content is
+// empty/whitespace-only
+TEST_P(ConversationHandlerUnitTest_AutoScreenshot,
+       AutoScreenshotOnEmptyContent) {
+  const EmptyContentTestData& test_data = GetParam();
+
+  // Mock associated content to return the test content
+  EXPECT_CALL(*associated_content_, GetTextContent)
+      .WillRepeatedly(testing::Return(test_data.content));
+
+  // Mock GetScreenshots to return sample screenshots
+  std::vector<mojom::UploadedFilePtr> mock_screenshots =
+      CreateSampleUploadedFiles(2, mojom::UploadedFileType::kScreenshot);
+  EXPECT_CALL(*associated_content_, GetScreenshots)
+      .WillOnce(base::test::RunOnceCallback<0>(Clone(mock_screenshots)));
+
+  // Mock engine response
+  MockEngineConsumer* engine = static_cast<MockEngineConsumer*>(
+      conversation_handler_->GetEngineForTesting());
+  EXPECT_CALL(*engine, GenerateAssistantResponse)
+      .WillOnce(base::test::RunOnceCallback<6>(
+          base::ok(EngineConsumer::GenerationResultData(
+              mojom::ConversationEntryEvent::NewCompletionEvent(
+                  mojom::CompletionEvent::New("Response with screenshots")),
+              std::nullopt /* model_key */))));
+
+  NiceMock<MockConversationHandlerClient> client(conversation_handler_.get());
+
+  // Submit a conversation entry
+  base::RunLoop loop;
+  EXPECT_CALL(client, OnAPIRequestInProgress(true)).Times(1);
+  EXPECT_CALL(client, OnAPIRequestInProgress(false))
+      .WillOnce(testing::InvokeWithoutArgs(&loop, &base::RunLoop::Quit));
+
+  conversation_handler_->SubmitHumanConversationEntry("Test question",
+                                                      std::nullopt);
+  loop.Run();
+
+  // Verify that screenshots were attached to the conversation turn
+  const auto& history = conversation_handler_->GetConversationHistory();
+  ASSERT_EQ(history.size(), 2u);        // Human turn + assistant turn
+  const auto& human_turn = history[0];  // Human turn (index 0)
+  EXPECT_TRUE(human_turn->uploaded_files.has_value());
+  EXPECT_EQ(human_turn->uploaded_files->size(), 2u);
+
+  // Verify that the files are screenshots
+  for (const auto& file : *human_turn->uploaded_files) {
+    EXPECT_EQ(file->type, mojom::UploadedFileType::kScreenshot);
+  }
+
+  testing::Mock::VerifyAndClearExpectations(associated_content_.get());
+  testing::Mock::VerifyAndClearExpectations(engine);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    EmptyContentVariations,
+    ConversationHandlerUnitTest_AutoScreenshot,
+    testing::ValuesIn(
+        ConversationHandlerUnitTest_AutoScreenshot::GetTestCases()),
+    [](const testing::TestParamInfo<EmptyContentTestData>& info) {
+      return info.param.name;
+    });
+
+// Test that screenshots are NOT taken when page content exists
+TEST_F(ConversationHandlerUnitTest, NoScreenshotWhenContentExists) {
+  // Mock associated content to return non-empty text content
+  EXPECT_CALL(*associated_content_, GetTextContent)
+      .WillRepeatedly(testing::Return("Some page content"));
+
+  // GetScreenshots should NOT be called
+  EXPECT_CALL(*associated_content_, GetScreenshots).Times(0);
+
+  // Mock engine response
+  MockEngineConsumer* engine = static_cast<MockEngineConsumer*>(
+      conversation_handler_->GetEngineForTesting());
+  EXPECT_CALL(*engine, GenerateAssistantResponse)
+      .WillOnce(base::test::RunOnceCallback<6>(
+          base::ok(EngineConsumer::GenerationResultData(
+              mojom::ConversationEntryEvent::NewCompletionEvent(
+                  mojom::CompletionEvent::New("Response without screenshots")),
+              std::nullopt /* model_key */))));
+
+  NiceMock<MockConversationHandlerClient> client(conversation_handler_.get());
+
+  // Submit a conversation entry
+  base::RunLoop loop;
+  EXPECT_CALL(client, OnAPIRequestInProgress(true)).Times(1);
+  EXPECT_CALL(client, OnAPIRequestInProgress(false))
+      .WillOnce(testing::InvokeWithoutArgs(&loop, &base::RunLoop::Quit));
+
+  conversation_handler_->SubmitHumanConversationEntry("Test question",
+                                                      std::nullopt);
+  loop.Run();
+
+  // Verify that no screenshots were attached
+  const auto& history = conversation_handler_->GetConversationHistory();
+  ASSERT_FALSE(history.empty());
+  const auto& last_turn = history.back();
+  EXPECT_FALSE(last_turn->uploaded_files.has_value());
+
+  testing::Mock::VerifyAndClearExpectations(associated_content_.get());
+  testing::Mock::VerifyAndClearExpectations(engine);
+}
+
+// Test that screenshots are NOT taken when screenshots already exist in
+// conversation
+TEST_F(ConversationHandlerUnitTest, NoScreenshotWhenScreenshotsAlreadyExist) {
+  // Mock associated content to return empty text content
+  EXPECT_CALL(*associated_content_, GetTextContent)
+      .WillRepeatedly(testing::Return(""));
+
+  // Add existing screenshots to conversation history
+  std::vector<mojom::ConversationTurnPtr> history;
+  auto turn_with_screenshots = mojom::ConversationTurn::New(
+      std::nullopt, mojom::CharacterType::HUMAN, mojom::ActionType::QUERY,
+      "Previous question", std::nullopt, std::nullopt, std::nullopt,
+      base::Time::Now(), std::nullopt,
+      CreateSampleUploadedFiles(1, mojom::UploadedFileType::kScreenshot), false,
+      std::nullopt);
+  history.push_back(std::move(turn_with_screenshots));
+  conversation_handler_->SetChatHistoryForTesting(std::move(history));
+
+  // GetScreenshots should NOT be called because screenshots already exist
+  EXPECT_CALL(*associated_content_, GetScreenshots).Times(0);
+
+  // Mock engine response
+  MockEngineConsumer* engine = static_cast<MockEngineConsumer*>(
+      conversation_handler_->GetEngineForTesting());
+  EXPECT_CALL(*engine, GenerateAssistantResponse)
+      .WillOnce(base::test::RunOnceCallback<6>(
+          base::ok(EngineConsumer::GenerationResultData(
+              mojom::ConversationEntryEvent::NewCompletionEvent(
+                  mojom::CompletionEvent::New(
+                      "Response without new screenshots")),
+              std::nullopt /* model_key */))));
+
+  NiceMock<MockConversationHandlerClient> client(conversation_handler_.get());
+
+  // Submit a conversation entry
+  base::RunLoop loop;
+  EXPECT_CALL(client, OnAPIRequestInProgress(true)).Times(1);
+  EXPECT_CALL(client, OnAPIRequestInProgress(false))
+      .WillOnce(testing::InvokeWithoutArgs(&loop, &base::RunLoop::Quit));
+
+  conversation_handler_->SubmitHumanConversationEntry("Test question",
+                                                      std::nullopt);
+  loop.Run();
+
+  // Verify that no new screenshots were attached
+  const auto& new_history = conversation_handler_->GetConversationHistory();
+  ASSERT_EQ(new_history.size(),
+            3u);  // Previous turn + human turn + assistant turn
+  const auto& new_turn = new_history.back();
+  EXPECT_FALSE(new_turn->uploaded_files.has_value());
+
+  testing::Mock::VerifyAndClearExpectations(associated_content_.get());
+  testing::Mock::VerifyAndClearExpectations(engine);
+}
+
+// Test that screenshots are appended to existing uploaded files
+TEST_F(ConversationHandlerUnitTest, ScreenshotsAppendToExistingFiles) {
+  // Mock associated content to return empty text content
+  EXPECT_CALL(*associated_content_, GetTextContent)
+      .WillRepeatedly(testing::Return(""));
+
+  // Mock GetScreenshots to return sample screenshots
+  std::vector<mojom::UploadedFilePtr> mock_screenshots =
+      CreateSampleUploadedFiles(1, mojom::UploadedFileType::kScreenshot);
+  EXPECT_CALL(*associated_content_, GetScreenshots)
+      .WillOnce(base::test::RunOnceCallback<0>(Clone(mock_screenshots)));
+
+  // Mock engine response
+  MockEngineConsumer* engine = static_cast<MockEngineConsumer*>(
+      conversation_handler_->GetEngineForTesting());
+  EXPECT_CALL(*engine, GenerateAssistantResponse)
+      .WillOnce(base::test::RunOnceCallback<6>(
+          base::ok(EngineConsumer::GenerationResultData(
+              mojom::ConversationEntryEvent::NewCompletionEvent(
+                  mojom::CompletionEvent::New("Response with mixed content")),
+              std::nullopt /* model_key */))));
+
+  NiceMock<MockConversationHandlerClient> client(conversation_handler_.get());
+
+  // Submit a conversation entry with existing images
+  base::RunLoop loop;
+  EXPECT_CALL(client, OnAPIRequestInProgress(true)).Times(1);
+  EXPECT_CALL(client, OnAPIRequestInProgress(false))
+      .WillOnce(testing::InvokeWithoutArgs(&loop, &base::RunLoop::Quit));
+
+  auto existing_images =
+      CreateSampleUploadedFiles(2, mojom::UploadedFileType::kImage);
+  conversation_handler_->SubmitHumanConversationEntry("Test question",
+                                                      Clone(existing_images));
+  loop.Run();
+
+  // Verify that screenshots were appended to existing files
+  const auto& new_history = conversation_handler_->GetConversationHistory();
+  ASSERT_EQ(new_history.size(), 2u);        // Human turn + assistant turn
+  const auto& human_turn = new_history[0];  // Human turn (index 0)
+  EXPECT_TRUE(human_turn->uploaded_files.has_value());
+  EXPECT_EQ(human_turn->uploaded_files->size(), 3u);  // 2 images + 1 screenshot
+
+  // Verify that the first two files are images and the last is a screenshot
+  EXPECT_EQ((*human_turn->uploaded_files)[0]->type,
+            mojom::UploadedFileType::kImage);
+  EXPECT_EQ((*human_turn->uploaded_files)[1]->type,
+            mojom::UploadedFileType::kImage);
+  EXPECT_EQ((*human_turn->uploaded_files)[2]->type,
+            mojom::UploadedFileType::kScreenshot);
+
+  testing::Mock::VerifyAndClearExpectations(associated_content_.get());
+  testing::Mock::VerifyAndClearExpectations(engine);
+}
+
+// Test that vision model is automatically switched when screenshots are taken
+TEST_F(ConversationHandlerUnitTest, VisionModelSwitchOnScreenshots) {
+  // Switch to a model without vision support first
+  base::RunLoop loop_for_change_model;
+  NiceMock<MockConversationHandlerClient> client(conversation_handler_.get());
+  EXPECT_CALL(client, OnModelDataChanged)
+      .WillOnce(testing::InvokeWithoutArgs(&loop_for_change_model,
+                                           &base::RunLoop::Quit));
+  conversation_handler_->ChangeModel("chat-basic");
+  loop_for_change_model.Run();
+  testing::Mock::VerifyAndClearExpectations(&client);
+
+  // Re-setting a mock engine because it was replaced due to ChangeModel call.
+  conversation_handler_->SetEngineForTesting(
+      std::make_unique<NiceMock<MockEngineConsumer>>());
+  MockEngineConsumer* engine = static_cast<MockEngineConsumer*>(
+      conversation_handler_->GetEngineForTesting());
+
+  EXPECT_FALSE(conversation_handler_->GetCurrentModel().vision_support);
+
+  // Mock associated content to return empty text content
+  EXPECT_CALL(*associated_content_, GetTextContent)
+      .WillRepeatedly(testing::Return(""));
+
+  // Mock GetScreenshots to return sample screenshots
+  std::vector<mojom::UploadedFilePtr> mock_screenshots =
+      CreateSampleUploadedFiles(1, mojom::UploadedFileType::kScreenshot);
+  EXPECT_CALL(*associated_content_, GetScreenshots)
+      .WillOnce(base::test::RunOnceCallback<0>(Clone(mock_screenshots)));
+
+  // Mock engine response
+  EXPECT_CALL(*engine, GenerateAssistantResponse)
+      .WillRepeatedly(testing::Invoke(
+          [](PageContents page_contents,
+             const std::vector<mojom::ConversationTurnPtr>& history,
+             const std::string& selected_language,
+             const std::vector<base::WeakPtr<Tool>>& tools,
+             std::optional<std::string_view> preferred_tool_name,
+             EngineConsumer::GenerationDataCallback callback,
+             EngineConsumer::GenerationCompletedCallback done_callback) {
+            std::move(done_callback)
+                .Run(base::ok(EngineConsumer::GenerationResultData(
+                    mojom::ConversationEntryEvent::NewCompletionEvent(
+                        mojom::CompletionEvent::New(
+                            "Response with vision model")),
+                    std::nullopt /* model_key */)));
+          }));
+
+  base::RunLoop loop;
+  // Note: OnModelDataChanged expectation is set at the end for auto model
+  // switch
+  EXPECT_CALL(client, OnModelDataChanged)
+      .WillOnce(base::test::RunClosure(base::BindLambdaForTesting([&]() {
+        // Verify auto switched to vision support model
+        EXPECT_TRUE(conversation_handler_->GetCurrentModel().vision_support);
+        loop.Quit();
+      })));
+
+  // Submit a conversation entry
+  conversation_handler_->SubmitHumanConversationEntry("Test question",
+                                                      std::nullopt);
+  loop.Run();
+
+  // Verify that screenshots were attached and model has vision support
+  const auto& history = conversation_handler_->GetConversationHistory();
+  ASSERT_EQ(history.size(), 1u);        // Only human turn (assistant turn won't
+                                        // complete due to model switch)
+  const auto& human_turn = history[0];  // Human turn (index 0)
+  EXPECT_TRUE(human_turn->uploaded_files.has_value());
+  EXPECT_EQ(human_turn->uploaded_files->size(), 1u);
+  EXPECT_EQ((*human_turn->uploaded_files)[0]->type,
+            mojom::UploadedFileType::kScreenshot);
+  EXPECT_TRUE(conversation_handler_->GetCurrentModel().vision_support);
+
+  testing::Mock::VerifyAndClearExpectations(&client);
+  testing::Mock::VerifyAndClearExpectations(associated_content_.get());
+  testing::Mock::VerifyAndClearExpectations(engine);
+}
+
+// Test that screenshots are NOT taken when there's no associated content
+TEST_F(ConversationHandlerUnitTest_NoAssociatedContent,
+       NoScreenshotWhenNoAssociatedContent) {
+  // Note: We can't mock associated_content_ here because it's null in this test
+  // class
+
+  // Mock engine response
+  MockEngineConsumer* engine = static_cast<MockEngineConsumer*>(
+      conversation_handler_->GetEngineForTesting());
+  EXPECT_CALL(*engine, GenerateAssistantResponse)
+      .WillOnce(base::test::RunOnceCallback<6>(
+          base::ok(EngineConsumer::GenerationResultData(
+              mojom::ConversationEntryEvent::NewCompletionEvent(
+                  mojom::CompletionEvent::New("Response without screenshots")),
+              std::nullopt /* model_key */))));
+
+  NiceMock<MockConversationHandlerClient> client(conversation_handler_.get());
+
+  // Submit a conversation entry
+  base::RunLoop loop;
+  EXPECT_CALL(client, OnAPIRequestInProgress(true)).Times(1);
+  EXPECT_CALL(client, OnAPIRequestInProgress(false))
+      .WillOnce(testing::InvokeWithoutArgs(&loop, &base::RunLoop::Quit));
+
+  conversation_handler_->SubmitHumanConversationEntry("Test question",
+                                                      std::nullopt);
+  loop.Run();
+
+  // Verify that no screenshots were attached
+  const auto& history = conversation_handler_->GetConversationHistory();
+  ASSERT_FALSE(history.empty());
+  const auto& last_turn = history.back();
+  EXPECT_FALSE(last_turn->uploaded_files.has_value());
+
+  testing::Mock::VerifyAndClearExpectations(engine);
 }
 
 }  // namespace ai_chat

--- a/components/ai_chat/core/browser/test/mock_associated_content.h
+++ b/components/ai_chat/core/browser/test/mock_associated_content.h
@@ -42,6 +42,10 @@ class MockAssociatedContent : public AssociatedContentDelegate {
               (GetStagedEntriesCallback),
               (override));
   MOCK_METHOD(bool, HasOpenAIChatPermission, (), (const, override));
+  MOCK_METHOD(void,
+              GetScreenshots,
+              (mojom::ConversationHandler::GetScreenshotsCallback),
+              (override));
 
   base::WeakPtr<AssociatedContentDelegate> GetWeakPtr() {
     return weak_ptr_factory_.GetWeakPtr();


### PR DESCRIPTION
which will automatically capture full page screenshots and submit when we detect empty page content text.
Auto screenshots will only be triggered per conversation and only if a user opt-in sharing page content.
Previously we use on device OCR path which is not supported on Linux, now our fallback appraoch is more consistent and not affected by OCR accuracy.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/47353

## Test plan
### Failed text fallback
1. Navigate to https://brianbondy.com/static/img/blogpost_190/tahoe-start.webp
2. Ask Leo "What doe the banner say?"
3. We should be able to get the correct answer

https://github.com/user-attachments/assets/f7ae827c-fa53-4829-bb21-af5041d45ee5



### Screenshot once per conversation
1. Follow "Failed text fallback"
2. Ask Leo "What doe the T-shirt say?"
3. We should be able to get the correct answer

### With upload images
1. Update some random images
2. Proceed "Failed text fallback"
5. We should see those uploaded images along side with screenshots

### No associated content
1. Remove tab content from staging area
2. Proceed  "Failed text fallback"
3. Screenshots won't be taken and we won't get the correct answer


<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
