### PR TITLE
Fix webpack config for web-discovery-project

### DIFF
--- a/browser/web_discovery/BUILD.gn
+++ b/browser/web_discovery/BUILD.gn
@@ -56,10 +56,6 @@ source_set("browser_tests") {
 
     sources = []
 
-    if (!is_android) {
-      sources += [ "web_discovery_browsertest.cc" ]
-    }
-
     deps = [
       "//base/test:test_support",
       "//brave/components/constants",
@@ -77,6 +73,15 @@ source_set("browser_tests") {
       "//testing/gmock",
       "//testing/gtest",
     ]
+
+    if (!is_android) {
+      sources += [ "web_discovery_browsertest.cc" ]
+      deps += [
+        "//extensions:test_support",
+        "//extensions/browser",
+        "//extensions/common:common_constants",
+      ]
+    }
 
     if (enable_web_discovery_native) {
       sources += [ "content_scraper_browsertest.cc" ]

--- a/browser/web_discovery/web_discovery_browsertest.cc
+++ b/browser/web_discovery/web_discovery_browsertest.cc
@@ -6,14 +6,20 @@
 #include "brave/browser/ui/views/infobars/web_discovery_infobar_view.h"
 #include "brave/browser/web_discovery/web_discovery_infobar_delegate.h"
 #include "brave/browser/web_discovery/web_discovery_tab_helper.h"
+#include "brave/components/constants/pref_names.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/tabs/tab_strip_model.h"
 #include "chrome/test/base/in_process_browser_test.h"
 #include "components/infobars/content/content_infobar_manager.h"
 #include "components/infobars/core/infobar_manager.h"
+#include "components/prefs/pref_service.h"
 #include "content/public/browser/web_contents.h"
 #include "content/public/test/browser_test.h"
+#include "extensions/browser/background_script_executor.h"
+#include "extensions/browser/extension_registry.h"
+#include "extensions/common/constants.h"
+#include "extensions/test/extension_background_page_waiter.h"
 #include "testing/gmock/include/gmock/gmock.h"
 
 namespace web_discovery {
@@ -52,6 +58,37 @@ IN_PROC_BROWSER_TEST_F(WebDiscoveryTest, InfobarAddedTest) {
       std::make_unique<WebDiscoveryInfoBarDelegate>(
           browser()->profile()->GetPrefs()));
   EXPECT_EQ(infobar.get(), infobar->content_view_->parent());
+}
+
+// Verifies that the WDP JS module loads without errors in the Brave Extension
+// background page. This catches webpack bundling regressions.
+IN_PROC_BROWSER_TEST_F(WebDiscoveryTest, ExtensionModuleLoads) {
+  browser()->profile()->GetPrefs()->SetBoolean(kWebDiscoveryEnabled, true);
+
+  // Wait for the extension to reload with its background page after the pref
+  // change triggers BraveComponentLoader::UpdateBraveExtension().
+  auto* registry = extensions::ExtensionRegistry::Get(browser()->profile());
+  const auto* extension =
+      registry->enabled_extensions().GetByID(brave_extension_id);
+  ASSERT_TRUE(extension);
+  extensions::ExtensionBackgroundPageWaiter(browser()->profile(), *extension)
+      .WaitForBackgroundOpen();
+
+  // setWDPStartedCallbackForTesting fires immediately if WDP is already
+  // running, or once start() completes.
+  constexpr char kScript[] = R"((async () => {
+    await new Promise(resolve => {
+      window.setWDPStartedCallbackForTesting(() => {
+        chrome.test.sendScriptResult(true);
+        resolve();
+      });
+    });
+  })();)";
+
+  base::Value result = extensions::BackgroundScriptExecutor::ExecuteScript(
+      browser()->profile(), brave_extension_id, kScript,
+      extensions::BackgroundScriptExecutor::ResultCapture::kSendScriptResult);
+  EXPECT_EQ(true, result);
 }
 
 }  // namespace web_discovery

--- a/components/brave_extension/extension/brave_extension/background/webDiscoveryProject.ts
+++ b/components/brave_extension/extension/brave_extension/background/webDiscoveryProject.ts
@@ -6,6 +6,18 @@ export {}
 
 declare let window: any
 
+let wdpStartedCallbackForTesting: (() => void) | undefined
+
+function setWDPStartedCallbackForTesting(callback: () => void) {
+  if (window.WDP !== undefined) {
+    callback()
+    return
+  }
+  wdpStartedCallbackForTesting = callback
+}
+
+window.setWDPStartedCallbackForTesting = setWDPStartedCallbackForTesting
+
 async function startWDP() {
   if (window.WDP === undefined) {
     const wdp = await import('gen/brave/web-discovery-project')
@@ -18,7 +30,13 @@ async function startWDP() {
     return
 
   window.WDP.start()
+
+  if (wdpStartedCallbackForTesting) {
+    wdpStartedCallbackForTesting()
+    wdpStartedCallbackForTesting = undefined
+  }
 }
+
 
 function stopWDP() {
   if (window.WDP === undefined)

--- a/components/webpack/webpack.config.js
+++ b/components/webpack/webpack.config.js
@@ -209,6 +209,13 @@ module.exports = async function (env, argv) {
           test: /\.(ttf|eot|ico|svg|png|jpg|jpeg|gif|webp)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
           loader: 'file-loader'
         },
+        // web-discovery-project is built as CommonJS but may be classified
+        // as ESM by webpack. Force auto-detection for correct CJS handling.
+        {
+          test: /\.js$/,
+          include: /web-discovery-project/,
+          type: 'javascript/auto'
+        },
         // Unfortunately, brave-ui is compiled as a "module" so Webpack5 expects
         // it to provide file extensions (which it does not), so we need to
         // special case it here.


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/54545

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

## Test plan

0. Start with fresh profile
1. Enable WDP
2. Go to `brave://inspect`, click the "inspect" link under the Brave extension
3. Ensure there are no errors in the DevTools console
4. Execute `window.WDP`, ensure it returns an object like so:

<img width="657" height="43" alt="Screenshot-2026-04-15_20-36" src="https://github.com/user-attachments/assets/3aae2fff-1229-4b85-9e1e-2fedcbf41c89" />
