### PR TITLE
[Wallet] Security fixes for Polkadot metadata parsing

### DIFF
--- a/components/brave_wallet/browser/internal/polkadot_chain_metadata.rs
+++ b/components/brave_wallet/browser/internal/polkadot_chain_metadata.rs
@@ -74,9 +74,15 @@ fn decode_scale<T: Decode>(input: &mut &[u8]) -> Result<T, Error> {
     T::decode(input).map_err(|_| Error::InvalidScale)
 }
 
+const MAX_VEC_LEN: usize = 10_000;
+
 fn decode_vec_len(input: &mut &[u8]) -> Result<usize, Error> {
     let len: Compact<u32> = decode_scale(input)?;
-    usize::try_from(len.0).map_err(|_| Error::InvalidLength)
+    let len = usize::try_from(len.0).map_err(|_| Error::InvalidLength)?;
+    if len > MAX_VEC_LEN {
+        return Err(Error::InvalidLength);
+    }
+    Ok(len)
 }
 
 fn decode_type_id(input: &mut &[u8]) -> Result<u32, Error> {
@@ -233,10 +239,21 @@ fn parse_storage_entry_type(input: &mut &[u8]) -> Result<(), Error> {
         }
         // Map { hashers, key, value }
         1 => {
-            let _ = decode_vec(input, |input| {
+            let saved = *input;
+            // Most runtimes (including v14 Polkadot) use Vec<StorageHasher>.
+            if decode_vec(input, |input| {
                 let _: u8 = decode_scale(input)?;
                 Ok(())
-            })?;
+            })
+            .is_ok()
+            {
+                let _: u32 = decode_type_id(input)?;
+                let _: u32 = decode_type_id(input)?;
+                return Ok(());
+            }
+            // Fallback: v14 spec defines a single StorageHasher byte.
+            *input = saved;
+            let _: u8 = decode_scale(input)?;
             let _: u32 = decode_type_id(input)?;
             let _: u32 = decode_type_id(input)?;
             Ok(())
@@ -302,8 +319,11 @@ fn parse_pallets(input: &mut &[u8], has_pallet_docs: bool) -> Result<Vec<PalletI
 }
 
 // SS58Prefix constant is SCALE-encoded but the concrete integer width varies
-// across runtimes (u8, u16, or u32). Try each width and accept the first that
-// consumes the entire buffer.
+// across runtimes (u8, u16, u32, or Compact<u32>). Try fixed-width first,
+// then Compact<u32>, accepting whichever consumes the entire buffer.
+// Compact<u32> must come after u16/u32 to avoid misinterpreting multi-byte
+// fixed-width encodings as compact (e.g. u16(42)=[0x2a,0x00] has mode bits
+// 10 which compact decodes as value 10, not 42).
 fn decode_ss58_prefix(raw: &[u8]) -> Option<u16> {
     let mut input = raw;
     if let Ok(v) = u16::decode(&mut input) {
@@ -313,6 +333,12 @@ fn decode_ss58_prefix(raw: &[u8]) -> Option<u16> {
     }
     let mut input = raw;
     if let Ok(v) = u32::decode(&mut input) {
+        if input.is_empty() {
+            return u16::try_from(v).ok();
+        }
+    }
+    let mut input = raw;
+    if let Ok(Compact(v)) = Compact::<u32>::decode(&mut input) {
         if input.is_empty() {
             return u16::try_from(v).ok();
         }

--- a/components/brave_wallet/browser/internal/polkadot_chain_metadata.rs
+++ b/components/brave_wallet/browser/internal/polkadot_chain_metadata.rs
@@ -178,7 +178,6 @@ fn parse_storage_entry_type(input: &mut &[u8]) -> Result<(), Error> {
         // Map { hashers, key, value }
         1 => {
             let saved = *input;
-            // Most runtimes (including v14 Polkadot) use Vec<StorageHasher>.
             if decode_vec(input, decode_scale::<u8>).is_ok() {
                 let _: u32 = decode_type_id(input)?;
                 let _: u32 = decode_type_id(input)?;
@@ -251,11 +250,8 @@ fn parse_pallets(input: &mut &[u8], has_pallet_docs: bool) -> Result<Vec<PalletI
 }
 
 // SS58Prefix constant is SCALE-encoded but the concrete integer width varies
-// across runtimes (u8, u16, u32, or Compact<u32>). Try fixed-width first,
-// then Compact<u32>, accepting whichever consumes the entire buffer.
-// Compact<u32> must come after u16/u32 to avoid misinterpreting multi-byte
-// fixed-width encodings as compact (e.g. u16(42)=[0x2a,0x00] has mode bits
-// 10 which compact decodes as value 10, not 42).
+// across runtimes (u8, u16, u32, or Compact<u32>). Try fixed-width first to
+// avoid misinterpreting multi-byte fixed-width encodings as compact.
 fn decode_ss58_prefix(raw: &[u8]) -> Option<u16> {
     let mut input = raw;
     if let Ok(v) = u16::decode(&mut input) {

--- a/components/brave_wallet/browser/internal/polkadot_chain_metadata.rs
+++ b/components/brave_wallet/browser/internal/polkadot_chain_metadata.rs
@@ -11,9 +11,15 @@ fn decode_scale<T: Decode>(input: &mut &[u8]) -> Result<T, Error> {
     T::decode(input).map_err(|_| Error::InvalidScale)
 }
 
+const MAX_VEC_LEN: usize = 10_000;
+
 fn decode_vec_len(input: &mut &[u8]) -> Result<usize, Error> {
     let len: Compact<u32> = decode_scale(input)?;
-    usize::try_from(len.0).map_err(|_| Error::InvalidLength)
+    let len = usize::try_from(len.0).map_err(|_| Error::InvalidLength)?;
+    if len > MAX_VEC_LEN {
+        return Err(Error::InvalidLength);
+    }
+    Ok(len)
 }
 
 fn decode_type_id(input: &mut &[u8]) -> Result<u32, Error> {
@@ -171,10 +177,21 @@ fn parse_storage_entry_type(input: &mut &[u8]) -> Result<(), Error> {
         }
         // Map { hashers, key, value }
         1 => {
-            let _ = decode_vec(input, |input| {
+            let saved = *input;
+            // Most runtimes (including v14 Polkadot) use Vec<StorageHasher>.
+            if decode_vec(input, |input| {
                 let _: u8 = decode_scale(input)?;
                 Ok(())
-            })?;
+            })
+            .is_ok()
+            {
+                let _: u32 = decode_type_id(input)?;
+                let _: u32 = decode_type_id(input)?;
+                return Ok(());
+            }
+            // Fallback: v14 spec defines a single StorageHasher byte.
+            *input = saved;
+            let _: u8 = decode_scale(input)?;
             let _: u32 = decode_type_id(input)?;
             let _: u32 = decode_type_id(input)?;
             Ok(())
@@ -239,8 +256,11 @@ fn parse_pallets(input: &mut &[u8], has_pallet_docs: bool) -> Result<Vec<PalletI
 }
 
 // SS58Prefix constant is SCALE-encoded but the concrete integer width varies
-// across runtimes (u8, u16, or u32). Try each width and accept the first that
-// consumes the entire buffer.
+// across runtimes (u8, u16, u32, or Compact<u32>). Try fixed-width first,
+// then Compact<u32>, accepting whichever consumes the entire buffer.
+// Compact<u32> must come after u16/u32 to avoid misinterpreting multi-byte
+// fixed-width encodings as compact (e.g. u16(42)=[0x2a,0x00] has mode bits
+// 10 which compact decodes as value 10, not 42).
 fn decode_ss58_prefix(raw: &[u8]) -> Option<u16> {
     let mut input = raw;
     if let Ok(v) = u16::decode(&mut input) {
@@ -250,6 +270,12 @@ fn decode_ss58_prefix(raw: &[u8]) -> Option<u16> {
     }
     let mut input = raw;
     if let Ok(v) = u32::decode(&mut input) {
+        if input.is_empty() {
+            return u16::try_from(v).ok();
+        }
+    }
+    let mut input = raw;
+    if let Ok(Compact(v)) = Compact::<u32>::decode(&mut input) {
         if input.is_empty() {
             return u16::try_from(v).ok();
         }

--- a/components/brave_wallet/browser/internal/polkadot_chain_metadata.rs
+++ b/components/brave_wallet/browser/internal/polkadot_chain_metadata.rs
@@ -179,12 +179,7 @@ fn parse_storage_entry_type(input: &mut &[u8]) -> Result<(), Error> {
         1 => {
             let saved = *input;
             // Most runtimes (including v14 Polkadot) use Vec<StorageHasher>.
-            if decode_vec(input, |input| {
-                let _: u8 = decode_scale(input)?;
-                Ok(())
-            })
-            .is_ok()
-            {
+            if decode_vec(input, decode_scale::<u8>).is_ok() {
                 let _: u32 = decode_type_id(input)?;
                 let _: u32 = decode_type_id(input)?;
                 return Ok(());

--- a/components/brave_wallet/browser/polkadot/polkadot_chain_metadata_unittest.cc
+++ b/components/brave_wallet/browser/polkadot/polkadot_chain_metadata_unittest.cc
@@ -149,4 +149,218 @@ TEST(PolkadotChainMetadataUnitTest, ParseRealStateGetMetadataResponseWestend) {
   EXPECT_EQ(metadata->GetSpecVersion(), 1022000u);
 }
 
+// ---------------------------------------------------------------------------
+// Security validation tests: these tests document parsing bugs that could
+// lead to incorrect extrinsic construction (wrong pallet/call indices) and
+// thus potential loss of funds.  Each test is labelled with a concern number
+// that maps to the security review findings for PR #34784.
+// ---------------------------------------------------------------------------
+
+// Concern #1: v14 Map storage format mismatch.
+//
+// In RuntimeMetadataV14, StorageEntryType::Map encodes the hasher as a
+// single StorageHasher enum byte:
+//   Map { hasher: StorageHasher, key: TypeId, value: TypeId }
+//
+// In RuntimeMetadataV15, it was changed to a Vec:
+//   Map { hashers: Vec<StorageHasher>, key: TypeId, value: TypeId }
+//
+// The parser always uses the v15 Vec format regardless of the version byte,
+// so v14 metadata with Map storage entries where the hasher byte is != 0
+// will be misinterpreted.  When hasher=0 (Blake2_128), the byte 0x00
+// accidentally decodes as Compact(0) → empty Vec, so it works by luck.
+// When hasher=1 (Blake2_256), byte 0x01 triggers two-byte Compact mode,
+// overconsuming the next byte and causing a parse failure or silent misparse.
+//
+// Impact: A malicious or legacy v14 RPC node could return metadata that the
+// parser silently misparses, producing wrong pallet/call indices that flow
+// directly into extrinsic encoding for fund transfers.
+
+// v14 metadata with no storage entries — baseline that should parse correctly.
+TEST(PolkadotChainMetadataUnitTest, Security_V14NoStorage_ParsesCorrectly) {
+  std::vector<uint8_t> bytes;
+  ASSERT_TRUE(PrefixedHexStringToBytes(
+      "0x6d6574610e0c0000000104507472616e736665725f616c6c6f775f6465617468000000"
+      "0004043852756e74696d6556657273696f6e0000000008041c4163636f756e7404045401"
+      "08000800000000000000000000c1853797374656d00000008285353353850726566697808"
+      "082a00001c56657273696f6e0428000000000000640000000000002042616c616e636573"
+      "00010000000005485472616e73616374696f6e5061796d656e74000000000020",
+      &bytes));
+  auto metadata = PolkadotChainMetadata::FromBytes(bytes);
+  ASSERT_TRUE(metadata);
+  EXPECT_EQ(metadata->GetSs58Prefix(), 42u);
+  EXPECT_EQ(metadata->GetBalancesPalletIndex(), 5u);
+  EXPECT_EQ(metadata->GetSpecVersion(), 100u);
+}
+
+// v14 metadata with Map storage, hasher=0 (Blake2_128).
+// Byte 0x00 accidentally decodes as Compact(0)=empty Vec, so this works.
+TEST(PolkadotChainMetadataUnitTest, Security_V14MapStorageHasher0_ParsesByLuck) {
+  std::vector<uint8_t> bytes;
+  ASSERT_TRUE(PrefixedHexStringToBytes(
+      "0x6d6574610e0c0000000104507472616e736665725f616c6c6f775f6465617468000000"
+      "0004043852756e74696d6556657273696f6e0000000008041c4163636f756e7404045401"
+      "08000800000000000000000000c1853797374656d011853797374656d041c4163636f756e"
+      "740101000808040000000008285353353850726566697808082a00001c56657273696f6e04"
+      "28000000000000640000000000002042616c616e63657300010000000005485472616e7361"
+      "6374696f6e5061796d656e74000000000020",
+      &bytes));
+  auto metadata = PolkadotChainMetadata::FromBytes(bytes);
+  ASSERT_TRUE(metadata);
+  EXPECT_EQ(metadata->GetSs58Prefix(), 42u);
+  EXPECT_EQ(metadata->GetBalancesPalletIndex(), 5u);
+}
+
+// v14 metadata with Map storage, hasher=1 (Blake2_256).
+// Byte 0x01 triggers two-byte Compact mode, consuming the next byte and
+// producing a bogus vec length. The parser then fails to decode.
+// BUG: The parser accepts version=14 but doesn't handle v14 Map format.
+TEST(PolkadotChainMetadataUnitTest, Security_V14MapStorageHasher1_FailsToParse) {
+  std::vector<uint8_t> bytes;
+  ASSERT_TRUE(PrefixedHexStringToBytes(
+      "0x6d6574610e0c0000000104507472616e736665725f616c6c6f775f6465617468000000"
+      "0004043852756e74696d6556657273696f6e0000000008041c4163636f756e7404045401"
+      "08000800000000000000000000c1853797374656d011853797374656d041c4163636f756e"
+      "740101010808040000000008285353353850726566697808082a00001c56657273696f6e04"
+      "28000000000000640000000000002042616c616e63657300010000000005485472616e7361"
+      "6374696f6e5061796d656e74000000000020",
+      &bytes));
+  auto metadata = PolkadotChainMetadata::FromBytes(bytes);
+  // BUG: This should parse correctly for v14 metadata. Instead it returns
+  // nullopt because the parser always uses the v15 Vec<StorageHasher> format
+  // for Map storage entries, which is incompatible with v14's single-byte
+  // hasher encoding.
+  EXPECT_FALSE(metadata);
+}
+
+// v15 metadata with the same Map storage entry (hasher=1 as Vec<u8>).
+// This is the correct format and should parse without issues.
+TEST(PolkadotChainMetadataUnitTest, Security_V15MapStorageHasher1_ParsesCorrectly) {
+  std::vector<uint8_t> bytes;
+  ASSERT_TRUE(PrefixedHexStringToBytes(
+      "0x6d6574610f0c0000000104507472616e736665725f616c6c6f775f6465617468000000"
+      "0004043852756e74696d6556657273696f6e0000000008041c4163636f756e7404045401"
+      "08000800000000000000000000c1853797374656d011853797374656d041c4163636f756e"
+      "74010104010808040000000008285353353850726566697808082a00001c56657273696f6e"
+      "042800000000000064000000000000002042616c616e6365730001000000000500485472"
+      "616e73616374696f6e5061796d656e7400000000002000",
+      &bytes));
+  auto metadata = PolkadotChainMetadata::FromBytes(bytes);
+  ASSERT_TRUE(metadata);
+  EXPECT_EQ(metadata->GetSs58Prefix(), 42u);
+  EXPECT_EQ(metadata->GetBalancesPalletIndex(), 5u);
+}
+
+// Concern #2: decode_ss58_prefix doesn't handle Compact<u32> encoding.
+//
+// The SS58Prefix constant is SCALE-encoded, but its concrete integer width
+// varies across runtimes (u8, u16, u32, or Compact<u32>). The parser tries
+// fixed-width u16, u32, u8 in order, checking that all bytes are consumed.
+//
+// When a runtime encodes SS58Prefix as Compact<u32>(42), the bytes are
+// [0xa8] (single-byte Compact: (42 << 2) | 0b00 = 168). The parser's u16
+// decode fails (needs 2 bytes), u32 decode fails (needs 4 bytes), then u8
+// decode succeeds reading 0xa8=168. The parser returns ss58_prefix=168
+// instead of the correct value 42.
+//
+// Impact: Wrong ss58_prefix flows into ParsePolkadotAccount, which decodes
+// recipient addresses. A wrong prefix could cause address misinterpretation,
+// potentially sending funds to a different address than intended.
+
+// Control: v15 metadata with SS58Prefix as u16(42)=[0x2a, 0x00] → returns 42.
+TEST(PolkadotChainMetadataUnitTest, Security_SS58PrefixU16_ReturnsCorrectValue) {
+  std::vector<uint8_t> bytes;
+  ASSERT_TRUE(PrefixedHexStringToBytes(
+      "0x6d6574610f0c0000000104507472616e736665725f616c6c6f775f6465617468000000"
+      "0004043852756e74696d6556657273696f6e0000000008041c4163636f756e7404045401"
+      "08000800000000000000000000c1853797374656d011853797374656d041c4163636f756e"
+      "74010104010808040000000008285353353850726566697808082a00001c56657273696f6e"
+      "042800000000000064000000000000002042616c616e6365730001000000000500485472"
+      "616e73616374696f6e5061796d656e7400000000002000",
+      &bytes));
+  auto metadata = PolkadotChainMetadata::FromBytes(bytes);
+  ASSERT_TRUE(metadata);
+  EXPECT_EQ(metadata->GetSs58Prefix(), 42u);
+}
+
+// BUG: v15 metadata with SS58Prefix as Compact<u32>(42)=[0xa8].
+// The parser reads 0xa8 as u8=168, returning ss58_prefix=168 instead of 42.
+TEST(PolkadotChainMetadataUnitTest, Security_SS58PrefixCompact_ReturnsWrongValue) {
+  std::vector<uint8_t> bytes;
+  ASSERT_TRUE(PrefixedHexStringToBytes(
+      "0x6d6574610f0c0000000104507472616e736665725f616c6c6f775f6465617468000000"
+      "0004043852756e74696d6556657273696f6e0000000008041c4163636f756e7404045401"
+      "08000800000000000000000000c1853797374656d011853797374656d041c4163636f756e"
+      "7401010401080804000000000828535335385072656669780804a8001c56657273696f6e"
+      "042800000000000064000000000000002042616c616e6365730001000000000500485472"
+      "616e73616374696f6e5061796d656e7400000000002000",
+      &bytes));
+  auto metadata = PolkadotChainMetadata::FromBytes(bytes);
+  ASSERT_TRUE(metadata);
+  // BUG: ss58_prefix should be 42 but the parser returns 168 because
+  // decode_ss58_prefix doesn't attempt Compact<u32> decoding before the
+  // fixed-width fallbacks.  Compact<u32>(42) encodes as [0xa8], which the
+  // u8 fallback reads as the raw byte value 168.
+  EXPECT_EQ(metadata->GetSs58Prefix(), 168u);
+}
+
+// Concern #3: Parser does not validate that all input bytes are consumed.
+//
+// After reading all expected fields, the parser never checks that the input
+// buffer is empty. If the metadata format is subtly different from what the
+// parser expects (e.g., an extra field in a future version), the parser could
+// silently succeed with wrong values while leaving trailing data unread.
+//
+// Impact: A compromised RPC could append arbitrary bytes to a valid metadata
+// response. While the current parser reads specific fields in order and would
+// likely still extract correct values, the lack of a trailing-bytes check
+// means format drift would go undetected.
+
+TEST(PolkadotChainMetadataUnitTest,
+     Security_TrailingBytesNotRejected_ShouldFail) {
+  std::vector<uint8_t> bytes;
+  ASSERT_TRUE(PrefixedHexStringToBytes(
+      "0x6d6574610f0c0000000104507472616e736665725f616c6c6f775f6465617468000000"
+      "0004043852756e74696d6556657273696f6e0000000008041c4163636f756e7404045401"
+      "08000800000000000000000000c1853797374656d011853797374656d041c4163636f756e"
+      "74010104010808040000000008285353353850726566697808082a00001c56657273696f6e"
+      "042800000000000064000000000000002042616c616e6365730001000000000500485472"
+      "616e73616374696f6e5061796d656e7400000000002000deadbeef",
+      &bytes));
+  auto metadata = PolkadotChainMetadata::FromBytes(bytes);
+  // BUG: FromBytes should reject metadata with trailing bytes, but it
+  // silently accepts them. The metadata values happen to be correct here
+  // because the parser reads fields in order and stops after the last one
+  // it needs, ignoring the trailing 0xdeadbeef.
+  ASSERT_TRUE(metadata);
+  EXPECT_EQ(metadata->GetSs58Prefix(), 42u);
+  EXPECT_EQ(metadata->GetBalancesPalletIndex(), 5u);
+}
+
+// Concern #4: Unbounded Vec::with_capacity on untrusted vec length.
+//
+// decode_vec reads a Compact<u32> length from the input and immediately
+// calls Vec::with_capacity(len) without any bounds check. A malicious RPC
+// response with a huge Compact length could cause the browser to allocate
+// excessive memory before the first element decode fails.
+//
+// This is a DoS vector — no fund loss, but it could crash the browser tab.
+// The test below uses a moderate length that won't OOM but demonstrates the
+// parser doesn't validate lengths before allocation.
+//
+// Note: A truly malicious length (e.g., Compact(u32::MAX)) could allocate
+// several GB before failing. The fix would be to add a reasonable upper
+// bound in decode_vec_len (e.g., reject lengths > 10_000).
+
+TEST(PolkadotChainMetadataUnitTest,
+     Security_HugeVecLength_ParserDoesNotValidateLength) {
+  // Valid magic + version 15, then a Compact<u32>(50000) for the portable
+  // registry types vec. There is nowhere near enough data for 50000 types,
+  // so the parser will fail — but it allocates a HashMap and iterates before
+  // detecting the insufficient data.
+  std::vector<uint8_t> bytes;
+  ASSERT_TRUE(PrefixedHexStringToBytes("0x6d6574610f420d0300", &bytes));
+  EXPECT_FALSE(PolkadotChainMetadata::FromBytes(bytes));
+}
+
 }  // namespace brave_wallet

--- a/components/brave_wallet/browser/polkadot/polkadot_chain_metadata_unittest.cc
+++ b/components/brave_wallet/browser/polkadot/polkadot_chain_metadata_unittest.cc
@@ -150,9 +150,7 @@ TEST(PolkadotChainMetadataUnitTest, ParseRealStateGetMetadataResponseWestend) {
 }
 
 // ---------------------------------------------------------------------------
-// Security validation tests: these tests document parsing bugs that could
-// lead to incorrect extrinsic construction (wrong pallet/call indices) and
-// thus potential loss of funds.  Each test is labelled with a concern number
+// Security validation tests: each test is labelled with a concern number
 // that maps to the security review findings for PR #34784.
 // ---------------------------------------------------------------------------
 
@@ -165,26 +163,18 @@ TEST(PolkadotChainMetadataUnitTest, ParseRealStateGetMetadataResponseWestend) {
 // In RuntimeMetadataV15, it was changed to a Vec:
 //   Map { hashers: Vec<StorageHasher>, key: TypeId, value: TypeId }
 //
-// The parser always uses the v15 Vec format regardless of the version byte,
-// so v14 metadata with Map storage entries where the hasher byte is != 0
-// will be misinterpreted.  When hasher=0 (Blake2_128), the byte 0x00
-// accidentally decodes as Compact(0) → empty Vec, so it works by luck.
-// When hasher=1 (Blake2_256), byte 0x01 triggers two-byte Compact mode,
-// overconsuming the next byte and causing a parse failure or silent misparse.
-//
-// Impact: A malicious or legacy v14 RPC node could return metadata that the
-// parser silently misparses, producing wrong pallet/call indices that flow
-// directly into extrinsic encoding for fund transfers.
+// FIX: The parser now tries Vec<StorageHasher> first, and falls back to a
+// single byte on decode failure, handling both v14 and v15 formats.
 
 // v14 metadata with no storage entries — baseline that should parse correctly.
 TEST(PolkadotChainMetadataUnitTest, Security_V14NoStorage_ParsesCorrectly) {
   std::vector<uint8_t> bytes;
   ASSERT_TRUE(PrefixedHexStringToBytes(
-      "0x6d6574610e0c0000000104507472616e736665725f616c6c6f775f6465617468000000"
-      "0004043852756e74696d6556657273696f6e0000000008041c4163636f756e7404045401"
-      "08000800000000000000000000c1853797374656d00000008285353353850726566697808"
-      "082a00001c56657273696f6e0428000000000000640000000000002042616c616e636573"
-      "00010000000005485472616e73616374696f6e5061796d656e74000000000020",
+      "0x6d6574610e080000000000000400000104507472616e736665725f616c6c6f"
+      "775f6465617468000000000c1853797374656d00000008285353353850726566"
+      "697800082a00001c56657273696f6e005820706f6c6b61646f74106e6f646501"
+      "000000640000000000002042616c616e63657300010400000005485472616e73"
+      "616374696f6e5061796d656e74000000000003",
       &bytes));
   auto metadata = PolkadotChainMetadata::FromBytes(bytes);
   ASSERT_TRUE(metadata);
@@ -194,16 +184,16 @@ TEST(PolkadotChainMetadataUnitTest, Security_V14NoStorage_ParsesCorrectly) {
 }
 
 // v14 metadata with Map storage, hasher=0 (Blake2_128).
-// Byte 0x00 accidentally decodes as Compact(0)=empty Vec, so this works.
-TEST(PolkadotChainMetadataUnitTest, Security_V14MapStorageHasher0_ParsesByLuck) {
+// Vec<StorageHasher> decode succeeds: 0x00 decodes as Compact(0)=empty vec.
+TEST(PolkadotChainMetadataUnitTest, Security_V14MapStorageHasher0_ParsesCorrectly) {
   std::vector<uint8_t> bytes;
   ASSERT_TRUE(PrefixedHexStringToBytes(
-      "0x6d6574610e0c0000000104507472616e736665725f616c6c6f775f6465617468000000"
-      "0004043852756e74696d6556657273696f6e0000000008041c4163636f756e7404045401"
-      "08000800000000000000000000c1853797374656d011853797374656d041c4163636f756e"
-      "740101000808040000000008285353353850726566697808082a00001c56657273696f6e04"
-      "28000000000000640000000000002042616c616e63657300010000000005485472616e7361"
-      "6374696f6e5061796d656e74000000000020",
+      "0x6d6574610e080000000000000400000104507472616e736665725f616c6c6f"
+      "775f6465617468000000000c1853797374656d011853797374656d041c416363"
+      "6f756e7400010000000000000008285353353850726566697800082a00001c56"
+      "657273696f6e005820706f6c6b61646f74106e6f646501000000640000000000"
+      "002042616c616e63657300010400000005485472616e73616374696f6e506179"
+      "6d656e74000000000003",
       &bytes));
   auto metadata = PolkadotChainMetadata::FromBytes(bytes);
   ASSERT_TRUE(metadata);
@@ -212,38 +202,34 @@ TEST(PolkadotChainMetadataUnitTest, Security_V14MapStorageHasher0_ParsesByLuck) 
 }
 
 // v14 metadata with Map storage, hasher=1 (Blake2_256).
-// Byte 0x01 triggers two-byte Compact mode, consuming the next byte and
-// producing a bogus vec length. The parser then fails to decode.
-// BUG: The parser accepts version=14 but doesn't handle v14 Map format.
-TEST(PolkadotChainMetadataUnitTest, Security_V14MapStorageHasher1_FailsToParse) {
+// Vec<StorageHasher> decode fails (0x01 triggers two-byte Compact mode),
+// but the single-byte fallback succeeds.
+TEST(PolkadotChainMetadataUnitTest, Security_V14MapStorageHasher1_ParsesCorrectly) {
   std::vector<uint8_t> bytes;
   ASSERT_TRUE(PrefixedHexStringToBytes(
-      "0x6d6574610e0c0000000104507472616e736665725f616c6c6f775f6465617468000000"
-      "0004043852756e74696d6556657273696f6e0000000008041c4163636f756e7404045401"
-      "08000800000000000000000000c1853797374656d011853797374656d041c4163636f756e"
-      "740101010808040000000008285353353850726566697808082a00001c56657273696f6e04"
-      "28000000000000640000000000002042616c616e63657300010000000005485472616e7361"
-      "6374696f6e5061796d656e74000000000020",
+      "0x6d6574610e080000000000000400000104507472616e736665725f616c6c6f"
+      "775f6465617468000000000c1853797374656d011853797374656d041c416363"
+      "6f756e7400010100000000000008285353353850726566697800082a00001c56"
+      "657273696f6e005820706f6c6b61646f74106e6f646501000000640000000000"
+      "002042616c616e63657300010400000005485472616e73616374696f6e506179"
+      "6d656e74000000000003",
       &bytes));
   auto metadata = PolkadotChainMetadata::FromBytes(bytes);
-  // BUG: This should parse correctly for v14 metadata. Instead it returns
-  // nullopt because the parser always uses the v15 Vec<StorageHasher> format
-  // for Map storage entries, which is incompatible with v14's single-byte
-  // hasher encoding.
-  EXPECT_FALSE(metadata);
+  ASSERT_TRUE(metadata);
+  EXPECT_EQ(metadata->GetSs58Prefix(), 42u);
+  EXPECT_EQ(metadata->GetBalancesPalletIndex(), 5u);
 }
 
-// v15 metadata with the same Map storage entry (hasher=1 as Vec<u8>).
-// This is the correct format and should parse without issues.
+// v15 metadata with Map storage, hasher=1 encoded as Vec<StorageHasher>([1]).
 TEST(PolkadotChainMetadataUnitTest, Security_V15MapStorageHasher1_ParsesCorrectly) {
   std::vector<uint8_t> bytes;
   ASSERT_TRUE(PrefixedHexStringToBytes(
-      "0x6d6574610f0c0000000104507472616e736665725f616c6c6f775f6465617468000000"
-      "0004043852756e74696d6556657273696f6e0000000008041c4163636f756e7404045401"
-      "08000800000000000000000000c1853797374656d011853797374656d041c4163636f756e"
-      "74010104010808040000000008285353353850726566697808082a00001c56657273696f6e"
-      "042800000000000064000000000000002042616c616e6365730001000000000500485472"
-      "616e73616374696f6e5061796d656e7400000000002000",
+      "0x6d6574610f080000000000000400000104507472616e736665725f616c6c6f"
+      "775f6465617468000000000c1853797374656d011853797374656d041c416363"
+      "6f756e740001040100000000000008285353353850726566697800082a00001c"
+      "56657273696f6e005820706f6c6b61646f74106e6f6465010000006400000000"
+      "0000002042616c616e6365730001040000000500485472616e73616374696f6e"
+      "5061796d656e7400000000000300",
       &bytes));
   auto metadata = PolkadotChainMetadata::FromBytes(bytes);
   ASSERT_TRUE(metadata);
@@ -254,84 +240,66 @@ TEST(PolkadotChainMetadataUnitTest, Security_V15MapStorageHasher1_ParsesCorrectl
 // Concern #2: decode_ss58_prefix doesn't handle Compact<u32> encoding.
 //
 // The SS58Prefix constant is SCALE-encoded, but its concrete integer width
-// varies across runtimes (u8, u16, u32, or Compact<u32>). The parser tries
-// fixed-width u16, u32, u8 in order, checking that all bytes are consumed.
+// varies across runtimes (u8, u16, u32, or Compact<u32>).
 //
-// When a runtime encodes SS58Prefix as Compact<u32>(42), the bytes are
-// [0xa8] (single-byte Compact: (42 << 2) | 0b00 = 168). The parser's u16
-// decode fails (needs 2 bytes), u32 decode fails (needs 4 bytes), then u8
-// decode succeeds reading 0xa8=168. The parser returns ss58_prefix=168
-// instead of the correct value 42.
-//
-// Impact: Wrong ss58_prefix flows into ParsePolkadotAccount, which decodes
-// recipient addresses. A wrong prefix could cause address misinterpretation,
-// potentially sending funds to a different address than intended.
+// FIX: The parser now tries u16, u32, Compact<u32>, then u8 in order,
+// checking that all bytes are consumed. Compact<u32> is tried after u16/u32
+// to avoid misinterpreting multi-byte fixed-width encodings as compact.
 
-// Control: v15 metadata with SS58Prefix as u16(42)=[0x2a, 0x00] → returns 42.
+// v15 metadata with SS58Prefix as u16(42)=[0x2a, 0x00] → returns 42.
 TEST(PolkadotChainMetadataUnitTest, Security_SS58PrefixU16_ReturnsCorrectValue) {
   std::vector<uint8_t> bytes;
   ASSERT_TRUE(PrefixedHexStringToBytes(
-      "0x6d6574610f0c0000000104507472616e736665725f616c6c6f775f6465617468000000"
-      "0004043852756e74696d6556657273696f6e0000000008041c4163636f756e7404045401"
-      "08000800000000000000000000c1853797374656d011853797374656d041c4163636f756e"
-      "74010104010808040000000008285353353850726566697808082a00001c56657273696f6e"
-      "042800000000000064000000000000002042616c616e6365730001000000000500485472"
-      "616e73616374696f6e5061796d656e7400000000002000",
+      "0x6d6574610f080000000000000400000104507472616e736665725f616c6c6f"
+      "775f6465617468000000000c1853797374656d00000008285353353850726566"
+      "697800082a00001c56657273696f6e005820706f6c6b61646f74106e6f646501"
+      "00000064000000000000002042616c616e636573000104000000050048547261"
+      "6e73616374696f6e5061796d656e7400000000000300",
       &bytes));
   auto metadata = PolkadotChainMetadata::FromBytes(bytes);
   ASSERT_TRUE(metadata);
   EXPECT_EQ(metadata->GetSs58Prefix(), 42u);
 }
 
-// BUG: v15 metadata with SS58Prefix as Compact<u32>(42)=[0xa8].
-// The parser reads 0xa8 as u8=168, returning ss58_prefix=168 instead of 42.
-TEST(PolkadotChainMetadataUnitTest, Security_SS58PrefixCompact_ReturnsWrongValue) {
+// v15 metadata with SS58Prefix as Compact<u32>(42)=[0xa8] → returns 42.
+TEST(PolkadotChainMetadataUnitTest, Security_SS58PrefixCompact_ReturnsCorrectValue) {
   std::vector<uint8_t> bytes;
   ASSERT_TRUE(PrefixedHexStringToBytes(
-      "0x6d6574610f0c0000000104507472616e736665725f616c6c6f775f6465617468000000"
-      "0004043852756e74696d6556657273696f6e0000000008041c4163636f756e7404045401"
-      "08000800000000000000000000c1853797374656d011853797374656d041c4163636f756e"
-      "7401010401080804000000000828535335385072656669780804a8001c56657273696f6e"
-      "042800000000000064000000000000002042616c616e6365730001000000000500485472"
-      "616e73616374696f6e5061796d656e7400000000002000",
+      "0x6d6574610f080000000000000400000104507472616e736665725f616c6c6f"
+      "775f6465617468000000000c1853797374656d00000008285353353850726566"
+      "69780004a8001c56657273696f6e005820706f6c6b61646f74106e6f64650100"
+      "000064000000000000002042616c616e6365730001040000000500485472616e"
+      "73616374696f6e5061796d656e7400000000000300",
       &bytes));
   auto metadata = PolkadotChainMetadata::FromBytes(bytes);
   ASSERT_TRUE(metadata);
-  // BUG: ss58_prefix should be 42 but the parser returns 168 because
-  // decode_ss58_prefix doesn't attempt Compact<u32> decoding before the
-  // fixed-width fallbacks.  Compact<u32>(42) encodes as [0xa8], which the
-  // u8 fallback reads as the raw byte value 168.
-  EXPECT_EQ(metadata->GetSs58Prefix(), 168u);
+  EXPECT_EQ(metadata->GetSs58Prefix(), 42u);
 }
 
 // Concern #3: Parser does not validate that all input bytes are consumed.
 //
 // After reading all expected fields, the parser never checks that the input
-// buffer is empty. If the metadata format is subtly different from what the
-// parser expects (e.g., an extra field in a future version), the parser could
-// silently succeed with wrong values while leaving trailing data unread.
+// buffer is empty. A compromised RPC could append arbitrary bytes to valid
+// metadata. Note: real metadata also has trailing fields (extrinsics, APIs,
+// outer_event) that this partial parser doesn't consume, so a trailing-bytes
+// check cannot be added without breaking real-world parsing.
 //
-// Impact: A compromised RPC could append arbitrary bytes to a valid metadata
-// response. While the current parser reads specific fields in order and would
-// likely still extract correct values, the lack of a trailing-bytes check
-// means format drift would go undetected.
+// This test documents the known limitation.
 
 TEST(PolkadotChainMetadataUnitTest,
-     Security_TrailingBytesNotRejected_ShouldFail) {
+     Security_TrailingBytesNotRejected_KnownLimitation) {
   std::vector<uint8_t> bytes;
   ASSERT_TRUE(PrefixedHexStringToBytes(
-      "0x6d6574610f0c0000000104507472616e736665725f616c6c6f775f6465617468000000"
-      "0004043852756e74696d6556657273696f6e0000000008041c4163636f756e7404045401"
-      "08000800000000000000000000c1853797374656d011853797374656d041c4163636f756e"
-      "74010104010808040000000008285353353850726566697808082a00001c56657273696f6e"
-      "042800000000000064000000000000002042616c616e6365730001000000000500485472"
-      "616e73616374696f6e5061796d656e7400000000002000deadbeef",
+      "0x6d6574610f080000000000000400000104507472616e736665725f616c6c6f"
+      "775f6465617468000000000c1853797374656d00000008285353353850726566"
+      "697800082a00001c56657273696f6e005820706f6c6b61646f74106e6f646501"
+      "00000064000000000000002042616c616e636573000104000000050048547261"
+      "6e73616374696f6e5061796d656e7400000000000300deadbeef",
       &bytes));
   auto metadata = PolkadotChainMetadata::FromBytes(bytes);
-  // BUG: FromBytes should reject metadata with trailing bytes, but it
-  // silently accepts them. The metadata values happen to be correct here
-  // because the parser reads fields in order and stops after the last one
-  // it needs, ignoring the trailing 0xdeadbeef.
+  // Known limitation: trailing bytes are silently accepted. Cannot add a
+  // trailing-bytes check because real metadata has fields after the pallets
+  // section that this partial parser doesn't consume.
   ASSERT_TRUE(metadata);
   EXPECT_EQ(metadata->GetSs58Prefix(), 42u);
   EXPECT_EQ(metadata->GetBalancesPalletIndex(), 5u);
@@ -339,25 +307,11 @@ TEST(PolkadotChainMetadataUnitTest,
 
 // Concern #4: Unbounded Vec::with_capacity on untrusted vec length.
 //
-// decode_vec reads a Compact<u32> length from the input and immediately
-// calls Vec::with_capacity(len) without any bounds check. A malicious RPC
-// response with a huge Compact length could cause the browser to allocate
-// excessive memory before the first element decode fails.
-//
-// This is a DoS vector — no fund loss, but it could crash the browser tab.
-// The test below uses a moderate length that won't OOM but demonstrates the
-// parser doesn't validate lengths before allocation.
-//
-// Note: A truly malicious length (e.g., Compact(u32::MAX)) could allocate
-// several GB before failing. The fix would be to add a reasonable upper
-// bound in decode_vec_len (e.g., reject lengths > 10_000).
+// FIX: decode_vec_len now rejects vec lengths > 10_000 before allocation,
+// preventing a DoS via maliciously large Compact length values.
 
 TEST(PolkadotChainMetadataUnitTest,
-     Security_HugeVecLength_ParserDoesNotValidateLength) {
-  // Valid magic + version 15, then a Compact<u32>(50000) for the portable
-  // registry types vec. There is nowhere near enough data for 50000 types,
-  // so the parser will fail — but it allocates a HashMap and iterates before
-  // detecting the insufficient data.
+     Security_HugeVecLength_RejectedByBoundsCheck) {
   std::vector<uint8_t> bytes;
   ASSERT_TRUE(PrefixedHexStringToBytes("0x6d6574610f420d0300", &bytes));
   EXPECT_FALSE(PolkadotChainMetadata::FromBytes(bytes));

--- a/components/brave_wallet/browser/polkadot/polkadot_chain_metadata_unittest.cc
+++ b/components/brave_wallet/browser/polkadot/polkadot_chain_metadata_unittest.cc
@@ -271,9 +271,7 @@ TEST(PolkadotChainMetadataUnitTest,
 }
 
 // ---------------------------------------------------------------------------
-// Security validation tests: these tests document parsing bugs that could
-// lead to incorrect extrinsic construction (wrong pallet/call indices) and
-// thus potential loss of funds.  Each test is labelled with a concern number
+// Security validation tests: each test is labelled with a concern number
 // that maps to the security review findings for PR #34784.
 // ---------------------------------------------------------------------------
 
@@ -286,26 +284,18 @@ TEST(PolkadotChainMetadataUnitTest,
 // In RuntimeMetadataV15, it was changed to a Vec:
 //   Map { hashers: Vec<StorageHasher>, key: TypeId, value: TypeId }
 //
-// The parser always uses the v15 Vec format regardless of the version byte,
-// so v14 metadata with Map storage entries where the hasher byte is != 0
-// will be misinterpreted.  When hasher=0 (Blake2_128), the byte 0x00
-// accidentally decodes as Compact(0) → empty Vec, so it works by luck.
-// When hasher=1 (Blake2_256), byte 0x01 triggers two-byte Compact mode,
-// overconsuming the next byte and causing a parse failure or silent misparse.
-//
-// Impact: A malicious or legacy v14 RPC node could return metadata that the
-// parser silently misparses, producing wrong pallet/call indices that flow
-// directly into extrinsic encoding for fund transfers.
+// FIX: The parser now tries Vec<StorageHasher> first, and falls back to a
+// single byte on decode failure, handling both v14 and v15 formats.
 
 // v14 metadata with no storage entries — baseline that should parse correctly.
 TEST(PolkadotChainMetadataUnitTest, Security_V14NoStorage_ParsesCorrectly) {
   std::vector<uint8_t> bytes;
   ASSERT_TRUE(PrefixedHexStringToBytes(
-      "0x6d6574610e0c0000000104507472616e736665725f616c6c6f775f6465617468000000"
-      "0004043852756e74696d6556657273696f6e0000000008041c4163636f756e7404045401"
-      "08000800000000000000000000c1853797374656d00000008285353353850726566697808"
-      "082a00001c56657273696f6e0428000000000000640000000000002042616c616e636573"
-      "00010000000005485472616e73616374696f6e5061796d656e74000000000020",
+      "0x6d6574610e080000000000000400000104507472616e736665725f616c6c6f"
+      "775f6465617468000000000c1853797374656d00000008285353353850726566"
+      "697800082a00001c56657273696f6e005820706f6c6b61646f74106e6f646501"
+      "000000640000000000002042616c616e63657300010400000005485472616e73"
+      "616374696f6e5061796d656e74000000000003",
       &bytes));
   auto metadata = PolkadotChainMetadata::FromBytes(bytes);
   ASSERT_TRUE(metadata);
@@ -315,16 +305,16 @@ TEST(PolkadotChainMetadataUnitTest, Security_V14NoStorage_ParsesCorrectly) {
 }
 
 // v14 metadata with Map storage, hasher=0 (Blake2_128).
-// Byte 0x00 accidentally decodes as Compact(0)=empty Vec, so this works.
-TEST(PolkadotChainMetadataUnitTest, Security_V14MapStorageHasher0_ParsesByLuck) {
+// Vec<StorageHasher> decode succeeds: 0x00 decodes as Compact(0)=empty vec.
+TEST(PolkadotChainMetadataUnitTest, Security_V14MapStorageHasher0_ParsesCorrectly) {
   std::vector<uint8_t> bytes;
   ASSERT_TRUE(PrefixedHexStringToBytes(
-      "0x6d6574610e0c0000000104507472616e736665725f616c6c6f775f6465617468000000"
-      "0004043852756e74696d6556657273696f6e0000000008041c4163636f756e7404045401"
-      "08000800000000000000000000c1853797374656d011853797374656d041c4163636f756e"
-      "740101000808040000000008285353353850726566697808082a00001c56657273696f6e04"
-      "28000000000000640000000000002042616c616e63657300010000000005485472616e7361"
-      "6374696f6e5061796d656e74000000000020",
+      "0x6d6574610e080000000000000400000104507472616e736665725f616c6c6f"
+      "775f6465617468000000000c1853797374656d011853797374656d041c416363"
+      "6f756e7400010000000000000008285353353850726566697800082a00001c56"
+      "657273696f6e005820706f6c6b61646f74106e6f646501000000640000000000"
+      "002042616c616e63657300010400000005485472616e73616374696f6e506179"
+      "6d656e74000000000003",
       &bytes));
   auto metadata = PolkadotChainMetadata::FromBytes(bytes);
   ASSERT_TRUE(metadata);
@@ -333,38 +323,34 @@ TEST(PolkadotChainMetadataUnitTest, Security_V14MapStorageHasher0_ParsesByLuck) 
 }
 
 // v14 metadata with Map storage, hasher=1 (Blake2_256).
-// Byte 0x01 triggers two-byte Compact mode, consuming the next byte and
-// producing a bogus vec length. The parser then fails to decode.
-// BUG: The parser accepts version=14 but doesn't handle v14 Map format.
-TEST(PolkadotChainMetadataUnitTest, Security_V14MapStorageHasher1_FailsToParse) {
+// Vec<StorageHasher> decode fails (0x01 triggers two-byte Compact mode),
+// but the single-byte fallback succeeds.
+TEST(PolkadotChainMetadataUnitTest, Security_V14MapStorageHasher1_ParsesCorrectly) {
   std::vector<uint8_t> bytes;
   ASSERT_TRUE(PrefixedHexStringToBytes(
-      "0x6d6574610e0c0000000104507472616e736665725f616c6c6f775f6465617468000000"
-      "0004043852756e74696d6556657273696f6e0000000008041c4163636f756e7404045401"
-      "08000800000000000000000000c1853797374656d011853797374656d041c4163636f756e"
-      "740101010808040000000008285353353850726566697808082a00001c56657273696f6e04"
-      "28000000000000640000000000002042616c616e63657300010000000005485472616e7361"
-      "6374696f6e5061796d656e74000000000020",
+      "0x6d6574610e080000000000000400000104507472616e736665725f616c6c6f"
+      "775f6465617468000000000c1853797374656d011853797374656d041c416363"
+      "6f756e7400010100000000000008285353353850726566697800082a00001c56"
+      "657273696f6e005820706f6c6b61646f74106e6f646501000000640000000000"
+      "002042616c616e63657300010400000005485472616e73616374696f6e506179"
+      "6d656e74000000000003",
       &bytes));
   auto metadata = PolkadotChainMetadata::FromBytes(bytes);
-  // BUG: This should parse correctly for v14 metadata. Instead it returns
-  // nullopt because the parser always uses the v15 Vec<StorageHasher> format
-  // for Map storage entries, which is incompatible with v14's single-byte
-  // hasher encoding.
-  EXPECT_FALSE(metadata);
+  ASSERT_TRUE(metadata);
+  EXPECT_EQ(metadata->GetSs58Prefix(), 42u);
+  EXPECT_EQ(metadata->GetBalancesPalletIndex(), 5u);
 }
 
-// v15 metadata with the same Map storage entry (hasher=1 as Vec<u8>).
-// This is the correct format and should parse without issues.
+// v15 metadata with Map storage, hasher=1 encoded as Vec<StorageHasher>([1]).
 TEST(PolkadotChainMetadataUnitTest, Security_V15MapStorageHasher1_ParsesCorrectly) {
   std::vector<uint8_t> bytes;
   ASSERT_TRUE(PrefixedHexStringToBytes(
-      "0x6d6574610f0c0000000104507472616e736665725f616c6c6f775f6465617468000000"
-      "0004043852756e74696d6556657273696f6e0000000008041c4163636f756e7404045401"
-      "08000800000000000000000000c1853797374656d011853797374656d041c4163636f756e"
-      "74010104010808040000000008285353353850726566697808082a00001c56657273696f6e"
-      "042800000000000064000000000000002042616c616e6365730001000000000500485472"
-      "616e73616374696f6e5061796d656e7400000000002000",
+      "0x6d6574610f080000000000000400000104507472616e736665725f616c6c6f"
+      "775f6465617468000000000c1853797374656d011853797374656d041c416363"
+      "6f756e740001040100000000000008285353353850726566697800082a00001c"
+      "56657273696f6e005820706f6c6b61646f74106e6f6465010000006400000000"
+      "0000002042616c616e6365730001040000000500485472616e73616374696f6e"
+      "5061796d656e7400000000000300",
       &bytes));
   auto metadata = PolkadotChainMetadata::FromBytes(bytes);
   ASSERT_TRUE(metadata);
@@ -375,84 +361,66 @@ TEST(PolkadotChainMetadataUnitTest, Security_V15MapStorageHasher1_ParsesCorrectl
 // Concern #2: decode_ss58_prefix doesn't handle Compact<u32> encoding.
 //
 // The SS58Prefix constant is SCALE-encoded, but its concrete integer width
-// varies across runtimes (u8, u16, u32, or Compact<u32>). The parser tries
-// fixed-width u16, u32, u8 in order, checking that all bytes are consumed.
+// varies across runtimes (u8, u16, u32, or Compact<u32>).
 //
-// When a runtime encodes SS58Prefix as Compact<u32>(42), the bytes are
-// [0xa8] (single-byte Compact: (42 << 2) | 0b00 = 168). The parser's u16
-// decode fails (needs 2 bytes), u32 decode fails (needs 4 bytes), then u8
-// decode succeeds reading 0xa8=168. The parser returns ss58_prefix=168
-// instead of the correct value 42.
-//
-// Impact: Wrong ss58_prefix flows into ParsePolkadotAccount, which decodes
-// recipient addresses. A wrong prefix could cause address misinterpretation,
-// potentially sending funds to a different address than intended.
+// FIX: The parser now tries u16, u32, Compact<u32>, then u8 in order,
+// checking that all bytes are consumed. Compact<u32> is tried after u16/u32
+// to avoid misinterpreting multi-byte fixed-width encodings as compact.
 
-// Control: v15 metadata with SS58Prefix as u16(42)=[0x2a, 0x00] → returns 42.
+// v15 metadata with SS58Prefix as u16(42)=[0x2a, 0x00] → returns 42.
 TEST(PolkadotChainMetadataUnitTest, Security_SS58PrefixU16_ReturnsCorrectValue) {
   std::vector<uint8_t> bytes;
   ASSERT_TRUE(PrefixedHexStringToBytes(
-      "0x6d6574610f0c0000000104507472616e736665725f616c6c6f775f6465617468000000"
-      "0004043852756e74696d6556657273696f6e0000000008041c4163636f756e7404045401"
-      "08000800000000000000000000c1853797374656d011853797374656d041c4163636f756e"
-      "74010104010808040000000008285353353850726566697808082a00001c56657273696f6e"
-      "042800000000000064000000000000002042616c616e6365730001000000000500485472"
-      "616e73616374696f6e5061796d656e7400000000002000",
+      "0x6d6574610f080000000000000400000104507472616e736665725f616c6c6f"
+      "775f6465617468000000000c1853797374656d00000008285353353850726566"
+      "697800082a00001c56657273696f6e005820706f6c6b61646f74106e6f646501"
+      "00000064000000000000002042616c616e636573000104000000050048547261"
+      "6e73616374696f6e5061796d656e7400000000000300",
       &bytes));
   auto metadata = PolkadotChainMetadata::FromBytes(bytes);
   ASSERT_TRUE(metadata);
   EXPECT_EQ(metadata->GetSs58Prefix(), 42u);
 }
 
-// BUG: v15 metadata with SS58Prefix as Compact<u32>(42)=[0xa8].
-// The parser reads 0xa8 as u8=168, returning ss58_prefix=168 instead of 42.
-TEST(PolkadotChainMetadataUnitTest, Security_SS58PrefixCompact_ReturnsWrongValue) {
+// v15 metadata with SS58Prefix as Compact<u32>(42)=[0xa8] → returns 42.
+TEST(PolkadotChainMetadataUnitTest, Security_SS58PrefixCompact_ReturnsCorrectValue) {
   std::vector<uint8_t> bytes;
   ASSERT_TRUE(PrefixedHexStringToBytes(
-      "0x6d6574610f0c0000000104507472616e736665725f616c6c6f775f6465617468000000"
-      "0004043852756e74696d6556657273696f6e0000000008041c4163636f756e7404045401"
-      "08000800000000000000000000c1853797374656d011853797374656d041c4163636f756e"
-      "7401010401080804000000000828535335385072656669780804a8001c56657273696f6e"
-      "042800000000000064000000000000002042616c616e6365730001000000000500485472"
-      "616e73616374696f6e5061796d656e7400000000002000",
+      "0x6d6574610f080000000000000400000104507472616e736665725f616c6c6f"
+      "775f6465617468000000000c1853797374656d00000008285353353850726566"
+      "69780004a8001c56657273696f6e005820706f6c6b61646f74106e6f64650100"
+      "000064000000000000002042616c616e6365730001040000000500485472616e"
+      "73616374696f6e5061796d656e7400000000000300",
       &bytes));
   auto metadata = PolkadotChainMetadata::FromBytes(bytes);
   ASSERT_TRUE(metadata);
-  // BUG: ss58_prefix should be 42 but the parser returns 168 because
-  // decode_ss58_prefix doesn't attempt Compact<u32> decoding before the
-  // fixed-width fallbacks.  Compact<u32>(42) encodes as [0xa8], which the
-  // u8 fallback reads as the raw byte value 168.
-  EXPECT_EQ(metadata->GetSs58Prefix(), 168u);
+  EXPECT_EQ(metadata->GetSs58Prefix(), 42u);
 }
 
 // Concern #3: Parser does not validate that all input bytes are consumed.
 //
 // After reading all expected fields, the parser never checks that the input
-// buffer is empty. If the metadata format is subtly different from what the
-// parser expects (e.g., an extra field in a future version), the parser could
-// silently succeed with wrong values while leaving trailing data unread.
+// buffer is empty. A compromised RPC could append arbitrary bytes to valid
+// metadata. Note: real metadata also has trailing fields (extrinsics, APIs,
+// outer_event) that this partial parser doesn't consume, so a trailing-bytes
+// check cannot be added without breaking real-world parsing.
 //
-// Impact: A compromised RPC could append arbitrary bytes to a valid metadata
-// response. While the current parser reads specific fields in order and would
-// likely still extract correct values, the lack of a trailing-bytes check
-// means format drift would go undetected.
+// This test documents the known limitation.
 
 TEST(PolkadotChainMetadataUnitTest,
-     Security_TrailingBytesNotRejected_ShouldFail) {
+     Security_TrailingBytesNotRejected_KnownLimitation) {
   std::vector<uint8_t> bytes;
   ASSERT_TRUE(PrefixedHexStringToBytes(
-      "0x6d6574610f0c0000000104507472616e736665725f616c6c6f775f6465617468000000"
-      "0004043852756e74696d6556657273696f6e0000000008041c4163636f756e7404045401"
-      "08000800000000000000000000c1853797374656d011853797374656d041c4163636f756e"
-      "74010104010808040000000008285353353850726566697808082a00001c56657273696f6e"
-      "042800000000000064000000000000002042616c616e6365730001000000000500485472"
-      "616e73616374696f6e5061796d656e7400000000002000deadbeef",
+      "0x6d6574610f080000000000000400000104507472616e736665725f616c6c6f"
+      "775f6465617468000000000c1853797374656d00000008285353353850726566"
+      "697800082a00001c56657273696f6e005820706f6c6b61646f74106e6f646501"
+      "00000064000000000000002042616c616e636573000104000000050048547261"
+      "6e73616374696f6e5061796d656e7400000000000300deadbeef",
       &bytes));
   auto metadata = PolkadotChainMetadata::FromBytes(bytes);
-  // BUG: FromBytes should reject metadata with trailing bytes, but it
-  // silently accepts them. The metadata values happen to be correct here
-  // because the parser reads fields in order and stops after the last one
-  // it needs, ignoring the trailing 0xdeadbeef.
+  // Known limitation: trailing bytes are silently accepted. Cannot add a
+  // trailing-bytes check because real metadata has fields after the pallets
+  // section that this partial parser doesn't consume.
   ASSERT_TRUE(metadata);
   EXPECT_EQ(metadata->GetSs58Prefix(), 42u);
   EXPECT_EQ(metadata->GetBalancesPalletIndex(), 5u);
@@ -460,25 +428,11 @@ TEST(PolkadotChainMetadataUnitTest,
 
 // Concern #4: Unbounded Vec::with_capacity on untrusted vec length.
 //
-// decode_vec reads a Compact<u32> length from the input and immediately
-// calls Vec::with_capacity(len) without any bounds check. A malicious RPC
-// response with a huge Compact length could cause the browser to allocate
-// excessive memory before the first element decode fails.
-//
-// This is a DoS vector — no fund loss, but it could crash the browser tab.
-// The test below uses a moderate length that won't OOM but demonstrates the
-// parser doesn't validate lengths before allocation.
-//
-// Note: A truly malicious length (e.g., Compact(u32::MAX)) could allocate
-// several GB before failing. The fix would be to add a reasonable upper
-// bound in decode_vec_len (e.g., reject lengths > 10_000).
+// FIX: decode_vec_len now rejects vec lengths > 10_000 before allocation,
+// preventing a DoS via maliciously large Compact length values.
 
 TEST(PolkadotChainMetadataUnitTest,
-     Security_HugeVecLength_ParserDoesNotValidateLength) {
-  // Valid magic + version 15, then a Compact<u32>(50000) for the portable
-  // registry types vec. There is nowhere near enough data for 50000 types,
-  // so the parser will fail — but it allocates a HashMap and iterates before
-  // detecting the insufficient data.
+     Security_HugeVecLength_RejectedByBoundsCheck) {
   std::vector<uint8_t> bytes;
   ASSERT_TRUE(PrefixedHexStringToBytes("0x6d6574610f420d0300", &bytes));
   EXPECT_FALSE(PolkadotChainMetadata::FromBytes(bytes));

--- a/components/brave_wallet/browser/polkadot/polkadot_chain_metadata_unittest.cc
+++ b/components/brave_wallet/browser/polkadot/polkadot_chain_metadata_unittest.cc
@@ -306,7 +306,8 @@ TEST(PolkadotChainMetadataUnitTest, Security_V14NoStorage_ParsesCorrectly) {
 
 // v14 metadata with Map storage, hasher=0 (Blake2_128).
 // Vec<StorageHasher> decode succeeds: 0x00 decodes as Compact(0)=empty vec.
-TEST(PolkadotChainMetadataUnitTest, Security_V14MapStorageHasher0_ParsesCorrectly) {
+TEST(PolkadotChainMetadataUnitTest,
+     Security_V14MapStorageHasher0_ParsesCorrectly) {
   std::vector<uint8_t> bytes;
   ASSERT_TRUE(PrefixedHexStringToBytes(
       "0x6d6574610e080000000000000400000104507472616e736665725f616c6c6f"
@@ -325,7 +326,8 @@ TEST(PolkadotChainMetadataUnitTest, Security_V14MapStorageHasher0_ParsesCorrectl
 // v14 metadata with Map storage, hasher=1 (Blake2_256).
 // Vec<StorageHasher> decode fails (0x01 triggers two-byte Compact mode),
 // but the single-byte fallback succeeds.
-TEST(PolkadotChainMetadataUnitTest, Security_V14MapStorageHasher1_ParsesCorrectly) {
+TEST(PolkadotChainMetadataUnitTest,
+     Security_V14MapStorageHasher1_ParsesCorrectly) {
   std::vector<uint8_t> bytes;
   ASSERT_TRUE(PrefixedHexStringToBytes(
       "0x6d6574610e080000000000000400000104507472616e736665725f616c6c6f"
@@ -342,7 +344,8 @@ TEST(PolkadotChainMetadataUnitTest, Security_V14MapStorageHasher1_ParsesCorrectl
 }
 
 // v15 metadata with Map storage, hasher=1 encoded as Vec<StorageHasher>([1]).
-TEST(PolkadotChainMetadataUnitTest, Security_V15MapStorageHasher1_ParsesCorrectly) {
+TEST(PolkadotChainMetadataUnitTest,
+     Security_V15MapStorageHasher1_ParsesCorrectly) {
   std::vector<uint8_t> bytes;
   ASSERT_TRUE(PrefixedHexStringToBytes(
       "0x6d6574610f080000000000000400000104507472616e736665725f616c6c6f"
@@ -368,7 +371,8 @@ TEST(PolkadotChainMetadataUnitTest, Security_V15MapStorageHasher1_ParsesCorrectl
 // to avoid misinterpreting multi-byte fixed-width encodings as compact.
 
 // v15 metadata with SS58Prefix as u16(42)=[0x2a, 0x00] → returns 42.
-TEST(PolkadotChainMetadataUnitTest, Security_SS58PrefixU16_ReturnsCorrectValue) {
+TEST(PolkadotChainMetadataUnitTest,
+     Security_SS58PrefixU16_ReturnsCorrectValue) {
   std::vector<uint8_t> bytes;
   ASSERT_TRUE(PrefixedHexStringToBytes(
       "0x6d6574610f080000000000000400000104507472616e736665725f616c6c6f"
@@ -383,7 +387,8 @@ TEST(PolkadotChainMetadataUnitTest, Security_SS58PrefixU16_ReturnsCorrectValue) 
 }
 
 // v15 metadata with SS58Prefix as Compact<u32>(42)=[0xa8] → returns 42.
-TEST(PolkadotChainMetadataUnitTest, Security_SS58PrefixCompact_ReturnsCorrectValue) {
+TEST(PolkadotChainMetadataUnitTest,
+     Security_SS58PrefixCompact_ReturnsCorrectValue) {
   std::vector<uint8_t> bytes;
   ASSERT_TRUE(PrefixedHexStringToBytes(
       "0x6d6574610f080000000000000400000104507472616e736665725f616c6c6f"

--- a/components/brave_wallet/browser/polkadot/polkadot_chain_metadata_unittest.cc
+++ b/components/brave_wallet/browser/polkadot/polkadot_chain_metadata_unittest.cc
@@ -273,123 +273,284 @@ TEST(PolkadotChainMetadataUnitTest,
 TEST(PolkadotChainMetadataUnitTest, Security_V14NoStorage_ParsesCorrectly) {
   std::vector<uint8_t> bytes;
   ASSERT_TRUE(PrefixedHexStringToBytes(
-      "0x6d6574610e080000000000000400000104507472616e736665725f616c6c6f"
-      "775f6465617468000000000c1853797374656d00000008285353353850726566"
-      "697800082a00001c56657273696f6e005820706f6c6b61646f74106e6f646501"
-      "000000640000000000002042616c616e63657300010400000005485472616e73"
-      "616374696f6e5061796d656e74000000000003",
+      // RuntimeMetadataPrefixed: magic "meta", V14, and portable
+      // registry. Balances calls include transfer_allow_death(0),
+      // transfer_keep_alive(3), and transfer_all(4).
+      "0x6d6574610e08000000000000040000010c507472616e736665725f616c6c6f775f6465"
+      "6174680000004c7472616e736665725f6b6565705f616c697665000300307472616e7366"
+      "65725f616c6c00040000"
+      // System pallet has no storage; constants encode SS58Prefix=42 and
+      // Version.spec_version=100.
+      "0c1853797374656d00000008285353353850726566697800082a00001c56657273696f6e"
+      "005820706f6c6b61646f74106e6f64650100000064000000000000"
+      // Balances pallet index 5 references the call enum above;
+      // TransactionPayment pallet index 3 is present for fee metadata.
+      "2042616c616e63657300010400000005485472616e73616374696f6e5061796d656e7400"
+      "0000000003"
+      // Minimal V14 extrinsic metadata with no signed extensions.
+      "000400",
       &bytes));
   auto metadata = PolkadotChainMetadata::FromBytes(bytes);
   ASSERT_TRUE(metadata);
-  EXPECT_EQ(metadata->GetSs58Prefix(), 42u);
-  EXPECT_EQ(metadata->GetBalancesPalletIndex(), 5u);
-  EXPECT_EQ(metadata->GetSpecVersion(), 100u);
+  auto expected = PolkadotChainMetadata::FromFields(
+      /*system_pallet_index=*/0, /*balances_pallet_index=*/5,
+      /*transaction_payment_pallet_index=*/3,
+      /*transfer_allow_death_call_index=*/0,
+      /*transfer_keep_alive_call_index=*/3,
+      /*transfer_all_call_index=*/4,
+      /*ss58_prefix=*/42, /*spec_version=*/100,
+      /*asset_tx_payment=*/false,
+      /*has_assets_pallet=*/false,
+      /*assets_pallet_index=*/0,
+      /*assets_transfer_all_call_index=*/0,
+      /*assets_transfer_keep_alive_call_index=*/0);
+  EXPECT_EQ(*metadata, expected);
 }
 
 TEST(PolkadotChainMetadataUnitTest,
      Security_V14MapStorageHasher0_ParsesCorrectly) {
   std::vector<uint8_t> bytes;
   ASSERT_TRUE(PrefixedHexStringToBytes(
-      "0x6d6574610e080000000000000400000104507472616e736665725f616c6c6f"
-      "775f6465617468000000000c1853797374656d011853797374656d041c416363"
-      "6f756e7400010000000000000008285353353850726566697800082a00001c56"
-      "657273696f6e005820706f6c6b61646f74106e6f646501000000640000000000"
-      "002042616c616e63657300010400000005485472616e73616374696f6e506179"
-      "6d656e74000000000003",
+      // RuntimeMetadataPrefixed: magic "meta", V14, and portable
+      // registry. Balances calls include transfer_allow_death(0),
+      // transfer_keep_alive(3), and transfer_all(4).
+      "0x6d6574610e08000000000000040000010c507472616e736665725f616c6c6f775f6465"
+      "6174680000004c7472616e736665725f6b6565705f616c697665000300307472616e7366"
+      "65725f616c6c00040000"
+      // System pallet includes Account map storage using StorageHasher
+      // discriminant 0; constants encode SS58Prefix=42 and spec_version=100.
+      "0c1853797374656d011853797374656d041c4163636f756e740001000000000000000828"
+      "5353353850726566697800082a00001c56657273696f6e005820706f6c6b61646f74106e"
+      "6f64650100000064000000000000"
+      // Balances pallet index 5 references the call enum above;
+      // TransactionPayment pallet index 3 is present for fee metadata.
+      "2042616c616e63657300010400000005485472616e73616374696f6e5061796d656e7400"
+      "0000000003"
+      // Minimal V14 extrinsic metadata with no signed extensions.
+      "000400",
       &bytes));
   auto metadata = PolkadotChainMetadata::FromBytes(bytes);
   ASSERT_TRUE(metadata);
-  EXPECT_EQ(metadata->GetSs58Prefix(), 42u);
-  EXPECT_EQ(metadata->GetBalancesPalletIndex(), 5u);
+  auto expected = PolkadotChainMetadata::FromFields(
+      /*system_pallet_index=*/0, /*balances_pallet_index=*/5,
+      /*transaction_payment_pallet_index=*/3,
+      /*transfer_allow_death_call_index=*/0,
+      /*transfer_keep_alive_call_index=*/3,
+      /*transfer_all_call_index=*/4,
+      /*ss58_prefix=*/42, /*spec_version=*/100,
+      /*asset_tx_payment=*/false,
+      /*has_assets_pallet=*/false,
+      /*assets_pallet_index=*/0,
+      /*assets_transfer_all_call_index=*/0,
+      /*assets_transfer_keep_alive_call_index=*/0);
+  EXPECT_EQ(*metadata, expected);
 }
 
 TEST(PolkadotChainMetadataUnitTest,
      Security_V14MapStorageHasher1_ParsesCorrectly) {
   std::vector<uint8_t> bytes;
   ASSERT_TRUE(PrefixedHexStringToBytes(
-      "0x6d6574610e080000000000000400000104507472616e736665725f616c6c6f"
-      "775f6465617468000000000c1853797374656d011853797374656d041c416363"
-      "6f756e7400010100000000000008285353353850726566697800082a00001c56"
-      "657273696f6e005820706f6c6b61646f74106e6f646501000000640000000000"
-      "002042616c616e63657300010400000005485472616e73616374696f6e506179"
-      "6d656e74000000000003",
+      // RuntimeMetadataPrefixed: magic "meta", V14, and portable
+      // registry. Balances calls include transfer_allow_death(0),
+      // transfer_keep_alive(3), and transfer_all(4).
+      "0x6d6574610e08000000000000040000010c507472616e736665725f616c6c6f775f6465"
+      "6174680000004c7472616e736665725f6b6565705f616c697665000300307472616e7366"
+      "65725f616c6c00040000"
+      // System pallet includes Account map storage using StorageHasher
+      // discriminant 1; constants encode SS58Prefix=42 and spec_version=100.
+      "0c1853797374656d011853797374656d041c4163636f756e740001010000000000000828"
+      "5353353850726566697800082a00001c56657273696f6e005820706f6c6b61646f74106e"
+      "6f64650100000064000000000000"
+      // Balances pallet index 5 references the call enum above;
+      // TransactionPayment pallet index 3 is present for fee metadata.
+      "2042616c616e63657300010400000005485472616e73616374696f6e5061796d656e7400"
+      "0000000003"
+      // Minimal V14 extrinsic metadata with no signed extensions.
+      "000400",
       &bytes));
   auto metadata = PolkadotChainMetadata::FromBytes(bytes);
   ASSERT_TRUE(metadata);
-  EXPECT_EQ(metadata->GetSs58Prefix(), 42u);
-  EXPECT_EQ(metadata->GetBalancesPalletIndex(), 5u);
+  auto expected = PolkadotChainMetadata::FromFields(
+      /*system_pallet_index=*/0, /*balances_pallet_index=*/5,
+      /*transaction_payment_pallet_index=*/3,
+      /*transfer_allow_death_call_index=*/0,
+      /*transfer_keep_alive_call_index=*/3,
+      /*transfer_all_call_index=*/4,
+      /*ss58_prefix=*/42, /*spec_version=*/100,
+      /*asset_tx_payment=*/false,
+      /*has_assets_pallet=*/false,
+      /*assets_pallet_index=*/0,
+      /*assets_transfer_all_call_index=*/0,
+      /*assets_transfer_keep_alive_call_index=*/0);
+  EXPECT_EQ(*metadata, expected);
 }
 
 TEST(PolkadotChainMetadataUnitTest,
      Security_V15MapStorageHasher1_ParsesCorrectly) {
   std::vector<uint8_t> bytes;
   ASSERT_TRUE(PrefixedHexStringToBytes(
-      "0x6d6574610f080000000000000400000104507472616e736665725f616c6c6f"
-      "775f6465617468000000000c1853797374656d011853797374656d041c416363"
-      "6f756e740001040100000000000008285353353850726566697800082a00001c"
-      "56657273696f6e005820706f6c6b61646f74106e6f6465010000006400000000"
-      "0000002042616c616e6365730001040000000500485472616e73616374696f6e"
-      "5061796d656e7400000000000300",
+      // RuntimeMetadataPrefixed: magic "meta", V15, and portable
+      // registry. Balances calls include transfer_allow_death(0),
+      // transfer_keep_alive(3), and transfer_all(4).
+      "0x6d6574610f08000000000000040000010c507472616e736665725f616c6c6f775f6465"
+      "6174680000004c7472616e736665725f6b6565705f616c697665000300307472616e7366"
+      "65725f616c6c00040000"
+      // System pallet includes Account map storage with one hasher
+      // (discriminant 1), empty pallet docs, SS58Prefix=42, and
+      // spec_version=100.
+      "0c1853797374656d011853797374656d041c4163636f756e740001040100000000000008"
+      "285353353850726566697800082a00001c56657273696f6e005820706f6c6b61646f7410"
+      "6e6f6465010000006400000000000000"
+      // Balances pallet index 5 references the call enum above;
+      // TransactionPayment pallet index 3 is present for fee metadata.
+      "2042616c616e6365730001040000000500485472616e73616374696f6e5061796d656e74"
+      "00000000000300"
+      // Minimal V15 extrinsic metadata with no signed extensions.
+      "040000000000",
       &bytes));
   auto metadata = PolkadotChainMetadata::FromBytes(bytes);
   ASSERT_TRUE(metadata);
-  EXPECT_EQ(metadata->GetSs58Prefix(), 42u);
-  EXPECT_EQ(metadata->GetBalancesPalletIndex(), 5u);
+  auto expected = PolkadotChainMetadata::FromFields(
+      /*system_pallet_index=*/0, /*balances_pallet_index=*/5,
+      /*transaction_payment_pallet_index=*/3,
+      /*transfer_allow_death_call_index=*/0,
+      /*transfer_keep_alive_call_index=*/3,
+      /*transfer_all_call_index=*/4,
+      /*ss58_prefix=*/42, /*spec_version=*/100,
+      /*asset_tx_payment=*/false,
+      /*has_assets_pallet=*/false,
+      /*assets_pallet_index=*/0,
+      /*assets_transfer_all_call_index=*/0,
+      /*assets_transfer_keep_alive_call_index=*/0);
+  EXPECT_EQ(*metadata, expected);
 }
 
 TEST(PolkadotChainMetadataUnitTest,
      Security_SS58PrefixU16_ReturnsCorrectValue) {
   std::vector<uint8_t> bytes;
   ASSERT_TRUE(PrefixedHexStringToBytes(
-      "0x6d6574610f080000000000000400000104507472616e736665725f616c6c6f"
-      "775f6465617468000000000c1853797374656d00000008285353353850726566"
-      "697800082a00001c56657273696f6e005820706f6c6b61646f74106e6f646501"
-      "00000064000000000000002042616c616e636573000104000000050048547261"
-      "6e73616374696f6e5061796d656e7400000000000300",
+      // RuntimeMetadataPrefixed: magic "meta", V15, and portable
+      // registry. Balances calls include transfer_allow_death(0),
+      // transfer_keep_alive(3), and transfer_all(4).
+      "0x6d6574610f08000000000000040000010c507472616e736665725f616c6c6f775f6465"
+      "6174680000004c7472616e736665725f6b6565705f616c697665000300307472616e7366"
+      "65725f616c6c00040000"
+      // System pallet has no storage; SS58Prefix is encoded as fixed-width
+      // u16(42), with Version.spec_version=100.
+      "0c1853797374656d00000008285353353850726566697800082a00001c56657273696f6e"
+      "005820706f6c6b61646f74106e6f6465010000006400000000000000"
+      // Balances pallet index 5 references the call enum above;
+      // TransactionPayment pallet index 3 is present for fee metadata.
+      "2042616c616e6365730001040000000500485472616e73616374696f6e5061796d656e74"
+      "00000000000300"
+      // Minimal V15 extrinsic metadata with no signed extensions.
+      "040000000000",
       &bytes));
   auto metadata = PolkadotChainMetadata::FromBytes(bytes);
   ASSERT_TRUE(metadata);
-  EXPECT_EQ(metadata->GetSs58Prefix(), 42u);
+  auto expected = PolkadotChainMetadata::FromFields(
+      /*system_pallet_index=*/0, /*balances_pallet_index=*/5,
+      /*transaction_payment_pallet_index=*/3,
+      /*transfer_allow_death_call_index=*/0,
+      /*transfer_keep_alive_call_index=*/3,
+      /*transfer_all_call_index=*/4,
+      /*ss58_prefix=*/42, /*spec_version=*/100,
+      /*asset_tx_payment=*/false,
+      /*has_assets_pallet=*/false,
+      /*assets_pallet_index=*/0,
+      /*assets_transfer_all_call_index=*/0,
+      /*assets_transfer_keep_alive_call_index=*/0);
+  EXPECT_EQ(*metadata, expected);
 }
 
 TEST(PolkadotChainMetadataUnitTest,
      Security_SS58PrefixCompact_ReturnsCorrectValue) {
   std::vector<uint8_t> bytes;
   ASSERT_TRUE(PrefixedHexStringToBytes(
-      "0x6d6574610f080000000000000400000104507472616e736665725f616c6c6f"
-      "775f6465617468000000000c1853797374656d00000008285353353850726566"
-      "69780004a8001c56657273696f6e005820706f6c6b61646f74106e6f64650100"
-      "000064000000000000002042616c616e6365730001040000000500485472616e"
-      "73616374696f6e5061796d656e7400000000000300",
+      // RuntimeMetadataPrefixed: magic "meta", V15, and portable
+      // registry. Balances calls include transfer_allow_death(0),
+      // transfer_keep_alive(3), and transfer_all(4).
+      "0x6d6574610f08000000000000040000010c507472616e736665725f616c6c6f775f6465"
+      "6174680000004c7472616e736665725f6b6565705f616c697665000300307472616e7366"
+      "65725f616c6c00040000"
+      // System pallet has no storage; SS58Prefix is encoded as
+      // Compact<u32>(42), with Version.spec_version=100.
+      "0c1853797374656d0000000828535335385072656669780004a8001c56657273696f6e00"
+      "5820706f6c6b61646f74106e6f6465010000006400000000000000"
+      // Balances pallet index 5 references the call enum above;
+      // TransactionPayment pallet index 3 is present for fee metadata.
+      "2042616c616e6365730001040000000500485472616e73616374696f6e5061796d656e74"
+      "00000000000300"
+      // Minimal V15 extrinsic metadata with no signed extensions.
+      "040000000000",
       &bytes));
   auto metadata = PolkadotChainMetadata::FromBytes(bytes);
   ASSERT_TRUE(metadata);
-  EXPECT_EQ(metadata->GetSs58Prefix(), 42u);
+  auto expected = PolkadotChainMetadata::FromFields(
+      /*system_pallet_index=*/0, /*balances_pallet_index=*/5,
+      /*transaction_payment_pallet_index=*/3,
+      /*transfer_allow_death_call_index=*/0,
+      /*transfer_keep_alive_call_index=*/3,
+      /*transfer_all_call_index=*/4,
+      /*ss58_prefix=*/42, /*spec_version=*/100,
+      /*asset_tx_payment=*/false,
+      /*has_assets_pallet=*/false,
+      /*assets_pallet_index=*/0,
+      /*assets_transfer_all_call_index=*/0,
+      /*assets_transfer_keep_alive_call_index=*/0);
+  EXPECT_EQ(*metadata, expected);
 }
 
 TEST(PolkadotChainMetadataUnitTest,
      Security_TrailingBytesNotRejected_KnownLimitation) {
   std::vector<uint8_t> bytes;
   ASSERT_TRUE(PrefixedHexStringToBytes(
-      "0x6d6574610f080000000000000400000104507472616e736665725f616c6c6f"
-      "775f6465617468000000000c1853797374656d00000008285353353850726566"
-      "697800082a00001c56657273696f6e005820706f6c6b61646f74106e6f646501"
-      "00000064000000000000002042616c616e636573000104000000050048547261"
-      "6e73616374696f6e5061796d656e7400000000000300deadbeef",
+      // RuntimeMetadataPrefixed: magic "meta", V15, and portable
+      // registry. Balances calls include transfer_allow_death(0),
+      // transfer_keep_alive(3), and transfer_all(4).
+      "0x6d6574610f08000000000000040000010c507472616e736665725f616c6c6f775f6465"
+      "6174680000004c7472616e736665725f6b6565705f616c697665000300307472616e7366"
+      "65725f616c6c00040000"
+      // System pallet has no storage; constants encode SS58Prefix=42 and
+      // Version.spec_version=100.
+      "0c1853797374656d00000008285353353850726566697800082a00001c56657273696f6e"
+      "005820706f6c6b61646f74106e6f6465010000006400000000000000"
+      // Balances pallet index 5 references the call enum above;
+      // TransactionPayment pallet index 3 is present for fee metadata.
+      "2042616c616e6365730001040000000500485472616e73616374696f6e5061796d656e74"
+      "00000000000300"
+      // Minimal V15 extrinsic metadata with no signed extensions.
+      "040000000000"
+      // Extra bytes preserved for the trailing-bytes limitation check.
+      "deadbeef",
       &bytes));
   auto metadata = PolkadotChainMetadata::FromBytes(bytes);
   // Known limitation: trailing bytes are silently accepted. Cannot add a
-  // trailing-bytes check because real metadata has fields after the pallets
-  // section that this partial parser doesn't consume.
+  // trailing-bytes check because real metadata may include fields after the
+  // subset this partial parser consumes.
   ASSERT_TRUE(metadata);
-  EXPECT_EQ(metadata->GetSs58Prefix(), 42u);
-  EXPECT_EQ(metadata->GetBalancesPalletIndex(), 5u);
+  auto expected = PolkadotChainMetadata::FromFields(
+      /*system_pallet_index=*/0, /*balances_pallet_index=*/5,
+      /*transaction_payment_pallet_index=*/3,
+      /*transfer_allow_death_call_index=*/0,
+      /*transfer_keep_alive_call_index=*/3,
+      /*transfer_all_call_index=*/4,
+      /*ss58_prefix=*/42, /*spec_version=*/100,
+      /*asset_tx_payment=*/false,
+      /*has_assets_pallet=*/false,
+      /*assets_pallet_index=*/0,
+      /*assets_transfer_all_call_index=*/0,
+      /*assets_transfer_keep_alive_call_index=*/0);
+  EXPECT_EQ(*metadata, expected);
 }
 
 TEST(PolkadotChainMetadataUnitTest,
      Security_HugeVecLength_RejectedByBoundsCheck) {
   std::vector<uint8_t> bytes;
-  ASSERT_TRUE(PrefixedHexStringToBytes("0x6d6574610f420d0300", &bytes));
+  ASSERT_TRUE(PrefixedHexStringToBytes(
+      // RuntimeMetadataPrefixed: magic "meta", V15, then an oversized
+      // PortableRegistry vector length rejected by bounds checks.
+      "0x6d6574610f420d0300", &bytes));
   EXPECT_FALSE(PolkadotChainMetadata::FromBytes(bytes));
 }
 

--- a/components/brave_wallet/browser/polkadot/polkadot_chain_metadata_unittest.cc
+++ b/components/brave_wallet/browser/polkadot/polkadot_chain_metadata_unittest.cc
@@ -270,24 +270,6 @@ TEST(PolkadotChainMetadataUnitTest,
   EXPECT_EQ(*metadata2, expected_from_name);
 }
 
-// ---------------------------------------------------------------------------
-// Security validation tests: each test is labelled with a concern number
-// that maps to the security review findings for PR #34784.
-// ---------------------------------------------------------------------------
-
-// Concern #1: v14 Map storage format mismatch.
-//
-// In RuntimeMetadataV14, StorageEntryType::Map encodes the hasher as a
-// single StorageHasher enum byte:
-//   Map { hasher: StorageHasher, key: TypeId, value: TypeId }
-//
-// In RuntimeMetadataV15, it was changed to a Vec:
-//   Map { hashers: Vec<StorageHasher>, key: TypeId, value: TypeId }
-//
-// FIX: The parser now tries Vec<StorageHasher> first, and falls back to a
-// single byte on decode failure, handling both v14 and v15 formats.
-
-// v14 metadata with no storage entries — baseline that should parse correctly.
 TEST(PolkadotChainMetadataUnitTest, Security_V14NoStorage_ParsesCorrectly) {
   std::vector<uint8_t> bytes;
   ASSERT_TRUE(PrefixedHexStringToBytes(
@@ -304,8 +286,6 @@ TEST(PolkadotChainMetadataUnitTest, Security_V14NoStorage_ParsesCorrectly) {
   EXPECT_EQ(metadata->GetSpecVersion(), 100u);
 }
 
-// v14 metadata with Map storage, hasher=0 (Blake2_128).
-// Vec<StorageHasher> decode succeeds: 0x00 decodes as Compact(0)=empty vec.
 TEST(PolkadotChainMetadataUnitTest,
      Security_V14MapStorageHasher0_ParsesCorrectly) {
   std::vector<uint8_t> bytes;
@@ -323,9 +303,6 @@ TEST(PolkadotChainMetadataUnitTest,
   EXPECT_EQ(metadata->GetBalancesPalletIndex(), 5u);
 }
 
-// v14 metadata with Map storage, hasher=1 (Blake2_256).
-// Vec<StorageHasher> decode fails (0x01 triggers two-byte Compact mode),
-// but the single-byte fallback succeeds.
 TEST(PolkadotChainMetadataUnitTest,
      Security_V14MapStorageHasher1_ParsesCorrectly) {
   std::vector<uint8_t> bytes;
@@ -343,7 +320,6 @@ TEST(PolkadotChainMetadataUnitTest,
   EXPECT_EQ(metadata->GetBalancesPalletIndex(), 5u);
 }
 
-// v15 metadata with Map storage, hasher=1 encoded as Vec<StorageHasher>([1]).
 TEST(PolkadotChainMetadataUnitTest,
      Security_V15MapStorageHasher1_ParsesCorrectly) {
   std::vector<uint8_t> bytes;
@@ -361,16 +337,6 @@ TEST(PolkadotChainMetadataUnitTest,
   EXPECT_EQ(metadata->GetBalancesPalletIndex(), 5u);
 }
 
-// Concern #2: decode_ss58_prefix doesn't handle Compact<u32> encoding.
-//
-// The SS58Prefix constant is SCALE-encoded, but its concrete integer width
-// varies across runtimes (u8, u16, u32, or Compact<u32>).
-//
-// FIX: The parser now tries u16, u32, Compact<u32>, then u8 in order,
-// checking that all bytes are consumed. Compact<u32> is tried after u16/u32
-// to avoid misinterpreting multi-byte fixed-width encodings as compact.
-
-// v15 metadata with SS58Prefix as u16(42)=[0x2a, 0x00] → returns 42.
 TEST(PolkadotChainMetadataUnitTest,
      Security_SS58PrefixU16_ReturnsCorrectValue) {
   std::vector<uint8_t> bytes;
@@ -386,7 +352,6 @@ TEST(PolkadotChainMetadataUnitTest,
   EXPECT_EQ(metadata->GetSs58Prefix(), 42u);
 }
 
-// v15 metadata with SS58Prefix as Compact<u32>(42)=[0xa8] → returns 42.
 TEST(PolkadotChainMetadataUnitTest,
      Security_SS58PrefixCompact_ReturnsCorrectValue) {
   std::vector<uint8_t> bytes;
@@ -401,16 +366,6 @@ TEST(PolkadotChainMetadataUnitTest,
   ASSERT_TRUE(metadata);
   EXPECT_EQ(metadata->GetSs58Prefix(), 42u);
 }
-
-// Concern #3: Parser does not validate that all input bytes are consumed.
-//
-// After reading all expected fields, the parser never checks that the input
-// buffer is empty. A compromised RPC could append arbitrary bytes to valid
-// metadata. Note: real metadata also has trailing fields (extrinsics, APIs,
-// outer_event) that this partial parser doesn't consume, so a trailing-bytes
-// check cannot be added without breaking real-world parsing.
-//
-// This test documents the known limitation.
 
 TEST(PolkadotChainMetadataUnitTest,
      Security_TrailingBytesNotRejected_KnownLimitation) {
@@ -430,11 +385,6 @@ TEST(PolkadotChainMetadataUnitTest,
   EXPECT_EQ(metadata->GetSs58Prefix(), 42u);
   EXPECT_EQ(metadata->GetBalancesPalletIndex(), 5u);
 }
-
-// Concern #4: Unbounded Vec::with_capacity on untrusted vec length.
-//
-// FIX: decode_vec_len now rejects vec lengths > 10_000 before allocation,
-// preventing a DoS via maliciously large Compact length values.
 
 TEST(PolkadotChainMetadataUnitTest,
      Security_HugeVecLength_RejectedByBoundsCheck) {

--- a/components/brave_wallet/browser/polkadot/polkadot_chain_metadata_unittest.cc
+++ b/components/brave_wallet/browser/polkadot/polkadot_chain_metadata_unittest.cc
@@ -270,4 +270,218 @@ TEST(PolkadotChainMetadataUnitTest,
   EXPECT_EQ(*metadata2, expected_from_name);
 }
 
+// ---------------------------------------------------------------------------
+// Security validation tests: these tests document parsing bugs that could
+// lead to incorrect extrinsic construction (wrong pallet/call indices) and
+// thus potential loss of funds.  Each test is labelled with a concern number
+// that maps to the security review findings for PR #34784.
+// ---------------------------------------------------------------------------
+
+// Concern #1: v14 Map storage format mismatch.
+//
+// In RuntimeMetadataV14, StorageEntryType::Map encodes the hasher as a
+// single StorageHasher enum byte:
+//   Map { hasher: StorageHasher, key: TypeId, value: TypeId }
+//
+// In RuntimeMetadataV15, it was changed to a Vec:
+//   Map { hashers: Vec<StorageHasher>, key: TypeId, value: TypeId }
+//
+// The parser always uses the v15 Vec format regardless of the version byte,
+// so v14 metadata with Map storage entries where the hasher byte is != 0
+// will be misinterpreted.  When hasher=0 (Blake2_128), the byte 0x00
+// accidentally decodes as Compact(0) → empty Vec, so it works by luck.
+// When hasher=1 (Blake2_256), byte 0x01 triggers two-byte Compact mode,
+// overconsuming the next byte and causing a parse failure or silent misparse.
+//
+// Impact: A malicious or legacy v14 RPC node could return metadata that the
+// parser silently misparses, producing wrong pallet/call indices that flow
+// directly into extrinsic encoding for fund transfers.
+
+// v14 metadata with no storage entries — baseline that should parse correctly.
+TEST(PolkadotChainMetadataUnitTest, Security_V14NoStorage_ParsesCorrectly) {
+  std::vector<uint8_t> bytes;
+  ASSERT_TRUE(PrefixedHexStringToBytes(
+      "0x6d6574610e0c0000000104507472616e736665725f616c6c6f775f6465617468000000"
+      "0004043852756e74696d6556657273696f6e0000000008041c4163636f756e7404045401"
+      "08000800000000000000000000c1853797374656d00000008285353353850726566697808"
+      "082a00001c56657273696f6e0428000000000000640000000000002042616c616e636573"
+      "00010000000005485472616e73616374696f6e5061796d656e74000000000020",
+      &bytes));
+  auto metadata = PolkadotChainMetadata::FromBytes(bytes);
+  ASSERT_TRUE(metadata);
+  EXPECT_EQ(metadata->GetSs58Prefix(), 42u);
+  EXPECT_EQ(metadata->GetBalancesPalletIndex(), 5u);
+  EXPECT_EQ(metadata->GetSpecVersion(), 100u);
+}
+
+// v14 metadata with Map storage, hasher=0 (Blake2_128).
+// Byte 0x00 accidentally decodes as Compact(0)=empty Vec, so this works.
+TEST(PolkadotChainMetadataUnitTest, Security_V14MapStorageHasher0_ParsesByLuck) {
+  std::vector<uint8_t> bytes;
+  ASSERT_TRUE(PrefixedHexStringToBytes(
+      "0x6d6574610e0c0000000104507472616e736665725f616c6c6f775f6465617468000000"
+      "0004043852756e74696d6556657273696f6e0000000008041c4163636f756e7404045401"
+      "08000800000000000000000000c1853797374656d011853797374656d041c4163636f756e"
+      "740101000808040000000008285353353850726566697808082a00001c56657273696f6e04"
+      "28000000000000640000000000002042616c616e63657300010000000005485472616e7361"
+      "6374696f6e5061796d656e74000000000020",
+      &bytes));
+  auto metadata = PolkadotChainMetadata::FromBytes(bytes);
+  ASSERT_TRUE(metadata);
+  EXPECT_EQ(metadata->GetSs58Prefix(), 42u);
+  EXPECT_EQ(metadata->GetBalancesPalletIndex(), 5u);
+}
+
+// v14 metadata with Map storage, hasher=1 (Blake2_256).
+// Byte 0x01 triggers two-byte Compact mode, consuming the next byte and
+// producing a bogus vec length. The parser then fails to decode.
+// BUG: The parser accepts version=14 but doesn't handle v14 Map format.
+TEST(PolkadotChainMetadataUnitTest, Security_V14MapStorageHasher1_FailsToParse) {
+  std::vector<uint8_t> bytes;
+  ASSERT_TRUE(PrefixedHexStringToBytes(
+      "0x6d6574610e0c0000000104507472616e736665725f616c6c6f775f6465617468000000"
+      "0004043852756e74696d6556657273696f6e0000000008041c4163636f756e7404045401"
+      "08000800000000000000000000c1853797374656d011853797374656d041c4163636f756e"
+      "740101010808040000000008285353353850726566697808082a00001c56657273696f6e04"
+      "28000000000000640000000000002042616c616e63657300010000000005485472616e7361"
+      "6374696f6e5061796d656e74000000000020",
+      &bytes));
+  auto metadata = PolkadotChainMetadata::FromBytes(bytes);
+  // BUG: This should parse correctly for v14 metadata. Instead it returns
+  // nullopt because the parser always uses the v15 Vec<StorageHasher> format
+  // for Map storage entries, which is incompatible with v14's single-byte
+  // hasher encoding.
+  EXPECT_FALSE(metadata);
+}
+
+// v15 metadata with the same Map storage entry (hasher=1 as Vec<u8>).
+// This is the correct format and should parse without issues.
+TEST(PolkadotChainMetadataUnitTest, Security_V15MapStorageHasher1_ParsesCorrectly) {
+  std::vector<uint8_t> bytes;
+  ASSERT_TRUE(PrefixedHexStringToBytes(
+      "0x6d6574610f0c0000000104507472616e736665725f616c6c6f775f6465617468000000"
+      "0004043852756e74696d6556657273696f6e0000000008041c4163636f756e7404045401"
+      "08000800000000000000000000c1853797374656d011853797374656d041c4163636f756e"
+      "74010104010808040000000008285353353850726566697808082a00001c56657273696f6e"
+      "042800000000000064000000000000002042616c616e6365730001000000000500485472"
+      "616e73616374696f6e5061796d656e7400000000002000",
+      &bytes));
+  auto metadata = PolkadotChainMetadata::FromBytes(bytes);
+  ASSERT_TRUE(metadata);
+  EXPECT_EQ(metadata->GetSs58Prefix(), 42u);
+  EXPECT_EQ(metadata->GetBalancesPalletIndex(), 5u);
+}
+
+// Concern #2: decode_ss58_prefix doesn't handle Compact<u32> encoding.
+//
+// The SS58Prefix constant is SCALE-encoded, but its concrete integer width
+// varies across runtimes (u8, u16, u32, or Compact<u32>). The parser tries
+// fixed-width u16, u32, u8 in order, checking that all bytes are consumed.
+//
+// When a runtime encodes SS58Prefix as Compact<u32>(42), the bytes are
+// [0xa8] (single-byte Compact: (42 << 2) | 0b00 = 168). The parser's u16
+// decode fails (needs 2 bytes), u32 decode fails (needs 4 bytes), then u8
+// decode succeeds reading 0xa8=168. The parser returns ss58_prefix=168
+// instead of the correct value 42.
+//
+// Impact: Wrong ss58_prefix flows into ParsePolkadotAccount, which decodes
+// recipient addresses. A wrong prefix could cause address misinterpretation,
+// potentially sending funds to a different address than intended.
+
+// Control: v15 metadata with SS58Prefix as u16(42)=[0x2a, 0x00] → returns 42.
+TEST(PolkadotChainMetadataUnitTest, Security_SS58PrefixU16_ReturnsCorrectValue) {
+  std::vector<uint8_t> bytes;
+  ASSERT_TRUE(PrefixedHexStringToBytes(
+      "0x6d6574610f0c0000000104507472616e736665725f616c6c6f775f6465617468000000"
+      "0004043852756e74696d6556657273696f6e0000000008041c4163636f756e7404045401"
+      "08000800000000000000000000c1853797374656d011853797374656d041c4163636f756e"
+      "74010104010808040000000008285353353850726566697808082a00001c56657273696f6e"
+      "042800000000000064000000000000002042616c616e6365730001000000000500485472"
+      "616e73616374696f6e5061796d656e7400000000002000",
+      &bytes));
+  auto metadata = PolkadotChainMetadata::FromBytes(bytes);
+  ASSERT_TRUE(metadata);
+  EXPECT_EQ(metadata->GetSs58Prefix(), 42u);
+}
+
+// BUG: v15 metadata with SS58Prefix as Compact<u32>(42)=[0xa8].
+// The parser reads 0xa8 as u8=168, returning ss58_prefix=168 instead of 42.
+TEST(PolkadotChainMetadataUnitTest, Security_SS58PrefixCompact_ReturnsWrongValue) {
+  std::vector<uint8_t> bytes;
+  ASSERT_TRUE(PrefixedHexStringToBytes(
+      "0x6d6574610f0c0000000104507472616e736665725f616c6c6f775f6465617468000000"
+      "0004043852756e74696d6556657273696f6e0000000008041c4163636f756e7404045401"
+      "08000800000000000000000000c1853797374656d011853797374656d041c4163636f756e"
+      "7401010401080804000000000828535335385072656669780804a8001c56657273696f6e"
+      "042800000000000064000000000000002042616c616e6365730001000000000500485472"
+      "616e73616374696f6e5061796d656e7400000000002000",
+      &bytes));
+  auto metadata = PolkadotChainMetadata::FromBytes(bytes);
+  ASSERT_TRUE(metadata);
+  // BUG: ss58_prefix should be 42 but the parser returns 168 because
+  // decode_ss58_prefix doesn't attempt Compact<u32> decoding before the
+  // fixed-width fallbacks.  Compact<u32>(42) encodes as [0xa8], which the
+  // u8 fallback reads as the raw byte value 168.
+  EXPECT_EQ(metadata->GetSs58Prefix(), 168u);
+}
+
+// Concern #3: Parser does not validate that all input bytes are consumed.
+//
+// After reading all expected fields, the parser never checks that the input
+// buffer is empty. If the metadata format is subtly different from what the
+// parser expects (e.g., an extra field in a future version), the parser could
+// silently succeed with wrong values while leaving trailing data unread.
+//
+// Impact: A compromised RPC could append arbitrary bytes to a valid metadata
+// response. While the current parser reads specific fields in order and would
+// likely still extract correct values, the lack of a trailing-bytes check
+// means format drift would go undetected.
+
+TEST(PolkadotChainMetadataUnitTest,
+     Security_TrailingBytesNotRejected_ShouldFail) {
+  std::vector<uint8_t> bytes;
+  ASSERT_TRUE(PrefixedHexStringToBytes(
+      "0x6d6574610f0c0000000104507472616e736665725f616c6c6f775f6465617468000000"
+      "0004043852756e74696d6556657273696f6e0000000008041c4163636f756e7404045401"
+      "08000800000000000000000000c1853797374656d011853797374656d041c4163636f756e"
+      "74010104010808040000000008285353353850726566697808082a00001c56657273696f6e"
+      "042800000000000064000000000000002042616c616e6365730001000000000500485472"
+      "616e73616374696f6e5061796d656e7400000000002000deadbeef",
+      &bytes));
+  auto metadata = PolkadotChainMetadata::FromBytes(bytes);
+  // BUG: FromBytes should reject metadata with trailing bytes, but it
+  // silently accepts them. The metadata values happen to be correct here
+  // because the parser reads fields in order and stops after the last one
+  // it needs, ignoring the trailing 0xdeadbeef.
+  ASSERT_TRUE(metadata);
+  EXPECT_EQ(metadata->GetSs58Prefix(), 42u);
+  EXPECT_EQ(metadata->GetBalancesPalletIndex(), 5u);
+}
+
+// Concern #4: Unbounded Vec::with_capacity on untrusted vec length.
+//
+// decode_vec reads a Compact<u32> length from the input and immediately
+// calls Vec::with_capacity(len) without any bounds check. A malicious RPC
+// response with a huge Compact length could cause the browser to allocate
+// excessive memory before the first element decode fails.
+//
+// This is a DoS vector — no fund loss, but it could crash the browser tab.
+// The test below uses a moderate length that won't OOM but demonstrates the
+// parser doesn't validate lengths before allocation.
+//
+// Note: A truly malicious length (e.g., Compact(u32::MAX)) could allocate
+// several GB before failing. The fix would be to add a reasonable upper
+// bound in decode_vec_len (e.g., reject lengths > 10_000).
+
+TEST(PolkadotChainMetadataUnitTest,
+     Security_HugeVecLength_ParserDoesNotValidateLength) {
+  // Valid magic + version 15, then a Compact<u32>(50000) for the portable
+  // registry types vec. There is nowhere near enough data for 50000 types,
+  // so the parser will fail — but it allocates a HashMap and iterates before
+  // detecting the insufficient data.
+  std::vector<uint8_t> bytes;
+  ASSERT_TRUE(PrefixedHexStringToBytes("0x6d6574610f420d0300", &bytes));
+  EXPECT_FALSE(PolkadotChainMetadata::FromBytes(bytes));
+}
+
 }  // namespace brave_wallet


### PR DESCRIPTION
## Summary

Fixes several security issues in the Polkadot chain metadata parser (`polkadot_chain_metadata.rs`) identified during the review of #34784, and adds comprehensive test coverage for each concern.

## Fixes

1. **v14/v15 Map storage format mismatch** — `parse_storage_entry_type` now tries decoding hashers as `Vec<StorageHasher>` (v15) first, and falls back to a single `StorageHasher` byte (v14) on failure. Previously, v14 metadata with certain hasher values (e.g. `Blake2_256`) would fail to parse, causing the wallet to not recognize the chain.

2. **SS58 prefix Compact\<u32\> encoding not handled** — `decode_ss58_prefix` now also tries `Compact<u32>` decoding (after fixed-width `u16`/`u32` to avoid misinterpreting multi-byte encodings). Some runtimes encode SS58Prefix as compact, which would previously be silently skipped, falling through to incorrect values.

3. **Unbounded Vec allocation** — `decode_vec_len` now rejects lengths > 10,000 before allocation, preventing a potential DoS from a malicious RPC response with an enormous Compact length value.

## Tests

Adds 7 targeted unit tests covering each security concern:
- v14 metadata with no storage entries (baseline)
- v14 Map storage with hasher=0 (Blake2_128) — Vec path
- v14 Map storage with hasher=1 (Blake2_256) — single-byte fallback
- v15 Map storage with hasher=1 as Vec\<StorageHasher\>
- SS58Prefix encoded as u16 and as Compact\<u32\>
- Known limitation: trailing bytes not rejected (documented)
- Huge vec length rejected by bounds check