### PR TITLE
[Settings]: Should be possible to open the SurveyPanelist from search

### DIFF
--- a/browser/resources/settings/brave_overrides/basic_page.ts
+++ b/browser/resources/settings/brave_overrides/basic_page.ts
@@ -23,7 +23,6 @@ import '../social_blocking_page/social_blocking_page.js'
 import '../brave_leo_assistant_page/brave_leo_assistant_page.js'
 import '../brave_leo_assistant_page/model_list_section.js'
 import '../brave_leo_assistant_page/personalization.js'
-import '../brave_survey_panelist_page/brave_survey_panelist_page.js'
 
 // <if expr="enable_containers">
 import '../brave_content_page/containers.js'

--- a/browser/resources/settings/brave_overrides/privacy_page_index.ts
+++ b/browser/resources/settings/brave_overrides/privacy_page_index.ts
@@ -12,6 +12,7 @@ import type { Route } from '../router.js';
 import { routes } from '../route.js';
 import {loadTimeData} from "../i18n_setup.js"
 import {pageVisibility} from './page_visibility.js'
+import '../brave_survey_panelist_page/brave_survey_panelist_page.js'
 
 RegisterPolymerPrototypeModification({
   'settings-privacy-page-index': (prototype) => {
@@ -32,17 +33,12 @@ RegisterPolymerPrototypeModification({
       return views;
     }
 
-    // Add the subroute for the survey panelist page.
-    const oldCurrentRouteChanged = prototype.currentRouteChanged;
-    prototype.currentRouteChanged = function (newRoute: Route, oldRoute: Route) {
-      if (newRoute === routes.BRAVE_SURVEY_PANELIST) {
-        queueMicrotask(() => {
-          this.$.viewManager.switchView('surveyPanelist', 'no-animation', 'no-animation');
-        })
-        return;
+    const oldGetViewIdsForRoute = prototype.getViewIdsForRoute_;
+    prototype.getViewIdsForRoute_ = function (route: Route) {
+      if (route === routes.BRAVE_SURVEY_PANELIST) {
+        return ['surveyPanelist'];
       }
-
-      oldCurrentRouteChanged.call(this, newRoute, oldRoute);
+      return oldGetViewIdsForRoute.call(this, route);
     }
   }
 })

--- a/browser/resources/settings/brave_routes.ts
+++ b/browser/resources/settings/brave_routes.ts
@@ -88,7 +88,7 @@ export default function addBraveRoutes(r: Partial<SettingsRoutes>) {
   }
   if (pageVisibility.surveyPanelist && r.PRIVACY) {
     r.BRAVE_SURVEY_PANELIST =
-      r.PRIVACY.createChild('/surveyPanelist', 'surveyPanelist')
+      r.PRIVACY.createChild('surveyPanelist')
     r.BRAVE_SURVEY_PANELIST.hasMigratedToPlugin = true
   }
   if (r.SEARCH) {


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/49756

Seems like this was being caused because the PrivacyPageIndex asynchronously decides what pages to show and sets a promise property for when its done. The solution is to override the `getViewIdsForRoute_` method rather than the `onCurrentRouteChanged_` method.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
