### PR TITLE
[ubsan] Fix uninitialised read in `BraveGCMDriverDesktop`

### DIFF
--- a/chromium_src/components/gcm_driver/gcm_driver_desktop.h
+++ b/chromium_src/components/gcm_driver/gcm_driver_desktop.h
@@ -22,7 +22,7 @@ class BraveGCMDriverDesktop : public GCMDriverDesktop {
   GCMClient::Result EnsureStarted(GCMClient::StartMode start_mode) override;
 
  private:
-  bool enabled_;
+  bool enabled_ = false;
 };
 
 }  // namespace gcm


### PR DESCRIPTION
This change fixes an uninitialised read in `BraveGCMDriverDesktop`, as
the `enabled_`, which can happen to be read in some cases.

Resolves https://github.com/brave/internal/issues/1368
