### PR TITLE
Fix Leo right-click actions not working in PDF

### DIFF
--- a/browser/ai_chat/ai_chat_render_view_context_menu_browsertest.cc
+++ b/browser/ai_chat/ai_chat_render_view_context_menu_browsertest.cc
@@ -15,6 +15,7 @@
 #include "brave/browser/ui/sidebar/sidebar_model.h"
 #include "brave/components/ai_chat/content/browser/ai_chat_tab_helper.h"
 #include "brave/components/ai_chat/core/browser/ai_chat_service.h"
+#include "brave/components/ai_chat/core/browser/conversation_handler.h"
 #include "brave/components/ai_chat/core/browser/engine/engine_consumer.h"
 #include "brave/components/ai_chat/core/browser/engine/mock_engine_consumer.h"
 #include "brave/components/ai_chat/core/browser/utils.h"
@@ -29,6 +30,7 @@
 #include "chrome/test/base/in_process_browser_test.h"
 #include "chrome/test/base/ui_test_utils.h"
 #include "components/prefs/pref_service.h"
+#include "content/public/browser/context_menu_params.h"
 #include "content/public/browser/render_frame_host.h"
 #include "content/public/browser/render_view_host.h"
 #include "content/public/browser/render_widget_host.h"
@@ -42,6 +44,10 @@
 #include "testing/gtest/include/gtest/gtest.h"
 #include "ui/base/mojom/menu_source_type.mojom.h"
 #include "url/gurl.h"
+
+#if BUILDFLAG(ENABLE_PDF)
+#include "chrome/browser/pdf/pdf_extension_test_util.h"
+#endif  // BUILDFLAG(ENABLE_PDF)
 
 using ::testing::_;
 
@@ -119,9 +125,9 @@ class AIChatRenderViewContextMenuBrowserTest : public InProcessBrowserTest {
     host_resolver()->AddRule("*", "127.0.0.1");
 
     base::FilePath test_data_dir =
-        base::PathService::CheckedGet(brave::DIR_TEST_DATA)
-            .AppendASCII("ai_chat");
-    https_server_.ServeFilesFromDirectory(test_data_dir);
+        base::PathService::CheckedGet(brave::DIR_TEST_DATA);
+    https_server_.ServeFilesFromDirectory(test_data_dir.AppendASCII("ai_chat"));
+    https_server_.ServeFilesFromDirectory(test_data_dir.AppendASCII("leo"));
     ASSERT_TRUE(https_server_.Start());
   }
 
@@ -242,6 +248,67 @@ class AIChatRenderViewContextMenuBrowserTest : public InProcessBrowserTest {
     return sidebar_controller->IsActiveIndex(index);
   }
 
+  ConversationHandler* GetConversationHandler() {
+    AIChatTabHelper* helper = AIChatTabHelper::FromWebContents(web_contents());
+    if (!helper) {
+      return nullptr;
+    }
+
+    return AIChatServiceFactory::GetInstance()
+        ->GetForBrowserContext(browser()->profile())
+        ->GetOrCreateConversationHandlerForContent(helper->content_id(),
+                                                   helper->GetWeakPtr());
+  }
+
+  std::unique_ptr<testing::NiceMock<MockConversationHandlerClient>>
+  SetupMockConversationHandler(const base::Location& location) {
+    SCOPED_TRACE(testing::Message() << location.ToString());
+    ConversationHandler* conversation_handler = GetConversationHandler();
+    if (!conversation_handler) {
+      ADD_FAILURE() << "Could not get ConversationHandler";
+      return nullptr;
+    }
+
+    return std::make_unique<testing::NiceMock<MockConversationHandlerClient>>(
+        conversation_handler);
+  }
+
+  // This is to wait for the conversation history update event.
+  // Note that this event would only happen in non rewrite-in-place path.
+  void ListenForConversationHistoryUpdate(
+      testing::NiceMock<MockConversationHandlerClient>& client,
+      base::RunLoop& run_loop,
+      std::string& submitted_text,
+      const base::Location& location) {
+    EXPECT_CALL(client, OnConversationHistoryUpdate(_))
+        .WillOnce(testing::Invoke([&, location](
+                                      const mojom::ConversationTurnPtr turn) {
+          SCOPED_TRACE(testing::Message() << location.ToString());
+          ConversationHandler* conversation_handler = GetConversationHandler();
+          ASSERT_TRUE(conversation_handler);
+          auto& history = conversation_handler->GetConversationHistory();
+          ASSERT_EQ(history.size(), 1u);
+          auto& entry = history[0];
+          ASSERT_TRUE(entry);
+          ASSERT_TRUE(entry->selected_text);
+          submitted_text = *entry->selected_text;
+          run_loop.Quit();
+        }));
+  }
+
+  std::unique_ptr<TestRenderViewContextMenu> CreateContextMenu(
+      content::RenderFrameHost* target_frame,
+      bool is_editable,
+      const std::u16string& selection_text) {
+    content::ContextMenuParams params;
+    params.is_editable = is_editable;
+    params.selection_text = selection_text;
+    auto menu =
+        std::make_unique<TestRenderViewContextMenu>(*target_frame, params);
+    menu->Init();
+    return menu;
+  }
+
  private:
   std::unique_ptr<MockEngineConsumer> ai_engine_;
   content::ContentMockCertVerifier mock_cert_verifier_;
@@ -257,20 +324,9 @@ IN_PROC_BROWSER_TEST_F(AIChatRenderViewContextMenuBrowserTest, RewriteInPlace) {
   ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
   auto* contents = web_contents();
 
-  // Setup a mock completion client to handle the request.
-  ai_chat::AIChatTabHelper* helper =
-      ai_chat::AIChatTabHelper::FromWebContents(contents);
-  ASSERT_TRUE(helper);
-
-  ConversationHandler* conversation_handler =
-      ai_chat::AIChatServiceFactory::GetInstance()
-          ->GetForBrowserContext(browser()->profile())
-          ->GetOrCreateConversationHandlerForContent(helper->content_id(),
-                                                     helper->GetWeakPtr());
-  // Keep the ConversationHandler alive until the test is done.
-  testing::NiceMock<MockConversationHandlerClient> client(conversation_handler);
-
-  ASSERT_TRUE(conversation_handler);
+  // This is to keep the ConversationHandler alive until the test is done.
+  auto client = SetupMockConversationHandler(FROM_HERE);
+  ASSERT_TRUE(client);
 
   // Test rewriting textarea value and verify that the response tag is ignored
   // by BraveRenderViewContextMenu
@@ -302,5 +358,113 @@ IN_PROC_BROWSER_TEST_F(AIChatRenderViewContextMenuBrowserTest, RewriteInPlace) {
                      base::unexpected(mojom::APIError::ConnectionIssue), "OK2");
   EXPECT_TRUE(IsAIChatSidebarActive());
 }
+
+IN_PROC_BROWSER_TEST_F(AIChatRenderViewContextMenuBrowserTest,
+                       SubmitSelectedText) {
+  // Mimic user opt-in by setting pref.
+  SetUserOptedIn(GetPrefs(), true);
+
+  GURL url = https_server()->GetURL("/text.html");
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
+  auto* contents = web_contents();
+
+  // Setup a mock completion client to handle the request.
+  auto client = SetupMockConversationHandler(FROM_HERE);
+  ASSERT_TRUE(client);
+
+  base::RunLoop run_loop;
+  std::string submitted_text;
+  ListenForConversationHistoryUpdate(*client, run_loop, submitted_text,
+                                     FROM_HERE);
+
+  // Create a context menu with selected text.
+  content::RenderFrameHost* target_frame = contents->GetPrimaryMainFrame();
+  auto menu = CreateContextMenu(target_frame, /*is_editable=*/false,
+                                u"This is the way");
+
+  ASSERT_TRUE(menu->IsCommandIdEnabled(IDC_AI_CHAT_CONTEXT_SUMMARIZE_TEXT));
+
+  // Execute the command.
+  menu->ExecuteCommand(IDC_AI_CHAT_CONTEXT_SUMMARIZE_TEXT, 0);
+  run_loop.Run();
+
+  EXPECT_EQ(submitted_text, "This is the way");
+  EXPECT_TRUE(IsAIChatSidebarActive());
+}
+
+#if BUILDFLAG(ENABLE_PDF)
+IN_PROC_BROWSER_TEST_F(AIChatRenderViewContextMenuBrowserTest,
+                       SubmitSelectedTextInPDF) {
+  // Mimic user opt-in by setting pref.
+  SetUserOptedIn(GetPrefs(), true);
+
+  // Load a dummy PDF page.
+  GURL url = https_server()->GetURL("/dummy.pdf");
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
+  ASSERT_TRUE(pdf_extension_test_util::EnsurePDFHasLoaded(web_contents()));
+
+  // Setup a mock client to listen to the conversation history update.
+  auto client = SetupMockConversationHandler(FROM_HERE);
+  ASSERT_TRUE(client);
+
+  base::RunLoop run_loop;
+  std::string submitted_text;
+  ListenForConversationHistoryUpdate(*client, run_loop, submitted_text,
+                                     FROM_HERE);
+
+  // Create a context menu on PDF frame with selected text.
+  content::RenderFrameHost* target_frame =
+      pdf_extension_test_util::GetOnlyPdfPluginFrame(web_contents());
+  auto menu = CreateContextMenu(target_frame, /*is_editable=*/false,
+                                u"This is the way");
+
+  ASSERT_TRUE(menu->IsCommandIdEnabled(IDC_AI_CHAT_CONTEXT_SUMMARIZE_TEXT));
+
+  // Execute the command.
+  menu->ExecuteCommand(IDC_AI_CHAT_CONTEXT_SUMMARIZE_TEXT, 0);
+  run_loop.Run();
+
+  EXPECT_EQ(submitted_text, "This is the way");
+  EXPECT_TRUE(IsAIChatSidebarActive());
+}
+
+// Rewrite commands in PDF would always go through the same path as
+// SubmitSelectedTextInPDF currently because the rewrite in place
+// implementation does not support PDF. This test is to verify that
+// it would work by going through the same path as SubmitSelectedTextInPDF.
+IN_PROC_BROWSER_TEST_F(AIChatRenderViewContextMenuBrowserTest,
+                       RewriteInPlaceDisabledInPDF) {
+  // Mimic user opt-in by setting pref.
+  SetUserOptedIn(GetPrefs(), true);
+
+  // Load a dummy PDF page.
+  GURL url = https_server()->GetURL("/dummy.pdf");
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
+  ASSERT_TRUE(pdf_extension_test_util::EnsurePDFHasLoaded(web_contents()));
+
+  auto client = SetupMockConversationHandler(FROM_HERE);
+  ASSERT_TRUE(client);
+
+  base::RunLoop run_loop;
+  std::string submitted_text;
+  ListenForConversationHistoryUpdate(*client, run_loop, submitted_text,
+                                     FROM_HERE);
+
+  // Create a context menu on PDF frame with selected text.
+  content::RenderFrameHost* target_frame =
+      pdf_extension_test_util::GetOnlyPdfPluginFrame(web_contents());
+  auto menu =
+      CreateContextMenu(target_frame, /*is_editable=*/true, u"This is the way");
+
+  ASSERT_TRUE(menu->IsCommandIdEnabled(IDC_AI_CHAT_CONTEXT_SHORTEN));
+
+  // Execute the command.
+  menu->ExecuteCommand(IDC_AI_CHAT_CONTEXT_SHORTEN, 0);
+  run_loop.Run();
+
+  EXPECT_EQ(submitted_text, "This is the way");
+  EXPECT_TRUE(IsAIChatSidebarActive());
+}
+#endif  // BUILDFLAG(ENABLE_PDF)
 
 }  // namespace ai_chat

--- a/chromium_src/chrome/browser/renderer_context_menu/render_view_context_menu.cc
+++ b/chromium_src/chrome/browser/renderer_context_menu/render_view_context_menu.cc
@@ -20,6 +20,7 @@
 #include "brave/browser/misc_metrics/profile_misc_metrics_service.h"
 #include "brave/browser/misc_metrics/profile_misc_metrics_service_factory.h"
 #include "brave/browser/renderer_context_menu/brave_spelling_options_submenu_observer.h"
+#include "brave/browser/ui/ai_chat/utils.h"
 #include "brave/browser/ui/brave_pages.h"
 #include "brave/browser/ui/browser_commands.h"
 #include "brave/browser/ui/browser_dialogs.h"
@@ -52,7 +53,6 @@
 #include "brave/browser/ai_chat/ai_chat_service_factory.h"
 #include "brave/browser/brave_browser_process.h"
 #include "brave/browser/misc_metrics/process_misc_metrics.h"
-#include "brave/browser/ui/sidebar/sidebar_controller.h"
 #include "brave/components/ai_chat/content/browser/ai_chat_tab_helper.h"
 #include "brave/components/ai_chat/core/browser/ai_chat_metrics.h"
 #include "brave/components/ai_chat/core/browser/ai_chat_service.h"
@@ -313,10 +313,6 @@ void OnRewriteSuggestionCompleted(
     }
 
     // Show the error in Leo side panel UI.
-    Browser* browser = chrome::FindBrowserWithTab(web_contents.get());
-    if (!browser) {
-      return;
-    }
     ai_chat::AIChatService* ai_chat_service =
         ai_chat::AIChatServiceFactory::GetForBrowserContext(
             web_contents.get()->GetBrowserContext());
@@ -336,10 +332,7 @@ void OnRewriteSuggestionCompleted(
     }
     conversation->MaybeUnlinkAssociatedContent();
 
-    auto* sidebar_controller = browser->GetFeatures().sidebar_controller();
-    CHECK(sidebar_controller);
-    sidebar_controller->ActivatePanelItem(
-        sidebar::SidebarItem::BuiltInItemType::kChatUI);
+    ai_chat::OpenAIChatForTab(web_contents.get());
 
     conversation->AddSubmitSelectedTextError(selected_text, action_type,
                                              result.error());
@@ -546,12 +539,15 @@ void BraveRenderViewContextMenu::ExecuteAIChatCommand(int command) {
   // 3) Context menu rewrite in place feature is enabled.
   // 4) SSE is enabled, it is required otherwise the UI update will be too slow.
   // 5) The command is a rewrite command.
-  // 6) There's no in-progress in-place rewrite.
+  // 6) Not in the case of MimeHandlerView (ex: PDF) where
+  // embedder_web_contents_ is different from source_web_contents_.
+  // 7) There's no in-progress in-place rewrite.
   bool rewrite_in_place =
       params_.is_editable &&
       ai_chat::HasUserOptedIn(GetProfile()->GetPrefs()) &&
       ai_chat::features::IsContextMenuRewriteInPlaceEnabled() &&
       ai_chat::features::kAIChatSSE.Get() && IsRewriteCommand(command) &&
+      source_web_contents_ == embedder_web_contents_ &&
       !source_web_contents_->GetUserData(kAIChatRewriteDataKey);
 
   auto [action_type, p3a_action] = GetActionTypeAndP3A(command);
@@ -589,13 +585,8 @@ void BraveRenderViewContextMenu::ExecuteAIChatCommand(int command) {
                        source_web_contents_->GetWeakPtr(), selected_text,
                        action_type));
   } else {
-    if (!browser) {
-      VLOG(1) << "Can't get browser";
-      return;
-    }
-
     ai_chat::AIChatTabHelper* helper =
-        ai_chat::AIChatTabHelper::FromWebContents(source_web_contents_);
+        ai_chat::AIChatTabHelper::FromWebContents(embedder_web_contents_);
     if (!helper) {
       VLOG(1) << "Can't get AI chat tab helper";
       return;
@@ -603,7 +594,7 @@ void BraveRenderViewContextMenu::ExecuteAIChatCommand(int command) {
 
     ai_chat::ConversationHandler* conversation =
         ai_chat::AIChatServiceFactory::GetForBrowserContext(
-            source_web_contents_->GetBrowserContext())
+            embedder_web_contents_->GetBrowserContext())
             ->GetOrCreateConversationHandlerForContent(helper->content_id(),
                                                        helper->GetWeakPtr());
     // Before trying to activate the panel, unlink page content if needed.
@@ -612,10 +603,7 @@ void BraveRenderViewContextMenu::ExecuteAIChatCommand(int command) {
     conversation->MaybeUnlinkAssociatedContent();
 
     // Active the panel.
-    auto* sidebar_controller = browser->GetFeatures().sidebar_controller();
-    CHECK(sidebar_controller);
-    sidebar_controller->ActivatePanelItem(
-        sidebar::SidebarItem::BuiltInItemType::kChatUI);
+    ai_chat::OpenAIChatForTab(embedder_web_contents_);
     conversation->SubmitSelectedText(selected_text, action_type);
   }
 


### PR DESCRIPTION
Currently when trying to do right-click actions in PDF, it would fail silently because it cannot get a tab helper due to tab_helper won't be installed in guest WebContents (PDF plugin).
embedder_web_contents should be used instead to access the tab helper.

Also, for rewrite-in-place, it turns out current implementation won't work on pdf anyway (also the server side support was broken for a while now in general) , so added a check to not use rewrite-in-place when `embedder_web_contents` != `source_web_contents`.

Another side change in this PR is replacing side panel op with existing util.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/46771

Manual test Plan:
Visit a pdf page, select some texts, right click to open context menu, and click on the explain action should work.