### PR TITLE
Ad block only mode support for content settings

### DIFF
--- a/browser/brave_prefs_browsertest.cc
+++ b/browser/brave_prefs_browsertest.cc
@@ -67,6 +67,8 @@ IN_PROC_BROWSER_TEST_F(BraveProfilePrefsBrowserTest, MiscBravePrefs) {
       kNoScriptControlType));
   EXPECT_FALSE(chrome_test_utils::GetProfile(this)->GetPrefs()->GetBoolean(
       kShieldsAdvancedViewEnabled));
+  EXPECT_FALSE(chrome_test_utils::GetProfile(this)->GetPrefs()->GetBoolean(
+      brave_shields::prefs::kAdBlockOnlyModeEnabled));
   EXPECT_TRUE(chrome_test_utils::GetProfile(this)->GetPrefs()->GetBoolean(
       kShieldsStatsBadgeVisible));
   EXPECT_TRUE(chrome_test_utils::GetProfile(this)->GetPrefs()->GetBoolean(

--- a/browser/brave_profile_prefs.cc
+++ b/browser/brave_profile_prefs.cc
@@ -381,6 +381,8 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
                                 false);
   registry->RegisterBooleanPref(brave_shields::prefs::kAdBlockDeveloperMode,
                                 false);
+  registry->RegisterBooleanPref(brave_shields::prefs::kAdBlockOnlyModeEnabled,
+                                false);
 
 #if BUILDFLAG(ENABLE_BRAVE_WAYBACK_MACHINE)
   registry->RegisterBooleanPref(kBraveWaybackMachineEnabled, true);

--- a/components/brave_shields/core/common/DEPS
+++ b/components/brave_shields/core/common/DEPS
@@ -1,5 +1,6 @@
 include_rules = [
   "+components/content_settings",
   "+components/grit/brave_components_strings.h",
+  "+components/prefs/pref_service.h",
   "+ui/base",
 ]

--- a/components/brave_shields/core/common/brave_shield_utils.cc
+++ b/components/brave_shields/core/common/brave_shield_utils.cc
@@ -9,11 +9,15 @@
 #include <set>
 #include <string>
 
+#include "base/check.h"
 #include "base/containers/map_util.h"
 #include "base/no_destructor.h"
+#include "brave/components/brave_shields/core/common/features.h"
+#include "brave/components/brave_shields/core/common/pref_names.h"
 #include "brave/components/webcompat/core/common/features.h"
 #include "components/content_settings/core/common/content_settings.h"
 #include "components/content_settings/core/common/content_settings_pattern.h"
+#include "components/prefs/pref_service.h"
 #include "url/gurl.h"
 
 namespace brave_shields {
@@ -110,6 +114,20 @@ ShieldsSettingCounts GetAdsSettingCountFromRules(
   }
 
   return result;
+}
+
+bool IsBraveShieldsAdBlockOnlyModeEnabled(PrefService* prefs) {
+  CHECK(prefs);
+  // PrefService::FindPreference call is needed because the
+  // kAdBlockOnlyModeEnabled preference might not be registered for tests.
+  return base::FeatureList::IsEnabled(features::kAdblockOnlyMode) &&
+         prefs->FindPreference(prefs::kAdBlockOnlyModeEnabled) &&
+         prefs->GetBoolean(prefs::kAdBlockOnlyModeEnabled);
+}
+
+void SetBraveShieldsAdBlockOnlyModeEnabled(PrefService* prefs, bool enabled) {
+  CHECK(prefs);
+  prefs->SetBoolean(prefs::kAdBlockOnlyModeEnabled, enabled);
 }
 
 }  // namespace brave_shields

--- a/components/brave_shields/core/common/brave_shield_utils.h
+++ b/components/brave_shields/core/common/brave_shield_utils.h
@@ -11,6 +11,7 @@
 #include "components/content_settings/core/common/content_settings.h"
 
 class GURL;
+class PrefService;
 
 namespace brave_shields {
 
@@ -34,6 +35,10 @@ ShieldsSettingCounts GetFPSettingCountFromRules(
     const ContentSettingsForOneType& fp_rules);
 ShieldsSettingCounts GetAdsSettingCountFromRules(
     const ContentSettingsForOneType& ads_rules);
+
+bool IsBraveShieldsAdBlockOnlyModeEnabled(PrefService* prefs);
+void SetBraveShieldsAdBlockOnlyModeEnabled(PrefService* prefs, bool enabled);
+
 }  // namespace brave_shields
 
 #endif  // BRAVE_COMPONENTS_BRAVE_SHIELDS_CORE_COMMON_BRAVE_SHIELD_UTILS_H_

--- a/components/brave_shields/core/common/features.cc
+++ b/components/brave_shields/core/common/features.cc
@@ -148,6 +148,10 @@ BASE_FEATURE(kBraveShieldsElementPicker,
              "BraveShieldsElementPicker",
              base::FEATURE_ENABLED_BY_DEFAULT);
 
+BASE_FEATURE(kAdblockOnlyMode,
+             "AdblockOnlyMode",
+             base::FEATURE_DISABLED_BY_DEFAULT);
+
 // Enables extra TRACE_EVENTs in content filter js. The feature is
 // primary designed for local debugging.
 BASE_FEATURE(kCosmeticFilteringExtraPerfMetrics,

--- a/components/brave_shields/core/common/features.h
+++ b/components/brave_shields/core/common/features.h
@@ -56,6 +56,7 @@ extern const base::FeatureParam<int>
     kAdblockOverrideRegexDiscardPolicyCleanupIntervalSec;
 extern const base::FeatureParam<int>
     kAdblockOverrideRegexDiscardPolicyDiscardUnusedSec;
+BASE_DECLARE_FEATURE(kAdblockOnlyMode);
 
 }  // namespace features
 }  // namespace brave_shields

--- a/components/brave_shields/core/common/pref_names.h
+++ b/components/brave_shields/core/common/pref_names.h
@@ -34,6 +34,9 @@ inline constexpr char kLinkedInEmbedControlType[] =
     "brave.linkedin_embed_default";
 inline constexpr char kReduceLanguageEnabled[] = "brave.reduce_language";
 
+inline constexpr char kAdBlockOnlyModeEnabled[] =
+    "brave.shields.adblock_only_mode_enabled";
+
 }  // namespace prefs
 }  // namespace brave_shields
 

--- a/components/content_settings/core/browser/ad_block_only_mode_content_settings_utils.cc
+++ b/components/content_settings/core/browser/ad_block_only_mode_content_settings_utils.cc
@@ -1,0 +1,99 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/content_settings/core/browser/ad_block_only_mode_content_settings_utils.h"
+
+#include "base/containers/fixed_flat_set.h"
+#include "base/time/time.h"
+#include "components/content_settings/core/browser/content_settings_origin_value_map.h"
+#include "components/content_settings/core/common/content_settings_enums.mojom.h"
+#include "components/content_settings/core/common/content_settings_metadata.h"
+#include "components/content_settings/core/common/content_settings_utils.h"
+
+namespace content_settings {
+
+namespace {
+
+// JAVASCRIPT and COOKIES content settings types are handled by Brave Profile
+// Policy Provider.
+constexpr auto kAdBlockOnlyModeContentSettingsTypes =
+    base::MakeFixedFlatSet<ContentSettingsType>({
+        ContentSettingsType::BRAVE_COOKIES,
+        ContentSettingsType::BRAVE_REFERRERS,
+        ContentSettingsType::BRAVE_ADS,
+        ContentSettingsType::BRAVE_TRACKERS,
+        ContentSettingsType::BRAVE_COSMETIC_FILTERING,
+        ContentSettingsType::BRAVE_FINGERPRINTING_V2,
+        ContentSettingsType::BRAVE_REMEMBER_1P_STORAGE,
+        ContentSettingsType::BRAVE_HTTPS_UPGRADE,
+    });
+
+// These types are off the record aware so we don't override them in off the
+// record mode.
+static constexpr auto kOffTheRecordAwareTypes =
+    base::MakeFixedFlatSet<ContentSettingsType>({
+        ContentSettingsType::BRAVE_HTTPS_UPGRADE,
+    });
+
+}  // namespace
+
+bool IsAdBlockOnlyModeType(ContentSettingsType content_type,
+                           bool is_off_the_record) {
+  if (!kAdBlockOnlyModeContentSettingsTypes.contains(content_type)) {
+    return false;
+  }
+
+  if (is_off_the_record && kOffTheRecordAwareTypes.contains(content_type)) {
+    return false;
+  }
+
+  return true;
+}
+
+void SetAdBlockOnlyModeRules(OriginValueMap& ad_block_only_mode_rules) {
+  RuleMetaData metadata;
+  metadata.SetExpirationAndLifetime(base::Time(), base::TimeDelta());
+  metadata.set_session_model(mojom::SessionModel::DURABLE);
+
+  base::AutoLock auto_lock(ad_block_only_mode_rules.GetLock());
+  ad_block_only_mode_rules.SetValue(
+      ContentSettingsPattern::Wildcard(), ContentSettingsPattern::Wildcard(),
+      ContentSettingsType::BRAVE_COOKIES,
+      ContentSettingToValue(CONTENT_SETTING_ALLOW), metadata.Clone());
+  ad_block_only_mode_rules.SetValue(
+      ContentSettingsPattern::Wildcard(), ContentSettingsPattern::Wildcard(),
+      ContentSettingsType::BRAVE_REFERRERS,
+      ContentSettingToValue(CONTENT_SETTING_ALLOW), metadata.Clone());
+
+  ad_block_only_mode_rules.SetValue(
+      ContentSettingsPattern::Wildcard(), ContentSettingsPattern::Wildcard(),
+      ContentSettingsType::BRAVE_ADS,
+      ContentSettingToValue(CONTENT_SETTING_BLOCK), metadata.Clone());
+  ad_block_only_mode_rules.SetValue(
+      ContentSettingsPattern::Wildcard(), ContentSettingsPattern::Wildcard(),
+      ContentSettingsType::BRAVE_TRACKERS,
+      ContentSettingToValue(CONTENT_SETTING_ALLOW), metadata.Clone());
+  ad_block_only_mode_rules.SetValue(
+      ContentSettingsPattern::Wildcard(), ContentSettingsPattern::Wildcard(),
+      ContentSettingsType::BRAVE_COSMETIC_FILTERING,
+      ContentSettingToValue(CONTENT_SETTING_ALLOW), metadata.Clone());
+
+  ad_block_only_mode_rules.SetValue(
+      ContentSettingsPattern::Wildcard(), ContentSettingsPattern::Wildcard(),
+      ContentSettingsType::BRAVE_FINGERPRINTING_V2,
+      ContentSettingToValue(CONTENT_SETTING_ALLOW), metadata.Clone());
+
+  ad_block_only_mode_rules.SetValue(
+      ContentSettingsPattern::Wildcard(), ContentSettingsPattern::Wildcard(),
+      ContentSettingsType::BRAVE_REMEMBER_1P_STORAGE,
+      ContentSettingToValue(CONTENT_SETTING_ALLOW), metadata.Clone());
+
+  ad_block_only_mode_rules.SetValue(
+      ContentSettingsPattern::Wildcard(), ContentSettingsPattern::Wildcard(),
+      ContentSettingsType::BRAVE_HTTPS_UPGRADE,
+      ContentSettingToValue(CONTENT_SETTING_ASK), metadata.Clone());
+}
+
+}  // namespace content_settings

--- a/components/content_settings/core/browser/ad_block_only_mode_content_settings_utils.h
+++ b/components/content_settings/core/browser/ad_block_only_mode_content_settings_utils.h
@@ -1,0 +1,22 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_CONTENT_SETTINGS_CORE_BROWSER_AD_BLOCK_ONLY_MODE_CONTENT_SETTINGS_UTILS_H_
+#define BRAVE_COMPONENTS_CONTENT_SETTINGS_CORE_BROWSER_AD_BLOCK_ONLY_MODE_CONTENT_SETTINGS_UTILS_H_
+
+#include "components/content_settings/core/common/content_settings_types.h"
+
+namespace content_settings {
+
+class OriginValueMap;
+
+bool IsAdBlockOnlyModeType(ContentSettingsType content_type,
+                           bool is_off_the_record);
+
+void SetAdBlockOnlyModeRules(OriginValueMap& ad_block_only_mode_rules);
+
+}  // namespace content_settings
+
+#endif  // BRAVE_COMPONENTS_CONTENT_SETTINGS_CORE_BROWSER_AD_BLOCK_ONLY_MODE_CONTENT_SETTINGS_UTILS_H_

--- a/components/content_settings/core/browser/ad_block_only_mode_content_settings_utils_unittest.cc
+++ b/components/content_settings/core/browser/ad_block_only_mode_content_settings_utils_unittest.cc
@@ -1,0 +1,164 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/content_settings/core/browser/ad_block_only_mode_content_settings_utils.h"
+
+#include "base/time/time.h"
+#include "components/content_settings/core/browser/content_settings_origin_value_map.h"
+#include "components/content_settings/core/common/content_settings_enums.mojom.h"
+#include "components/content_settings/core/common/content_settings_metadata.h"
+#include "components/content_settings/core/common/content_settings_pattern.h"
+#include "components/content_settings/core/common/content_settings_types.h"
+#include "components/content_settings/core/common/content_settings_utils.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "url/gurl.h"
+
+namespace content_settings {
+
+class AdBlockOnlyModeContentSettingsUtilsTest : public testing::Test {
+ public:
+  AdBlockOnlyModeContentSettingsUtilsTest() = default;
+  ~AdBlockOnlyModeContentSettingsUtilsTest() override = default;
+
+  void VerifyAdBlockOnlyModeTypes(bool is_off_the_record) {
+    EXPECT_TRUE(IsAdBlockOnlyModeType(ContentSettingsType::JAVASCRIPT,
+                                      is_off_the_record));
+    EXPECT_TRUE(
+        IsAdBlockOnlyModeType(ContentSettingsType::COOKIES, is_off_the_record));
+    EXPECT_TRUE(IsAdBlockOnlyModeType(ContentSettingsType::BRAVE_COOKIES,
+                                      is_off_the_record));
+    EXPECT_TRUE(IsAdBlockOnlyModeType(ContentSettingsType::BRAVE_REFERRERS,
+                                      is_off_the_record));
+    EXPECT_TRUE(IsAdBlockOnlyModeType(ContentSettingsType::BRAVE_ADS,
+                                      is_off_the_record));
+    EXPECT_TRUE(IsAdBlockOnlyModeType(ContentSettingsType::BRAVE_TRACKERS,
+                                      is_off_the_record));
+    EXPECT_TRUE(IsAdBlockOnlyModeType(
+        ContentSettingsType::BRAVE_COSMETIC_FILTERING, is_off_the_record));
+    EXPECT_TRUE(IsAdBlockOnlyModeType(
+        ContentSettingsType::BRAVE_FINGERPRINTING_V2, is_off_the_record));
+    EXPECT_TRUE(IsAdBlockOnlyModeType(
+        ContentSettingsType::BRAVE_REMEMBER_1P_STORAGE, is_off_the_record));
+
+    if (!is_off_the_record) {
+      EXPECT_TRUE(IsAdBlockOnlyModeType(
+          ContentSettingsType::BRAVE_HTTPS_UPGRADE, is_off_the_record));
+    } else {
+      EXPECT_FALSE(IsAdBlockOnlyModeType(
+          ContentSettingsType::BRAVE_HTTPS_UPGRADE, is_off_the_record));
+    }
+  }
+
+  void VerifyNonAdBlockOnlyModeTypes(bool is_off_the_record) {
+    EXPECT_FALSE(IsAdBlockOnlyModeType(ContentSettingsType::GEOLOCATION,
+                                       is_off_the_record));
+    EXPECT_FALSE(IsAdBlockOnlyModeType(ContentSettingsType::NOTIFICATIONS,
+                                       is_off_the_record));
+    EXPECT_FALSE(
+        IsAdBlockOnlyModeType(ContentSettingsType::IMAGES, is_off_the_record));
+    EXPECT_FALSE(IsAdBlockOnlyModeType(ContentSettingsType::BRAVE_SHIELDS,
+                                       is_off_the_record));
+  }
+
+  void VerifyMetaDataExpectation(const RuleMetaData& metadata) {
+    EXPECT_EQ(metadata.session_model(), mojom::SessionModel::DURABLE);
+    EXPECT_EQ(metadata.expiration(), base::Time());
+    EXPECT_EQ(metadata.lifetime(), base::TimeDelta());
+  }
+
+  void VerifyAdBlockOnlyModeRule(OriginValueMap& ad_block_only_mode_rules,
+                                 ContentSettingsType type,
+                                 ContentSetting value) {
+    base::AutoLock auto_lock(ad_block_only_mode_rules.GetLock());
+    auto rule = ad_block_only_mode_rules.GetRule(
+        GURL("https://example.com"), GURL("https://example.com"), type);
+    EXPECT_TRUE(rule);
+    EXPECT_EQ(ValueToContentSetting(rule->value), value);
+    VerifyMetaDataExpectation(rule->metadata);
+  }
+
+  void VerifyNonAdBlockOnlyModeRule(OriginValueMap& ad_block_only_mode_rules,
+                                    ContentSettingsType type) {
+    base::AutoLock auto_lock(ad_block_only_mode_rules.GetLock());
+    auto rule = ad_block_only_mode_rules.GetRule(
+        GURL("https://example.com"), GURL("https://example.com"), type);
+    EXPECT_FALSE(rule);
+  }
+};
+
+TEST_F(AdBlockOnlyModeContentSettingsUtilsTest, IsAdBlockOnlyModeType) {
+  VerifyAdBlockOnlyModeTypes(/*is_off_the_record*/ false);
+  VerifyNonAdBlockOnlyModeTypes(/*is_off_the_record*/ false);
+}
+
+TEST_F(AdBlockOnlyModeContentSettingsUtilsTest,
+       IsAdBlockOnlyModeTypeWhenOffTheRecord) {
+  VerifyAdBlockOnlyModeTypes(/*is_off_the_record*/ true);
+  VerifyNonAdBlockOnlyModeTypes(/*is_off_the_record*/ true);
+}
+
+TEST_F(AdBlockOnlyModeContentSettingsUtilsTest, VerifyAdBlockOnlyModeRules) {
+  OriginValueMap ad_block_only_mode_rules;
+  SetAdBlockOnlyModeRules(ad_block_only_mode_rules);
+
+  VerifyAdBlockOnlyModeRule(ad_block_only_mode_rules,
+                            ContentSettingsType::JAVASCRIPT,
+                            CONTENT_SETTING_ALLOW);
+
+  VerifyAdBlockOnlyModeRule(ad_block_only_mode_rules,
+                            ContentSettingsType::COOKIES,
+                            CONTENT_SETTING_ALLOW);
+
+  VerifyAdBlockOnlyModeRule(ad_block_only_mode_rules,
+                            ContentSettingsType::BRAVE_COOKIES,
+                            CONTENT_SETTING_ALLOW);
+
+  VerifyAdBlockOnlyModeRule(ad_block_only_mode_rules,
+                            ContentSettingsType::BRAVE_REFERRERS,
+                            CONTENT_SETTING_ALLOW);
+
+  VerifyAdBlockOnlyModeRule(ad_block_only_mode_rules,
+                            ContentSettingsType::BRAVE_ADS,
+                            CONTENT_SETTING_BLOCK);
+
+  VerifyAdBlockOnlyModeRule(ad_block_only_mode_rules,
+                            ContentSettingsType::BRAVE_TRACKERS,
+                            CONTENT_SETTING_ALLOW);
+
+  VerifyAdBlockOnlyModeRule(ad_block_only_mode_rules,
+                            ContentSettingsType::BRAVE_COSMETIC_FILTERING,
+                            CONTENT_SETTING_ALLOW);
+
+  VerifyAdBlockOnlyModeRule(ad_block_only_mode_rules,
+                            ContentSettingsType::BRAVE_FINGERPRINTING_V2,
+                            CONTENT_SETTING_ALLOW);
+
+  VerifyAdBlockOnlyModeRule(ad_block_only_mode_rules,
+                            ContentSettingsType::BRAVE_REMEMBER_1P_STORAGE,
+                            CONTENT_SETTING_ALLOW);
+
+  VerifyAdBlockOnlyModeRule(ad_block_only_mode_rules,
+                            ContentSettingsType::BRAVE_HTTPS_UPGRADE,
+                            CONTENT_SETTING_ASK);
+}
+
+TEST_F(AdBlockOnlyModeContentSettingsUtilsTest, VerifyNonAdBlockOnlyModeRules) {
+  OriginValueMap ad_block_only_mode_rules;
+  SetAdBlockOnlyModeRules(ad_block_only_mode_rules);
+
+  VerifyNonAdBlockOnlyModeRule(ad_block_only_mode_rules,
+                               ContentSettingsType::GEOLOCATION);
+
+  VerifyNonAdBlockOnlyModeRule(ad_block_only_mode_rules,
+                               ContentSettingsType::NOTIFICATIONS);
+
+  VerifyNonAdBlockOnlyModeRule(ad_block_only_mode_rules,
+                               ContentSettingsType::IMAGES);
+
+  VerifyNonAdBlockOnlyModeRule(ad_block_only_mode_rules,
+                               ContentSettingsType::BRAVE_SHIELDS);
+}
+
+}  // namespace content_settings

--- a/components/content_settings/core/browser/brave_content_settings_pref_provider.cc
+++ b/components/content_settings/core/browser/brave_content_settings_pref_provider.cc
@@ -22,7 +22,10 @@
 #include "base/task/bind_post_task.h"
 #include "base/task/sequenced_task_runner.h"
 #include "brave/components/brave_shields/core/common/brave_shield_constants.h"
+#include "brave/components/brave_shields/core/common/brave_shield_utils.h"
+#include "brave/components/brave_shields/core/common/pref_names.h"
 #include "brave/components/constants/pref_names.h"
+#include "brave/components/content_settings/core/browser/ad_block_only_mode_content_settings_utils.h"
 #include "brave/components/content_settings/core/browser/brave_content_settings_utils.h"
 #include "brave/components/content_settings/core/common/content_settings_util.h"
 #include "brave/components/google_sign_in_permission/google_sign_in_permission_util.h"
@@ -115,11 +118,18 @@ BravePrefProvider::BravePrefProvider(PrefService* prefs,
       kGoogleLoginControlType,
       base::BindRepeating(&BravePrefProvider::OnCookiePrefsChanged,
                           base::Unretained(this)));
+  pref_change_registrar_.Add(
+      brave_shields::prefs::kAdBlockOnlyModeEnabled,
+      base::BindRepeating(&BravePrefProvider::UpdateAdBlockOnlyModeEnabledFlag,
+                          base::Unretained(this)));
 
   MigrateShieldsSettings(off_the_record_);
   MigrateFingerprintingSetingsToOriginScoped();
 
   OnCookieSettingsChanged(ContentSettingsType::BRAVE_COOKIES);
+
+  SetAdBlockOnlyModeRules(ad_block_only_mode_rules_);
+  UpdateAdBlockOnlyModeEnabledFlag();
 
   // Enable change notifications after initial setup to avoid notification spam
   initialized_ = true;
@@ -635,10 +645,19 @@ bool BravePrefProvider::SetWebsiteSettingInternal(
                                          constraints, partition_key);
 }
 
+bool BravePrefProvider::IsAdBlockOnlyModeEnabled() const {
+  return ad_block_only_mode_enabled_.load(std::memory_order_relaxed);
+}
+
 std::unique_ptr<RuleIterator> BravePrefProvider::GetRuleIterator(
     ContentSettingsType content_type,
     bool incognito,
     const PartitionKey& partition_key) const {
+  if (IsAdBlockOnlyModeType(content_type, incognito) &&
+      IsAdBlockOnlyModeEnabled()) {
+    return ad_block_only_mode_rules_.GetRuleIterator(content_type);
+  }
+
   if (content_type == ContentSettingsType::COOKIES) {
     const auto& rules = cookie_rules_.at(incognito);
     return rules.GetRuleIterator(content_type);
@@ -653,6 +672,13 @@ std::unique_ptr<Rule> BravePrefProvider::GetRule(
     ContentSettingsType content_type,
     bool off_the_record,
     const PartitionKey& partition_key) const {
+  if (IsAdBlockOnlyModeType(content_type, off_the_record) &&
+      IsAdBlockOnlyModeEnabled()) {
+    base::AutoLock auto_lock(ad_block_only_mode_rules_.GetLock());
+    return ad_block_only_mode_rules_.GetRule(primary_url, secondary_url,
+                                             content_type);
+  }
+
   if (content_type == ContentSettingsType::COOKIES) {
     const auto& rules = cookie_rules_.at(off_the_record);
     base::AutoLock auto_lock(rules.GetLock());
@@ -922,6 +948,13 @@ void BravePrefProvider::NotifyChanges(
 
 void BravePrefProvider::OnCookiePrefsChanged(const std::string& pref) {
   OnCookieSettingsChanged(ContentSettingsType::BRAVE_COOKIES);
+}
+
+void BravePrefProvider::UpdateAdBlockOnlyModeEnabledFlag() {
+  const bool ad_block_only_mode_enabled =
+      brave_shields::IsBraveShieldsAdBlockOnlyModeEnabled(prefs_);
+  ad_block_only_mode_enabled_.store(ad_block_only_mode_enabled,
+                                    std::memory_order_relaxed);
 }
 
 void BravePrefProvider::OnCookieSettingsChanged(

--- a/components/content_settings/core/browser/brave_content_settings_pref_provider.h
+++ b/components/content_settings/core/browser/brave_content_settings_pref_provider.h
@@ -6,6 +6,7 @@
 #ifndef BRAVE_COMPONENTS_CONTENT_SETTINGS_CORE_BROWSER_BRAVE_CONTENT_SETTINGS_PREF_PROVIDER_H_
 #define BRAVE_COMPONENTS_CONTENT_SETTINGS_CORE_BROWSER_BRAVE_CONTENT_SETTINGS_PREF_PROVIDER_H_
 
+#include <atomic>
 #include <map>
 #include <memory>
 #include <string>
@@ -115,22 +116,28 @@ class BravePrefProvider : public PrefProvider, public Observer {
       const ContentSettingConstraints& constraints,
       const PartitionKey& partition_key = PartitionKey::WipGetDefault());
 
+  bool IsAdBlockOnlyModeEnabled() const;
+
   // content_settings::Observer overrides:
   void OnContentSettingChanged(const ContentSettingsPattern& primary_pattern,
                                const ContentSettingsPattern& secondary_pattern,
                                ContentSettingsType content_type) override;
   void OnCookiePrefsChanged(const std::string& pref);
+  void UpdateAdBlockOnlyModeEnabledFlag();
 
   std::map<bool /* is_incognito */, OriginValueMap> cookie_rules_;
   std::map<bool /* is_incognito */, std::vector<std::unique_ptr<Rule>>>
       brave_cookie_rules_;
   std::map<bool /* is_incognito */, std::vector<std::unique_ptr<Rule>>>
       brave_shield_down_rules_;
+  OriginValueMap ad_block_only_mode_rules_;
 
   bool initialized_;
   bool store_last_modified_;
 
   PrefChangeRegistrar pref_change_registrar_;
+
+  mutable std::atomic<bool> ad_block_only_mode_enabled_ = false;
 
   base::WeakPtrFactory<BravePrefProvider> weak_factory_;
 };

--- a/components/content_settings/core/browser/brave_content_settings_pref_provider_unittest.cc
+++ b/components/content_settings/core/browser/brave_content_settings_pref_provider_unittest.cc
@@ -14,8 +14,11 @@
 #include "base/json/values_util.h"
 #include "base/memory/raw_ptr.h"
 #include "base/strings/string_number_conversions.h"
+#include "base/test/scoped_feature_list.h"
 #include "base/values.h"
 #include "brave/components/brave_shields/core/common/brave_shield_constants.h"
+#include "brave/components/brave_shields/core/common/features.h"
+#include "brave/components/brave_shields/core/common/pref_names.h"
 #include "brave/components/constants/pref_names.h"
 #include "brave/components/content_settings/core/browser/brave_content_settings_utils.h"
 #include "chrome/test/base/testing_profile.h"
@@ -154,6 +157,15 @@ class ShieldsSetting {
     CheckSettings(url, CONTENT_SETTING_ASK);
   }
 
+  void CheckIncognitoSettings(const GURL& url, ContentSetting setting) const {
+    for (const auto& url_source : urls_) {
+      EXPECT_EQ(setting,
+                TestUtils::GetContentSetting(provider_, url, url_source.first,
+                                             url_source.second,
+                                             /*include_incognito=*/true));
+    }
+  }
+
  protected:
   virtual void CheckSettings(const GURL& url, ContentSetting setting) const {
     for (const auto& url_source : urls_) {
@@ -245,6 +257,13 @@ class ShieldsHTTPSESetting : public ShieldsSetting {
       : ShieldsSetting(
             provider,
             {{GURL(), ContentSettingsType::BRAVE_HTTP_UPGRADABLE_RESOURCES}}) {}
+};
+
+class ShieldsHttpsUpgradeSetting : public ShieldsSetting {
+ public:
+  explicit ShieldsHttpsUpgradeSetting(BravePrefProvider* provider)
+      : ShieldsSetting(provider,
+                       {{GURL(), ContentSettingsType::BRAVE_HTTPS_UPGRADE}}) {}
 };
 
 class ShieldsAdsSetting : public ShieldsSetting {
@@ -726,6 +745,245 @@ TEST_F(BravePrefProviderTest, EnsureNoWildcardEntries) {
   base::RunLoop().RunUntilIdle();
   // Verify global has reset
   shields_enabled_settings.CheckSettingsAreDefault(example_url);
+  provider.ShutdownOnUIThread();
+}
+
+TEST_F(BravePrefProviderTest, AdblockOnlyModeContentSettingsDefaultValues) {
+  base::test::ScopedFeatureList feature_list;
+  feature_list.InitAndEnableFeature(brave_shields::features::kAdblockOnlyMode);
+
+  BravePrefProvider provider(
+      testing_profile()->GetPrefs(), false /* incognito */,
+      true /* store_last_modified */, false /* restore_session */);
+  GURL url("https://brave.com/");
+
+  ShieldsCookieSetting shields_cookie_settings(&provider,
+                                               testing_profile()->GetPrefs());
+  CookieSettings cookie_settings(&provider);
+  ShieldsFingerprintingSetting fp_settings(&provider);
+  ShieldsScriptSetting script_settings(&provider);
+  ShieldsHttpsUpgradeSetting https_upgrade_settings(&provider);
+
+  // Verify that the settings are default values.
+  shields_cookie_settings.CheckSettingsAreDefault(url);
+  cookie_settings.CheckSettingsAreDefault(url);
+  fp_settings.CheckSettingsAreDefault(url);
+  script_settings.CheckSettingsAreDefault(url);
+  https_upgrade_settings.CheckSettingsAreDefault(url);
+
+  testing_profile()->GetPrefs()->SetBoolean(
+      brave_shields::prefs::kAdBlockOnlyModeEnabled, true);
+
+  // Verify that adblock only mode overrides settings.
+  shields_cookie_settings.CheckSettingsWouldAllow(url);
+  cookie_settings.CheckSettingsWouldAllow(url);
+  fp_settings.CheckSettingsWouldAllow(url);
+  script_settings.CheckSettingsWouldAllow(url);
+  https_upgrade_settings.CheckSettingsWouldAsk(url);
+
+  provider.ShutdownOnUIThread();
+}
+
+TEST_F(BravePrefProviderTest,
+       AdblockOnlyModeContentSettingsWhenFeatureDisabled) {
+  base::test::ScopedFeatureList feature_list;
+  feature_list.InitAndDisableFeature(brave_shields::features::kAdblockOnlyMode);
+
+  BravePrefProvider provider(
+      testing_profile()->GetPrefs(), false /* incognito */,
+      true /* store_last_modified */, false /* restore_session */);
+  GURL url("https://brave.com/");
+
+  ShieldsCookieSetting shields_cookie_settings(&provider,
+                                               testing_profile()->GetPrefs());
+  CookieSettings cookie_settings(&provider);
+  ShieldsFingerprintingSetting fp_settings(&provider);
+  ShieldsScriptSetting script_settings(&provider);
+  ShieldsHttpsUpgradeSetting https_upgrade_settings(&provider);
+
+  // Verify that the settings are default values.
+  shields_cookie_settings.CheckSettingsAreDefault(url);
+  cookie_settings.CheckSettingsAreDefault(url);
+  fp_settings.CheckSettingsAreDefault(url);
+  script_settings.CheckSettingsAreDefault(url);
+  https_upgrade_settings.CheckSettingsAreDefault(url);
+
+  testing_profile()->GetPrefs()->SetBoolean(
+      brave_shields::prefs::kAdBlockOnlyModeEnabled, true);
+
+  // Verify that adblock only mode doesn't override settings.
+  shields_cookie_settings.CheckSettingsAreDefault(url);
+  cookie_settings.CheckSettingsAreDefault(url);
+  fp_settings.CheckSettingsAreDefault(url);
+  script_settings.CheckSettingsAreDefault(url);
+  https_upgrade_settings.CheckSettingsAreDefault(url);
+
+  provider.ShutdownOnUIThread();
+}
+
+TEST_F(BravePrefProviderTest, NonAdblockOnlyModeContentSettingsDefaultValues) {
+  base::test::ScopedFeatureList feature_list;
+  feature_list.InitAndEnableFeature(brave_shields::features::kAdblockOnlyMode);
+
+  BravePrefProvider provider(
+      testing_profile()->GetPrefs(), false /* incognito */,
+      true /* store_last_modified */, false /* restore_session */);
+  GURL url("https://brave.com/");
+
+  ShieldsEnabledSetting enabled_settings(&provider);
+  ShieldsHTTPSESetting httpse_settings(&provider);
+
+  // Verify that the settings are default values.
+  enabled_settings.CheckSettingsAreDefault(url);
+  httpse_settings.CheckSettingsAreDefault(url);
+
+  // Verify that adblock only mode doesn't override settings.
+  testing_profile()->GetPrefs()->SetBoolean(
+      brave_shields::prefs::kAdBlockOnlyModeEnabled, true);
+  enabled_settings.CheckSettingsAreDefault(url);
+  httpse_settings.CheckSettingsAreDefault(url);
+
+  provider.ShutdownOnUIThread();
+}
+
+TEST_F(BravePrefProviderTest, AdblockOnlyModeContentSettingsUserDefinedValues) {
+  base::test::ScopedFeatureList feature_list;
+  feature_list.InitAndEnableFeature(brave_shields::features::kAdblockOnlyMode);
+
+  BravePrefProvider provider(
+      testing_profile()->GetPrefs(), false /* incognito */,
+      true /* store_last_modified */, false /* restore_session */);
+  GURL url("https://brave.com/");
+
+  ShieldsCookieSetting shields_cookie_settings(&provider,
+                                               testing_profile()->GetPrefs());
+  CookieSettings cookie_settings(&provider);
+  ShieldsFingerprintingSetting fp_settings(&provider);
+  ShieldsScriptSetting script_settings(&provider);
+  ShieldsHttpsUpgradeSetting https_upgrade_settings(&provider);
+
+  shields_cookie_settings.SetPreMigrationSettings(
+      ContentSettingsPattern::FromURL(url), CONTENT_SETTING_BLOCK);
+  cookie_settings.SetPreMigrationSettings(ContentSettingsPattern::FromURL(url),
+                                          CONTENT_SETTING_BLOCK);
+  fp_settings.SetPreMigrationSettings(ContentSettingsPattern::FromURL(url),
+                                      CONTENT_SETTING_BLOCK);
+  script_settings.SetPreMigrationSettings(ContentSettingsPattern::FromURL(url),
+                                          CONTENT_SETTING_BLOCK);
+  https_upgrade_settings.SetPreMigrationSettings(
+      ContentSettingsPattern::FromURL(url), CONTENT_SETTING_BLOCK);
+
+  testing_profile()->GetPrefs()->SetBoolean(
+      brave_shields::prefs::kAdBlockOnlyModeEnabled, true);
+
+  // Verify that adblock only mode overrides settings.
+  shields_cookie_settings.CheckSettingsWouldAllow(url);
+  cookie_settings.CheckSettingsWouldAllow(url);
+  fp_settings.CheckSettingsWouldAllow(url);
+  script_settings.CheckSettingsWouldAllow(url);
+  https_upgrade_settings.CheckSettingsWouldAsk(url);
+
+  provider.ShutdownOnUIThread();
+}
+
+TEST_F(BravePrefProviderTest,
+       AdblockOnlyModeContentSettingsDefaultValuesWhenOffTheRecord) {
+  base::test::ScopedFeatureList feature_list;
+  feature_list.InitAndEnableFeature(brave_shields::features::kAdblockOnlyMode);
+
+  BravePrefProvider provider(
+      testing_profile()->GetPrefs(), true /* incognito */,
+      true /* store_last_modified */, false /* restore_session */);
+  GURL url("https://brave.com/");
+
+  ShieldsCookieSetting shields_cookie_settings(&provider,
+                                               testing_profile()->GetPrefs());
+  CookieSettings cookie_settings(&provider);
+  ShieldsFingerprintingSetting fp_settings(&provider);
+  ShieldsScriptSetting script_settings(&provider);
+
+  // Verify that the settings are default values.
+  shields_cookie_settings.CheckIncognitoSettings(url, CONTENT_SETTING_DEFAULT);
+  cookie_settings.CheckIncognitoSettings(url, CONTENT_SETTING_DEFAULT);
+  fp_settings.CheckIncognitoSettings(url, CONTENT_SETTING_DEFAULT);
+  script_settings.CheckIncognitoSettings(url, CONTENT_SETTING_DEFAULT);
+
+  testing_profile()->GetPrefs()->SetBoolean(
+      brave_shields::prefs::kAdBlockOnlyModeEnabled, true);
+
+  // Verify that adblock only mode overrides settings.
+  shields_cookie_settings.CheckIncognitoSettings(url, CONTENT_SETTING_ALLOW);
+  cookie_settings.CheckIncognitoSettings(url, CONTENT_SETTING_ALLOW);
+  fp_settings.CheckIncognitoSettings(url, CONTENT_SETTING_ALLOW);
+  script_settings.CheckIncognitoSettings(url, CONTENT_SETTING_ALLOW);
+
+  provider.ShutdownOnUIThread();
+}
+
+TEST_F(BravePrefProviderTest,
+       NonAdblockOnlyModeContentSettingsDefaultValuesWhenOffTheRecord) {
+  base::test::ScopedFeatureList feature_list;
+  feature_list.InitAndEnableFeature(brave_shields::features::kAdblockOnlyMode);
+
+  BravePrefProvider provider(
+      testing_profile()->GetPrefs(), true /* incognito */,
+      true /* store_last_modified */, false /* restore_session */);
+  GURL url("https://brave.com/");
+
+  ShieldsEnabledSetting enabled_settings(&provider);
+  ShieldsHTTPSESetting httpse_settings(&provider);
+
+  // Verify that the settings are default values.
+  enabled_settings.CheckIncognitoSettings(url, CONTENT_SETTING_DEFAULT);
+  httpse_settings.CheckIncognitoSettings(url, CONTENT_SETTING_DEFAULT);
+
+  // Verify that adblock only mode doesn't override settings.
+  testing_profile()->GetPrefs()->SetBoolean(
+      brave_shields::prefs::kAdBlockOnlyModeEnabled, true);
+  enabled_settings.CheckIncognitoSettings(url, CONTENT_SETTING_DEFAULT);
+  httpse_settings.CheckIncognitoSettings(url, CONTENT_SETTING_DEFAULT);
+
+  provider.ShutdownOnUIThread();
+}
+
+TEST_F(BravePrefProviderTest,
+       AdblockOnlyModeContentSettingsUserDefinedValuesWhenOffTheRecord) {
+  base::test::ScopedFeatureList feature_list;
+  feature_list.InitAndEnableFeature(brave_shields::features::kAdblockOnlyMode);
+
+  BravePrefProvider provider(
+      testing_profile()->GetPrefs(), true /* incognito */,
+      true /* store_last_modified */, false /* restore_session */);
+  GURL url("https://brave.com/");
+
+  ShieldsCookieSetting shields_cookie_settings(&provider,
+                                               testing_profile()->GetPrefs());
+  CookieSettings cookie_settings(&provider);
+  ShieldsFingerprintingSetting fp_settings(&provider);
+  ShieldsScriptSetting script_settings(&provider);
+  ShieldsHttpsUpgradeSetting https_upgrade_settings(&provider);
+
+  shields_cookie_settings.SetPreMigrationSettings(
+      ContentSettingsPattern::FromURL(url), CONTENT_SETTING_BLOCK);
+  cookie_settings.SetPreMigrationSettings(ContentSettingsPattern::FromURL(url),
+                                          CONTENT_SETTING_BLOCK);
+  fp_settings.SetPreMigrationSettings(ContentSettingsPattern::FromURL(url),
+                                      CONTENT_SETTING_BLOCK);
+  script_settings.SetPreMigrationSettings(ContentSettingsPattern::FromURL(url),
+                                          CONTENT_SETTING_BLOCK);
+  https_upgrade_settings.SetPreMigrationSettings(
+      ContentSettingsPattern::FromURL(url), CONTENT_SETTING_BLOCK);
+
+  testing_profile()->GetPrefs()->SetBoolean(
+      brave_shields::prefs::kAdBlockOnlyModeEnabled, true);
+
+  // Verify that adblock only mode overrides settings.
+  shields_cookie_settings.CheckIncognitoSettings(url, CONTENT_SETTING_ALLOW);
+  cookie_settings.CheckIncognitoSettings(url, CONTENT_SETTING_ALLOW);
+  fp_settings.CheckIncognitoSettings(url, CONTENT_SETTING_ALLOW);
+  script_settings.CheckIncognitoSettings(url, CONTENT_SETTING_ALLOW);
+  https_upgrade_settings.CheckIncognitoSettings(url, CONTENT_SETTING_BLOCK);
+
   provider.ShutdownOnUIThread();
 }
 

--- a/components/content_settings/core/browser/sources.gni
+++ b/components/content_settings/core/browser/sources.gni
@@ -8,6 +8,8 @@ brave_components_content_settings_core_browser_deps = []
 
 if (!is_ios) {
   brave_components_content_settings_core_browser_sources += [
+    "//brave/components/content_settings/core/browser/ad_block_only_mode_content_settings_utils.cc",
+    "//brave/components/content_settings/core/browser/ad_block_only_mode_content_settings_utils.h",
     "//brave/components/content_settings/core/browser/brave_content_settings_pref_provider.cc",
     "//brave/components/content_settings/core/browser/brave_content_settings_pref_provider.h",
     "//brave/components/content_settings/core/browser/brave_content_settings_utils.cc",

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -120,6 +120,7 @@ test("brave_unit_tests") {
     "//brave/components/brave_search/browser/brave_search_default_host_unittest.cc",
     "//brave/components/brave_search/browser/brave_search_fallback_host_unittest.cc",
     "//brave/components/brave_sync/crypto/crypto_unittest.cc",
+    "//brave/components/content_settings/core/browser/ad_block_only_mode_content_settings_utils_unittest.cc",
     "//brave/components/content_settings/core/browser/brave_content_settings_pref_provider_unittest.cc",
     "//brave/components/content_settings/core/browser/brave_content_settings_utils_unittest.cc",
     "//brave/components/ntp_background_images/browser/ntp_background_images_service_unittest.cc",


### PR DESCRIPTION
The PR sets some content settings to always have certain predefined values if `ad blocking only mode` preference is enabled.

This is a content setting handling part of `ad blocking only mode` functionality separated from full implementation draft PR https://github.com/brave/brave-core/pull/30695.
For more details please see security/privacy issue https://github.com/brave/reviews/issues/2021 and the spec.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/48522

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
