### PR TITLE
feat(wallet): Add or Switch Networks Panel UI Revisions

### DIFF
--- a/components/brave_wallet_ui/components/extension/allow_add_change_network_panel/allow_add_change_network_panel.style.ts
+++ b/components/brave_wallet_ui/components/extension/allow_add_change_network_panel/allow_add_change_network_panel.style.ts
@@ -19,11 +19,6 @@ export const HeaderText = styled(Text)`
   letter-spacing: ${leo.typography.letterSpacing.large};
 `
 
-export const OriginText = styled(Text)`
-  font: ${leo.font.small.regular};
-  letter-spacing: ${leo.typography.letterSpacing.small};
-`
-
 export const Title = styled(Text)`
   font: ${leo.font.heading.h3};
   letter-spacing: ${leo.typography.letterSpacing.headings};
@@ -35,7 +30,7 @@ export const Description = styled(Text)`
 `
 
 export const NetworkInfoBox = styled(Column)`
-  background-color: ${leo.color.container.background};
+  background-color: ${leo.color.container.highlight};
   border-radius: ${leo.radius.xl};
 `
 
@@ -47,13 +42,6 @@ export const NetworkInfoLabel = styled(Text)`
 export const NetworkInfoText = styled(Text)`
   font: ${leo.font.default.semibold};
   letter-spacing: ${leo.typography.letterSpacing.default};
-`
-
-export const FavIcon = styled.img`
-  width: 64px;
-  height: 64px;
-  border-radius: 16px;
-  background-color: ${leo.color.container.background};
 `
 
 export const DividerWrapper = styled(Row)`
@@ -96,4 +84,11 @@ export const DetailsButton = styled(WalletButton)`
 export const LearnMoreButton = styled(DetailsButton)`
   font: ${leo.font.default.semibold};
   letter-spacing: ${leo.typography.letterSpacing.default};
+`
+
+export const Card = styled(Column)`
+  background-color: ${leo.color.container.background};
+  border-radius: ${leo.radius.xl};
+  box-shadow: ${leo.effect.elevation['01']};
+  overflow: hidden;
 `

--- a/components/brave_wallet_ui/components/extension/allow_add_change_network_panel/allow_add_change_network_panel.tsx
+++ b/components/brave_wallet_ui/components/extension/allow_add_change_network_panel/allow_add_change_network_panel.tsx
@@ -23,10 +23,10 @@ import {
 } from '../../../common/slices/api.slice.extra'
 
 // Components
-import { CreateSiteOrigin } from '../../shared/create-site-origin/index'
 import { CreateNetworkIcon } from '../../shared/create-network-icon'
 import { BottomSheet } from '../../shared/bottom_sheet/bottom_sheet'
 import { NetworkInfo } from '../network_info/network_info'
+import { OriginInfoCard } from '../origin_info_card/origin_info_card'
 
 // Styled Components
 import {
@@ -34,16 +34,15 @@ import {
   HeaderText,
   Title,
   Description,
-  OriginText,
   DetailsButton,
   LearnMoreButton,
-  FavIcon,
   NetworkInfoBox,
   NetworkInfoLabel,
   NetworkInfoText,
   DividerWrapper,
   ArrowIconWrapper,
   ArrowIcon,
+  Card,
 } from './allow_add_change_network_panel.style'
 import { Column, Row, VerticalDivider } from '../../shared/style'
 
@@ -157,219 +156,222 @@ export function AllowAddChangeNetworkPanel(props: Props) {
       width='100%'
       height='100%'
     >
-      <Column width='100%'>
-        <Row padding='18px'>
-          <HeaderText textColor='primary'>
-            {switchChainRequest
-              ? getLocale('braveWalletAllowChangeNetworkButton')
-              : getLocale('braveWalletAddNetwork')}
-          </HeaderText>
-        </Row>
-        <Column
-          padding='16px 24px 24px 24px'
-          gap='8px'
-        >
-          <FavIcon
-            src={`chrome://favicon2?size=64&pageUrl=${encodeURIComponent(
-              originInfo.originSpec,
-            )}`}
-          />
-          <OriginText textColor='tertiary'>
-            <CreateSiteOrigin
-              originSpec={originInfo.originSpec}
-              eTldPlusOne={originInfo.eTldPlusOne}
-            />
-          </OriginText>
-          <Title textColor='primary'>
-            {switchChainRequest
-              ? getLocale('braveWalletAllowChangeNetworkTitle')
-              : getLocale('braveWalletAllowAddNetworkTitle')}
-          </Title>
-          <Description textColor='tertiary'>
-            {switchChainRequest
-              ? getLocale('braveWalletAllowChangeNetworkDescription')
-              : getLocale('braveWalletAllowAddNetworkDescription')}{' '}
-            {addChainRequest && (
-              <LearnMoreButton onClick={onLearnMore}>
-                {getLocale('braveWalletAllowAddNetworkLearnMoreButton')}
-              </LearnMoreButton>
-            )}
-          </Description>
-        </Column>
-        <Column
-          padding='0 24px'
+      <Row padding='18px'>
+        <HeaderText textColor='primary'>
+          {switchChainRequest
+            ? getLocale('braveWalletAllowChangeNetworkButton')
+            : getLocale('braveWalletAddNetwork')}
+        </HeaderText>
+      </Row>
+      <VerticalDivider />
+      <Column
+        padding='8px'
+        width='100%'
+        height='100%'
+      >
+        <Card
           width='100%'
-          gap='16px'
+          height='100%'
+          justifyContent='space-between'
         >
-          {switchChainRequest && (
-            <NetworkInfoBox
-              alignItems='flex-start'
-              justifyContent='flex-start'
-              padding='16px'
-              gap='22px'
-              width='100%'
-            >
-              <Column
+          {originInfo && <OriginInfoCard origin={originInfo} />}
+          <Column
+            padding='0px 16px'
+            gap='8px'
+          >
+            <Title textColor='primary'>
+              {switchChainRequest
+                ? getLocale('braveWalletAllowChangeNetworkTitle')
+                : getLocale('braveWalletAllowAddNetworkTitle')}
+            </Title>
+            <Description textColor='tertiary'>
+              {switchChainRequest
+                ? getLocale('braveWalletAllowChangeNetworkDescription')
+                : getLocale('braveWalletAllowAddNetworkDescription')}{' '}
+              {addChainRequest && (
+                <LearnMoreButton onClick={onLearnMore}>
+                  {getLocale('braveWalletAllowAddNetworkLearnMoreButton')}
+                </LearnMoreButton>
+              )}
+            </Description>
+          </Column>
+          <Column
+            padding='0px 10px'
+            width='100%'
+            gap='16px'
+          >
+            {switchChainRequest && (
+              <NetworkInfoBox
                 alignItems='flex-start'
                 justifyContent='flex-start'
-              >
-                <NetworkInfoLabel textColor='secondary'>
-                  {getLocale('braveWalletFrom')}:
-                </NetworkInfoLabel>
-                <Row
-                  gap='8px'
-                  justifyContent='flex-start'
-                >
-                  <CreateNetworkIcon
-                    size='huge'
-                    network={selectedNetwork}
-                  />
-                  <Column
-                    alignItems='flex-start'
-                    justifyContent='flex-start'
-                  >
-                    <NetworkInfoText
-                      textColor='primary'
-                      textAlign='left'
-                    >
-                      {selectedNetwork?.chainName ?? ''}
-                    </NetworkInfoText>
-                    <NetworkInfoLabel
-                      textColor='secondary'
-                      textAlign='left'
-                    >
-                      {selectedNetwork?.rpcEndpoints[
-                        selectedNetwork?.activeRpcEndpointIndex
-                      ]?.url ?? ''}
-                    </NetworkInfoLabel>
-                  </Column>
-                </Row>
-              </Column>
-              <DividerWrapper>
-                <ArrowIconWrapper>
-                  <ArrowIcon />
-                </ArrowIconWrapper>
-                <VerticalDivider />
-              </DividerWrapper>
-              <Column
-                alignItems='flex-start'
-                justifyContent='flex-start'
+                padding='16px'
+                gap='22px'
                 width='100%'
               >
-                <NetworkInfoLabel textColor='secondary'>
-                  {getLocale('braveWalletSwapTo')}:
-                </NetworkInfoLabel>
-                <Row
-                  gap='8px'
+                <Column
+                  alignItems='flex-start'
                   justifyContent='flex-start'
                 >
-                  <CreateNetworkIcon
-                    size='huge'
-                    network={switchChainRequestNetwork}
-                  />
-                  <Column
-                    alignItems='flex-start'
+                  <NetworkInfoLabel textColor='secondary'>
+                    {getLocale('braveWalletFrom')}:
+                  </NetworkInfoLabel>
+                  <Row
+                    gap='8px'
                     justifyContent='flex-start'
-                    width='100%'
                   >
-                    <Row
-                      justifyContent='space-between'
-                      alignItems='center'
+                    <CreateNetworkIcon
+                      size='huge'
+                      network={selectedNetwork}
+                    />
+                    <Column
+                      alignItems='flex-start'
+                      justifyContent='flex-start'
                     >
                       <NetworkInfoText
                         textColor='primary'
                         textAlign='left'
                       >
-                        {switchChainRequestNetwork?.chainName ?? ''}
+                        {selectedNetwork?.chainName ?? ''}
                       </NetworkInfoText>
-                      <DetailsButton
-                        onClick={() => setShowNetworkDetails(true)}
+                      <NetworkInfoLabel
+                        textColor='secondary'
+                        textAlign='left'
                       >
-                        {getLocale('braveWalletDetails')}
-                      </DetailsButton>
-                    </Row>
-                    <NetworkInfoLabel
-                      textColor='secondary'
-                      textAlign='left'
+                        {selectedNetwork?.rpcEndpoints[
+                          selectedNetwork?.activeRpcEndpointIndex
+                        ]?.url ?? ''}
+                      </NetworkInfoLabel>
+                    </Column>
+                  </Row>
+                </Column>
+                <DividerWrapper>
+                  <ArrowIconWrapper>
+                    <ArrowIcon />
+                  </ArrowIconWrapper>
+                  <VerticalDivider />
+                </DividerWrapper>
+                <Column
+                  alignItems='flex-start'
+                  justifyContent='flex-start'
+                  width='100%'
+                >
+                  <NetworkInfoLabel textColor='secondary'>
+                    {getLocale('braveWalletSwapTo')}:
+                  </NetworkInfoLabel>
+                  <Row
+                    gap='8px'
+                    justifyContent='flex-start'
+                  >
+                    <CreateNetworkIcon
+                      size='huge'
+                      network={switchChainRequestNetwork}
+                    />
+                    <Column
+                      alignItems='flex-start'
+                      justifyContent='flex-start'
+                      width='100%'
                     >
-                      {switchChainRequestNetwork?.rpcEndpoints[
-                        switchChainRequestNetwork?.activeRpcEndpointIndex
-                      ]?.url || ''}
-                    </NetworkInfoLabel>
-                  </Column>
-                </Row>
-              </Column>
-            </NetworkInfoBox>
-          )}
-          {addChainRequest && (
-            <NetworkInfoBox
-              alignItems='flex-start'
-              justifyContent='flex-start'
-              padding='16px'
-              gap='16px'
-              width='100%'
-            >
-              <Column
+                      <Row
+                        justifyContent='space-between'
+                        alignItems='center'
+                      >
+                        <NetworkInfoText
+                          textColor='primary'
+                          textAlign='left'
+                        >
+                          {switchChainRequestNetwork?.chainName ?? ''}
+                        </NetworkInfoText>
+                        <DetailsButton
+                          onClick={() => setShowNetworkDetails(true)}
+                        >
+                          {getLocale('braveWalletDetails')}
+                        </DetailsButton>
+                      </Row>
+                      <NetworkInfoLabel
+                        textColor='secondary'
+                        textAlign='left'
+                      >
+                        {switchChainRequestNetwork?.rpcEndpoints[
+                          switchChainRequestNetwork?.activeRpcEndpointIndex
+                        ]?.url || ''}
+                      </NetworkInfoLabel>
+                    </Column>
+                  </Row>
+                </Column>
+              </NetworkInfoBox>
+            )}
+            {addChainRequest && (
+              <NetworkInfoBox
                 alignItems='flex-start'
                 justifyContent='flex-start'
+                padding='16px'
+                gap='16px'
+                width='100%'
               >
-                <NetworkInfoLabel textColor='secondary'>
-                  {getLocale('braveWalletAllowAddNetworkName')}
-                </NetworkInfoLabel>
-                <NetworkInfoText textColor='primary'>
-                  {addChainRequestNetwork?.chainName ?? ''}
-                </NetworkInfoText>
-              </Column>
-              <VerticalDivider />
-              <Column
-                alignItems='flex-start'
-                justifyContent='flex-start'
+                <Column
+                  alignItems='flex-start'
+                  justifyContent='flex-start'
+                >
+                  <NetworkInfoLabel textColor='secondary'>
+                    {getLocale('braveWalletAllowAddNetworkName')}
+                  </NetworkInfoLabel>
+                  <NetworkInfoText textColor='primary'>
+                    {addChainRequestNetwork?.chainName ?? ''}
+                  </NetworkInfoText>
+                </Column>
+                <VerticalDivider />
+                <Column
+                  alignItems='flex-start'
+                  justifyContent='flex-start'
+                >
+                  <NetworkInfoLabel textColor='secondary'>
+                    {getLocale('braveWalletAllowAddNetworkUrl')}
+                  </NetworkInfoLabel>
+                  <NetworkInfoText textColor='primary'>
+                    {addChainRequestNetwork?.rpcEndpoints[
+                      addChainRequestNetwork?.activeRpcEndpointIndex
+                    ]?.url || ''}
+                  </NetworkInfoText>
+                </Column>
+              </NetworkInfoBox>
+            )}
+            {addChainRequest && (
+              <Button
+                kind='plain'
+                size='medium'
+                onClick={() => setShowNetworkDetails(true)}
               >
-                <NetworkInfoLabel textColor='secondary'>
-                  {getLocale('braveWalletAllowAddNetworkUrl')}
-                </NetworkInfoLabel>
-                <NetworkInfoText textColor='primary'>
-                  {addChainRequestNetwork?.rpcEndpoints[
-                    addChainRequestNetwork?.activeRpcEndpointIndex
-                  ]?.url || ''}
-                </NetworkInfoText>
-              </Column>
-            </NetworkInfoBox>
-          )}
-          {addChainRequest && (
+                {getLocale('braveWalletAllowAddNetworkDetailsButton')}
+              </Button>
+            )}
+          </Column>
+          <Row
+            padding='16px'
+            gap='8px'
+          >
             <Button
-              kind='plain'
+              kind='outline'
               size='medium'
-              onClick={() => setShowNetworkDetails(true)}
+              onClick={
+                addChainRequest ? onCancelAddNetwork : onCancelChangeNetwork
+              }
             >
-              {getLocale('braveWalletAllowAddNetworkDetailsButton')}
+              {getLocale('braveWalletButtonCancel')}
             </Button>
-          )}
-        </Column>
+            <Button
+              kind='filled'
+              size='medium'
+              onClick={
+                addChainRequest ? onApproveAddNetwork : onApproveChangeNetwork
+              }
+            >
+              {switchChainRequest
+                ? getLocale('braveWalletAllowChangeNetworkButton')
+                : getLocale('braveWalletAllowAddNetworkButton')}
+            </Button>
+          </Row>
+        </Card>
       </Column>
-      <Row
-        padding='16px'
-        gap='8px'
-      >
-        <Button
-          kind='outline'
-          size='medium'
-          onClick={addChainRequest ? onCancelAddNetwork : onCancelChangeNetwork}
-        >
-          {getLocale('braveWalletButtonCancel')}
-        </Button>
-        <Button
-          kind='filled'
-          size='medium'
-          onClick={
-            addChainRequest ? onApproveAddNetwork : onApproveChangeNetwork
-          }
-        >
-          {switchChainRequest
-            ? getLocale('braveWalletAllowChangeNetworkButton')
-            : getLocale('braveWalletAllowAddNetworkButton')}
-        </Button>
-      </Row>
       <BottomSheet
         isOpen={showNetworkDetails}
         onClose={() => setShowNetworkDetails(false)}


### PR DESCRIPTION
## Description 

Small revisions to the `Add or Switch Networks Panel` UI
- Replaces the current origin info with the new `Origin Info Card` component
- Changes to panel `Background`
- Now wraps content in a card.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/47571>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
## Test Plan:
The `Add or Switch Networks Panel` should continue to work as expected and should now have the updated UI changes.

Before:

<img width="395" height="656" alt="Screenshot 77" src="https://github.com/user-attachments/assets/1dee1c1c-df69-466b-a0b4-b2f0cfb91cfb" /> | <img width="395" height="654" alt="Screenshot 79" src="https://github.com/user-attachments/assets/85ff19fc-8455-41df-ba29-39c628d18352" />
--|--

After:

<img width="397" height="658" alt="Screenshot 16" src="https://github.com/user-attachments/assets/ee554ba9-58fe-4e53-8903-034b75fc33db" /> | <img width="399" height="660" alt="Screenshot 15" src="https://github.com/user-attachments/assets/9d1f60e8-71ec-45fe-9edb-6f80beca7c38" />
--|--


