### PR TITLE
Add clickjacking protection to interstitial pages

### DIFF
--- a/browser/decentralized_dns/test/decentralized_dns_navigation_throttle_browsertest.cc
+++ b/browser/decentralized_dns/test/decentralized_dns_navigation_throttle_browsertest.cc
@@ -305,32 +305,23 @@ IN_PROC_BROWSER_TEST_F(DecentralizedDnsNavigationThrottleBrowserTest,
   EXPECT_EQ(DecentralizedDnsOptInPage::kTypeForTesting,
             GetInterstitialType(web_contents));
 
-  // Test that clicks within the first 500ms are ignored (clickjacking
-  // protection) by verifying that the proceed command doesn't work immediately
   content::RenderFrameHost* main_frame = web_contents->GetPrimaryMainFrame();
 
-  // Try to trigger proceed immediately - should be blocked by clickjacking
-  // protection
-  bool js_result = false;
   EXPECT_TRUE(content::ExecJs(
       main_frame,
       "window.domAutomationController.send(typeof proceedClicksEnabled !== "
-      "'undefined' && !proceedClicksEnabled);",
-      content::EXECUTE_SCRIPT_USE_MANUAL_REPLY));
+      "'undefined' && !proceedClicksEnabled);"));
 
-  // Verify the proceed clicks are initially disabled
   EXPECT_TRUE(content::EvalJs(main_frame,
                               "typeof proceedClicksEnabled !== 'undefined' && "
                               "!proceedClicksEnabled")
                   .ExtractBool());
 
-  // Wait for the clickjacking protection delay to pass
   base::RunLoop run_loop;
   base::SingleThreadTaskRunner::GetCurrentDefault()->PostDelayedTask(
       FROM_HERE, run_loop.QuitClosure(), base::Milliseconds(600));
   run_loop.Run();
 
-  // Verify proceed clicks are now enabled
   EXPECT_TRUE(
       content::EvalJs(main_frame, "proceedClicksEnabled").ExtractBool());
 }

--- a/components/decentralized_dns/content/resources/decentralized_dns_interstitial.js
+++ b/components/decentralized_dns/content/resources/decentralized_dns_interstitial.js
@@ -5,6 +5,10 @@
 
 import { HIDDEN_CLASS, SecurityInterstitialCommandId, sendCommand } from 'chrome://interstitials/common/resources/interstitial_common.js';
 
+// Clickjacking protection: delay before accepting proceed clicks
+const PROCEED_CLICK_DELAY_MS = 500;
+let proceedClicksEnabled = false;
+
 function setupEvents() {
   const body = document.querySelector('#body');
   body.classList.add('decentralized_dns');
@@ -12,7 +16,12 @@ function setupEvents() {
   icon.classList.add('icon');
 
   const primaryButton = document.querySelector('#primary-button');
-  primaryButton.addEventListener('click', function() {
+  primaryButton.addEventListener('click', function(event) {
+    // Prevent clickjacking by requiring a delay before allowing proceed
+    if (!proceedClicksEnabled) {
+      event.preventDefault();
+      return;
+    }
     sendCommand(SecurityInterstitialCommandId.CMD_PROCEED);
   });
 
@@ -20,9 +29,15 @@ function setupEvents() {
   mainContent.classList.remove(HIDDEN_CLASS);
 
   const dontProceedButton = document.querySelector('#dont-proceed-button')
-  dontProceedButton.addEventListener('click', function(event) {
+  dontProceedButton.addEventListener('click', function() {
+    // Don't proceed is always allowed (safer action)
     sendCommand(SecurityInterstitialCommandId.CMD_DONT_PROCEED);
   });
+
+  // Enable proceed clicks after delay to prevent clickjacking
+  setTimeout(function() {
+    proceedClicksEnabled = true;
+  }, PROCEED_CLICK_DELAY_MS);
 }
 
 document.addEventListener('DOMContentLoaded', setupEvents);

--- a/components/decentralized_dns/content/resources/decentralized_dns_interstitial.js
+++ b/components/decentralized_dns/content/resources/decentralized_dns_interstitial.js
@@ -1,7 +1,7 @@
-// Copyright 2021 The Brave Authors. All rights reserved.
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
-// you can obtain one at https://mozilla.org/MPL/2.0/.
+// You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import { HIDDEN_CLASS, SecurityInterstitialCommandId, sendCommand } from 'chrome://interstitials/common/resources/interstitial_common.js';
 

--- a/ios/brave-ios/Sources/Brave/Assets/Interstitial Pages/Pages/Web3Domain.html
+++ b/ios/brave-ios/Sources/Brave/Assets/Interstitial Pages/Pages/Web3Domain.html
@@ -33,22 +33,37 @@ You can obtain one at https://mozilla.org/MPL/2.0/.
     </div>
     
     <script type="text/javascript">
+      // Clickjacking protection: delay before accepting proceed clicks
+      var PROCEED_CLICK_DELAY_MS = 500;
+      var proceedClicksEnabled = false;
+      
       var disableButton = document.getElementById("disableWeb3Button")
       disableButton.addEventListener('click', function(e) {
         e.preventDefault();
+        // Don't proceed is always allowed (safer action)
         webkit.messageHandlers["%message_handler%"].postMessage({
           "button_type": "disable",
           "service_id": "%service_id%"
         });
       });
+      
       var proceedButton = document.getElementById("proceedWeb3Button")
       proceedButton.addEventListener('click', function(e) {
         e.preventDefault();
+        // Prevent clickjacking by requiring a delay before allowing proceed
+        if (!proceedClicksEnabled) {
+          return;
+        }
         webkit.messageHandlers["%message_handler%"].postMessage({
           "button_type": "proceed",
           "service_id": "%service_id%"
         });
       });
+      
+      // Enable proceed clicks after delay to prevent clickjacking
+      setTimeout(function() {
+        proceedClicksEnabled = true;
+      }, PROCEED_CLICK_DELAY_MS);
       
     </script>
   </div>


### PR DESCRIPTION
This commit introduces a delay before allowing proceed clicks on the decentralized DNS interstitial pages to prevent clickjacking attacks. The changes include:

- Added a delay mechanism in both the JavaScript for the interstitial page and the corresponding browser test to ensure that clicks within the first 500ms are ignored.
- Implemented tests to verify that the proceed command is blocked initially and only enabled after the delay.

This enhancement improves security by ensuring that users cannot inadvertently proceed too quickly on interstitial pages.

Resolves https://github.com/brave/brave-browser/issues/47407