### PR TITLE
[Android] Fix crash in search widget when native library not loaded (uplift to 1.89.x)

### DIFF
--- a/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/suggestions/BraveDropdownItemViewInfoListBuilder.java
+++ b/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/suggestions/BraveDropdownItemViewInfoListBuilder.java
@@ -191,10 +191,10 @@ class BraveDropdownItemViewInfoListBuilder extends DropdownItemViewInfoListBuild
 
     private boolean isBraveLeoEnabled() {
         Tab tab = mActivityTabSupplier.get();
-        if (mLeoAutocompleteDelegate != null
-                && mLeoAutocompleteDelegate.isLeoEnabled()
-                && tab != null
+        if (tab != null
                 && !tab.isIncognito()
+                && mLeoAutocompleteDelegate != null
+                && mLeoAutocompleteDelegate.isLeoEnabled()
                 && ChromeSharedPreferences.getInstance()
                         .readBoolean(BravePreferenceKeys.BRAVE_LEO_AUTOCOMPLETE, true)) {
             return true;
@@ -205,11 +205,11 @@ class BraveDropdownItemViewInfoListBuilder extends DropdownItemViewInfoListBuild
 
     private boolean isBraveSearchPromoBanner() {
         Tab activeTab = mActivityTabSupplier.get();
-        if (ChromeFeatureList.isEnabled(BraveFeatureList.BRAVE_SEARCH_OMNIBOX_BANNER)
+        if (activeTab != null
+                && !activeTab.isIncognito()
+                && ChromeFeatureList.isEnabled(BraveFeatureList.BRAVE_SEARCH_OMNIBOX_BANNER)
                 && mUrlBarEditingTextProvider != null
                 && mUrlBarEditingTextProvider.getTextWithoutAutocomplete().length() > 0
-                && activeTab != null
-                && !activeTab.isIncognito()
                 && sBraveSearchEngineDefaultRegions.contains(Locale.getDefault().getCountry())
                 && !BraveSearchEngineAdapter.getDSEShortName(
                                 Profile.fromWebContents(activeTab.getWebContents()), false, null)


### PR DESCRIPTION
Uplift of #35458
Resolves https://github.com/brave/brave-browser/issues/54444

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.