### PR TITLE
[CodeHealth] Remove uses of `base::StringPrintf` pt.3

### DIFF
--- a/browser/ai_chat/full_screenshotter_unittest.cc
+++ b/browser/ai_chat/full_screenshotter_unittest.cc
@@ -367,7 +367,7 @@ TEST_F(FullScreenshotterTest, CaptureFailedAllErrorStates) {
     auto result = CaptureScreenshots(web_contents());
     ASSERT_FALSE(result.has_value());
     EXPECT_EQ(result.error(),
-              base::StringPrintf(
+              absl::StrFormat(
                   "Failed to capture a screenshot (CaptureStatus=%d)",
                   static_cast<int>(paint_preview::PaintPreviewBaseService::
                                        CaptureStatus::kCaptureFailed)));
@@ -507,8 +507,8 @@ TEST_F(FullScreenshotterTest, BitmapForMainFrameFailed) {
     auto result = CaptureScreenshots(web_contents());
     ASSERT_FALSE(result.has_value());
     EXPECT_EQ(result.error(),
-              base::StringPrintf("Failed to get bitmap (BitmapStatus=%d)",
-                                 static_cast<int>(status)));
+              absl::StrFormat("Failed to get bitmap (BitmapStatus=%d)",
+                              static_cast<int>(status)));
   }
 }
 

--- a/browser/ai_chat/print_preview_extractor_unittest.cc
+++ b/browser/ai_chat/print_preview_extractor_unittest.cc
@@ -397,7 +397,7 @@ class PrintPreviewExtractorTest : public ChromeRenderViewHostTestHarness {
     ASSERT_TRUE(print_preview_ui_id);
     EXPECT_EQ(
         print_render_frame->GetSettings(),
-        base::test::ParseJsonDict(base::StringPrintf(
+        base::test::ParseJsonDict(absl::StrFormat(
             kSettingTemplate,
             static_cast<int>(printing::mojom::MarginType::kDefaultMargins),
             static_cast<int>(printing::mojom::ColorModel::kColor),
@@ -407,7 +407,7 @@ class PrintPreviewExtractorTest : public ChromeRenderViewHostTestHarness {
             static_cast<int>(printing::ScalingType::DEFAULT),
             *print_preview_ui_id, request_id,
             base::UTF16ToUTF8(web_contents()->GetTitle()),
-            expect_preview_modifiable ? "true" : "false",
+            base::ToString(expect_preview_modifiable),
             web_contents()->GetLastCommittedURL().spec())));
   }
 

--- a/browser/brave_rewards/test/util/rewards_browsertest_context_util.cc
+++ b/browser/brave_rewards/test/util/rewards_browsertest_context_util.cc
@@ -345,7 +345,7 @@ void DragAndDrop(content::WebContents* context,
     return;
   }
 
-  const std::string js_code = base::StringPrintf(
+  const std::string js_code = absl::StrFormat(
       R"(
         var triggerDragAndDrop = function (selectorDrag, selectorDrop) {
 
@@ -401,7 +401,7 @@ void DragAndDrop(content::WebContents* context,
           '%s',
           '%s')
       )",
-      drag_selector.c_str(), drop_selector.c_str());
+      drag_selector, drop_selector);
   content::EvalJsResult jsResult =
       EvalJs(context, js_code, content::EXECUTE_SCRIPT_NO_RESOLVE_PROMISES,
              content::ISOLATED_WORLD_ID_CONTENT_END);

--- a/browser/brave_rewards/test/util/rewards_browsertest_contribution.cc
+++ b/browser/brave_rewards/test/util/rewards_browsertest_contribution.cc
@@ -133,7 +133,7 @@ void RewardsBrowserTestContribution::TipPublisher(
         site_banner_contents.get())[selection];
 
     // Select the tip amount (default is 1.000 BAT)
-    std::string amount_selector = base::StringPrintf(
+    std::string amount_selector = absl::StrFormat(
         "[data-test-id=tip-amount-options] [data-option-index='%u']",
         selection);
 
@@ -197,7 +197,7 @@ void RewardsBrowserTestContribution::VerifyTip(const double amount,
                                    : "[data-test-id=rewards-summary-one-time]";
 
   test_util::WaitForElementToContain(contents(), selector,
-                                     base::StringPrintf("%.2f BAT", amount));
+                                     absl::StrFormat("%.2f BAT", amount));
 }
 
 void RewardsBrowserTestContribution::IsBalanceCorrect() {

--- a/browser/brave_rewards/test/util/rewards_browsertest_network_util.cc
+++ b/browser/brave_rewards/test/util/rewards_browsertest_network_util.cc
@@ -124,7 +124,7 @@ std::string GetUpholdUser() {
 
 std::string GetUpholdCard(const std::string& balance,
                           const std::string& address) {
-  return base::StringPrintf(
+  return absl::StrFormat(
       R"({
         "available": "%s",
         "balance": "%s",
@@ -138,14 +138,14 @@ std::string GetUpholdCard(const std::string& balance,
           "starred": false
         }
       })",
-      balance.c_str(), balance.c_str(), address.c_str());
+      balance, balance, address);
 }
 
 std::string GetOrderCreateResponse(mojom::SKUOrderPtr sku_order) {
   DCHECK(sku_order);
   std::string items;
   for (const auto& item : sku_order->items) {
-    items.append(base::StringPrintf(
+    items.append(absl::StrFormat(
         R"({
         "id": "%s",
         "orderId": "%s",
@@ -157,11 +157,11 @@ std::string GetOrderCreateResponse(mojom::SKUOrderPtr sku_order) {
         "price": "%g",
         "description": "%s"
       })",
-        item->order_item_id.c_str(), sku_order->order_id.c_str(),
-        item->quantity, item->price, item->description.c_str()));
+        item->order_item_id, sku_order->order_id, item->quantity, item->price,
+        item->description));
   }
 
-  return base::StringPrintf(
+  return absl::StrFormat(
       R"({
         "id": "%s",
         "createdAt": "2020-04-08T08:22:26.288974Z",
@@ -172,7 +172,7 @@ std::string GetOrderCreateResponse(mojom::SKUOrderPtr sku_order) {
         "status": "pending",
         "items": [%s]
       })",
-      sku_order->order_id.c_str(), sku_order->total_amount, items.c_str());
+      sku_order->order_id, sku_order->total_amount, items);
 }
 
 }  // namespace brave_rewards::test_util

--- a/browser/brave_rewards/test/util/rewards_browsertest_util.cc
+++ b/browser/brave_rewards/test/util/rewards_browsertest_util.cc
@@ -161,7 +161,7 @@ void ActivateTabAtIndex(Browser* browser, const int32_t index) {
 }
 
 std::string BalanceDoubleToString(double amount) {
-  return base::StringPrintf("%.3f", amount);
+  return absl::StrFormat("%.3f", amount);
 }
 
 std::string GetUpholdExternalAddress() {

--- a/browser/brave_wallet/cardano_provider_renderer_browsertest.cc
+++ b/browser/brave_wallet/cardano_provider_renderer_browsertest.cc
@@ -90,10 +90,10 @@ std::string EnableScript() {
 }
 
 std::string NonWriteableScriptProperty(const std::string& property) {
-  return base::StringPrintf(
+  return absl::StrFormat(
       R"(window.cardano.brave.%s = "brave";
          !(window.cardano.brave.%s === "brave");)",
-      property.c_str(), property.c_str());
+      property, property);
 }
 
 class TestCardanoProvider : public brave_wallet::mojom::CardanoProvider {

--- a/browser/content_settings/brave_content_settings_browsertest.cc
+++ b/browser/content_settings/brave_content_settings_browsertest.cc
@@ -37,7 +37,7 @@ class BraveContentSettingsBrowserTest : public InProcessBrowserTest {
     InProcessBrowserTest::SetUpCommandLine(command_line);
     command_line->AppendSwitchASCII(
         network::switches::kHostResolverRules,
-        base::StringPrintf("MAP *:443 127.0.0.1:%d", https_server_.port()));
+        absl::StrFormat("MAP *:443 127.0.0.1:%d", https_server_.port()));
   }
 
   void SetUpOnMainThread() override {

--- a/browser/debounce/debounce_browsertest.cc
+++ b/browser/debounce/debounce_browsertest.cc
@@ -143,8 +143,7 @@ class DebounceBrowserTest : public BaseLocalDataFilesBrowserTest {
     base::Base64UrlEncode(landing_url.spec(),
                           base::Base64UrlEncodePolicy::OMIT_PADDING,
                           &encoded_destination);
-    const std::string query =
-        base::StringPrintf("url=%s", encoded_destination.c_str());
+    const std::string query = absl::StrFormat("url=%s", encoded_destination);
     GURL::Replacements replacement;
     replacement.SetQueryStr(query);
     return original_url.ReplaceComponents(replacement);

--- a/browser/ephemeral_storage/ephemeral_storage_blink_memory_cache_browsertest.cc
+++ b/browser/ephemeral_storage/ephemeral_storage_blink_memory_cache_browsertest.cc
@@ -46,9 +46,9 @@ class EphemeralStorageBlinkMemoryCacheBrowserTestBase
     auto* rfh = ui_test_utils::NavigateToURLWithDisposition(
         browser, url, WindowOpenDisposition::NEW_FOREGROUND_TAB,
         ui_test_utils::BROWSER_TEST_WAIT_FOR_LOAD_STOP);
-    EXPECT_TRUE(content::ExecJs(
-        content::ChildFrameAt(rfh, 0),
-        base::StringPrintf(kLoadImgAsync, img_url.spec().c_str())));
+    EXPECT_TRUE(
+        content::ExecJs(content::ChildFrameAt(rfh, 0),
+                        absl::StrFormat(kLoadImgAsync, img_url.spec())));
   }
 
   void ClearHttpCache() {

--- a/browser/ephemeral_storage/ephemeral_storage_browsertest.cc
+++ b/browser/ephemeral_storage/ephemeral_storage_browsertest.cc
@@ -123,9 +123,8 @@ std::unique_ptr<HttpResponse> HandleCrossSiteRedirectWithSiteCookie(
   std::string dest;
   size_t delimiter = dest_all.find("/");
   if (delimiter != std::string::npos) {
-    dest = base::StringPrintf(
-        "//%s:%hu/%s", dest_all.substr(0, delimiter).c_str(), server->port(),
-        dest_all.substr(delimiter + 1).c_str());
+    dest = absl::StrFormat("//%s:%hu/%s", dest_all.substr(0, delimiter),
+                           server->port(), dest_all.substr(delimiter + 1));
   }
 
   auto http_response = std::make_unique<BasicHttpResponse>();
@@ -136,7 +135,7 @@ std::unique_ptr<HttpResponse> HandleCrossSiteRedirectWithSiteCookie(
       "server-redirect=true;path=/;SameSite=None;Secure;Max-Age=600");
   http_response->set_content_type("text/html");
   http_response->set_content(
-      base::StringPrintf("<!doctype html><p>Redirecting to %s", dest.c_str()));
+      absl::StrFormat("<!doctype html><p>Redirecting to %s", dest));
   return http_response;
 }
 
@@ -250,7 +249,7 @@ void EphemeralStorageBrowserTest::SetUpCommandLine(
   command_line->AppendSwitch(switches::kDisableRendererBackgrounding);
   command_line->AppendSwitchASCII(
       network::switches::kHostResolverRules,
-      base::StringPrintf("MAP *:443 127.0.0.1:%d", https_server_.port()));
+      absl::StrFormat("MAP *:443 127.0.0.1:%d", https_server_.port()));
 }
 
 void EphemeralStorageBrowserTest::SetUpInProcessBrowserTestFixture() {
@@ -321,24 +320,23 @@ void EphemeralStorageBrowserTest::SetStorageValueInFrame(
     RenderFrameHost* host,
     std::string value,
     StorageType storage_type) {
-  std::string script =
-      base::StringPrintf("%sStorage.setItem('storage_key', '%s');",
-                         ToString(storage_type), value.c_str());
+  std::string script = absl::StrFormat(
+      "%sStorage.setItem('storage_key', '%s');", ToString(storage_type), value);
   ASSERT_TRUE(content::ExecJs(host, script));
 }
 
 content::EvalJsResult EphemeralStorageBrowserTest::GetStorageValueInFrame(
     RenderFrameHost* host,
     StorageType storage_type) {
-  std::string script = base::StringPrintf("%sStorage.getItem('storage_key');",
-                                          ToString(storage_type));
+  std::string script = absl::StrFormat("%sStorage.getItem('storage_key');",
+                                       ToString(storage_type));
   return content::EvalJs(host, script);
 }
 
 void EphemeralStorageBrowserTest::SetCookieInFrame(RenderFrameHost* host,
                                                    std::string cookie) {
-  std::string script = base::StringPrintf(
-      "document.cookie='%s; path=/; SameSite=None; Secure'", cookie.c_str());
+  std::string script = absl::StrFormat(
+      "document.cookie='%s; path=/; SameSite=None; Secure'", cookie);
   ASSERT_TRUE(content::ExecJs(host, script));
 }
 

--- a/browser/ephemeral_storage/hsts_partitioning_browsertest.cc
+++ b/browser/ephemeral_storage/hsts_partitioning_browsertest.cc
@@ -76,10 +76,9 @@ class HSTSPartitioningBrowserTestBase : public InProcessBrowserTest {
     mock_cert_verifier_.SetUpCommandLine(command_line);
     command_line->AppendSwitchASCII(
         network::switches::kHostResolverRules,
-        base::StringPrintf("MAP *:80 127.0.0.1:%d,"
-                           "MAP *:443 127.0.0.1:%d",
-                           embedded_test_server()->port(),
-                           https_server_.port()));
+        absl::StrFormat("MAP *:80 127.0.0.1:%d,"
+                        "MAP *:443 127.0.0.1:%d",
+                        embedded_test_server()->port(), https_server_.port()));
   }
 
   void SetUpOnMainThread() override {

--- a/browser/extensions/extension_system_browsertest.cc
+++ b/browser/extensions/extension_system_browsertest.cc
@@ -38,7 +38,7 @@ class ExtensionSystemBrowserTest : public ExtensionBrowserTest {
     ExtensionBrowserTest::SetUpCommandLine(command_line);
     command_line->AppendSwitchASCII(
         network::switches::kHostResolverRules,
-        base::StringPrintf("MAP *:443 127.0.0.1:%d", https_server_.port()));
+        absl::StrFormat("MAP *:443 127.0.0.1:%d", https_server_.port()));
     mock_cert_verifier_.SetUpCommandLine(command_line);
   }
 

--- a/browser/farbling/brave_dark_mode_fingerprint_protection_browsertest.cc
+++ b/browser/farbling/brave_dark_mode_fingerprint_protection_browsertest.cc
@@ -150,15 +150,15 @@ class BraveDarkModeFingerprintProtectionTest : public InProcessBrowserTest {
   bool IsReportingDarkMode() {
     bool light_mode_result =
         content::EvalJs(contents(),
-                        base::StringPrintf(kMatchDarkModeFormatString, "light"))
+                        absl::StrFormat(kMatchDarkModeFormatString, "light"))
             .ExtractBool();
 
     if (!light_mode_result) {
       // Sanity check to make sure that 'dark' is reported for
       // prefers-color-scheme when 'light' was not found before.
-      EXPECT_EQ(true, content::EvalJs(contents(),
-                                      base::StringPrintf(
-                                          kMatchDarkModeFormatString, "dark")));
+      EXPECT_EQ(true, content::EvalJs(
+                          contents(),
+                          absl::StrFormat(kMatchDarkModeFormatString, "dark")));
 
       // Report dark mode.
       return true;

--- a/browser/farbling/brave_navigator_useragent_farbling_browsertest.cc
+++ b/browser/farbling/brave_navigator_useragent_farbling_browsertest.cc
@@ -178,7 +178,7 @@ class BraveNavigatorUserAgentFarblingBrowserTest : public InProcessBrowserTest {
     mock_cert_verifier_.SetUpCommandLine(command_line);
     command_line->AppendSwitchASCII(
         network::switches::kHostResolverRules,
-        base::StringPrintf("MAP *:443 127.0.0.1:%d", https_server_->port()));
+        absl::StrFormat("MAP *:443 127.0.0.1:%d", https_server_->port()));
 #if BUILDFLAG(ENABLE_EXTENSIONS)
     command_line->AppendSwitch(extensions::switches::kOffscreenDocumentTesting);
 #endif  // BUILDFLAG(ENABLE_EXTENSIONS)

--- a/browser/net/brave_network_audit_search_ad_browsertest.cc
+++ b/browser/net/brave_network_audit_search_ad_browsertest.cc
@@ -122,7 +122,7 @@ class BraveNetworkAuditSearchAdTest : public InProcessBrowserTest {
     static constexpr char kAllowedBraveSearchTemplate[] =
         "https://search.brave.com:%s/";
     allowed_prefixes.push_back(
-        base::StringPrintf(kAllowedBraveSearchTemplate, port.c_str()));
+        absl::StrFormat(kAllowedBraveSearchTemplate, port));
     VerifyNetworkAuditLog(net_log_path_, audit_results_path_, allowed_prefixes);
   }
 

--- a/browser/net/brave_network_delegate_browsertest.cc
+++ b/browser/net/brave_network_delegate_browsertest.cc
@@ -37,11 +37,11 @@ namespace {
 bool NavigateRenderFrameToURL(content::RenderFrameHost* frame,
                               std::string iframe_id,
                               const GURL& url) {
-  std::string script = base::StringPrintf(
+  std::string script = absl::StrFormat(
       "setTimeout(\""
       "var iframes = document.getElementById('%s');iframes.src='%s';"
       "\",0)",
-      iframe_id.c_str(), url.spec().c_str());
+      iframe_id, url.spec());
 
   content::TestNavigationManager navigation_manager(
       content::WebContents::FromRenderFrameHost(frame), url);

--- a/browser/net/brave_proxying_url_loader_factory.cc
+++ b/browser/net/brave_proxying_url_loader_factory.cc
@@ -286,11 +286,11 @@ void BraveProxyingURLLoaderFactory::InProgressRequest::
 
   network::mojom::URLResponseHeadPtr head =
       network::mojom::URLResponseHead::New();
-  std::string headers = base::StringPrintf(
+  std::string headers = absl::StrFormat(
       "HTTP/1.1 %i Internal Redirect\n"
       "Location: %s\n"
       "Non-Authoritative-Reason: WebRequest API\n\n",
-      kInternalRedirectStatusCode, redirect_url_.spec().c_str());
+      kInternalRedirectStatusCode, redirect_url_.spec());
 
   // Cross-origin requests need to modify the Origin header to 'null'. Since
   // CorsURLLoader sets |request_initiator| to the Origin request header in

--- a/browser/net/brave_site_hacks_network_delegate_helper_browsertest.cc
+++ b/browser/net/brave_site_hacks_network_delegate_helper_browsertest.cc
@@ -130,8 +130,7 @@ class BraveSiteHacksNetworkDelegateBrowserTest : public InProcessBrowserTest {
     base::Base64UrlEncode(destination_url.spec(),
                           base::Base64UrlEncodePolicy::OMIT_PADDING,
                           &encoded_destination);
-    const std::string query =
-        base::StringPrintf("url=%s", encoded_destination.c_str());
+    const std::string query = absl::StrFormat("url=%s", encoded_destination);
     GURL::Replacements replacement;
     replacement.SetQueryStr(query);
     return navigation_url.ReplaceComponents(replacement);

--- a/browser/ntp_background/custom_background_file_manager.cc
+++ b/browser/ntp_background/custom_background_file_manager.cc
@@ -201,8 +201,8 @@ void CustomBackgroundFileManager::SaveImageAsPNG(
 
         base::FilePath modified_path = target_path;
         for (int i = 1; base::PathExists(modified_path); ++i) {
-          modified_path = target_path.InsertBeforeExtensionASCII(
-              base::StringPrintf("-%d", i));
+          modified_path =
+              target_path.InsertBeforeExtensionASCII(absl::StrFormat("-%d", i));
         }
 
         if (!base::WriteFile(modified_path, *encoded)) {

--- a/browser/ntp_background/custom_background_file_manager_browsertest.cc
+++ b/browser/ntp_background/custom_background_file_manager_browsertest.cc
@@ -120,8 +120,8 @@ IN_PROC_BROWSER_TEST_F(CustomBackgroundFileManagerBrowserTest,
         custom_file_manager().GetCustomBackgroundDirectory().AppendASCII(
             kTestImageName);
     if (i > 0) {
-      expected_path = expected_path.InsertBeforeExtensionASCII(
-          base::StringPrintf("-%d", i));
+      expected_path =
+          expected_path.InsertBeforeExtensionASCII(absl::StrFormat("-%d", i));
     }
 
     auto check_res =

--- a/browser/script_injector/script_injector_browsertest.cc
+++ b/browser/script_injector/script_injector_browsertest.cc
@@ -108,7 +108,7 @@ IN_PROC_BROWSER_TEST_F(ScriptInjectorBrowserTest, InjectScriptAwaitPromise) {
     EXPECT_TRUE(value.GetBool());
     run_loop.Quit();
   });
-  auto script = base::StringPrintf(kScript, "true");
+  auto script = absl::StrFormat(kScript, "true");
   const GURL url = https_server_.GetURL("a.com", "/");
   ASSERT_TRUE(content::NavigateToURL(web_contents(), url));
   auto remote = GetRemote(web_contents()->GetPrimaryMainFrame());
@@ -133,7 +133,7 @@ IN_PROC_BROWSER_TEST_F(ScriptInjectorBrowserTest, InjectedScriptReturnsDict) {
     EXPECT_TRUE(*val);
     run_loop.Quit();
   });
-  auto script = base::StringPrintf(kScript, "{ok: true}");
+  auto script = absl::StrFormat(kScript, "{ok: true}");
   ASSERT_TRUE(content::NavigateToURL(web_contents(), url));
   auto remote = GetRemote(web_contents()->GetPrimaryMainFrame());
   remote->RequestAsyncExecuteScript(
@@ -150,7 +150,7 @@ IN_PROC_BROWSER_TEST_F(ScriptInjectorBrowserTest,
                        InjectScriptDoNotAwaitPromise) {
   const GURL url = https_server_.GetURL("a.com", "/");
   auto cb = base::BindOnce([](base::Value value) { FAIL(); });
-  auto script = base::StringPrintf(kScript, "true");
+  auto script = absl::StrFormat(kScript, "true");
   ASSERT_TRUE(content::NavigateToURL(web_contents(), url));
   auto remote = GetRemote(web_contents()->GetPrimaryMainFrame());
   remote->RequestAsyncExecuteScript(

--- a/browser/sessions/brave_session_restore_browsertest.cc
+++ b/browser/sessions/brave_session_restore_browsertest.cc
@@ -129,8 +129,8 @@ class SessionCookiesCleanupOnSessionRestoreBrowserTest
     ASSERT_TRUE(embedded_test_server()->Start());
     command_line->AppendSwitchASCII(
         network::switches::kHostResolverRules,
-        base::StringPrintf("MAP *:80 127.0.0.1:%d",
-                           embedded_test_server()->port()));
+        absl::StrFormat("MAP *:80 127.0.0.1:%d",
+                        embedded_test_server()->port()));
   }
 
   void SetUpOnMainThread() override {

--- a/browser/test/disabled_features/disable_client_hints_browsertest.cc
+++ b/browser/test/disabled_features/disable_client_hints_browsertest.cc
@@ -299,6 +299,6 @@ INSTANTIATE_TEST_SUITE_P(
     ClientHintsBrowserTest,
     ::testing::Bool(),
     [](const testing::TestParamInfo<ClientHintsBrowserTest::ParamType>& info) {
-      return base::StringPrintf("ChromiumCHFeatures_%s",
-                                info.param ? "Enabled" : "Disabled");
+      return absl::StrFormat("ChromiumCHFeatures_%s",
+                             info.param ? "Enabled" : "Disabled");
     });

--- a/browser/tor/test/onion_domain_throttle_browsertest.cc
+++ b/browser/tor/test/onion_domain_throttle_browsertest.cc
@@ -66,7 +66,7 @@ class OnionDomainThrottleBrowserTest : public InProcessBrowserTest {
   net::EmbeddedTestServer* test_server() { return https_server_.get(); }
 
   std::string image_script(const std::string& src) {
-    return base::StringPrintf(R"(
+    return absl::StrFormat(R"(
         new Promise(resolve => {
           let img = document.createElement('img');
           img.src = '%s';
@@ -78,7 +78,7 @@ class OnionDomainThrottleBrowserTest : public InProcessBrowserTest {
           };
         });
     )",
-                              src.c_str());
+                           src);
   }
 
   Browser* OpenTorWindow() {

--- a/browser/translate/brave_translate_browsertest.cc
+++ b/browser/translate/brave_translate_browsertest.cc
@@ -161,9 +161,9 @@ class BraveTranslateBrowserTest : public InProcessBrowserTest {
 
     if (request.GetURL().path() == "/translate") {
       const auto query = request.GetURL().query();
-      EXPECT_NE(query.find(base::StringPrintf("&key=%s",
-                                              BUILDFLAG(BRAVE_SERVICES_KEY))),
-                std::string::npos)
+      EXPECT_NE(
+          query.find(absl::StrFormat("&key=%s", BUILDFLAG(BRAVE_SERVICES_KEY))),
+          std::string::npos)
           << "bad brave api key for request " << request.GetURL();
     }
 
@@ -290,7 +290,7 @@ IN_PROC_BROWSER_TEST_F(BraveTranslateBrowserTest, InternalTranslation) {
                                        "application/json", "[\"This\"]")));
   EXPECT_EQ(
       "[\"This\"]",
-      EvalTranslateJs(base::StringPrintf(
+      EvalTranslateJs(absl::StrFormat(
           kXhrPromiseTemplate, "response",
           "https://translate.googleapis.com/translate_a/t?query=something",
           "true")));
@@ -375,7 +375,7 @@ IN_PROC_BROWSER_TEST_F(BraveTranslateBrowserGoogleRedirectTest,
                                              "image/svg+xml", kTestSvg)));
 
   const auto do_xhr_and_get_final_url =
-      base::StringPrintf(kXhrPromiseTemplate, "responseURL", kTestURL, "false");
+      absl::StrFormat(kXhrPromiseTemplate, "responseURL", kTestURL, "false");
 
   // Check that a page request is unaffected by the js redirections.
   EXPECT_EQ(kTestURL, content::EvalJs(
@@ -395,7 +395,7 @@ IN_PROC_BROWSER_TEST_F(BraveTranslateBrowserGoogleRedirectTest,
     });
   )";
 
-  const auto load_image = base::StringPrintf(kLoadImageTemplate, kTestURL);
+  const auto load_image = absl::StrFormat(kLoadImageTemplate, kTestURL);
 
   // Check that the image is loaded in the main world correctly.
   EXPECT_EQ(true, content::EvalJs(

--- a/browser/ui/ai_chat/ai_chat_tab_helper_unittest.cc
+++ b/browser/ui/ai_chat/ai_chat_tab_helper_unittest.cc
@@ -190,8 +190,8 @@ INSTANTIATE_TEST_SUITE_P(
     AIChatTabHelperUnitTest,
     ::testing::Bool(),
     [](const testing::TestParamInfo<AIChatTabHelperUnitTest::ParamType>& info) {
-      return base::StringPrintf("PrintPreview_%s",
-                                info.param ? "Enabled" : "Disabled");
+      return absl::StrFormat("PrintPreview_%s",
+                             info.param ? "Enabled" : "Disabled");
     });
 
 TEST_P(AIChatTabHelperUnitTest, OnNewPage) {

--- a/browser/ui/views/overlay/brave_video_overlay_window_views.cc
+++ b/browser/ui/views/overlay/brave_video_overlay_window_views.cc
@@ -41,8 +41,8 @@ std::u16string ToString(base::TimeDelta time) {
   const int seconds = (time_in_seconds % 60);
 
   return base::ASCIIToUTF16(
-      hours ? base::StringPrintf("%02d:%02d:%02d", hours, minutes, seconds)
-            : base::StringPrintf("%02d:%02d", minutes, seconds));
+      hours ? absl::StrFormat("%02d:%02d:%02d", hours, minutes, seconds)
+            : absl::StrFormat("%02d:%02d", minutes, seconds));
 }
 
 std::u16string ToString(const media_session::MediaPosition& position) {

--- a/browser/ui/views/playlist/playlist_action_dialogs.cc
+++ b/browser/ui/views/playlist/playlist_action_dialogs.cc
@@ -180,7 +180,7 @@ class BoundedTextfield : public views::Textfield {
 
   void UpdateLengthLabel() {
     length_label_->SetText(base::UTF8ToUTF16(
-        base::StringPrintf("%zu/%zu", GetText().length(), max_length_)));
+        absl::StrFormat("%zu/%zu", GetText().length(), max_length_)));
   }
 
   const size_t max_length_;

--- a/browser/ui/webui/ai_chat/ai_chat_ui.cc
+++ b/browser/ui/webui/ai_chat/ai_chat_ui.cc
@@ -107,7 +107,7 @@ AIChatUI::AIChatUI(content::WebUI* web_ui)
       "font-src 'self' chrome://resources;");
   source->OverrideContentSecurityPolicy(
       network::mojom::CSPDirectiveName::ChildSrc,
-      base::StringPrintf("child-src %s;", kAIChatUntrustedConversationUIURL));
+      absl::StrFormat("child-src %s;", kAIChatUntrustedConversationUIURL));
 
   source->OverrideContentSecurityPolicy(
       network::mojom::CSPDirectiveName::TrustedTypes, "trusted-types default;");

--- a/browser/ui/webui/ai_chat/ai_chat_untrusted_conversation_ui.cc
+++ b/browser/ui/webui/ai_chat/ai_chat_untrusted_conversation_ui.cc
@@ -183,7 +183,7 @@ AIChatUntrustedConversationUI::AIChatUntrustedConversationUI(
       "font-src 'self' chrome-untrusted://resources;");
   source->OverrideContentSecurityPolicy(
       network::mojom::CSPDirectiveName::FrameAncestors,
-      base::StringPrintf("frame-ancestors %s;", kAIChatUIURL));
+      absl::StrFormat("frame-ancestors %s;", kAIChatUIURL));
   source->OverrideContentSecurityPolicy(
       network::mojom::CSPDirectiveName::TrustedTypes, "trusted-types default;");
 

--- a/browser/ui/webui/brave_wallet/wallet_panel_ui_browsertest.cc
+++ b/browser/ui/webui/brave_wallet/wallet_panel_ui_browsertest.cc
@@ -41,14 +41,13 @@ namespace {
 constexpr char kSomeEndpoint[] = "https://some.endpoint.com/";
 
 std::string SelectInNetworkList(const std::string& selector) {
-  return base::StringPrintf(
-      "window.testing.walletNetworks60.querySelector(`%s`)", selector.c_str());
+  return absl::StrFormat("window.testing.walletNetworks60.querySelector(`%s`)",
+                         selector);
 }
 
 std::string SelectInAddNetworkDialog(const std::string& selector) {
-  return base::StringPrintf(
-      "window.testing.addWalletNetworkDialog.querySelector(`%s`)",
-      selector.c_str());
+  return absl::StrFormat(
+      "window.testing.addWalletNetworkDialog.querySelector(`%s`)", selector);
 }
 
 std::string DoubleClickOn(const std::string& element) {
@@ -83,13 +82,12 @@ std::string NetworksButton() {
 }
 
 std::string QuerySelectorJS(const std::string& selector) {
-  return base::StringPrintf(R"(document.querySelector(`%s`))",
-                            selector.c_str());
+  return absl::StrFormat(R"(document.querySelector(`%s`))", selector);
 }
 
 std::string Select(const std::string& selector1, const std::string& selector2) {
-  return base::StringPrintf(R"(document.querySelector(`%s %s`))",
-                            selector1.c_str(), selector2.c_str());
+  return absl::StrFormat(R"(document.querySelector(`%s %s`))", selector1,
+                         selector2);
 }
 
 void NonBlockingDelay(base::TimeDelta delay) {
@@ -202,8 +200,8 @@ class WalletPanelUIBrowserTest : public InProcessBrowserTest {
                                               .AsStringPiece());
           url_loader_factory_.ClearResponses();
           if (request_string.find("eth_chainId") != std::string::npos) {
-            const std::string response = base::StringPrintf(
-                R"({"jsonrpc":"2.0","id":1,"result":"%s"})", chain_id.c_str());
+            const std::string response = absl::StrFormat(
+                R"({"jsonrpc":"2.0","id":1,"result":"%s"})", chain_id);
             for (auto& url : network_urls) {
               url_loader_factory_.AddResponse(url.spec(), response);
             }

--- a/browser/ui/webui/new_tab_page/brave_new_tab_ui.cc
+++ b/browser/ui/webui/new_tab_page/brave_new_tab_ui.cc
@@ -155,7 +155,7 @@ BraveNewTabUI::BraveNewTabUI(
 
   source->OverrideContentSecurityPolicy(
       network::mojom::CSPDirectiveName::FrameSrc,
-      base::StringPrintf("frame-src %s;", kNTPNewTabTakeoverRichMediaUrl));
+      absl::StrFormat("frame-src %s;", kNTPNewTabTakeoverRichMediaUrl));
   source->AddString("ntpNewTabTakeoverRichMediaUrl",
                     kNTPNewTabTakeoverRichMediaUrl);
 

--- a/browser/ui/webui/new_tab_takeover/android/new_tab_takeover_ui.cc
+++ b/browser/ui/webui/new_tab_takeover/android/new_tab_takeover_ui.cc
@@ -57,7 +57,7 @@ NewTabTakeoverUI::NewTabTakeoverUI(
 
   source->OverrideContentSecurityPolicy(
       network::mojom::CSPDirectiveName::FrameSrc,
-      base::StringPrintf("frame-src %s;", kNTPNewTabTakeoverRichMediaUrl));
+      absl::StrFormat("frame-src %s;", kNTPNewTabTakeoverRichMediaUrl));
   source->AddString("ntpNewTabTakeoverRichMediaUrl",
                     kNTPNewTabTakeoverRichMediaUrl);
 }

--- a/browser/ui/whats_new/whats_new_util.cc
+++ b/browser/ui/whats_new/whats_new_util.cc
@@ -44,10 +44,9 @@ double g_testing_major_version = 0;
 std::optional<double> GetBraveMajorVersionAsDouble(
     const base::Version& version) {
   double brave_major_version;
-  CHECK(
-      base::StringToDouble(base::StringPrintf("%d.%d", version.components()[1],
-                                              version.components()[2]),
-                           &brave_major_version));
+  CHECK(base::StringToDouble(absl::StrFormat("%d.%d", version.components()[1],
+                                             version.components()[2]),
+                             &brave_major_version));
   return brave_major_version;
 }
 


### PR DESCRIPTION
This PR has additional replacements for `base::StringPrintf` with the
underlying abseil implementation `absl::StrFormat`.

This is mostly a mechanical change.

Resolves https://github.com/brave/brave-browser/issues/47968
