### PR TITLE
Proxy the favicon URL used on search engines page

### DIFF
--- a/chromium_src/components/favicon/core/large_icon_service_impl.cc
+++ b/chromium_src/components/favicon/core/large_icon_service_impl.cc
@@ -1,0 +1,12 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "components/favicon/core/large_icon_service_impl.h"
+
+#define server_url_(URL) \
+  server_url_("https://favicons.proxy.brave.com/faviconV2")
+
+#include "src/components/favicon/core/large_icon_service_impl.cc"
+#undef server_url_

--- a/patches/content-browser-loader-reconnectable_url_loader_factory.cc.patch
+++ b/patches/content-browser-loader-reconnectable_url_loader_factory.cc.patch
@@ -1,5 +1,5 @@
 diff --git a/content/browser/loader/reconnectable_url_loader_factory.cc b/content/browser/loader/reconnectable_url_loader_factory.cc
-index 1a82d44aade7d4c2648d9f8a370cbee97fc4163c..f52909192d834fefc7fc41987bbe922679056cf5 100644
+index 1a82d44aade7d4c2648d9f8a370cbee97fc4163c..f90d449d0cc5468df6183c6b1d87e37e987ba333 100644
 --- a/content/browser/loader/reconnectable_url_loader_factory.cc
 +++ b/content/browser/loader/reconnectable_url_loader_factory.cc
 @@ -10,6 +10,7 @@
@@ -10,6 +10,15 @@ index 1a82d44aade7d4c2648d9f8a370cbee97fc4163c..f52909192d834fefc7fc41987bbe9226
  
  namespace content {
  
+@@ -29,7 +30,7 @@ void ReconnectableURLLoaderFactory::CreateLoaderAndStart(
+     const net::MutableNetworkTrafficAnnotationTag& traffic_annotation) {
+   if (network::mojom::URLLoaderFactory* factory = GetURLLoaderFactory()) {
+     factory->CreateLoaderAndStart(std::move(receiver), request_id, options,
+-                                  url_request, std::move(client),
++                                  network::SystemRequestHandler::GetInstance()->OnBeforeSystemRequest(url_request), std::move(client),
+                                   traffic_annotation);
+   }
+ }
 @@ -136,7 +137,7 @@ class ReconnectableURLLoaderFactoryForIOThread::URLLoaderFactoryForIOThread
        override {
      DCHECK(BrowserThread::CurrentlyOn(BrowserThread::IO));


### PR DESCRIPTION
## Description
Fixes https://github.com/brave/brave-browser/issues/42127

Originally submitted in https://github.com/brave/brave-core/pull/28646

## Test plan
With this change, we are proxying the URL used in Chromium. It's important to ensure that all favicons display properly on the search engine screen.

1. Install fresh build (Android)
2. Go to `Settings` > `Search engines` > `Standard Tab`
3. Observe the favicon URL in charles proxy (or similar proxy tool)
4. URL should be `favicons.proxy.brave.com` instead of `t0.gstatic.com`