### PR TITLE
Add opt-in debug logs for iOS user agent

### DIFF
--- a/ios/brave-ios/Package.swift
+++ b/ios/brave-ios/Package.swift
@@ -532,7 +532,11 @@ var package = Package(
       ],
       plugins: ["LoggerPlugin"]
     ),
-    .target(name: "UserAgent", dependencies: ["Preferences", "BraveCore"]),
+    .target(
+      name: "UserAgent",
+      dependencies: ["Preferences", "BraveCore"],
+      plugins: ["LoggerPlugin"]
+    ),
     .target(
       name: "CredentialProviderUI",
       dependencies: ["BraveCore", "DesignSystem", "BraveShared", "Strings", "BraveUI"]

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabPolicyDecider.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabPolicyDecider.swift
@@ -495,8 +495,12 @@ extension BrowserViewController {
       )
 
       if let url = modifiedRequest.url {
-        Logger.module.debug(
-          "Cancelled and recreating request to `\(url.absoluteString, privacy: .private)`"
+        Logger(
+          subsystem: "\(Bundle.main.bundleIdentifier ?? "com.brave.ios")",
+          category: "UserAgent"
+        )
+        .info(
+          "getInternalRedirect() - Detected incorrect UA in header. Cancelled and recreating request to `\(url.baseDomain ?? "nil", privacy: .public)` for user agent change from `\(headerUserAgent, privacy: .public)` to `\(userAgentForType, privacy: .public)`."
         )
       }
       return modifiedRequest

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+UserAgent.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+UserAgent.swift
@@ -4,7 +4,9 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import BraveCore
+import BraveShared
 import Foundation
+import OSLog
 import Preferences
 import UserAgent
 import Web
@@ -17,6 +19,10 @@ extension BrowserViewController {
     braveUserAgentExceptions: BraveUserAgentExceptionsIOS?
   ) -> String {
     if !Preferences.Debug.userAgentOverride.value.isEmpty {
+      Logger(subsystem: "\(Bundle.main.bundleIdentifier ?? "com.brave.ios")", category: "UserAgent")
+        .info(
+          "userAgent(for:userAgentForType:braveUserAgentExceptions:) - `\(request.mainDocumentURL?.baseDomain ?? "nil", privacy: .public)`, returning override"
+        )
       return Preferences.Debug.userAgentOverride.value
     }
     let isBraveAllowedInUA =
@@ -35,17 +41,24 @@ extension BrowserViewController {
       desktop = UserAgent.desktopMasked
     }
 
-    switch type {
-    case .none, .automatic:
-      let screenWidth = UIScreen.main.bounds.width
-      if traitCollection.horizontalSizeClass == .compact && view.bounds.width < screenWidth / 2 {
-        return mobile
+    let userAgent: String = {
+      switch type {
+      case .none, .automatic:
+        let screenWidth = UIScreen.main.bounds.width
+        if traitCollection.horizontalSizeClass == .compact && view.bounds.width < screenWidth / 2 {
+          return mobile
+        }
+        return traitCollection.userInterfaceIdiom == .pad
+          && profileController.defaultHostContentSettings.defaultPageMode == .desktop
+          ? desktop : mobile
+      case .desktop: return desktop
+      case .mobile: return mobile
       }
-      return traitCollection.userInterfaceIdiom == .pad
-        && profileController.defaultHostContentSettings.defaultPageMode == .desktop
-        ? desktop : mobile
-    case .desktop: return desktop
-    case .mobile: return mobile
-    }
+    }()
+    Logger(subsystem: "\(Bundle.main.bundleIdentifier ?? "com.brave.ios")", category: "UserAgent")
+      .info(
+        "userAgent(for:userAgentForType:braveUserAgentExceptions:) - `\(request.mainDocumentURL?.baseDomain ?? "nil", privacy: .public)`, returning \(userAgent, privacy: .public))"
+      )
+    return userAgent
   }
 }

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/SettingsViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/SettingsViewController.swift
@@ -1559,6 +1559,15 @@ class SettingsViewController: TableViewController, BraveAccountAuthenticationObs
           cellClass: MultilineValue1Cell.self
         ),
         Row(
+          text: "User Agent Logs",
+          selection: { [unowned self] in
+            let controller = UIHostingController(rootView: UserAgentLogsView())
+            self.navigationController?.pushViewController(controller, animated: true)
+          },
+          accessory: .disclosureIndicator,
+          cellClass: MultilineValue1Cell.self
+        ),
+        Row(
           text: "Secure Content State Debug",
           selection: { [unowned self] in
             self.navigationController?.pushViewController(

--- a/ios/brave-ios/Sources/UserAgent/UserAgentLogsView.swift
+++ b/ios/brave-ios/Sources/UserAgent/UserAgentLogsView.swift
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import OSLog
+import SwiftUI
+import os.log
+
+public struct UserAgentLogsView: View {
+  @State private var logs: String = ""
+  @State private var isLoading: Bool = true
+  @State private var showShareSheet: Bool = false
+  @State private var fileURL: URL?
+
+  public init() {}
+
+  public var body: some View {
+    VStack {
+      if isLoading {
+        ProgressView()
+      } else {
+        ScrollView {
+          Text(logs.isEmpty ? "No logs" : logs)
+            .padding()
+        }
+      }
+    }
+    .toolbar {
+      ToolbarItemGroup(placement: .topBarTrailing) {
+        ShareLink(item: fileURL ?? URL(string: "disabled")!)
+          .disabled(fileURL == nil || logs.isEmpty)
+      }
+    }
+    .task {
+      logs = await getLogs()
+      fileURL = createTemporaryLogFile()
+      isLoading = false
+    }
+  }
+
+  private func createTemporaryLogFile() -> URL {
+    let temporaryDirectoryURL = FileManager.default.temporaryDirectory
+    let logFileURL = temporaryDirectoryURL.appendingPathComponent("Logs.txt")
+
+    try? logs.write(to: logFileURL, atomically: true, encoding: .utf8)
+    return logFileURL
+  }
+
+  private func getLogs() async -> String {
+    return await Task.detached(priority: .background) {
+      do {
+        let store = try OSLogStore(scope: .currentProcessIdentifier)
+
+        return
+          try store
+          .getEntries()
+          .compactMap { $0 as? OSLogEntryLog }
+          .filter { $0.category == "UserAgent" && $0.subsystem == Bundle.main.bundleIdentifier }
+          .map { "[\($0.date.formatted())] \($0.composedMessage)" }
+          .joined(separator: "\n")
+      } catch {
+        await MainActor.run {
+          Logger.module.error("\(error.localizedDescription, privacy: .public)")
+        }
+      }
+      return ""
+    }.value
+  }
+}

--- a/ios/brave-ios/Sources/Web/Chromium/TabCWVNavigationHandler.swift
+++ b/ios/brave-ios/Sources/Web/Chromium/TabCWVNavigationHandler.swift
@@ -4,6 +4,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import BraveCore
+import OSLog
 
 class TabCWVNavigationHandler: NSObject, BraveWebViewNavigationDelegate {
   private weak var tab: ChromiumTabState?
@@ -75,6 +76,11 @@ class TabCWVNavigationHandler: NSObject, BraveWebViewNavigationDelegate {
     decisionHandler: @escaping (CWVNavigationActionPolicy) -> Void
   ) {
     guard let tab else { return }
+    Logger(subsystem: "\(Bundle.main.bundleIdentifier ?? "com.brave.ios")", category: "UserAgent")
+      .info(
+        "webView(_:decidePolicyFor:decisionHandler:) - navigationAction.request=\(navigationAction.request.mainDocumentURL?.baseDomain ?? "nil", privacy: .private)"
+      )
+
     let navigationType: WebNavigationType = {
       if navigationAction.navigationType.contains(.forwardBack) {
         return .backForward


### PR DESCRIPTION
Adds a User Agent Debug Logs view to Developer Options. Logs are entirely local to device.
    - Developer Options is hidden by default, locked behind password and biometrics.
    - After Developer Options are enabled/exposed, logs are still disabled by default. User must opt-in via toggle in `User Agent Debug` view.
    - Logs are cleared on app launch.
    
<img width="500" alt="User Agent Debug Logs" src="https://github.com/user-attachments/assets/d5573747-44e9-403f-a877-c90a5b9fc0a6" />

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

### Testplan

1. Visit some websites both on and not on [brave-checks.txt](https://github.com/brave/adblock-lists/blob/master/brave-lists/brave-checks.txt)
2. Open Settings > Developer Options > User Agent Debug
3. Verify toggle in navigation bar is disabled (default) and no logs are displayed
4. Enable the toggle
5. Visit some websites both on and not on [brave-checks.txt](https://github.com/brave/adblock-lists/blob/master/brave-lists/brave-checks.txt)
6. Verify logs are now displayed in Settings > Developer Options > User Agent Debug