### PR TITLE
[iOS] Add missing IOSChromeAimEligibilityServiceFactory to dependencies (uplift to 1.82.x)

### DIFF
--- a/chromium_src/ios/chrome/browser/profile/model/keyed_service_factories.mm
+++ b/chromium_src/ios/chrome/browser/profile/model/keyed_service_factories.mm
@@ -7,6 +7,7 @@
 
 #include "brave/ios/browser/profile/model/brave_keyed_service_factories.h"
 #include "ios/chrome/browser/affiliations/model/ios_chrome_affiliation_service_factory.h"
+#include "ios/chrome/browser/aim/model/ios_chrome_aim_eligibility_service_factory.h"
 #include "ios/chrome/browser/autocomplete/model/autocomplete_classifier_factory.h"
 #include "ios/chrome/browser/autocomplete/model/zero_suggest_cache_service_factory.h"
 #include "ios/chrome/browser/autofill/model/autofill_log_router_factory.h"
@@ -122,6 +123,7 @@ void EnsureProfileKeyedServiceFactoriesBuilt() {
   HttpsUpgradeServiceFactory::GetInstance();
   IdentityManagerFactory::GetInstance();
   IOSChromeAccountPasswordStoreFactory::GetInstance();
+  IOSChromeAimEligibilityServiceFactory::GetInstance();
   IOSChromeAffiliationServiceFactory::GetInstance();
   IOSChromeBulkLeakCheckServiceFactory::GetInstance();
   IOSChromeFaviconLoaderFactory::GetInstance();


### PR DESCRIPTION
Uplift of #30921
Resolves https://github.com/brave/brave-browser/issues/48808

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.