### PR TITLE
Fix chrome://version favicon race on Origin builds

### DIFF
--- a/build/commands/lib/branding.js
+++ b/build/commands/lib/branding.js
@@ -158,6 +158,22 @@ const update = () => {
         'product_logo_white.png',
       ),
     ])
+    fileMap.add([
+      path.join(
+        braveAppDir,
+        'theme',
+        scale,
+        productLogoSource,
+        'product_logo_16.png',
+      ),
+      path.join(
+        chromeComponentsDir,
+        'resources',
+        scale,
+        'chromium',
+        'favicon_product.png',
+      ),
+    ])
   }
   for (const branding of ['brave', 'brave_origin']) {
     fileMap.add([


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/54529

## Summary
`build/chromium/resources/` bulk-copies a generic Brave lion `favicon_product.png` for all builds. The branding script already overwrites `product_logo.png` and `product_logo_white.png` with Origin variants afterward, but `favicon_product.png` was missed. This caused `chrome://version` (and omnibox suggestions for it) to show the wrong icon on Origin builds.

Fix: on Origin builds, copy `brave_origin/product_logo_16.png` over `favicon_product.png` after the bulk copy, same pattern as the other logos. Non-Origin builds are unaffected.

## Test plan
- [ ] Origin build: `chrome://version` tab shows the Origin icon
- [ ] Non-Origin build: `chrome://version` tab still shows the Brave lion