### PR TITLE
Uplift intermittent test fixes to 1.90.x

### DIFF
--- a/browser/speedreader/speedreader_browsertest.cc
+++ b/browser/speedreader/speedreader_browsertest.cc
@@ -652,8 +652,7 @@ IN_PROC_BROWSER_TEST_F(SpeedReaderBrowserTest, ReloadContent) {
 IN_PROC_BROWSER_TEST_F(SpeedReaderBrowserTest, ShowOriginalPage) {
   EnableSpeedreaderAllowedForAllSites();
   NavigateToPageSynchronously(kTestPageReadable);
-  // Wait for distillation to complete before interacting with distilled content
-  WaitDistilled();
+  ASSERT_TRUE(WaitDistilled());
   auto* web_contents = ActiveWebContents();
 
   static constexpr char kCheckNoApiInMainWorld[] =

--- a/test/filters/browser_tests-linux.filter
+++ b/test/filters/browser_tests-linux.filter
@@ -128,6 +128,14 @@
 # https://github.com/brave/brave-browser/issues/54159
 -ObservationDelayControllerTest.UsePageStabilityForSameDocumentNavigation
 
+# Brave's canvas farbling (PerturbPixels) modifies getImageData() results,
+# breaking this test's canvas-based video playback detection. The test only
+# compiles on Linux non-sanitizer builds (#if BUILDFLAG(IS_LINUX)).
+# Upstream stable: 640x480 0.6%, 3840x2160 0.3% flake rate (30-day LUCI).
+# https://github.com/brave/brave-browser/issues/54521
+-All/GetDisplayMediaHiDpiBrowserTest.Capture/640x480
+-All/GetDisplayMediaHiDpiBrowserTest.Capture/3840x2160
+
 # Tests below this point have not been diagnosed or had issues created yet.
 -AccessCodeCastHandlerBrowserTest.*
 -AdsPageLoadMetricsObserverBrowserTest.*

--- a/test/filters/browser_tests.filter
+++ b/test/filters/browser_tests.filter
@@ -3603,6 +3603,12 @@
 # https://github.com/brave/brave-browser/issues/54219
 -All/SaveToDriveEventDispatcherBrowserTest.GetFileMetadataStringForUploadInProgress/0
 
+# Chromium test: known upstream flake (3.7% flake rate over 30 days,
+# 114k+ verdicts). No Brave modifications in chrome/browser/save_to_drive/.
+# Test times out during QuitBrowsers in PostRunTestOnMainThread teardown.
+# https://github.com/brave/brave-browser/issues/54240
+-All/SaveToDriveEventDispatcherBrowserTest.Notify/0
+
 # Known upstream flake (8.2% flake rate over 30 days). Race condition between
 # autofill form classification and APC extraction: GetAutofillFieldData()
 # returns nullopt when autofill hasn't cached the cross-site iframe's form yet,


### PR DESCRIPTION
Uplift of #35842
Uplift of #35890
Uplift of #35718

## Included PRs
- #35842 - Disable flaky Chromium test SaveToDriveEventDispatcherBrowserTest.Notify/0
- #35890 - Disable Chromium test GetDisplayMediaHiDpiBrowserTest.Capture
- #35718 - Fix intermittent SpeedReaderBrowserTest.ShowOriginalPage failure

Pre-approval checklist:
- [ ] You have tested your change on Nightly.
- [ ] This contains text which needs to be translated.
    - [ ] There are more than 7 days before the release.
    - [ ] I've notified folks in #l10n on Slack that translations are needed.
- [x] The PR milestones match the branch they are landing to.


Pre-merge checklist:
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.

Post-merge checklist:
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.