### PR TITLE
[CodeHealth] Replace ternary ops with logical expressions

### DIFF
--- a/android/java/org/chromium/chrome/browser/externalnav/BraveExternalNavigationHandler.java
+++ b/android/java/org/chromium/chrome/browser/externalnav/BraveExternalNavigationHandler.java
@@ -53,9 +53,7 @@ public class BraveExternalNavigationHandler extends ExternalNavigationHandler {
             GURL browserFallbackUrl,
             GURL intentTargetUrl) {
         boolean isYoutubeDomain =
-                intentTargetUrl != null
-                        ? intentTargetUrl.domainIs(BraveConstants.YOUTUBE_DOMAIN)
-                        : false;
+                intentTargetUrl != null && intentTargetUrl.domainIs(BraveConstants.YOUTUBE_DOMAIN);
         if ((isYoutubeDomain
                         && !BravePrefServiceBridge.getInstance().getPlayYTVideoInBrowserEnabled())
                 || (!isYoutubeDomain

--- a/android/java/org/chromium/chrome/browser/notifications/BravePermissionUtils.java
+++ b/android/java/org/chromium/chrome/browser/notifications/BravePermissionUtils.java
@@ -65,7 +65,7 @@ public class BravePermissionUtils {
                     (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
             NotificationChannelGroup notificationChannelGroup =
                     notificationManager.getNotificationChannelGroup(channelGroupName);
-            return notificationChannelGroup != null ? notificationChannelGroup.isBlocked() : false;
+            return notificationChannelGroup != null && notificationChannelGroup.isBlocked();
         } else {
             return !NotificationManagerCompat.from(context).areNotificationsEnabled();
         }

--- a/android/java/org/chromium/chrome/browser/shields/BraveShieldsHandler.java
+++ b/android/java/org/chromium/chrome/browser/shields/BraveShieldsHandler.java
@@ -824,8 +824,7 @@ public class BraveShieldsHandler implements BraveRewardsHelper.LargeIconReadyCal
         }
 
         Tab currentActiveTab = mIconFetcher.getTab();
-        final boolean isPrivateWindow =
-                currentActiveTab != null ? currentActiveTab.isIncognito() : false;
+        final boolean isPrivateWindow = currentActiveTab != null && currentActiveTab.isIncognito();
 
         TextView blockElementsText =
                 mSecondaryLayout.findViewById(R.id.brave_shields_block_element_text);

--- a/android/java/org/chromium/chrome/browser/util/TabUtils.java
+++ b/android/java/org/chromium/chrome/browser/util/TabUtils.java
@@ -204,9 +204,8 @@ public class TabUtils {
     public static void openNewTab() {
         try {
             BraveActivity braveActivity = BraveActivity.getBraveActivity();
-            boolean isIncognito = braveActivity != null
-                    ? braveActivity.getCurrentTabModel().isIncognito()
-                    : false;
+            boolean isIncognito =
+                    braveActivity != null && braveActivity.getCurrentTabModel().isIncognito();
             openNewTab(braveActivity, isIncognito);
         } catch (BraveActivity.BraveActivityNotFoundException e) {
             Log.e(TAG, "openNewTab " + e);

--- a/android/java/org/chromium/chrome/browser/vpn/utils/BraveVpnProfileUtils.java
+++ b/android/java/org/chromium/chrome/browser/vpn/utils/BraveVpnProfileUtils.java
@@ -46,11 +46,12 @@ public class BraveVpnProfileUtils {
         boolean isVpnConnected = false;
         if (connectivityManager != null) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                NetworkCapabilities capabilities = connectivityManager.getNetworkCapabilities(
-                        connectivityManager.getActiveNetwork());
-                isVpnConnected = capabilities != null
-                        ? capabilities.hasTransport(NetworkCapabilities.TRANSPORT_VPN)
-                        : false;
+                NetworkCapabilities capabilities =
+                        connectivityManager.getNetworkCapabilities(
+                                connectivityManager.getActiveNetwork());
+                isVpnConnected =
+                        capabilities != null
+                                && capabilities.hasTransport(NetworkCapabilities.TRANSPORT_VPN);
             } else {
                 NetworkInfo activeNetwork = connectivityManager.getActiveNetworkInfo();
                 isVpnConnected = activeNetwork.getType() == ConnectivityManager.TYPE_VPN;

--- a/browser/ai_chat/ai_chat_ui_browsertest.cc
+++ b/browser/ai_chat/ai_chat_ui_browsertest.cc
@@ -206,7 +206,7 @@ class AIChatUIBrowserTest : public InProcessBrowserTest {
   }
 
   bool HasPendingGetContentRequest() {
-    return chat_tab_helper_->pending_get_page_content_callback_ ? true : false;
+    return !!chat_tab_helper_->pending_get_page_content_callback_;
   }
 
   std::optional<std::vector<ai_chat::mojom::UploadedFilePtr>>

--- a/browser/net/url_context.cc
+++ b/browser/net/url_context.cc
@@ -107,25 +107,22 @@ std::shared_ptr<brave::BraveRequestInfo> BraveRequestInfo::MakeCTX(
   ctx->allow_brave_shields =
       map ? brave_shields::GetBraveShieldsEnabled(map, ctx->tab_origin) : true;
   ctx->allow_ads =
-      map ? brave_shields::GetAdControlType(map, ctx->tab_origin) ==
-                brave_shields::ControlType::ALLOW
-          : false;
+      map && brave_shields::GetAdControlType(map, ctx->tab_origin) ==
+                 brave_shields::ControlType::ALLOW;
   // Currently, "aggressive" mode is registered as a cosmetic filtering control
   // type, even though it can also affect network blocking.
   ctx->aggressive_blocking =
-      map ? brave_shields::GetCosmeticFilteringControlType(
-                map, ctx->tab_origin) == brave_shields::ControlType::BLOCK
-          : false;
+      map && brave_shields::GetCosmeticFilteringControlType(
+                 map, ctx->tab_origin) == brave_shields::ControlType::BLOCK;
 
   // HACK: after we fix multiple creations of BraveRequestInfo we should
   // use only tab_origin. Since we recreate BraveRequestInfo during consequent
   // stages of navigation, |tab_origin| changes and so does |allow_referrers|
   // flag, which is not what we want for determining referrers.
   ctx->allow_referrers =
-      map ? brave_shields::AreReferrersAllowed(
-                map, ctx->redirect_source.is_empty() ? ctx->tab_origin
-                                                     : ctx->redirect_source)
-          : false;
+      map && brave_shields::AreReferrersAllowed(
+                 map, ctx->redirect_source.is_empty() ? ctx->tab_origin
+                                                      : ctx->redirect_source);
   ctx->upload_data = GetUploadData(request);
 
   ctx->browser_context = browser_context;

--- a/browser/ntp_background/view_counter_service_factory.cc
+++ b/browser/ntp_background/view_counter_service_factory.cc
@@ -73,7 +73,7 @@ ViewCounterServiceFactory::BuildServiceInstanceForBrowserContext(
     brave_ads::AdsService* const ads_service =
         brave_ads::AdsServiceFactory::GetForProfile(profile);
     const bool is_supported_locale =
-        ads_service ? brave_ads::IsSupportedRegion() : false;
+        ads_service && brave_ads::IsSupportedRegion();
 
     content::URLDataSource::Add(
         browser_context, std::make_unique<NTPBackgroundImagesSource>(service));

--- a/browser/playlist/test/playlist_browsertest.cc
+++ b/browser/playlist/test/playlist_browsertest.cc
@@ -565,7 +565,7 @@ IN_PROC_BROWSER_TEST_F(PlaylistBrowserTestWithSitesUsingMediaSource,
 
   WaitUntil(base::BindLambdaForTesting([&] {
     auto* add_bubble = views::AsViewClass<PlaylistAddBubbleView>(GetBubble());
-    return add_bubble ? !add_bubble->loading_spinner_->GetVisible() : false;
+    return add_bubble && !add_bubble->loading_spinner_->GetVisible();
   }));
 
   EXPECT_TRUE(playlist_tab_helper->saved_items().empty());

--- a/browser/renderer_context_menu/brave_mock_render_view_context_menu.cc
+++ b/browser/renderer_context_menu/brave_mock_render_view_context_menu.cc
@@ -139,12 +139,10 @@ void BraveMockRenderViewContextMenu::AddSubMenu(int command_id,
     sub_item.is_submenu = true;
     if (model->GetTypeAt(i) != ui::MenuModel::TYPE_SEPARATOR) {
       sub_item.command_id = model->GetCommandIdAt(i);
-      sub_item.enabled = observer_->IsCommandIdSupported(sub_item.command_id)
-                             ? model->IsEnabledAt(i)
-                             : false;
-      sub_item.checked = observer_->IsCommandIdSupported(sub_item.command_id)
-                             ? model->IsItemCheckedAt(i)
-                             : false;
+      sub_item.enabled = observer_->IsCommandIdSupported(sub_item.command_id) &&
+                         model->IsEnabledAt(i);
+      sub_item.checked = observer_->IsCommandIdSupported(sub_item.command_id) &&
+                         model->IsItemCheckedAt(i);
       sub_item.hidden = !model->IsVisibleAt(i);
       sub_item.title = model->GetLabelAt(i);
     } else {

--- a/browser/sync/brave_sync_devices_android.cc
+++ b/browser/sync/brave_sync_devices_android.cc
@@ -76,7 +76,7 @@ base::Value::List BraveSyncDevicesAndroid::GetSyncDeviceList() {
   for (const auto& device : tracker->GetAllBraveDeviceInfo()) {
     auto device_value = device->ToValue();
     bool is_current_device =
-        local_device_info ? local_device_info->guid() == device->guid() : false;
+        local_device_info && local_device_info->guid() == device->guid();
     device_value.Set("isCurrentDevice", is_current_device);
     // DeviceInfo::ToValue doesn't put guid
     device_value.Set("guid", device->guid());

--- a/browser/ui/webui/new_tab_page/brave_new_tab_ui.cc
+++ b/browser/ui/webui/new_tab_page/brave_new_tab_ui.cc
@@ -78,8 +78,7 @@ BraveNewTabUI::BraveNewTabUI(
 
   content::NavigationEntry* navigation_entry =
       web_contents->GetController().GetLastCommittedEntry();
-  const bool was_restored =
-      navigation_entry ? navigation_entry->IsRestored() : false;
+  const bool was_restored = navigation_entry && navigation_entry->IsRestored();
 
   Profile* profile = Profile::FromWebUI(web_ui);
   web_ui->OverrideTitle(l10n_util::GetStringUTF16(IDS_NEW_TAB_TITLE));

--- a/browser/ui/webui/settings/brave_sync_handler.cc
+++ b/browser/ui/webui/settings/brave_sync_handler.cc
@@ -418,7 +418,7 @@ base::Value::List BraveSyncHandler::GetSyncDeviceList() {
   for (const auto& device : tracker->GetAllBraveDeviceInfo()) {
     auto device_value = device->ToValue();
     bool is_current_device =
-        local_device_info ? local_device_info->guid() == device->guid() : false;
+        local_device_info && local_device_info->guid() == device->guid();
     device_value.Set("isCurrentDevice", is_current_device);
     device_value.Set("guid", device->guid());
     device_value.Set("supportsSelfDelete",

--- a/browser/ui/webui/settings/brave_wallet_handler.cc
+++ b/browser/ui/webui/settings/brave_wallet_handler.cc
@@ -356,10 +356,9 @@ void BraveWalletHandler::SetDefaultNetwork(const base::Value::List& args) {
   auto* brave_wallet_service =
       brave_wallet::BraveWalletServiceFactory::GetServiceForContext(
           Profile::FromWebUI(web_ui()));
-  auto result = brave_wallet_service
-                    ? brave_wallet_service->json_rpc_service()->SetNetwork(
-                          *chain_id, *coin, std::nullopt)
-                    : false;
+  auto result = brave_wallet_service &&
+                brave_wallet_service->json_rpc_service()->SetNetwork(
+                    *chain_id, *coin, std::nullopt);
   ResolveJavascriptCallback(args[0], base::Value(result));
 }
 

--- a/components/brave_ads/core/internal/serving/targeting/condition_matcher/condition_matcher_util.cc
+++ b/components/brave_ads/core/internal/serving/targeting/condition_matcher/condition_matcher_util.cc
@@ -77,7 +77,7 @@ bool MatchConditions(const base::Value::Dict& virtual_prefs,
           return MatchCondition(value.value_or("0"), condition);
         }
 
-        return value ? MatchCondition(*value, condition) : false;
+        return value && MatchCondition(*value, condition);
       });
 }
 

--- a/components/brave_wallet/browser/network_manager.cc
+++ b/components/brave_wallet/browser/network_manager.cc
@@ -1229,7 +1229,7 @@ bool NetworkManager::IsEip1559Chain(std::string_view chain_id) {
   }
   const auto* known_chain =
       base::FindOrNull(kEip1559ForKnownChains, chain_id_lwr);
-  return known_chain ? *known_chain : false;
+  return known_chain && *known_chain;
 }
 
 void NetworkManager::SetEip1559ForCustomChain(std::string_view chain_id,

--- a/components/brave_wallet/resources/solana_web3_script.js
+++ b/components/brave_wallet/resources/solana_web3_script.js
@@ -12708,7 +12708,9 @@ var solanaWeb3 = $(function (exports) {
           return uuid();
         });
         result.version = typeof options.version !== "undefined" ? options.version : 2;
-        result.notificationIdNull = typeof options.notificationIdNull === "boolean" ? options.notificationIdNull : false;
+        result.notificationIdNull =
+            typeof options.notificationIdNull === 'boolean' &&
+            options.notificationIdNull;
         return result;
       })();
       this.callServer = callServer;

--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/AllFrames/AtDocumentStart/FullscreenHelper.js
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/AllFrames/AtDocumentStart/FullscreenHelper.js
@@ -3,11 +3,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-window.__firefox__.includeOnce("FullscreenHelper", function($) {
+window.__firefox__.includeOnce('FullscreenHelper', function($) {
   let isFullscreenSupportedNatively = document.fullscreenEnabled ||
-                                      document.webkitFullscreenEnabled ||
-                                      document.mozFullScreenEnabled ||
-                                      document.msFullscreenEnabled ? true : false;
+      document.webkitFullscreenEnabled || document.mozFullScreenEnabled ||
+      document.msFullscreenEnabled;
 
   let videosSupportFullscreen = HTMLVideoElement.prototype.webkitEnterFullscreen !== undefined
 

--- a/ios/browser/api/sync/brave_sync_api.mm
+++ b/ios/browser/api/sync/brave_sync_api.mm
@@ -318,7 +318,7 @@ BraveSyncAPIWordsValidationStatus const
   for (const auto& device : device_list) {
     auto device_value = device->ToValue();
     bool is_current_device =
-        local_device_info ? local_device_info->guid() == device->guid() : false;
+        local_device_info && local_device_info->guid() == device->guid();
     device_value.Set("isCurrentDevice", is_current_device);
     device_value.Set("guid", device->guid());
     device_value.Set("supportsSelfDelete", device->is_self_delete_supported());

--- a/test/data/speedreader/rewriter/pages/news_pages/nypost.com/original.html
+++ b/test/data/speedreader/rewriter/pages/news_pages/nypost.com/original.html
@@ -120,7 +120,7 @@
 				// Check if we have a cookie.
 				if ( GACookie.length ) {
 					// If the cookie value is not empty we have a GA cookie.
-					hasGACookie = GACookie[0].trim().length > 4 ? true : false;
+					hasGACookie = GACookie[0].trim().length > 4;
 				}
 
 				// Id to use for localStorage object which holds the GA clientId and expire time.

--- a/test/data/speedreader/rewriter/pages/news_pages/www.thestandard.com/original.html
+++ b/test/data/speedreader/rewriter/pages/news_pages/www.thestandard.com/original.html
@@ -553,7 +553,7 @@ window.idgus = window.idgus || {};
 window.idgus.cmp = window.idgus.cmp || {};
 (function (promise) {
 	promise.then(function (consentOk) {
-		var isDebug = !!window.idgus.cmp.isDebug ? window.idgus.cmp.isDebug() : false;
+		var isDebug = !!window.idgus.cmp.isDebug && window.idgus.cmp.isDebug();
 		if (isDebug) console.log('GDPR', 'blueconic - consentOk', consentOk);
 		if (!consentOk) return;
 		var bcscript = document.createElement("script");
@@ -7525,7 +7525,7 @@ _comscore.push(
 		    		return; 
 		    	} else {
 		    		console.log("*****GDPR: sp_analytics.js: consent = " + consentOk);
-					var isDebug = !!window.idgus.cmp.isDebug ? window.idgus.cmp.isDebug() : false;
+					var isDebug = !!window.idgus.cmp.isDebug && window.idgus.cmp.isDebug();
 					if (isDebug) console.log('GDPR', 'sp_analytics - consentOk', consentOk);
 					if (!consentOk) return;
 					var spscript = document.createElement("script");


### PR DESCRIPTION
This PR is part of a couple of changes correcting these redundant
ternary operations:

```
x ? y : false -> x && y
x ? false : y -> !x && y
x ? y : true - > !x || y
x ? true : y -> x || y
```

This PR mirrors upstream work being done in the same direction:
https://issues.chromium.org/issues/416294715

Bug: https://github.com/brave/brave-browser/issues/49819
