### PR TITLE
fix(privacy): Save context after Shields Domain model mutations

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -740,12 +740,6 @@ public class BrowserViewController: UIViewController {
       return
     }
 
-    // TODO: brave/brave-browser/issues/46565
-    // Remove when all direct mutations on CoreData types are replaced
-    DataController.performOnMainContext { context in
-      try? context.save()
-    }
-
     tabManager.saveAllTabs()
 
     // If we are displaying a private tab, hide any elements in the tab that we wouldn't want shown

--- a/ios/brave-ios/Sources/BraveShields/BraveShieldsTabHelper.swift
+++ b/ios/brave-ios/Sources/BraveShields/BraveShieldsTabHelper.swift
@@ -49,6 +49,9 @@ public class BraveShieldsTabHelper {
     // Also assign to Domain until deprecated so reverse migration is required
     let domain = Domain.getOrCreate(forUrl: url, persistent: !isPrivate)
     domain.shield_allOff = NSNumber(booleanLiteral: !isEnabled)
+    DataController.performOnMainContext { context in
+      try? context.save()
+    }
   }
 
   public func shieldLevel(for url: URL?, considerAllShieldsOption: Bool) -> ShieldLevel {
@@ -72,6 +75,9 @@ public class BraveShieldsTabHelper {
     // Also assign to Domain until deprecated so reverse migration is required
     let domain = Domain.getOrCreate(forUrl: url, persistent: !isPrivate)
     domain.domainBlockAdsAndTrackingLevel = shieldLevel
+    DataController.performOnMainContext { context in
+      try? context.save()
+    }
   }
 
   public func setBlockScriptsEnabled(_ isEnabled: Bool, for url: URL?) {
@@ -82,6 +88,9 @@ public class BraveShieldsTabHelper {
     // Also assign to Domain until deprecated so reverse migration is required
     let domain = Domain.getOrCreate(forUrl: url, persistent: !isPrivate)
     domain.shield_noScript = NSNumber(booleanLiteral: isEnabled)
+    DataController.performOnMainContext { context in
+      try? context.save()
+    }
   }
 
   public func setBlockFingerprintingEnabled(_ isEnabled: Bool, for url: URL?) {
@@ -92,6 +101,9 @@ public class BraveShieldsTabHelper {
     // Also assign to Domain until deprecated so reverse migration is required
     let domain = Domain.getOrCreate(forUrl: url, persistent: !isPrivate)
     domain.shield_fpProtection = NSNumber(booleanLiteral: isEnabled)
+    DataController.performOnMainContext { context in
+      try? context.save()
+    }
   }
 
   /// Whether or not a given shield should be enabled based on domain exceptions and the users global preference
@@ -136,5 +148,8 @@ public class BraveShieldsTabHelper {
     // TODO: Support AutoShred via content settings brave-browser#47753
     let domain = Domain.getOrCreate(forUrl: url, persistent: !isPrivate)
     domain.shredLevel = shredLevel
+    DataController.performOnMainContext { context in
+      try? context.save()
+    }
   }
 }


### PR DESCRIPTION
- Previously assignments to shields settings on `Domain` CoreData object were not being saved, so we added a temporary save on app will resign notification. Now that these Shields assignments are all handled in `BraveShieldsTabHelper`, we can save in each `set*` function after mutating the `Domain` object.

Resolves https://github.com/brave/brave-browser/issues/46565

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

### Testplan

1. Ensure `#brave-shields-content-settings` feature flag is disabled.
2. Visit some website and open shields panel
3. Change the Shield level, block scripts, block fingerprinting, and auto shred level to a new value
4. Disable shields for the site
5. Quit the app
6. Relaunch the app
7. Open Shields panel for site previously updated. 
8. Verify Shields is disabled for the site (setting was persisted), then enable it again.
9. Verify Shield level, block scripts, block fingerprinting, and auto shred level updates were persisted
