### PR TITLE
Updated vertical tab strip bottom corner radius per macOS version (uplift to 1.82.x)

### DIFF
--- a/browser/ui/views/frame/vertical_tabs/BUILD.gn
+++ b/browser/ui/views/frame/vertical_tabs/BUILD.gn
@@ -17,7 +17,10 @@ source_set("vertical_tabs") {
   ]
 
   if (is_mac) {
-    sources += [ "vertical_tab_strip_region_view_mac.mm" ]
+    sources += [
+      "vertical_tab_strip_region_view_mac.mm",
+      "vertical_tab_strip_widget_delegate_view_mac.mm",
+    ]
   }
   deps = [
     "//base",

--- a/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.cc
@@ -1124,10 +1124,8 @@ void VerticalTabStripRegionView::UpdateBorder() {
       (sidebar_on_same_side
            ? 0
            : BraveContentsViewUtil::GetRoundedCornersWebViewMargin(browser_));
-  gfx::Insets border_insets =
-      (is_on_right)
-          ? gfx::Insets::TLBR(0, inset, tabs::kVerticalTabsSpacing, 0)
-          : gfx::Insets::TLBR(0, 0, tabs::kVerticalTabsSpacing, inset);
+  gfx::Insets border_insets = (is_on_right) ? gfx::Insets::TLBR(0, inset, 0, 0)
+                                            : gfx::Insets::TLBR(0, 0, 0, inset);
 
   if (show_visible_border()) {
     SetBorder(views::CreateSolidSidedBorder(

--- a/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_widget_delegate_view.cc
+++ b/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_widget_delegate_view.cc
@@ -226,25 +226,22 @@ void VerticalTabStripWidgetDelegateView::OnWidgetDestroying(
 void VerticalTabStripWidgetDelegateView::UpdateClip() {
   // On mac, child window can be drawn out of parent window. We should clip
   // the border line and corner radius manually.
-  // The corner radius value refers to the that of menu widget. Looks fit for
-  // us.
-  // https://github.com/chromium/chromium/blob/371d67fd9c7db16c32f22e3ba247a07aa5e81487/ui/views/controls/menu/menu_config_mac.mm#L35
   SkPath path;
-  constexpr int kCornerRadius = 8;
+  const int corner_radius = GetVerticalTabStripCornerRadiusMac();
   if (tabs::utils::IsVerticalTabOnRight(browser_view_->browser())) {
     path.moveTo(width(), 0);
     path.lineTo(0, 0);
     path.lineTo(0, height() - 1);
-    path.lineTo(width() - kCornerRadius, height() - 1);
-    path.rArcTo(kCornerRadius, kCornerRadius, 0, SkPath::kSmall_ArcSize,
-                SkPathDirection::kCCW, kCornerRadius, -kCornerRadius);
+    path.lineTo(width() - corner_radius, height() - 1);
+    path.rArcTo(corner_radius, corner_radius, 0, SkPath::kSmall_ArcSize,
+                SkPathDirection::kCCW, corner_radius, -corner_radius);
   } else {
     path.moveTo(0, 0);
     path.lineTo(width(), 0);
     path.lineTo(width(), height() - 1);
-    path.lineTo(kCornerRadius, height() - 1);
-    path.rArcTo(kCornerRadius, kCornerRadius, 0, SkPath::kSmall_ArcSize,
-                SkPathDirection::kCW, -kCornerRadius, -kCornerRadius);
+    path.lineTo(corner_radius, height() - 1);
+    path.rArcTo(corner_radius, corner_radius, 0, SkPath::kSmall_ArcSize,
+                SkPathDirection::kCW, -corner_radius, -corner_radius);
   }
   path.close();
   SetClipPath(path);

--- a/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_widget_delegate_view.h
+++ b/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_widget_delegate_view.h
@@ -70,6 +70,7 @@ class VerticalTabStripWidgetDelegateView : public views::WidgetDelegateView,
 
 #if BUILDFLAG(IS_MAC)
   void UpdateClip();
+  int GetVerticalTabStripCornerRadiusMac() const;
 #endif
 
   raw_ptr<BrowserView> browser_view_ = nullptr;

--- a/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_widget_delegate_view_mac.mm
+++ b/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_widget_delegate_view_mac.mm
@@ -1,0 +1,14 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_widget_delegate_view.h"
+
+int VerticalTabStripWidgetDelegateView::GetVerticalTabStripCornerRadiusMac()
+    const {
+  if (@available(macOS 26, *)) {
+    return 20;
+  }
+  return 8;
+}


### PR DESCRIPTION
Uplift of #31147
Resolves https://github.com/brave/brave-browser/issues/49171

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.