### PR TITLE
feat(wallet): Edit Spend Limit Popup

### DIFF
--- a/components/brave_wallet/browser/brave_wallet_constants.h
+++ b/components/brave_wallet/browser/brave_wallet_constants.h
@@ -955,6 +955,8 @@ inline constexpr webui::LocalizedString kLocalizedStrings[] = {
      IDS_BRAVE_WALLET_EDIT_PERMISSIONS_PROPOSED_ALLOWANCE},
     {"braveWalletEditPermissionsCustomAllowance",
      IDS_BRAVE_WALLET_EDIT_PERMISSIONS_CUSTOM_ALLOWANCE},
+    {"braveWalletProposedSpendLimit", IDS_BRAVE_WALLET_PROPOSED_SPEND_LIMIT},
+    {"braveWalletCustomSpendLimit", IDS_BRAVE_WALLET_CUSTOM_SPEND_LIMIT},
     {"braveWalletNotValidEthAddress", IDS_BRAVE_WALLET_NOT_VALID_ETH_ADDRESS},
     {"braveWalletNotValidSolAddress", IDS_BRAVE_WALLET_NOT_VALID_SOL_ADDRESS},
     {"braveWalletNotValidAddress", IDS_BRAVE_WALLET_NOT_VALID_ADDRESS},

--- a/components/brave_wallet_ui/components/extension/edit_spend_permissions/edit_spend_limit.stories.tsx
+++ b/components/brave_wallet_ui/components/extension/edit_spend_permissions/edit_spend_limit.stories.tsx
@@ -1,0 +1,54 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import * as React from 'react'
+
+// Utils
+import { getLocale } from '../../../../common/locale'
+
+// Components
+import {
+  EditSpendLimit, //
+} from './edit_spend_limit'
+import { BottomSheet } from '../../shared/bottom_sheet/bottom_sheet'
+import {
+  WalletPanelStory, //
+} from '../../../stories/wrappers/wallet-panel-story-wrapper'
+
+export const _EditSpendLimit = {
+  render: () => {
+    return (
+      <BottomSheet
+        isOpen={true}
+        title={getLocale('braveWalletEditPermissionsTitle')}
+        onClose={() => alert('Close Clicked')}
+      >
+        <EditSpendLimit
+          onCancel={() => alert('Cancel Clicked')}
+          onSave={(limit: string) => alert(`Spend limit updated to ${limit}`)}
+          approvalTarget='0x Exchange Proxy'
+          isApprovalUnlimited={false}
+          proposedAllowance='100'
+          symbol='ETH'
+        />
+      </BottomSheet>
+    )
+  },
+}
+
+export default {
+  title: 'Wallet/Panel/Components/Edit Spend Limit',
+  component: EditSpendLimit,
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    (Story: any) => (
+      <WalletPanelStory>
+        <Story />
+      </WalletPanelStory>
+    ),
+  ],
+}

--- a/components/brave_wallet_ui/components/extension/edit_spend_permissions/edit_spend_limit.style.ts
+++ b/components/brave_wallet_ui/components/extension/edit_spend_permissions/edit_spend_limit.style.ts
@@ -1,0 +1,68 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import styled from 'styled-components'
+import * as leo from '@brave/leo/tokens/css/variables'
+
+// Shared Styles
+import { Column, Text } from '../../shared/style'
+
+export const StyledWrapper = styled(Column)`
+  overflow: hidden;
+`
+
+export const LabelText = styled(Text)`
+  font: ${leo.font.default.regular};
+  letter-spacing: ${leo.typography.letterSpacing.default};
+`
+
+export const AmountText = styled(Text)`
+  font: ${leo.font.large.semibold};
+  letter-spacing: ${leo.typography.letterSpacing.default};
+`
+
+export const Input = styled.input<{
+  hasError?: boolean
+}>`
+  font: ${leo.font.small.regular};
+  letter-spacing: ${leo.typography.letterSpacing.small};
+  background-color: ${leo.color.container.highlight};
+  color: ${leo.color.text.primary};
+  border: none;
+  width: 100%;
+  padding: 0px;
+  outline: 1px solid ${leo.color.container.highlight};
+  transition:
+    outline 0.1s ease-in-out,
+    box-shadow 0.1s ease-in-out;
+  border-radius: ${leo.radius.m};
+  padding: 10px 12px;
+  ::placeholder {
+    font: ${leo.font.small.regular};
+    letter-spacing: ${leo.typography.letterSpacing.small};
+    color: ${leo.color.text.tertiary};
+  }
+  :hover {
+    outline: 1px solid ${leo.color.divider.strong};
+    box-shadow: ${leo.effect.elevation['02']};
+  }
+  :focus {
+    outline: 2px solid ${leo.color.primary[40]};
+  }
+  ::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+  ::-webkit-outer-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+`
+
+export const ButtonText = styled.span`
+  display: flex;
+  width: 80px;
+  justify-content: center;
+`

--- a/components/brave_wallet_ui/components/extension/edit_spend_permissions/edit_spend_limit.test.tsx
+++ b/components/brave_wallet_ui/components/extension/edit_spend_permissions/edit_spend_limit.test.tsx
@@ -1,0 +1,55 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import * as React from 'react'
+import { render, screen } from '@testing-library/react'
+import { Provider } from 'react-redux'
+
+// Utils
+import {
+  // eslint-disable-next-line import/no-named-default
+  default as BraveCoreThemeProvider,
+} from '../../../../common/BraveCoreThemeProvider'
+import { createMockStore } from '../../../utils/test-utils'
+
+// Components
+import { EditSpendLimit } from './edit_spend_limit'
+
+describe('EditSpendLimit', () => {
+  const renderComponent = () => {
+    const store = createMockStore({})
+    return render(
+      <Provider store={store}>
+        <BraveCoreThemeProvider>
+          <EditSpendLimit
+            onCancel={jest.fn()}
+            onSave={jest.fn()}
+            proposedAllowance='100'
+            symbol='ETH'
+            approvalTarget='Uniswap V3'
+            isApprovalUnlimited={false}
+          />
+        </BraveCoreThemeProvider>
+      </Provider>,
+    )
+  }
+
+  it('should render the component', () => {
+    renderComponent()
+
+    expect(
+      screen.getByText('braveWalletEditPermissionsDescription'),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('braveWalletProposedSpendLimit'),
+    ).toBeInTheDocument()
+    expect(screen.getByText('100 ETH')).toBeInTheDocument()
+    expect(screen.getByText('braveWalletCustomSpendLimit')).toBeInTheDocument()
+    expect(screen.getByText('braveWalletButtonCancel')).toBeInTheDocument()
+    expect(
+      screen.getByText('braveWalletAccountSettingsSave'),
+    ).toBeInTheDocument()
+  })
+})

--- a/components/brave_wallet_ui/components/extension/edit_spend_permissions/edit_spend_limit.tsx
+++ b/components/brave_wallet_ui/components/extension/edit_spend_permissions/edit_spend_limit.tsx
@@ -1,0 +1,166 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import * as React from 'react'
+import Button from '@brave/leo/react/button'
+import RadioButton from '@brave/leo/react/radioButton'
+
+// Utils
+import { getLocale } from '../../../../common/locale'
+
+// Styled Components
+import {
+  StyledWrapper,
+  LabelText,
+  AmountText,
+  Input,
+  ButtonText,
+} from './edit_spend_limit.style'
+import { Column, Row } from '../../shared/style'
+
+type AllowanceTypes = 'proposed' | 'custom'
+
+export interface Props {
+  onCancel: () => void
+  onSave: (limit: string) => void
+  proposedAllowance: string
+  symbol: string
+  approvalTarget: string
+  isApprovalUnlimited: boolean
+}
+
+export const EditSpendLimit = (props: Props) => {
+  const {
+    onCancel,
+    onSave,
+    approvalTarget,
+    isApprovalUnlimited,
+    proposedAllowance,
+    symbol,
+  } = props
+
+  // State
+  const [allowanceType, setAllowanceType] =
+    React.useState<AllowanceTypes>('proposed')
+  const [customAllowance, setCustomAllowance] = React.useState<string>('')
+
+  // Refs
+  const customAllowanceInputRef = React.useRef<HTMLInputElement>(null)
+
+  // Methods
+  const toggleAllowanceRadio = (key: AllowanceTypes) => {
+    if (key === 'custom') {
+      customAllowanceInputRef.current?.focus()
+    }
+    setAllowanceType(key)
+  }
+
+  const onChangeCustomAllowance = (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    setCustomAllowance(event.target.value)
+  }
+
+  const onClickSave = React.useCallback(() => {
+    onSave(allowanceType === 'custom' ? customAllowance : proposedAllowance)
+    onCancel()
+  }, [allowanceType, customAllowance, proposedAllowance, onSave, onCancel])
+
+  // Memos
+  const isSaveButtonDisabled = React.useMemo(() => {
+    return allowanceType === 'custom' && customAllowance === ''
+  }, [allowanceType, customAllowance])
+
+  const formattedProposedAllowance = React.useMemo(() => {
+    return isApprovalUnlimited
+      ? getLocale('braveWalletTransactionApproveUnlimited')
+      : proposedAllowance
+  }, [proposedAllowance, isApprovalUnlimited])
+
+  return (
+    <StyledWrapper
+      gap='32px'
+      padding='16px'
+      width='100%'
+    >
+      <LabelText
+        textColor='secondary'
+        textAlign='left'
+      >
+        {getLocale('braveWalletEditPermissionsDescription').replace(
+          '$1',
+          approvalTarget,
+        )}
+      </LabelText>
+      <Column
+        gap='16px'
+        width='100%'
+        alignItems='flex-start'
+        justifyContent='flex-start'
+      >
+        <RadioButton
+          name='proposed'
+          value='proposed'
+          currentValue={allowanceType}
+          onChange={() => toggleAllowanceRadio('proposed')}
+        >
+          <Column
+            alignItems='flex-start'
+            justifyContent='flex-start'
+          >
+            <LabelText textColor='primary'>
+              {getLocale('braveWalletProposedSpendLimit')}
+            </LabelText>
+            <AmountText textColor='primary'>
+              {formattedProposedAllowance} {symbol}
+            </AmountText>
+          </Column>
+        </RadioButton>
+        <RadioButton
+          name='custom'
+          value='custom'
+          currentValue={allowanceType}
+          onChange={() => toggleAllowanceRadio('custom')}
+        >
+          <Column
+            alignItems='flex-start'
+            justifyContent='flex-start'
+            gap='4px'
+          >
+            <LabelText textColor='primary'>
+              {getLocale('braveWalletCustomSpendLimit')}
+            </LabelText>
+            <Input
+              ref={customAllowanceInputRef}
+              placeholder={proposedAllowance}
+              type='number'
+              value={customAllowance}
+              onChange={onChangeCustomAllowance}
+              data-testid='custom-allowance-input'
+            />
+          </Column>
+        </RadioButton>
+      </Column>
+      <Row gap='16px'>
+        <Button
+          kind='outline'
+          size='medium'
+          onClick={onCancel}
+        >
+          <ButtonText>{getLocale('braveWalletButtonCancel')}</ButtonText>
+        </Button>
+        <Button
+          size='medium'
+          onClick={onClickSave}
+          isDisabled={isSaveButtonDisabled}
+        >
+          <ButtonText>{getLocale('braveWalletAccountSettingsSave')}</ButtonText>
+        </Button>
+      </Row>
+    </StyledWrapper>
+  )
+}
+
+export default EditSpendLimit

--- a/components/brave_wallet_ui/stories/locale.ts
+++ b/components/brave_wallet_ui/stories/locale.ts
@@ -1075,6 +1075,8 @@ provideStrings({
   braveWalletEditPermissionsButton: 'Edit permissions',
   braveWalletEditPermissionsProposedAllowance: 'Proposed allowance',
   braveWalletEditPermissionsCustomAllowance: 'Custom allowance',
+  braveWalletProposedSpendLimit: 'Proposed spend limit',
+  braveWalletCustomSpendLimit: 'Custom spend limit',
 
   // Send Input Errors
   braveWalletNotValidFilAddress: 'Not a valid FIL address',

--- a/components/resources/wallet_strings.grdp
+++ b/components/resources/wallet_strings.grdp
@@ -514,6 +514,8 @@
   <message name="IDS_BRAVE_WALLET_EDIT_PERMISSIONS_BUTTON" desc="Edit allowance panel button">Edit permissions</message>
   <message name="IDS_BRAVE_WALLET_EDIT_PERMISSIONS_PROPOSED_ALLOWANCE" desc="Edit allowance panel button">Proposed allowance</message>
   <message name="IDS_BRAVE_WALLET_EDIT_PERMISSIONS_CUSTOM_ALLOWANCE" desc="Edit allowance panel button">Custom allowance</message>
+  <message name="IDS_BRAVE_WALLET_PROPOSED_SPEND_LIMIT" desc="Edit allowance proposed spend limit label">Proposed spend limit</message>
+  <message name="IDS_BRAVE_WALLET_CUSTOM_SPEND_LIMIT" desc="Edit allowance custom spend limit label">Custom spend limit</message>
   <message name="IDS_BRAVE_WALLET_NOT_VALID_ETH_ADDRESS" desc="Send input not valid ETH address error">Not a valid ETH address</message>
   <message name="IDS_BRAVE_WALLET_NOT_VALID_SOL_ADDRESS" desc="Send input not valid SOL address error">Not a valid SOL address</message>
   <message name="IDS_BRAVE_WALLET_NOT_VALID_ADDRESS" desc="Send input not valid address error">Not a valid <ph name="COIN_TYPE_SYMBOL"><ex>ETH</ex>$1</ph> address.</message>


### PR DESCRIPTION
## Description 

Built out the new `Edit Spend Limit` popup to be used in the future.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/48483>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->


## Test Plan:
This PR was to just build out the `Component`, test plan for this component will be in a separate PR when this component is used. You are able to view though in `Storybook`

<img width="435" height="686" alt="Screenshot 14" src="https://github.com/user-attachments/assets/1a5d5930-cfb4-428e-8fee-ac3cf6f93878" /> | <img width="419" height="675" alt="Screenshot 15" src="https://github.com/user-attachments/assets/1f399eb6-77a1-402e-9861-b210b9d9d4e5" />
--|--