### PR TITLE
[iOS] Remove additional check when handling WebState closure events (uplift to 1.82.x)

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabDelegate.swift
@@ -16,7 +16,7 @@ import Web
 
 extension BrowserViewController: TabDelegate {
   public func tabWebViewDidClose(_ tab: some TabState) {
-    if tab.browserData?.isInternalRedirect == true, tab.lastCommittedURL == nil {
+    if tab.browserData?.isInternalRedirect == true {
       // Avoid closing the tab if we cancelled the initial navigation to perform a redirect since
       // we are now performing a new request that may not cancel without user interaction.
       return


### PR DESCRIPTION
Uplift of #30588
Resolves https://github.com/brave/brave-browser/issues/48317

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.