### PR TITLE
Enable Brave Origin by default and add chrome://flags entry

### DIFF
--- a/android/javatests/org/chromium/chrome/browser/settings/BraveMainSettingsFragmentTest.java
+++ b/android/javatests/org/chromium/chrome/browser/settings/BraveMainSettingsFragmentTest.java
@@ -193,7 +193,7 @@ public class BraveMainSettingsFragmentTest {
                         // check
                         + "INDEX_DATA_PROVIDER.updateDynamicPreferences"
                         + " to exclude new from indexing.",
-                34,
+                35,
                 nonVpnCount);
     }
 

--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -15,6 +15,7 @@
 #include "brave/components/brave_component_updater/browser/features.h"
 #include "brave/components/brave_education/buildflags.h"
 #include "brave/components/brave_news/common/buildflags/buildflags.h"
+#include "brave/components/brave_origin/features.h"
 #include "brave/components/brave_rewards/core/buildflags/buildflags.h"
 #include "brave/components/brave_rewards/core/features.h"
 #include "brave/components/brave_shields/core/common/features.h"
@@ -1350,6 +1351,13 @@ constexpr flags_ui::FeatureEntry::Choice kVerticalTabCollapseDelayChoices[] = {
   BRAVE_UPDATER_FEATURE_ENTRIES                                                \
   PSST_FEATURE_ENTRIES                                                         \
   BRAVE_FORCE_POPUP_TO_BE_OPENED_IN_NEW_TAB_FEATURE_ENTRY                      \
+  EXPAND_FEATURE_ENTRIES({                                                     \
+      "brave-origin",                                                          \
+      "Enable Brave Origin",                                                   \
+      "Enables Brave Origin features and settings.",                           \
+      kOsDesktop | kOsAndroid,                                                 \
+      FEATURE_VALUE_TYPE(brave_origin::features::kBraveOrigin),                \
+  })                                                                           \
   LAST_BRAVE_FEATURE_ENTRIES_ITEM  // Keep it as the last item.
 namespace flags_ui {
 namespace {

--- a/components/brave_origin/features.cc
+++ b/components/brave_origin/features.cc
@@ -6,15 +6,9 @@
 #include "brave/components/brave_origin/features.h"
 
 #include "base/feature_list.h"
-#include "brave/components/brave_origin/buildflags/buildflags.h"
-#include "build/build_config.h"
 
 namespace brave_origin::features {
 
-#if BUILDFLAG(IS_BRAVE_ORIGIN_BRANDED)
 BASE_FEATURE(kBraveOrigin, base::FEATURE_ENABLED_BY_DEFAULT);
-#else
-BASE_FEATURE(kBraveOrigin, base::FEATURE_DISABLED_BY_DEFAULT);
-#endif
 
 }  // namespace brave_origin::features


### PR DESCRIPTION
## Summary
- Enable the `kBraveOrigin` feature flag by default on all platforms (previously only enabled for branded builds)
- Add a `chrome://flags#brave-origin` entry on desktop and Android so the feature can be toggled for testing or reverted

## Test plan
- [ ] Verify `chrome://flags#brave-origin` is visible and defaults to Enabled on desktop and Android
- [ ] Toggling the flag to Disabled hides the Origin settings page
- [ ] Branded builds are unaffected