### PR TITLE
Fix NPE by adding null checks to BraveMediaSessionTabHelper (uplift to 1.83.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/media/ui/BraveMediaSessionTabHelper.java
+++ b/android/java/org/chromium/chrome/browser/media/ui/BraveMediaSessionTabHelper.java
@@ -5,15 +5,20 @@
 
 package org.chromium.chrome.browser.media.ui;
 
+import static org.chromium.build.NullUtil.assumeNonNull;
+
+import org.chromium.build.annotations.NullMarked;
+import org.chromium.build.annotations.Nullable;
 import org.chromium.chrome.R;
 import org.chromium.chrome.browser.tab.Tab;
 import org.chromium.components.browser_ui.media.BraveMediaSessionHelper;
 import org.chromium.components.browser_ui.media.MediaNotificationInfo;
 import org.chromium.components.browser_ui.media.MediaNotificationManager;
 
+@NullMarked
 public class BraveMediaSessionTabHelper extends MediaSessionTabHelper {
     /** Will be deleted in bytecode, value from the parent class will be used instead. */
-    private Tab mTab;
+    private @Nullable Tab mTab;
 
     BraveMediaSessionTabHelper(Tab tab) {
         super(tab);
@@ -21,17 +26,19 @@ public class BraveMediaSessionTabHelper extends MediaSessionTabHelper {
 
     @Override
     public MediaNotificationInfo.Builder createMediaNotificationInfoBuilder() {
-        if (!BraveMediaSessionHelper.isBraveTalk(mTab.getWebContents())) {
+        if (!BraveMediaSessionHelper.isBraveTalk(assumeNonNull(mTab).getWebContents())) {
             return super.createMediaNotificationInfoBuilder();
         }
 
         return new MediaNotificationInfo.Builder()
-                .setInstanceId(mTab.getId())
+                .setInstanceId(assumeNonNull(mTab).getId())
                 .setId(R.id.media_playback_mic_notification);
     }
 
     @Override
     public void hideMediaNotification() {
+        if (mTab == null) return; // Return early if onDestroy was already called.
+
         if (!BraveMediaSessionHelper.isBraveTalk(mTab.getWebContents())) {
             super.hideMediaNotification();
             return;
@@ -41,6 +48,8 @@ public class BraveMediaSessionTabHelper extends MediaSessionTabHelper {
 
     @Override
     public void activateAndroidMediaSession() {
+        if (mTab == null) return; // Return early if onDestroy was already called.
+
         if (!BraveMediaSessionHelper.isBraveTalk(mTab.getWebContents())) {
             super.activateAndroidMediaSession();
             return;


### PR DESCRIPTION
Uplift of #31456
Resolves https://github.com/brave/brave-browser/issues/49674

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.