### PR TITLE
[AI Chat]: Fix Suggested Questions Overlapping Menu

### DIFF
--- a/components/ai_chat/core/common/mojom/untrusted_frame.mojom
+++ b/components/ai_chat/core/common/mojom/untrusted_frame.mojom
@@ -35,6 +35,12 @@ interface ParentUIFrame {
   // a corresponding DragEnd because the parent should intercept the drag event
   // with an overlay.
   DragStart();
+
+  // This is sent to the parent trusted webui to allow settings the iframes
+  // wrapper position to relative while the Regenerate Answer Menu is open.
+  // Otherwise the menu can sometimes be overlapped by the Suggested question
+  // buttons.
+  RegenerateAnswerMenuIsOpen(bool is_open);
 };
 
 // Browser-side handler for untrusted frame that handles rendering of

--- a/components/ai_chat/resources/page/chat_ui.tsx
+++ b/components/ai_chat/resources/page/chat_ui.tsx
@@ -122,6 +122,24 @@ function ConversationEntries(props: ConversationEntriesProps) {
     }
   }, [props.onHeightChanged, props.onIsContentReady])
 
+  React.useEffect(() => {
+    // Set the iframe position to relative when the regenerate
+    // answer menu is open. Otherwise the menu can sometimes be
+    // overlapped by the Suggested question buttons.
+    const listener = (isOpen: boolean) => {
+      document.body.style.setProperty(
+        '--iframe-position-for-menus',
+        isOpen ? 'relative' : 'unset',
+      )
+    }
+    const id = api.conversationEntriesFrameObserver.regenerateAnswerMenuIsOpen
+      .addListener(listener)
+
+    return () => {
+      api.conversationEntriesFrameObserver.removeListener(id)
+    }
+  }, [])
+
   return (
     <iframe
       sandbox='allow-scripts allow-same-origin'

--- a/components/ai_chat/resources/page/components/main/style.module.scss
+++ b/components/ai_chat/resources/page/components/main/style.module.scss
@@ -243,6 +243,11 @@
   // added to the iframe.
   // See https://github.com/brave/brave-browser/issues/46042
   margin-bottom: calc(-1 * var(--iframe-additional-margin-for-menus));
+  // Position the iframe relative to the main content when the regenerate
+  // answer menu is open.
+  // Otherwise the menu can sometimes be overlapped by the Suggested question
+  // buttons.
+  position: var(--iframe-position-for-menus);
 }
 
 .aichatIframeContainer.dragActive {

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/context_actions_assistant/index.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/context_actions_assistant/index.tsx
@@ -57,6 +57,14 @@ export default function ContextActionsAssistant(
       model.key !== 'chat-automatic'
   )
 
+  const handleOpenCloseRegenerateAnswerMenu = React.useCallback(
+    (isOpen: boolean) => {
+      setIsRegenerateAnswerMenuOpen(isOpen)
+      conversationContext.parentUiFrame?.regenerateAnswerMenuIsOpen(isOpen)
+    },
+    [conversationContext],
+  )
+
   return (
     <div className={styles.actionsWrapper}>
       {props.onCopyTextClicked &&
@@ -107,8 +115,8 @@ export default function ContextActionsAssistant(
       {props.turnModelKey &&(
         <RegenerateAnswerMenu
           isOpen={isRegenerateAnswerMenuOpen}
-          onOpen={() => setIsRegenerateAnswerMenuOpen(true)}
-          onClose={() => setIsRegenerateAnswerMenuOpen(false)}
+          onOpen={() => handleOpenCloseRegenerateAnswerMenu(true)}
+          onClose={() => handleOpenCloseRegenerateAnswerMenu(false)}
           onRegenerate={handleRegenerateAnswer}
           leoModels={leoModels}
           turnModelKey={props.turnModelKey}


### PR DESCRIPTION
## Description 

Fixes a style bug where the `Suggested Question` buttons would sometimes overlap the `Regenerate Answer` menu.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/48256>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

## Test Plan:
1. Start a conversations with `Leo` ai with a `Tab` attached to the question
2. After you get an answer, open the `Regenerate Answer` menu
3. The `Suggested Questions` should not overlap the `Menu`

Before:

<img width="735" height="414" alt="Screenshot 8" src="https://github.com/user-attachments/assets/d0b4803f-cbc1-4803-ab99-164222727990" />

After:

<img width="717" height="401" alt="Screenshot 7" src="https://github.com/user-attachments/assets/a3d1965c-773b-4e39-b622-46880ce35090" />
