### PR TITLE
Attempt to fix issue w/ Wayland for our Snap

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -19,7 +19,6 @@ apps:
     extensions:
       - gnome
     environment:
-      DISABLE_WAYLAND: 1
       GTK_USE_PORTAL: 1
       BRAVE_SNAP: 1
       BRAVE_DESKTOP: brave.desktop


### PR DESCRIPTION
Ultimately, we should do better to match upstream
(see https://github.com/brave/brave-browser/issues/45357)

Upstream snap config can be seen here:
https://git.launchpad.net/~chromium-team/chromium-browser/+git/snap-from-source/tree/snapcraft.yaml

This entry being removed is not in the upstream one. Removing this should fix https://github.com/brave/brave-browser/issues/49160
