### PR TITLE
[CR141] Fixed split view border drawing regressions from cr141

### DIFF
--- a/browser/ui/views/frame/split_view/brave_contents_container_view.cc
+++ b/browser/ui/views/frame/split_view/brave_contents_container_view.cc
@@ -29,6 +29,28 @@
 #include "ui/gfx/geometry/rect.h"
 #include "ui/views/border.h"
 
+namespace {
+
+// We dont' let this outline visible always but it sets mini toolbar's clip path
+// even it's hidden. We set mini toolbar's clip path from
+// BraveMultiContentsViewMiniToolbar.
+class BraveContentsContainerOutline : public ContentsContainerOutline {
+  METADATA_HEADER(BraveContentsContainerOutline, ContentsContainerOutline)
+ public:
+  using ContentsContainerOutline::ContentsContainerOutline;
+  ~BraveContentsContainerOutline() override = default;
+
+  // ContentsContainerOutline:
+  void OnViewBoundsChanged(views::View* observed_view) override {
+    // Ignore chromium's mini toolbar path clipping.
+  }
+};
+
+BEGIN_METADATA(BraveContentsContainerOutline)
+END_METADATA
+
+}  // namespace
+
 // static
 BraveContentsContainerView* BraveContentsContainerView::From(
     ContentsContainerView* view) {
@@ -59,8 +81,8 @@ BraveContentsContainerView::BraveContentsContainerView(
     mini_toolbar_ =
         AddChildView(std::make_unique<BraveMultiContentsViewMiniToolbar>(
             browser_view, contents_view_));
-    container_outline_ =
-        AddChildView(std::make_unique<ContentsContainerOutline>(mini_toolbar_));
+    container_outline_ = AddChildView(
+        std::make_unique<BraveContentsContainerOutline>(mini_toolbar_));
   }
 }
 
@@ -68,15 +90,15 @@ BraveContentsContainerView::~BraveContentsContainerView() = default;
 
 void BraveContentsContainerView::UpdateBorderAndOverlay(bool is_in_split,
                                                         bool is_active,
-                                                        bool show_scrim) {
+                                                        bool is_highlighted) {
+  // We don't use highlighted state as we're always using thicker border
+  // for highlighting active split tab.
   ContentsContainerView::UpdateBorderAndOverlay(is_in_split, is_active,
-                                                show_scrim);
-  gfx::RoundedCornersF contents_corner_radius(GetCornerRadius(false));
-  auto* contents_web_view = contents_view();
-  contents_web_view->layer()->SetRoundedCornerRadius(contents_corner_radius);
-  if (contents_web_view->holder()->native_view()) {
-    contents_web_view->holder()->SetCornerRadii(contents_corner_radius);
-  }
+                                                /*is_highlighted*/ false);
+
+  // Don't draw any borders from outline.
+  container_outline_->SetVisible(false);
+  UpdateBorderRoundedCorners();
 
   if (!is_in_split) {
     return;
@@ -100,6 +122,17 @@ void BraveContentsContainerView::UpdateBorderAndOverlay(bool is_in_split,
             /*should_border_scale*/ true),
         gfx::Insets(kBorderThickness)));
   }
+}
+
+void BraveContentsContainerView::UpdateBorderRoundedCorners() {
+  const gfx::RoundedCornersF contents_corner_radius(GetCornerRadius(false));
+
+  contents_view_->layer()->SetRoundedCornerRadius(contents_corner_radius);
+  contents_view_->holder()->SetCornerRadii(contents_corner_radius);
+  contents_scrim_view_->SetRoundedCorners(contents_corner_radius);
+
+  devtools_web_view_->holder()->SetCornerRadii(contents_corner_radius);
+  devtools_scrim_view_->SetRoundedCorners(contents_corner_radius);
 }
 
 views::ProposedLayout BraveContentsContainerView::CalculateProposedLayout(

--- a/browser/ui/views/frame/split_view/brave_contents_container_view.h
+++ b/browser/ui/views/frame/split_view/brave_contents_container_view.h
@@ -34,7 +34,8 @@ class BraveContentsContainerView :
   // ContentsContainerView:
   void UpdateBorderAndOverlay(bool is_in_split,
                               bool is_active,
-                              bool show_scrim) override;
+                              bool is_highlighted) override;
+  void UpdateBorderRoundedCorners() override;
   views::ProposedLayout CalculateProposedLayout(
       const views::SizeBounds& size_bounds) const override;
   void ChildVisibilityChanged(views::View* child) override;

--- a/chromium_src/chrome/browser/ui/views/frame/contents_container_view.h
+++ b/chromium_src/chrome/browser/ui/views/frame/contents_container_view.h
@@ -11,8 +11,11 @@
   friend class BraveContentsContainerView; \
   virtual void UpdateBorderAndOverlay
 
+#define UpdateBorderRoundedCorners virtual UpdateBorderRoundedCorners
+
 #include <chrome/browser/ui/views/frame/contents_container_view.h>  // IWYU pragma: export
 
+#undef UpdateBorderRoundedCorners
 #undef UpdateBorderAndOverlay
 
 #endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_FRAME_CONTENTS_CONTAINER_VIEW_H_


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/49529

In cr141, chromium introduced `ContentsContainerOutline` for handling split view's outline and it's conflicted with ours.
With this PR, only our border drawing is done.

<img width="800" alt="Screenshot 2025-09-23 161951" src="https://github.com/user-attachments/assets/554a73a4-6268-4fe2-a7c2-999a2ecaf139" />
<img width="800" alt="Screenshot 2025-09-23 162015" src="https://github.com/user-attachments/assets/7d4170b1-abf8-4c54-a902-b013128ccbae" />


<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
