### PR TITLE
Ensure cargo uses the correct rustc

### DIFF
--- a/components/common/rust_to_wasm.gni
+++ b/components/common/rust_to_wasm.gni
@@ -4,6 +4,7 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import("//brave/tools/crates/config.gni")
+import("//build/config/rust.gni")
 
 template("rust_to_wasm") {
   assert(defined(invoker.rust_packages),
@@ -41,6 +42,8 @@ template("rust_to_wasm") {
     # - causes a race condition between the processes (that action_foreach forks) for wasm-pack's cache directory (if wasm-pack is run for the first time),
     # - makes our approach less self-contained.
     args = [
+      "--rust_path",
+      rebase_path("$rust_sysroot/bin"),
       "--wasm_bindgen_cli_path",
       get_path_info(rebase_path(wasm_bindgen_cli_exe), "dir"),
       "--wasm_opt_path",

--- a/script/build_crate.py
+++ b/script/build_crate.py
@@ -12,11 +12,13 @@ import subprocess
 parser = argparse.ArgumentParser(
     description='Build crates in //brave/tools/crates/config.gni')
 parser.add_argument('--temp_dir_path', required=True)
+parser.add_argument('--rust_path', required=True)
 args, cargo_args = parser.parse_known_args()
 env = os.environ.copy()
 if platform.system() == "Windows":
     env['TEMP'] = env['TMP'] = args.temp_dir_path
 else:
     env["TMPDIR"] = args.temp_dir_path
+env["PATH"] = args.rust_path + os.pathsep + env["PATH"]
 subprocess.check_call(cargo_args, env=env)
 Path(f'{args.temp_dir_path}/.stamp').touch()

--- a/script/rust_to_wasm.py
+++ b/script/rust_to_wasm.py
@@ -25,6 +25,7 @@ parser.add_argument('--wasm_opt_path', required=True)
 parser.add_argument('--rust_path', required=True)
 args, wasm_pack_args = parser.parse_known_args()
 env = os.environ.copy()
-env['PATH'] = args.wasm_bindgen_cli_path + os.pathsep + args.wasm_opt_path + os.pathsep + env['PATH']
+env['PATH'] = args.wasm_bindgen_cli_path + os.pathsep + args.wasm_opt_path + os.pathsep + env[
+    'PATH']
 env['PATH'] = args.rust_path + os.pathsep + env['PATH']
 subprocess.check_call(wasm_pack_args, env=env)

--- a/script/rust_to_wasm.py
+++ b/script/rust_to_wasm.py
@@ -22,8 +22,9 @@ import subprocess
 parser = argparse.ArgumentParser(description='Compile Rust packages to WASM')
 parser.add_argument('--wasm_bindgen_cli_path', required=True)
 parser.add_argument('--wasm_opt_path', required=True)
+parser.add_argument('--rust_path', required=True)
 args, wasm_pack_args = parser.parse_known_args()
 env = os.environ.copy()
-env['PATH'] = args.wasm_bindgen_cli_path + os.pathsep + args.wasm_opt_path + os.pathsep + env[
-    'PATH']
+env['PATH'] = args.wasm_bindgen_cli_path + os.pathsep + args.wasm_opt_path + os.pathsep + env['PATH']
+env['PATH'] = args.rust_path + os.pathsep + env['PATH']
 subprocess.check_call(wasm_pack_args, env=env)

--- a/tools/crates/build_crate.gni
+++ b/tools/crates/build_crate.gni
@@ -3,6 +3,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import("//build/config/rust.gni")
+
 template("build_crate") {
   crate = target_name
   assert(
@@ -18,7 +20,8 @@ template("build_crate") {
 
     script = "//brave/script/build_crate.py"
 
-    cargo_exe = "//third_party/rust-toolchain/bin/cargo"
+    rust_path = "$rust_sysroot/bin"
+    cargo_exe = "$rust_path/cargo"
     if (host_os == "win") {
       cargo_exe += ".exe"
     }
@@ -44,6 +47,8 @@ template("build_crate") {
     args = [
       "--temp_dir_path",
       rebase_path(crate_target_dir),
+      "--rust_path",
+      rebase_path(rust_path),
       rebase_path(cargo_exe),
       "build",
       "--quiet",


### PR DESCRIPTION
We are passing the absolute path to cargo, but cargo uses internal mechanisms to find rustc which will incorrectly use system installed rustc or fail

```
err: exit=1
python3 ../../brave/script/build_crate.py --temp_dir_path [redacted]brave/src/out/Component_arm64/wasm_opt [redacted]brave/src/third_party/rust-toolchain/bin/cargo build --quiet --release --manifest-path [redacted]brave/src/brave/tools/crates/Cargo.toml --config [redacted]brave/src/brave/tools/crates/.cargo/config.toml --target-dir [redacted]brave/src/out/Component_arm64/wasm_opt --frozen --package wasm-opt
build step: __brave_tools_crates_build_wasm_opt___build_toolchain_mac_clang_arm64__rule "./wasm_opt/release/wasm-opt"
stderr:
error: process didn't exit successfully: `rustc -vV` (exit status: 1)
--- stderr
error: rustup could not choose a version of rustc to run, because one wasn't specified explicitly, and no default is configured.
help: run 'rustup default stable' to download the latest stable release of Rust and set it as your default toolchain.

Traceback (most recent call last):
  File "[redacted]brave/src/out/Component_arm64/../../brave/script/build_crate.py", line 21, in <module>
    subprocess.check_call(cargo_args, env=env)
  File "[redacted]brave/src/brave/vendor/depot_tools/bootstrap-2@3.11.8.chromium.35_bin/python3/lib/python3.11/subprocess.py", line 413, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['[redacted]brave/src/third_party/rust-toolchain/bin/cargo', 'build', '--quiet', '--release', '--manifest-path', '[redacted]brave/src/brave/tools/crates/Cargo.toml', '--config', '[redacted]brave/src/brave/tools/crates/.cargo/config.toml', '--target-dir', '[redacted]brave/src/out/Component_arm64/wasm_opt', '--frozen', '--package', 'wasm-opt']' returned non-zero exit status 101.
```
