### PR TITLE
[iOS] Add missing collections dependency to Brave Talk target

### DIFF
--- a/ios/brave-ios/Package.swift
+++ b/ios/brave-ios/Package.swift
@@ -657,7 +657,10 @@ var package = Package(
     .executableTarget(name: "LeoAssetCatalogGenerator"),
     .target(
       name: "BraveTalk",
-      dependencies: ["Shared", "Preferences", "JitsiMeet", "BraveCore"],
+      dependencies: [
+        "Shared", "Preferences", "JitsiMeet", "BraveCore",
+        .product(name: "Collections", package: "swift-collections"),
+      ],
       plugins: ["LoggerPlugin"]
     ),
     .testTarget(


### PR DESCRIPTION
This could lead to an intermittient build issue if the `BraveTalk` target was compiled prior to one that also depended on `swift-collections`