### PR TITLE
Reuse existing Filter lists tab from Shields panel

### DIFF
--- a/components/brave_shields/resources/panel/components/advanced-controls-content/index.tsx
+++ b/components/brave_shields/resources/panel/components/advanced-controls-content/index.tsx
@@ -54,13 +54,53 @@ const httpsUpgradeModeOptions = [
   { value: HttpsUpgradeMode.DISABLED_MODE, text: getLocale('braveShieldsHttpsUpgradeModeDisabled') }
 ]
 
+function isSettingsPageTab(tab: chrome.tabs.Tab, pagePath: string) {
+  const tabUrl = tab.pendingUrl ?? tab.url
+  if (!tabUrl) {
+    return false
+  }
+
+  try {
+    const parsedUrl = new URL(tabUrl)
+    return (
+      (parsedUrl.protocol === 'chrome:' || parsedUrl.protocol === 'brave:') &&
+      parsedUrl.hostname === 'settings' &&
+      parsedUrl.pathname === pagePath
+    )
+  } catch {
+    return false
+  }
+}
+
+function openOrFocusSettingsPage(pagePath: string) {
+  const url = `chrome://settings${pagePath}`
+  chrome.tabs.query({}, (tabs) => {
+    if (chrome.runtime.lastError) {
+      chrome.tabs.create({ url, active: true })
+      return
+    }
+
+    const existingTab = tabs.find((tab) => isSettingsPageTab(tab, pagePath))
+    if (existingTab?.id === undefined) {
+      chrome.tabs.create({ url, active: true })
+      return
+    }
+
+    if (existingTab.windowId !== undefined) {
+      chrome.windows.update(existingTab.windowId, { focused: true })
+    }
+
+    chrome.tabs.update(existingTab.id, { active: true })
+  })
+}
+
 interface Props {
   showAdblockLists: boolean
 }
 
 export function GlobalSettings(props: Props) {
   const onAdBlockListsClick = () => {
-    chrome.tabs.create({ url: 'chrome://settings/shields/filters', active: true })
+    openOrFocusSettingsPage('/shields/filters')
   }
 
   const onSettingsClick = () => {

--- a/components/brave_shields/resources/panel_new/shields_panel.tsx
+++ b/components/brave_shields/resources/panel_new/shields_panel.tsx
@@ -20,13 +20,76 @@ function hasReloadsDetectedFlag() {
   return urlParams.get('mode') === 'afterRepeatedReloads'
 }
 
+function getSettingsPagePath(url: string) {
+  try {
+    const parsedUrl = new URL(url)
+    if (
+      (parsedUrl.protocol === 'chrome:' || parsedUrl.protocol === 'brave:') &&
+      parsedUrl.hostname === 'settings'
+    ) {
+      return parsedUrl.pathname
+    }
+  } catch {
+    return null
+  }
+
+  return null
+}
+
+function isSettingsPageTab(tab: chrome.tabs.Tab, pagePath: string) {
+  const tabUrl = tab.pendingUrl ?? tab.url
+  if (!tabUrl) {
+    return false
+  }
+
+  try {
+    const parsedUrl = new URL(tabUrl)
+    return (
+      (parsedUrl.protocol === 'chrome:' || parsedUrl.protocol === 'brave:') &&
+      parsedUrl.hostname === 'settings' &&
+      parsedUrl.pathname === pagePath
+    )
+  } catch {
+    return false
+  }
+}
+
+function openOrFocusTab(url: string) {
+  const settingsPagePath = getSettingsPagePath(url)
+  if (settingsPagePath !== '/shields/filters') {
+    chrome.tabs.create({ url, active: true })
+    return
+  }
+
+  chrome.tabs.query({}, (tabs) => {
+    if (chrome.runtime.lastError) {
+      chrome.tabs.create({ url, active: true })
+      return
+    }
+
+    const existingTab = tabs.find((tab) => {
+      return isSettingsPageTab(tab, settingsPagePath)
+    })
+    if (existingTab?.id === undefined) {
+      chrome.tabs.create({ url, active: true })
+      return
+    }
+
+    if (existingTab.windowId !== undefined) {
+      chrome.windows.update(existingTab.windowId, { focused: true })
+    }
+
+    chrome.tabs.update(existingTab.id, { active: true })
+  })
+}
+
 function createBrowserShieldsApi() {
   const proxy = ShieldsPanelProxy.getInstance()
   return createShieldsApi({
     dataHandler: proxy.dataHandler,
     panelHandler: proxy.panelHandler,
     createUIHandlerRemote: (impl) => proxy.createUIHandlerRemote(impl),
-    openTab: (url) => chrome.tabs.create({ url, active: true }),
+    openTab,
     loadTimeState: {
       isHttpsByDefaultEnabled: loadTimeData.getBoolean(
         'isHttpsByDefaultEnabled',


### PR DESCRIPTION
## Summary
- reuse an existing settings tab when Filter lists is already open
- handle both legacy and new Shields panel entry points
- keep opening a new tab as the fallback when no matching settings tab exists

## Test plan
- open any site and expand the Shields advanced view
- click Filter lists multiple times
- verify the existing settings tab is focused instead of opening duplicate tabs

Fixes brave/brave-browser#24120