### PR TITLE
[iOS] Replace Brave Talk deprecated event listener for MutationObserver (uplift to 1.83.x)

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/DomainSpecific/Paged/BraveTalkScript.js
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/DomainSpecific/Paged/BraveTalkScript.js
@@ -29,12 +29,21 @@ window.__firefox__.includeOnce("BraveTalkScript", function($) {
     });
   });
 
-  const postRoom = $((event) => {
-    if (event.target.tagName !== undefined && event.target.tagName.toLowerCase() == "iframe") {
-      launchNativeBraveTalk(event.target.src);
-      window.removeEventListener("DOMNodeInserted", postRoom)
-    }
+  const observer = new MutationObserver($((mutations) => {
+    mutations.forEach((mutation) => {
+      mutation.addedNodes.forEach((node) => {
+        if (node.nodeType === Node.ELEMENT_NODE && node.tagName &&
+            node.tagName.toLowerCase() === "iframe") {
+          launchNativeBraveTalk(node.src);
+          observer.disconnect();
+        }
+      });
+    });
+  }));
+
+  observer.observe(document, {
+    childList: true,
+    subtree: true
   });
-  window.addEventListener("DOMNodeInserted", postRoom);
 });
 


### PR DESCRIPTION
Uplift of #30850
Resolves https://github.com/brave/brave-browser/issues/48732

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.