### PR TITLE
Use generic folder icon for Bookmarks side panel row

### DIFF
--- a/chromium_src/chrome/browser/resources/side_panel/bookmarks/power_bookmark_row_item.html.ts.lit_mangler.ts
+++ b/chromium_src/chrome/browser/resources/side_panel/bookmarks/power_bookmark_row_item.html.ts.lit_mangler.ts
@@ -1,0 +1,16 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { mangle } from 'lit_mangler'
+
+mangle(fragment => {
+  const bookmarksBarIcon = fragment.querySelector(
+    'cr-icon.bookmark-icon[slot="folder-icon"][icon="bookmarks:bookmarks-bar"]',
+  )
+  if (!bookmarksBarIcon) {
+    throw new Error('Bookmarks bar icon not found')
+  }
+  bookmarksBarIcon.remove()
+})


### PR DESCRIPTION
## Summary
- remove the bookmarks bar-specific side panel icon override for the Bookmarks root row
- let the row fall back to the standard folder icon shown in the expected design

## Test plan
- not run (UI template override only)

Fixes brave/brave-browser#42163