### PR TITLE
Add best practice: raw_ref<T> vs raw_ptr<T> for non-owning fields (CSM-036)

### DIFF
--- a/docs/best-practices/coding-standards-apis.md
+++ b/docs/best-practices/coding-standards-apis.md
@@ -529,25 +529,6 @@ Topic& operator=(Topic&&) noexcept = default;
 
 ---
 
-<a id="CSA-030"></a>
-
-## ✅ Use References for Non-Nullable Parameters; `raw_ref` for Stored References
-
-**When a function parameter cannot be null, use a reference (`T&`) instead of a pointer (`T*`).** For stored member references that cannot be null, use `raw_ref<T>`.
-
-```cpp
-// ❌ WRONG - pointer suggests nullability
-NetworkClient(PrefService* pref_service);
-
-// ✅ CORRECT - reference communicates non-null requirement
-NetworkClient(PrefService& pref_service);
-
-// For stored references:
-raw_ref<PrefService> pref_service_;  // not raw_ptr
-```
-
----
-
 <a id="CSA-031"></a>
 
 ## ❌ Avoid `std::optional<T>&` References

--- a/docs/best-practices/coding-standards-memory.md
+++ b/docs/best-practices/coding-standards-memory.md
@@ -606,3 +606,51 @@ When `thread_local` is truly needed, Chromium requires:
 - Cannot be constructed in OOM handlers (POSIX construction may allocate)
 
 If these requirements cannot be met, use `base::ThreadLocalOwnedPointer` instead. See [Chromium C++ style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md).
+
+---
+
+<a id="CSM-036"></a>
+
+## ✅ Use `raw_ref<T>` for Fields That Must Never Be Null; `raw_ptr<T>` Otherwise
+
+**`raw_ptr<T>` is the default for non-owning fields. Choose `raw_ref<T>` when the field must never be null — it communicates that the referenced object is expected to outlive the holder, and the holder cannot function without it. Both types enforce that the pointee remains alive for as long as the field holds a reference to it: they detect use-after-free rather than silently operating on freed memory, and in doing so document the lifetime contract — whenever a field of either type holds a value, the expectation is that the memory it points to is alive.**
+
+```cpp
+// raw_ptr<T> - default for non-owning fields (can be null or reassigned)
+class TabFeatures {
+  raw_ptr<content::WebContents> web_contents_;
+};
+
+// raw_ref<T> - for a mandatory dependency that must outlive the holder
+// Constructor takes a reference when the caller already holds one
+class BraveBrowserDelegate {
+ public:
+  explicit BraveBrowserDelegate(BrowserWindowInterface& window)
+      : window_(window) {}
+
+ private:
+  raw_ref<BrowserWindowInterface> window_;
+};
+
+// CHECK_DEREF - when a pointer-returning function result must be stored in a raw_ref
+class MyService {
+ public:
+  explicit MyService(Profile& profile)
+      : prefs_(CHECK_DEREF(profile.GetPrefs())) {}
+
+ private:
+  raw_ref<PrefService> prefs_;
+};
+```
+
+**Use `CHECK_DEREF` when a pointer-returning function result must be stored in a `raw_ref<T>` field.** It asserts non-null and converts to a reference, which is safer than `*ptr` (undefined behavior on null).
+
+**`RAW_PTR_EXCLUSION` (per-field) is acceptable only for:**
+- Pointers to unprotected memory where BackupRefPtr provides no benefit: literals, stack allocations, `mmap`'d or shared memory, V8/Oilpan/Java heaps, TLS
+- Fields that won't compile with `raw_ptr<T>`: pointer fields in unions (prefer `std::variant`), pointer fields in classes/structs used as `global`, `static`, or `thread_local` variables
+- (Very rare) cases with a measured, documented performance regression
+- (Very rare) cases where `raw_ptr<T>` causes runtime errors — add a comment and consult `base/memory/raw_ptr.md`
+
+Types not flagged by the Clang plugin — raw `T*` is fine, no annotation required: function pointers, ObjC pointers, `const char*`/`const wchar_t*` pointing to string literals (if they may point to heap-allocated objects, use `raw_ptr<const char>` for UaF safety).
+
+Blink renderer code using Oilpan, and any other code whose objects are allocated outside PartitionAlloc (V8 heap, Java heap, etc.), cannot use `raw_ptr<T>` or `raw_ref<T>`.


### PR DESCRIPTION
## Summary
- Adds **CSM-036** to `docs/best-practices/coding-standards-memory.md`
- Provides decision guidance on when to use `raw_ptr<T>` (default for non-owning fields) vs `raw_ref<T>` (mandatory non-null dependencies)
- Documents the `CHECK_DEREF` pattern for initializing `raw_ref<T>` from pointer-returning functions
- Covers acceptable uses of `RAW_PTR_EXCLUSION` and types exempt from the Clang plugin
- Notes that Oilpan/non-PartitionAlloc code cannot use these types