### PR TITLE
[iOS] Support the new obscured insets API in iOS 26

### DIFF
--- a/chromium_src/ios/web/web_state/crw_web_view.mm
+++ b/chromium_src/ios/web/web_state/crw_web_view.mm
@@ -1,0 +1,30 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#import <UIKit/UIKit.h>
+
+#include <ios/web/web_state/crw_web_view.mm>
+
+@implementation CRWWebView (Brave)
+
+- (UIEdgeInsets)safeAreaInsets {
+  // In iOS 26+ we are using the new `obscuredContentInsets` API to fix the
+  // pages viewport and allow us to apply decorative blur effects behind
+  // toolbars. Using this API though only seems to only work correctly when the
+  // `safeAreaInsets` are set to 0 because we have to add the safe area already
+  // to the obscuredContentInsets for it to adjust the viewport correctly.
+  // WKWebView will still report the safe area to the page despite the viewport
+  // CSS metrics being correctly reported and you end up with pages like YouTube
+  // having extra whitespace added to the top & bottom of the page.
+  //
+  // Chromium may support this properly through CRWViewportAdjustment in the
+  // future but for now we have to use the WKWebView API directly.
+  if (@available(iOS 26.0, *)) {
+    return UIEdgeInsetsZero;
+  }
+  return [super safeAreaInsets];
+}
+
+@end

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserColors.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserColors.swift
@@ -153,7 +153,10 @@ struct StandardBrowserColors: BrowserColors {
   }
 
   var tabBarTabBackground: UIColor {
-    .init(light: .primitiveNeutral95, dark: .primitiveNeutral5)
+    .init(
+      lightColor: UIColor.black.withAlphaComponent(0.05),
+      darkColor: UIColor.black.withAlphaComponent(0.1)
+    )
   }
 
   var tabBarTabActiveBackground: UIColor {
@@ -260,7 +263,7 @@ struct PrivateModeBrowserColors: BrowserColors {
   }
 
   var tabBarTabBackground: UIColor {
-    .init(braveSystemName: .primitivePrivateWindow5)
+    UIColor.black.withAlphaComponent(0.05)
   }
 
   var tabBarTabActiveBackground: UIColor {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabManagerDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabManagerDelegate.swift
@@ -227,7 +227,7 @@ extension BrowserViewController: TabManagerDelegate {
 
       webViewContainer.addSubview(tab.view)
       tab.view.snp.remakeConstraints { make in
-        make.left.right.top.bottom.equalTo(self.webViewContainer)
+        make.edges.equalTo(self.webViewContainer)
       }
 
       // Add ScreenTime above the WebView

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabObserver.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabObserver.swift
@@ -16,8 +16,19 @@ extension BrowserViewController: TabObserver {
   public func tabDidCreateWebView(_ tab: some TabState) {
     tab.view.frame = webViewContainer.frame
 
-    if tab.isVisible, let scrollView = tab.webViewProxy?.scrollView {
-      toolbarVisibilityViewModel.beginObservingScrollView(scrollView)
+    if let scrollView = tab.webViewProxy?.scrollView {
+      if tab.isVisible {
+        toolbarVisibilityViewModel.beginObservingScrollView(scrollView)
+      }
+      if #available(iOS 26.0, *) {
+        // We set the content inset + safe area insets ourselves so we normalize this to `always`
+        scrollView.contentInsetAdjustmentBehavior = .always
+      } else {
+        // On iOS 17/18 setting clipsToBounds as false can still let us achieve the visual effect
+        // of the web view scrolling under blurred toolbars despite the frame being tied to the
+        // toolbars itself.
+        scrollView.clipsToBounds = false
+      }
     }
 
     if !FeatureList.kUseProfileWebViewConfiguration.enabled {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ToolbarDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ToolbarDelegate.swift
@@ -344,11 +344,13 @@ extension BrowserViewController: TopToolbarDelegate {
   }
 
   func topToolbarDidEnterOverlayMode(_ topToolbar: TopToolbarView) {
+    header.backgroundView.isHidden = false
     updateTabsBarVisibility()
     displayFavoritesController()
   }
 
   func topToolbarDidLeaveOverlayMode(_ topToolbar: TopToolbarView) {
+    header.backgroundView.isHidden = true
     hideSearchController()
     hideFavoritesController()
     updateScreenTimeUrl(tabManager.selectedTab?.visibleURL)
@@ -759,7 +761,7 @@ extension BrowserViewController: TopToolbarDelegate {
       // Two different behaviors here:
       // 1. For bottom bar we do not want to show the status bar color
       // 2. For top bar we do so it matches the address bar background
-      let subview = isUsingBottomBar ? statusBarOverlay : footer
+      let subview = isUsingBottomBar ? topBarsBackgroundView : footer
       view.insertSubview(favoritesController.view, aboveSubview: subview)
     }
   }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -66,6 +66,13 @@ public class BrowserViewController: UIViewController {
   }()
 
   // These views wrap the top and bottom toolbars to provide background effects on them
+  let topBarsBackgroundView: UIVisualEffectView = .init(
+    effect: UIBlurEffect(style: .systemThinMaterial)
+  )
+  let bottomBarsBackgroundView: UIVisualEffectView = .init(
+    effect: UIBlurEffect(style: .systemThinMaterial)
+  )
+
   private(set) lazy var header = HeaderContainerView(privateBrowsingManager: privateBrowsingManager)
   private let headerHeightLayoutGuide = UILayoutGuide()
 
@@ -667,7 +674,9 @@ public class BrowserViewController: UIViewController {
     super.viewSafeAreaInsetsDidChange()
 
     topTouchArea.isEnabled = view.safeAreaInsets.top > 0
-    statusBarOverlay.isHidden = view.safeAreaInsets.top.isZero
+    if isStatusBarOverlayNeeded {
+      statusBarOverlay.isHidden = view.safeAreaInsets.top.isZero
+    }
   }
 
   fileprivate func updateToolbarStateForTraitCollection(
@@ -735,6 +744,7 @@ public class BrowserViewController: UIViewController {
           self.updateStatusBarOverlayColor()
           self.bottomBarKeyboardBackground.backgroundColor =
             self.privateBrowsingManager.browserColors.chromeBackground
+          self.updateBrowserColors(traitCollection: newCollection)
           self.setNeedsStatusBarAppearanceUpdate()
         }
       }
@@ -850,6 +860,7 @@ public class BrowserViewController: UIViewController {
 
   private(set) var isUsingBottomBar: Bool = false {
     didSet {
+      topBarsBackgroundView.isHidden = isUsingBottomBar
       header.isUsingBottomBar = isUsingBottomBar
       collapsedURLBarView.isUsingBottomBar = isUsingBottomBar
       searchController?.isUsingBottomBar = isUsingBottomBar
@@ -859,6 +870,20 @@ public class BrowserViewController: UIViewController {
       updateStatusBarOverlayColor()
       updateViewConstraints()
     }
+  }
+
+  private var isStatusBarOverlayNeeded: Bool {
+    if #unavailable(iOS 26) {
+      return true
+    }
+    guard
+      let requiredCompatability = Bundle.main.infoDictionary?["UIDesignRequiresCompatibility"]
+        as? Bool
+    else {
+      // No key means its running without compatibility mode
+      return false
+    }
+    return requiredCompatability
   }
 
   override public func viewDidLoad() {
@@ -873,6 +898,7 @@ public class BrowserViewController: UIViewController {
     // Add views
     view.addSubview(webViewContainerBackdrop)
     view.addSubview(webViewContainer)
+
     header.expandedBarStackView.addArrangedSubview(topToolbar)
     header.collapsedBarContainerView.addSubview(collapsedURLBarView)
 
@@ -887,13 +913,20 @@ public class BrowserViewController: UIViewController {
     view.addSubview(bottomTouchArea)
     view.addSubview(topTouchArea)
     view.addSubview(bottomBarKeyboardBackground)
+    view.addSubview(bottomBarsBackgroundView)
     view.addSubview(footer)
-    view.addSubview(statusBarOverlay)
+    if isStatusBarOverlayNeeded {
+      view.addSubview(statusBarOverlay)
+    }
+    view.addSubview(topBarsBackgroundView)
     view.addSubview(header)
 
     // For now we hide some elements so they are not visible
     header.isHidden = true
+    header.backgroundView.isHidden = true
     footer.isHidden = true
+
+    updateBrowserColors()
 
     // Setup constraints
     setupConstraints()
@@ -1232,14 +1265,27 @@ public class BrowserViewController: UIViewController {
       make.bottom.left.right.equalTo(self.view)
       make.height.equalTo(44)
     }
+
+    bottomBarsBackgroundView.snp.makeConstraints {
+      $0.top.equalTo(pageOverlayLayoutGuide.snp.bottom)
+      $0.left.right.bottom.equalTo(view)
+    }
+
+    topBarsBackgroundView.snp.makeConstraints {
+      $0.bottom.equalTo(pageOverlayLayoutGuide.snp.top)
+      $0.left.right.top.equalTo(view)
+    }
+
+    if isStatusBarOverlayNeeded {
+      statusBarOverlay.snp.makeConstraints { make in
+        make.top.left.right.equalTo(self.view)
+        make.bottom.equalTo(view.safeArea.top)
+      }
+    }
   }
 
   override public func viewDidLayoutSubviews() {
     super.viewDidLayoutSubviews()
-    statusBarOverlay.snp.remakeConstraints { make in
-      make.top.left.right.equalTo(self.view)
-      make.bottom.equalTo(view.safeArea.top)
-    }
 
     toolbarVisibilityViewModel.transitionDistance =
       header.expandedBarStackView.bounds.height - header.collapsedBarContainerView.bounds.height
@@ -1257,6 +1303,26 @@ public class BrowserViewController: UIViewController {
     }
     searchController?.additionalSafeAreaInsets = additionalInsets
     favoritesController?.additionalSafeAreaInsets = additionalInsets
+
+    if #available(iOS 26.0, *), let webViewProxy = tabManager.selectedTab?.webViewProxy {
+      var webViewInsets: UIEdgeInsets = .zero
+      if isUsingBottomBar {
+        let unifiedToolbarHeight = view.bounds.height - header.frame.minY
+        webViewInsets.top = view.safeAreaInsets.top
+        webViewInsets.bottom = unifiedToolbarHeight
+      } else {
+        webViewInsets.top = header.frame.maxY
+        webViewInsets.bottom = view.bounds.height - footer.frame.minY
+      }
+      webViewInsets.left = view.safeAreaInsets.left
+      webViewInsets.right = view.safeAreaInsets.right
+      if webViewProxy.obscuredContentInsets != webViewInsets {
+        // For some reason its required that you set both obscuredContentInsets _and_ contentInset
+        webViewProxy.obscuredContentInsets = webViewInsets
+        webViewProxy.scrollView?.contentInset = webViewInsets
+        webViewProxy.scrollView?.scrollIndicatorInsets = webViewInsets
+      }
+    }
   }
 
   override public var canBecomeFirstResponder: Bool {
@@ -1387,22 +1453,28 @@ public class BrowserViewController: UIViewController {
       }
     }
 
-    webViewContainer.snp.remakeConstraints { make in
-      make.left.right.equalTo(self.view)
-
-      if self.isUsingBottomBar {
-        webViewContainerTopOffset =
-          make.top.equalTo(self.readerModeBar?.snp.bottom ?? self.toolbarLayoutGuide.snp.top)
-          .constraint
-      } else {
-        webViewContainerTopOffset =
-          make.top.equalTo(self.readerModeBar?.snp.bottom ?? self.header.snp.bottom).constraint
+    if #available(iOS 26.0, *) {
+      webViewContainer.snp.remakeConstraints { make in
+        make.edges.equalTo(self.view)
       }
+    } else {
+      webViewContainer.snp.remakeConstraints { make in
+        make.left.right.equalTo(self.view)
 
-      if self.isUsingBottomBar {
-        make.bottom.equalTo(self.header.snp.top)
-      } else {
-        make.bottom.equalTo(self.footer.snp.top)
+        if self.isUsingBottomBar {
+          webViewContainerTopOffset =
+            make.top.equalTo(self.readerModeBar?.snp.bottom ?? self.toolbarLayoutGuide.snp.top)
+            .constraint
+        } else {
+          webViewContainerTopOffset =
+            make.top.equalTo(self.readerModeBar?.snp.bottom ?? self.header.snp.bottom).constraint
+        }
+
+        if self.isUsingBottomBar {
+          make.bottom.equalTo(self.header.snp.top)
+        } else {
+          make.bottom.equalTo(self.footer.snp.top)
+        }
       }
     }
 
@@ -1583,7 +1655,7 @@ public class BrowserViewController: UIViewController {
       activeNewTabPageViewController = ntpController
 
       addChild(ntpController)
-      let subview = isUsingBottomBar ? header : statusBarOverlay
+      let subview = isUsingBottomBar ? header : topBarsBackgroundView
       view.insertSubview(ntpController.view, belowSubview: subview)
       ntpController.didMove(toParent: self)
 
@@ -1591,6 +1663,8 @@ public class BrowserViewController: UIViewController {
         $0.edges.equalTo(pageOverlayLayoutGuide)
       }
       ntpController.view.layoutIfNeeded()
+
+      updateBrowserColors()
 
       self.webViewContainer.accessibilityElementsHidden = true
       UIAccessibility.post(notification: .screenChanged, argument: nil)
@@ -1622,6 +1696,8 @@ public class BrowserViewController: UIViewController {
       self.showReaderModeBar(animated: false)
       self.updatePlaylistURLBar(tab: tab, state: state, item: tab.playlistItem)
     }
+
+    updateBrowserColors()
   }
 
   func updateInContentHomePanel(_ url: URL?) {
@@ -2074,7 +2150,7 @@ public class BrowserViewController: UIViewController {
 
   func clearPageZoomDialog() {
     pageZoomBar?.view.removeFromSuperview()
-    updateViewConstraints()
+    view.setNeedsUpdateConstraints()
     pageZoomBar = nil
   }
 
@@ -2120,16 +2196,33 @@ public class BrowserViewController: UIViewController {
   }
 
   public override var preferredStatusBarStyle: UIStatusBarStyle {
-    if isUsingBottomBar, let tab = tabManager.selectedTab, let url = tab.visibleURL,
-      !url.isNewTabURL, !InternalURL.isValid(url: url),
-      let color = tab.sampledPageTopColor
-    {
-      return color.isLight ? .darkContent : .lightContent
-    }
-    return super.preferredStatusBarStyle
+    return .default
+  }
+
+  func updateBrowserColors(traitCollection: UITraitCollection? = nil) {
+    let traitCollection = traitCollection ?? self.traitCollection
+    self.bottomBarKeyboardBackground.backgroundColor = self.topToolbar.backgroundColor
+    self.collapsedURLBarView.browserColors = self.privateBrowsingManager.browserColors
+
+    let isNewTabPageVisible = self.activeNewTabPageViewController?.parent != nil
+    let backgroundViewColor = privateBrowsingManager.browserColors.chromeBackground
+      .withAlphaComponent(
+        isNewTabPageVisible ? 1 : (traitCollection.userInterfaceStyle == .dark ? 0.8 : 0.6)
+      )
+    let backgroundViewEffect = UIBlurEffect(
+      style: privateBrowsingManager.isPrivateBrowsing
+        ? .systemChromeMaterialDark : .systemChromeMaterial
+    )
+    self.topBarsBackgroundView.contentView.backgroundColor = backgroundViewColor
+    self.topBarsBackgroundView.effect = backgroundViewEffect
+    self.bottomBarsBackgroundView.contentView.backgroundColor = backgroundViewColor
+    self.bottomBarsBackgroundView.effect = backgroundViewEffect
   }
 
   func updateStatusBarOverlayColor() {
+    if !isStatusBarOverlayNeeded {
+      return
+    }
     defer { setNeedsStatusBarAppearanceUpdate() }
     guard isUsingBottomBar, let tab = tabManager.selectedTab, let url = tab.visibleURL,
       !url.isNewTabURL, !InternalURL.isValid(url: url),

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/PullToRefreshTabHelper.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/PullToRefreshTabHelper.swift
@@ -47,6 +47,11 @@ class PullToRefreshTabHelper: TabObserver, PreferencesObserver {
     } else {
       scrollView.refreshControl = nil
     }
+    if #unavailable(iOS 26) {
+      // Ensure we disable clipsToBounds again as its re-enabled when you set `refreshControl` and
+      // we want it disabled to have a stylistic blur shown below the toolbars
+      scrollView.clipsToBounds = false
+    }
   }
 
   func tabDidUpdateURL(_ tab: some TabState) {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Tabs/TabBar/TabBarCell.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Tabs/TabBar/TabBarCell.swift
@@ -78,7 +78,6 @@ class TabBarCell: UICollectionViewCell {
   private func updateColors() {
     let browserColors: any BrowserColors =
       tabManager?.privateBrowsingManager.browserColors ?? .standard
-    backgroundColor = browserColors.tabBarTabBackground
     separatorLine.backgroundColor = browserColors.dividerSubtle
     highlightView.backgroundColor = isSelected ? browserColors.tabBarTabActiveBackground : .clear
     highlightView.layer.shadowOpacity = isSelected ? 0.05 : 0.0

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Tabs/TabBar/TabsBarViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Tabs/TabBar/TabsBarViewController.swift
@@ -69,7 +69,7 @@ class TabsBarViewController: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    collectionView.backgroundColor = view.backgroundColor
+    collectionView.backgroundColor = .clear
     tabManager?.addDelegate(self)
 
     // Can't get view.frame inside of lazy property, need to put this code here.
@@ -367,10 +367,7 @@ class TabsBarViewController: UIViewController {
   private func addScrollHint(for side: HintSide, maskLayer: CAGradientLayer) {
     maskLayer.removeFromSuperlayer()
 
-    guard
-      let barsColor = collectionView.backgroundColor?.resolvedColor(with: traitCollection)
-        ?? view.backgroundColor
-    else {
+    guard let barsColor = view.backgroundColor else {
       // If not setup now, will be at some point, and then this can be flushed
       return
     }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/ToolbarVisibilityViewModel.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/ToolbarVisibilityViewModel.swift
@@ -197,7 +197,8 @@ import UIKit
     }
 
     let ty = pan.yTranslation
-    let normalizedOffset = snapshot.contentOffset.y + snapshot.contentInset.top
+    let contentInsetTop = initialSnapshot?.contentInset.top ?? snapshot.contentInset.top
+    let normalizedOffset = snapshot.contentOffset.y + contentInsetTop
     let isRubberBandingBottomEdge =
       snapshot.contentOffset.y + snapshot.frameHeight > snapshot.contentHeight
     // If we're not starting from 0 and are expanded then we actually want to handle it the same way as from
@@ -243,7 +244,7 @@ import UIKit
       return
     }
 
-    let normalizedOffset = snapshot.contentOffset.y + snapshot.contentInset.top
+    let normalizedOffset = snapshot.contentOffset.y + initialSnapshot.contentInset.top
     let velocity = pan.yVelocity
     let projectedDelta = project(
       initialVelocity: velocity,

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/BottomToolbarView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/BottomToolbarView.swift
@@ -38,8 +38,6 @@ class BottomToolbarView: UIView, ToolbarProtocol {
     super.init(frame: .zero)
     setupAccessibility()
 
-    backgroundColor = privateBrowsingManager.browserColors.chromeBackground
-
     addSubview(contentView)
     addSubview(line)
     helper = ToolbarHelper(toolbar: self)
@@ -62,7 +60,6 @@ class BottomToolbarView: UIView, ToolbarProtocol {
       .receive(on: RunLoop.main)
       .sink(receiveValue: { [weak self] isPrivateBrowsing in
         guard let self = self else { return }
-        self.updateColors()
         self.helper?.updateForTraitCollection(
           self.traitCollection,
           browserColors: privateBrowsingManager.browserColors,
@@ -75,14 +72,9 @@ class BottomToolbarView: UIView, ToolbarProtocol {
       browserColors: privateBrowsingManager.browserColors,
       isBottomToolbar: true
     )
-
-    updateColors()
   }
 
   private var privateModeCancellable: AnyCancellable?
-  private func updateColors() {
-    backgroundColor = privateBrowsingManager.browserColors.chromeBackground
-  }
 
   private var isSearchButtonEnabled: Bool = false {
     didSet {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/HeaderContainerView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/HeaderContainerView.swift
@@ -27,6 +27,10 @@ class HeaderContainerView: UIView {
   /// Container view for both the expanded & collapsed variants of the bar
   let contentView = UIView()
 
+  /// The background view placed behind the content view, use this to show/hide the background as
+  /// needed (for instance when showing a unified toolbar blur behind on the main browser)
+  let backgroundView = UIView()
+
   private var cancellables: Set<AnyCancellable> = []
   private let privateBrowsingManager: PrivateBrowsingManager
 
@@ -35,11 +39,15 @@ class HeaderContainerView: UIView {
 
     super.init(frame: .zero)
 
+    addSubview(backgroundView)
     addSubview(contentView)
     contentView.addSubview(expandedBarStackView)
     contentView.addSubview(collapsedBarContainerView)
     addSubview(line)
 
+    backgroundView.snp.makeConstraints {
+      $0.edges.equalToSuperview()
+    }
     contentView.snp.makeConstraints {
       $0.edges.equalToSuperview()
     }
@@ -88,7 +96,7 @@ class HeaderContainerView: UIView {
   private func updateColors() {
     let browserColors = privateBrowsingManager.browserColors
     line.backgroundColor = browserColors.dividerSubtle
-    backgroundColor = browserColors.chromeBackground
+    backgroundView.backgroundColor = browserColors.chromeBackground
   }
 
   @available(*, unavailable)

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
@@ -510,6 +510,7 @@ class TopToolbarView: UIView, ToolbarProtocol {
       additionalButtons: [shortcutButton]
     )
     updateForTraitCollection()
+    updateColors()
   }
 
   private func updateForTraitCollection() {
@@ -597,7 +598,9 @@ class TopToolbarView: UIView, ToolbarProtocol {
   private func updateColors() {
     overrideUserInterfaceStyle = privateBrowsingManager.isPrivateBrowsing ? .dark : .unspecified
     let browserColors = privateBrowsingManager.browserColors
-    backgroundColor = browserColors.chromeBackground
+    let isDark = traitCollection.userInterfaceStyle == .dark
+    locationContainer.layer.borderColor = isDark ? browserColors.dividerSubtle.cgColor : nil
+    locationContainer.layer.borderWidth = isDark ? 1.0 / traitCollection.displayScale : 0
     locationTextField?.backgroundColor = browserColors.containerBackground
     locationTextField?.textColor = browserColors.textPrimary
     locationTextField?.attributedPlaceholder = makePlaceholder(colors: browserColors)

--- a/ios/brave-ios/Sources/Web/Chromium/ChromiumTabState.swift
+++ b/ios/brave-ios/Sources/Web/Chromium/ChromiumTabState.swift
@@ -547,7 +547,20 @@ class ChromiumTabState: TabState, TabStateImpl {
   var policyDeciders: OrderedSet<AnyTabPolicyDecider> = []
 }
 
-extension CWVWebView: WebViewProxy {}
+extension CWVWebView: WebViewProxy {
+  #if compiler(>=6.2)
+  @available(iOS 26.0, *)
+  public var obscuredContentInsets: UIEdgeInsets {
+    get { internalWebView?.obscuredContentInsets ?? .zero }
+    set { internalWebView?.obscuredContentInsets = newValue }
+  }
+  #else
+  public var obscuredContentInsets: UIEdgeInsets {
+    get { .zero }
+    set {}
+  }
+  #endif
+}
 
 extension CWVUserAgentType {
   init(_ userAgentType: UserAgentType) {

--- a/ios/brave-ios/Sources/Web/TabState.swift
+++ b/ios/brave-ios/Sources/Web/TabState.swift
@@ -261,6 +261,12 @@ public protocol TabState: AnyObject {
   /// Returns the PDF data for the current page if one is being displayed
   var dataForDisplayedPDF: Data? { get }
   /// Returns a colour that was sampled from the top of the page for UI purposes
+  @available(
+    iOS,
+    deprecated: 26.0,
+    message:
+      "Use WebViewProxy.obscuredContentInsets and avoid adding views in the top safe area when compiling without UIDesignRequiresCompatibility"
+  )
   var sampledPageTopColor: UIColor? { get }
   /// The scale applied to the WKWebView which can be used to apply custom zoom settings to a page
   var viewScale: CGFloat { get set }
@@ -368,11 +374,13 @@ extension TabState {
 }
 
 /// A basic proxy over the underlying web view that may be displaying web content
-public protocol WebViewProxy {
+public protocol WebViewProxy: AnyObject {
   var scrollView: UIScrollView? { get }
   var bounds: CGRect { get }
   var frame: CGRect { get }
   var isKeyboardVisible: Bool { get }
+  @available(iOS 26.0, *)
+  var obscuredContentInsets: UIEdgeInsets { get set }
   func becomeFirstResponder() -> Bool
 }
 


### PR DESCRIPTION
This change adds support for setting the obscured insets of the page which fixes the page always getting a fixed viewport. As a side effect, this now allows the web view to fill the entire space and let us use blur effects on the toolbars.

On iOS 18 and below the viewports will still be incorrect but we disable the web view's clipping so that it renders under the toolbars and maintain the same blur effects.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/47891 **on iOS 26 only**
Resolves https://github.com/brave/brave-browser/issues/49178

### Test Case

For CSS viewport tests on iOS 26:
- Visit https://bokand.github.io/demo/urlbarsize.html and verify that the dvh bar adjusts when the toolbar shrinks & expands

For toolbar blur:
- Verify that content is blurred under the toolbars on both iOS 18 & 26
- Verify that tapping on the URL bar sets up a solid background
- Verify that things work with both URL bar placements (top bar/bottom bar modes)
- Verify that things work correctly on both iPad/iPhone, orientations, etc.
- Test a number of webpages that have fixed elements such as YouTube, TheVerge, TheGlobeAndMail, etc.
- Test that when the software keyboard is visible the page is still inset correctly and that you can scroll under them

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
