### PR TITLE
Fixed WDP Infobar is not rendered properly

### DIFF
--- a/browser/ui/views/infobars/web_discovery_infobar_view.cc
+++ b/browser/ui/views/infobars/web_discovery_infobar_view.cc
@@ -21,7 +21,7 @@ std::unique_ptr<infobars::InfoBar> CreateWebDiscoveryInfoBar(
 WebDiscoveryInfoBarView::WebDiscoveryInfoBarView(
     std::unique_ptr<WebDiscoveryInfoBarDelegate> delegate)
     : InfoBarView(std::move(delegate)) {
-  content_view_ = AddContentChildView(
+  content_view_ = AddChildView(
       std::make_unique<WebDiscoveryInfoBarContentView>(GetDelegate()));
 }
 

--- a/browser/ui/views/infobars/web_discovery_infobar_view.h
+++ b/browser/ui/views/infobars/web_discovery_infobar_view.h
@@ -8,9 +8,14 @@
 
 #include <memory>
 
+#include "base/gtest_prod_util.h"
 #include "base/memory/raw_ptr.h"
 #include "chrome/browser/ui/views/infobars/infobar_view.h"
 #include "ui/base/metadata/metadata_header_macros.h"
+
+namespace web_discovery {
+FORWARD_DECLARE_TEST(WebDiscoveryTest, InfobarAddedTest);
+}  // namespace web_discovery
 
 class WebDiscoveryInfoBarDelegate;
 
@@ -26,6 +31,8 @@ class WebDiscoveryInfoBarView : public InfoBarView {
   WebDiscoveryInfoBarView& operator=(const WebDiscoveryInfoBarView&) = delete;
 
  private:
+  FRIEND_TEST_ALL_PREFIXES(web_discovery::WebDiscoveryTest, InfobarAddedTest);
+
   // InfoBarView overrides:
   void Layout(PassKey) override;
   void ChildPreferredSizeChanged(views::View* child) override;

--- a/browser/web_discovery/web_discovery_browsertest.cc
+++ b/browser/web_discovery/web_discovery_browsertest.cc
@@ -3,6 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include "brave/browser/ui/views/infobars/web_discovery_infobar_view.h"
+#include "brave/browser/web_discovery/web_discovery_infobar_delegate.h"
 #include "brave/browser/web_discovery/web_discovery_tab_helper.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser.h"
@@ -42,6 +44,14 @@ IN_PROC_BROWSER_TEST_F(WebDiscoveryTest, InfobarAddedTest) {
   infobar_manager->AddObserver(&observer);
   tab_helper->ShowInfoBar(browser()->profile()->GetPrefs());
   infobar_manager->RemoveObserver(&observer);
+
+  // Verify WebDiscoveryInfoBarView.
+  // WebDiscoveryInfoBarView::content_view_ should be direct child as
+  // it occupies whole parent rect.
+  auto infobar = std::make_unique<WebDiscoveryInfoBarView>(
+      std::make_unique<WebDiscoveryInfoBarDelegate>(
+          browser()->profile()->GetPrefs()));
+  EXPECT_EQ(infobar.get(), infobar->content_view_->parent());
 }
 
 }  // namespace web_discovery

--- a/chromium_src/chrome/browser/ui/views/infobars/infobar_view.h
+++ b/chromium_src/chrome/browser/ui/views/infobars/infobar_view.h
@@ -10,9 +10,10 @@
 #include "ui/views/focus/external_focus_tracker.h"
 #include "ui/views/view.h"
 
-#define CloseButtonPressed          \
-  CloseButtonPressed_Unused() {}    \
-  friend class BraveConfirmInfoBar; \
+#define CloseButtonPressed              \
+  CloseButtonPressed_Unused() {}        \
+  friend class BraveConfirmInfoBar;     \
+  friend class WebDiscoveryInfoBarView; \
   virtual void CloseButtonPressed
 
 #include <chrome/browser/ui/views/infobars/infobar_view.h>  // IWYU pragma: export


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/47836


`WebDiscoveryInfoBarContentView` should be the direct children as it occupies whole InfoBarView bounds.
Upstream prevent to call `AddChildView()` from `InfoBarView`'s sub class. but we need it.
Fixed by using `friend class WebDiscoveryInfoBarContentView`.

TEST=`WebDiscoveryTest.InfobarAddedTest`

<img width="1019" height="328" alt="Screenshot 2025-07-29 122342" src="https://github.com/user-attachments/assets/5c80f344-f1b6-476e-8fc9-644bb7fce4fb" />

See the linked issue for manual test.


<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
