### PR TITLE
[NTP] Fix settings modal popping over News modal

### DIFF
--- a/browser/resources/brave_new_tab_page_refresh/components/settings/settings_modal.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/settings/settings_modal.tsx
@@ -125,14 +125,8 @@ export function SettingsModal(props: Props) {
       <Dialog
         isOpen={props.isOpen}
         showClose
-        onClose={() => {
-          // If the News dialog is open, keep the settings dialog open so that
-          // closing the News dialog will bring the user back to the settings
-          // dialog.
-          if (!braveNews.customizePage) {
-            props.onClose()
-          }
-        }}
+        onClose={() => props.onClose()}
+        backdropClickCloses={!braveNews.customizePage}
       >
         <h3>
           {getString('settingsTitle')}

--- a/components/brave_new_tab_ui/containers/newTab/settings.tsx
+++ b/components/brave_new_tab_ui/containers/newTab/settings.tsx
@@ -140,13 +140,12 @@ export default function Settings(props: Props) {
     changeTab(props.setActiveTab)
   }, [props.setActiveTab])
 
-  return <SettingsDialog isOpen={props.showSettingsMenu} showClose onClose={() => {
-    if (customizePage) {
-      return
-    }
-
-    props.onClose?.()
-  }}>
+  return <SettingsDialog
+    isOpen={props.showSettingsMenu}
+    showClose
+    onClose={() => { props.onClose?.() }}
+    backdropClickCloses={!customizePage}
+  >
     <SettingsTitle slot='title'>
       {getLocale('dashboardSettingsTitle')}
     </SettingsTitle>


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/49423

### Explanation

Both the NTP settings modal and News modal are HTML top-layer dialogs. The settings modal is configured to close when the user clicks outside of the modal rectangle. When the user opens the News modal from the settings modal, both modals are displayed. When the user clicks "outside" the settings modal, it closes the modal. When the React component for the settings modal is re-rendered (due to a state change), the modal is re-opened. Since it is a top-layer element, it displays on top of the News modal.

It's not clear why this worked previously (perhaps there was a blink rendering change?). The solution is to disable the "close on click outside" behavior if the News modal is open.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
