### PR TITLE
Prevent setting location bar layout twice in a single ToolbarView::Layout() (uplift to 1.82.x)

### DIFF
--- a/browser/ui/views/location_bar/brave_location_bar_view.cc
+++ b/browser/ui/views/location_bar/brave_location_bar_view.cc
@@ -197,6 +197,22 @@ void BraveLocationBarView::OnOmniboxBlurred() {
   LocationBarView::OnOmniboxBlurred();
 }
 
+void BraveLocationBarView::Layout(PassKey) {
+  if (ignore_layout_) {
+    return;
+  }
+
+  LayoutSuperclass<LocationBarView>(this);
+}
+
+void BraveLocationBarView::OnVisibleBoundsChanged() {
+  if (ignore_layout_) {
+    return;
+  }
+
+  LocationBarView::OnVisibleBoundsChanged();
+}
+
 void BraveLocationBarView::OnChanged() {
   auto hide_page_actions = ShouldHidePageActionIcons();
   if (brave_actions_) {

--- a/browser/ui/views/location_bar/brave_location_bar_view.h
+++ b/browser/ui/views/location_bar/brave_location_bar_view.h
@@ -10,8 +10,10 @@
 #include <vector>
 
 #include "base/gtest_prod_util.h"
+#include "base/types/pass_key.h"
 #include "brave/browser/ui/views/brave_news/brave_news_action_icon_view.h"
 #include "brave/browser/ui/views/playlist/playlist_bubbles_controller.h"
+#include "brave/browser/ui/views/toolbar/brave_toolbar_view.h"
 #include "brave/browser/ui/views/view_shadow.h"
 #include "brave/components/tor/buildflags/buildflags.h"
 #include "chrome/browser/ui/views/location_bar/location_bar_view.h"
@@ -75,6 +77,8 @@ class BraveLocationBarView : public LocationBarView {
   views::View* GetSearchPromotionButton() const override;
   void RefreshBackground() override;
   void OnOmniboxBlurred() override;
+  void Layout(PassKey) override;
+  void OnVisibleBoundsChanged() override;
 
   // views::View:
   gfx::Size CalculatePreferredSize(
@@ -94,6 +98,11 @@ class BraveLocationBarView : public LocationBarView {
   void ShowPlaylistBubble(
       playlist::PlaylistBubblesController::BubbleType type =
           playlist::PlaylistBubblesController::BubbleType::kInfer);
+
+  void set_ignore_layout(base::PassKey<BraveToolbarView::LayoutGuard>,
+                         bool ignore) {
+    ignore_layout_ = ignore;
+  }
 
  private:
   FRIEND_TEST_ALL_PREFIXES(playlist::PlaylistBrowserTest, AddItemsToList);
@@ -115,6 +124,10 @@ class BraveLocationBarView : public LocationBarView {
   PlaylistActionIconView* GetPlaylistActionIconView();
   void SetupShadow();
 
+  // Prevent layout with invalid rect.
+  // It also could make omnibox popup have wrong position.
+  // See the comments of BraveToolbarView::Layout().
+  bool ignore_layout_ = false;
   std::unique_ptr<ViewShadow> shadow_;
   raw_ptr<BraveActionsContainer> brave_actions_ = nullptr;
   raw_ptr<BraveNewsActionIconView> brave_news_action_icon_view_ = nullptr;

--- a/browser/ui/views/toolbar/brave_toolbar_view.h
+++ b/browser/ui/views/toolbar/brave_toolbar_view.h
@@ -29,6 +29,8 @@ class BraveToolbarView : public ToolbarView,
                          public ProfileAttributesStorage::Observer {
   METADATA_HEADER(BraveToolbarView, ToolbarView)
  public:
+  class LayoutGuard;
+
   explicit BraveToolbarView(Browser* browser, BrowserView* browser_view);
   ~BraveToolbarView() override;
 


### PR DESCRIPTION
Uplift of #30867
Resolves https://github.com/brave/brave-browser/issues/48629

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.