### PR TITLE
[iOS] Dont update url when safe browsing interstitials are visible

### DIFF
--- a/ios/brave-ios/Sources/Web/Chromium/ChromiumTabState.swift
+++ b/ios/brave-ios/Sources/Web/Chromium/ChromiumTabState.swift
@@ -84,17 +84,6 @@ class ChromiumTabState: TabState, TabStateImpl {
   }
 
   private func webViewTitleDidChange() {
-    if let webView = webView?.internalWebView, let url = webView.url,
-      webView.configuration.preferences.isFraudulentWebsiteWarningEnabled,
-      webView.responds(to: Selector(("_safeBrowsingWarning"))),
-      webView.value(forKey: "_safeBrowsingWarning") != nil
-    {
-      self.virtualURL = url  // We can update the URL whenever showing an interstitial warning
-      observers.forEach {
-        $0.tabDidUpdateURL(self)
-      }
-    }
-
     observers.forEach {
       $0.tabDidChangeTitle(self)
     }


### PR DESCRIPTION
This created further issues with Chromium web views and never updated the security icon either

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/54756
