### PR TITLE
[NTP Next] Fix typo in WebUI string registration (uplift to 1.83.x)

### DIFF
--- a/browser/ui/webui/brave_new_tab_page_refresh/new_tab_page_initializer.cc
+++ b/browser/ui/webui/brave_new_tab_page_refresh/new_tab_page_initializer.cc
@@ -210,7 +210,7 @@ void NewTabPageInitializer::AddStrings() {
       {"rewardsOnboardingButtonLabel",
        IDS_NEW_TAB_REWARDS_ONBOARDING_BUTTON_LABEL},
       {"rewardsOnboardingLink", IDS_NEW_TAB_REWARDS_ONBOARDING_LINK},
-      {"rewardsPayoutCompleteText", IDS_REWARDS_PAYMENT_COMPLETED},
+      {"rewardsPayoutCompletedText", IDS_REWARDS_PAYMENT_COMPLETED},
       {"rewardsPayoutDetailsLink", IDS_NEW_TAB_REWARDS_PAYOUT_DETAILS_LINK},
       {"rewardsPayoutProcessingText", IDS_REWARDS_PAYMENT_PROCESSING},
       {"rewardsTosUpdateButtonLabel", IDS_REWARDS_TOS_UPDATE_NTP_BUTTON_LABEL},


### PR DESCRIPTION
Uplift of #31074
Resolves https://github.com/brave/brave-browser/issues/49040

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.