### PR TITLE
[Wallet]: Display Origin in Permission Panel

### DIFF
--- a/components/brave_wallet_ui/components/extension/connect-with-site-panel/connect-with-site-header/connect-with-site-header.style.ts
+++ b/components/brave_wallet_ui/components/extension/connect-with-site-panel/connect-with-site-header/connect-with-site-header.style.ts
@@ -83,6 +83,10 @@ export const SiteURL = styled.span`
   margin-bottom: 6px;
 `
 
+export const SiteURLCentered = styled(SiteURL)`
+  text-align: center;
+`
+
 export const FavIcon = styled.img<{ isReadyToConnect: boolean }>`
   width: ${(p) => (p.isReadyToConnect ? 40 : 48)}px;
   height: ${(p) => (p.isReadyToConnect ? 40 : 48)}px;

--- a/components/brave_wallet_ui/components/extension/connect-with-site-panel/connect-with-site-header/connect-with-site-header.tsx
+++ b/components/brave_wallet_ui/components/extension/connect-with-site-panel/connect-with-site-header/connect-with-site-header.tsx
@@ -26,6 +26,7 @@ import {
   TitleWrapper,
   SiteName,
   SiteURL,
+  SiteURLCentered,
   MessageBox,
   InfoIcon,
   BackButton,
@@ -88,33 +89,42 @@ export const ConnectWithSiteHeader = (props: Props) => {
           alignItems='flex-start'
         >
           {isReadyToConnect && (
-            <Row
-              justifyContent='center'
-              marginBottom={18}
+            <Column
+              width='100%'
+              margin='0px 0px 18px 0px'
+              gap='8px'
             >
-              <Tooltip
-                isAddress={true}
-                minWidth={120}
-                maxWidth={120}
-                text={address}
-              >
-                <AccountCircle orb={orb} />
-              </Tooltip>
-              <GradientLine>
-                <LinkIconCircle>
-                  <LinkIcon name='link-normal' />
-                </LinkIconCircle>
-              </GradientLine>
-              <Tooltip text={originInfo.eTldPlusOne}>
-                <FavIcon
-                  src={`chrome://favicon2?size=64&pageUrl=${encodeURIComponent(
-                    originInfo.originSpec,
-                  )}`}
-                  isReadyToConnect={isReadyToConnect}
+              <Row justifyContent='center'>
+                <Tooltip
+                  isAddress={true}
+                  minWidth={120}
+                  maxWidth={120}
+                  text={address}
+                >
+                  <AccountCircle orb={orb} />
+                </Tooltip>
+                <GradientLine>
+                  <LinkIconCircle>
+                    <LinkIcon name='link-normal' />
+                  </LinkIconCircle>
+                </GradientLine>
+                <Tooltip text={originInfo.eTldPlusOne}>
+                  <FavIcon
+                    src={`chrome://favicon2?size=64&pageUrl=${encodeURIComponent(
+                      originInfo.originSpec,
+                    )}`}
+                    isReadyToConnect={isReadyToConnect}
+                  />
+                  {isDAppVerified && <VerifiedIcon />}
+                </Tooltip>
+              </Row>
+              <SiteURLCentered>
+                <CreateSiteOrigin
+                  originSpec={originInfo.originSpec}
+                  eTldPlusOne={originInfo.eTldPlusOne}
                 />
-                {isDAppVerified && <VerifiedIcon />}
-              </Tooltip>
-            </Row>
+              </SiteURLCentered>
+            </Column>
           )}
 
           {!isReadyToConnect && (

--- a/components/brave_wallet_ui/components/extension/connect-with-site-panel/connect-with-site-panel.style.ts
+++ b/components/brave_wallet_ui/components/extension/connect-with-site-panel/connect-with-site-panel.style.ts
@@ -90,7 +90,7 @@ export const WhiteSpace = styled.div`
 `
 
 export const PermissionsWrapper = styled(Column)`
-  top: 160px;
+  top: 180px;
   position: relative;
   z-index: 9;
 `


### PR DESCRIPTION
## Description 

Will now display the `Site Origin` in the `Permission Duration` step of the `Connect With Site` panel

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/54482>

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

## Test Plan:
1. Navigate to a `DApp` and start a connection with you wallet
2. On the second step (Permission Duration) the site `Origin` should be visible.

<img width="410" height="620" alt="Screenshot 83" src="https://github.com/user-attachments/assets/cabc0b39-cf9c-49e1-9250-298dcd594a9b" />
