### PR TITLE
Remove profile migration for legacy users from 5y ago

### DIFF
--- a/browser/profiles/brave_profile_manager.cc
+++ b/browser/profiles/brave_profile_manager.cc
@@ -108,7 +108,6 @@ void RecordInitialP3AValues(Profile* profile) {
 
 BraveProfileManager::BraveProfileManager(const base::FilePath& user_data_dir)
     : ProfileManager(user_data_dir) {
-  MigrateProfileNames();
 }
 
 size_t BraveProfileManager::GetNumberOfProfiles() {
@@ -231,29 +230,6 @@ void BraveProfileManager::SetNonPersonalProfilePrefs(Profile* profile) {
   prefs->SetBoolean(bookmarks::prefs::kShowBookmarkBar, false);
 }
 
-void BraveProfileManager::MigrateProfileNames() {
-#if !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_CHROMEOS)
-  // If any profiles have a default name using an
-  // older version of the default name string format,
-  // then name it with the new default name string format.
-  // e.g. 'Person X' --> 'Profile X'.
-  ProfileAttributesStorage& storage = GetProfileAttributesStorage();
-  std::vector<ProfileAttributesEntry*> entries =
-      storage.GetAllProfilesAttributesSortedByNameWithCheck();
-  // Make sure we keep the numbering the same.
-  for (auto* entry : entries) {
-    // Rename the necessary profiles. Don't check for legacy names as profile
-    // info cache should have migrated them by now.
-    if (entry->IsUsingDefaultName() &&
-        !storage.IsDefaultProfileName(
-            entry->GetName(),
-            /*include_check_for_legacy_profile_name=*/false)) {
-      entry->SetLocalProfileName(storage.ChooseNameForNewProfile(),
-                                 /*is_default_name=*/true);
-    }
-  }
-#endif
-}
 
 BraveProfileManagerWithoutInit::BraveProfileManagerWithoutInit(
     const base::FilePath& user_data_dir)

--- a/browser/profiles/brave_profile_manager.h
+++ b/browser/profiles/brave_profile_manager.h
@@ -27,8 +27,6 @@ class BraveProfileManager : public ProfileManager {
   void DoFinalInitForServices(Profile* profile,
                               bool go_off_the_record) override;
 
- private:
-  void MigrateProfileNames();
 };
 
 class BraveProfileManagerWithoutInit : public BraveProfileManager {


### PR DESCRIPTION
The migration was no longer needed because:
- It was added in 2019 (5+ years ago)
- Only migrated "Person X" → "Profile X" for legacy users
- Tests were disabled for 4+ years, indicating lack of active maintenance
- Any users needing migration would have been migrated long ago

It was introduced at first here af4f1e901aba92a3e19ac4263a95368c777b7fe9 The test was originally dsiabled here 27bf9e3b0b972bdfbe402998548d7a0ae1985846

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/48290

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
