### PR TITLE
Remove Switch to Brave Search banners for Brave Origin

### DIFF
--- a/components/brave_search/browser/brave_search_default_host_unittest.cc
+++ b/components/brave_search/browser/brave_search_default_host_unittest.cc
@@ -18,6 +18,7 @@
 #include "base/test/scoped_feature_list.h"
 #include "base/test/task_environment.h"
 #include "base/time/time.h"
+#include "brave/components/brave_origin/buildflags/buildflags.h"
 #include "brave/components/brave_search/browser/prefs.h"
 #include "brave/components/brave_search/common/features.h"
 #include "brave/components/brave_search_conversion/features.h"
@@ -161,6 +162,8 @@ TEST_F(BraveSearchDefaultHostTest, DisallowsAfterMaxTimesAsked) {
   host->GetCanSetDefaultSearchProvider(fourth.Get());
 }
 
+// Brave Search conversion promotions are suppressed in branded builds.
+#if !BUILDFLAG(IS_BRAVE_ORIGIN_BRANDED)
 TEST_F(BraveSearchDefaultHostTest, CanSetDefaultAlwaysTestWithSearchPromotion) {
   base::test::ScopedFeatureList feature_list;
 
@@ -214,6 +217,7 @@ TEST_F(BraveSearchDefaultHostTest, CanSetDefaultAlwaysTestWithSearchPromotion) {
   EXPECT_CALL(seventh, Run(true));
   host->GetCanSetDefaultSearchProvider(seventh.Get());
 }
+#endif  // !BUILDFLAG(IS_BRAVE_ORIGIN_BRANDED)
 
 }  // namespace
 }  // namespace brave_search

--- a/components/brave_search_conversion/BUILD.gn
+++ b/components/brave_search_conversion/BUILD.gn
@@ -18,6 +18,8 @@ static_library("brave_search_conversion") {
 
   deps = [
     "//base",
+    "//brave/components/brave_origin",
+    "//brave/components/brave_origin/buildflags",
     "//brave/components/p3a_utils",
     "//brave/components/search_engines",
     "//components/prefs",
@@ -43,6 +45,7 @@ if (!is_ios) {
       ":brave_search_conversion",
       "//base",
       "//base/test:test_support",
+      "//brave/components/brave_origin/buildflags",
       "//brave/components/search_engines",
       "//components/prefs",
       "//components/prefs:test_support",

--- a/components/brave_search_conversion/DEPS
+++ b/components/brave_search_conversion/DEPS
@@ -1,4 +1,5 @@
 include_rules = [
+  "+brave/components/brave_origin",
   "+components/prefs",
   "+components/search_engines",
   "+content/public/test",

--- a/components/brave_search_conversion/brave_search_conversion_unittest.cc
+++ b/components/brave_search_conversion/brave_search_conversion_unittest.cc
@@ -9,6 +9,7 @@
 #include "base/metrics/field_trial.h"
 #include "base/metrics/field_trial_param_associator.h"
 #include "base/test/scoped_feature_list.h"
+#include "brave/components/brave_origin/buildflags/buildflags.h"
 #include "brave/components/brave_search_conversion/features.h"
 #include "brave/components/brave_search_conversion/types.h"
 #include "brave/components/brave_search_conversion/utils.h"
@@ -84,6 +85,8 @@ TEST_F(BraveSearchConversionTest, DefaultValueTest) {
             GetPromoURL(u"brave"));
 }
 
+// In branded builds, GetConversionType unconditionally returns kNone.
+#if !BUILDFLAG(IS_BRAVE_ORIGIN_BRANDED)
 TEST_F(BraveSearchConversionTest, ConversionTypeTest) {
   base::test::ScopedFeatureList feature_list;
 
@@ -210,5 +213,6 @@ TEST_F(BraveSearchConversionTest, ConversionTypeTest) {
                 &pref_service_,
                 search_engines_test_environment_.template_url_service()));
 }
+#endif  // !BUILDFLAG(IS_BRAVE_ORIGIN_BRANDED)
 
 }  // namespace brave_search_conversion

--- a/components/brave_search_conversion/utils.cc
+++ b/components/brave_search_conversion/utils.cc
@@ -14,6 +14,8 @@
 #include "base/strings/string_util.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/time/time.h"
+#include "brave/components/brave_origin/brave_origin_utils.h"
+#include "brave/components/brave_origin/buildflags/buildflags.h"
 #include "brave/components/brave_search_conversion/constants.h"
 #include "brave/components/brave_search_conversion/features.h"
 #include "brave/components/brave_search_conversion/pref_names.h"
@@ -101,11 +103,23 @@ void UpdateDDGConversionType(PrefService* prefs) {
   }
 }
 
+bool ShouldSuppressForBraveOrigin() {
+#if BUILDFLAG(IS_BRAVE_ORIGIN_BRANDED)
+  return true;
+#else
+  return brave_origin::IsBraveOriginPurchased();
+#endif
+}
+
 }  // namespace
 
 bool IsNTPPromotionEnabled(PrefService* prefs, TemplateURLService* service) {
   DCHECK(prefs);
   DCHECK(service);
+
+  if (ShouldSuppressForBraveOrigin()) {
+    return false;
+  }
 
   if (prefs->GetBoolean(prefs::kDismissed)) {
     return false;
@@ -131,6 +145,10 @@ ConversionType GetConversionType(PrefService* prefs,
                                  TemplateURLService* service) {
   DCHECK(prefs);
   DCHECK(service);
+
+  if (ShouldSuppressForBraveOrigin()) {
+    return ConversionType::kNone;
+  }
 
   if (prefs->GetBoolean(prefs::kDismissed)) {
     return ConversionType::kNone;

--- a/components/omnibox/browser/BUILD.gn
+++ b/components/omnibox/browser/BUILD.gn
@@ -36,6 +36,7 @@ source_set("unit_tests") {
     "//base",
     "//base/test:test_support",
     "//brave/components/ai_chat/core/common/buildflags",
+    "//brave/components/brave_origin/buildflags",
     "//brave/components/brave_search_conversion",
     "//brave/components/constants",
     "//brave/components/l10n/common:test_support",

--- a/components/omnibox/browser/promotion_unittest.cc
+++ b/components/omnibox/browser/promotion_unittest.cc
@@ -11,6 +11,7 @@
 #include "base/metrics/field_trial.h"
 #include "base/metrics/field_trial_param_associator.h"
 #include "base/test/scoped_feature_list.h"
+#include "brave/components/brave_origin/buildflags/buildflags.h"
 #include "brave/components/brave_search_conversion/features.h"
 #include "brave/components/brave_search_conversion/types.h"
 #include "brave/components/brave_search_conversion/utils.h"
@@ -158,6 +159,8 @@ class OmniboxPromotionTest : public testing::Test {
 };
 
 // Promotion match should not be added for private profile.
+// Brave Search conversion promotions are suppressed in branded builds.
+#if !BUILDFLAG(IS_BRAVE_ORIGIN_BRANDED)
 TEST_F(OmniboxPromotionTest, ProfileTest) {
   base::test::ScopedFeatureList feature_list;
   feature_list.InitAndEnableFeatureWithParameters(
@@ -221,6 +224,7 @@ TEST_F(OmniboxPromotionTest, PromotionEntrySortTest) {
   controller->Start(input);
   EXPECT_FALSE(HasPromotionMatch(controller.get()));
 }
+#endif  // !BUILDFLAG(IS_BRAVE_ORIGIN_BRANDED)
 
 TEST_F(OmniboxPromotionTest, AutocompleteResultTest) {
   AutocompleteInput input(u"brave", metrics::OmniboxEventProto::OTHER,


### PR DESCRIPTION
Suppress the omnibox and NTP Brave Search conversion banners on is_brave_origin_branded=true builds, and on non-branded builds when Brave Origin has been purchased.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/54581

# Test plan 
- Start with a new profile with `--enable-features=BraveSearchOmniboxBanner:banner_type/type_B`
- Type something (not a URL) in the url bar and the promotional banner should show up for normal builds but not for Brave Origin upgrade and not for Brave Origin separate build.


<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
