### PR TITLE
[AI Chat] Remove Conversation API v2 flag entry from brave://flags

### DIFF
--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -630,13 +630,6 @@ constexpr flags_ui::FeatureEntry::Choice kVerticalTabCollapseDelayChoices[] = {
           FEATURE_VALUE_TYPE(ai_chat::features::kPageContextEnabledInitially), \
       },                                                                       \
       {                                                                        \
-          "brave-ai-chat-conversation-api-v2",                                 \
-          "Brave AI Chat Conversation API V2",                                 \
-          "Enables Conversation API V2 for AI Chat",                           \
-          kOsAll,                                                              \
-          FEATURE_VALUE_TYPE(ai_chat::features::kAIChatConversationAPIV2),     \
-      },                                                                       \
-      {                                                                        \
           "brave-ai-chat-show-input-on-new-tab-page",                          \
           "Show AI Chat input on the New Tab Page",                            \
           "Show a Brave AI chat input on the New Tab Page.",                   \


### PR DESCRIPTION
Conversation API v2 is currently enabled 100% on all channels and stable, remove the entry from UI first in preparation for future feature flag retirement.
This PR just removes the entry from UI which was added for easier internal testing, feature flag is still intact and can be used to control the feature switch via griffin or command line.

Resolves https://github.com/brave/brave-browser/issues/54905