### PR TITLE
[iOS] Allow Playlist to be disabled within Origin settings

### DIFF
--- a/ios/brave-ios/Sources/Origin/OriginSettingsView.swift
+++ b/ios/brave-ios/Sources/Origin/OriginSettingsView.swift
@@ -53,6 +53,11 @@ public struct OriginSettingsView: View {
         }
         .toggleStyle(.origin)
         .listRowBackground(Color(.secondaryBraveGroupedBackground))
+        Toggle(isOn: $viewModel.isPlaylistEnabled) {
+          Label(Strings.Origin.playlistLabel, braveSystemImage: "leo.product.playlist")
+        }
+        .toggleStyle(.origin)
+        .listRowBackground(Color(.secondaryBraveGroupedBackground))
         Toggle(isOn: $viewModel.isTalkDisabled.inversed) {
           Label(Strings.Origin.talkLabel, braveSystemImage: "leo.product.brave-talk")
         }

--- a/ios/brave-ios/Sources/Origin/OriginSettingsViewModel.swift
+++ b/ios/brave-ios/Sources/Origin/OriginSettingsViewModel.swift
@@ -81,6 +81,10 @@ public class OriginSettingsViewModel {
   @OriginPolicyBooleanValue(key: .vpnDisabled)
   var isVPNDisabled: Bool
 
+  @ObservationIgnored
+  @OriginPolicyBooleanValue(key: .playlistEnabled)
+  var isPlaylistEnabled: Bool
+
   private(set) var isPuchaseLinkable: Bool = false
 
   @MainActor

--- a/ios/browser/brave_origin/brave_origin_service_bridge.h
+++ b/ios/browser/brave_origin/brave_origin_service_bridge.h
@@ -19,6 +19,7 @@ OBJC_EXPORT BraveOriginPolicyKey const BraveOriginPolicyKeyNewsDisabled;
 OBJC_EXPORT BraveOriginPolicyKey const BraveOriginPolicyKeyVPNDisabled;
 OBJC_EXPORT BraveOriginPolicyKey const BraveOriginPolicyKeyP3AEnabled;
 OBJC_EXPORT BraveOriginPolicyKey const BraveOriginPolicyKeyStatsPingEnabled;
+OBJC_EXPORT BraveOriginPolicyKey const BraveOriginPolicyKeyPlaylistEnabled;
 
 NS_SWIFT_NAME(BraveOriginService)
 @protocol BraveOriginServiceBridge

--- a/ios/browser/brave_origin/brave_origin_service_bridge.mm
+++ b/ios/browser/brave_origin/brave_origin_service_bridge.mm
@@ -24,3 +24,5 @@ BraveOriginPolicyKey const BraveOriginPolicyKeyP3AEnabled =
     base::SysUTF8ToNSString(policy::key::kBraveP3AEnabled);
 BraveOriginPolicyKey const BraveOriginPolicyKeyStatsPingEnabled =
     base::SysUTF8ToNSString(policy::key::kBraveStatsPingEnabled);
+BraveOriginPolicyKey const BraveOriginPolicyKeyPlaylistEnabled =
+    base::SysUTF8ToNSString(policy::key::kBravePlaylistEnabled);

--- a/ios/browser/brave_origin/brave_origin_service_factory.mm
+++ b/ios/browser/brave_origin/brave_origin_service_factory.mm
@@ -21,6 +21,7 @@
 #include "brave/components/brave_vpn/common/buildflags/buildflags.h"
 #include "brave/components/constants/pref_names.h"
 #include "brave/components/p3a/pref_names.h"
+#include "brave/components/playlist/core/common/pref_names.h"
 #include "brave/ios/browser/policy/brave_simple_policy_map_ios.h"
 #include "brave/ios/browser/skus/skus_service_factory.h"
 #include "components/keyed_service/core/keyed_service.h"
@@ -139,6 +140,12 @@ constexpr auto kBraveOriginProfileMetadata =
              true,
              /*user_settable=*/false)},
 #endif
+
+        // Playlist preferences
+        {playlist::kPlaylistEnabledPref,
+         BraveOriginServiceFactory::BraveOriginPrefMetadata(
+             false,
+             /*user_settable=*/false)},
     });
 
 }  // namespace


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/54992

### Test
- Purchase Origin
- Verify Playlist is automatically disabled/hidden
- Verify Playlist can be enabled/disabled from Origin settings (see: https://github.com/brave/brave-browser/issues/49011)