### PR TITLE
Brand chrome://apps empty-state icon for Brave

### DIFF
--- a/chromium_src/chrome/browser/resources/app_home/app_home_empty_page.html.ts.lit_mangler.ts
+++ b/chromium_src/chrome/browser/resources/app_home/app_home_empty_page.html.ts.lit_mangler.ts
@@ -6,6 +6,16 @@
 import { mangle } from 'lit_mangler'
 
 mangle(fragment => {
+  const image = fragment.querySelector('img')
+  if (!image) {
+    throw new Error('image not found')
+  }
+  image.setAttribute('src', 'chrome://theme/current-channel-logo')
+  image.setAttribute(
+    'srcset',
+    'chrome://theme/current-channel-logo@1x, chrome://theme/current-channel-logo@2x 2x',
+  )
+
   const anchor = fragment.querySelector('a')
   if (!anchor) {
     throw new Error('anchor not found')


### PR DESCRIPTION
## Summary
Updates the App Home (chrome://apps) empty-state branding so it uses a Brave logo image instead of the Chromium empty-state image.

## Changes
- override empty-state image source and srcset to Brave channel logo theme URL
- keep the existing Brave support link override in place

## Issue
Fixes brave/brave-browser#38755