### PR TITLE
fix: replace NOTREACHED() crash with fallback in GetRegionPrecisionForName

### DIFF
--- a/components/brave_vpn/browser/connection/brave_vpn_region_data_manager.cc
+++ b/components/brave_vpn/browser/connection/brave_vpn_region_data_manager.cc
@@ -86,7 +86,9 @@ std::string BraveVPNRegionDataManager::GetRegionPrecisionForName(
       }
     }
   }
-  NOTREACHED();
+  // Region may not be found if the user's cached selection was removed from
+  // the server-side list. Fall back to country precision rather than crashing.
+  return brave_vpn::mojom::kRegionPrecisionCountry;
 }
 
 void BraveVPNRegionDataManager::SetFallbackDeviceRegion() {

--- a/components/brave_vpn/browser/connection/brave_vpn_region_data_manager.cc
+++ b/components/brave_vpn/browser/connection/brave_vpn_region_data_manager.cc
@@ -27,8 +27,7 @@ namespace brave_vpn {
 BraveVPNRegionDataManager::BraveVPNRegionDataManager(
     scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
     PrefService* local_prefs)
-    : url_loader_factory_(url_loader_factory), local_prefs_(local_prefs) {
-}
+    : url_loader_factory_(url_loader_factory), local_prefs_(local_prefs) {}
 
 BraveVPNRegionDataManager::~BraveVPNRegionDataManager() = default;
 


### PR DESCRIPTION
## Description

In modern Chromium, `NOTREACHED()` is equivalent to `CHECK(false)` — it crashes the browser in ALL builds (not just debug).

`GetRegionPrecisionForName()` is called during VPN connection with the user's selected region name. If the selected region was removed from the server-side list (stale cached selection, region data update without pref cleanup), the name won't match any entry and the browser crashes.

## Fix

Return `kRegionPrecisionCountry` as a safe default instead of crashing.

## Test

1. Select a VPN region, then simulate a server-side removal of that region
2. Attempt to connect
3. Before: crash. After: connects using country-level precision fallback.

Resolves brave/brave-browser#53253