### PR TITLE
fix(sync): Enable password sync by default (for new users) on iOS

### DIFF
--- a/ios/brave-ios/App/iOS/Delegates/AppDelegate.swift
+++ b/ios/brave-ios/App/iOS/Delegates/AppDelegate.swift
@@ -219,16 +219,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
       Preferences.Search.shouldOverrideDSEForJapanRegion.value = false
     }
 
-    if FeatureList.kBraveSyncDefaultPasswords.enabled, isFirstLaunch {
-      // For new users, we want to enable by sync passwords by default.
-      // However, if we update the `defaultValue` then existing users
-      // who setup a sync chain but never enabled password sync would
-      // see password sync change to enabled. We only want this for new
-      // users, so we assign on first launch.
-      // This preference will be removed with brave-browser#47487.
-      Preferences.Chromium.syncPasswordsEnabled.value = true
-    }
-
     Preferences.General.isFirstLaunch.value = false
 
     Task {

--- a/ios/brave-ios/App/iOS/Delegates/AppDelegate.swift
+++ b/ios/brave-ios/App/iOS/Delegates/AppDelegate.swift
@@ -219,6 +219,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
       Preferences.Search.shouldOverrideDSEForJapanRegion.value = false
     }
 
+    if FeatureList.kBraveSyncDefaultPasswords.enabled, isFirstLaunch {
+      // For new users, we want to enable by sync passwords by default.
+      // However, if we update the `defaultValue` then existing users
+      // who setup a sync chain but never enabled password sync would
+      // see password sync change to enabled. We only want this for new
+      // users, so we assign on first launch.
+      // This preference will be removed with brave-browser#47487.
+      Preferences.Chromium.syncPasswordsEnabled.value = true
+    }
+
     Preferences.General.isFirstLaunch.value = false
 
     Task {

--- a/ios/brave-ios/Sources/Brave/Frontend/Sync/BraveCore/BraveSyncAPIExtensions.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Sync/BraveCore/BraveSyncAPIExtensions.swift
@@ -59,6 +59,10 @@ extension BraveSyncAPI {
     if setSyncCode(codeWords) {
       // Enable default sync type Bookmarks when joining a chain
       Preferences.Chromium.syncBookmarksEnabled.value = true
+      // when setting up a new chain, use the feature flag to determine if
+      // password sync is enabled or not
+      Preferences.Chromium.syncPasswordsEnabled.value =
+        FeatureList.kBraveSyncDefaultPasswords.enabled
       enableSyncTypes(syncProfileService: syncProfileService)
       requestSync()
       setSetupComplete()
@@ -88,7 +92,7 @@ extension BraveSyncAPI {
 
   func resetSyncChain() {
     Preferences.Chromium.syncHistoryEnabled.value = false
-    Preferences.Chromium.syncPasswordsEnabled.value = false
+    Preferences.Chromium.syncPasswordsEnabled.value = FeatureList.kBraveSyncDefaultPasswords.enabled
     Preferences.Chromium.syncOpenTabsEnabled.value = false
 
     resetSync()

--- a/ios/brave-ios/Sources/Brave/Frontend/Sync/SyncWelcomeViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Sync/SyncWelcomeViewController.swift
@@ -559,6 +559,9 @@ extension SyncWelcomeViewController: SyncPairControllerDelegate {
   private func enableDefaultTypeAndPushSettings() {
     // Enable default sync type Bookmarks and push settings
     Preferences.Chromium.syncBookmarksEnabled.value = true
+    // when setting up a new chain, use the feature flag to determine if
+    // password sync is enabled or not
+    Preferences.Chromium.syncPasswordsEnabled.value = FeatureList.kBraveSyncDefaultPasswords.enabled
     syncAPI.enableSyncTypes(syncProfileService: syncProfileServices)
     pushSettings()
   }

--- a/ios/brave-ios/Sources/Brave/Migration/Migration.swift
+++ b/ios/brave-ios/Sources/Brave/Migration/Migration.swift
@@ -563,9 +563,6 @@ extension Preferences.Option {
   }
 
   fileprivate var isValueStored: Bool {
-    guard let value = container.object(forKey: key) else {
-      return false
-    }
-    return (value as? ValueType) != nil
+    (container.object(forKey: key) as? ValueType) != nil
   }
 }

--- a/ios/brave-ios/Sources/Brave/Migration/Migration.swift
+++ b/ios/brave-ios/Sources/Brave/Migration/Migration.swift
@@ -24,6 +24,7 @@ public class BraveProfileMigrations {
     migrateDebouncePreferences()
     migrateDefaultUserAgentPreferences()
     migrateBlockPopupsPreferences()
+    migrateSyncPasswordsDefault()
   }
 
   private func migrateDefaultUserAgentPreferences() {
@@ -54,6 +55,31 @@ public class BraveProfileMigrations {
     let debounceService = DebounceServiceFactory.get(privateMode: false)
     debounceService?.isEnabled = isDebounceEnabled
     Preferences.Shields.autoRedirectTrackingURLsDeprecated.value = nil
+  }
+
+  /// Migrate sync passwords default value to enabled.
+  /// If a user has a sync chain, but has not touched the sync passwords value,
+  /// we do not want their passwords sync pref to enable so we assign the old
+  /// default value.
+  private func migrateSyncPasswordsDefault() {
+    guard !Preferences.Migration.syncPasswordsEnabledByDefault.value else {
+      // already ran this migration
+      return
+    }
+    guard profileController.syncAPI.isInSyncGroup else {
+      // user is not in a sync chain, so the
+      // Preferences.Chromium.syncPasswordsEnabled default can be used
+      return
+    }
+    guard !Preferences.Chromium.syncPasswordsEnabled.isValueStored else {
+      // user has either enabled/disabled sync passwords, do not change it
+      // from their explict set preference
+      return
+    }
+    // user is currently using the `defaultValue`, which is updating from
+    // disabled to enabled. Keep them on the old `defaultValue`
+    Preferences.Chromium.syncPasswordsEnabled.value = false
+    Preferences.Migration.syncPasswordsEnabledByDefault.value = true
   }
 }
 
@@ -309,6 +335,12 @@ extension Preferences {
       key: "migration.youtube-high-quality-default",
       default: false
     )
+
+    /// Migrated sync passwords to enabled by default.
+    static let syncPasswordsEnabledByDefault = Option<Bool>(
+      key: "migration.sync-passwords-enabled-by-default",
+      default: false
+    )
   }
 
   /// Migrate a given key from `Prefs` into a specific option
@@ -528,5 +560,12 @@ extension Preferences.Option {
     } else {
       Logger.module.info("Could not migrate legacy pref with key: \"\(self.key)\".")
     }
+  }
+
+  fileprivate var isValueStored: Bool {
+    guard let value = container.object(forKey: key) else {
+      return false
+    }
+    return (value as? ValueType) != nil
   }
 }

--- a/ios/brave-ios/Sources/Preferences/GlobalPreferences.swift
+++ b/ios/brave-ios/Sources/Preferences/GlobalPreferences.swift
@@ -239,7 +239,7 @@ extension Preferences {
     /// The sync type passwords enabled the device in sync chain
     public static let syncPasswordsEnabled = Option<Bool>(
       key: "chromium.sync.syncPasswordsEnabled",
-      default: false
+      default: false  // set to true on first launch
     )
     /// The sync type open tabs enabled the device in sync chain
     public static let syncOpenTabsEnabled = Option<Bool>(

--- a/ios/brave-ios/Sources/Preferences/GlobalPreferences.swift
+++ b/ios/brave-ios/Sources/Preferences/GlobalPreferences.swift
@@ -239,7 +239,7 @@ extension Preferences {
     /// The sync type passwords enabled the device in sync chain
     public static let syncPasswordsEnabled = Option<Bool>(
       key: "chromium.sync.syncPasswordsEnabled",
-      default: false  // set to true on first launch
+      default: true  // default is unused; kBraveSyncDefaultPasswords respected
     )
     /// The sync type open tabs enabled the device in sync chain
     public static let syncOpenTabsEnabled = Option<Bool>(

--- a/ios/browser/api/features/features.h
+++ b/ios/browser/api/features/features.h
@@ -84,6 +84,7 @@ OBJC_EXPORT
 @property(class, nonatomic, readonly) Feature* kModernTabTrayEnabled;
 @property(class, nonatomic, readonly) Feature* kBraveWalletWebUIIOS;
 @property(class, nonatomic, readonly) Feature* kAIChatWebUIEnabled;
+@property(class, nonatomic, readonly) Feature* kBraveSyncDefaultPasswords;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/browser/api/features/features.mm
+++ b/ios/browser/api/features/features.mm
@@ -362,4 +362,9 @@
       [[Feature alloc] initWithFeature:&ai_chat::features::kAIChatWebUIEnabled];
 }
 
++ (Feature*)kBraveSyncDefaultPasswords {
+  return [[Feature alloc]
+      initWithFeature:&brave_sync::features::kBraveSyncDefaultPasswords];
+}
+
 @end

--- a/ios/browser/flags/DEPS
+++ b/ios/browser/flags/DEPS
@@ -3,6 +3,7 @@ include_rules = [
   "+brave/components/brave_component_updater/browser/features.h",
   "+brave/components/brave_rewards/core/features.h",
   "+brave/components/brave_shields/core/common/features.h",
+  "+brave/components/brave_sync/features.h",
   "+brave/components/brave_wallet/common/features.h",
   "+brave/components/brave_user_agent/common/features.h",
   "+brave/components/de_amp/common/features.h",

--- a/ios/browser/flags/about_flags.mm
+++ b/ios/browser/flags/about_flags.mm
@@ -9,6 +9,7 @@
 #include "brave/components/brave_component_updater/browser/features.h"
 #include "brave/components/brave_rewards/core/features.h"
 #include "brave/components/brave_shields/core/common/features.h"
+#include "brave/components/brave_sync/features.h"
 #include "brave/components/brave_user_agent/common/features.h"
 #include "brave/components/brave_wallet/common/features.h"
 #include "brave/components/de_amp/common/features.h"
@@ -184,6 +185,14 @@
           "Replace the tab tray UI with a modern replacement",                 \
           flags_ui::kOsIos,                                                    \
           FEATURE_VALUE_TYPE(brave::features::kModernTabTrayEnabled),          \
+      },                                                                       \
+      {                                                                        \
+          "brave-sync-default-passwords",                                      \
+          "Enable password syncing by default",                                \
+          "Turn on password syncing when Sync is enabled.",                    \
+          flags_ui::kOsIos,                                                    \
+          FEATURE_VALUE_TYPE(                                                  \
+              brave_sync::features::kBraveSyncDefaultPasswords),               \
       },                                                                       \
       {                                                                        \
           "brave-translate-enabled",                                           \

--- a/ios/browser/flags/sources.gni
+++ b/ios/browser/flags/sources.gni
@@ -10,6 +10,7 @@ brave_flags_deps = [
   "//brave/components/brave_rewards/core",
   "//brave/components/brave_rewards/core/buildflags",
   "//brave/components/brave_shields/core/common",
+  "//brave/components/brave_sync:features",
   "//brave/components/brave_user_agent/common",
   "//brave/components/brave_wallet/common",
   "//brave/components/de_amp/common",


### PR DESCRIPTION
- Enable password sync by default for new users (those who have never launched the app before), when the feature flag is enabled.

Resolves https://github.com/brave/brave-browser/issues/49454

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

### Testplan

New Users:
1) Verify `brave-sync-default-passwords` flag is enabled.
2) Setup or join a sync chain
3) Verify Passwords sync is enabled by default .

New Users (flag disabled):
1) disable `brave-sync-default-passwords` flag.
2) Setup or join a sync chain
3) Verify Passwords sync is disabled by default.

Existing Users (passwords unchanged):
1) On prior build, setup a sync chain and leave Passwords sync disabled.
2) Update the app to version with this change. 
3) Verify Passwords sync remains disabled.

Existing Users (passwords unchanged):
1) On prior build, setup a sync chain and update Password sync to enabled
2) Update the app to version with this change
3) Verify Passwords sync remains enabled.