### PR TITLE
Intermittent browser test failures (uplift to 1.83.x)

### DIFF
--- a/components/brave_wallet/browser/android_page_appearing_browsertest.cc
+++ b/components/brave_wallet/browser/android_page_appearing_browsertest.cc
@@ -399,7 +399,8 @@ IN_PROC_BROWSER_TEST_F(AndroidPageAppearingBrowserTest,
   }
 }
 
-IN_PROC_BROWSER_TEST_F(AndroidPageAppearingBrowserTest, TestSwapPageAppearing) {
+IN_PROC_BROWSER_TEST_F(AndroidPageAppearingBrowserTest,
+                       DISABLED_TestSwapPageAppearing) {
   const GURL expected_url = GURL("brave://wallet/swap");
   for (auto scheme : GetWebUISchemes()) {
     GURL url = GURL(base::StrCat({scheme, "wallet/swap"}));


### PR DESCRIPTION
Uplift of #31151
Resolves https://github.com/brave/brave-browser/issues/49175

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.