### PR TITLE
Jest - use guessConfig to use brave-core config and env variables

### DIFF
--- a/build/commands/lib/guessConfig.js
+++ b/build/commands/lib/guessConfig.js
@@ -34,16 +34,19 @@ let outputPath = config.outputDir
 function getBuildOutputPathList() {
   if (os.platform() === 'win32') {
     return buildConfigs.flatMap((config) => [
-      path.win32.resolve(__dirname, `..\\..\\..\\..\\out\\${config}`),
+      path.win32.resolve(import.meta.dirname, `..\\..\\..\\..\\out\\${config}`),
       ...extraArchitectures.map((arch) =>
-        path.win32.resolve(__dirname, `..\\..\\..\\..\\out\\${config}_${arch}`),
+        path.win32.resolve(
+          import.meta.dirname,
+          `..\\..\\..\\..\\out\\${config}_${arch}`,
+        ),
       ),
     ])
   } else {
     return buildConfigs.flatMap((config) => [
-      path.resolve(__dirname, `../../../../out/${config}`),
+      path.resolve(import.meta.dirname, `../../../../out/${config}`),
       ...extraArchitectures.map((arch) =>
-        path.resolve(__dirname, `../../../../out/${config}_${arch}`),
+        path.resolve(import.meta.dirname, `../../../../out/${config}_${arch}`),
       ),
     ])
   }

--- a/build/commands/lib/guessConfig.js
+++ b/build/commands/lib/guessConfig.js
@@ -4,8 +4,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import config from './config.ts'
-import os from 'node:os'
-import path from 'node:path/posix'
+import path from 'node:path'
 import fs from 'node:fs'
 
 const buildConfigs = ['Component', 'Static', 'Debug', 'Release']
@@ -29,35 +28,18 @@ config.update({
   build_config: process.env.BUILD_CONFIG,
 })
 
-let outputPath = config.outputDir
-
 function getBuildOutputPathList() {
-  if (os.platform() === 'win32') {
-    return buildConfigs.flatMap((config) => [
-      path.win32.resolve(import.meta.dirname, `..\\..\\..\\..\\out\\${config}`),
-      ...extraArchitectures.map((arch) =>
-        path.win32.resolve(
-          import.meta.dirname,
-          `..\\..\\..\\..\\out\\${config}_${arch}`,
-        ),
-      ),
-    ])
-  } else {
-    return buildConfigs.flatMap((config) => [
-      path.resolve(import.meta.dirname, `../../../../out/${config}`),
-      ...extraArchitectures.map((arch) =>
-        path.resolve(import.meta.dirname, `../../../../out/${config}_${arch}`),
-      ),
-    ])
-  }
+  return buildConfigs.flatMap((buildConfig) => [
+    path.resolve(config.srcDir, 'out', buildConfig),
+    ...extraArchitectures.map((arch) =>
+      path.resolve(config.srcDir, 'out', `${buildConfig}_${arch}`),
+    ),
+  ])
 }
 
-if (fs.existsSync(outputPath)) {
-  console.log(
-    'Assuming precompiled dependencies can be found at the existing path found from brave-core configuration: '
-      + outputPath,
-  )
-} else {
+export let outputPath = config.outputDir
+
+if (!fs.existsSync(outputPath)) {
   const outDirectories = getBuildOutputPathList()
     .filter((a) => fs.existsSync(a))
     .sort(
@@ -71,5 +53,9 @@ if (fs.existsSync(outputPath)) {
   outputPath = outDirectories[0]
 }
 
-const genPath = path.join(outputPath, 'gen')
-export { outputPath, genPath }
+console.log(
+  'Assuming precompiled dependencies can be found at the path:',
+  outputPath,
+)
+
+export const genPath = path.join(outputPath, 'gen')

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -6,33 +6,14 @@
 // For a detailed explanation regarding each configuration property, visit:
 // https://jestjs.io/docs/en/configuration.html
 
-import fs from 'fs'
+import fs from 'node:fs'
+import path from 'node:path'
 import type { Config } from 'jest'
 import { createJsWithTsEsmPreset } from 'ts-jest'
+import { genPath, outputPath } from './build/commands/lib/guessConfig.js'
 
-const crossPlatforms = ['mac', 'win']
-const buildConfigs = ['Component', 'Static', 'Debug', 'Release']
-const extraArchitectures = ['arm64', 'x86']
-
-function getBuildOutputPathList(buildOutputRelativePath: string): string[] {
-  return buildConfigs
-    .reduce(
-      (outDirs, outDir) => [
-        ...outDirs,
-        outDir,
-        ...crossPlatforms.map((platform) => `${platform}_${outDir}`),
-      ],
-      [],
-    )
-    .reduce(
-      (outDirs, outDir) => [
-        ...outDirs,
-        outDir,
-        ...extraArchitectures.map((arch) => `${outDir}_${arch}`),
-      ],
-      [],
-    )
-    .map((outDir) => `<rootDir>/../out/${outDir}/${buildOutputRelativePath}`)
+function getBuildOutputPath(buildOutputRelativePath: string): string {
+  return `${outputPath}/${buildOutputRelativePath}`
 }
 
 function getReporters() {
@@ -48,31 +29,9 @@ function getReporters() {
   }
 }
 
-function getBuildConfig() {
-  // Try to find the build config in any of the possible build directories
-  const possiblePaths = getBuildOutputPathList('gen/brave/build_flags.json')
-
-  for (const configPath of possiblePaths) {
-    // Remove <rootDir> placeholder and resolve the actual path
-    const actualPath = configPath.replace('<rootDir>', import.meta.dirname)
-    if (fs.existsSync(actualPath)) {
-      try {
-        return JSON.parse(fs.readFileSync(actualPath, 'utf8'))
-      } catch (e) {
-        // Continue to next path
-      }
-    }
-  }
-
-  // Default to all features enabled if no config found
-  return {
-    enable_ai_chat: true,
-    enable_brave_wallet: true,
-    enable_email_aliases: true,
-  }
-}
-
-const buildConfig = getBuildConfig()
+const buildConfig = JSON.parse(
+  fs.readFileSync(path.join(genPath, 'brave/build_flags.json'), 'utf8'),
+)
 
 const jestConfig: Config = {
   ...createJsWithTsEsmPreset({
@@ -150,11 +109,11 @@ const jestConfig: Config = {
     // It can also break if CI or devs perform a build in a directory not known
     // by this list.
     // Instead, we should get the directory from config.js:outputDir.
-    '^gen\\/(.*)': getBuildOutputPathList('gen/$1'),
-    'chrome://resources\\/(.*)': getBuildOutputPathList(
+    '^gen\\/(.*)': getBuildOutputPath('gen/$1'),
+    'chrome://resources\\/(.*)': getBuildOutputPath(
       'gen/ui/webui/resources/tsc/$1',
     ),
-    'chrome://interstitials\\/(.*)': getBuildOutputPathList(
+    'chrome://interstitials\\/(.*)': getBuildOutputPath(
       'gen/components/security_interstitials/core/$1',
     ),
     // workaround for https://github.com/LedgerHQ/ledger-live/issues/763


### PR DESCRIPTION
Remove hard-coded list of possible platforms and build type configurations. Instead rely on the same mechanics as regular build (and storybook)