### PR TITLE
[AI Chat] Use correct header for ContentBlock

### DIFF
--- a/browser/ai_chat/page_content_blocks.cc
+++ b/browser/ai_chat/page_content_blocks.cc
@@ -14,7 +14,7 @@
 #include "brave/components/ai_chat/core/browser/tools/tool_utils.h"
 #include "brave/components/ai_chat/core/common/constants.h"
 #include "brave/components/ai_chat/core/common/features.h"
-#include "brave/components/ai_chat/core/common/mojom/ai_chat.mojom.h"
+#include "brave/components/ai_chat/core/common/mojom/common.mojom.h"
 #include "third_party/abseil-cpp/absl/strings/str_format.h"
 
 namespace ai_chat {

--- a/browser/ai_chat/page_content_blocks.h
+++ b/browser/ai_chat/page_content_blocks.h
@@ -8,7 +8,7 @@
 
 #include <vector>
 
-#include "brave/components/ai_chat/core/common/mojom/ai_chat.mojom-forward.h"
+#include "brave/components/ai_chat/core/common/mojom/common.mojom-forward.h"
 #include "components/optimization_guide/proto/features/common_quality_data.pb.h"
 
 namespace ai_chat {


### PR DESCRIPTION
This type moved into `common.mojom`
