### PR TITLE
Update sidebar item state with sidebar v2

### DIFF
--- a/browser/ui/sidebar/sidebar_browsertest.cc
+++ b/browser/ui/sidebar/sidebar_browsertest.cc
@@ -2067,6 +2067,65 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, SidebarV2PanelPositionTest) {
       << "sidebar=" << sidebar->bounds().ToString()
       << " panel=" << panel->bounds().ToString();
 }
+
+// Verify that the sidebar item active state in SidebarModel is updated:
+// - When clicking a panel item via the sidebar UI.
+// - When the side panel is opened or closed via the side panel UI directly
+//   (e.g. toolbar toggle button), which bypasses SidebarController.
+//   In V1, SidebarContainerView monitors panel show/hide events and asks
+//   SidebarController to update the active state. In V2,
+//   SidebarContainerView does not do that, so BraveSidePanelCoordinator
+//   handles it in Show() and Close().
+IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, SidebarV2ActiveItemStateSync) {
+  auto* panel_ui = browser()->GetFeatures().side_panel_ui();
+  panel_ui->DisableAnimationsForTesting();
+
+  auto bookmark_item_index =
+      model()->GetIndexOf(SidebarItem::BuiltInItemType::kBookmarks);
+  ASSERT_TRUE(bookmark_item_index.has_value());
+
+  // Initially no item is active.
+  EXPECT_FALSE(model()->active_index());
+
+  // Clicking a panel item via the sidebar UI activates it in the model.
+  SimulateSidebarItemClickAt(*bookmark_item_index);
+  EXPECT_EQ(model()->active_index(), bookmark_item_index);
+
+  // Deactivate by closing the panel.
+  panel_ui->Close(SidePanelEntry::PanelType::kContent);
+  ASSERT_TRUE(base::test::RunUntil(
+      [&]() { return !model()->active_index().has_value(); }));
+
+  // Opening the side panel via the panel UI (e.g. toolbar toggle button path)
+  // also activates the corresponding sidebar item in the model.
+  panel_ui->Show(SidePanelEntryId::kBookmarks);
+  ASSERT_TRUE(base::test::RunUntil(
+      [&]() { return controller()->IsActiveIndex(bookmark_item_index); }));
+
+  // Closing the side panel via the panel UI deactivates the item in the model.
+  panel_ui->Close(SidePanelEntry::PanelType::kContent);
+  ASSERT_TRUE(base::test::RunUntil(
+      [&]() { return !model()->active_index().has_value(); }));
+
+  // Toggling the panel open (as the toolbar button does) activates the
+  // last-used sidebar item in the model.
+  panel_ui->Toggle();
+  ASSERT_TRUE(base::test::RunUntil(
+      [&]() { return controller()->IsActiveIndex(bookmark_item_index); }));
+
+  // Wait for the panel to be fully shown before toggling closed, so that
+  // BraveSidePanelCoordinator::Toggle() sees IsSidePanelShowing() == true
+  // and takes the close branch instead of the show branch.
+  ASSERT_TRUE(base::test::RunUntil([&]() {
+    return panel_ui->IsSidePanelShowing(SidePanelEntry::PanelType::kContent);
+  }));
+
+  // Toggling the panel closed deactivates the item in the model.
+  panel_ui->Toggle();
+  ASSERT_TRUE(base::test::RunUntil(
+      [&]() { return !model()->active_index().has_value(); }));
+}
+
 #endif  // BUILDFLAG(ENABLE_SIDEBAR_V2)
 
 }  // namespace sidebar

--- a/browser/ui/sidebar/sidebar_browsertest.cc
+++ b/browser/ui/sidebar/sidebar_browsertest.cc
@@ -2080,7 +2080,7 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, SidebarV2ActiveItemStateSync) {
   auto* panel_ui = browser()->GetFeatures().side_panel_ui();
   panel_ui->DisableAnimationsForTesting();
 
-  auto bookmark_item_index =
+  const auto bookmark_item_index =
       model()->GetIndexOf(SidebarItem::BuiltInItemType::kBookmarks);
   ASSERT_TRUE(bookmark_item_index.has_value());
 

--- a/browser/ui/views/side_panel/brave_side_panel_coordinator.cc
+++ b/browser/ui/views/side_panel/brave_side_panel_coordinator.cc
@@ -13,6 +13,8 @@
 #include "base/debug/crash_logging.h"
 #include "base/debug/dump_without_crashing.h"
 #include "base/logging.h"
+#include "brave/browser/ui/sidebar/buildflags/buildflags.h"
+#include "brave/browser/ui/sidebar/sidebar_controller.h"
 #include "brave/browser/ui/sidebar/sidebar_service_factory.h"
 #include "brave/browser/ui/sidebar/sidebar_utils.h"
 #include "brave/browser/ui/views/frame/brave_browser_view.h"
@@ -22,6 +24,7 @@
 #include "brave/components/sidebar/browser/sidebar_service.h"
 #include "brave/grit/brave_generated_resources.h"
 #include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/ui/browser_window/public/browser_window_features.h"
 #include "chrome/browser/ui/side_panel/side_panel_entry.h"
 
 namespace {
@@ -47,6 +50,35 @@ void BraveSidePanelCoordinator::Show(
                                 entry.key.id());
 
   SidePanelCoordinator::Show(entry, open_trigger, suppress_animations);
+
+#if BUILDFLAG(ENABLE_SIDEBAR_V2)
+  // In sidebar v1, SidebarContainerView monitors panel show/hide events and
+  // asks SidebarController to update the active item state. In sidebar v2,
+  // SidebarContainerView does not monitor panel state, so the coordinator
+  // must update it directly here.
+  browser_view_->browser()
+      ->GetFeatures()
+      .sidebar_controller()
+      ->UpdateActiveItemState(
+          sidebar::BuiltInItemTypeFromSidePanelId(entry.key.id()));
+#endif
+}
+
+void BraveSidePanelCoordinator::Close(SidePanelEntry::PanelType panel_type,
+                                      SidePanelEntryHideReason hide_reason,
+                                      bool suppress_animations) {
+#if BUILDFLAG(ENABLE_SIDEBAR_V2)
+  // Same as Show(): sidebar v2 does not rely on SidebarContainerView to
+  // propagate panel close events, so clear the active item state here.
+  if (panel_type == SidePanelEntry::PanelType::kContent) {
+    browser_view_->browser()
+        ->GetFeatures()
+        .sidebar_controller()
+        ->UpdateActiveItemState();
+  }
+#endif
+
+  SidePanelCoordinator::Close(panel_type, hide_reason, suppress_animations);
 }
 
 void BraveSidePanelCoordinator::OnActiveTabChanged(
@@ -67,7 +99,7 @@ void BraveSidePanelCoordinator::OnActiveTabChanged(
 void BraveSidePanelCoordinator::Toggle() {
   if (IsSidePanelShowing(SidePanelEntry::PanelType::kContent) &&
       !browser_view_->contents_height_side_panel()->IsClosing()) {
-    Close(SidePanelEntry::PanelType::kContent);
+    SidePanelCoordinator::Close(SidePanelEntry::PanelType::kContent);
   } else if (const auto key = GetLastActiveEntryKey()) {
     SidePanelUIBase::Show(*key, SidePanelOpenTrigger::kToolbarButton);
   }

--- a/browser/ui/views/side_panel/brave_side_panel_coordinator.cc
+++ b/browser/ui/views/side_panel/brave_side_panel_coordinator.cc
@@ -56,6 +56,7 @@ void BraveSidePanelCoordinator::Show(
   // asks SidebarController to update the active item state. In sidebar v2,
   // SidebarContainerView does not monitor panel state, so the coordinator
   // must update it directly here.
+  CHECK(browser_view_->browser()->GetFeatures().sidebar_controller());
   browser_view_->browser()
       ->GetFeatures()
       .sidebar_controller()
@@ -70,6 +71,7 @@ void BraveSidePanelCoordinator::Close(SidePanelEntry::PanelType panel_type,
 #if BUILDFLAG(ENABLE_SIDEBAR_V2)
   // Same as Show(): sidebar v2 does not rely on SidebarContainerView to
   // propagate panel close events, so clear the active item state here.
+  CHECK(browser_view_->browser()->GetFeatures().sidebar_controller());
   if (panel_type == SidePanelEntry::PanelType::kContent) {
     browser_view_->browser()
         ->GetFeatures()

--- a/browser/ui/views/side_panel/brave_side_panel_coordinator.h
+++ b/browser/ui/views/side_panel/brave_side_panel_coordinator.h
@@ -28,6 +28,9 @@ class BraveSidePanelCoordinator : public SidePanelCoordinator {
   void Show(const UniqueKey& entry,
             std::optional<SidePanelOpenTrigger> open_trigger,
             bool suppress_animations) override;
+  void Close(SidePanelEntry::PanelType panel_type,
+             SidePanelEntryHideReason hide_reason,
+             bool suppress_animations) override;
   void OnActiveTabChanged(content::WebContents* old_contents,
                           content::WebContents* new_contents,
                           bool tab_removed_for_deletion) override;


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/54274

In sidebar v1, SidebarContainerView observes panel show/hide events and propagates
them to SidebarController to keep the active item state in sync.
In sidebar v2, SidebarContainerView no longer monitors panel state, so that sync was missing.

Fix by overriding Show() and Close() in BraveSidePanelCoordinator and calling
SidebarController::UpdateActiveItemState() there under BUILDFLAG(ENABLE_SIDEBAR_V2).
This covers all show/close paths since every panel open/close flows through these
two methods in the coordinator.

TEST=SidebarBrowserTest.SidebarV2ActiveItemStateSync

[Screencast from 2026-04-15 13-23-38.webm](https://github.com/user-attachments/assets/76b52803-dca9-4bb7-945b-cf09b3882cc3)


<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
