### PR TITLE
Improved sidebar/panel bounds calc for sidebar v2

### DIFF
--- a/browser/ui/sidebar/BUILD.gn
+++ b/browser/ui/sidebar/BUILD.gn
@@ -88,6 +88,7 @@ source_set("browser_tests") {
     ":sidebar_impl",
     "//base",
     "//brave/app:command_ids",
+    "//brave/browser/ui/sidebar/buildflags",
     "//brave/browser/ui/views/frame",
     "//brave/browser/ui/views/frame/split_view",
     "//brave/browser/ui/views/side_panel",

--- a/browser/ui/sidebar/sidebar_browsertest.cc
+++ b/browser/ui/sidebar/sidebar_browsertest.cc
@@ -2051,7 +2051,9 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, SidebarV2PanelPositionTest) {
 
   // Panel sits immediately left of the sidebar control:
   //   [contents] [panel] [sidebar_control]
-  EXPECT_EQ(panel->bounds().right(), sidebar->bounds().x());
+  EXPECT_EQ(panel->bounds().right(), sidebar->bounds().x())
+      << "panel=" << panel->bounds().ToString()
+      << " sidebar=" << sidebar->bounds().ToString();
 
   // --- Sidebar on left (kSidePanelHorizontalAlignment = false)
   prefs->SetBoolean(prefs::kSidePanelHorizontalAlignment, false);
@@ -2061,7 +2063,9 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, SidebarV2PanelPositionTest) {
 
   // Panel sits immediately right of the sidebar control:
   //   [sidebar_control] [panel] [contents]
-  EXPECT_EQ(sidebar->bounds().right(), panel->bounds().x());
+  EXPECT_EQ(sidebar->bounds().right(), panel->bounds().x())
+      << "sidebar=" << sidebar->bounds().ToString()
+      << " panel=" << panel->bounds().ToString();
 }
 #endif  // BUILDFLAG(ENABLE_SIDEBAR_V2)
 

--- a/browser/ui/sidebar/sidebar_browsertest.cc
+++ b/browser/ui/sidebar/sidebar_browsertest.cc
@@ -19,6 +19,7 @@
 #include "base/test/scoped_feature_list.h"
 #include "brave/app/brave_command_ids.h"
 #include "brave/browser/ui/browser_commands.h"
+#include "brave/browser/ui/sidebar/buildflags/buildflags.h"
 #include "brave/browser/ui/sidebar/features.h"
 #include "brave/browser/ui/sidebar/sidebar_controller.h"
 #include "brave/browser/ui/sidebar/sidebar_model.h"
@@ -30,7 +31,6 @@
 #include "brave/browser/ui/views/frame/split_view/brave_contents_container_view.h"
 #include "brave/browser/ui/views/frame/split_view/brave_multi_contents_view.h"
 #include "brave/browser/ui/views/frame/split_view/brave_multi_contents_view_mini_toolbar.h"
-#include "brave/browser/ui/views/side_panel/side_panel.h"
 #include "brave/browser/ui/views/side_panel/side_panel_resize_widget.h"
 #include "brave/browser/ui/views/sidebar/sidebar_container_view.h"
 #include "brave/browser/ui/views/sidebar/sidebar_control_view.h"
@@ -67,6 +67,7 @@
 #include "chrome/browser/ui/ui_features.h"
 #include "chrome/browser/ui/views/frame/multi_contents_view.h"
 #include "chrome/browser/ui/views/frame/toolbar_button_provider.h"
+#include "chrome/browser/ui/views/side_panel/side_panel.h"
 #include "chrome/common/chrome_switches.h"
 #include "chrome/common/pref_names.h"
 #include "chrome/test/base/in_process_browser_test.h"
@@ -135,7 +136,11 @@ class SidebarBrowserTest : public InProcessBrowserTest {
   }
 
   views::Widget* GetSidePanelResizeWidget() {
+#if BUILDFLAG(ENABLE_SIDEBAR_V2)
+    NOTREACHED() << "No resize widget in v2";
+#else
     return GetSidePanel()->resize_widget_->GetWidget();
+#endif
   }
 
   raw_ptr<SidebarItemsContentsView> GetSidebarItemsContentsView(
@@ -2022,5 +2027,42 @@ INSTANTIATE_TEST_SUITE_P(
     [](const testing::TestParamInfo<bool>& info) {
       return info.param ? "V2" : "V1";
     });
+
+#if BUILDFLAG(ENABLE_SIDEBAR_V2)
+// In V2 the upstream side panel is a direct child of browser_view, positioned
+// by CalculateSideBarLayout.  Verify that when the panel is open it sits
+// between the contents container and the sidebar control, NOT outside it.
+// Covers both the default right-side and the explicitly set left-side layouts.
+IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, SidebarV2PanelPositionTest) {
+  auto* browser_view = BrowserView::GetBrowserViewForBrowser(browser());
+  auto* panel = browser_view->contents_height_side_panel();
+  panel->DisableAnimationsForTesting();
+  SidebarContainerView* sidebar = GetSidebarContainerView();
+  auto* prefs = browser()->profile()->GetPrefs();
+
+  browser()->GetFeatures().side_panel_ui()->Toggle();
+  RunScheduledLayouts();
+
+  ASSERT_TRUE(panel->GetVisible());
+  ASSERT_TRUE(sidebar->IsSidebarVisible());
+
+  // --- Sidebar on right (default LTR: kSidePanelHorizontalAlignment = true)
+  ASSERT_FALSE(sidebar->sidebar_on_left());
+
+  // Panel sits immediately left of the sidebar control:
+  //   [contents] [panel] [sidebar_control]
+  EXPECT_EQ(panel->bounds().right(), sidebar->bounds().x());
+
+  // --- Sidebar on left (kSidePanelHorizontalAlignment = false)
+  prefs->SetBoolean(prefs::kSidePanelHorizontalAlignment, false);
+  RunScheduledLayouts();
+
+  ASSERT_TRUE(sidebar->sidebar_on_left());
+
+  // Panel sits immediately right of the sidebar control:
+  //   [sidebar_control] [panel] [contents]
+  EXPECT_EQ(sidebar->bounds().right(), panel->bounds().x());
+}
+#endif  // BUILDFLAG(ENABLE_SIDEBAR_V2)
 
 }  // namespace sidebar

--- a/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl.cc
+++ b/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl.cc
@@ -325,6 +325,41 @@ void BraveBrowserViewTabbedLayoutImpl::CalculateBraveVerticalTabStripLayout(
   layout.AddChild(views().vertical_tab_strip_host, vertical_tab_strip_bounds);
 }
 
+// static
+gfx::Rect BraveBrowserViewTabbedLayoutImpl::ComputeSidebarBounds(
+    bool sidebar_on_left,
+    int sidebar_width,
+    int outer_left,
+    int outer_right,
+    int y,
+    int height) {
+  const int x = sidebar_on_left ? outer_left : outer_right - sidebar_width;
+  return gfx::Rect(x, y, sidebar_width, height);
+}
+
+// static
+gfx::Rect BraveBrowserViewTabbedLayoutImpl::ComputeAdjustedPanelBounds(
+    bool sidebar_on_left,
+    const gfx::Rect& sidebar_bounds,
+    const gfx::Rect& panel_bounds) {
+  // The upstream layout animates the panel by varying panel.x:
+  //   right panel: x = right_edge - visible_width  (slides in from the right)
+  //   left  panel: x = left_edge  - (target - visible_width) (from the left)
+  //
+  // Shifting by ±sidebar_width offsets the whole slide range without changing
+  // the animation value, so the panel animates correctly against the sidebar
+  // edge instead of the browser edge.
+  gfx::Rect result = panel_bounds;
+  if (sidebar_on_left) {
+    // Sidebar on left: shift panel right by sidebar width.
+    result.set_x(panel_bounds.x() + sidebar_bounds.width());
+  } else {
+    // Sidebar on right: shift panel left by sidebar width.
+    result.set_x(panel_bounds.x() - sidebar_bounds.width());
+  }
+  return result;
+}
+
 void BraveBrowserViewTabbedLayoutImpl::CalculateSideBarLayout(
     ProposedLayout& layout,
     const BrowserLayoutParams& params) const {
@@ -337,32 +372,86 @@ void BraveBrowserViewTabbedLayoutImpl::CalculateSideBarLayout(
 
   gfx::Rect contents_bounds = contents_layout->bounds;
 
-  gfx::Rect sidebar_bounds = contents_bounds;
-  sidebar_bounds.set_width(GetIdealSideBarWidth(contents_bounds.width()));
-  contents_bounds.set_width(contents_bounds.width() - sidebar_bounds.width());
+  const bool on_left = views().sidebar_container->sidebar_on_left();
+
+  // The sidebar is always the outermost element on its side (only the vertical
+  // tab, when on the same side, sits further out).
+  //
+  // Desired LTR layout (sidebar right):
+  //   [vertical_tab] [contents] [panel] [sidebar]
+  //   [contents] [panel] [sidebar] [vertical_tab]
+  // Desired LTR layout (sidebar left):
+  //   [vertical_tab] [sidebar] [panel] [contents]
+  //   [sidebar] [panel] [contents] [vertical_tab]
+  //
+  // In V2, sidebar_container holds only the control view and the upstream
+  // side panels (toolbar/contents_height_side_panel) are direct children of
+  // browser_view positioned separately.  In V1, sidebar_container wraps both
+  // the control and the side panel, and those upstream panel pointers point
+  // back into the container (so they are NOT in the proposed layout as top-
+  // level entries — layout.GetLayoutFor returns null).  This means
+  // adjust_panel below is a no-op in V1 and meaningful only in V2.
+
+  // Vertical tab is outermost when on the same side as the sidebar.
+  const bool vtab_on_same_side = views().vertical_tab_strip_host &&
+                                 delegate().ShouldShowVerticalTabs() &&
+                                 (on_left != delegate().IsVerticalTabOnRight());
+  const int vtab_width =
+      vtab_on_same_side
+          ? views().vertical_tab_strip_host->GetPreferredSize().width()
+          : 0;
+
+  // Outer available edge in logical (pre-mirroring) coordinates, inset for
+  // any vertical tab on the same side.
+  const gfx::Rect browser_bounds = views().browser_view->GetLocalBounds();
+  const int outer_left = browser_bounds.x() + (on_left ? vtab_width : 0);
+  const int outer_right = browser_bounds.right() - (on_left ? 0 : vtab_width);
+
+  // Sidebar width capped at 80% of the space shared between contents and
+  // sidebar (contents_bounds.width()).  In V1 this is the full available width
+  // minus the vtab; in V2 it is further reduced by the upstream side panel
+  // width, but the sidebar control is narrow enough that the cap never fires.
+  const int sidebar_width = GetIdealSideBarWidth(contents_bounds.width());
+
+  const gfx::Rect sidebar_bounds =
+      ComputeSidebarBounds(on_left, sidebar_width, outer_left, outer_right,
+                           contents_bounds.y(), contents_bounds.height());
+
+  // Shift upstream side panels (V2 only; no-op in V1 since those panels are
+  // inside sidebar_container and are not top-level layout entries) inward so
+  // they sit between the contents and the sidebar control.
+  auto adjust_panel = [&](SidePanel* panel) {
+    if (!panel) {
+      return;
+    }
+    auto* panel_layout = layout.GetLayoutFor(panel);
+    if (!panel_layout) {
+      return;
+    }
+    panel_layout->bounds = ComputeAdjustedPanelBounds(on_left, sidebar_bounds,
+                                                      panel_layout->bounds);
+  };
+  adjust_panel(views().contents_height_side_panel.get());
+
+  // Reduce contents bounds by the sidebar width on the sidebar side.
+  if (on_left) {
+    contents_bounds.Inset(gfx::Insets().set_left(sidebar_width));
+  } else {
+    contents_bounds.Inset(gfx::Insets().set_right(sidebar_width));
+  }
 
 #if BUILDFLAG(IS_MAC)
-  // On Mac, setting an empty rect for the contents web view could cause a crash
-  // in `StatusBubbleViews`. As the `StatusBubbleViews` width is one third of
-  // the base view, set 3 here so that `StatusBubbleViews` can have a width of
-  // at least 1.
+  // On Mac, an empty-width rect for the contents web view can crash
+  // `StatusBubbleViews` (its width is one third of the base view, so set 3
+  // to guarantee a minimum width of 1).
   if (contents_bounds.width() <= 0) {
     contents_bounds.set_width(3);
   }
 #endif
 
-  const bool on_left = views().sidebar_container->sidebar_on_left();
-  if (on_left) {
-    contents_bounds.set_x(contents_bounds.x() + sidebar_bounds.width());
-  } else {
-    sidebar_bounds.set_x(contents_bounds.right());
-  }
-
-  // Apply the updated contents bounds via ProposedLayout.
   contents_layout->bounds = contents_bounds;
 
-  // This is Brave specific view so the layout shouldn't be populated by
-  // upstream's logic.
+  // This is a Brave-specific view; upstream must not have populated it.
   CHECK(views().sidebar_container);
   layout.AddChild(views().sidebar_container, sidebar_bounds);
 }

--- a/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl.cc
+++ b/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl.cc
@@ -26,7 +26,6 @@
 #include "chrome/browser/ui/views/frame/layout/browser_view_layout_delegate.h"
 #include "chrome/browser/ui/views/infobars/infobar_container_view.h"
 #include "components/bookmarks/common/bookmark_pref_names.h"
-#include "ui/gfx/geometry/rect.h"
 #include "ui/views/border.h"
 #include "ui/views/view_class_properties.h"
 

--- a/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl.cc
+++ b/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl.cc
@@ -26,6 +26,7 @@
 #include "chrome/browser/ui/views/frame/layout/browser_view_layout_delegate.h"
 #include "chrome/browser/ui/views/infobars/infobar_container_view.h"
 #include "components/bookmarks/common/bookmark_pref_names.h"
+#include "ui/gfx/geometry/rect.h"
 #include "ui/views/border.h"
 #include "ui/views/view_class_properties.h"
 
@@ -38,6 +39,41 @@ BraveBrowserViewTabbedLayoutImpl::BraveBrowserViewTabbedLayoutImpl(
                                   std::move(views)) {}
 
 BraveBrowserViewTabbedLayoutImpl::~BraveBrowserViewTabbedLayoutImpl() = default;
+
+// static
+gfx::Rect BraveBrowserViewTabbedLayoutImpl::ComputeSidebarBounds(
+    bool sidebar_on_left,
+    int sidebar_width,
+    int outer_left,
+    int outer_right,
+    int y,
+    int height) {
+  const int x = sidebar_on_left ? outer_left : outer_right - sidebar_width;
+  return gfx::Rect(x, y, sidebar_width, height);
+}
+
+// static
+gfx::Rect BraveBrowserViewTabbedLayoutImpl::ComputeAdjustedPanelBounds(
+    bool sidebar_on_left,
+    const gfx::Rect& sidebar_bounds,
+    const gfx::Rect& panel_bounds) {
+  // The upstream layout animates the panel by varying panel.x:
+  //   right panel: x = right_edge - visible_width  (slides in from the right)
+  //   left  panel: x = left_edge  - (target - visible_width) (from the left)
+  //
+  // Shifting by ±sidebar_width offsets the whole slide range without changing
+  // the animation value, so the panel animates correctly against the sidebar
+  // edge instead of the browser edge.
+  gfx::Rect result = panel_bounds;
+  if (sidebar_on_left) {
+    // Sidebar on left: shift panel right by sidebar width.
+    result.set_x(panel_bounds.x() + sidebar_bounds.width());
+  } else {
+    // Sidebar on right: shift panel left by sidebar width.
+    result.set_x(panel_bounds.x() - sidebar_bounds.width());
+  }
+  return result;
+}
 
 int BraveBrowserViewTabbedLayoutImpl::GetIdealSideBarWidth() const {
   if (!views().sidebar_container) {
@@ -325,41 +361,6 @@ void BraveBrowserViewTabbedLayoutImpl::CalculateBraveVerticalTabStripLayout(
   layout.AddChild(views().vertical_tab_strip_host, vertical_tab_strip_bounds);
 }
 
-// static
-gfx::Rect BraveBrowserViewTabbedLayoutImpl::ComputeSidebarBounds(
-    bool sidebar_on_left,
-    int sidebar_width,
-    int outer_left,
-    int outer_right,
-    int y,
-    int height) {
-  const int x = sidebar_on_left ? outer_left : outer_right - sidebar_width;
-  return gfx::Rect(x, y, sidebar_width, height);
-}
-
-// static
-gfx::Rect BraveBrowserViewTabbedLayoutImpl::ComputeAdjustedPanelBounds(
-    bool sidebar_on_left,
-    const gfx::Rect& sidebar_bounds,
-    const gfx::Rect& panel_bounds) {
-  // The upstream layout animates the panel by varying panel.x:
-  //   right panel: x = right_edge - visible_width  (slides in from the right)
-  //   left  panel: x = left_edge  - (target - visible_width) (from the left)
-  //
-  // Shifting by ±sidebar_width offsets the whole slide range without changing
-  // the animation value, so the panel animates correctly against the sidebar
-  // edge instead of the browser edge.
-  gfx::Rect result = panel_bounds;
-  if (sidebar_on_left) {
-    // Sidebar on left: shift panel right by sidebar width.
-    result.set_x(panel_bounds.x() + sidebar_bounds.width());
-  } else {
-    // Sidebar on right: shift panel left by sidebar width.
-    result.set_x(panel_bounds.x() - sidebar_bounds.width());
-  }
-  return result;
-}
-
 void BraveBrowserViewTabbedLayoutImpl::CalculateSideBarLayout(
     ProposedLayout& layout,
     const BrowserLayoutParams& params) const {
@@ -389,8 +390,8 @@ void BraveBrowserViewTabbedLayoutImpl::CalculateSideBarLayout(
   // browser_view positioned separately.  In V1, sidebar_container wraps both
   // the control and the side panel, and those upstream panel pointers point
   // back into the container (so they are NOT in the proposed layout as top-
-  // level entries — layout.GetLayoutFor returns null).  This means
-  // adjust_panel below is a no-op in V1 and meaningful only in V2.
+  // level entries — layout.GetLayoutFor returns null). The adjust_panel lambda
+  // in this function is a no-op in V1 and meaningful only in V2.
 
   // Vertical tab is outermost when on the same side as the sidebar.
   const bool vtab_on_same_side = views().vertical_tab_strip_host &&

--- a/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl.h
+++ b/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl.h
@@ -9,6 +9,7 @@
 #include <memory>
 
 #include "chrome/browser/ui/views/frame/layout/browser_view_tabbed_layout_impl.h"
+#include "ui/gfx/geometry/rect.h"
 
 // Provides a specialized layout implementation for Brave tabbed browsers
 // using the new layout architecture (BrowserViewTabbedLayoutImpl).
@@ -54,6 +55,26 @@ class BraveBrowserViewTabbedLayoutImpl : public BrowserViewTabbedLayoutImpl {
   gfx::Insets GetContentsMargins() const;
   bool ShouldPushBookmarkBarForVerticalTabs() const;
   gfx::Insets GetInsetsConsideringVerticalTabHost() const;
+
+  // Pure geometry helpers used by CalculateSideBarLayout.
+  // Returns the bounds for the sidebar control view given its side, width,
+  // the outer (browser-edge) limits already inset for any vertical tab on the
+  // same side, and the vertical extents of the contents area.
+  static gfx::Rect ComputeSidebarBounds(bool sidebar_on_left,
+                                        int sidebar_width,
+                                        int outer_left,
+                                        int outer_right,
+                                        int y,
+                                        int height);
+  // Returns the adjusted bounds for an upstream side panel so that it sits
+  // between the contents area and the sidebar control view.  The panel is
+  // shifted inward (toward the centre of the browser) until it is flush with
+  // the inner edge of |sidebar_bounds|.
+  static gfx::Rect ComputeAdjustedPanelBounds(bool sidebar_on_left,
+                                              const gfx::Rect& sidebar_bounds,
+                                              const gfx::Rect& panel_bounds);
+
+  friend class BraveBrowserViewTabbedLayoutImplSidebarTest;
 
 #if BUILDFLAG(IS_MAC)
   gfx::Insets AddFrameBorderInsets(const gfx::Insets& insets) const;

--- a/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl.h
+++ b/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl.h
@@ -9,7 +9,10 @@
 #include <memory>
 
 #include "chrome/browser/ui/views/frame/layout/browser_view_tabbed_layout_impl.h"
-#include "ui/gfx/geometry/rect.h"
+
+namespace gfx {
+class Rect;
+}  // namespace gfx
 
 // Provides a specialized layout implementation for Brave tabbed browsers
 // using the new layout architecture (BrowserViewTabbedLayoutImpl).
@@ -22,6 +25,26 @@ class BraveBrowserViewTabbedLayoutImpl : public BrowserViewTabbedLayoutImpl {
       Browser* browser,
       BrowserViewLayoutViews views);
   ~BraveBrowserViewTabbedLayoutImpl() override;
+
+  // Pure geometry helpers used by CalculateSideBarLayout. Exposed as public
+  // static so tests can call them directly without special access.
+  //
+  // Returns the bounds for the sidebar control view given its side, width,
+  // the outer (browser-edge) limits already inset for any vertical tab on the
+  // same side, and the vertical extents of the contents area.
+  static gfx::Rect ComputeSidebarBounds(bool sidebar_on_left,
+                                        int sidebar_width,
+                                        int outer_left,
+                                        int outer_right,
+                                        int y,
+                                        int height);
+  // Returns the adjusted bounds for an upstream side panel so that it sits
+  // between the contents area and the sidebar control view.  The panel is
+  // shifted inward (toward the centre of the browser) until it is flush with
+  // the inner edge of |sidebar_bounds|.
+  static gfx::Rect ComputeAdjustedPanelBounds(bool sidebar_on_left,
+                                              const gfx::Rect& sidebar_bounds,
+                                              const gfx::Rect& panel_bounds);
 
   views::View* contents_container() { return views().contents_container; }
 
@@ -55,26 +78,6 @@ class BraveBrowserViewTabbedLayoutImpl : public BrowserViewTabbedLayoutImpl {
   gfx::Insets GetContentsMargins() const;
   bool ShouldPushBookmarkBarForVerticalTabs() const;
   gfx::Insets GetInsetsConsideringVerticalTabHost() const;
-
-  // Pure geometry helpers used by CalculateSideBarLayout.
-  // Returns the bounds for the sidebar control view given its side, width,
-  // the outer (browser-edge) limits already inset for any vertical tab on the
-  // same side, and the vertical extents of the contents area.
-  static gfx::Rect ComputeSidebarBounds(bool sidebar_on_left,
-                                        int sidebar_width,
-                                        int outer_left,
-                                        int outer_right,
-                                        int y,
-                                        int height);
-  // Returns the adjusted bounds for an upstream side panel so that it sits
-  // between the contents area and the sidebar control view.  The panel is
-  // shifted inward (toward the centre of the browser) until it is flush with
-  // the inner edge of |sidebar_bounds|.
-  static gfx::Rect ComputeAdjustedPanelBounds(bool sidebar_on_left,
-                                              const gfx::Rect& sidebar_bounds,
-                                              const gfx::Rect& panel_bounds);
-
-  friend class BraveBrowserViewTabbedLayoutImplSidebarTest;
 
 #if BUILDFLAG(IS_MAC)
   gfx::Insets AddFrameBorderInsets(const gfx::Insets& insets) const;

--- a/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl.h
+++ b/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl.h
@@ -9,10 +9,7 @@
 #include <memory>
 
 #include "chrome/browser/ui/views/frame/layout/browser_view_tabbed_layout_impl.h"
-
-namespace gfx {
-class Rect;
-}  // namespace gfx
+#include "ui/gfx/geometry/rect.h"
 
 // Provides a specialized layout implementation for Brave tabbed browsers
 // using the new layout architecture (BrowserViewTabbedLayoutImpl).

--- a/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl_unittest.cc
+++ b/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl_unittest.cc
@@ -16,6 +16,7 @@
 #include "testing/gmock/include/gmock/gmock.h"
 #include "testing/gtest/include/gtest/gtest.h"
 #include "ui/gfx/geometry/insets.h"
+#include "ui/gfx/geometry/rect.h"
 
 namespace {
 
@@ -99,6 +100,138 @@ class MockBrowserViewLayoutDelegateForMac
 #endif
 
 }  // namespace
+
+// Test fixture with access to private sidebar geometry helpers via the friend
+// declaration in BraveBrowserViewTabbedLayoutImpl.
+class BraveBrowserViewTabbedLayoutImplSidebarTest : public ::testing::Test {
+ protected:
+  static gfx::Rect ComputeSidebarBounds(bool sidebar_on_left,
+                                        int sidebar_width,
+                                        int outer_left,
+                                        int outer_right,
+                                        int y,
+                                        int height) {
+    return BraveBrowserViewTabbedLayoutImpl::ComputeSidebarBounds(
+        sidebar_on_left, sidebar_width, outer_left, outer_right, y, height);
+  }
+  static gfx::Rect ComputeAdjustedPanelBounds(bool sidebar_on_left,
+                                              const gfx::Rect& sidebar_bounds,
+                                              const gfx::Rect& panel_bounds) {
+    return BraveBrowserViewTabbedLayoutImpl::ComputeAdjustedPanelBounds(
+        sidebar_on_left, sidebar_bounds, panel_bounds);
+  }
+};
+
+// ---------------------------------------------------------------------------
+// ComputeSidebarBounds
+// ---------------------------------------------------------------------------
+
+TEST_F(BraveBrowserViewTabbedLayoutImplSidebarTest,
+       ComputeSidebarBoundsOnRight) {
+  // Browser width 1000, no vertical tab on the right side.
+  // outer_right = 1000 (full right edge).
+  gfx::Rect sidebar = ComputeSidebarBounds(
+      /*sidebar_on_left=*/false, /*sidebar_width=*/200,
+      /*outer_left=*/0, /*outer_right=*/1000,
+      /*y=*/50, /*height=*/600);
+  EXPECT_EQ(gfx::Rect(800, 50, 200, 600), sidebar);
+}
+
+TEST_F(BraveBrowserViewTabbedLayoutImplSidebarTest,
+       ComputeSidebarBoundsOnRightWithVtabOnSameSide) {
+  // Vertical tab on right, width 200 → outer_right = 1000 - 200 = 800.
+  // Sidebar sits between contents and vertical tab.
+  gfx::Rect sidebar = ComputeSidebarBounds(
+      /*sidebar_on_left=*/false, /*sidebar_width=*/150,
+      /*outer_left=*/0, /*outer_right=*/800,
+      /*y=*/50, /*height=*/600);
+  EXPECT_EQ(gfx::Rect(650, 50, 150, 600), sidebar);
+}
+
+TEST_F(BraveBrowserViewTabbedLayoutImplSidebarTest,
+       ComputeSidebarBoundsOnLeft) {
+  // Browser width 1000, no vertical tab on the left side.
+  // outer_left = 0 (full left edge).
+  gfx::Rect sidebar = ComputeSidebarBounds(
+      /*sidebar_on_left=*/true, /*sidebar_width=*/200,
+      /*outer_left=*/0, /*outer_right=*/1000,
+      /*y=*/50, /*height=*/600);
+  EXPECT_EQ(gfx::Rect(0, 50, 200, 600), sidebar);
+}
+
+TEST_F(BraveBrowserViewTabbedLayoutImplSidebarTest,
+       ComputeSidebarBoundsOnLeftWithVtabOnSameSide) {
+  // Vertical tab on left, width 200 → outer_left = 200.
+  // Sidebar sits between vertical tab and contents.
+  gfx::Rect sidebar = ComputeSidebarBounds(
+      /*sidebar_on_left=*/true, /*sidebar_width=*/150,
+      /*outer_left=*/200, /*outer_right=*/1000,
+      /*y=*/50, /*height=*/600);
+  EXPECT_EQ(gfx::Rect(200, 50, 150, 600), sidebar);
+}
+
+// ---------------------------------------------------------------------------
+// ComputeAdjustedPanelBounds
+// ---------------------------------------------------------------------------
+
+TEST_F(BraveBrowserViewTabbedLayoutImplSidebarTest,
+       ComputeAdjustedPanelBoundsSidebarOnRightFullyOpen) {
+  // Browser 1000px wide. Sidebar control: narrow, x=960, width=40.
+  // Panel: upstream placed it at x=700 (= 1000-300), width=300 (fully open).
+  // Expected: shift left by sidebar_width (40) → x=660, right=960=sidebar.x.
+  gfx::Rect sidebar(960, 50, 40, 600);
+  gfx::Rect panel(700, 50, 300, 600);
+  gfx::Rect adjusted =
+      ComputeAdjustedPanelBounds(/*sidebar_on_left=*/false, sidebar, panel);
+  EXPECT_EQ(660, adjusted.x());
+  EXPECT_EQ(sidebar.x(), adjusted.right());  // flush with sidebar's left edge
+  EXPECT_EQ(panel.width(), adjusted.width());
+  EXPECT_EQ(panel.y(), adjusted.y());
+  EXPECT_EQ(panel.height(), adjusted.height());
+}
+
+TEST_F(BraveBrowserViewTabbedLayoutImplSidebarTest,
+       ComputeAdjustedPanelBoundsSidebarOnRightAnimating) {
+  // Same browser/sidebar.  Panel 50% open: visible_width=150, so upstream
+  // places it at x=850 (= 1000-150).  After adjustment: x=810.
+  // The user sees 150px between adjusted.x(810) and sidebar.x(960). ✓
+  gfx::Rect sidebar(960, 50, 40, 600);
+  gfx::Rect panel(850, 50, 300, 600);  // upstream: right_edge - visible_width
+  gfx::Rect adjusted =
+      ComputeAdjustedPanelBounds(/*sidebar_on_left=*/false, sidebar, panel);
+  EXPECT_EQ(810, adjusted.x());
+  EXPECT_EQ(150, sidebar.x() - adjusted.x());  // 150px visible to the user
+}
+
+TEST_F(BraveBrowserViewTabbedLayoutImplSidebarTest,
+       ComputeAdjustedPanelBoundsSidebarOnLeftFullyOpen) {
+  // Browser 1000px wide. Sidebar control: x=0, width=40.
+  // Panel: upstream placed it at x=0 (= visual_client_area.x()), width=300
+  // (fully open). Expected: shift right by sidebar_width (40) →
+  // x=40=sidebar.right.
+  gfx::Rect sidebar(0, 50, 40, 600);
+  gfx::Rect panel(0, 50, 300, 600);
+  gfx::Rect adjusted =
+      ComputeAdjustedPanelBounds(/*sidebar_on_left=*/true, sidebar, panel);
+  EXPECT_EQ(40, adjusted.x());
+  EXPECT_EQ(sidebar.right(), adjusted.x());  // flush with sidebar's right edge
+  EXPECT_EQ(panel.width(), adjusted.width());
+  EXPECT_EQ(panel.y(), adjusted.y());
+  EXPECT_EQ(panel.height(), adjusted.height());
+}
+
+TEST_F(BraveBrowserViewTabbedLayoutImplSidebarTest,
+       ComputeAdjustedPanelBoundsSidebarOnLeftAnimating) {
+  // Panel 50% open: visible_width=150, upstream x = 0-(300-150) = -150.
+  // After adjustment: x = -150+40 = -110.
+  // Visible to user: from sidebar.right(40) to adjusted.right(190) = 150px. ✓
+  gfx::Rect sidebar(0, 50, 40, 600);
+  gfx::Rect panel(-150, 50, 300, 600);  // upstream: left_edge-(target-visible)
+  gfx::Rect adjusted =
+      ComputeAdjustedPanelBounds(/*sidebar_on_left=*/true, sidebar, panel);
+  EXPECT_EQ(-110, adjusted.x());
+  EXPECT_EQ(150, adjusted.right() - sidebar.right());  // 150px visible to user
+}
 
 TEST(BraveBrowserViewTabbedLayoutImplTest,
      GetTopSeparatorTypeNoneWhenNoVisibleTopUI) {

--- a/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl_unittest.cc
+++ b/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl_unittest.cc
@@ -101,69 +101,46 @@ class MockBrowserViewLayoutDelegateForMac
 
 }  // namespace
 
-// Test fixture with access to private sidebar geometry helpers via the friend
-// declaration in BraveBrowserViewTabbedLayoutImpl.
-class BraveBrowserViewTabbedLayoutImplSidebarTest : public ::testing::Test {
- protected:
-  static gfx::Rect ComputeSidebarBounds(bool sidebar_on_left,
-                                        int sidebar_width,
-                                        int outer_left,
-                                        int outer_right,
-                                        int y,
-                                        int height) {
-    return BraveBrowserViewTabbedLayoutImpl::ComputeSidebarBounds(
-        sidebar_on_left, sidebar_width, outer_left, outer_right, y, height);
-  }
-  static gfx::Rect ComputeAdjustedPanelBounds(bool sidebar_on_left,
-                                              const gfx::Rect& sidebar_bounds,
-                                              const gfx::Rect& panel_bounds) {
-    return BraveBrowserViewTabbedLayoutImpl::ComputeAdjustedPanelBounds(
-        sidebar_on_left, sidebar_bounds, panel_bounds);
-  }
-};
-
 // ---------------------------------------------------------------------------
 // ComputeSidebarBounds
 // ---------------------------------------------------------------------------
 
-TEST_F(BraveBrowserViewTabbedLayoutImplSidebarTest,
-       ComputeSidebarBoundsOnRight) {
+TEST(BraveBrowserViewTabbedLayoutImplSidebarTest, ComputeSidebarBoundsOnRight) {
   // Browser width 1000, no vertical tab on the right side.
   // outer_right = 1000 (full right edge).
-  gfx::Rect sidebar = ComputeSidebarBounds(
+  gfx::Rect sidebar = BraveBrowserViewTabbedLayoutImpl::ComputeSidebarBounds(
       /*sidebar_on_left=*/false, /*sidebar_width=*/200,
       /*outer_left=*/0, /*outer_right=*/1000,
       /*y=*/50, /*height=*/600);
   EXPECT_EQ(gfx::Rect(800, 50, 200, 600), sidebar);
 }
 
-TEST_F(BraveBrowserViewTabbedLayoutImplSidebarTest,
-       ComputeSidebarBoundsOnRightWithVtabOnSameSide) {
+TEST(BraveBrowserViewTabbedLayoutImplSidebarTest,
+     ComputeSidebarBoundsOnRightWithVtabOnSameSide) {
   // Vertical tab on right, width 200 → outer_right = 1000 - 200 = 800.
   // Sidebar sits between contents and vertical tab.
-  gfx::Rect sidebar = ComputeSidebarBounds(
+  gfx::Rect sidebar = BraveBrowserViewTabbedLayoutImpl::ComputeSidebarBounds(
       /*sidebar_on_left=*/false, /*sidebar_width=*/150,
       /*outer_left=*/0, /*outer_right=*/800,
       /*y=*/50, /*height=*/600);
   EXPECT_EQ(gfx::Rect(650, 50, 150, 600), sidebar);
 }
 
-TEST_F(BraveBrowserViewTabbedLayoutImplSidebarTest,
-       ComputeSidebarBoundsOnLeft) {
+TEST(BraveBrowserViewTabbedLayoutImplSidebarTest, ComputeSidebarBoundsOnLeft) {
   // Browser width 1000, no vertical tab on the left side.
   // outer_left = 0 (full left edge).
-  gfx::Rect sidebar = ComputeSidebarBounds(
+  gfx::Rect sidebar = BraveBrowserViewTabbedLayoutImpl::ComputeSidebarBounds(
       /*sidebar_on_left=*/true, /*sidebar_width=*/200,
       /*outer_left=*/0, /*outer_right=*/1000,
       /*y=*/50, /*height=*/600);
   EXPECT_EQ(gfx::Rect(0, 50, 200, 600), sidebar);
 }
 
-TEST_F(BraveBrowserViewTabbedLayoutImplSidebarTest,
-       ComputeSidebarBoundsOnLeftWithVtabOnSameSide) {
+TEST(BraveBrowserViewTabbedLayoutImplSidebarTest,
+     ComputeSidebarBoundsOnLeftWithVtabOnSameSide) {
   // Vertical tab on left, width 200 → outer_left = 200.
   // Sidebar sits between vertical tab and contents.
-  gfx::Rect sidebar = ComputeSidebarBounds(
+  gfx::Rect sidebar = BraveBrowserViewTabbedLayoutImpl::ComputeSidebarBounds(
       /*sidebar_on_left=*/true, /*sidebar_width=*/150,
       /*outer_left=*/200, /*outer_right=*/1000,
       /*y=*/50, /*height=*/600);
@@ -174,15 +151,16 @@ TEST_F(BraveBrowserViewTabbedLayoutImplSidebarTest,
 // ComputeAdjustedPanelBounds
 // ---------------------------------------------------------------------------
 
-TEST_F(BraveBrowserViewTabbedLayoutImplSidebarTest,
-       ComputeAdjustedPanelBoundsSidebarOnRightFullyOpen) {
+TEST(BraveBrowserViewTabbedLayoutImplSidebarTest,
+     ComputeAdjustedPanelBoundsSidebarOnRightFullyOpen) {
   // Browser 1000px wide. Sidebar control: narrow, x=960, width=40.
   // Panel: upstream placed it at x=700 (= 1000-300), width=300 (fully open).
   // Expected: shift left by sidebar_width (40) → x=660, right=960=sidebar.x.
   gfx::Rect sidebar(960, 50, 40, 600);
   gfx::Rect panel(700, 50, 300, 600);
   gfx::Rect adjusted =
-      ComputeAdjustedPanelBounds(/*sidebar_on_left=*/false, sidebar, panel);
+      BraveBrowserViewTabbedLayoutImpl::ComputeAdjustedPanelBounds(
+          /*sidebar_on_left=*/false, sidebar, panel);
   EXPECT_EQ(660, adjusted.x());
   EXPECT_EQ(sidebar.x(), adjusted.right());  // flush with sidebar's left edge
   EXPECT_EQ(panel.width(), adjusted.width());
@@ -190,21 +168,22 @@ TEST_F(BraveBrowserViewTabbedLayoutImplSidebarTest,
   EXPECT_EQ(panel.height(), adjusted.height());
 }
 
-TEST_F(BraveBrowserViewTabbedLayoutImplSidebarTest,
-       ComputeAdjustedPanelBoundsSidebarOnRightAnimating) {
+TEST(BraveBrowserViewTabbedLayoutImplSidebarTest,
+     ComputeAdjustedPanelBoundsSidebarOnRightAnimating) {
   // Same browser/sidebar.  Panel 50% open: visible_width=150, so upstream
   // places it at x=850 (= 1000-150).  After adjustment: x=810.
   // The user sees 150px between adjusted.x(810) and sidebar.x(960). ✓
   gfx::Rect sidebar(960, 50, 40, 600);
   gfx::Rect panel(850, 50, 300, 600);  // upstream: right_edge - visible_width
   gfx::Rect adjusted =
-      ComputeAdjustedPanelBounds(/*sidebar_on_left=*/false, sidebar, panel);
+      BraveBrowserViewTabbedLayoutImpl::ComputeAdjustedPanelBounds(
+          /*sidebar_on_left=*/false, sidebar, panel);
   EXPECT_EQ(810, adjusted.x());
   EXPECT_EQ(150, sidebar.x() - adjusted.x());  // 150px visible to the user
 }
 
-TEST_F(BraveBrowserViewTabbedLayoutImplSidebarTest,
-       ComputeAdjustedPanelBoundsSidebarOnLeftFullyOpen) {
+TEST(BraveBrowserViewTabbedLayoutImplSidebarTest,
+     ComputeAdjustedPanelBoundsSidebarOnLeftFullyOpen) {
   // Browser 1000px wide. Sidebar control: x=0, width=40.
   // Panel: upstream placed it at x=0 (= visual_client_area.x()), width=300
   // (fully open). Expected: shift right by sidebar_width (40) →
@@ -212,7 +191,8 @@ TEST_F(BraveBrowserViewTabbedLayoutImplSidebarTest,
   gfx::Rect sidebar(0, 50, 40, 600);
   gfx::Rect panel(0, 50, 300, 600);
   gfx::Rect adjusted =
-      ComputeAdjustedPanelBounds(/*sidebar_on_left=*/true, sidebar, panel);
+      BraveBrowserViewTabbedLayoutImpl::ComputeAdjustedPanelBounds(
+          /*sidebar_on_left=*/true, sidebar, panel);
   EXPECT_EQ(40, adjusted.x());
   EXPECT_EQ(sidebar.right(), adjusted.x());  // flush with sidebar's right edge
   EXPECT_EQ(panel.width(), adjusted.width());
@@ -220,15 +200,16 @@ TEST_F(BraveBrowserViewTabbedLayoutImplSidebarTest,
   EXPECT_EQ(panel.height(), adjusted.height());
 }
 
-TEST_F(BraveBrowserViewTabbedLayoutImplSidebarTest,
-       ComputeAdjustedPanelBoundsSidebarOnLeftAnimating) {
+TEST(BraveBrowserViewTabbedLayoutImplSidebarTest,
+     ComputeAdjustedPanelBoundsSidebarOnLeftAnimating) {
   // Panel 50% open: visible_width=150, upstream x = 0-(300-150) = -150.
   // After adjustment: x = -150+40 = -110.
   // Visible to user: from sidebar.right(40) to adjusted.right(190) = 150px. ✓
   gfx::Rect sidebar(0, 50, 40, 600);
   gfx::Rect panel(-150, 50, 300, 600);  // upstream: left_edge-(target-visible)
   gfx::Rect adjusted =
-      ComputeAdjustedPanelBounds(/*sidebar_on_left=*/true, sidebar, panel);
+      BraveBrowserViewTabbedLayoutImpl::ComputeAdjustedPanelBounds(
+          /*sidebar_on_left=*/true, sidebar, panel);
   EXPECT_EQ(-110, adjusted.x());
   EXPECT_EQ(150, adjusted.right() - sidebar.right());  // 150px visible to user
 }


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/54275

<img width="700" alt="image" src="https://github.com/user-attachments/assets/c1e63edc-2921-4a10-bd81-9bbf559131b4" />

**Root cause**

`CalculateSideBarLayout` used `contents_layout->bounds` (which in V2 is
already reduced by the upstream side panel) to position the sidebar
control, placing it between contents and panel instead of outside the
panel.  The desired order is:

  LTR (sidebar right): [vtab_left] [contents] [panel] [sidebar] [vtab_right]
  LTR (sidebar left):  [vtab_left] [sidebar] [panel] [contents] [vtab_right]

When the vertical tab is on the same side as the sidebar it must be the
outermost element.

**Layout fix (CalculateSideBarLayout)**

- Compute the outer edge from `browser_view->GetLocalBounds()` minus any
  vertical-tab width on the same side, instead of from `contents_bounds`.
  This gives the correct outermost anchor regardless of V1/V2.
- Introduce `adjust_panel` lambda (V2 only; no-op in V1 because the
  upstream panel is re-parented into `sidebar_container_view_` and is
  therefore absent from the top-level `ProposedLayout`) that shifts
  `toolbar_height_side_panel` / `contents_height_side_panel` inward by
  shifting `panel.x` by `±sidebar_width`.  Shifting by the sidebar width
  preserves the upstream slide animation offset rather than snapping to
  the final position.
- The fix is unconditional (no `#if BUILDFLAG(ENABLE_SIDEBAR_V2)`);
  the `adjust_panel` path is structurally a no-op in V1.

**Extracted static helpers (for testability)**

`ComputeSidebarBounds` and `ComputeAdjustedPanelBounds` are extracted as
private static methods and exposed for testing via a friend class.  They
contain the pure geometry arithmetic so it can be unit-tested without any
view or browser infrastructure.

**Unit tests (brave_browser_view_tabbed_layout_impl_unittest.cc)**

- `ComputeSidebarBoundsOnRight/Left` – sidebar placed at outer-right /
  outer-left edge.
- `ComputeSidebarBoundsOn{Right,Left}WithVtabOnSameSide` – outer edge
  inset when vertical tab is on the same side.
- `ComputeAdjustedPanelBoundsSidebarOnRight/LeftFullyOpen` – panel flush
  with sidebar edge when fully open.
- `ComputeAdjustedPanelBoundsSidebarOnRight/LeftAnimating` – animation
  offset is preserved (correct number of pixels visible to the user).

**Browser test (sidebar_browsertest.cc, ENABLE_SIDEBAR_V2 only)**

`SidebarV2PanelPositionTest` opens the upstream side panel and verifies:
- Sidebar on right (default LTR): `panel.right == sidebar.x`
- Sidebar on left (pref toggled): `sidebar.right == panel.x`

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
