### PR TITLE
[Leo] Add "Manage memories" into the main 3 dot menu

### DIFF
--- a/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
+++ b/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
@@ -15,6 +15,7 @@
 #include "base/check.h"
 #include "base/functional/bind.h"
 #include "base/functional/callback_forward.h"
+#include "base/notimplemented.h"
 #include "brave/browser/ai_chat/ai_chat_service_factory.h"
 #include "brave/browser/ai_chat/ai_chat_urls.h"
 #include "brave/browser/misc_metrics/profile_misc_metrics_service.h"
@@ -49,6 +50,8 @@
 #include "chrome/browser/android/tab_android.h"
 #include "chrome/browser/ui/android/tab_model/tab_model.h"
 #include "chrome/browser/ui/android/tab_model/tab_model_list.h"
+#else
+#include "chrome/browser/ui/chrome_pages.h"
 #endif
 
 #if BUILDFLAG(ENABLE_BRAVE_AI_CHAT_AGENT_PROFILE)
@@ -243,6 +246,15 @@ void AIChatUIPageHandler::OpenAIChatSettings() {
   }
 #else
   ai_chat::ShowBraveLeoSettings(contents_to_navigate);
+#endif
+}
+
+void AIChatUIPageHandler::OpenMemorySettings() {
+#if !BUILDFLAG(IS_ANDROID)
+  chrome::ShowSettingsSubPageForProfile(
+      profile_, ai_chat::kBraveAIChatCustomizationSubPage);
+#else
+  NOTIMPLEMENTED();
 #endif
 }
 

--- a/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.h
+++ b/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.h
@@ -49,6 +49,7 @@ class AIChatUIPageHandler : public mojom::AIChatUIHandler,
 
   // mojom::AIChatUIHandler
   void OpenAIChatSettings() override;
+  void OpenMemorySettings() override;
   void OpenConversationFullPage(const std::string& conversation_uuid) override;
   void OpenAIChatAgentProfile() override;
   void OpenURL(const GURL& url) override;

--- a/browser/ui/webui/ai_chat/ai_chat_untrusted_conversation_ui.cc
+++ b/browser/ui/webui/ai_chat/ai_chat_untrusted_conversation_ui.cc
@@ -28,7 +28,6 @@
 #include "brave/components/ai_chat/resources/grit/ai_chat_ui_generated_map.h"
 #include "brave/components/constants/webui_url_constants.h"
 #include "chrome/browser/profiles/profile.h"
-#include "chrome/browser/ui/chrome_pages.h"
 #include "chrome/browser/ui/webui/favicon_source.h"
 #include "components/favicon_base/favicon_url_parser.h"
 #include "components/grit/brave_components_resources.h"
@@ -52,6 +51,7 @@
 #include "brave/browser/ui/android/ai_chat/brave_leo_settings_launcher_helper.h"
 #else
 #include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/chrome_pages.h"
 #include "chrome/browser/ui/webui/theme_source.h"
 #endif
 

--- a/components/ai_chat/core/common/mojom/ai_chat.mojom
+++ b/components/ai_chat/core/common/mojom/ai_chat.mojom
@@ -465,6 +465,9 @@ interface AIChatUIHandler {
   // Open various external links or dialogs depending on the platform
   OpenAIChatSettings();
 
+  // Open AI Chat memory management settings
+  OpenMemorySettings();
+
   // From a sidebar or popup conversation, open the conversation in the
   // full-page UI.
   // TODO(petemill): WebUI Compile-timesupport for build flags

--- a/components/ai_chat/resources/page/components/feature_button_menu/index.tsx
+++ b/components/ai_chat/resources/page/components/feature_button_menu/index.tsx
@@ -144,6 +144,22 @@ export default function FeatureMenu(props: Props) {
           </leo-menu-item>
         </>
       )}
+      {!aiChatContext.isMobile && (
+        <leo-menu-item
+          onClick={() => aiChatContext.uiHandler?.openMemorySettings()}>
+          <div
+            className={classnames(
+              styles.menuItemWithIcon,
+              styles.menuItemMainItem
+            )}
+          >
+            <Icon name='database' />
+            <span className={styles.menuText}>
+              {getLocale(S.CHAT_UI_MENU_MANAGE_MEMORIES)}
+            </span>
+          </div>
+        </leo-menu-item>
+      )}
       <leo-menu-item onClick={handleSettingsClick}>
         <div
           className={classnames(

--- a/components/resources/ai_chat_ui_strings.grdp
+++ b/components/resources/ai_chat_ui_strings.grdp
@@ -147,6 +147,9 @@
   <message name="IDS_CHAT_UI_MENU_CONVERSATION_HISTORY" desc="Menu item for opening the list of conversations" formatter_data="webui=AiChat">
     Conversation history
   </message>
+  <message name="IDS_CHAT_UI_MENU_MANAGE_MEMORIES" desc="Menu item for managing AI Chat memories" formatter_data="webui=AiChat">
+    Manage memories
+  </message>
   <message name="IDS_CHAT_UI_MENU_SETTINGS" desc="Menu item for Settings" formatter_data="webui=AiChat">
     Advanced Settings
   </message>


### PR DESCRIPTION
Adding "Manage memories" as a main menu item which takes user to the customization and memory settings subpage.

<img width="505" height="364" alt="Screenshot 2025-09-02 at 4 10 20 PM" src="https://github.com/user-attachments/assets/3b8ea082-c11c-4814-81e6-3df089fe9231" />
<img width="398" height="369" alt="Screenshot 2025-09-02 at 4 10 11 PM" src="https://github.com/user-attachments/assets/b389ce0c-49be-4f2d-93bc-63a58af865ff" />

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/48898

Test plan:
Open 3 dot menu in Leo UI and click on `Manage memories` should take you to brave://settings/leo-ai/customization.