### PR TITLE
Fix BraveBrowserViewWithRoundedCornersTest.RoundedCornersForContentTest/1 for macos Tahoe

### DIFF
--- a/browser/ui/views/brave_layout_provider_mac.mm
+++ b/browser/ui/views/brave_layout_provider_mac.mm
@@ -11,9 +11,6 @@ int BraveLayoutProviderMac::GetCornerRadiusMetric(
     views::ShapeContextTokensOverride token) const {
   switch (token) {
     case views::ShapeContextTokensOverride::kRoundedCornersBorderRadius:
-      if (@available(macOS 26, *)) {
-        return 17;
-      }
       return 6;
     case views::ShapeContextTokensOverride::
         kRoundedCornersBorderRadiusAtWindowCorner:

--- a/browser/ui/views/brave_layout_provider_mac.mm
+++ b/browser/ui/views/brave_layout_provider_mac.mm
@@ -11,6 +11,9 @@ int BraveLayoutProviderMac::GetCornerRadiusMetric(
     views::ShapeContextTokensOverride token) const {
   switch (token) {
     case views::ShapeContextTokensOverride::kRoundedCornersBorderRadius:
+      if (@available(macOS 26, *)) {
+        return 17;
+      }
       return 6;
     case views::ShapeContextTokensOverride::
         kRoundedCornersBorderRadiusAtWindowCorner:

--- a/browser/ui/views/frame/brave_browser_view_browsertest.cc
+++ b/browser/ui/views/frame/brave_browser_view_browsertest.cc
@@ -289,6 +289,24 @@ IN_PROC_BROWSER_TEST_P(BraveBrowserViewWithRoundedCornersTest,
           kRoundedCornersBorderRadiusAtWindowCorner);
 
   if (IsRoundedCornersEnabled()) {
+    // Check correct contents raidus with right-side sidebar.
+    ASSERT_TRUE(base::test::RunUntil([&]() {
+      return rounded_corners_border_radius_at_window_corner ==
+             browser_view()
+                 ->GetActiveContentsContainerView()
+                 ->contents_view()
+                 ->GetBackgroundRadii()
+                 .lower_left();
+    }));
+    ASSERT_TRUE(base::test::RunUntil([&]() {
+      return rounded_corners_border_radius ==
+             browser_view()
+                 ->GetActiveContentsContainerView()
+                 ->contents_view()
+                 ->GetBackgroundRadii()
+                 .lower_right();
+    }));
+
     // Check contents container has margin by comparing simply its left & bottom
     // with main container's local bounds. As views local bounds' origin is (0,
     // 0), checking child view's margin with child view's bounds works.
@@ -348,6 +366,24 @@ IN_PROC_BROWSER_TEST_P(BraveBrowserViewWithRoundedCornersTest,
   NewSplitTab();
   browser_view()->DeprecatedLayoutImmediately();
 
+  // Check correct contents raidus w/o split view.
+  ASSERT_TRUE(base::test::RunUntil([&]() {
+    return rounded_corners_border_radius_at_window_corner ==
+           browser_view()
+               ->GetContentsContainerViews()[0]
+               ->contents_view()
+               ->GetBackgroundRadii()
+               .lower_left();
+  }));
+
+  ASSERT_TRUE(base::test::RunUntil([&]() {
+    return rounded_corners_border_radius == browser_view()
+                                                ->GetContentsContainerViews()[1]
+                                                ->contents_view()
+                                                ->GetBackgroundRadii()
+                                                .lower_right();
+  }));
+
   EXPECT_EQ(rounded_corners_margin,
             BraveContentsViewUtil::GetRoundedCornersWebViewMargin(browser()));
   EXPECT_EQ(contents_container->bounds().x() - rounded_corners_margin,
@@ -366,17 +402,6 @@ IN_PROC_BROWSER_TEST_P(BraveBrowserViewWithRoundedCornersTest,
                                              ->GetContentsContainerViews()[0]
                                              ->contents_view()
                                              ->GetBackgroundRadii();
-
-  // Wait till end contents view gets proper rounded corners as it's newly
-  // created tabs by opening split view.
-  ASSERT_TRUE(base::test::RunUntil([&]() {
-    return rounded_corners_border_radius == browser_view()
-                                                ->GetContentsContainerViews()[1]
-                                                ->contents_view()
-                                                ->GetBackgroundRadii()
-                                                .lower_right();
-  }));
-
   const auto end_contents_view_radii = browser_view()
                                            ->GetContentsContainerViews()[1]
                                            ->contents_view()
@@ -397,6 +422,24 @@ IN_PROC_BROWSER_TEST_P(BraveBrowserViewWithRoundedCornersTest,
   browser_view()->DeprecatedLayoutImmediately();
 
   if (IsRoundedCornersEnabled()) {
+    // Check correct contents raidus w/o split view.
+    ASSERT_TRUE(base::test::RunUntil([&]() {
+      return rounded_corners_border_radius_at_window_corner ==
+             browser_view()
+                 ->GetActiveContentsContainerView()
+                 ->contents_view()
+                 ->GetBackgroundRadii()
+                 .lower_left();
+    }));
+    ASSERT_TRUE(base::test::RunUntil([&]() {
+      return rounded_corners_border_radius ==
+             browser_view()
+                 ->GetActiveContentsContainerView()
+                 ->contents_view()
+                 ->GetBackgroundRadii()
+                 .lower_right();
+    }));
+
     EXPECT_EQ(contents_container->bounds().x() - rounded_corners_margin,
               browser_view()->GetLocalBounds().x());
     EXPECT_EQ(contents_container->bounds().bottom() + rounded_corners_margin,
@@ -441,6 +484,16 @@ IN_PROC_BROWSER_TEST_P(BraveBrowserViewWithRoundedCornersTest,
   // Test with vertical tab.
   ToggleVerticalTabStrip();
   if (IsRoundedCornersEnabled()) {
+    // Check correct contents raidus with vertical tab.
+    ASSERT_TRUE(base::test::RunUntil([&]() {
+      return rounded_corners_border_radius ==
+             browser_view()
+                 ->GetActiveContentsContainerView()
+                 ->contents_view()
+                 ->GetBackgroundRadii()
+                 .lower_left();
+    }));
+
     auto contents_view_radii = browser_view()
                                    ->GetActiveContentsContainerView()
                                    ->contents_view()
@@ -464,6 +517,17 @@ IN_PROC_BROWSER_TEST_P(BraveBrowserViewWithRoundedCornersTest,
     EXPECT_EQ(rounded_corners_border_radius, contents_view_radii.lower_left());
 
     region_view->ToggleState();
+
+    // Check correct contents raidus w/o vertical tab.
+    ASSERT_TRUE(base::test::RunUntil([&]() {
+      return rounded_corners_border_radius_at_window_corner ==
+             browser_view()
+                 ->GetActiveContentsContainerView()
+                 ->contents_view()
+                 ->GetBackgroundRadii()
+                 .lower_left();
+    }));
+
     contents_view_radii = browser_view()
                               ->GetActiveContentsContainerView()
                               ->contents_view()

--- a/browser/ui/views/frame/brave_browser_view_browsertest.cc
+++ b/browser/ui/views/frame/brave_browser_view_browsertest.cc
@@ -277,6 +277,8 @@ IN_PROC_BROWSER_TEST_P(BraveBrowserViewWithRoundedCornersTest,
 
   auto* panel_ui = browser()->GetFeatures().side_panel_ui();
   panel_ui->Toggle();
+  RunScheduledLayouts();
+
   views::View* contents_container = browser_view()->contents_container();
   views::View* side_panel = browser_view()->contents_height_side_panel();
   const auto rounded_corners_margin = BraveContentsViewUtil::kMarginThickness;
@@ -289,24 +291,6 @@ IN_PROC_BROWSER_TEST_P(BraveBrowserViewWithRoundedCornersTest,
           kRoundedCornersBorderRadiusAtWindowCorner);
 
   if (IsRoundedCornersEnabled()) {
-    // Check correct contents raidus with right-side sidebar.
-    ASSERT_TRUE(base::test::RunUntil([&]() {
-      return rounded_corners_border_radius_at_window_corner ==
-             browser_view()
-                 ->GetActiveContentsContainerView()
-                 ->contents_view()
-                 ->GetBackgroundRadii()
-                 .lower_left();
-    }));
-    ASSERT_TRUE(base::test::RunUntil([&]() {
-      return rounded_corners_border_radius ==
-             browser_view()
-                 ->GetActiveContentsContainerView()
-                 ->contents_view()
-                 ->GetBackgroundRadii()
-                 .lower_right();
-    }));
-
     // Check contents container has margin by comparing simply its left & bottom
     // with main container's local bounds. As views local bounds' origin is (0,
     // 0), checking child view's margin with child view's bounds works.
@@ -365,24 +349,7 @@ IN_PROC_BROWSER_TEST_P(BraveBrowserViewWithRoundedCornersTest,
   // margin.
   NewSplitTab();
   browser_view()->DeprecatedLayoutImmediately();
-
-  // Check correct contents raidus w/o split view.
-  ASSERT_TRUE(base::test::RunUntil([&]() {
-    return rounded_corners_border_radius_at_window_corner ==
-           browser_view()
-               ->GetContentsContainerViews()[0]
-               ->contents_view()
-               ->GetBackgroundRadii()
-               .lower_left();
-  }));
-
-  ASSERT_TRUE(base::test::RunUntil([&]() {
-    return rounded_corners_border_radius == browser_view()
-                                                ->GetContentsContainerViews()[1]
-                                                ->contents_view()
-                                                ->GetBackgroundRadii()
-                                                .lower_right();
-  }));
+  RunScheduledLayouts();
 
   EXPECT_EQ(rounded_corners_margin,
             BraveContentsViewUtil::GetRoundedCornersWebViewMargin(browser()));
@@ -420,26 +387,9 @@ IN_PROC_BROWSER_TEST_P(BraveBrowserViewWithRoundedCornersTest,
   // disabled.
   chrome::AddTabAt(browser(), GURL(), -1, true);
   browser_view()->DeprecatedLayoutImmediately();
+  RunScheduledLayouts();
 
   if (IsRoundedCornersEnabled()) {
-    // Check correct contents raidus w/o split view.
-    ASSERT_TRUE(base::test::RunUntil([&]() {
-      return rounded_corners_border_radius_at_window_corner ==
-             browser_view()
-                 ->GetActiveContentsContainerView()
-                 ->contents_view()
-                 ->GetBackgroundRadii()
-                 .lower_left();
-    }));
-    ASSERT_TRUE(base::test::RunUntil([&]() {
-      return rounded_corners_border_radius ==
-             browser_view()
-                 ->GetActiveContentsContainerView()
-                 ->contents_view()
-                 ->GetBackgroundRadii()
-                 .lower_right();
-    }));
-
     EXPECT_EQ(contents_container->bounds().x() - rounded_corners_margin,
               browser_view()->GetLocalBounds().x());
     EXPECT_EQ(contents_container->bounds().bottom() + rounded_corners_margin,
@@ -483,17 +433,8 @@ IN_PROC_BROWSER_TEST_P(BraveBrowserViewWithRoundedCornersTest,
 
   // Test with vertical tab.
   ToggleVerticalTabStrip();
+  RunScheduledLayouts();
   if (IsRoundedCornersEnabled()) {
-    // Check correct contents raidus with vertical tab.
-    ASSERT_TRUE(base::test::RunUntil([&]() {
-      return rounded_corners_border_radius ==
-             browser_view()
-                 ->GetActiveContentsContainerView()
-                 ->contents_view()
-                 ->GetBackgroundRadii()
-                 .lower_left();
-    }));
-
     auto contents_view_radii = browser_view()
                                    ->GetActiveContentsContainerView()
                                    ->contents_view()
@@ -517,17 +458,7 @@ IN_PROC_BROWSER_TEST_P(BraveBrowserViewWithRoundedCornersTest,
     EXPECT_EQ(rounded_corners_border_radius, contents_view_radii.lower_left());
 
     region_view->ToggleState();
-
-    // Check correct contents raidus w/o vertical tab.
-    ASSERT_TRUE(base::test::RunUntil([&]() {
-      return rounded_corners_border_radius_at_window_corner ==
-             browser_view()
-                 ->GetActiveContentsContainerView()
-                 ->contents_view()
-                 ->GetBackgroundRadii()
-                 .lower_left();
-    }));
-
+    RunScheduledLayouts();
     contents_view_radii = browser_view()
                               ->GetActiveContentsContainerView()
                               ->contents_view()


### PR DESCRIPTION
```
Expected equality of these values:
  rounded_corners_border_radius_at_window_corner
    Which is: 17
  contents_view_radii.lower_left()
    Which is: 6
```

f/u PR to https://github.com/brave/brave-core/pull/33131

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
