### PR TITLE
Changed default value for BRAVE_COOKIES content settings.

### DIFF
--- a/browser/content_settings/brave_content_settings_registry_unittest.cc
+++ b/browser/content_settings/brave_content_settings_registry_unittest.cc
@@ -59,7 +59,9 @@ TEST_F(BraveContentSettingsRegistryTest, Properties) {
             website_settings_info->pref_name());
   EXPECT_EQ("profile.default_content_setting_values.shieldsCookiesV3",
             website_settings_info->default_value_pref_name());
-  ASSERT_TRUE(website_settings_info->initial_default_value().is_none());
+  ASSERT_TRUE(website_settings_info->initial_default_value().is_int());
+  EXPECT_EQ(CONTENT_SETTING_ALLOW,
+            website_settings_info->initial_default_value().GetInt());
 #if BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_IOS)
   EXPECT_EQ(PrefRegistry::NO_REGISTRATION_FLAGS,
             website_settings_info->GetPrefRegistrationFlags());
@@ -118,8 +120,9 @@ TEST_F(BraveContentSettingsRegistryTest, Inheritance) {
     SCOPED_TRACE("Content setting: " + info->website_settings_info()->name());
 
     if (info->website_settings_info()->type() <
-        ContentSettingsType::BRAVE_START)
+        ContentSettingsType::BRAVE_START) {
       continue;
+    }
 
     if (info->incognito_behavior() ==
         ContentSettingsInfo::INHERIT_IN_INCOGNITO) {

--- a/chromium_src/components/content_settings/core/browser/content_settings_registry.cc
+++ b/chromium_src/components/content_settings/core/browser/content_settings_registry.cc
@@ -99,10 +99,10 @@ void ContentSettingsRegistry::BraveInit() {
 
   Register(
       ContentSettingsType::BRAVE_COOKIES, brave_shields::kCookies,
-      CONTENT_SETTING_DEFAULT, WebsiteSettingsInfo::SYNCABLE,
+      CONTENT_SETTING_ALLOW, WebsiteSettingsInfo::SYNCABLE,
       /*allowlisted_schemes=*/{kChromeUIScheme, kChromeDevToolsScheme},
       /*valid_settings=*/
-      {CONTENT_SETTING_ALLOW, CONTENT_SETTING_BLOCK, CONTENT_SETTING_DEFAULT},
+      {CONTENT_SETTING_ALLOW, CONTENT_SETTING_BLOCK},
       WebsiteSettingsInfo::REQUESTING_ORIGIN_WITH_TOP_ORIGIN_EXCEPTIONS_SCOPE,
       WebsiteSettingsRegistry::DESKTOP |
           WebsiteSettingsRegistry::PLATFORM_ANDROID,

--- a/chromium_src/components/content_settings/core/browser/content_settings_registry.cc
+++ b/chromium_src/components/content_settings/core/browser/content_settings_registry.cc
@@ -97,6 +97,11 @@ void ContentSettingsRegistry::BraveInit() {
            ContentSettingsInfo::INHERIT_IN_INCOGNITO,
            PermissionSettingsInfo::EXCEPTIONS_ON_SECURE_AND_INSECURE_ORIGINS);
 
+  /* The default value for BRAVE_COOKIES specified during registration isn't
+   * important because the GetCookieControlType function identifies the default
+   * by looking for a (*,*) pattern and uses the COOKIES value.
+   * BRAVE_COOKIES is registered with CONTENT_SETTING_ALLOW for consistency with
+   * the COOKIES type. */
   Register(
       ContentSettingsType::BRAVE_COOKIES, brave_shields::kCookies,
       CONTENT_SETTING_ALLOW, WebsiteSettingsInfo::SYNCABLE,

--- a/components/brave_shields/core/test/brave_shields_utils_unittest.cc
+++ b/components/brave_shields/core/test/brave_shields_utils_unittest.cc
@@ -539,6 +539,9 @@ TEST_F(BraveShieldsUtilTest, GetCookieControlType_Default) {
   auto* map = HostContentSettingsMapFactory::GetForProfile(profile());
   auto cookies = CookieSettingsFactory::GetForProfile(profile());
 
+  EXPECT_EQ(CONTENT_SETTING_ALLOW,
+            map->GetContentSetting(GURL::EmptyGURL(), GURL::EmptyGURL(),
+                                   ContentSettingsType::BRAVE_COOKIES));
   auto setting =
       brave_shields::GetCookieControlType(map, cookies.get(), GURL());
   EXPECT_EQ(ControlType::BLOCK_THIRD_PARTY, setting);
@@ -572,6 +575,10 @@ TEST_F(BraveShieldsUtilTest, GetCookieControlType_Default) {
   setting = brave_shields::GetCookieControlType(map, cookies.get(),
                                                 GURL("http://brave.com"));
   EXPECT_EQ(ControlType::BLOCK_THIRD_PARTY, setting);
+
+  // Setting CONTENT_SETTING_DEFAULT doesn't produce any CHECKS or crashes.
+  map->SetDefaultContentSetting(ContentSettingsType::BRAVE_COOKIES,
+                                CONTENT_SETTING_DEFAULT);
 }
 
 TEST_F(BraveShieldsUtilTest, GetCookieControlType_WithUserSettings) {


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/48499

The `BRAVE_COOKIES` content setting does not use `CONTENT_SETTING_DEFAULT`. All access is managed by helper functions that defer to the default `COOKIES` setting. The value specified during registration isn't important because the `GetCookieControlType` function identifies the default by looking for a `(*,*)` pattern and uses the `COOKIES` value. So, `BRAVE_COOKIES` is registered with `CONTENT_SETTING_ALLOW` for consistency with the `COOKIES` type. 