### PR TITLE
[iOS] Remove basic auth failure count from TabDelegate

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Authenticator.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Authenticator.swift
@@ -26,23 +26,14 @@ class Authenticator {
   enum LoginDataError: Error {
     case usernameOrPasswordFieldLeftBlank
     case userCancelledAuthentication
-    case tooManyAttemptsFailed
     case missingProtectionSpaceHostName
   }
-
-  private static let maxAuthenticationAttempts = 3
 
   static func handleAuthRequest(
     _ viewController: UIViewController,
     credential: URLCredential?,
-    protectionSpace: URLProtectionSpace,
-    previousFailureCount: Int
+    protectionSpace: URLProtectionSpace
   ) async throws -> LoginData {
-    // If there have already been too many login attempts, we'll just fail.
-    if previousFailureCount >= Authenticator.maxAuthenticationAttempts {
-      throw LoginDataError.tooManyAttemptsFailed
-    }
-
     // Show a prompt, possibly prefilled with credentials
     return try await promptForUsernamePassword(
       viewController,

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabDelegate.swift
@@ -586,8 +586,7 @@ extension BrowserViewController {
   public func tab(
     _ tab: some TabState,
     didRequestHTTPAuthFor protectionSpace: URLProtectionSpace,
-    proposedCredential credential: URLCredential?,
-    previousFailureCount: Int
+    proposedCredential credential: URLCredential?
   ) async -> URLCredential? {
     let host = protectionSpace.host
     let origin = "\(host):\(protectionSpace.port)"
@@ -618,8 +617,7 @@ extension BrowserViewController {
       let resolvedCredential = try await Authenticator.handleAuthRequest(
         self,
         credential: credential,
-        protectionSpace: protectionSpace,
-        previousFailureCount: previousFailureCount
+        protectionSpace: protectionSpace
       ).credentials
 
       if BasicAuthCredentialsManager.validDomains.contains(host) {

--- a/ios/brave-ios/Sources/Web/Chromium/TabCWVNavigationHandler.swift
+++ b/ios/brave-ios/Sources/Web/Chromium/TabCWVNavigationHandler.swift
@@ -51,8 +51,7 @@ class TabCWVNavigationHandler: NSObject, BraveWebViewNavigationDelegate {
       let resolvedCredential = await delegate.tab(
         tab,
         didRequestHTTPAuthFor: protectionSpace,
-        proposedCredential: proposedCredential,
-        previousFailureCount: 0
+        proposedCredential: proposedCredential
       )
       handler(resolvedCredential?.user, resolvedCredential?.password)
     }

--- a/ios/brave-ios/Sources/Web/TabDelegate.swift
+++ b/ios/brave-ios/Sources/Web/TabDelegate.swift
@@ -45,8 +45,7 @@ public protocol TabDelegate: AnyObject {
   func tab(
     _ tab: some TabState,
     didRequestHTTPAuthFor protectionSpace: URLProtectionSpace,
-    proposedCredential credential: URLCredential?,
-    previousFailureCount: Int
+    proposedCredential credential: URLCredential?
   ) async -> URLCredential?
   func tab(
     _ tab: some TabState,
@@ -135,8 +134,7 @@ extension TabDelegate {
   public func tab(
     _ tab: some TabState,
     didRequestHTTPAuthFor protectionSpace: URLProtectionSpace,
-    proposedCredential credential: URLCredential?,
-    previousFailureCount: Int
+    proposedCredential credential: URLCredential?
   ) async -> URLCredential? {
     return nil
   }


### PR DESCRIPTION
This argument was never used with Chromium web views and now can be fully removed
