### PR TITLE
[macOS] Re-enable vertical tabs toggle when fullscreen has no immersive conflict

### DIFF
--- a/browser/ui/brave_browser_command_controller.cc
+++ b/browser/ui/brave_browser_command_controller.cc
@@ -96,6 +96,11 @@
 #include "brave/components/brave_wallet/browser/brave_wallet_utils.h"
 #endif
 
+#if BUILDFLAG(IS_MAC)
+#include "brave/browser/ui/views/frame/brave_browser_view.h"
+#include "chrome/browser/ui/views/frame/browser_view.h"
+#endif
+
 namespace {
 
 bool IsBraveCommands(int id) {
@@ -365,14 +370,21 @@ void BraveBrowserCommandController::InitBraveCommandState() {
 void BraveBrowserCommandController::UpdateCommandsForFullscreenMode() {
   BrowserCommandController::UpdateCommandsForFullscreenMode();
 
-// On macOS, we block vertical tab mode toggling in fullscreen.
-// Immersive fullscreen feeature is enabled by default but
-// it's not compatible with vertical tab. See the comments in
-// BraveBrowserView::UsesImmersiveFullscreenMode() for more datail. Otherwise,
-// crash happens when turn on vertical tab while fullscreen.
+// On macOS, block vertical tab toggling only when immersive fullscreen is
+// active. Immersive fullscreen and vertical tabs both manage the tab strip
+// through separate widgets, which conflict. However, when vertical tabs are
+// already active (or the window started with vertical tabs), immersive mode
+// is disabled and there is no conflict, so toggling should remain available.
 #if BUILDFLAG(IS_MAC)
-  UpdateCommandEnabled(IDC_TOGGLE_VERTICAL_TABS,
-                       window() && !window()->IsFullscreen());
+  if (window() && window()->IsFullscreen()) {
+    auto* browser_view = static_cast<BraveBrowserView*>(
+        BrowserView::GetBrowserViewForBrowser(&*browser_));
+    const bool immersive_active =
+        browser_view && browser_view->UsesImmersiveFullscreenMode();
+    UpdateCommandEnabled(IDC_TOGGLE_VERTICAL_TABS, !immersive_active);
+  } else {
+    UpdateCommandEnabled(IDC_TOGGLE_VERTICAL_TABS, true);
+  }
 #endif
 }
 

--- a/browser/ui/brave_browser_command_controller_browsertest.cc
+++ b/browser/ui/brave_browser_command_controller_browsertest.cc
@@ -550,15 +550,17 @@ IN_PROC_BROWSER_TEST_F(BraveBrowserCommandControllerTest,
 }
 
 #if BUILDFLAG(IS_MAC)
-// On macOS, we block vertical tab mode toggling in fullscreen.
-// Immersive fullscreen feeature is enabled by default but
-// it's not compatible with vertical tab now.
+// On macOS, vertical tab toggling is blocked only when immersive fullscreen is
+// active. With horizontal tabs (default), entering fullscreen activates
+// immersive mode, so the toggle should be disabled. With vertical tabs active,
+// immersive mode is not used, so the toggle should remain enabled.
 IN_PROC_BROWSER_TEST_F(BraveBrowserCommandControllerTest,
                        VerticalTabToggleEnabledState) {
   EXPECT_FALSE(browser()->window()->IsFullscreen());
   EXPECT_TRUE(tabs::utils::IsVerticalTabToggleEnabled(browser()));
 
-  // Enter browser fullscreen.
+  // With horizontal tabs (default), fullscreen activates immersive mode,
+  // so the toggle should be disabled.
   chrome::ToggleFullscreenMode(browser());
   EXPECT_TRUE(browser()->window()->IsFullscreen());
   browser()->command_controller()->FullscreenStateChanged();
@@ -568,6 +570,28 @@ IN_PROC_BROWSER_TEST_F(BraveBrowserCommandControllerTest,
   chrome::ToggleFullscreenMode(browser());
   EXPECT_FALSE(browser()->window()->IsFullscreen());
   browser()->command_controller()->FullscreenStateChanged();
+  EXPECT_TRUE(tabs::utils::IsVerticalTabToggleEnabled(browser()));
+}
+
+IN_PROC_BROWSER_TEST_F(BraveBrowserCommandControllerTest,
+                       VerticalTabToggleEnabledInFullscreenWithVerticalTabs) {
+  auto* command_controller = browser()->command_controller();
+
+  // Enable vertical tabs.
+  command_controller->ExecuteCommand(IDC_TOGGLE_VERTICAL_TABS);
+  ASSERT_TRUE(tabs::utils::ShouldShowBraveVerticalTabs(browser()));
+
+  // Enter fullscreen. With vertical tabs active, immersive mode is not used,
+  // so the toggle should remain enabled.
+  chrome::ToggleFullscreenMode(browser());
+  EXPECT_TRUE(browser()->window()->IsFullscreen());
+  command_controller->FullscreenStateChanged();
+  EXPECT_TRUE(tabs::utils::IsVerticalTabToggleEnabled(browser()));
+
+  // Exit fullscreen -- toggle should still be enabled.
+  chrome::ToggleFullscreenMode(browser());
+  EXPECT_FALSE(browser()->window()->IsFullscreen());
+  command_controller->FullscreenStateChanged();
   EXPECT_TRUE(tabs::utils::IsVerticalTabToggleEnabled(browser()));
 }
 #endif


### PR DESCRIPTION
Resolves brave/brave-browser#54320

## Summary

PR #34663 disabled `IDC_TOGGLE_VERTICAL_TABS` for **all** fullscreen modes on macOS to prevent a crash caused by immersive fullscreen and vertical tabs sharing the same tab strip widget. However, the actual conflict only exists when immersive fullscreen is active (horizontal tabs, window started with horizontal tabs). When vertical tabs are already active, `BraveBrowserView::UsesImmersiveFullscreenMode()` returns `false` and there is no conflict.

This PR narrows the disable rule: instead of checking `IsFullscreen()`, it checks `UsesImmersiveFullscreenMode()`. This keeps the toggle disabled when there is a real immersive conflict, but re-enables it when vertical tabs are active and immersive mode is not in use.

## Changes

- **`browser/ui/brave_browser_command_controller.cc`**: `UpdateCommandsForFullscreenMode()` now queries `UsesImmersiveFullscreenMode()` instead of `IsFullscreen()` to decide whether to disable the vertical tabs toggle.
- **`browser/ui/brave_browser_command_controller_browsertest.cc`**: Updated existing test comments and added `VerticalTabToggleEnabledInFullscreenWithVerticalTabs` to verify the toggle remains enabled when vertical tabs are active in fullscreen.

## Test Plan

`TEST=BraveBrowserCommandControllerTest.VerticalTabToggleEnabledState`
`TEST=BraveBrowserCommandControllerTest.VerticalTabToggleEnabledInFullscreenWithVerticalTabs`

### Manual test (macOS):

1. Launch Brave with horizontal tabs (default)
2. Enter fullscreen (green button) → vertical tabs toggle in settings and context menu should be **disabled** (immersive active)
3. Exit fullscreen → toggle should be **enabled**
4. Enable vertical tabs
5. Enter fullscreen → toggle should remain **enabled** (no immersive conflict)
6. Exit fullscreen → toggle should**enabled**
7. Relaunch with vertical tabs already on → enter fullscreen → toggle should remain **enabled**