### PR TITLE
[Brave Origin] Set window icon on startup dialog

### DIFF
--- a/browser/ui/views/brave_origin/BUILD.gn
+++ b/browser/ui/views/brave_origin/BUILD.gn
@@ -21,6 +21,7 @@ source_set("brave_origin") {
     "//brave/components/brave_origin/buildflags",
     "//brave/components/resources:strings_grit",
     "//brave/components/skus/browser",
+    "//chrome/app/theme:chrome_unscaled_resources",
     "//chrome/browser/profiles:profile",
     "//chrome/browser/profiles/keep_alive",
     "//components/keep_alive_registry",

--- a/browser/ui/views/brave_origin/brave_origin_startup_view.cc
+++ b/browser/ui/views/brave_origin/brave_origin_startup_view.cc
@@ -20,6 +20,7 @@
 #include "chrome/browser/profiles/keep_alive/profile_keep_alive_types.h"
 #include "chrome/browser/profiles/keep_alive/scoped_profile_keep_alive.h"
 #include "chrome/browser/profiles/profile.h"
+#include "chrome/grit/chrome_unscaled_resources.h"
 #include "components/grit/brave_components_strings.h"
 #include "components/keep_alive_registry/keep_alive_types.h"
 #include "components/keep_alive_registry/scoped_keep_alive.h"
@@ -28,6 +29,7 @@
 #include "content/public/browser/web_contents.h"
 #include "content/public/browser/web_ui.h"
 #include "content/public/common/content_switches.h"
+#include "ui/base/resource/resource_bundle.h"
 #include "ui/gfx/geometry/size.h"
 #include "ui/views/controls/webview/webview.h"
 #include "ui/views/widget/widget.h"
@@ -217,6 +219,20 @@ void BraveOriginStartupView::Init(Profile* profile) {
 
 views::View* BraveOriginStartupView::GetContentsView() {
   return web_view_.get();
+}
+
+bool BraveOriginStartupView::ShouldShowWindowIcon() const {
+  return true;
+}
+
+ui::ImageModel BraveOriginStartupView::GetWindowAppIcon() {
+  ui::ResourceBundle& rb = ui::ResourceBundle::GetSharedInstance();
+  return ui::ImageModel::FromImageSkia(
+      *rb.GetImageSkiaNamed(IDR_PRODUCT_LOGO_128));
+}
+
+ui::ImageModel BraveOriginStartupView::GetWindowIcon() {
+  return GetWindowAppIcon();
 }
 
 void BraveOriginStartupView::WidgetIsZombie(views::Widget* widget) {

--- a/browser/ui/views/brave_origin/brave_origin_startup_view.h
+++ b/browser/ui/views/brave_origin/brave_origin_startup_view.h
@@ -18,6 +18,7 @@ static_assert(BUILDFLAG(IS_BRAVE_ORIGIN_BRANDED));
 #include "base/memory/weak_ptr.h"
 #include "content/public/browser/web_contents_delegate.h"
 #include "content/public/browser/web_contents_observer.h"
+#include "ui/base/models/image_model.h"
 #include "ui/views/controls/webview/unhandled_keyboard_event_handler.h"
 #include "ui/views/widget/widget_delegate.h"
 
@@ -110,6 +111,9 @@ class BraveOriginStartupView : public views::WidgetDelegate,
 
   // views::WidgetDelegate:
   views::View* GetContentsView() override;
+  bool ShouldShowWindowIcon() const override;
+  ui::ImageModel GetWindowAppIcon() override;
+  ui::ImageModel GetWindowIcon() override;
   void WidgetIsZombie(views::Widget* widget) override;
   void WindowClosing() override;
 


### PR DESCRIPTION
## Summary

- Override `GetWindowAppIcon()`, `GetWindowIcon()`, and `ShouldShowWindowIcon()` on `BraveOriginStartupView` to return the branded product logo (`IDR_PRODUCT_LOGO_128`)
- Fixes incorrect/missing icon in taskbar on Ubuntu (showed generic settings icon) and in macOS Sequoia menus (showed wrong icon) while the startup dialog was displayed

## Test plan

- [ ] On Ubuntu: launch Brave Origin, verify the taskbar icon shows the Brave Origin logo while the startup dialog is open
- [ ] On macOS Sequoia: launch Brave Origin, verify the menu bar app icon is the Brave Origin logo during the startup dialog
- [ ] After dismissing the dialog, verify the icon remains correct when the browser window opens