### PR TITLE
feat(wallet): New Confirmation Panels Insufficient Gas Errors

### DIFF
--- a/components/brave_wallet_ui/components/extension/allow_spend_panel/allow_spend_panel.style.ts
+++ b/components/brave_wallet_ui/components/extension/allow_spend_panel/allow_spend_panel.style.ts
@@ -14,6 +14,10 @@ export const StyledWrapper = styled(Column)`
   background-color: ${leo.color.page.background};
 `
 
+export const ContentWrapper = styled(Column)`
+  overflow: hidden;
+`
+
 export const Title = styled(Row)`
   font: ${leo.font.heading.h4};
   letter-spacing: ${leo.typography.letterSpacing.headings};
@@ -35,6 +39,7 @@ export const Card = styled(Column)`
 export const InfoBox = styled(Column)`
   background-color: ${leo.color.container.highlight};
   border-radius: ${leo.radius.xl};
+  overflow: hidden;
 `
 
 export const AmountText = styled(Text)`

--- a/components/brave_wallet_ui/components/extension/allow_spend_panel/allow_spend_panel.tsx
+++ b/components/brave_wallet_ui/components/extension/allow_spend_panel/allow_spend_panel.tsx
@@ -40,6 +40,12 @@ import {
   AdvancedTransactionSettings, //
 } from '../advanced_transaction_settings/advanced_transaction_settings'
 import { LoadingPanel } from '../loading_panel/loading_panel'
+import {
+  ConfirmRejectButtons, //
+} from '../confirm_reject_buttons/confirm_reject_buttons'
+import {
+  ConfirmationError, //
+} from '../confirmation_error/confirmation_error'
 
 // Styled Components
 import {
@@ -50,11 +56,13 @@ import {
   InfoBox,
   AmountText,
   TokenButtonLink,
+  ContentWrapper,
 } from './allow_spend_panel.style'
 import { Column, Row, VerticalDivider } from '../../shared/style'
 import {
   ConfirmationInfoLabel,
   ConfirmationButtonLink,
+  ScrollableColumn,
 } from '../shared-panel-styles'
 
 export const AllowSpendPanel = () => {
@@ -89,6 +97,10 @@ export const AllowSpendPanel = () => {
     transactionsQueueLength,
     rejectAllTransactions,
     canEditNetworkFee,
+    isConfirmButtonDisabled,
+    insufficientFundsError,
+    insufficientFundsForGasError,
+    fromAccount,
   } = usePendingTransactions()
 
   const onClickViewOnBlockExplorer = useExplorer(transactionsNetwork)
@@ -119,7 +131,7 @@ export const AllowSpendPanel = () => {
         <VerticalDivider />
 
         {/* Content */}
-        <Column
+        <ContentWrapper
           padding='8px'
           width='100%'
           height='100%'
@@ -131,11 +143,17 @@ export const AllowSpendPanel = () => {
             height='100%'
             justifyContent='space-between'
           >
-            <Column>
-              {originInfo && <OriginInfoCard origin={originInfo} />}
+            {originInfo && <OriginInfoCard origin={originInfo} />}
+            <ScrollableColumn
+              width='100%'
+              height='100%'
+              justifyContent='flex-start'
+            >
               <Column
+                width='100%'
                 padding='16px 16px 0px 16px'
                 gap='8px'
+                justifyContent='flex-start'
               >
                 <Title>
                   {formatLocale('braveWalletAllowSpendTitle', {
@@ -177,20 +195,33 @@ export const AllowSpendPanel = () => {
                 </Row>
 
                 {/* Network info box */}
-                <InfoBox
-                  padding='16px'
-                  gap='8px'
-                  width='100%'
-                >
-                  <ConfirmationNetworkFee
-                    transactionsNetwork={transactionsNetwork}
-                    gasFee={gasFee}
-                    transactionDetails={transactionDetails}
-                    onClickEditNetworkFee={
-                      canEditNetworkFee
-                        ? () => setShowEditNetworkFee(true)
-                        : undefined
+                <InfoBox width='100%'>
+                  <Column
+                    padding={
+                      isConfirmButtonDisabled ? '16px 16px 8px 16px' : '16px'
                     }
+                    gap='8px'
+                    width='100%'
+                  >
+                    <ConfirmationNetworkFee
+                      transactionsNetwork={transactionsNetwork}
+                      gasFee={gasFee}
+                      transactionDetails={transactionDetails}
+                      onClickEditNetworkFee={
+                        canEditNetworkFee
+                          ? () => setShowEditNetworkFee(true)
+                          : undefined
+                      }
+                    />
+                  </Column>
+
+                  {/* Transaction errors */}
+                  <ConfirmationError
+                    insufficientFundsError={insufficientFundsError}
+                    insufficientFundsForGasError={insufficientFundsForGasError}
+                    transactionDetails={transactionDetails}
+                    transactionsNetwork={transactionsNetwork}
+                    account={fromAccount}
                   />
                 </InfoBox>
 
@@ -285,30 +316,16 @@ export const AllowSpendPanel = () => {
                   onClickDetails={() => setShowTransactionDetails(true)}
                 />
               </Column>
-            </Column>
+            </ScrollableColumn>
 
-            {/* Reject and confirm buttons */}
-            <Row
-              padding='16px'
-              gap='8px'
-            >
-              <Button
-                kind='outline'
-                size='medium'
-                onClick={onReject}
-              >
-                {getLocale('braveWalletAllowSpendRejectButton')}
-              </Button>
-              <Button
-                kind='filled'
-                size='medium'
-                onClick={onConfirm}
-              >
-                {getLocale('braveWalletAllowSpendConfirmButton')}
-              </Button>
-            </Row>
+            {/* Confirm and reject buttons */}
+            <ConfirmRejectButtons
+              onConfirm={onConfirm}
+              onReject={onReject}
+              isConfirmButtonDisabled={isConfirmButtonDisabled}
+            />
           </Card>
-        </Column>
+        </ContentWrapper>
       </StyledWrapper>
 
       {/* Edit spend limit */}

--- a/components/brave_wallet_ui/components/extension/confirm_reject_buttons/confirm_reject_buttons.tsx
+++ b/components/brave_wallet_ui/components/extension/confirm_reject_buttons/confirm_reject_buttons.tsx
@@ -1,0 +1,73 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import * as React from 'react'
+import Button from '@brave/leo/react/button'
+
+// Utils
+import { getLocale } from '../../../../common/locale'
+
+// Styled Components
+import { Row } from '../../shared/style'
+
+export interface Props {
+  onConfirm: (() => Promise<void>) | (() => void)
+  onReject: () => void
+  isConfirmButtonDisabled: boolean
+  isAccountSyncing?: boolean
+  isShieldingFunds?: boolean
+}
+
+export const ConfirmRejectButtons = (props: Props) => {
+  const {
+    onConfirm,
+    onReject,
+    isConfirmButtonDisabled,
+    isAccountSyncing,
+    isShieldingFunds,
+  } = props
+
+  // State
+  const [transactionConfirmed, setTranactionConfirmed] = React.useState(false)
+
+  // Methods
+  const onClickConfirmTransaction = React.useCallback(async () => {
+    // Sets transactionConfirmed state to disable the send button to prevent
+    // being clicked again and submitting the same transaction.
+    setTranactionConfirmed(true)
+    await onConfirm()
+  }, [onConfirm])
+
+  return (
+    <Row
+      padding='16px'
+      gap='8px'
+    >
+      <Button
+        kind='outline'
+        size='medium'
+        onClick={onReject}
+        disabled={transactionConfirmed}
+        isDisabled={transactionConfirmed}
+      >
+        {getLocale('braveWalletAllowSpendRejectButton')}
+      </Button>
+      <Button
+        kind='filled'
+        size='medium'
+        onClick={onClickConfirmTransaction}
+        disabled={isConfirmButtonDisabled}
+        isDisabled={isConfirmButtonDisabled}
+        isLoading={transactionConfirmed}
+      >
+        {isAccountSyncing
+          ? getLocale('braveWalletSyncing')
+          : isShieldingFunds
+            ? getLocale('braveWalletShieldZEC')
+            : getLocale('braveWalletAllowSpendConfirmButton')}
+      </Button>
+    </Row>
+  )
+}

--- a/components/brave_wallet_ui/components/extension/confirm_send_transaction/confirm_send_transaction.tsx
+++ b/components/brave_wallet_ui/components/extension/confirm_send_transaction/confirm_send_transaction.tsx
@@ -4,7 +4,6 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import * as React from 'react'
-import Button from '@brave/leo/react/button'
 
 // Constants
 import { BraveWallet } from '../../../constants/types'
@@ -46,6 +45,12 @@ import { EditNetworkFee } from '../edit_network_fee/edit_network_fee'
 import {
   CreateAccountIcon, //
 } from '../../shared/create-account-icon/create-account-icon'
+import {
+  ConfirmRejectButtons, //
+} from '../confirm_reject_buttons/confirm_reject_buttons'
+import {
+  ConfirmationError, //
+} from '../confirmation_error/confirmation_error'
 
 // Styled Components
 import {
@@ -58,6 +63,7 @@ import { Column, Row, VerticalDivider } from '../../shared/style'
 import {
   ConfirmationInfoLabel,
   ConfirmationInfoText,
+  ScrollableColumn,
 } from '../shared-panel-styles'
 
 export function ConfirmSendTransaction() {
@@ -87,6 +93,11 @@ export function ConfirmSendTransaction() {
     canEditNetworkFee,
     isEthereumTransaction,
     isAssociatedTokenAccountCreation,
+    isConfirmButtonDisabled,
+    isAccountSyncing,
+    isShieldingFunds,
+    insufficientFundsForGasError,
+    insufficientFundsError,
   } = usePendingTransactions()
 
   // Queries
@@ -151,143 +162,144 @@ export function ConfirmSendTransaction() {
           queuePreviousTransaction={queuePreviousTransaction}
           rejectAllTransactions={rejectAllTransactions}
         />
-        <Column
+        <ScrollableColumn
           width='100%'
           height='100%'
-          padding='0px 16px'
-          gap='12px'
           justifyContent='flex-start'
         >
-          <CreateAccountIcon
-            size='extra-huge'
-            account={fromAccount}
-          />
-          <Title textColor='primary'>
-            {getLocale('braveWalletPanelTitle')}
-          </Title>
-          <InfoBox width='100%'>
-            {/* Swap details */}
-            <Card
-              width='100%'
-              padding='16px'
-            >
-              {/* Send token and amount */}
-              <ConfirmationTokenInfo
-                token={transactionDetails.token}
-                label='send'
-                valueExact={transactionDetails.valueExact}
-                fiatValue={transactionDetails.fiatValue}
-                network={transactionsNetwork}
+          <Column
+            width='100%'
+            padding='0px 16px'
+            gap='8px'
+          >
+            <CreateAccountIcon
+              size='extra-huge'
+              account={fromAccount}
+            />
+            <Title textColor='primary'>
+              {getLocale('braveWalletPanelTitle')}
+            </Title>
+            <InfoBox width='100%'>
+              {/* Swap details */}
+              <Card
+                width='100%'
+                padding='16px'
+              >
+                {/* Send token and amount */}
+                <ConfirmationTokenInfo
+                  token={transactionDetails.token}
+                  label='send'
+                  valueExact={transactionDetails.valueExact}
+                  fiatValue={transactionDetails.fiatValue}
+                  network={transactionsNetwork}
+                  account={fromAccount}
+                />
+
+                {/* Divider */}
+                <Row
+                  justifyContent='space-between'
+                  padding='16px 0px'
+                >
+                  <VerticalDivider />
+                </Row>
+
+                {/* Recipient info */}
+                <ConfirmationTokenInfo
+                  label='to'
+                  receiveAddress={transactionDetails.recipient}
+                  isAssociatedTokenAccountCreation={
+                    isAssociatedTokenAccountCreation
+                  }
+                  network={transactionsNetwork}
+                  account={toAccount}
+                />
+              </Card>
+
+              {/* Network fee details */}
+              <Column
+                width='100%'
+                padding='16px'
+                gap='8px'
+              >
+                <ConfirmationNetworkFee
+                  transactionsNetwork={transactionsNetwork}
+                  gasFee={gasFee}
+                  transactionDetails={transactionDetails}
+                  onClickEditNetworkFee={
+                    canEditNetworkFee
+                      ? () => setShowEditNetworkFee(true)
+                      : undefined
+                  }
+                />
+                <VerticalDivider />
+
+                {/* Transaction total amount */}
+                <Column width='100%'>
+                  <Row justifyContent='space-between'>
+                    <ConfirmationInfoLabel
+                      textColor='secondary'
+                      textAlign='left'
+                    >
+                      {getLocale('braveWalletConfirmTransactionTotal')}
+                    </ConfirmationInfoLabel>
+                    <ConfirmationInfoLabel
+                      textColor='primary'
+                      textAlign='right'
+                    >
+                      {totalAmount}
+                    </ConfirmationInfoLabel>
+                  </Row>
+                  <Row justifyContent='space-between'>
+                    <ConfirmationInfoText
+                      textColor='tertiary'
+                      textAlign='left'
+                    >
+                      {getLocale('braveWalletConfirmTransactionAmountFee')}
+                    </ConfirmationInfoText>
+                    <ConfirmationInfoText
+                      textColor='tertiary'
+                      textAlign='right'
+                    >
+                      {new Amount(transactionDetails.fiatValue)
+                        .plus(transactionDetails.gasFeeFiat)
+                        .formatAsFiat(defaultFiatCurrency)}
+                    </ConfirmationInfoText>
+                  </Row>
+                </Column>
+              </Column>
+
+              {/* Transaction errors */}
+              <ConfirmationError
+                insufficientFundsError={insufficientFundsError}
+                insufficientFundsForGasError={insufficientFundsForGasError}
+                transactionDetails={transactionDetails}
+                transactionsNetwork={transactionsNetwork}
                 account={fromAccount}
               />
+            </InfoBox>
 
-              {/* Divider */}
-              <Row
-                justifyContent='space-between'
-                padding='16px 0px'
-              >
-                <VerticalDivider />
-              </Row>
+            {/* Advanced settings and details buttons */}
+            <ConfirmationFooterActions
+              onClickAdvancedSettings={
+                isEthereumTransaction
+                  ? () => setShowAdvancedTransactionSettings(true)
+                  : undefined
+              }
+              onClickDetails={() => {
+                setShowTransactionDetails(true)
+              }}
+            />
+          </Column>
+        </ScrollableColumn>
 
-              {/* Recipient info */}
-              <ConfirmationTokenInfo
-                label='to'
-                receiveAddress={transactionDetails.recipient}
-                isAssociatedTokenAccountCreation={
-                  isAssociatedTokenAccountCreation
-                }
-                network={transactionsNetwork}
-                account={toAccount}
-              />
-            </Card>
-
-            {/* Network fee details */}
-            <Column
-              width='100%'
-              padding='16px'
-              gap='8px'
-            >
-              <ConfirmationNetworkFee
-                transactionsNetwork={transactionsNetwork}
-                gasFee={gasFee}
-                transactionDetails={transactionDetails}
-                onClickEditNetworkFee={
-                  canEditNetworkFee
-                    ? () => setShowEditNetworkFee(true)
-                    : undefined
-                }
-              />
-              <VerticalDivider />
-
-              {/* Transaction total amount */}
-              <Column width='100%'>
-                <Row justifyContent='space-between'>
-                  <ConfirmationInfoLabel
-                    textColor='secondary'
-                    textAlign='left'
-                  >
-                    {getLocale('braveWalletConfirmTransactionTotal')}
-                  </ConfirmationInfoLabel>
-                  <ConfirmationInfoLabel
-                    textColor='primary'
-                    textAlign='right'
-                  >
-                    {totalAmount}
-                  </ConfirmationInfoLabel>
-                </Row>
-                <Row justifyContent='space-between'>
-                  <ConfirmationInfoText
-                    textColor='tertiary'
-                    textAlign='left'
-                  >
-                    {getLocale('braveWalletConfirmTransactionAmountFee')}
-                  </ConfirmationInfoText>
-                  <ConfirmationInfoText
-                    textColor='tertiary'
-                    textAlign='right'
-                  >
-                    {new Amount(transactionDetails.fiatValue)
-                      .plus(transactionDetails.gasFeeFiat)
-                      .formatAsFiat(defaultFiatCurrency)}
-                  </ConfirmationInfoText>
-                </Row>
-              </Column>
-            </Column>
-          </InfoBox>
-
-          {/* Advanced settings and details buttons */}
-          <ConfirmationFooterActions
-            onClickAdvancedSettings={
-              isEthereumTransaction
-                ? () => setShowAdvancedTransactionSettings(true)
-                : undefined
-            }
-            onClickDetails={() => {
-              setShowTransactionDetails(true)
-            }}
-          />
-        </Column>
-
-        {/* Reject and confirm buttons */}
-        <Row
-          padding='16px'
-          gap='8px'
-        >
-          <Button
-            kind='outline'
-            size='medium'
-            onClick={onReject}
-          >
-            {getLocale('braveWalletAllowSpendRejectButton')}
-          </Button>
-          <Button
-            kind='filled'
-            size='medium'
-            onClick={onConfirm}
-          >
-            {getLocale('braveWalletAllowSpendConfirmButton')}
-          </Button>
-        </Row>
+        {/* Confirm and reject buttons */}
+        <ConfirmRejectButtons
+          onConfirm={onConfirm}
+          onReject={onReject}
+          isConfirmButtonDisabled={isConfirmButtonDisabled}
+          isAccountSyncing={isAccountSyncing}
+          isShieldingFunds={isShieldingFunds}
+        />
       </StyledWrapper>
 
       {/* Transaction details */}

--- a/components/brave_wallet_ui/components/extension/confirmation_error/confirmation_error.style.ts
+++ b/components/brave_wallet_ui/components/extension/confirmation_error/confirmation_error.style.ts
@@ -1,0 +1,21 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import styled from 'styled-components'
+import * as leo from '@brave/leo/tokens/css/variables'
+
+// Shared Styles
+import { Row, Text } from '../../shared/style'
+
+export const Wrapper = styled(Row)`
+  --leo-icon-size: 16px;
+  --leo-icon-color: ${leo.color.systemfeedback.errorIcon};
+  background-color: ${leo.color.systemfeedback.errorBackground};
+`
+
+export const ErrorText = styled(Text)`
+  font: ${leo.font.small.regular};
+  letter-spacing: ${leo.typography.letterSpacing.small};
+`

--- a/components/brave_wallet_ui/components/extension/confirmation_error/confirmation_error.tsx
+++ b/components/brave_wallet_ui/components/extension/confirmation_error/confirmation_error.tsx
@@ -1,0 +1,111 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import * as React from 'react'
+import Icon from '@brave/leo/react/icon'
+import Button from '@brave/leo/react/button'
+
+// Hooks
+import {
+  useFindBuySupportedToken, //
+} from '../../../common/hooks/use-multi-chain-buy-assets'
+
+// Types
+import { BraveWallet } from '../../../constants/types'
+import { ParsedTransaction } from '../../../utils/tx-utils'
+
+// Utils
+import { getLocale } from '../../../../common/locale'
+import { makeNetworkAsset } from '../../../options/asset-options'
+import {
+  makeFundWalletRoute,
+  openWalletRouteTab,
+} from '../../../utils/routes-utils'
+
+// Styled Components
+import { Wrapper, ErrorText } from './confirmation_error.style'
+import { Row } from '../../shared/style'
+
+export interface Props {
+  insufficientFundsError?: boolean
+  insufficientFundsForGasError?: boolean
+  transactionDetails?: ParsedTransaction
+  transactionsNetwork?: BraveWallet.NetworkInfo
+  account?: BraveWallet.AccountInfo
+}
+
+export const ConfirmationError = (props: Props) => {
+  const {
+    insufficientFundsError,
+    insufficientFundsForGasError,
+    transactionDetails,
+    transactionsNetwork,
+    account,
+  } = props
+
+  // memos
+  const errors = React.useMemo(() => {
+    return [
+      transactionDetails?.contractAddressError,
+      transactionDetails?.sameAddressError,
+      transactionDetails?.missingGasLimitError,
+      insufficientFundsForGasError
+        ? getLocale('braveWalletSwapInsufficientFundsForGas')
+        : undefined,
+      !insufficientFundsForGasError && insufficientFundsError
+        ? getLocale('braveWalletSwapInsufficientBalance')
+        : undefined,
+    ].filter((error): error is string => Boolean(error))
+  }, [transactionDetails, insufficientFundsForGasError, insufficientFundsError])
+
+  // Computed
+  const nativeAsset = makeNetworkAsset(transactionsNetwork)
+  const hasErrors = Boolean(errors.length)
+
+  // Hooks
+  const { foundMeldBuyToken } = useFindBuySupportedToken(nativeAsset)
+
+  // Methods
+  const onClickBuy = React.useCallback(() => {
+    if (foundMeldBuyToken) {
+      openWalletRouteTab(makeFundWalletRoute(foundMeldBuyToken, account))
+    }
+  }, [foundMeldBuyToken, account])
+
+  if (!hasErrors) {
+    return null
+  }
+
+  return errors.map((error) => (
+    <Wrapper
+      padding='8px 16px'
+      justifyContent='space-between'
+      key={error}
+    >
+      <Row
+        width='unset'
+        gap='8px'
+      >
+        <Icon name='warning-triangle-filled' />
+        <ErrorText textColor='error'>{error}</ErrorText>
+      </Row>
+      {(insufficientFundsForGasError || insufficientFundsError)
+        && foundMeldBuyToken && (
+          <div>
+            <Button
+              kind='plain'
+              size='tiny'
+              onClick={onClickBuy}
+            >
+              {getLocale('braveWalletBuyAsset').replace(
+                '$1',
+                nativeAsset?.symbol ?? '',
+              )}
+            </Button>
+          </div>
+        )}
+    </Wrapper>
+  ))
+}

--- a/components/brave_wallet_ui/components/extension/shared-panel-styles.ts
+++ b/components/brave_wallet_ui/components/extension/shared-panel-styles.ts
@@ -5,7 +5,7 @@
 import styled from 'styled-components'
 import * as leo from '@brave/leo/tokens/css/variables'
 
-import { WalletButton, Text } from '../shared/style'
+import { WalletButton, Text, Column } from '../shared/style'
 import WarningTriangle from '../../assets/svg-icons/warning-triangle.svg'
 import IThemeProps from 'brave-ui/theme/theme-interface'
 
@@ -254,4 +254,9 @@ export const ConfirmationButtonLink = styled(WalletButton)`
   font: ${leo.font.small.semibold};
   letter-spacing: ${leo.typography.letterSpacing.small};
   color: ${leo.color.text.interactive};
+`
+
+export const ScrollableColumn = styled(Column)`
+  overflow-x: hidden;
+  overflow-y: auto;
 `

--- a/components/brave_wallet_ui/utils/routes-utils.ts
+++ b/components/brave_wallet_ui/utils/routes-utils.ts
@@ -447,7 +447,7 @@ export function openTab(url: string) {
 }
 
 // Wallet Page Tabs
-export const openWalletRouteTab = (route: WalletRoutes) => {
+export const openWalletRouteTab = (route: WalletRoutes | string) => {
   openTab(`${WalletOrigin}${route}`)
 }
 


### PR DESCRIPTION
## Description 

- Handles `Insufficient Funds for Gas` errors in the new `Confirmation` panels
- Disables `Confirm` buttons if errors exist
- Displays a `Buy` button if there is `Insufficient Funds for Gas`

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/49345>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

### Test Plan:
1. Create a `Send`, `Swap` or `ERC20 Approve` transaction
2. Update the `Gas` to be something extremely large
3. You should then see the `Insufficient Funds for Gas` error
4. If available, you will see a `Buy` button to purchase for of the transactions `Native` token for gas
5. The `Confirm` button should be disabled if there is an error.

<img width="396" height="658" alt="Screenshot 11" src="https://github.com/user-attachments/assets/6949efc8-88b5-4e68-8800-7eb448031b54" /> | <img width="396" height="654" alt="Screenshot 12" src="https://github.com/user-attachments/assets/685880d3-5e9c-4d58-86e0-afa4e41a8667" /> | <img width="397" height="657" alt="Screenshot 13" src="https://github.com/user-attachments/assets/bb06626f-c438-40d0-997f-cee5085d8ee9" />
--|--|--

https://github.com/user-attachments/assets/e98b3730-72df-4e3a-96bc-86b73a85bb3e


