### PR TITLE
[Settings] Move "showSavedTabGroups" and "autoPinNewTabGroups" to the toolbar from appearance (uplift to 1.82.x)

### DIFF
--- a/browser/resources/settings/brave_appearance_page/toolbar.html
+++ b/browser/resources/settings/brave_appearance_page/toolbar.html
@@ -9,6 +9,7 @@
   }
 </style>
 <settings-toggle-button elide-label
+  class="cr-row"
   hidden="[[!pageVisibility.homeButton]]"
   pref="{{prefs.browser.show_home_button}}"
   label="$i18n{showHomeButton}"
@@ -51,6 +52,14 @@
 </settings-toggle-button>
 <settings-brave-appearance-bookmark-bar prefs="{{prefs}}">
 </settings-brave-appearance-bookmark-bar>
+<settings-toggle-button class="hr" id="showSavedTabGroups"
+    pref="{{prefs.bookmark_bar.show_tab_groups}}"
+    label="$i18n{showTabGroupsInBookmarksBar}">
+</settings-toggle-button>
+<settings-toggle-button class="hr" id="autoPinNewTabGroups"
+    pref="{{prefs.auto_pin_new_tab_groups}}"
+    label="$i18n{autoPinNewTabGroups}">
+</settings-toggle-button>
 <settings-toggle-button
   id="autocomplete-suggestion-sources"
   class="cr-row"

--- a/browser/resources/settings/brave_overrides/appearance_page.ts
+++ b/browser/resources/settings/brave_overrides/appearance_page.ts
@@ -191,5 +191,19 @@ RegisterPolymerTemplateModifications({
           </settings-brave-appearance-toolbar>
         `)
     }
+
+    // Remove a couple of items to from appearance page as we have them in
+    // <settings-brave-appearance-toolbar>
+    // - showSavedTabGroups and autoPinNewTabGroups should be after bookmark bar setting
+    const removeElementWithId = (id: string) => {
+      const elem = templateContent.querySelector(`#${id}`)
+      if (!elem) {
+        console.error(`[Settings] Couldn't find element with id: ${id}`)
+      } else {
+        elem.remove()
+      }
+    }
+    removeElementWithId('showSavedTabGroups')
+    removeElementWithId('autoPinNewTabGroups')
   }
 })


### PR DESCRIPTION
Uplift of #30546
Resolves https://github.com/brave/brave-browser/issues/48268

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.