### PR TITLE
Add disable-model-invocation to all Claude Code skills

### DIFF
--- a/.claude/skills/add-best-practice/SKILL.md
+++ b/.claude/skills/add-best-practice/SKILL.md
@@ -5,6 +5,7 @@ description:
   assigns stable IDs, creates new category docs if needed. Triggers on: add best
   practice, new best practice, add bp, new bp.'
 argument-hint: '<best practice description>'
+disable-model-invocation: true
 allowed-tools:
   Bash(python3:*), Bash(git:*), Bash(gh:*), Bash(ls:*), Read, Grep, Glob, Edit,
   Write, Agent, WebFetch

--- a/.claude/skills/check-upstream-flake/SKILL.md
+++ b/.claude/skills/check-upstream-flake/SKILL.md
@@ -6,6 +6,7 @@ description:
   filter file decisions. Triggers on: check upstream flake, is this test flaky
   upstream, check luci flakiness, upstream flake check."
 argument-hint: <TestSuite.TestMethod>
+disable-model-invocation: true
 ---
 
 # Check Upstream Flake

--- a/.claude/skills/clean-branches/SKILL.md
+++ b/.claude/skills/clean-branches/SKILL.md
@@ -4,6 +4,7 @@ description:
   'Delete local branches whose PRs have been merged upstream. Checks GitHub PR
   status for each branch. Triggers on: clean branches, delete merged branches,
   prune branches, branch cleanup.'
+disable-model-invocation: true
 ---
 
 # Clean Branches - Delete Merged Local Branches

--- a/.claude/skills/fix-bp-docs/SKILL.md
+++ b/.claude/skills/fix-bp-docs/SKILL.md
@@ -4,6 +4,7 @@ description:
   'Audit and fix best practices docs for stale references, duplicates, obsolete
   content, and formatting issues. Triggers on: fix bp docs, fix best practice
   docs, audit bp docs.'
+disable-model-invocation: true
 allowed-tools:
   Bash(find:*), Bash(ls:*), Bash(head:*), Bash(git:*), Bash(python3:*), Read,
   Grep, Glob, Edit

--- a/.claude/skills/force-push-downstream/SKILL.md
+++ b/.claude/skills/force-push-downstream/SKILL.md
@@ -5,6 +5,7 @@ description:
   the downstream tree and skips branches already up-to-date. Triggers on: force
   push downstream, push chain, push all branches.'
 argument-hint: '[starting-branch]'
+disable-model-invocation: true
 ---
 
 # Force Push Downstream

--- a/.claude/skills/impl-review/SKILL.md
+++ b/.claude/skills/impl-review/SKILL.md
@@ -6,6 +6,7 @@ description:
   impl-review, implement review, implement review feedback, address review
   comments.'
 argument-hint: '<pr-number>'
+disable-model-invocation: true
 ---
 
 # Implement Review Feedback

--- a/.claude/skills/make-ci-green/SKILL.md
+++ b/.claude/skills/make-ci-green/SKILL.md
@@ -5,6 +5,7 @@ description:
   uses WIPE_WORKSPACE for build/infra failures. Triggers on: make ci green,
   retry ci, rerun ci, fix ci, re-run failed jobs, retrigger ci.'
 argument-hint: '<pr-number> [--dry-run]'
+disable-model-invocation: true
 ---
 
 # Make CI Green

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: pr
 description: Create a pull request for the current branch using `gh`.
+disable-model-invocation: true
 ---
 
 # Create Pull Request

--- a/.claude/skills/preflight/SKILL.md
+++ b/.claude/skills/preflight/SKILL.md
@@ -3,6 +3,7 @@ name: preflight
 description:
   'Run all preflight checks (format, gn_check, presubmit, build, tests) to make
   sure the current work is ready for review.'
+disable-model-invocation: true
 ---
 
 # Preflight Checks

--- a/.claude/skills/prs-reviewed/SKILL.md
+++ b/.claude/skills/prs-reviewed/SKILL.md
@@ -5,6 +5,7 @@ description:
   state, and links. Triggers on: prs reviewed, reviewed prs, review activity,
   what did I review, review history.'
 argument-hint: '<username> <num>d'
+disable-model-invocation: true
 ---
 
 # PRs Reviewed

--- a/.claude/skills/rebase-downstream/SKILL.md
+++ b/.claude/skills/rebase-downstream/SKILL.md
@@ -4,6 +4,7 @@ description:
   'Rebase a tree of dependent branches (including siblings) after upstream
   changes. Auto-detects downstream branches and rebases each in order. Triggers
   on: rebase downstream, rebase chain, propagate changes downstream.'
+disable-model-invocation: true
 ---
 
 # Rebase Downstream Tree

--- a/.claude/skills/review-prs/SKILL.md
+++ b/.claude/skills/review-prs/SKILL.md
@@ -7,6 +7,7 @@ description:
   best practices.'
 argument-hint:
   '[days|page<N>|#<PR>] [open|closed|all] [auto] [reviewer-priority]'
+disable-model-invocation: true
 allowed-tools: Bash(gh pr diff:*)
 ---
 

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -5,6 +5,7 @@ description:
   review and local review of uncommitted/branch changes. Default mode is local
   (reviews current branch changes). Triggers on: review pr, review this pr,
   /review <pr_url>, /review local, /review, check bot pr quality.'
+disable-model-invocation: true
 allowed-tools:
   Bash(gh issue list:*), Bash(gh issue view:*), Bash(gh pr list:*), Bash(gh pr
   view:*), Bash(gh pr diff:*), Bash(git diff:*), Bash(git log:*), Bash(git

--- a/.claude/skills/top-crashers/SKILL.md
+++ b/.claude/skills/top-crashers/SKILL.md
@@ -5,6 +5,7 @@ description:
   signatures, stacks, platforms, versions, channel breakdown, code origin, and
   regression detection. Triggers on: top crashers, crash report, what's
   crashing, top crashes, crash analysis, regression crashers, new crashes."
+disable-model-invocation: true
 argument-hint:
   '[--days 7] [--platform Windows] [--compare 2] [--new-only] [--crashes-only]
   [--channels nightly,beta] [--brave-only]'


### PR DESCRIPTION
## Summary

- Adds `disable-model-invocation: true` to all 14 skill frontmatter files (uplift already had it)
- Skills will only load into context when explicitly invoked via `/<skill-name>`, reducing baseline context token usage by ~1.2k tokens per session

## Test plan

- [x] Start a new Claude Code session and verify `/context` shows reduced skill token usage
- [x] Verify each skill still works when invoked explicitly (e.g. `/preflight`, `/pr`, `/review`)