### PR TITLE
[brockit] Fix `git_status` trimming issue

### DIFF
--- a/tools/cr/brockit.py
+++ b/tools/cr/brockit.py
@@ -1146,17 +1146,19 @@ class Upgrade(Versioned):
         if status.has_deleted_patch_files():
             raise InvalidInputException(
                 'Deleted patches detected. These should be committed as their '
-                'own changes:\n%s' % '\n'.join(status.deleted))
+                'own changes:\n%s' %
+                '\n'.join(status.staged.deleted + status.unstaged.deleted))
         if status.has_untracked_patch_files():
             raise InvalidInputException(
                 'Untracked patch files detected. These should be committed as '
-                'their own changes:\n%s' % '\n'.join(status.untracked))
+                'their own changes:\n%s' % '\n'.join(status.unstaged.added))
         if status.has_staged_files():
             raise InvalidInputException(
                 'Staged files detected after running update_patches. Please '
                 'make sure to commit or unstage any changes, to avoid '
                 'committing changes unintentionally.\n'
-                'Staged files:\n%s' % '\n'.join(status.staged))
+                'Staged files:\n%s' %
+                '\n'.join(status.get_all_staged_entries()))
 
         # The resulting updated patches should not be doing anything beyond
         # what they were doing already, both for "Update patches" and
@@ -1164,8 +1166,9 @@ class Upgrade(Versioned):
         # patches to make sure that the number of hunks in these patch files
         # have not changed, as any significant change to a patchfile should be
         # submitted as its own change, with a culprit for visibility.
+        all_modified = status.staged.modified + status.unstaged.modified
         modified_patches = [
-            path for path in status.modified
+            path for path in all_modified
             if path.startswith('patches/') and path.endswith('.patch')
         ]
         if not modified_patches:
@@ -2060,6 +2063,13 @@ class Reassign(Task):
             The change for which the authorship should be reassigned. This is
             any valid git reference that resolves to a single commit.
         """
+
+        status = GitStatus()
+        if status.has_staged_files():
+            raise InvalidInputException(
+                'Staged files detected. Please commit or unstage changes '
+                'before reassigning:\n%s' %
+                '\n'.join(status.get_all_staged_entries()))
 
         commit, message = repository.brave.run_git('log', '-1', change, '-s',
                                                    '--format=%h %s').split(

--- a/tools/cr/git_status.py
+++ b/tools/cr/git_status.py
@@ -3,50 +3,104 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
+from dataclasses import dataclass, field
+
 import repository
 
 
 class GitStatus:
-    """Runs `git status` and provides a summary.
+    '''Parses `git status --porcelain` output into categorized file lists.
 
-    This class is very simple and it is designed around the use case where we
-    want to check for the status of the repository before committing the common
-    version bump patches.
-    """
+    Files are grouped into two areas based on the XY status code from the
+    porcelain output: `staged` (X column, index vs. HEAD) and `unstaged`
+    (Y column, working tree vs. index). Staged renames are stored separately
+    in `renamed` as (old_path, new_path) tuples because they span two paths.
+
+    A single file can appear in both areas simultaneously — for example, a
+    file staged as modified (X='M') and then further edited (Y='M') will
+    appear in both `staged.modified` and `unstaged.modified`.
+    '''
+
+    @dataclass
+    class Area:
+        '''A view of file changes within one git status area.
+
+        Each field holds the relative paths of files in that state. A path
+        appears in exactly one field within an area.
+
+        Fields:
+            added:    Paths that are new in this area (X='A' or Y='?').
+            modified: Paths that were changed relative to the previous state
+                      (X='M' or Y='M').
+            deleted:  Paths that were removed relative to the previous state
+                      (X='D' or Y='D').
+        '''
+        added: list[str] = field(default_factory=list)
+        modified: list[str] = field(default_factory=list)
+        deleted: list[str] = field(default_factory=list)
 
     def __init__(self):
-        self.git_status = repository.brave.run_git('status', '--short')
+        porcelain = repository.brave.run_git('status',
+                                             '--porcelain',
+                                             no_trim=True)
 
-        # a list of all deleted files, regardless of their staged status.
-        self.deleted = []
+        self.staged: GitStatus.Area = GitStatus.Area()
+        self.unstaged: GitStatus.Area = GitStatus.Area()
 
-        # a list of all modified files, regardless of their staged status.
-        self.modified = []
+        # Staged renames as (old_path, new_path) tuples. Kept separate from
+        # Area because a rename inherently involves two paths.
+        self.renamed: list[tuple[str, str]] = []
 
-        # a list of all untracked files.
-        self.untracked = []
-
-        # a list of all staged files.
-        self.staged = []
-
-        for line in self.git_status.splitlines():
+        for line in porcelain.splitlines():
             xy = line[:2]
             path = line[3:]
-            if xy[0] not in (' ', '?'):
-                self.staged.append(path)
-            status = line.lstrip().split(' ', 1)[0]
-            if status == 'D':
-                self.deleted.append(path)
-            elif status == 'M':
-                self.modified.append(path)
-            elif status == '??':
-                self.untracked.append(path)
+            x, y = xy[0], xy[1]
 
-    def has_staged_files(self):
-        return len(self.staged) > 0
+            if x == 'M':
+                self.staged.modified.append(path)
+            elif x == 'A':
+                self.staged.added.append(path)
+            elif x == 'D':
+                self.staged.deleted.append(path)
+            elif x == 'R':
+                old_path, new_path = path.split(' -> ', 1)
+                self.renamed.append((old_path, new_path))
+                path = new_path
 
-    def has_deleted_patch_files(self):
-        return any(path.endswith('.patch') for path in self.deleted)
+            if y == 'M':
+                self.unstaged.modified.append(path)
+            elif y == '?':
+                self.unstaged.added.append(path)
+            elif y == 'D':
+                self.unstaged.deleted.append(path)
 
-    def has_untracked_patch_files(self):
-        return any(path.endswith('.patch') for path in self.untracked)
+    def get_all_staged_entries(self) -> list[str]:
+        '''Returns a flat list of all paths with staged changes.
+
+        For renames, the new (current) path is included.
+        '''
+        return (self.staged.added + self.staged.modified +
+                self.staged.deleted +
+                [new_path for _, new_path in self.renamed])
+
+    def has_staged_files(self) -> bool:
+        '''Returns True if any staged changes exist.'''
+        return bool(self.staged.added or self.staged.modified
+                    or self.staged.deleted or self.renamed)
+
+    def has_deleted_patch_files(self) -> bool:
+        '''Returns True if any patch files under patches/ are deleted.
+
+        Checks both staged and unstaged deletions, since a deletion can be
+        present in either area.
+        '''
+        all_deleted = self.staged.deleted + self.unstaged.deleted
+        return any(
+            path.startswith('patches/') and path.endswith('.patch')
+            for path in all_deleted)
+
+    def has_untracked_patch_files(self) -> bool:
+        '''Returns True if any patch files under patches/ are untracked.'''
+        return any(
+            path.startswith('patches/') and path.endswith('.patch')
+            for path in self.unstaged.added)

--- a/tools/cr/git_status_test.py
+++ b/tools/cr/git_status_test.py
@@ -4,6 +4,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import subprocess
 import unittest
 from pathlib import Path
 
@@ -19,69 +20,315 @@ class GitStatusTest(unittest.TestCase):
         self.fake_chromium_src.setup()
         self.addCleanup(self.fake_chromium_src.cleanup)
 
-    def test_has_deleted_patch_files(self):
-        """Test has_deleted_patch_files method."""
+    # -- Helpers ---------------------------------------------------------------
+
+    def _brave(self):
+        return self.fake_chromium_src.brave
+
+    def _commit_file(self, path, content='content'):
+        self.fake_chromium_src.write_and_stage_file(path, content,
+                                                    self._brave())
+        self.fake_chromium_src.commit(f'Add {path}', self._brave())
+
+    def _stage_file(self, path, content='content'):
+        self.fake_chromium_src.write_and_stage_file(path, content,
+                                                    self._brave())
+
+    def _stage_delete(self, path):
+        self.fake_chromium_src.delete_file(path, self._brave())
+
+    def _write_file(self, path, content='content'):
+        full = Path(self._brave() / path)
+        full.parent.mkdir(parents=True, exist_ok=True)
+        full.write_text(content)
+
+    def _delete_file(self, path):
+        Path(self._brave() / path).unlink()
+
+    def _git_mv(self, old_path, new_path):
+        subprocess.check_call(['git', 'mv', old_path, new_path],
+                              cwd=self._brave(),
+                              stderr=subprocess.DEVNULL)
+
+    def _assert_empty(self, status):
+        self.assertEqual(status.staged.added, [])
+        self.assertEqual(status.staged.modified, [])
+        self.assertEqual(status.staged.deleted, [])
+        self.assertEqual(status.renamed, [])
+        self.assertEqual(status.unstaged.added, [])
+        self.assertEqual(status.unstaged.modified, [])
+        self.assertEqual(status.unstaged.deleted, [])
+
+    # -- XY state tests --------------------------------------------------------
+
+    def test_clean_state(self):
+        """No changes: all areas are empty."""
+        self._assert_empty(GitStatus())
+        self.assertFalse(GitStatus().has_staged_files())
+        self.assertFalse(GitStatus().has_deleted_patch_files())
+        self.assertFalse(GitStatus().has_untracked_patch_files())
+
+    def test_staged_added(self):
+        """XY='A ': new files staged."""
+        self._stage_file('a.txt')
+        self._stage_file('b.txt')
         status = GitStatus()
-        self.assertFalse(status.has_deleted_patch_files())
-        self.assertEqual(status.deleted, [])
+        self.assertEqual(status.staged.added, ['a.txt', 'b.txt'])
+        self.assertEqual(status.staged.modified, [])
+        self.assertEqual(status.staged.deleted, [])
+        self.assertEqual(status.unstaged.added, [])
+        self.assertEqual(status.unstaged.modified, [])
+        self.assertEqual(status.unstaged.deleted, [])
 
-        # Create a patch file and commit it
-        patch_file = 'patches/test.patch'
-        self.fake_chromium_src.write_and_stage_file(
-            patch_file, 'Patch content', self.fake_chromium_src.brave)
-        self.fake_chromium_src.commit('Add test.patch',
-                                      self.fake_chromium_src.brave)
-
-        # Delete the patch file
-        self.fake_chromium_src.delete_file(patch_file,
-                                           self.fake_chromium_src.brave)
-
-        # Run GitStatus and verify the deleted patch file is detected
+    def test_staged_added_then_unstaged_modified(self):
+        """XY='AM': files staged then modified."""
+        self._stage_file('a.txt', 'v1')
+        self._stage_file('b.txt', 'v1')
+        self._write_file('a.txt', 'v2')
+        self._write_file('b.txt', 'v2')
         status = GitStatus()
-        self.assertTrue(status.has_deleted_patch_files())
-        self.assertEqual(status.deleted, [patch_file])
+        self.assertEqual(status.staged.added, ['a.txt', 'b.txt'])
+        self.assertEqual(status.staged.modified, [])
+        self.assertEqual(status.staged.deleted, [])
+        self.assertEqual(status.unstaged.added, [])
+        self.assertEqual(status.unstaged.modified, ['a.txt', 'b.txt'])
+        self.assertEqual(status.unstaged.deleted, [])
 
-    def test_test_has_staged_files(self):
-        """Test staged files summary."""
+    def test_staged_added_then_unstaged_deleted(self):
+        """XY='AD': files staged then deleted."""
+        self._stage_file('a.txt')
+        self._stage_file('b.txt')
+        self._delete_file('a.txt')
+        self._delete_file('b.txt')
         status = GitStatus()
-        self.assertFalse(status.has_staged_files())
-        self.assertEqual(status.staged, [])
+        self.assertEqual(status.staged.added, ['a.txt', 'b.txt'])
+        self.assertEqual(status.staged.modified, [])
+        self.assertEqual(status.staged.deleted, [])
+        self.assertEqual(status.unstaged.added, [])
+        self.assertEqual(status.unstaged.modified, [])
+        self.assertEqual(status.unstaged.deleted, ['a.txt', 'b.txt'])
 
-        # Stage one file and leave another one untracked.
-        staged_file = 'staged_file.txt'
-        untracked_file = 'untracked_file.txt'
-        self.fake_chromium_src.write_and_stage_file(
-            staged_file, 'staged content', self.fake_chromium_src.brave)
-        Path(self.fake_chromium_src.brave /
-             untracked_file).write_text('untracked content')
+    def test_staged_modified(self):
+        """XY='M ': committed files with staged modifications."""
+        self._commit_file('a.txt', 'v1')
+        self._commit_file('b.txt', 'v1')
+        self._stage_file('a.txt', 'v2')
+        self._stage_file('b.txt', 'v2')
+        status = GitStatus()
+        self.assertEqual(status.staged.added, [])
+        self.assertEqual(status.staged.modified, ['a.txt', 'b.txt'])
+        self.assertEqual(status.staged.deleted, [])
+        self.assertEqual(status.unstaged.added, [])
+        self.assertEqual(status.unstaged.modified, [])
+        self.assertEqual(status.unstaged.deleted, [])
 
+    def test_staged_modified_then_unstaged_modified(self):
+        """XY='MM': staged modification, then further modified."""
+        self._commit_file('a.txt', 'v1')
+        self._commit_file('b.txt', 'v1')
+        self._stage_file('a.txt', 'v2')
+        self._stage_file('b.txt', 'v2')
+        self._write_file('a.txt', 'v3')
+        self._write_file('b.txt', 'v3')
+        status = GitStatus()
+        self.assertEqual(status.staged.added, [])
+        self.assertEqual(status.staged.modified, ['a.txt', 'b.txt'])
+        self.assertEqual(status.staged.deleted, [])
+        self.assertEqual(status.unstaged.added, [])
+        self.assertEqual(status.unstaged.modified, ['a.txt', 'b.txt'])
+        self.assertEqual(status.unstaged.deleted, [])
+
+    def test_staged_modified_then_unstaged_deleted(self):
+        """XY='MD': staged modification, then deleted."""
+        self._commit_file('a.txt', 'v1')
+        self._commit_file('b.txt', 'v1')
+        self._stage_file('a.txt', 'v2')
+        self._stage_file('b.txt', 'v2')
+        self._delete_file('a.txt')
+        self._delete_file('b.txt')
+        status = GitStatus()
+        self.assertEqual(status.staged.added, [])
+        self.assertEqual(status.staged.modified, ['a.txt', 'b.txt'])
+        self.assertEqual(status.staged.deleted, [])
+        self.assertEqual(status.unstaged.added, [])
+        self.assertEqual(status.unstaged.modified, [])
+        self.assertEqual(status.unstaged.deleted, ['a.txt', 'b.txt'])
+
+    def test_staged_deleted(self):
+        """XY='D ': committed files with staged deletions."""
+        self._commit_file('a.txt')
+        self._commit_file('b.txt')
+        self._stage_delete('a.txt')
+        self._stage_delete('b.txt')
+        status = GitStatus()
+        self.assertEqual(status.staged.added, [])
+        self.assertEqual(status.staged.modified, [])
+        self.assertEqual(status.staged.deleted, ['a.txt', 'b.txt'])
+        self.assertEqual(status.unstaged.added, [])
+        self.assertEqual(status.unstaged.modified, [])
+        self.assertEqual(status.unstaged.deleted, [])
+
+    def test_unstaged_modified(self):
+        """XY=' M': committed files modified without staging."""
+        self._commit_file('a.txt', 'v1')
+        self._commit_file('b.txt', 'v1')
+        self._write_file('a.txt', 'v2')
+        self._write_file('b.txt', 'v2')
+        status = GitStatus()
+        self.assertEqual(status.staged.added, [])
+        self.assertEqual(status.staged.modified, [])
+        self.assertEqual(status.staged.deleted, [])
+        self.assertEqual(status.unstaged.added, [])
+        self.assertEqual(status.unstaged.modified, ['a.txt', 'b.txt'])
+        self.assertEqual(status.unstaged.deleted, [])
+
+    def test_unstaged_deleted(self):
+        """XY=' D': committed files deleted without staging."""
+        self._commit_file('a.txt')
+        self._commit_file('b.txt')
+        self._delete_file('a.txt')
+        self._delete_file('b.txt')
+        status = GitStatus()
+        self.assertEqual(status.staged.added, [])
+        self.assertEqual(status.staged.modified, [])
+        self.assertEqual(status.staged.deleted, [])
+        self.assertEqual(status.unstaged.added, [])
+        self.assertEqual(status.unstaged.modified, [])
+        self.assertEqual(status.unstaged.deleted, ['a.txt', 'b.txt'])
+
+    def test_untracked(self):
+        """XY='??': untracked files."""
+        self._write_file('a.txt')
+        self._write_file('b.txt')
+        status = GitStatus()
+        self.assertEqual(status.staged.added, [])
+        self.assertEqual(status.staged.modified, [])
+        self.assertEqual(status.staged.deleted, [])
+        self.assertEqual(status.unstaged.added, ['a.txt', 'b.txt'])
+        self.assertEqual(status.unstaged.modified, [])
+        self.assertEqual(status.unstaged.deleted, [])
+
+    def test_staged_renamed(self):
+        """XY='R ': committed files renamed via git mv."""
+        self._commit_file('a_old.txt')
+        self._commit_file('b_old.txt')
+        self._git_mv('a_old.txt', 'a_new.txt')
+        self._git_mv('b_old.txt', 'b_new.txt')
+        status = GitStatus()
+        self.assertEqual(status.staged.added, [])
+        self.assertEqual(status.staged.modified, [])
+        self.assertEqual(status.staged.deleted, [])
+        self.assertEqual(status.renamed, [('a_old.txt', 'a_new.txt'),
+                                          ('b_old.txt', 'b_new.txt')])
+        self.assertEqual(status.unstaged.added, [])
+        self.assertEqual(status.unstaged.modified, [])
+        self.assertEqual(status.unstaged.deleted, [])
+
+    def test_staged_renamed_then_unstaged_modified(self):
+        """XY='RM': staged rename, then new path modified."""
+        self._commit_file('a_old.txt', 'v1')
+        self._commit_file('b_old.txt', 'v1')
+        self._git_mv('a_old.txt', 'a_new.txt')
+        self._git_mv('b_old.txt', 'b_new.txt')
+        self._write_file('a_new.txt', 'v2')
+        self._write_file('b_new.txt', 'v2')
+        status = GitStatus()
+        self.assertEqual(status.staged.added, [])
+        self.assertEqual(status.staged.modified, [])
+        self.assertEqual(status.staged.deleted, [])
+        self.assertEqual(status.renamed, [('a_old.txt', 'a_new.txt'),
+                                          ('b_old.txt', 'b_new.txt')])
+        self.assertEqual(status.unstaged.added, [])
+        self.assertEqual(status.unstaged.modified, ['a_new.txt', 'b_new.txt'])
+        self.assertEqual(status.unstaged.deleted, [])
+
+    # -- Helper method tests ---------------------------------------------------
+
+    def test_has_staged_files(self):
+        """has_staged_files is True for any staged change across all types."""
+        self.assertFalse(GitStatus().has_staged_files())
+
+        self._stage_file('a.txt')
+        self._stage_file('b.txt')
         status = GitStatus()
         self.assertTrue(status.has_staged_files())
-        self.assertEqual(status.staged, [staged_file])
+        self.assertEqual(len(status.staged.added), 2)
+
+        self.fake_chromium_src.commit('add', self._brave())
+        self._stage_file('a.txt', 'v2')
+        self._stage_file('b.txt', 'v2')
+        status = GitStatus()
+        self.assertTrue(status.has_staged_files())
+        self.assertEqual(len(status.staged.modified), 2)
+
+        self.fake_chromium_src.commit('modify', self._brave())
+        self._stage_delete('a.txt')
+        self._stage_delete('b.txt')
+        status = GitStatus()
+        self.assertTrue(status.has_staged_files())
+        self.assertEqual(len(status.staged.deleted), 2)
+
+        self.fake_chromium_src.commit('delete', self._brave())
+        self._commit_file('c.txt')
+        self._commit_file('d.txt')
+        self._git_mv('c.txt', 'c_new.txt')
+        self._git_mv('d.txt', 'd_new.txt')
+        status = GitStatus()
+        self.assertTrue(status.has_staged_files())
+        self.assertEqual(len(status.renamed), 2)
+
+    def test_has_deleted_patch_files(self):
+        """has_deleted_patch_files() detects staged/unstaged deletions."""
+        self.assertFalse(GitStatus().has_deleted_patch_files())
+        self.assertEqual(GitStatus().staged.deleted, [])
+        self.assertEqual(GitStatus().unstaged.deleted, [])
+
+        # Staged deletions of multiple patch files are detected.
+        self._commit_file('patches/a.patch', 'patch a')
+        self._commit_file('patches/b.patch', 'patch b')
+        self._stage_delete('patches/a.patch')
+        self._stage_delete('patches/b.patch')
+        status = GitStatus()
+        self.assertTrue(status.has_deleted_patch_files())
+        self.assertEqual(status.staged.deleted,
+                         ['patches/a.patch', 'patches/b.patch'])
+        self.assertEqual(status.unstaged.deleted, [])
+
+        # After committing the deletions, the slate is clean again.
+        self.fake_chromium_src.commit('Delete patches', self._brave())
+        self.assertFalse(GitStatus().has_deleted_patch_files())
+
+        # Unstaged deletions of multiple patch files are also detected.
+        self._commit_file('patches/a.patch', 'patch a again')
+        self._commit_file('patches/b.patch', 'patch b again')
+        self._delete_file('patches/a.patch')
+        self._delete_file('patches/b.patch')
+        status = GitStatus()
+        self.assertTrue(status.has_deleted_patch_files())
+        self.assertEqual(status.staged.deleted, [])
+        self.assertEqual(status.unstaged.deleted,
+                         ['patches/a.patch', 'patches/b.patch'])
 
     def test_has_untracked_patch_files(self):
-        """Test has_untracked_patch_files method."""
+        """has_untracked_patch_files() only fires for untracked patches."""
+        self.assertFalse(GitStatus().has_untracked_patch_files())
+        self.assertEqual(GitStatus().unstaged.added, [])
+
+        # Staged patch files do not count as untracked.
+        self._stage_file('patches/staged_a.patch', 'content a')
+        self._stage_file('patches/staged_b.patch', 'content b')
         status = GitStatus()
         self.assertFalse(status.has_untracked_patch_files())
-        self.assertEqual(status.untracked, [])
+        self.assertEqual(status.unstaged.added, [])
 
-        # Stage a patch file; this should not count as untracked.
-        self.fake_chromium_src.write_and_stage_file(
-            'staged.patch', 'staged patch content',
-            self.fake_chromium_src.brave)
-        status = GitStatus()
-        self.assertFalse(status.has_untracked_patch_files())
-        self.assertEqual(status.untracked, [])
-
-        # Create a patch file but do not stage it
-        untracked_patch_file = 'test_untracked.patch'
-        Path(self.fake_chromium_src.brave /
-             untracked_patch_file).write_text('Untracked patch content')
-
-        # Run GitStatus and verify the untracked patch file is detected
+        # Multiple untracked patch files are all detected.
+        self._write_file('patches/untracked_a.patch', 'untracked a')
+        self._write_file('patches/untracked_b.patch', 'untracked b')
         status = GitStatus()
         self.assertTrue(status.has_untracked_patch_files())
-        self.assertEqual(status.untracked, [untracked_patch_file])
+        self.assertEqual(
+            status.unstaged.added,
+            ['patches/untracked_a.patch', 'patches/untracked_b.patch'])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR fixes `lift` being broken due to git status output being
trimmed, and tilting the xy axis for git status. On top of that, this PR
overhauls `GitStatus` to be more accurate and comprehensive, as there
were a few corner cases.
