### PR TITLE
[ads] Multiple tabs can be in focus at the same time for multiple windows

### DIFF
--- a/browser/brave_ads/tabs/BUILD.gn
+++ b/browser/brave_ads/tabs/BUILD.gn
@@ -35,6 +35,13 @@ source_set("tabs") {
     "//components/sessions",
     "//ui/base",
   ]
+
+  if (!is_android) {
+    deps += [
+      "//chrome/browser/ui/browser_window",
+      "//components/tabs:public",
+    ]
+  }
 }
 
 source_set("browser_tests") {

--- a/browser/brave_ads/tabs/ads_tab_helper.cc
+++ b/browser/brave_ads/tabs/ads_tab_helper.cc
@@ -27,6 +27,9 @@
 #if !BUILDFLAG(IS_ANDROID)
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/browser_list.h"
+#include "chrome/browser/ui/browser_window/public/browser_window_interface.h"
+#include "chrome/browser/ui/browser_window/public/browser_window_interface_iterator.h"
+#include "components/tabs/public/tab_interface.h"
 #endif
 
 namespace brave_ads {
@@ -88,9 +91,11 @@ AdsTabHelper::AdsTabHelper(content::WebContents* const web_contents)
 #if !BUILDFLAG(IS_ANDROID)
   // See `application_state_monitor_android.h` for Android.
   BrowserList::AddObserver(this);
-#endif  // !BUILDFLAG(IS_ANDROID)
 
-  MaybeSetBrowserIsActive();
+  MaybeSetInitialBrowserIsActive();
+#else
+  MaybeSetBrowserIsActive(/*browser_window=*/nullptr);
+#endif  // !BUILDFLAG(IS_ANDROID)
 
   OnVisibilityChanged(web_contents->GetVisibility());
 }
@@ -121,7 +126,17 @@ bool AdsTabHelper::IsVisible() const {
   return is_web_contents_visible_ && is_browser_active_.value_or(false);
 }
 
-void AdsTabHelper::MaybeSetBrowserIsActive() {
+void AdsTabHelper::MaybeSetBrowserIsActive(
+    const BrowserWindowInterface* const browser_window) {
+#if !BUILDFLAG(IS_ANDROID)
+  const tabs::TabInterface* const tab =
+      tabs::TabInterface::MaybeGetFromContents(web_contents());
+  if (tab && tab->GetBrowserWindowInterface() != browser_window) {
+    // Not this tab's browser window.
+    return;
+  }
+#endif
+
   if (is_browser_active_.has_value() && *is_browser_active_) {
     // Already active.
     return;
@@ -136,7 +151,17 @@ void AdsTabHelper::MaybeSetBrowserIsActive() {
   MaybeNotifyTabDidChange();
 }
 
-void AdsTabHelper::MaybeSetBrowserIsNoLongerActive() {
+void AdsTabHelper::MaybeSetBrowserIsNoLongerActive(
+    const BrowserWindowInterface* const browser_window) {
+#if !BUILDFLAG(IS_ANDROID)
+  const tabs::TabInterface* const tab =
+      tabs::TabInterface::MaybeGetFromContents(web_contents());
+  if (tab && tab->GetBrowserWindowInterface() != browser_window) {
+    // Not this tab's browser window.
+    return;
+  }
+#endif
+
   if (is_browser_active_.has_value() && !*is_browser_active_) {
     // Already inactive.
     return;
@@ -439,15 +464,52 @@ void AdsTabHelper::WebContentsDestroyed() {
 }
 
 #if !BUILDFLAG(IS_ANDROID)
-// TODO(https://github.com/brave/brave-browser/issues/24970): Decouple
-// BrowserListObserver.
+void AdsTabHelper::MaybeSetInitialBrowserIsActive() {
+  // Only mark the browser as active if this tab belongs to the currently active
+  // browser window. Tabs opened in background windows must start inactive.
+  const tabs::TabInterface* const tab =
+      tabs::TabInterface::MaybeGetFromContents(web_contents());
+  if (!tab) {
+    return;
+  }
 
-void AdsTabHelper::OnBrowserSetLastActive(Browser* /*browser*/) {
-  MaybeSetBrowserIsActive();
+  const BrowserWindowInterface* const browser_window =
+      tab->GetBrowserWindowInterface();
+  if (!browser_window) {
+    return;
+  }
+
+  if (browser_window->IsActive()) {
+    MaybeSetBrowserIsActive(browser_window);
+  }
 }
 
-void AdsTabHelper::OnBrowserNoLongerActive(Browser* /*browser*/) {
-  MaybeSetBrowserIsNoLongerActive();
+void AdsTabHelper::OnBrowserRemoved(Browser* const /*browser*/) {
+  // `BrowserListObserver::OnBrowserSetLastActive` is not automatically called
+  // when a browser closes, so check whether our browser is now the last active.
+  const tabs::TabInterface* const tab =
+      tabs::TabInterface::MaybeGetFromContents(web_contents());
+  if (!tab) {
+    return;
+  }
+
+  const BrowserWindowInterface* const browser_window =
+      tab->GetBrowserWindowInterface();
+  if (!browser_window) {
+    return;
+  }
+
+  if (GetLastActiveBrowserWindowInterfaceWithAnyProfile() == browser_window) {
+    MaybeSetBrowserIsActive(browser_window);
+  }
+}
+
+void AdsTabHelper::OnBrowserSetLastActive(Browser* const browser) {
+  MaybeSetBrowserIsActive(browser);
+}
+
+void AdsTabHelper::OnBrowserNoLongerActive(Browser* const browser) {
+  MaybeSetBrowserIsNoLongerActive(browser);
 }
 #endif
 

--- a/browser/brave_ads/tabs/ads_tab_helper.h
+++ b/browser/brave_ads/tabs/ads_tab_helper.h
@@ -24,6 +24,7 @@
 #endif
 
 class Browser;
+class BrowserWindowInterface;
 class GURL;
 
 
@@ -55,8 +56,9 @@ class AdsTabHelper final : public content::WebContentsObserver,
 
   bool IsVisible() const;
 
-  void MaybeSetBrowserIsActive();
-  void MaybeSetBrowserIsNoLongerActive();
+  void MaybeSetBrowserIsActive(const BrowserWindowInterface* browser_window);
+  void MaybeSetBrowserIsNoLongerActive(
+      const BrowserWindowInterface* browser_window);
 
   void ProcessNavigation();
   void ResetNavigationState();
@@ -103,7 +105,13 @@ class AdsTabHelper final : public content::WebContentsObserver,
   void WebContentsDestroyed() override;
 
 #if !BUILDFLAG(IS_ANDROID)
+  void MaybeSetInitialBrowserIsActive();
+
+  // TODO(https://github.com/brave/brave-browser/issues/24970): Decouple
+  // BrowserListObserver from AdsTabHelper.
+
   // BrowserListObserver:
+  void OnBrowserRemoved(Browser* browser) override;
   void OnBrowserSetLastActive(Browser* browser) override;
   void OnBrowserNoLongerActive(Browser* browser) override;
 #endif

--- a/browser/brave_ads/tabs/ads_tab_helper_browsertest.cc
+++ b/browser/brave_ads/tabs/ads_tab_helper_browsertest.cc
@@ -39,6 +39,7 @@
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/browser_commands.h"
 #include "chrome/browser/ui/browser_tabstrip.h"
+#include "chrome/browser/ui/browser_window.h"
 #include "chrome/common/pref_names.h"
 #include "chrome/test/base/chrome_test_utils.h"
 #include "chrome/test/base/in_process_browser_test.h"
@@ -522,22 +523,151 @@ IN_PROC_BROWSER_TEST_F(BraveAdsTabHelperTest,
   SimulateHttpStatusCodePage(net::HTTP_OK);
 }
 
+IN_PROC_BROWSER_TEST_F(BraveAdsTabHelperTest,
+                       NotifyTabHtmlContentDidChangeForRewardsUser) {
+  GetPrefs()->SetBoolean(brave_rewards::prefs::kEnabled, true);
+
+  base::test::TestFuture<void> future;
+  EXPECT_CALL(
+      GetAdsServiceMock(),
+      NotifyTabHtmlContentDidChange(
+          TabId(), RedirectChainExpectation(kMultiPageApplicationWebpage),
+          kMultiPageApplicationWebpageHtmlContent))
+      .WillOnce(base::test::RunOnceClosure(future.GetCallback()));
+  NavigateToRelativeURL(kMultiPageApplicationWebpage,
+                        /*has_user_gesture=*/true);
+  ASSERT_TRUE(future.Wait());
+}
+
+IN_PROC_BROWSER_TEST_F(
+    BraveAdsTabHelperTest,
+    NotifyTabHtmlContentDidChangeWithEmptyHtmlForNonRewardsUser) {
+  GetPrefs()->SetBoolean(brave_rewards::prefs::kEnabled, false);
+
+  base::test::TestFuture<void> future;
+  EXPECT_CALL(
+      GetAdsServiceMock(),
+      NotifyTabHtmlContentDidChange(
+          TabId(), RedirectChainExpectation(kMultiPageApplicationWebpage),
+          /*html=*/::testing::IsEmpty()))
+      .WillOnce(base::test::RunOnceClosure(future.GetCallback()));
+  NavigateToRelativeURL(kMultiPageApplicationWebpage,
+                        /*has_user_gesture=*/true);
+  ASSERT_TRUE(future.Wait());
+}
+
+IN_PROC_BROWSER_TEST_F(BraveAdsTabHelperTest,
+                       DoNotNotifyTabHtmlContentDidChangeIfTabWasRestored) {
+  GetPrefs()->SetBoolean(brave_rewards::prefs::kEnabled, true);
+
+  base::test::TestFuture<void> future;
+  EXPECT_CALL(GetAdsServiceMock(), NotifyTabHtmlContentDidChange)
+      .WillOnce(base::test::RunOnceClosure(future.GetCallback()));
+  NavigateToRelativeURL(kMultiPageApplicationWebpage,
+                        /*has_user_gesture=*/true);
+  ASSERT_TRUE(future.Wait());
+  ::testing::Mock::VerifyAndClearExpectations(&GetAdsServiceMock());
+
+  // Must occur before the browser is closed.
+  Profile* const profile = GetProfile();
+  AdsServiceMock& ads_service_mock = GetAdsServiceMock();
+
+  const ScopedKeepAlive scoped_keep_alive(KeepAliveOrigin::SESSION_RESTORE,
+                                          KeepAliveRestartOption::DISABLED);
+  const ScopedProfileKeepAlive scoped_profile_keep_alive(
+      profile, ProfileKeepAliveOrigin::kSessionRestore);
+  CloseBrowserSynchronously(browser());
+
+  // We should not notify about changes to the tab's HTML content, as the
+  // session will be restored and the tab will reload.
+  EXPECT_CALL(ads_service_mock, NotifyTabHtmlContentDidChange).Times(0);
+  RestoreBrowser(profile);
+
+  EXPECT_TRUE(WaitForActiveWebContentsToLoad());
+}
+
+IN_PROC_BROWSER_TEST_F(
+    BraveAdsTabHelperTest,
+    DoNotNotifyTabHtmlContentDidChangeForPreviouslyCommittedNavigation) {
+  GetPrefs()->SetBoolean(brave_rewards::prefs::kEnabled, true);
+
+  base::test::TestFuture<void> future;
+  EXPECT_CALL(GetAdsServiceMock(), NotifyTabHtmlContentDidChange)
+      .WillOnce(base::test::RunOnceClosure(future.GetCallback()));
+  NavigateToRelativeURL(kMultiPageApplicationWebpage,
+                        /*has_user_gesture=*/true);
+  ASSERT_TRUE(future.Wait());
+  ::testing::Mock::VerifyAndClearExpectations(&GetAdsServiceMock());
+
+  EXPECT_CALL(GetAdsServiceMock(), NotifyTabHtmlContentDidChange).Times(0);
+  GoBack();
+  GoForward();
+  Reload();
+
+  EXPECT_TRUE(WaitForActiveWebContentsToLoad());
+}
+
+IN_PROC_BROWSER_TEST_F(
+    BraveAdsTabHelperTest,
+    DoNotNotifyTabHtmlContentDidChangeForHttpClientErrorResponsePage) {
+  GetPrefs()->SetBoolean(brave_rewards::prefs::kEnabled, true);
+
+  EXPECT_CALL(GetAdsServiceMock(), NotifyTabHtmlContentDidChange).Times(0);
+  SimulateHttpStatusCodePage(net::HTTP_NOT_FOUND);
+}
+
+IN_PROC_BROWSER_TEST_F(
+    BraveAdsTabHelperTest,
+    DoNotNotifyTabHtmlContentDidChangeForHttpServerErrorResponsePage) {
+  GetPrefs()->SetBoolean(brave_rewards::prefs::kEnabled, true);
+
+  EXPECT_CALL(GetAdsServiceMock(), NotifyTabHtmlContentDidChange).Times(0);
+  SimulateHttpStatusCodePage(net::HTTP_INTERNAL_SERVER_ERROR);
+}
+
+IN_PROC_BROWSER_TEST_F(BraveAdsTabHelperTest,
+                       NotifyTabHtmlContentDidChangeForSameDocumentNavigation) {
+  GetPrefs()->SetBoolean(brave_rewards::prefs::kEnabled, true);
+
+  {
+    base::test::TestFuture<void> future;
+    EXPECT_CALL(GetAdsServiceMock(), NotifyTabHtmlContentDidChange)
+        .WillOnce(base::test::RunOnceClosure(future.GetCallback()));
+    NavigateToRelativeURL(kSinglePageApplicationWebpage,
+                          /*has_user_gesture=*/true);
+    ASSERT_TRUE(future.Wait());
+    ::testing::Mock::VerifyAndClearExpectations(&GetAdsServiceMock());
+  }
+
+  {
+    base::test::TestFuture<void> future;
+    EXPECT_CALL(GetAdsServiceMock(),
+                NotifyTabHtmlContentDidChange(
+                    TabId(), ::testing::Contains(FileName("same_document")),
+                    kSinglePageApplicationWebpageHtmlContent))
+        .WillOnce(base::test::RunOnceClosure(future.GetCallback()));
+    SimulateClick(kSinglePageApplicationClickSelector,
+                  /*has_user_gesture=*/true);
+    ASSERT_TRUE(future.Wait());
+  }
+}
+
 IN_PROC_BROWSER_TEST_F(
     BraveAdsTabHelperTest,
     NotifyTabTextContentDidChangeForRewardsUserOptedInToNotificationAds) {
   GetPrefs()->SetBoolean(brave_rewards::prefs::kEnabled, true);
   GetPrefs()->SetBoolean(prefs::kOptedInToNotificationAds, true);
 
-  base::RunLoop run_loop;
+  base::test::TestFuture<void> future;
   EXPECT_CALL(
       GetAdsServiceMock(),
       NotifyTabTextContentDidChange(
           TabId(), RedirectChainExpectation(kMultiPageApplicationWebpage),
           kMultiPageApplicationWebpageTextContent))
-      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
+      .WillOnce(base::test::RunOnceClosure(future.GetCallback()));
   NavigateToRelativeURL(kMultiPageApplicationWebpage,
                         /*has_user_gesture=*/true);
-  run_loop.Run();
+  ASSERT_TRUE(future.Wait());
 }
 
 IN_PROC_BROWSER_TEST_F(BraveAdsTabHelperTest,
@@ -576,12 +706,12 @@ IN_PROC_BROWSER_TEST_F(BraveAdsTabHelperTest,
   GetPrefs()->SetBoolean(brave_rewards::prefs::kEnabled, true);
   GetPrefs()->SetBoolean(prefs::kOptedInToNotificationAds, true);
 
-  base::RunLoop run_loop;
+  base::test::TestFuture<void> future;
   EXPECT_CALL(GetAdsServiceMock(), NotifyTabTextContentDidChange)
-      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
+      .WillOnce(base::test::RunOnceClosure(future.GetCallback()));
   NavigateToRelativeURL(kMultiPageApplicationWebpage,
                         /*has_user_gesture=*/true);
-  run_loop.Run();
+  ASSERT_TRUE(future.Wait());
   ::testing::Mock::VerifyAndClearExpectations(&GetAdsServiceMock());
 
   // Must occur before the browser is closed.
@@ -608,12 +738,12 @@ IN_PROC_BROWSER_TEST_F(
   GetPrefs()->SetBoolean(brave_rewards::prefs::kEnabled, true);
   GetPrefs()->SetBoolean(prefs::kOptedInToNotificationAds, true);
 
-  base::RunLoop run_loop;
+  base::test::TestFuture<void> future;
   EXPECT_CALL(GetAdsServiceMock(), NotifyTabTextContentDidChange)
-      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
+      .WillOnce(base::test::RunOnceClosure(future.GetCallback()));
   NavigateToRelativeURL(kMultiPageApplicationWebpage,
                         /*has_user_gesture=*/true);
-  run_loop.Run();
+  ASSERT_TRUE(future.Wait());
   ::testing::Mock::VerifyAndClearExpectations(&GetAdsServiceMock());
 
   EXPECT_CALL(GetAdsServiceMock(), NotifyTabTextContentDidChange).Times(0);
@@ -650,12 +780,12 @@ IN_PROC_BROWSER_TEST_F(
   GetPrefs()->SetBoolean(brave_rewards::prefs::kEnabled, true);
   GetPrefs()->SetBoolean(prefs::kOptedInToNotificationAds, true);
 
-  base::RunLoop run_loop;
+  base::test::TestFuture<void> future;
   EXPECT_CALL(GetAdsServiceMock(), NotifyTabTextContentDidChange)
-      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
+      .WillOnce(base::test::RunOnceClosure(future.GetCallback()));
   NavigateToRelativeURL(kSinglePageApplicationWebpage,
                         /*has_user_gesture=*/true);
-  run_loop.Run();
+  ASSERT_TRUE(future.Wait());
   ::testing::Mock::VerifyAndClearExpectations(&GetAdsServiceMock());
 
   EXPECT_CALL(GetAdsServiceMock(), NotifyTabTextContentDidChange).Times(0);
@@ -903,5 +1033,95 @@ IN_PROC_BROWSER_TEST_F(BraveAdsTabHelperTest,
 
   EXPECT_FALSE(ads_tab_helper->ads_service());
 }
+
+#if !BUILDFLAG(IS_ANDROID)
+IN_PROC_BROWSER_TEST_F(BraveAdsTabHelperTest,
+                       TabBecomesOccludedWhenItsWindowBecomesInactive) {
+  NavigateToRelativeURL(kMultiPageApplicationWebpage,
+                        /*has_user_gesture=*/true);
+
+  const int32_t tab_1_id = TabId();
+
+  EXPECT_CALL(GetAdsServiceMock(), NotifyTabDidChange)
+      .Times(::testing::AnyNumber());
+  EXPECT_CALL(GetAdsServiceMock(),
+              NotifyTabDidChange(tab_1_id, /*redirect_chain=*/::testing::_,
+                                 /*is_new_navigation=*/::testing::_,
+                                 /*is_restoring=*/::testing::_,
+                                 /*is_visible=*/true))
+      .Times(0);
+
+  CreateBrowser(GetProfile());
+
+  ::testing::Mock::VerifyAndClearExpectations(&GetAdsServiceMock());
+}
+
+IN_PROC_BROWSER_TEST_F(BraveAdsTabHelperTest,
+                       TabBecomesVisibleWhenItsWindowBecomesActive) {
+  NavigateToRelativeURL(kMultiPageApplicationWebpage,
+                        /*has_user_gesture=*/true);
+
+  const int32_t tab_1_id = TabId();
+
+  Browser* const browser_2 = CreateBrowser(GetProfile());
+
+  base::test::TestFuture<void> future;
+  EXPECT_CALL(GetAdsServiceMock(), NotifyTabDidChange)
+      .Times(::testing::AnyNumber());
+  EXPECT_CALL(
+      GetAdsServiceMock(),
+      NotifyTabDidChange(tab_1_id,
+                         RedirectChainExpectation(kMultiPageApplicationWebpage),
+                         /*is_new_navigation=*/true, /*is_restoring=*/false,
+                         /*is_visible=*/true))
+      .Times(1)
+      .WillOnce(base::test::RunOnceClosure(future.GetCallback()));
+
+  CloseBrowserSynchronously(browser_2);
+  ASSERT_TRUE(future.Wait());
+
+  ::testing::Mock::VerifyAndClearExpectations(&GetAdsServiceMock());
+}
+
+IN_PROC_BROWSER_TEST_F(BraveAdsTabHelperTest,
+                       TabBecomesVisibleWhenItsWindowBecomesActiveAgain) {
+  NavigateToRelativeURL(kMultiPageApplicationWebpage,
+                        /*has_user_gesture=*/true);
+
+  const int32_t tab_1_id = TabId();
+
+  CreateBrowser(GetProfile());
+
+  base::test::TestFuture<void> future;
+  EXPECT_CALL(GetAdsServiceMock(), NotifyTabDidChange)
+      .Times(::testing::AnyNumber());
+  EXPECT_CALL(
+      GetAdsServiceMock(),
+      NotifyTabDidChange(tab_1_id,
+                         RedirectChainExpectation(kMultiPageApplicationWebpage),
+                         /*is_new_navigation=*/true, /*is_restoring=*/false,
+                         /*is_visible=*/true))
+      .Times(1)
+      .WillOnce(base::test::RunOnceClosure(future.GetCallback()));
+
+  browser()->window()->Activate();
+  ASSERT_TRUE(future.Wait());
+
+  ::testing::Mock::VerifyAndClearExpectations(&GetAdsServiceMock());
+}
+
+IN_PROC_BROWSER_TEST_F(
+    BraveAdsTabHelperTest,
+    BrowserActiveNotificationsAreNotDuplicatedAcrossWindows) {
+  NavigateToRelativeURL(kMultiPageApplicationWebpage,
+                        /*has_user_gesture=*/true);
+
+  EXPECT_CALL(GetAdsServiceMock(), NotifyBrowserDidBecomeActive).Times(1);
+
+  CreateBrowser(GetProfile());
+
+  ::testing::Mock::VerifyAndClearExpectations(&GetAdsServiceMock());
+}
+#endif  // !BUILDFLAG(IS_ANDROID)
 
 }  // namespace brave_ads


### PR DESCRIPTION
OnBrowserSetLastActive and OnBrowserNoLongerActive previously ignored their browser argument so every tab helper responded to every browser focus change, causing all open tabs to simultaneously report as focused when switching windows. The browser argument is now passed through to MaybeSetBrowserIsActive and MaybeSetBrowserIsNoLongerActive, which use a stored TabInterface to compare the owning browser window and skip events from unrelated windows. The constructor is also updated to only mark the browser as active when the tab's own browser window is already active, so tabs opened in background windows start correctly inactive. Browser tests that wait for async notifications are converted from base::RunLoop to base::test::TestFuture so that Wait returns a timeout failure instead of hanging, and notifications that fire inside nested message loops such as CloseBrowserSynchronously are handled correctly regardless of call ordering.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/38427

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
