### PR TITLE
[ubsan] Add `is_ubsan` support to `.env`

### DIFF
--- a/build/commands/lib/config.js
+++ b/build/commands/lib/config.js
@@ -249,6 +249,7 @@ const Config = function () {
   ])
   this.skip_download_rust_toolchain_aux =
     getEnvConfig(['skip_download_rust_toolchain_aux']) || false
+  this.is_ubsan = getEnvConfig(['is_ubsan'])
 
   this.forwardEnvArgsToGn = [
     'bitflyer_production_client_id',
@@ -940,7 +941,9 @@ Config.prototype.updateInternal = function (options) {
     this.is_asan = false
   }
 
-  this.is_ubsan = options.is_ubsan || false
+  if (options.is_ubsan) {
+    this.is_ubsan = true
+  }
 
   if (options.use_remoteexec !== undefined) {
     this.useRemoteExec = options.use_remoteexec

--- a/build/commands/lib/test.js
+++ b/build/commands/lib/test.js
@@ -70,9 +70,7 @@ const getApplicableFilters = (config, suite) => {
   ]
 
   if (config.is_ubsan) {
-    possibleFilters.push(
-      [suite, targetPlatform, config.targetArch, 'ubsan'].join('-'),
-    )
+    possibleFilters.push([suite, targetPlatform, 'ubsan'].join('-'))
   }
 
   possibleFilters.forEach((filterName) => {


### PR DESCRIPTION
This is a follow up to https://github.com/brave/brave-core/pull/30254.

Support to test filter files specifically for ubsan runs has been added
in previous work, however this has not been picked up on CI, as it is
also necessary to provide the `--is_ubsan` flag to `npm run tests`.

This change provides `.env` support for this flag, so we can avoid the
question of making the flags for `npm run build` and `npm run test` to
match, which will make the CI changes smoother.

Resolves https://github.com/brave/brave-browser/issues/47969
