### PR TITLE
[msan] Fix uninitialised read caused by `SetCookieInfo`

### DIFF
--- a/chromium_src/chrome/browser/ui/views/page_info/page_info_cookies_content_view.cc
+++ b/chromium_src/chrome/browser/ui/views/page_info/page_info_cookies_content_view.cc
@@ -7,20 +7,13 @@
 
 #include "chrome/browser/ui/views/page_info/page_info_main_view.h"
 
-#define SetCookieInfo SetCookieInfo_ChromiumImpl
+#define PageInfoCookiesContentView PageInfoCookiesContentView_ChromiumImpl
 #include "src/chrome/browser/ui/views/page_info/page_info_cookies_content_view.cc"
-#undef SetCookieInfo
+#undef PageInfoCookiesContentView
 
 void PageInfoCookiesContentView::SetCookieInfo(
     const CookiesNewInfo& cookie_info) {
-  // We need to call SetCookieInfo with controls_state = kHidden, or the layout
-  // will DCHECK since we hide the cookie container. We can't copy the existing
-  // struct when doing this because its copy constructor is implicitly deleted,
-  // so we just copy over the only other setting that's relevant for us.
-  CookiesNewInfo mutable_cookie_info;
-  mutable_cookie_info.allowed_sites_count = cookie_info.allowed_sites_count;
-  mutable_cookie_info.controls_state = CookieControlsState::kHidden;
-  SetCookieInfo_ChromiumImpl(mutable_cookie_info);
+  PageInfoCookiesContentView_ChromiumImpl::SetCookieInfo(cookie_info);
 
   // Hide cookies description and link to settings.
   cookies_description_label_->SetVisible(false);
@@ -37,4 +30,16 @@ void PageInfoCookiesContentView::SetCookieInfo(
     }
   }
   PreferredSizeChanged();
+}
+
+void PageInfoCookiesContentView::SetThirdPartyCookiesInfo(
+    CookieControlsState controls_state,
+    CookieControlsEnforcement enforcement,
+    CookieBlocking3pcdStatus blocking_status,
+    base::Time expiration) {
+  // Passing `kHidden` always to make sure we hide the third-party cookies, but
+  // also avoid a CHECK down the line, due to having set other controls as
+  // not visible.
+  PageInfoCookiesContentView_ChromiumImpl::SetThirdPartyCookiesInfo(
+      CookieControlsState::kHidden, enforcement, blocking_status, expiration);
 }

--- a/chromium_src/chrome/browser/ui/views/page_info/page_info_cookies_content_view.h
+++ b/chromium_src/chrome/browser/ui/views/page_info/page_info_cookies_content_view.h
@@ -8,11 +8,39 @@
 
 #include "components/page_info/page_info_ui.h"
 
-#define SetCookieInfo                                            \
-  SetCookieInfo_ChromiumImpl(const CookiesNewInfo& cookie_info); \
-  void SetCookieInfo
+class PageInfoCookiesContentView;
+using PageInfoCookiesContentView_BraveImpl = PageInfoCookiesContentView;
 
+#define InitCookiesDialogButton                \
+  Unused();                                    \
+  friend PageInfoCookiesContentView_BraveImpl; \
+  void InitCookiesDialogButton
+
+#define SetThirdPartyCookiesInfo virtual SetThirdPartyCookiesInfo
+
+#define PageInfoCookiesContentView PageInfoCookiesContentView_ChromiumImpl
 #include "src/chrome/browser/ui/views/page_info/page_info_cookies_content_view.h"  // IWYU pragma: export
-#undef SetCookieInfo
+#undef PageInfoCookiesContentView
+#undef SetThirdPartyCookiesInfo
+#undef InitCookiesDialogButton
+
+// This class is used to provide the necessary overrides to hide from view
+// the third-party cookies section in the Page Info UI for Brave. This means
+// intercepting `SetCookieInfo` and disabling the controls at that stage, and
+// also intercepting `SetThirdPartyCookiesInfo` to ensure that the third-party
+// cookie is processed as `kHidden`.
+class PageInfoCookiesContentView
+    : public PageInfoCookiesContentView_ChromiumImpl {
+ public:
+  using PageInfoCookiesContentView_ChromiumImpl::
+      PageInfoCookiesContentView_ChromiumImpl;
+
+  // Overrides from PageInfoCookiesContentView_ChromiumImpl.
+  void SetCookieInfo(const CookiesNewInfo& cookie_info) override;
+  void SetThirdPartyCookiesInfo(CookieControlsState controls_state,
+                                CookieControlsEnforcement enforcement,
+                                CookieBlocking3pcdStatus blocking_status,
+                                base::Time expiration) override;
+};
 
 #endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_PAGE_INFO_PAGE_INFO_COOKIES_CONTENT_VIEW_H_


### PR DESCRIPTION
This override was doing a copy of the value passed in, `cookie_info`,
and then changing the value of one of the fields to `kHide`, in order to
make things work properly for the rest of the things done by the
override, and avoid a `CHECK`. The issue here is that `cookie_info` is a
`const` reference, and `cookie_info` have a copy constructor, so the
fields were being copied manually. This worked for a short time, until
other fields were added to this struct, with some being uninitialised.

This change removes the whole copying of this type, as that is
bug-prone, with new fields being added, and rather patches off
`SetThirdPartyCookiesInfo` to always bail out, as this is the actual
effect we are looking for by mutating the value of `cookie_info`.
`SetThirdPartyCookiesInfo` is only used by `SetCookieInfo` in fact.

Resolves https://github.com/brave/brave-browser/issues/47875
