### PR TITLE
Add dep crx to target create_dist_mac

### DIFF
--- a/build/mac/BUILD.gn
+++ b/build/mac/BUILD.gn
@@ -24,6 +24,8 @@ packaged_basename =
 
 dmg_path = "$packaged_basename.dmg"
 
+crx_private_key = "//brave/updater/crx-private-key.der"
+
 if (is_universal_binary) {
   assert(target_cpu == "arm64")
   x64_arch_app_path = "$root_out_dir/x64/$brave_exe"
@@ -401,16 +403,17 @@ group("create_dist_mac") {
       }
     }
   }
+  if (path_exists(crx_private_key)) {
+    deps += [ ":crx" ]
+  }
 }
 
-crx3("crx") {
-  inputs = [ dmg_path ]
-  output = "$packaged_basename.crx3"
-  base_dir = get_path_info(dmg_path, "dir")
-
-  # The private key file is not in Git for obvious reasons. It needs to be
-  # copied into this directory manually. Changing the private key requires
-  # also changing kBravePublisherKeyHash in crx_verifier.cc.
-  key = "//brave/updater/crx-private-key.der"
-  deps = [ ":package" ]
+if (path_exists(crx_private_key)) {
+  crx3("crx") {
+    inputs = [ dmg_path ]
+    output = "$packaged_basename.crx3"
+    base_dir = get_path_info(dmg_path, "dir")
+    key = crx_private_key
+    deps = [ ":package" ]
+  }
 }


### PR DESCRIPTION
This lets us use `npm run create_dist` to build the crx for macOS. It's a preparation for [uploading Omaha 4 builds to the update server during releases](https://github.com/brave/devops/issues/13476).

Pure dev concern, no QA required.