### PR TITLE
Remove unnecessary width declaration on privacy agreement dialog (uplift to 1.82.x)

### DIFF
--- a/components/ai_chat/resources/page/components/privacy_message/style.module.scss
+++ b/components/ai_chat/resources/page/components/privacy_message/style.module.scss
@@ -3,10 +3,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // you can obtain one at https://mozilla.org/MPL/2.0/.
 
-.dialog {
-  --leo-dialog-width: 80vw;
-}
-
 .content {
   p {
     margin-top: 0;


### PR DESCRIPTION
Uplift of #30649
Resolves https://github.com/brave/brave-browser/issues/46618

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.