### PR TITLE
Add pref to control "Hide vertical tabs completely when minimized" feature

### DIFF
--- a/app/brave_settings_strings.grdp
+++ b/app/brave_settings_strings.grdp
@@ -157,7 +157,7 @@
     Show title bar
   </message>
   <message name="IDS_SETTINGS_APPEARANCE_SETTINGS_TABS_HIDE_COMPLETELY_WHEN_COLLPASED" desc="The label for hiding vertical tabs completely when collapsed" formatter_data="webui=BraveSettings">
-    Hide completely when collapsed
+    Hide completely when minimized
   </message>
   <message name="IDS_SETTINGS_APPEARANCE_SETTINGS_TABS_USE_FLOATING_VERTICAL_TABS" desc="The label for enabling floating mode for vertical tab strip">
     Expand vertical tabs panel on mouseover when collapsed

--- a/app/brave_settings_strings.grdp
+++ b/app/brave_settings_strings.grdp
@@ -160,7 +160,7 @@
     Hide completely when minimized
   </message>
   <message name="IDS_SETTINGS_APPEARANCE_SETTINGS_TABS_USE_FLOATING_VERTICAL_TABS" desc="The label for enabling floating mode for vertical tab strip">
-    Expand vertical tabs panel on mouseover when collapsed
+    Expand vertical tabs panel on mouseover when minimized
   </message>
   <message name="IDS_SETTINGS_APPEARANCE_SETTINGS_BRAVE_TAB_HOVER_MODE" desc="The label for the settings select controlling what happens when a user hovers over a tab.">
     Tab hover mode

--- a/app/brave_settings_strings.grdp
+++ b/app/brave_settings_strings.grdp
@@ -156,6 +156,9 @@
   <message name="IDS_SETTINGS_APPEARANCE_SETTINGS_TABS_SHOW_TITLE_BAR" desc="The label for showing window title when vertical tab strip is enabled.">
     Show title bar
   </message>
+  <message name="IDS_SETTINGS_APPEARANCE_SETTINGS_TABS_HIDE_COMPLETELY_WHEN_COLLPASED" desc="The label for hiding vertical tabs completely when collapsed" formatter_data="webui=BraveSettings">
+    Hide completely when collapsed
+  </message>
   <message name="IDS_SETTINGS_APPEARANCE_SETTINGS_TABS_USE_FLOATING_VERTICAL_TABS" desc="The label for enabling floating mode for vertical tab strip">
     Expand vertical tabs panel on mouseover when collapsed
   </message>

--- a/browser/extensions/api/settings_private/brave_prefs_util.cc
+++ b/browser/extensions/api/settings_private/brave_prefs_util.cc
@@ -321,6 +321,8 @@ const PrefsUtil::TypedPrefMap& BravePrefsUtil::GetAllowlistedKeys() {
       settings_api::PrefType::kBoolean;
   (*s_brave_allowlist)[brave_tabs::kVerticalTabsExpandedStatePerWindow] =
       settings_api::PrefType::kBoolean;
+  (*s_brave_allowlist)[brave_tabs::kVerticalTabsHideCompletelyWhenCollapsed] =
+      settings_api::PrefType::kBoolean;
 #endif
 
 #if BUILDFLAG(ENABLE_PLAYLIST)

--- a/browser/resources/settings/brave_appearance_page/tabs.html
+++ b/browser/resources/settings/brave_appearance_page/tabs.html
@@ -20,11 +20,39 @@
       pref="{{prefs.brave.tabs.vertical_tabs_show_title_on_window}}"
       label="$i18n{appearanceSettingsTabsShowWindowTitle}">
     </settings-checkbox>
-    <settings-checkbox
-      class="list-item"
-      pref="{{prefs.brave.tabs.vertical_tabs_floating_enabled}}"
-      label="$i18n{appearanceSettingsTabsFloatOnMouseOver}">
-    </settings-checkbox>
+    <template is="dom-if" if="[[isHideVerticalTabCompletelyFlagEnabled()]]">
+      <settings-checkbox
+        class="list-item"
+        pref="{{prefs.brave.tabs.vertical_tabs_hide_completely_when_collapsed}}"
+        label="$i18n{SETTINGS_APPEARANCE_SETTINGS_TABS_HIDE_COMPLETELY_WHEN_COLLPASED}">
+      </settings-checkbox>
+      <template is="dom-if" if="[[prefs.brave.tabs.vertical_tabs_hide_completely_when_collapsed.value]]">
+        <!-- Show always checked and disabled checkbox. When 
+             vertical_tabs_hide_completely_when_collapsed is true
+             "Float on mouse over" is always enabled -->
+        <settings-checkbox
+          class="list-item"
+          disabled="true"
+          no-set-pref
+          pref="{{prefs.brave.tabs.vertical_tabs_hide_completely_when_collapsed}}"
+          label="$i18n{appearanceSettingsTabsFloatOnMouseOver}">
+        </settings-checkbox>
+      </template>
+      <template is="dom-if" if="[[!prefs.brave.tabs.vertical_tabs_hide_completely_when_collapsed.value]]">
+        <settings-checkbox
+          class="list-item"
+          pref="{{prefs.brave.tabs.vertical_tabs_floating_enabled}}"
+          label="$i18n{appearanceSettingsTabsFloatOnMouseOver}">
+        </settings-checkbox>
+      </template>
+    </template>
+    <template is="dom-if" if="[[!isHideVerticalTabCompletelyFlagEnabled()]]">
+      <settings-checkbox
+        class="list-item"
+        pref="{{prefs.brave.tabs.vertical_tabs_floating_enabled}}"
+        label="$i18n{appearanceSettingsTabsFloatOnMouseOver}">
+      </settings-checkbox>
+    </template>
     <settings-checkbox
       class="list-item"
       pref="{{prefs.brave.tabs.vertical_tabs_expanded_state_per_window}}"

--- a/browser/resources/settings/brave_appearance_page/tabs.ts
+++ b/browser/resources/settings/brave_appearance_page/tabs.ts
@@ -69,6 +69,10 @@ export class SettingsBraveAppearanceTabsElement extends SettingsBraveAppearanceT
   private isTreeTabsFlagEnabled() {
     return loadTimeData.getBoolean('isTreeTabsFlagEnabled');
   }
+
+  private isHideVerticalTabCompletelyFlagEnabled() {
+    return loadTimeData.getBoolean('isHideVerticalTabCompletelyFlagEnabled');
+  }
 }
 
 customElements.define(SettingsBraveAppearanceTabsElement.is, SettingsBraveAppearanceTabsElement)

--- a/browser/ui/tabs/brave_tab_prefs.cc
+++ b/browser/ui/tabs/brave_tab_prefs.cc
@@ -23,6 +23,13 @@ void RegisterBraveProfilePrefs(PrefRegistrySimple* registry) {
 #else
   registry->RegisterBooleanPref(kVerticalTabsShowTitleOnWindow, false);
 #endif
+
+  if (base::FeatureList::IsEnabled(
+          tabs::features::kBraveVerticalTabHideCompletely)) {
+    registry->RegisterBooleanPref(kVerticalTabsHideCompletelyWhenCollapsed,
+                                  false);
+  }
+
   registry->RegisterBooleanPref(kVerticalTabsFloatingEnabled, true);
   registry->RegisterIntegerPref(kVerticalTabsExpandedWidth, 220);
   registry->RegisterBooleanPref(kVerticalTabsOnRight, false);

--- a/browser/ui/tabs/brave_tab_prefs.h
+++ b/browser/ui/tabs/brave_tab_prefs.h
@@ -23,6 +23,8 @@ inline constexpr char kVerticalTabsExpandedStatePerWindow[] =
     "brave.tabs.vertical_tabs_expanded_state_per_window";
 inline constexpr char kVerticalTabsShowTitleOnWindow[] =
     "brave.tabs.vertical_tabs_show_title_on_window";
+inline constexpr char kVerticalTabsHideCompletelyWhenCollapsed[] =
+    "brave.tabs.vertical_tabs_hide_completely_when_collapsed";
 inline constexpr char kVerticalTabsFloatingEnabled[] =
     "brave.tabs.vertical_tabs_floating_enabled";
 inline constexpr char kVerticalTabsExpandedWidth[] =

--- a/browser/ui/webui/brave_settings_ui.cc
+++ b/browser/ui/webui/brave_settings_ui.cc
@@ -245,6 +245,9 @@ void BraveSettingsUI::AddResources(content::WebUIDataSource* html_source,
       base::FeatureList::IsEnabled(tabs::features::kBraveTreeTab));
   html_source->AddString("braveSearchEngineName",
                          TemplateURLPrepopulateData::brave_search.name);
+  html_source->AddBoolean("isHideVerticalTabCompletelyFlagEnabled",
+                          base::FeatureList::IsEnabled(
+                              tabs::features::kBraveVerticalTabHideCompletely));
 }
 
 // static


### PR DESCRIPTION
This PR adds a new preference to control the "Hide vertical tabs completely when collapsed" feature.

<img width="721" height="332" alt="image" src="https://github.com/user-attachments/assets/34bb9398-87c0-41f6-bb3c-ade17e0c84d3" />

<!-- Add brave-browser issue below that this PR will resolve -->
part of https://github.com/brave/brave-browser/issues/49115

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
