### PR TITLE
[iOS] Enable password sync by default (for new users) (uplift to 1.84.x)

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Sync/BraveCore/BraveSyncAPIExtensions.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Sync/BraveCore/BraveSyncAPIExtensions.swift
@@ -59,6 +59,10 @@ extension BraveSyncAPI {
     if setSyncCode(codeWords) {
       // Enable default sync type Bookmarks when joining a chain
       Preferences.Chromium.syncBookmarksEnabled.value = true
+      // when setting up a new chain, use the feature flag to determine if
+      // password sync is enabled or not
+      Preferences.Chromium.syncPasswordsEnabled.value =
+        FeatureList.kBraveSyncDefaultPasswords.enabled
       enableSyncTypes(syncProfileService: syncProfileService)
       requestSync()
       setSetupComplete()
@@ -88,7 +92,7 @@ extension BraveSyncAPI {
 
   func resetSyncChain() {
     Preferences.Chromium.syncHistoryEnabled.value = false
-    Preferences.Chromium.syncPasswordsEnabled.value = false
+    Preferences.Chromium.syncPasswordsEnabled.value = FeatureList.kBraveSyncDefaultPasswords.enabled
     Preferences.Chromium.syncOpenTabsEnabled.value = false
 
     resetSync()

--- a/ios/brave-ios/Sources/Brave/Frontend/Sync/SyncWelcomeViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Sync/SyncWelcomeViewController.swift
@@ -559,6 +559,9 @@ extension SyncWelcomeViewController: SyncPairControllerDelegate {
   private func enableDefaultTypeAndPushSettings() {
     // Enable default sync type Bookmarks and push settings
     Preferences.Chromium.syncBookmarksEnabled.value = true
+    // when setting up a new chain, use the feature flag to determine if
+    // password sync is enabled or not
+    Preferences.Chromium.syncPasswordsEnabled.value = FeatureList.kBraveSyncDefaultPasswords.enabled
     syncAPI.enableSyncTypes(syncProfileService: syncProfileServices)
     pushSettings()
   }

--- a/ios/brave-ios/Sources/Preferences/GlobalPreferences.swift
+++ b/ios/brave-ios/Sources/Preferences/GlobalPreferences.swift
@@ -239,7 +239,7 @@ extension Preferences {
     /// The sync type passwords enabled the device in sync chain
     public static let syncPasswordsEnabled = Option<Bool>(
       key: "chromium.sync.syncPasswordsEnabled",
-      default: false
+      default: true  // default is unused; kBraveSyncDefaultPasswords respected
     )
     /// The sync type open tabs enabled the device in sync chain
     public static let syncOpenTabsEnabled = Option<Bool>(

--- a/ios/browser/api/features/features.h
+++ b/ios/browser/api/features/features.h
@@ -82,6 +82,7 @@ OBJC_EXPORT
 @property(class, nonatomic, readonly) Feature* kUseChromiumWebViews;
 @property(class, nonatomic, readonly) Feature* kBraveAllowExternalPurchaseLinks;
 @property(class, nonatomic, readonly) Feature* kModernTabTrayEnabled;
+@property(class, nonatomic, readonly) Feature* kBraveSyncDefaultPasswords;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/browser/api/features/features.mm
+++ b/ios/browser/api/features/features.mm
@@ -350,4 +350,9 @@
       [[Feature alloc] initWithFeature:&brave::features::kModernTabTrayEnabled];
 }
 
++ (Feature*)kBraveSyncDefaultPasswords {
+  return [[Feature alloc]
+      initWithFeature:&brave_sync::features::kBraveSyncDefaultPasswords];
+}
+
 @end

--- a/ios/browser/flags/DEPS
+++ b/ios/browser/flags/DEPS
@@ -3,6 +3,7 @@ include_rules = [
   "+brave/components/brave_component_updater/browser/features.h",
   "+brave/components/brave_rewards/core/features.h",
   "+brave/components/brave_shields/core/common/features.h",
+  "+brave/components/brave_sync/features.h",
   "+brave/components/brave_wallet/common/features.h",
   "+brave/components/brave_user_agent/common/features.h",
   "+brave/components/de_amp/common/features.h",

--- a/ios/browser/flags/about_flags.mm
+++ b/ios/browser/flags/about_flags.mm
@@ -9,6 +9,7 @@
 #include "brave/components/brave_component_updater/browser/features.h"
 #include "brave/components/brave_rewards/core/features.h"
 #include "brave/components/brave_shields/core/common/features.h"
+#include "brave/components/brave_sync/features.h"
 #include "brave/components/brave_user_agent/common/features.h"
 #include "brave/components/brave_wallet/common/features.h"
 #include "brave/components/de_amp/common/features.h"
@@ -166,6 +167,14 @@
           "Replace the tab tray UI with a modern replacement",                 \
           flags_ui::kOsIos,                                                    \
           FEATURE_VALUE_TYPE(brave::features::kModernTabTrayEnabled),          \
+      },                                                                       \
+      {                                                                        \
+          "brave-sync-default-passwords",                                      \
+          "Enable password syncing by default",                                \
+          "Turn on password syncing when Sync is enabled.",                    \
+          flags_ui::kOsIos,                                                    \
+          FEATURE_VALUE_TYPE(                                                  \
+              brave_sync::features::kBraveSyncDefaultPasswords),               \
       },                                                                       \
       {                                                                        \
           "brave-translate-enabled",                                           \

--- a/ios/browser/flags/sources.gni
+++ b/ios/browser/flags/sources.gni
@@ -10,6 +10,7 @@ brave_flags_deps = [
   "//brave/components/brave_rewards/core",
   "//brave/components/brave_rewards/core/buildflags",
   "//brave/components/brave_shields/core/common",
+  "//brave/components/brave_sync:features",
   "//brave/components/brave_user_agent/common",
   "//brave/components/brave_wallet/common",
   "//brave/components/de_amp/common",


### PR DESCRIPTION
Uplift of #31313
Resolves https://github.com/brave/brave-browser/issues/49454

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.