### PR TITLE
Enable the Force Context Menu on Shift Right Click feature by default

### DIFF
--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -528,20 +528,6 @@ constexpr flags_ui::FeatureEntry::Choice kVerticalTabCollapseDelayChoices[] = {
 #define BRAVE_MIDDLE_CLICK_AUTOSCROLL_FEATURE_ENTRY
 #endif
 
-#if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_MAC)
-#define BRAVE_FORCE_CONTEXT_MENU_ON_SHIFT_RIGHT_CLICK_FEATURE_ENTRY            \
-  EXPAND_FEATURE_ENTRIES({                                                     \
-      "force-context-menu-on-shift-right-click",                               \
-      "Force context menu on Shift + Right Click on elements in pages",        \
-      "Always show the context menu when Shift + Right Click is used, "        \
-      "even if a web page is preventing it.",                                  \
-      kOsWin | kOsLinux | kOsMac,                                              \
-      FEATURE_VALUE_TYPE(blink::features::kForceContextMenuOnShiftRightClick), \
-  })
-#else
-#define BRAVE_FORCE_CONTEXT_MENU_ON_SHIFT_RIGHT_CLICK_FEATURE_ENTRY
-#endif  // BUILDFLAG(IS_WIN) || BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_MAC)
-
 #if BUILDFLAG(ENABLE_AI_CHAT)
 #define BRAVE_AI_CHAT_FEATURE_ENTRIES                                          \
   EXPAND_FEATURE_ENTRIES(                                                      \
@@ -1335,7 +1321,6 @@ constexpr flags_ui::FeatureEntry::Choice kVerticalTabCollapseDelayChoices[] = {
   BRAVE_LOCAL_AI_MODELS                                                        \
   BRAVE_OMNIBOX_FEATURES                                                       \
   BRAVE_MIDDLE_CLICK_AUTOSCROLL_FEATURE_ENTRY                                  \
-  BRAVE_FORCE_CONTEXT_MENU_ON_SHIFT_RIGHT_CLICK_FEATURE_ENTRY                  \
   BRAVE_UPGRADE_WHEN_IDLE_FEATURE_ENTRY                                        \
   BRAVE_EXTENSIONS_MANIFEST_V2                                                 \
   BRAVE_EXTENSION_AUTO_UPDATE_FEATURE_ENTRY                                    \

--- a/chromium_src/third_party/blink/common/features.cc
+++ b/chromium_src/third_party/blink/common/features.cc
@@ -86,7 +86,7 @@ BASE_FEATURE(kMiddleButtonClickAutoscroll,
 
 #if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_MAC)
 BASE_FEATURE(kForceContextMenuOnShiftRightClick,
-             base::FEATURE_DISABLED_BY_DEFAULT);
+             base::FEATURE_ENABLED_BY_DEFAULT);
 #endif  // BUILDFLAG(IS_WIN) || BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_MAC)
 
 bool IsPrerender2Enabled() {


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/54790

- Enables feature by default
- Removes feature from brave://flags
- Code still behind feature flag and can still be disabled by Griffin if needed
