### PR TITLE
[iOS] Re-add legacy NTP internal scheme handler (uplift to 1.89.x)

### DIFF
--- a/ios/brave-ios/App/iOS/Delegates/AppState.swift
+++ b/ios/brave-ios/App/iOS/Delegates/AppState.swift
@@ -202,6 +202,7 @@ public class AppState {
 
   private func setupCustomSchemeHandlers() {
     let responders: [(String, InternalSchemeResponse)] = [
+      (LegacyNTPHandler.path, LegacyNTPHandler()),
       (ReaderModeHandler.path, ReaderModeHandler()),
       (Web3DomainHandler.path, Web3DomainHandler()),
       (BlockedDomainHandler.path, BlockedDomainHandler()),

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Handlers/LegacyNTPHandler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Handlers/LegacyNTPHandler.swift
@@ -1,0 +1,16 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Foundation
+
+/// A scheme handler to deal with the old NTP urls while users migrate away from them
+public class LegacyNTPHandler: InternalSchemeResponse {
+  public static let path = "about/home"
+  public func response(forRequest request: URLRequest) async -> (URLResponse, Data)? {
+    guard let url = request.url else { return nil }
+    return (InternalSchemeHandler.response(forUrl: url), Data())
+  }
+  public init() {}
+}

--- a/ios/brave-ios/Sources/BraveShared/Extensions/URLExtensions.swift
+++ b/ios/brave-ios/Sources/BraveShared/Extensions/URLExtensions.swift
@@ -25,6 +25,10 @@ extension URL {
   }
 
   public var isNewTabURL: Bool {
+    // For now also include the prior legacy URL in the check
+    if InternalURL.isValid(url: self) && path.contains("about/home") {
+      return true
+    }
     return scheme == "about" && host == "newtab"
   }
 


### PR DESCRIPTION
Uplift of #35844
Resolves https://github.com/brave/brave-browser/issues/54904

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.