### PR TITLE
Hide chevron on Brave Origin reset to defaults row

### DIFF
--- a/browser/resources/settings/brave_origin_page/brave_origin_page.html
+++ b/browser/resources/settings/brave_origin_page/brave_origin_page.html
@@ -65,6 +65,10 @@
     font-size: .875rem;
     padding: 14px 38px;
   }
+
+  #resetToDefaults::part(icon) {
+    display: none;
+  }
 </style>
 
 <template is="dom-if" if="[[!isPurchased_]]">
@@ -192,7 +196,7 @@
   </origin-toggle-button>
   -->
 
-  <cr-link-row class="hr"
+  <cr-link-row id="resetToDefaults" class="hr"
     label="$i18n{braveOriginResetToDefaultsTitle}"
     on-click="resetToDefaults_"
     start-icon="refresh">


### PR DESCRIPTION
## Summary
- The reset to defaults row on `chrome://settings/origin` is an action button, not a link to another page.
- Hide the trailing chevron on the `cr-link-row` so it no longer looks like it navigates.