### PR TITLE
[AI Chat]: Fix parsing of unsupported textDirectives (uplift to 1.90.x)

### DIFF
--- a/components/ai_chat/resources/untrusted_conversation_frame/components/markdown_renderer/remark_directives.test.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/markdown_renderer/remark_directives.test.tsx
@@ -135,6 +135,47 @@ test('directiveComponents has components for all allowed directives', () => {
   })
 })
 
+test('remarkDirectives converts textDirectives to plain text', () => {
+  // remark-directive v4 parses time-like strings (e.g. "12:45") as textDirectives,
+  // causing the ":45" part to be silently dropped. The fix converts all
+  // textDirective nodes back to plain text nodes.
+  const tree: Node = {
+    type: 'root',
+    children: [
+      {
+        type: 'textDirective',
+        name: '45',
+        children: [],
+      },
+    ],
+  }
+
+  const plugin = remarkDirectives()
+  plugin(tree)
+
+  const node = (tree as any).children[0]
+  expect(node.type).toBe('text')
+  expect(node.value).toBe(':45')
+})
+
+test('remarkDirectives converts multiple textDirectives to plain text', () => {
+  const tree: Node = {
+    type: 'root',
+    children: [
+      { type: 'textDirective', name: '45', children: [] },
+      { type: 'textDirective', name: 'foo', children: [] },
+    ],
+  }
+
+  const plugin = remarkDirectives()
+  plugin(tree)
+
+  expect((tree as any).children[0].type).toBe('text')
+  expect((tree as any).children[0].value).toBe(':45')
+  expect((tree as any).children[1].type).toBe('text')
+  expect((tree as any).children[1].value).toBe(':foo')
+})
+
 test('search directive renders something', () => {
   const { container } = render(
     <AssistantResponseContextProvider events={[]}>

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/markdown_renderer/remark_directives.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/markdown_renderer/remark_directives.tsx
@@ -34,6 +34,16 @@ export function remarkDirectives() {
 
       return CONTINUE
     })
+
+    // Unfortunately as of version 4 remark-directive automatically parses all directives (even ones you haven't listed).
+    // https://github.com/remarkjs/remark-directive/issues/19
+    // This means text like 12:45 parses the :45 as a textDirective and hides it.
+    // As a workaround, we just display all textDirectives as text.
+    visit(tree, ['textDirective'], (node) => {
+      node.type = 'text'
+      ;(node as any).value = `:${node.name}`
+      return CONTINUE
+    })
   }
 }
 


### PR DESCRIPTION
Uplift of #35516
Resolves https://github.com/brave/brave-browser/issues/54494

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.