### PR TITLE
[Customize Chrome] Change l10n string in "Customize Toolbar" side panel

### DIFF
--- a/browser/ui/webui/side_panel/customize_chrome/customize_toolbar/customize_toolbar_handler_unittest.cc
+++ b/browser/ui/webui/side_panel/customize_chrome/customize_toolbar/customize_toolbar_handler_unittest.cc
@@ -100,9 +100,9 @@ TEST_F(CustomizeToolbarHandlerUnitTest, YourChromeLabelShouldBeBraveMenu) {
             side_panel::customize_chrome::mojom::CategoryId::kYourChrome,
             [](const auto& category) { return category->id; });
         ASSERT_NE(your_chrome_it, categories.end());
-        EXPECT_EQ((*your_chrome_it)->display_name,
-                  l10n_util::GetStringUTF8(
-                      IDS_CUSTOMIZE_TOOLBAR_CATEGORY_BRAVE_MENU));
+        EXPECT_EQ(
+            (*your_chrome_it)->display_name,
+            l10n_util::GetStringUTF8(IDS_CUSTOMIZE_TOOLBAR_CATEGORY_TOOLBAR));
       }));
 }
 

--- a/chromium_src/chrome/browser/ui/webui/side_panel/customize_chrome/customize_toolbar/customize_toolbar_handler.cc
+++ b/chromium_src/chrome/browser/ui/webui/side_panel/customize_chrome/customize_toolbar/customize_toolbar_handler.cc
@@ -26,7 +26,7 @@
 // resource ID.
 #undef IDS_NTP_CUSTOMIZE_TOOLBAR_CATEGORY_YOUR_CHROME
 #define IDS_NTP_CUSTOMIZE_TOOLBAR_CATEGORY_YOUR_CHROME \
-  IDS_CUSTOMIZE_TOOLBAR_CATEGORY_BRAVE_MENU
+  IDS_CUSTOMIZE_TOOLBAR_CATEGORY_TOOLBAR
 
 #include "src/chrome/browser/ui/webui/side_panel/customize_chrome/customize_toolbar/customize_toolbar_handler.cc"
 

--- a/components/resources/customize_toolbar_ui_strings.grdp
+++ b/components/resources/customize_toolbar_ui_strings.grdp
@@ -12,7 +12,7 @@
   <message name="IDS_CUSTOMIZE_TOOLBAR_TOGGLE_VPN" desc="Title for a toggle button to show or hide VPN">
     VPN
   </message>
-  <message name="IDS_CUSTOMIZE_TOOLBAR_CATEGORY_BRAVE_MENU" desc="Title for the Brave menu category in the customize toolbar page">
-    Brave Menu
+  <message name="IDS_CUSTOMIZE_TOOLBAR_CATEGORY_TOOLBAR" desc="Title for the toolbar category in the customize toolbar page">
+    Toolbar
   </message>
 </grit-part>


### PR DESCRIPTION
Changes the second section's label from "Brave Menu" to "Toolbar" in the "Customize Toolbar" side panel.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/47867

<img width="662" height="1230" alt="image" src="https://github.com/user-attachments/assets/52cce636-5a77-4c1b-aa59-3b65dcf3823b" />


<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
