### PR TITLE
[AI Chat]: Fix Clear Conversation Button Style

### DIFF
--- a/components/ai_chat/resources/page/components/alerts/alerts.module.scss
+++ b/components/ai_chat/resources/page/components/alerts/alerts.module.scss
@@ -37,11 +37,13 @@
 }
 
 .link {
-  --leo-button-padding: 0;
+  font: var(--leo-font-small-regular);
   text-decoration: underline;
+  color: var(--leo-color-text-tertiary);
+  border: none;
+  background: none;
   cursor: pointer;
-
-  span {
-    font: var(--leo-font-small-regular);
+  &:hover {
+    color: var(--leo-color-text-primary);
   }
 }

--- a/components/ai_chat/resources/page/components/alerts/long_conversation_info.tsx
+++ b/components/ai_chat/resources/page/components/alerts/long_conversation_info.tsx
@@ -5,7 +5,6 @@
 
 import * as React from 'react'
 import Icon from '@brave/leo/react/icon'
-import Button from '@brave/leo/react/button'
 import { getLocale } from '$web-common/locale'
 import { useConversation } from '../../state/conversation_context'
 import styles from './alerts.module.scss'
@@ -27,13 +26,12 @@ export default function LongConversationInfo() {
       </div>
       <div className={styles.infoText}>
         {getLocale(S.CHAT_UI_ERROR_CONTEXT_LIMIT_REACHING)}
-        <Button
-          kind='plain-faint'
+        <button
           className={styles.link}
           onClick={handleClearChat}
         >
           <span>{getLocale(S.CHAT_UI_CLEAR_CHAT_BUTTON_LABEL)}</span>
-        </Button>
+        </button>
       </div>
     </div>
   )


### PR DESCRIPTION
## Description 

Fixes the styling for the `Clear Conversation` button

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/42631>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

## Test Plan:
1. Start a conversation with `Leo AI`
2. Trigger the `Long conversation warning`
3. The `Clear Conversation` button should now look more like a `link`

Before:

<img width="740" height="140" alt="Screenshot 87" src="https://github.com/user-attachments/assets/865f0c7d-74d9-4aeb-baf8-7b042eae6298" />

After:

<img width="758" height="132" alt="Screenshot 88" src="https://github.com/user-attachments/assets/d3528573-4ac6-416a-936e-ce3ca73f6867" />
