### PR TITLE
[iOS] Always show basic auth prompt even with a preexisting credential

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Authenticator.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Authenticator.swift
@@ -38,36 +38,15 @@ class Authenticator {
     protectionSpace: URLProtectionSpace,
     previousFailureCount: Int
   ) async throws -> LoginData {
-    var credential = credential
     // If there have already been too many login attempts, we'll just fail.
     if previousFailureCount >= Authenticator.maxAuthenticationAttempts {
       throw LoginDataError.tooManyAttemptsFailed
     }
 
-    // If we were passed an initial set of credentials from iOS, try and use them.
-    if let proposed = credential {
-      if !(proposed.user?.isEmpty ?? true) {
-        if previousFailureCount == 0 {
-          return LoginData(credentials: proposed, protectionSpace: protectionSpace)
-        }
-      } else {
-        credential = nil
-      }
-    }
-
-    // If we have some credentials, we'll show a prompt with them.
-    if let credential = credential {
-      return try await promptForUsernamePassword(
-        viewController,
-        credentials: credential,
-        protectionSpace: protectionSpace
-      )
-    }
-
-    // No credentials, so show an empty prompt.
-    return try await self.promptForUsernamePassword(
+    // Show a prompt, possibly prefilled with credentials
+    return try await promptForUsernamePassword(
       viewController,
-      credentials: nil,
+      credentials: credential,
       protectionSpace: protectionSpace
     )
   }


### PR DESCRIPTION
This fixes a bug where the a webpage could request basic auth credentials indefinitely after a user inputs invalid credentials as Brave would simply automatically resubmit with those credentials. This change ensures that the prompt is always displayed to the user regardless and just pre-fills the prompt with the supplied credential for the user to correct on follow-up auth attempts.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/54746
