### PR TITLE
adds all.json and brave_test.json creation to gn

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -132,6 +132,8 @@ group("all") {
       "//brave/test:brave_junit_tests",
     ]
   }
+
+  write_file("$root_out_dir/all.json", deps, "json")
 }
 
 if (!is_ios) {
@@ -337,6 +339,8 @@ if (!is_ios) {
     if (use_libfuzzer) {
       deps += [ "//brave/fuzzers:brave_fuzzers" ]
     }
+
+    write_file("$root_out_dir/brave_tests.json", deps, "json")
   }
 }
 


### PR DESCRIPTION
This is not only added for consistency but also because it's needed for `getTestGroupDeps` to work correctly see:

https://github.com/brave/brave-core/blob/master/build/commands/lib/testUtils.js#L38

Remark: 
seems like you can use `deps` like any other variable directly and pass it to `write_file`. In other places we created a dedicated variable. Shall we remove the intermediate variables?


Just noticed all also has //brave as a dep; need to split it out after all