### PR TITLE
[CodeHealth] Remove uses of `base::StringPrintf` pt.4

### DIFF
--- a/chromium_src/chrome/installer/setup/brave_behaviors.cc
+++ b/chromium_src/chrome/installer/setup/brave_behaviors.cc
@@ -44,8 +44,8 @@ void DoPostUninstallOperations(const base::Version& version,
   const base::win::OSInfo* os_info = base::win::OSInfo::GetInstance();
   base::win::OSInfo::VersionNumber version_number = os_info->version_number();
   const std::wstring os_version = base::ASCIIToWide(
-      base::StringPrintf("%d.%d.%d", version_number.major, version_number.minor,
-                         version_number.build));
+      absl::StrFormat("%d.%d.%d", version_number.major, version_number.minor,
+                      version_number.build));
 
   const std::wstring survey_url = std::wstring(kBraveUninstallSurveyUrl);
 #if DCHECK_IS_ON()

--- a/chromium_src/components/translate/core/browser/translate_script.cc
+++ b/chromium_src/components/translate/core/browser/translate_script.cc
@@ -8,6 +8,7 @@
 #include "base/functional/callback.h"
 #include "base/strings/strcat.h"
 #include "base/strings/stringprintf.h"
+#include "base/strings/to_string.h"
 #include "base/task/sequenced_task_runner.h"
 #include "brave/components/constants/brave_services_key.h"
 #include "brave/components/translate/core/common/brave_translate_constants.h"
@@ -53,11 +54,10 @@ void TranslateScript::Request(RequestCallback callback, bool is_incognito) {
 void TranslateScript::OnScriptFetchComplete(bool success,
                                             const std::string& data) {
   const std::string new_data = base::StrCat(
-      {base::StringPrintf(
-           "const useGoogleTranslateEndpoint = %s;",
-           translate::UseGoogleTranslateEndpoint() ? "true" : "false"),
-       base::StringPrintf("const braveTranslateStaticPath = '%s';",
-                          kBraveTranslateStaticPath),
+      {absl::StrFormat("const useGoogleTranslateEndpoint = %s;",
+                       base::ToString(translate::UseGoogleTranslateEndpoint())),
+       absl::StrFormat("const braveTranslateStaticPath = '%s';",
+                       kBraveTranslateStaticPath),
        ui::ResourceBundle::GetSharedInstance().LoadDataResourceString(
            IDR_BRAVE_TRANSLATE_JS),
        data});

--- a/components/brave_shields/content/test/ad_block_custom_filter_reset_util_unittest.cc
+++ b/components/brave_shields/content/test/ad_block_custom_filter_reset_util_unittest.cc
@@ -43,7 +43,7 @@ void CheckCase(const std::string& host_pos0,
                const std::string& host_pos1,
                const std::string& reset_for_host) {
   const auto custom_filters_current_host =
-      base::StringPrintf(kTestCustomFiltersList, host_pos0, host_pos1);
+      absl::StrFormat(kTestCustomFiltersList, host_pos0, host_pos1);
   const auto resetted_cf_list =
       ResetCustomFiltersForHost(reset_for_host, custom_filters_current_host);
 

--- a/components/brave_stats/browser/brave_stats_updater_util.cc
+++ b/components/brave_stats/browser/brave_stats_updater_util.cc
@@ -25,8 +25,8 @@ namespace brave_stats {
 std::string GetDateAsYMD(const base::Time& time) {
   base::Time::Exploded exploded;
   time.LocalExplode(&exploded);
-  return base::StringPrintf("%d-%02d-%02d", exploded.year, exploded.month,
-                            exploded.day_of_month);
+  return absl::StrFormat("%d-%02d-%02d", exploded.year, exploded.month,
+                         exploded.day_of_month);
 }
 
 std::string GetPlatformIdentifier() {

--- a/components/brave_vpn/browser/brave_vpn_service.cc
+++ b/components/brave_vpn/browser/brave_vpn_service.cc
@@ -409,12 +409,12 @@ void BraveVpnService::UpdatePurchasedStateForSessionExpired(
     std::string expiry_message;
     base::TimeDelta delta = (last_credential_expiry - base::Time::Now());
     if (delta.InHours() == 0) {
-      expiry_message = base::StringPrintf(
+      expiry_message = absl::StrFormat(
           "Out of credentials; check again in %d minutes.", delta.InMinutes());
     } else {
       int delta_hours = delta.InHours();
       base::TimeDelta delta_minutes = (delta - base::Hours(delta_hours));
-      expiry_message = base::StringPrintf(
+      expiry_message = absl::StrFormat(
           "Out of credentials; check again in %d hours %d minutes.",
           delta_hours, delta_minutes.InMinutes());
     }

--- a/components/brave_wallet/browser/asset_ratio_response_parser.cc
+++ b/components/brave_wallet/browser/asset_ratio_response_parser.cc
@@ -96,7 +96,7 @@ bool ParseAssetPrice(const base::Value& json_value,
       }
       asset_price->price = base::NumberToString(*to_price);
       std::string to_asset_timeframe_key =
-          base::StringPrintf("%s_timeframe_change", to_asset.c_str());
+          absl::StrFormat("%s_timeframe_change", to_asset);
       std::optional<double> to_timeframe_change =
           from_asset_dict->FindDoubleByDottedPath(to_asset_timeframe_key);
       if (!to_timeframe_change) {

--- a/components/brave_wallet/browser/asset_ratio_service.cc
+++ b/components/brave_wallet/browser/asset_ratio_service.cc
@@ -205,11 +205,11 @@ GURL AssetRatioService::GetPriceURL(const std::vector<std::string>& from_assets,
                                     mojom::AssetPriceTimeframe timeframe) {
   std::string from = VectorToCommaSeparatedList(from_assets);
   std::string to = VectorToCommaSeparatedList(to_assets);
-  std::string spec = base::StringPrintf(
-      "%s/v2/relative/provider/coingecko/%s/%s/%s",
-      base_url_for_test_.is_empty() ? GetAssetRatioBaseURL().c_str()
-                                    : base_url_for_test_.spec().c_str(),
-      from.c_str(), to.c_str(), TimeFrameKeyToString(timeframe).c_str());
+  std::string spec =
+      absl::StrFormat("%s/v2/relative/provider/coingecko/%s/%s/%s",
+                      base_url_for_test_.is_empty() ? GetAssetRatioBaseURL()
+                                                    : base_url_for_test_.spec(),
+                      from, to, TimeFrameKeyToString(timeframe));
   return GURL(spec);
 }
 
@@ -218,11 +218,11 @@ GURL AssetRatioService::GetPriceHistoryURL(
     const std::string& asset,
     const std::string& vs_asset,
     mojom::AssetPriceTimeframe timeframe) {
-  std::string spec = base::StringPrintf(
-      "%s/v2/history/coingecko/%s/%s/%s",
-      base_url_for_test_.is_empty() ? GetAssetRatioBaseURL().c_str()
-                                    : base_url_for_test_.spec().c_str(),
-      asset.c_str(), vs_asset.c_str(), TimeFrameKeyToString(timeframe).c_str());
+  std::string spec =
+      absl::StrFormat("%s/v2/history/coingecko/%s/%s/%s",
+                      base_url_for_test_.is_empty() ? GetAssetRatioBaseURL()
+                                                    : base_url_for_test_.spec(),
+                      asset, vs_asset, TimeFrameKeyToString(timeframe));
   return GURL(spec);
 }
 
@@ -260,12 +260,11 @@ void AssetRatioService::GetBuyUrlV1(mojom::OnRampProvider provider,
     std::string payload;
     base::JSONWriter::Write(payload_value, &payload);
     base::flat_map<std::string, std::string> request_headers;
-    std::string credentials = base::StringPrintf(
-        "%s:%s", sardine_client_id.c_str(),  // username:password
-        sardine_client_secret.c_str());
+    std::string credentials =
+        absl::StrFormat("%s:%s", sardine_client_id,  // username:password
+                        sardine_client_secret);
     std::string base64_credentials = base::Base64Encode(credentials);
-    std::string header =
-        base::StringPrintf("Basic %s", base64_credentials.c_str());
+    std::string header = absl::StrFormat("Basic %s", base64_credentials);
     request_headers["Authorization"] = std::move(header);
     api_request_helper_->Request("POST", sardine_token_url, payload,
                                  "application/json",
@@ -435,10 +434,10 @@ void AssetRatioService::GetStripeBuyURL(
 
   const std::string json_payload = GetJSON(payload);
 
-  GURL url = GURL(base::StringPrintf("%s/v2/stripe/onramp_sessions",
-                                     base_url_for_test_.is_empty()
-                                         ? GetAssetRatioBaseURL().c_str()
-                                         : base_url_for_test_.spec().c_str()));
+  GURL url = GURL(absl::StrFormat("%s/v2/stripe/onramp_sessions",
+                                  base_url_for_test_.is_empty()
+                                      ? GetAssetRatioBaseURL()
+                                      : base_url_for_test_.spec()));
 
   auto internal_callback =
       base::BindOnce(&AssetRatioService::OnGetStripeBuyURL,
@@ -517,10 +516,10 @@ void AssetRatioService::OnGetPriceHistory(GetPriceHistoryCallback callback,
 // static
 GURL AssetRatioService::GetCoinMarketsURL(const std::string& vs_asset,
                                           const uint8_t limit) {
-  GURL url = GURL(base::StringPrintf("%s/v2/market/provider/coingecko",
-                                     base_url_for_test_.is_empty()
-                                         ? GetAssetRatioBaseURL().c_str()
-                                         : base_url_for_test_.spec().c_str()));
+  GURL url = GURL(absl::StrFormat("%s/v2/market/provider/coingecko",
+                                  base_url_for_test_.is_empty()
+                                      ? GetAssetRatioBaseURL()
+                                      : base_url_for_test_.spec()));
   url = net::AppendQueryParameter(url, "vsCurrency", vs_asset);
   url = net::AppendQueryParameter(url, "limit", base::NumberToString(limit));
   return url;

--- a/components/brave_wallet/browser/bitcoin/bitcoin_wallet_service.cc
+++ b/components/brave_wallet/browser/bitcoin/bitcoin_wallet_service.cc
@@ -70,11 +70,11 @@ std::string MakeHwPath(const mojom::AccountIdPtr& account,
                        const mojom::BitcoinKeyIdPtr& key_id) {
   CHECK(IsBitcoinHardwareKeyring(account->keyring_id));
   if (account->keyring_id == mojom::KeyringId::kBitcoinHardware) {
-    return base::StringPrintf("84'/0'/%d'/%d/%d", account->account_index,
-                              key_id->change, key_id->index);
+    return absl::StrFormat("84'/0'/%d'/%d/%d", account->account_index,
+                           key_id->change, key_id->index);
   } else if (account->keyring_id == mojom::KeyringId::kBitcoinHardwareTestnet) {
-    return base::StringPrintf("84'/1'/%d'/%d/%d", account->account_index,
-                              key_id->change, key_id->index);
+    return absl::StrFormat("84'/1'/%d'/%d/%d", account->account_index,
+                           key_id->change, key_id->index);
   }
   NOTREACHED();
 }

--- a/components/brave_wallet/browser/blockchain_list_parser.cc
+++ b/components/brave_wallet/browser/blockchain_list_parser.cc
@@ -524,7 +524,7 @@ bool ParseChainList(const std::string& json, ChainList* result) {
     if (!chain_id) {
       continue;
     }
-    network->chain_id = base::StringPrintf("0x%x", chain_id);
+    network->chain_id = absl::StrFormat("0x%x", chain_id);
 
     network->chain_name = EmptyIfNull(chain_item->FindString("name"));
     if (network->chain_name.empty()) {

--- a/components/brave_wallet/browser/filecoin_keyring.cc
+++ b/components/brave_wallet/browser/filecoin_keyring.cc
@@ -55,7 +55,7 @@ std::optional<std::string> GetExportEncodedJSON(
   if (!protocol) {
     return std::nullopt;
   }
-  std::string json = base::StringPrintf(
+  std::string json = absl::StrFormat(
       "{\"Type\":\"%s\",\"PrivateKey\":\"%s\"}",
       protocol.value() == mojom::FilecoinAddressProtocol::BLS ? "bls"
                                                               : "secp256k1",

--- a/components/brave_wallet/browser/json_rpc_service_test_utils.cc
+++ b/components/brave_wallet/browser/json_rpc_service_test_utils.cc
@@ -23,8 +23,8 @@ std::string MakeJsonRpcStringArrayResponse(
   std::string encoded_array;
   EXPECT_TRUE(EncodeStringArray(items, &encoded_array));
   encoded_array = encoded_array.substr(2);
-  return base::StringPrintf(R"({"jsonrpc":"2.0", "id":1, "result":"%s"})",
-                            (encoded_head + encoded_array).c_str());
+  return absl::StrFormat(R"({"jsonrpc":"2.0", "id":1, "result":"%s"})",
+                         (encoded_head + encoded_array));
 }
 
 std::string MakeJsonRpcStringResponse(const std::string& str) {
@@ -33,36 +33,36 @@ std::string MakeJsonRpcStringResponse(const std::string& str) {
   std::string encoded_string;
   EXPECT_TRUE(EncodeString(str, &encoded_string));
   encoded_string = encoded_string.substr(2);
-  return base::StringPrintf(R"({"jsonrpc":"2.0", "id":1, "result":"%s"})",
-                            (encoded_head + encoded_string).c_str());
+  return absl::StrFormat(R"({"jsonrpc":"2.0", "id":1, "result":"%s"})",
+                         (encoded_head + encoded_string));
 }
 
 std::string MakeJsonRpcTupleResponse(const eth_abi::TupleEncoder& tuple) {
-  return base::StringPrintf(R"({"jsonrpc":"2.0", "id":1, "result":"%s"})",
-                            ToHex(tuple.Encode()).c_str());
+  return absl::StrFormat(R"({"jsonrpc":"2.0", "id":1, "result":"%s"})",
+                         ToHex(tuple.Encode()));
 }
 
 std::string MakeJsonRpcRawBytesResponse(const std::vector<uint8_t>& bytes) {
-  return base::StringPrintf(R"({"jsonrpc":"2.0", "id":1, "result":"%s"})",
-                            ToHex(bytes).c_str());
+  return absl::StrFormat(R"({"jsonrpc":"2.0", "id":1, "result":"%s"})",
+                         ToHex(bytes));
 }
 
 std::string MakeJsonRpcErrorResponse(int error,
                                      const std::string& error_message) {
-  return base::StringPrintf(R"({"jsonrpc":"2.0", "id":1,)"
-                            R"("error": {"code":%d, "message": "%s"})"
-                            R"(})",
-                            error, error_message.c_str());
+  return absl::StrFormat(R"({"jsonrpc":"2.0", "id":1,)"
+                         R"("error": {"code":%d, "message": "%s"})"
+                         R"(})",
+                         error, error_message);
 }
 
 std::string MakeJsonRpcErrorResponseWithData(int error,
                                              const std::string& error_message,
                                              const std::string& data) {
-  return base::StringPrintf(
+  return absl::StrFormat(
       R"({"jsonrpc":"2.0", "id":1, )"
       R"("error": {"code":%d, "message": "%s", "data": "%s"})"
       R"(})",
-      error, error_message.c_str(), data.c_str());
+      error, error_message, data);
 }
 
 std::string MakeJsonRpcValueResponse(const base::Value& value) {

--- a/components/brave_wallet/browser/permission_utils.cc
+++ b/components/brave_wallet/browser/permission_utils.cc
@@ -207,15 +207,15 @@ GURL GetConnectWithSiteWebUIURL(const GURL& webui_base_url,
 
   std::vector<std::string> query_parts;
   for (const auto& account : accounts) {
-    query_parts.push_back(base::StringPrintf("addr=%s", account.c_str()));
+    query_parts.push_back(absl::StrFormat("addr=%s", account));
   }
 
   mojom::OriginInfoPtr origin_info = MakeOriginInfo(origin);
 
   query_parts.push_back(
-      base::StringPrintf("origin-spec=%s", origin_info->origin_spec.c_str()));
-  query_parts.push_back(base::StringPrintf(
-      "etld-plus-one=%s", origin_info->e_tld_plus_one.c_str()));
+      absl::StrFormat("origin-spec=%s", origin_info->origin_spec));
+  query_parts.push_back(
+      absl::StrFormat("etld-plus-one=%s", origin_info->e_tld_plus_one));
 
   std::string query_str = base::JoinString(query_parts, "&");
   GURL::Replacements replacements;

--- a/components/brave_wallet/browser/simulation_response_parser_unittest.cc
+++ b/components/brave_wallet/browser/simulation_response_parser_unittest.cc
@@ -970,7 +970,7 @@ TEST(SimulationResponseParserUnitTest, ParseEvmErc1155ApprovalForAll) {
     }
   )";
 
-  auto json_with_token_name = base::StringPrintf(kJson, "\"Sandbox ASSET\"");
+  auto json_with_token_name = absl::StrFormat(kJson, "\"Sandbox ASSET\"");
 
   auto simulation_response = evm::ParseSimulationResponse(
       ParseJson(json_with_token_name),
@@ -1021,22 +1021,22 @@ TEST(SimulationResponseParserUnitTest, ParseEvmErc1155ApprovalForAll) {
   EXPECT_EQ(state_change_raw_info->asset->price->dollar_value_per_token,
             "232.43");
 
-  json_with_token_name = base::StringPrintf(kJson, "null");
+  json_with_token_name = absl::StrFormat(kJson, "null");
   EXPECT_TRUE(evm::ParseSimulationResponse(
       ParseJson(json_with_token_name),
       "0xd8da6bf26964af9d7eed9e03e53415d37aa96045"));
 
-  json_with_token_name = base::StringPrintf(kJson, "[]");
+  json_with_token_name = absl::StrFormat(kJson, "[]");
   EXPECT_FALSE(evm::ParseSimulationResponse(
       ParseJson(json_with_token_name),
       "0xd8da6bf26964af9d7eed9e03e53415d37aa96045"));
 
-  json_with_token_name = base::StringPrintf(kJson, "{}");
+  json_with_token_name = absl::StrFormat(kJson, "{}");
   EXPECT_FALSE(evm::ParseSimulationResponse(
       ParseJson(json_with_token_name),
       "0xd8da6bf26964af9d7eed9e03e53415d37aa96045"));
 
-  json_with_token_name = base::StringPrintf(kJson, "false");
+  json_with_token_name = absl::StrFormat(kJson, "false");
   EXPECT_FALSE(evm::ParseSimulationResponse(
       ParseJson(json_with_token_name),
       "0xd8da6bf26964af9d7eed9e03e53415d37aa96045"));
@@ -1245,7 +1245,7 @@ TEST(SimulationResponseParserUnitTest, ParseEvmNullableFields) {
   )";
 
   {
-    auto json = base::StringPrintf(kJson, "null", "null", "null", "null");
+    auto json = absl::StrFormat(kJson, "null", "null", "null", "null");
     auto simulation_response = evm::ParseSimulationResponse(
         ParseJson(json), "0xd8da6bf26964af9d7eed9e03e53415d37aa96045");
 
@@ -1290,7 +1290,7 @@ TEST(SimulationResponseParserUnitTest, ParseEvmNullableFields) {
   }
 
   {
-    auto json = base::StringPrintf(kJson, "null", "null", "true", "null");
+    auto json = absl::StrFormat(kJson, "null", "null", "true", "null");
     // OK: invalid values for nullable field asset->imageUrl are treated as
     // null.
     auto simulation_response = evm::ParseSimulationResponse(
@@ -1304,7 +1304,7 @@ TEST(SimulationResponseParserUnitTest, ParseEvmNullableFields) {
   }
 
   {
-    auto json = base::StringPrintf(kJson, "null", "null", "null", "true");
+    auto json = absl::StrFormat(kJson, "null", "null", "null", "true");
     // OK: invalid values for nullable field asset->price are treated as
     // null.
     auto simulation_response = evm::ParseSimulationResponse(
@@ -1318,8 +1318,7 @@ TEST(SimulationResponseParserUnitTest, ParseEvmNullableFields) {
   }
 
   {
-    auto json =
-        base::StringPrintf(kJson, "null", "null", "null", "{\"foo\": 1}");
+    auto json = absl::StrFormat(kJson, "null", "null", "null", "{\"foo\": 1}");
     // OK: invalid dict for nullable field asset->price is treated as null.
     auto simulation_response = evm::ParseSimulationResponse(
         ParseJson(json), "0xd8da6bf26964af9d7eed9e03e53415d37aa96045");
@@ -1820,7 +1819,7 @@ TEST(SimulationResponseParserUnitTest, ParseSolanaNullableFields) {
   )";
 
   {
-    auto json = base::StringPrintf(kJson, "null");
+    auto json = absl::StrFormat(kJson, "null");
     auto simulation_response = solana::ParseSimulationResponse(
         ParseJson(json), "8eekKfUAGSJbq3CdA2TmHb8tKuyzd5gtEas3MYAtXzrT");
 
@@ -1837,7 +1836,7 @@ TEST(SimulationResponseParserUnitTest, ParseSolanaNullableFields) {
   }
 
   {
-    auto json = base::StringPrintf(kJson, "true");
+    auto json = absl::StrFormat(kJson, "true");
     auto simulation_response = solana::ParseSimulationResponse(
         ParseJson(json), "8eekKfUAGSJbq3CdA2TmHb8tKuyzd5gtEas3MYAtXzrT");
 
@@ -1855,7 +1854,7 @@ TEST(SimulationResponseParserUnitTest, ParseSolanaNullableFields) {
   }
 
   {
-    auto json = base::StringPrintf(kJson, "{\"foo\": 1}");
+    auto json = absl::StrFormat(kJson, "{\"foo\": 1}");
     auto simulation_response = solana::ParseSimulationResponse(
         ParseJson(json), "8eekKfUAGSJbq3CdA2TmHb8tKuyzd5gtEas3MYAtXzrT");
 

--- a/components/brave_wallet/browser/solana_requests_unittest.cc
+++ b/components/brave_wallet/browser/solana_requests_unittest.cc
@@ -124,17 +124,17 @@ TEST(SolanaRequestsUnitTest, getTokenAccountsByOwner) {
   ASSERT_EQ(base::test::ParseJsonDict(
                 getTokenAccountsByOwner("pubkey", "base64", "program")),
             base::test::ParseJsonDict(
-                base::StringPrintf(kExpectedJsonStringFormat, "base64")));
+                absl::StrFormat(kExpectedJsonStringFormat, "base64")));
 
   ASSERT_EQ(base::test::ParseJsonDict(
                 getTokenAccountsByOwner("pubkey", "base58", "program")),
             base::test::ParseJsonDict(
-                base::StringPrintf(kExpectedJsonStringFormat, "base58")));
+                absl::StrFormat(kExpectedJsonStringFormat, "base58")));
 
   ASSERT_EQ(base::test::ParseJsonDict(
                 getTokenAccountsByOwner("pubkey", "jsonParsed", "program")),
             base::test::ParseJsonDict(
-                base::StringPrintf(kExpectedJsonStringFormat, "jsonParsed")));
+                absl::StrFormat(kExpectedJsonStringFormat, "jsonParsed")));
 
   EXPECT_CHECK_DEATH(
       getTokenAccountsByOwner("pubkey", "invalid encoding", "program"));

--- a/components/brave_wallet/browser/solana_response_parser_unittest.cc
+++ b/components/brave_wallet/browser/solana_response_parser_unittest.cc
@@ -181,7 +181,7 @@ TEST(SolanaResponseParserUnitTest, ParseGetSPLTokenBalances) {
   )";
 
   // OK: well-formed json
-  auto json = base::StringPrintf(kJsonFmt, "9");
+  auto json = absl::StrFormat(kJsonFmt, "9");
   auto result = ParseGetSPLTokenBalances(ParseJson(json));
   ASSERT_TRUE(result.has_value());
   ASSERT_EQ(result->size(), 2UL);
@@ -199,15 +199,15 @@ TEST(SolanaResponseParserUnitTest, ParseGetSPLTokenBalances) {
   EXPECT_EQ(result->at(1)->decimals, 6);
 
   // KO: decimals uint8_t overflow
-  json = base::StringPrintf(kJsonFmt, "256");
+  json = absl::StrFormat(kJsonFmt, "256");
   EXPECT_FALSE(ParseGetSPLTokenBalances(ParseJson(json)));
 
   // KO: decimals uint8_t underflow
-  json = base::StringPrintf(kJsonFmt, "-1");
+  json = absl::StrFormat(kJsonFmt, "-1");
   EXPECT_FALSE(ParseGetSPLTokenBalances(ParseJson(json)));
 
   // KO: decimals type mismatch
-  json = base::StringPrintf(kJsonFmt, "\"not a decimal\"");
+  json = absl::StrFormat(kJsonFmt, "\"not a decimal\"");
   EXPECT_FALSE(ParseGetSPLTokenBalances(ParseJson(json)));
 }
 

--- a/components/brave_wallet/browser/swap_request_helper.cc
+++ b/components/brave_wallet/browser/swap_request_helper.cc
@@ -145,7 +145,7 @@ std::optional<std::string> EncodeTransactionParams(
 
   for (int i = 0; i < static_cast<int>(params.quote->route_plan.size()); i++) {
     result = json::convert_string_value_to_uint64(
-        base::StringPrintf("/quoteResponse/routePlan/%d/percent", i), result,
+        absl::StrFormat("/quoteResponse/routePlan/%d/percent", i), result,
         false);
   }
 

--- a/components/brave_wallet/browser/swap_request_helper_unittest.cc
+++ b/components/brave_wallet/browser/swap_request_helper_unittest.cc
@@ -830,9 +830,9 @@ constexpr char kLiFiEvmToSolQuoteTemplate2[] = R"(
 }  // namespace
 
 TEST(SwapRequestHelperUnitTest, EncodeJupiterTransactionParams) {
-  std::string json = base::StringPrintf(
-      kJupiterQuoteTemplate,
-      "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");  // USDC
+  std::string json =
+      absl::StrFormat(kJupiterQuoteTemplate,
+                      "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");  // USDC
   mojom::JupiterQuotePtr swap_quote =
       jupiter::ParseQuoteResponse(ParseJson(json));
   ASSERT_TRUE(swap_quote);

--- a/components/brave_wallet/browser/swap_service.cc
+++ b/components/brave_wallet/browser/swap_service.cc
@@ -11,6 +11,7 @@
 
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/stringprintf.h"
+#include "base/strings/to_string.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_constants.h"
 #include "brave/components/brave_wallet/browser/json_rpc_response_parser.h"
 #include "brave/components/brave_wallet/browser/json_rpc_service.h"
@@ -166,7 +167,7 @@ GURL AppendZeroExSwapParams(const GURL& swap_url,
   if (base::StringToDouble(params.slippage_percentage, &slippage_percentage)) {
     url = net::AppendQueryParameter(
         url, "slippageBps",
-        base::StringPrintf("%d", static_cast<int>(slippage_percentage * 100)));
+        base::ToString(static_cast<int>(slippage_percentage * 100)));
   }
 
   // TODO(onyb): custom gas_price is currently unused and may be removed in
@@ -202,7 +203,7 @@ GURL AppendJupiterQuoteParams(const GURL& swap_url,
   if (base::StringToDouble(params.slippage_percentage, &slippage_percentage)) {
     url = net::AppendQueryParameter(
         url, "slippageBps",
-        base::StringPrintf("%d", static_cast<int>(slippage_percentage * 100)));
+        base::ToString(static_cast<int>(slippage_percentage * 100)));
   }
 
   if (fee_param.has_value() && !fee_param->empty()) {

--- a/components/brave_wallet/browser/swap_service_unittest.cc
+++ b/components/brave_wallet/browser/swap_service_unittest.cc
@@ -866,7 +866,7 @@ TEST_F(SwapServiceUnitTest, GetZeroExQuoteURL) {
                                   mojom::SwapProvider::kZeroEx),
         "85");
     EXPECT_EQ(url,
-              base::StringPrintf(
+              absl::StrFormat(
                   "https://api.0x.wallet.brave.com/swap/allowance-holder/price?"
                   "chainId=%s&"
                   "taker=0xa92D461a9a988A7f11ec285d39783A637Fdd6ba4&"
@@ -877,7 +877,7 @@ TEST_F(SwapServiceUnitTest, GetZeroExQuoteURL) {
                   "swapFeeRecipient=0xbd9420A98a7Bd6B89765e5715e169481602D9c3d&"
                   "swapFeeToken=ETH&"
                   "slippageBps=300",
-                  encoded_chain_id.c_str()));
+                  encoded_chain_id));
 
     // Ok: no fees
     url = swap_service_->GetZeroExQuoteURL(
@@ -886,7 +886,7 @@ TEST_F(SwapServiceUnitTest, GetZeroExQuoteURL) {
                                   mojom::SwapProvider::kZeroEx),
         "");
     EXPECT_EQ(url,
-              base::StringPrintf(
+              absl::StrFormat(
                   "https://api.0x.wallet.brave.com/swap/allowance-holder/price?"
                   "chainId=%s&"
                   "taker=0xa92D461a9a988A7f11ec285d39783A637Fdd6ba4&"
@@ -894,7 +894,7 @@ TEST_F(SwapServiceUnitTest, GetZeroExQuoteURL) {
                   "buyToken=ETH&"
                   "sellToken=DAI&"
                   "slippageBps=300",
-                  encoded_chain_id.c_str()));
+                  encoded_chain_id));
   }
 
   // KO: unsupported network
@@ -929,7 +929,7 @@ TEST_F(SwapServiceUnitTest, GetZeroExTransactionURL) {
                                   mojom::SwapProvider::kZeroEx),
         "85");
     EXPECT_EQ(url,
-              base::StringPrintf(
+              absl::StrFormat(
                   "https://api.0x.wallet.brave.com/swap/allowance-holder/quote?"
                   "chainId=%s&"
                   "taker=0xa92D461a9a988A7f11ec285d39783A637Fdd6ba4&"
@@ -940,7 +940,7 @@ TEST_F(SwapServiceUnitTest, GetZeroExTransactionURL) {
                   "swapFeeRecipient=0xbd9420A98a7Bd6B89765e5715e169481602D9c3d&"
                   "swapFeeToken=ETH&"
                   "slippageBps=300",
-                  encoded_chain_id.c_str()));
+                  encoded_chain_id));
 
     // OK: no fees
     url = swap_service_->GetZeroExTransactionURL(
@@ -949,7 +949,7 @@ TEST_F(SwapServiceUnitTest, GetZeroExTransactionURL) {
                                   mojom::SwapProvider::kZeroEx),
         "");
     EXPECT_EQ(url,
-              base::StringPrintf(
+              absl::StrFormat(
                   "https://api.0x.wallet.brave.com/swap/allowance-holder/quote?"
                   "chainId=%s&"
                   "taker=0xa92D461a9a988A7f11ec285d39783A637Fdd6ba4&"
@@ -957,7 +957,7 @@ TEST_F(SwapServiceUnitTest, GetZeroExTransactionURL) {
                   "buyToken=ETH&"
                   "sellToken=DAI&"
                   "slippageBps=300",
-                  encoded_chain_id.c_str()));
+                  encoded_chain_id));
   }
 
   // KO: unsupported network

--- a/components/brave_wallet/common/eth_request_helper.cc
+++ b/components/brave_wallet/common/eth_request_helper.cc
@@ -596,8 +596,7 @@ mojom::BlockchainTokenPtr ParseWalletWatchAssetParams(
   }
   // Only ERC20 is supported currently.
   if (*type != "ERC20") {
-    error_message =
-        base::StringPrintf("Asset of type '%s' not supported", type->c_str());
+    error_message = absl::StrFormat("Asset of type '%s' not supported", *type);
     return nullptr;
   }
 
@@ -615,8 +614,7 @@ mojom::BlockchainTokenPtr ParseWalletWatchAssetParams(
 
   const auto eth_addr = EthAddress::FromHex(*address);
   if (eth_addr.IsEmpty()) {
-    error_message =
-        base::StringPrintf("Invalid address '%s'", address->c_str());
+    error_message = absl::StrFormat("Invalid address '%s'", *address);
     return nullptr;
   }
 
@@ -629,10 +627,10 @@ mojom::BlockchainTokenPtr ParseWalletWatchAssetParams(
   // EIP-747 limits the symbol length to 5, but metamask uses 11, so we use
   // the same limit here for compatibility.
   if (symbol->size() == 0 || symbol->size() > 11) {
-    error_message = base::StringPrintf(
+    error_message = absl::StrFormat(
         "Invalid symbol '%s': symbol length should be greater than 0 and less "
         "than 12",
-        symbol->c_str());
+        *symbol);
     return nullptr;
   }
 
@@ -648,15 +646,15 @@ mojom::BlockchainTokenPtr ParseWalletWatchAssetParams(
   int decimals = decimals_value->is_int() ? decimals_value->GetInt() : 0;
   if (decimals_value->is_string() &&
       !base::StringToInt(decimals_value->GetString(), &decimals)) {
-    error_message = base::StringPrintf(
+    error_message = absl::StrFormat(
         "Invalid decimals '%s': decimals should be a number greater than 0 and "
         "less than 36",
-        decimals_value->GetString().c_str());
+        decimals_value->GetString());
     return nullptr;
   }
 
   if (decimals < 0 || decimals > 36) {
-    error_message = base::StringPrintf(
+    error_message = absl::StrFormat(
         "Invalid decimals '%d': decimals should be greater than 0 and less "
         "than 36",
         decimals);

--- a/components/brave_wallet/common/eth_request_helper_unittest.cc
+++ b/components/brave_wallet/common/eth_request_helper_unittest.cc
@@ -674,7 +674,7 @@ TEST(EthRequestHelperUnitTest, ParseEthSignTypedDataParams) {
       }"
     ])";
 
-  std::string json = base::StringPrintf(kJson, R"({
+  std::string json = absl::StrFormat(kJson, R"({
     \"from\": {
       \"name\":\"Cow\",
       \"wallet\":\"0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826\"
@@ -769,7 +769,7 @@ TEST(EthRequestHelperUnitTest, ParseEthSignTypedDataParams) {
   EXPECT_FALSE(eth_sign_typed_data->meta);
 
   // Test with extra fields in the message.
-  json = base::StringPrintf(kJson, R"({
+  json = absl::StrFormat(kJson, R"({
     \"from\": {
       \"name\":\"Cow\",
       \"wallet\":\"0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826\"
@@ -1154,7 +1154,7 @@ TEST(EthResponseHelperUnitTest, ParseEthSendRawTransaction) {
       "2dcba0b632c1a039d0379cdbfb54cfd1894de3bb5c0583a11bc79abf19b6961e948e2127"
       "f47bec";
 
-  std::string json = base::StringPrintf(
+  std::string json = absl::StrFormat(
       R"({
         "method": "eth_sendRawTransaction",
         "params": ["%s"]

--- a/components/brave_wallet/common/test_utils.cc
+++ b/components/brave_wallet/common/test_utils.cc
@@ -68,8 +68,8 @@ mojom::ChainIdPtr SolMainnetChainId() {
 namespace mojom {
 
 void PrintTo(const BitcoinAddressPtr& address, ::std::ostream* os) {
-  *os << base::StringPrintf("[%s %d/%d]", address->address_string.c_str(),
-                            address->key_id->change, address->key_id->index);
+  *os << absl::StrFormat("[%s %d/%d]", address->address_string,
+                         address->key_id->change, address->key_id->index);
 }
 
 void PrintTo(const BlockchainTokenPtr& token, ::std::ostream* os) {
@@ -102,13 +102,13 @@ void PrintTo(const BtcHardwareTransactionSignInputDataPtr& input_data,
 }
 
 void PrintTo(const CardanoAddressPtr& address, ::std::ostream* os) {
-  *os << base::StringPrintf("[%s %d/%d]", address->address_string.c_str(),
-                            address->payment_key_id->role,
-                            address->payment_key_id->index);
+  *os << absl::StrFormat("[%s %d/%d]", address->address_string,
+                         address->payment_key_id->role,
+                         address->payment_key_id->index);
 }
 
 void PrintTo(const CardanoBalancePtr& balance, ::std::ostream* os) {
-  *os << base::StringPrintf("[%d]", balance->total_balance);
+  *os << absl::StrFormat("[%d]", balance->total_balance);
 }
 
 }  // namespace mojom

--- a/components/brave_wayback_machine/brave_wayback_machine_utils.cc
+++ b/components/brave_wayback_machine/brave_wayback_machine_utils.cc
@@ -63,8 +63,8 @@ GURL FixupWaybackQueryURL(const GURL& url) {
     if (decoded_key == kTimeStampKey || decoded_key == kCallbackKey)
       continue;
 
-    query_parts.push_back(base::StringPrintf(
-        "%s=%s", key.c_str(), std::string(it.GetValue()).c_str()));
+    query_parts.push_back(
+        absl::StrFormat("%s=%s", key, std::string(it.GetValue())));
   }
 
   std::string query = base::JoinString(query_parts, "&");

--- a/components/cosmetic_filters/renderer/cosmetic_filters_js_handler.cc
+++ b/components/cosmetic_filters/renderer/cosmetic_filters_js_handler.cc
@@ -694,10 +694,10 @@ void CosmeticFiltersJSHandler::ApplyRules(bool de_amp_enabled) {
     const bool scriptlet_debug_enabled = base::FeatureList::IsEnabled(
         brave_shields::features::kBraveAdblockScriptletDebugLogs);
 
-    scriptlet_script = base::StringPrintf(
-        kScriptletInitScript,
-        scriptlet_debug_enabled ? "[[\"canDebug\", true]]" : "",
-        de_amp_enabled ? "true" : "false", scriptlet_script.c_str());
+    scriptlet_script =
+        absl::StrFormat(kScriptletInitScript,
+                        scriptlet_debug_enabled ? "[[\"canDebug\", true]]" : "",
+                        de_amp_enabled ? "true" : "false", scriptlet_script);
   }
   if (!scriptlet_script.empty()) {
     web_frame->ExecuteScriptInIsolatedWorld(
@@ -709,17 +709,16 @@ void CosmeticFiltersJSHandler::ApplyRules(bool de_amp_enabled) {
   // Working on css rules
   generichide_ = resources_dict_->FindBool("generichide").value_or(false);
   namespace bf = brave_shields::features;
-  std::string cosmetic_filtering_init_script = base::StringPrintf(
+  std::string cosmetic_filtering_init_script = absl::StrFormat(
       kCosmeticFilteringInitScript, enabled_1st_party_cf_ ? "true" : "false",
       generichide_ ? "true" : "false",
       render_frame_->IsMainFrame()
           ? "undefined"
-          : bf::kCosmeticFilteringSubFrameFirstSelectorsPollingDelayMs.Get()
-                .c_str(),
-      bf::kCosmeticFilteringswitchToSelectorsPollingThreshold.Get().c_str(),
-      bf::kCosmeticFilteringFetchNewClassIdRulesThrottlingMs.Get().c_str());
-  std::string pre_init_script = base::StringPrintf(
-      kPreInitScript, cosmetic_filtering_init_script.c_str());
+          : bf::kCosmeticFilteringSubFrameFirstSelectorsPollingDelayMs.Get(),
+      bf::kCosmeticFilteringswitchToSelectorsPollingThreshold.Get(),
+      bf::kCosmeticFilteringFetchNewClassIdRulesThrottlingMs.Get());
+  std::string pre_init_script =
+      absl::StrFormat(kPreInitScript, cosmetic_filtering_init_script);
 
   web_frame->ExecuteScriptInIsolatedWorld(
       isolated_world_id_,
@@ -793,8 +792,8 @@ void CosmeticFiltersJSHandler::CSSRulesRoutine(
         json_selectors = "[]";
       }
       // Building a script for stylesheet modifications
-      std::string new_selectors_script = base::StringPrintf(
-          kHideSelectorsInjectScript, json_selectors.c_str());
+      std::string new_selectors_script =
+          absl::StrFormat(kHideSelectorsInjectScript, json_selectors);
       web_frame->ExecuteScriptInIsolatedWorld(
           isolated_world_id_,
           blink::WebScriptSource(
@@ -871,7 +870,7 @@ void CosmeticFiltersJSHandler::OnHiddenClassIdSelectors(
     }
     // Building a script for stylesheet modifications
     std::string new_selectors_script =
-        base::StringPrintf(kHideSelectorsInjectScript, json_selectors.c_str());
+        absl::StrFormat(kHideSelectorsInjectScript, json_selectors);
     if (hide_selectors->size() != 0) {
       web_frame->ExecuteScriptInIsolatedWorld(
           isolated_world_id_,

--- a/components/de_amp/browser/test/de_amp_browsertest.cc
+++ b/components/de_amp/browser/test/de_amp_browsertest.cc
@@ -85,10 +85,9 @@ std::string Location(const std::string& path) {
 }
 
 std::string Amp(const GURL& custom_url) {
-  return base::StringPrintf(
+  return absl::StrFormat(
       kTestAmpBodyScaffolding,
-      base::StringPrintf(kTestAmpCanonicalLink, custom_url.spec().c_str())
-          .c_str());
+      absl::StrFormat(kTestAmpCanonicalLink, custom_url.spec()).c_str());
 }
 
 std::string Amp(const std::string& path) {
@@ -96,7 +95,7 @@ std::string Amp(const std::string& path) {
 }
 
 std::string Canonical(const std::string& custom_head = "It's canonical") {
-  return base::StringPrintf(kTestAmpBodyScaffolding, custom_head.c_str());
+  return absl::StrFormat(kTestAmpBodyScaffolding, custom_head);
 }
 
 }  // namespace
@@ -250,13 +249,12 @@ IN_PROC_BROWSER_TEST_F(DeAmpBrowserTest, SimpleDeAmp) {
 IN_PROC_BROWSER_TEST_F(DeAmpBrowserTest, CanonicalLinkOutsideChunkWithinMax) {
   TogglePref(true);
   // Construct page with large <head>
-  const std::string large_string = base::StringPrintf(
-      "%s\n%s", std::string(kTestReadBufferSize, 'a').c_str(),
-      base::StringPrintf(kTestAmpCanonicalLink,
-                         Location(kTestCanonicalPage).c_str())
+  const std::string large_string = absl::StrFormat(
+      "%s\n%s", std::string(kTestReadBufferSize, 'a'),
+      absl::StrFormat(kTestAmpCanonicalLink, Location(kTestCanonicalPage))
           .c_str());
   const std::string amp_body_large =
-      base::StringPrintf(kTestAmpBodyScaffolding, large_string.c_str());
+      absl::StrFormat(kTestAmpBodyScaffolding, large_string);
 
   SetRequestHandler(kTestCanonicalPage, Canonical());
   SetRequestHandler(kTestAmpPage, amp_body_large);
@@ -269,13 +267,11 @@ IN_PROC_BROWSER_TEST_F(DeAmpBrowserTest, CanonicalLinkOutsideChunkWithinMax) {
 IN_PROC_BROWSER_TEST_F(DeAmpBrowserTest, CanonicalLinkOutsideChunkOutsideMax) {
   TogglePref(true);
   // Construct page with large <head>
-  const std::string large_string = base::StringPrintf(
-      "%s\n%s", std::string(3 * kTestReadBufferSize, 'a').c_str(),
-      base::StringPrintf(kTestAmpCanonicalLink,
-                         Location(kTestCanonicalPage).c_str())
-          .c_str());
+  const std::string large_string = absl::StrFormat(
+      "%s\n%s", std::string(3 * kTestReadBufferSize, 'a'),
+      absl::StrFormat(kTestAmpCanonicalLink, Location(kTestCanonicalPage)));
   const std::string amp_body_large =
-      base::StringPrintf(kTestAmpBodyScaffolding, large_string.c_str());
+      absl::StrFormat(kTestAmpBodyScaffolding, large_string);
 
   SetRequestHandler(kTestCanonicalPage, Canonical());
   SetRequestHandler(kTestAmpPage, amp_body_large);

--- a/components/debounce/core/browser/debounce_rule.cc
+++ b/components/debounce/core/browser/debounce_rule.cc
@@ -362,8 +362,7 @@ bool DebounceRule::Apply(const GURL& original_url,
     std::string scheme = (prepend_scheme_ == kDebounceSchemePrependHttp)
                              ? url::kHttpScheme
                              : url::kHttpsScheme;
-    new_url_spec =
-        base::StringPrintf("%s://%s", scheme.c_str(), unescaped_value.c_str());
+    new_url_spec = absl::StrFormat("%s://%s", scheme, unescaped_value);
     new_url = GURL(new_url_spec);
     if (new_url.is_valid()) {
       DCHECK(new_url.scheme() == scheme);

--- a/components/ipfs/ipfs_utils.cc
+++ b/components/ipfs/ipfs_utils.cc
@@ -107,9 +107,8 @@ bool TranslateIPFSURI(const GURL& url, GURL* new_url, bool use_subdomain) {
       std::string new_host = gateway_url.host();
       std::string new_path = path;
       if (use_subdomain) {
-        new_host = base::StringPrintf("%s.%s.%s", cid.c_str(),
-                                      ipfs_scheme ? "ipfs" : "ipns",
-                                      gateway_url.host().c_str());
+        new_host = absl::StrFormat(
+            "%s.%s.%s", cid, ipfs_scheme ? "ipfs" : "ipns", gateway_url.host());
       } else {
         new_path = (ipfs_scheme ? "ipfs/" : "ipns/") + cid + path;
       }

--- a/components/l10n/common/ofac_sanction_util_unittest.cc
+++ b/components/l10n/common/ofac_sanction_util_unittest.cc
@@ -187,9 +187,8 @@ std::string TestParamToString(
           ? "WhenShouldSanctionUNM49CodesIsSetToTrue"
           : "WhenShouldSanctionUNM49CodesIsSetToFalse";
 
-  return base::StringPrintf("%s_%s_%s", is_ofac_sanctioned.c_str(),
-                            locale.c_str(),
-                            should_sanction_un_m49_codes.c_str());
+  return absl::StrFormat("%s_%s_%s", is_ofac_sanctioned, locale,
+                         should_sanction_un_m49_codes);
 }
 
 INSTANTIATE_TEST_SUITE_P(,

--- a/components/ntp_background_images/browser/ntp_background_images_data.cc
+++ b/components/ntp_background_images/browser/ntp_background_images_data.cc
@@ -54,9 +54,9 @@ Background& Background::operator=(Background&& other) = default;
 Background::~Background() = default;
 
 NTPBackgroundImagesData::NTPBackgroundImagesData()
-    : url_prefix(base::StringPrintf("%s://%s/",
-                                    content::kChromeUIScheme,
-                                    kBackgroundWallpaperHost)) {}
+    : url_prefix(absl::StrFormat("%s://%s/",
+                                 content::kChromeUIScheme,
+                                 kBackgroundWallpaperHost)) {}
 
 NTPBackgroundImagesData::NTPBackgroundImagesData(
     const std::string& json_string,

--- a/components/ntp_background_images/browser/ntp_background_images_service.cc
+++ b/components/ntp_background_images/browser/ntp_background_images_service.cc
@@ -250,7 +250,7 @@ void NTPBackgroundImagesService::RegisterSponsoredImagesComponent() {
   RegisterNTPSponsoredImagesComponent(
       component_update_service_, std::string(data->component_base64_public_key),
       std::string(data->component_id),
-      base::StringPrintf("NTP Sponsored Images (%s)", data->region.data()),
+      absl::StrFormat("NTP Sponsored Images (%s)", data->region),
       base::BindRepeating(
           &NTPBackgroundImagesService::OnSponsoredComponentReady,
           weak_factory_.GetWeakPtr(), false));
@@ -415,7 +415,7 @@ void NTPBackgroundImagesService::RegisterSuperReferralComponent() {
 
   RegisterNTPSponsoredImagesComponent(
       component_update_service_, public_key, id,
-      base::StringPrintf("NTP Super Referral (%s)", theme_name.c_str()),
+      absl::StrFormat("NTP Super Referral (%s)", theme_name),
       base::BindRepeating(
           &NTPBackgroundImagesService::OnSponsoredComponentReady,
           weak_factory_.GetWeakPtr(), true));

--- a/components/ntp_background_images/browser/ntp_sponsored_images_data.cc
+++ b/components/ntp_background_images/browser/ntp_sponsored_images_data.cc
@@ -144,8 +144,8 @@ NTPSponsoredImagesData::NTPSponsoredImagesData(
     return;
   }
 
-  url_prefix = base::StringPrintf("%s://%s/", content::kChromeUIScheme,
-                                  kBrandedWallpaperHost);
+  url_prefix = absl::StrFormat("%s://%s/", content::kChromeUIScheme,
+                               kBrandedWallpaperHost);
   if (const std::string* const name = dict.FindString(kThemeNameKey)) {
     theme_name = *name;
     url_prefix += kSuperReferralPath;

--- a/components/ntp_background_images/browser/ntp_sponsored_rich_media_source.cc
+++ b/components/ntp_background_images/browser/ntp_sponsored_rich_media_source.cc
@@ -80,8 +80,8 @@ std::string NTPSponsoredRichMediaSource::GetContentSecurityPolicy(
     network::mojom::CSPDirectiveName directive) {
   switch (directive) {
     case network::mojom::CSPDirectiveName::FrameAncestors:
-      return base::StringPrintf("frame-ancestors %s %s;", kBraveUINewTabURL,
-                                kBraveUINewTabTakeoverURL);
+      return absl::StrFormat("frame-ancestors %s %s;", kBraveUINewTabURL,
+                             kBraveUINewTabTakeoverURL);
     case network::mojom::CSPDirectiveName::Sandbox:
       return "sandbox allow-scripts;";
     case network::mojom::CSPDirectiveName::DefaultSrc:

--- a/components/p3a/constellation_helper_unittest.cc
+++ b/components/p3a/constellation_helper_unittest.cc
@@ -57,8 +57,8 @@ constexpr char kTestHost[] = "https://localhost:8443";
 std::string FormatUTCDateFromTime(const base::Time& time) {
   base::Time::Exploded exploded;
   time.UTCExplode(&exploded);
-  return base::StringPrintf("%d-%02d-%02d", exploded.year, exploded.month,
-                            exploded.day_of_month);
+  return absl::StrFormat("%d-%02d-%02d", exploded.year, exploded.month,
+                         exploded.day_of_month);
 }
 
 std::vector<std::string> SplitMessageLayers(const std::string& message) {

--- a/components/p3a/p3a_message.cc
+++ b/components/p3a/p3a_message.cc
@@ -77,8 +77,8 @@ constexpr auto kNotableCountries = base::MakeFixedFlatSet<std::string_view>(
 constexpr base::TimeDelta kDateOmissionThreshold = base::Days(31);
 
 std::string FormatUTCDateFromExploded(const base::Time::Exploded& exploded) {
-  return base::StringPrintf("%d-%02d-%02d", exploded.year, exploded.month,
-                            exploded.day_of_month);
+  return absl::StrFormat("%d-%02d-%02d", exploded.year, exploded.month,
+                         exploded.day_of_month);
 }
 
 std::string FormatUTCDateFromTime(const base::Time& time) {

--- a/components/permissions/permission_lifetime_utils.cc
+++ b/components/permissions/permission_lifetime_utils.cc
@@ -43,7 +43,7 @@ std::optional<PermissionLifetimeOption> GetTestSecondsOption() {
     return std::nullopt;
   }
   return PermissionLifetimeOption(
-      base::UTF8ToUTF16(base::StringPrintf("%d seconds", *test_seconds)),
+      base::UTF8ToUTF16(absl::StrFormat("%d seconds", *test_seconds)),
       base::Seconds(*test_seconds));
 }
 

--- a/components/safe_builtins/renderer/safe_builtins.cc
+++ b/components/safe_builtins/renderer/safe_builtins.cc
@@ -108,8 +108,8 @@ inline bool IsTrue(v8::Maybe<bool> maybe) {
 
 v8::Local<v8::Private> MakeKey(const char* name, v8::Isolate* isolate) {
   return v8::Private::ForApi(
-      isolate, ToV8StringUnsafe(
-                   isolate, base::StringPrintf("%s::%s", kClassName, name)));
+      isolate,
+      ToV8StringUnsafe(isolate, absl::StrFormat("%s::%s", kClassName, name)));
 }
 
 // GetProperty() family calls V8::Object::Get() and extracts a value from

--- a/components/safe_builtins/renderer/safe_builtins_helpers.cc
+++ b/components/safe_builtins/renderer/safe_builtins_helpers.cc
@@ -46,8 +46,8 @@ std::string CreateExceptionString(v8::Local<v8::Context> context,
   auto maybe = message->GetLineNumber(context);
   line_number = maybe.IsJust() ? maybe.FromJust() : 0;
 
-  return base::StringPrintf("%s:%d: %s", resource_name.c_str(), line_number,
-                            error_message.c_str());
+  return absl::StrFormat("%s:%d: %s", resource_name, line_number,
+                         error_message);
 }
 
 v8::Local<v8::String> WrapSource(v8::Isolate* isolate,
@@ -130,10 +130,9 @@ v8::MaybeLocal<v8::Value> LoadScriptWithSafeBuiltins(
   // Wrapping script in function(...) {...}
   v8::Local<v8::Value> func_as_value = RunScript(context, wrapped_source);
   if (func_as_value.IsEmpty() || func_as_value->IsUndefined()) {
-    std::string message = base::StringPrintf("Bad source");
     web_frame->AddMessageToConsole(
         blink::WebConsoleMessage(blink::mojom::ConsoleMessageLevel::kError,
-                                 blink::WebString::FromUTF8(message)));
+                                 blink::WebString::FromUTF8("Bad source")));
     return v8::MaybeLocal<v8::Value>();
   }
 

--- a/components/tor/tor_control.cc
+++ b/components/tor/tor_control.cc
@@ -550,16 +550,14 @@ void TorControl::SetupPluggableTransport(
       "stun:stun.uls.co.za:3478,stun:stun.voipgate.com:3478,stun:stun.voys.nl:"
       "3478\"";
 
-  const std::string snowflake_setup = base::StringPrintf(
+  const std::string snowflake_setup = absl::StrFormat(
       kSnowflakeConfigCmd,
       snowflake_path.NormalizePathSeparatorsTo(FILE_PATH_LITERAL('/'))
-          .AsUTF8Unsafe()
-          .c_str());
-  const std::string obfs4_setup = base::StringPrintf(
+          .AsUTF8Unsafe());
+  const std::string obfs4_setup = absl::StrFormat(
       kObfs4ConfigCmd,
       obfs4_path.NormalizePathSeparatorsTo(FILE_PATH_LITERAL('/'))
-          .AsUTF8Unsafe()
-          .c_str());
+          .AsUTF8Unsafe());
 
   const std::string configure_pluggable_transport =
       base::StrCat({"SETCONF ", snowflake_setup, " ", obfs4_setup});

--- a/components/web_discovery/browser/util.cc
+++ b/components/web_discovery/browser/util.cc
@@ -71,8 +71,8 @@ std::unique_ptr<network::ResourceRequest> CreateResourceRequest(GURL url) {
 std::string FormatServerDate(const base::Time& date) {
   base::Time::Exploded exploded;
   date.UTCExplode(&exploded);
-  return base::StringPrintf("%04d%02d%02d", exploded.year, exploded.month,
-                            exploded.day_of_month);
+  return absl::StrFormat("%04d%02d%02d", exploded.year, exploded.month,
+                         exploded.day_of_month);
 }
 
 std::string DecodeURLComponent(const std::string_view value) {

--- a/components/web_discovery/browser/web_discovery_service.cc
+++ b/components/web_discovery/browser/web_discovery_service.cc
@@ -257,8 +257,8 @@ bool WebDiscoveryService::UpdatePageCountStartTime() {
     return false;
   }
   current_page_count_hour_key_ =
-      base::StringPrintf("%04d%02d%02d%02d", exploded.year, exploded.month,
-                         exploded.day_of_month, exploded.hour);
+      absl::StrFormat("%04d%02d%02d%02d", exploded.year, exploded.month,
+                      exploded.day_of_month, exploded.hour);
   return true;
 }
 

--- a/components/webcompat_reporter/browser/webcompat_report_uploader_unittest.cc
+++ b/components/webcompat_reporter/browser/webcompat_report_uploader_unittest.cc
@@ -11,6 +11,7 @@
 
 #include "base/strings/stringprintf.h"
 #include "base/test/bind.h"
+#include "base/test/run_until.h"
 #include "base/test/task_environment.h"
 #include "base/test/values_test_util.h"
 #include "base/values.h"
@@ -18,6 +19,7 @@
 #include "services/network/public/cpp/resource_request.h"
 #include "services/network/public/cpp/weak_wrapper_shared_url_loader_factory.h"
 #include "services/network/test/test_url_loader_factory.h"
+#include "services/network/test/test_utils.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 namespace webcompat_reporter {
@@ -32,58 +34,24 @@ class WebcompatReportUploaderUnitTest : public testing::Test {
         std::make_unique<WebcompatReportUploader>(shared_url_loader_factory_);
   }
 
-  using OnRequestPayloadCallback =
-      base::RepeatingCallback<void(const std::string& request_payload)>;
-
-  void SetInterceptor(
-      OnRequestPayloadCallback* request_payload_callback = nullptr) {
-    url_loader_factory_.SetInterceptor(base::BindLambdaForTesting(
-        [&, request_payload_callback](const network::ResourceRequest& request) {
-          url_loader_factory_.ClearResponses();
-          if (request_payload_callback) {
-            std::string request_string(request.request_body->elements()
-                                           ->at(0)
-                                           .As<network::DataElementBytes>()
-                                           .AsStringPiece());
-            request_payload_callback->Run(request_string);
-          }
-        }));
-  }
-
   WebcompatReportUploader* GetWebcompatUploader() {
     return webcompat_report_uploader_.get();
   }
 
-  void TestReportGeneration(webcompat_reporter::mojom::ReportInfoPtr report,
-                            const std::string& content) {
-    auto content_vals = base::test::ParseJson(content);
-    EXPECT_TRUE(content_vals.is_dict());
-    auto& content_dict_vals = content_vals.GetDict();
+  base::Value::Dict TestReportGeneration(
+      webcompat_reporter::mojom::ReportInfoPtr report) {
+    std::optional<std::string> request_payload;
+    url_loader_factory_.SetInterceptor(base::BindLambdaForTesting(
+        [&request_payload](const network::ResourceRequest& request) {
+          ASSERT_TRUE(request_payload = network::GetUploadData(request));
+        }));
 
-    base::RunLoop run_loop;
-    auto request_payload_check_callback =
-        base::BindLambdaForTesting([&](const std::string& request_payload) {
-          auto request_vals = base::test::ParseJson(request_payload);
-          EXPECT_TRUE(request_vals.is_dict());
-
-          auto& request_dict_vals = request_vals.GetDict();
-
-          for (base::Value::Dict::iterator it = content_dict_vals.begin();
-               it != content_dict_vals.end(); ++it) {
-            EXPECT_NE(request_dict_vals.Find(it->first), nullptr);
-            auto* request_val = request_dict_vals.Find(it->first);
-            if (request_val->is_bool()) {
-              EXPECT_EQ(*request_val, it->second == "true");
-            } else {
-              EXPECT_EQ(*request_val, it->second);
-            }
-          }
-          run_loop.Quit();
-        });
-
-    SetInterceptor(&request_payload_check_callback);
     GetWebcompatUploader()->SubmitReport(std::move(report));
-    run_loop.Run();
+
+    EXPECT_TRUE(
+        base::test::RunUntil([&]() { return request_payload.has_value(); }));
+
+    return base::test::ParseJsonDict(*request_payload);
   }
 
  protected:
@@ -96,9 +64,8 @@ class WebcompatReportUploaderUnitTest : public testing::Test {
 
 TEST_F(WebcompatReportUploaderUnitTest, GenerateReport) {
   auto report_empty = webcompat_reporter::mojom::ReportInfo::New();
-  TestReportGeneration(std::move(report_empty),
-                       base::StringPrintf(R"({"api_key":"%s"})",
-                                          brave_stats::GetAPIKey().c_str()));
+  EXPECT_EQ(TestReportGeneration(std::move(report_empty)),
+            base::Value::Dict().Set("api_key", brave_stats::GetAPIKey()));
 
   std::vector<webcompat_reporter::mojom::ComponentInfoPtr> components;
   components.push_back(
@@ -118,46 +85,35 @@ TEST_F(WebcompatReportUploaderUnitTest, GenerateReport) {
 
   auto report_copy = report->Clone();
 
-  TestReportGeneration(
-      std::move(report),
-      base::StringPrintf(
-          R"({
-  "adBlockComponentsInfo": %s,
-  "adBlockLists": "%s",
-  "adBlockSetting": "%s",
-  "additionalDetails": "%s",
-  "api_key": "%s",
-  "block_scripts": "%s",
-  "braveVPNEnabled": "%s",
-  "category": "%s",
-  "channel": "%s",
-  "contactInfo": "%s",
-  "cookie_policy": "%s",
-  "domain": "%s",
-  "fpBlockSetting": "%s",
-  "languageFarblingEnabled": "%s",
-  "languages": "%s",
-  "shieldsEnabled": "%s",
-  "url": "%s",
-  "version": "%s",
-  "webcompatReportErrors": %s
-})",
-          R"([{"id": "id", "name": "name", "version": "version"}])",
-          report_copy->ad_block_list_names->c_str(),
-          report_copy->ad_block_setting->c_str(), report_copy->details->c_str(),
-          brave_stats::GetAPIKey().c_str(), report_copy->block_scripts->c_str(),
-          report_copy->brave_vpn_connected ? "true" : "false",
-          report_copy->category->c_str(), report_copy->channel->c_str(),
-          report_copy->contact->c_str(), report_copy->cookie_policy->c_str(),
-          url::Origin::Create(GURL(report_copy->report_url.value()))
-              .Serialize()
-              .c_str(),
-          report_copy->fp_block_setting->c_str(),
-          report_copy->language_farbling ? "true" : "false",
-          report_copy->languages->c_str(),
-          report_copy->shields_enabled ? "true" : "false",
-          GURL(report_copy->report_url.value()).spec().c_str(),
-          report_copy->brave_version->c_str(), errors_list.DebugString()));
+  EXPECT_EQ(
+      TestReportGeneration(std::move(report)),
+      base::Value::Dict()
+          .Set("adBlockComponentsInfo",
+               base::Value::List().Append(base::Value::Dict()
+                                              .Set("id", "id")
+                                              .Set("name", "name")
+                                              .Set("version", "version")))
+          .Set("adBlockLists", *report_copy->ad_block_list_names)
+          .Set("adBlockSetting", *report_copy->ad_block_setting)
+          .Set("additionalDetails", *report_copy->details)
+          .Set("api_key", brave_stats::GetAPIKey())
+          .Set("block_scripts", *report_copy->block_scripts == "true")
+          .Set("braveVPNEnabled", report_copy->brave_vpn_connected.has_value())
+          .Set("category", *report_copy->category)
+          .Set("channel", *report_copy->channel)
+          .Set("contactInfo", *report_copy->contact)
+          .Set("cookie_policy", *report_copy->cookie_policy)
+          .Set("domain",
+               url::Origin::Create(GURL(report_copy->report_url.value()))
+                   .Serialize())
+          .Set("fpBlockSetting", *report_copy->fp_block_setting)
+          .Set("languageFarblingEnabled",
+               report_copy->language_farbling.has_value())
+          .Set("languages", *report_copy->languages)
+          .Set("shieldsEnabled", report_copy->shields_enabled.has_value())
+          .Set("url", GURL(report_copy->report_url.value()).spec())
+          .Set("version", *report_copy->brave_version)
+          .Set("webcompatReportErrors", std::move(errors_list)));
 }
 
 }  // namespace webcompat_reporter

--- a/renderer/test/js_ethereum_provider_browsertest.cc
+++ b/renderer/test/js_ethereum_provider_browsertest.cc
@@ -61,17 +61,17 @@ constexpr char kTestEIP6963[] = R"(
     })();)";
 
 std::string NonWriteableScriptProperty(const std::string& property) {
-  return base::StringPrintf(
+  return absl::StrFormat(
       R"(window.ethereum.%s = "brave";
          !(window.ethereum.%s === "brave");)",
-      property.c_str(), property.c_str());
+      property, property);
 }
 std::string NonWriteableScriptMethod(const std::string& provider,
                                      const std::string& method) {
-  return base::StringPrintf(
+  return absl::StrFormat(
       R"(window.%s.%s = "brave";
          typeof window.%s.%s === "function";)",
-      provider.c_str(), method.c_str(), provider.c_str(), method.c_str());
+      provider, method, provider, method);
 }
 }  // namespace
 


### PR DESCRIPTION
This PR has additional replacements for base::StringPrintf with the
underlying abseil implementation absl::StrFormat.

This is mostly a mechanical change.

Resolves https://github.com/brave/brave-browser/issues/48076
