### PR TITLE
[iOS][Wallet] Fix .zec/.btc/.ada tx doesn't show to address in pending tx screen (uplift to 1.90.x)

### DIFF
--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Transactions/TransactionHeader.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Transactions/TransactionHeader.swift
@@ -28,9 +28,7 @@ struct TransactionHeader: View {
   var body: some View {
     VStack(spacing: 8) {
       VStack(spacing: 8) {
-        if fromAccountInfo.address == toAccountAddress || toAccountAddress.isEmpty
-          || txCoinType == .btc || txCoinType == .ada || txCoinType == .zec
-        {
+        if fromAccountInfo.address == toAccountAddress || toAccountAddress.isEmpty {
           Blockie(address: fromAccountInfo.blockieSeed)
             .frame(
               width: min(blockieSize, maxBlockieSize),
@@ -40,11 +38,19 @@ struct TransactionHeader: View {
             Text(fromAccountName)
           }
         } else {
-          BlockieGroup(
-            fromAddress: fromAccountInfo.blockieSeed,
-            toAddress: toAccountAddress,
-            size: min(blockieSize, maxBlockieSize)
-          )
+          if txCoinType == .btc || txCoinType == .ada || txCoinType == .zec {
+            Blockie(address: fromAccountInfo.blockieSeed)
+              .frame(
+                width: min(blockieSize, maxBlockieSize),
+                height: min(blockieSize, maxBlockieSize)
+              )
+          } else {
+            BlockieGroup(
+              fromAddress: fromAccountInfo.blockieSeed,
+              toAddress: toAccountAddress,
+              size: min(blockieSize, maxBlockieSize)
+            )
+          }
           Group {
             if sizeCategory.isAccessibilityCategory {
               VStack {


### PR DESCRIPTION
Uplift of #35494
Resolves https://github.com/brave/brave-browser/issues/54476

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.