### PR TITLE
Fix crash when toolbar overflow menu is clicked (uplift to 1.89.x)

### DIFF
--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -1533,6 +1533,7 @@ source_set("browser_tests") {
     defines = [ "HAS_OUT_OF_PROC_TEST_RUNNER" ]
 
     sources = [
+      "brave_browser_actions_browsertest.cc",
       "brave_browser_browsertest.cc",
       "views/frame/brave_system_menu_model_builder_browsertest.cc",
       "window_closing_confirm_browsertest.cc",
@@ -1545,6 +1546,7 @@ source_set("browser_tests") {
       "//chrome/browser/devtools:test_support",
       "//chrome/browser/profiles:profile",
       "//chrome/browser/ui",
+      "//chrome/browser/ui:tab_search_feature",
       "//chrome/browser/ui/browser_window",
       "//chrome/browser/ui/startup",
       "//chrome/test:test_support",
@@ -1554,6 +1556,7 @@ source_set("browser_tests") {
       "//components/optimization_guide/optimization_guide_internals/webui:url_constants",
       "//components/prefs",
       "//content/test:test_support",
+      "//ui/actions",
     ]
 
     if (enable_playlist_webui) {

--- a/browser/ui/brave_browser_actions.cc
+++ b/browser/ui/brave_browser_actions.cc
@@ -17,6 +17,7 @@
 #include "chrome/browser/ui/side_panel/side_panel_action_callback.h"
 #include "chrome/browser/ui/side_panel/side_panel_entry_id.h"
 #include "chrome/browser/ui/side_panel/side_panel_entry_key.h"
+#include "chrome/browser/ui/tab_search_feature.h"
 #include "components/grit/brave_components_strings.h"
 #include "ui/actions/actions.h"
 #include "ui/base/l10n/l10n_util.h"
@@ -58,6 +59,25 @@ BraveBrowserActions::~BraveBrowserActions() = default;
 
 void BraveBrowserActions::InitializeBrowserActions() {
   BrowserActions::InitializeBrowserActions();
+
+  // browser_actions.cc initializes kActionTabSearch as kNotPinnable.
+  // In Brave, HasTabSearchToolbarButton() is always true and the button is
+  // shown via the pinned-actions model, so
+  // ToolbarController::GetDefaultResponsiveElements() must see it as kPinnable
+  // when the toolbar is initialized — otherwise kActionTabSearch is missing
+  // from responsive_elements_ and the overflow menu crashes when clicked if
+  // search buton is the only item in overflow menu.
+  if (features::HasTabSearchToolbarButton()) {
+    auto* tab_search_action = actions::ActionManager::Get().FindAction(
+        kActionTabSearch, root_action_item_.get());
+    if (tab_search_action) {
+      tab_search_action->SetProperty(
+          actions::kActionItemPinnableKey,
+          static_cast<std::underlying_type_t<actions::ActionPinnableState>>(
+              actions::ActionPinnableState::kPinnable));
+    }
+  }
+
   BrowserWindowInterface* const bwi = base::to_address(bwi_);
 
   if (base::FeatureList::IsEnabled(playlist::features::kPlaylist)) {

--- a/browser/ui/brave_browser_actions_browsertest.cc
+++ b/browser/ui/brave_browser_actions_browsertest.cc
@@ -1,0 +1,36 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "chrome/browser/ui/actions/chrome_action_id.h"
+#include "chrome/browser/ui/tab_search_feature.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "content/public/test/browser_test.h"
+#include "ui/actions/actions.h"
+
+using BraveBrowserActionsBrowserTest = InProcessBrowserTest;
+
+// Regression test for https://github.com/brave/brave-browser/issues/54449
+//
+// kActionTabSearch must be kPinnable immediately after InitializeBrowserActions
+// so that ToolbarController::GetDefaultResponsiveElements() includes it in
+// responsive_elements_. Without this, the overflow menu is empty when
+// kActionTabSearch overflows, causing a crash on click.
+IN_PROC_BROWSER_TEST_F(BraveBrowserActionsBrowserTest,
+                       TabSearchActionIsPinnableAfterInit) {
+  ASSERT_TRUE(features::HasTabSearchToolbarButton())
+      << "Tab search toolbar button not enabled";
+
+  auto& action_manager = actions::ActionManager::GetForTesting();
+  auto* tab_search_action = action_manager.FindAction(kActionTabSearch);
+  ASSERT_NE(tab_search_action, nullptr)
+      << "kActionTabSearch not found in ActionManager";
+
+  const actions::ActionPinnableState pinnable_state =
+      static_cast<actions::ActionPinnableState>(
+          tab_search_action->GetProperty(actions::kActionItemPinnableKey));
+  EXPECT_EQ(pinnable_state, actions::ActionPinnableState::kPinnable)
+      << "kActionTabSearch must be kPinnable so ToolbarController includes it "
+         "in responsive_elements_";
+}


### PR DESCRIPTION
Uplift of #35477
Resolves https://github.com/brave/brave-browser/issues/54449

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.