### PR TITLE
[ads] Fix database maintenance startup to run after ads is initialized

### DIFF
--- a/components/brave_ads/core/internal/database/database_maintenance.cc
+++ b/components/brave_ads/core/internal/database/database_maintenance.cc
@@ -14,7 +14,6 @@
 #include "brave/components/brave_ads/core/internal/common/logging_util.h"
 #include "brave/components/brave_ads/core/internal/common/time/time_formatting_util.h"
 #include "brave/components/brave_ads/core/internal/creatives/conversions/creative_set_conversion_database_table_util.h"
-#include "brave/components/brave_ads/core/internal/database/database_manager.h"
 #include "brave/components/brave_ads/core/internal/history/ad_history_database_table_util.h"
 #include "brave/components/brave_ads/core/internal/prefs/pref_path_util.h"
 #include "brave/components/brave_ads/core/internal/settings/settings.h"
@@ -28,13 +27,6 @@ namespace {
 constexpr base::TimeDelta kInitialDelay = base::Minutes(1);
 constexpr base::TimeDelta kRecurringInterval = base::Days(1);
 
-void RunOnStartup() {
-  PurgeAllOrphanedAdEvents();
-}
-
-// Notification and search result ad events are not purged since only Brave
-// Rewards users can opt out of them.
-
 void MaybePurgeNewTabPageAdEvents() {
   if (UserHasJoinedBraveRewards()) {
     // Do not purge ad events if the user has joined Brave Rewards.
@@ -46,16 +38,19 @@ void MaybePurgeNewTabPageAdEvents() {
   }
 }
 
+void RunOnStartup() {
+  PurgeAllOrphanedAdEvents();
+  MaybePurgeNewTabPageAdEvents();
+}
+
 }  // namespace
 
 Maintenance::Maintenance() {
   GetAdsClient().AddObserver(this);
-  DatabaseManager::GetInstance().AddObserver(this);
 }
 
 Maintenance::~Maintenance() {
   GetAdsClient().RemoveObserver(this);
-  DatabaseManager::GetInstance().RemoveObserver(this);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -79,16 +74,22 @@ void Maintenance::RepeatedlyScheduleAfterCallback() {
   RepeatedlyScheduleAfter(kRecurringInterval);
 }
 
-void Maintenance::OnNotifyPrefDidChange(const std::string& path) {
-  if (DoesMatchUserHasOptedInToNewTabPageAdsPrefPath(path)) {
-    MaybePurgeNewTabPageAdEvents();
-  }
-}
+void Maintenance::OnNotifyDidInitializeAds() {
+  is_initialized_ = true;
 
-void Maintenance::OnDatabaseIsReady() {
   RunOnStartup();
 
   RepeatedlyScheduleAfter(kInitialDelay);
+}
+
+void Maintenance::OnNotifyPrefDidChange(const std::string& path) {
+  if (!is_initialized_) {
+    return;
+  }
+
+  if (DoesMatchUserHasOptedInToNewTabPageAdsPrefPath(path)) {
+    MaybePurgeNewTabPageAdEvents();
+  }
 }
 
 }  // namespace brave_ads::database

--- a/components/brave_ads/core/internal/database/database_maintenance.h
+++ b/components/brave_ads/core/internal/database/database_maintenance.h
@@ -10,7 +10,6 @@
 
 #include "base/memory/weak_ptr.h"
 #include "brave/components/brave_ads/core/internal/common/timer/timer.h"
-#include "brave/components/brave_ads/core/internal/database/database_manager_observer.h"
 #include "brave/components/brave_ads/core/public/ads_client/ads_client_notifier_observer.h"
 
 namespace base {
@@ -19,8 +18,7 @@ class TimeDelta;
 
 namespace brave_ads::database {
 
-class Maintenance final : public AdsClientNotifierObserver,
-                          public DatabaseManagerObserver {
+class Maintenance final : public AdsClientNotifierObserver {
  public:
   Maintenance();
 
@@ -34,10 +32,10 @@ class Maintenance final : public AdsClientNotifierObserver,
   void RepeatedlyScheduleAfterCallback();
 
   // AdsClientNotifierObserver:
+  void OnNotifyDidInitializeAds() override;
   void OnNotifyPrefDidChange(const std::string& path) override;
 
-  // DatabaseManagerObserver:
-  void OnDatabaseIsReady() override;
+  bool is_initialized_ = false;
 
   Timer timer_;
 

--- a/components/brave_ads/core/internal/database/database_maintenance_issue_54710_unittest.cc
+++ b/components/brave_ads/core/internal/database/database_maintenance_issue_54710_unittest.cc
@@ -1,0 +1,106 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include <memory>
+
+#include "base/test/mock_callback.h"
+#include "base/test/test_future.h"
+#include "brave/components/brave_ads/core/internal/ad_units/test/ad_test_util.h"
+#include "brave/components/brave_ads/core/internal/ads_client/ads_client_util.h"
+#include "brave/components/brave_ads/core/internal/common/test/test_base.h"
+#include "brave/components/brave_ads/core/internal/database/database_maintenance.h"
+#include "brave/components/brave_ads/core/internal/settings/test/settings_test_util.h"
+#include "brave/components/brave_ads/core/internal/user_engagement/ad_events/ad_events.h"
+#include "brave/components/brave_ads/core/internal/user_engagement/ad_events/ad_events_database_table.h"
+#include "brave/components/brave_ads/core/mojom/brave_ads.mojom.h"
+#include "brave/components/ntp_background_images/common/pref_names.h"
+
+// npm run test -- brave_unit_tests --filter=BraveAds*
+
+namespace brave_ads::database {
+
+class BraveAdsDatabaseMaintenanceIssue54710Test : public test::TestBase {
+ protected:
+  void SetUp() override {
+    TestBase::SetUp();
+    maintenance_ = std::make_unique<Maintenance>();
+    ads_client_notifier_.NotifyDidInitializeAds();
+  }
+
+  AdEventList GetAllAdEvents() {
+    base::test::TestFuture<bool, AdEventList> test_future;
+    database_table_.GetAll(test_future.GetCallback<bool, const AdEventList&>());
+    const auto [success, ad_events] = test_future.Take();
+    EXPECT_TRUE(success);
+    return ad_events;
+  }
+
+  std::unique_ptr<Maintenance> maintenance_;
+
+  database::table::AdEvents database_table_;
+};
+
+TEST_F(BraveAdsDatabaseMaintenanceIssue54710Test,
+       PurgesNewTabPageAdEventsOnPrefChangeWhenNotOptedInToNewTabPageAds) {
+  // Arrange
+  test::DisableBraveRewards();
+
+  const AdInfo ad =
+      test::BuildAd(mojom::AdType::kNewTabPageAd, /*use_random_uuids=*/true);
+  base::MockCallback<AdEventCallback> record_callback;
+  EXPECT_CALL(record_callback, Run(/*success=*/true));
+  RecordAdEvent(ad, mojom::ConfirmationType::kViewedImpression,
+                record_callback.Get());
+
+  // Act
+  GetAdsClient().SetProfilePref(
+      ntp_background_images::prefs::kNewTabPageShowBackgroundImage,
+      base::Value(false));
+
+  // Assert
+  EXPECT_THAT(GetAllAdEvents(), ::testing::IsEmpty());
+}
+
+TEST_F(BraveAdsDatabaseMaintenanceIssue54710Test,
+       DoesNotPurgeNewTabPageAdEventsOnPrefChangeWhenJoinedBraveRewards) {
+  // Arrange
+  const AdInfo ad =
+      test::BuildAd(mojom::AdType::kNewTabPageAd, /*use_random_uuids=*/true);
+  base::MockCallback<AdEventCallback> record_callback;
+  EXPECT_CALL(record_callback, Run(/*success=*/true));
+  RecordAdEvent(ad, mojom::ConfirmationType::kViewedImpression,
+                record_callback.Get());
+
+  // Act
+  GetAdsClient().SetProfilePref(
+      ntp_background_images::prefs::kNewTabPageShowBackgroundImage,
+      base::Value(false));
+
+  // Assert
+  EXPECT_THAT(GetAllAdEvents(), ::testing::SizeIs(1U));
+}
+
+TEST_F(BraveAdsDatabaseMaintenanceIssue54710Test,
+       DoesNotPurgeNewTabPageAdEventsOnPrefChangeWhenOptedInToNewTabPageAds) {
+  // Arrange
+  test::DisableBraveRewards();
+
+  const AdInfo ad =
+      test::BuildAd(mojom::AdType::kNewTabPageAd, /*use_random_uuids=*/true);
+  base::MockCallback<AdEventCallback> record_callback;
+  EXPECT_CALL(record_callback, Run(/*success=*/true));
+  RecordAdEvent(ad, mojom::ConfirmationType::kViewedImpression,
+                record_callback.Get());
+
+  // Act
+  GetAdsClient().SetProfilePref(
+      ntp_background_images::prefs::kNewTabPageShowBackgroundImage,
+      base::Value(true));
+
+  // Assert
+  EXPECT_THAT(GetAllAdEvents(), ::testing::SizeIs(1U));
+}
+
+}  // namespace brave_ads::database

--- a/components/brave_ads/core/internal/database/database_maintenance_unittest.cc
+++ b/components/brave_ads/core/internal/database/database_maintenance_unittest.cc
@@ -16,10 +16,10 @@ namespace brave_ads::database {
 
 class BraveAdsDatabaseMaintenanceTest : public test::TestBase {
  protected:
-  void SetUpMocks() override {
-    // Must be created here so it registers with DatabaseManager before
-    // OnDatabaseIsReady fires during TestBase::SetUp.
+  void SetUp() override {
+    TestBase::SetUp();
     maintenance_ = std::make_unique<Maintenance>();
+    ads_client_notifier_.NotifyDidInitializeAds();
   }
 
   std::unique_ptr<Maintenance> maintenance_;

--- a/components/brave_ads/core/test/BUILD.gn
+++ b/components/brave_ads/core/test/BUILD.gn
@@ -382,6 +382,7 @@ source_set("brave_ads_unit_tests") {
     "//brave/components/brave_ads/core/internal/creatives/segments_database_table_unittest.cc",
     "//brave/components/brave_ads/core/internal/creatives/test/creative_ad_test_util.cc",
     "//brave/components/brave_ads/core/internal/creatives/test/creative_ad_test_util.h",
+    "//brave/components/brave_ads/core/internal/database/database_maintenance_issue_54710_unittest.cc",
     "//brave/components/brave_ads/core/internal/database/database_maintenance_unittest.cc",
     "//brave/components/brave_ads/core/internal/database/database_manager_unittest.cc",
     "//brave/components/brave_ads/core/internal/database/test/database_manager_observer_mock.cc",


### PR DESCRIPTION
Previously, maintenance startup tasks ran when the database was ready, which can occur before ads is fully initialized. Moving this to after initialization ensures the ads system is in a consistent state when startup tasks execute. NTP ad event purge requests arriving before initialization are now deferred and applied once initialization completes.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
