### PR TITLE
[Android] Site Settings should work the same for any Containment option

### DIFF
--- a/android/javatests/org/chromium/chrome/browser/site_settings/BraveSiteSettingsTest.java
+++ b/android/javatests/org/chromium/chrome/browser/site_settings/BraveSiteSettingsTest.java
@@ -14,6 +14,9 @@ import org.junit.runner.RunWith;
 
 import org.chromium.base.test.util.Batch;
 import org.chromium.base.test.util.Feature;
+import org.chromium.base.test.util.Features.DisableFeatures;
+import org.chromium.base.test.util.Features.EnableFeatures;
+import org.chromium.chrome.browser.flags.ChromeFeatureList;
 import org.chromium.chrome.browser.settings.SettingsActivity;
 import org.chromium.chrome.test.ChromeJUnit4ClassRunner;
 import org.chromium.components.browser_ui.site_settings.SiteSettings;
@@ -32,6 +35,7 @@ public class BraveSiteSettingsTest {
     @Test
     @SmallTest
     @Feature({"Preferences"})
+    @DisableFeatures(ChromeFeatureList.ANDROID_SETTINGS_CONTAINMENT)
     public void testSiteSettingsMenuPermissionAutorevocationOrder() {
         final SettingsActivity settingsActivity = SiteSettingsTestUtils.startSiteSettingsMenu("");
         SiteSettings siteSettings = (SiteSettings) settingsActivity.getMainFragment();
@@ -47,6 +51,26 @@ public class BraveSiteSettingsTest {
         Assert.assertEquals(prefSolanaConnectedSites.getOrder(), prefDivider.getOrder() - 1);
         Assert.assertEquals(
                 prefSolanaConnectedSites.getOrder(), prefPermissionAutorevocation.getOrder() - 2);
+        settingsActivity.finish();
+    }
+
+    /** The same but with `Android Settings Containment` flag enabled */
+    @Test
+    @SmallTest
+    @Feature({"Preferences"})
+    @EnableFeatures(ChromeFeatureList.ANDROID_SETTINGS_CONTAINMENT)
+    public void testSiteSettingsMenuPermissionAutorevocationOrderWithContainment() {
+        final SettingsActivity settingsActivity = SiteSettingsTestUtils.startSiteSettingsMenu("");
+        SiteSettings siteSettings = (SiteSettings) settingsActivity.getMainFragment();
+        Assert.assertNotNull(siteSettings);
+        Preference prefPermissionAutorevocation =
+                siteSettings.findPreference(PERMISSION_AUTOREVOCATION_KEY);
+        Assert.assertNotNull(prefPermissionAutorevocation);
+        Preference prefSolanaConnectedSites =
+                siteSettings.findPreference(SOLANA_CONNECTED_SITES_KEY);
+        Assert.assertNotNull(prefSolanaConnectedSites);
+        Assert.assertEquals(
+                prefSolanaConnectedSites.getOrder(), prefPermissionAutorevocation.getOrder() - 1);
         settingsActivity.finish();
     }
 }

--- a/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/BraveSiteSettingsPreferencesBase.java
+++ b/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/BraveSiteSettingsPreferencesBase.java
@@ -82,19 +82,24 @@ public class BraveSiteSettingsPreferencesBase extends BaseSiteSettingsFragment {
         // We want to place these Settings at the bottom.
         // See https://github.com/brave/brave-browser/issues/46547
         // for the context
-        Preference prefDivider = getPreferenceScreen().findPreference(DIVIDER_KEY);
         Preference prefPermissionAutorevocation =
                 getPreferenceScreen().findPreference(PERMISSION_AUTOREVOCATION_KEY);
-        assert prefDivider != null && prefPermissionAutorevocation != null
+        assert prefPermissionAutorevocation != null
                 : "Remove the order adjustment if the prefs are removed from upstream";
-        if (prefDivider != null && prefPermissionAutorevocation != null) {
+        if (prefPermissionAutorevocation != null) {
             Preference prefSolanaConnectedSites =
                     getPreferenceScreen().findPreference(SOLANA_CONNECTED_SITES_KEY);
             // Solana preference may be removed if wallet is disabled by policy.
             if (prefSolanaConnectedSites != null) {
                 int solanaConnectedSitesOrder = prefSolanaConnectedSites.getOrder();
-                prefDivider.setOrder(solanaConnectedSitesOrder + 1);
-                prefPermissionAutorevocation.setOrder(solanaConnectedSitesOrder + 2);
+                Preference prefDivider = getPreferenceScreen().findPreference(DIVIDER_KEY);
+                if (prefDivider == null) {
+                    // There is divider when `Android Settings Containment` flag is turned on
+                    prefPermissionAutorevocation.setOrder(solanaConnectedSitesOrder + 1);
+                } else {
+                    prefDivider.setOrder(solanaConnectedSitesOrder + 1);
+                    prefPermissionAutorevocation.setOrder(solanaConnectedSitesOrder + 2);
+                }
             }
         }
     }


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/54486

Current PR adapts the Site settings for both cases - when `Android Settings Containment` flag is turned off or on.

### Screenshots
`Settings Containment` off|`Settings Containment` on
--|--
<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/b25dc817-f366-446f-bec7-26151384eeef" />|<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/ebbc4182-f03a-4e94-9be2-a25f6f8960dc" />


### Test Plan:
1. Open `Settings` => `Site Settings`
2. Scroll down
3. `Automatically remove permission` should be at the very end
4. Enable `Android Settings Containment` flag, restart
5. Again open `Settings` => `Site Settings`
6. Scroll down
7. `Automatically remove permission` should be at the very end

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
