### PR TITLE
Ignore settings with missing `setting` value for MigrateCosmeticFilte… (uplift to 1.84.x)

### DIFF
--- a/components/content_settings/core/browser/brave_content_settings_pref_provider.cc
+++ b/components/content_settings/core/browser/brave_content_settings_pref_provider.cc
@@ -583,14 +583,22 @@ void BravePrefProvider::MigrateCosmeticFilteringSettings() {
 
   auto merge_values = [](const Rule* fp_rule, const Rule* general_rule) {
     // Same logic as in GetCosmeticFilteringControlType.
-    if (content_settings::ValueToContentSetting(
-            *general_rule->value.GetDict().Find("setting")) ==
+    const auto* setting = general_rule->value.GetDict().Find("setting");
+    if (!setting) {
+      return base::Value();
+    }
+    if (content_settings::ValueToContentSetting(*setting) ==
         CONTENT_SETTING_ALLOW) {
       return brave_shields::CosmeticFilteringSetting::ToValue(
           brave_shields::ControlType::ALLOW);
     }
-    if (content_settings::ValueToContentSetting(*fp_rule->value.GetDict().Find(
-            "setting")) != CONTENT_SETTING_BLOCK) {
+
+    setting = fp_rule->value.GetDict().Find("setting");
+    if (!setting) {
+      return base::Value();
+    }
+    if (content_settings::ValueToContentSetting(*setting) !=
+        CONTENT_SETTING_BLOCK) {
       return brave_shields::CosmeticFilteringSetting::ToValue(
           brave_shields::ControlType::BLOCK_THIRD_PARTY);
     }

--- a/components/content_settings/core/browser/brave_content_settings_pref_provider_unittest.cc
+++ b/components/content_settings/core/browser/brave_content_settings_pref_provider_unittest.cc
@@ -315,6 +315,11 @@ class DirectAccessContentSettings {
     prefs_value_.Set(primary + "," + secondary, std::move(value));
   }
 
+  void AddRuleWithoutSettingValue(const std::string& primary,
+                                  const std::string& secondary) {
+    prefs_value_.Set(primary + "," + secondary, base::Value::Dict());
+  }
+
   void Write() { prefs_->SetDict(GetPrefName(), prefs_value_.Clone()); }
 
   size_t GetRulesCount() const { return prefs_value_.size(); }
@@ -818,7 +823,12 @@ TEST_F(BravePrefProviderTest, CosmeticFilteringMigration) {
   cosmetic_filtering_v1.AddRule("brave.block", kFirstParty,
                                 CONTENT_SETTING_BLOCK);
 
-  EXPECT_EQ(6u, cosmetic_filtering_v1.GetRulesCount());
+  // Missing setting value https://github.com/brave/brave-browser/issues/49861
+  cosmetic_filtering_v1.AddRuleWithoutSettingValue("brave.missing", "*");
+  cosmetic_filtering_v1.AddRuleWithoutSettingValue("brave.missing",
+                                                   kFirstParty);
+
+  EXPECT_EQ(8u, cosmetic_filtering_v1.GetRulesCount());
   cosmetic_filtering_v1.Write();
 
   testing_profile()->GetPrefs()->ClearPref(


### PR DESCRIPTION
Uplift of #31609
Resolves https://github.com/brave/brave-browser/issues/49861

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.