### PR TITLE
AutoScreenshots should respect MAX_IMAGES limit

### DIFF
--- a/components/ai_chat/core/browser/conversation_handler.h
+++ b/components/ai_chat/core/browser/conversation_handler.h
@@ -278,6 +278,12 @@ class ConversationHandler : public mojom::ConversationHandler,
                            SelectedLanguage);
   FRIEND_TEST_ALL_PREFIXES(ConversationHandlerUnitTest_NoAssociatedContent,
                            ContentReceipt);
+  FRIEND_TEST_ALL_PREFIXES(ConversationHandlerUnitTest,
+                           OnAutoScreenshotsTaken_AppliesMaxImagesLimit);
+  FRIEND_TEST_ALL_PREFIXES(ConversationHandlerUnitTest,
+                           OnAutoScreenshotsTaken_NoLimitWhenUnderMax);
+  FRIEND_TEST_ALL_PREFIXES(ConversationHandlerUnitTest,
+                           OnAutoScreenshotsTaken_SamePercentageNoUIUpdate);
 
   struct Suggestion {
     std::string title;
@@ -318,7 +324,7 @@ class ConversationHandler : public mojom::ConversationHandler,
 
   void OnGeneratePageContentComplete(GetAllContentCallback callback,
                                      bool content_changed);
-  void OnScreenshotsTaken(
+  void OnAutoScreenshotsTaken(
       GetAllContentCallback callback,
       std::optional<std::vector<mojom::UploadedFilePtr>> screenshots);
 
@@ -386,6 +392,10 @@ class ConversationHandler : public mojom::ConversationHandler,
   // When this is true, the most recent content retrieval was different to the
   // previous one.
   bool is_content_different_ = true;
+
+  // Percentage of visual content used (0-100), tracks image truncation
+  // during screenshot capture due to MAX_IMAGES limits
+  std::optional<uint32_t> visual_content_used_percentage_;
 
   // Whether further assistant responses should be appended to the last or
   // created in a new sibling ConversationEntry.

--- a/components/ai_chat/core/common/mojom/ai_chat.mojom
+++ b/components/ai_chat/core/common/mojom/ai_chat.mojom
@@ -94,7 +94,7 @@ struct AssociatedContent {
 
   url.mojom.Url url;
 
-  // Percentage of the content that has been utilized by remote LLM (0-100)
+  // Percentage of the text content that has been utilized by remote LLM (0-100)
   int32 content_used_percentage;
 };
 
@@ -545,6 +545,10 @@ struct ConversationEntriesState {
   // How much of the content has been used by the AI engine, percentage,or null
   // if no content is associated.
   uint32? content_used_percentage;
+  // Percentage of the visual content that has been utilized by remote LLM
+  // (0-100)
+  // This tracks image/screenshot truncation due to MAX_IMAGES limits
+  uint32? visual_content_used_percentage;
   // Whether the UI should represent that the user cannot submit new messages
   // or edits to the conversation.
   bool can_submit_user_entries;

--- a/components/ai_chat/resources/page/stories/components_panel.tsx
+++ b/components/ai_chat/resources/page/stories/components_panel.tsx
@@ -651,6 +651,7 @@ type CustomArgs = {
   isDefaultConversation: boolean
   shouldShowLongConversationInfo: boolean
   shouldShowLongPageWarning: boolean
+  shouldShowLongVisualContentWarning: boolean
   totalTokens: number
   trimmedTokens: number
   isGenerating: boolean
@@ -691,6 +692,7 @@ const args: CustomArgs = {
   isDefaultConversation: true,
   shouldShowLongConversationInfo: false,
   shouldShowLongPageWarning: false,
+  shouldShowLongVisualContentWarning: false,
   totalTokens: 0,
   trimmedTokens: 0,
   isGenerating: false,
@@ -926,6 +928,8 @@ function StoryContext(props: React.PropsWithChildren<{ args: CustomArgs, setArgs
     isLeoModel: conversationContext.isCurrentModelLeo,
     contentUsedPercentage: options.args.shouldShowLongPageWarning
       ? 48 : 100,
+    visualContentUsedPercentage: options.args.shouldShowLongVisualContentWarning
+      ? 75 : undefined,
     totalTokens: BigInt(options.args.totalTokens),
     trimmedTokens: BigInt(options.args.trimmedTokens),
     canSubmitUserEntries: !conversationContext.shouldDisableUserInput,

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/conversation_entries/index.test.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/conversation_entries/index.test.tsx
@@ -324,7 +324,7 @@ describe('ConversationEntries visualContentUsedPercentage handling', () => {
     assistantResponseMock.mockClear()
   })
 
-  test('should show LongPageInfo when visualContentUsedPercentage is less than 100', () => {
+  test('should show visual content warning when visualContentUsedPercentage is less than 100', () => {
     const { container } = render(
       <MockContext
         conversationHistory={[createHumanTurn(), createAssistantTurn()]}
@@ -337,13 +337,13 @@ describe('ConversationEntries visualContentUsedPercentage handling', () => {
       </MockContext>
     )
 
-    // Should render LongPageInfo component when visual content is truncated
-    // We check for the info icon which is part of LongPageInfo
+    // Should render LongVisualContentWarning component when visual content is truncated
+    // We check for the info icon which is part of the warning components
     const infoElement = container.querySelector('leo-icon[name="info-outline"]')
     expect(infoElement).toBeInTheDocument()
   })
 
-  test('should show LongPageInfo when visualContentUsedPercentage is 0', () => {
+  test('should show visual content warning when visualContentUsedPercentage is 0', () => {
     const { container } = render(
       <MockContext
         conversationHistory={[createHumanTurn(), createAssistantTurn()]}
@@ -360,7 +360,7 @@ describe('ConversationEntries visualContentUsedPercentage handling', () => {
     expect(infoElement).toBeInTheDocument()
   })
 
-  test('should not show LongPageInfo when visualContentUsedPercentage is 100', () => {
+  test('should not show content warning when visualContentUsedPercentage is 100', () => {
     const { container } = render(
       <MockContext
         conversationHistory={[createHumanTurn(), createAssistantTurn()]}
@@ -373,12 +373,12 @@ describe('ConversationEntries visualContentUsedPercentage handling', () => {
       </MockContext>
     )
 
-    // Should not show LongPageInfo when no content truncation
+    // Should not show warning when no content truncation
     const infoElement = container.querySelector('leo-icon[name="info-outline"]')
     expect(infoElement).not.toBeInTheDocument()
   })
 
-  test('should not show LongPageInfo when visualContentUsedPercentage is undefined (defaults to 100)', () => {
+  test('should not show content warning when visualContentUsedPercentage is undefined (defaults to 100)', () => {
     const { container } = render(
       <MockContext
         conversationHistory={[createHumanTurn(), createAssistantTurn()]}
@@ -391,12 +391,12 @@ describe('ConversationEntries visualContentUsedPercentage handling', () => {
       </MockContext>
     )
 
-    // Should not show LongPageInfo when visualContentUsedPercentage is undefined
+    // Should not show warning when visualContentUsedPercentage is undefined
     const infoElement = container.querySelector('leo-icon[name="info-outline"]')
     expect(infoElement).not.toBeInTheDocument()
   })
 
-  test('should show LongPageInfo when both contentUsedPercentage and visualContentUsedPercentage are truncated', () => {
+  test('should show visual content warning when both contentUsedPercentage and visualContentUsedPercentage are truncated', () => {
     const { container } = render(
       <MockContext
         conversationHistory={[createHumanTurn(), createAssistantTurn()]}
@@ -409,12 +409,12 @@ describe('ConversationEntries visualContentUsedPercentage handling', () => {
       </MockContext>
     )
 
-    // Should show LongPageInfo (prioritizes visual content warning over page content warning)
+    // Should show visual content warning (prioritizes visual content warning over page content warning)
     const infoElement = container.querySelector('leo-icon[name="info-outline"]')
     expect(infoElement).toBeInTheDocument()
   })
 
-  test('should show LongPageInfo when visualContentUsedPercentage is fine but trimmed tokens exist', () => {
+  test('should show text content warning when visualContentUsedPercentage is fine but trimmed tokens exist', () => {
     const { container } = render(
       <MockContext
         conversationHistory={[createHumanTurn(), createAssistantTurn()]}
@@ -427,12 +427,12 @@ describe('ConversationEntries visualContentUsedPercentage handling', () => {
       </MockContext>
     )
 
-    // Should show LongPageInfo due to trimmed tokens (highest priority)
+    // Should show text content warning due to trimmed tokens (highest priority)
     const infoElement = container.querySelector('leo-icon[name="info-outline"]')
     expect(infoElement).toBeInTheDocument()
   })
 
-  test('should only show LongPageInfo for assistant responses, not human turns', () => {
+  test('should only show content warnings for assistant responses, not human turns', () => {
     const { container } = render(
       <MockContext
         conversationHistory={[createHumanTurn()]} // Only human turn
@@ -445,7 +445,7 @@ describe('ConversationEntries visualContentUsedPercentage handling', () => {
       </MockContext>
     )
 
-    // Should not show LongPageInfo for human-only conversation
+    // Should not show warnings for human-only conversation
     const infoElement = container.querySelector('leo-icon[name="info-outline"]')
     expect(infoElement).not.toBeInTheDocument()
   })

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/conversation_entries/index.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/conversation_entries/index.tsx
@@ -92,7 +92,8 @@ function ConversationEntries() {
             index === 1 &&
             isAIAssistant &&
             ((conversationContext.contentUsedPercentage ?? 100) < 100 ||
-              (conversationContext.trimmedTokens > 0 && conversationContext.totalTokens > 0))
+              (conversationContext.trimmedTokens > 0 && conversationContext.totalTokens > 0) ||
+              (conversationContext.visualContentUsedPercentage ?? 100) < 100)
 
           const showEditInput = editInputId === index
           const showEditIndicator = !showEditInput && !!group[0].edits?.length

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/conversation_entries/index.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/conversation_entries/index.tsx
@@ -16,7 +16,11 @@ import AssistantReasoning from '../assistant_reasoning'
 import ContextActionsAssistant from '../context_actions_assistant'
 import ContextMenuHuman from '../context_menu_human'
 import Quote from '../quote'
-import LongPageInfo from '../page_context_message/long_page_info'
+import {
+  LongPageContentWarning,
+  LongTextContentWarning,
+  LongVisualContentWarning
+} from '../page_context_message/long_page_info'
 import AssistantResponse from '../assistant_response'
 import EditInput from '../edit_input'
 import EditIndicator from '../edit_indicator'
@@ -234,7 +238,23 @@ function ConversationEntries() {
                           <ActionTypeLabel actionType={firstEntryEdit.actionType} />
                         )}
                         {firstEntryEdit.selectedText && <Quote text={firstEntryEdit.selectedText} />}
-                        {showLongPageContentInfo && <LongPageInfo />}
+                        {showLongPageContentInfo && (() => {
+                          if (conversationContext.trimmedTokens > 0 &&
+                              conversationContext.totalTokens > 0) {
+                            const percentage = 100 - Math.floor(
+                              (Number(conversationContext.trimmedTokens) /
+                               Number(conversationContext.totalTokens)) * 100)
+                            return <LongTextContentWarning
+                              percentageUsed={percentage} />
+                          } else if ((conversationContext.visualContentUsedPercentage ?? 100) < 100) {
+                            return <LongVisualContentWarning
+                              visualContentUsedPercentage={conversationContext.visualContentUsedPercentage!} />
+                          } else if ((conversationContext.contentUsedPercentage ?? 100) < 100) {
+                            return <LongPageContentWarning
+                              contentUsedPercentage={conversationContext.contentUsedPercentage!} />
+                          }
+                          return null
+                        })()}
                       </React.Fragment>
                     )
                   })}

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/page_context_message/long_page_info.test.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/page_context_message/long_page_info.test.tsx
@@ -5,8 +5,11 @@
 
 import * as React from 'react'
 import { render } from '@testing-library/react'
-import { UntrustedConversationReactContext } from '../../untrusted_conversation_context'
-import LongPageInfo from './long_page_info'
+import {
+  LongVisualContentWarning,
+  LongTextContentWarning,
+  LongPageContentWarning
+} from './long_page_info'
 
 // Mock the formatLocale function from $web-common/locale
 jest.mock('$web-common/locale', () => ({
@@ -24,50 +27,7 @@ jest.mock('$web-common/locale', () => ({
   }
 }))
 
-const mockContext = {
-  conversationHistory: [],
-  conversationUuid: '',
-  allModels: [],
-  currentModelKey: '',
-  contentUsedPercentage: undefined,
-  visualContentUsedPercentage: undefined,
-  trimmedTokens: BigInt(0),
-  totalTokens: BigInt(0),
-  canSubmitUserEntries: false,
-  hasGeneratedAssistantResponse: false,
-  generatePageContent: jest.fn(),
-  generateSuggestions: jest.fn(),
-  rateMessage: jest.fn(),
-  sendFeedback: jest.fn(),
-  modifyConversation: jest.fn(),
-  regenerateAnswer: jest.fn(),
-  setCurrentModel: jest.fn(),
-  submitHumanConversationEntry: jest.fn(),
-  submitSelectedTextWithAction: jest.fn(),
-  retryAPIRequest: jest.fn(),
-  clearAPIError: jest.fn(),
-  editMessageText: jest.fn(),
-  submitUserEntryWithAction: jest.fn(),
-  submitSummarizationRequest: jest.fn(),
-  stopGeneratingResponse: jest.fn(),
-  switchToModel: jest.fn(),
-  clearConversation: jest.fn(),
-  closeConversation: jest.fn(),
-  resetAssistantChatHistory: jest.fn(),
-  getPageContent: jest.fn(),
-  updateShouldDisableUserInput: jest.fn(),
-}
-
-const renderWithContext = (contextOverrides = {}) => {
-  const context = { ...mockContext, ...contextOverrides }
-  return render(
-    <UntrustedConversationReactContext.Provider value={context}>
-      <LongPageInfo />
-    </UntrustedConversationReactContext.Provider>
-  )
-}
-
-describe('LongPageInfo', () => {
+describe('Long Page Warning Components', () => {
   beforeEach(() => {
     // Mock the global S object
     global.S = {
@@ -81,140 +41,73 @@ describe('LongPageInfo', () => {
     jest.restoreAllMocks()
   })
 
-  describe('visualContentUsedPercentage handling', () => {
-    test('should show visual content warning when visualContentUsedPercentage is less than 100', () => {
-      const { getByText } = renderWithContext({
-        visualContentUsedPercentage: 75,
-        contentUsedPercentage: 85,
-        trimmedTokens: BigInt(0),
-        totalTokens: BigInt(0),
-      })
+  describe('LongVisualContentWarning', () => {
+    test('should display visual content warning with correct percentage', () => {
+      const { getByText } = render(
+        <LongVisualContentWarning visualContentUsedPercentage={75} />
+      )
 
       expect(getByText('Only 75% of visual content could be used')).toBeInTheDocument()
     })
 
-    test('should show visual content warning when visualContentUsedPercentage is 0', () => {
-      const { getByText } = renderWithContext({
-        visualContentUsedPercentage: 0,
-        contentUsedPercentage: 100,
-        trimmedTokens: BigInt(0),
-        totalTokens: BigInt(0),
-      })
+    test('should display visual content warning with 0%', () => {
+      const { getByText } = render(
+        <LongVisualContentWarning visualContentUsedPercentage={0} />
+      )
 
       expect(getByText('Only 0% of visual content could be used')).toBeInTheDocument()
     })
 
-    test('should not show visual content warning when visualContentUsedPercentage is 100', () => {
-      const { queryByText, getByText } = renderWithContext({
-        visualContentUsedPercentage: 100,
-        contentUsedPercentage: 80,
-        trimmedTokens: BigInt(0),
-        totalTokens: BigInt(0),
-      })
-
-      // Should show page content warning instead
-      expect(queryByText(/visual content could be used/)).not.toBeInTheDocument()
-      expect(getByText('80% of the page content was used')).toBeInTheDocument()
-    })
-
-    test('should not show visual content warning when visualContentUsedPercentage is undefined', () => {
-      const { queryByText, getByText } = renderWithContext({
-        visualContentUsedPercentage: undefined,
-        contentUsedPercentage: 90,
-        trimmedTokens: BigInt(0),
-        totalTokens: BigInt(0),
-      })
-
-      // Should show page content warning instead (undefined defaults to 100)
-      expect(queryByText(/visual content could be used/)).not.toBeInTheDocument()
-      expect(getByText('90% of the page content was used')).toBeInTheDocument()
-    })
-  })
-
-  describe('warning priority order', () => {
-    test('should prioritize trimmed tokens warning over visual content warning', () => {
-      const { queryByText, getByText } = renderWithContext({
-        visualContentUsedPercentage: 50,
-        contentUsedPercentage: 80,
-        trimmedTokens: BigInt(100),
-        totalTokens: BigInt(1000),
-      })
-
-      // Should show trimmed tokens warning (90% used)
-      expect(getByText('90% of the content was used')).toBeInTheDocument()
-      expect(queryByText(/visual content could be used/)).not.toBeInTheDocument()
-    })
-
-    test('should prioritize visual content warning over page content warning', () => {
-      const { queryByText, getByText } = renderWithContext({
-        visualContentUsedPercentage: 60,
-        contentUsedPercentage: 70,
-        trimmedTokens: BigInt(0),
-        totalTokens: BigInt(0),
-      })
-
-      // Should show visual content warning
-      expect(getByText('Only 60% of visual content could be used')).toBeInTheDocument()
-      expect(queryByText(/page content was used/)).not.toBeInTheDocument()
-    })
-
-    test('should show page content warning when no other warnings apply', () => {
-      const { getByText } = renderWithContext({
-        visualContentUsedPercentage: 100,
-        contentUsedPercentage: 85,
-        trimmedTokens: BigInt(0),
-        totalTokens: BigInt(0),
-      })
-
-      expect(getByText('85% of the page content was used')).toBeInTheDocument()
-    })
-  })
-
-  describe('edge cases', () => {
-    test('should handle null visualContentUsedPercentage (defaults to 100)', () => {
-      const { queryByText, getByText } = renderWithContext({
-        visualContentUsedPercentage: null,
-        contentUsedPercentage: 75,
-        trimmedTokens: BigInt(0),
-        totalTokens: BigInt(0),
-      })
-
-      // null should be treated as 100% (no visual content warning)
-      expect(queryByText(/visual content could be used/)).not.toBeInTheDocument()
-      expect(getByText('75% of the page content was used')).toBeInTheDocument()
-    })
-
-    test('should handle very low visual content percentage', () => {
-      const { getByText } = renderWithContext({
-        visualContentUsedPercentage: 1,
-        contentUsedPercentage: 100,
-        trimmedTokens: BigInt(0),
-        totalTokens: BigInt(0),
-      })
-
-      expect(getByText('Only 1% of visual content could be used')).toBeInTheDocument()
-    })
-
-    test('should handle very high visual content percentage (just under 100)', () => {
-      const { getByText } = renderWithContext({
-        visualContentUsedPercentage: 99,
-        contentUsedPercentage: 100,
-        trimmedTokens: BigInt(0),
-        totalTokens: BigInt(0),
-      })
+    test('should display visual content warning with 99%', () => {
+      const { getByText } = render(
+        <LongVisualContentWarning visualContentUsedPercentage={99} />
+      )
 
       expect(getByText('Only 99% of visual content could be used')).toBeInTheDocument()
     })
   })
 
+  describe('LongTextContentWarning', () => {
+    test('should display text content warning with correct percentage', () => {
+      const { getByText } = render(
+        <LongTextContentWarning percentageUsed={90} />
+      )
+
+      expect(getByText('90% of the content was used')).toBeInTheDocument()
+    })
+
+    test('should display text content warning with low percentage', () => {
+      const { getByText } = render(
+        <LongTextContentWarning percentageUsed={25} />
+      )
+
+      expect(getByText('25% of the content was used')).toBeInTheDocument()
+    })
+  })
+
+  describe('LongPageContentWarning', () => {
+    test('should display page content warning with correct percentage', () => {
+      const { getByText } = render(
+        <LongPageContentWarning contentUsedPercentage={85} />
+      )
+
+      expect(getByText('85% of the page content was used')).toBeInTheDocument()
+    })
+
+    test('should display page content warning with low percentage', () => {
+      const { getByText } = render(
+        <LongPageContentWarning contentUsedPercentage={50} />
+      )
+
+      expect(getByText('50% of the page content was used')).toBeInTheDocument()
+    })
+  })
+
   describe('component structure', () => {
     test('should render with info icon', () => {
-      const { container } = renderWithContext({
-        visualContentUsedPercentage: 80,
-        contentUsedPercentage: 100,
-        trimmedTokens: BigInt(0),
-        totalTokens: BigInt(0),
-      })
+      const { container } = render(
+        <LongVisualContentWarning visualContentUsedPercentage={80} />
+      )
 
       // Check for icon (leo-icon with name 'info-outline')
       const icon = container.querySelector('leo-icon[name="info-outline"]')
@@ -222,12 +115,9 @@ describe('LongPageInfo', () => {
     })
 
     test('should have correct CSS class structure', () => {
-      const { container } = renderWithContext({
-        visualContentUsedPercentage: 80,
-        contentUsedPercentage: 100,
-        trimmedTokens: BigInt(0),
-        totalTokens: BigInt(0),
-      })
+      const { container } = render(
+        <LongPageContentWarning contentUsedPercentage={75} />
+      )
 
       // Check for info container with CSS class
       const infoDiv = container.querySelector('div[class*="info"]')

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/page_context_message/long_page_info.test.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/page_context_message/long_page_info.test.tsx
@@ -1,0 +1,237 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import * as React from 'react'
+import { render } from '@testing-library/react'
+import { UntrustedConversationReactContext } from '../../untrusted_conversation_context'
+import LongPageInfo from './long_page_info'
+
+// Mock the formatLocale function from $web-common/locale
+jest.mock('$web-common/locale', () => ({
+  formatLocale: (key: string, params?: Record<string, string>) => {
+    if (key === 'CHAT_UI_VISUAL_CONTENT_TOO_MUCH_WARNING') {
+      return `Only ${params?.$1} of visual content could be used`
+    }
+    if (key === 'CHAT_UI_TRIMMED_TOKENS_WARNING') {
+      return `${params?.$1} of the content was used`
+    }
+    if (key === 'CHAT_UI_PAGE_CONTENT_TOO_LONG_WARNING') {
+      return `${params?.$1} of the page content was used`
+    }
+    return key
+  }
+}))
+
+const mockContext = {
+  conversationHistory: [],
+  conversationUuid: '',
+  allModels: [],
+  currentModelKey: '',
+  contentUsedPercentage: undefined,
+  visualContentUsedPercentage: undefined,
+  trimmedTokens: BigInt(0),
+  totalTokens: BigInt(0),
+  canSubmitUserEntries: false,
+  hasGeneratedAssistantResponse: false,
+  generatePageContent: jest.fn(),
+  generateSuggestions: jest.fn(),
+  rateMessage: jest.fn(),
+  sendFeedback: jest.fn(),
+  modifyConversation: jest.fn(),
+  regenerateAnswer: jest.fn(),
+  setCurrentModel: jest.fn(),
+  submitHumanConversationEntry: jest.fn(),
+  submitSelectedTextWithAction: jest.fn(),
+  retryAPIRequest: jest.fn(),
+  clearAPIError: jest.fn(),
+  editMessageText: jest.fn(),
+  submitUserEntryWithAction: jest.fn(),
+  submitSummarizationRequest: jest.fn(),
+  stopGeneratingResponse: jest.fn(),
+  switchToModel: jest.fn(),
+  clearConversation: jest.fn(),
+  closeConversation: jest.fn(),
+  resetAssistantChatHistory: jest.fn(),
+  getPageContent: jest.fn(),
+  updateShouldDisableUserInput: jest.fn(),
+}
+
+const renderWithContext = (contextOverrides = {}) => {
+  const context = { ...mockContext, ...contextOverrides }
+  return render(
+    <UntrustedConversationReactContext.Provider value={context}>
+      <LongPageInfo />
+    </UntrustedConversationReactContext.Provider>
+  )
+}
+
+describe('LongPageInfo', () => {
+  beforeEach(() => {
+    // Mock the global S object
+    global.S = {
+      CHAT_UI_VISUAL_CONTENT_TOO_MUCH_WARNING: 'CHAT_UI_VISUAL_CONTENT_TOO_MUCH_WARNING',
+      CHAT_UI_TRIMMED_TOKENS_WARNING: 'CHAT_UI_TRIMMED_TOKENS_WARNING',
+      CHAT_UI_PAGE_CONTENT_TOO_LONG_WARNING: 'CHAT_UI_PAGE_CONTENT_TOO_LONG_WARNING'
+    }
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe('visualContentUsedPercentage handling', () => {
+    test('should show visual content warning when visualContentUsedPercentage is less than 100', () => {
+      const { getByText } = renderWithContext({
+        visualContentUsedPercentage: 75,
+        contentUsedPercentage: 85,
+        trimmedTokens: BigInt(0),
+        totalTokens: BigInt(0),
+      })
+
+      expect(getByText('Only 75% of visual content could be used')).toBeInTheDocument()
+    })
+
+    test('should show visual content warning when visualContentUsedPercentage is 0', () => {
+      const { getByText } = renderWithContext({
+        visualContentUsedPercentage: 0,
+        contentUsedPercentage: 100,
+        trimmedTokens: BigInt(0),
+        totalTokens: BigInt(0),
+      })
+
+      expect(getByText('Only 0% of visual content could be used')).toBeInTheDocument()
+    })
+
+    test('should not show visual content warning when visualContentUsedPercentage is 100', () => {
+      const { queryByText, getByText } = renderWithContext({
+        visualContentUsedPercentage: 100,
+        contentUsedPercentage: 80,
+        trimmedTokens: BigInt(0),
+        totalTokens: BigInt(0),
+      })
+
+      // Should show page content warning instead
+      expect(queryByText(/visual content could be used/)).not.toBeInTheDocument()
+      expect(getByText('80% of the page content was used')).toBeInTheDocument()
+    })
+
+    test('should not show visual content warning when visualContentUsedPercentage is undefined', () => {
+      const { queryByText, getByText } = renderWithContext({
+        visualContentUsedPercentage: undefined,
+        contentUsedPercentage: 90,
+        trimmedTokens: BigInt(0),
+        totalTokens: BigInt(0),
+      })
+
+      // Should show page content warning instead (undefined defaults to 100)
+      expect(queryByText(/visual content could be used/)).not.toBeInTheDocument()
+      expect(getByText('90% of the page content was used')).toBeInTheDocument()
+    })
+  })
+
+  describe('warning priority order', () => {
+    test('should prioritize trimmed tokens warning over visual content warning', () => {
+      const { queryByText, getByText } = renderWithContext({
+        visualContentUsedPercentage: 50,
+        contentUsedPercentage: 80,
+        trimmedTokens: BigInt(100),
+        totalTokens: BigInt(1000),
+      })
+
+      // Should show trimmed tokens warning (90% used)
+      expect(getByText('90% of the content was used')).toBeInTheDocument()
+      expect(queryByText(/visual content could be used/)).not.toBeInTheDocument()
+    })
+
+    test('should prioritize visual content warning over page content warning', () => {
+      const { queryByText, getByText } = renderWithContext({
+        visualContentUsedPercentage: 60,
+        contentUsedPercentage: 70,
+        trimmedTokens: BigInt(0),
+        totalTokens: BigInt(0),
+      })
+
+      // Should show visual content warning
+      expect(getByText('Only 60% of visual content could be used')).toBeInTheDocument()
+      expect(queryByText(/page content was used/)).not.toBeInTheDocument()
+    })
+
+    test('should show page content warning when no other warnings apply', () => {
+      const { getByText } = renderWithContext({
+        visualContentUsedPercentage: 100,
+        contentUsedPercentage: 85,
+        trimmedTokens: BigInt(0),
+        totalTokens: BigInt(0),
+      })
+
+      expect(getByText('85% of the page content was used')).toBeInTheDocument()
+    })
+  })
+
+  describe('edge cases', () => {
+    test('should handle null visualContentUsedPercentage (defaults to 100)', () => {
+      const { queryByText, getByText } = renderWithContext({
+        visualContentUsedPercentage: null,
+        contentUsedPercentage: 75,
+        trimmedTokens: BigInt(0),
+        totalTokens: BigInt(0),
+      })
+
+      // null should be treated as 100% (no visual content warning)
+      expect(queryByText(/visual content could be used/)).not.toBeInTheDocument()
+      expect(getByText('75% of the page content was used')).toBeInTheDocument()
+    })
+
+    test('should handle very low visual content percentage', () => {
+      const { getByText } = renderWithContext({
+        visualContentUsedPercentage: 1,
+        contentUsedPercentage: 100,
+        trimmedTokens: BigInt(0),
+        totalTokens: BigInt(0),
+      })
+
+      expect(getByText('Only 1% of visual content could be used')).toBeInTheDocument()
+    })
+
+    test('should handle very high visual content percentage (just under 100)', () => {
+      const { getByText } = renderWithContext({
+        visualContentUsedPercentage: 99,
+        contentUsedPercentage: 100,
+        trimmedTokens: BigInt(0),
+        totalTokens: BigInt(0),
+      })
+
+      expect(getByText('Only 99% of visual content could be used')).toBeInTheDocument()
+    })
+  })
+
+  describe('component structure', () => {
+    test('should render with info icon', () => {
+      const { container } = renderWithContext({
+        visualContentUsedPercentage: 80,
+        contentUsedPercentage: 100,
+        trimmedTokens: BigInt(0),
+        totalTokens: BigInt(0),
+      })
+
+      // Check for icon (leo-icon with name 'info-outline')
+      const icon = container.querySelector('leo-icon[name="info-outline"]')
+      expect(icon).toBeInTheDocument()
+    })
+
+    test('should have correct CSS class structure', () => {
+      const { container } = renderWithContext({
+        visualContentUsedPercentage: 80,
+        contentUsedPercentage: 100,
+        trimmedTokens: BigInt(0),
+        totalTokens: BigInt(0),
+      })
+
+      // Check for info container with CSS class
+      const infoDiv = container.querySelector('div[class*="info"]')
+      expect(infoDiv).toBeInTheDocument()
+    })
+  })
+})

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/page_context_message/long_page_info.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/page_context_message/long_page_info.tsx
@@ -11,11 +11,16 @@ import styles from './style.module.scss'
 
 export default function LongPageInfo() {
   const context = useUntrustedConversationContext()
+
   let warningText
   if (context.trimmedTokens > 0 && context.totalTokens > 0) {
       const percentage = 100 - Math.floor((Number(context.trimmedTokens) / Number(context.totalTokens)) * 100)
       warningText = formatLocale(S.CHAT_UI_TRIMMED_TOKENS_WARNING, {
         $1: percentage + '%'
+      })
+  } else if ((context.visualContentUsedPercentage ?? 100) < 100) {
+    warningText = formatLocale(S.CHAT_UI_VISUAL_CONTENT_TOO_MUCH_WARNING, {
+        $1: context.visualContentUsedPercentage + '%'
       })
   } else {
     warningText = formatLocale(S.CHAT_UI_PAGE_CONTENT_TOO_LONG_WARNING, {

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/page_context_message/long_page_info.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/page_context_message/long_page_info.tsx
@@ -6,28 +6,9 @@
 import * as React from 'react'
 import Icon from '@brave/leo/react/icon'
 import { formatLocale } from '$web-common/locale'
-import { useUntrustedConversationContext } from '../../untrusted_conversation_context'
 import styles from './style.module.scss'
 
-export default function LongPageInfo() {
-  const context = useUntrustedConversationContext()
-
-  let warningText
-  if (context.trimmedTokens > 0 && context.totalTokens > 0) {
-      const percentage = 100 - Math.floor((Number(context.trimmedTokens) / Number(context.totalTokens)) * 100)
-      warningText = formatLocale(S.CHAT_UI_TRIMMED_TOKENS_WARNING, {
-        $1: percentage + '%'
-      })
-  } else if ((context.visualContentUsedPercentage ?? 100) < 100) {
-    warningText = formatLocale(S.CHAT_UI_VISUAL_CONTENT_TOO_MUCH_WARNING, {
-        $1: context.visualContentUsedPercentage + '%'
-      })
-  } else {
-    warningText = formatLocale(S.CHAT_UI_PAGE_CONTENT_TOO_LONG_WARNING, {
-        $1: context.contentUsedPercentage + '%'
-      })
-  }
-
+function LongPageInfoInternal({ warningText }: { warningText: string }) {
   return (
     <div className={styles.info}>
       <Icon name='info-outline' />
@@ -35,3 +16,37 @@ export default function LongPageInfo() {
     </div>
   )
 }
+
+export function LongVisualContentWarning({
+  visualContentUsedPercentage
+}: {
+  visualContentUsedPercentage: number
+}) {
+  return <LongPageInfoInternal warningText={formatLocale(
+    S.CHAT_UI_VISUAL_CONTENT_TOO_MUCH_WARNING, {
+      $1: visualContentUsedPercentage + '%'
+    })} />
+}
+
+export function LongTextContentWarning({
+  percentageUsed
+}: {
+  percentageUsed: number
+}) {
+  return <LongPageInfoInternal warningText={formatLocale(
+    S.CHAT_UI_TRIMMED_TOKENS_WARNING, {
+      $1: percentageUsed + '%'
+    })} />
+}
+
+export function LongPageContentWarning({
+  contentUsedPercentage
+}: {
+  contentUsedPercentage: number
+}) {
+  return <LongPageInfoInternal warningText={formatLocale(
+    S.CHAT_UI_PAGE_CONTENT_TOO_LONG_WARNING, {
+      $1: contentUsedPercentage + '%'
+    })} />
+}
+

--- a/components/ai_chat/resources/untrusted_conversation_frame/untrusted_conversation_frame_api.ts
+++ b/components/ai_chat/resources/untrusted_conversation_frame/untrusted_conversation_frame_api.ts
@@ -23,6 +23,7 @@ export const defaultConversationEntriesUIState: ConversationEntriesUIState = {
   allModels: [],
   currentModelKey: '',
   contentUsedPercentage: undefined,
+  visualContentUsedPercentage: undefined,
   trimmedTokens: BigInt(0),
   totalTokens: BigInt(0),
   canSubmitUserEntries: false,

--- a/components/resources/ai_chat_ui_strings.grdp
+++ b/components/resources/ai_chat_ui_strings.grdp
@@ -372,6 +372,9 @@
   <message name="IDS_CHAT_UI_TRIMMED_TOKENS_WARNING" desc="A warning issued when the user is trying to summarize a long content page" formatter_data="webui=AiChat">
     Some context could be missing from the conversation. Leo was able to retain <ph name="PERCENTAGE">$1<ex>75.5%</ex></ph> of the conversation's associated content.
   </message>
+  <message name="IDS_CHAT_UI_VISUAL_CONTENT_TOO_MUCH_WARNING" desc="A warning issued when too many images are captured and some had to be discarded due to limits" formatter_data="webui=AiChat">
+    Too many images were captured from the page. Leo was able to use <ph name="PERCENTAGE">$1<ex>75.5%</ex></ph> of the available visual content.
+  </message>
   <message name="IDS_CHAT_UI_CONVERSATION_END_ERROR" desc="An error issued when the user cannot continue chatting" formatter_data="webui=AiChat">
     This conversation is too long and cannot continue. There may be other models available with which Leo is capable of maintaining accuracy for longer conversations.
   </message>


### PR DESCRIPTION

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/48269

Backend initiated screenshots will now respect the max images limit before submitting it to prevent error from LLM.
When some screenshots are truncated, we will show vision content use percentage warning to users.

## Test plan
1. Navigate to long content site that will trigger autoscreenshots ex. https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1299
2. Open Leo and summarize the page with context
3. There should be no error and be able to get summary
4. It should display vision content usage like
<img width="758" height="923" alt="Screenshot 2025-08-08 at 16 55 19" src="https://github.com/user-attachments/assets/bf4d6f4f-8942-4e64-aace-4f7c1032f55b" />

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
