### PR TITLE
Don't provide -t to jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "web-ui": "webpack --config components/webpack/webpack.config.js",
     "build-storybook": "npm run build -- --target=brave:storybook && storybook build -c .storybook -o .storybook-out",
     "storybook": "storybook dev",
-    "test-unit": "jest -t",
+    "test-unit": "jest",
     "test-unit:wallet": "jest --coverage=false components/brave_wallet_ui",
     "test-python-scripts": "npm run pep8 && PYTHONPATH=./script python -m unittest discover -s ./script/test",
     "update_symlink": "node ./build/commands/scripts/commands.js update_symlink",


### PR DESCRIPTION
This enables us to filter tests whichever way we want, e.g. `npm run  test-unit -- ./a/path/to/feature/`

I'm not sure why we even have the param. Seeing if CI passes...

- Resolves https://github.com/brave/brave-browser/issues/48208
