### PR TITLE
[AI Chat]: Collapsible Skills Menu and Styling Update

### DIFF
--- a/components/ai_chat/resources/page/components/filter_menu/attachments_menu.tsx
+++ b/components/ai_chat/resources/page/components/filter_menu/attachments_menu.tsx
@@ -162,6 +162,7 @@ export default function TabsMenu() {
         const hasMatches = results.some((result) => result.entries.length > 0)
         setIsOpen(query !== null && hasMatches)
       }}
+      isFullWidth
     >
       {(item, category, match) => (
         <leo-menu-item

--- a/components/ai_chat/resources/page/components/filter_menu/filter_menu.tsx
+++ b/components/ai_chat/resources/page/components/filter_menu/filter_menu.tsx
@@ -5,6 +5,7 @@
 
 import * as React from 'react'
 import ButtonMenu from '@brave/leo/react/buttonMenu'
+import Icon from '@brave/leo/react/icon'
 import classnames from '$web-common/classnames'
 import styles from './style.module.scss'
 import { useMemo } from 'react'
@@ -24,6 +25,7 @@ export interface Props<T> {
   onAutoSelect?: () => void
 
   onResultsChanged?: (results: { category: string; entries: T[] }[]) => void
+  isFullWidth?: boolean
 
   // Note: undefined means no match.
   matchesQuery: (
@@ -33,6 +35,51 @@ export interface Props<T> {
   ) => Match | undefined
 
   children: (entry: T, category?: string, match?: Match) => React.ReactNode
+}
+
+function FilterMenuCategoryGroup<T>(props: {
+  entries: T[]
+  lookup: Map<T, Match | undefined>
+  renderEntry: Props<T>['children']
+  highlightFirstItem: boolean
+  categoryLabel?: string
+}) {
+  const [isExpanded, setIsExpanded] = React.useState(true)
+
+  return (
+    <>
+      {props.categoryLabel && (
+        <button
+          className={styles.menuSectionTitle}
+          onClick={(e) => {
+            e.stopPropagation()
+            e.preventDefault()
+            setIsExpanded((open) => !open)
+          }}
+        >
+          {props.categoryLabel}
+          <Icon name={isExpanded ? 'carat-up' : 'carat-down'} />
+        </button>
+      )}
+      <leo-menu-section
+        class={classnames(styles.categoryEntriesWrap, {
+          [styles.categoryEntriesWrapExpanded]:
+            !props.categoryLabel || isExpanded,
+          [styles.highlightFirstItem]: props.highlightFirstItem,
+        })}
+      >
+        {props.entries.map((entry, i) => (
+          <React.Fragment key={i}>
+            {props.renderEntry(
+              entry,
+              props.categoryLabel,
+              props.lookup.get(entry),
+            )}
+          </React.Fragment>
+        ))}
+      </leo-menu-section>
+    </>
+  )
 }
 
 export function MatchedText(props: { text: string; match?: Match }) {
@@ -97,6 +144,8 @@ export default function FilterMenu<T>(props: Props<T>) {
     () => !filtered.some((g) => g.entries.length !== 0),
     [filtered],
   )
+  const firstNamedCategoryIndex = filtered.findIndex((g) => g.category)
+  const firstFlatCategoryIndex = filtered.findIndex((g) => !g.category)
   const ref = React.useRef<HTMLElement>(null)
 
   React.useEffect(() => {
@@ -162,8 +211,7 @@ export default function FilterMenu<T>(props: Props<T>) {
       ref={ref}
       className={classnames({
         [styles.buttonMenu]: true,
-        // If we're filtering the list, highlight the first item
-        [styles.highlightFirstItem]: props.query !== null,
+        [styles.fullWidth]: props.isFullWidth,
       })}
       isOpen={props.isOpen}
       onClose={() => {
@@ -173,18 +221,25 @@ export default function FilterMenu<T>(props: Props<T>) {
       widthIsMaxWidth
     >
       {props.header}
-      {filtered.map((category) => {
+      {filtered.map((category, categoryIndex) => {
+        // Idle row tint (see .highlightFirstItem): first named section when any
+        // exist; otherwise the first flat (empty title) block only.
+        const highlightFirstItem =
+          props.query !== null
+          && (category.category
+            ? categoryIndex === firstNamedCategoryIndex
+            : firstNamedCategoryIndex < 0
+              && categoryIndex === firstFlatCategoryIndex)
+
         return (
-          <React.Fragment key={category.category}>
-            {category.category && (
-              <div className={styles.menuSectionTitle}>{category.category}</div>
-            )}
-            {category.entries.map((entry, i) => (
-              <React.Fragment key={i}>
-                {props.children(entry, category.category, lookup.get(entry))}
-              </React.Fragment>
-            ))}
-          </React.Fragment>
+          <FilterMenuCategoryGroup
+            key={category.category || `filter-section-${categoryIndex}`}
+            categoryLabel={category.category}
+            entries={category.entries}
+            lookup={lookup}
+            renderEntry={props.children}
+            highlightFirstItem={highlightFirstItem}
+          />
         )
       })}
       {noMatches && props.noMatchesMessage}

--- a/components/ai_chat/resources/page/components/filter_menu/style.module.scss
+++ b/components/ai_chat/resources/page/components/filter_menu/style.module.scss
@@ -5,40 +5,81 @@
 
 .buttonMenu {
   --menu-width: 270px;
-  --leo-menu-max-height: 320px;
-  width: 100cqi;
-}
-
-.highlightFirstItem {
-  &:not(:focus-within) leo-menu-item {
-    &:first-of-type {
-      background: var(--leo-color-container-interactive);
-      color: var(--leo-color-text-interactive);
-    }
-  }
+  --leo-menu-max-height: calc(100vh - 180px);
+  width: var(--menu-width);
 
   leo-menu-item:focus-visible {
     box-shadow: none;
     border: none;
+    outline: none;
+    background: var(--leo-color-container-interactive);
+    color: var(--leo-color-text-interactive);
+  }
+
+  // Idle tint for the first selectable row: .highlightFirstItem is set only on the
+  // first relevant leo-menu-section (see filter_menu.tsx). Uses :not(:focus-within)
+  // on the whole menu so moving focus to another row/section does not re-tint the first.
+  &:not(:focus-within) .highlightFirstItem leo-menu-item:first-of-type {
     background: var(--leo-color-container-interactive);
     color: var(--leo-color-text-interactive);
   }
 }
 
+.fullWidth {
+  width: 100cqi;
+}
+
 .menuSectionTitle {
-  background-color: var(--leo-color-page-background);
-  padding: var(--leo-spacing-l);
+  --leo-icon-size: 16px;
+  --leo-icon-color: var(--leo-color-icon-secondary);
+  background: none;
+  border: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--leo-spacing-m);
+  padding: var(--leo-spacing-m) var(--leo-spacing-l);
+  margin: 0;
   color: var(--leo-color-text-tertiary);
-  font: var(--leo-font-components-label);
-  text-transform: uppercase;
+  font: var(--leo-font-default-regular);
+  leo-icon {
+    transition: transform 0.2s ease-in-out;
+  }
+}
+
+.categoryEntriesWrap {
+  display: none;
+  flex-direction: column;
+  transition: display 0.25s ease-in-out;
+  padding: var(--leo-spacing-s);
+  min-height: fit-content;
+  leo-menu-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--leo-spacing-m);
+    min-width: 240px;
+    border-radius: var(--leo-radius-s);
+    &:hover {
+      background-color: var(--leo-color-container-highlight);
+    }
+    &[aria-selected] {
+      background-color: var(--leo-color-container-interactive);
+      color: var(--leo-color-text-interactive);
+    }
+  }
+}
+
+.categoryEntriesWrapExpanded {
+  display: flex;
 }
 
 .menuSubtitle {
   margin: 0 var(--leo-spacing-s);
-  padding: var(--leo-spacing-l);
+  padding: var(--leo-spacing-l) var(--leo-spacing-s);
   color: var(--leo-color-text-tertiary);
   font: var(--leo-font-components-label);
-  text-transform: uppercase;
   border-top: 1px solid var(--leo-color-divider-subtle);
 }
 


### PR DESCRIPTION
## Description 

- Makes each section collapsible
- Menu is no longer full width of the input
- Menu is now taller
- Sections no longer have a background
- Section labels are no longer `uppercase`

<img width="308" height="429" alt="Screenshot 11" src="https://github.com/user-attachments/assets/d0bd679b-dae4-457d-8771-8686dc06e06d" />

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/53559>

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

https://github.com/user-attachments/assets/23769575-1640-4cd5-83f8-65d0373c2379
