### PR TITLE
[CR141] Fixed crash when clicking a split tab

### DIFF
--- a/browser/ui/views/split_view/split_view_browsertest.cc
+++ b/browser/ui/views/split_view/split_view_browsertest.cc
@@ -119,6 +119,22 @@ class SideBySideEnabledBrowserTest : public InProcessBrowserTest {
     browser_non_client_frame_view()->DeprecatedLayoutImmediately();
   }
 
+  javascript_dialogs::TabModalDialogManager* GetTabModalDialogManagerAt(
+      int index) {
+    return javascript_dialogs::TabModalDialogManager::FromWebContents(
+        GetWebContentsAt(index));
+  }
+
+  web_modal::WebContentsModalDialogManager* GetWebModalDialogManagerAt(
+      int index) {
+    return web_modal::WebContentsModalDialogManager::FromWebContents(
+        GetWebContentsAt(index));
+  }
+
+  content::WebContents* GetWebContentsAt(int index) {
+    return browser()->tab_strip_model()->GetWebContentsAt(index);
+  }
+
  protected:
   base::test::ScopedFeatureList scoped_features_;
 };
@@ -279,6 +295,34 @@ IN_PROC_BROWSER_TEST_F(SideBySideEnabledBrowserTest, SelectTabTest) {
   EXPECT_EQ(3, tab_strip()->GetActiveIndex());
   EXPECT_FALSE(tab_strip()->tab_at(2)->IsActive());
   EXPECT_TRUE(tab_strip()->tab_at(3)->IsActive());
+
+  // Flaky with dialog test on macOS.
+#if !BUILDFLAG(IS_MAC)
+  // Activate split tab at 2
+  tab_strip()->SelectTab(tab_strip()->tab_at(2), GetDummyEvent());
+  EXPECT_EQ(2, tab_strip()->GetActiveIndex());
+
+  // Check activated split tab is the the that owned tab modal.
+  // Launch dialog from active split tab (at 2).
+  bool did_suppress = false;
+  GetTabModalDialogManagerAt(2)->RunJavaScriptDialog(
+      GetWebContentsAt(2), GetWebContentsAt(2)->GetPrimaryMainFrame(),
+      content::JAVASCRIPT_DIALOG_TYPE_ALERT, std::u16string(), std::u16string(),
+      base::BindOnce([](bool, const std::u16string&) {}), &did_suppress);
+
+  EXPECT_TRUE(GetTabModalDialogManagerAt(2)->IsShowingDialogForTesting());
+  EXPECT_TRUE(GetWebModalDialogManagerAt(2)->IsDialogActive());
+
+  // Activate non split tab at 0.
+  tab_strip()->SelectTab(tab_strip()->tab_at(0), GetDummyEvent());
+  EXPECT_EQ(0, tab_strip()->GetActiveIndex());
+
+  // Activate split tab that doesn't have tab modal.
+  // Check tab at 2 is activated because only a split tab that owns
+  // tab modal can be activated till that modal is dismissed.
+  tab_strip()->SelectTab(tab_strip()->tab_at(3), GetDummyEvent());
+  EXPECT_EQ(2, tab_strip()->GetActiveIndex());
+#endif
 }
 
 class SideBySideWithRoundedCornersTest : public SideBySideEnabledBrowserTest {

--- a/chromium_src/chrome/browser/ui/tabs/tab_strip_model.h
+++ b/chromium_src/chrome/browser/ui/tabs/tab_strip_model.h
@@ -20,8 +20,21 @@
 #define IsReadLaterSupportedForAny virtual IsReadLaterSupportedForAny
 #define UpdateWebContentsStateAt virtual UpdateWebContentsStateAt
 
+// Moved to public to call from split_tabs::BraveGetIndexOfLastActiveTab().
+#define CanActivateTabAt            \
+  CanActivateTabAt_Unused() {       \
+    return false;                   \
+  }                                 \
+                                    \
+ public:                            \
+  bool CanActivateTabAt(int index); \
+                                    \
+ private:                           \
+  bool Unused
+
 #include <chrome/browser/ui/tabs/tab_strip_model.h>  // IWYU pragma: export
 
+#undef CanActivateTabAt
 #undef UpdateWebContentsStateAt
 #undef IsReadLaterSupportedForAny
 #undef DraggingTabsSession

--- a/chromium_src/chrome/browser/ui/views/tabs/browser_tab_strip_controller.cc
+++ b/chromium_src/chrome/browser/ui/views/tabs/browser_tab_strip_controller.cc
@@ -6,18 +6,29 @@
 #include "chrome/browser/ui/views/tabs/browser_tab_strip_controller.h"
 
 #include "chrome/browser/ui/tabs/split_tab_util.h"
-
-namespace split_tabs {
-int PassThrough(int model_index) {
-  return model_index;
-}
-}  // namespace split_tabs
+#include "chrome/browser/ui/tabs/tab_strip_model.h"
 
 // To use original |model_index| value always instead of updating it from
 // split_tabs::GetIndexOfLastActiveTab(). We want to activate clicked tab. But
 // upstream activates the most recently focused tab in the split when selecting
-// a split tab.
-#define GetIndexOfLastActiveTab(...) PassThrough(model_index)
+// a split tab. If it's in split tab and another tab in same split can't be
+// activated, follow upstream's behavior. Ex, when another tab in split is
+// blocked tab with tab-modal, clicked tab can't be activated till that tab
+// model is dismissed.
+namespace split_tabs {
+int BraveGetIndexOfLastActiveTab(TabStripModel* tab_strip_model,
+                                 SplitTabId id,
+                                 int model_index) {
+  if (tab_strip_model->CanActivateTabAt(model_index)) {
+    return model_index;
+  }
+
+  return GetIndexOfLastActiveTab(tab_strip_model, id);
+}
+}  // namespace split_tabs
+
+#define GetIndexOfLastActiveTab(...) \
+  BraveGetIndexOfLastActiveTab(__VA_ARGS__, model_index)
 
 #include <chrome/browser/ui/views/tabs/browser_tab_strip_controller.cc>
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/49533

When split tab has tab modal, it's blocked tab and other tab in that split can't be activated.
Regarding to split tab activation, Brave and chromium have difference.
When clicking any split tab in chromium, always activated last active tab in that split.
However, we activate clicked tab. This works well in most cases.
But when one of split tab has tab modal, only that tab could be activated.
This caused crash from Brave.
To fix this, we follow chromium's activation logic when there is tab modal in split.

TEST=SideBySideEnabledBrowserTest.SelectTabTest

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
