### PR TITLE
[CodeHealth] Remove deprecated single-arg `Invoke`

### DIFF
--- a/browser/ai_chat/ai_chat_render_view_context_menu_browsertest.cc
+++ b/browser/ai_chat/ai_chat_render_view_context_menu_browsertest.cc
@@ -282,8 +282,7 @@ class AIChatRenderViewContextMenuBrowserTest : public InProcessBrowserTest {
       std::string& submitted_text,
       const base::Location& location) {
     EXPECT_CALL(client, OnConversationHistoryUpdate(_))
-        .WillOnce(testing::Invoke([&, location](
-                                      const mojom::ConversationTurnPtr turn) {
+        .WillOnce([&, location](const mojom::ConversationTurnPtr turn) {
           SCOPED_TRACE(testing::Message() << location.ToString());
           ConversationHandler* conversation_handler = GetConversationHandler();
           ASSERT_TRUE(conversation_handler);
@@ -294,7 +293,7 @@ class AIChatRenderViewContextMenuBrowserTest : public InProcessBrowserTest {
           ASSERT_TRUE(entry->selected_text);
           submitted_text = *entry->selected_text;
           run_loop.Quit();
-        }));
+        });
   }
 
   std::unique_ptr<TestRenderViewContextMenu> CreateContextMenu(

--- a/browser/ai_chat/tools/navigation_tool_unittest.cc
+++ b/browser/ai_chat/tools/navigation_tool_unittest.cc
@@ -109,12 +109,12 @@ TEST_F(NavigationToolTest, ValidInputHttpsUrl) {
 
   optimization_guide::proto::Actions captured_actions;
   EXPECT_CALL(*mock_task_provider_, ExecuteActions(testing::_, testing::_))
-      .WillOnce(testing::Invoke([&captured_actions, &run_loop](
-                                    optimization_guide::proto::Actions actions,
-                                    Tool::UseToolCallback callback) {
+      .WillOnce([&captured_actions, &run_loop](
+                    optimization_guide::proto::Actions actions,
+                    Tool::UseToolCallback callback) {
         captured_actions = std::move(actions);
         run_loop.Quit();
-      }));
+      });
 
   navigation_tool_->UseTool(input_json, base::DoNothing());
   run_loop.Run();
@@ -130,13 +130,13 @@ TEST_F(NavigationToolTest, ValidInputComplexUrl) {
 
   optimization_guide::proto::Actions captured_actions;
   EXPECT_CALL(*mock_task_provider_, ExecuteActions(testing::_, testing::_))
-      .WillOnce(testing::Invoke([&captured_actions, &run_loop](
-                                    optimization_guide::proto::Actions actions,
-                                    Tool::UseToolCallback callback) {
+      .WillOnce([&captured_actions, &run_loop](
+                    optimization_guide::proto::Actions actions,
+                    Tool::UseToolCallback callback) {
         captured_actions = std::move(actions);
         std::move(callback).Run(CreateContentBlocksForText("Success"));
         run_loop.Quit();
-      }));
+      });
 
   navigation_tool_->UseTool(input_json, base::DoNothing());
   run_loop.Run();

--- a/browser/brave_wallet/cardano_provider_renderer_browsertest.cc
+++ b/browser/brave_wallet/cardano_provider_renderer_browsertest.cc
@@ -399,11 +399,10 @@ IN_PROC_BROWSER_TEST_F(CardanoProviderRendererTest,
   TestCardanoProvider* provider = test_content_browser_client_.GetProvider(
       web_contents(browser())->GetPrimaryMainFrame());
   ON_CALL(*provider, Enable(_, _))
-      .WillByDefault(::testing::Invoke(
-          [&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
-              TestCardanoProvider::EnableCallback callback) {
-            std::move(callback).Run(nullptr);
-          }));
+      .WillByDefault([&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
+                         TestCardanoProvider::EnableCallback callback) {
+        std::move(callback).Run(nullptr);
+      });
   for (const std::string& method :
        {"getNetworkId", "getUsedAddresses", "getUnusedAddresses",
         "getChangeAddress", "getRewardAddresses", "getUtxos", "getBalance",
@@ -419,11 +418,10 @@ IN_PROC_BROWSER_TEST_F(CardanoProviderRendererTest, EnableSuccess) {
   TestCardanoProvider* provider = test_content_browser_client_.GetProvider(
       web_contents(browser())->GetPrimaryMainFrame());
   ON_CALL(*provider, Enable(_, _))
-      .WillByDefault(::testing::Invoke(
-          [&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
-              TestCardanoProvider::EnableCallback callback) {
-            std::move(callback).Run(nullptr);
-          }));
+      .WillByDefault([&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
+                         TestCardanoProvider::EnableCallback callback) {
+        std::move(callback).Run(nullptr);
+      });
 
   auto result = EvalJs(web_contents(browser()), EnableScript());
   EXPECT_EQ(base::Value(true), result);
@@ -433,12 +431,11 @@ IN_PROC_BROWSER_TEST_F(CardanoProviderRendererTest, EnableFail) {
   TestCardanoProvider* provider = test_content_browser_client_.GetProvider(
       web_contents(browser())->GetPrimaryMainFrame());
   ON_CALL(*provider, Enable(_, _))
-      .WillByDefault(::testing::Invoke(
-          [&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
-              TestCardanoProvider::EnableCallback callback) {
-            std::move(callback).Run(
-                mojom::CardanoProviderErrorBundle::New(-3, "Refused", nullptr));
-          }));
+      .WillByDefault([&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
+                         TestCardanoProvider::EnableCallback callback) {
+        std::move(callback).Run(
+            mojom::CardanoProviderErrorBundle::New(-3, "Refused", nullptr));
+      });
 
   auto result =
       content::EvalJs(web_contents(browser()), R"(async function connect() {
@@ -461,10 +458,9 @@ IN_PROC_BROWSER_TEST_F(CardanoProviderRendererTest, IsEnabled) {
   TestCardanoProvider* provider = test_content_browser_client_.GetProvider(
       web_contents(browser())->GetPrimaryMainFrame());
   ON_CALL(*provider, IsEnabled(_))
-      .WillByDefault(::testing::Invoke(
-          [&](TestCardanoProvider::IsEnabledCallback callback) {
-            std::move(callback).Run(true);
-          }));
+      .WillByDefault([&](TestCardanoProvider::IsEnabledCallback callback) {
+        std::move(callback).Run(true);
+      });
 
   auto result = EvalJs(
       web_contents(browser()),
@@ -476,10 +472,9 @@ IN_PROC_BROWSER_TEST_F(CardanoProviderRendererTest, NotIsEnabled) {
   TestCardanoProvider* provider = test_content_browser_client_.GetProvider(
       web_contents(browser())->GetPrimaryMainFrame());
   ON_CALL(*provider, IsEnabled(_))
-      .WillByDefault(::testing::Invoke(
-          [&](TestCardanoProvider::IsEnabledCallback callback) {
-            std::move(callback).Run(false);
-          }));
+      .WillByDefault([&](TestCardanoProvider::IsEnabledCallback callback) {
+        std::move(callback).Run(false);
+      });
 
   auto result = EvalJs(
       web_contents(browser()),
@@ -492,17 +487,15 @@ IN_PROC_BROWSER_TEST_F(CardanoProviderRendererTest, GetNetworkId) {
       web_contents(browser())->GetPrimaryMainFrame());
   auto cardano_api = std::make_unique<TestCardanoApi>();
   ON_CALL(*provider, Enable(_, _))
-      .WillByDefault(::testing::Invoke(
-          [&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
-              TestCardanoProvider::EnableCallback callback) {
-            cardano_api->BindReceiver(std::move(receiver));
-            std::move(callback).Run(nullptr);
-          }));
+      .WillByDefault([&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
+                         TestCardanoProvider::EnableCallback callback) {
+        cardano_api->BindReceiver(std::move(receiver));
+        std::move(callback).Run(nullptr);
+      });
   ON_CALL(*cardano_api, GetNetworkId(_))
-      .WillByDefault(
-          ::testing::Invoke([&](TestCardanoApi::GetNetworkIdCallback callback) {
-            std::move(callback).Run(1, nullptr);
-          }));
+      .WillByDefault([&](TestCardanoApi::GetNetworkIdCallback callback) {
+        std::move(callback).Run(1, nullptr);
+      });
   auto result = EvalJs(web_contents(browser()),
                        "(async () => { return await (await "
                        "window.cardano.brave.enable()).getNetworkId() })();");
@@ -514,18 +507,16 @@ IN_PROC_BROWSER_TEST_F(CardanoProviderRendererTest, GetNetworkId_Error) {
       web_contents(browser())->GetPrimaryMainFrame());
   auto cardano_api = std::make_unique<TestCardanoApi>();
   ON_CALL(*provider, Enable(_, _))
-      .WillByDefault(::testing::Invoke(
-          [&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
-              TestCardanoProvider::EnableCallback callback) {
-            cardano_api->BindReceiver(std::move(receiver));
-            std::move(callback).Run(nullptr);
-          }));
+      .WillByDefault([&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
+                         TestCardanoProvider::EnableCallback callback) {
+        cardano_api->BindReceiver(std::move(receiver));
+        std::move(callback).Run(nullptr);
+      });
   ON_CALL(*cardano_api, GetNetworkId(_))
-      .WillByDefault(
-          ::testing::Invoke([&](TestCardanoApi::GetNetworkIdCallback callback) {
-            std::move(callback).Run(0, mojom::CardanoProviderErrorBundle::New(
-                                           -1, "Invalid", nullptr));
-          }));
+      .WillByDefault([&](TestCardanoApi::GetNetworkIdCallback callback) {
+        std::move(callback).Run(
+            0, mojom::CardanoProviderErrorBundle::New(-1, "Invalid", nullptr));
+      });
   auto result = EvalJs(web_contents(browser()),
                        "(async () => { try { return await (await "
                        "window.cardano.brave.enable()).getNetworkId() } "
@@ -542,18 +533,16 @@ IN_PROC_BROWSER_TEST_F(CardanoProviderRendererTest, GetUsedAddresses) {
       web_contents(browser())->GetPrimaryMainFrame());
   auto cardano_api = std::make_unique<TestCardanoApi>();
   ON_CALL(*provider, Enable(_, _))
-      .WillByDefault(::testing::Invoke(
-          [&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
-              TestCardanoProvider::EnableCallback callback) {
-            cardano_api->BindReceiver(std::move(receiver));
-            std::move(callback).Run(nullptr);
-          }));
+      .WillByDefault([&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
+                         TestCardanoProvider::EnableCallback callback) {
+        cardano_api->BindReceiver(std::move(receiver));
+        std::move(callback).Run(nullptr);
+      });
   ON_CALL(*cardano_api, GetUsedAddresses(_))
-      .WillByDefault(::testing::Invoke(
-          [&](TestCardanoApi::GetUsedAddressesCallback callback) {
-            std::vector<std::string> result{"1", "2"};
-            std::move(callback).Run(result, nullptr);
-          }));
+      .WillByDefault([&](TestCardanoApi::GetUsedAddressesCallback callback) {
+        std::vector<std::string> result{"1", "2"};
+        std::move(callback).Run(result, nullptr);
+      });
   auto result =
       EvalJs(web_contents(browser()),
              "(async () => { return await (await "
@@ -570,18 +559,17 @@ IN_PROC_BROWSER_TEST_F(CardanoProviderRendererTest, GetUsedAddresses_Error) {
       web_contents(browser())->GetPrimaryMainFrame());
   auto cardano_api = std::make_unique<TestCardanoApi>();
   ON_CALL(*provider, Enable(_, _))
-      .WillByDefault(::testing::Invoke(
-          [&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
-              TestCardanoProvider::EnableCallback callback) {
-            cardano_api->BindReceiver(std::move(receiver));
-            std::move(callback).Run(nullptr);
-          }));
+      .WillByDefault([&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
+                         TestCardanoProvider::EnableCallback callback) {
+        cardano_api->BindReceiver(std::move(receiver));
+        std::move(callback).Run(nullptr);
+      });
   ON_CALL(*cardano_api, GetUsedAddresses(_))
-      .WillByDefault(::testing::Invoke(
+      .WillByDefault(
           [&](TestCardanoApi::GetUsedAddressesCallback callback) {
             std::move(callback).Run({}, mojom::CardanoProviderErrorBundle::New(
                                             -4, "Account change", nullptr));
-          }));
+          });
   auto result = EvalJs(web_contents(browser()),
                        "(async () => { try { return await (await "
                        "window.cardano.brave.enable()).getUsedAddresses() } "
@@ -598,18 +586,16 @@ IN_PROC_BROWSER_TEST_F(CardanoProviderRendererTest, GetUnusedAddresses) {
       web_contents(browser())->GetPrimaryMainFrame());
   auto cardano_api = std::make_unique<TestCardanoApi>();
   ON_CALL(*provider, Enable(_, _))
-      .WillByDefault(::testing::Invoke(
-          [&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
-              TestCardanoProvider::EnableCallback callback) {
-            cardano_api->BindReceiver(std::move(receiver));
-            std::move(callback).Run(nullptr);
-          }));
+      .WillByDefault([&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
+                         TestCardanoProvider::EnableCallback callback) {
+        cardano_api->BindReceiver(std::move(receiver));
+        std::move(callback).Run(nullptr);
+      });
   ON_CALL(*cardano_api, GetUnusedAddresses(_))
-      .WillByDefault(::testing::Invoke(
-          [&](TestCardanoApi::GetUnusedAddressesCallback callback) {
-            std::vector<std::string> result{"1", "2"};
-            std::move(callback).Run(result, nullptr);
-          }));
+      .WillByDefault([&](TestCardanoApi::GetUnusedAddressesCallback callback) {
+        std::vector<std::string> result{"1", "2"};
+        std::move(callback).Run(result, nullptr);
+      });
   auto result =
       EvalJs(web_contents(browser()),
              "(async () => { return await (await "
@@ -626,18 +612,17 @@ IN_PROC_BROWSER_TEST_F(CardanoProviderRendererTest, GetUnusedAddresses_Error) {
       web_contents(browser())->GetPrimaryMainFrame());
   auto cardano_api = std::make_unique<TestCardanoApi>();
   ON_CALL(*provider, Enable(_, _))
-      .WillByDefault(::testing::Invoke(
-          [&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
-              TestCardanoProvider::EnableCallback callback) {
-            cardano_api->BindReceiver(std::move(receiver));
-            std::move(callback).Run(nullptr);
-          }));
+      .WillByDefault([&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
+                         TestCardanoProvider::EnableCallback callback) {
+        cardano_api->BindReceiver(std::move(receiver));
+        std::move(callback).Run(nullptr);
+      });
   ON_CALL(*cardano_api, GetUnusedAddresses(_))
-      .WillByDefault(::testing::Invoke(
+      .WillByDefault(
           [&](TestCardanoApi::GetUnusedAddressesCallback callback) {
             std::move(callback).Run({}, mojom::CardanoProviderErrorBundle::New(
                                             -2, "Internal", nullptr));
-          }));
+          });
   auto result = EvalJs(web_contents(browser()),
                        "(async () => { try { return await (await "
                        "window.cardano.brave.enable()).getUnusedAddresses() } "
@@ -655,17 +640,15 @@ IN_PROC_BROWSER_TEST_F(CardanoProviderRendererTest, GetBalance) {
       web_contents(browser())->GetPrimaryMainFrame());
   auto cardano_api = std::make_unique<TestCardanoApi>();
   ON_CALL(*provider, Enable(_, _))
-      .WillByDefault(::testing::Invoke(
-          [&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
-              TestCardanoProvider::EnableCallback callback) {
-            cardano_api->BindReceiver(std::move(receiver));
-            std::move(callback).Run(nullptr);
-          }));
+      .WillByDefault([&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
+                         TestCardanoProvider::EnableCallback callback) {
+        cardano_api->BindReceiver(std::move(receiver));
+        std::move(callback).Run(nullptr);
+      });
   ON_CALL(*cardano_api, GetBalance(_))
-      .WillByDefault(
-          ::testing::Invoke([&](TestCardanoApi::GetBalanceCallback callback) {
-            std::move(callback).Run("1", nullptr);
-          }));
+      .WillByDefault([&](TestCardanoApi::GetBalanceCallback callback) {
+        std::move(callback).Run("1", nullptr);
+      });
   auto result = EvalJs(web_contents(browser()),
                        "(async () => { return await (await "
                        "window.cardano.brave.enable()).getBalance() })();");
@@ -678,19 +661,18 @@ IN_PROC_BROWSER_TEST_F(CardanoProviderRendererTest, GetBalance_Error) {
       web_contents(browser())->GetPrimaryMainFrame());
   auto cardano_api = std::make_unique<TestCardanoApi>();
   ON_CALL(*provider, Enable(_, _))
-      .WillByDefault(::testing::Invoke(
-          [&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
-              TestCardanoProvider::EnableCallback callback) {
-            cardano_api->BindReceiver(std::move(receiver));
-            std::move(callback).Run(nullptr);
-          }));
+      .WillByDefault([&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
+                         TestCardanoProvider::EnableCallback callback) {
+        cardano_api->BindReceiver(std::move(receiver));
+        std::move(callback).Run(nullptr);
+      });
   ON_CALL(*cardano_api, GetBalance(_))
       .WillByDefault(
-          ::testing::Invoke([&](TestCardanoApi::GetBalanceCallback callback) {
+          [&](TestCardanoApi::GetBalanceCallback callback) {
             std::move(callback).Run(std::nullopt,
                                     mojom::CardanoProviderErrorBundle::New(
                                         -2, "Internal", nullptr));
-          }));
+          });
   auto result = EvalJs(web_contents(browser()),
                        "(async () => { try { return await (await "
                        "window.cardano.brave.enable()).getBalance() } "
@@ -708,17 +690,15 @@ IN_PROC_BROWSER_TEST_F(CardanoProviderRendererTest, GetChangeAddress) {
       web_contents(browser())->GetPrimaryMainFrame());
   auto cardano_api = std::make_unique<TestCardanoApi>();
   ON_CALL(*provider, Enable(_, _))
-      .WillByDefault(::testing::Invoke(
-          [&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
-              TestCardanoProvider::EnableCallback callback) {
-            cardano_api->BindReceiver(std::move(receiver));
-            std::move(callback).Run(nullptr);
-          }));
+      .WillByDefault([&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
+                         TestCardanoProvider::EnableCallback callback) {
+        cardano_api->BindReceiver(std::move(receiver));
+        std::move(callback).Run(nullptr);
+      });
   ON_CALL(*cardano_api, GetChangeAddress(_))
-      .WillByDefault(::testing::Invoke(
-          [&](TestCardanoApi::GetChangeAddressCallback callback) {
-            std::move(callback).Run("1", nullptr);
-          }));
+      .WillByDefault([&](TestCardanoApi::GetChangeAddressCallback callback) {
+        std::move(callback).Run("1", nullptr);
+      });
   auto result =
       EvalJs(web_contents(browser()),
              "(async () => { return await (await "
@@ -732,19 +712,18 @@ IN_PROC_BROWSER_TEST_F(CardanoProviderRendererTest, GetChangeAddress_Error) {
       web_contents(browser())->GetPrimaryMainFrame());
   auto cardano_api = std::make_unique<TestCardanoApi>();
   ON_CALL(*provider, Enable(_, _))
-      .WillByDefault(::testing::Invoke(
-          [&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
-              TestCardanoProvider::EnableCallback callback) {
-            cardano_api->BindReceiver(std::move(receiver));
-            std::move(callback).Run(nullptr);
-          }));
+      .WillByDefault([&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
+                         TestCardanoProvider::EnableCallback callback) {
+        cardano_api->BindReceiver(std::move(receiver));
+        std::move(callback).Run(nullptr);
+      });
   ON_CALL(*cardano_api, GetChangeAddress(_))
-      .WillByDefault(::testing::Invoke(
+      .WillByDefault(
           [&](TestCardanoApi::GetChangeAddressCallback callback) {
             std::move(callback).Run(std::nullopt,
                                     mojom::CardanoProviderErrorBundle::New(
                                         -2, "Internal", nullptr));
-          }));
+          });
   auto result = EvalJs(web_contents(browser()),
                        "(async () => { try{ return await (await "
                        "window.cardano.brave.enable()).getChangeAddress() } "
@@ -762,18 +741,16 @@ IN_PROC_BROWSER_TEST_F(CardanoProviderRendererTest, GetRewardAddresses) {
       web_contents(browser())->GetPrimaryMainFrame());
   auto cardano_api = std::make_unique<TestCardanoApi>();
   ON_CALL(*provider, Enable(_, _))
-      .WillByDefault(::testing::Invoke(
-          [&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
-              TestCardanoProvider::EnableCallback callback) {
-            cardano_api->BindReceiver(std::move(receiver));
-            std::move(callback).Run(nullptr);
-          }));
+      .WillByDefault([&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
+                         TestCardanoProvider::EnableCallback callback) {
+        cardano_api->BindReceiver(std::move(receiver));
+        std::move(callback).Run(nullptr);
+      });
   ON_CALL(*cardano_api, GetRewardAddresses(_))
-      .WillByDefault(::testing::Invoke(
-          [&](TestCardanoApi::GetRewardAddressesCallback callback) {
-            std::vector<std::string> result{"1", "2"};
-            std::move(callback).Run(result, nullptr);
-          }));
+      .WillByDefault([&](TestCardanoApi::GetRewardAddressesCallback callback) {
+        std::vector<std::string> result{"1", "2"};
+        std::move(callback).Run(result, nullptr);
+      });
 
   auto result =
       EvalJs(web_contents(browser()),
@@ -792,18 +769,17 @@ IN_PROC_BROWSER_TEST_F(CardanoProviderRendererTest, GetRewardAddresses_Error) {
       web_contents(browser())->GetPrimaryMainFrame());
   auto cardano_api = std::make_unique<TestCardanoApi>();
   ON_CALL(*provider, Enable(_, _))
-      .WillByDefault(::testing::Invoke(
-          [&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
-              TestCardanoProvider::EnableCallback callback) {
-            cardano_api->BindReceiver(std::move(receiver));
-            std::move(callback).Run(nullptr);
-          }));
+      .WillByDefault([&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
+                         TestCardanoProvider::EnableCallback callback) {
+        cardano_api->BindReceiver(std::move(receiver));
+        std::move(callback).Run(nullptr);
+      });
   ON_CALL(*cardano_api, GetRewardAddresses(_))
-      .WillByDefault(::testing::Invoke(
+      .WillByDefault(
           [&](TestCardanoApi::GetRewardAddressesCallback callback) {
             std::move(callback).Run({}, mojom::CardanoProviderErrorBundle::New(
                                             -2, "Internal", nullptr));
-          }));
+          });
 
   auto result = EvalJs(web_contents(browser()),
                        "(async () => { try { return await (await "
@@ -822,23 +798,20 @@ IN_PROC_BROWSER_TEST_F(CardanoProviderRendererTest, GetUtxos) {
       web_contents(browser())->GetPrimaryMainFrame());
   auto cardano_api = std::make_unique<TestCardanoApi>();
   ON_CALL(*provider, Enable(_, _))
-      .WillByDefault(::testing::Invoke(
-          [&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
-              TestCardanoProvider::EnableCallback callback) {
-            cardano_api->BindReceiver(std::move(receiver));
-            std::move(callback).Run(nullptr);
-          }));
+      .WillByDefault([&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
+                         TestCardanoProvider::EnableCallback callback) {
+        cardano_api->BindReceiver(std::move(receiver));
+        std::move(callback).Run(nullptr);
+      });
   ON_CALL(*cardano_api, GetUtxos(_, _, _))
-      .WillByDefault(
-          ::testing::Invoke([&](const std::optional<std::string>& amount,
-                                mojom::CardanoProviderPaginationPtr paginate,
-                                TestCardanoApi::GetUtxosCallback callback) {
-            EXPECT_EQ("1", amount.value());
-            EXPECT_EQ(2, paginate->page);
-            EXPECT_EQ(3, paginate->limit);
-            std::move(callback).Run(std::vector<std::string>({"1", "2"}),
-                                    nullptr);
-          }));
+      .WillByDefault([&](const std::optional<std::string>& amount,
+                         mojom::CardanoProviderPaginationPtr paginate,
+                         TestCardanoApi::GetUtxosCallback callback) {
+        EXPECT_EQ("1", amount.value());
+        EXPECT_EQ(2, paginate->page);
+        EXPECT_EQ(3, paginate->limit);
+        std::move(callback).Run(std::vector<std::string>({"1", "2"}), nullptr);
+      });
 
   auto result = EvalJs(web_contents(browser()),
                        "(async () => { return await (await "
@@ -856,22 +829,19 @@ IN_PROC_BROWSER_TEST_F(CardanoProviderRendererTest, GetUtxos_NoArgs) {
       web_contents(browser())->GetPrimaryMainFrame());
   auto cardano_api = std::make_unique<TestCardanoApi>();
   ON_CALL(*provider, Enable(_, _))
-      .WillByDefault(::testing::Invoke(
-          [&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
-              TestCardanoProvider::EnableCallback callback) {
-            cardano_api->BindReceiver(std::move(receiver));
-            std::move(callback).Run(nullptr);
-          }));
+      .WillByDefault([&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
+                         TestCardanoProvider::EnableCallback callback) {
+        cardano_api->BindReceiver(std::move(receiver));
+        std::move(callback).Run(nullptr);
+      });
   ON_CALL(*cardano_api, GetUtxos(_, _, _))
-      .WillByDefault(
-          ::testing::Invoke([&](const std::optional<std::string>& amount,
-                                mojom::CardanoProviderPaginationPtr paginate,
-                                TestCardanoApi::GetUtxosCallback callback) {
-            EXPECT_FALSE(amount);
-            EXPECT_FALSE(paginate);
-            std::move(callback).Run(std::vector<std::string>({"1", "2"}),
-                                    nullptr);
-          }));
+      .WillByDefault([&](const std::optional<std::string>& amount,
+                         mojom::CardanoProviderPaginationPtr paginate,
+                         TestCardanoApi::GetUtxosCallback callback) {
+        EXPECT_FALSE(amount);
+        EXPECT_FALSE(paginate);
+        std::move(callback).Run(std::vector<std::string>({"1", "2"}), nullptr);
+      });
 
   auto result = EvalJs(web_contents(browser()),
                        "(async () => { return await (await "
@@ -889,22 +859,19 @@ IN_PROC_BROWSER_TEST_F(CardanoProviderRendererTest, GetUtxos_NoPagination) {
       web_contents(browser())->GetPrimaryMainFrame());
   auto cardano_api = std::make_unique<TestCardanoApi>();
   ON_CALL(*provider, Enable(_, _))
-      .WillByDefault(::testing::Invoke(
-          [&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
-              TestCardanoProvider::EnableCallback callback) {
-            cardano_api->BindReceiver(std::move(receiver));
-            std::move(callback).Run(nullptr);
-          }));
+      .WillByDefault([&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
+                         TestCardanoProvider::EnableCallback callback) {
+        cardano_api->BindReceiver(std::move(receiver));
+        std::move(callback).Run(nullptr);
+      });
   ON_CALL(*cardano_api, GetUtxos(_, _, _))
-      .WillByDefault(
-          ::testing::Invoke([&](const std::optional<std::string>& amount,
-                                mojom::CardanoProviderPaginationPtr paginate,
-                                TestCardanoApi::GetUtxosCallback callback) {
-            EXPECT_EQ("1", amount);
-            EXPECT_FALSE(paginate);
-            std::move(callback).Run(std::vector<std::string>({"1", "2"}),
-                                    nullptr);
-          }));
+      .WillByDefault([&](const std::optional<std::string>& amount,
+                         mojom::CardanoProviderPaginationPtr paginate,
+                         TestCardanoApi::GetUtxosCallback callback) {
+        EXPECT_EQ("1", amount);
+        EXPECT_FALSE(paginate);
+        std::move(callback).Run(std::vector<std::string>({"1", "2"}), nullptr);
+      });
 
   auto result = EvalJs(web_contents(browser()),
                        "(async () => { return await (await "
@@ -922,20 +889,17 @@ IN_PROC_BROWSER_TEST_F(CardanoProviderRendererTest, GetUtxos_WrongArguments) {
       web_contents(browser())->GetPrimaryMainFrame());
   auto cardano_api = std::make_unique<TestCardanoApi>();
   ON_CALL(*provider, Enable(_, _))
-      .WillByDefault(::testing::Invoke(
-          [&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
-              TestCardanoProvider::EnableCallback callback) {
-            cardano_api->BindReceiver(std::move(receiver));
-            std::move(callback).Run(nullptr);
-          }));
+      .WillByDefault([&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
+                         TestCardanoProvider::EnableCallback callback) {
+        cardano_api->BindReceiver(std::move(receiver));
+        std::move(callback).Run(nullptr);
+      });
   ON_CALL(*cardano_api, GetUtxos(_, _, _))
-      .WillByDefault(
-          ::testing::Invoke([&](const std::optional<std::string>& amount,
-                                mojom::CardanoProviderPaginationPtr paginate,
-                                TestCardanoApi::GetUtxosCallback callback) {
-            std::move(callback).Run(std::vector<std::string>({"1", "2"}),
-                                    nullptr);
-          }));
+      .WillByDefault([&](const std::optional<std::string>& amount,
+                         mojom::CardanoProviderPaginationPtr paginate,
+                         TestCardanoApi::GetUtxosCallback callback) {
+        std::move(callback).Run(std::vector<std::string>({"1", "2"}), nullptr);
+      });
 
   {
     auto result = EvalJs(web_contents(browser()),
@@ -950,23 +914,22 @@ IN_PROC_BROWSER_TEST_F(CardanoProviderRendererTest, GetUtxos_WrongPagination) {
       web_contents(browser())->GetPrimaryMainFrame());
   auto cardano_api = std::make_unique<TestCardanoApi>();
   ON_CALL(*provider, Enable(_, _))
-      .WillByDefault(::testing::Invoke(
-          [&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
-              TestCardanoProvider::EnableCallback callback) {
-            cardano_api->BindReceiver(std::move(receiver));
-            std::move(callback).Run(nullptr);
-          }));
+      .WillByDefault([&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
+                         TestCardanoProvider::EnableCallback callback) {
+        cardano_api->BindReceiver(std::move(receiver));
+        std::move(callback).Run(nullptr);
+      });
   ON_CALL(*cardano_api, GetUtxos(_, _, _))
       .WillByDefault(
-          ::testing::Invoke([&](const std::optional<std::string>& amount,
-                                mojom::CardanoProviderPaginationPtr paginate,
-                                TestCardanoApi::GetUtxosCallback callback) {
+          [&](const std::optional<std::string>& amount,
+              mojom::CardanoProviderPaginationPtr paginate,
+              TestCardanoApi::GetUtxosCallback callback) {
             std::move(callback).Run(
                 std::vector<std::string>(),
                 mojom::CardanoProviderErrorBundle::New(
                     0, "error",
                     mojom::CardanoProviderPaginationErrorPayload::New(2)));
-          }));
+          });
 
   {
     auto result = EvalJs(web_contents(browser()),
@@ -985,19 +948,17 @@ IN_PROC_BROWSER_TEST_F(CardanoProviderRendererTest, GetUtxos_NullResult) {
       web_contents(browser())->GetPrimaryMainFrame());
   auto cardano_api = std::make_unique<TestCardanoApi>();
   ON_CALL(*provider, Enable(_, _))
-      .WillByDefault(::testing::Invoke(
-          [&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
-              TestCardanoProvider::EnableCallback callback) {
-            cardano_api->BindReceiver(std::move(receiver));
-            std::move(callback).Run(nullptr);
-          }));
+      .WillByDefault([&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
+                         TestCardanoProvider::EnableCallback callback) {
+        cardano_api->BindReceiver(std::move(receiver));
+        std::move(callback).Run(nullptr);
+      });
   ON_CALL(*cardano_api, GetUtxos(_, _, _))
-      .WillByDefault(
-          ::testing::Invoke([&](const std::optional<std::string>& amount,
-                                mojom::CardanoProviderPaginationPtr paginate,
-                                TestCardanoApi::GetUtxosCallback callback) {
-            std::move(callback).Run(std::nullopt, nullptr);
-          }));
+      .WillByDefault([&](const std::optional<std::string>& amount,
+                         mojom::CardanoProviderPaginationPtr paginate,
+                         TestCardanoApi::GetUtxosCallback callback) {
+        std::move(callback).Run(std::nullopt, nullptr);
+      });
 
   {
     auto result = EvalJs(web_contents(browser()),
@@ -1013,20 +974,18 @@ IN_PROC_BROWSER_TEST_F(CardanoProviderRendererTest, SignTx) {
       web_contents(browser())->GetPrimaryMainFrame());
   auto cardano_api = std::make_unique<TestCardanoApi>();
   ON_CALL(*provider, Enable(_, _))
-      .WillByDefault(::testing::Invoke(
-          [&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
-              TestCardanoProvider::EnableCallback callback) {
-            cardano_api->BindReceiver(std::move(receiver));
-            std::move(callback).Run(nullptr);
-          }));
+      .WillByDefault([&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
+                         TestCardanoProvider::EnableCallback callback) {
+        cardano_api->BindReceiver(std::move(receiver));
+        std::move(callback).Run(nullptr);
+      });
   ON_CALL(*cardano_api, SignTx(_, _, _))
-      .WillByDefault(
-          ::testing::Invoke([&](const std::string& tx, bool partial_sign,
-                                TestCardanoApi::SignTxCallback callback) {
-            EXPECT_EQ(partial_sign, true);
-            EXPECT_EQ(tx, "tx");
-            std::move(callback).Run("signed_tx", nullptr);
-          }));
+      .WillByDefault([&](const std::string& tx, bool partial_sign,
+                         TestCardanoApi::SignTxCallback callback) {
+        EXPECT_EQ(partial_sign, true);
+        EXPECT_EQ(tx, "tx");
+        std::move(callback).Run("signed_tx", nullptr);
+      });
 
   auto result =
       EvalJs(web_contents(browser()),
@@ -1041,22 +1000,21 @@ IN_PROC_BROWSER_TEST_F(CardanoProviderRendererTest, SignTx_Error) {
       web_contents(browser())->GetPrimaryMainFrame());
   auto cardano_api = std::make_unique<TestCardanoApi>();
   ON_CALL(*provider, Enable(_, _))
-      .WillByDefault(::testing::Invoke(
-          [&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
-              TestCardanoProvider::EnableCallback callback) {
-            cardano_api->BindReceiver(std::move(receiver));
-            std::move(callback).Run(nullptr);
-          }));
+      .WillByDefault([&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
+                         TestCardanoProvider::EnableCallback callback) {
+        cardano_api->BindReceiver(std::move(receiver));
+        std::move(callback).Run(nullptr);
+      });
   ON_CALL(*cardano_api, SignTx(_, _, _))
       .WillByDefault(
-          ::testing::Invoke([&](const std::string& tx, bool partial_sign,
-                                TestCardanoApi::SignTxCallback callback) {
+          [&](const std::string& tx, bool partial_sign,
+              TestCardanoApi::SignTxCallback callback) {
             EXPECT_EQ(partial_sign, true);
             EXPECT_EQ(tx, "tx");
             std::move(callback).Run(std::nullopt,
                                     mojom::CardanoProviderErrorBundle::New(
                                         1, "Proof error", nullptr));
-          }));
+          });
 
   auto result = EvalJs(web_contents(browser()),
                        "(async () => { try { return await (await "
@@ -1075,20 +1033,18 @@ IN_PROC_BROWSER_TEST_F(CardanoProviderRendererTest, SignTx_PartialUndefined) {
       web_contents(browser())->GetPrimaryMainFrame());
   auto cardano_api = std::make_unique<TestCardanoApi>();
   ON_CALL(*provider, Enable(_, _))
-      .WillByDefault(::testing::Invoke(
-          [&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
-              TestCardanoProvider::EnableCallback callback) {
-            cardano_api->BindReceiver(std::move(receiver));
-            std::move(callback).Run(nullptr);
-          }));
+      .WillByDefault([&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
+                         TestCardanoProvider::EnableCallback callback) {
+        cardano_api->BindReceiver(std::move(receiver));
+        std::move(callback).Run(nullptr);
+      });
   ON_CALL(*cardano_api, SignTx(_, _, _))
-      .WillByDefault(
-          ::testing::Invoke([&](const std::string& tx, bool partial_sign,
-                                TestCardanoApi::SignTxCallback callback) {
-            EXPECT_EQ(partial_sign, false);
-            EXPECT_EQ(tx, "tx");
-            std::move(callback).Run("signed_tx", nullptr);
-          }));
+      .WillByDefault([&](const std::string& tx, bool partial_sign,
+                         TestCardanoApi::SignTxCallback callback) {
+        EXPECT_EQ(partial_sign, false);
+        EXPECT_EQ(tx, "tx");
+        std::move(callback).Run("signed_tx", nullptr);
+      });
 
   auto result = EvalJs(web_contents(browser()),
                        "(async () => { return await (await "
@@ -1102,20 +1058,18 @@ IN_PROC_BROWSER_TEST_F(CardanoProviderRendererTest, SignTx_WrongArguments) {
       web_contents(browser())->GetPrimaryMainFrame());
   auto cardano_api = std::make_unique<TestCardanoApi>();
   ON_CALL(*provider, Enable(_, _))
-      .WillByDefault(::testing::Invoke(
-          [&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
-              TestCardanoProvider::EnableCallback callback) {
-            cardano_api->BindReceiver(std::move(receiver));
-            std::move(callback).Run(nullptr);
-          }));
+      .WillByDefault([&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
+                         TestCardanoProvider::EnableCallback callback) {
+        cardano_api->BindReceiver(std::move(receiver));
+        std::move(callback).Run(nullptr);
+      });
   ON_CALL(*cardano_api, SignTx(_, _, _))
-      .WillByDefault(
-          ::testing::Invoke([&](const std::string& tx, bool partial_sign,
-                                TestCardanoApi::SignTxCallback callback) {
-            EXPECT_EQ(partial_sign, true);
-            EXPECT_EQ(tx, "tx");
-            std::move(callback).Run("signed_tx", nullptr);
-          }));
+      .WillByDefault([&](const std::string& tx, bool partial_sign,
+                         TestCardanoApi::SignTxCallback callback) {
+        EXPECT_EQ(partial_sign, true);
+        EXPECT_EQ(tx, "tx");
+        std::move(callback).Run("signed_tx", nullptr);
+      });
 
   {
     auto result =
@@ -1161,23 +1115,21 @@ IN_PROC_BROWSER_TEST_F(CardanoProviderRendererTest, SignData) {
       web_contents(browser())->GetPrimaryMainFrame());
   auto cardano_api = std::make_unique<TestCardanoApi>();
   ON_CALL(*provider, Enable(_, _))
-      .WillByDefault(::testing::Invoke(
-          [&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
-              TestCardanoProvider::EnableCallback callback) {
-            cardano_api->BindReceiver(std::move(receiver));
-            std::move(callback).Run(nullptr);
-          }));
+      .WillByDefault([&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
+                         TestCardanoProvider::EnableCallback callback) {
+        cardano_api->BindReceiver(std::move(receiver));
+        std::move(callback).Run(nullptr);
+      });
   ON_CALL(*cardano_api, SignData(_, _, _))
-      .WillByDefault(::testing::Invoke(
-          [&](const std::string& address, const std::string& data,
-              TestCardanoApi::SignDataCallback callback) {
-            EXPECT_EQ("addr", address);
-            EXPECT_EQ("data", data);
-            base::Value::Dict signature_dict;
-            signature_dict.Set("key", "key_value");
-            signature_dict.Set("signature", "signature_value");
-            std::move(callback).Run(std::move(signature_dict), nullptr);
-          }));
+      .WillByDefault([&](const std::string& address, const std::string& data,
+                         TestCardanoApi::SignDataCallback callback) {
+        EXPECT_EQ("addr", address);
+        EXPECT_EQ("data", data);
+        base::Value::Dict signature_dict;
+        signature_dict.Set("key", "key_value");
+        signature_dict.Set("signature", "signature_value");
+        std::move(callback).Run(std::move(signature_dict), nullptr);
+      });
 
   auto result = EvalJs(
       web_contents(browser()),
@@ -1196,23 +1148,21 @@ IN_PROC_BROWSER_TEST_F(CardanoProviderRendererTest, SignData_WrongArguments) {
       web_contents(browser())->GetPrimaryMainFrame());
   auto cardano_api = std::make_unique<TestCardanoApi>();
   ON_CALL(*provider, Enable(_, _))
-      .WillByDefault(::testing::Invoke(
-          [&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
-              TestCardanoProvider::EnableCallback callback) {
-            cardano_api->BindReceiver(std::move(receiver));
-            std::move(callback).Run(nullptr);
-          }));
+      .WillByDefault([&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
+                         TestCardanoProvider::EnableCallback callback) {
+        cardano_api->BindReceiver(std::move(receiver));
+        std::move(callback).Run(nullptr);
+      });
   ON_CALL(*cardano_api, SignData(_, _, _))
-      .WillByDefault(::testing::Invoke(
-          [&](const std::string& address, const std::string& data,
-              TestCardanoApi::SignDataCallback callback) {
-            EXPECT_EQ("addr", address);
-            EXPECT_EQ("data", data);
-            base::Value::Dict signature_dict;
-            signature_dict.Set("key", "key_value");
-            signature_dict.Set("signature", "signature_value");
-            std::move(callback).Run(std::move(signature_dict), nullptr);
-          }));
+      .WillByDefault([&](const std::string& address, const std::string& data,
+                         TestCardanoApi::SignDataCallback callback) {
+        EXPECT_EQ("addr", address);
+        EXPECT_EQ("data", data);
+        base::Value::Dict signature_dict;
+        signature_dict.Set("key", "key_value");
+        signature_dict.Set("signature", "signature_value");
+        std::move(callback).Run(std::move(signature_dict), nullptr);
+      });
 
   {
     auto result =
@@ -1251,14 +1201,13 @@ IN_PROC_BROWSER_TEST_F(CardanoProviderRendererTest, SignData_Error) {
       web_contents(browser())->GetPrimaryMainFrame());
   auto cardano_api = std::make_unique<TestCardanoApi>();
   ON_CALL(*provider, Enable(_, _))
-      .WillByDefault(::testing::Invoke(
-          [&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
-              TestCardanoProvider::EnableCallback callback) {
-            cardano_api->BindReceiver(std::move(receiver));
-            std::move(callback).Run(nullptr);
-          }));
+      .WillByDefault([&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
+                         TestCardanoProvider::EnableCallback callback) {
+        cardano_api->BindReceiver(std::move(receiver));
+        std::move(callback).Run(nullptr);
+      });
   ON_CALL(*cardano_api, SignData(_, _, _))
-      .WillByDefault(::testing::Invoke(
+      .WillByDefault(
           [&](const std::string& address, const std::string& data,
               TestCardanoApi::SignDataCallback callback) {
             EXPECT_EQ("addr", address);
@@ -1266,7 +1215,7 @@ IN_PROC_BROWSER_TEST_F(CardanoProviderRendererTest, SignData_Error) {
             std::move(callback).Run(std::nullopt,
                                     mojom::CardanoProviderErrorBundle::New(
                                         2, "Data sign error", nullptr));
-          }));
+          });
 
   auto result = EvalJs(web_contents(browser()),
                        "(async () => { try { return await (await "
@@ -1285,20 +1234,19 @@ IN_PROC_BROWSER_TEST_F(CardanoProviderRendererTest, SubmitTx_Error) {
       web_contents(browser())->GetPrimaryMainFrame());
   auto cardano_api = std::make_unique<TestCardanoApi>();
   ON_CALL(*provider, Enable(_, _))
-      .WillByDefault(::testing::Invoke(
-          [&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
-              TestCardanoProvider::EnableCallback callback) {
-            cardano_api->BindReceiver(std::move(receiver));
-            std::move(callback).Run(nullptr);
-          }));
+      .WillByDefault([&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
+                         TestCardanoProvider::EnableCallback callback) {
+        cardano_api->BindReceiver(std::move(receiver));
+        std::move(callback).Run(nullptr);
+      });
   ON_CALL(*cardano_api, SubmitTx(_, _))
       .WillByDefault(
-          ::testing::Invoke([&](const std::string& tx,
-                                TestCardanoApi::SubmitTxCallback callback) {
+          [&](const std::string& tx,
+              TestCardanoApi::SubmitTxCallback callback) {
             std::move(callback).Run(
                 std::nullopt,
                 mojom::CardanoProviderErrorBundle::New(1, "Refused", nullptr));
-          }));
+          });
 
   auto result = EvalJs(web_contents(browser()),
                        "(async () => { try { return await (await "
@@ -1317,18 +1265,16 @@ IN_PROC_BROWSER_TEST_F(CardanoProviderRendererTest, SubmitTx) {
       web_contents(browser())->GetPrimaryMainFrame());
   auto cardano_api = std::make_unique<TestCardanoApi>();
   ON_CALL(*provider, Enable(_, _))
-      .WillByDefault(::testing::Invoke(
-          [&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
-              TestCardanoProvider::EnableCallback callback) {
-            cardano_api->BindReceiver(std::move(receiver));
-            std::move(callback).Run(nullptr);
-          }));
+      .WillByDefault([&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
+                         TestCardanoProvider::EnableCallback callback) {
+        cardano_api->BindReceiver(std::move(receiver));
+        std::move(callback).Run(nullptr);
+      });
   ON_CALL(*cardano_api, SubmitTx(_, _))
-      .WillByDefault(
-          ::testing::Invoke([&](const std::string& tx,
-                                TestCardanoApi::SubmitTxCallback callback) {
-            std::move(callback).Run("hash", nullptr);
-          }));
+      .WillByDefault([&](const std::string& tx,
+                         TestCardanoApi::SubmitTxCallback callback) {
+        std::move(callback).Run("hash", nullptr);
+      });
 
   auto result = EvalJs(web_contents(browser()),
                        "(async () => { return await (await "
@@ -1342,17 +1288,15 @@ IN_PROC_BROWSER_TEST_F(CardanoProviderRendererTest, SubmitTx_WrongArguments) {
       web_contents(browser())->GetPrimaryMainFrame());
   auto cardano_api = std::make_unique<TestCardanoApi>();
   ON_CALL(*provider, Enable(_, _))
-      .WillByDefault(::testing::Invoke(
-          [&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
-              TestCardanoProvider::EnableCallback callback) {
-            std::move(callback).Run(nullptr);
-          }));
+      .WillByDefault([&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
+                         TestCardanoProvider::EnableCallback callback) {
+        std::move(callback).Run(nullptr);
+      });
   ON_CALL(*cardano_api, SubmitTx(_, _))
-      .WillByDefault(
-          ::testing::Invoke([&](const std::string& tx,
-                                TestCardanoApi::SubmitTxCallback callback) {
-            std::move(callback).Run("hash", nullptr);
-          }));
+      .WillByDefault([&](const std::string& tx,
+                         TestCardanoApi::SubmitTxCallback callback) {
+        std::move(callback).Run("hash", nullptr);
+      });
 
   {
     auto result = EvalJs(web_contents(browser()),
@@ -1384,11 +1328,10 @@ IN_PROC_BROWSER_TEST_F(CardanoProviderRendererTest, GetExtensions) {
   TestCardanoProvider* provider = test_content_browser_client_.GetProvider(
       web_contents(browser())->GetPrimaryMainFrame());
   ON_CALL(*provider, Enable(_, _))
-      .WillByDefault(::testing::Invoke(
-          [&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
-              TestCardanoProvider::EnableCallback callback) {
-            std::move(callback).Run(nullptr);
-          }));
+      .WillByDefault([&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
+                         TestCardanoProvider::EnableCallback callback) {
+        std::move(callback).Run(nullptr);
+      });
 
   auto result = EvalJs(web_contents(browser()),
                        "(async () => { return await (await "
@@ -1401,20 +1344,17 @@ IN_PROC_BROWSER_TEST_F(CardanoProviderRendererTest, GetCollateral) {
       web_contents(browser())->GetPrimaryMainFrame());
   auto cardano_api = std::make_unique<TestCardanoApi>();
   ON_CALL(*provider, Enable(_, _))
-      .WillByDefault(::testing::Invoke(
-          [&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
-              TestCardanoProvider::EnableCallback callback) {
-            cardano_api->BindReceiver(std::move(receiver));
-            std::move(callback).Run(nullptr);
-          }));
+      .WillByDefault([&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
+                         TestCardanoProvider::EnableCallback callback) {
+        cardano_api->BindReceiver(std::move(receiver));
+        std::move(callback).Run(nullptr);
+      });
   ON_CALL(*cardano_api, GetCollateral(_, _))
-      .WillByDefault(::testing::Invoke(
-          [&](const std::string& amount,
-              TestCardanoApi::GetCollateralCallback callback) {
-            EXPECT_EQ("amount", amount);
-            std::move(callback).Run(std::vector<std::string>({"1", "2"}),
-                                    nullptr);
-          }));
+      .WillByDefault([&](const std::string& amount,
+                         TestCardanoApi::GetCollateralCallback callback) {
+        EXPECT_EQ("amount", amount);
+        std::move(callback).Run(std::vector<std::string>({"1", "2"}), nullptr);
+      });
 
   auto result = EvalJs(web_contents(browser()),
                        "(async () => { return await (await "
@@ -1433,20 +1373,17 @@ IN_PROC_BROWSER_TEST_F(CardanoProviderRendererTest,
       web_contents(browser())->GetPrimaryMainFrame());
   auto cardano_api = std::make_unique<TestCardanoApi>();
   ON_CALL(*provider, Enable(_, _))
-      .WillByDefault(::testing::Invoke(
-          [&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
-              TestCardanoProvider::EnableCallback callback) {
-            cardano_api->BindReceiver(std::move(receiver));
-            std::move(callback).Run(nullptr);
-          }));
+      .WillByDefault([&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
+                         TestCardanoProvider::EnableCallback callback) {
+        cardano_api->BindReceiver(std::move(receiver));
+        std::move(callback).Run(nullptr);
+      });
   ON_CALL(*cardano_api, GetCollateral(_, _))
-      .WillByDefault(::testing::Invoke(
-          [&](const std::string& amount,
-              TestCardanoApi::GetCollateralCallback callback) {
-            EXPECT_EQ("amount", amount);
-            std::move(callback).Run(std::vector<std::string>({"1", "2"}),
-                                    nullptr);
-          }));
+      .WillByDefault([&](const std::string& amount,
+                         TestCardanoApi::GetCollateralCallback callback) {
+        EXPECT_EQ("amount", amount);
+        std::move(callback).Run(std::vector<std::string>({"1", "2"}), nullptr);
+      });
 
   {
     auto result =
@@ -1646,11 +1583,10 @@ IN_PROC_BROWSER_TEST_F(CardanoProviderRendererTest,
   TestCardanoProvider* provider = test_content_browser_client_.GetProvider(
       web_contents(browser())->GetPrimaryMainFrame());
   ON_CALL(*provider, Enable(_, _))
-      .WillByDefault(::testing::Invoke(
-          [&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
-              TestCardanoProvider::EnableCallback callback) {
-            std::move(callback).Run(nullptr);
-          }));
+      .WillByDefault([&](mojo::PendingReceiver<mojom::CardanoApi> receiver,
+                         TestCardanoProvider::EnableCallback callback) {
+        std::move(callback).Run(nullptr);
+      });
   auto result = EvalJs(web_contents(browser()), EnableScript());
   EXPECT_EQ(base::Value(true), result);
 }

--- a/browser/ephemeral_storage/ephemeral_storage_service_unittest.cc
+++ b/browser/ephemeral_storage/ephemeral_storage_service_unittest.cc
@@ -56,14 +56,13 @@ class MockDelegate : public EphemeralStorageServiceDelegate {
   void ExpectRegisterFirstWindowOpenedCallback(base::OnceClosure callback,
                                                bool trigger_callback) {
     EXPECT_CALL(*this, RegisterFirstWindowOpenedCallback(_))
-        .WillOnce(testing::Invoke(
-            [this, trigger_callback](base::OnceClosure callback) {
-              if (trigger_callback) {
-                std::move(callback).Run();
-              } else {
-                first_window_opened_callback_ = std::move(callback);
-              }
-            }));
+        .WillOnce([this, trigger_callback](base::OnceClosure callback) {
+          if (trigger_callback) {
+            std::move(callback).Run();
+          } else {
+            first_window_opened_callback_ = std::move(callback);
+          }
+        });
   }
 
   void TriggerFirstWindowOpenedCallback() {

--- a/browser/permissions/permission_lifetime_manager_browsertest.cc
+++ b/browser/permissions/permission_lifetime_manager_browsertest.cc
@@ -243,12 +243,12 @@ IN_PROC_BROWSER_TEST_F(PermissionLifetimeManagerBrowserTest, ExpirationSmoke) {
     std::unique_ptr<base::ScopedMockTimeMessageLoopTaskRunner>
         scoped_mock_time_task_runner;
     EXPECT_CALL(*prompt_factory_, OnPermissionPromptCreated(_))
-        .WillOnce(testing::Invoke([&](MockPermissionLifetimePrompt* prompt) {
+        .WillOnce([&](MockPermissionLifetimePrompt* prompt) {
           run_loop.Quit();
           prompt->delegate()->Requests()[0]->SetLifetime(base::Seconds(30));
           scoped_mock_time_task_runner =
               std::make_unique<base::ScopedMockTimeMessageLoopTaskRunner>();
-        }));
+        });
     GURL target_url = RequestPermission(entry, url);
     run_loop.Run();
 
@@ -285,9 +285,9 @@ IN_PROC_BROWSER_TEST_F(PermissionLifetimeManagerBrowserTest,
     SCOPED_TRACE(GetContentSettingTypeString(entry.type));
     ++show_count;
     EXPECT_CALL(*prompt_factory_, OnPermissionPromptCreated(_))
-        .WillOnce(testing::Invoke([&](MockPermissionLifetimePrompt* prompt) {
+        .WillOnce([&](MockPermissionLifetimePrompt* prompt) {
           prompt->delegate()->Requests()[0]->SetLifetime(base::Seconds(30));
-        }));
+        });
 
     GURL target_url = RequestPermission(entry, url);
     prompt_factory_->WaitForPermissionBubble();
@@ -362,9 +362,9 @@ IN_PROC_BROWSER_TEST_F(PermissionLifetimeManagerBrowserTest,
     ++show_count;
 
     EXPECT_CALL(*prompt_factory_, OnPermissionPromptCreated(_))
-        .WillOnce(testing::Invoke([&](MockPermissionLifetimePrompt* prompt) {
+        .WillOnce([&](MockPermissionLifetimePrompt* prompt) {
           prompt->delegate()->Requests()[0]->SetLifetime(base::Seconds(30));
-        }));
+        });
     GURL target_url = RequestPermission(entry, url);
     prompt_factory_->WaitForPermissionBubble();
 
@@ -395,9 +395,9 @@ IN_PROC_BROWSER_TEST_F(PermissionLifetimeManagerBrowserTest,
     prompt_factory_->set_response_type(
         PermissionRequestManager::AutoResponseType::ACCEPT_ALL);
     EXPECT_CALL(*prompt_factory_, OnPermissionPromptCreated(_))
-        .WillOnce(testing::Invoke([](MockPermissionLifetimePrompt* prompt) {
+        .WillOnce([](MockPermissionLifetimePrompt* prompt) {
           prompt->delegate()->Requests()[0]->SetLifetime(base::TimeDelta());
-        }));
+        });
     GURL target_url = RequestPermission(entry, url);
     prompt_factory_->WaitForPermissionBubble();
 
@@ -438,9 +438,9 @@ IN_PROC_BROWSER_TEST_F(PermissionLifetimeManagerBrowserTest,
     prompt_factory_->set_response_type(
         PermissionRequestManager::AutoResponseType::ACCEPT_ALL);
     EXPECT_CALL(*prompt_factory_, OnPermissionPromptCreated(_))
-        .WillOnce(testing::Invoke([](MockPermissionLifetimePrompt* prompt) {
+        .WillOnce([](MockPermissionLifetimePrompt* prompt) {
           prompt->delegate()->Requests()[0]->SetLifetime(base::TimeDelta());
-        }));
+        });
     GURL target_url = RequestPermission(entry, url);
     prompt_factory_->WaitForPermissionBubble();
 
@@ -485,9 +485,9 @@ IN_PROC_BROWSER_TEST_F(PermissionLifetimeManagerBrowserTest,
         PermissionRequestManager::AutoResponseType::ACCEPT_ALL);
 
     EXPECT_CALL(*prompt_factory_, OnPermissionPromptCreated(_))
-        .WillOnce(testing::Invoke([](MockPermissionLifetimePrompt* prompt) {
+        .WillOnce([](MockPermissionLifetimePrompt* prompt) {
           prompt->delegate()->Requests()[0]->SetLifetime(base::TimeDelta());
-        }));
+        });
     GURL target_url = RequestPermission(entry, url);
     prompt_factory_->WaitForPermissionBubble();
 
@@ -539,9 +539,9 @@ IN_PROC_BROWSER_TEST_F(PermissionLifetimeManagerBrowserTest,
         PermissionRequestManager::AutoResponseType::ACCEPT_ALL);
 
     EXPECT_CALL(*prompt_factory_, OnPermissionPromptCreated(_))
-        .WillOnce(testing::Invoke([](MockPermissionLifetimePrompt* prompt) {
+        .WillOnce([](MockPermissionLifetimePrompt* prompt) {
           prompt->delegate()->Requests()[0]->SetLifetime(base::TimeDelta());
-        }));
+        });
     GURL target_url = RequestPermission(entry, url);
     prompt_factory_->WaitForPermissionBubble();
 
@@ -593,9 +593,9 @@ IN_PROC_BROWSER_TEST_F(PermissionLifetimeManagerBrowserTest,
         PermissionRequestManager::AutoResponseType::ACCEPT_ALL);
 
     EXPECT_CALL(*prompt_factory_, OnPermissionPromptCreated(_))
-        .WillOnce(testing::Invoke([](MockPermissionLifetimePrompt* prompt) {
+        .WillOnce([](MockPermissionLifetimePrompt* prompt) {
           prompt->delegate()->Requests()[0]->SetLifetime(base::TimeDelta());
-        }));
+        });
     GURL target_url = RequestPermission(entry, url);
     prompt_factory_->WaitForPermissionBubble();
 

--- a/components/ai_chat/content/browser/page_content_fetcher_unittest.cc
+++ b/components/ai_chat/content/browser/page_content_fetcher_unittest.cc
@@ -220,12 +220,11 @@ TEST_F(PageContentFetcherTest, YouTubeInnerTubeAPISuccess) {
   auto youtube_content = CreateYoutubePageContent(api_key, video_id);
 
   EXPECT_CALL(*mock_extractor, ExtractPageContent(_))
-      .WillOnce(
-          Invoke([&youtube_content](
-                     mojom::PageContentExtractor::ExtractPageContentCallback
-                         callback) {
-            std::move(callback).Run(youtube_content.Clone());
-          }));
+      .WillOnce([&youtube_content](
+                    mojom::PageContentExtractor::ExtractPageContentCallback
+                        callback) {
+        std::move(callback).Run(youtube_content.Clone());
+      });
 
   // Set up network responses
   GURL inner_tube_url("https://www.youtube.com/youtubei/v1/player?key=" +
@@ -315,12 +314,11 @@ TEST_F(PageContentFetcherTest, YouTubeInnerTubeAPINetworkError) {
   auto youtube_content = CreateYoutubePageContent(api_key, video_id);
 
   EXPECT_CALL(*mock_extractor, ExtractPageContent(_))
-      .WillOnce(
-          Invoke([&youtube_content](
-                     mojom::PageContentExtractor::ExtractPageContentCallback
-                         callback) {
-            std::move(callback).Run(youtube_content.Clone());
-          }));
+      .WillOnce([&youtube_content](
+                    mojom::PageContentExtractor::ExtractPageContentCallback
+                        callback) {
+        std::move(callback).Run(youtube_content.Clone());
+      });
 
   // Track the requests that are made
   std::vector<network::ResourceRequest> requests_made;
@@ -362,12 +360,11 @@ TEST_F(PageContentFetcherTest, YouTubeInnerTubeAPIInvalidJsonResponse) {
   auto youtube_content = CreateYoutubePageContent(api_key, video_id);
 
   EXPECT_CALL(*mock_extractor, ExtractPageContent(_))
-      .WillOnce(
-          Invoke([&youtube_content](
-                     mojom::PageContentExtractor::ExtractPageContentCallback
-                         callback) {
-            std::move(callback).Run(youtube_content.Clone());
-          }));
+      .WillOnce([&youtube_content](
+                    mojom::PageContentExtractor::ExtractPageContentCallback
+                        callback) {
+        std::move(callback).Run(youtube_content.Clone());
+      });
 
   // Track the requests that are made
   std::vector<network::ResourceRequest> requests_made;
@@ -409,12 +406,11 @@ TEST_F(PageContentFetcherTest, YouTubeInnerTubeAPINoCaptionTracks) {
   auto youtube_content = CreateYoutubePageContent(api_key, video_id);
 
   EXPECT_CALL(*mock_extractor, ExtractPageContent(_))
-      .WillOnce(
-          Invoke([&youtube_content](
-                     mojom::PageContentExtractor::ExtractPageContentCallback
-                         callback) {
-            std::move(callback).Run(youtube_content.Clone());
-          }));
+      .WillOnce([&youtube_content](
+                    mojom::PageContentExtractor::ExtractPageContentCallback
+                        callback) {
+        std::move(callback).Run(youtube_content.Clone());
+      });
 
   // Track the requests that are made
   std::vector<network::ResourceRequest> requests_made;
@@ -457,12 +453,11 @@ TEST_F(PageContentFetcherTest, InvalidationTokenCaching) {
   auto youtube_content = CreateYoutubePageContent(api_key, video_id);
 
   EXPECT_CALL(*mock_extractor, ExtractPageContent(_))
-      .WillOnce(
-          Invoke([&youtube_content](
-                     mojom::PageContentExtractor::ExtractPageContentCallback
-                         callback) {
-            std::move(callback).Run(youtube_content.Clone());
-          }));
+      .WillOnce([&youtube_content](
+                    mojom::PageContentExtractor::ExtractPageContentCallback
+                        callback) {
+        std::move(callback).Run(youtube_content.Clone());
+      });
 
   // Track the requests that are made
   std::vector<network::ResourceRequest> requests_made;
@@ -499,12 +494,11 @@ TEST_F(PageContentFetcherTest, InvalidationTokenCaching) {
   auto youtube_content2 = CreateYoutubePageContent(api_key, video_id);
 
   EXPECT_CALL(*mock_extractor2, ExtractPageContent(_))
-      .WillOnce(
-          Invoke([&youtube_content2](
-                     mojom::PageContentExtractor::ExtractPageContentCallback
-                         callback) {
-            std::move(callback).Run(youtube_content2.Clone());
-          }));
+      .WillOnce([&youtube_content2](
+                    mojom::PageContentExtractor::ExtractPageContentCallback
+                        callback) {
+        std::move(callback).Run(youtube_content2.Clone());
+      });
 
   base::test::TestFuture<std::string, bool, std::string> future2;
   fetcher_->FetchPageContent(invalidation_token1, future2.GetCallback());
@@ -530,12 +524,11 @@ TEST_F(PageContentFetcherTest, ContentUrlExtraction) {
   auto content_url_page_content = CreateContentUrlPageContent(content_url);
 
   EXPECT_CALL(*mock_extractor, ExtractPageContent(_))
-      .WillOnce(
-          Invoke([&content_url_page_content](
-                     mojom::PageContentExtractor::ExtractPageContentCallback
-                         callback) {
-            std::move(callback).Run(content_url_page_content.Clone());
-          }));
+      .WillOnce([&content_url_page_content](
+                    mojom::PageContentExtractor::ExtractPageContentCallback
+                        callback) {
+        std::move(callback).Run(content_url_page_content.Clone());
+      });
 
   // Track the requests that are made
   std::vector<network::ResourceRequest> requests_made;
@@ -571,10 +564,10 @@ TEST_F(PageContentFetcherTest, NullPageContentResponse) {
   MockPageContentExtractor* mock_extractor = SetUpMockExtractor();
 
   EXPECT_CALL(*mock_extractor, ExtractPageContent(_))
-      .WillOnce(Invoke(
+      .WillOnce(
           [](mojom::PageContentExtractor::ExtractPageContentCallback callback) {
             std::move(callback).Run(nullptr);
-          }));
+          });
 
   base::test::TestFuture<std::string, bool, std::string> future;
   fetcher_->FetchPageContent("", future.GetCallback());
@@ -599,12 +592,11 @@ TEST_F(PageContentFetcherTest, TextContentExtraction) {
   auto text_page_content = CreateTextPageContent(text_content);
 
   EXPECT_CALL(*mock_extractor, ExtractPageContent(_))
-      .WillOnce(
-          Invoke([&text_page_content](
-                     mojom::PageContentExtractor::ExtractPageContentCallback
-                         callback) {
-            std::move(callback).Run(text_page_content.Clone());
-          }));
+      .WillOnce([&text_page_content](
+                    mojom::PageContentExtractor::ExtractPageContentCallback
+                        callback) {
+        std::move(callback).Run(text_page_content.Clone());
+      });
 
   base::test::TestFuture<std::string, bool, std::string> future;
   fetcher_->FetchPageContent("", future.GetCallback());
@@ -634,12 +626,11 @@ TEST_F(PageContentFetcherTest, YouTubeInnerTubeAPIKeyUrlEncoding) {
       CreateYoutubePageContent(api_key_with_special_chars, video_id);
 
   EXPECT_CALL(*mock_extractor, ExtractPageContent(_))
-      .WillOnce(
-          Invoke([&youtube_content](
-                     mojom::PageContentExtractor::ExtractPageContentCallback
-                         callback) {
-            std::move(callback).Run(youtube_content.Clone());
-          }));
+      .WillOnce([&youtube_content](
+                    mojom::PageContentExtractor::ExtractPageContentCallback
+                        callback) {
+        std::move(callback).Run(youtube_content.Clone());
+      });
 
   // Track the requests that are made
   std::vector<network::ResourceRequest> requests_made;

--- a/components/ai_chat/core/browser/conversation_handler_unittest.cc
+++ b/components/ai_chat/core/browser/conversation_handler_unittest.cc
@@ -1843,7 +1843,7 @@ TEST_F(ConversationHandlerUnitTest, UploadFile) {
 
   constexpr char kTestPrompt[] = "What is this?";
   EXPECT_CALL(*engine, GenerateAssistantResponse)
-      .WillRepeatedly(testing::Invoke(
+      .WillRepeatedly(
           [](PageContentsMap page_contents,
              const std::vector<mojom::ConversationTurnPtr>& history,
              const std::string& selected_language, bool is_temporary_chat,
@@ -1857,7 +1857,7 @@ TEST_F(ConversationHandlerUnitTest, UploadFile) {
                     mojom::ConversationEntryEvent::NewCompletionEvent(
                         mojom::CompletionEvent::New("This is a lion.")),
                     std::nullopt /* model_key */)));
-          }));
+          });
   ASSERT_FALSE(conversation_handler_->GetCurrentModel().vision_support);
 
   // No uploaded files
@@ -3744,7 +3744,7 @@ TEST_F(ConversationHandlerUnitTest, VisionModelSwitchOnScreenshots) {
 
   // Mock engine response
   EXPECT_CALL(*engine, GenerateAssistantResponse)
-      .WillRepeatedly(testing::Invoke(
+      .WillRepeatedly(
           [](PageContentsMap page_contents,
              const std::vector<mojom::ConversationTurnPtr>& history,
              const std::string& selected_language, bool is_temporary_chat,
@@ -3759,7 +3759,7 @@ TEST_F(ConversationHandlerUnitTest, VisionModelSwitchOnScreenshots) {
                         mojom::CompletionEvent::New(
                             "Response with vision model")),
                     std::nullopt /* model_key */)));
-          }));
+          });
 
   base::RunLoop loop;
   // Note: OnModelDataChanged expectation is set at the end for auto model

--- a/components/ai_chat/core/browser/customization_settings_handler_unittest.cc
+++ b/components/ai_chat/core/browser/customization_settings_handler_unittest.cc
@@ -100,10 +100,10 @@ TEST_F(CustomizationSettingsHandlerTest, SetCustomizations_Valid) {
   base::RunLoop run_loop;
   EXPECT_CALL(*mock_ui, OnCustomizationsChanged(_))
       .Times(1)
-      .WillOnce(testing::Invoke([&](mojom::CustomizationsPtr result) {
+      .WillOnce([&](mojom::CustomizationsPtr result) {
         EXPECT_EQ(customizations, result);
         run_loop.Quit();
-      }));
+      });
 
   base::test::TestFuture<std::optional<mojom::CustomizationOperationError>>
       future;
@@ -142,11 +142,11 @@ TEST_F(CustomizationSettingsHandlerTest, AddMemory_Valid) {
   base::RunLoop run_loop;
   EXPECT_CALL(*mock_ui, OnMemoriesChanged(_))
       .Times(1)
-      .WillOnce(testing::Invoke([&](const std::vector<std::string>& result) {
+      .WillOnce([&](const std::vector<std::string>& result) {
         EXPECT_EQ(result,
                   std::vector<std::string>{"I like creative solutions"});
         run_loop.Quit();
-      }));
+      });
 
   base::test::TestFuture<std::optional<mojom::CustomizationOperationError>>
       future;
@@ -208,10 +208,10 @@ TEST_F(CustomizationSettingsHandlerTest, EditMemory_Success) {
   base::RunLoop run_loop;
   EXPECT_CALL(*mock_ui, OnMemoriesChanged(_))
       .Times(1)
-      .WillOnce(testing::Invoke([&](const std::vector<std::string>& result) {
+      .WillOnce([&](const std::vector<std::string>& result) {
         EXPECT_EQ(result, std::vector<std::string>{"Old memory"});
         run_loop.Quit();
-      }));
+      });
 
   base::test::TestFuture<std::optional<mojom::CustomizationOperationError>>
       future;
@@ -224,10 +224,10 @@ TEST_F(CustomizationSettingsHandlerTest, EditMemory_Success) {
   base::RunLoop run_loop2;
   EXPECT_CALL(*mock_ui, OnMemoriesChanged(_))
       .Times(1)
-      .WillOnce(testing::Invoke([&](const std::vector<std::string>& result) {
+      .WillOnce([&](const std::vector<std::string>& result) {
         EXPECT_EQ(result, std::vector<std::string>{"New memory"});
         run_loop2.Quit();
-      }));
+      });
 
   // Edit the memory
   base::test::TestFuture<std::optional<mojom::CustomizationOperationError>>
@@ -347,10 +347,10 @@ TEST_F(CustomizationSettingsHandlerTest, BindUI_Notifications) {
   base::RunLoop run_loop;
   EXPECT_CALL(*mock_ui, OnCustomizationsChanged(_))
       .Times(1)
-      .WillOnce(testing::Invoke([&](mojom::CustomizationsPtr result) {
+      .WillOnce([&](mojom::CustomizationsPtr result) {
         EXPECT_EQ(customizations, result);
         run_loop.Quit();
-      }));
+      });
 
   base::test::TestFuture<std::optional<mojom::CustomizationOperationError>>
       future;
@@ -365,10 +365,10 @@ TEST_F(CustomizationSettingsHandlerTest, BindUI_Notifications) {
   base::RunLoop run_loop2;
   EXPECT_CALL(*mock_ui, OnMemoriesChanged(_))
       .Times(1)
-      .WillOnce(testing::Invoke([&](const std::vector<std::string>& result) {
+      .WillOnce([&](const std::vector<std::string>& result) {
         EXPECT_EQ(result, std::vector<std::string>{"Test Memory"});
         run_loop2.Quit();
-      }));
+      });
 
   base::test::TestFuture<std::optional<mojom::CustomizationOperationError>>
       future2;

--- a/components/brave_ads/core/browser/service/new_tab_page_ad_prefetcher_unittest.cc
+++ b/components/brave_ads/core/browser/service/new_tab_page_ad_prefetcher_unittest.cc
@@ -62,10 +62,9 @@ TEST_F(BraveAdsNewTabPageAdPrefetcherTest, Prefetch) {
   const NewTabPageAdInfo expected_ad = BuildNewTabPageAd();
 
   EXPECT_CALL(ads_service(), MaybeServeNewTabPageAd)
-      .WillOnce(::testing::Invoke(
-          [&expected_ad](MaybeServeNewTabPageAdCallback callback) {
-            std::move(callback).Run(expected_ad);
-          }));
+      .WillOnce([&expected_ad](MaybeServeNewTabPageAdCallback callback) {
+        std::move(callback).Run(expected_ad);
+      });
 
   // Act
   prefetcher().Prefetch();
@@ -77,9 +76,9 @@ TEST_F(BraveAdsNewTabPageAdPrefetcherTest, Prefetch) {
 TEST_F(BraveAdsNewTabPageAdPrefetcherTest, PrefetchFailed) {
   // Arrange
   EXPECT_CALL(ads_service(), MaybeServeNewTabPageAd)
-      .WillOnce(::testing::Invoke([](MaybeServeNewTabPageAdCallback callback) {
+      .WillOnce([](MaybeServeNewTabPageAdCallback callback) {
         std::move(callback).Run(/*ad=*/std::nullopt);
-      }));
+      });
 
   // Act
   prefetcher().Prefetch();
@@ -94,10 +93,9 @@ TEST_F(BraveAdsNewTabPageAdPrefetcherTest, PrefetchInvalidAd) {
   ASSERT_FALSE(invalid_ad.IsValid());
 
   EXPECT_CALL(ads_service(), MaybeServeNewTabPageAd)
-      .WillOnce(::testing::Invoke(
-          [&invalid_ad](MaybeServeNewTabPageAdCallback callback) {
-            std::move(callback).Run(invalid_ad);
-          }));
+      .WillOnce([&invalid_ad](MaybeServeNewTabPageAdCallback callback) {
+        std::move(callback).Run(invalid_ad);
+      });
 
   // Act
   prefetcher().Prefetch();
@@ -113,10 +111,9 @@ TEST_F(BraveAdsNewTabPageAdPrefetcherTest,
 
   EXPECT_CALL(ads_service(), MaybeServeNewTabPageAd)
       .Times(2)
-      .WillRepeatedly(::testing::Invoke(
-          [&expected_ad](MaybeServeNewTabPageAdCallback callback) {
-            std::move(callback).Run(expected_ad);
-          }));
+      .WillRepeatedly([&expected_ad](MaybeServeNewTabPageAdCallback callback) {
+        std::move(callback).Run(expected_ad);
+      });
 
   prefetcher().Prefetch();
   ASSERT_EQ(expected_ad, prefetcher().MaybeGetPrefetchedAd());
@@ -134,10 +131,9 @@ TEST_F(BraveAdsNewTabPageAdPrefetcherTest,
   const NewTabPageAdInfo expected_ad = BuildNewTabPageAd();
 
   EXPECT_CALL(ads_service(), MaybeServeNewTabPageAd)
-      .WillOnce(::testing::Invoke(
-          [&expected_ad](MaybeServeNewTabPageAdCallback callback) {
-            std::move(callback).Run(expected_ad);
-          }));
+      .WillOnce([&expected_ad](MaybeServeNewTabPageAdCallback callback) {
+        std::move(callback).Run(expected_ad);
+      });
 
   prefetcher().Prefetch();
 
@@ -155,10 +151,10 @@ TEST_F(BraveAdsNewTabPageAdPrefetcherTest,
 
   MaybeServeNewTabPageAdCallback deferred_maybe_serve_ad_callback;
   EXPECT_CALL(ads_service(), MaybeServeNewTabPageAd)
-      .WillOnce(::testing::Invoke([&deferred_maybe_serve_ad_callback](
-                                      MaybeServeNewTabPageAdCallback callback) {
+      .WillOnce([&deferred_maybe_serve_ad_callback](
+                    MaybeServeNewTabPageAdCallback callback) {
         deferred_maybe_serve_ad_callback = std::move(callback);
-      }));
+      });
 
   prefetcher().Prefetch();
 
@@ -175,10 +171,9 @@ TEST_F(BraveAdsNewTabPageAdPrefetcherTest, ShouldOnlyGetPrefetchedAdOnce) {
   const NewTabPageAdInfo expected_ad = BuildNewTabPageAd();
 
   EXPECT_CALL(ads_service(), MaybeServeNewTabPageAd)
-      .WillOnce(::testing::Invoke(
-          [&expected_ad](MaybeServeNewTabPageAdCallback callback) {
-            std::move(callback).Run(expected_ad);
-          }));
+      .WillOnce([&expected_ad](MaybeServeNewTabPageAdCallback callback) {
+        std::move(callback).Run(expected_ad);
+      });
 
   prefetcher().Prefetch();
   ASSERT_EQ(expected_ad, prefetcher().MaybeGetPrefetchedAd());
@@ -191,10 +186,10 @@ TEST_F(BraveAdsNewTabPageAdPrefetcherTest, CancelPrefetch) {
   // Arrange
   MaybeServeNewTabPageAdCallback deferred_maybe_serve_ad_callback;
   EXPECT_CALL(ads_service(), MaybeServeNewTabPageAd)
-      .WillOnce(::testing::Invoke([&deferred_maybe_serve_ad_callback](
-                                      MaybeServeNewTabPageAdCallback callback) {
+      .WillOnce([&deferred_maybe_serve_ad_callback](
+                    MaybeServeNewTabPageAdCallback callback) {
         deferred_maybe_serve_ad_callback = std::move(callback);
-      }));
+      });
 
   // Act
   prefetcher().Prefetch();

--- a/components/brave_ads/core/internal/account/issuers/issuers_unittest.cc
+++ b/components/brave_ads/core/internal/account/issuers/issuers_unittest.cc
@@ -78,10 +78,10 @@ TEST_F(BraveAdsIssuersTest,
   test::MockUrlResponses(ads_client_mock_, url_responses);
 
   ON_CALL(delegate_mock_, OnDidFetchIssuers)
-      .WillByDefault(::testing::Invoke([](const IssuersInfo& issuers) {
+      .WillByDefault([](const IssuersInfo& issuers) {
         // Set issuers to prevent further retries.
         SetIssuers(issuers);
-      }));
+      });
 
   // Act & Assert
   EXPECT_CALL(delegate_mock_, OnFailedToFetchIssuers);

--- a/components/brave_ads/core/internal/ad_units/notification_ad/notification_ad_for_mobile_test.cc
+++ b/components/brave_ads/core/internal/ad_units/notification_ad/notification_ad_for_mobile_test.cc
@@ -53,11 +53,11 @@ TEST_F(BraveAdsNotificationAdForMobileIntegrationTest,
   // Act & Assert
   base::RunLoop run_loop;
   EXPECT_CALL(ads_client_mock_, ShowNotificationAd)
-      .WillOnce(::testing::Invoke([&](const NotificationAdInfo& ad) {
+      .WillOnce([&](const NotificationAdInfo& ad) {
         EXPECT_TRUE(
             NotificationAdManager::GetInstance().Exists(ad.placement_id));
         run_loop.Quit();
-      }));
+      });
 
   ServeAd();
   run_loop.Run();
@@ -94,7 +94,7 @@ TEST_F(BraveAdsNotificationAdForMobileIntegrationTest, TriggerViewedEvent) {
 
   base::RunLoop run_loop;
   EXPECT_CALL(ads_client_mock_, ShowNotificationAd)
-      .WillOnce(::testing::Invoke([&](const NotificationAdInfo& ad) {
+      .WillOnce([&](const NotificationAdInfo& ad) {
         ASSERT_TRUE(
             NotificationAdManager::GetInstance().Exists(ad.placement_id));
 
@@ -113,7 +113,7 @@ TEST_F(BraveAdsNotificationAdForMobileIntegrationTest, TriggerViewedEvent) {
         EXPECT_TRUE(
             NotificationAdManager::GetInstance().Exists(ad.placement_id));
         run_loop.Quit();
-      }));
+      });
 
   ServeAd();
   run_loop.Run();
@@ -128,7 +128,7 @@ TEST_F(BraveAdsNotificationAdForMobileIntegrationTest, TriggerClickedEvent) {
 
   base::RunLoop run_loop;
   EXPECT_CALL(ads_client_mock_, ShowNotificationAd)
-      .WillOnce(::testing::Invoke([&](const NotificationAdInfo& ad) {
+      .WillOnce([&](const NotificationAdInfo& ad) {
         ASSERT_TRUE(
             NotificationAdManager::GetInstance().Exists(ad.placement_id));
 
@@ -149,7 +149,7 @@ TEST_F(BraveAdsNotificationAdForMobileIntegrationTest, TriggerClickedEvent) {
         EXPECT_FALSE(
             NotificationAdManager::GetInstance().Exists(ad.placement_id));
         run_loop.Quit();
-      }));
+      });
 
   ServeAd();
   run_loop.Run();
@@ -164,7 +164,7 @@ TEST_F(BraveAdsNotificationAdForMobileIntegrationTest, TriggerDismissedEvent) {
 
   base::RunLoop run_loop;
   EXPECT_CALL(ads_client_mock_, ShowNotificationAd)
-      .WillOnce(::testing::Invoke([&](const NotificationAdInfo& ad) {
+      .WillOnce([&](const NotificationAdInfo& ad) {
         ASSERT_TRUE(
             NotificationAdManager::GetInstance().Exists(ad.placement_id));
 
@@ -183,7 +183,7 @@ TEST_F(BraveAdsNotificationAdForMobileIntegrationTest, TriggerDismissedEvent) {
         EXPECT_FALSE(
             NotificationAdManager::GetInstance().Exists(ad.placement_id));
         run_loop.Quit();
-      }));
+      });
 
   ServeAd();
   run_loop.Run();
@@ -198,7 +198,7 @@ TEST_F(BraveAdsNotificationAdForMobileIntegrationTest, TriggerTimedOutEvent) {
 
   base::RunLoop run_loop;
   EXPECT_CALL(ads_client_mock_, ShowNotificationAd)
-      .WillOnce(::testing::Invoke([&](const NotificationAdInfo& ad) {
+      .WillOnce([&](const NotificationAdInfo& ad) {
         ASSERT_TRUE(
             NotificationAdManager::GetInstance().Exists(ad.placement_id));
 
@@ -217,7 +217,7 @@ TEST_F(BraveAdsNotificationAdForMobileIntegrationTest, TriggerTimedOutEvent) {
         EXPECT_FALSE(
             NotificationAdManager::GetInstance().Exists(ad.placement_id));
         run_loop.Quit();
-      }));
+      });
 
   ServeAd();
   run_loop.Run();

--- a/components/brave_ads/core/internal/ad_units/notification_ad/notification_ad_test.cc
+++ b/components/brave_ads/core/internal/ad_units/notification_ad/notification_ad_test.cc
@@ -88,7 +88,7 @@ TEST_F(BraveAdsNotificationAdIntegrationTest, TriggerViewedEvent) {
 
   base::RunLoop run_loop;
   EXPECT_CALL(ads_client_mock_, ShowNotificationAd)
-      .WillOnce(::testing::Invoke([&](const NotificationAdInfo& ad) {
+      .WillOnce([&](const NotificationAdInfo& ad) {
         ASSERT_TRUE(
             NotificationAdManager::GetInstance().Exists(ad.placement_id));
 
@@ -107,7 +107,7 @@ TEST_F(BraveAdsNotificationAdIntegrationTest, TriggerViewedEvent) {
         EXPECT_TRUE(
             NotificationAdManager::GetInstance().Exists(ad.placement_id));
         run_loop.Quit();
-      }));
+      });
 
   ServeAd();
   run_loop.Run();
@@ -122,7 +122,7 @@ TEST_F(BraveAdsNotificationAdIntegrationTest, TriggerClickedEvent) {
 
   base::RunLoop run_loop;
   EXPECT_CALL(ads_client_mock_, ShowNotificationAd)
-      .WillOnce(::testing::Invoke([&](const NotificationAdInfo& ad) {
+      .WillOnce([&](const NotificationAdInfo& ad) {
         ASSERT_TRUE(
             NotificationAdManager::GetInstance().Exists(ad.placement_id));
 
@@ -144,7 +144,7 @@ TEST_F(BraveAdsNotificationAdIntegrationTest, TriggerClickedEvent) {
         EXPECT_FALSE(
             NotificationAdManager::GetInstance().Exists(ad.placement_id));
         run_loop.Quit();
-      }));
+      });
 
   ServeAd();
   run_loop.Run();
@@ -159,7 +159,7 @@ TEST_F(BraveAdsNotificationAdIntegrationTest, TriggerDismissedEvent) {
 
   base::RunLoop run_loop;
   EXPECT_CALL(ads_client_mock_, ShowNotificationAd)
-      .WillOnce(::testing::Invoke([&](const NotificationAdInfo& ad) {
+      .WillOnce([&](const NotificationAdInfo& ad) {
         ASSERT_TRUE(
             NotificationAdManager::GetInstance().Exists(ad.placement_id));
 
@@ -178,7 +178,7 @@ TEST_F(BraveAdsNotificationAdIntegrationTest, TriggerDismissedEvent) {
         EXPECT_FALSE(
             NotificationAdManager::GetInstance().Exists(ad.placement_id));
         run_loop.Quit();
-      }));
+      });
 
   ServeAd();
   run_loop.Run();
@@ -193,7 +193,7 @@ TEST_F(BraveAdsNotificationAdIntegrationTest, TriggerTimedOutEvent) {
 
   base::RunLoop run_loop;
   EXPECT_CALL(ads_client_mock_, ShowNotificationAd)
-      .WillOnce(::testing::Invoke([&](const NotificationAdInfo& ad) {
+      .WillOnce([&](const NotificationAdInfo& ad) {
         ASSERT_TRUE(
             NotificationAdManager::GetInstance().Exists(ad.placement_id));
 
@@ -212,7 +212,7 @@ TEST_F(BraveAdsNotificationAdIntegrationTest, TriggerTimedOutEvent) {
         EXPECT_FALSE(
             NotificationAdManager::GetInstance().Exists(ad.placement_id));
         run_loop.Quit();
-      }));
+      });
 
   ServeAd();
   run_loop.Run();

--- a/components/brave_ads/core/internal/common/test/internal/mock_test_util_internal.cc
+++ b/components/brave_ads/core/internal/common/test/internal/mock_test_util_internal.cc
@@ -50,23 +50,21 @@ void MockContentSettings() {
 void MockAdsClientNotifierAddObserver(AdsClientMock& ads_client_mock,
                                       TestBase& test_base) {
   ON_CALL(ads_client_mock, AddObserver)
-      .WillByDefault(::testing::Invoke(
-          [&test_base](AdsClientNotifierObserver* const observer) {
-            CHECK(observer);
-            test_base.AddObserver(observer);
-          }));
+      .WillByDefault([&test_base](AdsClientNotifierObserver* const observer) {
+        CHECK(observer);
+        test_base.AddObserver(observer);
+      });
 }
 
 void MockNotifyPendingObservers(AdsClientMock& ads_client_mock,
                                 TestBase& test_base) {
   ON_CALL(ads_client_mock, NotifyPendingObservers)
-      .WillByDefault(::testing::Invoke(
-          [&test_base]() { test_base.NotifyPendingObservers(); }));
+      .WillByDefault([&test_base]() { test_base.NotifyPendingObservers(); });
 }
 
 void MockShowNotificationAd(AdsClientMock& ads_client_mock) {
   ON_CALL(ads_client_mock, ShowNotificationAd)
-      .WillByDefault(::testing::Invoke([](const NotificationAdInfo& ad) {
+      .WillByDefault([](const NotificationAdInfo& ad) {
         // TODO(https://github.com/brave/brave-browser/issues/29587): Decouple
         // reminders from push notification ads.
         const bool is_reminder_valid = !ad.placement_id.empty() &&
@@ -74,29 +72,28 @@ void MockShowNotificationAd(AdsClientMock& ads_client_mock) {
                                        ad.target_url.is_valid();
 
         CHECK(ad.IsValid() || is_reminder_valid);
-      }));
+      });
 }
 
 void MockCloseNotificationAd(AdsClientMock& ads_client_mock) {
   ON_CALL(ads_client_mock, CloseNotificationAd)
-      .WillByDefault(::testing::Invoke([](const std::string& placement_id) {
+      .WillByDefault([](const std::string& placement_id) {
         CHECK(!placement_id.empty());
-      }));
+      });
 }
 
 void MockSave(AdsClientMock& ads_client_mock) {
   ON_CALL(ads_client_mock, Save)
-      .WillByDefault(::testing::Invoke([](const std::string& /*name*/,
-                                          const std::string& /*value*/,
-                                          SaveCallback callback) {
+      .WillByDefault([](const std::string& /*name*/,
+                        const std::string& /*value*/, SaveCallback callback) {
         std::move(callback).Run(/*success=*/true);
-      }));
+      });
 }
 
 void MockLoad(AdsClientMock& ads_client_mock,
               const base::FilePath& profile_path) {
   ON_CALL(ads_client_mock, Load)
-      .WillByDefault(::testing::Invoke(
+      .WillByDefault(
           [&profile_path](const std::string& name, LoadCallback callback) {
             base::FilePath path = profile_path.AppendASCII(name);
             if (!base::PathExists(path)) {
@@ -111,103 +108,98 @@ void MockLoad(AdsClientMock& ads_client_mock,
             }
 
             std::move(callback).Run(value);
-          }));
+          });
 }
 
 void MockLoadResourceComponent(AdsClientMock& ads_client_mock,
                                const base::FilePath& profile_path) {
   ON_CALL(ads_client_mock, LoadResourceComponent)
-      .WillByDefault(::testing::Invoke(
-          [&profile_path](const std::string& id, int /*version*/,
-                          LoadFileCallback callback) {
-            base::FilePath path = profile_path.AppendASCII(id);
+      .WillByDefault([&profile_path](const std::string& id, int /*version*/,
+                                     LoadFileCallback callback) {
+        base::FilePath path = profile_path.AppendASCII(id);
 
-            if (!base::PathExists(path)) {
-              // If path does not exist attempt to load the file from the test
-              // resource components data path.
-              path = ResourceComponentsDataPath().AppendASCII(id);
-            }
+        if (!base::PathExists(path)) {
+          // If path does not exist attempt to load the file from the test
+          // resource components data path.
+          path = ResourceComponentsDataPath().AppendASCII(id);
+        }
 
-            base::File file(path, base::File::Flags::FLAG_OPEN |
-                                      base::File::Flags::FLAG_READ);
-            std::move(callback).Run(std::move(file));
-          }));
+        base::File file(
+            path, base::File::Flags::FLAG_OPEN | base::File::Flags::FLAG_READ);
+        std::move(callback).Run(std::move(file));
+      });
 }
 
 void MockFindProfilePref(const AdsClientMock& ads_client_mock) {
   ON_CALL(ads_client_mock, FindProfilePref)
-      .WillByDefault(::testing::Invoke([](const std::string& path) -> bool {
+      .WillByDefault([](const std::string& path) -> bool {
         return FindProfilePref(path);
-      }));
+      });
 }
 
 void MockGetProfilePref(const AdsClientMock& ads_client_mock) {
   ON_CALL(ads_client_mock, GetProfilePref)
-      .WillByDefault(::testing::Invoke(
-          [](const std::string& path) -> std::optional<base::Value> {
-            return GetProfilePrefValue(path);
-          }));
+      .WillByDefault([](const std::string& path) -> std::optional<base::Value> {
+        return GetProfilePrefValue(path);
+      });
 }
 
 void MockSetProfilePref(const AdsClientMock& ads_client_mock,
                         TestBase& test_base) {
   ON_CALL(ads_client_mock, SetProfilePref)
-      .WillByDefault(::testing::Invoke(
-          [&test_base](const std::string& path, base::Value value) {
-            SetProfilePrefValue(path, std::move(value));
-            test_base.NotifyPrefDidChange(path);
-          }));
+      .WillByDefault([&test_base](const std::string& path, base::Value value) {
+        SetProfilePrefValue(path, std::move(value));
+        test_base.NotifyPrefDidChange(path);
+      });
 }
 
 void MockClearProfilePref(AdsClientMock& ads_client_mock) {
   ON_CALL(ads_client_mock, ClearProfilePref)
-      .WillByDefault(::testing::Invoke(
-          [](const std::string& path) { ClearProfilePrefValue(path); }));
+      .WillByDefault(
+          [](const std::string& path) { ClearProfilePrefValue(path); });
 }
 
 void MockHasProfilePrefPath(const AdsClientMock& ads_client_mock) {
   ON_CALL(ads_client_mock, HasProfilePrefPath)
-      .WillByDefault(::testing::Invoke([](const std::string& path) -> bool {
+      .WillByDefault([](const std::string& path) -> bool {
         return HasProfilePrefPathValue(path);
-      }));
+      });
 }
 
 void MockFindLocalStatePref(const AdsClientMock& ads_client_mock) {
   ON_CALL(ads_client_mock, FindLocalStatePref)
-      .WillByDefault(::testing::Invoke([](const std::string& path) -> bool {
+      .WillByDefault([](const std::string& path) -> bool {
         return FindLocalStatePref(path);
-      }));
+      });
 }
 
 void MockGetLocalStatePref(const AdsClientMock& ads_client_mock) {
   ON_CALL(ads_client_mock, GetLocalStatePref)
-      .WillByDefault(::testing::Invoke(
-          [](const std::string& path) -> std::optional<base::Value> {
-            return GetLocalStatePrefValue(path);
-          }));
+      .WillByDefault([](const std::string& path) -> std::optional<base::Value> {
+        return GetLocalStatePrefValue(path);
+      });
 }
 
 void MockSetLocalStatePref(const AdsClientMock& ads_client_mock,
                            TestBase& test_base) {
   ON_CALL(ads_client_mock, SetLocalStatePref)
-      .WillByDefault(::testing::Invoke(
-          [&test_base](const std::string& path, base::Value value) {
-            SetLocalStatePrefValue(path, std::move(value));
-            test_base.NotifyPrefDidChange(path);
-          }));
+      .WillByDefault([&test_base](const std::string& path, base::Value value) {
+        SetLocalStatePrefValue(path, std::move(value));
+        test_base.NotifyPrefDidChange(path);
+      });
 }
 
 void MockClearLocalStatePref(AdsClientMock& ads_client_mock) {
   ON_CALL(ads_client_mock, ClearLocalStatePref)
-      .WillByDefault(::testing::Invoke(
-          [](const std::string& path) { ClearLocalStatePrefValue(path); }));
+      .WillByDefault(
+          [](const std::string& path) { ClearLocalStatePrefValue(path); });
 }
 
 void MockHasLocalStatePrefPath(const AdsClientMock& ads_client_mock) {
   ON_CALL(ads_client_mock, HasLocalStatePrefPath)
-      .WillByDefault(::testing::Invoke([](const std::string& path) -> bool {
+      .WillByDefault([](const std::string& path) -> bool {
         return HasLocalStatePrefPathValue(path);
-      }));
+      });
 }
 
 }  // namespace brave_ads::test

--- a/components/brave_ads/core/internal/common/test/mock_test_util.cc
+++ b/components/brave_ads/core/internal/common/test/mock_test_util.cc
@@ -156,19 +156,19 @@ void MockCanShowNotificationAdsWhileBrowserIsBackgrounded(
 void MockGetSiteHistory(const AdsClientMock& ads_client_mock,
                         const SiteHistoryList& site_history) {
   ON_CALL(ads_client_mock, GetSiteHistory)
-      .WillByDefault(::testing::Invoke(
-          [site_history](size_t max_count, size_t /*recent_day_range*/,
-                         GetSiteHistoryCallback callback) {
-            CHECK_LE(site_history.size(), max_count);
+      .WillByDefault([site_history](size_t max_count,
+                                    size_t /*recent_day_range*/,
+                                    GetSiteHistoryCallback callback) {
+        CHECK_LE(site_history.size(), max_count);
 
-            std::move(callback).Run(site_history);
-          }));
+        std::move(callback).Run(site_history);
+      });
 }
 
 void MockUrlResponses(const AdsClientMock& ads_client_mock,
                       const URLResponseMap& url_responses) {
   ON_CALL(ads_client_mock, UrlRequest)
-      .WillByDefault(::testing::Invoke(
+      .WillByDefault(
           [url_responses](const mojom::UrlRequestInfoPtr& mojom_url_request,
                           UrlRequestCallback callback) {
             std::optional<mojom::UrlResponseInfo> url_response =
@@ -179,7 +179,7 @@ void MockUrlResponses(const AdsClientMock& ads_client_mock,
             }
 
             std::move(callback).Run(*url_response);
-          }));
+          });
 }
 
 }  // namespace brave_ads::test

--- a/components/brave_ads/core/internal/targeting/behavioral/purchase_intent/resource/purchase_intent_resource_unittest.cc
+++ b/components/brave_ads/core/internal/targeting/behavioral/purchase_intent/resource/purchase_intent_resource_unittest.cc
@@ -69,9 +69,8 @@ TEST_F(BraveAdsPurchaseIntentResourceTest, DoNotLoadMissingResource) {
   ON_CALL(ads_client_mock_, LoadResourceComponent(kPurchaseIntentResourceId,
                                                   /*version=*/::testing::_,
                                                   /*callback=*/::testing::_))
-      .WillByDefault(::testing::Invoke([](const std::string& /*id*/,
-                                          int /*version*/,
-                                          LoadFileCallback callback) {
+      .WillByDefault([](const std::string& /*id*/, int /*version*/,
+                        LoadFileCallback callback) {
         const base::FilePath path =
             test::ResourceComponentsDataPath().AppendASCII(
                 test::kMissingResourceId);
@@ -79,7 +78,7 @@ TEST_F(BraveAdsPurchaseIntentResourceTest, DoNotLoadMissingResource) {
         base::File file(
             path, base::File::Flags::FLAG_OPEN | base::File::Flags::FLAG_READ);
         std::move(callback).Run(std::move(file));
-      }));
+      });
 
   NotifyResourceComponentDidChange(test::kCountryComponentManifestVersion,
                                    test::kCountryComponentId);

--- a/components/brave_ads/core/internal/targeting/contextual/text_classification/resource/text_classification_resource_unittest.cc
+++ b/components/brave_ads/core/internal/targeting/contextual/text_classification/resource/text_classification_resource_unittest.cc
@@ -69,9 +69,8 @@ TEST_F(BraveAdsTextClassificationResourceTest, DoNotLoadMissingResource) {
   ON_CALL(ads_client_mock_, LoadResourceComponent(kTextClassificationResourceId,
                                                   /*version=*/::testing::_,
                                                   /*callback=*/::testing::_))
-      .WillByDefault(::testing::Invoke([](const std::string& /*id*/,
-                                          int /*version*/,
-                                          LoadFileCallback callback) {
+      .WillByDefault([](const std::string& /*id*/, int /*version*/,
+                        LoadFileCallback callback) {
         const base::FilePath path =
             test::ResourceComponentsDataPath().AppendASCII(
                 test::kMissingResourceId);
@@ -79,7 +78,7 @@ TEST_F(BraveAdsTextClassificationResourceTest, DoNotLoadMissingResource) {
         base::File file(
             path, base::File::Flags::FLAG_OPEN | base::File::Flags::FLAG_READ);
         std::move(callback).Run(std::move(file));
-      }));
+      });
 
   NotifyResourceComponentDidChange(test::kLanguageComponentManifestVersion,
                                    test::kLanguageComponentId);

--- a/components/brave_wallet/browser/zcash/zcash_auto_sync_manager_unittest.cc
+++ b/components/brave_wallet/browser/zcash/zcash_auto_sync_manager_unittest.cc
@@ -101,12 +101,12 @@ class ZCashAutoSyncManagerTest : public testing::Test {
 TEST_F(ZCashAutoSyncManagerTest, InitialSync) {
   EXPECT_CALL(mock_zcash_wallet_service(), StartShieldSync(_, _, _));
   ON_CALL(mock_zcash_wallet_service(), GetChainTipStatus(_, _, _))
-      .WillByDefault(::testing::Invoke(
+      .WillByDefault(
           [](mojom::AccountIdPtr account_id, const std::string& chain_id,
              MockZCashWalletService::GetChainTipStatusCallback callback) {
             std::move(callback).Run(mojom::ZCashChainTipStatus::New(0, 1000),
                                     std::nullopt);
-          }));
+          });
 
   EXPECT_FALSE(zcash_auto_sync_manager().IsStarted());
   zcash_auto_sync_manager().Start();
@@ -117,12 +117,12 @@ TEST_F(ZCashAutoSyncManagerTest, InitialSync) {
 TEST_F(ZCashAutoSyncManagerTest, TimerHit) {
   EXPECT_CALL(mock_zcash_wallet_service(), StartShieldSync(_, _, _)).Times(2);
   ON_CALL(mock_zcash_wallet_service(), GetChainTipStatus(_, _, _))
-      .WillByDefault(::testing::Invoke(
+      .WillByDefault(
           [](mojom::AccountIdPtr account_id, const std::string& chain_id,
              MockZCashWalletService::GetChainTipStatusCallback callback) {
             std::move(callback).Run(mojom::ZCashChainTipStatus::New(0, 1000),
                                     std::nullopt);
-          }));
+          });
 
   EXPECT_FALSE(zcash_auto_sync_manager().IsStarted());
   zcash_auto_sync_manager().Start();

--- a/components/brave_wallet/browser/zcash/zcash_blocks_batch_scan_task_unittest.cc
+++ b/components/brave_wallet/browser/zcash/zcash_blocks_batch_scan_task_unittest.cc
@@ -78,17 +78,17 @@ class ZCashBlocksBatchScanTest : public testing::Test {
 
   void InitZCashRpc() {
     ON_CALL(zcash_rpc(), GetTreeState(_, _, _))
-        .WillByDefault(::testing::Invoke(
+        .WillByDefault(
             [](const std::string& chain_id, zcash::mojom::BlockIDPtr block,
                ZCashRpc::GetTreeStateCallback callback) {
               // Valid tree state
               auto tree_state = zcash::mojom::TreeState::New(
                   chain_id, block->height, "aabb", 0, "", "");
               std::move(callback).Run(std::move(tree_state));
-            }));
+            });
 
     ON_CALL(zcash_rpc(), GetCompactBlocks(_, _, _, _))
-        .WillByDefault(::testing::Invoke(
+        .WillByDefault(
             [](const std::string& chain_id, uint32_t from, uint32_t to,
                ZCashRpc::GetCompactBlocksCallback callback) {
               // Only 600 blocks available
@@ -108,7 +108,7 @@ class ZCashBlocksBatchScanTest : public testing::Test {
                     std::move(chain_metadata)));
               }
               std::move(callback).Run(std::move(blocks));
-            }));
+            });
   }
 
   ZCashActionContext CreateContext() {
@@ -374,11 +374,10 @@ TEST_F(ZCashBlocksBatchScanTest, Error_PartialDecoding) {
 
 TEST_F(ZCashBlocksBatchScanTest, NetworkError_Blocks) {
   ON_CALL(zcash_rpc(), GetCompactBlocks(_, _, _, _))
-      .WillByDefault(::testing::Invoke(
-          [](const std::string& chain_id, uint32_t from, uint32_t to,
-             ZCashRpc::GetCompactBlocksCallback callback) {
-            std::move(callback).Run(base::unexpected("error"));
-          }));
+      .WillByDefault([](const std::string& chain_id, uint32_t from, uint32_t to,
+                        ZCashRpc::GetCompactBlocksCallback callback) {
+        std::move(callback).Run(base::unexpected("error"));
+      });
 
   auto block_scanner = CreateMockOrchardBlockScannerProxy();
   ZCashActionContext context = CreateContext();
@@ -401,11 +400,11 @@ TEST_F(ZCashBlocksBatchScanTest, NetworkError_Blocks) {
 
 TEST_F(ZCashBlocksBatchScanTest, NetworkError_TreeState) {
   ON_CALL(zcash_rpc(), GetTreeState(_, _, _))
-      .WillByDefault(::testing::Invoke(
-          [](const std::string& chain_id, zcash::mojom::BlockIDPtr block,
-             ZCashRpc::GetTreeStateCallback callback) {
-            std::move(callback).Run(base::unexpected("error"));
-          }));
+      .WillByDefault([](const std::string& chain_id,
+                        zcash::mojom::BlockIDPtr block,
+                        ZCashRpc::GetTreeStateCallback callback) {
+        std::move(callback).Run(base::unexpected("error"));
+      });
 
   auto block_scanner = CreateMockOrchardBlockScannerProxy();
   ZCashActionContext context = CreateContext();

--- a/components/brave_wallet/browser/zcash/zcash_create_orchard_to_orchard_transaction_task_unittest.cc
+++ b/components/brave_wallet/browser/zcash/zcash_create_orchard_to_orchard_transaction_task_unittest.cc
@@ -155,27 +155,26 @@ class ZCashCreateOrchardToOrchardTransactionTaskTest : public testing::Test {
 
 TEST_F(ZCashCreateOrchardToOrchardTransactionTaskTest, TransactionCreated) {
   ON_CALL(mock_orchard_sync_state(), GetSpendableNotes(_, _))
-      .WillByDefault(
-          ::testing::Invoke([&](const mojom::AccountIdPtr& account_id,
-                                const OrchardAddrRawPart& addr) {
-            OrchardSyncState::SpendableNotesBundle spendable_notes_bundle;
-            {
-              OrchardNote note;
-              note.block_id = 1u;
-              note.amount = 70000u;
-              spendable_notes_bundle.spendable_notes.push_back(std::move(note));
-            }
+      .WillByDefault([&](const mojom::AccountIdPtr& account_id,
+                         const OrchardAddrRawPart& addr) {
+        OrchardSyncState::SpendableNotesBundle spendable_notes_bundle;
+        {
+          OrchardNote note;
+          note.block_id = 1u;
+          note.amount = 70000u;
+          spendable_notes_bundle.spendable_notes.push_back(std::move(note));
+        }
 
-            {
-              OrchardNote note;
-              note.block_id = 2u;
-              note.amount = 80000u;
-              spendable_notes_bundle.spendable_notes.push_back(std::move(note));
-            }
-            spendable_notes_bundle.anchor_block_id = 10u;
+        {
+          OrchardNote note;
+          note.block_id = 2u;
+          note.amount = 80000u;
+          spendable_notes_bundle.spendable_notes.push_back(std::move(note));
+        }
+        spendable_notes_bundle.anchor_block_id = 10u;
 
-            return spendable_notes_bundle;
-          }));
+        return spendable_notes_bundle;
+      });
 
   base::MockCallback<ZCashWalletService::CreateTransactionCallback> callback;
 
@@ -224,27 +223,26 @@ TEST_F(ZCashCreateOrchardToOrchardTransactionTaskTest, TransactionCreated) {
 TEST_F(ZCashCreateOrchardToOrchardTransactionTaskTest,
        TransactionCreated_u64Check) {
   ON_CALL(mock_orchard_sync_state(), GetSpendableNotes(_, _))
-      .WillByDefault(
-          ::testing::Invoke([&](const mojom::AccountIdPtr& account_id,
-                                const OrchardAddrRawPart& addr) {
-            OrchardSyncState::SpendableNotesBundle spendable_notes_bundle;
-            {
-              OrchardNote note;
-              note.block_id = 1u;
-              note.amount = 70000000000u;
-              spendable_notes_bundle.spendable_notes.push_back(std::move(note));
-            }
+      .WillByDefault([&](const mojom::AccountIdPtr& account_id,
+                         const OrchardAddrRawPart& addr) {
+        OrchardSyncState::SpendableNotesBundle spendable_notes_bundle;
+        {
+          OrchardNote note;
+          note.block_id = 1u;
+          note.amount = 70000000000u;
+          spendable_notes_bundle.spendable_notes.push_back(std::move(note));
+        }
 
-            {
-              OrchardNote note;
-              note.block_id = 2u;
-              note.amount = 80000000000u;
-              spendable_notes_bundle.spendable_notes.push_back(std::move(note));
-            }
-            spendable_notes_bundle.anchor_block_id = 10u;
+        {
+          OrchardNote note;
+          note.block_id = 2u;
+          note.amount = 80000000000u;
+          spendable_notes_bundle.spendable_notes.push_back(std::move(note));
+        }
+        spendable_notes_bundle.anchor_block_id = 10u;
 
-            return spendable_notes_bundle;
-          }));
+        return spendable_notes_bundle;
+      });
 
   base::MockCallback<ZCashWalletService::CreateTransactionCallback> callback;
 
@@ -296,27 +294,26 @@ TEST_F(ZCashCreateOrchardToOrchardTransactionTaskTest,
 TEST_F(ZCashCreateOrchardToOrchardTransactionTaskTest,
        TransactionCreated_OverflowCheck_FullAmount) {
   ON_CALL(mock_orchard_sync_state(), GetSpendableNotes(_, _))
-      .WillByDefault(
-          ::testing::Invoke([&](const mojom::AccountIdPtr& account_id,
-                                const OrchardAddrRawPart& addr) {
-            OrchardSyncState::SpendableNotesBundle spendable_notes_bundle;
-            {
-              OrchardNote note;
-              note.block_id = 1u;
-              note.amount = 0xFFFFFFFFFFFFFFFFu;
-              spendable_notes_bundle.spendable_notes.push_back(std::move(note));
-            }
+      .WillByDefault([&](const mojom::AccountIdPtr& account_id,
+                         const OrchardAddrRawPart& addr) {
+        OrchardSyncState::SpendableNotesBundle spendable_notes_bundle;
+        {
+          OrchardNote note;
+          note.block_id = 1u;
+          note.amount = 0xFFFFFFFFFFFFFFFFu;
+          spendable_notes_bundle.spendable_notes.push_back(std::move(note));
+        }
 
-            {
-              OrchardNote note;
-              note.block_id = 2u;
-              note.amount = 0x2222222222222222u;
-              spendable_notes_bundle.spendable_notes.push_back(std::move(note));
-            }
-            spendable_notes_bundle.anchor_block_id = 10u;
+        {
+          OrchardNote note;
+          note.block_id = 2u;
+          note.amount = 0x2222222222222222u;
+          spendable_notes_bundle.spendable_notes.push_back(std::move(note));
+        }
+        spendable_notes_bundle.anchor_block_id = 10u;
 
-            return spendable_notes_bundle;
-          }));
+        return spendable_notes_bundle;
+      });
 
   base::MockCallback<ZCashWalletService::CreateTransactionCallback> callback;
 
@@ -348,27 +345,26 @@ TEST_F(ZCashCreateOrchardToOrchardTransactionTaskTest,
 TEST_F(ZCashCreateOrchardToOrchardTransactionTaskTest,
        TransactionCreated_OverflowCheck_CustomAmount) {
   ON_CALL(mock_orchard_sync_state(), GetSpendableNotes(_, _))
-      .WillByDefault(
-          ::testing::Invoke([&](const mojom::AccountIdPtr& account_id,
-                                const OrchardAddrRawPart& addr) {
-            OrchardSyncState::SpendableNotesBundle spendable_notes_bundle;
-            {
-              OrchardNote note;
-              note.block_id = 1u;
-              note.amount = 0xFFFFFFFFFFFFFFFFu;
-              spendable_notes_bundle.spendable_notes.push_back(std::move(note));
-            }
+      .WillByDefault([&](const mojom::AccountIdPtr& account_id,
+                         const OrchardAddrRawPart& addr) {
+        OrchardSyncState::SpendableNotesBundle spendable_notes_bundle;
+        {
+          OrchardNote note;
+          note.block_id = 1u;
+          note.amount = 0xFFFFFFFFFFFFFFFFu;
+          spendable_notes_bundle.spendable_notes.push_back(std::move(note));
+        }
 
-            {
-              OrchardNote note;
-              note.block_id = 2u;
-              note.amount = 0x2222222222222222u;
-              spendable_notes_bundle.spendable_notes.push_back(std::move(note));
-            }
-            spendable_notes_bundle.anchor_block_id = 10u;
+        {
+          OrchardNote note;
+          note.block_id = 2u;
+          note.amount = 0x2222222222222222u;
+          spendable_notes_bundle.spendable_notes.push_back(std::move(note));
+        }
+        spendable_notes_bundle.anchor_block_id = 10u;
 
-            return spendable_notes_bundle;
-          }));
+        return spendable_notes_bundle;
+      });
 
   base::MockCallback<ZCashWalletService::CreateTransactionCallback> callback;
 
@@ -400,27 +396,26 @@ TEST_F(ZCashCreateOrchardToOrchardTransactionTaskTest,
 TEST_F(ZCashCreateOrchardToOrchardTransactionTaskTest,
        TransactionCreated_MaxAmount) {
   ON_CALL(mock_orchard_sync_state(), GetSpendableNotes(_, _))
-      .WillByDefault(
-          ::testing::Invoke([&](const mojom::AccountIdPtr& account_id,
-                                const OrchardAddrRawPart& addr) {
-            OrchardSyncState::SpendableNotesBundle spendable_notes_bundle;
-            {
-              OrchardNote note;
-              note.block_id = 1u;
-              note.amount = 70000u;
-              spendable_notes_bundle.spendable_notes.push_back(std::move(note));
-            }
+      .WillByDefault([&](const mojom::AccountIdPtr& account_id,
+                         const OrchardAddrRawPart& addr) {
+        OrchardSyncState::SpendableNotesBundle spendable_notes_bundle;
+        {
+          OrchardNote note;
+          note.block_id = 1u;
+          note.amount = 70000u;
+          spendable_notes_bundle.spendable_notes.push_back(std::move(note));
+        }
 
-            {
-              OrchardNote note;
-              note.block_id = 2u;
-              note.amount = 80000u;
-              spendable_notes_bundle.spendable_notes.push_back(std::move(note));
-            }
-            spendable_notes_bundle.anchor_block_id = 10u;
+        {
+          OrchardNote note;
+          note.block_id = 2u;
+          note.amount = 80000u;
+          spendable_notes_bundle.spendable_notes.push_back(std::move(note));
+        }
+        spendable_notes_bundle.anchor_block_id = 10u;
 
-            return spendable_notes_bundle;
-          }));
+        return spendable_notes_bundle;
+      });
 
   base::MockCallback<ZCashWalletService::CreateTransactionCallback> callback;
 
@@ -465,27 +460,26 @@ TEST_F(ZCashCreateOrchardToOrchardTransactionTaskTest,
 TEST_F(ZCashCreateOrchardToOrchardTransactionTaskTest,
        TransactionCreated_MaxAmount_OverflowCheck) {
   ON_CALL(mock_orchard_sync_state(), GetSpendableNotes(_, _))
-      .WillByDefault(
-          ::testing::Invoke([&](const mojom::AccountIdPtr& account_id,
-                                const OrchardAddrRawPart& addr) {
-            OrchardSyncState::SpendableNotesBundle spendable_notes_bundle;
-            {
-              OrchardNote note;
-              note.block_id = 1u;
-              note.amount = 70000000000u;
-              spendable_notes_bundle.spendable_notes.push_back(std::move(note));
-            }
+      .WillByDefault([&](const mojom::AccountIdPtr& account_id,
+                         const OrchardAddrRawPart& addr) {
+        OrchardSyncState::SpendableNotesBundle spendable_notes_bundle;
+        {
+          OrchardNote note;
+          note.block_id = 1u;
+          note.amount = 70000000000u;
+          spendable_notes_bundle.spendable_notes.push_back(std::move(note));
+        }
 
-            {
-              OrchardNote note;
-              note.block_id = 2u;
-              note.amount = 80000000000u;
-              spendable_notes_bundle.spendable_notes.push_back(std::move(note));
-            }
-            spendable_notes_bundle.anchor_block_id = 10u;
+        {
+          OrchardNote note;
+          note.block_id = 2u;
+          note.amount = 80000000000u;
+          spendable_notes_bundle.spendable_notes.push_back(std::move(note));
+        }
+        spendable_notes_bundle.anchor_block_id = 10u;
 
-            return spendable_notes_bundle;
-          }));
+        return spendable_notes_bundle;
+      });
 
   base::MockCallback<ZCashWalletService::CreateTransactionCallback> callback;
 
@@ -532,26 +526,25 @@ TEST_F(ZCashCreateOrchardToOrchardTransactionTaskTest,
 
 TEST_F(ZCashCreateOrchardToOrchardTransactionTaskTest, NotEnoughFunds) {
   ON_CALL(mock_orchard_sync_state(), GetSpendableNotes(_, _))
-      .WillByDefault(
-          ::testing::Invoke([&](const mojom::AccountIdPtr& account_id,
-                                const OrchardAddrRawPart& internal_address) {
-            OrchardSyncState::SpendableNotesBundle spendable_notes_bundle;
-            {
-              OrchardNote note;
-              note.block_id = 1u;
-              note.amount = 70000u;
-              spendable_notes_bundle.spendable_notes.push_back(std::move(note));
-            }
+      .WillByDefault([&](const mojom::AccountIdPtr& account_id,
+                         const OrchardAddrRawPart& internal_address) {
+        OrchardSyncState::SpendableNotesBundle spendable_notes_bundle;
+        {
+          OrchardNote note;
+          note.block_id = 1u;
+          note.amount = 70000u;
+          spendable_notes_bundle.spendable_notes.push_back(std::move(note));
+        }
 
-            {
-              OrchardNote note;
-              note.block_id = 2u;
-              note.amount = 80000u;
-              spendable_notes_bundle.spendable_notes.push_back(std::move(note));
-            }
+        {
+          OrchardNote note;
+          note.block_id = 2u;
+          note.amount = 80000u;
+          spendable_notes_bundle.spendable_notes.push_back(std::move(note));
+        }
 
-            return spendable_notes_bundle;
-          }));
+        return spendable_notes_bundle;
+      });
 
   base::MockCallback<ZCashWalletService::CreateTransactionCallback> callback;
 
@@ -583,11 +576,11 @@ TEST_F(ZCashCreateOrchardToOrchardTransactionTaskTest, NotEnoughFunds) {
 TEST_F(ZCashCreateOrchardToOrchardTransactionTaskTest, Error) {
   ON_CALL(mock_orchard_sync_state(), GetSpendableNotes(_, _))
       .WillByDefault(
-          ::testing::Invoke([&](const mojom::AccountIdPtr& account_id,
-                                const OrchardAddrRawPart& internal_addr) {
+          [&](const mojom::AccountIdPtr& account_id,
+              const OrchardAddrRawPart& internal_addr) {
             return base::unexpected(OrchardStorage::Error{
                 OrchardStorage::ErrorCode::kConsistencyError, ""});
-          }));
+          });
 
   base::MockCallback<ZCashWalletService::CreateTransactionCallback> callback;
 

--- a/components/brave_wallet/browser/zcash/zcash_create_transparent_to_orchard_transaction_task_unittest.cc
+++ b/components/brave_wallet/browser/zcash/zcash_create_transparent_to_orchard_transaction_task_unittest.cc
@@ -174,33 +174,31 @@ class ZCashCreateTransparentToOrchardTransactionTaskTest
 
 TEST_F(ZCashCreateTransparentToOrchardTransactionTaskTest, TransactionCreated) {
   ON_CALL(zcash_wallet_service(), GetUtxos(_, _, _))
-      .WillByDefault(
-          ::testing::Invoke([&](const std::string& chain_id,
-                                const mojom::AccountIdPtr& account_id,
-                                ZCashWalletService::GetUtxosCallback callback) {
-            ZCashWalletService::UtxoMap utxo_map;
-            utxo_map["60000"] = GetZCashUtxo(60000);
-            utxo_map["70000"] = GetZCashUtxo(70000);
-            utxo_map["80000"] = GetZCashUtxo(80000);
-            std::move(callback).Run(std::move(utxo_map));
-          }));
+      .WillByDefault([&](const std::string& chain_id,
+                         const mojom::AccountIdPtr& account_id,
+                         ZCashWalletService::GetUtxosCallback callback) {
+        ZCashWalletService::UtxoMap utxo_map;
+        utxo_map["60000"] = GetZCashUtxo(60000);
+        utxo_map["70000"] = GetZCashUtxo(70000);
+        utxo_map["80000"] = GetZCashUtxo(80000);
+        std::move(callback).Run(std::move(utxo_map));
+      });
 
   ON_CALL(zcash_wallet_service(), DiscoverNextUnusedAddress(_, _, _))
-      .WillByDefault(::testing::Invoke(
+      .WillByDefault(
           [&](const mojom::AccountIdPtr& account_id, bool change,
               ZCashWalletService::DiscoverNextUnusedAddressCallback callback) {
             auto id = mojom::ZCashKeyId::New(account_id->account_index, 1, 0);
             auto addr = keyring_service().GetZCashAddress(account_id, *id);
             std::move(callback).Run(std::move(addr));
-          }));
+          });
 
   ON_CALL(mock_zcash_rpc(), GetLatestBlock(_, _))
-      .WillByDefault(
-          ::testing::Invoke([](const std::string& chain_id,
-                               ZCashRpc::GetLatestBlockCallback callback) {
-            std::move(callback).Run(
-                zcash::mojom::BlockID::New(1000u, std::vector<uint8_t>({})));
-          }));
+      .WillByDefault([](const std::string& chain_id,
+                        ZCashRpc::GetLatestBlockCallback callback) {
+        std::move(callback).Run(
+            zcash::mojom::BlockID::New(1000u, std::vector<uint8_t>({})));
+      });
 
   base::MockCallback<ZCashWalletService::CreateTransactionCallback> callback;
 
@@ -246,32 +244,30 @@ TEST_F(ZCashCreateTransparentToOrchardTransactionTaskTest, TransactionCreated) {
 TEST_F(ZCashCreateTransparentToOrchardTransactionTaskTest,
        TransactionCreated_u64Check) {
   ON_CALL(zcash_wallet_service(), GetUtxos(_, _, _))
-      .WillByDefault(
-          ::testing::Invoke([&](const std::string& chain_id,
-                                const mojom::AccountIdPtr& account_id,
-                                ZCashWalletService::GetUtxosCallback callback) {
-            ZCashWalletService::UtxoMap utxo_map;
-            utxo_map["10000000000"] = GetZCashUtxo(10000000000u);
-            utxo_map["20000000000"] = GetZCashUtxo(20000000000u);
-            std::move(callback).Run(std::move(utxo_map));
-          }));
+      .WillByDefault([&](const std::string& chain_id,
+                         const mojom::AccountIdPtr& account_id,
+                         ZCashWalletService::GetUtxosCallback callback) {
+        ZCashWalletService::UtxoMap utxo_map;
+        utxo_map["10000000000"] = GetZCashUtxo(10000000000u);
+        utxo_map["20000000000"] = GetZCashUtxo(20000000000u);
+        std::move(callback).Run(std::move(utxo_map));
+      });
 
   ON_CALL(zcash_wallet_service(), DiscoverNextUnusedAddress(_, _, _))
-      .WillByDefault(::testing::Invoke(
+      .WillByDefault(
           [&](const mojom::AccountIdPtr& account_id, bool change,
               ZCashWalletService::DiscoverNextUnusedAddressCallback callback) {
             auto id = mojom::ZCashKeyId::New(account_id->account_index, 1, 0);
             auto addr = keyring_service().GetZCashAddress(account_id, *id);
             std::move(callback).Run(std::move(addr));
-          }));
+          });
 
   ON_CALL(mock_zcash_rpc(), GetLatestBlock(_, _))
-      .WillByDefault(
-          ::testing::Invoke([](const std::string& chain_id,
-                               ZCashRpc::GetLatestBlockCallback callback) {
-            std::move(callback).Run(
-                zcash::mojom::BlockID::New(1000u, std::vector<uint8_t>({})));
-          }));
+      .WillByDefault([](const std::string& chain_id,
+                        ZCashRpc::GetLatestBlockCallback callback) {
+        std::move(callback).Run(
+            zcash::mojom::BlockID::New(1000u, std::vector<uint8_t>({})));
+      });
 
   base::MockCallback<ZCashWalletService::CreateTransactionCallback> callback;
 
@@ -318,33 +314,30 @@ TEST_F(ZCashCreateTransparentToOrchardTransactionTaskTest,
 TEST_F(ZCashCreateTransparentToOrchardTransactionTaskTest,
        TransactionCreated_OverflowCheck_CustomValue) {
   ON_CALL(zcash_wallet_service(), GetUtxos(_, _, _))
-      .WillByDefault(
-          ::testing::Invoke([&](const std::string& chain_id,
-                                const mojom::AccountIdPtr& account_id,
-                                ZCashWalletService::GetUtxosCallback callback) {
-            ZCashWalletService::UtxoMap utxo_map;
-            utxo_map["18446744073709551615"] =
-                GetZCashUtxo(18446744073709551615u);
-            utxo_map["20000000000"] = GetZCashUtxo(20000000000u);
-            std::move(callback).Run(std::move(utxo_map));
-          }));
+      .WillByDefault([&](const std::string& chain_id,
+                         const mojom::AccountIdPtr& account_id,
+                         ZCashWalletService::GetUtxosCallback callback) {
+        ZCashWalletService::UtxoMap utxo_map;
+        utxo_map["18446744073709551615"] = GetZCashUtxo(18446744073709551615u);
+        utxo_map["20000000000"] = GetZCashUtxo(20000000000u);
+        std::move(callback).Run(std::move(utxo_map));
+      });
 
   ON_CALL(zcash_wallet_service(), DiscoverNextUnusedAddress(_, _, _))
-      .WillByDefault(::testing::Invoke(
+      .WillByDefault(
           [&](const mojom::AccountIdPtr& account_id, bool change,
               ZCashWalletService::DiscoverNextUnusedAddressCallback callback) {
             auto id = mojom::ZCashKeyId::New(account_id->account_index, 1, 0);
             auto addr = keyring_service().GetZCashAddress(account_id, *id);
             std::move(callback).Run(std::move(addr));
-          }));
+          });
 
   ON_CALL(mock_zcash_rpc(), GetLatestBlock(_, _))
-      .WillByDefault(
-          ::testing::Invoke([](const std::string& chain_id,
-                               ZCashRpc::GetLatestBlockCallback callback) {
-            std::move(callback).Run(
-                zcash::mojom::BlockID::New(1000u, std::vector<uint8_t>({})));
-          }));
+      .WillByDefault([](const std::string& chain_id,
+                        ZCashRpc::GetLatestBlockCallback callback) {
+        std::move(callback).Run(
+            zcash::mojom::BlockID::New(1000u, std::vector<uint8_t>({})));
+      });
 
   base::MockCallback<ZCashWalletService::CreateTransactionCallback> callback;
 
@@ -371,33 +364,30 @@ TEST_F(ZCashCreateTransparentToOrchardTransactionTaskTest,
 TEST_F(ZCashCreateTransparentToOrchardTransactionTaskTest,
        TransactionCreated_OverflowCheck) {
   ON_CALL(zcash_wallet_service(), GetUtxos(_, _, _))
-      .WillByDefault(
-          ::testing::Invoke([&](const std::string& chain_id,
-                                const mojom::AccountIdPtr& account_id,
-                                ZCashWalletService::GetUtxosCallback callback) {
-            ZCashWalletService::UtxoMap utxo_map;
-            utxo_map["18446744073709551615"] =
-                GetZCashUtxo(18446744073709551615u);
-            utxo_map["20000000000"] = GetZCashUtxo(20000000000u);
-            std::move(callback).Run(std::move(utxo_map));
-          }));
+      .WillByDefault([&](const std::string& chain_id,
+                         const mojom::AccountIdPtr& account_id,
+                         ZCashWalletService::GetUtxosCallback callback) {
+        ZCashWalletService::UtxoMap utxo_map;
+        utxo_map["18446744073709551615"] = GetZCashUtxo(18446744073709551615u);
+        utxo_map["20000000000"] = GetZCashUtxo(20000000000u);
+        std::move(callback).Run(std::move(utxo_map));
+      });
 
   ON_CALL(zcash_wallet_service(), DiscoverNextUnusedAddress(_, _, _))
-      .WillByDefault(::testing::Invoke(
+      .WillByDefault(
           [&](const mojom::AccountIdPtr& account_id, bool change,
               ZCashWalletService::DiscoverNextUnusedAddressCallback callback) {
             auto id = mojom::ZCashKeyId::New(account_id->account_index, 1, 0);
             auto addr = keyring_service().GetZCashAddress(account_id, *id);
             std::move(callback).Run(std::move(addr));
-          }));
+          });
 
   ON_CALL(mock_zcash_rpc(), GetLatestBlock(_, _))
-      .WillByDefault(
-          ::testing::Invoke([](const std::string& chain_id,
-                               ZCashRpc::GetLatestBlockCallback callback) {
-            std::move(callback).Run(
-                zcash::mojom::BlockID::New(1000u, std::vector<uint8_t>({})));
-          }));
+      .WillByDefault([](const std::string& chain_id,
+                        ZCashRpc::GetLatestBlockCallback callback) {
+        std::move(callback).Run(
+            zcash::mojom::BlockID::New(1000u, std::vector<uint8_t>({})));
+      });
 
   base::MockCallback<ZCashWalletService::CreateTransactionCallback> callback;
 
@@ -424,33 +414,31 @@ TEST_F(ZCashCreateTransparentToOrchardTransactionTaskTest,
 TEST_F(ZCashCreateTransparentToOrchardTransactionTaskTest,
        TransactionCreated_MaxAmount) {
   ON_CALL(zcash_wallet_service(), GetUtxos(_, _, _))
-      .WillByDefault(
-          ::testing::Invoke([&](const std::string& chain_id,
-                                const mojom::AccountIdPtr& account_id,
-                                ZCashWalletService::GetUtxosCallback callback) {
-            ZCashWalletService::UtxoMap utxo_map;
-            utxo_map["60000"] = GetZCashUtxo(60000);
-            utxo_map["70000"] = GetZCashUtxo(70000);
-            utxo_map["80000"] = GetZCashUtxo(80000);
-            std::move(callback).Run(std::move(utxo_map));
-          }));
+      .WillByDefault([&](const std::string& chain_id,
+                         const mojom::AccountIdPtr& account_id,
+                         ZCashWalletService::GetUtxosCallback callback) {
+        ZCashWalletService::UtxoMap utxo_map;
+        utxo_map["60000"] = GetZCashUtxo(60000);
+        utxo_map["70000"] = GetZCashUtxo(70000);
+        utxo_map["80000"] = GetZCashUtxo(80000);
+        std::move(callback).Run(std::move(utxo_map));
+      });
 
   ON_CALL(zcash_wallet_service(), DiscoverNextUnusedAddress(_, _, _))
-      .WillByDefault(::testing::Invoke(
+      .WillByDefault(
           [&](const mojom::AccountIdPtr& account_id, bool change,
               ZCashWalletService::DiscoverNextUnusedAddressCallback callback) {
             auto id = mojom::ZCashKeyId::New(account_id->account_index, 1, 0);
             auto addr = keyring_service().GetZCashAddress(account_id, *id);
             std::move(callback).Run(std::move(addr));
-          }));
+          });
 
   ON_CALL(mock_zcash_rpc(), GetLatestBlock(_, _))
-      .WillByDefault(
-          ::testing::Invoke([](const std::string& chain_id,
-                               ZCashRpc::GetLatestBlockCallback callback) {
-            std::move(callback).Run(
-                zcash::mojom::BlockID::New(1000u, std::vector<uint8_t>({})));
-          }));
+      .WillByDefault([](const std::string& chain_id,
+                        ZCashRpc::GetLatestBlockCallback callback) {
+        std::move(callback).Run(
+            zcash::mojom::BlockID::New(1000u, std::vector<uint8_t>({})));
+      });
 
   base::MockCallback<ZCashWalletService::CreateTransactionCallback> callback;
 
@@ -490,31 +478,29 @@ TEST_F(ZCashCreateTransparentToOrchardTransactionTaskTest,
 TEST_F(ZCashCreateTransparentToOrchardTransactionTaskTest,
        TransactionCreated_MaxAmount_OverflowCheck) {
   ON_CALL(zcash_wallet_service(), GetUtxos(_, _, _))
-      .WillByDefault(
-          ::testing::Invoke([&](const std::string& chain_id,
-                                const mojom::AccountIdPtr& account_id,
-                                ZCashWalletService::GetUtxosCallback callback) {
-            ZCashWalletService::UtxoMap utxo_map;
-            utxo_map["10000000000"] = GetZCashUtxo(10000000000);
-            std::move(callback).Run(std::move(utxo_map));
-          }));
+      .WillByDefault([&](const std::string& chain_id,
+                         const mojom::AccountIdPtr& account_id,
+                         ZCashWalletService::GetUtxosCallback callback) {
+        ZCashWalletService::UtxoMap utxo_map;
+        utxo_map["10000000000"] = GetZCashUtxo(10000000000);
+        std::move(callback).Run(std::move(utxo_map));
+      });
 
   ON_CALL(zcash_wallet_service(), DiscoverNextUnusedAddress(_, _, _))
-      .WillByDefault(::testing::Invoke(
+      .WillByDefault(
           [&](const mojom::AccountIdPtr& account_id, bool change,
               ZCashWalletService::DiscoverNextUnusedAddressCallback callback) {
             auto id = mojom::ZCashKeyId::New(account_id->account_index, 1, 0);
             auto addr = keyring_service().GetZCashAddress(account_id, *id);
             std::move(callback).Run(std::move(addr));
-          }));
+          });
 
   ON_CALL(mock_zcash_rpc(), GetLatestBlock(_, _))
-      .WillByDefault(
-          ::testing::Invoke([](const std::string& chain_id,
-                               ZCashRpc::GetLatestBlockCallback callback) {
-            std::move(callback).Run(
-                zcash::mojom::BlockID::New(1000u, std::vector<uint8_t>({})));
-          }));
+      .WillByDefault([](const std::string& chain_id,
+                        ZCashRpc::GetLatestBlockCallback callback) {
+        std::move(callback).Run(
+            zcash::mojom::BlockID::New(1000u, std::vector<uint8_t>({})));
+      });
 
   base::MockCallback<ZCashWalletService::CreateTransactionCallback> callback;
 
@@ -554,33 +540,31 @@ TEST_F(ZCashCreateTransparentToOrchardTransactionTaskTest,
 
 TEST_F(ZCashCreateTransparentToOrchardTransactionTaskTest, NotEnoughFunds) {
   ON_CALL(zcash_wallet_service(), GetUtxos(_, _, _))
-      .WillByDefault(
-          ::testing::Invoke([&](const std::string& chain_id,
-                                const mojom::AccountIdPtr& account_id,
-                                ZCashWalletService::GetUtxosCallback callback) {
-            ZCashWalletService::UtxoMap utxo_map;
-            utxo_map["6000"] = GetZCashUtxo(6000);
-            utxo_map["7000"] = GetZCashUtxo(7000);
-            utxo_map["8000"] = GetZCashUtxo(8000);
-            std::move(callback).Run(std::move(utxo_map));
-          }));
+      .WillByDefault([&](const std::string& chain_id,
+                         const mojom::AccountIdPtr& account_id,
+                         ZCashWalletService::GetUtxosCallback callback) {
+        ZCashWalletService::UtxoMap utxo_map;
+        utxo_map["6000"] = GetZCashUtxo(6000);
+        utxo_map["7000"] = GetZCashUtxo(7000);
+        utxo_map["8000"] = GetZCashUtxo(8000);
+        std::move(callback).Run(std::move(utxo_map));
+      });
 
   ON_CALL(zcash_wallet_service(), DiscoverNextUnusedAddress(_, _, _))
-      .WillByDefault(::testing::Invoke(
+      .WillByDefault(
           [&](const mojom::AccountIdPtr& account_id, bool change,
               ZCashWalletService::DiscoverNextUnusedAddressCallback callback) {
             auto id = mojom::ZCashKeyId::New(account_id->account_index, 1, 0);
             auto addr = keyring_service().GetZCashAddress(account_id, *id);
             std::move(callback).Run(std::move(addr));
-          }));
+          });
 
   ON_CALL(mock_zcash_rpc(), GetLatestBlock(_, _))
-      .WillByDefault(
-          ::testing::Invoke([](const std::string& chain_id,
-                               ZCashRpc::GetLatestBlockCallback callback) {
-            std::move(callback).Run(
-                zcash::mojom::BlockID::New(1000u, std::vector<uint8_t>({})));
-          }));
+      .WillByDefault([](const std::string& chain_id,
+                        ZCashRpc::GetLatestBlockCallback callback) {
+        std::move(callback).Run(
+            zcash::mojom::BlockID::New(1000u, std::vector<uint8_t>({})));
+      });
 
   base::MockCallback<ZCashWalletService::CreateTransactionCallback> callback;
 
@@ -606,29 +590,27 @@ TEST_F(ZCashCreateTransparentToOrchardTransactionTaskTest, NotEnoughFunds) {
 
 TEST_F(ZCashCreateTransparentToOrchardTransactionTaskTest, UtxosError) {
   ON_CALL(zcash_wallet_service(), GetUtxos(_, _, _))
-      .WillByDefault(
-          ::testing::Invoke([&](const std::string& chain_id,
-                                const mojom::AccountIdPtr& account_id,
-                                ZCashWalletService::GetUtxosCallback callback) {
-            std::move(callback).Run(base::unexpected("error"));
-          }));
+      .WillByDefault([&](const std::string& chain_id,
+                         const mojom::AccountIdPtr& account_id,
+                         ZCashWalletService::GetUtxosCallback callback) {
+        std::move(callback).Run(base::unexpected("error"));
+      });
 
   ON_CALL(zcash_wallet_service(), DiscoverNextUnusedAddress(_, _, _))
-      .WillByDefault(::testing::Invoke(
+      .WillByDefault(
           [&](const mojom::AccountIdPtr& account_id, bool change,
               ZCashWalletService::DiscoverNextUnusedAddressCallback callback) {
             auto id = mojom::ZCashKeyId::New(account_id->account_index, 1, 0);
             auto addr = keyring_service().GetZCashAddress(account_id, *id);
             std::move(callback).Run(std::move(addr));
-          }));
+          });
 
   ON_CALL(mock_zcash_rpc(), GetLatestBlock(_, _))
-      .WillByDefault(
-          ::testing::Invoke([](const std::string& chain_id,
-                               ZCashRpc::GetLatestBlockCallback callback) {
-            std::move(callback).Run(
-                zcash::mojom::BlockID::New(1000u, std::vector<uint8_t>({})));
-          }));
+      .WillByDefault([](const std::string& chain_id,
+                        ZCashRpc::GetLatestBlockCallback callback) {
+        std::move(callback).Run(
+            zcash::mojom::BlockID::New(1000u, std::vector<uint8_t>({})));
+      });
 
   base::MockCallback<ZCashWalletService::CreateTransactionCallback> callback;
 
@@ -651,31 +633,29 @@ TEST_F(ZCashCreateTransparentToOrchardTransactionTaskTest, UtxosError) {
 
 TEST_F(ZCashCreateTransparentToOrchardTransactionTaskTest, ChangeAddressError) {
   ON_CALL(zcash_wallet_service(), GetUtxos(_, _, _))
-      .WillByDefault(
-          ::testing::Invoke([&](const std::string& chain_id,
-                                const mojom::AccountIdPtr& account_id,
-                                ZCashWalletService::GetUtxosCallback callback) {
-            ZCashWalletService::UtxoMap utxo_map;
-            utxo_map["60000"] = GetZCashUtxo(60000);
-            utxo_map["70000"] = GetZCashUtxo(70000);
-            utxo_map["80000"] = GetZCashUtxo(80000);
-            std::move(callback).Run(std::move(utxo_map));
-          }));
+      .WillByDefault([&](const std::string& chain_id,
+                         const mojom::AccountIdPtr& account_id,
+                         ZCashWalletService::GetUtxosCallback callback) {
+        ZCashWalletService::UtxoMap utxo_map;
+        utxo_map["60000"] = GetZCashUtxo(60000);
+        utxo_map["70000"] = GetZCashUtxo(70000);
+        utxo_map["80000"] = GetZCashUtxo(80000);
+        std::move(callback).Run(std::move(utxo_map));
+      });
 
   ON_CALL(zcash_wallet_service(), DiscoverNextUnusedAddress(_, _, _))
-      .WillByDefault(::testing::Invoke(
+      .WillByDefault(
           [&](const mojom::AccountIdPtr& account_id, bool change,
               ZCashWalletService::DiscoverNextUnusedAddressCallback callback) {
             std::move(callback).Run(base::unexpected("error"));
-          }));
+          });
 
   ON_CALL(mock_zcash_rpc(), GetLatestBlock(_, _))
-      .WillByDefault(
-          ::testing::Invoke([](const std::string& chain_id,
-                               ZCashRpc::GetLatestBlockCallback callback) {
-            std::move(callback).Run(
-                zcash::mojom::BlockID::New(1000u, std::vector<uint8_t>({})));
-          }));
+      .WillByDefault([](const std::string& chain_id,
+                        ZCashRpc::GetLatestBlockCallback callback) {
+        std::move(callback).Run(
+            zcash::mojom::BlockID::New(1000u, std::vector<uint8_t>({})));
+      });
 
   base::MockCallback<ZCashWalletService::CreateTransactionCallback> callback;
 
@@ -698,32 +678,30 @@ TEST_F(ZCashCreateTransparentToOrchardTransactionTaskTest, ChangeAddressError) {
 
 TEST_F(ZCashCreateTransparentToOrchardTransactionTaskTest, LatestBlockError) {
   ON_CALL(zcash_wallet_service(), GetUtxos(_, _, _))
-      .WillByDefault(
-          ::testing::Invoke([&](const std::string& chain_id,
-                                const mojom::AccountIdPtr& account_id,
-                                ZCashWalletService::GetUtxosCallback callback) {
-            ZCashWalletService::UtxoMap utxo_map;
-            utxo_map["60000"] = GetZCashUtxo(60000);
-            utxo_map["70000"] = GetZCashUtxo(70000);
-            utxo_map["80000"] = GetZCashUtxo(80000);
-            std::move(callback).Run(std::move(utxo_map));
-          }));
+      .WillByDefault([&](const std::string& chain_id,
+                         const mojom::AccountIdPtr& account_id,
+                         ZCashWalletService::GetUtxosCallback callback) {
+        ZCashWalletService::UtxoMap utxo_map;
+        utxo_map["60000"] = GetZCashUtxo(60000);
+        utxo_map["70000"] = GetZCashUtxo(70000);
+        utxo_map["80000"] = GetZCashUtxo(80000);
+        std::move(callback).Run(std::move(utxo_map));
+      });
 
   ON_CALL(zcash_wallet_service(), DiscoverNextUnusedAddress(_, _, _))
-      .WillByDefault(::testing::Invoke(
+      .WillByDefault(
           [&](const mojom::AccountIdPtr& account_id, bool change,
               ZCashWalletService::DiscoverNextUnusedAddressCallback callback) {
             auto id = mojom::ZCashKeyId::New(account_id->account_index, 1, 0);
             auto addr = keyring_service().GetZCashAddress(account_id, *id);
             std::move(callback).Run(std::move(addr));
-          }));
+          });
 
   ON_CALL(mock_zcash_rpc(), GetLatestBlock(_, _))
-      .WillByDefault(
-          ::testing::Invoke([](const std::string& chain_id,
-                               ZCashRpc::GetLatestBlockCallback callback) {
-            std::move(callback).Run(base::unexpected("network error"));
-          }));
+      .WillByDefault([](const std::string& chain_id,
+                        ZCashRpc::GetLatestBlockCallback callback) {
+        std::move(callback).Run(base::unexpected("network error"));
+      });
 
   base::MockCallback<ZCashWalletService::CreateTransactionCallback> callback;
 

--- a/components/brave_wallet/browser/zcash/zcash_create_transparent_transaction_task_unittest.cc
+++ b/components/brave_wallet/browser/zcash/zcash_create_transparent_transaction_task_unittest.cc
@@ -147,33 +147,31 @@ class ZCashCreateTransparentTransactionTaskTest : public testing::Test {
 
 TEST_F(ZCashCreateTransparentTransactionTaskTest, TransactionCreated) {
   ON_CALL(zcash_wallet_service(), GetUtxos(_, _, _))
-      .WillByDefault(
-          ::testing::Invoke([&](const std::string& chain_id,
-                                const mojom::AccountIdPtr& account_id,
-                                ZCashWalletService::GetUtxosCallback callback) {
-            ZCashWalletService::UtxoMap utxo_map;
-            utxo_map["60000"] = GetZCashUtxo(60000);
-            utxo_map["70000"] = GetZCashUtxo(70000);
-            utxo_map["80000"] = GetZCashUtxo(80000);
-            std::move(callback).Run(std::move(utxo_map));
-          }));
+      .WillByDefault([&](const std::string& chain_id,
+                         const mojom::AccountIdPtr& account_id,
+                         ZCashWalletService::GetUtxosCallback callback) {
+        ZCashWalletService::UtxoMap utxo_map;
+        utxo_map["60000"] = GetZCashUtxo(60000);
+        utxo_map["70000"] = GetZCashUtxo(70000);
+        utxo_map["80000"] = GetZCashUtxo(80000);
+        std::move(callback).Run(std::move(utxo_map));
+      });
 
   ON_CALL(zcash_wallet_service(), DiscoverNextUnusedAddress(_, _, _))
-      .WillByDefault(::testing::Invoke(
+      .WillByDefault(
           [&](const mojom::AccountIdPtr& account_id, bool change,
               ZCashWalletService::DiscoverNextUnusedAddressCallback callback) {
             auto id = mojom::ZCashKeyId::New(account_id->account_index, 1, 0);
             auto addr = keyring_service().GetZCashAddress(account_id, *id);
             std::move(callback).Run(std::move(addr));
-          }));
+          });
 
   ON_CALL(mock_zcash_rpc(), GetLatestBlock(_, _))
-      .WillByDefault(
-          ::testing::Invoke([](const std::string& chain_id,
-                               ZCashRpc::GetLatestBlockCallback callback) {
-            std::move(callback).Run(
-                zcash::mojom::BlockID::New(1000u, std::vector<uint8_t>({})));
-          }));
+      .WillByDefault([](const std::string& chain_id,
+                        ZCashRpc::GetLatestBlockCallback callback) {
+        std::move(callback).Run(
+            zcash::mojom::BlockID::New(1000u, std::vector<uint8_t>({})));
+      });
 
   base::MockCallback<
       ZCashCreateTransparentTransactionTask::CreateTransactionCallback>
@@ -208,32 +206,30 @@ TEST_F(ZCashCreateTransparentTransactionTaskTest, TransactionCreated) {
 
 TEST_F(ZCashCreateTransparentTransactionTaskTest, TransactionCreated_u64Check) {
   ON_CALL(zcash_wallet_service(), GetUtxos(_, _, _))
-      .WillByDefault(
-          ::testing::Invoke([&](const std::string& chain_id,
-                                const mojom::AccountIdPtr& account_id,
-                                ZCashWalletService::GetUtxosCallback callback) {
-            ZCashWalletService::UtxoMap utxo_map;
-            utxo_map["10000000000"] = GetZCashUtxo(10000000000u);
-            utxo_map["20000000000"] = GetZCashUtxo(20000000000u);
-            std::move(callback).Run(std::move(utxo_map));
-          }));
+      .WillByDefault([&](const std::string& chain_id,
+                         const mojom::AccountIdPtr& account_id,
+                         ZCashWalletService::GetUtxosCallback callback) {
+        ZCashWalletService::UtxoMap utxo_map;
+        utxo_map["10000000000"] = GetZCashUtxo(10000000000u);
+        utxo_map["20000000000"] = GetZCashUtxo(20000000000u);
+        std::move(callback).Run(std::move(utxo_map));
+      });
 
   ON_CALL(zcash_wallet_service(), DiscoverNextUnusedAddress(_, _, _))
-      .WillByDefault(::testing::Invoke(
+      .WillByDefault(
           [&](const mojom::AccountIdPtr& account_id, bool change,
               ZCashWalletService::DiscoverNextUnusedAddressCallback callback) {
             auto id = mojom::ZCashKeyId::New(account_id->account_index, 1, 0);
             auto addr = keyring_service().GetZCashAddress(account_id, *id);
             std::move(callback).Run(std::move(addr));
-          }));
+          });
 
   ON_CALL(mock_zcash_rpc(), GetLatestBlock(_, _))
-      .WillByDefault(
-          ::testing::Invoke([](const std::string& chain_id,
-                               ZCashRpc::GetLatestBlockCallback callback) {
-            std::move(callback).Run(
-                zcash::mojom::BlockID::New(1000u, std::vector<uint8_t>({})));
-          }));
+      .WillByDefault([](const std::string& chain_id,
+                        ZCashRpc::GetLatestBlockCallback callback) {
+        std::move(callback).Run(
+            zcash::mojom::BlockID::New(1000u, std::vector<uint8_t>({})));
+      });
 
   base::MockCallback<
       ZCashCreateTransparentTransactionTask::CreateTransactionCallback>
@@ -271,33 +267,30 @@ TEST_F(ZCashCreateTransparentTransactionTaskTest, TransactionCreated_u64Check) {
 TEST_F(ZCashCreateTransparentTransactionTaskTest,
        TransactionCreated_OverflowCheck_FullAmount) {
   ON_CALL(zcash_wallet_service(), GetUtxos(_, _, _))
-      .WillByDefault(
-          ::testing::Invoke([&](const std::string& chain_id,
-                                const mojom::AccountIdPtr& account_id,
-                                ZCashWalletService::GetUtxosCallback callback) {
-            ZCashWalletService::UtxoMap utxo_map;
-            utxo_map["18446744073709551615"] =
-                GetZCashUtxo(18446744073709551615u);
-            utxo_map["20000000000"] = GetZCashUtxo(20000000000u);
-            std::move(callback).Run(std::move(utxo_map));
-          }));
+      .WillByDefault([&](const std::string& chain_id,
+                         const mojom::AccountIdPtr& account_id,
+                         ZCashWalletService::GetUtxosCallback callback) {
+        ZCashWalletService::UtxoMap utxo_map;
+        utxo_map["18446744073709551615"] = GetZCashUtxo(18446744073709551615u);
+        utxo_map["20000000000"] = GetZCashUtxo(20000000000u);
+        std::move(callback).Run(std::move(utxo_map));
+      });
 
   ON_CALL(zcash_wallet_service(), DiscoverNextUnusedAddress(_, _, _))
-      .WillByDefault(::testing::Invoke(
+      .WillByDefault(
           [&](const mojom::AccountIdPtr& account_id, bool change,
               ZCashWalletService::DiscoverNextUnusedAddressCallback callback) {
             auto id = mojom::ZCashKeyId::New(account_id->account_index, 1, 0);
             auto addr = keyring_service().GetZCashAddress(account_id, *id);
             std::move(callback).Run(std::move(addr));
-          }));
+          });
 
   ON_CALL(mock_zcash_rpc(), GetLatestBlock(_, _))
-      .WillByDefault(
-          ::testing::Invoke([](const std::string& chain_id,
-                               ZCashRpc::GetLatestBlockCallback callback) {
-            std::move(callback).Run(
-                zcash::mojom::BlockID::New(1000u, std::vector<uint8_t>({})));
-          }));
+      .WillByDefault([](const std::string& chain_id,
+                        ZCashRpc::GetLatestBlockCallback callback) {
+        std::move(callback).Run(
+            zcash::mojom::BlockID::New(1000u, std::vector<uint8_t>({})));
+      });
 
   base::MockCallback<
       ZCashCreateTransparentTransactionTask::CreateTransactionCallback>
@@ -323,33 +316,30 @@ TEST_F(ZCashCreateTransparentTransactionTaskTest,
 TEST_F(ZCashCreateTransparentTransactionTaskTest,
        TransactionCreated_OverflowCheck_CustomAmount) {
   ON_CALL(zcash_wallet_service(), GetUtxos(_, _, _))
-      .WillByDefault(
-          ::testing::Invoke([&](const std::string& chain_id,
-                                const mojom::AccountIdPtr& account_id,
-                                ZCashWalletService::GetUtxosCallback callback) {
-            ZCashWalletService::UtxoMap utxo_map;
-            utxo_map["18446744073709551615"] =
-                GetZCashUtxo(18446744073709551615u);
-            utxo_map["20000000000"] = GetZCashUtxo(20000000000u);
-            std::move(callback).Run(std::move(utxo_map));
-          }));
+      .WillByDefault([&](const std::string& chain_id,
+                         const mojom::AccountIdPtr& account_id,
+                         ZCashWalletService::GetUtxosCallback callback) {
+        ZCashWalletService::UtxoMap utxo_map;
+        utxo_map["18446744073709551615"] = GetZCashUtxo(18446744073709551615u);
+        utxo_map["20000000000"] = GetZCashUtxo(20000000000u);
+        std::move(callback).Run(std::move(utxo_map));
+      });
 
   ON_CALL(zcash_wallet_service(), DiscoverNextUnusedAddress(_, _, _))
-      .WillByDefault(::testing::Invoke(
+      .WillByDefault(
           [&](const mojom::AccountIdPtr& account_id, bool change,
               ZCashWalletService::DiscoverNextUnusedAddressCallback callback) {
             auto id = mojom::ZCashKeyId::New(account_id->account_index, 1, 0);
             auto addr = keyring_service().GetZCashAddress(account_id, *id);
             std::move(callback).Run(std::move(addr));
-          }));
+          });
 
   ON_CALL(mock_zcash_rpc(), GetLatestBlock(_, _))
-      .WillByDefault(
-          ::testing::Invoke([](const std::string& chain_id,
-                               ZCashRpc::GetLatestBlockCallback callback) {
-            std::move(callback).Run(
-                zcash::mojom::BlockID::New(1000u, std::vector<uint8_t>({})));
-          }));
+      .WillByDefault([](const std::string& chain_id,
+                        ZCashRpc::GetLatestBlockCallback callback) {
+        std::move(callback).Run(
+            zcash::mojom::BlockID::New(1000u, std::vector<uint8_t>({})));
+      });
 
   base::MockCallback<
       ZCashCreateTransparentTransactionTask::CreateTransactionCallback>
@@ -375,32 +365,30 @@ TEST_F(ZCashCreateTransparentTransactionTaskTest,
 TEST_F(ZCashCreateTransparentTransactionTaskTest,
        TransactionNotCreated_LastBlockError) {
   ON_CALL(zcash_wallet_service(), GetUtxos(_, _, _))
-      .WillByDefault(
-          ::testing::Invoke([&](const std::string& chain_id,
-                                const mojom::AccountIdPtr& account_id,
-                                ZCashWalletService::GetUtxosCallback callback) {
-            ZCashWalletService::UtxoMap utxo_map;
-            utxo_map["60000"] = GetZCashUtxo(60000);
-            utxo_map["70000"] = GetZCashUtxo(70000);
-            utxo_map["80000"] = GetZCashUtxo(80000);
-            std::move(callback).Run(std::move(utxo_map));
-          }));
+      .WillByDefault([&](const std::string& chain_id,
+                         const mojom::AccountIdPtr& account_id,
+                         ZCashWalletService::GetUtxosCallback callback) {
+        ZCashWalletService::UtxoMap utxo_map;
+        utxo_map["60000"] = GetZCashUtxo(60000);
+        utxo_map["70000"] = GetZCashUtxo(70000);
+        utxo_map["80000"] = GetZCashUtxo(80000);
+        std::move(callback).Run(std::move(utxo_map));
+      });
 
   ON_CALL(zcash_wallet_service(), DiscoverNextUnusedAddress(_, _, _))
-      .WillByDefault(::testing::Invoke(
+      .WillByDefault(
           [&](const mojom::AccountIdPtr& account_id, bool change,
               ZCashWalletService::DiscoverNextUnusedAddressCallback callback) {
             auto id = mojom::ZCashKeyId::New(account_id->account_index, 1, 0);
             auto addr = keyring_service().GetZCashAddress(account_id, *id);
             std::move(callback).Run(std::move(addr));
-          }));
+          });
 
   ON_CALL(mock_zcash_rpc(), GetLatestBlock(_, _))
-      .WillByDefault(
-          ::testing::Invoke([](const std::string& chain_id,
-                               ZCashRpc::GetLatestBlockCallback callback) {
-            std::move(callback).Run(base::unexpected("error"));
-          }));
+      .WillByDefault([](const std::string& chain_id,
+                        ZCashRpc::GetLatestBlockCallback callback) {
+        std::move(callback).Run(base::unexpected("error"));
+      });
 
   base::MockCallback<
       ZCashCreateTransparentTransactionTask::CreateTransactionCallback>
@@ -426,31 +414,29 @@ TEST_F(ZCashCreateTransparentTransactionTaskTest,
 TEST_F(ZCashCreateTransparentTransactionTaskTest,
        TransactionNotCreated_NotEnoughFunds) {
   ON_CALL(zcash_wallet_service(), GetUtxos(_, _, _))
-      .WillByDefault(
-          ::testing::Invoke([&](const std::string& chain_id,
-                                const mojom::AccountIdPtr& account_id,
-                                ZCashWalletService::GetUtxosCallback callback) {
-            ZCashWalletService::UtxoMap utxo_map;
-            utxo_map["60000"] = GetZCashUtxo(60000);
-            std::move(callback).Run(std::move(utxo_map));
-          }));
+      .WillByDefault([&](const std::string& chain_id,
+                         const mojom::AccountIdPtr& account_id,
+                         ZCashWalletService::GetUtxosCallback callback) {
+        ZCashWalletService::UtxoMap utxo_map;
+        utxo_map["60000"] = GetZCashUtxo(60000);
+        std::move(callback).Run(std::move(utxo_map));
+      });
 
   ON_CALL(zcash_wallet_service(), DiscoverNextUnusedAddress(_, _, _))
-      .WillByDefault(::testing::Invoke(
+      .WillByDefault(
           [&](const mojom::AccountIdPtr& account_id, bool change,
               ZCashWalletService::DiscoverNextUnusedAddressCallback callback) {
             auto id = mojom::ZCashKeyId::New(account_id->account_index, 1, 0);
             auto addr = keyring_service().GetZCashAddress(account_id, *id);
             std::move(callback).Run(std::move(addr));
-          }));
+          });
 
   ON_CALL(mock_zcash_rpc(), GetLatestBlock(_, _))
-      .WillByDefault(
-          ::testing::Invoke([](const std::string& chain_id,
-                               ZCashRpc::GetLatestBlockCallback callback) {
-            std::move(callback).Run(
-                zcash::mojom::BlockID::New(1000u, std::vector<uint8_t>({})));
-          }));
+      .WillByDefault([](const std::string& chain_id,
+                        ZCashRpc::GetLatestBlockCallback callback) {
+        std::move(callback).Run(
+            zcash::mojom::BlockID::New(1000u, std::vector<uint8_t>({})));
+      });
 
   base::MockCallback<
       ZCashCreateTransparentTransactionTask::CreateTransactionCallback>
@@ -475,33 +461,31 @@ TEST_F(ZCashCreateTransparentTransactionTaskTest,
 
 TEST_F(ZCashCreateTransparentTransactionTaskTest, TransactionCreated_MaxFunds) {
   ON_CALL(zcash_wallet_service(), GetUtxos(_, _, _))
-      .WillByDefault(
-          ::testing::Invoke([&](const std::string& chain_id,
-                                const mojom::AccountIdPtr& account_id,
-                                ZCashWalletService::GetUtxosCallback callback) {
-            ZCashWalletService::UtxoMap utxo_map;
-            utxo_map["60000"] = GetZCashUtxo(60000);
-            utxo_map["70000"] = GetZCashUtxo(70000);
-            utxo_map["80000"] = GetZCashUtxo(80000);
-            std::move(callback).Run(std::move(utxo_map));
-          }));
+      .WillByDefault([&](const std::string& chain_id,
+                         const mojom::AccountIdPtr& account_id,
+                         ZCashWalletService::GetUtxosCallback callback) {
+        ZCashWalletService::UtxoMap utxo_map;
+        utxo_map["60000"] = GetZCashUtxo(60000);
+        utxo_map["70000"] = GetZCashUtxo(70000);
+        utxo_map["80000"] = GetZCashUtxo(80000);
+        std::move(callback).Run(std::move(utxo_map));
+      });
 
   ON_CALL(zcash_wallet_service(), DiscoverNextUnusedAddress(_, _, _))
-      .WillByDefault(::testing::Invoke(
+      .WillByDefault(
           [&](const mojom::AccountIdPtr& account_id, bool change,
               ZCashWalletService::DiscoverNextUnusedAddressCallback callback) {
             auto id = mojom::ZCashKeyId::New(account_id->account_index, 1, 0);
             auto addr = keyring_service().GetZCashAddress(account_id, *id);
             std::move(callback).Run(std::move(addr));
-          }));
+          });
 
   ON_CALL(mock_zcash_rpc(), GetLatestBlock(_, _))
-      .WillByDefault(
-          ::testing::Invoke([](const std::string& chain_id,
-                               ZCashRpc::GetLatestBlockCallback callback) {
-            std::move(callback).Run(
-                zcash::mojom::BlockID::New(1000u, std::vector<uint8_t>({})));
-          }));
+      .WillByDefault([](const std::string& chain_id,
+                        ZCashRpc::GetLatestBlockCallback callback) {
+        std::move(callback).Run(
+            zcash::mojom::BlockID::New(1000u, std::vector<uint8_t>({})));
+      });
 
   base::MockCallback<
       ZCashCreateTransparentTransactionTask::CreateTransactionCallback>

--- a/components/brave_wallet/browser/zcash/zcash_get_chaintip_status_task_unittest.cc
+++ b/components/brave_wallet/browser/zcash/zcash_get_chaintip_status_task_unittest.cc
@@ -157,20 +157,18 @@ class ZCashGetChainTipStatusTaskTest : public testing::Test {
 
 TEST_F(ZCashGetChainTipStatusTaskTest, Success) {
   ON_CALL(mocked_sync_state(), GetAccountMeta(_))
-      .WillByDefault(
-          ::testing::Invoke([](const mojom::AccountIdPtr& account_id) {
-            OrchardStorage::AccountMeta meta;
-            meta.latest_scanned_block_id = 100;
-            return meta;
-          }));
+      .WillByDefault([](const mojom::AccountIdPtr& account_id) {
+        OrchardStorage::AccountMeta meta;
+        meta.latest_scanned_block_id = 100;
+        return meta;
+      });
 
   ON_CALL(zcash_rpc(), GetLatestBlock(_, _))
-      .WillByDefault(
-          ::testing::Invoke([](const std::string& chain_id,
-                               ZCashRpc::GetLatestBlockCallback callback) {
-            std::move(callback).Run(
-                zcash::mojom::BlockID::New(1000u, std::vector<uint8_t>({})));
-          }));
+      .WillByDefault([](const std::string& chain_id,
+                        ZCashRpc::GetLatestBlockCallback callback) {
+        std::move(callback).Run(
+            zcash::mojom::BlockID::New(1000u, std::vector<uint8_t>({})));
+      });
 
   base::MockCallback<
       ZCashGetZCashChainTipStatusTask::ZCashGetZCashChainTipStatusTaskCallback>
@@ -195,19 +193,18 @@ TEST_F(ZCashGetChainTipStatusTaskTest, EmptyAccount) {
   AccountUtils(&keyring_service())
       .EnsureAccount(mojom::KeyringId::kZCashMainnet, 0);
   ON_CALL(mocked_sync_state(), GetAccountMeta(_))
-      .WillByDefault(::testing::Invoke(
-          [](const mojom::AccountIdPtr& account_id) { return std::nullopt; }));
+      .WillByDefault(
+          [](const mojom::AccountIdPtr& account_id) { return std::nullopt; });
 
   keyring_service().SetZCashAccountBirthday(
       account_id(), mojom::ZCashAccountShieldBirthday::New(100u, "hash"));
 
   ON_CALL(zcash_rpc(), GetLatestBlock(_, _))
-      .WillByDefault(
-          ::testing::Invoke([](const std::string& chain_id,
-                               ZCashRpc::GetLatestBlockCallback callback) {
-            std::move(callback).Run(
-                zcash::mojom::BlockID::New(1000u, std::vector<uint8_t>({})));
-          }));
+      .WillByDefault([](const std::string& chain_id,
+                        ZCashRpc::GetLatestBlockCallback callback) {
+        std::move(callback).Run(
+            zcash::mojom::BlockID::New(1000u, std::vector<uint8_t>({})));
+      });
 
   base::MockCallback<
       ZCashGetZCashChainTipStatusTask::ZCashGetZCashChainTipStatusTaskCallback>
@@ -230,16 +227,15 @@ TEST_F(ZCashGetChainTipStatusTaskTest, EmptyAccount) {
 
 TEST_F(ZCashGetChainTipStatusTaskTest, Error_AccountNotShielded) {
   ON_CALL(mocked_sync_state(), GetAccountMeta(_))
-      .WillByDefault(::testing::Invoke(
-          [](const mojom::AccountIdPtr& account_id) { return std::nullopt; }));
+      .WillByDefault(
+          [](const mojom::AccountIdPtr& account_id) { return std::nullopt; });
 
   ON_CALL(zcash_rpc(), GetLatestBlock(_, _))
-      .WillByDefault(
-          ::testing::Invoke([](const std::string& chain_id,
-                               ZCashRpc::GetLatestBlockCallback callback) {
-            std::move(callback).Run(
-                zcash::mojom::BlockID::New(1000u, std::vector<uint8_t>({})));
-          }));
+      .WillByDefault([](const std::string& chain_id,
+                        ZCashRpc::GetLatestBlockCallback callback) {
+        std::move(callback).Run(
+            zcash::mojom::BlockID::New(1000u, std::vector<uint8_t>({})));
+      });
 
   base::MockCallback<
       ZCashGetZCashChainTipStatusTask::ZCashGetZCashChainTipStatusTaskCallback>
@@ -260,20 +256,19 @@ TEST_F(ZCashGetChainTipStatusTaskTest, Error_AccountNotShielded) {
 TEST_F(ZCashGetChainTipStatusTaskTest, Error_GetAccountMeta) {
   ON_CALL(mocked_sync_state(), GetAccountMeta(_))
       .WillByDefault(
-          ::testing::Invoke([](const mojom::AccountIdPtr& account_id) {
+          [](const mojom::AccountIdPtr& account_id) {
             OrchardStorage::AccountMeta meta;
             meta.latest_scanned_block_id = 100;
             return base::unexpected(OrchardStorage::Error{
                 OrchardStorage::ErrorCode::kInternalError, ""});
-          }));
+          });
 
   ON_CALL(zcash_rpc(), GetLatestBlock(_, _))
-      .WillByDefault(
-          ::testing::Invoke([](const std::string& chain_id,
-                               ZCashRpc::GetLatestBlockCallback callback) {
-            std::move(callback).Run(
-                zcash::mojom::BlockID::New(1000u, std::vector<uint8_t>({})));
-          }));
+      .WillByDefault([](const std::string& chain_id,
+                        ZCashRpc::GetLatestBlockCallback callback) {
+        std::move(callback).Run(
+            zcash::mojom::BlockID::New(1000u, std::vector<uint8_t>({})));
+      });
 
   base::MockCallback<
       ZCashGetZCashChainTipStatusTask::ZCashGetZCashChainTipStatusTaskCallback>
@@ -293,19 +288,17 @@ TEST_F(ZCashGetChainTipStatusTaskTest, Error_GetAccountMeta) {
 
 TEST_F(ZCashGetChainTipStatusTaskTest, Error_GetLatestBlock) {
   ON_CALL(mocked_sync_state(), GetAccountMeta(_))
-      .WillByDefault(
-          ::testing::Invoke([](const mojom::AccountIdPtr& account_id) {
-            OrchardStorage::AccountMeta meta;
-            meta.latest_scanned_block_id = 100;
-            return meta;
-          }));
+      .WillByDefault([](const mojom::AccountIdPtr& account_id) {
+        OrchardStorage::AccountMeta meta;
+        meta.latest_scanned_block_id = 100;
+        return meta;
+      });
 
   ON_CALL(zcash_rpc(), GetLatestBlock(_, _))
-      .WillByDefault(
-          ::testing::Invoke([](const std::string& chain_id,
-                               ZCashRpc::GetLatestBlockCallback callback) {
-            std::move(callback).Run(base::unexpected("error"));
-          }));
+      .WillByDefault([](const std::string& chain_id,
+                        ZCashRpc::GetLatestBlockCallback callback) {
+        std::move(callback).Run(base::unexpected("error"));
+      });
 
   base::MockCallback<
       ZCashGetZCashChainTipStatusTask::ZCashGetZCashChainTipStatusTaskCallback>

--- a/components/brave_wallet/browser/zcash/zcash_resolve_transaction_status_task_unittest.cc
+++ b/components/brave_wallet/browser/zcash/zcash_resolve_transaction_status_task_unittest.cc
@@ -134,20 +134,20 @@ TEST_F(ZCashResolveTransactionStatusTaskTest, Confirmed) {
 
   ON_CALL(zcash_rpc(), GetLatestBlock(_, _))
       .WillByDefault(
-          ::testing::Invoke([](const std::string& chain_id,
-                               MockZCashRPC::GetLatestBlockCallback callback) {
+          [](const std::string& chain_id,
+             MockZCashRPC::GetLatestBlockCallback callback) {
             std::move(callback).Run(zcash::mojom::BlockID::New(
                 kTransactionHeight + 5u, std::vector<uint8_t>()));
-          }));
+          });
 
   ON_CALL(zcash_rpc(), GetTransaction(_, _, _))
-      .WillByDefault(::testing::Invoke(
+      .WillByDefault(
           [](const std::string& chain_id, const std::string& tx_hash,
              MockZCashRPC::GetTransactionCallback callback) {
             EXPECT_EQ(tx_hash, "tx_hash");
             std::move(callback).Run(zcash::mojom::RawTransaction::New(
                 std::vector<uint8_t>(), kTransactionHeight));
-          }));
+          });
 
   base::MockCallback<ZCashResolveTransactionStatusTask::
                          ZCashResolveTransactionStatusTaskCallback>
@@ -175,21 +175,19 @@ TEST_F(ZCashResolveTransactionStatusTaskTest, Expired_ExpiryHeight) {
   tx_meta->set_tx_hash("tx_hash");
 
   ON_CALL(zcash_rpc(), GetLatestBlock(_, _))
-      .WillByDefault(
-          ::testing::Invoke([](const std::string& chain_id,
-                               MockZCashRPC::GetLatestBlockCallback callback) {
-            std::move(callback).Run(
-                zcash::mojom::BlockID::New(20u, std::vector<uint8_t>()));
-          }));
+      .WillByDefault([](const std::string& chain_id,
+                        MockZCashRPC::GetLatestBlockCallback callback) {
+        std::move(callback).Run(
+            zcash::mojom::BlockID::New(20u, std::vector<uint8_t>()));
+      });
 
   ON_CALL(zcash_rpc(), GetTransaction(_, _, _))
-      .WillByDefault(::testing::Invoke(
-          [](const std::string& chain_id, const std::string& tx_hash,
-             MockZCashRPC::GetTransactionCallback callback) {
-            EXPECT_EQ(tx_hash, "tx_hash");
-            std::move(callback).Run(
-                zcash::mojom::RawTransaction::New(std::vector<uint8_t>(), 0));
-          }));
+      .WillByDefault([](const std::string& chain_id, const std::string& tx_hash,
+                        MockZCashRPC::GetTransactionCallback callback) {
+        EXPECT_EQ(tx_hash, "tx_hash");
+        std::move(callback).Run(
+            zcash::mojom::RawTransaction::New(std::vector<uint8_t>(), 0));
+      });
 
   base::MockCallback<ZCashResolveTransactionStatusTask::
                          ZCashResolveTransactionStatusTaskCallback>
@@ -218,21 +216,19 @@ TEST_F(ZCashResolveTransactionStatusTaskTest, Expired_Time) {
   tx_meta->set_tx_hash("tx_hash");
 
   ON_CALL(zcash_rpc(), GetLatestBlock(_, _))
-      .WillByDefault(
-          ::testing::Invoke([](const std::string& chain_id,
-                               MockZCashRPC::GetLatestBlockCallback callback) {
-            std::move(callback).Run(
-                zcash::mojom::BlockID::New(20u, std::vector<uint8_t>()));
-          }));
+      .WillByDefault([](const std::string& chain_id,
+                        MockZCashRPC::GetLatestBlockCallback callback) {
+        std::move(callback).Run(
+            zcash::mojom::BlockID::New(20u, std::vector<uint8_t>()));
+      });
 
   ON_CALL(zcash_rpc(), GetTransaction(_, _, _))
-      .WillByDefault(::testing::Invoke(
-          [](const std::string& chain_id, const std::string& tx_hash,
-             MockZCashRPC::GetTransactionCallback callback) {
-            EXPECT_EQ(tx_hash, "tx_hash");
-            std::move(callback).Run(
-                zcash::mojom::RawTransaction::New(std::vector<uint8_t>(), 0));
-          }));
+      .WillByDefault([](const std::string& chain_id, const std::string& tx_hash,
+                        MockZCashRPC::GetTransactionCallback callback) {
+        EXPECT_EQ(tx_hash, "tx_hash");
+        std::move(callback).Run(
+            zcash::mojom::RawTransaction::New(std::vector<uint8_t>(), 0));
+      });
 
   base::MockCallback<ZCashResolveTransactionStatusTask::
                          ZCashResolveTransactionStatusTaskCallback>
@@ -260,21 +256,19 @@ TEST_F(ZCashResolveTransactionStatusTaskTest, InProgress_ExpiryHeight) {
   tx_meta->set_tx_hash("tx_hash");
 
   ON_CALL(zcash_rpc(), GetLatestBlock(_, _))
-      .WillByDefault(
-          ::testing::Invoke([](const std::string& chain_id,
-                               MockZCashRPC::GetLatestBlockCallback callback) {
-            std::move(callback).Run(
-                zcash::mojom::BlockID::New(12u, std::vector<uint8_t>()));
-          }));
+      .WillByDefault([](const std::string& chain_id,
+                        MockZCashRPC::GetLatestBlockCallback callback) {
+        std::move(callback).Run(
+            zcash::mojom::BlockID::New(12u, std::vector<uint8_t>()));
+      });
 
   ON_CALL(zcash_rpc(), GetTransaction(_, _, _))
-      .WillByDefault(::testing::Invoke(
-          [](const std::string& chain_id, const std::string& tx_hash,
-             MockZCashRPC::GetTransactionCallback callback) {
-            EXPECT_EQ(tx_hash, "tx_hash");
-            std::move(callback).Run(
-                zcash::mojom::RawTransaction::New(std::vector<uint8_t>(), 0));
-          }));
+      .WillByDefault([](const std::string& chain_id, const std::string& tx_hash,
+                        MockZCashRPC::GetTransactionCallback callback) {
+        EXPECT_EQ(tx_hash, "tx_hash");
+        std::move(callback).Run(
+            zcash::mojom::RawTransaction::New(std::vector<uint8_t>(), 0));
+      });
 
   base::MockCallback<ZCashResolveTransactionStatusTask::
                          ZCashResolveTransactionStatusTaskCallback>
@@ -303,21 +297,19 @@ TEST_F(ZCashResolveTransactionStatusTaskTest, InProgress_Time) {
   tx_meta->set_tx_hash("tx_hash");
 
   ON_CALL(zcash_rpc(), GetLatestBlock(_, _))
-      .WillByDefault(
-          ::testing::Invoke([](const std::string& chain_id,
-                               MockZCashRPC::GetLatestBlockCallback callback) {
-            std::move(callback).Run(
-                zcash::mojom::BlockID::New(12u, std::vector<uint8_t>()));
-          }));
+      .WillByDefault([](const std::string& chain_id,
+                        MockZCashRPC::GetLatestBlockCallback callback) {
+        std::move(callback).Run(
+            zcash::mojom::BlockID::New(12u, std::vector<uint8_t>()));
+      });
 
   ON_CALL(zcash_rpc(), GetTransaction(_, _, _))
-      .WillByDefault(::testing::Invoke(
-          [](const std::string& chain_id, const std::string& tx_hash,
-             MockZCashRPC::GetTransactionCallback callback) {
-            EXPECT_EQ(tx_hash, "tx_hash");
-            std::move(callback).Run(
-                zcash::mojom::RawTransaction::New(std::vector<uint8_t>(), 0));
-          }));
+      .WillByDefault([](const std::string& chain_id, const std::string& tx_hash,
+                        MockZCashRPC::GetTransactionCallback callback) {
+        EXPECT_EQ(tx_hash, "tx_hash");
+        std::move(callback).Run(
+            zcash::mojom::RawTransaction::New(std::vector<uint8_t>(), 0));
+      });
 
   base::MockCallback<ZCashResolveTransactionStatusTask::
                          ZCashResolveTransactionStatusTaskCallback>
@@ -346,21 +338,19 @@ TEST_F(ZCashResolveTransactionStatusTaskTest,
   tx_meta->set_tx_hash("tx_hash");
 
   ON_CALL(zcash_rpc(), GetLatestBlock(_, _))
-      .WillByDefault(
-          ::testing::Invoke([](const std::string& chain_id,
-                               MockZCashRPC::GetLatestBlockCallback callback) {
-            std::move(callback).Run(
-                zcash::mojom::BlockID::New(12u, std::vector<uint8_t>()));
-          }));
+      .WillByDefault([](const std::string& chain_id,
+                        MockZCashRPC::GetLatestBlockCallback callback) {
+        std::move(callback).Run(
+            zcash::mojom::BlockID::New(12u, std::vector<uint8_t>()));
+      });
 
   ON_CALL(zcash_rpc(), GetTransaction(_, _, _))
-      .WillByDefault(::testing::Invoke(
-          [](const std::string& chain_id, const std::string& tx_hash,
-             MockZCashRPC::GetTransactionCallback callback) {
-            EXPECT_EQ(tx_hash, "tx_hash");
-            std::move(callback).Run(
-                zcash::mojom::RawTransaction::New(std::vector<uint8_t>(), 0));
-          }));
+      .WillByDefault([](const std::string& chain_id, const std::string& tx_hash,
+                        MockZCashRPC::GetTransactionCallback callback) {
+        EXPECT_EQ(tx_hash, "tx_hash");
+        std::move(callback).Run(
+            zcash::mojom::RawTransaction::New(std::vector<uint8_t>(), 0));
+      });
 
   base::MockCallback<ZCashResolveTransactionStatusTask::
                          ZCashResolveTransactionStatusTaskCallback>
@@ -387,20 +377,18 @@ TEST_F(ZCashResolveTransactionStatusTaskTest, Error_Transaction) {
   tx_meta->set_tx_hash("tx_hash");
 
   ON_CALL(zcash_rpc(), GetLatestBlock(_, _))
-      .WillByDefault(
-          ::testing::Invoke([](const std::string& chain_id,
-                               MockZCashRPC::GetLatestBlockCallback callback) {
-            std::move(callback).Run(
-                zcash::mojom::BlockID::New(12u, std::vector<uint8_t>()));
-          }));
+      .WillByDefault([](const std::string& chain_id,
+                        MockZCashRPC::GetLatestBlockCallback callback) {
+        std::move(callback).Run(
+            zcash::mojom::BlockID::New(12u, std::vector<uint8_t>()));
+      });
 
   ON_CALL(zcash_rpc(), GetTransaction(_, _, _))
-      .WillByDefault(::testing::Invoke(
-          [](const std::string& chain_id, const std::string& tx_hash,
-             MockZCashRPC::GetTransactionCallback callback) {
-            EXPECT_EQ(tx_hash, "tx_hash");
-            std::move(callback).Run(base::unexpected("error"));
-          }));
+      .WillByDefault([](const std::string& chain_id, const std::string& tx_hash,
+                        MockZCashRPC::GetTransactionCallback callback) {
+        EXPECT_EQ(tx_hash, "tx_hash");
+        std::move(callback).Run(base::unexpected("error"));
+      });
 
   base::MockCallback<ZCashResolveTransactionStatusTask::
                          ZCashResolveTransactionStatusTaskCallback>
@@ -426,20 +414,18 @@ TEST_F(ZCashResolveTransactionStatusTaskTest, Error_LatestBlock) {
   tx_meta->set_tx_hash("tx_hash");
 
   ON_CALL(zcash_rpc(), GetLatestBlock(_, _))
-      .WillByDefault(
-          ::testing::Invoke([](const std::string& chain_id,
-                               MockZCashRPC::GetLatestBlockCallback callback) {
-            std::move(callback).Run(base::unexpected("error"));
-          }));
+      .WillByDefault([](const std::string& chain_id,
+                        MockZCashRPC::GetLatestBlockCallback callback) {
+        std::move(callback).Run(base::unexpected("error"));
+      });
 
   ON_CALL(zcash_rpc(), GetTransaction(_, _, _))
-      .WillByDefault(::testing::Invoke(
-          [](const std::string& chain_id, const std::string& tx_hash,
-             MockZCashRPC::GetTransactionCallback callback) {
-            EXPECT_EQ(tx_hash, "tx_hash");
-            std::move(callback).Run(
-                zcash::mojom::RawTransaction::New(std::vector<uint8_t>(), 0));
-          }));
+      .WillByDefault([](const std::string& chain_id, const std::string& tx_hash,
+                        MockZCashRPC::GetTransactionCallback callback) {
+        EXPECT_EQ(tx_hash, "tx_hash");
+        std::move(callback).Run(
+            zcash::mojom::RawTransaction::New(std::vector<uint8_t>(), 0));
+      });
 
   base::MockCallback<ZCashResolveTransactionStatusTask::
                          ZCashResolveTransactionStatusTaskCallback>

--- a/components/brave_wallet/browser/zcash/zcash_scan_blocks_task_unittest.cc
+++ b/components/brave_wallet/browser/zcash/zcash_scan_blocks_task_unittest.cc
@@ -87,24 +87,24 @@ class ZCashScanBlocksTaskTest : public testing::Test {
   void InitZCashRpc() {
     ON_CALL(zcash_rpc(), GetLatestBlock(_, _))
         .WillByDefault(
-            ::testing::Invoke([](const std::string& chain_id,
-                                 ZCashRpc::GetLatestBlockCallback callback) {
+            [](const std::string& chain_id,
+               ZCashRpc::GetLatestBlockCallback callback) {
               std::move(callback).Run(zcash::mojom::BlockID::New(
                   kChainTipHeight, std::vector<uint8_t>({})));
-            }));
+            });
 
     ON_CALL(zcash_rpc(), GetTreeState(_, _, _))
-        .WillByDefault(::testing::Invoke(
+        .WillByDefault(
             [](const std::string& chain_id, zcash::mojom::BlockIDPtr block,
                ZCashRpc::GetTreeStateCallback callback) {
               // Valid tree state
               auto tree_state = zcash::mojom::TreeState::New(
                   chain_id, block->height, "aabb", 0, "", "");
               std::move(callback).Run(std::move(tree_state));
-            }));
+            });
 
     ON_CALL(zcash_rpc(), GetCompactBlocks(_, _, _, _))
-        .WillByDefault(::testing::Invoke(
+        .WillByDefault(
             [](const std::string& chain_id, uint32_t from, uint32_t to,
                ZCashRpc::GetCompactBlocksCallback callback) {
               std::vector<zcash::mojom::CompactBlockPtr> blocks;
@@ -119,7 +119,7 @@ class ZCashScanBlocksTaskTest : public testing::Test {
                     std::move(chain_metadata)));
               }
               std::move(callback).Run(std::move(blocks));
-            }));
+            });
   }
 
   ZCashActionContext CreateContext() {
@@ -484,7 +484,7 @@ TEST_F(ZCashScanBlocksTaskTest, ScanUnlimited) {
 
 TEST_F(ZCashScanBlocksTaskTest, PartialScanningDueError) {
   ON_CALL(zcash_rpc(), GetCompactBlocks(_, _, _, _))
-      .WillByDefault(::testing::Invoke(
+      .WillByDefault(
           [](const std::string& chain_id, uint32_t from, uint32_t to,
              ZCashRpc::GetCompactBlocksCallback callback) {
             std::vector<zcash::mojom::CompactBlockPtr> blocks;
@@ -504,7 +504,7 @@ TEST_F(ZCashScanBlocksTaskTest, PartialScanningDueError) {
                   std::move(chain_metadata)));
             }
             std::move(callback).Run(std::move(blocks));
-          }));
+          });
 
   auto block_scanner = CreateMockOrchardBlockScannerProxy();
   ZCashActionContext context = CreateContext();
@@ -544,11 +544,11 @@ TEST_F(ZCashScanBlocksTaskTest, PartialScanningDueError) {
 TEST_F(ZCashScanBlocksTaskTest, ChainTipMismatch) {
   ON_CALL(zcash_rpc(), GetLatestBlock(_, _))
       .WillByDefault(
-          ::testing::Invoke([](const std::string& chain_id,
-                               ZCashRpc::GetLatestBlockCallback callback) {
+          [](const std::string& chain_id,
+             ZCashRpc::GetLatestBlockCallback callback) {
             std::move(callback).Run(zcash::mojom::BlockID::New(
                 kChainTipHeight - 200, std::vector<uint8_t>({})));
-          }));
+          });
 
   auto block_scanner = CreateMockOrchardBlockScannerProxy();
   ZCashActionContext context = CreateContext();
@@ -571,11 +571,10 @@ TEST_F(ZCashScanBlocksTaskTest, ChainTipMismatch) {
 
 TEST_F(ZCashScanBlocksTaskTest, NetworkError_LatestBlock) {
   ON_CALL(zcash_rpc(), GetLatestBlock(_, _))
-      .WillByDefault(
-          ::testing::Invoke([](const std::string& chain_id,
-                               ZCashRpc::GetLatestBlockCallback callback) {
-            std::move(callback).Run(base::unexpected("error"));
-          }));
+      .WillByDefault([](const std::string& chain_id,
+                        ZCashRpc::GetLatestBlockCallback callback) {
+        std::move(callback).Run(base::unexpected("error"));
+      });
 
   auto block_scanner = CreateMockOrchardBlockScannerProxy();
   ZCashActionContext context = CreateContext();
@@ -598,11 +597,10 @@ TEST_F(ZCashScanBlocksTaskTest, NetworkError_LatestBlock) {
 
 TEST_F(ZCashScanBlocksTaskTest, NetworkError_CompactBlocks) {
   ON_CALL(zcash_rpc(), GetCompactBlocks(_, _, _, _))
-      .WillByDefault(::testing::Invoke(
-          [](const std::string& chain_id, uint32_t from, uint32_t to,
-             ZCashRpc::GetCompactBlocksCallback callback) {
-            std::move(callback).Run(base::unexpected("error"));
-          }));
+      .WillByDefault([](const std::string& chain_id, uint32_t from, uint32_t to,
+                        ZCashRpc::GetCompactBlocksCallback callback) {
+        std::move(callback).Run(base::unexpected("error"));
+      });
 
   auto block_scanner = CreateMockOrchardBlockScannerProxy();
   ZCashActionContext context = CreateContext();
@@ -627,11 +625,11 @@ TEST_F(ZCashScanBlocksTaskTest, NetworkError_CompactBlocks) {
 
 TEST_F(ZCashScanBlocksTaskTest, NetworkError_TreeState) {
   ON_CALL(zcash_rpc(), GetTreeState(_, _, _))
-      .WillByDefault(::testing::Invoke(
-          [](const std::string& chain_id, zcash::mojom::BlockIDPtr block,
-             ZCashRpc::GetTreeStateCallback callback) {
-            std::move(callback).Run(base::unexpected("error"));
-          }));
+      .WillByDefault([](const std::string& chain_id,
+                        zcash::mojom::BlockIDPtr block,
+                        ZCashRpc::GetTreeStateCallback callback) {
+        std::move(callback).Run(base::unexpected("error"));
+      });
 
   auto block_scanner = CreateMockOrchardBlockScannerProxy();
   ZCashActionContext context = CreateContext();

--- a/components/brave_wallet/browser/zcash/zcash_shield_sync_service_unittest.cc
+++ b/components/brave_wallet/browser/zcash/zcash_shield_sync_service_unittest.cc
@@ -247,24 +247,24 @@ TEST_F(ZCashShieldSyncServiceTest, ScanBlocks) {
 
   ON_CALL(zcash_rpc(), GetLatestBlock(_, _))
       .WillByDefault(
-          ::testing::Invoke([](const std::string& chain_id,
-                               ZCashRpc::GetLatestBlockCallback callback) {
+          [](const std::string& chain_id,
+             ZCashRpc::GetLatestBlockCallback callback) {
             std::move(callback).Run(zcash::mojom::BlockID::New(
                 kNu5BlockUpdate + 500u, std::vector<uint8_t>({})));
-          }));
+          });
 
   ON_CALL(zcash_rpc(), GetTreeState(_, _, _))
-      .WillByDefault(::testing::Invoke(
+      .WillByDefault(
           [](const std::string& chain_id, zcash::mojom::BlockIDPtr block,
              ZCashRpc::GetTreeStateCallback callback) {
             // Valid tree state
             auto tree_state = zcash::mojom::TreeState::New(
                 chain_id, block->height, "aabb", 0, "", "");
             std::move(callback).Run(std::move(tree_state));
-          }));
+          });
 
   ON_CALL(zcash_rpc(), GetCompactBlocks(_, _, _, _))
-      .WillByDefault(::testing::Invoke(
+      .WillByDefault(
           [](const std::string& chain_id, uint32_t from, uint32_t to,
              ZCashRpc::GetCompactBlocksCallback callback) {
             std::vector<zcash::mojom::CompactBlockPtr> blocks;
@@ -279,7 +279,7 @@ TEST_F(ZCashShieldSyncServiceTest, ScanBlocks) {
                   std::move(chain_metadata)));
             }
             std::move(callback).Run(std::move(blocks));
-          }));
+          });
 
   {
     EXPECT_CALL(zcash_wallet_service(), OnSyncFinished(EqualsMojo(account())));
@@ -298,11 +298,11 @@ TEST_F(ZCashShieldSyncServiceTest, ScanBlocks) {
 
   ON_CALL(zcash_rpc(), GetLatestBlock(_, _))
       .WillByDefault(
-          ::testing::Invoke([](const std::string& chain_id,
-                               ZCashRpc::GetLatestBlockCallback callback) {
+          [](const std::string& chain_id,
+             ZCashRpc::GetLatestBlockCallback callback) {
             std::move(callback).Run(zcash::mojom::BlockID::New(
                 kNu5BlockUpdate + 1000u, std::vector<uint8_t>({})));
-          }));
+          });
 
   sync_service()->SetOrchardBlockScannerProxyForTesting(
       std::make_unique<MockOrchardBlockScannerProxy>(base::BindRepeating(
@@ -368,15 +368,15 @@ TEST_F(ZCashShieldSyncServiceTest, ScanBlocks) {
   // Reorg case, chain tip after the latest scanned block.
   ON_CALL(zcash_rpc(), GetLatestBlock(_, _))
       .WillByDefault(
-          ::testing::Invoke([](const std::string& chain_id,
-                               ZCashRpc::GetLatestBlockCallback callback) {
+          [](const std::string& chain_id,
+             ZCashRpc::GetLatestBlockCallback callback) {
             // New chain tip is after the previous one.
             std::move(callback).Run(zcash::mojom::BlockID::New(
                 kNu5BlockUpdate + 1100u, std::vector<uint8_t>({})));
-          }));
+          });
 
   ON_CALL(zcash_rpc(), GetTreeState(_, _, _))
-      .WillByDefault(::testing::Invoke(
+      .WillByDefault(
           [](const std::string& chain_id, zcash::mojom::BlockIDPtr block,
              ZCashRpc::GetTreeStateCallback callback) {
             // Hash of the latest scanned block
@@ -384,7 +384,7 @@ TEST_F(ZCashShieldSyncServiceTest, ScanBlocks) {
             auto tree_state = zcash::mojom::TreeState::New(
                 chain_id, block->height, "aabbccdd", 0, "", "");
             std::move(callback).Run(std::move(tree_state));
-          }));
+          });
 
   sync_service()->SetOrchardBlockScannerProxyForTesting(
       std::make_unique<MockOrchardBlockScannerProxy>(base::BindRepeating(
@@ -434,22 +434,22 @@ TEST_F(ZCashShieldSyncServiceTest, ScanBlocks) {
 
   ON_CALL(zcash_rpc(), GetLatestBlock(_, _))
       .WillByDefault(
-          ::testing::Invoke([](const std::string& chain_id,
-                               ZCashRpc::GetLatestBlockCallback callback) {
+          [](const std::string& chain_id,
+             ZCashRpc::GetLatestBlockCallback callback) {
             // New chain tip below previous one.
             std::move(callback).Run(zcash::mojom::BlockID::New(
                 kNu5BlockUpdate + 1030u, std::vector<uint8_t>({})));
-          }));
+          });
 
   ON_CALL(zcash_rpc(), GetTreeState(_, _, _))
-      .WillByDefault(::testing::Invoke(
+      .WillByDefault(
           [](const std::string& chain_id, zcash::mojom::BlockIDPtr block,
              ZCashRpc::GetTreeStateCallback callback) {
             // Hash of the latest scanned block differs
             auto tree_state = zcash::mojom::TreeState::New(
                 chain_id, block->height, "aabbccddee", 0, "", "");
             std::move(callback).Run(std::move(tree_state));
-          }));
+          });
 
   sync_service()->SetOrchardBlockScannerProxyForTesting(
       std::make_unique<MockOrchardBlockScannerProxy>(base::BindRepeating(

--- a/components/brave_wallet/browser/zcash/zcash_verify_chain_state_task_unittest.cc
+++ b/components/brave_wallet/browser/zcash/zcash_verify_chain_state_task_unittest.cc
@@ -167,22 +167,20 @@ class ZCashVerifyChainStateTaskTest : public testing::Test {
 
 TEST_F(ZCashVerifyChainStateTaskTest, NoReorg) {
   ON_CALL(mocked_sync_state(), GetMinCheckpointId(_))
-      .WillByDefault(
-          ::testing::Invoke([](const mojom::AccountIdPtr& account_id) {
-            return base::ok(
-                std::optional<uint32_t>(kLatestScannedBlock - 100u));
-          }));
+      .WillByDefault([](const mojom::AccountIdPtr& account_id) {
+        return base::ok(std::optional<uint32_t>(kLatestScannedBlock - 100u));
+      });
 
   ON_CALL(zcash_rpc(), GetLatestBlock(_, _))
       .WillByDefault(
-          ::testing::Invoke([](const std::string& chain_id,
-                               ZCashRpc::GetLatestBlockCallback callback) {
+          [](const std::string& chain_id,
+             ZCashRpc::GetLatestBlockCallback callback) {
             std::move(callback).Run(zcash::mojom::BlockID::New(
                 kLatestScannedBlock + 1000u, std::vector<uint8_t>({})));
-          }));
+          });
 
   ON_CALL(zcash_rpc(), GetTreeState(_, _, _))
-      .WillByDefault(::testing::Invoke(
+      .WillByDefault(
           [](const std::string& chain_id, zcash::mojom::BlockIDPtr block,
              ZCashRpc::GetTreeStateCallback callback) {
             if (block->height == kLatestScannedBlock) {
@@ -195,7 +193,7 @@ TEST_F(ZCashVerifyChainStateTaskTest, NoReorg) {
             auto tree_state = zcash::mojom::TreeState::New(
                 chain_id, block->height, "aabb", 0, "", "");
             std::move(callback).Run(std::move(tree_state));
-          }));
+          });
 
   ZCashActionContext context = CreateContext();
 
@@ -219,22 +217,20 @@ TEST_F(ZCashVerifyChainStateTaskTest, NoReorg) {
 
 TEST_F(ZCashVerifyChainStateTaskTest, Reorg_ChainTipBeforeLatestScannedBlock) {
   ON_CALL(mocked_sync_state(), GetMinCheckpointId(_))
-      .WillByDefault(
-          ::testing::Invoke([](const mojom::AccountIdPtr& account_id) {
-            return base::ok(
-                std::optional<uint32_t>(kLatestScannedBlock - 100u));
-          }));
+      .WillByDefault([](const mojom::AccountIdPtr& account_id) {
+        return base::ok(std::optional<uint32_t>(kLatestScannedBlock - 100u));
+      });
 
   ON_CALL(zcash_rpc(), GetLatestBlock(_, _))
       .WillByDefault(
-          ::testing::Invoke([](const std::string& chain_id,
-                               ZCashRpc::GetLatestBlockCallback callback) {
+          [](const std::string& chain_id,
+             ZCashRpc::GetLatestBlockCallback callback) {
             std::move(callback).Run(zcash::mojom::BlockID::New(
                 kLatestScannedBlock - 1u, std::vector<uint8_t>({})));
-          }));
+          });
 
   ON_CALL(zcash_rpc(), GetTreeState(_, _, _))
-      .WillByDefault(::testing::Invoke(
+      .WillByDefault(
           [](const std::string& chain_id, zcash::mojom::BlockIDPtr block,
              ZCashRpc::GetTreeStateCallback callback) {
             if (block->height == kLatestScannedBlock - 100) {
@@ -254,7 +250,7 @@ TEST_F(ZCashVerifyChainStateTaskTest, Reorg_ChainTipBeforeLatestScannedBlock) {
             auto tree_state = zcash::mojom::TreeState::New(
                 chain_id, block->height, "aabb", 0, "", "");
             std::move(callback).Run(std::move(tree_state));
-          }));
+          });
 
   ZCashActionContext context = CreateContext();
 
@@ -281,22 +277,20 @@ TEST_F(ZCashVerifyChainStateTaskTest, Reorg_ChainTipBeforeLatestScannedBlock) {
 
 TEST_F(ZCashVerifyChainStateTaskTest, Reorg_ChainTipAfterLatestScannedBlock) {
   ON_CALL(mocked_sync_state(), GetMinCheckpointId(_))
-      .WillByDefault(
-          ::testing::Invoke([](const mojom::AccountIdPtr& account_id) {
-            return base::ok(
-                std::optional<uint32_t>(kLatestScannedBlock - 100u));
-          }));
+      .WillByDefault([](const mojom::AccountIdPtr& account_id) {
+        return base::ok(std::optional<uint32_t>(kLatestScannedBlock - 100u));
+      });
 
   ON_CALL(zcash_rpc(), GetLatestBlock(_, _))
       .WillByDefault(
-          ::testing::Invoke([](const std::string& chain_id,
-                               ZCashRpc::GetLatestBlockCallback callback) {
+          [](const std::string& chain_id,
+             ZCashRpc::GetLatestBlockCallback callback) {
             std::move(callback).Run(zcash::mojom::BlockID::New(
                 kLatestScannedBlock + 1000u, std::vector<uint8_t>({})));
-          }));
+          });
 
   ON_CALL(zcash_rpc(), GetTreeState(_, _, _))
-      .WillByDefault(::testing::Invoke(
+      .WillByDefault(
           [](const std::string& chain_id, zcash::mojom::BlockIDPtr block,
              ZCashRpc::GetTreeStateCallback callback) {
             if (block->height == kLatestScannedBlock) {
@@ -318,7 +312,7 @@ TEST_F(ZCashVerifyChainStateTaskTest, Reorg_ChainTipAfterLatestScannedBlock) {
             auto tree_state = zcash::mojom::TreeState::New(
                 chain_id, block->height, "aabb", 0, "", "");
             std::move(callback).Run(std::move(tree_state));
-          }));
+          });
 
   ZCashActionContext context = CreateContext();
 
@@ -345,22 +339,20 @@ TEST_F(ZCashVerifyChainStateTaskTest, Reorg_ChainTipAfterLatestScannedBlock) {
 
 TEST_F(ZCashVerifyChainStateTaskTest, Reorg_LatestBlockHashChanged) {
   ON_CALL(mocked_sync_state(), GetMinCheckpointId(_))
-      .WillByDefault(
-          ::testing::Invoke([](const mojom::AccountIdPtr& account_id) {
-            return base::ok(
-                std::optional<uint32_t>(kLatestScannedBlock - 100u));
-          }));
+      .WillByDefault([](const mojom::AccountIdPtr& account_id) {
+        return base::ok(std::optional<uint32_t>(kLatestScannedBlock - 100u));
+      });
 
   ON_CALL(zcash_rpc(), GetLatestBlock(_, _))
       .WillByDefault(
-          ::testing::Invoke([](const std::string& chain_id,
-                               ZCashRpc::GetLatestBlockCallback callback) {
+          [](const std::string& chain_id,
+             ZCashRpc::GetLatestBlockCallback callback) {
             std::move(callback).Run(zcash::mojom::BlockID::New(
                 kLatestScannedBlock, std::vector<uint8_t>({})));
-          }));
+          });
 
   ON_CALL(zcash_rpc(), GetTreeState(_, _, _))
-      .WillByDefault(::testing::Invoke(
+      .WillByDefault(
           [](const std::string& chain_id, zcash::mojom::BlockIDPtr block,
              ZCashRpc::GetTreeStateCallback callback) {
             if (block->height == kLatestScannedBlock - 100) {
@@ -379,7 +371,7 @@ TEST_F(ZCashVerifyChainStateTaskTest, Reorg_LatestBlockHashChanged) {
             auto tree_state = zcash::mojom::TreeState::New(
                 chain_id, block->height, "aabb", 0, "", "");
             std::move(callback).Run(std::move(tree_state));
-          }));
+          });
 
   ZCashActionContext context = CreateContext();
 
@@ -406,21 +398,20 @@ TEST_F(ZCashVerifyChainStateTaskTest, Reorg_LatestBlockHashChanged) {
 
 TEST_F(ZCashVerifyChainStateTaskTest, Error_CheckpointIdFailed) {
   ON_CALL(mocked_sync_state(), GetMinCheckpointId(_))
-      .WillByDefault(
-          ::testing::Invoke([](const mojom::AccountIdPtr& account_id) {
-            return base::unexpected(OrchardStorage::Error());
-          }));
+      .WillByDefault([](const mojom::AccountIdPtr& account_id) {
+        return base::unexpected(OrchardStorage::Error());
+      });
 
   ON_CALL(zcash_rpc(), GetLatestBlock(_, _))
       .WillByDefault(
-          ::testing::Invoke([](const std::string& chain_id,
-                               ZCashRpc::GetLatestBlockCallback callback) {
+          [](const std::string& chain_id,
+             ZCashRpc::GetLatestBlockCallback callback) {
             std::move(callback).Run(zcash::mojom::BlockID::New(
                 kLatestScannedBlock, std::vector<uint8_t>({})));
-          }));
+          });
 
   ON_CALL(zcash_rpc(), GetTreeState(_, _, _))
-      .WillByDefault(::testing::Invoke(
+      .WillByDefault(
           [](const std::string& chain_id, zcash::mojom::BlockIDPtr block,
              ZCashRpc::GetTreeStateCallback callback) {
             if (block->height == kLatestScannedBlock) {
@@ -433,7 +424,7 @@ TEST_F(ZCashVerifyChainStateTaskTest, Error_CheckpointIdFailed) {
             auto tree_state = zcash::mojom::TreeState::New(
                 chain_id, block->height, "aabb", 0, "", "");
             std::move(callback).Run(std::move(tree_state));
-          }));
+          });
 
   ZCashActionContext context = CreateContext();
 
@@ -457,21 +448,20 @@ TEST_F(ZCashVerifyChainStateTaskTest, Error_CheckpointIdFailed) {
 
 TEST_F(ZCashVerifyChainStateTaskTest, Error_NoCheckpointId) {
   ON_CALL(mocked_sync_state(), GetMinCheckpointId(_))
-      .WillByDefault(
-          ::testing::Invoke([](const mojom::AccountIdPtr& account_id) {
-            return base::ok(std::nullopt);
-          }));
+      .WillByDefault([](const mojom::AccountIdPtr& account_id) {
+        return base::ok(std::nullopt);
+      });
 
   ON_CALL(zcash_rpc(), GetLatestBlock(_, _))
       .WillByDefault(
-          ::testing::Invoke([](const std::string& chain_id,
-                               ZCashRpc::GetLatestBlockCallback callback) {
+          [](const std::string& chain_id,
+             ZCashRpc::GetLatestBlockCallback callback) {
             std::move(callback).Run(zcash::mojom::BlockID::New(
                 kLatestScannedBlock, std::vector<uint8_t>({})));
-          }));
+          });
 
   ON_CALL(zcash_rpc(), GetTreeState(_, _, _))
-      .WillByDefault(::testing::Invoke(
+      .WillByDefault(
           [](const std::string& chain_id, zcash::mojom::BlockIDPtr block,
              ZCashRpc::GetTreeStateCallback callback) {
             if (block->height == kLatestScannedBlock) {
@@ -484,7 +474,7 @@ TEST_F(ZCashVerifyChainStateTaskTest, Error_NoCheckpointId) {
             auto tree_state = zcash::mojom::TreeState::New(
                 chain_id, block->height, "aabb", 0, "", "");
             std::move(callback).Run(std::move(tree_state));
-          }));
+          });
 
   ZCashActionContext context = CreateContext();
 
@@ -508,21 +498,18 @@ TEST_F(ZCashVerifyChainStateTaskTest, Error_NoCheckpointId) {
 
 TEST_F(ZCashVerifyChainStateTaskTest, Error_LatestBlockFailed) {
   ON_CALL(mocked_sync_state(), GetMinCheckpointId(_))
-      .WillByDefault(
-          ::testing::Invoke([](const mojom::AccountIdPtr& account_id) {
-            return base::ok(
-                std::optional<uint32_t>(kLatestScannedBlock - 100u));
-          }));
+      .WillByDefault([](const mojom::AccountIdPtr& account_id) {
+        return base::ok(std::optional<uint32_t>(kLatestScannedBlock - 100u));
+      });
 
   ON_CALL(zcash_rpc(), GetLatestBlock(_, _))
-      .WillByDefault(
-          ::testing::Invoke([](const std::string& chain_id,
-                               ZCashRpc::GetLatestBlockCallback callback) {
-            std::move(callback).Run(base::unexpected("error"));
-          }));
+      .WillByDefault([](const std::string& chain_id,
+                        ZCashRpc::GetLatestBlockCallback callback) {
+        std::move(callback).Run(base::unexpected("error"));
+      });
 
   ON_CALL(zcash_rpc(), GetTreeState(_, _, _))
-      .WillByDefault(::testing::Invoke(
+      .WillByDefault(
           [](const std::string& chain_id, zcash::mojom::BlockIDPtr block,
              ZCashRpc::GetTreeStateCallback callback) {
             if (block->height == kLatestScannedBlock - 100) {
@@ -541,7 +528,7 @@ TEST_F(ZCashVerifyChainStateTaskTest, Error_LatestBlockFailed) {
             auto tree_state = zcash::mojom::TreeState::New(
                 chain_id, block->height, "aabb", 0, "", "");
             std::move(callback).Run(std::move(tree_state));
-          }));
+          });
 
   ZCashActionContext context = CreateContext();
 
@@ -565,26 +552,24 @@ TEST_F(ZCashVerifyChainStateTaskTest, Error_LatestBlockFailed) {
 
 TEST_F(ZCashVerifyChainStateTaskTest, Error_TreeStateFailed) {
   ON_CALL(mocked_sync_state(), GetMinCheckpointId(_))
-      .WillByDefault(
-          ::testing::Invoke([](const mojom::AccountIdPtr& account_id) {
-            return base::ok(
-                std::optional<uint32_t>(kLatestScannedBlock - 100u));
-          }));
+      .WillByDefault([](const mojom::AccountIdPtr& account_id) {
+        return base::ok(std::optional<uint32_t>(kLatestScannedBlock - 100u));
+      });
 
   ON_CALL(zcash_rpc(), GetLatestBlock(_, _))
       .WillByDefault(
-          ::testing::Invoke([](const std::string& chain_id,
-                               ZCashRpc::GetLatestBlockCallback callback) {
+          [](const std::string& chain_id,
+             ZCashRpc::GetLatestBlockCallback callback) {
             std::move(callback).Run(zcash::mojom::BlockID::New(
                 kLatestScannedBlock, std::vector<uint8_t>({})));
-          }));
+          });
 
   ON_CALL(zcash_rpc(), GetTreeState(_, _, _))
-      .WillByDefault(::testing::Invoke(
-          [](const std::string& chain_id, zcash::mojom::BlockIDPtr block,
-             ZCashRpc::GetTreeStateCallback callback) {
-            std::move(callback).Run(base::unexpected("error"));
-          }));
+      .WillByDefault([](const std::string& chain_id,
+                        zcash::mojom::BlockIDPtr block,
+                        ZCashRpc::GetTreeStateCallback callback) {
+        std::move(callback).Run(base::unexpected("error"));
+      });
 
   ZCashActionContext context = CreateContext();
 

--- a/components/brave_wallet/browser/zcash/zcash_wallet_service_unittest.cc
+++ b/components/brave_wallet/browser/zcash/zcash_wallet_service_unittest.cc
@@ -206,12 +206,11 @@ class ZCashWalletServiceUnitTest : public testing::Test {
     ASSERT_TRUE(zcash_account_);
 
     ON_CALL(zcash_rpc(), GetLightdInfo(_, _))
-        .WillByDefault(
-            ::testing::Invoke([&](const std::string& chain_id,
-                                  ZCashRpc::GetLightdInfoCallback callback) {
-              auto response = zcash::mojom::LightdInfo::New("c2d6d0b4");
-              std::move(callback).Run(std::move(response));
-            }));
+        .WillByDefault([&](const std::string& chain_id,
+                           ZCashRpc::GetLightdInfoCallback callback) {
+          auto response = zcash::mojom::LightdInfo::New("c2d6d0b4");
+          std::move(callback).Run(std::move(response));
+        });
   }
 
   AccountUtils GetAccountUtils() {
@@ -283,42 +282,41 @@ TEST_F(ZCashWalletServiceUnitTest, GetBalance) {
 
   ON_CALL(zcash_rpc(), GetLatestBlock(_, _))
       .WillByDefault(
-          ::testing::Invoke([&](const std::string& chain_id,
-                                ZCashRpc::GetLatestBlockCallback callback) {
+          [&](const std::string& chain_id,
+              ZCashRpc::GetLatestBlockCallback callback) {
             auto response = zcash::mojom::BlockID::New(
                 2625446u,
                 *PrefixedHexStringToBytes("0x0000000001a01b5fd794e4b071443974c8"
                                           "35b3e0ff8f96bf3600e07afdbf89c5"));
             std::move(callback).Run(std::move(response));
-          }));
+          });
 
   ON_CALL(zcash_rpc(), IsKnownAddress(_, _, _, _, _))
-      .WillByDefault(::testing::Invoke(
-          [](const std::string& chain_id, const std::string& addr,
-             uint64_t block_start, uint64_t block_end,
-             ZCashRpc::IsKnownAddressCallback callback) {
-            // Receiver addresses
-            if (addr == "t1ShtibD2UJkYTeGPxeLrMf3jvE11S4Lpwj") {
-              std::move(callback).Run(true);
-              return;
-            }
-            if (addr == "t1aW1cW7wf6KMuKrjDinyv9tK6F6hrBkRAY") {
-              std::move(callback).Run(true);
-              return;
-            }
-            if (addr == "t1aW1cW7wf6KMuKrjDinyv9tK6F6hrBkRAY") {
-              std::move(callback).Run(true);
-              return;
-            }
-            if (addr == "t1MF6q7rTYJMMKLgzQ58mCuo76EVhLfSAkW") {
-              std::move(callback).Run(true);
-              return;
-            }
-            std::move(callback).Run(false);
-          }));
+      .WillByDefault([](const std::string& chain_id, const std::string& addr,
+                        uint64_t block_start, uint64_t block_end,
+                        ZCashRpc::IsKnownAddressCallback callback) {
+        // Receiver addresses
+        if (addr == "t1ShtibD2UJkYTeGPxeLrMf3jvE11S4Lpwj") {
+          std::move(callback).Run(true);
+          return;
+        }
+        if (addr == "t1aW1cW7wf6KMuKrjDinyv9tK6F6hrBkRAY") {
+          std::move(callback).Run(true);
+          return;
+        }
+        if (addr == "t1aW1cW7wf6KMuKrjDinyv9tK6F6hrBkRAY") {
+          std::move(callback).Run(true);
+          return;
+        }
+        if (addr == "t1MF6q7rTYJMMKLgzQ58mCuo76EVhLfSAkW") {
+          std::move(callback).Run(true);
+          return;
+        }
+        std::move(callback).Run(false);
+      });
 
   ON_CALL(zcash_rpc(), GetUtxoList(_, _, _))
-      .WillByDefault(::testing::Invoke(
+      .WillByDefault(
           [&](const std::string& chain_id, const std::string& address,
               ZCashRpc::GetUtxoListCallback callback) {
             std::vector<zcash::mojom::ZCashUtxoPtr> utxos;
@@ -359,16 +357,16 @@ TEST_F(ZCashWalletServiceUnitTest, GetBalance) {
             auto response =
                 zcash::mojom::GetAddressUtxosResponse::New(std::move(utxos));
             std::move(callback).Run(std::move(response));
-          }));
+          });
 
   base::MockCallback<ZCashWalletService::GetBalanceCallback> balance_callback;
   EXPECT_CALL(balance_callback, Run(_, _))
-      .WillOnce(::testing::Invoke([&](mojom::ZCashBalancePtr balance,
-                                      std::optional<std::string> error) {
+      .WillOnce([&](mojom::ZCashBalancePtr balance,
+                    std::optional<std::string> error) {
         EXPECT_EQ(balance->total_balance, 50u);
         EXPECT_EQ(balance->transparent_balance, 50u);
         EXPECT_EQ(balance->shielded_balance, 0u);
-      }));
+      });
 
   zcash_wallet_service_->GetBalance(mojom::kZCashMainnet, account_id.Clone(),
                                     balance_callback.Get());
@@ -393,30 +391,29 @@ TEST_F(ZCashWalletServiceUnitTest, GetBalanceWithShielded) {
 
   ON_CALL(zcash_rpc(), GetLatestBlock(_, _))
       .WillByDefault(
-          ::testing::Invoke([&](const std::string& chain_id,
-                                ZCashRpc::GetLatestBlockCallback callback) {
+          [&](const std::string& chain_id,
+              ZCashRpc::GetLatestBlockCallback callback) {
             auto response = zcash::mojom::BlockID::New(
                 2625446u,
                 *PrefixedHexStringToBytes("0x0000000001a01b5fd794e4b071443974c8"
                                           "35b3e0ff8f96bf3600e07afdbf89c5"));
             std::move(callback).Run(std::move(response));
-          }));
+          });
 
   ON_CALL(zcash_rpc(), IsKnownAddress(_, _, _, _, _))
-      .WillByDefault(::testing::Invoke(
-          [](const std::string& chain_id, const std::string& addr,
-             uint64_t block_start, uint64_t block_end,
-             ZCashRpc::IsKnownAddressCallback callback) {
-            // Receiver addresses
-            if (addr == "t1ShtibD2UJkYTeGPxeLrMf3jvE11S4Lpwj") {
-              std::move(callback).Run(true);
-              return;
-            }
-            std::move(callback).Run(false);
-          }));
+      .WillByDefault([](const std::string& chain_id, const std::string& addr,
+                        uint64_t block_start, uint64_t block_end,
+                        ZCashRpc::IsKnownAddressCallback callback) {
+        // Receiver addresses
+        if (addr == "t1ShtibD2UJkYTeGPxeLrMf3jvE11S4Lpwj") {
+          std::move(callback).Run(true);
+          return;
+        }
+        std::move(callback).Run(false);
+      });
 
   ON_CALL(zcash_rpc(), GetUtxoList(_, _, _))
-      .WillByDefault(::testing::Invoke(
+      .WillByDefault(
           [&](const std::string& chain_id, const std::string& address,
               ZCashRpc::GetUtxoListCallback callback) {
             std::vector<zcash::mojom::ZCashUtxoPtr> utxos;
@@ -435,26 +432,25 @@ TEST_F(ZCashWalletServiceUnitTest, GetBalanceWithShielded) {
             auto response =
                 zcash::mojom::GetAddressUtxosResponse::New(std::move(utxos));
             std::move(callback).Run(std::move(response));
-          }));
+          });
 
   ON_CALL(mock_orchard_sync_state(), GetSpendableNotes(_, _))
-      .WillByDefault(
-          ::testing::Invoke([](const mojom::AccountIdPtr& account_id,
-                               const OrchardAddrRawPart& internal_addr) {
-            OrchardSyncState::SpendableNotesBundle spendable_notes_bundle;
-            {
-              OrchardNote note;
-              note.amount = 10u;
-              spendable_notes_bundle.all_notes.push_back(note);
-              spendable_notes_bundle.spendable_notes.push_back(note);
-            }
-            {
-              OrchardNote note;
-              note.amount = 20u;
-              spendable_notes_bundle.all_notes.push_back(note);
-            }
-            return spendable_notes_bundle;
-          }));
+      .WillByDefault([](const mojom::AccountIdPtr& account_id,
+                        const OrchardAddrRawPart& internal_addr) {
+        OrchardSyncState::SpendableNotesBundle spendable_notes_bundle;
+        {
+          OrchardNote note;
+          note.amount = 10u;
+          spendable_notes_bundle.all_notes.push_back(note);
+          spendable_notes_bundle.spendable_notes.push_back(note);
+        }
+        {
+          OrchardNote note;
+          note.amount = 20u;
+          spendable_notes_bundle.all_notes.push_back(note);
+        }
+        return spendable_notes_bundle;
+      });
 
   base::SequenceBound<MockOrchardSyncStateProxy> overrided_sync_state(
       base::SequencedTaskRunner::GetCurrentDefault(), db_path(),
@@ -463,13 +459,13 @@ TEST_F(ZCashWalletServiceUnitTest, GetBalanceWithShielded) {
 
   base::MockCallback<ZCashWalletService::GetBalanceCallback> balance_callback;
   EXPECT_CALL(balance_callback, Run(_, _))
-      .WillOnce(::testing::Invoke([&](mojom::ZCashBalancePtr balance,
-                                      std::optional<std::string> error) {
+      .WillOnce([&](mojom::ZCashBalancePtr balance,
+                    std::optional<std::string> error) {
         EXPECT_EQ(balance->total_balance, 20u);
         EXPECT_EQ(balance->transparent_balance, 10u);
         EXPECT_EQ(balance->shielded_balance, 10u);
         EXPECT_EQ(balance->shielded_pending_balance, 20u);
-      }));
+      });
   zcash_wallet_service_->GetBalance(mojom::kZCashMainnet, account_id.Clone(),
                                     balance_callback.Get());
   task_environment_.RunUntilIdle();
@@ -499,30 +495,29 @@ TEST_F(ZCashWalletServiceUnitTest, GetBalanceWithShielded_FeatureDisabled) {
 
   ON_CALL(zcash_rpc(), GetLatestBlock(_, _))
       .WillByDefault(
-          ::testing::Invoke([&](const std::string& chain_id,
-                                ZCashRpc::GetLatestBlockCallback callback) {
+          [&](const std::string& chain_id,
+              ZCashRpc::GetLatestBlockCallback callback) {
             auto response = zcash::mojom::BlockID::New(
                 2625446u,
                 *PrefixedHexStringToBytes("0x0000000001a01b5fd794e4b071443974c8"
                                           "35b3e0ff8f96bf3600e07afdbf89c5"));
             std::move(callback).Run(std::move(response));
-          }));
+          });
 
   ON_CALL(zcash_rpc(), IsKnownAddress(_, _, _, _, _))
-      .WillByDefault(::testing::Invoke(
-          [](const std::string& chain_id, const std::string& addr,
-             uint64_t block_start, uint64_t block_end,
-             ZCashRpc::IsKnownAddressCallback callback) {
-            // Receiver addresses
-            if (addr == "t1ShtibD2UJkYTeGPxeLrMf3jvE11S4Lpwj") {
-              std::move(callback).Run(true);
-              return;
-            }
-            std::move(callback).Run(false);
-          }));
+      .WillByDefault([](const std::string& chain_id, const std::string& addr,
+                        uint64_t block_start, uint64_t block_end,
+                        ZCashRpc::IsKnownAddressCallback callback) {
+        // Receiver addresses
+        if (addr == "t1ShtibD2UJkYTeGPxeLrMf3jvE11S4Lpwj") {
+          std::move(callback).Run(true);
+          return;
+        }
+        std::move(callback).Run(false);
+      });
 
   ON_CALL(zcash_rpc(), GetUtxoList(_, _, _))
-      .WillByDefault(::testing::Invoke(
+      .WillByDefault(
           [&](const std::string& chain_id, const std::string& address,
               ZCashRpc::GetUtxoListCallback callback) {
             std::vector<zcash::mojom::ZCashUtxoPtr> utxos;
@@ -541,7 +536,7 @@ TEST_F(ZCashWalletServiceUnitTest, GetBalanceWithShielded_FeatureDisabled) {
             auto response =
                 zcash::mojom::GetAddressUtxosResponse::New(std::move(utxos));
             std::move(callback).Run(std::move(response));
-          }));
+          });
 
   OrchardNote note;
   note.amount = 10u;
@@ -563,12 +558,12 @@ TEST_F(ZCashWalletServiceUnitTest, GetBalanceWithShielded_FeatureDisabled) {
 
   base::MockCallback<ZCashWalletService::GetBalanceCallback> balance_callback;
   EXPECT_CALL(balance_callback, Run(_, _))
-      .WillOnce(::testing::Invoke([&](mojom::ZCashBalancePtr balance,
-                                      std::optional<std::string> error) {
+      .WillOnce([&](mojom::ZCashBalancePtr balance,
+                    std::optional<std::string> error) {
         EXPECT_EQ(balance->total_balance, 10u);
         EXPECT_EQ(balance->transparent_balance, 10u);
         EXPECT_EQ(balance->shielded_balance, 0u);
-      }));
+      });
   zcash_wallet_service_->GetBalance(mojom::kZCashMainnet, account_id.Clone(),
                                     balance_callback.Get());
   task_environment_.RunUntilIdle();
@@ -619,13 +614,12 @@ TEST_F(ZCashWalletServiceUnitTest, SignAndPostTransaction) {
   }
 
   ON_CALL(zcash_rpc(), GetLatestBlock(_, _))
-      .WillByDefault(
-          ::testing::Invoke([](const std::string& chain_id,
-                               ZCashRpc::GetLatestBlockCallback callback) {
-            zcash::mojom::BlockIDPtr response = zcash::mojom::BlockID::New();
-            response->height = 2286687;
-            std::move(callback).Run(std::move(response));
-          }));
+      .WillByDefault([](const std::string& chain_id,
+                        ZCashRpc::GetLatestBlockCallback callback) {
+        zcash::mojom::BlockIDPtr response = zcash::mojom::BlockID::New();
+        response->height = 2286687;
+        std::move(callback).Run(std::move(response));
+      });
 
   base::MockCallback<ZCashWalletService::SignAndPostTransactionCallback>
       sign_callback;
@@ -674,47 +668,45 @@ TEST_F(ZCashWalletServiceUnitTest, SignAndPostTransaction) {
 
 TEST_F(ZCashWalletServiceUnitTest, AddressDiscovery) {
   ON_CALL(zcash_rpc(), GetLatestBlock(_, _))
-      .WillByDefault(
-          ::testing::Invoke([](const std::string& chain_id,
-                               ZCashRpc::GetLatestBlockCallback callback) {
-            zcash::mojom::BlockIDPtr response = zcash::mojom::BlockID::New();
-            response->height = 2286687;
-            std::move(callback).Run(std::move(response));
-          }));
+      .WillByDefault([](const std::string& chain_id,
+                        ZCashRpc::GetLatestBlockCallback callback) {
+        zcash::mojom::BlockIDPtr response = zcash::mojom::BlockID::New();
+        response->height = 2286687;
+        std::move(callback).Run(std::move(response));
+      });
 
   ON_CALL(zcash_rpc(), IsKnownAddress(_, _, _, _, _))
-      .WillByDefault(::testing::Invoke(
-          [](const std::string& chain_id, const std::string& addr,
-             uint64_t block_start, uint64_t block_end,
-             ZCashRpc::IsKnownAddressCallback callback) {
-            EXPECT_EQ(2286687u, block_end);
-            // Receiver addresses
-            if (addr == "t1c61yifRMgyhMsBYsFDBa5aEQkgU65CGau") {
-              std::move(callback).Run(true);
-              return;
-            }
-            if (addr == "t1V7JBWXRYPA19nBLBFTm8669DhQgErMAnK") {
-              std::move(callback).Run(true);
-              return;
-            }
-            if (addr == "t1UCYMSUdkGXEyeKPqgwiDn8NwGv5JKmJoL") {
-              std::move(callback).Run(false);
-              return;
-            }
-            // Change addresses
-            if (addr == "t1RDtGXzcfchmtrE8pGLorefgtspgcNZbrE") {
-              std::move(callback).Run(true);
-              return;
-            }
-            if (addr == "t1VUdyCuqWgeBPJvfhWvHLD5iDUfkdLrwWz") {
-              std::move(callback).Run(true);
-              return;
-            }
-            if (addr == "t1QJuws2nGqDNJEKsKniUPDNLbMw5R9ixGj") {
-              std::move(callback).Run(false);
-              return;
-            }
-          }));
+      .WillByDefault([](const std::string& chain_id, const std::string& addr,
+                        uint64_t block_start, uint64_t block_end,
+                        ZCashRpc::IsKnownAddressCallback callback) {
+        EXPECT_EQ(2286687u, block_end);
+        // Receiver addresses
+        if (addr == "t1c61yifRMgyhMsBYsFDBa5aEQkgU65CGau") {
+          std::move(callback).Run(true);
+          return;
+        }
+        if (addr == "t1V7JBWXRYPA19nBLBFTm8669DhQgErMAnK") {
+          std::move(callback).Run(true);
+          return;
+        }
+        if (addr == "t1UCYMSUdkGXEyeKPqgwiDn8NwGv5JKmJoL") {
+          std::move(callback).Run(false);
+          return;
+        }
+        // Change addresses
+        if (addr == "t1RDtGXzcfchmtrE8pGLorefgtspgcNZbrE") {
+          std::move(callback).Run(true);
+          return;
+        }
+        if (addr == "t1VUdyCuqWgeBPJvfhWvHLD5iDUfkdLrwWz") {
+          std::move(callback).Run(true);
+          return;
+        }
+        if (addr == "t1QJuws2nGqDNJEKsKniUPDNLbMw5R9ixGj") {
+          std::move(callback).Run(false);
+          return;
+        }
+      });
 
   {
     bool callback_called = false;
@@ -739,30 +731,29 @@ TEST_F(ZCashWalletServiceUnitTest, AddressDiscovery) {
   }
 
   ON_CALL(zcash_rpc(), IsKnownAddress(_, _, _, _, _))
-      .WillByDefault(::testing::Invoke(
-          [](const std::string& chain_id, const std::string& addr,
-             uint64_t block_start, uint64_t block_end,
-             ZCashRpc::IsKnownAddressCallback callback) {
-            EXPECT_EQ(2286687u, block_end);
-            // Receiver addresses
-            if (addr == "t1UCYMSUdkGXEyeKPqgwiDn8NwGv5JKmJoL") {
-              std::move(callback).Run(true);
-              return;
-            }
-            if (addr == "t1JEfEPQDGruzd7Q42pdwHmR4sRHGLRF48m") {
-              std::move(callback).Run(false);
-              return;
-            }
-            // Change addresses
-            if (addr == "t1QJuws2nGqDNJEKsKniUPDNLbMw5R9ixGj") {
-              std::move(callback).Run(true);
-              return;
-            }
-            if (addr == "t1gKxueg76TtvVmMQ6swDmvHxtmLTSQv6KP") {
-              std::move(callback).Run(false);
-              return;
-            }
-          }));
+      .WillByDefault([](const std::string& chain_id, const std::string& addr,
+                        uint64_t block_start, uint64_t block_end,
+                        ZCashRpc::IsKnownAddressCallback callback) {
+        EXPECT_EQ(2286687u, block_end);
+        // Receiver addresses
+        if (addr == "t1UCYMSUdkGXEyeKPqgwiDn8NwGv5JKmJoL") {
+          std::move(callback).Run(true);
+          return;
+        }
+        if (addr == "t1JEfEPQDGruzd7Q42pdwHmR4sRHGLRF48m") {
+          std::move(callback).Run(false);
+          return;
+        }
+        // Change addresses
+        if (addr == "t1QJuws2nGqDNJEKsKniUPDNLbMw5R9ixGj") {
+          std::move(callback).Run(true);
+          return;
+        }
+        if (addr == "t1gKxueg76TtvVmMQ6swDmvHxtmLTSQv6KP") {
+          std::move(callback).Run(false);
+          return;
+        }
+      });
 
   {
     bool callback_called = false;
@@ -789,35 +780,33 @@ TEST_F(ZCashWalletServiceUnitTest, AddressDiscovery) {
 
 TEST_F(ZCashWalletServiceUnitTest, AddressDiscovery_FromPrefs) {
   ON_CALL(zcash_rpc(), GetLatestBlock(_, _))
-      .WillByDefault(
-          ::testing::Invoke([](const std::string& chain_id,
-                               ZCashRpc::GetLatestBlockCallback callback) {
-            zcash::mojom::BlockIDPtr response = zcash::mojom::BlockID::New();
-            response->height = 2286687;
-            std::move(callback).Run(std::move(response));
-          }));
+      .WillByDefault([](const std::string& chain_id,
+                        ZCashRpc::GetLatestBlockCallback callback) {
+        zcash::mojom::BlockIDPtr response = zcash::mojom::BlockID::New();
+        response->height = 2286687;
+        std::move(callback).Run(std::move(response));
+      });
 
   ON_CALL(zcash_rpc(), IsKnownAddress(_, _, _, _, _))
-      .WillByDefault(::testing::Invoke(
-          [](const std::string& chain_id, const std::string& addr,
-             uint64_t block_start, uint64_t block_end,
-             ZCashRpc::IsKnownAddressCallback callback) {
-            EXPECT_EQ(2286687u, block_end);
-            // Receiver addresses
-            if (addr == "t1UCYMSUdkGXEyeKPqgwiDn8NwGv5JKmJoL") {
-              std::move(callback).Run(true);
-              return;
-            }
-            if (addr == "t1JEfEPQDGruzd7Q42pdwHmR4sRHGLRF48m") {
-              std::move(callback).Run(false);
-              return;
-            }
-            // Change addresses
-            if (addr == "t1RDtGXzcfchmtrE8pGLorefgtspgcNZbrE") {
-              std::move(callback).Run(false);
-              return;
-            }
-          }));
+      .WillByDefault([](const std::string& chain_id, const std::string& addr,
+                        uint64_t block_start, uint64_t block_end,
+                        ZCashRpc::IsKnownAddressCallback callback) {
+        EXPECT_EQ(2286687u, block_end);
+        // Receiver addresses
+        if (addr == "t1UCYMSUdkGXEyeKPqgwiDn8NwGv5JKmJoL") {
+          std::move(callback).Run(true);
+          return;
+        }
+        if (addr == "t1JEfEPQDGruzd7Q42pdwHmR4sRHGLRF48m") {
+          std::move(callback).Run(false);
+          return;
+        }
+        // Change addresses
+        if (addr == "t1RDtGXzcfchmtrE8pGLorefgtspgcNZbrE") {
+          std::move(callback).Run(false);
+          return;
+        }
+      });
 
   {
     auto account_id = MakeIndexBasedAccountId(mojom::CoinType::ZEC,
@@ -994,16 +983,15 @@ TEST_F(ZCashWalletServiceUnitTest, AutoSync) {
                                               mojom::AccountKind::kDerived, 0);
 
   ON_CALL(zcash_rpc(), GetLatestBlock(_, _))
-      .WillByDefault(
-          ::testing::Invoke([&](const std::string& chain_id,
-                                ZCashRpc::GetLatestBlockCallback callback) {
-            auto response =
-                zcash::mojom::BlockID::New(100000u, std::vector<uint8_t>());
-            std::move(callback).Run(std::move(response));
-          }));
+      .WillByDefault([&](const std::string& chain_id,
+                         ZCashRpc::GetLatestBlockCallback callback) {
+        auto response =
+            zcash::mojom::BlockID::New(100000u, std::vector<uint8_t>());
+        std::move(callback).Run(std::move(response));
+      });
 
   ON_CALL(zcash_rpc(), GetTreeState(_, _, _))
-      .WillByDefault(::testing::Invoke(
+      .WillByDefault(
           [&](const std::string& chain_id, zcash::mojom::BlockIDPtr block_id,
               ZCashRpc::GetTreeStateCallback callback) {
             EXPECT_EQ(block_id->height, 100000u - kChainReorgBlockDelta);
@@ -1013,7 +1001,7 @@ TEST_F(ZCashWalletServiceUnitTest, AutoSync) {
                 "hexhexhex2" /* hash */, 123 /* time */, "" /* sapling tree */,
                 "" /* orchard tree */);
             std::move(callback).Run(std::move(tree_state));
-          }));
+          });
 
   EXPECT_FALSE(auto_sync_managers().contains(account_id_1));
   {
@@ -1053,7 +1041,7 @@ TEST_F(ZCashWalletServiceUnitTest, ZCashAccountInfo) {
         get_zcash_account_info_callback;
     EXPECT_CALL(get_zcash_account_info_callback, Run(_))
         .WillOnce(
-            ::testing::Invoke([&](mojom::ZCashAccountInfoPtr account_info) {
+            [&](mojom::ZCashAccountInfoPtr account_info) {
               EXPECT_EQ(account_info->unified_address.value(),
                         "u1gjrzpk0v0v2ae359cp296zapth9mw8xseyzhu44a4ftux3gn8gh9"
                         "hmzazrz6f3yvjyglrchz68g0s2hwpjknw3eywxgp0tn3p5p3g94w4j"
@@ -1065,7 +1053,7 @@ TEST_F(ZCashWalletServiceUnitTest, ZCashAccountInfo) {
                   account_info->orchard_internal_address.value(),
                   "u1dl9dtss80tsutx3xfje4vlndwhc2f2pernhhpxfsz9vw6nr0zz"
                   "lkw9p2m22xjcn5588fp3tnta9uqhpk4nh06xumwvt8ff7w653g5pvk");
-            }));
+            });
     zcash_wallet_service_->GetZCashAccountInfo(
         account_id_1.Clone(), get_zcash_account_info_callback.Get());
     task_environment_.RunUntilIdle();
@@ -1198,16 +1186,15 @@ TEST_F(ZCashWalletServiceUnitTest, MakeAccountShielded) {
                                               mojom::AccountKind::kDerived, 1);
 
   ON_CALL(zcash_rpc(), GetLatestBlock(_, _))
-      .WillByDefault(
-          ::testing::Invoke([&](const std::string& chain_id,
-                                ZCashRpc::GetLatestBlockCallback callback) {
-            auto response =
-                zcash::mojom::BlockID::New(100000u, std::vector<uint8_t>());
-            std::move(callback).Run(std::move(response));
-          }));
+      .WillByDefault([&](const std::string& chain_id,
+                         ZCashRpc::GetLatestBlockCallback callback) {
+        auto response =
+            zcash::mojom::BlockID::New(100000u, std::vector<uint8_t>());
+        std::move(callback).Run(std::move(response));
+      });
 
   ON_CALL(zcash_rpc(), GetTreeState(_, _, _))
-      .WillByDefault(::testing::Invoke(
+      .WillByDefault(
           [&](const std::string& chain_id, zcash::mojom::BlockIDPtr block_id,
               ZCashRpc::GetTreeStateCallback callback) {
             EXPECT_EQ(block_id->height, 100000u - kChainReorgBlockDelta);
@@ -1217,7 +1204,7 @@ TEST_F(ZCashWalletServiceUnitTest, MakeAccountShielded) {
                 "hexhexhex2" /* hash */, 123 /* time */, "" /* sapling tree */,
                 "" /* orchard tree */);
             std::move(callback).Run(std::move(tree_state));
-          }));
+          });
 
   {
     base::MockCallback<ZCashWalletService::MakeAccountShieldedCallback>
@@ -1234,11 +1221,11 @@ TEST_F(ZCashWalletServiceUnitTest, MakeAccountShielded) {
         get_zcash_account_info_callback;
     EXPECT_CALL(get_zcash_account_info_callback, Run(_))
         .WillOnce(
-            ::testing::Invoke([&](mojom::ZCashAccountInfoPtr account_info) {
+            [&](mojom::ZCashAccountInfoPtr account_info) {
               EXPECT_EQ(mojom::ZCashAccountShieldBirthday::New(
                             100000u - kChainReorgBlockDelta, "hexhexhex2"),
                         account_info->account_shield_birthday);
-            }));
+            });
     zcash_wallet_service_->GetZCashAccountInfo(
         account_id_1.Clone(), get_zcash_account_info_callback.Get());
     task_environment_.RunUntilIdle();
@@ -1250,10 +1237,9 @@ TEST_F(ZCashWalletServiceUnitTest, MakeAccountShielded) {
     base::MockCallback<ZCashWalletService::GetZCashAccountInfoCallback>
         get_zcash_account_info_callback;
     EXPECT_CALL(get_zcash_account_info_callback, Run(_))
-        .WillOnce(
-            ::testing::Invoke([&](mojom::ZCashAccountInfoPtr account_info) {
-              EXPECT_TRUE(account_info->account_shield_birthday.is_null());
-            }));
+        .WillOnce([&](mojom::ZCashAccountInfoPtr account_info) {
+          EXPECT_TRUE(account_info->account_shield_birthday.is_null());
+        });
     zcash_wallet_service_->GetZCashAccountInfo(
         account_id_2.Clone(), get_zcash_account_info_callback.Get());
     task_environment_.RunUntilIdle();
@@ -1283,7 +1269,7 @@ TEST_F(ZCashWalletServiceUnitTest, ShieldFunds_FailsOnNetworkError) {
                                             mojom::AccountKind::kDerived, 0);
   keyring_service()->UpdateNextUnusedAddressForZCashAccount(account_id, 1, 0);
   ON_CALL(zcash_rpc(), GetUtxoList(_, _, _))
-      .WillByDefault(::testing::Invoke(
+      .WillByDefault(
           [&](const std::string& chain_id, const std::string& address,
               ZCashRpc::GetUtxoListCallback callback) {
             std::vector<zcash::mojom::ZCashUtxoPtr> utxos;
@@ -1302,21 +1288,20 @@ TEST_F(ZCashWalletServiceUnitTest, ShieldFunds_FailsOnNetworkError) {
             auto response =
                 zcash::mojom::GetAddressUtxosResponse::New(std::move(utxos));
             std::move(callback).Run(std::move(response));
-          }));
+          });
   ON_CALL(zcash_rpc(), GetLatestBlock(_, _))
-      .WillByDefault(
-          ::testing::Invoke([&](const std::string& chain_id,
-                                ZCashRpc::GetLatestBlockCallback callback) {
-            auto response =
-                zcash::mojom::BlockID::New(100000u, std::vector<uint8_t>());
-            std::move(callback).Run(std::move(response));
-          }));
+      .WillByDefault([&](const std::string& chain_id,
+                         ZCashRpc::GetLatestBlockCallback callback) {
+        auto response =
+            zcash::mojom::BlockID::New(100000u, std::vector<uint8_t>());
+        std::move(callback).Run(std::move(response));
+      });
   ON_CALL(zcash_rpc(), GetTreeState(_, _, _))
-      .WillByDefault(::testing::Invoke(
-          [&](const std::string& chain_id, zcash::mojom::BlockIDPtr block_id,
-              ZCashRpc::GetTreeStateCallback callback) {
-            std::move(callback).Run(base::unexpected("error"));
-          }));
+      .WillByDefault([&](const std::string& chain_id,
+                         zcash::mojom::BlockIDPtr block_id,
+                         ZCashRpc::GetTreeStateCallback callback) {
+        std::move(callback).Run(base::unexpected("error"));
+      });
 
   base::MockCallback<ZCashWalletService::ShieldAllFundsCallback>
       shield_funds_callback;
@@ -1365,29 +1350,27 @@ TEST_F(ZCashWalletServiceUnitTest, MAYBE_ShieldFunds) {
   keyring_service()->UpdateNextUnusedAddressForZCashAccount(account_id, 1, 0);
 
   ON_CALL(zcash_rpc(), IsKnownAddress(_, _, _, _, _))
-      .WillByDefault(::testing::Invoke(
-          [](const std::string& chain_id, const std::string& addr,
-             uint64_t block_start, uint64_t block_end,
-             ZCashRpc::IsKnownAddressCallback callback) {
-            std::move(callback).Run(false);
-          }));
+      .WillByDefault([](const std::string& chain_id, const std::string& addr,
+                        uint64_t block_start, uint64_t block_end,
+                        ZCashRpc::IsKnownAddressCallback callback) {
+        std::move(callback).Run(false);
+      });
 
   ON_CALL(zcash_rpc(), GetLatestBlock(_, _))
       .WillByDefault(
-          ::testing::Invoke([&](const std::string& chain_id,
-                                ZCashRpc::GetLatestBlockCallback callback) {
+          [&](const std::string& chain_id,
+              ZCashRpc::GetLatestBlockCallback callback) {
             auto response = zcash::mojom::BlockID::New(
                 2625446u,
                 *PrefixedHexStringToBytes("0x0000000001a01b5fd794e4b071443974c8"
                                           "35b3e0ff8f96bf3600e07afdbf89c5"));
             std::move(callback).Run(std::move(response));
-          }));
+          });
 
   ON_CALL(zcash_rpc(), GetTreeState(_, _, _))
-      .WillByDefault(::testing::Invoke([&](const std::string& chain_id,
-                                           zcash::mojom::BlockIDPtr block_id,
-                                           ZCashRpc::GetTreeStateCallback
-                                               callback) {
+      .WillByDefault([&](const std::string& chain_id,
+                         zcash::mojom::BlockIDPtr block_id,
+                         ZCashRpc::GetTreeStateCallback callback) {
         auto tree_state = zcash::mojom::TreeState::New(
             "main" /* network */, 2625446 /* height */,
             "0000000001a01b5fd794e4b071443974c835b3e0ff8f96bf3600e07afdbf89c5"
@@ -1422,20 +1405,19 @@ TEST_F(ZCashWalletServiceUnitTest, MAYBE_ShieldFunds) {
             "190cddecef1b10653248a234150001e2bca6a8d987d668defba89dc082196a9226"
             "34ed88e065c669e526bb8815ee1b000000000000" /* orchard tree */);
         std::move(callback).Run(std::move(tree_state));
-      }));
+      });
 
   std::unique_ptr<MockOrchardSyncState> mocked_sync_state =
       std::make_unique<MockOrchardSyncState>(db_path());
   ON_CALL(*mocked_sync_state, GetSpendableNotes(_, _))
-      .WillByDefault(
-          ::testing::Invoke([&](const mojom::AccountIdPtr& account_id,
-                                const OrchardAddrRawPart& internal_addr) {
-            OrchardSyncState::SpendableNotesBundle spendable_notes_bundle;
-            return spendable_notes_bundle;
-          }));
+      .WillByDefault([&](const mojom::AccountIdPtr& account_id,
+                         const OrchardAddrRawPart& internal_addr) {
+        OrchardSyncState::SpendableNotesBundle spendable_notes_bundle;
+        return spendable_notes_bundle;
+      });
 
   ON_CALL(zcash_rpc(), GetUtxoList(_, _, _))
-      .WillByDefault(::testing::Invoke(
+      .WillByDefault(
           [&](const std::string& chain_id, const std::string& address,
               ZCashRpc::GetUtxoListCallback callback) {
             std::vector<zcash::mojom::ZCashUtxoPtr> utxos;
@@ -1454,7 +1436,7 @@ TEST_F(ZCashWalletServiceUnitTest, MAYBE_ShieldFunds) {
             auto response =
                 zcash::mojom::GetAddressUtxosResponse::New(std::move(utxos));
             std::move(callback).Run(std::move(response));
-          }));
+          });
 
   OrchardMemo memo;
   memo.fill('a');
@@ -1782,17 +1764,17 @@ TEST_F(ZCashWalletServiceUnitTest, MAYBE_ShieldAllFunds) {
 
   ON_CALL(zcash_rpc(), GetLatestBlock(_, _))
       .WillByDefault(
-          ::testing::Invoke([&](const std::string& chain_id,
-                                ZCashRpc::GetLatestBlockCallback callback) {
+          [&](const std::string& chain_id,
+              ZCashRpc::GetLatestBlockCallback callback) {
             auto response = zcash::mojom::BlockID::New(
                 2468414u,
                 *PrefixedHexStringToBytes("0x0000000000b9f12d757cf10d5164c8eb2d"
                                           "ceb79efbebd15939ac0c2ef69857c5"));
             std::move(callback).Run(std::move(response));
-          }));
+          });
 
   ON_CALL(zcash_rpc(), GetTreeState(_, _, _))
-      .WillByDefault(::testing::Invoke(
+      .WillByDefault(
           [&](const std::string& chain_id, zcash::mojom::BlockIDPtr block_id,
               ZCashRpc::GetTreeStateCallback callback) {
             auto tree_state = zcash::mojom::TreeState::New(
@@ -1835,10 +1817,10 @@ TEST_F(ZCashWalletServiceUnitTest, MAYBE_ShieldAllFunds) {
                 "ecef1b10653248a234150001e2bca6a8d987d668defba89dc082196a922634"
                 "ed88e065c669e526bb8815ee1b000000000000" /* orchard tree */);
             std::move(callback).Run(std::move(tree_state));
-          }));
+          });
 
   ON_CALL(zcash_rpc(), GetUtxoList(_, _, _))
-      .WillByDefault(::testing::Invoke(
+      .WillByDefault(
           [&](const std::string& chain_id, const std::string& address,
               ZCashRpc::GetUtxoListCallback callback) {
             std::vector<zcash::mojom::ZCashUtxoPtr> utxos;
@@ -1857,7 +1839,7 @@ TEST_F(ZCashWalletServiceUnitTest, MAYBE_ShieldAllFunds) {
             auto response =
                 zcash::mojom::GetAddressUtxosResponse::New(std::move(utxos));
             std::move(callback).Run(std::move(response));
-          }));
+          });
 
   std::vector<uint8_t> captured_data;
   EXPECT_CALL(zcash_rpc(), SendTransaction(_, _, _))
@@ -2153,17 +2135,16 @@ TEST_F(ZCashWalletServiceUnitTest, MAYBE_SendShieldedFunds) {
       {{"zcash_shielded_transactions_enabled", "true"}});
 
   ON_CALL(zcash_rpc(), GetLightdInfo(_, _))
-      .WillByDefault(
-          ::testing::Invoke([&](const std::string& chain_id,
-                                ZCashRpc::GetLightdInfoCallback callback) {
-            auto response = zcash::mojom::LightdInfo::New("C8E71055");
-            std::move(callback).Run(std::move(response));
-          }));
+      .WillByDefault([&](const std::string& chain_id,
+                         ZCashRpc::GetLightdInfoCallback callback) {
+        auto response = zcash::mojom::LightdInfo::New("C8E71055");
+        std::move(callback).Run(std::move(response));
+      });
 
   ON_CALL(mock_orchard_sync_state(), GetSpendableNotes(_, _))
       .WillByDefault(
-          ::testing::Invoke([&](const mojom::AccountIdPtr& account_id,
-                                const OrchardAddrRawPart& internal_addr) {
+          [&](const mojom::AccountIdPtr& account_id,
+              const OrchardAddrRawPart& internal_addr) {
             OrchardSyncState::SpendableNotesBundle spendable_notes_bundle;
             OrchardNote note;
             base::span(note.addr).copy_from(*PrefixedHexStringToBytes(
@@ -2185,12 +2166,12 @@ TEST_F(ZCashWalletServiceUnitTest, MAYBE_SendShieldedFunds) {
             spendable_notes_bundle.spendable_notes.push_back(std::move(note));
             spendable_notes_bundle.anchor_block_id = 2765375u;
             return spendable_notes_bundle;
-          }));
+          });
   ON_CALL(mock_orchard_sync_state(), CalculateWitnessForCheckpoint(_, _, _))
       .WillByDefault(
-          ::testing::Invoke([&](const mojom::AccountIdPtr& account_id,
-                                const std::vector<OrchardInput>& notes,
-                                uint32_t checkpoint_position) {
+          [&](const mojom::AccountIdPtr& account_id,
+              const std::vector<OrchardInput>& notes,
+              uint32_t checkpoint_position) {
             std::vector<OrchardInput> notes_with_witness = notes;
             OrchardNoteWitness witness;
             AppendMerklePath(witness,
@@ -2292,7 +2273,7 @@ TEST_F(ZCashWalletServiceUnitTest, MAYBE_SendShieldedFunds) {
             witness.position = 48973018u;
             notes_with_witness[0].witness = std::move(witness);
             return base::ok(notes_with_witness);
-          }));
+          });
 
   base::SequenceBound<MockOrchardSyncStateProxy> overrided_sync_state(
       base::ThreadPool::CreateSequencedTaskRunner({base::MayBlock()}),
@@ -2310,17 +2291,17 @@ TEST_F(ZCashWalletServiceUnitTest, MAYBE_SendShieldedFunds) {
                                             mojom::AccountKind::kDerived, 6);
   ON_CALL(zcash_rpc(), GetLatestBlock(_, _))
       .WillByDefault(
-          ::testing::Invoke([&](const std::string& chain_id,
-                                ZCashRpc::GetLatestBlockCallback callback) {
+          [&](const std::string& chain_id,
+              ZCashRpc::GetLatestBlockCallback callback) {
             auto response = zcash::mojom::BlockID::New(
                 2769076u,
                 *PrefixedHexStringToBytes("0x000000000003b74b5acfd73e70b1a8e8de"
                                           "5f5557e560d524037cf40d3190a804"));
             std::move(callback).Run(std::move(response));
-          }));
+          });
 
   ON_CALL(zcash_rpc(), GetTreeState(_, _, _))
-      .WillByDefault(::testing::Invoke(
+      .WillByDefault(
           [&](const std::string& chain_id, zcash::mojom::BlockIDPtr block_id,
               ZCashRpc::GetTreeStateCallback callback) {
             auto tree_state = zcash::mojom::TreeState::New(
@@ -2367,7 +2348,7 @@ TEST_F(ZCashWalletServiceUnitTest, MAYBE_SendShieldedFunds) {
                 "ef1b10653248a234150001e2bca6a8d987d668defba89dc082196a922634ed"
                 "88e065c669e526bb8815ee1b000000000000");
             std::move(callback).Run(std::move(tree_state));
-          }));
+          });
 
   std::optional<ZCashTransaction> created_transaction;
   base::MockCallback<ZCashWalletService::CreateTransactionCallback>

--- a/components/sync/service/brave_sync_service_impl_unittest.cc
+++ b/components/sync/service/brave_sync_service_impl_unittest.cc
@@ -764,11 +764,11 @@ TEST_F(BraveSyncServiceImplTest_DisableSyncDefaultPasswordsTest,
   base::RepeatingClosure quit_closure = engine_waiter.QuitClosure();
   NiceMock<SyncServiceObserverMock> observer_mock;
   ON_CALL(observer_mock, OnStateChanged(_))
-      .WillByDefault(testing::Invoke([this, quit_closure]() {
+      .WillByDefault([this, quit_closure]() {
         if (engine()) {
           quit_closure.Run();
         }
-      }));
+      });
   brave_sync_service_impl()->AddObserver(&observer_mock);
 
   brave_sync_service_impl()->SetSyncCode(kValidSyncCode);


### PR DESCRIPTION
Not needed and deprecated [0]. This PR should be a no-op.

This is a semi-mechanical change.

[0]: https://chromium.googlesource.com/external/github.com/google/googletest.git/+/a05c0915074bcd1b82f232e081da9bb6c205c28d/googlemock/include/gmock/gmock-actions.h#2046

Bug: https://github.com/brave/brave-browser/issues/49857
