### PR TITLE
[ads] Brave ads startup delay as a feature param (uplift to 1.83.x)

### DIFF
--- a/browser/brave_ads/services/bat_ads_service_factory_impl.cc
+++ b/browser/brave_ads/services/bat_ads_service_factory_impl.cc
@@ -8,10 +8,13 @@
 #include <memory>
 #include <utility>
 
+#include "base/feature_list.h"
 #include "base/functional/bind.h"
+#include "base/metrics/field_trial_params.h"
 #include "base/task/single_thread_task_runner.h"
 #include "base/task/single_thread_task_runner_thread_mode.h"
 #include "base/task/thread_pool.h"
+#include "base/time/time.h"
 #include "brave/browser/brave_ads/services/service_sandbox_type.h"
 #include "brave/components/services/bat_ads/bat_ads_service_impl.h"
 #include "content/public/browser/browser_thread.h"
@@ -21,6 +24,13 @@
 namespace brave_ads {
 
 namespace {
+
+BASE_FEATURE(kInProcessBraveAdsServiceFeature,
+             "InProcessBraveAdsService",
+             base::FEATURE_ENABLED_BY_DEFAULT);
+
+constexpr base::FeatureParam<base::TimeDelta> kBraveAdsServiceStartupDelay{
+    &kInProcessBraveAdsServiceFeature, "startup_delay", base::Seconds(3)};
 
 // Binds the `receiver` to a new provider on a background task runner.
 void BindInProcessBatAdsService(
@@ -40,7 +50,7 @@ mojo::Remote<bat_ads::mojom::BatAdsService> LaunchInProcessBatAdsService() {
           FROM_HERE,
           base::BindOnce(&BindInProcessBatAdsService,
                          bat_ads_service_remote.BindNewPipeAndPassReceiver()),
-          base::Seconds(3));
+          kBraveAdsServiceStartupDelay.Get());
   return bat_ads_service_remote;
 }
 


### PR DESCRIPTION
Uplift of #31064
Resolves https://github.com/brave/brave-browser/issues/49009

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.