### PR TITLE
Reenable Split button in toolbar view

### DIFF
--- a/browser/ui/views/toolbar/brave_toolbar_view.cc
+++ b/browser/ui/views/toolbar/brave_toolbar_view.cc
@@ -166,12 +166,6 @@ void BraveToolbarView::Init() {
     return;
   }
 
-  // We don't use chromium's split tabs button in toolbar.
-  if (split_tabs_) {
-    auto split_tabs = container_view->RemoveChildViewT(split_tabs_);
-    split_tabs_ = nullptr;
-  }
-
   Profile* profile = browser()->profile();
 
   // We don't use divider between extensions container and other toolbar

--- a/browser/ui/views/toolbar/brave_toolbar_view.h
+++ b/browser/ui/views/toolbar/brave_toolbar_view.h
@@ -59,7 +59,6 @@ class BraveToolbarView : public ToolbarView,
       const views::ViewHierarchyChangedDetails& details) override;
 
  private:
-  friend class BraveToolbarViewTest;
   FRIEND_TEST_ALL_PREFIXES(BraveToolbarViewTest, ToolbarDividerNotShownTest);
 
   void LoadImages() override;
@@ -76,7 +75,6 @@ class BraveToolbarView : public ToolbarView,
   void UpdateWalletButtonVisibility();
 
   views::View* toolbar_divider_for_testing() { return toolbar_divider_; }
-  views::View* split_tabs_for_testing() const { return split_tabs_; }
 
   raw_ptr<BraveBookmarkButton> bookmark_ = nullptr;
   // Tracks the preference to determine whether bookmark editing is allowed.

--- a/browser/ui/views/toolbar/brave_toolbar_view_browsertest.cc
+++ b/browser/ui/views/toolbar/brave_toolbar_view_browsertest.cc
@@ -36,7 +36,6 @@
 #include "chrome/browser/ui/browser_list_observer.h"
 #include "chrome/browser/ui/browser_window/public/browser_window_features.h"
 #include "chrome/browser/ui/tabs/tab_strip_model.h"
-#include "chrome/browser/ui/ui_features.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
 #include "chrome/browser/ui/views/frame/toolbar_button_provider.h"
 #include "chrome/browser/ui/views/side_panel/side_panel_coordinator.h"
@@ -149,10 +148,6 @@ class BraveToolbarViewTest : public InProcessBrowserTest {
       return false;
     }
     return button->GetVisible();
-  }
-
-  views::View* split_tabs() const {
-    return toolbar_view_->split_tabs_for_testing();
   }
 
   AvatarToolbarButton* GetAvatarToolbarButton(Browser* browser) {
@@ -499,25 +494,4 @@ IN_PROC_BROWSER_TEST_F(BraveToolbarViewTest,
 
   // Normal winwow still has visible button.
   EXPECT_TRUE(is_wallet_button_shown(browser()));
-}
-
-// Check split tabs toolbar button is disabled always.
-class BraveToolbarViewTest_SideBySideEnabled : public BraveToolbarViewTest {
- public:
-  BraveToolbarViewTest_SideBySideEnabled() {
-    scoped_feature_list_.InitWithFeatures({features::kSideBySide}, {});
-  }
-
- protected:
-  base::test::ScopedFeatureList scoped_feature_list_;
-};
-
-IN_PROC_BROWSER_TEST_F(BraveToolbarViewTest_SideBySideEnabled,
-                       SplitTabsToolbarButtonDisabledTest) {
-  EXPECT_FALSE(split_tabs());
-}
-
-IN_PROC_BROWSER_TEST_F(BraveToolbarViewTest,
-                       SplitTabsToolbarButtonDisabledTest) {
-  EXPECT_FALSE(split_tabs());
 }


### PR DESCRIPTION
This reverts commit 476cf2e1e76dd3dfebf45d3ad616a00e3970d157.
- "Hide split tabs toolbar button (#29305)"

As we've defaulted "SideBySide" of upstream, reenabling it makes sense.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/47390

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
