### PR TITLE
Fix crash when toolbar overflow menu is clicked

### DIFF
--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -1545,6 +1545,7 @@ source_set("browser_tests") {
     defines = [ "HAS_OUT_OF_PROC_TEST_RUNNER" ]
 
     sources = [
+      "brave_browser_actions_browsertest.cc",
       "brave_browser_browsertest.cc",
       "views/frame/brave_system_menu_model_builder_browsertest.cc",
       "window_closing_confirm_browsertest.cc",
@@ -1557,6 +1558,7 @@ source_set("browser_tests") {
       "//chrome/browser/devtools:test_support",
       "//chrome/browser/profiles:profile",
       "//chrome/browser/ui",
+      "//chrome/browser/ui:tab_search_feature",
       "//chrome/browser/ui/browser_window",
       "//chrome/browser/ui/startup",
       "//chrome/test:test_support",
@@ -1566,6 +1568,7 @@ source_set("browser_tests") {
       "//components/optimization_guide/optimization_guide_internals/webui:url_constants",
       "//components/prefs",
       "//content/test:test_support",
+      "//ui/actions",
     ]
 
     if (enable_playlist_webui) {

--- a/browser/ui/brave_browser_actions.cc
+++ b/browser/ui/brave_browser_actions.cc
@@ -18,6 +18,7 @@
 #include "chrome/browser/ui/side_panel/side_panel_action_callback.h"
 #include "chrome/browser/ui/side_panel/side_panel_entry_id.h"
 #include "chrome/browser/ui/side_panel/side_panel_entry_key.h"
+#include "chrome/browser/ui/tab_search_feature.h"
 #include "components/grit/brave_components_strings.h"
 #include "ui/actions/actions.h"
 #include "ui/base/l10n/l10n_util.h"
@@ -59,6 +60,25 @@ BraveBrowserActions::~BraveBrowserActions() = default;
 
 void BraveBrowserActions::InitializeBrowserActions() {
   BrowserActions::InitializeBrowserActions();
+
+  // browser_actions.cc initializes kActionTabSearch as kNotPinnable.
+  // In Brave, HasTabSearchToolbarButton() is always true and the button is
+  // shown via the pinned-actions model, so
+  // ToolbarController::GetDefaultResponsiveElements() must see it as kPinnable
+  // when the toolbar is initialized — otherwise kActionTabSearch is missing
+  // from responsive_elements_ and the overflow menu crashes when clicked if
+  // search buton is the only item in overflow menu.
+  if (features::HasTabSearchToolbarButton()) {
+    auto* tab_search_action = actions::ActionManager::Get().FindAction(
+        kActionTabSearch, root_action_item_.get());
+    if (tab_search_action) {
+      tab_search_action->SetProperty(
+          actions::kActionItemPinnableKey,
+          static_cast<std::underlying_type_t<actions::ActionPinnableState>>(
+              actions::ActionPinnableState::kPinnable));
+    }
+  }
+
   BrowserWindowInterface* const bwi = base::to_address(bwi_);
 
   if (base::FeatureList::IsEnabled(playlist::features::kPlaylist)) {

--- a/browser/ui/brave_browser_actions_browsertest.cc
+++ b/browser/ui/brave_browser_actions_browsertest.cc
@@ -1,0 +1,32 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "chrome/browser/ui/actions/chrome_action_id.h"
+#include "chrome/browser/ui/tab_search_feature.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "content/public/test/browser_test.h"
+#include "ui/actions/actions.h"
+
+using BraveBrowserActionsBrowserTest = InProcessBrowserTest;
+
+// Regression test for https://github.com/brave/brave-browser/issues/54449
+//
+// kActionTabSearch must be kPinnable immediately after InitializeBrowserActions
+// so that ToolbarController::GetDefaultResponsiveElements() includes it in
+// responsive_elements_. Without this, the overflow menu is empty when
+// kActionTabSearch overflows, causing a crash on click.
+IN_PROC_BROWSER_TEST_F(BraveBrowserActionsBrowserTest,
+                       TabSearchActionIsPinnableAfterInit) {
+  ASSERT_TRUE(features::HasTabSearchToolbarButton())
+      << "Tab search toolbar button not enabled";
+
+  auto& action_manager = actions::ActionManager::GetForTesting();
+  auto* tab_search_action = action_manager.FindAction(kActionTabSearch);
+  ASSERT_NE(tab_search_action, nullptr);
+
+  const auto pinnable_state = static_cast<actions::ActionPinnableState>(
+      tab_search_action->GetProperty(actions::kActionItemPinnableKey));
+  EXPECT_EQ(pinnable_state, actions::ActionPinnableState::kPinnable);
+}

--- a/browser/ui/brave_browser_actions_browsertest.cc
+++ b/browser/ui/brave_browser_actions_browsertest.cc
@@ -24,9 +24,13 @@ IN_PROC_BROWSER_TEST_F(BraveBrowserActionsBrowserTest,
 
   auto& action_manager = actions::ActionManager::GetForTesting();
   auto* tab_search_action = action_manager.FindAction(kActionTabSearch);
-  ASSERT_NE(tab_search_action, nullptr);
+  ASSERT_NE(tab_search_action, nullptr)
+      << "kActionTabSearch not found in ActionManager";
 
-  const auto pinnable_state = static_cast<actions::ActionPinnableState>(
-      tab_search_action->GetProperty(actions::kActionItemPinnableKey));
-  EXPECT_EQ(pinnable_state, actions::ActionPinnableState::kPinnable);
+  const actions::ActionPinnableState pinnable_state =
+      static_cast<actions::ActionPinnableState>(
+          tab_search_action->GetProperty(actions::kActionItemPinnableKey));
+  EXPECT_EQ(pinnable_state, actions::ActionPinnableState::kPinnable)
+      << "kActionTabSearch must be kPinnable so ToolbarController includes it "
+         "in responsive_elements_";
 }


### PR DESCRIPTION
This crash happens when tab search button the only pinned button.
I can repro this crash with Chrome(147.0.7727.56) also when search button is pinned. (edited) 
In chrome, tab search button position varies per platforms.
If tab search button is at tab strip(not toolbar), this crash doesn't happen.

In Brave, HasTabSearchToolbarButton() is always true, so PinnedToolbarActionsModel
migration adds kActionTabSearch to pinned_buttons_.
However, browser_actions.cc initializes kActionTabSearch as kNotPinnable, causing
ToolbarController::GetDefaultResponsiveElements() to exclude it from responsive_elements_
when the toolbar is first built.

When the toolbar is narrow enough that the overflow button appears
(because kActionTabSearch is in pinned_buttons_), clicking the overflow button crashes
because CreateOverflowMenuModel() iterates responsive_elements_ — where kActionTabSearch is absent — producing an empty menu model with no submenu.

Fix by overriding kActionTabSearch to kPinnable in BraveBrowserActions::InitializeBrowserActions(),
which runs before toolbar_->Init(). This ensures GetDefaultResponsiveElements() includes
kActionTabSearch in responsive_elements_ so the overflow menu populates correctly.

Resolves https://github.com/brave/brave-browser/issues/54449

Manual test:
1. Launch Brave
2. Make search tab button is the only pinned button in toolbar
3. Resize browser window till overflow button is visible
4. Click overflow button

Chromium changes:
https://chromium.googlesource.com/chromium/src/+/e80c78d2936c935b0f1c951c0ccf341b4fd3dbf8

commit e80c78d2936c935b0f1c951c0ccf341b4fd3dbf8
Author: Eshwar Stalin <estalin@chromium.org>
Date:   Wed Feb 18 22:12:10 2026 -0800

    [Vertical Tabs] Fix an issue where tab search toolbar button is visible incorrectly

    This was a regression that was introduced with a previous change. This
    was caused because the initial state at startup was incorrect. To fix
    this updating the default pinning state to not pinnable and instead
    updating that through the tab search toolbar controller. This ensures
    the correct behavior.

    Fixed: 485672653
    Change-Id: I317e3f540f4db82cb765bd15621b33c4b964badb
    Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7591063
    Commit-Queue: Eshwar Stalin <estalin@chromium.org>
    Reviewed-by: Tom Lukaszewicz <tluk@chromium.org>
    Cr-Commit-Position: refs/heads/main@{#1586899}

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
