### PR TITLE
[ads] Only allow conversion confirmations for Search Result ads

### DIFF
--- a/components/brave_ads/core/internal/account/account.cc
+++ b/components/brave_ads/core/internal/account/account.cc
@@ -165,7 +165,7 @@ void Account::SuccessfullyProcessedDeposit(const TransactionInfo& transaction,
               << transaction.confirmation_type << " valued at "
               << transaction.value);
 
-  confirmations_->Confirm(transaction, std::move(user_data));
+  confirmations_->MaybeConfirm(transaction, std::move(user_data));
 
   NotifyDidProcessDeposit(transaction);
 

--- a/components/brave_ads/core/internal/account/confirmations/confirmations.cc
+++ b/components/brave_ads/core/internal/account/confirmations/confirmations.cc
@@ -11,6 +11,7 @@
 #include "base/check.h"
 #include "base/time/time.h"
 #include "brave/components/brave_ads/core/internal/account/confirmations/confirmation_info.h"
+#include "brave/components/brave_ads/core/internal/account/confirmations/confirmations_util.h"
 #include "brave/components/brave_ads/core/internal/account/confirmations/non_reward/non_reward_confirmation_util.h"
 #include "brave/components/brave_ads/core/internal/account/confirmations/queue/confirmation_queue.h"
 #include "brave/components/brave_ads/core/internal/account/confirmations/reward/reward_confirmation_util.h"
@@ -30,9 +31,13 @@ Confirmations::~Confirmations() {
   delegate_ = nullptr;
 }
 
-void Confirmations::Confirm(const TransactionInfo& transaction,
-                            base::Value::Dict user_data) {
+void Confirmations::MaybeConfirm(const TransactionInfo& transaction,
+                                 base::Value::Dict user_data) {
   CHECK(transaction.IsValid());
+
+  if (!IsAllowedToConfirm(transaction)) {
+    return;
+  }
 
   BLOG(1, "Confirming " << transaction.confirmation_type << " for "
                         << transaction.ad_type << " with transaction id "

--- a/components/brave_ads/core/internal/account/confirmations/confirmations.h
+++ b/components/brave_ads/core/internal/account/confirmations/confirmations.h
@@ -34,7 +34,8 @@ class Confirmations final : public ConfirmationQueueDelegate,
     delegate_ = delegate;
   }
 
-  void Confirm(const TransactionInfo& transaction, base::Value::Dict user_data);
+  void MaybeConfirm(const TransactionInfo& transaction,
+                    base::Value::Dict user_data);
 
  private:
   void NotifyDidConfirm(const ConfirmationInfo& confirmation) const;

--- a/components/brave_ads/core/internal/account/confirmations/confirmations_unittest.cc
+++ b/components/brave_ads/core/internal/account/confirmations/confirmations_unittest.cc
@@ -47,7 +47,7 @@ TEST_F(BraveAdsConfirmationsTest, ConfirmForRewardsUser) {
       /*should_generate_random_uuids=*/false);
 
   // Act
-  confirmations_->Confirm(transaction, /*user_data=*/{});
+  confirmations_->MaybeConfirm(transaction, /*user_data=*/{});
 
   // Assert
   base::MockCallback<database::table::GetConfirmationQueueCallback> callback;
@@ -69,7 +69,7 @@ TEST_F(BraveAdsConfirmationsTest, ConfirmForNonRewardsUser) {
       /*should_generate_random_uuids=*/false);
 
   // Act
-  confirmations_->Confirm(transaction, /*user_data=*/{});
+  confirmations_->MaybeConfirm(transaction, /*user_data=*/{});
 
   // Assert
   base::MockCallback<database::table::GetConfirmationQueueCallback> callback;

--- a/components/brave_ads/core/internal/account/confirmations/confirmations_util.cc
+++ b/components/brave_ads/core/internal/account/confirmations/confirmations_util.cc
@@ -11,6 +11,7 @@
 #include "base/base64url.h"
 #include "base/check.h"
 #include "base/json/json_reader.h"
+#include "base/types/cxx23_to_underlying.h"
 #include "brave/components/brave_ads/core/internal/account/confirmations/confirmation_info.h"
 #include "brave/components/brave_ads/core/internal/account/confirmations/payload/confirmation_payload_json_writer.h"
 #include "brave/components/brave_ads/core/internal/account/confirmations/reward/reward_info.h"
@@ -82,6 +83,31 @@ bool IsValid(const ConfirmationInfo& confirmation) {
   }
 
   return Verify(confirmation);
+}
+
+bool IsAllowedToConfirm(const TransactionInfo& transaction) {
+  switch (transaction.ad_type) {
+    case mojom::AdType::kInlineContentAd:
+    case mojom::AdType::kPromotedContentAd:
+    case mojom::AdType::kNewTabPageAd:
+    case mojom::AdType::kNotificationAd: {
+      // Always allow confirmations.
+      return true;
+    }
+
+    case mojom::AdType::kSearchResultAd: {
+      // Only allow conversion confirmations.
+      return transaction.confirmation_type ==
+             mojom::ConfirmationType::kConversion;
+    }
+
+    case mojom::AdType::kUndefined: {
+      break;
+    }
+  }
+
+  NOTREACHED() << "Unexpected value for mojom::AdType: "
+               << base::to_underlying(transaction.ad_type);
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/account/confirmations/confirmations_util.h
+++ b/components/brave_ads/core/internal/account/confirmations/confirmations_util.h
@@ -6,11 +6,16 @@
 #ifndef BRAVE_COMPONENTS_BRAVE_ADS_CORE_INTERNAL_ACCOUNT_CONFIRMATIONS_CONFIRMATIONS_UTIL_H_
 #define BRAVE_COMPONENTS_BRAVE_ADS_CORE_INTERNAL_ACCOUNT_CONFIRMATIONS_CONFIRMATIONS_UTIL_H_
 
+#include "brave/components/brave_ads/core/internal/account/transactions/transaction_info.h"
+
 namespace brave_ads {
 
 struct ConfirmationInfo;
+struct TransactionInfo;
 
 [[nodiscard]] bool IsValid(const ConfirmationInfo& confirmation);
+
+bool IsAllowedToConfirm(const TransactionInfo& transaction);
 
 }  // namespace brave_ads
 

--- a/components/brave_ads/core/internal/account/confirmations/confirmations_util_unittest.cc
+++ b/components/brave_ads/core/internal/account/confirmations/confirmations_util_unittest.cc
@@ -15,6 +15,7 @@
 #include "brave/components/brave_ads/core/internal/account/confirmations/reward/reward_confirmation_util.h"
 #include "brave/components/brave_ads/core/internal/account/tokens/confirmation_tokens/confirmation_tokens_test_util.h"
 #include "brave/components/brave_ads/core/internal/account/tokens/token_generator_test_util.h"
+#include "brave/components/brave_ads/core/internal/account/transactions/transactions_test_util.h"
 #include "brave/components/brave_ads/core/internal/common/test/test_base.h"
 #include "brave/components/brave_ads/core/internal/settings/settings_test_util.h"
 
@@ -52,12 +53,92 @@ TEST_F(BraveAdsConfirmationsUtilTest, IsNonRewardConfirmationValid) {
   EXPECT_TRUE(IsValid(*confirmation));
 }
 
-TEST_F(BraveAdsConfirmationsUtilTest, IsConfirmationNotValid) {
+TEST_F(BraveAdsConfirmationsUtilTest, IsInvalidConfirmation) {
   // Arrange
   const ConfirmationInfo confirmation;
 
   // Act & Assert
   EXPECT_FALSE(IsValid(confirmation));
+}
+
+TEST_F(BraveAdsConfirmationsUtilTest, AlwaysAllowNotificationAdConfirmations) {
+  // Arrange
+  TransactionInfo transaction = test::BuildUnreconciledTransaction(
+      /*value=*/0.01, mojom::AdType::kNotificationAd,
+      mojom::ConfirmationType::kUndefined,
+      /*should_generate_random_uuids=*/false);
+
+  // Act & Assert
+  for (int i = 0; i < static_cast<int>(mojom::ConfirmationType::kMaxValue);
+       ++i) {
+    transaction.confirmation_type = static_cast<mojom::ConfirmationType>(i);
+    EXPECT_TRUE(IsAllowedToConfirm(transaction));
+  }
+}
+
+TEST_F(BraveAdsConfirmationsUtilTest, AlwaysAllowNewTabPageAdConfirmations) {
+  // Arrange
+  TransactionInfo transaction = test::BuildUnreconciledTransaction(
+      /*value=*/0.01, mojom::AdType::kNewTabPageAd,
+      mojom::ConfirmationType::kUndefined,
+      /*should_generate_random_uuids=*/false);
+
+  // Act & Assert
+  for (int i = 0; i < static_cast<int>(mojom::ConfirmationType::kMaxValue);
+       ++i) {
+    transaction.confirmation_type = static_cast<mojom::ConfirmationType>(i);
+    EXPECT_TRUE(IsAllowedToConfirm(transaction));
+  }
+}
+
+TEST_F(BraveAdsConfirmationsUtilTest,
+       AlwaysAllowPromotedContentAdConfirmations) {
+  // Arrange
+  TransactionInfo transaction = test::BuildUnreconciledTransaction(
+      /*value=*/0.01, mojom::AdType::kPromotedContentAd,
+      mojom::ConfirmationType::kUndefined,
+      /*should_generate_random_uuids=*/false);
+
+  // Act & Assert
+  for (int i = 0; i < static_cast<int>(mojom::ConfirmationType::kMaxValue);
+       ++i) {
+    transaction.confirmation_type = static_cast<mojom::ConfirmationType>(i);
+    EXPECT_TRUE(IsAllowedToConfirm(transaction));
+  }
+}
+
+TEST_F(BraveAdsConfirmationsUtilTest, AlwaysAllowInlineContentAdConfirmations) {
+  // Arrange
+  TransactionInfo transaction = test::BuildUnreconciledTransaction(
+      /*value=*/0.01, mojom::AdType::kInlineContentAd,
+      mojom::ConfirmationType::kUndefined,
+      /*should_generate_random_uuids=*/false);
+
+  // Act & Assert
+  for (int i = 0; i < static_cast<int>(mojom::ConfirmationType::kMaxValue);
+       ++i) {
+    transaction.confirmation_type = static_cast<mojom::ConfirmationType>(i);
+    EXPECT_TRUE(IsAllowedToConfirm(transaction));
+  }
+}
+
+TEST_F(BraveAdsConfirmationsUtilTest, AlwaysAllowSearchResultAdConfirmations) {
+  // Arrange
+  TransactionInfo transaction = test::BuildUnreconciledTransaction(
+      /*value=*/0.01, mojom::AdType::kSearchResultAd,
+      mojom::ConfirmationType::kUndefined,
+      /*should_generate_random_uuids=*/false);
+
+  // Act & Assert
+  for (int i = 0; i < static_cast<int>(mojom::ConfirmationType::kMaxValue);
+       ++i) {
+    transaction.confirmation_type = static_cast<mojom::ConfirmationType>(i);
+    if (transaction.confirmation_type == mojom::ConfirmationType::kConversion) {
+      EXPECT_TRUE(IsAllowedToConfirm(transaction));
+    } else {
+      EXPECT_FALSE(IsAllowedToConfirm(transaction));
+    }
+  }
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/account/tokens/confirmation_tokens/confirmation_tokens_util_unittest.cc
+++ b/components/brave_ads/core/internal/account/tokens/confirmation_tokens/confirmation_tokens_util_unittest.cc
@@ -83,7 +83,7 @@ TEST_F(BraveAdsConfirmationTokenUtilTest, IsValid) {
   EXPECT_TRUE(IsValid(test::BuildConfirmationToken()));
 }
 
-TEST_F(BraveAdsConfirmationTokenUtilTest, IsNotValid) {
+TEST_F(BraveAdsConfirmationTokenUtilTest, IsInvalid) {
   // Arrange
   const ConfirmationTokenInfo confirmation_token;
 


### PR DESCRIPTION
Determines if a transaction is allowed to send a confirmation based on its ad type and confirmation type. It returns true for all confirmation types when the ad type is Notification, New Tab Page, Promoted Content, or Inline Content. For Search Result ads, it only allows sending a confirmation if the confirmation type is kConversion; otherwise, it returns false.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/49883

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
