### PR TITLE
[AI Chat] Allow both Active and ActiveDisconnected users to attempt credential refresh (uplift to 1.90.x)

### DIFF
--- a/components/ai_chat/core/browser/ai_chat_credential_manager.cc
+++ b/components/ai_chat/core/browser/ai_chat_credential_manager.cc
@@ -241,7 +241,8 @@ void AIChatCredentialManager::OnGetPremiumStatus(
         callback,
     mojom::PremiumStatus status,
     mojom::PremiumInfoPtr info) {
-  if (status != mojom::PremiumStatus::Active) {
+  if (status != mojom::PremiumStatus::Active &&
+      status != mojom::PremiumStatus::ActiveDisconnected) {
     std::move(callback).Run(std::nullopt);
     return;
   }


### PR DESCRIPTION
Uplift of #35229
Resolves https://github.com/brave/brave-browser/issues/54375

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.