### PR TITLE
[Shortcuts]: Use `output_module` and simplify loading logic

### DIFF
--- a/browser/resources/settings/shortcuts_page/BUILD.gn
+++ b/browser/resources/settings/shortcuts_page/BUILD.gn
@@ -7,6 +7,7 @@ import("//brave/components/common/typescript.gni")
 
 transpile_web_ui("commands_ui") {
   generate_grdp = true
+  output_module = true
 
   entry_points = [ [
         "commands",

--- a/browser/resources/settings/shortcuts_page/commands.tsx
+++ b/browser/resources/settings/shortcuts_page/commands.tsx
@@ -121,5 +121,3 @@ export const mount = (at: HTMLElement) => {
     at
   )
 }
-
-;(window as any).mountCommands = mount

--- a/browser/resources/settings/shortcuts_page/shortcuts_page.ts
+++ b/browser/resources/settings/shortcuts_page/shortcuts_page.ts
@@ -23,8 +23,10 @@ class ShortcutsPage extends HTMLElement {
 
 
     import('/commands.bundle.js' as any)
-      .then(() => (window as any).mountCommands(this.shadowRoot))
-      .catch(() => {})
+      .then(({ mount }) => {
+        mount(this.shadowRoot)
+      })
+      .catch(() => { })
   }
 }
 


### PR DESCRIPTION
This uses `ouput_module` to simplify loading the shortcuts subpage