### PR TITLE
Add support of user customizations and memories for custom models (BYOM)

### DIFF
--- a/components/ai_chat/core/browser/engine/engine_consumer.cc
+++ b/components/ai_chat/core/browser/engine/engine_consumer.cc
@@ -35,8 +35,8 @@ std::string EngineConsumer::GetPromptForEntry(
   return prompt_entry->prompt.value_or(prompt_entry->text);
 }
 
-EngineConsumer::EngineConsumer(ModelService* model_service)
-    : model_service_(model_service) {}
+EngineConsumer::EngineConsumer(ModelService* model_service, PrefService* prefs)
+    : model_service_(model_service), prefs_(prefs) {}
 EngineConsumer::~EngineConsumer() = default;
 
 bool EngineConsumer::SupportsDeltaTextResponses() const {

--- a/components/ai_chat/core/browser/engine/engine_consumer.h
+++ b/components/ai_chat/core/browser/engine/engine_consumer.h
@@ -19,6 +19,8 @@
 #include "brave/components/ai_chat/core/browser/types.h"
 #include "brave/components/ai_chat/core/common/mojom/ai_chat.mojom.h"
 
+class PrefService;
+
 namespace ai_chat {
 class Tool;
 
@@ -72,7 +74,7 @@ class EngineConsumer {
 
   static std::string GetPromptForEntry(const mojom::ConversationTurnPtr& entry);
 
-  explicit EngineConsumer(ModelService* model_service);
+  EngineConsumer(ModelService* model_service, PrefService* prefs);
   EngineConsumer(const EngineConsumer&) = delete;
   EngineConsumer& operator=(const EngineConsumer&) = delete;
   virtual ~EngineConsumer();
@@ -139,6 +141,7 @@ class EngineConsumer {
   uint32_t max_associated_content_length_ = 0;
   std::string model_name_ = "";
   raw_ptr<ModelService> model_service_;
+  raw_ptr<PrefService> prefs_ = nullptr;
 };
 
 }  // namespace ai_chat

--- a/components/ai_chat/core/browser/engine/engine_consumer_conversation_api.cc
+++ b/components/ai_chat/core/browser/engine/engine_consumer_conversation_api.cc
@@ -32,8 +32,7 @@
 #include "brave/components/ai_chat/core/browser/model_service.h"
 #include "brave/components/ai_chat/core/common/features.h"
 #include "brave/components/ai_chat/core/common/mojom/ai_chat.mojom.h"
-#include "brave/components/ai_chat/core/common/pref_names.h"
-#include "components/prefs/pref_service.h"
+#include "brave/components/ai_chat/core/common/prefs.h"
 #include "services/network/public/cpp/shared_url_loader_factory.h"
 #include "third_party/abseil-cpp/absl/container/flat_hash_set.h"
 #include "third_party/re2/src/re2/re2.h"
@@ -56,8 +55,8 @@ EngineConsumerConversationAPI::EngineConsumerConversationAPI(
     scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
     AIChatCredentialManager* credential_manager,
     ModelService* model_service,
-    PrefService* pref_service)
-    : EngineConsumer(model_service), pref_service_(pref_service) {
+    PrefService* prefs)
+    : EngineConsumer(model_service, prefs) {
   DCHECK(!model_options.name.empty());
   model_name_ = model_options.name;
   api_ = std::make_unique<ConversationAPIClient>(
@@ -201,51 +200,8 @@ void EngineConsumerConversationAPI::OnGenerateQuestionSuggestionsResponse(
 
 std::optional<ConversationEvent>
 EngineConsumerConversationAPI::GetUserMemoryEvent() const {
-  bool customization_enabled =
-      pref_service_->GetBoolean(prefs::kBraveAIChatUserCustomizationEnabled);
-  bool memory_enabled =
-      pref_service_->GetBoolean(prefs::kBraveAIChatUserMemoryEnabled);
-  if (!customization_enabled && !memory_enabled) {
-    return std::nullopt;
-  }
-
-  base::Value::Dict user_memory;
-  if (customization_enabled) {
-    const base::Value::Dict& customizations_dict =
-        pref_service_->GetDict(prefs::kBraveAIChatUserCustomizations);
-
-    // Only set values when they have actual content
-    if (const std::string* name = customizations_dict.FindString("name")) {
-      if (!name->empty()) {
-        user_memory.Set("name", *name);
-      }
-    }
-    if (const std::string* job = customizations_dict.FindString("job")) {
-      if (!job->empty()) {
-        user_memory.Set("job", *job);
-      }
-    }
-    if (const std::string* tone = customizations_dict.FindString("tone")) {
-      if (!tone->empty()) {
-        user_memory.Set("tone", *tone);
-      }
-    }
-    if (const std::string* other = customizations_dict.FindString("other")) {
-      if (!other->empty()) {
-        user_memory.Set("other", *other);
-      }
-    }
-  }
-
-  if (memory_enabled) {
-    const base::Value::List& memories =
-        pref_service_->GetList(prefs::kBraveAIChatUserMemories);
-    if (!memories.empty()) {
-      user_memory.Set("memories", memories.Clone());
-    }
-  }
-
-  if (user_memory.empty()) {
+  auto user_memory_dict = prefs::GetUserMemoryDictFromPrefs(*prefs_);
+  if (!user_memory_dict.has_value()) {
     return std::nullopt;
   }
 
@@ -253,7 +209,7 @@ EngineConsumerConversationAPI::GetUserMemoryEvent() const {
                            ConversationEventType::kUserMemory,
                            std::vector<std::string>(),  // Empty content
                            "",                          // Empty topic
-                           std::move(user_memory));
+                           std::move(*user_memory_dict));
 }
 
 void EngineConsumerConversationAPI::GenerateAssistantResponse(

--- a/components/ai_chat/core/browser/engine/engine_consumer_conversation_api.h
+++ b/components/ai_chat/core/browser/engine/engine_consumer_conversation_api.h
@@ -128,7 +128,6 @@ class EngineConsumerConversationAPI : public EngineConsumer {
       const;
 
   std::unique_ptr<ConversationAPIClient> api_ = nullptr;
-  raw_ptr<PrefService> pref_service_ = nullptr;
 
   base::WeakPtrFactory<EngineConsumerConversationAPI> weak_ptr_factory_{this};
 };

--- a/components/ai_chat/core/browser/engine/engine_consumer_conversation_api_unittest.cc
+++ b/components/ai_chat/core/browser/engine/engine_consumer_conversation_api_unittest.cc
@@ -2306,11 +2306,6 @@ TEST_F(EngineConsumerConversationAPIUnitTest,
     run_loop.Run();
     testing::Mock::VerifyAndClearExpectations(mock_api_client);
   }
-
-  // Reset prefs
-  prefs_.ClearPref(prefs::kBraveAIChatUserCustomizationEnabled);
-  prefs_.ClearPref(prefs::kBraveAIChatUserMemoryEnabled);
-  prefs_.ClearPref(prefs::kBraveAIChatUserCustomizations);
 }
 
 TEST_F(EngineConsumerConversationAPIUnitTest,

--- a/components/ai_chat/core/browser/engine/engine_consumer_oai.h
+++ b/components/ai_chat/core/browser/engine/engine_consumer_oai.h
@@ -21,6 +21,8 @@
 template <class T>
 class scoped_refptr;
 
+class PrefService;
+
 namespace api_request_helper {
 class APIRequestResult;
 }  // namespace api_request_helper
@@ -38,7 +40,8 @@ class EngineConsumerOAIRemote : public EngineConsumer {
   explicit EngineConsumerOAIRemote(
       const mojom::CustomModelOptions& model_options,
       scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
-      ModelService* model_service);
+      ModelService* model_service,
+      PrefService* prefs);
   EngineConsumerOAIRemote(const EngineConsumerOAIRemote&) = delete;
   EngineConsumerOAIRemote& operator=(const EngineConsumerOAIRemote&) = delete;
   ~EngineConsumerOAIRemote() override;
@@ -87,6 +90,9 @@ class EngineConsumerOAIRemote : public EngineConsumer {
       uint32_t max_associated_content_length,
       int video_message_id,
       int page_message_id);
+
+  std::optional<base::Value::Dict> BuildUserMemoryMessage();
+
   void OnGenerateQuestionSuggestionsResponse(
       SuggestedQuestionsCallback callback,
       GenerationResult result);

--- a/components/ai_chat/core/browser/engine/mock_engine_consumer.cc
+++ b/components/ai_chat/core/browser/engine/mock_engine_consumer.cc
@@ -7,7 +7,7 @@
 
 namespace ai_chat {
 
-MockEngineConsumer::MockEngineConsumer() : EngineConsumer(nullptr) {}
+MockEngineConsumer::MockEngineConsumer() : EngineConsumer(nullptr, nullptr) {}
 MockEngineConsumer::~MockEngineConsumer() = default;
 
 }  // namespace ai_chat

--- a/components/ai_chat/core/browser/model_service.cc
+++ b/components/ai_chat/core/browser/model_service.cc
@@ -758,7 +758,7 @@ std::unique_ptr<EngineConsumer> ModelService::GetEngineForModel(
     auto& custom_model_opts = model->options->get_custom_model_options();
     DVLOG(1) << "Started AI engine: custom";
     engine = std::make_unique<EngineConsumerOAIRemote>(
-        *custom_model_opts, url_loader_factory, this);
+        *custom_model_opts, url_loader_factory, this, pref_service_);
   }
 
   return engine;

--- a/components/ai_chat/core/common/prefs.cc
+++ b/components/ai_chat/core/common/prefs.cc
@@ -86,4 +86,56 @@ void DeleteAllMemoriesFromPrefs(PrefService& prefs) {
   prefs.ClearPref(prefs::kBraveAIChatUserMemories);
 }
 
+std::optional<base::Value::Dict> GetUserMemoryDictFromPrefs(
+    PrefService& prefs) {
+  bool customization_enabled =
+      prefs.GetBoolean(prefs::kBraveAIChatUserCustomizationEnabled);
+  bool memory_enabled = prefs.GetBoolean(prefs::kBraveAIChatUserMemoryEnabled);
+  if (!customization_enabled && !memory_enabled) {
+    return std::nullopt;
+  }
+
+  base::Value::Dict user_memory;
+  if (customization_enabled) {
+    const base::Value::Dict& customizations_dict =
+        prefs.GetDict(prefs::kBraveAIChatUserCustomizations);
+
+    // Only set values when they have actual content
+    if (const std::string* name = customizations_dict.FindString("name")) {
+      if (!name->empty()) {
+        user_memory.Set("name", *name);
+      }
+    }
+    if (const std::string* job = customizations_dict.FindString("job")) {
+      if (!job->empty()) {
+        user_memory.Set("job", *job);
+      }
+    }
+    if (const std::string* tone = customizations_dict.FindString("tone")) {
+      if (!tone->empty()) {
+        user_memory.Set("tone", *tone);
+      }
+    }
+    if (const std::string* other = customizations_dict.FindString("other")) {
+      if (!other->empty()) {
+        user_memory.Set("other", *other);
+      }
+    }
+  }
+
+  if (memory_enabled) {
+    const base::Value::List& memories =
+        prefs.GetList(prefs::kBraveAIChatUserMemories);
+    if (!memories.empty()) {
+      user_memory.Set("memories", memories.Clone());
+    }
+  }
+
+  if (user_memory.empty()) {
+    return std::nullopt;
+  }
+
+  return user_memory;
+}
+
 }  // namespace ai_chat::prefs

--- a/components/ai_chat/core/common/prefs.h
+++ b/components/ai_chat/core/common/prefs.h
@@ -6,9 +6,11 @@
 #ifndef BRAVE_COMPONENTS_AI_CHAT_CORE_COMMON_PREFS_H_
 #define BRAVE_COMPONENTS_AI_CHAT_CORE_COMMON_PREFS_H_
 
+#include <optional>
 #include <string>
 #include <vector>
 
+#include "base/values.h"
 #include "brave/components/ai_chat/core/common/mojom/customization_settings.mojom-forward.h"
 
 class PrefService;
@@ -47,6 +49,9 @@ void DeleteMemoryFromPrefs(const std::string& memory, PrefService& prefs);
 // Resets the memories list in the pref.
 COMPONENT_EXPORT(AI_CHAT_COMMON)
 void DeleteAllMemoriesFromPrefs(PrefService& prefs);
+
+COMPONENT_EXPORT(AI_CHAT_COMMON)
+std::optional<base::Value::Dict> GetUserMemoryDictFromPrefs(PrefService& prefs);
 
 }  // namespace ai_chat::prefs
 

--- a/components/resources/ai_chat_prompts.grdp
+++ b/components/resources/ai_chat_prompts.grdp
@@ -125,6 +125,16 @@ You are **Leo**, a helpful AI assistant by Brave. Assist Brave browser users wit
 - **Markdown:** Use Markdown where appropriate, but do not include links or image URLs.
 </message>
 
+<message name="IDS_AI_CHAT_CUSTOM_MODEL_USER_MEMORY_SYSTEM_PROMPT_SEGMENT" translateable="false">
+- **Memory:** Use &lt;user_memory&gt; only when it clearly improves your reply, don’t use it for greetings or vague queries.
+</message>
+<message name="IDS_AI_CHAT_CUSTOM_MODEL_USER_MEMORY_PROMPT_SEGMENT" translateable="false">
+About this user:
+&lt;user_memory&gt;
+<ph name="USER_MEMORY">$1</ph>
+&lt;/user_memory&gt;
+</message>
+
 <message name="IDS_AI_CHAT_LLAMA2_GENERAL_SEED" translateable="false">
 Here is your response:</message>
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/47981

This commit implements support for user customizations and memories in
AI Chat custom models, enabling personalized AI interactions by
incorporating user-specific information into conversation contexts.

A similar system prompt instruction and user prompt template to what we
use on aichat backend for Leo models are added to support custom models,
which will be included into requests if customization and memories are
enabled. Values in customizations and memories preference will be HTML
escaped, similar to our aichat backend behavior.

Test plan:
1. Set up ollama custom model (reference: https://brave.com/blog/byom-nightly/#getting-started-using-local-models-with-byom-in-leo)
2. Create some customization & memory (put name, place, interest for example) in brave://settings/leo-ai/customization.
3. Open Leo in sidebar and choose ollama custom model
4. Ask a question related to the customization & memory (suggest a weekend plan for example), the response should be personalized based on your customization & memory.
5. Turn off switch for customization & memory in settings.
6. Create a new conversation and choose ollama custom model and ask the same question again, the response should not be personalized based on your customization & memory.
<img width="1208" height="1142" alt="Screenshot 2025-08-05 at 10 05 40 AM" src="https://github.com/user-attachments/assets/61d3de99-099b-4981-ac78-34ca54f1024d" />
<img width="1212" height="1242" alt="Screenshot 2025-08-05 at 10 06 54 AM" src="https://github.com/user-attachments/assets/347f5535-e919-4e3f-bcf5-ffe1ecd381fb" />

