### PR TITLE
Change Brave.Shields.UpgradeHTTPSPerSite to report any non-default per-site setting (uplift to 1.89.x)

### DIFF
--- a/components/brave_shields/core/browser/brave_shields_p3a.cc
+++ b/components/brave_shields/core/browser/brave_shields_p3a.cc
@@ -269,7 +269,7 @@ void RecordHTTPSUpgradeSettingP3A(HostContentSettingsMap* map) {
       GURL(), GURL(), ContentSettingsType::BRAVE_HTTPS_UPGRADE);
   constexpr int kHTTPSUpgradeStrict = 2;
   constexpr int kHTTPSUpgradeStandard = 1;
-  constexpr int kHTTPSUpgradePerSiteStrict = 1;
+  constexpr int kHTTPSUpgradePerSiteNonDefault = 1;
   int global_answer = INT_MAX - 1;
   if (global_setting != CONTENT_SETTING_ALLOW) {
     global_answer = global_setting == CONTENT_SETTING_BLOCK
@@ -281,13 +281,14 @@ void RecordHTTPSUpgradeSettingP3A(HostContentSettingsMap* map) {
 
   auto per_site_settings =
       map->GetSettingsForOneType(ContentSettingsType::BRAVE_HTTPS_UPGRADE);
-  bool has_per_site_strict = std::ranges::any_of(
-      per_site_settings, [](const ContentSettingPatternSource& entry) {
-        return entry.GetContentSetting() == CONTENT_SETTING_BLOCK &&
+  bool has_per_site_non_default = std::ranges::any_of(
+      per_site_settings,
+      [&global_setting](const ContentSettingPatternSource& entry) {
+        return entry.GetContentSetting() != global_setting &&
                !entry.primary_pattern.MatchesAllHosts();
       });
   int per_site_answer =
-      has_per_site_strict ? kHTTPSUpgradePerSiteStrict : INT_MAX - 1;
+      has_per_site_non_default ? kHTTPSUpgradePerSiteNonDefault : INT_MAX - 1;
   UMA_HISTOGRAM_EXACT_LINEAR(kUpgradeHTTPSPerSiteHistogramName, per_site_answer,
                              2);
 }

--- a/components/brave_shields/core/browser/brave_shields_p3a.h
+++ b/components/brave_shields/core/browser/brave_shields_p3a.h
@@ -51,7 +51,7 @@ inline constexpr char kForgetFirstPartyHistogramName[] =
 inline constexpr char kUpgradeHTTPSGlobalHistogramName[] =
     "Brave.Shields.UpgradeHTTPSGlobal";
 inline constexpr char kUpgradeHTTPSPerSiteHistogramName[] =
-    "Brave.Shields.UpgradeHTTPSPerSite";
+    "Brave.Shields.UpgradeHTTPSPerSite.2";
 // Note: append-only enumeration! Never remove any existing values, as this enum
 // is used to bucket a UMA histogram, and removing values breaks that.
 enum ShieldsIconUsage {

--- a/components/brave_shields/core/test/brave_shields_p3a_unittest.cc
+++ b/components/brave_shields/core/test/brave_shields_p3a_unittest.cc
@@ -227,28 +227,31 @@ TEST_F(BraveShieldsP3ATest, RecordHTTPSUpgradeGlobalSetting) {
   histogram_tester_->ExpectBucketCount(kUpgradeHTTPSGlobalHistogramName, 1, 2);
 }
 
-TEST_F(BraveShieldsP3ATest, RecordHTTPSUpgradePerSiteStrict) {
+TEST_F(BraveShieldsP3ATest, RecordHTTPSUpgradePerSiteNonDefault) {
   auto* map = HostContentSettingsMapFactory::GetForProfile(GetProfile());
 
-  // No per-site strict settings - should suspend
+  // No per-site settings - should suspend
   RecordHTTPSUpgradeSettingP3A(map);
   histogram_tester_->ExpectBucketCount(kUpgradeHTTPSPerSiteHistogramName,
                                        INT_MAX - 1, 1);
 
-  // Add a per-site strict setting
+  // Add a per-site strict (BLOCK) setting - differs from global, should report
+  // 1
   SetHttpsUpgradeControlType(map, ControlType::BLOCK,
                              GURL("https://brave.com"));
   histogram_tester_->ExpectBucketCount(kUpgradeHTTPSPerSiteHistogramName, 1, 1);
 
-  // Add another per-site strict setting - still reports 1
-  SetHttpsUpgradeControlType(map, ControlType::BLOCK,
-                             GURL("https://example.com"));
-  histogram_tester_->ExpectBucketCount(kUpgradeHTTPSPerSiteHistogramName, 1, 2);
-
-  // Change one to standard - other is still strict, should still report 1
+  // Change to same as global (BLOCK_THIRD_PARTY) - matches global, should
+  // suspend
   SetHttpsUpgradeControlType(map, ControlType::BLOCK_THIRD_PARTY,
                              GURL("https://brave.com"));
-  histogram_tester_->ExpectBucketCount(kUpgradeHTTPSPerSiteHistogramName, 1, 3);
+  histogram_tester_->ExpectBucketCount(kUpgradeHTTPSPerSiteHistogramName,
+                                       INT_MAX - 1, 2);
+
+  // Change to disabled (ALLOW) - differs from global, should report 1
+  SetHttpsUpgradeControlType(map, ControlType::ALLOW,
+                             GURL("https://brave.com"));
+  histogram_tester_->ExpectBucketCount(kUpgradeHTTPSPerSiteHistogramName, 1, 2);
 }
 
 TEST_F(BraveShieldsP3ATest, RecordHTTPSUpgradeDisabledGlobalNoPerSite) {

--- a/components/p3a/metric_names.h
+++ b/components/p3a/metric_names.h
@@ -145,7 +145,7 @@ inline constexpr auto kCollectedTypicalHistograms =
     {"Brave.Shields.FilterLists.2", {}},
     {"Brave.Shields.FingerprintBlockSetting", {}},
     {"Brave.Shields.UpgradeHTTPSGlobal", {}},
-    {"Brave.Shields.UpgradeHTTPSPerSite", {}},
+    {"Brave.Shields.UpgradeHTTPSPerSite.2", {}},
     {"Brave.Shields.UsageStatus", {}},
     {"Brave.Sidebar.Enabled", {}},
     {"Brave.Sync.JoinType", MetricConfig{.ephemeral = true}},


### PR DESCRIPTION
Uplift of #35708
Resolves https://github.com/brave/brave-browser/issues/54764

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.