### PR TITLE
Elevate the z-order of the walle panels's parent widget

### DIFF
--- a/browser/brave_wallet/brave_wallet_tab_helper.cc
+++ b/browser/brave_wallet/brave_wallet_tab_helper.cc
@@ -293,6 +293,11 @@ content::WebContents* BraveWalletTabHelper::GetBubbleWebContentsForTesting() {
   return wallet_bubble_manager_delegate_->GetWebContentsForTesting();
 }
 
+views::Widget* BraveWalletTabHelper::GetBubbleWidgetForTesting() {
+  return wallet_bubble_manager_delegate_
+      ->GetBubbleWidgetForTesting();  // IN-TEST
+}
+
 const std::vector<int32_t>& BraveWalletTabHelper::GetPopupIdsForTesting() {
   return wallet_bubble_manager_delegate_->GetPopupIdsForTesting();
 }

--- a/browser/brave_wallet/brave_wallet_tab_helper.h
+++ b/browser/brave_wallet/brave_wallet_tab_helper.h
@@ -28,6 +28,12 @@ class WebContents;
 
 }  // namespace content
 
+#if !BUILDFLAG(IS_ANDROID)
+namespace views {
+class Widget;
+}  // namespace views
+#endif  // !BUILDFLAG(IS_ANDROID)
+
 namespace brave_wallet {
 
 class WalletBubbleManagerDelegate;
@@ -72,6 +78,7 @@ class BraveWalletTabHelper
   void SetSkipDelegateForTesting(bool skip) {
     skip_delegate_for_testing_ = skip;
   }
+  views::Widget* GetBubbleWidgetForTesting();
 #endif
 
  private:

--- a/browser/ui/brave_wallet/wallet_bubble_manager_delegate.h
+++ b/browser/ui/brave_wallet/wallet_bubble_manager_delegate.h
@@ -17,6 +17,10 @@ namespace content {
 class WebContents;
 }  // namespace content
 
+namespace views {
+class Widget;
+}  // namespace views
+
 namespace brave_wallet {
 
 class WalletBubbleManagerDelegate {
@@ -37,6 +41,7 @@ class WalletBubbleManagerDelegate {
   virtual bool IsBubbleClosedForTesting() = 0;
   virtual content::WebContents* GetWebContentsForTesting() = 0;
   virtual const std::vector<int32_t>& GetPopupIdsForTesting() = 0;
+  virtual views::Widget* GetBubbleWidgetForTesting() = 0;
 
  protected:
   WalletBubbleManagerDelegate() = default;

--- a/browser/ui/views/toolbar/wallet_button.cc
+++ b/browser/ui/views/toolbar/wallet_button.cc
@@ -265,6 +265,12 @@ bool WalletButton::IsBubbleClosedForTesting() {
       ->IsBubbleClosedForTesting();
 }
 
+views::Widget* WalletButton::GetBubbleWidgetForTesting() {
+  return brave_wallet::BraveWalletTabHelper::FromWebContents(
+             GetActiveWebContents())
+      ->GetBubbleWidgetForTesting();  // IN-TEST
+}
+
 views::View* WalletButton::GetAsAnchorView() {
   View* anchor_view = this;
   if (!prefs_->GetBoolean(brave_wallet::kShowWalletIconOnToolbar)) {

--- a/browser/ui/views/toolbar/wallet_button.h
+++ b/browser/ui/views/toolbar/wallet_button.h
@@ -32,6 +32,7 @@ class WalletButton : public ToolbarButton {
   void CloseWalletBubble();
   bool IsShowingBubble();
   bool IsBubbleClosedForTesting();
+  views::Widget* GetBubbleWidgetForTesting();
 
   void UpdateImageAndText(bool activated = false);
 

--- a/browser/ui/views/toolbar/wallet_button_browsertest.cc
+++ b/browser/ui/views/toolbar/wallet_button_browsertest.cc
@@ -7,7 +7,9 @@
 
 #include "base/feature_list.h"
 #include "base/run_loop.h"
+#include "base/test/run_until.h"
 #include "base/test/scoped_feature_list.h"
+#include "brave/browser/brave_wallet/brave_wallet_tab_helper.h"
 #include "brave/browser/ui/views/frame/brave_browser_view.h"
 #include "brave/components/brave_wallet/common/features.h"
 #include "chrome/browser/ui/browser.h"
@@ -15,7 +17,9 @@
 #include "chrome/browser/ui/views/bubble/webui_bubble_manager.h"
 #include "chrome/test/base/in_process_browser_test.h"
 #include "content/public/test/browser_test.h"
+#include "ui/base/ui_base_types.h"
 #include "ui/views/test/button_test_api.h"
+#include "ui/views/widget/widget.h"
 
 namespace {
 ui::MouseEvent GetDummyEvent() {
@@ -55,6 +59,50 @@ IN_PROC_BROWSER_TEST_F(WalletButtonButtonBrowserTest,
 
   wallet_button()->CloseWalletBubble();
   ASSERT_TRUE(wallet_button()->IsBubbleClosedForTesting());
+}
+
+#if BUILDFLAG(IS_MAC)
+// Flaky on Mac CI.
+#define MAYBE_ZOrderLevelShouldBeSecuritySurface \
+  DISABLED_ZOrderLevelShouldBeSecuritySurface
+#else
+#define MAYBE_ZOrderLevelShouldBeSecuritySurface \
+  ZOrderLevelShouldBeSecuritySurface
+#endif
+
+IN_PROC_BROWSER_TEST_F(WalletButtonButtonBrowserTest,
+                       MAYBE_ZOrderLevelShouldBeSecuritySurface) {
+  // Create widget
+  ASSERT_FALSE(wallet_button()->IsShowingBubble());
+  views::test::ButtonTestApi(wallet_button()).NotifyClick(GetDummyEvent());
+
+  // Wait until the bubble is shown and widget is created.
+  ASSERT_TRUE(base::test::RunUntil(
+      [&]() { return wallet_button()->IsShowingBubble(); }));
+
+  // Wait until the widget is created and active.
+  auto* widget = wallet_button()->GetBubbleWidgetForTesting();
+  ASSERT_TRUE(widget);
+  ASSERT_TRUE(base::test::RunUntil([&]() { return widget->IsActive(); }));
+
+  // When the bubble is shown, the widget should have the z-order level of
+  // kSecuritySurface.
+  EXPECT_EQ(widget->GetZOrderLevel(), ui::ZOrderLevel::kSecuritySurface);
+
+  // Also parent widget should have the same z-order level.
+  auto* parent_widget = widget->parent();
+  ASSERT_TRUE(parent_widget);
+  EXPECT_EQ(parent_widget->GetZOrderLevel(), ui::ZOrderLevel::kSecuritySurface);
+
+  auto widget_weak_ptr = widget->GetWeakPtr();
+  ASSERT_TRUE(widget_weak_ptr);
+  auto* parent_widget_weak_ptr = widget_weak_ptr->parent();
+
+  wallet_button()->CloseWalletBubble();
+
+  ASSERT_TRUE(base::test::RunUntil([&]() { return !widget_weak_ptr; }));
+  EXPECT_NE(parent_widget_weak_ptr->GetZOrderLevel(),
+            ui::ZOrderLevel::kSecuritySurface);
 }
 
 class WalletButtonBrowserUITest : public DialogBrowserTest {

--- a/browser/ui/wallet_bubble_manager_delegate_impl.cc
+++ b/browser/ui/wallet_bubble_manager_delegate_impl.cc
@@ -12,7 +12,9 @@
 
 #include "base/check.h"
 #include "base/memory/raw_ptr.h"
+#include "base/memory/raw_ref.h"
 #include "base/memory/scoped_refptr.h"
+#include "base/scoped_observation.h"
 #include "brave/browser/brave_wallet/brave_wallet_context_utils.h"
 #include "brave/browser/ui/views/frame/brave_browser_view.h"
 #include "brave/browser/ui/webui/brave_wallet/wallet_common_ui.h"
@@ -27,10 +29,49 @@
 #include "content/public/browser/web_contents.h"
 #include "ui/base/metadata/metadata_header_macros.h"
 #include "ui/base/metadata/metadata_impl_macros.h"
+#include "ui/base/ui_base_types.h"
 #include "ui/views/widget/widget.h"
+#include "ui/views/widget/widget_observer.h"
 #include "url/gurl.h"
 
 namespace brave_wallet {
+
+// Forward declaration
+class WalletWebUIBubbleDialogView;
+
+// This class manages z-order of wallet bubble and its parent widget
+class WalletBubbleZOrderManager : public views::WidgetObserver {
+ public:
+  explicit WalletBubbleZOrderManager(WalletWebUIBubbleDialogView& bubble_view);
+  WalletBubbleZOrderManager(const WalletBubbleZOrderManager&) = delete;
+  WalletBubbleZOrderManager& operator=(const WalletBubbleZOrderManager&) =
+      delete;
+  ~WalletBubbleZOrderManager() override;
+
+  // views::WidgetObserver:
+  void OnWidgetDestroying(views::Widget* widget) override;
+  void OnWidgetActivationChanged(views::Widget* widget, bool active) override;
+
+ private:
+  // Sets the zorder for wallet bubble to kSecuritySurface, so that it
+  // appears above other UI elements even they are floating on top. For
+  // example, Picture-in-Picture window is on top of other widgets, but
+  // wallet bubble should still be on top of it.
+  void ElevateZOrder();
+
+  // Restores z-order of widget and its parent widget to the level before
+  // elevation.
+  void RestoreZOrder();
+
+  raw_ref<WalletWebUIBubbleDialogView> bubble_view_;
+
+  bool z_order_elevated_ = false;
+
+  ui::ZOrderLevel widget_z_order_level_;
+  ui::ZOrderLevel parent_widget_z_order_level_;
+  base::ScopedObservation<views::Widget, views::WidgetObserver>
+      wallet_bubble_observer_{this};
+};
 
 class WalletWebUIBubbleDialogView : public WebUIBubbleDialogView {
   METADATA_HEADER(WalletWebUIBubbleDialogView, WebUIBubbleDialogView)
@@ -63,6 +104,12 @@ class WalletWebUIBubbleDialogView : public WebUIBubbleDialogView {
                                      params);
   }
 
+  // views::BubbleDialogDelegateView:
+  void AddedToWidget() override {
+    WebUIBubbleDialogView::AddedToWidget();
+    z_order_manager_ = std::make_unique<WalletBubbleZOrderManager>(*this);
+  }
+
  private:
   // WidgetObserver:
   void OnWidgetTreeActivated(views::Widget* root_widget,
@@ -80,10 +127,79 @@ class WalletWebUIBubbleDialogView : public WebUIBubbleDialogView {
 
   base::ScopedObservation<views::Widget, views::WidgetObserver>
       anchor_widget_observation_{this};
+
+  std::unique_ptr<WalletBubbleZOrderManager> z_order_manager_;
 };
 
 BEGIN_METADATA(WalletWebUIBubbleDialogView)
 END_METADATA
+
+// WalletBubbleZOrderManager implementation
+// -----------------------------------------------------------------------------
+
+WalletBubbleZOrderManager::WalletBubbleZOrderManager(
+    WalletWebUIBubbleDialogView& bubble_view)
+    : bubble_view_(bubble_view) {
+  auto* widget = bubble_view_->GetWidget();
+  CHECK(widget);
+  wallet_bubble_observer_.Observe(widget);
+
+  if (widget->IsActive()) {
+    ElevateZOrder();
+  }
+}
+
+WalletBubbleZOrderManager::~WalletBubbleZOrderManager() = default;
+
+void WalletBubbleZOrderManager::OnWidgetDestroying(views::Widget* widget) {
+  CHECK_EQ(widget, bubble_view_->GetWidget());
+  RestoreZOrder();
+  wallet_bubble_observer_.Reset();
+}
+
+void WalletBubbleZOrderManager::OnWidgetActivationChanged(views::Widget* widget,
+                                                          bool active) {
+  CHECK_EQ(widget, bubble_view_->GetWidget());
+  if (active) {
+    ElevateZOrder();
+  } else {
+    RestoreZOrder();
+  }
+}
+
+void WalletBubbleZOrderManager::ElevateZOrder() {
+  if (z_order_elevated_) {
+    return;
+  }
+
+  auto* widget = bubble_view_->GetWidget();
+  CHECK(widget);
+  auto* parent_widget = widget->parent();
+  CHECK(parent_widget);
+  z_order_elevated_ = false;
+
+  // Store current z-order level to restore later.
+  widget_z_order_level_ = widget->GetZOrderLevel();
+  parent_widget_z_order_level_ = parent_widget->GetZOrderLevel();
+
+  parent_widget->SetZOrderLevel(ui::ZOrderLevel::kSecuritySurface);
+  widget->SetZOrderLevel(ui::ZOrderLevel::kSecuritySurface);
+  z_order_elevated_ = true;
+}
+
+void WalletBubbleZOrderManager::RestoreZOrder() {
+  if (!z_order_elevated_) {
+    return;
+  }
+  auto* widget = bubble_view_->GetWidget();
+  CHECK(widget);
+  auto* parent_widget = widget->parent();
+  CHECK(parent_widget);
+
+  parent_widget->SetZOrderLevel(parent_widget_z_order_level_);
+  widget->SetZOrderLevel(widget_z_order_level_);
+  z_order_elevated_ = false;
+}
 
 class WalletWebUIBubbleManager : public WebUIBubbleManagerImpl<WalletPanelUI>,
                                  public views::ViewObserver {
@@ -121,7 +237,6 @@ class WalletWebUIBubbleManager : public WebUIBubbleManagerImpl<WalletPanelUI>,
     auto* widget =
         views::BubbleDialogDelegateView::CreateBubble(std::move(bubble_view));
     CHECK(widget);
-    widget->SetZOrderLevel(ui::ZOrderLevel::kSecuritySurface);
 
     // Checking if we create WalletPanelUI instance of WebUI and
     // extracting WebUIContentsWrapper class to pass real browser delegate
@@ -259,6 +374,13 @@ bool WalletBubbleManagerDelegateImpl::IsShowingBubble() {
 bool WalletBubbleManagerDelegateImpl::IsBubbleClosedForTesting() {
   return !webui_bubble_manager_ || !webui_bubble_manager_->GetBubbleWidget() ||
          webui_bubble_manager_->GetBubbleWidget()->IsClosed();
+}
+
+views::Widget* WalletBubbleManagerDelegateImpl::GetBubbleWidgetForTesting() {
+  if (!webui_bubble_manager_) {
+    return nullptr;
+  }
+  return webui_bubble_manager_->GetBubbleWidget();
 }
 
 }  // namespace brave_wallet

--- a/browser/ui/wallet_bubble_manager_delegate_impl.h
+++ b/browser/ui/wallet_bubble_manager_delegate_impl.h
@@ -13,6 +13,10 @@
 #include "brave/browser/ui/brave_wallet/wallet_bubble_manager_delegate.h"
 #include "url/gurl.h"
 
+namespace views {
+class Widget;
+}  // namespace views
+
 namespace brave_wallet {
 
 class WalletWebUIBubbleManager;
@@ -33,6 +37,7 @@ class WalletBubbleManagerDelegateImpl : public WalletBubbleManagerDelegate {
   bool IsBubbleClosedForTesting() override;
   content::WebContents* GetWebContentsForTesting() override;
   const std::vector<int32_t>& GetPopupIdsForTesting() override;
+  views::Widget* GetBubbleWidgetForTesting() override;
 
  private:
   raw_ptr<content::WebContents> web_contents_ = nullptr;


### PR DESCRIPTION
when the wallet panel is shown, elevate the z-order of the wallet panel's parent widget to kSecuritySurface. When the walle panel has high level of z-order by itself, the panel will be shown with its parent still being covered by other applications. This makes users feel the panel is floating detached from browser, which looks weird.

In order to fix this, elevates the z-order of the wallet panel's parent with the wallet panel's z-order together.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/48487

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
