### PR TITLE
Set Android renderer size in backup results service (uplift to 1.83.x)

### DIFF
--- a/browser/brave_search/BUILD.gn
+++ b/browser/brave_search/BUILD.gn
@@ -24,6 +24,10 @@ source_set("brave_search") {
     "//content/public/browser",
     "//services/network/public/cpp",
   ]
+
+  if (is_android) {
+    deps += [ "//ui/android" ]
+  }
 }
 
 if (!is_android) {

--- a/browser/brave_search/backup_results_service_impl.cc
+++ b/browser/brave_search/backup_results_service_impl.cc
@@ -33,6 +33,10 @@
 #include "third_party/blink/public/common/navigation/navigation_policy.h"
 #include "third_party/blink/public/common/web_preferences/web_preferences.h"
 
+#if BUILDFLAG(IS_ANDROID)
+#include "ui/android/view_android.h"
+#endif
+
 namespace brave_search {
 
 namespace {
@@ -145,7 +149,12 @@ void BackupResultsServiceImpl::FetchBackupResults(
 
     int random_width = base::RandInt(800, 1920);
     int random_height = base::RandInt(600, 1080);
+#if BUILDFLAG(IS_ANDROID)
+    auto* native_view = web_contents->GetNativeView();
+    native_view->OnSizeChanged(random_width, random_height);
+#else
     web_contents->Resize({random_width, random_height});
+#endif
 
     auto web_preferences = web_contents->GetOrCreateWebPreferences();
     web_preferences.supports_multiple_windows = false;


### PR DESCRIPTION
Uplift of #31375
Resolves https://github.com/brave/brave-browser/issues/49559

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.