### PR TITLE
Utilities for shields content settings values.

### DIFF
--- a/components/BUILD.gn
+++ b/components/BUILD.gn
@@ -27,6 +27,7 @@ test("brave_components_unittests") {
     "//brave/components/brave_account/endpoints:unit_tests",
     "//brave/components/brave_policy:unit_tests",
     "//brave/components/brave_shields/core/browser:unit_tests",
+    "//brave/components/brave_shields/core/common:unit_tests",
     "//brave/components/brave_wallet/common:unit_tests",
     "//brave/components/email_aliases:unit_tests",
     "//brave/components/json:unit_tests",

--- a/components/brave_shields/core/browser/brave_shields_utils.h
+++ b/components/brave_shields/core/browser/brave_shields_utils.h
@@ -8,6 +8,7 @@
 
 #include <string>
 
+#include "brave/components/brave_shields/core/common/brave_shields_settings_values.h"
 #include "brave/components/brave_shields/core/common/shields_settings.mojom.h"
 #include "components/content_settings/core/common/content_settings_pattern.h"
 #include "components/content_settings/core/common/content_settings_types.h"
@@ -25,13 +26,6 @@ class HostContentSettingsMap;
 class PrefService;
 
 namespace brave_shields {
-
-enum ControlType {
-  ALLOW = 0,
-  BLOCK,
-  BLOCK_THIRD_PARTY,
-  DEFAULT,
-};
 
 // List of possible blocking modes when accessing blocked websites.
 enum class DomainBlockingType {

--- a/components/brave_shields/core/common/BUILD.gn
+++ b/components/brave_shields/core/common/BUILD.gn
@@ -10,6 +10,7 @@ static_library("common") {
     "brave_shield_constants.h",
     "brave_shield_utils.cc",
     "brave_shield_utils.h",
+    "brave_shields_settings_values.h",
     "features.cc",
     "features.h",
     "pref_names.h",
@@ -55,4 +56,16 @@ mojom_component("mojom") {
   export_class_attribute_blink = "BLINK_PLATFORM_EXPORT"
   export_define_blink = "BLINK_PLATFORM_IMPLEMENTATION=1"
   export_header_blink = "third_party/blink/public/platform/web_common.h"
+}
+
+source_set("unit_tests") {
+  testonly = true
+
+  sources = [ "brave_shields_settings_values_unittest.cc" ]
+
+  deps = [
+    ":common",
+    "//base",
+    "//testing/gtest",
+  ]
 }

--- a/components/brave_shields/core/common/brave_shield_constants.h
+++ b/components/brave_shields/core/common/brave_shield_constants.h
@@ -6,10 +6,15 @@
 #ifndef BRAVE_COMPONENTS_BRAVE_SHIELDS_CORE_COMMON_BRAVE_SHIELD_CONSTANTS_H_
 #define BRAVE_COMPONENTS_BRAVE_SHIELDS_CORE_COMMON_BRAVE_SHIELD_CONSTANTS_H_
 
+#include "base/containers/fixed_flat_map.h"
+#include "base/containers/fixed_flat_set.h"
+#include "base/containers/map_util.h"
 #include "base/files/file_path.h"
+#include "components/content_settings/core/common/content_settings_types.h"
 
 namespace brave_shields {
 
+// Content/Web settings:
 inline constexpr char kAds[] = "shieldsAds";
 inline constexpr char kCosmeticFiltering[] = "cosmeticFiltering";
 inline constexpr char kTrackers[] = "trackers";
@@ -21,12 +26,67 @@ inline constexpr char kBraveShields[] = "braveShields";
 inline constexpr char kBraveShieldsMetadata[] = "braveShieldsMetadata";
 inline constexpr char kReferrers[] = "referrers";
 inline constexpr char kCookies[] = "shieldsCookiesV3";
+
+// Prefs:
 inline constexpr char kFacebookEmbeds[] = "fb-embeds";
 inline constexpr char kTwitterEmbeds[] = "twitter-embeds";
 inline constexpr char kLinkedInEmbeds[] = "linked-in-embeds";
 
-// Values used before the migration away from ResourceIdentifier, kept around
-// for migration purposes only.
+inline constexpr auto kShieldsContentSettingsTypes =
+    base::MakeFixedFlatSet<ContentSettingsType>({
+        ContentSettingsType::BRAVE_ADS,
+        ContentSettingsType::BRAVE_COSMETIC_FILTERING,
+        ContentSettingsType::BRAVE_TRACKERS,
+        ContentSettingsType::BRAVE_HTTP_UPGRADABLE_RESOURCES,
+        ContentSettingsType::BRAVE_FINGERPRINTING_V2,
+        ContentSettingsType::BRAVE_SHIELDS,
+        ContentSettingsType::BRAVE_REFERRERS,
+        ContentSettingsType::BRAVE_COOKIES,
+    });
+
+using ShieldsContentSettingsTypes = decltype(kShieldsContentSettingsTypes);
+
+inline constexpr auto kShieldsContentTypeNames =
+    base::MakeFixedFlatMap<ContentSettingsType, const char*>({
+        {ContentSettingsType::BRAVE_ADS, kAds},
+        {ContentSettingsType::BRAVE_COSMETIC_FILTERING, kCosmeticFiltering},
+        {ContentSettingsType::BRAVE_TRACKERS, kTrackers},
+        {ContentSettingsType::BRAVE_HTTP_UPGRADABLE_RESOURCES,
+         kHTTPUpgradableResources},
+        {ContentSettingsType::BRAVE_HTTPS_UPGRADE, kHTTPSUpgrades},
+        {ContentSettingsType::JAVASCRIPT, kJavaScript},
+        {ContentSettingsType::BRAVE_FINGERPRINTING_V2, kFingerprintingV2},
+        {ContentSettingsType::BRAVE_SHIELDS, kBraveShields},
+        {ContentSettingsType::BRAVE_SHIELDS_METADATA, kBraveShieldsMetadata},
+        {ContentSettingsType::BRAVE_REFERRERS, kReferrers},
+        {ContentSettingsType::BRAVE_COOKIES, kCookies},
+    });
+
+using ShieldsContentTypeNames = decltype(kShieldsContentTypeNames);
+
+namespace internal {
+consteval bool CheckShieldsContentTypeNames() {
+  for (const auto& [key_a, value_a] : kShieldsContentTypeNames) {
+    for (const auto& [key_b, value_b] : kShieldsContentTypeNames) {
+      if (key_a == key_b) {
+        continue;
+      }
+      if (!value_a || !value_b || value_a == value_b) {
+        // Name is null or not unique.
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+static_assert(
+    CheckShieldsContentTypeNames(),
+    "Invalid kShieldsContentTypeNames. Name should be unique and non-null.");
+}  // namespace internal
+
+// Values used before the migration away from ResourceIdentifier, kept
+// around for migration purposes only.
 inline constexpr char kObsoleteAds[] = "ads";
 inline constexpr char kObsoleteCookies[] = "cookies";
 inline constexpr char kObsoleteShieldsCookies[] = "shieldsCookies";

--- a/components/brave_shields/core/common/brave_shields_settings_values.h
+++ b/components/brave_shields/core/common/brave_shields_settings_values.h
@@ -1,0 +1,107 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_COMPONENTS_BRAVE_SHIELDS_CORE_COMMON_BRAVE_SHIELDS_SETTINGS_VALUES_H_
+#define BRAVE_COMPONENTS_BRAVE_SHIELDS_CORE_COMMON_BRAVE_SHIELDS_SETTINGS_VALUES_H_
+
+#include <optional>
+
+#include "base/types/cxx23_to_underlying.h"
+#include "base/values.h"
+#include "brave/components/brave_shields/core/common/brave_shield_constants.h"
+#include "components/content_settings/core/common/content_settings_types.h"
+
+namespace brave_shields {
+
+enum ControlType {
+  ALLOW = 0,
+  BLOCK,
+  BLOCK_THIRD_PARTY,
+  DEFAULT,
+};
+
+namespace traits {
+
+template <typename Setting>
+struct SettingTraits;
+
+template <>
+struct SettingTraits<ControlType> {
+  static std::optional<ControlType> From(
+      std::underlying_type_t<ControlType> v) {
+    if (v >= ControlType::ALLOW && v <= ControlType::DEFAULT) {
+      return static_cast<ControlType>(v);
+    }
+    return std::nullopt;
+  }
+
+  static int To(ControlType setting) {
+    CHECK(setting >= ControlType::ALLOW && setting <= ControlType::DEFAULT)
+        << "Invalid setting.";
+    return base::to_underlying(setting);
+  }
+};
+
+namespace internal {
+const char* NotShieldCntentTypeFailure();
+}
+
+consteval const char* GetShieldsContentTypeName(
+    ContentSettingsType content_type) {
+  // Linear, because `find` isn't constexpr/consteval.
+  for (const auto& v : kShieldsContentTypeNames) {
+    if (v.first == content_type) {
+      return v.second;
+    }
+  }
+  return internal::NotShieldCntentTypeFailure();
+}
+
+template <ContentSettingsType content_settings_type, typename SettingT>
+struct BraveShieldsSettingSettingType {
+  static constexpr ContentSettingsType kContentSettingsType =
+      content_settings_type;
+  static constexpr const char* kName =
+      GetShieldsContentTypeName(content_settings_type);
+
+  using SettingType = SettingT;
+  using SettingTraits = SettingTraits<SettingType>;
+};
+
+template <ContentSettingsType content_settings_type,
+          typename SettingType,
+          SettingType default_value>
+struct BraveShieldsSetting
+    : BraveShieldsSettingSettingType<content_settings_type, SettingType> {
+  static constexpr SettingType kDefaultValue = default_value;
+
+  static base::Value DefaultValue() { return ToValue(kDefaultValue); }
+
+  static base::Value ToValue(SettingType setting) {
+    return base::Value(base::Value::Dict().Set(
+        BraveShieldsSetting::kName,
+        traits::SettingTraits<SettingType>::To(setting)));
+  }
+
+  static SettingType FromValue(const base::Value& value) {
+    if (const auto* dict = value.GetIfDict()) {
+      if (const auto v = dict->FindInt(BraveShieldsSetting::kName);
+          v.has_value()) {
+        return traits::SettingTraits<SettingType>::From(*v).value_or(
+            kDefaultValue);
+      }
+    }
+    LOG(ERROR) << "ShieldSetting " << BraveShieldsSetting::kName
+               << " failed to parse value: " << value.DebugString();
+    DCHECK(false) << "Invalid value.";
+    return kDefaultValue;
+  }
+};
+
+}  // namespace traits
+
+}  // namespace brave_shields
+
+#endif  // BRAVE_COMPONENTS_BRAVE_SHIELDS_CORE_COMMON_BRAVE_SHIELDS_SETTINGS_VALUES_H_

--- a/components/brave_shields/core/common/brave_shields_settings_values.h
+++ b/components/brave_shields/core/common/brave_shields_settings_values.h
@@ -45,7 +45,7 @@ struct SettingTraits<ControlType> {
 };
 
 namespace internal {
-const char* NotShieldCntentTypeFailure();
+const char* NotShieldContentTypeFailure();
 }
 
 consteval const char* GetShieldsContentTypeName(
@@ -56,7 +56,7 @@ consteval const char* GetShieldsContentTypeName(
       return v.second;
     }
   }
-  return internal::NotShieldCntentTypeFailure();
+  return internal::NotShieldContentTypeFailure();
 }
 
 template <ContentSettingsType content_settings_type, typename SettingT>

--- a/components/brave_shields/core/common/brave_shields_settings_values_unittest.cc
+++ b/components/brave_shields/core/common/brave_shields_settings_values_unittest.cc
@@ -89,6 +89,7 @@ TEST_F(ShieldsSettingsValuesTest, ControlTypeSettingTypeSuccess) {
   EXPECT_TRUE(checker.SuccessCheck());
 }
 
+#if !BUILDFLAG(IS_IOS)  // iOS doesn't support EXPECT_DEATH
 TEST_F(ShieldsSettingsValuesTest, ControlTypeSettingTypeFailure) {
   using ControlTypeTrait = traits::SettingTraits<ControlType>;
   EXPECT_DEATH(ControlTypeTrait::To(static_cast<ControlType>(-1)),
@@ -114,5 +115,6 @@ TEST_F(ShieldsSettingsValuesTest, ControlTypeSettingTypeFailure) {
                     ContentSettingsType::BRAVE_COSMETIC_FILTERING),
                 -1))));
 }
+#endif
 
 }  // namespace brave_shields

--- a/components/brave_shields/core/common/brave_shields_settings_values_unittest.cc
+++ b/components/brave_shields/core/common/brave_shields_settings_values_unittest.cc
@@ -1,0 +1,118 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/components/brave_shields/core/common/brave_shields_settings_values.h"
+
+#include "base/check.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace brave_shields {
+
+using ShieldsSettingsValuesTest = ::testing::Test;
+
+template <ContentSettingsType content_settings_type,
+          typename SettingT,
+          SettingT... values>
+struct ValuesChecker {
+  template <SettingT value>
+  bool SuccessCheckValue(
+      base::FunctionRef<bool(const base::Value&)> structure_checker) {
+    using TypeToCheck =
+        typename traits::BraveShieldsSetting<content_settings_type, SettingT,
+                                             value>;
+    if (TypeToCheck::kDefaultValue != value) {
+      return false;
+    }
+    if (TypeToCheck::ToValue(value) != TypeToCheck::DefaultValue()) {
+      return false;
+    }
+    if (TypeToCheck::FromValue(TypeToCheck::DefaultValue()) !=
+        TypeToCheck::kDefaultValue) {
+      return false;
+    }
+    if (TypeToCheck::FromValue(TypeToCheck::ToValue(value)) != value) {
+      return false;
+    }
+    if (!structure_checker(TypeToCheck::ToValue(value))) {
+      return false;
+    }
+    return true;
+  }
+
+  bool SuccessCheckValues(
+      base::FunctionRef<bool(const base::Value&)> structure_checker) {
+    return (SuccessCheckValue<values>(structure_checker) && ...);
+  }
+};
+
+template <ContentSettingsType... content_settings_types>
+struct ControlTypeShieldsSettingsValuesChecker {
+  static_assert(kShieldsContentTypeNames.size() ==
+                sizeof...(content_settings_types));
+
+  template <ContentSettingsType content_settings_type>
+  bool SuccessCheckOne() {
+    ValuesChecker<content_settings_type, ControlType, ControlType::DEFAULT,
+                  ControlType::ALLOW, ControlType::BLOCK,
+                  ControlType::BLOCK_THIRD_PARTY>
+        checker;
+    return checker.SuccessCheckValues([](const base::Value& value) {
+      return value.is_dict() &&
+             value.GetDict().FindInt(
+                 traits::GetShieldsContentTypeName(content_settings_type));
+    });
+  }
+
+  bool SuccessCheck() {
+    return (SuccessCheckOne<content_settings_types>() && ...);
+  }
+};
+
+using ControlTypeAllShieldsSettingsValuesChecker =
+    ControlTypeShieldsSettingsValuesChecker<
+        ContentSettingsType::BRAVE_ADS,
+        ContentSettingsType::BRAVE_COSMETIC_FILTERING,
+        ContentSettingsType::BRAVE_TRACKERS,
+        ContentSettingsType::BRAVE_HTTP_UPGRADABLE_RESOURCES,
+        ContentSettingsType::BRAVE_HTTPS_UPGRADE,
+        ContentSettingsType::JAVASCRIPT,
+        ContentSettingsType::BRAVE_FINGERPRINTING_V2,
+        ContentSettingsType::BRAVE_SHIELDS,
+        ContentSettingsType::BRAVE_SHIELDS_METADATA,
+        ContentSettingsType::BRAVE_REFERRERS,
+        ContentSettingsType::BRAVE_COOKIES>;
+
+TEST_F(ShieldsSettingsValuesTest, ControlTypeSettingTypeSuccess) {
+  ControlTypeAllShieldsSettingsValuesChecker checker;
+  EXPECT_TRUE(checker.SuccessCheck());
+}
+
+TEST_F(ShieldsSettingsValuesTest, ControlTypeSettingTypeFailure) {
+  using ControlTypeTrait = traits::SettingTraits<ControlType>;
+  EXPECT_DEATH(ControlTypeTrait::To(static_cast<ControlType>(-1)),
+               "Invalid setting.");
+
+  EXPECT_EQ(std::nullopt, ControlTypeTrait::From(-1));
+
+  using Setting =
+      traits::BraveShieldsSetting<ContentSettingsType::BRAVE_COSMETIC_FILTERING,
+                                  ControlType, ControlType::BLOCK_THIRD_PARTY>;
+
+  // Structure is invalid.
+  if constexpr (DCHECK_IS_ON()) {
+    EXPECT_DEATH(Setting::FromValue(base::Value()), "Invalid value.");
+  } else {
+    EXPECT_EQ(Setting::kDefaultValue, Setting::FromValue(base::Value()));
+  }
+
+  // Structure is ok, but contains an invalid value.
+  EXPECT_EQ(Setting::kDefaultValue,
+            Setting::FromValue(base::Value(base::DictValue().Set(
+                traits::GetShieldsContentTypeName(
+                    ContentSettingsType::BRAVE_COSMETIC_FILTERING),
+                -1))));
+}
+
+}  // namespace brave_shields

--- a/components/content_settings/core/browser/brave_content_settings_utils.cc
+++ b/components/content_settings/core/browser/brave_content_settings_utils.cc
@@ -5,12 +5,11 @@
 
 #include "brave/components/content_settings/core/browser/brave_content_settings_utils.h"
 
-#include <algorithm>
 #include <optional>
 
 #include "base/check.h"
 #include "base/containers/contains.h"
-#include "base/no_destructor.h"
+#include "base/containers/map_util.h"
 #include "base/notreached.h"
 #include "base/values.h"
 #include "brave/components/brave_shields/core/common/brave_shield_constants.h"
@@ -28,19 +27,22 @@ bool CanPatternBeConvertedToWildcardSchemeAndPort(
   if (pattern == ContentSettingsPattern::Wildcard() ||
       pattern == ContentSettingsPattern::FromString("https://firstParty/*") ||
       pattern.GetScheme() == ContentSettingsPattern::SCHEME_FILE ||
-      pattern.MatchesAllHosts() || pattern.GetHost().empty())
+      pattern.MatchesAllHosts() || pattern.GetHost().empty()) {
     return false;
+  }
   // Check for the case when the scheme is wildcard, but the port isn't.
   if (pattern.GetScheme() == ContentSettingsPattern::SCHEME_WILDCARD) {
     GURL check_for_port_url("http://" + pattern.ToString());
     return check_for_port_url.has_port();
   }
   GURL url(pattern.ToString());
-  if (!url.is_valid() || url.is_empty() || !url.has_host())
+  if (!url.is_valid() || url.is_empty() || !url.has_host()) {
     return false;
-  if (url.has_scheme())
+  }
+  if (url.has_scheme()) {
     return !ContentSettingsPattern::IsNonWildcardDomainNonPortScheme(
         url.scheme_piece());
+  }
   return url.has_port();
 }
 
@@ -48,44 +50,19 @@ bool CanPatternBeConvertedToWildcardSchemeAndPort(
 
 namespace content_settings {
 
-const std::vector<ContentSettingsType>& GetShieldsContentSettingsTypes() {
-  static const base::NoDestructor<std::vector<ContentSettingsType>>
-      kShieldsContentSettingsTypes({
-          ContentSettingsType::BRAVE_ADS,
-          ContentSettingsType::BRAVE_COSMETIC_FILTERING,
-          ContentSettingsType::BRAVE_TRACKERS,
-          ContentSettingsType::BRAVE_HTTP_UPGRADABLE_RESOURCES,
-          ContentSettingsType::BRAVE_FINGERPRINTING_V2,
-          ContentSettingsType::BRAVE_SHIELDS,
-          ContentSettingsType::BRAVE_REFERRERS,
-          ContentSettingsType::BRAVE_COOKIES,
-      });
-
-  return *kShieldsContentSettingsTypes;
+const brave_shields::ShieldsContentSettingsTypes&
+GetShieldsContentSettingsTypes() {
+  return brave_shields::kShieldsContentSettingsTypes;
 }
 
 std::string GetShieldsContentTypeName(const ContentSettingsType& content_type) {
-  switch (content_type) {
-    case ContentSettingsType::BRAVE_ADS:
-      return brave_shields::kAds;
-    case ContentSettingsType::BRAVE_COSMETIC_FILTERING:
-      return brave_shields::kCosmeticFiltering;
-    case ContentSettingsType::BRAVE_TRACKERS:
-      return brave_shields::kTrackers;
-    case ContentSettingsType::BRAVE_HTTP_UPGRADABLE_RESOURCES:
-      return brave_shields::kHTTPUpgradableResources;
-    case ContentSettingsType::BRAVE_FINGERPRINTING_V2:
-      return brave_shields::kFingerprintingV2;
-    case ContentSettingsType::BRAVE_SHIELDS:
-      return brave_shields::kBraveShields;
-    case ContentSettingsType::BRAVE_REFERRERS:
-      return brave_shields::kReferrers;
-    case ContentSettingsType::BRAVE_COOKIES:
-      return brave_shields::kCookies;
-    default:
-      break;
-  }
-  NOTREACHED() << "All handled shields content type above.";
+  const auto* name =
+      IsShieldsContentSettingsType(content_type)
+          ? base::FindOrNull(brave_shields::kShieldsContentTypeNames,
+                             content_type)
+          : nullptr;
+  CHECK(name) << "Content type isn't a shield content type.";
+  return *name;
 }
 
 bool IsShieldsContentSettingsType(const ContentSettingsType& content_type) {
@@ -94,16 +71,18 @@ bool IsShieldsContentSettingsType(const ContentSettingsType& content_type) {
 
 bool IsShieldsContentSettingsTypeName(const std::string& content_type_name) {
   for (auto content_type : GetShieldsContentSettingsTypes()) {
-    if (GetShieldsContentTypeName(content_type) == content_type_name)
+    if (GetShieldsContentTypeName(content_type) == content_type_name) {
       return true;
+    }
   }
   return false;
 }
 
 std::optional<ContentSettingsPattern> ConvertPatternToWildcardSchemeAndPort(
     const ContentSettingsPattern& pattern) {
-  if (!CanPatternBeConvertedToWildcardSchemeAndPort(pattern))
+  if (!CanPatternBeConvertedToWildcardSchemeAndPort(pattern)) {
     return std::nullopt;
+  }
   DCHECK(!pattern.GetHost().empty());
   std::optional<ContentSettingsPattern> new_pattern =
       ContentSettingsPattern::FromString("*://" + pattern.GetHost() + "/*");

--- a/components/content_settings/core/browser/brave_content_settings_utils.h
+++ b/components/content_settings/core/browser/brave_content_settings_utils.h
@@ -8,15 +8,17 @@
 
 #include <optional>
 #include <string>
-#include <vector>
 
-#include "components/content_settings/core/common/content_settings.h"
-#include "components/content_settings/core/common/content_settings_constraints.h"
+#include "base/values.h"
+#include "brave/components/brave_shields/core/common/brave_shield_constants.h"
+#include "components/content_settings/core/common/content_settings_enums.mojom.h"
+#include "components/content_settings/core/common/content_settings_pattern.h"
 #include "components/content_settings/core/common/content_settings_types.h"
 
 namespace content_settings {
 
-const std::vector<ContentSettingsType>& GetShieldsContentSettingsTypes();
+const brave_shields::ShieldsContentSettingsTypes&
+GetShieldsContentSettingsTypes();
 
 std::string GetShieldsContentTypeName(const ContentSettingsType& content_type);
 


### PR DESCRIPTION
The split of https://github.com/brave/brave-core/pull/30839, requested [here ](https://github.com/brave/brave-core/pull/30839#discussion_r2337322307).

1. `ControlType` enum has been moved to `common`
2. `ShieldsContentSettingsTypes` has been changed to be constexpr
3. Added utilities for serialize web settings into base:::Value