### PR TITLE
Hide vertical tabs completely based on pref

### DIFF
--- a/browser/ui/views/frame/brave_browser_view.h
+++ b/browser/ui/views/frame/brave_browser_view.h
@@ -167,7 +167,7 @@ class BraveBrowserView : public BrowserView,
                            BraveMultiContentsViewTest);
   FRIEND_TEST_ALL_PREFIXES(VerticalTabStripHideCompletelyTest, GetMinimumWidth);
   FRIEND_TEST_ALL_PREFIXES(VerticalTabStripHideCompletelyTest,
-                           ShouldBeInVisible);
+                           ShouldBeInvisible);
   FRIEND_TEST_ALL_PREFIXES(SideBySideWithRoundedCornersTest,
                            TabFullscreenStateTest);
   FRIEND_TEST_ALL_PREFIXES(BraveBrowserViewWithRoundedCornersTest,

--- a/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.h
+++ b/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.h
@@ -153,6 +153,7 @@ class VerticalTabStripRegionView : public views::View,
   void OnFloatingModePrefChanged();
   void OnExpandedStatePerWindowPrefChanged();
   void OnExpandedWidthPrefChanged();
+  void OnHideComopletelyWhenCollapsedPrefChanged();
 
   bool IsFloatingVerticalTabsEnabled() const;
   bool IsFloatingEnabledForBrowserFullscreen() const;
@@ -212,6 +213,7 @@ class VerticalTabStripRegionView : public views::View,
   BooleanPrefMember collapsed_pref_;
   BooleanPrefMember expanded_state_per_window_pref_;
   BooleanPrefMember floating_mode_pref_;
+  BooleanPrefMember hide_completely_when_collapsed_pref_;
 
   IntegerPrefMember expanded_width_pref_;
   int expanded_width_ = 220;

--- a/browser/ui/views/tabs/vertical_tab_utils.cc
+++ b/browser/ui/views/tabs/vertical_tab_utils.cc
@@ -9,6 +9,7 @@
 #include "base/check_is_test.h"
 #include "base/command_line.h"
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
+#include "brave/browser/ui/tabs/features.h"
 #include "brave/browser/ui/views/tabs/switches.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser.h"
@@ -72,6 +73,12 @@ bool ShouldShowWindowTitleForVerticalTabs(const Browser* browser) {
 bool IsFloatingVerticalTabsEnabled(const Browser* browser) {
   if (!ShouldShowVerticalTabs(browser)) {
     return false;
+  }
+
+  if (ShouldHideVerticalTabsCompletelyWhenCollapsed(browser)) {
+    // In this case, we should support floating mode regardless of the setting
+    // of kVerticalTabsFloatingEnabled.
+    return true;
   }
 
   return browser->profile()->GetPrefs()->GetBoolean(
@@ -152,6 +159,13 @@ std::pair<int, int> GetLeadingTrailingCaptionButtonWidth(
 #else
 #error "not handled platform"
 #endif
+}
+
+bool ShouldHideVerticalTabsCompletelyWhenCollapsed(const Browser* browser) {
+  return base::FeatureList::IsEnabled(
+             tabs::features::kBraveVerticalTabHideCompletely) &&
+         browser->profile()->GetPrefs()->GetBoolean(
+             brave_tabs::kVerticalTabsHideCompletelyWhenCollapsed);
 }
 
 }  // namespace tabs::utils

--- a/browser/ui/views/tabs/vertical_tab_utils.h
+++ b/browser/ui/views/tabs/vertical_tab_utils.h
@@ -28,6 +28,12 @@ bool IsFloatingVerticalTabsEnabled(const Browser* browser);
 
 bool IsVerticalTabOnRight(const Browser* browser);
 
+// Returns true if we should hide vertical tab completely when collapsed. In
+// this case vertical tab strip will be almost a few pixels wide vertical bar
+// when collapsed. And will expand to show tab icons when mouse is over the bar
+// regardless of the setting of kVerticalTabsFloatingEnabled.
+bool ShouldHideVerticalTabsCompletelyWhenCollapsed(const Browser* browser);
+
 // Returns window caption buttons' width based on the current platform
 std::pair<int, int> GetLeadingTrailingCaptionButtonWidth(
     const BrowserFrame* frame);


### PR DESCRIPTION
Previously, we hid vertical tabs when the flag is on. Now we have a pref to control this feature, so we should consider the pref together.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/49115

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
