### PR TITLE
Remove explicit lint filters passed in when running cpplint in presubmit (uplift to 1.81.x)

### DIFF
--- a/PRESUBMIT.py
+++ b/PRESUBMIT.py
@@ -102,9 +102,7 @@ def CheckWebDevStyle(input_api, output_api):
 
 
 def CheckChangeLintsClean(input_api, output_api):
-    return input_api.canned_checks.CheckChangeLintsClean(input_api,
-                                                         output_api,
-                                                         lint_filters=[])
+    return input_api.canned_checks.CheckChangeLintsClean(input_api, output_api)
 
 
 def CheckPylint(input_api, output_api):


### PR DESCRIPTION
Uplift of #30372
Resolves https://github.com/brave/brave-browser/issues/48049

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.