### PR TITLE
Add chrome://local-ai-internals debug page

### DIFF
--- a/browser/brave_content_browser_client.cc
+++ b/browser/brave_content_browser_client.cc
@@ -86,6 +86,7 @@
 #include "brave/components/google_sign_in_permission/google_sign_in_permission_util.h"
 #include "brave/components/local_ai/core/features.h"
 #include "brave/components/local_ai/core/local_ai.mojom.h"
+#include "brave/components/local_ai/core/local_ai_internals.mojom.h"
 #include "brave/components/ntp_background_images/browser/mojom/ntp_background_images.mojom.h"
 #include "brave/components/password_strength_meter/password_strength_meter.mojom.h"
 #include "brave/components/playlist/content/browser/playlist_background_web_contents_helper.h"
@@ -160,6 +161,7 @@
 #include "brave/browser/ui/webui/brave_settings_ui.h"
 #include "brave/browser/ui/webui/brave_shields/shields_panel_ui.h"
 #include "brave/browser/ui/webui/email_aliases/email_aliases_panel_ui.h"
+#include "brave/browser/ui/webui/local_ai_internals/local_ai_internals_ui.h"
 #include "brave/browser/ui/webui/new_tab_page/brave_new_tab_ui.h"
 #include "brave/browser/ui/webui/private_new_tab_page/brave_private_new_tab_ui.h"
 #include "brave/components/brave_new_tab_ui/brave_new_tab_page.mojom.h"
@@ -945,6 +947,9 @@ void BraveContentBrowserClient::RegisterBrowserInterfaceBindersForFrame(
   content::RegisterWebUIControllerInterfaceBinder<
       brave_shields::mojom::PanelHandlerFactory, ShieldsPanelUI>(map);
 #if BUILDFLAG(ENABLE_BRAVE_REWARDS)
+  content::RegisterWebUIControllerInterfaceBinder<
+      local_ai_internals::mojom::PageHandler, local_ai::LocalAIInternalsUI>(
+      map);
   content::RegisterWebUIControllerInterfaceBinder<
       brave_rewards::mojom::RewardsPageHandler,
       brave_rewards::RewardsPageTopUI>(map);

--- a/browser/sources.gni
+++ b/browser/sources.gni
@@ -229,6 +229,7 @@ brave_chrome_browser_deps = [
   "//brave/components/l10n/common",
   "//brave/components/local_ai/core",
   "//brave/components/local_ai/core:features",
+  "//brave/components/local_ai/core:local_ai_internals",
   "//brave/components/local_ai/core:mojom",
   "//brave/components/ntp_background_images/browser",
   "//brave/components/ntp_background_images/buildflags",

--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -81,6 +81,7 @@ source_set("ui") {
 
     # Unconditional for gn check since the mojom header is included
     # in brave_new_tab_ui.h (guarded by ENABLE_BRAVE_NEWS buildflag).
+    "//brave/browser/local_ai",
     "//brave/components/brave_news/common:mojom",
     "//brave/components/brave_news/common/buildflags",
     "//brave/components/brave_origin",
@@ -88,6 +89,10 @@ source_set("ui") {
     "//brave/components/brave_rewards/core/buildflags",
     "//brave/components/brave_shields/core/browser",
     "//brave/components/brave_wallet/common/buildflags",
+    "//brave/components/local_ai/core:features",
+    "//brave/components/local_ai/core:local_ai_internals",
+    "//brave/components/local_ai/core:mojom",
+    "//brave/components/local_ai/resources:local_ai_internals_generated",
     "//brave/components/webcompat/core/common",
     "//chrome/browser/contextual_search",
     "//chrome/browser/history",
@@ -123,6 +128,8 @@ source_set("ui") {
     "webui/brave_web_ui_controller_factory.h",
     "webui/brave_webui_source.cc",
     "webui/brave_webui_source.h",
+    "webui/local_ai_internals/local_ai_internals_ui.cc",
+    "webui/local_ai_internals/local_ai_internals_ui.h",
     "webui/skus_internals_ui.cc",
     "webui/skus_internals_ui.h",
     "webui/untrusted_sanitized_image_source.cc",

--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -103,6 +103,7 @@ source_set("ui") {
     "//chrome/browser/ui/startup",
     "//chrome/browser/ui/tabs:tabs_public",
     "//chrome/browser/ui/toolbar",
+    "//components/passage_embeddings/core",
     "//media",
   ]
 

--- a/browser/ui/webui/DEPS
+++ b/browser/ui/webui/DEPS
@@ -9,6 +9,7 @@ include_rules += [
   "+brave/components/brave_ads/core/mojom",
   "+brave/components/brave_private_cdn",
   "+brave/components/brave_rewards/resources",
+  "+brave/components/local_ai/resources",
   "+brave/components/email_aliases",
   "+brave/components/local_ai/resources",
   "+brave/components/ntp_background_images/browser",

--- a/browser/ui/webui/local_ai_internals/DEPS
+++ b/browser/ui/webui/local_ai_internals/DEPS
@@ -1,0 +1,4 @@
+include_rules = [
+  "+brave/components/local_ai/core",
+  "+brave/components/local_ai/resources",
+]

--- a/browser/ui/webui/local_ai_internals/local_ai_internals_ui.cc
+++ b/browser/ui/webui/local_ai_internals/local_ai_internals_ui.cc
@@ -1,0 +1,139 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/browser/ui/webui/local_ai_internals/local_ai_internals_ui.h"
+
+#include <utility>
+
+#include "base/feature_list.h"
+#include "brave/browser/local_ai/local_ai_service_factory.h"
+#include "brave/components/constants/webui_url_constants.h"
+#include "brave/components/local_ai/core/features.h"
+#include "brave/components/local_ai/resources/grit/local_ai_generated.h"
+#include "brave/components/local_ai/resources/grit/local_ai_generated_map.h"
+#include "chrome/browser/profiles/profile.h"
+#include "components/grit/brave_components_resources.h"
+#include "content/public/browser/web_ui.h"
+#include "content/public/browser/web_ui_data_source.h"
+#include "content/public/common/url_constants.h"
+#include "ui/webui/webui_util.h"
+
+namespace local_ai {
+
+LocalAIInternalsPageHandler::LocalAIInternalsPageHandler(
+    mojo::PendingReceiver<local_ai_internals::mojom::PageHandler> receiver,
+    mojo::PendingRemote<mojom::LocalAIService> local_ai_service)
+    : receiver_(this, std::move(receiver)),
+      local_ai_service_(std::move(local_ai_service)) {}
+
+LocalAIInternalsPageHandler::~LocalAIInternalsPageHandler() {
+  // Must drain pending callbacks before receiver_ is destroyed, otherwise
+  // the mojo responders are destroyed while the pipe is still connected.
+  CancelAllPending();
+}
+
+void LocalAIInternalsPageHandler::GenerateEmbedding(
+    const std::string& text,
+    GenerateEmbeddingCallback callback) {
+  if (!local_ai_service_.is_bound()) {
+    std::move(callback).Run({});
+    return;
+  }
+  pending_callbacks_.push_back(std::move(callback));
+  if (passage_embedder_.is_bound()) {
+    passage_embedder_->GenerateEmbeddings(
+        text, base::BindOnce(&LocalAIInternalsPageHandler::OnEmbeddingResult,
+                             weak_ptr_factory_.GetWeakPtr()));
+    return;
+  }
+  pending_texts_.push_back(text);
+  if (pending_texts_.size() == 1) {
+    local_ai_service_->GetPassageEmbedder(
+        base::BindOnce(&LocalAIInternalsPageHandler::OnPassageEmbedderReady,
+                       weak_ptr_factory_.GetWeakPtr()));
+  }
+}
+
+void LocalAIInternalsPageHandler::OnPassageEmbedderReady(
+    mojo::PendingRemote<mojom::PassageEmbedder> remote) {
+  if (!remote.is_valid()) {
+    CancelAllPending();
+    return;
+  }
+  if (!passage_embedder_.is_bound()) {
+    passage_embedder_.Bind(std::move(remote));
+    passage_embedder_.set_disconnect_handler(base::BindOnce(
+        &LocalAIInternalsPageHandler::OnPassageEmbedderDisconnected,
+        weak_ptr_factory_.GetWeakPtr()));
+  }
+  auto texts = std::move(pending_texts_);
+  for (const auto& text : texts) {
+    passage_embedder_->GenerateEmbeddings(
+        text, base::BindOnce(&LocalAIInternalsPageHandler::OnEmbeddingResult,
+                             weak_ptr_factory_.GetWeakPtr()));
+  }
+}
+
+void LocalAIInternalsPageHandler::OnEmbeddingResult(
+    const std::vector<double>& embedding) {
+  if (pending_callbacks_.empty()) {
+    return;
+  }
+  auto callback = std::move(pending_callbacks_.front());
+  pending_callbacks_.erase(pending_callbacks_.begin());
+  std::move(callback).Run(embedding);
+
+  // Release the embedder when all requests are done so the JS side
+  // can detect the disconnect and call notifyWorkerIdle().
+  if (pending_callbacks_.empty()) {
+    passage_embedder_.reset();
+  }
+}
+
+void LocalAIInternalsPageHandler::OnPassageEmbedderDisconnected() {
+  passage_embedder_.reset();
+  CancelAllPending();
+}
+
+void LocalAIInternalsPageHandler::CancelAllPending() {
+  pending_texts_.clear();
+  auto callbacks = std::move(pending_callbacks_);
+  for (auto& cb : callbacks) {
+    std::move(cb).Run({});
+  }
+}
+
+LocalAIInternalsUI::LocalAIInternalsUI(content::WebUI* web_ui)
+    : ui::MojoWebUIController(web_ui) {
+  auto* profile = Profile::FromWebUI(web_ui);
+
+  content::WebUIDataSource* source =
+      content::WebUIDataSource::CreateAndAdd(profile, kLocalAIInternalsHost);
+
+  webui::SetupWebUIDataSource(source, kLocalAiGenerated,
+                              IDR_LOCAL_AI_INTERNALS_HTML);
+}
+
+LocalAIInternalsUI::~LocalAIInternalsUI() = default;
+
+void LocalAIInternalsUI::BindInterface(
+    mojo::PendingReceiver<local_ai_internals::mojom::PageHandler> receiver) {
+  mojo::PendingRemote<mojom::LocalAIService> service_remote;
+  if (base::FeatureList::IsEnabled(features::kLocalAIModels)) {
+    auto* profile = Profile::FromWebUI(web_ui());
+    service_remote = LocalAIServiceFactory::GetForProfile(profile);
+  }
+  page_handler_ = std::make_unique<LocalAIInternalsPageHandler>(
+      std::move(receiver), std::move(service_remote));
+}
+
+WEB_UI_CONTROLLER_TYPE_IMPL(LocalAIInternalsUI)
+
+///////////////////////////////////////////////////////////////////////////////
+
+LocalAIInternalsUIConfig::LocalAIInternalsUIConfig()
+    : DefaultWebUIConfig(content::kChromeUIScheme, kLocalAIInternalsHost) {}
+
+}  // namespace local_ai

--- a/browser/ui/webui/local_ai_internals/local_ai_internals_ui.cc
+++ b/browser/ui/webui/local_ai_internals/local_ai_internals_ui.cc
@@ -11,8 +11,8 @@
 #include "brave/browser/local_ai/local_ai_service_factory.h"
 #include "brave/components/constants/webui_url_constants.h"
 #include "brave/components/local_ai/core/features.h"
-#include "brave/components/local_ai/resources/grit/local_ai_generated.h"
-#include "brave/components/local_ai/resources/grit/local_ai_generated_map.h"
+#include "brave/components/local_ai/resources/grit/local_ai_internals_generated.h"
+#include "brave/components/local_ai/resources/grit/local_ai_internals_generated_map.h"
 #include "chrome/browser/profiles/profile.h"
 #include "components/grit/brave_components_resources.h"
 #include "content/public/browser/web_ui.h"
@@ -112,7 +112,7 @@ LocalAIInternalsUI::LocalAIInternalsUI(content::WebUI* web_ui)
   content::WebUIDataSource* source =
       content::WebUIDataSource::CreateAndAdd(profile, kLocalAIInternalsHost);
 
-  webui::SetupWebUIDataSource(source, kLocalAiGenerated,
+  webui::SetupWebUIDataSource(source, kLocalAiInternalsGenerated,
                               IDR_LOCAL_AI_INTERNALS_HTML);
 }
 

--- a/browser/ui/webui/local_ai_internals/local_ai_internals_ui.cc
+++ b/browser/ui/webui/local_ai_internals/local_ai_internals_ui.cc
@@ -15,6 +15,7 @@
 #include "brave/components/local_ai/resources/grit/local_ai_internals_generated_map.h"
 #include "chrome/browser/profiles/profile.h"
 #include "components/grit/brave_components_resources.h"
+#include "components/passage_embeddings/core/passage_embeddings_features.h"
 #include "content/public/browser/web_ui.h"
 #include "content/public/browser/web_ui_data_source.h"
 #include "content/public/common/url_constants.h"
@@ -41,6 +42,7 @@ void LocalAIInternalsPageHandler::GenerateEmbedding(
     std::move(callback).Run({});
     return;
   }
+  idle_timer_.Stop();
   pending_callbacks_.push_back(std::move(callback));
   if (passage_embedder_.is_bound()) {
     passage_embedder_->GenerateEmbeddings(
@@ -84,17 +86,22 @@ void LocalAIInternalsPageHandler::OnEmbeddingResult(
   auto callback = std::move(pending_callbacks_.front());
   pending_callbacks_.erase(pending_callbacks_.begin());
   std::move(callback).Run(embedding);
-
-  // Release the embedder when all requests are done so the JS side
-  // can detect the disconnect and call notifyWorkerIdle().
-  if (pending_callbacks_.empty()) {
-    passage_embedder_.reset();
+  if (pending_callbacks_.empty() && passage_embedder_.is_bound()) {
+    idle_timer_.Start(
+        FROM_HERE, passage_embeddings::kEmbedderTimeout.Get(),
+        base::BindOnce(&LocalAIInternalsPageHandler::OnIdleTimeout,
+                       weak_ptr_factory_.GetWeakPtr()));
   }
 }
 
 void LocalAIInternalsPageHandler::OnPassageEmbedderDisconnected() {
+  idle_timer_.Stop();
   passage_embedder_.reset();
   CancelAllPending();
+}
+
+void LocalAIInternalsPageHandler::OnIdleTimeout() {
+  passage_embedder_.reset();
 }
 
 void LocalAIInternalsPageHandler::CancelAllPending() {

--- a/browser/ui/webui/local_ai_internals/local_ai_internals_ui.h
+++ b/browser/ui/webui/local_ai_internals/local_ai_internals_ui.h
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "base/memory/weak_ptr.h"
+#include "base/timer/timer.h"
 #include "brave/components/local_ai/core/local_ai.mojom.h"
 #include "brave/components/local_ai/core/local_ai_internals.mojom.h"
 #include "content/public/browser/webui_config.h"
@@ -43,11 +44,17 @@ class LocalAIInternalsPageHandler
       mojo::PendingRemote<mojom::PassageEmbedder> remote);
   void OnEmbeddingResult(const std::vector<double>& embedding);
   void OnPassageEmbedderDisconnected();
+  void OnIdleTimeout();
   void CancelAllPending();
 
   mojo::Receiver<local_ai_internals::mojom::PageHandler> receiver_;
   mojo::Remote<mojom::LocalAIService> local_ai_service_;
   mojo::Remote<mojom::PassageEmbedder> passage_embedder_;
+
+  // Mojo's set_idle_handler() relies on the receiver sending MessageAck
+  // and NotifyIdle control messages, but the JS Mojo bindings don't
+  // implement this protocol. Use an explicit timer instead.
+  base::OneShotTimer idle_timer_;
 
   // Texts queued while waiting for the embedder to bind.
   std::vector<std::string> pending_texts_;

--- a/browser/ui/webui/local_ai_internals/local_ai_internals_ui.h
+++ b/browser/ui/webui/local_ai_internals/local_ai_internals_ui.h
@@ -1,0 +1,86 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_BROWSER_UI_WEBUI_LOCAL_AI_INTERNALS_LOCAL_AI_INTERNALS_UI_H_
+#define BRAVE_BROWSER_UI_WEBUI_LOCAL_AI_INTERNALS_LOCAL_AI_INTERNALS_UI_H_
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "base/memory/weak_ptr.h"
+#include "brave/components/local_ai/core/local_ai.mojom.h"
+#include "brave/components/local_ai/core/local_ai_internals.mojom.h"
+#include "content/public/browser/webui_config.h"
+#include "mojo/public/cpp/bindings/pending_receiver.h"
+#include "mojo/public/cpp/bindings/pending_remote.h"
+#include "mojo/public/cpp/bindings/receiver.h"
+#include "mojo/public/cpp/bindings/remote.h"
+#include "ui/webui/mojo_web_ui_controller.h"
+
+namespace local_ai {
+
+class LocalAIInternalsPageHandler
+    : public local_ai_internals::mojom::PageHandler {
+ public:
+  explicit LocalAIInternalsPageHandler(
+      mojo::PendingReceiver<local_ai_internals::mojom::PageHandler> receiver,
+      mojo::PendingRemote<mojom::LocalAIService> local_ai_service);
+  ~LocalAIInternalsPageHandler() override;
+
+  LocalAIInternalsPageHandler(const LocalAIInternalsPageHandler&) = delete;
+  LocalAIInternalsPageHandler& operator=(const LocalAIInternalsPageHandler&) =
+      delete;
+
+  // local_ai_internals::mojom::PageHandler:
+  void GenerateEmbedding(const std::string& text,
+                         GenerateEmbeddingCallback callback) override;
+
+ private:
+  void OnPassageEmbedderReady(
+      mojo::PendingRemote<mojom::PassageEmbedder> remote);
+  void OnEmbeddingResult(const std::vector<double>& embedding);
+  void OnPassageEmbedderDisconnected();
+  void CancelAllPending();
+
+  mojo::Receiver<local_ai_internals::mojom::PageHandler> receiver_;
+  mojo::Remote<mojom::LocalAIService> local_ai_service_;
+  mojo::Remote<mojom::PassageEmbedder> passage_embedder_;
+
+  // Texts queued while waiting for the embedder to bind.
+  std::vector<std::string> pending_texts_;
+  // Response callbacks in FIFO order matching the request order.
+  std::vector<GenerateEmbeddingCallback> pending_callbacks_;
+
+  base::WeakPtrFactory<LocalAIInternalsPageHandler> weak_ptr_factory_{this};
+};
+
+// Trusted WebUI at chrome://local-ai-internals
+class LocalAIInternalsUI : public ui::MojoWebUIController {
+ public:
+  explicit LocalAIInternalsUI(content::WebUI* web_ui);
+  LocalAIInternalsUI(const LocalAIInternalsUI&) = delete;
+  LocalAIInternalsUI& operator=(const LocalAIInternalsUI&) = delete;
+  ~LocalAIInternalsUI() override;
+
+  void BindInterface(
+      mojo::PendingReceiver<local_ai_internals::mojom::PageHandler> receiver);
+
+  WEB_UI_CONTROLLER_TYPE_DECL();
+
+ private:
+  std::unique_ptr<LocalAIInternalsPageHandler> page_handler_;
+};
+
+class LocalAIInternalsUIConfig
+    : public content::DefaultWebUIConfig<LocalAIInternalsUI> {
+ public:
+  LocalAIInternalsUIConfig();
+  ~LocalAIInternalsUIConfig() override = default;
+};
+
+}  // namespace local_ai
+
+#endif  // BRAVE_BROWSER_UI_WEBUI_LOCAL_AI_INTERNALS_LOCAL_AI_INTERNALS_UI_H_

--- a/chromium_src/chrome/browser/ui/webui/chrome_web_ui_configs.cc
+++ b/chromium_src/chrome/browser/ui/webui/chrome_web_ui_configs.cc
@@ -55,6 +55,7 @@
 
 #include "brave/browser/ui/webui/brave_adblock_internals_ui.h"
 #include "brave/browser/ui/webui/brave_adblock_ui.h"
+#include "brave/browser/ui/webui/local_ai_internals/local_ai_internals_ui.h"
 
 #if BUILDFLAG(ENABLE_BRAVE_EDUCATION)
 #include "brave/browser/ui/webui/brave_education/brave_education_page_ui.h"
@@ -132,6 +133,7 @@ void RegisterChromeWebUIConfigs() {
 #endif  // !BUILDFLAG(IS_ANDROID)
   map.AddWebUIConfig(std::make_unique<BraveAdblockUIConfig>());
   map.AddWebUIConfig(std::make_unique<BraveAdblockInternalsUIConfig>());
+  map.AddWebUIConfig(std::make_unique<local_ai::LocalAIInternalsUIConfig>());
 
 #if BUILDFLAG(ENABLE_AI_CHAT)
   if (ai_chat::features::IsAIChatEnabled()) {

--- a/components/constants/webui_url_constants.h
+++ b/components/constants/webui_url_constants.h
@@ -65,6 +65,8 @@ inline constexpr char kUntrustedMarketURL[] =
 inline constexpr char kUntrustedTrezorHost[] = "trezor-bridge";
 inline constexpr char kUntrustedTrezorURL[] =
     "chrome-untrusted://trezor-bridge/";
+inline constexpr char kLocalAIInternalsHost[] = "local-ai-internals";
+inline constexpr char kLocalAIInternalsURL[] = "chrome://local-ai-internals/";
 inline constexpr char kShieldsPanelURL[] = "chrome://brave-shields.top-chrome";
 inline constexpr char kShieldsPanelHost[] = "brave-shields.top-chrome";
 inline constexpr char kCookieListOptInHost[] = "cookie-list-opt-in.top-chrome";

--- a/components/local_ai/core/BUILD.gn
+++ b/components/local_ai/core/BUILD.gn
@@ -27,6 +27,13 @@ source_set("features") {
   public_deps = [ "//base" ]
 }
 
+mojom("local_ai_internals") {
+  sources = [ "local_ai_internals.mojom" ]
+
+  generate_legacy_js_bindings = true
+  webui_module_path = "chrome://local-ai-internals/"
+}
+
 static_library("core") {
   assert_no_deps = [ "//content/public/*" ]
   friend = [ ":unit_tests" ]

--- a/components/local_ai/core/local_ai_internals.mojom
+++ b/components/local_ai/core/local_ai_internals.mojom
@@ -1,0 +1,12 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+module local_ai_internals.mojom;
+
+// Browser-side handler for chrome://local-ai-internals
+interface PageHandler {
+  // Generate embedding for the given text
+  GenerateEmbedding(string text) => (array<double> embedding);
+};

--- a/components/local_ai/resources/BUILD.gn
+++ b/components/local_ai/resources/BUILD.gn
@@ -28,3 +28,23 @@ pack_web_resources("local_ai_generated") {
   output_dir = "$root_gen_dir/brave/components/local_ai/resources"
   deps = [ ":local_ai_ui" ]
 }
+
+# Trusted WebUI at chrome://local-ai-internals
+transpile_web_ui("local_ai_internals_ui") {
+  entry_points = [ [
+        "local_ai_internals",
+        rebase_path("local_ai_internals.ts"),
+      ] ]
+  webpack_aliases = [ "browser" ]
+  resource_name = "local_ai_internals"
+
+  imports_from = [ "//brave/components/local_ai/resources/" ]
+
+  deps = [ "//brave/components/local_ai/core:local_ai_internals_js" ]
+}
+
+pack_web_resources("local_ai_internals_generated") {
+  resource_name = "local_ai_internals"
+  output_dir = "$root_gen_dir/brave/components/local_ai/resources"
+  deps = [ ":local_ai_internals_ui" ]
+}

--- a/components/local_ai/resources/local_ai_internals.html
+++ b/components/local_ai/resources/local_ai_internals.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Local AI Internals</title>
+    <style>
+      body {
+        font-family: system-ui, -apple-system, sans-serif;
+        margin: 20px;
+      }
+      .info {
+        background: #e3f2fd;
+        padding: 15px;
+        border-radius: 4px;
+        margin-bottom: 20px;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Local AI Internals</h1>
+    <div class="info" style="background: #fff3cd; border-left: 4px solid #ffc107;">
+      <p><strong>⚠️ Developer Feature:</strong> This feature is intended for developers. See <a href="https://github.com/brave/brave-core/pull/32261" target="_blank">brave-core#32261</a> for more details.</p>
+    </div>
+    <div class="info">
+      <p><strong>Architecture:</strong></p>
+      <p>The Embedding Gemma model runs in a shared CandleService (per-profile) that owns a hidden WebContents with the WASM. This service is shared by History Embeddings and this debug UI.</p>
+      <p>The model is automatically loaded on service creation. Check the console for logs.</p>
+    </div>
+
+    <h2>Embedding Gemma Status:</h2>
+    <div class="model-config">
+      <div id="serviceStatus"
+        style="padding: 15px; margin: 10px 0; border-radius: 4px;
+        background: #f5f5f5; border-left: 4px solid #2196f3;">
+        <strong>Initializing CandleService...</strong>
+      </div>
+
+      <h3>Compare Embeddings:</h3>
+      <p>Compare similarity between two texts:</p>
+      <div class="input-group">
+        <label>Text 1:
+          <input type="text" id="text1"
+            placeholder="Enter first text..."
+            value="What is the capital of France?"
+            style="width: 100%; padding: 8px; margin: 5px 0;">
+        </label>
+      </div>
+      <div class="input-group">
+        <label>Text 2:
+          <input type="text" id="text2"
+            placeholder="Enter second text..."
+            value="Paris is the capital of France"
+            style="width: 100%; padding: 8px; margin: 5px 0;">
+        </label>
+      </div>
+      <button id="compareBtn"
+        style="padding: 10px 20px; margin: 10px 0; cursor: pointer;
+        background: #1a73e8; color: white; border: none;
+        border-radius: 4px;" disabled>
+        Compare Embeddings
+      </button>
+      <div id="result"
+        style="padding: 15px; margin: 10px 0; border-radius: 4px;
+        background: #f5f5f5; white-space: pre-wrap; font-family: monospace;
+        display: none;"></div>
+
+      <h3>Example Comparisons:</h3>
+      <button class="example-compare"
+        data-text1="What is the capital of France?"
+        data-text2="Paris is the capital of France"
+        style="padding: 8px 12px; margin: 5px; cursor: pointer;
+        background: #e8f5e9; border: 1px solid #4caf50;
+        border-radius: 4px;">
+        Similar: Question & Answer
+      </button>
+      <button class="example-compare"
+        data-text1="The weather is sunny today"
+        data-text2="It's raining heavily outside"
+        style="padding: 8px 12px; margin: 5px; cursor: pointer;
+        background: #fff3e0; border: 1px solid #ff9800;
+        border-radius: 4px;">
+        Different: Opposite weather
+      </button>
+      <button class="example-compare"
+        data-text1="I love programming in Python"
+        data-text2="Python is my favorite programming language"
+        style="padding: 8px 12px; margin: 5px; cursor: pointer;
+        background: #e8f5e9; border: 1px solid #4caf50;
+        border-radius: 4px;">
+        Similar: Same topic
+      </button>
+    </div>
+    <script type="module" src="local_ai_internals.bundle.js"></script>
+  </body>
+</html>

--- a/components/local_ai/resources/local_ai_internals.ts
+++ b/components/local_ai/resources/local_ai_internals.ts
@@ -1,0 +1,159 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { PageHandler } from 'gen/brave/components/local_ai/core/local_ai_internals.mojom.m.js'
+
+console.log('[Local AI Internals] Script loaded')
+
+// Initialize Mojo connection to page handler
+const pageHandler = PageHandler.getRemote()
+
+const serviceStatus = document.getElementById('serviceStatus')!
+const compareBtn = document.getElementById('compareBtn')! as HTMLButtonElement
+const text1Input = document.getElementById('text1')! as HTMLInputElement
+const text2Input = document.getElementById('text2')! as HTMLInputElement
+const result = document.getElementById('result')!
+
+// Update status to show service is shared
+// Use DOM APIs instead of innerHTML to avoid Trusted Types violations
+const strongEl = document.createElement('strong')
+strongEl.textContent = '✓ CandleService is running'
+const brEl = document.createElement('br')
+const smallEl = document.createElement('small')
+smallEl.textContent =
+  'Shared per-profile service that automatically loads the model from '
+  + 'component updater'
+
+serviceStatus.textContent = ''
+serviceStatus.appendChild(strongEl)
+serviceStatus.appendChild(brEl)
+serviceStatus.appendChild(smallEl)
+serviceStatus.style.borderLeftColor = '#4caf50'
+serviceStatus.style.background = '#e8f5e9'
+
+// Enable the compare button
+compareBtn.disabled = false
+
+// Calculate cosine similarity between two vectors
+function cosineSimilarity(vec1: number[], vec2: number[]): number {
+  if (vec1.length !== vec2.length) {
+    throw new Error('Vectors must have the same length')
+  }
+
+  let dotProduct = 0
+  let norm1 = 0
+  let norm2 = 0
+
+  for (let i = 0; i < vec1.length; i++) {
+    dotProduct += vec1[i] * vec2[i]
+    norm1 += vec1[i] * vec1[i]
+    norm2 += vec2[i] * vec2[i]
+  }
+
+  const magnitude = Math.sqrt(norm1) * Math.sqrt(norm2)
+  if (magnitude === 0) {
+    return 0
+  }
+
+  return dotProduct / magnitude
+}
+
+// Get similarity interpretation
+function getSimilarityInterpretation(similarity: number) {
+  if (similarity >= 0.9) {
+    return { label: 'Very High', color: '#4caf50', bg: '#e8f5e9' }
+  } else if (similarity >= 0.7) {
+    return { label: 'High', color: '#8bc34a', bg: '#f1f8e9' }
+  } else if (similarity >= 0.5) {
+    return { label: 'Moderate', color: '#ff9800', bg: '#fff3e0' }
+  } else if (similarity >= 0.3) {
+    return { label: 'Low', color: '#ff5722', bg: '#fbe9e7' }
+  } else {
+    return { label: 'Very Low', color: '#f44336', bg: '#ffebee' }
+  }
+}
+
+// Handle compare button click
+compareBtn.addEventListener('click', async () => {
+  const text1 = text1Input.value.trim()
+  const text2 = text2Input.value.trim()
+
+  if (!text1 || !text2) {
+    result.textContent = 'Please enter both texts'
+    result.style.display = 'block'
+    result.style.background = '#ffebee'
+    return
+  }
+
+  compareBtn.disabled = true
+  result.style.display = 'none'
+  const startTime = performance.now()
+
+  try {
+    // Call CandleService to generate embeddings for both texts
+    const [result1, result2] = await Promise.all([
+      pageHandler.generateEmbedding(text1),
+      pageHandler.generateEmbedding(text2),
+    ])
+
+    const embedding1 = result1.embedding
+    const embedding2 = result2.embedding
+
+    if (!embedding1.length || !embedding2.length) {
+      throw new Error('Failed to generate embeddings')
+    }
+
+    const embedTime = performance.now() - startTime
+
+    // Calculate cosine similarity
+    const similarity = cosineSimilarity(embedding1, embedding2)
+    const interpretation = getSimilarityInterpretation(similarity)
+
+    // Display results
+    const text1Preview = `"${text1.substring(0, 50)}${
+      text1.length > 50 ? '...' : ''
+    }"`
+    const text2Preview = `"${text2.substring(0, 50)}${
+      text2.length > 50 ? '...' : ''
+    }"`
+
+    result.textContent = [
+      `Text 1: ${text1Preview}`,
+      `Text 2: ${text2Preview}`,
+      ``,
+      `Embedding dimensions: ${embedding1.length}`,
+      `Processing time: ${embedTime.toFixed(0)}ms`,
+      ``,
+      `Cosine Similarity: ${similarity.toFixed(4)}`,
+      `Interpretation: ${interpretation.label}`,
+    ].join('\n')
+    result.style.display = 'block'
+    result.style.background = interpretation.bg
+    result.style.borderLeftColor = interpretation.color
+  } catch (error) {
+    result.textContent = `Error: ${(error as Error).message || error}`
+    result.style.display = 'block'
+    result.style.background = '#ffebee'
+    result.style.borderLeftColor = '#f44336'
+  } finally {
+    compareBtn.disabled = false
+  }
+})
+
+// Handle example comparison buttons
+document.querySelectorAll('.example-compare').forEach((btn) => {
+  btn.addEventListener('click', () => {
+    const text1 = btn.getAttribute('data-text1')
+    const text2 = btn.getAttribute('data-text2')
+    if (text1 && text2) {
+      text1Input.value = text1
+      text2Input.value = text2
+      // Automatically trigger comparison
+      compareBtn.click()
+    }
+  })
+})
+
+console.log('[Local AI Internals] CandleService debug UI ready')

--- a/components/resources/BUILD.gn
+++ b/components/resources/BUILD.gn
@@ -87,6 +87,7 @@ repack("resources") {
     "//brave/components/brave_account/resources",
     "//brave/components/cosmetic_filters/resources/data:generated_resources",
     "//brave/components/local_ai/resources:local_ai_generated",
+    "//brave/components/local_ai/resources:local_ai_internals_generated",
     "//brave/components/local_ai/resources/candle_embedding_gemma:candle_embedding_module_generated",
     "//brave/components/skus/browser/resources:generated_resources",
   ]
@@ -95,6 +96,7 @@ repack("resources") {
     "$root_gen_dir/brave/components/cosmetic_filters/resources/cosmetic_filters_generated.pak",
     "$root_gen_dir/brave/components/local_ai/resources/candle_embedding_module_generated.pak",
     "$root_gen_dir/brave/components/local_ai/resources/local_ai_generated.pak",
+    "$root_gen_dir/brave/components/local_ai/resources/local_ai_internals_generated.pak",
     "$root_gen_dir/brave/components/skus/browser/resources/skus_internals_generated.pak",
     "$root_gen_dir/components/brave_components_static.pak",
   ]

--- a/components/resources/brave_components_resources.grd
+++ b/components/resources/brave_components_resources.grd
@@ -44,6 +44,9 @@
         <include name="IDR_BRAVE_NEW_TAB_IMG2" file="../img/newtab/settings_prefs_btn.svg" type="BINDATA" />
       </if>
 
+      <!-- WebUI Local AI resources -->
+      <include name="IDR_LOCAL_AI_INTERNALS_HTML" file="../local_ai/resources/local_ai_internals.html" type="BINDATA" />
+
       <!-- WebUI wallet resources -->
       <if expr="enable_brave_wallet">
         <include name="IDR_WALLET_PAGE_HTML" file="${root_gen_dir}/brave/components/brave_wallet_ui/page/preprocessed/wallet_page.html" use_base_dir="false" type="BINDATA" />

--- a/resources/resource_ids.spec
+++ b/resources/resource_ids.spec
@@ -238,6 +238,10 @@
     "META": {"sizes": {"includes": [1]}},
     "includes": [54037],
   },
+  "<(SHARED_INTERMEDIATE_DIR)/brave/web-ui-local_ai_internals/local_ai_internals.grd": {
+    "META": {"sizes": {"includes": [1]}},
+    "includes": [54038],
+  },
   "<(SHARED_INTERMEDIATE_DIR)/brave/web-ui-ai_chat_agent_new_tab_page/ai_chat_agent_new_tab_page.grd": {
     "META": {"sizes": {"includes": [20]}},
     "includes": [54040],


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/52528
Depends on #33726

- Add `local_ai_internals.mojom` with a `PageHandler` interface that
  exposes `GenerateEmbedding` for the debug UI
- Add `LocalAIInternalsUI`, a trusted `MojoWebUIController` at
  `chrome://local-ai-internals` that delegates embedding requests to
  the shared `LocalAIService` via `GetPassageEmbedder()`
- Queue-based request handling: supports concurrent embedding
  requests (e.g. `Promise.all` from frontend), uses FIFO callback
  matching, and releases the PassageEmbedder when all requests
  complete to trigger idle cleanup of the BackgroundWebContents
- Add a frontend with text input fields for comparing embeddings
  between two passages, displaying the cosine similarity score and
  raw embedding vectors
- Register the WebUI config and add URL constants