### PR TITLE
[msan] Adding support on `.env` for `is_msan`

### DIFF
--- a/build/commands/lib/config.js
+++ b/build/commands/lib/config.js
@@ -288,6 +288,8 @@ const Config = function () {
     'gemini_sandbox_oauth_url',
     'google_default_client_id',
     'google_default_client_secret',
+    'is_msan',
+    'msan_track_origins',
     'rewards_grant_dev_endpoint',
     'rewards_grant_prod_endpoint',
     'rewards_grant_staging_endpoint',


### PR DESCRIPTION
This PR adds support for `is_msan` and `msan_track_origins` in
`config.js`. This is being done mostly to enable the sanitise in CI,
following what we did for `is_ubsan` there to.

There are two reasons why a `--is_msan` flag has not been added yet: 1)
we cannot run CI with `msan_track_origins=2`, but when investigating,
this value is most likely necessary at the engineers computer. This
means that CI already can't use the default we would have. 2) There has
been a lot of `msan` fixes, but there are still two tests that only fail
in CI, and it is not very clear why they fail, so we should let the door
open to introduce an exclusion file to this mode in the feature, if
that's deemed necessary, and having these values passed in through
`.env` will allow such a change to occur, without involving CI changes.

Resolves https://github.com/brave/brave-browser/issues/48182
