### PR TITLE
disable brave_all_build for 1.83.x only

### DIFF
--- a/build/.ci_features
+++ b/build/.ci_features
@@ -8,4 +8,4 @@ ios_output_xml
 
 # TODO(https://github.com/brave/brave-browser/issues/48001): Remove this CI
 # feature when `1.82.x` is retired.
-brave_all_build
+# brave_all_build


### PR DESCRIPTION
Afaik not needed in 1.83.x. We just must not uplift this change.
Would shave off +10mins of the main build