### PR TITLE
fix(wallet): Remove button to copy wallet address for btc/zec wallet account

### DIFF
--- a/ios/brave-ios/Sources/BraveWallet/Crypto/SelectAccountTokenView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/SelectAccountTokenView.swift
@@ -140,7 +140,7 @@ struct SelectAccountTokenView: View {
           WalletListHeaderView {
             CopyAddressHeader(
               displayText: accountSection.account.accountNameDisplay,
-              address: accountSection.copyAddress
+              address: accountSection.account.address
             )
           }
         }

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/SelectAccountTokenStore.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/SelectAccountTokenStore.swift
@@ -36,16 +36,6 @@ class SelectAccountTokenStore: ObservableObject, WalletObserverStore {
     let bitcoinAccountInfo: BraveWallet.BitcoinAccountInfo?
     let zcashAccountInfo: BraveWallet.ZCashAccountInfo?
     let tokenBalances: [TokenBalance]
-
-    var copyAddress: String {
-      if let bitcoinAccountInfo {
-        return bitcoinAccountInfo.nextReceiveAddress.addressString
-      } else if let zcashAccountInfo {
-        return zcashAccountInfo.nextTransparentChangeAddress.addressString
-      } else {
-        return account.address
-      }
-    }
   }
 
   /// The networks to filter the tokens/accounts by.

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/WalletActions/CopyAddressHeader.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/WalletActions/CopyAddressHeader.swift
@@ -9,8 +9,6 @@ import Strings
 import SwiftUI
 
 /// List header for displaying text with `...` menu to copy address.
-/// Bitcoin accounts will only display `...` menu when `btcAccountInfo`
-/// is populated, allowing copy of `nextReceiveAddress`.
 struct CopyAddressHeader: View {
 
   let displayText: String
@@ -28,7 +26,9 @@ struct CopyAddressHeader: View {
     HStack {
       Text(displayText)
       Spacer()
-      addressMenu(for: address)
+      if !address.isEmpty {
+        addressMenu(for: address)
+      }
     }
   }
 

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/WalletActions/SendTokenView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/WalletActions/SendTokenView.swift
@@ -157,8 +157,6 @@ struct SendTokenView: View {
       Form {
         Section(
           header: WalletListHeaderView {
-            // User doesn't need from BTC/ZEC account receive address in Send
-            // Can either use Deposit or Select Token modal
             CopyAddressHeader(
               displayText:
                 "\(Strings.Wallet.sendCryptoFromTitle): \(keyringStore.selectedAccount.accountNameDisplay)",


### PR DESCRIPTION
Since they generate many public sending addresses using UTXO model. Using next receive address does not make sense here since it is only for receiving deposit. 
Next receiving address for btc/zec wallet account will be used in Deposit screen.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/47966

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

## Test Plan
1. open brave wallet 
2. restore a wallet that has some balance 
3. open Send 
4. pick ether Bitcoin or Zcash token to send 
5. observe in the header of the token section, it only displays the account name with no `...` in the end. 
6. pick other token on other chains
7. observe in the header of the token section, it will display the account name with truncated account address with `...` in the end
8. tap on `...`, it will open the copy address menu 
9. observe it's the same in Select a Token to Send screen