### PR TITLE
Hide Survey Panelist in settings for Origin builds

### DIFF
--- a/browser/ui/webui/brave_settings_ui.cc
+++ b/browser/ui/webui/brave_settings_ui.cc
@@ -254,11 +254,15 @@ void BraveSettingsUI::AddResources(content::WebUIDataSource* html_source,
                           ai_chat::features::IsAIChatHistoryEnabled());
 #endif
 
+#if BUILDFLAG(IS_BRAVE_ORIGIN_BRANDED)
+  html_source->AddBoolean("isSurveyPanelistAllowed", false);
+#else
   html_source->AddBoolean("isSurveyPanelistAllowed",
                           base::FeatureList::IsEnabled(
                               ntp_background_images::features::
                                   kBraveNTPBrandedWallpaperSurveyPanelist) &&
-                              !BUILDFLAG(IS_BRAVE_ORIGIN_BRANDED));
+                              !brave_origin::IsBraveOriginPurchased());
+#endif  // BUILDFLAG(IS_BRAVE_ORIGIN_BRANDED)
   html_source->AddBoolean(
       "isPlaylistAllowed",
       base::FeatureList::IsEnabled(playlist::features::kPlaylist) &&

--- a/browser/ui/webui/brave_settings_ui.cc
+++ b/browser/ui/webui/brave_settings_ui.cc
@@ -257,7 +257,8 @@ void BraveSettingsUI::AddResources(content::WebUIDataSource* html_source,
   html_source->AddBoolean("isSurveyPanelistAllowed",
                           base::FeatureList::IsEnabled(
                               ntp_background_images::features::
-                                  kBraveNTPBrandedWallpaperSurveyPanelist));
+                                  kBraveNTPBrandedWallpaperSurveyPanelist) &&
+                              !BUILDFLAG(IS_BRAVE_ORIGIN_BRANDED));
   html_source->AddBoolean(
       "isPlaylistAllowed",
       base::FeatureList::IsEnabled(playlist::features::kPlaylist) &&

--- a/components/brave_ads/core/browser/virtual_pref/BUILD.gn
+++ b/components/brave_ads/core/browser/virtual_pref/BUILD.gn
@@ -19,6 +19,7 @@ source_set("virtual_pref") {
     "//base/version_info",
     "//brave/components/brave_ads/buildflags",
     "//brave/components/brave_ads/core/public:headers",
+    "//brave/components/brave_origin",
     "//brave/components/ntp_background_images/common",
     "//brave/components/skus/browser",
     "//components/prefs",

--- a/components/brave_ads/core/browser/virtual_pref/virtual_pref_provider.cc
+++ b/components/brave_ads/core/browser/virtual_pref/virtual_pref_provider.cc
@@ -13,6 +13,7 @@
 #include "base/values.h"
 #include "base/version_info/version_info.h"
 #include "brave/components/brave_ads/core/public/common/locale/locale_util.h"
+#include "brave/components/brave_origin/brave_origin_utils.h"
 #include "brave/components/ntp_background_images/common/pref_names.h"
 #include "brave/components/skus/browser/pref_names.h"
 #include "components/prefs/pref_service.h"
@@ -121,6 +122,9 @@ base::DictValue GetSkus(const PrefService& local_state) {
 }
 
 bool IsSurveyPanelist(const PrefService& prefs) {
+  if (brave_origin::IsBraveOriginPurchased()) {
+    return false;
+  }
   return prefs.GetBoolean(
       ntp_background_images::prefs::kNewTabPageSponsoredImagesSurveyPanelist);
 }

--- a/components/brave_ads/core/internal/BUILD.gn
+++ b/components/brave_ads/core/internal/BUILD.gn
@@ -1129,6 +1129,7 @@ static_library("internal") {
   deps = [
     "//base",
     "//brave/components/brave_ads/core/browser/service",
+    "//brave/components/brave_origin",
     "//brave/components/brave_rewards/core",
     "//brave/components/challenge_bypass_ristretto",
     "//brave/components/constants",

--- a/components/brave_ads/core/internal/settings/settings.cc
+++ b/components/brave_ads/core/internal/settings/settings.cc
@@ -8,6 +8,7 @@
 #include "brave/components/brave_ads/core/internal/prefs/pref_util.h"
 #include "brave/components/brave_ads/core/public/ad_units/notification_ad/notification_ad_feature.h"
 #include "brave/components/brave_ads/core/public/prefs/pref_names.h"
+#include "brave/components/brave_origin/brave_origin_utils.h"
 #include "brave/components/brave_rewards/core/pref_names.h"
 #include "brave/components/ntp_background_images/common/pref_names.h"
 
@@ -59,6 +60,9 @@ bool UserHasOptedInToSearchResultAds() {
 }
 
 bool UserHasOptedInToSurveyPanelist() {
+  if (brave_origin::IsBraveOriginPurchased()) {
+    return false;
+  }
   return GetProfileBooleanPref(
       ntp_background_images::prefs::kNewTabPageSponsoredImagesSurveyPanelist);
 }


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/54584


Shows there is no item in Data Collection:
<img width="822" height="643" alt="Screenshot 2026-04-17 at 1 08 59 PM" src="https://github.com/user-attachments/assets/2b842f4b-4072-4fb3-8bc2-da4c8a829589" />

## Summary

- Hide the Survey Panelist row in `brave://settings/privacy` → Data Collection on Brave Origin. The `isSurveyPanelistAllowed` loadTimeData boolean is now also false when `BUILDFLAG(IS_BRAVE_ORIGIN_BRANDED)` is set, or when the user has upgraded a regular build to Brave Origin (`brave_origin::IsBraveOriginPurchased()`). This drops the link row, the subpage registration in `privacy_page_index.ts`, and the `pageVisibility.surveyPanelist` entry all at once.
- Also force the backend opt-in check (`UserHasOptedInToSurveyPanelist()` in `brave_ads`) and the virtual pref `[virtual]:is_survey_panelist` to `false` on Origin. Without this, a user who had previously opted in and then upgraded to Origin would have the toggle removed from settings, but the feature (90-day ad-event retention, `is_survey_panelist` ads targeting) would keep running invisibly with no way to turn it off.

## Test plan

- [ ] On a Brave Origin branded build, `brave://settings/privacy` → Data Collection does not show the Survey Panelist row; navigating directly to `brave://settings/surveyPanelist` does not surface the subpage.
- [ ] On a regular (non-branded) build with Origin purchased, the row is also hidden.
- [ ] On a regular build with Origin not purchased and the `BraveNTPBrandedWallpaperSurveyPanelist` feature enabled, the row still appears and still toggles the pref as before.
- [ ] With the pref pre-seeded to true, entering the Origin state (branded build or purchased) causes `UserHasOptedInToSurveyPanelist()` to return false (verified via ad event retention falling back to 2 days) and the virtual pref `[virtual]:is_survey_panelist` to report false.