### PR TITLE
[Leo] Add memory search box in memory UI

### DIFF
--- a/app/brave_settings_strings.grdp
+++ b/app/brave_settings_strings.grdp
@@ -1757,6 +1757,15 @@
   <message name="IDS_SETTINGS_LEO_ASSISTANT_DELETE_ALL_MEMORIES_CONFIRMATION" desc="The confirmation message for deleting all memories">
     Are you sure you want to delete all memories? This action cannot be undone.
   </message>
+  <message name="IDS_SETTINGS_LEO_ASSISTANT_NO_SEARCH_RESULTS_FOUND" desc="The message shown when no search results are found in memory search">
+    No results found
+  </message>
+  <message name="IDS_SETTINGS_LEO_ASSISTANT_CLEAR_SEARCH" desc="The label for the link to clear search in memory search">
+    Clear search
+  </message>
+  <message name="IDS_SETTINGS_LEO_ASSISTANT_SEARCH_MEMORIES_PLACEHOLDER" desc="The placeholder text for the memory search input field">
+    Search for a memory
+  </message>
 
   <!-- Settings / Survey Panelist -->
   <message name="IDS_SETTINGS_SURVEY_PANELIST" desc="Title for an item in the 'Survey Panelist' section of Brave Settings">

--- a/browser/resources/settings/brave_leo_assistant_page/memory_section.html
+++ b/browser/resources/settings/brave_leo_assistant_page/memory_section.html
@@ -136,6 +136,21 @@ You can obtain one at https://mozilla.org/MPL/2.0/. -->
   .memory-input {
     width: 100%;
   }
+
+  .search-container {
+    margin-bottom: var(--leo-spacing-l);
+  }
+
+  .no-results-title {
+    color: var(--leo-color-text-primary);
+    font-weight: 600;
+  }
+
+  .clear-search-link {
+    color: var(--leo-color-text-primary);
+    text-decoration: underline;
+    font-weight: 400;
+  }
 </style>
 
 <div class="settings-box header">
@@ -155,6 +170,26 @@ You can obtain one at https://mozilla.org/MPL/2.0/. -->
 
 <template is="dom-if" if="[[prefs.brave.ai_chat.user_memory_enabled.value]]" restamp>
   <div class="list-container">
+    <div class="search-container">
+      <leo-input
+        type="text"
+        placeholder="$i18n{braveLeoAssistantSearchMemoriesPlaceholder}"
+        value="[[searchQuery_]]"
+        disabled$="[[!hasMemories_(memoriesList_)]]"
+        on-input="onSearchInput_">
+        <leo-icon name="search" slot="left-icon"></leo-icon>
+        <template is="dom-if" if="[[searchQuery_]]">
+          <leo-button
+            kind="plain-faint"
+            fab
+            size="small"
+            slot="right-icon"
+            on-click="clearSearch_">
+            <leo-icon name="close"></leo-icon>
+          </leo-button>
+        </template>
+      </leo-input>
+    </div>
     <template
       is="dom-if"
       if="[[!hasMemories_(memoriesList_)]]"
@@ -169,12 +204,22 @@ You can obtain one at https://mozilla.org/MPL/2.0/. -->
 
     <template
       is="dom-if"
-      if="[[hasMemories_(memoriesList_)]]"
+      if="[[hasNoSearchResults_(memoriesList_, searchQuery_)]]"
+    >
+      <div class="empty-memories-table">
+        <div class="no-results-title">$i18n{braveLeoAssistantNoSearchResultsFound}</div>
+        <div class="clear-search-link" on-click="clearSearch_">$i18n{braveLeoAssistantClearSearch}</div>
+      </div>
+    </template>
+
+    <template
+      is="dom-if"
+      if="[[shouldShowMemories_(memoriesList_, searchQuery_)]]"
     >
       <div class="list">
         <template
           is="dom-repeat"
-          items="[[memoriesList_]]"
+          items="[[getFilteredMemories_(memoriesList_, searchQuery_)]]"
         >
           <div class="memory">
             <div class="memory-info">

--- a/browser/resources/settings/brave_leo_assistant_page/memory_section.ts
+++ b/browser/resources/settings/brave_leo_assistant_page/memory_section.ts
@@ -75,6 +75,10 @@ class MemorySection extends MemorySectionBase {
       showDeleteAllDialog_: {
         type: Boolean,
         value: false
+      },
+      searchQuery_: {
+        type: String,
+        value: ''
       }
     }
   }
@@ -89,6 +93,7 @@ class MemorySection extends MemorySectionBase {
   declare showDeleteDialog_: boolean
   declare deleteMemoryItem_: string | null
   declare showDeleteAllDialog_: boolean
+  declare searchQuery_: string
 
   override ready() {
     super.ready()
@@ -230,6 +235,47 @@ class MemorySection extends MemorySectionBase {
     handler.deleteAllMemories()
     this.showDeleteAllDialog_ = false
   }
+
+  onSearchInput_(e: { value: string }) {
+    this.searchQuery_ = e.value
+  }
+
+  clearSearch_() {
+    this.searchQuery_ = ''
+  }
+
+  getFilteredMemories_(memoriesList: string[], searchQuery: string): string[] {
+    if (!searchQuery || !searchQuery.trim()) {
+      return memoriesList
+    }
+
+    const query = searchQuery.trim().toLowerCase()
+    return memoriesList.filter(memory =>
+      memory.toLowerCase().includes(query)
+    )
+  }
+
+  hasNoSearchResults_(memoriesList: string[], searchQuery: string): boolean {
+    if (!searchQuery || !searchQuery.trim()) {
+      return false // No search query means we're not searching
+    }
+
+    // If no memories exist at all, clear search instead of showing "no results"
+    if (memoriesList.length === 0) {
+      this.searchQuery_ = ''
+      return false
+    }
+
+    const filteredResults = this.getFilteredMemories_(memoriesList, searchQuery)
+    return filteredResults.length === 0
+  }
+
+  shouldShowMemories_(memoriesList: string[], searchQuery: string): boolean {
+    // Show memories if we have memories AND we're not in the "no results" state
+    return this.hasMemories_(memoriesList) &&
+           !this.hasNoSearchResults_(memoriesList, searchQuery)
+  }
+
 }
 
 customElements.define(MemorySection.is, MemorySection)

--- a/browser/ui/webui/settings/brave_settings_localized_strings_provider.cc
+++ b/browser/ui/webui/settings/brave_settings_localized_strings_provider.cc
@@ -653,6 +653,11 @@ void BraveAddCommonStrings(content::WebUIDataSource* html_source,
        IDS_SETTINGS_LEO_ASSISTANT_DELETE_ALL_MEMORIES_CONFIRMATION},
       {"braveLeoAssistantDeleteAllMemoriesConfirmationTitle",
        IDS_SETTINGS_LEO_ASSISTANT_DELETE_ALL_MEMORIES_CONFIRMATION_TITLE},
+      {"braveLeoAssistantNoSearchResultsFound",
+       IDS_SETTINGS_LEO_ASSISTANT_NO_SEARCH_RESULTS_FOUND},
+      {"braveLeoAssistantClearSearch", IDS_SETTINGS_LEO_ASSISTANT_CLEAR_SEARCH},
+      {"braveLeoAssistantSearchMemoriesPlaceholder",
+       IDS_SETTINGS_LEO_ASSISTANT_SEARCH_MEMORIES_PLACEHOLDER},
 
       // Survey Panelist Page
       {"surveyPanelist", IDS_SETTINGS_SURVEY_PANELIST},


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/47979

Note: Highlighting the search text in those entries are not implemented by this PR, tracked separately in https://github.com/brave/brave-browser/issues/49007.

Search box with placeholder shown:
<img width="691" height="570" alt="Screenshot 2025-09-04 at 9 19 49 PM" src="https://github.com/user-attachments/assets/9dd5823f-4d00-47c4-97b0-396f85a79c5a" />
Search box when memories are found:
<img width="703" height="449" alt="Screenshot 2025-09-04 at 9 21 38 PM" src="https://github.com/user-attachments/assets/d4526d3d-4453-4d77-9135-ac40a5d61b4e" />
Disabled search box when there are no memories:
<img width="695" height="435" alt="Screenshot 2025-09-04 at 9 21 50 PM" src="https://github.com/user-attachments/assets/de736d92-a23b-4fa6-ba0f-9d73db36efb8" />
Not found UI when search has no result:
<img width="695" height="452" alt="Screenshot 2025-09-04 at 9 22 00 PM" src="https://github.com/user-attachments/assets/8a9ce8e6-1f9d-4b40-aaa2-3ecb68cecd41" />

Test plan:
1. Without any memory added, search box should be disabled
2. Add a few memory and search them through the search box should work
3. Search a non-existent memory should show the not found UI as shown in the screenshot above