### PR TITLE
Fix use-after-free crash in BraveAppMenu::OnMenuClosed (uplift to 1.90.x)

### DIFF
--- a/browser/ui/views/toolbar/brave_app_menu.cc
+++ b/browser/ui/views/toolbar/brave_app_menu.cc
@@ -226,10 +226,10 @@ void BraveAppMenu::ExecuteCommand(int command_id, int mouse_event_flags) {
 }
 
 void BraveAppMenu::OnMenuClosed(views::MenuItemView* menu) {
-  AppMenu::OnMenuClosed(menu);
   if (menu == nullptr) {
     menu_metrics_->RecordMenuDismiss();
   }
+  AppMenu::OnMenuClosed(menu);
 }
 
 void BraveAppMenu::RecordMenuUsage(int command_id) {


### PR DESCRIPTION
Uplift of #35436
Resolves https://github.com/brave/brave-browser/issues/54403

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.