### PR TITLE
Revert "Error exporting bookmarks on latest version on Android 10 (uplift to 1.80.x)"

### DIFF
--- a/android/java/org/chromium/chrome/browser/bookmarks/BraveBookmarkBridge.java
+++ b/android/java/org/chromium/chrome/browser/bookmarks/BraveBookmarkBridge.java
@@ -5,36 +5,16 @@
 
 package org.chromium.chrome.browser.bookmarks;
 
-import android.content.ContentResolver;
-import android.content.ContentValues;
-import android.content.Context;
-import android.net.Uri;
-import android.os.Build;
-import android.os.Environment;
-import android.provider.MediaStore;
-
-import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 
 import org.jni_zero.CalledByNative;
 import org.jni_zero.NativeMethods;
 
-import org.chromium.base.Log;
-import org.chromium.base.ThreadUtils;
-import org.chromium.base.task.PostTask;
-import org.chromium.base.task.TaskTraits;
 import org.chromium.chrome.browser.profiles.Profile;
 import org.chromium.ui.base.WindowAndroid;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-
 class BraveBookmarkBridge extends BookmarkBridge {
     // Overridden Chromium's BookmarkBridge.mNativeBookmarkBridge
-    private static final String TAG = "BraveBookmarkBridge";
     private long mNativeBookmarkBridge;
     private WindowAndroid mWindowAndroid;
     private String mExportFilePath;
@@ -59,88 +39,18 @@ class BraveBookmarkBridge extends BookmarkBridge {
     }
 
     @CalledByNative
-    public void bookmarksExported(final boolean isSuccess) {
-        if (mWindowAndroid == null
-                || mWindowAndroid.getContext().get() == null
-                || !(mWindowAndroid.getContext().get() instanceof AppCompatActivity)) {
-            return;
+    public void bookmarksExported(boolean isSuccess) {
+        if (mWindowAndroid != null && mWindowAndroid.getContext().get() != null
+                && mWindowAndroid.getContext().get() instanceof AppCompatActivity) {
+            ((AppCompatActivity) mWindowAndroid.getContext().get()).runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    BraveBookmarkUtils.showBookmarkImportExportDialog(
+                            (AppCompatActivity) mWindowAndroid.getContext().get(), false, isSuccess,
+                            mExportFilePath);
+                }
+            });
         }
-        if (Build.VERSION.SDK_INT == Build.VERSION_CODES.Q && isSuccess) {
-            PostTask.postTask(
-                    TaskTraits.BEST_EFFORT_MAY_BLOCK,
-                    () -> {
-                        ThreadUtils.assertOnBackgroundThread();
-                        boolean result = isSuccess;
-                        try {
-                            moveInternalFileToDownloads(
-                                    mWindowAndroid.getContext().get(), mExportFilePath);
-                        } catch (IOException e) {
-                            Log.e(TAG, "Failed to move file to public Downloads", e);
-                            result = false;
-                        }
-                        showExportedDialog(result);
-                    });
-        } else {
-            showExportedDialog(isSuccess);
-        }
-    }
-
-    private void moveInternalFileToDownloads(
-            @NonNull Context context, @NonNull String internalFileName) throws IOException {
-        ContentResolver resolver = context.getContentResolver();
-        // Open internal file to copy to the MediaStore URI
-        File internalFile = new File(internalFileName);
-
-        ContentValues values = new ContentValues();
-        values.put(MediaStore.MediaColumns.DISPLAY_NAME, internalFile.getName());
-        values.put(MediaStore.MediaColumns.MIME_TYPE, "text/html");
-        values.put(MediaStore.MediaColumns.RELATIVE_PATH, Environment.DIRECTORY_DOWNLOADS);
-
-        // Insert ContentValues into MediaStore to get a new URI
-        Uri uri = resolver.insert(MediaStore.Downloads.EXTERNAL_CONTENT_URI, values);
-        if (uri == null) {
-            throw new IOException("Failed to create file in MediaStore");
-        }
-
-        try (InputStream inputStream = new FileInputStream(internalFile);
-                OutputStream outputStream = resolver.openOutputStream(uri)) {
-
-            if (outputStream == null) {
-                resolver.delete(uri, null, null);
-                throw new IOException("Failed to open output stream");
-            }
-
-            byte[] buffer = new byte[1024];
-            int bytesRead;
-            while ((bytesRead = inputStream.read(buffer)) != -1) {
-                outputStream.write(buffer, 0, bytesRead);
-            }
-
-            if (internalFile.exists() && !internalFile.delete()) {
-                throw new IOException("Failed to delete internal file after copying");
-            }
-            mExportFilePath =
-                    new File(Environment.DIRECTORY_DOWNLOADS, internalFile.getName()).getPath();
-        } catch (Exception e) {
-            // Clean up the MediaStore entry on failure
-            resolver.delete(uri, null, null);
-            throw new IOException("Failed to copy or delete file", e);
-        }
-    }
-
-    private void showExportedDialog(boolean isSuccess) {
-        ((AppCompatActivity) mWindowAndroid.getContext().get())
-                .runOnUiThread(
-                        new Runnable() {
-                            @Override
-                            public void run() {
-                                BraveBookmarkUtils.showBookmarkImportExportDialog(
-                                        (AppCompatActivity) mWindowAndroid.getContext().get(),
-                                        false,
-                                        isSuccess,
-                                        mExportFilePath);
-                            }
-                        });
     }
 
     public void importBookmarks(WindowAndroid windowAndroid, String importFilePath) {

--- a/android/java/org/chromium/chrome/browser/bookmarks/BraveBookmarkManagerMediator.java
+++ b/android/java/org/chromium/chrome/browser/bookmarks/BraveBookmarkManagerMediator.java
@@ -20,7 +20,6 @@ import androidx.recyclerview.widget.RecyclerView;
 import androidx.recyclerview.widget.RecyclerView.OnScrollListener;
 
 import org.chromium.base.Log;
-import org.chromium.base.PathUtils;
 import org.chromium.base.supplier.ObservableSupplierImpl;
 import org.chromium.base.task.PostTask;
 import org.chromium.base.task.TaskTraits;
@@ -223,66 +222,29 @@ class BraveBookmarkManagerMediator extends BookmarkManagerMediator
         PostTask.postTask(
                 TaskTraits.BEST_EFFORT_MAY_BLOCK,
                 () -> {
-                    doExportBookmarksOnUI(getUniqueFile(getDownloadDir()));
+                    File downloadDir =
+                            Environment.getExternalStoragePublicDirectory(
+                                    Environment.DIRECTORY_DOWNLOADS);
+                    int num = 1;
+                    String exportFileName = "bookmarks.html";
+                    File file = new File(downloadDir, exportFileName);
+                    while (file.exists()) {
+                        exportFileName = "bookmarks (" + num++ + ").html";
+                        file = new File(downloadDir, exportFileName);
+                    }
+                    doExportBookmarksOnUI(file);
                 });
     }
 
-    private File getUniqueFile(File downloadDir) {
-        int num = 1;
-        String exportFileName = "bookmarks.html";
-        File file = new File(downloadDir, exportFileName);
-        boolean filePublicExist = false;
-        File filePublic;
-        // We check for file existence on both Public Downloads storage
-        // and internal Downloads storage on Android 10
-        if (Build.VERSION.SDK_INT == Build.VERSION_CODES.Q) {
-            filePublic =
-                    new File(
-                            Environment.getExternalStoragePublicDirectory(
-                                    Environment.DIRECTORY_DOWNLOADS),
-                            exportFileName);
-            filePublicExist = filePublic.exists();
-        }
-        while (file.exists() || filePublicExist) {
-            exportFileName = "bookmarks (" + num++ + ").html";
-            file = new File(downloadDir, exportFileName);
-            if (Build.VERSION.SDK_INT == Build.VERSION_CODES.Q) {
-                filePublic =
-                        new File(
-                                Environment.getExternalStoragePublicDirectory(
-                                        Environment.DIRECTORY_DOWNLOADS),
-                                exportFileName);
-                filePublicExist = filePublic.exists();
-            }
-        }
-
-        return file;
-    }
-
-    private File getDownloadDir() {
-        // Android 10 apps may encounter issues when trying to write to the
-        // public Downloads directory because the scoped storage model is not
-        // fully enforced. On Android 11 and above, apps can write to the
-        // public Downloads directory. On Android below 10 the scoped storage
-        // model hasn't been introduced yet.
-        if (Build.VERSION.SDK_INT == Build.VERSION_CODES.Q) {
-            return new File(PathUtils.getDownloadsDirectory());
-        }
-
-        return Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS);
-    }
-
     private void doExportBookmarksOnUI(File file) {
-        ((AppCompatActivity) mWindowAndroid.getContext().get())
-                .runOnUiThread(
-                        new Runnable() {
-                            @Override
-                            public void run() {
-                                if (mBookmarkModel instanceof BraveBookmarkModel) {
-                                    ((BraveBookmarkModel) mBookmarkModel)
-                                            .exportBookmarks(mWindowAndroid, file.getPath());
-                                }
-                            }
-                        });
+        ((AppCompatActivity) mWindowAndroid.getContext().get()).runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                if (mBookmarkModel instanceof BraveBookmarkModel) {
+                    ((BraveBookmarkModel) mBookmarkModel)
+                            .exportBookmarks(mWindowAndroid, file.getPath());
+                }
+            }
+        });
     }
 }


### PR DESCRIPTION
This reverts commit cb5cf9b58c89f720be9f4c073d1992e53069620d.

This PR reverts https://github.com/brave/brave-core/pull/30315 from `1.80.x` to unblock release.

Build error
```
[2025-07-30T07:03:27.723Z] ../../brave/android/java/org/chromium/chrome/browser/bookmarks/BraveBookmarkBridge.java:100: Error: Field requires API level 29 (current min is 26): android.provider.MediaStore.Downloads#EXTERNAL_CONTENT_URI [NewApi]
```
