### PR TITLE
[Wallet] update GenerateReceiveAddress for Polkadot

### DIFF
--- a/browser/brave_wallet/brave_wallet_service_unittest.cc
+++ b/browser/brave_wallet/brave_wallet_service_unittest.cc
@@ -308,8 +308,11 @@ class BraveWalletServiceUnitTest : public testing::Test {
  protected:
   void SetUp() override {
     scoped_feature_list_.InitWithFeatures(
-        {features::kBraveWalletBitcoinFeature,
-         features::kBraveWalletCardanoFeature},
+        {
+            features::kBraveWalletBitcoinFeature,
+            features::kBraveWalletCardanoFeature,
+            features::kBraveWalletPolkadotFeature,
+        },
         {});
 
     brave_wallet::RegisterLocalStatePrefs(local_state_.registry());
@@ -2889,14 +2892,16 @@ TEST_F(BraveWalletServiceUnitTest, ConvertFEVMToFVMAddress) {
   }
 }
 
-TEST_F(BraveWalletServiceUnitTest, GenerateReceiveAddress_EthFilSol) {
+TEST_F(BraveWalletServiceUnitTest, GenerateReceiveAddress_EthFilSolDot) {
   SetupWallet();
 
   std::vector<mojom::AccountInfoPtr> accounts;
   accounts.push_back(GetAccountUtils().EnsureEthAccount(0));
   accounts.push_back(GetAccountUtils().EnsureSolAccount(0));
   accounts.push_back(GetAccountUtils().EnsureFilAccount(0));
+  accounts.push_back(GetAccountUtils().EnsureDotAccount(0));
   accounts.push_back(GetAccountUtils().EnsureFilTestAccount(0));
+  accounts.push_back(GetAccountUtils().EnsureDotTestAccount(0));
 
   for (auto& acc : accounts) {
     base::MockCallback<BraveWalletService::GenerateReceiveAddressCallback>

--- a/components/brave_wallet/browser/brave_wallet_service.cc
+++ b/components/brave_wallet/browser/brave_wallet_service.cc
@@ -1870,6 +1870,18 @@ void BraveWalletService::GenerateReceiveAddress(
     return;
   }
 
+  if (account_id->coin == mojom::CoinType::DOT) {
+    if (!polkadot_wallet_service_) {
+      std::move(callback).Run("", WalletInternalErrorMessage());
+      return;
+    }
+
+    const auto chain_id = GetNetworkForPolkadotKeyring(account_id->keyring_id);
+    polkadot_wallet_service_->GetAddress(std::move(account_id), chain_id,
+                                         std::move(callback));
+    return;
+  }
+
   NOTREACHED() << account_id->coin;
 }
 

--- a/components/brave_wallet/browser/test_utils.cc
+++ b/components/brave_wallet/browser/test_utils.cc
@@ -300,6 +300,14 @@ mojom::AccountInfoPtr AccountUtils::EnsureAdaTestAccount(uint32_t index) {
   return EnsureAccount(mojom::KeyringId::kCardanoTestnet, index);
 }
 
+mojom::AccountInfoPtr AccountUtils::EnsureDotAccount(uint32_t index) {
+  return EnsureAccount(mojom::KeyringId::kPolkadotMainnet, index);
+}
+
+mojom::AccountInfoPtr AccountUtils::EnsureDotTestAccount(uint32_t index) {
+  return EnsureAccount(mojom::KeyringId::kPolkadotTestnet, index);
+}
+
 mojom::AccountInfoPtr AccountUtils::CreateEthAccount(const std::string& name) {
   return CreateDerivedAccount(mojom::KeyringId::kDefault, name);
 }

--- a/components/brave_wallet/browser/test_utils.h
+++ b/components/brave_wallet/browser/test_utils.h
@@ -114,6 +114,8 @@ class AccountUtils {
   mojom::AccountInfoPtr EnsureZecTestAccount(uint32_t index);
   mojom::AccountInfoPtr EnsureAdaAccount(uint32_t index);
   mojom::AccountInfoPtr EnsureAdaTestAccount(uint32_t index);
+  mojom::AccountInfoPtr EnsureDotAccount(uint32_t index);
+  mojom::AccountInfoPtr EnsureDotTestAccount(uint32_t index);
 
   mojom::AccountInfoPtr CreateEthAccount(const std::string& name);
   mojom::AccountInfoPtr CreateSolAccount(const std::string& name);


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
This update prevents the `BraveWalletService::GenerateReceiveAddress` from hitting a `NOTREACHED()` when it's called for Polkadot accounts.

I didn't realize until I had started writing the tests that we actually already populate the `address` field of the `AccountInfo` structure correctly. I'm not sure exactly how this should be implemented, but we do need to address this because the `NOTREACHED()` will crash the browser during regular testing.

I think how we handle this will tie into how we eventually handle supporting multiple parachains. Because each parachain can have governance of the assets on it (including DOT), we need to somehow tie that directly to the AccountInfo or AccountId structure. To this end, I think maybe relying on `address` for `AccountInfo` is okay as we can add new KeyringIds for each parachain we want to support.

I'm not sure what this kind of change would look like if we wanted to support arbitrary parachains, however. But even in that instance, we'd still need to store an identifier for the parachain regardless as those are usually hosted using their own URL.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
