### PR TITLE
[iOS] Bump default simulator versions used for testing

### DIFF
--- a/build/commands/scripts/commands.js
+++ b/build/commands/scripts/commands.js
@@ -408,7 +408,7 @@ program
   .option(
     '--ios_simulator_platform <simulator_platform>',
     'platform to use for ios simulator',
-    'iPhone 16',
+    'iPhone 17',
   )
   .option(
     '--ios_simulator_version <simulator_version>',

--- a/ios/brave-ios/fastlane/Fastfile
+++ b/ios/brave-ios/fastlane/Fastfile
@@ -172,7 +172,7 @@ platform :ios do
     {
       project: "App/Client.xcodeproj",
       scheme: "Debug (No Core)",
-      devices: ["iPhone 16 (26.0)"],
+      devices: ["iPhone 17 (26.0)"],
       code_coverage: true,
       output_types: "junit",
       output_files: "junit.xml",


### PR DESCRIPTION
CI now has Xcode 26 installed on all nodes, so we should update the default simulators that run unit tests

Resolves https://github.com/brave/brave-browser/issues/49567