### PR TITLE
Fix "Relaunch to update" button on macOS when Omaha 4 is active

### DIFF
--- a/browser/ui/views/update_recommended_message_box_mac.mm
+++ b/browser/ui/views/update_recommended_message_box_mac.mm
@@ -16,8 +16,6 @@ void UpdateRecommendedMessageBoxMac::Show(gfx::NativeWindow parent_window) {
 }
 
 bool UpdateRecommendedMessageBoxMac::Accept() {
-  if (brave_relaunch_handler::RelaunchOnMac()) {
-    return true;
-  }
-  return UpdateRecommendedMessageBox::Accept();
+  return brave_relaunch_handler::RelaunchOnMac() ||
+         UpdateRecommendedMessageBox::Accept();
 }


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/48890.

# Test plan

1. Follow the "steps to reproduce" from the [issue description](https://github.com/brave/brave-browser/issues/48890) and check that you get the expected result.
2. Repeat the steps with just `--simulate-upgrade` (so, without `--enable-features=...`). Check that you also get the expected result of the browser relaunching.