### PR TITLE
[Android] Honor Brave Rewards disabled-by-policy pref

### DIFF
--- a/android/java/org/chromium/chrome/browser/vpn/BraveVpnNativeWorker.java
+++ b/android/java/org/chromium/chrome/browser/vpn/BraveVpnNativeWorker.java
@@ -176,6 +176,10 @@ public class BraveVpnNativeWorker {
         return BraveVpnNativeWorkerJni.get().isPurchasedUser(mNativeBraveVpnNativeWorker);
     }
 
+    public boolean isSupportedRegion() {
+        return BraveVpnNativeWorkerJni.get().isSupportedRegion(mNativeBraveVpnNativeWorker);
+    }
+
     public void getSubscriberCredentialV12() {
         BraveVpnNativeWorkerJni.get().getSubscriberCredentialV12(mNativeBraveVpnNativeWorker);
     }
@@ -238,6 +242,8 @@ public class BraveVpnNativeWorker {
         void reloadPurchasedState(long nativeBraveVpnNativeWorker);
 
         boolean isPurchasedUser(long nativeBraveVpnNativeWorker);
+
+        boolean isSupportedRegion(long nativeBraveVpnNativeWorker);
 
         void getSubscriberCredentialV12(long nativeBraveVpnNativeWorker);
 

--- a/android/java/org/chromium/chrome/browser/vpn/utils/BraveVpnUtils.java
+++ b/android/java/org/chromium/chrome/browser/vpn/utils/BraveVpnUtils.java
@@ -26,7 +26,6 @@ import org.chromium.base.ContextUtils;
 import org.chromium.base.Log;
 import org.chromium.brave_vpn.mojom.BraveVpnConstants;
 import org.chromium.brave_vpn.mojom.Region;
-import org.chromium.chrome.browser.BraveRewardsNativeWorker;
 import org.chromium.chrome.browser.vpn.BraveVpnNativeWorker;
 import org.chromium.chrome.browser.vpn.activities.BraveVpnProfileActivity;
 import org.chromium.chrome.browser.vpn.activities.BraveVpnSupportActivity;
@@ -310,8 +309,8 @@ public class BraveVpnUtils {
     }
 
     private static boolean isRegionSupported() {
-        BraveRewardsNativeWorker braveRewardsNativeWorker = BraveRewardsNativeWorker.getInstance();
-        return (braveRewardsNativeWorker != null && braveRewardsNativeWorker.isSupported());
+        BraveVpnNativeWorker braveVpnNativeWorker = BraveVpnNativeWorker.getInstance();
+        return braveVpnNativeWorker != null && braveVpnNativeWorker.isSupportedRegion();
     }
 
     public static boolean isVpnFeatureSupported(Context context) {

--- a/browser/DEPS
+++ b/browser/DEPS
@@ -129,6 +129,10 @@ specific_include_rules = {
   "brave_local_state_prefs\.cc": [
     "!brave/components/l10n/common/prefs.h",
   ],
+  "brave_vpn_native_worker\.cc": [
+    "!brave/components/l10n/common/locale_util.h",
+    "!brave/components/l10n/common/ofac_sanction_util.h",
+  ],
   "brave_browser_process_impl\.cc": [
     "+brave/components/brave_component_updater/browser/brave_component_updater_delegate.h",
     "+brave/components/brave_component_updater/browser/local_data_files_service.h",

--- a/browser/brave_vpn/android/brave_vpn_native_worker.cc
+++ b/browser/brave_vpn/android/brave_vpn_native_worker.cc
@@ -13,6 +13,8 @@
 #include "base/values.h"
 #include "brave/browser/brave_vpn/brave_vpn_service_factory.h"
 #include "brave/components/brave_vpn/browser/brave_vpn_service.h"
+#include "brave/components/l10n/common/locale_util.h"
+#include "brave/components/l10n/common/ofac_sanction_util.h"
 #include "chrome/android/chrome_jni_headers/BraveVpnNativeWorker_jni.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/profiles/profile_manager.h"
@@ -258,6 +260,11 @@ void BraveVpnNativeWorker::ReloadPurchasedState(JNIEnv* env) {
   if (brave_vpn_service) {
     brave_vpn_service->ReloadPurchasedState();
   }
+}
+
+bool BraveVpnNativeWorker::IsSupportedRegion(JNIEnv* env) {
+  return !brave_l10n::IsISOCountryCodeOFACSanctioned(
+      brave_l10n::GetDefaultISOCountryCodeString());
 }
 
 void BraveVpnNativeWorker::ReportForegroundP3A(JNIEnv* env) {

--- a/browser/brave_vpn/android/brave_vpn_native_worker.h
+++ b/browser/brave_vpn/android/brave_vpn_native_worker.h
@@ -94,6 +94,8 @@ class BraveVpnNativeWorker {
 
   jboolean IsPurchasedUser(JNIEnv* env);
 
+  bool IsSupportedRegion(JNIEnv* env);
+
   void ReportForegroundP3A(JNIEnv* env);
   void ReportBackgroundP3A(JNIEnv* env,
                            jlong session_start_time_ms,

--- a/browser/brave_vpn/sources.gni
+++ b/browser/brave_vpn/sources.gni
@@ -57,6 +57,7 @@ if (enable_brave_vpn) {
     ]
     brave_browser_brave_vpn_deps += [
       "//brave/build/android:jni_headers",
+      "//brave/components/l10n/common",
       "//mojo/public/cpp/bindings",
     ]
   }

--- a/components/brave_rewards/core/rewards_util.cc
+++ b/components/brave_rewards/core/rewards_util.cc
@@ -9,6 +9,7 @@
 
 #include "base/check.h"
 #include "base/no_destructor.h"
+#include "brave/components/brave_rewards/core/pref_names.h"
 #include "brave/components/l10n/common/locale_util.h"
 #include "brave/components/l10n/common/ofac_sanction_util.h"
 #include "build/build_config.h"
@@ -19,22 +20,14 @@
 #include "brave/components/brave_rewards/core/features.h"
 #endif  // BUILDFLAG(IS_ANDROID)
 
-#if !BUILDFLAG(IS_ANDROID)
-#include "brave/components/brave_rewards/core/pref_names.h"
-#endif  // !BUILDFLAG(IS_ANDROID)
-
 namespace brave_rewards {
 
 namespace {
 
 bool IsDisabledByPolicy(PrefService* prefs) {
-#if BUILDFLAG(IS_ANDROID)
-  return false;
-#else
   DCHECK(prefs);
   return prefs->IsManagedPreference(prefs::kDisabledByPolicy) &&
          prefs->GetBoolean(prefs::kDisabledByPolicy);
-#endif
 }
 
 bool IsDisabledByFeature() {


### PR DESCRIPTION
`brave_rewards::IsDisabledByPolicy()` was hardcoded to return false on Android regardless of the managed `kDisabledByPolicy` pref, so every native call site that gates on `brave_rewards::IsSupported()` failed to suppress for Brave Origin subscribers (and enterprise admins setting the `BraveRewardsDisabled` policy).

Symptoms fixed:
- Ads service kept initializing on Android for Origin profiles (`AdsServiceFactory::GetForProfile` gates on `IsSupported`).
- NTP sponsored background images and sponsored rich-media takeover rendered (downstream of the ads service via ViewCounterService).
- DAY_10 / DAY_30 / DAY_35 Rewards retention notifications fired (`RetentionNotificationPublisher` gates on `rewardsNativeWorker .isSupported`).

Java-side Rewards UI surfaces were already correctly gated via `BraveRewardsPolicy.isDisabledByPolicy(profile)` and are unaffected.

Also decouples `BraveVpnUtils.isRegionSupported()` from `BraveRewardsNativeWorker.isSupported()` — otherwise the guard flip would cause VPN UI to hide for any profile where Rewards is policy-disabled as a side effect. Added `BraveVpnNativeWorker.isSupportedRegion` that does the OFAC region check directly via `brave_l10n`.

Resolves: https://github.com/brave/brave-browser/issues/54703

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
