### PR TITLE
fix(privacy): Use last committed url for debounce eTLD+1 comparison (uplift to 1.82.x)

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabPolicyDecider.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabPolicyDecider.swift
@@ -579,8 +579,8 @@ extension BrowserViewController {
     // (i.e. appropriate settings are enabled for that redirect rule)
     if let debounceService = DebounceServiceFactory.get(privateMode: tab.isPrivate),
       debounceService.isEnabled,
-      let currentURL = tab.visibleURL,
-      currentURL.baseDomain != requestURL.baseDomain
+      let lastCommittedURL = tab.lastCommittedURL,
+      lastCommittedURL.baseDomain != requestURL.baseDomain
     {
       if let redirectURL = debounceService.debounce(requestURL) {
         // For now we only allow the `Referer`. The browser will add other headers during navigation.


### PR DESCRIPTION
Uplift of #30876
Resolves https://github.com/brave/brave-browser/issues/48763

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.