### PR TITLE
Add enable_playlist buildflag gated on is_brave_origin_branded

### DIFF
--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -27,7 +27,7 @@
 #include "brave/components/debounce/core/common/features.h"
 #include "brave/components/email_aliases/buildflags/buildflags.h"
 #include "brave/components/google_sign_in_permission/features.h"
-#include "brave/components/playlist/core/common/features.h"
+#include "brave/components/playlist/core/common/buildflags/buildflags.h"
 #include "brave/components/psst/buildflags/buildflags.h"
 #include "brave/components/request_otr/common/buildflags/buildflags.h"
 #include "brave/components/skus/common/features.h"
@@ -60,6 +60,10 @@
 
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
 #include "brave/components/brave_vpn/common/features.h"
+#endif
+
+#if BUILDFLAG(ENABLE_PLAYLIST)
+#include "brave/components/playlist/core/common/features.h"
 #endif
 
 #if BUILDFLAG(ENABLE_SPEEDREADER)
@@ -257,6 +261,7 @@ const char* const kBraveSyncImplLink[1] = {"https://github.com/brave/go-sync"};
 #define BRAVE_NEWS_FEATURE_ENTRIES
 #endif  // BUILDFLAG(ENABLE_BRAVE_NEWS)
 
+#if BUILDFLAG(ENABLE_PLAYLIST)
 #define PLAYLIST_FEATURE_ENTRIES                                   \
   EXPAND_FEATURE_ENTRIES(                                          \
       {                                                            \
@@ -273,6 +278,9 @@ const char* const kBraveSyncImplLink[1] = {"https://github.com/brave/go-sync"};
           kOsMac | kOsWin | kOsLinux | kOsAndroid,                 \
           FEATURE_VALUE_TYPE(playlist::features::kPlaylistFakeUA), \
       })
+#else
+#define PLAYLIST_FEATURE_ENTRIES
+#endif  // BUILDFLAG(ENABLE_PLAYLIST)
 
 #define PSST_FEATURE_ENTRIES                                           \
   IF_BUILDFLAG(ENABLE_PSST,                                            \

--- a/browser/brave_content_browser_client.cc
+++ b/browser/brave_content_browser_client.cc
@@ -87,11 +87,7 @@
 #include "brave/components/local_ai/core/local_ai.mojom.h"
 #include "brave/components/ntp_background_images/browser/mojom/ntp_background_images.mojom.h"
 #include "brave/components/password_strength_meter/password_strength_meter.mojom.h"
-#include "brave/components/playlist/content/browser/playlist_background_web_contents_helper.h"
-#include "brave/components/playlist/content/browser/playlist_media_handler.h"
 #include "brave/components/playlist/core/common/buildflags/buildflags.h"
-#include "brave/components/playlist/core/common/features.h"
-#include "brave/components/playlist/core/common/mojom/playlist.mojom.h"
 #include "brave/components/request_otr/common/buildflags/buildflags.h"
 #include "brave/components/skus/common/features.h"
 #include "brave/components/skus/common/skus_internals.mojom.h"
@@ -311,6 +307,13 @@ using extensions::ChromeContentBrowserClientExtensionsPart;
 #include "brave/components/brave_shields/core/common/brave_shields_panel.mojom.h"
 #include "components/omnibox/browser/searchbox.mojom.h"
 #endif  // !BUILDFLAG(IS_ANDROID)
+
+#if BUILDFLAG(ENABLE_PLAYLIST)
+#include "brave/components/playlist/content/browser/playlist_background_web_contents_helper.h"
+#include "brave/components/playlist/content/browser/playlist_media_handler.h"
+#include "brave/components/playlist/core/common/features.h"
+#include "brave/components/playlist/core/common/mojom/playlist.mojom.h"
+#endif  // BUILDFLAG(ENABLE_PLAYLIST)
 
 #if BUILDFLAG(ENABLE_PLAYLIST_WEBUI)
 #include "brave/browser/ui/webui/playlist_ui.h"
@@ -606,10 +609,12 @@ void BraveContentBrowserClient::
           &render_frame_host));
 #endif
 
+#if BUILDFLAG(ENABLE_PLAYLIST)
   associated_registry.AddInterface<playlist::mojom::PlaylistMediaResponder>(
       base::BindRepeating(
           &playlist::PlaylistMediaHandler::BindMediaResponderReceiver,
           &render_frame_host));
+#endif  // BUILDFLAG(ENABLE_PLAYLIST)
 
   associated_registry.AddInterface<
       cosmetic_filters::mojom::CosmeticFiltersHandler>(base::BindRepeating(
@@ -1504,10 +1509,12 @@ void BraveContentBrowserClient::OverrideWebPreferences(
   PreventDarkModeFingerprinting(web_contents, main_frame_site, web_prefs);
   UpdateGlobalPrivacyControlWebPreference(web_contents, web_prefs);
 
+#if BUILDFLAG(ENABLE_PLAYLIST)
   if (playlist::PlaylistBackgroundWebContentsHelper::FromWebContents(
           web_contents)) {
     web_prefs->force_cosmetic_filtering = true;
   }
+#endif  // BUILDFLAG(ENABLE_PLAYLIST)
 }
 
 blink::UserAgentMetadata BraveContentBrowserClient::GetUserAgentMetadata() {

--- a/browser/brave_local_state_prefs.cc
+++ b/browser/brave_local_state_prefs.cc
@@ -13,7 +13,6 @@
 #include "brave/browser/metrics/metrics_reporting_util.h"
 #include "brave/browser/misc_metrics/process_misc_metrics.h"
 #include "brave/browser/misc_metrics/uptime_monitor_impl.h"
-#include "brave/browser/playlist/playlist_service_factory.h"
 #include "brave/browser/search_engines/search_engine_tracker.h"
 #include "brave/browser/updater/buildflags.h"
 #include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
@@ -37,6 +36,7 @@
 #include "brave/components/p3a/metric_log_store.h"
 #include "brave/components/p3a/p3a_service.h"
 #include "brave/components/p3a/rotation_scheduler.h"
+#include "brave/components/playlist/core/common/buildflags/buildflags.h"
 #include "brave/components/skus/browser/skus_utils.h"
 #include "brave/components/speedreader/common/buildflags/buildflags.h"
 #include "brave/components/tor/buildflags/buildflags.h"
@@ -47,6 +47,10 @@
 #include "components/prefs/pref_registry_simple.h"
 #include "components/webui/chrome_urls/pref_names.h"
 #include "third_party/widevine/cdm/buildflags.h"
+
+#if BUILDFLAG(ENABLE_PLAYLIST)
+#include "brave/browser/playlist/playlist_service_factory.h"
+#endif
 
 #if BUILDFLAG(ENABLE_AI_CHAT)
 #include "brave/components/ai_chat/core/browser/ai_chat_metrics.h"
@@ -245,7 +249,9 @@ void RegisterLocalStatePrefs(PrefRegistrySimple* registry) {
 #endif
   brave_search::BackupResultsMetrics::RegisterPrefs(registry);
 
+#if BUILDFLAG(ENABLE_PLAYLIST)
   playlist::PlaylistServiceFactory::RegisterLocalStatePrefs(registry);
+#endif
 #if BUILDFLAG(ENABLE_WEB_DISCOVERY_NATIVE)
   web_discovery::WebDiscoveryService::RegisterLocalStatePrefs(registry);
 #endif

--- a/browser/brave_shields/ad_block_service_browsertest.cc
+++ b/browser/brave_shields/ad_block_service_browsertest.cc
@@ -29,7 +29,6 @@
 #include "brave/app/brave_command_ids.h"
 #include "brave/browser/brave_browser_process.h"
 #include "brave/browser/net/brave_ad_block_tp_network_delegate_helper.h"
-#include "brave/browser/playlist/playlist_service_factory.h"
 #include "brave/components/brave_shields/content/browser/ad_block_custom_filters_provider.h"
 #include "brave/components/brave_shields/content/browser/ad_block_engine.h"
 #include "brave/components/brave_shields/content/browser/ad_block_engine_wrapper.h"
@@ -48,9 +47,7 @@
 #include "brave/components/constants/brave_paths.h"
 #include "brave/components/constants/pref_names.h"
 #include "brave/components/de_amp/common/pref_names.h"
-#include "brave/components/playlist/content/browser/playlist_background_web_contentses.h"
-#include "brave/components/playlist/content/browser/playlist_service.h"
-#include "brave/components/playlist/core/common/features.h"
+#include "brave/components/playlist/core/common/buildflags/buildflags.h"
 #include "brave/components/speedreader/common/buildflags/buildflags.h"
 #include "build/build_config.h"
 #include "chrome/browser/browser_process.h"
@@ -81,6 +78,13 @@
 #include "brave/components/speedreader/speedreader_service.h"  // nogncheck
 #include "third_party/blink/public/common/web_preferences/web_preferences.h"
 #endif
+
+#if BUILDFLAG(ENABLE_PLAYLIST)
+#include "brave/browser/playlist/playlist_service_factory.h"
+#include "brave/components/playlist/content/browser/playlist_background_web_contentses.h"
+#include "brave/components/playlist/content/browser/playlist_service.h"
+#include "brave/components/playlist/core/common/features.h"
+#endif  // BUILDFLAG(ENABLE_PLAYLIST)
 
 constexpr char kAdBlockTestPage[] = "/blocking.html";
 
@@ -2044,6 +2048,7 @@ IN_PROC_BROWSER_TEST_F(ProceduralFilteringFlagDisabledTest,
   }
 }
 
+#if BUILDFLAG(ENABLE_PLAYLIST)
 class CosmeticFilteringPlaylistFlagEnabledTest : public AdBlockServiceTest {
  public:
   CosmeticFilteringPlaylistFlagEnabledTest() {
@@ -2078,6 +2083,7 @@ IN_PROC_BROWSER_TEST_F(CosmeticFilteringPlaylistFlagEnabledTest,
   EXPECT_EQ(false, EvalJs(web_contents,
                           "checkSelector('#ad-banner', 'display', 'block')"));
 }
+#endif  // BUILDFLAG(ENABLE_PLAYLIST)
 
 // Ensure no cosmetic filtering occurs when the shields setting is disabled
 IN_PROC_BROWSER_TEST_F(AdBlockServiceTest, CosmeticFilteringDisabled) {

--- a/browser/brave_tab_helpers.cc
+++ b/browser/brave_tab_helpers.cc
@@ -17,7 +17,6 @@
 #include "brave/browser/ephemeral_storage/ephemeral_storage_tab_helper.h"
 #include "brave/browser/misc_metrics/page_metrics_tab_helper.h"
 #include "brave/browser/misc_metrics/process_misc_metrics.h"
-#include "brave/browser/playlist/playlist_service_factory.h"
 #include "brave/browser/serp_metrics/serp_metrics_tab_helper.h"
 #include "brave/browser/ui/brave_ui_features.h"
 #include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
@@ -27,8 +26,7 @@
 #include "brave/components/brave_rewards/core/buildflags/buildflags.h"
 #include "brave/components/brave_wallet/common/buildflags/buildflags.h"
 #include "brave/components/brave_wayback_machine/buildflags/buildflags.h"
-#include "brave/components/playlist/content/browser/playlist_tab_helper.h"
-#include "brave/components/playlist/core/common/features.h"
+#include "brave/components/playlist/core/common/buildflags/buildflags.h"
 #include "brave/components/request_otr/common/buildflags/buildflags.h"
 #include "brave/components/serp_metrics/serp_metrics_feature.h"
 #include "brave/components/speedreader/common/buildflags/buildflags.h"
@@ -60,6 +58,12 @@
 
 #if BUILDFLAG(ENABLE_BRAVE_REWARDS)
 #include "brave/browser/brave_rewards/rewards_tab_helper.h"
+#endif
+
+#if BUILDFLAG(ENABLE_PLAYLIST)
+#include "brave/browser/playlist/playlist_service_factory.h"
+#include "brave/components/playlist/content/browser/playlist_tab_helper.h"
+#include "brave/components/playlist/core/common/features.h"
 #endif
 
 #if BUILDFLAG(IS_ANDROID)
@@ -246,6 +250,7 @@ void AttachTabHelpers(content::WebContents* web_contents) {
   }
 #endif
 
+#if BUILDFLAG(ENABLE_PLAYLIST)
   if (base::FeatureList::IsEnabled(playlist::features::kPlaylist)) {
     if (auto* playlist_service =
             playlist::PlaylistServiceFactory::GetForBrowserContext(
@@ -254,6 +259,7 @@ void AttachTabHelpers(content::WebContents* web_contents) {
                                                         playlist_service);
     }
   }
+#endif  // BUILDFLAG(ENABLE_PLAYLIST)
 }
 
 void AttachPrivacySensitiveTabHelpers(content::WebContents* web_contents) {

--- a/browser/browser_context_keyed_service_factories.cc
+++ b/browser/browser_context_keyed_service_factories.cc
@@ -18,7 +18,6 @@
 #include "brave/browser/misc_metrics/profile_misc_metrics_service_factory.h"
 #include "brave/browser/ntp_background/view_counter_service_factory.h"
 #include "brave/browser/permissions/permission_lifetime_manager_factory.h"
-#include "brave/browser/playlist/playlist_service_factory.h"
 #include "brave/browser/profiles/brave_renderer_updater_factory.h"
 #include "brave/browser/search_engines/search_engine_provider_service_factory.h"
 #include "brave/browser/search_engines/search_engine_tracker.h"
@@ -38,7 +37,7 @@
 #include "brave/components/commander/common/buildflags/buildflags.h"
 #include "brave/components/containers/buildflags/buildflags.h"
 #include "brave/components/email_aliases/buildflags/buildflags.h"
-#include "brave/components/playlist/core/common/features.h"
+#include "brave/components/playlist/core/common/buildflags/buildflags.h"
 #include "brave/components/psst/buildflags/buildflags.h"
 #include "brave/components/request_otr/common/buildflags/buildflags.h"
 #include "brave/components/speedreader/common/buildflags/buildflags.h"
@@ -127,6 +126,11 @@
 #include "brave/components/email_aliases/features.h"
 #endif
 
+#if BUILDFLAG(ENABLE_PLAYLIST)
+#include "brave/browser/playlist/playlist_service_factory.h"
+#include "brave/components/playlist/core/common/features.h"
+#endif
+
 namespace brave {
 
 void EnsureBrowserContextKeyedServiceFactoriesBuilt() {
@@ -190,9 +194,11 @@ void EnsureBrowserContextKeyedServiceFactoriesBuilt() {
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
   brave_vpn::BraveVpnServiceFactory::GetInstance();
 #endif
+#if BUILDFLAG(ENABLE_PLAYLIST)
   if (base::FeatureList::IsEnabled(playlist::features::kPlaylist)) {
     playlist::PlaylistServiceFactory::GetInstance();
   }
+#endif
 #if BUILDFLAG(ENABLE_REQUEST_OTR)
   request_otr::RequestOTRServiceFactory::GetInstance();
 #endif

--- a/browser/extensions/BUILD.gn
+++ b/browser/extensions/BUILD.gn
@@ -10,6 +10,7 @@ import("//brave/components/brave_talk/buildflags/buildflags.gni")
 import("//brave/components/brave_vpn/common/buildflags/buildflags.gni")
 import("//brave/components/brave_wallet/common/buildflags/buildflags.gni")
 import("//brave/components/brave_wayback_machine/buildflags/buildflags.gni")
+import("//brave/components/playlist/core/common/buildflags/buildflags.gni")
 import("//brave/components/speedreader/common/buildflags/buildflags.gni")
 import("//brave/components/tor/buildflags/buildflags.gni")
 import("//brave/components/web_discovery/buildflags/buildflags.gni")
@@ -113,7 +114,6 @@ source_set("extensions") {
     "//brave/components/de_amp/common",
     "//brave/components/debounce/core/common",
     "//brave/components/ntp_background_images/common",
-    "//brave/components/playlist/core/common",
     "//brave/components/request_otr/common",
     "//brave/components/sidebar/browser",
     "//brave/components/speedreader/common/buildflags",
@@ -205,6 +205,10 @@ source_set("extensions") {
       "api/brave_talk_api.h",
     ]
     deps += [ "//brave/components/brave_talk" ]
+  }
+
+  if (enable_playlist) {
+    deps += [ "//brave/components/playlist/core/common" ]
   }
 
   allow_circular_includes_from = [ ":brave_prefs_util_impl" ]

--- a/browser/extensions/api/settings_private/brave_prefs_util.cc
+++ b/browser/extensions/api/settings_private/brave_prefs_util.cc
@@ -21,7 +21,7 @@
 #include "brave/components/decentralized_dns/core/pref_names.h"
 #include "brave/components/ntp_background_images/common/pref_names.h"
 #include "brave/components/omnibox/browser/brave_omnibox_prefs.h"
-#include "brave/components/playlist/core/common/pref_names.h"
+#include "brave/components/playlist/core/common/buildflags/buildflags.h"
 #include "brave/components/request_otr/common/pref_names.h"
 #include "brave/components/speedreader/common/buildflags/buildflags.h"
 #include "brave/components/tor/buildflags/buildflags.h"
@@ -66,6 +66,10 @@
 
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
 #include "brave/components/brave_vpn/common/pref_names.h"
+#endif
+
+#if BUILDFLAG(ENABLE_PLAYLIST)
+#include "brave/components/playlist/core/common/pref_names.h"
 #endif
 
 #if BUILDFLAG(IS_WIN)
@@ -348,10 +352,12 @@ const PrefsUtil::TypedPrefMap& BravePrefsUtil::GetAllowlistedKeys() {
       settings_api::PrefType::kBoolean;
 #endif
 
+#if BUILDFLAG(ENABLE_PLAYLIST)
   (*s_brave_allowlist)[playlist::kPlaylistEnabledPref] =
       settings_api::PrefType::kBoolean;
   (*s_brave_allowlist)[playlist::kPlaylistCacheByDefault] =
       settings_api::PrefType::kBoolean;
+#endif  // BUILDFLAG(ENABLE_PLAYLIST)
 
 #if !BUILDFLAG(IS_ANDROID)
   (*s_brave_allowlist)[brave_tabs::kSharedPinnedTab] =

--- a/browser/playlist/test/BUILD.gn
+++ b/browser/playlist/test/BUILD.gn
@@ -6,6 +6,8 @@
 import("//brave/components/playlist/core/common/buildflags/buildflags.gni")
 import("//build/config/features.gni")
 
+assert(enable_playlist)
+
 source_set("browser_tests") {
   testonly = true
   defines = [ "HAS_OUT_OF_PROC_TEST_RUNNER" ]

--- a/browser/policy/BUILD.gn
+++ b/browser/policy/BUILD.gn
@@ -10,6 +10,7 @@ import("//brave/components/brave_vpn/common/buildflags/buildflags.gni")
 import("//brave/components/brave_wallet/common/buildflags/buildflags.gni")
 import("//brave/components/brave_wayback_machine/buildflags/buildflags.gni")
 import("//brave/components/ipfs/buildflags/buildflags.gni")
+import("//brave/components/playlist/core/common/buildflags/buildflags.gni")
 import("//brave/components/speedreader/common/buildflags/buildflags.gni")
 import("//brave/components/tor/buildflags/buildflags.gni")
 import("//build/config/features.gni")
@@ -34,7 +35,6 @@ source_set("brave_simple_policy_map") {
     "//brave/components/global_privacy_control",
     "//brave/components/ipfs/buildflags",
     "//brave/components/p3a",
-    "//brave/components/playlist/content/browser",
     "//brave/components/playlist/core/common/buildflags",
     "//brave/components/query_filter",
     "//brave/components/speedreader/common/buildflags",
@@ -77,5 +77,9 @@ source_set("brave_simple_policy_map") {
 
   if (enable_brave_talk) {
     deps += [ "//brave/components/brave_talk" ]
+  }
+
+  if (enable_playlist) {
+    deps += [ "//brave/components/playlist/content/browser" ]
   }
 }

--- a/browser/policy/brave_simple_policy_map.h
+++ b/browser/policy/brave_simple_policy_map.h
@@ -21,7 +21,7 @@
 #include "brave/components/global_privacy_control/pref_names.h"
 #include "brave/components/ipfs/buildflags/buildflags.h"
 #include "brave/components/p3a/pref_names.h"
-#include "brave/components/playlist/core/common/pref_names.h"
+#include "brave/components/playlist/core/common/buildflags/buildflags.h"
 #include "brave/components/query_filter/pref_names.h"
 #include "brave/components/speedreader/common/buildflags/buildflags.h"
 #include "brave/components/tor/buildflags/buildflags.h"
@@ -65,6 +65,10 @@
 #include "brave/components/brave_talk/pref_names.h"
 #endif
 
+#if BUILDFLAG(ENABLE_PLAYLIST)
+#include "brave/components/playlist/core/common/pref_names.h"
+#endif
+
 namespace policy {
 
 inline constexpr PolicyToPreferenceMapEntry kBraveSimplePolicyMap[] = {
@@ -96,8 +100,10 @@ inline constexpr PolicyToPreferenceMapEntry kBraveSimplePolicyMap[] = {
      base::Value::Type::BOOLEAN},
     {policy::key::kBraveStatsPingEnabled, kStatsReportingEnabled,
      base::Value::Type::BOOLEAN},
+#if BUILDFLAG(ENABLE_PLAYLIST)
     {policy::key::kBravePlaylistEnabled, playlist::kPlaylistEnabledPref,
      base::Value::Type::BOOLEAN},
+#endif
 #if BUILDFLAG(ENABLE_WEB_DISCOVERY)
     {policy::key::kBraveWebDiscoveryEnabled, kWebDiscoveryEnabled,
      base::Value::Type::BOOLEAN},

--- a/browser/profiles/brave_renderer_updater.cc
+++ b/browser/profiles/brave_renderer_updater.cc
@@ -14,8 +14,7 @@
 #include "brave/components/constants/pref_names.h"
 #include "brave/components/de_amp/browser/de_amp_util.h"
 #include "brave/components/de_amp/common/pref_names.h"
-#include "brave/components/playlist/core/common/features.h"
-#include "brave/components/playlist/core/common/pref_names.h"
+#include "brave/components/playlist/core/common/buildflags/buildflags.h"
 #include "chrome/browser/profiles/profile.h"
 #include "components/prefs/pref_service.h"
 #include "content/public/browser/render_process_host.h"
@@ -38,6 +37,11 @@
 
 #if BUILDFLAG(ENABLE_EXTENSIONS)
 #include "extensions/browser/extension_registry.h"
+#endif
+
+#if BUILDFLAG(ENABLE_PLAYLIST)
+#include "brave/components/playlist/core/common/features.h"
+#include "brave/components/playlist/core/common/pref_names.h"
 #endif
 
 BraveRendererUpdater::BraveRendererUpdater(
@@ -117,10 +121,12 @@ BraveRendererUpdater::BraveRendererUpdater(
   }
 #endif
 
+#if BUILDFLAG(ENABLE_PLAYLIST)
   pref_change_registrar_.Add(
       playlist::kPlaylistEnabledPref,
       base::BindRepeating(&BraveRendererUpdater::UpdateAllRenderers,
                           base::Unretained(this)));
+#endif  // BUILDFLAG(ENABLE_PLAYLIST)
 }
 
 BraveRendererUpdater::~BraveRendererUpdater() = default;
@@ -274,9 +280,13 @@ void BraveRendererUpdater::UpdateRenderer(
   }
 #endif
 
+#if BUILDFLAG(ENABLE_PLAYLIST)
   const bool playlist_enabled =
       base::FeatureList::IsEnabled(playlist::features::kPlaylist) &&
       pref_service->GetBoolean(playlist::kPlaylistEnabledPref);
+#else
+  const bool playlist_enabled = false;
+#endif  // BUILDFLAG(ENABLE_PLAYLIST)
 
   auto params = brave::mojom::DynamicParams::New();
 #if BUILDFLAG(ENABLE_BRAVE_WALLET)

--- a/browser/sources.gni
+++ b/browser/sources.gni
@@ -21,7 +21,6 @@ import("//brave/browser/new_tab/sources.gni")
 import("//brave/browser/onboarding/sources.gni")
 import("//brave/browser/perf/sources.gni")
 import("//brave/browser/permissions/sources.gni")
-import("//brave/browser/playlist/sources.gni")
 import("//brave/browser/profiles/sources.gni")
 import("//brave/browser/renderer_context_menu/sources.gni")
 import("//brave/browser/request_otr/sources.gni")
@@ -50,6 +49,7 @@ import("//brave/components/commander/common/buildflags/buildflags.gni")
 import("//brave/components/containers/buildflags/buildflags.gni")
 import("//brave/components/email_aliases/buildflags/buildflags.gni")
 import("//brave/components/ipfs/buildflags/buildflags.gni")
+import("//brave/components/playlist/core/common/buildflags/buildflags.gni")
 import("//brave/components/psst/buildflags/buildflags.gni")
 import("//brave/components/tor/buildflags/buildflags.gni")
 import("//brave/components/web_discovery/buildflags/buildflags.gni")
@@ -64,6 +64,10 @@ if (enable_brave_rewards) {
 if (enable_brave_wallet) {
   import("//brave/browser/brave_wallet/android/sources.gni")
   import("//brave/browser/brave_wallet/notifications/sources.gni")
+}
+
+if (enable_playlist) {
+  import("//brave/browser/playlist/sources.gni")
 }
 
 brave_chrome_browser_allow_circular_includes_from = []
@@ -705,7 +709,6 @@ brave_chrome_browser_sources += brave_browser_net_sources
 brave_chrome_browser_sources += brave_browser_new_tab_sources
 brave_chrome_browser_sources += brave_browser_perf_sources
 brave_chrome_browser_sources += brave_browser_permissions_sources
-brave_chrome_browser_sources += brave_browser_playlist_sources
 brave_chrome_browser_sources += brave_browser_renderer_context_menu_sources
 brave_chrome_browser_sources += brave_browser_request_otr_sources
 brave_chrome_browser_sources += brave_browser_search_engines_sources
@@ -730,7 +733,6 @@ brave_chrome_browser_deps += brave_browser_net_deps
 brave_chrome_browser_deps += brave_browser_new_tab_deps
 brave_chrome_browser_deps += brave_browser_perf_deps
 brave_chrome_browser_deps += brave_browser_permissions_deps
-brave_chrome_browser_deps += brave_browser_playlist_deps
 brave_chrome_browser_deps += brave_browser_profiles_deps
 brave_chrome_browser_deps += brave_browser_renderer_context_menu_deps
 brave_chrome_browser_deps += brave_browser_request_otr_deps
@@ -767,6 +769,11 @@ if (enable_ai_chat) {
   # Remove this once webui/ai_chat does not depend on chrome/browser.
   brave_chrome_browser_allow_circular_includes_from +=
       [ "//brave/browser/ui/webui/ai_chat" ]
+}
+
+if (enable_playlist) {
+  brave_chrome_browser_sources += brave_browser_playlist_sources
+  brave_chrome_browser_deps += brave_browser_playlist_deps
 }
 
 if (enable_brave_ai_chat_agent_profile) {

--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -150,6 +150,10 @@ source_set("ui") {
     ]
   }
 
+  if (enable_playlist) {
+    deps += [ "//brave/components/playlist/core/common" ]
+  }
+
   if (enable_brave_rewards) {
     deps += [
       "//brave/browser/brave_rewards",
@@ -880,7 +884,6 @@ source_set("ui") {
     "//brave/components/ntp_background_images/common",
     "//brave/components/p3a",
     "//brave/components/p3a_utils",
-    "//brave/components/playlist/core/common",
     "//brave/components/query_filter",
     "//brave/components/resources:scaled_resources",
     "//brave/components/resources:static_resources",

--- a/browser/ui/brave_browser_actions.cc
+++ b/browser/ui/brave_browser_actions.cc
@@ -10,7 +10,7 @@
 #include "brave/browser/ui/browser_commands.h"
 #include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
 #include "brave/components/containers/buildflags/buildflags.h"
-#include "brave/components/playlist/core/common/features.h"
+#include "brave/components/playlist/core/common/buildflags/buildflags.h"
 #include "brave/components/vector_icons/vector_icons.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/actions/chrome_action_id.h"
@@ -32,8 +32,13 @@
 #include "brave/components/containers/core/common/features.h"
 #endif
 
+#if BUILDFLAG(ENABLE_PLAYLIST)
+#include "brave/components/playlist/core/common/features.h"
+#endif
+
 namespace {
 
+#if BUILDFLAG(ENABLE_PLAYLIST) || BUILDFLAG(ENABLE_AI_CHAT)
 actions::ActionItem::ActionItemBuilder SidePanelAction(
     SidePanelEntryId id,
     int title_id,
@@ -50,6 +55,7 @@ actions::ActionItem::ActionItemBuilder SidePanelAction(
       .SetImage(ui::ImageModel::FromVectorIcon(icon, ui::kColorIcon))
       .SetProperty(actions::kActionItemPinnableKey, is_pinnable);
 }
+#endif  // BUILDFLAG(ENABLE_PLAYLIST) || BUILDFLAG(ENABLE_AI_CHAT)
 
 }  // namespace
 
@@ -81,6 +87,7 @@ void BraveBrowserActions::InitializeBrowserActions() {
 
   BrowserWindowInterface* const bwi = base::to_address(bwi_);
 
+#if BUILDFLAG(ENABLE_PLAYLIST)
   if (base::FeatureList::IsEnabled(playlist::features::kPlaylist)) {
     root_action_item_->AddChild(
         SidePanelAction(
@@ -89,6 +96,7 @@ void BraveBrowserActions::InitializeBrowserActions() {
             kActionSidePanelShowPlaylist, bwi, true)
             .Build());
   }
+#endif  // BUILDFLAG(ENABLE_PLAYLIST)
 
 #if BUILDFLAG(ENABLE_AI_CHAT)
   if (ai_chat::IsAIChatEnabled(profile_->GetPrefs())) {

--- a/browser/ui/brave_browser_command_controller.cc
+++ b/browser/ui/brave_browser_command_controller.cc
@@ -678,10 +678,10 @@ bool BraveBrowserCommandController::ExecuteBraveCommandWithDisposition(
     case IDC_SHOW_PLAYLIST_BUBBLE:
 #if BUILDFLAG(ENABLE_PLAYLIST_WEBUI)
       brave::ShowPlaylistBubble(&*browser_);
+      break;
 #else
       NOTREACHED() << " This command shouldn't be enabled";
 #endif
-      break;
     case IDC_SHOW_WAYBACK_MACHINE_BUBBLE:
 #if BUILDFLAG(ENABLE_BRAVE_WAYBACK_MACHINE)
       brave::ShowWaybackMachineBubble(&*browser_);

--- a/browser/ui/browser_window/BUILD.gn
+++ b/browser/ui/browser_window/BUILD.gn
@@ -10,7 +10,10 @@ source_set("browser_window") {
 
   sources = [ "public/browser_window_features.h" ]
 
-  public_deps = [ "//base" ]
+  public_deps = [
+    "//base",
+    "//brave/components/playlist/core/common/buildflags",
+  ]
 
   deps = [ "//brave/components/email_aliases/buildflags" ]
 }

--- a/browser/ui/browser_window/internal/BUILD.gn
+++ b/browser/ui/browser_window/internal/BUILD.gn
@@ -6,6 +6,7 @@
 import("//brave/components/brave_rewards/core/buildflags/buildflags.gni")
 import("//brave/components/brave_vpn/common/buildflags/buildflags.gni")
 import("//brave/components/email_aliases/buildflags/buildflags.gni")
+import("//brave/components/playlist/core/common/buildflags/buildflags.gni")
 import("//build/config/ui.gni")
 
 source_set("internal") {
@@ -19,10 +20,14 @@ source_set("internal") {
     "//brave/components/brave_rewards/core/buildflags",
     "//brave/components/brave_vpn/common/buildflags",
     "//brave/components/email_aliases/buildflags",
-    "//brave/components/playlist/core/common",
+    "//brave/components/playlist/core/common/buildflags",
     "//chrome/browser/tab_group_sync:factories",
     "//chrome/browser/ui/browser_window",
   ]
+
+  if (enable_playlist) {
+    deps += [ "//brave/components/playlist/core/common" ]
+  }
 
   if (toolkit_views) {
     deps += [ "//brave/browser/ui/sidebar:sidebar_impl" ]

--- a/browser/ui/browser_window/internal/browser_window_features.cc
+++ b/browser/ui/browser_window/internal/browser_window_features.cc
@@ -12,11 +12,10 @@
 #include "brave/browser/ui/sidebar/sidebar_utils.h"
 #include "brave/browser/ui/tabs/brave_browser_tab_menu_model_delegate.h"
 #include "brave/browser/ui/views/page_info/brave_shields_ui_contents_cache.h"
-#include "brave/browser/ui/views/side_panel/playlist/playlist_side_panel_coordinator.h"
 #include "brave/components/brave_rewards/core/buildflags/buildflags.h"
 #include "brave/components/brave_vpn/common/buildflags/buildflags.h"
 #include "brave/components/email_aliases/buildflags/buildflags.h"
-#include "brave/components/playlist/core/common/features.h"
+#include "brave/components/playlist/core/common/buildflags/buildflags.h"
 #include "chrome/browser/tab_group_sync/tab_group_sync_service_factory.h"
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/browser_window/public/browser_window_interface.h"
@@ -46,6 +45,11 @@ class BraveVPNController {};
 #if BUILDFLAG(ENABLE_EMAIL_ALIASES)
 #include "brave/browser/email_aliases/email_aliases_service_factory.h"
 #include "brave/browser/ui/email_aliases/email_aliases_controller.h"
+#endif
+
+#if BUILDFLAG(ENABLE_PLAYLIST)
+#include "brave/browser/ui/views/side_panel/playlist/playlist_side_panel_coordinator.h"
+#include "brave/components/playlist/core/common/features.h"
 #endif
 
 BrowserWindowFeatures::BrowserWindowFeatures() = default;
@@ -96,12 +100,14 @@ void BrowserWindowFeatures::InitPostBrowserViewConstruction(
   if (sidebar::CanUseSidebar(browser_view->browser())) {
     sidebar_controller_ = std::make_unique<sidebar::SidebarController>(
         browser_view->browser(), browser_view->GetProfile());
+#if BUILDFLAG(ENABLE_PLAYLIST)
     if (base::FeatureList::IsEnabled(playlist::features::kPlaylist)) {
       playlist_side_panel_coordinator_ =
           std::make_unique<PlaylistSidePanelCoordinator>(
               browser_view->browser(), sidebar_controller_.get(),
               browser_view->GetProfile());
     }
+#endif  // BUILDFLAG(ENABLE_PLAYLIST)
   }
 
 #if BUILDFLAG(ENABLE_EMAIL_ALIASES)
@@ -134,6 +140,8 @@ void BrowserWindowFeatures::TearDownPreBrowserWindowDestruction() {
 
   if (sidebar_controller_) {
     sidebar_controller_->TearDownPreBrowserWindowDestruction();
+#if BUILDFLAG(ENABLE_PLAYLIST)
     playlist_side_panel_coordinator_.reset();
+#endif
   }
 }

--- a/browser/ui/browser_window/public/browser_window_features.h
+++ b/browser/ui/browser_window/public/browser_window_features.h
@@ -9,6 +9,7 @@
 #include <memory>
 
 #include "brave/components/email_aliases/buildflags/buildflags.h"
+#include "brave/components/playlist/core/common/buildflags/buildflags.h"
 
 class BraveShieldsUIContentsCache;
 class BraveVPNController;
@@ -50,9 +51,11 @@ class BrowserWindowFeatures : public BrowserWindowFeatures_ChromiumImpl {
 
   BraveVPNController* brave_vpn_controller();
 
+#if BUILDFLAG(ENABLE_PLAYLIST)
   PlaylistSidePanelCoordinator* playlist_side_panel_coordinator() {
     return playlist_side_panel_coordinator_.get();
   }
+#endif
 
 #if BUILDFLAG(ENABLE_EMAIL_ALIASES)
   email_aliases::EmailAliasesController* email_aliases_controller() {
@@ -69,8 +72,10 @@ class BrowserWindowFeatures : public BrowserWindowFeatures_ChromiumImpl {
   std::unique_ptr<BraveVPNController> brave_vpn_controller_;
   std::unique_ptr<brave_rewards::RewardsPanelCoordinator>
       rewards_panel_coordinator_;
+#if BUILDFLAG(ENABLE_PLAYLIST)
   std::unique_ptr<PlaylistSidePanelCoordinator>
       playlist_side_panel_coordinator_;
+#endif
 #if BUILDFLAG(ENABLE_EMAIL_ALIASES)
   std::unique_ptr<email_aliases::EmailAliasesController>
       email_aliases_controller_;

--- a/browser/ui/color/sources.gni
+++ b/browser/ui/color/sources.gni
@@ -3,6 +3,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import("//brave/components/playlist/core/common/buildflags/buildflags.gni")
 import("//build/config/ui.gni")
 
 brave_browser_ui_color_mixers_sources = []
@@ -18,20 +19,27 @@ if (!is_android) {
     "//brave/browser/ui/color/color_palette.h",
     "//brave/browser/ui/color/material_brave_color_mixer.cc",
     "//brave/browser/ui/color/material_brave_color_mixer.h",
-    "//brave/browser/ui/color/playlist/playlist_color_mixer.cc",
-    "//brave/browser/ui/color/playlist/playlist_color_mixer.h",
   ]
 
   brave_browser_ui_color_mixers_deps += [
     "//brave/components/brave_vpn/common/buildflags",
     "//brave/components/brave_wayback_machine/buildflags",
-    "//brave/components/playlist/core/common",
+    "//brave/components/playlist/core/common/buildflags",
     "//brave/components/speedreader/common/buildflags",
     "//skia",
     "//ui/color",
     "//ui/gfx",
     "//ui/native_theme",
   ]
+
+  if (enable_playlist) {
+    brave_browser_ui_color_mixers_sources += [
+      "//brave/browser/ui/color/playlist/playlist_color_mixer.cc",
+      "//brave/browser/ui/color/playlist/playlist_color_mixer.h",
+    ]
+    brave_browser_ui_color_mixers_deps +=
+        [ "//brave/components/playlist/core/common" ]
+  }
 }
 
 if (toolkit_views) {

--- a/browser/ui/sidebar/BUILD.gn
+++ b/browser/ui/sidebar/BUILD.gn
@@ -7,6 +7,7 @@ import("//brave/components/ai_chat/core/common/buildflags/buildflags.gni")
 import("//brave/components/brave_origin/buildflags/buildflags.gni")
 import("//brave/components/brave_talk/buildflags/buildflags.gni")
 import("//brave/components/brave_wallet/common/buildflags/buildflags.gni")
+import("//brave/components/playlist/core/common/buildflags/buildflags.gni")
 import("//build/config/ui.gni")
 import("//extensions/buildflags/buildflags.gni")
 
@@ -96,7 +97,7 @@ source_set("browser_tests") {
     "//brave/components/ai_chat/core/common/buildflags",
     "//brave/components/brave_talk/buildflags",
     "//brave/components/brave_wallet/common/buildflags",
-    "//brave/components/playlist/core/common",
+    "//brave/components/playlist/core/common/buildflags",
     "//brave/components/sidebar/browser",
     "//brave/components/sidebar/common",
     "//chrome/browser",
@@ -120,6 +121,10 @@ source_set("browser_tests") {
   if (enable_ai_chat) {
     deps += [ "//brave/components/ai_chat/core/common" ]
   }
+
+  if (enable_playlist) {
+    deps += [ "//brave/components/playlist/core/common" ]
+  }
 }
 
 source_set("unit_tests") {
@@ -135,7 +140,7 @@ source_set("unit_tests") {
     "//brave/components/ai_chat/core/common/buildflags",
     "//brave/components/brave_origin/buildflags",
     "//brave/components/brave_talk/buildflags",
-    "//brave/components/playlist/core/common",
+    "//brave/components/playlist/core/common/buildflags",
     "//brave/components/sidebar/browser",
     "//chrome/browser/ui",
     "//chrome/test:test_support",
@@ -145,4 +150,8 @@ source_set("unit_tests") {
     "//testing/gmock",
     "//testing/gtest",
   ]
+
+  if (enable_playlist) {
+    deps += [ "//brave/components/playlist/core/common" ]
+  }
 }

--- a/browser/ui/sidebar/sidebar_browsertest.cc
+++ b/browser/ui/sidebar/sidebar_browsertest.cc
@@ -44,7 +44,7 @@
 #include "brave/components/brave_talk/buildflags/buildflags.h"
 #include "brave/components/brave_wallet/common/buildflags/buildflags.h"
 #include "brave/components/constants/brave_switches.h"
-#include "brave/components/playlist/core/common/features.h"
+#include "brave/components/playlist/core/common/buildflags/buildflags.h"
 #include "brave/components/sidebar/browser/constants.h"
 #include "brave/components/sidebar/browser/pref_names.h"
 #include "brave/components/sidebar/browser/sidebar_item.h"
@@ -87,6 +87,10 @@
 
 #if BUILDFLAG(ENABLE_AI_CHAT)
 #include "brave/components/ai_chat/core/common/features.h"
+#endif
+
+#if BUILDFLAG(ENABLE_PLAYLIST)
+#include "brave/components/playlist/core/common/features.h"
 #endif
 
 using ::testing::Eq;
@@ -290,9 +294,11 @@ class SidebarBrowserTest : public InProcessBrowserTest {
     auto item_count =
         std::size(SidebarServiceFactory::kDefaultBuiltInItemTypes) -
         1 /* for history*/;
+#if BUILDFLAG(ENABLE_PLAYLIST)
     if (!base::FeatureList::IsEnabled(playlist::features::kPlaylist)) {
       item_count -= 1;
     }
+#endif
 
 #if BUILDFLAG(ENABLE_AI_CHAT)
     if (!ai_chat::features::IsAIChatEnabled()) {
@@ -1620,6 +1626,7 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Bool());
 #endif  // BUILDFLAG(ENABLE_AI_CHAT)
 
+#if BUILDFLAG(ENABLE_PLAYLIST)
 class SidebarBrowserTestWithPlaylist : public SidebarBrowserTest {
  public:
   SidebarBrowserTestWithPlaylist() {
@@ -1657,6 +1664,7 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTestWithPlaylist, Incognito) {
   // Try Remove an item
   sidebar_service->RemoveItemAt(0);
 }
+#endif  // BUILDFLAG(ENABLE_PLAYLIST)
 
 #if BUILDFLAG(ENABLE_AI_CHAT)
 

--- a/browser/ui/sidebar/sidebar_service_factory.h
+++ b/browser/ui/sidebar/sidebar_service_factory.h
@@ -12,6 +12,7 @@
 
 #include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
 #include "brave/components/brave_talk/buildflags/buildflags.h"
+#include "brave/components/playlist/core/common/buildflags/buildflags.h"
 #include "brave/components/sidebar/browser/sidebar_item.h"
 #include "components/keyed_service/content/browser_context_keyed_service_factory.h"
 #include "components/keyed_service/core/keyed_service.h"
@@ -49,7 +50,9 @@ class SidebarServiceFactory : public BrowserContextKeyedServiceFactory {
           SidebarItem::BuiltInItemType::kBookmarks,
           SidebarItem::BuiltInItemType::kReadingList,
           SidebarItem::BuiltInItemType::kHistory,
+#if BUILDFLAG(ENABLE_PLAYLIST)
           SidebarItem::BuiltInItemType::kPlaylist,
+#endif
       });
 
   static_assert(SidebarItem::kBuiltInItemsCount ==

--- a/browser/ui/sidebar/sidebar_utils.cc
+++ b/browser/ui/sidebar/sidebar_utils.cc
@@ -19,6 +19,7 @@
 #include "brave/components/brave_talk/buildflags/buildflags.h"
 #include "brave/components/constants/brave_switches.h"
 #include "brave/components/constants/webui_url_constants.h"
+#include "brave/components/playlist/core/common/buildflags/buildflags.h"
 #include "brave/components/sidebar/browser/constants.h"
 #include "brave/components/sidebar/browser/pref_names.h"
 #include "brave/components/sidebar/common/features.h"
@@ -144,8 +145,10 @@ SidePanelEntryId SidePanelIdFromSideBarItemType(BuiltInItemType type) {
       return SidePanelEntryId::kReadingList;
     case BuiltInItemType::kBookmarks:
       return SidePanelEntryId::kBookmarks;
+#if BUILDFLAG(ENABLE_PLAYLIST)
     case BuiltInItemType::kPlaylist:
       return SidePanelEntryId::kPlaylist;
+#endif
 #if BUILDFLAG(ENABLE_AI_CHAT)
     case BuiltInItemType::kChatUI:
       return SidePanelEntryId::kChatUI;
@@ -173,8 +176,10 @@ std::optional<BuiltInItemType> BuiltInItemTypeFromSidePanelId(
       return BuiltInItemType::kReadingList;
     case SidePanelEntryId::kBookmarks:
       return BuiltInItemType::kBookmarks;
+#if BUILDFLAG(ENABLE_PLAYLIST)
     case SidePanelEntryId::kPlaylist:
       return BuiltInItemType::kPlaylist;
+#endif
 #if BUILDFLAG(ENABLE_AI_CHAT)
     case SidePanelEntryId::kChatUI:
       return BuiltInItemType::kChatUI;
@@ -221,9 +226,11 @@ void SetLastUsedSidePanel(PrefService* prefs,
       case SidePanelEntryId::kBookmarks:
         type = BuiltInItemType::kBookmarks;
         break;
+#if BUILDFLAG(ENABLE_PLAYLIST)
       case SidePanelEntryId::kPlaylist:
         type = BuiltInItemType::kPlaylist;
         break;
+#endif
 #if BUILDFLAG(ENABLE_AI_CHAT)
       case SidePanelEntryId::kChatUI:
         type = BuiltInItemType::kChatUI;
@@ -252,9 +259,12 @@ bool IsDisabledItemForPrivate(SidebarItem::BuiltInItemType type) {
   switch (type) {
 #if BUILDFLAG(ENABLE_AI_CHAT)
     case SidebarItem::BuiltInItemType::kChatUI:
+      return true;
 #endif
+#if BUILDFLAG(ENABLE_PLAYLIST)
     case SidebarItem::BuiltInItemType::kPlaylist:
       return true;
+#endif
     default:
       break;
   }
@@ -265,11 +275,15 @@ bool IsDisabledItemForGuest(SidebarItem::BuiltInItemType type) {
   switch (type) {
     case SidebarItem::BuiltInItemType::kBookmarks:
     case SidebarItem::BuiltInItemType::kReadingList:
+      return true;
 #if BUILDFLAG(ENABLE_AI_CHAT)
     case SidebarItem::BuiltInItemType::kChatUI:
+      return true;
 #endif
+#if BUILDFLAG(ENABLE_PLAYLIST)
     case SidebarItem::BuiltInItemType::kPlaylist:
       return true;
+#endif
     default:
       break;
   }

--- a/browser/ui/views/location_bar/brave_location_bar_view.cc
+++ b/browser/ui/views/location_bar/brave_location_bar_view.cc
@@ -19,10 +19,10 @@
 #include "brave/browser/ui/views/location_bar/brave_search_conversion/promotion_button_controller.h"
 #include "brave/browser/ui/views/location_bar/brave_search_conversion/promotion_button_view.h"
 #include "brave/browser/ui/views/location_bar/brave_shields_page_info_controller.h"
-#include "brave/browser/ui/views/playlist/playlist_action_icon_view.h"
 #include "brave/browser/ui/views/toolbar/brave_toolbar_view.h"
 #include "brave/components/brave_news/common/buildflags/buildflags.h"
 #include "brave/components/commander/common/buildflags/buildflags.h"
+#include "brave/components/playlist/core/common/buildflags/buildflags.h"
 #include "brave/grit/brave_theme_resources.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/themes/theme_service_factory.h"
@@ -50,6 +50,10 @@
 #include "ui/views/animation/ink_drop.h"
 #include "ui/views/controls/highlight_path_generator.h"
 #include "ui/views/view_utils.h"
+
+#if BUILDFLAG(ENABLE_PLAYLIST_WEBUI)
+#include "brave/browser/ui/views/playlist/playlist_action_icon_view.h"
+#endif
 
 #if BUILDFLAG(ENABLE_TOR)
 #include "brave/browser/ui/views/location_bar/onion_location_view.h"
@@ -160,6 +164,7 @@ void BraveLocationBarView::Init() {
   }
 }
 
+#if BUILDFLAG(ENABLE_PLAYLIST_WEBUI)
 void BraveLocationBarView::ShowPlaylistBubble(
     playlist::PlaylistBubblesController::BubbleType type) {
   if (auto* playlist_action_icon_view = GetPlaylistActionIconView()) {
@@ -176,6 +181,7 @@ PlaylistActionIconView* BraveLocationBarView::GetPlaylistActionIconView() {
 
   return views::AsViewClass<PlaylistActionIconView>(playlist_action_icon_view);
 }
+#endif  // BUILDFLAG(ENABLE_PLAYLIST_WEBUI)
 
 void BraveLocationBarView::Update(content::WebContents* contents) {
   // base Init calls update before our Init is run, so our children

--- a/browser/ui/views/location_bar/brave_location_bar_view.h
+++ b/browser/ui/views/location_bar/brave_location_bar_view.h
@@ -11,13 +11,17 @@
 
 #include "base/gtest_prod_util.h"
 #include "base/types/pass_key.h"
-#include "brave/browser/ui/views/playlist/playlist_bubbles_controller.h"
 #include "brave/browser/ui/views/toolbar/brave_toolbar_view.h"
 #include "brave/browser/ui/views/view_shadow.h"
 #include "brave/components/brave_news/common/buildflags/buildflags.h"
+#include "brave/components/playlist/core/common/buildflags/buildflags.h"
 #include "brave/components/tor/buildflags/buildflags.h"
 #include "chrome/browser/ui/views/location_bar/location_bar_view.h"
 #include "ui/base/metadata/metadata_header_macros.h"
+
+#if BUILDFLAG(ENABLE_PLAYLIST_WEBUI)
+#include "brave/browser/ui/views/playlist/playlist_bubbles_controller.h"
+#endif
 
 class BraveActionsContainer;
 class BraveActionsContainerTest;
@@ -106,9 +110,11 @@ class BraveLocationBarView : public LocationBarView {
     return brave_actions_;
   }
 
+#if BUILDFLAG(ENABLE_PLAYLIST_WEBUI)
   void ShowPlaylistBubble(
       playlist::PlaylistBubblesController::BubbleType type =
           playlist::PlaylistBubblesController::BubbleType::kInfer);
+#endif
 
   void set_ignore_layout(base::PassKey<BraveToolbarView::LayoutGuard>,
                          bool ignore) {
@@ -133,7 +139,9 @@ class BraveLocationBarView : public LocationBarView {
   friend class ::BraveActionsContainerTest;
   friend class ::RewardsBrowserTest;
 
+#if BUILDFLAG(ENABLE_PLAYLIST_WEBUI)
   PlaylistActionIconView* GetPlaylistActionIconView();
+#endif
   void SetupShadow();
 
   // Prevent layout with invalid rect.

--- a/browser/ui/views/page_action/brave_page_action_icon_container_view.cc
+++ b/browser/ui/views/page_action/brave_page_action_icon_container_view.cc
@@ -9,13 +9,17 @@
 
 #include "base/check_is_test.h"
 #include "brave/components/brave_wayback_machine/buildflags/buildflags.h"
-#include "brave/components/playlist/core/common/features.h"
+#include "brave/components/playlist/core/common/buildflags/buildflags.h"
 #include "brave/components/speedreader/common/buildflags/buildflags.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/sharing_hub/sharing_hub_features.h"
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/views/page_action/page_action_icon_params.h"
 #include "ui/base/metadata/metadata_impl_macros.h"
+
+#if BUILDFLAG(ENABLE_PLAYLIST)
+#include "brave/components/playlist/core/common/features.h"
+#endif
 
 #if BUILDFLAG(ENABLE_SPEEDREADER)
 #include "brave/components/speedreader/common/features.h"
@@ -41,6 +45,7 @@ PageActionIconParams& ModifyIconParamsForBrave(PageActionIconParams& params) {
       brave::kWaybackMachineActionIconType);
 #endif
 
+#if BUILDFLAG(ENABLE_PLAYLIST)
   if (base::FeatureList::IsEnabled(playlist::features::kPlaylist)) {
     // Browser could be null if the location bar was created for
     // PresentationReceiverWindowView.
@@ -53,6 +58,7 @@ PageActionIconParams& ModifyIconParamsForBrave(PageActionIconParams& params) {
           brave::kPlaylistPageActionIconType);
     }
   }
+#endif  // BUILDFLAG(ENABLE_PLAYLIST)
 
 #if BUILDFLAG(ENABLE_SPEEDREADER)
   if (base::FeatureList::IsEnabled(

--- a/browser/ui/views/sidebar/sidebar_container_view.cc
+++ b/browser/ui/views/sidebar/sidebar_container_view.cc
@@ -27,12 +27,12 @@
 #include "brave/browser/ui/views/frame/brave_browser_view.h"
 #include "brave/browser/ui/views/frame/brave_contents_view_util.h"
 #include "brave/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl.h"
-#include "brave/browser/ui/views/side_panel/playlist/playlist_side_panel_coordinator.h"
 #include "brave/browser/ui/views/sidebar/sidebar_control_view.h"
 #include "brave/browser/ui/views/toolbar/brave_toolbar_view.h"
 #include "brave/browser/ui/views/toolbar/side_panel_button.h"
 #include "brave/components/constants/pref_names.h"
 #include "brave/components/constants/webui_url_constants.h"
+#include "brave/components/playlist/core/common/buildflags/buildflags.h"
 #include "brave/components/sidebar/browser/sidebar_item.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser_window.h"
@@ -69,6 +69,10 @@
 #include "ui/views/view_class_properties.h"
 #include "ui/views/view_utils.h"
 #include "ui/views/widget/widget.h"
+
+#if BUILDFLAG(ENABLE_PLAYLIST)
+#include "brave/browser/ui/views/side_panel/playlist/playlist_side_panel_coordinator.h"
+#endif
 
 namespace {
 
@@ -250,6 +254,9 @@ void SidebarContainerView::WillShowSidePanel() {
 bool SidebarContainerView::IsFullscreenForCurrentEntry() const {
   CHECK(!base::FeatureList::IsEnabled(sidebar::features::kSidebarV2));
 
+#if !BUILDFLAG(ENABLE_PLAYLIST)
+  return false;
+#else
   // For now, we only supports fullscreen from playlist.
   if (side_panel_coordinator_->GetCurrentEntryId(
           SidePanelEntry::PanelType::kContent) != SidePanelEntryId::kPlaylist) {
@@ -278,6 +285,7 @@ bool SidebarContainerView::IsFullscreenForCurrentEntry() const {
   }
 
   return false;
+#endif  // BUILDFLAG(ENABLE_PLAYLIST)
 }
 
 void SidebarContainerView::UpdateBorder() {

--- a/browser/ui/views/sidebar/sidebar_items_contents_view.cc
+++ b/browser/ui/views/sidebar/sidebar_items_contents_view.cc
@@ -32,7 +32,7 @@
 #include "brave/browser/ui/views/sidebar/sidebar_item_view.h"
 #include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
 #include "brave/components/brave_talk/buildflags/buildflags.h"
-#include "brave/components/playlist/core/common/features.h"
+#include "brave/components/playlist/core/common/buildflags/buildflags.h"
 #include "brave/components/sidebar/browser/pref_names.h"
 #include "brave/components/sidebar/browser/sidebar_item.h"
 #include "brave/components/sidebar/browser/sidebar_service.h"
@@ -597,8 +597,10 @@ ui::ImageModel SidebarItemsContentsView::GetImageForBuiltInItems(
       return get_image_model(kLeoReadingListIcon, state);
     case sidebar::SidebarItem::BuiltInItemType::kHistory:
       return get_image_model(kLeoHistoryIcon, state);
+#if BUILDFLAG(ENABLE_PLAYLIST)
     case sidebar::SidebarItem::BuiltInItemType::kPlaylist:
       return get_image_model(kLeoProductPlaylistIcon, state);
+#endif
 #if BUILDFLAG(ENABLE_AI_CHAT)
     case sidebar::SidebarItem::BuiltInItemType::kChatUI:
       return get_image_model(kLeoProductBraveLeoIcon, state);

--- a/browser/ui/webui/brave_settings_ui.cc
+++ b/browser/ui/webui/brave_settings_ui.cc
@@ -47,8 +47,7 @@
 #include "brave/components/commands/common/features.h"
 #include "brave/components/email_aliases/buildflags/buildflags.h"
 #include "brave/components/ntp_background_images/browser/features.h"
-#include "brave/components/playlist/core/common/features.h"
-#include "brave/components/playlist/core/common/pref_names.h"
+#include "brave/components/playlist/core/common/buildflags/buildflags.h"
 #include "brave/components/search_engines/brave_prepopulated_engines.h"
 #include "brave/components/speedreader/common/buildflags/buildflags.h"
 #include "brave/components/tor/buildflags/buildflags.h"
@@ -103,6 +102,11 @@
 
 #if BUILDFLAG(ENABLE_BRAVE_WAYBACK_MACHINE)
 #include "brave/components/brave_wayback_machine/pref_names.h"
+#endif
+
+#if BUILDFLAG(ENABLE_PLAYLIST)
+#include "brave/components/playlist/core/common/features.h"
+#include "brave/components/playlist/core/common/pref_names.h"
 #endif
 
 #if BUILDFLAG(ENABLE_TOR)
@@ -265,10 +269,14 @@ void BraveSettingsUI::AddResources(content::WebUIDataSource* html_source,
                                   kBraveNTPBrandedWallpaperSurveyPanelist) &&
                               !profile->GetPrefs()->GetBoolean(
                                   brave_rewards::prefs::kDisabledByPolicy));
+#if BUILDFLAG(ENABLE_PLAYLIST)
   html_source->AddBoolean(
       "isPlaylistAllowed",
       base::FeatureList::IsEnabled(playlist::features::kPlaylist) &&
           profile->GetPrefs()->GetBoolean(playlist::kPlaylistEnabledPref));
+#else
+  html_source->AddBoolean("isPlaylistAllowed", false);
+#endif  // BUILDFLAG(ENABLE_PLAYLIST)
 
   html_source->AddBoolean(
       "showCommandsInOmnibox",

--- a/browser/ui/webui/settings/brave_settings_localized_strings_provider.cc
+++ b/browser/ui/webui/settings/brave_settings_localized_strings_provider.cc
@@ -28,7 +28,7 @@
 #include "brave/components/constants/webui_url_constants.h"
 #include "brave/components/containers/buildflags/buildflags.h"
 #include "brave/components/email_aliases/buildflags/buildflags.h"
-#include "brave/components/playlist/core/common/features.h"
+#include "brave/components/playlist/core/common/buildflags/buildflags.h"
 #include "brave/components/request_otr/common/buildflags/buildflags.h"
 #include "brave/components/tor/buildflags/buildflags.h"
 #include "brave/components/version_info/version_info.h"
@@ -73,6 +73,10 @@
 
 #if BUILDFLAG(ENABLE_EMAIL_ALIASES)
 #include "brave/components/email_aliases/features.h"
+#endif
+
+#if BUILDFLAG(ENABLE_PLAYLIST)
+#include "brave/components/playlist/core/common/features.h"
 #endif
 
 namespace settings {

--- a/chromium_src/chrome/browser/ui/views/page_action/page_action_icon_controller.cc
+++ b/chromium_src/chrome/browser/ui/views/page_action/page_action_icon_controller.cc
@@ -7,6 +7,14 @@
 #include "brave/components/brave_wayback_machine/buildflags/buildflags.h"
 #include "brave/components/playlist/core/common/buildflags/buildflags.h"
 #include "brave/components/speedreader/common/buildflags/buildflags.h"
+// Pull in `cc/input/browser_controls_state.h` before the `#define kShown`
+// below, so the `BrowserControlsState::kShown` enumerator is parsed intact.
+// Otherwise the macro shadows it when the upstream .cc (included at the bottom
+// of this file) transitively pulls the header in. Required for
+// enable_playlist_webui=false builds, where the playlist header that
+// previously brought this header in via `page_action_icon_view.h` is no
+// longer included.
+#include "cc/input/browser_controls_state.h"
 #include "chrome/browser/ui/page_action/page_action_icon_type.h"
 #include "chrome/browser/ui/views/page_action/page_action_icon_view.h"
 
@@ -20,9 +28,6 @@
 
 #if BUILDFLAG(ENABLE_PLAYLIST_WEBUI)
 #include "brave/browser/ui/views/playlist/playlist_action_icon_view.h"
-constexpr bool kSupportsPlaylistActionIconView = true;
-#else
-constexpr bool kSupportsPlaylistActionIconView = false;
 #endif
 
 #if BUILDFLAG(ENABLE_SPEEDREADER)
@@ -53,23 +58,32 @@ constexpr bool kSupportsPlaylistActionIconView = false;
 #define BRAVE_WAYBACK_MACHINE_PAGE_ACTION_CASE
 #endif
 
+#if BUILDFLAG(ENABLE_PLAYLIST_WEBUI)
+// CHROMIUM_SRC_INTERNAL_USE
+#define BRAVE_PAGE_ACTION_ICON_CONTROLLER_PLAYLIST_CASE                        \
+  case brave::kPlaylistPageActionIconType:                                     \
+    playlist_action_icon_view_ =                                               \
+        add_page_action_icon(type, std::make_unique<PlaylistActionIconView>(   \
+                                       params.command_updater, params.browser, \
+                                       params.icon_label_bubble_delegate,      \
+                                       params.page_action_icon_delegate));     \
+    break;
+#else
+// CHROMIUM_SRC_INTERNAL_USE
+#define BRAVE_PAGE_ACTION_ICON_CONTROLLER_PLAYLIST_CASE \
+  case brave::kPlaylistPageActionIconType:              \
+    break;
+#endif
+
 // Circumvent creation of CookieControlsIconView in
 // PageActionIconController::Init's switch statement by injecting a case
 // with a non-existent value created above.
-#define kCookieControls                                     \
-  kCookieControls:                                          \
-  break;                                                    \
-  case brave::kPlaylistPageActionIconType:                  \
-    if constexpr (kSupportsPlaylistActionIconView) {        \
-      playlist_action_icon_view_ = add_page_action_icon(    \
-          type, std::make_unique<PlaylistActionIconView>(   \
-                    params.command_updater, params.browser, \
-                    params.icon_label_bubble_delegate,      \
-                    params.page_action_icon_delegate));     \
-    }                                                       \
-    break;                                                  \
-    BRAVE_WAYBACK_MACHINE_PAGE_ACTION_CASE                  \
-    BRAVE_PAGE_ACTION_ICON_CONTROLLER_SPEEDREADER_CASE      \
+#define kCookieControls                              \
+  kCookieControls:                                   \
+  break;                                             \
+  BRAVE_PAGE_ACTION_ICON_CONTROLLER_PLAYLIST_CASE    \
+  BRAVE_WAYBACK_MACHINE_PAGE_ACTION_CASE             \
+  BRAVE_PAGE_ACTION_ICON_CONTROLLER_SPEEDREADER_CASE \
   case brave::kUndefinedPageActionIconType
 
 // We define additional PageActionIconType values (in
@@ -91,6 +105,7 @@ constexpr bool kSupportsPlaylistActionIconView = false;
 #undef kCookieControls
 #undef BRAVE_WAYBACK_MACHINE_PAGE_ACTION_CASE
 #undef BRAVE_PAGE_ACTION_ICON_CONTROLLER_SPEEDREADER_CASE
+#undef BRAVE_PAGE_ACTION_ICON_CONTROLLER_PLAYLIST_CASE
 
 PageActionIconView* PageActionIconController::GetPlaylistActionIconView() {
   return playlist_action_icon_view_.get();

--- a/chromium_src/chrome/browser/ui/views/side_panel/side_panel_util.cc
+++ b/chromium_src/chrome/browser/ui/views/side_panel/side_panel_util.cc
@@ -5,8 +5,12 @@
 
 #include "chrome/browser/ui/views/side_panel/side_panel_util.h"
 
-#include "brave/browser/ui/views/side_panel/playlist/playlist_side_panel_coordinator.h"
 #include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
+#include "brave/components/playlist/core/common/buildflags/buildflags.h"
+
+#if BUILDFLAG(ENABLE_PLAYLIST)
+#include "brave/browser/ui/views/side_panel/playlist/playlist_side_panel_coordinator.h"
+#endif
 
 #if BUILDFLAG(ENABLE_AI_CHAT)
 #include "brave/browser/ai_chat/ai_chat_service_factory.h"
@@ -23,12 +27,14 @@ void SidePanelUtil::PopulateGlobalEntries(Browser* browser,
                                           SidePanelRegistry* global_registry) {
   PopulateGlobalEntries_ChromiumImpl(browser, global_registry);
 
+#if BUILDFLAG(ENABLE_PLAYLIST)
   // the playlist coordinator is not created for popup windows, or for
   // desktop PWAs.
   if (auto* playlist_coordinator =
           browser->GetFeatures().playlist_side_panel_coordinator()) {
     playlist_coordinator->CreateAndRegisterEntry(global_registry);
   }
+#endif  // BUILDFLAG(ENABLE_PLAYLIST)
 
 #if BUILDFLAG(ENABLE_AI_CHAT)
   // AI Chat side panel as a global panel and not tab-specific is conditional

--- a/components/playlist/content/browser/BUILD.gn
+++ b/components/playlist/content/browser/BUILD.gn
@@ -4,6 +4,9 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import("//brave/build/config.gni")
+import("//brave/components/playlist/core/common/buildflags/buildflags.gni")
+
+assert(enable_playlist)
 
 # TODO(sko) This should be component() target.
 # https://github.com/brave/brave-browser/issues/27764

--- a/components/playlist/content/browser/playlist_service.h
+++ b/components/playlist/content/browser/playlist_service.h
@@ -21,10 +21,13 @@
 #include "brave/components/playlist/content/browser/playlist_p3a.h"
 #include "brave/components/playlist/content/browser/playlist_streaming.h"
 #include "brave/components/playlist/content/browser/playlist_thumbnail_downloader.h"
+#include "brave/components/playlist/core/common/buildflags/buildflags.h"
 #include "brave/components/playlist/core/common/mojom/playlist.mojom.h"
 #include "components/keyed_service/core/keyed_service.h"
 #include "components/prefs/pref_member.h"
 #include "mojo/public/cpp/bindings/remote_set.h"
+
+static_assert(BUILDFLAG(ENABLE_PLAYLIST));
 
 #if BUILDFLAG(IS_ANDROID)
 #include "mojo/public/cpp/bindings/receiver_set.h"

--- a/components/playlist/content/renderer/BUILD.gn
+++ b/components/playlist/content/renderer/BUILD.gn
@@ -3,6 +3,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import("//brave/components/playlist/core/common/buildflags/buildflags.gni")
+
+assert(enable_playlist)
+
 # TODO(sko) This should be component() target.
 # https://github.com/brave/brave-browser/issues/27764
 static_library("renderer") {

--- a/components/playlist/content/renderer/playlist_render_frame_observer.h
+++ b/components/playlist/content/renderer/playlist_render_frame_observer.h
@@ -13,12 +13,15 @@
 #include "base/functional/callback_forward.h"
 #include "base/memory/weak_ptr.h"
 #include "base/values.h"
+#include "brave/components/playlist/core/common/buildflags/buildflags.h"
 #include "brave/components/playlist/core/common/mojom/playlist.mojom.h"
 #include "content/public/renderer/render_frame_observer.h"
 #include "content/public/renderer/render_frame_observer_tracker.h"
 #include "mojo/public/cpp/bindings/associated_receiver.h"
 #include "mojo/public/cpp/bindings/associated_remote.h"
 #include "mojo/public/cpp/bindings/pending_associated_receiver.h"
+
+static_assert(BUILDFLAG(ENABLE_PLAYLIST));
 
 namespace playlist {
 

--- a/components/playlist/core/common/BUILD.gn
+++ b/components/playlist/core/common/BUILD.gn
@@ -3,6 +3,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import("//brave/components/playlist/core/common/buildflags/buildflags.gni")
+
+assert(enable_playlist)
+
 # TODO(sko) This should be component() target.
 # https://github.com/brave/brave-browser/issues/27764
 static_library("common") {

--- a/components/playlist/core/common/buildflags/BUILD.gn
+++ b/components/playlist/core/common/buildflags/BUILD.gn
@@ -8,5 +8,8 @@ import("//build/buildflag_header.gni")
 
 buildflag_header("buildflags") {
   header = "buildflags.h"
-  flags = [ "ENABLE_PLAYLIST_WEBUI=$enable_playlist_webui" ]
+  flags = [
+    "ENABLE_PLAYLIST=$enable_playlist",
+    "ENABLE_PLAYLIST_WEBUI=$enable_playlist_webui",
+  ]
 }

--- a/components/playlist/core/common/buildflags/buildflags.gni
+++ b/components/playlist/core/common/buildflags/buildflags.gni
@@ -3,8 +3,18 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import("//brave/components/brave_origin/buildflags/buildflags.gni")
 import("//build/config/ui.gni")
 
 declare_args() {
-  enable_playlist_webui = toolkit_views
+  enable_playlist = !is_brave_origin_branded
 }
+
+declare_args() {
+  enable_playlist_webui = enable_playlist && toolkit_views
+}
+
+assert(enable_playlist || !is_android,
+       "enable_playlist=false is not supported on Android")
+assert(enable_playlist || !is_ios,
+       "enable_playlist=false is not supported on iOS")

--- a/components/playlist/core/common/features.h
+++ b/components/playlist/core/common/features.h
@@ -7,6 +7,9 @@
 #define BRAVE_COMPONENTS_PLAYLIST_CORE_COMMON_FEATURES_H_
 
 #include "base/feature_list.h"
+#include "brave/components/playlist/core/common/buildflags/buildflags.h"
+
+static_assert(BUILDFLAG(ENABLE_PLAYLIST));
 
 namespace playlist::features {
 

--- a/components/playlist/core/common/mojom/BUILD.gn
+++ b/components/playlist/core/common/mojom/BUILD.gn
@@ -3,7 +3,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import("//brave/components/playlist/core/common/buildflags/buildflags.gni")
 import("//mojo/public/tools/bindings/mojom.gni")
+
+assert(enable_playlist)
 
 mojom("mojom") {
   generate_java = true

--- a/components/playlist/core/common/pref_names.h
+++ b/components/playlist/core/common/pref_names.h
@@ -6,6 +6,10 @@
 #ifndef BRAVE_COMPONENTS_PLAYLIST_CORE_COMMON_PREF_NAMES_H_
 #define BRAVE_COMPONENTS_PLAYLIST_CORE_COMMON_PREF_NAMES_H_
 
+#include "brave/components/playlist/core/common/buildflags/buildflags.h"
+
+static_assert(BUILDFLAG(ENABLE_PLAYLIST));
+
 namespace playlist {
 
 // A boolean preference indicates whether playlist feature is enabled or not by

--- a/components/sidebar/browser/BUILD.gn
+++ b/components/sidebar/browser/BUILD.gn
@@ -6,6 +6,7 @@
 import("//brave/components/ai_chat/core/common/buildflags/buildflags.gni")
 import("//brave/components/brave_talk/buildflags/buildflags.gni")
 import("//brave/components/brave_wallet/common/buildflags/buildflags.gni")
+import("//brave/components/playlist/core/common/buildflags/buildflags.gni")
 import("//build/config/ui.gni")
 
 assert(toolkit_views)
@@ -26,13 +27,13 @@ static_library("browser") {
     "//brave/components/ai_chat/core/common/buildflags",
     "//brave/components/brave_talk/buildflags",
     "//brave/components/brave_wallet/common/buildflags",
+    "//brave/components/playlist/core/common/buildflags",
   ]
 
   deps = [
     "//base",
     "//brave/components/constants",
     "//brave/components/l10n/common",
-    "//brave/components/playlist/core/common",
     "//brave/components/resources:strings",
     "//brave/components/sidebar/common",
     "//components/keyed_service/core",
@@ -41,6 +42,10 @@ static_library("browser") {
     "//ui/base",
     "//url",
   ]
+
+  if (enable_playlist) {
+    deps += [ "//brave/components/playlist/core/common" ]
+  }
 
   if (enable_ai_chat) {
     deps += [
@@ -69,13 +74,13 @@ source_set("unit_tests") {
     "//brave/components/ai_chat/core/common/buildflags",
     "//brave/components/brave_talk/buildflags",
     "//brave/components/brave_wallet/common/buildflags",
+    "//brave/components/playlist/core/common/buildflags",
   ]
 
   deps = [
     "//base",
     "//base/test:test_support",
     "//brave/components/constants",
-    "//brave/components/playlist/core/common",
     "//brave/components/sidebar/browser",
     "//brave/components/sidebar/common",
     "//components/prefs",
@@ -87,6 +92,10 @@ source_set("unit_tests") {
     "//testing/gmock",
     "//testing/gtest",
   ]
+
+  if (enable_playlist) {
+    deps += [ "//brave/components/playlist/core/common" ]
+  }
 
   if (enable_ai_chat) {
     deps += [ "//brave/components/ai_chat/core/common" ]

--- a/components/sidebar/browser/sidebar_item.h
+++ b/components/sidebar/browser/sidebar_item.h
@@ -8,6 +8,7 @@
 
 #include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
 #include "brave/components/brave_talk/buildflags/buildflags.h"
+#include "brave/components/playlist/core/common/buildflags/buildflags.h"
 #include "brave/components/sidebar/common/features.h"
 #include "url/gurl.h"
 
@@ -30,7 +31,9 @@ struct SidebarItem {
     kBookmarks = 3,
     kReadingList = 4,
     kHistory = 5,
+#if BUILDFLAG(ENABLE_PLAYLIST)
     kPlaylist = 6,
+#endif
 #if BUILDFLAG(ENABLE_AI_CHAT)
     kChatUI = 7,
 #endif
@@ -38,7 +41,10 @@ struct SidebarItem {
 
   // Count of built-in items based on enabled features.
   static constexpr size_t kBuiltInItemsCount =
-      5  // kWallet, kBookmarks, kReadingList, kHistory, kPlaylist
+      4  // kWallet, kBookmarks, kReadingList, kHistory
+#if BUILDFLAG(ENABLE_PLAYLIST)
+      + 1  // kPlaylist
+#endif
 #if BUILDFLAG(ENABLE_AI_CHAT)
       + 1  // kChatUI
 #endif

--- a/components/sidebar/browser/sidebar_service.cc
+++ b/components/sidebar/browser/sidebar_service.cc
@@ -26,7 +26,7 @@
 #include "brave/components/constants/pref_names.h"
 #include "brave/components/constants/webui_url_constants.h"
 #include "brave/components/l10n/common/locale_util.h"
-#include "brave/components/playlist/core/common/features.h"
+#include "brave/components/playlist/core/common/buildflags/buildflags.h"
 #include "brave/components/sidebar/browser/constants.h"
 #include "brave/components/sidebar/browser/pref_names.h"
 #include "brave/components/sidebar/browser/sidebar_item.h"
@@ -51,6 +51,10 @@
 #include "brave/components/ai_chat/core/browser/utils.h"
 #include "brave/components/ai_chat/core/common/pref_names.h"
 #endif  // BUILDFLAG(ENABLE_AI_CHAT)
+
+#if BUILDFLAG(ENABLE_PLAYLIST)
+#include "brave/components/playlist/core/common/features.h"
+#endif
 
 namespace sidebar {
 
@@ -496,7 +500,10 @@ std::optional<SidebarItem> SidebarService::GetDefaultPanelItem() const {
 #endif
       SidebarItem::BuiltInItemType::kReadingList,
       SidebarItem::BuiltInItemType::kBookmarks,
-      SidebarItem::BuiltInItemType::kPlaylist};
+#if BUILDFLAG(ENABLE_PLAYLIST)
+      SidebarItem::BuiltInItemType::kPlaylist,
+#endif
+  };
 
   std::optional<SidebarItem> default_item;
   for (const auto& type : kPreferredPanelOrder) {
@@ -695,6 +702,7 @@ SidebarItem SidebarService::GetBuiltInItemForType(
         return SidebarItem();
       }
     }
+#if BUILDFLAG(ENABLE_PLAYLIST)
     case SidebarItem::BuiltInItemType::kPlaylist: {
       if (base::FeatureList::IsEnabled(playlist::features::kPlaylist)) {
         return SidebarItem::Create(
@@ -707,6 +715,7 @@ SidebarItem SidebarService::GetBuiltInItemForType(
 
       return SidebarItem();
     }
+#endif  // BUILDFLAG(ENABLE_PLAYLIST)
 #if BUILDFLAG(ENABLE_AI_CHAT)
     case SidebarItem::BuiltInItemType::kChatUI: {
       if (ai_chat::IsAIChatEnabled(prefs_)) {

--- a/components/sidebar/browser/sidebar_service_unittest.cc
+++ b/components/sidebar/browser/sidebar_service_unittest.cc
@@ -19,7 +19,7 @@
 #include "brave/components/brave_talk/buildflags/buildflags.h"
 #include "brave/components/brave_wallet/common/buildflags/buildflags.h"
 #include "brave/components/constants/pref_names.h"
-#include "brave/components/playlist/core/common/features.h"
+#include "brave/components/playlist/core/common/buildflags/buildflags.h"
 #include "brave/components/sidebar/browser/constants.h"
 #include "brave/components/sidebar/browser/pref_names.h"
 #include "brave/components/sidebar/browser/sidebar_item.h"
@@ -36,6 +36,10 @@
 
 #if BUILDFLAG(ENABLE_AI_CHAT)
 #include "brave/components/ai_chat/core/common/features.h"
+#endif
+
+#if BUILDFLAG(ENABLE_PLAYLIST)
+#include "brave/components/playlist/core/common/features.h"
 #endif
 
 using ::testing::Eq;
@@ -58,7 +62,10 @@ constexpr sidebar::SidebarItem::BuiltInItemType
         sidebar::SidebarItem::BuiltInItemType::kBookmarks,
         sidebar::SidebarItem::BuiltInItemType::kReadingList,
         sidebar::SidebarItem::BuiltInItemType::kHistory,
-        sidebar::SidebarItem::BuiltInItemType::kPlaylist};
+#if BUILDFLAG(ENABLE_PLAYLIST)
+        sidebar::SidebarItem::BuiltInItemType::kPlaylist,
+#endif
+};
 
 constexpr char sidebar_all_builtin_visible_json[] = R"({
         "hidden_built_in_items": [  ],
@@ -243,9 +250,11 @@ class SidebarServiceTest : public testing::Test {
   size_t GetDefaultItemCount() const {
     auto item_count =
         std::size(kDefaultBuiltInItemTypesForTest) - 1 /* for history*/;
+#if BUILDFLAG(ENABLE_PLAYLIST)
     if (!base::FeatureList::IsEnabled(playlist::features::kPlaylist)) {
       item_count -= 1;
     }
+#endif
 
 #if BUILDFLAG(ENABLE_AI_CHAT)
     if (!ai_chat::features::IsAIChatEnabled()) {
@@ -542,10 +551,12 @@ TEST_F(SidebarServiceTest, NewDefaultItemAdded) {
         }
 #endif
 
+#if BUILDFLAG(ENABLE_PLAYLIST)
         if (!base::FeatureList::IsEnabled(playlist::features::kPlaylist) &&
             built_in_type == SidebarItem::BuiltInItemType::kPlaylist) {
           return false;
         }
+#endif  // BUILDFLAG(ENABLE_PLAYLIST)
 
         return true;
       });
@@ -855,9 +866,11 @@ TEST_F(SidebarServiceTest, BuiltInItemUpdateTestWithBuiltInItemTypeKey) {
 
   // Brave Talk and Reading list.
   auto expected_count = 2UL;
+#if BUILDFLAG(ENABLE_PLAYLIST)
   if (base::FeatureList::IsEnabled(playlist::features::kPlaylist)) {
     expected_count += 1;
   }
+#endif
 
 #if BUILDFLAG(ENABLE_AI_CHAT)
   if (ai_chat::features::IsAIChatEnabled()) {
@@ -950,6 +963,7 @@ TEST_F(SidebarServiceTest, SidebarEnabledHistogram) {
   histogram_tester_.ExpectTotalCount(p3a::kSidebarEnabledHistogramName, 4);
 }
 
+#if BUILDFLAG(ENABLE_PLAYLIST)
 class SidebarServiceTestWithPlaylist : public SidebarServiceTest {
  public:
   SidebarServiceTestWithPlaylist() {
@@ -992,6 +1006,7 @@ TEST_F(SidebarServiceTestWithPlaylist, GetDefaultPanelItem) {
 
   EXPECT_FALSE(service_->GetDefaultPanelItem());
 }
+#endif  // BUILDFLAG(ENABLE_PLAYLIST)
 
 class SidebarServiceOrderingTest : public SidebarServiceTest {
  public:
@@ -1071,7 +1086,10 @@ TEST_F(SidebarServiceOrderingTest, BuiltInItemsDefaultOrder) {
       SidebarItem::BuiltInItemType::kBookmarks,
       SidebarItem::BuiltInItemType::kReadingList,
       SidebarItem::BuiltInItemType::kHistory,
-      SidebarItem::BuiltInItemType::kPlaylist}));
+#if BUILDFLAG(ENABLE_PLAYLIST)
+      SidebarItem::BuiltInItemType::kPlaylist,
+#endif
+  }));
 }
 
 TEST_F(SidebarServiceOrderingTest, LoadFromPrefsAllBuiltInVisible) {
@@ -1112,10 +1130,12 @@ TEST_F(SidebarServiceOrderingTest, LoadFromPrefsAllBuiltInVisible) {
   expected_count--;
 #endif
 
+#if BUILDFLAG(ENABLE_PLAYLIST)
   if (base::FeatureList::IsEnabled(playlist::features::kPlaylist)) {
     expected_count++;
     items.push_back(SidebarItem::BuiltInItemType::kPlaylist);
   }
+#endif  // BUILDFLAG(ENABLE_PLAYLIST)
   LoadFromPrefsTest(std::move(sidebar), items, expected_count);
 }
 
@@ -1135,7 +1155,9 @@ TEST_F(SidebarServiceOrderingTest, LoadFromPrefsWalletBuiltInHidden) {
 #if BUILDFLAG(ENABLE_AI_CHAT)
       SidebarItem::BuiltInItemType::kChatUI,
 #endif
+#if BUILDFLAG(ENABLE_PLAYLIST)
       SidebarItem::BuiltInItemType::kPlaylist,
+#endif
   };
 
   auto expected_count = sidebar_items->size();
@@ -1150,10 +1172,12 @@ TEST_F(SidebarServiceOrderingTest, LoadFromPrefsWalletBuiltInHidden) {
   expected_count--;
 #endif
 
+#if BUILDFLAG(ENABLE_PLAYLIST)
   if (base::FeatureList::IsEnabled(playlist::features::kPlaylist)) {
     expected_count++;
     items.push_back(SidebarItem::BuiltInItemType::kPlaylist);
   }
+#endif  // BUILDFLAG(ENABLE_PLAYLIST)
 
   LoadFromPrefsTest(std::move(sidebar), items, expected_count);
 }
@@ -1195,10 +1219,12 @@ TEST_F(SidebarServiceOrderingTest, LoadFromPrefsAIChatBuiltInNotListed) {
   expected_count--;
 #endif
 
+#if BUILDFLAG(ENABLE_PLAYLIST)
   if (base::FeatureList::IsEnabled(playlist::features::kPlaylist)) {
     expected_count++;
     items.push_back(SidebarItem::BuiltInItemType::kPlaylist);
   }
+#endif  // BUILDFLAG(ENABLE_PLAYLIST)
 
   LoadFromPrefsTest(std::move(sidebar), items, expected_count);
 }

--- a/renderer/brave_content_renderer_client.cc
+++ b/renderer/brave_content_renderer_client.cc
@@ -15,8 +15,7 @@
 #include "brave/components/brave_shields/core/common/features.h"
 #include "brave/components/brave_vpn/common/buildflags/buildflags.h"
 #include "brave/components/cosmetic_filters/renderer/cosmetic_filters_js_render_frame_observer.h"
-#include "brave/components/playlist/content/renderer/playlist_render_frame_observer.h"
-#include "brave/components/playlist/core/common/features.h"
+#include "brave/components/playlist/core/common/buildflags/buildflags.h"
 #include "brave/components/safe_builtins/renderer/safe_builtins.h"
 #include "brave/components/script_injector/renderer/script_injector_render_frame_observer.h"
 #include "brave/components/skus/common/features.h"
@@ -47,6 +46,11 @@
 #if BUILDFLAG(ENABLE_SPEEDREADER)
 #include "brave/components/speedreader/common/features.h"
 #include "brave/components/speedreader/renderer/speedreader_render_frame_observer.h"
+#endif
+
+#if BUILDFLAG(ENABLE_PLAYLIST)
+#include "brave/components/playlist/content/renderer/playlist_render_frame_observer.h"
+#include "brave/components/playlist/core/common/features.h"
 #endif
 
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
@@ -208,6 +212,7 @@ void BraveContentRendererClient::RenderFrameCreated(
   }
 #endif
 
+#if BUILDFLAG(ENABLE_PLAYLIST)
   if (base::FeatureList::IsEnabled(playlist::features::kPlaylist) &&
       !process_state::IsIncognitoProcess()) {
     new playlist::PlaylistRenderFrameObserver(
@@ -216,6 +221,7 @@ void BraveContentRendererClient::RenderFrameCreated(
         }),
         ISOLATED_WORLD_ID_BRAVE_INTERNAL);
   }
+#endif  // BUILDFLAG(ENABLE_PLAYLIST)
 
 #if BUILDFLAG(ENABLE_AI_CHAT)
   if (ai_chat::features::IsAIChatEnabled() &&
@@ -252,24 +258,28 @@ void BraveContentRendererClient::RunScriptsAtDocumentStart(
     observer->RunScriptsAtDocumentStart();
   }
 
+#if BUILDFLAG(ENABLE_PLAYLIST)
   if (base::FeatureList::IsEnabled(playlist::features::kPlaylist)) {
     if (auto* playlist_observer =
             playlist::PlaylistRenderFrameObserver::Get(render_frame)) {
       playlist_observer->RunScriptsAtDocumentStart();
     }
   }
+#endif  // BUILDFLAG(ENABLE_PLAYLIST)
 
   ChromeContentRendererClient::RunScriptsAtDocumentStart(render_frame);
 }
 
 void BraveContentRendererClient::RunScriptsAtDocumentEnd(
     content::RenderFrame* render_frame) {
+#if BUILDFLAG(ENABLE_PLAYLIST)
   if (base::FeatureList::IsEnabled(playlist::features::kPlaylist)) {
     if (auto* playlist_observer =
             playlist::PlaylistRenderFrameObserver::Get(render_frame)) {
       playlist_observer->RunScriptsAtDocumentEnd();
     }
   }
+#endif  // BUILDFLAG(ENABLE_PLAYLIST)
 
   ChromeContentRendererClient::RunScriptsAtDocumentEnd(render_frame);
 }

--- a/renderer/sources.gni
+++ b/renderer/sources.gni
@@ -6,6 +6,7 @@
 import("//brave/components/ai_chat/core/common/buildflags/buildflags.gni")
 import("//brave/components/brave_vpn/common/buildflags/buildflags.gni")
 import("//brave/components/brave_wallet/common/buildflags/buildflags.gni")
+import("//brave/components/playlist/core/common/buildflags/buildflags.gni")
 import("//brave/components/speedreader/common/buildflags/buildflags.gni")
 import("//brave/components/tor/buildflags/buildflags.gni")
 import("//brave/components/web_discovery/buildflags/buildflags.gni")
@@ -30,7 +31,6 @@ brave_chrome_renderer_deps = [
   "//brave/components/brave_vpn/common/buildflags",
   "//brave/components/brave_wallet/common/buildflags",
   "//brave/components/cosmetic_filters/renderer",
-  "//brave/components/playlist/content/renderer",
   "//brave/components/playlist/core/common/buildflags",
   "//brave/components/safe_builtins/renderer",
   "//brave/components/script_injector/renderer",
@@ -72,6 +72,11 @@ if (enable_brave_wallet) {
     "//brave/components/brave_wallet/renderer",
     "//brave/renderer/brave_wallet",
   ]
+}
+
+if (enable_playlist) {
+  brave_chrome_renderer_deps +=
+      [ "//brave/components/playlist/content/renderer" ]
 }
 
 if (is_android) {

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -171,7 +171,6 @@ test("brave_unit_tests") {
     "//brave/browser/new_tab:unittest",
     "//brave/browser/ntp_background:unit_tests",
     "//brave/browser/permissions:unit_tests",
-    "//brave/browser/playlist/test:unit_tests",
     "//brave/browser/policy/handlers:unit_tests",
     "//brave/browser/profiles:unit_tests",
     "//brave/browser/profiles:util",
@@ -253,7 +252,6 @@ test("brave_unit_tests") {
     "//brave/components/p3a:unit_tests",
     "//brave/components/p3a_utils/test:p3a_utils_unit_tests",
     "//brave/components/permissions:unit_tests",
-    "//brave/components/playlist/core/common:unit_tests",
     "//brave/components/query_filter:unit_tests",
     "//brave/components/request_otr/browser:unit_tests",
     "//brave/components/resources:strings_grit",
@@ -365,6 +363,13 @@ test("brave_unit_tests") {
       "//brave/browser/brave_wallet:unit_tests",
       "//brave/browser/decentralized_dns/test:unit_tests",
       "//brave/components/services/brave_wallet/zcash:zcash_decoder_unit_tests",
+    ]
+  }
+
+  if (enable_playlist) {
+    deps += [
+      "//brave/browser/playlist/test:unit_tests",
+      "//brave/components/playlist/core/common:unit_tests",
     ]
   }
 
@@ -950,7 +955,6 @@ test("brave_browser_tests") {
     "//brave/browser/new_tab:browser_tests",
     "//brave/browser/ntp_background",
     "//brave/browser/permissions:browser_tests",
-    "//brave/browser/playlist/test:browser_tests",
     "//brave/browser/profiles:util",
     "//brave/browser/psst:browser_tests",
     "//brave/browser/regional_capabilities:browser_tests",
@@ -1021,7 +1025,6 @@ test("brave_browser_tests") {
     "//brave/components/l10n/common:test_support",
     "//brave/components/ntp_background_images/buildflags",
     "//brave/components/ntp_background_images/common",
-    "//brave/components/playlist/content/browser",
     "//brave/components/query_filter",
     "//brave/components/resources:strings_grit",
     "//brave/components/skus/common",
@@ -1167,6 +1170,13 @@ test("brave_browser_tests") {
 
   if (enable_tor && enable_extensions) {
     sources += [ "//brave/browser/ui/webui/settings/brave_tor_snowflake_extension_browsertest.cc" ]
+  }
+
+  if (enable_playlist) {
+    deps += [
+      "//brave/browser/playlist/test:browser_tests",
+      "//brave/components/playlist/content/browser",
+    ]
   }
 
   if (enable_brave_wallet) {


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/54129

- New `enable_playlist` GN buildflag, defaults to `!is_brave_origin_branded`.
- Follows the same pattern as `enable_brave_wallet` / `enable_ai_chat` — gates all Playlist code out of origin-branded desktop builds.
- `enable_playlist_webui` now chains through `enable_playlist`.
- Desktop-only: iOS and Android already assert `!is_brave_origin_branded`, so no guards on those platforms.
