### PR TITLE
Require private browsing lock auth from Playlist

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Playlist/ManagersAndCache/PlaylistCoordinator.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Playlist/ManagersAndCache/PlaylistCoordinator.swift
@@ -121,15 +121,15 @@ public class PlaylistCoordinator: NSObject {
         openTabURL: { [weak browserController] url, isPrivate in
           guard let browserController else { return }
           let isPrivate = Preferences.Privacy.privateBrowsingOnly.value ? true : isPrivate
-          let openTab: () -> Void = { [weak browserController] in
-            browserController?.dismiss(animated: true)
-            browserController?.openURLInNewTab(
+          let openTab: () -> Void = {
+            browserController.dismiss(animated: true)
+            browserController.openURLInNewTab(
               url,
               isPrivate: isPrivate,
               isPrivileged: false
             )
           }
-          
+
           if isPrivate,
             !browserController.privateBrowsingManager.isPrivateBrowsing,
             Preferences.Privacy.privateBrowsingLock.value

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Playlist/ManagersAndCache/PlaylistCoordinator.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Playlist/ManagersAndCache/PlaylistCoordinator.swift
@@ -119,12 +119,29 @@ public class PlaylistCoordinator: NSObject {
       player: player,
       delegate: .init(
         openTabURL: { [weak browserController] url, isPrivate in
-          browserController?.dismiss(animated: true)
-          browserController?.openURLInNewTab(
-            url,
-            isPrivate: Preferences.Privacy.privateBrowsingOnly.value ? true : isPrivate,
-            isPrivileged: false
-          )
+          guard let browserController else { return }
+          let isPrivate = Preferences.Privacy.privateBrowsingOnly.value ? true : isPrivate
+          let openTab: () -> Void = { [weak browserController] in
+            browserController?.dismiss(animated: true)
+            browserController?.openURLInNewTab(
+              url,
+              isPrivate: isPrivate,
+              isPrivileged: false
+            )
+          }
+          
+          if isPrivate,
+            !browserController.privateBrowsingManager.isPrivateBrowsing,
+            Preferences.Privacy.privateBrowsingLock.value
+          {
+            browserController.askForLocalAuthentication { success, _ in
+              if success {
+                openTab()
+              }
+            }
+          } else {
+            openTab()
+          }
         },
         onDismissal: { [weak self, weak player] in
           guard let self else { return }


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->

Resolves https://github.com/brave/brave-browser/issues/54935
Resolves https://github.com/brave/internal/issues/1716

## Summary

The Playlist context menu's "Open in New Private Tab" action opened a new private tab without consulting the Private Browsing Lock preference. This bypassed biometric / Passcode authentication  and, when combined with "Keep Private Tabs", let anyone with access to an unlocked device reach the user's existing private tab session
directly from Playlist.

This PR gates the private-tab open in `PlaylistCoordinator`'s `openTabURL` delegate on `askForLocalAuthentication` when transitioning from regular into private browsing with the lock enabled, matching the existing pattern used by every other private-tab entry point (tabs bar "+", new-tab long-press menu, link context menu, history, bookmarks, favourites, URL bar / navigation router, key commands, shortcuts, quick actions).

If authentication fails or is cancelled, Playlist stays on screen and no private tab is created. When already in private browsing, or when the lock is disabled, behaviour is unchanged.

## Test Plan

- [ ] With Private Browsing Lock enabled + Keep Private Tabs enabled, long-press a Playlist item and select "Open in New Private Tab": verify FaceID/Passcode is required and cancelling leaves no new private tab.
- [ ] Same flow with Private Browsing Lock **disabled**: verify the private tab opens directly, no prompt (unchanged behaviour).
- [ ] While already in Private Browsing mode, repeat the flow: verify no extra auth prompt (unchanged behaviour).
- [ ] With `privateBrowsingOnly` enabled (PBO), the flow still opens a private tab; since that mode is always private, no extra prompt is expected.
- [ ] "Open in New Tab" from the same Playlist context menu is unaffected.
- [ ] Sanity check on iPad: same behaviour.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
