### PR TITLE
Enabled injecting command line options from a config file on Linux

### DIFF
--- a/patches/chrome-installer-linux-common-wrapper.patch
+++ b/patches/chrome-installer-linux-common-wrapper.patch
@@ -1,8 +1,8 @@
 diff --git a/chrome/installer/linux/common/wrapper b/chrome/installer/linux/common/wrapper
-index aaa46bf71f6a3..22e4412a127e1 100755
+index aaa46bf71f6a3..58fd403372220 100755
 --- a/chrome/installer/linux/common/wrapper
 +++ b/chrome/installer/linux/common/wrapper
-@@ -27,6 +27,40 @@ fi
+@@ -27,6 +27,41 @@ fi
  
  export CHROME_VERSION_EXTRA="@@CHANNEL@@"
  
@@ -12,6 +12,7 @@ index aaa46bf71f6a3..22e4412a127e1 100755
 +cfg_options=()
 +
 +shopt -s extglob
++
 +if [[ -f "$cfg_file" ]]; then
 +  # Parse options after comments have been removed.
 +  parse_cfg_options() {
@@ -31,7 +32,7 @@ index aaa46bf71f6a3..22e4412a127e1 100755
 +    parse_cfg_options "$rest"
 +  }
 +
-+  # Remove comments and parse the remaining options.
++  # Read the config file, remove comments and parse the remaining options.
 +  while read -r cfg_line; do
 +    read -ra cfg_line_items <<<"${cfg_line%%[[:space:]]#*}"
 +    if [[ "${cfg_line_items[0]:0:1}" != "#" ]]; then
@@ -43,7 +44,7 @@ index aaa46bf71f6a3..22e4412a127e1 100755
  # We don't want bug-buddy intercepting our crashes. http://crbug.com/24120
  export GNOME_DISABLE_CRASH_DIALOG=SET_BY_GOOGLE_CHROME
  
-@@ -37,4 +71,4 @@ exec > >(exec cat)
+@@ -37,4 +72,4 @@ exec > >(exec cat)
  exec 2> >(exec cat >&2)
  
  # Note: exec -a below is a bashism.


### PR DESCRIPTION
**EARLY DRAFT, PLEASE DON'T REVIEW, UNLESS EXPLICITLY REQUESTED**

Resolves https://github.com/brave/brave-browser/issues/49220

This will fix a number of issues on Arch and port a feature that was Arch-specific to all Linux distributions, with improvements.

The feature allows users to add command-line options to a file (~/.config/brave-flags.conf, ~/.config/brave-beta-flags.conf, ~/.config/brave-nightly-flags.conf), to be injected each time the browser is launched.

This was originally implemented by previous maintainers of Arch packages, before Brave took over maintenance. As such, users are already relying on this behavior.

On Arch, we would drop the custom wrapper and rely on the newly patched upstream one, which would, most importantly, fix PWAs, probably fix https://github.com/brave/brave-browser/issues/14603 (haven't tested yet) and bring in a few other improvements (see: https://github.com/brave/brave-browser/issues/49220).

On all other distributions, it would enable this useful feature that only Arch users had access to.

Beyond that, we'd be fixing some issues with the [previous](https://aur.archlinux.org/cgit/aur.git/tree/brave-bin.sh?h=brave-bin) [wrappers](https://aur.archlinux.org/cgit/aur.git/tree/brave-nightly-bin.sh?h=brave-nightly-bin) (max one option per line, no inline comment support, inadequate quoting, no whitespace stripping, use of tools from packages that aren't dependencies, issues with passing multiple options).

This also removes a workaround for https://github.com/brave/brave-browser/issues/4142, which, at this point, was leaving a shell process in the tree unnecessarily and unconditionally changing the exit code to 0.

To anyone who thinks this should be implemented in the browser - right on. Until a PR for that materializes, this is the solution.