### PR TITLE
Disables Tab Search in-product-help popup. (uplift to 1.82.x)

### DIFF
--- a/app/feature_defaults_unittest.cc
+++ b/app/feature_defaults_unittest.cc
@@ -131,6 +131,7 @@ TEST(FeatureDefaultsTest, DisabledFeatures) {
 #if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_APPLE) || BUILDFLAG(IS_LINUX)
       &feature_engagement::kIPHGMCCastStartStopFeature,
       &feature_engagement::kIPHPasswordsManagementBubbleAfterSaveFeature,
+      &feature_engagement::kIPHTabSearchToolbarButtonFeature,
 #endif
       &features::kBookmarkTriggerForPrerender2,
       &features::kChromeStructuredMetrics,

--- a/chromium_src/components/feature_engagement/public/feature_constants.cc
+++ b/chromium_src/components/feature_engagement/public/feature_constants.cc
@@ -14,6 +14,7 @@ OVERRIDE_FEATURE_DEFAULT_STATES({{
     {kIPHGMCCastStartStopFeature, base::FEATURE_DISABLED_BY_DEFAULT},
     {kIPHPasswordsManagementBubbleAfterSaveFeature,
      base::FEATURE_DISABLED_BY_DEFAULT},
+    {kIPHTabSearchToolbarButtonFeature, base::FEATURE_DISABLED_BY_DEFAULT},
 #endif
 }});
 


### PR DESCRIPTION
Uplift of #30851
Resolves https://github.com/brave/brave-browser/issues/48512

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.