### PR TITLE
Fix Origin branded build settings page issues

### DIFF
--- a/browser/resources/settings/br/page_visibility.ts
+++ b/browser/resources/settings/br/page_visibility.ts
@@ -112,7 +112,8 @@ function getPageVisibility () {
     braveTor: !loadTimeData.getBoolean('braveTorDisabledByPolicy') ||
               loadTimeData.getBoolean('shouldExposeElementsForTesting'),
     // </if>
-    origin: loadTimeData.getBoolean('isBraveOriginPurchased'),
+    origin: loadTimeData.getBoolean('isBraveOriginPurchased') &&
+            !loadTimeData.getBoolean('isBraveOriginBrandedBuild'),
   }
   // Proxy so we can respond to any other property
   return new Proxy(staticProps, {

--- a/browser/resources/settings/br/settings_main.ts
+++ b/browser/resources/settings/br/settings_main.ts
@@ -144,6 +144,7 @@ RegisterPolymerTemplateModifications({
     // </if>
 
     // Insert the leo page into the view manager
+    // <if expr="enable_ai_chat">
     switcher.appendChild(
       html`
         <template is="dom-if" if="[[showPage_(pageVisibility_.leoAssistant)]]">
@@ -158,6 +159,7 @@ RegisterPolymerTemplateModifications({
           </div>
         </template>
       `)
+    // </if>
 
     // Insert the sync page into the view manager
     switcher.appendChild(


### PR DESCRIPTION
Fix: https://github.com/brave/brave-browser/issues/54531
Fix https://github.com/brave/brave-browser/issues/54530

`Promise.all` was hanging because leoAssistant was undefined and never resolved. But it shouldn't be included at all.  Also the Brave Origin settings item shouldn't show but regressed in some recent PR. 

## Summary
- Hide the Origin settings page in `is_brave_origin_branded` builds, since the browser itself is the Origin product and the page is redundant
- Guard Leo settings page insertion with `enable_ai_chat` build flag to match the existing import guard — when the flag is off, the element class is never registered but the page visibility Proxy defaults missing properties to `true`, causing the unregistered element to be stamped and crash settings search (`searchContents` is `undefined`)

## Test plan
- [ ] In a branded Origin build, verify the Origin settings page does not appear in the settings menu or search results
- [ ] In a branded Origin build, verify the Leo AI page does not appear in the settings menu or search results
- [ ] In a branded Origin build, verify settings search works (type a query, clear it, click menu items)
- [ ] In a regular Brave build with `enable_ai_chat=true`, verify Leo AI settings page still appears and works
- [ ] In a regular Brave build with Leo disabled via admin policy, verify Leo settings page is hidden