### PR TITLE
Show sidebar UI when mouse enters into rounded corners padding

### DIFF
--- a/browser/ui/views/frame/brave_browser_view.h
+++ b/browser/ui/views/frame/brave_browser_view.h
@@ -122,6 +122,7 @@ class BraveBrowserView : public BrowserView,
   views::View* GetContentsContainerForLayoutManager() override;
   void ReadyToListenFullscreenChanges() override;
   bool PreHandleMouseEvent(const blink::WebMouseEvent& event) override;
+  void OnMouseMoved(const ui::MouseEvent& event) override;
 
 #if defined(USE_AURA)
   views::View* sidebar_host_view() { return sidebar_host_view_; }

--- a/browser/ui/views/sidebar/sidebar_container_view.cc
+++ b/browser/ui/views/sidebar/sidebar_container_view.cc
@@ -177,13 +177,12 @@ bool SidebarContainerView::IsSidebarVisible() const {
 }
 
 bool SidebarContainerView::PreHandleMouseEvent(
-    const blink::WebMouseEvent& event) {
+    const gfx::PointF& point_in_screen) {
   if (IsSidebarVisible()) {
     return false;
   }
 
-  if (show_sidebar_option_ != ShowSidebarOption::kShowOnMouseOver ||
-      event.GetTypeAsUiEventType() != ui::EventType::kMouseMoved) {
+  if (show_sidebar_option_ != ShowSidebarOption::kShowOnMouseOver) {
     return false;
   }
 
@@ -191,15 +190,20 @@ bool SidebarContainerView::PreHandleMouseEvent(
   gfx::RectF mouse_event_detect_bounds(
       browser_view->GetContentsContainerForLayoutManager()
           ->GetBoundsInScreen());
-  constexpr int kHotCorenerWidth = 7;
+
+  // Detect bounds should include rounded corners margin to make sidebar
+  // visible from that padding also.
+  mouse_event_detect_bounds.Outset(
+      BraveContentsViewUtil::GetRoundedCornersWebViewMargin(browser_));
+  constexpr int kHotCornerWidth = 7;
+  const int inset = mouse_event_detect_bounds.width() - kHotCornerWidth;
   if (sidebar_on_left_) {
-    mouse_event_detect_bounds.set_width(kHotCorenerWidth);
+    mouse_event_detect_bounds.Inset(gfx::InsetsF::TLBR(0, 0, 0, inset));
   } else {
-    mouse_event_detect_bounds.set_x(mouse_event_detect_bounds.right() -
-                                    kHotCorenerWidth);
+    mouse_event_detect_bounds.Inset(gfx::InsetsF::TLBR(0, inset, 0, 0));
   }
 
-  if (mouse_event_detect_bounds.Contains(event.PositionInScreen())) {
+  if (mouse_event_detect_bounds.Contains(point_in_screen)) {
     ShowSidebarControlView();
     return true;
   }

--- a/browser/ui/views/sidebar/sidebar_container_view.h
+++ b/browser/ui/views/sidebar/sidebar_container_view.h
@@ -33,10 +33,6 @@ namespace sidebar {
 class SidebarBrowserTest;
 }  // namespace sidebar
 
-namespace blink {
-class WebMouseEvent;
-}  // namespace blink
-
 class BraveBrowser;
 class SidePanelEntry;
 
@@ -75,7 +71,7 @@ class SidebarContainerView
   bool IsSidebarVisible() const;
 
   // Return false if this mouse event can't make sidebar UI visible.
-  bool PreHandleMouseEvent(const blink::WebMouseEvent& event);
+  bool PreHandleMouseEvent(const gfx::PointF& point_in_screen);
 
   BraveSidePanel* side_panel() { return side_panel_; }
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

So far, we only handled mouse move event from web contents for showing sidebar on mouseover.
This has drawback in fullscreen mode. In window fullscreen, user can move mouse quickly to right edge to show sidebar
but it could not be shown as we don't handle mouse move from rounded corners padding.
With this PR, we handle mouse move event from there.

TEST=SidebarBrowserWithSplitViewTest.ShowSidebarOnMouseOverTest

Manual test:
1. Enable rounded corners feature and relaunch
2. Set sidebar option as `on mouseover`
3. Make window fullscreen
4. Move mouse quickly to window's right edge
5. Check sidebar is shown always

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
