### PR TITLE
[iOS][P3A] Add Brave.Search.QuickMostUsedAction P3A answer in iOS

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/InitialSearchEngines.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/InitialSearchEngines.swift
@@ -57,6 +57,10 @@ class InitialSearchEngines {
       default: return false
       }
     }
+
+    var quickSearchP3AId: String {
+      rawValue.lowercased()
+    }
   }
 
   struct SearchEngine: Equatable, CustomStringConvertible {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/SearchViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/SearchViewController.swift
@@ -1253,23 +1253,23 @@ extension SearchViewController: NSFetchedResultsControllerDelegate {
 
 // MARK: - P3A
 
+private enum QuickSearchP3AAnswer: Int, CaseIterable {
+  case leo = 1
+  case defaultEngine = 2
+  case google = 3
+  case youtube = 4
+  case bing = 5
+  case ecosia = 6
+  case duckduckgo = 7
+  case qwant = 8
+  case startpage = 9
+  case brave = 10
+  case other = 11
+}
+
 extension SearchViewController {
   func recordQuickSearchActionP3A(engine: OpenSearchEngine?) {
-    enum Answer: Int, CaseIterable {
-      case leo = 1
-      case defaultEngine = 2
-      case google = 3
-      case youtube = 4
-      case bing = 5
-      case ecosia = 6
-      case duckduckgo = 7
-      case qwant = 8
-      case startpage = 9
-      case brave = 10
-      case other = 11
-    }
-
-    var answer: Answer = .leo
+    var answer: QuickSearchP3AAnswer = .leo
     if let engine {
       if let engineID = engine.engineID, !engine.isCustomEngine {
         let isDefaultEngine =
@@ -1309,7 +1309,33 @@ extension SearchViewController {
         answer = .other
       }
     }
-    UmaHistogramEnumeration("Brave.Search.QuickMostUsedAction", sample: answer)
+    var storage = P3ATimedStorage<Int>.quickSearchMostUsedStorage(for: answer)
+    storage.append(value: 1)
+
+    let maxCount =
+      QuickSearchP3AAnswer.allCases
+      .map { P3ATimedStorage<Int>.quickSearchMostUsedStorage(for: $0).combinedValue }
+      .max() ?? 0
+    let currentCount = P3ATimedStorage<Int>.quickSearchMostUsedStorage(for: answer).combinedValue
+
+    let mostUsedAnswer: QuickSearchP3AAnswer
+    if currentCount == maxCount {
+      // Current engine is tied — prefer it
+      mostUsedAnswer = answer
+    } else {
+      mostUsedAnswer =
+        QuickSearchP3AAnswer.allCases.max { a, b in
+          P3ATimedStorage<Int>.quickSearchMostUsedStorage(for: a).combinedValue
+            < P3ATimedStorage<Int>.quickSearchMostUsedStorage(for: b).combinedValue
+        } ?? answer
+    }
+    UmaHistogramEnumeration("Brave.Search.QuickMostUsedAction", sample: mostUsedAnswer)
+  }
+}
+
+extension P3ATimedStorage where Value == Int {
+  fileprivate static func quickSearchMostUsedStorage(for answer: QuickSearchP3AAnswer) -> Self {
+    .init(name: "quick-search-most-used-\(answer.rawValue)", lifetimeInDays: 7)
   }
 }
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/SearchViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/SearchViewController.swift
@@ -6,6 +6,7 @@ import CoreData
 import Data
 import DesignSystem
 import Favicon
+import Growth
 import Preferences
 import Shared
 import Storage
@@ -857,6 +858,7 @@ public class SearchViewController: UIViewController, LoaderListener {
       RecentSearch.addItem(type: .website, text: localSearchQuery, websiteUrl: url.absoluteString)
     }
     searchDelegate?.searchViewController(self, didSelectURL: url)
+    recordQuickSearchActionP3A(engine: engine)
   }
 
   @objc func didClickSettingsButton() {
@@ -865,6 +867,7 @@ public class SearchViewController: UIViewController, LoaderListener {
 
   @objc func didClickLeoButton() {
     submitSearchQueryToAIChat()
+    recordQuickSearchActionP3A(engine: nil)
   }
 
   @objc func onShowMorePressed() {
@@ -1245,6 +1248,68 @@ extension SearchViewController: NSFetchedResultsControllerDelegate {
     _ controller: NSFetchedResultsController<NSFetchRequestResult>
   ) {
     updateAvailableOnYourDeviceItems()
+  }
+}
+
+// MARK: - P3A
+
+extension SearchViewController {
+  func recordQuickSearchActionP3A(engine: OpenSearchEngine?) {
+    enum Answer: Int, CaseIterable {
+      case leo = 1
+      case defaultEngine = 2
+      case google = 3
+      case youtube = 4
+      case bing = 5
+      case ecosia = 6
+      case duckduckgo = 7
+      case qwant = 8
+      case startpage = 9
+      case brave = 10
+      case other = 11
+    }
+
+    var answer: Answer = .leo
+    if let engine {
+      if let engineID = engine.engineID, !engine.isCustomEngine {
+        let isDefaultEngine =
+          dataSource.searchEngines?.isEngineDefault(
+            engine,
+            type: dataSource.isPrivate ? .privateMode : .standard
+          ) ?? false
+        if isDefaultEngine {
+          answer = .defaultEngine
+        } else {
+          switch engineID {
+          case InitialSearchEngines.SearchEngineID.google.quickSearchP3AId:
+            answer = .google
+          case InitialSearchEngines.SearchEngineID.bing.quickSearchP3AId:
+            answer = .bing
+          case InitialSearchEngines.SearchEngineID.ecosia.quickSearchP3AId:
+            answer = .ecosia
+          case InitialSearchEngines.SearchEngineID.duckduckgo.quickSearchP3AId:
+            answer = .duckduckgo
+          case InitialSearchEngines.SearchEngineID.qwant.quickSearchP3AId:
+            answer = .qwant
+          case InitialSearchEngines.SearchEngineID.startpage.quickSearchP3AId:
+            answer = .startpage
+          case InitialSearchEngines.SearchEngineID.braveSearch.quickSearchP3AId:
+            answer = .brave
+          default:
+            answer = .other
+          }
+        }
+      } else if engine.isCustomEngine {
+        if engine.shortName.caseInsensitiveCompare("Youtube") == .orderedSame {
+          answer = .youtube
+        } else {
+          answer = .other
+        }
+      } else {
+        answer = .other
+      }
+    }
+    UmaHistogramEnumeration("Brave.Search.QuickMostUsedAction", sample: answer)
   }
 }
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/SearchViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/SearchViewController.swift
@@ -858,7 +858,7 @@ public class SearchViewController: UIViewController, LoaderListener {
       RecentSearch.addItem(type: .website, text: localSearchQuery, websiteUrl: url.absoluteString)
     }
     searchDelegate?.searchViewController(self, didSelectURL: url)
-    recordQuickSearchActionP3A(engine: engine)
+    recordQuickSearchActionP3A(option: .searchEngine(engine))
   }
 
   @objc func didClickSettingsButton() {
@@ -867,7 +867,7 @@ public class SearchViewController: UIViewController, LoaderListener {
 
   @objc func didClickLeoButton() {
     submitSearchQueryToAIChat()
-    recordQuickSearchActionP3A(engine: nil)
+    recordQuickSearchActionP3A(option: .leo)
   }
 
   @objc func onShowMorePressed() {
@@ -1267,10 +1267,18 @@ private enum QuickSearchP3AAnswer: Int, CaseIterable {
   case other = 11
 }
 
+private enum P3AQuickSearchOption {
+  case leo
+  case searchEngine(OpenSearchEngine)
+}
+
 extension SearchViewController {
-  func recordQuickSearchActionP3A(engine: OpenSearchEngine?) {
-    var answer: QuickSearchP3AAnswer = .leo
-    if let engine {
+  fileprivate func recordQuickSearchActionP3A(option: P3AQuickSearchOption) {
+    let answer: QuickSearchP3AAnswer
+    switch option {
+    case .leo:
+      answer = .leo
+    case .searchEngine(let engine):
       if let engineID = engine.engineID, !engine.isCustomEngine {
         let isDefaultEngine =
           dataSource.searchEngines?.isEngineDefault(
@@ -1299,36 +1307,25 @@ extension SearchViewController {
             answer = .other
           }
         }
-      } else if engine.isCustomEngine {
-        if engine.shortName.caseInsensitiveCompare("Youtube") == .orderedSame {
-          answer = .youtube
-        } else {
-          answer = .other
-        }
+      } else if engine.isCustomEngine,
+        engine.shortName.caseInsensitiveCompare("Youtube") == .orderedSame
+      {
+        answer = .youtube
       } else {
         answer = .other
       }
     }
-    var storage = P3ATimedStorage<Int>.quickSearchMostUsedStorage(for: answer)
-    storage.append(value: 1)
-
-    let maxCount =
-      QuickSearchP3AAnswer.allCases
-      .map { P3ATimedStorage<Int>.quickSearchMostUsedStorage(for: $0).combinedValue }
-      .max() ?? 0
-    let currentCount = P3ATimedStorage<Int>.quickSearchMostUsedStorage(for: answer).combinedValue
-
-    let mostUsedAnswer: QuickSearchP3AAnswer
-    if currentCount == maxCount {
-      // Current engine is tied — prefer it
-      mostUsedAnswer = answer
-    } else {
-      mostUsedAnswer =
-        QuickSearchP3AAnswer.allCases.max { a, b in
-          P3ATimedStorage<Int>.quickSearchMostUsedStorage(for: a).combinedValue
-            < P3ATimedStorage<Int>.quickSearchMostUsedStorage(for: b).combinedValue
-        } ?? answer
-    }
+    var storages = Dictionary(
+      uniqueKeysWithValues: QuickSearchP3AAnswer.allCases.map {
+        ($0, P3ATimedStorage<Int>.quickSearchMostUsedStorage(for: $0))
+      }
+    )
+    storages[answer]?.append(value: 1)
+    let maxCount = storages.values.map(\.combinedValue).max() ?? 0
+    let mostUsedAnswer =
+      storages[answer]?.combinedValue == maxCount
+      ? answer
+      : storages.max { $0.value.combinedValue < $1.value.combinedValue }?.key ?? answer
     UmaHistogramEnumeration("Brave.Search.QuickMostUsedAction", sample: mostUsedAnswer)
   }
 }


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/53303

Test:
1. open browser and visit brave://histograms/
2. verify there is no entry of `Brave.Search.QuickMostUsedAction`
3. open a new tab. input some search query in omnibox and perform a leo query by clicking leo icon inside quick search bar
4. verify that Leo chat is opened and search performed via Leo chat
5. Reload brave://histograms/
6. verify that the metrics Brave.Search.QuickMostUsedAction response value is 1 with 1 hit
7. perform a new quick search using the default search engine
8. Reload brave://histograms/
6. verify that the metrics Brave.Search.QuickMostUsedAction response value is 2 with 1 hit
7. perform few new quick searches using different search engines
8. Reload brave://histograms/
9. verify that the metrics Brave.Search.QuickMostUsedAction response value is correct as following:

case leo = 1
case defaultEngine = 2
case google = 3
youtube = 4
bing = 5
ecosia = 6
duckduckgo = 7
qwant = 8
startpage = 9
brave = 10
other = 11

10. verify far so far every value above appears on brave://histograms/ after reload and each value with 1 hit
11. Now perform another search with brave search engine
12. Reload brave://histograms/
13. verify the metrics Brave.Search.QuickMostUsedAction has value 10 with 2 hits 
14. repeat step 11 and 12
15. verify the metrics Brave.Search.QuickMostUsedAction has value 10 with 3 hits 
16. now perform another search with another search engine other than brave 
17. reload brave://histograms/
18. verify the Brave.Search.QuickMostUsedAction has value 10 with 4 hits, other values with the same amount of hits.  

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
