### PR TITLE
[Tree Tabs] Don't access the opener collection if it's not in the same window.

### DIFF
--- a/browser/ui/tabs/brave_tree_tab_strip_collection_delegate.cc
+++ b/browser/ui/tabs/brave_tree_tab_strip_collection_delegate.cc
@@ -302,6 +302,12 @@ BraveTreeTabStripCollectionDelegate::TryAddTabToSameTreeAsOpener(
 
   tabs::TreeTabNodeTabCollection* opener_collection = nullptr;
   if (opener) {
+    // The opener may belong to another Browser (e.g. a PWA / app window) when
+    // opening into this window. It is not under |collection_|, so there is no
+    // valid tree parent in this strip to attach to.
+    if (!collection_->GetIndexOfTabRecursive(opener).has_value()) {
+      return base::unexpected(std::move(tab));
+    }
     opener_collection = static_cast<tabs::TreeTabNodeTabCollection*>(
         GetParentTreeNodeCollectionOfTab(opener));
   } else {

--- a/browser/ui/tabs/test/tree_tabs_browsertest.cc
+++ b/browser/ui/tabs/test/tree_tabs_browsertest.cc
@@ -122,7 +122,11 @@ class TreeTabsBrowserTest : public InProcessBrowserTest {
     return *static_cast<BraveTabStripModel*>(browser()->tab_strip_model());
   }
   tabs::TabStripCollection& tab_strip_collection() {
-    return tab_strip_model().GetTabStripCollectionForTesting();
+    return tab_strip_collection_for_model(&tab_strip_model());
+  }
+  tabs::TabStripCollection& tab_strip_collection_for_model(
+      BraveTabStripModel* model) {
+    return model->GetTabStripCollectionForTesting();
   }
   tabs::UnpinnedTabCollection& unpinned_collection() {
     return *tab_strip_collection().unpinned_collection();
@@ -199,6 +203,48 @@ class TreeTabsBrowserTest : public InProcessBrowserTest {
 
   void SetSplitPinned(split_tabs::SplitTabId split, bool pinned) {
     tab_strip_model().SetSplitPinnedImplForTesting(split, pinned);
+  }
+
+  // Adds a tab to |destination_model| with |opener_window|'s first tab as
+  // opener. The opener lives in a different TabStripModel (popup, app window,
+  // etc.); tree insertion must not assume it belongs to |destination_model|.
+  void ExpectAddTabWithCrossStripOpenerSucceeds(
+      Browser* opener_window,
+      BraveTabStripModel& destination_model) {
+    auto* opener_model =
+        static_cast<BraveTabStripModel*>(opener_window->tab_strip_model());
+    tabs::TabInterface* const opener_tab = opener_model->GetTabAtIndex(0);
+    // None normal window should not have tabs in tree node.
+    ASSERT_NE(opener_tab->GetParentCollection()->type(),
+              tabs::TabCollection::Type::TREE_NODE);
+
+    tabs::TabStripCollection& dest_collection =
+        tab_strip_collection_for_model(&destination_model);
+    tabs::UnpinnedTabCollection& dest_unpinned =
+        *dest_collection.unpinned_collection();
+
+    EXPECT_FALSE(
+        dest_collection.GetIndexOfTabRecursive(opener_tab).has_value());
+
+    const int count_before = destination_model.count();
+    auto new_tab = std::make_unique<tabs::TabModel>(CreateWebContents(),
+                                                    &destination_model);
+    new_tab->set_opener(opener_tab);
+
+    destination_model.AddTab(std::move(new_tab), -1,
+                             ui::PAGE_TRANSITION_AUTO_BOOKMARK, ADD_NONE);
+
+    ASSERT_EQ(destination_model.count(), count_before + 1);
+    tabs::TabInterface* const added =
+        destination_model.GetTabAtIndex(count_before);
+    ASSERT_TRUE(static_cast<tabs::TabModel*>(added)->opener());
+    EXPECT_EQ(static_cast<tabs::TabModel*>(added)->opener(), opener_tab);
+
+    ASSERT_EQ(added->GetParentCollection()->type(),
+              tabs::TabCollection::Type::TREE_NODE);
+    EXPECT_EQ(added->GetParentCollection()->GetParentCollection(),
+              &dest_unpinned);
+    EXPECT_NE(added->GetParentCollection(), opener_tab->GetParentCollection());
   }
 
   void SetUpOnMainThread() override {
@@ -850,6 +896,24 @@ IN_PROC_BROWSER_TEST_F(TreeTabsBrowserTest, AddTabRecursive) {
             tabs::TabCollection::Type::TREE_NODE);
   EXPECT_EQ(added_tab->GetParentCollection()->GetParentCollection(),
             &unpinned_collection());
+}
+
+// Regression: opening into the tabbed browser from a popup or app (PWA-like)
+// window can pass an opener tab that belongs to another TabStripModel.
+// https://github.com/brave/brave-browser/issues/54334
+IN_PROC_BROWSER_TEST_F(TreeTabsBrowserTest,
+                       AddTab_OpenerInPopupWindow_DoesNotCrashAndUsesOwnTree) {
+  Browser* const popup_browser = CreateBrowserForPopup(profile());
+  SetTreeTabsEnabled(true);
+  ExpectAddTabWithCrossStripOpenerSucceeds(popup_browser, tab_strip_model());
+}
+
+IN_PROC_BROWSER_TEST_F(TreeTabsBrowserTest,
+                       AddTab_OpenerInAppWindow_DoesNotCrashAndUsesOwnTree) {
+  Browser* const app_browser =
+      CreateBrowserForApp("TreeTabsOpenerAppBrowserTest", profile());
+  SetTreeTabsEnabled(true);
+  ExpectAddTabWithCrossStripOpenerSucceeds(app_browser, tab_strip_model());
 }
 
 // Mock observer for testing OnTreeTabChanged callback.


### PR DESCRIPTION
When a link is opened from a PWA window, the opener collection is not in the same window. - link can be opened in normal window type from PWA window. In this case, we should not try accessing the opener collection.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/54334

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
