### PR TITLE
Update crash reporting disabled message with privacy settings path

### DIFF
--- a/components/components_brave_origin_strings.grd
+++ b/components/components_brave_origin_strings.grd
@@ -266,7 +266,7 @@
 
       <!-- chrome://crashes strings -->
       <message name="IDS_CRASH_DISABLED_MESSAGE" desc="The explanatory message for chrome://crashes when crash reporting is disabled">
-        Crash reporting is not available in Brave.
+        Crash reporting is not available in Brave. Change these choices at any time in Brave at brave://settings/privacy.
       </message>
 
       <!-- Version UI -->

--- a/components/components_brave_strings.grd
+++ b/components/components_brave_strings.grd
@@ -266,7 +266,7 @@
 
       <!-- chrome://crashes strings -->
       <message name="IDS_CRASH_DISABLED_MESSAGE" desc="The explanatory message for chrome://crashes when crash reporting is disabled">
-        Crash reporting is not available in Brave.
+        Crash reporting is not available in Brave. Change these choices at any time in Brave at brave://settings/privacy.
       </message>
 
       <!-- Version UI -->


### PR DESCRIPTION
## Summary
Updates the chrome://crashes disabled-reporting message so it tells users they can change this setting at brave://settings/privacy.

## Changes
- extend the Brave crash-disabled explanatory copy with the privacy settings path
- keep Brave and Brave Origin string variants in sync

## Validation
- verified the string change is scoped to IDS_CRASH_DISABLED_MESSAGE only

## Issue
Fixes brave/brave-browser#27491