### PR TITLE
feat: Allow focusing address bar in fullscreen via Ctrl+L

### DIFF
--- a/browser/ui/brave_browser_command_controller.cc
+++ b/browser/ui/brave_browser_command_controller.cc
@@ -120,6 +120,7 @@ bool IsBraveOverrideCommands(int id) {
       IDC_NEW_WINDOW,
       IDC_NEW_INCOGNITO_WINDOW,
       IDC_TOGGLE_VERTICAL_TABS,
+      IDC_FOCUS_LOCATION,
   });
   return kOverrideCommands.contains(id);
 }
@@ -613,6 +614,13 @@ bool BraveBrowserCommandController::ExecuteBraveCommandWithDisposition(
       }
       NewIncognitoWindow(browser_->profile()->GetOriginalProfile());
       break;
+    case IDC_FOCUS_LOCATION:
+      if (browser_->window() && browser_->window()->IsFullscreen()) {
+        brave::FocusLocationBarInFullscreen(base::to_address(browser_));
+        break;
+      }
+      return BrowserCommandController::ExecuteCommandWithDisposition(
+          id, disposition, time_stamp);
     case IDC_SHOW_BRAVE_REWARDS:
       brave::ShowBraveRewards(&*browser_);
       break;

--- a/browser/ui/browser_commands.cc
+++ b/browser/ui/browser_commands.cc
@@ -35,6 +35,7 @@
 #include "brave/browser/ui/tabs/brave_tab_strip_model.h"
 #include "brave/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_container_view.h"
 #include "brave/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.h"
+#include "brave/browser/ui/views/location_bar/brave_location_bar_view.h"
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 #include "brave/browser/url_sanitizer/url_sanitizer_service_factory.h"
 #include "brave/components/brave_vpn/common/buildflags/buildflags.h"
@@ -1326,5 +1327,26 @@ void OpenPsstMenuOnPageActionView(BrowserWindowInterface* browser_window,
                             event_flags);
 }
 #endif  // BUILDFLAG(ENABLE_PSST)
+
+void FocusLocationBarInFullscreen(Browser* browser) {
+  if (!browser || !browser->window() || !browser->window()->IsFullscreen())
+    return;
+
+  BrowserView* browser_view = BrowserView::GetBrowserViewForBrowser(browser);
+  if (!browser_view)
+    return;
+
+  ToolbarView* toolbar = browser_view->toolbar();
+  if (!toolbar)
+    return;
+
+  auto* brave_location_bar =
+      views::AsViewClass<BraveLocationBarView>(toolbar->location_bar());
+  if (!brave_location_bar)
+    return;
+
+  brave_location_bar->SetTemporaryVisibilityInFullscreen(true);
+  brave_location_bar->FocusLocation(false);
+}
 
 }  // namespace brave

--- a/browser/ui/browser_commands.h
+++ b/browser/ui/browser_commands.h
@@ -203,6 +203,10 @@ void OpenPsstMenuOnPageActionView(BrowserWindowInterface* browser_window,
                                   int event_flags = ui::EF_NONE);
 #endif
 
+// Shows the location bar temporarily in fullscreen and focuses it.
+// Used when the user triggers Ctrl+L while in fullscreen mode.
+void FocusLocationBarInFullscreen(Browser* browser);
+
 }  // namespace brave
 
 #endif  // BRAVE_BROWSER_UI_BROWSER_COMMANDS_H_

--- a/browser/ui/views/frame/brave_browser_view.cc
+++ b/browser/ui/views/frame/brave_browser_view.cc
@@ -1386,6 +1386,42 @@ void BraveBrowserView::UpdateWebViewRoundedCorners() {
   }
 }
 
+void BraveBrowserView::SetToolbarTemporarilyVisibleInFullscreen(bool visible) {
+  if (is_toolbar_temporarily_visible_in_fullscreen_ == visible)
+    return;
+  is_toolbar_temporarily_visible_in_fullscreen_ = visible;
+
+  if (!IsFullscreen())
+    return;
+
+  if (visible) {
+    // Show toolbar as an overlay on top of content.
+    // Fullscreen layout hides the toolbar by setting top_container
+    // to 0 height. We override that by expanding top_container and
+    // bringing it to the front so it overlays the content area.
+    gfx::Size preferred = top_container_->GetPreferredSize();
+    if (preferred.height() <= 0)
+      return;
+
+    top_container_->SetBounds(0, 0, width(), preferred.height());
+    top_container_->SetVisible(true);
+    top_container_->DeprecatedLayoutImmediately();
+
+    auto* tb = toolbar();
+    if (tb) {
+      tb->SetVisible(true);
+    }
+
+    // Bring to front so it overlays the web content.
+    ReorderChildView(top_container_, -1);
+  } else {
+    // Restore fullscreen layout.
+    // The next Layout() call (from BrowserView) will reset top_container
+    // to 0 height since we're in fullscreen.
+    Layout();
+  }
+}
+
 void BraveBrowserView::Layout(PassKey) {
   LayoutSuperclass<BrowserView>(this);
   UpdateWebViewRoundedCorners();

--- a/browser/ui/views/frame/brave_browser_view.h
+++ b/browser/ui/views/frame/brave_browser_view.h
@@ -150,6 +150,11 @@ class BraveBrowserView : public BrowserView,
   }
   bool ShowBraveHelpBubbleView(const std::string& text) override;
 
+  // Temporarily shows/hides the toolbar while in fullscreen (e.g. Ctrl+L).
+  // When visible, the toolbar area is shown on top of the content and
+  // collapses again when the caller decides (e.g. omnibox loses focus).
+  void SetToolbarTemporarilyVisibleInFullscreen(bool visible);
+
   // commands::AcceleratorService:
   void OnAcceleratorsChanged(
       const commands::AcceleratorPrefManager::Accelerators& changed) override;
@@ -315,6 +320,7 @@ class BraveBrowserView : public BrowserView,
                           commands::AcceleratorService::Observer>
       accelerators_observation_{this};
 
+  bool is_toolbar_temporarily_visible_in_fullscreen_ = false;
   base::WeakPtrFactory<BraveBrowserView> weak_ptr_{this};
 };
 

--- a/browser/ui/views/location_bar/brave_location_bar_view.cc
+++ b/browser/ui/views/location_bar/brave_location_bar_view.cc
@@ -20,6 +20,7 @@
 #include "brave/browser/ui/views/location_bar/brave_search_conversion/promotion_button_view.h"
 #include "brave/browser/ui/views/location_bar/brave_shields_page_info_controller.h"
 #include "brave/browser/ui/views/toolbar/brave_toolbar_view.h"
+#include "brave/browser/ui/views/frame/brave_browser_view.h"
 #include "brave/components/brave_news/common/buildflags/buildflags.h"
 #include "brave/components/commander/common/buildflags/buildflags.h"
 #include "brave/components/playlist/core/common/buildflags/buildflags.h"
@@ -32,6 +33,7 @@
 #include "chrome/browser/ui/omnibox/omnibox_theme.h"
 #include "chrome/browser/ui/tabs/features.h"
 #include "chrome/browser/ui/views/chrome_layout_provider.h"
+#include "chrome/browser/ui/views/frame/browser_view.h"
 #include "chrome/browser/ui/views/location_bar/location_bar_view.h"
 #include "chrome/browser/ui/views/omnibox/omnibox_view_views.h"
 #include "chrome/browser/ui/views/page_action/page_action_icon_controller.h"
@@ -221,6 +223,11 @@ void BraveLocationBarView::OnOmniboxBlurred() {
   }
 #endif
   LocationBarView::OnOmniboxBlurred();
+
+  // If the location bar was temporarily revealed in fullscreen, restore it.
+  if (is_temporarily_visible_in_fullscreen_) {
+    SetTemporaryVisibilityInFullscreen(false);
+  }
 }
 
 void BraveLocationBarView::Layout(PassKey) {
@@ -472,6 +479,25 @@ ContentSettingImageView*
 BraveLocationBarView::GetContentSettingsImageViewForTesting(size_t idx) {
   DCHECK(idx < content_setting_views_.size());
   return content_setting_views_[idx];
+}
+
+void BraveLocationBarView::SetTemporaryVisibilityInFullscreen(bool visible) {
+  if (!browser_ || !browser_->window() ||
+      !browser_->window()->IsFullscreen()) {
+    return;
+  }
+
+  is_temporarily_visible_in_fullscreen_ = visible;
+
+  BrowserView* browser_view = BrowserView::GetBrowserViewForBrowser(browser_);
+  if (!browser_view) {
+    return;
+  }
+
+  auto* brave_browser_view = BraveBrowserView::From(browser_view);
+  if (brave_browser_view) {
+    brave_browser_view->SetToolbarTemporarilyVisibleInFullscreen(visible);
+  }
 }
 
 BEGIN_METADATA(BraveLocationBarView)

--- a/browser/ui/views/location_bar/brave_location_bar_view.h
+++ b/browser/ui/views/location_bar/brave_location_bar_view.h
@@ -121,6 +121,11 @@ class BraveLocationBarView : public LocationBarView {
     ignore_layout_ = ignore;
   }
 
+  // Shows/hides the location bar temporarily during fullscreen for
+  // omnibox interaction. The toolbar is restored to its hidden state
+  // on omnibox blur.
+  void SetTemporaryVisibilityInFullscreen(bool visible);
+
  private:
   FRIEND_TEST_ALL_PREFIXES(playlist::PlaylistBrowserTest, AddItemsToList);
   FRIEND_TEST_ALL_PREFIXES(playlist::PlaylistBrowserTest, UIHiddenWhenDisabled);
@@ -136,6 +141,8 @@ class BraveLocationBarView : public LocationBarView {
   FRIEND_TEST_ALL_PREFIXES(policy::BraveRewardsPolicyTest, RewardsIconIsHidden);
   FRIEND_TEST_ALL_PREFIXES(BraveLocationBarViewBrowserTest,
                            SearchConversionButtonTest);
+  FRIEND_TEST_ALL_PREFIXES(BraveLocationBarViewBrowserTest,
+                           FocusLocationBarInFullscreenTest);
   friend class ::BraveActionsContainerTest;
   friend class ::RewardsBrowserTest;
 
@@ -148,6 +155,11 @@ class BraveLocationBarView : public LocationBarView {
   // It also could make omnibox popup have wrong position.
   // See the comments of BraveToolbarView::Layout().
   bool ignore_layout_ = false;
+
+  // Whether the location bar is temporarily shown in fullscreen for omnibox
+  // interaction. Reset on omnibox blur.
+  bool is_temporarily_visible_in_fullscreen_ = false;
+
   std::unique_ptr<ViewShadow> shadow_;
   raw_ptr<BraveActionsContainer> brave_actions_ = nullptr;
 #if BUILDFLAG(ENABLE_BRAVE_NEWS)

--- a/browser/ui/views/location_bar/brave_location_bar_view_browsertest.cc
+++ b/browser/ui/views/location_bar/brave_location_bar_view_browsertest.cc
@@ -19,6 +19,7 @@
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/search_engines/template_url_service_factory.h"
 #include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/browser_commands.h"
 #include "chrome/browser/ui/omnibox/omnibox_controller.h"
 #include "chrome/browser/ui/omnibox/omnibox_edit_model.h"
 #include "chrome/browser/ui/omnibox/omnibox_view.h"
@@ -30,6 +31,7 @@
 #include "chrome/test/base/in_process_browser_test.h"
 #include "chrome/test/base/interactive_test_utils.h"
 #include "chrome/test/base/search_test_utils.h"
+#include "chrome/test/base/ui_test_utils.h"
 #include "components/search_engines/template_url.h"
 #include "components/search_engines/template_url_data_util.h"
 #include "components/search_engines/template_url_service.h"
@@ -246,4 +248,29 @@ IN_PROC_BROWSER_TEST_F(BraveLocationBarViewBrowserTest,
   toolbar()->SetBoundsRect(toolbar_bounds);
 
   EXPECT_EQ(1, observer.bounds_changed_count_);
+}
+
+IN_PROC_BROWSER_TEST_F(BraveLocationBarViewBrowserTest,
+                       FocusLocationBarInFullscreenTest) {
+  // Enter fullscreen mode.
+  ui_test_utils::ToggleFullscreenModeAndWait(browser());
+  ASSERT_TRUE(browser()->window()->IsFullscreen());
+
+  // The location bar should not be temporarily visible initially.
+  EXPECT_FALSE(location_bar()->is_temporarily_visible_in_fullscreen_);
+
+  // Trigger IDC_FOCUS_LOCATION (simulating Ctrl+L in fullscreen).
+  chrome::ExecuteCommand(browser(), IDC_FOCUS_LOCATION);
+
+  // The toolbar should now be revealed and the omnibox focused.
+  EXPECT_TRUE(location_bar()->is_temporarily_visible_in_fullscreen_);
+  EXPECT_TRUE(toolbar()->GetVisible());
+  EXPECT_TRUE(omnibox_view()->HasFocus());
+
+  // Blur the omnibox by focusing the web contents.
+  web_contents()->Focus();
+
+  // Toolbar should return to hidden state.
+  EXPECT_FALSE(location_bar()->is_temporarily_visible_in_fullscreen_);
+  EXPECT_FALSE(toolbar()->GetVisible());
 }


### PR DESCRIPTION

```markdown
### Summary
Allows users to focus the address bar in fullscreen mode using Ctrl+L. The toolbar becomes temporarily visible and automatically hides when focus is lost.

### Motivation
In fullscreen mode, users cannot currently access the address bar, even though other UI elements (e.g. vertical tabs) remain interactive. This prevents navigation without exiting fullscreen.

### Implementation
- Routes Ctrl+L to a Brave-specific fullscreen command
- Temporarily reveals the toolbar for omnibox interaction
- Automatically restores fullscreen state on blur
- Uses safe view traversal via BrowserView and views::AsViewClass

### Notes
- Brave-specific behavior; does not modify Chromium code
- Keyboard-only access (no hover UI changes)
- Safe against popup/PWA windows via views::AsViewClass type checking
- Toolbar visibility is restored immediately on blur

Resolves brave/brave-browser#51397
```
