### PR TITLE
[ads] Fix active creative set conversions returning duplicate results

### DIFF
--- a/components/brave_ads/core/internal/creatives/conversions/creative_set_conversion_database_table.cc
+++ b/components/brave_ads/core/internal/creatives/conversions/creative_set_conversion_database_table.cc
@@ -227,7 +227,7 @@ void CreativeSetConversions::GetActive(
   mojom_db_action->type = mojom::DBActionInfo::Type::kExecuteQueryWithBindings;
   mojom_db_action->sql = base::ReplaceStringPlaceholders(
       R"(
-          SELECT
+          SELECT DISTINCT
             creative_set_conversion.creative_set_id,
             creative_set_conversion.url_pattern,
             creative_set_conversion.observation_window,

--- a/components/brave_ads/core/internal/creatives/conversions/creative_set_conversion_database_table_unittest.cc
+++ b/components/brave_ads/core/internal/creatives/conversions/creative_set_conversion_database_table_unittest.cc
@@ -7,9 +7,13 @@
 
 #include "base/test/test_future.h"
 #include "brave/components/brave_ads/core/internal/ad_units/test/ad_test_constants.h"
+#include "brave/components/brave_ads/core/internal/ad_units/test/ad_test_util.h"
 #include "brave/components/brave_ads/core/internal/common/test/test_base.h"
 #include "brave/components/brave_ads/core/internal/creatives/conversions/creative_set_conversion_database_table_util.h"
 #include "brave/components/brave_ads/core/internal/creatives/conversions/test/creative_set_conversion_test_util.h"
+#include "brave/components/brave_ads/core/internal/user_engagement/ad_events/test/ad_event_test_util.h"
+#include "brave/components/brave_ads/core/mojom/brave_ads.mojom.h"
+#include "brave/components/brave_ads/core/public/ad_units/ad_info.h"
 
 // npm run test -- brave_unit_tests --filter=BraveAds*
 
@@ -146,6 +150,29 @@ TEST_F(BraveAdsCreativeSetConversionDatabaseTableTest,
   EXPECT_TRUE(success);
   EXPECT_THAT(creative_set_conversions,
               ::testing::ElementsAre(creative_set_conversion_2));
+}
+
+TEST_F(BraveAdsCreativeSetConversionDatabaseTableTest,
+       GetActiveDoesNotReturnDuplicatesWhenMultipleAdEventsMatch) {
+  // Arrange
+  test::BuildAndSaveCreativeSetConversion(
+      test::kCreativeSetId, /*url_pattern=*/"https://www.brave.com/*",
+      /*observation_window=*/base::Days(3));
+
+  const AdInfo ad =
+      test::BuildAd(mojom::AdType::kNotificationAd, /*use_random_uuids=*/false);
+  test::RecordAdEvents(ad, mojom::ConfirmationType::kViewedImpression,
+                       /*count=*/3);
+
+  // Act
+  base::test::TestFuture<bool, CreativeSetConversionList> test_future;
+  database_table_.GetActive(
+      test_future.GetCallback<bool, const CreativeSetConversionList&>());
+  const auto [success, creative_set_conversions] = test_future.Take();
+
+  // Assert
+  EXPECT_TRUE(success);
+  EXPECT_THAT(creative_set_conversions, ::testing::SizeIs(1));
 }
 
 }  // namespace brave_ads


### PR DESCRIPTION
The GetActive query joined creative_set_conversions with ad_events on creative_set_id. Because ad_events can have multiple rows per creative_set_id, the join produced one row per matching ad event. Added SELECT DISTINCT so the result contains one row per conversion regardless of how many ad events match.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
