### PR TITLE
[CodeHealth] Remove unused API from SerpMetricsTimePeriodStorage

### DIFF
--- a/components/serp_metrics/serp_metrics.cc
+++ b/components/serp_metrics/serp_metrics.cc
@@ -49,9 +49,7 @@ BuildTimePeriodStorages(
     time_period_storages.emplace(
         type,
         std::make_unique<SerpMetricsTimePeriodStorage>(
-            std::move(time_period_store), kSerpMetricsTimePeriodInDays.Get(),
-            /*should_use_utc=*/false,
-            /*should_offset_dst=*/false));
+            std::move(time_period_store), kSerpMetricsTimePeriodInDays.Get()));
   }
 
   return time_period_storages;

--- a/components/serp_metrics/time_period_storage/serp_metrics_time_period_storage.cc
+++ b/components/serp_metrics/time_period_storage/serp_metrics_time_period_storage.cc
@@ -5,213 +5,32 @@
 
 #include "brave/components/serp_metrics/time_period_storage/serp_metrics_time_period_storage.h"
 
-#include <algorithm>
 #include <numeric>
 #include <utility>
 
 #include "base/check.h"
 #include "base/check_op.h"
-#include "base/time/clock.h"
-#include "base/time/default_clock.h"
 #include "base/time/time.h"
 #include "base/values.h"
-#include "brave/components/serp_metrics/time_period_storage/serp_metrics_pref_time_period_store.h"
 #include "brave/components/serp_metrics/time_period_storage/serp_metrics_time_period_store.h"
-#include "components/prefs/pref_service.h"
 
 namespace serp_metrics {
 
 namespace {
 
-// Used to compensate for DST-related differences. i.e. time
-// method arguments not matching up with stored time values.
-constexpr base::TimeDelta kPotentialDSTOffset = base::Hours(1);
-
-// Used by `NextMidnight` when `should_use_fixed_day` is `false`. 24 hours
-// covers a standard day; the extra 2 hours covers the maximum DST shift
-// (Antarctica/Troll), guaranteeing the result lands inside the next calendar
-// day without overshooting into the day after.
+// 24 hours covers a standard day; the extra 2 hours covers the maximum DST
+// shift (Antarctica/Troll), guaranteeing the result lands inside the next
+// calendar day without overshooting into the day after.
 constexpr base::TimeDelta kNextMidnightOffset =
     base::Hours(24) + base::Hours(2);
 
-}  // namespace
-
-SerpMetricsTimePeriodStorage::SerpMetricsTimePeriodStorage(
-    std::unique_ptr<SerpMetricsTimePeriodStore> store,
-    size_t period_days,
-    bool should_use_utc,
-    bool should_offset_dst)
-    : clock_(std::make_unique<base::DefaultClock>()),
-      store_(std::move(store)),
-      period_days_(period_days),
-      should_use_utc_(should_use_utc),
-      should_offset_dst_(should_offset_dst) {
-  CHECK(store_);
-  Load();
+base::Time Midnight(base::Time time) {
+  return time.LocalMidnight();
 }
 
-SerpMetricsTimePeriodStorage::SerpMetricsTimePeriodStorage(
-    PrefService* prefs,
-    const char* pref_name,
-    size_t period_days,
-    bool should_use_utc,
-    bool should_offset_dst)
-    : SerpMetricsTimePeriodStorage(prefs,
-                                   pref_name,
-                                   nullptr,
-                                   period_days,
-                                   should_use_utc,
-                                   should_offset_dst) {}
-
-SerpMetricsTimePeriodStorage::SerpMetricsTimePeriodStorage(
-    PrefService* prefs,
-    const char* pref_name,
-    const char* dict_key,
-    size_t period_days,
-    bool should_use_utc,
-    bool should_offset_dst)
-    : clock_(std::make_unique<base::DefaultClock>()),
-      store_(std::make_unique<SerpMetricsPrefTimePeriodStore>(prefs,
-                                                              pref_name,
-                                                              dict_key)),
-      period_days_(period_days),
-      should_use_utc_(should_use_utc),
-      should_offset_dst_(should_offset_dst) {
-  CHECK(pref_name);
-  if (prefs) {
-    Load();
-  }
-}
-
-SerpMetricsTimePeriodStorage::SerpMetricsTimePeriodStorage(
-    PrefService* prefs,
-    const char* pref_name,
-    const char* dict_key,
-    size_t period_days,
-    std::unique_ptr<base::Clock> clock,
-    bool should_use_utc,
-    bool should_offset_dst)
-    : clock_(std::move(clock)),
-      store_(std::make_unique<SerpMetricsPrefTimePeriodStore>(prefs,
-                                                              pref_name,
-                                                              dict_key)),
-      period_days_(period_days),
-      should_use_utc_(should_use_utc),
-      should_offset_dst_(should_offset_dst) {
-  CHECK(prefs);
-  CHECK(pref_name);
-  Load();
-}
-
-SerpMetricsTimePeriodStorage::~SerpMetricsTimePeriodStorage() = default;
-
-void SerpMetricsTimePeriodStorage::AddDelta(uint64_t delta) {
-  FilterToPeriod();
-  daily_values_.front().value += delta;
-  Save();
-}
-
-void SerpMetricsTimePeriodStorage::SubDelta(uint64_t delta) {
-  FilterToPeriod();
-  for (DailyValue& daily_value : daily_values_) {
-    if (delta == 0) {
-      break;
-    }
-    uint64_t day_delta = std::min(daily_value.value, delta);
-    daily_value.value -= day_delta;
-    delta -= day_delta;
-  }
-  Save();
-}
-
-void SerpMetricsTimePeriodStorage::ReplaceTodaysValueIfGreater(uint64_t value) {
-  FilterToPeriod();
-  DailyValue& today = daily_values_.front();
-  if (today.value < value) {
-    today.value = value;
-  }
-  Save();
-}
-
-void SerpMetricsTimePeriodStorage::ReplaceIfGreaterForDate(
-    const base::Time& date,
-    uint64_t value) {
-  FilterToPeriod();
-  base::Time date_mn = Midnight(date);
-  std::list<DailyValue>::iterator day_insert_it = std::ranges::find_if(
-      daily_values_,
-      [date_mn](const DailyValue& val) { return val.day <= date_mn; });
-  if (day_insert_it != daily_values_.end() && day_insert_it->day == date_mn) {
-    // update daily value if it exists for date
-    if (value > day_insert_it->value) {
-      day_insert_it->value = value;
-    }
-  } else {
-    daily_values_.insert(day_insert_it, {date_mn, value});
-  }
-  Save();
-}
-
-uint64_t SerpMetricsTimePeriodStorage::GetPeriodSumInTimeRange(
-    const base::Time& start_time,
-    const base::Time& end_time) const {
-  const base::TimeDelta dst_offset = GetDstOffset();
-  // We only record values between the specified time range (inclusive).
-  return std::accumulate(
-      daily_values_.begin(), daily_values_.end(), 0ULL,
-      [start_time, end_time, dst_offset](uint64_t acc, const auto& u2) {
-        uint64_t add = 0;
-        // Check only last continious days.
-        if (u2.day >= start_time - dst_offset &&
-            u2.day <= end_time + dst_offset) {
-          add = u2.value;
-        }
-        return acc + add;
-      });
-}
-
-uint64_t SerpMetricsTimePeriodStorage::GetPeriodSum() const {
-  const base::Time now = clock_->Now();
-  const base::Time n_days_ago = Midnight(now) - base::Days(period_days_ - 1);
-  return GetPeriodSumInTimeRange(n_days_ago, now);
-}
-
-uint64_t SerpMetricsTimePeriodStorage::GetHighestValueInPeriod() const {
-  // We record only value for last N days.
-  const base::Time n_days_ago = clock_->Now() - base::Days(period_days_);
-  std::list<DailyValue> in_period_daily_values(daily_values_.size());
-  auto copied_it =
-      std::copy_if(daily_values_.begin(), daily_values_.end(),
-                   in_period_daily_values.begin(),
-                   [n_days_ago](auto i) { return i.day > n_days_ago; });
-  in_period_daily_values.resize(
-      std::distance(in_period_daily_values.begin(), copied_it));
-
-  auto highest_it = std::max_element(in_period_daily_values.begin(),
-                                     in_period_daily_values.end(),
-                                     [](const auto& left, const auto& right) {
-                                       return left.value < right.value;
-                                     });
-  if (highest_it == in_period_daily_values.end()) {
-    return 0;
-  }
-  return highest_it->value;
-}
-
-bool SerpMetricsTimePeriodStorage::IsOnePeriodPassed() const {
-  return daily_values_.size() == period_days_;
-}
-
-void SerpMetricsTimePeriodStorage::Clear() {
-  daily_values_.clear();
-  store_->Clear();
-}
-
-base::Time SerpMetricsTimePeriodStorage::Midnight(base::Time time) const {
-  return should_use_utc_ ? time.UTCMidnight() : time.LocalMidnight();
-}
-
-base::Time SerpMetricsTimePeriodStorage::NextMidnight(base::Time time) const {
+// Returns the midnight that starts the calendar day after `time`. Safe
+// across DST transitions and does not require `time` to be at midnight.
+base::Time NextMidnight(base::Time time) {
   // No precondition is enforced on `time` being at midnight. Two legitimate
   // cases produce non-midnight inputs: legacy prefs written by the old
   // DST-offset code contain timestamps 1 hour past midnight, and travel across
@@ -232,18 +51,52 @@ base::Time SerpMetricsTimePeriodStorage::NextMidnight(base::Time time) const {
   return Midnight(time + kNextMidnightOffset);
 }
 
-base::TimeDelta SerpMetricsTimePeriodStorage::GetDstOffset() const {
-  // DST offset is only applied when using local time, since UTC time does not
-  // have DST adjustments.
-  if (should_use_utc_ || !should_offset_dst_) {
-    return base::TimeDelta();
-  }
+}  // namespace
 
-  return kPotentialDSTOffset;
+SerpMetricsTimePeriodStorage::SerpMetricsTimePeriodStorage(
+    std::unique_ptr<SerpMetricsTimePeriodStore> store,
+    size_t period_days)
+    : store_(std::move(store)), period_days_(period_days) {
+  CHECK(store_);
+  Load();
+}
+
+SerpMetricsTimePeriodStorage::~SerpMetricsTimePeriodStorage() = default;
+
+void SerpMetricsTimePeriodStorage::AddDelta(uint64_t delta) {
+  FilterToPeriod();
+  daily_values_.front().value += delta;
+  Save();
+}
+
+uint64_t SerpMetricsTimePeriodStorage::GetPeriodSumInTimeRange(
+    const base::Time& start_time,
+    const base::Time& end_time) const {
+  // We only record values between the specified time range (inclusive).
+  return std::accumulate(daily_values_.begin(), daily_values_.end(), 0ULL,
+                         [start_time, end_time](uint64_t acc, const auto& u2) {
+                           uint64_t add = 0;
+                           // Check only last continious days.
+                           if (u2.day >= start_time && u2.day <= end_time) {
+                             add = u2.value;
+                           }
+                           return acc + add;
+                         });
+}
+
+uint64_t SerpMetricsTimePeriodStorage::GetPeriodSum() const {
+  const base::Time now = base::Time::Now();
+  const base::Time n_days_ago = Midnight(now) - base::Days(period_days_ - 1);
+  return GetPeriodSumInTimeRange(n_days_ago, now);
+}
+
+void SerpMetricsTimePeriodStorage::Clear() {
+  daily_values_.clear();
+  store_->Clear();
 }
 
 void SerpMetricsTimePeriodStorage::FilterToPeriod() {
-  const base::Time now_midnight = Midnight(clock_->Now());
+  const base::Time now_midnight = Midnight(base::Time::Now());
 
   if (daily_values_.empty()) {
     // No prior data; seed the list with an empty bucket for today.
@@ -251,16 +104,10 @@ void SerpMetricsTimePeriodStorage::FilterToPeriod() {
     return;
   }
 
-  // When DST offsetting is disabled and local time is used (SERP), use
-  // `NextMidnight` to correctly handle short calendar days at DST start.
-  // For P3A, `GetDstOffset` extends the loop condition by one hour to cover
-  // a potential DST shift. For UTC, days are always exactly 24 hours.
-  const bool should_use_fixed_day = should_offset_dst_ || should_use_utc_;
+  // Use `NextMidnight` to correctly handle short calendar days at DST start.
   const base::Time last_recorded_midnight = daily_values_.front().day;
-  base::Time bucket_midnight = should_use_fixed_day
-                                   ? last_recorded_midnight + base::Days(1)
-                                   : NextMidnight(last_recorded_midnight);
-  while (bucket_midnight <= now_midnight + GetDstOffset()) {
+  base::Time bucket_midnight = NextMidnight(last_recorded_midnight);
+  while (bucket_midnight <= now_midnight) {
     // Add an empty bucket for the missed day.
     daily_values_.push_front({bucket_midnight, 0});
 
@@ -269,9 +116,7 @@ void SerpMetricsTimePeriodStorage::FilterToPeriod() {
       daily_values_.pop_back();
     }
 
-    // Advance to the next bucket.
-    bucket_midnight = should_use_fixed_day ? bucket_midnight + base::Days(1)
-                                           : NextMidnight(bucket_midnight);
+    bucket_midnight = NextMidnight(bucket_midnight);
   }
 }
 

--- a/components/serp_metrics/time_period_storage/serp_metrics_time_period_storage.h
+++ b/components/serp_metrics/time_period_storage/serp_metrics_time_period_storage.h
@@ -11,94 +11,42 @@
 
 #include "base/time/time.h"
 
-namespace base {
-class Clock;
-}
-
-class PrefService;
-
 namespace serp_metrics {
 
 class SerpMetricsTimePeriodStore;
 
-// Allows to track a sum of some values added from time to time via |AddDelta|
+// Allows to track a sum of some values added from time to time via `AddDelta`
 // over the last predefined time period.
-// When using deprecated constructors, |pref_name| must be already registered.
 class SerpMetricsTimePeriodStorage {
  public:
-  // Will use a `SerpMetricsTimePeriodStore` for storage.
   SerpMetricsTimePeriodStorage(
       std::unique_ptr<SerpMetricsTimePeriodStore> store,
-      size_t period_days,
-      bool should_use_utc = false,
-      bool should_offset_dst = true);
-
-  // Will use a list pref for storage. This is a deprecated constructor for
-  // backward compatibility. Use constructor with `SerpMetricsTimePeriodStore`
-  // instead.
-  SerpMetricsTimePeriodStorage(PrefService* prefs,
-                               const char* pref_name,
-                               size_t period_days,
-                               bool should_use_utc = false,
-                               bool should_offset_dst = true);
-  // Will use a list within a dictionary pref for storage. This is a deprecated
-  // constructor for backward compatibility. Use constructor with
-  // `SerpMetricsTimePeriodStore` instead.
-  SerpMetricsTimePeriodStorage(PrefService* prefs,
-                               const char* pref_name,
-                               const char* dict_key,
-                               size_t period_days,
-                               bool should_use_utc = false,
-                               bool should_offset_dst = true);
-
-  // For tests only. Deprecated constructor for backward compatibility. Use
-  // constructor with `SerpMetricsTimePeriodStore` instead.
-  SerpMetricsTimePeriodStorage(PrefService* prefs,
-                               const char* pref_name,
-                               const char* dict_key,
-                               size_t period_days,
-                               std::unique_ptr<base::Clock> clock,
-                               bool should_use_utc = false,
-                               bool should_offset_dst = true);
-  ~SerpMetricsTimePeriodStorage();
+      size_t period_days);
 
   SerpMetricsTimePeriodStorage(const SerpMetricsTimePeriodStorage&) = delete;
   SerpMetricsTimePeriodStorage& operator=(const SerpMetricsTimePeriodStorage&) =
       delete;
 
+  ~SerpMetricsTimePeriodStorage();
+
   void AddDelta(uint64_t delta);
-  void SubDelta(uint64_t delta);
-  void ReplaceTodaysValueIfGreater(uint64_t value);
-  void ReplaceIfGreaterForDate(const base::Time& date, uint64_t value);
   uint64_t GetPeriodSumInTimeRange(const base::Time& start_time,
                                    const base::Time& end_time) const;
   uint64_t GetPeriodSum() const;
-  uint64_t GetHighestValueInPeriod() const;
-  bool IsOnePeriodPassed() const;
 
   void Clear();
-
- protected:
-  std::unique_ptr<base::Clock> clock_;
 
  private:
   struct DailyValue {
     base::Time day;
     uint64_t value = 0ULL;
   };
-  base::Time Midnight(base::Time time) const;
-  // Returns the midnight that starts the calendar day after `time`. Safe
-  // across DST transitions and does not require `time` to be at midnight.
-  base::Time NextMidnight(base::Time time) const;
-  base::TimeDelta GetDstOffset() const;
   void FilterToPeriod();
   void Load();
   void Save();
 
   std::unique_ptr<SerpMetricsTimePeriodStore> store_;
   size_t period_days_;
-  const bool should_use_utc_;
-  const bool should_offset_dst_;
 
   std::list<DailyValue> daily_values_;
 };

--- a/components/serp_metrics/time_period_storage/serp_metrics_time_period_storage_dst_end_unittest.cc
+++ b/components/serp_metrics/time_period_storage/serp_metrics_time_period_storage_dst_end_unittest.cc
@@ -11,6 +11,7 @@
 #include "base/test/task_environment.h"
 #include "base/test/values_test_util.h"
 #include "base/time/time.h"
+#include "brave/components/serp_metrics/time_period_storage/serp_metrics_pref_time_period_store.h"
 #include "brave/components/serp_metrics/time_period_storage/serp_metrics_scoped_timezone_for_testing.h"
 #include "brave/components/serp_metrics/time_period_storage/serp_metrics_time_period_storage.h"
 #include "components/prefs/pref_registry_simple.h"
@@ -137,9 +138,9 @@ TEST_P(SerpMetricsTimePeriodStorageDSTEndTest,
 
   const auto time_period_storage =
       std::make_unique<SerpMetricsTimePeriodStorage>(
-          &pref_service, kPrefName, /*period_days=*/28,
-          /*should_use_utc=*/false,
-          /*should_offset_dst=*/false);
+          std::make_unique<SerpMetricsPrefTimePeriodStore>(&pref_service,
+                                                           kPrefName),
+          /*period_days=*/28);
 
   // Day 1: the DST end day itself. The local day is longer than 24 hours
   // because clocks fall back.

--- a/components/serp_metrics/time_period_storage/serp_metrics_time_period_storage_dst_start_unittest.cc
+++ b/components/serp_metrics/time_period_storage/serp_metrics_time_period_storage_dst_start_unittest.cc
@@ -11,6 +11,7 @@
 #include "base/test/task_environment.h"
 #include "base/test/values_test_util.h"
 #include "base/time/time.h"
+#include "brave/components/serp_metrics/time_period_storage/serp_metrics_pref_time_period_store.h"
 #include "brave/components/serp_metrics/time_period_storage/serp_metrics_scoped_timezone_for_testing.h"
 #include "brave/components/serp_metrics/time_period_storage/serp_metrics_time_period_storage.h"
 #include "components/prefs/pref_registry_simple.h"
@@ -137,9 +138,9 @@ TEST_P(SerpMetricsTimePeriodStorageDSTStartTest,
 
   const auto time_period_storage =
       std::make_unique<SerpMetricsTimePeriodStorage>(
-          &pref_service, kPrefName, /*period_days=*/28,
-          /*should_use_utc=*/false,
-          /*should_offset_dst=*/false);
+          std::make_unique<SerpMetricsPrefTimePeriodStore>(&pref_service,
+                                                           kPrefName),
+          /*period_days=*/28);
 
   // Day 1: the DST start day itself. The local day is shorter than 24 hours.
   time_period_storage->AddDelta(1);

--- a/components/serp_metrics/time_period_storage/serp_metrics_time_period_storage_issue_54427_unittest.cc
+++ b/components/serp_metrics/time_period_storage/serp_metrics_time_period_storage_issue_54427_unittest.cc
@@ -10,6 +10,7 @@
 #include "base/test/task_environment.h"
 #include "base/test/values_test_util.h"
 #include "base/time/time.h"
+#include "brave/components/serp_metrics/time_period_storage/serp_metrics_pref_time_period_store.h"
 #include "brave/components/serp_metrics/time_period_storage/serp_metrics_scoped_timezone_for_testing.h"
 #include "brave/components/serp_metrics/time_period_storage/serp_metrics_time_period_storage.h"
 #include "components/prefs/pref_registry_simple.h"
@@ -176,9 +177,9 @@ TEST_F(SerpMetricsTimePeriodStorageIssue54427Test,
   ])JSON"));
 
   time_period_storage_ = std::make_unique<SerpMetricsTimePeriodStorage>(
-      &pref_service_, kPrefName, /*period_days=*/28,
-      /*should_use_utc=*/false,
-      /*should_offset_dst=*/false);
+      std::make_unique<SerpMetricsPrefTimePeriodStore>(&pref_service_,
+                                                       kPrefName),
+      /*period_days=*/28);
 
   // April 10 09:00 CEST (April 10 07:00 UTC).
   base::Time april_10;
@@ -323,9 +324,9 @@ TEST_F(SerpMetricsTimePeriodStorageIssue54427Test,
       "Europe/Berlin");
 
   time_period_storage_ = std::make_unique<SerpMetricsTimePeriodStorage>(
-      &pref_service_, kPrefName, /*period_days=*/28,
-      /*should_use_utc=*/false,
-      /*should_offset_dst=*/false);
+      std::make_unique<SerpMetricsPrefTimePeriodStore>(&pref_service_,
+                                                       kPrefName),
+      /*period_days=*/28);
 
   base::Time march_13_cet_midnight;
   ASSERT_TRUE(base::Time::FromUTCString("12 Mar 2026 23:00:00",
@@ -496,9 +497,9 @@ TEST_F(SerpMetricsTimePeriodStorageIssue54427Test,
   const test::SerpMetricsScopedTimezoneForTesting scoped_timezone(
       "Europe/Berlin");
   time_period_storage_ = std::make_unique<SerpMetricsTimePeriodStorage>(
-      &pref_service_, kPrefName, kPeriodDays,
-      /*should_use_utc=*/false,
-      /*should_offset_dst=*/false);
+      std::make_unique<SerpMetricsPrefTimePeriodStore>(&pref_service_,
+                                                       kPrefName),
+      kPeriodDays);
 
   // DST starts in Europe/Berlin at 28 March 2027 01:00:00 UTC. Clocks move
   // forward from 02:00 CET to 03:00 CEST, so the day is 23 hours long.
@@ -539,9 +540,9 @@ TEST_F(SerpMetricsTimePeriodStorageIssue54427Test,
   const test::SerpMetricsScopedTimezoneForTesting scoped_timezone(
       "Antarctica/Troll");
   time_period_storage_ = std::make_unique<SerpMetricsTimePeriodStorage>(
-      &pref_service_, kPrefName, kPeriodDays,
-      /*should_use_utc=*/false,
-      /*should_offset_dst=*/false);
+      std::make_unique<SerpMetricsPrefTimePeriodStore>(&pref_service_,
+                                                       kPrefName),
+      kPeriodDays);
 
   base::Time dst_start;
   ASSERT_TRUE(base::Time::FromUTCString("28 Mar 2027 01:00:00", &dst_start));
@@ -581,9 +582,9 @@ TEST_F(
   const test::SerpMetricsScopedTimezoneForTesting scoped_timezone(
       "Australia/Lord_Howe");
   time_period_storage_ = std::make_unique<SerpMetricsTimePeriodStorage>(
-      &pref_service_, kPrefName, kPeriodDays,
-      /*should_use_utc=*/false,
-      /*should_offset_dst=*/false);
+      std::make_unique<SerpMetricsPrefTimePeriodStore>(&pref_service_,
+                                                       kPrefName),
+      kPeriodDays);
 
   base::Time dst_start;
   ASSERT_TRUE(base::Time::FromUTCString("2 Oct 2027 15:30:00", &dst_start));
@@ -619,9 +620,9 @@ TEST_F(SerpMetricsTimePeriodStorageIssue54427Test,
   const test::SerpMetricsScopedTimezoneForTesting scoped_timezone(
       "Europe/Berlin");
   time_period_storage_ = std::make_unique<SerpMetricsTimePeriodStorage>(
-      &pref_service_, kPrefName, kPeriodDays,
-      /*should_use_utc=*/false,
-      /*should_offset_dst=*/false);
+      std::make_unique<SerpMetricsPrefTimePeriodStore>(&pref_service_,
+                                                       kPrefName),
+      kPeriodDays);
 
   // DST ends in Europe/Berlin at 31 October 2027 01:00:00 UTC.
   // Clocks move back from 03:00 CEST to 02:00 CET.
@@ -661,9 +662,9 @@ TEST_F(SerpMetricsTimePeriodStorageIssue54427Test,
   const test::SerpMetricsScopedTimezoneForTesting scoped_timezone(
       "Europe/Berlin");
   time_period_storage_ = std::make_unique<SerpMetricsTimePeriodStorage>(
-      &pref_service_, kPrefName, kPeriodDays,
-      /*should_use_utc=*/false,
-      /*should_offset_dst=*/false);
+      std::make_unique<SerpMetricsPrefTimePeriodStore>(&pref_service_,
+                                                       kPrefName),
+      kPeriodDays);
 
   base::Time dst_start;
   ASSERT_TRUE(base::Time::FromUTCString("28 Mar 2027 01:00:00", &dst_start));
@@ -686,9 +687,8 @@ TEST_F(SerpMetricsTimePeriodStorageIssue54427Test,
   // hour. Because of that, the gap between those two midnights is 25 hours.
   // GetPeriodSum() returns 6 rather than 7: the October 28 CEST bucket is at
   // October 27 22:00 UTC, one hour before the window start at October 27
-  // 23:00 UTC (CET midnight minus 6 days). With should_offset_dst=false the
-  // DST offset is not applied to the window boundary, so that bucket falls
-  // outside.
+  // 23:00 UTC (CET midnight minus 6 days). The DST offset is not applied to
+  // the window boundary, so that bucket falls outside.
   EXPECT_EQ(base::test::ParseJson(R"JSON([
       {  // November 3 00:00 CET (November 2 23:00 UTC)
         "day": 1825196400.0,
@@ -729,9 +729,9 @@ TEST_F(SerpMetricsTimePeriodStorageIssue54427Test,
   // Asia/Tokyo stays on UTC+9 all year, so every local day is exactly 24 hours.
   const test::SerpMetricsScopedTimezoneForTesting scoped_timezone("Asia/Tokyo");
   time_period_storage_ = std::make_unique<SerpMetricsTimePeriodStorage>(
-      &pref_service_, kPrefName, kPeriodDays,
-      /*should_use_utc=*/false,
-      /*should_offset_dst=*/false);
+      std::make_unique<SerpMetricsPrefTimePeriodStore>(&pref_service_,
+                                                       kPrefName),
+      kPeriodDays);
 
   base::Time january_1;
   ASSERT_TRUE(base::Time::FromUTCString("1 Jan 2027 00:00:00", &january_1));
@@ -796,9 +796,9 @@ TEST_F(SerpMetricsTimePeriodStorageIssue54427Test,
   const test::SerpMetricsScopedTimezoneForTesting scoped_auckland_timezone(
       "Pacific/Auckland");
   time_period_storage_ = std::make_unique<SerpMetricsTimePeriodStorage>(
-      &pref_service_, kPrefName, kPeriodDays,
-      /*should_use_utc=*/false,
-      /*should_offset_dst=*/false);
+      std::make_unique<SerpMetricsPrefTimePeriodStore>(&pref_service_,
+                                                       kPrefName),
+      kPeriodDays);
 
   // In Auckland. Bucket is October 10 00:00 NZDT (October 9 11:00 UTC).
   time_period_storage_->AddDelta(1);
@@ -812,7 +812,6 @@ TEST_F(SerpMetricsTimePeriodStorageIssue54427Test,
     time_period_storage_->AddDelta(1);
   }  // Returning to Auckland.
 
-  EXPECT_EQ(1U, time_period_storage_->GetHighestValueInPeriod());
   EXPECT_EQ(2U, time_period_storage_->GetPeriodSum());
 }
 
@@ -829,9 +828,9 @@ TEST_F(SerpMetricsTimePeriodStorageIssue54427Test,
   const test::SerpMetricsScopedTimezoneForTesting scoped_los_angeles_timezone(
       "America/Los_Angeles");
   time_period_storage_ = std::make_unique<SerpMetricsTimePeriodStorage>(
-      &pref_service_, kPrefName, kPeriodDays,
-      /*should_use_utc=*/false,
-      /*should_offset_dst=*/false);
+      std::make_unique<SerpMetricsPrefTimePeriodStore>(&pref_service_,
+                                                       kPrefName),
+      kPeriodDays);
 
   // In Los Angeles. Bucket is October 9 00:00 PDT (October 9 07:00 UTC).
   time_period_storage_->AddDelta(1);
@@ -845,7 +844,6 @@ TEST_F(SerpMetricsTimePeriodStorageIssue54427Test,
     time_period_storage_->AddDelta(1);
   }  // Returning to Los Angeles.
 
-  EXPECT_EQ(1U, time_period_storage_->GetHighestValueInPeriod());
   EXPECT_EQ(2U, time_period_storage_->GetPeriodSum());
 }
 

--- a/components/serp_metrics/time_period_storage/serp_metrics_time_period_storage_unittest.cc
+++ b/components/serp_metrics/time_period_storage/serp_metrics_time_period_storage_unittest.cc
@@ -10,8 +10,7 @@
 #include "base/check.h"
 #include "base/test/task_environment.h"
 #include "base/time/time.h"
-#include "brave/components/serp_metrics/time_period_storage/serp_metrics_scoped_timezone_for_testing.h"
-#include "build/buildflag.h"
+#include "brave/components/serp_metrics/time_period_storage/serp_metrics_pref_time_period_store.h"
 #include "components/prefs/pref_registry_simple.h"
 #include "components/prefs/testing_pref_service.h"
 #include "testing/gtest/include/gtest/gtest.h"
@@ -23,13 +22,7 @@ constexpr char kDictPrefName[] = "brave.weekly_dict_test";
 constexpr char kDictKey1[] = "key1";
 constexpr char kDictKey2[] = "key2";
 
-struct SerpMetricsTimePeriodStorageTestParam {
-  bool should_use_utc;
-  bool should_offset_dst;
-};
-
-class SerpMetricsTimePeriodStorageTest
-    : public ::testing::TestWithParam<SerpMetricsTimePeriodStorageTestParam> {
+class SerpMetricsTimePeriodStorageTest : public ::testing::Test {
  public:
   SerpMetricsTimePeriodStorageTest() {
     pref_service_.registry()->RegisterListPref(kListPrefName);
@@ -46,17 +39,12 @@ class SerpMetricsTimePeriodStorageTest
   void InitStorage(size_t days, const char* dict_key = nullptr) {
     const char* pref_name = dict_key ? kDictPrefName : kListPrefName;
     state_ = std::make_unique<SerpMetricsTimePeriodStorage>(
-        &pref_service_, pref_name, dict_key, days, should_use_utc(),
-        should_offset_dst());
+        std::make_unique<SerpMetricsPrefTimePeriodStore>(&pref_service_,
+                                                         pref_name, dict_key),
+        days);
   }
 
-  static bool should_use_utc() { return GetParam().should_use_utc; }
-
-  static bool should_offset_dst() { return GetParam().should_offset_dst; }
-
-  static base::Time Midnight(base::Time time) {
-    return should_use_utc() ? time.UTCMidnight() : time.LocalMidnight();
-  }
+  static base::Time Midnight(base::Time time) { return time.LocalMidnight(); }
 
  protected:
   base::test::TaskEnvironment task_environment_{
@@ -65,12 +53,12 @@ class SerpMetricsTimePeriodStorageTest
   std::unique_ptr<SerpMetricsTimePeriodStorage> state_;
 };
 
-TEST_P(SerpMetricsTimePeriodStorageTest, StartsZero) {
+TEST_F(SerpMetricsTimePeriodStorageTest, StartsZero) {
   InitStorage(7);
   EXPECT_EQ(state_->GetPeriodSum(), 0ULL);
 }
 
-TEST_P(SerpMetricsTimePeriodStorageTest, AddsSavings) {
+TEST_F(SerpMetricsTimePeriodStorageTest, AddsSavings) {
   InitStorage(7);
   uint64_t saving = 10000;
   state_->AddDelta(saving);
@@ -82,34 +70,7 @@ TEST_P(SerpMetricsTimePeriodStorageTest, AddsSavings) {
   EXPECT_EQ(state_->GetPeriodSum(), saving * 3);
 }
 
-TEST_P(SerpMetricsTimePeriodStorageTest, SubDelta) {
-  InitStorage(7);
-  state_->AddDelta(5000);
-  task_environment_.AdvanceClock(base::Days(1));
-  state_->AddDelta(3000);
-  task_environment_.AdvanceClock(base::Days(1));
-  state_->AddDelta(1000);
-  task_environment_.AdvanceClock(base::Days(1));
-
-  state_->SubDelta(500);
-  EXPECT_EQ(state_->GetPeriodSum(), 8500U);
-  state_->SubDelta(4000);
-  EXPECT_EQ(state_->GetPeriodSum(), 4500U);
-
-  task_environment_.AdvanceClock(base::Days(4));
-  // First day value should expire
-  EXPECT_EQ(state_->GetPeriodSum(), 0U);
-
-  // If subtracting by an amount greater than the current sum,
-  // the sum should not become negative or underflow.
-  state_->AddDelta(3000);
-  state_->SubDelta(5000);
-  EXPECT_EQ(state_->GetPeriodSum(), 0U);
-  state_->SubDelta(100000);
-  EXPECT_EQ(state_->GetPeriodSum(), 0U);
-}
-
-TEST_P(SerpMetricsTimePeriodStorageTest, GetSumInCustomPeriod) {
+TEST_F(SerpMetricsTimePeriodStorageTest, GetSumInCustomPeriod) {
   base::TimeDelta start_time_delta = base::Days(9) + base::Hours(1);
   base::TimeDelta end_time_delta = base::Days(4) - base::Hours(1);
   uint64_t saving = 10000;
@@ -153,7 +114,7 @@ TEST_P(SerpMetricsTimePeriodStorageTest, GetSumInCustomPeriod) {
             0U);
 }
 
-TEST_P(SerpMetricsTimePeriodStorageTest, ForgetsOldSavingsWeekly) {
+TEST_F(SerpMetricsTimePeriodStorageTest, ForgetsOldSavingsWeekly) {
   InitStorage(7);
   uint64_t saving = 10000;
   state_->AddDelta(saving);
@@ -168,7 +129,7 @@ TEST_P(SerpMetricsTimePeriodStorageTest, ForgetsOldSavingsWeekly) {
   EXPECT_EQ(state_->GetPeriodSum(), saving * 2);
 }
 
-TEST_P(SerpMetricsTimePeriodStorageTest, ForgetsOldSavingsMonthly) {
+TEST_F(SerpMetricsTimePeriodStorageTest, ForgetsOldSavingsMonthly) {
   InitStorage(30);
   uint64_t saving = 10000;
   state_->AddDelta(saving);
@@ -183,7 +144,7 @@ TEST_P(SerpMetricsTimePeriodStorageTest, ForgetsOldSavingsMonthly) {
   EXPECT_EQ(state_->GetPeriodSum(), saving * 2);
 }
 
-TEST_P(SerpMetricsTimePeriodStorageTest, RetrievesDailySavings) {
+TEST_F(SerpMetricsTimePeriodStorageTest, RetrievesDailySavings) {
   InitStorage(7);
   uint64_t saving = 10000;
   for (int day = 0; day <= 7; day++) {
@@ -193,7 +154,7 @@ TEST_P(SerpMetricsTimePeriodStorageTest, RetrievesDailySavings) {
   EXPECT_EQ(state_->GetPeriodSum(), 7 * saving);
 }
 
-TEST_P(SerpMetricsTimePeriodStorageTest, HandlesSkippedDay) {
+TEST_F(SerpMetricsTimePeriodStorageTest, HandlesSkippedDay) {
   InitStorage(7);
   uint64_t saving = 10000;
   for (int day = 0; day < 7; day++) {
@@ -206,7 +167,7 @@ TEST_P(SerpMetricsTimePeriodStorageTest, HandlesSkippedDay) {
   EXPECT_EQ(state_->GetPeriodSum(), 6 * saving);
 }
 
-TEST_P(SerpMetricsTimePeriodStorageTest, IntermittentUsageWeekly) {
+TEST_F(SerpMetricsTimePeriodStorageTest, IntermittentUsageWeekly) {
   InitStorage(7);
   uint64_t saving = 10000;
   for (int day = 0; day < 10; day++) {
@@ -216,7 +177,7 @@ TEST_P(SerpMetricsTimePeriodStorageTest, IntermittentUsageWeekly) {
   EXPECT_EQ(state_->GetPeriodSum(), 4 * saving);
 }
 
-TEST_P(SerpMetricsTimePeriodStorageTest, IntermittentUsageMonthly) {
+TEST_F(SerpMetricsTimePeriodStorageTest, IntermittentUsageMonthly) {
   InitStorage(30);
   uint64_t saving = 10000;
   for (int day = 0; day < 40; day++) {
@@ -226,7 +187,7 @@ TEST_P(SerpMetricsTimePeriodStorageTest, IntermittentUsageMonthly) {
   EXPECT_EQ(state_->GetPeriodSum(), 3 * saving);
 }
 
-TEST_P(SerpMetricsTimePeriodStorageTest, InfrequentUsageWeekly) {
+TEST_F(SerpMetricsTimePeriodStorageTest, InfrequentUsageWeekly) {
   InitStorage(7);
   uint64_t saving = 10000;
   state_->AddDelta(saving);
@@ -235,7 +196,7 @@ TEST_P(SerpMetricsTimePeriodStorageTest, InfrequentUsageWeekly) {
   EXPECT_EQ(state_->GetPeriodSum(), 2 * saving);
 }
 
-TEST_P(SerpMetricsTimePeriodStorageTest, InfrequentUsageMonthly) {
+TEST_F(SerpMetricsTimePeriodStorageTest, InfrequentUsageMonthly) {
   InitStorage(30);
   uint64_t saving = 10000;
   state_->AddDelta(saving);
@@ -244,79 +205,7 @@ TEST_P(SerpMetricsTimePeriodStorageTest, InfrequentUsageMonthly) {
   EXPECT_EQ(state_->GetPeriodSum(), 2 * saving);
 }
 
-TEST_P(SerpMetricsTimePeriodStorageTest, GetHighestValueInPeriod) {
-  InitStorage(7);
-  uint64_t lowest_value = 20;
-  uint64_t low_value = 50;
-  uint64_t high_value = 75;
-  state_->AddDelta(low_value);
-  task_environment_.AdvanceClock(base::Days(1));
-  state_->AddDelta(high_value);
-  task_environment_.AdvanceClock(base::Days(1));
-  state_->AddDelta(lowest_value);
-  EXPECT_EQ(state_->GetHighestValueInPeriod(), high_value);
-  task_environment_.AdvanceClock(base::Days(1));
-  EXPECT_EQ(state_->GetHighestValueInPeriod(), high_value);
-}
-
-TEST_P(SerpMetricsTimePeriodStorageTest, RecordsHigherValueForToday) {
-  InitStorage(30);
-  uint64_t low_value = 50;
-  uint64_t high_value = 75;
-  state_->ReplaceTodaysValueIfGreater(low_value);
-  EXPECT_EQ(state_->GetHighestValueInPeriod(), low_value);
-  // Replace with higher value
-  state_->ReplaceTodaysValueIfGreater(high_value);
-  EXPECT_EQ(state_->GetHighestValueInPeriod(), high_value);
-  // Sanity check value was replaced and not added.
-  EXPECT_EQ(state_->GetPeriodSum(), high_value);
-  // Should not replace with lower value
-  state_->ReplaceTodaysValueIfGreater(low_value);
-  EXPECT_EQ(state_->GetHighestValueInPeriod(), high_value);
-}
-
-TEST_P(SerpMetricsTimePeriodStorageTest,
-       GetsHighestValueInWeekFromReplacement) {
-  InitStorage(30);
-  // Add a low value a couple days after a high value,
-  // should return highest day value.
-  uint64_t low_value = 50;
-  uint64_t high_value = 75;
-  state_->ReplaceTodaysValueIfGreater(high_value);
-  task_environment_.AdvanceClock(base::Days(2));
-  state_->ReplaceTodaysValueIfGreater(low_value);
-  EXPECT_EQ(state_->GetHighestValueInPeriod(), high_value);
-  // Sanity check disparate days were not replaced
-  EXPECT_EQ(state_->GetPeriodSum(), high_value + low_value);
-}
-
-TEST_P(SerpMetricsTimePeriodStorageTest, ReplaceIfGreaterForDate) {
-  InitStorage(30);
-
-  state_->AddDelta(4);
-  task_environment_.AdvanceClock(base::Days(1));
-  state_->AddDelta(2);
-  task_environment_.AdvanceClock(base::Days(1));
-  state_->AddDelta(1);
-  task_environment_.AdvanceClock(base::Days(1));
-
-  // should replace
-  state_->ReplaceIfGreaterForDate(base::Time::Now() - base::Days(2), 3);
-  // should not replace
-  state_->ReplaceIfGreaterForDate(base::Time::Now() - base::Days(3), 3);
-
-  EXPECT_EQ(state_->GetPeriodSum(), 8U);
-
-  // should insert new daily value
-  state_->ReplaceIfGreaterForDate(base::Time::Now() - base::Days(4), 3);
-  EXPECT_EQ(state_->GetPeriodSum(), 11U);
-
-  // should store, but should not be in sum because it's too old
-  state_->ReplaceIfGreaterForDate(base::Time::Now() - base::Days(31), 10);
-  EXPECT_EQ(state_->GetPeriodSum(), 11U);
-}
-
-TEST_P(SerpMetricsTimePeriodStorageTest, SegregatedListsInDictionary) {
+TEST_F(SerpMetricsTimePeriodStorageTest, SegregatedListsInDictionary) {
   InitStorage(7, kDictKey1);
   state_->AddDelta(55);
 
@@ -330,73 +219,16 @@ TEST_P(SerpMetricsTimePeriodStorageTest, SegregatedListsInDictionary) {
   EXPECT_EQ(state_->GetPeriodSum(), 33U);
 }
 
-// The DST offset expands the query range by 1 hour, allowing values stored at
-// midnight to be counted when querying up to 1 hour after midnight.
-TEST_P(SerpMetricsTimePeriodStorageTest, DstOffsetExpandsQueryRange) {
+TEST_F(SerpMetricsTimePeriodStorageTest,
+       ValueStoredAtMidnightIsExcludedWhenRangeStartsAfterMidnight) {
   InitStorage(7);
   const uint64_t saving = 10000;
   state_->AddDelta(saving);
 
-  const bool dst_offset_active = !should_use_utc() && should_offset_dst();
-  const uint64_t expected_saving = dst_offset_active ? saving : 0U;
-
   const base::Time midnight = Midnight(base::Time::Now());
   EXPECT_EQ(state_->GetPeriodSumInTimeRange(midnight + base::Minutes(30),
                                             midnight + base::Days(1)),
-            expected_saving);
+            0U);
 }
-
-// The test is disabled on Windows because `SerpMetricsScopedTimezoneForTesting`
-// relies on `ScopedLibcTimezoneOverride`, which is a no-op for IANA timezone
-// identifiers on Windows, causing spurious failures.
-#if !BUILDFLAG(IS_WIN)
-TEST_P(SerpMetricsTimePeriodStorageTest,
-       GetHighestValueInPeriodExcludesDataOutsideWindowAfterDSTTransition) {
-  // America/New_York DST starts in 2050 on March 13 (the second Sunday of
-  // March). Clocks advance at 02:00 EST (07:00 UTC) to 03:00 EDT. These
-  // dates are safely after the fixture's mock-time start of 2050-01-04.
-  const test::SerpMetricsScopedTimezoneForTesting scoped_timezone(
-      "America/New_York");
-  const uint64_t low_value = 50;
-  const uint64_t high_value = 75;
-
-  InitStorage(7);
-
-  base::Time time;
-  ASSERT_TRUE(base::Time::FromString("March 13 2050 01:30:00", &time));
-  task_environment_.AdvanceClock(time - base::Time::Now());
-  state_->AddDelta(high_value);
-
-  ASSERT_TRUE(base::Time::FromString("March 19 2050 02:30:00", &time));
-  task_environment_.AdvanceClock(time - base::Time::Now());
-  state_->AddDelta(low_value);
-  // Advance two days so the high-value entry falls outside the seven-day
-  // window. Two days are needed because the DST transition shifts the local
-  // midnight by one hour — one day is not enough to clear the boundary in
-  // local-time mode.
-  task_environment_.AdvanceClock(base::Days(2));
-
-  EXPECT_EQ(state_->GetHighestValueInPeriod(), low_value);
-}
-#endif  // !BUILDFLAG(IS_WIN)
-
-INSTANTIATE_TEST_SUITE_P(
-    ,
-    SerpMetricsTimePeriodStorageTest,
-    ::testing::Values(
-        SerpMetricsTimePeriodStorageTestParam{/*should_use_utc=*/true,
-                                              /*should_offset_dst=*/true},
-        SerpMetricsTimePeriodStorageTestParam{/*should_use_utc=*/true,
-                                              /*should_offset_dst=*/false},
-        SerpMetricsTimePeriodStorageTestParam{/*should_use_utc=*/false,
-                                              /*should_offset_dst=*/true},
-        SerpMetricsTimePeriodStorageTestParam{/*should_use_utc=*/false,
-                                              /*should_offset_dst=*/false}),
-    [](const ::testing::TestParamInfo<SerpMetricsTimePeriodStorageTestParam>&
-           info) {
-      return std::string(info.param.should_use_utc ? "UTC" : "LocalTime") +
-             (info.param.should_offset_dst ? "WithOffsetDST"
-                                           : "WithoutOffsetDST");
-    });
 
 }  // namespace serp_metrics


### PR DESCRIPTION
The deprecated PrefService-based constructors and five methods with no production callsites were carried over from TimePeriodStorage. The UTC and DST-offset modes were always disabled in every caller, and the internal clock was always the system clock, leaving them dead code. All are removed; tests are migrated to the store-based constructor and a plain fixture.

This is a pre-requisite for https://github.com/brave/brave-browser/issues/54758.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
