### PR TITLE
Fully prevent "Can't update Brave" popup on macOS

### DIFF
--- a/chromium_src/chrome/browser/upgrade_detector/upgrade_detector_impl.cc
+++ b/chromium_src/chrome/browser/upgrade_detector/upgrade_detector_impl.cc
@@ -3,27 +3,22 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-#include "brave/browser/updater/buildflags.h"
+#include "build/build_config.h"
 
-#if BUILDFLAG(ENABLE_OMAHA4)
+#if BUILDFLAG(IS_MAC)
 // When the current build is more than several weeks old, upstream takes this as
 // a sign that automatic updates are broken and shows a prominent "Can't update
-// - please reinstall" notification. This makes sense for upstream, which uses
-// Omaha 4 with background updates on macOS. But we still use Sparkle, which
-// only updates while the browser is running and requires a relaunch to install
-// new versions. In this case, the "reinstall" prompt is very confusing,
-// especially because it is likely that Brave is just downloading an update in
-// the background. To work around this, we disable outdated build detection
-// until we also have background updates on macOS.
-#include "brave/browser/updater/features.h"
-
-#define BRAVE_UPGRADE_DETECTOR_IMPL_START_OUTDATED_BUILD_DETECTOR \
-  if (!brave_updater::ShouldUseOmaha4()) {                        \
-    return;                                                       \
-  }
+// - please reinstall" notification. This makes sense for upstream, which has
+// background updates on macOS. But we do not have background updates on macOS
+// yet - see github.com/brave/brave-browser/issues/45086. Under these
+// circumstances, the "reinstall" prompt is very confusing, especially because
+// it is likely that Brave is just downloading an update in the background. To
+// work around this, we disable outdated build detection until we also have
+// background updates on macOS.
+#define BRAVE_UPGRADE_DETECTOR_IMPL_START_OUTDATED_BUILD_DETECTOR return;
 #else
 #define BRAVE_UPGRADE_DETECTOR_IMPL_START_OUTDATED_BUILD_DETECTOR
-#endif  // BUILDFLAG(ENABLE_OMAHA4)
+#endif  // BUILDFLAG(IS_MAC)
 
 #include <chrome/browser/upgrade_detector/upgrade_detector_impl.cc>
 

--- a/chromium_src/chrome/updater/mac/setup/mac_setup.mm
+++ b/chromium_src/chrome/updater/mac/setup/mac_setup.mm
@@ -9,10 +9,13 @@
 // differently: Sparkle checks for updates in the browser, while Omaha 4
 // registers a wake job that runs periodically in the background, also when the
 // browser isn't running. We must prevent Omaha 4 and Sparkle from running at
-// the same time. We do this by not registering Omaha 4's wake job, and instead
-// invoking its on-demand API from inside the browser instead of Sparkle. Once
-// the migration to Sparkle is complete, we will re-enable the wake job by
-// releasing a new version of Omaha 4 itself.
+// the same time. We do this here by preventing Omaha 4's wake job from being
+// registered, and instead invoke its on-demand API from inside the browser
+// instead of Sparkle. Once the migration to Sparkle is complete and we have
+// background updates on macOS, we should re-enable the wake job by removing
+// this code and releasing a new version of Omaha 4 itself. When we do this, we
+// should also re-enable the outdated build detector in
+// upgrade_detector_impl.cc.
 #define GetWakeTaskPlistPath(scope) \
   std::nullopt;                     \
   return true;


### PR DESCRIPTION
The popup makes no sense for us because we don't have background updates on macOS. The previous implementation assumed that we do have background updates with Omaha 4. But this is no longer the case. This PR updates the implementation to reflect this.

Resolves https://github.com/brave/brave-browser/issues/47268.

# Test Plan

1. Launch Brave on macOS with command-line parameters `--enable-features=BraveUseOmaha4Alpha:legacy-fallback-interval-days/9999999 "--simulate-outdated=Tue, 15 Nov 1994 12:45:26 GMT"`. The popup shown in https://github.com/brave/brave-browser/issues/47268 should not appear, even when you wait for a few seconds.
2. Launch Brave on Windows and Linux with command-line parameter `"--simulate-outdated=Tue, 15 Nov 1994 12:45:26 GMT"` (include the `"`s). The popup should appear.