### PR TITLE
[ads] Fix iOS NTT are not shown after clearing ads data (uplift to 1.83.x)

### DIFF
--- a/ios/browser/brave_ads/ads_service_impl_ios.h
+++ b/ios/browser/brave_ads/ads_service_impl_ios.h
@@ -57,6 +57,10 @@ class AdsServiceImplIOS : public AdsService {
       mojom::NotificationAdEventType mojom_ad_event_type,
       TriggerAdEventCallback callback);
 
+  void NotifyDidInitializeAdsService() const;
+  void NotifyDidShutdownAdsService() const;
+  void NotifyDidClearAdsServiceData() const;
+
   // AdsService:
   bool IsBrowserUpgradeRequiredToServeAds() const override;
 

--- a/ios/browser/brave_ads/ads_service_impl_ios.mm
+++ b/ios/browser/brave_ads/ads_service_impl_ios.mm
@@ -109,6 +109,24 @@ void AdsServiceImplIOS::TriggerNotificationAdEvent(
                                    std::move(callback));
 }
 
+void AdsServiceImplIOS::NotifyDidInitializeAdsService() const {
+  for (AdsServiceObserver& observer : observers_) {
+    observer.OnDidInitializeAdsService();
+  }
+}
+
+void AdsServiceImplIOS::NotifyDidShutdownAdsService() const {
+  for (AdsServiceObserver& observer : observers_) {
+    observer.OnDidShutdownAdsService();
+  }
+}
+
+void AdsServiceImplIOS::NotifyDidClearAdsServiceData() const {
+  for (AdsServiceObserver& observer : observers_) {
+    observer.OnDidClearAdsServiceData();
+  }
+}
+
 bool AdsServiceImplIOS::IsBrowserUpgradeRequiredToServeAds() const {
   return false;
 }
@@ -476,6 +494,8 @@ void AdsServiceImplIOS::NotifyDidSolveAdaptiveCaptcha() {
 void AdsServiceImplIOS::Shutdown() {
   ResetNewTabPageAd();
 
+  NotifyDidShutdownAdsService();
+
   ads_.reset();
 }
 
@@ -499,6 +519,8 @@ void AdsServiceImplIOS::InitializeAdsCallback(InitializeCallback callback,
                                               bool success) {
   if (!success) {
     Shutdown();
+  } else {
+    NotifyDidInitializeAdsService();
   }
 
   task_queue_.FlushAndStopQueueing();
@@ -539,6 +561,7 @@ void AdsServiceImplIOS::ClearAdsData(ClearDataCallback callback, bool success) {
 }
 
 void AdsServiceImplIOS::ClearAdsDataCallback(ClearDataCallback callback) {
+  NotifyDidClearAdsServiceData();
   InitializeAds(std::move(callback));
 }
 


### PR DESCRIPTION
Uplift of #31173
Resolves https://github.com/brave/brave-browser/issues/44966

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.