### PR TITLE
[msan] Fix `AssociatedContentDriver` uninitiated field

### DIFF
--- a/components/ai_chat/core/browser/associated_content_driver.h
+++ b/components/ai_chat/core/browser/associated_content_driver.h
@@ -135,7 +135,7 @@ class AssociatedContentDriver : public AssociatedContentDelegate {
   // Store the unique ID for each "page" so that
   // we can ignore API async responses against any navigated-away-from
   // documents.
-  int64_t current_navigation_id_;
+  int64_t current_navigation_id_{0};
 
   base::WeakPtrFactory<AssociatedContentDriver> weak_ptr_factory_{this};
 };


### PR DESCRIPTION
This class has an `int64_t` field that is being left uninitialised, and
this is causing uninitialised reads in certain tests, when that class is
mocked, which yields Undefined Behaviour.

Resolves https://github.com/brave/brave-browser/issues/47852
