### PR TITLE
Sync group toggle command with vertical tabs

### DIFF
--- a/browser/ui/browser_commands.cc
+++ b/browser/ui/browser_commands.cc
@@ -713,9 +713,16 @@ void ToggleGroupExpanded(Browser* browser) {
 
   auto* group = tsm->group_model()->GetTabGroup(*group_id);
   auto* vd = group->visual_data();
+  const bool collapsed = !vd->is_collapsed();
   tab_groups::TabGroupVisualData vd_update(vd->title(), vd->color(),
-                                           !vd->is_collapsed());
+                                           collapsed);
   group->SetVisualData(vd_update);
+
+  auto* brave_tsm = static_cast<BraveTabStripModel*>(tsm);
+  if (const auto* tree_node_id = brave_tsm->GetTreeTabNodeIdForGroup(*group_id);
+      tree_node_id) {
+    brave_tsm->SetTreeTabNodeCollapsed(*tree_node_id, collapsed);
+  }
 }
 
 void CloseUngroupedTabs(Browser* browser) {

--- a/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_browsertest.cc
+++ b/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_browsertest.cc
@@ -1876,6 +1876,48 @@ IN_PROC_BROWSER_TEST_P(VerticalTabStripBrowserTest,
             TabSlotView::ViewType::kTabGroupHeader);
 }
 
+IN_PROC_BROWSER_TEST_P(VerticalTabStripBrowserTest,
+                       ToggleGroupExpandedCommandUpdatesLayout) {
+  ToggleVerticalTabStrip();
+
+  auto* brave_tab_container = views::AsViewClass<BraveTabContainer>(
+      views::AsViewClass<BraveTabStrip>(
+          browser_view()->horizontal_tab_strip_for_testing())
+          ->GetTabContainerForTesting());
+  ASSERT_TRUE(brave_tab_container);
+
+  // Deflake the test by setting TabGroupSyncService initialized.
+  tab_groups::TabGroupSyncService* service =
+      tab_groups::TabGroupSyncServiceFactory::GetForProfile(
+          browser()->profile());
+  service->SetIsInitializedForTesting(true);
+
+  auto* model = browser()->tab_strip_model();
+  browser_view()->horizontal_tab_strip_for_testing()->StopAnimating();
+
+  while (brave_tab_container->GetMaxScrollOffset() <=
+         5 * tabs::kVerticalTabHeight) {
+    AppendTab(browser());
+    browser_view()->horizontal_tab_strip_for_testing()->StopAnimating();
+    InvalidateAndRunLayoutForVerticalTabStrip();
+  }
+
+  tab_groups::TabGroupId group1 =
+      AddTabToNewGroup(browser(), model->count() - 1);
+  model->ActivateTabAt(model->count() - 1);
+  const int expanded_scroll_offset = brave_tab_container->GetMaxScrollOffset();
+
+  brave::ToggleGroupExpanded(browser());
+
+  ASSERT_TRUE(browser_view()
+                  ->horizontal_tab_strip_for_testing()
+                  ->controller()
+                  ->IsGroupCollapsed(group1));
+  EXPECT_EQ(brave_tab_container->GetMaxScrollOffset(),
+            expanded_scroll_offset - tabs::kVerticalTabHeight -
+                tabs::kVerticalTabsSpacing);
+}
+
 // * Non-type argument of 'float' or 'double' for template is unsupported
 // * Passing template as argument of IN_PROC_BROWSER_TEST_F is not working
 // > thus, use macro instead.


### PR DESCRIPTION
## Summary
- sync `ToggleGroupExpanded` with the vertical-tabs tree node state used for layout updates
- add a browser regression test that exercises the command path and verifies the vertical tab strip layout updates immediately

## Test plan
- run `git diff --check`
- inspect `browser/ui/browser_commands.cc` to confirm the command updates both tab-group visual data and the matching tree node state
- inspect `browser/ui/views/frame/vertical_tabs/vertical_tab_strip_browsertest.cc` for the new `ToggleGroupExpandedCommandUpdatesLayout` coverage

Fixes brave/brave-browser#47434