### PR TITLE
[Rewards] Disable self-custody invite on NTP widget (uplift to 1.82.x)

### DIFF
--- a/components/brave_new_tab_ui/components/default/rewards/index.tsx
+++ b/components/brave_new_tab_ui/components/default/rewards/index.tsx
@@ -17,10 +17,7 @@ import {
 } from '../../../../brave_rewards/resources/shared/lib/optional'
 
 import {
-  externalWalletFromExtensionData,
-  isExternalWalletProviderAllowed,
-  externalWalletProviderFromString,
-  isSelfCustodyProvider
+  externalWalletFromExtensionData
 } from '../../../../brave_rewards/resources/shared/lib/external_wallet'
 
 import {
@@ -76,26 +73,6 @@ export const RewardsWidget = createWidget((props: RewardsProps) => {
     return getProviderPayoutStatus(payoutStatus, walletProvider)
   }
 
-  const showSelfCustodyInvite = () => {
-    if (props.userType !== 'unconnected') {
-      return false
-    }
-    if (props.selfCustodyInviteDismissed) {
-      return false
-    }
-    const { walletProviderRegions } = props.parameters
-    for (const name of (props.externalWalletProviders || [])) {
-      const provider = externalWalletProviderFromString(name)
-      if (provider && isSelfCustodyProvider(provider)) {
-        const regions = (walletProviderRegions || {})[provider] || null
-        if (isExternalWalletProviderAllowed(props.declaredCountry, regions)) {
-          return true
-        }
-      }
-    }
-    return false
-  }
-
   const openRewardsPanel = () => {
     chrome.braveRewards.recordNTPPanelTrigger()
     chrome.braveRewards.openRewardsPanel()
@@ -121,7 +98,7 @@ export const RewardsWidget = createWidget((props: RewardsProps) => {
           minEarningsLastMonth={adsInfo ? adsInfo.minEarningsLastMonth : 0}
           maxEarningsLastMonth={adsInfo ? adsInfo.maxEarningsLastMonth : 0}
           contributionsThisMonth={props.totalContribution}
-          showSelfCustodyInvite={showSelfCustodyInvite()}
+          showSelfCustodyInvite={false}
           isTermsOfServiceUpdateRequired={props.isTermsOfServiceUpdateRequired}
           publishersVisited={props.publishersVisitedCount || 0}
           onEnableRewards={openRewardsPanel}


### PR DESCRIPTION
Uplift of #30491
Resolves https://github.com/brave/brave-browser/issues/48215

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.