### PR TITLE
Use a Brave-owned domain for the DoH verification probe

### DIFF
--- a/patches/net-dns-dns_transaction.h.patch
+++ b/patches/net-dns-dns_transaction.h.patch
@@ -1,0 +1,13 @@
+diff --git a/net/dns/dns_transaction.h b/net/dns/dns_transaction.h
+--- a/net/dns/dns_transaction.h
++++ b/net/dns/dns_transaction.h
+@@ -27,7 +27,7 @@ class DnsSession;
+ class NetLogWithSource;
+ class ResolveContext;
+ 
+ // The hostname probed by CreateDohProbeRunner().
+-inline constexpr std::string_view kDohProbeHostname = "www.gstatic.com";
++inline constexpr std::string_view kDohProbeHostname = "brave.com";
+ 
+ // DnsTransaction implements a stub DNS resolver as defined in RFC 1034.
+ // The DnsTransaction takes care of retransmissions, name server fallback (or


### PR DESCRIPTION
## Summary
- change the DoH probe hostname from `www.gstatic.com` to `brave.com`
- avoid sending the custom-provider verification lookup to a Google-owned domain

## Test plan
- `git apply --check patches/net-dns-dns_transaction.h.patch` against a temp copy of upstream `net/dns/dns_transaction.h`
- not run (full Chromium/Brave build not available in this workspace)

Fixes brave/brave-browser#38555
