### PR TITLE
feat(wallet): Suggested Max Priority Fee Selector

### DIFF
--- a/components/brave_wallet/browser/brave_wallet_constants.h
+++ b/components/brave_wallet/browser/brave_wallet_constants.h
@@ -220,6 +220,7 @@ inline constexpr webui::LocalizedString kLocalizedStrings[] = {
     {"braveWalletEnableTransactionSimulation",
      IDS_BRAVE_WALLET_ENABLE_TRANSACTION_SIMULATION},
     {"braveWalletNetworkFees", IDS_BRAVE_WALLET_NETWORK_FEES},
+    {"braveWalletNetworkFee", IDS_BRAVE_WALLET_NETWORK_FEE},
     {"braveWalletSolanaSysvarRentProgram",
      IDS_BRAVE_WALLET_SOLANA_SYSVAR_RENT_PROGRAM},
     {"braveWalletSolanaMetaDataProgram",

--- a/components/brave_wallet_ui/components/extension/edit_network_fee/suggested_max_priority_fee_selector/suggested_max_priority_fee_selector.stories.tsx
+++ b/components/brave_wallet_ui/components/extension/edit_network_fee/suggested_max_priority_fee_selector/suggested_max_priority_fee_selector.stories.tsx
@@ -1,0 +1,67 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import * as React from 'react'
+
+// Mock Data
+import {
+  mockSuggestedMaxPriorityFeeOptions, //
+  mockTransactionInfo,
+} from '../../../../stories/mock-data/mock-transaction-info'
+import { mockEthMainnet } from '../../../../stories/mock-data/mock-networks'
+
+// Utils
+import { getLocale } from '../../../../../common/locale'
+
+// Types
+import { MaxPriorityFeeTypes } from '../../../../constants/types'
+
+// Components
+import {
+  SuggestedMaxPriorityFeeSelector, //
+} from './suggested_max_priority_fee_selector'
+import {
+  WalletPanelStory, //
+} from '../../../../stories/wrappers/wallet-panel-story-wrapper'
+import { BottomSheet } from '../../../shared/bottom_sheet/bottom_sheet'
+
+export const _SuggestedMaxPriorityFeeSelector = {
+  render: () => {
+    return (
+      <BottomSheet
+        isOpen={true}
+        title={getLocale('braveWalletNetworkFee')}
+        onClose={() => alert('Close Clicked')}
+      >
+        <SuggestedMaxPriorityFeeSelector
+          transactionInfo={mockTransactionInfo}
+          selectedNetwork={mockEthMainnet}
+          baseFeePerGas={'1'}
+          suggestedMaxPriorityFee='average'
+          suggestedMaxPriorityFeeOptions={mockSuggestedMaxPriorityFeeOptions}
+          onClickCustom={() => alert('Custom Clicked')}
+          setSuggestedMaxPriorityFee={(value: MaxPriorityFeeTypes) =>
+            alert(`Updated to ${value}`)
+          }
+        />
+      </BottomSheet>
+    )
+  },
+}
+
+export default {
+  title: 'Wallet/Panel/Components/Edit Network Fee',
+  component: SuggestedMaxPriorityFeeSelector,
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    (Story: any) => (
+      <WalletPanelStory>
+        <Story />
+      </WalletPanelStory>
+    ),
+  ],
+}

--- a/components/brave_wallet_ui/components/extension/edit_network_fee/suggested_max_priority_fee_selector/suggested_max_priority_fee_selector.styles.ts
+++ b/components/brave_wallet_ui/components/extension/edit_network_fee/suggested_max_priority_fee_selector/suggested_max_priority_fee_selector.styles.ts
@@ -1,0 +1,67 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import styled from 'styled-components'
+import * as leo from '@brave/leo/tokens/css/variables'
+import Icon from '@brave/leo/react/icon'
+
+// Shared Styles
+import { Column, WalletButton, Text } from '../../../shared/style'
+
+export const StyledWrapper = styled(Column)`
+  overflow: hidden;
+`
+
+export const FeeOptionButton = styled(WalletButton)<{
+  isSelected: boolean
+}>`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-start;
+  background: none;
+  cursor: pointer;
+  outline: none;
+  margin: 0px;
+  background-color: ${({ isSelected }) =>
+    isSelected
+      ? leo.color.container.background
+      : leo.color.container.highlight};
+  border-radius: ${leo.radius.m};
+  border: 2px solid
+    ${({ isSelected }) =>
+      isSelected ? leo.color.button.background : 'transparent'};
+  padding: 12px;
+  width: 100%;
+`
+
+export const NameText = styled(Text)`
+  font: ${leo.font.small.semibold};
+  letter-spacing: ${leo.typography.letterSpacing.small};
+`
+
+export const TimeText = styled(Text)`
+  font: ${leo.font.heading.h4};
+  letter-spacing: ${leo.typography.letterSpacing.large};
+`
+
+export const FeeAmountText = styled(Text)`
+  font: ${leo.font.xSmall.semibold};
+  letter-spacing: ${leo.typography.letterSpacing.small};
+  word-break: break-all;
+`
+
+export const FiatAmountText = styled(Text)`
+  font: ${leo.font.small.regular};
+  letter-spacing: ${leo.typography.letterSpacing.small};
+`
+
+export const RadioIcon = styled(Icon)<{
+  isSelected: boolean
+}>`
+  --leo-icon-size: 18px;
+  --leo-icon-color: ${({ isSelected }) =>
+    isSelected ? leo.color.icon.interactive : leo.color.icon.disabled};
+`

--- a/components/brave_wallet_ui/components/extension/edit_network_fee/suggested_max_priority_fee_selector/suggested_max_priority_fee_selector.test.tsx
+++ b/components/brave_wallet_ui/components/extension/edit_network_fee/suggested_max_priority_fee_selector/suggested_max_priority_fee_selector.test.tsx
@@ -1,0 +1,96 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import * as React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import { Provider } from 'react-redux'
+
+// Components
+import {
+  SuggestedMaxPriorityFeeSelector, //
+} from './suggested_max_priority_fee_selector'
+
+// Mocks
+import { mockEthMainnet } from '../../../../stories/mock-data/mock-networks'
+import {
+  mockSuggestedMaxPriorityFeeOptions,
+  mockTransactionInfo,
+} from '../../../../stories/mock-data/mock-transaction-info'
+import { createMockStore } from '../../../../utils/test-utils'
+import {
+  // eslint-disable-next-line import/no-named-default
+  default as BraveCoreThemeProvider,
+} from '../../../../../common/BraveCoreThemeProvider'
+
+// Mock the specific query hooks
+jest.mock('../../../../common/slices/api.slice', () => {
+  const originalModule = jest.requireActual(
+    '../../../../common/slices/api.slice',
+  )
+  return {
+    ...originalModule,
+    useGetDefaultFiatCurrencyQuery: () => ({
+      data: 'USD',
+    }),
+    useGetTokenSpotPricesQuery: () => ({
+      data: {
+        'ethereum': {
+          usd: 1600.92,
+          usd_24h_change: -0.69088,
+          usd_24h_vol: 6076168182,
+          usd_market_cap: 223895622340,
+        },
+      },
+    }),
+  }
+})
+
+describe('SuggestedMaxPriorityFeeSelector', () => {
+  const renderComponent = () => {
+    const store = createMockStore({})
+    return render(
+      <Provider store={store}>
+        <BraveCoreThemeProvider>
+          <SuggestedMaxPriorityFeeSelector
+            transactionInfo={mockTransactionInfo}
+            selectedNetwork={mockEthMainnet}
+            baseFeePerGas={'0x59682f00'} // 1500000000 wei (1.5 gwei)
+            suggestedMaxPriorityFee='average'
+            suggestedMaxPriorityFeeOptions={mockSuggestedMaxPriorityFeeOptions}
+            setSuggestedMaxPriorityFee={() => {}}
+            onClickCustom={() => {}}
+          />
+        </BraveCoreThemeProvider>
+      </Provider>,
+    )
+  }
+
+  it('Should render suggested max priority fee options', async () => {
+    renderComponent()
+
+    await waitFor(() => {
+      // Check if all fee options are rendered
+      expect(screen.getByText('braveSwapSlow')).toBeInTheDocument()
+      expect(screen.getByText('braveSwapAverage')).toBeInTheDocument()
+      expect(screen.getByText('braveSwapFast')).toBeInTheDocument()
+
+      // Check if durations are displayed
+      expect(screen.getByText('28 min')).toBeInTheDocument()
+      expect(screen.getByText('7 min')).toBeInTheDocument()
+      expect(screen.getByText('1 min')).toBeInTheDocument()
+
+      // Check if gas fees are displayed
+      expect(screen.getByText('0.003048 ETH')).toBeInTheDocument()
+      expect(screen.getByText('0.01171 ETH')).toBeInTheDocument()
+      expect(screen.getByText('0.02664 ETH')).toBeInTheDocument()
+
+      // Check if custom button is rendered
+      expect(screen.getByText('braveWalletCustom')).toBeInTheDocument()
+
+      // Check if Update button is rendered
+      expect(screen.getByText('braveWalletUpdate')).toBeInTheDocument()
+    })
+  })
+})

--- a/components/brave_wallet_ui/components/extension/edit_network_fee/suggested_max_priority_fee_selector/suggested_max_priority_fee_selector.tsx
+++ b/components/brave_wallet_ui/components/extension/edit_network_fee/suggested_max_priority_fee_selector/suggested_max_priority_fee_selector.tsx
@@ -1,0 +1,184 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import * as React from 'react'
+import { skipToken } from '@reduxjs/toolkit/query/react'
+import Button from '@brave/leo/react/button'
+
+// Types
+import {
+  BraveWallet,
+  MaxPriorityFeeOptionType,
+  MaxPriorityFeeTypes,
+  SerializableTransactionInfo,
+} from '../../../../constants/types'
+
+// Queries
+import {
+  useGetDefaultFiatCurrencyQuery,
+  useGetTokenSpotPricesQuery,
+} from '../../../../common/slices/api.slice'
+import {
+  querySubscriptionOptions60s, //
+} from '../../../../common/slices/constants'
+
+// Utils
+import { getLocale } from '../../../../../common/locale'
+import {
+  makeNetworkAsset, //
+} from '../../../../options/asset-options'
+import {
+  getPriceIdForToken,
+  getTokenPriceAmountFromRegistry,
+} from '../../../../utils/pricing-utils'
+import {
+  parseTransactionFeesWithoutPrices, //
+} from '../../../../utils/tx-utils'
+import Amount from '../../../../utils/amount'
+
+// Styled Components
+import { Row } from '../../../shared/style'
+import {
+  StyledWrapper,
+  FeeOptionButton,
+  NameText,
+  TimeText,
+  FeeAmountText,
+  FiatAmountText,
+  RadioIcon,
+} from './suggested_max_priority_fee_selector.styles'
+
+const MAX_PRIORITY_FEE_LABEL_MAP = {
+  slow: 'braveSwapSlow',
+  average: 'braveSwapAverage',
+  fast: 'braveSwapFast',
+}
+
+interface Props {
+  transactionInfo: SerializableTransactionInfo
+  selectedNetwork: BraveWallet.NetworkInfo
+  baseFeePerGas: string
+  suggestedMaxPriorityFee: MaxPriorityFeeTypes
+  suggestedMaxPriorityFeeOptions: MaxPriorityFeeOptionType[]
+  setSuggestedMaxPriorityFee: (value: MaxPriorityFeeTypes) => void
+  onClickCustom: () => void
+}
+
+export function SuggestedMaxPriorityFeeSelector(props: Props) {
+  const {
+    transactionInfo,
+    selectedNetwork,
+    baseFeePerGas,
+    suggestedMaxPriorityFee,
+    suggestedMaxPriorityFeeOptions,
+    setSuggestedMaxPriorityFee,
+    onClickCustom,
+  } = props
+
+  // State
+  const [userSelectedMaxPriorityFee, setUserSelectedMaxPriorityFee] =
+    React.useState<MaxPriorityFeeTypes>(suggestedMaxPriorityFee)
+
+  // queries
+  const networkAsset = React.useMemo(() => {
+    return makeNetworkAsset(selectedNetwork)
+  }, [selectedNetwork])
+
+  const networkTokenPriceIds = React.useMemo(
+    () => (networkAsset ? [getPriceIdForToken(networkAsset)] : []),
+    [networkAsset],
+  )
+
+  const { data: defaultFiatCurrency } = useGetDefaultFiatCurrencyQuery()
+
+  const { data: spotPriceRegistry } = useGetTokenSpotPricesQuery(
+    networkTokenPriceIds.length && defaultFiatCurrency
+      ? { ids: networkTokenPriceIds, toCurrency: defaultFiatCurrency }
+      : skipToken,
+    querySubscriptionOptions60s,
+  )
+
+  // Methods
+  const onUpdateMaxPriorityFee = React.useCallback(() => {
+    setSuggestedMaxPriorityFee(userSelectedMaxPriorityFee)
+  }, [setSuggestedMaxPriorityFee, userSelectedMaxPriorityFee])
+
+  // Memos
+  const transactionFees = React.useMemo(
+    () => parseTransactionFeesWithoutPrices(transactionInfo),
+    [transactionInfo],
+  )
+
+  // render
+  return (
+    <StyledWrapper
+      width='100%'
+      height='100%'
+      justifyContent='space-between'
+      padding='16px'
+      gap='16px'
+    >
+      <Row gap='12px'>
+        {suggestedMaxPriorityFeeOptions.map((option) => {
+          const isSelected = option.id === userSelectedMaxPriorityFee
+
+          const gasFee = new Amount(baseFeePerGas)
+            .plus(option.fee)
+            .times(transactionFees.gasLimit) // Wei-per-gas → Wei conversion
+            .divideByDecimals(selectedNetwork.decimals) // Wei → ETH conversion
+            .format(4)
+
+          const gasFeeFiat =
+            gasFee
+            && spotPriceRegistry
+            && new Amount(gasFee)
+              .times(
+                getTokenPriceAmountFromRegistry(
+                  spotPriceRegistry,
+                  networkAsset,
+                ),
+              )
+              .formatAsFiat()
+
+          return (
+            <FeeOptionButton
+              isSelected={isSelected}
+              onClick={() => setUserSelectedMaxPriorityFee(option.id)}
+            >
+              <Row justifyContent='space-between'>
+                <NameText>
+                  {getLocale(MAX_PRIORITY_FEE_LABEL_MAP[option.id])}
+                </NameText>
+                <RadioIcon
+                  isSelected={isSelected}
+                  name={isSelected ? 'radio-checked' : 'radio-unchecked'}
+                />
+              </Row>
+              <TimeText>{option.duration}</TimeText>
+              <FeeAmountText textAlign='left'>
+                {gasFee} {selectedNetwork.symbol}
+              </FeeAmountText>
+              <FiatAmountText>~${gasFeeFiat}</FiatAmountText>
+            </FeeOptionButton>
+          )
+        })}
+      </Row>
+      <Button
+        kind='plain-faint'
+        size='tiny'
+        onClick={onClickCustom}
+      >
+        {getLocale('braveWalletCustom')}
+      </Button>
+      <Row>
+        <Button onClick={onUpdateMaxPriorityFee}>
+          {getLocale('braveWalletUpdate')}
+        </Button>
+      </Row>
+    </StyledWrapper>
+  )
+}
+
+export default SuggestedMaxPriorityFeeSelector

--- a/components/brave_wallet_ui/constants/types.ts
+++ b/components/brave_wallet_ui/constants/types.ts
@@ -1147,3 +1147,11 @@ export type zcashAddressOptionType = {
 export type MeldCryptoCurrency = MeldTypes.MeldCryptoCurrency & {
   coingeckoId?: string
 }
+
+export type MaxPriorityFeeTypes = 'slow' | 'average' | 'fast'
+
+export type MaxPriorityFeeOptionType = {
+  id: MaxPriorityFeeTypes
+  fee: string
+  duration: string
+}

--- a/components/brave_wallet_ui/stories/locale.ts
+++ b/components/brave_wallet_ui/stories/locale.ts
@@ -825,6 +825,7 @@ provideStrings({
   braveWalletTransactionGasPremium: 'Gas Premium',
   braveWalletTransactionGasFeeCap: 'Gas Fee Cap',
   braveWalletNetworkFees: 'Network fees',
+  braveWalletNetworkFee: 'Network fee',
   braveWalletTransactionMayIncludeAccountCreationFee:
     'This transaction may include an account creation fee',
   braveWalletSystemProgramAssignWarningTitle:
@@ -832,6 +833,9 @@ provideStrings({
   braveWalletSystemProgramAssignWarningDescription:
     'This transaction will reassign ownership of the account to a new '
     + 'program. This action is irreversible and may result in loss of funds.',
+  braveSwapSlow: 'Slow',
+  braveSwapAverage: 'Average',
+  braveSwapFast: 'Fast',
 
   // Wallet Main Panel
   braveWalletPanelTitle: 'Brave Wallet',

--- a/components/brave_wallet_ui/stories/mock-data/mock-transaction-info.ts
+++ b/components/brave_wallet_ui/stories/mock-data/mock-transaction-info.ts
@@ -6,6 +6,7 @@
 // Types
 import {
   BraveWallet,
+  MaxPriorityFeeOptionType,
   SerializableTransactionInfo,
   StorybookCoinTypes,
   StorybookTransactionTypes,
@@ -626,3 +627,22 @@ export const getPostConfirmationStatusMockTransaction = (
       : undefined,
   } as SerializableTransactionInfo
 }
+
+export const mockSuggestedMaxPriorityFeeOptions: MaxPriorityFeeOptionType[] = [
+  {
+    id: 'slow',
+    fee: '0x2171aa3351',
+    duration: '28 min',
+  },
+  {
+    id: 'average',
+    fee: '0x8171aa3357',
+    duration: '7 min',
+  },
+
+  {
+    id: 'fast',
+    fee: '0x1270aa33510',
+    duration: '1 min',
+  },
+]

--- a/components/brave_wallet_ui/stories/wrappers/wallet_story_wrapper.style.ts
+++ b/components/brave_wallet_ui/stories/wrappers/wallet_story_wrapper.style.ts
@@ -18,4 +18,5 @@ export const PanelWrapper = styled.div`
   box-shadow: ${leo.effect.elevation['02']};
   border: 1px solid ${leo.color.divider.subtle};
   overflow: hidden;
+  contain: layout;
 `

--- a/components/resources/wallet_strings.grdp
+++ b/components/resources/wallet_strings.grdp
@@ -1087,6 +1087,7 @@
   <message name="IDS_BRAVE_WALLET_AUTO_DISCOVERY_EMPTY_STATE_ACTIONS" desc="NFTs tab empty state action button text when auto discovery is enabled"><ph name="REFRESH_START">$1</ph>Refresh<ph name="REFRESH_END">/$1</ph> or <ph name="IMPORT_START">$2</ph>Import Manually<ph name="IMPORT_END">/$2</ph></message>
   <message name="IDS_BRAVE_WALLET_AUTO_DISCOVERY_EMPTY_STATE_REFRESH" desc="NFTs tab empty state refreshing text">Refreshing</message>
   <message name="IDS_BRAVE_WALLET_NETWORK_FEES" desc="Label for blockchain network fees">Network fees</message>
+  <message name="IDS_BRAVE_WALLET_NETWORK_FEE" desc="Label for blockchain network fee">Network fee</message>
   <message name="IDS_WALLET_EIP6963_PROVIDER_NAME" desc="Provider name which will be return when announce ethereum provider">Brave Wallet</message>
   <message name="IDS_BRAVE_WALLET_RECEIVE" desc="Receive asset event title">Receive</message>
   <message name="IDS_BRAVE_WALLET_FROM" desc="From address label">From</message>


### PR DESCRIPTION
## Description 

Built out the new `Suggested Max Priority Fee` selector to be used in the future.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/47947>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

## Test Plan:
This PR was to just build out the `Component`, test plan for this component will be in a separate PR when this component is used. You are able to view though in `Storybook`

<img width="428" height="319" alt="Screenshot 22" src="https://github.com/user-attachments/assets/23a3031e-9085-4752-8b65-3470c2c1512f" />

