### PR TITLE
fix(privacy): iOS not masking forced aggressive mode in shields panel

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Shields/ShieldsSettingsViewModel.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Shields/ShieldsSettingsViewModel.swift
@@ -54,9 +54,14 @@ class ShieldsSettingsViewModel: ObservableObject {
     self.shieldsEnabled =
       tab.braveShieldsHelper?.isBraveShieldsEnabled(for: tab.visibleURL)
       ?? true
+    // `considerAlwaysAggressiveETLDs` is `false` to mask that we may force
+    // aggressive mode on some domains.
     self.blockAdsAndTrackingLevel =
-      tab.braveShieldsHelper?.shieldLevel(for: tab.visibleURL, considerAllShieldsOption: true)
-      ?? .standard
+      tab.braveShieldsHelper?.shieldLevel(
+        for: tab.visibleURL,
+        considerAllShieldsOption: true,
+        considerAlwaysAggressiveETLDs: false
+      ) ?? .standard
     self.blockScripts =
       tab.braveShieldsHelper?.isShieldExpected(
         for: tab.visibleURL,
@@ -81,10 +86,13 @@ class ShieldsSettingsViewModel: ObservableObject {
     isUpdatingState = true
     defer { isUpdatingState = false }
     shieldsEnabled = tab.braveShieldsHelper?.isBraveShieldsEnabled(for: tab.visibleURL) ?? true
+    // `considerAlwaysAggressiveETLDs` is `false` to mask that we may force
+    // aggressive mode on some domains.
     blockAdsAndTrackingLevel =
       tab.braveShieldsHelper?.shieldLevel(
         for: tab.visibleURL,
-        considerAllShieldsOption: false
+        considerAllShieldsOption: true,
+        considerAlwaysAggressiveETLDs: false
       ) ?? .standard
     self.blockScripts =
       tab.braveShieldsHelper?.isShieldExpected(

--- a/ios/brave-ios/Sources/BraveShields/Domain+Extensions.swift
+++ b/ios/brave-ios/Sources/BraveShields/Domain+Extensions.swift
@@ -7,10 +7,6 @@ import Data
 import Foundation
 import Preferences
 
-// https://github.com/brave/brave-ios/issues/7611
-/// A list of etld+1s that are always aggressive
-private let alwaysAggressiveETLDs: Set<String> = ["youtube.com"]
-
 extension Domain {
   @MainActor var areAllShieldsOff: Bool {
     return shield_allOff?.boolValue ?? false
@@ -52,28 +48,11 @@ extension Domain {
     domainBlockAdsAndTrackingLevel = isEnabled ? .standard : .disabled
   }
 
-  /// Return the shield level for this domain.
-  ///
-  /// - Warning: This does not consider the "all off" setting
-  /// This also takes into consideration certain domains that are always aggressive.
+  /// Return the shield level for this domain, taking into account if all
+  /// shields are disabled for this domain.
   @MainActor var globalBlockAdsAndTrackingLevel: ShieldLevel {
     guard !areAllShieldsOff else { return .disabled }
-    let globalLevel = domainBlockAdsAndTrackingLevel
-
-    switch globalLevel {
-    case .standard:
-      guard let urlString = self.url else { return globalLevel }
-      guard let url = URL(string: urlString) else { return globalLevel }
-      guard let etldPlusOne = url.baseDomain else { return globalLevel }
-
-      if alwaysAggressiveETLDs.contains(etldPlusOne) {
-        return .aggressive
-      } else {
-        return globalLevel
-      }
-    case .disabled, .aggressive:
-      return globalLevel
-    }
+    return domainBlockAdsAndTrackingLevel
   }
 
   /// Whether or not a given shield should be enabled based on domain exceptions and the users global preference


### PR DESCRIPTION
- On some websites, we force aggressive mode when user has standard mode selected. We mask this in the Shields panel UI across all platforms.
- This change fixes a regression on iOS where this behaviour was not respected by moving the always aggressive check to the tab helper, with a function property to respect the always aggressive check as needed. In the shields panel (using view model `ShieldsSettingsViewModel.swift`), we do not respect the always aggressive check for display purposes to align with other platforms and prior iOS behaviour.

Resolves https://github.com/brave/brave-browser/issues/49348

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

### Testplan

1. Fresh install the app
2. Open Settings > Shields & Privacy and confirm Trackers & Ad Blocking is set to `Standard`
3. Visit `youtube.com`
4. Open shields panel, open advanced controls
5. Verify Trackers & Ad Blocking displays as `Standard`.
    - Do not change this setting or open the dropdown
6. Open Settings > Shields & Privacy and updated Trackers & Ad Blocking to `Aggressive`
7. On `youtube.com` tab, check shields panel displays Trackers & Ad Blocking as `Aggressive`
8. Open Settings > Shields & Privacy and updated Trackers & Ad Blocking to `Disabled`
9. On `youtube.com` tab, check shields panel displays Trackers & Ad Blocking as `Disabled`