### PR TITLE
[brockit] Detection for meaningful changes after `apply_patches`

### DIFF
--- a/tools/cr/brockit.py
+++ b/tools/cr/brockit.py
@@ -1144,6 +1144,47 @@ class Upgrade(Versioned):
             raise InvalidInputException(
                 'Untracked patch files detected. These should be committed as '
                 'their own changes:\n%s' % '\n'.join(status.untracked))
+        if status.has_staged_files():
+            raise InvalidInputException(
+                'Staged files detected after running update_patches. Please make '
+                'sure to commit or unstage any changes, to avoid committing '
+                'changes unintentionally.\n'
+                'Staged files:\n%s' % '\n'.join(status.staged))
+
+        # The resulting updated patches should not be doing anything beyond
+        # what they were doing already, both for "Update patches" and
+        # "Conflict-resolved patches". Therefore, we check all the modified
+        # patches to make sure that the number of hunks in these patch files
+        # have not changed, as any significant change to a patchfile should be
+        # submitted as its own change, with a culprit for visibility.
+        modified_patches = [
+            path for path in status.modified
+            if path.startswith('patches/') and path.endswith('.patch')
+        ]
+        if not modified_patches:
+            return
+
+        def count_hunks(contents: str) -> int:
+            return contents.count('\n@@ -')
+
+        patches_with_hunk_changes = []
+        for patch in modified_patches:
+            hunks_before = count_hunks(repository.brave.read_file(patch))
+            hunks_after = count_hunks(
+                Path(repository.brave.path / patch).read_text())
+            if hunks_before != hunks_after:
+                patches_with_hunk_changes.append(
+                    (patch, hunks_before, hunks_after))
+
+        if patches_with_hunk_changes:
+            list_str = '\n'.join([
+                f'  * {patch}: {b} hunks before, {a} hunks after'
+                for patch, b, a in patches_with_hunk_changes
+            ])
+            raise InvalidInputException(
+                'The following modified patches have changes in the number of hunks, '
+                'and are expected to be submitted separately as fixes with Chromium culprits:\n'
+                f'{list_str}')
 
     def look_for_diffs(self, *files) -> str:
         """Return the diffs for the files provided for this upgrade.

--- a/tools/cr/git_status.py
+++ b/tools/cr/git_status.py
@@ -8,6 +8,10 @@ import repository
 
 class GitStatus:
     """Runs `git status` and provides a summary.
+
+    This class is very simple and it is designed around the use case where we
+    want to check for the status of the repository before committing the common
+    version bump patches.
     """
 
     def __init__(self):
@@ -22,14 +26,24 @@ class GitStatus:
         # a list of all untracked files.
         self.untracked = []
 
+        # a list of all staged files.
+        self.staged = []
+
         for line in self.git_status.splitlines():
-            [status, path] = line.lstrip().split(' ', 1)
+            xy = line[:2]
+            path = line[3:]
+            if xy[0] not in (' ', '?'):
+                self.staged.append(path)
+            status = line.lstrip().split(' ', 1)[0]
             if status == 'D':
                 self.deleted.append(path)
             elif status == 'M':
                 self.modified.append(path)
             elif status == '??':
                 self.untracked.append(path)
+
+    def has_staged_files(self):
+        return len(self.staged) > 0
 
     def has_deleted_patch_files(self):
         return any(path.endswith('.patch') for path in self.deleted)

--- a/tools/cr/git_status_test.py
+++ b/tools/cr/git_status_test.py
@@ -21,7 +21,9 @@ class GitStatusTest(unittest.TestCase):
 
     def test_has_deleted_patch_files(self):
         """Test has_deleted_patch_files method."""
-        self.assertFalse(GitStatus().has_deleted_patch_files())
+        status = GitStatus()
+        self.assertFalse(status.has_deleted_patch_files())
+        self.assertEqual(status.deleted, [])
 
         # Create a patch file and commit it
         patch_file = 'patches/test.patch'
@@ -35,18 +37,51 @@ class GitStatusTest(unittest.TestCase):
                                            self.fake_chromium_src.brave)
 
         # Run GitStatus and verify the deleted patch file is detected
-        self.assertTrue(GitStatus().has_deleted_patch_files())
+        status = GitStatus()
+        self.assertTrue(status.has_deleted_patch_files())
+        self.assertEqual(status.deleted, [patch_file])
+
+    def test_test_has_staged_files(self):
+        """Test staged files summary."""
+        status = GitStatus()
+        self.assertFalse(status.has_staged_files())
+        self.assertEqual(status.staged, [])
+
+        # Stage one file and leave another one untracked.
+        staged_file = 'staged_file.txt'
+        untracked_file = 'untracked_file.txt'
+        self.fake_chromium_src.write_and_stage_file(
+            staged_file, 'staged content', self.fake_chromium_src.brave)
+        Path(self.fake_chromium_src.brave /
+             untracked_file).write_text('untracked content')
+
+        status = GitStatus()
+        self.assertTrue(status.has_staged_files())
+        self.assertEqual(status.staged, [staged_file])
 
     def test_has_untracked_patch_files(self):
         """Test has_untracked_patch_files method."""
-        self.assertFalse(GitStatus().has_untracked_patch_files())
+        status = GitStatus()
+        self.assertFalse(status.has_untracked_patch_files())
+        self.assertEqual(status.untracked, [])
+
+        # Stage a patch file; this should not count as untracked.
+        self.fake_chromium_src.write_and_stage_file(
+            'staged.patch', 'staged patch content',
+            self.fake_chromium_src.brave)
+        status = GitStatus()
+        self.assertFalse(status.has_untracked_patch_files())
+        self.assertEqual(status.untracked, [])
 
         # Create a patch file but do not stage it
+        untracked_patch_file = 'test_untracked.patch'
         Path(self.fake_chromium_src.brave /
-             'test_untracked.patch').write_text('Untracked patch content')
+             untracked_patch_file).write_text('Untracked patch content')
 
         # Run GitStatus and verify the untracked patch file is detected
-        self.assertTrue(GitStatus().has_untracked_patch_files())
+        status = GitStatus()
+        self.assertTrue(status.has_untracked_patch_files())
+        self.assertEqual(status.untracked, [untracked_patch_file])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR introduces a check in brockit, to go over all modified patch
files that are about to be committed, be it as updated patches, or
conflict-resolved, and checks if any of them have a different number of
hunks, and if so, stops the process for intervention, the same way it is
done when deleted patches are detected.

This check will prevent cases where hunks of a patch file are being
dropped, either through `apply_patches`, or through 3way resolution,
which should be of interest, and definitely should be submitted
separately as an individual fix.

Resolves https://github.com/brave/brave-browser/issues/47717
