### PR TITLE
Bold the Brave wordmark on the Settings About page

### DIFF
--- a/browser/resources/settings/br/about_page.ts
+++ b/browser/resources/settings/br/about_page.ts
@@ -14,6 +14,10 @@ RegisterStyleOverride(
   'settings-about-page',
   html`
     <style>
+      .product-title {
+        font-weight: 600;
+      }
+
       #release-notes {
         display: block;
         margin-inline-start: unset;


### PR DESCRIPTION
## Summary
- increase the About page product title weight so the Brave wordmark appears bold
- keep the existing Brave-specific release-notes link override unchanged

## Test plan
- open brave://settings/help
- verify the Brave wordmark beside the lion logo appears bold
- verify the release notes link still renders and works as before

Fixes brave/brave-browser#41637