### PR TITLE
Fix mojo event loss in createInterfaceApi QueryObserver subscribe

### DIFF
--- a/components/common/api/create_interface_api.test.tsx
+++ b/components/common/api/create_interface_api.test.tsx
@@ -960,4 +960,121 @@ describe('createInterfaceApi', () => {
     expect(secondHookResult.result.current.data).toEqual(['5', 5])
     expect(secondHookResult.result.current.hasEmitted).toBe(true)
   })
+
+  it('delivers pre-existing event data to late subscribers', () => {
+    const api = createInterfaceApi({
+      actions: {},
+      endpoints: {},
+      events: {
+        myEvent: event<[], [string, number]>(() => {}),
+      },
+    })
+
+    // Emit event BEFORE any subscriber exists — this is the scenario where
+    // the QueryObserver constructor reads cached data into #currentResult
+    // and .subscribe() skips notification due to shallowEqualObjects.
+    api.emitEvent('myEvent', ['hello', 42])
+
+    // Now subscribe after the event was already emitted
+    const observer = jest.fn()
+    const unsubscribe = api.subscribeToMyEvent(observer)
+
+    // The subscriber should receive the pre-existing data immediately
+    expect(observer).toHaveBeenCalledTimes(1)
+    expect(observer).toHaveBeenCalledWith('hello', 42)
+
+    // Subsequent events should still work normally
+    api.emitEvent('myEvent', ['world', 99])
+    expect(observer).toHaveBeenCalledTimes(2)
+    expect(observer).toHaveBeenLastCalledWith('world', 99)
+
+    unsubscribe()
+  })
+
+  it('delivers pre-existing void event data to late subscribers', () => {
+    const api = createInterfaceApi({
+      actions: {},
+      endpoints: {},
+      events: {
+        myVoidEvent: event<[], []>(() => {}),
+      },
+    })
+
+    // Emit void event before subscriber exists
+    api.emitEvent('myVoidEvent', [])
+
+    const observer = jest.fn()
+    const unsubscribe = api.subscribeToMyVoidEvent(observer)
+
+    // Late subscriber should still be notified of the pre-existing event
+    expect(observer).toHaveBeenCalledTimes(1)
+
+    // Subsequent void events should still work
+    api.emitEvent('myVoidEvent', [])
+    expect(observer).toHaveBeenCalledTimes(2)
+
+    unsubscribe()
+  })
+
+  it('useMyEvent hook receives event emitted before mount', async () => {
+    let emitter: (...args: [string, number]) => void = () => {}
+    const api = createInterfaceApi({
+      actions: {},
+      endpoints: {},
+      events: {
+        myEvent: event<[], [string, number]>((emit) => {
+          emitter = emit
+        }),
+      },
+    })
+
+    // Emit event BEFORE any React component mounts — simulates the scenario
+    // where a Mojo event arrives before useEffect runs (e.g., sidebar open).
+    emitter('pre-mount', 1)
+
+    // Now mount a component that uses useMyEvent
+    const handler = jest.fn()
+    function useMyEventHook() {
+      api.useMyEvent(handler, [])
+    }
+
+    await act(async () => renderHook(useMyEventHook))
+
+    // The handler should have been called with the pre-existing data
+    expect(handler).toHaveBeenCalledTimes(1)
+    expect(handler).toHaveBeenCalledWith('pre-mount', 1)
+
+    // New events after mount should also fire
+    await act(async () => emitter('post-mount', 2))
+    expect(handler).toHaveBeenCalledTimes(2)
+    expect(handler).toHaveBeenLastCalledWith('post-mount', 2)
+  })
+
+  it('does not double-deliver when subscriber is called synchronously', () => {
+    const api = createInterfaceApi({
+      actions: {},
+      endpoints: {},
+      events: {
+        myEvent: event<[], [string, number]>(() => {}),
+      },
+    })
+
+    // Subscribe first, then emit — the normal flow where .subscribe()
+    // callback fires synchronously. Should NOT double-deliver.
+    const observer = jest.fn()
+    const unsubscribe = api.subscribeToMyEvent(observer)
+
+    // No pre-existing event, so nothing should have been called
+    expect(observer).toHaveBeenCalledTimes(0)
+
+    api.emitEvent('myEvent', ['test', 1])
+    expect(observer).toHaveBeenCalledTimes(1)
+    expect(observer).toHaveBeenCalledWith('test', 1)
+
+    api.emitEvent('myEvent', ['test', 2])
+    expect(observer).toHaveBeenCalledTimes(2)
+    expect(observer).toHaveBeenLastCalledWith('test', 2)
+
+    unsubscribe()
+  })
 })

--- a/components/common/api/create_interface_api.ts
+++ b/components/common/api/create_interface_api.ts
@@ -799,7 +799,15 @@ export function createInterfaceApi<
           ),
       })
 
+      // Track whether the subscribe callback fires synchronously during
+      // .subscribe(). The QueryObserver constructor already reads cached
+      // data into #currentResult, so onSubscribe → updateResult() may find
+      // no change via shallowEqualObjects and skip notifying the listener.
+      // In that case we need to manually deliver the pre-existing data.
+      let handlerCalledOnSubscribe = false
+
       const unsubscribe = observer.subscribe((result) => {
+        handlerCalledOnSubscribe = true
         if (result.data !== undefined) {
           handler(...result.data.payload)
         } else {
@@ -809,6 +817,13 @@ export function createInterfaceApi<
           handler()
         }
       })
+
+      if (!handlerCalledOnSubscribe) {
+        const existingResult = observer.getCurrentResult()
+        if (existingResult.data !== undefined) {
+          handler(...existingResult.data.payload)
+        }
+      }
 
       return unsubscribe
     }


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/54502

## Summary

- Fix a race condition in `createInterfaceApi` where mojo events arriving before React `useEffect` subscribes are silently dropped by Tanstack Query's `QueryObserver` deduplication logic
- After `.subscribe()`, check if the handler was invoked synchronously; if not, manually deliver any pre-existing cached event data

## Root Cause

When a mojo event (e.g., `OnNewDefaultConversation`) fires before the React component mounts and subscribes via `useEffect`, the event data is stored in the Tanstack Query cache by `emitEvent`. However, when the `QueryObserver` is later created in `subscribeToMyEvent`, its constructor eagerly reads the cached data into `#currentResult`. The subsequent `.subscribe()` call triggers `onSubscribe → updateResult()`, which compares the new result against `#currentResult` via `shallowEqualObjects` — finds no change — and **never invokes the listener callback**.

This causes the AI Chat "Current tab contents" button in the attachment menu to fail to appear ~80-90% of the time when `brave://flags/#brave-ai-chat-web-content-association-default` is Disabled, because `defaultTabContentId` is never set in React state.

## Fix

After calling `.subscribe()`, track whether the handler was called synchronously. If it wasn't (the dedup case), check `observer.getCurrentResult()` for pre-existing data and manually invoke the handler. This ensures events that arrived before subscription are always delivered.