### PR TITLE
[PSST] Add consent dialog back-end

### DIFF
--- a/android/android_browser_tests.gni
+++ b/android/android_browser_tests.gni
@@ -82,7 +82,6 @@ android_test_exception_deps = [
   "//brave/browser/farbling:browser_tests",
   "//brave/browser/net:browser_tests",
   "//brave/browser/permissions:browser_tests",
-  "//brave/browser/psst:browser_tests",
   "//brave/browser/test:browser_tests",
   "//brave/browser/ui:browser_tests",
   "//brave/browser/ui/tabs/test:browser_tests",

--- a/brave_paks.gni
+++ b/brave_paks.gni
@@ -6,6 +6,7 @@
 import("//brave/components/ai_chat/core/common/buildflags/buildflags.gni")
 import("//brave/components/brave_origin/buildflags/buildflags.gni")
 import("//brave/components/brave_rewards/core/buildflags/buildflags.gni")
+import("//brave/components/psst/buildflags/buildflags.gni")
 import("//brave/components/tor/buildflags/buildflags.gni")
 import("//build/config/locales.gni")
 import("//chrome/common/features.gni")
@@ -114,6 +115,11 @@ template("brave_extra_paks") {
           [ "$root_gen_dir/brave/components/tor/resources/tor_resources.pak" ]
 
       deps += [ "//brave/components/tor/resources" ]
+    }
+
+    if (enable_psst) {
+      sources += [ "$root_gen_dir/brave/components/psst/resources/brave_psst_resources.pak" ]
+      deps += [ "//brave/components/psst/resources" ]
     }
 
     if (enable_extensions) {

--- a/browser/brave_content_browser_client.cc
+++ b/browser/brave_content_browser_client.cc
@@ -89,6 +89,7 @@
 #include "brave/components/ntp_background_images/browser/mojom/ntp_background_images.mojom.h"
 #include "brave/components/password_strength_meter/password_strength_meter.mojom.h"
 #include "brave/components/playlist/core/common/buildflags/buildflags.h"
+#include "brave/components/psst/buildflags/buildflags.h"
 #include "brave/components/request_otr/common/buildflags/buildflags.h"
 #include "brave/components/skus/common/features.h"
 #include "brave/components/skus/common/skus_internals.mojom.h"
@@ -324,6 +325,11 @@ using extensions::ChromeContentBrowserClientExtensionsPart;
 
 #if BUILDFLAG(ENABLE_BRAVE_EDUCATION)
 #include "brave/browser/ui/webui/brave_education/brave_education_page_ui.h"
+#endif
+
+#if BUILDFLAG(ENABLE_PSST)
+#include "brave/browser/ui/webui/psst/brave_psst_dialog_ui.h"
+#include "brave/components/psst/common/psst_ui_common.mojom-shared.h"
 #endif
 
 #if BUILDFLAG(IS_BRAVE_ORIGIN_BRANDED)
@@ -797,6 +803,11 @@ void BraveContentBrowserClient::RegisterTrustedWebUIInterfaceBrokers(
         .Add<password_strength_meter::mojom::PasswordStrengthMeter>();
   }
 #endif  // !BUILDFLAG(IS_ANDROID)
+
+#if BUILDFLAG(ENABLE_PSST)
+  registry.ForWebUI<psst::BravePsstDialogUI>()
+      .Add<psst::mojom::PsstConsentFactory>();
+#endif
 }
 
 void BraveContentBrowserClient::RegisterUntrustedWebUIInterfaceBrokers(

--- a/browser/psst/BUILD.gn
+++ b/browser/psst/BUILD.gn
@@ -19,6 +19,8 @@ static_library("psst") {
     "psst_ui_desktop_presenter.cc",
   ]
 
+  public_deps = [ "//ui/web_dialogs" ]
+
   deps = [
     "//base",
     "//brave/app:brave_generated_resources_grit",
@@ -35,7 +37,6 @@ static_library("psst") {
     "//components/infobars/core",
     "//components/permissions",
     "//components/prefs",
-    "//ui/web_dialogs",
   ]
 }
 

--- a/browser/psst/BUILD.gn
+++ b/browser/psst/BUILD.gn
@@ -29,10 +29,13 @@ static_library("psst") {
     "//chrome/browser/content_settings:content_settings_factory",
     "//chrome/browser/infobars",
     "//chrome/browser/profiles",
+    "//chrome/browser/ui/dialogs",
+    "//chrome/browser/ui/webui",
     "//components/content_settings/core/browser",
     "//components/infobars/core",
     "//components/permissions",
     "//components/prefs",
+    "//ui/web_dialogs",
   ]
 }
 

--- a/browser/psst/BUILD.gn
+++ b/browser/psst/BUILD.gn
@@ -66,6 +66,7 @@ source_set("browser_tests") {
 
   deps = [
     "//base",
+    "//brave/browser/ui/webui/psst",
     "//brave/components/brave_shields/content/browser",
     "//brave/components/cosmetic_filters/browser",
     "//brave/components/psst/browser/content",

--- a/browser/psst/psst_settings_service_unittest.cc
+++ b/browser/psst/psst_settings_service_unittest.cc
@@ -29,12 +29,12 @@ base::DictValue CreatePsstSettingsDict(
     psst::ConsentStatus consent_status,
     int script_version,
     const std::string& user_id,
-    const std::vector<std::string>& urls_to_skip) {
+    const std::vector<std::string>& uids_to_perform) {
   base::DictValue object;
   object.Set("user_id", user_id);
   object.Set("consent_status", ToString(consent_status));
   object.Set("script_version", script_version);
-  object.Set("urls_to_skip", VectorToList(urls_to_skip));
+  object.Set("uids_to_perform", VectorToList(uids_to_perform));
   return object;
 }
 

--- a/browser/psst/psst_settings_service_unittest.cc
+++ b/browser/psst/psst_settings_service_unittest.cc
@@ -152,8 +152,8 @@ TEST_F(PsstSettingsServiceUnitTest, CreateOrUpdateMetadata) {
   ASSERT_EQ(first_metadata_value.value().script_version,
             first_metadata->script_version);
   ASSERT_EQ(first_metadata_value.value().user_id, first_metadata->user_id);
-  ASSERT_EQ(first_metadata_value.value().urls_to_skip,
-            first_metadata->urls_to_skip);
+  ASSERT_EQ(first_metadata_value.value().uids_to_perform,
+            first_metadata->uids_to_perform);
 
   auto second_metadata_value = settings_service()->GetPsstWebsiteSettings(
       origin, second_metadata->user_id);
@@ -163,8 +163,8 @@ TEST_F(PsstSettingsServiceUnitTest, CreateOrUpdateMetadata) {
   ASSERT_EQ(second_metadata_value.value().script_version,
             second_metadata->script_version);
   ASSERT_EQ(second_metadata_value.value().user_id, second_metadata->user_id);
-  ASSERT_EQ(second_metadata_value.value().urls_to_skip,
-            second_metadata->urls_to_skip);
+  ASSERT_EQ(second_metadata_value.value().uids_to_perform,
+            second_metadata->uids_to_perform);
 
   const auto modified_metadata =
       PsstWebsiteSettings::FromValue(CreatePsstSettingsDict(
@@ -184,8 +184,8 @@ TEST_F(PsstSettingsServiceUnitTest, CreateOrUpdateMetadata) {
             modified_metadata->script_version);
   ASSERT_EQ(modified_metadata_value.value().user_id,
             modified_metadata->user_id);
-  ASSERT_EQ(modified_metadata_value.value().urls_to_skip,
-            modified_metadata->urls_to_skip);
+  ASSERT_EQ(modified_metadata_value.value().uids_to_perform,
+            modified_metadata->uids_to_perform);
 }
 
 }  // namespace psst

--- a/browser/psst/psst_tab_web_contents_observer_browsertest.cc
+++ b/browser/psst/psst_tab_web_contents_observer_browsertest.cc
@@ -26,15 +26,19 @@
 #include "components/infobars/content/content_infobar_manager.h"
 #include "components/infobars/core/confirm_infobar_delegate.h"
 #include "components/infobars/core/infobar.h"
+#include "content/public/browser/web_contents.h"
 #include "content/public/test/browser_test.h"
 #include "content/public/test/browser_test_utils.h"
 #include "net/dns/mock_host_resolver.h"
 #include "net/test/embedded_test_server/embedded_test_server.h"
 #include "testing/gtest/include/gtest/gtest.h"
+#include "url/gurl.h"
 
 namespace psst {
 
 namespace {
+constexpr char kExpectedSchema[] = "chrome";
+constexpr char kExpectedHost[] = "psst";
 
 class InfobarObserver : public infobars::InfoBarManager::Observer {
  public:
@@ -117,23 +121,6 @@ infobars::InfoBar* GetPsstInfobar(infobars::ContentInfoBarManager* manager) {
   return *infobar;
 }
 
-class DialogCloseObserver : public content::WebContentsObserver {
- public:
-  explicit DialogCloseObserver(content::WebContents* web_contents)
-      : content::WebContentsObserver(web_contents) {}
-
-  void OnVisibilityChanged(content::Visibility visibility) override {
-    if (visibility == content::Visibility::HIDDEN) {
-      run_loop_.Quit();
-    }
-  }
-
-  void Wait() { run_loop_.Run(); }
-
- private:
-  base::RunLoop run_loop_;
-};
-
 }  // namespace
 
 class PsstTabWebContentsObserverBrowserTest : public PlatformBrowserTest {
@@ -177,79 +164,39 @@ class PsstTabWebContentsObserverBrowserTest : public PlatformBrowserTest {
     return chrome_test_utils::GetActiveWebContents(this);
   }
 
-  content::WebContents* WaitForAndGetDialogWebContents() {
-    auto start_time = base::TimeTicks::Now();
-    const auto timeout = base::Seconds(10);  // 10 second timeout
-
-    base::RunLoop run_loop;
-    base::RepeatingTimer timer;
-    content::WebContents* result = nullptr;
-    timer.Start(FROM_HERE, base::Milliseconds(100),
-                base::BindLambdaForTesting([&, start_time, timeout]() {
-                  if (base::TimeTicks::Now() - start_time >= timeout) {
-                    timer.Stop();
-                    run_loop.Quit();
-                    return;
-                  }
-
-                  std::vector<content::WebContents*> all_web_contents =
-                      content::GetAllWebContents();
-
-                  for (auto* wc : all_web_contents) {
-                    GURL url = wc->GetLastCommittedURL();
-                    // Look for chrome://psst URL
-                    if (url.SchemeIs("chrome") && url.host() == "psst") {
-                      timer.Stop();
-                      run_loop.Quit();
-                      result = wc;
-                      return;
-                    }
-                  }
-                }));
-
-    // Wait for the timer to find the dialog or timeout
-    run_loop.Run();
-    EXPECT_TRUE(result) << "Timeout waiting for dialog to appear";
-    return result;
+  content::WebContents* WaitForAndGetDialogWebContents(
+      content::CreateAndLoadWebContentsObserver& new_web_contents_observer) {
+    GURL current_url;
+    content::WebContents* dialog_wc = nullptr;
+    do {
+      dialog_wc = new_web_contents_observer.Wait();
+      if (dialog_wc) {
+        current_url = dialog_wc->GetLastCommittedURL();
+      }
+    } while (!current_url.SchemeIs(kExpectedSchema) &&
+             current_url.host() != kExpectedHost);
+    return dialog_wc;
   }
 
   bool AcceptModalDialog(content::WebContents* dialog_wc,
                          const std::string& site_name,
                          const std::vector<std::string>& perform_for_uids) {
+    if (!dialog_wc) {
+      return false;
+    }
+
     auto* dialog_ui =
         dialog_wc->GetWebUI()->GetController()->GetAs<BravePsstDialogUI>();
     if (!dialog_ui) {
       return false;
     }
 
-    auto start_time = base::TimeTicks::Now();
-    const auto timeout = base::Seconds(10);  // 10 second timeout
+    if (dialog_ui->psst_consent_handler_) {
+      dialog_ui->psst_consent_handler_->PerformPrivacyTuning(perform_for_uids);
+      return true;
+    }
 
-    base::RunLoop run_loop;
-    base::RepeatingTimer timer;
-
-    bool is_found = false;
-    timer.Start(FROM_HERE, base::Milliseconds(100),
-                base::BindLambdaForTesting([&, start_time, timeout]() {
-                  if (base::TimeTicks::Now() - start_time >= timeout) {
-                    timer.Stop();
-                    run_loop.Quit();
-                    return;
-                  }
-
-                  if (dialog_ui->psst_consent_handler_) {
-                    timer.Stop();
-                    run_loop.Quit();
-                    dialog_ui->psst_consent_handler_->PerformPrivacyTuning(
-                        perform_for_uids);
-                    is_found = true;
-                    return;
-                  }
-                }));
-
-    // Wait for the timer to find the dialog or timeout
-    run_loop.Run();
-    return is_found;
+    return false;
   }
 
   bool CloseModalDialog(content::WebContents* dialog_wc) {
@@ -281,6 +228,7 @@ IN_PROC_BROWSER_TEST_F(PsstTabWebContentsObserverBrowserTest,
 
   InfobarObserver infobar_observer(
       manager, infobars::InfoBarDelegate::BRAVE_PSST_INFOBAR_DELEGATE);
+  content::CreateAndLoadWebContentsObserver new_web_contents_observer;
 
   std::u16string expected_title(u"a_user-a_policy");
   content::TitleWatcher watcher(web_contents(), expected_title);
@@ -294,7 +242,7 @@ IN_PROC_BROWSER_TEST_F(PsstTabWebContentsObserverBrowserTest,
             infobars::InfoBarDelegate::BRAVE_PSST_INFOBAR_DELEGATE);
   confirm_delegate->Accept();
 
-  auto* dialog_wc = WaitForAndGetDialogWebContents();
+  auto* dialog_wc = WaitForAndGetDialogWebContents(new_web_contents_observer);
   ASSERT_TRUE(dialog_wc);
 
   const std::vector<std::string> perform_uids = {"1", "2"};

--- a/browser/psst/psst_tab_web_contents_observer_browsertest.cc
+++ b/browser/psst/psst_tab_web_contents_observer_browsertest.cc
@@ -166,15 +166,19 @@ class PsstTabWebContentsObserverBrowserTest : public PlatformBrowserTest {
 
   content::WebContents* WaitForAndGetDialogWebContents(
       content::CreateAndLoadWebContentsObserver& new_web_contents_observer) {
+    int iterations_count = 5;
     GURL current_url;
     content::WebContents* dialog_wc = nullptr;
     do {
+      if (--iterations_count <= 0) {
+        break;
+      }
       dialog_wc = new_web_contents_observer.Wait();
       if (dialog_wc) {
         current_url = dialog_wc->GetLastCommittedURL();
       }
-    } while (!current_url.SchemeIs(kExpectedSchema) ||
-             current_url.host() != kExpectedHost);
+    } while (dialog_wc && (!current_url.SchemeIs(kExpectedSchema) ||
+                           current_url.host() != kExpectedHost));
     return dialog_wc;
   }
 

--- a/browser/psst/psst_tab_web_contents_observer_browsertest.cc
+++ b/browser/psst/psst_tab_web_contents_observer_browsertest.cc
@@ -173,7 +173,7 @@ class PsstTabWebContentsObserverBrowserTest : public PlatformBrowserTest {
       if (dialog_wc) {
         current_url = dialog_wc->GetLastCommittedURL();
       }
-    } while (!current_url.SchemeIs(kExpectedSchema) &&
+    } while (!current_url.SchemeIs(kExpectedSchema) ||
              current_url.host() != kExpectedHost);
     return dialog_wc;
   }

--- a/browser/psst/psst_tab_web_contents_observer_browsertest.cc
+++ b/browser/psst/psst_tab_web_contents_observer_browsertest.cc
@@ -13,6 +13,7 @@
 #include "base/test/bind.h"
 #include "base/test/scoped_feature_list.h"
 #include "base/test/test_future.h"
+#include "brave/browser/ui/webui/psst/brave_psst_dialog_ui.h"
 #include "brave/components/psst/browser/core/psst_rule.h"
 #include "brave/components/psst/browser/core/psst_rule_registry.h"
 #include "brave/components/psst/buildflags/buildflags.h"
@@ -116,6 +117,23 @@ infobars::InfoBar* GetPsstInfobar(infobars::ContentInfoBarManager* manager) {
   return *infobar;
 }
 
+class DialogCloseObserver : public content::WebContentsObserver {
+ public:
+  explicit DialogCloseObserver(content::WebContents* web_contents)
+      : content::WebContentsObserver(web_contents) {}
+
+  void OnVisibilityChanged(content::Visibility visibility) override {
+    if (visibility == content::Visibility::HIDDEN) {
+      run_loop_.Quit();
+    }
+  }
+
+  void Wait() { run_loop_.Run(); }
+
+ private:
+  base::RunLoop run_loop_;
+};
+
 }  // namespace
 
 class PsstTabWebContentsObserverBrowserTest : public PlatformBrowserTest {
@@ -159,6 +177,95 @@ class PsstTabWebContentsObserverBrowserTest : public PlatformBrowserTest {
     return chrome_test_utils::GetActiveWebContents(this);
   }
 
+  content::WebContents* WaitForAndGetDialogWebContents() {
+    auto start_time = base::TimeTicks::Now();
+    const auto timeout = base::Seconds(10);  // 10 second timeout
+
+    base::RunLoop run_loop;
+    base::RepeatingTimer timer;
+    content::WebContents* result = nullptr;
+    timer.Start(FROM_HERE, base::Milliseconds(100),
+                base::BindLambdaForTesting([&, start_time, timeout]() {
+                  if (base::TimeTicks::Now() - start_time >= timeout) {
+                    timer.Stop();
+                    run_loop.Quit();
+                    return;
+                  }
+
+                  std::vector<content::WebContents*> all_web_contents =
+                      content::GetAllWebContents();
+
+                  for (auto* wc : all_web_contents) {
+                    GURL url = wc->GetLastCommittedURL();
+                    // Look for chrome://psst URL
+                    if (url.SchemeIs("chrome") && url.host() == "psst") {
+                      timer.Stop();
+                      run_loop.Quit();
+                      result = wc;
+                      return;
+                    }
+                  }
+                }));
+
+    // Wait for the timer to find the dialog or timeout
+    run_loop.Run();
+    EXPECT_TRUE(result) << "Timeout waiting for dialog to appear";
+    return result;
+  }
+
+  bool AcceptModalDialog(content::WebContents* dialog_wc,
+                         const std::string& site_name,
+                         const std::vector<std::string>& perform_for_uids) {
+    auto* dialog_ui =
+        dialog_wc->GetWebUI()->GetController()->GetAs<BravePsstDialogUI>();
+    if (!dialog_ui) {
+      return false;
+    }
+
+    auto start_time = base::TimeTicks::Now();
+    const auto timeout = base::Seconds(10);  // 10 second timeout
+
+    base::RunLoop run_loop;
+    base::RepeatingTimer timer;
+
+    bool is_found = false;
+    timer.Start(FROM_HERE, base::Milliseconds(100),
+                base::BindLambdaForTesting([&, start_time, timeout]() {
+                  if (base::TimeTicks::Now() - start_time >= timeout) {
+                    timer.Stop();
+                    run_loop.Quit();
+                    return;
+                  }
+
+                  if (dialog_ui->psst_consent_handler_) {
+                    timer.Stop();
+                    run_loop.Quit();
+                    dialog_ui->psst_consent_handler_->PerformPrivacyTuning(
+                        perform_for_uids);
+                    is_found = true;
+                    return;
+                  }
+                }));
+
+    // Wait for the timer to find the dialog or timeout
+    run_loop.Run();
+    return is_found;
+  }
+
+  bool CloseModalDialog(content::WebContents* dialog_wc) {
+    auto* dialog_ui =
+        dialog_wc->GetWebUI()->GetController()->GetAs<BravePsstDialogUI>();
+    if (!dialog_ui) {
+      return false;
+    }
+    if (dialog_ui->psst_consent_handler_) {
+      dialog_ui->psst_consent_handler_->CloseDialog();
+      return true;
+    }
+
+    return false;
+  }
+
  protected:
   base::ScopedTempDir component_dir_;
   net::EmbeddedTestServer https_server_;
@@ -187,7 +294,16 @@ IN_PROC_BROWSER_TEST_F(PsstTabWebContentsObserverBrowserTest,
             infobars::InfoBarDelegate::BRAVE_PSST_INFOBAR_DELEGATE);
   confirm_delegate->Accept();
 
+  auto* dialog_wc = WaitForAndGetDialogWebContents();
+  ASSERT_TRUE(dialog_wc);
+
+  const std::vector<std::string> perform_uids = {"1", "2"};
+  // Accept the consent dialog to continue the flow and apply PSST settings
+  ASSERT_TRUE(AcceptModalDialog(
+      dialog_wc, url::Origin::Create(url).GetURL().spec(), perform_uids));
+
   EXPECT_EQ(expected_title, watcher.WaitAndGetTitle());
+  ASSERT_TRUE(CloseModalDialog(dialog_wc));
   EXPECT_TRUE(GetPrefs()->GetBoolean(prefs::kPsstEnabled));
 }
 

--- a/browser/psst/psst_tab_web_contents_observer_browsertest.cc
+++ b/browser/psst/psst_tab_web_contents_observer_browsertest.cc
@@ -205,12 +205,9 @@ class PsstTabWebContentsObserverBrowserTest : public PlatformBrowserTest {
     if (!dialog_ui) {
       return false;
     }
-    if (dialog_ui->psst_consent_handler_) {
-      dialog_ui->psst_consent_handler_->CloseDialog();
-      return true;
-    }
 
-    return false;
+    dialog_ui->Close();
+    return true;
   }
 
  protected:

--- a/browser/psst/psst_ui_delegate_impl.cc
+++ b/browser/psst/psst_ui_delegate_impl.cc
@@ -25,14 +25,17 @@ PsstUiDelegateImpl::PsstUiDelegateImpl(
 PsstUiDelegateImpl::~PsstUiDelegateImpl() = default;
 
 void PsstUiDelegateImpl::Show(
-    const url::Origin& origin,
+    url::Origin origin,
     PsstWebsiteSettings dialog_data,
+    std::optional<UserScriptResult> user_script_result,
     PsstTabWebContentsObserver::ConsentCallback apply_changes_callback) {
   apply_changes_callback_ = std::move(apply_changes_callback);
   dialog_data_ = std::move(dialog_data);
+  origin_ = std::move(origin);
+  user_script_result_ = std::move(user_script_result);
   ui_presenter_->ShowInfoBar(
       base::BindOnce(&PsstUiDelegateImpl::OnUserAcceptedInfobar,
-                     weak_ptr_factory_.GetWeakPtr(), std::move(origin)));
+                     weak_ptr_factory_.GetWeakPtr()));
 }
 
 void PsstUiDelegateImpl::UpdateTasks(
@@ -48,24 +51,54 @@ std::optional<PsstWebsiteSettings> PsstUiDelegateImpl::GetPsstWebsiteSettings(
   return psst_settings_service_->GetPsstWebsiteSettings(origin, user_id);
 }
 
-void PsstUiDelegateImpl::OnUserAcceptedPsstSettings(const url::Origin& origin) {
+void PsstUiDelegateImpl::AddObserver(Observer* obs) {
+  observer_list_.AddObserver(obs);
+}
+void PsstUiDelegateImpl::RemoveObserver(Observer* obs) {
+  observer_list_.RemoveObserver(obs);
+}
+base::WeakPtr<PsstUiDelegateImpl> PsstUiDelegateImpl::AsWeakPtr() {
+  return weak_ptr_factory_.GetWeakPtr();
+}
+
+psst::mojom::SettingCardDataPtr PsstUiDelegateImpl::GetShowDialogData() {
+  if (!origin_ || !user_script_result_.has_value() ||
+      user_script_result_->tasks.empty()) {
+    return nullptr;
+  }
+
+  std::vector<mojom::SettingCardDataItemPtr> items;
+  for (const auto& task : user_script_result_->tasks) {
+    items.push_back(
+        psst::mojom::SettingCardDataItem::New(task.description, task.uid));
+  }
+
+  return psst::mojom::SettingCardData::New(origin_->GetURL().spec(),
+                                           std::move(items));
+}
+
+void PsstUiDelegateImpl::OnUserAcceptedPsstSettings(
+    const std::vector<std::string>& perform_for_uids) {
+  CHECK(origin_);
+  CHECK(dialog_data_);
+  base::ListValue perform_for_uids_list;
+  for (const auto& item : perform_for_uids) {
+    perform_for_uids_list.Append(item);
+  }
   // Save the PSST settings when user accepts the dialog
   psst_settings_service_->SetPsstWebsiteSettings(
-      origin, ConsentStatus::kAllow, dialog_data_->script_version,
-      dialog_data_->user_id, base::ListValue());
+      origin_.value(), ConsentStatus::kAllow, dialog_data_->script_version,
+      dialog_data_->user_id, std::move(perform_for_uids_list));
 
   if (apply_changes_callback_) {
     std::move(apply_changes_callback_).Run();
   }
 }
 
-void PsstUiDelegateImpl::OnUserAcceptedInfobar(const url::Origin& origin,
-                                               const bool is_accepted) {
+void PsstUiDelegateImpl::OnUserAcceptedInfobar(const bool is_accepted) {
   // Handle the user's response to the infobar
   if (is_accepted) {
-    // Simulate the consent dialog is accepted by the user and apply PSST
-    // settings accordingly.
-    OnUserAcceptedPsstSettings(origin);
+    ui_presenter_->ShowConsentDialog();
   } else {
     // Disable PSST if user declined the infobar
     prefs_->SetBoolean(prefs::kPsstEnabled, false);

--- a/browser/psst/psst_ui_delegate_impl.h
+++ b/browser/psst/psst_ui_delegate_impl.h
@@ -14,6 +14,7 @@
 #include "brave/components/psst/browser/core/psst_settings_service.h"
 #include "brave/components/psst/common/psst_script_responses.h"
 #include "brave/components/psst/common/psst_ui_common.mojom-shared.h"
+#include "brave/components/psst/common/psst_ui_common.mojom.h"
 #include "components/content_settings/core/browser/host_content_settings_map.h"
 
 class PrefService;
@@ -22,6 +23,12 @@ namespace psst {
 
 class PsstUiDelegateImpl : public PsstTabWebContentsObserver::PsstUiDelegate {
  public:
+  class Observer : public base::CheckedObserver {
+   public:
+    virtual void OnSetRequestStatus(const std::string& uid,
+                                    const std::optional<std::string>& error) {}
+  };
+
   explicit PsstUiDelegateImpl(PsstSettingsService* psst_settings_service,
                               PrefService* prefs,
                               std::unique_ptr<PsstUiPresenter> ui_presenter);
@@ -30,28 +37,39 @@ class PsstUiDelegateImpl : public PsstTabWebContentsObserver::PsstUiDelegate {
   PsstUiDelegateImpl(const PsstUiDelegateImpl&) = delete;
   PsstUiDelegateImpl& operator=(const PsstUiDelegateImpl&) = delete;
 
-  void Show(const url::Origin& origin,
+  void Show(url::Origin origin,
             PsstWebsiteSettings dialog_data,
+            std::optional<UserScriptResult> user_script_result,
             PsstTabWebContentsObserver::ConsentCallback apply_changes_callback)
       override;
 
   // PsstUiDelegate overrides
   void UpdateTasks(long progress,
-                   const std::vector<PolicyTask>& applied_tasks,
+                   const std::vector<PolicyTask>& performed_tasks,
                    const mojom::PsstStatus status) override;
 
   std::optional<PsstWebsiteSettings> GetPsstWebsiteSettings(
       const url::Origin& origin,
       const std::string& user_id) override;
 
+  void AddObserver(Observer* obs);
+  void RemoveObserver(Observer* obs);
+  base::WeakPtr<PsstUiDelegateImpl> AsWeakPtr();
+
+  psst::mojom::SettingCardDataPtr GetShowDialogData();
+  void OnUserAcceptedPsstSettings(
+      const std::vector<std::string>& perform_for_uids);
+
  private:
-  void OnUserAcceptedPsstSettings(const url::Origin& origin);
-  void OnUserAcceptedInfobar(const url::Origin& origin, const bool is_accepted);
+  void OnUserAcceptedInfobar(const bool is_accepted);
 
   std::unique_ptr<PsstUiPresenter> ui_presenter_;
   std::optional<PsstWebsiteSettings> dialog_data_;
+  std::optional<url::Origin> origin_;
+  std::optional<UserScriptResult> user_script_result_;
   PsstTabWebContentsObserver::ConsentCallback apply_changes_callback_;
   raw_ptr<PsstSettingsService> psst_settings_service_ = nullptr;
+  base::ObserverList<Observer> observer_list_;
   raw_ptr<PrefService> prefs_ = nullptr;  // not owned
   base::WeakPtrFactory<PsstUiDelegateImpl> weak_ptr_factory_{this};
 };

--- a/browser/psst/psst_ui_desktop_presenter.cc
+++ b/browser/psst/psst_ui_desktop_presenter.cc
@@ -6,14 +6,120 @@
 #include "brave/browser/psst/psst_ui_desktop_presenter.h"
 
 #include "brave/browser/psst/psst_infobar_delegate.h"
+#include "brave/components/psst/common/constants.h"
+#include "chrome/browser/ui/webui/constrained_web_dialog_ui.h"
 #include "components/infobars/content/content_infobar_manager.h"
 #include "content/public/browser/web_contents.h"
 
+namespace {
+
+constexpr int kDialogMinHeight = 100;
+constexpr int kDialogMaxHeight = 700;
+constexpr int kDialogWidth = 475;
+const char kUiDesktopDelegateUserDataKey[] = "UiDesktopDelegateUserData";
+
+class UiDesktopDelegateUserData : public base::SupportsUserData::Data {
+ public:
+  explicit UiDesktopDelegateUserData(
+      psst::PsstUiDesktopPresenter::PsstUiDesktopDelegate* delegate)
+      : delegate_(delegate) {}
+  ~UiDesktopDelegateUserData() override = default;
+  UiDesktopDelegateUserData(const UiDesktopDelegateUserData&) = delete;
+  UiDesktopDelegateUserData& operator=(const UiDesktopDelegateUserData&) =
+      delete;
+
+  psst::PsstUiDesktopPresenter::PsstUiDesktopDelegate* delegate() {
+    return delegate_;
+  }
+
+ private:
+  raw_ptr<psst::PsstUiDesktopPresenter::PsstUiDesktopDelegate>
+      delegate_;  // unowned
+};
+
+base::WeakPtr<psst::PsstUiDesktopPresenter::PsstUiDesktopDelegate>
+OpenPsstDialog(content::WebContents* initiator) {
+  const gfx::Size min_size(kDialogWidth, kDialogMinHeight);
+  const gfx::Size max_size(kDialogWidth, kDialogMaxHeight);
+  auto ui_desktop_delegate =
+      std::make_unique<psst::PsstUiDesktopPresenter::PsstUiDesktopDelegate>(
+          initiator->GetWeakPtr());
+  auto* ui_desktop_delegate_ptr = ui_desktop_delegate.get();
+  auto* delegate = ShowConstrainedWebDialogWithAutoResize(
+      initiator->GetBrowserContext(), std::move(ui_desktop_delegate), initiator,
+      min_size, max_size);
+  CHECK(delegate);
+  CHECK(ui_desktop_delegate_ptr);
+
+  ui_desktop_delegate_ptr->SetDelegateToWebContents(
+      delegate->GetWebContents()->GetWeakPtr());
+  return ui_desktop_delegate_ptr->GetWeakPtr();
+}
+
+}  // namespace
+
 namespace psst {
+
+// static
+PsstUiDesktopPresenter::PsstUiDesktopDelegate*
+PsstUiDesktopPresenter::PsstUiDesktopDelegate::GetDelegateFromWebContents(
+    content::WebContents* web_contents) {
+  if (!web_contents) {
+    return nullptr;
+  }
+  auto* user_data = static_cast<UiDesktopDelegateUserData*>(
+      web_contents->GetUserData(kUiDesktopDelegateUserDataKey));
+  return user_data ? user_data->delegate() : nullptr;
+}
+
+PsstUiDesktopPresenter::PsstUiDesktopDelegate::PsstUiDesktopDelegate(
+    base::WeakPtr<content::WebContents> initiator_web_contents)
+    : initiator_web_contents_(std::move(initiator_web_contents)) {
+  set_dialog_content_url(GURL(psst::kBraveUIPsstURL));
+  set_show_dialog_title(false);
+  set_can_close(true);
+}
+PsstUiDesktopPresenter::PsstUiDesktopDelegate::~PsstUiDesktopDelegate() =
+    default;
+
+void PsstUiDesktopPresenter::PsstUiDesktopDelegate::SetDelegateToWebContents(
+    base::WeakPtr<content::WebContents> dialog_web_contents) {
+  if (!dialog_web_contents) {
+    return;
+  }
+  dialog_web_contents->SetUserData(
+      kUiDesktopDelegateUserDataKey,
+      std::make_unique<UiDesktopDelegateUserData>(this));
+  dialog_web_contents_ = std::move(dialog_web_contents);
+}
+
+content::WebContents*
+PsstUiDesktopPresenter::PsstUiDesktopDelegate::GetInitiatorWebContents() const {
+  return initiator_web_contents_.get();
+}
+
+void PsstUiDesktopPresenter::PsstUiDesktopDelegate::OnDialogClosed(
+    const std::string& /* json_retval */) {
+  if (!dialog_web_contents_) {
+    return;
+  }
+  dialog_web_contents_->RemoveUserData(kUiDesktopDelegateUserDataKey);
+  dialog_web_contents_ = nullptr;
+  initiator_web_contents_ = nullptr;
+}
+
+base::WeakPtr<PsstUiDesktopPresenter::PsstUiDesktopDelegate>
+PsstUiDesktopPresenter::PsstUiDesktopDelegate::GetWeakPtr() {
+  return weak_ptr_factory_.GetWeakPtr();
+}
+
+bool PsstUiDesktopPresenter::PsstUiDesktopDelegate::IsDialogShown() const {
+  return dialog_web_contents_ != nullptr;
+}
 
 PsstUiDesktopPresenter::PsstUiDesktopPresenter(
     base::WeakPtr<content::WebContents> web_contents)
-    : web_contents_(web_contents) {}
+    : web_contents_(std::move(web_contents)) {}
 PsstUiDesktopPresenter::~PsstUiDesktopPresenter() = default;
 
 void PsstUiDesktopPresenter::ShowInfoBar(InfoBarCallback on_accept_callback) {
@@ -28,6 +134,22 @@ void PsstUiDesktopPresenter::ShowInfoBar(InfoBarCallback on_accept_callback) {
   }
 
   PsstInfoBarDelegate::Create(infobar_manager, std::move(on_accept_callback));
+}
+
+void PsstUiDesktopPresenter::ShowConsentDialog() {
+  if (!web_contents_) {
+    return;
+  }
+
+  dialog_delegate_ = OpenPsstDialog(web_contents_.get());
+}
+
+bool PsstUiDesktopPresenter::IsDialogShown() const {
+  if (!dialog_delegate_) {
+    return false;
+  }
+
+  return dialog_delegate_->IsDialogShown();
 }
 
 }  // namespace psst

--- a/browser/psst/psst_ui_desktop_presenter.cc
+++ b/browser/psst/psst_ui_desktop_presenter.cc
@@ -115,6 +115,7 @@ void PsstUiDesktopPresenter::PsstUiDesktopDelegate::OnDialogClosed(
   }
   dialog_web_contents->RemoveUserData(kUiDesktopDelegateUserDataKey);
   initiator_web_contents_ = nullptr;
+  web_dialog_delegate_ = nullptr;
 }
 
 base::WeakPtr<PsstUiDesktopPresenter::PsstUiDesktopDelegate>

--- a/browser/psst/psst_ui_desktop_presenter.cc
+++ b/browser/psst/psst_ui_desktop_presenter.cc
@@ -51,9 +51,16 @@ OpenPsstDialog(content::WebContents* initiator) {
   CHECK(delegate);
   CHECK(ui_desktop_delegate_ptr);
 
-  ui_desktop_delegate_ptr->SetDelegateToWebContents(
-      delegate->GetWebContents()->GetWeakPtr());
+  ui_desktop_delegate_ptr->SetDelegateToWebContents(delegate);
   return ui_desktop_delegate_ptr->GetWeakPtr();
+}
+
+content::WebContents* GetDialogWebContents(
+    ConstrainedWebDialogDelegate* dialog_delegate) {
+  if (!dialog_delegate) {
+    return nullptr;
+  }
+  return dialog_delegate->GetWebContents();
 }
 
 }  // namespace
@@ -83,14 +90,16 @@ PsstUiDesktopPresenter::PsstUiDesktopDelegate::~PsstUiDesktopDelegate() =
     default;
 
 void PsstUiDesktopPresenter::PsstUiDesktopDelegate::SetDelegateToWebContents(
-    base::WeakPtr<content::WebContents> dialog_web_contents) {
+    ConstrainedWebDialogDelegate* dialog_delegate) {
+  auto* dialog_web_contents = GetDialogWebContents(dialog_delegate);
   if (!dialog_web_contents) {
     return;
   }
+  dialog_delegate_ = dialog_delegate;
+
   dialog_web_contents->SetUserData(
       kUiDesktopDelegateUserDataKey,
       std::make_unique<UiDesktopDelegateUserData>(this));
-  dialog_web_contents_ = std::move(dialog_web_contents);
 }
 
 content::WebContents*
@@ -100,11 +109,11 @@ PsstUiDesktopPresenter::PsstUiDesktopDelegate::GetInitiatorWebContents() const {
 
 void PsstUiDesktopPresenter::PsstUiDesktopDelegate::OnDialogClosed(
     const std::string& /* json_retval */) {
-  if (!dialog_web_contents_) {
+  auto* dialog_web_contents = GetDialogWebContents(dialog_delegate_);
+  if (!dialog_web_contents) {
     return;
   }
-  dialog_web_contents_->RemoveUserData(kUiDesktopDelegateUserDataKey);
-  dialog_web_contents_ = nullptr;
+  dialog_web_contents->RemoveUserData(kUiDesktopDelegateUserDataKey);
   initiator_web_contents_ = nullptr;
 }
 
@@ -114,7 +123,16 @@ PsstUiDesktopPresenter::PsstUiDesktopDelegate::GetWeakPtr() {
 }
 
 bool PsstUiDesktopPresenter::PsstUiDesktopDelegate::IsDialogShown() const {
-  return dialog_web_contents_ != nullptr;
+  return GetDialogWebContents(dialog_delegate_) != nullptr;
+}
+
+void PsstUiDesktopPresenter::PsstUiDesktopDelegate::CloseDialog() {
+  if (!dialog_delegate_) {
+    return;
+  }
+
+  dialog_delegate_->OnDialogCloseFromWebUI();
+  dialog_delegate_->GetWebDialogDelegate()->OnDialogClosed({});
 }
 
 PsstUiDesktopPresenter::PsstUiDesktopPresenter(

--- a/browser/psst/psst_ui_desktop_presenter.cc
+++ b/browser/psst/psst_ui_desktop_presenter.cc
@@ -95,7 +95,7 @@ void PsstUiDesktopPresenter::PsstUiDesktopDelegate::SetDelegateToWebContents(
   if (!dialog_web_contents) {
     return;
   }
-  dialog_delegate_ = dialog_delegate;
+  web_dialog_delegate_ = dialog_delegate;
 
   dialog_web_contents->SetUserData(
       kUiDesktopDelegateUserDataKey,
@@ -109,7 +109,7 @@ PsstUiDesktopPresenter::PsstUiDesktopDelegate::GetInitiatorWebContents() const {
 
 void PsstUiDesktopPresenter::PsstUiDesktopDelegate::OnDialogClosed(
     const std::string& /* json_retval */) {
-  auto* dialog_web_contents = GetDialogWebContents(dialog_delegate_);
+  auto* dialog_web_contents = GetDialogWebContents(web_dialog_delegate_);
   if (!dialog_web_contents) {
     return;
   }
@@ -123,16 +123,16 @@ PsstUiDesktopPresenter::PsstUiDesktopDelegate::GetWeakPtr() {
 }
 
 bool PsstUiDesktopPresenter::PsstUiDesktopDelegate::IsDialogShown() const {
-  return GetDialogWebContents(dialog_delegate_) != nullptr;
+  return GetDialogWebContents(web_dialog_delegate_) != nullptr;
 }
 
 void PsstUiDesktopPresenter::PsstUiDesktopDelegate::CloseDialog() {
-  if (!dialog_delegate_) {
+  if (!web_dialog_delegate_) {
     return;
   }
 
-  dialog_delegate_->OnDialogCloseFromWebUI();
-  dialog_delegate_->GetWebDialogDelegate()->OnDialogClosed({});
+  web_dialog_delegate_->OnDialogCloseFromWebUI();
+  web_dialog_delegate_->GetWebDialogDelegate()->OnDialogClosed({});
 }
 
 PsstUiDesktopPresenter::PsstUiDesktopPresenter(

--- a/browser/psst/psst_ui_desktop_presenter.h
+++ b/browser/psst/psst_ui_desktop_presenter.h
@@ -8,6 +8,8 @@
 
 #include "base/memory/weak_ptr.h"
 #include "brave/browser/psst/psst_ui_presenter.h"
+#include "chrome/browser/ui/dialogs/browser_dialogs.h"
+#include "ui/web_dialogs/web_dialog_delegate.h"
 
 namespace content {
 class WebContents;
@@ -18,14 +20,46 @@ namespace psst {
 // Implementation of PsstUiPresenter for desktop platforms
 class PsstUiDesktopPresenter : public PsstUiPresenter {
  public:
+  class PsstUiDesktopDelegate : public ui::WebDialogDelegate {
+   public:
+    static PsstUiDesktopDelegate* GetDelegateFromWebContents(
+        content::WebContents* web_contents);
+    explicit PsstUiDesktopDelegate(
+        base::WeakPtr<content::WebContents> initiator_web_contents);
+    PsstUiDesktopDelegate(const PsstUiDesktopDelegate&) = delete;
+    PsstUiDesktopDelegate& operator=(const PsstUiDesktopDelegate&) = delete;
+    ~PsstUiDesktopDelegate() override;
+
+    void SetDelegateToWebContents(
+        base::WeakPtr<content::WebContents> dialog_web_contents);
+    content::WebContents* GetInitiatorWebContents() const;
+
+    // ui::WebDialogDelegate:
+    void OnDialogClosed(const std::string& json_retval) override;
+
+    base::WeakPtr<PsstUiDesktopDelegate> GetWeakPtr();
+    bool IsDialogShown() const;
+
+   private:
+    base::WeakPtr<content::WebContents> initiator_web_contents_;  // unowned
+    base::WeakPtr<content::WebContents> dialog_web_contents_;     // unowned
+    base::WeakPtrFactory<PsstUiDesktopDelegate> weak_ptr_factory_{this};
+  };
+
   explicit PsstUiDesktopPresenter(
       base::WeakPtr<content::WebContents> web_contents);
   ~PsstUiDesktopPresenter() override;
 
   void ShowInfoBar(InfoBarCallback on_accept_callback) override;
 
+  void ShowConsentDialog() override;
+
+  bool IsDialogShown() const override;
+
  private:
   base::WeakPtr<content::WebContents> web_contents_;
+  base::WeakPtr<psst::PsstUiDesktopPresenter::PsstUiDesktopDelegate>
+      dialog_delegate_;
 };
 
 }  // namespace psst

--- a/browser/psst/psst_ui_desktop_presenter.h
+++ b/browser/psst/psst_ui_desktop_presenter.h
@@ -6,6 +6,7 @@
 #ifndef BRAVE_BROWSER_PSST_PSST_UI_DESKTOP_PRESENTER_H_
 #define BRAVE_BROWSER_PSST_PSST_UI_DESKTOP_PRESENTER_H_
 
+#include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
 #include "brave/browser/psst/psst_ui_presenter.h"
 #include "chrome/browser/ui/dialogs/browser_dialogs.h"
@@ -14,6 +15,8 @@
 namespace content {
 class WebContents;
 }  // namespace content
+
+class ConstrainedWebDialogDelegate;
 
 namespace psst {
 
@@ -31,7 +34,7 @@ class PsstUiDesktopPresenter : public PsstUiPresenter {
     ~PsstUiDesktopDelegate() override;
 
     void SetDelegateToWebContents(
-        base::WeakPtr<content::WebContents> dialog_web_contents);
+        ConstrainedWebDialogDelegate* dialog_delegate);
     content::WebContents* GetInitiatorWebContents() const;
 
     // ui::WebDialogDelegate:
@@ -40,9 +43,11 @@ class PsstUiDesktopPresenter : public PsstUiPresenter {
     base::WeakPtr<PsstUiDesktopDelegate> GetWeakPtr();
     bool IsDialogShown() const;
 
+    void CloseDialog();
+
    private:
     base::WeakPtr<content::WebContents> initiator_web_contents_;  // unowned
-    base::WeakPtr<content::WebContents> dialog_web_contents_;     // unowned
+    raw_ptr<ConstrainedWebDialogDelegate> dialog_delegate_;       // unowned
     base::WeakPtrFactory<PsstUiDesktopDelegate> weak_ptr_factory_{this};
   };
 

--- a/browser/psst/psst_ui_desktop_presenter.h
+++ b/browser/psst/psst_ui_desktop_presenter.h
@@ -47,7 +47,8 @@ class PsstUiDesktopPresenter : public PsstUiPresenter {
 
    private:
     base::WeakPtr<content::WebContents> initiator_web_contents_;  // unowned
-    raw_ptr<ConstrainedWebDialogDelegate> web_dialog_delegate_;   // unowned
+    raw_ptr<ConstrainedWebDialogDelegate> web_dialog_delegate_ =
+        nullptr;  // unowned
     base::WeakPtrFactory<PsstUiDesktopDelegate> weak_ptr_factory_{this};
   };
 

--- a/browser/psst/psst_ui_desktop_presenter.h
+++ b/browser/psst/psst_ui_desktop_presenter.h
@@ -47,7 +47,7 @@ class PsstUiDesktopPresenter : public PsstUiPresenter {
 
    private:
     base::WeakPtr<content::WebContents> initiator_web_contents_;  // unowned
-    raw_ptr<ConstrainedWebDialogDelegate> dialog_delegate_;       // unowned
+    raw_ptr<ConstrainedWebDialogDelegate> web_dialog_delegate_;   // unowned
     base::WeakPtrFactory<PsstUiDesktopDelegate> weak_ptr_factory_{this};
   };
 

--- a/browser/psst/psst_ui_presenter.h
+++ b/browser/psst/psst_ui_presenter.h
@@ -18,6 +18,8 @@ class PsstUiPresenter {
   virtual ~PsstUiPresenter() = default;
 
   virtual void ShowInfoBar(InfoBarCallback on_accept_callback) = 0;
+  virtual void ShowConsentDialog() = 0;
+  virtual bool IsDialogShown() const = 0;
 };
 
 }  // namespace psst

--- a/browser/sources.gni
+++ b/browser/sources.gni
@@ -321,6 +321,7 @@ if (enable_brave_rewards) {
 if (enable_psst) {
   brave_chrome_browser_deps += [
     "//brave/browser/psst",
+    "//brave/browser/ui/webui/psst",
     "//brave/components/psst/browser/content",
     "//brave/components/psst/browser/core",
     "//brave/components/psst/common",

--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -22,6 +22,7 @@ import("//brave/components/containers/buildflags/buildflags.gni")
 import("//brave/components/email_aliases/buildflags/buildflags.gni")
 import("//brave/components/ntp_background_images/buildflags/buildflags.gni")
 import("//brave/components/playlist/core/common/buildflags/buildflags.gni")
+import("//brave/components/psst/buildflags/buildflags.gni")
 import("//brave/components/request_otr/common/buildflags/buildflags.gni")
 import("//brave/components/speedreader/common/buildflags/buildflags.gni")
 import("//brave/components/text_recognition/common/buildflags/buildflags.gni")
@@ -953,6 +954,16 @@ source_set("ui") {
     "//ui/webui",
     "//url",
   ]
+
+  if (enable_psst) {
+    deps += [
+      "//brave/components/psst/browser/core",
+      "//brave/components/psst/buildflags",
+      "//brave/components/psst/common",
+      "//brave/components/psst/resources",
+      "//brave/components/psst/resources:psst_dialog_generated_resources",
+    ]
+  }
 
   if (enable_brave_vpn) {
     deps += [

--- a/browser/ui/tabs/BUILD.gn
+++ b/browser/ui/tabs/BUILD.gn
@@ -5,6 +5,7 @@
 
 import("//brave/components/ai_chat/core/common/buildflags/buildflags.gni")
 import("//brave/components/containers/buildflags/buildflags.gni")
+import("//brave/components/psst/buildflags/buildflags.gni")
 
 assert(is_win || is_mac || is_linux || is_chromeos || is_android)
 
@@ -33,11 +34,8 @@ if (!is_android) {
 
     deps = [
       ":tabs_public",
-      "//brave/browser/psst",
       "//brave/browser/ui/side_panel",
       "//brave/browser/ui/views/page_action",
-      "//brave/components/psst/browser/content",
-      "//brave/components/psst/common",
       "//chrome/browser/content_settings:content_settings_factory",
       "//chrome/browser/profiles",
       "//chrome/browser/ui/side_panel:side_panel_views_dependent",
@@ -53,6 +51,14 @@ if (!is_android) {
         "//brave/browser/containers",
         "//brave/components/containers/core/browser",
         "//brave/components/containers/core/common:features",
+      ]
+    }
+
+    if (enable_psst) {
+      deps += [
+        "//brave/browser/psst",
+        "//brave/components/psst/browser/content",
+        "//brave/components/psst/common",
       ]
     }
   }

--- a/browser/ui/webui/psst/BUILD.gn
+++ b/browser/ui/webui/psst/BUILD.gn
@@ -1,0 +1,36 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import("//brave/components/psst/buildflags/buildflags.gni")
+
+assert(enable_psst)
+
+static_library("psst") {
+  sources = [
+    "brave_psst_dialog_handler.cc",
+    "brave_psst_dialog_handler.h",
+    "brave_psst_dialog_ui.cc",
+    "brave_psst_dialog_ui.h",
+  ]
+
+  deps = [
+    "//brave/browser/psst",
+    "//brave/browser/ui/tabs:tabs_public",
+    "//brave/components/psst/browser/content",
+    "//brave/components/psst/common",
+    "//brave/components/psst/common:mojom",
+    "//brave/components/psst/resources:psst_dialog_generated_resources_grit",
+    "//brave/components/psst/resources:static_resources_grit",
+    "//brave/components/resources:strings_grit",
+    "//chrome/browser/ui",
+    "//chrome/browser/ui/browser_window",
+    "//chrome/browser/ui/tabs",
+    "//chrome/browser/ui/webui",
+    "//chrome/browser/ui/webui/top_chrome",
+    "//components/constrained_window",
+    "//components/web_modal",
+    "//ui/web_dialogs",
+  ]
+}

--- a/browser/ui/webui/psst/BUILD.gn
+++ b/browser/ui/webui/psst/BUILD.gn
@@ -15,12 +15,15 @@ static_library("psst") {
     "brave_psst_dialog_ui.h",
   ]
 
-  deps = [
+  public_deps = [
     "//brave/browser/psst",
-    "//brave/browser/ui/tabs:tabs_public",
     "//brave/components/psst/browser/content",
     "//brave/components/psst/common",
     "//brave/components/psst/common:mojom",
+  ]
+
+  deps = [
+    "//brave/browser/ui/tabs:tabs_public",
     "//brave/components/psst/resources:psst_dialog_generated_resources_grit",
     "//brave/components/psst/resources:static_resources_grit",
     "//brave/components/resources:strings_grit",

--- a/browser/ui/webui/psst/DEPS
+++ b/browser/ui/webui/psst/DEPS
@@ -1,0 +1,4 @@
+include_rules = [
+  "+brave/components/psst",
+  "+brave/components/psst/resources/grit"
+]

--- a/browser/ui/webui/psst/brave_psst_dialog_handler.cc
+++ b/browser/ui/webui/psst/brave_psst_dialog_handler.cc
@@ -1,0 +1,183 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/webui/psst/brave_psst_dialog_handler.h"
+
+#include <cstddef>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "base/memory/weak_ptr.h"
+#include "base/values.h"
+#include "brave/browser/psst/psst_ui_delegate_impl.h"
+#include "brave/browser/ui/tabs/public/brave_tab_features.h"
+#include "brave/browser/ui/webui/psst/brave_psst_dialog_ui.h"
+#include "brave/components/psst/browser/content/psst_tab_web_contents_observer.h"
+#include "brave/components/psst/common/psst_ui_common.mojom-shared.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/browser_window.h"
+#include "chrome/browser/ui/browser_window/public/browser_window_features.h"
+#include "chrome/browser/ui/tabs/public/tab_features.h"
+#include "chrome/browser/ui/views/frame/browser_view.h"
+#include "chrome/browser/ui/webui/constrained_web_dialog_ui.h"
+#include "components/constrained_window/constrained_window_views.h"
+#include "components/web_modal/web_contents_modal_dialog_manager.h"
+#include "content/public/browser/web_contents.h"
+
+namespace psst {
+
+namespace {
+
+void CloseDialog(content::WebContents* initiator_contents) {
+  DCHECK(initiator_contents);
+  auto* top_level_web_contents =
+      constrained_window::GetTopLevelWebContents(initiator_contents);
+  if (!top_level_web_contents) {
+    return;
+  }
+
+  auto* manager = web_modal::WebContentsModalDialogManager::FromWebContents(
+      top_level_web_contents);
+  if (!manager) {
+    return;
+  }
+
+  manager->CloseAllDialogs();
+}
+
+base::WeakPtr<psst::PsstTabWebContentsObserver>
+GetActivePsstTabHelperFromContext(content::WebContents* web_contents) {
+  auto* tab_interface = tabs::TabInterface::GetFromContents(web_contents);
+  if (!tab_interface) {
+    return nullptr;
+  }
+
+  auto* brave_tab_features =
+      tabs::BraveTabFeatures::FromTabFeatures(tab_interface->GetTabFeatures());
+  if (!brave_tab_features) {
+    return nullptr;
+  }
+
+  auto* tab_helper = brave_tab_features->psst_web_contents_observer();
+  if (!tab_helper) {
+    return nullptr;
+  }
+
+  return tab_helper->AsWeakPtr();
+}
+
+base::WeakPtr<PsstUiDelegateImpl> GetPsstUIDelegate(
+    base::WeakPtr<psst::PsstTabWebContentsObserver> tab_helper) {
+  if (!tab_helper) {
+    return nullptr;
+  }
+
+  auto* psst_ui_delegate =
+      static_cast<PsstUiDelegateImpl*>(tab_helper->GetPsstUiDelegate());
+  if (!psst_ui_delegate) {
+    return nullptr;
+  }
+
+  return psst_ui_delegate->AsWeakPtr();
+}
+
+}  // namespace
+
+BravePsstDialogHandler::BravePsstDialogHandler(
+    TabStripModel* tab_strip_model,
+    BravePsstDialogUI* dialog_ui,
+    mojo::PendingReceiver<psst::mojom::PsstConsentHelper> pending_receiver,
+    mojo::PendingRemote<psst::mojom::PsstConsentDialog> client_page,
+    psst::mojom::PsstConsentFactory::CreatePsstConsentHandlerCallback callback)
+    : dialog_ui_(dialog_ui),
+      receiver_(this, std::move(pending_receiver)),
+      client_page_(std::move(client_page)) {
+  DCHECK(tab_strip_model);
+  tab_strip_model->AddObserver(this);
+  auto* web_contents = tab_strip_model->GetActiveWebContents();
+  if (!web_contents) {
+    return;
+  }
+
+  active_tab_helper_ = GetActivePsstTabHelperFromContext(web_contents);
+  if (!active_tab_helper_) {
+    return;
+  }
+
+  psst_dialog_delegate_ = GetPsstUIDelegate(active_tab_helper_);
+  if (!psst_dialog_delegate_) {
+    return;
+  }
+
+  psst_dialog_delegate_->AddObserver(this);
+
+  auto setting_card_data = psst_dialog_delegate_->GetShowDialogData();
+  CHECK(setting_card_data);
+  // Set initial dialog data
+  std::move(callback).Run(std::move(setting_card_data));
+}
+
+BravePsstDialogHandler::~BravePsstDialogHandler() = default;
+
+void BravePsstDialogHandler::OnSetRequestStatus(
+    const std::string& uid,
+    const std::optional<std::string>& error) {
+  if (!client_page_ || !client_page_.is_bound() ||
+      !client_page_.is_connected()) {
+    return;
+  }
+  client_page_->OnSetRequestStatus(uid, error);
+}
+
+void BravePsstDialogHandler::OnTabStripModelChanged(
+    TabStripModel* tab_strip_model,
+    const TabStripModelChange& change,
+    const TabStripSelectionChange& selection) {
+  if (selection.active_tab_changed() && psst_dialog_delegate_) {
+    psst_dialog_delegate_->RemoveObserver(this);
+  }
+
+  if (selection.new_contents) {
+    active_tab_helper_ =
+        GetActivePsstTabHelperFromContext(selection.new_contents);
+    if (!active_tab_helper_) {
+      return;
+    }
+
+    psst_dialog_delegate_ = GetPsstUIDelegate(active_tab_helper_);
+    if (!psst_dialog_delegate_) {
+      return;
+    }
+    psst_dialog_delegate_->AddObserver(this);
+  }
+}
+
+void BravePsstDialogHandler::PerformPrivacyTuning(
+    const std::vector<std::string>& perform_for_uids) {
+  if (!psst_dialog_delegate_) {
+    return;
+  }
+
+  psst_dialog_delegate_->OnUserAcceptedPsstSettings(perform_for_uids);
+}
+
+void BravePsstDialogHandler::ReportFailedContent() {
+  if (!psst_dialog_delegate_) {
+    return;
+  }
+
+  // psst_dialog_delegate_->OnUserRejectedPsstSettings();
+}
+
+void BravePsstDialogHandler::CloseDialog() {
+  CHECK(active_tab_helper_);
+  if (psst_dialog_delegate_) {
+    psst_dialog_delegate_->RemoveObserver(this);
+  }
+  ::psst::CloseDialog(active_tab_helper_->web_contents());
+}
+
+}  // namespace psst

--- a/browser/ui/webui/psst/brave_psst_dialog_handler.cc
+++ b/browser/ui/webui/psst/brave_psst_dialog_handler.cc
@@ -72,13 +72,14 @@ BravePsstDialogHandler::BravePsstDialogHandler(
     mojo::PendingReceiver<psst::mojom::PsstConsentHelper> pending_receiver,
     mojo::PendingRemote<psst::mojom::PsstConsentDialog> client_page,
     psst::mojom::PsstConsentFactory::CreatePsstConsentHandlerCallback callback)
-    : dialog_ui_(dialog_ui),
+    : tab_strip_model_(tab_strip_model),
+      dialog_ui_(dialog_ui),
       receiver_(this, std::move(pending_receiver)),
       client_page_(std::move(client_page)) {
   CHECK(dialog_ui_);
-  CHECK(tab_strip_model);
-  tab_strip_model->AddObserver(this);
-  auto* web_contents = tab_strip_model->GetActiveWebContents();
+  CHECK(tab_strip_model_);
+  tab_strip_model_->AddObserver(this);
+  auto* web_contents = tab_strip_model_->GetActiveWebContents();
   if (!web_contents) {
     return;
   }
@@ -102,6 +103,9 @@ BravePsstDialogHandler::BravePsstDialogHandler(
 BravePsstDialogHandler::~BravePsstDialogHandler() {
   if (psst_dialog_delegate_) {
     psst_dialog_delegate_->RemoveObserver(this);
+  }
+  if (tab_strip_model_) {
+    tab_strip_model_->RemoveObserver(this);
   }
 }
 

--- a/browser/ui/webui/psst/brave_psst_dialog_handler.cc
+++ b/browser/ui/webui/psst/brave_psst_dialog_handler.cc
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "base/memory/weak_ptr.h"
+#include "base/notimplemented.h"
 #include "brave/browser/psst/psst_ui_delegate_impl.h"
 #include "brave/browser/ui/tabs/public/brave_tab_features.h"
 #include "brave/browser/ui/webui/psst/brave_psst_dialog_ui.h"
@@ -154,6 +155,7 @@ void BravePsstDialogHandler::ReportFailedContent() {
   }
 
   // Report Submission Implementation
+  NOTIMPLEMENTED();
 }
 
 void BravePsstDialogHandler::CloseDialog() {

--- a/browser/ui/webui/psst/brave_psst_dialog_handler.cc
+++ b/browser/ui/webui/psst/brave_psst_dialog_handler.cc
@@ -11,42 +11,21 @@
 #include <vector>
 
 #include "base/memory/weak_ptr.h"
-#include "base/values.h"
 #include "brave/browser/psst/psst_ui_delegate_impl.h"
 #include "brave/browser/ui/tabs/public/brave_tab_features.h"
 #include "brave/browser/ui/webui/psst/brave_psst_dialog_ui.h"
 #include "brave/components/psst/browser/content/psst_tab_web_contents_observer.h"
-#include "brave/components/psst/common/psst_ui_common.mojom-shared.h"
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/browser_window.h"
 #include "chrome/browser/ui/browser_window/public/browser_window_features.h"
 #include "chrome/browser/ui/tabs/public/tab_features.h"
-#include "chrome/browser/ui/views/frame/browser_view.h"
 #include "chrome/browser/ui/webui/constrained_web_dialog_ui.h"
 #include "components/constrained_window/constrained_window_views.h"
-#include "components/web_modal/web_contents_modal_dialog_manager.h"
 #include "content/public/browser/web_contents.h"
 
 namespace psst {
 
 namespace {
-
-void CloseDialog(content::WebContents* initiator_contents) {
-  DCHECK(initiator_contents);
-  auto* top_level_web_contents =
-      constrained_window::GetTopLevelWebContents(initiator_contents);
-  if (!top_level_web_contents) {
-    return;
-  }
-
-  auto* manager = web_modal::WebContentsModalDialogManager::FromWebContents(
-      top_level_web_contents);
-  if (!manager) {
-    return;
-  }
-
-  manager->CloseAllDialogs();
-}
 
 base::WeakPtr<psst::PsstTabWebContentsObserver>
 GetActivePsstTabHelperFromContext(content::WebContents* web_contents) {
@@ -95,7 +74,8 @@ BravePsstDialogHandler::BravePsstDialogHandler(
     : dialog_ui_(dialog_ui),
       receiver_(this, std::move(pending_receiver)),
       client_page_(std::move(client_page)) {
-  DCHECK(tab_strip_model);
+  CHECK(dialog_ui_);
+  CHECK(tab_strip_model);
   tab_strip_model->AddObserver(this);
   auto* web_contents = tab_strip_model->GetActiveWebContents();
   if (!web_contents) {
@@ -120,7 +100,11 @@ BravePsstDialogHandler::BravePsstDialogHandler(
   std::move(callback).Run(std::move(setting_card_data));
 }
 
-BravePsstDialogHandler::~BravePsstDialogHandler() = default;
+BravePsstDialogHandler::~BravePsstDialogHandler() {
+  if (psst_dialog_delegate_) {
+    psst_dialog_delegate_->RemoveObserver(this);
+  }
+}
 
 void BravePsstDialogHandler::OnSetRequestStatus(
     const std::string& uid,
@@ -169,15 +153,16 @@ void BravePsstDialogHandler::ReportFailedContent() {
     return;
   }
 
-  // psst_dialog_delegate_->OnUserRejectedPsstSettings();
+  // Report Submission Implementation
 }
 
 void BravePsstDialogHandler::CloseDialog() {
-  CHECK(active_tab_helper_);
-  if (psst_dialog_delegate_) {
-    psst_dialog_delegate_->RemoveObserver(this);
+  if (!psst_dialog_delegate_ || !dialog_ui_) {
+    return;
   }
-  ::psst::CloseDialog(active_tab_helper_->web_contents());
+
+  psst_dialog_delegate_->RemoveObserver(this);
+  dialog_ui_->Close();
 }
 
 }  // namespace psst

--- a/browser/ui/webui/psst/brave_psst_dialog_handler.cc
+++ b/browser/ui/webui/psst/brave_psst_dialog_handler.cc
@@ -95,10 +95,8 @@ BravePsstDialogHandler::BravePsstDialogHandler(
 
   psst_dialog_delegate_->AddObserver(this);
 
-  auto setting_card_data = psst_dialog_delegate_->GetShowDialogData();
-  CHECK(setting_card_data);
   // Set initial dialog data
-  std::move(callback).Run(std::move(setting_card_data));
+  std::move(callback).Run(psst_dialog_delegate_->GetShowDialogData());
 }
 
 BravePsstDialogHandler::~BravePsstDialogHandler() {

--- a/browser/ui/webui/psst/brave_psst_dialog_handler.h
+++ b/browser/ui/webui/psst/brave_psst_dialog_handler.h
@@ -1,0 +1,67 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_WEBUI_PSST_BRAVE_PSST_DIALOG_HANDLER_H_
+#define BRAVE_BROWSER_UI_WEBUI_PSST_BRAVE_PSST_DIALOG_HANDLER_H_
+
+#include <string>
+#include <vector>
+
+#include "brave/browser/psst/psst_ui_delegate_impl.h"
+#include "brave/components/psst/browser/content/psst_tab_web_contents_observer.h"
+#include "brave/components/psst/common/psst_ui_common.mojom-shared.h"
+#include "brave/components/psst/common/psst_ui_common.mojom.h"
+#include "chrome/browser/ui/tabs/tab_strip_model_observer.h"
+#include "mojo/public/cpp/bindings/receiver.h"
+#include "mojo/public/cpp/bindings/remote.h"
+
+namespace psst {
+
+class BravePsstDialogUI;
+class PsstTabWebContentsObserver;
+
+class BravePsstDialogHandler : public psst::mojom::PsstConsentHelper,
+                               public PsstUiDelegateImpl::Observer,
+                               public TabStripModelObserver {
+ public:
+  explicit BravePsstDialogHandler(
+      TabStripModel* tab_strip_model,
+      BravePsstDialogUI* dialog_ui,
+      mojo::PendingReceiver<psst::mojom::PsstConsentHelper> pending_receiver,
+      mojo::PendingRemote<psst::mojom::PsstConsentDialog> client_page,
+      psst::mojom::PsstConsentFactory::CreatePsstConsentHandlerCallback
+          callback);
+
+  BravePsstDialogHandler() = delete;
+  BravePsstDialogHandler(const BravePsstDialogHandler&) = delete;
+  BravePsstDialogHandler& operator=(const BravePsstDialogHandler&) = delete;
+
+  ~BravePsstDialogHandler() override;
+
+ private:
+  friend class PsstTabWebContentsObserverBrowserTest;
+  void PerformPrivacyTuning(const std::vector<std::string>& perform_for_uids) override;
+  void ReportFailedContent() override;
+  void CloseDialog() override;
+
+  void OnSetRequestStatus(const std::string& uid,
+                          const std::optional<std::string>& error) override;
+
+  // TabStripModelObserver
+  void OnTabStripModelChanged(
+      TabStripModel* tab_strip_model,
+      const TabStripModelChange& change,
+      const TabStripSelectionChange& selection) override;
+
+  base::WeakPtr<psst::PsstTabWebContentsObserver> active_tab_helper_;
+  base::WeakPtr<PsstUiDelegateImpl> psst_dialog_delegate_;
+  raw_ptr<BravePsstDialogUI> const dialog_ui_{nullptr};
+  mojo::Receiver<psst::mojom::PsstConsentHelper> receiver_;
+  mojo::Remote<psst::mojom::PsstConsentDialog> client_page_;
+};
+
+}  // namespace psst
+
+#endif  // BRAVE_BROWSER_UI_WEBUI_PSST_BRAVE_PSST_DIALOG_HANDLER_H_

--- a/browser/ui/webui/psst/brave_psst_dialog_handler.h
+++ b/browser/ui/webui/psst/brave_psst_dialog_handler.h
@@ -58,6 +58,7 @@ class BravePsstDialogHandler : public psst::mojom::PsstConsentHelper,
 
   base::WeakPtr<psst::PsstTabWebContentsObserver> active_tab_helper_;
   base::WeakPtr<PsstUiDelegateImpl> psst_dialog_delegate_;
+  raw_ptr<TabStripModel> tab_strip_model_{nullptr};
   raw_ptr<BravePsstDialogUI> const dialog_ui_{nullptr};
   mojo::Receiver<psst::mojom::PsstConsentHelper> receiver_;
   mojo::Remote<psst::mojom::PsstConsentDialog> client_page_;

--- a/browser/ui/webui/psst/brave_psst_dialog_handler.h
+++ b/browser/ui/webui/psst/brave_psst_dialog_handler.h
@@ -42,7 +42,8 @@ class BravePsstDialogHandler : public psst::mojom::PsstConsentHelper,
 
  private:
   friend class PsstTabWebContentsObserverBrowserTest;
-  void PerformPrivacyTuning(const std::vector<std::string>& perform_for_uids) override;
+  void PerformPrivacyTuning(
+      const std::vector<std::string>& perform_for_uids) override;
   void ReportFailedContent() override;
   void CloseDialog() override;
 

--- a/browser/ui/webui/psst/brave_psst_dialog_ui.cc
+++ b/browser/ui/webui/psst/brave_psst_dialog_ui.cc
@@ -1,0 +1,73 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/webui/psst/brave_psst_dialog_ui.h"
+
+#include <cstddef>
+#include <memory>
+#include <utility>
+
+#include "base/check.h"
+#include "brave/browser/psst/psst_ui_desktop_presenter.h"
+#include "brave/browser/ui/webui/brave_webui_source.h"
+#include "brave/browser/ui/webui/psst/brave_psst_dialog_handler.h"
+#include "brave/components/psst/resources/grit/brave_psst_dialog_generated_map.h"
+#include "brave/components/psst/resources/grit/brave_psst_resources.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/ui/browser_list.h"
+#include "chrome/browser/ui/browser_window/public/browser_window_interface.h"
+#include "chrome/browser/ui/browser_window/public/browser_window_interface_iterator.h"
+#include "components/grit/brave_components_webui_strings.h"
+#include "content/public/browser/web_contents.h"
+#include "content/public/browser/web_ui_data_source.h"
+
+using content::WebUIMessageHandler;
+
+namespace psst {
+
+BravePsstDialogUI::BravePsstDialogUI(content::WebUI* web_ui)
+    : MojoWebDialogUI(web_ui) {
+  auto* source = CreateAndAddWebUIDataSource(web_ui, kBravePsstHost,
+                                             kBravePsstDialogGenerated,
+                                             IDR_BRAVE_PSST_DIALOG_HTML);
+  source->AddLocalizedStrings(webui::kPsstStrings);
+}
+
+BravePsstDialogUI::~BravePsstDialogUI() = default;
+
+void BravePsstDialogUI::BindInterface(
+    mojo::PendingReceiver<psst::mojom::PsstConsentFactory> receiver) {
+  psst_consent_factory_receiver_.reset();
+  psst_consent_factory_receiver_.Bind(std::move(receiver));
+}
+
+void BravePsstDialogUI::CreatePsstConsentHandler(
+    ::mojo::PendingReceiver<psst::mojom::PsstConsentHelper> psst_consent_helper,
+    ::mojo::PendingRemote<psst::mojom::PsstConsentDialog> psst_consent_dialog,
+    psst::mojom::PsstConsentFactory::CreatePsstConsentHandlerCallback
+        callback) {
+  auto* delegate =
+      PsstUiDesktopPresenter::PsstUiDesktopDelegate::GetDelegateFromWebContents(
+          web_ui()->GetWebContents());
+  CHECK(delegate);
+  auto* initiator_contents = delegate->GetInitiatorWebContents();
+  CHECK(initiator_contents);
+
+  auto* tab_interface =
+      tabs::TabInterface::MaybeGetFromContents(initiator_contents);
+  CHECK(tab_interface);
+
+  TabStripModel* tab_strip_model =
+      tab_interface->GetBrowserWindowInterface()->GetTabStripModel();
+  CHECK(tab_strip_model);
+
+  psst_consent_handler_ = std::make_unique<BravePsstDialogHandler>(
+      tab_strip_model, this, std::move(psst_consent_helper),
+      std::move(psst_consent_dialog), std::move(callback));
+}
+
+WEB_UI_CONTROLLER_TYPE_IMPL(BravePsstDialogUI)
+
+}  // namespace psst

--- a/browser/ui/webui/psst/brave_psst_dialog_ui.cc
+++ b/browser/ui/webui/psst/brave_psst_dialog_ui.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
@@ -10,7 +10,6 @@
 #include <utility>
 
 #include "base/check.h"
-#include "brave/browser/psst/psst_ui_desktop_presenter.h"
 #include "brave/browser/ui/webui/brave_webui_source.h"
 #include "brave/browser/ui/webui/psst/brave_psst_dialog_handler.h"
 #include "brave/components/psst/resources/grit/brave_psst_dialog_generated_map.h"
@@ -48,11 +47,12 @@ void BravePsstDialogUI::CreatePsstConsentHandler(
     ::mojo::PendingRemote<psst::mojom::PsstConsentDialog> psst_consent_dialog,
     psst::mojom::PsstConsentFactory::CreatePsstConsentHandlerCallback
         callback) {
-  auto* delegate =
+  desktop_dialog_delegate_ =
       PsstUiDesktopPresenter::PsstUiDesktopDelegate::GetDelegateFromWebContents(
           web_ui()->GetWebContents());
-  CHECK(delegate);
-  auto* initiator_contents = delegate->GetInitiatorWebContents();
+  CHECK(desktop_dialog_delegate_);
+  auto* initiator_contents =
+      desktop_dialog_delegate_->GetInitiatorWebContents();
   CHECK(initiator_contents);
 
   auto* tab_interface =
@@ -66,6 +66,13 @@ void BravePsstDialogUI::CreatePsstConsentHandler(
   psst_consent_handler_ = std::make_unique<BravePsstDialogHandler>(
       tab_strip_model, this, std::move(psst_consent_helper),
       std::move(psst_consent_dialog), std::move(callback));
+}
+
+void BravePsstDialogUI::Close() {
+  if (!desktop_dialog_delegate_) {
+    return;
+  }
+  desktop_dialog_delegate_->CloseDialog();
 }
 
 WEB_UI_CONTROLLER_TYPE_IMPL(BravePsstDialogUI)

--- a/browser/ui/webui/psst/brave_psst_dialog_ui.cc
+++ b/browser/ui/webui/psst/brave_psst_dialog_ui.cc
@@ -72,7 +72,11 @@ void BravePsstDialogUI::Close() {
   if (!desktop_dialog_delegate_) {
     return;
   }
-  desktop_dialog_delegate_->CloseDialog();
+  base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
+      FROM_HERE,
+      base::BindOnce(
+          &PsstUiDesktopPresenter::PsstUiDesktopDelegate::CloseDialog,
+          desktop_dialog_delegate_->GetWeakPtr()));
 }
 
 WEB_UI_CONTROLLER_TYPE_IMPL(BravePsstDialogUI)

--- a/browser/ui/webui/psst/brave_psst_dialog_ui.h
+++ b/browser/ui/webui/psst/brave_psst_dialog_ui.h
@@ -1,0 +1,64 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_WEBUI_PSST_BRAVE_PSST_DIALOG_UI_H_
+#define BRAVE_BROWSER_UI_WEBUI_PSST_BRAVE_PSST_DIALOG_UI_H_
+
+#include <memory>
+#include <string>
+
+#include "base/memory/raw_ptr.h"
+#include "brave/browser/ui/webui/psst/brave_psst_dialog_handler.h"
+#include "brave/components/constants/webui_url_constants.h"
+#include "brave/components/psst/common/constants.h"
+#include "brave/components/psst/common/psst_ui_common.mojom-shared.h"
+#include "chrome/browser/ui/webui/top_chrome/top_chrome_web_ui_controller.h"
+#include "content/public/browser/web_ui_controller.h"
+#include "content/public/browser/web_ui_message_handler.h"
+#include "content/public/browser/webui_config.h"
+#include "content/public/common/url_constants.h"
+#include "mojo/public/cpp/bindings/receiver_set.h"
+#include "ui/web_dialogs/web_dialog_ui.h"
+#include "ui/webui/mojo_web_ui_controller.h"
+
+namespace psst {
+
+class BravePsstDialogUI;
+class BravePsstDialogUIConfig
+    : public content::DefaultWebUIConfig<BravePsstDialogUI> {
+ public:
+  BravePsstDialogUIConfig()
+      : DefaultWebUIConfig(content::kChromeUIScheme, kBravePsstHost) {}
+};
+
+class BravePsstDialogUI : public ui::MojoWebDialogUI,
+                          public psst::mojom::PsstConsentFactory {
+ public:
+  explicit BravePsstDialogUI(content::WebUI* web_ui);
+  ~BravePsstDialogUI() override;
+  BravePsstDialogUI(const BravePsstDialogUI&) = delete;
+  BravePsstDialogUI& operator=(const BravePsstDialogUI&) = delete;
+
+  void BindInterface(
+      mojo::PendingReceiver<psst::mojom::PsstConsentFactory> receiver);
+
+ private:
+  friend class PsstTabWebContentsObserverBrowserTest;
+  void CreatePsstConsentHandler(
+      ::mojo::PendingReceiver<psst::mojom::PsstConsentHelper>
+          psst_consent_helper,
+      ::mojo::PendingRemote<psst::mojom::PsstConsentDialog> psst_consent_dialog,
+      psst::mojom::PsstConsentFactory::CreatePsstConsentHandlerCallback
+          callback) override;
+
+  std::unique_ptr<BravePsstDialogHandler> psst_consent_handler_;
+  mojo::Receiver<psst::mojom::PsstConsentFactory>
+      psst_consent_factory_receiver_{this};
+
+  WEB_UI_CONTROLLER_TYPE_DECL();
+};
+}  // namespace psst
+
+#endif  // BRAVE_BROWSER_UI_WEBUI_PSST_BRAVE_PSST_DIALOG_UI_H_

--- a/browser/ui/webui/psst/brave_psst_dialog_ui.h
+++ b/browser/ui/webui/psst/brave_psst_dialog_ui.h
@@ -7,11 +7,10 @@
 #define BRAVE_BROWSER_UI_WEBUI_PSST_BRAVE_PSST_DIALOG_UI_H_
 
 #include <memory>
-#include <string>
 
 #include "base/memory/raw_ptr.h"
+#include "brave/browser/psst/psst_ui_desktop_presenter.h"
 #include "brave/browser/ui/webui/psst/brave_psst_dialog_handler.h"
-#include "brave/components/constants/webui_url_constants.h"
 #include "brave/components/psst/common/constants.h"
 #include "brave/components/psst/common/psst_ui_common.mojom-shared.h"
 #include "chrome/browser/ui/webui/top_chrome/top_chrome_web_ui_controller.h"
@@ -19,9 +18,7 @@
 #include "content/public/browser/web_ui_message_handler.h"
 #include "content/public/browser/webui_config.h"
 #include "content/public/common/url_constants.h"
-#include "mojo/public/cpp/bindings/receiver_set.h"
 #include "ui/web_dialogs/web_dialog_ui.h"
-#include "ui/webui/mojo_web_ui_controller.h"
 
 namespace psst {
 
@@ -44,6 +41,8 @@ class BravePsstDialogUI : public ui::MojoWebDialogUI,
   void BindInterface(
       mojo::PendingReceiver<psst::mojom::PsstConsentFactory> receiver);
 
+  void Close();
+
  private:
   friend class PsstTabWebContentsObserverBrowserTest;
   void CreatePsstConsentHandler(
@@ -53,12 +52,15 @@ class BravePsstDialogUI : public ui::MojoWebDialogUI,
       psst::mojom::PsstConsentFactory::CreatePsstConsentHandlerCallback
           callback) override;
 
+  raw_ptr<PsstUiDesktopPresenter::PsstUiDesktopDelegate>
+      desktop_dialog_delegate_;
   std::unique_ptr<BravePsstDialogHandler> psst_consent_handler_;
   mojo::Receiver<psst::mojom::PsstConsentFactory>
       psst_consent_factory_receiver_{this};
 
   WEB_UI_CONTROLLER_TYPE_DECL();
 };
+
 }  // namespace psst
 
 #endif  // BRAVE_BROWSER_UI_WEBUI_PSST_BRAVE_PSST_DIALOG_UI_H_

--- a/browser/ui/webui/sources.gni
+++ b/browser/ui/webui/sources.gni
@@ -8,6 +8,7 @@ import("//brave/components/brave_origin/buildflags/buildflags.gni")
 import("//brave/components/brave_vpn/common/buildflags/buildflags.gni")
 import("//brave/components/containers/buildflags/buildflags.gni")
 import("//brave/components/playlist/core/common/buildflags/buildflags.gni")
+import("//brave/components/psst/buildflags/buildflags.gni")
 
 # This is required for chromium_src overrides.
 brave_browser_ui_webui_configs_deps = [
@@ -48,4 +49,8 @@ if (enable_containers) {
     "//brave/components/containers/core/common",
     "//brave/components/containers/core/mojom",
   ]
+}
+
+if (enable_psst) {
+  brave_browser_ui_webui_configs_deps += [ "//brave/browser/ui/webui/psst" ]
 }

--- a/chromium_src/chrome/browser/ui/webui/DEPS
+++ b/chromium_src/chrome/browser/ui/webui/DEPS
@@ -16,4 +16,5 @@ include_rules = [
   "+brave/components/speedreader/common/buildflags",
   "+brave/components/email_aliases",
   "+brave/components/local_ai/core/features.h",
+  "+brave/components/psst/buildflags",
 ]

--- a/chromium_src/chrome/browser/ui/webui/chrome_web_ui_configs.cc
+++ b/chromium_src/chrome/browser/ui/webui/chrome_web_ui_configs.cc
@@ -12,6 +12,7 @@
 #include "brave/components/brave_rewards/core/buildflags/buildflags.h"
 #include "brave/components/brave_wallet/common/buildflags/buildflags.h"
 #include "brave/components/email_aliases/buildflags/buildflags.h"
+#include "brave/components/psst/buildflags/buildflags.h"
 #include "brave/components/speedreader/common/buildflags/buildflags.h"
 #include "content/public/browser/webui_config_map.h"
 
@@ -66,6 +67,10 @@
 #if BUILDFLAG(ENABLE_EMAIL_ALIASES)
 #include "brave/browser/ui/webui/email_aliases/email_aliases_panel_ui.h"
 #include "brave/components/email_aliases/features.h"
+#endif
+
+#if BUILDFLAG(ENABLE_PSST)
+#include "brave/browser/ui/webui/psst/brave_psst_dialog_ui.h"
 #endif
 
 namespace {
@@ -152,5 +157,9 @@ void RegisterChromeWebUIConfigs() {
   if (email_aliases::features::IsEmailAliasesEnabled()) {
     map.AddWebUIConfig(std::make_unique<EmailAliasesPanelUIConfig>());
   }
+#endif
+
+#if BUILDFLAG(ENABLE_PSST)
+  map.AddWebUIConfig(std::make_unique<psst::BravePsstDialogUIConfig>());
 #endif
 }

--- a/components/psst/browser/content/psst_tab_web_contents_observer.cc
+++ b/components/psst/browser/content/psst_tab_web_contents_observer.cc
@@ -120,6 +120,14 @@ PsstTabWebContentsObserver::PsstTabWebContentsObserver(
 
 PsstTabWebContentsObserver::~PsstTabWebContentsObserver() = default;
 
+PsstTabWebContentsObserver::PsstUiDelegate*
+PsstTabWebContentsObserver::GetPsstUiDelegate() const {
+  return ui_delegate_.get();
+}
+base::WeakPtr<PsstTabWebContentsObserver>
+PsstTabWebContentsObserver::AsWeakPtr() {
+  return weak_factory_.GetWeakPtr();
+}
 void PsstTabWebContentsObserver::DidFinishNavigation(
     content::NavigationHandle* handle) {
   if (!handle->IsInPrimaryMainFrame() || !handle->HasCommitted() ||
@@ -187,7 +195,7 @@ void PsstTabWebContentsObserver::OnUserScriptResult(
     return;
   }
 
-  const auto user_script_result_parsed =
+  auto user_script_result_parsed =
       UserScriptResult::FromValue(user_script_result);
   if (!user_script_result_parsed) {
     ui_delegate_->UpdateTasks(100, {}, mojom::PsstStatus::kFailed);
@@ -219,6 +227,7 @@ void PsstTabWebContentsObserver::OnUserScriptResult(
   auto origin = url::Origin::Create(web_contents()->GetLastCommittedURL());
   ui_delegate_->Show(
       std::move(origin), std::move(*psst_settings),
+      std::move(user_script_result_parsed),
       base::BindOnce(
           &PsstTabWebContentsObserver::OnUserAcceptedPsstSettings,
           weak_factory_.GetWeakPtr(), id,

--- a/components/psst/browser/content/psst_tab_web_contents_observer.h
+++ b/components/psst/browser/content/psst_tab_web_contents_observer.h
@@ -42,8 +42,9 @@ class PsstTabWebContentsObserver : public content::WebContentsObserver {
    public:
     virtual ~PsstUiDelegate() = default;
     // Show the consent dialog to the user with the provided data.
-    virtual void Show(const url::Origin& origin,
+    virtual void Show(url::Origin origin,
                       PsstWebsiteSettings dialog_data,
+                      std::optional<UserScriptResult> user_script_result,
                       ConsentCallback apply_changes_callback) = 0;
     // Update the UI state based on the applied tasks and progress.
     virtual void UpdateTasks(long progress,
@@ -67,6 +68,8 @@ class PsstTabWebContentsObserver : public content::WebContentsObserver {
   PsstTabWebContentsObserver& operator=(const PsstTabWebContentsObserver&) =
       delete;
 
+  PsstUiDelegate* GetPsstUiDelegate() const;
+  base::WeakPtr<PsstTabWebContentsObserver> AsWeakPtr();
  private:
   friend class PsstTabWebContentsObserverUnitTestBase;
 

--- a/components/psst/browser/content/psst_tab_web_contents_observer.h
+++ b/components/psst/browser/content/psst_tab_web_contents_observer.h
@@ -70,6 +70,7 @@ class PsstTabWebContentsObserver : public content::WebContentsObserver {
 
   PsstUiDelegate* GetPsstUiDelegate() const;
   base::WeakPtr<PsstTabWebContentsObserver> AsWeakPtr();
+
  private:
   friend class PsstTabWebContentsObserverUnitTestBase;
 

--- a/components/psst/browser/content/psst_tab_web_contents_observer_unittest.cc
+++ b/components/psst/browser/content/psst_tab_web_contents_observer_unittest.cc
@@ -52,15 +52,16 @@ MATCHER_P4(PsstWebsiteSettingsEq,
            consent_status,
            script_version,
            user_id,
-           urls_to_skip,
+           uids_to_perform,
            "PsstWebsiteSettings with consent_status=" +
                ::testing::PrintToString(consent_status) +
                ", script_version=" + ::testing::PrintToString(script_version) +
                ", user_id=" + ::testing::PrintToString(user_id) +
-               ", urls_to_skip=" + ::testing::PrintToString(urls_to_skip)) {
+               ", uids_to_perform=" +
+               ::testing::PrintToString(uids_to_perform)) {
   return arg.consent_status == consent_status &&
          arg.script_version == script_version && arg.user_id == user_id &&
-         arg.urls_to_skip == urls_to_skip;
+         arg.uids_to_perform == uids_to_perform;
 }
 
 }  // namespace
@@ -119,7 +120,7 @@ ACTION_P(InsertScriptInPageCallback, future, value) {
   future->SetValue(value.Clone());
 }
 ACTION_P(ShowCallback, future) {
-  std::move(const_cast<PsstTabWebContentsObserver::ConsentCallback&>(arg2))
+  std::move(const_cast<PsstTabWebContentsObserver::ConsentCallback&>(arg3))
       .Run();
   future->SetValue();
 }
@@ -156,8 +157,9 @@ class MockUiDelegate : public PsstTabWebContentsObserver::PsstUiDelegate {
   MOCK_METHOD(
       void,
       Show,
-      (const url::Origin& origin,
+      (url::Origin origin,
        PsstWebsiteSettings dialog_data,
+       std::optional<UserScriptResult> user_script_result,
        PsstTabWebContentsObserver::ConsentCallback apply_changes_callback),
       (override));
 
@@ -596,7 +598,15 @@ TEST_F(PsstTabWebContentsObserverUnitTest,
 
   // User script result is an dictionary, and user key is not empty
   auto script_params = base::Value(
-      base::DictValue().Set("user_id", user_id).Set("site_name", "example"));
+      base::DictValue()
+          .Set("initial_execution", true)
+          .Set("user_id", user_id)
+          .Set("site_name", "example")
+          .Set("tasks",
+               base::ListValue().Append(base::DictValue()
+                                            .Set("uid", "1")
+                                            .Set("url", "https://example1.com")
+                                            .Set("description", "settings"))));
 
   // Policy script result is a dictionary, but it is not deserializable
   auto policy_script_result = base::Value(
@@ -604,6 +614,7 @@ TEST_F(PsstTabWebContentsObserverUnitTest,
           .Set("progress", 100)
           .Set("applied_tasks",
                base::ListValue().Append(base::DictValue()
+                                            .Set("uid", "1")
                                             .Set("url", "https://example1.com")
                                             .Set("description", "settings"))));
 
@@ -623,7 +634,7 @@ TEST_F(PsstTabWebContentsObserverUnitTest,
               Show(url::Origin::Create(url),
                    PsstWebsiteSettingsEq(ConsentStatus::kAsk, 1, user_id,
                                          std::vector<std::string>()),
-                   _))
+                   _, _))
       .WillOnce(ShowCallback(&user_accept_psst_settings_future));
 
   const auto script_with_parameters = base::StrCat(
@@ -720,6 +731,7 @@ TEST_F(PsstTabWebContentsObserverUnitTest,
           .Set("user_id", user_id)
           .Set("tasks",
                base::ListValue().Append(base::DictValue()
+                                            .Set("uid", "1")
                                             .Set("url", "https://example1.com")
                                             .Set("description", "settings")))
           .Set("site_name", "example")
@@ -740,7 +752,7 @@ TEST_F(PsstTabWebContentsObserverUnitTest,
               Show(url::Origin::Create(url),
                    PsstWebsiteSettingsEq(ConsentStatus::kAsk, 1, user_id,
                                          std::vector<std::string>()),
-                   _))
+                   _, _))
       .WillOnce(ShowCallback(&user_accept_psst_settings_future));
 
   // Policy script executed, parameters not added
@@ -802,6 +814,7 @@ TEST_F(PsstTabWebContentsObserverUnitTest, UiDelegateUpdateTasksCalled) {
           .Set("user_id", user_id)
           .Set("tasks",
                base::ListValue().Append(base::DictValue()
+                                            .Set("uid", "1")
                                             .Set("url", "https://example1.com")
                                             .Set("description", "settings")))
           .Set("site_name", "example"));
@@ -813,6 +826,7 @@ TEST_F(PsstTabWebContentsObserverUnitTest, UiDelegateUpdateTasksCalled) {
                       .Set("applied_tasks",
                            base::ListValue().Append(
                                base::DictValue()
+                                    .Set("uid", "1")
                                    .Set("url", url.spec())
                                    .Set("description", task_description))));
 
@@ -824,7 +838,7 @@ TEST_F(PsstTabWebContentsObserverUnitTest, UiDelegateUpdateTasksCalled) {
               Show(url::Origin::Create(url),
                    PsstWebsiteSettingsEq(ConsentStatus::kAsk, 1, user_id,
                                          std::vector<std::string>()),
-                   _))
+                   _, _))
       .WillOnce(ShowCallback(&user_accept_psst_settings_future));
 
   const auto policy_script_with_parameters = base::StrCat(

--- a/components/psst/browser/content/psst_tab_web_contents_observer_unittest.cc
+++ b/components/psst/browser/content/psst_tab_web_contents_observer_unittest.cc
@@ -826,7 +826,7 @@ TEST_F(PsstTabWebContentsObserverUnitTest, UiDelegateUpdateTasksCalled) {
                       .Set("applied_tasks",
                            base::ListValue().Append(
                                base::DictValue()
-                                    .Set("uid", "1")
+                                   .Set("uid", "1")
                                    .Set("url", url.spec())
                                    .Set("description", task_description))));
 

--- a/components/psst/browser/core/psst_settings_service.cc
+++ b/components/psst/browser/core/psst_settings_service.cc
@@ -14,7 +14,7 @@ namespace {
 constexpr char kUserIdSettingsKey[] = "user_id";
 constexpr char kConsentStatusSettingsKey[] = "consent_status";
 constexpr char kScriptVersionSettingsKey[] = "script_version";
-constexpr char kUrlsToSkipSettingsKey[] = "urls_to_skip";
+constexpr char kUidsToPerformSettingsKey[] = "uids_to_perform";
 
 base::ListValue VectorToList(std::vector<std::string> values) {
   base::ListValue list;
@@ -30,8 +30,8 @@ base::DictValue CreatePsstSettingsObject(PsstWebsiteSettings psst_metadata) {
   object.Set(kUserIdSettingsKey, psst_metadata.user_id);
   object.Set(kConsentStatusSettingsKey, ToString(psst_metadata.consent_status));
   object.Set(kScriptVersionSettingsKey, psst_metadata.script_version);
-  object.Set(kUrlsToSkipSettingsKey,
-             VectorToList(std::move(psst_metadata.urls_to_skip)));
+  object.Set(kUidsToPerformSettingsKey,
+             VectorToList(std::move(psst_metadata.uids_to_perform)));
   return object;
 }
 
@@ -65,13 +65,13 @@ void PsstSettingsService::SetPsstWebsiteSettings(const url::Origin& origin,
                                                  ConsentStatus consent_status,
                                                  int script_version,
                                                  std::string_view user_id,
-                                                 base::ListValue urls_to_skip) {
+                                                 base::ListValue uids_to_perform) {
   auto psst_metadata = PsstWebsiteSettings::FromValue(
       base::DictValue()
           .Set(kUserIdSettingsKey, user_id)
           .Set(kConsentStatusSettingsKey, ToString(consent_status))
           .Set(kScriptVersionSettingsKey, script_version)
-          .Set(kUrlsToSkipSettingsKey, std::move(urls_to_skip)));
+          .Set(kUidsToPerformSettingsKey, std::move(uids_to_perform)));
   if (!psst_metadata) {
     return;
   }

--- a/components/psst/browser/core/psst_settings_service.cc
+++ b/components/psst/browser/core/psst_settings_service.cc
@@ -61,11 +61,12 @@ std::optional<PsstWebsiteSettings> PsstSettingsService::GetPsstWebsiteSettings(
   return PsstWebsiteSettings::FromValue(*user_id_metadata_dict);
 }
 
-void PsstSettingsService::SetPsstWebsiteSettings(const url::Origin& origin,
-                                                 ConsentStatus consent_status,
-                                                 int script_version,
-                                                 std::string_view user_id,
-                                                 base::ListValue uids_to_perform) {
+void PsstSettingsService::SetPsstWebsiteSettings(
+    const url::Origin& origin,
+    ConsentStatus consent_status,
+    int script_version,
+    std::string_view user_id,
+    base::ListValue uids_to_perform) {
   auto psst_metadata = PsstWebsiteSettings::FromValue(
       base::DictValue()
           .Set(kUserIdSettingsKey, user_id)

--- a/components/psst/buildflags/buildflags.gni
+++ b/components/psst/buildflags/buildflags.gni
@@ -3,6 +3,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import("//brave/components/brave_origin/buildflags/buildflags.gni")
+
 declare_args() {
-  enable_psst = !is_android && !is_ios
+  enable_psst = !is_android && !is_ios && !is_brave_origin_branded
 }

--- a/components/psst/common/constants.h
+++ b/components/psst/common/constants.h
@@ -10,6 +10,9 @@ namespace psst {
 
 inline constexpr char kBravePsst[] = "bravePsst";
 
+inline constexpr char kBravePsstHost[] = "psst";
+inline constexpr char kBraveUIPsstURL[] = "chrome://psst/";
+
 }  // namespace psst
 
 #endif  // BRAVE_COMPONENTS_PSST_COMMON_CONSTANTS_H_

--- a/components/psst/common/psst_metadata_schema.idl
+++ b/components/psst/common/psst_metadata_schema.idl
@@ -20,7 +20,7 @@ namespace psst {
         long script_version;
         // Signed user identifier
         DOMString user_id;
-        // List of URLs where the user decided not to apply privacy settings
-        DOMString[] urls_to_skip;
+        // List of URLs where the user decided to apply privacy settings
+        DOMString[] uids_to_perform;
     };
 };

--- a/components/psst/common/psst_metadata_schema.idl
+++ b/components/psst/common/psst_metadata_schema.idl
@@ -20,7 +20,7 @@ namespace psst {
         long script_version;
         // Signed user identifier
         DOMString user_id;
-        // List of URLs where the user decided to apply privacy settings
+        // List of UIDs to which the user has applied privacy settings
         DOMString[] uids_to_perform;
     };
 };

--- a/components/psst/common/psst_script_responses.idl
+++ b/components/psst/common/psst_script_responses.idl
@@ -5,12 +5,20 @@
 
 // Schema for Brave PSST script responses.
 namespace psst {
+    dictionary UserScriptTask {
+        DOMString uid;
+        DOMString url;
+        DOMString description;
+    };
+
     dictionary UserScriptResult {
        DOMString user_id;
        DOMString site_name;
+       UserScriptTask[] tasks;
     };
 
     dictionary PolicyTask {
+        DOMString uid;
         DOMString url;
         DOMString description;
         DOMString? error_description;

--- a/components/psst/resources/ui/brave_psst_dialog.html
+++ b/components/psst/resources/ui/brave_psst_dialog.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width">
   <title>$i18n{PSST_CONSENT_DIALOG_TITLE}</title>
   <link rel="stylesheet" href="chrome://resources/brave/css/reset.css" blocking="render" >
-  <link rel="stylesheet" href="chrome://resources/brave/leo/css/nala.css" blocking="render" >
+  <link rel="stylesheet" href="chrome://resources/brave/css/nala.css" blocking="render" >
   <script src="chrome://resources/js/load_time_data_deprecated.js"></script>
   <script src="/strings.js"></script>
   <script src="/brave_psst_dialog.bundle.js"></script> 

--- a/components/test/data/psst/scripts/a/user.js
+++ b/components/test/data/psst/scripts/a/user.js
@@ -12,8 +12,8 @@
       "user_id": getUserId(),
       "site_name": "site name",
       "tasks": [
-        {"url": "https://a.test/settings/privacy_setting_1", "description": "privacy setting #1"},
-        {"url": "https://a.test/settings/privacy_setting_2", "description": "privacy setting #2"},
+        {"uid": "1", "url": "https://a.test/settings/privacy_setting_1", "description": "privacy setting #1"},
+        {"uid": "2", "url": "https://a.test/settings/privacy_setting_2", "description": "privacy setting #2"},
       ]
   }
 })();

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -959,7 +959,6 @@ test("brave_browser_tests") {
     "//brave/browser/ntp_background",
     "//brave/browser/permissions:browser_tests",
     "//brave/browser/profiles:util",
-    "//brave/browser/psst:browser_tests",
     "//brave/browser/regional_capabilities:browser_tests",
     "//brave/browser/sandbox:browser_tests",
     "//brave/browser/script_injector:browser_tests",
@@ -1472,6 +1471,13 @@ test("brave_browser_tests") {
     deps += android_only_test_deps
     sources -= android_test_exception_sources
     sources += android_only_test_sources
+  }
+
+  if (enable_psst) {
+    if (!is_mac) {
+      # Skip tests on MAC, See crbug.com/363677523
+      deps += [ "//brave/browser/psst:browser_tests" ]
+    }
   }
 }
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/53941

Added the back-end part for the previously added content dialog UI (https://github.com/brave/brave-core/pull/35441).
Implementation contains just a basic UI integration without modifying any existing PSST logic:
- Added an ability to display the consent dialog 
- Added handling of the Apply and Cancel buttons
- Updated the PSST Website settings schema to align with the front-end (saving UIDs to perform instead of URLs to skip)
- Updated unit and browser tests


<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
