### PR TITLE
[AI Chat] Bind conversation handler with an explicit ID from the frame

### DIFF
--- a/browser/brave_content_browser_client.cc
+++ b/browser/brave_content_browser_client.cc
@@ -593,8 +593,7 @@ void BraveContentBrowserClient::RegisterWebUIInterfaceBrokers(
         .Add<ai_chat::mojom::Service>()
         .Add<ai_chat::mojom::TabTrackerService>();
     registry.ForWebUI<AIChatUntrustedConversationUI>()
-        .Add<ai_chat::mojom::UntrustedUIHandler>()
-        .Add<ai_chat::mojom::UntrustedConversationHandler>();
+        .Add<ai_chat::mojom::UntrustedUIHandler>();
   }
 
 #if BUILDFLAG(ENABLE_AI_REWRITER)

--- a/browser/ui/webui/ai_chat/ai_chat_untrusted_conversation_ui.h
+++ b/browser/ui/webui/ai_chat/ai_chat_untrusted_conversation_ui.h
@@ -42,9 +42,6 @@ class AIChatUntrustedConversationUI : public ui::MojoWebUIController {
 
   void BindInterface(
       mojo::PendingReceiver<ai_chat::mojom::UntrustedUIHandler> receiver);
-  void BindInterface(
-      mojo::PendingReceiver<ai_chat::mojom::UntrustedConversationHandler>
-          receiver);
 
  private:
   std::unique_ptr<ai_chat::mojom::UntrustedUIHandler> ui_handler_;

--- a/components/ai_chat/core/common/mojom/untrusted_frame.mojom
+++ b/components/ai_chat/core/common/mojom/untrusted_frame.mojom
@@ -88,6 +88,12 @@ interface UntrustedUI {
 // Browser-side handler for untrusted frame that handles rendering of
 // conversation entries.
 interface UntrustedUIHandler {
+  // Bind the conversation handler
+  BindConversationHandler(
+    string conversation_id,
+    pending_receiver<UntrustedConversationHandler> conversation_handler
+  );
+
   // Bind UntrustedUI for callbacks
   BindUntrustedUI(pending_remote<UntrustedUI> untrusted_ui);
 

--- a/components/ai_chat/resources/untrusted_conversation_frame/untrusted_conversation_frame_api.ts
+++ b/components/ai_chat/resources/untrusted_conversation_frame/untrusted_conversation_frame_api.ts
@@ -62,7 +62,7 @@ export function updateToolUseEventInHistory(
 // Define how to get the initial data and update the state from events
 export default class UntrustedConversationFrameAPI extends API<ConversationEntriesUIState> {
   public conversationHandler: Mojom.UntrustedConversationHandlerRemote =
-    Mojom.UntrustedConversationHandler.getRemote()
+    new Mojom.UntrustedConversationHandlerRemote()
 
   public uiHandler: Mojom.UntrustedUIHandlerRemote =
     Mojom.UntrustedUIHandler.getRemote()
@@ -84,6 +84,11 @@ export default class UntrustedConversationFrameAPI extends API<ConversationEntri
   async initialize() {
     // Bind UntrustedUI for memory notifications
     this.uiHandler.bindUntrustedUI(this.uiObserver.$.bindNewPipeAndPassRemote())
+    const conversationId = window.location.pathname.split('/').pop() || ''
+    this.uiHandler.bindConversationHandler(
+      conversationId,
+      this.conversationHandler.$.bindNewPipeAndPassReceiver(),
+    )
 
     const [{ conversationEntriesState }, { conversationHistory }] =
       await Promise.all([


### PR DESCRIPTION
This change updates how the `UntrustedConversationHandler` is bound to explicitly pass in the conversation ID from the untrusted frame rather than rely on the client to fetch the URL. This is a prerequisite for iOS as there is no way to get the associated frame's URL from its WebUI currently. Unfortunately since we needed to reference `UntrustedConversationHandler` and its associated types we needed to also move the types defined in `untrusted_frame.mojom` into the main `ai_chat.mojom` file

<!-- Add brave-browser issue below that this PR will resolve --> 
Resolves https://github.com/brave/brave-browser/issues/49939

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
