### PR TITLE
Various intermittent test fixes (Uplift to 1.82.x)

### DIFF
--- a/browser/brave_shields/ad_block_service_browsertest.cc
+++ b/browser/brave_shields/ad_block_service_browsertest.cc
@@ -157,6 +157,17 @@ void AdBlockServiceTest::SetUpOnMainThread() {
 void AdBlockServiceTest::PreRunTestOnMainThread() {
   PlatformBrowserTest::PreRunTestOnMainThread();
   WaitForAdBlockServiceThreads();
+
+  // Wait for initial engine creation to complete, especially on slower
+  // platforms
+  ASSERT_TRUE(base::test::RunUntil([&]() {
+    auto counts = histogram_tester_.GetTotalCountsForPrefix(
+        "Brave.Adblock.MakeEngineWithRules.Default");
+    return counts.find("Brave.Adblock.MakeEngineWithRules.Default") !=
+               counts.end() &&
+           counts.at("Brave.Adblock.MakeEngineWithRules.Default") >= 1;
+  })) << "Timeout waiting for initial engine creation";
+
   histogram_tester_.ExpectTotalCount(
       "Brave.Adblock.MakeEngineWithRules.Default", 1);
   InstallDefaultAdBlockComponent();

--- a/browser/brave_shields/ad_block_service_browsertest.cc
+++ b/browser/brave_shields/ad_block_service_browsertest.cc
@@ -19,6 +19,7 @@
 #include "base/memory/raw_ptr.h"
 #include "base/path_service.h"
 #include "base/task/sequenced_task_runner.h"
+#include "base/test/run_until.h"
 #include "base/test/scoped_feature_list.h"
 #include "base/test/thread_test_helper.h"
 #include "base/threading/thread_restrictions.h"
@@ -779,21 +780,6 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest,
   EXPECT_EQ(profile()->GetPrefs()->GetUint64(kAdsBlocked), 1ULL);
 }
 
-// These tests fail intermittently on macOS; see
-// https://github.com/brave/brave-browser/issues/15912
-#if BUILDFLAG(IS_MAC)
-#define MAYBE_CnameCloakedRequestsGetBlocked \
-  DISABLED_CnameCloakedRequestsGetBlocked
-#define MAYBE_CnameCloakedRequestsCanBeExcepted \
-  DISABLED_CnameCloakedRequestsCanBeExcepted
-#define MAYBE_NoRemoveparamOnCnameUncloakedUrl \
-  DISABLED_NoRemoveparamOnCnameUncloakedUrl
-#else
-#define MAYBE_CnameCloakedRequestsGetBlocked CnameCloakedRequestsGetBlocked
-#define MAYBE_CnameCloakedRequestsCanBeExcepted \
-  CnameCloakedRequestsCanBeExcepted
-#define MAYBE_NoRemoveparamOnCnameUncloakedUrl NoRemoveparamOnCnameUncloakedUrl
-#endif
 
 // A test observer that allows blocking waits for the
 // AdBlockSubscriptionServiceManager to update the status of any registered
@@ -1031,8 +1017,7 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, SubscribeToListUrlTwice) {
 
 // Make sure that CNAME cloaked network requests get blocked correctly and
 // issue the correct number of DNS resolutions
-IN_PROC_BROWSER_TEST_F(AdBlockServiceTest,
-                       MAYBE_CnameCloakedRequestsGetBlocked) {
+IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, CnameCloakedRequestsGetBlocked) {
   UpdateAdBlockInstanceWithRules("||cname-cloak-endpoint.tracking.com^");
   GURL tab_url = embedded_test_server()->GetURL("a.com", kAdBlockTestPage);
   GURL direct_resource_url =
@@ -1078,6 +1063,9 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest,
                                                 direct_resource_url.spec())));
   EXPECT_EQ(profile()->GetPrefs()->GetUint64(kAdsBlocked), 1ULL);
   // Note one resolution for the root document
+  ASSERT_TRUE(base::test::RunUntil([&]() {
+    return inner_resolver->num_resolve() >= 2ULL;
+  })) << "Timeout waiting for DNS resolution count to reach 2";
   ASSERT_EQ(2ULL, inner_resolver->num_resolve());
 
   // XHR request to an unblocked first-party endpoint that is CNAME cloaked with
@@ -1088,6 +1076,9 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest,
                                                 "xhr($1)",
                                                 chain_resource_url.spec())));
   EXPECT_EQ(profile()->GetPrefs()->GetUint64(kAdsBlocked), 2ULL);
+  ASSERT_TRUE(base::test::RunUntil([&]() {
+    return inner_resolver->num_resolve() >= 3ULL;
+  })) << "Timeout waiting for DNS resolution count to reach 3";
   ASSERT_EQ(3ULL, inner_resolver->num_resolve());
 
   // XHR request to an unblocked first-party endpoint that is CNAME cloaked.
@@ -1097,6 +1088,9 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest,
                                                 "xhr($1)",
                                                 safe_resource_url.spec())));
   EXPECT_EQ(profile()->GetPrefs()->GetUint64(kAdsBlocked), 2ULL);
+  ASSERT_TRUE(base::test::RunUntil([&]() {
+    return inner_resolver->num_resolve() >= 4ULL;
+  })) << "Timeout waiting for DNS resolution count to reach 4";
   ASSERT_EQ(4ULL, inner_resolver->num_resolve());
 
   // XHR request directly to a blocked third-party endpoint.
@@ -1106,13 +1100,15 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest,
                                                 "xhr($1)",
                                                 bad_resource_url.spec())));
   EXPECT_EQ(profile()->GetPrefs()->GetUint64(kAdsBlocked), 3ULL);
+  ASSERT_TRUE(base::test::RunUntil([&]() {
+    return inner_resolver->num_resolve() >= 4ULL;
+  })) << "Timeout waiting for DNS resolution count to reach 4";
   ASSERT_EQ(4ULL, inner_resolver->num_resolve());
 }
 
 // Make sure that an exception for a URL can apply to a blocking decision made
 // to its CNAME-uncloaked equivalent.
-IN_PROC_BROWSER_TEST_F(AdBlockServiceTest,
-                       MAYBE_CnameCloakedRequestsCanBeExcepted) {
+IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, CnameCloakedRequestsCanBeExcepted) {
   UpdateAdBlockInstanceWithRules(
       "||cname-cloak-endpoint.tracking.com^\n"
       "@@a.com*/logo.png?unblock^");
@@ -1162,6 +1158,9 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest,
                                                 direct_resource_url.spec())));
   EXPECT_EQ(profile()->GetPrefs()->GetUint64(kAdsBlocked), 1ULL);
   // Note one resolution for the root document
+  ASSERT_TRUE(base::test::RunUntil([&]() {
+    return inner_resolver->num_resolve() >= 2ULL;
+  })) << "Timeout waiting for DNS resolution count to reach 2";
   ASSERT_EQ(2ULL, inner_resolver->num_resolve());
 
   // XHR request to an unblocked first-party endpoint that is CNAME cloaked with
@@ -1172,6 +1171,9 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest,
                                                 "xhr($1)",
                                                 chain_resource_url.spec())));
   EXPECT_EQ(profile()->GetPrefs()->GetUint64(kAdsBlocked), 2ULL);
+  ASSERT_TRUE(base::test::RunUntil([&]() {
+    return inner_resolver->num_resolve() >= 3ULL;
+  })) << "Timeout waiting for DNS resolution count to reach 3";
   ASSERT_EQ(3ULL, inner_resolver->num_resolve());
 
   // XHR request to an unblocked first-party endpoint that is CNAME cloaked.
@@ -1181,6 +1183,9 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest,
                                                 "xhr($1)",
                                                 safe_resource_url.spec())));
   EXPECT_EQ(profile()->GetPrefs()->GetUint64(kAdsBlocked), 2ULL);
+  ASSERT_TRUE(base::test::RunUntil([&]() {
+    return inner_resolver->num_resolve() >= 4ULL;
+  })) << "Timeout waiting for DNS resolution count to reach 4";
   ASSERT_EQ(4ULL, inner_resolver->num_resolve());
 
   // XHR request directly to a blocked third-party endpoint.
@@ -1190,6 +1195,9 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest,
                                                 "xhr($1)",
                                                 bad_resource_url.spec())));
   EXPECT_EQ(profile()->GetPrefs()->GetUint64(kAdsBlocked), 3ULL);
+  ASSERT_TRUE(base::test::RunUntil([&]() {
+    return inner_resolver->num_resolve() >= 4ULL;
+  })) << "Timeout waiting for DNS resolution count to reach 4";
   ASSERT_EQ(4ULL, inner_resolver->num_resolve());
 
   // The original URL only matches an exception.
@@ -1206,8 +1214,7 @@ IN_PROC_BROWSER_TEST_F(AdBlockServiceTest,
 
 // `$removeparam` should happen for the original URL, not the CNAME-uncloaked
 // one
-IN_PROC_BROWSER_TEST_F(AdBlockServiceTest,
-                       MAYBE_NoRemoveparamOnCnameUncloakedUrl) {
+IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, NoRemoveparamOnCnameUncloakedUrl) {
   UpdateAdBlockInstanceWithRules(
       "||frame.com^$subdocument,removeparam=evil\n"
       "||assets.cdn.net^$subdocument,removeparam=test");

--- a/browser/misc_metrics/vertical_tab_metrics.cc
+++ b/browser/misc_metrics/vertical_tab_metrics.cc
@@ -102,7 +102,11 @@ size_t VerticalTabBrowserMetrics::GetTabCount(TabCountType count_type) const {
   if (!vertical_tabs_enabled_) {
     return 0;
   }
-  return counts_.at(count_type);
+  auto it = counts_.find(count_type);
+  if (it == counts_.end()) {
+    return 0;
+  }
+  return it->second;
 }
 
 void VerticalTabBrowserMetrics::UpdateEnabledStatus() {

--- a/browser/permissions/localhost_access_permission_browsertest.cc
+++ b/browser/permissions/localhost_access_permission_browsertest.cc
@@ -156,8 +156,6 @@ class LocalhostAccessBrowserTest : public InProcessBrowserTest {
         (async () => {
           console.log("Entered insert image script");
           const img = document.createElement('img');
-          img.src = $1;
-          document.body.appendChild(img);
           return await new Promise((resolve) => {
             img.addEventListener("load", () => {
               resolve(true);
@@ -165,6 +163,8 @@ class LocalhostAccessBrowserTest : public InProcessBrowserTest {
             img.addEventListener("error", () => {
               resolve(false);
             }, {once: true});
+            img.src = $1;
+            document.body.appendChild(img);
           });
         })();
         )",

--- a/browser/ui/sidebar/sidebar_browsertest.cc
+++ b/browser/ui/sidebar/sidebar_browsertest.cc
@@ -351,7 +351,13 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, BasicTest) {
   // Remove Item at index 0 to change active index.
   sidebar_service->RemoveItemAt(0);
   active_item_index--;
-  EXPECT_EQ(--expected_count, model()->GetAllSidebarItems().size());
+  --expected_count;
+
+  // Wait for sidebar item removal to complete before navigation.
+  WaitUntil(base::BindLambdaForTesting([&]() {
+    return model()->GetAllSidebarItems().size() == expected_count;
+  }));
+  EXPECT_EQ(expected_count, model()->GetAllSidebarItems().size());
   EXPECT_THAT(model()->active_index(), Optional(active_item_index));
 
   // If current active tab is not NTP, we can add current url to sidebar.

--- a/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_browsertest.cc
+++ b/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_browsertest.cc
@@ -779,12 +779,16 @@ IN_PROC_BROWSER_TEST_F(VerticalTabStripBrowserTest, PinningGroupedTab) {
   AddTabToExistingGroup(browser(), 3, group);
 
   browser()->tab_strip_model()->SetTabPinned(1, true);
+  browser_view()->tabstrip()->StopAnimating(true);
   EXPECT_EQ(GetTabStrip(browser())->tab_at(0)->group(), std::nullopt);
 
   browser()->tab_strip_model()->SetTabPinned(2, true);
+  browser_view()->tabstrip()->StopAnimating(true);
   EXPECT_EQ(GetTabStrip(browser())->tab_at(1)->group(), std::nullopt);
 
+  ASSERT_TRUE(GetTabStrip(browser())->tab_at(2)->group().has_value());
   EXPECT_EQ(GetTabStrip(browser())->tab_at(2)->group().value(), group);
+  ASSERT_TRUE(GetTabStrip(browser())->tab_at(3)->group().has_value());
   EXPECT_EQ(GetTabStrip(browser())->tab_at(3)->group().value(), group);
 }
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->

Resolves https://github.com/brave/brave-browser/issues/48375 
Resolves https://github.com/brave/brave-browser/issues/47547
Resolves https://github.com/brave/brave-browser/issues/48280
Resolves https://github.com/brave/brave-browser/issues/48056
Resolves https://github.com/brave/brave-browser/issues/47954
Resolves https://github.com/brave/brave-browser/issues/48320
Resolves https://github.com/brave/brave-browser/issues/47687

Uplift of: https://github.com/brave/brave-core/pull/30626
Uplift of: https://github.com/brave/brave-core/pull/30671
Uplift of: https://github.com/brave/brave-core/pull/30672
Uplift of: https://github.com/brave/brave-core/pull/30673
Uplift of: https://github.com/brave/brave-core/pull/30674
Uplift of: https://github.com/brave/brave-core/pull/30675

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
