### PR TITLE
Hide VerticalTabStripRegionView when hiding completely

### DIFF
--- a/browser/ui/views/frame/brave_browser_view.h
+++ b/browser/ui/views/frame/brave_browser_view.h
@@ -165,6 +165,8 @@ class BraveBrowserView : public BrowserView,
   FRIEND_TEST_ALL_PREFIXES(SideBySideEnabledBrowserTest,
                            BraveMultiContentsViewTest);
   FRIEND_TEST_ALL_PREFIXES(VerticalTabStripHideCompletelyTest, GetMinimumWidth);
+  FRIEND_TEST_ALL_PREFIXES(VerticalTabStripHideCompletelyTest,
+                           ShouldBeInVisible);
   FRIEND_TEST_ALL_PREFIXES(SideBySideWithRoundedCornersTest,
                            TabFullscreenStateTest);
   FRIEND_TEST_ALL_PREFIXES(BraveBrowserViewWithRoundedCornersTest,

--- a/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_browsertest.cc
+++ b/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_browsertest.cc
@@ -48,6 +48,7 @@
 #include "chrome/test/base/ui_test_utils.h"
 #include "content/public/test/browser_test.h"
 #include "ui/base/test/ui_controls.h"
+#include "ui/gfx/animation/animation_test_api.h"
 #include "ui/views/layout/flex_layout.h"
 #include "ui/views/layout/layout_manager.h"
 
@@ -1161,4 +1162,32 @@ IN_PROC_BROWSER_TEST_F(VerticalTabStripHideCompletelyTest, GetMinimumWidth) {
   // The minimum width of the region view should be 4px, which is narrower than
   // it used to be.
   EXPECT_EQ(4, region_view->GetMinimumSize().width());
+}
+
+IN_PROC_BROWSER_TEST_F(VerticalTabStripHideCompletelyTest, ShouldBeInVisible) {
+  ToggleVerticalTabStrip();
+
+  const gfx::AnimationTestApi::RenderModeResetter render_mode_resetter =
+      gfx::AnimationTestApi::SetRichAnimationRenderMode(
+          gfx::Animation::RichAnimationRenderMode::FORCE_DISABLED);
+
+  auto* widget_delegate_view =
+      browser_view()->vertical_tab_strip_widget_delegate_view_.get();
+  ASSERT_TRUE(widget_delegate_view);
+
+  auto* region_view = widget_delegate_view->vertical_tab_strip_region_view();
+  ASSERT_TRUE(region_view);
+
+  region_view->ToggleState();
+  ASSERT_EQ(VerticalTabStripRegionView::State::kCollapsed,
+            region_view->state());
+
+  // When collapsed, it should be inivisible.
+  EXPECT_FALSE(region_view->GetVisible());
+
+  region_view->ToggleState();
+  ASSERT_EQ(VerticalTabStripRegionView::State::kExpanded, region_view->state());
+
+  // When expanded, it should get visible again.
+  EXPECT_TRUE(region_view->GetVisible());
 }

--- a/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.cc
@@ -703,11 +703,16 @@ void VerticalTabStripRegionView::SetState(State state) {
   if (gfx::Animation::ShouldRenderRichAnimation()) {
     state_ == State::kCollapsed ? width_animation_.Hide()
                                 : width_animation_.Show();
+  } else if (state_ == State::kCollapsed) {
+    // Call the callback immediately if no animation.
+    OnCollapseAnimationEnded();
   }
 
   if (!GetVisible() && state_ != State::kCollapsed) {
-    // This means vertical tab strip is expanded temporarily in browser
-    // fullscreen mode.
+    // This can happen when
+    // * vertical tab strip is expanded temporarily in browser fullscreen mode.
+    // * vertical tab strip is shown from collapsed state with
+    // tabs::features::kBraveVerticalTabHideCompletely on.
     SetVisible(true);
   }
 
@@ -1064,9 +1069,8 @@ void VerticalTabStripRegionView::AnimationEnded(
     const gfx::Animation* animation) {
   PreferredSizeChanged();
 
-  if (IsFloatingEnabledForBrowserFullscreen() && state_ == State::kCollapsed) {
-    // When the animation ends, we should hide the vertical tab strip.
-    SetVisible(false);
+  if (state_ == State::kCollapsed) {
+    OnCollapseAnimationEnded();
   }
 }
 
@@ -1366,6 +1370,19 @@ std::u16string VerticalTabStripRegionView::GetShortcutTextForNewTabButton(
 
 views::LabelButton& VerticalTabStripRegionView::GetToggleButtonForTesting() {
   return *header_view_->toggle_button();
+}
+
+void VerticalTabStripRegionView::OnCollapseAnimationEnded() {
+  CHECK_EQ(state_, State::kCollapsed);
+
+  if (IsFloatingEnabledForBrowserFullscreen() ||
+      base::FeatureList::IsEnabled(
+          tabs::features::kBraveVerticalTabHideCompletely)) {
+    // When the animation ends, we should hide the vertical tab strip as we
+    // don't want the tabstrip to be visible partially. This view only takes a
+    // little width and watches mouse movement to expand itself.
+    SetVisible(false);
+  }
 }
 
 bool VerticalTabStripRegionView::IsMenuShowing() const {

--- a/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.h
+++ b/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.h
@@ -181,6 +181,10 @@ class VerticalTabStripRegionView : public views::View,
 
   views::LabelButton& GetToggleButtonForTesting();
 
+  // Callback that is called when collapse animation ends. We update visibility
+  // of this view if it's needed
+  void OnCollapseAnimationEnded();
+
   raw_ptr<BrowserView> browser_view_ = nullptr;
   raw_ptr<Browser> browser_ = nullptr;
 


### PR DESCRIPTION
This will prevent the vertical tab strip from being shown partially when it is supposed to be completely hidden.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/47520

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
