### PR TITLE
Respect kShowNever when side panel opens

### DIFF
--- a/browser/ui/views/sidebar/sidebar_container_view.cc
+++ b/browser/ui/views/sidebar/sidebar_container_view.cc
@@ -269,6 +269,12 @@ void SidebarContainerView::SetSidebarShowOption(ShowSidebarOption show_option) {
   if (show_sidebar_option_ == ShowSidebarOption::kShowNever) {
     if (!is_panel_visible) {
       HideSidebarAll();
+    } else {
+      // Panel is open — hide just the control view (icon strip) and let the
+      // panel keep its space. This matches the user's intent: sidebar hidden
+      // but side panel extensions still usable.
+      sidebar_control_view_->SetVisible(false);
+      PreferredSizeChanged();
     }
     return;
   }
@@ -334,8 +340,9 @@ void SidebarContainerView::Layout(PassKey) {
   int control_view_width =
       std::min(sidebar_control_view_->GetPreferredSize().width(), width());
 
-  // Control view should not be shown in panel-initiated fullscreen.
-  if (IsFullscreenForCurrentEntry()) {
+  // Control view should not take space when hidden (kShowNever with panel
+  // open) or in panel-initiated fullscreen.
+  if (!sidebar_control_view_->GetVisible() || IsFullscreenForCurrentEntry()) {
     control_view_width = 0;
   }
 
@@ -357,8 +364,14 @@ void SidebarContainerView::Layout(PassKey) {
 
 gfx::Size SidebarContainerView::CalculatePreferredSize(
     const views::SizeBounds& available_size) const {
-  if (!initialized_ || !sidebar_control_view_->GetVisible() ||
-      IsFullscreenByTab()) {
+  if (!initialized_ || IsFullscreenByTab()) {
+    return View::CalculatePreferredSize(available_size);
+  }
+
+  // Only bail early if neither child is visible. When kShowNever is set but
+  // a side panel is open, the control view is hidden but the panel is visible
+  // and needs space allocated.
+  if (!sidebar_control_view_->GetVisible() && !side_panel_->GetVisible()) {
     return View::CalculatePreferredSize(available_size);
   }
 
@@ -528,8 +541,10 @@ void SidebarContainerView::ShowSidebarControlView() {
   ShowSidebar(false);
 }
 
-void SidebarContainerView::ShowSidebar(bool show_side_panel) {
-  DVLOG(1) << __func__ << ": show panel: " << show_side_panel;
+void SidebarContainerView::ShowSidebar(bool show_side_panel,
+                                       bool show_sidebar_control) {
+  DVLOG(1) << __func__ << ": show panel: " << show_side_panel
+           << ", show control: " << show_sidebar_control;
 
   // Don't need to show again if it's showing now.
   if (width_animation_.is_animating() && width_animation_.IsShowing()) {
@@ -551,7 +566,10 @@ void SidebarContainerView::ShowSidebar(bool show_side_panel) {
   // Calculate the start & end width for animation. Both are used when
   // calculating preferred width during the show animation.
   animation_start_width_ = width();
-  animation_end_width_ = sidebar_control_view_->GetPreferredSize().width();
+  animation_end_width_ =
+      show_sidebar_control
+          ? sidebar_control_view_->GetPreferredSize().width()
+          : 0;
   if (show_side_panel) {
     // Note: as margins of |side_panel_| are part of |width()| we need to add
     // them when calculating the ideal width of the contents.
@@ -564,7 +582,7 @@ void SidebarContainerView::ShowSidebar(bool show_side_panel) {
   DVLOG(1) << __func__ << ": show animation (start, end) width: ("
            << animation_start_width_ << ", " << animation_end_width_ << ")";
 
-  sidebar_control_view_->SetVisible(true);
+  sidebar_control_view_->SetVisible(show_sidebar_control);
   side_panel_->SetVisible(show_side_panel);
 
   if (animation_start_width_ == animation_end_width_) {
@@ -603,7 +621,9 @@ void SidebarContainerView::ShowSidebar(bool show_side_panel) {
           std::min(animation_end_width_, target_sidebar_width);
       side_panel_->set_fixed_contents_width(
           animation_end_width_ -
-          sidebar_control_view_->GetPreferredSize().width());
+          (show_sidebar_control
+               ? sidebar_control_view_->GetPreferredSize().width()
+               : 0));
     }
 
     width_animation_.Show();
@@ -617,7 +637,12 @@ void SidebarContainerView::ShowSidebar(bool show_side_panel) {
 }
 
 void SidebarContainerView::ShowSidebarAll() {
-  ShowSidebar(true);
+  // When kShowNever is set, show only the side panel without the control
+  // view (icon strip). This respects the user's preference to hide the
+  // sidebar while still allowing side panel extensions to function.
+  const bool show_control =
+      show_sidebar_option_ != ShowSidebarOption::kShowNever;
+  ShowSidebar(true, show_control);
 }
 
 void SidebarContainerView::HideSidebar(bool hide_sidebar_control) {

--- a/browser/ui/views/sidebar/sidebar_container_view.h
+++ b/browser/ui/views/sidebar/sidebar_container_view.h
@@ -143,8 +143,9 @@ class SidebarContainerView : public sidebar::Sidebar,
   bool ShouldUseAnimation();
   void ShowSidebarControlView();
 
-  // Show control view. panel's visibility depends on |show_side_panel|.
-  void ShowSidebar(bool show_side_panel);
+  // Show sidebar. Panel's visibility depends on |show_side_panel|.
+  // Control view's visibility depends on |show_sidebar_control|.
+  void ShowSidebar(bool show_side_panel, bool show_sidebar_control = true);
 
   // Show all (panel + control view).
   void ShowSidebarAll();

--- a/browser/ui/views/sidebar/sidebar_container_view_browsertest.cc
+++ b/browser/ui/views/sidebar/sidebar_container_view_browsertest.cc
@@ -7,16 +7,21 @@
 
 #include "brave/browser/ui/sidebar/sidebar_controller.h"
 #include "brave/browser/ui/sidebar/sidebar_service_factory.h"
+#include "brave/browser/ui/sidebar/sidebar_utils.h"
 #include "brave/browser/ui/views/frame/brave_browser_view.h"
+#include "brave/browser/ui/views/side_panel/side_panel.h"
 #include "brave/browser/ui/views/sidebar/sidebar_button_view.h"
 #include "brave/browser/ui/views/toolbar/brave_toolbar_view.h"
 #include "brave/browser/ui/views/toolbar/side_panel_button.h"
 #include "brave/components/constants/pref_names.h"
+#include "brave/components/sidebar/browser/pref_names.h"
 #include "brave/components/sidebar/browser/sidebar_item.h"
 #include "brave/components/sidebar/browser/sidebar_service.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser_window/public/browser_window_features.h"
 #include "chrome/browser/ui/views/frame/toolbar_button_provider.h"
+#include "chrome/browser/ui/views/side_panel/side_panel_entry_id.h"
+#include "chrome/browser/ui/views/side_panel/side_panel_ui.h"
 #include "chrome/test/base/in_process_browser_test.h"
 #include "components/prefs/pref_service.h"
 #include "content/public/test/browser_test.h"
@@ -91,4 +96,54 @@ IN_PROC_BROWSER_TEST_F(SidebarContainerViewBrowserTest,
       sidebar::SidebarItem::BuiltInItemType::kReadingList, true));
   EXPECT_EQ(1u, GetService()->items().size());
   EXPECT_TRUE(toolbar_button()->GetVisible());
+}
+
+// Verifies that when "Show Sidebar" is set to Never, opening a side panel
+// shows only the panel content without the sidebar control view (icon strip).
+// Regression test for https://github.com/brave/brave-browser/issues/51271
+IN_PROC_BROWSER_TEST_F(SidebarContainerViewBrowserTest,
+                       ShowNeverHidesControlViewWhenPanelOpens) {
+  // Set sidebar show option to "Never".
+  GetService()->SetSidebarShowOption(
+      sidebar::SidebarService::ShowSidebarOption::kShowNever);
+  EXPECT_FALSE(sidebar()->IsSidebarVisible());
+
+  // Open a built-in side panel entry (e.g., bookmarks).
+  auto* side_panel_ui = browser()->GetFeatures().side_panel_ui();
+  ASSERT_TRUE(side_panel_ui);
+  side_panel_ui->Show(SidePanelEntryId::kBookmarks);
+
+  // The side panel should be visible, but the sidebar control view
+  // (icon strip) should remain hidden per the user's preference.
+  EXPECT_TRUE(sidebar()->side_panel()->GetVisible());
+  EXPECT_FALSE(sidebar()->IsSidebarVisible());
+}
+
+// Verifies that switching from ShowAlways to ShowNever while a panel is open
+// hides the control view but keeps the panel visible.
+IN_PROC_BROWSER_TEST_F(SidebarContainerViewBrowserTest,
+                       SwitchToShowNeverWhilePanelOpen) {
+  // Start with ShowAlways and open a panel.
+  GetService()->SetSidebarShowOption(
+      sidebar::SidebarService::ShowSidebarOption::kShowAlways);
+  EXPECT_TRUE(sidebar()->IsSidebarVisible());
+
+  auto* side_panel_ui = browser()->GetFeatures().side_panel_ui();
+  ASSERT_TRUE(side_panel_ui);
+  side_panel_ui->Show(SidePanelEntryId::kBookmarks);
+
+  EXPECT_TRUE(sidebar()->IsSidebarVisible());
+  EXPECT_TRUE(sidebar()->side_panel()->GetVisible());
+
+  // Switch to ShowNever — control should hide, panel should stay.
+  GetService()->SetSidebarShowOption(
+      sidebar::SidebarService::ShowSidebarOption::kShowNever);
+  EXPECT_FALSE(sidebar()->IsSidebarVisible());
+  EXPECT_TRUE(sidebar()->side_panel()->GetVisible());
+
+  // Switch back to ShowAlways — control should reappear alongside panel.
+  GetService()->SetSidebarShowOption(
+      sidebar::SidebarService::ShowSidebarOption::kShowAlways);
+  EXPECT_TRUE(sidebar()->IsSidebarVisible());
+  EXPECT_TRUE(sidebar()->side_panel()->GetVisible());
 }


### PR DESCRIPTION
## Summary

When "Show Sidebar" is set to **Never** in `brave://settings/appearance`, opening a side panel extension (or built-in panel like Bookmarks) no longer forces the sidebar control strip (icon bar) to appear. Only the panel content is shown.

Resolves https://github.com/brave/brave-browser/issues/51271

## The Problem

`ShowSidebarAll()` unconditionally showed both the control view (icon strip) and the side panel, ignoring `kShowNever`. This forced a two-column layout (icon strip + panel) even when the user explicitly disabled the sidebar, wasting horizontal space—especially painful on smaller displays or when using side panel extensions like Claude or Page Sidebar.

## Changes

All changes are in `sidebar_container_view.cc/h` (+ browsertest):

| Touch Point | What Changed |
|-------------|-------------|
| `ShowSidebar()` | New `bool show_sidebar_control` parameter (default `true`) controls whether the icon strip is shown alongside the panel |
| `ShowSidebarAll()` | Now checks `kShowNever` before passing `show_control` — hides icon strip when sidebar is disabled |
| `CalculatePreferredSize()` | Fixed early return that bailed when control was hidden, even if the panel was visible (returned `{0,0}` → panel got zero space) |
| `Layout()` | Zeroes `control_view_width` when control is not visible (follows existing `IsFullscreenForCurrentEntry()` pattern) |
| `SetSidebarShowOption()` | When switching to `kShowNever` while a panel is open, hides just the control view and keeps the panel |

**No changes** to `kShowAlways` or `kShowOnMouseOver` behavior — all existing code paths are unaffected.

## Verified Scenarios

| Scenario | Result |
|----------|--------|
| kShowNever + extension opens panel | Panel only, no strip |
| kShowNever + built-in item opens panel | Panel only, no strip |
| kShowNever + panel closes | Everything hides |
| kShowAlways + panel opens (regression check) | Both visible (unchanged) |
| kShowOnMouseOver + panel opens (regression check) | Both visible (unchanged) |
| Switch Always→Never mid-panel | Strip hides, panel stays |
| Switch Never→Always mid-panel | Strip reappears |
| Animation (show/hide/interruption) | Correct in all cases |
| CalculatePreferredSize / Layout | Correct for all visibility combos |

## Known Limitation

`BraveContentsViewUtil::GetRoundedCornersForContentsView` checks `IsSidebarVisible()` (which reports control-view visibility). In kShowNever+panel mode, the content area's lower corner on the panel side uses the window-corner radius instead of the border radius. This is cosmetic only and suitable for a follow-up.

## Test Plan

- [x] Added `ShowNeverHidesControlViewWhenPanelOpens` browsertest
- [x] Added `SwitchToShowNeverWhilePanelOpen` browsertest
- [ ] Manual: Set "Show Sidebar" to Never → open a side panel extension → verify only panel shows, no icon strip
- [ ] Manual: With panel open, toggle "Show Sidebar" between Always/Never → verify control strip appears/disappears correctly
- [ ] Manual: Close panel in Never mode → verify everything hides cleanly
- [ ] Verify existing `SidebarContainerViewBrowserTest` tests still pass