### PR TITLE
Let review-prs skill come back after approval when re-requested

### DIFF
--- a/.claude/skills/review-prs/fetch-prs.py
+++ b/.claude/skills/review-prs/fetch-prs.py
@@ -191,6 +191,11 @@ def load_cache():
         return {}
 
 
+def save_cache(cache):
+    with open(CACHE_PATH, "w") as f:
+        json.dump(cache, f, indent=2)
+
+
 def load_org_members():
     """Load Brave org member logins from the cached file."""
     if not os.path.isfile(ORG_MEMBERS_PATH):
@@ -247,6 +252,7 @@ def filter_prs(prs, mode, days, cache, org_members, reviewer_priority=None):
     skipped_approved = 0
     skipped_external = 0
     skipped_uplift = 0
+    cache_dirty = False
 
     for pr in prs:
         if pr.get("isDraft"):
@@ -285,18 +291,25 @@ def filter_prs(prs, mode, days, cache, org_members, reviewer_priority=None):
                     continue
 
         pr_num = str(pr["number"])
+        head_sha = pr.get("headRefOid", "")
 
-        # Bot previously approved this PR — don't come back
-        # UNLESS the bot has been explicitly re-requested as a reviewer
+        # Bot previously approved this PR — don't come back UNLESS the bot
+        # has been explicitly re-requested as a reviewer AND new commits have
+        # landed since the prior review. In that case the prior approval is
+        # stale and must be cleared so the bot can re-approve if appropriate.
         if pr_num in approved:
-            if reviewer_priority and is_requested_reviewer(
-                    pr, reviewer_priority):
-                pass  # Explicit re-review request after approval
+            is_rerequest_on_new_sha = (reviewer_priority
+                                       and is_requested_reviewer(
+                                           pr, reviewer_priority)
+                                       and cache.get(pr_num) != head_sha)
+            if is_rerequest_on_new_sha:
+                approved.discard(pr_num)
+                cache["_approved"] = sorted(approved)
+                cache_dirty = True
             else:
                 skipped_approved += 1
                 continue
 
-        head_sha = pr.get("headRefOid", "")
         if cache.get(pr_num) == head_sha:
             # If the bot is a requested reviewer, force a full re-review
             # even if the SHA hasn't changed (explicit re-request)
@@ -309,6 +322,9 @@ def filter_prs(prs, mode, days, cache, org_members, reviewer_priority=None):
                 continue
 
         to_review.append(pr)
+
+    if cache_dirty:
+        save_cache(cache)
 
     return (
         to_review,

--- a/.claude/skills/review-prs/fetch-prs.py
+++ b/.claude/skills/review-prs/fetch-prs.py
@@ -287,9 +287,14 @@ def filter_prs(prs, mode, days, cache, org_members, reviewer_priority=None):
         pr_num = str(pr["number"])
 
         # Bot previously approved this PR — don't come back
+        # UNLESS the bot has been explicitly re-requested as a reviewer
         if pr_num in approved:
-            skipped_approved += 1
-            continue
+            if reviewer_priority and is_requested_reviewer(
+                    pr, reviewer_priority):
+                pass  # Explicit re-review request after approval
+            else:
+                skipped_approved += 1
+                continue
 
         head_sha = pr.get("headRefOid", "")
         if cache.get(pr_num) == head_sha:


### PR DESCRIPTION
## Summary
- Once the review-prs skill approved a PR, the PR number was added to `_approved` in the local cache and `fetch-prs.py` permanently skipped it — even after new commits and an explicit re-request of the bot as a reviewer. This caused e.g. #35089 to never get re-reviewed after the initial approval.
- First commit lets an approved PR fall through when the bot is in `reviewRequests`, mirroring the existing reviewer-priority escape hatch used for the SHA-cache check below it.
- Second commit clears the stale `_approved` entry when the override fires on a *new* SHA, so `check-can-approve.py` (which also gates on the local `_approved` set) no longer blocks a fresh approval. Adds a `save_cache` helper and `cache_dirty` tracking so the clear persists.

Same-SHA re-requests still go to `skipped_approved` — nothing new to review, and re-approving the exact same commit would be a duplicate.

## Test plan
- [x] Run `/review-prs #35089 open auto reviewer-priority` — bot should now pick up the PR instead of skipping as `skipped_approved`.
- [x] Confirm on a clean re-review that a fresh APPROVE is submitted at the new SHA and `_approved` is re-populated in the cache.
- [x] Confirm that re-requesting the bot on a same-SHA approved PR still skips (no duplicate approval).