### PR TITLE
Disable OfferPinToTaskbarInFirstRunExperience (uplift to 1.83.x)

### DIFF
--- a/patches/chrome-browser-ui-ui_features.cc.patch
+++ b/patches/chrome-browser-ui-ui_features.cc.patch
@@ -1,0 +1,13 @@
+diff --git a/chrome/browser/ui/ui_features.cc b/chrome/browser/ui/ui_features.cc
+index 647b359c32d14ce04d2d8a206d567b8cca9c5fb8..45e5b72a1d601588cbc916177eeea706b06f8862 100644
+--- a/chrome/browser/ui/ui_features.cc
++++ b/chrome/browser/ui/ui_features.cc
+@@ -60,7 +60,7 @@ BASE_FEATURE(kOfferPinToTaskbarWhenSettingToDefault,
+              base::FEATURE_ENABLED_BY_DEFAULT);
+ BASE_FEATURE(kOfferPinToTaskbarInFirstRunExperience,
+              "OfferPinToTaskbarInFirstRunExperience",
+-             base::FEATURE_ENABLED_BY_DEFAULT);
++             base::FEATURE_DISABLED_BY_DEFAULT);
+ BASE_FEATURE(kOfferPinToTaskbarInfoBar,
+              "OfferPinToTaskbarInfoBar",
+              base::FEATURE_DISABLED_BY_DEFAULT);


### PR DESCRIPTION
Uplift of #30953
Resolves https://github.com/brave/brave-browser/issues/48866

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.