### PR TITLE
[ads] Fix idle notification dropped by IDLE_STATE_UNKNOWN transitions

### DIFF
--- a/components/brave_ads/browser/BUILD.gn
+++ b/components/brave_ads/browser/BUILD.gn
@@ -93,6 +93,8 @@ source_set("test_support") {
     "test/fake_ads_tooltips_delegate.h",
     "test/fake_bat_ads.cc",
     "test/fake_bat_ads.h",
+    "test/fake_bat_ads_client_notifier.cc",
+    "test/fake_bat_ads_client_notifier.h",
     "test/fake_bat_ads_service.cc",
     "test/fake_bat_ads_service.h",
     "test/fake_bat_ads_service_factory.cc",
@@ -110,6 +112,7 @@ source_set("test_support") {
     "//brave/components/services/bat_ads/public/interfaces",
     "//components/prefs",
     "//mojo/public/cpp/bindings",
+    "//ui/base/idle",
     "//url",
   ]
 
@@ -154,6 +157,7 @@ source_set("unit_tests") {
     "//components/variations",
     "//content/test:test_support",
     "//testing/gtest",
+    "//ui/base/idle",
   ]
 
   if (enable_brave_rewards) {

--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -776,7 +776,7 @@ void AdsServiceImpl::CheckIdleState() {
   last_idle_time_ = base::Seconds(ui::CalculateIdleTime());
 }
 
-void AdsServiceImpl::ProcessIdleState(const ui::IdleState idle_state,
+void AdsServiceImpl::ProcessIdleState(ui::IdleState idle_state,
                                       base::TimeDelta idle_time) {
   if (idle_state == last_idle_state_) {
     return;
@@ -804,7 +804,10 @@ void AdsServiceImpl::ProcessIdleState(const ui::IdleState idle_state,
     }
 
     case ui::IdleState::IDLE_STATE_UNKNOWN: {
-      break;
+      // Preserve the last known state; the OS cannot determine the current
+      // state, so treating this as a real transition would corrupt
+      // `last_idle_state_` and cause missed or duplicate notifications.
+      return;
     }
   }
 

--- a/components/brave_ads/browser/ads_service_impl.h
+++ b/components/brave_ads/browser/ads_service_impl.h
@@ -65,18 +65,19 @@ namespace brave_ads {
 
 class AdsTooltipsDelegate;
 class BatAdsServiceFactory;
+class BraveAdsAdsServiceImplTest;
 class DeviceId;
 class ResourceComponent;
 
-class AdsServiceImpl final : public AdsService,
-                             public bat_ads::mojom::BatAdsClient,
-                             public bat_ads::mojom::BatAdsObserver,
-                             public ApplicationStateObserver,
-                             public ResourceComponentObserver,
+class AdsServiceImpl : public AdsService,
+                       public bat_ads::mojom::BatAdsClient,
+                       public bat_ads::mojom::BatAdsObserver,
+                       public ApplicationStateObserver,
+                       public ResourceComponentObserver,
 #if BUILDFLAG(ENABLE_BRAVE_REWARDS)
-                             public brave_rewards::RewardsServiceObserver,
+                       public brave_rewards::RewardsServiceObserver,
 #endif
-                             public content_settings::Observer {
+                       public content_settings::Observer {
  public:
   // `http_client`, `resource_component`, `history_service`, and
   // `host_content_settings` can be `nullptr` in tests. `rewards_service`
@@ -109,6 +110,7 @@ class AdsServiceImpl final : public AdsService,
   void Shutdown() override;
 
  private:
+  friend class BraveAdsAdsServiceImplTest;
   bool IsBatAdsServiceBound() const;
 
   void RegisterResourceComponents();

--- a/components/brave_ads/browser/ads_service_impl_unittest.cc
+++ b/components/brave_ads/browser/ads_service_impl_unittest.cc
@@ -13,6 +13,7 @@
 #include "base/test/run_until.h"
 #include "base/test/scoped_feature_list.h"
 #include "base/test/task_environment.h"
+#include "base/time/time.h"
 #include "base/values.h"
 #include "brave/components/brave_ads/browser/test/fake_ads_service_delegate.h"
 #include "brave/components/brave_ads/browser/test/fake_ads_tooltips_delegate.h"
@@ -31,6 +32,7 @@
 #include "components/prefs/testing_pref_service.h"
 #include "components/variations/pref_names.h"
 #include "testing/gtest/include/gtest/gtest.h"
+#include "ui/base/idle/idle.h"
 
 #if BUILDFLAG(ENABLE_BRAVE_REWARDS)
 #include "brave/components/brave_ads/browser/test/fake_rewards_service.h"
@@ -107,11 +109,13 @@ class BraveAdsAdsServiceImplTest : public testing::Test {
 
   void Shutdown() { ads_service_->Shutdown(); }
 
-#if BUILDFLAG(IS_ANDROID)
-  base::test::ScopedFeatureList scoped_feature_list_;
-#endif  // BUILDFLAG(IS_ANDROID)
+  void SimulateIdleState(ui::IdleState idle_state, base::TimeDelta idle_time) {
+    ads_service_->ProcessIdleState(idle_state, idle_time);
+  }
 
   base::test::TaskEnvironment task_environment_;
+
+  base::test::ScopedFeatureList scoped_feature_list_;
 
   base::ScopedTempDir profile_dir_;
 
@@ -376,7 +380,6 @@ TEST_F(
 }
 #endif  // BUILDFLAG(ENABLE_BRAVE_REWARDS)
 
-#if !BUILDFLAG(IS_ANDROID)
 TEST_F(BraveAdsAdsServiceImplTest,
        ServiceDoesNotStartForSearchResultAdsWhenRewardsIsDisabledByPolicy) {
   // Arrange
@@ -442,6 +445,159 @@ TEST_F(
   EXPECT_EQ(0U, bat_ads_service_factory_->launch_count());
 }
 #endif  // BUILDFLAG(ENABLE_BRAVE_REWARDS)
-#endif  // !BUILDFLAG(IS_ANDROID)
+
+TEST_F(BraveAdsAdsServiceImplTest,
+       ProcessIdleStateNotifiesWhenUserBecomesIdle) {
+  // Arrange
+  prefs_.SetBoolean(prefs::kOptedInToSearchResultAds, true);
+  Startup();
+  ASSERT_TRUE(base::test::RunUntil(
+      [&] { return bat_ads_service_factory_->initialize_count() == 1U; }));
+
+  // Act
+  SimulateIdleState(ui::IdleState::IDLE_STATE_IDLE, base::Seconds(7));
+
+  // Assert
+  EXPECT_TRUE(base::test::RunUntil(
+      [&] { return bat_ads_service_factory_->become_idle_count() == 1U; }));
+}
+
+TEST_F(BraveAdsAdsServiceImplTest, ProcessIdleStateNotifiesWhenScreenLocks) {
+  // Arrange
+  prefs_.SetBoolean(prefs::kOptedInToSearchResultAds, true);
+  Startup();
+  ASSERT_TRUE(base::test::RunUntil(
+      [&] { return bat_ads_service_factory_->initialize_count() == 1U; }));
+
+  // Act
+  SimulateIdleState(ui::IdleState::IDLE_STATE_LOCKED, base::Seconds(0));
+
+  // Assert
+  EXPECT_TRUE(base::test::RunUntil(
+      [&] { return bat_ads_service_factory_->become_idle_count() == 1U; }));
+}
+
+TEST_F(BraveAdsAdsServiceImplTest, ProcessIdleStateDoesNotNotifyIdleTwice) {
+  // Arrange
+  prefs_.SetBoolean(prefs::kOptedInToSearchResultAds, true);
+  Startup();
+  ASSERT_TRUE(base::test::RunUntil(
+      [&] { return bat_ads_service_factory_->initialize_count() == 1U; }));
+  SimulateIdleState(ui::IdleState::IDLE_STATE_IDLE, base::Seconds(7));
+  ASSERT_TRUE(base::test::RunUntil(
+      [&] { return bat_ads_service_factory_->become_idle_count() == 1U; }));
+
+  // Act: UNKNOWN must not corrupt `last_idle_state_`, or the repeated IDLE
+  // below would be treated as a new transition and send a duplicate.
+  SimulateIdleState(ui::IdleState::IDLE_STATE_UNKNOWN, base::Seconds(0));
+  SimulateIdleState(ui::IdleState::IDLE_STATE_IDLE, base::Seconds(7));
+  SimulateIdleState(ui::IdleState::IDLE_STATE_ACTIVE, base::Seconds(7));
+  ASSERT_TRUE(base::test::RunUntil(
+      [&] { return bat_ads_service_factory_->become_active_count() == 1U; }));
+
+  // Assert
+  EXPECT_EQ(1U, bat_ads_service_factory_->become_idle_count());
+}
+
+TEST_F(BraveAdsAdsServiceImplTest,
+       ProcessIdleStateNotifiesWhenUserBecomesActive) {
+  // Arrange
+  prefs_.SetBoolean(prefs::kOptedInToSearchResultAds, true);
+  Startup();
+  ASSERT_TRUE(base::test::RunUntil(
+      [&] { return bat_ads_service_factory_->initialize_count() == 1U; }));
+  SimulateIdleState(ui::IdleState::IDLE_STATE_IDLE, base::Seconds(7));
+  ASSERT_TRUE(base::test::RunUntil(
+      [&] { return bat_ads_service_factory_->become_idle_count() == 1U; }));
+
+  // Act
+  SimulateIdleState(ui::IdleState::IDLE_STATE_ACTIVE, base::Seconds(7));
+
+  // Assert
+  EXPECT_TRUE(base::test::RunUntil(
+      [&] { return bat_ads_service_factory_->become_active_count() == 1U; }));
+}
+
+TEST_F(BraveAdsAdsServiceImplTest,
+       ProcessIdleStateNotifiesWhenUserBecomesActiveAfterScreenLock) {
+  // Arrange
+  prefs_.SetBoolean(prefs::kOptedInToSearchResultAds, true);
+  Startup();
+  ASSERT_TRUE(base::test::RunUntil(
+      [&] { return bat_ads_service_factory_->initialize_count() == 1U; }));
+  SimulateIdleState(ui::IdleState::IDLE_STATE_LOCKED, base::Seconds(0));
+  ASSERT_TRUE(base::test::RunUntil(
+      [&] { return bat_ads_service_factory_->become_idle_count() == 1U; }));
+
+  // Act
+  SimulateIdleState(ui::IdleState::IDLE_STATE_ACTIVE, base::Seconds(42));
+
+  // Assert
+  ASSERT_TRUE(base::test::RunUntil(
+      [&] { return bat_ads_service_factory_->become_active_count() == 1U; }));
+  EXPECT_TRUE(bat_ads_service_factory_->last_screen_was_locked());
+}
+
+TEST_F(BraveAdsAdsServiceImplTest,
+       ProcessIdleStateDoesNotSetScreenWasLockedWhenActiveTransitionsFromIdle) {
+  // Arrange
+  prefs_.SetBoolean(prefs::kOptedInToSearchResultAds, true);
+  Startup();
+  ASSERT_TRUE(base::test::RunUntil(
+      [&] { return bat_ads_service_factory_->initialize_count() == 1U; }));
+  SimulateIdleState(ui::IdleState::IDLE_STATE_IDLE, base::Seconds(7));
+  ASSERT_TRUE(base::test::RunUntil(
+      [&] { return bat_ads_service_factory_->become_idle_count() == 1U; }));
+
+  // Act
+  SimulateIdleState(ui::IdleState::IDLE_STATE_ACTIVE, base::Seconds(7));
+
+  // Assert
+  ASSERT_TRUE(base::test::RunUntil(
+      [&] { return bat_ads_service_factory_->become_active_count() == 1U; }));
+  EXPECT_FALSE(bat_ads_service_factory_->last_screen_was_locked());
+}
+
+TEST_F(BraveAdsAdsServiceImplTest,
+       ProcessIdleStatePassesIdleTimeWhenUserBecomesActive) {
+  // Arrange
+  prefs_.SetBoolean(prefs::kOptedInToSearchResultAds, true);
+  Startup();
+  ASSERT_TRUE(base::test::RunUntil(
+      [&] { return bat_ads_service_factory_->initialize_count() == 1U; }));
+  SimulateIdleState(ui::IdleState::IDLE_STATE_IDLE, base::Seconds(7));
+  ASSERT_TRUE(base::test::RunUntil(
+      [&] { return bat_ads_service_factory_->become_idle_count() == 1U; }));
+
+  // Act
+  SimulateIdleState(ui::IdleState::IDLE_STATE_ACTIVE, base::Seconds(42));
+
+  // Assert
+  ASSERT_TRUE(base::test::RunUntil(
+      [&] { return bat_ads_service_factory_->become_active_count() == 1U; }));
+  EXPECT_EQ(base::Seconds(42), bat_ads_service_factory_->last_idle_time());
+}
+
+TEST_F(BraveAdsAdsServiceImplTest, ProcessIdleStateDoesNotNotifyActiveTwice) {
+  // Arrange
+  prefs_.SetBoolean(prefs::kOptedInToSearchResultAds, true);
+  Startup();
+  ASSERT_TRUE(base::test::RunUntil(
+      [&] { return bat_ads_service_factory_->initialize_count() == 1U; }));
+  SimulateIdleState(ui::IdleState::IDLE_STATE_IDLE, base::Seconds(7));
+  ASSERT_TRUE(base::test::RunUntil(
+      [&] { return bat_ads_service_factory_->become_idle_count() == 1U; }));
+  SimulateIdleState(ui::IdleState::IDLE_STATE_ACTIVE, base::Seconds(7));
+  ASSERT_TRUE(base::test::RunUntil(
+      [&] { return bat_ads_service_factory_->become_active_count() == 1U; }));
+
+  // Act: UNKNOWN must not corrupt `last_idle_state_`, or the repeated ACTIVE
+  // below would be treated as a new transition and send a duplicate.
+  SimulateIdleState(ui::IdleState::IDLE_STATE_UNKNOWN, base::Seconds(0));
+  SimulateIdleState(ui::IdleState::IDLE_STATE_ACTIVE, base::Seconds(7));
+
+  // Assert
+  EXPECT_EQ(1U, bat_ads_service_factory_->become_active_count());
+}
 
 }  // namespace brave_ads

--- a/components/brave_ads/browser/test/fake_bat_ads_client_notifier.cc
+++ b/components/brave_ads/browser/test/fake_bat_ads_client_notifier.cc
@@ -1,0 +1,34 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_ads/browser/test/fake_bat_ads_client_notifier.h"
+
+#include <utility>
+
+namespace brave_ads::test {
+
+FakeBatAdsClientNotifier::FakeBatAdsClientNotifier() = default;
+
+FakeBatAdsClientNotifier::~FakeBatAdsClientNotifier() = default;
+
+void FakeBatAdsClientNotifier::BindReceiver(
+    mojo::PendingReceiver<bat_ads::mojom::BatAdsClientNotifier>
+        pending_receiver) {
+  receiver_.Bind(std::move(pending_receiver));
+}
+
+void FakeBatAdsClientNotifier::NotifyUserDidBecomeIdle() {
+  ++become_idle_count_;
+}
+
+void FakeBatAdsClientNotifier::NotifyUserDidBecomeActive(
+    base::TimeDelta idle_time,
+    bool screen_was_locked) {
+  ++become_active_count_;
+  last_idle_time_ = idle_time;
+  last_screen_was_locked_ = screen_was_locked;
+}
+
+}  // namespace brave_ads::test

--- a/components/brave_ads/browser/test/fake_bat_ads_client_notifier.h
+++ b/components/brave_ads/browser/test/fake_bat_ads_client_notifier.h
@@ -1,0 +1,86 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_ADS_BROWSER_TEST_FAKE_BAT_ADS_CLIENT_NOTIFIER_H_
+#define BRAVE_COMPONENTS_BRAVE_ADS_BROWSER_TEST_FAKE_BAT_ADS_CLIENT_NOTIFIER_H_
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "base/time/time.h"
+#include "brave/components/services/bat_ads/public/interfaces/bat_ads.mojom.h"
+#include "mojo/public/cpp/bindings/pending_receiver.h"
+#include "mojo/public/cpp/bindings/receiver.h"
+#include "url/gurl.h"
+
+namespace brave_ads::test {
+
+// Records calls to `NotifyUserDidBecomeIdle` and `NotifyUserDidBecomeActive`
+// so tests can assert on idle notification counts and arguments.
+class FakeBatAdsClientNotifier : public bat_ads::mojom::BatAdsClientNotifier {
+ public:
+  FakeBatAdsClientNotifier();
+
+  FakeBatAdsClientNotifier(const FakeBatAdsClientNotifier&) = delete;
+  FakeBatAdsClientNotifier& operator=(const FakeBatAdsClientNotifier&) = delete;
+
+  ~FakeBatAdsClientNotifier() override;
+
+  void BindReceiver(mojo::PendingReceiver<bat_ads::mojom::BatAdsClientNotifier>
+                        pending_receiver);
+
+  size_t become_idle_count() const { return become_idle_count_; }
+  size_t become_active_count() const { return become_active_count_; }
+  base::TimeDelta last_idle_time() const { return last_idle_time_; }
+  bool last_screen_was_locked() const { return last_screen_was_locked_; }
+
+  // bat_ads::mojom::BatAdsClientNotifier:
+  void NotifyDidInitializeAds() override {}
+  void NotifyPrefDidChange(const std::string& /*path*/) override {}
+  void NotifyResourceComponentDidChange(const std::string& /*manifest_version*/,
+                                        const std::string& /*id*/) override {}
+  void NotifyDidUnregisterResourceComponent(
+      const std::string& /*id*/) override {}
+  void NotifyRewardsWalletDidUpdate(
+      const std::string& /*payment_id*/,
+      const std::string& /*recovery_seed_base64*/) override {}
+  void NotifyTabTextContentDidChange(
+      int32_t /*tab_id*/,
+      const std::vector<GURL>& /*redirect_chain*/,
+      const std::string& /*text*/) override {}
+  void NotifyTabDidStartPlayingMedia(int32_t /*tab_id*/) override {}
+  void NotifyTabDidStopPlayingMedia(int32_t /*tab_id*/) override {}
+  void NotifyTabDidChange(int32_t /*tab_id*/,
+                          const std::vector<GURL>& /*redirect_chain*/,
+                          bool /*is_new_navigation*/,
+                          bool /*is_restoring*/,
+                          bool /*is_visible*/) override {}
+  void NotifyTabDidLoad(int32_t /*tab_id*/,
+                        int32_t /*http_status_code*/) override {}
+  void NotifyDidCloseTab(int32_t /*tab_id*/) override {}
+  void NotifyUserGestureEventTriggered(int32_t /*page_transition*/) override {}
+  void NotifyUserDidBecomeIdle() override;
+  void NotifyUserDidBecomeActive(base::TimeDelta idle_time,
+                                 bool screen_was_locked) override;
+  void NotifyBrowserDidEnterForeground() override {}
+  void NotifyBrowserDidEnterBackground() override {}
+  void NotifyBrowserDidBecomeActive() override {}
+  void NotifyBrowserDidResignActive() override {}
+  void NotifyDidSolveAdaptiveCaptcha() override {}
+
+ private:
+  size_t become_idle_count_ = 0;
+  size_t become_active_count_ = 0;
+  base::TimeDelta last_idle_time_;
+  bool last_screen_was_locked_ = false;
+
+  mojo::Receiver<bat_ads::mojom::BatAdsClientNotifier> receiver_{this};
+};
+
+}  // namespace brave_ads::test
+
+#endif  // BRAVE_COMPONENTS_BRAVE_ADS_BROWSER_TEST_FAKE_BAT_ADS_CLIENT_NOTIFIER_H_

--- a/components/brave_ads/browser/test/fake_bat_ads_service.cc
+++ b/components/brave_ads/browser/test/fake_bat_ads_service.cc
@@ -36,9 +36,11 @@ void FakeBatAdsService::Create(
     mojo::PendingAssociatedReceiver<bat_ads::mojom::BatAds>
         bat_ads_pending_associated_receiver,
     mojo::PendingReceiver<bat_ads::mojom::BatAdsClientNotifier>
-    /*bat_ads_client_notifier_pending_receiver*/,
+        bat_ads_client_notifier_pending_receiver,
     CreateCallback callback) {
   bat_ads_.BindReceiver(std::move(bat_ads_pending_associated_receiver));
+  bat_ads_client_notifier_.BindReceiver(
+      std::move(bat_ads_client_notifier_pending_receiver));
   std::move(callback).Run();
 }
 

--- a/components/brave_ads/browser/test/fake_bat_ads_service.h
+++ b/components/brave_ads/browser/test/fake_bat_ads_service.h
@@ -8,6 +8,7 @@
 
 #include "base/functional/callback.h"
 #include "brave/components/brave_ads/browser/test/fake_bat_ads.h"
+#include "brave/components/brave_ads/browser/test/fake_bat_ads_client_notifier.h"
 #include "brave/components/services/bat_ads/public/interfaces/bat_ads.mojom.h"
 #include "mojo/public/cpp/bindings/pending_associated_receiver.h"
 #include "mojo/public/cpp/bindings/pending_associated_remote.h"
@@ -33,6 +34,10 @@ class FakeBatAdsService : public bat_ads::mojom::BatAdsService {
   void BindReceiver(mojo::PendingReceiver<bat_ads::mojom::BatAdsService>
                         bat_ads_service_pending_receiver);
 
+  const FakeBatAdsClientNotifier* bat_ads_client_notifier() const {
+    return &bat_ads_client_notifier_;
+  }
+
   // bat_ads::mojom::BatAdsService:
   void Create(const base::FilePath& /*service_path*/,
               mojo::PendingAssociatedRemote<bat_ads::mojom::BatAdsClient>
@@ -40,13 +45,14 @@ class FakeBatAdsService : public bat_ads::mojom::BatAdsService {
               mojo::PendingAssociatedReceiver<bat_ads::mojom::BatAds>
                   bat_ads_pending_associated_receiver,
               mojo::PendingReceiver<bat_ads::mojom::BatAdsClientNotifier>
-              /*bat_ads_client_notifier_pending_receiver*/,
+                  bat_ads_client_notifier_pending_receiver,
               CreateCallback callback) override;
 
  private:
   base::RepeatingClosure shutdown_callback_;
 
   FakeBatAds bat_ads_;
+  FakeBatAdsClientNotifier bat_ads_client_notifier_;
   mojo::Receiver<bat_ads::mojom::BatAdsService> bat_ads_service_receiver_{this};
 };
 

--- a/components/brave_ads/browser/test/fake_bat_ads_service_factory.cc
+++ b/components/brave_ads/browser/test/fake_bat_ads_service_factory.cc
@@ -8,6 +8,7 @@
 #include <memory>
 
 #include "base/functional/bind.h"
+#include "brave/components/brave_ads/browser/test/fake_bat_ads_client_notifier.h"
 #include "brave/components/brave_ads/browser/test/fake_bat_ads_service.h"
 
 namespace brave_ads::test {
@@ -15,6 +16,32 @@ namespace brave_ads::test {
 FakeBatAdsServiceFactory::FakeBatAdsServiceFactory() = default;
 
 FakeBatAdsServiceFactory::~FakeBatAdsServiceFactory() = default;
+
+const FakeBatAdsClientNotifier*
+FakeBatAdsServiceFactory::bat_ads_client_notifier() const {
+  return bat_ads_service_ ? bat_ads_service_->bat_ads_client_notifier()
+                          : nullptr;
+}
+
+size_t FakeBatAdsServiceFactory::become_idle_count() const {
+  const FakeBatAdsClientNotifier* const notifier = bat_ads_client_notifier();
+  return notifier ? notifier->become_idle_count() : 0U;
+}
+
+size_t FakeBatAdsServiceFactory::become_active_count() const {
+  const FakeBatAdsClientNotifier* const notifier = bat_ads_client_notifier();
+  return notifier ? notifier->become_active_count() : 0U;
+}
+
+base::TimeDelta FakeBatAdsServiceFactory::last_idle_time() const {
+  const FakeBatAdsClientNotifier* const notifier = bat_ads_client_notifier();
+  return notifier ? notifier->last_idle_time() : base::TimeDelta{};
+}
+
+bool FakeBatAdsServiceFactory::last_screen_was_locked() const {
+  const FakeBatAdsClientNotifier* const notifier = bat_ads_client_notifier();
+  return notifier ? notifier->last_screen_was_locked() : false;
+}
 
 mojo::Remote<bat_ads::mojom::BatAdsService> FakeBatAdsServiceFactory::Launch()
     const {

--- a/components/brave_ads/browser/test/fake_bat_ads_service_factory.h
+++ b/components/brave_ads/browser/test/fake_bat_ads_service_factory.h
@@ -9,11 +9,13 @@
 #include <cstddef>
 #include <memory>
 
+#include "base/time/time.h"
 #include "brave/components/brave_ads/browser/bat_ads_service_factory.h"
 #include "mojo/public/cpp/bindings/remote.h"
 
 namespace brave_ads::test {
 
+class FakeBatAdsClientNotifier;
 class FakeBatAdsService;
 
 // Records launch, initialization, and shutdown counts and controls whether
@@ -32,6 +34,11 @@ class FakeBatAdsServiceFactory : public BatAdsServiceFactory {
   size_t initialize_count() const { return initialize_count_; }
   size_t shutdown_count() const { return shutdown_count_; }
 
+  size_t become_idle_count() const;
+  size_t become_active_count() const;
+  base::TimeDelta last_idle_time() const;
+  bool last_screen_was_locked() const;
+
   // Causes subsequently launched services to report initialization failure.
   void set_simulate_initialization_failure() {
     simulate_initialization_failure_ = true;
@@ -43,6 +50,10 @@ class FakeBatAdsServiceFactory : public BatAdsServiceFactory {
  private:
   void OnInitialize() const { ++initialize_count_; }
   void OnShutdown() const { ++shutdown_count_; }
+
+  // Returns the notifier from the most recently launched service, or `nullptr`
+  // if no service has been launched yet.
+  const FakeBatAdsClientNotifier* bat_ads_client_notifier() const;
 
   // `mutable` because `Launch`, `OnInitialize`, and `OnShutdown` are `const`
   // per the base class interface but must increment these counters.


### PR DESCRIPTION
When the OS returns IDLE_STATE_UNKNOWN, the previous code updated last_idle_state_ even though no notification was sent, corrupting the last known good state. An ACTIVE to UNKNOWN to ACTIVE sequence dropped the idle notification entirely; an IDLE to UNKNOWN to IDLE sequence fired a duplicate idle notification. Returning early on UNKNOWN preserves the last known state. Adds FakeBatAdsClientNotifier and TestingAdsServiceImpl with two regression tests covering both failure modes.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
