### PR TITLE
require commit hash for sync rebase pr workflow

### DIFF
--- a/.github/workflows/sync-and-rebase-pr-from-fork.yml
+++ b/.github/workflows/sync-and-rebase-pr-from-fork.yml
@@ -6,6 +6,9 @@ on:
       PR_NUMBER:
         required: true
         description: "Number of the PR from the fork"
+      COMMIT_HASH:
+        required: true
+        description: "Commit hash of the PR"
 
 jobs:
   sync-and-rebase-pr-from-fork:
@@ -26,6 +29,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           PR_NUMBER: ${{ inputs.PR_NUMBER }}
+          COMMIT_HASH: ${{ inputs.COMMIT_HASH }}
         run: |
           set -x
           JQ="jq -e -r"
@@ -48,6 +52,13 @@ jobs:
           # Rebase the branch with the latest targeting branch HEAD
           git checkout "$contribHeadRefName"
           git fetch origin "$baseRefName"
+
+          ACTUAL_PR_HASH=$(git rev-parse HEAD)
+          if [[ "$ACTUAL_PR_HASH" != "$COMMI_THASH" ]]; then
+            echo "FORK HASH does not match provided hash! Make sure the PR has no changes that have not been reviewed. Exiting!"
+            exit 1
+          fi
+
           if ! git rebase FETCH_HEAD; then
             echo "Rebase conflict detected. Please resolve the conflicts and push the changes to your fork. Exiting!"
             exit 1

--- a/.github/workflows/sync-and-rebase-pr-from-fork.yml
+++ b/.github/workflows/sync-and-rebase-pr-from-fork.yml
@@ -48,11 +48,12 @@ jobs:
           git remote add contributor "https://github.com/$headRepositoryOwnerLogin/$headRepositoryName.git" || :
           contribHeadRefName="contributor-$headRepositoryOwnerLogin-$headRefName"
           git fetch --no-tags contributor +"$headRefName":"$contribHeadRefName"
-
-          # Rebase the branch with the latest targeting branch HEAD
+          # Note we are checking out the provided commit hash instead of the pr-branch to avoid race condition
+          # The author could have commited malicious code between the last review and the execution of this workflow
           git checkout "$COMMIT_HASH"
+          
+          # Rebase the branch with the latest targeting branch HEAD
           git fetch origin "$baseRefName"
-
           if ! git rebase FETCH_HEAD; then
             echo "Rebase conflict detected. Please resolve the conflicts and push the changes to your fork. Exiting!"
             exit 1

--- a/.github/workflows/sync-and-rebase-pr-from-fork.yml
+++ b/.github/workflows/sync-and-rebase-pr-from-fork.yml
@@ -32,10 +32,15 @@ jobs:
           COMMIT_HASH: ${{ inputs.COMMIT_HASH }}
         run: |
           set -x
-          JQ="jq -e -r"
+
+          if ! grep -qix '[0-9a-f]\{40,40\}' <<<"$COMMIT_HASH"; then 
+            echo "Provide a full commit hash; got: $COMMIT_HASH"
+            exit 1
+          fi
 
           gh_pr_view=$(gh pr view "$PR_NUMBER" --json baseRefName,headRefName,headRepository,headRepositoryOwner,id,isCrossRepository,url)
 
+          JQ="jq -e -r"
           baseRefName=$($JQ ".baseRefName" <<<"$gh_pr_view")
           headRefName=$($JQ ".headRefName" <<<"$gh_pr_view")
           headRepositoryName=$($JQ ".headRepository.name" <<<"$gh_pr_view")

--- a/.github/workflows/sync-and-rebase-pr-from-fork.yml
+++ b/.github/workflows/sync-and-rebase-pr-from-fork.yml
@@ -50,14 +50,8 @@ jobs:
           git fetch --no-tags contributor +"$headRefName":"$contribHeadRefName"
 
           # Rebase the branch with the latest targeting branch HEAD
-          git checkout "$contribHeadRefName"
+          git checkout "$COMMIT_HASH"
           git fetch origin "$baseRefName"
-
-          ACTUAL_PR_HASH=$(git rev-parse HEAD)
-          if [[ "$ACTUAL_PR_HASH" != "$COMMI_THASH" ]]; then
-            echo "FORK HASH does not match provided hash! Make sure the PR has no changes that have not been reviewed. Exiting!"
-            exit 1
-          fi
 
           if ! git rebase FETCH_HEAD; then
             echo "Rebase conflict detected. Please resolve the conflicts and push the changes to your fork. Exiting!"


### PR DESCRIPTION
Resolves  https://bravesoftware.slack.com/archives/C6R461GF4/p1757771585820629

There is a race condition between pr review and workflow execution that could be exploited to run untrusted code on our CI.

This PR introduces an additional check against the reviewed commit hash that will need to be provided by the user of the workflow