### PR TITLE
Remove duplicate upstream tests on CI

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -68,7 +68,7 @@ group("chromium_unit_tests") {
   testonly = true
   data_deps = chromium_unit_tests_deps
   write_file("$root_out_dir/chromium_unit_tests.json",
-             chromium_unit_tests_deps,
+             [],
              "json")
 }
 

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -93,10 +93,9 @@ group("brave_all_unit_tests") {
              brave_all_unit_tests_deps,
              "json")
 
-  # This is a workaround to prevent upstream component units from
-  # building or running by default for except on CI
+  # Add here additional unit tests you want to run on CI
   write_file("$root_out_dir/brave_all_unit_tests_ci.json",
-             chromium_unit_tests_deps,
+             [],
              "json")
 }
 


### PR DESCRIPTION
@mkarolin noticed that the CI runs the upstream test suites twice. 
Looking at the issue we find the following:


We define groups of tests in gn and the result is as follows:

```
git:(master) ✗ cat ../out/Static_arm64/brave_all_unit_tests.json   
[
  "//brave/components:brave_components_unittests",
  "//brave/test:brave_unit_tests",
  "//brave/test:brave_installer_unittests"
]%   

➜  brave git:(master) ✗ cat ../out/Static_arm64/brave_all_unit_tests_ci.json 
[
  "//base:base_unittests",
  "//net:net_unittests",
  "//chrome/test:unit_tests",
  "//content/test:content_unittests",
  "//components:components_unittests"
]%     
                                                                                                                                                                                                                              
➜  brave git:(master) ✗ cat ../out/Static_arm64/chromium_unit_tests.json 
[
  "//base:base_unittests",
  "//net:net_unittests",
  "//chrome/test:unit_tests",
  "//content/test:content_unittests",
  "//components:components_unittests"
]%  
```     

On linux/ci we  merge brave_all_unit_tests_ci.json  brave_all_unit_tests.json
However the ci version contains all upstream tests already.

 brave_all_unit_tests + brave_all_unit_tests_ci  and chromium_unit_testsare run in seperate CI stages, the latter conditions on CI/{run|skip}-upstream label.

brave_all_unit_tests_ci is defined in brave/Build.gn` and reads as follows:

```
# This group is for unit tests that run as part of brave_all_unit_tests. Other
# tests that you only want to build should be added directly to `all` group
group("brave_all_unit_tests") {
  testonly = true
  data_deps = brave_all_unit_tests_deps
  write_file("$root_out_dir/brave_all_unit_tests.json",
             brave_all_unit_tests_deps,
             "json")

  # This is a workaround to prevent upstream component units from
  # building or running by default for except on CI
  write_file("$root_out_dir/brave_all_unit_tests_ci.json",
             chromium_unit_tests_deps,
             "json")
}
```

```
group("chromium_unit_tests") {
  testonly = true
  data_deps = chromium_unit_tests_deps
  write_file("$root_out_dir/chromium_unit_tests.json",
             chromium_unit_tests_deps,
             "json")
}
```

I think we don't need the workaround anymore and can change it to just:
`write_file("$root_out_dir/brave_all_unit_tests_ci.json", [], "json")`
