### PR TITLE
fix(iOS): Pickers in Settings not displayed as expected when build with Xcode 26 / iOS 26

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/Debug/AdBlock/AdBlockDebugView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/Debug/AdBlock/AdBlockDebugView.swift
@@ -4,6 +4,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import BraveShared
+import BraveUI
 import Strings
 import SwiftUI
 import WebKit
@@ -45,7 +46,7 @@ private struct CompileContentBlockersSectionView: View {
         .multilineTextAlignment(.trailing)
       }
 
-      Picker(selection: $selection) {
+      FormPicker(selection: $selection) {
         ForEach(availableSelections) { selection in
           Group {
             Text(getTitle(for: selection)) + Text(verbatim: " v\(selection.filterListInfo.version)")

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/DefaultShieldsSectionView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/DefaultShieldsSectionView.swift
@@ -19,7 +19,7 @@ struct DefaultShieldsSectionView: View {
 
   var body: some View {
     Section {
-      Picker(selection: $settings.adBlockAndTrackingPreventionLevel) {
+      FormPicker(selection: $settings.adBlockAndTrackingPreventionLevel) {
         ForEach(ShieldLevel.allCases) { level in
           Text(level.localizedTitle)
             .foregroundColor(Color(.secondaryBraveLabel))
@@ -33,7 +33,7 @@ struct DefaultShieldsSectionView: View {
       }
 
       if FeatureList.kBraveHttpsByDefault.enabled {
-        Picker(selection: $settings.httpsUpgradeLevel) {
+        FormPicker(selection: $settings.httpsUpgradeLevel) {
           ForEach(HTTPSUpgradeLevel.allCases) { level in
             Text(level.localizedTitle)
               .foregroundColor(Color(.secondaryBraveLabel))
@@ -97,7 +97,7 @@ struct DefaultShieldsSectionView: View {
       )
 
       if FeatureList.kBraveShredFeature.enabled {
-        Picker(selection: $settings.shredLevel) {
+        FormPicker(selection: $settings.shredLevel) {
           ForEach(SiteShredLevel.allCases) { level in
             Text(level.localizedTitle)
               .foregroundColor(Color(.secondaryBraveLabel))

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/ShredSettingsView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/ShredSettingsView.swift
@@ -24,7 +24,7 @@ struct ShredSettingsView: View {
   var body: some View {
     Form {
       Section {
-        Picker(selection: $settings.shredLevel) {
+        FormPicker(selection: $settings.shredLevel) {
           ForEach(SiteShredLevel.allCases) { level in
             Text(level.localizedTitle)
               .foregroundColor(Color(.secondaryBraveLabel))

--- a/ios/brave-ios/Sources/BraveNews/Settings/BraveNewsDebugSettingsView.swift
+++ b/ios/brave-ios/Sources/BraveNews/Settings/BraveNewsDebugSettingsView.swift
@@ -64,15 +64,19 @@ public struct BraveNewsDebugSettingsView: View {
   public var body: some View {
     Form {
       Section {
-        Picker("Environment", selection: $environment) {
+        FormPicker(selection: $environment) {
           ForEach(FeedDataSource.Environment.allCases, id: \.self) { env in
             Text(env.name)
           }
+        } label: {
+          Text("Environment")
         }
-        Picker("Selected Locale", selection: $localeOverride) {
+        FormPicker(selection: $localeOverride) {
           ForEach(Array(feedDataSource.availableLocales).sorted(), id: \.self) { locale in
             Text(locale).tag(locale)
           }
+        } label: {
+          Text("Selected Locale")
         }
       } footer: {
         Text("Changing the environment will purge all cached resources immediately.")

--- a/ios/brave-ios/Sources/BraveUI/SwiftUI/FormPicker.swift
+++ b/ios/brave-ios/Sources/BraveUI/SwiftUI/FormPicker.swift
@@ -1,0 +1,54 @@
+// Copyright 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import SwiftUI
+
+/// When building with iOS 26, using a Picker in a Form will prioritize the
+/// label text and push the Picker to be below the label when the text is long
+/// enough. This can be used as a drop-in replacement for Picker when used in
+/// a Form to force the Picker to stay beside the text, except when in an
+/// accessibility size category.
+public struct FormPicker<Label: View, SelectionValue: Hashable, Content: View>: View {
+  var content: Content
+  var label: Label
+  @Binding var selection: SelectionValue
+
+  @Environment(\.sizeCategory) private var sizeCategory
+
+  public init(
+    selection: Binding<SelectionValue>,
+    @ViewBuilder content: () -> Content,
+    @ViewBuilder label: () -> Label
+  ) {
+    self.content = content()
+    self.label = label()
+    self._selection = selection
+  }
+
+  public var body: some View {
+    if sizeCategory.isAccessibilityCategory {
+      VStack(alignment: .leading) {
+        stackContent
+      }
+    } else {
+      HStack {
+        stackContent
+      }
+    }
+  }
+
+  @ViewBuilder private var stackContent: some View {
+    label
+      .accessibilityHidden(true)
+    Spacer()
+    Picker(selection: $selection) {
+      content
+    } label: {
+      label
+        .accessibilityHidden(false)
+    }
+    .labelsHidden()
+  }
+}

--- a/ios/brave-ios/Sources/BraveWallet/Settings/Web3SettingsView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Settings/Web3SettingsView.swift
@@ -136,7 +136,7 @@ private struct WalletSettingsView: View {
       footer: Text(Strings.Wallet.autoLockFooter)
         .foregroundColor(Color(.secondaryBraveLabel))
     ) {
-      Picker(selection: $settingsStore.autoLockInterval) {
+      FormPicker(selection: $settingsStore.autoLockInterval) {
         ForEach(autoLockIntervals) { interval in
           Text(interval.label)
             .foregroundColor(Color(.secondaryBraveLabel))
@@ -150,7 +150,7 @@ private struct WalletSettingsView: View {
       .listRowBackground(Color(.secondaryBraveGroupedBackground))
     }
     Section {
-      Picker(selection: $settingsStore.currencyCode) {
+      FormPicker(selection: $settingsStore.currencyCode) {
         ForEach(CurrencyCode.allCodes) { currencyCode in
           Text(currencyCode.code)
             .foregroundColor(Color(.secondaryBraveLabel))
@@ -314,7 +314,7 @@ private struct Web3DomainSettingsView: View {
   }
 
   @ViewBuilder private var ensResolveMethodPreference: some View {
-    Picker(selection: $settingsStore.ensResolveMethod) {
+    FormPicker(selection: $settingsStore.ensResolveMethod) {
       ForEach(BraveWallet.ResolveMethod.allCases) { option in
         Text(option.name)
           .foregroundColor(Color(.secondaryBraveLabel))
@@ -328,7 +328,7 @@ private struct Web3DomainSettingsView: View {
   }
 
   @ViewBuilder private var ensOffchainResolveMethodPreference: some View {
-    Picker(selection: $settingsStore.ensOffchainResolveMethod) {
+    FormPicker(selection: $settingsStore.ensOffchainResolveMethod) {
       ForEach(BraveWallet.ResolveMethod.allCases) { option in
         Text(option.name)
           .foregroundColor(Color(.secondaryBraveLabel))
@@ -355,7 +355,7 @@ private struct Web3DomainSettingsView: View {
   }
 
   @ViewBuilder private var snsResolveMethodPreference: some View {
-    Picker(selection: $settingsStore.snsResolveMethod) {
+    FormPicker(selection: $settingsStore.snsResolveMethod) {
       ForEach(BraveWallet.ResolveMethod.allCases) { option in
         Text(option.name)
           .foregroundColor(Color(.secondaryBraveLabel))
@@ -369,7 +369,7 @@ private struct Web3DomainSettingsView: View {
   }
 
   @ViewBuilder private var udResolveMethodPreference: some View {
-    Picker(selection: $settingsStore.udResolveMethod) {
+    FormPicker(selection: $settingsStore.udResolveMethod) {
       ForEach(BraveWallet.ResolveMethod.allCases) { option in
         Text(option.name)
           .foregroundColor(Color(.secondaryBraveLabel))


### PR DESCRIPTION
- Added a new `FormPicker`, updated all our `Picker`s displayed beside a label in our Settings Forms

Resolves https://github.com/brave/brave-browser/issues/49156

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

### Testplan

1. When app is build with Xcode 26, verify: 
- Shields & Privacy settings screen
- Shields panel -> Shred Site Data settings screen
- Web3 settings screen (please create or restore a wallet to see all settings available)