### PR TITLE
[build] Support `concurrent_links` in `.env`

### DIFF
--- a/build/.ci_features
+++ b/build/.ci_features
@@ -8,6 +8,4 @@ ios_output_xml
 
 # TODO(https://github.com/brave/brave-browser/issues/48001): Remove this CI
 # feature when `1.82.x` is retired.
-# TODO(https://github.com/brave/brave-browser/issues/48090): Re-enable this once
-# a solution to pass `concurrent_links` to the Windows CI is deployed.
-# brave_all_build
+brave_all_build

--- a/build/commands/lib/config.js
+++ b/build/commands/lib/config.js
@@ -85,8 +85,10 @@ const getEnvConfig = (key, defaultValue = undefined) => {
 
     // Convert 'true' and 'false' strings into booleans.
     for (const [key, value] of Object.entries(envConfig)) {
-      if (value === 'true' || value === 'false') {
-        envConfig[key] = value === 'true'
+      try {
+        envConfig[key] = JSON.parse(value)
+      } catch (e) {
+        envConfig[key] = value
       }
     }
   }
@@ -273,6 +275,7 @@ const Config = function () {
     'brave_stats_updater_url',
     'brave_sync_endpoint',
     'brave_variations_server_url',
+    'concurrent_links',
     'gemini_production_api_url',
     'gemini_production_client_id',
     'gemini_production_client_secret',
@@ -328,10 +331,10 @@ Config.prototype.isBraveReleaseBuild = function () {
   const isBraveReleaseBuildValue = getEnvConfig(['is_brave_release_build'])
   if (isBraveReleaseBuildValue !== undefined) {
     assert(
-      isBraveReleaseBuildValue === '0' || isBraveReleaseBuildValue === '1',
+      isBraveReleaseBuildValue === 0 || isBraveReleaseBuildValue === 1,
       'Bad is_brave_release_build value (should be 0 or 1)',
     )
-    return isBraveReleaseBuildValue === '1'
+    return isBraveReleaseBuildValue === 1
   }
 
   return false


### PR DESCRIPTION
This gn arg allows the control of how linking instances can happen
concurrently. This is necessary for the Windows PR build CI which is
running out of memory when linking targets.

Resolves https://github.com/brave/brave-browser/issues/48090
