### PR TITLE
[CodeHealth] Fix `Prefs::GetSeed` interface

### DIFF
--- a/browser/infobars/sync_cannot_run_infobar_delegate.cc
+++ b/browser/infobars/sync_cannot_run_infobar_delegate.cc
@@ -23,17 +23,6 @@
 #include "ui/base/l10n/l10n_util.h"
 #include "ui/views/vector_icons.h"
 
-namespace {
-
-bool SeedDecryptionFailed(raw_ptr<brave_sync::Prefs> brave_sync_prefs) {
-  CHECK_NE(brave_sync_prefs, nullptr);
-  bool failed_to_decrypt = false;
-  std::string seed = brave_sync_prefs->GetSeed(&failed_to_decrypt);
-  return failed_to_decrypt;
-}
-
-}  // namespace
-
 // static
 void SyncCannotRunInfoBarDelegate::Create(
     infobars::ContentInfoBarManager* infobar_manager,
@@ -44,7 +33,7 @@ void SyncCannotRunInfoBarDelegate::Create(
     return;
   }
 
-  if (!SeedDecryptionFailed(&brave_sync_prefs)) {
+  if (brave_sync_prefs.GetSeed().has_value()) {
     return;
   }
 

--- a/browser/profiles/delete_profile_helper_browsertest.cc
+++ b/browser/profiles/delete_profile_helper_browsertest.cc
@@ -20,10 +20,15 @@
 #include "chrome/browser/ui/browser.h"
 #include "chrome/test/base/in_process_browser_test.h"
 #include "content/public/test/browser_test.h"
+#include "testing/gmock/include/gmock/gmock.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 // Profiles are not supported on Android and iOS, so can't do the test
 static_assert(!BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_IOS));
+
+using testing::IsEmpty;
+using testing::Not;
+using testing::Optional;
 
 namespace {
 constexpr char kValidSyncCode[] =
@@ -66,10 +71,9 @@ IN_PROC_BROWSER_TEST_F(DeleteProfileHelperBrowserTest,
   EXPECT_TRUE(brave_sync_service->SetSyncCode(kValidSyncCode));
 
   brave_sync::Prefs brave_sync_prefs(profile_to_delete.GetPrefs());
-  bool failed_to_decrypt;
-  std::string seed = brave_sync_prefs.GetSeed(&failed_to_decrypt);
-  ASSERT_FALSE(failed_to_decrypt);
-  EXPECT_FALSE(seed.empty());
+  std::optional<std::string> seed = brave_sync_prefs.GetSeed();
+  ASSERT_TRUE(seed.has_value());
+  EXPECT_THAT(seed.value(), Not(IsEmpty()));
 
   base::RunLoop loop;
   profile_manager->GetDeleteProfileHelper().MaybeScheduleProfileForDeletion(
@@ -83,7 +87,6 @@ IN_PROC_BROWSER_TEST_F(DeleteProfileHelperBrowserTest,
   // Ensure that we've invoked BraveSyncServiceImpl::StopAndClear() from
   // DisableSyncForProfileDeletion at delete_profile_helper.cc, so
   // now seed should be empty
-  seed = brave_sync_prefs.GetSeed(&failed_to_decrypt);
-  ASSERT_FALSE(failed_to_decrypt);
-  EXPECT_TRUE(seed.empty());
+  seed = brave_sync_prefs.GetSeed();
+  EXPECT_THAT(seed, Optional(IsEmpty()));
 }

--- a/chromium_src/chrome/browser/ui/webui/settings/people_handler.cc
+++ b/chromium_src/chrome/browser/ui/webui/settings/people_handler.cc
@@ -17,11 +17,10 @@
     syncer::BraveSyncServiceImpl* brave_sync_service =                       \
         static_cast<syncer::BraveSyncServiceImpl*>(service);                 \
     if (brave_sync_service) {                                                \
-      bool failed_to_decrypt = false;                                        \
-      brave_sync_service->prefs().GetSeed(&failed_to_decrypt);               \
-      sync_status.Set("hasSyncWordsDecryptionError", failed_to_decrypt);     \
+      auto seed = brave_sync_service->prefs().GetSeed();                     \
+      sync_status.Set("hasSyncWordsDecryptionError", !seed.has_value());     \
       sync_status.Set("isOsEncryptionAvailable",                             \
-                      OSCrypt::IsEncryptionAvailable());                     \
+                      brave_sync_service->prefs().IsEncryptionAvailable());  \
     }                                                                        \
   }
 

--- a/chromium_src/components/sync/service/sync_internals_util.cc
+++ b/chromium_src/components/sync/service/sync_internals_util.cc
@@ -28,17 +28,16 @@ base::DictValue ConstructAboutInformation(
       section_brave_sync.AddBoolStat("Passphrase is set");
   BraveSyncServiceImpl* brave_sync_service =
       static_cast<BraveSyncServiceImpl*>(service);
-  bool failed_to_decrypt = false;
-  std::string seed = brave_sync_service->prefs().GetSeed(&failed_to_decrypt);
+  std::optional<std::string> seed = brave_sync_service->prefs().GetSeed();
   // If the passphrase has been set, either we can see it or we failed to
   // decrypt it
-  bool is_passphrase_set_val = !seed.empty() || failed_to_decrypt;
+  bool is_passphrase_set_val = !seed || !seed->empty();
   is_passphrase_set->Set(is_passphrase_set_val);
 
   // OSCrypt behavior varies depending on OS. It is possible that
   // OSCrypt::IsEncryptionAvailable reports false, but OSCrypt::DecryptString
   // succeeds. So put the additional field with actual decryption result.
-  if (failed_to_decrypt) {
+  if (!seed) {
     Stat<bool>* failed_to_decrypt_passphrase =
         section_brave_sync.AddBoolStat("Passphrase decryption failed");
     failed_to_decrypt_passphrase->Set(true);
@@ -46,7 +45,8 @@ base::DictValue ConstructAboutInformation(
 
   Stat<bool>* is_os_encryption_available =
       section_brave_sync.AddBoolStat("OS encryption available");
-  is_os_encryption_available->Set(OSCrypt::IsEncryptionAvailable());
+  is_os_encryption_available->Set(
+      brave_sync_service->prefs().IsEncryptionAvailable());
 
   Stat<std::string>* leave_chain_details =
       section_brave_sync.AddStringStat("Leave chain details");

--- a/components/brave_sync/brave_sync_prefs.cc
+++ b/components/brave_sync/brave_sync_prefs.cc
@@ -123,29 +123,23 @@ std::string Prefs::GetSeedPath() {
   return kSyncV2Seed;
 }
 
-std::string Prefs::GetSeed(bool* failed_to_decrypt) const {
-  CHECK(failed_to_decrypt);
-  *failed_to_decrypt = true;
-
+std::optional<std::string> Prefs::GetSeed() const {
   const auto& encoded_seed = pref_service_->GetString(kSyncV2Seed);
   if (encoded_seed.empty()) {
-    *failed_to_decrypt = false;
     return std::string();
   }
 
   std::string encrypted_seed;
   if (!base::Base64Decode(encoded_seed, &encrypted_seed)) {
     LOG(ERROR) << "base64 decode sync seed failure";
-    return std::string();
+    return std::nullopt;
   }
 
   std::string seed;
   if (!OSCrypt::DecryptString(encrypted_seed, &seed)) {
     LOG(ERROR) << "Decrypt sync seed failure";
-    return std::string();
+    return std::nullopt;
   }
-
-  *failed_to_decrypt = false;
   return seed;
 }
 
@@ -227,6 +221,12 @@ void Prefs::SetAddLeaveChainDetailBehaviourForTests(
 void Prefs::Clear() {
   pref_service_->ClearPref(kSyncV2Seed);
   pref_service_->ClearPref(kSyncFailedDecryptSeedNoticeDismissed);
+}
+
+bool Prefs::IsEncryptionAvailable() const {
+  // This is being added here only temporarily, as the async backend will come
+  // in to replace this OSCrypt use.
+  return OSCrypt::IsEncryptionAvailable();
 }
 
 void MigrateBraveSyncPrefs(PrefService* prefs) {

--- a/components/brave_sync/brave_sync_prefs.h
+++ b/components/brave_sync/brave_sync_prefs.h
@@ -7,6 +7,7 @@
 #define BRAVE_COMPONENTS_BRAVE_SYNC_BRAVE_SYNC_PREFS_H_
 
 #include <memory>
+#include <optional>
 #include <string>
 
 #include "base/memory/raw_ref.h"
@@ -37,7 +38,7 @@ class Prefs {
 
   static std::string GetSeedPath();
 
-  std::string GetSeed(bool* failed_to_decrypt) const;
+  std::optional<std::string> GetSeed() const;
   bool SetSeed(const std::string& seed);
 
   bool IsSyncAccountDeletedNoticePending() const;
@@ -54,6 +55,7 @@ class Prefs {
   static std::string GetLeaveChainDetailsPathForTests();
   void SetAddLeaveChainDetailBehaviourForTests(
       AddLeaveChainDetailBehaviour add_leave_chain_detail_behaviour);
+  bool IsEncryptionAvailable() const;
 
   void Clear();
 

--- a/components/brave_sync/brave_sync_prefs_unittest.cc
+++ b/components/brave_sync/brave_sync_prefs_unittest.cc
@@ -20,6 +20,10 @@
 #include "components/sync/service/sync_prefs.h"
 #endif
 
+using testing::Eq;
+using testing::IsEmpty;
+using testing::Optional;
+
 namespace brave_sync {
 
 namespace {
@@ -42,6 +46,9 @@ class BraveSyncPrefsTest : public testing::Test {
 #endif
   }
 
+  void SetUp() override { OSCryptMocker::SetUp(); }
+  void TearDown() override { OSCryptMocker::TearDown(); }
+
   brave_sync::Prefs* brave_sync_prefs() { return brave_sync_prefs_.get(); }
 
   PrefService* pref_service() { return &pref_service_; }
@@ -60,32 +67,20 @@ class BraveSyncPrefsTest : public testing::Test {
 // On macOS expected to see decryption failure when reading seed on
 // locked keyring
 TEST_F(BraveSyncPrefsTest, ValidPassphraseKeyringLocked) {
-  OSCryptMocker::SetUp();
-
   brave_sync_prefs()->SetSeed(kValidSyncCode);
-
-  bool failed_to_decrypt = false;
   OSCryptMocker::SetBackendLocked(true);
-  EXPECT_EQ(brave_sync_prefs()->GetSeed(&failed_to_decrypt), "");
-  EXPECT_TRUE(failed_to_decrypt);
-
-  OSCryptMocker::TearDown();
+  EXPECT_THAT(brave_sync_prefs()->GetSeed(), Eq(std::nullopt));
 }
 
 #endif  // BUILDFLAG(IS_APPLE)
 
 TEST_F(BraveSyncPrefsTest, FailedToDecryptBraveSeedValue) {
-  OSCryptMocker::SetUp();
-
   // Empty seed is expected as valid when sync is not turned on
-  bool failed_to_decrypt = false;
-  EXPECT_EQ(brave_sync_prefs()->GetSeed(&failed_to_decrypt), "");
-  EXPECT_FALSE(failed_to_decrypt);
+  EXPECT_THAT(brave_sync_prefs()->GetSeed(), Optional(IsEmpty()));
 
   // Valid code does not set failed_to_decrypt
   brave_sync_prefs()->SetSeed(kValidSyncCode);
-  EXPECT_EQ(brave_sync_prefs()->GetSeed(&failed_to_decrypt), kValidSyncCode);
-  EXPECT_FALSE(failed_to_decrypt);
+  EXPECT_THAT(brave_sync_prefs()->GetSeed(), Eq(kValidSyncCode));
 
   // Wrong base64-encoded seed must set failed_to_decrypt to true
   const char kWrongBase64String[] = "AA%BB";
@@ -93,32 +88,17 @@ TEST_F(BraveSyncPrefsTest, FailedToDecryptBraveSeedValue) {
   EXPECT_FALSE(base::Base64Decode(kWrongBase64String, &base64_decoded));
   pref_service()->SetString(brave_sync::Prefs::GetSeedPath(),
                             kWrongBase64String);
-  EXPECT_EQ(brave_sync_prefs()->GetSeed(&failed_to_decrypt), "");
-  EXPECT_TRUE(failed_to_decrypt);
+  EXPECT_THAT(brave_sync_prefs()->GetSeed(), Eq(std::nullopt));
 
   // Valid base64 string but not valid encrypted string must set
   // failed_to_decrypt to true. Note: "v10" prefix is important to make
   // DecryptString fail. Also the remaining string must be 12 or more bytes.
   pref_service()->SetString(brave_sync::Prefs::GetSeedPath(),
                             base::Base64Encode("v10_AABBCCDDEEFF"));
-  EXPECT_EQ(brave_sync_prefs()->GetSeed(&failed_to_decrypt), "");
-  EXPECT_TRUE(failed_to_decrypt);
-
-  OSCryptMocker::TearDown();
+  EXPECT_THAT(brave_sync_prefs()->GetSeed(), Eq(std::nullopt));
 }
 
 using BraveSyncPrefsDeathTest = BraveSyncPrefsTest;
-
-// Some tests are failing for Windows x86 CI,
-// See https://github.com/brave/brave-browser/issues/22767
-#if BUILDFLAG(IS_WIN) && defined(ARCH_CPU_X86)
-#define MAYBE_GetSeedOutNullptrCHECK DISABLED_GetSeedOutNullptrCHECK
-#else
-#define MAYBE_GetSeedOutNullptrCHECK GetSeedOutNullptrCHECK
-#endif
-TEST_F(BraveSyncPrefsDeathTest, MAYBE_GetSeedOutNullptrCHECK) {
-  EXPECT_CHECK_DEATH(brave_sync_prefs()->GetSeed(nullptr));
-}
 
 TEST_F(BraveSyncPrefsTest, LeaveChainDetailsMaxLenIOS) {
   brave_sync_prefs()->SetAddLeaveChainDetailBehaviourForTests(

--- a/components/sync/service/brave_sync_service_impl.cc
+++ b/components/sync/service/brave_sync_service_impl.cc
@@ -45,10 +45,9 @@ BraveSyncServiceImpl::BraveSyncServiceImpl(
       brave_sync::Prefs::GetSeedPath(),
       base::BindRepeating(&BraveSyncServiceImpl::OnBraveSyncPrefsChanged,
                           base::Unretained(this)));
-  bool failed_to_decrypt = false;
-  GetBraveSyncAuthManager()->DeriveSigningKeys(
-      brave_sync_prefs_.GetSeed(&failed_to_decrypt));
-  DCHECK(!failed_to_decrypt);
+  std::optional<std::string> seed = brave_sync_prefs_.GetSeed();
+  CHECK(seed.has_value());
+  GetBraveSyncAuthManager()->DeriveSigningKeys(*seed);
 
   sync_service_impl_delegate_->set_profile_sync_service(this);
 }
@@ -87,27 +86,24 @@ void BraveSyncServiceImpl::StopAndClear(ResetEngineReason reset_engine_reason) {
 }
 
 std::string BraveSyncServiceImpl::GetOrCreateSyncCode() {
-  bool failed_to_decrypt = false;
-  std::string sync_code = brave_sync_prefs_.GetSeed(&failed_to_decrypt);
-
-  if (failed_to_decrypt) {
+  std::optional<std::string> sync_code = brave_sync_prefs_.GetSeed();
+  if (!sync_code.has_value()) {
     // Do not try to re-create seed when OSCrypt fails, for example on macOS
     // when the keyring is locked.
-    DCHECK(sync_code.empty());
     return std::string();
   }
 
-  if (sync_code.empty()) {
+  if (sync_code->empty()) {
     std::vector<uint8_t> seed = brave_sync::crypto::GetSeed();
-    sync_code = brave_sync::crypto::PassphraseFromBytes32(seed);
+    *sync_code = brave_sync::crypto::PassphraseFromBytes32(seed);
     sync_code_monitor_.RecordCodeGenerated();
   }
 
-  CHECK(!sync_code.empty()) << "Attempt to return empty sync code";
-  CHECK(brave_sync::crypto::IsPassphraseValid(sync_code))
+  CHECK(!sync_code->empty()) << "Attempt to return empty sync code";
+  CHECK(brave_sync::crypto::IsPassphraseValid(*sync_code))
       << "Attempt to return non-valid sync code";
 
-  return sync_code;
+  return std::move(sync_code).value();
 }
 
 bool BraveSyncServiceImpl::SetSyncCode(const std::string& sync_code) {
@@ -161,12 +157,11 @@ BraveSyncAuthManager* BraveSyncServiceImpl::GetBraveSyncAuthManager() {
 void BraveSyncServiceImpl::OnBraveSyncPrefsChanged(const std::string& path) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
   if (path == brave_sync::Prefs::GetSeedPath()) {
-    bool failed_to_decrypt = false;
-    const std::string seed = brave_sync_prefs_.GetSeed(&failed_to_decrypt);
-    DCHECK(!failed_to_decrypt);
+    std::optional<std::string> seed = brave_sync_prefs_.GetSeed();
+    CHECK(seed.has_value());
 
-    if (!seed.empty()) {
-      GetBraveSyncAuthManager()->DeriveSigningKeys(seed);
+    if (!seed->empty()) {
+      GetBraveSyncAuthManager()->DeriveSigningKeys(*seed);
       // Default enabled types: Bookmarks, Passwords
 
       // Related Chromium change: 33441a0f3f9a591693157f2fd16852ce072e6f9d
@@ -218,16 +213,15 @@ void BraveSyncServiceImpl::OnEngineInitialized(
     return;
   }
 
-  bool failed_to_decrypt = false;
-  std::string passphrase = brave_sync_prefs_.GetSeed(&failed_to_decrypt);
-  DCHECK(!failed_to_decrypt);
-  if (passphrase.empty()) {
+  std::optional<std::string> passphrase = brave_sync_prefs_.GetSeed();
+  CHECK(passphrase.has_value());
+  if (passphrase->empty()) {
     return;
   }
 
   if (sync_user_settings->IsPassphraseRequired()) {
     bool set_passphrase_result =
-        sync_user_settings->SetDecryptionPassphrase(passphrase);
+        sync_user_settings->SetDecryptionPassphrase(*passphrase);
     VLOG(1) << "Forced set decryption passphrase result is "
             << set_passphrase_result;
   }

--- a/components/sync/service/brave_sync_service_impl_unittest.cc
+++ b/components/sync/service/brave_sync_service_impl_unittest.cc
@@ -52,7 +52,10 @@
 
 using testing::_;
 using testing::ByMove;
+using testing::Eq;
+using testing::IsEmpty;
 using testing::NiceMock;
+using testing::Optional;
 using testing::Return;
 
 namespace syncer {
@@ -122,6 +125,7 @@ class BraveSyncServiceImplTest : public testing::Test {
 
   void SetUp() override {
     testing::Test::SetUp();
+    OSCryptMocker::SetUp();
     network_time_tracker_ = std::make_unique<network_time::NetworkTimeTracker>(
         std::unique_ptr<base::Clock>(new base::DefaultClock()),
         std::unique_ptr<base::TickClock>(new base::DefaultTickClock()),
@@ -134,6 +138,7 @@ class BraveSyncServiceImplTest : public testing::Test {
   void TearDown() override {
     brave_sync::NetworkTimeHelper::GetInstance()->Shutdown();
     testing::Test::TearDown();
+    OSCryptMocker::TearDown();
   }
 
   void CreateSyncService(
@@ -194,8 +199,6 @@ TEST_F(BraveSyncServiceImplTest, GroupPolicyOverride) {
   pref_service()->SetManagedPref(brave_sync::kCustomSyncServiceUrl,
                                  base::Value("https://sync.example.com/v2"));
 
-  OSCryptMocker::SetUp();
-
   CreateSyncService();
 
   EXPECT_FALSE(engine());
@@ -205,8 +208,6 @@ TEST_F(BraveSyncServiceImplTest, GroupPolicyOverride) {
       brave_sync_service_impl()->GetSyncServiceUrlForDebugging();
   EXPECT_EQ(expected_service_url, actual_service_url);
 
-  OSCryptMocker::TearDown();
-
   pref_service()->SetManagedPref(brave_sync::kCustomSyncServiceUrl,
                                  base::Value(""));
 }
@@ -214,8 +215,6 @@ TEST_F(BraveSyncServiceImplTest, GroupPolicyOverride) {
 TEST_F(BraveSyncServiceImplTest, GroupPolicyNonHttpsOverride) {
   pref_service()->SetManagedPref(brave_sync::kCustomSyncServiceUrl,
                                  base::Value("http://sync.example.com/v2"));
-
-  OSCryptMocker::SetUp();
 
   CreateSyncService();
 
@@ -226,15 +225,11 @@ TEST_F(BraveSyncServiceImplTest, GroupPolicyNonHttpsOverride) {
       brave_sync_service_impl()->GetSyncServiceUrlForDebugging();
   EXPECT_NE(expected_service_url, actual_service_url);
 
-  OSCryptMocker::TearDown();
-
   pref_service()->SetManagedPref(brave_sync::kCustomSyncServiceUrl,
                                  base::Value(""));
 }
 
 TEST_F(BraveSyncServiceImplTest, ValidPassphrase) {
-  OSCryptMocker::SetUp();
-
   CreateSyncService();
 
   EXPECT_FALSE(engine());
@@ -242,16 +237,10 @@ TEST_F(BraveSyncServiceImplTest, ValidPassphrase) {
   bool set_code_result = brave_sync_service_impl()->SetSyncCode(kValidSyncCode);
   EXPECT_TRUE(set_code_result);
 
-  bool failed_to_decrypt = false;
-  EXPECT_EQ(brave_sync_prefs()->GetSeed(&failed_to_decrypt), kValidSyncCode);
-  EXPECT_FALSE(failed_to_decrypt);
-
-  OSCryptMocker::TearDown();
+  EXPECT_THAT(brave_sync_prefs()->GetSeed(), testing::Eq(kValidSyncCode));
 }
 
 TEST_F(BraveSyncServiceImplTest, InvalidPassphrase) {
-  OSCryptMocker::SetUp();
-
   CreateSyncService();
   EXPECT_FALSE(engine());
 
@@ -259,16 +248,11 @@ TEST_F(BraveSyncServiceImplTest, InvalidPassphrase) {
       brave_sync_service_impl()->SetSyncCode("word one and then two");
   EXPECT_FALSE(set_code_result);
 
-  bool failed_to_decrypt = false;
-  EXPECT_EQ(brave_sync_prefs()->GetSeed(&failed_to_decrypt), "");
-  EXPECT_FALSE(failed_to_decrypt);
-
-  OSCryptMocker::TearDown();
+  EXPECT_THAT(brave_sync_prefs()->GetSeed(),
+              testing::Optional(::testing::IsEmpty()));
 }
 
 TEST_F(BraveSyncServiceImplTest, ValidPassphraseLeadingTrailingWhitespace) {
-  OSCryptMocker::SetUp();
-
   CreateSyncService();
   EXPECT_FALSE(engine());
 
@@ -278,11 +262,7 @@ TEST_F(BraveSyncServiceImplTest, ValidPassphraseLeadingTrailingWhitespace) {
       brave_sync_service_impl()->SetSyncCode(sync_code_extra_whitespace);
   EXPECT_TRUE(set_code_result);
 
-  bool failed_to_decrypt = false;
-  EXPECT_EQ(brave_sync_prefs()->GetSeed(&failed_to_decrypt), kValidSyncCode);
-  EXPECT_FALSE(failed_to_decrypt);
-
-  OSCryptMocker::TearDown();
+  EXPECT_THAT(brave_sync_prefs()->GetSeed(), testing::Eq(kValidSyncCode));
 }
 
 // Google test doc strongly recommends to use `*DeathTest` naming
@@ -298,8 +278,6 @@ using BraveSyncServiceImplDeathTest = BraveSyncServiceImplTest;
 #define MAYBE_EmulateGetOrCreateSyncCodeCHECK EmulateGetOrCreateSyncCodeCHECK
 #endif
 TEST_F(BraveSyncServiceImplDeathTest, MAYBE_EmulateGetOrCreateSyncCodeCHECK) {
-  OSCryptMocker::SetUp();
-
   CreateSyncService();
   EXPECT_FALSE(engine());
 
@@ -320,13 +298,9 @@ TEST_F(BraveSyncServiceImplDeathTest, MAYBE_EmulateGetOrCreateSyncCodeCHECK) {
                             base::Base64Encode(encrypted_wrong_seed));
 
   EXPECT_CHECK_DEATH(brave_sync_service_impl()->GetOrCreateSyncCode());
-
-  OSCryptMocker::TearDown();
 }
 
 TEST_F(BraveSyncServiceImplTest, StopAndClearForBraveSeed) {
-  OSCryptMocker::SetUp();
-
   CreateSyncService();
   EXPECT_FALSE(engine());
 
@@ -335,15 +309,10 @@ TEST_F(BraveSyncServiceImplTest, StopAndClearForBraveSeed) {
 
   brave_sync_service_impl()->StopAndClearWithResetLocalDataReason();
 
-  bool failed_to_decrypt = false;
-  EXPECT_EQ(brave_sync_prefs()->GetSeed(&failed_to_decrypt), "");
-  EXPECT_FALSE(failed_to_decrypt);
-
-  OSCryptMocker::TearDown();
+  EXPECT_THAT(brave_sync_prefs()->GetSeed(), Optional(IsEmpty()));
 }
 
 TEST_F(BraveSyncServiceImplTest, ForcedSetDecryptionPassphrase) {
-  OSCryptMocker::SetUp();
   CreateSyncService();
   EXPECT_FALSE(engine());
   brave_sync_service_impl()->SetSyncCode(kValidSyncCode);
@@ -397,12 +366,9 @@ TEST_F(BraveSyncServiceImplTest, ForcedSetDecryptionPassphrase) {
   brave_sync_service_impl()->OnEngineInitialized(true, false);
   EXPECT_FALSE(
       brave_sync_service_impl()->GetUserSettings()->IsPassphraseRequired());
-
-  OSCryptMocker::TearDown();
 }
 
 TEST_F(BraveSyncServiceImplTest, OnSelfDeviceInfoDeleted) {
-  OSCryptMocker::SetUp();
   CreateSyncService();
   EXPECT_FALSE(engine());
 
@@ -446,12 +412,9 @@ TEST_F(BraveSyncServiceImplTest, OnSelfDeviceInfoDeleted) {
   data_type_manager_mock_ptr.release();
   brave_sync_service_impl()->data_type_manager_ =
       std::move(bak_data_type_manager);
-
-  OSCryptMocker::TearDown();
 }
 
 TEST_F(BraveSyncServiceImplTest, PermanentlyDeleteAccount) {
-  OSCryptMocker::SetUp();
   CreateSyncService();
   EXPECT_FALSE(engine());
   brave_sync_service_impl()->SetSyncCode(kValidSyncCode);
@@ -472,11 +435,9 @@ TEST_F(BraveSyncServiceImplTest, PermanentlyDeleteAccount) {
   brave_sync_service_impl()->PermanentlyDeleteAccount(base::BindOnce(
       [](const syncer::SyncProtocolError& sync_protocol_error) {}));
   brave_sync_service_impl()->engine_ = std::move(engine_orig);
-  OSCryptMocker::TearDown();
 }
 
 TEST_F(BraveSyncServiceImplTest, OnAccountDeleted_Success) {
-  OSCryptMocker::SetUp();
   CreateSyncService();
   EXPECT_FALSE(engine());
 
@@ -489,12 +450,9 @@ TEST_F(BraveSyncServiceImplTest, OnAccountDeleted_Success) {
         EXPECT_EQ(spe.error_type, SYNC_SUCCESS);
       }),
       sync_protocol_error);
-
-  OSCryptMocker::TearDown();
 }
 
 TEST_F(BraveSyncServiceImplTest, OnAccountDeleted_FailureAndRetry) {
-  OSCryptMocker::SetUp();
   CreateSyncService();
   EXPECT_FALSE(engine());
 
@@ -521,12 +479,9 @@ TEST_F(BraveSyncServiceImplTest, OnAccountDeleted_FailureAndRetry) {
 
     EXPECT_EQ(on_account_deleted_invoked, UNSAFE_TODO(was_callback_invoked[i]));
   }
-
-  OSCryptMocker::TearDown();
 }
 
 TEST_F(BraveSyncServiceImplTest, JoinActiveOrNewChain) {
-  OSCryptMocker::SetUp();
   CreateSyncService();
   EXPECT_FALSE(engine());
 
@@ -545,12 +500,9 @@ TEST_F(BraveSyncServiceImplTest, JoinActiveOrNewChain) {
   EXPECT_FALSE(join_chain_callback_invoked);
   brave_sync_service_impl()->LocalDeviceAppeared();
   EXPECT_TRUE(join_chain_callback_invoked);
-
-  OSCryptMocker::TearDown();
 }
 
 TEST_F(BraveSyncServiceImplTest, JoinDeletedChain) {
-  OSCryptMocker::SetUp();
   CreateSyncService();
   EXPECT_FALSE(engine());
 
@@ -581,8 +533,6 @@ TEST_F(BraveSyncServiceImplTest, JoinDeletedChain) {
       SyncServiceImpl::ResetEngineReason::kDisabledAccount);
 
   EXPECT_TRUE(join_chain_callback_invoked);
-
-  OSCryptMocker::TearDown();
 }
 
 TEST_F(BraveSyncServiceImplTest, HistoryPreconditions) {
@@ -595,7 +545,6 @@ TEST_F(BraveSyncServiceImplTest, HistoryPreconditions) {
   // Otherwise TestSyncUserSettings would not allow to override
   // IsEncryptEverythingEnabled.
 
-  OSCryptMocker::SetUp();
   CreateSyncService();
   EXPECT_FALSE(engine());
   brave_sync_service_impl()->SetSyncCode(kValidSyncCode);
@@ -640,12 +589,9 @@ TEST_F(BraveSyncServiceImplTest, HistoryPreconditions) {
               signin::AccountManagedStatusFinderOutcome::kConsumerGmail));
   EXPECT_EQ(history_delete_directives_precondition_state,
             DataTypeController::PreconditionState::kPreconditionsMet);
-
-  OSCryptMocker::TearDown();
 }
 
 TEST_F(BraveSyncServiceImplTest, BookmarksAndPasswordsAfterSetup) {
-  OSCryptMocker::SetUp();
   CreateSyncService();
   EXPECT_FALSE(engine());
   brave_sync_service_impl()->SetSyncCode(kValidSyncCode);
@@ -664,12 +610,9 @@ TEST_F(BraveSyncServiceImplTest, BookmarksAndPasswordsAfterSetup) {
   EXPECT_EQ(selected_types.size(), 2u);
   EXPECT_TRUE(selected_types.Has(UserSelectableType::kBookmarks));
   EXPECT_TRUE(selected_types.Has(UserSelectableType::kPasswords));
-
-  OSCryptMocker::TearDown();
 }
 
 TEST_F(BraveSyncServiceImplTest, P3aForHistoryThroughDelegate) {
-  OSCryptMocker::SetUp();
   CreateSyncService(DataTypeSet({BOOKMARKS, HISTORY, PASSWORDS}));
   EXPECT_FALSE(engine());
   brave_sync_service_impl()->SetSyncCode(kValidSyncCode);
@@ -708,8 +651,6 @@ TEST_F(BraveSyncServiceImplTest, P3aForHistoryThroughDelegate) {
   brave_sync_service_impl()->OnGetTypeEntitiesCount(bookmarks_count);
   histogram_tester.ExpectBucketCount(
       brave_sync::p3a::kSyncedObjectsCountHistogramNameV2, 2, 1);
-
-  OSCryptMocker::TearDown();
 }
 
 TEST_F(BraveSyncServiceImplTest, NoLeaveDetailsWhenInitializeIOS) {
@@ -756,7 +697,6 @@ class BraveSyncServiceImplTest_DisableSyncDefaultPasswordsTest
 
 TEST_F(BraveSyncServiceImplTest_DisableSyncDefaultPasswordsTest,
        OnlyBookmarks) {
-  OSCryptMocker::SetUp();
   CreateSyncService();
   EXPECT_FALSE(engine());
 
@@ -790,8 +730,6 @@ TEST_F(BraveSyncServiceImplTest_DisableSyncDefaultPasswordsTest,
   EXPECT_EQ(selected_types.size(), 1u);
   EXPECT_TRUE(selected_types.Has(UserSelectableType::kBookmarks));
   EXPECT_FALSE(selected_types.Has(UserSelectableType::kPasswords));
-
-  OSCryptMocker::TearDown();
 }
 
 namespace {


### PR DESCRIPTION
This PR corrects `GetSeed` to be easier to use and less bug prone. This
is being done in preparation to the `os_crypt_sync` migration. An
interface change was the addition of `IsEncryptionAvailable()`, which
will be useful when this type is given an encryptor.

This PR also removes a lot of the os crypt setup and tearr down for
tests, to make it easier to have them removed once they are not needed
anymore.
