### PR TITLE
[ads] Connected Rewards users should not see SERP Ads (uplift to 1.83.x)

### DIFF
--- a/browser/net/search_ads_header_network_delegate_helper_unittest.cc
+++ b/browser/net/search_ads_header_network_delegate_helper_unittest.cc
@@ -6,27 +6,23 @@
 #include "brave/browser/net/search_ads_header_network_delegate_helper.h"
 
 #include <memory>
-#include <string>
+#include <string_view>
 #include <utility>
 
 #include "base/test/scoped_feature_list.h"
 #include "brave/browser/net/url_context.h"
 #include "brave/components/brave_ads/core/public/prefs/pref_names.h"
-#include "brave/components/brave_ads/core/public/prefs/pref_registry.h"
 #include "brave/components/brave_rewards/core/pref_names.h"
-#include "brave/components/brave_rewards/core/pref_registry.h"
 #include "brave/components/l10n/common/test/scoped_default_locale.h"
 #include "chrome/browser/prefs/browser_prefs.h"
 #include "chrome/test/base/testing_profile.h"
-#include "components/prefs/pref_registry_simple.h"
 #include "components/prefs/pref_service.h"
-#include "components/prefs/testing_pref_service.h"
 #include "components/sync_preferences/testing_pref_service_syncable.h"
 #include "content/public/test/browser_task_environment.h"
 #include "net/base/net_errors.h"
 #include "testing/gmock/include/gmock/gmock.h"
 #include "testing/gtest/include/gtest/gtest.h"
-#include "third_party/blink/public/mojom/loader/resource_load_info.mojom-shared.h"
+#include "third_party/blink/public/mojom/loader/resource_load_info.mojom-data-view.h"
 #include "url/gurl.h"
 
 #if BUILDFLAG(IS_ANDROID)
@@ -35,16 +31,18 @@
 
 using testing::Return;
 
+namespace brave {
+
 namespace {
 
-constexpr char kBraveSearchRequestUrl[] =
+constexpr std::string_view kBraveSearchRequestUrl =
     "https://search.brave.com/search?q=qwerty";
-constexpr char kBraveSearchImageRequestUrl[] =
+constexpr std::string_view kBraveSearchImageRequestUrl =
     "https://search.brave.com/img.png";
-constexpr char kNonBraveSearchRequestUrl[] =
+constexpr std::string_view kNonBraveSearchRequestUrl =
     "https://brave.com/search?q=qwerty";
-constexpr char kBraveSearchTabUrl[] = "https://search.brave.com";
-constexpr char kNonBraveSearchTabUrl[] = "https://brave.com";
+constexpr std::string_view kBraveSearchTabUrl = "https://search.brave.com";
+constexpr std::string_view kNonBraveSearchTabUrl = "https://brave.com";
 
 }  // namespace
 
@@ -67,243 +65,192 @@ class SearchAdsHeaderDelegateHelperTest : public testing::Test {
     profile_ = builder.Build();
   }
 
+  void EnableBraveRewards() {
+    // Disabled by default.
+    profile_->GetPrefs()->SetBoolean(brave_rewards::prefs::kEnabled, true);
+  }
+
+  void ConnectExternalBraveRewardsWallet() {
+    // Disconnected by default.
+    profile_->GetPrefs()->SetString(brave_rewards::prefs::kExternalWalletType,
+                                    "connected");
+  }
+
+  void OptOutOfSearchResultAds() {
+    // Opted-in by default.
+    profile_->GetPrefs()->SetBoolean(
+        brave_ads::prefs::kOptedInToSearchResultAds, false);
+  }
+
+  std::shared_ptr<BraveRequestInfo> MakeRequest(std::string_view url,
+                                                TestingProfile* profile) {
+    auto request = std::make_shared<BraveRequestInfo>(GURL(url));
+    request->request_url = GURL(kBraveSearchTabUrl);
+    request->tab_origin = GURL(kBraveSearchTabUrl);
+    request->initiator_url = GURL(kBraveSearchTabUrl);
+    request->resource_type = blink::mojom::ResourceType::kMainFrame;
+    request->browser_context = profile;
+    return request;
+  }
+
+  void VerifyHeaderExistsExpectation(
+      std::shared_ptr<BraveRequestInfo> request) {
+    net::HttpRequestHeaders request_headers;
+    const int result_code = OnBeforeStartTransaction_SearchAdsHeader(
+        &request_headers, ResponseCallback(), request);
+    EXPECT_EQ(result_code, net::OK);
+    EXPECT_TRUE(request_headers.HasHeader(kSearchAdsHeader));
+    EXPECT_EQ(request_headers.GetHeader(kSearchAdsHeader),
+              kSearchAdsDisabledValue);
+  }
+
+  void VerifyMissingHeaderExpectation(
+      std::shared_ptr<BraveRequestInfo> request) {
+    net::HttpRequestHeaders request_headers;
+    const int result_code = OnBeforeStartTransaction_SearchAdsHeader(
+        &request_headers, ResponseCallback(), request);
+    EXPECT_EQ(result_code, net::OK);
+    EXPECT_FALSE(request_headers.HasHeader(kSearchAdsHeader));
+  }
+
   brave_l10n::test::ScopedDefaultLocale scoped_locale_{"en_US"};
   content::BrowserTaskEnvironment task_environment_;
   base::test::ScopedFeatureList scoped_feature_list_;
   std::unique_ptr<TestingProfile> profile_;
 };
 
-TEST_F(SearchAdsHeaderDelegateHelperTest, BraveSearchTabRewardsEnabled) {
-  profile_->GetPrefs()->SetBoolean(brave_rewards::prefs::kEnabled, true);
-  profile_->GetPrefs()->SetBoolean(brave_ads::prefs::kOptedInToSearchResultAds,
-                                   false);
+TEST_F(SearchAdsHeaderDelegateHelperTest,
+       HeaderShouldExistForMainFrameResource) {
+  EnableBraveRewards();
+  OptOutOfSearchResultAds();
 
-  auto request_info = std::make_shared<brave::BraveRequestInfo>();
-  request_info->browser_context = profile_.get();
-  request_info->tab_origin = GURL(kBraveSearchTabUrl);
+  auto request = MakeRequest(kBraveSearchRequestUrl, profile_.get());
+  request->resource_type = blink::mojom::ResourceType::kMainFrame;
+  VerifyHeaderExistsExpectation(request);
+}
 
-  {
-    request_info->request_url = GURL(kBraveSearchTabUrl);
-    request_info->resource_type = blink::mojom::ResourceType::kMainFrame;
+TEST_F(SearchAdsHeaderDelegateHelperTest, HeaderShouldExistForXhrResource) {
+  EnableBraveRewards();
+  OptOutOfSearchResultAds();
 
-    net::HttpRequestHeaders headers;
-    const int result_code = brave::OnBeforeStartTransaction_SearchAdsHeader(
-        &headers, brave::ResponseCallback(), request_info);
-    EXPECT_EQ(result_code, net::OK);
+  auto request = MakeRequest(kBraveSearchRequestUrl, profile_.get());
+  request->resource_type = blink::mojom::ResourceType::kXhr;
+  VerifyHeaderExistsExpectation(request);
+}
 
-    auto header_value = headers.GetHeader(brave::kSearchAdsHeader);
-    ASSERT_TRUE(header_value);
-    EXPECT_EQ(*header_value, brave::kSearchAdsDisabledValue);
-  }
+TEST_F(SearchAdsHeaderDelegateHelperTest, HeaderShouldExistForImageResource) {
+  EnableBraveRewards();
+  OptOutOfSearchResultAds();
 
-  {
-    request_info->request_url = GURL(kBraveSearchTabUrl);
-    request_info->resource_type = blink::mojom::ResourceType::kXhr;
-
-    net::HttpRequestHeaders headers;
-    const int result_code = brave::OnBeforeStartTransaction_SearchAdsHeader(
-        &headers, brave::ResponseCallback(), request_info);
-    EXPECT_EQ(result_code, net::OK);
-
-    auto header_value = headers.GetHeader(brave::kSearchAdsHeader);
-    ASSERT_TRUE(header_value);
-    EXPECT_EQ(*header_value, brave::kSearchAdsDisabledValue);
-  }
-
-  {
-    request_info->request_url = GURL(kBraveSearchImageRequestUrl);
-    request_info->resource_type = blink::mojom::ResourceType::kImage;
-
-    net::HttpRequestHeaders headers;
-    const int result_code = brave::OnBeforeStartTransaction_SearchAdsHeader(
-        &headers, brave::ResponseCallback(), request_info);
-    EXPECT_EQ(result_code, net::OK);
-
-    auto header_value = headers.GetHeader(brave::kSearchAdsHeader);
-    ASSERT_TRUE(header_value);
-    EXPECT_EQ(*header_value, brave::kSearchAdsDisabledValue);
-  }
-
-  {
-    request_info->tab_origin = GURL();
-    request_info->initiator_url = GURL(kBraveSearchTabUrl);
-    request_info->request_url = GURL(kBraveSearchTabUrl);
-    request_info->resource_type = blink::mojom::ResourceType::kXhr;
-
-    net::HttpRequestHeaders headers;
-    const int result_code = brave::OnBeforeStartTransaction_SearchAdsHeader(
-        &headers, brave::ResponseCallback(), request_info);
-    EXPECT_EQ(result_code, net::OK);
-
-    auto header_value = headers.GetHeader(brave::kSearchAdsHeader);
-    ASSERT_TRUE(header_value);
-    EXPECT_EQ(*header_value, brave::kSearchAdsDisabledValue);
-  }
+  auto request = MakeRequest(kBraveSearchImageRequestUrl, profile_.get());
+  request->resource_type = blink::mojom::ResourceType::kImage;
+  VerifyHeaderExistsExpectation(request);
 }
 
 TEST_F(SearchAdsHeaderDelegateHelperTest,
-       NonBraveSearchTabSearchRewardsEnabled) {
-  profile_->GetPrefs()->SetBoolean(brave_rewards::prefs::kEnabled, true);
-  profile_->GetPrefs()->SetBoolean(brave_ads::prefs::kOptedInToSearchResultAds,
-                                   false);
+       HeaderShouldNotExistForDisallowedTabOriginHost) {
+  EnableBraveRewards();
 
-  auto request_info =
-      std::make_shared<brave::BraveRequestInfo>(GURL(kBraveSearchRequestUrl));
-  request_info->browser_context = profile_.get();
-  request_info->resource_type = blink::mojom::ResourceType::kMainFrame;
-
-  {
-    request_info->tab_origin = GURL(kNonBraveSearchTabUrl);
-    request_info->initiator_url = GURL();
-
-    net::HttpRequestHeaders headers;
-    const int result_code = brave::OnBeforeStartTransaction_SearchAdsHeader(
-        &headers, brave::ResponseCallback(), request_info);
-    EXPECT_EQ(result_code, net::OK);
-
-    EXPECT_FALSE(headers.HasHeader(brave::kSearchAdsHeader));
-  }
-
-  {
-    request_info->tab_origin = GURL();
-    request_info->initiator_url = GURL(kNonBraveSearchTabUrl);
-
-    net::HttpRequestHeaders headers;
-    const int result_code = brave::OnBeforeStartTransaction_SearchAdsHeader(
-        &headers, brave::ResponseCallback(), request_info);
-    EXPECT_EQ(result_code, net::OK);
-
-    EXPECT_FALSE(headers.HasHeader(brave::kSearchAdsHeader));
-  }
+  auto request = MakeRequest(kBraveSearchRequestUrl, profile_.get());
+  request->tab_origin = GURL();
+  VerifyMissingHeaderExpectation(request);
 }
 
 TEST_F(SearchAdsHeaderDelegateHelperTest,
-       NonBraveSearchRequestSearchRewardsEnabled) {
-  profile_->GetPrefs()->SetBoolean(brave_rewards::prefs::kEnabled, true);
-  profile_->GetPrefs()->SetBoolean(brave_ads::prefs::kOptedInToSearchResultAds,
-                                   false);
+       HeaderShouldNotExistForDisallowedInitiatorUrlHost) {
+  EnableBraveRewards();
 
-  auto request_info = std::make_shared<brave::BraveRequestInfo>(
-      GURL(kNonBraveSearchRequestUrl));
-  request_info->browser_context = profile_.get();
-  request_info->tab_origin = GURL(kBraveSearchTabUrl);
-  request_info->initiator_url = GURL(kBraveSearchTabUrl);
-  request_info->resource_type = blink::mojom::ResourceType::kXhr;
-
-  net::HttpRequestHeaders headers;
-  const int result_code = brave::OnBeforeStartTransaction_SearchAdsHeader(
-      &headers, brave::ResponseCallback(), request_info);
-  EXPECT_EQ(result_code, net::OK);
-
-  EXPECT_FALSE(headers.HasHeader(brave::kSearchAdsHeader));
+  auto request = MakeRequest(kBraveSearchRequestUrl, profile_.get());
+  request->initiator_url = GURL();
+  VerifyMissingHeaderExpectation(request);
 }
 
-TEST_F(SearchAdsHeaderDelegateHelperTest, BraveSearchHostRewardsDisabled) {
-  profile_->GetPrefs()->SetBoolean(brave_rewards::prefs::kEnabled, false);
+TEST_F(
+    SearchAdsHeaderDelegateHelperTest,
+    HeaderShouldNotExistForDisallowedTabOriginHostAndDisallowedInitiatorUrlHost) {
+  EnableBraveRewards();
 
-  auto request_info =
-      std::make_shared<brave::BraveRequestInfo>(GURL(kBraveSearchRequestUrl));
-  request_info->browser_context = profile_.get();
-  request_info->tab_origin = GURL(kBraveSearchTabUrl);
-  request_info->initiator_url = GURL(kBraveSearchTabUrl);
-
-  {
-    request_info->resource_type = blink::mojom::ResourceType::kMainFrame;
-
-    net::HttpRequestHeaders headers;
-    const int result_code = brave::OnBeforeStartTransaction_SearchAdsHeader(
-        &headers, brave::ResponseCallback(), request_info);
-    EXPECT_EQ(result_code, net::OK);
-
-    EXPECT_FALSE(headers.HasHeader(brave::kSearchAdsHeader));
-  }
-
-  {
-    request_info->resource_type = blink::mojom::ResourceType::kXhr;
-
-    net::HttpRequestHeaders headers;
-    const int result_code = brave::OnBeforeStartTransaction_SearchAdsHeader(
-        &headers, brave::ResponseCallback(), request_info);
-    EXPECT_EQ(result_code, net::OK);
-
-    EXPECT_FALSE(headers.HasHeader(brave::kSearchAdsHeader));
-  }
+  auto request = MakeRequest(kBraveSearchRequestUrl, profile_.get());
+  request->tab_origin = GURL();
+  request->initiator_url = GURL();
+  VerifyMissingHeaderExpectation(request);
 }
 
 TEST_F(SearchAdsHeaderDelegateHelperTest,
-       BraveSearchHostSearchResultAdsEnabled) {
-  profile_->GetPrefs()->SetBoolean(brave_rewards::prefs::kEnabled, true);
-  profile_->GetPrefs()->SetBoolean(brave_ads::prefs::kOptedInToSearchResultAds,
-                                   true);
+       HeaderShouldNotExistForNonSearchTabOrigin) {
+  EnableBraveRewards();
 
-  auto request_info =
-      std::make_shared<brave::BraveRequestInfo>(GURL(kBraveSearchRequestUrl));
-  request_info->browser_context = profile_.get();
-  request_info->tab_origin = GURL(kBraveSearchTabUrl);
-  request_info->initiator_url = GURL(kBraveSearchTabUrl);
-
-  {
-    request_info->resource_type = blink::mojom::ResourceType::kMainFrame;
-
-    net::HttpRequestHeaders headers;
-    const int result_code = brave::OnBeforeStartTransaction_SearchAdsHeader(
-        &headers, brave::ResponseCallback(), request_info);
-    EXPECT_EQ(result_code, net::OK);
-
-    EXPECT_FALSE(headers.HasHeader(brave::kSearchAdsHeader));
-  }
-
-  {
-    request_info->resource_type = blink::mojom::ResourceType::kXhr;
-
-    net::HttpRequestHeaders headers;
-    const int result_code = brave::OnBeforeStartTransaction_SearchAdsHeader(
-        &headers, brave::ResponseCallback(), request_info);
-    EXPECT_EQ(result_code, net::OK);
-
-    EXPECT_FALSE(headers.HasHeader(brave::kSearchAdsHeader));
-  }
-}
-
-TEST_F(SearchAdsHeaderDelegateHelperTest, BraveSearchHostIncognitoProfile) {
-  TestingProfile* incognito_profile =
-      TestingProfile::Builder().BuildIncognito(profile_.get());
-
-  auto request_info =
-      std::make_shared<brave::BraveRequestInfo>(GURL(kBraveSearchRequestUrl));
-  request_info->browser_context = incognito_profile;
-  request_info->tab_origin = GURL(kBraveSearchTabUrl);
-  request_info->initiator_url = GURL(kBraveSearchTabUrl);
-  request_info->resource_type = blink::mojom::ResourceType::kMainFrame;
-
-  net::HttpRequestHeaders headers;
-  const int result_code = brave::OnBeforeStartTransaction_SearchAdsHeader(
-      &headers, brave::ResponseCallback(), request_info);
-  EXPECT_EQ(result_code, net::OK);
-
-  EXPECT_FALSE(headers.HasHeader(brave::kSearchAdsHeader));
+  auto request = MakeRequest(kBraveSearchRequestUrl, profile_.get());
+  request->tab_origin = GURL(kNonBraveSearchTabUrl);
+  VerifyMissingHeaderExpectation(request);
 }
 
 TEST_F(SearchAdsHeaderDelegateHelperTest,
-       BraveSearchHostIncognitoProfileWhenRewardsEnabledInMainProfile) {
-  profile_->GetPrefs()->SetBoolean(brave_rewards::prefs::kEnabled, true);
-  profile_->GetPrefs()->SetBoolean(brave_ads::prefs::kOptedInToSearchResultAds,
-                                   false);
+       HeaderShouldNotExistForNonSearchInitiatorUrl) {
+  EnableBraveRewards();
 
-  TestingProfile* incognito_profile =
-      TestingProfile::Builder().BuildIncognito(profile_.get());
-
-  auto request_info =
-      std::make_shared<brave::BraveRequestInfo>(GURL(kBraveSearchRequestUrl));
-  request_info->browser_context = incognito_profile;
-  request_info->tab_origin = GURL(kBraveSearchTabUrl);
-  request_info->initiator_url = GURL(kBraveSearchTabUrl);
-  request_info->resource_type = blink::mojom::ResourceType::kMainFrame;
-
-  net::HttpRequestHeaders headers;
-  const int result_code = brave::OnBeforeStartTransaction_SearchAdsHeader(
-      &headers, brave::ResponseCallback(), request_info);
-  EXPECT_EQ(result_code, net::OK);
-
-  EXPECT_FALSE(headers.HasHeader(brave::kSearchAdsHeader));
+  auto request = MakeRequest(kBraveSearchRequestUrl, profile_.get());
+  request->initiator_url = GURL(kNonBraveSearchTabUrl);
+  VerifyMissingHeaderExpectation(request);
 }
+
+TEST_F(SearchAdsHeaderDelegateHelperTest,
+       HeaderShouldNotExistForNonSearchRequest) {
+  EnableBraveRewards();
+
+  auto request = MakeRequest(kNonBraveSearchRequestUrl, profile_.get());
+  VerifyMissingHeaderExpectation(request);
+}
+
+TEST_F(SearchAdsHeaderDelegateHelperTest, HeaderShouldNotExistForIncognito) {
+  EnableBraveRewards();
+
+  auto request =
+      MakeRequest(kBraveSearchRequestUrl,
+                  TestingProfile::Builder().BuildIncognito(profile_.get()));
+  VerifyMissingHeaderExpectation(request);
+}
+
+TEST_F(SearchAdsHeaderDelegateHelperTest,
+       HeaderShouldNotExistForNonRewardsUser) {
+  auto request = MakeRequest(kBraveSearchRequestUrl, profile_.get());
+  VerifyMissingHeaderExpectation(request);
+}
+
+TEST_F(SearchAdsHeaderDelegateHelperTest,
+       HeaderShouldExistForDisconnectedRewardsUserOptedOutOfAds) {
+  EnableBraveRewards();
+  OptOutOfSearchResultAds();
+
+  auto request = MakeRequest(kBraveSearchRequestUrl, profile_.get());
+  VerifyHeaderExistsExpectation(request);
+}
+
+TEST_F(SearchAdsHeaderDelegateHelperTest,
+       HeaderShouldNotExistForDisconnectedRewardsUserOptedInToAds) {
+  EnableBraveRewards();
+
+  auto request = MakeRequest(kBraveSearchRequestUrl, profile_.get());
+  VerifyMissingHeaderExpectation(request);
+}
+
+TEST_F(SearchAdsHeaderDelegateHelperTest,
+       HeaderShouldExistForConnectedRewardsUserOptedOutOfAds) {
+  EnableBraveRewards();
+  ConnectExternalBraveRewardsWallet();
+  OptOutOfSearchResultAds();
+
+  auto request = MakeRequest(kBraveSearchRequestUrl, profile_.get());
+  VerifyHeaderExistsExpectation(request);
+}
+
+TEST_F(SearchAdsHeaderDelegateHelperTest,
+       HeaderShouldExistForConnectedRewardsUserOptedInToAds) {
+  EnableBraveRewards();
+  ConnectExternalBraveRewardsWallet();
+
+  auto request = MakeRequest(kBraveSearchRequestUrl, profile_.get());
+  VerifyHeaderExistsExpectation(request);
+}
+
+}  // namespace brave


### PR DESCRIPTION
Uplift of #31682
Resolves https://github.com/brave/brave-browser/issues/49960

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.