### PR TITLE
Update the built-in Tor bridges config only if they are enabled.

### DIFF
--- a/browser/tor/test/tor_profile_manager_browsertest.cc
+++ b/browser/tor/test/tor_profile_manager_browsertest.cc
@@ -539,7 +539,8 @@ IN_PROC_BROWSER_TEST_F(TorProfileManagerTest, CanWebRTC) {
 IN_PROC_BROWSER_TEST_F(TorProfileManagerTest, BuiltInBridgesRequest) {
   // No bridges.
   SwitchToTorProfile(browser()->profile(), GetTorLauncherFactory());
-  EXPECT_EQ(0u, test_url_loader_factory_.total_requests());
+  EXPECT_EQ(0u, test_url_loader_factory_.total_requests())
+      << "No requests expected";
 
   tor::BridgesConfig bridges_config;
   bridges_config.use_bridges = tor::BridgesConfig::Usage::kBuiltIn;

--- a/browser/tor/test/tor_profile_manager_browsertest.cc
+++ b/browser/tor/test/tor_profile_manager_browsertest.cc
@@ -9,6 +9,7 @@
 #include "base/process/launch.h"
 #include "base/test/bind.h"
 #include "base/threading/thread_restrictions.h"
+#include "brave/browser/brave_browser_process.h"
 #include "brave/browser/tor/tor_profile_service_factory.h"
 #include "brave/components/brave_ads/buildflags/buildflags.h"
 #include "brave/components/brave_rewards/core/buildflags/buildflags.h"
@@ -17,6 +18,7 @@
 #include "brave/components/tor/mock_tor_launcher_factory.h"
 #include "brave/components/tor/tor_launcher_observer.h"
 #include "brave/components/tor/tor_profile_service.h"
+#include "brave/components/tor/tor_profile_service_impl.h"
 #include "chrome/browser/bookmarks/bookmark_model_factory.h"
 #include "chrome/browser/browser_process.h"
 #include "chrome/browser/content_settings/host_content_settings_map_factory.h"
@@ -36,6 +38,8 @@
 #include "content/public/test/browser_test.h"
 #include "content/public/test/browser_test_utils.h"
 #include "extensions/buildflags/buildflags.h"
+#include "services/network/public/cpp/weak_wrapper_shared_url_loader_factory.h"
+#include "services/network/test/test_url_loader_factory.h"
 
 #if BUILDFLAG(ENABLE_BRAVE_ADS)
 #include "brave/browser/brave_ads/ads_service_factory.h"
@@ -54,8 +58,6 @@
 #include "extensions/browser/extension_util.h"
 #include "extensions/common/extension_id.h"
 #endif
-
-#include <algorithm>
 
 namespace {
 
@@ -100,6 +102,24 @@ class TorProfileManagerTest : public InProcessBrowserTest {
   void Relaunch(const base::CommandLine& new_command_line) {
     base::LaunchProcess(new_command_line, base::LaunchOptionsForTest());
   }
+
+  void SetUpBrowserContextKeyedServices(
+      content::BrowserContext* context) override {
+    TorProfileServiceFactory::GetInstance()->SetTestingFactory(
+        context,
+        base::BindLambdaForTesting([&](content::BrowserContext* context)
+                                       -> std::unique_ptr<KeyedService> {
+          CHECK(context->IsTor());
+          return std::make_unique<tor::TorProfileServiceImpl>(
+              test_url_loader_factory_.GetSafeWeakWrapper(), context,
+              g_browser_process->local_state(),
+              g_brave_browser_process->tor_client_updater(),
+              g_brave_browser_process->tor_pluggable_transport_updater());
+        }));
+  }
+
+ protected:
+  network::TestURLLoaderFactory test_url_loader_factory_;
 };
 
 class MockWebContentsDelegate : public content::WebContentsDelegate {
@@ -514,6 +534,59 @@ IN_PROC_BROWSER_TEST_F(TorProfileManagerTest, CanWebRTC) {
   TorProfileManager::CloseTorProfileWindows(tor_profile);
   observer.Wait();
   EXPECT_EQ(0UL, chrome::GetBrowserCount(tor_profile));
+}
+
+IN_PROC_BROWSER_TEST_F(TorProfileManagerTest, BuiltInBridgesRequest) {
+  // No bridges.
+  SwitchToTorProfile(browser()->profile(), GetTorLauncherFactory());
+  EXPECT_EQ(0u, test_url_loader_factory_.total_requests());
+
+  tor::BridgesConfig bridges_config;
+  bridges_config.use_bridges = tor::BridgesConfig::Usage::kBuiltIn;
+  TorProfileServiceFactory::SetTorBridgesConfig(bridges_config);
+
+  test_url_loader_factory_.WaitForRequest(
+      GURL("https://bridges.torproject.org/moat/circumvention/builtin"));
+  EXPECT_EQ(1u, test_url_loader_factory_.total_requests());
+}
+
+IN_PROC_BROWSER_TEST_F(TorProfileManagerTest,
+                       BuiltInBridgesRequestOnOpenWindow) {
+  tor::BridgesConfig bridges_config;
+  bridges_config.use_bridges = tor::BridgesConfig::Usage::kBuiltIn;
+  TorProfileServiceFactory::SetTorBridgesConfig(bridges_config);
+
+  SwitchToTorProfile(browser()->profile(), GetTorLauncherFactory());
+
+  test_url_loader_factory_.WaitForRequest(
+      GURL("https://bridges.torproject.org/moat/circumvention/builtin"));
+  EXPECT_EQ(1u, test_url_loader_factory_.total_requests());
+}
+
+IN_PROC_BROWSER_TEST_F(TorProfileManagerTest, NoBuiltInBridgesRequest) {
+  {
+    // No bridges.
+    SwitchToTorProfile(browser()->profile(), GetTorLauncherFactory());
+    EXPECT_EQ(0u, test_url_loader_factory_.total_requests());
+  }
+  {
+    tor::BridgesConfig bridges_config;
+    bridges_config.use_bridges = tor::BridgesConfig::Usage::kNotUsed;
+    TorProfileServiceFactory::SetTorBridgesConfig(bridges_config);
+    EXPECT_EQ(0u, test_url_loader_factory_.total_requests());
+  }
+  {
+    tor::BridgesConfig bridges_config;
+    bridges_config.use_bridges = tor::BridgesConfig::Usage::kRequest;
+    TorProfileServiceFactory::SetTorBridgesConfig(bridges_config);
+    EXPECT_EQ(0u, test_url_loader_factory_.total_requests());
+  }
+  {
+    tor::BridgesConfig bridges_config;
+    bridges_config.use_bridges = tor::BridgesConfig::Usage::kProvide;
+    TorProfileServiceFactory::SetTorBridgesConfig(bridges_config);
+    EXPECT_EQ(0u, test_url_loader_factory_.total_requests());
+  }
 }
 
 #if BUILDFLAG(ENABLE_EXTENSIONS)

--- a/browser/tor/tor_profile_service_factory.cc
+++ b/browser/tor/tor_profile_service_factory.cc
@@ -21,11 +21,9 @@
 #include "components/keyed_service/content/browser_context_dependency_manager.h"
 #include "components/prefs/pref_service.h"
 #include "content/public/browser/browser_context.h"
+#include "content/public/browser/storage_partition.h"
 
-namespace {
-
-
-}  // namespace
+namespace {}  // namespace
 
 // static
 tor::TorProfileService* TorProfileServiceFactory::GetForContext(
@@ -130,8 +128,11 @@ TorProfileServiceFactory::BuildServiceInstanceForBrowserContext(
         g_brave_browser_process->tor_pluggable_transport_updater();
   }
   return std::make_unique<tor::TorProfileServiceImpl>(
-      Profile::FromBrowserContext(context)->GetOriginalProfile(), context,
-      g_browser_process->local_state(), tor_client_updater,
+      Profile::FromBrowserContext(context)
+          ->GetOriginalProfile()
+          ->GetDefaultStoragePartition()
+          ->GetURLLoaderFactoryForBrowserProcess(),
+      context, g_browser_process->local_state(), tor_client_updater,
       tor_pluggable_transport_updater);
 }
 

--- a/browser/tor/tor_profile_service_factory.cc
+++ b/browser/tor/tor_profile_service_factory.cc
@@ -23,8 +23,6 @@
 #include "content/public/browser/browser_context.h"
 #include "content/public/browser/storage_partition.h"
 
-namespace {}  // namespace
-
 // static
 tor::TorProfileService* TorProfileServiceFactory::GetForContext(
     content::BrowserContext* context) {

--- a/components/tor/tor_profile_service_impl.cc
+++ b/components/tor/tor_profile_service_impl.cc
@@ -151,9 +151,9 @@ class BuiltinBridgesRequest {
       scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
       PrefService* local_state,
       ResultCallback callback) {
-    auto config = tor::BridgesConfig::FromDict(
-                      local_state->GetDict(tor::prefs::kBridgesConfig))
-                      .value_or(tor::BridgesConfig());
+    const auto config = tor::BridgesConfig::FromDict(
+                            local_state->GetDict(tor::prefs::kBridgesConfig))
+                            .value_or(tor::BridgesConfig());
     if (config.use_bridges != tor::BridgesConfig::Usage::kBuiltIn) {
       return nullptr;
     }

--- a/components/tor/tor_profile_service_impl.cc
+++ b/components/tor/tor_profile_service_impl.cc
@@ -148,25 +148,32 @@ class BuiltinBridgesRequest {
   using ResultCallback = base::OnceCallback<void(const base::DictValue&)>;
 
   static std::unique_ptr<BuiltinBridgesRequest> MaybeUpdateBuiltinBridges(
-      content::BrowserContext* browser_context,
+      scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
       PrefService* local_state,
       ResultCallback callback) {
+    auto config = tor::BridgesConfig::FromDict(
+                      local_state->GetDict(tor::prefs::kBridgesConfig))
+                      .value_or(tor::BridgesConfig());
+    if (config.use_bridges != tor::BridgesConfig::Usage::kBuiltIn) {
+      return nullptr;
+    }
+
     const base::Time last_request_time =
         local_state->GetTime(prefs::kBuiltinBridgesRequestTime);
     if (base::Time::Now() > last_request_time + base::Days(1)) {
       local_state->SetTime(prefs::kBuiltinBridgesRequestTime,
                            base::Time::Now());
-      return base::WrapUnique(
-          new BuiltinBridgesRequest(browser_context, std::move(callback)));
+      return base::WrapUnique(new BuiltinBridgesRequest(
+          std::move(url_loader_factory), std::move(callback)));
     }
     return nullptr;
   }
 
  private:
-  BuiltinBridgesRequest(content::BrowserContext* browser_context,
-                        ResultCallback callback)
-      : url_loader_factory_(browser_context->GetDefaultStoragePartition()
-                                ->GetURLLoaderFactoryForBrowserProcess()),
+  BuiltinBridgesRequest(
+      scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
+      ResultCallback callback)
+      : url_loader_factory_(std::move(url_loader_factory)),
         result_callback_(std::move(callback)) {
     auto request = std::make_unique<network::ResourceRequest>();
     request->url = GURL(kTorBuiltinBridgesFetchUrl);
@@ -206,12 +213,13 @@ class BuiltinBridgesRequest {
 };
 
 TorProfileServiceImpl::TorProfileServiceImpl(
-    content::BrowserContext* original_context,
+    scoped_refptr<network::SharedURLLoaderFactory> direct_url_loader_factory,
     content::BrowserContext* context,
     PrefService* local_state,
     BraveTorClientUpdater* tor_client_updater,
     BraveTorPluggableTransportUpdater* tor_pluggable_transport_updater)
-    : context_(context),
+    : direct_url_loader_factory_(std::move(direct_url_loader_factory)),
+      context_(context),
       local_state_(local_state),
       tor_client_updater_(tor_client_updater),
       tor_pluggable_transport_updater_(tor_pluggable_transport_updater),
@@ -232,7 +240,7 @@ TorProfileServiceImpl::TorProfileServiceImpl(
   pref_change_registrar_.Init(local_state_.get());
 
   builtin_bridges_request_ = BuiltinBridgesRequest::MaybeUpdateBuiltinBridges(
-      original_context, local_state,
+      direct_url_loader_factory_, local_state,
       base::BindOnce(&TorProfileServiceImpl::OnBuiltinBridgesResponse,
                      weak_ptr_factory_.GetWeakPtr()));
 }
@@ -302,6 +310,13 @@ void TorProfileServiceImpl::OnBridgesConfigChanged() {
   if (!tor_pluggable_transport_updater_->IsReady()) {
     if (config.use_bridges != tor::BridgesConfig::Usage::kNotUsed) {
       tor_pluggable_transport_updater_->Register();
+      if (!builtin_bridges_request_) {
+        builtin_bridges_request_ =
+            BuiltinBridgesRequest::MaybeUpdateBuiltinBridges(
+                direct_url_loader_factory_, local_state_,
+                base::BindOnce(&TorProfileServiceImpl::OnBuiltinBridgesResponse,
+                               weak_ptr_factory_.GetWeakPtr()));
+      }
       return;
     } else {
       tor_pluggable_transport_updater_->Unregister();

--- a/components/tor/tor_profile_service_impl.h
+++ b/components/tor/tor_profile_service_impl.h
@@ -29,6 +29,10 @@ class ProxyConfigService;
 class ProxyConfigServiceTor;
 }  // namespace net
 
+namespace network {
+class SharedURLLoaderFactory;
+}
+
 namespace tor {
 
 using NewTorCircuitCallback =
@@ -41,7 +45,7 @@ class TorProfileServiceImpl
       public TorLauncherObserver {
  public:
   TorProfileServiceImpl(
-      content::BrowserContext* original_context,
+      scoped_refptr<network::SharedURLLoaderFactory> direct_url_loader_factory,
       content::BrowserContext* context,
       PrefService* local_state,
       BraveTorClientUpdater* tor_client_updater,
@@ -76,6 +80,7 @@ class TorProfileServiceImpl
 
   void OnBuiltinBridgesResponse(const base::DictValue& bridges);
 
+  scoped_refptr<network::SharedURLLoaderFactory> direct_url_loader_factory_;
   raw_ptr<content::BrowserContext> context_ = nullptr;
   raw_ptr<PrefService> local_state_ = nullptr;
   raw_ptr<BraveTorClientUpdater> tor_client_updater_ = nullptr;

--- a/components/tor/tor_profile_service_impl.h
+++ b/components/tor/tor_profile_service_impl.h
@@ -11,6 +11,7 @@
 #include <string>
 
 #include "base/memory/raw_ptr.h"
+#include "base/memory/scoped_refptr.h"
 #include "base/memory/weak_ptr.h"
 #include "brave/components/tor/brave_tor_client_updater.h"
 #include "brave/components/tor/brave_tor_pluggable_transport_updater.h"


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/54289

Test plan:
1. Launch a network sniffer
2. Launch Brave, ensure bridges are off
3. Check there is no requests to `https://bridges.torproject.org/moat/circumvention/builtin`
4. Enable bridges (use Built-in)
5. Check there is request to `https://bridges.torproject.org/moat/circumvention/builtin`
6. Relaunch Brave, check there is no requests to torproject (it should only request once a day)