### PR TITLE
[CodeHealth] Fix more GetString() cases that shouldn't copy

### DIFF
--- a/browser/ui/webui/new_tab_page/brave_new_tab_message_handler.cc
+++ b/browser/ui/webui/new_tab_page/brave_new_tab_message_handler.cc
@@ -390,7 +390,7 @@ void BraveNewTabMessageHandler::HandleSaveNewTabPagePref(
 
   // Handle string settings
   if (settings_value.is_string()) {
-    const auto settings_value_string = settings_value.GetString();
+    const auto& settings_value_string = settings_value.GetString();
     if (settings_key_input == "clockFormat") {
       settings_key = kNewTabPageClockFormat;
     } else if (settings_key_input == "lastUsedNtpSearchEngine") {

--- a/components/brave_referrals/browser/brave_referrals_service.cc
+++ b/components/brave_referrals/browser/brave_referrals_service.cc
@@ -182,7 +182,7 @@ void BraveReferralsService::Start() {
   // users without download_ids from initializing.
   bool checked_for_promo_code_file =
       pref_service_->GetBoolean(kReferralCheckedForPromoCodeFile);
-  std::string download_id = pref_service_->GetString(kReferralDownloadID);
+  const auto& download_id = pref_service_->GetString(kReferralDownloadID);
   if (!checked_for_promo_code_file && !has_initialized && download_id.empty()) {
 #if !BUILDFLAG(IS_ANDROID)
     task_runner_->PostTaskAndReplyWithResult(
@@ -397,7 +397,7 @@ base::FilePath BraveReferralsService::GetPromoCodeFileName() const {
 void BraveReferralsService::MaybeCheckForReferralFinalization() {
   DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
 
-  std::string download_id = pref_service_->GetString(kReferralDownloadID);
+  const auto& download_id = pref_service_->GetString(kReferralDownloadID);
   if (download_id.empty()) {
     return;
   }

--- a/components/brave_rewards/content/rewards_notification_service_impl.cc
+++ b/components/brave_rewards/content/rewards_notification_service_impl.cc
@@ -133,7 +133,7 @@ RewardsNotificationServiceImpl::GenerateRewardsNotificationTimestamp() const {
 }
 
 void RewardsNotificationServiceImpl::ReadRewardsNotificationsJSON() {
-  std::string json = prefs_->GetString(prefs::kNotifications);
+  const auto& json = prefs_->GetString(prefs::kNotifications);
   if (json.empty()) {
     return;
   }
@@ -197,9 +197,8 @@ void RewardsNotificationServiceImpl::ReadRewardsNotifications(
 
     const base::Value::List* args = dict.FindList("args");
     if (args) {
-      for (auto& arg : *args) {
-        std::string arg_string = arg.GetString();
-        notification_args.push_back(arg_string);
+      for (const auto& arg : *args) {
+        notification_args.push_back(arg.GetString());
       }
     }
 

--- a/components/brave_rewards/content/rewards_service_impl.cc
+++ b/components/brave_rewards/content/rewards_service_impl.cc
@@ -480,7 +480,7 @@ void RewardsServiceImpl::AcceptTermsOfServiceUpdate() {
 }
 
 std::string RewardsServiceImpl::GetCountryCode() const {
-  std::string declared_geo = prefs_->GetString(prefs::kDeclaredGeo);
+  const auto& declared_geo = prefs_->GetString(prefs::kDeclaredGeo);
   return !declared_geo.empty()
              ? declared_geo
              : std::string(
@@ -2023,7 +2023,7 @@ std::string RewardsServiceImpl::GetExternalWalletType() const {
     return internal::constant::kWalletBitflyer;
   }
 
-  const std::string type = prefs_->GetString(prefs::kExternalWalletType);
+  const auto& type = prefs_->GetString(prefs::kExternalWalletType);
 
   if (IsValidWalletType(type)) {
     return type;

--- a/components/brave_rewards/core/engine/credentials/credentials_util.cc
+++ b/components/brave_rewards/core/engine/credentials/credentials_util.cc
@@ -156,7 +156,7 @@ std::vector<std::string> UnBlindCredsMock(const mojom::CredsBatch& creds) {
   DCHECK(signed_creds_base64.has_value());
 
   for (auto& item : signed_creds_base64.value()) {
-    unblinded_encoded_creds.push_back(item.GetString());
+    unblinded_encoded_creds.push_back(std::move(item).TakeString());
   }
 
   return unblinded_encoded_creds;

--- a/components/brave_rewards/core/engine/rewards_engine.cc
+++ b/components/brave_rewards/core/engine/rewards_engine.cc
@@ -359,7 +359,7 @@ void RewardsEngine::FetchBalance(FetchBalanceCallback callback) {
 void RewardsEngine::GetExternalWallet(GetExternalWalletCallback callback) {
   WhenReady([this, callback = std::move(callback)]() mutable {
     mojom::ExternalWalletPtr wallet;
-    auto wallet_type =
+    const auto& wallet_type =
         Get<RewardsPrefs>().GetString(prefs::kExternalWalletType);
     if (auto* provider = GetExternalWalletProvider(wallet_type)) {
       wallet = provider->GetWallet();

--- a/components/brave_rewards/core/engine/wallet/wallet.cc
+++ b/components/brave_rewards/core/engine/wallet/wallet.cc
@@ -43,7 +43,8 @@ mojom::RewardsWalletPtr Wallet::GetWallet(bool* corrupted) {
   DCHECK(corrupted);
   *corrupted = false;
 
-  auto json = engine_->Get<RewardsPrefs>().GetString(prefs::kWalletBrave);
+  const auto& json =
+      engine_->Get<RewardsPrefs>().GetString(prefs::kWalletBrave);
   if (json.empty()) {
     return nullptr;
   }

--- a/components/brave_rewards/core/engine/wallet_provider/linkage_checker.cc
+++ b/components/brave_rewards/core/engine/wallet_provider/linkage_checker.cc
@@ -55,7 +55,8 @@ bool LinkageChecker::ShouldPerformCheck() {
 }
 
 mojom::ExternalWalletPtr LinkageChecker::GetExternalWallet() {
-  auto wallet_type = Get<RewardsPrefs>().GetString(prefs::kExternalWalletType);
+  const auto& wallet_type =
+      Get<RewardsPrefs>().GetString(prefs::kExternalWalletType);
   if (wallet_type.empty()) {
     return nullptr;
   }

--- a/components/brave_sync/brave_sync_prefs.cc
+++ b/components/brave_sync/brave_sync_prefs.cc
@@ -127,7 +127,7 @@ std::string Prefs::GetSeed(bool* failed_to_decrypt) const {
   CHECK(failed_to_decrypt);
   *failed_to_decrypt = true;
 
-  const std::string encoded_seed = pref_service_->GetString(kSyncV2Seed);
+  const auto& encoded_seed = pref_service_->GetString(kSyncV2Seed);
   if (encoded_seed.empty()) {
     *failed_to_decrypt = false;
     return std::string();
@@ -184,7 +184,7 @@ void Prefs::AddLeaveChainDetail(const char* file, int line, const char* func) {
     return;
   }
 
-  std::string details = pref_service_->GetString(kSyncLeaveChainDetails);
+  const auto& details = pref_service_->GetString(kSyncLeaveChainDetails);
 
   std::ostringstream stream;
   stream << base::Time::Now() << " "

--- a/components/misc_metrics/language_metrics.cc
+++ b/components/misc_metrics/language_metrics.cc
@@ -228,7 +228,8 @@ LanguageMetrics::LanguageMetrics(PrefService* profile_prefs)
 LanguageMetrics::~LanguageMetrics() = default;
 
 void LanguageMetrics::RecordLanguageMetric() {
-  auto languages = profile_prefs_->GetString(language::prefs::kAcceptLanguages);
+  const auto& languages =
+      profile_prefs_->GetString(language::prefs::kAcceptLanguages);
   auto languages_split = base::SplitString(
       languages, ",", base::WhitespaceHandling::TRIM_WHITESPACE,
       base::SplitResult::SPLIT_WANT_NONEMPTY);

--- a/components/playlist/content/browser/type_converter.cc
+++ b/components/playlist/content/browser/type_converter.cc
@@ -87,7 +87,7 @@ void MigratePlaylistOrder(const base::Value::Dict& playlists,
 
   base::flat_set<std::string> removed_ids;
   for (const auto& existing_id_value : order) {
-    auto existing_id = existing_id_value.GetString();
+    const auto& existing_id = existing_id_value.GetString();
     if (base::Contains(missing_ids, existing_id)) {
       missing_ids.erase(existing_id);
     } else {

--- a/components/psst/browser/core/psst_rule.cc
+++ b/components/psst/browser/core/psst_rule.cc
@@ -48,7 +48,7 @@ bool GetFilePathFromValue(const base::Value* value, base::FilePath* result) {
   if (!value->is_string()) {
     return false;
   }
-  auto val = value->GetString();
+  const auto& val = value->GetString();
   *result = base::FilePath::FromASCII(val);
   return true;
 }


### PR DESCRIPTION
This commit fixes more code that takes unnecessary std::string copies by qualifying lvalues to `const &`

For consistency, any lines that explicitly declared an lvalue as `std::string` now use `auto` instead.

One exception is that `credentials_util.cc` was changed to move the string out of the object straight into the container since the owner is discarded immediately after all values have been taken.

See https://github.com/orgs/brave/projects/152?pane=issue&itemId=122345450