### PR TITLE
[iOS] Add ability to shred all tabs from new tab tray UI

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/TabManager.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/TabManager.swift
@@ -796,6 +796,16 @@ class TabManager: NSObject {
     }
   }
 
+  @MainActor func shredAllTabsForCurrentMode() {
+    let isPrivateBrowsing = privateBrowsingManager.isPrivateBrowsing
+    let configuration = isPrivateBrowsing ? Self.privateConfiguration : Self.defaultConfiguration
+    let urlsToShred = Set(tabs(isPrivate: isPrivateBrowsing).compactMap(\.visibleURL))
+    Task {
+      removeAllTabsForPrivateMode(isPrivate: isPrivateBrowsing)
+      await forgetData(for: Array(urlsToShred), dataStore: configuration.websiteDataStore)
+    }
+  }
+
   @MainActor func shredData(for url: URL, in tab: some TabState) {
     guard let url = url.urlToShred,
       let baseDomain = url.baseDomain

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Tabs/TabGrid/TabGridView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Tabs/TabGrid/TabGridView.swift
@@ -338,7 +338,7 @@ struct TabGridView: View {
             } label: {
               Text(Strings.TabGrid.shredSelectedTabButtonTitle)
             }
-            .disabled(!viewModel.isSingleTabShredAvailable)
+            .disabled(!viewModel.isSelectedTabShredAvailable)
             Button(role: .destructive) {
               isShredAlertPresented = true
               activeShredMode = .allTabs

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Tabs/TabGrid/TabGridView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Tabs/TabGrid/TabGridView.swift
@@ -330,24 +330,25 @@ struct TabGridView: View {
       PrivateBrowsingPicker(isPrivateBrowsing: $viewModel.isPrivateBrowsing)
       Spacer()
       HStack(spacing: 20) {
-        Menu {
-          Button {
-            isShredAlertPresented = true
-            activeShredMode = .selectedTab
+        if viewModel.isShredMenuVisible {
+          Menu {
+            Button {
+              isShredAlertPresented = true
+              activeShredMode = .selectedTab
+            } label: {
+              Text(Strings.TabGrid.shredSelectedTabButtonTitle)
+            }
+            .disabled(!viewModel.isSingleTabShredAvailable)
+            Button(role: .destructive) {
+              isShredAlertPresented = true
+              activeShredMode = .allTabs
+            } label: {
+              Text(Strings.TabGrid.shredAllTabsButtonTitle)
+            }
           } label: {
-            Text(Strings.TabGrid.shredSelectedTabButtonTitle)
+            Label(Strings.TabGrid.shredTabsAccessibilityLabel, braveSystemImage: "leo.shred.data")
           }
-          .disabled(viewModel.selectedTab == nil)
-          Button(role: .destructive) {
-            isShredAlertPresented = true
-            activeShredMode = .allTabs
-          } label: {
-            Text(Strings.TabGrid.shredAllTabsButtonTitle)
-          }
-        } label: {
-          Label(Strings.TabGrid.shredTabsAccessibilityLabel, braveSystemImage: "leo.shred.data")
         }
-        .disabled(viewModel.tabs.isEmpty)
         Button {
           destinationSheet = .history
         } label: {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Tabs/TabGrid/TabGridViewModel.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Tabs/TabGrid/TabGridViewModel.swift
@@ -131,13 +131,12 @@ class TabGridViewModel {
   }
 
   var isShredMenuVisible: Bool {
-    isSingleTabShredAvailable
+    isSelectedTabShredAvailable
       || tabManager.tabsForCurrentMode.contains(where: { $0.visibleURL?.isShredAvailable == true })
   }
 
-  var isSingleTabShredAvailable: Bool {
-    guard let url = tabManager.selectedTab?.visibleURL else { return false }
-    return url.isShredAvailable
+  var isSelectedTabShredAvailable: Bool {
+    tabManager.selectedTab?.visibleURL?.isShredAvailable == true
   }
 
   func shredSelectedTab() {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Tabs/TabGrid/TabGridViewModel.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Tabs/TabGrid/TabGridViewModel.swift
@@ -130,6 +130,16 @@ class TabGridViewModel {
     }
   }
 
+  var isShredMenuVisible: Bool {
+    isSingleTabShredAvailable
+      || tabManager.tabsForCurrentMode.contains(where: { $0.visibleURL?.isShredAvailable == true })
+  }
+
+  var isSingleTabShredAvailable: Bool {
+    guard let url = tabManager.selectedTab?.visibleURL else { return false }
+    return url.isShredAvailable
+  }
+
   func shredSelectedTab() {
     guard let tab = tabManager.selectedTab, let url = tab.visibleURL else { return }
     tabManager.shredData(for: url, in: tab)

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Tabs/TabGrid/TabGridViewModel.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Tabs/TabGrid/TabGridViewModel.swift
@@ -135,6 +135,10 @@ class TabGridViewModel {
     tabManager.shredData(for: url, in: tab)
   }
 
+  func shredAllTabs() {
+    tabManager.shredAllTabsForCurrentMode()
+  }
+
   func selectTab(_ tab: any TabState) {
     withAnimation {
       tabManager.selectTab(tab)

--- a/ios/brave-ios/Sources/BraveShields/ShieldStrings.swift
+++ b/ios/brave-ios/Sources/BraveShields/ShieldStrings.swift
@@ -427,6 +427,18 @@ extension Strings.Shields {
       """
   )
 
+  /// A message for a confirmation window that appears when a user clicks on 'Shred All Tabs'.
+  public static let shredSiteAllTabsConfirmationMessage = NSLocalizedString(
+    "ShredSiteDataConfirmationMessage",
+    tableName: "BraveShared",
+    bundle: .module,
+    value:
+      "Shredding will close all tabs, and delete all site data. This cannot be undone.",
+    comment: """
+      A message for a confirmation window that appears when a user clicks on 'Shred All Tabs'.
+      """
+  )
+
   /// A list row label for accessing the shred settings screen
   public static let shredDataButtonTitle = NSLocalizedString(
     "ShredDataButtonTitle",

--- a/ios/brave-ios/Sources/BraveStrings/BraveStrings.swift
+++ b/ios/brave-ios/Sources/BraveStrings/BraveStrings.swift
@@ -1304,6 +1304,20 @@ extension Strings {
       value: "Shred Tabs",
       comment: "Accessibility label for a button that allows users to shred their tabs (erase them & associated data)"
     )
+    public static let shredSelectedTabButtonTitle = NSLocalizedString(
+      "tabGrid.shredSelectedTabButtonTitle",
+      tableName: "BraveShared",
+      bundle: .module,
+      value: "Shred Selected Tab",
+      comment: "A button title that when tapped allows users to shred the currently selected tab"
+    )
+    public static let shredAllTabsButtonTitle = NSLocalizedString(
+      "tabGrid.shredAllTabsButtonTitle",
+      tableName: "BraveShared",
+      bundle: .module,
+      value: "Shred All Tabs",
+      comment: "A button title that when tapped allows users to shred all of their tabs"
+    )
     public static let viewHistoryAccessibilityLabel = NSLocalizedString(
       "tabGrid.viewHistoryAccessibilityLabel",
       tableName: "BraveShared",


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/47942

### Test Case

- Enable the Modern Tab Tray UI via feature flags if not enabled already
- Find a site that saves cookies/login data
- Verify "Shred Selected Tab" functions the same as before (closing tabs and erasing data for that URL)
- Repeat step 1, but also open multiple tabs
- Verify the new "Shred All Tabs" closes all tabs and functions the same as shredding a single tab in terms of data removal

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
