### PR TITLE
[Leo] [BYOM] Add support of title generation

### DIFF
--- a/components/ai_chat/core/browser/constants.h
+++ b/components/ai_chat/core/browser/constants.h
@@ -49,6 +49,10 @@ inline constexpr float kMaxContentLengthThreshold = 0.6f;
 inline constexpr size_t kReservedTokensForPrompt = 300;
 inline constexpr size_t kReservedTokensForMaxNewTokens = 400;
 
+// Maximum characters per content for title generation to avoid overly long
+// context.
+inline constexpr uint32_t kMaxContextCharsForTitleGeneration = 1200u;
+
 // Model name to send to the server for Claude Haiku model.
 inline constexpr char kClaudeHaikuModelName[] = "claude-3-haiku";
 // Model name to send to the server for Claude Sonnet model.

--- a/components/ai_chat/core/browser/conversation_handler.h
+++ b/components/ai_chat/core/browser/conversation_handler.h
@@ -352,6 +352,8 @@ class ConversationHandler : public mojom::ConversationHandler,
   void OnEngineCompletionDataReceived(
       EngineConsumer::GenerationResultData result);
   void OnEngineCompletionComplete(EngineConsumer::GenerationResult result);
+  void OnTitleGenerated(EngineConsumer::GenerationResult result);
+  void CompleteGeneration(bool success);
   void OnSuggestedQuestionsResponse(
       EngineConsumer::SuggestedQuestionResult result);
 

--- a/components/ai_chat/core/browser/engine/engine_consumer.cc
+++ b/components/ai_chat/core/browser/engine/engine_consumer.cc
@@ -43,6 +43,10 @@ bool EngineConsumer::SupportsDeltaTextResponses() const {
   return false;
 }
 
+bool EngineConsumer::RequiresClientSideTitleGeneration() const {
+  return false;  // Default: server handles titles (e.g., conversation API)
+}
+
 std::string EngineConsumer::GetImageDataURL(base::span<uint8_t> image_data) {
   constexpr char kDataUrlPrefix[] = "data:image/png;base64,";
   return base::StrCat({kDataUrlPrefix, base::Base64Encode(image_data)});

--- a/components/ai_chat/core/browser/engine/engine_consumer.h
+++ b/components/ai_chat/core/browser/engine/engine_consumer.h
@@ -101,6 +101,15 @@ class EngineConsumer {
       GenerationDataCallback received_callback,
       GenerationCompletedCallback completed_callback) {}
 
+  // Generate a conversation title based on the conversation history.
+  // Only called for engines that return true for
+  // RequiresClientSideTitleGeneration(). Conversation history should ONLY
+  // contain the first turn and completed assistant response.
+  virtual void GenerateConversationTitle(
+      const PageContentsMap& page_contents,
+      const ConversationHistory& conversation_history,
+      GenerationCompletedCallback completed_callback) {}
+
   // Prevent indirect prompt injections being sent to the AI model.
   // Include break-out strings contained in prompts, as well as the base
   // model command separators.
@@ -113,6 +122,10 @@ class EngineConsumer {
   // each time the callback is run (use |false|) or whether it provides a delta
   // from the previous run (use |true|).
   virtual bool SupportsDeltaTextResponses() const;
+
+  // Whether this engine requires client-side conversation title generation.
+  // Returns true for OAI engines, false for conversation API (server-side).
+  virtual bool RequiresClientSideTitleGeneration() const;
 
   virtual void UpdateModelOptions(const mojom::ModelOptions& options) = 0;
 

--- a/components/ai_chat/core/browser/engine/mock_engine_consumer.h
+++ b/components/ai_chat/core/browser/engine/mock_engine_consumer.h
@@ -49,6 +49,13 @@ class MockEngineConsumer : public EngineConsumer {
                GenerationCompletedCallback completed_callback),
               (override));
 
+  MOCK_METHOD(void,
+              GenerateConversationTitle,
+              (const PageContentsMap& page_contents,
+               const ConversationHistory& conversation_history,
+               GenerationCompletedCallback completed_callback),
+              (override));
+
   MOCK_METHOD(void, SanitizeInput, (std::string & input), (override));
 
   MOCK_METHOD(void, ClearAllQueries, (), (override));
@@ -64,6 +71,8 @@ class MockEngineConsumer : public EngineConsumer {
                GetFocusTabsCallback),
               (override));
   MOCK_METHOD(const std::string&, GetModelName, (), (const, override));
+
+  MOCK_METHOD(bool, RequiresClientSideTitleGeneration, (), (const, override));
 
   bool SupportsDeltaTextResponses() const override {
     return supports_delta_text_responses_;

--- a/components/ai_chat/core/browser/engine/oai_api_client.cc
+++ b/components/ai_chat/core/browser/engine/oai_api_client.cc
@@ -59,13 +59,22 @@ net::NetworkTrafficAnnotationTag GetNetworkTrafficAnnotationTag() {
 std::string CreateJSONRequestBody(
     base::Value::List messages,
     const bool is_sse_enabled,
-    const mojom::CustomModelOptions& model_options) {
+    const mojom::CustomModelOptions& model_options,
+    const std::optional<std::vector<std::string>>& stop_sequences) {
   base::Value::Dict dict;
 
   dict.Set("messages", std::move(messages));
   dict.Set("stream", is_sse_enabled);
   dict.Set("temperature", 0.7);
   dict.Set("model", model_options.model_request_name);
+
+  if (stop_sequences && !stop_sequences->empty()) {
+    base::Value::List stop_list;
+    for (const auto& sequence : *stop_sequences) {
+      stop_list.Append(sequence);
+    }
+    dict.Set("stop", std::move(stop_list));
+  }
 
   std::string json;
   base::JSONWriter::Write(dict, &json);
@@ -90,7 +99,8 @@ void OAIAPIClient::PerformRequest(
     const mojom::CustomModelOptions& model_options,
     base::Value::List messages,
     GenerationDataCallback data_received_callback,
-    GenerationCompletedCallback completed_callback) {
+    GenerationCompletedCallback completed_callback,
+    const std::optional<std::vector<std::string>>& stop_sequences) {
   if (!model_options.endpoint.is_valid()) {
     std::move(completed_callback).Run(base::unexpected(mojom::APIError::None));
     return;
@@ -98,8 +108,8 @@ void OAIAPIClient::PerformRequest(
 
   const bool is_sse_enabled =
       ai_chat::features::kAIChatSSE.Get() && !data_received_callback.is_null();
-  const std::string request_body =
-      CreateJSONRequestBody(std::move(messages), is_sse_enabled, model_options);
+  const std::string request_body = CreateJSONRequestBody(
+      std::move(messages), is_sse_enabled, model_options, stop_sequences);
   base::flat_map<std::string, std::string> headers;
   if (!model_options.api_key.empty()) {
     headers.emplace("Authorization",

--- a/components/ai_chat/core/browser/engine/oai_api_client.h
+++ b/components/ai_chat/core/browser/engine/oai_api_client.h
@@ -7,8 +7,10 @@
 #define BRAVE_COMPONENTS_AI_CHAT_CORE_BROWSER_ENGINE_OAI_API_CLIENT_H_
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "base/functional/callback.h"
 #include "base/memory/scoped_refptr.h"
@@ -50,7 +52,9 @@ class OAIAPIClient {
   virtual void PerformRequest(const mojom::CustomModelOptions& model_options,
                               base::Value::List messages,
                               GenerationDataCallback data_received_callback,
-                              GenerationCompletedCallback completed_callback);
+                              GenerationCompletedCallback completed_callback,
+                              const std::optional<std::vector<std::string>>&
+                                  stop_sequences = std::nullopt);
 
   void ClearAllQueries();
 


### PR DESCRIPTION
This PR changes ConversationHandler::OnEngineCompletionComplete which is called when an assistance response generation is completed. When we received the completion of the first assistant response in the conversation, for engines which require a client side title generation (all custom models), after reporting the conversation history updates from the agent response to UI, we keep request_in_progress_ to be true and send a separate title generation request. Previous actions which happen in the end of assistance completion will be performed after title generation is done regardless of whether the title generation is successful or not.

This PR also implements GenerateConversationTitle in OAI engine, which mimics what we do on the server side for conversation API engines. We first create messages with attach associated content up to 1200 chars. Then append a message for requesting title using the same title prompt we have on server side, which would include first user turn's text or the first assistant response's text (if there are uploaded files) in the content. Lastly, append a message for seeding the response and use </title> as the stop sequence. A successful title response with title less than 100 chars will be used to update the conversation title, otherwise it would just be dropped or failed silently.

Referenced server side implementation: https://github.com/brave/aichat/blob/5bbddbe406cef5a671c8567ff293485900e9e840/aichat/serve/conversation_api.py#L80
https://github.com/brave/aichat/blob/5bbddbe406cef5a671c8567ff293485900e9e840/aichat/serve/utils.py#L400
Uploaded files are not included in the title generation request in this PR though, just the server response in this case.
We should be updating the server side to exclude them too as we already put the server response in the title request, and the truncate we currently do for these events also could make the data became garbage too.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/46689

<img width="1491" height="1060" alt="Screenshot 2025-09-02 at 1 03 46 PM" src="https://github.com/user-attachments/assets/af88bd97-7001-460c-a67c-a2a4bb102544" />
<img width="1513" height="957" alt="Screenshot 2025-09-02 at 1 03 53 PM" src="https://github.com/user-attachments/assets/9070d3d8-7ecb-4919-94fd-dae7bf978d04" />
<img width="1530" height="557" alt="Screenshot 2025-09-04 at 2 23 53 PM" src="https://github.com/user-attachments/assets/15d535c5-1766-4641-a750-f00189749bba" />


Test plan:
1. Add a local/custom model with vision support, make sure to click on vision support when you add the model, I used https://ollama.com/library/gemma3:4b for my testing.
2. Start a normal conversation with the model, it should be able to generate a title.
3. Start another conversation with the model by attach an image and ask what it is, it should be using the response to generate the title (you can tell by seeing the title is related to it's first response).
