### PR TITLE
Add "did not navigate" answer to daily query metrics (uplift to 1.90.x)

### DIFF
--- a/browser/misc_metrics/BUILD.gn
+++ b/browser/misc_metrics/BUILD.gn
@@ -142,6 +142,7 @@ source_set("unit_tests") {
     "//brave/browser/misc_metrics:misc_metrics_impl",
     "//brave/components/brave_rewards/core",
     "//brave/components/misc_metrics",
+    "//brave/components/p3a_utils:test_support",
     "//chrome/browser",
     "//chrome/browser/bookmarks",
     "//chrome/browser/content_settings:content_settings_factory",

--- a/browser/misc_metrics/media_session_metrics.cc
+++ b/browser/misc_metrics/media_session_metrics.cc
@@ -5,6 +5,7 @@
 
 #include "brave/browser/misc_metrics/media_session_metrics.h"
 
+#include <array>
 #include <utility>
 
 #include "base/check.h"
@@ -13,6 +14,7 @@
 #include "brave/components/misc_metrics/pref_names.h"
 #include "brave/components/misc_metrics/uptime_monitor.h"
 #include "brave/components/p3a_utils/bucket.h"
+#include "brave/components/p3a_utils/custom_attributes.h"
 #include "components/prefs/pref_registry_simple.h"
 #include "components/prefs/pref_service.h"
 #include "content/public/browser/media_session.h"
@@ -26,6 +28,9 @@ constexpr base::TimeDelta kTickInterval = base::Seconds(30);
 constexpr base::TimeDelta kFrameDuration = base::Days(7);
 
 constexpr int kMediaSessionUsageBuckets[] = {0, 20, 40, 60, 80, 100};
+constexpr int kMediaSessionUsageAttributeThresholds[] = {0, 33, 67};
+constexpr std::array<std::string_view, 4> kMediaSessionUsageAttributeValues = {
+    "0", "1-33", "34-67", "68-100"};
 
 }  // namespace
 
@@ -149,6 +154,8 @@ void MediaSessionMetrics::ReportMetric() {
   base::TimeDelta active_time =
       local_state_->GetTimeDelta(kMiscMetricsMediaSessionActiveProcessTime);
   if (active_time.is_zero()) {
+    p3a_utils::SetCustomAttribute(kMediaSessionUsageAttributeName,
+                                  std::nullopt);
     return;
   }
 
@@ -158,6 +165,11 @@ void MediaSessionMetrics::ReportMetric() {
   if (percentage == 0 && !media_time.is_zero()) {
     percentage = 1;
   }
+
+  p3a_utils::SetCustomAttribute(
+      kMediaSessionUsageAttributeName,
+      kMediaSessionUsageAttributeValues.at(p3a_utils::BucketIndex(
+          kMediaSessionUsageAttributeThresholds, percentage)));
 
   p3a_utils::RecordToHistogramBucket(kMediaSessionUsageHistogramName,
                                      kMediaSessionUsageBuckets, percentage);

--- a/browser/misc_metrics/media_session_metrics.h
+++ b/browser/misc_metrics/media_session_metrics.h
@@ -29,6 +29,7 @@ namespace misc_metrics {
 
 inline constexpr char kMediaSessionUsageHistogramName[] =
     "Brave.Core.MediaSessionUsage";
+inline constexpr char kMediaSessionUsageAttributeName[] = "media_session_usage";
 
 // Observes media session activity to track the percentage of active browsing
 // time during which media was playing. Reports metrics on a weekly basis.

--- a/browser/misc_metrics/media_session_metrics_unittest.cc
+++ b/browser/misc_metrics/media_session_metrics_unittest.cc
@@ -6,10 +6,13 @@
 #include "brave/browser/misc_metrics/media_session_metrics.h"
 
 #include <memory>
+#include <string>
 
 #include "base/test/metrics/histogram_tester.h"
 #include "base/test/task_environment.h"
 #include "brave/components/misc_metrics/uptime_monitor.h"
+#include "brave/components/p3a_utils/custom_attributes.h"
+#include "brave/components/p3a_utils/test_event_relay_observer.h"
 #include "components/prefs/testing_pref_service.h"
 #include "content/public/test/mock_media_session.h"
 #include "mojo/public/cpp/bindings/remote.h"
@@ -76,6 +79,7 @@ class MediaSessionMetricsTest : public testing::Test {
   base::test::TaskEnvironment task_environment_;
   TestingPrefServiceSimple local_state_;
   base::HistogramTester histogram_tester_;
+  p3a_utils::TestEventRelayObserver relay_observer_;
 
   MockUptimeMonitor uptime_monitor_;
 
@@ -91,16 +95,20 @@ TEST_F(MediaSessionMetricsTest, NoReportBeforeOneWeek) {
   AddSession();
   task_environment_.FastForwardBy(base::Days(6));
   histogram_tester_.ExpectTotalCount(kMediaSessionUsageHistogramName, 0);
+  EXPECT_EQ(relay_observer_.GetCustomAttribute(kMediaSessionUsageAttributeName),
+            std::nullopt);
 }
 
 TEST_F(MediaSessionMetricsTest, ZeroPercentBucket) {
   // No media playing → 0 media minutes → 0% → bucket 0.
   task_environment_.FastForwardBy(base::Days(7));
   histogram_tester_.ExpectUniqueSample(kMediaSessionUsageHistogramName, 0, 1);
+  EXPECT_EQ(relay_observer_.GetCustomAttribute(kMediaSessionUsageAttributeName),
+            "0");
 }
 
 TEST_F(MediaSessionMetricsTest, CorrectPercentageBucket) {
-  // 40h playing → ~20% → bucket 2.
+  // 40h playing → ~20% → bucket 2. Attribute: 20% → "1-33".
   task_environment_.FastForwardBy(base::Days(1));
   auto* session = AddSession();
   task_environment_.FastForwardBy(base::Hours(40));
@@ -109,6 +117,8 @@ TEST_F(MediaSessionMetricsTest, CorrectPercentageBucket) {
   task_environment_.FastForwardBy(base::Days(7));
 
   histogram_tester_.ExpectUniqueSample(kMediaSessionUsageHistogramName, 2, 1);
+  EXPECT_EQ(relay_observer_.GetCustomAttribute(kMediaSessionUsageAttributeName),
+            "1-33");
 }
 
 TEST_F(MediaSessionMetricsTest, SimultaneousSessionsNoDuplication) {
@@ -124,6 +134,8 @@ TEST_F(MediaSessionMetricsTest, SimultaneousSessionsNoDuplication) {
   task_environment_.FastForwardBy(base::Days(7));
 
   histogram_tester_.ExpectUniqueSample(kMediaSessionUsageHistogramName, 2, 1);
+  EXPECT_EQ(relay_observer_.GetCustomAttribute(kMediaSessionUsageAttributeName),
+            "1-33");
 }
 
 TEST_F(MediaSessionMetricsTest, SessionRemovedWhilePlaying) {
@@ -136,6 +148,9 @@ TEST_F(MediaSessionMetricsTest, SessionRemovedWhilePlaying) {
   task_environment_.FastForwardBy(base::Days(7));
 
   histogram_tester_.ExpectUniqueSample(kMediaSessionUsageHistogramName, 1, 1);
+  // 2h media / ~8 days active ≈ 1% → attribute "1-33".
+  EXPECT_EQ(relay_observer_.GetCustomAttribute(kMediaSessionUsageAttributeName),
+            "1-33");
 }
 
 TEST_F(MediaSessionMetricsTest, FrameResetAfterReport) {
@@ -148,10 +163,29 @@ TEST_F(MediaSessionMetricsTest, FrameResetAfterReport) {
 
   task_environment_.FastForwardBy(base::Days(7));
   histogram_tester_.ExpectBucketCount(kMediaSessionUsageHistogramName, 1, 1);
+  EXPECT_EQ(relay_observer_.GetCustomAttribute(kMediaSessionUsageAttributeName),
+            "1-33");
 
   task_environment_.FastForwardBy(base::Days(7));
   histogram_tester_.ExpectBucketCount(kMediaSessionUsageHistogramName, 0, 1);
   histogram_tester_.ExpectTotalCount(kMediaSessionUsageHistogramName, 2);
+  EXPECT_EQ(relay_observer_.GetCustomAttribute(kMediaSessionUsageAttributeName),
+            "0");
+}
+
+TEST_F(MediaSessionMetricsTest, NoActiveTimeAttributeCleared) {
+  // Pre-set the attribute to a known value so we can confirm it is cleared.
+  p3a_utils::SetCustomAttribute(kMediaSessionUsageAttributeName, "1-33");
+  ASSERT_EQ(relay_observer_.GetCustomAttribute(kMediaSessionUsageAttributeName),
+            "1-33");
+
+  // Browser never in use and no media playing: active_time stays zero.
+  // After the frame elapses the attribute should be cleared to std::nullopt.
+  uptime_monitor_.is_in_use = false;
+  task_environment_.FastForwardBy(base::Days(7));
+  histogram_tester_.ExpectTotalCount(kMediaSessionUsageHistogramName, 0);
+  EXPECT_EQ(relay_observer_.GetCustomAttribute(kMediaSessionUsageAttributeName),
+            std::nullopt);
 }
 
 TEST_F(MediaSessionMetricsTest, ActiveProcessTimeOnlyWhenInUseOrPlaying) {
@@ -171,8 +205,10 @@ TEST_F(MediaSessionMetricsTest, ActiveProcessTimeOnlyWhenInUseOrPlaying) {
   // Advance remaining time to trigger report.
   task_environment_.FastForwardBy(base::Days(4));
 
-  // 1 day playing / 1 day active = 100% → bucket 5.
+  // 1 day playing / 1 day active = 100% → bucket 5. Attribute: "68-100".
   histogram_tester_.ExpectUniqueSample(kMediaSessionUsageHistogramName, 5, 1);
+  EXPECT_EQ(relay_observer_.GetCustomAttribute(kMediaSessionUsageAttributeName),
+            "68-100");
 }
 
 }  // namespace misc_metrics

--- a/components/misc_metrics/brave_search_metrics.cc
+++ b/components/misc_metrics/brave_search_metrics.cc
@@ -16,6 +16,7 @@
 #include "build/build_config.h"
 #include "components/prefs/pref_registry_simple.h"
 #include "components/prefs/pref_service.h"
+#include "components/prefs/scoped_user_pref_update.h"
 #include "components/search_engines/template_url.h"
 #include "components/search_engines/template_url_service.h"
 
@@ -23,8 +24,12 @@ namespace misc_metrics {
 
 namespace {
 
-constexpr int kDailyQueriesBuckets[] = {0, 3, 7};
+// Buckets for DailyQueries. Answers 0 and 1 are reserved for the zero-query
+// cases (no navigation and had navigation respectively), so two dummy leading
+// values push real query counts to indices 2 and above.
+constexpr int kDailyQueriesBuckets[] = {0, 0, 3, 7};
 constexpr char kQueriesCountKey[] = "queries";
+constexpr char kAnyNavigationKey[] = "any_navigation";
 constexpr char kPrimaryQueriesCountKey[] = "primary";
 constexpr char kOmniboxTypedCountKey[] = "omnibox_typed";
 constexpr char kOmniboxSuggestionCountKey[] = "omnibox_suggestion";
@@ -71,6 +76,9 @@ void BraveSearchMetrics::RegisterPrefs(PrefRegistrySimple* registry) {
 
 void BraveSearchMetrics::MaybeRecordBraveQuery(const GURL& previous_url,
                                                const GURL& current_url) {
+  ScopedDictPrefUpdate(local_state_, kMiscMetricsBraveSearchQueryCounts)
+      ->Set(kAnyNavigationKey, true);
+
   if (!IsBraveSearchURL(current_url)) {
     return;
   }
@@ -148,6 +156,7 @@ void BraveSearchMetrics::ReportAllMetrics() {
   const base::DictValue& counts =
       local_state_->GetDict(kMiscMetricsBraveSearchQueryCounts);
   int sum = counts.FindInt(kQueriesCountKey).value_or(0);
+  bool any_navigation = counts.FindBool(kAnyNavigationKey).value_or(false);
 
   auto* histogram_name_ptr =
       base::FindOrNull(kDailyQueriesHistogramMap, engine_type);
@@ -155,7 +164,13 @@ void BraveSearchMetrics::ReportAllMetrics() {
                              ? *histogram_name_ptr
                              : kSearchDailyQueriesOtherDefaultHistogramName;
 
-  p3a_utils::RecordToHistogramBucket(histogram_name, kDailyQueriesBuckets, sum);
+  if (sum == 0) {
+    base::UmaHistogramExactLinear(histogram_name, any_navigation ? 1 : 0,
+                                  std::size(kDailyQueriesBuckets) + 1);
+  } else {
+    p3a_utils::RecordToHistogramBucket(histogram_name, kDailyQueriesBuckets,
+                                       sum);
+  }
 
   int primary_queries = counts.FindInt(kPrimaryQueriesCountKey).value_or(0);
   if (primary_queries > 0) {

--- a/components/misc_metrics/brave_search_metrics.h
+++ b/components/misc_metrics/brave_search_metrics.h
@@ -22,15 +22,15 @@ class TemplateURLService;
 namespace misc_metrics {
 
 inline constexpr char kSearchDailyQueriesBraveDefaultHistogramName[] =
-    "Brave.Search.DailyQueries.BraveDefault";
+    "Brave.Search.DailyQueries.BraveDefault.2";
 inline constexpr char kSearchDailyQueriesGoogleDefaultHistogramName[] =
-    "Brave.Search.DailyQueries.GoogleDefault";
+    "Brave.Search.DailyQueries.GoogleDefault.2";
 inline constexpr char kSearchDailyQueriesDDGDefaultHistogramName[] =
-    "Brave.Search.DailyQueries.DDGDefault";
+    "Brave.Search.DailyQueries.DDGDefault.2";
 inline constexpr char kSearchDailyQueriesYahooDefaultHistogramName[] =
-    "Brave.Search.DailyQueries.YahooDefault";
+    "Brave.Search.DailyQueries.YahooDefault.2";
 inline constexpr char kSearchDailyQueriesOtherDefaultHistogramName[] =
-    "Brave.Search.DailyQueries.OtherDefault";
+    "Brave.Search.DailyQueries.OtherDefault.2";
 inline constexpr char kSearchOmniboxTypedPercentHistogramName[] =
     "Brave.Search.OmniboxTypedPercent";
 inline constexpr char kSearchOmniboxSuggestionPercentHistogramName[] =

--- a/components/misc_metrics/brave_search_metrics_unittest.cc
+++ b/components/misc_metrics/brave_search_metrics_unittest.cc
@@ -80,9 +80,11 @@ TEST_F(BraveSearchMetricsUnitTest, DailyQueriesBuckets) {
   // Advance 24 hours then report.
   FastForwardAndReport(base::Days(1));
 
-  // Should report bucket 1 (3 queries -> 1-3 range).
+  // Buckets 0 and 1 are reserved for zero-query cases (no navigation / had
+  // navigation). Real query counts start at index 2.
+  // Should report bucket 2 (3 queries -> 1-3 range).
   histogram_tester_.ExpectUniqueSample(
-      kSearchDailyQueriesBraveDefaultHistogramName, 1, 1);
+      kSearchDailyQueriesBraveDefaultHistogramName, 2, 1);
   histogram_tester_.ExpectTotalCount(
       kSearchDailyQueriesGoogleDefaultHistogramName, 0);
   histogram_tester_.ExpectTotalCount(
@@ -95,9 +97,9 @@ TEST_F(BraveSearchMetricsUnitTest, DailyQueriesBuckets) {
 
   FastForwardAndReport(base::Days(1));
 
-  // Should report bucket 2 (7 queries -> 4-7 range).
+  // Should report bucket 3 (7 queries -> 4-7 range).
   histogram_tester_.ExpectBucketCount(
-      kSearchDailyQueriesBraveDefaultHistogramName, 2, 1);
+      kSearchDailyQueriesBraveDefaultHistogramName, 3, 1);
 
   // Record 8 queries in the new window.
   for (int i = 0; i < 8; i++) {
@@ -106,9 +108,9 @@ TEST_F(BraveSearchMetricsUnitTest, DailyQueriesBuckets) {
 
   FastForwardAndReport(base::Days(1));
 
-  // Should report bucket 3 (8 queries -> 8+ range).
+  // Should report bucket 4 (8 queries -> 8+ range).
   histogram_tester_.ExpectBucketCount(
-      kSearchDailyQueriesBraveDefaultHistogramName, 3, 1);
+      kSearchDailyQueriesBraveDefaultHistogramName, 4, 1);
 
   histogram_tester_.ExpectTotalCount(
       kSearchDailyQueriesBraveDefaultHistogramName, 3);
@@ -130,9 +132,9 @@ TEST_F(BraveSearchMetricsUnitTest, DailyQueriesEngineSwitch) {
   // Advance past 24 hours then report.
   FastForwardAndReport(base::Days(1));
 
-  // Should report under Google (3 queries -> bucket 1).
+  // Should report under Google (3 queries -> bucket 2, 1-3 range).
   histogram_tester_.ExpectUniqueSample(
-      kSearchDailyQueriesGoogleDefaultHistogramName, 1, 1);
+      kSearchDailyQueriesGoogleDefaultHistogramName, 2, 1);
   histogram_tester_.ExpectTotalCount(
       kSearchDailyQueriesBraveDefaultHistogramName, 0);
   histogram_tester_.ExpectTotalCount(kSearchDailyQueriesDDGDefaultHistogramName,
@@ -153,13 +155,13 @@ TEST_F(BraveSearchMetricsUnitTest, DailyQueriesEngineSwitch) {
   // Advance past 24 hours then report.
   FastForwardAndReport(base::Days(1));
 
-  // Should report under OtherDefault (5 queries -> bucket 2).
+  // Should report under OtherDefault (5 queries -> bucket 3, 4-7 range).
   histogram_tester_.ExpectUniqueSample(
-      kSearchDailyQueriesOtherDefaultHistogramName, 2, 1);
+      kSearchDailyQueriesOtherDefaultHistogramName, 3, 1);
   histogram_tester_.ExpectTotalCount(
       kSearchDailyQueriesBraveDefaultHistogramName, 0);
   histogram_tester_.ExpectUniqueSample(
-      kSearchDailyQueriesGoogleDefaultHistogramName, 1, 1);
+      kSearchDailyQueriesGoogleDefaultHistogramName, 2, 1);
   histogram_tester_.ExpectTotalCount(kSearchDailyQueriesDDGDefaultHistogramName,
                                      0);
   histogram_tester_.ExpectTotalCount(
@@ -176,13 +178,13 @@ TEST_F(BraveSearchMetricsUnitTest, DailyQueriesEngineSwitch) {
   // Advance past 24 hours then report.
   FastForwardAndReport(base::Days(1));
 
-  // Should report under BraveDefault (8 queries -> bucket 3).
+  // Should report under BraveDefault (8 queries -> bucket 4, 8+ range).
   histogram_tester_.ExpectUniqueSample(
-      kSearchDailyQueriesBraveDefaultHistogramName, 3, 1);
+      kSearchDailyQueriesBraveDefaultHistogramName, 4, 1);
   histogram_tester_.ExpectUniqueSample(
-      kSearchDailyQueriesOtherDefaultHistogramName, 2, 1);
+      kSearchDailyQueriesOtherDefaultHistogramName, 3, 1);
   histogram_tester_.ExpectUniqueSample(
-      kSearchDailyQueriesGoogleDefaultHistogramName, 1, 1);
+      kSearchDailyQueriesGoogleDefaultHistogramName, 2, 1);
   histogram_tester_.ExpectTotalCount(kSearchDailyQueriesDDGDefaultHistogramName,
                                      0);
   histogram_tester_.ExpectTotalCount(
@@ -195,9 +197,9 @@ TEST_F(BraveSearchMetricsUnitTest, CountsClearedAfterReport) {
   // Advance past 24 hours then report.
   FastForwardAndReport(base::Days(1));
 
-  // Previous window reported 1 query -> bucket 1.
+  // Previous window reported 1 query -> bucket 2 (1-3 range).
   histogram_tester_.ExpectBucketCount(
-      kSearchDailyQueriesBraveDefaultHistogramName, 1, 1);
+      kSearchDailyQueriesBraveDefaultHistogramName, 2, 1);
 
   // Record 1 query in the new window.
   brave_search_metrics_->MaybeRecordBraveQuery(empty_url_, brave_search_url_);
@@ -207,7 +209,7 @@ TEST_F(BraveSearchMetricsUnitTest, CountsClearedAfterReport) {
 
   // Should report 1 query again for the new window.
   histogram_tester_.ExpectBucketCount(
-      kSearchDailyQueriesBraveDefaultHistogramName, 1, 2);
+      kSearchDailyQueriesBraveDefaultHistogramName, 2, 2);
 }
 
 TEST_F(BraveSearchMetricsUnitTest, ClearQueryCounts) {
@@ -224,9 +226,34 @@ TEST_F(BraveSearchMetricsUnitTest, ClearQueryCounts) {
   // Advance past 24 hours and report.
   FastForwardAndReport(base::Days(1));
 
-  // Should report bucket 0 (0 queries) since counts were cleared.
+  // Counts cleared means sum=0 and any_navigation=false -> bucket 0.
   histogram_tester_.ExpectUniqueSample(
       kSearchDailyQueriesBraveDefaultHistogramName, 0, 1);
+}
+
+TEST_F(BraveSearchMetricsUnitTest, DailyQueriesNoNavigationReportsZero) {
+  // No queries and no navigation in this window -> bucket 0.
+  FastForwardAndReport(base::Days(1));
+  histogram_tester_.ExpectUniqueSample(
+      kSearchDailyQueriesBraveDefaultHistogramName, 0, 1);
+
+  // After reset, another empty window also reports bucket 0.
+  FastForwardAndReport(base::Days(1));
+  histogram_tester_.ExpectBucketCount(
+      kSearchDailyQueriesBraveDefaultHistogramName, 0, 2);
+}
+
+TEST_F(BraveSearchMetricsUnitTest,
+       DailyQueriesNavigationButNoSearchReportsOne) {
+  // Navigate to a non-search URL: sets any_navigation=true but sum stays 0.
+  const GURL non_search_url{"https://example.com"};
+  brave_search_metrics_->MaybeRecordBraveQuery(empty_url_, non_search_url);
+
+  FastForwardAndReport(base::Days(1));
+
+  // any_navigation=true, sum=0 -> bucket 1.
+  histogram_tester_.ExpectUniqueSample(
+      kSearchDailyQueriesBraveDefaultHistogramName, 1, 1);
 }
 
 TEST_F(BraveSearchMetricsUnitTest, NoReportBeforeFrameExpires) {

--- a/components/p3a/BUILD.gn
+++ b/components/p3a/BUILD.gn
@@ -60,6 +60,8 @@ static_library("p3a") {
     "utils.h",
   ]
 
+  public_deps = [ "//brave/components/p3a_utils" ]
+
   deps = [
     "constellation/rs/cxx:rust_lib",
     "//base",
@@ -68,7 +70,6 @@ static_library("p3a") {
     "//brave/components/brave_origin/buildflags",
     "//brave/components/brave_stats/browser",
     "//brave/components/l10n/common",
-    "//brave/components/p3a_utils",
     "//brave/components/version_info",
     "//brave/vendor/brave_base",
     "//components/cbor",
@@ -99,10 +100,12 @@ source_set("unit_tests") {
     "constellation_helper_unittest.cc",
     "constellation_log_store_unittest.cc",
     "message_manager_unittest.cc",
+    "metric_config_unittest.cc",
     "metric_log_store_unittest.cc",
     "metric_names_unittest.cc",
     "nitro_utils/attestation_unittest.cc",
     "nitro_utils/cose_unittest.cc",
+    "p3a_message_unittest.cc",
     "p3a_service_unittest.cc",
     "region_unittest.cc",
     "remote_config_manager_unittest.cc",
@@ -117,6 +120,7 @@ source_set("unit_tests") {
     "//brave/components/brave_stats/browser",
     "//brave/components/constants",
     "//brave/components/p3a",
+    "//brave/components/p3a_utils",
     "//components/cbor",
     "//components/prefs:test_support",
     "//net",

--- a/components/p3a/metric_config.cc
+++ b/components/p3a/metric_config.cc
@@ -30,6 +30,7 @@ constexpr auto kMetricAttributeMap =
         {"dtoa", MetricAttribute::kDateOfActivation},
         {"woa", MetricAttribute::kWeekOfActivation},
         {"is_browser_default", MetricAttribute::kIsBrowserDefault},
+        {"custom_attribute", MetricAttribute::kCustomAttribute},
     });
 
 bool GetMetricAttribute(const base::Value* value,
@@ -120,6 +121,27 @@ bool GetOptionalBool(const base::Value* value, std::optional<bool>* field) {
   return true;
 }
 
+bool GetCustomAttributes(const base::Value* value,
+                         std::optional<RemoteCustomAttributes>* field) {
+  if (!value || !value->is_list()) {
+    return false;
+  }
+
+  const auto& list = value->GetList();
+
+  RemoteCustomAttributes attributes;
+
+  for (size_t i = 0; i < list.size() && i < attributes.size(); i++) {
+    if (!list[i].is_string()) {
+      return false;
+    }
+    attributes[i] = list[i].GetString();
+  }
+
+  *field = attributes;
+  return true;
+}
+
 }  // namespace
 
 RemoteMetricConfig::RemoteMetricConfig() = default;
@@ -151,6 +173,9 @@ void RemoteMetricConfig::RegisterJSONConverter(
       &GetOptionalString);
   converter->RegisterCustomValueField("cadence", &RemoteMetricConfig::cadence,
                                       &GetMetricLogType);
+  converter->RegisterCustomValueField("custom_attributes",
+                                      &RemoteMetricConfig::custom_attributes,
+                                      &GetCustomAttributes);
 }
 
 }  // namespace p3a

--- a/components/p3a/metric_config.h
+++ b/components/p3a/metric_config.h
@@ -35,7 +35,8 @@ enum class MetricAttribute {
   kWeekOfActivation,
   kDateOfActivation,
   kIsBrowserDefault,
-  kMaxValue = kIsBrowserDefault,
+  kCustomAttribute,
+  kMaxValue = kCustomAttribute,
 };
 
 inline constexpr MetricAttribute kDefaultMetricAttributes[] = {
@@ -47,6 +48,8 @@ inline constexpr MetricAttribute kDefaultMetricAttributes[] = {
 
 using MetricAttributes = std::array<std::optional<MetricAttribute>, 8>;
 using MetricAttributesToAppend = std::array<std::optional<MetricAttribute>, 2>;
+using CustomAttributes = std::array<std::optional<std::string_view>, 2>;
+using RemoteCustomAttributes = std::array<std::optional<std::string>, 2>;
 
 struct MetricConfig {
   // Once the metric value has been sent, the value will be removed from the log
@@ -72,6 +75,11 @@ struct MetricConfig {
   // If specified in a remote configuration, the cadence of the metric will be
   // overridden.
   std::optional<MetricLogType> cadence;
+
+  // Custom attribute key names to include with the metric. Each
+  // kCustomAttribute in the attributes list is replaced in order with the next
+  // key from this array.
+  CustomAttributes custom_attributes;
 };
 
 // This struct is used to store the remote configuration for a metric.
@@ -91,6 +99,7 @@ struct RemoteMetricConfig {
   std::optional<bool> record_activation_date;
   std::optional<std::string> activation_metric_name;
   std::optional<MetricLogType> cadence;
+  std::optional<RemoteCustomAttributes> custom_attributes;
 
   static void RegisterJSONConverter(
       base::JSONValueConverter<RemoteMetricConfig>* converter);

--- a/components/p3a/metric_config_unittest.cc
+++ b/components/p3a/metric_config_unittest.cc
@@ -1,0 +1,51 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/p3a/metric_config.h"
+
+#include "base/json/json_value_converter.h"
+#include "base/values.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace p3a {
+
+namespace {
+
+RemoteMetricConfig ConvertFromDict(base::DictValue dict) {
+  base::JSONValueConverter<RemoteMetricConfig> converter;
+  RemoteMetricConfig config;
+  converter.Convert(base::Value(std::move(dict)), &config);
+  return config;
+}
+
+}  // namespace
+
+TEST(P3AMetricConfigTest, CustomAttributesValidList) {
+  auto dict = base::DictValue().Set(
+      "custom_attributes", base::ListValue().Append("attr_a").Append("attr_b"));
+  auto config = ConvertFromDict(std::move(dict));
+  ASSERT_TRUE(config.custom_attributes.has_value());
+  EXPECT_EQ((*config.custom_attributes)[0], "attr_a");
+  EXPECT_EQ((*config.custom_attributes)[1], "attr_b");
+}
+
+TEST(P3AMetricConfigTest, CustomAttributesNonList) {
+  // custom_attributes must be a list; a non-list value should leave the field
+  // unset.
+  auto dict = base::DictValue().Set("custom_attributes", "not_a_list");
+  auto config = ConvertFromDict(std::move(dict));
+  EXPECT_FALSE(config.custom_attributes.has_value());
+}
+
+TEST(P3AMetricConfigTest, CustomAttributesListWithNonStringElement) {
+  // A list element that is not a string should cause parsing to fail and leave
+  // the field unset.
+  auto dict = base::DictValue().Set(
+      "custom_attributes", base::ListValue().Append("valid_attr").Append(42));
+  auto config = ConvertFromDict(std::move(dict));
+  EXPECT_FALSE(config.custom_attributes.has_value());
+}
+
+}  // namespace p3a

--- a/components/p3a/metric_names.h
+++ b/components/p3a/metric_names.h
@@ -276,23 +276,28 @@ inline constexpr auto kCollectedExpressHistograms =
     }},
     {"Brave.Search.DailyQueries.BraveDefault", MetricConfig{
       .ephemeral = true,
-      .attributes = MetricAttributes{MetricAttribute::kIsBrowserDefault, MetricAttribute::kAnswerIndex, MetricAttribute::kCountryCode, MetricAttribute::kPlatform, MetricAttribute::kYoi},
+      .attributes = MetricAttributes{MetricAttribute::kIsBrowserDefault, MetricAttribute::kAnswerIndex, MetricAttribute::kCustomAttribute, MetricAttribute::kCountryCode, MetricAttribute::kPlatform, MetricAttribute::kYoi},
+      .custom_attributes = {"media_session_usage"},
     }},
     {"Brave.Search.DailyQueries.DDGDefault", MetricConfig{
       .ephemeral = true,
-      .attributes = MetricAttributes{MetricAttribute::kIsBrowserDefault, MetricAttribute::kAnswerIndex, MetricAttribute::kCountryCode, MetricAttribute::kPlatform, MetricAttribute::kYoi},
+      .attributes = MetricAttributes{MetricAttribute::kIsBrowserDefault, MetricAttribute::kAnswerIndex, MetricAttribute::kCustomAttribute, MetricAttribute::kCountryCode, MetricAttribute::kPlatform, MetricAttribute::kYoi},
+      .custom_attributes = {"media_session_usage"},
     }},
     {"Brave.Search.DailyQueries.GoogleDefault", MetricConfig{
       .ephemeral = true,
-      .attributes = MetricAttributes{MetricAttribute::kIsBrowserDefault, MetricAttribute::kAnswerIndex, MetricAttribute::kCountryCode, MetricAttribute::kPlatform, MetricAttribute::kYoi},
+      .attributes = MetricAttributes{MetricAttribute::kIsBrowserDefault, MetricAttribute::kAnswerIndex, MetricAttribute::kCustomAttribute, MetricAttribute::kCountryCode, MetricAttribute::kPlatform, MetricAttribute::kYoi},
+      .custom_attributes = {"media_session_usage"},
     }},
     {"Brave.Search.DailyQueries.OtherDefault", MetricConfig{
       .ephemeral = true,
-      .attributes = MetricAttributes{MetricAttribute::kIsBrowserDefault, MetricAttribute::kAnswerIndex, MetricAttribute::kCountryCode, MetricAttribute::kPlatform, MetricAttribute::kYoi},
+      .attributes = MetricAttributes{MetricAttribute::kIsBrowserDefault, MetricAttribute::kAnswerIndex, MetricAttribute::kCustomAttribute, MetricAttribute::kCountryCode, MetricAttribute::kPlatform, MetricAttribute::kYoi},
+      .custom_attributes = {"media_session_usage"},
     }},
     {"Brave.Search.DailyQueries.YahooDefault", MetricConfig{
       .ephemeral = true,
-      .attributes = MetricAttributes{MetricAttribute::kIsBrowserDefault, MetricAttribute::kAnswerIndex, MetricAttribute::kCountryCode, MetricAttribute::kPlatform, MetricAttribute::kYoi},
+      .attributes = MetricAttributes{MetricAttribute::kIsBrowserDefault, MetricAttribute::kAnswerIndex, MetricAttribute::kCustomAttribute, MetricAttribute::kCountryCode, MetricAttribute::kPlatform, MetricAttribute::kYoi},
+      .custom_attributes = {"media_session_usage"},
     }},
     {"Brave.Search.DefaultEngine.4", MetricConfig{
       .attributes = MetricAttributes{MetricAttribute::kAnswerIndex, MetricAttribute::kChannel, MetricAttribute::kPlatform, MetricAttribute::kDateOfInstall, MetricAttribute::kVersion, MetricAttribute::kLocaleCountryCode},

--- a/components/p3a/metric_names.h
+++ b/components/p3a/metric_names.h
@@ -274,27 +274,27 @@ inline constexpr auto kCollectedExpressHistograms =
       .ephemeral = true,
       .attributes = MetricAttributes{MetricAttribute::kAnswerIndex, MetricAttribute::kVersion, MetricAttribute::kChannel, MetricAttribute::kPlatform, MetricAttribute::kCountryCode},
     }},
-    {"Brave.Search.DailyQueries.BraveDefault", MetricConfig{
+    {"Brave.Search.DailyQueries.BraveDefault.2", MetricConfig{
       .ephemeral = true,
       .attributes = MetricAttributes{MetricAttribute::kIsBrowserDefault, MetricAttribute::kAnswerIndex, MetricAttribute::kCustomAttribute, MetricAttribute::kCountryCode, MetricAttribute::kPlatform, MetricAttribute::kYoi},
       .custom_attributes = {"media_session_usage"},
     }},
-    {"Brave.Search.DailyQueries.DDGDefault", MetricConfig{
+    {"Brave.Search.DailyQueries.DDGDefault.2", MetricConfig{
       .ephemeral = true,
       .attributes = MetricAttributes{MetricAttribute::kIsBrowserDefault, MetricAttribute::kAnswerIndex, MetricAttribute::kCustomAttribute, MetricAttribute::kCountryCode, MetricAttribute::kPlatform, MetricAttribute::kYoi},
       .custom_attributes = {"media_session_usage"},
     }},
-    {"Brave.Search.DailyQueries.GoogleDefault", MetricConfig{
+    {"Brave.Search.DailyQueries.GoogleDefault.2", MetricConfig{
       .ephemeral = true,
       .attributes = MetricAttributes{MetricAttribute::kIsBrowserDefault, MetricAttribute::kAnswerIndex, MetricAttribute::kCustomAttribute, MetricAttribute::kCountryCode, MetricAttribute::kPlatform, MetricAttribute::kYoi},
       .custom_attributes = {"media_session_usage"},
     }},
-    {"Brave.Search.DailyQueries.OtherDefault", MetricConfig{
+    {"Brave.Search.DailyQueries.OtherDefault.2", MetricConfig{
       .ephemeral = true,
       .attributes = MetricAttributes{MetricAttribute::kIsBrowserDefault, MetricAttribute::kAnswerIndex, MetricAttribute::kCustomAttribute, MetricAttribute::kCountryCode, MetricAttribute::kPlatform, MetricAttribute::kYoi},
       .custom_attributes = {"media_session_usage"},
     }},
-    {"Brave.Search.DailyQueries.YahooDefault", MetricConfig{
+    {"Brave.Search.DailyQueries.YahooDefault.2", MetricConfig{
       .ephemeral = true,
       .attributes = MetricAttributes{MetricAttribute::kIsBrowserDefault, MetricAttribute::kAnswerIndex, MetricAttribute::kCustomAttribute, MetricAttribute::kCountryCode, MetricAttribute::kPlatform, MetricAttribute::kYoi},
       .custom_attributes = {"media_session_usage"},

--- a/components/p3a/p3a_message.cc
+++ b/components/p3a/p3a_message.cc
@@ -64,6 +64,7 @@ constexpr char kSlowCadence[] = "slow";
 constexpr char kTypicalCadence[] = "typical";
 constexpr char kExpressCadence[] = "express";
 
+constexpr char kCustomAttributeKeyPrefix[] = "custom_";
 constexpr char kOrganicRefPrefix[] = "BRV";
 constexpr char kNone[] = "none";
 constexpr char kRefOther[] = "other";
@@ -113,6 +114,26 @@ std::string InferActivationDate(const MessageMetainfo& meta,
   return FormatUTCDateFromTime(*activation_date);
 }
 
+std::optional<std::array<std::string, 2>> FetchCustomAttribute(
+    const MessageMetainfo& meta,
+    const MetricConfig* metric_config,
+    size_t custom_attr_index) {
+  if (!metric_config ||
+      custom_attr_index >= metric_config->custom_attributes.size()) {
+    return std::nullopt;
+  }
+  const auto& key_opt = metric_config->custom_attributes[custom_attr_index];
+  if (!key_opt) {
+    return std::nullopt;
+  }
+  auto value = meta.GetCustomAttribute(*key_opt);
+  if (!value) {
+    return std::nullopt;
+  }
+  return std::array<std::string, 2>{
+      base::StrCat({kCustomAttributeKeyPrefix, *key_opt}), std::move(*value)};
+}
+
 std::vector<std::array<std::string, 2>> PopulateConstellationAttributes(
     const std::string_view metric_name,
     const uint64_t metric_value,
@@ -134,6 +155,7 @@ std::vector<std::array<std::string, 2>> PopulateConstellationAttributes(
     attributes = {{kMetricNameAttributeName, std::string(metric_name)}};
   }
   std::string attribute_value;
+  size_t custom_attr_index = 0;
 
   for (const auto& attribute : attributes_to_load) {
     switch (attribute) {
@@ -221,6 +243,12 @@ std::vector<std::array<std::string, 2>> PopulateConstellationAttributes(
         attributes.push_back(
             {kIsBrowserDefaultAttributeName,
              base::ToString(meta.is_browser_default().value_or(false))});
+        break;
+      case MetricAttribute::kCustomAttribute:
+        if (auto attr = FetchCustomAttribute(meta, metric_config,
+                                             custom_attr_index++)) {
+          attributes.push_back(std::move(*attr));
+        }
         break;
     }
   }
@@ -468,6 +496,16 @@ std::optional<base::Time> MessageMetainfo::GetActivationDate(
   }
 
   return base::ValueToTime(*time_val);
+}
+
+std::optional<std::string> MessageMetainfo::GetCustomAttribute(
+    std::string_view attribute_name) const {
+  const auto* value = local_state_->GetDict(kCustomAttributesDictPref)
+                          .FindString(attribute_name);
+  if (!value || value->empty()) {
+    return std::nullopt;
+  }
+  return *value;
 }
 
 }  // namespace p3a

--- a/components/p3a/p3a_message.h
+++ b/components/p3a/p3a_message.h
@@ -43,6 +43,9 @@ class MessageMetainfo {
   std::optional<base::Time> GetActivationDate(
       std::string_view histogram_name) const;
 
+  std::optional<std::string> GetCustomAttribute(
+      std::string_view attribute_name) const;
+
   const std::string& platform() const { return platform_; }
   const std::string& general_platform() const { return general_platform_; }
   const std::string& channel() const { return channel_; }

--- a/components/p3a/p3a_message_unittest.cc
+++ b/components/p3a/p3a_message_unittest.cc
@@ -1,0 +1,146 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/components/p3a/p3a_message.h"
+
+#include "base/time/time.h"
+#include "brave/components/p3a/metric_config.h"
+#include "brave/components/p3a/pref_names.h"
+#include "brave/components/p3a/uploader.h"
+#include "components/prefs/pref_registry_simple.h"
+#include "components/prefs/scoped_user_pref_update.h"
+#include "components/prefs/testing_pref_service.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+#if !BUILDFLAG(IS_IOS)
+#include "brave/components/brave_referrals/common/pref_names.h"
+#endif  // !BUILDFLAG(IS_IOS)
+
+namespace p3a {
+
+namespace {
+
+constexpr char kTestMetricName[] = "Brave.Test.Message";
+constexpr uint64_t kTestMetricValue = 3;
+
+}  // namespace
+
+class P3AMessageTest : public testing::Test {
+ protected:
+  void SetUp() override {
+    local_state_.registry()->RegisterDictionaryPref(kActivationDatesDictPref);
+    local_state_.registry()->RegisterDictionaryPref(kCustomAttributesDictPref);
+
+#if !BUILDFLAG(IS_IOS)
+    local_state_.registry()->RegisterStringPref(kReferralPromoCode, {});
+#endif
+
+    base::Time install_time;
+    ASSERT_TRUE(base::Time::FromString("2020-01-01", &install_time));
+    meta_.Init(&local_state_, "release", install_time);
+  }
+
+  TestingPrefServiceSimple local_state_;
+  MessageMetainfo meta_;
+};
+
+// Verifies GenerateP3AConstellationMessage serializes metric name, value, and
+// channel correctly using fully deterministic attributes.
+TEST_F(P3AMessageTest, Basic) {
+  constexpr MetricConfig kConfig = {
+      .attributes = MetricAttributes{MetricAttribute::kAnswerIndex,
+                                     MetricAttribute::kChannel,
+                                     MetricAttribute::kDateOfInstall},
+  };
+
+  std::string message = GenerateP3AConstellationMessage(
+      kTestMetricName, kTestMetricValue, meta_, kP3AUploadType, &kConfig);
+
+  EXPECT_EQ(message,
+            "metric_name|Brave.Test.Message"
+            ";metric_value|3"
+            ";channel|release"
+            ";dtoi|none");
+
+  constexpr MetricConfig kNullAttrConfig = {
+      .attributes = MetricAttributes{MetricAttribute::kAnswerIndex,
+                                     std::nullopt, MetricAttribute::kChannel,
+                                     MetricAttribute::kDateOfInstall},
+  };
+
+  std::string message_null_attr =
+      GenerateP3AConstellationMessage(kTestMetricName, kTestMetricValue, meta_,
+                                      kP3AUploadType, &kNullAttrConfig);
+
+  EXPECT_EQ(message_null_attr,
+            "metric_name|Brave.Test.Message"
+            ";metric_value|3"
+            ";channel|release"
+            ";dtoi|none");
+}
+
+// Verifies that custom attributes are included with the "custom_" prefix, and
+// that missing attributes are not included in the message.
+TEST_F(P3AMessageTest, CustomAttributes) {
+  {
+    ScopedDictPrefUpdate update(&local_state_, kCustomAttributesDictPref);
+    update->Set("color", "blue");
+    update->Set("size", "large");
+  }
+
+  constexpr MetricConfig kConfig = {
+      .attributes = MetricAttributes{MetricAttribute::kAnswerIndex,
+                                     MetricAttribute::kCustomAttribute,
+                                     MetricAttribute::kCustomAttribute,
+                                     MetricAttribute::kDateOfInstall},
+      .custom_attributes = CustomAttributes{"color", "size"},
+  };
+
+  std::string message = GenerateP3AConstellationMessage(
+      kTestMetricName, kTestMetricValue, meta_, kP3AUploadType, &kConfig);
+
+  EXPECT_EQ(message,
+            "metric_name|Brave.Test.Message"
+            ";metric_value|3"
+            ";custom_color|blue"
+            ";custom_size|large"
+            ";dtoi|none");
+
+  constexpr MetricConfig kMissingFirstConfig = {
+      .attributes = MetricAttributes{MetricAttribute::kAnswerIndex,
+                                     MetricAttribute::kCustomAttribute,
+                                     MetricAttribute::kCustomAttribute,
+                                     MetricAttribute::kDateOfInstall},
+      .custom_attributes = CustomAttributes{"nonexistent", "color"},
+  };
+
+  std::string message_missing_first =
+      GenerateP3AConstellationMessage(kTestMetricName, kTestMetricValue, meta_,
+                                      kP3AUploadType, &kMissingFirstConfig);
+
+  EXPECT_EQ(message_missing_first,
+            "metric_name|Brave.Test.Message"
+            ";metric_value|3"
+            ";custom_color|blue"
+            ";dtoi|none");
+
+  constexpr MetricConfig kAllMissingConfig = {
+      .attributes = MetricAttributes{MetricAttribute::kAnswerIndex,
+                                     MetricAttribute::kCustomAttribute,
+                                     MetricAttribute::kDateOfInstall},
+      .custom_attributes = CustomAttributes{"nonexistent"},
+  };
+
+  std::string message_all_missing =
+      GenerateP3AConstellationMessage(kTestMetricName, kTestMetricValue, meta_,
+                                      kP3AUploadType, &kAllMissingConfig);
+
+  EXPECT_EQ(message_all_missing,
+            "metric_name|Brave.Test.Message"
+            ";metric_value|3"
+            ";dtoi|none");
+}
+
+}  // namespace p3a

--- a/components/p3a/p3a_service.cc
+++ b/components/p3a/p3a_service.cc
@@ -22,6 +22,7 @@
 #include "brave/components/p3a/metric_names.h"
 #include "brave/components/p3a/p3a_config.h"
 #include "brave/components/p3a/pref_names.h"
+#include "brave/components/p3a_utils/event_relay.h"
 #include "components/prefs/pref_registry_simple.h"
 #include "components/prefs/pref_service.h"
 #include "components/prefs/scoped_user_pref_update.h"
@@ -84,6 +85,8 @@ P3AService::P3AService(PrefService& local_state,
 
   message_manager_ = std::make_unique<MessageManager>(
       local_state, &config_, *this, channel, first_run_time);
+
+  event_relay_observation_.Observe(p3a_utils::EventRelay::GetInstance());
 }
 
 P3AService::~P3AService() = default;
@@ -95,6 +98,7 @@ void P3AService::RegisterPrefs(PrefRegistrySimple* registry, bool first_run) {
   // New users are shown the P3A notice via the welcome page.
   registry->RegisterBooleanPref(kP3ANoticeAcknowledged, first_run);
 
+  registry->RegisterDictionaryPref(kCustomAttributesDictPref);
   registry->RegisterDictionaryPref(kDynamicMetricsDictPref);
   registry->RegisterDictionaryPref(kActivationDatesDictPref);
 }
@@ -341,6 +345,17 @@ void P3AService::OnDefaultBrowserStatusChanged(bool is_default) {
   message_manager_->SetIsBrowserDefault(is_default);
 }
 #endif  // !BUILDFLAG(IS_IOS)
+
+void P3AService::OnCustomAttributeSet(
+    std::string_view attribute_name,
+    std::optional<std::string_view> attribute_value) {
+  ScopedDictPrefUpdate update(&*local_state_, kCustomAttributesDictPref);
+  if (attribute_value) {
+    update->Set(attribute_name, *attribute_value);
+  } else {
+    update->Remove(attribute_name);
+  }
+}
 
 void P3AService::HandleHistogramChange(std::string_view histogram_name,
                                        size_t bucket) {

--- a/components/p3a/p3a_service.h
+++ b/components/p3a/p3a_service.h
@@ -24,6 +24,7 @@
 #include "brave/components/p3a/metric_log_type.h"
 #include "brave/components/p3a/p3a_config.h"
 #include "brave/components/p3a/remote_config_manager.h"
+#include "brave/components/p3a_utils/event_relay.h"
 #include "build/build_config.h"
 #include "components/prefs/pref_change_registrar.h"
 
@@ -57,6 +58,7 @@ class P3AService : public base::RefCountedThreadSafe<P3AService>,
 #if !BUILDFLAG(IS_IOS)
                    public misc_metrics::DefaultBrowserMonitor::Observer,
 #endif  // !BUILDFLAG(IS_IOS)
+                   public p3a_utils::EventRelay::Observer,
                    public RemoteConfigManager::Delegate {
  public:
   P3AService(PrefService& local_state,
@@ -128,6 +130,11 @@ class P3AService : public base::RefCountedThreadSafe<P3AService>,
   // RemoteConfigManager::Delegate
   void OnRemoteConfigLoaded() override;
 
+  // p3a_utils::EventRelay::Observer
+  void OnCustomAttributeSet(
+      std::string_view attribute_name,
+      std::optional<std::string_view> attribute_value) override;
+
 #if !BUILDFLAG(IS_IOS)
   // misc_metrics::DefaultBrowserMonitor::Observer
   void OnDefaultBrowserStatusChanged(bool is_default) override;
@@ -190,6 +197,10 @@ class P3AService : public base::RefCountedThreadSafe<P3AService>,
   // Contains callbacks registered via `RegisterMetricCycledCallback`
   base::RepeatingCallbackList<void(const std::string& histogram_name)>
       metric_cycled_callbacks_;
+
+  base::ScopedObservation<p3a_utils::EventRelay,
+                          p3a_utils::EventRelay::Observer>
+      event_relay_observation_{this};
 
 #if !BUILDFLAG(IS_IOS)
   base::ScopedObservation<misc_metrics::DefaultBrowserMonitor,

--- a/components/p3a/p3a_service_unittest.cc
+++ b/components/p3a/p3a_service_unittest.cc
@@ -11,6 +11,7 @@
 #include "base/test/values_test_util.h"
 #include "base/time/time.h"
 #include "brave/components/p3a/pref_names.h"
+#include "brave/components/p3a_utils/custom_attributes.h"
 #include "components/prefs/testing_pref_service.h"
 #include "content/public/test/browser_task_environment.h"
 #include "services/network/public/cpp/weak_wrapper_shared_url_loader_factory.h"
@@ -137,6 +138,21 @@ TEST_F(P3AServiceTest, MetricValueStored) {
   stored_log = local_state_.GetDict(kSlowConstellationPrepPrefName)
                    .FindDict(kTestSlowHistogramName);
   EXPECT_TRUE(stored_log != nullptr);
+}
+
+TEST_F(P3AServiceTest, CustomAttributeStored) {
+  CreateP3AService();
+
+  p3a_utils::SetCustomAttribute("foo", "bar");
+
+  const auto* value =
+      local_state_.GetDict(kCustomAttributesDictPref).FindString("foo");
+  ASSERT_TRUE(value != nullptr);
+  EXPECT_EQ(*value, "bar");
+
+  p3a_utils::SetCustomAttribute("foo", std::nullopt);
+  EXPECT_FALSE(
+      local_state_.GetDict(kCustomAttributesDictPref).FindString("foo"));
 }
 
 }  // namespace p3a

--- a/components/p3a/pref_names.h
+++ b/components/p3a/pref_names.h
@@ -40,6 +40,7 @@ inline constexpr char kLastExpressConstellationRotationTimeStampPref[] =
     "p3a.last_express_constellation_rotation_timestamp";
 
 // P3A service preference names
+inline constexpr char kCustomAttributesDictPref[] = "p3a.custom_attributes";
 inline constexpr char kDynamicMetricsDictPref[] = "p3a.dynamic_metrics";
 
 // Star randomness meta preference names

--- a/components/p3a/remote_config_manager.cc
+++ b/components/p3a/remote_config_manager.cc
@@ -107,13 +107,24 @@ void RemoteConfigManager::SetMetricConfigs(
 
   metric_configs_.clear();
   activation_metric_names_.clear();
+  custom_attribute_names_.clear();
 
   for (const auto& entry : *result) {
-    if (!entry.second.activation_metric_name ||
+    if ((!entry.second.activation_metric_name &&
+         !entry.second.custom_attributes) ||
         !delegate_->GetLogTypeForHistogram(entry.first)) {
       continue;
     }
-    activation_metric_names_.insert(*entry.second.activation_metric_name);
+    if (entry.second.activation_metric_name) {
+      activation_metric_names_.insert(*entry.second.activation_metric_name);
+    }
+    if (entry.second.custom_attributes) {
+      for (const auto& attr : *entry.second.custom_attributes) {
+        if (attr) {
+          custom_attribute_names_.insert(*attr);
+        }
+      }
+    }
   }
 
   for (const auto& entry : *result) {
@@ -150,6 +161,18 @@ void RemoteConfigManager::SetMetricConfigs(
     }
     if (remote_config.cadence) {
       metric_config.cadence = remote_config.cadence;
+    }
+    if (remote_config.custom_attributes) {
+      for (size_t i = 0; i < remote_config.custom_attributes->size(); i++) {
+        const auto& attr = (*remote_config.custom_attributes)[i];
+        if (!attr) {
+          continue;
+        }
+        auto it = custom_attribute_names_.find(*attr);
+        if (it != custom_attribute_names_.end()) {
+          metric_config.custom_attributes[i] = *it;
+        }
+      }
     }
 
     metric_configs_.emplace(entry.first, metric_config);

--- a/components/p3a/remote_config_manager.h
+++ b/components/p3a/remote_config_manager.h
@@ -57,6 +57,7 @@ class RemoteConfigManager {
 
   base::flat_map<std::string, MetricConfig> metric_configs_;
   base::flat_set<std::string> activation_metric_names_;
+  base::flat_set<std::string> custom_attribute_names_;
 
   bool is_loaded_ = false;
 

--- a/components/p3a_utils/BUILD.gn
+++ b/components/p3a_utils/BUILD.gn
@@ -15,3 +15,18 @@ static_library("p3a_utils") {
     "//components/prefs",
   ]
 }
+
+source_set("test_support") {
+  testonly = true
+
+  sources = [
+    "test_event_relay_observer.cc",
+    "test_event_relay_observer.h",
+  ]
+
+  public_deps = [
+    ":p3a_utils",
+    "//base",
+    "//third_party/abseil-cpp:absl",
+  ]
+}

--- a/components/p3a_utils/BUILD.gn
+++ b/components/p3a_utils/BUILD.gn
@@ -1,6 +1,10 @@
 static_library("p3a_utils") {
   sources = [
     "bucket.h",
+    "custom_attributes.cc",
+    "custom_attributes.h",
+    "event_relay.cc",
+    "event_relay.h",
     "feature_usage.cc",
     "feature_usage.h",
   ]

--- a/components/p3a_utils/bucket.h
+++ b/components/p3a_utils/bucket.h
@@ -15,14 +15,18 @@
 namespace p3a_utils {
 
 template <std::size_t N>
+int BucketIndex(const int (&buckets)[N], int value) {
+  DCHECK_GE(value, 0);
+  return std::lower_bound(buckets, std::end(buckets), value) - buckets;
+}
+
+template <std::size_t N>
 void RecordToHistogramBucket(const char* histogram_name,
                              const int (&buckets)[N],
                              int value) {
   DCHECK(histogram_name);
-  DCHECK_GE(value, 0);
-  const int* it_count = std::lower_bound(buckets, std::end(buckets), value);
-  int answer = it_count - buckets;
-  base::UmaHistogramExactLinear(histogram_name, answer, std::size(buckets) + 1);
+  base::UmaHistogramExactLinear(histogram_name, BucketIndex(buckets, value),
+                                std::size(buckets) + 1);
 }
 
 }  // namespace p3a_utils

--- a/components/p3a_utils/custom_attributes.cc
+++ b/components/p3a_utils/custom_attributes.cc
@@ -1,0 +1,18 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/p3a_utils/custom_attributes.h"
+
+#include "brave/components/p3a_utils/event_relay.h"
+
+namespace p3a_utils {
+
+void SetCustomAttribute(std::string_view attribute_name,
+                        std::optional<std::string_view> attribute_value) {
+  EventRelay::GetInstance()->NotifyCustomAttributeSet(attribute_name,
+                                                      attribute_value);
+}
+
+}  // namespace p3a_utils

--- a/components/p3a_utils/custom_attributes.h
+++ b/components/p3a_utils/custom_attributes.h
@@ -1,0 +1,23 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_P3A_UTILS_CUSTOM_ATTRIBUTES_H_
+#define BRAVE_COMPONENTS_P3A_UTILS_CUSTOM_ATTRIBUTES_H_
+
+#include <optional>
+#include <string_view>
+
+namespace p3a_utils {
+
+// Sets a custom attribute value, which can be included
+// in any metric report, depending on metric configuration.
+// If nullopt is provided for attribute_value, the attribute
+// will be cleared.
+void SetCustomAttribute(std::string_view attribute_name,
+                        std::optional<std::string_view> attribute_value);
+
+}  // namespace p3a_utils
+
+#endif  // BRAVE_COMPONENTS_P3A_UTILS_CUSTOM_ATTRIBUTES_H_

--- a/components/p3a_utils/event_relay.cc
+++ b/components/p3a_utils/event_relay.cc
@@ -1,0 +1,34 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/p3a_utils/event_relay.h"
+
+namespace p3a_utils {
+
+// static
+EventRelay* EventRelay::GetInstance() {
+  static base::NoDestructor<EventRelay> instance;
+  return instance.get();
+}
+
+EventRelay::EventRelay() = default;
+EventRelay::~EventRelay() = default;
+
+void EventRelay::AddObserver(Observer* observer) {
+  observers_.AddObserver(observer);
+}
+
+void EventRelay::RemoveObserver(Observer* observer) {
+  observers_.RemoveObserver(observer);
+}
+
+void EventRelay::NotifyCustomAttributeSet(
+    std::string_view attribute_name,
+    std::optional<std::string_view> attribute_value) {
+  observers_.Notify(&Observer::OnCustomAttributeSet, attribute_name,
+                    attribute_value);
+}
+
+}  // namespace p3a_utils

--- a/components/p3a_utils/event_relay.h
+++ b/components/p3a_utils/event_relay.h
@@ -1,0 +1,50 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_P3A_UTILS_EVENT_RELAY_H_
+#define BRAVE_COMPONENTS_P3A_UTILS_EVENT_RELAY_H_
+
+#include <optional>
+#include <string_view>
+
+#include "base/no_destructor.h"
+#include "base/observer_list.h"
+#include "base/observer_list_types.h"
+
+namespace p3a_utils {
+
+class EventRelay {
+ public:
+  class Observer : public base::CheckedObserver {
+   public:
+    virtual void OnCustomAttributeSet(
+        std::string_view attribute_name,
+        std::optional<std::string_view> attribute_value) = 0;
+  };
+
+  static EventRelay* GetInstance();
+
+  EventRelay(const EventRelay&) = delete;
+  EventRelay& operator=(const EventRelay&) = delete;
+
+  void AddObserver(Observer* observer);
+  void RemoveObserver(Observer* observer);
+
+  void NotifyCustomAttributeSet(
+      std::string_view attribute_name,
+      std::optional<std::string_view> attribute_value);
+
+ private:
+  friend class base::NoDestructor<EventRelay>;
+
+  EventRelay();
+  ~EventRelay();
+
+  base::ObserverList<Observer> observers_;
+};
+
+}  // namespace p3a_utils
+
+#endif  // BRAVE_COMPONENTS_P3A_UTILS_EVENT_RELAY_H_

--- a/components/p3a_utils/event_relay.h
+++ b/components/p3a_utils/event_relay.h
@@ -7,6 +7,7 @@
 #define BRAVE_COMPONENTS_P3A_UTILS_EVENT_RELAY_H_
 
 #include <optional>
+#include <string>
 #include <string_view>
 
 #include "base/no_destructor.h"

--- a/components/p3a_utils/test_event_relay_observer.cc
+++ b/components/p3a_utils/test_event_relay_observer.cc
@@ -1,0 +1,32 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/p3a_utils/test_event_relay_observer.h"
+
+#include "base/containers/map_util.h"
+
+namespace p3a_utils {
+
+TestEventRelayObserver::TestEventRelayObserver() {
+  observation_.Observe(EventRelay::GetInstance());
+}
+
+TestEventRelayObserver::~TestEventRelayObserver() = default;
+
+std::optional<std::string> TestEventRelayObserver::GetCustomAttribute(
+    std::string_view attribute_name) const {
+  const auto* value = base::FindOrNull(attributes_, attribute_name);
+  return value ? *value : std::nullopt;
+}
+
+void TestEventRelayObserver::OnCustomAttributeSet(
+    std::string_view attribute_name,
+    std::optional<std::string_view> attribute_value) {
+  attributes_[std::string(attribute_name)] =
+      attribute_value ? std::optional<std::string>(*attribute_value)
+                      : std::nullopt;
+}
+
+}  // namespace p3a_utils

--- a/components/p3a_utils/test_event_relay_observer.h
+++ b/components/p3a_utils/test_event_relay_observer.h
@@ -1,0 +1,42 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_P3A_UTILS_TEST_EVENT_RELAY_OBSERVER_H_
+#define BRAVE_COMPONENTS_P3A_UTILS_TEST_EVENT_RELAY_OBSERVER_H_
+
+#include <optional>
+#include <string>
+#include <string_view>
+
+#include "base/scoped_observation.h"
+#include "brave/components/p3a_utils/event_relay.h"
+#include "third_party/abseil-cpp/absl/container/flat_hash_map.h"
+
+namespace p3a_utils {
+
+// Test helper that observes EventRelay and caches custom attribute values.
+class TestEventRelayObserver : public EventRelay::Observer {
+ public:
+  TestEventRelayObserver();
+  ~TestEventRelayObserver() override;
+
+  // Returns the cached value for |attribute_name|, or std::nullopt if the
+  // attribute was cleared or never set.
+  std::optional<std::string> GetCustomAttribute(
+      std::string_view attribute_name) const;
+
+  // EventRelay::Observer
+  void OnCustomAttributeSet(
+      std::string_view attribute_name,
+      std::optional<std::string_view> attribute_value) override;
+
+ private:
+  absl::flat_hash_map<std::string, std::optional<std::string>> attributes_;
+  base::ScopedObservation<EventRelay, EventRelay::Observer> observation_{this};
+};
+
+}  // namespace p3a_utils
+
+#endif  // BRAVE_COMPONENTS_P3A_UTILS_TEST_EVENT_RELAY_OBSERVER_H_


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->

Resolves https://github.com/brave/brave-browser/issues/54500
Resolves https://github.com/brave/brave-browser/issues/54382
Resolves https://github.com/brave/brave-browser/issues/54377
Uplift of https://github.com/brave/brave-core/pull/35418
Uplift of https://github.com/brave/brave-core/pull/35420
Uplift of https://github.com/brave/brave-core/pull/35519

Test plan in description of https://github.com/brave/brave-core/pull/35519

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
