### PR TITLE
Reload only active split tab

### DIFF
--- a/chromium_src/chrome/browser/ui/BUILD.gn
+++ b/chromium_src/chrome/browser/ui/BUILD.gn
@@ -9,6 +9,14 @@ import("//build/config/ui.gni")
 group("ui") {
   deps = [ "//brave/components/brave_vpn/common/buildflags" ]
 
+  if (!is_android) {
+    deps += [
+      "//chrome/browser/ui/tabs:tab_strip",
+      "//components/tabs:public",
+      "//content/public/browser",
+    ]
+  }
+
   if (is_mac) {
     deps += [ "//brave/browser/updater:buildflags" ]
   }

--- a/chromium_src/chrome/browser/ui/browser_commands.cc
+++ b/chromium_src/chrome/browser/ui/browser_commands.cc
@@ -5,16 +5,61 @@
 
 #include "brave/browser/ui/browser_commands.h"
 
+#include <vector>
+
 #include "base/check.h"
 #include "brave/components/commander/common/buildflags/buildflags.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser_commands.h"
+#include "chrome/browser/ui/tabs/tab_strip_model.h"
 #include "chrome/common/webui_url_constants.h"
+#include "components/tabs/public/tab_interface.h"
+#include "content/public/browser/web_contents.h"
+
+namespace {
+
+// If |selected_tabs| only has two tabs from same split tab,
+// make |selected_tabs| includes only active split tab to reload
+// active tab not the both tab.
+void MakeActiveTabReloadOnlyForSplitTab(
+    TabStripModel* tab_strip_model,
+    std::vector<content::WebContents*>& selected_tabs) {
+  if (selected_tabs.size() != 2) {
+    return;
+  }
+
+  // Only have interests when two tabs are in the same split tab.
+  auto* first_tab = tabs::TabInterface::GetFromContents(selected_tabs[0]);
+  if (!first_tab->GetSplit()) {
+    return;
+  }
+
+  // Only give active tab if two tabs are in the same split tab.
+  auto* second_tab = tabs::TabInterface::GetFromContents(selected_tabs[1]);
+  if (first_tab->GetSplit() == second_tab->GetSplit()) {
+    auto* active_web_contents = tab_strip_model->GetActiveWebContents();
+    if (selected_tabs[0] != active_web_contents &&
+        selected_tabs[1] != active_web_contents) {
+      return;
+    }
+    auto* reload_target =
+        first_tab->IsActivated() ? selected_tabs[0] : selected_tabs[1];
+    selected_tabs.clear();
+    selected_tabs.push_back(reload_target);
+  }
+}
+
+}  // namespace
 
 #define ReloadBypassingCache ReloadBypassingCache_ChromiumImpl
 #define GetReadingListModel GetReadingListModel_ChromiumImpl
 #define kChromeUISplitViewNewTabPageURL kChromeUINewTabURL
+#define BRAVE_RELOAD_INTERNAL \
+  MakeActiveTabReloadOnlyForSplitTab(browser->tab_strip_model(), selected_tabs);
+
 #include <chrome/browser/ui/browser_commands.cc>
+
+#undef BRAVE_RELOAD_INTERNAL
 #undef kChromeUISplitViewNewTabPageURL
 #undef ReloadBypassingCache
 #undef GetReadingListModel

--- a/chromium_src/chrome/browser/ui/browser_commands.cc
+++ b/chromium_src/chrome/browser/ui/browser_commands.cc
@@ -54,6 +54,8 @@ void MakeActiveTabReloadOnlyForSplitTab(
 #define ReloadBypassingCache ReloadBypassingCache_ChromiumImpl
 #define GetReadingListModel GetReadingListModel_ChromiumImpl
 #define kChromeUISplitViewNewTabPageURL kChromeUINewTabURL
+
+// Need to patch to adjust |selected_tabs| in the middle of ReloadInternal().
 #define BRAVE_RELOAD_INTERNAL \
   MakeActiveTabReloadOnlyForSplitTab(browser->tab_strip_model(), selected_tabs);
 

--- a/patches/chrome-browser-ui-browser_commands.cc.patch
+++ b/patches/chrome-browser-ui-browser_commands.cc.patch
@@ -1,0 +1,12 @@
+diff --git a/chrome/browser/ui/browser_commands.cc b/chrome/browser/ui/browser_commands.cc
+index 62380119545c936ee3b517b390212fec31c96356..cf0c03b8b8a715d3fa01d2d840cc7c7465947493 100644
+--- a/chrome/browser/ui/browser_commands.cc
++++ b/chrome/browser/ui/browser_commands.cc
+@@ -489,6 +489,7 @@ void ReloadInternal(Browser* browser,
+     selected_tabs.push_back(
+         browser->tab_strip_model()->GetWebContentsAt(selected_index));
+   }
++  BRAVE_RELOAD_INTERNAL
+ 
+   base::UmaHistogramCounts100("TabStrip.Tab.ReloadCount", selected_tabs.size());
+ 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/47896

Reload button reloads tabs that currently selected tabs.
With `SideBySide`, all split tabs(left & right) are added in selected tab when it's activated.
So, both split tabs are all reloaded. But we only want to reload active split tab.
It's difficult to touch selection model because it's related whole split tabs behavior.
To resolve this, inactive split tab is removed from selected tabs in `chrome::ReloadInternal()` 
when only that split tabs is selected.

TEST=`SplitViewWithTabDialogBrowserTest.SplitViewReloadTest`

Manual test:
1. Launch Brave with `--enable-features=SideBySide`
2. Create split tab
3. Click reload and check only active split tab is reloaded

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
