### PR TITLE
Fix: Scripts blocked details button hidden right after enabling Block Scripts

### DIFF
--- a/components/brave_shields/resources/panel_new/components/advanced_settings.style.ts
+++ b/components/brave_shields/resources/panel_new/components/advanced_settings.style.ts
@@ -38,6 +38,10 @@ export const style = scoped.css`
       }
 
       > leo-button[isdisabled=true] {
+        opacity: 0.4;
+      }
+
+      > leo-button.hidden {
         visibility: hidden;
       }
 

--- a/components/brave_shields/resources/panel_new/components/advanced_settings.tsx
+++ b/components/brave_shields/resources/panel_new/components/advanced_settings.tsx
@@ -216,8 +216,9 @@ function BlockScriptsControls(props: { showDetails: () => void }) {
       </div>
       <Button
         onClick={props.showDetails}
-        isDisabled={
-          !isNoscriptEnabled || !hasBlockedOrAllowed || scriptsBlockedEnforced
+        isDisabled={!hasBlockedOrAllowed || scriptsBlockedEnforced}
+        className={
+          !isNoscriptEnabled || scriptsBlockedEnforced ? 'hidden' : undefined
         }
         kind='plain-faint'
         fab

--- a/components/brave_shields/resources/panel_new/components/advanced_settings.tsx
+++ b/components/brave_shields/resources/panel_new/components/advanced_settings.tsx
@@ -216,7 +216,7 @@ function BlockScriptsControls(props: { showDetails: () => void }) {
       </div>
       <Button
         onClick={props.showDetails}
-        isDisabled={!hasBlockedOrAllowed || scriptsBlockedEnforced}
+        isDisabled={!isNoscriptEnabled || !hasBlockedOrAllowed || scriptsBlockedEnforced}
         className={
           !isNoscriptEnabled || scriptsBlockedEnforced ? 'hidden' : undefined
         }


### PR DESCRIPTION
## What's the problem?

When you open the Shields panel and turn on **Block Scripts**, the little arrow button (›) on the right that takes you to the scripts details page is invisible immediately after you toggle it on.

It only shows up after you reload the page — because by that point some scripts have actually been blocked and the counter has data. But the button should appear the moment you enable blocking, even if no scripts have been captured yet.

## Why does this happen?

There are two things working together to cause this:

1. The CSS hides any `leo-button` with `isdisabled=true` using `visibility: hidden`, to preserve layout spacing when the button isn't usable.
2. The button was marked as `isDisabled` whenever there were no blocked/allowed scripts yet (`!hasBlockedOrAllowed`), even if the user had just turned blocking on.

So the timeline looks like this:

- User turns on Block Scripts → toggle is `true`, but `hasBlockedOrAllowed` is still `false`
- Button gets `isDisabled=true` → CSS hides it → user sees nothing
- User reloads page → scripts get captured → `hasBlockedOrAllowed` becomes `true` → button appears

The button was essentially invisible at exactly the moment the user would expect to see it.

## What did I change?

I separated **visibility** from **clickability** for this button:

- The button is now **hidden** only when Block Scripts is completely off, or when an extension/policy is forcing a setting (same logic as before for those cases).
- When Block Scripts is **on but no scripts captured yet**, the button is now **visible but dimmed** — you can see it there, but you can't click it yet.
- Once scripts start getting blocked after a reload, the button becomes **fully clickable** as expected.

### Files changed

- `advanced_settings.tsx` — Updated the button's disabled/visibility conditions
- `advanced_settings.style.ts` — Disabled buttons now show at reduced opacity instead of being hidden; added a `.hidden` class for explicit visibility control

## How to test

1. Open any website in Brave
2. Click the Shields icon
3. Go to Advanced Settings
4. Toggle **Block Scripts** ON
5. **Before fix:** the `›` arrow is invisible
6. **After fix:** the `›` arrow is visible (dimmed), and becomes clickable after page reload when scripts are captured

Fixes: brave/brave-browser#54693