### PR TITLE
Close only active tab from split tab

### DIFF
--- a/browser/ui/tabs/brave_tab_menu_model.h
+++ b/browser/ui/tabs/brave_tab_menu_model.h
@@ -73,7 +73,7 @@ class BraveTabMenuModel : public TabMenuModel {
   bool IsNewFeatureAt(size_t index) const override;
 
  private:
-  FRIEND_TEST_ALL_PREFIXES(BraveTabContextMenuWithSideBySideTest,
+  FRIEND_TEST_ALL_PREFIXES(BraveTabContextMenuContentsTest,
                            SplitViewMenuCustomizationTest);
 
   void Build(Browser* browser,

--- a/browser/ui/tabs/brave_tab_strip_model.cc
+++ b/browser/ui/tabs/brave_tab_strip_model.cc
@@ -132,3 +132,24 @@ void BraveTabStripModel::SetCustomTitleForTab(
 
   NotifyTabChanged(tab_interface, TabChangeType::kAll);
 }
+
+void BraveTabStripModel::CloseSelectedTabsFromBrowserCommands() {
+  auto selected_indices = selection_model().selected_indices();
+  if (selected_indices.size() != 2) {
+    return CloseSelectedTabs();
+  }
+
+  // If selected tabs only include two tabs from same split tab,
+  // close active tab only.
+  auto first_tab = selected_indices.begin();
+  auto first_tab_split = GetSplitForTab(*first_tab);
+  if (first_tab_split.has_value() &&
+      first_tab_split == GetSplitForTab(*(first_tab + 1))) {
+    CloseWebContentsAt(active_index(),
+                       TabCloseTypes::CLOSE_USER_GESTURE |
+                           TabCloseTypes::CLOSE_CREATE_HISTORICAL_TAB);
+    return;
+  }
+
+  return CloseSelectedTabs();
+}

--- a/browser/ui/tabs/brave_tab_strip_model.cc
+++ b/browser/ui/tabs/brave_tab_strip_model.cc
@@ -133,7 +133,7 @@ void BraveTabStripModel::SetCustomTitleForTab(
   NotifyTabChanged(tab_interface, TabChangeType::kAll);
 }
 
-void BraveTabStripModel::CloseSelectedTabsFromBrowserCommands() {
+void BraveTabStripModel::CloseSelectedTabsWithSplitView() {
   auto selected_indices = selection_model().selected_indices();
   if (selected_indices.size() != 2) {
     return CloseSelectedTabs();

--- a/browser/ui/tabs/brave_tab_strip_model.h
+++ b/browser/ui/tabs/brave_tab_strip_model.h
@@ -50,7 +50,7 @@ class BraveTabStripModel : public TabStripModel {
   void SelectRelativeTab(TabRelativeDirection direction,
                          TabStripUserGestureDetails detail) override;
   void UpdateWebContentsStateAt(int index, TabChangeType change_type) override;
-  void CloseSelectedTabsFromBrowserCommands() override;
+  void CloseSelectedTabsWithSplitView() override;
 
  private:
   // List of tab indexes sorted by most recently used

--- a/browser/ui/tabs/brave_tab_strip_model.h
+++ b/browser/ui/tabs/brave_tab_strip_model.h
@@ -50,6 +50,7 @@ class BraveTabStripModel : public TabStripModel {
   void SelectRelativeTab(TabRelativeDirection direction,
                          TabStripUserGestureDetails detail) override;
   void UpdateWebContentsStateAt(int index, TabChangeType change_type) override;
+  void CloseSelectedTabsFromBrowserCommands() override;
 
  private:
   // List of tab indexes sorted by most recently used

--- a/browser/ui/views/split_view/split_view_browsertest.cc
+++ b/browser/ui/views/split_view/split_view_browsertest.cc
@@ -905,6 +905,46 @@ IN_PROC_BROWSER_TEST_P(SplitViewCommonBrowserTest, SplitViewReloadTest) {
   }
 }
 
+IN_PROC_BROWSER_TEST_P(SplitViewCommonBrowserTest, SplitViewCloseTabTest) {
+  NewSplitTab();
+
+  auto* tab_strip_model = browser()->tab_strip_model();
+  EXPECT_EQ(1, tab_strip_model->active_index());
+  EXPECT_EQ(2, tab_strip_model->count());
+  EXPECT_TRUE(IsSplitTabAt(0));
+  EXPECT_TRUE(IsSplitTabAt(1));
+
+  // Check only active tab is closed from split tab when split tab is
+  // the only selected tabs.
+  chrome::CloseTab(browser());
+  EXPECT_EQ(0, tab_strip_model->active_index());
+  EXPECT_EQ(1, tab_strip_model->count());
+
+  // Create another active tab.
+  chrome::AddTabAt(browser(), GURL(), -1, /*foreground*/ true);
+  NewSplitTab();
+
+  EXPECT_EQ(2, tab_strip_model->active_index());
+  EXPECT_EQ(3, tab_strip_model->count());
+  EXPECT_TRUE(IsSplitTabAt(1));
+  EXPECT_TRUE(IsSplitTabAt(2));
+  chrome::AddTabAt(browser(), GURL(), -1, /*foreground*/ true);
+
+  // Make tabs at 1, 2, 3 selected.
+  // Check selected tab is not the only split tab,
+  // we'll close all selected tabs.
+  tab_strip_model->ExtendSelectionTo(1);
+  EXPECT_TRUE(IsSplitTabAt(1));
+  EXPECT_TRUE(IsSplitTabAt(2));
+  EXPECT_EQ(1, tab_strip_model->active_index());
+  EXPECT_EQ(4, tab_strip_model->count());
+
+  // Check all selected tabs are closed (tab at 1, 2, 3).
+  chrome::CloseTab(browser());
+  EXPECT_EQ(0, tab_strip_model->active_index());
+  EXPECT_EQ(1, tab_strip_model->count());
+}
+
 INSTANTIATE_TEST_SUITE_P(
     /* no prefix */,
     SplitViewCommonBrowserTest,

--- a/browser/ui/views/tabs/brave_browser_tab_strip_controller.cc
+++ b/browser/ui/views/tabs/brave_browser_tab_strip_controller.cc
@@ -58,3 +58,19 @@ void BraveBrowserTabStripController::ShowContextMenuForTab(
       std::make_unique<BraveTabContextMenuContents>(tab, this, *tab_index);
   context_menu_contents_->RunMenuAt(p, source_type);
 }
+
+void BraveBrowserTabStripController::ExecuteCommandForTab(
+    TabStripModel::ContextMenuCommand command_id,
+    const Tab* tab) {
+  const std::optional<int> model_index = tabstrip_->GetModelIndexOf(tab);
+  if (!model_index.has_value()) {
+    return;
+  }
+
+  if (command_id == TabStripModel::CommandCloseTab) {
+    model_->CloseSelectedTabsFromBrowserCommands();
+    return;
+  }
+
+  model_->ExecuteContextMenuCommand(model_index.value(), command_id);
+}

--- a/browser/ui/views/tabs/brave_browser_tab_strip_controller.cc
+++ b/browser/ui/views/tabs/brave_browser_tab_strip_controller.cc
@@ -68,7 +68,7 @@ void BraveBrowserTabStripController::ExecuteCommandForTab(
   }
 
   if (command_id == TabStripModel::CommandCloseTab) {
-    model_->CloseSelectedTabsFromBrowserCommands();
+    model_->CloseSelectedTabsWithSplitView();
     return;
   }
 

--- a/browser/ui/views/tabs/brave_browser_tab_strip_controller.h
+++ b/browser/ui/views/tabs/brave_browser_tab_strip_controller.h
@@ -39,6 +39,8 @@ class BraveBrowserTabStripController : public BrowserTabStripController {
   void ShowContextMenuForTab(Tab* tab,
                              const gfx::Point& p,
                              ui::mojom::MenuSourceType source_type) override;
+  void ExecuteCommandForTab(TabStripModel::ContextMenuCommand command_id,
+                            const Tab* tab) override;
 
  private:
   // If non-NULL it means we're showing a menu for the tab.

--- a/browser/ui/views/tabs/brave_tab_context_menu_contents.h
+++ b/browser/ui/views/tabs/brave_tab_context_menu_contents.h
@@ -80,7 +80,7 @@ class BraveTabContextMenuContents
  private:
   FRIEND_TEST_ALL_PREFIXES(VerticalTabStripStringBrowserTest,
                            ContextMenuString);
-  FRIEND_TEST_ALL_PREFIXES(BraveTabContextMenuWithSideBySideTest,
+  FRIEND_TEST_ALL_PREFIXES(BraveTabContextMenuContentsTest,
                            SplitViewMenuCustomizationTest);
 
   bool IsBraveCommandIdEnabled(int command_id) const;

--- a/chromium_src/chrome/browser/ui/browser_commands.cc
+++ b/chromium_src/chrome/browser/ui/browser_commands.cc
@@ -54,7 +54,7 @@ void MakeActiveTabReloadOnlyForSplitTab(
 #define ReloadBypassingCache ReloadBypassingCache_ChromiumImpl
 #define GetReadingListModel GetReadingListModel_ChromiumImpl
 #define kChromeUISplitViewNewTabPageURL kChromeUINewTabURL
-#define CloseSelectedTabs CloseSelectedTabsFromBrowserCommands
+#define CloseSelectedTabs CloseSelectedTabsWithSplitView
 
 // Need to patch to adjust |selected_tabs| in the middle of ReloadInternal().
 #define BRAVE_RELOAD_INTERNAL                                    \

--- a/chromium_src/chrome/browser/ui/browser_commands.cc
+++ b/chromium_src/chrome/browser/ui/browser_commands.cc
@@ -54,6 +54,7 @@ void MakeActiveTabReloadOnlyForSplitTab(
 #define ReloadBypassingCache ReloadBypassingCache_ChromiumImpl
 #define GetReadingListModel GetReadingListModel_ChromiumImpl
 #define kChromeUISplitViewNewTabPageURL kChromeUINewTabURL
+#define CloseSelectedTabs CloseSelectedTabsFromBrowserCommands
 
 // Need to patch to adjust |selected_tabs| in the middle of ReloadInternal().
 #define BRAVE_RELOAD_INTERNAL                                    \
@@ -62,6 +63,7 @@ void MakeActiveTabReloadOnlyForSplitTab(
 
 #include <chrome/browser/ui/browser_commands.cc>
 
+#undef CloseSelectedTabs
 #undef BRAVE_RELOAD_INTERNAL
 #undef kChromeUISplitViewNewTabPageURL
 #undef ReloadBypassingCache

--- a/chromium_src/chrome/browser/ui/tabs/split_tab_menu_model.h
+++ b/chromium_src/chrome/browser/ui/tabs/split_tab_menu_model.h
@@ -7,12 +7,12 @@
 #define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_TABS_SPLIT_TAB_MENU_MODEL_H_
 
 // Export GetCommandIdXXX() functions from cc to call it in subclass and test.
-#define CloseTabAtIndex(...)                                      \
-  CloseTabAtIndex(__VA_ARGS__);                                   \
-  friend class BraveSplitTabMenuModel;                            \
-  FRIEND_TEST_ALL_PREFIXES(BraveTabContextMenuWithSideBySideTest, \
-                           SplitViewMenuCustomizationTest);       \
-  static CommandId GetCommandIdEnum(int command_id);              \
+#define CloseTabAtIndex(...)                                \
+  CloseTabAtIndex(__VA_ARGS__);                             \
+  friend class BraveSplitTabMenuModel;                      \
+  FRIEND_TEST_ALL_PREFIXES(BraveTabContextMenuContentsTest, \
+                           SplitViewMenuCustomizationTest); \
+  static CommandId GetCommandIdEnum(int command_id);        \
   static int GetCommandIdInt(CommandId command_id)
 
 #define GetReversePositionIcon(...) \

--- a/chromium_src/chrome/browser/ui/tabs/tab_strip_model.cc
+++ b/chromium_src/chrome/browser/ui/tabs/tab_strip_model.cc
@@ -8,3 +8,7 @@
 #define DraggingTabsSession DraggingTabsSessionChromium
 #include <chrome/browser/ui/tabs/tab_strip_model.cc>  // IWYU pragma: export
 #undef DraggingTabsSession
+
+void TabStripModel::CloseSelectedTabsFromBrowserCommands() {
+  NOTREACHED();
+}

--- a/chromium_src/chrome/browser/ui/tabs/tab_strip_model.cc
+++ b/chromium_src/chrome/browser/ui/tabs/tab_strip_model.cc
@@ -9,6 +9,6 @@
 #include <chrome/browser/ui/tabs/tab_strip_model.cc>  // IWYU pragma: export
 #undef DraggingTabsSession
 
-void TabStripModel::CloseSelectedTabsFromBrowserCommands() {
+void TabStripModel::CloseSelectedTabsWithSplitView() {
   NOTREACHED();
 }

--- a/chromium_src/chrome/browser/ui/tabs/tab_strip_model.h
+++ b/chromium_src/chrome/browser/ui/tabs/tab_strip_model.h
@@ -10,6 +10,10 @@
   virtual SelectRelativeTab(__VA_ARGS__); \
   friend class BraveTabStripModel
 
+#define CloseSelectedTabs(...)    \
+  CloseSelectedTabs(__VA_ARGS__); \
+  virtual void CloseSelectedTabsFromBrowserCommands()
+
 #define DraggingTabsSession DraggingTabsSessionChromium
 #define IsReadLaterSupportedForAny virtual IsReadLaterSupportedForAny
 #define UpdateWebContentsStateAt virtual UpdateWebContentsStateAt
@@ -19,6 +23,7 @@
 #undef UpdateWebContentsStateAt
 #undef IsReadLaterSupportedForAny
 #undef DraggingTabsSession
+#undef CloseSelectedTabs
 #undef SelectRelativeTab
 
 #endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_TABS_TAB_STRIP_MODEL_H_

--- a/chromium_src/chrome/browser/ui/tabs/tab_strip_model.h
+++ b/chromium_src/chrome/browser/ui/tabs/tab_strip_model.h
@@ -10,9 +10,11 @@
   virtual SelectRelativeTab(__VA_ARGS__); \
   friend class BraveTabStripModel
 
+// Added another closing selected tabs method to handle close activ tab
+// in split tab. We only want to close active tab from split tab.
 #define CloseSelectedTabs(...)    \
   CloseSelectedTabs(__VA_ARGS__); \
-  virtual void CloseSelectedTabsFromBrowserCommands()
+  virtual void CloseSelectedTabsWithSplitView()
 
 #define DraggingTabsSession DraggingTabsSessionChromium
 #define IsReadLaterSupportedForAny virtual IsReadLaterSupportedForAny

--- a/chromium_src/chrome/browser/ui/views/tabs/browser_tab_strip_controller.h
+++ b/chromium_src/chrome/browser/ui/views/tabs/browser_tab_strip_controller.h
@@ -6,13 +6,12 @@
 #ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_TABS_BROWSER_TAB_STRIP_CONTROLLER_H_
 #define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_TABS_BROWSER_TAB_STRIP_CONTROLLER_H_
 
-#define CloseContextMenuForTesting             \
-  CloseContextMenuForTesting_UnUsed() {}       \
-  friend class BraveBrowserTabStripController; \
-  void CloseContextMenuForTesting
+#define ExecuteCommandForTab(...)            \
+  virtual ExecuteCommandForTab(__VA_ARGS__); \
+  friend class BraveBrowserTabStripController
 
 #include <chrome/browser/ui/views/tabs/browser_tab_strip_controller.h>  // IWYU pragma: export
 
-#undef CloseContextMenuForTesting
+#undef ExecuteCommandForTab
 
 #endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_TABS_BROWSER_TAB_STRIP_CONTROLLER_H_


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/48406

In SideBySide, two tabs in one split tab are in selected state.
As `chrome::CloseTab()` closes selected tabs, both tabs are closed together for tab closing shortcut(ex, `cmd + w`).
We want to close only active tab not both tab. So, closing active tab only if current selected tabs are only two and both
are from same split tab.

Handled tab ctx menu's closed tab in a same way.

TEST=SplitViewCommonBrowserTest.SplitViewCloseTabTest
          BraveTabContextMenuContentsTest.SplitViewMenuCustomizationTest

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
