### PR TITLE
[msan] Fix uninitialised read by `ZCashTransaction` (uplift to 1.80.x)

### DIFF
--- a/components/brave_wallet/browser/zcash/zcash_transaction.h
+++ b/components/brave_wallet/browser/zcash/zcash_transaction.h
@@ -33,7 +33,7 @@ class ZCashTransaction {
     base::Value::Dict ToValue() const;
     static std::optional<Outpoint> FromValue(const base::Value::Dict& value);
 
-    std::array<uint8_t, 32> txid;
+    std::array<uint8_t, 32> txid{};
     uint32_t index = 0;
   };
 


### PR DESCRIPTION
Uplift of #30232
Resolves https://github.com/brave/brave-browser/issues/47870

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.