### PR TITLE
wip [Sync] [AI Chat] (3 of n) Add SyncMetadataStore to AIChatDatabase

### DIFF
--- a/components/ai_chat/core/browser/BUILD.gn
+++ b/components/ai_chat/core/browser/BUILD.gn
@@ -107,6 +107,7 @@ static_library("browser") {
   public_deps = [
     "//base",
     "//components/os_crypt/async/common",
+    "//components/sync/model",
   ]
 
   deps = [
@@ -134,6 +135,7 @@ static_library("browser") {
     "//components/keyed_service/core",
     "//components/os_crypt/async/browser",
     "//components/prefs",
+    "//components/sync/protocol",
     "//components/update_client",
     "//components/user_prefs",
     "//mojo/public/cpp/bindings",
@@ -216,6 +218,7 @@ source_set("unit_tests") {
     "//components/history/core/test",
     "//components/os_crypt/async/browser:test_support",
     "//components/prefs:test_support",
+    "//components/sync/protocol",
     "//components/sync_preferences:test_support",
     "//net/traffic_annotation:test_support",
     "//services/network:test_support",

--- a/components/ai_chat/core/browser/DEPS
+++ b/components/ai_chat/core/browser/DEPS
@@ -11,6 +11,8 @@ include_rules = [
   "+components/keyed_service",
   "+components/os_crypt/async",
   "+components/prefs",
+  "+components/sync/model",
+  "+components/sync/protocol",
   "+components/sync_preferences/testing_pref_service_syncable.h",
   "+crypto",
   "+services/network/public",

--- a/components/ai_chat/core/browser/ai_chat_database.cc
+++ b/components/ai_chat/core/browser/ai_chat_database.cc
@@ -26,6 +26,9 @@
 #include "brave/components/ai_chat/core/common/proto_conversion.h"
 #include "brave/components/ai_chat/core/proto/store.pb.h"
 #include "components/os_crypt/async/common/encryptor.h"
+#include "components/sync/model/metadata_batch.h"
+#include "components/sync/protocol/data_type_state.pb.h"
+#include "components/sync/protocol/entity_metadata.pb.h"
 #include "sql/init_status.h"
 #include "sql/meta_table.h"
 #include "sql/statement.h"
@@ -176,6 +179,9 @@ bool MigrateFrom9to10(sql::Database* db) {
       db->GetUniqueStatement(kAddExtractedTextColumnQuery));
   return statement.is_valid() && statement.Run();
 }
+
+// Key in sql::MetaTable for the serialized DataTypeState.
+const char kAIChatDataTypeStateKey[] = "ai_chat_data_type_state";
 
 }  // namespace
 
@@ -335,7 +341,6 @@ sql::InitStatus AIChatDatabase::InitInternal() {
       }
       current_version = 10;
     }
-
     // Migration unsuccessful, raze the database and re-init
     if (!migration_success) {
       transaction.Rollback();
@@ -1824,7 +1829,142 @@ bool AIChatDatabase::CreateSchema() {
     return false;
   }
 
+  // Sync metadata table for AI Chat sync.
+  static constexpr char kCreateSyncMetadataTableQuery[] =
+      "CREATE TABLE IF NOT EXISTS ai_chat_sync_metadata("
+      "storage_key TEXT PRIMARY KEY NOT NULL,"
+      "value BLOB NOT NULL"
+      ")";
+  CHECK(GetDB().IsSQLValid(kCreateSyncMetadataTableQuery));
+  if (!GetDB().Execute(kCreateSyncMetadataTableQuery)) {
+    return false;
+  }
+
   return true;
+}
+
+bool AIChatDatabase::GetAllSyncMetadata(syncer::MetadataBatch* metadata_batch) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  if (!LazyInit()) {
+    return false;
+  }
+  DCHECK(metadata_batch);
+  if (!GetAllEntityMetadata(metadata_batch)) {
+    return false;
+  }
+  sync_pb::DataTypeState data_type_state;
+  if (!GetDataTypeState(&data_type_state)) {
+    return false;
+  }
+  metadata_batch->SetDataTypeState(data_type_state);
+  return true;
+}
+
+bool AIChatDatabase::ClearAllEntityMetadata() {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  if (!LazyInit()) {
+    return false;
+  }
+  sql::Statement s(
+      GetDB().GetUniqueStatement("DELETE FROM ai_chat_sync_metadata"));
+  return s.Run();
+}
+
+bool AIChatDatabase::UpdateEntityMetadata(
+    syncer::DataType data_type,
+    const std::string& storage_key,
+    const sync_pb::EntityMetadata& metadata) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  DCHECK_EQ(data_type, syncer::AI_CHAT_CONVERSATION);
+  DCHECK(!storage_key.empty());
+  if (!LazyInit()) {
+    return false;
+  }
+  sql::Statement s(
+      GetDB().GetUniqueStatement("INSERT OR REPLACE INTO ai_chat_sync_metadata "
+                                 "(storage_key, value) VALUES(?, ?)"));
+  s.BindString(0, storage_key);
+  s.BindString(1, metadata.SerializeAsString());
+  return s.Run();
+}
+
+bool AIChatDatabase::ClearEntityMetadata(syncer::DataType data_type,
+                                         const std::string& storage_key) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  DCHECK_EQ(data_type, syncer::AI_CHAT_CONVERSATION);
+  DCHECK(!storage_key.empty());
+  if (!LazyInit()) {
+    return false;
+  }
+  sql::Statement s(GetDB().GetUniqueStatement(
+      "DELETE FROM ai_chat_sync_metadata WHERE storage_key=?"));
+  s.BindString(0, storage_key);
+  return s.Run();
+}
+
+bool AIChatDatabase::UpdateDataTypeState(
+    syncer::DataType data_type,
+    const sync_pb::DataTypeState& data_type_state) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  DCHECK_EQ(data_type, syncer::AI_CHAT_CONVERSATION);
+  if (!LazyInit()) {
+    return false;
+  }
+  // Store in meta table as the init creates it.
+  sql::MetaTable meta_table;
+  if (!meta_table.Init(&GetDB(), kCurrentDatabaseVersion,
+                       kCompatibleDatabaseVersionNumber)) {
+    return false;
+  }
+  return meta_table.SetValue(kAIChatDataTypeStateKey,
+                             data_type_state.SerializeAsString());
+}
+
+bool AIChatDatabase::ClearDataTypeState(syncer::DataType data_type) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  DCHECK_EQ(data_type, syncer::AI_CHAT_CONVERSATION);
+  if (!LazyInit()) {
+    return false;
+  }
+  sql::MetaTable meta_table;
+  if (!meta_table.Init(&GetDB(), kCurrentDatabaseVersion,
+                       kCompatibleDatabaseVersionNumber)) {
+    return false;
+  }
+  return meta_table.DeleteKey(kAIChatDataTypeStateKey);
+}
+
+bool AIChatDatabase::GetAllEntityMetadata(
+    syncer::MetadataBatch* metadata_batch) {
+  DCHECK(metadata_batch);
+  sql::Statement s(GetDB().GetUniqueStatement(
+      "SELECT storage_key, value FROM ai_chat_sync_metadata"));
+  while (s.Step()) {
+    std::string storage_key = s.ColumnString(0);
+    std::string_view serialized_metadata = s.ColumnStringView(1);
+    auto entity_metadata = std::make_unique<sync_pb::EntityMetadata>();
+    if (!entity_metadata->ParseFromString(serialized_metadata)) {
+      DLOG(WARNING) << "Failed to deserialize AI_CHAT_CONVERSATION "
+                       "sync_pb::EntityMetadata.";
+      return false;
+    }
+    metadata_batch->AddMetadata(storage_key, std::move(entity_metadata));
+  }
+  return true;
+}
+
+bool AIChatDatabase::GetDataTypeState(sync_pb::DataTypeState* state) {
+  sql::MetaTable meta_table;
+  if (!meta_table.Init(&GetDB(), kCurrentDatabaseVersion,
+                       kCompatibleDatabaseVersionNumber)) {
+    return false;
+  }
+  std::string serialized_state;
+  if (!meta_table.GetValue(kAIChatDataTypeStateKey, &serialized_state)) {
+    *state = sync_pb::DataTypeState();
+    return true;
+  }
+  return state->ParseFromString(serialized_state);
 }
 
 }  // namespace ai_chat

--- a/components/ai_chat/core/browser/ai_chat_database.h
+++ b/components/ai_chat/core/browser/ai_chat_database.h
@@ -16,8 +16,13 @@
 #include "brave/components/ai_chat/core/common/mojom/ai_chat.mojom-forward.h"
 #include "brave/components/ai_chat/core/common/mojom/common.mojom-forward.h"
 #include "components/os_crypt/async/common/encryptor.h"
+#include "components/sync/model/sync_metadata_store.h"
 #include "sql/database.h"
 #include "sql/init_status.h"
+
+namespace syncer {
+class MetadataBatch;
+}  // namespace syncer
 
 namespace ai_chat {
 
@@ -30,13 +35,13 @@ extern const int kCurrentDatabaseVersion;
 // should be handled with removal and re-adding so that other classes can make
 // decisions about how it affects the rest of history.
 // All data should be stored encrypted.
-class AIChatDatabase {
+class AIChatDatabase : public syncer::SyncMetadataStore {
  public:
   AIChatDatabase(const base::FilePath& db_file_path,
                  scoped_refptr<os_crypt_async::Encryptor> encryptor);
   AIChatDatabase(const AIChatDatabase&) = delete;
   AIChatDatabase& operator=(const AIChatDatabase&) = delete;
-  virtual ~AIChatDatabase();
+  ~AIChatDatabase() override;
 
   // Gets lightweight metadata for all conversations. No high-memory-consuming
   // data is returned.
@@ -94,6 +99,23 @@ class AIChatDatabase {
   virtual bool DeleteAssociatedWebContent(std::optional<base::Time> begin_time,
                                           std::optional<base::Time> end_time);
 
+  // Reads all sync metadata (entity metadata + data type state) into the batch.
+  bool GetAllSyncMetadata(syncer::MetadataBatch* metadata_batch);
+
+  // Deletes all entity metadata (but not data type state).
+  bool ClearAllEntityMetadata();
+
+  // syncer::SyncMetadataStore:
+  bool UpdateEntityMetadata(syncer::DataType data_type,
+                            const std::string& storage_key,
+                            const sync_pb::EntityMetadata& metadata) override;
+  bool ClearEntityMetadata(syncer::DataType data_type,
+                           const std::string& storage_key) override;
+  bool UpdateDataTypeState(
+      syncer::DataType data_type,
+      const sync_pb::DataTypeState& data_type_state) override;
+  bool ClearDataTypeState(syncer::DataType data_type) override;
+
  private:
   friend class AIChatDatabaseTest;
   friend class AIChatDatabaseMigrationTest;
@@ -110,6 +132,9 @@ class AIChatDatabase {
       std::string_view conversation_id);
   std::vector<mojom::ContentArchivePtr> GetArchiveContentsForConversation(
       std::string_view conversation_uuid);
+
+  bool GetAllEntityMetadata(syncer::MetadataBatch* metadata_batch);
+  bool GetDataTypeState(sync_pb::DataTypeState* state);
 
   std::string DecryptColumnToString(sql::Statement& statement, int index);
   std::optional<std::string> DecryptOptionalColumnToString(

--- a/components/ai_chat/core/browser/ai_chat_database_unittest.cc
+++ b/components/ai_chat/core/browser/ai_chat_database_unittest.cc
@@ -28,6 +28,9 @@
 #include "brave/components/ai_chat/core/common/mojom/ai_chat.mojom.h"
 #include "brave/components/ai_chat/core/common/mojom/common.mojom.h"
 #include "components/os_crypt/async/browser/test_utils.h"
+#include "components/sync/model/metadata_batch.h"
+#include "components/sync/protocol/data_type_state.pb.h"
+#include "components/sync/protocol/entity_metadata.pb.h"
 #include "sql/init_status.h"
 #include "sql/meta_table.h"
 #include "sql/test/test_helpers.h"
@@ -1169,6 +1172,105 @@ TEST_P(AIChatDatabaseTest, DeleteConversationEntryWithAssociatedContent) {
 
   // Verify the middle turn (without associated content) remains
   EXPECT_EQ(archive_result->entries[0]->uuid.value(), history[1]->uuid.value());
+}
+
+// Sync metadata tests (non-parameterized, use the same fixture setup pattern).
+class AIChatDatabaseSyncTest : public testing::Test {
+ public:
+  void SetUp() override {
+    CHECK(temp_directory_.CreateUniqueTempDir());
+    os_crypt_ = os_crypt_async::GetTestOSCryptAsyncForTesting(
+        /*is_sync_for_unittests=*/true);
+    base::test::TestFuture<scoped_refptr<os_crypt_async::Encryptor>> future;
+    os_crypt_->GetInstance(future.GetCallback());
+    db_ = std::make_unique<AIChatDatabase>(db_file_path(), future.Take());
+  }
+
+  void TearDown() override {
+    db_.reset();
+    CHECK(temp_directory_.Delete());
+  }
+
+  base::FilePath db_file_path() {
+    return temp_directory_.GetPath().AppendASCII("test_sync_ai_chat.db");
+  }
+
+ protected:
+  base::test::TaskEnvironment task_environment_{
+      base::test::TaskEnvironment::TimeSource::MOCK_TIME};
+  base::ScopedTempDir temp_directory_;
+  std::unique_ptr<os_crypt_async::OSCryptAsync> os_crypt_;
+  std::unique_ptr<AIChatDatabase> db_;
+};
+
+TEST_F(AIChatDatabaseSyncTest, UpdateAndGetEntityMetadata) {
+  sync_pb::EntityMetadata metadata;
+  metadata.set_creation_time(12345);
+  metadata.set_sequence_number(1);
+
+  EXPECT_TRUE(db_->UpdateEntityMetadata(syncer::AI_CHAT_CONVERSATION,
+                                        "conv-uuid-1", metadata));
+
+  syncer::MetadataBatch batch;
+  ASSERT_TRUE(db_->GetAllSyncMetadata(&batch));
+  ASSERT_EQ(batch.GetAllMetadata().size(), 1u);
+
+  const auto& entry = batch.GetAllMetadata().begin();
+  EXPECT_EQ(entry->first, "conv-uuid-1");
+  EXPECT_EQ(entry->second->creation_time(), 12345);
+}
+
+TEST_F(AIChatDatabaseSyncTest, ClearEntityMetadata) {
+  sync_pb::EntityMetadata metadata;
+  metadata.set_creation_time(1);
+  db_->UpdateEntityMetadata(syncer::AI_CHAT_CONVERSATION, "key1", metadata);
+  db_->UpdateEntityMetadata(syncer::AI_CHAT_CONVERSATION, "key2", metadata);
+
+  EXPECT_TRUE(db_->ClearEntityMetadata(syncer::AI_CHAT_CONVERSATION, "key1"));
+
+  syncer::MetadataBatch batch;
+  ASSERT_TRUE(db_->GetAllSyncMetadata(&batch));
+  EXPECT_EQ(batch.GetAllMetadata().size(), 1u);
+  EXPECT_EQ(batch.GetAllMetadata().begin()->first, "key2");
+}
+
+TEST_F(AIChatDatabaseSyncTest, ClearAllEntityMetadata) {
+  sync_pb::EntityMetadata metadata;
+  metadata.set_creation_time(1);
+  db_->UpdateEntityMetadata(syncer::AI_CHAT_CONVERSATION, "key1", metadata);
+  db_->UpdateEntityMetadata(syncer::AI_CHAT_CONVERSATION, "key2", metadata);
+
+  EXPECT_TRUE(db_->ClearAllEntityMetadata());
+
+  syncer::MetadataBatch batch;
+  ASSERT_TRUE(db_->GetAllSyncMetadata(&batch));
+  EXPECT_TRUE(batch.GetAllMetadata().empty());
+}
+
+TEST_F(AIChatDatabaseSyncTest, UpdateAndGetDataTypeState) {
+  sync_pb::DataTypeState state;
+  state.set_initial_sync_state(sync_pb::DataTypeState::INITIAL_SYNC_DONE);
+
+  EXPECT_TRUE(db_->UpdateDataTypeState(syncer::AI_CHAT_CONVERSATION, state));
+
+  syncer::MetadataBatch batch;
+  ASSERT_TRUE(db_->GetAllSyncMetadata(&batch));
+  EXPECT_EQ(batch.GetDataTypeState().initial_sync_state(),
+            sync_pb::DataTypeState::INITIAL_SYNC_DONE);
+}
+
+TEST_F(AIChatDatabaseSyncTest, ClearDataTypeState) {
+  sync_pb::DataTypeState state;
+  state.set_initial_sync_state(sync_pb::DataTypeState::INITIAL_SYNC_DONE);
+  db_->UpdateDataTypeState(syncer::AI_CHAT_CONVERSATION, state);
+
+  EXPECT_TRUE(db_->ClearDataTypeState(syncer::AI_CHAT_CONVERSATION));
+
+  syncer::MetadataBatch batch;
+  ASSERT_TRUE(db_->GetAllSyncMetadata(&batch));
+  // After clearing, GetDataTypeState returns default (no initial sync).
+  EXPECT_EQ(batch.GetDataTypeState().initial_sync_state(),
+            sync_pb::DataTypeState::INITIAL_SYNC_STATE_UNSPECIFIED);
 }
 
 // Test the migration for each version upgrade


### PR DESCRIPTION
Implements `syncer::SyncMetadataStore` on `AIChatDatabase` so the sync
infrastructure can persist entity metadata and data type state alongside
conversation data.

- New `ai_chat_sync_metadata` table (`storage_key TEXT PK`, `value BLOB`),
  created in `CreateSchema()`. No schema version bump or migration is
  needed: adding a new table doesn't modify existing tables, so older
  databases get it created via `CREATE TABLE IF NOT EXISTS` on init.
- `GetAllSyncMetadata` / `UpdateEntityMetadata` / `ClearEntityMetadata` /
  `UpdateDataTypeState` / `ClearDataTypeState`
- `DataTypeState` serialized into `sql::MetaTable`
- Unit tests for the metadata store (`AIChatDatabaseSyncTest`)

Spec:
- https://github.com/brave/brave-core/blob/aichat-sync-flow/docs/aichat-sync.md

Based on:
- https://github.com/brave/brave-core/pull/35028
- https://github.com/brave/brave-core/pull/35242

Series:
- https://github.com/brave/brave-browser/issues/53978
- https://github.com/brave/brave-core/pull/35028
- https://github.com/brave/brave-core/pull/35242
- https://github.com/brave/brave-core/pull/35029
- https://github.com/brave/brave-core/pull/35030
- https://github.com/brave/go-sync/pull/427 (server)
