### PR TITLE
Remove `sensitive` flag on `MetricsReportingEnabled` policy

### DIFF
--- a/patches/components-policy-resources-templates-policy_definitions-Miscellaneous-MetricsReportingEnabled.yaml.patch
+++ b/patches/components-policy-resources-templates-policy_definitions-Miscellaneous-MetricsReportingEnabled.yaml.patch
@@ -1,0 +1,12 @@
+diff --git a/components/policy/resources/templates/policy_definitions/Miscellaneous/MetricsReportingEnabled.yaml b/components/policy/resources/templates/policy_definitions/Miscellaneous/MetricsReportingEnabled.yaml
+index 31df634c993eda0a026459655dc7c2a4605ce694..2e40c7c2546f458a2f42b022bc5d5d2060d22427 100644
+--- a/components/policy/resources/templates/policy_definitions/Miscellaneous/MetricsReportingEnabled.yaml
++++ b/components/policy/resources/templates/policy_definitions/Miscellaneous/MetricsReportingEnabled.yaml
+@@ -27,7 +27,6 @@ owners:
+ - zmin@chromium.org
+ schema:
+   type: boolean
+-sensitive: true
+ supported_on:
+ - chrome.*:8-
+ - ios:88-


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/49357

Docs on the sensitive policy flag: https://source.chromium.org/chromium/chromium/src/+/main:components/policy/resources/new_policy_templates/policy.yaml;l=110-114
```
# Optional field that is `false` by default.
# When set to true, this policy is considered only if the user is part of a an
# an Active Directory domain on Windows, managed on the Mac, or enrolled in
# Chrome Enterprise Core.
```

Removing this restriction so users can set the policy value without needing a fully managed machine, like we already allow for our usage ping and P3A policies.