### PR TITLE
[History Embeddings] Clarify zero data collection for history semantic search

### DIFF
--- a/app/brave_generated_resources.grd
+++ b/app/brave_generated_resources.grd
@@ -1472,6 +1472,15 @@ Or change later at <ph name="SETTINGS_EXTENIONS_LINK">$2<ex>brave://settings/ext
       <message name="IDS_LOCAL_AI_TASK_MANAGER_TITLE" desc="The label for the on-device AI background process in the Task Manager.">
         On-Device AI
       </message>
+
+      <!-- History semantic search disclaimer. Upstream's text implies a
+           round-trip to the vendor with human review; Brave's implementation
+           runs entirely on-device (see
+           brave/browser/history_embeddings/README.md), so we ship our own
+           string and swap the IDS in chromium_src overrides. -->
+      <message name="IDS_BRAVE_HISTORY_EMBEDDINGS_DISCLAIMER" desc="Disclaimer shown on chrome://history and in the history search IPH promo, indicating that history semantic search runs entirely on-device.">
+        Your searches and page contents are processed on this device. Nothing is sent to Brave or seen by human reviewers.
+      </message>
       <!--Add new items to the appropriate sections above -->
     </messages>
   </release>

--- a/chromium_src/chrome/browser/history_embeddings/history_embeddings_utils.cc
+++ b/chromium_src/chrome/browser/history_embeddings/history_embeddings_utils.cc
@@ -4,17 +4,27 @@
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 // Override IsHistoryEmbeddingsEnabledForProfile() to bypass upstream's
-// OptimizationGuide pref checks that we don't use.
+// OptimizationGuide pref checks that we don't use, and force
+// IsHistoryEmbeddingsSettingVisible() to false so the chrome://settings/ai
+// History Search entry (and, transitively, the AI settings page) is not
+// surfaced. The disclaimer IDS swap for this file is handled in
+// brave/rewrite/chrome/browser/history_embeddings/history_embeddings_utils.cc.toml;
+// brave_generated_resources.h below supplies the IDS_BRAVE_* definitions
+// referenced after the swap.
 #include "base/feature_list.h"
 #include "base/feature_override.h"
+#include "brave/grit/brave_generated_resources.h"
 #include "components/history_embeddings/core/history_embeddings_features.h"
 
 #define IsHistoryEmbeddingsEnabledForProfile \
   IsHistoryEmbeddingsEnabledForProfile_ChromiumImpl
+#define IsHistoryEmbeddingsSettingVisible \
+  IsHistoryEmbeddingsSettingVisible_ChromiumImpl
 
 #include <chrome/browser/history_embeddings/history_embeddings_utils.cc>
 
 #undef IsHistoryEmbeddingsEnabledForProfile
+#undef IsHistoryEmbeddingsSettingVisible
 
 namespace history_embeddings {
 
@@ -24,6 +34,10 @@ OVERRIDE_FEATURE_DEFAULT_STATES({{
 
 bool IsHistoryEmbeddingsEnabledForProfile(Profile* profile) {
   return IsHistoryEmbeddingsFeatureEnabled();
+}
+
+bool IsHistoryEmbeddingsSettingVisible(Profile* profile) {
+  return false;
 }
 
 }  // namespace history_embeddings

--- a/chromium_src/components/omnibox/browser/featured_search_provider.cc
+++ b/chromium_src/components/omnibox/browser/featured_search_provider.cc
@@ -3,6 +3,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+// The disclaimer/link-text IDS swap for this file is handled in
+// brave/rewrite/components/omnibox/browser/featured_search_provider.cc.toml;
+// brave_components_strings.h below supplies the IDS_BRAVE_* definitions
+// referenced after the swap.
+#include "components/grit/brave_components_strings.h"
 #include "components/omnibox/browser/omnibox_field_trial.h"
 #include "components/search_engines/template_url_starter_pack_data.h"
 

--- a/components/resources/brave_components_strings.grd
+++ b/components/resources/brave_components_strings.grd
@@ -949,6 +949,18 @@
       <if expr="enable_psst">
         <part file="psst_ui_strings.grdp" />
       </if>
+
+      <!-- History semantic search disclaimer shown in the omnibox @history
+           scope. Upstream's text implies a round-trip to the vendor with
+           human review; Brave's implementation runs entirely on-device
+           (see brave/browser/history_embeddings/README.md), so we ship our
+           own string and swap the IDS in the chromium_src override for
+           components/omnibox/browser/featured_search_provider.cc. -->
+      <message name="IDS_BRAVE_OMNIBOX_HISTORY_EMBEDDINGS_DISCLAIMER_IPH" desc="Disclaimer shown as the last row in the omnibox @history scope, indicating that history semantic search runs entirely on-device.">
+        Your searches and page contents are processed on this device. Nothing is sent to Brave or seen by human reviewers. This is an experimental feature and won't always get it right.
+      </message>
+      <message name="IDS_BRAVE_EMPTY_STRING" desc="Empty string. Swapped into upstream IDSes whose value we want to suppress without patching the call site." translateable="false">
+      </message>
     </messages>
   </release>
 </grit>

--- a/patches/chrome-browser-history_embeddings-history_embeddings_utils.cc.patch
+++ b/patches/chrome-browser-history_embeddings-history_embeddings_utils.cc.patch
@@ -1,0 +1,17 @@
+diff --git a/chrome/browser/history_embeddings/history_embeddings_utils.cc b/chrome/browser/history_embeddings/history_embeddings_utils.cc
+index 8198ba0c74bbfb0e68f8334f9592dddccb182c28..d829b6e1448dc9ef7c000dfcad93e7039c2d32fe 100644
+--- a/chrome/browser/history_embeddings/history_embeddings_utils.cc
++++ b/chrome/browser/history_embeddings/history_embeddings_utils.cc
+@@ -163,10 +163,10 @@ void PopulateSourceForWebUI(content::WebUIDataSource* source,
+               ModelExecutionEnterprisePolicyValue::kAllowWithoutLogging);
+   if (logging_disabled_by_enterprise) {
+     source->AddLocalizedString("historyEmbeddingsDisclaimer",
+-                               IDS_HISTORY_EMBEDDINGS_DISCLAIMER_LOGGING_OFF);
++                               IDS_BRAVE_HISTORY_EMBEDDINGS_DISCLAIMER);
+   } else {
+     source->AddLocalizedString("historyEmbeddingsDisclaimer",
+-                               IDS_HISTORY_EMBEDDINGS_DISCLAIMER);
++                               IDS_BRAVE_HISTORY_EMBEDDINGS_DISCLAIMER);
+   }
+ }
+ 

--- a/patches/chrome-browser-resources-history-app.html.ts.patch
+++ b/patches/chrome-browser-resources-history-app.html.ts.patch
@@ -1,0 +1,18 @@
+diff --git a/chrome/browser/resources/history/app.html.ts b/chrome/browser/resources/history/app.html.ts
+index c920480cb8e8cb1a51d8ac47c1eab200698e4737..cd4c26e687f6a136a9a643b4ba81a4381835845e 100644
+--- a/chrome/browser/resources/history/app.html.ts
++++ b/chrome/browser/resources/history/app.html.ts
+@@ -54,13 +54,6 @@ export function getHtml(this: HistoryAppElement) {
+               ?narrow="${this.hasDrawer_}">
+             <div id="historyEmbeddingsDisclaimerContent">
+               $i18n{historyEmbeddingsDisclaimer}
+-              <a id="historyEmbeddingsDisclaimerLink"
+-                  href="$i18n{historyEmbeddingsSettingsUrl}" target="_blank"
+-                  aria-describedby="historyEmbeddingsDisclaimer"
+-                  @click="${this.onHistoryEmbeddingsDisclaimerLinkClick_}"
+-                  @auxclick="${this.onHistoryEmbeddingsDisclaimerLinkAuxclick_}">
+-                $i18n{learnMore}
+-              </a>
+             </div>
+           </div>
+           ${this.showTabs_ ? html`

--- a/patches/chrome-browser-resources-history-history_embeddings_promo.html.ts.patch
+++ b/patches/chrome-browser-resources-history-history_embeddings_promo.html.ts.patch
@@ -1,0 +1,14 @@
+diff --git a/chrome/browser/resources/history/history_embeddings_promo.html.ts b/chrome/browser/resources/history/history_embeddings_promo.html.ts
+index 1948b83f22cc1fb0d56ebe61f8ba223245b5294f..2bbfaf51bcf39e12dbf03c2f2c30f44927c59cec 100644
+--- a/chrome/browser/resources/history/history_embeddings_promo.html.ts
++++ b/chrome/browser/resources/history/history_embeddings_promo.html.ts
+@@ -33,9 +33,6 @@ export function getHtml(this: HistoryEmbeddingsPromoElement) {
+       </div>
+       <div>
+         $i18n{historyEmbeddingsDisclaimer}
+-        <a href="$i18n{historyEmbeddingsSettingsUrl}" target="_blank">
+-          $i18n{historyEmbeddingsPromoSettingsLinkText}
+-        </a>
+       </div>
+     </div>
+   </div>

--- a/patches/chrome-browser-resources-side_panel-history_clusters-app.html.ts.patch
+++ b/patches/chrome-browser-resources-side_panel-history_clusters-app.html.ts.patch
@@ -1,0 +1,17 @@
+diff --git a/chrome/browser/resources/side_panel/history_clusters/app.html.ts b/chrome/browser/resources/side_panel/history_clusters/app.html.ts
+index 9276e87e8d156faf0a497fe25fdb1ff106a80afd..86d512837eb507d177b50c92855060e5e42b1cc9 100644
+--- a/chrome/browser/resources/side_panel/history_clusters/app.html.ts
++++ b/chrome/browser/resources/side_panel/history_clusters/app.html.ts
+@@ -21,12 +21,6 @@ export function getHtml(this: HistoryClustersAppElement) {
+ ${this.enableHistoryEmbeddings_ ? html`
+ <div id="historyEmbeddingsDisclaimer">
+   $i18n{historyEmbeddingsDisclaimer}
+-  <a id="historyEmbeddingsDisclaimerLink" href="#"
+-      aria-describedby="historyEmbeddingsDisclaimer"
+-      @click="${this.onHistoryEmbeddingsDisclaimerLinkClick_}"
+-      @auxclick="${this.onHistoryEmbeddingsDisclaimerLinkAuxclick_}">
+-    $i18n{learnMore}
+-  </a>
+ </div>
+ ` : ''}
+ <div id="embeddingsScrollContainer"

--- a/patches/components-omnibox-browser-featured_search_provider.cc.patch
+++ b/patches/components-omnibox-browser-featured_search_provider.cc.patch
@@ -1,0 +1,17 @@
+diff --git a/components/omnibox/browser/featured_search_provider.cc b/components/omnibox/browser/featured_search_provider.cc
+index 29b83c6edeee8a467ef5bb7e2773586024b4fb22..66d6b9af9ac3315891810d15355d330f50864c97 100644
+--- a/components/omnibox/browser/featured_search_provider.cc
++++ b/components/omnibox/browser/featured_search_provider.cc
+@@ -609,10 +609,10 @@ bool FeaturedSearchProvider::ShouldShowHistoryEmbeddingsDisclaimerIphMatch()
+ 
+ void FeaturedSearchProvider::AddHistoryEmbeddingsDisclaimerIphMatch() {
+   std::u16string text =
+-      l10n_util::GetStringUTF16(IDS_OMNIBOX_HISTORY_EMBEDDINGS_DISCLAIMER_IPH) +
++      l10n_util::GetStringUTF16(IDS_BRAVE_OMNIBOX_HISTORY_EMBEDDINGS_DISCLAIMER_IPH) +
+       u" ";
+   std::u16string link_text = l10n_util::GetStringUTF16(
+-      IDS_OMNIBOX_HISTORY_EMBEDDINGS_DISCLAIMER_IPH_LINK_TEXT);
++      IDS_BRAVE_EMPTY_STRING);
+   AddIPHMatch(IphType::kHistoryEmbeddingsDisclaimer,
+               /*iph_contents=*/text,
+               /*matched_term=*/u"",

--- a/patches/ui-webui-resources-cr_components-history_embeddings-history_embeddings.html.ts.patch
+++ b/patches/ui-webui-resources-cr_components-history_embeddings-history_embeddings.html.ts.patch
@@ -1,0 +1,26 @@
+diff --git a/ui/webui/resources/cr_components/history_embeddings/history_embeddings.html.ts b/ui/webui/resources/cr_components/history_embeddings/history_embeddings.html.ts
+index 068b469dea6f13595b32bb25d8df0d69c1cfd357..aeff49145975b5e251ed640702b2579ccc6bab0a 100644
+--- a/ui/webui/resources/cr_components/history_embeddings/history_embeddings.html.ts
++++ b/ui/webui/resources/cr_components/history_embeddings/history_embeddings.html.ts
+@@ -57,10 +57,6 @@ ${!this.enableAnswers_ ? html`
+ 
+         <div class="footer">
+           <div>${this.i18n('historyEmbeddingsFooter')}</div>
+-          <cr-feedback-buttons
+-              selected-option="${this.feedbackState_}"
+-              @selected-option-changed="${this.onFeedbackSelectedOptionChanged_}">
+-          </cr-feedback-buttons>
+         </div>
+       </div>
+     `}
+@@ -178,10 +174,6 @@ ${this.enableAnswers_ ? html`
+   </div>
+   <div class="footer">
+     <div>${this.i18n('historyEmbeddingsFooter')}</div>
+-    <cr-feedback-buttons
+-        selected-option="${this.feedbackState_}"
+-        @selected-option-changed="${this.onFeedbackSelectedOptionChanged_}">
+-    </cr-feedback-buttons>
+   </div>
+ ` : ''}
+ 

--- a/rewrite/chrome/browser/history_embeddings/history_embeddings_utils.cc.toml
+++ b/rewrite/chrome/browser/history_embeddings/history_embeddings_utils.cc.toml
@@ -1,0 +1,21 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+# Swap the upstream history semantic search disclaimer IDS references to
+# Brave-owned strings. Brave's implementation runs entirely on-device (see
+# brave/browser/history_embeddings/README.md), so the upstream text about
+# data being sent to Brave and seen by human reviewers is inaccurate. The
+# IDS_BRAVE_* definitions are pulled in by the chromium_src override at
+# brave/chromium_src/chrome/browser/history_embeddings/history_embeddings_utils.cc.
+
+[[substitution]]
+description = 'Swap IDS_HISTORY_EMBEDDINGS_DISCLAIMER_LOGGING_OFF to the Brave-owned string.'
+re_pattern = '\bIDS_HISTORY_EMBEDDINGS_DISCLAIMER_LOGGING_OFF\b'
+replace = 'IDS_BRAVE_HISTORY_EMBEDDINGS_DISCLAIMER'
+
+[[substitution]]
+description = 'Swap IDS_HISTORY_EMBEDDINGS_DISCLAIMER to the Brave-owned string.'
+re_pattern = '\bIDS_HISTORY_EMBEDDINGS_DISCLAIMER\b'
+replace = 'IDS_BRAVE_HISTORY_EMBEDDINGS_DISCLAIMER'

--- a/rewrite/chrome/browser/resources/history/app.html.ts.toml
+++ b/rewrite/chrome/browser/resources/history/app.html.ts.toml
@@ -1,0 +1,13 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+# Brave has no user-facing history-search setting page, so the disclaimer's
+# "Learn more" link (which points at historyEmbeddingsSettingsUrl) would
+# navigate to a page we hide. Drop the link; the disclaimer still renders.
+
+[[substitution]]
+description = 'Remove the disclaimer Learn more link from the history page.'
+re_pattern = '\s*<a id="historyEmbeddingsDisclaimerLink"[\s\S]+?</a>'
+replace = ''

--- a/rewrite/chrome/browser/resources/history/history_embeddings_promo.html.ts.toml
+++ b/rewrite/chrome/browser/resources/history/history_embeddings_promo.html.ts.toml
@@ -1,0 +1,14 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+# Brave doesn't expose a user-facing toggle for history semantic search
+# (it runs entirely on-device), so strip the "Manage your history search
+# setting" link from the IPH promo — it would navigate to a page we also
+# hide (see chromium_src/.../history_embeddings_utils.cc).
+
+[[substitution]]
+description = 'Remove the Manage-history-search-setting link from the history embeddings promo.'
+re_pattern = '\s*<a href="\$i18n\{historyEmbeddingsSettingsUrl\}"[\s\S]+?</a>'
+replace = ''

--- a/rewrite/chrome/browser/resources/side_panel/history_clusters/app.html.ts.toml
+++ b/rewrite/chrome/browser/resources/side_panel/history_clusters/app.html.ts.toml
@@ -1,0 +1,13 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+# Brave has no user-facing history-search setting page, so remove the
+# side panel disclaimer's "Learn more" link (pairs with the drop on the
+# main history page in chrome/browser/resources/history/app.html.ts).
+
+[[substitution]]
+description = 'Remove the disclaimer Learn more link from the history side panel.'
+re_pattern = '\s*<a id="historyEmbeddingsDisclaimerLink"[\s\S]+?</a>'
+replace = ''

--- a/rewrite/components/omnibox/browser/featured_search_provider.cc.toml
+++ b/rewrite/components/omnibox/browser/featured_search_provider.cc.toml
@@ -1,0 +1,21 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+# Swap the upstream omnibox history embeddings disclaimer IDS to
+# Brave-owned strings. The disclaimer text is replaced with the
+# on-device-only wording; the trailing link text is replaced with
+# IDS_BRAVE_EMPTY_STRING so the "Learn more" link renders at zero width.
+# The IDS_BRAVE_* definitions are pulled in by the chromium_src override
+# at brave/chromium_src/components/omnibox/browser/featured_search_provider.cc.
+
+[[substitution]]
+description = 'Swap IDS_OMNIBOX_HISTORY_EMBEDDINGS_DISCLAIMER_IPH_LINK_TEXT to an empty string so the "Learn more" link view renders at zero width.'
+re_pattern = '\bIDS_OMNIBOX_HISTORY_EMBEDDINGS_DISCLAIMER_IPH_LINK_TEXT\b'
+replace = 'IDS_BRAVE_EMPTY_STRING'
+
+[[substitution]]
+description = 'Swap IDS_OMNIBOX_HISTORY_EMBEDDINGS_DISCLAIMER_IPH to the Brave-owned string.'
+re_pattern = '\bIDS_OMNIBOX_HISTORY_EMBEDDINGS_DISCLAIMER_IPH\b'
+replace = 'IDS_BRAVE_OMNIBOX_HISTORY_EMBEDDINGS_DISCLAIMER_IPH'

--- a/rewrite/ui/webui/resources/cr_components/history_embeddings/history_embeddings.html.ts.toml
+++ b/rewrite/ui/webui/resources/cr_components/history_embeddings/history_embeddings.html.ts.toml
@@ -1,0 +1,10 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+[[substitution]]
+description = 'Hide thumbs up/down feedback buttons to avoid exposing a feedback mechanism; nothing leaves the device.'
+re_pattern = '\s*<cr-feedback-buttons[\s\S]+?</cr-feedback-buttons>'
+replace = ''
+count = 0


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/54798

  Brave's history semantic search runs entirely on-device, but the inherited
  Chromium UI still implies a cloud round-trip. This PR reconciles the UI
  with reality:

  - Reword the history/omnibox disclaimer text — no data leaves the device,
    no human reviewers — by adding Brave-owned strings
    (`IDS_BRAVE_HISTORY_EMBEDDINGS_DISCLAIMER`,
    `IDS_BRAVE_OMNIBOX_HISTORY_EMBEDDINGS_DISCLAIMER_IPH`) and swapping the
    IDS in the chromium_src overrides for `history_embeddings_utils.cc` and
    `featured_search_provider.cc`. Owning the strings is resilient to
    upstream wording tweaks, and neither override needs a new GN dep —
    `brave/grit/brave_generated_resources.h` is reachable via the existing
    `//chrome/app:generated_resources` transitive dep, and
    `components/grit/brave_components_strings.h` via the existing
    `brave_components_omnibox_browser_deps` injection.
  - Remove UI that implies a cloud feature: thumbs up/down feedback buttons,
    the "Learn more" link on chrome://history and the history side panel,
    the IPH promo's "Manage your history search setting" link, and the
    omnibox disclaimer IPH "Learn more" link.
  - Hide `chrome://settings/ai` by forcing `IsHistoryEmbeddingsSettingVisible()`
    to false; with History Search being the only AI feature Brave surfaces,
    the entire AI settings section drops out.


<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

## Test plan
### Side note
If you accidentally dismiss promo in brave://history, you can open dev tools console and 
```
localStorage.removeItem('history-embeddings-promo');
localStorage.removeItem('history-embeddings-answers-promo');
```
then reload the page

### Steps
1. Enable  brave://flags/#brave-history-embeddings and relaunch
2. Navigate to https://www.teslarati.com/tesla-robotaxi-appears-heading-new-u-s-city/ 
3. Wait for a few moments (embeddings are calculated in the background)
4. Navigate to brave://history/ and check disclaimer
<img width="1002" height="345" alt="Screenshot 2026-04-22 at 14 08 38" src="https://github.com/user-attachments/assets/b5c983b1-5f93-4c56-b332-e39ad2d40905" />
5. Search for "self driving" and check result, there should be no thumb up/down button
<img width="1001" height="288" alt="Screenshot 2026-04-22 at 14 08 55" src="https://github.com/user-attachments/assets/31a35408-66c1-4adc-984d-06657266fff7" />
6. Try to search on omnibox with `@history` with "self driving" and check disclaimer
<img width="1005" height="192" alt="Screenshot 2026-04-22 at 14 09 11" src="https://github.com/user-attachments/assets/9e2964c9-d754-4ce0-a31f-6157cf308b29" />
7. Go to setting, and check there is no "AI innovations" section
8. Type brave://settings/ai/ or brave://settings/ai/historySearch in omnibox, both should be not accessible

