### PR TITLE
[iOS] Adds `result<>` support to `ios_objc_mojom_wrappers`

### DIFF
--- a/build/ios/mojom/mojom_objc_generator.py
+++ b/build/ios/mojom/mojom_objc_generator.py
@@ -452,7 +452,9 @@ class Generator(generator.Generator):
             "objc_method_name_formatter": self._ObjCMethodNameFormatter,
             "objc_enum_formatter": self._ObjCEnumFormatter,
             "objc_argument_modifiers": self._GetObjCArgumentModifiers,
-            "cpp_to_objc_assign": self._CppToObjCAssign,
+            "cpp_result_callback_type": self._CppResultCallbackType,
+            "cpp_to_objc_assign": self._CppToObjCAssignFromField,
+            "cpp_to_objc_assign_kind": self._CppToObjCAssignFromKind,
             "const_objc_assign": self._ConstObjCAssign,
             "objc_to_cpp_assign": self._ObjCToCppAssign,
             "expected_cpp_param_type": self._GetExpectedCppParamType,
@@ -599,10 +601,36 @@ class Generator(generator.Generator):
                 cpp_assign = "%s ? %s : nullptr" % (accessor, cpp_assign)
         return cpp_assign
 
-    def _CppToObjCAssign(self, field, prefix=None, suffix=None):
-        kind = field.kind
-        accessor = "%s%s%s" % (prefix if prefix else "",
-                               field.name, (suffix if suffix else ""))
+    def _CppResultCallbackType(self, method):
+        # A `result<S, F>` callback is represented as two nullable
+        # Obj-C object pointer parameters, exactly one of which is nil.
+        # Since `_Nullable` only applies to Obj-C object pointer types,
+        # both arms must map to object pointers.
+        success_kind = method.result_response.success_kind
+        failure_kind = method.result_response.failure_kind
+
+        for kind in (success_kind, failure_kind):
+            if not (mojom.IsObjectKind(kind)
+                    or mojom.IsPendingRemoteKind(kind)):
+                raise Exception(
+                    f"result<S, F> callback for {method.name} contains a kind "
+                    "that does not map to an Obj-C object pointer!")
+
+        success = MojoTypemapForKind(success_kind, False).ExpectedCppType()
+        failure = MojoTypemapForKind(failure_kind, False).ExpectedCppType()
+
+        return f"base::expected<{success}, {failure}>"
+
+    def _CppToObjCAssignFromField(self, field, prefix=None, suffix=None):
+        return self._CppToObjCAssignImpl(
+            kind=field.kind,
+            accessor=f"{prefix or ''}{field.name}{suffix or ''}",
+        )
+
+    def _CppToObjCAssignFromKind(self, kind, accessor):
+        return self._CppToObjCAssignImpl(kind=kind, accessor=accessor)
+
+    def _CppToObjCAssignImpl(self, *, kind, accessor):
         typemap = MojoTypemapForKind(kind)
         if mojom.IsNullableKind(kind):
             if ((self._IsTypemappedKind(kind)

--- a/build/ios/mojom/objc_templates/interface_macros.tmpl
+++ b/build/ios/mojom/objc_templates/interface_macros.tmpl
@@ -1,3 +1,18 @@
+{%- macro result_or_response_callback_type(method) -%}
+{%- if method.result_response -%}
+({{method.result_response.success_kind|objc_wrapper_type}} _Nullable success, {{method.result_response.failure_kind|objc_wrapper_type}} _Nullable failure)
+{%- else -%}
+(
+{%- for param in method.response_parameters -%}
+{%-   set nullable = param.kind|objc_argument_modifiers(inside_callback=True) -%}
+{%-   set type = "%s%s"|format(param.kind|objc_wrapper_type, " " + nullable if nullable) -%}
+{{type}} {{param.name|under_to_lower_camel}}
+{%- if not loop.last -%},{{" "}}{%- endif -%}
+{%- endfor -%}
+)
+{%- endif -%}
+{%- endmacro -%}
+
 {%- macro objc_method(method) -%}
 {%-   set name = method|objc_method_name_formatter %}
 - (void){{name}}
@@ -13,14 +28,7 @@
 {%- if method.parameters -%}
 {{" "}}completion:
 {%- endif -%}
-(void (^)(
-{%- for param in method.response_parameters -%}
-{%-   set nullable = param.kind|objc_argument_modifiers(inside_callback=True) -%}
-{%-   set type = "%s%s"|format(param.kind|objc_wrapper_type, " " + nullable if nullable) -%}
-{{type}} {{param.name|under_to_lower_camel}}
-{%- if not loop.last -%},{{" "}}{%- endif -%}
-{%- endfor -%}
-))completion
+(void (^){{ result_or_response_callback_type(method) }})completion
 {%- endif -%}
 {%- if method.parameters or method.response_parameters -%}
 {%- set swift_name = "initialize" if name == "init" else name -%}

--- a/build/ios/mojom/objc_templates/module.mm.tmpl
+++ b/build/ios/mojom/objc_templates/module.mm.tmpl
@@ -10,6 +10,7 @@
 #include "base/task/sequenced_task_runner.h"
 #include "base/threading/sequence_bound.h"
 #include "base/time/time.h"
+#include "base/types/expected.h"
 #include "ios/web/public/thread/web_task_traits.h"
 #include "ios/web/public/thread/web_thread.h"
 #include "mojo/public/cpp/bindings/pending_remote.h"

--- a/build/ios/mojom/objc_templates/private_interface_implementation.tmpl
+++ b/build/ios/mojom/objc_templates/private_interface_implementation.tmpl
@@ -1,3 +1,4 @@
+{%- from "interface_macros.tmpl" import result_or_response_callback_type -%}
 {%- macro objc_methods_impls(interface) -%}
 {%  for method in interface.methods %}
 {%-   set name = method|objc_method_name_formatter %}
@@ -12,16 +13,18 @@
 {%- endfor -%}
 {%- if method.response_parameters -%}
 {%- if method.parameters %} completion:{% endif -%}
-(void (^)(
-{%- for param in method.response_parameters -%}
-{%-   set nullable = param.kind|objc_argument_modifiers(inside_callback=True) -%}
-{%-   set type = "%s%s"|format(param.kind|objc_wrapper_type, " " + nullable if nullable) -%}
-{{type}} {{param.name|under_to_lower_camel}}
-{%- if not loop.last -%},{{" "}}{%- endif -%}
-{%- endfor -%}
-))completion
+(void (^){{ result_or_response_callback_type(method) }})completion
 {%- endif %} {
 {%- if method.response_parameters %}
+{%- if method.result_response %}
+  auto callback = ^({{method|cpp_result_callback_type}} result) {
+    if (result.has_value()) {
+      completion({{method.result_response.success_kind|cpp_to_objc_assign_kind("result.value()")}}, nil);
+    } else {
+      completion(nil, {{method.result_response.failure_kind|cpp_to_objc_assign_kind("result.error()")}});
+    }
+  };
+{%- else %}
   auto callback = ^(
 {%- for param in method.response_parameters -%}
 {{param.kind|expected_cpp_param_type}} {{param.name}}_arg
@@ -35,6 +38,7 @@
 {%- endfor -%}
     );
   };
+{%- endif %}
 {%- endif %}
   web::GetUIThreadTaskRunner({})->PostTask(FROM_HERE, base::BindOnce(^{
     self->_wrappedValue->{{method.name}}(

--- a/build/ios/mojom/objc_templates/test_interface_declaration.tmpl
+++ b/build/ios/mojom/objc_templates/test_interface_declaration.tmpl
@@ -1,3 +1,4 @@
+{%- from "interface_macros.tmpl" import result_or_response_callback_type %}
 
 OBJC_EXPORT
 NS_SWIFT_NAME({{class_prefix}}.Test{{interface.name}})
@@ -13,14 +14,7 @@ NS_SWIFT_NAME({{class_prefix}}.Test{{interface.name}})
 {%-   endfor -%}
 {%-   if method.response_parameters -%}
 {%-   if method.parameters -%},{{" "}}{%- endif -%}
-void (^completion)(
-{%- for param in method.response_parameters -%}
-{%-   set nullable = param.kind|objc_argument_modifiers(inside_callback=True) -%}
-{%-   set type = "%s%s"|format(param.kind|objc_wrapper_type, " " + nullable if nullable) -%}
-{{type}} {{param.name|under_to_lower_camel}}
-{%- if not loop.last -%},{{" "}}{%- endif -%}
-{%- endfor -%}
-)
+void (^completion){{ result_or_response_callback_type(method) }}
 {%- endif -%}
 );
 {%- endfor %}


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/54916.

Adds support for Mojom's `result<S, F>` response syntax to `ios_objc_mojom_wrappers`.

Until now, the Obj-C generator only handled the older `=> (...)` response-parameter form. Interfaces using `=> result<S, F>` caused wrapper generation to fail.

With this change, generated methods expose `result<S, F>` as a two-argument completion block
```objc
(S* _Nullable success, F* _Nullable failure)
```
where exactly one argument is non-`nil`.

Example:
```mojom
interface Authentication {
  ...
  // Resends the confirmation email to the user during the registration process.
  // Returns `ResendConfirmationEmailResult` on success, or
  //         `ResendConfirmationEmailError` on failure.
  ResendConfirmationEmail()
    => result<ResendConfirmationEmailResult, ResendConfirmationEmailError>;
  ...
};
```
The generator now produces:
- `brave_account.mojom.objc.h`:
```objc
OBJC_EXPORT
NS_SWIFT_SENDABLE
@protocol BraveAccountAuthentication
@required
...
- (void)resendConfirmationEmail:(void (^)(BraveAccountResendConfirmationEmailResult* _Nullable success, BraveAccountResendConfirmationEmailError* _Nullable failure))completion NS_SWIFT_NAME(resendConfirmationEmail(completion:));
...
@end
```
- `brave_account.mojom.objc+private.h`:
```objc
@interface BraveAccountAuthenticationMojoImpl : NSObject <BraveAccountAuthentication>
- (void)resendConfirmationEmail:(void (^)(BraveAccountResendConfirmationEmailResult* _Nullable success, BraveAccountResendConfirmationEmailError* _Nullable failure))completion NS_SWIFT_NAME(resendConfirmationEmail(completion:));
@end
```
- `brave_account.mojom.objc.mm`:
```objc
...
- (void)resendConfirmationEmail:(void (^)(BraveAccountResendConfirmationEmailResult* _Nullable success, BraveAccountResendConfirmationEmailError* _Nullable failure))completion {
  auto callback = ^(base::expected<brave_account::mojom::ResendConfirmationEmailResultPtr, brave_account::mojom::ResendConfirmationEmailErrorPtr> result) {
    if (result.has_value()) {
      completion([[BraveAccountResendConfirmationEmailResult alloc] initWithResendConfirmationEmailResult:*result.value()], nil);
    } else {
      completion(nil, [[BraveAccountResendConfirmationEmailError alloc] initWithResendConfirmationEmailError:*result.error()]);
    }
  };
  web::GetUIThreadTaskRunner({})->PostTask(FROM_HERE, base::BindOnce(^{
    self->_wrappedValue->ResendConfirmationEmail(base::BindOnce(callback));
  }));
}
...
```

Swift callers get
```swift
resendConfirmationEmail { success, failure in ... }
```
with nullable success/failure. 

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
