### PR TITLE
[toolchain] `fetch` the minimum necessary

### DIFF
--- a/tools/rust/build_rust_toolchain_standalone.py
+++ b/tools/rust/build_rust_toolchain_standalone.py
@@ -438,7 +438,11 @@ class ToolchainBuilder:
         self._bootstrap_depot_tools()
 
         self.chromium_src.parent.mkdir(parents=True, exist_ok=True)
-        _check_call('fetch', 'chromium', cwd=self.chromium_src.parent)
+        _check_call('fetch',
+                    '--nohistory',
+                    '--nohooks',
+                    'chromium',
+                    cwd=self.chromium_src.parent)
 
     def run(self, use_ref: str = None):
         """Execute the full build-and-package pipeline.


### PR DESCRIPTION
This change adds `--nohistory`, and `--nohooks` to `fetch`, to make
cloning Chromium leaner.

Bug: https://github.com/brave/brave-browser/issues/54478
