### PR TITLE
Fix bottom spacing for Save changes button in adblock custom filters editor

### DIFF
--- a/browser/resources/settings/default_brave_shields_page/components/brave_adblock_editor.html
+++ b/browser/resources/settings/default_brave_shields_page/components/brave_adblock_editor.html
@@ -44,6 +44,10 @@
     font-size: 13px;
     line-height: 1.5;
   }
+
+  .save-button {
+    margin-bottom: 8px;
+  }
 </style>
 
 <div>
@@ -58,6 +62,7 @@
     </textarea>
   </div>
   <cr-button
+    class="save-button"
     on-click="handleSave_"
     disabled="[[!prefs.brave.ad_block.developer_mode.value]]">
     $i18n{adblockSaveChangesButtonLabel}


### PR DESCRIPTION
## Summary
Adds bottom spacing to the Save changes button in Shields > Content filtering custom filters editor.

## Changes
- add \.save-button with bottom margin in adblock editor component
- apply class to Save changes button

## Issue
Fixes brave/brave-browser#47782