### PR TITLE
Fix NPE by adding null checks to BraveMediaSessionTabHelper

### DIFF
--- a/android/java/org/chromium/chrome/browser/media/ui/BraveMediaSessionTabHelper.java
+++ b/android/java/org/chromium/chrome/browser/media/ui/BraveMediaSessionTabHelper.java
@@ -5,15 +5,20 @@
 
 package org.chromium.chrome.browser.media.ui;
 
+import static org.chromium.build.NullUtil.assumeNonNull;
+
+import org.chromium.build.annotations.NullMarked;
+import org.chromium.build.annotations.Nullable;
 import org.chromium.chrome.R;
 import org.chromium.chrome.browser.tab.Tab;
 import org.chromium.components.browser_ui.media.BraveMediaSessionHelper;
 import org.chromium.components.browser_ui.media.MediaNotificationInfo;
 import org.chromium.components.browser_ui.media.MediaNotificationManager;
 
+@NullMarked
 public class BraveMediaSessionTabHelper extends MediaSessionTabHelper {
     /** Will be deleted in bytecode, value from the parent class will be used instead. */
-    private Tab mTab;
+    private @Nullable Tab mTab;
 
     BraveMediaSessionTabHelper(Tab tab) {
         super(tab);
@@ -21,17 +26,19 @@ public class BraveMediaSessionTabHelper extends MediaSessionTabHelper {
 
     @Override
     public MediaNotificationInfo.Builder createMediaNotificationInfoBuilder() {
-        if (!BraveMediaSessionHelper.isBraveTalk(mTab.getWebContents())) {
+        if (!BraveMediaSessionHelper.isBraveTalk(assumeNonNull(mTab).getWebContents())) {
             return super.createMediaNotificationInfoBuilder();
         }
 
         return new MediaNotificationInfo.Builder()
-                .setInstanceId(mTab.getId())
+                .setInstanceId(assumeNonNull(mTab).getId())
                 .setId(R.id.media_playback_mic_notification);
     }
 
     @Override
     public void hideMediaNotification() {
+        if (mTab == null) return; // Return early if onDestroy was already called.
+
         if (!BraveMediaSessionHelper.isBraveTalk(mTab.getWebContents())) {
             super.hideMediaNotification();
             return;
@@ -41,6 +48,8 @@ public class BraveMediaSessionTabHelper extends MediaSessionTabHelper {
 
     @Override
     public void activateAndroidMediaSession() {
+        if (mTab == null) return; // Return early if onDestroy was already called.
+
         if (!BraveMediaSessionHelper.isBraveTalk(mTab.getWebContents())) {
             super.activateAndroidMediaSession();
             return;


### PR DESCRIPTION
The mTab must be getting destroyed before these methods are being run.
Corresponding upstream changes https://github.com/chromium/chromium/commit/f46e6b5081d3ec23f0926847586ec75ed1b4862f and https://github.com/chromium/chromium/commit/10fdf24ec056e6e74cfc781ecd6382ed9791c7dc
Resolves: https://github.com/brave/brave-browser/issues/49674

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
