### PR TITLE
[Shields UI] Enable shields when adblock-only mode is enabled (uplift to 1.90.x)

### DIFF
--- a/components/brave_shields/resources/panel_new/components/ad_block_only_prompt.tsx
+++ b/components/brave_shields/resources/panel_new/components/ad_block_only_prompt.tsx
@@ -30,9 +30,9 @@ export function MaybeAdBlockOnlyPrompt() {
     siteBlockInfo.showShieldsDisabledAdBlockOnlyModePrompt
 
   if (!adblockOnlyEnabled) {
-    const showForRepeatedDownloads = shieldsEnabled && repeatedReloadsDetected
+    const showForRepeatedReloads = shieldsEnabled && repeatedReloadsDetected
     const showForShieldsDisabled = !shieldsEnabled && showDisabledPrompt
-    if (showForRepeatedDownloads || showForShieldsDisabled) {
+    if (showForRepeatedReloads || showForShieldsDisabled) {
       return <AdBlockOnlyEnablePrompt />
     }
   }
@@ -46,6 +46,7 @@ export function MaybeAdBlockOnlyPrompt() {
 
 function AdBlockOnlyEnablePrompt() {
   const api = useShieldsApi()
+  const setShieldsEnabled = api.setBraveShieldsEnabled
   const setAdBlockOnlyModeEnabled = api.setBraveShieldsAdBlockOnlyModeEnabled
   const setAdBlockOnlyModePromptDismissed =
     api.setBraveShieldsAdBlockOnlyModePromptDismissed
@@ -72,7 +73,12 @@ function AdBlockOnlyEnablePrompt() {
         )}
       </p>
       <div className='actions'>
-        <Button onClick={() => setAdBlockOnlyModeEnabled([true])}>
+        <Button
+          onClick={() => {
+            setShieldsEnabled([true])
+            setAdBlockOnlyModeEnabled([true])
+          }}
+        >
           {getString('BRAVE_SHIELDS_ENABLE_AD_BLOCK_ONLY_MODE')}
         </Button>
         <Button


### PR DESCRIPTION
Uplift of #35825
Resolves https://github.com/brave/brave-browser/issues/54868

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.