### PR TITLE
[msan] Fix uninitialised read by `ZCashTransaction`

### DIFF
--- a/components/brave_wallet/browser/zcash/zcash_transaction.h
+++ b/components/brave_wallet/browser/zcash/zcash_transaction.h
@@ -34,7 +34,7 @@ class ZCashTransaction {
     base::Value::Dict ToValue() const;
     static std::optional<Outpoint> FromValue(const base::Value::Dict& value);
 
-    std::array<uint8_t, 32> txid;
+    std::array<uint8_t, 32> txid{};
     uint32_t index = 0;
   };
 


### PR DESCRIPTION
The array in `Outpoint` was being left uninitialised and this was
leading to a uninitialised read, which yields Undefined Behaviour.

Resolves https://github.com/brave/brave-browser/issues/47870
