### PR TITLE
[iOS] Replace "Search Web" web view menu item with Brave's

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabDelegate.swift
@@ -364,6 +364,24 @@ extension BrowserViewController: TabDelegate {
     return false
   }
 
+  private class LookupMenuReplacement: UIMenu {
+    convenience init(lookupMenu: UIMenu, searchWebAction: UIAction) {
+      self.init(
+        title: lookupMenu.title,
+        image: lookupMenu.image,
+        identifier: lookupMenu.identifier,
+        options: lookupMenu.options,
+        children: lookupMenu.children + [searchWebAction]
+      )
+    }
+
+    override func replacingChildren(_ newChildren: [UIMenuElement]) -> UIMenu {
+      // The lookup menu calls this to add the "Search Web" action, which we want to remove. So this
+      // method is overridden to do nothing
+      return self
+    }
+  }
+
   public func tab(_ tab: some TabState, buildEditMenuWithBuilder builder: any UIMenuBuilder) {
     let forcePaste = UIAction(title: Strings.forcePaste) { [weak tab] _ in
       if let string = UIPasteboard.general.string {
@@ -387,9 +405,18 @@ extension BrowserViewController: TabDelegate {
     }
     let braveMenuItems: UIMenu = .init(
       options: [.displayInline],
-      children: [forcePaste, searchWithBrave]
+      children: [forcePaste]
     )
     builder.insertChild(braveMenuItems, atEndOfMenu: .root)
+    if let lookupMenu = builder.menu(for: .lookup) {
+      builder.replace(
+        menu: .lookup,
+        with: LookupMenuReplacement(
+          lookupMenu: lookupMenu,
+          searchWebAction: searchWithBrave
+        )
+      )
+    }
   }
 }
 


### PR DESCRIPTION
This change replaces the "Search Web" action that appears when you've selected text on the page and opened the context menu with the "Search with Brave" action we typically placed at the end of the list. We do this because "Search Web" would use Safari or–in the case where Brave is the default–Safari's selected search engine to perform the search.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/49623

### Test Case
- Load a page and select some text (and tap on the selected portion so that a menu appears)
- In the standard menu, verify that "Search Web" does not appear after "Translate" where it typically would and in its place "Search with Brave" now appears 
- Verify that tapping "Search with Brave" correctly opens a new tab for that selected search term

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
