### PR TITLE
[iOS] Handle purchase flow cancellation in Origin paywall correctly

### DIFF
--- a/ios/brave-ios/Sources/BraveStore/Subscription/SDK/BraveStoreSDK.swift
+++ b/ios/brave-ios/Sources/BraveStore/Subscription/SDK/BraveStoreSDK.swift
@@ -366,12 +366,14 @@ public class BraveStoreSDK: AppStoreSDK {
   /// - Throws: An exception if purchasing fails for any reason.
   ///           Purchase may be successful with the AppStore, but fail with SkusSDK.
   @MainActor
-  public func purchase(product: BraveStoreProduct) async throws {
+  @discardableResult
+  public func purchase(product: BraveStoreProduct) async throws -> Bool {
     // Handle non-consumable purchases (Origin)
     if product == .originPurchase {
       if let nonConsumableProduct = await nonConsumablePurchase(for: product) {
         if try await super.purchase(nonConsumableProduct) != nil {
           Logger.module.info("[BraveStoreSDK] - Product Purchase Successful")
+          return true
         }
       }
     } else {
@@ -379,9 +381,11 @@ public class BraveStoreSDK: AppStoreSDK {
       if let subscription = await subscription(for: product) {
         if try await super.purchase(subscription) != nil {
           Logger.module.info("[BraveStoreSDK] - Product Purchase Successful")
+          return true
         }
       }
     }
+    return false
   }
 
   /// Retrieves a non-consumable product from the loaded products

--- a/ios/brave-ios/Sources/Origin/OriginPaywallViewModel.swift
+++ b/ios/brave-ios/Sources/Origin/OriginPaywallViewModel.swift
@@ -34,8 +34,9 @@ public class OriginPaywallViewModel {
     defer { isStoreOperationActive = false }
 
     do {
-      try await store.purchase(product: .originPurchase)
-      return true
+      if try await store.purchase(product: .originPurchase) {
+        return true
+      }
     } catch {
       isErrorPresented = true
     }


### PR DESCRIPTION
This fixes a bug where if you cancelled the payment flow on the Origin paywall it would still dismiss the paywall and send you to the Origin settings page

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/55002
