### PR TITLE
[NTP Next] Use "hide news" text when user has not enabled News

### DIFF
--- a/browser/resources/brave_new_tab_page_refresh/components/widgets/news_widget.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/widgets/news_widget.tsx
@@ -31,7 +31,12 @@ export function NewsWidget() {
             </leo-menu-item>
         }
         <leo-menu-item onClick={() => braveNews.toggleBraveNewsOnNTP(false)}>
-          <Icon name='disable-outline' /> {getString('newsDisableButtonLabel')}
+          <Icon name='disable-outline' />
+          {
+            braveNews.isOptInPrefEnabled
+              ? getString('newsDisableButtonLabel')
+              : getString('newsHideButtonLabel')
+          }
         </leo-menu-item>
       </WidgetMenu>
       <div className='title'>

--- a/browser/resources/brave_new_tab_page_refresh/lib/strings.ts
+++ b/browser/resources/brave_new_tab_page_refresh/lib/strings.ts
@@ -33,6 +33,7 @@ export type StringKey =
   'newsDisableButtonLabel' |
   'newsEnableButtonLabel' |
   'newsEnableText' |
+  'newsHideButtonLabel' |
   'newsSettingsTitle' |
   'newsWidgetTitle' |
   'photoCreditsText' |

--- a/browser/resources/brave_new_tab_page_refresh/stories/storybook_locale.ts
+++ b/browser/resources/brave_new_tab_page_refresh/stories/storybook_locale.ts
@@ -35,6 +35,7 @@ const localeStrings: Record<StringKey, string>  = {
   newsDisableButtonLabel: 'Disable News',
   newsEnableButtonLabel: 'Turn on Brave News',
   newsEnableText: 'Turn on Brave News, and never miss a story',
+  newsHideButtonLabel: 'Hide News',
   newsSettingsTitle: 'Brave News',
   newsWidgetTitle: 'NEWS',
   photoCreditsText: 'Photo by $1',

--- a/browser/ui/webui/brave_new_tab_page_refresh/new_tab_page_initializer.cc
+++ b/browser/ui/webui/brave_new_tab_page_refresh/new_tab_page_initializer.cc
@@ -196,6 +196,7 @@ void NewTabPageInitializer::AddStrings() {
       {"hideTopSitesLabel", IDS_NEW_TAB_HIDE_TOP_SITES_LABEL},
       {"newsEnableButtonLabel", IDS_BRAVE_NEWS_OPT_IN_ACTION_LABEL},
       {"newsEnableText", IDS_BRAVE_NEWS_INTRO_TITLE},
+      {"newsHideButtonLabel", IDS_NEW_TAB_NEWS_HIDE_BUTTON_LABEL},
       {"newsSettingsTitle", IDS_BRAVE_NEWS_SETTINGS_TITLE},
       {"newsWidgetTitle", IDS_NEW_TAB_NEWS_WIDGET_TITLE},
       {"photoCreditsText", IDS_NEW_TAB_PHOTO_CREDITS_TEXT},

--- a/components/resources/brave_new_tab_page_strings.grdp
+++ b/components/resources/brave_new_tab_page_strings.grdp
@@ -93,6 +93,10 @@
     Disable News
   </message>
 
+  <message name="IDS_NEW_TAB_NEWS_HIDE_BUTTON_LABEL" desc="Label for button that hides News on the NTP">
+    Hide News
+  </message>
+
   <message name="IDS_NEW_TAB_NEWS_WIDGET_TITLE" desc="Title for Brave News widget">
     NEWS
   </message>


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/49159

<img width="540" height="150" alt="Screenshot 2025-09-17 at 4 33 50 PM" src="https://github.com/user-attachments/assets/c5404f86-b50e-4ee1-92fe-5d044e5f8168" />


<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
