### PR TITLE
chore(wallet): Move ERC20 Approve out of Confirm Transaction Component

### DIFF
--- a/components/brave_wallet_ui/components/extension/allow_spend_panel/allow_spend_panel.stories.tsx
+++ b/components/brave_wallet_ui/components/extension/allow_spend_panel/allow_spend_panel.stories.tsx
@@ -7,17 +7,8 @@ import * as React from 'react'
 
 // Mocks
 import {
-  mockUniswapOriginInfo, //
-} from '../../../stories/mock-data/mock-origin-info'
-import {
-  mockParsedERC20ApprovalTransaction, //
+  mockedErc20ApprovalTransaction, //
 } from '../../../stories/mock-data/mock-transaction-info'
-import {
-  mockEthMainnet, //
-} from '../../../stories/mock-data/mock-networks'
-import {
-  mockBasicAttentionToken, //
-} from '../../../stories/mock-data/mock-asset-options'
 
 // Components
 import { AllowSpendPanel } from './allow_spend_panel'
@@ -27,39 +18,7 @@ import {
 
 export const _AllowSpendPanel = {
   render: () => {
-    return (
-      <AllowSpendPanel
-        token={mockBasicAttentionToken}
-        transactionDetails={mockParsedERC20ApprovalTransaction}
-        network={mockEthMainnet}
-        originInfo={mockUniswapOriginInfo}
-        currentLimit='1000'
-        isCurrentAllowanceUnlimited={false}
-        gasFee='3641000000'
-        onSaveSpendLimit={() => {
-          alert('Clicked save spend limit')
-        }}
-        onClickDetails={() => {
-          alert('Clicked details')
-        }}
-        onClickAdvancedSettings={() => {
-          alert('Clicked advanced settings')
-        }}
-        onConfirm={() => {
-          alert('Clicked confirm')
-        }}
-        onReject={() => {
-          alert('Clicked reject')
-        }}
-        onClickEditNetworkFee={() => {
-          alert('Clicked edit network fee')
-        }}
-        transactionsQueueLength={1}
-        queueNextTransaction={() => {}}
-        queuePreviousTransaction={() => {}}
-        rejectAllTransactions={() => {}}
-      />
-    )
+    return <AllowSpendPanel />
   },
 }
 
@@ -71,7 +30,11 @@ export default {
   },
   decorators: [
     (Story: any) => (
-      <WalletPanelStory>
+      <WalletPanelStory
+        uiStateOverride={{
+          selectedPendingTransactionId: mockedErc20ApprovalTransaction.id,
+        }}
+      >
         <Story />
       </WalletPanelStory>
     ),

--- a/components/brave_wallet_ui/components/extension/confirm-transaction-panel/confirm-transaction-panel.tsx
+++ b/components/brave_wallet_ui/components/extension/confirm-transaction-panel/confirm-transaction-panel.tsx
@@ -50,19 +50,6 @@ import {
 import {
   TransactionSimulationNotSupportedSheet, //
 } from '../transaction_simulation_not_supported_sheet/transaction_simulation_not_supported_sheet'
-import {
-  AllowSpendPanel, //
-} from '../allow_spend_panel/allow_spend_panel'
-import {
-  PendingTransactionDetails, //
-} from '../pending_transaction_details/pending_transaction_details'
-import {
-  BottomSheet, //
-} from '../../shared/bottom_sheet/bottom_sheet'
-import {
-  AdvancedTransactionSettings, //
-} from '../advanced_transaction_settings/advanced_transaction_settings'
-import { EditNetworkFee } from '../edit_network_fee/edit_network_fee'
 
 // Styled Components
 import {
@@ -117,7 +104,6 @@ export const ConfirmTransactionPanel = ({
 
   // custom hooks
   const {
-    erc20ApproveTokenInfo,
     fromAccount,
     fromOrb,
     isERC20Approve,
@@ -125,7 +111,6 @@ export const ConfirmTransactionPanel = ({
     isERC721TransferFrom,
     isEthereumTransaction,
     isAssociatedTokenAccountCreation,
-    onEditAllowanceSave,
     toOrb,
     transactionDetails,
     transactionsNetwork,
@@ -140,7 +125,6 @@ export const ConfirmTransactionPanel = ({
     insufficientFundsError,
     insufficientFundsForGasError,
     queueNextTransaction,
-    queuePreviousTransaction,
     transactionQueueNumber,
     transactionsQueueLength,
     isSolanaTransaction,
@@ -184,8 +168,6 @@ export const ConfirmTransactionPanel = ({
   const [showAdvancedTransactionSettings, setShowAdvancedTransactionSettings] =
     React.useState<boolean>(false)
   const [isWarningCollapsed, setIsWarningCollapsed] = React.useState(true)
-  const [showTransactionDetails, setShowTransactionDetails] =
-    React.useState<boolean>(false)
 
   // methods
   const onSelectTab = (tab: confirmPanelTabs) => () => setSelectedTab(tab)
@@ -209,65 +191,6 @@ export const ConfirmTransactionPanel = ({
       <LongWrapper>
         <LoadingPanel />
       </LongWrapper>
-    )
-  }
-
-  if (isERC20Approve) {
-    return (
-      <>
-        <AllowSpendPanel
-          token={erc20ApproveTokenInfo}
-          network={transactionsNetwork}
-          originInfo={originInfo}
-          transactionDetails={transactionDetails}
-          currentLimit={currentTokenAllowance}
-          isCurrentAllowanceUnlimited={isCurrentAllowanceUnlimited}
-          gasFee={gasFee}
-          onSaveSpendLimit={onEditAllowanceSave}
-          onConfirm={onConfirm}
-          onReject={onReject}
-          onClickDetails={() => setShowTransactionDetails(true)}
-          onClickAdvancedSettings={() =>
-            setShowAdvancedTransactionSettings(true)
-          }
-          onClickEditNetworkFee={() => setIsEditing(true)}
-          transactionsQueueLength={transactionsQueueLength}
-          queueNextTransaction={queueNextTransaction}
-          queuePreviousTransaction={queuePreviousTransaction}
-          rejectAllTransactions={rejectAllTransactions}
-        />
-        <BottomSheet
-          isOpen={showTransactionDetails}
-          title={getLocale('braveWalletDetails')}
-          onClose={() => setShowTransactionDetails(false)}
-        >
-          <PendingTransactionDetails
-            transactionInfo={selectedPendingTransaction}
-            instructions={transactionDetails.instructions}
-          />
-        </BottomSheet>
-        <BottomSheet
-          isOpen={showAdvancedTransactionSettings}
-          title={getLocale('braveWalletAdvancedTransactionSettings')}
-          onClose={() => setShowAdvancedTransactionSettings(false)}
-        >
-          <AdvancedTransactionSettings
-            onCancel={() => setShowAdvancedTransactionSettings(false)}
-            nonce={transactionDetails.nonce}
-            onSave={(nonce: string) =>
-              updateUnapprovedTransactionNonce({
-                chainId: selectedPendingTransaction.chainId,
-                txMetaId: selectedPendingTransaction.id,
-                nonce: nonce,
-              })
-            }
-          />
-        </BottomSheet>
-        <EditNetworkFee
-          isOpen={isEditing}
-          onCancel={() => setIsEditing(false)}
-        />
-      </>
     )
   }
 

--- a/components/brave_wallet_ui/components/extension/pending_transaction_panel/pending_transaction_panel.tsx
+++ b/components/brave_wallet_ui/components/extension/pending_transaction_panel/pending_transaction_panel.tsx
@@ -28,6 +28,7 @@ import {
 import {
   ConfirmSimulatedTransactionPanel, //
 } from '../confirm-transaction-panel/confirm_simulated_tx_panel'
+import { AllowSpendPanel } from '../allow_spend_panel/allow_spend_panel'
 
 // Utils
 import { getCoinFromTxDataUnion } from '../../../utils/network-utils'
@@ -205,6 +206,14 @@ export const PendingTransactionPanel: React.FC<Props> = ({
     selectedPendingTransaction.txType === BraveWallet.TransactionType.ETHSwap
   ) {
     return <ConfirmSwapTransaction />
+  }
+
+  // Allow spend
+  if (
+    selectedPendingTransaction.txType
+    === BraveWallet.TransactionType.ERC20Approve
+  ) {
+    return <AllowSpendPanel />
   }
 
   // Defaults

--- a/components/brave_wallet_ui/stories/mock-data/mock-transaction-info.ts
+++ b/components/brave_wallet_ui/stories/mock-data/mock-transaction-info.ts
@@ -357,6 +357,7 @@ export const mockFilSendTransaction: FileCoinTransactionInfo = {
 export const mockedErc20ApprovalTransaction = {
   ...mockTransactionInfo,
   txType: BraveWallet.TransactionType.ERC20Approve,
+  id: 'erc20-approve-tx',
 }
 
 export const mockEthSendTransaction = {


### PR DESCRIPTION
## Description 

Moves the `ERC20 Approve` logic out of the `Confirm Transaction` component and is now rendered in the `Pending Transactions` component

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/49118>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

## Test Plan
1. The `Allow Spend` panel should continue to work as expected.