### PR TITLE
Fix JS flags passthrough in RenderProcessHostImpl

### DIFF
--- a/patches/content-browser-renderer_host-render_process_host_impl.cc.patch
+++ b/patches/content-browser-renderer_host-render_process_host_impl.cc.patch
@@ -1,0 +1,50 @@
+diff --git a/content/browser/renderer_host/render_process_host_impl.cc b/content/browser/renderer_host/render_process_host_impl.cc
+index 3f7b3f4bc3a26954781a4db58e0b301c686f7fad..0df28ee900dced6eb1f9ad1d09e252336f0fc348 100644
+--- a/content/browser/renderer_host/render_process_host_impl.cc
++++ b/content/browser/renderer_host/render_process_host_impl.cc
+@@ -54,6 +54,7 @@
+ #include "base/observer_list.h"
+ #include "base/process/process_handle.h"
+ #include "base/rand_util.h"
++#include "base/strings/strcat.h"
+ #include "base/strings/string_number_conversions.h"
+ #include "base/strings/string_util.h"
+ #include "base/strings/stringprintf.h"
+@@ -1335,6 +1336,20 @@ void RecordMissedReuseOpportunityMetric(
+       site_instance->GetBrowserContext());
+ }
+ 
++// Appends a `new_value` to a command-line switch that holds a comma-separated
++// list of values.
++void AppendToCommaSeparatedSwitch(base::CommandLine* command_line,
++                                  const std::string& switch_name,
++                                  const std::string& new_value) {
++  const std::string existing_values =
++      command_line->GetSwitchValueASCII(switch_name);
++  command_line->RemoveSwitch(switch_name);
++  command_line->AppendSwitchASCII(
++      switch_name, existing_values.empty()
++                       ? new_value
++                       : base::StrCat({existing_values, ",", new_value}));
++}
++
+ }  // namespace
+ 
+ RenderProcessHostImpl::IOThreadHostImpl::IOThreadHostImpl(
+@@ -3423,11 +3438,12 @@ void RenderProcessHostImpl::AppendRendererCommandLine(
+   }
+ 
+   if (IsJitDisabled()) {
+-    command_line->AppendSwitchASCII(blink::switches::kJavaScriptFlags,
+-                                    "--jitless");
++    AppendToCommaSeparatedSwitch(
++        command_line, blink::switches::kJavaScriptFlags, "--jitless");
+   } else if (AreV8OptimizationsDisabled()) {
+-    command_line->AppendSwitchASCII(blink::switches::kJavaScriptFlags,
+-                                    "--disable-optimizing-compilers");
++    AppendToCommaSeparatedSwitch(command_line,
++                                 blink::switches::kJavaScriptFlags,
++                                 "--disable-optimizing-compilers");
+   }
+ 
+   if (DisallowV8FeatureFlagOverrides()) {


### PR DESCRIPTION
Properly combine existing JavaScript flags with new flags instead of overwriting them. This ensures that flags passed via command line are preserved when adding internal flags like --jitless or --disable-optimizing-compilers.

Change-Id: https://chromium-review.googlesource.com/q/Ic1723cbb9a40adecefe8ca3f492ce004a7917abb
Bug: https://issues.chromium.org/issues/442950572

Relates to: https://github.com/brave/brave-core/pull/30703

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
