### PR TITLE
[rust] Cherry-pick and `gnrt` run for proc-macro fix

### DIFF
--- a/patches/tools-crates-gnrt-lib-condition.rs.patch
+++ b/patches/tools-crates-gnrt-lib-condition.rs.patch
@@ -1,0 +1,13 @@
+diff --git a/tools/crates/gnrt/lib/condition.rs b/tools/crates/gnrt/lib/condition.rs
+index 512c46f7613002e7ea0d49142c65f94d3b141f48..60641c0b7dfee3c457551a117e20d8d68ae83872 100644
+--- a/tools/crates/gnrt/lib/condition.rs
++++ b/tools/crates/gnrt/lib/condition.rs
+@@ -30,7 +30,7 @@ impl Condition {
+         Condition(Ok(HashSet::new()))
+     }
+ 
+-    fn is_always_true(&self) -> bool {
++    pub fn is_always_true(&self) -> bool {
+         self.0.as_ref().is_ok_and(|triple_set| *triple_set == *RustTargetTriple::all())
+     }
+ 

--- a/patches/tools-crates-gnrt-lib-deps.rs.patch
+++ b/patches/tools-crates-gnrt-lib-deps.rs.patch
@@ -1,0 +1,92 @@
+diff --git a/tools/crates/gnrt/lib/deps.rs b/tools/crates/gnrt/lib/deps.rs
+index 7f9072258419784eb034cf152515595bec30e9ca..8c6f8b6fdd6d4cdb9310e5e55ea726bf918f38e8 100644
+--- a/tools/crates/gnrt/lib/deps.rs
++++ b/tools/crates/gnrt/lib/deps.rs
+@@ -376,12 +376,12 @@ impl MemoizationTables {
+         Self { package_conditions: HashMap::new() }
+     }
+ 
+-    fn get_package_condition(&mut self, package: &PackageMetadata) -> Condition {
+-        if let Some(condition) = self.package_conditions.get(&package.into()) {
+-            return condition.clone();
++    fn get_package_condition_unmemoized(&mut self, package: &PackageMetadata) -> Condition {
++        if package.is_proc_macro() {
++            return Condition::always_true();
+         }
+ 
+-        let condition = package
++        package
+             .reverse_direct_links()
+             .flat_map(|link| {
+                 [
+@@ -390,7 +390,15 @@ impl MemoizationTables {
+                 ]
+             })
+             .reduce(Condition::or)
+-            .unwrap_or_else(Condition::always_true);
++            .unwrap_or_else(Condition::always_true)
++    }
++
++    fn get_package_condition(&mut self, package: &PackageMetadata) -> Condition {
++        if let Some(condition) = self.package_conditions.get(&package.into()) {
++            return condition.clone();
++        }
++
++        let condition = self.get_package_condition_unmemoized(package);
+         self.package_conditions.insert(package.into(), condition.clone());
+         condition
+     }
+@@ -456,7 +464,11 @@ fn get_reverse_dependency_kinds(
+     };
+     let mut result = HashMap::new();
+     let mut insert_if_present = |link: PackageLink, kind: DependencyKind| {
+-        let condition = condition_getter(&link, kind);
++        let condition = if kind == DependencyKind::Normal && link.to().is_proc_macro() {
++            Condition::always_true()
++        } else {
++            condition_getter(&link, kind)
++        };
+         if !condition.is_always_false() {
+             let features = match kind {
+                 // ... => `build.rs` deps only care about host-side features.
+@@ -1129,4 +1141,40 @@ mod tests {
+     // `gnrt/sample_package3` directory.  See the `Cargo.toml` for more
+     // information.
+     static SAMPLE_CARGO_METADATA3: &str = include_str!("test_metadata3.json");
++
++    #[test]
++    fn collect_dependencies_on_sample_output4() {
++        let config = BuildConfig::default();
++        let metadata = PackageGraph::from_json(SAMPLE_CARGO_METADATA4).unwrap();
++        let dependencies = collect_dependencies(&metadata, "sample_package4", &config).unwrap();
++        let dependencies = dependencies
++            .into_iter()
++            .map(|package| (package.package_name.to_string(), package))
++            .collect::<HashMap<_, _>>();
++
++        // When compiling for arm64 **target**, there is a foo => prost-derive
++        // dependency.
++        let foo = &dependencies["foo"];
++        assert_eq!(foo.dependencies.len(), 1);
++        assert_eq!(foo.dependencies[0].package_name, "prost-derive");
++        assert_eq!(
++            foo.dependencies[0].condition.to_handlebars_value().unwrap(),
++            Some("current_cpu == \"arm64\"".to_string()),
++        );
++
++        // We can cross-compile for arm64 **target** when building on x86 **host**.
++        // Therefore the arm64 condition should *not* propagate 1) into when
++        // `prost` is enabled via its reverse dependencies, nor 2) into transitive
++        // dependnecies of `prost`.
++        let prost = &dependencies["prost-derive"];
++        assert_eq!(prost.dependencies.len(), 5);
++        assert_eq!(prost.dependencies[0].package_name, "anyhow");
++        assert!(prost.dependencies[0].condition.is_always_true());
++        assert!(prost.dependency_kinds[&DependencyKind::Normal].condition.is_always_true());
++    }
++
++    // `test_metadata4.json` contains the output of `cargo metadata` run in
++    // `gnrt/sample_package4` directory.  See the `Cargo.toml` for more
++    // information.
++    static SAMPLE_CARGO_METADATA4: &str = include_str!("test_metadata4.json");
+ }

--- a/third_party/rust/chromium_crates_io/gnrt_config.toml
+++ b/third_party/rust/chromium_crates_io/gnrt_config.toml
@@ -185,16 +185,6 @@ extra_input_roots = [ "../docs", "../README.md" ]
 
 [crate.curve25519-dalek-derive]
 extra_input_roots = [ "../README.md" ]
-extra_kv = { raw_gn = '''
-enabled = true
-if (current_cpu != "x64") {
-  deps = [
-    "//brave/third_party/rust/proc_macro2/v1:lib",
-    "//brave/third_party/rust/quote/v1:lib",
-    "//brave/third_party/rust/syn/v2:lib",
-  ]
-}
-''' }
 
 [crate.dtoa-short]
 license_files = ['LICENSE']

--- a/third_party/rust/curve25519_dalek_derive/v0_1/BUILD.gn
+++ b/third_party/rust/curve25519_dalek_derive/v0_1/BUILD.gn
@@ -11,7 +11,6 @@ import("//build/rust/cargo_crate.gni")
 cargo_crate("lib") {
   crate_name = "curve25519_dalek_derive"
   epoch = "0.1"
-  enabled = current_cpu == "x64"
   crate_type = "proc-macro"
   crate_root = "//brave/third_party/rust/chromium_crates_io/vendor/curve25519-dalek-derive-v0_1/src/lib.rs"
   sources = [ "//brave/third_party/rust/chromium_crates_io/vendor/curve25519-dalek-derive-v0_1/src/lib.rs" ]
@@ -23,24 +22,13 @@ cargo_crate("lib") {
   cargo_pkg_description = "curve25519-dalek Derives"
   cargo_pkg_version = "0.1.1"
 
-  deps = []
-  if (current_cpu == "x64") {
-    deps += [
-      "//brave/third_party/rust/proc_macro2/v1:lib",
-      "//brave/third_party/rust/quote/v1:lib",
-      "//brave/third_party/rust/syn/v2:lib",
-    ]
-  }
+  deps = [
+    "//brave/third_party/rust/proc_macro2/v1:lib",
+    "//brave/third_party/rust/quote/v1:lib",
+    "//brave/third_party/rust/syn/v2:lib",
+  ]
   rustenv = []
   rustflags = []
-  enabled = true
-  if (current_cpu != "x64") {
-    deps = [
-      "//brave/third_party/rust/proc_macro2/v1:lib",
-      "//brave/third_party/rust/quote/v1:lib",
-      "//brave/third_party/rust/syn/v2:lib",
-    ]
-  }
 
   #####################################################################
   # Tweaking which GN `config`s apply to this target.


### PR DESCRIPTION
This is a cherry-pick and `gnrt` rerun for the proc-macro fix relating
to the recent breakage of Mac x64 cross compile.

This PR also reverts the previous interim fix:
https://github.com/brave/brave-core/pull/30316