### PR TITLE
Make PermissionPromptBubble always on top

### DIFF
--- a/browser/ui/views/permissions/BUILD.gn
+++ b/browser/ui/views/permissions/BUILD.gn
@@ -1,0 +1,18 @@
+# Copyright (c) 2025 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+source_set("browser_tests") {
+  testonly = true
+  defines = [ "HAS_OUT_OF_PROC_TEST_RUNNER" ]
+
+  sources = [ "permission_prompt_bubble_base_view_browsertest.cc" ]
+
+  deps = [
+    "//base",
+    "//chrome/test:test_support",
+    "//testing/gmock",
+    "//testing/gtest",
+  ]
+}

--- a/browser/ui/views/permissions/permission_prompt_bubble_base_view_browsertest.cc
+++ b/browser/ui/views/permissions/permission_prompt_bubble_base_view_browsertest.cc
@@ -1,0 +1,112 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "chrome/browser/ui/views/permissions/permission_prompt_bubble_base_view.h"
+
+#include "chrome/browser/ui/views/permissions/permission_prompt_style.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "components/content_settings/core/common/content_settings_types.mojom.h"
+#include "components/permissions/permission_request.h"
+#include "components/permissions/resolvers/content_setting_permission_resolver.h"
+#include "components/permissions/test/mock_permission_prompt.h"
+#include "content/public/test/browser_test.h"
+#include "testing/gmock/include/gmock/gmock.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+using PermissionPromptBubbleBaseViewBrowserTest = InProcessBrowserTest;
+
+namespace {
+
+class MockPermissionPromptDelegate
+    : public permissions::PermissionPrompt::Delegate {
+ public:
+  MockPermissionPromptDelegate() {
+    request_.push_back(std::make_unique<permissions::PermissionRequest>(
+        std::make_unique<permissions::PermissionRequestData>(
+            std::make_unique<permissions::ContentSettingPermissionResolver>(
+                ContentSettingsType::MEDIASTREAM_CAMERA),
+            true, GURL()),
+        base::DoNothing()));
+  }
+  ~MockPermissionPromptDelegate() override = default;
+
+  const std::vector<std::unique_ptr<permissions::PermissionRequest>>& Requests()
+      override {
+    return request_;
+  }
+
+  GURL GetRequestingOrigin() const override { return GURL(); }
+
+  GURL GetEmbeddingOrigin() const override { return GURL(); }
+
+  void Accept() override {}
+  void AcceptThisTime() override {}
+  void Deny() override {}
+  void Dismiss() override {}
+  void Ignore() override {}
+  void FinalizeCurrentRequests() override {}
+  void OpenHelpCenterLink(const ui::Event& event) override {}
+  void PreIgnoreQuietPrompt() override {}
+  void SetManageClicked() override {}
+  void SetLearnMoreClicked() override {}
+  void SetHatsShownCallback(base::OnceCallback<void()> callback) override {}
+
+  bool WasCurrentRequestAlreadyDisplayed() override { return false; }
+  bool ShouldDropCurrentRequestIfCannotShowQuietly() const override {
+    return false;
+  }
+  bool ShouldCurrentRequestUseQuietUI() const override { return false; }
+  std::optional<permissions::PermissionUiSelector::QuietUiReason>
+  ReasonForUsingQuietUi() const override {
+    return std::nullopt;
+  }
+  void SetDismissOnTabClose() override {}
+  void SetPromptShown() override {}
+  void SetDecisionTime() override {}
+  bool RecreateView() override { return false; }
+  const permissions::PermissionPrompt* GetCurrentPrompt() const override {
+    return nullptr;
+  }
+
+  base::WeakPtr<permissions::PermissionPrompt::Delegate> GetWeakPtr() override {
+    return weak_ptr_factory_.GetWeakPtr();
+  }
+
+  content::WebContents* GetAssociatedWebContents() override { return nullptr; }
+
+ private:
+  std::vector<std::unique_ptr<permissions::PermissionRequest>> request_;
+
+  base::WeakPtrFactory<MockPermissionPromptDelegate> weak_ptr_factory_{this};
+};
+
+class MockPermissionPromptBubbleBaseView
+    : public PermissionPromptBubbleBaseView {
+ public:
+  MockPermissionPromptBubbleBaseView(
+      Browser* browser,
+      base::WeakPtr<permissions::PermissionPrompt::Delegate> delegate)
+      : PermissionPromptBubbleBaseView(browser,
+                                       delegate,
+                                       base::TimeTicks::Now(),
+                                       PermissionPromptStyle::kBubbleOnly) {
+    CreateWidget();
+    ShowWidget();
+  }
+};
+
+}  // namespace
+
+IN_PROC_BROWSER_TEST_F(PermissionPromptBubbleBaseViewBrowserTest,
+                       ZOrderLevelShouldBeSecuritySurface) {
+  // This test checks that the permission prompt bubble is created with the
+  // correct z-order level, which should be kSecuritySurface.
+  MockPermissionPromptDelegate mock_delegate;
+  auto* permission_prompt = new MockPermissionPromptBubbleBaseView(
+      browser(), mock_delegate.GetWeakPtr());
+  EXPECT_EQ(permission_prompt->GetWidget()->GetZOrderLevel(),
+            ui::ZOrderLevel::kSecuritySurface);
+  permission_prompt->GetWidget()->CloseNow();
+}

--- a/chromium_src/chrome/browser/ui/views/permissions/permission_prompt_bubble_base_view.cc
+++ b/chromium_src/chrome/browser/ui/views/permissions/permission_prompt_bubble_base_view.cc
@@ -49,6 +49,7 @@
 #include "ui/views/controls/styled_label.h"
 #include "ui/views/layout/box_layout.h"
 #include "ui/views/style/typography.h"
+#include "ui/views/widget/widget.h"
 #include "ui/views/window/dialog_client_view.h"
 #include "ui/views/window/dialog_delegate.h"
 
@@ -433,5 +434,15 @@ void AddFootnoteViewIfNeeded(
   }                                                                       \
   AddGeolocationDescriptionIfNeeded(this, delegate_.get(), browser());
 
+// Sets the zorder for permission prompt bubble to kSecuritySurface, so that it
+// appears above other UI elements even they are floating on top.For example,
+// Picture-in-Picture window is on top of other widgets, but permission prompt
+// bubble should still be on top of it.
+#define SetZOrderSublevel(...)    \
+  SetZOrderSublevel(__VA_ARGS__); \
+  widget->SetZOrderLevel(ui::ZOrderLevel::kSecuritySurface);
+
 #include <chrome/browser/ui/views/permissions/permission_prompt_bubble_base_view.cc>
+
+#undef SetZOrderSublevel
 #undef BRAVE_PERMISSION_PROMPT_BUBBLE_BASE_VIEW

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -1120,6 +1120,7 @@ test("brave_browser_tests") {
       "//brave/browser/ui/views/frame:browser_tests",
       "//brave/browser/ui/views/frame/vertical_tabs:browser_tests",
       "//brave/browser/ui/views/location_bar:browser_tests",
+      "//brave/browser/ui/views/permissions:browser_tests",
       "//brave/browser/ui/views/split_view:browser_tests",
       "//brave/browser/ui/views/tabs:browser_tests",
       "//brave/components/sidebar/browser",


### PR DESCRIPTION
Sets the zorder for permission prompt bubble to kSecuritySurface, so that it appears above other UI elements even they are floating on top.For example, Picture-in-Picture window is on top of other widgets, but permission prompt bubble should still be on top of it.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/internal/issues/1318

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
