### PR TITLE
Fix unwanted `WrapUnique` substitution on mac-rel

### DIFF
--- a/chromium_src/chrome/browser/ui/webui/help/version_updater_mac.mm
+++ b/chromium_src/chrome/browser/ui/webui/help/version_updater_mac.mm
@@ -14,6 +14,7 @@
 #include "base/notimplemented.h"
 #include "base/notreached.h"
 #include "base/strings/escape.h"
+#include "base/strings/stringprintf.h"
 #include "base/strings/sys_string_conversions.h"
 #include "base/strings/utf_string_conversions.h"
 #include "brave/browser/mac/keystone_glue.h"


### PR DESCRIPTION
This is a follow up to:
https://github.com/brave/brave-core/pull/30441

The latest nightly build had a build failure due to the removal of an
unused header for `base::StringPrintf`.

```
In file included from ../../brave/chromium_src/chrome/browser/ui/webui/help/version_updater_mac.mm:218:
In file included from ../../chrome/browser/ui/webui/help/version_updater_mac.mm:22:
In file included from ../../base/strings/stringprintf.h:16:
In file included from ../../third_party/abseil-cpp/absl/strings/str_format.h:84:
In file included from ../../third_party/abseil-cpp/absl/strings/internal/str_format/bind.h:24:
In file included from ../../third_party/abseil-cpp/absl/container/inlined_vector.h:55:
In file included from ../../third_party/abseil-cpp/absl/container/internal/inlined_vector.h:33:
../../third_party/abseil-cpp/absl/memory/memory.h:72:31: error: 'T' does not refer to a value
   72 | std::unique_ptr<T> WrapUnique(T* ptr) {
      |                               ^
../../brave/chromium_src/chrome/browser/ui/webui/help/version_updater_mac.mm:214:20: note: expanded from macro 'WrapUnique'
  214 |                  ? X                          \
      |                    ^
../../third_party/abseil-cpp/absl/memory/memory.h:71:20: note: declared here
   71 | template <typename T>
      |                    ^
../../third_party/abseil-cpp/absl/memory/memory.h:72:34: error: use of undeclared identifier 'ptr'
   72 | std::unique_ptr<T> WrapUnique(T* ptr) {
      |                                  ^~~
../../third_party/abseil-cpp/absl/memory/memory.h:72:38: error: expected ';' after top level declarator
   72 | std::unique_ptr<T> WrapUnique(T* ptr) {
      |                                      ^
      |                                      ;
3 errors generated.
```
