### PR TITLE
[Linux] Fixes search engines not persisting for locale.

### DIFF
--- a/browser/regional_capabilities/BUILD.gn
+++ b/browser/regional_capabilities/BUILD.gn
@@ -1,0 +1,23 @@
+# Copyright (c) 2025 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+source_set("browser_tests") {
+  testonly = true
+
+  if (!is_android && !is_ios) {
+    sources = [ "regional_capabilities_service_browsertest.cc" ]
+
+    defines = [ "HAS_OUT_OF_PROC_TEST_RUNNER" ]
+    deps = [
+      "//base",
+      "//chrome/browser/regional_capabilities",
+      "//chrome/test:test_support",
+      "//components/country_codes",
+      "//components/regional_capabilities",
+      "//components/variations",
+      "//testing/gtest",
+    ]
+  }
+}

--- a/browser/regional_capabilities/regional_capabilities_service_browsertest.cc
+++ b/browser/regional_capabilities/regional_capabilities_service_browsertest.cc
@@ -1,0 +1,48 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "components/regional_capabilities/regional_capabilities_service.h"
+
+#include "base/check_deref.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/regional_capabilities/regional_capabilities_service_factory.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "components/country_codes/country_codes.h"
+#include "components/regional_capabilities/regional_capabilities_country_id.h"
+#include "components/variations/variations_switches.h"
+#include "content/public/test/browser_test.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace regional_capabilities {
+
+class RegionalCapabilitiesServiceBrowserTest : public InProcessBrowserTest {
+ public:
+  void SetUpCommandLine(base::CommandLine* command_line) override {
+    ASSERT_NE("FR", country_codes::GetCurrentCountryID().CountryCode());
+    command_line->AppendSwitchASCII(
+        variations::switches::kVariationsOverrideCountry, "fr");
+  }
+};
+
+// Make sure that regional capabilities service retrieves locale from
+// the device (`country_codes::GetCurrentCountryID()`) rather than from
+// the variations service on all desktop platforms.
+IN_PROC_BROWSER_TEST_F(RegionalCapabilitiesServiceBrowserTest, GetCountryId) {
+  auto& service = CHECK_DEREF(
+      RegionalCapabilitiesServiceFactory::GetForProfile(browser()->profile()));
+
+  country_codes::CountryId expected_country_id =
+      country_codes::GetCurrentCountryID();
+  country_codes::CountryId actual_country_id =
+      service.GetCountryId().GetForTesting();
+  EXPECT_EQ(expected_country_id, actual_country_id)
+      << "Country id retrieved by the regional capabilities service doesn't "
+         "match the device locale (actual = "
+      << actual_country_id.CountryCode()
+      << " vs. expected = " << expected_country_id.CountryCode() << ")";
+}
+
+}  // namespace regional_capabilities

--- a/chromium_src/chrome/browser/regional_capabilities/regional_capabilities_service_client_linux.cc
+++ b/chromium_src/chrome/browser/regional_capabilities/regional_capabilities_service_client_linux.cc
@@ -1,0 +1,26 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "chrome/browser/regional_capabilities/regional_capabilities_service_client_linux.h"
+
+#define RegionalCapabilitiesServiceClientLinux \
+  RegionalCapabilitiesServiceClientLinux_ChromiumImpl
+
+#include <chrome/browser/regional_capabilities/regional_capabilities_service_client_linux.cc>
+#undef RegionalCapabilitiesServiceClientLinux
+
+namespace regional_capabilities {
+
+RegionalCapabilitiesServiceClientLinux::
+    ~RegionalCapabilitiesServiceClientLinux() = default;
+
+void RegionalCapabilitiesServiceClientLinux::FetchCountryId(
+    CountryIdCallback country_id_fetched_callback) {
+  // Fall back onto the platform neutral implementation that uses device locale.
+  return RegionalCapabilitiesServiceClient::FetchCountryId(
+      std::move(country_id_fetched_callback));
+}
+
+}  // namespace regional_capabilities

--- a/chromium_src/chrome/browser/regional_capabilities/regional_capabilities_service_client_linux.h
+++ b/chromium_src/chrome/browser/regional_capabilities/regional_capabilities_service_client_linux.h
@@ -1,0 +1,34 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_REGIONAL_CAPABILITIES_REGIONAL_CAPABILITIES_SERVICE_CLIENT_LINUX_H_
+#define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_REGIONAL_CAPABILITIES_REGIONAL_CAPABILITIES_SERVICE_CLIENT_LINUX_H_
+
+// Subclass RegionalCapabilitiesServiceClientLinux so that we can override
+// FetchCountryId. On other platforms this methods retrives locale from the
+// device, but on Linux upstream only relies on the variations service to get
+// the current locale. This doesn't work right since, for example, search
+// engines selection switches based on your locale.
+#define RegionalCapabilitiesServiceClientLinux \
+  RegionalCapabilitiesServiceClientLinux_ChromiumImpl
+
+#include <chrome/browser/regional_capabilities/regional_capabilities_service_client_linux.h>  // IWYU pragma: export
+#undef RegionalCapabilitiesServiceClientLinux
+
+namespace regional_capabilities {
+
+class RegionalCapabilitiesServiceClientLinux
+    : public RegionalCapabilitiesServiceClientLinux_ChromiumImpl {
+ public:
+  using RegionalCapabilitiesServiceClientLinux_ChromiumImpl::
+      RegionalCapabilitiesServiceClientLinux_ChromiumImpl;
+  ~RegionalCapabilitiesServiceClientLinux() override;
+
+  void FetchCountryId(CountryIdCallback country_id_fetched_callback) override;
+};
+
+}  // namespace regional_capabilities
+
+#endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_REGIONAL_CAPABILITIES_REGIONAL_CAPABILITIES_SERVICE_CLIENT_LINUX_H_

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -858,6 +858,7 @@ test("brave_browser_tests") {
     "//brave/browser/permissions:browser_tests",
     "//brave/browser/profiles:util",
     "//brave/browser/psst:browser_tests",
+    "//brave/browser/regional_capabilities:browser_tests",
     "//brave/browser/sandbox:browser_tests",
     "//brave/browser/script_injector:browser_tests",
     "//brave/browser/sessions:browser_tests",

--- a/test/filters/browser_tests-linux.filter
+++ b/test/filters/browser_tests-linux.filter
@@ -52,6 +52,10 @@
 # signin::ConsentLevel::kSignin
 -All/AvatarToolbarButtonEnterpriseBadgingWithSyncPromoParamsBrowserTest.*
 
+# This test fails because we override RegionalCapabilitiesServiceClientLinux::
+# FetchCountryId to get locale from device instead of the variations service.
+-RegionalCapabilitiesServiceFactoryBrowserTestForVariationsCountry.GetCountryId/FR
+
 # Tests below this point have not been diagnosed or had issues created yet.
 -AccessCodeCastHandlerBrowserTest.*
 -AdsPageLoadMetricsObserverBrowserTest.*

--- a/test/filters/unit_tests-linux.filter
+++ b/test/filters/unit_tests-linux.filter
@@ -5,6 +5,11 @@
 ## why the filter is required and create an associated tracking issue.
 ##
 
+# These tests fail because we override RegionalCapabilitiesServiceClientLinux::
+# FetchCountryId to get locale from device instead of the variations service.
+-RegionalCapabilitiesServiceClientLinuxTest.FetchCountryId
+-RegionalCapabilitiesServiceClientLinuxTest.FetchCountryIdWithDisabledUseFinchPermanentCountryForFetchCountryId
+
 # These tests pass locally but fail on CI (flaky).
 -PasswordStatusCheckServiceBaseTest.PrefInitialized
 


### PR DESCRIPTION
On Linux, unlike other platforms, RegionalCapabilitiesServiceClientLinux::FetchCountryId only relies on variations service to retrieve the locale. On the initial run, there's no valid locale set from the variations service and the regional capabilities service falls back on the device locale. On the consecutive runs the locale is retrieved from the variations service and that causes the search engines selection to change as well. This makes little sense since the user would likely prefer to retain the same set of search engines regardless of their physical location.

This change overrides RegionalCapabilitiesServiceClientLinux::FetchCountryId to use the platform-neutral implementation in RegionalCapabilitiesServiceClient that gets the locale from the device.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/47914

Also,
Resolves https://github.com/brave/brave-browser/issues/47913
by the virtue of locale being retrieved from the device the kCountryIDAtInstall pref getting set correctly.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
