### PR TITLE
Let users to display only one tiles row in in quick action search widget

### DIFF
--- a/android/java/org/chromium/chrome/browser/widget/quickactionsearchandbookmark/QuickActionSearchAndBookmarkWidgetProvider.java
+++ b/android/java/org/chromium/chrome/browser/widget/quickactionsearchandbookmark/QuickActionSearchAndBookmarkWidgetProvider.java
@@ -95,8 +95,12 @@ public class QuickActionSearchAndBookmarkWidgetProvider extends AppWidgetProvide
 
     private static final int TOTAL_TILES = 12;
     private static final int TILES_PER_ROW = 4;
-    private static final int MIN_VISIBLE_HEIGHT_ROW_1 = 125;
-    private static final int MIN_VISIBLE_HEIGHT_ROW_2 = 150;
+    // Tiles row is ~72dp + search bar height(48dp)(depends on the text size
+    // settings on the device)
+    private static final int MIN_VISIBLE_HEIGHT_ROW_1 = 110;
+    // Two tiles rows height is ~144dp + search bar height
+    private static final int MIN_VISIBLE_HEIGHT_ROW_2 = 177;
+    // The rest could be visible after that point
     private static final int MIN_VISIBLE_HEIGHT_ROW_3 = 210;
     private static final int DESIRED_ICON_SIZE = 44;
     private static final int DESIRED_ICON_RADIUS = 16;

--- a/android/java/res/xml/quick_action_search_and_bookmark_widget_info.xml
+++ b/android/java/res/xml/quick_action_search_and_bookmark_widget_info.xml
@@ -8,7 +8,6 @@
     android:initialLayout="@layout/quick_action_search_and_bookmark_widget_layout"
     android:minWidth="304dp"
     android:minHeight="44dp"
-    android:maxResizeHeight="270dp"
     android:description="@string/brave_quick_action_search"
     android:previewImage="@drawable/ic_quick_action_search_and_bookmark_widget_preview"
     android:resizeMode="horizontal|vertical"


### PR DESCRIPTION
There are cases on some devices where it is impossible to display only one tiles row, it displays two right away.
Resolves: https://github.com/brave/brave-browser/issues/49110

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

Test plan:
1. Create Brave quick action search widget
2. Make sure you have at least 5 fav tiles in Brave(open diff websites)
3. Expand the widget to have only first row with 4 tiles visible.