### PR TITLE
Remove shell=true on Windows from build/commands to fix DEP0190.

### DIFF
--- a/build/commands/lib/config.js
+++ b/build/commands/lib/config.js
@@ -1317,8 +1317,6 @@ Object.defineProperty(Config.prototype, 'defaultOptions', {
       env,
       stdio: stdio,
       cwd: this.srcDir,
-      // Shell is required to launch .bat files (gclient, vpython3, etc.).
-      shell: process.platform === 'win32',
       git_cwd: '.',
     }
   },

--- a/build/commands/lib/perfTests.js
+++ b/build/commands/lib/perfTests.js
@@ -50,15 +50,7 @@ const runPerfTests = (
   args.push(...passthroughArgs)
   console.log(args)
 
-  let cmdOptions = {
-    ...config.defaultOptions,
-    shell: false,
-  }
-  if (process.platform === 'win32') {
-    util.run('cmd.exe', ['/c', 'vpython3.bat', ...args], cmdOptions)
-  } else {
-    util.run('vpython3', args, cmdOptions)
-  }
+  util.run('vpython3', args, config.defaultOptions)
 }
 
 module.exports = { runPerfTests }

--- a/build/commands/lib/util.js
+++ b/build/commands/lib/util.js
@@ -158,12 +158,20 @@ const getAdditionalGenLocation = () => {
   return ''
 }
 
+const normalizeCommand = (cmd, args) => {
+  if (process.platform === 'win32') {
+    args = ['/c', cmd, ...args]
+    cmd = 'cmd'
+  }
+  return [ cmd, args ]
+}
+
 const util = {
   runProcess: (cmd, args = [], options = {}, skipLogging = false) => {
     if (!skipLogging) {
       Log.command(options.cwd, cmd, args)
     }
-    return spawnSync(cmd, args, options)
+    return spawnSync(...normalizeCommand(cmd, args), options)
   },
 
   run: (cmd, args = [], options = {}) => {
@@ -200,7 +208,7 @@ const util = {
       Log.command(cmdOptions.cwd, cmd, args)
     }
     return new Promise((resolve, reject) => {
-      const prog = spawn(cmd, args, cmdOptions)
+      const prog = spawn(...normalizeCommand(cmd, args), cmdOptions)
       const signalsToForward = ['SIGINT', 'SIGTERM', 'SIGQUIT', 'SIGHUP']
       const signalHandler = (s) => {
         prog.kill(s)


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Fix DEP0190 warning we now see after migration to Node v24 by explicitly calling `cmd /c` instead of depending on `shell=true`.

Resolves https://github.com/brave/brave-browser/issues/48584

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
