### PR TITLE
[VPN 2.0] Add WinTun 3p dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ patches/**/*.patchinfo
 /third_party/macholib
 /third_party/libdmg-hfsplus/
 /third_party/opengrep/bin/
+/third_party/wintun/
 *.xcodeproj
 !/ios/brave-ios/App/*.xcodeproj
 *.swp

--- a/DEPS
+++ b/DEPS
@@ -129,6 +129,14 @@ hooks = [
                '//brave/third_party/brave-vpn-wireguard-tunnel-dlls'],
   },
   {
+    'name': 'download_wintun',
+    'pattern': '.',
+    'condition': 'checkout_win',
+    'action': ['vpython3', 'build/win/download_wintun.py',
+               'wintun/wintun-0.14.1.zip', '//brave/third_party/wintun',
+               '07c256185d6ee3652e09fa55c0b673e2624b565e02c4b9091c79ca7d2f24ef51'],
+  },
+  {
     # Install Web Discovery Project dependencies for Windows, Linux, and macOS
     'name': 'web_discovery_project_npm_deps',
     'pattern': '.',

--- a/build/download_dep.py
+++ b/build/download_dep.py
@@ -17,9 +17,9 @@ def main():
     args = parse_args()
     dep_url = DEPS_PACKAGES_URL + '/' + args.dep_path
     dest_dir = wspath(args.dest_dir)
-    if dep_url != get_url(dest_dir):
-        deps.DownloadAndUnpack(dep_url, dest_dir, args.path_prefix)
-        set_url(dest_dir, dep_url)
+    deps.DownloadIfChanged(
+        dep_url, dest_dir,
+        lambda: deps.DownloadAndUnpack(dep_url, dest_dir, args.path_prefix))
 
 
 def parse_args():
@@ -28,19 +28,6 @@ def parse_args():
     parser.add_argument('dest_dir')
     parser.add_argument('path_prefix', nargs='?', default=None)
     return parser.parse_args()
-
-
-def get_url(dest_dir):
-    try:
-        with open(join(dest_dir, '.url')) as f:
-            return f.read()
-    except FileNotFoundError:
-        return None
-
-
-def set_url(dest_dir, value):
-    with open(join(dest_dir, '.url'), 'w') as f:
-        f.write(value)
 
 
 if __name__ == '__main__':

--- a/build/download_dep.py
+++ b/build/download_dep.py
@@ -17,9 +17,7 @@ def main():
     args = parse_args()
     dep_url = DEPS_PACKAGES_URL + '/' + args.dep_path
     dest_dir = wspath(args.dest_dir)
-    deps.DownloadIfChanged(
-        dep_url, dest_dir,
-        lambda: deps.DownloadAndUnpack(dep_url, dest_dir, args.path_prefix))
+    deps.DownloadIfChanged(dep_url, dest_dir, args.path_prefix)
 
 
 def parse_args():

--- a/build/win/download_wintun.py
+++ b/build/win/download_wintun.py
@@ -1,0 +1,148 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""
+Downloads and stages the Wintun prebuilt binaries for Brave VPN on Windows.
+
+Invoked from DEPS as a hook on Windows checkouts. Downloads the archive from
+DEPS_PACKAGES_URL, verifies its SHA-256, replaces the destination directory
+with a fresh extraction, and writes a README.chromium so the binaries show up
+in brave://credits.
+"""
+
+from argparse import ArgumentParser
+from brave_chromium_utils import wspath
+from deps_config import DEPS_PACKAGES_URL
+from lib.util import extract_zip
+from os.path import basename, exists, join
+
+import hashlib
+import os
+import shutil
+import tempfile
+
+import deps
+
+README_TEMPLATE = """Name: WinTun
+Version: {version}
+URL: {url}
+Update Mechanism: Manual
+License: Prebuilt Binaries License
+License File: /brave/third_party/wintun/LICENSE.txt
+Security Critical: yes
+Shipped: yes
+
+Description:
+Wintun is a Layer 3 TUN driver for Windows, used by the Brave VPN WireGuard
+service. The signed wintun.dll is shipped unmodified from upstream; only the
+Permitted API (wintun.h) is used at compile time.
+
+Local Modifications:
+No modifications.
+"""
+
+
+def main():
+    args = parse_args()
+    dep_url = DEPS_PACKAGES_URL + '/' + args.dep_path
+    dest_dir = wspath(args.dest_dir)
+    deps.DownloadIfChanged(
+        dep_url, dest_dir,
+        lambda: fetch_and_stage(args.dep_path, args.sha256, dep_url, dest_dir))
+
+
+def parse_args():
+    parser = ArgumentParser(
+        description='Download and stage the Wintun prebuilt binaries.')
+    parser.add_argument('dep_path')
+    parser.add_argument('dest_dir')
+    parser.add_argument('sha256')
+    return parser.parse_args()
+
+
+def verify_sha256(path, expected, url):
+    with open(path, 'rb') as f:
+        actual = hashlib.file_digest(f, 'sha256').hexdigest()
+    if actual.lower() != expected.lower():
+        raise ValueError(f'SHA-256 mismatch for {url}\n'
+                         f'  expected: {expected.lower()}\n'
+                         f'  actual:   {actual}')
+
+
+def parse_version(filename):
+    # wintun-0.14.1.zip -> 0.14.1
+    prefix, suffix = 'wintun-', '.zip'
+    if not filename.startswith(prefix) or not filename.endswith(suffix):
+        raise ValueError(
+            f'Could not parse version from filename: {filename!r}. '
+            f'Expected the form "wintun-<version>.zip".')
+    return filename[len(prefix):-len(suffix)]
+
+
+def write_readme(dest_dir, version, url):
+    with open(join(dest_dir, 'README.chromium'),
+              'w',
+              encoding='utf-8',
+              newline='\n') as f:
+        f.write(README_TEMPLATE.format(version=version, url=url))
+
+
+def fetch_and_stage(dep_path, dep_sha256, dep_url, dest_dir):
+    filename = basename(dep_path)
+
+    # Download to a temporary file. delete=False so we can close the
+    # handle (required on Windows) and re-open it for hashing/extraction.
+    with tempfile.NamedTemporaryFile(suffix='.zip', delete=False) as tmp:
+        tmp_path = tmp.name
+        deps.DownloadUrl(dep_url, tmp)
+
+    try:
+        # Verify the archive matches the SHA pinned in DEPS.
+        verify_sha256(tmp_path, dep_sha256, dep_url)
+
+        # Wipe the destination so stale files from a previous version
+        # can never linger.
+        if exists(dest_dir):
+            shutil.rmtree(dest_dir)
+        deps.EnsureDirExists(dest_dir)
+
+        # The archive nests everything under a top-level 'wintun/' folder.
+        # Extract to a scratch dir, then lift the inner contents up so
+        # callers reference '//brave/third_party/wintun/...' directly.
+        with tempfile.TemporaryDirectory() as scratch:
+            extract_zip(tmp_path, scratch)
+            inner = join(scratch, 'wintun')
+            if not exists(inner):
+                raise ValueError(
+                    f'Expected a top-level "wintun/" directory in '
+                    f'{filename}, but it was missing.')
+            for entry in os.listdir(inner):
+                shutil.move(join(inner, entry), join(dest_dir, entry))
+    finally:
+        # Always remove the temp zip, even if verification or extraction
+        # raised.
+        os.unlink(tmp_path)
+
+    # Rename amd64 -> x64 so on-disk paths match GN's target_cpu values
+    # and BUILD.gn can use sources = [ "bin/$target_cpu/wintun.dll" ].
+    amd64_dir = join(dest_dir, 'bin', 'amd64')
+    x64_dir = join(dest_dir, 'bin', 'x64')
+    if exists(amd64_dir):
+        os.rename(amd64_dir, x64_dir)
+
+    # Sanity-check the license file the README points at, then write the
+    # README. A missing license file would break tools/licenses.py.
+    if not exists(join(dest_dir, 'LICENSE.txt')):
+        raise ValueError(
+            f'LICENSE.txt not found in {dest_dir} after extraction. '
+            f'README.chromium references it, so the credits build would '
+            f'fail.')
+
+    write_readme(
+        dest_dir, parse_version(filename),
+        'https://www.wintun.net/builds/{filename}'.format(filename=filename))
+
+
+if __name__ == '__main__':
+    main()

--- a/build/win/download_wintun.py
+++ b/build/win/download_wintun.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env vpython3
+
 # Copyright (c) 2026 The Brave Authors. All rights reserved.
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
@@ -14,13 +16,10 @@ in brave://credits.
 from argparse import ArgumentParser
 from brave_chromium_utils import wspath
 from deps_config import DEPS_PACKAGES_URL
-from lib.util import extract_zip
 from os.path import basename, exists, join
 
-import hashlib
 import os
 import shutil
-import tempfile
 
 import deps
 
@@ -39,7 +38,7 @@ service. The signed wintun.dll is shipped unmodified from upstream; only the
 Permitted API (wintun.h) is used at compile time.
 
 Local Modifications:
-No modifications.
+None.
 """
 
 
@@ -47,9 +46,10 @@ def main():
     args = parse_args()
     dep_url = DEPS_PACKAGES_URL + '/' + args.dep_path
     dest_dir = wspath(args.dest_dir)
-    deps.DownloadIfChanged(
-        dep_url, dest_dir,
-        lambda: fetch_and_stage(args.dep_path, args.sha256, dep_url, dest_dir))
+    deps.DownloadIfChanged(dep_url,
+                           dest_dir,
+                           sha256=args.sha256,
+                           download_fn=fetch_and_stage)
 
 
 def parse_args():
@@ -59,15 +59,6 @@ def parse_args():
     parser.add_argument('dest_dir')
     parser.add_argument('sha256')
     return parser.parse_args()
-
-
-def verify_sha256(path, expected, url):
-    with open(path, 'rb') as f:
-        actual = hashlib.file_digest(f, 'sha256').hexdigest()
-    if actual.lower() != expected.lower():
-        raise ValueError(f'SHA-256 mismatch for {url}\n'
-                         f'  expected: {expected.lower()}\n'
-                         f'  actual:   {actual}')
 
 
 def parse_version(filename):
@@ -88,41 +79,21 @@ def write_readme(dest_dir, version, url):
         f.write(README_TEMPLATE.format(version=version, url=url))
 
 
-def fetch_and_stage(dep_path, dep_sha256, dep_url, dest_dir):
-    filename = basename(dep_path)
+def fetch_and_stage(dep_url, dest_dir, sha256):
+    deps.DownloadAndUnpack(dep_url, dest_dir, sha256=sha256)
+    filename = basename(dep_url)
 
-    # Download to a temporary file. delete=False so we can close the
-    # handle (required on Windows) and re-open it for hashing/extraction.
-    with tempfile.NamedTemporaryFile(suffix='.zip', delete=False) as tmp:
-        tmp_path = tmp.name
-        deps.DownloadUrl(dep_url, tmp)
-
-    try:
-        # Verify the archive matches the SHA pinned in DEPS.
-        verify_sha256(tmp_path, dep_sha256, dep_url)
-
-        # Wipe the destination so stale files from a previous version
-        # can never linger.
-        if exists(dest_dir):
-            shutil.rmtree(dest_dir)
-        deps.EnsureDirExists(dest_dir)
-
-        # The archive nests everything under a top-level 'wintun/' folder.
-        # Extract to a scratch dir, then lift the inner contents up so
-        # callers reference '//brave/third_party/wintun/...' directly.
-        with tempfile.TemporaryDirectory() as scratch:
-            extract_zip(tmp_path, scratch)
-            inner = join(scratch, 'wintun')
-            if not exists(inner):
-                raise ValueError(
-                    f'Expected a top-level "wintun/" directory in '
-                    f'{filename}, but it was missing.')
-            for entry in os.listdir(inner):
-                shutil.move(join(inner, entry), join(dest_dir, entry))
-    finally:
-        # Always remove the temp zip, even if verification or extraction
-        # raised.
-        os.unlink(tmp_path)
+    # The archive nests everything under a top-level 'wintun/' folder.
+    # Extract to a scratch dir, then lift the inner contents up so
+    # callers reference '//brave/third_party/wintun/...' directly.
+    inner = join(dest_dir, 'wintun')
+    if not exists(inner):
+        raise ValueError(f'Expected a top-level "wintun/" directory in '
+                         f'{filename}, but it was missing.')
+    for entry in os.listdir(inner):
+        shutil.move(join(inner, entry), join(dest_dir, entry))
+    # The inner directory must be empty by now; rmdir asserts that.
+    os.rmdir(inner)
 
     # Rename amd64 -> x64 so on-disk paths match GN's target_cpu values
     # and BUILD.gn can use sources = [ "bin/$target_cpu/wintun.dll" ].
@@ -139,9 +110,8 @@ def fetch_and_stage(dep_path, dep_sha256, dep_url, dest_dir):
             f'README.chromium references it, so the credits build would '
             f'fail.')
 
-    write_readme(
-        dest_dir, parse_version(filename),
-        'https://www.wintun.net/builds/{filename}'.format(filename=filename))
+    write_readme(dest_dir, parse_version(filename),
+                 f'https://www.wintun.net/builds/{filename}')
 
 
 if __name__ == '__main__':

--- a/script/brave_license_helper.py
+++ b/script/brave_license_helper.py
@@ -180,6 +180,11 @@ def AddBraveCredits(root, prune_paths, special_cases, prune_dirs,
         # plaster .toml file location should be skipped.
         os.path.join('brave', 'rewrite', 'third_party'),
 
+        # TODO(https://github.com/brave/brave-browser/issues/54804)
+        # remove the following line once we start putting
+        # WinTun binaries into the browser distribution on Windows.
+        os.path.join('brave', 'third_party', 'wintun'),
+
         # Transitive deps in brave/third_party/wasm.
         *GetRustWorkspaceTransitiveDeps(Path('brave/third_party/wasm')),
     ])

--- a/script/deps.py
+++ b/script/deps.py
@@ -57,7 +57,7 @@ def DownloadUrl(url, output_file):
             sys.stdout.write('\n')
             print(e)
             if num_retries == 0 or isinstance(
-                    e, HTTPError) and e.code in [403, 404]:  # pylint: disable=no-member,line-too-long
+                    e, HTTPError) and e.code in [403, 404]:  # pylint: disable=line-too-long,no-member
                 raise e
             num_retries -= 1
             print("Retrying in {} s ...".format(retry_wait_s))
@@ -97,3 +97,19 @@ def DownloadAndUnpack(url, output_dir, path_prefix=None):
                     t.extractall(path=output_dir, members=members)
         finally:
             os.unlink(tmp_file.name)
+
+
+def DownloadIfChanged(url, dest_dir, download_fn):
+    """Run download_fn() only if dest_dir isn't already recorded as
+    containing a download from url. On success, records url in a
+    '.url' file inside dest_dir so subsequent calls can skip."""
+    url_file = os.path.join(dest_dir, '.url')
+    try:
+        with open(url_file) as f:
+            if f.read() == url:
+                return
+    except FileNotFoundError:
+        pass
+    download_fn()
+    with open(url_file, 'w') as f:
+        f.write(url)

--- a/script/deps.py
+++ b/script/deps.py
@@ -6,6 +6,7 @@
 
 """This script is used to download deps."""
 
+import hashlib
 import os
 import shutil
 import sys
@@ -70,7 +71,16 @@ def EnsureDirExists(path):
         os.makedirs(path)
 
 
-def DownloadAndUnpack(url, output_dir, path_prefix=None):
+def VerifySHA256(path, expected, url):
+    with open(path, 'rb') as f:
+        actual = hashlib.file_digest(f, 'sha256').hexdigest()
+    if actual.lower() != expected.lower():
+        raise ValueError(f'SHA-256 mismatch for {url}\n'
+                         f'  expected: {expected.lower()}\n'
+                         f'  actual:   {actual}')
+
+
+def DownloadAndUnpack(url, output_dir, path_prefix=None, sha256=None):
     """Download an archive from url and extract into output_dir. If path_prefix
        is not None, only extract files whose paths within the archive start
        with path_prefix."""
@@ -78,6 +88,8 @@ def DownloadAndUnpack(url, output_dir, path_prefix=None):
         try:
             DownloadUrl(url, tmp_file)
             tmp_file.close()
+            if sha256:
+                VerifySHA256(tmp_file.name, sha256, url)
             try:
                 os.unlink(output_dir)
             except OSError:
@@ -99,7 +111,11 @@ def DownloadAndUnpack(url, output_dir, path_prefix=None):
             os.unlink(tmp_file.name)
 
 
-def DownloadIfChanged(url, dest_dir, download_fn):
+def DownloadIfChanged(url,
+                      dest_dir,
+                      *args,
+                      download_fn=DownloadAndUnpack,
+                      **kwargs):
     """Run download_fn() only if dest_dir isn't already recorded as
     containing a download from url. On success, records url in a
     '.url' file inside dest_dir so subsequent calls can skip."""
@@ -110,6 +126,6 @@ def DownloadIfChanged(url, dest_dir, download_fn):
                 return
     except FileNotFoundError:
         pass
-    download_fn()
-    with open(url_file, 'w') as f:
+    download_fn(url, dest_dir, *args, **kwargs)
+    with open(url_file, 'w', newline='\n') as f:
         f.write(url)


### PR DESCRIPTION
Add WinTun dependency to the brave-core, to be used later in the VPN 2.0 architecture by a privileged helper on desktop OSes, on Windows only.
Since it's a prebuilt binary dependency, we don't add it as an existing build dependency, as we don't have to build it.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/54589

Design spec signed off: [link](https://docs.google.com/document/d/1X6EWWqrFGeSXUBXW9mn0o5bsFyeOzZvmuMTcWdvJ_dc/edit?tab=t.0#heading=h.le3o6s1n5d9i)
Security and privacy review complete: [link](https://github.com/brave/reviews/issues/2207)

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
