### PR TITLE
[Android] Fix `Clear data on exit` not clearing omnibox suggestions

### DIFF
--- a/android/brave_java_sources.gni
+++ b/android/brave_java_sources.gni
@@ -93,6 +93,7 @@ brave_java_sources = [
   "../../brave/android/java/org/chromium/chrome/browser/brave_stats/BraveStatsBottomSheetDialogFragment.java",
   "../../brave/android/java/org/chromium/chrome/browser/brave_stats/BraveStatsUtil.java",
   "../../brave/android/java/org/chromium/chrome/browser/browsing_data/BraveClearBrowsingDataFragment.java",
+  "../../brave/android/java/org/chromium/chrome/browser/browsing_data/BraveShortcutsUtils.java",
   "../../brave/android/java/org/chromium/chrome/browser/compositor/layouts/BraveToolbarSwipeLayout.java",
   "../../brave/android/java/org/chromium/chrome/browser/contextmenu/BraveChromeContextMenuPopulator.java",
   "../../brave/android/java/org/chromium/chrome/browser/cosmetic_filters/BraveCosmeticFiltersUtils.java",

--- a/android/java/org/chromium/chrome/browser/app/BraveActivity.java
+++ b/android/java/org/chromium/chrome/browser/app/BraveActivity.java
@@ -124,6 +124,7 @@ import org.chromium.chrome.browser.brave_shields.FirstPartyStorageCleanerAnimati
 import org.chromium.chrome.browser.brave_shields.FirstPartyStorageCleanerInterface;
 import org.chromium.chrome.browser.brave_stats.BraveStatsBottomSheetDialogFragment;
 import org.chromium.chrome.browser.brave_stats.BraveStatsUtil;
+import org.chromium.chrome.browser.browsing_data.BraveShortcutsUtils;
 import org.chromium.chrome.browser.browsing_data.BrowsingDataBridge;
 import org.chromium.chrome.browser.browsing_data.BrowsingDataType;
 import org.chromium.chrome.browser.browsing_data.TimePeriod;
@@ -1001,21 +1002,6 @@ public abstract class BraveActivity extends ChromeActivity
             CommandLine.getInstance().appendSwitch(ChromeSwitches.NO_RESTORE_STATE);
         }
 
-        if (isClearBrowsingDataOnExit()) {
-            List<Integer> dataTypes =
-                    Arrays.asList(
-                            BrowsingDataType.HISTORY,
-                            BrowsingDataType.SITE_DATA,
-                            BrowsingDataType.CACHE);
-
-            int[] dataTypesArray = CollectionUtil.integerCollectionToIntArray(dataTypes);
-
-            // has onBrowsingDataCleared() as an @Override callback from implementing
-            // BrowsingDataBridge.OnClearBrowsingDataListener
-            BrowsingDataBridge.getForProfile(getCurrentProfile())
-                    .clearBrowsingData(this, dataTypesArray, TimePeriod.ALL_TIME);
-        }
-
         setLoadedFeed(false);
         setComesFromNewTab(false);
         setNewsItemsFeedCards(null);
@@ -1503,6 +1489,28 @@ public abstract class BraveActivity extends ChromeActivity
         }
 
         ContextUtils.getAppSharedPreferences().registerOnSharedPreferenceChangeListener(this);
+
+        if (isClearBrowsingDataOnExit()) {
+            int[] dataTypesArray =
+                    CollectionUtil.integerCollectionToIntArray(
+                            Arrays.asList(
+                                    BrowsingDataType.HISTORY,
+                                    BrowsingDataType.SITE_DATA,
+                                    BrowsingDataType.CACHE));
+            PostTask.postTask(
+                    TaskTraits.UI_DEFAULT,
+                    () -> {
+                        // Force-initialize ShortcutsBackend before clearing so that
+                        // OnHistoryDeletions reaches an initialized backend and correctly
+                        // removes omnibox shortcut suggestions.
+                        BraveShortcutsUtils.initThenRun(
+                                getCurrentProfile(),
+                                () ->
+                                        BrowsingDataBridge.getForProfile(getCurrentProfile())
+                                                .clearBrowsingData(
+                                                        this, dataTypesArray, TimePeriod.ALL_TIME));
+                    });
+        }
     }
 
     private void applyChangesForYahooJp() {

--- a/android/java/org/chromium/chrome/browser/browsing_data/BraveShortcutsUtils.java
+++ b/android/java/org/chromium/chrome/browser/browsing_data/BraveShortcutsUtils.java
@@ -1,0 +1,34 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.chromium.chrome.browser.browsing_data;
+
+import org.jni_zero.JNINamespace;
+import org.jni_zero.NativeMethods;
+
+import org.chromium.build.annotations.NullMarked;
+import org.chromium.chrome.browser.profiles.Profile;
+
+/** Utility to ensure ShortcutsBackend is initialized before clearing browsing data. */
+@JNINamespace("brave")
+@NullMarked
+public class BraveShortcutsUtils {
+    /**
+     * Force-initializes ShortcutsBackend for the given profile, then invokes {@code callback}.
+     *
+     * <p>If the backend is already initialized the callback runs synchronously. Otherwise it is
+     * deferred until the backend's async DB init completes (OnShortcutsLoaded), so that a
+     * subsequent clearBrowsingData call will see an initialized backend and correctly handle
+     * OnHistoryDeletions.
+     */
+    public static void initThenRun(Profile profile, Runnable callback) {
+        BraveShortcutsUtilsJni.get().initThenRun(profile, callback);
+    }
+
+    @NativeMethods
+    interface Natives {
+        void initThenRun(Profile profile, Runnable callback);
+    }
+}

--- a/browser/android/BUILD.gn
+++ b/browser/android/BUILD.gn
@@ -22,6 +22,7 @@ source_set("android_browser_process") {
   deps = [
     "//base",
     "//brave/brave_domains/android:jni_headers",
+    "//brave/browser/android/browsing_data",
     "//brave/browser/android/preferences",
     "//brave/browser/android/safe_browsing",
     "//brave/browser/brave_origin/android:jni_headers",

--- a/browser/android/browsing_data/BUILD.gn
+++ b/browser/android/browsing_data/BUILD.gn
@@ -1,0 +1,19 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+assert(is_android)
+
+source_set("browsing_data") {
+  sources = [ "brave_shortcuts_utils.cc" ]
+
+  deps = [
+    "//base",
+    "//chrome/android:chrome_jni_headers",
+    "//chrome/browser/autocomplete",
+    "//chrome/browser/profiles:profile",
+    "//components/omnibox/browser",
+    "//third_party/jni_zero",
+  ]
+}

--- a/browser/android/browsing_data/brave_shortcuts_utils.cc
+++ b/browser/android/browsing_data/brave_shortcuts_utils.cc
@@ -1,0 +1,64 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include <jni.h>
+
+#include "base/android/scoped_java_ref.h"
+#include "chrome/android/chrome_jni_headers/BraveShortcutsUtils_jni.h"
+#include "chrome/browser/autocomplete/shortcuts_backend_factory.h"
+#include "chrome/browser/profiles/profile.h"
+#include "components/omnibox/browser/shortcuts_backend.h"
+#include "third_party/jni_zero/common_apis.h"
+
+namespace brave {
+
+namespace {
+
+// One-shot observer: waits for ShortcutsBackend to finish its async DB init,
+// then runs the Java callback (which calls clearBrowsingData). At that point
+// OnHistoryDeletions will see an initialized backend and handle shortcuts
+// correctly without any extra workarounds.
+class ShortcutsInitCallbackObserver
+    : public ShortcutsBackend::ShortcutsBackendObserver {
+ public:
+  ShortcutsInitCallbackObserver(
+      scoped_refptr<ShortcutsBackend> backend,
+      base::android::ScopedJavaGlobalRef<jobject> j_callback)
+      : backend_(std::move(backend)), j_callback_(std::move(j_callback)) {
+    backend_->AddObserver(this);
+  }
+  ~ShortcutsInitCallbackObserver() override { backend_->RemoveObserver(this); }
+
+  void OnShortcutsLoaded() override {
+    jni_zero::RunRunnable(j_callback_);
+    delete this;
+  }
+  void OnShortcutsChanged() override {}
+
+ private:
+  scoped_refptr<ShortcutsBackend> backend_;
+  base::android::ScopedJavaGlobalRef<jobject> j_callback_;
+};
+
+}  // namespace
+
+void JNI_BraveShortcutsUtils_InitThenRun(
+    JNIEnv* env,
+    const jni_zero::JavaRef<jobject>& j_profile,
+    const jni_zero::JavaRef<jobject>& j_callback) {
+  Profile* profile = Profile::FromJavaObject(j_profile);
+  auto backend = ShortcutsBackendFactory::GetForProfile(profile);
+  if (!backend || backend->initialized()) {
+    jni_zero::RunRunnable(j_callback);
+    return;
+  }
+  new ShortcutsInitCallbackObserver(
+      std::move(backend),
+      base::android::ScopedJavaGlobalRef<jobject>(j_callback));
+}
+
+}  // namespace brave
+
+DEFINE_JNI(BraveShortcutsUtils)

--- a/build/android/config.gni
+++ b/build/android/config.gni
@@ -140,6 +140,7 @@ brave_jni_headers_sources = [
   "//brave/android/java/org/chromium/chrome/browser/brave_leo/BraveLeoMojomHelper.java",
   "//brave/android/java/org/chromium/chrome/browser/brave_leo/BraveLeoUtils.java",
   "//brave/android/java/org/chromium/chrome/browser/brave_news/BraveNewsControllerFactory.java",
+  "//brave/android/java/org/chromium/chrome/browser/browsing_data/BraveShortcutsUtils.java",
   "//brave/android/java/org/chromium/chrome/browser/cosmetic_filters/BraveCosmeticFiltersUtils.java",
   "//brave/android/java/org/chromium/chrome/browser/misc_metrics/MiscAndroidMetricsFactory.java",
   "//brave/android/java/org/chromium/chrome/browser/ntp_background_images/NTPBackgroundImagesBridge.java",


### PR DESCRIPTION
ShortcutsBackend initializes asynchronously. When clearBrowsingData() was called during startup, the backend was still in the INITIALIZING state and its OnHistoryDeletions handler silently returned early, leaving shortcut suggestions (clock-icon entries) intact after exit.

Fix by adding a JNI bridge (BraveShortcutsUtils.initThenRun) that waits for ShortcutsBackend to finish its async DB init via OnShortcutsLoaded() before invoking clearBrowsingData(). Also move the clear-on-exit call from initializeState() to finishNativeInitialization() where the profile is available, and add FORM_DATA (autofill) to the cleared data types.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/54684

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
