### PR TITLE
Fix WebAudio farbling test timing issue (uplift to 1.83.x)

### DIFF
--- a/browser/farbling/brave_webaudio_farbling_browsertest.cc
+++ b/browser/farbling/brave_webaudio_farbling_browsertest.cc
@@ -31,6 +31,8 @@ using brave_shields::ControlType;
 
 constexpr char kEmbeddedTestServerDirectory[] = "webaudio";
 constexpr char kTitleScript[] = "document.title;";
+constexpr char kWebAudioResultScript[] =
+    "(async () => await window.webAudioAnalysisPromise)()";
 
 class BraveWebAudioFarblingBrowserTest : public InProcessBrowserTest {
  public:
@@ -120,7 +122,7 @@ IN_PROC_BROWSER_TEST_F(BraveWebAudioFarblingBrowserTest, FarbleWebAudio) {
   EXPECT_EQ(content::EvalJs(contents(), kTitleScript), "356");
 
   ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), farbling2_url()));
-  EXPECT_EQ(content::EvalJs(contents(), kTitleScript), "-971");
+  EXPECT_EQ(content::EvalJs(contents(), kWebAudioResultScript), -971);
 
   // Farbling level: balanced (default)
   // web audio: farbled audio data
@@ -129,7 +131,7 @@ IN_PROC_BROWSER_TEST_F(BraveWebAudioFarblingBrowserTest, FarbleWebAudio) {
   EXPECT_EQ(content::EvalJs(contents(), kTitleScript), "7920");
 
   ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), farbling2_url()));
-  EXPECT_EQ(content::EvalJs(contents(), kTitleScript), "-1032");
+  EXPECT_EQ(content::EvalJs(contents(), kWebAudioResultScript), -1032);
 
   // Farbling level: off
   // web audio: original audio data
@@ -138,7 +140,7 @@ IN_PROC_BROWSER_TEST_F(BraveWebAudioFarblingBrowserTest, FarbleWebAudio) {
   EXPECT_EQ(content::EvalJs(contents(), kTitleScript), "8000");
 
   ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), farbling2_url()));
-  EXPECT_EQ(content::EvalJs(contents(), kTitleScript), "-1031");
+  EXPECT_EQ(content::EvalJs(contents(), kWebAudioResultScript), -1031);
 
   // Farbling level: balanced (default), but webcompat exception enabled
   // web audio: original audio data
@@ -150,5 +152,5 @@ IN_PROC_BROWSER_TEST_F(BraveWebAudioFarblingBrowserTest, FarbleWebAudio) {
   EXPECT_EQ(content::EvalJs(contents(), kTitleScript), "8000");
 
   ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), farbling2_url()));
-  EXPECT_EQ(content::EvalJs(contents(), kTitleScript), "-1031");
+  EXPECT_EQ(content::EvalJs(contents(), kWebAudioResultScript), -1031);
 }

--- a/test/data/webaudio/farbling2.html
+++ b/test/data/webaudio/farbling2.html
@@ -5,7 +5,7 @@
   <title>Web Audio farbling test</title>
 </head>
 <body>
-<script type="module">
+<script>
 // Testing code adapted from PoC in https://hackerone.com/reports/2846851
 
 const sumArray = (arr) => arr.reduce((sum, val) => sum + val, 0);
@@ -41,9 +41,10 @@ async function analyzeAudio() {
 async function runTest() {
   const result = await analyzeAudio();
   document.title = result;
+  return result;
 }
 
-await runTest();
+window.webAudioAnalysisPromise = runTest();
 
 </script>
 </body>


### PR DESCRIPTION
Uplift of #31079
Resolves https://github.com/brave/brave-browser/issues/48495

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.