### PR TITLE
[ads] Fixes NTT component is not updated after variation seed country change

### DIFF
--- a/chromium_src/components/variations/service/variations_service.cc
+++ b/chromium_src/components/variations/service/variations_service.cc
@@ -5,12 +5,12 @@
 
 #include "net/http/http_response_headers.h"
 
-// At browser startup, the country code is updated using the X-Country header
-// from the response if the status is `HTTP_NOT_MODIFIED`, avoiding the need
-// to wait for the next update, which happens every 5 hours.
+// Update the country code from the X-Country header on every 304 Not Modified
+// response so that mid-session country changes (e.g. a VPN change) propagate
+// without requiring a browser restart.
 #define GetDateValue(...)                                               \
   GetDateValue(__VA_ARGS__);                                            \
-  if (response_code == net::HTTP_NOT_MODIFIED && is_first_request) {    \
+  if (response_code == net::HTTP_NOT_MODIFIED) {                        \
     std::string_view country_code =                                     \
         GetHeaderValue(headers.get(), "X-Country");                     \
     if (!country_code.empty()) {                                        \

--- a/chromium_src/components/variations/service/variations_service_unittest.cc
+++ b/chromium_src/components/variations/service/variations_service_unittest.cc
@@ -32,7 +32,7 @@ TEST_F(VariationsServiceTest,
 }
 
 TEST_F(VariationsServiceTest,
-       DoNotSetVariationsCountryWithNotModifiedResponseOnSubsequentFetch) {
+       SetVariationsCountryWithNotModifiedResponseOnSubsequentFetch) {
   VariationsService::EnableFetchForTesting();
 
   TestVariationsService service(
@@ -66,7 +66,7 @@ TEST_F(VariationsServiceTest,
 
   service.DoActualFetch();
 
-  EXPECT_EQ(prefs_.GetString(prefs::kVariationsCountry), "FOO");
+  EXPECT_EQ(prefs_.GetString(prefs::kVariationsCountry), "BAR");
 }
 
 TEST_F(VariationsServiceTest,


### PR DESCRIPTION
The country code from the variations seed was only written to prefs on
the first seed fetch of a session. Subsequent 304 Not Modified responses
carrying a new X-Country header were silently ignored, so country-keyed
components such as the NTT and ads resource components would not update
when the user's location changed mid-session via VPN. The fix writes the
country code on every 304 response that carries a non-empty X-Country
header. This does not affect Chromium field trial membership, which is
evaluated once at startup from the stored seed.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/47909

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
