### PR TITLE
[GitPatcher] tests - don't sign commits during unit test

### DIFF
--- a/build/commands/lib/gitPatcher.test.js
+++ b/build/commands/lib/gitPatcher.test.js
@@ -52,6 +52,11 @@ describe('Apply Patches', function () {
       'user.name',
       'Unit Tests',
     ])
+    await runGitAsyncWithErrorLog(repoPath, [
+      'config',
+      'commit.gpgsign',
+      'false',
+    ])
     await fs.writeFile(testFile1Path, file1InitialContent, writeReadFileOptions)
     await runGitAsyncWithErrorLog(repoPath, ['add', '.'])
     await runGitAsyncWithErrorLog(repoPath, ['commit', '-m', '"file1 initial"'])


### PR DESCRIPTION
Locally, running this tests prompts me to unlock 1pw to sign the commits it makes during the unit test. We don't need to sign those commits.

Ideally when we run git in both tests and patch application, we should ignore the user's entire git profile config, but this is simpler to start with (https://github.com/brave/brave-browser/issues/55015).