### PR TITLE
[cr141][Android] Fix for crash on `invalidateAccessToken` (uplift to 1.84.x)

### DIFF
--- a/build/android/bytecode/bytecode_rewriter.gni
+++ b/build/android/bytecode/bytecode_rewriter.gni
@@ -57,6 +57,7 @@ brave_bytecode_jars = [
   "obj/components/external_intents/android/java.javac.jar",
   "obj/components/minidump_uploader/minidump_uploader_java.javac.jar",
   "obj/components/permissions/android/java.javac.jar",
+  "obj/components/signin/public/android/java.javac.jar",
   "obj/components/sync/android/sync_java.javac.jar",
   "obj/components/variations/android/variations_java.javac.jar",
   "obj/chrome/browser/language/android/base_module_java.javac.jar",

--- a/components/signin/public/android/java/src/org/chromium/components/signin/BraveNullAccountManagerDelegate.java
+++ b/components/signin/public/android/java/src/org/chromium/components/signin/BraveNullAccountManagerDelegate.java
@@ -5,15 +5,8 @@
 
 package org.chromium.components.signin;
 
-import android.accounts.Account;
-
 import org.chromium.build.annotations.NullMarked;
-import org.chromium.components.externalauth.ExternalAuthUtils;
 
-/**
- * That class extends upstream's NullAccountManagerDelegate.java to be able run Brave on devices
- * without Google Play Services
- */
 @NullMarked
 public class BraveNullAccountManagerDelegate extends NullAccountManagerDelegate {
     public BraveNullAccountManagerDelegate() {
@@ -21,11 +14,15 @@ public class BraveNullAccountManagerDelegate extends NullAccountManagerDelegate 
     }
 
     @Override
-    public Account[] getAccountsSynchronous() {
-        if (!ExternalAuthUtils.getInstance().canUseGooglePlayServices()) {
-            return new Account[] {};
-        }
-
-        return super.getAccountsSynchronous();
+    public void invalidateAccessToken(String authToken) throws AuthException {
+        // No-op implementation. Token invalidation is not needed because:
+        // 1. This delegate doesn't fetch tokens via getAccessToken(), so no tokens
+        //    should exist from this delegate's perspective.
+        // 2. However, tokens can still be passed here from other sources.
+        // 3. Chromium already removes tokens from its internal cache before calling
+        //    this method, so the token is already invalidated from Chromium's perspective.
+        // 4. This method would normally call GoogleAuthUtil.clearToken() to invalidate
+        //    the token in Android's AccountManager cache, but since we're not managing
+        //    real Google accounts, there's nothing to clear at the system level.
     }
 }


### PR DESCRIPTION
Uplift of #31553
Resolves https://github.com/brave/brave-browser/issues/49814

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.