### PR TITLE
Use regional capabilities service instead of accessing kCountryIDAtInstall pref.

### DIFF
--- a/browser/brave_rewards/BUILD.gn
+++ b/browser/brave_rewards/BUILD.gn
@@ -46,6 +46,7 @@ source_set("brave_rewards_impl") {
     "//chrome/browser/bitmap_fetcher",
     "//chrome/browser/favicon",
     "//chrome/browser/profiles",
+    "//chrome/browser/regional_capabilities",
     "//chrome/browser/ui",
     "//components/keyed_service/content",
     "//components/prefs",

--- a/browser/brave_rewards/rewards_service_factory.cc
+++ b/browser/brave_rewards/rewards_service_factory.cc
@@ -20,6 +20,7 @@
 #include "chrome/browser/favicon/favicon_service_factory.h"
 #include "chrome/browser/profiles/incognito_helpers.h"
 #include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/regional_capabilities/regional_capabilities_service_factory.h"
 #include "components/keyed_service/content/browser_context_dependency_manager.h"
 #include "content/public/browser/storage_partition.h"
 #include "extensions/buildflags/buildflags.h"
@@ -62,6 +63,8 @@ RewardsServiceFactory::RewardsServiceFactory()
   DependsOn(extensions::EventRouterFactory::GetInstance());
 #endif
   DependsOn(brave_wallet::BraveWalletServiceFactory::GetInstance());
+  DependsOn(
+      regional_capabilities::RegionalCapabilitiesServiceFactory::GetInstance());
 }
 
 std::unique_ptr<KeyedService>
@@ -105,15 +108,16 @@ RewardsServiceFactory::BuildServiceInstanceForBrowserContext(
       },
       profile);
 
-  std::unique_ptr<RewardsServiceImpl> rewards_service =
-      std::make_unique<RewardsServiceImpl>(
-          profile->GetPrefs(), profile->GetPath(),
-          FaviconServiceFactory::GetForProfile(
-              profile, ServiceAccessType::EXPLICIT_ACCESS),
-          request_image_callback, cancel_request_image_callback,
-          profile->GetDefaultStoragePartition(),
-          brave_wallet::BraveWalletServiceFactory::GetServiceForContext(
-              context));
+  std::unique_ptr<RewardsServiceImpl> rewards_service = std::make_unique<
+      RewardsServiceImpl>(
+      profile->GetPrefs(), profile->GetPath(),
+      FaviconServiceFactory::GetForProfile(profile,
+                                           ServiceAccessType::EXPLICIT_ACCESS),
+      request_image_callback, cancel_request_image_callback,
+      profile->GetDefaultStoragePartition(),
+      brave_wallet::BraveWalletServiceFactory::GetServiceForContext(context),
+      regional_capabilities::RegionalCapabilitiesServiceFactory::GetForProfile(
+          profile));
   rewards_service->Init(std::move(extension_observer),
                         std::move(notification_observer));
   return rewards_service;

--- a/browser/ui/webui/welcome_page/brave_welcome_ui.cc
+++ b/browser/ui/webui/welcome_page/brave_welcome_ui.cc
@@ -35,7 +35,7 @@
 #include "components/grit/brave_components_resources.h"
 #include "components/grit/brave_components_strings.h"
 #include "components/prefs/pref_service.h"
-#include "components/regional_capabilities/regional_capabilities_prefs.h"
+#include "components/regional_capabilities/regional_capabilities_country_id.h"
 #include "content/public/browser/gpu_data_manager.h"
 #include "content/public/browser/page_navigator.h"
 #include "content/public/browser/web_ui_data_source.h"
@@ -121,17 +121,17 @@ BraveWelcomeUI::BraveWelcomeUI(content::WebUI* web_ui, const std::string& name)
                                                              // browser
 
   Profile* profile = Profile::FromWebUI(web_ui);
-  // added to allow front end to read/modify default search engine
-  web_ui->AddMessageHandler(std::make_unique<
-                            settings::BraveSearchEnginesHandler>(
-      profile,
+  auto* regional_capabilities_service =
       regional_capabilities::RegionalCapabilitiesServiceFactory::GetForProfile(
-          profile)));
+          profile);
+  // added to allow front end to read/modify default search engine
+  web_ui->AddMessageHandler(
+      std::make_unique<settings::BraveSearchEnginesHandler>(
+          profile, regional_capabilities_service));
 
   // Open additional page in Japanese region
   country_codes::CountryId country_id =
-      country_codes::CountryId::Deserialize(profile->GetPrefs()->GetInteger(
-          regional_capabilities::prefs::kCountryIDAtInstall));
+      regional_capabilities_service->GetCountryId().GetCountryCode();
   const bool is_jpn = country_id == country_codes::CountryId("JP");
   if (!profile->GetPrefs()->GetBoolean(
           brave::welcome_ui::prefs::kHasSeenBraveWelcomePage)) {

--- a/components/brave_rewards/content/rewards_service_impl.cc
+++ b/components/brave_rewards/content/rewards_service_impl.cc
@@ -58,7 +58,8 @@
 #include "components/grit/brave_components_strings.h"
 #include "components/os_crypt/sync/os_crypt.h"
 #include "components/prefs/pref_service.h"
-#include "components/regional_capabilities/regional_capabilities_prefs.h"
+#include "components/regional_capabilities/regional_capabilities_country_id.h"
+#include "components/regional_capabilities/regional_capabilities_service.h"
 #include "content/public/browser/service_process_host.h"
 #include "content/public/browser/storage_partition.h"
 #include "content/public/browser/url_data_source.h"
@@ -202,13 +203,16 @@ RewardsServiceImpl::RewardsServiceImpl(
     RequestImageCallback request_image_callback,
     CancelImageRequestCallback cancel_image_request_callback,
     content::StoragePartition* storage_partition,
-    brave_wallet::BraveWalletService* brave_wallet_service)
+    brave_wallet::BraveWalletService* brave_wallet_service,
+    regional_capabilities::RegionalCapabilitiesService*
+        regional_capabilities_service)
     : prefs_(prefs),
       favicon_service_(favicon_service),
       request_image_callback_(request_image_callback),
       cancel_image_request_callback_(cancel_image_request_callback),
       storage_partition_(storage_partition),
       brave_wallet_service_(brave_wallet_service),
+      regional_capabilities_service_(regional_capabilities_service),
       receiver_(this),
       file_task_runner_(base::ThreadPool::CreateSequencedTaskRunner(
           {base::MayBlock(), base::TaskPriority::USER_VISIBLE,
@@ -487,11 +491,9 @@ std::string RewardsServiceImpl::GetCountryCode() const {
   std::string declared_geo = prefs_->GetString(prefs::kDeclaredGeo);
   return !declared_geo.empty()
              ? declared_geo
-             : std::string(
-                   country_codes::CountryId::Deserialize(
-                       prefs_->GetInteger(
-                           regional_capabilities::prefs::kCountryIDAtInstall))
-                       .CountryCode());
+             : std::string(regional_capabilities_service_->GetCountryId()
+                               .GetCountryCode()
+                               .CountryCode());
 }
 
 void RewardsServiceImpl::GetAvailableCountries(

--- a/components/brave_rewards/content/rewards_service_impl.h
+++ b/components/brave_rewards/content/rewards_service_impl.h
@@ -51,7 +51,9 @@ class FaviconService;
 namespace network {
 class SimpleURLLoader;
 }  // namespace network
-
+namespace regional_capabilities {
+class RegionalCapabilitiesService;
+}  // namespace regional_capabilities
 namespace brave_wallet {
 class BraveWalletService;
 }
@@ -86,7 +88,9 @@ class RewardsServiceImpl final : public RewardsService,
                      RequestImageCallback request_image_callback,
                      CancelImageRequestCallback cancel_image_request_callback,
                      content::StoragePartition* storage_partition,
-                     brave_wallet::BraveWalletService* brave_wallet_service);
+                     brave_wallet::BraveWalletService* brave_wallet_service,
+                     regional_capabilities::RegionalCapabilitiesService*
+                         regional_capabilities_service);
 
   RewardsServiceImpl(const RewardsServiceImpl&) = delete;
   RewardsServiceImpl& operator=(const RewardsServiceImpl&) = delete;
@@ -446,6 +450,8 @@ class RewardsServiceImpl final : public RewardsService,
   const CancelImageRequestCallback cancel_image_request_callback_;
   raw_ptr<content::StoragePartition> storage_partition_;  // NOT OWNED
   raw_ptr<brave_wallet::BraveWalletService> brave_wallet_service_ = nullptr;
+  raw_ptr<regional_capabilities::RegionalCapabilitiesService>
+      regional_capabilities_service_ = nullptr;
   mojo::AssociatedReceiver<mojom::RewardsEngineClient> receiver_;
   mojo::AssociatedRemote<mojom::RewardsEngine> engine_;
   mojo::Remote<mojom::RewardsEngineFactory> engine_factory_;

--- a/components/brave_rewards/content/rewards_service_impl_jp_unittest.cc
+++ b/components/brave_rewards/content/rewards_service_impl_jp_unittest.cc
@@ -43,7 +43,7 @@ class RewardsServiceJPTest : public testing::Test {
             const GURL& url, base::OnceCallback<void(const SkBitmap& bitmap)>,
             const net::NetworkTrafficAnnotationTag& traffic_annotation)>(),
         base::RepeatingCallback<void(int)>(),
-        profile()->GetDefaultStoragePartition(), nullptr);
+        profile()->GetDefaultStoragePartition(), nullptr, nullptr);
     ASSERT_TRUE(rewards_service());
 
     profile()->GetPrefs()->SetString(prefs::kDeclaredGeo, "JP");

--- a/components/brave_rewards/content/rewards_service_impl_unittest.cc
+++ b/components/brave_rewards/content/rewards_service_impl_unittest.cc
@@ -70,8 +70,9 @@ class RewardsServiceTest : public testing::Test {
             const GURL& url, base::OnceCallback<void(const SkBitmap& bitmap)>,
             const net::NetworkTrafficAnnotationTag& traffic_annotation)>(),
         base::RepeatingCallback<void(int)>(),
-        profile()->GetDefaultStoragePartition(), nullptr);
+        profile()->GetDefaultStoragePartition(), nullptr, nullptr);
     ASSERT_TRUE(rewards_service());
+    profile()->GetPrefs()->SetString(prefs::kDeclaredGeo, "US");
     observer_ = std::make_unique<MockRewardsServiceObserver>();
     rewards_service_->AddObserver(observer_.get());
   }


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/47913

Fixes additional Welcome page in Japanese not showing up on Linux.
Also, fixes default country not being auto-highlighted in the Rewards country selection dialog (on Linux).

These happen on Linux only because regional capabilities service client on Linux only uses variations service values and doesn't fall back onto the device locale which causes kCountryIDAtInstall  preference to never be set. Since we were accessing the preference directly we were ending up with an invalid country id on Linux ("ZZ"). Using regional capabilities service instead gets the correct value since the service falls back on the device locale when the client returns an invalid country id.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
