### PR TITLE
Update MediaSessionUsage metric with 96-100% bucket (uplift to 1.90.x)

### DIFF
--- a/browser/misc_metrics/media_session_metrics.cc
+++ b/browser/misc_metrics/media_session_metrics.cc
@@ -27,7 +27,7 @@ constexpr base::TimeDelta kReportInterval = base::Minutes(20);
 constexpr base::TimeDelta kTickInterval = base::Seconds(30);
 constexpr base::TimeDelta kFrameDuration = base::Days(7);
 
-constexpr int kMediaSessionUsageBuckets[] = {0, 20, 40, 60, 80, 100};
+constexpr int kMediaSessionUsageBuckets[] = {0, 20, 40, 60, 80, 95};
 constexpr int kMediaSessionUsageAttributeThresholds[] = {0, 33, 67};
 constexpr std::array<std::string_view, 4> kMediaSessionUsageAttributeValues = {
     "0", "1-33", "34-67", "68-100"};

--- a/browser/misc_metrics/media_session_metrics.h
+++ b/browser/misc_metrics/media_session_metrics.h
@@ -28,7 +28,7 @@ class MediaSession;
 namespace misc_metrics {
 
 inline constexpr char kMediaSessionUsageHistogramName[] =
-    "Brave.Core.MediaSessionUsage";
+    "Brave.Core.MediaSessionUsage.2";
 inline constexpr char kMediaSessionUsageAttributeName[] = "media_session_usage";
 
 // Observes media session activity to track the percentage of active browsing

--- a/browser/misc_metrics/media_session_metrics_unittest.cc
+++ b/browser/misc_metrics/media_session_metrics_unittest.cc
@@ -205,8 +205,8 @@ TEST_F(MediaSessionMetricsTest, ActiveProcessTimeOnlyWhenInUseOrPlaying) {
   // Advance remaining time to trigger report.
   task_environment_.FastForwardBy(base::Days(4));
 
-  // 1 day playing / 1 day active = 100% → bucket 5. Attribute: "68-100".
-  histogram_tester_.ExpectUniqueSample(kMediaSessionUsageHistogramName, 5, 1);
+  // 1 day playing / 1 day active = 100% → bucket 6. Attribute: "68-100".
+  histogram_tester_.ExpectUniqueSample(kMediaSessionUsageHistogramName, 6, 1);
   EXPECT_EQ(relay_observer_.GetCustomAttribute(kMediaSessionUsageAttributeName),
             "68-100");
 }

--- a/components/p3a/metric_names.h
+++ b/components/p3a/metric_names.h
@@ -71,7 +71,7 @@ inline constexpr auto kCollectedTypicalHistograms =
     {"Brave.Core.IsDefault", MetricConfig{
       .attributes = MetricAttributes{MetricAttribute::kAnswerIndex, MetricAttribute::kChannel, MetricAttribute::kGeneralPlatform, MetricAttribute::kYoi, MetricAttribute::kSubregion, MetricAttribute::kVersion, MetricAttribute::kWoi},
     }},
-    {"Brave.Core.MediaSessionUsage", MetricConfig{.ephemeral = true, .attributes = MetricAttributes{MetricAttribute::kIsBrowserDefault, MetricAttribute::kAnswerIndex, MetricAttribute::kCountryCode, MetricAttribute::kPlatform, MetricAttribute::kYoi}}},
+    {"Brave.Core.MediaSessionUsage.2", MetricConfig{.ephemeral = true, .attributes = MetricAttributes{MetricAttribute::kIsBrowserDefault, MetricAttribute::kAnswerIndex, MetricAttribute::kCountryCode, MetricAttribute::kPlatform, MetricAttribute::kYoi}}},
     {"Brave.Core.NumberOfExtensions", {}},
     {"Brave.Core.PagesLoaded.NonRewards", {}},
     {"Brave.Core.PagesLoaded.Rewards", {}},


### PR DESCRIPTION
Uplift of #35729
Resolves https://github.com/brave/brave-browser/issues/54800

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.