### PR TITLE
Fix macOS deprecation infobar message to reference macOS 13 instead o…

### DIFF
--- a/app/brave_generated_resources.grd
+++ b/app/brave_generated_resources.grd
@@ -680,7 +680,7 @@ Or change later at <ph name="SETTINGS_EXTENIONS_LINK">$2<ex>brave://settings/ext
         </if>
         <if expr="is_macosx">
           <message name="IDS_OBSOLETE_SYSTEM_CONFIRM_DIALOG_CONTENT" desc="The text for obsolete system confirm dialog">
-            By clicking OK, you acknowledge that your installation of Brave will NOT receive critical security fixes until you update to macOS 10.15 or later. This warning will NOT show again.
+            By clicking OK, you acknowledge that your installation of Brave will NOT receive critical security fixes until you update to macOS 13 or later. This warning will NOT show again.
           </message>
         </if>
 


### PR DESCRIPTION
Fix macOS deprecation infobar message to reference macOS 13 instead of 10.15

The warning message shown when dismissing the OS deprecation infobar
incorrectly referenced macOS 10.15. Since Chromium 150 is dropping
support for macOS 12.x (Monterey), update the string to reflect 13.x.

Resolves brave/brave-browser#54848