### PR TITLE
Fix GetBoundingBoxInScreenForMouseOverHandling() to use stable bounds

### DIFF
--- a/browser/ui/views/frame/brave_browser_view.cc
+++ b/browser/ui/views/frame/brave_browser_view.cc
@@ -619,8 +619,11 @@ void BraveBrowserView::ShowUpdateChromeDialog() {
 }
 
 gfx::Rect BraveBrowserView::GetBoundingBoxInScreenForMouseOverHandling() const {
-  CHECK(contents_background_view_);
-  return contents_background_view_->GetBoundsInScreen();
+  gfx::Rect browser_bounds = GetBoundsInScreen();
+  gfx::Rect top_container_bounds = top_container_->GetBoundsInScreen();
+  int top = top_container_bounds.bottom();
+  return gfx::Rect(browser_bounds.x(), top, browser_bounds.width(),
+                   browser_bounds.bottom() - top);
 }
 
 bool BraveBrowserView::HasSelectedURL() const {

--- a/browser/ui/views/frame/brave_browser_view_browsertest.cc
+++ b/browser/ui/views/frame/brave_browser_view_browsertest.cc
@@ -563,6 +563,43 @@ INSTANTIATE_TEST_SUITE_P(
     BraveBrowserViewWithRoundedCornersTest,
     testing::Bool());
 
+IN_PROC_BROWSER_TEST_F(BraveBrowserViewTest,
+                       BoundingBoxStableWithSidePanelTest) {
+  auto* panel_ui = browser()->GetFeatures().side_panel_ui();
+  auto* brave_view = brave_browser_view();
+
+  // Get bounds with panel closed.
+  auto bounds_panel_closed =
+      brave_view->GetBoundingBoxInScreenForMouseOverHandling();
+
+  // Bounds should span the full browser width.
+  EXPECT_EQ(browser_view()->width(), bounds_panel_closed.width());
+
+  // Bounds should start at the bottom of the top container.
+  EXPECT_EQ(browser_view()->top_container()->GetBoundsInScreen().bottom(),
+            bounds_panel_closed.y());
+
+  // Bounds should extend to the bottom of the browser window.
+  EXPECT_EQ(brave_view->GetBoundsInScreen().bottom(),
+            bounds_panel_closed.bottom());
+
+  // Open the side panel.
+  panel_ui->Toggle();
+  RunScheduledLayouts();
+
+  // Bounds should be unchanged after opening the side panel.
+  EXPECT_EQ(bounds_panel_closed,
+            brave_view->GetBoundingBoxInScreenForMouseOverHandling());
+
+  // Close the side panel.
+  panel_ui->Toggle();
+  RunScheduledLayouts();
+
+  // Bounds should be unchanged after closing the side panel.
+  EXPECT_EQ(bounds_panel_closed,
+            brave_view->GetBoundingBoxInScreenForMouseOverHandling());
+}
+
 // MacOS does not need views window scrim. We use sheet to show window modals
 // (-[NSWindow beginSheet:]), which natively draws a scrim since macOS 11.
 // Tests that a scrim is still disabled when a window modal dialog is active.


### PR DESCRIPTION
Resolves

  Previously, this returned contents_background_view_ bounds, which                                                                                   
  shrank in width when the side panel was open. This caused the mouse-over                                                                            
  hot corner detection area for the sidebar and vertical tab strip to shift                                                                           
  depending on panel state.                                                                                                                           
                                                                                                                                                      
  This only affects sidebar V2. In V1, Chromium's layout does not account                                                                             
  for the side panel — panel layout is handled later via the sidebar
  container — so contents_background_view_ bounds are unaffected by                                                                                   
  panel visibility. In V2, Chromium's layout handles the side panel
  directly (see BraveBrowserViewTabbedLayoutImpl::CalculateProposedLayout),                                                                           
  so contents_layout bounds shrink when the panel is open, causing
  contents_background_view_ to follow.                                                                                                                
                                                                                                                                                      
  Fix it to return the full area below top_container, spanning the entire                                                                             
  browser width regardless of visible UI panels.                                                                                                      
                  
  Add BoundingBoxStableWithSidePanelTest to verify the returned bounds:
  - span the full browser width
  - start at top_container's bottom edge
  - remain identical before, during, and after a side panel toggle

<!-- Add brave-browser issue below that this PR will resolve -->


<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
