### PR TITLE
Fix Linux free tier proceed button on Origin settings page

### DIFF
--- a/browser/resources/settings/brave_origin_page/brave_origin_onboarding.html
+++ b/browser/resources/settings/brave_origin_page/brave_origin_onboarding.html
@@ -13,11 +13,15 @@
     padding-bottom: var(--leo-spacing-m);
   }
 
+  #learnMoreLink,
+  #proceedFreeButton {
+    margin-inline-start: var(--leo-spacing-xl);
+  }
+
   #learnMoreLink {
     color: var(--cr-link-color);
     cursor: pointer;
     font: var(--cr-button-font);
-    margin-inline-start: var(--leo-spacing-xl);
   }
 </style>
 
@@ -35,6 +39,11 @@
     <cr-button class="action-button" on-click="onBuyNowClick_">
       $i18n{braveOriginOnboardingBuyNow}
     </cr-button>
+    <if expr="is_linux">
+      <cr-button id="proceedFreeButton" on-click="onProceedFreeClick_">
+        $i18n{braveOriginOnboardingProceedFree}
+      </cr-button>
+    </if>
     <a id="learnMoreLink" on-click="onLearnMoreClick_">
       $i18n{braveOriginOnboardingLearnMore}
     </a>

--- a/browser/resources/settings/brave_origin_page/brave_origin_onboarding.ts
+++ b/browser/resources/settings/brave_origin_page/brave_origin_onboarding.ts
@@ -12,6 +12,7 @@ import {PolymerElement} from 'chrome://resources/polymer/v3_0/polymer/polymer_bu
 
 import {BaseMixin} from '../base_mixin.js';
 import {getTemplate} from './brave_origin_onboarding.html.js';
+import * as BraveOriginMojom from '../brave_origin_settings.mojom-webui.js';
 
 const SettingsBraveOriginOnboardingElementBase =
     BaseMixin(I18nMixin(PolymerElement)) as {
@@ -44,6 +45,13 @@ export class SettingsBraveOriginOnboardingElement extends
         'https://support.brave.app/hc/en-us/articles/38561489788173',
         '_blank',
         'noopener');
+  }
+
+  private async onProceedFreeClick_() {
+    const handler =
+        BraveOriginMojom.BraveOriginSettingsHandler.getRemote();
+    await handler.proceedFree();
+    window.location.assign('chrome://settings/origin');
   }
 }
 

--- a/browser/resources/settings/brave_origin_page/brave_origin_page.ts
+++ b/browser/resources/settings/brave_origin_page/brave_origin_page.ts
@@ -94,6 +94,10 @@ export class SettingsBraveOriginPageElement
     // Check purchase state
     this.checkPurchaseState_()
 
+    // Handle proceed-free from onboarding component
+    this.addEventListener('proceed-free-clicked',
+        () => this.onProceedFreeClicked_())
+
     // Re-check when the tab becomes visible (user may return from
     // account page after purchasing)
     this.boundOnVisibilityChange_ = this.onVisibilityChange_.bind(this)
@@ -125,6 +129,11 @@ export class SettingsBraveOriginPageElement
     const {isPurchased} =
         await this.braveOriginHandler_.refreshPurchaseState()
     this.isPurchased_ = isPurchased
+  }
+
+  private async onProceedFreeClicked_() {
+    await this.braveOriginHandler_.proceedFree()
+    this.isPurchased_ = true
   }
 
   private async resetToDefaults_() {

--- a/browser/ui/webui/settings/brave_settings_localized_strings_provider.cc
+++ b/browser/ui/webui/settings/brave_settings_localized_strings_provider.cc
@@ -35,6 +35,7 @@
 #include "brave/components/web_discovery/buildflags/buildflags.h"
 #include "brave/grit/brave_generated_resources.h"
 #include "brave/grit/brave_generated_resources_webui_strings.h"
+#include "build/build_config.h"
 #include "chrome/browser/browser_process.h"
 #include "chrome/browser/media/router/media_router_feature.h"
 #include "chrome/browser/profiles/profile.h"
@@ -223,6 +224,10 @@ void BraveAddCommonStrings(content::WebUIDataSource* html_source,
        IDS_SETTINGS_BRAVE_ORIGIN_ONBOARDING_BUY_NOW},
       {"braveOriginOnboardingLearnMore",
        IDS_SETTINGS_BRAVE_ORIGIN_ONBOARDING_LEARN_MORE},
+#if BUILDFLAG(IS_LINUX)
+      {"braveOriginOnboardingProceedFree",
+       IDS_BRAVE_ORIGIN_STARTUP_LINUX_FREE_BUTTON},
+#endif
       {"siteSettingsShields", IDS_SETTINGS_SITE_SETTINGS_SHIELDS},
       {"siteSettingsShieldsStatus", IDS_SETTINGS_SITE_SETTINGS_SHIELDS_STATUS},
       {"siteSettingsShieldsUp", IDS_SETTINGS_SITE_SETTINGS_SHIELDS_UP},

--- a/components/brave_origin/brave_origin_service.cc
+++ b/components/brave_origin/brave_origin_service.cc
@@ -69,6 +69,14 @@ BraveOriginService::BraveOriginService(
   CHECK(profile_prefs_);
   CHECK(!profile_id_.empty());
 
+#if BUILDFLAG(IS_LINUX)
+  // On Linux, treat free tier acceptance as a valid purchase so policies
+  // are applied immediately at startup without waiting for the SKU check.
+  if (local_state_->GetBoolean(kOriginFreeTierAccepted)) {
+    BraveOriginPolicyManager::GetInstance()->SetPurchased(true);
+  }
+#endif
+
   // Eagerly check purchase state on startup so the cached value is available.
   CheckPurchaseState(base::DoNothing());
 
@@ -241,6 +249,15 @@ void BraveOriginService::OnCredentialSummary(
   const bool was_previously_purchased =
       local_state_ && local_state_->GetBoolean(kOriginPurchaseValidated);
 
+#if BUILDFLAG(IS_LINUX)
+  // On Linux, free tier acceptance overrides the SKU result so that
+  // policies remain active even when there is no purchase credential.
+  if (!purchased && local_state_ &&
+      local_state_->GetBoolean(kOriginFreeTierAccepted)) {
+    purchased = true;
+  }
+#endif
+
   BraveOriginPolicyManager::GetInstance()->SetPurchased(purchased);
 
   // Persist enforcement state so NeedsRestart() can detect first-purchase
@@ -274,5 +291,18 @@ bool BraveOriginService::EnsureSkusConnected() {
   }
   return !!skus_service_;
 }
+
+#if BUILDFLAG(IS_LINUX)
+void BraveOriginService::AcceptFreeTier() {
+  if (local_state_) {
+    local_state_->SetBoolean(kOriginFreeTierAccepted, true);
+  }
+  BraveOriginPolicyManager::GetInstance()->SetPurchased(true);
+}
+
+bool BraveOriginService::IsFreeTierAccepted() const {
+  return local_state_ && local_state_->GetBoolean(kOriginFreeTierAccepted);
+}
+#endif
 
 }  // namespace brave_origin

--- a/components/brave_origin/brave_origin_service.h
+++ b/components/brave_origin/brave_origin_service.h
@@ -17,6 +17,7 @@
 #include "base/values.h"
 #include "brave/components/brave_origin/brave_origin_policy_info.h"
 #include "brave/components/skus/common/skus_sdk.mojom.h"
+#include "build/build_config.h"
 #include "components/keyed_service/core/keyed_service.h"
 #include "components/prefs/pref_change_registrar.h"
 #include "mojo/public/cpp/bindings/remote.h"
@@ -78,6 +79,15 @@ class BraveOriginService : public KeyedService {
   // was created (i.e., since browser startup). This indicates that a restart
   // is needed for the changes to fully take effect.
   bool NeedsRestart() const;
+
+#if BUILDFLAG(IS_LINUX)
+  // Accept the Linux free tier: sets the kOriginFreeTierAccepted pref and
+  // marks the policy manager as purchased so policies take effect.
+  void AcceptFreeTier();
+
+  // Returns true if the user has accepted the Linux free tier.
+  bool IsFreeTierAccepted() const;
+#endif
 
  protected:
   // Local state and profile preferences this state is associated with

--- a/components/brave_origin/brave_origin_service_unittest.cc
+++ b/components/brave_origin/brave_origin_service_unittest.cc
@@ -18,6 +18,7 @@
 #include "brave/components/brave_origin/pref_names.h"
 #include "brave/components/skus/browser/pref_names.h"
 #include "brave/components/skus/browser/test/fake_skus_service.h"
+#include "build/build_config.h"
 #include "components/policy/core/common/mock_policy_service.h"
 #include "components/prefs/pref_registry_simple.h"
 #include "components/prefs/testing_pref_service.h"
@@ -89,6 +90,10 @@ class BraveOriginServiceTest : public testing::Test {
     local_state_.registry()->RegisterBooleanPref(kOriginPoliciesWereEnforced,
                                                  false);
     local_state_.registry()->RegisterDictionaryPref(skus::prefs::kSkusState);
+#if BUILDFLAG(IS_LINUX)
+    local_state_.registry()->RegisterBooleanPref(kOriginFreeTierAccepted,
+                                                 false);
+#endif
 
     // Register test browser preferences in local_state
     // These are needed because BraveOriginService::SetBrowserPolicyValue()
@@ -605,6 +610,10 @@ class BraveOriginServiceWithSkusTest : public testing::Test {
     local_state_.registry()->RegisterBooleanPref(kOriginPoliciesWereEnforced,
                                                  false);
     local_state_.registry()->RegisterDictionaryPref(skus::prefs::kSkusState);
+#if BUILDFLAG(IS_LINUX)
+    local_state_.registry()->RegisterBooleanPref(kOriginFreeTierAccepted,
+                                                 false);
+#endif
 
     local_state_.registry()->RegisterBooleanPref(kTestBrowserPref, false);
     profile_prefs_.registry()->RegisterBooleanPref(kTestProfilePref, true);
@@ -909,6 +918,10 @@ class BraveOriginServiceDisabledTest : public testing::Test {
     local_state_.registry()->RegisterBooleanPref(kOriginPoliciesWereEnforced,
                                                  false);
     local_state_.registry()->RegisterDictionaryPref(skus::prefs::kSkusState);
+#if BUILDFLAG(IS_LINUX)
+    local_state_.registry()->RegisterBooleanPref(kOriginFreeTierAccepted,
+                                                 false);
+#endif
 
     // Register test preferences (needed for pref service not to crash)
     local_state_.registry()->RegisterBooleanPref(kTestBrowserPref, false);

--- a/components/brave_origin/brave_origin_settings_handler_impl.cc
+++ b/components/brave_origin/brave_origin_settings_handler_impl.cc
@@ -10,6 +10,7 @@
 #include "brave/components/brave_origin/brave_origin_service.h"
 #include "brave/components/brave_origin/brave_origin_utils.h"
 #include "brave/components/brave_origin/buildflags/buildflags.h"
+#include "build/build_config.h"
 
 namespace brave_origin {
 
@@ -89,6 +90,15 @@ void BraveOriginSettingsHandlerImpl::SetPolicyValue(
 void BraveOriginSettingsHandlerImpl::GetNeedsRestart(
     GetNeedsRestartCallback callback) {
   std::move(callback).Run(brave_origin_service_->NeedsRestart());
+}
+
+void BraveOriginSettingsHandlerImpl::ProceedFree(ProceedFreeCallback callback) {
+#if BUILDFLAG(IS_LINUX)
+  brave_origin_service_->AcceptFreeTier();
+  std::move(callback).Run(true);
+#else
+  std::move(callback).Run(false);
+#endif
 }
 
 }  // namespace brave_origin

--- a/components/brave_origin/brave_origin_settings_handler_impl.h
+++ b/components/brave_origin/brave_origin_settings_handler_impl.h
@@ -40,6 +40,7 @@ class BraveOriginSettingsHandlerImpl
                       bool value,
                       SetPolicyValueCallback callback) override;
   void GetNeedsRestart(GetNeedsRestartCallback callback) override;
+  void ProceedFree(ProceedFreeCallback callback) override;
 
  private:
   raw_ptr<BraveOriginService> brave_origin_service_;

--- a/components/brave_origin/brave_origin_settings_handler_impl_unittest.cc
+++ b/components/brave_origin/brave_origin_settings_handler_impl_unittest.cc
@@ -21,6 +21,7 @@
 #include "brave/components/brave_origin/features.h"
 #include "brave/components/brave_origin/pref_names.h"
 #include "brave/components/skus/browser/test/fake_skus_service.h"
+#include "build/build_config.h"
 #include "components/policy/core/common/mock_policy_service.h"
 #include "components/prefs/pref_registry_simple.h"
 #include "components/prefs/testing_pref_service.h"

--- a/components/brave_origin/mojom/brave_origin_settings.mojom
+++ b/components/brave_origin/mojom/brave_origin_settings.mojom
@@ -28,6 +28,10 @@ interface BraveOriginSettingsHandler {
   // Check if any Brave Origin policy values have been changed since
   // browser startup, indicating a restart is needed.
   GetNeedsRestart() => (bool needs_restart);
+
+  // Accept the Linux free tier without purchasing. Only functional on
+  // Linux builds; returns false on all other platforms.
+  ProceedFree() => (bool success);
 };
 
 // Interface for interaction between SubscriptionRenderFrameObserver


### PR DESCRIPTION
## Summary
- Fix the Proceed Free button on the Origin settings onboarding page which was non-functional due to the `// <if>` preprocessor guard stripping the click handler method
- The button now calls the mojo handler directly (like the adjacent Buy Now button) and reloads the settings page after accepting the free tier

## Test plan
- [ ] On Linux non-branded build, verify Origin settings page shows onboarding with "Proceed free" button
- [ ] Click "Proceed free" and verify the page reloads showing the full Origin settings with toggles
- [ ] Verify the button does not exist on macOS/Windows builds
- [ ] Verify branded builds are unaffected