### PR TITLE
[ads] Remove kShouldSupportNewTabPageAdConfirmationsForNonRewards feature param

### DIFF
--- a/android/java/org/chromium/chrome/browser/ntp/BraveNewTabTakeoverInfobar.java
+++ b/android/java/org/chromium/chrome/browser/ntp/BraveNewTabTakeoverInfobar.java
@@ -10,7 +10,6 @@ import android.app.Activity;
 import org.chromium.build.annotations.NullMarked;
 import org.chromium.chrome.R;
 import org.chromium.chrome.browser.BraveRewardsHelper;
-import org.chromium.chrome.browser.flags.ChromeFeatureList;
 import org.chromium.chrome.browser.infobar.BraveInfoBarIdentifier;
 import org.chromium.chrome.browser.preferences.BravePref;
 import org.chromium.chrome.browser.profiles.Profile;
@@ -26,9 +25,6 @@ public class BraveNewTabTakeoverInfobar {
     private static final String TAG = "NewTabTakeover";
     private static final String LEARN_MORE_URL =
             "https://support.brave.app/hc/en-us/articles/35182999599501";
-    private static final String NEW_TAB_PAGE_ADS_FEATURE = "NewTabPageAds";
-    private static final String SHOULD_SUPPORT_CONFIRMATIONS_FOR_NON_REWARDS_FEATURE_PARAM =
-            "should_support_confirmations_for_non_rewards";
     private final Profile mProfile;
 
     public BraveNewTabTakeoverInfobar(Profile profile) {
@@ -77,13 +73,6 @@ public class BraveNewTabTakeoverInfobar {
     }
 
     private boolean shouldDisplayInfobar() {
-        if (!ChromeFeatureList.getFieldTrialParamByFeatureAsBoolean(
-                NEW_TAB_PAGE_ADS_FEATURE,
-                SHOULD_SUPPORT_CONFIRMATIONS_FOR_NON_REWARDS_FEATURE_PARAM,
-                /* defaultValue= */ false)) {
-            return false;
-        }
-
         if (BraveRewardsHelper.isRewardsEnabled()) {
             return false;
         }

--- a/browser/ntp_background/new_tab_takeover_infobar_delegate_unittest.cc
+++ b/browser/ntp_background/new_tab_takeover_infobar_delegate_unittest.cc
@@ -5,7 +5,6 @@
 
 #include "brave/browser/ntp_background/new_tab_takeover_infobar_delegate.h"
 
-#include "brave/components/brave_ads/core/public/ad_units/new_tab_page_ad/new_tab_page_ad_feature.h"
 #include "brave/components/brave_rewards/core/pref_names.h"
 #include "brave/components/ntp_background_images/browser/new_tab_takeover_infobar_util.h"
 #include "brave/components/ntp_background_images/common/infobar_constants.h"
@@ -57,31 +56,19 @@ class NewTabTakeoverInfoBarDelegateTest
     EXPECT_THAT(GetInfobarManager()->infobars(), ::testing::IsEmpty());
   }
 
-  void SetShouldSupportConfirmationsForNonRewardsFeatureEnabled(bool enabled) {
-    scoped_feature_list_.InitWithFeaturesAndParameters(
-        {{brave_ads::kNewTabPageAdFeature,
-          {{"should_support_confirmations_for_non_rewards",
-            enabled ? "true" : "false"}}}},
-        {});
-  }
-
   void SetRewardsEnabled(bool enabled) {
     GetPrefs()->SetBoolean(brave_rewards::prefs::kEnabled, enabled);
   }
 
  private:
-  base::test::ScopedFeatureList scoped_feature_list_;
-
 #if !BUILDFLAG(IS_ANDROID)
   ChromeLayoutProvider layout_provider_;
 #endif  // !BUILDFLAG(IS_ANDROID)
 };
 
-TEST_F(
-    NewTabTakeoverInfoBarDelegateTest,
-    ShouldDisplayInfobarIfShouldSupportConfirmationsForNonRewardsFeatureIsEnabled) {
+TEST_F(NewTabTakeoverInfoBarDelegateTest,
+       ShouldDisplayInfobarIfShouldSupportConfirmationsForNonRewards) {
   SetRewardsEnabled(/*enabled=*/false);
-  SetShouldSupportConfirmationsForNonRewardsFeatureEnabled(/*enabled=*/true);
 
   EXPECT_THAT(
       GetPrefs()->GetInteger(
@@ -96,39 +83,9 @@ TEST_F(
       ::testing::Eq(kNewTabTakeoverInfobarRemainingDisplayCountThreshold - 1));
 }
 
-TEST_F(
-    NewTabTakeoverInfoBarDelegateTest,
-    ShouldNotDisplayInfobarIfShouldSupportConfirmationsForNonRewardsFeatureIsDisabled) {
-  SetRewardsEnabled(/*enabled=*/false);
-  SetShouldSupportConfirmationsForNonRewardsFeatureEnabled(/*enabled=*/false);
-
-  EXPECT_THAT(
-      GetPrefs()->GetInteger(
-          prefs::kNewTabTakeoverInfobarRemainingDisplayCount),
-      ::testing::Eq(kNewTabTakeoverInfobarRemainingDisplayCountThreshold));
-
-  VerifyInfobarWasNotDisplayedExpectation();
-}
-
-TEST_F(
-    NewTabTakeoverInfoBarDelegateTest,
-    ShouldNotDisplayInfobarIfShouldSupportConfirmationsForNonRewardsFeatureIsEnabledAndRewardsIsEnabled) {
+TEST_F(NewTabTakeoverInfoBarDelegateTest,
+       ShouldNotDisplayInfobarIfShouldSupportConfirmationsForRewards) {
   SetRewardsEnabled(/*enabled=*/true);
-  SetShouldSupportConfirmationsForNonRewardsFeatureEnabled(/*enabled=*/true);
-
-  EXPECT_THAT(
-      GetPrefs()->GetInteger(
-          prefs::kNewTabTakeoverInfobarRemainingDisplayCount),
-      ::testing::Eq(kNewTabTakeoverInfobarRemainingDisplayCountThreshold));
-
-  VerifyInfobarWasNotDisplayedExpectation();
-}
-
-TEST_F(
-    NewTabTakeoverInfoBarDelegateTest,
-    ShouldNotDisplayInfobarIfShouldSupportConfirmationsForNonRewardsFeatureIsDisabledAndRewardsIsEnabled) {
-  SetRewardsEnabled(/*enabled=*/true);
-  SetShouldSupportConfirmationsForNonRewardsFeatureEnabled(/*enabled=*/false);
 
   EXPECT_THAT(
       GetPrefs()->GetInteger(
@@ -141,7 +98,6 @@ TEST_F(
 TEST_F(NewTabTakeoverInfoBarDelegateTest,
        ShouldDisplayInfobarWhenThresholdHasNotBeenExceeded) {
   SetRewardsEnabled(/*enabled=*/false);
-  SetShouldSupportConfirmationsForNonRewardsFeatureEnabled(/*enabled=*/true);
 
   EXPECT_THAT(
       GetPrefs()->GetInteger(
@@ -164,7 +120,6 @@ TEST_F(NewTabTakeoverInfoBarDelegateTest,
 TEST_F(NewTabTakeoverInfoBarDelegateTest,
        ShouldNotDisplayInfobarWhenThresholdIsMet) {
   SetRewardsEnabled(/*enabled=*/false);
-  SetShouldSupportConfirmationsForNonRewardsFeatureEnabled(/*enabled=*/true);
 
   GetPrefs()->SetInteger(prefs::kNewTabTakeoverInfobarRemainingDisplayCount, 0);
 
@@ -174,7 +129,6 @@ TEST_F(NewTabTakeoverInfoBarDelegateTest,
 TEST_F(NewTabTakeoverInfoBarDelegateTest,
        ShouldNotDisplayInfobarWhenThresholdIsExceeded) {
   SetRewardsEnabled(/*enabled=*/false);
-  SetShouldSupportConfirmationsForNonRewardsFeatureEnabled(/*enabled=*/true);
 
   GetPrefs()->SetInteger(prefs::kNewTabTakeoverInfobarRemainingDisplayCount,
                          -1);
@@ -185,7 +139,6 @@ TEST_F(NewTabTakeoverInfoBarDelegateTest,
 TEST_F(NewTabTakeoverInfoBarDelegateTest,
        ShouldNeverDisplayInfobarAgainIfClosedByUser) {
   SetRewardsEnabled(/*enabled=*/false);
-  SetShouldSupportConfirmationsForNonRewardsFeatureEnabled(/*enabled=*/true);
 
   CreateInfobar();
   ASSERT_THAT(GetInfobarManager()->infobars(), ::testing::SizeIs(1));
@@ -200,7 +153,6 @@ TEST_F(NewTabTakeoverInfoBarDelegateTest,
 TEST_F(NewTabTakeoverInfoBarDelegateTest,
        ShouldNeverDisplayInfobarAgainIfUserClicksLearnMoreLink) {
   SetRewardsEnabled(/*enabled=*/false);
-  SetShouldSupportConfirmationsForNonRewardsFeatureEnabled(/*enabled=*/true);
 
   CreateInfobar();
   ASSERT_THAT(GetInfobarManager()->infobars(), ::testing::SizeIs(1));

--- a/components/brave_ads/core/internal/account/account_unittest.cc
+++ b/components/brave_ads/core/internal/account/account_unittest.cc
@@ -9,7 +9,6 @@
 #include "base/run_loop.h"
 #include "base/test/gmock_callback_support.h"
 #include "base/test/mock_callback.h"
-#include "base/test/scoped_feature_list.h"
 #include "brave/components/brave_ads/core/internal/account/account_observer_mock.h"
 #include "brave/components/brave_ads/core/internal/account/deposits/deposit_util.h"
 #include "brave/components/brave_ads/core/internal/account/issuers/issuers_test_util.h"
@@ -38,7 +37,6 @@
 #include "brave/components/brave_ads/core/internal/creatives/notification_ads/creative_notification_ads_database_util.h"
 #include "brave/components/brave_ads/core/internal/settings/settings_test_util.h"
 #include "brave/components/brave_ads/core/mojom/brave_ads.mojom.h"
-#include "brave/components/brave_ads/core/public/ad_units/new_tab_page_ad/new_tab_page_ad_feature.h"
 #include "net/http/http_status_code.h"
 
 // npm run test -- brave_unit_tests --filter=BraveAds
@@ -466,11 +464,6 @@ TEST_F(BraveAdsAccountTest,
        DoNotAddTransactionWhenDepositingNonCashForNonRewardsUser) {
   // Arrange
   test::DisableBraveRewards();
-
-  base::test::ScopedFeatureList scoped_feature_list;
-  scoped_feature_list.InitAndEnableFeatureWithParameters(
-      kNewTabPageAdFeature,
-      {{"should_support_confirmations_for_non_rewards", "true"}});
 
   const CreativeNewTabPageAdInfo creative_ad =
       test::BuildCreativeNewTabPageAd(CreativeNewTabPageAdWallpaperType::kImage,

--- a/components/brave_ads/core/internal/account/account_util_unittest.cc
+++ b/components/brave_ads/core/internal/account/account_util_unittest.cc
@@ -9,12 +9,10 @@
 
 #include <cstddef>
 
-#include "base/test/scoped_feature_list.h"
 #include "brave/components/brave_ads/core/internal/ad_units/ad_test_constants.h"
 #include "brave/components/brave_ads/core/internal/ads_core/ads_core_util.h"
 #include "brave/components/brave_ads/core/internal/common/test/test_base.h"
 #include "brave/components/brave_ads/core/internal/settings/settings_test_util.h"
-#include "brave/components/brave_ads/core/public/ad_units/new_tab_page_ad/new_tab_page_ad_feature.h"
 
 namespace brave_ads {
 
@@ -97,11 +95,6 @@ TEST_F(BraveAdsAccountUtilTest, AllowNewTabPageAdDepositsForNonRewardsUser) {
   // Arrange
   test::DisableBraveRewards();
 
-  base::test::ScopedFeatureList scoped_feature_list;
-  scoped_feature_list.InitAndEnableFeatureWithParameters(
-      kNewTabPageAdFeature,
-      {{"should_support_confirmations_for_non_rewards", "true"}});
-
   // Act & Assert
   for (int i = 0; i < static_cast<int>(mojom::ConfirmationType::kMaxValue);
        ++i) {
@@ -113,36 +106,11 @@ TEST_F(BraveAdsAccountUtilTest, AllowNewTabPageAdDepositsForNonRewardsUser) {
 
 TEST_F(
     BraveAdsAccountUtilTest,
-    DoNotAllowNewTabPageAdDepositsForNonRewardsUserIfShouldNotSupportConfirmations) {
-  // Arrange
-  test::DisableBraveRewards();
-
-  base::test::ScopedFeatureList scoped_feature_list;
-  scoped_feature_list.InitAndEnableFeatureWithParameters(
-      kNewTabPageAdFeature,
-      {{"should_support_confirmations_for_non_rewards", "false"}});
-
-  // Act & Assert
-  for (int i = 0; i < static_cast<int>(mojom::ConfirmationType::kMaxValue);
-       ++i) {
-    EXPECT_FALSE(IsAllowedToDeposit(test::kCreativeInstanceId,
-                                    mojom::AdType::kNewTabPageAd,
-                                    static_cast<mojom::ConfirmationType>(i)));
-  }
-}
-
-TEST_F(
-    BraveAdsAccountUtilTest,
     DoNotAllowNewTabPageAdDepositsForNonRewardsUserIfOptedOutOfNewTabPageAds) {
   // Arrange
   test::DisableBraveRewards();
 
   test::OptOutOfNewTabPageAds();
-
-  base::test::ScopedFeatureList scoped_feature_list;
-  scoped_feature_list.InitAndEnableFeatureWithParameters(
-      kNewTabPageAdFeature,
-      {{"should_support_confirmations_for_non_rewards", "true"}});
 
   // Act & Assert
   for (int i = 0; i < static_cast<int>(mojom::ConfirmationType::kMaxValue);
@@ -161,11 +129,6 @@ TEST_F(
 
   UpdateP3aMetricsFallbackState(test::kCreativeInstanceId,
                                 /*should_metrics_fallback_to_p3a=*/true);
-
-  base::test::ScopedFeatureList scoped_feature_list;
-  scoped_feature_list.InitAndEnableFeatureWithParameters(
-      kNewTabPageAdFeature,
-      {{"should_support_confirmations_for_non_rewards", "true"}});
 
   // Act & Assert
   for (int i = 0; i < static_cast<int>(mojom::ConfirmationType::kMaxValue);

--- a/components/brave_ads/core/internal/ad_units/new_tab_page_ad/new_tab_page_ad_feature_unittest.cc
+++ b/components/brave_ads/core/internal/ad_units/new_tab_page_ad/new_tab_page_ad_feature_unittest.cc
@@ -16,11 +16,6 @@ TEST(BraveAdsNewTabPageAdFeatureTest, IsEnabled) {
   EXPECT_TRUE(base::FeatureList::IsEnabled(kNewTabPageAdFeature));
 }
 
-TEST(BraveAdsNewTabPageAdFeatureTest, ShouldSupportNewTabPageAdConfirmations) {
-  // Act & Assert
-  EXPECT_TRUE(kShouldSupportNewTabPageAdConfirmationsForNonRewards.Get());
-}
-
 TEST(BraveAdsNewTabPageAdFeatureTest,
      ShouldFrequencyCapNewTabPageAdsForNonRewards) {
   // Act & Assert

--- a/components/brave_ads/core/internal/ads_core/ads_core.cc
+++ b/components/brave_ads/core/internal/ads_core/ads_core.cc
@@ -9,7 +9,6 @@
 
 #include "base/check.h"
 #include "brave/components/brave_ads/core/internal/account/tokens/token_generator_interface.h"
-#include "brave/components/brave_ads/core/public/ad_units/new_tab_page_ad/new_tab_page_ad_feature.h"
 
 namespace brave_ads {
 
@@ -48,9 +47,7 @@ void AdsCore::UpdateP3aMetricsFallbackState(
 
 bool AdsCore::ShouldFallbackToP3aMetrics(
     const std::string& creative_instance_id) const {
-  // If we don't support confirmations, we should always fallback to P3A.
-  return !kShouldSupportNewTabPageAdConfirmationsForNonRewards.Get() ||
-         metrics_fallback_to_p3a_.contains(creative_instance_id);
+  return metrics_fallback_to_p3a_.contains(creative_instance_id);
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/public/ad_units/new_tab_page_ad/new_tab_page_ad_feature.h
+++ b/components/brave_ads/core/public/ad_units/new_tab_page_ad/new_tab_page_ad_feature.h
@@ -17,13 +17,6 @@ namespace brave_ads {
 
 BASE_DECLARE_FEATURE(kNewTabPageAdFeature);
 
-// Set to `true` to support sending metrics using confirmations; otherwise,
-// metrics are always reported using P3A.
-inline constexpr base::FeatureParam<bool>
-    kShouldSupportNewTabPageAdConfirmationsForNonRewards{
-        &kNewTabPageAdFeature, "should_support_confirmations_for_non_rewards",
-        true};
-
 // Set to `true` to support frequency capping; otherwise, no capping.
 inline constexpr base::FeatureParam<bool>
     kShouldFrequencyCapNewTabPageAdsForNonRewards{

--- a/components/ntp_background_images/browser/new_tab_takeover_infobar_util.cc
+++ b/components/ntp_background_images/browser/new_tab_takeover_infobar_util.cc
@@ -6,7 +6,6 @@
 #include "brave/components/ntp_background_images/browser/new_tab_takeover_infobar_util.h"
 
 #include "base/check.h"
-#include "brave/components/brave_ads/core/public/ad_units/new_tab_page_ad/new_tab_page_ad_feature.h"
 #include "brave/components/brave_rewards/core/pref_names.h"
 #include "brave/components/ntp_background_images/common/pref_names.h"
 #include "components/prefs/pref_service.h"
@@ -15,10 +14,6 @@ namespace ntp_background_images {
 
 bool ShouldDisplayNewTabTakeoverInfobar(const PrefService* prefs) {
   CHECK(prefs);
-
-  if (!brave_ads::kShouldSupportNewTabPageAdConfirmationsForNonRewards.Get()) {
-    return false;
-  }
 
   if (prefs->GetBoolean(brave_rewards::prefs::kEnabled)) {
     return false;

--- a/components/ntp_background_images/browser/new_tab_takeover_infobar_util_unittest.cc
+++ b/components/ntp_background_images/browser/new_tab_takeover_infobar_util_unittest.cc
@@ -5,8 +5,6 @@
 
 #include "brave/components/ntp_background_images/browser/new_tab_takeover_infobar_util.h"
 
-#include "base/test/scoped_feature_list.h"
-#include "brave/components/brave_ads/core/public/ad_units/new_tab_page_ad/new_tab_page_ad_feature.h"
 #include "brave/components/brave_rewards/core/pref_names.h"
 #include "brave/components/brave_rewards/core/pref_registry.h"
 #include "brave/components/ntp_background_images/common/infobar_constants.h"
@@ -28,27 +26,16 @@ class NewTabTakeoverInfobarUtilTest : public testing::Test {
 
   PrefService* pref_service() { return &pref_service_; }
 
-  void SetShouldSupportConfirmationsForNonRewardsFeatureEnabled(bool enabled) {
-    scoped_feature_list_.InitWithFeaturesAndParameters(
-        {{brave_ads::kNewTabPageAdFeature,
-          {{"should_support_confirmations_for_non_rewards",
-            enabled ? "true" : "false"}}}},
-        {});
-  }
-
   void SetRewardsEnabled(bool enabled) {
     pref_service()->SetBoolean(brave_rewards::prefs::kEnabled, enabled);
   }
 
  private:
-  base::test::ScopedFeatureList scoped_feature_list_;
-
   sync_preferences::TestingPrefServiceSyncable pref_service_;
 };
 
 TEST_F(NewTabTakeoverInfobarUtilTest, ShouldDisplayInfobar) {
   SetRewardsEnabled(/*enabled=*/false);
-  SetShouldSupportConfirmationsForNonRewardsFeatureEnabled(/*enabled=*/true);
 
   for (int i = 0; i < kNewTabTakeoverInfobarRemainingDisplayCountThreshold;
        ++i) {
@@ -59,28 +46,9 @@ TEST_F(NewTabTakeoverInfobarUtilTest, ShouldDisplayInfobar) {
   EXPECT_FALSE(ShouldDisplayNewTabTakeoverInfobar(pref_service()));
 }
 
-TEST_F(
-    NewTabTakeoverInfobarUtilTest,
-    ShouldNotDisplayInfobarIfShouldSupportConfirmationsForNonRewardsFeatureIsDisabled) {
-  SetRewardsEnabled(/*enabled=*/false);
-  SetShouldSupportConfirmationsForNonRewardsFeatureEnabled(/*enabled=*/false);
-
-  EXPECT_FALSE(ShouldDisplayNewTabTakeoverInfobar(pref_service()));
-}
-
-TEST_F(
-    NewTabTakeoverInfobarUtilTest,
-    DoNotShowInfobarWhenRewardsEnabledAndSupportNewTabPageAdConfirmationsForNonRewardsDisabled) {
-  SetRewardsEnabled(/*enabled=*/true);
-  SetShouldSupportConfirmationsForNonRewardsFeatureEnabled(/*enabled=*/false);
-
-  EXPECT_FALSE(ShouldDisplayNewTabTakeoverInfobar(pref_service()));
-}
-
 TEST_F(NewTabTakeoverInfobarUtilTest,
        ShouldNotDisplayInfobarIfRewardsIsEnabled) {
   SetRewardsEnabled(/*enabled=*/true);
-  SetShouldSupportConfirmationsForNonRewardsFeatureEnabled(/*enabled=*/true);
 
   EXPECT_FALSE(ShouldDisplayNewTabTakeoverInfobar(pref_service()));
 }
@@ -88,7 +56,6 @@ TEST_F(NewTabTakeoverInfobarUtilTest,
 TEST_F(NewTabTakeoverInfobarUtilTest,
        ShouldNotDisplayInfobarWhenThresholdIsMet) {
   SetRewardsEnabled(/*enabled=*/false);
-  SetShouldSupportConfirmationsForNonRewardsFeatureEnabled(/*enabled=*/true);
 
   pref_service()->SetInteger(prefs::kNewTabTakeoverInfobarRemainingDisplayCount,
                              0);
@@ -99,7 +66,6 @@ TEST_F(NewTabTakeoverInfobarUtilTest,
 TEST_F(NewTabTakeoverInfobarUtilTest,
        ShouldNotDisplayInfobarWhenThresholdIsExceeded) {
   SetRewardsEnabled(/*enabled=*/false);
-  SetShouldSupportConfirmationsForNonRewardsFeatureEnabled(/*enabled=*/true);
 
   pref_service()->SetInteger(prefs::kNewTabTakeoverInfobarRemainingDisplayCount,
                              -1);
@@ -109,7 +75,6 @@ TEST_F(NewTabTakeoverInfobarUtilTest,
 
 TEST_F(NewTabTakeoverInfobarUtilTest, RecordInfobarWasDisplayed) {
   SetRewardsEnabled(/*enabled=*/false);
-  SetShouldSupportConfirmationsForNonRewardsFeatureEnabled(/*enabled=*/true);
 
   RecordNewTabTakeoverInfobarWasDisplayed(pref_service());
   EXPECT_TRUE(ShouldDisplayNewTabTakeoverInfobar(pref_service()));
@@ -117,7 +82,6 @@ TEST_F(NewTabTakeoverInfobarUtilTest, RecordInfobarWasDisplayed) {
 
 TEST_F(NewTabTakeoverInfobarUtilTest, SuppressNewTabTakeoverInfobar) {
   SetRewardsEnabled(/*enabled=*/false);
-  SetShouldSupportConfirmationsForNonRewardsFeatureEnabled(/*enabled=*/true);
 
   SuppressNewTabTakeoverInfobar(pref_service());
   EXPECT_FALSE(ShouldDisplayNewTabTakeoverInfobar(pref_service()));

--- a/components/ntp_background_images/browser/ntp_sponsored_images_data.cc
+++ b/components/ntp_background_images/browser/ntp_sponsored_images_data.cc
@@ -11,7 +11,6 @@
 #include "base/strings/string_util.h"
 #include "base/time/time_delta_from_string.h"
 #include "base/uuid.h"
-#include "brave/components/brave_ads/core/public/ad_units/new_tab_page_ad/new_tab_page_ad_feature.h"
 #include "brave/components/brave_ads/core/public/ad_units/new_tab_page_ad/new_tab_page_ad_info.h"
 #include "brave/components/brave_ads/core/public/common/url/url_util.h"
 #include "brave/components/constants/webui_url_constants.h"
@@ -215,11 +214,7 @@ std::optional<Campaign> NTPSponsoredImagesData::MaybeParseCampaign(
   campaign.campaign_id = *campaign_id;
 
   bool should_metrics_fallback_to_p3a = false;
-  if (!brave_ads::kShouldSupportNewTabPageAdConfirmationsForNonRewards.Get()) {
-    // If we don't support confirmations, we should always fallback to P3A.
-    should_metrics_fallback_to_p3a = true;
-  } else if (const std::string* metrics =
-                 dict.FindString(kCampaignMetricsKey)) {
+  if (const std::string* metrics = dict.FindString(kCampaignMetricsKey)) {
     // Metrics (optional). If not provided, the default behavior is to send
     // confirmations.
     should_metrics_fallback_to_p3a = *metrics == "p3a";

--- a/components/ntp_background_images/browser/view_counter_service.cc
+++ b/components/ntp_background_images/browser/view_counter_service.cc
@@ -19,7 +19,6 @@
 #include "base/metrics/histogram_macros.h"
 #include "brave/components/brave_ads/core/browser/service/ads_service.h"
 #include "brave/components/brave_ads/core/mojom/brave_ads.mojom-shared.h"
-#include "brave/components/brave_ads/core/public/ad_units/new_tab_page_ad/new_tab_page_ad_feature.h"
 #include "brave/components/brave_rewards/core/pref_names.h"
 #include "brave/components/brave_rewards/core/rewards_flags.h"
 #include "brave/components/ntp_background_images/browser/brave_ntp_custom_background_service.h"
@@ -141,11 +140,6 @@ void ViewCounterService::BrandedWallpaperWillBeDisplayed(
     const std::string& campaign_id,
     const std::string& creative_instance_id,
     bool should_metrics_fallback_to_p3a) {
-  if (!brave_ads::kShouldSupportNewTabPageAdConfirmationsForNonRewards.Get()) {
-    // If we don't support confirmations, we should always fallback to P3A.
-    should_metrics_fallback_to_p3a = true;
-  }
-
   if (should_metrics_fallback_to_p3a && ntp_p3a_helper_) {
     ntp_p3a_helper_->RecordView(creative_instance_id, campaign_id);
   }
@@ -383,11 +377,6 @@ void ViewCounterService::BrandedWallpaperLogoClicked(
     const std::string& creative_instance_id,
     const std::string& /*target_url*/,
     bool should_metrics_fallback_to_p3a) {
-  if (!brave_ads::kShouldSupportNewTabPageAdConfirmationsForNonRewards.Get()) {
-    // If we don't support confirmations, we should always fallback to P3A.
-    should_metrics_fallback_to_p3a = true;
-  }
-
   if (should_metrics_fallback_to_p3a && ntp_p3a_helper_) {
     ntp_p3a_helper_->RecordNewTabPageAdEvent(
         brave_ads::mojom::NewTabPageAdEventType::kClicked,


### PR DESCRIPTION
We now fallback to confirmations by default in `campaigns.json` for all campaigns. The `kShouldSupportNewTabPageAdConfirmationsForNonRewards` feature param is no longer needed and should be removed.

Verify if the metrics key is set to "confirmation", confirmations are sent; if set to "p3a", P3A is sent; and if not specified, campaigns fallback to confirmations by default.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/49946

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
