### PR TITLE
Disable Chromium's default PDF viewer infobar

### DIFF
--- a/app/feature_defaults_unittest.cc
+++ b/app/feature_defaults_unittest.cc
@@ -166,6 +166,9 @@ TEST(FeatureDefaultsTest, DisabledFeatures) {
       &features::kFewerUpdateConfirmations,
       &features::kShortcutsNotApps,
 #endif
+#if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_MAC)
+      &features::kPdfInfoBar,
+#endif
       &features::kHttpsFirstBalancedMode,
       &features::kIdleDetection,
       &features::kIndigo,

--- a/chromium_src/chrome/browser/ui/ui_features.cc
+++ b/chromium_src/chrome/browser/ui/ui_features.cc
@@ -15,6 +15,10 @@ OVERRIDE_FEATURE_DEFAULT_STATES({{
 #if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_MAC) || BUILDFLAG(IS_LINUX)
     {kFewerUpdateConfirmations, base::FEATURE_DISABLED_BY_DEFAULT},
 #endif
+#if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_MAC)
+    // PDF infobar is only used on Windows and macOS upstream.
+    {kPdfInfoBar, base::FEATURE_DISABLED_BY_DEFAULT},
+#endif
     // TODO(https://github.com/brave/brave-browser/issues/46337): Re-enable
     // scrim views if needed.
     {kTabHoverCardImages, base::FEATURE_DISABLED_BY_DEFAULT},

--- a/test/filters/unit_tests.filter
+++ b/test/filters/unit_tests.filter
@@ -5,6 +5,9 @@
 ## why the filter is required and create an associated tracking issue.
 ##
 
+# Tests assume kPdfInfoBar is enabled; we disable it.
+-PdfInfoBarControllerTest.*
+
 # These tests won't work without TPM hardware
 -TPMMetricsProviderTest.GetMetricsFullName
 -TpmIdentifierTest.TpmTest


### PR DESCRIPTION
For some reason this is happening more on Origin builds, but it can also happen on normal Brave builds.

<img width="1171" height="871" alt="Screenshot 2026-04-15 at 2 28 35 PM" src="https://github.com/user-attachments/assets/f4719114-3ac9-4c0e-871f-76fcf2836cbe" />

## Summary
- Disables the `kPdfInfoBar` feature flag on Windows and macOS
- This Chromium feature prompts users to set Chrome as the default PDF viewer, which is not appropriate for Brave
- The infobar was stacking with the existing default browser infobar on startup (due to an upstream bug in the pin infobar controller not propagating `another_infobar_shown` through the callback chain)

## Test plan
- [ ] Verify the "Set Brave as your default PDF viewer" infobar no longer appears on startup (macOS, Windows)
- [ ] Verify the "Brave isn't your default browser" infobar still works correctly