### PR TITLE
[Android] Fixed NTP status bar dynamic color

### DIFF
--- a/android/java/org/chromium/chrome/browser/ui/system/BraveStatusBarColorController.java
+++ b/android/java/org/chromium/chrome/browser/ui/system/BraveStatusBarColorController.java
@@ -19,6 +19,7 @@ import org.chromium.chrome.browser.layouts.LayoutManager;
 import org.chromium.chrome.browser.lifecycle.ActivityLifecycleDispatcher;
 import org.chromium.chrome.browser.theme.TopUiThemeColorProvider;
 import org.chromium.chrome.browser.ui.system.StatusBarColorController.StatusBarColorProvider;
+import org.chromium.chrome.browser.util.BraveDynamicColors;
 import org.chromium.components.browser_ui.desktop_windowing.DesktopWindowStateManager;
 import org.chromium.ui.edge_to_edge.EdgeToEdgeSystemBarColorHelper;
 import org.chromium.ui.util.ColorUtils;
@@ -51,8 +52,10 @@ public class BraveStatusBarColorController extends StatusBarColorController {
                 desktopWindowStateManager,
                 overviewColorSupplier);
 
-        // Dark theme doesn't have the regression, apply adjustment to light one only
-        if (!ColorUtils.inNightMode(activity)) {
+        // Dark theme doesn't have the regression, apply adjustment to light one only.
+        // Skip when dynamic colors are enabled — the themed surface color should be used instead.
+        if (!ColorUtils.inNightMode(activity)
+                && !BraveDynamicColors.sDynamicColorsEnabled.isEnabled()) {
             mBackgroundColorForNtp = Color.WHITE;
         }
     }

--- a/android/junit/BUILD.gn
+++ b/android/junit/BUILD.gn
@@ -140,6 +140,12 @@ if (is_android) {
     deps = [ "//chrome/android/junit:chrome_junit_tests_helper" ]
   }
 
+  robolectric_library("brave_junit_tests_org.chromium.chrome.browser.ui") {
+    sources = [ "src/org/chromium/chrome/browser/ui/system/BraveStatusBarColorControllerUnitTest.java" ]
+
+    deps = [ "//chrome/android/junit:chrome_junit_tests_helper" ]
+  }
+
   robolectric_library(
       "brave_junit_tests_org.chromium.chrome.browser.autofill") {
     sources = [

--- a/android/junit/src/org/chromium/chrome/browser/ui/system/BraveStatusBarColorControllerUnitTest.java
+++ b/android/junit/src/org/chromium/chrome/browser/ui/system/BraveStatusBarColorControllerUnitTest.java
@@ -1,0 +1,111 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.chromium.chrome.browser.ui.system;
+
+import static org.junit.Assert.assertEquals;
+
+import android.app.Activity;
+import android.graphics.Color;
+
+import androidx.annotation.ColorInt;
+import androidx.core.content.ContextCompat;
+import androidx.test.ext.junit.rules.ActivityScenarioRule;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import org.chromium.base.BraveFeatureList;
+import org.chromium.base.supplier.MonotonicObservableSupplier;
+import org.chromium.base.supplier.ObservableSuppliers;
+import org.chromium.base.supplier.SettableNonNullObservableSupplier;
+import org.chromium.base.test.BaseRobolectricTestRunner;
+import org.chromium.base.test.util.Features.DisableFeatures;
+import org.chromium.base.test.util.Features.EnableFeatures;
+import org.chromium.chrome.R;
+import org.chromium.chrome.browser.ActivityTabProvider;
+import org.chromium.chrome.browser.layouts.LayoutManager;
+import org.chromium.chrome.browser.lifecycle.ActivityLifecycleDispatcher;
+import org.chromium.chrome.browser.theme.TopUiThemeColorProvider;
+import org.chromium.chrome.browser.ui.system.StatusBarColorController.StatusBarColorProvider;
+import org.chromium.components.browser_ui.desktop_windowing.DesktopWindowStateManager;
+import org.chromium.ui.base.TestActivity;
+import org.chromium.ui.edge_to_edge.EdgeToEdgeSystemBarColorHelper;
+
+/** Unit tests for {@link BraveStatusBarColorController}. */
+@RunWith(BaseRobolectricTestRunner.class)
+public class BraveStatusBarColorControllerUnitTest {
+    @Rule public final MockitoRule mMockitoRule = MockitoJUnit.rule();
+
+    @Rule
+    public final ActivityScenarioRule<TestActivity> mActivityScenarioRule =
+            new ActivityScenarioRule<>(TestActivity.class);
+
+    @Mock private StatusBarColorProvider mStatusBarColorProvider;
+    @Mock private ActivityLifecycleDispatcher mActivityLifecycleDispatcher;
+    @Mock private TopUiThemeColorProvider mTopUiThemeColorProvider;
+    @Mock private EdgeToEdgeSystemBarColorHelper mSystemBarColorHelper;
+    @Mock private DesktopWindowStateManager mDesktopWindowStateManager;
+
+    private final MonotonicObservableSupplier<LayoutManager> mLayoutManagerSupplier =
+            ObservableSuppliers.alwaysNull();
+    private final ActivityTabProvider mActivityTabProvider = new ActivityTabProvider();
+    private final SettableNonNullObservableSupplier<Integer> mOverviewColorSupplier =
+            ObservableSuppliers.createNonNull(Color.TRANSPARENT);
+
+    private Activity mActivity;
+
+    @Before
+    public void setUp() {
+        mActivityScenarioRule.getScenario().onActivity(activity -> mActivity = activity);
+    }
+
+    @Test
+    @DisableFeatures(BraveFeatureList.BRAVE_ANDROID_DYNAMIC_COLORS)
+    public void testBackgroundColorForNtp_dynamicColorsDisabled_returnsWhite() {
+        // Existing Brave behavior in light mode: force the NTP status-bar background to white
+        // to mask the upstream regression.
+        BraveStatusBarColorController controller = newController();
+        assertEquals(Color.WHITE, controller.getBackgroundColorForNtpForTesting());
+    }
+
+    @Test
+    @EnableFeatures(BraveFeatureList.BRAVE_ANDROID_DYNAMIC_COLORS)
+    public void testBackgroundColorForNtp_dynamicColorsEnabled_returnsUpstreamDefault() {
+        // With dynamic colors enabled the Brave override is skipped so the themed surface
+        // color (set by upstream's constructor) is preserved.
+        // home_surface_background_color resolves ?attr/colorSurface. In Robolectric the
+        // Material3 dynamic token chain isn't available, so colorSurface falls back to
+        // white - the same value Brave's override would set. The assertEquals below still
+        // documents that we preserve the upstream default; the companion test
+        // testBackgroundColorForNtp_dynamicColorsDisabled_returnsWhite provides the
+        // regression-catching coverage (if the guard is dropped, that test still asserts
+        // Color.WHITE is set, which is a deliberate Brave choice, not upstream's default).
+        @ColorInt
+        int upstreamDefault =
+                ContextCompat.getColor(mActivity, R.color.home_surface_background_color);
+        BraveStatusBarColorController controller = newController();
+        assertEquals(upstreamDefault, controller.getBackgroundColorForNtpForTesting());
+    }
+
+    private BraveStatusBarColorController newController() {
+        return new BraveStatusBarColorController(
+                mActivity,
+                /* isTablet= */ false,
+                mStatusBarColorProvider,
+                mLayoutManagerSupplier,
+                mActivityLifecycleDispatcher,
+                mActivityTabProvider,
+                mTopUiThemeColorProvider,
+                mSystemBarColorHelper,
+                mDesktopWindowStateManager,
+                mOverviewColorSupplier);
+    }
+}

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -1672,6 +1672,7 @@ if (is_android) {
       "//brave/android/junit:brave_junit_tests_org.chromium.chrome.browser.tabbed_mode",
       "//brave/android/junit:brave_junit_tests_org.chromium.chrome.browser.tasks",
       "//brave/android/junit:brave_junit_tests_org.chromium.chrome.browser.toolbar",
+      "//brave/android/junit:brave_junit_tests_org.chromium.chrome.browser.ui",
       "//brave/android/junit:brave_junit_tests_org.chromium.chrome.browser.vpn",
       "//brave/browser/customize_menu/android:junit",
       "//brave/browser/first_run/android:junit",


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/54252

### Screenshots 
Before|After
--|--
<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/f9bf114d-9e1b-4fc5-8f65-ff3fc2dc4dd5" />|<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/d484a881-de89-4c99-b622-fb13c9b23f4a" />

### Test plan
1. Enable `Dynamic Colors` at flags;
2. Open New Tab;
3. Expected to have the system status bar not of white color.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
