### PR TITLE
Don't reset custom title when it's initial navigation

### DIFF
--- a/browser/ui/tabs/test/brave_tab_strip_model_browsertest.cc
+++ b/browser/ui/tabs/test/brave_tab_strip_model_browsertest.cc
@@ -310,6 +310,10 @@ IN_PROC_BROWSER_TEST_F(BraveTabStripModelRenamingTabBrowserTest,
   // Given a tab has a custom title set.
   BraveTabStripModel* tab_strip_model =
       static_cast<BraveTabStripModel*>(browser()->tab_strip_model());
+  auto target_url = embedded_test_server()->GetURL("/");
+  ASSERT_TRUE(
+      content::NavigateToURL(tab_strip_model->GetWebContentsAt(0), target_url));
+
   tab_strip_model->SetCustomTitleForTab(0, u"Custom Title");
   ASSERT_EQ(TabRendererData::FromTabInModel(tab_strip_model, 0).title,
             u"Custom Title");
@@ -322,6 +326,9 @@ IN_PROC_BROWSER_TEST_F(BraveTabStripModelRenamingTabBrowserTest,
   ASSERT_TRUE(TabRestoreServiceFactory::GetForProfile(browser()->profile()));
   chrome::RestoreTab(browser());
   ASSERT_EQ(tab_strip_model->count(), 2);
+
+  base::test::RunUntil(
+      [&]() { return !tab_strip_model->GetWebContentsAt(0)->IsLoading(); });
 
   // Then the restored tab should have the custom title.
   EXPECT_EQ(TabRendererData::FromTabInModel(tab_strip_model, 0).title,

--- a/chromium_src/chrome/browser/ui/tab_ui_helper.cc
+++ b/chromium_src/chrome/browser/ui/tab_ui_helper.cc
@@ -38,7 +38,7 @@ void TabUIHelper::UpdateLastOrigin() {
   // custom title. This is to ensure that the custom title is not stale.
   const auto origin =
       web_contents()->GetPrimaryMainFrame()->GetLastCommittedOrigin();
-  if (last_origin_.IsSameOriginWith(origin)) {
+  if (last_origin_ && last_origin_->IsSameOriginWith(origin)) {
     return;
   }
 
@@ -53,10 +53,8 @@ void TabUIHelper::UpdateLastOrigin() {
   // We reset the custom title only when the last origin is initialized. When
   // restoring tabs, last origin could be uninitialized yet, and we do not want
   // to reset the custom title in that case.
-  if (last_origin_initialized_) {
+  if (last_origin_) {
     custom_title_.reset();
-  } else {
-    last_origin_initialized_ = true;
   }
   last_origin_ = origin;
 }

--- a/chromium_src/chrome/browser/ui/tab_ui_helper.cc
+++ b/chromium_src/chrome/browser/ui/tab_ui_helper.cc
@@ -42,6 +42,21 @@ void TabUIHelper::UpdateLastOrigin() {
     return;
   }
 
-  custom_title_.reset();
+  // In case this tab is newly created one and has not yet commited real page,
+  // e.g. restoring tabs, we do not reset the custom title. In case of
+  // restoring, the real page will be commited soon and the custom title will be
+  // reset or persisted based on the origin of the real page.
+  if (web_contents()->GetController().IsInitialNavigation()) {
+    return;
+  }
+
+  // We reset the custom title only when the last origin is initialized. When
+  // restoring tabs, last origin could be uninitialized yet, and we do not want
+  // to reset the custom title in that case.
+  if (last_origin_initialized_) {
+    custom_title_.reset();
+  } else {
+    last_origin_initialized_ = true;
+  }
   last_origin_ = origin;
 }

--- a/chromium_src/chrome/browser/ui/tab_ui_helper.h
+++ b/chromium_src/chrome/browser/ui/tab_ui_helper.h
@@ -20,6 +20,7 @@
                                                                    \
  private:                                                          \
   std::optional<std::u16string> custom_title_;                     \
+  bool last_origin_initialized_ = false;                           \
   url::Origin last_origin_;                                        \
                                                                    \
  public:                                                           \

--- a/chromium_src/chrome/browser/ui/tab_ui_helper.h
+++ b/chromium_src/chrome/browser/ui/tab_ui_helper.h
@@ -20,8 +20,7 @@
                                                                    \
  private:                                                          \
   std::optional<std::u16string> custom_title_;                     \
-  bool last_origin_initialized_ = false;                           \
-  url::Origin last_origin_;                                        \
+  std::optional<url::Origin> last_origin_;                         \
                                                                    \
  public:                                                           \
   std::u16string GetTitle(__VA_ARGS__)


### PR DESCRIPTION
When a tab is newly created, e.g. restoring tabs, it has not yet committed a real page. In this case the origin could be empty but we should not reset the custom title. As the real page will be committed soon and the custom title will be reset or persisted based on the origin of the real page once it's committed.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/49125

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
