### PR TITLE
[iOS] Add Youtube video quality JavaScriptFeature

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabManagerDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabManagerDelegate.swift
@@ -26,7 +26,9 @@ extension BrowserViewController: TabManagerDelegate {
     if tab.profile.prefs.isPlaylistAvailable {
       tab.playlist = .init(tab: tab)
     }
-    tab.youtubeQualityTabHelper = .init(tab: tab)
+    if !FeatureList.kUseProfileWebViewConfiguration.enabled {
+      tab.youtubeQualityTabHelper = .init(tab: tab)
+    }
     SnackBarTabHelper.create(for: tab)
     tab.braveUserAgentExceptions = braveCore.braveUserAgentExceptions
     if FeatureList.kUseProfileWebViewConfiguration.enabled {

--- a/ios/browser/api/web_view/BUILD.gn
+++ b/ios/browser/api/web_view/BUILD.gn
@@ -44,6 +44,7 @@ source_set("web_view") {
     "//brave/ios/browser/web/logins",
     "//brave/ios/browser/web/page_metadata",
     "//brave/ios/browser/web/reader_mode",
+    "//brave/ios/browser/youtube",
     "//brave/ios/web_view",
     "//components/favicon/core",
     "//ios/chrome/browser/affiliations/model",

--- a/ios/browser/api/web_view/brave_web_view.mm
+++ b/ios/browser/api/web_view/brave_web_view.mm
@@ -34,6 +34,7 @@
 #include "brave/ios/browser/web/logins/logins_tab_helper_bridge.h"
 #include "brave/ios/browser/web/page_metadata/page_metadata_javascript_feature.h"
 #include "brave/ios/browser/web/reader_mode/reader_mode_javascript_feature.h"
+#include "brave/ios/browser/youtube/youtube_network_change_observer.h"
 #include "components/autofill/core/browser/logging/log_manager.h"
 #include "components/autofill/core/browser/logging/log_router.h"
 #include "components/autofill/ios/browser/autofill_agent.h"
@@ -374,6 +375,8 @@ class FaviconDriverObserver : public favicon::FaviconDriverObserver {
         self.webState,
         ios::FaviconServiceFactory::GetForProfile(
             profile->GetOriginalProfile(), ServiceAccessType::IMPLICIT_ACCESS));
+
+    youtube::YouTubeNetworkChangeObserver::CreateForWebState(self.webState);
   }
 }
 

--- a/ios/browser/web/BUILD.gn
+++ b/ios/browser/web/BUILD.gn
@@ -37,6 +37,7 @@ source_set("web") {
     "//brave/ios/browser/web/night_mode",
     "//brave/ios/browser/web/page_metadata",
     "//brave/ios/browser/web/reader_mode",
+    "//brave/ios/browser/youtube",
     "//brave/ios/web/js_messaging",
     "//components/component_updater/installer_policies",
     "//components/language/ios/browser",

--- a/ios/browser/web/brave_web_client.mm
+++ b/ios/browser/web/brave_web_client.mm
@@ -29,6 +29,7 @@
 #include "brave/ios/browser/web/night_mode/night_mode_javascript_feature.h"
 #include "brave/ios/browser/web/page_metadata/page_metadata_javascript_feature.h"
 #include "brave/ios/browser/web/reader_mode/reader_mode_javascript_feature.h"
+#include "brave/ios/browser/youtube/youtube_quality_javascript_feature.h"
 #include "brave/ios/web/js_messaging/safe_builtins_javascript_feature.h"
 #include "components/autofill/ios/browser/autofill_java_script_feature.h"
 #include "components/autofill/ios/browser/suggestion_controller_java_script_feature.h"
@@ -143,6 +144,7 @@ std::vector<web::JavaScriptFeature*> BraveWebClient::GetJavaScriptFeatures(
     features.push_back(NightModeJavaScriptFeature::GetInstance());
     features.push_back(PageMetadataJavaScriptFeature::GetInstance());
     features.push_back(brave::ReaderModeJavaScriptFeature::GetInstance());
+    features.push_back(youtube::YouTubeQualityJavaScriptFeature::GetInstance());
     if (!base::FeatureList::IsEnabled(
             brave::features::kUseChromiumWebViewsAutofill)) {
       features.push_back(LoginsJavaScriptFeature::GetInstance());

--- a/ios/browser/youtube/BUILD.gn
+++ b/ios/browser/youtube/BUILD.gn
@@ -3,11 +3,56 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import("//ios/web/public/js_messaging/optimize_ts.gni")
+
 source_set("youtube") {
   sources = [
     "pref_names.h",
+    "youtube_network_change_observer.h",
+    "youtube_network_change_observer.mm",
     "youtube_pref_names_bridge.h",
     "youtube_pref_names_bridge.mm",
+    "youtube_quality_javascript_feature.h",
+    "youtube_quality_javascript_feature.mm",
   ]
-  deps = [ "//base" ]
+  deps = [
+    ":yt_video_quality_event_listeners_js",
+    ":yt_video_quality_js",
+    "//components/prefs",
+    "//ios/chrome/browser/shared/model/profile",
+    "//url",
+  ]
+  public_deps = [
+    "//base",
+    "//ios/web/public",
+    "//ios/web/public/js_messaging",
+    "//net",
+  ]
+}
+
+compile_ts("yt_video_quality_utils") {
+  sources = [ "resources/yt_video_quality_utils.ts" ]
+  deps = [ "//ios/web/public/js_messaging:util_scripts" ]
+}
+
+optimize_ts("yt_video_quality_js") {
+  visibility = [ ":youtube" ]
+
+  sources = [ "resources/yt_video_quality.ts" ]
+
+  deps = [
+    ":yt_video_quality_utils",
+    "//ios/web/public/js_messaging:gcrweb",
+  ]
+}
+
+optimize_ts("yt_video_quality_event_listeners_js") {
+  visibility = [ ":youtube" ]
+
+  sources = [ "resources/yt_video_quality_event_listeners.ts" ]
+
+  deps = [
+    ":yt_video_quality_utils",
+    "//ios/web/public/js_messaging:util_scripts",
+  ]
 }

--- a/ios/browser/youtube/resources/yt_video_quality.ts
+++ b/ios/browser/youtube/resources/yt_video_quality.ts
@@ -1,0 +1,13 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import {CrWebApi, gCrWeb} from
+    '//ios/web/public/js_messaging/resources/gcrweb.js';
+import {resetQuality} from
+    '//brave/ios/browser/youtube/resources/yt_video_quality_utils.js';
+
+const youtubeQualityApi = new CrWebApi('youtubeQuality');
+youtubeQualityApi.addFunction('resetQuality', resetQuality);
+gCrWeb.registerApi(youtubeQualityApi);

--- a/ios/browser/youtube/resources/yt_video_quality_event_listeners.ts
+++ b/ios/browser/youtube/resources/yt_video_quality_event_listeners.ts
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import {functionAsListener} from '//ios/web/public/js_messaging/resources/utils.js';
+import {requestVideoQualityPreference} from
+    '//brave/ios/browser/youtube/resources/yt_video_quality_utils.js';
+
+const allowedOrigins = [
+  'https://youtube.com',
+  'https://www.youtube.com',
+  'https://m.youtube.com',
+];
+
+if (allowedOrigins.includes(window.location.origin)) {
+  const listener = functionAsListener(requestVideoQualityPreference);
+
+  // Apply quality when the video element finishes loading data (covers the
+  // initial load as well as mid-session source changes).
+  document.addEventListener('loadeddata', listener, {capture: true});
+
+  // YouTube uses History API (pushState) for in-app navigation. The page
+  // dispatches 'yt-navigate-finish' on document when each navigation
+  // settles.
+  document.addEventListener('yt-navigate-finish', listener);
+
+  // Attempt to apply the highest quality immediately
+  requestVideoQualityPreference();
+}

--- a/ios/browser/youtube/resources/yt_video_quality_utils.ts
+++ b/ios/browser/youtube/resources/yt_video_quality_utils.ts
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import {sendWebKitMessageWithReply} from
+    '//ios/web/public/js_messaging/resources/utils.js';
+
+function findPlayer(): any {
+  return document.getElementById('movie_player') ||
+      document.querySelector('.html5-video-player');
+}
+
+export function applyHighestQuality(): void {
+  const player = findPlayer();
+  if (!player || typeof player.getAvailableQualityLevels === 'undefined' ||
+      !player.setPlaybackQualityRange) {
+    return;
+  }
+  const qualities: string[] = player.getAvailableQualityLevels();
+  if (qualities && qualities.length > 0) {
+    player.setPlaybackQualityRange(qualities[0], qualities[0]);
+  }
+}
+
+export function resetQuality(): void {
+  const player = findPlayer();
+  if (!player || !player.setPlaybackQualityRange) {
+    return;
+  }
+  player.setPlaybackQualityRange('auto', 'auto');
+}
+
+export function requestVideoQualityPreference() {
+  sendWebKitMessageWithReply('YouTubeQualityMessageHandler', {})
+    .then((shouldApplyHighestQuality: boolean) => {
+      if (shouldApplyHighestQuality) {
+        applyHighestQuality();
+      }
+    });
+}

--- a/ios/browser/youtube/youtube_network_change_observer.h
+++ b/ios/browser/youtube/youtube_network_change_observer.h
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_IOS_BROWSER_YOUTUBE_YOUTUBE_NETWORK_CHANGE_OBSERVER_H_
+#define BRAVE_IOS_BROWSER_YOUTUBE_YOUTUBE_NETWORK_CHANGE_OBSERVER_H_
+
+#include "base/memory/raw_ptr.h"
+#include "ios/web/public/web_state_user_data.h"
+#include "net/base/network_change_notifier.h"
+
+namespace web {
+class WebState;
+}
+
+namespace youtube {
+
+// A network change observer that observes when a users network drops to a
+// cellular connection to possibly reset a youtube pages video quality back to
+// auto.
+class YouTubeNetworkChangeObserver
+    : public web::WebStateUserData<YouTubeNetworkChangeObserver>,
+      public net::NetworkChangeNotifier::NetworkChangeObserver {
+ public:
+  ~YouTubeNetworkChangeObserver() override;
+
+  void OnNetworkChanged(
+      net::NetworkChangeNotifier::ConnectionType type) override;
+
+ private:
+  friend class web::WebStateUserData<YouTubeNetworkChangeObserver>;
+  explicit YouTubeNetworkChangeObserver(web::WebState* web_state);
+
+  raw_ptr<web::WebState> web_state_;
+};
+
+}  // namespace youtube
+
+#endif  // BRAVE_IOS_BROWSER_YOUTUBE_YOUTUBE_NETWORK_CHANGE_OBSERVER_H_

--- a/ios/browser/youtube/youtube_network_change_observer.mm
+++ b/ios/browser/youtube/youtube_network_change_observer.mm
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/ios/browser/youtube/youtube_network_change_observer.h"
+
+#include "base/containers/fixed_flat_set.h"
+#include "brave/ios/browser/youtube/pref_names.h"
+#include "brave/ios/browser/youtube/youtube_quality_javascript_feature.h"
+#include "components/prefs/pref_service.h"
+#include "ios/chrome/browser/shared/model/profile/profile_ios.h"
+#include "ios/web/public/web_state.h"
+#include "net/base/network_change_notifier.h"
+
+namespace youtube {
+
+namespace {
+constexpr auto kAllowedHosts = base::MakeFixedFlatSet<std::string_view>(
+    {"m.youtube.com", "www.youtube.com", "youtube.com"});
+}
+
+YouTubeNetworkChangeObserver::YouTubeNetworkChangeObserver(
+    web::WebState* web_state)
+    : web_state_(web_state) {
+  net::NetworkChangeNotifier::AddNetworkChangeObserver(this);
+}
+
+YouTubeNetworkChangeObserver::~YouTubeNetworkChangeObserver() {
+  net::NetworkChangeNotifier::RemoveNetworkChangeObserver(this);
+}
+
+void YouTubeNetworkChangeObserver::OnNetworkChanged(
+    net::NetworkChangeNotifier::ConnectionType type) {
+  if (web_state_->IsBeingDestroyed()) {
+    return;
+  }
+  bool is_youtube =
+      kAllowedHosts.contains(web_state_->GetLastCommittedURL().host());
+  if (is_youtube && net::NetworkChangeNotifier::IsConnectionCellular(type)) {
+    PrefService* prefs =
+        ProfileIOS::FromBrowserState(web_state_->GetBrowserState())->GetPrefs();
+    AutoQualityMode mode = static_cast<AutoQualityMode>(
+        prefs->GetInteger(prefs::kAutoQualityMode));
+    if (mode == AutoQualityMode::kWifiOnly) {
+      YouTubeQualityJavaScriptFeature::GetInstance()->ResetQuality(web_state_);
+    }
+  }
+}
+
+}  // namespace youtube

--- a/ios/browser/youtube/youtube_quality_javascript_feature.h
+++ b/ios/browser/youtube/youtube_quality_javascript_feature.h
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_IOS_BROWSER_YOUTUBE_YOUTUBE_QUALITY_JAVASCRIPT_FEATURE_H_
+#define BRAVE_IOS_BROWSER_YOUTUBE_YOUTUBE_QUALITY_JAVASCRIPT_FEATURE_H_
+
+#include <optional>
+#include <string>
+
+#include "base/no_destructor.h"
+#include "ios/web/public/js_messaging/java_script_feature.h"
+
+namespace web {
+class WebState;
+}  // namespace web
+
+namespace youtube {
+
+// A JavaScriptFeature that injects YouTube enhancement scripts into YouTube
+// pages. It handles video quality control by replying to boolean quality
+// queries from the page — whether to pin playback to the highest available
+// level or use automatic quality selection.
+class YouTubeQualityJavaScriptFeature : public web::JavaScriptFeature {
+ public:
+  // This feature holds no state, so only a single static instance is ever
+  // needed.
+  static YouTubeQualityJavaScriptFeature* GetInstance();
+
+  // Reverts the playback quality on the main frame of |web_state| to YouTube's
+  // automatic quality selection. Intended for use when a network condition
+  // change (e.g. leaving Wi-Fi) makes the current quality preference no longer
+  // applicable.
+  void ResetQuality(web::WebState* web_state);
+
+  // JavaScriptFeature:
+  bool GetFeatureRepliesToMessages() const override;
+  std::optional<std::string> GetScriptMessageHandlerName() const override;
+  void ScriptMessageReceivedWithReply(
+      web::WebState* web_state,
+      const web::ScriptMessage& message,
+      ScriptMessageReplyCallback callback) override;
+
+ private:
+  friend class base::NoDestructor<YouTubeQualityJavaScriptFeature>;
+
+  YouTubeQualityJavaScriptFeature();
+  ~YouTubeQualityJavaScriptFeature() override;
+
+  YouTubeQualityJavaScriptFeature(const YouTubeQualityJavaScriptFeature&) =
+      delete;
+  YouTubeQualityJavaScriptFeature& operator=(
+      const YouTubeQualityJavaScriptFeature&) = delete;
+};
+
+}  // namespace youtube
+
+#endif  // BRAVE_IOS_BROWSER_YOUTUBE_YOUTUBE_QUALITY_JAVASCRIPT_FEATURE_H_

--- a/ios/browser/youtube/youtube_quality_javascript_feature.mm
+++ b/ios/browser/youtube/youtube_quality_javascript_feature.mm
@@ -1,0 +1,105 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/ios/browser/youtube/youtube_quality_javascript_feature.h"
+
+#include <optional>
+#include <string>
+
+#include "base/containers/fixed_flat_set.h"
+#include "base/no_destructor.h"
+#include "base/values.h"
+#include "brave/ios/browser/youtube/pref_names.h"
+#include "brave/ios/browser/youtube/youtube_network_change_observer.h"
+#include "components/prefs/pref_service.h"
+#include "ios/chrome/browser/shared/model/profile/profile_ios.h"
+#include "ios/web/public/js_messaging/script_message.h"
+#include "ios/web/public/js_messaging/web_frame.h"
+#include "ios/web/public/js_messaging/web_frames_manager.h"
+#include "ios/web/public/web_state.h"
+#include "net/base/network_change_notifier.h"
+#include "url/gurl.h"
+
+namespace youtube {
+
+namespace {
+
+constexpr char kScriptName[] = "yt_video_quality";
+constexpr char kEventListenersScriptName[] = "yt_video_quality_event_listeners";
+constexpr char kScriptHandlerName[] = "YouTubeQualityMessageHandler";
+constexpr auto kAllowedHosts = base::MakeFixedFlatSet<std::string_view>(
+    {"m.youtube.com", "www.youtube.com", "youtube.com"});
+
+}  // namespace
+
+YouTubeQualityJavaScriptFeature::YouTubeQualityJavaScriptFeature()
+    : JavaScriptFeature(
+          web::ContentWorld::kPageContentWorld,
+          {FeatureScript::CreateWithFilename(
+               kScriptName,
+               FeatureScript::InjectionTime::kDocumentStart,
+               FeatureScript::TargetFrames::kMainFrame,
+               FeatureScript::ReinjectionBehavior::kInjectOncePerWindow),
+           FeatureScript::CreateWithFilename(
+               kEventListenersScriptName,
+               FeatureScript::InjectionTime::kDocumentStart,
+               FeatureScript::TargetFrames::kMainFrame,
+               FeatureScript::ReinjectionBehavior::
+                   kReinjectOnDocumentRecreation)}) {}
+
+YouTubeQualityJavaScriptFeature::~YouTubeQualityJavaScriptFeature() = default;
+
+// static
+YouTubeQualityJavaScriptFeature*
+YouTubeQualityJavaScriptFeature::GetInstance() {
+  static base::NoDestructor<YouTubeQualityJavaScriptFeature> instance;
+  return instance.get();
+}
+
+void YouTubeQualityJavaScriptFeature::ResetQuality(web::WebState* web_state) {
+  web::WebFrame* main_frame = GetWebFramesManager(web_state)->GetMainWebFrame();
+  if (!main_frame) {
+    return;
+  }
+  CallJavaScriptFunction(main_frame, "youtubeQuality.resetQuality",
+                         base::ListValue());
+}
+
+bool YouTubeQualityJavaScriptFeature::GetFeatureRepliesToMessages() const {
+  return true;
+}
+
+std::optional<std::string>
+YouTubeQualityJavaScriptFeature::GetScriptMessageHandlerName() const {
+  return kScriptHandlerName;
+}
+
+void YouTubeQualityJavaScriptFeature::ScriptMessageReceivedWithReply(
+    web::WebState* web_state,
+    const web::ScriptMessage& message,
+    ScriptMessageReplyCallback callback) {
+  GURL request_url = message.request_url().value_or(GURL());
+
+  if (!message.is_main_frame() || !request_url.is_valid() ||
+      !kAllowedHosts.contains(request_url.host())) {
+    std::move(callback).Run(nullptr, nil);
+    return;
+  }
+
+  PrefService* prefs =
+      ProfileIOS::FromBrowserState(web_state->GetBrowserState())->GetPrefs();
+  AutoQualityMode mode = static_cast<youtube::AutoQualityMode>(
+      prefs->GetInteger(prefs::kAutoQualityMode));
+  bool should_set_highest_quality =
+      mode == youtube::AutoQualityMode::kOn ||
+      (mode == youtube::AutoQualityMode::kWifiOnly &&
+       !net::NetworkChangeNotifier::IsConnectionCellular(
+           net::NetworkChangeNotifier::GetConnectionType()));
+
+  const base::Value reply(should_set_highest_quality);
+  std::move(callback).Run(&reply, nil);
+}
+
+}  // namespace youtube


### PR DESCRIPTION
This adds a JavaScriptFeature that enables the auto highest quality video feature on YouTube videos when using the `UseProfileWebViewConfiguration` feature flag

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/54806

### Test
Verify that YouTube quality upgrade feature (Media > Highest Quality Playback) works as usual depending on your setting

1. Enable the `UseProfileWebViewConfiguration` flag
2. Visit youtube on a phone and load a video, verify it starts as "auto" quality (the default)
3. Turn `Highest Quality Playback` preference to `On` and reload
4. Verify same video upgrades to the highest quality (typically 1080p)
5. Turn `Highest Quality Playback` preference to `Only on Wi-Fi` and reload
6. Verify same video upgrades to the highest quality (typically 1080p)
7. Disable Wi-Fi and drop to cellular
8. Verify video downgrades back to 'auto'