### PR TITLE
[iOS] Increase sync device limit to 50 to match backend

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Sync/SyncWelcomeViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Sync/SyncWelcomeViewController.swift
@@ -464,7 +464,7 @@ extension SyncWelcomeViewController: SyncPairControllerDelegate {
             )
             present(alert, animated: true, completion: nil)
           case .blocked:
-            // Devices 10 and more - add alert to block and prevent sync
+            // Devices 50 and more - add alert to block and prevent sync
             let alert = UIAlertController(
               title: Strings.genericErrorTitle,
               message: Strings.Sync.maximumDeviceReachedErrorDescription,
@@ -510,9 +510,9 @@ extension SyncWelcomeViewController: SyncPairControllerDelegate {
     switch devices.count {
     case 1...4:
       deviceLimitLevel = .safe
-    case 5...9:
+    case 5..<50:
       deviceLimitLevel = .approvalNeeded
-    case 10...:
+    case 50...:
       deviceLimitLevel = .blocked
     default:
       Logger.module.error("\(DeviceRetriavalError.deviceNumberError.errorDescription)")

--- a/ios/brave-ios/Sources/BraveStrings/BraveStrings+Sync.swift
+++ b/ios/brave-ios/Sources/BraveStrings/BraveStrings+Sync.swift
@@ -743,7 +743,7 @@ extension Strings {
         tableName: "BraveShared",
         bundle: .module,
         value:
-          "You've reached the maximum number of devices (10) allowed in a sync chain. Remove a device to continue.",
+          "You've reached the maximum number of devices (50) allowed in a sync chain. Remove a device to continue.",
         comment: "The message displayed in alert when the maxmium of devices is reached"
       )
     public static let joinChainWarningTitle =


### PR DESCRIPTION
The current client-side limit of 10 was out of date

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/54452