### PR TITLE
[Customize Chrome] Replace 'Appearance' section header with 'Theme and colors'

### DIFF
--- a/app/brave_generated_resources.grd
+++ b/app/brave_generated_resources.grd
@@ -1461,6 +1461,9 @@ Or change later at <ph name="SETTINGS_EXTENIONS_LINK">$2<ex>brave://settings/ext
       <message name="IDS_BRAVE_CUSTOMIZE_MENU_TOOLBAR_LABEL" desc="The label for the option to customize toolbar icons in the customization menu on the New Tab Page. This is a button which opens a panel for customizing toolbar icons when clicked.">
         Customize toolbar
       </message>
+      <message name="IDS_BRAVE_NTP_CUSTOMIZE_APPEARANCE_LABEL" desc="The label for header of the customize appearance section in customize chrome side panel">
+        Theme and colors
+      </message>
       <!--Add new items to the appropriate sections above -->
     </messages>
   </release>

--- a/chromium_src/chrome/browser/ui/webui/side_panel/customize_chrome/customize_chrome_ui.cc
+++ b/chromium_src/chrome/browser/ui/webui/side_panel/customize_chrome/customize_chrome_ui.cc
@@ -6,6 +6,7 @@
 #include "chrome/browser/ui/webui/side_panel/customize_chrome/customize_chrome_ui.h"
 
 #include "brave/browser/ui/webui/cr_components/customize_color_scheme_mode/brave_customize_color_scheme_mode_handler.h"
+#include "chrome/grit/generated_resources.h"
 #include "content/public/browser/web_ui_data_source.h"
 
 #define AddLocalizedStrings(...)                               \
@@ -16,8 +17,14 @@
 #define CreateCustomizeColorSchemeModeHandler \
   CreateCustomizeColorSchemeModeHandler_Unused
 
+// Replaces IDS_NTP_CUSTOMIZE_APPEARANCE_LABEL with a Brave-specific label.
+#undef IDS_NTP_CUSTOMIZE_APPEARANCE_LABEL
+#define IDS_NTP_CUSTOMIZE_APPEARANCE_LABEL \
+  IDS_BRAVE_NTP_CUSTOMIZE_APPEARANCE_LABEL
+
 #include <chrome/browser/ui/webui/side_panel/customize_chrome/customize_chrome_ui.cc>
 
+#undef IDS_NTP_CUSTOMIZE_APPEARANCE_LABEL
 #undef CreateCustomizeColorSchemeModeHandler
 #undef CreatePageHandler
 #undef AddLocalizedStrings


### PR DESCRIPTION
As requested, this commit replaces the header label for the appearance section in the customize chrome side panel from "Appearance" to "Theme and colors". This change is reflected in the resource file and the UI code that handles the customization panel.

<img width="316" height="522" alt="image" src="https://github.com/user-attachments/assets/2b623bab-4e7d-4e5e-8f61-43e8ba53a7a5" />

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/48321

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
