### PR TITLE
Removing unused variable that caused build warning

### DIFF
--- a/components/local_ai/resources/candle_embedding_gemma/src/lib.rs
+++ b/components/local_ai/resources/candle_embedding_gemma/src/lib.rs
@@ -1004,7 +1004,6 @@ impl Gemma3Embedder {
             cumulative.push(cumulative.last().unwrap() + len as u32);
         }
 
-        let token_len = all_ids.len();
         Ok(Batch {
             input_ids: all_ids,
             position_ids: all_positions,


### PR DESCRIPTION
Thanks @cmazakas for pointing out [this warning](https://bravesoftware.slack.com/archives/C7VLGSR55/p1775836490631349).

This PR removes the unused variable that causes this particular warning while building. 
