### PR TITLE
[Wallet]: Adjust Key Export Modal Padding

### DIFF
--- a/components/brave_wallet_ui/components/desktop/popup-modals/account-settings-modal/account-settings-modal.style.ts
+++ b/components/brave_wallet_ui/components/desktop/popup-modals/account-settings-modal/account-settings-modal.style.ts
@@ -14,7 +14,7 @@ import LeoSegmentedControl, {
 import ClipboardIcon from '../../../../assets/svg-icons/copy-to-clipboard-icon.svg'
 
 // Shared Styles
-import { WalletButton, Row } from '../../../shared/style'
+import { WalletButton, Row, Column } from '../../../shared/style'
 import {
   layoutPanelWidth, //
 } from '../../wallet-page-wrapper/wallet-page-wrapper.style'
@@ -90,14 +90,8 @@ export const CopyIcon = styled.div`
   margin-left: 10px;
 `
 
-export const PrivateKeyWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: flex-start;
-  width: 100%;
-  height: 100%;
-  width: 250px;
+export const PrivateKeyWrapper = styled(Column)`
+  max-width: 350px;
 `
 
 export const PrivateKeyBubble = styled(WalletButton)`
@@ -108,7 +102,7 @@ export const PrivateKeyBubble = styled(WalletButton)`
   flex-direction: row;
   background-color: ${(p) => p.theme.color.background01};
   padding: 5px 10px;
-  max-width: 240px;
+  max-width: 350px;
   height: auto;
   border-radius: 4px;
   margin: 0px;

--- a/components/brave_wallet_ui/components/desktop/popup-modals/account-settings-modal/account-settings-modal.tsx
+++ b/components/brave_wallet_ui/components/desktop/popup-modals/account-settings-modal/account-settings-modal.tsx
@@ -81,7 +81,7 @@ import {
   ControlsWrapper,
   SegmentedControl,
 } from './account-settings-modal.style'
-import { Column, Text, VerticalSpacer } from '../../../shared/style'
+import { Column, Row, Text, VerticalSpacer } from '../../../shared/style'
 import { Skeleton } from '../../../shared/loading-skeleton/styles'
 
 const zcashAddressOptions: zcashAddressOptionType[] = [
@@ -584,7 +584,12 @@ export const AccountSettingsModal = () => {
           </EditWrapper>
         )}
         {accountModalType === 'privateKey' && (
-          <PrivateKeyWrapper>
+          <PrivateKeyWrapper
+            width='100%'
+            height='100%'
+            justifyContent='flex-start'
+            padding='0px 16px'
+          >
             <Alert type='warning'>
               {getLocale('braveWalletAccountSettingsDisclaimer')}
             </Alert>
@@ -672,7 +677,7 @@ export const AccountSettingsModal = () => {
               && showEncryptionPassword
               && !privateKey ? (
                 // Show Cancel and Confirm buttons for encryption password
-                <ButtonRow>
+                <Row gap='8px'>
                   <Button
                     onClick={onCancelEncryptionPassword}
                     kind='outline'
@@ -686,10 +691,10 @@ export const AccountSettingsModal = () => {
                   >
                     {getLocale('braveWalletAccountSettingsShowKey')}
                   </Button>
-                </ButtonRow>
+                </Row>
               ) : privateKey ? (
                 // Show Download and Hide buttons when key is visible
-                <ButtonRow>
+                <Row gap='8px'>
                   {selectedAccount?.accountId.coin
                     === BraveWallet.CoinType.DOT && (
                     <Button
@@ -705,7 +710,7 @@ export const AccountSettingsModal = () => {
                   >
                     {getLocale('braveWalletAccountSettingsHideKey')}
                   </Button>
-                </ButtonRow>
+                </Row>
               ) : (
                 // Show "Show Key" button when no key is visible
                 <Button


### PR DESCRIPTION
## Description 

Adjusts the `padding` in the `Export Private Key` modal

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/52443>

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

Before:

<img width="621" height="600" alt="Screenshot 24" src="https://github.com/user-attachments/assets/dc377ec8-5116-46a2-94a9-2ade30e57de9" /> | <img width="620" height="764" alt="Screenshot 25" src="https://github.com/user-attachments/assets/51c62792-c9d1-4481-b8a7-e6162fb3d61d" />
--|--

After:

<img width="618" height="567" alt="Screenshot 22" src="https://github.com/user-attachments/assets/26d021b5-e00c-4f98-b74d-a9b5a520e03a" /> | <img width="633" height="670" alt="Screenshot 23" src="https://github.com/user-attachments/assets/07d5d066-8e26-44e4-9a81-f36af73aa057" />
--|--