### PR TITLE
Use private window terminology in Linux desktop action

### DIFF
--- a/patches/chrome-installer-linux-common-desktop.template.patch
+++ b/patches/chrome-installer-linux-common-desktop.template.patch
@@ -1,0 +1,21 @@
+diff --git a/chrome/installer/linux/common/desktop.template b/chrome/installer/linux/common/desktop.template
+--- a/chrome/installer/linux/common/desktop.template
++++ b/chrome/installer/linux/common/desktop.template
+@@ -170,7 +170,7 @@
+ Exec=/usr/bin/@@usr_bin_symlink_name
+ 
+ [Desktop Action new-private-window]
+-Name=New Incognito Window
++Name=New Private Window
+ Name[ar]=نافذة جديدة للتصفح المتخفي
+ Name[bg]=Нов прозорец „инкогнито“
+ Name[bn]=নতুন ছদ্মবেশী উইন্ডো
+@@ -179,7 +179,7 @@
+ Name[da]=Nyt inkognitovindue
+ Name[de]=Neues Inkognito-Fenster
+ Name[el]=Νέο παράθυρο για ανώνυμη περιήγηση
+-Name[en_GB]=New Incognito window
++Name[en_GB]=New Private window
+ Name[es]=Nueva ventana de incógnito
+ Name[et]=Uus inkognito aken
+ Name[fa]=پنجره جدید حالت ناشناس


### PR DESCRIPTION
## Summary
- update the Linux desktop action label from "New Incognito Window" to "New Private Window"
- update the `en_GB` variant to match Brave's private-window terminology

## Test plan
- `git apply --check patches/chrome-installer-linux-common-desktop.template.patch` against a fresh copy of Chromium's `chrome/installer/linux/common/desktop.template`
- not run (Linux package build not available in this workspace)

Fixes brave/brave-browser#37623
