### PR TITLE
Let chrome://apps background follow the active theme

### DIFF
--- a/chromium_src/chrome/browser/resources/app_home/app_home_empty_page.ts
+++ b/chromium_src/chrome/browser/resources/app_home/app_home_empty_page.ts
@@ -1,0 +1,25 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import {AppHomeEmptyPageElement} from './app_home_empty_page-chromium.js';
+
+const originalConnectedCallback =
+  AppHomeEmptyPageElement.prototype.connectedCallback;
+
+AppHomeEmptyPageElement.prototype.connectedCallback = function (
+  this: AppHomeEmptyPageElement,
+) {
+  originalConnectedCallback?.call(this);
+
+  // Let the page background follow the active browser theme instead of
+  // forcing the dark-only app home appearance.
+  document.documentElement.style.colorScheme = 'light dark';
+  document.documentElement.style.backgroundColor = 'Canvas';
+  document.documentElement.style.color = 'CanvasText';
+  document.body.style.backgroundColor = 'Canvas';
+  document.body.style.color = 'CanvasText';
+};
+
+export * from './app_home_empty_page-chromium.js';


### PR DESCRIPTION
## Summary
Updates the app home empty page so brave://apps no longer forces a dark-only background.

## Changes
- add a Brave overlay for app_home_empty_page.ts
- switch the document color scheme to light dark at runtime
- use Canvas and CanvasText system colors for the root document and body

## Validation
- verified the change is scoped to the app home empty page overlay only

## Issue
Fixes brave/brave-browser#25736