### PR TITLE
Fix settings search errors in origin-branded builds

### DIFF
--- a/browser/resources/settings/brave_origin_page/brave_origin_page.ts
+++ b/browser/resources/settings/brave_origin_page/brave_origin_page.ts
@@ -18,6 +18,9 @@ import {RelaunchMixin, RelaunchMixinInterface, RestartType} from '../relaunch_mi
 import '../relaunch_confirmation_dialog.js'
 
 import {getTemplate} from './brave_origin_page.html.js'
+import {getSearchManager} from '../search_settings.js'
+import type {SearchResult} from '../search_settings.js'
+import type {SettingsPlugin} from '../settings_main/settings_plugin.js'
 import * as BraveOriginMojom from '../brave_origin_settings.mojom-webui.js'
 import './brave_origin_onboarding.js'
 import './origin_toggle_button.js'
@@ -38,7 +41,7 @@ const SettingsBraveOriginPageElementBase =
  * Brave Origin features.
  */
 export class SettingsBraveOriginPageElement
-    extends SettingsBraveOriginPageElementBase {
+    extends SettingsBraveOriginPageElementBase implements SettingsPlugin {
 
   static get is() {
     return 'settings-brave-origin-page'
@@ -157,6 +160,11 @@ export class SettingsBraveOriginPageElement
   private restartBrowser_(e: Event) {
     e.stopPropagation()
     this.performRestart(RestartType.RESTART)
+  }
+
+  async searchContents(query: string): Promise<SearchResult> {
+    const searchRequest = await getSearchManager().search(query, this)
+    return searchRequest.getSearchResult()
   }
 }
 

--- a/browser/resources/settings/brave_search_engines_page/brave_search_engines_page.html
+++ b/browser/resources/settings/brave_search_engines_page/brave_search_engines_page.html
@@ -71,9 +71,9 @@
       sub-label="$i18n{searchSuggestDesc}">
   </settings-toggle-button>
 </template>
-<template is="dom-if" if="[[!isPrefManaged_(
-    prefs.brave.web_discovery_enabled)]]" restamp>
-  <if expr="enable_web_discovery">
+<if expr="enable_web_discovery">
+  <template is="dom-if" if="[[!isPrefManaged_(
+      prefs.brave.web_discovery_enabled)]]" restamp>
     <settings-toggle-button id="webDiscoveryEnabledExtension"
         class="cr-row"
         pref="{{prefs.brave.web_discovery_enabled}}"
@@ -81,5 +81,5 @@
         sub-label="$i18n{braveWebDiscoverySubLabel}"
         learn-more-url="$i18n{webDiscoveryLearnMoreURL}">
     </settings-toggle-button>
-  </if>
-</template>
+  </template>
+</if>

--- a/browser/resources/settings/brave_search_engines_page/brave_search_engines_page.ts
+++ b/browser/resources/settings/brave_search_engines_page/brave_search_engines_page.ts
@@ -106,7 +106,8 @@ class BraveSearchEnginesPage extends BraveSearchEnginesPageBase {
   }
 
   private isPrefManaged_(pref: chrome.settingsPrivate.PrefObject) {
-    return pref.enforcement === chrome.settingsPrivate.Enforcement.ENFORCED
+    return !!pref &&
+        pref.enforcement === chrome.settingsPrivate.Enforcement.ENFORCED
   }
 
   private isWebDiscoveryNativeEnabled_() {


### PR DESCRIPTION
## Summary
- Fix `isPrefManaged_` crash when `prefs.brave.web_discovery_enabled` is undefined by adding a null check and moving `<if expr="enable_web_discovery">` to wrap the entire `dom-if` template (previously only wrapped inner content, so the binding still evaluated).
- Add `searchContents()` to `settings-brave-origin-page` so settings search can call it without throwing `TypeError: element.searchContents is not a function`.

## Test plan
- [x] Build with `is_brave_origin_branded=true`
- [x] Open `chrome://settings` and type in the search box
- [x] Verify no console errors
- [x] Verify search results appear correctly