### PR TITLE
fix(wallet): Wrap Domain Text in Connections Panel

### DIFF
--- a/components/brave_wallet_ui/components/extension/connections/connections.style.ts
+++ b/components/brave_wallet_ui/components/extension/connections/connections.style.ts
@@ -6,10 +6,22 @@
 import styled from 'styled-components'
 import * as leo from '@brave/leo/tokens/css/variables'
 
+// Styled Styles
+import { Text, Column } from '../../shared/style'
+
 export const FavIcon = styled.img`
   width: 64px;
   height: 64px;
   border-radius: 5px;
   border: 1px solid ${leo.color.divider.subtle};
   margin-bottom: 12px;
+`
+
+export const DomainTextContainer = styled(Column)`
+  overflow: hidden;
+  box-sizing: border-box;
+`
+
+export const DomainText = styled(Text)`
+  word-break: break-all;
 `

--- a/components/brave_wallet_ui/components/extension/connections/connections.test.tsx
+++ b/components/brave_wallet_ui/components/extension/connections/connections.test.tsx
@@ -1,0 +1,100 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import * as React from 'react'
+import { render } from '@testing-library/react'
+
+import {
+  // eslint-disable-next-line import/no-named-default
+  default as BraveCoreThemeProvider,
+} from '../../../../common/BraveCoreThemeProvider'
+
+// Components
+import { DomainTextContainer, DomainText } from './connections.style'
+import { CreateSiteOrigin } from '../../shared/create-site-origin'
+
+const activeOrigin = {
+  originSpec:
+    'http://theofficialabsolutelongestdomainnameregisteredontheworldwideweb.'
+    + 'international/',
+  eTldPlusOne:
+    'theofficialabsolutelongestdomainnameregisteredontheworldwideweb.'
+    + 'international',
+}
+
+describe('Connections', () => {
+  const renderComponent = () => {
+    const { container } = render(
+      <BraveCoreThemeProvider>
+        <DomainTextContainer
+          data-key='domain-text-container'
+          width='100px'
+          padding='0px 24px'
+        >
+          <DomainText
+            data-key='domain-text-etldplusone'
+            textSize='16px'
+            isBold={true}
+            textColor='primary'
+          >
+            {activeOrigin.eTldPlusOne}
+          </DomainText>
+          <DomainText
+            textSize='14px'
+            isBold={false}
+            textColor='tertiary'
+            data-key='domain-text-origin'
+          >
+            <CreateSiteOrigin
+              originSpec={activeOrigin.originSpec}
+              eTldPlusOne={activeOrigin.eTldPlusOne}
+            />
+          </DomainText>
+        </DomainTextContainer>
+      </BraveCoreThemeProvider>,
+    )
+    return { container }
+  }
+  it('should render', async () => {
+    const { container } = renderComponent()
+
+    // Test domain text container styles
+    const domainContainer = container.querySelector(
+      '[data-key="domain-text-container"]',
+    )
+    expect(domainContainer).toBeInTheDocument()
+    expect(domainContainer).toBeVisible()
+    expect(domainContainer).toHaveStyle({
+      overflow: 'hidden',
+      boxSizing: 'border-box',
+    })
+
+    // Test domain text etldplusone and styles
+    const domainTextetldPlusOne = container.querySelector(
+      '[data-key="domain-text-etldplusone"]',
+    )
+    expect(domainTextetldPlusOne).toBeInTheDocument()
+    expect(domainTextetldPlusOne).toBeVisible()
+    expect(domainTextetldPlusOne).toHaveStyle({
+      wordBreak: 'break-all',
+    })
+
+    // Test etldplusone text
+    expect(domainTextetldPlusOne).toHaveTextContent(activeOrigin.eTldPlusOne)
+
+    // Test domain text origin and styles
+    const domainTextOrigin = container.querySelector(
+      '[data-key="domain-text-origin"]',
+    )
+    expect(domainTextOrigin).toBeInTheDocument()
+    expect(domainTextOrigin).toBeVisible()
+    expect(domainTextOrigin).toHaveStyle({
+      wordBreak: 'break-all',
+    })
+
+    // Test origin text
+    expect(domainTextOrigin).toHaveTextContent(activeOrigin.originSpec)
+  })
+})

--- a/components/brave_wallet_ui/components/extension/connections/connections.tsx
+++ b/components/brave_wallet_ui/components/extension/connections/connections.tsx
@@ -38,8 +38,12 @@ import {
 } from './components/connection_section/connection_section'
 
 // Styled Components
-import { FavIcon } from './connections.style'
-import { Column, Text } from '../../shared/style'
+import {
+  FavIcon,
+  DomainText,
+  DomainTextContainer, //
+} from './connections.style'
+import { Column } from '../../shared/style'
 import { VerifiedLabel } from '../../shared/verified_label/verified_label'
 
 const CONNECTABLE_COIN_TYPES = [
@@ -80,18 +84,19 @@ export const Connections = () => {
             activeOrigin.originSpec,
           )}`}
         />
-        <Column
+        <DomainTextContainer
           gap='4px'
           margin='0px 0px 24px 0px'
+          padding='0px 24px'
         >
-          <Text
+          <DomainText
             textSize='16px'
             isBold={true}
             textColor='primary'
           >
             {activeOrigin.eTldPlusOne}
-          </Text>
-          <Text
+          </DomainText>
+          <DomainText
             textSize='14px'
             isBold={false}
             textColor='tertiary'
@@ -100,9 +105,9 @@ export const Connections = () => {
               originSpec={activeOrigin.originSpec}
               eTldPlusOne={activeOrigin.eTldPlusOne}
             />
-          </Text>
+          </DomainText>
           {isDAppVerified && <VerifiedLabel />}
-        </Column>
+        </DomainTextContainer>
         <Column
           gap='16px'
           width='100%'


### PR DESCRIPTION
## Description 

Fixes a bug where the `Domain` text did not wrap on the `Connections` tab

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/48748>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

## Test Plan:
1. Visit a website with a really long domain name
2. Open the `Wallet` panel and navigate to the `Connections` tab
3. The `Domain` text should wrap and should not expand off the screen

Before:

<img width="402" height="662" alt="Screenshot 58" src="https://github.com/user-attachments/assets/f98bb698-bde6-4fff-b634-782a88999373" />

After:

<img width="399" height="660" alt="Screenshot 57" src="https://github.com/user-attachments/assets/ed5851a2-5917-41b2-aa6c-c01609fb0973" />
