### PR TITLE
[Sidebar V2] Manage side panel border and resize area based on rounded corners pref

### DIFF
--- a/browser/ui/sidebar/sidebar_browsertest.cc
+++ b/browser/ui/sidebar/sidebar_browsertest.cc
@@ -93,6 +93,10 @@
 #include "brave/components/playlist/core/common/features.h"
 #endif
 
+#if BUILDFLAG(ENABLE_SIDEBAR_V2)
+#include "brave/browser/ui/views/side_panel/brave_side_panel_resize_area.h"
+#endif
+
 using ::testing::Eq;
 using ::testing::Ne;
 using ::testing::Optional;
@@ -2057,11 +2061,20 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, SidebarV2PanelPositionTest) {
   // --- Sidebar on right (default LTR: kSidePanelHorizontalAlignment = true)
   ASSERT_FALSE(sidebar->sidebar_on_left());
 
+  auto* contents = browser_view->contents_container();
+
   // Panel sits immediately left of the sidebar control:
   //   [contents] [panel] [sidebar_control]
   EXPECT_EQ(panel->bounds().right(), sidebar->bounds().x())
       << "panel=" << panel->bounds().ToString()
       << " sidebar=" << sidebar->bounds().ToString();
+
+  // Panel top must align with the contents container — the upstream layout
+  // offsets the panel -1px to overlap the toolbar separator; Brave removes
+  // that offset so the separator is fully visible.
+  EXPECT_EQ(panel->bounds().y(), contents->bounds().y())
+      << "panel y=" << panel->bounds().y()
+      << " contents y=" << contents->bounds().y();
 
   // --- Sidebar on left (kSidePanelHorizontalAlignment = false)
   prefs->SetBoolean(prefs::kSidePanelHorizontalAlignment, false);
@@ -2074,6 +2087,10 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, SidebarV2PanelPositionTest) {
   EXPECT_EQ(sidebar->bounds().right(), panel->bounds().x())
       << "sidebar=" << sidebar->bounds().ToString()
       << " panel=" << panel->bounds().ToString();
+
+  EXPECT_EQ(panel->bounds().y(), contents->bounds().y())
+      << "panel y=" << panel->bounds().y()
+      << " contents y=" << contents->bounds().y();
 }
 
 // Verify that the sidebar item active state in SidebarModel is updated:
@@ -2158,6 +2175,56 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, SidebarV2NoUpstreamHeaderTest) {
   EXPECT_EQ(nullptr, side_panel->GetHeaderView<views::View>())
       << "Upstream SidePanelHeader should not be present for CustomizeChrome "
          "panel";
+}
+
+// Verify that the resize area is positioned correctly for both border states.
+// With border: the resize area sits inside the border inset strip (its width
+// equals the border inset and it starts at x=0).
+// Without border: the resize area is a narrow kNoBorderResizeAreaWidth strip
+// placed at the inner edge facing the web content.
+IN_PROC_BROWSER_TEST_F(SidebarBrowserTest,
+                       SidebarV2ResizeAreaPositionMatchesBorderState) {
+  auto* panel_ui = browser()->GetFeatures().side_panel_ui();
+  auto* browser_view = BrowserView::GetBrowserViewForBrowser(browser());
+  auto* side_panel = browser_view->contents_height_side_panel();
+  side_panel->DisableAnimationsForTesting();
+  auto* prefs = browser()->profile()->GetPrefs();
+
+  // Default: sidebar on right.
+  ASSERT_TRUE(prefs->GetBoolean(prefs::kSidePanelHorizontalAlignment));
+
+  panel_ui->Toggle();
+  ASSERT_TRUE(base::test::RunUntil([&]() { return side_panel->GetVisible(); }));
+
+  auto* resize_area = side_panel->resize_area_for_testing();
+  ASSERT_TRUE(resize_area);
+
+  // --- Border case (rounded corners ON) ---
+  prefs->SetBoolean(kWebViewRoundedCorners, true);
+  RunScheduledLayouts();
+  ASSERT_NE(side_panel->GetLocalBounds(), side_panel->GetContentsBounds());
+
+  // In the bordered case the resize strip sits in the gap between the panel
+  // edge and the content, at the left edge (panel is on the right in LTR).
+  const gfx::Rect bordered_bounds = resize_area->bounds();
+  EXPECT_EQ(bordered_bounds.top_right(),
+            side_panel->GetContentParentView()->origin())
+      << "Bordered resize area right edge should align with content origin";
+  EXPECT_EQ(bordered_bounds.width(), side_panel->GetInsets().left())
+      << "Bordered resize area width should match the left border inset";
+
+  // --- No-border case (rounded corners OFF) ---
+  prefs->SetBoolean(kWebViewRoundedCorners, false);
+  RunScheduledLayouts();
+  ASSERT_EQ(side_panel->GetLocalBounds(), side_panel->GetContentsBounds());
+
+  const gfx::Rect no_border_bounds = resize_area->bounds();
+  EXPECT_EQ(no_border_bounds.origin(),
+            side_panel->GetContentParentView()->origin())
+      << "No-border resize area should be placed at the inner edge of content";
+  EXPECT_EQ(no_border_bounds.width(),
+            views::BraveSidePanelResizeArea::kNoBorderResizeAreaWidth)
+      << "No-border resize area width should equal kNoBorderResizeAreaWidth";
 }
 
 #endif  // BUILDFLAG(ENABLE_SIDEBAR_V2)

--- a/browser/ui/sidebar/sidebar_browsertest.cc
+++ b/browser/ui/sidebar/sidebar_browsertest.cc
@@ -2202,7 +2202,7 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest,
   // --- Border case (rounded corners ON) ---
   prefs->SetBoolean(kWebViewRoundedCorners, true);
   RunScheduledLayouts();
-  ASSERT_NE(side_panel->GetLocalBounds(), side_panel->GetContentsBounds());
+  EXPECT_FALSE(side_panel->GetInsets().IsEmpty());
 
   // In the bordered case the resize strip sits in the gap between the panel
   // edge and the content, at the left edge (panel is on the right in LTR).
@@ -2216,7 +2216,7 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest,
   // --- No-border case (rounded corners OFF) ---
   prefs->SetBoolean(kWebViewRoundedCorners, false);
   RunScheduledLayouts();
-  ASSERT_EQ(side_panel->GetLocalBounds(), side_panel->GetContentsBounds());
+  EXPECT_TRUE(side_panel->GetInsets().IsEmpty());
 
   const gfx::Rect no_border_bounds = resize_area->bounds();
   EXPECT_EQ(no_border_bounds.origin(),

--- a/browser/ui/views/frame/brave_browser_view.cc
+++ b/browser/ui/views/frame/brave_browser_view.cc
@@ -1081,7 +1081,7 @@ void BraveBrowserView::UpdateVerticalTabStripBorder() {
 void BraveBrowserView::UpdateSidebarBorder() {
 #if BUILDFLAG(ENABLE_SIDEBAR_V2)
   if (contents_height_side_panel_) {
-    contents_height_side_panel_->SetBorderEnabled(
+    contents_height_side_panel_->SetRoundedBorderEnabled(
         ShouldUseBraveWebViewRoundedCornersForContents(browser_));
   }
 #else

--- a/browser/ui/views/frame/brave_browser_view.cc
+++ b/browser/ui/views/frame/brave_browser_view.cc
@@ -78,6 +78,7 @@
 #include "chrome/browser/ui/views/frame/multi_contents_view.h"
 #include "chrome/browser/ui/views/frame/top_container_view.h"
 #include "chrome/browser/ui/views/interaction/browser_elements_views.h"
+#include "chrome/browser/ui/views/side_panel/side_panel.h"
 #include "chrome/browser/ui/views/side_panel/side_panel_coordinator.h"
 #include "chrome/browser/ui/views/tabs/tab_search_button.h"
 #include "chrome/browser/ui/views/tabs/tab_strip.h"
@@ -107,6 +108,10 @@
 
 #if BUILDFLAG(ENABLE_BRAVE_WALLET)
 #include "brave/browser/ui/views/toolbar/wallet_button.h"
+#endif
+
+#if BUILDFLAG(ENABLE_SIDEBAR_V2)
+#include "brave/browser/ui/views/side_panel/brave_side_panel_resize_area.h"
 #endif
 
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
@@ -356,6 +361,11 @@ BraveBrowserView::BraveBrowserView(Browser* browser) : BrowserView(browser) {
       sidebar_container_view_ =
           AddChildView(std::make_unique<SidebarContainerView>(
               browser_, SidePanelCoordinator::From(browser_), nullptr));
+#if BUILDFLAG(ENABLE_SIDEBAR_V2)
+      contents_height_side_panel_->SetResizeArea(
+          std::make_unique<views::BraveSidePanelResizeArea>(
+              contents_height_side_panel_));
+#endif
     } else {
       // V1: wrap chromium's side panel inside SidebarContainerView.
       auto original_side_panel =
@@ -1069,7 +1079,12 @@ void BraveBrowserView::UpdateVerticalTabStripBorder() {
 }
 
 void BraveBrowserView::UpdateSidebarBorder() {
-#if !BUILDFLAG(ENABLE_SIDEBAR_V2)
+#if BUILDFLAG(ENABLE_SIDEBAR_V2)
+  if (contents_height_side_panel_) {
+    contents_height_side_panel_->SetBorderEnabled(
+        ShouldUseBraveWebViewRoundedCornersForContents(browser_));
+  }
+#else
   if (contents_height_side_panel_) {
     contents_height_side_panel_->UpdateBorder();
   }

--- a/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl.cc
+++ b/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl.cc
@@ -430,6 +430,11 @@ void BraveBrowserViewTabbedLayoutImpl::CalculateSideBarLayout(
     }
     panel_layout->bounds = ComputeAdjustedPanelBounds(on_left, sidebar_bounds,
                                                       panel_layout->bounds);
+    // The upstream layout offsets the panel -1px above the contents to overlap
+    // the toolbar separator. Brave doesn't need that overlap; align the panel's
+    // vertical extent with the contents container instead.
+    panel_layout->bounds.set_y(contents_bounds.y());
+    panel_layout->bounds.set_height(contents_bounds.height());
   };
   adjust_panel(views().contents_height_side_panel.get());
 

--- a/browser/ui/views/side_panel/BUILD.gn
+++ b/browser/ui/views/side_panel/BUILD.gn
@@ -3,6 +3,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import("//brave/browser/ui/sidebar/buildflags/buildflags.gni")
 import("//build/config/ui.gni")
 
 assert(toolkit_views)
@@ -19,4 +20,11 @@ source_set("side_panel") {
     "//ui/gfx",
     "//ui/views",
   ]
+
+  if (enable_sidebar_v2) {
+    sources += [
+      "brave_side_panel_resize_area.cc",
+      "brave_side_panel_resize_area.h",
+    ]
+  }
 }

--- a/browser/ui/views/side_panel/brave_side_panel_resize_area.cc
+++ b/browser/ui/views/side_panel/brave_side_panel_resize_area.cc
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/browser/ui/views/side_panel/brave_side_panel_resize_area.h"
+
+#include "base/i18n/rtl.h"
+#include "chrome/browser/ui/views/side_panel/side_panel.h"
+#include "ui/base/metadata/metadata_impl_macros.h"
+
+namespace views {
+
+BraveSidePanelResizeArea::~BraveSidePanelResizeArea() = default;
+
+gfx::Rect BraveSidePanelResizeArea::GetNoBorderResizeBounds(
+    bool panel_on_right,
+    const gfx::Rect& parent_bounds) const {
+  if (panel_on_right) {
+    // Panel is on the right → resize strip sits at the left (inner) edge.
+    return gfx::Rect(parent_bounds.x(), parent_bounds.y(),
+                     kNoBorderResizeAreaWidth, parent_bounds.height());
+  }
+  // Panel is on the left → resize strip sits at the right (inner) edge.
+  return gfx::Rect(parent_bounds.right() - kNoBorderResizeAreaWidth,
+                   parent_bounds.y(), kNoBorderResizeAreaWidth,
+                   parent_bounds.height());
+}
+
+void BraveSidePanelResizeArea::Layout(PassKey) {
+  gfx::Rect local_bounds = parent()->GetLocalBounds();
+  gfx::Rect contents_bounds = parent()->GetContentsBounds();
+
+  if (local_bounds != contents_bounds) {
+    // Parent has a border: resize area sits in the border gap between the
+    // panel edge and the content area. Delegate entirely to upstream.
+    LayoutSuperclass<SidePanelResizeArea>(this);
+    return;
+  }
+
+  // No border: content fills the full panel. Position this view as a
+  // narrow strip at the inner edge of the panel so it overlaps the content
+  // and can capture mouse events.
+  const bool panel_on_right =
+      (side_panel_->IsRightAligned() && !base::i18n::IsRTL()) ||
+      (!side_panel_->IsRightAligned() && base::i18n::IsRTL());
+  SetBoundsRect(GetNoBorderResizeBounds(panel_on_right, local_bounds));
+}
+
+BEGIN_METADATA(BraveSidePanelResizeArea)
+END_METADATA
+
+}  // namespace views

--- a/browser/ui/views/side_panel/brave_side_panel_resize_area.cc
+++ b/browser/ui/views/side_panel/brave_side_panel_resize_area.cc
@@ -15,23 +15,20 @@ BraveSidePanelResizeArea::~BraveSidePanelResizeArea() = default;
 
 gfx::Rect BraveSidePanelResizeArea::GetNoBorderResizeBounds(
     bool panel_on_right,
-    const gfx::Rect& parent_bounds) const {
+    const gfx::Rect& panel_bounds) const {
   if (panel_on_right) {
     // Panel is on the right → resize strip sits at the left (inner) edge.
-    return gfx::Rect(parent_bounds.x(), parent_bounds.y(),
-                     kNoBorderResizeAreaWidth, parent_bounds.height());
+    return gfx::Rect(panel_bounds.x(), panel_bounds.y(),
+                     kNoBorderResizeAreaWidth, panel_bounds.height());
   }
   // Panel is on the left → resize strip sits at the right (inner) edge.
-  return gfx::Rect(parent_bounds.right() - kNoBorderResizeAreaWidth,
-                   parent_bounds.y(), kNoBorderResizeAreaWidth,
-                   parent_bounds.height());
+  return gfx::Rect(panel_bounds.right() - kNoBorderResizeAreaWidth,
+                   panel_bounds.y(), kNoBorderResizeAreaWidth,
+                   panel_bounds.height());
 }
 
 void BraveSidePanelResizeArea::Layout(PassKey) {
-  gfx::Rect local_bounds = parent()->GetLocalBounds();
-  gfx::Rect contents_bounds = parent()->GetContentsBounds();
-
-  if (local_bounds != contents_bounds) {
+  if (!side_panel_->GetInsets().IsEmpty()) {
     // Parent has a border: resize area sits in the border gap between the
     // panel edge and the content area. Delegate entirely to upstream.
     LayoutSuperclass<SidePanelResizeArea>(this);
@@ -44,7 +41,8 @@ void BraveSidePanelResizeArea::Layout(PassKey) {
   const bool panel_on_right =
       (side_panel_->IsRightAligned() && !base::i18n::IsRTL()) ||
       (!side_panel_->IsRightAligned() && base::i18n::IsRTL());
-  SetBoundsRect(GetNoBorderResizeBounds(panel_on_right, local_bounds));
+  SetBoundsRect(
+      GetNoBorderResizeBounds(panel_on_right, side_panel_->GetLocalBounds()));
 }
 
 BEGIN_METADATA(BraveSidePanelResizeArea)

--- a/browser/ui/views/side_panel/brave_side_panel_resize_area.h
+++ b/browser/ui/views/side_panel/brave_side_panel_resize_area.h
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_BROWSER_UI_VIEWS_SIDE_PANEL_BRAVE_SIDE_PANEL_RESIZE_AREA_H_
+#define BRAVE_BROWSER_UI_VIEWS_SIDE_PANEL_BRAVE_SIDE_PANEL_RESIZE_AREA_H_
+
+#include "chrome/browser/ui/views/side_panel/side_panel_resize_area.h"
+#include "ui/gfx/geometry/rect.h"
+
+namespace views {
+
+// Custom SidePanelResizeArea to adjust its position based on the presence
+// of panel border.
+class BraveSidePanelResizeArea : public SidePanelResizeArea {
+  METADATA_HEADER(BraveSidePanelResizeArea, SidePanelResizeArea)
+
+ public:
+  using SidePanelResizeArea::SidePanelResizeArea;
+  ~BraveSidePanelResizeArea() override;
+
+  // Width of the resize strip when the panel has no border.
+  static constexpr int kNoBorderResizeAreaWidth = 5;
+
+  // Returns the resize area bounds for the no-border case.
+  // `panel_on_right` is true when the panel appears on the right side of the
+  // screen (right-aligned LTR or left-aligned RTL), which puts the resize
+  // strip at the left edge so it faces the web content.
+  gfx::Rect GetNoBorderResizeBounds(bool panel_on_right,
+                                    const gfx::Rect& parent_bounds) const;
+
+  // views::SidePanelResizeArea:
+  void Layout(PassKey) override;
+};
+
+}  // namespace views
+
+#endif  // BRAVE_BROWSER_UI_VIEWS_SIDE_PANEL_BRAVE_SIDE_PANEL_RESIZE_AREA_H_

--- a/browser/ui/views/side_panel/brave_side_panel_resize_area.h
+++ b/browser/ui/views/side_panel/brave_side_panel_resize_area.h
@@ -28,7 +28,7 @@ class BraveSidePanelResizeArea : public SidePanelResizeArea {
   // screen (right-aligned LTR or left-aligned RTL), which puts the resize
   // strip at the left edge so it faces the web content.
   gfx::Rect GetNoBorderResizeBounds(bool panel_on_right,
-                                    const gfx::Rect& parent_bounds) const;
+                                    const gfx::Rect& panel_bounds) const;
 
   // views::SidePanelResizeArea:
   void Layout(PassKey) override;

--- a/chromium_src/chrome/browser/ui/views/side_panel/side_panel.cc
+++ b/chromium_src/chrome/browser/ui/views/side_panel/side_panel.cc
@@ -7,9 +7,92 @@
 #include "build/buildflag.h"
 
 #if BUILDFLAG(ENABLE_SIDEBAR_V2)
-// V2: compile upstream's SidePanel implementation.
+// Include the Brave-overridden header first, WITHOUT the rename macros below
+// active, so that the class declaration keeps the original Open name and the
+// include guard prevents the header from being re-processed when the upstream
+// .cc pulls it in.
+#include "chrome/browser/ui/views/side_panel/side_panel.h"
+
+// Rename the upstream Open/Close implementation so we can provide a thin
+// wrapper that reapplies border state after UpdateVisibility() runs.
+// UpdateVisibility() unconditionally re-shows border_view_ whenever the panel
+// opens, which would undo SetBorderEnabled(false).
+#define Open Open_ChromiumImpl
+#define Close Close_ChromiumImpl
+
+// Rename the upstream RemoveHeaderView implementation so we can provide
+// a thin wrapper that reapplies the border state after it runs.
+// Upstream RemoveHeaderView() sets Border always but we want to preserve
+// the no-border state if it is set.
+#define RemoveHeaderView RemoveHeaderView_ChromiumImpl
+
 #include <chrome/browser/ui/views/side_panel/side_panel.cc>
-#else
-// V1: empty — upstream's SidePanel is excluded from the build.
-// brave/browser/ui/views/side_panel/side_panel.cc provides the replacement.
-#endif
+
+#undef RemoveHeaderView
+#undef Close
+#undef Open
+
+#endif  // BUILDFLAG(ENABLE_SIDEBAR_V2)
+
+#if BUILDFLAG(ENABLE_SIDEBAR_V2)
+
+void SidePanel::Open(bool animated) {
+  Open_ChromiumImpl(animated);
+
+  // UpdateVisibility() unconditionally sets border_view_ visible when opening;
+  // restore desired state.
+  UpdateBorder();
+}
+
+void SidePanel::Close(bool animated) {
+  Close_ChromiumImpl(animated);
+
+  // UpdateVisibility() unconditionally sets border_view_ visible when closing;
+  // restore desired state.
+  UpdateBorder();
+}
+
+void SidePanel::SetResizeArea(std::unique_ptr<views::View> resize_area) {
+  CHECK(resize_area);
+  auto old_resize_area = RemoveChildViewT(resize_area_);
+  // Add at the end so the resize area is above content_parent_view_ in z-order.
+  // This is required for the no-border case where the resize strip overlaps
+  // the content edge and must win the hit-test.
+  resize_area_ = AddChildView(std::move(resize_area));
+  resize_area_->InsertBeforeInFocusList(content_parent_view_);
+}
+
+void SidePanel::SetBorderEnabled(bool enabled) {
+  if (border_enabled_ == enabled) {
+    return;
+  }
+
+  border_enabled_ = enabled;
+
+  if (GetVisible()) {
+    UpdateBorder();
+  }
+}
+
+void SidePanel::UpdateBorder() {
+  // No border or not initialized yet.
+  if (!border_view_ || !border_view_->layer()) {
+    return;
+  }
+
+  if (border_enabled_) {
+    // Upstream GetBorderInsets() has a negative top to overlap the toolbar;
+    // Brave doesn't need that overlap.
+    SetBorder(views::CreateEmptyBorder(GetBorderInsets().set_top(0)));
+  } else {
+    SetBorder(nullptr);
+  }
+
+  border_view_->SetVisible(border_enabled_);
+}
+
+void SidePanel::RemoveHeaderView() {
+  // Do nothing here as we don't set header view.
+}
+
+#endif  // BUILDFLAG(ENABLE_SIDEBAR_V2)

--- a/chromium_src/chrome/browser/ui/views/side_panel/side_panel.cc
+++ b/chromium_src/chrome/browser/ui/views/side_panel/side_panel.cc
@@ -76,7 +76,7 @@ void SidePanel::UpdateBorder() {
 }
 
 void SidePanel::RemoveHeaderView() {
-  // See above method overring's comment why it's empty.
+  // See above method overriding's comment why it's empty.
 }
 
 #endif  // BUILDFLAG(ENABLE_SIDEBAR_V2)

--- a/chromium_src/chrome/browser/ui/views/side_panel/side_panel.cc
+++ b/chromium_src/chrome/browser/ui/views/side_panel/side_panel.cc
@@ -13,43 +13,28 @@
 // .cc pulls it in.
 #include "chrome/browser/ui/views/side_panel/side_panel.h"
 
-// Rename the upstream Open/Close implementation so we can provide a thin
-// wrapper that reapplies border state after UpdateVisibility() runs.
-// UpdateVisibility() unconditionally re-shows border_view_ whenever the panel
-// opens, which would undo SetBorderEnabled(false).
-#define Open Open_ChromiumImpl
-#define Close Close_ChromiumImpl
-
 // Rename the upstream RemoveHeaderView implementation so we can provide
-// a thin wrapper that reapplies the border state after it runs.
-// Upstream RemoveHeaderView() sets Border always but we want to preserve
-// the no-border state if it is set.
-#define RemoveHeaderView RemoveHeaderView_ChromiumImpl
+// our own method. Upstream RemoveHeaderView() resets Border always but we
+// want to preserve the no-border state. As we don't set any header to all
+// panels, making it empty would not add any side-effect.
+#define RemoveHeaderView RemoveHeaderView_UnUsed
 
 #include <chrome/browser/ui/views/side_panel/side_panel.cc>
 
 #undef RemoveHeaderView
-#undef Close
-#undef Open
 
 #endif  // BUILDFLAG(ENABLE_SIDEBAR_V2)
 
 #if BUILDFLAG(ENABLE_SIDEBAR_V2)
 
-void SidePanel::Open(bool animated) {
-  Open_ChromiumImpl(animated);
+void SidePanel::VisibilityChanged(View* starting_from, bool is_visible) {
+  AccessiblePaneView::VisibilityChanged(starting_from, is_visible);
 
-  // UpdateVisibility() unconditionally sets border_view_ visible when opening;
-  // restore desired state.
-  UpdateBorder();
-}
-
-void SidePanel::Close(bool animated) {
-  Close_ChromiumImpl(animated);
-
-  // UpdateVisibility() unconditionally sets border_view_ visible when closing;
-  // restore desired state.
-  UpdateBorder();
+  // Whenever open/closes, upstream resets border style.
+  // Set our border style again.
+  if (GetVisible()) {
+    UpdateBorder();
+  }
 }
 
 void SidePanel::SetResizeArea(std::unique_ptr<views::View> resize_area) {
@@ -62,12 +47,12 @@ void SidePanel::SetResizeArea(std::unique_ptr<views::View> resize_area) {
   resize_area_->InsertBeforeInFocusList(content_parent_view_);
 }
 
-void SidePanel::SetBorderEnabled(bool enabled) {
-  if (border_enabled_ == enabled) {
+void SidePanel::SetRoundedBorderEnabled(bool enabled) {
+  if (rounded_border_enabled_ == enabled) {
     return;
   }
 
-  border_enabled_ = enabled;
+  rounded_border_enabled_ = enabled;
 
   if (GetVisible()) {
     UpdateBorder();
@@ -75,12 +60,11 @@ void SidePanel::SetBorderEnabled(bool enabled) {
 }
 
 void SidePanel::UpdateBorder() {
-  // No border or not initialized yet.
-  if (!border_view_ || !border_view_->layer()) {
+  if (!border_view_) {
     return;
   }
 
-  if (border_enabled_) {
+  if (rounded_border_enabled_) {
     // Upstream GetBorderInsets() has a negative top to overlap the toolbar;
     // Brave doesn't need that overlap.
     SetBorder(views::CreateEmptyBorder(GetBorderInsets().set_top(0)));
@@ -88,11 +72,11 @@ void SidePanel::UpdateBorder() {
     SetBorder(nullptr);
   }
 
-  border_view_->SetVisible(border_enabled_);
+  border_view_->SetVisible(rounded_border_enabled_);
 }
 
 void SidePanel::RemoveHeaderView() {
-  // Do nothing here as we don't set header view.
+  // See above method overring's comment why it's empty.
 }
 
 #endif  // BUILDFLAG(ENABLE_SIDEBAR_V2)

--- a/chromium_src/chrome/browser/ui/views/side_panel/side_panel.h
+++ b/chromium_src/chrome/browser/ui/views/side_panel/side_panel.h
@@ -6,13 +6,36 @@
 #ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_SIDE_PANEL_SIDE_PANEL_H_
 #define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_SIDE_PANEL_SIDE_PANEL_H_
 
+#include <memory>
+
 #include "brave/browser/ui/sidebar/buildflags/buildflags.h"
 
 #if BUILDFLAG(ENABLE_SIDEBAR_V2)
 // V2: use upstream's SidePanel class directly.
 // Angle brackets are required here to resolve to the upstream file rather than
 // this chromium_src override (which would cause infinite recursion).
+
+// Need SetResizeArea() to replace resize area to customize its position, and
+// to support toggling the border at runtime (disabling it makes content fill
+// the panel).
+#define GetContentParentView(...)                               \
+  GetContentParentView(__VA_ARGS__);                            \
+  void SetResizeArea(std::unique_ptr<views::View> resize_area); \
+  void SetBorderEnabled(bool enabled);                          \
+  void UpdateBorder();                                          \
+  void Open_ChromiumImpl(bool animated);                        \
+  void Close_ChromiumImpl(bool animated);                       \
+  void RemoveHeaderView_ChromiumImpl()
+
+#define did_resize_    \
+  did_resize_ = false; \
+  bool border_enabled_
+
 #include <chrome/browser/ui/views/side_panel/side_panel.h>  // IWYU pragma: export
+
+#undef did_resize_
+#undef GetContentParentView
+
 #else
 // V1: use Brave's custom SidePanel replacement, which also prevents
 // `chrome/browser/ui/views/side_panel/side_panel.cc` from being built.

--- a/chromium_src/chrome/browser/ui/views/side_panel/side_panel.h
+++ b/chromium_src/chrome/browser/ui/views/side_panel/side_panel.h
@@ -18,18 +18,17 @@
 // Need SetResizeArea() to replace resize area to customize its position, and
 // to support toggling the border at runtime (disabling it makes content fill
 // the panel).
-#define GetContentParentView(...)                               \
-  GetContentParentView(__VA_ARGS__);                            \
-  void SetResizeArea(std::unique_ptr<views::View> resize_area); \
-  void SetBorderEnabled(bool enabled);                          \
-  void UpdateBorder();                                          \
-  void Open_ChromiumImpl(bool animated);                        \
-  void Close_ChromiumImpl(bool animated);                       \
-  void RemoveHeaderView_ChromiumImpl()
+#define GetContentParentView(...)                                        \
+  GetContentParentView(__VA_ARGS__);                                     \
+  void SetResizeArea(std::unique_ptr<views::View> resize_area);          \
+  void SetRoundedBorderEnabled(bool enabled);                            \
+  void UpdateBorder();                                                   \
+  void VisibilityChanged(View* starting_from, bool is_visible) override; \
+  void RemoveHeaderView_UnUsed()
 
 #define did_resize_    \
   did_resize_ = false; \
-  bool border_enabled_
+  bool rounded_border_enabled_
 
 #include <chrome/browser/ui/views/side_panel/side_panel.h>  // IWYU pragma: export
 

--- a/chromium_src/chrome/browser/ui/views/side_panel/side_panel_resize_area.h
+++ b/chromium_src/chrome/browser/ui/views/side_panel/side_panel_resize_area.h
@@ -10,7 +10,15 @@
 
 #if BUILDFLAG(ENABLE_SIDEBAR_V2)
 // V2: upstream's SidePanel uses SidePanelResizeArea directly.
+
+#define UpdateHandleVisibility(...)    \
+  UpdateHandleVisibility(__VA_ARGS__); \
+  friend class BraveSidePanelResizeArea
+
 #include <chrome/browser/ui/views/side_panel/side_panel_resize_area.h>  // IWYU pragma: export
+
+#undef UpdateHandleVisibility
+
 #else
 // V1: excluded — Brave uses SidePanelResizeWidget instead.
 #endif

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -5,6 +5,7 @@
 
 import("//brave/android/android_browser_tests.gni")
 import("//brave/browser/metrics/buildflags/buildflags.gni")
+import("//brave/browser/ui/sidebar/buildflags/buildflags.gni")
 import("//brave/browser/updater/buildflags.gni")
 import("//brave/build/config.gni")
 import("//brave/components/ai_chat/core/common/buildflags/buildflags.gni")

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -5,7 +5,6 @@
 
 import("//brave/android/android_browser_tests.gni")
 import("//brave/browser/metrics/buildflags/buildflags.gni")
-import("//brave/browser/ui/sidebar/buildflags/buildflags.gni")
 import("//brave/browser/updater/buildflags.gni")
 import("//brave/build/config.gni")
 import("//brave/components/ai_chat/core/common/buildflags/buildflags.gni")


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/54735

With this PR, side panel's padding is toggled per rounded corners setting.

Introduces BraveSidePanelResizeArea, a SidePanelResizeArea subclass
that adapts its layout based on whether the panel has a border:

 - With border (rounded corners on): delegates to the upstream layout
  so the resize strip sits inside the existing border gap.
 - Without border (rounded corners off): positions itself as a 5 px
   strip at the inner panel edge, overlapping the content area and
   sitting above it in z-order to win hit-testing.

Adds SidePanel::SetBorderEnabled() via chromium_src macro injection
to toggle the border at runtime. When disabled, the panel's views::Border
is removed so content fills the full panel area. UpdateBorder() centralises
the state management and is called from a wrapped Open() to undo the
unconditional border_view_ re-show that upstream's UpdateVisibility() performs.
The border insets are also corrected: upstream's negative top inset
(meant to overlap the toolbar) is zeroed out because Brave does not need that overlap.

Fixes the side panel's vertical position: the upstream layout places
contents_height_side_panel 1 px above visual_client_area.y() to overlap the toolbar separator.
CalculateSideBarLayout now aligns the panel's y and height with the contents container
so the top separator remains fully visible when rounded corners are off.

BraveBrowserView::UpdateSidebarBorder() calls SetBorderEnabled() based on
ShouldUseBraveWebViewRoundedCornersForContents(), and BraveSidePanelResizeArea
is installed via SetResizeArea() during sidebar setup.

TEST=SidebarBrowserTest.SidebarV2ResizeAreaPositionMatchesBorderState

**NOTE:** Applying Brave's specific border style (corner radius, shadow or border padding) is left for a follow-up issue.

<img width="800"  alt="image" src="https://github.com/user-attachments/assets/2615759e-373f-46e5-a392-36b2d9ba8599" />

<img width="800" alt="image" src="https://github.com/user-attachments/assets/0401e22a-8629-4f9d-abf7-26bf232209d7" />

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
