### PR TITLE
Use rounded corners with padding when split view is active

### DIFF
--- a/browser/ui/brave_browser.cc
+++ b/browser/ui/brave_browser.cc
@@ -23,6 +23,7 @@
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
 #include "brave/browser/ui/tabs/features.h"
 #include "brave/browser/ui/tabs/public/constants.h"
+#include "brave/browser/ui/tabs/split_view_browser_data.h"
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 #include "brave/components/constants/pref_names.h"
 #include "chrome/browser/lifetime/browser_close_manager.h"
@@ -36,6 +37,7 @@
 #include "chrome/browser/ui/browser_window/public/browser_window_features.h"
 #include "chrome/browser/ui/tabs/tab_strip_model.h"
 #include "chrome/browser/ui/tabs/tab_strip_model_observer.h"
+#include "chrome/browser/ui/ui_features.h"
 #include "chrome/browser/ui/webui/new_tab_page/new_tab_page_ui.h"
 #include "chrome/browser/ui/webui/new_tab_page_third_party/new_tab_page_third_party_ui.h"
 #include "chrome/browser/ui/webui/ntp/new_tab_ui.h"
@@ -63,9 +65,41 @@ void BraveBrowser::SuppressBrowserWindowClosingDialogForTesting(bool suppress) {
 }
 
 // static
-bool BraveBrowser::ShouldUseBraveWebViewRoundedCorners(Browser* browser) {
+bool BraveBrowser::IsBraveWebViewRoundedCornersFeatureEnabled(
+    Browser* browser) {
+  // If we have prefs for toggling rounded corners in runtime, check that prefs
+  // here.
   return base::FeatureList::IsEnabled(features::kBraveWebViewRoundedCorners) &&
          browser->is_type_normal();
+}
+
+// static
+bool BraveBrowser::ShouldUseBraveWebViewRoundedCornersForContents(
+    Browser* browser) {
+  if (!browser->is_type_normal()) {
+    return false;
+  }
+
+  if (base::FeatureList::IsEnabled(features::kBraveWebViewRoundedCorners)) {
+    return true;
+  }
+
+  if (!base::FeatureList::IsEnabled(features::kSideBySide)) {
+    return false;
+  }
+
+  auto* model = browser->tab_strip_model();
+  if (model->empty()) {
+    return false;
+  }
+
+  const int active_tab_index = model->active_index();
+
+  if (active_tab_index == TabStripModel::kNoTab) {
+    return false;
+  }
+
+  return model->IsActiveTabSplit();
 }
 
 BraveBrowser::BraveBrowser(const CreateParams& params) : Browser(params) {

--- a/browser/ui/brave_browser.h
+++ b/browser/ui/brave_browser.h
@@ -25,7 +25,12 @@ class BraveBrowser : public Browser {
   BraveBrowser(const BraveBrowser&) = delete;
   BraveBrowser& operator=(const BraveBrowser&) = delete;
 
-  static bool ShouldUseBraveWebViewRoundedCorners(Browser* browser);
+  // Use for whether |browser| supports rounded corners feature or not.
+  static bool IsBraveWebViewRoundedCornersFeatureEnabled(Browser* browser);
+
+  // We use rounded corners even rounded corners feature is disabled.
+  // Call this when we want to know
+  static bool ShouldUseBraveWebViewRoundedCornersForContents(Browser* browser);
 
   // Browser overrides:
   void ScheduleUIUpdate(content::WebContents* source,

--- a/browser/ui/views/frame/brave_browser_view.h
+++ b/browser/ui/views/frame/brave_browser_view.h
@@ -141,6 +141,9 @@ class BraveBrowserView : public BrowserView,
   void OnAcceleratorsChanged(const commands::Accelerators& changed) override;
 
   BraveMultiContentsView* GetBraveMultiContentsView() const;
+  void UpdateRoundedCornersUI();
+  void UpdateVerticalTabStripBorder();
+  void UpdateSidebarBorder();
 
   SidebarContainerView* sidebar_container_view() {
     return sidebar_container_view_;

--- a/browser/ui/views/frame/brave_browser_view_layout.cc
+++ b/browser/ui/views/frame/brave_browser_view_layout.cc
@@ -282,7 +282,7 @@ void BraveBrowserViewLayout::LayoutSideBar(gfx::Rect& contents_bounds) {
   }
 
   gfx::Insets panel_margins = GetContentsMargins();
-  if (BraveBrowser::ShouldUseBraveWebViewRoundedCorners(
+  if (BraveBrowser::ShouldUseBraveWebViewRoundedCornersForContents(
           browser_view_->browser())) {
     // In rounded mode, there is already a gap between the sidebar and the main
     // contents view, so we only remove from the margin from that side (we need
@@ -372,7 +372,7 @@ void BraveBrowserViewLayout::UpdateContentsContainerInsets(
 }
 
 gfx::Insets BraveBrowserViewLayout::GetContentsMargins() const {
-  if (!BraveBrowser::ShouldUseBraveWebViewRoundedCorners(
+  if (!BraveBrowser::ShouldUseBraveWebViewRoundedCornersForContents(
           browser_view_->browser())) {
     return {};
   }

--- a/browser/ui/views/frame/brave_contents_view_util.cc
+++ b/browser/ui/views/frame/brave_contents_view_util.cc
@@ -30,7 +30,7 @@ std::unique_ptr<ViewShadow> BraveContentsViewUtil::CreateShadow(
 }
 
 int BraveContentsViewUtil::GetRoundedCornersWebViewMargin(Browser* browser) {
-  return BraveBrowser::ShouldUseBraveWebViewRoundedCorners(browser)
+  return BraveBrowser::ShouldUseBraveWebViewRoundedCornersForContents(browser)
              ? BraveContentsViewUtil::kMarginThickness
              : 0;
 }

--- a/browser/ui/views/frame/split_view/brave_contents_container_view.cc
+++ b/browser/ui/views/frame/split_view/brave_contents_container_view.cc
@@ -63,10 +63,8 @@ BraveContentsContainerView::BraveContentsContainerView(
     : ContentsContainerView(browser_view), browser_view_(*browser_view) {
 #if BUILDFLAG(ENABLE_SPEEDREADER)
   auto* browser = browser_view_->browser();
-  const bool use_rounded_corners =
-      BraveBrowser::ShouldUseBraveWebViewRoundedCorners(browser);
-  reader_mode_toolbar_ = AddChildView(std::make_unique<ReaderModeToolbarView>(
-      browser->profile(), use_rounded_corners));
+  reader_mode_toolbar_ =
+      AddChildView(std::make_unique<ReaderModeToolbarView>(browser->profile()));
   reader_mode_toolbar_->SetDelegate(this);
 #endif
 
@@ -133,6 +131,10 @@ void BraveContentsContainerView::UpdateBorderRoundedCorners() {
 
   devtools_web_view_->holder()->SetCornerRadii(contents_corner_radius);
   devtools_scrim_view_->SetRoundedCorners(contents_corner_radius);
+
+  if (reader_mode_toolbar_) {
+    reader_mode_toolbar_->SetCornerRadius(GetCornerRadius(false));
+  }
 }
 
 views::ProposedLayout BraveContentsContainerView::CalculateProposedLayout(
@@ -189,7 +191,7 @@ float BraveContentsContainerView::GetCornerRadius(bool for_border) const {
     return 0;
   }
 
-  return BraveBrowser::ShouldUseBraveWebViewRoundedCorners(
+  return BraveBrowser::ShouldUseBraveWebViewRoundedCornersForContents(
              browser_view_->browser())
              ? BraveContentsViewUtil::kBorderRadius +
                    (for_border ? kBorderThickness : 0)

--- a/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.cc
@@ -1119,7 +1119,8 @@ void BraveVerticalTabStripRegionView::UpdateBorder() {
       return false;
     }
 
-    if (!BraveBrowser::ShouldUseBraveWebViewRoundedCorners(browser_)) {
+    if (!BraveBrowser::ShouldUseBraveWebViewRoundedCornersForContents(
+            browser_)) {
       return true;
     }
 
@@ -1153,6 +1154,8 @@ void BraveVerticalTabStripRegionView::UpdateBorder() {
   } else {
     SetBorder(views::CreateEmptyBorder(border_insets));
   }
+
+  PreferredSizeChanged();
 }
 
 void BraveVerticalTabStripRegionView::OnCollapsedPrefChanged() {

--- a/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.h
+++ b/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.h
@@ -86,6 +86,7 @@ class BraveVerticalTabStripRegionView : public views::View,
   void UpdateNewTabButtonVisibility();
 
   int GetTabStripViewportMaxHeight() const;
+  void UpdateBorder();
 
   void ResetExpandedWidth();
   bool IsMenuShowing() const;
@@ -151,8 +152,6 @@ class BraveVerticalTabStripRegionView : public views::View,
   void OnBrowserPanelsMoved();
 
   void UpdateLayout(bool in_destruction = false);
-
-  void UpdateBorder();
 
   void OnCollapsedPrefChanged();
   void OnFloatingModePrefChanged();

--- a/browser/ui/views/side_panel/brave_side_panel.cc
+++ b/browser/ui/views/side_panel/brave_side_panel.cc
@@ -73,13 +73,6 @@ BraveSidePanel::BraveSidePanel(BrowserView* browser_view,
     CHECK_IS_TEST();
   }
 
-  if (BraveBrowser::ShouldUseBraveWebViewRoundedCorners(
-          browser_view_->browser())) {
-    shadow_ = BraveContentsViewUtil::CreateShadow(this);
-    SetBackground(
-        views::CreateSolidBackground(kColorSidebarPanelHeaderBackground));
-  }
-
   content_parent_view_ = AddChildView(std::make_unique<ContentParentView>());
   content_parent_view_->SetVisible(false);
 }
@@ -110,13 +103,23 @@ bool BraveSidePanel::IsRightAligned() {
 }
 
 void BraveSidePanel::UpdateBorder() {
-  if (BraveBrowser::ShouldUseBraveWebViewRoundedCorners(
+  // Border and shadow should be updated together when rounded corner enabled
+  // condition is changed.
+  if (BraveBrowser::ShouldUseBraveWebViewRoundedCornersForContents(
           browser_view_->browser())) {
     // Use a negative top border to hide the separator inserted by the upstream
     // side panel implementation.
     SetBorder(views::CreateEmptyBorder(gfx::Insets::TLBR(-1, 0, 0, 0)));
+
+    shadow_ = BraveContentsViewUtil::CreateShadow(this);
+    SetBackground(
+        views::CreateSolidBackground(kColorSidebarPanelHeaderBackground));
+
     return;
   }
+
+  shadow_.reset();
+  SetBackground(nullptr);
 
   if (const ui::ColorProvider* color_provider = GetColorProvider()) {
     constexpr int kBorderThickness = 1;

--- a/browser/ui/views/side_panel/brave_side_panel.h
+++ b/browser/ui/views/side_panel/brave_side_panel.h
@@ -83,6 +83,8 @@ class BraveSidePanel : public views::View,
   void Open(bool animated);
   void Close(bool animated);
 
+  void UpdateBorder();
+
   // This is the parent view for the contents of the side panel.
   views::View* GetContentParentView();
 
@@ -98,7 +100,6 @@ class BraveSidePanel : public views::View,
   void OnChildViewAdded(View* observed_view, View* child) override;
   void OnChildViewRemoved(View* observed_view, View* child) override;
 
-  void UpdateBorder();
   void OnSidePanelWidthChanged();
 
   // Monitors addition of content view and change content view property that

--- a/browser/ui/views/sidebar/sidebar_container_view.cc
+++ b/browser/ui/views/sidebar/sidebar_container_view.cc
@@ -193,8 +193,9 @@ bool SidebarContainerView::PreHandleMouseEvent(
 
   // Detect bounds should include rounded corners margin to make sidebar
   // visible from that padding also.
-  mouse_event_detect_bounds.Outset(
-      BraveContentsViewUtil::GetRoundedCornersWebViewMargin(browser_));
+  const auto web_view_margin =
+      BraveContentsViewUtil::GetRoundedCornersWebViewMargin(browser_);
+  mouse_event_detect_bounds.Outset(web_view_margin);
   constexpr int kHotCornerWidth = 7;
   const int inset = mouse_event_detect_bounds.width() - kHotCornerWidth;
   if (sidebar_on_left_) {
@@ -256,6 +257,10 @@ bool SidebarContainerView::IsFullscreenForCurrentEntry() const {
   }
 
   return false;
+}
+
+void SidebarContainerView::UpdateBorder() {
+  sidebar_control_view_->UpdateBackgroundAndBorder();
 }
 
 void SidebarContainerView::SetSidebarShowOption(ShowSidebarOption show_option) {

--- a/browser/ui/views/sidebar/sidebar_container_view.h
+++ b/browser/ui/views/sidebar/sidebar_container_view.h
@@ -85,6 +85,7 @@ class SidebarContainerView
   // is called whether it's closing from deregistration.
   void WillShowSidePanel();
   bool IsFullscreenForCurrentEntry() const;
+  void UpdateBorder();
 
   void set_operation_from_active_tab_change(bool tab_change) {
     operation_from_active_tab_change_ = tab_change;

--- a/browser/ui/views/sidebar/sidebar_control_view.h
+++ b/browser/ui/views/sidebar/sidebar_control_view.h
@@ -76,6 +76,7 @@ class SidebarControlView : public views::View,
   bool IsItemReorderingInProgress() const;
   bool IsBubbleWidgetVisible() const;
   void SetSidebarOnLeft(bool sidebar_on_left);
+  void UpdateBackgroundAndBorder();
 
  private:
   friend class sidebar::SidebarBrowserTest;
@@ -87,7 +88,6 @@ class SidebarControlView : public views::View,
   // is NTP.
   void UpdateItemAddButtonState();
   void UpdateSettingsButtonState();
-  void UpdateBackgroundAndBorder();
 
   bool sidebar_on_left_ = true;
   raw_ptr<Delegate> delegate_ = nullptr;

--- a/browser/ui/views/speedreader/reader_mode_toolbar_view.h
+++ b/browser/ui/views/speedreader/reader_mode_toolbar_view.h
@@ -9,6 +9,7 @@
 #include <memory>
 
 #include "ui/base/metadata/metadata_header_macros.h"
+#include "ui/gfx/geometry/rounded_corners_f.h"
 #include "ui/views/controls/webview/webview.h"
 
 namespace content {
@@ -24,8 +25,7 @@ class ReaderModeToolbarView : public views::View {
     virtual void OnReaderModeToolbarActivate(ReaderModeToolbarView* toolbar) {}
   };
 
-  ReaderModeToolbarView(content::BrowserContext* browser_context,
-                        bool use_rounded_corners);
+  explicit ReaderModeToolbarView(content::BrowserContext* browser_context);
   ~ReaderModeToolbarView() override;
 
   ReaderModeToolbarView(const ReaderModeToolbarView&) = delete;
@@ -42,16 +42,20 @@ class ReaderModeToolbarView : public views::View {
   void SetDelegate(Delegate* delegate);
   void SwapToolbarContents(ReaderModeToolbarView* toolbar);
   void RestoreToolbarContents(ReaderModeToolbarView* toolbar);
-
+  void SetCornerRadius(int radius);
   void ActivateContents();
 
  private:
+  FRIEND_TEST_ALL_PREFIXES(SpeedReaderBrowserTest, ToolbarWithRoundedCorners);
+
   gfx::Size CalculatePreferredSize(
       const views::SizeBounds& available_size) const override;
   void OnBoundsChanged(const gfx::Rect& previous_bounds) override;
   bool OnMousePressed(const ui::MouseEvent& event) override;
 
-  bool use_rounded_corners_ = false;
+  void UpdateBorderAndBackground();
+
+  gfx::RoundedCornersF rounded_corners_;
   std::unique_ptr<views::WebView> toolbar_;
   std::unique_ptr<content::WebContents> toolbar_contents_;
   raw_ptr<Delegate> delegate_ = nullptr;

--- a/browser/ui/views/split_view/split_view.cc
+++ b/browser/ui/views/split_view/split_view.cc
@@ -429,7 +429,7 @@ void SplitView::UpdateContentsWebViewBorder() {
   if (split_view_browser_data->GetTile(GetActiveTabHandle()) &&
       !ShouldHideSecondaryContentsByTabFullscreen()) {
     const auto kRadius =
-        BraveBrowser::ShouldUseBraveWebViewRoundedCorners(
+        BraveBrowser::ShouldUseBraveWebViewRoundedCornersForContents(
             base::to_address(browser_))
             ? BraveContentsViewUtil::kBorderRadius + kBorderThickness
             : 0;

--- a/browser/ui/webui/speedreader/speedreader_toolbar_data_handler_impl.cc
+++ b/browser/ui/webui/speedreader/speedreader_toolbar_data_handler_impl.cc
@@ -271,6 +271,16 @@ void SpeedreaderToolbarDataHandlerImpl::OnTabStripModelChanged(
       tab_helper_observation_.Observe(active_tab_helper_);
       events_->SetPlaybackState(GetTabPlaybackState());
     }
+
+    UpdateToolbarTheme();
+  }
+}
+
+void SpeedreaderToolbarDataHandlerImpl::OnSplitTabChanged(
+    const SplitTabChange& change) {
+  if (change.type == SplitTabChange::Type::kAdded ||
+      change.type == SplitTabChange::Type::kRemoved) {
+    UpdateToolbarTheme();
   }
 }
 
@@ -280,33 +290,7 @@ bool SpeedreaderToolbarDataHandlerImpl::ShouldTrackBrowser(
 }
 
 void SpeedreaderToolbarDataHandlerImpl::OnThemeChanged() {
-  const auto* color_provider = browser_->window()->GetColorProvider();
-  if (!color_provider) {
-    return;
-  }
-
-  auto colors = speedreader::mojom::ToolbarColors::New();
-  colors->background =
-      color_provider->GetColor(kColorSpeedreaderToolbarBackground);
-  colors->foreground =
-      color_provider->GetColor(kColorSpeedreaderToolbarForeground);
-  colors->border = color_provider->GetColor(kColorSpeedreaderToolbarBorder);
-  if (BraveBrowser::ShouldUseBraveWebViewRoundedCorners(browser_)) {
-    // The border is rendered in HTML. Hide the border by giving it the same
-    // color as the background. When this feature flag is removed, consider
-    // removing the border in HTML.
-    colors->border =
-        color_provider->GetColor(kColorSpeedreaderToolbarBackground);
-  }
-  colors->button_hover =
-      color_provider->GetColor(kColorSpeedreaderToolbarButtonHover);
-  colors->button_active =
-      color_provider->GetColor(kColorSpeedreaderToolbarButtonActive);
-  colors->button_active_text =
-      color_provider->GetColor(kColorSpeedreaderToolbarButtonActiveText);
-  colors->button_border =
-      color_provider->GetColor(kColorSpeedreaderToolbarButtonBorder);
-  events_->OnBrowserThemeChanged(std::move(colors));
+  UpdateToolbarTheme();
 }
 
 void SpeedreaderToolbarDataHandlerImpl::OnNativeThemeUpdated(
@@ -330,4 +314,34 @@ void SpeedreaderToolbarDataHandlerImpl::OnContentsReady() {
   if (active_tab_helper_) {
     active_tab_helper_->OnToolbarStateChanged(current_button_);
   }
+}
+
+void SpeedreaderToolbarDataHandlerImpl::UpdateToolbarTheme() {
+  const auto* color_provider = browser_->window()->GetColorProvider();
+  if (!color_provider) {
+    return;
+  }
+
+  auto colors = speedreader::mojom::ToolbarColors::New();
+  colors->background =
+      color_provider->GetColor(kColorSpeedreaderToolbarBackground);
+  colors->foreground =
+      color_provider->GetColor(kColorSpeedreaderToolbarForeground);
+  colors->border = color_provider->GetColor(kColorToolbarContentAreaSeparator);
+  if (BraveBrowser::ShouldUseBraveWebViewRoundedCornersForContents(browser_)) {
+    // The border is rendered in HTML. Hide the border by giving it the same
+    // color as the background. When this feature flag is removed, consider
+    // removing the border in HTML.
+    colors->border =
+        color_provider->GetColor(kColorSpeedreaderToolbarBackground);
+  }
+  colors->button_hover =
+      color_provider->GetColor(kColorSpeedreaderToolbarButtonHover);
+  colors->button_active =
+      color_provider->GetColor(kColorSpeedreaderToolbarButtonActive);
+  colors->button_active_text =
+      color_provider->GetColor(kColorSpeedreaderToolbarButtonActiveText);
+  colors->button_border =
+      color_provider->GetColor(kColorSpeedreaderToolbarButtonBorder);
+  events_->OnBrowserThemeChanged(std::move(colors));
 }

--- a/browser/ui/webui/speedreader/speedreader_toolbar_data_handler_impl.h
+++ b/browser/ui/webui/speedreader/speedreader_toolbar_data_handler_impl.h
@@ -93,6 +93,7 @@ class SpeedreaderToolbarDataHandlerImpl
       TabStripModel* tab_strip_model,
       const TabStripModelChange& change,
       const TabStripSelectionChange& selection) override;
+  void OnSplitTabChanged(const SplitTabChange& change) override;
 
   // BrowserTabStripTrackerDelegate:
   bool ShouldTrackBrowser(BrowserWindowInterface* browser) override;
@@ -106,6 +107,11 @@ class SpeedreaderToolbarDataHandlerImpl
   // speedreader::SpeedreaderTabHelper::Observer:
   void OnTuneBubbleClosed() override;
   void OnContentsReady() override;
+
+  // Need to call whenever active tab's split view state is changed.
+  // Whenever active tab's split view state changed, reader mode
+  // toolbar's bottom border should be updated.
+  void UpdateToolbarTheme();
 
   raw_ptr<Browser> browser_ = nullptr;
   mojo::Receiver<speedreader::mojom::ToolbarDataHandler> receiver_;


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/49204

When split view is active, apply rounded corner and contents padding.
There is no behavioral change if rounded corners feature is on.
After this PR, we could have settings option for toggle rounded corners in runtime.

TEST=SpeedReaderBrowserTest.ToolbarWithRoundedCorners
BraveBrowserViewWithRoundedCornersTest.RoundedCornersForContentsTest

Manual test:
1. Launch Brave after disabling rounded corners feature
2. Open split view and rounded corner is shown
3. Create active NTP and check no rounded corners


https://github.com/user-attachments/assets/789b115a-755c-47c6-b8d8-262f233f0ae3


<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
