### PR TITLE
[ads] Fix NTP view counter on Android

### DIFF
--- a/android/java/org/chromium/chrome/browser/ntp_background_images/NTPBackgroundImagesBridge.java
+++ b/android/java/org/chromium/chrome/browser/ntp_background_images/NTPBackgroundImagesBridge.java
@@ -88,11 +88,6 @@ public class NTPBackgroundImagesBridge {
         }
     }
 
-    public void registerPageView() {
-        NTPBackgroundImagesBridgeJni.get().registerPageView(
-                mNativeNTPBackgroundImagesBridge, NTPBackgroundImagesBridge.this);
-    }
-
     public void wallpaperLogoClicked(Wallpaper wallpaper) {
         NTPBackgroundImagesBridgeJni.get()
                 .wallpaperLogoClicked(
@@ -189,9 +184,6 @@ public class NTPBackgroundImagesBridge {
         NTPBackgroundImagesBridge getInstance(Profile profile);
 
         NTPImage getCurrentWallpaper(
-                long nativeNTPBackgroundImagesBridge, NTPBackgroundImagesBridge caller);
-
-        void registerPageView(
                 long nativeNTPBackgroundImagesBridge, NTPBackgroundImagesBridge caller);
 
         void wallpaperLogoClicked(

--- a/android/java/org/chromium/chrome/browser/tabmodel/BraveTabCreator.java
+++ b/android/java/org/chromium/chrome/browser/tabmodel/BraveTabCreator.java
@@ -16,7 +16,6 @@ import org.chromium.chrome.browser.ChromeTabbedActivity;
 import org.chromium.chrome.browser.app.BraveActivity;
 import org.chromium.chrome.browser.compositor.CompositorViewHolder;
 import org.chromium.chrome.browser.multiwindow.MultiInstanceManager;
-import org.chromium.chrome.browser.ntp_background_images.NTPBackgroundImagesBridge;
 import org.chromium.chrome.browser.ntp_background_images.util.SponsoredImageUtil;
 import org.chromium.chrome.browser.preferences.BravePref;
 import org.chromium.chrome.browser.profiles.ProfileManager;
@@ -26,7 +25,6 @@ import org.chromium.chrome.browser.tab.TabDelegateFactory;
 import org.chromium.chrome.browser.tab.TabLaunchType;
 import org.chromium.components.embedder_support.util.UrlConstants;
 import org.chromium.components.user_prefs.UserPrefs;
-import org.chromium.content_public.browser.LoadUrlParams;
 import org.chromium.ui.base.WindowAndroid;
 
 public class BraveTabCreator extends ChromeTabCreator {
@@ -55,9 +53,9 @@ public class BraveTabCreator extends ChromeTabCreator {
     @Override
     public Tab launchUrl(String url, @TabLaunchType int type) {
         if (url.equals(UrlConstants.NTP_URL)
-                && (type == TabLaunchType.FROM_CHROME_UI || type == TabLaunchType.FROM_STARTUP
+                && (type == TabLaunchType.FROM_CHROME_UI
+                        || type == TabLaunchType.FROM_STARTUP
                         || type == TabLaunchType.FROM_TAB_SWITCHER_UI)) {
-            registerPageView();
             ChromeTabbedActivity chromeTabbedActivity = BraveActivity.getChromeTabbedActivity();
             if (chromeTabbedActivity != null && Build.VERSION.SDK_INT <= Build.VERSION_CODES.M) {
                 TabModel tabModel = chromeTabbedActivity.getCurrentTabModel();
@@ -81,19 +79,5 @@ public class BraveTabCreator extends ChromeTabCreator {
             }
         }
         return super.launchUrl(url, type);
-    }
-
-    @Override
-    public Tab createNewTab(LoadUrlParams loadUrlParams, @TabLaunchType int type, Tab parent) {
-        if (loadUrlParams.getUrl().equals(UrlConstants.NTP_URL)
-                && type == TabLaunchType.FROM_TAB_GROUP_UI) {
-            registerPageView();
-        }
-        return super.createNewTab(loadUrlParams, type, parent, null);
-    }
-
-    private void registerPageView() {
-        NTPBackgroundImagesBridge.getInstance(ProfileManager.getLastUsedRegularProfile())
-                .registerPageView();
     }
 }

--- a/browser/ntp_background/android/ntp_background_images_bridge.cc
+++ b/browser/ntp_background/android/ntp_background_images_bridge.cc
@@ -112,14 +112,6 @@ NTPBackgroundImagesBridge::GetJavaObject() {
   return base::android::ScopedJavaLocalRef<jobject>(java_object_);
 }
 
-void NTPBackgroundImagesBridge::RegisterPageView(
-    JNIEnv* env,
-    const JavaParamRef<jobject>& obj) {
-  DCHECK_CURRENTLY_ON(BrowserThread::UI);
-  if (view_counter_service_)
-    view_counter_service_->RegisterPageView();
-}
-
 void NTPBackgroundImagesBridge::WallpaperLogoClicked(
     JNIEnv* env,
     const base::android::JavaParamRef<jobject>& obj,
@@ -264,13 +256,17 @@ NTPBackgroundImagesBridge::GetCurrentWallpaper(
     JNIEnv* env,
     const JavaParamRef<jobject>& obj) {
   DCHECK_CURRENTLY_ON(BrowserThread::UI);
-
-  std::optional<base::Value::Dict> data;
-  if (view_counter_service_)
-    data = view_counter_service_->GetCurrentWallpaperForDisplay();
-
-  if (!data)
+  if (!view_counter_service_) {
     return base::android::ScopedJavaLocalRef<jobject>();
+  }
+
+  std::optional<base::Value::Dict> data =
+      view_counter_service_->GetCurrentWallpaperForDisplay();
+  if (!data) {
+    return base::android::ScopedJavaLocalRef<jobject>();
+  }
+
+  view_counter_service_->RegisterPageView();
 
   bool is_background =
       data->FindBool(ntp_background_images::kIsBackgroundKey).value_or(false);

--- a/browser/ntp_background/android/ntp_background_images_bridge.h
+++ b/browser/ntp_background/android/ntp_background_images_bridge.h
@@ -42,8 +42,6 @@ class NTPBackgroundImagesBridge : public NTPBackgroundImagesService::Observer,
       delete;
   ~NTPBackgroundImagesBridge() override;
 
-  void RegisterPageView(JNIEnv* env,
-                        const base::android::JavaParamRef<jobject>& obj);
   void WallpaperLogoClicked(
       JNIEnv* env,
       const base::android::JavaParamRef<jobject>& obj,


### PR DESCRIPTION
Changed RegisterPageView() to be called after GetCurrentWallpaperForDisplay().

## Test plan

### Test case 1
* Start browser with `reset_counter_after` parameter set to 2 minutes:
   `--enable-features=BraveNTPBrandedWallpaper:initial_count_to_branded_wallpaper/1/reset_counter_after/2m`
* Get NTT
* Wait for more than 2 minutes
* Open new NTP
   EXPECTATION: `NTT is shown`

### Test case 2
* Start browser
* Open some web page (i.e. https://brave.com)
* Close browser
* Start browser with:
   `--enable-features=BraveNTPBrandedWallpaper:initial_count_to_branded_wallpaper/1/count_to_branded_wallpaper/3`
* Wait for several seconds until Brave ads is initialized
* Open new NTP
   EXPECTATION: `NTT is shown`
* Open several NTPs
   EXPECTATION: `NTT is shown on each third NTP`

### Test case 3
* Start browser
* Open some web page (i.e. https://brave.com)
* Close browser
* Start browser with:
   `--enable-features=BraveNTPBrandedWallpaper:initial_count_to_branded_wallpaper/1/count_to_branded_wallpaper/3`
* Wait for several seconds until Brave ads is initialized
* Open new NTP
   EXPECTATION: `NTT is shown`
* Combine tabs to a Group
* Open several NTPs in the created Group
   EXPECTATION: `NTT is shown on each third NTP`

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/47689
Resolves https://github.com/brave/brave-browser/issues/49012

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
