### PR TITLE
Fixed DCHECK failure from InfoBarView::Layout()

### DIFF
--- a/browser/ui/views/infobars/BUILD.gn
+++ b/browser/ui/views/infobars/BUILD.gn
@@ -1,0 +1,19 @@
+# Copyright (c) 2025 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+source_set("unit_tests") {
+  testonly = true
+
+  sources = [ "brave_confirm_infobar_unittest.cc" ]
+
+  deps = [
+    "//base",
+    "//brave/common",
+    "//brave/components/infobars/core",
+    "//chrome/browser/ui",
+    "//chrome/test:test_support",
+    "//testing/gtest",
+  ]
+}

--- a/browser/ui/views/infobars/brave_confirm_infobar.cc
+++ b/browser/ui/views/infobars/brave_confirm_infobar.cc
@@ -187,6 +187,22 @@ void BraveConfirmInfoBar::Layout(PassKey) {
   link_->SetPosition(gfx::Point(GetEndX() - link_->width(), OffsetY(link_)));
 }
 
+void BraveConfirmInfoBar::ViewHierarchyChanged(
+    const views::ViewHierarchyChangedDetails& details) {
+  InfoBarView::ViewHierarchyChanged(details);
+
+  // Upstream doesnt need this reorder because all other children
+  // except icon and close button are in |content_container_| that lives
+  // between both. It guarantees that close button is always the last
+  // children. However, we just add children directly instead of
+  // that container.
+  // TODO(https://github.com/brave/brave-browser/issues/48822): Add our children
+  // into content container.
+  if (details.is_add && (details.child == this) && close_button_) {
+    ReorderChildView(close_button_, children().size());
+  }
+}
+
 void BraveConfirmInfoBar::MaybeLayoutMultiLineLabelAndLink() {
   if (!GetDelegate()->ShouldSupportMultiLine()) {
     return;

--- a/browser/ui/views/infobars/brave_confirm_infobar.cc
+++ b/browser/ui/views/infobars/brave_confirm_infobar.cc
@@ -117,6 +117,17 @@ BraveConfirmInfoBar::BraveConfirmInfoBar(
         base::BindRepeating(&BraveConfirmInfoBar::CheckboxPressed,
                             weak_ptr_factory_.GetWeakPtr())));
   }
+
+  // Upstream doesn't need this reorder because all other children
+  // except icon and close button are in |content_container_| that lives
+  // between both. It guarantees that close button is always the last
+  // children. However, we just add children directly instead of
+  // that container.
+  // TODO(https://github.com/brave/brave-browser/issues/48822): Add our children
+  // into content container.
+  if (close_button_) {
+    ReorderChildView(close_button_, children().size());
+  }
 }
 
 BraveConfirmInfoBar::~BraveConfirmInfoBar() = default;
@@ -185,22 +196,6 @@ void BraveConfirmInfoBar::Layout(PassKey) {
   }
 
   link_->SetPosition(gfx::Point(GetEndX() - link_->width(), OffsetY(link_)));
-}
-
-void BraveConfirmInfoBar::ViewHierarchyChanged(
-    const views::ViewHierarchyChangedDetails& details) {
-  InfoBarView::ViewHierarchyChanged(details);
-
-  // Upstream doesnt need this reorder because all other children
-  // except icon and close button are in |content_container_| that lives
-  // between both. It guarantees that close button is always the last
-  // children. However, we just add children directly instead of
-  // that container.
-  // TODO(https://github.com/brave/brave-browser/issues/48822): Add our children
-  // into content container.
-  if (details.is_add && (details.child == this) && close_button_) {
-    ReorderChildView(close_button_, children().size());
-  }
 }
 
 void BraveConfirmInfoBar::MaybeLayoutMultiLineLabelAndLink() {

--- a/browser/ui/views/infobars/brave_confirm_infobar.h
+++ b/browser/ui/views/infobars/brave_confirm_infobar.h
@@ -8,10 +8,12 @@
 
 #include <memory>
 
+#include "base/gtest_prod_util.h"
 #include "base/memory/raw_ptr.h"
 #include "brave/components/infobars/core/brave_confirm_infobar_delegate.h"
 #include "chrome/browser/ui/views/infobars/infobar_view.h"
 #include "ui/base/metadata/metadata_header_macros.h"
+#include "ui/views/controls/button/image_button.h"
 
 namespace views {
 class Checkbox;
@@ -35,10 +37,14 @@ class BraveConfirmInfoBar : public InfoBarView {
 
   // InfoBarView:
   void Layout(PassKey) override;
+  void ViewHierarchyChanged(
+      const views::ViewHierarchyChangedDetails& details) override;
 
   BraveConfirmInfoBarDelegate* GetDelegate() const;
 
  private:
+  FRIEND_TEST_ALL_PREFIXES(BraveConfirmInfoBarTest, CloseButtonOrderTest);
+
   // InfoBarView:
   int GetContentMinimumWidth() const override;
 
@@ -55,6 +61,8 @@ class BraveConfirmInfoBar : public InfoBarView {
   // Returns the width of all content other than the label and link.  Layout()
   // uses this to determine how much space the label and link can take.
   int NonLabelWidth() const;
+
+  views::View* close_button_for_testing() const { return close_button_.get(); }
 
   raw_ptr<views::Label> label_ = nullptr;
   raw_ptr<views::MdTextButton> ok_button_ = nullptr;

--- a/browser/ui/views/infobars/brave_confirm_infobar.h
+++ b/browser/ui/views/infobars/brave_confirm_infobar.h
@@ -37,8 +37,6 @@ class BraveConfirmInfoBar : public InfoBarView {
 
   // InfoBarView:
   void Layout(PassKey) override;
-  void ViewHierarchyChanged(
-      const views::ViewHierarchyChangedDetails& details) override;
 
   BraveConfirmInfoBarDelegate* GetDelegate() const;
 

--- a/browser/ui/views/infobars/brave_confirm_infobar_unittest.cc
+++ b/browser/ui/views/infobars/brave_confirm_infobar_unittest.cc
@@ -9,7 +9,6 @@
 #include "chrome/test/views/chrome_views_test_base.h"
 #include "testing/gtest/include/gtest/gtest.h"
 #include "ui/views/view.h"
-#include "ui/views/widget/widget.h"
 
 using BraveConfirmInfoBarTest = ChromeViewsTestBase;
 
@@ -34,15 +33,9 @@ class TestInfoBarDelegate : public BraveConfirmInfoBarDelegate {
 
 // Check close button is always the last children.
 TEST_F(BraveConfirmInfoBarTest, CloseButtonOrderTest) {
-  std::unique_ptr<views::Widget> widget =
-      CreateTestWidget(views::Widget::InitParams::CLIENT_OWNS_WIDGET);
   auto infobar = std::make_unique<BraveConfirmInfoBar>(
       (std::make_unique<TestInfoBarDelegate>()));
-
-  // Added to widget to get ViewHierarchyChanged().
-  widget->SetContentsView(infobar.get());
   auto* close_button = infobar->close_button_for_testing();
   ASSERT_TRUE(close_button);
   EXPECT_EQ(close_button, infobar->children().back());
-  infobar->DeprecatedLayoutImmediately();
 }

--- a/browser/ui/views/infobars/brave_confirm_infobar_unittest.cc
+++ b/browser/ui/views/infobars/brave_confirm_infobar_unittest.cc
@@ -1,0 +1,48 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/views/infobars/brave_confirm_infobar.h"
+
+#include "brave/components/infobars/core/brave_confirm_infobar_delegate.h"
+#include "chrome/test/views/chrome_views_test_base.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "ui/views/view.h"
+#include "ui/views/widget/widget.h"
+
+using BraveConfirmInfoBarTest = ChromeViewsTestBase;
+
+namespace {
+
+class TestInfoBarDelegate : public BraveConfirmInfoBarDelegate {
+ public:
+  TestInfoBarDelegate() = default;
+  ~TestInfoBarDelegate() override = default;
+
+  // BraveConfirmInfoBarDelegate:
+  infobars::InfoBarDelegate::InfoBarIdentifier GetIdentifier() const override {
+    return TEST_INFOBAR;
+  }
+
+  int GetButtons() const override { return BUTTON_NONE; }
+
+  std::u16string GetMessageText() const override { return u""; }
+};
+
+}  // namespace
+
+// Check close button is always the last children.
+TEST_F(BraveConfirmInfoBarTest, CloseButtonOrderTest) {
+  std::unique_ptr<views::Widget> widget =
+      CreateTestWidget(views::Widget::InitParams::CLIENT_OWNS_WIDGET);
+  auto infobar = std::make_unique<BraveConfirmInfoBar>(
+      (std::make_unique<TestInfoBarDelegate>()));
+
+  // Added to widget to get ViewHierarchyChanged().
+  widget->SetContentsView(infobar.get());
+  auto* close_button = infobar->close_button_for_testing();
+  ASSERT_TRUE(close_button);
+  EXPECT_EQ(close_button, infobar->children().back());
+  infobar->DeprecatedLayoutImmediately();
+}

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -460,6 +460,7 @@ test("brave_unit_tests") {
       "//brave/browser/ui/tabs/test:unit_tests",
       "//brave/browser/ui/toolbar:brave_app_menu_unit_test",
       "//brave/browser/ui/views/download/bubble:unit_tests",
+      "//brave/browser/ui/views/infobars:unit_tests",
       "//brave/browser/ui/views/split_view:unit_tests",
       "//brave/browser/ui/views/tabs:unit_tests",
       "//brave/browser/ui/webui/cr_components:unit_tests",


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves fix https://github.com/brave/brave-browser/issues/48814

Unlike upstream, Brave adds child views directly to the infobar instead of using the content_container_.
This causes the close button to not always be the last child in the view hierarchy, which triggers layout assertion failures.

Fixed by overriding `ViewHierarchyChanged()` in `BraveConfirmInfoBar` to ensure the close button is always reordered as the last child when views are added.

This upstream changes affected us - https://chromium-review.googlesource.com/c/chromium/src/+/6632793
Filed f/u issue for adding our children to `content_container_`. - https://github.com/brave/brave-browser/issues/48822

TEST=`BraveConfirmInfoBarTest.CloseButtonOrderTest`

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
