### PR TITLE
Fix cross-thread PrefService crash in BraveOriginPolicyManager::IsPurchased()

### DIFF
--- a/components/brave_origin/brave_origin_policy_manager.cc
+++ b/components/brave_origin/brave_origin_policy_manager.cc
@@ -31,6 +31,7 @@ void BraveOriginPolicyManager::Init(
   browser_policy_definitions_ = std::move(browser_policy_definitions);
   profile_policy_definitions_ = std::move(profile_policy_definitions);
   local_state_ = local_state;
+  is_purchased_from_pref_ = local_state_->GetBoolean(kOriginPurchaseValidated);
   initialized_ = true;
 
   // Notify observers that policies are now ready
@@ -172,6 +173,7 @@ void BraveOriginPolicyManager::SetPurchased(bool purchased) {
     return;
   }
   is_purchased_ = purchased;
+  is_purchased_from_pref_ = purchased;
   // Persist purchase state so policies can be applied immediately on next
   // startup, before the async SKU credential check completes.
   if (local_state_) {
@@ -183,20 +185,17 @@ void BraveOriginPolicyManager::SetPurchased(bool purchased) {
 }
 
 bool BraveOriginPolicyManager::IsPurchased() const {
-  if (is_purchased_) {
-    return true;
-  }
-  // Fall back to persisted pref so policies are applied immediately on startup,
-  // before the async purchase verification completes.
-  if (local_state_) {
-    return local_state_->GetBoolean(kOriginPurchaseValidated);
-  }
-  return false;
+  // `is_purchased_` is set by async verification; `is_purchased_from_pref_` is
+  // pre-cached at Init() from the persisted pref so policies apply immediately
+  // on startup. Neither requires PrefService access at call time, making this
+  // safe to call from any sequence.
+  return is_purchased_ || is_purchased_from_pref_;
 }
 
 void BraveOriginPolicyManager::Shutdown() {
   initialized_ = false;
   is_purchased_ = false;
+  is_purchased_from_pref_ = false;
   browser_policy_definitions_.clear();
   profile_policy_definitions_.clear();
   local_state_ = nullptr;

--- a/components/brave_origin/brave_origin_policy_manager.h
+++ b/components/brave_origin/brave_origin_policy_manager.h
@@ -98,6 +98,7 @@ class BraveOriginPolicyManager {
 
   bool initialized_ = false;
   bool is_purchased_ = false;
+  bool is_purchased_from_pref_ = false;
   BraveOriginPolicyMap browser_policy_definitions_;
   BraveOriginPolicyMap profile_policy_definitions_;
   raw_ptr<PrefService> local_state_ = nullptr;

--- a/components/brave_origin/brave_origin_policy_manager_unittest.cc
+++ b/components/brave_origin/brave_origin_policy_manager_unittest.cc
@@ -495,4 +495,140 @@ TEST_F(BraveOriginPolicyManagerTest,
   manager->RemoveObserver(&observer3);
 }
 
+// ---------------------------------------------------------------------------
+// IsPurchased / SetPurchased tests
+//
+// These cover the is_purchased_from_pref_ caching added to fix a sequence-
+// checker crash: BraveOriginPolicyManager::IsPurchased() was reading
+// local_state_->GetBoolean() at call time, which crashed when called from a
+// database worker thread. The fix pre-caches the pref value at Init() time
+// into is_purchased_from_pref_ so IsPurchased() only reads in-memory bools.
+// ---------------------------------------------------------------------------
+
+TEST_F(BraveOriginPolicyManagerTest, IsPurchased_FalseByDefault) {
+  InitializeManager();
+
+  auto* manager = BraveOriginPolicyManager::GetInstance();
+  EXPECT_FALSE(manager->IsPurchased());
+}
+
+// Key regression test: pref set to true BEFORE Init() must be visible through
+// IsPurchased() without any subsequent SetPurchased() call. This is the
+// startup path — the async SKU check hasn't run yet, but the persisted pref
+// tells us the user was a subscriber last session.
+TEST_F(BraveOriginPolicyManagerTest,
+       IsPurchased_TrueWhenPurchaseValidatedPrefSetBeforeInit) {
+  pref_service_.SetBoolean(kOriginPurchaseValidated, true);
+
+  InitializeManager();
+
+  auto* manager = BraveOriginPolicyManager::GetInstance();
+  EXPECT_TRUE(manager->IsPurchased());
+}
+
+TEST_F(BraveOriginPolicyManagerTest,
+       IsPurchased_FalseWhenPurchaseValidatedPrefFalseBeforeInit) {
+  pref_service_.SetBoolean(kOriginPurchaseValidated, false);
+
+  InitializeManager();
+
+  auto* manager = BraveOriginPolicyManager::GetInstance();
+  EXPECT_FALSE(manager->IsPurchased());
+}
+
+TEST_F(BraveOriginPolicyManagerTest, IsPurchased_TrueAfterSetPurchasedTrue) {
+  InitializeManager();
+
+  auto* manager = BraveOriginPolicyManager::GetInstance();
+  manager->SetPurchased(true);
+
+  EXPECT_TRUE(manager->IsPurchased());
+}
+
+TEST_F(BraveOriginPolicyManagerTest, IsPurchased_FalseAfterSetPurchasedFalse) {
+  InitializeManager();
+
+  auto* manager = BraveOriginPolicyManager::GetInstance();
+  manager->SetPurchased(true);
+  ASSERT_TRUE(manager->IsPurchased());
+
+  manager->SetPurchased(false);
+  EXPECT_FALSE(manager->IsPurchased());
+}
+
+// SetPurchased(true) must keep is_purchased_from_pref_ in sync so that a
+// subsequent SetPurchased(false) correctly brings IsPurchased() back to false.
+TEST_F(BraveOriginPolicyManagerTest,
+       SetPurchased_KeepsIsPurchasedFromPrefInSync) {
+  InitializeManager();
+
+  auto* manager = BraveOriginPolicyManager::GetInstance();
+
+  manager->SetPurchased(true);
+  EXPECT_TRUE(manager->IsPurchased());
+
+  manager->SetPurchased(false);
+  EXPECT_FALSE(manager->IsPurchased());
+}
+
+TEST_F(BraveOriginPolicyManagerTest, SetPurchased_PersistsToPref) {
+  InitializeManager();
+
+  auto* manager = BraveOriginPolicyManager::GetInstance();
+  ASSERT_FALSE(pref_service_.GetBoolean(kOriginPurchaseValidated));
+
+  manager->SetPurchased(true);
+  EXPECT_TRUE(pref_service_.GetBoolean(kOriginPurchaseValidated));
+
+  manager->SetPurchased(false);
+  EXPECT_FALSE(pref_service_.GetBoolean(kOriginPurchaseValidated));
+}
+
+// SetPurchased is idempotent — calling it twice with the same value should
+// not change the observable result.
+TEST_F(BraveOriginPolicyManagerTest, SetPurchased_IdempotentWhenSameValue) {
+  InitializeManager();
+
+  auto* manager = BraveOriginPolicyManager::GetInstance();
+
+  manager->SetPurchased(true);
+  manager->SetPurchased(true);
+  EXPECT_TRUE(manager->IsPurchased());
+
+  manager->SetPurchased(false);
+  manager->SetPurchased(false);
+  EXPECT_FALSE(manager->IsPurchased());
+}
+
+// After Shutdown(), is_purchased_from_pref_ must be reset so a re-Init()
+// starts from a clean slate.
+TEST_F(BraveOriginPolicyManagerTest, Shutdown_ResetsIsPurchasedState) {
+  pref_service_.SetBoolean(kOriginPurchaseValidated, true);
+  InitializeManager();
+
+  auto* manager = BraveOriginPolicyManager::GetInstance();
+  ASSERT_TRUE(manager->IsPurchased());
+
+  manager->Shutdown();
+  EXPECT_FALSE(manager->IsPurchased());
+}
+
+// The pref-cached path and the runtime path are independent — either alone
+// is sufficient to make IsPurchased() return true.
+TEST_F(BraveOriginPolicyManagerTest,
+       IsPurchased_TrueFromPrefCacheOrSetPurchasedIndependently) {
+  // Path 1: pref pre-set, SetPurchased never called.
+  pref_service_.SetBoolean(kOriginPurchaseValidated, true);
+  InitializeManager();
+  auto* manager = BraveOriginPolicyManager::GetInstance();
+  EXPECT_TRUE(manager->IsPurchased());
+  manager->Shutdown();
+
+  // Path 2: pref not set, SetPurchased(true) called at runtime.
+  pref_service_.SetBoolean(kOriginPurchaseValidated, false);
+  InitializeManager();
+  manager->SetPurchased(true);
+  EXPECT_TRUE(manager->IsPurchased());
+}
+
 }  // namespace brave_origin

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -186,6 +186,7 @@ test("brave_unit_tests") {
     "//brave/components/brave_adaptive_captcha/test:brave_adaptive_captcha_unit_tests",
     "//brave/components/brave_ads/buildflags",
     "//brave/components/brave_component_updater/browser",
+    "//brave/components/brave_origin:unit_tests",
     "//brave/components/brave_origin/buildflags",
     "//brave/components/brave_perf_predictor/browser",
   ]


### PR DESCRIPTION
## Description

`BraveOriginPolicyManager::IsPurchased()` previously called `local_state_->GetBoolean(kOriginPurchaseValidated)` at call time. `PrefService` is bound to the UI thread and enforces this via `ScopedValidateSequenceChecker`. Calling it from a database worker thread caused a fatal DCHECK crash ~60 seconds after browser startup.

**Call chain triggering the crash:**

```
brave_ads::database::Maintenance (WallClockTimer, DB thread)
→ AdEvents::PurgeExpired()
→ UserHasOptedInToSurveyPanelist()
→ BraveOriginPolicyManager::IsPurchased()
→ PrefService::GetBoolean()  ← DCHECK: wrong sequence

```

**Fix:** Pre-cache the pref value into `is_purchased_from_pref_` at `Init()` time (on the UI thread). `IsPurchased()` now only reads two `bool` fields — safe to call from any thread.

The existing `is_purchased_` (set by async SKU verification) is unchanged. `IsPurchased()` returns `true` if either bool is set, preserving correct behavior across both the startup path and the runtime verification path.

Manual test after fix below :

[Screencast from 2026-04-19 01-22-27.webm](https://github.com/user-attachments/assets/bfdbad58-5377-4796-8b36-35c1953418cc)

## Changes

- `brave_origin_policy_manager.h` — add `is_purchased_from_pref_` field
- `brave_origin_policy_manager.cc` — pre-cache at `Init()`, sync in `SetPurchased()`, reset in `Shutdown()`
- `brave_origin_policy_manager_unittest.cc` — 10 new unit tests covering the pref-caching and `SetPurchased`/`IsPurchased` behavior
- `test/BUILD.gn` — wire `//brave/components/brave_origin:unit_tests` into `brave_unit_tests` (was missing)

## Testing

```sh
npm run test brave_unit_tests -- --gtest_filter="BraveOriginPolicyManagerTest.*"
```

Fixes https://github.com/brave/brave-browser/issues/54718