### PR TITLE
[CodeHealth] Add DCHECK(prefs) in Has/SetUserOptedIn

### DIFF
--- a/components/ai_chat/core/browser/utils.cc
+++ b/components/ai_chat/core/browser/utils.cc
@@ -126,20 +126,14 @@ bool IsAIChatEnabled(PrefService* prefs) {
 }
 
 bool HasUserOptedIn(PrefService* prefs) {
-  if (!prefs) {
-    return false;
-  }
-
+  DCHECK(prefs);
   base::Time last_accepted_disclaimer =
       prefs->GetTime(prefs::kLastAcceptedDisclaimer);
   return !last_accepted_disclaimer.is_null();
 }
 
 void SetUserOptedIn(PrefService* prefs, bool opted_in) {
-  if (!prefs) {
-    return;
-  }
-
+  DCHECK(prefs);
   if (opted_in) {
     prefs->SetTime(prefs::kLastAcceptedDisclaimer, base::Time::Now());
   } else {


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/48223

We were siliently bail out when prefs is null, which we should not.
This PR added DCHECK(prefs) like other methods in this file.