### PR TITLE
[codehealth] Migrate to `v8::Isolate::GetCurrent`

### DIFF
--- a/chromium_src/third_party/blink/renderer/bindings/core/v8/referrer_script_info.cc
+++ b/chromium_src/third_party/blink/renderer/bindings/core/v8/referrer_script_info.cc
@@ -45,7 +45,7 @@ ReferrerScriptInfo ReferrerScriptInfo::FromV8HostDefinedOptions(
     v8::Local<v8::PrimitiveArray> host_defined_options =
         v8::Local<v8::PrimitiveArray>::Cast(raw_host_defined_options);
     if (host_defined_options->Length()) {
-      v8::Isolate* isolate = context->GetIsolate();
+      v8::Isolate* isolate = v8::Isolate::GetCurrent();
 
       v8::Local<v8::Primitive> dom_node_id_value = host_defined_options->Get(
           isolate, HostDefinedOptionsIndex::kDomNodeId);

--- a/chromium_src/third_party/blink/renderer/bindings/core/v8/to_v8_traits.h
+++ b/chromium_src/third_party/blink/renderer/bindings/core/v8/to_v8_traits.h
@@ -11,7 +11,7 @@
   [[nodiscard]] static v8::Local<v8::Value> ToV8(ScriptState* script_state,    \
                                                  const ContainerType* value) { \
     if (!value)                                                                \
-      return v8::Null(script_state->GetIsolate());                             \
+      return v8::Null(v8::Isolate::GetCurrent());                              \
     return ToV8Traits<IDLSequence<T>>::ToV8(script_state, *value);             \
   }
 

--- a/chromium_src/third_party/blink/renderer/bindings/core/v8/v8_script_runner.cc
+++ b/chromium_src/third_party/blink/renderer/bindings/core/v8/v8_script_runner.cc
@@ -25,7 +25,7 @@ v8::MaybeLocal<v8::Script> V8ScriptRunner::CompileScript(
     v8::Local<v8::Script> script;
     if (result.ToLocal(&script)) {
       const auto referrer_info = ReferrerScriptInfo::FromV8HostDefinedOptions(
-          script_state->GetIsolate()->GetCurrentContext(),
+          v8::Isolate::GetCurrent()->GetCurrentContext(),
           origin.GetHostDefinedOptions(), classic_script.SourceUrl());
       probe::RegisterPageGraphScriptCompilation(
           ExecutionContext::From(script_state), referrer_info, classic_script,

--- a/chromium_src/third_party/blink/renderer/core/frame/dom_window.cc
+++ b/chromium_src/third_party/blink/renderer/core/frame/dom_window.cc
@@ -17,7 +17,7 @@ LocalFrame* DOMWindow::GetDisconnectedFrame() const {
     return nullptr;
   }
 
-  v8::Isolate* isolate = window_proxy_manager_->GetIsolate();
+  v8::Isolate* isolate = v8::Isolate::GetCurrent();
   LocalDOMWindow* accessing_window = IncumbentDOMWindow(isolate);
   LocalFrame* accessing_frame = accessing_window->GetFrame();
   return accessing_frame;

--- a/chromium_src/third_party/blink/renderer/core/scheduler/scheduled_action.cc
+++ b/chromium_src/third_party/blink/renderer/core/scheduler/scheduled_action.cc
@@ -11,14 +11,14 @@
 #include "third_party/blink/renderer/core/script/classic_script.h"
 #include "third_party/blink/renderer/platform/loader/fetch/script_fetch_options.h"
 
-#define BRAVE_SCHEDULED_ACTION_STRING_HANDLER_CONSTRUCTOR                \
-  IF_BUILDFLAG(ENABLE_BRAVE_PAGE_GRAPH, {                                \
-    if (!code_.empty() &&                                                \
-        CoreProbeSink::HasAgentsGlobal(CoreProbeSink::kPageGraph)) {     \
-      parent_script_id_ =                                                \
-          v8::page_graph::GetExecutingScript(script_state->GetIsolate()) \
-              .script_id;                                                \
-    }                                                                    \
+#define BRAVE_SCHEDULED_ACTION_STRING_HANDLER_CONSTRUCTOR               \
+  IF_BUILDFLAG(ENABLE_BRAVE_PAGE_GRAPH, {                               \
+    if (!code_.empty() &&                                               \
+        CoreProbeSink::HasAgentsGlobal(CoreProbeSink::kPageGraph)) {    \
+      parent_script_id_ =                                               \
+          v8::page_graph::GetExecutingScript(v8::Isolate::GetCurrent()) \
+              .script_id;                                               \
+    }                                                                   \
   })
 
 #define ScriptFetchOptions GetScriptFetchOptions

--- a/chromium_src/third_party/blink/renderer/core/script/dynamic_module_resolver.cc
+++ b/chromium_src/third_party/blink/renderer/core/script/dynamic_module_resolver.cc
@@ -7,15 +7,14 @@
 #include "brave/v8/include/v8-isolate-page-graph-utils.h"
 #include "third_party/blink/renderer/core/probe/core_probes.h"
 
-#define BRAVE_DYNAMIC_MODULE_RESOLVER_RESOLVE_DYNAMICALLY            \
-  IF_BUILDFLAG(ENABLE_BRAVE_PAGE_GRAPH, {                            \
-    if (CoreProbeSink::HasAgentsGlobal(CoreProbeSink::kPageGraph)) { \
-      options.SetDOMNodeId(referrer_info.GetDOMNodeId());            \
-      options.SetParentScriptId(                                     \
-          v8::page_graph::GetExecutingScript(                        \
-              modulator_->GetScriptState()->GetIsolate())            \
-              .script_id);                                           \
-    }                                                                \
+#define BRAVE_DYNAMIC_MODULE_RESOLVER_RESOLVE_DYNAMICALLY               \
+  IF_BUILDFLAG(ENABLE_BRAVE_PAGE_GRAPH, {                               \
+    if (CoreProbeSink::HasAgentsGlobal(CoreProbeSink::kPageGraph)) {    \
+      options.SetDOMNodeId(referrer_info.GetDOMNodeId());               \
+      options.SetParentScriptId(                                        \
+          v8::page_graph::GetExecutingScript(v8::Isolate::GetCurrent()) \
+              .script_id);                                              \
+    }                                                                   \
   })
 
 #include <third_party/blink/renderer/core/script/dynamic_module_resolver.cc>

--- a/chromium_src/third_party/blink/renderer/modules/webgl/webgl2_rendering_context_base.cc
+++ b/chromium_src/third_party/blink/renderer/modules/webgl/webgl2_rendering_context_base.cc
@@ -63,7 +63,7 @@ ScriptValue FarbleGLInt64Parameter(WebGL2RenderingContextBase* owner,
   if (!brave::AllowFingerprinting(                      \
           ExecutionContext::From(script_state),         \
           ContentSettingsType::BRAVE_WEBCOMPAT_WEBGL2)) \
-    return ScriptValue::CreateNull(script_state->GetIsolate());
+    return ScriptValue::CreateNull(v8::Isolate::GetCurrent());
 
 #define BRAVE_WEBGL2_RENDERING_CONTEXT_BASE_GETPARAMETER                       \
   switch (brave::GetBraveFarblingLevelFor(                                     \
@@ -91,7 +91,7 @@ ScriptValue FarbleGLInt64Parameter(WebGL2RenderingContextBase* owner,
         case GL_MAX_COMBINED_UNIFORM_BLOCKS:                                   \
         case GL_MAX_COMBINED_VERTEX_UNIFORM_COMPONENTS:                        \
         case GL_MAX_COMBINED_FRAGMENT_UNIFORM_COMPONENTS:                      \
-          return ScriptValue::CreateNull(script_state->GetIsolate());          \
+          return ScriptValue::CreateNull(v8::Isolate::GetCurrent());           \
       }                                                                        \
       break;                                                                   \
     }                                                                          \

--- a/chromium_src/third_party/blink/renderer/modules/webgl/webgl_rendering_context_base.cc
+++ b/chromium_src/third_party/blink/renderer/modules/webgl/webgl_rendering_context_base.cc
@@ -46,7 +46,7 @@ bool AllowFingerprintingForHost(blink::CanvasRenderingContextHost* host) {
 
 #define BRAVE_WEBGL_RENDERING_CONTEXT_BASE_SCRIPT_VALUE \
   if (!AllowFingerprintingForHost(Host()))              \
-    return ScriptValue::CreateNull(script_state->GetIsolate());
+    return ScriptValue::CreateNull(v8::Isolate::GetCurrent());
 
 #define BRAVE_WEBGL_RENDERING_CONTEXT_BASE_STRING \
   if (!AllowFingerprintingForHost(Host()))        \
@@ -108,7 +108,7 @@ ScriptObject WebGLRenderingContextBase::getExtension(ScriptState* script_state,
                                                      const String& name) {
   if (!AllowFingerprintingForHost(Host())) {
     if (name != WebGLDebugRendererInfo::ExtensionName())
-      return ScriptObject::CreateNull(script_state->GetIsolate());
+      return ScriptObject::CreateNull(v8::Isolate::GetCurrent());
   }
   return getExtension_ChromiumImpl(script_state, name);
 }

--- a/chromium_src/v8/src/inspector/value-mirror.cc
+++ b/chromium_src/v8/src/inspector/value-mirror.cc
@@ -156,7 +156,7 @@ v8::Local<v8::Value> SerializeValue(v8::Local<v8::Context> context,
     return serialized_value;
   }
 
-  Isolate* isolate = context->GetIsolate();
+  Isolate* isolate = v8::Isolate::GetCurrent();
   serialized_value = Object::New(isolate);
 
   for (auto& mirror : properties.mirrors()) {
@@ -193,7 +193,7 @@ v8::Local<v8::Value> SerializeValue(v8::Local<v8::Context> context,
       }
 
       if (result->hasValue()) {
-        prop_value = ConvertProtocolValueToV8Value(context->GetIsolate(),
+        prop_value = ConvertProtocolValueToV8Value(v8::Isolate::GetCurrent(),
                                                    result->getValue(nullptr));
       } else if (result->hasUnserializableValue()) {
         prop_value = v8_inspector::toV8String(

--- a/components/brave_search/renderer/brave_search_fallback_js_handler.cc
+++ b/components/brave_search/renderer/brave_search_fallback_js_handler.cc
@@ -24,8 +24,8 @@ BraveSearchFallbackJSHandler::BraveSearchFallbackJSHandler(
     v8::Local<v8::Context> v8_context,
     blink::ThreadSafeBrowserInterfaceBrokerProxy* broker)
     : broker_(broker),
-      context_(v8_context->GetIsolate(), v8_context),
-      isolate_(v8_context->GetIsolate()) {}
+      context_(v8::Isolate::GetCurrent(), v8_context),
+      isolate_(v8::Isolate::GetCurrent()) {}
 
 BraveSearchFallbackJSHandler::~BraveSearchFallbackJSHandler() = default;
 

--- a/components/brave_search/renderer/brave_search_service_worker_holder.cc
+++ b/components/brave_search/renderer/brave_search_service_worker_holder.cc
@@ -102,7 +102,7 @@ void JsHandlersForCurrentThread::RemoveContext(
       js_handlers_,
       [&v8_context](
           const std::unique_ptr<BraveSearchFallbackJSHandler>& js_handler) {
-        v8::HandleScope handle_scope(js_handler->GetIsolate());
+        v8::HandleScope handle_scope(v8::Isolate::GetCurrent());
         v8::Context::Scope context_scope(js_handler->Context());
         return js_handler->Context() == v8_context;
       });

--- a/components/brave_wallet/renderer/js_cardano_wallet_api.cc
+++ b/components/brave_wallet/renderer/js_cardano_wallet_api.cc
@@ -118,10 +118,10 @@ void JSCardanoWalletApi::HandleStringResult(
   v8::Local<v8::Promise::Resolver> resolver = promise_resolver.Get(isolate);
   if (result) {
     std::ignore = resolver->Resolve(
-        context, gin::StringToV8(context->GetIsolate(), *result));
+        context, gin::StringToV8(v8::Isolate::GetCurrent(), *result));
   } else {
     std::ignore = resolver->Reject(
-        context, ConvertError(context->GetIsolate(), context, error));
+        context, ConvertError(v8::Isolate::GetCurrent(), context, error));
   }
 }
 
@@ -147,7 +147,7 @@ void JSCardanoWalletApi::HandleStringVecResult(
                      base::ToValueList(*result), context));
   } else {
     std::ignore = resolver->Reject(
-        context, ConvertError(context->GetIsolate(), context, error));
+        context, ConvertError(v8::Isolate::GetCurrent(), context, error));
   }
 }
 
@@ -173,7 +173,7 @@ void JSCardanoWalletApi::HandleUtxoVecResult(
                      base::ToValueList(*result), context));
   } else {
     std::ignore = resolver->Reject(
-        context, ConvertError(context->GetIsolate(), context, error));
+        context, ConvertError(v8::Isolate::GetCurrent(), context, error));
   }
 }
 
@@ -219,7 +219,7 @@ void JSCardanoWalletApi::OnGetNetworkId(
     std::ignore = resolver->Resolve(context, v8::Int32::New(isolate, network));
   } else {
     std::ignore = resolver->Reject(
-        context, ConvertError(context->GetIsolate(), context, error));
+        context, ConvertError(v8::Isolate::GetCurrent(), context, error));
   }
 }
 
@@ -520,7 +520,7 @@ void JSCardanoWalletApi::OnSignData(
                      *result, isolate->GetCurrentContext()));
   } else {
     std::ignore = resolver->Reject(
-        context, ConvertError(context->GetIsolate(), context, error));
+        context, ConvertError(v8::Isolate::GetCurrent(), context, error));
   }
 }
 

--- a/components/brave_wallet/renderer/js_solana_provider.cc
+++ b/components/brave_wallet/renderer/js_solana_provider.cc
@@ -788,7 +788,7 @@ void JSSolanaProvider::OnSignAllTransactions(
   if (error == mojom::SolanaProviderError::kSuccess) {
     size_t serialized_txs_length = serialized_txs.size();
     v8::Local<v8::Array> tx_array =
-        v8::Array::New(context->GetIsolate(), serialized_txs_length);
+        v8::Array::New(v8::Isolate::GetCurrent(), serialized_txs_length);
     for (size_t i = 0; i < serialized_txs_length; ++i) {
       v8::Local<v8::Value> transaction =
           CreateTransaction(context, serialized_txs[i], versions[i]);
@@ -1071,7 +1071,7 @@ bool JSSolanaProvider::LoadSolanaWeb3ModuleIfNeeded(v8::Isolate* isolate) {
 v8::Local<v8::Value> JSSolanaProvider::CreatePublicKey(
     v8::Local<v8::Context> context,
     const std::string& base58_str) {
-  v8::Isolate* isolate = context->GetIsolate();
+  v8::Isolate* isolate = v8::Isolate::GetCurrent();
   v8::MicrotasksScope microtasks(isolate, context->GetMicrotaskQueue(),
                                  v8::MicrotasksScope::kDoNotRunMicrotasks);
   v8::Context::Scope context_scope(context);
@@ -1103,7 +1103,7 @@ v8::Local<v8::Value> JSSolanaProvider::CreateTransaction(
     v8::Local<v8::Context> context,
     const std::vector<uint8_t> serialized_tx,
     mojom::SolanaMessageVersion version) {
-  v8::Isolate* isolate = context->GetIsolate();
+  v8::Isolate* isolate = v8::Isolate::GetCurrent();
   if (!render_frame()) {
     return v8::Undefined(isolate);
   }

--- a/components/brave_wallet/renderer/v8_helper.cc
+++ b/components/brave_wallet/renderer/v8_helper.cc
@@ -21,7 +21,8 @@ namespace brave_wallet {
 v8::MaybeLocal<v8::Value> GetProperty(v8::Local<v8::Context> context,
                                       v8::Local<v8::Value> object,
                                       std::string_view name) {
-  v8::Local<v8::String> name_str = gin::StringToV8(context->GetIsolate(), name);
+  v8::Local<v8::String> name_str =
+      gin::StringToV8(v8::Isolate::GetCurrent(), name);
   v8::Local<v8::Object> object_obj;
   if (!object->ToObject(context).ToLocal(&object_obj)) {
     return v8::MaybeLocal<v8::Value>();
@@ -34,7 +35,8 @@ v8::Maybe<bool> CreateDataProperty(v8::Local<v8::Context> context,
                                    v8::Local<v8::Object> object,
                                    std::string_view name,
                                    v8::Local<v8::Value> value) {
-  v8::Local<v8::String> name_str = gin::StringToV8(context->GetIsolate(), name);
+  v8::Local<v8::String> name_str =
+      gin::StringToV8(v8::Isolate::GetCurrent(), name);
 
   return object->CreateDataProperty(context, name_str, value);
 }

--- a/components/cosmetic_filters/renderer/cosmetic_filters_js_handler.cc
+++ b/components/cosmetic_filters/renderer/cosmetic_filters_js_handler.cc
@@ -211,7 +211,7 @@ v8::Maybe<bool> CreateDataProperty(v8::Local<v8::Context> context,
                                    std::string_view name,
                                    v8::Local<v8::Value> value) {
   const v8::Local<v8::String> name_str =
-      gin::StringToV8(context->GetIsolate(), name);
+      gin::StringToV8(v8::Isolate::GetCurrent(), name);
 
   return object->CreateDataProperty(context, name_str, value);
 }

--- a/components/playlist/renderer/playlist_render_frame_observer.cc
+++ b/components/playlist/renderer/playlist_render_frame_observer.cc
@@ -140,8 +140,8 @@ void PlaylistRenderFrameObserver::Inject(
       context, v8::MicrotasksScope::kDoNotRunMicrotasks);
 
   v8::Local<v8::Script> script =
-      v8::Script::Compile(context,
-                          gin::StringToV8(context->GetIsolate(), script_text))
+      v8::Script::Compile(
+          context, gin::StringToV8(v8::Isolate::GetCurrent(), script_text))
           .ToLocalChecked();
   v8::Local<v8::Function> function =
       v8::Local<v8::Function>::Cast(script->Run(context).ToLocalChecked());

--- a/components/safe_builtins/renderer/safe_builtins.cc
+++ b/components/safe_builtins/renderer/safe_builtins.cc
@@ -128,14 +128,14 @@ void SaveImpl(const char* name,
               v8::Local<v8::Context> context) {
   CHECK(!value.IsEmpty() && value->IsObject()) << std::string(name);
   context->Global()
-      ->SetPrivate(context, MakeKey(name, context->GetIsolate()), value)
+      ->SetPrivate(context, MakeKey(name, v8::Isolate::GetCurrent()), value)
       .FromJust();
 }
 
 v8::Local<v8::Object> Load(const char* name, v8::Local<v8::Context> context) {
   v8::Local<v8::Value> value =
       context->Global()
-          ->GetPrivate(context, MakeKey(name, context->GetIsolate()))
+          ->GetPrivate(context, MakeKey(name, v8::Isolate::GetCurrent()))
           .ToLocalChecked();
   CHECK(value->IsObject()) << std::string(name);
   return v8::Local<v8::Object>::Cast(value);
@@ -169,8 +169,9 @@ class ExtensionImpl : public v8::Extension {
           info[2]->IsObject() &&    // args
           info[3]->IsInt32() &&     // first_arg_index
           info[4]->IsInt32());      // args_length
-    v8::Local<v8::Context> context = info.GetIsolate()->GetCurrentContext();
-    v8::MicrotasksScope microtasks(info.GetIsolate(),
+    v8::Local<v8::Context> context =
+        v8::Isolate::GetCurrent()->GetCurrentContext();
+    v8::MicrotasksScope microtasks(v8::Isolate::GetCurrent(),
                                    context->GetMicrotaskQueue(),
                                    v8::MicrotasksScope::kDoNotRunMicrotasks);
     v8::Local<v8::Function> function = info[0].As<v8::Function>();
@@ -178,13 +179,13 @@ class ExtensionImpl : public v8::Extension {
     if (info[1]->IsObject()) {
       recv = v8::Local<v8::Object>::Cast(info[1]);
     } else if (info[1]->IsString()) {
-      recv = v8::StringObject::New(info.GetIsolate(),
+      recv = v8::StringObject::New(v8::Isolate::GetCurrent(),
                                    v8::Local<v8::String>::Cast(info[1]))
                  .As<v8::Object>();
     } else {
-      info.GetIsolate()->ThrowException(
+      v8::Isolate::GetCurrent()->ThrowException(
           v8::Exception::TypeError(ToV8StringUnsafe(
-              info.GetIsolate(),
+              v8::Isolate::GetCurrent(),
               "The first argument is the receiver and must be an object")));
       return;
     }
@@ -212,8 +213,8 @@ class ExtensionImpl : public v8::Extension {
 
   static void Save(const v8::FunctionCallbackInfo<v8::Value>& info) {
     CHECK(info.Length() == 2 && info[0]->IsString() && info[1]->IsObject());
-    SaveImpl(*v8::String::Utf8Value(info.GetIsolate(), info[0]), info[1],
-             info.GetIsolate()->GetCurrentContext());
+    SaveImpl(*v8::String::Utf8Value(v8::Isolate::GetCurrent(), info[0]),
+             info[1], v8::Isolate::GetCurrent()->GetCurrentContext());
   }
 };
 
@@ -225,8 +226,8 @@ std::unique_ptr<v8::Extension> SafeBuiltins::CreateV8Extension() {
 }
 
 SafeBuiltins::SafeBuiltins(const v8::Local<v8::Context>& context)
-    : context_(context->GetIsolate(), context),
-      isolate_(context->GetIsolate()) {}
+    : context_(v8::Isolate::GetCurrent(), context),
+      isolate_(v8::Isolate::GetCurrent()) {}
 
 SafeBuiltins::~SafeBuiltins() = default;
 

--- a/components/safe_builtins/renderer/safe_builtins_helpers.cc
+++ b/components/safe_builtins/renderer/safe_builtins_helpers.cc
@@ -31,13 +31,13 @@ std::string CreateExceptionString(v8::Local<v8::Context> context,
   std::string resource_name = "<unknown resource>";
   if (!message->GetScriptOrigin().ResourceName().IsEmpty()) {
     v8::String::Utf8Value resource_name_v8(
-        context->GetIsolate(), message->GetScriptOrigin().ResourceName());
+        v8::Isolate::GetCurrent(), message->GetScriptOrigin().ResourceName());
     resource_name.assign(*resource_name_v8, resource_name_v8.length());
   }
 
   std::string error_message = "<no error message>";
   if (!message->Get().IsEmpty()) {
-    v8::String::Utf8Value error_message_v8(context->GetIsolate(),
+    v8::String::Utf8Value error_message_v8(v8::Isolate::GetCurrent(),
                                            message->Get());
     error_message.assign(*error_message_v8, error_message_v8.length());
   }
@@ -64,13 +64,13 @@ v8::Local<v8::String> WrapSource(v8::Isolate* isolate,
 
 v8::Local<v8::Value> RunScript(v8::Local<v8::Context> context,
                                v8::Local<v8::String> code) {
-  v8::EscapableHandleScope handle_scope(context->GetIsolate());
+  v8::EscapableHandleScope handle_scope(v8::Isolate::GetCurrent());
   v8::Context::Scope context_scope(context);
 
-  v8::MicrotasksScope microtasks(context->GetIsolate(),
+  v8::MicrotasksScope microtasks(v8::Isolate::GetCurrent(),
                                  context->GetMicrotaskQueue(),
                                  v8::MicrotasksScope::kDoNotRunMicrotasks);
-  v8::TryCatch try_catch(context->GetIsolate());
+  v8::TryCatch try_catch(v8::Isolate::GetCurrent());
   try_catch.SetCaptureMessage(true);
   v8::ScriptCompiler::Source script_source(code);
   v8::Local<v8::Script> script;
@@ -83,7 +83,7 @@ v8::Local<v8::Value> RunScript(v8::Local<v8::Context> context,
                      blink::mojom::ConsoleMessageLevel::kError,
                      blink::WebString::FromUTF8(
                          CreateExceptionString(context, try_catch))));
-    return v8::Undefined(context->GetIsolate());
+    return v8::Undefined(v8::Isolate::GetCurrent());
   }
 
   v8::Local<v8::Value> result;
@@ -93,7 +93,7 @@ v8::Local<v8::Value> RunScript(v8::Local<v8::Context> context,
                      blink::mojom::ConsoleMessageLevel::kError,
                      blink::WebString::FromUTF8(
                          CreateExceptionString(context, try_catch))));
-    return v8::Undefined(context->GetIsolate());
+    return v8::Undefined(v8::Isolate::GetCurrent());
   }
 
   return handle_scope.Escape(result);
@@ -105,9 +105,9 @@ v8::MaybeLocal<v8::Value> SafeCallFunction(
     const v8::Local<v8::Function>& function,
     int argc,
     v8::Local<v8::Value> argv[]) {
-  v8::EscapableHandleScope handle_scope(context->GetIsolate());
+  v8::EscapableHandleScope handle_scope(v8::Isolate::GetCurrent());
   v8::Context::Scope scope(context);
-  v8::MicrotasksScope microtasks(context->GetIsolate(),
+  v8::MicrotasksScope microtasks(v8::Isolate::GetCurrent(),
                                  context->GetMicrotaskQueue(),
                                  v8::MicrotasksScope::kDoNotRunMicrotasks);
   v8::Local<v8::Object> global = context->Global();
@@ -124,8 +124,9 @@ v8::MaybeLocal<v8::Value> LoadScriptWithSafeBuiltins(
     blink::WebLocalFrame* web_frame,
     const std::string& script) {
   v8::Local<v8::Context> context = web_frame->MainWorldScriptContext();
-  v8::Local<v8::String> wrapped_source(WrapSource(
-      context->GetIsolate(), gin::StringToV8(context->GetIsolate(), script)));
+  v8::Local<v8::String> wrapped_source(
+      WrapSource(v8::Isolate::GetCurrent(),
+                 gin::StringToV8(v8::Isolate::GetCurrent(), script)));
   // Wrapping script in function(...) {...}
   v8::Local<v8::Value> func_as_value = RunScript(context, wrapped_source);
   if (func_as_value.IsEmpty() || func_as_value->IsUndefined()) {

--- a/third_party/blink/renderer/core/brave_page_graph/blink_converters.cc
+++ b/third_party/blink/renderer/core/brave_page_graph/blink_converters.cc
@@ -51,12 +51,12 @@ base::Value ToPageGraphValue(ScriptState* script_state,
   if (arg.IsEmpty()) {
     return base::Value();
   }
-  v8::String::Utf8Value utf8_string(script_state->GetIsolate(), arg);
+  v8::String::Utf8Value utf8_string(v8::Isolate::GetCurrent(), arg);
   std::string_view result(*utf8_string, utf8_string.length());
   // If the value is converted to string as [object something], we need to
   // serialize it using the inspector protocol.
   if (result.starts_with("[object ")) {
-    return V8ValueToPageGraphValue(script_state->GetIsolate(), arg);
+    return V8ValueToPageGraphValue(v8::Isolate::GetCurrent(), arg);
   }
   return base::Value(result);
 }
@@ -64,7 +64,7 @@ base::Value ToPageGraphValue(ScriptState* script_state,
 template <>
 base::Value ToPageGraphValue(ScriptState* script_state,
                              const v8::Local<v8::Object>& arg) {
-  return V8ValueToPageGraphValue(script_state->GetIsolate(), arg);
+  return V8ValueToPageGraphValue(v8::Isolate::GetCurrent(), arg);
 }
 
 template <>

--- a/third_party/blink/renderer/core/brave_page_graph/blink_converters.h
+++ b/third_party/blink/renderer/core/brave_page_graph/blink_converters.h
@@ -197,7 +197,7 @@ base::Value ToPageGraphValue(ScriptState* script_state,
                              const ScriptPromise<T>& script_promise) {
   return ToPageGraphValue(
       script_state,
-      ScriptValue(script_state->GetIsolate(), script_promise.V8Promise()));
+      ScriptValue(v8::Isolate::GetCurrent(), script_promise.V8Promise()));
 }
 
 // Convert v8::Value.


### PR DESCRIPTION
Those methods just return the value from TLS and do not read from the
object any more. Hence they should be replaced by
`v8::Isolate::GetCurrent()`.

Resolves https://github.com/brave/brave-browser/issues/48040
