### PR TITLE
feat(wallet): Handle Confirm Shield in New Confirmation Panel

### DIFF
--- a/components/brave_wallet/browser/brave_wallet_constants.h
+++ b/components/brave_wallet/browser/brave_wallet_constants.h
@@ -419,6 +419,7 @@ inline constexpr webui::LocalizedString kLocalizedStrings[] = {
     {"braveWalletConfirmSwap", IDS_BRAVE_WALLET_CONFIRM_SWAP},
     {"braveWalletConfirmBridge", IDS_BRAVE_WALLET_CONFIRM_BRIDGE},
     {"braveWalletConfirmSend", IDS_BRAVE_WALLET_CONFIRM_SEND},
+    {"braveWalletConfirmShield", IDS_BRAVE_WALLET_CONFIRM_SHIELD},
     {"braveWalletSpend", IDS_BRAVE_WALLET_SPEND},
     {"braveWalletEstTime", IDS_BRAVE_WALLET_EST_TIME},
     {"braveWalletExchangeRate", IDS_BRAVE_WALLET_EXCHANGE_RATE},

--- a/components/brave_wallet_ui/components/extension/confirm_send_transaction/confirm_send_transaction.tsx
+++ b/components/brave_wallet_ui/components/extension/confirm_send_transaction/confirm_send_transaction.tsx
@@ -156,7 +156,11 @@ export function ConfirmSendTransaction() {
       >
         {/* Header */}
         <ConfirmationHeader
-          title={getLocale('braveWalletConfirmSend')}
+          title={
+            isShieldingFunds
+              ? getLocale('braveWalletConfirmShield')
+              : getLocale('braveWalletConfirmSend')
+          }
           transactionsQueueLength={transactionsQueueLength}
           queueNextTransaction={queueNextTransaction}
           queuePreviousTransaction={queuePreviousTransaction}
@@ -188,7 +192,7 @@ export function ConfirmSendTransaction() {
                 {/* Send token and amount */}
                 <ConfirmationTokenInfo
                   token={transactionDetails.token}
-                  label='send'
+                  label={isShieldingFunds ? 'shield' : 'send'}
                   valueExact={transactionDetails.valueExact}
                   fiatValue={transactionDetails.fiatValue}
                   network={transactionsNetwork}

--- a/components/brave_wallet_ui/components/extension/confirmation_token_info/confirmation_token_info.tsx
+++ b/components/brave_wallet_ui/components/extension/confirmation_token_info/confirmation_token_info.tsx
@@ -76,7 +76,7 @@ interface Props {
   account?: BraveWallet.AccountInfo
   receiveAddress?: string
   isAssociatedTokenAccountCreation?: boolean
-  label: 'send' | 'spend' | 'receive' | 'bridge' | 'to'
+  label: 'send' | 'spend' | 'receive' | 'bridge' | 'to' | 'shield'
 }
 
 export function ConfirmationTokenInfo(props: Props) {
@@ -119,7 +119,9 @@ export function ConfirmationTokenInfo(props: Props) {
       ? getLocale('braveWalletSend')
       : label === 'spend'
         ? getLocale('braveWalletSpend')
-        : getLocale('braveWalletReceive')
+        : label === 'shield'
+          ? getLocale('braveWalletShielding')
+          : getLocale('braveWalletReceive')
 
   const ataCreationLocale = getLocale(
     'braveWalletConfirmTransactionAccountCreationFee',
@@ -254,6 +256,7 @@ export function ConfirmationTokenInfo(props: Props) {
       </Row>
     )
   }
+
   return (
     <Row
       justifyContent='space-between'

--- a/components/brave_wallet_ui/stories/locale.ts
+++ b/components/brave_wallet_ui/stories/locale.ts
@@ -651,6 +651,7 @@ provideStrings({
   braveWalletConfirmSwap: 'Confirm swap',
   braveWalletConfirmBridge: 'Confirm bridge',
   braveWalletConfirmSend: 'Confirm send',
+  braveWalletConfirmShield: 'Confirm shield',
   braveWalletSpend: 'Spend',
 
   // Buy

--- a/components/resources/wallet_strings.grdp
+++ b/components/resources/wallet_strings.grdp
@@ -148,6 +148,7 @@
   <message name="IDS_BRAVE_WALLET_CONFIRM_SWAP" desc="Confirm swap title">Confirm swap</message>
   <message name="IDS_BRAVE_WALLET_CONFIRM_BRIDGE" desc="Confirm bridge title">Confirm bridge</message>
   <message name="IDS_BRAVE_WALLET_CONFIRM_SEND" desc="Confirm send title">Confirm send</message>
+  <message name="IDS_BRAVE_WALLET_CONFIRM_SHIELD" desc="Confirm shield title">Confirm shield</message>
   <message name="IDS_BRAVE_WALLET_SPEND" desc="Spend button">Spend</message>
   <message name="IDS_BRAVE_WALLET_SORT_BY" desc="Sort by button label">Sort by</message>
   <message name="IDS_BRAVE_WALLET_REVIEW_BRIDGE" desc="Review bridge button">Review bridge</message>


### PR DESCRIPTION
## Description 

Handles `Confirm Shield` in the new `Confirmation Panel` UI

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/49621>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

## Test Plan:
1. Create a `Shield Funds` transaction and wait for the `Confirmation` panel to pop up
2. The title should be `Confirm shield`
3. The amount label should be `Shielding`
4. The confirm button should say `Shield ZEC`

Before:

<img width="401" height="661" alt="Screenshot 41" src="https://github.com/user-attachments/assets/268f03c3-b338-4e94-9e0a-0455fd640895" />

After:

<img width="403" height="662" alt="Screenshot 42" src="https://github.com/user-attachments/assets/c0b2b797-a1ae-4cc8-b1a1-3e830aed6147" />
