### PR TITLE
[Android] Fix `Clear data on exit` not clearing omnibox suggestions (uplift to 1.90.x)

### DIFF
--- a/android/brave_java_sources.gni
+++ b/android/brave_java_sources.gni
@@ -92,6 +92,7 @@ brave_java_sources = [
   "../../brave/android/java/org/chromium/chrome/browser/brave_stats/BraveStatsBottomSheetDialogFragment.java",
   "../../brave/android/java/org/chromium/chrome/browser/brave_stats/BraveStatsUtil.java",
   "../../brave/android/java/org/chromium/chrome/browser/browsing_data/BraveClearBrowsingDataFragment.java",
+  "../../brave/android/java/org/chromium/chrome/browser/browsing_data/BraveShortcutsUtils.java",
   "../../brave/android/java/org/chromium/chrome/browser/compositor/layouts/BraveToolbarSwipeLayout.java",
   "../../brave/android/java/org/chromium/chrome/browser/contextmenu/BraveChromeContextMenuPopulator.java",
   "../../brave/android/java/org/chromium/chrome/browser/cosmetic_filters/BraveCosmeticFiltersUtils.java",

--- a/android/java/org/chromium/chrome/browser/app/BraveActivity.java
+++ b/android/java/org/chromium/chrome/browser/app/BraveActivity.java
@@ -125,6 +125,7 @@ import org.chromium.chrome.browser.brave_shields.FirstPartyStorageCleanerAnimati
 import org.chromium.chrome.browser.brave_shields.FirstPartyStorageCleanerInterface;
 import org.chromium.chrome.browser.brave_stats.BraveStatsBottomSheetDialogFragment;
 import org.chromium.chrome.browser.brave_stats.BraveStatsUtil;
+import org.chromium.chrome.browser.browsing_data.BraveShortcutsUtils;
 import org.chromium.chrome.browser.browsing_data.BrowsingDataBridge;
 import org.chromium.chrome.browser.browsing_data.BrowsingDataType;
 import org.chromium.chrome.browser.browsing_data.TimePeriod;
@@ -1005,21 +1006,6 @@ public abstract class BraveActivity extends ChromeActivity
             CommandLine.getInstance().appendSwitch(ChromeSwitches.NO_RESTORE_STATE);
         }
 
-        if (isClearBrowsingDataOnExit()) {
-            List<Integer> dataTypes =
-                    Arrays.asList(
-                            BrowsingDataType.HISTORY,
-                            BrowsingDataType.SITE_DATA,
-                            BrowsingDataType.CACHE);
-
-            int[] dataTypesArray = CollectionUtil.integerCollectionToIntArray(dataTypes);
-
-            // has onBrowsingDataCleared() as an @Override callback from implementing
-            // BrowsingDataBridge.OnClearBrowsingDataListener
-            BrowsingDataBridge.getForProfile(getCurrentProfile())
-                    .clearBrowsingData(this, dataTypesArray, TimePeriod.ALL_TIME);
-        }
-
         setLoadedFeed(false);
         setComesFromNewTab(false);
         setNewsItemsFeedCards(null);
@@ -1507,6 +1493,28 @@ public abstract class BraveActivity extends ChromeActivity
         }
 
         ContextUtils.getAppSharedPreferences().registerOnSharedPreferenceChangeListener(this);
+
+        if (isClearBrowsingDataOnExit()) {
+            int[] dataTypesArray =
+                    CollectionUtil.integerCollectionToIntArray(
+                            Arrays.asList(
+                                    BrowsingDataType.HISTORY,
+                                    BrowsingDataType.SITE_DATA,
+                                    BrowsingDataType.CACHE));
+            PostTask.postTask(
+                    TaskTraits.UI_DEFAULT,
+                    () -> {
+                        // Force-initialize ShortcutsBackend before clearing so that
+                        // OnHistoryDeletions reaches an initialized backend and correctly
+                        // removes omnibox shortcut suggestions.
+                        BraveShortcutsUtils.initThenRun(
+                                getCurrentProfile(),
+                                () ->
+                                        BrowsingDataBridge.getForProfile(getCurrentProfile())
+                                                .clearBrowsingData(
+                                                        this, dataTypesArray, TimePeriod.ALL_TIME));
+                    });
+        }
     }
 
     private void applyChangesForYahooJp() {

--- a/android/java/org/chromium/chrome/browser/browsing_data/BraveShortcutsUtils.java
+++ b/android/java/org/chromium/chrome/browser/browsing_data/BraveShortcutsUtils.java
@@ -1,0 +1,34 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.chromium.chrome.browser.browsing_data;
+
+import org.jni_zero.JNINamespace;
+import org.jni_zero.NativeMethods;
+
+import org.chromium.build.annotations.NullMarked;
+import org.chromium.chrome.browser.profiles.Profile;
+
+/** Utility to ensure ShortcutsBackend is initialized before clearing browsing data. */
+@JNINamespace("brave")
+@NullMarked
+public class BraveShortcutsUtils {
+    /**
+     * Force-initializes ShortcutsBackend for the given profile, then invokes {@code callback}.
+     *
+     * <p>If the backend is already initialized the callback runs synchronously. Otherwise it is
+     * deferred until the backend's async DB init completes (OnShortcutsLoaded), so that a
+     * subsequent clearBrowsingData call will see an initialized backend and correctly handle
+     * OnHistoryDeletions.
+     */
+    public static void initThenRun(Profile profile, Runnable callback) {
+        BraveShortcutsUtilsJni.get().initThenRun(profile, callback);
+    }
+
+    @NativeMethods
+    interface Natives {
+        void initThenRun(Profile profile, Runnable callback);
+    }
+}

--- a/browser/android/BUILD.gn
+++ b/browser/android/BUILD.gn
@@ -22,6 +22,7 @@ source_set("android_browser_process") {
   deps = [
     "//base",
     "//brave/brave_domains/android:jni_headers",
+    "//brave/browser/android/browsing_data",
     "//brave/browser/android/preferences",
     "//brave/browser/android/safe_browsing",
     "//brave/browser/brave_origin/android:jni_headers",

--- a/browser/android/browsing_data/BUILD.gn
+++ b/browser/android/browsing_data/BUILD.gn
@@ -1,0 +1,19 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+assert(is_android)
+
+source_set("browsing_data") {
+  sources = [ "brave_shortcuts_utils.cc" ]
+
+  deps = [
+    "//base",
+    "//chrome/android:chrome_jni_headers",
+    "//chrome/browser/autocomplete",
+    "//chrome/browser/profiles:profile",
+    "//components/omnibox/browser",
+    "//third_party/jni_zero",
+  ]
+}

--- a/browser/android/browsing_data/brave_shortcuts_utils.cc
+++ b/browser/android/browsing_data/brave_shortcuts_utils.cc
@@ -1,0 +1,64 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include <jni.h>
+
+#include "base/android/scoped_java_ref.h"
+#include "chrome/android/chrome_jni_headers/BraveShortcutsUtils_jni.h"
+#include "chrome/browser/autocomplete/shortcuts_backend_factory.h"
+#include "chrome/browser/profiles/profile.h"
+#include "components/omnibox/browser/shortcuts_backend.h"
+#include "third_party/jni_zero/common_apis.h"
+
+namespace brave {
+
+namespace {
+
+// One-shot observer: waits for ShortcutsBackend to finish its async DB init,
+// then runs the Java callback (which calls clearBrowsingData). At that point
+// OnHistoryDeletions will see an initialized backend and handle shortcuts
+// correctly without any extra workarounds.
+class ShortcutsInitCallbackObserver
+    : public ShortcutsBackend::ShortcutsBackendObserver {
+ public:
+  ShortcutsInitCallbackObserver(
+      scoped_refptr<ShortcutsBackend> backend,
+      base::android::ScopedJavaGlobalRef<jobject> j_callback)
+      : backend_(std::move(backend)), j_callback_(std::move(j_callback)) {
+    backend_->AddObserver(this);
+  }
+  ~ShortcutsInitCallbackObserver() override { backend_->RemoveObserver(this); }
+
+  void OnShortcutsLoaded() override {
+    jni_zero::RunRunnable(j_callback_);
+    delete this;
+  }
+  void OnShortcutsChanged() override {}
+
+ private:
+  scoped_refptr<ShortcutsBackend> backend_;
+  base::android::ScopedJavaGlobalRef<jobject> j_callback_;
+};
+
+}  // namespace
+
+void JNI_BraveShortcutsUtils_InitThenRun(
+    JNIEnv* env,
+    const jni_zero::JavaRef<jobject>& j_profile,
+    const jni_zero::JavaRef<jobject>& j_callback) {
+  Profile* profile = Profile::FromJavaObject(j_profile);
+  auto backend = ShortcutsBackendFactory::GetForProfile(profile);
+  if (!backend || backend->initialized()) {
+    jni_zero::RunRunnable(j_callback);
+    return;
+  }
+  new ShortcutsInitCallbackObserver(
+      std::move(backend),
+      base::android::ScopedJavaGlobalRef<jobject>(j_callback));
+}
+
+}  // namespace brave
+
+DEFINE_JNI(BraveShortcutsUtils)

--- a/build/android/config.gni
+++ b/build/android/config.gni
@@ -139,6 +139,7 @@ brave_jni_headers_sources = [
   "//brave/android/java/org/chromium/chrome/browser/brave_leo/BraveLeoMojomHelper.java",
   "//brave/android/java/org/chromium/chrome/browser/brave_leo/BraveLeoUtils.java",
   "//brave/android/java/org/chromium/chrome/browser/brave_news/BraveNewsControllerFactory.java",
+  "//brave/android/java/org/chromium/chrome/browser/browsing_data/BraveShortcutsUtils.java",
   "//brave/android/java/org/chromium/chrome/browser/cosmetic_filters/BraveCosmeticFiltersUtils.java",
   "//brave/android/java/org/chromium/chrome/browser/misc_metrics/MiscAndroidMetricsFactory.java",
   "//brave/android/java/org/chromium/chrome/browser/ntp_background_images/NTPBackgroundImagesBridge.java",


### PR DESCRIPTION
Uplift of #35790
Resolves https://github.com/brave/brave-browser/issues/54684

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.