### PR TITLE
Require private browsing lock auth from Playlist (uplift to 1.90.x)

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Playlist/ManagersAndCache/PlaylistCoordinator.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Playlist/ManagersAndCache/PlaylistCoordinator.swift
@@ -119,12 +119,29 @@ public class PlaylistCoordinator: NSObject {
       player: player,
       delegate: .init(
         openTabURL: { [weak browserController] url, isPrivate in
-          browserController?.dismiss(animated: true)
-          browserController?.openURLInNewTab(
-            url,
-            isPrivate: Preferences.Privacy.privateBrowsingOnly.value ? true : isPrivate,
-            isPrivileged: false
-          )
+          guard let browserController else { return }
+          let isPrivate = Preferences.Privacy.privateBrowsingOnly.value ? true : isPrivate
+          let openTab: () -> Void = {
+            browserController.dismiss(animated: true)
+            browserController.openURLInNewTab(
+              url,
+              isPrivate: isPrivate,
+              isPrivileged: false
+            )
+          }
+
+          if isPrivate,
+            !browserController.privateBrowsingManager.isPrivateBrowsing,
+            Preferences.Privacy.privateBrowsingLock.value
+          {
+            browserController.askForLocalAuthentication { success, _ in
+              if success {
+                openTab()
+              }
+            }
+          } else {
+            openTab()
+          }
         },
         onDismissal: { [weak self, weak player] in
           guard let self else { return }


### PR DESCRIPTION
Uplift of #35891
Resolves https://github.com/brave/brave-browser/issues/54935
Resolves https://github.com/brave/internal/issues/1716

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.