### PR TITLE
BRAVE_COSMETIC_FILTERING no longer uses the firstParty pattern marker.

### DIFF
--- a/chromium_src/components/content_settings/core/browser/content_settings_registry.cc
+++ b/chromium_src/components/content_settings/core/browser/content_settings_registry.cc
@@ -109,18 +109,17 @@ void ContentSettingsRegistry::BraveInit() {
       ContentSettingsInfo::INHERIT_IN_INCOGNITO,
       PermissionSettingsInfo::EXCEPTIONS_ON_SECURE_AND_INSECURE_ORIGINS);
 
-  Register(
-      ContentSettingsType::BRAVE_COSMETIC_FILTERING,
-      brave_shields::kCosmeticFiltering, CONTENT_SETTING_DEFAULT,
-      WebsiteSettingsInfo::SYNCABLE, /*allowlisted_schemes=*/{},
-      /*valid_settings=*/
-      {CONTENT_SETTING_ALLOW, CONTENT_SETTING_BLOCK, CONTENT_SETTING_DEFAULT},
-      WebsiteSettingsInfo::REQUESTING_ORIGIN_WITH_TOP_ORIGIN_EXCEPTIONS_SCOPE,
-      WebsiteSettingsRegistry::DESKTOP |
-          WebsiteSettingsRegistry::PLATFORM_ANDROID |
-          WebsiteSettingsRegistry::PLATFORM_IOS,
-      ContentSettingsInfo::INHERIT_IN_INCOGNITO,
-      PermissionSettingsInfo::EXCEPTIONS_ON_SECURE_AND_INSECURE_ORIGINS);
+  Register(ContentSettingsType::BRAVE_COSMETIC_FILTERING,
+           brave_shields::kCosmeticFiltering, CONTENT_SETTING_ASK,
+           WebsiteSettingsInfo::SYNCABLE, /*allowlisted_schemes=*/{},
+           /*valid_settings=*/
+           {CONTENT_SETTING_ALLOW, CONTENT_SETTING_BLOCK, CONTENT_SETTING_ASK},
+           WebsiteSettingsInfo::TOP_ORIGIN_ONLY_SCOPE,
+           WebsiteSettingsRegistry::DESKTOP |
+               WebsiteSettingsRegistry::PLATFORM_ANDROID |
+               WebsiteSettingsRegistry::PLATFORM_IOS,
+           ContentSettingsInfo::INHERIT_IN_INCOGNITO,
+           PermissionSettingsInfo::EXCEPTIONS_ON_SECURE_AND_INSECURE_ORIGINS);
 
   Register(ContentSettingsType::BRAVE_FINGERPRINTING_V2,
            brave_shields::kFingerprintingV2, CONTENT_SETTING_ASK,

--- a/components/brave_shields/core/common/brave_shield_constants.h
+++ b/components/brave_shields/core/common/brave_shield_constants.h
@@ -11,7 +11,7 @@
 namespace brave_shields {
 
 inline constexpr char kAds[] = "shieldsAds";
-inline constexpr char kCosmeticFiltering[] = "cosmeticFiltering";
+inline constexpr char kCosmeticFiltering[] = "cosmeticFilteringV2";
 inline constexpr char kTrackers[] = "trackers";
 inline constexpr char kHTTPUpgradableResources[] = "httpUpgradableResources";
 inline constexpr char kHTTPSUpgrades[] = "httpsUpgrades";

--- a/components/content_settings/core/browser/brave_content_settings_pref_provider.h
+++ b/components/content_settings/core/browser/brave_content_settings_pref_provider.h
@@ -103,6 +103,7 @@ class BravePrefProvider : public PrefProvider, public Observer {
   void MigrateShieldsSettingsV3ToV4(int start_version);
   void MigrateFingerprintingSettings();
   void MigrateFingerprintingSetingsToOriginScoped();
+  void MigrateCosmeticFilteringSettings();
   void UpdateCookieRules(ContentSettingsType content_type, bool incognito);
   void OnCookieSettingsChanged(ContentSettingsType content_type);
   void NotifyChanges(const std::vector<std::unique_ptr<Rule>>& rules,


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/48500

1. The default value for `BRAVE_COSMETIC_FILTERING` has been changed from `CONTENT_SETTING_DEFAULT` to `CONTENT_SETTING_ASK`. This new default, which maps to `ControlType::BLOCK_THIRD_PARTY`, aligns with the value previously returned by `GetCosmeticFilteringControlType` by default.

2. Changed the `BRAVE_COSMETIC_FILTERING` content setting to no longer use the `https://firstparty` pattern marker. The associated preference has been renamed to `profile.content_settings.exceptions.cosmeticFilteringV2`, and a migration was implemented in `BravePrefProvider`.