### PR TITLE
Focus settings subpage search field when clicked

### DIFF
--- a/browser/resources/settings/br/settings_subpage.ts
+++ b/browser/resources/settings/br/settings_subpage.ts
@@ -3,8 +3,37 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import {RegisterStyleOverride} from 'chrome://resources/brave/polymer_overriding.js'
+import {
+  RegisterPolymerComponentBehaviors,
+  RegisterStyleOverride
+} from 'chrome://resources/brave/polymer_overriding.js'
 import {html} from 'chrome://resources/polymer/v3_0/polymer/polymer_bundled.min.js'
+
+type SearchFieldWithInput = HTMLElement & {
+  getSearchInput: () => HTMLInputElement
+}
+
+const BraveSubpageSearchFocusBehavior = {
+  ready: function(this: HTMLElement) {
+    this.addEventListener('click', (event: Event) => {
+      const searchField =
+        this.shadowRoot?.querySelector('cr-search-field') as SearchFieldWithInput | null
+      if (!searchField || !event.composedPath().includes(searchField)) {
+        return
+      }
+
+      // Keep the header's existing focus target from winning when the
+      // magnifier icon is clicked.
+      searchField.getSearchInput().focus()
+    })
+  }
+}
+
+RegisterPolymerComponentBehaviors({
+  'settings-subpage': [
+    BraveSubpageSearchFocusBehavior
+  ]
+})
 
 RegisterStyleOverride(
   'settings-subpage', html`


### PR DESCRIPTION
## Summary
- focus the embedded settings subpage search input whenever the shared search field is clicked
- keep the existing Brave settings layout overrides intact
- apply the fix at the shared subpage layer so it covers all affected settings sections

## Test plan
- open a settings subpage that shows the in-page search field
- click the search icon inside the subpage header
- start typing and verify the text goes into the search box immediately

Fixes brave/brave-browser#51316