### PR TITLE
[Nala]: Bump version to main

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@brave/brave-ui": "0.40.6",
-        "@brave/leo": "github:brave/leo#4499306e23fa9f86b297519a8f571231cc75d4bd",
+        "@brave/leo": "github:brave/leo#c6e366a08eb288b0d5900ef44c45441743bedc27",
         "@brave/leo-sf-symbols": "github:brave/leo-sf-symbols#17e29a0f1ffafdeefafc3015c687fc3f449401dc",
         "@brave/wallet-standard-brave": "0.0.16",
         "@dnd-kit/core": "6.0.5",
@@ -777,8 +777,8 @@
     },
     "node_modules/@brave/leo": {
       "version": "0.0.1",
-      "resolved": "git+ssh://git@github.com/brave/leo.git#4499306e23fa9f86b297519a8f571231cc75d4bd",
-      "integrity": "sha512-0eNLHzf/jcUoSCFj9iVTV2o8XtPtri/FP6PplTr04o2Q7g416i5L1iQkO/k03xv/Nb1D0R3erGHdZjmjCAR9Jw==",
+      "resolved": "git+ssh://git@github.com/brave/leo.git#c6e366a08eb288b0d5900ef44c45441743bedc27",
+      "integrity": "sha512-gSV51oJJ61CKZy4EK3sZ32ejJuLzculUpV7JjVUN8e8wN63vWDdJL93rt1c+wb60rXzN5EzA6LJMouON88zn1Q==",
       "license": "MIT",
       "dependencies": {
         "@storybook/test": "8.6.14",

--- a/package.json
+++ b/package.json
@@ -187,7 +187,7 @@
   },
   "dependencies": {
     "@brave/brave-ui": "0.40.6",
-    "@brave/leo": "github:brave/leo#4499306e23fa9f86b297519a8f571231cc75d4bd",
+    "@brave/leo": "github:brave/leo#c6e366a08eb288b0d5900ef44c45441743bedc27",
     "@brave/leo-sf-symbols": "github:brave/leo-sf-symbols#17e29a0f1ffafdeefafc3015c687fc3f449401dc",
     "@brave/wallet-standard-brave": "0.0.16",
     "@dnd-kit/core": "6.0.5",


### PR DESCRIPTION
Only the [1188](https://github.com/brave/leo/pull/1188) here is a functional change - everything else is a dependency bump

Changes https://github.com/brave/leo/compare/4499306e23fa9f86b297519a8f571231cc75d4bd...c6e366a08eb288b0d5900ef44c45441743bedc27
- chore(deps): update actions/github-script action to v8 ([https://github.com/brave/brave-core/pull/1209](https://github.com/brave/leo/pull/1209))
- chore(deps): update dependency sass to v1.92.0 ([https://github.com/brave/brave-core/pull/1203](https://github.com/brave/leo/pull/1203))
- package lock sync ([https://github.com/brave/brave-core/pull/1207](https://github.com/brave/leo/pull/1207))
- revert esbuild override bump ([https://github.com/brave/brave-core/pull/1206](https://github.com/brave/leo/pull/1206))
- chore(deps): update dependency @types/react to v18.3.24 ([https://github.com/brave/brave-core/pull/1200](https://github.com/brave/leo/pull/1200))
- chore(deps): update dependency tsx to v4.20.5 ([https://github.com/brave/brave-core/pull/1202](https://github.com/brave/leo/pull/1202))
- chore(deps): update actions/setup-node action to v5 ([https://github.com/brave/brave-core/pull/1204](https://github.com/brave/leo/pull/1204))
- chore(deps): update aws-actions/configure-aws-credentials action to v5 ([https://github.com/brave/brave-core/pull/1205](https://github.com/brave/leo/pull/1205))
- [Menu]: Only consider non slotted elements when deciding if an item is first/last ([https://github.com/brave/brave-core/pull/1188](https://github.com/brave/leo/pull/1188))
- chore(deps): update dependency rollup-plugin-svelte to v7.2.3 ([https://github.com/brave/brave-core/pull/1197](https://github.com/brave/leo/pull/1197))
- chore(deps): update dependency @tsconfig/svelte to v5.0.5 ([https://github.com/brave/brave-core/pull/1196](https://github.com/brave/leo/pull/1196))
- chore(deps): update dependency @babel/core to v7.28.3 ([https://github.com/brave/brave-core/pull/1195](https://github.com/brave/leo/pull/1195))
- chore(deps): update dependency vite to v5.4.20 ([https://github.com/brave/brave-core/pull/1191](https://github.com/brave/leo/pull/1191))
- chore(deps): update dependency node to v22.19.0 ([https://github.com/brave/brave-core/pull/1198](https://github.com/brave/leo/pull/1198))
- chore(deps): update actions/checkout action to v5 ([https://github.com/brave/brave-core/pull/1199](https://github.com/brave/leo/pull/1199))
- chore(deps): update dependency @floating-ui/dom to v1.7.4 ([https://github.com/brave/brave-core/pull/1168](https://github.com/brave/leo/pull/1168))
- chore(deps): update dependency undici to v7.15.0 ([https://github.com/brave/brave-core/pull/1166](https://github.com/brave/leo/pull/1166))
- chore(deps): update dependency esbuild to v0.25.9 ([https://github.com/brave/brave-core/pull/1165](https://github.com/brave/leo/pull/1165))
- chore(deps): update dependency svelte2tsx to v0.7.42 ([https://github.com/brave/brave-core/pull/1163](https://github.com/brave/leo/pull/1163))
- chore(deps): update actions/cache action to v4.2.4 ([https://github.com/brave/brave-core/pull/1190](https://github.com/brave/leo/pull/1190))
- chore(deps): update aws-actions/configure-aws-credentials action to v4.3.1 ([https://github.com/brave/brave-core/pull/1194](https://github.com/brave/leo/pull/1194))
- chore(deps): update actions/github-script action to v7.1.0 ([https://github.com/brave/brave-core/pull/1193](https://github.com/brave/leo/pull/1193))
- chore(deps): update actions/checkout action to v4.3.0 ([https://github.com/brave/brave-core/pull/1192](https://github.com/brave/leo/pull/1192))
- Bump vite from 7.0.0 to 7.1.5 in /examples/example-ui-react ([https://github.com/brave/brave-core/pull/1189](https://github.com/brave/leo/pull/1189))
