### PR TITLE
[ads][CodeHealth] Replace non-invariant CHECKs with graceful failure paths

### DIFF
--- a/components/brave_ads/core/internal/account/statement/next_payment_date_util.cc
+++ b/components/brave_ads/core/internal/account/statement/next_payment_date_util.cc
@@ -5,15 +5,25 @@
 
 #include "brave/components/brave_ads/core/internal/account/statement/next_payment_date_util.h"
 
-#include "base/check.h"
+#include <optional>
+
 #include "base/time/time.h"
 #include "brave/components/brave_ads/core/internal/account/statement/statement_feature.h"
 #include "brave/components/brave_ads/core/internal/account/transactions/reconciled_transactions_util.h"
 
 namespace brave_ads {
 
-base::Time CalculateNextPaymentDate(base::Time next_payment_token_redemption_at,
-                                    const TransactionList& transactions) {
+namespace {
+
+constexpr int kMonthAfterNext = 2;
+constexpr int kMonthsPerYear = 12;
+constexpr int kEndOfDayHour = 23;
+
+}  // namespace
+
+std::optional<base::Time> MaybeCalculateNextPaymentDate(
+    base::Time next_payment_token_redemption_at,
+    const TransactionList& transactions) {
   const base::Time now = base::Time::Now();
 
   base::Time::Exploded now_exploded;
@@ -51,15 +61,15 @@ base::Time CalculateNextPaymentDate(base::Time next_payment_token_redemption_at,
         // If this month does not have reconciled transactions and our next
         // token redemption date is next month, then the next payment date will
         // occur the month after next
-        month += 2;
+        month += kMonthAfterNext;
       }
     }
   }
 
   int year = now_exploded.year;
 
-  if (month > 12) {
-    month -= 12;
+  if (month > kMonthsPerYear) {
+    month -= kMonthsPerYear;
     ++year;
   }
 
@@ -67,14 +77,16 @@ base::Time CalculateNextPaymentDate(base::Time next_payment_token_redemption_at,
   next_payment_date_exploded.year = year;
   next_payment_date_exploded.month = month;
   next_payment_date_exploded.day_of_month = kNextPaymentDay.Get();
-  next_payment_date_exploded.hour = 23;
+  next_payment_date_exploded.hour = kEndOfDayHour;
   next_payment_date_exploded.minute = 59;
   next_payment_date_exploded.second = 59;
   next_payment_date_exploded.millisecond = 999;
 
   base::Time next_payment_date;
-  CHECK(base::Time::FromUTCExploded(next_payment_date_exploded,
-                                    &next_payment_date));
+  if (!base::Time::FromUTCExploded(next_payment_date_exploded,
+                                   &next_payment_date)) {
+    return std::nullopt;
+  }
 
   return next_payment_date;
 }

--- a/components/brave_ads/core/internal/account/statement/next_payment_date_util.h
+++ b/components/brave_ads/core/internal/account/statement/next_payment_date_util.h
@@ -6,16 +6,16 @@
 #ifndef BRAVE_COMPONENTS_BRAVE_ADS_CORE_INTERNAL_ACCOUNT_STATEMENT_NEXT_PAYMENT_DATE_UTIL_H_
 #define BRAVE_COMPONENTS_BRAVE_ADS_CORE_INTERNAL_ACCOUNT_STATEMENT_NEXT_PAYMENT_DATE_UTIL_H_
 
-#include "brave/components/brave_ads/core/internal/account/transactions/transaction_info.h"
+#include <optional>
 
-namespace base {
-class Time;
-}  // namespace base
+#include "base/time/time.h"
+#include "brave/components/brave_ads/core/internal/account/transactions/transaction_info.h"
 
 namespace brave_ads {
 
-base::Time CalculateNextPaymentDate(base::Time next_payment_token_redemption_at,
-                                    const TransactionList& transactions);
+std::optional<base::Time> MaybeCalculateNextPaymentDate(
+    base::Time next_payment_token_redemption_at,
+    const TransactionList& transactions);
 
 }  // namespace brave_ads
 

--- a/components/brave_ads/core/internal/account/statement/next_payment_date_util_unittest.cc
+++ b/components/brave_ads/core/internal/account/statement/next_payment_date_util_unittest.cc
@@ -5,6 +5,8 @@
 
 #include "brave/components/brave_ads/core/internal/account/statement/next_payment_date_util.h"
 
+#include <optional>
+
 #include "base/test/scoped_feature_list.h"
 #include "brave/components/brave_ads/core/internal/account/statement/statement_feature.h"
 #include "brave/components/brave_ads/core/internal/account/transactions/test/transactions_test_util.h"
@@ -47,12 +49,14 @@ TEST_F(BraveAdsNextPaymentDateUtilTest,
       test::TimeFromUTCString("5 February 2020");
 
   // Act
-  const base::Time next_payment_date =
-      CalculateNextPaymentDate(next_payment_token_redemption_at, transactions);
+  const std::optional<base::Time> next_payment_date =
+      MaybeCalculateNextPaymentDate(next_payment_token_redemption_at,
+                                    transactions);
 
   // Assert
+  ASSERT_TRUE(next_payment_date);
   EXPECT_EQ(test::TimeFromUTCString("5 February 2020 23:59:59.999"),
-            next_payment_date);
+            *next_payment_date);
 }
 
 TEST_F(BraveAdsNextPaymentDateUtilTest,
@@ -64,12 +68,14 @@ TEST_F(BraveAdsNextPaymentDateUtilTest,
       test::TimeFromUTCString("5 February 2020");
 
   // Act
-  const base::Time next_payment_date = CalculateNextPaymentDate(
-      next_payment_token_redemption_at, /*transactions=*/{});
+  const std::optional<base::Time> next_payment_date =
+      MaybeCalculateNextPaymentDate(next_payment_token_redemption_at,
+                                    /*transactions=*/{});
 
   // Assert
+  ASSERT_TRUE(next_payment_date);
   EXPECT_EQ(test::TimeFromUTCString("5 March 2020 23:59:59.999"),
-            next_payment_date);
+            *next_payment_date);
 }
 
 TEST_F(BraveAdsNextPaymentDateUtilTest,
@@ -88,12 +94,14 @@ TEST_F(BraveAdsNextPaymentDateUtilTest,
       test::TimeFromUTCString("5 February 2020");
 
   // Act
-  const base::Time next_payment_date =
-      CalculateNextPaymentDate(next_payment_token_redemption_at, transactions);
+  const std::optional<base::Time> next_payment_date =
+      MaybeCalculateNextPaymentDate(next_payment_token_redemption_at,
+                                    transactions);
 
   // Act & Assert
+  ASSERT_TRUE(next_payment_date);
   EXPECT_EQ(test::TimeFromUTCString("5 February 2020 23:59:59.999"),
-            next_payment_date);
+            *next_payment_date);
 }
 
 TEST_F(
@@ -106,12 +114,14 @@ TEST_F(
       test::TimeFromUTCString("31 January 2020");
 
   // Act
-  const base::Time next_payment_date = CalculateNextPaymentDate(
-      next_payment_token_redemption_at, /*transactions=*/{});
+  const std::optional<base::Time> next_payment_date =
+      MaybeCalculateNextPaymentDate(next_payment_token_redemption_at,
+                                    /*transactions=*/{});
 
   // Assert
+  ASSERT_TRUE(next_payment_date);
   EXPECT_EQ(test::TimeFromUTCString("5 February 2020 23:59:59.999"),
-            next_payment_date);
+            *next_payment_date);
 }
 
 TEST_F(
@@ -124,12 +134,38 @@ TEST_F(
       test::TimeFromUTCString("5 February 2020");
 
   // Act
-  const base::Time next_payment_date = CalculateNextPaymentDate(
-      next_payment_token_redemption_at, /*transactions=*/{});
+  const std::optional<base::Time> next_payment_date =
+      MaybeCalculateNextPaymentDate(next_payment_token_redemption_at,
+                                    /*transactions=*/{});
 
   // Assert
+  ASSERT_TRUE(next_payment_date);
   EXPECT_EQ(test::TimeFromUTCString("5 March 2020 23:59:59.999"),
-            next_payment_date);
+            *next_payment_date);
+}
+
+TEST_F(BraveAdsNextPaymentDateUtilTest,
+       DoesNotCalculateNextPaymentDateWhenPaymentDayIsInvalidForMonth) {
+  // Arrange
+  base::test::ScopedFeatureList scoped_feature_list;
+  scoped_feature_list.InitAndEnableFeatureWithParameters(
+      kAccountStatementFeature, {{"next_payment_day", "31"}});
+
+  // Today (March 1) is on or before payment day 31, and there are no
+  // reconciled transactions from last month, so the next payment is scheduled
+  // for April. April has no 31st day, so the date is uncalculable.
+  AdvanceClockTo(test::TimeFromUTCString("1 March 2020"));
+
+  const base::Time next_payment_token_redemption_at =
+      test::TimeFromUTCString("5 March 2020");
+
+  // Act
+  const std::optional<base::Time> next_payment_date =
+      MaybeCalculateNextPaymentDate(next_payment_token_redemption_at,
+                                    /*transactions=*/{});
+
+  // Assert
+  EXPECT_FALSE(next_payment_date);
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/account/statement/statement.cc
+++ b/components/brave_ads/core/internal/account/statement/statement.cc
@@ -5,6 +5,7 @@
 
 #include "brave/components/brave_ads/core/internal/account/statement/statement.h"
 
+#include <optional>
 #include <utility>
 
 #include "base/functional/bind.h"
@@ -45,7 +46,7 @@ void BuildStatement(BuildStatementCallback callback) {
             mojom_statement->max_earnings_this_month = max_earnings_this_month;
 
             mojom_statement->next_payment_date =
-                GetNextPaymentDate(transactions);
+                MaybeGetNextPaymentDate(transactions).value_or(base::Time{});
 
             mojom_statement->ads_received_this_month =
                 GetAdsReceivedThisMonth(transactions);

--- a/components/brave_ads/core/internal/account/statement/statement_util.cc
+++ b/components/brave_ads/core/internal/account/statement/statement_util.cc
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 #include <iterator>
+#include <optional>
 
 #include "base/time/time.h"
 #include "brave/components/brave_ads/core/internal/account/statement/ads_received_util.h"
@@ -36,14 +37,13 @@ TransactionList FilterTransactionsForEstimatedEarnings(
 
 }  // namespace
 
-base::Time GetNextPaymentDate(const TransactionList& transactions) {
+std::optional<base::Time> MaybeGetNextPaymentDate(
+    const TransactionList& transactions) {
   const base::Time next_payment_token_redemption_at =
       GetProfileTimePref(prefs::kNextPaymentTokenRedemptionAt);
 
-  const base::Time next_payment_date =
-      CalculateNextPaymentDate(next_payment_token_redemption_at, transactions);
-
-  return next_payment_date;
+  return MaybeCalculateNextPaymentDate(next_payment_token_redemption_at,
+                                       transactions);
 }
 
 std::pair<double, double> GetEstimatedEarningsForThisMonth(

--- a/components/brave_ads/core/internal/account/statement/statement_util.h
+++ b/components/brave_ads/core/internal/account/statement/statement_util.h
@@ -7,19 +7,18 @@
 #define BRAVE_COMPONENTS_BRAVE_ADS_CORE_INTERNAL_ACCOUNT_STATEMENT_STATEMENT_UTIL_H_
 
 #include <cstdint>
+#include <optional>
 #include <utility>
 
 #include "base/containers/flat_map.h"
+#include "base/time/time.h"
 #include "brave/components/brave_ads/core/internal/account/transactions/transaction_info.h"
 #include "brave/components/brave_ads/core/mojom/brave_ads.mojom-forward.h"
 
-namespace base {
-class Time;
-}  // namespace base
-
 namespace brave_ads {
 
-base::Time GetNextPaymentDate(const TransactionList& transactions);
+std::optional<base::Time> MaybeGetNextPaymentDate(
+    const TransactionList& transactions);
 
 std::pair</*range_low*/ double, /*range_high*/ double>
 GetEstimatedEarningsForThisMonth(const TransactionList& transactions);

--- a/components/brave_ads/core/internal/account/statement/statement_util_unittest.cc
+++ b/components/brave_ads/core/internal/account/statement/statement_util_unittest.cc
@@ -5,6 +5,8 @@
 
 #include "brave/components/brave_ads/core/internal/account/statement/statement_util.h"
 
+#include <optional>
+
 #include "brave/components/brave_ads/core/internal/account/statement/statement_feature.h"
 #include "brave/components/brave_ads/core/internal/account/transactions/test/transactions_test_util.h"
 #include "brave/components/brave_ads/core/internal/account/transactions/transaction_info.h"
@@ -20,7 +22,7 @@ namespace brave_ads {
 
 class BraveAdsStatementUtilTest : public test::TestBase {};
 
-TEST_F(BraveAdsStatementUtilTest, GetNextPaymentDate) {
+TEST_F(BraveAdsStatementUtilTest, MaybeGetNextPaymentDate) {
   // Arrange
   AdvanceClockTo(test::TimeFromUTCString("31 January 2020"));
 
@@ -30,11 +32,13 @@ TEST_F(BraveAdsStatementUtilTest, GetNextPaymentDate) {
                                 next_payment_token_redemption_at);
 
   // Act
-  const base::Time next_payment_date = GetNextPaymentDate(/*transactions=*/{});
+  const std::optional<base::Time> next_payment_date =
+      MaybeGetNextPaymentDate(/*transactions=*/{});
 
   // Assert
+  ASSERT_TRUE(next_payment_date);
   EXPECT_EQ(test::TimeFromUTCString("7 March 2020 23:59:59.999"),
-            next_payment_date);
+            *next_payment_date);
 }
 
 TEST_F(BraveAdsStatementUtilTest, GetEstimatedEarningsForThisMonth) {

--- a/components/brave_ads/core/internal/deprecated/client/client_info.cc
+++ b/components/brave_ads/core/internal/deprecated/client/client_info.cc
@@ -128,7 +128,10 @@ bool ClientInfo::FromDict(const base::DictValue& dict) {
           page_score = *page_score_value;
         } else if (const auto* const legacy_page_score_value =
                        dict.FindString("pageScore")) {
-          CHECK(base::StringToDouble(*legacy_page_score_value, &page_score));
+          if (!base::StringToDouble(*legacy_page_score_value, &page_score)) {
+            BLOG(0, "Failed to parse legacy pageScore from client state");
+            return false;
+          }
         }
 
         probabilities.insert({*segment, page_score});

--- a/components/brave_ads/core/internal/deprecated/client/client_state_manager.cc
+++ b/components/brave_ads/core/internal/deprecated/client/client_state_manager.cc
@@ -111,23 +111,23 @@ void ClientStateManager::SaveState() {
 
 void ClientStateManager::LoadCallback(ResultCallback callback,
                                       const std::optional<std::string>& json) {
+  CHECK(!is_initialized_);
+  is_initialized_ = true;
+
   if (!json) {
     BLOG(3, "Client state does not exist, creating default state");
 
-    is_initialized_ = true;
+    client_ = {};
+
+    SaveState();
+  } else if (!FromJson(*json)) {
+    BLOG(0, "Failed to parse client state, resetting to default state");
+
     client_ = {};
 
     SaveState();
   } else {
-    if (!FromJson(*json)) {
-      BLOG(0, "Failed to parse client state: " << *json);
-
-      return std::move(callback).Run(/*success=*/false);
-    }
-
     BLOG(3, "Successfully loaded client state");
-
-    is_initialized_ = true;
   }
 
   std::move(callback).Run(/*success=*/true);


### PR DESCRIPTION
Replaces CHECK calls that guard against legitimately possible runtime
failures rather than true invariants. The next payment date calculation
now returns std::optional and propagates nullopt when the calendar date
is invalid. Legacy client state parsing now logs and resets to defaults
on failure rather than crashing. The client state manager resets to
defaults and continues instead of aborting when JSON is malformed.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
