### PR TITLE
Disable `brave:all` due to OoM on the Windows CI (uplift to 1.82.x)

### DIFF
--- a/build/.ci_features
+++ b/build/.ci_features
@@ -8,4 +8,6 @@ ios_output_xml
 
 # TODO(https://github.com/brave/brave-browser/issues/48001): Remove this CI
 # feature when `1.82.x` is retired.
-brave_all_build
+# TODO(https://github.com/brave/brave-browser/issues/48090): Re-enable this once
+# a solution to pass `concurrent_links` to the Windows CI is deployed.
+# brave_all_build


### PR DESCRIPTION
Uplift of #30409
Resolves https://github.com/brave/brave-browser/issues/48094

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.