### PR TITLE
Fix Brave hiding logic not applying on server-side 302 redirects.

### DIFF
--- a/browser/net/brave_user_agent_network_delegate_helper.cc
+++ b/browser/net/brave_user_agent_network_delegate_helper.cc
@@ -22,7 +22,7 @@ constexpr char kHeaderSecCHUAFullVersionList[] = "Sec-CH-UA-Full-Version-List";
 constexpr char kBraveBrand[] = "\"Brave\"";
 constexpr char kGoogleChromeBrand[] = "\"Google Chrome\"";
 
-void ReplaceBraveWithGoogleChromeInHeader(net::HttpRequestHeaders* headers,
+bool ReplaceBraveWithGoogleChromeInHeader(net::HttpRequestHeaders* headers,
                                           const char* header_name) {
   std::optional<std::string> header_value = headers->GetHeader(header_name);
   if (header_value) {
@@ -30,7 +30,9 @@ void ReplaceBraveWithGoogleChromeInHeader(net::HttpRequestHeaders* headers,
     base::ReplaceFirstSubstringAfterOffset(&value, /*start_offset=*/0,
                                            kBraveBrand, kGoogleChromeBrand);
     headers->SetHeader(header_name, value);
+    return true;
   }
+  return false;
 }
 
 }  // namespace
@@ -46,9 +48,13 @@ int OnBeforeStartTransaction_UserAgentWork(
     if (exceptions) {
       bool show_brave = exceptions->CanShowBrave(ctx->tab_origin());
       if (!show_brave) {
-        ReplaceBraveWithGoogleChromeInHeader(headers, kHeaderSecCHUA);
-        ReplaceBraveWithGoogleChromeInHeader(headers,
-                                             kHeaderSecCHUAFullVersionList);
+        if (ReplaceBraveWithGoogleChromeInHeader(headers, kHeaderSecCHUA)) {
+          ctx->mutable_modified_headers().insert(kHeaderSecCHUA);
+        }
+        if (ReplaceBraveWithGoogleChromeInHeader(
+                headers, kHeaderSecCHUAFullVersionList)) {
+          ctx->mutable_modified_headers().insert(kHeaderSecCHUAFullVersionList);
+        }
       }
     }
   }

--- a/browser/net/brave_user_agent_network_delegate_helper_browsertest.cc
+++ b/browser/net/brave_user_agent_network_delegate_helper_browsertest.cc
@@ -3,6 +3,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include <optional>
+#include <string>
+#include <vector>
+
 #include "base/feature_list.h"
 #include "base/path_service.h"
 #include "base/test/scoped_feature_list.h"
@@ -15,6 +19,7 @@
 #include "content/public/test/browser_test.h"
 #include "content/public/test/browser_test_utils.h"
 #include "net/dns/mock_host_resolver.h"
+#include "net/http/http_status_code.h"
 #include "net/test/embedded_test_server/http_request.h"
 #include "net/test/embedded_test_server/http_response.h"
 #include "testing/gtest/include/gtest/gtest.h"
@@ -27,6 +32,8 @@ constexpr char kBraveBrand[] = "Brave";
 constexpr char kGoogleChromeBrand[] = "Google Chrome";
 
 struct HeaderCapture {
+  bool allows_brave_header = false;
+  std::string path;
   std::optional<std::string> sec_ch_ua;
   std::optional<std::string> sec_ch_ua_full_version_list;
 };
@@ -45,37 +52,35 @@ class BraveUserAgentNetworkDelegateBrowserTest
       public ::testing::WithParamInterface<bool> {
  public:
   BraveUserAgentNetworkDelegateBrowserTest() {
-    auto* command_line = base::CommandLine::ForCurrentProcess();
-    if (command_line->HasSwitch("enable-brave-user-agent")) {
+    if (GetParam()) {
       feature_list_.InitAndEnableFeature(
           brave_user_agent::features::kUseBraveUserAgent);
-    } else if (command_line->HasSwitch("disable-brave-user-agent")) {
+    } else {
       feature_list_.InitAndDisableFeature(
           brave_user_agent::features::kUseBraveUserAgent);
     }
   }
 
-  void SetUpCommandLine(base::CommandLine* command_line) override {
-    if (GetParam()) {
-      command_line->AppendSwitch("enable-brave-user-agent");
-    } else {
-      command_line->AppendSwitch("disable-brave-user-agent");
-    }
-  }
-
   void SetUpOnMainThread() override {
     InProcessBrowserTest::SetUpOnMainThread();
-    // Add excepted domains for testing
-    auto* exceptions =
-        brave_user_agent::BraveUserAgentExceptions::GetInstance();
-    exceptions->AddToExceptedDomainsForTesting("a.test");
-    exceptions->SetIsReadyForTesting();
+    if (GetParam()) {
+      // Add excepted domains for testing
+      auto* exceptions =
+          brave_user_agent::BraveUserAgentExceptions::GetInstance();
+      exceptions->AddToExceptedDomainsForTesting("a.test");
+      exceptions->SetIsReadyForTesting();
+    } else {
+      ASSERT_FALSE(brave_user_agent::BraveUserAgentExceptions::GetInstance());
+    }
+
     host_resolver()->AddRule("*", "127.0.0.1");
     https_server_.SetSSLConfig(net::EmbeddedTestServer::CERT_TEST_NAMES);
     https_server_.RegisterRequestMonitor(base::BindRepeating(
         &BraveUserAgentNetworkDelegateBrowserTest::HandleRequest,
         base::Unretained(this)));
-    RegisterImagePageHandler();
+    https_server_.RegisterRequestHandler(base::BindRepeating(
+        &BraveUserAgentNetworkDelegateBrowserTest::HandleCustomRequest,
+        base::Unretained(this)));
     base::FilePath test_data_dir =
         base::PathService::CheckedGet(brave::DIR_TEST_DATA);
     https_server_.ServeFilesFromDirectory(test_data_dir);
@@ -83,26 +88,38 @@ class BraveUserAgentNetworkDelegateBrowserTest
   }
 
  protected:
-  void RegisterImagePageHandler();
+  std::unique_ptr<::net::test_server::HttpResponse> HandleCustomRequest(
+      const net::test_server::HttpRequest& request);
   void HandleRequest(const net::test_server::HttpRequest& request);
   void StartTracking();
-  HeaderCapture header_capture();
+  const std::vector<HeaderCapture>& header_capture();
   net::EmbeddedTestServer& https_server();
   void RunBrandHeaderTest(const std::string& domain, const std::string& path);
   void NavigateAndWait(const GURL& url);
-  base::test::ScopedFeatureList feature_list_;
 
-  void ExpectHeaderBrands(const HeaderCapture& capture, bool feature_enabled) {
-    ASSERT_TRUE(capture.sec_ch_ua.has_value());
-    ASSERT_TRUE(capture.sec_ch_ua_full_version_list.has_value());
-    if (feature_enabled) {
-      // Excepted domain, feature enabled: expect Google Chrome
-      EXPECT_EQ(!feature_enabled, capture.sec_ch_ua->contains(kBraveBrand));
-      EXPECT_EQ(!feature_enabled,
+  void ExpectHeaderBrands(const std::vector<HeaderCapture>& captures) {
+    ASSERT_TRUE(!captures.empty());
+
+    for (const auto& capture : captures) {
+      SCOPED_TRACE(capture.path);
+
+      ASSERT_TRUE(capture.sec_ch_ua.has_value());
+      ASSERT_TRUE(capture.sec_ch_ua_full_version_list.has_value());
+
+      const bool feature_enabled = GetParam();
+      const bool contains_brave =
+          capture.allows_brave_header || !feature_enabled;
+      const bool contains_chrome =
+          !capture.allows_brave_header && feature_enabled;
+
+      EXPECT_NE(contains_brave, contains_chrome);
+
+      EXPECT_EQ(contains_brave, capture.sec_ch_ua->contains(kBraveBrand));
+      EXPECT_EQ(contains_brave,
                 capture.sec_ch_ua_full_version_list->contains(kBraveBrand));
-      EXPECT_EQ(feature_enabled,
+      EXPECT_EQ(contains_chrome,
                 capture.sec_ch_ua->contains(kGoogleChromeBrand));
-      EXPECT_EQ(feature_enabled, capture.sec_ch_ua_full_version_list->contains(
+      EXPECT_EQ(contains_chrome, capture.sec_ch_ua_full_version_list->contains(
                                      kGoogleChromeBrand));
     }
   }
@@ -110,35 +127,53 @@ class BraveUserAgentNetworkDelegateBrowserTest
  private:
   base::Lock header_lock_;
   bool start_tracking_ = false;
-  HeaderCapture header_capture_;
+  std::vector<HeaderCapture> header_capture_;
   net::EmbeddedTestServer https_server_{net::EmbeddedTestServer::TYPE_HTTPS};
+  base::test::ScopedFeatureList feature_list_;
 };
 
-void BraveUserAgentNetworkDelegateBrowserTest::RegisterImagePageHandler() {
-  https_server_.RegisterRequestHandler(base::BindRepeating(
-      [](const net::test_server::HttpRequest& request)
-          -> std::unique_ptr<::net::test_server::HttpResponse> {
-        if (request.relative_url == "/page_with_image.html") {
-          auto* response = new ::net::test_server::BasicHttpResponse();
-          response->set_content(
-              "<html><body><img src=\"https://b.test/image.png\" "
-              "/></body></html>");
-          response->set_content_type("text/html");
-          response->AddCustomHeader("Accept-CH", "Sec-CH-UA-Full-Version-List");
-          return std::unique_ptr<::net::test_server::HttpResponse>(response);
-        }
-        if (request.relative_url == "/simple.html") {
-          auto* response = new ::net::test_server::BasicHttpResponse();
-          response->set_content("<html><body>ok</body></html>");
-          response->set_content_type("text/html");
-          response->AddCustomHeader("Accept-CH", "Sec-CH-UA-Full-Version-List");
-          return std::unique_ptr<::net::test_server::HttpResponse>(response);
-        }
-        if (request.relative_url == "/image.png") {
-          return CreateBasicHttpResponse("fake image", "image/png");
-        }
-        return nullptr;
-      }));
+std::unique_ptr<::net::test_server::HttpResponse>
+BraveUserAgentNetworkDelegateBrowserTest::HandleCustomRequest(
+    const net::test_server::HttpRequest& request) {
+  if (request.relative_url == "/a.test/redirect_a_to_b.html") {
+    auto* response = new ::net::test_server::BasicHttpResponse();
+    response->set_code(net::HTTP_FOUND);
+    response->AddCustomHeader(
+        "Location",
+        https_server_.GetURL("b.test", "/b.test/simple.html").spec());
+    response->AddCustomHeader("Accept-CH", "Sec-CH-UA-Full-Version-List");
+    return std::unique_ptr<::net::test_server::HttpResponse>(response);
+  }
+  if (request.relative_url == "/b.test/redirect_b_to_a.html") {
+    auto* response = new ::net::test_server::BasicHttpResponse();
+    response->set_code(net::HTTP_FOUND);
+    response->AddCustomHeader(
+        "Location",
+        https_server_.GetURL("a.test", "/a.test/simple.html").spec());
+    response->AddCustomHeader("Accept-CH", "Sec-CH-UA-Full-Version-List");
+    return std::unique_ptr<::net::test_server::HttpResponse>(response);
+  }
+  if (request.relative_url == "/a.test/page_with_image.html") {
+    auto* response = new ::net::test_server::BasicHttpResponse();
+    response->set_content(
+        "<html><body><img src=\"https://b.test/b.test/image.png\" "
+        "/></body></html>");
+    response->set_content_type("text/html");
+    response->AddCustomHeader("Accept-CH", "Sec-CH-UA-Full-Version-List");
+    return std::unique_ptr<::net::test_server::HttpResponse>(response);
+  }
+  if (request.relative_url == "/a.test/simple.html" ||
+      request.relative_url == "/b.test/simple.html") {
+    auto* response = new ::net::test_server::BasicHttpResponse();
+    response->set_content("<html><body>ok</body></html>");
+    response->set_content_type("text/html");
+    response->AddCustomHeader("Accept-CH", "Sec-CH-UA-Full-Version-List");
+    return std::unique_ptr<::net::test_server::HttpResponse>(response);
+  }
+  if (request.relative_url == "/b.test/image.png") {
+    return CreateBasicHttpResponse("fake image", "image/png");
+  }
+  return nullptr;
 }
 
 void BraveUserAgentNetworkDelegateBrowserTest::HandleRequest(
@@ -147,23 +182,35 @@ void BraveUserAgentNetworkDelegateBrowserTest::HandleRequest(
   if (!start_tracking_) {
     return;
   }
+
+  if (request.relative_url.starts_with("/favicon")) {
+    return;
+  }
+
+  HeaderCapture capture;
+  capture.path = request.relative_url;
+  capture.allows_brave_header = !request.relative_url.starts_with("/a.test/");
+
   auto it = request.headers.find(kSecCHUAHeader);
   if (it != request.headers.end()) {
-    header_capture_.sec_ch_ua = it->second;
+    capture.sec_ch_ua = it->second;
   }
   auto it2 = request.headers.find(kSecCHUAFullVersionListHeader);
   if (it2 != request.headers.end()) {
-    header_capture_.sec_ch_ua_full_version_list = it2->second;
+    capture.sec_ch_ua_full_version_list = it2->second;
   }
+
+  header_capture_.push_back(std::move(capture));
 }
 
 void BraveUserAgentNetworkDelegateBrowserTest::StartTracking() {
   base::AutoLock auto_lock(header_lock_);
   start_tracking_ = true;
-  header_capture_ = HeaderCapture{};
+  header_capture_.clear();
 }
 
-HeaderCapture BraveUserAgentNetworkDelegateBrowserTest::header_capture() {
+const std::vector<HeaderCapture>&
+BraveUserAgentNetworkDelegateBrowserTest::header_capture() {
   base::AutoLock auto_lock(header_lock_);
   return header_capture_;
 }
@@ -195,20 +242,30 @@ void BraveUserAgentNetworkDelegateBrowserTest::RunBrandHeaderTest(
   NavigateAndWait(url);  // Prime client hint cache
   StartTracking();
   NavigateAndWait(url);  // Actual test navigation
-  ExpectHeaderBrands(header_capture(), GetParam());
+  ExpectHeaderBrands(header_capture());
 }
 
 IN_PROC_BROWSER_TEST_P(BraveUserAgentNetworkDelegateBrowserTest,
                        SecCHUAHeadersBrandCheck) {
-  RunBrandHeaderTest("a.test", "/simple.html");
+  RunBrandHeaderTest("a.test", "/a.test/simple.html");
 }
 
 IN_PROC_BROWSER_TEST_P(BraveUserAgentNetworkDelegateBrowserTest,
                        SecCHUAHeadersBrandCheckOnThirdPartyRequest) {
-  RunBrandHeaderTest("a.test", "/page_with_image.html");
+  RunBrandHeaderTest("a.test", "/a.test/page_with_image.html");
+}
+
+IN_PROC_BROWSER_TEST_P(BraveUserAgentNetworkDelegateBrowserTest,
+                       SecCHUAHeadersAfterRedirectFromExceptedToNonExcepted) {
+  RunBrandHeaderTest("a.test", "/a.test/redirect_a_to_b.html");
+}
+
+IN_PROC_BROWSER_TEST_P(BraveUserAgentNetworkDelegateBrowserTest,
+                       SecCHUAHeadersAfterRedirectFromNonExceptedToExcepted) {
+  RunBrandHeaderTest("b.test", "/b.test/redirect_b_to_a.html");
 }
 
 INSTANTIATE_TEST_SUITE_P(FeatureFlag,
                          BraveUserAgentNetworkDelegateBrowserTest,
-                         ::testing::Values(true, false));
+                         ::testing::Bool());
 }  // namespace


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/54406

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
