### PR TITLE
fix brave reward build

### DIFF
--- a/components/brave_rewards/resources/rewards_internals/BUILD.gn
+++ b/components/brave_rewards/resources/rewards_internals/BUILD.gn
@@ -13,7 +13,6 @@ transpile_web_ui("rewards_internals") {
   resource_name = "rewards_internals"
   output_module = true
   deps = [ 
-    "//mojo/public/js:bindings",
     "//mojo/public/js:resources",
     "//brave/components/brave_rewards/core/mojom:webui_js" 
   ]

--- a/components/brave_rewards/resources/rewards_internals/BUILD.gn
+++ b/components/brave_rewards/resources/rewards_internals/BUILD.gn
@@ -12,5 +12,9 @@ transpile_web_ui("rewards_internals") {
       ] ]
   resource_name = "rewards_internals"
   output_module = true
-  deps = [ "//brave/components/brave_rewards/core/mojom:webui_js" ]
+  deps = [ 
+    "//mojo/public/js:bindings",
+    "//mojo/public/js:resources",
+    "//brave/components/brave_rewards/core/mojom:webui_js" 
+  ]
 }

--- a/components/brave_rewards/resources/rewards_internals/BUILD.gn
+++ b/components/brave_rewards/resources/rewards_internals/BUILD.gn
@@ -12,8 +12,8 @@ transpile_web_ui("rewards_internals") {
       ] ]
   resource_name = "rewards_internals"
   output_module = true
-  deps = [ 
+  deps = [
+    "//brave/components/brave_rewards/core/mojom:webui_js",
     "//mojo/public/js:resources",
-    "//brave/components/brave_rewards/core/mojom:webui_js" 
   ]
 }


### PR DESCRIPTION
I got unlucky today and the build got stuck at building `components/brave_rewards/resources/rewards_internals` with
> Module not found: Error: Can't resolve '../../../../../mojo/public/js/bindings.js'

It's needed because we import mojos base module:

https://github.com/brave/brave-core/blob/master/components/brave_rewards/core/mojom/rewards.mojom#L8

I fixed it by adding the following deps:
"//mojo/public/js:resources"

"//mojo/public/js:bindings" is redundant given that it's already  part of :resources dependency tree but not sufficient alone to make the build pass. Happy to add it in if you think that it will be more resilient to changes in the build graph (we do that in storybook build)


Error:
```
10.62s F ACTION //brave/components/brave_rewards/resources/rewards_internals:rewards_internals(//build/toolchain/mac:clang_arm64)
FAILED: 7cdcc5d9-6a80-4107-b753-40518d9235cc "./gen/brave/web-ui-rewards_internals/rewards_internals.grd" ACTION //brave/components/brave_rewards/resources/rewards_internals:rewards_internals(//build/toolchain/mac:clang_arm64)
err: exit=1
python3 ../../brave/script/transpile-web-ui.py --output_path=gen/brave/web-ui-rewards_internals --root_gen_dir=/Users/gaetano/projects/brave-6/src/out/Component_arm64/gen --grd_name=rewards_internals.grd --resource_name=rewards_internals --depfile_path=/Users/gaetano/projects/brave-6/src/out/Component_arm64/gen/brave/components/brave_rewards/resources/rewards_internals/rewards_internals.d --webpack_alias=chromeapp --entry=rewards_internals=/Users/gaetano/projects/brave-6/src/brave/components/brave_rewards/resources/rewards_internals/rewards_internals.tsx --output_module
build step: __brave_components_brave_rewards_resources_rewards_internals_rewards_internals___build_toolchain_mac_clang_arm64__rule "./gen/brave/web-ui-rewards_internals/rewards_internals.grd"
stdout:

> brave-core@1.84.4 web-ui
> webpack --config components/webpack/webpack.config.js --mode=development --env=webpack_aliases=chromeapp --env=output_module --env=brave_entries=rewards_internals=/Users/gaetano/projects/brave-6/src/brave/components/brave_rewards/resources/rewards_internals/rewards_internals.tsx

asset rewards_internals.bundle.js 3.65 MiB [emitted] [javascript module] (name: rewards_internals)
asset a670c281f966b2ba161fca87726e7c42.svg 7.98 KiB [emitted] [immutable] [from: components/brave_rewards/resources/rewards_page/assets/rewards_logo.svg] (auxiliary name: rewards_internals)
asset 2b08db1827e2965cde7cc4f65f4b34bc.svg 7.96 KiB [emitted] [immutable] [from: components/brave_rewards/resources/rewards_page/assets/rewards_logo_dark.svg] (auxiliary name: rewards_internals)
orphan modules 305 KiB [orphan] 42 modules
runtime modules 151 bytes 2 modules
built modules 1.38 MiB [built]
  modules by path ./node_modules/react-dom/ 1000 KiB
    ./node_modules/react-dom/client.js 619 bytes [built] [code generated]
    ./node_modules/react-dom/index.js 1.33 KiB [built] [code generated]
    ./node_modules/react-dom/cjs/react-dom.development.js 1000 KiB [built] [code generated]
  modules by path ./node_modules/react/ 85.7 KiB
    ./node_modules/react/index.js 190 bytes [built] [code generated]
    ./node_modules/react/cjs/react.development.js 85.5 KiB [built] [code generated]
  modules by path ./node_modules/scheduler/ 17.3 KiB
    ./node_modules/scheduler/index.js 198 bytes [built] [code generated]
    ./node_modules/scheduler/cjs/scheduler.development.js 17.1 KiB [built] [code generated]
  ./components/brave_rewards/resources/rewards_internals/rewards_internals.ts...(truncated) 305 KiB [not cacheable] [built] [code generated]

ERROR in ../out/Component_arm64/gen/brave/components/brave_rewards/core/mojom/rewards.mojom.m.js 7:0-63
Module not found: Error: Can't resolve '../../../../../mojo/public/js/bindings.js' in '/Users/gaetano/projects/brave-6/src/out/Component_arm64/gen/brave/components/brave_rewards/core/mojom'
resolve '../../../../../mojo/public/js/bindings.js' in '/Users/gaetano/projects/brave-6/src/out/Component_arm64/gen/brave/components/brave_rewards/core/mojom'
  using description file: /Users/gaetano/projects/brave-6/package.json (relative path: ./src/out/Component_arm64/gen/brave/components/brave_rewards/core/mojom)
    Field 'chromeapp' doesn't contain a valid alias configuration
    using description file: /Users/gaetano/projects/brave-6/package.json (relative path: ./src/out/Component_arm64/gen/mojo/public/js/bindings.js)
      no extension
        Field 'chromeapp' doesn't contain a valid alias configuration
        /Users/gaetano/projects/brave-6/src/out/Component_arm64/gen/mojo/public/js/bindings.js doesn't exist
      .js
        Field 'chromeapp' doesn't contain a valid alias configuration
        /Users/gaetano/projects/brave-6/src/out/Component_arm64/gen/mojo/public/js/bindings.js.js doesn't exist
      .tsx
        Field 'chromeapp' doesn't contain a valid alias configuration
        /Users/gaetano/projects/brave-6/src/out/Component_arm64/gen/mojo/public/js/bindings.js.tsx doesn't exist
      .ts
        Field 'chromeapp' doesn't contain a valid alias configuration
        /Users/gaetano/projects/brave-6/src/out/Component_arm64/gen/mojo/public/js/bindings.js.ts doesn't exist
      .json
        Field 'chromeapp' doesn't contain a valid alias configuration
        /Users/gaetano/projects/brave-6/src/out/Component_arm64/gen/mojo/public/js/bindings.js.json doesn't exist
      as directory
        /Users/gaetano/projects/brave-6/src/out/Component_arm64/gen/mojo/public/js/bindings.js doesn't exist
 @ ./components/brave_rewards/resources/rewards_internals/webui/webui_model.ts 6:0-90 13:13-43 14:13-39 15:13-42 21:13-46 22:13-43 23:13-44 24:13-39 25:13-38 31:13-49 32:13-53 33:13-47 34:13-47
 @ ./components/brave_rewards/resources/rewards_internals/rewards_internals.tsx 9:0-50 12:14-25

ERROR in ../out/Component_arm64/gen/mojo/public/mojom/base/time.mojom.m.js 7:0-42
Module not found: Error: Can't resolve '../../js/bindings.js' in '/Users/gaetano/projects/brave-6/src/out/Component_arm64/gen/mojo/public/mojom/base'
resolve '../../js/bindings.js' in '/Users/gaetano/projects/brave-6/src/out/Component_arm64/gen/mojo/public/mojom/base'
  using description file: /Users/gaetano/projects/brave-6/package.json (relative path: ./src/out/Component_arm64/gen/mojo/public/mojom/base)
    Field 'chromeapp' doesn't contain a valid alias configuration
    using description file: /Users/gaetano/projects/brave-6/package.json (relative path: ./src/out/Component_arm64/gen/mojo/public/js/bindings.js)
      no extension
        Field 'chromeapp' doesn't contain a valid alias configuration
        /Users/gaetano/projects/brave-6/src/out/Component_arm64/gen/mojo/public/js/bindings.js doesn't exist
      .js
        Field 'chromeapp' doesn't contain a valid alias configuration
        /Users/gaetano/projects/brave-6/src/out/Component_arm64/gen/mojo/public/js/bindings.js.js doesn't exist
      .tsx
        Field 'chromeapp' doesn't contain a valid alias configuration
        /Users/gaetano/projects/brave-6/src/out/Component_arm64/gen/mojo/public/js/bindings.js.tsx doesn't exist
      .ts
        Field 'chromeapp' doesn't contain a valid alias configuration
        /Users/gaetano/projects/brave-6/src/out/Component_arm64/gen/mojo/public/js/bindings.js.ts doesn't exist
      .json
        Field 'chromeapp' doesn't contain a valid alias configuration
        /Users/gaetano/projects/brave-6/src/out/Component_arm64/gen/mojo/public/js/bindings.js.json doesn't exist
      as directory
        /Users/gaetano/projects/brave-6/src/out/Component_arm64/gen/mojo/public/js/bindings.js doesn't exist
 @ ../out/Component_arm64/gen/brave/components/brave_rewards/core/mojom/rewards.mojom.m.js 9:0-12:63 1106:8-33
 @ ./components/brave_rewards/resources/rewards_internals/webui/webui_model.ts 6:0-90 13:13-43 14:13-39 15:13-42 21:13-46 22:13-43 23:13-44 24:13-39 25:13-38 31:13-49 32:13-53 33:13-47 34:13-47
 @ ./components/brave_rewards/resources/rewards_internals/rewards_internals.tsx 9:0-50 12:14-25

webpack 5.97.1 compiled with 2 errors in 2024 ms

stderr:
Traceback (most recent call last):
  File "/Users/gaetano/projects/brave-6/src/out/Component_arm64/../../brave/script/transpile-web-ui.py", line 172, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/gaetano/projects/brave-6/src/out/Component_arm64/../../brave/script/transpile-web-ui.py", line 47, in main
    transpile_web_uis(transpile_options)
  File "/Users/gaetano/projects/brave-6/src/out/Component_arm64/../../brave/script/transpile-web-ui.py", line 149, in transpile_web_uis
    execute_stdout(args, env)
  File "/Users/gaetano/projects/brave-6/src/brave/script/lib/util.py", line 230, in execute_stdout
    execute(argv, env)
  File "/Users/gaetano/projects/brave-6/src/brave/script/lib/util.py", line 209, in execute
    raise RuntimeError('Command \'%s\' failed' % (argv_string),
RuntimeError: ("Command 'npm run web-ui -- --mode=development --env=webpack_aliases=chromeapp --env=output_module --env=brave_entries=rewards_internals=/Users/gaetano/projects/brave-6/src/brave/components/brave_rewards/resources/rewards_internals/rewards_internals.tsx' failed", '')
```


For reference the dependency tree of mojo/js:resources:

```
gn desc ../out/Component_arm64 '//mojo/public/js:resources' deps --all
//mojo/public/interfaces/bindings:bindings__build_metadata
//mojo/public/interfaces/bindings:bindings__parser
//mojo/public/interfaces/bindings:bindings__parser_action
//mojo/public/interfaces/bindings:bindings__parser_deps
//mojo/public/interfaces/bindings:bindings_js__generator
//mojo/public/js:bindings
//mojo/public/js:bindings_lite
//mojo/public/js:bindings_module
//mojo/public/js:bindings_uncompiled_module
//mojo/public/js:generate_interface_support_js
//mojo/public/js:generate_mojo_internal_js
//mojo/public/js:resources_grit
//mojo/public/mojom/base:base__build_metadata
//mojo/public/mojom/base:base__parser
//mojo/public/mojom/base:base__parser_action
//mojo/public/mojom/base:base__parser_deps
//mojo/public/mojom/base:base_js
//mojo/public/mojom/base:base_js__generator
//mojo/public/tools/bindings:precompile_templates
//third_party/node:check_version
//tools/grit:grit_sources
//tools/gritsettings:default_resource_ids
```