### PR TITLE
fix(iOS): Reader Mode not included in Recently Closed tabs on iOS

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/TabManager.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/TabManager.swift
@@ -1502,23 +1502,24 @@ class TabManager: NSObject {
       return nil
     }
 
-    // NTP should not be passed as Recently Closed item
-    let recentlyClosedURL = tab.visibleURL ?? SessionTab.from(tabId: tab.id)?.url
-
-    guard let tabUrl = recentlyClosedURL, tabUrl.isWebPage() else {
+    guard var recentlyClosedURL = tab.visibleURL ?? SessionTab.from(tabId: tab.id)?.url else {
       return nil
     }
 
-    // Convert any internal URLs to their real URL for the Recently Closed item
-    var fetchedTabURL = tabUrl
-    if let url = InternalURL(fetchedTabURL),
-      let actualURL = url.extractedUrlParam ?? url.originalURLFromErrorPage
-    {
-      fetchedTabURL = actualURL
+    if let internalURL = InternalURL(recentlyClosedURL) {
+      // NTP should not be passed as a Recently Closed item
+      if internalURL.isAboutHomeURL {
+        return nil
+      }
+
+      // Convert any internal URLs to their real URL for the Recently Closed item
+      if let actualURL = internalURL.extractedUrlParam ?? internalURL.originalURLFromErrorPage {
+        recentlyClosedURL = actualURL
+      }
     }
 
     return SavedRecentlyClosed(
-      url: fetchedTabURL,
+      url: recentlyClosedURL,
       title: tab.displayTitle,
       interactionState: tab.sessionData,
       order: -1


### PR DESCRIPTION
- Previously reader mode was included but removed in this PR when we started checking `isWebPage` before extracting internal url's: https://github.com/brave/brave-ios/pull/7848

Resolves https://github.com/brave/brave-browser/issues/48124

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

### Testplan

1. Launch Brave
2. Open `Wikipedia` in a new tab
3. Enable `Reader mode`
4. Close the tab
5. Open `Recently closed tabs`
6. Verify Wikipedia tab is there

Regression test https://github.com/brave/brave-ios/issues/7832
1. Open 2 or more tabs
2. Fully quit Brave from app switcher
3. Open Brave
4. Tap and hold on tab tray button and tap Recently Closed Tabs
5. Clear list if not empty (not required, but easier to see bug)
6. Tap and hold on tab button, tap Close All n Tabs
7. Tap and hold on tab tray button and tap Recently Closed Tabs
8. Verify all tabs closed were added