### PR TITLE
[perf] Load brave news images on demand

### DIFF
--- a/browser/resources/brave_new_tab_page_refresh/components/common/safe_image.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/common/safe_image.tsx
@@ -29,17 +29,16 @@ export function SafeImage(props: Props) {
     src = placeholderImageSrc
   }
 
-  const { scrolledToNews } = useBraveNews()
-  const delayLoad = !scrolledToNews && loading === 'lazy'
+  const { shouldRenderImages } = useBraveNews()
+  const delayLoad = !shouldRenderImages && loading === 'lazy'
 
   return (
     <img
-      src={!delayLoad ? src: undefined}
+      src={delayLoad ? undefined : src}
       loading={loading ?? 'lazy'}
       className={props.className}
       onError={(event) => { event.currentTarget.src = placeholderImageSrc }}
-      onLoad={(event) => { event.currentTarget.style.opacity = '1' }}
-      style={{ opacity: 0, transition: 'opacity 400ms ease-in-out' }}
+      onLoad={(event) => { event.currentTarget?.classList.add('loaded') }}
     />
   )
 }

--- a/browser/resources/brave_new_tab_page_refresh/components/common/safe_image.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/common/safe_image.tsx
@@ -10,7 +10,6 @@ import { placeholderImageSrc } from '../../lib/image_loader'
 interface Props {
   src: string
   className?: string
-  loading?: 'lazy' | 'eager'
   targetSize?: { width: number, height: number }
 }
 

--- a/browser/resources/brave_new_tab_page_refresh/components/common/safe_image.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/common/safe_image.tsx
@@ -6,15 +6,17 @@
 import * as React from 'react'
 
 import { placeholderImageSrc } from '../../lib/image_loader'
+import { useBraveNews } from '../../../../../components/brave_news/browser/resources/shared/Context'
 
 interface Props {
   src: string
   className?: string
+  loading?: 'lazy' | 'eager'
   targetSize?: { width: number, height: number }
 }
 
 export function SafeImage(props: Props) {
-  let { src } = props
+  let { src, loading } = props
   if (src) {
     src = 'chrome://brave-image?url=' + encodeURIComponent(src);
     if (props.targetSize) {
@@ -23,13 +25,21 @@ export function SafeImage(props: Props) {
       height = Math.round(height * window.devicePixelRatio)
       src += `&target_size=${width}x${height}`
     }
+  } else {
+    src = placeholderImageSrc
   }
+
+  const { scrolledToNews } = useBraveNews()
+  const delayLoad = !scrolledToNews && loading === 'lazy'
+
   return (
     <img
-      src={src || placeholderImageSrc}
-      loading='lazy'
+      src={!delayLoad ? src: undefined}
+      loading={loading ?? 'lazy'}
       className={props.className}
       onError={(event) => { event.currentTarget.src = placeholderImageSrc }}
+      onLoad={(event) => { event.currentTarget.style.opacity = '1' }}
+      style={{ opacity: 0, transition: 'opacity 400ms ease-in-out' }}
     />
   )
 }

--- a/browser/resources/brave_new_tab_page_refresh/components/common/safe_image.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/common/safe_image.tsx
@@ -15,7 +15,7 @@ interface Props {
 }
 
 export function SafeImage(props: Props) {
-  let { src, loading } = props
+  let { src } = props
   if (src) {
     src = 'chrome://brave-image?url=' + encodeURIComponent(src);
     if (props.targetSize) {
@@ -24,14 +24,12 @@ export function SafeImage(props: Props) {
       height = Math.round(height * window.devicePixelRatio)
       src += `&target_size=${width}x${height}`
     }
-  } else {
-    src = placeholderImageSrc
   }
 
   return (
     <img
-      src={src}
-      loading={loading ?? 'lazy'}
+      src={src || placeholderImageSrc}
+      loading='lazy'
       className={props.className}
       onError={(event) => { event.currentTarget.src = placeholderImageSrc }}
       onLoad={(event) => { event.currentTarget?.classList.add('loaded') }}

--- a/browser/resources/brave_new_tab_page_refresh/components/common/safe_image.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/common/safe_image.tsx
@@ -6,7 +6,6 @@
 import * as React from 'react'
 
 import { placeholderImageSrc } from '../../lib/image_loader'
-import { useBraveNews } from '../../../../../components/brave_news/browser/resources/shared/Context'
 
 interface Props {
   src: string
@@ -29,12 +28,9 @@ export function SafeImage(props: Props) {
     src = placeholderImageSrc
   }
 
-  const { shouldRenderImages } = useBraveNews()
-  const delayLoad = !shouldRenderImages && loading === 'lazy'
-
   return (
     <img
-      src={delayLoad ? undefined : src}
+      src={src}
       loading={loading ?? 'lazy'}
       className={props.className}
       onError={(event) => { event.currentTarget.src = placeholderImageSrc }}

--- a/browser/resources/brave_new_tab_page_refresh/components/news/news_feed.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/news/news_feed.tsx
@@ -22,12 +22,6 @@ export function NewsFeed() {
     setTimeout(() => setShouldRenderNews(true), 1000)
   }, [])
 
-  React.useEffect(() => {
-    const handleScroll = () => braveNews.setShouldRenderImages(true)
-    document.addEventListener('scroll', handleScroll, { once: true })
-    return () => document.removeEventListener('scroll', handleScroll)
-  }, [braveNews.shouldRenderImages])
-
   if (!newsFeatureEnabled) {
     return null
   }

--- a/browser/resources/brave_new_tab_page_refresh/components/news/news_feed.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/news/news_feed.tsx
@@ -22,6 +22,12 @@ export function NewsFeed() {
     setTimeout(() => setShouldRenderNews(true), 1000)
   }, [])
 
+  React.useEffect(() => {
+    const handleScroll = () => braveNews.setShouldRenderImages(true)
+    document.addEventListener('scroll', handleScroll, { once: true })
+    return () => document.removeEventListener('scroll', handleScroll)
+  }, [braveNews.shouldRenderImages])
+
   if (!newsFeatureEnabled) {
     return null
   }

--- a/browser/resources/brave_new_tab_page_refresh/components/widgets/news_widget.style.ts
+++ b/browser/resources/brave_new_tab_page_refresh/components/widgets/news_widget.style.ts
@@ -88,6 +88,16 @@ export const style = scoped.css`
     }
   }
 
+  .peek {
+    img {
+      opacity: 0;
+      transition: opacity 400ms ease-in-out;
+      &.loaded {
+        opacity: 1;
+      }
+    }
+  }
+
   .loading {
     .img {
       width: 71px;

--- a/browser/resources/brave_new_tab_page_refresh/components/widgets/news_widget.style.ts
+++ b/browser/resources/brave_new_tab_page_refresh/components/widgets/news_widget.style.ts
@@ -64,6 +64,11 @@ export const style = scoped.css`
       object-fit: cover;
       object-position: center top;
       border-radius: 4px;
+      opacity: 0;
+      transition: opacity 400ms ease-in-out;
+      &.loaded {
+        opacity: 1;
+      }
     }
 
     .meta {
@@ -85,16 +90,6 @@ export const style = scoped.css`
       display: -webkit-box;
       -webkit-box-orient: vertical;
       -webkit-line-clamp: 2;
-    }
-  }
-
-  .peek {
-    img {
-      opacity: 0;
-      transition: opacity 400ms ease-in-out;
-      &.loaded {
-        opacity: 1;
-      }
     }
   }
 

--- a/components/brave_news/browser/resources/feed/Card.tsx
+++ b/components/brave_news/browser/resources/feed/Card.tsx
@@ -51,8 +51,8 @@ const HidableImage = ({
 }: HidabeImageProps) => {
   const ref = React.useRef<HTMLImageElement>()
 
-  const { scrolledToNews } = useBraveNews()
-  const delayLoad = !scrolledToNews && loading === 'lazy'
+  const { shouldRenderImages } = useBraveNews()
+  const delayLoad = !shouldRenderImages && loading === 'lazy'
 
   const handleError = React.useCallback((e: React.UIEvent<HTMLImageElement>) => {
     ref.current!.style.opacity = '0'

--- a/components/brave_news/browser/resources/feed/Card.tsx
+++ b/components/brave_news/browser/resources/feed/Card.tsx
@@ -46,9 +46,13 @@ const HidableImage = ({
   targetHeight,
   targetWidth,
   src,
+  loading,
   ...rest
 }: HidabeImageProps) => {
   const ref = React.useRef<HTMLImageElement>()
+
+  const { scrolledToNews } = useBraveNews()
+  const delayLoad = !scrolledToNews && loading === 'lazy'
 
   const handleError = React.useCallback((e: React.UIEvent<HTMLImageElement>) => {
     ref.current!.style.opacity = '0'
@@ -56,7 +60,7 @@ const HidableImage = ({
   }, [onError])
 
   const handleLoad = React.useCallback((e: React.UIEvent<HTMLImageElement>) => {
-    ref.current!.style.opacity = ''
+    ref.current!.style.opacity = '1'
     onLoad?.(e)
   }, [onLoad])
 
@@ -69,7 +73,14 @@ const HidableImage = ({
     src += `&target_size=${width}x${height}`
   }
 
-  return <img {...rest} src={src} ref={ref as any} onError={handleError} onLoad={handleLoad} />
+  return <img
+    {...rest}
+    src={delayLoad ? undefined : src}
+    ref={ref as any}
+    onError={handleError}
+    onLoad={handleLoad}
+    style={{ opacity: 0, transition: 'opacity 400ms ease-in-out', ...rest.style }}
+  />
 }
 
 export const SmallImage = styled(HidableImage).attrs({ targetHeight: 64, targetWidth: 96 })`

--- a/components/brave_news/browser/resources/feed/Card.tsx
+++ b/components/brave_news/browser/resources/feed/Card.tsx
@@ -33,6 +33,12 @@ export const Title = styled.h3`
 
   &> a { all: unset; }
 `
+
+const BaseImg = styled.img`
+  opacity: 0;
+  transition: opacity 400ms ease-in-out;
+`
+
 type HidabeImageProps = React.DetailedHTMLProps<
   React.ImgHTMLAttributes<HTMLImageElement>,
   HTMLImageElement
@@ -54,11 +60,6 @@ const HidableImage = ({
   const { shouldRenderImages } = useBraveNews()
   const delayLoad = !shouldRenderImages && loading === 'lazy'
 
-  const handleError = React.useCallback((e: React.UIEvent<HTMLImageElement>) => {
-    ref.current!.style.opacity = '0'
-    onError?.(e)
-  }, [onError])
-
   const handleLoad = React.useCallback((e: React.UIEvent<HTMLImageElement>) => {
     ref.current!.style.opacity = '1'
     onLoad?.(e)
@@ -73,13 +74,12 @@ const HidableImage = ({
     src += `&target_size=${width}x${height}`
   }
 
-  return <img
+  return <BaseImg
     {...rest}
     src={delayLoad ? undefined : src}
+    loading={loading}
     ref={ref as any}
-    onError={handleError}
     onLoad={handleLoad}
-    style={{ opacity: 0, transition: 'opacity 400ms ease-in-out', ...rest.style }}
   />
 }
 

--- a/components/brave_news/browser/resources/shared/Context.tsx
+++ b/components/brave_news/browser/resources/shared/Context.tsx
@@ -49,7 +49,6 @@ interface BraveNewsContext {
   reportSessionStart: () => void
 
   shouldRenderImages: boolean
-  setShouldRenderImages: (scrolled: boolean) => void
 }
 
 export const BraveNewsContext = React.createContext<BraveNewsContext>({
@@ -78,7 +77,6 @@ export const BraveNewsContext = React.createContext<BraveNewsContext>({
   reportSidebarFilterUsage: () => { },
   reportSessionStart: () => { },
   shouldRenderImages: false,
-  setShouldRenderImages: (scrolled: boolean) => { },
 })
 
 export const publishersCache = new PublishersCachingWrapper()
@@ -131,6 +129,15 @@ export function BraveNewsContextProvider(props: { children: React.ReactNode }) {
     const handler = (publishers: Publishers) => setPublishers(publishers)
     publishersCache.addListener(handler)
     return () => { publishersCache.removeListener(handler) }
+  }, [])
+
+  React.useEffect(() => {
+    if (shouldRenderImages) {
+      return
+    }
+    const handleScroll = () => setShouldRenderImages(true)
+    document.addEventListener('scroll', handleScroll, { once: true })
+    return () => document.removeEventListener('scroll', handleScroll)
   }, [])
 
   const sortedPublishers = useMemo(() =>
@@ -209,8 +216,7 @@ export function BraveNewsContextProvider(props: { children: React.ReactNode }) {
     reportSidebarFilterUsage,
     reportSessionStart,
     shouldRenderImages,
-    setShouldRenderImages,
-  }), [customizePage, setFeedView, feedV2, feedV2UpdatesAvailable, channels, publishers, suggestedPublisherIds, filteredPublisherIds, updateSuggestedPublisherIds, configuration, toggleBraveNewsOnNTP, reportSidebarFilterUsage, reportViewCount, reportVisit, reportSessionStart, shouldRenderImages, setShouldRenderImages])
+  }), [customizePage, setFeedView, feedV2, feedV2UpdatesAvailable, channels, publishers, suggestedPublisherIds, filteredPublisherIds, updateSuggestedPublisherIds, configuration, toggleBraveNewsOnNTP, reportSidebarFilterUsage, reportViewCount, reportVisit, reportSessionStart, shouldRenderImages])
 
   return <BraveNewsContext.Provider value={context}>
     {props.children}

--- a/components/brave_news/browser/resources/shared/Context.tsx
+++ b/components/brave_news/browser/resources/shared/Context.tsx
@@ -132,9 +132,6 @@ export function BraveNewsContextProvider(props: { children: React.ReactNode }) {
   }, [])
 
   React.useEffect(() => {
-    if (shouldRenderImages) {
-      return
-    }
     const handleScroll = () => setShouldRenderImages(true)
     document.addEventListener('scroll', handleScroll, { once: true })
     return () => document.removeEventListener('scroll', handleScroll)

--- a/components/brave_news/browser/resources/shared/Context.tsx
+++ b/components/brave_news/browser/resources/shared/Context.tsx
@@ -48,8 +48,8 @@ interface BraveNewsContext {
   reportSidebarFilterUsage: () => void
   reportSessionStart: () => void
 
-  scrolledToNews: boolean
-  setScrolledToNews: (scrolled: boolean) => void
+  shouldRenderImages: boolean
+  setShouldRenderImages: (scrolled: boolean) => void
 }
 
 export const BraveNewsContext = React.createContext<BraveNewsContext>({
@@ -77,8 +77,8 @@ export const BraveNewsContext = React.createContext<BraveNewsContext>({
   reportVisit: (depth: number) => { },
   reportSidebarFilterUsage: () => { },
   reportSessionStart: () => { },
-  scrolledToNews: false,
-  setScrolledToNews: (scrolled: boolean) => { },
+  shouldRenderImages: false,
+  setShouldRenderImages: (scrolled: boolean) => { },
 })
 
 export const publishersCache = new PublishersCachingWrapper()
@@ -102,7 +102,7 @@ export function BraveNewsContextProvider(props: { children: React.ReactNode }) {
   const [channels, setChannels] = useState<Channels>({})
   const [publishers, setPublishers] = useState<Publishers>({})
   const [suggestedPublisherIds, setSuggestedPublisherIds] = useState<string[]>([])
-  const [scrolledToNews, setScrolledToNews] = useState(false)
+  const [shouldRenderImages, setShouldRenderImages] = useState(false)
 
   // Get the default locale on load.
   useEffect(() => {
@@ -120,16 +120,6 @@ export function BraveNewsContextProvider(props: { children: React.ReactNode }) {
     configurationCache.addListener(setConfiguration)
     return () => configurationCache.removeListener(setConfiguration)
   }, [])
-
-  React.useEffect(() => {
-    if (scrolledToNews) {
-      return
-    }
-
-    const handleScroll = () => setScrolledToNews(true)
-    document.addEventListener('scroll', handleScroll, { once: true })
-    return () => document.removeEventListener('scroll', handleScroll)
-  }, [scrolledToNews])
 
   const updateSuggestedPublisherIds = useCallback(async () => {
     setSuggestedPublisherIds([])
@@ -218,9 +208,9 @@ export function BraveNewsContextProvider(props: { children: React.ReactNode }) {
     reportVisit,
     reportSidebarFilterUsage,
     reportSessionStart,
-    scrolledToNews,
-    setScrolledToNews
-  }), [customizePage, setFeedView, feedV2, feedV2UpdatesAvailable, channels, publishers, suggestedPublisherIds, filteredPublisherIds, updateSuggestedPublisherIds, configuration, toggleBraveNewsOnNTP, reportSidebarFilterUsage, reportViewCount, reportVisit, reportSessionStart, scrolledToNews, setScrolledToNews])
+    shouldRenderImages,
+    setShouldRenderImages,
+  }), [customizePage, setFeedView, feedV2, feedV2UpdatesAvailable, channels, publishers, suggestedPublisherIds, filteredPublisherIds, updateSuggestedPublisherIds, configuration, toggleBraveNewsOnNTP, reportSidebarFilterUsage, reportViewCount, reportVisit, reportSessionStart, shouldRenderImages, setShouldRenderImages])
 
   return <BraveNewsContext.Provider value={context}>
     {props.children}

--- a/components/brave_news/browser/resources/shared/Context.tsx
+++ b/components/brave_news/browser/resources/shared/Context.tsx
@@ -47,6 +47,9 @@ interface BraveNewsContext {
   reportVisit: (depth: number) => void
   reportSidebarFilterUsage: () => void
   reportSessionStart: () => void
+
+  scrolledToNews: boolean
+  setScrolledToNews: (scrolled: boolean) => void
 }
 
 export const BraveNewsContext = React.createContext<BraveNewsContext>({
@@ -74,6 +77,8 @@ export const BraveNewsContext = React.createContext<BraveNewsContext>({
   reportVisit: (depth: number) => { },
   reportSidebarFilterUsage: () => { },
   reportSessionStart: () => { },
+  scrolledToNews: false,
+  setScrolledToNews: (scrolled: boolean) => { },
 })
 
 export const publishersCache = new PublishersCachingWrapper()
@@ -97,6 +102,7 @@ export function BraveNewsContextProvider(props: { children: React.ReactNode }) {
   const [channels, setChannels] = useState<Channels>({})
   const [publishers, setPublishers] = useState<Publishers>({})
   const [suggestedPublisherIds, setSuggestedPublisherIds] = useState<string[]>([])
+  const [scrolledToNews, setScrolledToNews] = useState(false)
 
   // Get the default locale on load.
   useEffect(() => {
@@ -114,6 +120,16 @@ export function BraveNewsContextProvider(props: { children: React.ReactNode }) {
     configurationCache.addListener(setConfiguration)
     return () => configurationCache.removeListener(setConfiguration)
   }, [])
+
+  React.useEffect(() => {
+    if (scrolledToNews) {
+      return
+    }
+
+    const handleScroll = () => setScrolledToNews(true)
+    document.addEventListener('scroll', handleScroll, { once: true })
+    return () => document.removeEventListener('scroll', handleScroll)
+  }, [scrolledToNews])
 
   const updateSuggestedPublisherIds = useCallback(async () => {
     setSuggestedPublisherIds([])
@@ -201,8 +217,10 @@ export function BraveNewsContextProvider(props: { children: React.ReactNode }) {
     reportViewCount,
     reportVisit,
     reportSidebarFilterUsage,
-    reportSessionStart
-  }), [customizePage, setFeedView, feedV2, feedV2UpdatesAvailable, channels, publishers, suggestedPublisherIds, filteredPublisherIds, updateSuggestedPublisherIds, configuration, toggleBraveNewsOnNTP, reportSidebarFilterUsage, reportViewCount, reportVisit, reportSessionStart])
+    reportSessionStart,
+    scrolledToNews,
+    setScrolledToNews
+  }), [customizePage, setFeedView, feedV2, feedV2UpdatesAvailable, channels, publishers, suggestedPublisherIds, filteredPublisherIds, updateSuggestedPublisherIds, configuration, toggleBraveNewsOnNTP, reportSidebarFilterUsage, reportViewCount, reportVisit, reportSessionStart, scrolledToNews, setScrolledToNews])
 
   return <BraveNewsContext.Provider value={context}>
     {props.children}


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/48998
The PR tracks the scroll event and postpone loading the most news-related images (marked as `loading=lazy`) until the scroll is started.
It also add 400ms fade effect when a loaded image appears to add smoothness (without on-disk caching it's still impossible to load images instantly).
A video how it looks like: https://github.com/user-attachments/assets/f57dbfa1-ae04-4548-82fd-ec4766e33369


<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
