### PR TITLE
Don't show "Add media from page" button when mini player is visible. 

### DIFF
--- a/browser/ui/views/playlist/playlist_bubbles_controller.cc
+++ b/browser/ui/views/playlist/playlist_bubbles_controller.cc
@@ -35,7 +35,12 @@ void PlaylistBubblesController::ShowBubble(
     return;
   }
 
-  CHECK(!bubble_);
+  if (bubble_) {
+    // When the bubble is already showing, do nothing. This can happen if the
+    // user clicks button multiple times quickly from web ui.
+    return;
+  }
+
   auto* tab_helper = PlaylistTabHelper::FromWebContents(&GetWebContents());
   CHECK(tab_helper);
 

--- a/components/playlist/browser/resources/components/app.v1.tsx
+++ b/components/playlist/browser/resources/components/app.v1.tsx
@@ -64,18 +64,16 @@ export default function App () {
         path={'/playlist/:playlistId'}
         children={({ match }) => {
           const playlistId = match?.params.playlistId
+          const isPlayerVisible = 
+                    !!lastPlayerState?.currentItem &&
+                    editMode !== PlaylistEditMode.BULK_EDIT
+          const isMiniPlayer = lastPlayerState?.currentList?.id !== playlistId
           return (
             <AppContainer isPlaylistPlayerPage={!!playlistId}>
               <StickyArea position='top'>
                 <StyledHeader playlistId={playlistId} />
                 <AlertCenter />
-                <VideoFrame
-                  visible={
-                    !!lastPlayerState?.currentItem &&
-                    editMode !== PlaylistEditMode.BULK_EDIT
-                  }
-                  isMiniPlayer={lastPlayerState?.currentList?.id !== playlistId}
-                />
+                <VideoFrame visible={isPlayerVisible} isMiniPlayer={isMiniPlayer} />
               </StickyArea>
               <section>
                 <Switch>
@@ -89,7 +87,7 @@ export default function App () {
                   ></Route>
                 </Switch>
               </section>
-              {shouldShowAddMediaFromPage ? (
+              {shouldShowAddMediaFromPage && !(isPlayerVisible && isMiniPlayer) ? (
                 <StickyArea position='bottom'>
                   <Footer>
                     <AddMediaFromPageButton />


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
These two UI elements overlap and it looks bad. So we should hide the button
when mini player is visible. Also this PR trys to avoid CHECK failure
that can happen when user clicks "Add media from page" button multiple times quickly.

Resolves https://github.com/brave/brave-browser/issues/48571

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
