### PR TITLE
Fix cookies page settings override after upstream 3PCD cleanup

### DIFF
--- a/browser/resources/settings/br/cookies_page.ts
+++ b/browser/resources/settings/br/cookies_page.ts
@@ -15,24 +15,13 @@ import { SettingsCookiesPageElement } from '../privacy_page/cookies_page.js'
 
 RegisterPolymerTemplateModifications({
   'settings-cookies-page': (templateContent) => {
-    const isNot3pcdRedesignEnabledTemplate = templateContent.
-      querySelector(
-        'template[if*="!is3pcdRedesignEnabled_"]'
-      )
-    if (!isNot3pcdRedesignEnabledTemplate) {
+    const generalControls = templateContent.getElementById('generalControls')
+    if (!generalControls) {
       console.error(
-        '[Brave Settings Overrides] Could not find template with ' +
-        'if*=!is3pcdRedesignEnabledTemplate on cookies page.')
+        '[Brave Settings Overrides] Could not find generalControls id ' +
+        'on cookies page.')
     } else {
-      const generalControls = isNot3pcdRedesignEnabledTemplate.content.
-          getElementById('generalControls')
-      if (!generalControls) {
-        console.error(
-          '[Brave Settings Overrides] Could not find generalControls id ' +
-          'on cookies page.')
-      } else {
-        generalControls.setAttribute('hidden', 'true')
-      }
+      generalControls.setAttribute('hidden', 'true')
     }
     const additionalProtections = templateContent.
       getElementById('additionalProtections')

--- a/browser/resources/settings/br/site_settings_page.ts
+++ b/browser/resources/settings/br/site_settings_page.ts
@@ -202,9 +202,21 @@ RegisterPolymerComponentReplacement(
     }
 
     override getAssociatedControlFor(childViewId: string): HTMLElement {
-      // Note: We use the ContentSettingsTypes.XXX as the childViewId and the id to the link for opening it.
-      const maybeChild = this.shadowRoot?.querySelector(`#${childViewId}`) as HTMLElement | null
-      return maybeChild ?? super.getAssociatedControlFor(childViewId)
+      // Link rows for each setting are rendered inside
+      // settings-site-settings-list shadow DOMs, not directly in this page's
+      // shadow root, so we need to search through them.
+      const lists = this.shadowRoot?.querySelectorAll(
+          'settings-site-settings-list')
+      if (lists) {
+        for (const list of lists) {
+          const child = list.shadowRoot?.querySelector(
+              `#${childViewId}`) as HTMLElement | null
+          if (child) {
+            return child
+          }
+        }
+      }
+      return super.getAssociatedControlFor(childViewId)
     }
   }
 )


### PR DESCRIPTION
## Summary
- Fix cookies page settings override after upstream 3PCD cleanup: Chromium removed the `dom-if` template conditioned on `is3pcdRedesignEnabled_` as part of the 3PCD experiment cleanup. The Brave settings override was still trying to find this template to access `#generalControls`, causing a console error on the cookies settings page. The fix finds `#generalControls` directly on `templateContent`, the same way the other elements (`additionalProtections`, `siteDataTrigger`, `doNotTrack`) are already found.
- Fix settings search crash in site settings page: The `getAssociatedControlFor` override was using `querySelector` on the page's shadow root, but list item link rows (e.g. `#autoplay`, `#ethereum`) are rendered inside `settings-site-settings-list` shadow DOMs. The `querySelector` couldn't find them, falling through to the base mixin's `assertNotReached()`. The fix searches through the list components' shadow DOMs instead.

## Test plan
- [ ] Open `brave://settings/cookies` and verify no console errors about `is3pcdRedesignEnabledTemplate`
- [ ] Verify the cookies page renders correctly with the expected Brave customizations
- [ ] Search in `brave://settings` for cookie-related terms and confirm no errors
- [ ] Search in `brave://settings` for site settings items (e.g. "autoplay", "ethereum") and confirm no crash
- [ ] Verify clicking search results for site settings items navigates correctly