### PR TITLE
Add best practice: No browser-process-only APIs in common/ directories

### DIFF
--- a/docs/best-practices/architecture.md
+++ b/docs/best-practices/architecture.md
@@ -1401,3 +1401,45 @@ Examples of ride-along changes to avoid:
 - Adding unrelated refactoring alongside a behavioral change
 - Large-scale renaming or reformatting unrelated to your change
 - Reordering functions or methods for aesthetic reasons
+
+---
+
+<a id="ARCH-071"></a>
+
+## ❌ No Browser-Process-Only APIs in `common/` Directories
+
+**Code under `components/.../common/` must not depend on APIs that only exist in the browser process** — `PrefService`, `content::BrowserContext`, `Profile`, `g_browser_process`, etc. `common/` is compiled into any process that links the component (browser, renderer, utility), so referencing browser-only types there is meaningless or unsafe for non-browser callers.
+
+This is the inverse of the `common/` rule above: code moves *into* `common/` only when it is genuinely safe for every process.
+
+```cpp
+// ❌ WRONG - common/ helper that takes a PrefService
+// components/playlist/core/common/utils.h
+namespace playlist {
+bool IsPlaylistEnabled(PrefService* prefs);  // PrefService is browser-only!
+}
+```
+
+```
+# ❌ WRONG - common/DEPS opening access to browser-only deps
+# components/playlist/core/common/DEPS
+include_rules = [
+  "+components/prefs",
+]
+```
+
+```cpp
+// ✅ CORRECT - helper lives in browser/, where PrefService is valid
+// components/playlist/core/browser/utils.h
+namespace playlist {
+bool IsPlaylistEnabled(PrefService* prefs);
+}
+```
+
+**Directory rules:**
+- `common/` — deps must be safe for every process: `//base`, mojom, shared structs
+- `browser/` — browser process only; `PrefService`, `BrowserContext`, `Profile`, `g_browser_process`
+- `renderer/` — renderer process only
+- `services/` — utility process services
+
+A new `+components/prefs` line (or similar) in a `common/DEPS` file is almost always a sign that the helper belongs in `browser/` instead.


### PR DESCRIPTION
## Summary

- Adds new best practice **ARCH-071** to `docs/best-practices/architecture.md`: **No Browser-Process-Only APIs in `common/` Directories**
- Codifies that code under `components/.../common/` must not depend on `PrefService`, `content::BrowserContext`, `Profile`, `g_browser_process`, etc., because `common/` compiles into any process that links the component
- Complements existing ARCH-040 (utility-process → browser dependency) by covering the inverse direction: what may live in `common/`

## Context

Flagged by review on #35823 (`components/playlist/core/common/utils.{h,cc}` taking `PrefService*`, and a `common/DEPS` adding `+components/prefs`). The reviewer's comments:

> "PrefService can only be accessed in the browser process so this code belongs in browser, not common"
> "this is not allowed because common can be accessed by any process"

The rule did not previously exist in our best-practices docs, so `/review` did not flag it.

## Test plan

- [x] `python3 ./script/manage-bp-ids.py --validate` passes (ARCH-071 assigned, no duplicates)