### PR TITLE
[bots] Move `gn` args to static `.gni` files

### DIFF
--- a/build/args/blink_platform_defaults.gni
+++ b/build/args/blink_platform_defaults.gni
@@ -1,0 +1,17 @@
+# Copyright (c) 2025 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+# This file contains defaults for gn values in Chromium which are always
+# overridden in Brave builds. This file in particular is only included in
+# builds for platforms supporting blink, meaning anything other than iOS.
+
+# Please provide a reason if you are adding new overrides to this file.
+
+proprietary_codecs = true
+ffmpeg_branding = "Chrome"
+branding_path_component = "brave"
+branding_path_product = "brave"
+enable_glic = false
+enable_widevine = true

--- a/build/args/brave_defaults.gni
+++ b/build/args/brave_defaults.gni
@@ -1,0 +1,13 @@
+# Copyright (c) 2025 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+# This file contains strict overrides for gn values in Chromium which we always
+# override in Brave builds.
+
+# Please provide a reason if you are adding new overrides to this file.
+
+disable_fieldtrial_testing_config = true
+root_extra_deps = [ "//brave" ]
+generate_about_credits = true

--- a/build/commands/lib/config.js
+++ b/build/commands/lib/config.js
@@ -399,6 +399,7 @@ Config.prototype.buildArgs = function () {
   versionParts = versionParts.split('.')
 
   let args = {
+    'import("//brave/build/args/brave_defaults.gni")': null,
     is_asan: this.isAsan(),
     enable_full_stack_frames_for_profiling: this.isAsan(),
     v8_enable_verify_heap: this.isAsan(),
@@ -406,20 +407,12 @@ Config.prototype.buildArgs = function () {
     is_ubsan_vptr: this.is_ubsan,
     is_ubsan_no_recover: this.is_ubsan,
     is_msan: this.is_msan,
-    disable_fieldtrial_testing_config: true,
     safe_browsing_mode: 1,
-    root_extra_deps: ['//brave'],
     // TODO: Re-enable when chromium_src overrides work for files in relative
     // paths like widevine_cmdm_compoennt_installer.cc
     // use_jumbo_build: !this.officialBuild,
     is_component_build: this.isComponentBuild(),
     is_universal_binary: this.isUniversalBinary,
-    proprietary_codecs: true,
-    ffmpeg_branding: 'Chrome',
-    branding_path_component: 'brave',
-    branding_path_product: 'brave',
-    enable_glic: false,
-    enable_widevine: true,
     // Our copy of signature_generator.py doesn't support --ignore_missing_cert:
     ignore_missing_widevine_signing_cert: false,
     target_cpu: this.targetArch,
@@ -442,6 +435,10 @@ Config.prototype.buildArgs = function () {
     use_libfuzzer: this.use_libfuzzer,
     enable_update_notifications: this.isOfficialBuild(),
     generate_about_credits: true,
+  }
+
+  if (this.targetOS !== 'ios') {
+    args['import("//brave/build/args/blink_platform_defaults.gni")'] = null
   }
 
   for (const key of this.forwardEnvArgsToGn) {
@@ -735,12 +732,6 @@ Config.prototype.buildArgs = function () {
 
     delete args.safebrowsing_api_endpoint
     delete args.safe_browsing_mode
-    delete args.proprietary_codecs
-    delete args.ffmpeg_branding
-    delete args.branding_path_component
-    delete args.branding_path_product
-    delete args.enable_glic
-    delete args.enable_widevine
     delete args.enable_hangout_services_extension
     delete args.brave_google_api_endpoint
     delete args.brave_google_api_key


### PR DESCRIPTION
This PR introduces:

  - `//brave/build/args/brave_defaults.gni`
  - `//brave/build/args/blink_platform_defaults.gni`

These two `.gni` sources are to be used to provide absolute overrides
for `gn` args that are always overridden in Brave builds. Unfortunately,
having a single `gni` was not possible, as `iOS` in particular does not
uses a good number of flags that the other platforms use, so
the blink platform defaults is provided for args that are supported in all
platforms but ios.

This change is one of many steps being taken to move handling of `gn`
args out of `config.js`.

Resolves https://github.com/brave/brave-browser/issues/47956
