### PR TITLE
sync is not taking into account .env and can break local build

### DIFF
--- a/build/commands/lib/util.js
+++ b/build/commands/lib/util.js
@@ -14,6 +14,7 @@ const Log = require('./logging')
 const assert = require('assert')
 const updateChromeVersion = require('./updateChromeVersion')
 const ActionGuard = require('./actionGuard')
+const dotenvPopulateWithIncludes = require('./dotenvPopulateWithIncludes');
 
 // Do not limit the number of listeners to avoid warnings from EventEmitter.
 process.setMaxListeners(0)
@@ -762,6 +763,9 @@ const util = {
       args.push('--verbose')
     }
     options.cwd = options.cwd || config.rootDir
+    const env = {}
+    dotenvPopulateWithIncludes(env, '.env')
+    options.env = {...env, ...options.env}
     options = util.mergeWithDefault(options)
     options.env.GCLIENT_FILE = gClientFile
     util.run('gclient', args, options)


### PR DESCRIPTION
`npm run sync` may break local builds if RBE_* variables are set in your .env and are not sourced.

This manifests in `npm run sync` reconfiguring your project and causes failures on subsequent `npm run build`s leading to the following error:


```
➜  brave git:(master) ✗ npm run build
You can't use rbe-chrome-untrusted on non-corp machine.
Plase use rbe-chromium-untrusted and non-@google.com account instead to build chromium.
Program autoninja exited with error code 1.
```

This error is foreshadowed during `npm run sync` where it warns you
> RBE_service environment variable is not set. Pass --force to configure reclient.


