### PR TITLE
[iOS] Migrate youtube quality preference to Chromium

### DIFF
--- a/ios/BUILD.gn
+++ b/ios/BUILD.gn
@@ -128,6 +128,7 @@ brave_core_public_headers = [
   "//brave/ios/browser/web/logins/logins_tab_helper_bridge.h",
   "//brave/ios/browser/brave_talk/brave_talk_tab_helper_bridge.h",
   "//ios/chrome/browser/web/model/print/print_handler.h",
+  "//brave/ios/browser/youtube/youtube_pref_names_bridge.h",
 ]
 
 brave_core_public_headers += ads_public_headers

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/YoutubeQualityTabHelper.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/YoutubeQualityTabHelper.swift
@@ -3,6 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import BraveCore
 import BraveShared
 import BraveUI
 import Combine
@@ -25,19 +26,24 @@ extension TabDataValues {
 }
 
 @MainActor
-class YoutubeQualityTabHelper: NSObject, TabObserver, PreferencesObserver {
+class YoutubeQualityTabHelper: NSObject, TabObserver {
   private var url: URL?
   private weak var tab: (any TabState)?
+  private let prefChangeRegistrar: PrefChangeRegistrar
 
-  public init(tab: (any TabState)?) {
+  public init(tab: some TabState) {
     self.tab = tab
-    self.url = tab?.visibleURL
+    self.url = tab.visibleURL
+    prefChangeRegistrar = .init(prefService: tab.profile.prefs)
+
     super.init()
 
-    tab?.addObserver(self)
+    tab.addObserver(self)
     self.observeReachability()
 
-    Preferences.General.youtubeHighQuality.observe(from: self)
+    prefChangeRegistrar.addObserver(forPath: kYouTubeAutoQualityMode) { [weak self] _ in
+      self?.setHighQuality(networkStatus: Reachability.shared.status)
+    }
   }
 
   private func observeReachability() {
@@ -51,8 +57,12 @@ class YoutubeQualityTabHelper: NSObject, TabObserver, PreferencesObserver {
   }
 
   private func setHighQuality(networkStatus: Reachability.Status) {
-    let enabled = YoutubeQualityTabHelper.canEnableHighQuality(connectionStatus: networkStatus)
-    tab?.evaluateJavaScript(
+    guard let tab else { return }
+    let enabled = YoutubeQualityTabHelper.canEnableHighQuality(
+      tab: tab,
+      connectionStatus: networkStatus
+    )
+    tab.evaluateJavaScript(
       functionName: "window.__firefox__.\(YoutubeQualityScriptHandler.setQuality)",
       args: [enabled ? YoutubeQualityScriptHandler.highestQuality : "'auto'"],
       contentWorld: YoutubeQualityScriptHandler.scriptSandbox,
@@ -61,10 +71,13 @@ class YoutubeQualityTabHelper: NSObject, TabObserver, PreferencesObserver {
     )
   }
 
-  static func canEnableHighQuality(connectionStatus: Reachability.Status) -> Bool {
+  static func canEnableHighQuality(
+    tab: some TabState,
+    connectionStatus: Reachability.Status
+  ) -> Bool {
     guard
       let qualityPreference = YoutubeHighQualityPreference(
-        rawValue: Preferences.General.youtubeHighQuality.value
+        rawValue: tab.profile.prefs.integer(forPath: kYouTubeAutoQualityMode)
       )
     else {
       return false
@@ -104,11 +117,5 @@ class YoutubeQualityTabHelper: NSObject, TabObserver, PreferencesObserver {
 
   func tabWillBeDestroyed(_ tab: some TabState) {
     tab.removeObserver(self)
-  }
-
-  // MAKR: - PreferencesObserver
-
-  func preferencesDidChange(for key: String) {
-    setHighQuality(networkStatus: Reachability.shared.status)
   }
 }

--- a/ios/brave-ios/Sources/Brave/Frontend/ClientPreferences.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/ClientPreferences.swift
@@ -83,11 +83,6 @@ extension Preferences {
       key: "general.media-auto-backgrounding",
       default: false
     )
-    /// Controls whether or not youtube videos should play with the highest quality by default
-    static let youtubeHighQuality = Option<String>(
-      key: "general.youtube-high-quality",
-      default: YoutubeHighQualityPreference.off.rawValue
-    )
     /// Controls whether or not to show the last visited bookmarks folder
     static let showLastVisitedBookmarksFolder = Option<Bool>(
       key: "general.bookmarks-show-last-visited-bookmarks-folder",

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/Display/MediaSettingsView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/Display/MediaSettingsView.swift
@@ -18,6 +18,8 @@ struct MediaSettingsView: View {
   @State var youtubeDistractingElementsBlocking = false
   @State var youtubeShortsBlocking = false
 
+  var prefs: any PrefService
+
   var body: some View {
     Form {
       Section(header: Text(Strings.Settings.mediaGeneralSection)) {
@@ -33,7 +35,7 @@ struct MediaSettingsView: View {
           Text(Strings.Settings.openYouTubeInBrave)
         }
         .toggleStyle(SwitchToggleStyle(tint: .accentColor))
-        NavigationLink(destination: QualitySettingsView()) {
+        NavigationLink(destination: QualitySettingsView(prefs: prefs)) {
           VStack(alignment: .leading) {
             Text(Strings.Settings.highestQualityPlayback)
             Text(Strings.Settings.highestQualityPlaybackDetail)
@@ -129,14 +131,18 @@ struct MediaSettingsView: View {
 
 private struct QualitySettingsView: View {
   @Environment(\.presentationMode) @Binding var presentationMode
-  @ObservedObject var qualityOption = Preferences.General.youtubeHighQuality
+
+  var prefs: any PrefService
 
   var body: some View {
     Form {
       Section(header: Text(Strings.Settings.qualitySettings)) {
         Button(
           action: {
-            qualityOption.value = YoutubeHighQualityPreference.on.rawValue
+            prefs.set(
+              YoutubeHighQualityPreference.on.rawValue,
+              forPath: kYouTubeAutoQualityMode
+            )
             presentationMode.dismiss()
           },
           label: {
@@ -146,7 +152,10 @@ private struct QualitySettingsView: View {
 
         Button(
           action: {
-            qualityOption.value = YoutubeHighQualityPreference.wifi.rawValue
+            prefs.set(
+              YoutubeHighQualityPreference.wifi.rawValue,
+              forPath: kYouTubeAutoQualityMode
+            )
             presentationMode.dismiss()
           },
           label: {
@@ -156,7 +165,10 @@ private struct QualitySettingsView: View {
 
         Button(
           action: {
-            qualityOption.value = YoutubeHighQualityPreference.off.rawValue
+            prefs.set(
+              YoutubeHighQualityPreference.off.rawValue,
+              forPath: kYouTubeAutoQualityMode
+            )
             presentationMode.dismiss()
           },
           label: {
@@ -175,17 +187,17 @@ private struct QualitySettingsView: View {
       Text(preference.displayString)
         .foregroundColor(Color(.braveLabel))
       Spacer()
-      if Preferences.General.youtubeHighQuality.value == preference.rawValue {
+      if prefs.integer(forPath: kYouTubeAutoQualityMode) == preference.rawValue {
         Image(braveSystemName: "leo.check.normal")
       }
     }
   }
 }
 
-enum YoutubeHighQualityPreference: String, CaseIterable {
-  case wifi
-  case on
+enum YoutubeHighQualityPreference: Int, CaseIterable {
   case off
+  case on
+  case wifi
 }
 
 extension YoutubeHighQualityPreference: RepresentableOptionType {
@@ -197,11 +209,3 @@ extension YoutubeHighQualityPreference: RepresentableOptionType {
     }
   }
 }
-
-#if DEBUG
-struct MediaSettingsView_Previews: PreviewProvider {
-  static var previews: some View {
-    MediaSettingsView()
-  }
-}
-#endif

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/SettingsViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/SettingsViewController.swift
@@ -1056,7 +1056,7 @@ class SettingsViewController: TableViewController {
       .init(
         text: Strings.Settings.mediaRootSetting,
         selection: { [unowned self] in
-          let vc = UIHostingController(rootView: MediaSettingsView())
+          let vc = UIHostingController(rootView: MediaSettingsView(prefs: braveCore.profile.prefs))
           self.navigationController?.pushViewController(vc, animated: true)
         },
         image: UIImage(braveSystemNamed: "leo.media.player"),

--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/YoutubeQualityScriptHandler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/YoutubeQualityScriptHandler.swift
@@ -54,7 +54,10 @@ class YoutubeQualityScriptHandler: NSObject, TabContentScript {
     }
 
     replyHandler(
-      YoutubeQualityTabHelper.canEnableHighQuality(connectionStatus: Reachability.shared.status)
+      YoutubeQualityTabHelper.canEnableHighQuality(
+        tab: tab,
+        connectionStatus: Reachability.shared.status
+      )
         ? Self.highestQuality : "",
       nil
     )

--- a/ios/brave-ios/Sources/Brave/Migration/Migration.swift
+++ b/ios/brave-ios/Sources/Brave/Migration/Migration.swift
@@ -27,6 +27,7 @@ public class BraveProfileMigrations {
     migrateBlockPopupsPreferences()
     migrateSyncPasswordsDefault()
     migrateShieldsToContentSettings()
+    migrateYouTubeQualityPreference()
   }
 
   private func migrateDefaultUserAgentPreferences() {
@@ -98,6 +99,18 @@ public class BraveProfileMigrations {
     // disabled to enabled. Keep them on the old `defaultValue`
     Preferences.Chromium.syncPasswordsEnabled.value = false
     Preferences.Migration.syncPasswordsEnabledByDefault.value = true
+  }
+
+  private func migrateYouTubeQualityPreference() {
+    Preferences.DeprecatedPreferences.youtubeHighQuality.migrate { value in
+      let value = DeprecatedYoutubeHighQualityPreference(rawValue: value)
+      if value != .off {
+        profileController.profile.prefs.set(
+          value == .on ? 1 : 2,
+          forPath: kYouTubeAutoQualityMode
+        )
+      }
+    }
   }
 }
 
@@ -278,6 +291,12 @@ extension Migration {
   }
 }
 
+private enum DeprecatedYoutubeHighQualityPreference: String {
+  case wifi
+  case on
+  case off
+}
+
 extension Preferences {
   fileprivate final class DeprecatedPreferences {
     static let sendUsagePing = Option<Bool>(key: "dau.send-usage-ping", default: true)
@@ -320,6 +339,12 @@ extension Preferences {
 
     /// Whether or not to block popups from websites automaticaly
     static let blockPopups = Option<Bool>(key: "general.block-popups", default: true)
+
+    /// Controls whether or not youtube videos should play with the highest quality by default
+    static let youtubeHighQuality = Option<String>(
+      key: "general.youtube-high-quality",
+      default: DeprecatedYoutubeHighQualityPreference.off.rawValue
+    )
   }
 
   /// Migration preferences
@@ -585,7 +610,8 @@ extension Preferences {
       return
     }
 
-    Preferences.General.youtubeHighQuality.value = YoutubeHighQualityPreference.off.rawValue
+    Preferences.DeprecatedPreferences.youtubeHighQuality.value =
+      DeprecatedYoutubeHighQualityPreference.off.rawValue
     Migration.youtubeHighQualityDefault.value = true
   }
 }

--- a/ios/browser/shared/prefs/BUILD.gn
+++ b/ios/browser/shared/prefs/BUILD.gn
@@ -33,6 +33,7 @@ source_set("prefs") {
     "//brave/components/playlist/core/common",
     "//brave/components/skus/browser",
     "//brave/ios/browser/brave_stats",
+    "//brave/ios/browser/youtube",
     "//components/omnibox/browser",
     "//components/pref_registry",
     "//components/prefs",

--- a/ios/browser/shared/prefs/browser_prefs_impl.mm
+++ b/ios/browser/shared/prefs/browser_prefs_impl.mm
@@ -32,6 +32,7 @@
 #include "brave/components/playlist/core/common/pref_names.h"
 #include "brave/components/skus/browser/skus_utils.h"
 #include "brave/ios/browser/brave_stats/brave_stats_prefs.h"
+#include "brave/ios/browser/youtube/pref_names.h"
 #include "components/pref_registry/pref_registry_syncable.h"
 
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
@@ -83,6 +84,8 @@ void RegisterBrowserStatePrefs(user_prefs::PrefRegistrySyncable* registry) {
   registry->RegisterBooleanPref(brave_vpn::prefs::kManagedBraveVPNDisabled,
                                 false);
 #endif
+
+  registry->RegisterIntegerPref(youtube::prefs::kAutoQualityMode, 0);
 }
 
 void RegisterLocalStatePrefs(PrefRegistrySimple* registry) {

--- a/ios/browser/youtube/BUILD.gn
+++ b/ios/browser/youtube/BUILD.gn
@@ -1,0 +1,13 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+source_set("youtube") {
+  sources = [
+    "pref_names.h",
+    "youtube_pref_names_bridge.h",
+    "youtube_pref_names_bridge.mm",
+  ]
+  deps = [ "//base" ]
+}

--- a/ios/browser/youtube/pref_names.h
+++ b/ios/browser/youtube/pref_names.h
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_IOS_BROWSER_YOUTUBE_PREF_NAMES_H_
+#define BRAVE_IOS_BROWSER_YOUTUBE_PREF_NAMES_H_
+
+namespace youtube {
+
+enum class AutoQualityMode {
+  // Video quality will remain automatic when visiting YouTube video pages
+  kOff = 0,
+  // YouTube video quality will always be set to the highest quality
+  kOn = 1,
+  // YouTube video quality will only ever be set to the highest quality if the
+  // user is on a wifi network. If the user drops to a cellular network while
+  // on a page it will update the quality back to `auto`
+  kWifiOnly = 2
+};
+
+namespace prefs {
+
+inline constexpr char kAutoQualityMode[] = "youtube_auto_quality_mode";
+
+}
+
+}  // namespace youtube
+
+#endif  // BRAVE_IOS_BROWSER_YOUTUBE_PREF_NAMES_H_

--- a/ios/browser/youtube/youtube_pref_names_bridge.h
+++ b/ios/browser/youtube/youtube_pref_names_bridge.h
@@ -1,0 +1,17 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_IOS_BROWSER_YOUTUBE_YOUTUBE_PREF_NAMES_BRIDGE_H_
+#define BRAVE_IOS_BROWSER_YOUTUBE_YOUTUBE_PREF_NAMES_BRIDGE_H_
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+OBJC_EXPORT NSString* const kYouTubeAutoQualityMode;
+
+NS_ASSUME_NONNULL_END
+
+#endif  // BRAVE_IOS_BROWSER_YOUTUBE_YOUTUBE_PREF_NAMES_BRIDGE_H_

--- a/ios/browser/youtube/youtube_pref_names_bridge.mm
+++ b/ios/browser/youtube/youtube_pref_names_bridge.mm
@@ -1,0 +1,12 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/ios/browser/youtube/youtube_pref_names_bridge.h"
+
+#include "base/strings/sys_string_conversions.h"
+#include "brave/ios/browser/youtube/pref_names.h"
+
+NSString* const kYouTubeAutoQualityMode =
+    base::SysUTF8ToNSString(youtube::prefs::kAutoQualityMode);


### PR DESCRIPTION
This migrates the media preference that controls whether or not we automatically set youtube videos to the highest quality to Chromium's preferences. This is required to implement the same JavaScript feature when using profile web view configurations.

Resolves https://github.com/brave/brave-browser/issues/54803

### Test
- Test an upgrade flow where the old build has the "Highest Quality Playback" setting in Settings > Media set to "On", "Allow over Wi-Fi", and "Off" and verify after upgrade the setting still shows the same value
- Sanity test youtube auto-highest quality feature works correctly

