### PR TITLE
[CodeHealth] Various `Wexit-time-destructors` fixes

### DIFF
--- a/browser/brave_wallet/solana_provider_renderer_browsertest.cc
+++ b/browser/brave_wallet/solana_provider_renderer_browsertest.cc
@@ -3,14 +3,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include <array>
 #include <optional>
 
 #include "base/containers/flat_map.h"
+#include "base/containers/to_vector.h"
 #include "base/feature_list.h"
 #include "base/memory/weak_ptr.h"
 #include "base/path_service.h"
 #include "base/strings/strcat.h"
 #include "base/strings/string_number_conversions.h"
+#include "base/strings/string_util.h"
 #include "base/test/values_test_util.h"
 #include "brave/browser/brave_content_browser_client.h"
 #include "brave/browser/brave_wallet/brave_wallet_service_factory.h"
@@ -65,52 +68,52 @@ constexpr char kTestSignature[] =
     "As4N6cok5f7nhXp56Hdw8dWZpUnY8zjYKzBqK45CexE1qNPCqt6Y2gnZduGgqASDD1c6QULBRy"
     "pVa9BikoxWpGA";
 
-const std::vector<uint8_t> kSerializedMessage = {
-    1,   0,   1,   2,   161, 51,  89,  91,  115, 210, 217, 212, 76,  159, 171,
-    200, 40,  150, 157, 70,  197, 71,  24,  44,  209, 108, 143, 4,   58,  251,
-    215, 62,  201, 172, 159, 197, 0,   0,   0,   0,   0,   0,   0,   0,   0,
-    0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
-    0,   0,   0,   0,   0,   0,   0,   0,   65,  223, 160, 84,  229, 200, 41,
-    124, 255, 227, 200, 207, 94,  13,  128, 218, 71,  139, 178, 169, 91,  44,
-    201, 177, 125, 166, 36,  96,  136, 125, 3,   136, 1,   1,   2,   0,   0,
-    12,  2,   0,   0,   0,   100, 0,   0,   0,   0,   0,   0,   0};
+constexpr auto kSerializedMessage = std::to_array<uint8_t>(
+    {1,   0,   1,   2,   161, 51,  89,  91,  115, 210, 217, 212, 76,  159, 171,
+     200, 40,  150, 157, 70,  197, 71,  24,  44,  209, 108, 143, 4,   58,  251,
+     215, 62,  201, 172, 159, 197, 0,   0,   0,   0,   0,   0,   0,   0,   0,
+     0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
+     0,   0,   0,   0,   0,   0,   0,   0,   65,  223, 160, 84,  229, 200, 41,
+     124, 255, 227, 200, 207, 94,  13,  128, 218, 71,  139, 178, 169, 91,  44,
+     201, 177, 125, 166, 36,  96,  136, 125, 3,   136, 1,   1,   2,   0,   0,
+     12,  2,   0,   0,   0,   100, 0,   0,   0,   0,   0,   0,   0});
 
-const std::vector<uint8_t> kSerializedTx = {
-    1,   224, 52,  14,  175, 211, 221, 245, 217, 123, 232, 68,  232, 120, 145,
-    131, 154, 133, 31,  130, 73,  190, 13,  227, 109, 83,  152, 160, 202, 226,
-    134, 138, 141, 135, 187, 72,  153, 173, 159, 205, 222, 253, 26,  44,  34,
-    18,  250, 176, 21,  84,  7,   142, 247, 65,  218, 40,  117, 145, 118, 52,
-    75,  183, 98,  232, 10,  1,   0,   1,   2,   161, 51,  89,  91,  115, 210,
-    217, 212, 76,  159, 171, 200, 40,  150, 157, 70,  197, 71,  24,  44,  209,
-    108, 143, 4,   58,  251, 215, 62,  201, 172, 159, 197, 0,   0,   0,   0,
-    0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
-    0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   65,  223,
-    160, 84,  229, 200, 41,  124, 255, 227, 200, 207, 94,  13,  128, 218, 71,
-    139, 178, 169, 91,  44,  201, 177, 125, 166, 36,  96,  136, 125, 3,   136,
-    1,   1,   2,   0,   0,   12,  2,   0,   0,   0,   100, 0,   0,   0,   0,
-    0,   0,   0};
+constexpr auto kSerializedTx = std::to_array<uint8_t>(
+    {1,   224, 52,  14,  175, 211, 221, 245, 217, 123, 232, 68,  232, 120, 145,
+     131, 154, 133, 31,  130, 73,  190, 13,  227, 109, 83,  152, 160, 202, 226,
+     134, 138, 141, 135, 187, 72,  153, 173, 159, 205, 222, 253, 26,  44,  34,
+     18,  250, 176, 21,  84,  7,   142, 247, 65,  218, 40,  117, 145, 118, 52,
+     75,  183, 98,  232, 10,  1,   0,   1,   2,   161, 51,  89,  91,  115, 210,
+     217, 212, 76,  159, 171, 200, 40,  150, 157, 70,  197, 71,  24,  44,  209,
+     108, 143, 4,   58,  251, 215, 62,  201, 172, 159, 197, 0,   0,   0,   0,
+     0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
+     0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   65,  223,
+     160, 84,  229, 200, 41,  124, 255, 227, 200, 207, 94,  13,  128, 218, 71,
+     139, 178, 169, 91,  44,  201, 177, 125, 166, 36,  96,  136, 125, 3,   136,
+     1,   1,   2,   0,   0,   12,  2,   0,   0,   0,   100, 0,   0,   0,   0,
+     0,   0,   0});
 
-const std::vector<uint8_t> kSignedTx = {
-    1,   231, 78,  150, 120, 219, 234, 88,  44,  144, 225, 53,  221, 88,  82,
-    59,  51,  62,  211, 225, 231, 182, 123, 231, 229, 201, 48,  30,  137, 119,
-    233, 102, 88,  31,  65,  88,  147, 197, 72,  166, 241, 126, 26,  59,  239,
-    64,  196, 116, 28,  17,  124, 0,   123, 13,  28,  65,  242, 241, 226, 46,
-    227, 55,  234, 251, 10,  1,   0,   1,   2,   161, 51,  89,  91,  115, 210,
-    217, 212, 76,  159, 171, 200, 40,  150, 157, 70,  197, 71,  24,  44,  209,
-    108, 143, 4,   58,  251, 215, 62,  201, 172, 159, 197, 0,   0,   0,   0,
-    0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
-    0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   62,  84,
-    174, 253, 228, 77,  50,  164, 215, 178, 46,  88,  242, 49,  114, 246, 244,
-    48,  9,   18,  36,  41,  160, 254, 174, 6,   207, 115, 11,  58,  220, 167,
-    1,   1,   2,   0,   0,   12,  2,   0,   0,   0,   100, 0,   0,   0,   0,
-    0,   0,   0};
+constexpr auto kSignedTx = std::to_array<uint8_t>(
+    {1,   231, 78,  150, 120, 219, 234, 88,  44,  144, 225, 53,  221, 88,  82,
+     59,  51,  62,  211, 225, 231, 182, 123, 231, 229, 201, 48,  30,  137, 119,
+     233, 102, 88,  31,  65,  88,  147, 197, 72,  166, 241, 126, 26,  59,  239,
+     64,  196, 116, 28,  17,  124, 0,   123, 13,  28,  65,  242, 241, 226, 46,
+     227, 55,  234, 251, 10,  1,   0,   1,   2,   161, 51,  89,  91,  115, 210,
+     217, 212, 76,  159, 171, 200, 40,  150, 157, 70,  197, 71,  24,  44,  209,
+     108, 143, 4,   58,  251, 215, 62,  201, 172, 159, 197, 0,   0,   0,   0,
+     0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
+     0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   62,  84,
+     174, 253, 228, 77,  50,  164, 215, 178, 46,  88,  242, 49,  114, 246, 244,
+     48,  9,   18,  36,  41,  160, 254, 174, 6,   207, 115, 11,  58,  220, 167,
+     1,   1,   2,   0,   0,   12,  2,   0,   0,   0,   100, 0,   0,   0,   0,
+     0,   0,   0});
 
-const std::vector<uint8_t> kMessageToSign = {
-    84,  111, 32,  97,  118, 111, 105, 100, 32,  100, 105, 103, 105, 116, 97,
-    108, 32,  100, 111, 103, 110, 97,  112, 112, 101, 114, 115, 44,  32,  115,
-    105, 103, 110, 32,  98,  101, 108, 111, 119, 32,  116, 111, 32,  97,  117,
-    116, 104, 101, 110, 116, 105, 99,  97,  116, 101, 32,  119, 105, 116, 104,
-    32,  67,  114, 121, 112, 116, 111, 67,  111, 114, 103, 105, 115, 46};
+constexpr auto kMessageToSign = std::to_array<uint8_t>(
+    {84,  111, 32,  97,  118, 111, 105, 100, 32,  100, 105, 103, 105, 116, 97,
+     108, 32,  100, 111, 103, 110, 97,  112, 112, 101, 114, 115, 44,  32,  115,
+     105, 103, 110, 32,  98,  101, 108, 111, 119, 32,  116, 111, 32,  97,  117,
+     116, 104, 101, 110, 116, 105, 99,  97,  116, 101, 32,  119, 105, 116, 104,
+     32,  67,  114, 121, 112, 116, 111, 67,  111, 114, 103, 105, 115, 46});
 
 constexpr char OnAccountChangedScript[] =
     R"(async function disconnect() {await window.braveSolana.disconnect()}
@@ -128,15 +131,11 @@ constexpr char OnAccountChangedScript[] =
 constexpr char CheckSolanaProviderScript[] = "!!window.braveSolana";
 constexpr char OverwriteScript[] = "window.solana = ['test'];window.solana[0]";
 
-std::string VectorToArrayString(const std::vector<uint8_t>& vec) {
-  std::string result;
-  for (size_t i = 0; i < vec.size(); ++i) {
-    base::StrAppend(&result, {base::NumberToString(vec[i])});
-    if (i != vec.size() - 1) {
-      base::StrAppend(&result, {", "});
-    }
-  }
-  return result;
+std::string VectorToArrayString(base::span<const uint8_t> data) {
+  return base::JoinString(
+      base::ToVector(data,
+                     [](int value) { return base::NumberToString(value); }),
+      ", ");
 }
 
 std::string GetRequestObject(std::string_view method) {
@@ -198,7 +197,7 @@ std::string ConnectScript(std::string_view args) {
       args);
 }
 
-std::string CreateTransactionScript(const std::vector<uint8_t>& serialized_tx) {
+std::string CreateTransactionScript(base::span<const uint8_t> serialized_tx) {
   const std::string serialized_tx_str = VectorToArrayString(serialized_tx);
   return absl::StrFormat(
       R"((function() {
@@ -358,7 +357,7 @@ class TestSolanaProvider final : public brave_wallet::mojom::SolanaProvider {
               brave_wallet::Base58Encode(kSerializedMessage));
     if (error_ == SolanaProviderError::kSuccess) {
       std::move(callback).Run(
-          SolanaProviderError::kSuccess, "", kSignedTx,
+          SolanaProviderError::kSuccess, "", base::ToVector(kSignedTx),
           brave_wallet::mojom::SolanaMessageVersion::kLegacy);
     } else {
       std::move(callback).Run(
@@ -376,7 +375,8 @@ class TestSolanaProvider final : public brave_wallet::mojom::SolanaProvider {
     }
     if (error_ == SolanaProviderError::kSuccess) {
       std::move(callback).Run(
-          SolanaProviderError::kSuccess, "", {kSignedTx, kSignedTx},
+          SolanaProviderError::kSuccess, "",
+          {base::ToVector(kSignedTx), base::ToVector(kSignedTx)},
           {brave_wallet::mojom::SolanaMessageVersion::kLegacy,
            brave_wallet::mojom::SolanaMessageVersion::kLegacy});
     } else {
@@ -409,7 +409,7 @@ class TestSolanaProvider final : public brave_wallet::mojom::SolanaProvider {
   void SignMessage(const std::vector<uint8_t>& blob_msg,
                    const std::optional<std::string>& display_encoding,
                    SignMessageCallback callback) override {
-    EXPECT_EQ(blob_msg, kMessageToSign);
+    EXPECT_EQ(blob_msg, base::ToVector(kMessageToSign));
     base::Value::Dict result;
     if (error_ == SolanaProviderError::kSuccess) {
       result.Set("publicKey", kTestPublicKey);

--- a/browser/metrics/variations_browsertest.cc
+++ b/browser/metrics/variations_browsertest.cc
@@ -19,32 +19,31 @@ BASE_FEATURE(kVariationsTestFeature,
              base::FEATURE_DISABLED_BY_DEFAULT);
 
 // The seed is signed with the private key of the Brave variations server.
-const SignedSeedData& GetBraveSignedSeedData() {
+SignedSeedData GetBraveSignedSeedData() {
   static const char* study_names[] = {"VariationsTestStudy"};
 
-  constexpr char kBase64UncompressedData[] =
+  static constexpr char kBase64UncompressedData[] =
       "CiA5NDIyMDlmNWEwYzRkOTFiYThiZDk4N2ZlOGU5NTcxMBJMChNWYXJpYXRpb25zVGVzdFN0"
       "dWR5OAFKJAoHRW5hYmxlZBBkYhcKFVZhcmlhdGlvbnNUZXN0RmVhdHVyZUoLCgdEZWZhdWx0"
       "EABgASIaQnJhdmUgdmFyaWF0aW9ucyB0ZXN0IHNlZWQ=";
 
-  constexpr char kBase64CompressedData[] =
+  static constexpr char kBase64CompressedData[] =
       "H4sIAAAAAAAAA+"
       "NSsDQxMjKwTDNNNEg2SbE0TEq0SEqxtDBPS7VItTQ1NzQQ8uESDkssykwsyczPKw5JLS4JLi"
       "lNqbRg9FLhYnfNS0zKSU0RSEkS5xJFVeWWmlhSWpTqxc3F7pKalliaUyLAkMCoJOVUlFiWql"
       "AGV6tQAlSsUJyamgIARXSxvIwAAAA=";
 
-  constexpr char kBase64Signature[] =
+  static constexpr char kBase64Signature[] =
       "MEUCIQDfayOr/"
       "xmQaBThr1i8ARQ1rKEinHluXeR7ve5fqy7L4AIgNym2PbtlL+9142+"
       "T8gUjjEsoT28J3HqE4IEa1eFvKLw=";
 
-  static const SignedSeedData kBraveTestSeedData{study_names,
-                                                 kBase64UncompressedData,
-                                                 kBase64CompressedData,
-                                                 kBase64Signature,
-                                                 /*in_compressed_data=*/{},
-                                                 /*in_compressed_data_size=*/0};
-  return kBraveTestSeedData;
+  return {study_names,
+          kBase64UncompressedData,
+          kBase64CompressedData,
+          kBase64Signature,
+          /*in_compressed_data=*/{},
+          /*in_compressed_data_size=*/0};
 }
 
 }  // namespace

--- a/chromium_src/components/search_engines/brave_template_url_prepopulate_data_unittest.cc
+++ b/chromium_src/components/search_engines/brave_template_url_prepopulate_data_unittest.cc
@@ -6,10 +6,10 @@
 
 #include <memory>
 #include <string>
-#include <unordered_set>
 #include <utility>
 
 #include "base/command_line.h"
+#include "base/containers/fixed_flat_set.h"
 #include "base/files/scoped_temp_dir.h"
 #include "base/stl_util.h"
 #include "base/values.h"
@@ -39,10 +39,11 @@ std::string GetHostFromTemplateURLData(const TemplateURLData& data) {
 
 using namespace TemplateURLPrepopulateData;  // NOLINT
 
-const PrepopulatedEngine* const kBraveAddedEngines[] = {};
+constexpr PrepopulatedEngine* const kBraveAddedEngines[] = {};
 
-const std::unordered_set<std::u16string_view> kOverriddenEnginesNames = {
-    u"DuckDuckGo", u"Qwant", u"Startpage"};
+constexpr auto kOverriddenEnginesNames =
+    base::MakeFixedFlatSet<std::u16string_view>(
+        {u"DuckDuckGo", u"Qwant", u"Startpage"});
 
 }  // namespace
 
@@ -112,9 +113,10 @@ TEST_F(BraveTemplateURLPrepopulateDataTest, OverriddenEngines) {
   const base::span<const PrepopulatedEngine* const> all_engines =
       GetAllPrepopulatedEngines();
   for (const PrepopulatedEngine* engine : all_engines) {
-    if (kOverriddenEnginesNames.count(engine->name) > 0)
+    if (kOverriddenEnginesNames.contains(engine->name)) {
       ASSERT_GE(static_cast<unsigned int>(engine->id),
                 TemplateURLPrepopulateData::BRAVE_PREPOPULATED_ENGINES_START);
+    }
   }
 }
 

--- a/components/ai_chat/core/browser/model_service_unittest.cc
+++ b/components/ai_chat/core/browser/model_service_unittest.cc
@@ -202,16 +202,16 @@ TEST_F(ModelServiceTest, ChangeOldDefaultKey) {
 TEST_F(ModelServiceTest, AddAndModifyCustomModel) {
   static constexpr char kRequestName[] = "request_name";
   static constexpr char kModelSystemPrompt[] = "model_system_prompt";
-  static const GURL kEndpoint = GURL("http://brave.com");
   static constexpr char kAPIKey[] = "foo_api_key";
   static constexpr char kDisplayName[] = "Custom display name";
+  const GURL endpoint = GURL("http://brave.com");
 
   {
     mojom::ModelPtr model = mojom::Model::New();
     model->display_name = kDisplayName;
     model->options = mojom::ModelOptions::NewCustomModelOptions(
         mojom::CustomModelOptions::New(kRequestName, 0, 0, 0,
-                                       kModelSystemPrompt, kEndpoint, kAPIKey));
+                                       kModelSystemPrompt, endpoint, kAPIKey));
 
     GetService()->AddCustomModel(std::move(model));
   }
@@ -226,7 +226,7 @@ TEST_F(ModelServiceTest, AddAndModifyCustomModel) {
       models.back()->options->get_custom_model_options()->model_system_prompt,
       kModelSystemPrompt);
   EXPECT_EQ(models.back()->options->get_custom_model_options()->endpoint.spec(),
-            kEndpoint.spec());
+            endpoint.spec());
   EXPECT_EQ(models.back()->options->get_custom_model_options()->api_key,
             kAPIKey);
 }


### PR DESCRIPTION
This PR concentrates primarily on fixing exit-time destructors on tests,
and for cases that are low-hanging fruits. With tests there is less of a
concern with reinstantiations and copies in general.

Resolves https://github.com/brave/brave-browser/issues/48790
