### PR TITLE
Autocomplete: commit suggestion on hardware Right Arrow (Fixes #44927)

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Widgets/AutocompleteTextField.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Widgets/AutocompleteTextField.swift
@@ -427,4 +427,19 @@ public class AutocompleteTextField: UITextField, UITextFieldDelegate {
     applyCompletion()
     super.touchesBegan(touches, with: event)
   }
+
+  public override func pressesEnded(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
+    for press in presses {
+      guard let key = press.key else { continue }
+      let chars = key.charactersIgnoringModifiers
+      let isRightArrowChar = chars == UIKeyCommand.inputRightArrow || chars == UIKeyCommand.inputRightArrow
+      let isRightArrowKeyCode = key.keyCode.rawValue == 79
+      if (isRightArrowChar || isRightArrowKeyCode) && isSelectionActive {
+        applyCompletion()
+        selectedTextRange = textRange(from: endOfDocument, to: endOfDocument)
+        return
+      }
+    }
+    super.pressesEnded(presses, with: event)
+  }
 }


### PR DESCRIPTION
**Summary**
This change ensures the Right Arrow key from hardware keyboards is treated like the autocomplete accessory arrow: when a suggestion is active, pressing Right Arrow commits the suggestion into the text field. Some hardware keyboards send arrow events as `UIPress` rather than triggering `UIKeyCommand`; handling `pressesEnded` provides a robust fallback.

**Motivation**
Reproduces and fixes the behavior described in brave/brave-browser#44927: on iPad (and simulator with hardware keyboard), pressing Right Arrow while an autocomplete suggestion is highlighted should commit the suggestion instead of moving the caret one character. The existing `UIKeyCommand` path was not triggered in certain contexts where the arrow arrives as a `UIPress`.

**What changed**
* Added a `pressesEnded(_:with:)` override to `AutocompleteTextField` that:

  * Detects Right Arrow via `charactersIgnoringModifiers` and HID usage (keyCode raw value 79) for compatibility.
  * If a suggestion is active (`isSelectionActive`), calls `applyCompletion()` and moves caret to the end.
  * Leaves normal caret movement untouched when no suggestion is active.

**How I tested**
* iPad Simulator with hardware keyboard connected:

  1. Focus the location/search bar.
  2. Type a prefix that triggers a known suggestion (e.g. `old.` for `old.reddit.com`).
  3. Press Right Arrow — suggestion is committed and caret placed at end.
  4. Press Right Arrow when no suggestion is active — caret behaves normally.
* Verified behavior on Simulator; recommend test on an actual iPad + external keyboard for final verification.

**Related**
Fixes brave/brave-browser#44927