### PR TITLE
[iOS] Only restore Origin when using restoring in Origin paywall

### DIFF
--- a/ios/brave-ios/Sources/BraveStore/Subscription/SDK/BraveStoreSDK.swift
+++ b/ios/brave-ios/Sources/BraveStore/Subscription/SDK/BraveStoreSDK.swift
@@ -302,7 +302,12 @@ public class BraveStoreSDK: AppStoreSDK {
   public func restorePurchase(_ product: BraveStoreProduct) async -> Bool {
     if await currentTransaction(for: product) != nil {
       try? await AppStoreReceipt.sync()
-      return true
+      do {
+        try await self.updateSkusPurchaseState(for: product)
+        return true
+      } catch {
+        return false
+      }
     }
 
     return false

--- a/ios/brave-ios/Sources/Origin/OriginPaywallViewModel.swift
+++ b/ios/brave-ios/Sources/Origin/OriginPaywallViewModel.swift
@@ -51,7 +51,7 @@ public class OriginPaywallViewModel {
         return false
       }
       group.addTask {
-        return await self.store.restorePurchases()
+        return await self.store.restorePurchase(.originPurchase)
       }
       let result = await group.next() ?? false
       group.cancelAll()


### PR DESCRIPTION
This avoids attempts to restore other Leo & VPN services when tapping the restore button on the Origin paywall
