### PR TITLE
Fixed webui event fired after js is disallowed. (uplift to 1.82.x)

### DIFF
--- a/browser/ui/webui/settings/brave_import_data_handler.cc
+++ b/browser/ui/webui/settings/brave_import_data_handler.cc
@@ -140,6 +140,14 @@ void BraveImportDataHandler::OnImportEnded(
                                                     : kImportStatusFailed));
 }
 
+void BraveImportDataHandler::OnJavascriptDisallowed() {
+  ImportDataHandler::OnJavascriptDisallowed();
+
+  // When the WebUI is unloading, we ignore all further updates from the host as
+  // ImportDataHandler does.
+  import_observers_.clear();
+}
+
 const user_data_importer::SourceProfile&
 BraveImportDataHandler::GetSourceProfileAt(int browser_index) {
   return importer_list_->GetSourceProfileAt(browser_index);

--- a/browser/ui/webui/settings/brave_import_data_handler.h
+++ b/browser/ui/webui/settings/brave_import_data_handler.h
@@ -57,6 +57,8 @@ class BraveImportDataHandler : public ImportDataHandler,
   virtual void OnImportEnded(
       const user_data_importer::SourceProfile& source_profile);
 
+  void OnJavascriptDisallowed() override;
+
   void OnStartImport(const user_data_importer::SourceProfile& source_profile,
                      uint16_t imported_items);
 #if BUILDFLAG(IS_MAC)


### PR DESCRIPTION
Uplift of #30392
Resolves https://github.com/brave/brave-browser/issues/47705

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.