### PR TITLE
[NTP] Isolate autocomplete results for separate search inputs

### DIFF
--- a/browser/resources/brave_new_tab_page_refresh/components/search/search_box.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/search/search_box.tsx
@@ -23,7 +23,7 @@ interface Props {
 }
 
 export function SearchBox(props: Props) {
-  const inputState = useSearchInputState()
+  const inputState = useSearchInputState('search-box')
   const searchFeatureEnabled = useSearchState((s) => s.searchFeatureEnabled)
   const showSearchBox = useSearchState((s) => s.showSearchBox)
   const [expanded, setExpanded] = React.useState(false)
@@ -73,6 +73,7 @@ export function SearchBox(props: Props) {
             }
             tabIndex={1}
             value={inputState.query}
+            onFocus={() => inputState.setActiveInput()}
             onClick={() => setExpanded(true)}
             onKeyDown={(event) => {
               inputState.handleActionKeyDown(event.nativeEvent)

--- a/browser/resources/brave_new_tab_page_refresh/components/search/search_input_state.ts
+++ b/browser/resources/brave_new_tab_page_refresh/components/search/search_input_state.ts
@@ -10,11 +10,15 @@ import {
   AutocompleteMatch,
   ClickEvent } from '../../state/search_state'
 
+import {
+  useSearchState,
+  useSearchActions,
+  useSearchMatches } from '../../context/search_context'
+
 import { ResultOption } from './search_results'
-import { useSearchState, useSearchActions } from '../../context/search_context'
 import { urlFromInput } from '../../lib/url_input'
 
-export function useSearchInputState() {
+export function useSearchInputState(inputKey: string) {
   const actions = useSearchActions()
 
   const showSearchBox = useSearchState((s) => s.showSearchBox)
@@ -22,7 +26,7 @@ export function useSearchInputState() {
   const enabledSearchEngines = useSearchState((s) => s.enabledSearchEngines)
   const defaultSearchEngine = useSearchState((s) => s.defaultSearchEngine)
   const lastUsedSearchEngine = useSearchState((s) => s.lastUsedSearchEngine)
-  const searchMatches = useSearchState((s) => s.searchMatches)
+  const searchMatches = useSearchMatches(inputKey)
   const searchSuggestionsEnabled =
       useSearchState((s) => s.searchSuggestionsEnabled)
 
@@ -51,7 +55,7 @@ export function useSearchInputState() {
   // Build the list of result options. The result options can contain a direct
   // URL (if the user has typed a URL) or a list of autocomplete options.
   const resultOptions = React.useMemo(
-      () => getResultOptions(query, searchMatches),
+      () => getResultOptions(query, searchMatches ?? []),
       [query, searchMatches])
 
   // When the result option list changes, select the first available option that
@@ -142,6 +146,10 @@ export function useSearchInputState() {
     }
   }
 
+  function setActiveInput() {
+    actions.setActiveSearchInputKey(inputKey)
+  }
+
   function handleActionKeyDown(event: KeyboardEvent) {
     if (event.key === 'Enter') {
       if (selectedResultOption !== null) {
@@ -165,6 +173,7 @@ export function useSearchInputState() {
   return {
     query,
     setQuery,
+    setActiveInput,
     handleActionKeyDown,
     openSearch,
     resultOptions,

--- a/browser/resources/brave_new_tab_page_refresh/context/search_context.ts
+++ b/browser/resources/brave_new_tab_page_refresh/context/search_context.ts
@@ -12,3 +12,24 @@ export const SearchProvider =
 
 export const useSearchState = SearchProvider.useState
 export const useSearchActions = SearchProvider.useActions
+
+// Returns the current autocomplete search result matches for the current search
+// query. If the currently active search input key is not `inputKey`, then null
+// is returned. Use this hook rather than accessing `searchMatches` directly.
+//
+// This hook (and the `activeSearchInputKey` state) was added to support rich
+// NTT backgrounds that display a functional Brave Search search box for
+// promotional purposes. Since the autocomplete interface only supports one
+// search input on the page, the `activeSearchInputKey` provides a way for
+// multiple search "boxes" to coexist on the page without using each other's
+// autocomplete results. Any component that queries autocomplete should first
+// call `setActiveSearchInputKey` on the SearchActions interface and then should
+// use this hook to access autocomplete results.
+export function useSearchMatches(inputKey: string) {
+  const searchMatches = useSearchState((s) => s.searchMatches)
+  const activeSearchInputKey = useSearchState((s) => s.activeSearchInputKey)
+  if (inputKey !== activeSearchInputKey) {
+    return null
+  }
+  return searchMatches
+}

--- a/browser/resources/brave_new_tab_page_refresh/state/search_handler.ts
+++ b/browser/resources/brave_new_tab_page_refresh/state/search_handler.ts
@@ -183,6 +183,17 @@ export function createSearchHandler(
       newTabProxy.handler.setLastUsedSearchEngine(engine)
     },
 
+    setActiveSearchInputKey(key) {
+      const { activeSearchInputKey } = store.getState()
+      if (key !== activeSearchInputKey) {
+        searchProxy.handler.stopAutocomplete(true)
+        store.update({
+          activeSearchInputKey: key,
+          searchMatches: []
+        })
+      }
+    },
+
     queryAutocomplete(query, engine) {
       const searchEngine = findSearchEngine(engine)
       if (searchEngine && searchEngine.keyword) {

--- a/browser/resources/brave_new_tab_page_refresh/state/search_state.ts
+++ b/browser/resources/brave_new_tab_page_refresh/state/search_state.ts
@@ -36,6 +36,7 @@ export interface SearchState {
   lastUsedSearchEngine: string
   searchSuggestionsEnabled: boolean
   searchSuggestionsPromptDismissed: boolean
+  activeSearchInputKey: string
   searchMatches: AutocompleteMatch[]
 }
 
@@ -50,6 +51,7 @@ export function defaultSearchState(): SearchState {
     lastUsedSearchEngine: '',
     searchSuggestionsEnabled: true,
     searchSuggestionsPromptDismissed: false,
+    activeSearchInputKey: '',
     searchMatches: []
   }
 }
@@ -68,6 +70,7 @@ export interface SearchActions {
   setSearchSuggestionsPromptDismissed: (dismissed: boolean) => void
   setLastUsedSearchEngine: (engine: string) => void
   setSearchEngineEnabled: (engine: string, enabled: boolean) => void
+  setActiveSearchInputKey: (key: string) => void
   queryAutocomplete: (query: string, engine: string) => void
   openAutocompleteMatch: (index: number, event: ClickEvent) => void
   stopAutocomplete: () => void
@@ -85,6 +88,7 @@ export function defaultSearchActions(): SearchActions {
     setSearchSuggestionsPromptDismissed(dismissed) {},
     setSearchEngineEnabled(engine, enabled) {},
     setLastUsedSearchEngine(engine) {},
+    setActiveSearchInputKey(key) {},
     queryAutocomplete(query, engine) {},
     openAutocompleteMatch(index, event) {},
     stopAutocomplete() {},

--- a/browser/resources/brave_new_tab_page_refresh/stories/background_handler.ts
+++ b/browser/resources/brave_new_tab_page_refresh/stories/background_handler.ts
@@ -9,7 +9,6 @@ import {
   BackgroundState,
   BackgroundActions,
   NewTabPageAdMetricType,
-  SponsoredImageBackground,
   SelectedBackgroundType } from '../state/background_state'
 
 function delay(ms: number) {
@@ -21,7 +20,7 @@ function delay(ms: number) {
 const sampleBackground =
     'https://brave.com/static-assets/images/coding-background-texture.jpg'
 
-const sponsoredBackgrounds: Record<string, SponsoredImageBackground | null> = {
+const sponsoredBackgrounds = {
   image: {
     wallpaperType: '',
     imageUrl: sampleBackground,
@@ -70,7 +69,8 @@ export function createBackgroundHandler(
   })
 
   store.update({
-    sponsoredRichMediaBaseUrl: 'https://brave.com'
+    sponsoredRichMediaBaseUrl:
+      new URL(sponsoredBackgrounds.richMedia.imageUrl).origin
   })
 
   return {
@@ -115,6 +115,8 @@ export function createBackgroundHandler(
 
     notifySponsoredImageLogoClicked() {},
 
-    notifySponsoredRichMediaEvent(type) {}
+    notifySponsoredRichMediaEvent(type) {
+      console.log('richMediaEvent', type)
+    }
   }
 }

--- a/browser/resources/brave_new_tab_page_refresh/stories/search_handler.ts
+++ b/browser/resources/brave_new_tab_page_refresh/stories/search_handler.ts
@@ -72,6 +72,10 @@ export function createSearchHandler(store: Store<SearchState>): SearchActions {
       })
     },
 
+    setActiveSearchInputKey(key) {
+      store.update({ activeSearchInputKey: key })
+    },
+
     queryAutocomplete(query, engine) {
       store.update({
         searchMatches: [{


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/49591

The approach here is to add an "active search input key" to the application state. Search boxes will set this state on focus and will not display autocomplete results if the current key does not match its own key.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
