### PR TITLE
(Wallet) Improve account name generation

### DIFF
--- a/android/java/org/chromium/chrome/browser/crypto_wallet/util/WalletUtils.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/util/WalletUtils.java
@@ -16,6 +16,7 @@ import org.chromium.base.Log;
 import org.chromium.brave_wallet.mojom.AccountId;
 import org.chromium.brave_wallet.mojom.AccountInfo;
 import org.chromium.brave_wallet.mojom.CoinType;
+import org.chromium.build.annotations.NullMarked;
 import org.chromium.chrome.R;
 import org.chromium.chrome.browser.app.BraveActivity;
 import org.chromium.chrome.browser.util.TabUtils;
@@ -23,23 +24,30 @@ import org.chromium.chrome.browser.util.TabUtils;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 
+@NullMarked
 public class WalletUtils {
     private static final String ACCOUNT_INFO = "accountInfo";
     private static final String TAG = "WalletUtils";
 
-    private static String getNewAccountPrefixForCoin(@CoinType.EnumType int coinType) {
+    private static String getNewAccountPrefixForCoin(@CoinType.EnumType final int coinType) {
         switch (coinType) {
-            case CoinType.ETH:
+            case CoinType.ETH -> {
                 return "Ethereum";
-            case CoinType.SOL:
+            }
+            case CoinType.SOL -> {
                 return "Solana";
-            case CoinType.FIL:
+            }
+            case CoinType.FIL -> {
                 return "Filecoin";
-            case CoinType.BTC:
+            }
+            case CoinType.BTC -> {
                 return "Bitcoin";
+            }
+            default -> {
+                assert false;
+                return "";
+            }
         }
-        assert false;
-        return "";
     }
 
     /**
@@ -52,7 +60,7 @@ public class WalletUtils {
      */
     @SuppressWarnings("NoStreams")
     public static String generateUniqueAccountName(
-            @CoinType.EnumType int coinType, AccountInfo[] accountInfos) {
+            @CoinType.EnumType final int coinType, final AccountInfo[] accountInfos) {
         final Context context = ContextUtils.getApplicationContext();
         final int sameCoinAccountCount =
                 (int) Arrays.stream(accountInfos)
@@ -119,7 +127,7 @@ public class WalletUtils {
         }
     }
 
-    public static void openWalletHelpCenter(Context context) {
+    public static void openWalletHelpCenter(@Nullable Context context) {
         if (context == null) return;
         TabUtils.openUrlInCustomTab(context, WalletConstants.WALLET_HELP_CENTER);
     }

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/util/WalletUtils.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/util/WalletUtils.java
@@ -19,14 +19,9 @@ import org.chromium.brave_wallet.mojom.CoinType;
 import org.chromium.chrome.R;
 import org.chromium.chrome.browser.app.BraveActivity;
 import org.chromium.chrome.browser.util.TabUtils;
-import org.chromium.mojo_base.mojom.TimeDelta;
 
 import java.nio.ByteBuffer;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
 import java.util.Arrays;
-import java.util.Date;
-import java.util.Locale;
 
 public class WalletUtils {
     private static final String ACCOUNT_INFO = "accountInfo";
@@ -45,11 +40,6 @@ public class WalletUtils {
         }
         assert false;
         return "";
-    }
-
-    public static String timeDeltaToDateString(TimeDelta timeDelta) {
-        DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd hh:mm a", Locale.getDefault());
-        return dateFormat.format(new Date(timeDelta.microseconds / 1000));
     }
 
     /**
@@ -86,15 +76,6 @@ public class WalletUtils {
             return false;
         }
         return accountIdsEqual(left.accountId, right.accountId);
-    }
-
-    public static void addAccountInfoToIntent(
-            @NonNull final Intent intent, @NonNull final AccountInfo accountInfo) {
-        ByteBuffer bb = accountInfo.serialize();
-        byte[] bytes = new byte[bb.remaining()];
-        bb.get(bytes);
-
-        intent.putExtra(ACCOUNT_INFO, bytes);
     }
 
     @Nullable

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/util/WalletUtils.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/util/WalletUtils.java
@@ -26,10 +26,7 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Date;
-import java.util.HashSet;
 import java.util.Locale;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 public class WalletUtils {
     private static final String ACCOUNT_INFO = "accountInfo";
@@ -55,31 +52,27 @@ public class WalletUtils {
         return dateFormat.format(new Date(timeDelta.microseconds / 1000));
     }
 
+    /**
+     * Generates a unique account name following the Desktop strategy: count existing accounts of
+     * the same coin type and use {@code count + 1} as the account number. This ensures the
+     * suggested name always increments based on total accounts, even if some were renamed.
+     *
+     * <p>Desktop implementation: {@code suggestNewAccountName} in {@code
+     * components/brave_wallet_ui/utils/address-utils.ts}.
+     */
     @SuppressWarnings("NoStreams")
     public static String generateUniqueAccountName(
             @CoinType.EnumType int coinType, AccountInfo[] accountInfos) {
-        Context context = ContextUtils.getApplicationContext();
-        if (context == null) {
-            Log.w(TAG, "Application context was null");
-            return "";
-        }
-        Set<String> allNames =
-                Arrays.stream(accountInfos)
-                        .map(acc -> acc.name)
-                        .collect(Collectors.toCollection(HashSet::new));
+        final Context context = ContextUtils.getApplicationContext();
+        final int sameCoinAccountCount =
+                (int) Arrays.stream(accountInfos)
+                        .filter(acc -> acc.accountId.coin == coinType)
+                        .count();
 
-        for (int number = 1; number < 1000; ++number) {
-            String accountName =
-                    context.getString(
-                            R.string.new_account_prefix,
-                            getNewAccountPrefixForCoin(coinType),
-                            String.valueOf(number));
-
-            if (!allNames.contains(accountName)) {
-                return accountName;
-            }
-        }
-        return "";
+        return context.getString(
+                R.string.new_account_prefix,
+                getNewAccountPrefixForCoin(coinType),
+                String.valueOf(sameCoinAccountCount + 1));
     }
 
     public static boolean accountIdsEqual(AccountId left, AccountId right) {

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/util/WalletUtils.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/util/WalletUtils.java
@@ -63,9 +63,10 @@ public class WalletUtils {
             @CoinType.EnumType final int coinType, final AccountInfo[] accountInfos) {
         final Context context = ContextUtils.getApplicationContext();
         final int sameCoinAccountCount =
-                (int) Arrays.stream(accountInfos)
-                        .filter(acc -> acc.accountId.coin == coinType)
-                        .count();
+                (int)
+                        Arrays.stream(accountInfos)
+                                .filter(acc -> acc.accountId.coin == coinType)
+                                .count();
 
         return context.getString(
                 R.string.new_account_prefix,


### PR DESCRIPTION
## Resolves https://github.com/brave/brave-browser/issues/37400

Improves account name generation suggestion following the same logic adopted by Desktop.
Improves `WalletUtils` class removing old unused methods and adding `@NullMarked` annotation.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

## Test Plan

For each coin type — Ethereum, Solana, Filecoin, Bitcoin — repeat:

1. Open Wallet → Accounts → Add account → pick the coin.
2. The pre-filled "Account name" field should show <Coin> 2 (since onboarding created <Coin> 1).
3. Confirm. Add another → field should show <Coin> 3.
4. Add a third → <Coin> 4.

✅ Expected: the suggested number is always (count of accounts for that coin) + 1.
