### PR TITLE
Revert "[AI Chat]: Don't crash when AssociatedContent is destroyed"

### DIFF
--- a/ios/browser/api/ai_chat/associated_content_driver_ios.mm
+++ b/ios/browser/api/ai_chat/associated_content_driver_ios.mm
@@ -28,10 +28,7 @@ AssociatedContentDriverIOS::AssociatedContentDriverIOS(
     id<AIChatDelegate> delegate)
     : AssociatedContentDriver(url_loader_factory), bridge_(delegate) {}
 
-AssociatedContentDriverIOS::~AssociatedContentDriverIOS() {
-  // Let the AssociatedContentManager know that we've been destroyed.
-  OnNewPage(-1);
-}
+AssociatedContentDriverIOS::~AssociatedContentDriverIOS() = default;
 
 std::u16string AssociatedContentDriverIOS::GetPageTitle() const {
   NSString* title = [bridge_ getPageTitle];


### PR DESCRIPTION
Reverts brave/brave-core#30653 as per https://bravesoftware.slack.com/archives/CHGKGMHDJ/p1755225030619599?thread_ts=1755224946.844539&cid=CHGKGMHDJ. Should have been labelled as a `Draft`.