### PR TITLE
[ads] Brave ads startup delay as a feature param

### DIFF
--- a/browser/brave_ads/services/bat_ads_service_factory_impl.cc
+++ b/browser/brave_ads/services/bat_ads_service_factory_impl.cc
@@ -8,10 +8,13 @@
 #include <memory>
 #include <utility>
 
+#include "base/feature_list.h"
 #include "base/functional/bind.h"
+#include "base/metrics/field_trial_params.h"
 #include "base/task/single_thread_task_runner.h"
 #include "base/task/single_thread_task_runner_thread_mode.h"
 #include "base/task/thread_pool.h"
+#include "base/time/time.h"
 #include "brave/browser/brave_ads/services/service_sandbox_type.h"
 #include "brave/components/services/bat_ads/bat_ads_service_impl.h"
 #include "content/public/browser/browser_thread.h"
@@ -21,6 +24,13 @@
 namespace brave_ads {
 
 namespace {
+
+BASE_FEATURE(kInProcessBraveAdsServiceFeature,
+             "InProcessBraveAdsService",
+             base::FEATURE_ENABLED_BY_DEFAULT);
+
+constexpr base::FeatureParam<base::TimeDelta> kBraveAdsServiceStartupDelay{
+    &kInProcessBraveAdsServiceFeature, "startup_delay", base::Seconds(3)};
 
 // Binds the `receiver` to a new provider on a background task runner.
 void BindInProcessBatAdsService(
@@ -40,7 +50,7 @@ mojo::Remote<bat_ads::mojom::BatAdsService> LaunchInProcessBatAdsService() {
           FROM_HERE,
           base::BindOnce(&BindInProcessBatAdsService,
                          bat_ads_service_remote.BindNewPipeAndPassReceiver()),
-          base::Seconds(3));
+          kBraveAdsServiceStartupDelay.Get());
   return bat_ads_service_remote;
 }
 


### PR DESCRIPTION
The PR converts Brave ads startup delay to a feature param
with delay 3s by default.

### Test plan

* Start the browser with ads logging enabled `--enable-logging=stderr --vmodule="*/brave_ads/*"=6`
* Make sure that `Initializing ads` log appears in 3 seconds after start
* Start the browser with `--enable-features=InProcessBraveAdsService:startup_delay/0 --enable-logging=stderr --vmodule="*/brave_ads/*"=6`
* Make sure that `Initializing ads` log appears in around 0 seconds after start (there can be delays depending on machine)

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/49009

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
