### PR TITLE
[CodeHealth] Use base::ByteCount instead of performing math on literals.

### DIFF
--- a/browser/brave_ads/device_id/device_id_impl_win.cc
+++ b/browser/brave_ads/device_id/device_id_impl_win.cc
@@ -22,6 +22,7 @@
 #include <string>
 #include <utility>
 
+#include "base/byte_count.h"
 #include "base/files/file_path.h"
 #include "base/functional/bind.h"
 #include "base/location.h"
@@ -104,7 +105,7 @@ std::string GetMacAddressFromGetAdaptersAddresses(
                                                 base::BlockingType::MAY_BLOCK);
 
   // Microsoft recommend a default size of 15k.
-  ULONG buffer_size = 15 * 1024;
+  ULONG buffer_size = base::KiB(15).InBytes();
 
   // Disable as much as we can, since all we want is MAC addresses.
   const ULONG flags = GAA_FLAG_SKIP_ANYCAST | GAA_FLAG_SKIP_DNS_SERVER |

--- a/browser/brave_search/backup_results_service_impl.cc
+++ b/browser/brave_search/backup_results_service_impl.cc
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <utility>
 
+#include "base/byte_count.h"
 #include "base/functional/bind.h"
 #include "brave/components/brave_search/browser/backup_results_allowed_urls.h"
 #include "brave/components/brave_search/browser/backup_results_service.h"
@@ -57,7 +58,7 @@ constexpr net::NetworkTrafficAnnotationTag kNetworkTrafficAnnotationTag =
       }
     )");
 
-constexpr size_t kMaxResponseSize = 5 * 1024 * 1024;
+constexpr base::ByteCount kMaxResponseSize = base::MiB(5);
 constexpr base::TimeDelta kTimeout = base::Seconds(5);
 
 class BackupResultsWebContentsObserver
@@ -291,7 +292,7 @@ void BackupResultsServiceImpl::MakeSimpleURLLoaderRequest(
       pending_request->shared_url_loader_factory.get(),
       base::BindOnce(&BackupResultsServiceImpl::HandleURLLoaderResponse,
                      base::Unretained(this), pending_request),
-      kMaxResponseSize);
+      kMaxResponseSize.InBytes());
 }
 
 void BackupResultsServiceImpl::HandleURLLoaderResponse(

--- a/browser/ui/webui/brave_adblock_internals_ui.cc
+++ b/browser/ui/webui/brave_adblock_internals_ui.cc
@@ -11,6 +11,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/byte_count.h"
 #include "base/check.h"
 #include "base/check_op.h"
 #include "base/functional/bind.h"
@@ -96,7 +97,7 @@ class BraveAdblockInternalsMessageHandler
       if (value) {
         mem_info.Set(
             std::string(metric.dump_name) + "/" + metric.metric + "_kb",
-            base::NumberToString(*value / 1024));
+            base::NumberToString(base::ByteCount(*value).InKiB()));
       }
     }
 

--- a/browser/ui/webui/brave_education/brave_education_server_checker.cc
+++ b/browser/ui/webui/brave_education/brave_education_server_checker.cc
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include "base/byte_count.h"
 #include "base/check.h"
 #include "base/strings/string_split.h"
 #include "components/language/core/browser/pref_names.h"
@@ -21,7 +22,7 @@ namespace brave_education {
 
 namespace {
 
-constexpr int64_t kMaxDownloadBytes = 1024 * 1024;
+constexpr base::ByteCount kMaxDownload = base::MiB(1);
 constexpr base::TimeDelta kTimeoutDuration = base::Seconds(2);
 
 constexpr auto kTrafficAnnotation =
@@ -97,7 +98,7 @@ void BraveEducationServerChecker::IsServerPageAvailable(
 
   url_loader_ptr->DownloadToString(url_loader_factory_.get(),
                                    std::move(download_callback),
-                                   kMaxDownloadBytes);
+                                   kMaxDownload.InBytes());
 }
 
 void BraveEducationServerChecker::OnURLResponse(

--- a/browser/ui/webui/settings/brave_tor_handler.cc
+++ b/browser/ui/webui/settings/brave_tor_handler.cc
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "base/base64.h"
+#include "base/byte_count.h"
 #include "base/check.h"
 #include "base/check_op.h"
 #include "base/functional/bind.h"
@@ -68,7 +69,7 @@ constexpr net::NetworkTrafficAnnotationTag kTorBridgesMoatAnnotation =
       cookies_allowed: NO
     })");
 
-constexpr size_t kMaxBodySize = 256 * 1024;
+constexpr base::ByteCount kMaxBodySize = base::KiB(256);
 
 base::Value FetchCaptchaData() {
   base::Value::Dict data;
@@ -265,7 +266,8 @@ class BridgeRequest {
       url_loader->AttachStringForUpload(data_content);
     }
     url_loader->DownloadToString(url_loader_factory_.get(),
-                                 std::move(response_callback), kMaxBodySize);
+                                 std::move(response_callback),
+                                 kMaxBodySize.InBytes());
 
     return url_loader;
   }

--- a/browser/ui/window_closing_confirm_browsertest.cc
+++ b/browser/ui/window_closing_confirm_browsertest.cc
@@ -3,6 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include "base/byte_count.h"
 #include "base/check.h"
 #include "base/functional/bind.h"
 #include "base/run_loop.h"
@@ -296,7 +297,7 @@ IN_PROC_BROWSER_TEST_F(WindowClosingConfirmBrowserTest,
   GURL url = embedded_test_server()->GetURL("/large_file");
 
   content::TestDownloadHttpResponse::Parameters parameters;
-  parameters.size = 1024 * 1024 * 32; /* 32MB file. */
+  parameters.size = base::MiB(32).InBytes(); /* 32MB file. */
   content::TestDownloadHttpResponse::StartServing(parameters, url);
 
   // Ensure that we have enough disk space to download the large file.


### PR DESCRIPTION
In CR140, `base::ByteCount` was introduced which takes care of converting between the various SI byte units. This commit introduces usage of the ByteCount class and related utility functions in all code under `browser/` where it makes sense to do so.
