### PR TITLE
[AI Chat]: Support BR Tags and Bold Headers in Tables

### DIFF
--- a/components/ai_chat/resources/untrusted_conversation_frame/components/markdown_renderer/render_table.test.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/markdown_renderer/render_table.test.tsx
@@ -213,5 +213,70 @@ describe('Table Rendering', () => {
         expect(table.querySelector('tbody')).toBeInTheDocument()
       })
     })
+
+    test('renders table with <br> tags', () => {
+      const markdown = `
+| Name | Description |
+|------|-------------|
+| John | Line 1<br>Line 2 |
+| Jane | Single line |
+      `.trim()
+
+      renderMarkdown(markdown)
+
+      // Check table structure
+      const table = document.querySelector('table')
+      expect(table).toBeInTheDocument()
+
+      // Check that the cell with <br> tag is rendered correctly
+      const cells = document.querySelectorAll('td')
+      expect(cells).toHaveLength(4) // 2 rows × 2 columns
+
+      // Find the cell containing the <br> tag
+      const cellWithBr = Array.from(cells).find((cell) =>
+        cell.innerHTML.includes('<br>'),
+      )
+      expect(cellWithBr).toBeInTheDocument()
+      expect(cellWithBr).toHaveTextContent('Line 1Line 2')
+      expect(cellWithBr!.innerHTML).toContain('<br>')
+
+      // Verify the <br> tag is properly rendered as an HTML element
+      const brElement = cellWithBr!.querySelector('br')
+      expect(brElement).toBeInTheDocument()
+    })
+
+    test('renders table with bold headers', () => {
+      const markdown = `
+| **Name** | **Age** | **Location** |
+|----------|---------|--------------|
+| John     | 25      | NYC          |
+| Jane     | 30      | LA           |
+      `.trim()
+
+      renderMarkdown(markdown)
+
+      // Check table structure
+      const table = document.querySelector('table')
+      expect(table).toBeInTheDocument()
+
+      // Check that bold headers are rendered
+      expect(screen.getByText('Name')).toBeInTheDocument()
+      expect(screen.getByText('Age')).toBeInTheDocument()
+      expect(screen.getByText('Location')).toBeInTheDocument()
+
+      // Check that data-label attributes contain the text content (without **)
+      const cells = document.querySelectorAll('td')
+      expect(cells).toHaveLength(6)
+
+      // First row cells should have data-label from first header
+      expect(cells[0]).toHaveAttribute('data-label', 'Name')
+      expect(cells[1]).toHaveAttribute('data-label', 'Age')
+      expect(cells[2]).toHaveAttribute('data-label', 'Location')
+
+      // Second row cells should have the same data-label attributes
+      expect(cells[3]).toHaveAttribute('data-label', 'Name')
+      expect(cells[4]).toHaveAttribute('data-label', 'Age')
+      expect(cells[5]).toHaveAttribute('data-label', 'Location')
+    })
   })
 })


### PR DESCRIPTION
## Description 

- Fixes a bug where `<br />` tags were not being parsed correctly in `Tables`
- Fixes a bug where `bold` header cells were not being parsed correctly in `Tables`

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/49048>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

## Test Plan for `<br>` tags:
1. Start a conversation with `Leo AI`
2. Prompt a question to render a table that would have `<br>` tags in it
3. The `<br>` tags should not be displayed and should render correctly

### Before and After

<img width="709" height="636" alt="Screenshot 1" src="https://github.com/user-attachments/assets/64a752ef-f278-472f-ad29-8661f1bf5b5f" /> | <img width="705" height="704" alt="Screenshot 2" src="https://github.com/user-attachments/assets/bc3bff38-e4a8-442e-becf-a3906642a5e1" />
--|--

## Test Plan for `Bold` header cells tags:
1. Start a conversation with `Leo AI` using `Lama 3.1` as the model in the side panel
2. Prompt a question to render a table
3. The `Header` cell text should be visible and not cut off before the `:`

### Before and After

<img width="294" height="549" alt="Screenshot 9" src="https://github.com/user-attachments/assets/4b620d06-cc15-4841-8095-7ac7bab93f99" /> | <img width="293" height="574" alt="Screenshot 8" src="https://github.com/user-attachments/assets/bdc7a8de-e6c2-42fe-ae4f-9a59e646568c" />
--|--
