### PR TITLE
Fix Playlist showing downloaded indicator for missing cached items

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Playlist/Debug/PlaylistDebugFilesView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Playlist/Debug/PlaylistDebugFilesView.swift
@@ -1,0 +1,177 @@
+// Copyright 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import SwiftUI
+
+struct PlaylistDebugFilesView: View {
+  @Environment(\.dismiss) private var dismiss
+  @State private var files: [URL] = []
+  @State private var errorMessage: String?
+  @State private var deleteError: String?
+  @State private var shouldDeleteAll = false
+  var body: some View {
+    NavigationStack {
+      Group {
+        if let errorMessage {
+          ContentUnavailableView(
+            "Couldn't load files",
+            systemImage: "exclamationmark.triangle",
+            description: Text(errorMessage)
+          )
+        } else if files.isEmpty {
+          ContentUnavailableView(
+            "No files",
+            systemImage: "tray",
+            description: Text("The Playlist folder is empty.")
+          )
+        } else {
+          List {
+            ForEach(files, id: \.self) { url in
+              HStack {
+                Image(systemName: "doc")
+                VStack(alignment: .leading) {
+                  Text(url.lastPathComponent)
+                  if let size = fileSize(url) {
+                    Text(size)
+                      .font(.caption)
+                      .foregroundStyle(.secondary)
+                  }
+                }
+              }
+              .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+                Button(role: .destructive) {
+                  delete(url)
+                } label: {
+                  Label("Delete", systemImage: "trash")
+                }
+              }
+            }
+            .onDelete(perform: deleteAt)
+          }
+        }
+      }
+      .navigationTitle("Playlist File")
+      .toolbar {
+        ToolbarItem(placement: .cancellationAction) {
+          Button("Done") { dismiss() }
+        }
+        ToolbarItem(placement: .primaryAction) {
+          Button {
+            loadFiles()
+          } label: {
+            Image(systemName: "arrow.clockwise")
+          }
+        }
+
+        ToolbarItem(placement: .bottomBar) {
+          Spacer()
+        }
+        ToolbarItem(placement: .bottomBar) {
+          Button {
+            shouldDeleteAll = true
+          } label: {
+            Label("Delete All", systemImage: "trash")
+              .foregroundStyle(Color(braveSystemName: .systemfeedbackErrorIcon))
+          }
+          .confirmationDialog(
+            "Delete all files?",
+            isPresented: $shouldDeleteAll,
+            titleVisibility: .visible
+          ) {
+            Button("Delete \(files.count) File\(files.count == 1 ? "" : "s")", role: .destructive) {
+              deleteAll()
+            }
+            Button("Cancel", role: .cancel) {}
+          } message: {
+            Text(
+              "This will permanently remove every file in the Playlist folder. This action cannot be undone."
+            )
+          }
+        }
+      }
+      .onAppear(perform: loadFiles)
+    }
+  }
+
+  private func loadFiles() {
+    do {
+      let fm = FileManager.default
+      let appSupport = try fm.url(
+        for: .applicationSupportDirectory,
+        in: .userDomainMask,
+        appropriateFor: nil,
+        create: true
+      )
+      let playlistURL = appSupport.appendingPathComponent("Playlist", isDirectory: true)
+
+      if !fm.fileExists(atPath: playlistURL.path) {
+        try fm.createDirectory(at: playlistURL, withIntermediateDirectories: true)
+      }
+
+      let contents = try fm.contentsOfDirectory(
+        at: playlistURL,
+        includingPropertiesForKeys: [.isRegularFileKey, .fileSizeKey],
+        options: [.skipsHiddenFiles]
+      )
+
+      files = contents.sorted {
+        $0.lastPathComponent.localizedCompare($1.lastPathComponent) == .orderedAscending
+      }
+      errorMessage = nil
+    } catch {
+      errorMessage = error.localizedDescription
+      files = []
+    }
+  }
+
+  private func fileSize(_ url: URL) -> String? {
+    guard let size = try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize else { return nil }
+    return ByteCountFormatter.string(fromByteCount: Int64(size), countStyle: .file)
+  }
+
+  private func delete(_ url: URL) {
+    do {
+      try FileManager.default.removeItem(at: url)
+      files.removeAll { $0 == url }
+    } catch {
+      deleteError = error.localizedDescription
+    }
+  }
+
+  private func deleteAt(_ offsets: IndexSet) {
+    for index in offsets {
+      let url = files[index]
+      do {
+        try FileManager.default.removeItem(at: url)
+      } catch {
+        deleteError = error.localizedDescription
+        return
+      }
+    }
+    files.remove(atOffsets: offsets)
+  }
+
+  private func deleteAll() {
+    do {
+      let fm = FileManager.default
+      let appSupport = try fm.url(
+        for: .applicationSupportDirectory,
+        in: .userDomainMask,
+        appropriateFor: nil,
+        create: false
+      )
+      let playlistURL = appSupport.appendingPathComponent("Playlist", isDirectory: true)
+      try fm.removeItem(at: playlistURL)
+      try fm.createDirectory(at: playlistURL, withIntermediateDirectories: true)
+      files = []
+    } catch {
+      deleteError = error.localizedDescription
+    }
+  }
+}
+
+#Preview {
+  PlaylistDebugFilesView()
+}

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Playlist/Debug/PlaylistDebugFilesView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Playlist/Debug/PlaylistDebugFilesView.swift
@@ -52,7 +52,8 @@ struct PlaylistDebugFilesView: View {
           }
         }
       }
-      .navigationTitle("Playlist File")
+      .navigationTitle("Playlist Files")
+      .navigationBarTitleDisplayMode(.inline)
       .toolbar {
         ToolbarItem(placement: .cancellationAction) {
           Button("Done") { dismiss() }
@@ -92,6 +93,18 @@ struct PlaylistDebugFilesView: View {
         }
       }
       .onAppear(perform: loadFiles)
+      .alert(
+        "Couldn't delete file",
+        isPresented: Binding(
+          get: { deleteError != nil },
+          set: { if !$0 { deleteError = nil } }
+        ),
+        presenting: deleteError
+      ) { _ in
+        Button("OK", role: .cancel) {}
+      } message: { message in
+        Text(message)
+      }
     }
   }
 
@@ -172,6 +185,8 @@ struct PlaylistDebugFilesView: View {
   }
 }
 
+#if DEBUG
 #Preview {
   PlaylistDebugFilesView()
 }
+#endif

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Playlist/Debug/PlaylistDebugView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Playlist/Debug/PlaylistDebugView.swift
@@ -25,6 +25,9 @@ struct PlaylistDebugView: View {
   @State
   private var isDeletingCaches = false
 
+  @State
+  private var isShowingPlaylistFiles = false
+
   private var formatter: NumberFormatter {
     return NumberFormatter().then {
       $0.numberStyle = .decimal
@@ -198,6 +201,24 @@ struct PlaylistDebugView: View {
         }
       }
       .disabled(isGenerating || isDeletingItems || isDeletingCaches)
+
+      Button {
+        isShowingPlaylistFiles = true
+      } label: {
+        Text("Manage Playlist Files")
+          .foregroundStyle(Color(braveSystemName: .tertiary5))
+          .padding()
+          .background(
+            ContainerRelativeShape()
+              .fill(Color(braveSystemName: .iconInteractive))
+              .shadow(color: Color.black.opacity(0.25), radius: 8.0, x: 0.0, y: 1.0)
+          )
+          .containerShape(RoundedRectangle(cornerRadius: 8.0, style: .continuous))
+      }
+      .padding(.top, 60)
+      .sheet(isPresented: $isShowingPlaylistFiles) {
+        PlaylistDebugFilesView()
+      }
     }
     .padding()
   }

--- a/ios/brave-ios/Sources/Playlist/PlaylistManager.swift
+++ b/ios/brave-ios/Sources/Playlist/PlaylistManager.swift
@@ -259,10 +259,10 @@ public class PlaylistManager: NSObject {
       return .inProgress
     }
 
-    if let assetUrl = await downloadManager.localAsset(for: itemId)?.url {
-      if await AsyncFileManager.default.fileExists(atPath: assetUrl.path) {
-        return .downloaded
-      }
+    if let assetUrl = await downloadManager.localAsset(for: itemId)?.url,
+      await AsyncFileManager.default.fileExists(atPath: assetUrl.path)
+    {
+      return .downloaded
     }
 
     return .invalid
@@ -596,40 +596,67 @@ public class PlaylistManager: NSObject {
   }
 
   @MainActor private func deleteDanglingManagedAssets() async {
-    if let playlistFolderPath = await PlaylistDownloadManager.playlistDirectory {
-      let items = PlaylistItem.all().compactMap(\.cachedData)
-      Task.detached {
-        let cachedURLs = items.compactMap { cachedData in
-          var isStale: Bool = false
-          if let url = try? URL(resolvingBookmarkData: cachedData, bookmarkDataIsStale: &isStale) {
-            return url
+    guard let playlistFolderPath = await PlaylistDownloadManager.playlistDirectory else {
+      return
+    }
+
+    // Snapshot every item's bookmark on the main actor so the resolution work below can run off the main actor without touching CoreData.
+    let cachedItems: [(itemId: String, cachedData: Data)] = PlaylistItem.all().compactMap { item in
+      guard let itemId = item.uuid, let cachedData = item.cachedData, !cachedData.isEmpty else {
+        return nil
+      }
+      return (itemId, cachedData)
+    }
+
+    let (validCachedPaths, staleItemIDs): (Set<String>, [String]) =
+      await Task.detached {
+        var validCachedPaths = Set<String>()
+        var staleItemIDs = [String]()
+
+        for entry in cachedItems {
+          var isStale = false
+          guard
+            let url = try? URL(
+              resolvingBookmarkData: entry.cachedData,
+              bookmarkDataIsStale: &isStale
+            ),
+            !isStale,
+            FileManager.default.fileExists(atPath: url.path)
+          else {
+            staleItemIDs.append(entry.itemId)
+            continue
           }
-          return nil
+          validCachedPaths.insert(url.path)
         }
+        return (validCachedPaths, staleItemIDs)
+      }.value
+
+    for itemId in staleItemIDs {
+      invalidateCachedState(for: itemId)
+    }
+
+    do {
+      let urls = try await AsyncFileManager.default.contentsOfDirectory(
+        at: playlistFolderPath,
+        includingPropertiesForKeys: nil,
+        options: [.skipsHiddenFiles]
+      )
+      for url in urls {
         do {
-          let urls = try FileManager.default.contentsOfDirectory(
-            at: playlistFolderPath,
-            includingPropertiesForKeys: nil,
-            options: [.skipsHiddenFiles]
-          )
-          for url in urls {
-            do {
-              // Playlist doesn't contain such an offline item, so it's dangling somehow and should be deleted.
-              if !cachedURLs.contains(where: { $0.path == url.path }) {
-                try FileManager.default.removeItem(at: url)
-              }
-            } catch {
-              Logger.module.error(
-                "Deleting Dangling Playlist Item for \(url.absoluteString) failed: \(error.localizedDescription)"
-              )
-            }
+          if !validCachedPaths.contains(url.path) {
+            // Playlist doesn't contain such an offline item, so it's dangling somehow and should be deleted.
+            try await AsyncFileManager.default.removeItem(at: url)
           }
         } catch {
           Logger.module.error(
-            "Deleting Dangling Playlist Incomplete Items failed: \(error.localizedDescription)"
+            "Deleting Dangling Playlist Item for \(url.absoluteString) failed: \(error.localizedDescription)"
           )
         }
       }
+    } catch {
+      Logger.module.error(
+        "Deleting Dangling Playlist Incomplete Items failed: \(error.localizedDescription)"
+      )
     }
   }
 
@@ -684,6 +711,23 @@ public class PlaylistManager: NSObject {
       Logger.module.error("Error Retrieving Disk Space: \(error.localizedDescription)")
     }
     return nil
+  }
+
+  /// Clears the persisted `cachedData` bookmark for `itemId` and notifies observers that the item is no longer downloaded.
+  /// Cancels any in-flight download as well so the item ends up in a fully invalid state.
+  /// No-op if the item is gone or already has no cached bookmark.
+  @MainActor private func invalidateCachedState(for itemId: String) {
+    guard
+      let item = PlaylistItem.getItem(uuid: itemId),
+      let cachedData = item.cachedData,
+      !cachedData.isEmpty
+    else {
+      return
+    }
+
+    cancelDownload(itemId: itemId)
+    PlaylistItem.updateCache(uuid: itemId, pageSrc: item.pageSrc, cachedData: nil)
+    onDownloadStateChanged(id: itemId, state: .invalid, displayName: nil, error: nil)
   }
 }
 

--- a/ios/brave-ios/Sources/PlaylistUI/CarPlayController.swift
+++ b/ios/brave-ios/Sources/PlaylistUI/CarPlayController.swift
@@ -62,7 +62,7 @@ public class CarPlayController {
       guard let self else { return }
       Task { @MainActor in
         self.updateFoldersList()
-        self.updateItemList()
+        await self.updateItemList()
       }
     }
     setUpPlayerBindings()
@@ -72,15 +72,16 @@ public class CarPlayController {
   private var currentItemListTemplate: CPListTemplate?
   private var selectedFolderID: PlaylistFolder.ID?
   private var isErrorPresented: Bool = false
+  private var downloadStates: [String: PlaylistDownloadManager.DownloadState] = [:]
 
   @MainActor private func updateFoldersList() {
     let folderListTemplate = self.folderListTemplate
     currentFolderListTemplate?.updateSections(folderListTemplate.sections)
   }
 
-  @MainActor private func updateItemList() {
+  @MainActor private func updateItemList() async {
     guard let selectedFolderID else { return }
-    let itemListTemplate = self.itemListTemplate(for: selectedFolderID)
+    let itemListTemplate = await self.itemListTemplate(for: selectedFolderID)
     currentItemListTemplate?.updateSections(itemListTemplate.sections)
   }
 
@@ -141,8 +142,8 @@ public class CarPlayController {
     player.objectWillChange
       .receive(on: RunLoop.main)
       .sink { [weak self] in
-        MainActor.assumeIsolated {
-          self?.updateItemList()
+        Task { @MainActor in
+          await self?.updateItemList()
           self?.handlePlayerError()
         }
       }
@@ -151,8 +152,8 @@ public class CarPlayController {
     PlaylistManager.shared.downloadStateChanged
       .receive(on: RunLoop.main)
       .sink { [weak self] _ in
-        MainActor.assumeIsolated {
-          self?.updateItemList()
+        Task { @MainActor in
+          await self?.updateItemList()
         }
       }
       .store(in: &cancellables)
@@ -189,16 +190,21 @@ public class CarPlayController {
 
   // MARK: - Template Generation
 
-  @MainActor private func itemListTemplate(for folderID: PlaylistFolder.ID) -> CPListTemplate {
+  @MainActor private func itemListTemplate(for folderID: PlaylistFolder.ID) async -> CPListTemplate
+  {
     guard let folder = PlaylistFolder.getFolder(uuid: folderID) else {
       return CPListTemplate(title: nil, sections: [])
     }
-    let items: [CPListItem] = PlaylistItem.getItems(parentFolder: folder)
+
+    let playlistItems = PlaylistItem.getItems(parentFolder: folder)
+    await refreshDownloadStates(for: playlistItems)
+    let items: [CPListItem] =
+      playlistItems
       .compactMap { item in
         guard let itemUUID = item.uuid else { return nil }
         let listItem = item.listItem
         listItem.accessoryType =
-          PlaylistManager.shared.state(for: itemUUID) != .downloaded ? .cloud : .none
+          downloadStates[itemUUID] != .downloaded ? .cloud : .none
         listItem.isPlaying = player.isPlaying && player.selectedItemID == item.id
         listItem.playingIndicatorLocation = .trailing
         listItem.userInfo = ["id": item.id, "uuid": itemUUID]
@@ -223,12 +229,17 @@ public class CarPlayController {
     for folder in folders {
       let listItem = folder.listItem
       listItem.handler = { [weak self, id = folder.id] _, completion in
-        guard let self else { return }
-        let template = itemListTemplate(for: id)
-        currentItemListTemplate = template
-        selectedFolderID = id
-        interface.pushTemplate(template, animated: true, completion: nil)
-        completion()
+        guard let self else {
+          completion()
+          return
+        }
+        Task { @MainActor in
+          let template = await self.itemListTemplate(for: id)
+          self.currentItemListTemplate = template
+          self.selectedFolderID = id
+          self.interface.pushTemplate(template, animated: true, completion: nil)
+          completion()
+        }
       }
       items.append(listItem)
     }
@@ -275,6 +286,29 @@ public class CarPlayController {
     )
     template.tabImage = UIImage(braveSystemNamed: "leo.settings")
     return template
+  }
+
+  @MainActor private func refreshDownloadStates(for items: [PlaylistItem]) async {
+    let uuids = items.compactMap(\.uuid)
+
+    // Fetch each item's download state concurrently so list refresh stays O(1) wall-clock in the number of items.
+    let resolvedStates = await withTaskGroup(
+      of: (String, PlaylistDownloadManager.DownloadState).self
+    ) { group in
+      for uuid in uuids {
+        group.addTask {
+          (uuid, await PlaylistManager.shared.downloadState(for: uuid))
+        }
+      }
+      var result: [String: PlaylistDownloadManager.DownloadState] = [:]
+      for await (uuid, state) in group {
+        result[uuid] = state
+      }
+      return result
+    }
+
+    // Replacing wholesale also drops entries for items that are no longer present.
+    downloadStates = resolvedStates
   }
 }
 

--- a/ios/brave-ios/Sources/PlaylistUI/PlayerModel.swift
+++ b/ios/brave-ios/Sources/PlaylistUI/PlayerModel.swift
@@ -40,6 +40,7 @@ public final class PlayerModel: ObservableObject {
     setupPlayerNotifications()
     setupPictureInPictureKeyPathObservation()
     setupRemoteCommandCenterHandlers()
+    setupPlaylistManagerObservation()
 
     Task { @MainActor in
       updateSystemPlayer()
@@ -148,6 +149,16 @@ public final class PlayerModel: ObservableObject {
 
   func play() {
     if isPlaying {
+      return
+    }
+    // Recover from an empty player when a selection still exists.
+    // This happens when a previous prepare left `currentItem == nil` (e.g. cache was missing and resolution failed)
+    // and the user has since made the asset available by tapping "Save offline data".
+    if player.currentItem == nil {
+      Task { @MainActor in
+        guard selectedItemID != nil, !isLoadingStreamingURL else { return }
+        await prepareToPlaySelectedItem(initialOffset: nil, playImmediately: true)
+      }
       return
     }
     if case .seconds(let duration) = duration, currentTime == duration {
@@ -814,6 +825,39 @@ public final class PlayerModel: ObservableObject {
       .init { _ = willResignActive },
       .init { _ = willTerminate },
     ])
+  }
+
+  /// Reacts to download lifecycle events from `PlaylistManager` so the player stays consistent with what's actually on disk.
+  ///
+  /// Specifically, when the user taps "Save offline data" for the currently selected item, the player may already be holding a stale `AVPlayerItem`
+  /// from an earlier prepare — typically a streaming URL that was resolved because the item's `cachedData` bookmark survived an
+  /// eviction of the actual file. In that state, `play()`'s smart recovery doesn't fire (it only triggers when `currentItem == nil`),
+  /// so a tap on play just runs `seek+play` against the stale asset and the user sees nothing happen. Replacing `currentItem`
+  /// with one backed by the freshly downloaded file unblocks the next play tap deterministically.
+  ///
+  /// Note: The player is not interrupted if it is actively playing a different content
+  private func setupPlaylistManagerObservation() {
+    PlaylistManager.shared.downloadStateChanged
+      .sink { [weak self] event in
+        guard let self, event.state == .downloaded else { return }
+        Task { @MainActor in
+          // Skip when an initial prepare is still in flight: it would race ours and could
+          // overwrite the local `AVPlayerItem` we install with a streaming one once it
+          // finishes resolving. The user can tap play once the original prepare settles.
+          guard event.id == self.selectedItem?.uuid,
+            !self.isPlaying,
+            !self.isLoadingStreamingURL
+          else { return }
+          // Resume from where the user paused (if anywhere) rather than from the persisted
+          // `lastPlayedOffset`, which may be stale until the next background/persist trigger.
+          let resumeOffset = self.currentTime
+          await self.prepareToPlaySelectedItem(
+            initialOffset: resumeOffset > 0 ? resumeOffset : nil,
+            playImmediately: false
+          )
+        }
+      }
+      .store(in: &cancellables)
   }
 
   /// Sets up KVO observations for AVPlayer properties which trigger the `objectWillChange` publisher

--- a/ios/brave-ios/Sources/PlaylistUI/PlaylistContentView.swift
+++ b/ios/brave-ios/Sources/PlaylistUI/PlaylistContentView.swift
@@ -63,7 +63,9 @@ struct PlaylistContentView: View {
         // FIXME: Move this into PlayerModel
         playerModel.makeItemQueue(selectedItemID: newValue)
         if selectedItemID == newValue {
-          // Already selected, restart it (based on prior behaviour)
+          // Re-tap on the same item. Rewind to the start and play; `play()` re-prepares the asset if
+          // a previous prepare left the player empty (e.g. cache missing and resolution failed, but the user
+          // has since tapped "Save offline data").
           Task {
             await playerModel.seek(to: 0, accurately: true)
             playerModel.play()

--- a/ios/brave-ios/Sources/PlaylistUI/PlaylistItemList.swift
+++ b/ios/brave-ios/Sources/PlaylistUI/PlaylistItemList.swift
@@ -81,7 +81,7 @@ struct PlaylistItemList: View {
           // Mirror the badge's source of truth: only offer "Remove offline data" when the cached file
           // actually exists on disk. Otherwise we'd offer to remove a phantom download for an item whose bookmark
           // survived but whose file was wiped (e.g. by iOS reclaiming `com.apple.UserManagedAssets*`).
-          if downloadStates[item.uuid ?? ""] == .downloaded {
+          if let uuid = item.uuid, downloadStates[uuid] == .downloaded {
             Button {
               Task { @MainActor in
                 await PlaylistManager.shared.deleteCache(item: .init(item: item))

--- a/ios/brave-ios/Sources/PlaylistUI/PlaylistItemList.swift
+++ b/ios/brave-ios/Sources/PlaylistUI/PlaylistItemList.swift
@@ -55,18 +55,16 @@ struct PlaylistItemList: View {
             isSelected: selectedItemID == item.id,
             isPlaying: isPlaying,
             downloadState: {
-              if let uuid = item.uuid, let state = downloadStates[uuid] {
-                if state == .downloaded {
-                  return .completed
-                }
-                if state == .inProgress {
-                  // PlaylistDownloadManager reports percent as 0...100 not 0...1
-                  let percentCompleted = downloadProgress[uuid, default: 0.0] / 100.0
-                  return .downloading(percentComplete: percentCompleted)
-                }
+              guard let uuid = item.uuid, let state = downloadStates[uuid] else {
+                return nil
               }
-              if let cachedData = item.cachedData, !cachedData.isEmpty {
+              if state == .downloaded {
                 return .completed
+              }
+              if state == .inProgress {
+                // PlaylistDownloadManager reports percent as 0...100 not 0...1
+                let percentCompleted = downloadProgress[uuid, default: 0.0] / 100.0
+                return .downloading(percentComplete: percentCompleted)
               }
               return nil
             }()
@@ -80,13 +78,13 @@ struct PlaylistItemList: View {
           PlaylistManager.shared.getAssetDuration(item: .init(item: item)) { _ in }
         }
         .contextMenu {
-          if let cachedData = item.cachedData, !cachedData.isEmpty {
+          // Mirror the badge's source of truth: only offer "Remove offline data" when the cached file
+          // actually exists on disk. Otherwise we'd offer to remove a phantom download for an item whose bookmark
+          // survived but whose file was wiped (e.g. by iOS reclaiming `com.apple.UserManagedAssets*`).
+          if downloadStates[item.uuid ?? ""] == .downloaded {
             Button {
               Task { @MainActor in
                 await PlaylistManager.shared.deleteCache(item: .init(item: item))
-                if let uuid = item.uuid {
-                  downloadStates.removeValue(forKey: uuid)
-                }
               }
             } label: {
               Label(Strings.Playlist.removeOfflineData, braveSystemImage: "leo.cloud.off")


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/54342

## Summary

On iOS, a Playlist item could display the "downloaded" checkmark while the underlying media file no longer existed on disk. Tapping the item would then silently fall back to streaming / re-downloading on the phone, and on CarPlay it would surface as an error.

1. `PlaylistItemList` rendered `.completed` whenever `PlaylistItem.cachedData` (a file bookmark) was non-empty, without verifying the file still existed. Even after the async `downloadState(for:)` lookup completed and returned `.invalid`, the closure fell through to the `cachedData` fallback and still returned `.completed` — so the tick persisted even once the authoritative check had contradicted it.
2. `deleteDanglingManagedAssets()` only cleaned up files-without-references. Items whose bookmarks were stale, or pointed to files iOS had reclaimed (HLS `.movpkg` cleanup, iCloud restore, storage pressure), were never cleared, so the tick persisted across cold starts.
3. `CarPlayController` read from synchronous `state(for:)` (which does verify file existence), while the phone list used the looser `cachedData` fallback. The two surfaces reported different offline states for the same item.

### Areas changed 
| Area | State | Source of truth |
| --- | --- | --- |
| Badge | Correct after wipe (no checkmark for missing file) | `downloadState(for:)` (`fileExists` check) |
| Context menu | "Save offline data" after wipe | Same `downloadState` dictionary as the badge |
| Player | Streams when there's no local file | `prepareToPlaySelectedItem` → `mediaStreamer` fallback |
| Re-tap recovery | Re-prepares when player is empty | `hasCurrentItem` check  |

## Changes

- **`PlaylistItemList.swift`** — derive the offline indicator exclusively from the async `PlaylistManager.downloadState(for:)` map. Drop the `cachedData` fallback.
- **`PlaylistManager.swift`**
  - `downloadState(for:)` now clears stale `cachedData` and emits `.invalid` when the bookmark resolves to a missing file, so the list refreshes promptly.
  - `deleteDanglingManagedAssets()` now reconciles the reverse direction as well — items whose bookmark is stale or whose file is missing have `cachedData` cleared and an `.invalid` state event fired. The reconciliation now also feeds the "valid paths" set used when deleting orphan files, so a single pass handles both directions.
- **`CarPlayController.swift`** — read from the same async `downloadState(for:)` path (cached per-refresh) so phone + CarPlay cannot disagree. `itemListTemplate(for:)`, the folder-list handler, and the `downloadStateChanged` / `objectWillChange` subscribers are now async-safe.

## Testplan
### Playing downloaded content offline
1. Navigate to a video on YouTube. Save a video to the playlist. Make sure that it is done downloading. 
2. Then go to another video and try saving it but before it is done turn off all network connections so that you have a partial download.
 - (Turn off wifi, Disable cellular data for Brave if testing with a physical device, you use the link conditioner). 
3. Restart the app (with no internet connection), go to the the playlist and observe that the fully downloaded video is what's in the playlist.
4. Attempt playing the downloaded video. Observe that it plays while the connection is still off.
5. Observe that you cannot play partially downloaded items.

### Test Stale or dangling data
1. Save a Playlist item for offline. Confirm the tick is present on the item.
2. Go to "All Settings" → "Playlist Debug" → "Manage Playlist Files".
3. Observe a list of files that represent the playlist items shown in the Playlist.
4. Delete all files, or swipe to delete a specific playlist file
5. Go back to the Playlist View in Brave
6. Observe that the delete playlist items do not have the tick items
7. Tap on any playlist item to play
8. Observe that it will begin to stream
9. Long press a playlist item and tap on "Save Offline Data "
10. Observe that it is downloading. Observe that when done, it has the tick mark to signify it has been saved for offline playback
11. Turn of all network connections and playback the item
12. Observe that it plays.


<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
