### PR TITLE
Fix SERP metrics migration not running for startup profile

### DIFF
--- a/browser/brave_stats/brave_stats_updater.cc
+++ b/browser/brave_stats/brave_stats_updater.cc
@@ -173,6 +173,16 @@ BraveStatsUpdater::BraveStatsUpdater(PrefService* pref_service,
 
   if (profile_manager != nullptr) {
     g_browser_process->profile_manager()->AddObserver(this);
+
+    // Run SERP metrics migration for profiles already loaded before we
+    // registered as an observer. OnProfileAdded only fires for profiles loaded
+    // after AddObserver, so existing profiles (including the Default profile)
+    // would otherwise never get migrated.
+    for (Profile* profile :
+         g_browser_process->profile_manager()->GetLoadedProfiles()) {
+      MaybeMigrateSerpMetricsToProfileAttributes(
+          g_browser_process->profile_manager(), *profile);
+    }
   }
 
   Start();


### PR DESCRIPTION
## Summary

- Fix SERP metrics migration from deprecated profile prefs to profile attributes never running for the startup (last-used) profile
- `BraveStatsUpdater` registers as a `ProfileManager` observer after the default profile is already loaded, so `OnProfileAdded` never fires for it
- After registering the observer, eagerly iterate already-loaded profiles and run the migration

## Root Cause

`BraveStatsUpdater` is lazily created in `BraveBrowserProcessImpl::brave_stats_updater()` and registers as a `ProfileManager` observer in its constructor. However, the default/startup profile is already loaded by that point. Since `ProfileManager::AddObserver` does not retroactively fire `OnProfileAdded` for already-loaded profiles, `MaybeMigrateSerpMetricsToProfileAttributes` never executes for the startup profile.

This causes the usage ping's `SerpMetricsAllProfilesAggregator` to read from empty profile attributes, reporting `braveSearch=0&googleSearch=0&otherSearch=0` for users who are actively searching — inflating the "No search activity" bucket in SERP metrics analytics.

Confirmed on local machines: deprecated pref `brave.stats.serp_metrics` contains search data, but `profile.info_cache.<profile>.serp_metrics` is empty.

## Fix

After registering the observer, iterate all already-loaded profiles and run the migration. The migration is idempotent (checks if deprecated pref is empty before acting), so duplicate calls from both the eager loop and `OnProfileAdded` are safe.

Related to brave/brave-browser#52104

## Test Plan

- [ ] Verify `brave_unit_tests --gtest_filter="*SerpMetricsMigration*"` passes
- [ ] Verify `brave_unit_tests --gtest_filter="*BraveStatsUpdater*"` passes
- [ ] On a profile with data in `brave.stats.serp_metrics` (deprecated prefs), confirm that after launching the browser, the data appears in `profile.info_cache.<profile>.serp_metrics` (profile attributes)
- [ ] Verify the usage ping includes non-zero `braveSearch`/`googleSearch`/`otherSearch` values for users who searched yesterday