### PR TITLE
[Rewards] Enable self-custody providers flag by default (uplift to 1.81.x)

### DIFF
--- a/components/brave_rewards/core/features.cc
+++ b/components/brave_rewards/core/features.cc
@@ -31,7 +31,7 @@ BASE_FEATURE(kAllowUnsupportedWalletProvidersFeature,
 
 BASE_FEATURE(kAllowSelfCustodyProvidersFeature,
              "BraveRewardsAllowSelfCustodyProviders",
-             base::FEATURE_DISABLED_BY_DEFAULT);
+             base::FEATURE_ENABLED_BY_DEFAULT);
 
 BASE_FEATURE(kAnimatedBackgroundFeature,
              "BraveRewardsAnimatedBackground",


### PR DESCRIPTION
Uplift of #30526
Resolves https://github.com/brave/brave-browser/issues/48222

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.