### PR TITLE
[Android] Fix Brave VPN server selection radio button interaction.

### DIFF
--- a/android/java/org/chromium/chrome/browser/vpn/activities/BraveVpnParentActivity.java
+++ b/android/java/org/chromium/chrome/browser/vpn/activities/BraveVpnParentActivity.java
@@ -29,7 +29,6 @@ import org.chromium.chrome.browser.init.ActivityProfileProvider;
 import org.chromium.chrome.browser.init.AsyncInitializationActivity;
 import org.chromium.chrome.browser.profiles.ProfileProvider;
 import org.chromium.chrome.browser.util.LiveDataUtil;
-import org.chromium.chrome.browser.util.TabUtils;
 import org.chromium.chrome.browser.vpn.BraveVpnNativeWorker;
 import org.chromium.chrome.browser.vpn.BraveVpnObserver;
 import org.chromium.chrome.browser.vpn.models.BraveVpnPrefModel;
@@ -285,7 +284,6 @@ public abstract class BraveVpnParentActivity extends AsyncInitializationActivity
                         return;
                     }
                     BraveVpnProfileUtils.getInstance().startVpn(BraveVpnParentActivity.this);
-                    TabUtils.bringChromeTabbedActivityToTheTop(BraveVpnParentActivity.this);
                 } catch (Exception e) {
                     BraveVpnUtils.dismissProgressDialog();
                     Log.e(TAG, e.getMessage());

--- a/android/java/org/chromium/chrome/browser/vpn/activities/VpnServerSelectionActivity.java
+++ b/android/java/org/chromium/chrome/browser/vpn/activities/VpnServerSelectionActivity.java
@@ -70,6 +70,10 @@ public class VpnServerSelectionActivity extends BraveVpnParentActivity
         void onServerRegionClick(Region region);
     }
 
+    public interface OnQuickServerSelection {
+        void onQuickServerSelect(Region region);
+    }
+
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         if (item.getItemId() == android.R.id.home) {
@@ -168,6 +172,24 @@ public class VpnServerSelectionActivity extends BraveVpnParentActivity
                                             BraveVpnUtils.selectedRegion = region;
                                             BraveVpnUtils.openVpnServerActivity(
                                                     VpnServerSelectionActivity.this, region);
+                                        }
+                                    });
+                            mBraveVpnServerSelectionAdapter.setOnQuickServerSelection(
+                                    new OnQuickServerSelection() {
+                                        @Override
+                                        public void onQuickServerSelect(Region region) {
+                                            BraveVpnUtils.selectedRegion = region;
+                                            BraveVpnUtils.selectedServerRegion =
+                                                    new BraveVpnServerRegion(
+                                                            false,
+                                                            region.country,
+                                                            region.continent,
+                                                            region.countryIsoCode,
+                                                            region.name,
+                                                            region.namePretty,
+                                                            BraveVpnConstants
+                                                                    .REGION_PRECISION_COUNTRY);
+                                            changeServerRegion();
                                         }
                                     });
                             mServerRegionList.setAdapter(mBraveVpnServerSelectionAdapter);

--- a/android/java/org/chromium/chrome/browser/vpn/activities/VpnServerSelectionActivity.java
+++ b/android/java/org/chromium/chrome/browser/vpn/activities/VpnServerSelectionActivity.java
@@ -57,6 +57,7 @@ public class VpnServerSelectionActivity extends BraveVpnParentActivity
 
     private void initVpnService() {
         if (mServiceHandler != null) {
+            mServiceHandler.close();
             mServiceHandler = null;
         }
         mServiceHandler =
@@ -218,4 +219,13 @@ public class VpnServerSelectionActivity extends BraveVpnParentActivity
 
     @Override
     public void updateProfileView() {}
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        if (mServiceHandler != null) {
+            mServiceHandler.close();
+            mServiceHandler = null;
+        }
+    }
 }

--- a/android/java/org/chromium/chrome/browser/vpn/utils/BraveVpnPrefUtils.java
+++ b/android/java/org/chromium/chrome/browser/vpn/utils/BraveVpnPrefUtils.java
@@ -11,6 +11,7 @@ import org.chromium.chrome.browser.preferences.BravePref;
 import org.chromium.chrome.browser.preferences.ChromeSharedPreferences;
 import org.chromium.chrome.browser.profiles.ProfileManager;
 import org.chromium.chrome.browser.vpn.models.BraveVpnPrefModel;
+import org.chromium.components.prefs.PrefService;
 import org.chromium.components.user_prefs.UserPrefs;
 
 import java.util.Collections;
@@ -125,13 +126,15 @@ public class BraveVpnPrefUtils {
     }
 
     public static void setPurchaseToken(String value) {
+        if (value == null) {
+            return;
+        }
         ChromeSharedPreferences.getInstance().writeString(PREF_BRAVE_VPN_PURCHASE_TOKEN, value);
-        UserPrefs.get(ProfileManager.getLastUsedRegularProfile())
-                .setString(BravePref.BRAVE_VPN_PURCHASE_TOKEN_ANDROID, value);
-        UserPrefs.get(ProfileManager.getLastUsedRegularProfile())
-                .setString(
-                        BravePref.BRAVE_VPN_PACKAGE_ANDROID,
-                        ContextUtils.getApplicationContext().getPackageName());
+        PrefService prefSvc = UserPrefs.get(ProfileManager.getLastUsedRegularProfile());
+        prefSvc.setString(BravePref.BRAVE_VPN_PURCHASE_TOKEN_ANDROID, value);
+        prefSvc.setString(
+                BravePref.BRAVE_VPN_PACKAGE_ANDROID,
+                ContextUtils.getApplicationContext().getPackageName());
     }
 
     public static String getPurchaseToken() {
@@ -139,6 +142,9 @@ public class BraveVpnPrefUtils {
     }
 
     public static void setProductId(String value) {
+        if (value == null) {
+            return;
+        }
         ChromeSharedPreferences.getInstance().writeString(PREF_BRAVE_VPN_PRODUCT_ID, value);
         UserPrefs.get(ProfileManager.getLastUsedRegularProfile())
                 .setString(BravePref.BRAVE_VPN_PRODUCT_ID_ANDROID, value);


### PR DESCRIPTION
Resolves brave/brave-browser#48327

## Test Plan

1. Test purchasing the Brave VPN service functions without issue.
2. Test activating the VPN service via an account that already has the VPN purchased also works without issue.
4. Navigate to the VPN menu and ensure automatic selection is turned off.
5. Test the radio buttons to ensure that the region is switched correctly.
6. Test the parent entry to ensure it still brings you into city selection.

