### PR TITLE
fix(wallet): Wrap Domain Text in Connect With Site Panel

### DIFF
--- a/components/brave_wallet_ui/components/extension/connect-with-site-panel/connect-with-site-header/connect-with-site-header.style.ts
+++ b/components/brave_wallet_ui/components/extension/connect-with-site-panel/connect-with-site-header/connect-with-site-header.style.ts
@@ -6,7 +6,7 @@
 import * as leo from '@brave/leo/tokens/css/variables'
 import Icon from '@brave/leo/react/icon'
 import styled from 'styled-components'
-import { Row, WalletButton } from '../../../shared/style'
+import { Column, Row, WalletButton } from '../../../shared/style'
 
 export const StyledWrapper = styled.div<{ isScrolled: boolean }>`
   display: flex;
@@ -55,14 +55,20 @@ export const Title = styled.span`
   color: ${leo.color.text.primary};
 `
 
+export const DomainTextContainer = styled(Column)`
+  overflow: hidden;
+  box-sizing: border-box;
+`
+
 export const SiteName = styled.span`
   font-family: Poppins;
   font-style: normal;
   font-weight: 600;
   font-size: 16px;
-  line-height: 28px;
+  line-height: 18px;
   text-align: left;
   color: ${leo.color.text.primary};
+  word-break: break-all;
 `
 
 export const SiteURL = styled.span`
@@ -70,10 +76,10 @@ export const SiteURL = styled.span`
   font-style: normal;
   font-weight: 400;
   font-size: 12px;
-  line-height: 18px;
+  line-height: 14px;
   text-align: left;
   color: ${leo.color.text.secondary};
-  word-break: break-word;
+  word-break: break-all;
   margin-bottom: 6px;
 `
 

--- a/components/brave_wallet_ui/components/extension/connect-with-site-panel/connect-with-site-header/connect-with-site-header.tsx
+++ b/components/brave_wallet_ui/components/extension/connect-with-site-panel/connect-with-site-header/connect-with-site-header.tsx
@@ -34,6 +34,7 @@ import {
   LinkIconCircle,
   LinkIcon,
   VerifiedIcon,
+  DomainTextContainer,
 } from './connect-with-site-header.style'
 import { AccountCircle } from '../select-account-item/select-account-item.style'
 import { HorizontalSpace, Column, Row } from '../../../shared/style'
@@ -127,7 +128,10 @@ export const ConnectWithSiteHeader = (props: Props) => {
                 )}`}
                 isReadyToConnect={isReadyToConnect}
               />
-              <Column alignItems='flex-start'>
+              <DomainTextContainer
+                alignItems='flex-start'
+                gap='4px'
+              >
                 <SiteName>{originInfo.eTldPlusOne}</SiteName>
                 <SiteURL>
                   <CreateSiteOrigin
@@ -136,7 +140,7 @@ export const ConnectWithSiteHeader = (props: Props) => {
                   />
                 </SiteURL>
                 {isDAppVerified && <VerifiedLabel />}
-              </Column>
+              </DomainTextContainer>
             </Row>
           )}
 

--- a/components/brave_wallet_ui/components/extension/connect-with-site-panel/connect-with-site-header/connect_with_site_header.test.tsx
+++ b/components/brave_wallet_ui/components/extension/connect-with-site-panel/connect-with-site-header/connect_with_site_header.test.tsx
@@ -1,0 +1,94 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import * as React from 'react'
+import { render } from '@testing-library/react'
+
+import {
+  // eslint-disable-next-line import/no-named-default
+  default as BraveCoreThemeProvider,
+} from '../../../../../common/BraveCoreThemeProvider'
+
+// Components
+import {
+  DomainTextContainer,
+  SiteName,
+  SiteURL,
+} from './connect-with-site-header.style'
+import { CreateSiteOrigin } from '../../../shared/create-site-origin'
+
+const activeOrigin = {
+  originSpec:
+    'http://theofficialabsolutelongestdomainnameregisteredontheworldwideweb.'
+    + 'international/',
+  eTldPlusOne:
+    'theofficialabsolutelongestdomainnameregisteredontheworldwideweb.'
+    + 'international',
+}
+
+describe('Connect with site header', () => {
+  const renderComponent = () => {
+    const { container } = render(
+      <BraveCoreThemeProvider>
+        <DomainTextContainer
+          data-key='domain-text-container'
+          width='100px'
+          padding='0px 24px'
+        >
+          <SiteName data-key='domain-text-etldplusone'>
+            {activeOrigin.eTldPlusOne}
+          </SiteName>
+          <SiteURL data-key='domain-text-origin'>
+            <CreateSiteOrigin
+              originSpec={activeOrigin.originSpec}
+              eTldPlusOne={activeOrigin.eTldPlusOne}
+            />
+          </SiteURL>
+        </DomainTextContainer>
+      </BraveCoreThemeProvider>,
+    )
+    return { container }
+  }
+  it('should render and wrap text', async () => {
+    const { container } = renderComponent()
+
+    // Test domain text container styles
+    const domainContainer = container.querySelector(
+      '[data-key="domain-text-container"]',
+    )
+    expect(domainContainer).toBeInTheDocument()
+    expect(domainContainer).toBeVisible()
+    expect(domainContainer).toHaveStyle({
+      overflow: 'hidden',
+      boxSizing: 'border-box',
+    })
+
+    // Test domain text etldplusone and styles
+    const domainTextetldPlusOne = container.querySelector(
+      '[data-key="domain-text-etldplusone"]',
+    )
+    expect(domainTextetldPlusOne).toBeInTheDocument()
+    expect(domainTextetldPlusOne).toBeVisible()
+    expect(domainTextetldPlusOne).toHaveStyle({
+      wordBreak: 'break-all',
+    })
+
+    // Test etldplusone text
+    expect(domainTextetldPlusOne).toHaveTextContent(activeOrigin.eTldPlusOne)
+
+    // Test domain text origin and styles
+    const domainTextOrigin = container.querySelector(
+      '[data-key="domain-text-origin"]',
+    )
+    expect(domainTextOrigin).toBeInTheDocument()
+    expect(domainTextOrigin).toBeVisible()
+    expect(domainTextOrigin).toHaveStyle({
+      wordBreak: 'break-all',
+    })
+
+    // Test origin text
+    expect(domainTextOrigin).toHaveTextContent(activeOrigin.originSpec)
+  })
+})

--- a/components/brave_wallet_ui/components/extension/connect-with-site-panel/connect-with-site-panel.style.ts
+++ b/components/brave_wallet_ui/components/extension/connect-with-site-panel/connect-with-site-panel.style.ts
@@ -70,7 +70,7 @@ export const SelectAddressContainer = styled.div`
   justify-content: flex-start;
   width: 100%;
   padding: 0px 16px;
-  top: 164px;
+  top: 200px;
   position: relative;
   z-index: 9;
   box-sizing: border-box;


### PR DESCRIPTION
## Description 

Fixes a bug where the `Domain` text did not wrap on the `Connect with Site` panel

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/48892>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

## Test Plan:
1. Visit a website with a really long domain name
2. Open the `Wallet` panel and navigate to the `Connections` tab
3. Click `Connect` for one of the `CoinTypes`
4. The `Domain` text should wrap and should not expand off the screen

Before:

<img width="587" height="901" alt="Image" src="https://github.com/user-attachments/assets/d4681481-dba4-49a5-8bef-746dd6eab321" />

After:

<img width="402" height="611" alt="Screenshot 72" src="https://github.com/user-attachments/assets/67aa631a-7048-4597-a3ca-6a4cccc19e80" />
