### PR TITLE
Add `brave_interactive_ui_tests target` and convert Commander MANUAL tests

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -339,6 +339,7 @@ if (!is_ios) {
     if (!is_android) {
       deps += [
         "test:brave_browser_tests",
+        "test:brave_interactive_ui_tests",
         "test:brave_network_audit_tests",
       ]
     }

--- a/browser/ui/commander/BUILD.gn
+++ b/browser/ui/commander/BUILD.gn
@@ -27,6 +27,24 @@ source_set("browser_tests") {
   ]
 }
 
+source_set("interactive_ui_tests") {
+  testonly = true
+  defines = [ "HAS_OUT_OF_PROC_TEST_RUNNER" ]
+
+  sources = [ "commander_service_interactive_ui_tests.cc" ]
+
+  deps = [
+    "//base",
+    "//brave/components/commander/browser",
+    "//chrome/browser/profiles:profile",
+    "//chrome/browser/ui",
+    "//chrome/browser/ui/location_bar",
+    "//chrome/test:test_support_ui",
+    "//content/test:test_support",
+    "//ui/base/interaction:test_support",
+  ]
+}
+
 source_set("unit_tests") {
   testonly = true
 

--- a/browser/ui/commander/commander_service_browsertest.cc
+++ b/browser/ui/commander/commander_service_browsertest.cc
@@ -109,35 +109,6 @@ IN_PROC_BROWSER_TEST_F(CommanderServiceBrowserTest, CanHideCommander) {
       base::BindLambdaForTesting([&]() { return !commander()->IsShowing(); }));
 }
 
-// NOTE: This test will pass in isolation but they depend on focus
-// so they'll fail if run with other tests. It'd be a good candidate for an
-// interactive UI test.
-IN_PROC_BROWSER_TEST_F(CommanderServiceBrowserTest, MANUAL_HideClearsText) {
-  commander()->Show();
-  omnibox()->SetUserText(
-      base::StrCat({commander::kCommandPrefix, u" Hello World"}));
-
-  commander()->Hide();
-  WaitUntil(
-      base::BindLambdaForTesting([&]() { return !commander()->IsShowing(); }));
-  EXPECT_EQ(u"about:blank", omnibox()->GetText());
-}
-
-// NOTE: This test will pass in isolation but they depend on focus
-// so they'll fail if run with other tests. It'd be a good candidate for an
-// interactive UI test.
-IN_PROC_BROWSER_TEST_F(CommanderServiceBrowserTest,
-                       MANUAL_CanHideCommanderViaText) {
-  omnibox()->SetUserText(
-      base::StrCat({commander::kCommandPrefix, u" Hello World"}));
-  WaitUntil(
-      base::BindLambdaForTesting([&]() { return commander()->IsShowing(); }));
-
-  omnibox()->SetUserText(u"Hello World");
-  WaitUntil(
-      base::BindLambdaForTesting([&]() { return !commander()->IsShowing(); }));
-}
-
 IN_PROC_BROWSER_TEST_F(CommanderServiceBrowserTest,
                        CommandsAreUpdatedViaOmnibox) {
   omnibox()->SetUserText(

--- a/browser/ui/commander/commander_service_interactive_ui_tests.cc
+++ b/browser/ui/commander/commander_service_interactive_ui_tests.cc
@@ -1,0 +1,83 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "base/strings/strcat.h"
+#include "base/test/scoped_feature_list.h"
+#include "brave/browser/ui/commander/commander_service.h"
+#include "brave/browser/ui/commander/commander_service_factory.h"
+#include "brave/components/commander/common/constants.h"
+#include "brave/components/commander/common/features.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/location_bar/location_bar.h"
+#include "chrome/browser/ui/omnibox/omnibox_view.h"
+#include "chrome/test/interaction/interactive_browser_test.h"
+#include "content/public/test/browser_test.h"
+#include "ui/base/interaction/state_observer.h"
+
+class CommanderServiceInteractiveUITest : public InteractiveBrowserTest {
+ public:
+  CommanderServiceInteractiveUITest() {
+    features_.InitAndEnableFeature(features::kBraveCommander);
+  }
+  ~CommanderServiceInteractiveUITest() override = default;
+
+  void TearDownOnMainThread() override {
+    commander()->Hide();
+    InteractiveBrowserTest::TearDownOnMainThread();
+  }
+
+ protected:
+  commander::CommanderService* commander() {
+    return commander::CommanderServiceFactory::GetForBrowserContext(
+        browser()->profile());
+  }
+
+  OmniboxView* omnibox() {
+    return browser()->window()->GetLocationBar()->GetOmniboxView();
+  }
+
+  auto WaitForShowing() {
+    DEFINE_LOCAL_STATE_IDENTIFIER_VALUE(ui::test::PollingStateObserver<bool>,
+                                        kCommanderShowing);
+    return Steps(PollState(kCommanderShowing,
+                           [this] { return commander()->IsShowing(); }),
+                 WaitForState(kCommanderShowing, true),
+                 StopObservingState(kCommanderShowing));
+  }
+
+  auto WaitForHidden() {
+    DEFINE_LOCAL_STATE_IDENTIFIER_VALUE(ui::test::PollingStateObserver<bool>,
+                                        kCommanderHidden);
+    return Steps(PollState(kCommanderHidden,
+                           [this] { return !commander()->IsShowing(); }),
+                 WaitForState(kCommanderHidden, true),
+                 StopObservingState(kCommanderHidden));
+  }
+
+ private:
+  base::test::ScopedFeatureList features_;
+};
+
+IN_PROC_BROWSER_TEST_F(CommanderServiceInteractiveUITest, HideClearsText) {
+  RunTestSequence(
+      Do([this] { commander()->Show(); }), Do([this] {
+        omnibox()->SetUserText(
+            base::StrCat({commander::kCommandPrefix, u" Hello World"}));
+      }),
+      Do([this] { commander()->Hide(); }), WaitForHidden(),
+      CheckResult([this] { return omnibox()->GetText(); }, u"about:blank"));
+}
+
+IN_PROC_BROWSER_TEST_F(CommanderServiceInteractiveUITest,
+                       CanHideCommanderViaText) {
+  RunTestSequence(
+      Do([this] {
+        omnibox()->SetUserText(
+            base::StrCat({commander::kCommandPrefix, u" Hello World"}));
+      }),
+      WaitForShowing(), Do([this] { omnibox()->SetUserText(u"Hello World"); }),
+      WaitForHidden());
+}

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -751,6 +751,10 @@ if (!is_android) {
       "//ui/compositor",
     ]
 
+    if (enable_commander) {
+      deps += [ "//brave/browser/ui/commander:interactive_ui_tests" ]
+    }
+
     if (is_win) {
       deps += [ "//ui/aura:test_support" ]
     }

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -27,6 +27,7 @@ import("//brave/components/tor/buildflags/buildflags.gni")
 import("//brave/components/web_discovery/buildflags/buildflags.gni")
 import("//brave/test/testing.gni")
 import("//brave/updater/config.gni")
+import("//build/config/ui.gni")
 import("//chrome/common/features.gni")
 import("//components/captive_portal/core/features.gni")
 import("//components/gcm_driver/config.gni")
@@ -727,6 +728,33 @@ static_library("browser_tests_runner") {
   }
   public_deps = [ ":browser_test_support" ]
   sources = [ "base/browser_tests_main.cc" ]
+}
+
+if (!is_android) {
+  test("brave_interactive_ui_tests") {
+    testonly = true
+
+    use_xvfb = use_xvfb_in_this_config
+
+    configs += [ "//build/config:precompiled_headers" ]
+
+    defines = [ "HAS_OUT_OF_PROC_TEST_RUNNER" ]
+
+    sources = [ "//chrome/test/base/interactive_ui_tests_main.cc" ]
+
+    deps = [
+      "//chrome/browser",
+      "//chrome/test:chrome_test_launcher",
+      "//chrome/test:test_support",
+      "//chrome/test:test_support_ui",
+      "//ui/base/interaction",
+      "//ui/compositor",
+    ]
+
+    if (is_win) {
+      deps += [ "//ui/aura:test_support" ]
+    }
+  }
 }
 
 if (!is_android) {

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -755,8 +755,15 @@ if (!is_android) {
       deps += [ "//brave/browser/ui/commander:interactive_ui_tests" ]
     }
 
-    if (is_win) {
+    if (use_aura) {
       deps += [ "//ui/aura:test_support" ]
+    }
+
+    if (use_ozone) {
+      deps += [
+        "//ui/ozone",
+        "//ui/platform_window/common",
+      ]
     }
   }
 }

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -743,6 +743,8 @@ if (!is_android) {
     sources = [ "//chrome/test/base/interactive_ui_tests_main.cc" ]
 
     deps = [
+      "//brave:packed_resources",
+      "//chrome:packed_resources",
       "//chrome/browser",
       "//chrome/test:chrome_test_launcher",
       "//chrome/test:test_support",


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/54558

  - Adds a brave_interactive_ui_tests test executable to brave/test/BUILD.gn mirroring Chromium's interactive_ui_tests target. It reuses chrome/test/base/interactive_ui_tests_main.cc directly to avoid divergence with upstream.
  - Converts MANUAL_HideClearsText and MANUAL_CanHideCommanderViaText from commander_service_browsertest.cc into proper interactive UI tests in a new brave/browser/ui/commander:interactive_ui_tests source set as a real example.                                  
  - Removes the two MANUAL tests from the browser test file; they were only manually runnable because they depend on window  focus, which is exactly what interactive_ui_tests provides (serial execution with exclusive focus).                        
                  
Tests rewritten with InteractiveBrowserTest.                                                                     
The new tests use RunTestSequence with PollState/WaitForState instead of timer-based polling,
which is the upstream-recommended pattern for async conditions in interactive UI tests

`npm run test brave_interactive_ui_tests -- --filter=CommanderServiceInteractiveUITest.*`   

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
