### PR TITLE
Do not retry on HTTP 403 and restrict catalog download to opted-in users

### DIFF
--- a/components/brave_ads/core/internal/account/issuers/issuers.h
+++ b/components/brave_ads/core/internal/account/issuers/issuers.h
@@ -39,7 +39,7 @@ class Issuers final {
   void FetchAfterDelay();
 
   void SuccessfullyFetchedIssuers(const IssuersInfo& issuers);
-  void FailedToFetchIssuers();
+  void FailedToFetchIssuers(bool should_retry);
 
   void Retry();
   void RetryCallback();

--- a/components/brave_ads/core/internal/catalog/catalog.cc
+++ b/components/brave_ads/core/internal/catalog/catalog.cc
@@ -22,20 +22,10 @@ namespace brave_ads {
 
 namespace {
 
-bool DoesRequireResourceForNewTabPageAds() {
-  // Require resource only if:
-  // - The user has opted into new tab page ads and joined Brave Rewards.
-  return UserHasJoinedBraveRewards() && UserHasOptedInToNewTabPageAds();
-}
-
 bool DoesRequireResource() {
   // Require resource only if:
-  // - The user has opted into Brave News ads.
-  // - The user has opted into new tab page ads and and joined Brave Rewards.
   // - The user has joined Brave Rewards and opted into notification ads.
-  return UserHasOptedInToBraveNewsAds() ||
-         DoesRequireResourceForNewTabPageAds() ||
-         UserHasOptedInToNotificationAds();
+  return UserHasOptedInToNotificationAds();
 }
 
 }  // namespace
@@ -115,8 +105,6 @@ void Catalog::OnNotifyDidInitializeAds() {
 
 void Catalog::OnNotifyPrefDidChange(const std::string& path) {
   if (DoesMatchUserHasJoinedBraveRewardsPrefPath(path) ||
-      DoesMatchUserHasOptedInToBraveNewsAdsPrefPath(path) ||
-      DoesMatchUserHasOptedInToNewTabPageAdsPrefPath(path) ||
       DoesMatchUserHasOptedInToNotificationAdsPrefPath(path)) {
     // This condition should include all the preferences that are present in the
     // `DoesRequireResource` function.

--- a/components/brave_ads/core/internal/common/subdivision/subdivision.cc
+++ b/components/brave_ads/core/internal/common/subdivision/subdivision.cc
@@ -20,20 +20,10 @@ namespace brave_ads {
 
 namespace {
 
-bool DoesRequireResourceForNewTabPageAds() {
-  // Require resource only if:
-  // - The user has opted into new tab page ads and joined Brave Rewards.
-  return UserHasJoinedBraveRewards() && UserHasOptedInToNewTabPageAds();
-}
-
 bool DoesRequireResource() {
   // Require resource only if:
-  // - The user has opted into Brave News ads.
-  // - The user has opted into new tab page ads and and joined Brave Rewards.
   // - The user has joined Brave Rewards and opted into notification ads.
-  return UserHasOptedInToBraveNewsAds() ||
-         DoesRequireResourceForNewTabPageAds() ||
-         UserHasOptedInToNotificationAds();
+  return UserHasOptedInToNotificationAds();
 }
 
 }  // namespace
@@ -100,8 +90,6 @@ void Subdivision::OnNotifyDidInitializeAds() {
 
 void Subdivision::OnNotifyPrefDidChange(const std::string& path) {
   if (DoesMatchUserHasJoinedBraveRewardsPrefPath(path) ||
-      DoesMatchUserHasOptedInToBraveNewsAdsPrefPath(path) ||
-      DoesMatchUserHasOptedInToNewTabPageAdsPrefPath(path) ||
       DoesMatchUserHasOptedInToNotificationAdsPrefPath(path)) {
     // This condition should include all the preferences that are present in the
     // `DoesRequireResource` function.

--- a/components/brave_ads/core/internal/common/subdivision/subdivision_unittest.cc
+++ b/components/brave_ads/core/internal/common/subdivision/subdivision_unittest.cc
@@ -12,8 +12,10 @@
 #include "brave/components/brave_ads/core/internal/common/test/test_base.h"
 #include "brave/components/brave_ads/core/internal/prefs/pref_util.h"
 #include "brave/components/brave_ads/core/internal/settings/settings_test_util.h"
+#include "brave/components/brave_ads/core/public/prefs/pref_names.h"
 #include "brave/components/brave_news/common/pref_names.h"
 #include "brave/components/brave_rewards/core/pref_names.h"
+#include "brave/components/ntp_background_images/common/pref_names.h"
 #include "net/http/http_status_code.h"
 
 // npm run test -- brave_unit_tests --filter=BraveAds*
@@ -63,93 +65,129 @@ TEST_F(BraveAdsSubdivisionTest, OnDidInitializeAds) {
   EXPECT_TRUE(HasPendingTasks());
 }
 
-TEST_F(BraveAdsSubdivisionTest, PrefsNotEnabledOnDidInitializeAds) {
+TEST_F(BraveAdsSubdivisionTest, FetchIfUserJoinsBraveRewards) {
   // Arrange
   test::DisableBraveRewards();
-  test::OptOutOfBraveNewsAds();
+
+  MockHttpOkUrlResponse(/*country_code=*/"US", /*subdivision_code=*/"CA");
+
+  EXPECT_CALL(subdivision_observer_mock_, OnDidUpdateSubdivision);
+
+  // Act & Assert
+  SetProfileBooleanPref(brave_rewards::prefs::kEnabled, true);
+}
+
+TEST_F(BraveAdsSubdivisionTest, DoNotFetchIfUserHasNotJoinedBraveRewards) {
+  // Arrange
+  MockHttpOkUrlResponse(/*country_code=*/"US", /*subdivision_code=*/"CA");
+
+  EXPECT_CALL(subdivision_observer_mock_, OnDidUpdateSubdivision).Times(0);
+
+  // Act & Assert
+  SetProfileBooleanPref(brave_rewards::prefs::kEnabled, false);
+}
+
+TEST_F(BraveAdsSubdivisionTest, DoNotFetchWhenOptingOutOfNotificationAds) {
+  // Arrange
+  MockHttpOkUrlResponse(/*country_code=*/"US", /*subdivision_code=*/"CA");
+
+  EXPECT_CALL(subdivision_observer_mock_, OnDidUpdateSubdivision).Times(0);
+
+  // Act & Assert
+  SetProfileBooleanPref(prefs::kOptedInToNotificationAds, false);
+}
+
+TEST_F(BraveAdsSubdivisionTest, FetchWhenOptingInToNotificationAds) {
+  // Arrange
+  test::OptOutOfAllAds();
+
+  MockHttpOkUrlResponse(/*country_code=*/"US", /*subdivision_code=*/"CA");
+
+  EXPECT_CALL(subdivision_observer_mock_, OnDidUpdateSubdivision);
+
+  // Act & Assert
+  SetProfileBooleanPref(prefs::kOptedInToNotificationAds, true);
+}
+
+TEST_F(BraveAdsSubdivisionTest, DoNotFetchWhenOptingOutOfBraveNewsAds) {
+  // Arrange
+  MockHttpOkUrlResponse(/*country_code=*/"US", /*subdivision_code=*/"CA");
+
+  EXPECT_CALL(subdivision_observer_mock_, OnDidUpdateSubdivision).Times(0);
+
+  // Act & Assert
+  SetProfileBooleanPref(brave_news::prefs::kBraveNewsOptedIn, false);
+  SetProfileBooleanPref(brave_news::prefs::kNewTabPageShowToday, false);
+  task_environment_.DescribeCurrentTasks();
+}
+
+TEST_F(BraveAdsSubdivisionTest, DoNotFetchWhenOptingInToBraveNewsAds) {
+  // Arrange
+  test::OptOutOfAllAds();
 
   MockHttpOkUrlResponse(/*country_code=*/"US", /*subdivision_code=*/"CA");
 
   EXPECT_CALL(subdivision_observer_mock_, OnDidUpdateSubdivision).Times(0);
 
-  // Act
-  NotifyDidInitializeAds();
-
-  // Assert
-  EXPECT_FALSE(HasPendingTasks());
+  // Act & Assert
+  SetProfileBooleanPref(brave_news::prefs::kBraveNewsOptedIn, true);
+  SetProfileBooleanPref(brave_news::prefs::kNewTabPageShowToday, true);
 }
 
-TEST_F(BraveAdsSubdivisionTest, OnDidJoinBraveRewards) {
+TEST_F(BraveAdsSubdivisionTest, DoNotFetchWhenOptingOutOfNewTabPageAds) {
   // Arrange
-  test::DisableBraveRewards();
-  test::OptOutOfBraveNewsAds();
+  MockHttpOkUrlResponse(/*country_code=*/"US", /*subdivision_code=*/"CA");
+
+  EXPECT_CALL(subdivision_observer_mock_, OnDidUpdateSubdivision).Times(0);
+
+  // Act & Assert
+  SetProfileBooleanPref(
+      ntp_background_images::prefs::kNewTabPageShowBackgroundImage, false);
+  SetProfileBooleanPref(ntp_background_images::prefs::
+                            kNewTabPageShowSponsoredImagesBackgroundImage,
+                        false);
+}
+
+TEST_F(BraveAdsSubdivisionTest, DoNotFetchWhenOptingInToNewTabPageAds) {
+  // Arrange
+  test::OptOutOfAllAds();
 
   MockHttpOkUrlResponse(/*country_code=*/"US", /*subdivision_code=*/"CA");
 
-  EXPECT_CALL(subdivision_observer_mock_, OnDidUpdateSubdivision("US-CA"));
+  EXPECT_CALL(subdivision_observer_mock_, OnDidUpdateSubdivision).Times(0);
 
-  // Act
-  SetProfileBooleanPref(brave_rewards::prefs::kEnabled, true);
+  // Act & Assert
+  SetProfileBooleanPref(
+      ntp_background_images::prefs::kNewTabPageShowBackgroundImage, true);
+  SetProfileBooleanPref(ntp_background_images::prefs::
+                            kNewTabPageShowSponsoredImagesBackgroundImage,
+                        true);
+}
 
-  // Assert
-  EXPECT_TRUE(HasPendingTasks());
+TEST_F(BraveAdsSubdivisionTest, DoNotFetchWhenOptingOutOfSearchResultAds) {
+  // Arrange
+  MockHttpOkUrlResponse(/*country_code=*/"US", /*subdivision_code=*/"CA");
+
+  EXPECT_CALL(subdivision_observer_mock_, OnDidUpdateSubdivision).Times(0);
+
+  // Act & Assert
+  SetProfileBooleanPref(prefs::kOptedInToSearchResultAds, false);
+}
+
+TEST_F(BraveAdsSubdivisionTest, DoNotFetchWhenOptingInToSearchResultAds) {
+  // Arrange
+  test::OptOutOfAllAds();
+
+  MockHttpOkUrlResponse(/*country_code=*/"US", /*subdivision_code=*/"CA");
+
+  EXPECT_CALL(subdivision_observer_mock_, OnDidUpdateSubdivision).Times(0);
+
+  // Act & Assert
+  SetProfileBooleanPref(prefs::kOptedInToSearchResultAds, true);
 }
 
 TEST_F(BraveAdsSubdivisionTest,
-       FetchWhenOptingInToBraveNewsIfBraveRewardsIsDisabled) {
-  // Arrange
-  test::DisableBraveRewards();
-  test::OptOutOfBraveNewsAds();
-
-  MockHttpOkUrlResponse(/*country_code=*/"US", /*subdivision_code=*/"CA");
-
-  EXPECT_CALL(subdivision_observer_mock_, OnDidUpdateSubdivision("US-CA"));
-
-  // Act
-  SetProfileBooleanPref(brave_news::prefs::kBraveNewsOptedIn, true);
-  SetProfileBooleanPref(brave_news::prefs::kNewTabPageShowToday, true);
-
-  // Assert
-  EXPECT_TRUE(HasPendingTasks());
-}
-
-TEST_F(BraveAdsSubdivisionTest, OnDidResetBraveRewards) {
-  // Arrange
-  test::OptOutOfBraveNewsAds();
-
-  MockHttpOkUrlResponse(/*country_code=*/"US", /*subdivision_code=*/"CA");
-
-  NotifyDidInitializeAds();
-
-  ASSERT_TRUE(HasPendingTasks());
-
-  // Act
-  SetProfileBooleanPref(brave_rewards::prefs::kEnabled, false);
-
-  // Assert
-  EXPECT_FALSE(HasPendingTasks());
-}
-
-TEST_F(BraveAdsSubdivisionTest, OnDidOptOutBraveNews) {
-  // Arrange
-  test::DisableBraveRewards();
-
-  MockHttpOkUrlResponse(/*country_code=*/"US", /*subdivision_code=*/"CA");
-
-  EXPECT_CALL(subdivision_observer_mock_, OnDidUpdateSubdivision("US-CA"));
-
-  NotifyDidInitializeAds();
-
-  ASSERT_TRUE(HasPendingTasks());
-
-  // Act
-  SetProfileBooleanPref(brave_news::prefs::kNewTabPageShowToday, false);
-
-  // Assert
-  EXPECT_FALSE(HasPendingTasks());
-}
-
-TEST_F(BraveAdsSubdivisionTest, DoNotRetryAfterForbiddenUrlResponseStatusCode) {
+       DoNotRetryIfHttpForbiddenUrlResponseStatusCode) {
   // Arrange
   const test::URLResponseMap url_responses = {
       {BuildSubdivisionUrlPath(),
@@ -168,7 +206,8 @@ TEST_F(BraveAdsSubdivisionTest, DoNotRetryAfterForbiddenUrlResponseStatusCode) {
   EXPECT_TRUE(HasPendingTasks());
 }
 
-TEST_F(BraveAdsSubdivisionTest, RetryAfterInvalidUrlResponseStatusCode) {
+TEST_F(BraveAdsSubdivisionTest,
+       RetryIfHttpInternalServerErrorResponseStatusCode) {
   // Arrange
   const test::URLResponseMap url_responses = {
       {BuildSubdivisionUrlPath(),
@@ -186,6 +225,21 @@ TEST_F(BraveAdsSubdivisionTest, RetryAfterInvalidUrlResponseStatusCode) {
 
   // Act
   FastForwardClockToNextPendingTask();
+
+  // Assert
+  EXPECT_TRUE(HasPendingTasks());
+}
+
+TEST_F(BraveAdsSubdivisionTest, RetryIfResponseBodyIsInvalid) {
+  // Arrange
+  const test::URLResponseMap url_responses = {
+      {BuildSubdivisionUrlPath(), {{net::HTTP_OK, /*response_body=*/"{}"}}}};
+  test::MockUrlResponses(ads_client_mock_, url_responses);
+
+  EXPECT_CALL(subdivision_observer_mock_, OnDidUpdateSubdivision).Times(0);
+
+  // Act
+  NotifyDidInitializeAds();
 
   // Assert
   EXPECT_TRUE(HasPendingTasks());
@@ -222,21 +276,6 @@ TEST_F(BraveAdsSubdivisionTest, EmptySubdivisionCode) {
 TEST_F(BraveAdsSubdivisionTest, EmptyCountryCode) {
   // Arrange
   MockHttpOkUrlResponse(/*country_code=*/"", /*subdivision_code=*/"CA");
-
-  EXPECT_CALL(subdivision_observer_mock_, OnDidUpdateSubdivision).Times(0);
-
-  // Act
-  NotifyDidInitializeAds();
-
-  // Assert
-  EXPECT_TRUE(HasPendingTasks());
-}
-
-TEST_F(BraveAdsSubdivisionTest, NotValidSubdivisionResonse) {
-  // Arrange
-  const test::URLResponseMap url_responses = {
-      {BuildSubdivisionUrlPath(), {{net::HTTP_OK, /*response_body=*/"{}"}}}};
-  test::MockUrlResponses(ads_client_mock_, url_responses);
 
   EXPECT_CALL(subdivision_observer_mock_, OnDidUpdateSubdivision).Times(0);
 

--- a/components/brave_ads/core/internal/targeting/geographical/subdivision/subdivision_targeting_unittest.cc
+++ b/components/brave_ads/core/internal/targeting/geographical/subdivision/subdivision_targeting_unittest.cc
@@ -50,8 +50,7 @@ class BraveAdsSubdivisionTargetingTest : public test::TestBase {
 TEST_F(BraveAdsSubdivisionTargetingTest,
        AllowAndFetchWhenOptingInToNotificationAds) {
   // Arrange
-  test::OptOutOfBraveNewsAds();
-  test::OptOutOfNotificationAds();
+  test::OptOutOfAllAds();
 
   MockHttpOkUrlResponse(/*country_code=*/"US", /*subdivision_code=*/"CA");
 
@@ -68,11 +67,9 @@ TEST_F(BraveAdsSubdivisionTargetingTest,
                          prefs::kSubdivisionTargetingAutoDetectedSubdivision));
 }
 
-TEST_F(BraveAdsSubdivisionTargetingTest,
-       AllowAndFetchWhenOptingInToBraveNewsAds) {
+TEST_F(BraveAdsSubdivisionTargetingTest, DoNotFetchWhenOptingInToBraveNewsAds) {
   // Arrange
-  test::OptOutOfBraveNewsAds();
-  test::OptOutOfNotificationAds();
+  test::OptOutOfAllAds();
 
   MockHttpOkUrlResponse(/*country_code=*/"US", /*subdivision_code=*/"CA");
 
@@ -83,17 +80,13 @@ TEST_F(BraveAdsSubdivisionTargetingTest,
   SetProfileBooleanPref(brave_news::prefs::kNewTabPageShowToday, true);
 
   // Assert
-  EXPECT_TRUE(SubdivisionTargeting::ShouldAllow());
-  EXPECT_FALSE(subdivision_targeting_->IsDisabled());
-  EXPECT_TRUE(subdivision_targeting_->ShouldAutoDetect());
-  EXPECT_EQ("US-CA", GetProfileStringPref(
-                         prefs::kSubdivisionTargetingAutoDetectedSubdivision));
+  EXPECT_FALSE(SubdivisionTargeting::ShouldAllow());
 }
 
 TEST_F(BraveAdsSubdivisionTargetingTest,
        DoNotFetchWhenOptingOutOfNotificationAds) {
   // Arrange
-  test::OptOutOfBraveNewsAds();
+  test::OptOutOfAllAds();
 
   MockHttpOkUrlResponse(/*country_code=*/"US", /*subdivision_code=*/"CA");
 
@@ -107,7 +100,7 @@ TEST_F(BraveAdsSubdivisionTargetingTest,
 TEST_F(BraveAdsSubdivisionTargetingTest,
        DoNotFetchWhenOptingOutOfBraveNewsAds) {
   // Arrange
-  test::OptOutOfNotificationAds();
+  test::OptOutOfAllAds();
 
   MockHttpOkUrlResponse(/*country_code=*/"US", /*subdivision_code=*/"CA");
 


### PR DESCRIPTION
- Do not retry v1/getstate after HTTP 403
- Do not retry v3/issuers after HTTP 403
- Download catalog only for users opted in to notification ads

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/49158

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
