### PR TITLE
[iOS] Enable smooth scrolling in BraveWebClient

### DIFF
--- a/ios/browser/web/brave_web_client.h
+++ b/ios/browser/web/brave_web_client.h
@@ -62,6 +62,7 @@ class BraveWebClient : public ChromeWebClient {
 
   void DidResetConfiguration(web::BrowserState* browser_state,
                              WKWebViewConfiguration* configuration) override;
+  bool IsSmoothScrollingSupported() const override;
 
  private:
   std::string legacy_user_agent_;

--- a/ios/browser/web/brave_web_client.mm
+++ b/ios/browser/web/brave_web_client.mm
@@ -267,3 +267,7 @@ void BraveWebClient::DidResetConfiguration(web::BrowserState* browser_state,
     BraveWebView.didResetConfiguration(profile_bridge, config);
   }
 }
+
+bool BraveWebClient::IsSmoothScrollingSupported() const {
+  return true;
+}


### PR DESCRIPTION
Brave handles the web views frame while scrolling on the Swift side so we need to return true for the `IsSmoothScrollingSupported` web client method so that it doesn't automatically inset the web view by the safe area

```
Chromium change:
commit 0b9166658b79a5f788860e3e215165d8d26d73b1
Author: Gauthier Ambard <gambard@chromium.org>
Date:   Mon Mar 9 08:40:04 2026 -0700

    [iOS] Replace use of SmoothScrolling flag with the provider

    This is how it is supposed to be used. Make sure to move all the uses of
    the smooth scrolling flag at the same time to have a state where half
    the app is using the flag and the other app the provider.

    Also, updates the test to ensure they only run when the provider is
    returning true.

    The download manager test is updated as the tap was failing.

    Bug: 483998779
    Change-Id: Ic81a977ecbc0ebc131c49bd992511a97eb916abb
    Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7648409
    Reviewed-by: Aliona Dangla <alionadangla@chromium.org>
    Commit-Queue: Gauthier Ambard <gambard@chromium.org>
    Cr-Commit-Position: refs/heads/main@{#1596357}
```

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/54808
