### PR TITLE
[AI Chat]: Add Locale Strings for Smart Mode Feature

### DIFF
--- a/components/resources/ai_chat_ui_strings.grdp
+++ b/components/resources/ai_chat_ui_strings.grdp
@@ -282,6 +282,63 @@
   <message name="IDS_CHAT_UI_COPY_PROMPT_BUTTON_LABEL" desc="Button title to copy prompt content" formatter_data="webui=AiChat">
     Copy prompt
   </message>
+  <message name="IDS_CHAT_UI_SAVE_AS_SMART_MODE_BUTTON_LABEL" desc="Button title to save prompt as smart mode" formatter_data="webui=AiChat">
+    Save as smart mode
+  </message>
+  <message name="IDS_CHAT_UI_SMART_MODES_GROUP" desc="Group label for smart modes in tools menu" formatter_data="webui=AiChat">
+    My Smart Modes
+  </message>
+  <message name="IDS_CHAT_UI_NEW_SMART_MODE_TITLE" desc="Title for new smart mode dialog" formatter_data="webui=AiChat">
+    New smart mode
+  </message>
+  <message name="IDS_CHAT_UI_SMART_MODE_DESCRIPTION" desc="Description text for smart mode dialog" formatter_data="webui=AiChat">
+    Smart modes will appear in your [/] tools and are accessible by just typing the "/name" you set up below.
+  </message>
+  <message name="IDS_CHAT_UI_MODEL_FOR_PROMPT_LABEL" desc="Label for model selection in smart mode dialog" formatter_data="webui=AiChat">
+    Model for prompt
+  </message>
+  <message name="IDS_CHAT_UI_USE_DEFAULT_MODEL_LABEL" desc="Label for using default model option" formatter_data="webui=AiChat">
+    Use default model
+  </message>
+  <message name="IDS_CHAT_UI_SHORTCUT_LABEL" desc="Label for shortcut input in smart mode dialog" formatter_data="webui=AiChat">
+    Shortcut
+  </message>
+  <message name="IDS_CHAT_UI_SHORTCUT_PLACEHOLDER" desc="Placeholder text for shortcut input" formatter_data="webui=AiChat">
+    tarot
+  </message>
+  <message name="IDS_CHAT_UI_PROMPT_LABEL" desc="Label for prompt input in smart mode dialog" formatter_data="webui=AiChat">
+    Prompt
+  </message>
+  <message name="IDS_CHAT_UI_PROMPT_PLACEHOLDER" desc="Placeholder text for prompt input" formatter_data="webui=AiChat">
+    Generate a 3-card Tarot reading. Includes names of each card and their meaning and an interpretation of all cards together.
+  </message>
+  <message name="IDS_CHAT_UI_EDIT_SMART_MODE_TITLE" desc="Title for edit smart mode dialog" formatter_data="webui=AiChat">
+    Edit smart mode
+  </message>
+  <message name="IDS_CHAT_UI_DELETE_SMART_MODE_TITLE" desc="Title for delete smart mode confirmation dialog" formatter_data="webui=AiChat">
+    Delete smart mode
+  </message>
+  <message name="IDS_CHAT_UI_DELETE_SMART_MODE_WARNING" desc="Warning message for deleting a smart mode" formatter_data="webui=AiChat">
+    Are you sure you want to delete this mode? This action cannot be undone.
+  </message>
+  <message name="IDS_CHAT_UI_SHORTCUT_REQUIRED_ERROR" desc="Error message when shortcut field is empty in smart mode dialog" formatter_data="webui=AiChat">
+    Shortcut is required
+  </message>
+  <message name="IDS_CHAT_UI_SHORTCUT_FORMAT_ERROR" desc="Error message when shortcut format is invalid in smart mode dialog" formatter_data="webui=AiChat">
+    Shortcut can only contain letters, numbers, underscore, and hyphen
+  </message>
+  <message name="IDS_CHAT_UI_SHORTCUT_TOO_LONG_ERROR" desc="Error message when shortcut exceeds maximum length in smart mode dialog" formatter_data="webui=AiChat">
+    Shortcut must be 64 characters or less
+  </message>
+  <message name="IDS_CHAT_UI_SHORTCUT_DUPLICATE_ERROR" desc="Error message when shortcut already exists" formatter_data="webui=AiChat">
+    Shortcut already exists
+  </message>
+  <message name="IDS_CHAT_UI_PROMPT_REQUIRED_ERROR" desc="Error message when prompt field is empty in smart mode dialog" formatter_data="webui=AiChat">
+    Prompt is required
+  </message>
+  <message name="IDS_CHAT_UI_PROMPT_TOO_LONG_ERROR" desc="Error message when prompt exceeds character limit" formatter_data="webui=AiChat">
+    Prompt must be 1000 characters or less
+  </message>
   <message name="IDS_CHAT_UI_EDIT_ANSWER_LABEL" desc="Button title to edit AI agent answer" formatter_data="webui=AiChat">
     Edit answer
   </message>


### PR DESCRIPTION
## Description 

Add's all needed `Locale` strings for the new `Smart Mode` feature

The `Smart Mode` front-end integration is being split into 4 smaller PR's, these strings will be utilized in 

- https://github.com/brave/brave-browser/issues/49770

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/49774>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

<img width="559" height="751" alt="Screenshot 62" src="https://github.com/user-attachments/assets/d35263fd-469c-4b51-a0f4-6a1ab9a6abdf" />

<img width="388" height="529" alt="Screenshot 64" src="https://github.com/user-attachments/assets/1e5bda82-f2f1-4205-a75c-06ab77076386" />

<img width="390" height="227" alt="Screenshot 65" src="https://github.com/user-attachments/assets/73073729-415c-488e-881c-18468f9d082f" />

<img width="424" height="252" alt="Screenshot 63" src="https://github.com/user-attachments/assets/8f45cdfe-e8c9-4d84-b7b9-ec734d267e81" />

<img width="833" height="165" alt="Screenshot 66" src="https://github.com/user-attachments/assets/408cf41f-0665-4a54-b4b1-173a15292163" />
