### PR TITLE
[CodeHealth] Replace `base::WrapUnique` with `std::make_unique` where applicable

### DIFF
--- a/browser/ui/webui/new_tab_page/brave_new_tab_ui.cc
+++ b/browser/ui/webui/new_tab_page/brave_new_tab_ui.cc
@@ -143,8 +143,7 @@ BraveNewTabUI::BraveNewTabUI(
 
   web_ui->AddMessageHandler(base::WrapUnique(
       BraveNewTabMessageHandler::Create(source, profile, was_restored)));
-  web_ui->AddMessageHandler(
-      base::WrapUnique(new TopSitesMessageHandler(profile)));
+  web_ui->AddMessageHandler(std::make_unique<TopSitesMessageHandler>(profile));
 
   // For custom background images.
   if (auto* ntp_custom_background_images_service =

--- a/chromium_src/chrome/browser/ui/browser.cc
+++ b/chromium_src/chrome/browser/ui/browser.cc
@@ -28,5 +28,5 @@ std::unique_ptr<Browser> Browser::DeprecatedCreateOwnedForTesting(
   // not possible, e.g. using the wrong profile or during shutdown. The caller
   // should handle this; see e.g. crbug.com/1141608 and crbug.com/1261628.
   CHECK_EQ(CreationStatus::kOk, GetCreationStatusForProfile(params.profile));
-  return base::WrapUnique(new BraveBrowser(params));
+  return std::make_unique<BraveBrowser>(params);
 }

--- a/chromium_src/extensions/browser/verified_contents.cc
+++ b/chromium_src/extensions/browser/verified_contents.cc
@@ -48,7 +48,7 @@ constexpr uint8_t kBraveVerifiedContentsPublicKey[] = {
     base::span<const uint8_t> public_key,
     std::string_view contents) {
   // Note: VerifiedContents constructor is private.
-  auto verified_contents = base::WrapUnique(new VerifiedContents(public_key));
+  auto verified_contents = std::make_unique<VerifiedContents>(public_key);
   std::string payload;
   if (!verified_contents->GetPayload(contents, &payload))
   ```

--- a/patches/chrome-browser-ui-views-overlay-video_overlay_window_views.cc.patch
+++ b/patches/chrome-browser-ui-views-overlay-video_overlay_window_views.cc.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/ui/views/overlay/video_overlay_window_views.cc b/chrome/browser/ui/views/overlay/video_overlay_window_views.cc
-index df6326f6ab2fd87abe4bf04834683f7ab500dd60..76e67d00361ea70064f505ad3ca87835bde2ec1b 100644
+index df6326f6ab2fd87abe4bf04834683f7ab500dd60..4857fc028efe7ae125e3401ea8c49d087ac23633 100644
 --- a/chrome/browser/ui/views/overlay/video_overlay_window_views.cc
 +++ b/chrome/browser/ui/views/overlay/video_overlay_window_views.cc
 @@ -382,7 +382,7 @@ std::unique_ptr<VideoOverlayWindowViews> VideoOverlayWindowViews::Create(
@@ -7,7 +7,7 @@ index df6326f6ab2fd87abe4bf04834683f7ab500dd60..76e67d00361ea70064f505ad3ca87835
    // doesn't initialize the object fully.
    auto overlay_window =
 -      base::WrapUnique(new VideoOverlayWindowViews(controller));
-+      base::WrapUnique(new BraveVideoOverlayWindowViews(controller));
++      std::make_unique<BraveVideoOverlayWindowViews>(controller);
  
    // The 2024 updated controls use dark mode colors.
    if (Use2024UI()) {


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/48816

Other instances of `base::WrapUnique(new X())` call private constructors, so they cannot be converted to `std::make_unique`.