### PR TITLE
[Android] Fix BraveAdsAdsServiceImplTest on is_official_build x86

### DIFF
--- a/components/brave_ads/browser/BUILD.gn
+++ b/components/brave_ads/browser/BUILD.gn
@@ -144,6 +144,7 @@ source_set("unit_tests") {
     "//brave/components/brave_ads/core/public:headers",
     "//brave/components/brave_component_updater/browser",
     "//brave/components/brave_rewards/core",
+    "//brave/components/brave_rewards/core:features",
     "//brave/components/brave_rewards/core/buildflags",
     "//brave/components/ntp_background_images/common",
     "//components/content_settings/core/browser",

--- a/components/brave_ads/browser/ads_service_impl_unittest.cc
+++ b/components/brave_ads/browser/ads_service_impl_unittest.cc
@@ -11,6 +11,7 @@
 #include "base/files/scoped_temp_dir.h"
 #include "base/memory/raw_ptr.h"
 #include "base/test/run_until.h"
+#include "base/test/scoped_feature_list.h"
 #include "base/test/task_environment.h"
 #include "base/values.h"
 #include "brave/components/brave_ads/browser/test/fake_ads_service_delegate.h"
@@ -21,6 +22,7 @@
 #include "brave/components/brave_ads/core/public/prefs/pref_names.h"
 #include "brave/components/brave_ads/core/public/prefs/pref_registry.h"
 #include "brave/components/brave_rewards/core/buildflags/buildflags.h"
+#include "brave/components/brave_rewards/core/features.h"
 #include "brave/components/brave_rewards/core/pref_names.h"
 #include "brave/components/brave_rewards/core/pref_registry.h"
 #include "brave/components/ntp_background_images/common/pref_names.h"
@@ -41,6 +43,16 @@ namespace brave_ads {
 class BraveAdsAdsServiceImplTest : public testing::Test {
  public:
   void SetUp() override {
+#if BUILDFLAG(IS_ANDROID)
+    // `brave_rewards::features::kBraveRewards` is `DISABLED_BY_DEFAULT` on
+    // `is_official_build=true` x86/x86_64 Android, which routes
+    // `brave_rewards::IsSupported` through `IsDisabledByFeature` and prevents
+    // the service from starting. Force-enable so Android matches the
+    // non-Android path these tests were written against.
+    scoped_feature_list_.InitAndEnableFeature(
+        brave_rewards::features::kBraveRewards);
+#endif  // BUILDFLAG(IS_ANDROID)
+
     ASSERT_TRUE(profile_dir_.CreateUniqueTempDir());
 
     RegisterProfilePrefs(prefs_.registry());
@@ -94,6 +106,10 @@ class BraveAdsAdsServiceImplTest : public testing::Test {
   }
 
   void Shutdown() { ads_service_->Shutdown(); }
+
+#if BUILDFLAG(IS_ANDROID)
+  base::test::ScopedFeatureList scoped_feature_list_;
+#endif  // BUILDFLAG(IS_ANDROID)
 
   base::test::TaskEnvironment task_environment_;
 


### PR DESCRIPTION
`brave_rewards::features::kBraveRewards` is `DISABLED_BY_DEFAULT` on `x86/x86_64` Android official builds, so `brave_rewards::IsSupported` returned false via `IsDisabledByFeature`. After https://github.com/brave/brave-core/pull/35698 moved the `IsSupported` gate into `AdsServiceImpl::CanStartBatAdsService`, that path now suppresses the service in unit tests too and launch_count stays 0. Force-enable the feature in the fixture so Android tests match the non-Android path they were written against.

Resolves: https://github.com/brave/brave-browser/issues/54831
Resolves: https://github.com/brave/brave-browser/issues/54832
Resolves: https://github.com/brave/brave-browser/issues/54833
Resolves: https://github.com/brave/brave-browser/issues/54834
Resolves: https://github.com/brave/brave-browser/issues/54835
Resolves: https://github.com/brave/brave-browser/issues/54836
Resolves: https://github.com/brave/brave-browser/issues/54837
Resolves: https://github.com/brave/brave-browser/issues/54838
Resolves: https://github.com/brave/brave-browser/issues/54839
Resolves: https://github.com/brave/brave-browser/issues/54840
Resolves: https://github.com/brave/brave-browser/issues/54841
Resolves: https://github.com/brave/brave-browser/issues/54842

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
