### PR TITLE
[iOS] Show "Force Paste" edit menu option even with no text selected

### DIFF
--- a/chromium_src/ios/web/web_state/web_view_internal_creation_util.mm
+++ b/chromium_src/ios/web/web_state/web_view_internal_creation_util.mm
@@ -1,0 +1,30 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#import "ios/web/common/crw_edit_menu_builder.h"
+#import "ios/web/web_state/crw_web_view.h"
+
+@interface BraveCRWWebView : CRWWebView
+@end
+
+#define CRWWebView BraveCRWWebView
+#include <ios/web/web_state/web_view_internal_creation_util.mm>
+#undef CRWWebView
+
+@implementation BraveCRWWebView
+
+- (void)buildMenuWithBuilder:(id<UIMenuBuilder>)builder {
+  [super buildMenuWithBuilder:builder];
+  // Typically Chromium only calls buildMenuWithBuilder when there is text
+  // selected by the user (`canPerformAction` returning true for the `copy`
+  // selector). This override allows it to also call the edit menu builder when
+  // paste is available so we can add additional menu items such as Force Paste
+  if (![self canPerformAction:@selector(copy:) withSender:self] &&
+      [self canPerformAction:@selector(paste:) withSender:self]) {
+    [self.editMenuBuilder buildMenuWithBuilder:builder];
+  }
+}
+
+@end

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabDelegate.swift
@@ -383,7 +383,13 @@ extension BrowserViewController: TabDelegate {
   }
 
   public func tab(_ tab: some TabState, buildEditMenuWithBuilder builder: any UIMenuBuilder) {
-    let forcePaste = UIAction(title: Strings.forcePaste) { [weak tab] _ in
+    // We only want to show Force Paste if the regular Paste command is available
+    let responder = UIView.findSubViewWithFirstResponder(tab.view)
+    let canPaste = responder?.canPerformAction(#selector(paste(_:)), withSender: responder) == true
+    let forcePaste = UIAction(
+      title: Strings.forcePaste,
+      attributes: !canPaste ? .hidden : []
+    ) { [weak tab] _ in
       if let string = UIPasteboard.general.string {
         tab?.evaluateJavaScript(
           functionName: "window.__firefox__.forcePaste",
@@ -403,11 +409,6 @@ extension BrowserViewController: TabDelegate {
         self?.didSelectSearchWithBrave(selectedText, tab: tab)
       }
     }
-    let braveMenuItems: UIMenu = .init(
-      options: [.displayInline],
-      children: [forcePaste]
-    )
-    builder.insertChild(braveMenuItems, atEndOfMenu: .root)
     if let lookupMenu = builder.menu(for: .lookup) {
       builder.replace(
         menu: .lookup,
@@ -415,6 +416,14 @@ extension BrowserViewController: TabDelegate {
           lookupMenu: lookupMenu,
           searchWebAction: searchWithBrave
         )
+      )
+    }
+    if #available(iOS 26, *) {
+      builder.insertElements([forcePaste], afterCommand: #selector(paste(_:)))
+    } else {
+      builder.insertSibling(
+        UIMenu(options: .displayInline, children: [forcePaste]),
+        afterMenu: .standardEdit
       )
     }
   }

--- a/ios/brave-ios/Sources/Web/WebKit/WebKitTabState.swift
+++ b/ios/brave-ios/Sources/Web/WebKit/WebKitTabState.swift
@@ -605,15 +605,6 @@ private class WebKitWebView: WKWebView {
 
   override func buildMenu(with builder: any UIMenuBuilder) {
     super.buildMenu(with: builder)
-    if !canPerformAction(#selector(copy(_:)), withSender: self) {
-      // This matches CRWWebView's implementation
-      //
-      // `WKWebView buildMenuWithBuilder:` is called too often in WKWebView,
-      // sometimes when there is no selection.
-      // As a proxy to detect if we should add our items, only add Chrome
-      // features if there is something to copy in the view.
-      return
-    }
     buildMenu?(builder)
   }
 }


### PR DESCRIPTION
This change ensures that the menu builder is called even when there is no active text selected by the user so that we can display `Force Paste` next to the standard `Paste` when the user is simply attempting to paste into an empty field.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/49636
 
<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
