### PR TITLE
Migrate DAU last ping date to local state pref on iOS

### DIFF
--- a/components/brave_stats/browser/brave_stats_updater_util.cc
+++ b/components/brave_stats/browser/brave_stats_updater_util.cc
@@ -23,9 +23,13 @@
 
 namespace brave_stats {
 
-std::string GetDateAsYMD(const base::Time& time) {
+std::string GetDateAsYMD(const base::Time& time, bool use_utc) {
   base::Time::Exploded exploded;
-  time.LocalExplode(&exploded);
+  if (use_utc) {
+    time.UTCExplode(&exploded);
+  } else {
+    time.LocalExplode(&exploded);
+  }
   return absl::StrFormat("%d-%02d-%02d", exploded.year, exploded.month,
                          exploded.day_of_month);
 }
@@ -103,7 +107,7 @@ base::Time GetLastMondayTime(const base::Time& time) {
   return last_monday;
 }
 
-base::Time GetYMDAsDate(std::string_view ymd) {
+base::Time GetYMDAsDate(std::string_view ymd, bool use_utc) {
   const auto pieces = base::SplitStringPiece(ymd, "-", base::TRIM_WHITESPACE,
                                              base::SPLIT_WANT_NONEMPTY);
   DCHECK_EQ(pieces.size(), 3ull);
@@ -119,7 +123,11 @@ base::Time GetYMDAsDate(std::string_view ymd) {
   DCHECK(time.HasValidValues());
 
   base::Time result;
-  ok = base::Time::FromLocalExploded(time, &result);
+  if (use_utc) {
+    ok = base::Time::FromUTCExploded(time, &result);
+  } else {
+    ok = base::Time::FromLocalExploded(time, &result);
+  }
   DCHECK(ok);
 
   return result;

--- a/components/brave_stats/browser/brave_stats_updater_util.h
+++ b/components/brave_stats/browser/brave_stats_updater_util.h
@@ -15,7 +15,7 @@ class PrefService;
 
 namespace brave_stats {
 
-std::string GetDateAsYMD(const base::Time& time);
+std::string GetDateAsYMD(const base::Time& time, bool use_utc = false);
 
 // Returns platform with architecture information i.e. winx64-bc, osxarm64-bc
 std::string GetPlatformIdentifier();
@@ -27,7 +27,7 @@ int GetIsoWeekNumber(const base::Time& time);
 
 base::Time GetLastMondayTime(const base::Time& time);
 
-base::Time GetYMDAsDate(std::string_view ymd);
+base::Time GetYMDAsDate(std::string_view ymd, bool use_utc = false);
 
 std::string GetAPIKey();
 

--- a/ios/brave-ios/Sources/Brave/Migration/Migration.swift
+++ b/ios/brave-ios/Sources/Brave/Migration/Migration.swift
@@ -109,12 +109,26 @@ public class BraveLocalStateMigration {
 
   public func launchMigrations() {
     migrateDAUPingPreference()
+    migrateDAULastLaunchInfoPreference()
     migrateAdsPreferences()
   }
 
   private func migrateDAUPingPreference() {
     Preferences.DeprecatedPreferences.sendUsagePing.migrate { value in
       localState.set(value, forPath: kStatsReportingEnabledPrefName)
+    }
+  }
+
+  private func migrateDAULastLaunchInfoPreference() {
+    Preferences.DeprecatedPreferences.lastLaunchInfo.migrate { value in
+      guard let lastPingTimestamp = value?.first else { return }
+
+      if !Preferences.DAU.firstPingParam.isValueStored {
+        Preferences.DAU.firstPingParam.value = false
+      }
+
+      let date = Date(timeIntervalSince1970: TimeInterval(lastPingTimestamp))
+      localState.set(DAU.dateFormatter.string(from: date), forPath: kLastCheckYMDPrefName)
     }
   }
 
@@ -267,6 +281,12 @@ extension Migration {
 extension Preferences {
   fileprivate final class DeprecatedPreferences {
     static let sendUsagePing = Option<Bool>(key: "dau.send-usage-ping", default: true)
+
+    /// Superseded by `brave.stats.last_ping_date` in local state.
+    static let lastLaunchInfo = Option<[Int]?>(
+      key: "dau.last-launch-info",
+      default: nil
+    )
 
     static let blockAdsAndTracking = Option<Bool>(
       key: "shields.block-ads-and-tracking",
@@ -446,7 +466,6 @@ extension Preferences {
     migrate(key: "braveAdblockUseRegional", to: Preferences.Shields.useRegionAdBlock)
 
     // DAU
-    migrate(key: "dau_stat", to: Preferences.DAU.lastLaunchInfo)
     migrate(key: "week_of_installation", to: Preferences.DAU.weekOfInstallation)
 
     // URP
@@ -462,9 +481,6 @@ extension Preferences {
     migrate(key: "fp_protection", to: Preferences.BlockStats.fingerprintingCount)
     migrate(key: "safebrowsing", to: Preferences.BlockStats.phishingCount)
 
-    // On 1.6 lastLaunchInfo is used to check if it's first app launch or not.
-    // This needs to be translated to our new preference.
-    Preferences.General.isFirstLaunch.value = Preferences.DAU.lastLaunchInfo.value == nil
     Preferences.Migration.completed.value = true
   }
 

--- a/ios/brave-ios/Sources/Growth/DAU.swift
+++ b/ios/brave-ios/Sources/Growth/DAU.swift
@@ -48,7 +48,7 @@ public class DAU {
   }
 
   /// Date formatted used for passing date strings to the DAU server.
-  static let dateFormatter = { () -> DateFormatter in
+  public static let dateFormatter = { () -> DateFormatter in
     let formatter = DateFormatter()
     formatter.dateFormat = "yyyy-MM-dd"
     formatter.calendar = DAU.calendar
@@ -111,7 +111,12 @@ public class DAU {
       Logger.module.debug("DAU ping disabled by the user.")
       return
     }
-    guard let paramsAndPrefs = paramsAndPrefsSetup(for: Date()) else {
+    guard
+      let paramsAndPrefs = paramsAndPrefsSetup(
+        for: Date(),
+        lastPingDate: stats.lastPingDate
+      )
+    else {
       Logger.module.debug("dau, no changes detected, no server ping")
       return
     }
@@ -154,8 +159,12 @@ public class DAU {
       // This preference is set for future DAU pings.
       Preferences.DAU.firstPingParam.value = false
 
-      // This preference is used to calculate whether user used the app in this month and/or day.
-      Preferences.DAU.lastLaunchInfo.value = paramsAndPrefs.lastLaunchInfoPreference
+      // Store the last ping date in local state so all platform components share one source of truth.
+      // Thread hop to main is required because `lastPingDate` sets `brave.stats.last_check_ymd`
+      // Chromium preference, which must be done from the main thread.
+      DispatchQueue.main.async { [weak self] in
+        self?.braveCoreStats?.lastPingDate = paramsAndPrefs.date
+      }
     }
 
     task.resume()
@@ -165,7 +174,7 @@ public class DAU {
   struct ParamsAndPrefs {
     let queryParams: [URLQueryItem]
     let headers: [String: String]
-    let lastLaunchInfoPreference: [Int]
+    let date: Date
   }
 
   func migrateInvalidWeekOfInstallPref() {
@@ -183,8 +192,8 @@ public class DAU {
   }
 
   /// Return params query or nil if no ping should be send to server and also preference values to set
-  /// after a succesful ing.
-  func paramsAndPrefsSetup(for date: Date) -> ParamsAndPrefs? {
+  /// after a succesful ping.
+  func paramsAndPrefsSetup(for date: Date, lastPingDate: Date?) -> ParamsAndPrefs? {
     var params = [channelParam(), versionParam()]
 
     let firstLaunch = Preferences.DAU.firstPingParam.value
@@ -201,7 +210,13 @@ public class DAU {
       migrateInvalidWeekOfInstallPref()
     }
 
-    guard let dauStatParams = dauStatParams(for: date, firstPing: firstLaunch) else {
+    guard
+      let dauStatParams = dauStatParams(
+        for: date,
+        lastPingDate: lastPingDate,
+        firstPing: firstLaunch
+      )
+    else {
       return nil
     }
 
@@ -231,8 +246,6 @@ public class DAU {
       params.append(URLQueryItem(name: "ref", value: referralCode))
     }
 
-    let lastPingTimestamp = [Int((date).timeIntervalSince1970)]
-
     var headers: [String: String] = [:]
 
     if let key = self.apiKey, !key.isEmpty {
@@ -242,7 +255,7 @@ public class DAU {
     return ParamsAndPrefs(
       queryParams: params,
       headers: headers,
-      lastLaunchInfoPreference: lastPingTimestamp
+      date: date
     )
   }
 
@@ -374,7 +387,7 @@ public class DAU {
   /// Returns nil if no dau changes detected.
   func dauStatParams(
     for date: Date,
-    dauStat: [Int?]? = Preferences.DAU.lastLaunchInfo.value,
+    lastPingDate: Date?,
     firstPing: Bool,
     channel: AppBuildChannel = AppConstants.buildChannel
   ) -> [URLQueryItem]? {
@@ -389,17 +402,10 @@ public class DAU {
       return dauParams(true, true, true)
     }
 
-    guard let stat = dauStat?.compactMap({ $0 }) else {
-      Logger.module.error("Cannot cast dauStat to [Int]")
+    guard let lastPingDate = lastPingDate else {
+      Logger.module.error("Can't get last ping date")
       return nil
     }
-
-    guard let lastPingStat = stat.first else {
-      Logger.module.error("Can't get last ping timestamp from dauStats")
-      return nil
-    }
-
-    let lastPingDate = Date(timeIntervalSince1970: TimeInterval(lastPingStat))
 
     let pings = getPings(forDate: date, lastPingDate: lastPingDate)
 

--- a/ios/brave-ios/Sources/Growth/GrowthPreferences.swift
+++ b/ios/brave-ios/Sources/Growth/GrowthPreferences.swift
@@ -8,15 +8,15 @@ import Preferences
 
 extension Preferences {
   public final class DAU {
-    public static let lastLaunchInfo = Option<[Int]?>(key: "dau.last-launch-info", default: nil)
     public static let weekOfInstallation = Option<String?>(
       key: "dau.week-of-installation",
       default: nil
     )
-    // On old codebase we checked existence of `dau_stat` to determine whether it's first server ping.
-    // We need to translate that to use the new `firstPingParam` preference.
-    static let firstPingParam: Option<Bool> =
-      Option<Bool>(key: "dau.first-ping", default: Preferences.DAU.lastLaunchInfo.value == nil)
+    public static let firstPingParam: Option<Bool> =
+      Option<Bool>(
+        key: "dau.first-ping",
+        default: true
+      )
     /// Date of installation, this preference is removed after 14 days of usage.
     public static let installationDate = Option<Date?>(key: "dau.installation-date", default: nil)
     /// The app launch date after retention

--- a/ios/brave-ios/Tests/ClientTests/BraveLocalStateMigrationTests.swift
+++ b/ios/brave-ios/Tests/ClientTests/BraveLocalStateMigrationTests.swift
@@ -1,0 +1,205 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import BraveCore
+import Foundation
+import Preferences
+import Web
+import XCTest
+
+@testable import Brave
+
+private let deprecatedLastLaunchInfoPrefKey = "dau.last-launch-info"
+
+private func utcTimestamp(year: Int, month: Int, day: Int) -> Int {
+  var components = DateComponents(
+    timeZone: TimeZone(identifier: "UTC")!,
+    year: year,
+    month: month,
+    day: day
+  )
+  var calendar = Calendar(identifier: .gregorian)
+  calendar.timeZone = TimeZone(identifier: "UTC")!
+  return Int(calendar.date(from: components)!.timeIntervalSince1970)
+}
+
+class BraveLocalStateMigrationTests: XCTestCase {
+
+  private var localState: FakePrefService!
+  private var migration: BraveLocalStateMigration!
+
+  override func setUp() {
+    super.setUp()
+    Preferences.defaultContainer.removeObject(
+      forKey: deprecatedLastLaunchInfoPrefKey
+    )
+    Preferences.defaultContainer.removeObject(forKey: Preferences.DAU.firstPingParam.key)
+    localState = FakePrefService()
+    migration = BraveLocalStateMigration(localState: localState)
+  }
+
+  override func tearDown() {
+    Preferences.defaultContainer.removeObject(
+      forKey: deprecatedLastLaunchInfoPrefKey
+    )
+    Preferences.defaultContainer.removeObject(forKey: Preferences.DAU.firstPingParam.key)
+    super.tearDown()
+  }
+
+  // MARK: - migrateDAULastLaunchInfoPreference
+
+  func testMigratingLastLaunchInfoWithValidTimestampSetsLastPingDate() {
+    let timestamp = utcTimestamp(year: 2026, month: 1, day: 2)
+    Preferences.defaultContainer.set(
+      [timestamp, 1, 2, 1],
+      forKey: deprecatedLastLaunchInfoPrefKey
+    )
+
+    migration.launchMigrations()
+
+    XCTAssertEqual(localState.string(forPath: kLastCheckYMDPrefName), "2026-01-02")
+  }
+
+  func testMigratingLastLaunchInfoWithSingleElementArraySetsLastPingDate() {
+    let timestamp = utcTimestamp(year: 2026, month: 1, day: 2)
+    Preferences.defaultContainer.set(
+      [timestamp],
+      forKey: deprecatedLastLaunchInfoPrefKey
+    )
+
+    migration.launchMigrations()
+
+    XCTAssertEqual(localState.string(forPath: kLastCheckYMDPrefName), "2026-01-02")
+  }
+
+  func testMigratingLastLaunchInfoWithEpochTimestampSetsEpochDate() {
+    Preferences.defaultContainer.set(
+      [0],
+      forKey: deprecatedLastLaunchInfoPrefKey
+    )
+
+    migration.launchMigrations()
+
+    XCTAssertEqual(localState.string(forPath: kLastCheckYMDPrefName), "1970-01-01")
+  }
+
+  func testMigratingLastLaunchInfoWithNonNilValueOverwritesFirstPingStatus() {
+    Preferences.DAU.firstPingParam.value = true
+    Preferences.defaultContainer.removeObject(forKey: Preferences.DAU.firstPingParam.key)
+    Preferences.defaultContainer.set(
+      [utcTimestamp(year: 2026, month: 1, day: 2)],
+      forKey: deprecatedLastLaunchInfoPrefKey
+    )
+
+    migration.launchMigrations()
+
+    XCTAssertFalse(Preferences.DAU.firstPingParam.value)
+  }
+
+  func testMigratingLastLaunchInfoWithNonNilValueClearsLegacyPreferenceKey() {
+    Preferences.defaultContainer.set(
+      [utcTimestamp(year: 2026, month: 1, day: 2)],
+      forKey: deprecatedLastLaunchInfoPrefKey
+    )
+
+    migration.launchMigrations()
+
+    XCTAssertNil(
+      Preferences.defaultContainer.object(
+        forKey: deprecatedLastLaunchInfoPrefKey
+      )
+    )
+  }
+
+  func testMigratingLastLaunchInfoWithEmptyArrayDoesNotSetLastPingDate() {
+    Preferences.defaultContainer.set(
+      [Int](),
+      forKey: deprecatedLastLaunchInfoPrefKey
+    )
+
+    migration.launchMigrations()
+
+    XCTAssertFalse(localState.hasPref(forPath: kLastCheckYMDPrefName))
+  }
+
+  func testMigratingLastLaunchInfoWithEmptyArrayDoesNotOverwriteFirstPingStatus() {
+    Preferences.DAU.firstPingParam.value = true
+    Preferences.defaultContainer.removeObject(forKey: Preferences.DAU.firstPingParam.key)
+    Preferences.defaultContainer.set(
+      [Int](),
+      forKey: deprecatedLastLaunchInfoPrefKey
+    )
+
+    migration.launchMigrations()
+
+    XCTAssertTrue(Preferences.DAU.firstPingParam.value)
+  }
+
+  func testMigratingLastLaunchInfoWithEmptyArrayClearsLegacyPreferenceKey() {
+    Preferences.defaultContainer.set(
+      [Int](),
+      forKey: deprecatedLastLaunchInfoPrefKey
+    )
+
+    migration.launchMigrations()
+
+    XCTAssertNil(
+      Preferences.defaultContainer.object(
+        forKey: deprecatedLastLaunchInfoPrefKey
+      )
+    )
+  }
+
+  func testMigratingLastLaunchInfoWithIncompatibleStoredTypeClearsLegacyKeyWithoutSideEffects() {
+    Preferences.DAU.firstPingParam.value = true
+    Preferences.defaultContainer.removeObject(forKey: Preferences.DAU.firstPingParam.key)
+    Preferences.defaultContainer.set(
+      "unexpected-string-value",
+      forKey: deprecatedLastLaunchInfoPrefKey
+    )
+
+    migration.launchMigrations()
+
+    XCTAssertNil(
+      Preferences.defaultContainer.object(
+        forKey: deprecatedLastLaunchInfoPrefKey
+      )
+    )
+    XCTAssertFalse(localState.hasPref(forPath: kLastCheckYMDPrefName))
+    XCTAssertTrue(Preferences.DAU.firstPingParam.value)
+  }
+
+  func testMigratingLastLaunchInfoWithNoLegacyPreferenceDoesNotSetLocalState() {
+    migration.launchMigrations()
+
+    XCTAssertFalse(localState.hasPref(forPath: kLastCheckYMDPrefName))
+  }
+
+  func testMigratingLastLaunchInfoWhenPingStatusAlreadyMigratedDoesNotOverwriteFistPingStatus() {
+    Preferences.DAU.firstPingParam.value = true
+    Preferences.defaultContainer.set(
+      [utcTimestamp(year: 2026, month: 1, day: 2)],
+      forKey: deprecatedLastLaunchInfoPrefKey
+    )
+
+    migration.launchMigrations()
+
+    XCTAssertTrue(Preferences.DAU.firstPingParam.value)
+  }
+
+  func testMigratingLastLaunchInfoTwiceDoesNotOverwriteLastPingDate() {
+    Preferences.defaultContainer.set(
+      [utcTimestamp(year: 2026, month: 1, day: 2)],
+      forKey: deprecatedLastLaunchInfoPrefKey
+    )
+
+    migration.launchMigrations()
+    let ymdAfterFirstCall = localState.string(forPath: kLastCheckYMDPrefName)
+
+    migration.launchMigrations()
+
+    XCTAssertEqual(localState.string(forPath: kLastCheckYMDPrefName), ymdAfterFirstCall)
+  }
+}

--- a/ios/brave-ios/Tests/GrowthTests/DAUTests.swift
+++ b/ios/brave-ios/Tests/GrowthTests/DAUTests.swift
@@ -16,11 +16,12 @@ extension DAU {
 
 class DAUTests: XCTestCase {
 
+  var lastKnownPingDate: Date? = nil
+
   override func setUp() {
     super.setUp()
 
     Preferences.DAU.weekOfInstallation.reset()
-    Preferences.DAU.lastLaunchInfo.reset()
     Preferences.DAU.firstPingParam.reset()
     Preferences.DAU.installationDate.reset()
   }
@@ -169,13 +170,14 @@ class DAUTests: XCTestCase {
   }
 
   func testStatParamsInvalidInputs() {
-    XCTAssertNil(dau.dauStatParams(for: date, dauStat: nil, firstPing: false, channel: .beta))
-    XCTAssertNil(dau.dauStatParams(for: date, dauStat: nil, firstPing: false, channel: .release))
-    XCTAssertNil(dau.dauStatParams(for: date, dauStat: [], firstPing: false, channel: .beta))
+    XCTAssertNil(dau.dauStatParams(for: date, lastPingDate: nil, firstPing: false, channel: .beta))
+    XCTAssertNil(
+      dau.dauStatParams(for: date, lastPingDate: nil, firstPing: false, channel: .release)
+    )
   }
 
   func testFirstLaunch() {
-    XCTAssertNil(Preferences.DAU.lastLaunchInfo.value)
+    XCTAssertNil(lastKnownPingDate)
     XCTAssertNil(Preferences.DAU.weekOfInstallation.value)
     XCTAssert(Preferences.DAU.firstPingParam.value)
 
@@ -195,7 +197,7 @@ class DAUTests: XCTestCase {
     )
 
     XCTAssertNotNil(firstLaunch)
-    XCTAssertNotNil(Preferences.DAU.lastLaunchInfo.value)
+    XCTAssertNotNil(lastKnownPingDate)
     XCTAssertNotNil(Preferences.DAU.weekOfInstallation.value)
     XCTAssertFalse(Preferences.DAU.firstPingParam.value)
 
@@ -238,25 +240,22 @@ class DAUTests: XCTestCase {
   func testTwoPingsSameDay() {
     let date = dateFrom(string: "2017-11-20")
 
-    XCTAssertNil(Preferences.DAU.lastLaunchInfo.value)
+    XCTAssertNil(lastKnownPingDate)
     XCTAssertNil(Preferences.DAU.weekOfInstallation.value)
 
-    // Acting like a first launch so preferences are going to be set up
-    let dauFirstLaunch = DAU()
-    let params = dauFirstLaunch.paramsAndPrefsSetup(for: date)
+    // Acting like a first launch so preferences are going to be set up.
+    let params = DAU().paramsAndPrefsSetup(for: date, lastPingDate: nil)
 
-    // These preferences should be set only after a successful ping.
-    XCTAssertNil(Preferences.DAU.lastLaunchInfo.value)
+    // These value should be set only after a successful ping.
+    XCTAssertNil(lastKnownPingDate)
 
     simulatePing(params: params)
 
-    let dauSecondLaunch = DAU()
-
-    XCTAssertNotNil(Preferences.DAU.lastLaunchInfo.value)
+    XCTAssertNotNil(lastKnownPingDate)
     XCTAssertNotNil(Preferences.DAU.weekOfInstallation.value)
 
     // Second launch on the same day
-    let params2 = dauSecondLaunch.paramsAndPrefsSetup(for: date)
+    let params2 = DAU().paramsAndPrefsSetup(for: date, lastPingDate: lastKnownPingDate)
 
     XCTAssertNil(params2)
   }
@@ -307,7 +306,7 @@ class DAUTests: XCTestCase {
 
   func testNonDefaultWoiDefaultConstructor() {
     let dauFirstLaunch = DAU()
-    let params = dauFirstLaunch.paramsAndPrefsSetup(for: date)
+    let params = dauFirstLaunch.paramsAndPrefsSetup(for: date, lastPingDate: nil)
     XCTAssertFalse(
       params!.queryParams.contains(URLQueryItem(name: "woi", value: DAU.defaultWoiDate))
     )
@@ -316,12 +315,11 @@ class DAUTests: XCTestCase {
   func testNotFirstLaunchSetDau() {
     let date = dateFrom(string: "2017-11-20")
 
-    XCTAssertNil(Preferences.DAU.lastLaunchInfo.value)
+    XCTAssertNil(lastKnownPingDate)
     XCTAssertNil(Preferences.DAU.weekOfInstallation.value)
 
-    // Acting like a first launch so preferences are going to be set up
-    let dauFirstLaunch = DAU()
-    let params = dauFirstLaunch.paramsAndPrefsSetup(for: date)
+    // Acting like a first launch so preferences are going to be set up.
+    let params = DAU().paramsAndPrefsSetup(for: date, lastPingDate: nil)
 
     simulatePing(params: params)
 
@@ -464,7 +462,7 @@ class DAUTests: XCTestCase {
     for (storedValue, fixedValue) in testValues {
       Preferences.DAU.weekOfInstallation.value = storedValue
       // Fetching params will trigger migration
-      let params = dau.paramsAndPrefsSetup(for: Date())
+      let params = dau.paramsAndPrefsSetup(for: Date(), lastPingDate: nil)
       XCTAssertEqual(try XCTUnwrap(Preferences.DAU.weekOfInstallation.value), fixedValue)
       Preferences.DAU.weekOfInstallation.reset()
     }
@@ -474,7 +472,7 @@ class DAUTests: XCTestCase {
   // TODO: Refactor DAU to not reach out to Info.plist
   //  func testAPIKeyHeader() throws {
   //    let dau = DAU()
-  //    let headers = try XCTUnwrap(dau.paramsAndPrefsSetup(for: date)).headers
+  //    let headers = try XCTUnwrap(dau.paramsAndPrefsSetup(for: date, lastPingDate: nil)).headers
   //    XCTAssertEqual(headers["x-brave-api-key"], "key")
   //  }
 
@@ -511,8 +509,7 @@ class DAUTests: XCTestCase {
   ) -> DAU.ParamsAndPrefs? {
 
     let date = dateFrom(string: dateString, format: dateFormat)
-    let dau = DAU()
-    let params = dau.paramsAndPrefsSetup(for: date)
+    let params = DAU().paramsAndPrefsSetup(for: date, lastPingDate: lastKnownPingDate)
 
     // All dau stats equal false means no ping is send to server
     if daily == false && weekly == false && monthly == false {
@@ -541,10 +538,13 @@ class DAUTests: XCTestCase {
   }
 
   /// This actually simulates business logic that's done after a successful ping.
+  /// The date is round-tripped through DAU.dateFormatter to match production behavior where
+  /// `lastPingDate` is reconstructed from a YYYY-MM-DD string.
   private func simulatePing(firstPing: Bool = false, params: DAU.ParamsAndPrefs?) {
     Preferences.DAU.firstPingParam.value = firstPing
-
-    Preferences.DAU.lastLaunchInfo.value = params!.lastLaunchInfoPreference
+    lastKnownPingDate = params.flatMap {
+      DAU.dateFormatter.date(from: DAU.dateFormatter.string(from: $0.date))
+    }
   }
 
   private var appVersion: String {

--- a/ios/browser/api/brave_stats/brave_stats.h
+++ b/ios/browser/api/brave_stats/brave_stats.h
@@ -21,6 +21,11 @@ OBJC_EXPORT
     BOOL statsReportingEnabled NS_SWIFT_NAME(isStatsReportingEnabled);
 @property(readonly, getter=isNotificationAdsEnabled)
     BOOL notificationAdsEnabled;
+
+/// The date of the last successful DAU ping, or nil if no ping has been
+/// recorded.
+@property(nonatomic, nullable) NSDate* lastPingDate;
+
 - (instancetype)init NS_UNAVAILABLE;
 
 @end

--- a/ios/browser/api/brave_stats/brave_stats.mm
+++ b/ios/browser/api/brave_stats/brave_stats.mm
@@ -7,7 +7,9 @@
 
 #include "base/memory/raw_ptr.h"
 #include "base/strings/sys_string_conversions.h"
+#include "base/time/time.h"
 #include "brave/components/brave_ads/core/public/prefs/pref_names.h"
+#include "brave/components/brave_stats/browser/brave_stats_updater_util.h"
 #include "brave/components/brave_stats/browser/buildflags.h"
 #include "brave/components/constants/pref_names.h"
 #include "brave/components/webcompat_reporter/buildflags/buildflags.h"
@@ -50,6 +52,26 @@ NSString* const kWebcompatReportEndpoint =
 
 - (BOOL)isNotificationAdsEnabled {
   return _profilePrefs->GetBoolean(brave_ads::prefs::kOptedInToNotificationAds);
+}
+
+- (nullable NSDate*)lastPingDate {
+  const std::string ymd = _localPrefs->GetString(kLastCheckYMD);
+  if (ymd.empty()) {
+    return nil;
+  }
+  // Daily usage pings on iOS use UTC for the date boundary.
+  return brave_stats::GetYMDAsDate(ymd, /*use_utc=*/true).ToNSDate();
+}
+
+- (void)setLastPingDate:(NSDate*)date {
+  if (!date) {
+    _localPrefs->SetString(kLastCheckYMD, std::string());
+    return;
+  }
+  // Daily usage pings on iOS use UTC for the date boundary.
+  _localPrefs->SetString(kLastCheckYMD,
+                         brave_stats::GetDateAsYMD(base::Time::FromNSDate(date),
+                                                   /*use_utc=*/true));
 }
 
 @end

--- a/ios/browser/brave_stats/brave_stats_prefs.cc
+++ b/ios/browser/brave_stats/brave_stats_prefs.cc
@@ -19,6 +19,7 @@ namespace brave_stats {
 
 void RegisterLocalStatePrefs(PrefRegistrySimple* registry) {
   registry->RegisterBooleanPref(kStatsReportingEnabled, true);
+  registry->RegisterStringPref(kLastCheckYMD, std::string());
 }
 
 void RegisterLocalStatePrefsForMigration(PrefRegistrySimple* registry) {

--- a/ios/components/constants/pref_names_bridge.h
+++ b/ios/components/constants/pref_names_bridge.h
@@ -11,6 +11,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 OBJC_EXPORT NSString* const kStatsReportingEnabledPrefName;
+OBJC_EXPORT NSString* const kLastCheckYMDPrefName;
 
 NS_ASSUME_NONNULL_END
 

--- a/ios/components/constants/pref_names_bridge.mm
+++ b/ios/components/constants/pref_names_bridge.mm
@@ -10,3 +10,5 @@
 
 NSString* const kStatsReportingEnabledPrefName =
     base::SysUTF8ToNSString(kStatsReportingEnabled);
+
+NSString* const kLastCheckYMDPrefName = base::SysUTF8ToNSString(kLastCheckYMD);


### PR DESCRIPTION
The Swift-only lastLaunchInfo preference could not be shared with C++ or Objective-C components, limiting which parts of the codebase could read or update the DAU last ping date.

The PR stores the date as brave.stats.last_ping_date in local state using base::Time so all platform layers share a single typed value.

## Test plan

### Test case 1

* Fresh install
* Verify that Daily usage ping was sent on start with first=true.
* Verify that only one Daily usage ping was sent on start.
* Verify `brave.stats.last_check_ymd` preference in brave://local-state that is set to current date in UTC
* Wait for 10 minutes (need to more that 5 minutes wait because Daily usage ping timer is fired every 5 minutes)
* Verify that Daily usage ping was not sent
~~* Forward clock to 12 hour~~
~~* Verify that Daily usage ping was not sent~~
~~* Forward clock to 11 hours~~
~~* Verify that Daily usage ping was not sent~~
* Forward clock to 1 day
* Verify that Daily usage ping was sent
* Verify `brave.stats.last_check_ymd` preference in brave://local-state that is set to new date
* Forward clock to 1 week
* Verify that weekly usage ping is sent
* Verify `brave.stats.last_check_ymd` preference in brave://local-state that is set to new date
* Forward clock to 1 month
* monthly usage ping is sent
* Verify `brave.stats.last_check_ymd` preference in brave://local-state that is set to new date

### Test case 2

* Fresh install of an old version
* Verify that only one Daily usage ping was sent on start.
* Close the browser
* Install latest version
* Verify  that Daily usage ping is NOT sent on start.
* Verify `brave.stats.last_check_ymd` preference in brave://local-state that is set to current date in UTC
* Forward clock to 1 day
* Verify that Daily usage ping was sent
* Verify `brave.stats.last_check_ymd` preference in brave://local-state that is set to new date

### Test case 3

* Fresh install of an old version
* Verify that only one Daily usage ping was sent on start.
* Close the browser
* Forward clock to 1 day
* Install latest version
* Verify that Daily usage ping was sent
* Verify `brave.stats.last_check_ymd` preference in brave://local-state that is set to current date in UTC


<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/54317

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
