### PR TITLE
Handle non parseable stored last daily ping date

### DIFF
--- a/browser/brave_stats/BUILD.gn
+++ b/browser/brave_stats/BUILD.gn
@@ -88,6 +88,7 @@ source_set("unit_tests") {
 
   sources = [
     "//brave/browser/brave_stats/brave_stats_updater_unittest.cc",
+    "//brave/browser/brave_stats/brave_stats_updater_util_unittest.cc",
     "//brave/browser/brave_stats/first_run_util_unittest.cc",
   ]
 

--- a/browser/brave_stats/brave_stats_updater_util_unittest.cc
+++ b/browser/brave_stats/brave_stats_updater_util_unittest.cc
@@ -1,0 +1,159 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_stats/browser/brave_stats_updater_util.h"
+
+#include <optional>
+#include <string>
+#include <string_view>
+
+#include "base/time/time.h"
+#include "testing/gmock/include/gmock/gmock.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace brave_stats {
+
+namespace {
+
+base::Time TimeFromLocal(int year, int month, int day) {
+  base::Time::Exploded exploded = {
+      .year = year, .month = month, .day_of_month = day};
+  base::Time time;
+  EXPECT_TRUE(base::Time::FromLocalExploded(exploded, &time));
+  return time;
+}
+
+base::Time TimeFromUTC(int year, int month, int day) {
+  base::Time::Exploded exploded = {
+      .year = year, .month = month, .day_of_month = day};
+  base::Time time;
+  EXPECT_TRUE(base::Time::FromUTCExploded(exploded, &time));
+  return time;
+}
+
+}  // namespace
+
+class BraveStatsUpdaterUtilTest : public testing::Test {};
+
+TEST_F(BraveStatsUpdaterUtilTest, GetYMDAsDateParsesValidLocalDate) {
+  std::optional<base::Time> time =
+      GetYMDAsDate("2018-06-22", /*use_utc=*/false);
+  ASSERT_TRUE(time);
+  base::Time::Exploded exploded;
+  time->LocalExplode(&exploded);
+  EXPECT_THAT(exploded, testing::FieldsAre(/*year=*/2018, /*month=*/6,
+                                           /*day_of_week=*/5,
+                                           /*day_of_month=*/22, /*hour=*/0,
+                                           /*minute=*/0, /*second=*/0,
+                                           /*millisecond=*/0));
+}
+
+TEST_F(BraveStatsUpdaterUtilTest, GetYMDAsDateParsesValidUtcDate) {
+  std::optional<base::Time> time = GetYMDAsDate("2018-06-22", /*use_utc=*/true);
+  ASSERT_TRUE(time);
+  base::Time::Exploded exploded;
+  time->UTCExplode(&exploded);
+  EXPECT_THAT(exploded, testing::FieldsAre(/*year=*/2018, /*month=*/6,
+                                           /*day_of_week=*/5,
+                                           /*day_of_month=*/22, /*hour=*/0,
+                                           /*minute=*/0, /*second=*/0,
+                                           /*millisecond=*/0));
+}
+
+TEST_F(BraveStatsUpdaterUtilTest, GetYMDAsDateReturnsNulloptForEmptyLocalDate) {
+  EXPECT_FALSE(GetYMDAsDate(/*ymd=*/"", /*use_utc=*/false));
+}
+
+TEST_F(BraveStatsUpdaterUtilTest, GetYMDAsDateReturnsNulloptForEmptyUtcDate) {
+  EXPECT_FALSE(GetYMDAsDate(/*ymd=*/"", /*use_utc=*/true));
+}
+
+TEST_F(BraveStatsUpdaterUtilTest,
+       GetYMDAsDateReturnsNulloptForInvalidOnePieceLocalDate) {
+  EXPECT_FALSE(GetYMDAsDate(/*ymd=*/"2018", /*use_utc=*/false));
+}
+
+TEST_F(BraveStatsUpdaterUtilTest,
+       GetYMDAsDateReturnsNulloptForInvalidOnePieceUtcDate) {
+  EXPECT_FALSE(GetYMDAsDate(/*ymd=*/"2018", /*use_utc=*/true));
+}
+
+TEST_F(BraveStatsUpdaterUtilTest,
+       GetYMDAsDateReturnsNulloptForInvalidTwoPiecesLocalDate) {
+  EXPECT_FALSE(GetYMDAsDate(/*ymd=*/"2018-06", /*use_utc=*/false));
+}
+
+TEST_F(BraveStatsUpdaterUtilTest,
+       GetYMDAsDateReturnsNulloptForInvalidTwoPiecesUtcDate) {
+  EXPECT_FALSE(GetYMDAsDate(/*ymd=*/"2018-06", /*use_utc=*/true));
+}
+
+TEST_F(BraveStatsUpdaterUtilTest,
+       GetYMDAsDateReturnsNulloptForNonNumericLocalDate) {
+  EXPECT_FALSE(GetYMDAsDate(/*ymd=*/"xxxx-xx-xx", /*use_utc=*/false));
+}
+
+TEST_F(BraveStatsUpdaterUtilTest,
+       GetYMDAsDateReturnsNulloptForNonNumericUtcDate) {
+  EXPECT_FALSE(GetYMDAsDate(/*ymd=*/"xxxx-xx-xx", /*use_utc=*/true));
+}
+
+TEST_F(BraveStatsUpdaterUtilTest,
+       GetYMDAsDateReturnsNulloptForInvalidLocalMonth) {
+  EXPECT_FALSE(GetYMDAsDate(/*ymd=*/"2018-13-01", /*use_utc=*/false));
+}
+
+TEST_F(BraveStatsUpdaterUtilTest,
+       GetYMDAsDateReturnsNulloptForInvalidUtcMonth) {
+  EXPECT_FALSE(GetYMDAsDate(/*ymd=*/"2018-13-01", /*use_utc=*/true));
+}
+
+TEST_F(BraveStatsUpdaterUtilTest,
+       GetYMDAsDateReturnsNulloptForInvalidLocalDay) {
+  EXPECT_FALSE(GetYMDAsDate(/*ymd=*/"2018-02-32", /*use_utc=*/false));
+}
+
+TEST_F(BraveStatsUpdaterUtilTest, GetYMDAsDateReturnsNulloptForInvalidUtcDay) {
+  EXPECT_FALSE(GetYMDAsDate(/*ymd=*/"2018-02-32", /*use_utc=*/true));
+}
+
+TEST_F(BraveStatsUpdaterUtilTest, GetDateAsYMDFormatsLocalDate) {
+  const base::Time time = TimeFromLocal(2018, 6, 22);
+  EXPECT_EQ("2018-06-22", GetDateAsYMD(time, /*use_utc=*/false));
+}
+
+TEST_F(BraveStatsUpdaterUtilTest, GetDateAsYMDCorrectlyFormatsUtcDate) {
+  const base::Time time = TimeFromUTC(2018, 6, 22);
+  EXPECT_EQ("2018-06-22", GetDateAsYMD(time, /*use_utc=*/true));
+}
+
+TEST_F(BraveStatsUpdaterUtilTest,
+       GetDateAsYMDReturnsOriginalStringForLocalTime) {
+  std::optional<base::Time> time =
+      GetYMDAsDate(/*ymd=*/"2018-06-22", /*use_utc=*/false);
+  ASSERT_TRUE(time);
+  EXPECT_EQ("2018-06-22", GetDateAsYMD(*time, /*use_utc=*/false));
+}
+
+TEST_F(BraveStatsUpdaterUtilTest, GetDateAsYMDReturnsOriginalStringForUtcTime) {
+  std::optional<base::Time> time =
+      GetYMDAsDate(/*ymd=*/"2018-06-22", /*use_utc=*/true);
+  ASSERT_TRUE(time);
+  EXPECT_EQ("2018-06-22", GetDateAsYMD(*time, /*use_utc=*/true));
+}
+
+TEST_F(BraveStatsUpdaterUtilTest, GetYMDAsDateForLocalTime) {
+  const base::Time time = TimeFromLocal(/*year=*/2018, /*month=*/6, /*day=*/22);
+  const std::string ymd = GetDateAsYMD(time, /*use_utc=*/false);
+  EXPECT_EQ(time, GetYMDAsDate(ymd, /*use_utc=*/false));
+}
+
+TEST_F(BraveStatsUpdaterUtilTest, GetYMDAsDateForUtcTime) {
+  const base::Time time = TimeFromUTC(/*year=*/2018, /*month=*/6, /*day=*/22);
+  const std::string ymd = GetDateAsYMD(time, /*use_utc=*/true);
+  EXPECT_EQ(time, GetYMDAsDate(ymd, /*use_utc=*/true));
+}
+
+}  // namespace brave_stats

--- a/components/brave_stats/browser/brave_stats_updater_util.cc
+++ b/components/brave_stats/browser/brave_stats_updater_util.cc
@@ -7,10 +7,9 @@
 
 #include <ctime>
 #include <memory>
+#include <optional>
 #include <string_view>
 
-#include "base/check.h"
-#include "base/check_op.h"
 #include "base/environment.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/string_split.h"
@@ -107,30 +106,32 @@ base::Time GetLastMondayTime(const base::Time& time) {
   return last_monday;
 }
 
-base::Time GetYMDAsDate(std::string_view ymd, bool use_utc) {
+std::optional<base::Time> GetYMDAsDate(std::string_view ymd, bool use_utc) {
   const auto pieces = base::SplitStringPiece(ymd, "-", base::TRIM_WHITESPACE,
                                              base::SPLIT_WANT_NONEMPTY);
-  DCHECK_EQ(pieces.size(), 3ull);
-  base::Time::Exploded time = {};
-
-  bool ok = base::StringToInt(pieces[0], &time.year);
-  DCHECK(ok);
-  ok = base::StringToInt(pieces[1], &time.month);
-  DCHECK(ok);
-  ok = base::StringToInt(pieces[2], &time.day_of_month);
-  DCHECK(ok);
-
-  DCHECK(time.HasValidValues());
-
-  base::Time result;
-  if (use_utc) {
-    ok = base::Time::FromUTCExploded(time, &result);
-  } else {
-    ok = base::Time::FromLocalExploded(time, &result);
+  if (pieces.size() != 3U) {
+    return std::nullopt;
   }
-  DCHECK(ok);
 
-  return result;
+  base::Time::Exploded exploded = {};
+  if (!base::StringToInt(pieces.at(0), &exploded.year) ||
+      !base::StringToInt(pieces.at(1), &exploded.month) ||
+      !base::StringToInt(pieces.at(2), &exploded.day_of_month)) {
+    return std::nullopt;
+  }
+
+  if (!exploded.HasValidValues()) {
+    return std::nullopt;
+  }
+
+  base::Time date;
+  const bool success = use_utc ? base::Time::FromUTCExploded(exploded, &date)
+                               : base::Time::FromLocalExploded(exploded, &date);
+  if (!success) {
+    return std::nullopt;
+  }
+
+  return date;
 }
 
 std::string GetAPIKey() {

--- a/components/brave_stats/browser/brave_stats_updater_util.h
+++ b/components/brave_stats/browser/brave_stats_updater_util.h
@@ -6,6 +6,7 @@
 #ifndef BRAVE_COMPONENTS_BRAVE_STATS_BROWSER_BRAVE_STATS_UPDATER_UTIL_H_
 #define BRAVE_COMPONENTS_BRAVE_STATS_BROWSER_BRAVE_STATS_UPDATER_UTIL_H_
 
+#include <optional>
 #include <string>
 #include <string_view>
 
@@ -27,7 +28,8 @@ int GetIsoWeekNumber(const base::Time& time);
 
 base::Time GetLastMondayTime(const base::Time& time);
 
-base::Time GetYMDAsDate(std::string_view ymd, bool use_utc = false);
+std::optional<base::Time> GetYMDAsDate(std::string_view ymd,
+                                       bool use_utc = false);
 
 std::string GetAPIKey();
 

--- a/ios/browser/api/brave_stats/brave_stats.mm
+++ b/ios/browser/api/brave_stats/brave_stats.mm
@@ -5,6 +5,7 @@
 
 #include "brave/ios/browser/api/brave_stats/brave_stats.h"
 
+#include "base/check.h"
 #include "base/memory/raw_ptr.h"
 #include "base/strings/sys_string_conversions.h"
 #include "base/time/time.h"
@@ -61,7 +62,18 @@ NSString* const kWebcompatReportEndpoint =
     return nil;
   }
   // Daily usage pings on iOS use UTC for the date boundary.
-  return brave_stats::GetYMDAsDate(ymd, /*use_utc=*/true).ToNSDate();
+  std::optional<base::Time> time =
+      brave_stats::GetYMDAsDate(ymd, /*use_utc=*/true);
+  if (!time) {
+    // If we can't parse the last daily usage ping date, reset it to today to
+    // avoid double reporting of previous daily usage pings data.
+    const std::string ymd_today =
+        brave_stats::GetDateAsYMD(base::Time::Now(), /*use_utc=*/true);
+    _localPrefs->SetString(kLastCheckYMD, ymd_today);
+    time = brave_stats::GetYMDAsDate(ymd_today, /*use_utc=*/true);
+    CHECK(time);
+  }
+  return time->ToNSDate();
 }
 
 - (void)setLastPingDate:(NSDate*)date {


### PR DESCRIPTION
A non parseable date in the `brave.stats.last_check_ymd` preference causes a crash
on iOS. To fix this, the date parser now returns a failure indicator so callers can
safely handle invalid last daily usage ping values. This aligns the behavior with SERP
metrics, which already handles non parseable `brave.stats.last_check_ymd` values.

The current PR aligns iOS with Desktop and Android, where browser is not crashing if pref is 
not parseable for any reason.

List to how this is handled in SERP metrics: 
https://github.com/brave/brave-core/blame/e9f4285068a4f4ac28a095e6913cce8e9c7d23d7/components/serp_metrics/serp_metrics.cc#L179

This is a follow-up to https://github.com/brave/brave-core/pull/35385.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
