### PR TITLE
[ubsan] Add test filter support for ubsan builds

### DIFF
--- a/build/commands/lib/test.js
+++ b/build/commands/lib/test.js
@@ -90,6 +90,13 @@ const getApplicableFilters = (config, suite) => {
     [suite, targetPlatform].join('-'),
     [suite, targetPlatform, config.targetArch].join('-'),
   ]
+
+  if (config.is_ubsan) {
+    possibleFilters.push(
+      [suite, targetPlatform, config.targetArch, 'ubsan'].join('-'),
+    )
+  }
+
   possibleFilters.forEach((filterName) => {
     let filterFilePath = path.join(
       config.braveCoreDir,

--- a/test/filters/browser_tests-linux-ubsan.filter
+++ b/test/filters/browser_tests-linux-ubsan.filter
@@ -1,0 +1,15 @@
+# Copyright (c) 2025 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+##
+## Upstream tests to disable
+##
+## When adding a new filter to this list, please include a short description of
+## why the filter is required and create an associated tracking issue.
+##
+
+# These tests are failing due to an upstream issue relating to test ordering and
+# service factories. See: https://crbug.com/433075170
+-MediaEffectsServiceFactoryTest.*


### PR DESCRIPTION
This PR adds support for test exclusion for ubsan CI runs in particular.
When it comes to UBSan, it is not clear how stable this modality is, and
we have already come across failures that are upstream issues, so we
need the ability to suppress some of these tests with ubsan.

For details on the upstream issue we are trying to suppress check:
https://crbug.com/433075170

Resolves https://github.com/brave/brave-browser/issues/47888
