### PR TITLE
Fix right-clicking in contents showing tab strip menu in fullscreen (uplift to 1.89.x)

### DIFF
--- a/browser/ui/views/frame/brave_browser_frame_view_mac.mm
+++ b/browser/ui/views/frame/brave_browser_frame_view_mac.mm
@@ -17,6 +17,7 @@
 #include "chrome/browser/ui/tabs/features.h"
 #include "chrome/browser/ui/view_ids.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
+#include "chrome/browser/ui/views/frame/immersive_mode_controller.h"
 #include "ui/base/hit_test.h"
 #include "ui/gfx/geometry/insets.h"
 #include "ui/gfx/geometry/rect.h"
@@ -129,9 +130,16 @@ int BraveBrowserFrameViewMac::NonClientHitTest(const gfx::Point& point) {
     return HTNOWHERE;
   }
 
-  if (auto res = brave::NonClientHitTest(GetBrowserView(), point);
-      res != HTNOWHERE) {
-    return res;
+  // In immersive fullscreen the toolbar is reparented to a separate overlay
+  // widget, violating brave::NonClientHitTest's precondition that the toolbar
+  // and browser view share the same widget. Skip it while immersive mode is
+  // active.
+  if (!ImmersiveModeController::From(GetBrowserView()->browser())
+           ->IsEnabled()) {
+    if (auto res = brave::NonClientHitTest(GetBrowserView(), point);
+        res != HTNOWHERE) {
+      return res;
+    }
   }
 
   return BrowserFrameViewMac::NonClientHitTest(point);

--- a/browser/ui/views/frame/brave_non_client_hit_test_helper.cc
+++ b/browser/ui/views/frame/brave_non_client_hit_test_helper.cc
@@ -24,6 +24,14 @@ int NonClientHitTest(BrowserView* browser_view,
     return HTNOWHERE;
   }
 
+  // The toolbar must live in the same widget as the browser view to make
+  // this method work properly. If it has been reparented to a different widget
+  // (e.g. overlay_widget_ during macOS immersive fullscreen),
+  // GetHitTestComponent() will convert |point_in_widget| using the wrong
+  // widget's coordinate space, producing spurious HTCAPTION results. Callers
+  // must guard against this before calling NonClientHitTest().
+  CHECK_EQ(browser_view->toolbar()->GetWidget(), browser_view->GetWidget());
+
   int hit_test_result =
       views::GetHitTestComponent(browser_view->toolbar(), point_in_widget);
   if (hit_test_result == HTNOWHERE || hit_test_result == HTCLIENT) {


### PR DESCRIPTION
Uplift of #35583
Resolves https://github.com/brave/brave-browser/issues/54456
Resolves https://github.com/brave/brave-browser/issues/54493

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.