### PR TITLE
[NTP] Fix settings modal popping over News modal (uplift to 1.83.x)

### DIFF
--- a/browser/resources/brave_new_tab_page_refresh/components/settings/settings_modal.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/settings/settings_modal.tsx
@@ -125,14 +125,8 @@ export function SettingsModal(props: Props) {
       <Dialog
         isOpen={props.isOpen}
         showClose
-        onClose={() => {
-          // If the News dialog is open, keep the settings dialog open so that
-          // closing the News dialog will bring the user back to the settings
-          // dialog.
-          if (!braveNews.customizePage) {
-            props.onClose()
-          }
-        }}
+        onClose={() => props.onClose()}
+        backdropClickCloses={!braveNews.customizePage}
       >
         <h3>
           {getString('settingsTitle')}

--- a/components/brave_new_tab_ui/containers/newTab/settings.tsx
+++ b/components/brave_new_tab_ui/containers/newTab/settings.tsx
@@ -140,13 +140,12 @@ export default function Settings(props: Props) {
     changeTab(props.setActiveTab)
   }, [props.setActiveTab])
 
-  return <SettingsDialog isOpen={props.showSettingsMenu} showClose onClose={() => {
-    if (customizePage) {
-      return
-    }
-
-    props.onClose?.()
-  }}>
+  return <SettingsDialog
+    isOpen={props.showSettingsMenu}
+    showClose
+    onClose={() => { props.onClose?.() }}
+    backdropClickCloses={!customizePage}
+  >
     <SettingsTitle slot='title'>
       {getLocale('dashboardSettingsTitle')}
     </SettingsTitle>


### PR DESCRIPTION
Uplift of #31304
Resolves https://github.com/brave/brave-browser/issues/49423

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.