### PR TITLE
adds help command

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Brave Core is a set of changes, APIs and scripts used for customizing Chromium to make Brave.",
   "main": "index.js",
   "scripts": {
+    "help": "node ./build/commands/scripts/commands.js --help",
     "audit_deps": "node ./build/commands/scripts/audit.js -- --audit_dev_deps",
     "cibuild": "node ./build/commands/scripts/commands.js cibuild",
     "init": "cd ../../ && npm run --prefix src/brave sync -- --init",


### PR DESCRIPTION
adds a help command which can act as automated documentation:

```
➜  brave git:(feat/adds-help-command) npm run help

> brave-core@1.82.132 help
> node ./build/commands/scripts/commands.js --help

Usage: commands [options] [command]

Options:
  -V, --version                                output the version number
  -h, --help                                   output usage information

Commands:
  versions
  gn_check [options] [build_config]
  apply_patches [options] [build_config]
  update_symlink [options] [build_config]
  build [options] [build_config]
  build_chromium_release [options]             Produces a chromium release build for performance testing.
  Uses the same /src directory; all brave patches are reverted.
  The default build_dir is `chromium_Release(_target_arch)`.
  Intended for use on CI, use locally with care.
  start [options] [build_config]
  pull_l10n [options]
  push_l10n [options]
  chromium_rebase_l10n
  update_patches [filePaths...]                Updates all patches in the brave-core repo. If a filePath is provider, only that specific file will be updated.
  cibuild [options]
  test [options] <suite> [build_config]
  presubmit [options]
  mass_rename
  build_fuzzer [options] <fuzzer_test_target>
  run_fuzzer <suite>
  run_perf_tests [perf_config] [targets]       Call npm run perf_tests -- --more-help for detailed help
  gen_gradle [options] [build_config]
  docs
```


TODO:
- [ ] add descriptions for commands that don't have one
- [ ] register other commands