### PR TITLE
Remove "Prefer const for Local Variables" best practice

### DIFF
--- a/docs/best-practices/coding-standards.md
+++ b/docs/best-practices/coding-standards.md
@@ -1061,26 +1061,6 @@ constexpr base::TimeDelta kAnimationDuration = base::Milliseconds(200);
 
 ---
 
-<a id="CS-064"></a>
-
-## ✅ Prefer `const` for Local Variables Where Possible
-
-**Mark local variables `const` when they are not modified after initialization.** This communicates intent, prevents accidental mutation, and can enable compiler optimizations.
-
-```cpp
-// ❌ WRONG - mutable but never modified
-size_t index = items.size() - 1;
-auto result = DoComputation(index);
-
-// ✅ CORRECT - const communicates intent
-const size_t index = items.size() - 1;
-const auto result = DoComputation(index);
-```
-
-This is a preference, not a hard rule — always prefix with `nit:` and do not insist if the developer declines.
-
----
-
 <a id="CS-066"></a>
 
 ## ❌ Don't Commit Commented-Out Code


### PR DESCRIPTION
- Removes the `CS-064` "Prefer `const` for Local Variables Where Possible" section from `docs/best-practices/coding-standards.md`.

People find it too annoying and not important enough to flag.  It's often more stylistic. 