### PR TITLE
Fix default browser detection for Origin branded builds

### DIFF
--- a/chromium_src/chrome/browser/shell_integration_linux.cc
+++ b/chromium_src/chrome/browser/shell_integration_linux.cc
@@ -3,6 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include "brave/components/brave_origin/buildflags/buildflags.h"
+
 #define GetDefaultBrowser GetDefaultBrowser_ChromiumImpl
 #include <chrome/browser/shell_integration_linux.cc>
 #undef GetDefaultBrowser
@@ -21,7 +23,14 @@ bool IsAnyBraveBrowserDefaultBrowser() {
   std::string browser;
   // We don't care about the return value here.
   base::GetAppOutput(base::CommandLine(argv), &browser);
+
+  // Only match the current brand's desktop file prefix so that Brave Origin
+  // doesn't consider regular Brave as "another channel" and vice versa.
+#if BUILDFLAG(IS_BRAVE_ORIGIN_BRANDED)
+  return browser.find("brave-origin") != std::string::npos;
+#else
   return browser.find("brave-browser") != std::string::npos;
+#endif
 }
 
 DefaultWebClientState GetDefaultBrowser() {
@@ -30,7 +39,7 @@ DefaultWebClientState GetDefaultBrowser() {
   if (state == IS_DEFAULT)
     return state;
 
-  // Check Other channel installs are default.
+  // Check other channel installs of the same brand are default.
   return IsAnyBraveBrowserDefaultBrowser() ? OTHER_MODE_IS_DEFAULT
                                            : NOT_DEFAULT;
 }

--- a/chromium_src/chrome/browser/shell_integration_mac.mm
+++ b/chromium_src/chrome/browser/shell_integration_mac.mm
@@ -42,6 +42,7 @@ bool IsBraveOriginBundleId(NSString* identifier) {
          [identifier hasPrefix:@"com.brave.Browser.origin."];
 }
 
+#if !BUILDFLAG(IS_BRAVE_ORIGIN_BRANDED)
 // Returns true if |identifier| is a regular (non-Origin) Brave bundle ID
 // (com.brave.Browser or com.brave.Browser.<channel>, excluding Origin).
 bool IsRegularBraveBundleId(NSString* identifier) {
@@ -49,6 +50,7 @@ bool IsRegularBraveBundleId(NSString* identifier) {
           [identifier hasPrefix:@"com.brave.Browser."]) &&
          !IsBraveOriginBundleId(identifier);
 }
+#endif
 
 // Returns true if |other_identifier| is another channel of the same Brave
 // brand as |my_identifier|. Unlike upstream's IsAnotherChromeChannel() which

--- a/chromium_src/chrome/browser/shell_integration_mac.mm
+++ b/chromium_src/chrome/browser/shell_integration_mac.mm
@@ -10,6 +10,7 @@
 #include "base/apple/scoped_cftyperef.h"
 #include "base/mac/mac_util.h"
 #include "base/strings/sys_string_conversions.h"
+#include "brave/components/brave_origin/buildflags/buildflags.h"
 #include "build/branding_buildflags.h"
 #include "chrome/common/channel_info.h"
 #include "components/version_info/version_info.h"
@@ -22,11 +23,89 @@
 
 #define GetPlatformSpecificDefaultWebClientSetPermission \
   GetPlatformSpecificDefaultWebClientSetPermission_Unused
+#define GetDefaultBrowser GetDefaultBrowser_ChromiumImpl
+#define IsDefaultHandlerForUTType IsDefaultHandlerForUTType_ChromiumImpl
 #include <chrome/browser/shell_integration_mac.mm>
+#undef IsDefaultHandlerForUTType
+#undef GetDefaultBrowser
 #undef GetPlatformSpecificDefaultWebClientSetPermission
 #undef BUILDFLAG_INTERNAL_GOOGLE_CHROME_BRANDING
 
 namespace shell_integration {
+
+namespace {
+
+// Returns true if |identifier| is a Brave Origin bundle ID
+// (com.brave.Browser.origin or com.brave.Browser.origin.<channel>).
+bool IsBraveOriginBundleId(NSString* identifier) {
+  return [identifier isEqualToString:@"com.brave.Browser.origin"] ||
+         [identifier hasPrefix:@"com.brave.Browser.origin."];
+}
+
+// Returns true if |identifier| is a regular (non-Origin) Brave bundle ID
+// (com.brave.Browser or com.brave.Browser.<channel>, excluding Origin).
+bool IsRegularBraveBundleId(NSString* identifier) {
+  return ([identifier isEqualToString:@"com.brave.Browser"] ||
+          [identifier hasPrefix:@"com.brave.Browser."]) &&
+         !IsBraveOriginBundleId(identifier);
+}
+
+// Returns true if |other_identifier| is another channel of the same Brave
+// brand as |my_identifier|. Unlike upstream's IsAnotherChromeChannel() which
+// only compares the first 3 bundle ID components, this correctly distinguishes
+// between regular Brave and Brave Origin which share the "com.brave.Browser"
+// prefix.
+bool IsAnotherBraveChannel(NSString* my_identifier,
+                           NSString* other_identifier) {
+#if BUILDFLAG(IS_BRAVE_ORIGIN_BRANDED)
+  return IsBraveOriginBundleId(my_identifier) &&
+         IsBraveOriginBundleId(other_identifier);
+#else
+  return IsRegularBraveBundleId(my_identifier) &&
+         IsRegularBraveBundleId(other_identifier);
+#endif
+}
+
+}  // namespace
+
+DefaultWebClientState GetDefaultBrowser() {
+  NSString* my_identifier = base::apple::OuterBundle().bundleIdentifier;
+  if (!my_identifier) {
+    return UNKNOWN_DEFAULT;
+  }
+
+  NSString* default_browser = GetBundleIdForDefaultAppForScheme(@"http");
+  if ([default_browser isEqualToString:my_identifier]) {
+    return IS_DEFAULT;
+  }
+
+  if (IsAnotherBraveChannel(my_identifier, default_browser)) {
+    return OTHER_MODE_IS_DEFAULT;
+  }
+  return NOT_DEFAULT;
+}
+
+DefaultWebClientState IsDefaultHandlerForUTType(const std::string& type) {
+  if (type.empty()) {
+    return UNKNOWN_DEFAULT;
+  }
+  NSString* my_identifier = base::apple::OuterBundle().bundleIdentifier;
+  if (!my_identifier) {
+    return UNKNOWN_DEFAULT;
+  }
+  NSString* default_app =
+      GetBundleIdForDefaultAppForUTType(base::SysUTF8ToNSString(type));
+  if (!default_app) {
+    return UNKNOWN_DEFAULT;
+  }
+  if ([default_app isEqualToString:my_identifier]) {
+    return IS_DEFAULT;
+  }
+  if (IsAnotherBraveChannel(my_identifier, default_app)) {
+    return OTHER_MODE_IS_DEFAULT;
+  }
+  return NOT_DEFAULT;
+}
 
 namespace internal {
 
@@ -37,4 +116,4 @@ DefaultWebClientSetPermission GetPlatformSpecificDefaultWebClientSetPermission(
 
 }  // namespace internal
 
-}  // shell_integration
+}  // namespace shell_integration


### PR DESCRIPTION
## Summary

Brave Origin was thinking it was default when Brave was default.

- **macOS**: Override `GetDefaultBrowser()` and `IsDefaultHandlerForUTType()` with Brave-aware brand comparison that correctly distinguishes Origin (`com.brave.Browser.origin.*`) from regular Brave (`com.brave.Browser.*`). The upstream `IsAnotherChromeChannel()` only compares the first 3 bundle ID components, which incorrectly treats Origin as "another channel" of regular Brave.
- **Linux**: Scope `IsAnyBraveBrowserDefaultBrowser()` to search for the current brand's desktop file prefix (`brave-origin` for Origin, `brave-browser` for regular) instead of always searching for `brave-browser`.

## Test plan
- [ ] On macOS with regular Brave as default, open Brave Origin — verify the "set as default browser" infobar appears
- [ ] On macOS with Brave Origin as default, open regular Brave — verify the infobar appears
- [ ] On macOS with Brave Beta as default, open Brave Stable — verify the infobar does NOT appear (same brand, different channel)
- [ ] On Linux, repeat the above scenarios using the appropriate desktop files