### PR TITLE
Delegate pinned tab width to Chromium when horizontal tabs update is off

### DIFF
--- a/browser/ui/views/tabs/brave_tab_unittest.cc
+++ b/browser/ui/views/tabs/brave_tab_unittest.cc
@@ -27,6 +27,7 @@
 #include "testing/gtest/include/gtest/gtest.h"
 #include "third_party/skia/include/core/SkPath.h"
 #include "third_party/skia/include/core/SkRegion.h"
+#include "ui/gfx/favicon_size.h"
 #include "ui/gfx/geometry/insets.h"
 #include "ui/gfx/geometry/rect.h"
 #include "ui/gfx/geometry/skia_conversions.h"
@@ -175,46 +176,45 @@ TEST_F(BraveTabTest, TabStyleTest) {
             tab_style->GetMinimumActiveWidth(/*is_split*/ false));
 }
 
-// Regression test for https://github.com/brave/brave-browser/issues/54972.
-//
-// Before the fix, BraveTabStyle::GetPinnedWidth() returned Brave's compact
-// 38 DIP value regardless of the kBraveHorizontalTabsUpdate flag state.
-// Chromium's classic painting code (TabStyleViewsImpl::GetPath) insets the
-// drawn path by GetBottomCornerRadius() (12 DIP) on each side, so a 38 DIP
-// pinned tab was rendered as a ~14 DIP sliver and visually unreadable when
-// the Updated horizontal tabs design flag was disabled.
-//
-// The fix delegates GetPinnedWidth to the upstream TabStyle implementation
-// when kBraveHorizontalTabsUpdate is disabled, producing a tab wide enough
-// to be paintable by upstream's classic path logic.
+// https://github.com/brave/brave-browser/issues/54972 — pinned tab width must
+// stay consistent with painting: the classic tab path insets the shape by
+// GetBottomCornerRadius() on each side, so the layout width must leave a usable
+// content region (including a favicon) after that inset.
+
+// With kBraveHorizontalTabsUpdate off, GetPinnedWidth() and GetContentsInsets()
+// follow Chromium: pinned width is kTabPinnedContentWidth plus the horizontal
+// content insets (see TabStyle::GetPinnedWidth() in tab_style.cc).
 TEST_F(BraveTabTest, PinnedTabWidthDelegatesUpstreamWhenHorizontalUpdateOff) {
   base::test::ScopedFeatureList feature_list;
   feature_list.InitAndDisableFeature(tabs::kBraveHorizontalTabsUpdate);
 
   const auto* tab_style = TabStyle::Get();
 
-  // When the flag is off, GetContentsInsets() also delegates to upstream, so
-  // the pinned width matches the upstream formula:
-  //   kTabPinnedContentWidth + GetContentsInsets().left() +
-  //                            GetContentsInsets().right()
-  // (see TabStyle::GetPinnedWidth() in chrome/browser/ui/tabs/tab_style.cc).
   constexpr int kTabPinnedContentWidth = 24;
   const auto insets = tab_style->GetContentsInsets();
   const int expected_unsplit =
       kTabPinnedContentWidth + insets.left() + insets.right();
   EXPECT_EQ(expected_unsplit, tab_style->GetPinnedWidth(/*is_split=*/false));
 
-  // Split tabs trim half of the tab overlap, also matching upstream.
   EXPECT_EQ(expected_unsplit - tab_style->GetTabOverlap() / 2,
             tab_style->GetPinnedWidth(/*is_split=*/true));
 
-  // Sanity check: the painted region must fit a favicon (16 DIP) after the
-  // path is inset by GetBottomCornerRadius() on each side. This is the
-  // property that was broken before the fix.
-  constexpr int kFaviconSize = 16;
   EXPECT_GE(tab_style->GetPinnedWidth(/*is_split=*/false) -
                 2 * tab_style->GetBottomCornerRadius(),
-            kFaviconSize);
+            gfx::kFaviconSize);
+}
+
+// With kBraveHorizontalTabsUpdate on, Brave uses its horizontal tab layout for
+// pinned width (see BraveTabStyle::GetPinnedWidth in tab_style.cc).
+TEST_F(BraveTabTest, PinnedTabWidthMatchesBraveLayoutWhenHorizontalUpdateOn) {
+  base::test::ScopedFeatureList feature_list;
+  feature_list.InitAndEnableFeature(tabs::kBraveHorizontalTabsUpdate);
+
+  const auto* tab_style = TabStyle::Get();
+  const int expected =
+      tabs::GetHorizontalTabHeight() + tabs::kHorizontalTabInset * 2;
+  EXPECT_EQ(expected, tab_style->GetPinnedWidth(/*is_split=*/false));
+  EXPECT_EQ(expected, tab_style->GetPinnedWidth(/*is_split=*/true));
 }
 
 TEST_F(BraveTabTest, ShouldAlwaysHideTabCloseButton) {

--- a/browser/ui/views/tabs/brave_tab_unittest.cc
+++ b/browser/ui/views/tabs/brave_tab_unittest.cc
@@ -5,6 +5,7 @@
 
 #include "brave/browser/ui/views/tabs/brave_tab.h"
 
+#include "base/test/scoped_feature_list.h"
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
 #include "brave/browser/ui/views/tabs/brave_tab_strip_layout_helper.h"
 #include "brave/components/tabs/public/tree_tab_node.h"
@@ -172,6 +173,48 @@ TEST_F(BraveTabTest, TabStyleTest) {
             tab_style->GetStandardWidth(/*is_split*/ false));
   EXPECT_EQ(tab_style->GetMinimumActiveWidth(/*is_split*/ true),
             tab_style->GetMinimumActiveWidth(/*is_split*/ false));
+}
+
+// Regression test for https://github.com/brave/brave-browser/issues/54972.
+//
+// Before the fix, BraveTabStyle::GetPinnedWidth() returned Brave's compact
+// 38 DIP value regardless of the kBraveHorizontalTabsUpdate flag state.
+// Chromium's classic painting code (TabStyleViewsImpl::GetPath) insets the
+// drawn path by GetBottomCornerRadius() (12 DIP) on each side, so a 38 DIP
+// pinned tab was rendered as a ~14 DIP sliver and visually unreadable when
+// the Updated horizontal tabs design flag was disabled.
+//
+// The fix delegates GetPinnedWidth to the upstream TabStyle implementation
+// when kBraveHorizontalTabsUpdate is disabled, producing a tab wide enough
+// to be paintable by upstream's classic path logic.
+TEST_F(BraveTabTest, PinnedTabWidthDelegatesUpstreamWhenHorizontalUpdateOff) {
+  base::test::ScopedFeatureList feature_list;
+  feature_list.InitAndDisableFeature(tabs::kBraveHorizontalTabsUpdate);
+
+  const auto* tab_style = TabStyle::Get();
+
+  // When the flag is off, GetContentsInsets() also delegates to upstream, so
+  // the pinned width matches the upstream formula:
+  //   kTabPinnedContentWidth + GetContentsInsets().left() +
+  //                            GetContentsInsets().right()
+  // (see TabStyle::GetPinnedWidth() in chrome/browser/ui/tabs/tab_style.cc).
+  constexpr int kTabPinnedContentWidth = 24;
+  const auto insets = tab_style->GetContentsInsets();
+  const int expected_unsplit =
+      kTabPinnedContentWidth + insets.left() + insets.right();
+  EXPECT_EQ(expected_unsplit, tab_style->GetPinnedWidth(/*is_split=*/false));
+
+  // Split tabs trim half of the tab overlap, also matching upstream.
+  EXPECT_EQ(expected_unsplit - tab_style->GetTabOverlap() / 2,
+            tab_style->GetPinnedWidth(/*is_split=*/true));
+
+  // Sanity check: the painted region must fit a favicon (16 DIP) after the
+  // path is inset by GetBottomCornerRadius() on each side. This is the
+  // property that was broken before the fix.
+  constexpr int kFaviconSize = 16;
+  EXPECT_GE(tab_style->GetPinnedWidth(/*is_split=*/false) -
+                2 * tab_style->GetBottomCornerRadius(),
+            kFaviconSize);
 }
 
 TEST_F(BraveTabTest, ShouldAlwaysHideTabCloseButton) {

--- a/chromium_src/chrome/browser/ui/tabs/tab_style.cc
+++ b/chromium_src/chrome/browser/ui/tabs/tab_style.cc
@@ -47,6 +47,9 @@ class BraveTabStyle : public TabStyle {
   }
 
   int GetPinnedWidth(const bool is_split) const override {
+    if (!tabs::HorizontalTabsUpdateEnabled()) {
+      return TabStyle::GetPinnedWidth(is_split);
+    }
     // We can ignore |is_split| because we're always using same width.
     return tabs::GetHorizontalTabHeight() + tabs::kHorizontalTabInset * 2;
   }


### PR DESCRIPTION
When kBraveHorizontalTabsUpdate is disabled, BraveTabStyle::GetPinnedWidth still returned the compact new-design width (~38 DIP). Upstream tab painting insets the path by the bottom corner radius on each side, so pinned tabs looked like a ~14 DIP strip (brave-browser#54972). Delegate to TabStyle::GetPinnedWidth when the flag is off so layout matches classic painting.

Add a BraveTabTest that asserts the upstream formula and a favicon-size sanity check when the feature is disabled.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/54972

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
