### PR TITLE
Containers render view context menu adjustments

### DIFF
--- a/app/brave_generated_resources.grd
+++ b/app/brave_generated_resources.grd
@@ -950,6 +950,9 @@ Or change later at <ph name="SETTINGS_EXTENIONS_LINK">$2<ex>brave://settings/ext
         <message name="IDS_CXMENU_OPEN_IN_CONTAINER" desc="The label of the 'Open in Container' context menu item">
           Open in container
         </message>
+        <message name="IDS_CXMENU_OPEN_LINK_IN_CONTAINER" desc="The label of the 'Open link in container' context menu item">
+          Open link in container
+        </message>
         <message name="IDS_CXMENU_OPEN_CONTAINERS_SETTINGS" desc="The label of the context menu item for opening the Containers settings page.">
           Manage containers
         </message>
@@ -984,6 +987,9 @@ Or change later at <ph name="SETTINGS_EXTENIONS_LINK">$2<ex>brave://settings/ext
         </message>
         <message name="IDS_CXMENU_OPEN_IN_CONTAINER" desc="The label of the 'Open in Container' context menu item">
           Open in Container
+        </message>
+        <message name="IDS_CXMENU_OPEN_LINK_IN_CONTAINER" desc="The label of the 'Open link in container' context menu item">
+          Open Link in Container
         </message>
         <message name="IDS_CXMENU_OPEN_CONTAINERS_SETTINGS" desc="The label of the tab context menu item for opening the Containers settings page.">
           Manage Containers

--- a/chromium_src/chrome/browser/renderer_context_menu/render_view_context_menu.cc
+++ b/chromium_src/chrome/browser/renderer_context_menu/render_view_context_menu.cc
@@ -8,6 +8,7 @@
 #include <optional>
 
 #include "base/check.h"
+#include "base/check_is_test.h"
 #include "base/containers/fixed_flat_map.h"
 #include "base/containers/fixed_flat_set.h"
 #include "base/feature_list.h"
@@ -652,7 +653,10 @@ float RenderViewContextMenu::GetScaleFactor() {
   auto* render_frame_host = GetRenderFrameHost();
   CHECK(render_frame_host);
   auto* render_view = render_frame_host->GetView();
-  CHECK(render_view);
+  if (!render_view) {
+    CHECK_IS_TEST();
+    return 1.0f;
+  }
   return render_view->GetDeviceScaleFactor();
 }
 #endif  // BUILDFLAG(ENABLE_CONTAINERS)

--- a/chromium_src/chrome/browser/renderer_context_menu/render_view_context_menu.cc
+++ b/chromium_src/chrome/browser/renderer_context_menu/render_view_context_menu.cc
@@ -637,12 +637,26 @@ void RenderViewContextMenu::BuildContainersMenu() {
     return;
   }
 
+  std::optional<size_t> first_separator_index;
+  for (size_t i = 0; i < menu_model_.GetItemCount(); ++i) {
+    if (menu_model_.GetTypeAt(i) == ui::MenuModel::TYPE_SEPARATOR) {
+      first_separator_index = i;
+      break;
+    }
+  }
+
   containers_submenu_model_ =
       std::make_unique<containers::ContainersMenuModel>(*this, *service);
 
-  menu_model_.AddSubMenuWithStringId(IDC_OPEN_IN_CONTAINER,
-                                     IDS_CXMENU_OPEN_IN_CONTAINER,
-                                     containers_submenu_model_.get());
+  if (first_separator_index.has_value()) {
+    menu_model_.InsertSubMenuWithStringIdAt(
+        *first_separator_index, IDC_OPEN_IN_CONTAINER,
+        IDS_CXMENU_OPEN_IN_CONTAINER, containers_submenu_model_.get());
+  } else {
+    menu_model_.AddSubMenuWithStringId(IDC_OPEN_IN_CONTAINER,
+                                       IDS_CXMENU_OPEN_IN_CONTAINER,
+                                       containers_submenu_model_.get());
+  }
 }
 
 Browser* RenderViewContextMenu::GetBrowserToOpenSettings() {

--- a/chromium_src/chrome/browser/renderer_context_menu/render_view_context_menu.cc
+++ b/chromium_src/chrome/browser/renderer_context_menu/render_view_context_menu.cc
@@ -651,10 +651,10 @@ void RenderViewContextMenu::BuildContainersMenu() {
   if (first_separator_index.has_value()) {
     menu_model_.InsertSubMenuWithStringIdAt(
         *first_separator_index, IDC_OPEN_IN_CONTAINER,
-        IDS_CXMENU_OPEN_IN_CONTAINER, containers_submenu_model_.get());
+        IDS_CXMENU_OPEN_LINK_IN_CONTAINER, containers_submenu_model_.get());
   } else {
     menu_model_.AddSubMenuWithStringId(IDC_OPEN_IN_CONTAINER,
-                                       IDS_CXMENU_OPEN_IN_CONTAINER,
+                                       IDS_CXMENU_OPEN_LINK_IN_CONTAINER,
                                        containers_submenu_model_.get());
   }
 }


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Changes:

1. Fix unit test crash when containers enabled globally.
2. Move menu item position and adjust text:

| before | after |
|--------|--------|
| <img width="473" height="532" alt="image" src="https://github.com/user-attachments/assets/99e353e0-6557-4430-8a0f-c1e8af268ebc" /> | <img width="458" height="530" alt="image" src="https://github.com/user-attachments/assets/23dae7e9-bffe-4dcd-aba2-7e33ba65248c" /> |

Resolves https://github.com/brave/brave-browser/issues/54513

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
