### PR TITLE
fix(privacy): Shred on app exit default value (uplift to 1.83.x)

### DIFF
--- a/ios/brave-ios/Sources/BraveShields/Domain+Extensions.swift
+++ b/ios/brave-ios/Sources/BraveShields/Domain+Extensions.swift
@@ -105,6 +105,6 @@ extension Domain {
     let allExplicitlySet = Domain.allDomainsWithAutoShredLevel(SiteShredLevel.appExit.rawValue)
     guard ShieldPreferences.shredLevel.shredOnAppExit else { return allExplicitlySet }
     // Default value is SiteShredLevel.appExit, include all with default value nil
-    return (allExplicitlySet ?? []) + (Domain.allDomainsWithAutoShredLevel("nil") ?? [])
+    return (allExplicitlySet ?? []) + (Domain.allDomainsWithAutoShredLevel(nil) ?? [])
   }
 }

--- a/ios/brave-ios/Sources/BraveShields/ShieldPreferences.swift
+++ b/ios/brave-ios/Sources/BraveShields/ShieldPreferences.swift
@@ -33,9 +33,9 @@ public class ShieldPreferences {
     default: nil
   )
 
-  /// Get the level of the https upgrade setting as a stored preference
-  /// - Warning: You should not access this directly but  through ``httpsUpgradeLevel``
-  private static var shredLevelRaw = Preferences.Option<String?>(
+  /// Get the auto shred level setting as a stored preference
+  /// - Warning: You should not access this directly but  through ``shredLevel``
+  static var shredLevelRaw = Preferences.Option<String?>(
     key: "shields.shred-level",
     default: nil
   )

--- a/ios/brave-ios/Sources/Data/models/Domain.swift
+++ b/ios/brave-ios/Sources/Data/models/Domain.swift
@@ -119,11 +119,18 @@ public final class Domain: NSManagedObject, CRUD {
     )
   }
 
-  public class func allDomainsWithAutoShredLevel(_ autoShredLevel: String) -> [Domain]? {
-    let shredLevelPredicate = NSPredicate(
-      format: "shield_shredLevel == %@",
-      autoShredLevel
-    )
+  /// Returns all domains with a given `SiteShredLevel`s rawValue, or `nil`
+  /// for Domains with no shred level assigned.
+  public class func allDomainsWithAutoShredLevel(_ siteShredLevel: String?) -> [Domain]? {
+    let shredLevelPredicate: NSPredicate
+    if let siteShredLevel {
+      shredLevelPredicate = NSPredicate(
+        format: "shield_shredLevel == %@",
+        siteShredLevel
+      )
+    } else {
+      shredLevelPredicate = NSPredicate(format: "shield_shredLevel == nil")
+    }
     return Domain.all(where: shredLevelPredicate)
   }
 


### PR DESCRIPTION
Uplift of #31358
Resolves https://github.com/brave/brave-browser/issues/49464

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.