### PR TITLE
[brockit] Conflict-resolved dev cycles patches just `fixup!`

### DIFF
--- a/tools/cr/brockit.py
+++ b/tools/cr/brockit.py
@@ -345,7 +345,8 @@ class ApplyPatchesRecord:
 
     # A dictionary of all patches with attempted `--3way`, grouped by
     # repository.
-    patch_files: dict[Repository, Patchfile] = field(default_factory=dict)
+    patch_files: dict[Repository,
+                      list[Patchfile]] = field(default_factory=dict)
 
     # A list of patches that cannot be applied due to their source file being
     # deleted.
@@ -357,6 +358,10 @@ class ApplyPatchesRecord:
     # A list of patches that fail entirely when running apply with `--3way`.
     broken_patches: list[Patchfile] = field(default_factory=list)
 
+    def all_conflict_resolved_patches(self) -> list[Patchfile]:
+        """Returns a flattened list of all conflict-resolved candidates."""
+        return [p for patches in self.patch_files.values() for p in patches]
+
     def requires_conflict_resolution(self):
         """Checks if there are any patches that require manual conflict
         resolution.
@@ -367,7 +372,7 @@ class ApplyPatchesRecord:
         return (self.files_with_conflicts or self.patches_to_deleted_files
                 or self.broken_patches)
 
-    def stage_all_patches(self, ignore_deleted_files=False):
+    def stage_all_patches(self):
         """Stages all patches that were applied, so they can be committed as
         conflict-resolved patches.
 
@@ -377,7 +382,7 @@ class ApplyPatchesRecord:
         """
         for _, patches in self.patch_files.items():
             for patch in patches:
-                if (ignore_deleted_files and not Path(patch.path).exists()):
+                if not Path(patch.path).exists():
                     # Skip deleted files.
                     continue
 
@@ -555,6 +560,10 @@ class Versioned(Task):
                 f'Target version {self.target_version} is not higher than base '
                 f'version {self.base_version}.')
 
+    def is_major(self) -> bool:
+        """Returns True if this is a major version upgrade."""
+        return self.target_version.major > self.base_version.major
+
     def _save_updated_patches(self):
         """Creates the updated patches change
 
@@ -656,7 +665,7 @@ class GitHubIssue(Versioned):
         This title is the same used for the push request.
         """
         title = 'Upgrade from Chromium {previous} to Chromium {to}'
-        if self.target_version.major > self.base_version.major:
+        if self.is_major():
             # For major updates, the issue description doesn't have a precise
             # version number.
             title = title.format(previous=str(self.base_version.major),
@@ -731,14 +740,12 @@ class GitHubIssue(Versioned):
         else:
             cmd += ['--assignee', 'mkarolin', '--assignee', 'samartnik']
 
-        is_major = self.target_version.major > self.base_version.major
-
-        if is_major or upstream_branch == 'master':
+        if self.is_major() or upstream_branch == 'master':
             # It is not common for upstream test to be run on uplifts of minor
             # upgrades.
             cmd += ['--label', '"CI/run-upstream-tests"']
 
-        if is_major:
+        if self.is_major():
             cmd += ['--label', '"CI/storybook-url"']
 
             # Always create PR for major version upgrades as draft
@@ -1124,13 +1131,8 @@ class Upgrade(Versioned):
             f'Update from Chromium {self.base_version} '
             f'to Chromium {self.target_version}.')
 
-    def _save_conflict_resolved_patches(self):
-        repository.brave.git_commit(
-            f'Conflict-resolved patches from Chromium {self.base_version} to '
-            f'Chromium {self.target_version}.')
-
-    def _run_update_patches_with_no_deletions(self):
-        """Runs update_patches and returns if any deleted patches are found.
+    def _run_update_patches(self) -> GitStatus:
+        """Runs update_patches and returns the resulting GitStatus.
 
         This function is usually preferred, as it checks if any patches are
         deleted after running update_patches. Deleted patches should be
@@ -1138,7 +1140,7 @@ class Upgrade(Versioned):
         anymore.
 
         return:
-          Returns True if no deleted patches are found, and False otherwise.
+          The GitStatus after running update_patches.
         """
         terminal.run_npm_command('update_patches')
 
@@ -1172,7 +1174,7 @@ class Upgrade(Versioned):
             if path.startswith('patches/') and path.endswith('.patch')
         ]
         if not modified_patches:
-            return
+            return status
 
         def count_hunks(contents: str) -> int:
             return contents.count('\n@@ -')
@@ -1196,6 +1198,8 @@ class Upgrade(Versioned):
                 'hunks, and are expected to be submitted separately as fixes '
                 'with Chromium culprits:\n'
                 f'{list_str}')
+
+        return status
 
     def look_for_diffs(self, *files) -> str:
         """Return the diffs for the files provided for this upgrade.
@@ -1470,25 +1474,71 @@ class Upgrade(Versioned):
             apply_record = (ContinuationFile.load(
                 self.target_version).apply_record)
 
-        self._run_update_patches_with_no_deletions()
+        update_status = self._run_update_patches()
 
-        # There are rare cases where we can end up hitting a continuation where
-        # a patch gets deleted due a cherry-pick finally being made obsolete,
-        # which means no apply records ever occurred, and therefore this value
-        # is None.
+        # `apply_records` is not guaranteed to exist for every continuation. In
+        # some cases `_run_update_patches` is reponsible for pausing the lift
+        # process (e.g. cherry-pick shows up in upstream and causes patch
+        # deletions without 3way apply).
+        conflict_resolved_patches = None
         if apply_record:
-            apply_record.stage_all_patches(ignore_deleted_files=True)
-            has_changes = repository.brave.has_staged_changed()
-        else:
-            has_changes = False
+            # A list of all "Conflict-resolved" candidates still waiting to be
+            # committed.
+            conflict_resolved_patches = {
+                patch.path.as_posix()
+                for patch in apply_record.all_conflict_resolved_patches()
+                if patch.path.as_posix() in update_status.unstaged.modified
+            }
 
-        if not has_changes and not no_conflict_continuation:
+            if (self.is_major()):
+                # When doing incremental lifts in branch, there can be cases
+                # where a patch has been added/changed by a particular fix in
+                # the branch, and therefore at this stage, it is more
+                # appropriate to commit that patch as a fixup to the last
+                # change in the branch that touched it, otherwise it will cause
+                # conflicts when doing `rebase --squash-minor-bumps`, with the
+                # conflict-resolved commit being moved above the last change
+                # for that patch.
+                up_to_git_ref = _solve_brave_ref('@previous-major')
+
+                fixup_groups: dict[str, list[str]] = {}
+                for patch_path in conflict_resolved_patches:
+                    commits = repository.brave.run_git(
+                        'log', '--pretty=%H %s', f'{up_to_git_ref}..HEAD',
+                        '--', patch_path)
+
+                    for line in commits.splitlines():
+                        commit_hash, subject = line.split(' ', 1)
+                        if (not subject.startswith(
+                                'Conflict-resolved patches from Chromium ')
+                                and not subject.startswith(
+                                    'Update patches from Chromium ')):
+                            fixup_groups.setdefault(commit_hash,
+                                                    []).append(patch_path)
+                            break
+
+                # Commit patches grouped by the target commit to avoid multiple
+                # fixups for the same change.
+                fixup_patches: set[str] = set()
+                for fixup_target, patch_paths in fixup_groups.items():
+                    for patch_path in patch_paths:
+                        repository.brave.run_git('add', patch_path)
+                        fixup_patches.add(patch_path)
+                    repository.brave.git_commit_fixup(fixup_target)
+
+                conflict_resolved_patches -= fixup_patches
+
+        if not conflict_resolved_patches and not no_conflict_continuation:
             raise InvalidInputException(
                 'Nothing has been staged to commit conflict-resolved patches. '
                 '(Did you mean to pass [bold cyan]--no-conflict-change[/]?)')
 
-        if has_changes:
-            self._save_conflict_resolved_patches()
+        if conflict_resolved_patches:
+            repository.brave.run_git('add', *conflict_resolved_patches)
+            repository.brave.git_commit(
+                f'Conflict-resolved patches from Chromium {self.base_version} '
+                f'to Chromium {self.target_version}.')
+
 
         self._save_updated_patches()
         # Run init again to make sure nothing is missing after updating
@@ -1508,7 +1558,7 @@ class Upgrade(Versioned):
     This function is responsible for starting the upgrade process. It will
     update the package version, run `npm run init`, and then run
     `npm run update_patches`. If any patches fail to apply, it will run
-    `npm run apply_patches_3way` to allow for manual conflict resolution.
+    `apply_patches_3way` to allow for manual conflict resolution.
 
     For cases where no conflict resolution is required, the process will
     will continue, concluding the whole four steps of the upgrade process.
@@ -1541,7 +1591,7 @@ class Upgrade(Versioned):
             'Changes since base version: %s' %
             self.target_version.get_googlesource_diff_link(self.base_version))
 
-        if self.target_version.major > self.base_version.major:
+        if self.is_major():
             # When doing a major lift, the branch name should indicate that
             # (e.g. `cr149`).
             expected_branch = f'cr{self.target_version.major}'
@@ -1564,7 +1614,7 @@ class Upgrade(Versioned):
 
             # When no conflicts come back, we can proceed with the
             # update_patches.
-            self._run_update_patches_with_no_deletions()
+            self._run_update_patches()
         except subprocess.CalledProcessError as e:
             if ('There were some failures during git reset of specific '
                     'repo paths' in e.stderr):

--- a/tools/cr/repository.py
+++ b/tools/cr/repository.py
@@ -84,7 +84,7 @@ class Repository:
         """
         self.run_git('reset', 'HEAD')
 
-    def has_staged_changed(self) -> bool:
+    def has_staged_changes(self) -> bool:
         return self.run_git('diff', '--cached', '--stat') != ''
 
     def get_commit_short_description(self, commit: str = 'HEAD') -> str:
@@ -93,6 +93,40 @@ class Repository:
         This is just the actual first line of the commit message.
         """
         return self.run_git('log', '-1', '--pretty=%s', commit)
+
+    def _git_commit_internal(self,
+                             args: list[str],
+                             allows_empty: bool,
+                             no_verify: bool = False):
+        """Shared implementation for git commit operations.
+
+        Args:
+        args:
+            The git commit arguments (everything after 'commit').
+        allows_empty:
+            Whether to allow empty commits.
+        no_verify:
+            Whether to skip pre-commit and commit-msg hooks.
+        """
+        has_staged_changes = self.has_staged_changes()
+        if not allows_empty and not has_staged_changes:
+            # Nothing to commit
+            return
+        if allows_empty and has_staged_changes:
+            # Throwing an error if anything is staged as that could result in
+            # unintentionally committing changes.
+            raise ValueError(
+                'Cannot allow empty commits if there are staged changes.')
+
+        if allows_empty:
+            args.append('--allow-empty')
+        if no_verify:
+            args.append('--no-verify')
+        self.run_git('commit', *args)
+
+        commit = self.run_git('log', '-1', '--pretty=oneline',
+                              '--abbrev-commit')
+        terminal.log_task(f'[bold]✔️ [/] [italic]{escape(commit)}')
 
     def git_commit(self,
                    message: str,
@@ -112,26 +146,22 @@ class Repository:
         no_verify:
             Whether to skip pre-commit and commit-msg hooks.
         """
-        has_staged_changed = self.has_staged_changed()
-        if not allows_empty and not has_staged_changed:
-            # Nothing to commit
-            return
-        if allows_empty and has_staged_changed:
-            # Throwing an error if anything is staged as that could result in
-            # unintentionally committing changes.
-            raise ValueError(
-                'Cannot allow empty commits if there are staged changes.')
+        self._git_commit_internal(['-m', message], allows_empty, no_verify)
 
-        args = ['commit', '-m', message]
-        if allows_empty:
-            args.append('--allow-empty')
-        if no_verify:
-            args.append('--no-verify')
-        self.run_git(*args)
+    def git_commit_fixup(self, commit: str, allows_empty: bool = False):
+        """Commits the current staged changes as a fixup for a given commit.
 
-        commit = self.run_git('log', '-1', '--pretty=oneline',
-                              '--abbrev-commit')
-        terminal.log_task(f'[bold]✔️ [/] [italic]{escape(commit)}')
+    This function calls `git commit --fixup` and prints a user friendly message
+    as a result. No commit will be created if nothing is staged, unless
+    allows_empty is set to True.
+
+        Args:
+        commit:
+            The commit hash to create a fixup for.
+        allows_empty:
+            Whether to allow empty commits.
+        """
+        self._git_commit_internal(['--fixup', commit], allows_empty)
 
     def is_valid_git_reference(self, reference: str) -> bool:
         """Checks if a name is a valid git branch name or hash.

--- a/tools/cr/repository_test.py
+++ b/tools/cr/repository_test.py
@@ -110,26 +110,26 @@ class RepositoryTest(unittest.TestCase):
             mock_run_git.assert_called_once_with("log", no_trim=False)
 
     def test_unstage_all_changes(self):
-        """Test unstage_all_changes and has_staged_changed."""
+        """Test unstage_all_changes and has_staged_changes."""
         # Create a new file and stage it
         test_file = self.fake_chromium_src.chromium / "test_file.txt"
         test_file.write_text("Test content")
         repository.chromium.run_git("add", str(test_file))
 
-        # Verify the file is staged and has_staged_changed returns True
+        # Verify the file is staged and has_staged_changes returns True
         staged_files = repository.chromium.run_git("diff", "--cached",
                                                    "--name-only")
         self.assertIn("test_file.txt", staged_files)
-        self.assertTrue(repository.chromium.has_staged_changed())
+        self.assertTrue(repository.chromium.has_staged_changes())
 
         # Unstage all changes
         repository.chromium.unstage_all_changes()
 
-        # Verify the file is no longer staged and has_staged_changed is false
+        # Verify the file is no longer staged and has_staged_changes is false
         staged_files_after = repository.chromium.run_git(
             "diff", "--cached", "--name-only")
         self.assertNotIn("test_file.txt", staged_files_after)
-        self.assertFalse(repository.chromium.has_staged_changed())
+        self.assertFalse(repository.chromium.has_staged_changes())
 
     def test_get_commit_short_description(self):
         """Test get_commit_short_description using the chromium repository."""
@@ -188,9 +188,66 @@ class RepositoryTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             repository.chromium.git_commit('Should fail', allows_empty=True)
 
+    def test_git_commit_fixup(self):
+        """Test git_commit_fixup."""
+
+        # Case 1: Fixup commit is created when there are staged changes.
+        target_hash = self.fake_chromium_src.commit_empty(
+            'Target commit', self.fake_chromium_src.chromium)
+
+        test_file = self.fake_chromium_src.chromium / 'fixup_file.txt'
+        test_file.write_text('fixup content')
+        repository.chromium.run_git('add', str(test_file))
+        repository.chromium.git_commit_fixup(target_hash)
+
+        last_subject = repository.chromium.get_commit_short_description()
+        self.assertEqual(last_subject, 'fixup! Target commit')
+
+        # Case 2: No commit is created when nothing is staged.
+        head_before = repository.chromium.run_git('rev-parse', 'HEAD')
+        repository.chromium.git_commit_fixup(target_hash)
+        self.assertEqual(repository.chromium.run_git('rev-parse', 'HEAD'),
+                         head_before)
+
+    def test_git_commit_fixup_allows_empty(self):
+        """Test git_commit_fixup with allows_empty."""
+        target_hash = self.fake_chromium_src.commit_empty(
+            'Target commit', self.fake_chromium_src.chromium)
+
+        # Case 1: Empty fixup commit is created when allows_empty=True and
+        # there are no staged changes.
+        head_before = repository.chromium.run_git('rev-parse', 'HEAD')
+        repository.chromium.git_commit_fixup(target_hash, allows_empty=True)
+
+        self.assertEqual(repository.chromium.get_commit_short_description(),
+                         'fixup! Target commit')
+        self.assertEqual(repository.chromium.run_git('rev-parse', 'HEAD~1'),
+                         head_before)
+
+        # Case 2: allows_empty=True raises when there are staged changes.
+        test_file = self.fake_chromium_src.chromium / 'fixup_file.txt'
+        test_file.write_text('staged content')
+        repository.chromium.run_git('add', str(test_file))
+
+        with self.assertRaises(ValueError):
+            repository.chromium.git_commit_fixup(target_hash,
+                                                 allows_empty=True)
+
+    def test_git_commit_fixup_uses_fixup_flag(self):
+        """Test git_commit_fixup passes --fixup to git commit."""
+        with patch.object(Repository, 'has_staged_changes',
+                          return_value=True), patch.object(
+                              Repository,
+                              'run_git',
+                              return_value='abcd123 msg') as mock_run_git:
+            repository.chromium.git_commit_fixup('deadbeef')
+
+        self.assertIn(unittest.mock.call('commit', '--fixup', 'deadbeef'),
+                      mock_run_git.mock_calls)
+
     def test_git_commit_no_verify(self):
         """Test git_commit passes --no-verify when no_verify=True."""
-        with patch.object(Repository, 'has_staged_changed',
+        with patch.object(Repository, 'has_staged_changes',
                           return_value=True), patch.object(
                               Repository,
                               'run_git',


### PR DESCRIPTION
Patch files flagged for conflict resolution in most cases will end up
committed by `brockit` in a "Conflict-Resolved" change. These
"Conflict-Resolved" commits tend to occur daily with brockit, and they
eventually get squashed when calling `rebase --squash-minor-bumps`. The
issue this PR solves, is that when a patch is added/changed during the
`cr` development cycle, that patch may end up becoming a conflict
resolution candidate, and added to a "Conflict-Resolved" commit, which
will eventually be picked up with `rebase --squash-minor-bumps` for
squashing, and this will cause the commit to be moved prior to the patch
being added/modified, resulting in a rebase conflict.

This PR adds additional handling committing conflict-resolved patches,
where a lookup for the patch in the branch history is carried out, to
verify if any changes in the branch dev cycle are relevant for that
patch, and if so, to commit the conflict-resolved patch as a `fixup!`
for that change. This way, the next `rebase --squash-minor-bumps`
squahses the fixup to the relevant changes, and no conflicts arise from
having a "Conflict-resolved" patch being squashed with changes that have
not been introduced yet.

This approach is only employed for lifts in branches doing major version
upgrades, as these branches are worked on an incremental schedule, where
the need for this type of handling becomes apparent.

Resolves https://github.com/brave/brave-browser/issues/54994
