### PR TITLE
[AI Chat]: Fix bug where content would be initially associated with flag disabled

### DIFF
--- a/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
+++ b/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
@@ -671,7 +671,8 @@ void AIChatUIPageHandler::BindRelatedConversation(
   } else {
     conversation = AIChatServiceFactory::GetForBrowserContext(profile_)
                        ->CreateConversation();
-    if (ai_chat::CanAssociateContent(
+    if (features::IsPageContextEnabledInitially() &&
+        ai_chat::CanAssociateContent(
             &active_chat_tab_helper_->web_contents_content())) {
       conversation->associated_content_manager()->AddContent(
           &active_chat_tab_helper_->web_contents_content());

--- a/browser/ui/webui/ai_chat/ai_chat_ui_page_handler_browsertest.cc
+++ b/browser/ui/webui/ai_chat/ai_chat_ui_page_handler_browsertest.cc
@@ -752,6 +752,59 @@ IN_PROC_BROWSER_TEST_F(AIChatGlobalSidePanelPageHandlerBrowserTest,
       << "New conversation on chrome:// page should have no associated content";
 }
 
+// Subclass of AIChatUIPageHandlerBrowserTest that disables
+// kPageContextEnabledInitially, to verify content is not attached when the flag
+// is off. Inherits the HTTPS server and cert verifier setup.
+class AIChatUIPageHandlerPageContextDisabledBrowserTest
+    : public AIChatUIPageHandlerBrowserTest {
+ public:
+  AIChatUIPageHandlerPageContextDisabledBrowserTest() {
+    scoped_feature_list_.InitAndDisableFeature(
+        ai_chat::features::kPageContextEnabledInitially);
+  }
+
+  // Creates a handler whose active_chat_tab_helper_ is set to |context|, which
+  // puts BindRelatedConversation into its content-associated else branch.
+  std::unique_ptr<AIChatUIPageHandler> CreateHandlerForContents(
+      content::WebContents* context) {
+    mojo::PendingReceiver<mojom::AIChatUIHandler> receiver;
+    return std::make_unique<AIChatUIPageHandler>(
+        context, context,
+        Profile::FromBrowserContext(context->GetBrowserContext()),
+        std::move(receiver), browser()->tab_strip_model());
+  }
+
+ private:
+  base::test::ScopedFeatureList scoped_feature_list_;
+};
+
+IN_PROC_BROWSER_TEST_F(
+    AIChatUIPageHandlerPageContextDisabledBrowserTest,
+    BindRelatedConversation_DoesNotAddContentWhenFlagDisabled) {
+  // OpenNewTab navigates to an HTTPS URL, so CanAssociateContent would normally
+  // pass — the flag check is the only thing preventing content from attaching.
+  OpenNewTab();
+  auto* tab_contents = web_contents();
+  ASSERT_TRUE(tab_contents);
+
+  auto handler = CreateHandlerForContents(tab_contents);
+
+  FakeConversationUI fake_conversation_ui;
+  mojo::Receiver<mojom::ConversationUI> conversation_ui_receiver(
+      &fake_conversation_ui);
+  mojo::Remote<mojom::ConversationHandler> conversation;
+  handler->BindRelatedConversation(
+      conversation.BindNewPipeAndPassReceiver(),
+      conversation_ui_receiver.BindNewPipeAndPassRemote());
+
+  base::test::TestFuture<std::vector<mojom::AssociatedContentPtr>>
+      content_future;
+  conversation->GetAssociatedContentInfo(content_future.GetCallback());
+  EXPECT_TRUE(content_future.Take().empty())
+      << "BindRelatedConversation should not add page content when "
+         "kPageContextEnabledInitially is disabled";
+}
+
 #endif  // !BUILDFLAG(IS_ANDROID)
 
 }  // namespace ai_chat


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Series https://github.com/brave/brave-browser/issues/53533

Follow up to the above

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
