### PR TITLE
[ads] /v1/getstate retry logic

### DIFF
--- a/components/brave_ads/core/internal/common/subdivision/subdivision_unittest.cc
+++ b/components/brave_ads/core/internal/common/subdivision/subdivision_unittest.cc
@@ -149,6 +149,25 @@ TEST_F(BraveAdsSubdivisionTest, OnDidOptOutBraveNews) {
   EXPECT_FALSE(HasPendingTasks());
 }
 
+TEST_F(BraveAdsSubdivisionTest, DoNotRetryAfterForbiddenUrlResponseStatusCode) {
+  // Arrange
+  const test::URLResponseMap url_responses = {
+      {BuildSubdivisionUrlPath(),
+       {{net::HTTP_FORBIDDEN,
+         /*response_body=*/net::GetHttpReasonPhrase(net::HTTP_FORBIDDEN)}}}};
+  test::MockUrlResponses(ads_client_mock_, url_responses);
+
+  EXPECT_CALL(subdivision_observer_mock_, OnDidUpdateSubdivision).Times(0);
+
+  NotifyDidInitializeAds();
+
+  // Act
+  FastForwardClockToNextPendingTask();
+
+  // Assert
+  EXPECT_TRUE(HasPendingTasks());
+}
+
 TEST_F(BraveAdsSubdivisionTest, RetryAfterInvalidUrlResponseStatusCode) {
   // Arrange
   const test::URLResponseMap url_responses = {

--- a/components/brave_ads/core/internal/common/subdivision/url_request/subdivision_url_request.h
+++ b/components/brave_ads/core/internal/common/subdivision/url_request/subdivision_url_request.h
@@ -39,7 +39,7 @@ class SubdivisionUrlRequest final {
   void FetchAfterDelay();
 
   void SuccessfullyFetchedSubdivision(const std::string& subdivision);
-  void FailedToFetchSubdivision();
+  void FailedToFetchSubdivision(bool should_retry);
 
   void Retry();
   void RetryCallback();


### PR DESCRIPTION
Resolved an issue where `/v1/getstate` did not fail fast on HTTP 403 (Forbidden) responses, causing clients to retry excessively and generate unnecessary load, wasted resources, and higher costs.

STR:
- Configure Charles Proxy to return HTTP 403 (HTTP_FORBIDDEN) for https://geo.ads.brave.com/v1/getstate and verify that no retries occur.
- Configure Charles Proxy to return HTTP 404 (HTTP_NOT_FOUND) for https://geo.ads.brave.com/v1/getstate and verify that retries do occur.
- Configure Charles Proxy to return HTTP 200 (HTTP_OK) for https://geo.ads.brave.com/v1/getstate and verify that no retries occur and the request succeeds.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/49055

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
