### PR TITLE
bump security alerts

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -17,7 +17,7 @@ deps = {
   },
   "vendor/bat-native-tweetnacl": "https://github.com/brave-intl/bat-native-tweetnacl.git@8b424ccf29957fe01c88c36076fd32006a357887",
   "vendor/gn-project-generators": "https://github.com/brave/gn-project-generators.git@b76e14b162aa0ce40f11920ec94bfc12da29e5d0",
-  "vendor/web-discovery-project": "https://github.com/brave/web-discovery-project@0b060c7e6a5f3a92d865c1ef958a575e3679df1f",
+  "vendor/web-discovery-project": "https://github.com/brave/web-discovery-project@ecc4f97d816329731c2eb4db2e0aba624efa475f",
   "third_party/bip39wally-core-native": "https://github.com/brave-intl/bat-native-bip39wally-core.git@547a7810333d821e29b8f55126aba031aa0d5fcd",
   "third_party/ethash/src": "https://github.com/chfast/ethash.git@e4a15c3d76dc09392c7efd3e30d84ee3b871e9ce",
   "third_party/bitcoin-core/src": "https://github.com/bitcoin/bitcoin.git@8105bce5b384c72cf08b25b7c5343622754e7337", # v25.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@brave/brave-ui": "0.40.6",
-        "@brave/leo": "github:brave/leo#c60b65212d7342d89596964170373a056a9a3cbd",
+        "@brave/leo": "github:brave/leo#eae4be033e636b8699a2459caa8b00bed1970b7f",
         "@brave/leo-sf-symbols": "github:brave/leo-sf-symbols#10e967f89a7a5d70fb03b820b13be03421eb53d3",
         "@brave/wallet-standard-brave": "0.0.16",
         "@dnd-kit/core": "6.0.5",
@@ -752,8 +752,8 @@
     },
     "node_modules/@brave/leo": {
       "version": "0.0.1",
-      "resolved": "git+ssh://git@github.com/brave/leo.git#c60b65212d7342d89596964170373a056a9a3cbd",
-      "integrity": "sha512-jrYDVRt4uv7IKGQ/bzbqLCeAJAS9NuScWTg9j1+pK7gNIKkDCXflXTlXov6lnHI5j0XvwPkHwYzxMtpROfjHMw==",
+      "resolved": "git+ssh://git@github.com/brave/leo.git#eae4be033e636b8699a2459caa8b00bed1970b7f",
+      "integrity": "sha512-cYH8M3pQN3VfcvaRmMAx+RlYDwUogVqXc8A+dwZv1LQgoLXOF4grjjGynWGZcHu/Bs22HUxykihLNklWNZ82wQ==",
       "license": "MIT",
       "dependencies": {
         "@storybook/test": "8.6.14",
@@ -4895,19 +4895,6 @@
       },
       "peerDependencies": {
         "storybook": "^8.6.14"
-      }
-    },
-    "node_modules/@storybook/addon-actions/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@storybook/addon-backgrounds": {
@@ -22643,11 +22630,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/package.json
+++ b/package.json
@@ -201,7 +201,7 @@
   },
   "dependencies": {
     "@brave/brave-ui": "0.40.6",
-    "@brave/leo": "github:brave/leo#c60b65212d7342d89596964170373a056a9a3cbd",
+    "@brave/leo": "github:brave/leo#eae4be033e636b8699a2459caa8b00bed1970b7f",
     "@brave/leo-sf-symbols": "github:brave/leo-sf-symbols#10e967f89a7a5d70fb03b820b13be03421eb53d3",
     "@brave/wallet-standard-brave": "0.0.16",
     "@dnd-kit/core": "6.0.5",
@@ -253,6 +253,7 @@
     "tiny-secp256k1": "1.1.7",
     "flatted": "3.4.2",
     "yaml@1": "1.10.3",
-    "yaml@2": "2.8.3"
+    "yaml@2": "2.8.3",
+    "uuid": "14.0.0"
   }
 }


### PR DESCRIPTION
closes https://github.com/brave/brave-browser/issues/54871
closes https://github.com/brave/brave-browser/issues/54872
closes https://github.com/brave/brave-browser/issues/54873
closes https://github.com/brave/brave-browser/issues/54874
closes https://github.com/brave/brave-browser/issues/54875

Leo changes: https://github.com/brave/leo/pull/1375/changes/0f4366293d3ae29cc9bd0985d7af285fa716a139

WDP commits below split in 2 PRs

UUID update: https://github.com/brave/web-discovery-project/commit/6b6eb0b0bbb4a99a71d4491131b5f601b565d69b
xmldom update: https://github.com/brave/web-discovery-project/commit/487bb82086ddc2fb8c04fa6d642760ed11c2a4a7
