### PR TITLE
Shields Panel Ad Block Only mode support

### DIFF
--- a/browser/brave_profile_prefs.cc
+++ b/browser/brave_profile_prefs.cc
@@ -383,6 +383,9 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
                                 false);
   registry->RegisterBooleanPref(brave_shields::prefs::kAdBlockDeveloperMode,
                                 false);
+  registry->RegisterIntegerPref(brave_shields::prefs::kShieldsDisabledCount, 0);
+  registry->RegisterBooleanPref(
+      brave_shields::prefs::kAdBlockOnlyModePromptDismissed, false);
 
 #if BUILDFLAG(ENABLE_BRAVE_WAYBACK_MACHINE)
   registry->RegisterBooleanPref(kBraveWaybackMachineEnabled, true);

--- a/browser/brave_shields/BUILD.gn
+++ b/browser/brave_shields/BUILD.gn
@@ -19,11 +19,16 @@ source_set("unit_tests") {
   ]
 
   if (!is_android) {
-    sources += [ "brave_shields_util_profiles_unittest.cc" ]
+    sources += [
+      "brave_shields_tab_helper_unittest.cc",
+      "brave_shields_util_profiles_unittest.cc",
+    ]
 
     deps += [
       "//chrome/browser",
       "//chrome/browser/content_settings:content_settings_factory",
+      "//components/favicon/content",
+      "//components/favicon/core/test:test_support",
     ]
   }
 }

--- a/browser/brave_shields/brave_shields_tab_helper.h
+++ b/browser/brave_shields/brave_shields_tab_helper.h
@@ -23,6 +23,7 @@
 #include "content/public/browser/navigation_entry.h"
 #include "content/public/browser/web_contents_observer.h"
 #include "content/public/browser/web_contents_user_data.h"
+#include "url/gurl.h"
 
 using brave_shields::mojom::AdBlockMode;
 using brave_shields::mojom::CookieBlockMode;
@@ -48,6 +49,8 @@ class BraveShieldsTabHelper
     virtual void OnResourcesChanged() = 0;
     virtual void OnFaviconUpdated() {}
     virtual void OnShieldsEnabledChanged() {}
+    virtual void OnShieldsAdBlockOnlyModeEnabledChanged() {}
+    virtual void OnRepeatedReloadsDetected() {}
   };
 
   void HandleItemBlocked(const std::string& block_type,
@@ -65,7 +68,11 @@ class BraveShieldsTabHelper
   std::vector<GURL> GetFingerprintsList();
   bool GetBraveShieldsEnabled();
   void SetBraveShieldsEnabled(bool is_enabled);
-  GURL GetCurrentSiteURL();
+  bool IsBraveShieldsAdBlockOnlyModeEnabled();
+  void SetBraveShieldsAdBlockOnlyModeEnabled(bool is_enabled);
+  bool ShouldShowShieldsDisabledAdBlockOnlyModePrompt();
+  void SetBraveShieldsAdBlockOnlyModePromptDismissed();
+  GURL GetCurrentSiteURL() const;
   GURL GetFaviconURL(bool refresh);
   const base::flat_set<ContentSettingsType>& GetInvokedWebcompatFeatures();
 
@@ -96,6 +103,11 @@ class BraveShieldsTabHelper
  private:
   friend class content::WebContentsUserData<BraveShieldsTabHelper>;
 
+  struct RepeatedReloadsCounter {
+    base::Time initial_reload_at;
+    size_t reloads_count = 0;
+  };
+
   explicit BraveShieldsTabHelper(content::WebContents* web_contents);
 
   // content::WebContentsObserver
@@ -117,6 +129,12 @@ class BraveShieldsTabHelper
                         const gfx::Image& image) override;
 
   void ReloadWebContents();
+  void MaybeNotifyRepeatedReloads(content::NavigationHandle* navigation_handle);
+
+  void OnShieldsAdBlockOnlyModeEnabledChanged();
+
+  bool navigation_triggered_by_shields_changes_ = false;
+  std::optional<RepeatedReloadsCounter> repeated_reloads_counter_;
 
   base::ObserverList<Observer> observer_list_;
   std::set<GURL> resource_list_blocked_ads_;
@@ -129,6 +147,8 @@ class BraveShieldsTabHelper
       observation_{this};
   const raw_ref<HostContentSettingsMap> host_content_settings_map_;
   std::unique_ptr<BraveShieldsSettings> brave_shields_settings_;
+
+  PrefChangeRegistrar local_state_change_registrar_;
 
   WEB_CONTENTS_USER_DATA_KEY_DECL();
 };

--- a/browser/brave_shields/brave_shields_tab_helper_unittest.cc
+++ b/browser/brave_shields/brave_shields_tab_helper_unittest.cc
@@ -1,0 +1,305 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/browser/brave_shields/brave_shields_tab_helper.h"
+
+#include <memory>
+
+#include "base/test/scoped_feature_list.h"
+#include "brave/components/brave_shields/core/common/brave_shield_utils.h"
+#include "brave/components/brave_shields/core/common/features.h"
+#include "brave/components/brave_shields/core/common/pref_names.h"
+#include "chrome/test/base/chrome_render_view_host_test_harness.h"
+#include "chrome/test/base/testing_browser_process.h"
+#include "chrome/test/base/testing_profile.h"
+#include "components/favicon/content/content_favicon_driver.h"
+#include "components/favicon/core/test/mock_favicon_service.h"
+#include "components/prefs/testing_pref_service.h"
+#include "content/public/browser/navigation_entry.h"
+#include "content/public/test/navigation_simulator.h"
+#include "content/public/test/test_renderer_host.h"
+#include "content/public/test/web_contents_tester.h"
+#include "content/test/test_web_contents.h"
+#include "testing/gmock/include/gmock/gmock.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace brave_shields {
+
+namespace {
+
+class MockBraveShieldsTabHelperObserver
+    : public BraveShieldsTabHelper::Observer {
+ public:
+  MOCK_METHOD(void, OnResourcesChanged, (), (override));
+  MOCK_METHOD(void, OnFaviconUpdated, (), (override));
+  MOCK_METHOD(void, OnShieldsEnabledChanged, (), (override));
+  MOCK_METHOD(void, OnShieldsAdBlockOnlyModeEnabledChanged, (), (override));
+  MOCK_METHOD(void, OnRepeatedReloadsDetected, (), (override));
+};
+
+}  // namespace
+
+class BraveShieldsTabHelperUnitTest
+    : public content::RenderViewHostTestHarness {
+ public:
+  BraveShieldsTabHelperUnitTest()
+      : content::RenderViewHostTestHarness(
+            base::test::TaskEnvironment::TimeSource::MOCK_TIME) {}
+
+  ~BraveShieldsTabHelperUnitTest() override = default;
+
+  void SetUp() override {
+    content::RenderViewHostTestHarness::SetUp();
+
+    favicon::ContentFaviconDriver::CreateForWebContents(web_contents(),
+                                                        &favicon_service_);
+    BraveShieldsTabHelper::CreateForWebContents(web_contents());
+    brave_shields_tab_helper_ =
+        BraveShieldsTabHelper::FromWebContents(web_contents());
+    observer_ = std::make_unique<
+        testing::NiceMock<MockBraveShieldsTabHelperObserver>>();
+    brave_shields_tab_helper_->AddObserver(observer_.get());
+  }
+
+  void TearDown() override {
+    brave_shields_tab_helper_->RemoveObserver(observer_.get());
+    brave_shields_tab_helper_ = nullptr;
+    content::RenderViewHostTestHarness::TearDown();
+  }
+
+  std::unique_ptr<content::BrowserContext> CreateBrowserContext() override {
+    return std::make_unique<TestingProfile>();
+  }
+
+  void NavigateTo(GURL url) {
+    content::NavigationSimulator::NavigateAndCommitFromBrowser(web_contents(),
+                                                               url);
+    EXPECT_EQ(web_contents()->GetLastCommittedURL(), url);
+  }
+
+  void Reload() { content::NavigationSimulator::Reload(web_contents()); }
+
+  PrefService* profile_prefs() {
+    return Profile::FromBrowserContext(web_contents()->GetBrowserContext())
+        ->GetPrefs();
+  }
+
+  PrefService* local_state() {
+    return TestingBrowserProcess::GetGlobal()->GetTestingLocalState();
+  }
+
+ protected:
+  testing::NiceMock<favicon::MockFaviconService> favicon_service_;
+  std::unique_ptr<testing::NiceMock<MockBraveShieldsTabHelperObserver>>
+      observer_;
+  raw_ptr<BraveShieldsTabHelper> brave_shields_tab_helper_;
+  base::test::ScopedFeatureList feature_list_;
+};
+
+TEST_F(BraveShieldsTabHelperUnitTest,
+       DontTriggerOnRepeatedReloadsDetectedWhenFeatureDisabled) {
+  feature_list_.InitAndDisableFeature(features::kAdblockOnlyMode);
+  SetBraveShieldsAdBlockOnlyModeEnabled(local_state(), false);
+
+  EXPECT_CALL(*observer_, OnRepeatedReloadsDetected).Times(0);
+
+  NavigateTo(GURL("https://example.com"));
+  Reload();
+  Reload();
+  Reload();
+}
+
+TEST_F(BraveShieldsTabHelperUnitTest,
+       DontTriggerOnRepeatedReloadsDetectedWhenAdBlockOnlyModeAlreadyEnabled) {
+  feature_list_.InitAndEnableFeatureWithParameters(
+      features::kAdblockOnlyMode,
+      {
+          {features::kAdblockOnlyModePromptAfterPageReloadsMin.name, "1"},
+          {features::kAdblockOnlyModePromptAfterPageReloadsMax.name, "2"},
+          {features::kAdblockOnlyModePromptAfterPageReloadsInterval.name, "1s"},
+      });
+  SetBraveShieldsAdBlockOnlyModeEnabled(local_state(), true);
+
+  EXPECT_CALL(*observer_, OnRepeatedReloadsDetected).Times(0);
+
+  NavigateTo(GURL("https://example.com"));
+  Reload();
+  Reload();
+  Reload();
+}
+
+TEST_F(BraveShieldsTabHelperUnitTest,
+       DontTriggerOnRepeatedReloadsDetectedOnNotReloadNavigation) {
+  feature_list_.InitAndEnableFeatureWithParameters(
+      features::kAdblockOnlyMode,
+      {
+          {features::kAdblockOnlyModePromptAfterPageReloadsMin.name, "1"},
+          {features::kAdblockOnlyModePromptAfterPageReloadsMax.name, "2"},
+          {features::kAdblockOnlyModePromptAfterPageReloadsInterval.name, "1s"},
+      });
+  SetBraveShieldsAdBlockOnlyModeEnabled(local_state(), false);
+
+  EXPECT_CALL(*observer_, OnRepeatedReloadsDetected).Times(0);
+
+  NavigateTo(GURL("https://example.com"));
+  NavigateTo(GURL("https://example.com"));
+  NavigateTo(GURL("https://example.com"));
+  NavigateTo(GURL("https://example.com"));
+  NavigateTo(GURL("https://example.com"));
+}
+
+TEST_F(BraveShieldsTabHelperUnitTest,
+       DontTriggerOnRepeatedReloadsDetectedWhenReloadsByShieldsChanges) {
+  feature_list_.InitAndEnableFeatureWithParameters(
+      features::kAdblockOnlyMode,
+      {
+          {features::kAdblockOnlyModePromptAfterPageReloadsMin.name, "1"},
+          {features::kAdblockOnlyModePromptAfterPageReloadsMax.name, "2"},
+          {features::kAdblockOnlyModePromptAfterPageReloadsInterval.name, "1s"},
+      });
+  SetBraveShieldsAdBlockOnlyModeEnabled(local_state(), false);
+
+  EXPECT_CALL(*observer_, OnRepeatedReloadsDetected).Times(0);
+
+  brave_shields_tab_helper_->SetBraveShieldsEnabled(true);
+  brave_shields_tab_helper_->SetBraveShieldsEnabled(false);
+  brave_shields_tab_helper_->SetBraveShieldsEnabled(true);
+  brave_shields_tab_helper_->SetBraveShieldsEnabled(false);
+}
+
+TEST_F(BraveShieldsTabHelperUnitTest,
+       DontTriggerOnRepeatedReloadsDetectedByZeroCountFeatureParameters) {
+  feature_list_.InitAndEnableFeatureWithParameters(
+      features::kAdblockOnlyMode,
+      {
+          {features::kAdblockOnlyModePromptAfterPageReloadsMin.name, "0"},
+          {features::kAdblockOnlyModePromptAfterPageReloadsMax.name, "0"},
+          {features::kAdblockOnlyModePromptAfterPageReloadsInterval.name, "1s"},
+      });
+  SetBraveShieldsAdBlockOnlyModeEnabled(local_state(), false);
+
+  EXPECT_CALL(*observer_, OnRepeatedReloadsDetected).Times(0);
+
+  NavigateTo(GURL("https://example.com"));
+  Reload();
+  Reload();
+  Reload();
+  Reload();
+  Reload();
+}
+
+TEST_F(BraveShieldsTabHelperUnitTest, TriggerOnRepeatedReloadsDetected) {
+  feature_list_.InitAndEnableFeatureWithParameters(
+      features::kAdblockOnlyMode,
+      {
+          {features::kAdblockOnlyModePromptAfterPageReloadsMin.name, "1"},
+          {features::kAdblockOnlyModePromptAfterPageReloadsMax.name, "2"},
+          {features::kAdblockOnlyModePromptAfterPageReloadsInterval.name, "1s"},
+      });
+  SetBraveShieldsAdBlockOnlyModeEnabled(local_state(), false);
+
+  EXPECT_CALL(*observer_, OnRepeatedReloadsDetected).Times(2);
+
+  NavigateTo(GURL("https://example.com"));
+  Reload();
+  Reload();
+  Reload();
+  Reload();
+  Reload();
+  testing::Mock::VerifyAndClearExpectations(observer_.get());
+
+  // Counter is reset after more than
+  // `kAdblockOnlyModePromptAfterPageReloadsInterval` time interval. Fast
+  // forward by 2 times to ensure the counter is reset.
+  task_environment()->FastForwardBy(
+      2 * features::kAdblockOnlyModePromptAfterPageReloadsInterval.Get());
+
+  EXPECT_CALL(*observer_, OnRepeatedReloadsDetected).Times(2);
+  Reload();
+  Reload();
+  Reload();
+  Reload();
+  Reload();
+  testing::Mock::VerifyAndClearExpectations(observer_.get());
+}
+
+TEST_F(BraveShieldsTabHelperUnitTest,
+       DontTriggerOnRepeatedReloadsDetectedWhenPromptDismissed) {
+  feature_list_.InitAndEnableFeatureWithParameters(
+      features::kAdblockOnlyMode,
+      {
+          {features::kAdblockOnlyModePromptAfterPageReloadsMin.name, "1"},
+          {features::kAdblockOnlyModePromptAfterPageReloadsMax.name, "2"},
+          {features::kAdblockOnlyModePromptAfterPageReloadsInterval.name, "1s"},
+      });
+  SetBraveShieldsAdBlockOnlyModeEnabled(local_state(), false);
+  brave_shields_tab_helper_->SetBraveShieldsAdBlockOnlyModePromptDismissed();
+
+  EXPECT_CALL(*observer_, OnRepeatedReloadsDetected).Times(0);
+
+  NavigateTo(GURL("https://example.com"));
+  Reload();
+  Reload();
+  Reload();
+  Reload();
+  Reload();
+}
+
+TEST_F(BraveShieldsTabHelperUnitTest,
+       DontShowShieldsDisabledAdBlockOnlyModePromptWhenFeatureDisabled) {
+  feature_list_.InitAndDisableFeature(features::kAdblockOnlyMode);
+  SetBraveShieldsAdBlockOnlyModeEnabled(local_state(), false);
+
+  // Default value of
+  // `features::kAdblockOnlyModePromptAfterShieldsDisabledCount` is 5.
+  brave_shields_tab_helper_->SetBraveShieldsEnabled(false);
+  brave_shields_tab_helper_->SetBraveShieldsEnabled(false);
+  brave_shields_tab_helper_->SetBraveShieldsEnabled(false);
+  brave_shields_tab_helper_->SetBraveShieldsEnabled(false);
+  brave_shields_tab_helper_->SetBraveShieldsEnabled(false);
+
+  EXPECT_EQ(
+      profile_prefs()->GetInteger(brave_shields::prefs::kShieldsDisabledCount),
+      0);
+
+  EXPECT_FALSE(brave_shields_tab_helper_
+                   ->ShouldShowShieldsDisabledAdBlockOnlyModePrompt());
+}
+
+TEST_F(BraveShieldsTabHelperUnitTest,
+       DontShowShieldsDisabledAdBlockOnlyModePromptWhenPromptDismissed) {
+  feature_list_.InitAndEnableFeatureWithParameters(
+      features::kAdblockOnlyMode,
+      {
+          {features::kAdblockOnlyModePromptAfterShieldsDisabledCount.name, "2"},
+      });
+  SetBraveShieldsAdBlockOnlyModeEnabled(local_state(), false);
+  brave_shields_tab_helper_->SetBraveShieldsAdBlockOnlyModePromptDismissed();
+
+  brave_shields_tab_helper_->SetBraveShieldsEnabled(false);
+  brave_shields_tab_helper_->SetBraveShieldsEnabled(false);
+  EXPECT_FALSE(brave_shields_tab_helper_
+                   ->ShouldShowShieldsDisabledAdBlockOnlyModePrompt());
+}
+
+TEST_F(BraveShieldsTabHelperUnitTest,
+       ShowShieldsDisabledAdBlockOnlyModePrompt) {
+  feature_list_.InitAndEnableFeatureWithParameters(
+      features::kAdblockOnlyMode,
+      {
+          {features::kAdblockOnlyModePromptAfterShieldsDisabledCount.name, "2"},
+      });
+  SetBraveShieldsAdBlockOnlyModeEnabled(local_state(), false);
+
+  brave_shields_tab_helper_->SetBraveShieldsEnabled(false);
+  EXPECT_FALSE(brave_shields_tab_helper_
+                   ->ShouldShowShieldsDisabledAdBlockOnlyModePrompt());
+
+  brave_shields_tab_helper_->SetBraveShieldsEnabled(false);
+  EXPECT_TRUE(brave_shields_tab_helper_
+                  ->ShouldShowShieldsDisabledAdBlockOnlyModePrompt());
+}
+
+}  // namespace brave_shields

--- a/browser/ui/views/brave_actions/brave_shields_action_view.h
+++ b/browser/ui/views/brave_actions/brave_shields_action_view.h
@@ -55,10 +55,12 @@ class BraveShieldsActionView
   void UpdateIconState();
   gfx::ImageSkia GetIconImage(bool is_enabled);
   std::unique_ptr<IconWithBadgeImageSource> GetImageSource();
+  void ShowBubble(GURL webui_url);
 
   // brave_shields::BraveShieldsTabHelper
   void OnResourcesChanged() override;
   void OnShieldsEnabledChanged() override;
+  void OnRepeatedReloadsDetected() override;
 
   // TabStripModelObserver
   void OnTabStripModelChanged(
@@ -66,10 +68,12 @@ class BraveShieldsActionView
       const TabStripModelChange& change,
       const TabStripSelectionChange& selection) override;
 
+  const raw_ptr<BrowserWindowInterface> browser_window_interface_ = nullptr;
   raw_ptr<views::MenuButtonController> menu_button_controller_ = nullptr;
   raw_ref<Profile> profile_;
   raw_ref<TabStripModel> tab_strip_model_;
   std::unique_ptr<WebUIBubbleManager> webui_bubble_manager_;
+  std::optional<GURL> last_webui_url_;
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_BRAVE_ACTIONS_BRAVE_SHIELDS_ACTION_VIEW_H_

--- a/browser/ui/webui/brave_shields/shields_panel_data_handler.cc
+++ b/browser/ui/webui/brave_shields/shields_panel_data_handler.cc
@@ -156,9 +156,25 @@ void ShieldsPanelDataHandler::SetBraveShieldsEnabled(bool is_enabled) {
 }
 
 void ShieldsPanelDataHandler::SetBraveShieldsAdBlockOnlyModeEnabled(
-    bool is_enabled) {}
+    bool is_enabled) {
+  if (!active_shields_data_controller_) {
+    return;
+  }
 
-void ShieldsPanelDataHandler::SetBraveShieldsAdBlockOnlyModePromptDismissed() {}
+  active_shields_data_controller_->SetBraveShieldsAdBlockOnlyModeEnabled(
+      is_enabled);
+}
+
+void ShieldsPanelDataHandler::SetBraveShieldsAdBlockOnlyModePromptDismissed() {
+  if (!active_shields_data_controller_) {
+    return;
+  }
+  active_shields_data_controller_
+      ->SetBraveShieldsAdBlockOnlyModePromptDismissed();
+
+  // Update site block info to set dismissed flag.
+  UpdateSiteBlockInfo();
+}
 
 void ShieldsPanelDataHandler::SetForgetFirstPartyStorageEnabled(
     bool is_enabled) {
@@ -252,8 +268,11 @@ void ShieldsPanelDataHandler::UpdateSiteBlockInfo() {
       active_shields_data_controller_->GetHttpRedirectsList();
   site_block_info_.is_brave_shields_enabled =
       active_shields_data_controller_->GetBraveShieldsEnabled();
-  site_block_info_.is_brave_shields_ad_block_only_mode_enabled = false;
-  site_block_info_.show_shields_disabled_ad_block_only_mode_prompt = false;
+  site_block_info_.is_brave_shields_ad_block_only_mode_enabled =
+      active_shields_data_controller_->IsBraveShieldsAdBlockOnlyModeEnabled();
+  site_block_info_.show_shields_disabled_ad_block_only_mode_prompt =
+      active_shields_data_controller_
+          ->ShouldShowShieldsDisabledAdBlockOnlyModePrompt();
   site_block_info_.is_brave_shields_managed =
       active_shields_data_controller_->IsBraveShieldsManaged();
   const auto& invoked_webcompat_set =
@@ -280,6 +299,10 @@ void ShieldsPanelDataHandler::OnResourcesChanged() {
 
 void ShieldsPanelDataHandler::OnFaviconUpdated() {
   UpdateFavicon();
+}
+
+void ShieldsPanelDataHandler::OnShieldsAdBlockOnlyModeEnabledChanged() {
+  UpdateSiteBlockInfo();
 }
 
 void ShieldsPanelDataHandler::OnTabStripModelChanged(

--- a/browser/ui/webui/brave_shields/shields_panel_data_handler.h
+++ b/browser/ui/webui/brave_shields/shields_panel_data_handler.h
@@ -67,6 +67,7 @@ class ShieldsPanelDataHandler
   // BraveShieldsTabHelper::Observer
   void OnResourcesChanged() override;
   void OnFaviconUpdated() override;
+  void OnShieldsAdBlockOnlyModeEnabledChanged() override;
 
   // TabStripModelObserver
   void OnTabStripModelChanged(

--- a/components/brave_shields/core/common/features.h
+++ b/components/brave_shields/core/common/features.h
@@ -6,10 +6,12 @@
 #ifndef BRAVE_COMPONENTS_BRAVE_SHIELDS_CORE_COMMON_FEATURES_H_
 #define BRAVE_COMPONENTS_BRAVE_SHIELDS_CORE_COMMON_FEATURES_H_
 
+#include <cstddef>
 #include <string>
 
 #include "base/feature_list.h"
 #include "base/metrics/field_trial_params.h"
+#include "base/time/time.h"
 
 namespace brave_shields {
 namespace features {
@@ -58,6 +60,27 @@ extern const base::FeatureParam<int>
     kAdblockOverrideRegexDiscardPolicyDiscardUnusedSec;
 
 BASE_DECLARE_FEATURE(kAdblockOnlyMode);
+// The number of times the shields are disabled before showing the Ad Block Only
+// mode prompt in Shields Panel.
+inline constexpr base::FeatureParam<int>
+    kAdblockOnlyModePromptAfterShieldsDisabledCount{
+        &kAdblockOnlyMode, "prompt_after_shields_disabled_count", 5};
+// The time interval after which the Ad Block Only mode repeated reloads prompt
+// is shown.
+inline constexpr base::FeatureParam<base::TimeDelta>
+    kAdblockOnlyModePromptAfterPageReloadsInterval{
+        &kAdblockOnlyMode, "prompt_after_page_reloads_interval",
+        base::Seconds(10)};
+// The minimum number of times the page is reloaded before showing the Ad Block
+// Only mode repeated reloads prompt.
+inline constexpr base::FeatureParam<size_t>
+    kAdblockOnlyModePromptAfterPageReloadsMin{
+        &kAdblockOnlyMode, "prompt_after_page_reloads_min", 0};
+// The maximum number of times the page is reloaded before showing the Ad Block
+// Only mode repeated reloads prompt.
+inline constexpr base::FeatureParam<size_t>
+    kAdblockOnlyModePromptAfterPageReloadsMax{
+        &kAdblockOnlyMode, "prompt_after_page_reloads_max", 0};
 
 }  // namespace features
 }  // namespace brave_shields

--- a/components/brave_shields/core/common/pref_names.h
+++ b/components/brave_shields/core/common/pref_names.h
@@ -36,6 +36,9 @@ inline constexpr char kReduceLanguageEnabled[] = "brave.reduce_language";
 
 inline constexpr char kAdBlockOnlyModeEnabled[] =
     "brave.shields.adblock_only_mode_enabled";
+inline constexpr char kShieldsDisabledCount[] = "brave.shields.disabled_count";
+inline constexpr char kAdBlockOnlyModePromptDismissed[] =
+    "brave.shields.adblock_only_mode_prompt_dismissed";
 
 }  // namespace prefs
 }  // namespace brave_shields


### PR DESCRIPTION
The PR adds Ad Block Only mode business logic for Shields Panel. Ad Block Only mode UI part was added here: https://github.com/brave/brave-core/pull/31380

The PR implements following functionality:

1) Enables `Ad Block Only mode` from Shields Panel on button press. Handles `Dismiss` button press, so prompt is no longer shown.
<img height="200" alt="image" src="https://github.com/user-attachments/assets/300537c6-bbe7-4edf-8dc1-e41d099d5a32" />

2) Shows following prompt when user disable shield specific number of times.
<img height="200" alt="image" src="https://github.com/user-attachments/assets/300537c6-bbe7-4edf-8dc1-e41d099d5a32" />

This is controlled by `AdBlockOnlyMode` feature parameters:
```
"prompt_after_shields_disabled_count" (default is 5)
```

3) Shows following prompt when user reloads web-page several times during specific time interval.
<img height="150" alt="image" src="https://github.com/user-attachments/assets/90f84b22-d146-4a8e-8033-d9d0c0d67122" />

This is controlled by `AdBlockOnlyMode` feature parameters:
```
"prompt_after_page_reloads_interval" (default is 10 seconds)
"prompt_after_page_reloads_min" (default is 0)
"prompt_after_page_reloads_max" (default is 0)
```
When `prompt_after_page_reloads_min` and `prompt_after_page_reloads_max` both equal to 0 then the prompt is not shown.


<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/49565

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
