### PR TITLE
[ads][CodeHealth] Use get() instead of &* to extract raw pointers

### DIFF
--- a/components/brave_ads/core/internal/ads_impl.cc
+++ b/components/brave_ads/core/internal/ads_impl.cc
@@ -378,7 +378,7 @@ void AdsImpl::SuccessfullyInitialized(mojom::WalletInfoPtr mojom_wallet,
 
   std::optional<WalletInfo> wallet;
   if (mojom_wallet) {
-    wallet = CreateWalletFromRecoverySeed(&*mojom_wallet);
+    wallet = CreateWalletFromRecoverySeed(mojom_wallet.get());
     if (!wallet) {
       BLOG(0, "Invalid wallet");
       return FailedToInitialize(std::move(callback));
@@ -415,7 +415,7 @@ void AdsImpl::LoadClientStateCallback(mojom::WalletInfoPtr mojom_wallet,
 
   std::optional<WalletInfo> wallet;
   if (mojom_wallet) {
-    wallet = CreateWalletFromRecoverySeed(&*mojom_wallet);
+    wallet = CreateWalletFromRecoverySeed(mojom_wallet.get());
     if (!wallet) {
       BLOG(0, "Invalid wallet");
       return FailedToInitialize(std::move(callback));

--- a/components/brave_ads/core/internal/common/resources/resource_util_impl.h
+++ b/components/brave_ads/core/internal/common/resources/resource_util_impl.h
@@ -40,7 +40,7 @@ std::optional<T> LoadAndParseResourceComponentOnBackgroundThread(
 
     std::string content;
     const base::ScopedFILE scoped_file(base::FileToFILE(std::move(file), "rb"));
-    if (!base::ReadStreamToString(&*scoped_file, &content)) {
+    if (!base::ReadStreamToString(scoped_file.get(), &content)) {
       return std::nullopt;
     }
 

--- a/components/brave_ads/core/internal/serving/eligible_ads/exclusion_rules/subdivision_targeting_exclusion_rule_unittest.cc
+++ b/components/brave_ads/core/internal/serving/eligible_ads/exclusion_rules/subdivision_targeting_exclusion_rule_unittest.cc
@@ -110,7 +110,7 @@ class BraveAdsSubdivisionTargetingExclusionRuleTest
 
     subdivision_targeting_ = std::make_unique<SubdivisionTargeting>();
     subdivision_ = std::make_unique<Subdivision>();
-    subdivision_->AddObserver(&*subdivision_targeting_);
+    subdivision_->AddObserver(subdivision_targeting_.get());
     exclusion_rule_ = std::make_unique<SubdivisionTargetingExclusionRule>(
         *subdivision_targeting_);
   }

--- a/components/brave_ads/core/internal/targeting/geographical/subdivision/subdivision_targeting_unittest.cc
+++ b/components/brave_ads/core/internal/targeting/geographical/subdivision/subdivision_targeting_unittest.cc
@@ -31,7 +31,7 @@ class BraveAdsSubdivisionTargetingTest : public test::TestBase {
 
     subdivision_targeting_ = std::make_unique<SubdivisionTargeting>();
     subdivision_ = std::make_unique<Subdivision>();
-    subdivision_->AddObserver(&*subdivision_targeting_);
+    subdivision_->AddObserver(subdivision_targeting_.get());
   }
 
   void MockHttpOkUrlResponse(const std::string& country_code,

--- a/components/brave_ads/core/internal/test/ads_observer_test_util.cc
+++ b/components/brave_ads/core/internal/test/ads_observer_test_util.cc
@@ -16,7 +16,7 @@ namespace brave_ads::test {
 AdsObserverMock* MockAdsObserver() {
   std::unique_ptr<AdsObserverMock> ads_observer_mock =
       std::make_unique<AdsObserverMock>();
-  AdsObserverMock* const ads_observer_mock_ptr = &*ads_observer_mock;
+  AdsObserverMock* const ads_observer_mock_ptr = ads_observer_mock.get();
 
   // `AdsNotifierManager` takes ownership of `ads_observer_mock`.
   AdsNotifierManager::GetInstance().AddObserver(std::move(ads_observer_mock));


### PR DESCRIPTION
Use the idiomatic Chromium form `.get()` to extract a raw pointer from smart pointers (mojo::StructPtr, std::unique_ptr, base::ScopedFILE) rather than the non-idiomatic `&*` dereference-and-address pattern. The three `raw_ref` sites are left unchanged because `raw_ref::get()` returns a reference, not a pointer, so `&*` is the correct form there.

No behavioral changes.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
