### PR TITLE
[AI Chat]: Leo Customization Save Button State

### DIFF
--- a/app/brave_settings_strings.grdp
+++ b/app/brave_settings_strings.grdp
@@ -1698,6 +1698,9 @@
   <message name="IDS_SETTINGS_LEO_ASSISTANT_CUSTOMIZATION_SAVE_BUTTON" desc="Label for the save changes button in Leo customization">
     Save changes
   </message>
+  <message name="IDS_SETTINGS_LEO_ASSISTANT_CUSTOMIZATION_CHANGES_SAVED" desc="Label for the save changes button in Leo customization when the changes are saved">
+    Changes saved
+  </message>
   <message name="IDS_SETTINGS_LEO_ASSISTANT_INPUT_LENGTH_ERROR" desc="General error message shown when any input exceeds the maximum length">
     Input is too long
   </message>

--- a/browser/resources/settings/brave_leo_assistant_page/customization_subpage.html
+++ b/browser/resources/settings/brave_leo_assistant_page/customization_subpage.html
@@ -76,7 +76,7 @@ You can obtain one at https://mozilla.org/MPL/2.0/. -->
   <div class="leo-customization-form">
     <leo-input
       placeholder="$i18n{braveLeoAssistantCustomizationNamePlaceholder}"
-      value="[[nameInput_]]" on-change="onNameInputChanged_"
+      value="[[nameInput_]]" on-input="onNameInputChanged_"
       showErrors$="[[isTooLong(nameInput_)]]">
       <span class="label-text">$i18n{braveLeoAssistantCustomizationNameLabel}</span>
       <div slot="errors" class="error-message" hidden$="[[!isTooLong(nameInput_)]]">
@@ -86,7 +86,7 @@ You can obtain one at https://mozilla.org/MPL/2.0/. -->
     </leo-input>
     <leo-input
       placeholder="$i18n{braveLeoAssistantCustomizationJobPlaceholder}"
-      value="[[jobInput_]]" on-change="onJobInputChanged_"
+      value="[[jobInput_]]" on-input="onJobInputChanged_"
       showErrors$="[[isTooLong(jobInput_)]]">
       <span class="label-text">$i18n{braveLeoAssistantCustomizationJobLabel}</span>
       <div slot="errors" class="error-message" hidden$="[[!isTooLong(jobInput_)]]">
@@ -96,7 +96,7 @@ You can obtain one at https://mozilla.org/MPL/2.0/. -->
     </leo-input>
     <leo-input
       placeholder="$i18n{braveLeoAssistantCustomizationTonePlaceholder}"
-      value="[[toneInput_]]" on-change="onToneInputChanged_"
+      value="[[toneInput_]]" on-input="onToneInputChanged_"
       showErrors$="[[isTooLong(toneInput_)]]">
       <span class="label-text">$i18n{braveLeoAssistantCustomizationToneLabel}</span>
       <div slot="errors" class="error-message" hidden$="[[!isTooLong(toneInput_)]]">
@@ -106,7 +106,7 @@ You can obtain one at https://mozilla.org/MPL/2.0/. -->
     </leo-input>
     <leo-input
       placeholder="$i18n{braveLeoAssistantCustomizationOtherPlaceholder}"
-      value="[[otherInput_]]" on-change="onOtherInputChanged_"
+      value="[[otherInput_]]" on-input="onOtherInputChanged_"
       showErrors$="[[isTooLong(otherInput_)]]">
       <span class="label-text">$i18n{braveLeoAssistantCustomizationOtherLabel}</span>
       <div slot="errors" class="error-message" hidden$="[[!isTooLong(otherInput_)]]">
@@ -115,7 +115,16 @@ You can obtain one at https://mozilla.org/MPL/2.0/. -->
       </div>
     </leo-input>
     <div class="actions">
-      <leo-button kind="outline" on-click="onSave" isDisabled$="[[isSaveDisabled_]]">$i18n{braveLeoAssistantCustomizationSaveButton}</leo-button>
+      <leo-button
+        kind="outline"
+        on-click="onSave"
+        isDisabled$="[[isSaveDisabled_]]"
+      >
+        [[getSaveButtonText_(changesSaved_)]]
+        <template is="dom-if" if="[[changesSaved_]]" restamp>
+          <leo-icon name="check-circle-outline" slot="icon-after"></leo-icon>
+        </template>
+      </leo-button>
     </div>
   </div>
 </template>

--- a/browser/ui/webui/settings/brave_settings_localized_strings_provider.cc
+++ b/browser/ui/webui/settings/brave_settings_localized_strings_provider.cc
@@ -614,6 +614,8 @@ void BraveAddCommonStrings(content::WebUIDataSource* html_source,
        IDS_SETTINGS_LEO_ASSISTANT_CUSTOMIZATION_OTHER_PLACEHOLDER},
       {"braveLeoAssistantCustomizationSaveButton",
        IDS_SETTINGS_LEO_ASSISTANT_CUSTOMIZATION_SAVE_BUTTON},
+      {"braveLeoAssistantCustomizationChangesSaved",
+       IDS_SETTINGS_LEO_ASSISTANT_CUSTOMIZATION_CHANGES_SAVED},
       {"braveLeoAssistantInputLengthError",
        IDS_SETTINGS_LEO_ASSISTANT_INPUT_LENGTH_ERROR},
 


### PR DESCRIPTION
## Description 

Adds state to the `Leo Customization` settings `Save changes` button

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/48005>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

## Test Plan:
1. Navigate to `brave://settings/leo-ai/customization`
2. The `Save changes` button should be `disabled` by default
3. Change an input value and the `Save changes` button should now be `enabled`
4. Click `Save changes` and the button should become `disabled` and the text should change to `Changes saved`
5. Change an input value and the it should change back to `Save changes` and be `enabled`.
6. Click `Save changes` again and it should become `disabled` and the text should change to `Changes saved`
7. Navigate away to some other settings page and then come back
8. The button should default back to `Save changes` and it should be `disabled` until you make a change.

https://github.com/user-attachments/assets/41bc076a-bf0e-4e57-98ca-a16543ddd706
