### PR TITLE
Improve picture in picture transition

### DIFF
--- a/android/java/org/chromium/chrome/browser/app/BraveActivity.java
+++ b/android/java/org/chromium/chrome/browser/app/BraveActivity.java
@@ -57,6 +57,7 @@ import com.google.android.play.core.install.model.UpdateAvailability;
 import com.google.android.play.core.tasks.Task;
 import com.wireguard.android.backend.GoBackend;
 
+import org.chromium.chrome.browser.fullscreen.FullscreenManager;
 import org.jni_zero.JNINamespace;
 import org.jni_zero.NativeMethods;
 
@@ -519,6 +520,10 @@ public abstract class BraveActivity extends ChromeActivity
             MediaSession mediaSession = MediaSession.fromWebContents(getCurrentWebContents());
             if (mediaSession != null) {
                 mediaSession.suspend();
+            }
+            FullscreenManager fullscreenManager = getFullscreenManager();
+            if (fullscreenManager.getPersistentFullscreenMode()) {
+                fullscreenManager.exitPersistentFullscreenMode();
             }
         }
     }

--- a/android/java/org/chromium/chrome/browser/app/BraveActivity.java
+++ b/android/java/org/chromium/chrome/browser/app/BraveActivity.java
@@ -57,7 +57,6 @@ import com.google.android.play.core.install.model.UpdateAvailability;
 import com.google.android.play.core.tasks.Task;
 import com.wireguard.android.backend.GoBackend;
 
-import org.chromium.chrome.browser.fullscreen.FullscreenManager;
 import org.jni_zero.JNINamespace;
 import org.jni_zero.NativeMethods;
 
@@ -134,6 +133,7 @@ import org.chromium.chrome.browser.customtabs.FullScreenCustomTabActivity;
 import org.chromium.chrome.browser.flags.ChromeFeatureList;
 import org.chromium.chrome.browser.flags.ChromeSwitches;
 import org.chromium.chrome.browser.fullscreen.BrowserControlsManager;
+import org.chromium.chrome.browser.fullscreen.FullscreenManager;
 import org.chromium.chrome.browser.informers.BraveSyncAccountDeletedInformer;
 import org.chromium.chrome.browser.lifetime.ApplicationLifetime;
 import org.chromium.chrome.browser.misc_metrics.MiscAndroidMetricsConnectionErrorHandler;

--- a/android/java/org/chromium/chrome/browser/toolbar/top/BraveToolbarLayoutImpl.java
+++ b/android/java/org/chromium/chrome/browser/toolbar/top/BraveToolbarLayoutImpl.java
@@ -114,7 +114,9 @@ import org.chromium.chrome.browser.util.ConfigurationUtils;
 import org.chromium.chrome.browser.util.PackageUtils;
 import org.chromium.components.embedder_support.util.UrlUtilities;
 import org.chromium.components.feature_engagement.Tracker;
+import org.chromium.content_public.browser.MediaSession;
 import org.chromium.content_public.browser.NavigationHandle;
+import org.chromium.content_public.browser.WebContents;
 import org.chromium.mojo.bindings.ConnectionErrorHandler;
 import org.chromium.mojo.system.MojoException;
 import org.chromium.playlist.mojom.PlaylistItem;
@@ -1691,8 +1693,13 @@ public abstract class BraveToolbarLayoutImpl extends ToolbarLayout
     // FullscreenManager.Observer method.
     @Override
     public void onEnterFullscreen(Tab tab, FullscreenOptions options) {
-        if (BraveYouTubeScriptInjectorNativeHelper.hasFullscreenBeenRequested(
-                tab.getWebContents())) {
+        final WebContents webContents = tab.getWebContents();
+        if (webContents != null && BraveYouTubeScriptInjectorNativeHelper.hasFullscreenBeenRequested(
+                webContents)) {
+            MediaSession mediaSession = MediaSession.fromWebContents(webContents);
+            if (mediaSession != null) {
+                mediaSession.resume();
+            }
             Activity activity = tab.getWindowAndroid().getActivity().get();
             if (activity != null) {
                 try {

--- a/android/java/org/chromium/chrome/browser/toolbar/top/BraveToolbarLayoutImpl.java
+++ b/android/java/org/chromium/chrome/browser/toolbar/top/BraveToolbarLayoutImpl.java
@@ -1694,8 +1694,8 @@ public abstract class BraveToolbarLayoutImpl extends ToolbarLayout
     @Override
     public void onEnterFullscreen(Tab tab, FullscreenOptions options) {
         final WebContents webContents = tab.getWebContents();
-        if (webContents != null && BraveYouTubeScriptInjectorNativeHelper.hasFullscreenBeenRequested(
-                webContents)) {
+        if (webContents != null
+                && BraveYouTubeScriptInjectorNativeHelper.hasFullscreenBeenRequested(webContents)) {
             MediaSession mediaSession = MediaSession.fromWebContents(webContents);
             if (mediaSession != null) {
                 mediaSession.resume();

--- a/browser/android/youtube_script_injector/youtube_script_injector_browsertest.cc
+++ b/browser/android/youtube_script_injector/youtube_script_injector_browsertest.cc
@@ -31,7 +31,8 @@ constexpr std::u16string_view kSimulateDelayedScriptLoad =
   const moviePlayer = document.getElementById('movie_player');
   if (moviePlayer) {
     moviePlayer.innerHTML = `
-      <video class="html5-main-video" src="mov_bbb.mp4" controls></video>
+      <video class="html5-main-video" src="mov_bbb.mp4" controls
+      onclick="requestFullscreen();"></video>
       <button class="fullscreen-icon"
       onclick="document.querySelector('video.html5-main-video')
         .requestFullscreen();">⛶</button>
@@ -170,11 +171,6 @@ IN_PROC_BROWSER_TEST_F(YouTubeScriptInjectorBrowserTest,
   // Check the video is in fullscreen mode.
   EXPECT_TRUE(
       WaitForJsResult(web_contents(), "document.fullscreenElement !== null"));
-
-  // Check the video is playing.
-  EXPECT_TRUE(WaitForJsResult(
-      web_contents(),
-      "document.querySelector('video.html5-main-video').paused === false"));
 }
 
 IN_PROC_BROWSER_TEST_F(YouTubeScriptInjectorBrowserTest,
@@ -216,7 +212,7 @@ IN_PROC_BROWSER_TEST_F(YouTubeScriptInjectorBrowserTest,
 }
 
 IN_PROC_BROWSER_TEST_F(YouTubeScriptInjectorBrowserTest,
-                       VideoIsPlayedFromFullscreenState) {
+                       NoOpIfAlreadyInFullscreen) {
   const GURL url = https_server_.GetURL("youtube.com", "/yt_fullscreen.html");
   content::NavigateToURLBlockUntilNavigationsComplete(web_contents(), url, 1,
                                                       true);
@@ -239,9 +235,9 @@ IN_PROC_BROWSER_TEST_F(YouTubeScriptInjectorBrowserTest,
 
   helper->MaybeSetFullscreen();
 
-  EXPECT_TRUE(WaitForJsResult(
-      web_contents(),
-      "document.querySelector('video.html5-main-video').paused === false"));
+  // Verify that the video is still in fullscreen mode.
+  EXPECT_TRUE(
+      WaitForJsResult(web_contents(), "document.fullscreenElement !== null"));
 }
 
 IN_PROC_BROWSER_TEST_F(YouTubeScriptInjectorBrowserTest,
@@ -330,10 +326,6 @@ IN_PROC_BROWSER_TEST_F(YouTubeScriptInjectorBrowserTest,
   // Wait for the mutation observer to complete and trigger fullscreen mode.
   EXPECT_TRUE(
       WaitForJsResult(web_contents(), "document.fullscreenElement !== null"));
-
-  EXPECT_TRUE(WaitForJsResult(
-      web_contents(),
-      "document.querySelector('video.html5-main-video').paused === false"));
 }
 
 // Test that MaybeSetFullscreen() works with multiple calls.

--- a/browser/android/youtube_script_injector/youtube_script_injector_tab_helper.cc
+++ b/browser/android/youtube_script_injector/youtube_script_injector_tab_helper.cc
@@ -236,7 +236,7 @@ void YouTubeScriptInjectorTabHelper::MaybeSetFullscreen() {
   // Mark fullscreen as requested for this page
   SetFullscreenRequested(true);
   content::RenderFrameHost* rfh = web_contents()->GetPrimaryMainFrame();
-    if (!script_injector_remote_.is_bound()) {
+  if (!script_injector_remote_.is_bound()) {
     rfh->GetRemoteAssociatedInterfaces()->GetInterface(
         &script_injector_remote_);
   }
@@ -245,8 +245,9 @@ void YouTubeScriptInjectorTabHelper::MaybeSetFullscreen() {
       ISOLATED_WORLD_ID_BRAVE_INTERNAL, kYoutubeFullscreen,
       blink::mojom::UserActivationOption::kActivate,
       blink::mojom::PromiseResultOption::kAwait,
-      base::BindOnce(&YouTubeScriptInjectorTabHelper::OnFullscreenScriptComplete,
-                     weak_factory_.GetWeakPtr(), rfh->GetGlobalFrameToken()));
+      base::BindOnce(
+          &YouTubeScriptInjectorTabHelper::OnFullscreenScriptComplete,
+          weak_factory_.GetWeakPtr(), rfh->GetGlobalFrameToken()));
 }
 
 bool YouTubeScriptInjectorTabHelper::IsYouTubeVideo(bool mobileOnly) const {

--- a/browser/android/youtube_script_injector/youtube_script_injector_tab_helper.cc
+++ b/browser/android/youtube_script_injector/youtube_script_injector_tab_helper.cc
@@ -212,6 +212,7 @@ YouTubeScriptInjectorTabHelper::YouTubeScriptInjectorTabHelper(
 YouTubeScriptInjectorTabHelper::~YouTubeScriptInjectorTabHelper() {}
 
 void YouTubeScriptInjectorTabHelper::PrimaryMainDocumentElementAvailable() {
+  SetFullscreenRequested(false);
   content::WebContents* contents = web_contents();
   // Filter only YouTube videos.
   if (!IsYouTubeVideo()) {
@@ -246,7 +247,6 @@ void YouTubeScriptInjectorTabHelper::MaybeSetFullscreen() {
 
   // Mark fullscreen as requested for this page
   SetFullscreenRequested(true);
-
   content::RenderFrameHost* rfh = web_contents()->GetPrimaryMainFrame();
     if (!script_injector_remote_.is_bound()) {
     rfh->GetRemoteAssociatedInterfaces()->GetInterface(

--- a/browser/android/youtube_script_injector/youtube_script_injector_tab_helper.h
+++ b/browser/android/youtube_script_injector/youtube_script_injector_tab_helper.h
@@ -9,10 +9,10 @@
 #include "base/memory/weak_ptr.h"
 #include "base/supports_user_data.h"
 #include "base/values.h"
+#include "brave/components/script_injector/common/mojom/script_injector.mojom.h"
 #include "content/public/browser/render_frame_host.h"
 #include "content/public/browser/web_contents_observer.h"
 #include "content/public/browser/web_contents_user_data.h"
-#include "brave/components/script_injector/common/mojom/script_injector.mojom.h"
 #include "mojo/public/cpp/bindings/associated_remote.h"
 
 class YouTubeScriptInjectorTabHelper

--- a/browser/android/youtube_script_injector/youtube_script_injector_tab_helper.h
+++ b/browser/android/youtube_script_injector/youtube_script_injector_tab_helper.h
@@ -12,6 +12,8 @@
 #include "content/public/browser/render_frame_host.h"
 #include "content/public/browser/web_contents_observer.h"
 #include "content/public/browser/web_contents_user_data.h"
+#include "brave/components/script_injector/common/mojom/script_injector.mojom.h"
+#include "mojo/public/cpp/bindings/associated_remote.h"
 
 class YouTubeScriptInjectorTabHelper
     : public content::WebContentsObserver,
@@ -44,6 +46,10 @@ class YouTubeScriptInjectorTabHelper
   // Callback for when the fullscreen script completes.
   void OnFullscreenScriptComplete(content::GlobalRenderFrameHostToken token,
                                   base::Value value);
+
+  // The remote used to send the fullscreen script to the renderer.
+  mojo::AssociatedRemote<script_injector::mojom::ScriptInjector>
+      script_injector_remote_;
 
   base::WeakPtrFactory<YouTubeScriptInjectorTabHelper> weak_factory_{this};
 };


### PR DESCRIPTION
## Resolves https://github.com/brave/brave-browser/issues/47993

This PR improves picture in picture transition and fixes a few glitches when entering and exiting fullscreen.
More specifically:

- It fixes an issue where `OnFullscreenScriptComplete` was never called.
- It restores the right screen state when exiting picture-in-picture mode.
- It improves the injected JS script by checking the video player state has enough buffer before showing the icon in the omnibox (`videoPlayer.readyState >= 3`).
- It removes the delay from the injected script and the media stream resume is delegated on Java layer in the appropriate callback `onEnterFullscreen`.


## Note for the Reviewers

This PR is a best effort to improve an issue affecting fullscreen transition. Slack discussion: https://bravesoftware.slack.com/archives/C08SPCYPH60/p1753208702567319

Currently, Chromium team, YouTube team, and Blink team are actively investigating this issue. There are multiple tickets open referring to the same issue:

* https://issues.chromium.org/issues/40207650 (Did a relayout and started working again comment 16)
* https://issues.chromium.org/issues/40242250 (This has a blocker link)
* https://issues.chromium.org/issues/426475679 (Dupe)
* https://issues.chromium.org/issues/421421331 (From Serg)

**Blocker link: https://issues.chromium.org/issues/40244577**

Some links are excluded from the list above as they are private and cannot be opened.
The issue has sparked a lot of discussion and it seems related to a bug affecting the viewport calculation when the video stream switches into fullscreen mode on YouTube videos. The issue affects only YouTube videos and is intermittent.
From my tests I was not able to find a reliable workaround; some comments (check the first link) suggested that a relayout could fix the issue but was not clear which APIs need to be called. I've tried tons of solution but was not able to observe any improvements forcing a relayout. 

Chromium code performs a check in `FullscreenVideoPictureInPictureController`: if the fullscreen transition is not properly calculated the window used to reproduce the video is cut off and calling picture in picture under this inconsistent state provokes the activity to dismiss picture in picture. No crash, no other side effects, no audio cuts. Just the PIP gets dismissed gracefully.

When the fullscreen_status is `blink::WebFullscreenVideoStatus::kNotEffectivelyFullscreen` the video stream gets suspended. And when the video stream gets suspended there's another call on Java side to dismiss the PIP.
With a physical device the issue can be observed less frequently.
When the fullscreen is not properly calculated while transitioning to PIP the final user will observe the same behavior described here: https://bravesoftware.slack.com/archives/C08SPCYPH60/p1753208702567319



