### PR TITLE
[AI Chat]: Show attachments from all edits on the edited conversation turn

### DIFF
--- a/components/ai_chat/resources/untrusted_conversation_frame/components/conversation_entries/index.test.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/conversation_entries/index.test.tsx
@@ -287,6 +287,144 @@ describe('conversation entries', () => {
     ).toBe(1)
   })
 
+  it('renders attached tabs from the original turn on edited conversation turns', () => {
+    const { container } = render(
+      <MockContext
+        overrides={{
+          associatedContent: [
+            {
+              contentId: 1,
+              contentType: Mojom.ContentType.PageContent,
+              contentUsedPercentage: 0.5,
+              title: 'Associated Content',
+              url: { url: 'https://example.com' },
+              uuid: '1234',
+              conversationTurnUuid: '111',
+            },
+          ],
+        }}
+        initialState={{
+          conversationHistory: [
+            {
+              characterType: Mojom.CharacterType.HUMAN,
+              text: 'Summarize this page',
+              actionType: Mojom.ActionType.SUMMARIZE_PAGE,
+              events: [],
+              createdTime: { internalValue: BigInt(0) },
+              edits: [
+                {
+                  characterType: Mojom.CharacterType.HUMAN,
+                  text: 'Summarize this page please',
+                  actionType: Mojom.ActionType.SUMMARIZE_PAGE,
+                  events: [],
+                  createdTime: { internalValue: BigInt(1) },
+                  edits: [],
+                  fromBraveSearchSERP: false,
+                  uploadedFiles: [],
+                  uuid: '222',
+                  prompt: undefined,
+                  selectedText: undefined,
+                  modelKey: 'gpt-4o',
+                },
+              ],
+              fromBraveSearchSERP: false,
+              uploadedFiles: [],
+              uuid: '111',
+              prompt: undefined,
+              selectedText: undefined,
+              modelKey: 'gpt-4o',
+            },
+          ],
+        }}
+      >
+        <ConversationEntries />
+      </MockContext>,
+    )
+
+    expect(
+      screen.getByText('Associated Content', { selector: '.title' }),
+    ).toBeInTheDocument()
+    expect(
+      container.querySelector('img[src*="//favicon2"]'),
+    ).toBeInTheDocument()
+  })
+
+  it('renders attached tabs from earlier edits on re-edited conversation turns', () => {
+    const { container } = render(
+      <MockContext
+        overrides={{
+          associatedContent: [
+            {
+              contentId: 1,
+              contentType: Mojom.ContentType.PageContent,
+              contentUsedPercentage: 0.5,
+              title: 'Associated Content',
+              url: { url: 'https://example.com' },
+              uuid: '1234',
+              conversationTurnUuid: '222',
+            },
+          ],
+        }}
+        initialState={{
+          conversationHistory: [
+            {
+              characterType: Mojom.CharacterType.HUMAN,
+              text: 'Summarize this page',
+              actionType: Mojom.ActionType.SUMMARIZE_PAGE,
+              events: [],
+              createdTime: { internalValue: BigInt(0) },
+              edits: [
+                {
+                  characterType: Mojom.CharacterType.HUMAN,
+                  text: 'Summarize this page please',
+                  actionType: Mojom.ActionType.SUMMARIZE_PAGE,
+                  events: [],
+                  createdTime: { internalValue: BigInt(1) },
+                  edits: [],
+                  fromBraveSearchSERP: false,
+                  uploadedFiles: [],
+                  uuid: '222',
+                  prompt: undefined,
+                  selectedText: undefined,
+                  modelKey: 'gpt-4o',
+                },
+                {
+                  characterType: Mojom.CharacterType.HUMAN,
+                  text: 'Summarize this page now',
+                  actionType: Mojom.ActionType.SUMMARIZE_PAGE,
+                  events: [],
+                  createdTime: { internalValue: BigInt(2) },
+                  edits: [],
+                  fromBraveSearchSERP: false,
+                  uploadedFiles: [],
+                  uuid: '333',
+                  prompt: undefined,
+                  selectedText: undefined,
+                  modelKey: 'gpt-4o',
+                },
+              ],
+              fromBraveSearchSERP: false,
+              uploadedFiles: [],
+              uuid: '111',
+              prompt: undefined,
+              selectedText: undefined,
+              modelKey: 'gpt-4o',
+            },
+          ],
+        }}
+      >
+        <ConversationEntries />
+      </MockContext>,
+    )
+
+    expect(
+      screen.getByText('Associated Content', { selector: '.title' }),
+    ).toBeInTheDocument()
+    expect(
+      container.querySelector('img[src*="//favicon2"]'),
+    ).toBeInTheDocument()
+  })
+
   test('allows editing of entries', () => {
     const humanTurn1: Mojom.ConversationTurn = {
       characterType: Mojom.CharacterType.HUMAN,

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/conversation_entries/index.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/conversation_entries/index.tsx
@@ -168,7 +168,10 @@ function ConversationEntries() {
 
     const showEditInput = editInputId === entryNumber
     const showEditIndicator = !showEditInput && !!group[0].edits?.length
-    const turnIds = new Set([firstEntry.uuid, ...firstEntry.edits?.map((edit) => edit.uuid) ?? []])
+    const turnIds = new Set([
+      firstEntry.uuid,
+      ...(firstEntry.edits?.map((edit) => edit.uuid) ?? []),
+    ])
 
     // Can't edit complicated structured content (for now)
     // Not allowed to edit agent conversations until the edit submission
@@ -195,8 +198,8 @@ function ConversationEntries() {
       useConversationEventClipboardCopyHandler(firstEntryEdit)
 
     const tabAttachments =
-      conversationContext.associatedContent?.filter(
-        (c) => turnIds.has(c.conversationTurnUuid),
+      conversationContext.associatedContent?.filter((c) =>
+        turnIds.has(c.conversationTurnUuid),
       ) ?? []
     const hasAttachments =
       !!firstEntryEdit.uploadedFiles?.length || tabAttachments.length > 0

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/conversation_entries/index.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/conversation_entries/index.tsx
@@ -168,6 +168,7 @@ function ConversationEntries() {
 
     const showEditInput = editInputId === entryNumber
     const showEditIndicator = !showEditInput && !!group[0].edits?.length
+    const turnIds = new Set([firstEntry.uuid, ...firstEntry.edits?.map((edit) => edit.uuid) ?? []])
 
     // Can't edit complicated structured content (for now)
     // Not allowed to edit agent conversations until the edit submission
@@ -195,7 +196,7 @@ function ConversationEntries() {
 
     const tabAttachments =
       conversationContext.associatedContent?.filter(
-        (c) => c.conversationTurnUuid === firstEntryEdit.uuid,
+        (c) => turnIds.has(c.conversationTurnUuid),
       ) ?? []
     const hasAttachments =
       !!firstEntryEdit.uploadedFiles?.length || tabAttachments.length > 0


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/54649

This is a not perfect fix for the above issue. However, you currently cannot edit attachments while editing your message. Additionally, we always send the attachments from the first turn to the backend.

This solves the issue where attachments are sent to the backend but not displayed in the UI.

In an ideal solution, it'd be possible to add/remove attachments while editing the conversation turn.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
