### PR TITLE
[Wallet] Fix bridge spinner and swap "()" in transaction activity

### DIFF
--- a/components/brave_wallet_ui/components/desktop/popup-modals/transaction_details_modal/transaction_details_modal.tsx
+++ b/components/brave_wallet_ui/components/desktop/popup-modals/transaction_details_modal/transaction_details_modal.tsx
@@ -72,6 +72,10 @@ import {
 } from '../../../../utils/account-utils'
 import { makeNetworkAsset } from '../../../../options/asset-options'
 import { openTab } from '../../../../utils/routes-utils'
+import {
+  errorTxTypes,
+  getGate3EffectiveStatus,
+} from '../../../../utils/gate3-status-utils'
 
 // Components
 import { PopupModal } from '../../popup-modals/index'
@@ -162,48 +166,6 @@ const successTxTypes = [
   BraveWallet.TransactionStatus.Confirmed,
   BraveWallet.TransactionStatus.Signed,
 ]
-
-const errorTxTypes = [
-  BraveWallet.TransactionStatus.Error,
-  BraveWallet.TransactionStatus.Dropped,
-  BraveWallet.TransactionStatus.Rejected,
-]
-
-function getGate3EffectiveStatus(
-  swapStatusCode: BraveWallet.Gate3SwapStatusCode,
-): { status: BraveWallet.TransactionStatus; label: string } | undefined {
-  switch (swapStatusCode) {
-    case BraveWallet.Gate3SwapStatusCode.kPending:
-      return {
-        status: BraveWallet.TransactionStatus.Submitted,
-        label: getLocale('braveWalletSwapPending'),
-      }
-    case BraveWallet.Gate3SwapStatusCode.kProcessing:
-      return {
-        status: BraveWallet.TransactionStatus.Submitted,
-        label: getLocale('braveWalletSwapProcessing'),
-      }
-    case BraveWallet.Gate3SwapStatusCode.kSuccess:
-      return {
-        status: BraveWallet.TransactionStatus.Confirmed,
-        label: getTransactionStatusString(
-          BraveWallet.TransactionStatus.Confirmed,
-        ),
-      }
-    case BraveWallet.Gate3SwapStatusCode.kFailed:
-      return {
-        status: BraveWallet.TransactionStatus.Error,
-        label: getTransactionStatusString(BraveWallet.TransactionStatus.Error),
-      }
-    case BraveWallet.Gate3SwapStatusCode.kRefunded:
-      return {
-        status: BraveWallet.TransactionStatus.Error,
-        label: getLocale('braveWalletSwapRefunded'),
-      }
-    default:
-      return undefined
-  }
-}
 
 interface Props {
   onClose: () => void
@@ -583,12 +545,14 @@ export const TransactionDetailsModal = ({ onClose, transaction }: Props) => {
                               >
                                 {formattedDestinationAmount}
                               </SwapAmountText>
-                              <SwapFiatValueText
-                                textSize='14px'
-                                textAlign='left'
-                              >
-                                {`(${formattedBuyFiatValue})`}
-                              </SwapFiatValueText>
+                              {formattedBuyFiatValue && (
+                                <SwapFiatValueText
+                                  textSize='14px'
+                                  textAlign='left'
+                                >
+                                  {`(${formattedBuyFiatValue})`}
+                                </SwapFiatValueText>
+                              )}
                             </RowWrapped>
                           </Row>
                         )}

--- a/components/brave_wallet_ui/components/desktop/portfolio_transaction_item/portfolio_transaction_item.tsx
+++ b/components/brave_wallet_ui/components/desktop/portfolio_transaction_item/portfolio_transaction_item.tsx
@@ -342,9 +342,8 @@ export const PortfolioTransactionItem = React.forwardRef<HTMLDivElement, Props>(
       : ''
     const isSolanaSwap = isSwap && isSolanaTx
     const showAmounts = !txToken?.isNft && !isSolanaSwap
-    const showTransactionStatus = !noneTxStatusDisplayTypes.includes(
-      effectiveStatus,
-    )
+    const showTransactionStatus =
+      !noneTxStatusDisplayTypes.includes(effectiveStatus)
     const nativeAssetWasSent = sendToken && isNativeAsset(sendToken)
     const showNetworkIcon = txNetwork && (!nativeAssetWasSent || isSwapOrBridge)
 

--- a/components/brave_wallet_ui/components/desktop/portfolio_transaction_item/portfolio_transaction_item.tsx
+++ b/components/brave_wallet_ui/components/desktop/portfolio_transaction_item/portfolio_transaction_item.tsx
@@ -59,6 +59,13 @@ import {
   useGetCombinedTokensListQuery,
 } from '../../../common/slices/api.slice.extra'
 import { useSwapTransactionParser } from '../../../common/hooks/use-swap-tx-parser'
+import {
+  useGate3SwapStatus, //
+} from '../../../page/screens/swap/hooks/useGate3SwapStatus'
+import {
+  errorTxTypes,
+  getGate3EffectiveStatus,
+} from '../../../utils/gate3-status-utils'
 
 // Components
 import { NftIcon } from '../../shared/nft-icon/nft-icon'
@@ -200,6 +207,25 @@ export const PortfolioTransactionItem = React.forwardRef<HTMLDivElement, Props>(
     const { sourceToken, destinationToken, sourceAmount, destinationAmount } =
       useSwapTransactionParser(transaction)
 
+    // Gate3 swap status awareness
+    const isGate3Swap =
+      transaction.swapInfo && transaction.swapInfo.routeId !== ''
+    const { status: swapStatus } = useGate3SwapStatus(
+      isGate3Swap ? transaction : null,
+    )
+
+    const effectiveStatus = React.useMemo(() => {
+      if (
+        isGate3Swap
+        && swapStatus
+        && !errorTxTypes.includes(transaction.txStatus)
+      ) {
+        const mapped = getGate3EffectiveStatus(swapStatus.status)
+        return mapped?.status ?? transaction.txStatus
+      }
+      return transaction.txStatus
+    }, [isGate3Swap, swapStatus, transaction.txStatus])
+
     const [normalizedTransferredValue, transferredValueWei] =
       React.useMemo(() => {
         const { normalized, wei } = getTransactionTransferredValue({
@@ -317,7 +343,7 @@ export const PortfolioTransactionItem = React.forwardRef<HTMLDivElement, Props>(
     const isSolanaSwap = isSwap && isSolanaTx
     const showAmounts = !txToken?.isNft && !isSolanaSwap
     const showTransactionStatus = !noneTxStatusDisplayTypes.includes(
-      transaction.txStatus,
+      effectiveStatus,
     )
     const nativeAssetWasSent = sendToken && isNativeAsset(sendToken)
     const showNetworkIcon = txNetwork && (!nativeAssetWasSent || isSwapOrBridge)
@@ -412,11 +438,11 @@ export const PortfolioTransactionItem = React.forwardRef<HTMLDivElement, Props>(
                   </>
                 )}
                 {showTransactionStatus && (
-                  <StatusBubble status={transaction.txStatus}>
+                  <StatusBubble status={effectiveStatus}>
                     {[
                       BraveWallet.TransactionStatus.Submitted,
                       BraveWallet.TransactionStatus.Unapproved,
-                    ].includes(transaction.txStatus) ? (
+                    ].includes(effectiveStatus) ? (
                       <LoadingIcon />
                     ) : (
                       <StatusIcon name='loading-spinner' />

--- a/components/brave_wallet_ui/utils/gate3-status-utils.ts
+++ b/components/brave_wallet_ui/utils/gate3-status-utils.ts
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { BraveWallet } from '../constants/types'
+
+// Utils
+import { getLocale } from '../../common/locale'
+import { getTransactionStatusString } from './tx-utils'
+
+export const errorTxTypes = [
+  BraveWallet.TransactionStatus.Error,
+  BraveWallet.TransactionStatus.Dropped,
+  BraveWallet.TransactionStatus.Rejected,
+]
+
+export function getGate3EffectiveStatus(
+  swapStatusCode: BraveWallet.Gate3SwapStatusCode,
+): { status: BraveWallet.TransactionStatus; label: string } | undefined {
+  switch (swapStatusCode) {
+    case BraveWallet.Gate3SwapStatusCode.kPending:
+      return {
+        status: BraveWallet.TransactionStatus.Submitted,
+        label: getLocale('braveWalletSwapPending'),
+      }
+    case BraveWallet.Gate3SwapStatusCode.kProcessing:
+      return {
+        status: BraveWallet.TransactionStatus.Submitted,
+        label: getLocale('braveWalletSwapProcessing'),
+      }
+    case BraveWallet.Gate3SwapStatusCode.kSuccess:
+      return {
+        status: BraveWallet.TransactionStatus.Confirmed,
+        label: getTransactionStatusString(
+          BraveWallet.TransactionStatus.Confirmed,
+        ),
+      }
+    case BraveWallet.Gate3SwapStatusCode.kFailed:
+      return {
+        status: BraveWallet.TransactionStatus.Error,
+        label: getTransactionStatusString(BraveWallet.TransactionStatus.Error),
+      }
+    case BraveWallet.Gate3SwapStatusCode.kRefunded:
+      return {
+        status: BraveWallet.TransactionStatus.Error,
+        label: getLocale('braveWalletSwapRefunded'),
+      }
+    default:
+      return undefined
+  }
+}


### PR DESCRIPTION
Use gate3 swap status in the activity list so confirmed bridge transactions no longer show a perpetual loading spinner. Extract `getGate3EffectiveStatus` into a shared utility for reuse. Guard the swap fiat value parentheses so empty `destinationAmount` doesn't render literal `"()"`.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/53750
Resolves https://github.com/brave/brave-browser/issues/53751

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
