### PR TITLE
Disable kSyncAutofillValuableMetadata to match kSyncAutofillLoyaltyCard (uplift to 1.89.x)

### DIFF
--- a/chromium_src/components/sync/base/features.cc
+++ b/chromium_src/components/sync/base/features.cc
@@ -11,6 +11,7 @@ namespace syncer {
 
 OVERRIDE_FEATURE_DEFAULT_STATES({{
     {kSyncAutofillLoyaltyCard, base::FEATURE_DISABLED_BY_DEFAULT},
+    {kSyncAutofillValuableMetadata, base::FEATURE_DISABLED_BY_DEFAULT},
     {kSyncDetermineAccountManagedStatus, base::FEATURE_DISABLED_BY_DEFAULT},
 }});
 


### PR DESCRIPTION
Uplift of #35701
Resolves https://github.com/brave/brave-browser/issues/54757

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.