### PR TITLE
[iOS] Add safe builtins JavaScript feature

### DIFF
--- a/ios/browser/web/BUILD.gn
+++ b/ios/browser/web/BUILD.gn
@@ -37,6 +37,7 @@ source_set("web") {
     "//brave/ios/browser/web/night_mode",
     "//brave/ios/browser/web/page_metadata",
     "//brave/ios/browser/web/reader_mode",
+    "//brave/ios/web/js_messaging",
     "//components/component_updater/installer_policies",
     "//components/language/ios/browser",
     "//components/translate/ios/browser",

--- a/ios/browser/web/brave_web_client.mm
+++ b/ios/browser/web/brave_web_client.mm
@@ -29,6 +29,7 @@
 #include "brave/ios/browser/web/night_mode/night_mode_javascript_feature.h"
 #include "brave/ios/browser/web/page_metadata/page_metadata_javascript_feature.h"
 #include "brave/ios/browser/web/reader_mode/reader_mode_javascript_feature.h"
+#include "brave/ios/web/js_messaging/safe_builtins_javascript_feature.h"
 #include "components/autofill/ios/browser/autofill_java_script_feature.h"
 #include "components/autofill/ios/browser/suggestion_controller_java_script_feature.h"
 #include "components/autofill/ios/form_util/form_handlers_java_script_feature.h"
@@ -123,6 +124,9 @@ std::vector<web::JavaScriptFeature*> BraveWebClient::GetJavaScriptFeatures(
     features.push_back(
         language::LanguageDetectionJavaScriptFeature::GetInstance());
     features.push_back(translate::TranslateJavaScriptFeature::GetInstance());
+
+    // The base safe builtins should be added before other Brave JS features
+    features.push_back(SafeBuiltinsJavaScriptFeature::GetInstance());
 
     // Add Brave iOS ported JavaScriptFeatures based on their original
     // counterpart in //brave-ios

--- a/ios/web/BUILD.gn
+++ b/ios/web/BUILD.gn
@@ -13,6 +13,7 @@ test("ios_brave_web_unittests") {
     "//ios/web:run_all_unittests",
 
     # Add individual test source_set targets here.
+    "//brave/ios/web/js_messaging:unittests",
     "//brave/ios/web/webui:ios_web_webui_unittests",
   ]
 }

--- a/ios/web/js_messaging/BUILD.gn
+++ b/ios/web/js_messaging/BUILD.gn
@@ -1,0 +1,44 @@
+# Copyright (c) 2025 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import("//ios/web/public/js_messaging/compile_ts.gni")
+import("//ios/web/public/js_messaging/optimize_js.gni")
+
+source_set("js_messaging") {
+  sources = [
+    "safe_builtins_javascript_feature.h",
+    "safe_builtins_javascript_feature.mm",
+  ]
+  deps = [ ":safe_builtins_js" ]
+  public_deps = [ "//ios/web/public/js_messaging" ]
+}
+
+source_set("unittests") {
+  testonly = true
+  sources = [ "safe_builtins_javascript_test.mm" ]
+  deps = [
+    ":safe_builtins_js",
+    "//base",
+    "//base/test:test_support",
+    "//ios/web/public/test:javascript_test",
+    "//ios/web/public/test:util",
+    "//testing/gtest",
+    "//url",
+  ]
+}
+
+compile_ts("safe_builtins") {
+  sources = [ "resources/safe_builtins.ts" ]
+}
+
+optimize_js("safe_builtins_js") {
+  _script = filter_include(get_target_outputs(":safe_builtins"),
+                           [ "*safe_builtins.js" ])
+  primary_script = _script[0]
+  sources = _script
+  output_name = "safe_builtins"
+
+  deps = [ ":safe_builtins" ]
+}

--- a/ios/web/js_messaging/resources/safe_builtins.ts
+++ b/ios/web/js_messaging/resources/safe_builtins.ts
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+class SafeBuiltins {
+  readonly $Object: typeof Object = this.secureCopy(Object);
+  readonly $Function: typeof Function = this.secureCopy(Function);
+  readonly $Array: typeof Array = this.secureCopy(Array);
+  readonly $ = function(value: any): any { return value; }
+
+  constructor() {
+    // Freeze all the safe builtins
+    for (const value of [this.$Object, this.$Function, this.$Array, this.$]) {
+      this.deepFreeze(value);
+    }
+  }
+
+  // Freeze an object and its prototype
+  deepFreeze(value: any) {
+    if (!value) {
+      return;
+    }
+    this.$Object.freeze(value);
+    const prototype = (value as any).prototype;
+    if (prototype) {
+      this.$Object.freeze(prototype);
+    }
+  }
+
+  // Copies an object's signature to an object with no prototype to prevent
+  // prototype polution attacks
+  private secureCopy(value: any): any {
+    let prototypeProperties = Object.create(null, value.prototype ?
+      Object.getOwnPropertyDescriptors(value.prototype) : {});
+    delete prototypeProperties['prototype'];
+
+    let properties = Object.assign(
+      Object.create(null),
+      Object.getOwnPropertyDescriptors(value),
+      value.prototype ? Object.getOwnPropertyDescriptors(value.prototype) :
+        {}
+    );
+
+    // Do not copy the prototype.
+    delete properties['prototype'];
+
+    return new Proxy(Object.create(null, properties), {
+      get(target, property, _receiver) {
+        if (property == 'prototype') {
+          return prototypeProperties;
+        }
+        return target[property];
+      }
+    });
+  }
+}
+
+type SafeBuiltinsType = Window&(typeof globalThis)&{readonly __gSafeBuiltins: SafeBuiltins};
+
+// Initializes window's `__gSafeBuiltins` property.
+if (!(window as SafeBuiltinsType).__gSafeBuiltins) {
+  Object.defineProperty(window, '__gSafeBuiltins', {
+    value: Object.freeze(new SafeBuiltins()),
+    writable: false,
+    configurable: false,
+    enumerable: false
+  });
+}
+
+export const gSafeBuiltins: SafeBuiltins = (window as SafeBuiltinsType).__gSafeBuiltins;
+
+// Export some shortcuts to items in SafeBuiltins
+export const $Object = gSafeBuiltins.$Object;
+export const $Function = gSafeBuiltins.$Function;
+export const $Array = gSafeBuiltins.$Array;
+export const $ = gSafeBuiltins.$;

--- a/ios/web/js_messaging/safe_builtins_javascript_feature.h
+++ b/ios/web/js_messaging/safe_builtins_javascript_feature.h
@@ -1,0 +1,25 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_IOS_WEB_JS_MESSAGING_SAFE_BUILTINS_JAVASCRIPT_FEATURE_H_
+#define BRAVE_IOS_WEB_JS_MESSAGING_SAFE_BUILTINS_JAVASCRIPT_FEATURE_H_
+
+#include "base/no_destructor.h"
+#include "ios/web/public/js_messaging/java_script_feature.h"
+
+class SafeBuiltinsJavaScriptFeature : public web::JavaScriptFeature {
+ public:
+  // This feature holds no state, so only a single static instance is ever
+  // needed.
+  static SafeBuiltinsJavaScriptFeature* GetInstance();
+
+ private:
+  friend class base::NoDestructor<SafeBuiltinsJavaScriptFeature>;
+
+  SafeBuiltinsJavaScriptFeature();
+  ~SafeBuiltinsJavaScriptFeature() override;
+};
+
+#endif  // BRAVE_IOS_WEB_JS_MESSAGING_SAFE_BUILTINS_JAVASCRIPT_FEATURE_H_

--- a/ios/web/js_messaging/safe_builtins_javascript_feature.mm
+++ b/ios/web/js_messaging/safe_builtins_javascript_feature.mm
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/ios/web/js_messaging/safe_builtins_javascript_feature.h"
+
+#include "ios/web/public/js_messaging/java_script_feature.h"
+
+namespace {
+constexpr char kScriptName[] = "safe_builtins";
+}
+
+SafeBuiltinsJavaScriptFeature::SafeBuiltinsJavaScriptFeature()
+    : JavaScriptFeature(
+          web::ContentWorld::kAllContentWorlds,
+          std::vector<JavaScriptFeature::FeatureScript>(
+              {JavaScriptFeature::FeatureScript::CreateWithFilename(
+                  kScriptName,
+                  JavaScriptFeature::FeatureScript::InjectionTime::
+                      kDocumentStart,
+                  JavaScriptFeature::FeatureScript::TargetFrames::
+                      kAllFrames)})) {}
+
+SafeBuiltinsJavaScriptFeature::~SafeBuiltinsJavaScriptFeature() = default;
+
+// static
+SafeBuiltinsJavaScriptFeature* SafeBuiltinsJavaScriptFeature::GetInstance() {
+  static base::NoDestructor<SafeBuiltinsJavaScriptFeature> instance;
+  return instance.get();
+}

--- a/ios/web/js_messaging/safe_builtins_javascript_test.mm
+++ b/ios/web/js_messaging/safe_builtins_javascript_test.mm
@@ -1,0 +1,130 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include <string>
+#include <utility>
+
+#include "ios/web/public/test/javascript_test.h"
+#include "ios/web/public/test/js_test_util.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "testing/gtest_mac.h"
+
+namespace {
+constexpr char kContainer[] = "window.__gSafeBuiltins";
+constexpr char kObject[] = "Object";
+constexpr char kArray[] = "Array";
+constexpr char kFunction[] = "Function";
+constexpr char kSafeObject[] = "window.__gSafeBuiltins.$Object";
+constexpr char kSafeArray[] = "window.__gSafeBuiltins.$Array";
+constexpr char kSafeFunction[] = "window.__gSafeBuiltins.$Function";
+}  // namespace
+
+class SafeBuiltinsContainerJavaScriptTest : public web::JavascriptTest {
+ protected:
+  void SetUp() override {
+    JavascriptTest::SetUp();
+    AddUserScript(@"safe_builtins");
+
+    ASSERT_TRUE(LoadHtml(@"<p>"));
+  }
+};
+
+// Tests that the safe builtins container (__gSafeBuiltins) is frozen and cannot
+// be altered
+TEST_F(SafeBuiltinsContainerJavaScriptTest, TestContainerIsFrozen) {
+  // The container has no prototype and should remain that way
+  id result = web::test::ExecuteJavaScript(
+      web_view(), [NSString stringWithFormat:@"%s.prototype", kContainer]);
+  EXPECT_NSEQ(nil, result);
+
+  web::test::ExecuteJavaScriptInWebView(
+      web_view(),
+      [NSString stringWithFormat:@"%s.prototype = {};", kContainer]);
+
+  id protectedResult = web::test::ExecuteJavaScript(
+      web_view(), [NSString stringWithFormat:@"%s.prototype", kContainer]);
+  EXPECT_NSEQ(nil, protectedResult);
+}
+
+class SafeBuiltinsJavaScriptTest
+    : public web::JavascriptTest,
+      public testing::WithParamInterface<std::pair<std::string, std::string>> {
+ protected:
+  void SetUp() override {
+    JavascriptTest::SetUp();
+    AddUserScript(@"safe_builtins");
+
+    ASSERT_TRUE(LoadHtml(@"<p>"));
+  }
+};
+
+INSTANTIATE_TEST_SUITE_P(AllSafeBuiltins,
+                         SafeBuiltinsJavaScriptTest,
+                         testing::Values(std::make_pair(kObject, kSafeObject),
+                                         std::make_pair(kArray, kSafeArray),
+                                         std::make_pair(kFunction,
+                                                        kSafeFunction)));
+
+// Tests that a value added to the prototype of a builtin is not visible in
+// the equivalent safe builtin prototype
+TEST_P(SafeBuiltinsJavaScriptTest, TestBuiltinPrototypeAssignment) {
+  std::string builtin = GetParam().first;
+  std::string safe_builtin = GetParam().second;
+
+  id result = web::test::ExecuteJavaScript(
+      web_view(), [NSString stringWithFormat:@"%s.prototype.testValue = 1;",
+                                             builtin.c_str()]);
+  EXPECT_NSEQ(@1, result);
+
+  id protectedResult = web::test::ExecuteJavaScript(
+      web_view(), [NSString stringWithFormat:@"%s.prototype.testValue",
+                                             safe_builtin.c_str()]);
+  EXPECT_NSNE(@1, protectedResult);
+}
+
+// Tests that the safe builtins prototype is frozen and cannot be altered
+TEST_P(SafeBuiltinsJavaScriptTest, TestSafeBuiltinPrototypeIsFrozen) {
+  std::string safe_builtin = GetParam().second;
+
+  web::test::ExecuteJavaScriptInWebView(
+      web_view(), [NSString stringWithFormat:@"%s.prototype.testValue = 1;",
+                                             safe_builtin.c_str()]);
+
+  id protectedResult = web::test::ExecuteJavaScript(
+      web_view(), [NSString stringWithFormat:@"%s.prototype.testValue",
+                                             safe_builtin.c_str()]);
+  EXPECT_NSNE(@1, protectedResult);
+}
+
+// Tests that editing a value on the builtin is does not alter it on the
+// equivalent safe builtin
+TEST_P(SafeBuiltinsJavaScriptTest, TestBuiltinAssignment) {
+  std::string builtin = GetParam().first;
+  std::string safe_builtin = GetParam().second;
+
+  web::test::ExecuteJavaScriptInWebView(
+      web_view(),
+      [NSString stringWithFormat:@"%s.name = function() { return 1; }",
+                                 builtin.c_str()]);
+
+  id protectedResult = web::test::ExecuteJavaScript(
+      web_view(), [NSString stringWithFormat:@"%s.name", safe_builtin.c_str()]);
+  EXPECT_NSNE(@1, protectedResult);
+}
+
+// Tests that the safe builtin is frozen and cannot be altered
+TEST_P(SafeBuiltinsJavaScriptTest, TestSafeBuiltinIsFrozen) {
+  std::string builtin = GetParam().first;
+  std::string safe_builtin = GetParam().second;
+
+  web::test::ExecuteJavaScriptInWebView(
+      web_view(),
+      [NSString stringWithFormat:@"%s.name = function() { return 1; }",
+                                 safe_builtin.c_str()]);
+
+  id protectedResult = web::test::ExecuteJavaScript(
+      web_view(), [NSString stringWithFormat:@"%s.name", safe_builtin.c_str()]);
+  EXPECT_NSNE(@1, protectedResult);
+}


### PR DESCRIPTION
This adds a base JavaScriptFeature for accessing safe builtins in Brave JS features that require it based on the code in `__firefox__.js`. The main difference here is that this PR only focuses on the builtins (Object, Function, Array) needed for Web3 scripts and does not handle any `toString` overrides (which were only needed for tokenized communication)

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/54685
