### PR TITLE
Fix blank space in cookies section of page info dialog

### DIFF
--- a/chromium_src/chrome/browser/ui/views/page_info/page_info_cookies_content_view.cc
+++ b/chromium_src/chrome/browser/ui/views/page_info/page_info_cookies_content_view.cc
@@ -23,23 +23,28 @@
 void PageInfoCookiesContentView::SetCookieInfo(const CookiesInfo& cookie_info) {
   SetCookieInfo_ChromiumImpl(cookie_info);
 
-  // Hide cookies description and link to settings.
-  cookies_description_label_->SetVisible(false);
-  third_party_cookies_container_->SetVisible(false);
+  // Remove cookies description child view
+  if (auto* parent = cookies_description_label_->parent()) {
+    parent->RemoveChildViewT(cookies_description_label_);
+  }
+
+  // Remove third-party cookies container with child view
+  if (auto* parent = third_party_cookies_container_->parent()) {
+    parent->RemoveChildViewT(third_party_cookies_container_);
+  }
 
   // Remove separator.
   // cookies_buttons_container_view_'s children are:
   // [0]: separator
   // [1]: on-site data button row, which we want to keep
-  if (cookies_buttons_container_view_) {
-    if (cookies_buttons_container_view_->children().size() > 0) {
-      // Setting `cookies_dialog_button_` to nullptr as removing the first child
-      // view below will result in this pointer being invalidated.
-      cookies_dialog_button_ = nullptr;
+  if (cookies_buttons_container_view_ &&
+      cookies_buttons_container_view_->children().size() > 0) {
+    // Setting `cookies_dialog_button_` to nullptr as removing the first child
+    // view below will result in this pointer being invalidated.
+    cookies_dialog_button_ = nullptr;
 
-      cookies_buttons_container_view_->RemoveChildViewT(
-          cookies_buttons_container_view_->children()[0]);
-    }
+    cookies_buttons_container_view_->RemoveChildViewT(
+        cookies_buttons_container_view_->children()[0]);
   }
   PreferredSizeChanged();
 }


### PR DESCRIPTION
We hide a few items on the site info dialog's cookies page. We were setting their visibility to false, but they were still taking up visual space in the dialog. Instead of changing their visibility, we now remove them just like we do with other controls in the dialog.

While I was in here, I also simplified a double `if` statement left over from previous refactoring.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/48608

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
