### PR TITLE
Move set_should_show_header(false) to PopulateSidePanel

### DIFF
--- a/browser/ui/sidebar/sidebar_browsertest.cc
+++ b/browser/ui/sidebar/sidebar_browsertest.cc
@@ -2139,6 +2139,17 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, SidebarV2NoUpstreamHeaderTest) {
 
   EXPECT_EQ(nullptr, side_panel->GetHeaderView<views::View>())
       << "Upstream SidePanelHeader should not be present after V2 panel open";
+
+  // Also verify CustomizeChrome panel does not get an upstream header.
+  panel_ui->Show(SidePanelEntryId::kCustomizeChrome);
+  ASSERT_TRUE(base::test::RunUntil([&]() {
+    return panel_ui->IsSidePanelEntryShowing(
+        SidePanelEntry::Key(SidePanelEntryId::kCustomizeChrome));
+  }));
+
+  EXPECT_EQ(nullptr, side_panel->GetHeaderView<views::View>())
+      << "Upstream SidePanelHeader should not be present for CustomizeChrome "
+         "panel";
 }
 
 #endif  // BUILDFLAG(ENABLE_SIDEBAR_V2)

--- a/browser/ui/views/side_panel/brave_side_panel_coordinator.cc
+++ b/browser/ui/views/side_panel/brave_side_panel_coordinator.cc
@@ -178,6 +178,10 @@ void BraveSidePanelCoordinator::PopulateSidePanel(
     SidePanelEntry* entry,
     std::optional<std::unique_ptr<views::View>> content_view) {
   CHECK(entry);
+
+  // Brave has its own side panel header, so hide the built-in entry headers.
+  entry->set_should_show_header(false);
+
   actions::ActionItem* const action_item =
       SidePanelUtil::GetActionItem(browser_view_->browser(), entry->key());
   if (!action_item) {

--- a/browser/ui/views/side_panel/brave_side_panel_utils.cc
+++ b/browser/ui/views/side_panel/brave_side_panel_utils.cc
@@ -36,11 +36,6 @@ void RegisterContextualSidePanel(SidePanelRegistry* registry,
         /*default_content_width_callback=*/base::NullCallback()));
   }
 #endif
-
-  // Brave has its own side panel header, so hide the built-in entry headers.
-  for (auto& entry : registry->entries()) {
-    entry->set_should_show_header(false);
-  }
 }
 
 }  // namespace brave

--- a/chromium_src/chrome/browser/ui/views/side_panel/side_panel_util.cc
+++ b/chromium_src/chrome/browser/ui/views/side_panel/side_panel_util.cc
@@ -45,9 +45,4 @@ void SidePanelUtil::PopulateGlobalEntries(Browser* browser,
         base::NullCallback()));
   }
 #endif
-
-  // Brave has its own side panel header, so hide the built-in entry headers.
-  for (auto& entry : global_registry->entries()) {
-    entry->set_should_show_header(false);
-  }
 }


### PR DESCRIPTION
F/U PR for https://github.com/brave/brave-core/pull/35616

Previously, Brave suppressed the upstream SidePanelHeader by iterating
all registry entries and calling set_should_show_header(false) at the
point when the global registry (SidePanelUtil::PopulateGlobalEntries)
and contextual registry (brave_side_panel_utils::RegisterContextualSidePanel)
were first populated. This missed entries registered later, such as
kCustomizeChrome, which registers its SidePanelEntry in DidFinishNavigation
after the initial registry setup loop had already run.

Move the call to BraveSidePanelCoordinator::PopulateSidePanel instead,
which is invoked unconditionally for every entry at the moment it is
displayed. This guarantees the upstream header is suppressed regardless
of when or how the entry was registered.

Also extend SidebarV2NoUpstreamHeaderTest to verify that the
CustomizeChrome panel does not receive an upstream header.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
