### PR TITLE
[time_period_storage][serp_metrics] Fix daily bucket rollover after DST start (uplift to 1.89.x)

### DIFF
--- a/components/serp_metrics/BUILD.gn
+++ b/components/serp_metrics/BUILD.gn
@@ -50,6 +50,16 @@ source_set("unit_tests") {
     "serp_metrics_unittest.cc",
   ]
 
+  # `ScopedLibcTimezoneOverride` is a no-op on Windows for IANA timezone
+  # identifiers, so timezone-parameterized tests are excluded on Windows to
+  # avoid spurious failures caused by a non-overridable libc timezone.
+  if (!is_win) {
+    sources += [
+      "serp_metrics_dst_end_unittest.cc",
+      "serp_metrics_dst_start_unittest.cc",
+    ]
+  }
+
   deps = [
     ":features",
     ":serp_metrics",
@@ -57,6 +67,7 @@ source_set("unit_tests") {
     "//base/test:test_support",
     "//brave/components/constants",
     "//brave/components/search_engines",
+    "//brave/components/time_period_storage:test_support",
     "//components/prefs",
     "//components/prefs:test_support",
     "//components/regional_capabilities",

--- a/components/serp_metrics/serp_metrics_dst_end_unittest.cc
+++ b/components/serp_metrics/serp_metrics_dst_end_unittest.cc
@@ -1,0 +1,152 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include <memory>
+#include <string>
+
+#include "base/check_op.h"
+#include "base/strings/string_util.h"
+#include "base/test/scoped_feature_list.h"
+#include "base/test/task_environment.h"
+#include "base/time/time.h"
+#include "brave/components/constants/pref_names.h"
+#include "brave/components/serp_metrics/serp_metric_type.h"
+#include "brave/components/serp_metrics/serp_metrics.h"
+#include "brave/components/serp_metrics/serp_metrics_feature.h"
+#include "brave/components/time_period_storage/scoped_timezone_for_testing.h"
+#include "brave/components/time_period_storage/time_period_storage.h"
+#include "brave/components/time_period_storage/time_period_store.h"
+#include "components/prefs/pref_registry_simple.h"
+#include "components/prefs/testing_pref_service.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace serp_metrics {
+
+namespace {
+
+struct DSTEndTimezoneParamInfo {
+  std::string_view timezone;
+  const char* standard_time_start = nullptr;
+};
+
+const auto kDSTEndTimezones = ::testing::Values(
+    // America/New_York: EDT -> EST, 1 November 2026 at 06:00 UTC (-4h -> -5h).
+    DSTEndTimezoneParamInfo{"America/New_York", "1 Nov 2026 14:00:00"},
+    // America/St_Johns: NDT -> NST, 1 November 2026 at 05:30 UTC (-2:30h ->
+    // -3:30h). Half-hour base UTC offset.
+    DSTEndTimezoneParamInfo{"America/St_Johns", "1 Nov 2026 14:00:00"},
+    // Antarctica/Troll: UTC+2 -> UTC+0, 25 October 2026 at 01:00 UTC. Only
+    // active timezone with a 2-hour DST shift.
+    DSTEndTimezoneParamInfo{"Antarctica/Troll", "25 Oct 2026 11:00:00"},
+    // Europe/Paris: CEST -> CET, 25 October 2026 at 01:00 UTC (+2h -> +1h).
+    DSTEndTimezoneParamInfo{"Europe/Paris", "25 Oct 2026 11:00:00"},
+    // Australia/Lord_Howe: LHDT -> LHST, 3 April 2027 at 15:00 UTC (+11h ->
+    // +10:30h). Only active timezone with a 30-minute DST shift.
+    DSTEndTimezoneParamInfo{"Australia/Lord_Howe", "4 Apr 2027 11:00:00"},
+    // Pacific/Auckland: NZDT -> NZST, 3 April 2027 at 14:00 UTC (+13h -> +12h).
+    // Far-east, southern hemisphere DST end in April.
+    DSTEndTimezoneParamInfo{"Pacific/Auckland", "3 Apr 2027 20:00:00"});
+
+class FakeTimePeriodStore : public TimePeriodStore {
+ public:
+  FakeTimePeriodStore() = default;
+
+  FakeTimePeriodStore(const FakeTimePeriodStore&) = delete;
+  FakeTimePeriodStore& operator=(const FakeTimePeriodStore&) = delete;
+
+  ~FakeTimePeriodStore() override = default;
+
+  const base::ListValue* Get() override { return &list_; }
+
+  void Set(base::ListValue list) override { list_ = std::move(list); }
+
+  void Clear() override { list_.clear(); }
+
+ private:
+  base::ListValue list_;
+};
+
+TimePeriodStorages BuildFakeTimePeriodStorages() {
+  TimePeriodStorages time_period_storages;
+  time_period_storages.emplace(SerpMetricType::kBrave,
+                               std::make_unique<TimePeriodStorage>(
+                                   std::make_unique<FakeTimePeriodStore>(),
+                                   kSerpMetricsTimePeriodInDays.Get(),
+                                   /*should_offset_dst=*/false));
+  time_period_storages.emplace(SerpMetricType::kGoogle,
+                               std::make_unique<TimePeriodStorage>(
+                                   std::make_unique<FakeTimePeriodStore>(),
+                                   kSerpMetricsTimePeriodInDays.Get(),
+                                   /*should_offset_dst=*/false));
+  time_period_storages.emplace(SerpMetricType::kOther,
+                               std::make_unique<TimePeriodStorage>(
+                                   std::make_unique<FakeTimePeriodStore>(),
+                                   kSerpMetricsTimePeriodInDays.Get(),
+                                   /*should_offset_dst=*/false));
+  return time_period_storages;
+}
+
+}  // namespace
+
+class SerpMetricsDSTEndTest
+    : public ::testing::TestWithParam<DSTEndTimezoneParamInfo> {
+ public:
+  SerpMetricsDSTEndTest() : scoped_timezone_(GetParam().timezone) {}
+
+  void SetUp() override {
+    const DSTEndTimezoneParamInfo& timezone_param = GetParam();
+
+    base::Time standard_time_start;
+    ASSERT_TRUE(base::Time::FromUTCString(timezone_param.standard_time_start,
+                                          &standard_time_start));
+    FastForwardClockTo(standard_time_start);
+
+    local_state_.registry()->RegisterStringPref(kLastCheckYMD, "");
+    scoped_feature_list_.InitAndEnableFeatureWithParameters(
+        kSerpMetricsFeature, {{"time_period_in_days", "7"}});
+    serp_metrics_ = std::make_unique<SerpMetrics>(
+        &local_state_, BuildFakeTimePeriodStorages());
+  }
+
+ protected:
+  void FastForwardClockTo(base::Time time) {
+    CHECK_GE(time, base::Time::Now());
+    task_environment_.AdvanceClock(time - base::Time::Now());
+  }
+
+  base::test::TaskEnvironment task_environment_{
+      base::test::TaskEnvironment::TimeSource::MOCK_TIME};
+  const ScopedTimezoneForTesting scoped_timezone_;
+  base::test::ScopedFeatureList scoped_feature_list_;
+  TestingPrefServiceSimple local_state_;
+  std::unique_ptr<SerpMetrics> serp_metrics_;
+};
+
+TEST_P(SerpMetricsDSTEndTest, YesterdayCountIsOneAfterDSTEnd) {
+  // Day 1: the DST end day itself. The local day is longer than 24 hours
+  // because clocks fall back.
+  serp_metrics_->RecordSearch(SerpMetricType::kBrave);
+
+  // Day 2: one full day later. `NextMidnight` must land at the correct next
+  // local midnight even though the previous day was longer than 24 hours.
+  task_environment_.AdvanceClock(base::Days(1));
+  serp_metrics_->RecordSearch(SerpMetricType::kBrave);
+
+  // Day 1 is yesterday from day 2's perspective and has exactly 1 search.
+  EXPECT_EQ(1U,
+            serp_metrics_->GetSearchCountForYesterday(SerpMetricType::kBrave));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    DSTEndTimezones,
+    SerpMetricsDSTEndTest,
+    kDSTEndTimezones,
+    [](const ::testing::TestParamInfo<DSTEndTimezoneParamInfo>& test_param) {
+      std::string name;
+      base::ReplaceChars(test_param.param.timezone, "/", "_", &name);
+      return name;
+    });
+
+}  // namespace serp_metrics

--- a/components/serp_metrics/serp_metrics_dst_start_unittest.cc
+++ b/components/serp_metrics/serp_metrics_dst_start_unittest.cc
@@ -1,0 +1,151 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include <memory>
+#include <string>
+
+#include "base/check_op.h"
+#include "base/strings/string_util.h"
+#include "base/test/scoped_feature_list.h"
+#include "base/test/task_environment.h"
+#include "base/time/time.h"
+#include "brave/components/constants/pref_names.h"
+#include "brave/components/serp_metrics/serp_metric_type.h"
+#include "brave/components/serp_metrics/serp_metrics.h"
+#include "brave/components/serp_metrics/serp_metrics_feature.h"
+#include "brave/components/time_period_storage/scoped_timezone_for_testing.h"
+#include "brave/components/time_period_storage/time_period_storage.h"
+#include "brave/components/time_period_storage/time_period_store.h"
+#include "components/prefs/pref_registry_simple.h"
+#include "components/prefs/testing_pref_service.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace serp_metrics {
+
+namespace {
+
+struct DSTStartTimezoneParamInfo {
+  std::string_view timezone;
+  const char* daylight_time_start = nullptr;
+};
+
+const auto kDSTStartTimezones = ::testing::Values(
+    // America/New_York: EST -> EDT, 14 March 2027 at 07:00 UTC (-5h -> -4h).
+    DSTStartTimezoneParamInfo{"America/New_York", "14 Mar 2027 11:00:00"},
+    // America/St_Johns: NST -> NDT, 14 March 2027 at 05:30 UTC (-3:30h ->
+    // -2:30h). Half-hour base UTC offset.
+    DSTStartTimezoneParamInfo{"America/St_Johns", "14 Mar 2027 11:00:00"},
+    // Antarctica/Troll: UTC+0 -> UTC+2, 28 March 2027 at 01:00 UTC. Only active
+    // timezone with a 2-hour DST shift.
+    DSTStartTimezoneParamInfo{"Antarctica/Troll", "28 Mar 2027 11:00:00"},
+    // Europe/Paris: CET -> CEST, 28 March 2027 at 01:00 UTC (+1h -> +2h).
+    DSTStartTimezoneParamInfo{"Europe/Paris", "28 Mar 2027 11:00:00"},
+    // Australia/Lord_Howe: LHST -> LHDT, 2 October 2027 at 15:30 UTC (+10:30h
+    // -> +11h). Only active timezone with a 30-minute DST shift.
+    DSTStartTimezoneParamInfo{"Australia/Lord_Howe", "3 Oct 2027 11:00:00"},
+    // Pacific/Auckland: NZST -> NZDT, 25 September 2027 at 14:00 UTC (+12h ->
+    // +13h). Far-east, southern hemisphere DST start in September.
+    DSTStartTimezoneParamInfo{"Pacific/Auckland", "25 Sep 2027 20:00:00"});
+
+class FakeTimePeriodStore : public TimePeriodStore {
+ public:
+  FakeTimePeriodStore() = default;
+
+  FakeTimePeriodStore(const FakeTimePeriodStore&) = delete;
+  FakeTimePeriodStore& operator=(const FakeTimePeriodStore&) = delete;
+
+  ~FakeTimePeriodStore() override = default;
+
+  const base::ListValue* Get() override { return &list_; }
+
+  void Set(base::ListValue list) override { list_ = std::move(list); }
+
+  void Clear() override { list_.clear(); }
+
+ private:
+  base::ListValue list_;
+};
+
+TimePeriodStorages BuildFakeTimePeriodStorages() {
+  TimePeriodStorages time_period_storages;
+  time_period_storages.emplace(SerpMetricType::kBrave,
+                               std::make_unique<TimePeriodStorage>(
+                                   std::make_unique<FakeTimePeriodStore>(),
+                                   kSerpMetricsTimePeriodInDays.Get(),
+                                   /*should_offset_dst=*/false));
+  time_period_storages.emplace(SerpMetricType::kGoogle,
+                               std::make_unique<TimePeriodStorage>(
+                                   std::make_unique<FakeTimePeriodStore>(),
+                                   kSerpMetricsTimePeriodInDays.Get(),
+                                   /*should_offset_dst=*/false));
+  time_period_storages.emplace(SerpMetricType::kOther,
+                               std::make_unique<TimePeriodStorage>(
+                                   std::make_unique<FakeTimePeriodStore>(),
+                                   kSerpMetricsTimePeriodInDays.Get(),
+                                   /*should_offset_dst=*/false));
+  return time_period_storages;
+}
+
+}  // namespace
+
+class SerpMetricsDSTStartTest
+    : public ::testing::TestWithParam<DSTStartTimezoneParamInfo> {
+ public:
+  SerpMetricsDSTStartTest() : scoped_timezone_(GetParam().timezone) {}
+
+  void SetUp() override {
+    const DSTStartTimezoneParamInfo& timezone_param = GetParam();
+
+    base::Time daylight_time_start;
+    ASSERT_TRUE(base::Time::FromUTCString(timezone_param.daylight_time_start,
+                                          &daylight_time_start));
+    FastForwardClockTo(daylight_time_start);
+
+    local_state_.registry()->RegisterStringPref(kLastCheckYMD, "");
+    scoped_feature_list_.InitAndEnableFeatureWithParameters(
+        kSerpMetricsFeature, {{"time_period_in_days", "7"}});
+    serp_metrics_ = std::make_unique<SerpMetrics>(
+        &local_state_, BuildFakeTimePeriodStorages());
+  }
+
+ protected:
+  void FastForwardClockTo(base::Time time) {
+    CHECK_GE(time, base::Time::Now());
+    task_environment_.AdvanceClock(time - base::Time::Now());
+  }
+
+  base::test::TaskEnvironment task_environment_{
+      base::test::TaskEnvironment::TimeSource::MOCK_TIME};
+  const ScopedTimezoneForTesting scoped_timezone_;
+  base::test::ScopedFeatureList scoped_feature_list_;
+  TestingPrefServiceSimple local_state_;
+  std::unique_ptr<SerpMetrics> serp_metrics_;
+};
+
+TEST_P(SerpMetricsDSTStartTest, YesterdayCountIsOneAfterDSTStart) {
+  // Day 1: the DST start day itself. The local day is shorter than 24 hours.
+  serp_metrics_->RecordSearch(SerpMetricType::kBrave);
+
+  // Day 2: one full day later. `NextMidnight` must skip over the shortened day
+  // and land at the correct next local midnight, not one clock-hour early.
+  task_environment_.AdvanceClock(base::Days(1));
+  serp_metrics_->RecordSearch(SerpMetricType::kBrave);
+
+  // Day 1 is yesterday from day 2's perspective and has exactly 1 search.
+  EXPECT_EQ(1U,
+            serp_metrics_->GetSearchCountForYesterday(SerpMetricType::kBrave));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    DSTStartTimezones,
+    SerpMetricsDSTStartTest,
+    kDSTStartTimezones,
+    [](const ::testing::TestParamInfo<DSTStartTimezoneParamInfo>& test_param) {
+      std::string name;
+      base::ReplaceChars(test_param.param.timezone, "/", "_", &name);
+      return name;
+    });
+
+}  // namespace serp_metrics

--- a/components/time_period_storage/BUILD.gn
+++ b/components/time_period_storage/BUILD.gn
@@ -31,6 +31,14 @@ static_library("time_period_storage") {
   ]
 }
 
+source_set("test_support") {
+  testonly = true
+
+  public = [ "scoped_timezone_for_testing.h" ]
+
+  deps = [ "//base/test:test_support" ]
+}
+
 source_set("unit_tests") {
   testonly = true
 
@@ -41,7 +49,19 @@ source_set("unit_tests") {
     "weekly_event_storage_unittest.cc",
   ]
 
+  # `ScopedLibcTimezoneOverride` is a no-op on Windows for IANA timezone
+  # identifiers, so timezone-dependent tests are excluded on Windows to avoid
+  # spurious failures caused by a non-overridable libc timezone.
+  if (!is_win) {
+    sources += [
+      "time_period_storage_dst_end_unittest.cc",
+      "time_period_storage_dst_start_unittest.cc",
+      "time_period_storage_issue_54427_unittest.cc",
+    ]
+  }
+
   deps = [
+    ":test_support",
     ":time_period_storage",
     "//base",
     "//base/test:test_support",

--- a/components/time_period_storage/scoped_timezone_for_testing.h
+++ b/components/time_period_storage/scoped_timezone_for_testing.h
@@ -1,0 +1,35 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_TIME_PERIOD_STORAGE_SCOPED_TIMEZONE_FOR_TESTING_H_
+#define BRAVE_COMPONENTS_TIME_PERIOD_STORAGE_SCOPED_TIMEZONE_FOR_TESTING_H_
+
+#include <string>
+#include <string_view>
+
+#include "base/test/icu_test_util.h"
+#include "base/test/scoped_libc_timezone_override.h"
+
+// Overrides both the libc and ICU timezones for the duration of a test scope.
+// Chromium date operations use both, so setting only one produces inconsistent
+// results for callers of `LocalMidnight()` and ICU date formatting functions.
+
+class ScopedTimezoneForTesting {
+ public:
+  explicit ScopedTimezoneForTesting(std::string_view timezone_id)
+      : timezone_(timezone_id), libc_(timezone_), icu_(timezone_.c_str()) {}
+
+  ScopedTimezoneForTesting(const ScopedTimezoneForTesting&) = delete;
+  ScopedTimezoneForTesting& operator=(const ScopedTimezoneForTesting&) = delete;
+
+  ~ScopedTimezoneForTesting() = default;
+
+ private:
+  const std::string timezone_;
+  const base::test::ScopedLibcTimezoneOverride libc_;
+  const base::test::ScopedRestoreDefaultTimezone icu_;
+};
+
+#endif  // BRAVE_COMPONENTS_TIME_PERIOD_STORAGE_SCOPED_TIMEZONE_FOR_TESTING_H_

--- a/components/time_period_storage/time_period_storage.cc
+++ b/components/time_period_storage/time_period_storage.cc
@@ -19,9 +19,18 @@
 #include "components/prefs/pref_service.h"
 
 namespace {
+
 // Used to compensate for DST-related differences. i.e. time
 // method arguments not matching up with stored time values.
 constexpr base::TimeDelta kPotentialDSTOffset = base::Hours(1);
+
+// Used by `NextMidnight` when `should_use_fixed_day` is `false`. 24 hours
+// covers a standard day; the extra 2 hours covers the maximum DST shift
+// (Antarctica/Troll), guaranteeing the result lands inside the next calendar
+// day without overshooting into the day after.
+constexpr base::TimeDelta kNextMidnightOffset =
+    base::Hours(24) + base::Hours(2);
+
 }  // namespace
 
 TimePeriodStorage::TimePeriodStorage(std::unique_ptr<TimePeriodStore> store,
@@ -180,38 +189,65 @@ void TimePeriodStorage::Clear() {
   store_->Clear();
 }
 
-void TimePeriodStorage::FilterToPeriod() {
-  base::Time now_midnight = clock_->Now().LocalMidnight();
-  base::Time last_saved_midnight;
+base::Time TimePeriodStorage::NextMidnight(base::Time time) const {
+  // No precondition is enforced on `time` being at midnight. Two legitimate
+  // cases produce non-midnight inputs: legacy prefs written by the old
+  // DST-offset code contain timestamps 1 hour past midnight, and travel across
+  // timezones means a timestamp that was midnight in the original timezone is
+  // no longer midnight in the current one. Adding `kNextMidnightOffset` always
+  // lands within the next calendar day regardless of the input, so `Midnight`
+  // returns its correct start.
+  //
+  // Known limitation: if `time` appears later than 22:00 in the current local
+  // timezone (possible when crossing more than 22 timezone hours, e.g. UTC+12
+  // to UTC-11), `time + kNextMidnightOffset` overshoots into the day after next
+  // and one empty bucket is silently skipped. A correct fix requires ICU
+  // calendar arithmetic to advance by exactly one calendar day. DST transitions
+  // shift clocks by at most 2 hours, so the 22:00 bound is never reached for
+  // DST and all DST cases are handled correctly. Migrating all
+  // `TimePeriodStorage` callers to UTC buckets would eliminate both the DST and
+  // timezone-travel edge cases entirely.
+  return (time + kNextMidnightOffset).LocalMidnight();
+}
 
-  if (!daily_values_.empty()) {
-    last_saved_midnight = daily_values_.front().day;
+base::TimeDelta TimePeriodStorage::GetDstOffset() const {
+  if (!should_offset_dst_) {
+    return base::TimeDelta();
   }
 
-  // Push daily values for new days. In loop condition, add one hour
-  // to now_midnight to account for DST changes.
-  base::TimeDelta dst_offset =
-      should_offset_dst_ ? kPotentialDSTOffset : base::TimeDelta();
-  for (base::Time day_midnight = last_saved_midnight + base::Days(1);
-       day_midnight <= (now_midnight + dst_offset);
-       day_midnight += base::Days(1)) {
-    // Day changed. Since we consider only small incoming intervals, lets just
-    // save it with a new timestamp.
-    if (last_saved_midnight.is_null()) {
-      // If this is a brand new list, insert one daily value
-      // with now_midnight...
-      day_midnight = now_midnight;
-    }
-    daily_values_.push_front({day_midnight, 0});
+  return kPotentialDSTOffset;
+}
+
+void TimePeriodStorage::FilterToPeriod() {
+  const base::Time now_midnight = clock_->Now().LocalMidnight();
+
+  if (daily_values_.empty()) {
+    // No prior data; seed the list with an empty bucket for today.
+    daily_values_.push_front({now_midnight, 0});
+    return;
+  }
+
+  // When DST offsetting is disabled and local time is used (SERP), use
+  // `NextMidnight` to correctly handle short calendar days at DST start.
+  // For P3A, `GetDstOffset` extends the loop condition by one hour to cover
+  // a potential DST shift.
+  const bool should_use_fixed_day = should_offset_dst_;
+  const base::Time last_recorded_midnight = daily_values_.front().day;
+  base::Time bucket_midnight = should_use_fixed_day
+                                   ? last_recorded_midnight + base::Days(1)
+                                   : NextMidnight(last_recorded_midnight);
+  while (bucket_midnight <= now_midnight + GetDstOffset()) {
+    // Add an empty bucket for the missed day.
+    daily_values_.push_front({bucket_midnight, 0});
+
     if (daily_values_.size() > period_days_) {
+      // Drop the oldest bucket outside the window.
       daily_values_.pop_back();
     }
-    if (last_saved_midnight.is_null()) {
-      // ...and break, so we only insert one element. We only want
-      // to insert multiple elements to make up for inactive days on
-      // existing lists, so that IsOnePeriodPassed works correctly.
-      break;
-    }
+
+    // Advance to the next bucket.
+    bucket_midnight = should_use_fixed_day ? bucket_midnight + base::Days(1)
+                                           : NextMidnight(bucket_midnight);
   }
 }
 

--- a/components/time_period_storage/time_period_storage.h
+++ b/components/time_period_storage/time_period_storage.h
@@ -77,6 +77,10 @@ class TimePeriodStorage {
     base::Time day;
     uint64_t value = 0ull;
   };
+  // Returns the midnight that starts the calendar day after `time`. Safe
+  // across DST transitions and does not require `time` to be at midnight.
+  base::Time NextMidnight(base::Time time) const;
+  base::TimeDelta GetDstOffset() const;
   void FilterToPeriod();
   void Load();
   void Save();

--- a/components/time_period_storage/time_period_storage_dst_end_unittest.cc
+++ b/components/time_period_storage/time_period_storage_dst_end_unittest.cc
@@ -1,0 +1,160 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include <memory>
+#include <string>
+
+#include "base/check_op.h"
+#include "base/strings/string_util.h"
+#include "base/test/task_environment.h"
+#include "base/test/values_test_util.h"
+#include "base/time/time.h"
+#include "brave/components/time_period_storage/scoped_timezone_for_testing.h"
+#include "brave/components/time_period_storage/time_period_storage.h"
+#include "components/prefs/pref_registry_simple.h"
+#include "components/prefs/testing_pref_service.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace {
+
+constexpr const char* kPrefName = "time_period_storage";
+
+struct DSTEndTimezoneParamInfo {
+  std::string_view timezone;
+  const char* standard_time_start = nullptr;
+  std::string_view expected_json;
+};
+
+const auto kDSTEndTimezones = ::testing::Values(
+    // America/New_York: EDT -> EST, 1 November 2026 at 06:00 UTC (-4h -> -5h).
+    DSTEndTimezoneParamInfo{"America/New_York", "1 Nov 2026 14:00:00",
+                            R"JSON([
+          {  // November 2 00:00 EST (November 2 05:00 UTC)
+            "day": 1793595600.0,
+            "value": 1.0
+          },
+          {  // November 1 00:00 EDT (November 1 04:00 UTC), the DST end day
+            "day": 1793505600.0,
+            "value": 1.0
+          }
+        ])JSON"},
+    // America/St_Johns: NDT -> NST, 1 November 2026 at 05:30 UTC (-2:30h ->
+    // -3:30h). Half-hour base UTC offset.
+    DSTEndTimezoneParamInfo{"America/St_Johns", "1 Nov 2026 14:00:00",
+                            R"JSON([
+          {  // November 2 00:00 NST (November 2 03:30 UTC)
+            "day": 1793590200.0,
+            "value": 1.0
+          },
+          {  // November 1 00:00 NDT (November 1 02:30 UTC), the DST end day
+            "day": 1793500200.0,
+            "value": 1.0
+          }
+        ])JSON"},
+    // Antarctica/Troll: UTC+2 -> UTC+0, 25 October 2026 at 01:00 UTC. Only
+    // active timezone with a 2-hour DST shift.
+    DSTEndTimezoneParamInfo{"Antarctica/Troll", "25 Oct 2026 11:00:00",
+                            R"JSON([
+          {  // October 26 00:00 UTC+0 (October 26 00:00 UTC)
+            "day": 1792972800.0,
+            "value": 1.0
+          },
+          {  // October 25 00:00 UTC+2 (October 24 22:00 UTC), the DST end day
+            "day": 1792879200.0,
+            "value": 1.0
+          }
+        ])JSON"},
+    // Europe/Paris: CEST -> CET, 25 October 2026 at 01:00 UTC (+2h -> +1h).
+    DSTEndTimezoneParamInfo{"Europe/Paris", "25 Oct 2026 11:00:00",
+                            R"JSON([
+          {  // October 26 00:00 CET (October 25 23:00 UTC)
+            "day": 1792969200.0,
+            "value": 1.0
+          },
+          {  // October 25 00:00 CEST (October 24 22:00 UTC), the DST end day
+            "day": 1792879200.0,
+            "value": 1.0
+          }
+        ])JSON"},
+    // Australia/Lord_Howe: LHDT -> LHST, 3 April 2027 at 15:00 UTC (+11h ->
+    // +10:30h). Only active timezone with a 30-minute DST shift.
+    DSTEndTimezoneParamInfo{"Australia/Lord_Howe", "4 Apr 2027 11:00:00",
+                            R"JSON([
+          {  // April 5 00:00 LHST (April 4 13:30 UTC)
+            "day": 1806845400.0,
+            "value": 1.0
+          },
+          {  // April 4 00:00 LHDT (April 3 13:00 UTC), the DST end day
+            "day": 1806757200.0,
+            "value": 1.0
+          }
+        ])JSON"},
+    // Pacific/Auckland: NZDT -> NZST, 3 April 2027 at 14:00 UTC (+13h ->
+    // +12h). Far-east, southern hemisphere DST end in April.
+    DSTEndTimezoneParamInfo{"Pacific/Auckland", "3 Apr 2027 20:00:00",
+                            R"JSON([
+          {  // April 5 00:00 NZST (April 4 12:00 UTC)
+            "day": 1806840000.0,
+            "value": 1.0
+          },
+          {  // April 4 00:00 NZDT (April 3 11:00 UTC), the DST end day
+            "day": 1806750000.0,
+            "value": 1.0
+          }
+        ])JSON"});
+
+}  // namespace
+
+class TimePeriodStorageDSTEndTest
+    : public ::testing::TestWithParam<DSTEndTimezoneParamInfo> {
+ protected:
+  void FastForwardClockTo(base::Time time) {
+    CHECK_GE(time, base::Time::Now());
+    task_environment_.AdvanceClock(time - base::Time::Now());
+  }
+
+  base::test::TaskEnvironment task_environment_{
+      base::test::TaskEnvironment::TimeSource::MOCK_TIME};
+};
+
+TEST_P(TimePeriodStorageDSTEndTest, CreatesNewDailyBucketAfterDSTEnd) {
+  const DSTEndTimezoneParamInfo& timezone_param = GetParam();
+  const ScopedTimezoneForTesting scoped_timezone(timezone_param.timezone);
+
+  TestingPrefServiceSimple pref_service;
+  pref_service.registry()->RegisterListPref(kPrefName);
+
+  base::Time standard_time_start;
+  ASSERT_TRUE(base::Time::FromUTCString(timezone_param.standard_time_start,
+                                        &standard_time_start));
+  FastForwardClockTo(standard_time_start);
+
+  const auto time_period_storage = std::make_unique<TimePeriodStorage>(
+      &pref_service, kPrefName, /*period_days=*/28,
+      /*should_offset_dst=*/false);
+
+  // Day 1: the DST end day itself. The local day is longer than 24 hours
+  // because clocks fall back.
+  time_period_storage->AddDelta(1);
+
+  // Day 2: one full day later. `NextMidnight` must land at the correct next
+  // local midnight even though the previous day was longer than 24 hours.
+  task_environment_.AdvanceClock(base::Days(1));
+  time_period_storage->AddDelta(1);
+
+  // Each call created its own daily bucket. Day 2 is at the front.
+  EXPECT_EQ(base::test::ParseJson(timezone_param.expected_json),
+            pref_service.GetValue(kPrefName));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    DSTEndTimezones,
+    TimePeriodStorageDSTEndTest,
+    kDSTEndTimezones,
+    [](const ::testing::TestParamInfo<DSTEndTimezoneParamInfo>& test_param) {
+      std::string name;
+      base::ReplaceChars(test_param.param.timezone, "/", "_", &name);
+      return name;
+    });

--- a/components/time_period_storage/time_period_storage_dst_start_unittest.cc
+++ b/components/time_period_storage/time_period_storage_dst_start_unittest.cc
@@ -1,0 +1,159 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include <memory>
+#include <string>
+
+#include "base/check_op.h"
+#include "base/strings/string_util.h"
+#include "base/test/task_environment.h"
+#include "base/test/values_test_util.h"
+#include "base/time/time.h"
+#include "brave/components/time_period_storage/scoped_timezone_for_testing.h"
+#include "brave/components/time_period_storage/time_period_storage.h"
+#include "components/prefs/pref_registry_simple.h"
+#include "components/prefs/testing_pref_service.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace {
+
+constexpr const char* kPrefName = "time_period_storage";
+
+struct DSTStartTimezoneParamInfo {
+  std::string_view timezone;
+  const char* daylight_time_start = nullptr;
+  std::string_view expected_json;
+};
+
+const auto kDSTStartTimezones = ::testing::Values(
+    // America/New_York: EST -> EDT, 14 March 2027 at 07:00 UTC (-5h -> -4h).
+    DSTStartTimezoneParamInfo{"America/New_York", "14 Mar 2027 11:00:00",
+                              R"JSON([
+          {  // March 15 00:00 EDT (March 15 04:00 UTC)
+            "day": 1805083200.0,
+            "value": 1.0
+          },
+          {  // March 14 00:00 EST (March 14 05:00 UTC), DST start day
+            "day": 1805000400.0,
+            "value": 1.0
+          }
+        ])JSON"},
+    // America/St_Johns: NST -> NDT, 14 March 2027 at 05:30 UTC (-3:30h ->
+    // -2:30h). Half-hour base UTC offset.
+    DSTStartTimezoneParamInfo{"America/St_Johns", "14 Mar 2027 11:00:00",
+                              R"JSON([
+          {  // March 15 00:00 NDT (March 15 02:30 UTC)
+            "day": 1805077800.0,
+            "value": 1.0
+          },
+          {  // March 14 00:00 NST (March 14 03:30 UTC), DST start day
+            "day": 1804995000.0,
+            "value": 1.0
+          }
+        ])JSON"},
+    // Antarctica/Troll: UTC+0 -> UTC+2, 28 March 2027 at 01:00 UTC. Only
+    // active timezone with a 2-hour DST shift.
+    DSTStartTimezoneParamInfo{"Antarctica/Troll", "28 Mar 2027 11:00:00",
+                              R"JSON([
+          {  // March 29 00:00 UTC+2 (March 28 22:00 UTC)
+            "day": 1806271200.0,
+            "value": 1.0
+          },
+          {  // March 28 00:00 UTC+0 (March 28 00:00 UTC), DST start day
+            "day": 1806192000.0,
+            "value": 1.0
+          }
+        ])JSON"},
+    // Europe/Paris: CET -> CEST, 28 March 2027 at 01:00 UTC (+1h -> +2h).
+    DSTStartTimezoneParamInfo{"Europe/Paris", "28 Mar 2027 11:00:00",
+                              R"JSON([
+          {  // March 29 00:00 CEST (March 28 22:00 UTC)
+            "day": 1806271200.0,
+            "value": 1.0
+          },
+          {  // March 28 00:00 CET (March 27 23:00 UTC), DST start day
+            "day": 1806188400.0,
+            "value": 1.0
+          }
+        ])JSON"},
+    // Australia/Lord_Howe: LHST -> LHDT, 2 October 2027 at 15:30 UTC
+    // (+10:30h -> +11h). Only active timezone with a 30-minute DST shift.
+    DSTStartTimezoneParamInfo{"Australia/Lord_Howe", "3 Oct 2027 11:00:00",
+                              R"JSON([
+          {  // October 4 00:00 LHDT (October 3 13:00 UTC)
+            "day": 1822568400.0,
+            "value": 1.0
+          },
+          {  // October 3 00:00 LHST (October 2 13:30 UTC), DST start day
+            "day": 1822483800.0,
+            "value": 1.0
+          }
+        ])JSON"},
+    // Pacific/Auckland: NZST -> NZDT, 25 September 2027 at 14:00 UTC (+12h ->
+    // +13h). Far-east, southern hemisphere DST start in September.
+    DSTStartTimezoneParamInfo{"Pacific/Auckland", "25 Sep 2027 20:00:00",
+                              R"JSON([
+          {  // September 27 00:00 NZDT (September 26 11:00 UTC)
+            "day": 1821956400.0,
+            "value": 1.0
+          },
+          {  // September 26 00:00 NZST (September 25 12:00 UTC), DST start day
+            "day": 1821873600.0,
+            "value": 1.0
+          }
+        ])JSON"});
+
+}  // namespace
+
+class TimePeriodStorageDSTStartTest
+    : public ::testing::TestWithParam<DSTStartTimezoneParamInfo> {
+ protected:
+  void FastForwardClockTo(base::Time time) {
+    CHECK_GE(time, base::Time::Now());
+    task_environment_.AdvanceClock(time - base::Time::Now());
+  }
+
+  base::test::TaskEnvironment task_environment_{
+      base::test::TaskEnvironment::TimeSource::MOCK_TIME};
+};
+
+TEST_P(TimePeriodStorageDSTStartTest, CreatesNewDailyBucketAfterDSTStart) {
+  const DSTStartTimezoneParamInfo& timezone_param = GetParam();
+  const ScopedTimezoneForTesting scoped_timezone(timezone_param.timezone);
+
+  TestingPrefServiceSimple pref_service;
+  pref_service.registry()->RegisterListPref(kPrefName);
+
+  base::Time daylight_time_start;
+  ASSERT_TRUE(base::Time::FromUTCString(timezone_param.daylight_time_start,
+                                        &daylight_time_start));
+  FastForwardClockTo(daylight_time_start);
+
+  const auto time_period_storage = std::make_unique<TimePeriodStorage>(
+      &pref_service, kPrefName, /*period_days=*/28,
+      /*should_offset_dst=*/false);
+
+  // Day 1: the DST start day itself. The local day is shorter than 24 hours.
+  time_period_storage->AddDelta(1);
+
+  // Day 2: one full day later. `NextMidnight` must skip over the shortened day
+  // and land at the correct next local midnight, not one clock-hour early.
+  task_environment_.AdvanceClock(base::Days(1));
+  time_period_storage->AddDelta(1);
+
+  // Each call created its own daily bucket. Day 2 is at the front.
+  EXPECT_EQ(base::test::ParseJson(timezone_param.expected_json),
+            pref_service.GetValue(kPrefName));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    DSTStartTimezones,
+    TimePeriodStorageDSTStartTest,
+    kDSTStartTimezones,
+    [](const ::testing::TestParamInfo<DSTStartTimezoneParamInfo>& test_param) {
+      std::string name;
+      base::ReplaceChars(test_param.param.timezone, "/", "_", &name);
+      return name;
+    });

--- a/components/time_period_storage/time_period_storage_issue_54427_unittest.cc
+++ b/components/time_period_storage/time_period_storage_issue_54427_unittest.cc
@@ -1,0 +1,829 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include <cstddef>
+#include <memory>
+
+#include "base/check_op.h"
+#include "base/test/task_environment.h"
+#include "base/test/values_test_util.h"
+#include "base/time/time.h"
+#include "brave/components/time_period_storage/scoped_timezone_for_testing.h"
+#include "brave/components/time_period_storage/time_period_storage.h"
+#include "components/prefs/pref_registry_simple.h"
+#include "components/prefs/testing_pref_service.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace {
+
+constexpr const char* kPrefName = "time_period_storage";
+constexpr size_t kPeriodDays = 7;
+
+}  // namespace
+
+// Regression test for https://github.com/brave/brave-browser/issues/54427.
+// In timezones that observe daylight saving time, activity from consecutive
+// days could be stored in the wrong daily bucket across the DST boundary.
+class TimePeriodStorageIssue54427Test : public ::testing::Test {
+ public:
+  TimePeriodStorageIssue54427Test() {
+    pref_service_.registry()->RegisterListPref(kPrefName);
+  }
+
+ protected:
+  void FastForwardClockTo(base::Time time) {
+    CHECK_GE(time, base::Time::Now());
+    task_environment_.AdvanceClock(time - base::Time::Now());
+  }
+
+  base::test::TaskEnvironment task_environment_{
+      base::test::TaskEnvironment::TimeSource::MOCK_TIME};
+  TestingPrefServiceSimple pref_service_;
+  std::unique_ptr<TimePeriodStorage> time_period_storage_;
+};
+
+TEST_F(TimePeriodStorageIssue54427Test,
+       AddDeltaCreatesNewBucketAfterDSTStartWhenStoredMidnightsAreBad) {
+  // Loads the production pref data from the bug report and verifies that
+  // `AddDelta` after the DST change creates a new bucket at the correct CEST
+  // midnight. In the broken code, all stored CEST timestamps from March 30 to
+  // April 9 were already 1 hour late, so computing the next bucket by adding
+  // 24 hours produced another late timestamp and prevented a new bucket from
+  // being created.
+  const ScopedTimezoneForTesting scoped_timezone("Europe/Berlin");
+
+  // Pre-populate the pref with the 28 entries from the bug report.
+  pref_service_.Set(kPrefName, base::test::ParseJson(R"JSON([
+    // These CEST entries are all 1 hour past local midnight.
+    {  // April 9 00:00 CEST + 1h
+      "day": 1775689200.0,
+      "value": 23.0
+    },
+    {  // April 8 00:00 CEST + 1h
+      "day": 1775602800.0,
+      "value": 5.0
+    },
+    {  // April 7 00:00 CEST + 1h
+      "day": 1775516400.0,
+      "value": 2.0
+    },
+    {  // April 6 00:00 CEST + 1h
+      "day": 1775430000.0,
+      "value": 2.0
+    },
+    {  // April 5 00:00 CEST + 1h
+      "day": 1775343600.0,
+      "value": 8.0
+    },
+    {  // April 4 00:00 CEST + 1h
+      "day": 1775257200.0,
+      "value": 0.0
+    },
+    {  // April 3 00:00 CEST + 1h
+      "day": 1775170800.0,
+      "value": 3.0
+    },
+    {  // April 2 00:00 CEST + 1h
+      "day": 1775084400.0,
+      "value": 2.0
+    },
+    {  // April 1 00:00 CEST + 1h
+      "day": 1774998000.0,
+      "value": 1.0
+    },
+    {  // March 31 00:00 CEST + 1h
+      "day": 1774911600.0,
+      "value": 11.0
+    },
+    {  // March 30 00:00 CEST + 1h
+      "day": 1774825200.0,
+      "value": 5.0
+    },
+    // CET entries below are at the correct midnight.
+    {  // March 29 00:00 CET (March 28 23:00 UTC)
+      "day": 1774738800.0,
+      "value": 22.0
+    },
+    {  // March 28 00:00 CET (March 27 23:00 UTC)
+      "day": 1774652400.0,
+      "value": 1.0
+    },
+    {  // March 27 00:00 CET (March 26 23:00 UTC)
+      "day": 1774566000.0,
+      "value": 4.0
+    },
+    {  // March 26 00:00 CET (March 25 23:00 UTC)
+      "day": 1774479600.0,
+      "value": 4.0
+    },
+    {  // March 25 00:00 CET (March 24 23:00 UTC)
+      "day": 1774393200.0,
+      "value": 5.0
+    },
+    {  // March 24 00:00 CET (March 23 23:00 UTC)
+      "day": 1774306800.0,
+      "value": 1.0
+    },
+    {  // March 23 00:00 CET (March 22 23:00 UTC)
+      "day": 1774220400.0,
+      "value": 1.0
+    },
+    {  // March 22 00:00 CET (March 21 23:00 UTC)
+      "day": 1774134000.0,
+      "value": 9.0
+    },
+    {  // March 21 00:00 CET (March 20 23:00 UTC)
+      "day": 1774047600.0,
+      "value": 10.0
+    },
+    {  // March 20 00:00 CET (March 19 23:00 UTC)
+      "day": 1773961200.0,
+      "value": 11.0
+    },
+    {  // March 19 00:00 CET (March 18 23:00 UTC)
+      "day": 1773874800.0,
+      "value": 4.0
+    },
+    {  // March 18 00:00 CET (March 17 23:00 UTC)
+      "day": 1773788400.0,
+      "value": 1.0
+    },
+    {  // March 17 00:00 CET (March 16 23:00 UTC)
+      "day": 1773702000.0,
+      "value": 0.0
+    },
+    {  // March 16 00:00 CET (March 15 23:00 UTC)
+      "day": 1773615600.0,
+      "value": 3.0
+    },
+    {  // March 15 00:00 CET (March 14 23:00 UTC)
+      "day": 1773529200.0,
+      "value": 2.0
+    },
+    {  // March 14 00:00 CET (March 13 23:00 UTC)
+      "day": 1773442800.0,
+      "value": 2.0
+    },
+    {  // March 13 00:00 CET (March 12 23:00 UTC)
+      "day": 1773356400.0,
+      "value": 0.0
+    }
+  ])JSON"));
+
+  time_period_storage_ = std::make_unique<TimePeriodStorage>(
+      &pref_service_, kPrefName, /*period_days=*/28,
+      /*should_offset_dst=*/false);
+
+  // April 10 09:00 CEST (April 10 07:00 UTC).
+  base::Time april_10;
+  ASSERT_TRUE(base::Time::FromUTCString("10 Apr 2026 07:00:00", &april_10));
+  FastForwardClockTo(april_10);
+
+  time_period_storage_->AddDelta(1);
+
+  // The new April 10 bucket is created at the correct CEST midnight. Older bad
+  // timestamps are unchanged. March 13 is dropped because the 28 day window can
+  // only keep 28 entries.
+  EXPECT_EQ(base::test::ParseJson(R"JSON([
+      {  // April 10 00:00 CEST (April 9 22:00 UTC)
+        "day": 1775772000.0,
+        "value": 1.0
+      },
+      // Older CEST entries remain 1 hour late because they were saved that way.
+      {  // April 9 00:00 CEST + 1h
+        "day": 1775689200.0,
+        "value": 23.0
+      },
+      {  // April 8 00:00 CEST + 1h
+        "day": 1775602800.0,
+        "value": 5.0
+      },
+      {  // April 7 00:00 CEST + 1h
+        "day": 1775516400.0,
+        "value": 2.0
+      },
+      {  // April 6 00:00 CEST + 1h
+        "day": 1775430000.0,
+        "value": 2.0
+      },
+      {  // April 5 00:00 CEST + 1h
+        "day": 1775343600.0,
+        "value": 8.0
+      },
+      {  // April 4 00:00 CEST + 1h
+        "day": 1775257200.0,
+        "value": 0.0
+      },
+      {  // April 3 00:00 CEST + 1h
+        "day": 1775170800.0,
+        "value": 3.0
+      },
+      {  // April 2 00:00 CEST + 1h
+        "day": 1775084400.0,
+        "value": 2.0
+      },
+      {  // April 1 00:00 CEST + 1h
+        "day": 1774998000.0,
+        "value": 1.0
+      },
+      {  // March 31 00:00 CEST + 1h
+        "day": 1774911600.0,
+        "value": 11.0
+      },
+      {  // March 30 00:00 CEST + 1h
+        "day": 1774825200.0,
+        "value": 5.0
+      },
+      // CET entries below are at the correct midnight.
+      {  // March 29 00:00 CET (March 28 23:00 UTC)
+        "day": 1774738800.0,
+        "value": 22.0
+      },
+      {  // March 28 00:00 CET (March 27 23:00 UTC)
+        "day": 1774652400.0,
+        "value": 1.0
+      },
+      {  // March 27 00:00 CET (March 26 23:00 UTC)
+        "day": 1774566000.0,
+        "value": 4.0
+      },
+      {  // March 26 00:00 CET (March 25 23:00 UTC)
+        "day": 1774479600.0,
+        "value": 4.0
+      },
+      {  // March 25 00:00 CET (March 24 23:00 UTC)
+        "day": 1774393200.0,
+        "value": 5.0
+      },
+      {  // March 24 00:00 CET (March 23 23:00 UTC)
+        "day": 1774306800.0,
+        "value": 1.0
+      },
+      {  // March 23 00:00 CET (March 22 23:00 UTC)
+        "day": 1774220400.0,
+        "value": 1.0
+      },
+      {  // March 22 00:00 CET (March 21 23:00 UTC)
+        "day": 1774134000.0,
+        "value": 9.0
+      },
+      {  // March 21 00:00 CET (March 20 23:00 UTC)
+        "day": 1774047600.0,
+        "value": 10.0
+      },
+      {  // March 20 00:00 CET (March 19 23:00 UTC)
+        "day": 1773961200.0,
+        "value": 11.0
+      },
+      {  // March 19 00:00 CET (March 18 23:00 UTC)
+        "day": 1773874800.0,
+        "value": 4.0
+      },
+      {  // March 18 00:00 CET (March 17 23:00 UTC)
+        "day": 1773788400.0,
+        "value": 1.0
+      },
+      {  // March 17 00:00 CET (March 16 23:00 UTC)
+        "day": 1773702000.0,
+        "value": 0.0
+      },
+      {  // March 16 00:00 CET (March 15 23:00 UTC)
+        "day": 1773615600.0,
+        "value": 3.0
+      },
+      {  // March 15 00:00 CET (March 14 23:00 UTC)
+        "day": 1773529200.0,
+        "value": 2.0
+      },
+      {  // March 14 00:00 CET (March 13 23:00 UTC)
+        "day": 1773442800.0,
+        "value": 2.0
+      }
+    ])JSON"),
+            pref_service_.GetValue(kPrefName));
+  EXPECT_EQ(143U, time_period_storage_->GetPeriodSum());
+}
+
+TEST_F(TimePeriodStorageIssue54427Test,
+       EachDayGetsItsOwnBucketWhenRecordingAcrossDSTStart) {
+  // Simulates 28 days of activity starting on March 13 in Munich (CET, UTC+1),
+  // then a trip to San Francisco starting on March 22 San Francisco time (PDT,
+  // UTC-7), and a return to Munich on March 28, just before the March 29
+  // switch to CEST. The bug showed up after DST started, when activity could be
+  // stored under the previous CET midnight instead of the correct CEST
+  // midnight.
+
+  const ScopedTimezoneForTesting scoped_munich_timezone("Europe/Berlin");
+
+  time_period_storage_ = std::make_unique<TimePeriodStorage>(
+      &pref_service_, kPrefName, /*period_days=*/28,
+      /*should_offset_dst=*/false);
+
+  base::Time march_13_cet_midnight;
+  ASSERT_TRUE(base::Time::FromUTCString("12 Mar 2026 23:00:00",
+                                        &march_13_cet_midnight));
+  FastForwardClockTo(march_13_cet_midnight);
+
+  // March 13 through March 22 in Munich. Local midnight is CET.
+  for (size_t day = 0; day < 10; ++day) {
+    if (day > 0) {
+      task_environment_.AdvanceClock(base::Days(1));
+    }
+    time_period_storage_->AddDelta(1);
+  }
+
+  {
+    const ScopedTimezoneForTesting scoped_los_angeles_timezone(
+        "America/Los_Angeles");
+    // March 22 through March 26 in San Francisco (local time). Local midnight
+    // is PDT.
+    for (size_t day = 0; day < 5; ++day) {
+      task_environment_.AdvanceClock(base::Days(1));
+      time_period_storage_->AddDelta(1);
+    }
+  }
+
+  // March 28 onward back in Munich. The San Francisco scope has ended, so the
+  // timezone reverts to Europe/Berlin. The first day is in CET, then Munich
+  // switches to CEST on March 29.
+  for (size_t day = 0; day < 13; ++day) {
+    task_environment_.AdvanceClock(base::Days(1));
+    time_period_storage_->AddDelta(1);
+  }
+
+  // March 22 has two buckets — CET and PDT — because `NextMidnight` from the
+  // March 22 CET midnight resolves to the March 22 PDT midnight (same calendar
+  // date, 8 hours later). March 27 has value 0 because the return trip crosses
+  // midnight in Munich without any activity recorded.
+  EXPECT_EQ(base::test::ParseJson(R"JSON([
+    {  // April 9 00:00 CEST (April 8 22:00 UTC)
+      "day": 1775685600.0,
+      "value": 1.0
+    },
+    {  // April 8 00:00 CEST (April 7 22:00 UTC)
+      "day": 1775599200.0,
+      "value": 1.0
+    },
+    {  // April 7 00:00 CEST (April 6 22:00 UTC)
+      "day": 1775512800.0,
+      "value": 1.0
+    },
+    {  // April 6 00:00 CEST (April 5 22:00 UTC)
+      "day": 1775426400.0,
+      "value": 1.0
+    },
+    {  // April 5 00:00 CEST (April 4 22:00 UTC)
+      "day": 1775340000.0,
+      "value": 1.0
+    },
+    {  // April 4 00:00 CEST (April 3 22:00 UTC)
+      "day": 1775253600.0,
+      "value": 1.0
+    },
+    {  // April 3 00:00 CEST (April 2 22:00 UTC)
+      "day": 1775167200.0,
+      "value": 1.0
+    },
+    {  // April 2 00:00 CEST (April 1 22:00 UTC)
+      "day": 1775080800.0,
+      "value": 1.0
+    },
+    {  // April 1 00:00 CEST (March 31 22:00 UTC)
+      "day": 1774994400.0,
+      "value": 1.0
+    },
+    {  // March 31 00:00 CEST (March 30 22:00 UTC)
+      "day": 1774908000.0,
+      "value": 1.0
+    },
+    {  // March 30 00:00 CEST (March 29 22:00 UTC)
+      "day": 1774821600.0,
+      "value": 1.0
+    },
+    {  // March 29 00:00 CET (March 28 23:00 UTC)
+      // DST starts later that morning at 02:00 CET.
+      "day": 1774738800.0,
+      "value": 1.0
+    },
+    {  // March 28 00:00 CET (March 27 23:00 UTC)
+      // First day back in Munich.
+      "day": 1774652400.0,
+      "value": 1.0
+    },
+    {  // March 27 00:00 CET (March 26 23:00 UTC)
+      // Flying from San Francisco to Munich: no activity recorded.
+      "day": 1774566000.0,
+      "value": 0.0
+    },
+    {  // March 26 00:00 PDT (March 26 07:00 UTC)
+      "day": 1774508400.0,
+      "value": 1.0
+    },
+    {  // March 25 00:00 PDT (March 25 07:00 UTC)
+      "day": 1774422000.0,
+      "value": 1.0
+    },
+    {  // March 24 00:00 PDT (March 24 07:00 UTC)
+      "day": 1774335600.0,
+      "value": 1.0
+    },
+    {  // March 23 00:00 PDT (March 23 07:00 UTC)
+      "day": 1774249200.0,
+      "value": 1.0
+    },
+    {  // March 22 00:00 PDT (March 22 07:00 UTC)
+      // First San Francisco entry. `NextMidnight` from the March 22 CET
+      // midnight resolves to the March 22 PDT midnight because they share the
+      // same calendar date (8 hours apart).
+      "day": 1774162800.0,
+      "value": 1.0
+    },
+    {  // March 22 00:00 CET (March 21 23:00 UTC)
+      // Last Munich entry.
+      "day": 1774134000.0,
+      "value": 1.0
+    },
+    {  // March 21 00:00 CET (March 20 23:00 UTC)
+      "day": 1774047600.0,
+      "value": 1.0
+    },
+    {  // March 20 00:00 CET (March 19 23:00 UTC)
+      "day": 1773961200.0,
+      "value": 1.0
+    },
+    {  // March 19 00:00 CET (March 18 23:00 UTC)
+      "day": 1773874800.0,
+      "value": 1.0
+    },
+    {  // March 18 00:00 CET (March 17 23:00 UTC)
+      "day": 1773788400.0,
+      "value": 1.0
+    },
+    {  // March 17 00:00 CET (March 16 23:00 UTC)
+      "day": 1773702000.0,
+      "value": 1.0
+    },
+    {  // March 16 00:00 CET (March 15 23:00 UTC)
+      "day": 1773615600.0,
+      "value": 1.0
+    },
+    {  // March 15 00:00 CET (March 14 23:00 UTC)
+      "day": 1773529200.0,
+      "value": 1.0
+    },
+    {  // March 14 00:00 CET (March 13 23:00 UTC)
+      "day": 1773442800.0,
+      "value": 1.0
+    }
+  ])JSON"),
+            pref_service_.GetValue(kPrefName));
+  // 28 entries: 27 with value 1 and one March 27 with value 0 (no activity
+  // during the return flight). March 13 drops off because the extra March 22
+  // PDT bucket pushes the list past 28 entries.
+  EXPECT_EQ(27U, time_period_storage_->GetPeriodSum());
+}
+
+TEST_F(TimePeriodStorageIssue54427Test,
+       NewDailyBucketIsCreatedOneSecondAfterMidnightOnDayAfterDSTStart) {
+  const ScopedTimezoneForTesting scoped_timezone("Europe/Berlin");
+  time_period_storage_ = std::make_unique<TimePeriodStorage>(
+      &pref_service_, kPrefName, kPeriodDays,
+      /*should_offset_dst=*/false);
+
+  // DST starts in Europe/Berlin at 28 March 2027 01:00:00 UTC. Clocks move
+  // forward from 02:00 CET to 03:00 CEST, so the day is 23 hours long.
+  base::Time dst_start;
+  ASSERT_TRUE(base::Time::FromUTCString("28 Mar 2027 01:00:00", &dst_start));
+
+  // Record one second before the DST transition: March 28 00:00 CET
+  // (March 27 23:00 UTC).
+  FastForwardClockTo(dst_start - base::Seconds(1));
+  time_period_storage_->AddDelta(1);
+
+  // Record one second after March 29 midnight in CEST (March 28 22:00:01 UTC).
+  // Only 23 hours and 1 second separate the two midnights. A naive +24h
+  // calculation would overshoot the next midnight.
+  FastForwardClockTo(dst_start + base::Hours(21) + base::Seconds(1));
+  time_period_storage_->AddDelta(1);
+
+  EXPECT_EQ(base::test::ParseJson(R"JSON([
+      {  // March 29 00:00 CEST (March 28 22:00 UTC)
+        "day": 1806271200.0,
+        "value": 1.0
+      },
+      {  // March 28 00:00 CET (March 27 23:00 UTC)
+        "day": 1806188400.0,
+        "value": 1.0
+      }
+    ])JSON"),
+            pref_service_.GetValue(kPrefName));
+  EXPECT_EQ(2U, time_period_storage_->GetPeriodSum());
+}
+
+TEST_F(TimePeriodStorageIssue54427Test,
+       NewDailyBucketIsCreatedOneSecondAfterMidnightOnDayAfterTwoHourDSTStart) {
+  // Antarctica/Troll switches from UTC+0 to UTC+2 at 01:00 UTC on 28 March
+  // 2027. March 28 is therefore only 22 hours long. This is the shortest
+  // possible calendar day in any active IANA timezone and is a good stress case
+  // for bucket rollover.
+  const ScopedTimezoneForTesting scoped_timezone("Antarctica/Troll");
+  time_period_storage_ = std::make_unique<TimePeriodStorage>(
+      &pref_service_, kPrefName, kPeriodDays,
+      /*should_offset_dst=*/false);
+
+  base::Time dst_start;
+  ASSERT_TRUE(base::Time::FromUTCString("28 Mar 2027 01:00:00", &dst_start));
+
+  // Record 30 minutes before the DST transition. This is still March 28 00:00
+  // in UTC+0, the midnight of the short day.
+  FastForwardClockTo(dst_start - base::Minutes(30));
+  time_period_storage_->AddDelta(1);
+
+  // Record one second after March 29 midnight in UTC+2 (March 28 22:00:01 UTC).
+  // Only 22 hours and 1 second separate the two midnights. A naive +24h
+  // calculation would overshoot the next midnight.
+  FastForwardClockTo(dst_start + base::Hours(21) + base::Seconds(1));
+  time_period_storage_->AddDelta(1);
+
+  EXPECT_EQ(base::test::ParseJson(R"JSON([
+      {  // March 29 00:00 UTC+2 (March 28 22:00 UTC)
+        "day": 1806271200.0,
+        "value": 1.0
+      },
+      {  // March 28 00:00 UTC+0 (March 28 00:00 UTC)
+        "day": 1806192000.0,
+        "value": 1.0
+      }
+    ])JSON"),
+            pref_service_.GetValue(kPrefName));
+  EXPECT_EQ(2U, time_period_storage_->GetPeriodSum());
+}
+
+TEST_F(
+    TimePeriodStorageIssue54427Test,
+    NewDailyBucketIsCreatedOneSecondAfterMidnightOnDayAfterThirtyMinuteDSTStart) {
+  // Australia/Lord_Howe switches from LHST (UTC+10:30) to LHDT (UTC+11) at
+  // 02:00 LHST on 3 October 2027, which is 2 October 2027 15:30 UTC. October 3
+  // is therefore only 23 hours and 30 minutes long. This is the only active
+  // timezone with a 30-minute DST shift.
+  const ScopedTimezoneForTesting scoped_timezone("Australia/Lord_Howe");
+  time_period_storage_ = std::make_unique<TimePeriodStorage>(
+      &pref_service_, kPrefName, kPeriodDays,
+      /*should_offset_dst=*/false);
+
+  base::Time dst_start;
+  ASSERT_TRUE(base::Time::FromUTCString("2 Oct 2027 15:30:00", &dst_start));
+
+  // Record 30 minutes before the DST transition. This is still October 3
+  // 01:30 LHST, within the midnight of the short day.
+  FastForwardClockTo(dst_start - base::Minutes(30));
+  time_period_storage_->AddDelta(1);
+
+  // Record one second after October 4 midnight in LHDT (October 3 13:00:01
+  // UTC). Only 23 hours, 30 minutes, and 1 second separate the two midnights.
+  // A naive +24h calculation would overshoot the next midnight by 30 minutes.
+  FastForwardClockTo(dst_start + base::Hours(21) + base::Minutes(30) +
+                     base::Seconds(1));
+  time_period_storage_->AddDelta(1);
+
+  EXPECT_EQ(base::test::ParseJson(R"JSON([
+      {  // October 4 00:00 LHDT (October 3 13:00 UTC)
+        "day": 1822568400.0,
+        "value": 1.0
+      },
+      {  // October 3 00:00 LHST (October 2 13:30 UTC)
+        "day": 1822483800.0,
+        "value": 1.0
+      }
+    ])JSON"),
+            pref_service_.GetValue(kPrefName));
+  EXPECT_EQ(2U, time_period_storage_->GetPeriodSum());
+}
+
+TEST_F(TimePeriodStorageIssue54427Test,
+       NewDailyBucketIsCreatedOneSecondAfterMidnightOnDayAfterDSTEnd) {
+  const ScopedTimezoneForTesting scoped_timezone("Europe/Berlin");
+  time_period_storage_ = std::make_unique<TimePeriodStorage>(
+      &pref_service_, kPrefName, kPeriodDays,
+      /*should_offset_dst=*/false);
+
+  // DST ends in Europe/Berlin at 31 October 2027 01:00:00 UTC.
+  // Clocks move back from 03:00 CEST to 02:00 CET.
+  base::Time dst_end;
+  ASSERT_TRUE(base::Time::FromUTCString("31 Oct 2027 01:00:00", &dst_end));
+
+  // Record one second before the DST transition: October 31 00:00 CEST
+  // (October 30 22:00 UTC).
+  FastForwardClockTo(dst_end - base::Seconds(1));
+  time_period_storage_->AddDelta(1);
+
+  // Record one second after November 1 midnight in CET
+  // (October 31 23:00:01 UTC). Because DST ends, the gap between
+  // the two local midnights is 25 hours. A naive +24h calculation
+  // would land an hour too early.
+  FastForwardClockTo(dst_end + base::Hours(22) + base::Seconds(1));
+  time_period_storage_->AddDelta(1);
+
+  EXPECT_EQ(base::test::ParseJson(R"JSON([
+      {  // November 1 00:00 CET (October 31 23:00 UTC)
+        "day": 1825023600.0,
+        "value": 1.0
+      },
+      {  // October 31 00:00 CEST (October 30 22:00 UTC)
+        "day": 1824933600.0,
+        "value": 1.0
+      }
+    ])JSON"),
+            pref_service_.GetValue(kPrefName));
+  EXPECT_EQ(2U, time_period_storage_->GetPeriodSum());
+}
+
+TEST_F(TimePeriodStorageIssue54427Test,
+       EachDayFromCETThroughCESTAndBackToCETHasItsOwnBucket) {
+  // In Europe/Berlin, DST starts at 01:00 UTC on 28 March 2027 and ends at
+  // 01:00 UTC on 31 October 2027. That covers 217 calendar days.
+  const ScopedTimezoneForTesting scoped_timezone("Europe/Berlin");
+  time_period_storage_ = std::make_unique<TimePeriodStorage>(
+      &pref_service_, kPrefName, kPeriodDays,
+      /*should_offset_dst=*/false);
+
+  base::Time dst_start;
+  ASSERT_TRUE(base::Time::FromUTCString("28 Mar 2027 01:00:00", &dst_start));
+  base::Time dst_end;
+  ASSERT_TRUE(base::Time::FromUTCString("31 Oct 2027 01:00:00", &dst_end));
+
+  // Record activity at March 28 midnight in CET, two hours before DST starts.
+  FastForwardClockTo(dst_start - base::Hours(2));
+  time_period_storage_->AddDelta(1);
+
+  // Advance one day at a time through the full CEST period and two days after
+  // it. Each local calendar day should get its own bucket with value 1.
+  while (base::Time::Now() < dst_end + base::Days(2)) {
+    task_environment_.AdvanceClock(base::Days(1));
+    time_period_storage_->AddDelta(1);
+  }
+
+  // The loop ends late on November 2 after 220 daily steps. The 7 day window
+  // crosses the DST change on October 31, when local midnight shifts by one
+  // hour. Because of that, the gap between those two midnights is 25 hours.
+  // GetPeriodSum() returns 6 rather than 7: the October 28 CEST bucket is at
+  // October 27 22:00 UTC, one hour before the window start at October 27
+  // 23:00 UTC (CET midnight minus 6 days). With should_offset_dst=false the
+  // DST offset is not applied to the window boundary, so that bucket falls
+  // outside.
+  EXPECT_EQ(base::test::ParseJson(R"JSON([
+      {  // November 3 00:00 CET (November 2 23:00 UTC)
+        "day": 1825196400.0,
+        "value": 1.0
+      },
+      {  // November 2 00:00 CET (November 1 23:00 UTC)
+        "day": 1825110000.0,
+        "value": 1.0
+      },
+      {  // November 1 00:00 CET (October 31 23:00 UTC)
+        // This bucket is 25 hours after the previous one.
+        "day": 1825023600.0,
+        "value": 1.0
+      },
+      {  // October 31 00:00 CEST (October 30 22:00 UTC)
+        "day": 1824933600.0,
+        "value": 1.0
+      },
+      {  // October 30 00:00 CEST (October 29 22:00 UTC)
+        "day": 1824847200.0,
+        "value": 1.0
+      },
+      {  // October 29 00:00 CEST (October 28 22:00 UTC)
+        "day": 1824760800.0,
+        "value": 1.0
+      },
+      {  // October 28 00:00 CEST (October 27 22:00 UTC)
+        "day": 1824674400.0,
+        "value": 1.0
+      }
+    ])JSON"),
+            pref_service_.GetValue(kPrefName));
+  EXPECT_EQ(6U, time_period_storage_->GetPeriodSum());
+}
+
+TEST_F(TimePeriodStorageIssue54427Test,
+       EachDayInFixedOffsetTimezoneHasItsOwnBucket) {
+  // Asia/Tokyo stays on UTC+9 all year, so every local day is exactly 24 hours.
+  const ScopedTimezoneForTesting scoped_timezone("Asia/Tokyo");
+  time_period_storage_ = std::make_unique<TimePeriodStorage>(
+      &pref_service_, kPrefName, kPeriodDays,
+      /*should_offset_dst=*/false);
+
+  base::Time january_1;
+  ASSERT_TRUE(base::Time::FromUTCString("1 Jan 2027 00:00:00", &january_1));
+  FastForwardClockTo(january_1);
+
+  // Record activity for `kPeriodDays + 2` consecutive days and verify that each
+  // day's activity lands in its own bucket.
+  for (size_t day = 0; day < kPeriodDays + 2; ++day) {
+    if (day > 0) {
+      task_environment_.AdvanceClock(base::Days(1));
+    }
+    time_period_storage_->AddDelta(1);
+  }
+
+  // Recording more than `kPeriodDays` entries pushes the two oldest days out
+  // of the rolling window.
+  EXPECT_EQ(base::test::ParseJson(R"JSON([
+      {  // January 9 00:00 JST (January 8 15:00 UTC)
+        "day": 1799420400.0,
+        "value": 1.0
+      },
+      {  // January 8 00:00 JST (January 7 15:00 UTC)
+        "day": 1799334000.0,
+        "value": 1.0
+      },
+      {  // January 7 00:00 JST (January 6 15:00 UTC)
+        "day": 1799247600.0,
+        "value": 1.0
+      },
+      {  // January 6 00:00 JST (January 5 15:00 UTC)
+        "day": 1799161200.0,
+        "value": 1.0
+      },
+      {  // January 5 00:00 JST (January 4 15:00 UTC)
+        "day": 1799074800.0,
+        "value": 1.0
+      },
+      {  // January 4 00:00 JST (January 3 15:00 UTC)
+        "day": 1798988400.0,
+        "value": 1.0
+      },
+      {  // January 3 00:00 JST (January 2 15:00 UTC)
+        "day": 1798902000.0,
+        "value": 1.0
+      }
+    ])JSON"),
+            pref_service_.GetValue(kPrefName));
+  EXPECT_EQ(7U, time_period_storage_->GetPeriodSum());
+}
+
+TEST_F(TimePeriodStorageIssue54427Test,
+       EastToWestTravelCreatesCorrectDailyBuckets) {
+  // Simulates travel from Auckland to Los Angeles, a 20-hour westward shift.
+  // Each entry must land in the correct bucket for the local timezone.
+
+  // October 10 04:00 NZDT (October 9 15:00 UTC).
+  base::Time october_10_nzdt;
+  ASSERT_TRUE(
+      base::Time::FromUTCString("9 Oct 2027 15:00:00", &october_10_nzdt));
+  FastForwardClockTo(october_10_nzdt);
+
+  const ScopedTimezoneForTesting scoped_auckland_timezone("Pacific/Auckland");
+  time_period_storage_ = std::make_unique<TimePeriodStorage>(
+      &pref_service_, kPrefName, kPeriodDays,
+      /*should_offset_dst=*/false);
+
+  // In Auckland. Bucket is October 10 00:00 NZDT (October 9 11:00 UTC).
+  time_period_storage_->AddDelta(1);
+
+  {
+    const ScopedTimezoneForTesting scoped_los_angeles_timezone(
+        "America/Los_Angeles");
+    // Arriving in Los Angeles after advancing 24 hours. Bucket is October 10
+    // 00:00 PDT (October 10 07:00 UTC).
+    task_environment_.AdvanceClock(base::Days(1));
+    time_period_storage_->AddDelta(1);
+  }  // Returning to Auckland.
+
+  EXPECT_EQ(1U, time_period_storage_->GetHighestValueInPeriod());
+  EXPECT_EQ(2U, time_period_storage_->GetPeriodSum());
+}
+
+TEST_F(TimePeriodStorageIssue54427Test,
+       WestToEastTravelCreatesCorrectDailyBuckets) {
+  // Simulates travel from Los Angeles to Auckland, a 20-hour eastward shift.
+  // Each entry must land in the correct bucket for the local timezone.
+
+  // October 9 13:00 PDT (October 9 20:00 UTC).
+  base::Time october_9_pdt;
+  ASSERT_TRUE(base::Time::FromUTCString("9 Oct 2027 20:00:00", &october_9_pdt));
+  FastForwardClockTo(october_9_pdt);
+
+  const ScopedTimezoneForTesting scoped_los_angeles_timezone(
+      "America/Los_Angeles");
+  time_period_storage_ = std::make_unique<TimePeriodStorage>(
+      &pref_service_, kPrefName, kPeriodDays,
+      /*should_offset_dst=*/false);
+
+  // In Los Angeles. Bucket is October 9 00:00 PDT (October 9 07:00 UTC).
+  time_period_storage_->AddDelta(1);
+
+  {
+    const ScopedTimezoneForTesting scoped_auckland_timezone("Pacific/Auckland");
+    // Arriving in Auckland after advancing 24 hours. Bucket is October 11
+    // 00:00 NZDT (October 10 11:00 UTC).
+    task_environment_.AdvanceClock(base::Days(1));
+    time_period_storage_->AddDelta(1);
+  }  // Returning to Los Angeles.
+
+  EXPECT_EQ(1U, time_period_storage_->GetHighestValueInPeriod());
+  EXPECT_EQ(2U, time_period_storage_->GetPeriodSum());
+}


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/35463
Resolves https://github.com/brave/brave-browser/issues/54427

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.