### PR TITLE
Temporarily disable `brave:all builds

### DIFF
--- a/build/.ci_features
+++ b/build/.ci_features
@@ -8,4 +8,4 @@ ios_output_xml
 
 # TODO(https://github.com/brave/brave-browser/issues/48001): Remove this CI
 # feature when `1.82.x` is retired.
-brave_all_build
+# brave_all_build


### PR DESCRIPTION
It looks like the iOS build is having linking error for
`components_unittests`.

https://ci.brave.com/blue/organizations/jenkins/brave-core-build-pr-ios/detail/PR-30370/3/pipeline/

This PR disables this mode for now.
