### PR TITLE
Adblock intermittent test failures

### DIFF
--- a/browser/brave_shields/ad_block_browser_test_helper.cc
+++ b/browser/brave_shields/ad_block_browser_test_helper.cc
@@ -5,6 +5,7 @@
 
 #include "brave/browser/brave_shields/ad_block_browser_test_helper.h"
 
+#include <memory>
 #include <utility>
 
 #include "base/functional/bind.h"
@@ -14,6 +15,7 @@
 #include "brave/browser/brave_browser_process.h"
 #include "brave/components/brave_shields/content/browser/ad_block_service.h"
 #include "brave/components/brave_shields/content/test/ad_block_unit_test_helper.h"
+#include "brave/components/brave_shields/content/test/engine_test_observer.h"
 #include "components/keyed_service/content/browser_context_dependency_manager.h"
 
 namespace brave_shields {
@@ -36,8 +38,25 @@ AdBlockBrowserTestHelper::AdBlockBrowserTestHelper(
 
 AdBlockBrowserTestHelper::~AdBlockBrowserTestHelper() = default;
 
+void AdBlockBrowserTestHelper::WaitForAdBlockEngineInitialLoad() {
+  if (initial_engine_observer_) {
+    initial_engine_observer_->Wait();
+    initial_engine_observer_.reset();
+  }
+}
+
 void AdBlockBrowserTestHelper::SetUpAdBlockService(
     content::BrowserContext* context) {
+  if (!initial_engine_observer_) {
+    // Attach before SetupAdBlockServiceForTesting posts SetFilterListCatalog({})
+    // so the observer is guaranteed to catch the resulting OnEngineUpdated.
+    // Tests that want to wait on the initial build call
+    // WaitForAdBlockEngineInitialLoad() before registering any
+    // TestFiltersProvider; other tests simply ignore it.
+    initial_engine_observer_ = std::make_unique<EngineTestObserver>(
+        &g_brave_browser_process->ad_block_service()
+             ->GetDefaultEngineForTesting());
+  }
   SetupAdBlockServiceForTesting(g_brave_browser_process->ad_block_service());
   callback_.Run();
 }

--- a/browser/brave_shields/ad_block_browser_test_helper.cc
+++ b/browser/brave_shields/ad_block_browser_test_helper.cc
@@ -48,10 +48,10 @@ void AdBlockBrowserTestHelper::WaitForAdBlockEngineInitialLoad() {
 void AdBlockBrowserTestHelper::SetUpAdBlockService(
     content::BrowserContext* context) {
   if (!initial_engine_observer_) {
-    // Attach before SetupAdBlockServiceForTesting posts SetFilterListCatalog({})
-    // so the observer is guaranteed to catch the resulting OnEngineUpdated.
-    // Tests that want to wait on the initial build call
-    // WaitForAdBlockEngineInitialLoad() before registering any
+    // Attach before SetupAdBlockServiceForTesting posts
+    // SetFilterListCatalog({}) so the observer is guaranteed to catch the
+    // resulting OnEngineUpdated. Tests that want to wait on the initial build
+    // call WaitForAdBlockEngineInitialLoad() before registering any
     // TestFiltersProvider; other tests simply ignore it.
     initial_engine_observer_ = std::make_unique<EngineTestObserver>(
         &g_brave_browser_process->ad_block_service()

--- a/browser/brave_shields/ad_block_browser_test_helper.h
+++ b/browser/brave_shields/ad_block_browser_test_helper.h
@@ -6,9 +6,13 @@
 #ifndef BRAVE_BROWSER_BRAVE_SHIELDS_AD_BLOCK_BROWSER_TEST_HELPER_H_
 #define BRAVE_BROWSER_BRAVE_SHIELDS_AD_BLOCK_BROWSER_TEST_HELPER_H_
 
+#include <memory>
+
 #include "base/callback_list.h"
 #include "base/functional/callback_forward.h"
 #include "base/functional/callback_helpers.h"
+
+class EngineTestObserver;
 
 namespace content {
 class BrowserContext;
@@ -31,10 +35,21 @@ class AdBlockBrowserTestHelper {
   AdBlockBrowserTestHelper& operator=(const AdBlockBrowserTestHelper&) = delete;
   ~AdBlockBrowserTestHelper();
 
+  // Blocks until the initial empty-catalog engine update fires. Idempotent —
+  // calling more than once is a no-op. Call this before registering any
+  // TestFiltersProvider so the subsequent EngineTestObserver only wakes for
+  // the rule load (not for a stale initial update).
+  //
+  // NOT safe with the DAT cache feature enabled — a cached DAT load may
+  // suppress the initial filter set build, making this wait hang. DAT cache
+  // tests should skip calling it.
+  void WaitForAdBlockEngineInitialLoad();
+
  private:
   void SetUpAdBlockService(content::BrowserContext* context);
 
   base::RepeatingClosure callback_;
+  std::unique_ptr<EngineTestObserver> initial_engine_observer_;
   base::CallbackListSubscription create_services_subscription_;
 };
 

--- a/browser/debounce/debounce_browsertest.cc
+++ b/browser/debounce/debounce_browsertest.cc
@@ -6,7 +6,6 @@
 #include <memory>
 
 #include "base/base64url.h"
-#include "base/functional/bind.h"
 #include "base/memory/raw_ptr.h"
 #include "base/scoped_observation.h"
 #include "base/test/scoped_feature_list.h"
@@ -119,15 +118,7 @@ class DebounceBrowserTest : public BaseLocalDataFilesBrowserTest {
   void SetUpInProcessBrowserTestFixture() override {
     BaseLocalDataFilesBrowserTest::SetUpInProcessBrowserTestFixture();
     ad_block_test_helper_ =
-        std::make_unique<brave_shields::AdBlockBrowserTestHelper>(
-            base::BindRepeating(&DebounceBrowserTest::OnAdBlockServiceCreated,
-                                base::Unretained(this)));
-  }
-
-  void OnAdBlockServiceCreated() {
-    initial_engine_observer_ = std::make_unique<EngineTestObserver>(
-        &g_brave_browser_process->ad_block_service()
-             ->GetDefaultEngineForTesting());
+        std::make_unique<brave_shields::AdBlockBrowserTestHelper>();
   }
 
   // BaseLocalDataFilesBrowserTest overrides
@@ -196,9 +187,7 @@ class DebounceBrowserTest : public BaseLocalDataFilesBrowserTest {
   void InitAdBlockForDebounce() {
     // Drain the initial empty-catalog engine update first so the observer
     // below can only wake on the rule-load update (not a stale one).
-    ASSERT_TRUE(initial_engine_observer_);
-    initial_engine_observer_->Wait();
-    initial_engine_observer_.reset();
+    ad_block_test_helper_->WaitForAdBlockEngineInitialLoad();
 
     auto source_provider =
         std::make_unique<brave_shields::TestFiltersProvider>("||blocked.com^");
@@ -222,7 +211,6 @@ class DebounceBrowserTest : public BaseLocalDataFilesBrowserTest {
       source_providers_;
   std::unique_ptr<brave_shields::AdBlockBrowserTestHelper>
       ad_block_test_helper_;
-  std::unique_ptr<EngineTestObserver> initial_engine_observer_;
 };
 
 // Test simple redirection by query parameter.

--- a/browser/ephemeral_storage/ephemeral_storage_1p_domain_block_browsertest.cc
+++ b/browser/ephemeral_storage/ephemeral_storage_1p_domain_block_browsertest.cc
@@ -52,6 +52,7 @@ class EphemeralStorage1pDomainBlockBrowserTest
   }
 
   void UpdateAdBlockInstanceWithRules(const std::string& rules) {
+    helper_->WaitForAdBlockEngineInitialLoad();
     source_provider_ =
         std::make_unique<brave_shields::TestFiltersProvider>(rules);
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Fixes intermittent adblock related test failures due to a race condition with adblock startup before attaching observers

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
