### PR TITLE
Use the BAT icon for Rewards sidebar items

### DIFF
--- a/browser/ui/views/sidebar/sidebar_items_contents_view.cc
+++ b/browser/ui/views/sidebar/sidebar_items_contents_view.cc
@@ -32,6 +32,7 @@
 #include "brave/browser/ui/views/sidebar/sidebar_item_view.h"
 #include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
 #include "brave/components/brave_talk/buildflags/buildflags.h"
+#include "brave/components/constants/webui_url_constants.h"
 #include "brave/components/playlist/core/common/features.h"
 #include "brave/components/sidebar/browser/pref_names.h"
 #include "brave/components/sidebar/browser/sidebar_item.h"
@@ -320,6 +321,13 @@ void SidebarItemsContentsView::SetDefaultImageFor(
   SkColor text_color = SK_ColorWHITE;
   if (const ui::ColorProvider* color_provider = GetColorProvider()) {
     text_color = color_provider->GetColor(kColorSidebarButtonBase);
+  }
+
+  if (item.url.host() == kRewardsPageHost) {
+    SetImageForItem(item,
+                    gfx::CreateVectorIcon(kBatIcon, kIconSize.width(),
+                                          text_color));
+    return;
   }
 
   const int scale = GetWidget()->GetCompositor()->device_scale_factor();


### PR DESCRIPTION
## Summary
- use the BAT vector icon as the default image for the Rewards internal page in the sidebar
- keep the existing one-letter fallback for other web sidebar items
- preserve the current favicon update path for pages that can provide a favicon

## Test plan
- add the Rewards internal page to the sidebar
- verify the sidebar shows the BAT icon instead of the letter R fallback
- verify other web sidebar items still use their existing favicon or letter fallback behavior

Fixes brave/brave-browser#41617