### PR TITLE
[Wallet]: Fix Icon Theme Changes

### DIFF
--- a/components/brave_wallet_ui/components/desktop/views/nfts/components/nfts-empty-state/nfts-empty-state.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/nfts/components/nfts-empty-state/nfts-empty-state.tsx
@@ -3,6 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 import * as React from 'react'
+import useMediaQuery from '$web-common/useMediaQuery'
 
 // utils
 import { getLocale } from '../../../../../../../common/locale'
@@ -23,22 +24,23 @@ interface Props {
   onImportNft: () => void
 }
 
-export const NftsEmptyState = ({ onImportNft }: Props) => (
-  <StyledWrapper>
-    <EmptyStateImage
-      src={
-        window.matchMedia('(prefers-color-scheme: dark)').matches
-          ? EmptyStateGraphicDark
-          : EmptyStateGraphicLight
-      }
-    />
-    <Heading>{getLocale('braveNftsTabEmptyStateHeading')}</Heading>
-    <SubHeading>{getLocale('braveNftsTabEmptyStateSubHeading')}</SubHeading>
-    <ImportButton onClick={onImportNft}>
-      {getLocale('braveNftsTabImportNft')}
-    </ImportButton>
-    <DisclaimerText>
-      {getLocale('braveNftsTabEmptyStateDisclaimer')}
-    </DisclaimerText>
-  </StyledWrapper>
-)
+export const NftsEmptyState = ({ onImportNft }: Props) => {
+  // hooks
+  const isDarkMode = useMediaQuery('(prefers-color-scheme: dark)')
+
+  return (
+    <StyledWrapper>
+      <EmptyStateImage
+        src={isDarkMode ? EmptyStateGraphicDark : EmptyStateGraphicLight}
+      />
+      <Heading>{getLocale('braveNftsTabEmptyStateHeading')}</Heading>
+      <SubHeading>{getLocale('braveNftsTabEmptyStateSubHeading')}</SubHeading>
+      <ImportButton onClick={onImportNft}>
+        {getLocale('braveNftsTabImportNft')}
+      </ImportButton>
+      <DisclaimerText>
+        {getLocale('braveNftsTabEmptyStateDisclaimer')}
+      </DisclaimerText>
+    </StyledWrapper>
+  )
+}

--- a/components/brave_wallet_ui/page/screens/backup-wallet/explain-recovery-phrase/explain-recovery-phrase.style.ts
+++ b/components/brave_wallet_ui/page/screens/backup-wallet/explain-recovery-phrase/explain-recovery-phrase.style.ts
@@ -10,8 +10,6 @@ import Icon from '@brave/leo/react/icon'
 import * as leo from '@brave/leo/tokens/css/variables'
 
 import WarningCircleOutlineIcon from '../../../../assets/svg-icons/warning-circle-outline-icon.svg'
-import ExamplePhraseLight from './images/example_recovery_phrase_light.png'
-import ExamplePhraseDark from './images/example_recovery_phrase_dark.png'
 
 export const BannerCard = styled.div`
   margin-top: 24px;
@@ -82,11 +80,7 @@ export const BackupInstructions = styled.p`
   margin: 14px 0 0;
 `
 
-export const ExampleRecoveryPhrase = styled.img.attrs(() => ({
-  src: window.matchMedia('(prefers-color-scheme: dark)').matches
-    ? ExamplePhraseDark
-    : ExamplePhraseLight,
-}))`
+export const ExampleRecoveryPhrase = styled.img`
   width: 100%;
   height: 208px;
   margin: 54px 0;

--- a/components/brave_wallet_ui/page/screens/backup-wallet/explain-recovery-phrase/explain-recovery-phrase.tsx
+++ b/components/brave_wallet_ui/page/screens/backup-wallet/explain-recovery-phrase/explain-recovery-phrase.tsx
@@ -8,6 +8,11 @@ import { useHistory, useLocation } from 'react-router'
 import { useDispatch } from 'react-redux'
 import Button from '@brave/leo/react/button'
 import * as leo from '@brave/leo/tokens/css/variables'
+import useMediaQuery from '$web-common/useMediaQuery'
+
+// assets
+import ExamplePhraseLight from './images/example_recovery_phrase_light.png'
+import ExamplePhraseDark from './images/example_recovery_phrase_dark.png'
 
 // utils
 import { getLocale } from '../../../../../common/locale'
@@ -73,6 +78,9 @@ export const RecoveryPhraseExplainer = () => {
     report(BraveWallet.OnboardingAction.RecoverySetup)
   }, [report])
 
+  // hooks
+  const isDarkMode = useMediaQuery('(prefers-color-scheme: dark)')
+
   // render
   return (
     <>
@@ -95,7 +103,9 @@ export const RecoveryPhraseExplainer = () => {
         <BackupInstructions>
           {getLocale('braveWalletRecoveryPhraseBackupWarningImportant')}
         </BackupInstructions>
-        <ExampleRecoveryPhrase />
+        <ExampleRecoveryPhrase
+          src={isDarkMode ? ExamplePhraseDark : ExamplePhraseLight}
+        />
         <Column gap='24px'>
           <ContinueButton onClick={onContinue}>
             {getLocale('braveWalletButtonVerifyPhrase')}

--- a/components/brave_wallet_ui/page/screens/fund-wallet/components/buy_quote/buy_quote.tsx
+++ b/components/brave_wallet_ui/page/screens/fund-wallet/components/buy_quote/buy_quote.tsx
@@ -5,6 +5,7 @@
 
 import * as React from 'react'
 import Icon from '@brave/leo/react/icon'
+import useMediaQuery from '$web-common/useMediaQuery'
 
 // Types
 import {
@@ -103,8 +104,7 @@ export const BuyQuote = ({
   const quoteServiceProvider = serviceProviders.find(
     (provider) => provider.serviceProvider === serviceProvider,
   )
-  const providerImageUrl = window.matchMedia('(prefers-color-scheme: dark)')
-    .matches
+  const providerImageUrl = useMediaQuery('(prefers-color-scheme: dark)')
     ? quoteServiceProvider?.logoImages?.darkShortUrl
     : quoteServiceProvider?.logoImages?.lightShortUrl
 

--- a/components/brave_wallet_ui/page/screens/fund-wallet/fund_wallet_v2.tsx
+++ b/components/brave_wallet_ui/page/screens/fund-wallet/fund_wallet_v2.tsx
@@ -5,6 +5,7 @@
 
 import * as React from 'react'
 import Icon from '@brave/leo/react/icon'
+import useMediaQuery from '$web-common/useMediaQuery'
 
 // Types
 import { WalletRoutes } from '../../../constants/types'
@@ -117,7 +118,7 @@ export const FundWalletScreen = () => {
     (country) =>
       country.countryCode.toLowerCase() === selectedCountryCode.toLowerCase(),
   )
-  const isDarkMode = window.matchMedia('(prefers-color-scheme: dark)').matches
+  const isDarkMode = useMediaQuery('(prefers-color-scheme: dark)')
   const isStorybook = isComponentInStorybook()
   const pageTitle = getLocale('braveWalletBuyAsset').replace(
     '$1',

--- a/components/brave_wallet_ui/page/screens/onboarding/import_hardware_wallet_welcome/import_hardware_wallet_welcome.style.ts
+++ b/components/brave_wallet_ui/page/screens/onboarding/import_hardware_wallet_welcome/import_hardware_wallet_welcome.style.ts
@@ -6,14 +6,7 @@
 import styled from 'styled-components'
 import * as leo from '@brave/leo/tokens/css/variables'
 
-import HardwareGraphicLightSvg from './images/hardware_graphic_light.svg'
-import HardwareGraphicDarkSvg from './images/hardware_graphic_dark.svg'
-
-export const HardwareGraphic = styled.img.attrs({
-  src: window.matchMedia('(prefers-color-scheme: dark)').matches
-    ? HardwareGraphicDarkSvg
-    : HardwareGraphicLightSvg,
-})`
+export const HardwareGraphic = styled.img`
   width: 100%;
   height: auto;
   margin: 98px 0 40px;

--- a/components/brave_wallet_ui/page/screens/onboarding/import_hardware_wallet_welcome/import_hardware_wallet_welcome.tsx
+++ b/components/brave_wallet_ui/page/screens/onboarding/import_hardware_wallet_welcome/import_hardware_wallet_welcome.tsx
@@ -5,6 +5,11 @@
 
 import * as React from 'react'
 import { useHistory } from 'react-router'
+import useMediaQuery from '$web-common/useMediaQuery'
+
+// assets
+import HardwareGraphicLightSvg from './images/hardware_graphic_light.svg'
+import HardwareGraphicDarkSvg from './images/hardware_graphic_dark.svg'
 
 // utils
 import { getLocale, formatLocale } from '$web-common/locale'
@@ -33,8 +38,11 @@ const walletHardwareDescription = formatLocale(
 )
 
 export const OnboardingImportHardwareWalletWelcome = () => {
+  // hooks
   const history = useHistory()
+  const isDarkMode = useMediaQuery('(prefers-color-scheme: dark)')
 
+  // methods
   const onClickContinue = () => {
     history.push(WalletRoutes.OnboardingHardwareWalletCreatePassword)
   }
@@ -43,7 +51,9 @@ export const OnboardingImportHardwareWalletWelcome = () => {
     <OnboardingContentLayout
       title={getLocale('braveWalletConnectHardwareWallet')}
     >
-      <HardwareGraphic />
+      <HardwareGraphic
+        src={isDarkMode ? HardwareGraphicDarkSvg : HardwareGraphicLightSvg}
+      />
       <Description>
         {getLocale('braveWalletImportHardwareWalletDescription')}
       </Description>

--- a/components/brave_wallet_ui/page/screens/onboarding/onboarding_success/onboarding_success.style.ts
+++ b/components/brave_wallet_ui/page/screens/onboarding/onboarding_success/onboarding_success.style.ts
@@ -6,15 +6,7 @@
 import styled from 'styled-components'
 import * as leo from '@brave/leo/tokens/css/variables'
 
-// images
-import CompleteGraphicLight from './images/complete_light.svg'
-import CompleteGraphicDark from './images/complete_dark.svg'
-
-export const IntroImg = styled.img.attrs({
-  src: window.matchMedia('(prefers-color-scheme: dark)').matches
-    ? CompleteGraphicDark
-    : CompleteGraphicLight,
-})`
+export const IntroImg = styled.img`
   width: 336px;
   height: 264px;
   margin: 0 auto;

--- a/components/brave_wallet_ui/page/screens/onboarding/onboarding_success/onboarding_success.tsx
+++ b/components/brave_wallet_ui/page/screens/onboarding/onboarding_success/onboarding_success.tsx
@@ -6,6 +6,11 @@
 import * as React from 'react'
 import { useHistory } from 'react-router'
 import { useDispatch } from 'react-redux'
+import useMediaQuery from '$web-common/useMediaQuery'
+
+// images
+import CompleteGraphicLight from './images/complete_light.svg'
+import CompleteGraphicDark from './images/complete_dark.svg'
 
 // utils
 import { getLocale } from '../../../../../common/locale'
@@ -53,13 +58,16 @@ export const OnboardingSuccess = () => {
     report(BraveWallet.OnboardingAction.Complete)
   }, [report, discoverAssets])
 
+  // hooks
+  const isDarkMode = useMediaQuery('(prefers-color-scheme: dark)')
+
   // render
   return (
     <OnboardingContentLayout
       showBackButton={false}
       padding='0 0 100px 0'
     >
-      <IntroImg />
+      <IntroImg src={isDarkMode ? CompleteGraphicDark : CompleteGraphicLight} />
       <Title>{getLocale('braveWalletOnboardingSuccessTitle')}</Title>
       <VerticalSpace space='16px' />
       <SubTitle>


### PR DESCRIPTION
## Description 

Fixes a bug where `Icons` were not observing `Theme` changes from settings.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/49053>

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

1. Create a new `Profile` and then go through the `Wallet` onboarding
2. Once you reach the `Success` page, open a new tab and change the theme between `Light` and `Dark` theme
3. The illustration `Icon` should also change

<img width="799" height="703" alt="Screenshot 1" src="https://github.com/user-attachments/assets/5801c772-502f-4bd3-a43f-59ebc7edacf3" /> | <img width="794" height="707" alt="Screenshot" src="https://github.com/user-attachments/assets/2f80bc09-e765-4d5e-8d18-d9d51fdb5d02" />
--|--
