### PR TITLE
[iOS] Replace legacy NTP urls during tab restoration

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/TabManager.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/TabManager.swift
@@ -1354,7 +1354,11 @@ class TabManager: NSObject {
 
     var tabToSelect: (any TabState)?
     for savedTab in savedTabs {
-      if let tabURL = savedTab.url {
+      if var tabURL = savedTab.url {
+        // Replace any old NTP tab urls with the updated one
+        if InternalURL.isValid(url: tabURL) && tabURL.path.contains("about/home") {
+          tabURL = Self.ntpInteralURL
+        }
         // Provide an empty request to prevent a new tab from loading the home screen
         let request =
           InternalURL.isValid(url: tabURL)


### PR DESCRIPTION
This fixes a regression where upgrading with new tab pages opened would load to invalid `internal` urls since the NTP url changed to `about://newtab` to match Chromium

Resolves https://github.com/brave/brave-browser/issues/54904
