### PR TITLE
[iOS] Enable design compatibility mode for iOS 26 (uplift to 1.83.x)

### DIFF
--- a/ios/brave-ios/App/iOS/Supporting Files/Info.plist
+++ b/ios/brave-ios/App/iOS/Supporting Files/Info.plist
@@ -192,5 +192,7 @@
 		<string>A000000527471117</string>
 		<string>A0000006472F0001</string>
 	</array>
+	<key>UIDesignRequiresCompatibility</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
Uplift of #30853
Resolves https://github.com/brave/brave-browser/issues/48747

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.