### PR TITLE
fix(wallet): Onboarding Lock Icon Color

### DIFF
--- a/components/brave_wallet_ui/page/screens/onboarding/components/auto_lock_settings/auto_lock_settings.style.ts
+++ b/components/brave_wallet_ui/page/screens/onboarding/components/auto_lock_settings/auto_lock_settings.style.ts
@@ -15,7 +15,7 @@ export const LockIconContainer = styled.div`
   justify-content: center;
   min-width: 30px;
   height: 30px;
-  background-color: ${leo.color.purple[10]};
+  background-color: ${leo.color.container.interactive};
   border-radius: 50%;
 `
 
@@ -23,7 +23,7 @@ export const LockIcon = styled(Icon).attrs({
   name: 'lock',
 })`
   --leo-icon-size: ${leo.icon.xs};
-  color: ${leo.color.purple[30]};
+  color: ${leo.color.icon.interactive};
 `
 
 export const SettingDescription = styled.div`


### PR DESCRIPTION
## Description 

Fixes the `Lock Icon` color during the `Create Password` onboarding step

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/48580>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

1. Start the `Wallet` onboarding process
2. Once you get to the `Create Password` step
3. Check and make sure the `Lock Icon` colors are correct for `Dark` and `Light` theme

Before:

<img width="433" height="76" alt="Screenshot 42" src="https://github.com/user-attachments/assets/d11ac856-565c-4ac8-86e7-551752d8922e" /> | <img width="433" height="73" alt="Screenshot 43" src="https://github.com/user-attachments/assets/fe4d71d4-9798-4c56-bf7b-a9f761e14cac" />
-|-


After:

<img width="428" height="83" alt="Screenshot 40" src="https://github.com/user-attachments/assets/7101d4eb-c37a-48db-b593-6de3cc82788e" /> | <img width="436" height="77" alt="Screenshot 41" src="https://github.com/user-attachments/assets/e49997d9-b0b5-48b7-9ea2-7bdab48d59e7" />
-|-
