### PR TITLE
Apply updater GN args from .env

### DIFF
--- a/build/commands/lib/config.js
+++ b/build/commands/lib/config.js
@@ -536,9 +536,7 @@ Config.prototype.buildArgs = function () {
     args.enable_updater = true
   }
 
-  if (getEnvConfig(['use_prebuilt_omaha4']) !== undefined) {
-    args.use_prebuilt_omaha4 = getEnvConfig(['use_prebuilt_omaha4'])
-  }
+  args.use_prebuilt_omaha4 = getEnvConfig(['use_prebuilt_omaha4'])
 
   if (!this.isBraveReleaseBuild()) {
     args.chrome_pgo_phase = 0

--- a/build/commands/lib/config.js
+++ b/build/commands/lib/config.js
@@ -532,8 +532,12 @@ Config.prototype.buildArgs = function () {
     generate_about_credits: true,
   }
 
-  if (this.isOfficialBuild()) {
+  if (this.isOfficialBuild() || getEnvConfig(['enable_updater'])) {
     args.enable_updater = true
+  }
+
+  if (getEnvConfig(['use_prebuilt_omaha4']) !== undefined) {
+    args.use_prebuilt_omaha4 = getEnvConfig(['use_prebuilt_omaha4'])
   }
 
   if (!this.isBraveReleaseBuild()) {


### PR DESCRIPTION
This lets us set `enable_updater=True`, `use_prebuilt_omaha4=False` in CI builds (which are Static and thus would normally have different values). This in turn ensures that all updater-related code gets built by CI.