### PR TITLE
[iOS] Fix multiple calls to handlers when fetching last used VPN region (uplift to 1.82.x)

### DIFF
--- a/ios/brave-ios/Sources/BraveVPN/Components/Region/BraveVPN+Region.swift
+++ b/ios/brave-ios/Sources/BraveVPN/Components/Region/BraveVPN+Region.swift
@@ -130,6 +130,7 @@ extension BraveVPN {
             printToConsole: true
           )
           completion?(nil, false)
+          return
         }
 
         guard let timeZones = timeZones else {


### PR DESCRIPTION
Uplift of #30982
Resolves https://github.com/brave/brave-browser/issues/48844

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.