### PR TITLE
Fix crash in BraveTabStrip::UpdateOrientation() with upstream vertical tabs

### DIFF
--- a/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_browsertest.cc
+++ b/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_browsertest.cc
@@ -2312,3 +2312,27 @@ INSTANTIATE_TEST_SUITE_P(,
                          [](const testing::TestParamInfo<bool>& info) {
                            return info.param ? "Embedded" : "NonEmbedded";
                          });
+
+// Regression test: When Chromium's upstream vertical tabs feature is active,
+// TabStrip::Initialize() is never called so tab_container_ remains null.
+// BraveTabStrip::UpdateOrientation() was crashing by accessing the null
+// tab_container_ via SetAvailableWidthCallback() during startup.
+class UpstreamVerticalTabsCrashTest : public InProcessBrowserTest {
+ public:
+  UpstreamVerticalTabsCrashTest() {
+    scoped_feature_list_.InitAndEnableFeature(tabs::kVerticalTabs);
+  }
+  ~UpstreamVerticalTabsCrashTest() override = default;
+
+ private:
+  base::test::ScopedFeatureList scoped_feature_list_;
+};
+
+IN_PROC_BROWSER_TEST_F(UpstreamVerticalTabsCrashTest, NoCrashOnStartup) {
+  // Simulate the user choosing "Side" in Tab strip position settings,
+  // then opening a new window. Previously this crashed in
+  // BraveTabStrip::UpdateOrientation() because tab_container_ was null.
+  browser()->profile()->GetPrefs()->SetBoolean(prefs::kVerticalTabsEnabled,
+                                               true);
+  CreateBrowser(browser()->profile());
+}

--- a/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_browsertest.cc
+++ b/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_browsertest.cc
@@ -2330,9 +2330,12 @@ class UpstreamVerticalTabsCrashTest : public InProcessBrowserTest {
 
 IN_PROC_BROWSER_TEST_F(UpstreamVerticalTabsCrashTest, NoCrashOnStartup) {
   // Simulate the user choosing "Side" in Tab strip position settings,
-  // then opening a new window. Previously this crashed in
-  // BraveTabStrip::UpdateOrientation() because tab_container_ was null.
+  // then opening a new window. verifies no crash when kVerticalTabs is active
+  // and kVerticalTabsEnabled is set, since tab_container_ may be null in that
+  // configuration.
   browser()->profile()->GetPrefs()->SetBoolean(prefs::kVerticalTabsEnabled,
                                                true);
-  CreateBrowser(browser()->profile());
+  Browser* new_browser = CreateBrowser(browser()->profile());
+  ASSERT_TRUE(new_browser);
+  EXPECT_EQ(1, new_browser->tab_strip_model()->count());
 }

--- a/browser/ui/views/tabs/brave_tab_strip.cc
+++ b/browser/ui/views/tabs/brave_tab_strip.cc
@@ -306,7 +306,8 @@ bool BraveTabStrip::ShouldShowPinnedTabsInGrid() const {
 
 void BraveTabStrip::UpdateOrientation() {
   // When Chromium's upstream vertical tabs feature is active,
-  // TabStrip::Initialize() is never called so tab_container_ remains null.
+  // TabStrip::Initialize() is never called because it's only used by
+  // horizontal tab mode so tab_container_ remains null.
   // This method must bail out early to avoid crashing when accessing it.
   if (!tabs::utils::SupportsBraveVerticalTabs(GetBrowserWindowInterface())) {
     return;

--- a/browser/ui/views/tabs/brave_tab_strip.cc
+++ b/browser/ui/views/tabs/brave_tab_strip.cc
@@ -305,6 +305,13 @@ bool BraveTabStrip::ShouldShowPinnedTabsInGrid() const {
 }
 
 void BraveTabStrip::UpdateOrientation() {
+  // When Chromium's upstream vertical tabs feature is active,
+  // TabStrip::Initialize() is never called so tab_container_ remains null.
+  // This method must bail out early to avoid crashing when accessing it.
+  if (!tabs::utils::SupportsBraveVerticalTabs(GetBrowserWindowInterface())) {
+    return;
+  }
+
   const bool using_vertical_tabs = ShouldShowVerticalTabs();
   auto* browser = GetBrowserWindowInterface();
   DCHECK(browser);

--- a/browser/ui/views/tabs/brave_tab_strip.cc
+++ b/browser/ui/views/tabs/brave_tab_strip.cc
@@ -244,6 +244,13 @@ void BraveTabStrip::MaybeStartDrag(TabSlotView* source,
 void BraveTabStrip::AddedToWidget() {
   TabStrip::AddedToWidget();
 
+  // When Chromium's upstream vertical tabs feature is active,
+  // TabStrip::Initialize() is never called so tab_container_ remains null.
+  // Skip UpdateOrientation() to avoid crashing when accessing it.
+  if (!tabs::utils::SupportsBraveVerticalTabs(GetBrowserWindowInterface())) {
+    return;
+  }
+
   if (BrowserView::GetBrowserViewForBrowser(GetBrowserWindowInterface())) {
     UpdateOrientation();
   } else {
@@ -305,13 +312,9 @@ bool BraveTabStrip::ShouldShowPinnedTabsInGrid() const {
 }
 
 void BraveTabStrip::UpdateOrientation() {
-  // When Chromium's upstream vertical tabs feature is active,
-  // TabStrip::Initialize() is never called because it's only used by
-  // horizontal tab mode so tab_container_ remains null.
-  // This method must bail out early to avoid crashing when accessing it.
-  if (!tabs::utils::SupportsBraveVerticalTabs(GetBrowserWindowInterface())) {
-    return;
-  }
+  // Callers must guard against unsupported configurations (e.g. upstream
+  // vertical tabs where tab_container_ is null).
+  CHECK(tabs::utils::SupportsBraveVerticalTabs(GetBrowserWindowInterface()));
 
   const bool using_vertical_tabs = ShouldShowVerticalTabs();
   auto* browser = GetBrowserWindowInterface();


### PR DESCRIPTION
When Chromium's vertical tabs feature is enabled, TabStrip::Initialize() is never called
so tab_container_ remains null. This caused a crash in SetAvailableWidthCallback() during startup.
Early return when Brave vertical tabs are not supported.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/54419

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
