### PR TITLE
feat(wallet): Use DApp Radar Info in Origin Info Card

### DIFF
--- a/components/brave_wallet_ui/common/hooks/use_is_dapp_verified.test.ts
+++ b/components/brave_wallet_ui/common/hooks/use_is_dapp_verified.test.ts
@@ -18,6 +18,21 @@ import { useIsDAppVerified } from './use_is_dapp_verified'
 import { mockUniswapOriginInfo } from '../../stories/mock-data/mock-origin-info'
 import { mockEthMainnet } from '../../stories/mock-data/mock-networks'
 
+// Mock the useGetTopDappsQuery hook
+jest.mock('../slices/api.slice', () => ({
+  ...jest.requireActual('../slices/api.slice'),
+  useGetTopDappsQuery: () => ({
+    data: [
+      {
+        id: 4096,
+        name: 'Uniswap V2',
+        website: 'https://app.uniswap.org/',
+        chains: ['ethereum'],
+      },
+    ],
+  }),
+}))
+
 describe('useIsDAppVerified hook', () => {
   it('should return true when origin exists.', async () => {
     // setup
@@ -42,7 +57,8 @@ describe('useIsDAppVerified hook', () => {
       expect(result.current).toBeDefined()
     })
 
-    expect(result.current).toBe(true)
+    expect(result.current.isDAppVerified).toBe(true)
+    expect(result.current.dapp?.name).toBe('Uniswap V2')
   })
 
   it('should return false when origin does not exist.', async () => {
@@ -69,6 +85,7 @@ describe('useIsDAppVerified hook', () => {
       expect(result.current).toBeDefined()
     })
 
-    expect(result.current).toBe(false)
+    expect(result.current.isDAppVerified).toBe(false)
+    expect(result.current.dapp).toBeUndefined()
   })
 })

--- a/components/brave_wallet_ui/common/hooks/use_is_dapp_verified.tsx
+++ b/components/brave_wallet_ui/common/hooks/use_is_dapp_verified.tsx
@@ -13,8 +13,10 @@ export const useIsDAppVerified = (originInfo: BraveWallet.OriginInfo) => {
   // Queries
   const { data: topDapps } = useGetTopDappsQuery()
 
-  return topDapps?.some((dapp) =>
+  const foundDApp = topDapps?.find((dapp) =>
     dapp.website.startsWith(originInfo.originSpec),
   )
+
+  return { isDAppVerified: foundDApp !== undefined, dapp: foundDApp }
 }
 export default useIsDAppVerified

--- a/components/brave_wallet_ui/components/extension/connect-with-site-panel/connect-with-site-header/connect-with-site-header.tsx
+++ b/components/brave_wallet_ui/components/extension/connect-with-site-panel/connect-with-site-header/connect-with-site-header.tsx
@@ -56,7 +56,7 @@ export const ConnectWithSiteHeader = (props: Props) => {
   const { originInfo, address, isReadyToConnect, isScrolled, onBack } = props
 
   // Hooks
-  const isDAppVerified = useIsDAppVerified(originInfo)
+  const { isDAppVerified } = useIsDAppVerified(originInfo)
 
   // Memos
   const orb = useAddressOrb(address)

--- a/components/brave_wallet_ui/components/extension/connections/connections.tsx
+++ b/components/brave_wallet_ui/components/extension/connections/connections.tsx
@@ -59,7 +59,7 @@ export const Connections = () => {
   )
 
   // Hooks
-  const isDAppVerified = useIsDAppVerified(activeOrigin)
+  const { isDAppVerified } = useIsDAppVerified(activeOrigin)
 
   return (
     <WalletPageWrapper

--- a/components/brave_wallet_ui/components/extension/origin_info_card/origin_info_card.stories.tsx
+++ b/components/brave_wallet_ui/components/extension/origin_info_card/origin_info_card.stories.tsx
@@ -7,7 +7,8 @@ import * as React from 'react'
 
 // Mocks
 import {
-  mockUniswapOriginInfo, //
+  mockUniswapOriginInfo,
+  mockOriginInfo, //
 } from '../../../stories/mock-data/mock-origin-info'
 
 // Components
@@ -19,9 +20,15 @@ import {
 // Styled Components
 import { Column } from '../../shared/style'
 
-export const _OriginInfoCard = {
+export const _OriginInfoCardVerified = {
   render: () => {
     return <OriginInfoCard origin={mockUniswapOriginInfo} />
+  },
+}
+
+export const _OriginInfoCardNotVerified = {
+  render: () => {
+    return <OriginInfoCard origin={mockOriginInfo} />
   },
 }
 

--- a/components/brave_wallet_ui/components/extension/origin_info_card/origin_info_card.tsx
+++ b/components/brave_wallet_ui/components/extension/origin_info_card/origin_info_card.tsx
@@ -8,8 +8,15 @@ import * as React from 'react'
 // Types
 import { BraveWallet } from '../../../constants/types'
 
+// Utils
+import { isComponentInStorybook } from '../../../utils/string-utils'
+
+// Hooks
+import { useIsDAppVerified } from '../../../common/hooks/use_is_dapp_verified'
+
 // Components
 import { CreateSiteOrigin } from '../../shared/create-site-origin'
+import { VerifiedLabel } from '../../shared/verified_label/verified_label'
 
 // Styled Components
 import {
@@ -20,6 +27,8 @@ import {
 } from './origin_info_card.style'
 import { Column } from '../../shared/style'
 
+const isStorybook = isComponentInStorybook()
+
 interface Props {
   origin: BraveWallet.OriginInfo
 }
@@ -27,20 +36,32 @@ interface Props {
 export const OriginInfoCard = (props: Props) => {
   const { origin } = props
 
+  // Hooks
+  const { isDAppVerified, dapp } = useIsDAppVerified(origin)
+
+  // Computed
+  const dappIcon = dapp
+    ? isStorybook
+      ? dapp.logo
+      : `chrome://image?url=${encodeURIComponent(dapp.logo)}&staticEncode=true`
+    : undefined
+
+  const iconSrc =
+    dappIcon
+    ?? 'chrome://favicon2?size=64&pageUrl='
+      + encodeURIComponent(origin.originSpec)
+
   return (
     <StyledWrapper
       padding='10px 16px'
       gap='16px'
       justifyContent='flex-start'
     >
-      <FavIcon
-        src={
-          'chrome://favicon2?size=64&pageUrl='
-          + encodeURIComponent(origin.originSpec)
-        }
-      />
+      <FavIcon src={iconSrc} />
       <Column alignItems='flex-start'>
-        <OriginName textColor='primary'>{origin.eTldPlusOne}</OriginName>
+        <OriginName textColor='primary'>
+          {dapp ? dapp.name : origin.eTldPlusOne}
+        </OriginName>
         <Column
           gap='4px'
           alignItems='flex-start'
@@ -51,6 +72,7 @@ export const OriginInfoCard = (props: Props) => {
               eTldPlusOne={origin.eTldPlusOne}
             />
           </OriginUrl>
+          {isDAppVerified && <VerifiedLabel />}
         </Column>
       </Column>
     </StyledWrapper>


### PR DESCRIPTION
## Description 

Will now display `DAppRadar` information in our `Panels` if a `DApp` can be verified by `DAppRadar`

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/47884>
Security Review <https://github.com/brave/reviews/issues/2003>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

## Test Plan:
1. Connect to a well known `DApp` and perform an action that would prompt the `Switch` or `Add` network panel
2. The `Origin Info Card` should display a `Verified by DAppRadar` badge and use the `Icon` and `Name` provided by `DAppRadar`

Before and After:

<img width="401" height="155" alt="Screenshot 18" src="https://github.com/user-attachments/assets/c26549db-7b7c-48cb-a8ba-b05daa64517f" /> | <img width="399" height="173" alt="Screenshot 17" src="https://github.com/user-attachments/assets/4d41cafb-1368-48c0-ac8e-14da2c42d5ba" />
--|--
