### PR TITLE
[Brave Midnight] Apply darker theme colors to toolbar buttons

### DIFF
--- a/browser/ui/color/brave_color_mixer.cc
+++ b/browser/ui/color/brave_color_mixer.cc
@@ -145,6 +145,18 @@ void AddBraveVpnColorMixer(ui::ColorProvider* provider,
   }
 
   mixer[kColorBraveVpnButtonBackgroundNormal] = {kColorToolbar};
+
+#if defined(TOOLKIT_VIEWS)
+  if (!base::FeatureList::IsEnabled(
+          darker_theme::features::kBraveDarkerTheme) ||
+      key.scheme_variant != ui::ColorProviderKey::SchemeVariant::kDarker) {
+    return;
+  }
+
+  auto& postprocessing_mixer = provider->AddPostprocessingMixer();
+  postprocessing_mixer[kColorBraveVpnButtonBackgroundNormal] =
+      darker_theme::ApplyDarknessFromColor(nala::kColorPrimitiveNeutral5);
+#endif  // defined(TOOLKIT_VIEWS)
 }
 #endif
 
@@ -765,6 +777,27 @@ void AddBraveOmniboxColorMixer(ui::ColorProvider* provider,
       darker_theme::ApplyDarknessFromColor(nala::kColorPrimitiveNeutral20);
   postprocessing_mixer[kColorBraveOmniboxResultViewSeparator] =
       darker_theme::ApplyDarknessFromColor(nala::kColorPrimitiveNeutral20);
+
+  // Toolbar
+  postprocessing_mixer[kColorToolbarButtonIcon] =
+      darker_theme::ApplyDarknessFromColor(nala::kColorPrimitiveNeutral40);
+  postprocessing_mixer[kColorToolbarButtonIconHovered] =
+      darker_theme::ApplyDarknessFromColor(nala::kColorPrimitiveNeutral50);
+  postprocessing_mixer[kColorToolbarButtonActivated] = {
+      nala::kColorPrimitivePrimary50};
+  postprocessing_mixer[kColorToolbarInkDrop] = {nala::kColorPrimitiveNeutral10};
+  postprocessing_mixer[kColorToolbarInkDropHover] = {
+      nala::kColorPrimitiveNeutral10};
+  postprocessing_mixer[kColorToolbarInkDropRipple] = {
+      nala::kColorPrimitiveNeutral20};
+
+  // Sidebar button
+  postprocessing_mixer[kColorSidebarButtonBase] = {
+      postprocessing_mixer.GetResultColor(kColorToolbarButtonIcon)};
+  if (!HasCustomToolbarColor(key)) {
+    mixer[kColorSidebarButtonPressed] = {
+        postprocessing_mixer.GetResultColor(kColorToolbarButtonActivated)};
+  }
 #endif  // defined(TOOLKIT_VIEWS)
 }
 


### PR DESCRIPTION
When darker theme mode is enabled, apply darker colors to toolbar buttons.

### Before: default gray
<img width="227" height="235" alt="image" src="https://github.com/user-attachments/assets/4cea01fd-6552-42d8-9189-0d842a466daf" />


### Before: with custom theme
<img width="225" height="280" alt="image" src="https://github.com/user-attachments/assets/6efe2475-d908-4453-9d5c-43b24da3a6f3" />

### After: default gray
<img width="237" height="227" alt="image" src="https://github.com/user-attachments/assets/f4fd3640-1b93-41d8-bf35-5fe1a23b4678" />


### After: with custom theme
<img width="235" height="271" alt="image" src="https://github.com/user-attachments/assets/653eb68e-307f-4f1c-899e-e5d05bda2628" />


<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/48197

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
