### PR TITLE
Fix right-clicking in contents showing tab strip menu in fullscreen

### DIFF
--- a/browser/ui/views/frame/brave_browser_frame_view_mac.mm
+++ b/browser/ui/views/frame/brave_browser_frame_view_mac.mm
@@ -17,6 +17,7 @@
 #include "chrome/browser/ui/tabs/features.h"
 #include "chrome/browser/ui/view_ids.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
+#include "chrome/browser/ui/views/frame/immersive_mode_controller.h"
 #include "ui/base/hit_test.h"
 #include "ui/gfx/geometry/insets.h"
 #include "ui/gfx/geometry/rect.h"
@@ -129,9 +130,16 @@ int BraveBrowserFrameViewMac::NonClientHitTest(const gfx::Point& point) {
     return HTNOWHERE;
   }
 
-  if (auto res = brave::NonClientHitTest(GetBrowserView(), point);
-      res != HTNOWHERE) {
-    return res;
+  // In immersive fullscreen the toolbar is reparented to a separate overlay
+  // widget, violating brave::NonClientHitTest's precondition that the toolbar
+  // and browser view share the same widget. Skip it while immersive mode is
+  // active.
+  if (!ImmersiveModeController::From(GetBrowserView()->browser())
+           ->IsEnabled()) {
+    if (auto res = brave::NonClientHitTest(GetBrowserView(), point);
+        res != HTNOWHERE) {
+      return res;
+    }
   }
 
   return BrowserFrameViewMac::NonClientHitTest(point);

--- a/browser/ui/views/frame/brave_non_client_hit_test_helper.cc
+++ b/browser/ui/views/frame/brave_non_client_hit_test_helper.cc
@@ -24,6 +24,14 @@ int NonClientHitTest(BrowserView* browser_view,
     return HTNOWHERE;
   }
 
+  // The toolbar must live in the same widget as the browser view to make
+  // this method work properly. If it has been reparented to a different widget
+  // (e.g. overlay_widget_ during macOS immersive fullscreen),
+  // GetHitTestComponent() will convert |point_in_widget| using the wrong
+  // widget's coordinate space, producing spurious HTCAPTION results. Callers
+  // must guard against this before calling NonClientHitTest().
+  CHECK_EQ(browser_view->toolbar()->GetWidget(), browser_view->GetWidget());
+
   int hit_test_result =
       views::GetHitTestComponent(browser_view->toolbar(), point_in_widget);
   if (hit_test_result == HTNOWHERE || hit_test_result == HTCLIENT) {


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/54456
Resolves https://github.com/brave/brave-browser/issues/54493

In immersive fullscreen, the toolbar is reparented to a separate overlay widget.
`brave::NonClientHitTest()` passes the point (in main window coordinates) to
`GetHitTestComponent(toolbar)`, which converts it using the toolbar's widget instead.
Since both widgets share the same screen origin, clicks in the web content area spuriously
match the toolbar bounds and return HTCAPTION. Then, showing the tab strip context menu.

Fix by skipping brave::NonClientHitTest in BraveBrowserFrameViewMac::NonClientHitTest
when immersive mode is active. Add a CHECK in brave::NonClientHitTest to document
the precondition that the toolbar must live in the same widget as the browser view.

We can  skip `brave::NonClientHitTest()` in immersive mode because we added it to make toolbar
draggable. but don't need to drag by grabbing toolar in fullscreen on macOS.

Manual test:
1. Launch with horizontal tab mode
2. Enters fullscreen by clicking green button
3. Check top most area in web contents gives content's context menu

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
