### PR TITLE
[Wallet]: Fix Broken Accounts List Styles

### DIFF
--- a/components/brave_wallet_ui/components/desktop/views/portfolio/components/portfolio_overview_distribution/portfolio_overview_distribution.style.ts
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/components/portfolio_overview_distribution/portfolio_overview_distribution.style.ts
@@ -14,15 +14,10 @@ export const Title = styled(Text)`
   letter-spacing: ${leo.typography.letterSpacing.default};
 `
 
-// Named container so fiat can hide when the flex slice is too narrow (panel / small widths).
-const distributionSegmentContainerName = 'distribution-segment'
-
 export const Segment = styled(Column)<{ $grow: number }>`
   flex: ${(p) => p.$grow} 1 0;
   min-width: 0;
   overflow: hidden;
-  container-type: inline-size;
-  container-name: ${distributionSegmentContainerName};
 `
 
 export const SegmentBar = styled.div<{ $color: string }>`
@@ -49,17 +44,10 @@ export const SegmentPercent = styled(Title)`
   flex-shrink: 0;
 `
 
-// ~12px figures: hide fiat below this inline size so labels do not collide in narrow flex slots.
-const minSegmentWidthPxToShowFiat = 104
-
 export const SegmentFiat = styled(Text)`
   width: 100%;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-
-  @container ${distributionSegmentContainerName} (max-width: ${minSegmentWidthPxToShowFiat}px) {
-    display: none;
-  }
 `

--- a/components/brave_wallet_ui/components/desktop/views/portfolio/components/portfolio_overview_distribution/portfolio_overview_distribution.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/components/portfolio_overview_distribution/portfolio_overview_distribution.tsx
@@ -34,6 +34,7 @@ import {
   SegmentFiat,
 } from './portfolio_overview_distribution.style'
 import { Column, Row } from '../../../../../shared/style'
+import styles from './style.module.scss'
 
 // iOS WebKit blocks sampling remote images to canvas; use fixed segment hues instead.
 const IOS_DISTRIBUTION_SEGMENT_COLORS: string[] = [
@@ -143,6 +144,7 @@ export function PortfolioOverviewDistribution({ data }: Props) {
           return (
             <Segment
               key={key}
+              className={styles.portfolioOverviewDistributionSegment}
               $grow={item.value}
               alignItems='center'
               gap='4px'
@@ -186,6 +188,7 @@ export function PortfolioOverviewDistribution({ data }: Props) {
               >
                 {item.fiatValue ? (
                   <SegmentFiat
+                    className={styles.portfolioOverviewDistributionFiat}
                     textSize='12px'
                     textColor='primary'
                     textAlign='left'

--- a/components/brave_wallet_ui/components/desktop/views/portfolio/components/portfolio_overview_distribution/style.module.scss
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/components/portfolio_overview_distribution/style.module.scss
@@ -1,0 +1,15 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+.portfolioOverviewDistributionSegment {
+  container-type: inline-size;
+}
+
+/* <=62px segment width: hide fiat in narrow flex slots */
+@container (width <= 62px) {
+  .portfolioOverviewDistributionSegment .portfolioOverviewDistributionFiat {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Description 

Fixes a bug where @container rules inside styled-components v5’s CSS preprocessor broke style injection in the wallet WebUI (affecting portfolio views such as Portfolio Asset Details). Container queries for the distribution bar were moved to a SCSS module so they bypass that path.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/54696>

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

## Test Plan:
1. Open the `Wallet` and navigate to the `Portfolio` screen
2. Click on an asset to view it's details
3. Styles should not be broken for the `Accounts List`

Before:

https://github.com/user-attachments/assets/b9efa678-b7ee-49d6-8d88-314565102337

<img width="781" height="283" alt="Screenshot 6" src="https://github.com/user-attachments/assets/9afa1899-5c81-44b5-be00-ed741167f4e9" />

After:

https://github.com/user-attachments/assets/54c7fe92-095c-4635-bf85-bdf7c13b4f25

<img width="788" height="254" alt="Screenshot 8" src="https://github.com/user-attachments/assets/27dd9756-b5c4-4033-8642-e3eace2fc84d" />
