### PR TITLE
Cleanup Speedreader group policy

### DIFF
--- a/browser/policy/brave_simple_policy_map.h
+++ b/browser/policy/brave_simple_policy_map.h
@@ -83,8 +83,8 @@ inline constexpr PolicyToPreferenceMapEntry kBraveSimplePolicyMap[] = {
     {policy::key::kBraveTalkDisabled, kBraveTalkDisabledByPolicy,
      base::Value::Type::BOOLEAN},
 #if BUILDFLAG(ENABLE_SPEEDREADER)
-    {policy::key::kBraveSpeedreaderDisabled,
-     speedreader::kSpeedreaderDisabledByPolicy, base::Value::Type::BOOLEAN},
+    {policy::key::kBraveSpeedreaderEnabled,
+     speedreader::kSpeedreaderPrefFeatureEnabled, base::Value::Type::BOOLEAN},
 #endif
 #endif
 #if BUILDFLAG(ENABLE_BRAVE_WAYBACK_MACHINE)

--- a/browser/resources/settings/brave_content_page/speedreader.html
+++ b/browser/resources/settings/brave_content_page/speedreader.html
@@ -9,7 +9,8 @@ You can obtain one at https://mozilla.org/MPL/2.0/. -->
     pref="{{prefs.brave.speedreader.feature_enabled}}"
     label="$i18n{speedreaderFeatureLabel}"
     sub-label="$i18n{speedreaderFeatureSubLabel}"
-    learn-more-url="$i18n{speedreaderLearnMoreURL}">
+    learn-more-url="$i18n{speedreaderLearnMoreURL}"
+    hidden="[[isSpeedreaderFeatureManaged_(prefs.brave.speedreader.feature_enabled)]]">
 </settings-toggle-button>
 
 <template is="dom-if" if="[[prefs.brave.speedreader.feature_enabled.value]]">

--- a/browser/resources/settings/brave_content_page/speedreader.ts
+++ b/browser/resources/settings/brave_content_page/speedreader.ts
@@ -24,6 +24,12 @@ class SettingsBraveContentSpeedreaderElement extends SpeedreaderBase {
   static get template () {
     return getTemplate()
   }
+
+  private isSpeedreaderFeatureManaged_(
+      pref: chrome.settingsPrivate.PrefObject): boolean {
+    return pref &&
+        pref.enforcement === chrome.settingsPrivate.Enforcement.ENFORCED;
+  }
 }
 
 customElements.define(SettingsBraveContentSpeedreaderElement.is, SettingsBraveContentSpeedreaderElement)

--- a/browser/resources/settings/brave_overrides/page_visibility.ts
+++ b/browser/resources/settings/brave_overrides/page_visibility.ts
@@ -89,8 +89,7 @@ function getPageVisibility () {
     // </if>
     content: alwaysTrueProxy,
     playlist: loadTimeData.getBoolean('isPlaylistAllowed'),
-    speedreader: loadTimeData.getBoolean('isSpeedreaderFeatureEnabled') &&
-                 !loadTimeData.getBoolean('isSpeedreaderDisabledByPolicy'),
+    speedreader: loadTimeData.getBoolean('isSpeedreaderAllowed'),
     braveTor: !loadTimeData.getBoolean('braveTorDisabledByPolicy') ||
               loadTimeData.getBoolean('shouldExposeElementsForTesting'),
   }

--- a/browser/speedreader/speedreader_service_factory.cc
+++ b/browser/speedreader/speedreader_service_factory.cc
@@ -52,10 +52,6 @@ SpeedreaderServiceFactory::BuildServiceInstanceForBrowserContext(
     return {};
   }
 
-  // Don't create service if disabled by policy
-  if (speedreader::IsDisabledByPolicy(user_prefs::UserPrefs::Get(context))) {
-    return {};
-  }
 
   return std::make_unique<SpeedreaderService>(
       context, g_browser_process->local_state(),

--- a/browser/ui/commands/accelerator_service.cc
+++ b/browser/ui/commands/accelerator_service.cc
@@ -428,8 +428,8 @@ bool AcceleratorService::IsCommandDisabledByPolicy(int command_id) const {
 #endif
     case IDC_SPEEDREADER_ICON_ONCLICK:
 #if BUILDFLAG(ENABLE_SPEEDREADER)
-      return pref_service_->GetBoolean(
-          speedreader::kSpeedreaderDisabledByPolicy);
+      return !pref_service_->GetBoolean(
+          speedreader::kSpeedreaderPrefFeatureEnabled);
 #else
       return true;  // Speedreader not compiled in, always disabled
 #endif

--- a/browser/ui/commands/accelerator_service_unittest.cc
+++ b/browser/ui/commands/accelerator_service_unittest.cc
@@ -364,11 +364,11 @@ TEST_F(AcceleratorServiceUnitTest, PolicyFiltering) {
 #if BUILDFLAG(ENABLE_SPEEDREADER)
   // Test Speedreader
   EXPECT_FALSE(service.IsCommandDisabledByPolicy(IDC_SPEEDREADER_ICON_ONCLICK));
-  profile().GetPrefs()->SetBoolean(speedreader::kSpeedreaderDisabledByPolicy,
-                                   true);
-  EXPECT_TRUE(service.IsCommandDisabledByPolicy(IDC_SPEEDREADER_ICON_ONCLICK));
-  profile().GetPrefs()->SetBoolean(speedreader::kSpeedreaderDisabledByPolicy,
+  profile().GetPrefs()->SetBoolean(speedreader::kSpeedreaderPrefFeatureEnabled,
                                    false);
+  EXPECT_TRUE(service.IsCommandDisabledByPolicy(IDC_SPEEDREADER_ICON_ONCLICK));
+  profile().GetPrefs()->SetBoolean(speedreader::kSpeedreaderPrefFeatureEnabled,
+                                   true);
   EXPECT_FALSE(service.IsCommandDisabledByPolicy(IDC_SPEEDREADER_ICON_ONCLICK));
 #endif
 

--- a/browser/ui/webui/brave_settings_ui.cc
+++ b/browser/ui/webui/brave_settings_ui.cc
@@ -70,6 +70,7 @@
 #if BUILDFLAG(ENABLE_SPEEDREADER)
 #include "brave/components/speedreader/common/features.h"
 #include "brave/components/speedreader/speedreader_pref_names.h"
+#include "brave/components/speedreader/speedreader_service.h"
 #endif
 
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
@@ -172,11 +173,11 @@ void BraveSettingsUI::AddResources(content::WebUIDataSource* html_source,
 #endif  // BUILDFLAG(ENABLE_BRAVE_VPN)
 #if BUILDFLAG(ENABLE_SPEEDREADER)
   html_source->AddBoolean(
-      "isSpeedreaderFeatureEnabled",
-      base::FeatureList::IsEnabled(speedreader::kSpeedreaderFeature));
-  html_source->AddBoolean("isSpeedreaderDisabledByPolicy",
-                          profile->GetPrefs()->GetBoolean(
-                              speedreader::kSpeedreaderDisabledByPolicy));
+      "isSpeedreaderAllowed",
+      base::FeatureList::IsEnabled(speedreader::kSpeedreaderFeature) &&
+          (speedreader::IsSpeedreaderFeatureEnabled(profile->GetPrefs()) ||
+           !profile->GetPrefs()->IsManagedPreference(
+               speedreader::kSpeedreaderPrefFeatureEnabled)));
 #endif
   html_source->AddBoolean(
       "isNativeBraveWalletFeatureEnabled",

--- a/components/policy/resources/templates/policy_definitions/BraveSoftware/BraveSpeedreaderEnabled.yaml
+++ b/components/policy/resources/templates/policy_definitions/BraveSoftware/BraveSpeedreaderEnabled.yaml
@@ -1,13 +1,13 @@
-caption: Disable Speedreader
+caption: Enable Speedreader
 default: null
 desc: |-
-  Disable Speedreader in Brave.
+  Enable Speedreader in Brave.
 
   Speedreader is a feature that provides a clutter-free reading experience by automatically cleaning up articles and simplifying page layouts.
 
-            If this policy is set to true, Speedreader will always be disabled and all related UI elements will be hidden.
+            If this policy is set to true, Speedreader will always be enabled.
 
-            If this policy is set to false, Speedreader will always be enabled.
+            If this policy is set to false, Speedreader will always be disabled and all related UI elements will be hidden.
 
             If you set this policy, users cannot change or override it.
 
@@ -20,9 +20,9 @@ features:
   per_profile: true
 items:
 - caption: Enable Speedreader
-  value: false
-- caption: Disable Speedreader
   value: true
+- caption: Disable Speedreader
+  value: false
 - caption: Allow the user to decide
   value: null
 owners:

--- a/components/policy/resources/templates/policy_definitions/brave_policies.gni
+++ b/components/policy/resources/templates/policy_definitions/brave_policies.gni
@@ -11,7 +11,7 @@ _brave_policies = [
   "BraveSoftware/BraveRewardsDisabled.yaml",
   "BraveSoftware/BraveShieldsDisabledForUrls.yaml",
   "BraveSoftware/BraveShieldsEnabledForUrls.yaml",
-  "BraveSoftware/BraveSpeedreaderDisabled.yaml",
+  "BraveSoftware/BraveSpeedreaderEnabled.yaml",
   "BraveSoftware/BraveStatsPingEnabled.yaml",
   "BraveSoftware/BraveSyncUrl.yaml",
   "BraveSoftware/BraveTalkDisabled.yaml",

--- a/components/speedreader/speedreader_pref_names.h
+++ b/components/speedreader/speedreader_pref_names.h
@@ -48,9 +48,6 @@ inline constexpr char kSpeedreaderPrefTtsSpeed[] =
 inline constexpr char kSpeedreaderPageViewsStoragePref[] =
     "brave.speedreader.page_views";
 
-// Used to enable/disable Speedreader via a policy.
-inline constexpr char kSpeedreaderDisabledByPolicy[] =
-    "brave.speedreader.disabled_by_policy";
 
 // Top-level feature toggle for Speedreader (named feature_enabled to
 // distinguish from the legacy "enabled" pref which actually controls all-sites

--- a/components/speedreader/speedreader_service.cc
+++ b/components/speedreader/speedreader_service.cc
@@ -45,8 +45,8 @@ bool IsSpeedreaderEnabled() {
 
 }  // namespace features
 
-bool IsDisabledByPolicy(PrefService* prefs) {
-  return prefs->GetBoolean(kSpeedreaderDisabledByPolicy);
+bool IsSpeedreaderFeatureEnabled(PrefService* prefs) {
+  return prefs->GetBoolean(kSpeedreaderPrefFeatureEnabled);
 }
 
 SpeedreaderService::SpeedreaderService(content::BrowserContext* browser_context,
@@ -91,7 +91,6 @@ void SpeedreaderService::RegisterProfilePrefs(PrefRegistrySimple* registry) {
   registry->RegisterStringPref(kSpeedreaderPrefTtsVoice, "");
   registry->RegisterIntegerPref(kSpeedreaderPrefTtsSpeed,
                                 static_cast<int>(PlaybackSpeed::k100));
-  registry->RegisterBooleanPref(kSpeedreaderDisabledByPolicy, false);
 }
 
 // static
@@ -108,9 +107,7 @@ void SpeedreaderService::RemoveObserver(Observer* observer) {
 }
 
 bool SpeedreaderService::IsFeatureEnabled() {
-  bool disabled_by_policy = speedreader::IsDisabledByPolicy(prefs_);
-  bool feature_enabled = prefs_->GetBoolean(kSpeedreaderPrefFeatureEnabled);
-  return !disabled_by_policy && feature_enabled;
+  return speedreader::IsSpeedreaderFeatureEnabled(prefs_);
 }
 
 bool SpeedreaderService::IsEnabledForAllSites() {

--- a/components/speedreader/speedreader_service.h
+++ b/components/speedreader/speedreader_service.h
@@ -31,8 +31,8 @@ namespace features {
 bool IsSpeedreaderEnabled();
 }
 
-// Returns true if Speedreader is disabled by policy.
-bool IsDisabledByPolicy(PrefService* prefs);
+// Returns true if Speedreader feature is enabled.
+bool IsSpeedreaderFeatureEnabled(PrefService* prefs);
 
 class SpeedreaderService : public KeyedService {
  public:

--- a/components/speedreader/speedreader_service_unittest.cc
+++ b/components/speedreader/speedreader_service_unittest.cc
@@ -22,65 +22,58 @@ class SpeedreaderPolicyTest : public testing::Test {
   }
 
  protected:
-  void SetSpeedreaderDisabledByPolicy(bool value) {
-    pref_service_.SetManagedPref(kSpeedreaderDisabledByPolicy,
+  void SetSpeedreaderFeatureEnabledByPolicy(bool value) {
+    pref_service_.SetManagedPref(kSpeedreaderPrefFeatureEnabled,
                                  base::Value(value));
+  }
+
+  bool IsManaged() {
+    return pref_service_.IsManagedPreference(kSpeedreaderPrefFeatureEnabled);
   }
 
   sync_preferences::TestingPrefServiceSyncable pref_service_;
 };
 
 TEST_F(SpeedreaderPolicyTest, PolicyDisablesSpeedreader) {
-  // Initially, policy should not be disabled
-  EXPECT_FALSE(pref_service_.GetBoolean(kSpeedreaderDisabledByPolicy));
-  EXPECT_FALSE(pref_service_.IsManagedPreference(kSpeedreaderDisabledByPolicy));
-  EXPECT_FALSE(IsDisabledByPolicy(&pref_service_));
+  // Initially, feature should be enabled by default and not managed
+  EXPECT_TRUE(pref_service_.GetBoolean(kSpeedreaderPrefFeatureEnabled));
+  EXPECT_FALSE(IsManaged());
 
   // Set policy to disable Speedreader
-  SetSpeedreaderDisabledByPolicy(true);
+  SetSpeedreaderFeatureEnabledByPolicy(false);
 
-  // Test that the policy preference is set correctly
-  EXPECT_TRUE(pref_service_.FindPreference(kSpeedreaderDisabledByPolicy));
-  EXPECT_TRUE(pref_service_.IsManagedPreference(kSpeedreaderDisabledByPolicy));
-  EXPECT_TRUE(pref_service_.GetBoolean(kSpeedreaderDisabledByPolicy));
-
-  // Test that IsDisabledByPolicy function works
-  EXPECT_TRUE(IsDisabledByPolicy(&pref_service_));
+  // Test that the policy preference is managed and disabled
+  EXPECT_TRUE(IsManaged());
+  EXPECT_FALSE(pref_service_.GetBoolean(kSpeedreaderPrefFeatureEnabled));
 }
 
 TEST_F(SpeedreaderPolicyTest, PolicyEnablesSpeedreader) {
-  // Set policy to explicitly enable Speedreader (policy value false = not
-  // disabled)
-  SetSpeedreaderDisabledByPolicy(false);
+  // Set policy to explicitly enable Speedreader
+  SetSpeedreaderFeatureEnabledByPolicy(true);
 
-  // Test that the policy preference is set correctly
-  EXPECT_TRUE(pref_service_.FindPreference(kSpeedreaderDisabledByPolicy));
-  EXPECT_TRUE(pref_service_.IsManagedPreference(kSpeedreaderDisabledByPolicy));
-  EXPECT_FALSE(pref_service_.GetBoolean(kSpeedreaderDisabledByPolicy));
-
-  // Test that IsDisabledByPolicy function works
-  EXPECT_FALSE(IsDisabledByPolicy(&pref_service_));
+  // Test that the policy preference is managed and enabled
+  EXPECT_TRUE(IsManaged());
+  EXPECT_TRUE(pref_service_.GetBoolean(kSpeedreaderPrefFeatureEnabled));
 }
 
 TEST_F(SpeedreaderPolicyTest, DefaultValueWhenNotManaged) {
-  // When not managed by policy, should be false by default
-  EXPECT_FALSE(pref_service_.GetBoolean(kSpeedreaderDisabledByPolicy));
-  EXPECT_FALSE(pref_service_.IsManagedPreference(kSpeedreaderDisabledByPolicy));
-  EXPECT_FALSE(IsDisabledByPolicy(&pref_service_));
+  // When not managed by policy, feature should be enabled by default
+  EXPECT_TRUE(pref_service_.GetBoolean(kSpeedreaderPrefFeatureEnabled));
+  EXPECT_FALSE(IsManaged());
 }
 
 TEST_F(SpeedreaderPolicyTest, PolicyChangesAreReflected) {
-  // Start with policy allowing speedreader
-  SetSpeedreaderDisabledByPolicy(false);
-  EXPECT_FALSE(IsDisabledByPolicy(&pref_service_));
+  // Start with policy enabling speedreader
+  SetSpeedreaderFeatureEnabledByPolicy(true);
+  EXPECT_TRUE(IsSpeedreaderFeatureEnabled(&pref_service_));
 
   // Change policy to disable speedreader
-  SetSpeedreaderDisabledByPolicy(true);
-  EXPECT_TRUE(IsDisabledByPolicy(&pref_service_));
+  SetSpeedreaderFeatureEnabledByPolicy(false);
+  EXPECT_FALSE(IsSpeedreaderFeatureEnabled(&pref_service_));
 
-  // Change back to allowing speedreader
-  SetSpeedreaderDisabledByPolicy(false);
-  EXPECT_FALSE(IsDisabledByPolicy(&pref_service_));
+  // Change back to enabling speedreader
+  SetSpeedreaderFeatureEnabledByPolicy(true);
+  EXPECT_TRUE(IsSpeedreaderFeatureEnabled(&pref_service_));
 }
 
 TEST_F(SpeedreaderPolicyTest, PolicyWorksWithDefaultsWrite) {
@@ -88,15 +81,15 @@ TEST_F(SpeedreaderPolicyTest, PolicyWorksWithDefaultsWrite) {
   // where the preference is set but not marked as managed
 
   // Manually set the preference value without using SetManagedPref
-  pref_service_.SetBoolean(kSpeedreaderDisabledByPolicy, true);
+  pref_service_.SetBoolean(kSpeedreaderPrefFeatureEnabled, false);
 
   // Verify the preference is set but not marked as managed
-  EXPECT_TRUE(pref_service_.GetBoolean(kSpeedreaderDisabledByPolicy));
-  EXPECT_FALSE(pref_service_.IsManagedPreference(kSpeedreaderDisabledByPolicy));
+  EXPECT_FALSE(pref_service_.GetBoolean(kSpeedreaderPrefFeatureEnabled));
+  EXPECT_FALSE(IsManaged());
 
-  // IsDisabledByPolicy should still return true since we just check the
-  // preference value
-  EXPECT_TRUE(IsDisabledByPolicy(&pref_service_));
+  // IsSpeedreaderFeatureEnabled should return false since preference is
+  // disabled
+  EXPECT_FALSE(IsSpeedreaderFeatureEnabled(&pref_service_));
 }
 
 class SpeedreaderPrefMigrationTest : public testing::Test {


### PR DESCRIPTION
- BraveSpeedReaderDisabled is now called BraveSpeedReaderEnabled
- Replace kSpeedreaderDisabledByPolicy with kSpeedreaderPrefFeatureEnabled which already existed
- Invert Disabled policy name to Enabled to match the pref that already existed.
- Invert logic at various places to be for enabled checks instead of disabled.
- Update tests and policy definitions accordingly.
- We now show opt-ins for Recommended policy enforcement (things set via `defaults write` on macOS, it should show an indicator if you match the recommended setting or not)
- We now hide opt-ins for Mandatory enforcements (things set via `sudo /usr/libexec/PlistBuddy`)
- We no longer avoid creating the service itself, because otherwise it won't work with policy changes dynamically

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/48470

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
