### PR TITLE
Fixed WDP Infobar is not rendered properly (uplift to 1.81.x)

### DIFF
--- a/browser/ui/views/infobars/web_discovery_infobar_view.cc
+++ b/browser/ui/views/infobars/web_discovery_infobar_view.cc
@@ -21,7 +21,7 @@ std::unique_ptr<infobars::InfoBar> CreateWebDiscoveryInfoBar(
 WebDiscoveryInfoBarView::WebDiscoveryInfoBarView(
     std::unique_ptr<WebDiscoveryInfoBarDelegate> delegate)
     : InfoBarView(std::move(delegate)) {
-  content_view_ = AddContentChildView(
+  content_view_ = AddChildView(
       std::make_unique<WebDiscoveryInfoBarContentView>(GetDelegate()));
 }
 

--- a/browser/ui/views/infobars/web_discovery_infobar_view.h
+++ b/browser/ui/views/infobars/web_discovery_infobar_view.h
@@ -8,9 +8,14 @@
 
 #include <memory>
 
+#include "base/gtest_prod_util.h"
 #include "base/memory/raw_ptr.h"
 #include "chrome/browser/ui/views/infobars/infobar_view.h"
 #include "ui/base/metadata/metadata_header_macros.h"
+
+namespace web_discovery {
+FORWARD_DECLARE_TEST(WebDiscoveryTest, InfobarAddedTest);
+}  // namespace web_discovery
 
 class WebDiscoveryInfoBarDelegate;
 
@@ -26,6 +31,8 @@ class WebDiscoveryInfoBarView : public InfoBarView {
   WebDiscoveryInfoBarView& operator=(const WebDiscoveryInfoBarView&) = delete;
 
  private:
+  FRIEND_TEST_ALL_PREFIXES(web_discovery::WebDiscoveryTest, InfobarAddedTest);
+
   // InfoBarView overrides:
   void Layout(PassKey) override;
   void ChildPreferredSizeChanged(views::View* child) override;

--- a/browser/web_discovery/web_discovery_browsertest.cc
+++ b/browser/web_discovery/web_discovery_browsertest.cc
@@ -3,6 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include "brave/browser/ui/views/infobars/web_discovery_infobar_view.h"
+#include "brave/browser/web_discovery/web_discovery_infobar_delegate.h"
 #include "brave/browser/web_discovery/web_discovery_tab_helper.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser.h"
@@ -42,6 +44,14 @@ IN_PROC_BROWSER_TEST_F(WebDiscoveryTest, InfobarAddedTest) {
   infobar_manager->AddObserver(&observer);
   tab_helper->ShowInfoBar(browser()->profile()->GetPrefs());
   infobar_manager->RemoveObserver(&observer);
+
+  // Verify WebDiscoveryInfoBarView.
+  // WebDiscoveryInfoBarView::content_view_ should be direct child as
+  // it occupies whole parent rect.
+  auto infobar = std::make_unique<WebDiscoveryInfoBarView>(
+      std::make_unique<WebDiscoveryInfoBarDelegate>(
+          browser()->profile()->GetPrefs()));
+  EXPECT_EQ(infobar.get(), infobar->content_view_->parent());
 }
 
 }  // namespace web_discovery

--- a/chromium_src/chrome/browser/ui/views/infobars/infobar_view.h
+++ b/chromium_src/chrome/browser/ui/views/infobars/infobar_view.h
@@ -10,9 +10,10 @@
 #include "ui/views/focus/external_focus_tracker.h"
 #include "ui/views/view.h"
 
-#define CloseButtonPressed          \
-  CloseButtonPressed_Unused() {}    \
-  friend class BraveConfirmInfoBar; \
+#define CloseButtonPressed              \
+  CloseButtonPressed_Unused() {}        \
+  friend class BraveConfirmInfoBar;     \
+  friend class WebDiscoveryInfoBarView; \
   virtual void CloseButtonPressed
 
 #include "src/chrome/browser/ui/views/infobars/infobar_view.h"  // IWYU pragma: export


### PR DESCRIPTION
Uplift of #30329
Resolves https://github.com/brave/brave-browser/issues/47836

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.