### PR TITLE
[iOS] NTP fav page icons are being incorrectly cached

### DIFF
--- a/ios/brave-ios/Sources/Favicon/FaviconFetcher.swift
+++ b/ios/brave-ios/Sources/Favicon/FaviconFetcher.swift
@@ -108,6 +108,14 @@ public class FaviconFetcher {
       return favicon
     }
 
+    // We stored favicons using `url.domain` before.
+    // Now we are using the full url.
+    // Try to fetch with url.domain if favicon has not yet
+    // updated with the full url.
+    if let favicon = await getFromCache(for: url.domainURL) {
+      return favicon
+    }
+
     // When we search for a domain in the URL bar,
     // it automatically makes the scheme `http`
     // Even if the website loads/redirects as `https`
@@ -127,9 +135,8 @@ public class FaviconFetcher {
   /// Updates the Favicon in the cache with the specified icon if any, otherwise removes the favicon from the cache.
   public static func updateCache(_ favicon: Favicon?, for url: URL, persistent: Bool) async {
     guard let favicon, !favicon.isMonogramImage else {
-      let cachedURL = cacheURL(for: url)
-      SDImageCache.shared.memoryCache.removeObject(forKey: cachedURL.absoluteString)
-      SDImageCache.shared.diskCache.removeData(forKey: cachedURL.absoluteString)
+      SDImageCache.shared.memoryCache.removeObject(forKey: url.absoluteString)
+      SDImageCache.shared.diskCache.removeData(forKey: url.absoluteString)
       return
     }
 
@@ -138,53 +145,42 @@ public class FaviconFetcher {
 
   /// Delete the favicon from disk and memory cache for the given URL
   public static func deleteCache(for url: URL) async {
-    let cachedURL = cacheURL(for: url)
-    SDImageCache.shared.memoryCache.removeObject(forKey: cachedURL.absoluteString)
-    SDImageCache.shared.diskCache.removeData(forKey: cachedURL.absoluteString)
-  }
-
-  private static func cacheURL(for url: URL) -> URL {
-    // Some websites still only have a favicon for the FULL url including the fragmented parts
-    // But they won't have a favicon for their domain
-    // In this case, we want to store the favicon for the entire domain regardless of query parameters or fragmented parts
-    // Example: `https://app.uniswap.org/` has no favicon, but `https://app.uniswap.org/#/swap?chain=mainnet` does.
-    return url.domainURL
+    SDImageCache.shared.memoryCache.removeObject(forKey: url.absoluteString)
+    SDImageCache.shared.diskCache.removeData(forKey: url.absoluteString)
   }
 
   private static func storeInCache(_ favicon: Favicon, for url: URL, persistent: Bool) async {
     // Do not cache non-persistent icons to disk
     if persistent {
       do {
-        let cachedURL = cacheURL(for: url)
-        SDImageCache.shared.memoryCache.setObject(favicon, forKey: cachedURL.absoluteString)
+        SDImageCache.shared.memoryCache.setObject(favicon, forKey: url.absoluteString)
         SDImageCache.shared.diskCache.setData(
           try JSONEncoder().encode(favicon),
-          forKey: cachedURL.absoluteString
+          forKey: url.absoluteString
         )
       } catch {
         Logger.module.error("Error Caching Favicon: \(error)")
       }
     } else {
       // Cache non-persistent icons to memory only
-      SDImageCache.shared.memoryCache.setObject(favicon, forKey: cacheURL(for: url).absoluteString)
+      SDImageCache.shared.memoryCache.setObject(favicon, forKey: url.absoluteString)
     }
   }
 
   private static func getFromCache(for url: URL) async -> Favicon? {
-    let cachedURL = cacheURL(for: url)
-    if let favicon = SDImageCache.shared.memoryCache.object(forKey: cachedURL.absoluteString)
+    if let favicon = SDImageCache.shared.memoryCache.object(forKey: url.absoluteString)
       as? Favicon
     {
       return favicon
     }
 
-    guard let data = SDImageCache.shared.diskCache.data(forKey: cachedURL.absoluteString) else {
+    guard let data = SDImageCache.shared.diskCache.data(forKey: url.absoluteString) else {
       return nil
     }
 
     do {
       let favicon = try JSONDecoder().decode(Favicon.self, from: data)
-      SDImageCache.shared.memoryCache.setObject(favicon, forKey: cachedURL.absoluteString)
+      SDImageCache.shared.memoryCache.setObject(favicon, forKey: url.absoluteString)
       return favicon
     } catch {
       Logger.module.error("Error Decoding Favicon: \(error)")


### PR DESCRIPTION
Fix favicon is not cached correctly for sites have same domain but different favicons with different fragmented parts.
We used to cache favicon only using domain value not the full url. This will cause some same domain sites that have different favicons based on their query parameters or fragmented parts. 
We did this this way to avoid issues when some websites still only have a favicon for the FULL url including the fragmented parts, but no favicon for their domain. Back then, we were only experiencing this scenario for `https://app.uniswap.org/`. But now they have fixed. 
This change will start caching favicons using the FULL urls. As long as user visit any site, the favicon of this site will be cached with its FULL url and will be fetched later using its FULL url.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/50741

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

Test:
1. open a build without this change and visiting some sites have favicons that don't share domain. Save them as a Favorite. (You can only see 4 Favorites in NTP. Full list is revealed in the edit mode by tapping the omnibox. Verify all favicons are displayed correctly.
2. add some sites as Favorites that share the same domain but have different favicons. For example:  google.com, google.com/finance, google.com/flights
3. Verify all the sites's favicon in step 2 are displayed as the last visited site's favicon
4. Upgrade this build to a build that has this PR's changes
5. visit those Favorites in step 2 
6. Verify both Favorite favicons in step 1 and step 2 are displayed correctly in NTP and edit mode 
7. Relaunch the build and verify again. 