### PR TITLE
[iOS] Disable privacy reports & other notifications with Origin

### DIFF
--- a/ios/brave-ios/App/iOS/Delegates/SceneDelegate.swift
+++ b/ios/brave-ios/App/iOS/Delegates/SceneDelegate.swift
@@ -38,8 +38,11 @@ struct ProfileState {
   var migrations: BraveProfileMigrations
   var dau: DAU
   var attributionManager: AttributionManager
+  let profile: any Profile
 
   init(profileController: BraveProfileController) {
+    profile = profileController.profile
+
     // Setup DAU
     dau = DAU(braveCoreStats: profileController.braveStats)
 
@@ -453,7 +456,17 @@ extension SceneDelegate {
       object: nil
     )
 
-    PrivacyReportsManager.scheduleNotification(debugMode: !AppConstants.isOfficialBuild)
+    let originService = BraveOriginServiceFactory.get(profile: profileState.profile)
+    Task {
+      // This is early enough in the app lifetime that we need to explicitly call
+      // `checkPurchaseState` rather than simply read `isPurchased` as it wont yet be cached.
+      let isOriginPurchased = await originService?.checkPurchaseState() ?? false
+      if isOriginPurchased {
+        PrivacyReportsManager.cancelNotification()
+      } else {
+        PrivacyReportsManager.scheduleNotification(debugMode: !AppConstants.isOfficialBuild)
+      }
+    }
     PrivacyReportsManager.consolidateData()
     PrivacyReportsManager.scheduleProcessingBlockedRequests(
       isPrivateBrowsing: browserViewController.privateBrowsingManager.isPrivateBrowsing

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -1044,6 +1044,11 @@ public class BrowserViewController: UIViewController {
   public static let defaultBrowserNotificationId = "defaultBrowserNotification"
 
   private func scheduleDefaultBrowserNotification() {
+    if BraveOriginServiceFactory.get(profile: profileController.profile)?.isPurchased() == true {
+      Self.cancelScheduleDefaultBrowserNotification()
+      return
+    }
+
     let center = UNUserNotificationCenter.current()
 
     center.requestAuthorization(options: [.provisional, .alert, .sound, .badge]) { granted, error in
@@ -1096,7 +1101,7 @@ public class BrowserViewController: UIViewController {
     }
   }
 
-  private func cancelScheduleDefaultBrowserNotification() {
+  static func cancelScheduleDefaultBrowserNotification() {
     let center = UNUserNotificationCenter.current()
     center.removePendingNotificationRequests(withIdentifiers: [Self.defaultBrowserNotificationId])
 
@@ -2972,7 +2977,11 @@ extension BrowserViewController: PreferencesObserver {
       PrivacyReportsManager.scheduleProcessingBlockedRequests(
         isPrivateBrowsing: privateBrowsingManager.isPrivateBrowsing
       )
-      PrivacyReportsManager.scheduleNotification(debugMode: !AppConstants.isOfficialBuild)
+      if BraveOriginServiceFactory.get(profile: profileController.profile)?.isPurchased() == true {
+        PrivacyReportsManager.cancelNotification()
+      } else {
+        PrivacyReportsManager.scheduleNotification(debugMode: !AppConstants.isOfficialBuild)
+      }
     case Preferences.PrivacyReports.captureVPNAlerts.key:
       PrivacyReportsManager.scheduleVPNAlertsTask()
     case Preferences.Wallet.defaultEthWallet.key:
@@ -3060,7 +3069,7 @@ extension BrowserViewController {
         // Remove pending notification if default browser is set brave
         // Recognized by external link is open
         if !Preferences.DefaultBrowserIntro.defaultBrowserNotificationIsCanceled.value {
-          cancelScheduleDefaultBrowserNotification()
+          Self.cancelScheduleDefaultBrowserNotification()
         }
       }
     }
@@ -3185,9 +3194,12 @@ extension BrowserViewController {
       return
     }
 
+    let isOriginPurchased =
+      BraveOriginServiceFactory.get(profile: profileController.profile)?.isPurchased() == true
     let host = UIHostingController(
       rootView: PrivacyReportsManager.prepareView(
-        isPrivateBrowsing: privateBrowsingManager.isPrivateBrowsing
+        isPrivateBrowsing: privateBrowsingManager.isPrivateBrowsing,
+        isOriginPurchased: isOriginPurchased
       )
     )
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/NewTabPage/NewTabPageViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/NewTabPage/NewTabPageViewController.swift
@@ -204,9 +204,12 @@ class NewTabPageViewController: UIViewController {
             return
           }
 
+          let isOriginPurchased =
+            BraveOriginServiceFactory.get(profile: tab.profile)?.isPurchased() == true
           let host = UIHostingController(
             rootView: PrivacyReportsManager.prepareView(
-              isPrivateBrowsing: privateBrowsingManager.isPrivateBrowsing
+              isPrivateBrowsing: privateBrowsingManager.isPrivateBrowsing,
+              isOriginPurchased: isOriginPurchased
             )
           )
           host.rootView.onDismiss = { [weak self] in

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/PrivacyHub/PrivacyReportsManager.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/PrivacyHub/PrivacyReportsManager.swift
@@ -83,9 +83,16 @@ public struct PrivacyReportsManager {
 
   // MARK: - View
   /// Fetches required data to present the privacy reports view and returns the view.
-  static func prepareView(isPrivateBrowsing: Bool) -> PrivacyReportsView {
+  static func prepareView(
+    isPrivateBrowsing: Bool,
+    isOriginPurchased: Bool
+  ) -> PrivacyReportsView {
     let last = BraveVPNAlert.last(3)
-    let view = PrivacyReportsView(lastVPNAlerts: last, isPrivateBrowsing: isPrivateBrowsing)
+    var view = PrivacyReportsView(
+      lastVPNAlerts: last,
+      isPrivateBrowsing: isPrivateBrowsing,
+      isOriginPurchased: isOriginPurchased
+    )
 
     Preferences.PrivacyReports.ntpOnboardingCompleted.value = true
 
@@ -154,7 +161,7 @@ public struct PrivacyReportsManager {
     }
   }
 
-  static func cancelNotification() {
+  public static func cancelNotification() {
     UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: [
       notificationID
     ])

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/PrivacyHub/PrivacyReportsView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/PrivacyHub/PrivacyReportsView.swift
@@ -14,6 +14,7 @@ struct PrivacyReportsView: View {
   let lastVPNAlerts: [BraveVPNAlert]?
 
   private(set) var isPrivateBrowsing: Bool
+  var isOriginPurchased: Bool
   var onDismiss: (() -> Void)?
   var openPrivacyReportsUrl: (() -> Void)?
 
@@ -82,7 +83,7 @@ struct PrivacyReportsView: View {
       ScrollView(.vertical) {
         VStack(alignment: .leading, spacing: 16) {
 
-          if showNotificationPermissionCallout.value && correctAuthStatus {
+          if showNotificationPermissionCallout.value && correctAuthStatus && !isOriginPurchased {
             NotificationCalloutView()
           }
 
@@ -146,9 +147,11 @@ struct PrivacyReports_Previews: PreviewProvider {
   static var previews: some View {
 
     Group {
-      PrivacyReportsView(lastVPNAlerts: nil, isPrivateBrowsing: false)
+      PrivacyReportsView(lastVPNAlerts: nil, isPrivateBrowsing: false, isOriginPurchased: false)
 
-      PrivacyReportsView(lastVPNAlerts: nil, isPrivateBrowsing: false)
+      PrivacyReportsView(lastVPNAlerts: nil, isPrivateBrowsing: false, isOriginPurchased: true)
+
+      PrivacyReportsView(lastVPNAlerts: nil, isPrivateBrowsing: false, isOriginPurchased: false)
         .preferredColorScheme(.dark)
     }
   }

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/SettingsViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/SettingsViewController.swift
@@ -889,6 +889,8 @@ class SettingsViewController: TableViewController {
                 rootView: OriginPaywallView(
                   viewModel: .init(store: .init(skusService: skusService)),
                   didPurchase: { [weak self] in
+                    PrivacyReportsManager.cancelNotification()
+                    BrowserViewController.cancelScheduleDefaultBrowserNotification()
                     self?.navigationController?.pushViewController(
                       originSettingsController(),
                       animated: true


### PR DESCRIPTION
This avoids scheduling the privacy reports & default browser notifications when the user has Brave Origin purchased

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/54828

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
