### PR TITLE
feat(wallet): New Confirm Send Panel UI

### DIFF
--- a/components/brave_wallet/browser/brave_wallet_constants.h
+++ b/components/brave_wallet/browser/brave_wallet_constants.h
@@ -419,6 +419,7 @@ inline constexpr webui::LocalizedString kLocalizedStrings[] = {
     {"braveWalletSortBy", IDS_BRAVE_WALLET_SORT_BY},
     {"braveWalletConfirmSwap", IDS_BRAVE_WALLET_CONFIRM_SWAP},
     {"braveWalletConfirmBridge", IDS_BRAVE_WALLET_CONFIRM_BRIDGE},
+    {"braveWalletConfirmSend", IDS_BRAVE_WALLET_CONFIRM_SEND},
     {"braveWalletSpend", IDS_BRAVE_WALLET_SPEND},
     {"braveWalletEstTime", IDS_BRAVE_WALLET_EST_TIME},
     {"braveWalletExchangeRate", IDS_BRAVE_WALLET_EXCHANGE_RATE},

--- a/components/brave_wallet_ui/common/async/__mocks__/bridge.ts
+++ b/components/brave_wallet_ui/common/async/__mocks__/bridge.ts
@@ -55,6 +55,7 @@ import {
 } from '../../../stories/mock-data/mock-asset-options'
 import {
   mockETHSwapTransaction,
+  mockETHNativeTokenSendTransaction,
   mockFilSendTransaction,
   mockTransactionInfo,
   mockedErc20ApprovalTransaction,
@@ -196,6 +197,7 @@ export class MockedWalletApiProxy {
     deserializeTransaction(mockTransactionInfo),
     mockFilSendTransaction as BraveWallet.TransactionInfo,
     deserializeTransaction(mockedErc20ApprovalTransaction),
+    deserializeTransaction(mockETHNativeTokenSendTransaction),
     mockETHSwapTransaction,
   ]
 

--- a/components/brave_wallet_ui/common/hooks/use-pending-transaction.ts
+++ b/components/brave_wallet_ui/common/hooks/use-pending-transaction.ts
@@ -56,6 +56,7 @@ import {
   usePendingTransactionsQuery,
   useGetCombinedTokensListQuery,
   useAccountQuery,
+  useAccountFromAddressQuery,
 } from '../slices/api.slice.extra'
 import { useSwapTransactionParser } from './use-swap-tx-parser'
 import {
@@ -686,12 +687,24 @@ export const usePendingTransactions = () => {
       : skipToken,
   )
 
+  const { account: toAccount } = useAccountFromAddressQuery(
+    transactionDetails?.recipient,
+  )
+
+  const canEditNetworkFee = React.useMemo(() => {
+    return (
+      isEthereumTransaction(transactionInfo)
+      || transactionDetails?.isFilecoinTransaction
+    )
+  }, [transactionInfo, transactionDetails?.isFilecoinTransaction])
+
   return {
     baseFeePerGas,
     currentTokenAllowance,
     isCurrentAllowanceUnlimited,
     erc20ApproveTokenInfo,
     fromAccount: txAccount,
+    toAccount,
     fromOrb,
     isConfirmButtonDisabled,
     isEthereumTransaction: isEthereumTransaction(transactionInfo),
@@ -731,5 +744,6 @@ export const usePendingTransactions = () => {
     isCardanoTransaction: isCardanoTransaction(transactionInfo),
     isAccountSyncing,
     isShieldingFunds,
+    canEditNetworkFee,
   }
 }

--- a/components/brave_wallet_ui/components/extension/allow_spend_panel/allow_spend_panel.tsx
+++ b/components/brave_wallet_ui/components/extension/allow_spend_panel/allow_spend_panel.tsx
@@ -88,6 +88,7 @@ export const AllowSpendPanel = () => {
     queuePreviousTransaction,
     transactionsQueueLength,
     rejectAllTransactions,
+    canEditNetworkFee,
   } = usePendingTransactions()
 
   const onClickViewOnBlockExplorer = useExplorer(transactionsNetwork)
@@ -185,7 +186,11 @@ export const AllowSpendPanel = () => {
                     transactionsNetwork={transactionsNetwork}
                     gasFee={gasFee}
                     transactionDetails={transactionDetails}
-                    onClickEditNetworkFee={() => setShowEditNetworkFee(true)}
+                    onClickEditNetworkFee={
+                      canEditNetworkFee
+                        ? () => setShowEditNetworkFee(true)
+                        : undefined
+                    }
                   />
                 </InfoBox>
 

--- a/components/brave_wallet_ui/components/extension/confirm_send_transaction/confirm_send_transaction.stories.tsx
+++ b/components/brave_wallet_ui/components/extension/confirm_send_transaction/confirm_send_transaction.stories.tsx
@@ -1,0 +1,41 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import * as React from 'react'
+
+import {
+  mockETHNativeTokenSendTransaction, //
+} from '../../../stories/mock-data/mock-transaction-info'
+
+// Components
+import { ConfirmSendTransaction } from './confirm_send_transaction'
+import {
+  WalletPanelStory, //
+} from '../../../stories/wrappers/wallet-panel-story-wrapper'
+
+export const _ConfirmSendTransaction = {
+  render: () => {
+    return <ConfirmSendTransaction />
+  },
+}
+
+export default {
+  title: 'Wallet/Panel/Panels/Confirm Send Transaction Panel',
+  component: ConfirmSendTransaction,
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    (Story: any) => (
+      <WalletPanelStory
+        uiStateOverride={{
+          selectedPendingTransactionId: mockETHNativeTokenSendTransaction.id,
+        }}
+      >
+        <Story />
+      </WalletPanelStory>
+    ),
+  ],
+}

--- a/components/brave_wallet_ui/components/extension/confirm_send_transaction/confirm_send_transaction.style.ts
+++ b/components/brave_wallet_ui/components/extension/confirm_send_transaction/confirm_send_transaction.style.ts
@@ -1,0 +1,32 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import styled from 'styled-components'
+import * as leo from '@brave/leo/tokens/css/variables'
+
+// Shared Styles
+import { Column, Text } from '../../shared/style'
+
+export const StyledWrapper = styled(Column)`
+  background-color: ${leo.color.page.background};
+`
+
+export const Card = styled(Column)`
+  background-color: ${leo.color.container.background};
+  border-radius: ${leo.radius.xl};
+  box-shadow: ${leo.effect.elevation['01']};
+  overflow: hidden;
+`
+
+export const InfoBox = styled(Column)`
+  background-color: ${leo.color.container.highlight};
+  border-radius: ${leo.radius.xl};
+  overflow: hidden;
+`
+
+export const Title = styled(Text)`
+  font: ${leo.font.heading.h4};
+  letter-spacing: ${leo.typography.letterSpacing.large};
+`

--- a/components/brave_wallet_ui/components/extension/confirmation_footer_actions/confirmation_footer_actions.tsx
+++ b/components/brave_wallet_ui/components/extension/confirmation_footer_actions/confirmation_footer_actions.tsx
@@ -14,8 +14,8 @@ import { getLocale } from '../../../../common/locale'
 import { Row } from '../../shared/style'
 
 interface Props {
-  onClickAdvancedSettings: () => void
-  onClickDetails: () => void
+  onClickAdvancedSettings?: () => void
+  onClickDetails?: () => void
 }
 
 export function ConfirmationFooterActions(props: Props) {
@@ -24,30 +24,34 @@ export function ConfirmationFooterActions(props: Props) {
   return (
     <Row justifyContent='space-between'>
       <div>
-        <Button
-          kind='plain'
-          size='tiny'
-          onClick={onClickAdvancedSettings}
-        >
-          <Icon
-            name='settings'
-            slot='icon-before'
-          />
-          {getLocale('braveWalletAdvancedTransactionSettings')}
-        </Button>
+        {onClickAdvancedSettings && (
+          <Button
+            kind='plain'
+            size='tiny'
+            onClick={onClickAdvancedSettings}
+          >
+            <Icon
+              name='settings'
+              slot='icon-before'
+            />
+            {getLocale('braveWalletAdvancedTransactionSettings')}
+          </Button>
+        )}
       </div>
       <div>
-        <Button
-          kind='plain'
-          size='tiny'
-          onClick={onClickDetails}
-        >
-          <Icon
-            name='info-outline'
-            slot='icon-before'
-          />
-          {getLocale('braveWalletDetails')}
-        </Button>
+        {onClickDetails && (
+          <Button
+            kind='plain'
+            size='tiny'
+            onClick={onClickDetails}
+          >
+            <Icon
+              name='info-outline'
+              slot='icon-before'
+            />
+            {getLocale('braveWalletDetails')}
+          </Button>
+        )}
       </div>
     </Row>
   )

--- a/components/brave_wallet_ui/components/extension/confirmation_network_fee/confirmation_network_fee.tsx
+++ b/components/brave_wallet_ui/components/extension/confirmation_network_fee/confirmation_network_fee.tsx
@@ -31,7 +31,7 @@ interface Props {
   gasFee: string
   transactionsNetwork?: BraveWallet.NetworkInfo
   transactionDetails?: ParsedTransaction
-  onClickEditNetworkFee: () => void
+  onClickEditNetworkFee?: () => void
 }
 
 export function ConfirmationNetworkFee(props: Props) {
@@ -68,22 +68,23 @@ export function ConfirmationNetworkFee(props: Props) {
           >
             {getLocale('braveWalletAllowSpendTransactionFee')}
           </ConfirmationInfoLabel>
-          <Button
-            size='tiny'
-            kind='plain'
-            onClick={onClickEditNetworkFee}
-          >
-            <Icon
-              name='tune'
-              slot='icon-before'
-            />
-            {getLocale('braveWalletAllowSpendEditButton')}
-          </Button>
+          {onClickEditNetworkFee && (
+            <Button
+              size='tiny'
+              kind='plain'
+              onClick={onClickEditNetworkFee}
+            >
+              <Icon
+                name='tune'
+                slot='icon-before'
+              />
+              {getLocale('braveWalletAllowSpendEditButton')}
+            </Button>
+          )}
         </Column>
         <Column
           alignItems='flex-end'
           justifyContent='flex-start'
-          gap='8px'
         >
           <ConfirmationInfoLabel
             textColor='primary'

--- a/components/brave_wallet_ui/components/extension/confirmation_token_info/confirmation_token_info.style.ts
+++ b/components/brave_wallet_ui/components/extension/confirmation_token_info/confirmation_token_info.style.ts
@@ -4,6 +4,8 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import styled from 'styled-components'
+import Button from '@brave/leo/react/button'
+import Tooltip from '@brave/leo/react/tooltip'
 import * as leo from '@brave/leo/tokens/css/variables'
 
 // Shared Styles
@@ -14,6 +16,7 @@ import {
   Column,
   WalletButton,
 } from '../../shared/style'
+import { ConfirmationButtonLink } from '../shared-panel-styles'
 
 export const IconsWrapper = styled(Column)`
   position: relative;
@@ -46,4 +49,39 @@ export const AccountButton = styled(WalletButton)`
   outline: none;
   border: none;
   background: transparent;
+`
+
+export const ArrowIconContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 40px;
+  min-height: 40px;
+  border-radius: 100%;
+  background-color: ${leo.color.page.background};
+  --leo-icon-size: 16px;
+  --leo-icon-color: ${leo.color.icon.default};
+`
+
+export const AddressText = styled(Text)`
+  font: ${leo.font.large.semibold};
+  letter-spacing: ${leo.typography.letterSpacing.large};
+`
+
+export const WarningTooltip = styled(Tooltip)`
+  --leo-icon-size: 16px;
+  --leo-icon-color: ${leo.color.icon.default};
+`
+
+export const WarningTooltipContent = styled(Column)`
+  white-space: pre-line;
+`
+
+export const LearnMoreButton = styled(ConfirmationButtonLink)`
+  display: inline-flex;
+`
+
+export const BlockExplorerButton = styled(Button)`
+  --leo-icon-size: 20px;
+  color: ${leo.color.icon.default};
 `

--- a/components/brave_wallet_ui/components/extension/confirmation_token_info/confirmation_token_info.tsx
+++ b/components/brave_wallet_ui/components/extension/confirmation_token_info/confirmation_token_info.tsx
@@ -6,6 +6,7 @@
 import * as React from 'react'
 import { skipToken } from '@reduxjs/toolkit/query/react'
 import Label from '@brave/leo/react/label'
+import Tooltip from '@brave/leo/react/tooltip'
 import Icon from '@brave/leo/react/icon'
 
 // Queries
@@ -25,6 +26,9 @@ import {
   computeFiatAmount,
   getPriceIdForToken,
 } from '../../../utils/pricing-utils'
+import {
+  openAssociatedTokenAccountSupportArticleTab, //
+} from '../../../utils/routes-utils'
 import Amount from '../../../utils/amount'
 
 // Types
@@ -47,11 +51,18 @@ import {
   NetworkIconWrapper,
   TokenAmountText,
   AccountButton,
+  ArrowIconContainer,
+  AddressText,
+  WarningTooltip,
+  WarningTooltipContent,
+  LearnMoreButton,
+  BlockExplorerButton,
 } from './confirmation_token_info.style'
 import {
   ConfirmationInfoLabel,
   ConfirmationInfoText,
 } from '../shared-panel-styles'
+import useExplorer from '../../../common/hooks/explorer'
 
 const ICON_CONFIG = { size: 'big', marginLeft: 0, marginRight: 0 } as const
 const AssetIconWithPlaceholder = withPlaceholderIcon(AssetIcon, ICON_CONFIG)
@@ -60,13 +71,29 @@ interface Props {
   token?: BraveWallet.BlockchainToken
   network?: BraveWallet.NetworkInfo
   amount?: string
+  valueExact?: string
+  fiatValue?: string
   account?: BraveWallet.AccountInfo
   receiveAddress?: string
-  label: 'send' | 'spend' | 'receive' | 'bridge'
+  isAssociatedTokenAccountCreation?: boolean
+  label: 'send' | 'spend' | 'receive' | 'bridge' | 'to'
 }
 
 export function ConfirmationTokenInfo(props: Props) {
-  const { token, label, amount, network, account, receiveAddress } = props
+  const {
+    token,
+    label,
+    amount,
+    network,
+    account,
+    receiveAddress,
+    valueExact,
+    fiatValue,
+    isAssociatedTokenAccountCreation,
+  } = props
+
+  // Hooks
+  const onClickViewOnBlockExplorer = useExplorer(network)
 
   // Queries
   const { data: defaultFiatCurrency } = useGetDefaultFiatCurrencyQuery()
@@ -92,6 +119,139 @@ export function ConfirmationTokenInfo(props: Props) {
         ? getLocale('braveWalletSpend')
         : getLocale('braveWalletReceive')
 
+  const ataCreationLocale = getLocale(
+    'braveWalletConfirmTransactionAccountCreationFee',
+  )
+
+  // Memos
+  const formattedAmount = React.useMemo(() => {
+    if (valueExact) {
+      return new Amount(valueExact).formatAsAsset(
+        undefined,
+        token?.symbol ?? '',
+      )
+    }
+    if (amount && token) {
+      return new Amount(amount)
+        .divideByDecimals(token.decimals)
+        .formatAsAsset(6, token.symbol)
+    }
+    return ''
+  }, [valueExact, amount, token])
+
+  const formattedFiatAmount = React.useMemo(() => {
+    if (fiatValue) {
+      return new Amount(fiatValue).formatAsFiat(defaultFiatCurrency)
+    }
+    if (amount && token) {
+      return computeFiatAmount({
+        spotPriceRegistry,
+        value: amount,
+        token: token,
+      }).formatAsFiat(defaultFiatCurrency)
+    }
+    return ''
+  }, [fiatValue, amount, token, defaultFiatCurrency, spotPriceRegistry])
+
+  if (label === 'to' && account) {
+    return (
+      <Row
+        justifyContent='space-between'
+        gap='16px'
+      >
+        <CreateAccountIcon
+          size='big'
+          account={account}
+        />
+        <Column
+          width='100%'
+          alignItems='flex-start'
+          justifyContent='flex-start'
+        >
+          <ConfirmationInfoLabel textColor='secondary'>
+            {getLocale('braveWalletSwapTo')}
+          </ConfirmationInfoLabel>
+          <AddressText
+            textColor='primary'
+            textAlign='left'
+          >
+            {account.name}
+          </AddressText>
+          <Tooltip text={account.address}>
+            <ConfirmationInfoText
+              textColor='tertiary'
+              textAlign='left'
+            >
+              {reduceAddress(account.address)}
+            </ConfirmationInfoText>
+          </Tooltip>
+        </Column>
+      </Row>
+    )
+  }
+
+  if (label === 'to') {
+    return (
+      <Row
+        justifyContent='space-between'
+        gap='16px'
+      >
+        <ArrowIconContainer>
+          <Icon name='arrow-right' />
+        </ArrowIconContainer>
+        <Row alignItems='flex-start'>
+          <Column
+            width='100%'
+            alignItems='flex-start'
+            justifyContent='flex-start'
+            gap='4px'
+          >
+            <ConfirmationInfoLabel
+              textColor='secondary'
+              textAlign='left'
+            >
+              {getLocale('braveWalletSwapTo')}
+            </ConfirmationInfoLabel>
+            <Row gap='16px'>
+              <Tooltip text={receiveAddress ?? ''}>
+                <AddressText textColor='primary'>
+                  {reduceAddress(receiveAddress ?? '')}
+                </AddressText>
+              </Tooltip>
+              <BlockExplorerButton
+                kind='plain-faint'
+                fab
+                onClick={onClickViewOnBlockExplorer(
+                  'address',
+                  receiveAddress ?? '',
+                )}
+              >
+                <Icon name='launch' />
+              </BlockExplorerButton>
+            </Row>
+          </Column>
+          {isAssociatedTokenAccountCreation && (
+            <WarningTooltip>
+              <WarningTooltipContent
+                slot='content'
+                width='250px'
+              >
+                <span>
+                  {ataCreationLocale}{' '}
+                  <LearnMoreButton
+                    onClick={openAssociatedTokenAccountSupportArticleTab}
+                  >
+                    {getLocale('braveWalletAllowAddNetworkLearnMoreButton')}
+                  </LearnMoreButton>
+                </span>
+              </WarningTooltipContent>
+              <Icon name='warning-circle-outline' />
+            </WarningTooltip>
+          )}
+        </Row>
+      </Row>
+    )
+  }
   return (
     <Row
       justifyContent='space-between'
@@ -127,54 +287,59 @@ export function ConfirmationTokenInfo(props: Props) {
           <ConfirmationInfoLabel textColor='secondary'>
             {labelText}
           </ConfirmationInfoLabel>
-          <AccountButton
-            onClick={() => copyToClipboard(account?.address ?? '')}
+          <Tooltip
+            text={account ? (account?.address ?? '') : (receiveAddress ?? '')}
           >
-            <Label>
-              {account ? (
-                <Row>
-                  <CreateAccountIcon
-                    size='x-tiny'
-                    account={account}
-                    marginRight={4}
-                  />
-                  {account?.name ?? ''}
-                </Row>
-              ) : (
-                reduceAddress(receiveAddress ?? '')
-              )}
-              <Icon
-                name='copy'
-                slot='icon-after'
-              />
-            </Label>
-          </AccountButton>
+            <AccountButton
+              onClick={() => copyToClipboard(account?.address ?? '')}
+            >
+              <Label>
+                {account ? (
+                  <Row>
+                    <CreateAccountIcon
+                      size='x-tiny'
+                      account={account}
+                      marginRight={4}
+                    />
+                    {account?.name ?? ''}
+                  </Row>
+                ) : (
+                  reduceAddress(receiveAddress ?? '')
+                )}
+                <Icon
+                  name='copy'
+                  slot='icon-after'
+                />
+              </Label>
+            </AccountButton>
+          </Tooltip>
         </Row>
         {label === 'bridge' && !token && (
-          <TokenAmountText textColor='success'>
+          <TokenAmountText
+            textColor='success'
+            textAlign='left'
+          >
             {getLocale('braveWalletOnNetwork').replace(
               '$1',
               network?.chainName ?? '',
             )}
           </TokenAmountText>
         )}
-        {label !== 'bridge' && amount && token && (
-          <>
-            <TokenAmountText
-              textColor={label === 'receive' ? 'success' : 'primary'}
-            >
-              {new Amount(amount)
-                .divideByDecimals(token.decimals)
-                .formatAsAsset(6, token.symbol)}
-            </TokenAmountText>
-            <ConfirmationInfoText textColor='tertiary'>
-              {computeFiatAmount({
-                spotPriceRegistry,
-                value: amount,
-                token: token,
-              }).formatAsFiat(defaultFiatCurrency)}
-            </ConfirmationInfoText>
-          </>
+        {label !== 'bridge' && formattedAmount && (
+          <TokenAmountText
+            textColor={label === 'receive' ? 'success' : 'primary'}
+            textAlign='left'
+          >
+            {formattedAmount}
+          </TokenAmountText>
+        )}
+        {label !== 'bridge' && formattedFiatAmount && (
+          <ConfirmationInfoText
+            textColor='tertiary'
+            textAlign='left'
+          >
+            {formattedFiatAmount}
+          </ConfirmationInfoText>
         )}
       </Column>
     </Row>

--- a/components/brave_wallet_ui/components/extension/pending_transaction_panel/pending_transaction_panel.tsx
+++ b/components/brave_wallet_ui/components/extension/pending_transaction_panel/pending_transaction_panel.tsx
@@ -29,6 +29,9 @@ import {
   ConfirmSimulatedTransactionPanel, //
 } from '../confirm-transaction-panel/confirm_simulated_tx_panel'
 import { AllowSpendPanel } from '../allow_spend_panel/allow_spend_panel'
+import {
+  ConfirmSendTransaction, //
+} from '../confirm_send_transaction/confirm_send_transaction'
 
 // Utils
 import { getCoinFromTxDataUnion } from '../../../utils/network-utils'
@@ -214,6 +217,23 @@ export const PendingTransactionPanel: React.FC<Props> = ({
     === BraveWallet.TransactionType.ERC20Approve
   ) {
     return <AllowSpendPanel />
+  }
+
+  // Send
+  if (
+    selectedPendingTransaction.txType === BraveWallet.TransactionType.ETHSend
+    || selectedPendingTransaction.txType
+      === BraveWallet.TransactionType.ERC20Transfer
+    || selectedPendingTransaction.txType
+      === BraveWallet.TransactionType.SolanaSystemTransfer
+    || selectedPendingTransaction.txType
+      === BraveWallet.TransactionType.SolanaSPLTokenTransfer
+    || selectedPendingTransaction.txType
+      === BraveWallet.TransactionType
+        .SolanaSPLTokenTransferWithAssociatedTokenAccountCreation
+    || selectedPendingTransaction.txType === BraveWallet.TransactionType.Other
+  ) {
+    return <ConfirmSendTransaction />
   }
 
   // Defaults

--- a/components/brave_wallet_ui/components/shared/create-account-icon/create-account-icon.style.ts
+++ b/components/brave_wallet_ui/components/shared/create-account-icon/create-account-icon.style.ts
@@ -13,10 +13,11 @@ import { ExternalWalletProvider } from '../../../../brave_rewards/resources/shar
 
 export const AccountBox = styled.div<{
   orb?: string
-  size?: 'huge' | 'big' | 'medium' | 'small' | 'tiny' | 'x-tiny'
+  size?: 'extra-huge' | 'huge' | 'big' | 'medium' | 'small' | 'tiny' | 'x-tiny'
   marginRight?: number
   round?: boolean
 }>`
+  --box-extra-huge: 56px;
   --box-huge: 48px;
   --box-big: 40px;
   --box-medium: 32px;
@@ -45,8 +46,9 @@ export const ExternalAccountBox = styled(AccountBox)<{
 `
 
 export const ExternalAccountIcon = styled.img<{
-  size?: 'huge' | 'big' | 'medium' | 'small' | 'tiny' | 'x-tiny'
+  size?: 'extra-huge' | 'huge' | 'big' | 'medium' | 'small' | 'tiny' | 'x-tiny'
 }>`
+  --icon-extra-huge: 40px;
   --icon-huge: 32px;
   --icon-big: 28px;
   --icon-medium: 24px;

--- a/components/brave_wallet_ui/components/shared/create-account-icon/create-account-icon.tsx
+++ b/components/brave_wallet_ui/components/shared/create-account-icon/create-account-icon.tsx
@@ -24,7 +24,7 @@ import { useAccountOrb } from '../../../common/hooks/use-orb'
 interface Props {
   account?: BraveWallet.AccountInfo
   externalProvider?: ExternalWalletProvider | null
-  size?: 'huge' | 'big' | 'medium' | 'small' | 'tiny' | 'x-tiny'
+  size?: 'extra-huge' | 'huge' | 'big' | 'medium' | 'small' | 'tiny' | 'x-tiny'
   marginRight?: number
   round?: boolean
 }

--- a/components/brave_wallet_ui/stories/locale.ts
+++ b/components/brave_wallet_ui/stories/locale.ts
@@ -647,6 +647,7 @@ provideStrings({
   braveWalletSortBy: 'Sort by',
   braveWalletConfirmSwap: 'Confirm swap',
   braveWalletConfirmBridge: 'Confirm bridge',
+  braveWalletConfirmSend: 'Confirm send',
   braveWalletSpend: 'Spend',
 
   // Buy
@@ -823,7 +824,7 @@ provideStrings({
   braveWalletConfirmTransactionTransactionFee: 'Transaction fee',
   braveWalletConfirmTransactionBid: 'Bid',
   braveWalletConfirmTransactionAmountGas: 'Amount + gas',
-  braveWalletConfirmTransactionAmountFee: 'Amount + fee',
+  braveWalletConfirmTransactionAmountFee: 'Amount + Network fee',
   braveWalletConfirmTransactionNoData: 'No data.',
   braveWalletConfirmTransactionNext: 'next',
   braveWalletConfirmTransactionFirst: 'first',

--- a/components/brave_wallet_ui/stories/mock-data/mock-transaction-info.ts
+++ b/components/brave_wallet_ui/stories/mock-data/mock-transaction-info.ts
@@ -21,6 +21,7 @@ import {
 // Mocks
 import {
   mockAccount,
+  mockEthAccountInfo,
   mockBtcAccount,
   mockFilecoinAccount,
   mockSolanaAccount,
@@ -361,7 +362,7 @@ export const mockedErc20ApprovalTransaction = {
 }
 
 export const mockEthSendTransaction = {
-  id: '8e41ec0c-9e62-45fc-904f-a25b42275a1a',
+  id: 'eth-send-tx',
   fromAddress: mockAccount.address,
   fromAccountId: mockAccount.accountId,
   txHash: '0xbabaaaaaaaaaaa',
@@ -875,5 +876,48 @@ export const mockETHSwapTransaction: BraveWallet.TransactionInfo = {
     toChainId: BraveWallet.MAINNET_CHAIN_ID,
     receiver: mockAccount.address,
     provider: 'lifi',
+  },
+}
+
+export const mockETHNativeTokenSendTransaction = {
+  chainId: BraveWallet.MAINNET_CHAIN_ID,
+  confirmedTime: { microseconds: 0 },
+  createdTime: {
+    microseconds: 1697722990427000,
+  },
+  submittedTime: {
+    microseconds: 0,
+  },
+  effectiveRecipient: mockEthAccountInfo.accountId.address,
+  fromAccountId: mockAccount.accountId,
+  id: 'eth-native-token-send-tx',
+  isRetriable: false,
+  originInfo: {
+    originSpec: 'chrome://wallet',
+    eTldPlusOne: '',
+  },
+  swapInfo: undefined,
+  txArgs: [],
+  txHash: '',
+  txParams: [],
+  txStatus: BraveWallet.TransactionStatus.Unapproved,
+  txType: BraveWallet.TransactionType.ETHSend,
+  txDataUnion: {
+    ethTxData1559: {
+      baseData: {
+        nonce: '',
+        gasPrice: '0x5f5e100',
+        gasLimit: '0x5208',
+        to: mockEthAccountInfo.accountId.address,
+        value: '0xad78ebc5ac620000',
+        data: [],
+        signOnly: false,
+        signedTransaction: undefined,
+      },
+      chainId: '',
+      maxPriorityFeePerGas: '',
+      maxFeePerGas: '',
+      gasEstimation: undefined,
+    },
   },
 }

--- a/components/resources/wallet_strings.grdp
+++ b/components/resources/wallet_strings.grdp
@@ -147,6 +147,7 @@
   <message name="IDS_BRAVE_WALLET_EXCHANGE_VIA_PROVIDER" desc="Exchange being used via API provider"><ph name="EXCHANGE_NAME"><ex>0x</ex>$1</ph> via <ph name="PROVIDER_NAME"><ex>Li.Fi</ex>$2</ph></message>
   <message name="IDS_BRAVE_WALLET_CONFIRM_SWAP" desc="Confirm swap title">Confirm swap</message>
   <message name="IDS_BRAVE_WALLET_CONFIRM_BRIDGE" desc="Confirm bridge title">Confirm bridge</message>
+  <message name="IDS_BRAVE_WALLET_CONFIRM_SEND" desc="Confirm send title">Confirm send</message>
   <message name="IDS_BRAVE_WALLET_SPEND" desc="Spend button">Spend</message>
   <message name="IDS_BRAVE_WALLET_SORT_BY" desc="Sort by button label">Sort by</message>
   <message name="IDS_BRAVE_WALLET_REVIEW_BRIDGE" desc="Review bridge button">Review bridge</message>
@@ -410,7 +411,7 @@
   <message name="IDS_BRAVE_WALLET_CONFIRM_TRANSACTION_TRANSACTION_FEE" desc="Confirm transaction panel transaction fee label">Transaction fee</message>
   <message name="IDS_BRAVE_WALLET_CONFIRM_TRANSACTION_BID" desc="Confirm transaction panel bid label">Bid</message>
   <message name="IDS_BRAVE_WALLET_CONFIRM_TRANSACTION_AMOUNT_GAS" desc="Confirm transaction panel total gas label">Amount + gas</message>
-  <message name="IDS_BRAVE_WALLET_CONFIRM_TRANSACTION_AMOUNT_FEE" desc="Confirm transaction panel total fee label">Amount + fee</message>
+  <message name="IDS_BRAVE_WALLET_CONFIRM_TRANSACTION_AMOUNT_FEE" desc="Confirm transaction panel total fee label">Amount + Network fee</message>
   <message name="IDS_BRAVE_WALLET_CONFIRM_TRANSACTION_NO_DATA" desc="Confirm transaction panel no data placeholder">No data.</message>
   <message name="IDS_BRAVE_WALLET_CONFIRM_TRANSACTION_NEXT" desc="Confirm transaction panel next transaction button">next</message>
   <message name="IDS_BRAVE_WALLET_CONFIRM_TRANSACTION_FIRST" desc="Confirm transaction panel first transaction button">first</message>


### PR DESCRIPTION
## Description 

Built out the new `Confirm Send` panel UI for general `Send` transactions.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/49235>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

### Test ETH Send:
<img width="397" height="657" alt="Screenshot" src="https://github.com/user-attachments/assets/b42c872b-c22f-407c-9f20-3a852e68d75a" />

### Test ERC20 Token Transfers:
<img width="399" height="656" alt="Screenshot 1" src="https://github.com/user-attachments/assets/964edc97-521f-49a8-a7d4-735663e0e38a" />

### Test SOL Send:
<img width="398" height="657" alt="Screenshot 2" src="https://github.com/user-attachments/assets/2c1142b0-0bb9-4041-adf9-f59aa1b90d5a" />

### Test SPL Token Transfers:
<img width="398" height="657" alt="Screenshot 3" src="https://github.com/user-attachments/assets/b49ad2b9-c400-444c-b1d3-61cb436bbc9c" />

### Test BTC Send:
<img width="398" height="658" alt="Screenshot 5" src="https://github.com/user-attachments/assets/a3eb2027-16f6-4220-ae19-1424de0275c9" />

### Test ZEC Send:
<img width="396" height="655" alt="Screenshot 4" src="https://github.com/user-attachments/assets/d9ea78d9-0bf2-42a6-85a0-872aa042e7d8" />

### Test FIL Send:
<img width="397" height="657" alt="Screenshot 6" src="https://github.com/user-attachments/assets/d76885a3-5b6a-4588-a763-75ad464bc074" />
