### PR TITLE
Set renderer size in backup results service (uplift to 1.82.x)

### DIFF
--- a/browser/brave_search/backup_results_service_impl.cc
+++ b/browser/brave_search/backup_results_service_impl.cc
@@ -9,6 +9,7 @@
 #include <utility>
 
 #include "base/functional/bind.h"
+#include "base/rand_util.h"
 #include "brave/components/brave_search/browser/backup_results_allowed_urls.h"
 #include "brave/components/brave_search/browser/backup_results_service.h"
 #include "brave/components/brave_search/common/features.h"
@@ -139,6 +140,11 @@ void BackupResultsServiceImpl::FetchBackupResults(
   if (should_render) {
     auto create_params = content::WebContents::CreateParams(otr_profile);
     web_contents = content::WebContents::Create(create_params);
+
+    int random_width = base::RandInt(800, 1920);
+    int random_height = base::RandInt(600, 1080);
+    web_contents->Resize({random_width, random_height});
+
     auto web_preferences = web_contents->GetOrCreateWebPreferences();
     web_preferences.supports_multiple_windows = false;
     web_contents->SetWebPreferences(web_preferences);


### PR DESCRIPTION
Uplift of #31142
Resolves https://github.com/brave/brave-browser/issues/49165
Resolves https://github.com/brave/internal/issues/1464

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.