### PR TITLE
[AI Chat]: Make Code Block Header Sticky

### DIFF
--- a/components/ai_chat/resources/untrusted_conversation_frame/components/code_block/index.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/code_block/index.tsx
@@ -32,7 +32,7 @@ interface CodeBlockProps {
 
 function Inline(props: CodeInlineProps) {
   return (
-    <span className={styles.container}>
+    <span className={styles.inline}>
       <code>{props.code}</code>
     </span>
   )
@@ -50,7 +50,7 @@ function Block(props: CodeBlockProps) {
   }
 
   return (
-    <div className={styles.container}>
+    <div className={styles.blockRoot}>
       <div className={styles.toolbar}>
         <div className={styles.toolbarLabel}>{props.lang}</div>
         <Button
@@ -67,16 +67,18 @@ function Block(props: CodeBlockProps) {
           <div>{getLocale(S.CHAT_UI_COPY_BUTTON_LABEL)}</div>
         </Button>
       </div>
-      <SyntaxHighlighter
-        className={styles.codeBlock}
-        language={props.lang}
-        style={isDarkMode ? darkStyle : lightStyle}
-        wrapLines
-        wrapLongLines
-        codeTagProps={{ style: { wordBreak: 'break-word' } }}
-      >
-        {props.code}
-      </SyntaxHighlighter>
+      <div className={styles.codeBody}>
+        <SyntaxHighlighter
+          className={styles.codeBlock}
+          language={props.lang}
+          style={isDarkMode ? darkStyle : lightStyle}
+          wrapLines
+          wrapLongLines
+          codeTagProps={{ style: { wordBreak: 'break-word' } }}
+        >
+          {props.code}
+        </SyntaxHighlighter>
+      </div>
     </div>
   )
 }

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/code_block/style.module.scss
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/code_block/style.module.scss
@@ -3,7 +3,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // you can obtain one at https://mozilla.org/MPL/2.0/.
 
-.container {
+.inline,
+.blockRoot {
   overflow: auto;
   background: var(--leo-color-page-background);
   border: 1px solid var(--leo-color-divider-subtle);
@@ -26,8 +27,33 @@
   font-size: inherit;
 }
 
+.blockRoot {
+  // No overflow on this shell so the toolbar can use `position: sticky` against
+  // the conversation scroller.
+  overflow: visible;
+  // Omit the top segment here so it can live on `.toolbar` (sticky). That way
+  // the top edge stays visible when the shell scrolls under the chat.
+  border-top-width: 0;
+  pre {
+    white-space: pre-wrap;
+    margin: 0;
+    border-radius: 0 0 8px 8px;
+  }
+}
+
+.codeBody {
+  min-width: 0;
+  overflow-x: auto;
+}
+
 .toolbar {
+  position: sticky;
+  top: 0;
+  z-index: 1;
   background: var(--leo-color-page-background);
+  border-top: 1px solid var(--leo-color-divider-subtle);
+  border-bottom: 1px solid var(--leo-color-divider-subtle);
+  border-radius: 8px 8px 0 0;
   padding: var(--leo-spacing-m) var(--leo-spacing-m) var(--leo-spacing-m)
     var(--leo-spacing-xl);
   display: flex;


### PR DESCRIPTION
## Description 

Makes Code Block `Headers` sticky when scrolling through the chat.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/53704>

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

https://github.com/user-attachments/assets/9677fbbd-6509-4770-9865-4c117daa6df6
