### PR TITLE
[ubsan] Fix `TestingBrowserProcess` cast override

### DIFF
--- a/chromium_src/chrome/test/base/testing_browser_process.h
+++ b/chromium_src/chrome/test/base/testing_browser_process.h
@@ -36,6 +36,7 @@ class TestingBrowserProcess : public TestingBrowserProcess_ChromiumImpl {
   static TestingBrowserProcess* GetGlobal();
 
  private:
+  friend class TestingBrowserProcess_ChromiumImpl;
   TestingBrowserProcess();
   ~TestingBrowserProcess() override;
 };

--- a/patches/chrome-test-base-testing_browser_process.cc.patch
+++ b/patches/chrome-test-base-testing_browser_process.cc.patch
@@ -1,0 +1,13 @@
+diff --git a/chrome/test/base/testing_browser_process.cc b/chrome/test/base/testing_browser_process.cc
+index 693321f66c798fc35a8f3246d1257d03377d1798..a082af9280de8b279ddb222b12afe3d6ed6ecfcf 100644
+--- a/chrome/test/base/testing_browser_process.cc
++++ b/chrome/test/base/testing_browser_process.cc
+@@ -113,7 +113,7 @@ TestingBrowserProcess* TestingBrowserProcess::GetGlobal() {
+ // static
+ void TestingBrowserProcess::CreateInstance() {
+   DCHECK(!g_browser_process);
+-  TestingBrowserProcess* process = new TestingBrowserProcess;
++  TestingBrowserProcess* process = new TestingBrowserProcess_BraveImpl;
+   // Set |g_browser_process| before initializing the TestingBrowserProcess
+   // because some members may depend on |g_browser_process| (in particular,
+   // ChromeExtensionsBrowserClient).


### PR DESCRIPTION
This override has been broken for a while, and has been doing a broken
cast that yields undefined behaviour, as the type is not the same as the
one in the downcast. This has never been noticed until we started
running UBsan.

This fix corrects this override, by using a patch in the original class
to instantiate the override class.

https://github.com/brave/internal/issues/1406
