### PR TITLE
[Android] Fix Leo file upload using display_name for type detection

### DIFF
--- a/browser/ai_chat/upload_file_helper.cc
+++ b/browser/ai_chat/upload_file_helper.cc
@@ -77,7 +77,17 @@ std::optional<std::vector<uint8_t>> ReadFileToBytes(
 
 std::tuple<std::optional<std::vector<uint8_t>>, base::FilePath>
 ReadSelectedFile(const ui::SelectedFileInfo& info) {
-  return std::make_tuple(ai_chat::ReadFileToBytes(info.path()), info.path());
+  return std::make_tuple(ai_chat::ReadFileToBytes(info.path()),
+#if BUILDFLAG(IS_ANDROID)
+                         // On Android info.path() is a content:// URI with no
+                         // extension, so DetermineFileType() cannot classify
+                         // it. Use display_name, which holds the real filename
+                         // (e.g. "photo.png").
+                         base::FilePath(info.display_name)
+#else
+                         info.path()
+#endif
+  );
 }
 
 void OnImageDecoded(

--- a/browser/ai_chat/upload_file_helper_unittest.cc
+++ b/browser/ai_chat/upload_file_helper_unittest.cc
@@ -54,6 +54,16 @@ constexpr uint8_t kSamplePdf[] = {
     0x74, 0x78, 0x72, 0x65, 0x66, 0x0a, 0x31, 0x32, 0x38, 0x0a, 0x25, 0x25,
     0x45, 0x4f, 0x46, 0x0a};
 
+// Android returns just the basename as the UploadedFile filename since
+// ReadSelectedFile uses display_name there (info.path() is a content:// URI).
+std::string ExpectedFilename(const base::FilePath& path) {
+#if BUILDFLAG(IS_ANDROID)
+  return path.BaseName().AsUTF8Unsafe();
+#else
+  return path.AsUTF8Unsafe();
+#endif
+}
+
 class MockObserver : UploadFileHelper::Observer {
  public:
   explicit MockObserver(UploadFileHelper* helper) { obs_.Observe(helper); }
@@ -186,7 +196,7 @@ TEST_F(UploadFileHelperTest, ImageRead) {
   testing::Mock::VerifyAndClearExpectations(&observer);
   ASSERT_TRUE(sample_result);
   ASSERT_EQ(1u, sample_result->size());
-  EXPECT_EQ((*sample_result)[0]->filename, path3.AsUTF8Unsafe());
+  EXPECT_EQ((*sample_result)[0]->filename, ExpectedFilename(path3));
   EXPECT_EQ((*sample_result)[0]->filesize, (*sample_result)[0]->data.size());
   EXPECT_EQ((*sample_result)[0]->type, mojom::UploadedFileType::kImage);
   auto encoded_bitmap = gfx::PNGCodec::Decode((*sample_result)[0]->data);
@@ -207,7 +217,7 @@ TEST_F(UploadFileHelperTest, ImageRead) {
   testing::Mock::VerifyAndClearExpectations(&observer);
   ASSERT_TRUE(large_result);
   ASSERT_EQ(1u, large_result->size());
-  EXPECT_EQ((*large_result)[0]->filename, path4.AsUTF8Unsafe());
+  EXPECT_EQ((*large_result)[0]->filename, ExpectedFilename(path4));
   EXPECT_EQ((*large_result)[0]->filesize, (*large_result)[0]->data.size());
   EXPECT_EQ((*large_result)[0]->type, mojom::UploadedFileType::kImage);
   EXPECT_LE((*large_result)[0]->filesize, large_png_bytes->size());
@@ -227,7 +237,7 @@ TEST_F(UploadFileHelperTest, ImageRead) {
   ASSERT_TRUE(result);
   ASSERT_EQ(2u, result->size());
 
-  EXPECT_EQ((*result)[0]->filename, path3.AsUTF8Unsafe());
+  EXPECT_EQ((*result)[0]->filename, ExpectedFilename(path3));
   EXPECT_EQ((*result)[0]->filesize, (*result)[0]->data.size());
   EXPECT_EQ((*result)[0]->type, mojom::UploadedFileType::kImage);
   auto encoded_bitmap1 = gfx::PNGCodec::Decode((*result)[0]->data);
@@ -235,7 +245,7 @@ TEST_F(UploadFileHelperTest, ImageRead) {
   EXPECT_EQ(sample_bitmap.width(), encoded_bitmap1.width());
   EXPECT_EQ(sample_bitmap.height(), encoded_bitmap1.height());
 
-  EXPECT_EQ((*result)[1]->filename, path4.AsUTF8Unsafe());
+  EXPECT_EQ((*result)[1]->filename, ExpectedFilename(path4));
   EXPECT_EQ((*result)[1]->filesize, (*result)[1]->data.size());
   EXPECT_EQ((*result)[1]->type, mojom::UploadedFileType::kImage);
   auto encoded_bitmap2 = gfx::PNGCodec::Decode((*result)[1]->data);
@@ -261,7 +271,7 @@ TEST_F(UploadFileHelperTest, PdfFileHandling) {
 
   ASSERT_TRUE(result);
   ASSERT_EQ(1u, result->size());
-  EXPECT_EQ((*result)[0]->filename, pdf_path.AsUTF8Unsafe());
+  EXPECT_EQ((*result)[0]->filename, ExpectedFilename(pdf_path));
   EXPECT_EQ((*result)[0]->filesize, (*result)[0]->data.size());
   EXPECT_EQ((*result)[0]->type, mojom::UploadedFileType::kPdf);
 
@@ -341,11 +351,11 @@ TEST_F(UploadFileHelperTest, MixedFileTypes) {
   ASSERT_TRUE(result);
   ASSERT_EQ(2u, result->size());
 
-  EXPECT_EQ((*result)[0]->filename, pdf_path.AsUTF8Unsafe());
+  EXPECT_EQ((*result)[0]->filename, ExpectedFilename(pdf_path));
   EXPECT_EQ((*result)[0]->type, mojom::UploadedFileType::kPdf);
   EXPECT_EQ((*result)[0]->data.size(), sizeof(kSamplePdf));
 
-  EXPECT_EQ((*result)[1]->filename, png_path.AsUTF8Unsafe());
+  EXPECT_EQ((*result)[1]->filename, ExpectedFilename(png_path));
   EXPECT_EQ((*result)[1]->type, mojom::UploadedFileType::kImage);
   EXPECT_GT((*result)[1]->data.size(), 0u);
 }


### PR DESCRIPTION
On Android, `SelectFileDialog` returns `info.path()` as a `content://` URI without a file extension, so `DetermineFileType()` cannot classify the file and uploads silently fail. Use `info.display_name`, which carries the real filename with extension, for the Android path.

Resolves: https://github.com/brave/brave-browser/issues/54555

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
