### PR TITLE
Revert "Temporarily disable `brave:all builds (#30373)" (uplift to 1.82.x)

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -47,13 +47,14 @@ declare_args() {
 
 chromium_unit_tests_deps = [
   "//base:base_unittests",
-  "//components:components_unittests",
   "//net:net_unittests",
 ]
 if (!is_ios) {
   chromium_unit_tests_deps += [ "//chrome/test:unit_tests" ]
 }
-if (use_blink) {
+if (use_blink && !is_android) {
+  # TODO(https://github.com/brave/brave-browser/issues/48062): Fix this target
+  # for android.
   chromium_unit_tests_deps += [ "//content/test:content_unittests" ]
 }
 
@@ -73,7 +74,15 @@ if (!is_ios) {
   brave_all_unit_tests_deps += [ "//brave/ios/testing:ios_brave_unit_tests" ]
 }
 if (!is_ios && !is_android) {
-  brave_all_unit_tests_deps += [ "//brave/test:brave_installer_unittests" ]
+  brave_all_unit_tests_deps += [
+    "//brave/test:brave_installer_unittests",
+
+    # TODO(https://github.com/brave/brave-browser/issues/48061): Fix this target
+    # for iOS.
+    # TODO(https://github.com/brave/brave-browser/issues/48062): Fix this target
+    # for android.
+    "//components:components_unittests",
+  ]
 }
 group("brave_all_unit_tests") {
   testonly = true

--- a/build/.ci_features
+++ b/build/.ci_features
@@ -8,4 +8,4 @@ ios_output_xml
 
 # TODO(https://github.com/brave/brave-browser/issues/48001): Remove this CI
 # feature when `1.82.x` is retired.
-# brave_all_build
+brave_all_build


### PR DESCRIPTION
Uplift of #30377

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.