### PR TITLE
[iOS] Track the last default browser check date when rate limited

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/ClientPreferences.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/ClientPreferences.swift
@@ -143,6 +143,10 @@ extension Preferences {
       key: "general.isdefault-api-last-check-date",
       default: nil
     )
+    static let isDefaultAPILastResultDate = Option<Date?>(
+      key: "general.isdefault-api-last-result-date",
+      default: nil
+    )
   }
 
   final public class Search {

--- a/ios/brave-ios/Sources/Brave/Helpers/DefaultBrowserHelper.swift
+++ b/ios/brave-ios/Sources/Brave/Helpers/DefaultBrowserHelper.swift
@@ -67,10 +67,11 @@ class DefaultBrowserHelper {
       return
     }
     do {
+      Preferences.General.isDefaultAPILastCheckDate.value = now()
       let isDefault = try isDefaultAppChecker.isDefaultWebBrowser()
       // Cache the result and current date
       Preferences.General.isDefaultAPILastResult.value = isDefault
-      Preferences.General.isDefaultAPILastCheckDate.value = now()
+      Preferences.General.isDefaultAPILastResultDate.value = now()
     } catch {
       // Handle rate limiting or other errors - keep existing cached values
     }
@@ -94,7 +95,7 @@ class DefaultBrowserHelper {
     // Check for cached API result within 14-day validity window
     let fourteenDaysAgo = now().addingTimeInterval(-14.days)
     if let cachedResult = Preferences.General.isDefaultAPILastResult.value,
-      let cachedDate = Preferences.General.isDefaultAPILastCheckDate.value,
+      let cachedDate = Preferences.General.isDefaultAPILastResultDate.value,
       cachedDate >= fourteenDaysAgo
     {
       // HTTP url opened logic: if user opened a link more recently than the cached check,


### PR DESCRIPTION
This ensures that the preference that tracks the last time we call the `isDefault` API is updated before the call so that even if the call fails we do not show the default browser prompt again and adds a new pref that tracks the last time we got a result successfully from the API and use that for cache invalidation

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/48912

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
