### PR TITLE
fix(iOS): Pickers in Settings not displayed as expected when build with Xcode 26 / iOS 26 (uplift to 1.83.x)

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/Debug/AdBlock/AdBlockDebugView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/Debug/AdBlock/AdBlockDebugView.swift
@@ -4,6 +4,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import BraveShared
+import BraveUI
 import Strings
 import SwiftUI
 import WebKit
@@ -45,7 +46,7 @@ private struct CompileContentBlockersSectionView: View {
         .multilineTextAlignment(.trailing)
       }
 
-      Picker(selection: $selection) {
+      FormPicker(selection: $selection) {
         ForEach(availableSelections) { selection in
           Group {
             Text(getTitle(for: selection)) + Text(verbatim: " v\(selection.filterListInfo.version)")

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/DefaultShieldsSectionView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/DefaultShieldsSectionView.swift
@@ -19,7 +19,7 @@ struct DefaultShieldsSectionView: View {
 
   var body: some View {
     Section {
-      Picker(selection: $settings.adBlockAndTrackingPreventionLevel) {
+      FormPicker(selection: $settings.adBlockAndTrackingPreventionLevel) {
         ForEach(ShieldLevel.allCases) { level in
           Text(level.localizedTitle)
             .foregroundColor(Color(.secondaryBraveLabel))
@@ -33,7 +33,7 @@ struct DefaultShieldsSectionView: View {
       }
 
       if FeatureList.kBraveHttpsByDefault.enabled {
-        Picker(selection: $settings.httpsUpgradeLevel) {
+        FormPicker(selection: $settings.httpsUpgradeLevel) {
           ForEach(HTTPSUpgradeLevel.allCases) { level in
             Text(level.localizedTitle)
               .foregroundColor(Color(.secondaryBraveLabel))
@@ -97,7 +97,7 @@ struct DefaultShieldsSectionView: View {
       )
 
       if FeatureList.kBraveShredFeature.enabled {
-        Picker(selection: $settings.shredLevel) {
+        FormPicker(selection: $settings.shredLevel) {
           ForEach(SiteShredLevel.allCases) { level in
             Text(level.localizedTitle)
               .foregroundColor(Color(.secondaryBraveLabel))

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/ShredSettingsView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/ShredSettingsView.swift
@@ -24,7 +24,7 @@ struct ShredSettingsView: View {
   var body: some View {
     Form {
       Section {
-        Picker(selection: $settings.shredLevel) {
+        FormPicker(selection: $settings.shredLevel) {
           ForEach(SiteShredLevel.allCases) { level in
             Text(level.localizedTitle)
               .foregroundColor(Color(.secondaryBraveLabel))

--- a/ios/brave-ios/Sources/BraveNews/Settings/BraveNewsDebugSettingsView.swift
+++ b/ios/brave-ios/Sources/BraveNews/Settings/BraveNewsDebugSettingsView.swift
@@ -64,15 +64,19 @@ public struct BraveNewsDebugSettingsView: View {
   public var body: some View {
     Form {
       Section {
-        Picker("Environment", selection: $environment) {
+        FormPicker(selection: $environment) {
           ForEach(FeedDataSource.Environment.allCases, id: \.self) { env in
             Text(env.name)
           }
+        } label: {
+          Text("Environment")
         }
-        Picker("Selected Locale", selection: $localeOverride) {
+        FormPicker(selection: $localeOverride) {
           ForEach(Array(feedDataSource.availableLocales).sorted(), id: \.self) { locale in
             Text(locale).tag(locale)
           }
+        } label: {
+          Text("Selected Locale")
         }
       } footer: {
         Text("Changing the environment will purge all cached resources immediately.")

--- a/ios/brave-ios/Sources/BraveUI/SwiftUI/FormPicker.swift
+++ b/ios/brave-ios/Sources/BraveUI/SwiftUI/FormPicker.swift
@@ -1,0 +1,54 @@
+// Copyright 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import SwiftUI
+
+/// When building with iOS 26, using a Picker in a Form will prioritize the
+/// label text and push the Picker to be below the label when the text is long
+/// enough. This can be used as a drop-in replacement for Picker when used in
+/// a Form to force the Picker to stay beside the text, except when in an
+/// accessibility size category.
+public struct FormPicker<Label: View, SelectionValue: Hashable, Content: View>: View {
+  var content: Content
+  var label: Label
+  @Binding var selection: SelectionValue
+
+  @Environment(\.sizeCategory) private var sizeCategory
+
+  public init(
+    selection: Binding<SelectionValue>,
+    @ViewBuilder content: () -> Content,
+    @ViewBuilder label: () -> Label
+  ) {
+    self.content = content()
+    self.label = label()
+    self._selection = selection
+  }
+
+  public var body: some View {
+    if sizeCategory.isAccessibilityCategory {
+      VStack(alignment: .leading) {
+        stackContent
+      }
+    } else {
+      HStack {
+        stackContent
+      }
+    }
+  }
+
+  @ViewBuilder private var stackContent: some View {
+    label
+      .accessibilityHidden(true)
+    Spacer()
+    Picker(selection: $selection) {
+      content
+    } label: {
+      label
+        .accessibilityHidden(false)
+    }
+    .labelsHidden()
+  }
+}

--- a/ios/brave-ios/Sources/BraveWallet/Settings/Web3SettingsView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Settings/Web3SettingsView.swift
@@ -136,7 +136,7 @@ private struct WalletSettingsView: View {
       footer: Text(Strings.Wallet.autoLockFooter)
         .foregroundColor(Color(.secondaryBraveLabel))
     ) {
-      Picker(selection: $settingsStore.autoLockInterval) {
+      FormPicker(selection: $settingsStore.autoLockInterval) {
         ForEach(autoLockIntervals) { interval in
           Text(interval.label)
             .foregroundColor(Color(.secondaryBraveLabel))
@@ -150,7 +150,7 @@ private struct WalletSettingsView: View {
       .listRowBackground(Color(.secondaryBraveGroupedBackground))
     }
     Section {
-      Picker(selection: $settingsStore.currencyCode) {
+      FormPicker(selection: $settingsStore.currencyCode) {
         ForEach(CurrencyCode.allCodes) { currencyCode in
           Text(currencyCode.code)
             .foregroundColor(Color(.secondaryBraveLabel))
@@ -314,7 +314,7 @@ private struct Web3DomainSettingsView: View {
   }
 
   @ViewBuilder private var ensResolveMethodPreference: some View {
-    Picker(selection: $settingsStore.ensResolveMethod) {
+    FormPicker(selection: $settingsStore.ensResolveMethod) {
       ForEach(BraveWallet.ResolveMethod.allCases) { option in
         Text(option.name)
           .foregroundColor(Color(.secondaryBraveLabel))
@@ -328,7 +328,7 @@ private struct Web3DomainSettingsView: View {
   }
 
   @ViewBuilder private var ensOffchainResolveMethodPreference: some View {
-    Picker(selection: $settingsStore.ensOffchainResolveMethod) {
+    FormPicker(selection: $settingsStore.ensOffchainResolveMethod) {
       ForEach(BraveWallet.ResolveMethod.allCases) { option in
         Text(option.name)
           .foregroundColor(Color(.secondaryBraveLabel))
@@ -355,7 +355,7 @@ private struct Web3DomainSettingsView: View {
   }
 
   @ViewBuilder private var snsResolveMethodPreference: some View {
-    Picker(selection: $settingsStore.snsResolveMethod) {
+    FormPicker(selection: $settingsStore.snsResolveMethod) {
       ForEach(BraveWallet.ResolveMethod.allCases) { option in
         Text(option.name)
           .foregroundColor(Color(.secondaryBraveLabel))
@@ -369,7 +369,7 @@ private struct Web3DomainSettingsView: View {
   }
 
   @ViewBuilder private var udResolveMethodPreference: some View {
-    Picker(selection: $settingsStore.udResolveMethod) {
+    FormPicker(selection: $settingsStore.udResolveMethod) {
       ForEach(BraveWallet.ResolveMethod.allCases) { option in
         Text(option.name)
           .foregroundColor(Color(.secondaryBraveLabel))


### PR DESCRIPTION
Uplift of #31153
Resolves https://github.com/brave/brave-browser/issues/49156

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.