### PR TITLE
[build] Add `brave_all_build` CI feature

### DIFF
--- a/build/.ci_features
+++ b/build/.ci_features
@@ -5,3 +5,7 @@ gn_check_supports_checkdeps_only
 test_report_lists
 android_output_xml
 ios_output_xml
+
+# TODO(https://github.com/brave/brave-browser/issues/48001): Remove this CI
+# feature when `1.82.x` is retired.
+brave_all_build


### PR DESCRIPTION
This CI feature will be used by CI to select start building `brave:all`.

Resolves https://github.com/brave/brave-browser/issues/48000
