### PR TITLE
[iOS] Dismiss and show Origin settings after successful purchase

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/SettingsViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/SettingsViewController.swift
@@ -831,7 +831,7 @@ class SettingsViewController: TableViewController {
             else {
               return
             }
-            if originService.isPurchased() {
+            let originSettingsController: () -> UIViewController = {
               let controller = UIHostingController(
                 rootView: OriginSettingsView(
                   viewModel: .init(
@@ -850,12 +850,24 @@ class SettingsViewController: TableViewController {
                 )
               )
               controller.title = Strings.Origin.originProductName  // Not Translated
-              self.navigationController?.pushViewController(controller, animated: true)
+              return controller
+            }
+            if originService.isPurchased() {
+              self.navigationController?.pushViewController(
+                originSettingsController(),
+                animated: true
+              )
             } else {
               let skusService = Skus.SkusServiceFactory.get(profile: braveCore.profile)
               let controller = UIHostingController(
                 rootView: OriginPaywallView(
-                  viewModel: .init(store: .init(skusService: skusService))
+                  viewModel: .init(store: .init(skusService: skusService)),
+                  didPurchase: { [weak self] in
+                    self?.navigationController?.pushViewController(
+                      originSettingsController(),
+                      animated: true
+                    )
+                  }
                 )
                 .environment(
                   \.openURL,

--- a/ios/brave-ios/Sources/Origin/OriginPaywallView.swift
+++ b/ios/brave-ios/Sources/Origin/OriginPaywallView.swift
@@ -18,8 +18,11 @@ public struct OriginPaywallView: View {
   @Environment(\.dismiss) private var dismiss
   @Environment(\.openURL) private var openURL
 
-  public init(viewModel: OriginPaywallViewModel) {
+  var didPurchase: (() -> Void)
+
+  public init(viewModel: OriginPaywallViewModel, didPurchase: @escaping () -> Void = {}) {
     self.viewModel = viewModel
+    self.didPurchase = didPurchase
   }
 
   public var body: some View {
@@ -79,7 +82,10 @@ public struct OriginPaywallView: View {
         ToolbarItemGroup(placement: .topBarTrailing) {
           Button(Strings.Origin.restoreButton) {
             Task {
-              await viewModel.restore()
+              if await viewModel.restore() {
+                dismiss()
+                didPurchase()
+              }
             }
           }
           .tint(.white)
@@ -111,7 +117,10 @@ public struct OriginPaywallView: View {
   private var standardPaywallActionView: some View {
     Button {
       Task {
-        await viewModel.purchase()
+        if await viewModel.purchase() {
+          dismiss()
+          didPurchase()
+        }
       }
     } label: {
       HStack {
@@ -160,7 +169,10 @@ public struct OriginPaywallView: View {
       VStack {
         Button {
           Task {
-            await viewModel.purchase()
+            if await viewModel.purchase() {
+              dismiss()
+              didPurchase()
+            }
           }
         } label: {
           HStack {

--- a/ios/brave-ios/Sources/Origin/OriginPaywallViewModel.swift
+++ b/ios/brave-ios/Sources/Origin/OriginPaywallViewModel.swift
@@ -29,18 +29,20 @@ public class OriginPaywallViewModel {
 
   var product: Product?
 
-  func purchase() async {
+  func purchase() async -> Bool {
     isStoreOperationActive = true
     defer { isStoreOperationActive = false }
 
     do {
       try await store.purchase(product: .originPurchase)
+      return true
     } catch {
       isErrorPresented = true
     }
+    return false
   }
 
-  func restore() async {
+  func restore() async -> Bool {
     isStoreOperationActive = true
     defer { isStoreOperationActive = false }
 
@@ -60,5 +62,6 @@ public class OriginPaywallViewModel {
     if !success {
       isErrorPresented = true
     }
+    return success
   }
 }


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/54700

### Test
Prefix: Must be built to a real device using `Debug (App Store)` scheme (**⚠️ warning: will overwrite the App Store build you have installed**)
- Install the build
- Switch Brave Services environment to staging via BraveCore Switches setting (may be on prod by time of testing)
- Tap Origin to present paywall and go through the purchase flow
- Verify after successful purchase the paywall is dismissed and you are automatically pushed to the Origin settings view