### PR TITLE
[cr139][Android] Makes sure zero tabs are closing app only when appro… (uplift to 1.81.x)

### DIFF
--- a/patches/chrome-android-java-src-org-chromium-chrome-browser-ChromeTabbedActivity.java.patch
+++ b/patches/chrome-android-java-src-org-chromium-chrome-browser-ChromeTabbedActivity.java.patch
@@ -1,0 +1,12 @@
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/ChromeTabbedActivity.java b/chrome/android/java/src/org/chromium/chrome/browser/ChromeTabbedActivity.java
+index cdc5657b0dc63661e4e255e3082f2d0ec793a943..33aff13c99040d39d6dfdeb0f9cedadfa4606709 100644
+--- a/chrome/android/java/src/org/chromium/chrome/browser/ChromeTabbedActivity.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/ChromeTabbedActivity.java
+@@ -778,6 +778,7 @@ public class ChromeTabbedActivity extends ChromeActivity {
+                         private void closeIfNoTabsAndHomepageEnabled(
+                                 boolean isPendingClosure, boolean shouldRemoveWindowWithZeroTabs) {
+                             if (getTabModelSelector().getTotalTabCount() == 0) {
++                                shouldRemoveWindowWithZeroTabs = shouldRemoveWindowWithZeroTabs && org.chromium.chrome.browser.partnercustomizations.CloseBraveManager.shouldCloseAppWithZeroTabs();
+                                 if (shouldRemoveWindowWithZeroTabs) {
+                                     finishAndRemoveTask();
+                                 } else if (HomepageManager.getInstance()


### PR DESCRIPTION
Uplift of #30289
Resolves https://github.com/brave/brave-browser/issues/47887

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.