### PR TITLE
Android: Remove Password Manager's redundant help/exit title icons

### DIFF
--- a/android/java/brave-res/menu/save_password_preferences_action_bar_menu.xml
+++ b/android/java/brave-res/menu/save_password_preferences_action_bar_menu.xml
@@ -21,15 +21,8 @@ found in the LICENSE file.
         app:actionViewClass="androidx.appcompat.widget.SearchView" />
 
     <item
-        android:id="@id/menu_id_targeted_help"
-        android:icon="@drawable/ic_help_24dp"
-        android:title="@string/menu_help"
-        app:showAsAction="ifRoom"/>
-
-    <item
         android:id="@+id/export_passwords"
         android:title="@string/password_settings_export_action_title"
         android:contentDescription="@string/password_settings_export_action_description"
         app:showAsAction="never"/>
-    <item android:id="@+id/close_menu_id" android:title="@string/menu_exit" android:contentDescription="@string/menu_exit" app:showAsAction="never"/>
 </menu>

--- a/android/java/brave-res/menu/save_password_preferences_action_bar_menu.xml
+++ b/android/java/brave-res/menu/save_password_preferences_action_bar_menu.xml
@@ -17,7 +17,7 @@ found in the LICENSE file.
         android:id="@+id/menu_id_search"
         android:icon="@drawable/ic_search"
         android:title="@string/search"
-        app:showAsAction="always"
+        app:showAsAction="ifRoom"
         app:actionViewClass="androidx.appcompat.widget.SearchView" />
 
     <item

--- a/android/java/org/chromium/chrome/browser/password_manager/settings/PasswordSettings.java
+++ b/android/java/org/chromium/chrome/browser/password_manager/settings/PasswordSettings.java
@@ -111,7 +111,6 @@ public class PasswordSettings extends ChromeBaseSettingsFragment
     private boolean mNoPasswords;
     private boolean mNoPasswordExceptions;
 
-    private /*@Nullable*/ MenuItem mHelpItem;
     private /*@Nullable*/ MenuItem mSearchItem;
 
     private @Nullable String mSearchQuery;
@@ -338,7 +337,6 @@ public class PasswordSettings extends ChromeBaseSettingsFragment
         menu.findItem(R.id.export_passwords).setVisible(false);
         mSearchItem = menu.findItem(R.id.menu_id_search);
         mSearchItem.setVisible(true);
-        mHelpItem = menu.findItem(R.id.menu_id_targeted_help);
         SearchUtils.initializeSearchView(
                 mSearchItem,
                 mSearchQuery,
@@ -355,14 +353,8 @@ public class PasswordSettings extends ChromeBaseSettingsFragment
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
-        int id = item.getItemId();
         if (SearchUtils.handleSearchNavigation(item, mSearchItem, mSearchQuery, getActivity())) {
             filterPasswords(null);
-            return true;
-        }
-        if (id == R.id.menu_id_targeted_help) {
-            getHelpAndFeedbackLauncher()
-                    .show(getActivity(), getString(R.string.help_context_passwords), null);
             return true;
         }
         return super.onOptionsItemSelected(item);
@@ -370,10 +362,6 @@ public class PasswordSettings extends ChromeBaseSettingsFragment
 
     private void filterPasswords(@Nullable String query) {
         mSearchQuery = query;
-        mHelpItem.setShowAsAction(
-                mSearchQuery == null
-                        ? MenuItem.SHOW_AS_ACTION_IF_ROOM
-                        : MenuItem.SHOW_AS_ACTION_NEVER);
         rebuildPasswordLists();
     }
 

--- a/android/javatests/org/chromium/chrome/browser/password_manager/settings/PasswordSettingsSearchTest.java
+++ b/android/javatests/org/chromium/chrome/browser/password_manager/settings/PasswordSettingsSearchTest.java
@@ -166,60 +166,6 @@ public class PasswordSettingsSearchTest {
         onView(withText(R.string.search)).check(matches(isDisplayed()));
     }
 
-    /**
-     * Check that searching doesn't push the help icon into the overflow menu permanently. On screen
-     * sizes where the help item starts out in the overflow menu, ensure it stays there.
-     */
-    @Test
-    @SmallTest
-    @Feature({"Preferences"})
-    public void testTriggeringSearchRestoresHelpIcon() {
-        mTestHelper.setPasswordSource(null);
-        mTestHelper.startPasswordSettingsFromMainSettings(mSettingsActivityTestRule);
-        // Use a more specific matcher that excludes section headers in LinearLayouts
-        onViewWaiting(
-                allOf(
-                        withText(R.string.password_manager_settings_title),
-                        not(withParent(isAssignableFrom(LinearLayout.class)))));
-
-        // Retrieve the initial status and ensure that the help option is there at all.
-        final AtomicReference<Boolean> helpInOverflowMenu = new AtomicReference<>(false);
-        onView(withId(R.id.menu_id_targeted_help))
-                .check(
-                        (helpMenuItem, e) -> {
-                            ActionMenuItemView view = (ActionMenuItemView) helpMenuItem;
-                            helpInOverflowMenu.set(view == null || !view.showsIcon());
-                        });
-        if (helpInOverflowMenu.get()) {
-            openActionBarOverflowOrOptionsMenu(
-                    InstrumentationRegistry.getInstrumentation().getTargetContext());
-            onView(withText(R.string.menu_help)).check(matches(isDisplayed()));
-            Espresso.pressBack(); // to close the Overflow menu.
-        } else {
-            onView(withId(R.id.menu_id_targeted_help)).check(matches(isDisplayed()));
-        }
-
-        // Trigger the search, close it and wait for UI to be restored.
-        onView(withSearchMenuIdOrText()).perform(click());
-        onView(withContentDescription(R.string.abc_action_bar_up_description)).perform(click());
-        // Use a more specific matcher that excludes section headers in LinearLayouts
-        onViewWaiting(
-                allOf(
-                        withText(R.string.password_manager_settings_title),
-                        not(withParent(isAssignableFrom(LinearLayout.class)))));
-
-        // Check that the help option is exactly where it was to begin with.
-        if (helpInOverflowMenu.get()) {
-            openActionBarOverflowOrOptionsMenu(
-                    InstrumentationRegistry.getInstrumentation().getTargetContext());
-            onView(withText(R.string.menu_help)).check(matches(isDisplayed()));
-            onView(withId(R.id.menu_id_targeted_help)).check(doesNotExist());
-        } else {
-            onView(withText(R.string.menu_help)).check(doesNotExist());
-            onView(withId(R.id.menu_id_targeted_help)).check(matches(isDisplayed()));
-        }
-    }
-
     /** Check that the search filters the list by name. */
     @Test
     @SmallTest
@@ -277,14 +223,6 @@ public class PasswordSettingsSearchTest {
                     .check(doesNotExist());
         }
         onView(withText(R.string.saved_passwords_none_text)).check(doesNotExist());
-        // Check that the section header for saved passwords is not present. Do not confuse it with
-        // the toolbar label which contains the same string, look for the one inside a linear
-        // layout.
-        onView(
-                        allOf(
-                                withParent(isAssignableFrom(LinearLayout.class)),
-                                withText(R.string.password_manager_settings_title)))
-                .check(doesNotExist());
         // Check the message for no result.
         onView(withText(R.string.password_no_result)).check(matches(isDisplayed()));
     }


### PR DESCRIPTION
Within the Password Manager UI, the title bar contained two redundant icons to the left of the title:

1. The help icon - since it only takes the user to the generic help page, this isn't particularly "helpful"
2. The 3 vertical dots simply display an exit option which is also redundant since the back arrow does the same thing.

Resolves brave/brave-browser#52765

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
