### PR TITLE
[NTP Next] Use "hide news" text when user has not enabled News (uplift to 1.83.x)

### DIFF
--- a/browser/resources/brave_new_tab_page_refresh/components/widgets/news_widget.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/widgets/news_widget.tsx
@@ -31,7 +31,12 @@ export function NewsWidget() {
             </leo-menu-item>
         }
         <leo-menu-item onClick={() => braveNews.toggleBraveNewsOnNTP(false)}>
-          <Icon name='disable-outline' /> {getString('newsDisableButtonLabel')}
+          <Icon name='disable-outline' />
+          {
+            braveNews.isOptInPrefEnabled
+              ? getString('newsDisableButtonLabel')
+              : getString('newsHideButtonLabel')
+          }
         </leo-menu-item>
       </WidgetMenu>
       <div className='title'>

--- a/browser/resources/brave_new_tab_page_refresh/lib/strings.ts
+++ b/browser/resources/brave_new_tab_page_refresh/lib/strings.ts
@@ -33,6 +33,7 @@ export type StringKey =
   'newsDisableButtonLabel' |
   'newsEnableButtonLabel' |
   'newsEnableText' |
+  'newsHideButtonLabel' |
   'newsSettingsTitle' |
   'newsWidgetTitle' |
   'photoCreditsText' |

--- a/browser/resources/brave_new_tab_page_refresh/stories/storybook_locale.ts
+++ b/browser/resources/brave_new_tab_page_refresh/stories/storybook_locale.ts
@@ -35,6 +35,7 @@ const localeStrings: Record<StringKey, string>  = {
   newsDisableButtonLabel: 'Disable News',
   newsEnableButtonLabel: 'Turn on Brave News',
   newsEnableText: 'Turn on Brave News, and never miss a story',
+  newsHideButtonLabel: 'Hide News',
   newsSettingsTitle: 'Brave News',
   newsWidgetTitle: 'NEWS',
   photoCreditsText: 'Photo by $1',

--- a/browser/ui/webui/brave_new_tab_page_refresh/new_tab_page_initializer.cc
+++ b/browser/ui/webui/brave_new_tab_page_refresh/new_tab_page_initializer.cc
@@ -192,6 +192,7 @@ void NewTabPageInitializer::AddStrings() {
       {"hideTopSitesLabel", IDS_NEW_TAB_HIDE_TOP_SITES_LABEL},
       {"newsEnableButtonLabel", IDS_BRAVE_NEWS_OPT_IN_ACTION_LABEL},
       {"newsEnableText", IDS_BRAVE_NEWS_INTRO_TITLE},
+      {"newsHideButtonLabel", IDS_NEW_TAB_NEWS_HIDE_BUTTON_LABEL},
       {"newsSettingsTitle", IDS_BRAVE_NEWS_SETTINGS_TITLE},
       {"newsWidgetTitle", IDS_NEW_TAB_NEWS_WIDGET_TITLE},
       {"photoCreditsText", IDS_NEW_TAB_PHOTO_CREDITS_TEXT},

--- a/components/resources/brave_new_tab_page_strings.grdp
+++ b/components/resources/brave_new_tab_page_strings.grdp
@@ -93,6 +93,10 @@
     Disable News
   </message>
 
+  <message name="IDS_NEW_TAB_NEWS_HIDE_BUTTON_LABEL" desc="Label for button that hides News on the NTP">
+    Hide News
+  </message>
+
   <message name="IDS_NEW_TAB_NEWS_WIDGET_TITLE" desc="Title for Brave News widget">
     NEWS
   </message>


### PR DESCRIPTION
Uplift of #31270
Resolves https://github.com/brave/brave-browser/issues/49159

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.