### PR TITLE
[presubmit] Warn on TS error suppressions with no reason

### DIFF
--- a/PRESUBMIT.py
+++ b/PRESUBMIT.py
@@ -52,6 +52,84 @@ def CheckLeoVariables(input_api, output_api):
         return [output_api.PresubmitError(str(err))]
 
 
+def CheckTypeScriptSuppressionsHaveReasons(input_api, output_api):
+    """Checks that @ts-ignore/@ts-expect-error have reasons.
+
+    This check looks for TypeScript suppression annotations (@ts-ignore and
+    @ts-expect-error) are provided with a reason, and if not a warning is
+    emitted.
+
+    This chek also emits an educational warning for uses of @ts-ignore
+    even when a reason is provided, to raise awareness of the differences
+    between @ts-ignore and @ts-expect-error, and help developers choose the
+    right one for their use case. This education warning is only emitted for
+    @ts-ignore, because @ts-ignore has a broader scope than @ts-expect-error.
+    """
+    files_to_check = (
+        r'.+\.js$',
+        r'.+\.ts$',
+        r'.+\.tsx$',
+    )
+    file_filter = lambda f: input_api.FilterSourceFile(
+        f,
+        files_to_check=files_to_check,
+        files_to_skip=input_api.DEFAULT_FILES_TO_SKIP)
+
+    # Match suppression annotations not followed by any non-whitespace reason.
+    missing_reason_pattern = input_api.re.compile(
+        r'//\s*@ts-(ignore|expect-error)(?!-)\s*$')
+    ts_ignore_pattern = input_api.re.compile(r'//\s*@ts-ignore(?!-)\b')
+
+    missing_reason_problems = []
+    ts_ignore_with_reason_items = []
+    for f in input_api.AffectedFiles(file_filter=file_filter,
+                                     include_deletes=False):
+        for line_num, line in f.ChangedContents():
+            line_item = f'{f.LocalPath()}:{line_num}: {line.strip()}'
+            if missing_reason_pattern.search(line):
+                missing_reason_problems.append(line_item)
+                continue
+
+            # Emit educational guidance for @ts-ignore only when a reason
+            # exists.
+            if ts_ignore_pattern.search(line):
+                ts_ignore_with_reason_items.append(line_item)
+
+    results = []
+    if missing_reason_problems:
+        results.append(
+            output_api.PresubmitPromptWarning(
+                'TypeScript suppression annotations (@ts-ignore, '
+                '@ts-expect-error) must be followed by a '
+                'reason explaining the suppression.\n'
+                'Example: // @ts-expect-error: This will be fixed in v148.',
+                items=missing_reason_problems,
+                long_text=(
+                    'Prefer @ts-expect-error over @ts-ignore when the '
+                    'suppression is intended to be temporary, or when you '
+                    'want TypeScript to alert you if the suppression is no '
+                    'longer needed.\n'
+                    'If you intend to remove the suppression and fix the '
+                    'underlying issue later, add a TODO comment line to track '
+                    'follow-up work.\n')))
+
+    if ts_ignore_with_reason_items:
+        results.append(
+            output_api.PresubmitPromptWarning(
+                'Educational guideline for @ts-ignore usage.',
+                items=ts_ignore_with_reason_items,
+                long_text=(
+                    '@ts-ignore always suppresses the error even if it '
+                    'disappears later, whilst @ts-expect-error provides an '
+                    'alert if no error occurs. Therefore, @ts-expect-error is '
+                    'often a better fit for temporary suppressions, or even '
+                    'for permanent suppression where it is important to be '
+                    'aware about changes on the underlying assumptions that '
+                    'made the suppression necessary. The use of @ts-ignore is '
+                    'allowed when appropriate though.')))
+
+    return results
+
 # Check and fix formatting issues (supports --fix).
 def CheckPatchFormatted(input_api, output_api):
     cmd = [

--- a/PRESUBMIT_test.py
+++ b/PRESUBMIT_test.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from pathlib import PurePath
+import sys
+import unittest
+
+# Append paths needed to import presubmit modules and shared test mocks.
+BRAVE_PATH = PurePath(__file__).parent
+CHROMIUM_SRC_PATH = BRAVE_PATH.parent
+sys.path.append(str(BRAVE_PATH / 'script'))
+sys.path.append(str(CHROMIUM_SRC_PATH))
+
+import PRESUBMIT
+
+from PRESUBMIT_test_mocks import MockAffectedFile
+from PRESUBMIT_test_mocks import MockInputApi, MockOutputApi
+
+
+class CheckTypeScriptSuppressionsHaveReasonsTest(unittest.TestCase):
+
+    def testFlagsSuppressionsWithoutReason(self):
+        input_api = MockInputApi()
+        input_api.files = [
+            MockAffectedFile('brave/foo.ts', ['// @ts-expect-error']),
+            MockAffectedFile('brave/bar.tsx', ['// @ts-ignore']),
+        ]
+
+        errors = PRESUBMIT.CheckTypeScriptSuppressionsHaveReasons(
+            input_api, MockOutputApi())
+
+        self.assertEqual(1, len(errors))
+        self.assertEqual(2, len(errors[0].items))
+        self.assertIn('brave/foo.ts:1: // @ts-expect-error', errors[0].items)
+        self.assertIn('brave/bar.tsx:1: // @ts-ignore', errors[0].items)
+
+    def testAllowsSuppressionsWithReason(self):
+        input_api = MockInputApi()
+        input_api.files = [
+            MockAffectedFile(
+                'brave/foo.ts',
+                ['// @ts-expect-error: This will be fixed in v148.']),
+        ]
+
+        errors = PRESUBMIT.CheckTypeScriptSuppressionsHaveReasons(
+            input_api, MockOutputApi())
+
+        self.assertEqual(0, len(errors))
+
+    def testWarnsForTsIgnoreWithReason(self):
+        input_api = MockInputApi()
+        input_api.files = [
+            MockAffectedFile(
+                'brave/bar.tsx',
+                ['// @ts-ignore because upstream typing is incorrect']),
+        ]
+
+        errors = PRESUBMIT.CheckTypeScriptSuppressionsHaveReasons(
+            input_api, MockOutputApi())
+
+        self.assertEqual(1, len(errors))
+        self.assertIn('Educational guideline for @ts-ignore usage.',
+                      errors[0].message)
+        self.assertEqual(1, len(errors[0].items))
+        self.assertIn(
+            'brave/bar.tsx:1: // @ts-ignore because upstream typing is '
+            'incorrect', errors[0].items)
+
+    def testIgnoresNonTargetExtensions(self):
+        input_api = MockInputApi()
+        input_api.files = [
+            MockAffectedFile('brave/foo.jsx', ['// @ts-expect-error']),
+        ]
+
+        errors = PRESUBMIT.CheckTypeScriptSuppressionsHaveReasons(
+            input_api, MockOutputApi())
+
+        self.assertEqual(0, len(errors))
+
+    def testIgnoresUnknownTsSuppressionAnnotations(self):
+        input_api = MockInputApi()
+        input_api.files = [
+            MockAffectedFile('brave/foo.ts', ['// @ts-ignore-error']),
+        ]
+
+        errors = PRESUBMIT.CheckTypeScriptSuppressionsHaveReasons(
+            input_api, MockOutputApi())
+
+        self.assertEqual(0, len(errors))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR adds a presubmit check to require authors to provide a reason
for using suppresion tags for the TS compiler, these being:

- `@ts-ignore`: Suppresses the error on the next line.
- `@ts-expect-error`: Suppresses the error, but alerts if not error.

Additionally, and educational warning is being added to make sure that
authors consider the use `@ts-expect-error` when appropriate, as
`@ts-ignore` is more permissive, and can become quietly obsolete.

Resolves https://github.com/brave/brave-browser/issues/54575
