### PR TITLE
[iOS] Hide shortcut button for features disabled by Origin

### DIFF
--- a/ios/brave-ios/Sources/Brave/Extensions/WidgetShortcutExtension.swift
+++ b/ios/brave-ios/Sources/Brave/Extensions/WidgetShortcutExtension.swift
@@ -3,24 +3,44 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import BraveCore
 import BraveStrings
 import BraveWidgetsModels
 import DesignSystem
 import Foundation
+import OrderedCollections
 import Strings
 import UIKit
 
 extension WidgetShortcut {
-  static let eligibleButtonShortcuts: [WidgetShortcut] = [
-    .bookmarks,
-    .history,
-    .downloads,
-    .playlist,
-    .wallet,
-    .braveNews,
-    .braveLeo,
-    .askBrave,
-  ]
+  static func eligibleButtonShortcuts(
+    prefs: any PrefService,
+    isWalletAvailable: Bool
+  ) -> OrderedSet<WidgetShortcut> {
+    var options = OrderedSet<WidgetShortcut>([
+      .bookmarks,
+      .history,
+      .downloads,
+      .playlist,
+      .wallet,
+      .braveNews,
+      .braveLeo,
+      .askBrave,
+    ])
+    if !prefs.isPlaylistAvailable {
+      options.remove(.playlist)
+    }
+    if !prefs.isBraveNewsAvailable {
+      options.remove(.braveNews)
+    }
+    if !isWalletAvailable {
+      options.remove(.wallet)
+    }
+    if !AIChatUtils.isAIChatEnabled(for: prefs) {
+      options.remove(.braveLeo)
+    }
+    return options
+  }
 
   var displayString: String {
     switch self {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ToolbarDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ToolbarDelegate.swift
@@ -16,6 +16,7 @@ import CertificateUtilities
 import Data
 import Lottie
 import Onboarding
+import OrderedCollections
 import Playlist
 import Preferences
 import Shared
@@ -570,6 +571,15 @@ extension BrowserViewController: TopToolbarDelegate {
       return
     }
     NavigationPath.handleWidgetShortcut(shortcut, with: self)
+  }
+
+  func topToolbarAvailableShortcutButtons(
+    _ topToolbar: TopToolbarView
+  ) -> OrderedSet<WidgetShortcut> {
+    return WidgetShortcut.eligibleButtonShortcuts(
+      prefs: profileController.profile.prefs,
+      isWalletAvailable: profileController.braveWalletAPI.isAllowed
+    )
   }
 
   func topToolbarDidTapBraveRewardsButton(_ topToolbar: TopToolbarView) {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -559,6 +559,14 @@ public class BrowserViewController: UIViewController {
         configuration.prepareBraveConfiguration()
       }
     }
+
+    Task { @MainActor in
+      if let originService = BraveOriginServiceFactory.get(profile: profileController.profile),
+        await originService.checkPurchaseState()
+      {
+        topToolbar.updateViewsForOverlayModeAndToolbarChanges()
+      }
+    }
   }
 
   private func setupAdsNotificationHandler() {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
@@ -8,6 +8,7 @@ import BraveWidgetsModels
 import Combine
 import Data
 import DesignSystem
+import OrderedCollections
 import Preferences
 import Shared
 import SnapKit
@@ -32,6 +33,9 @@ protocol TopToolbarDelegate: AnyObject {
   // Returns either (search query, true) or (url, false).
   func topToolbarDisplayTextForURL(_ url: URL?) -> (String?, Bool)
   func topToolbarDidBeginDragInteraction(_ topToolbar: TopToolbarView)
+  func topToolbarAvailableShortcutButtons(
+    _ topToolbar: TopToolbarView
+  ) -> OrderedSet<WidgetShortcut>
   func topToolbarDidTapShortcutButton(_ topToolbar: TopToolbarView)
   func topToolbarDidTapBraveShieldsButton(_ topToolbar: TopToolbarView)
   func topToolbarDidTapBraveRewardsButton(_ topToolbar: TopToolbarView)
@@ -68,7 +72,12 @@ class TopToolbarView: UIView, ToolbarProtocol {
 
   var helper: ToolbarHelper?
 
-  weak var delegate: TopToolbarDelegate?
+  weak var delegate: TopToolbarDelegate? {
+    didSet {
+      guard delegate !== oldValue else { return }
+      updateViewsForOverlayModeAndToolbarChanges()
+    }
+  }
   weak var tabToolbarDelegate: ToolbarDelegate?
 
   private var cancellables: Set<AnyCancellable> = []
@@ -166,10 +175,15 @@ class TopToolbarView: UIView, ToolbarProtocol {
       $0.size.greaterThanOrEqualTo(32)
     }
     $0.menu = .init(children: [
-      UIDeferredMenuElement.uncached { handler in
+      UIDeferredMenuElement.uncached { [weak self] handler in
+        guard let self, let availableShortcuts = delegate?.topToolbarAvailableShortcutButtons(self)
+        else {
+          handler([])
+          return
+        }
         let options = UIMenu(
           options: [.singleSelection, .displayInline],
-          children: WidgetShortcut.eligibleButtonShortcuts.map { shortcut in
+          children: availableShortcuts.map { shortcut in
             UIAction(
               title: shortcut.displayString,
               image: shortcut.image,
@@ -808,7 +822,7 @@ class TopToolbarView: UIView, ToolbarProtocol {
     delegate?.topToolbarDidLeaveOverlayMode(self)
   }
 
-  private func updateViewsForOverlayModeAndToolbarChanges() {
+  func updateViewsForOverlayModeAndToolbarChanges() {
     cancelButton.stackViewAnimationSafeIsHidden = !inOverlayMode
     backButton.stackViewAnimationSafeIsHidden = toolbarIsShowing || inOverlayMode
     forwardButton.stackViewAnimationSafeIsHidden = toolbarIsShowing || inOverlayMode
@@ -817,9 +831,15 @@ class TopToolbarView: UIView, ToolbarProtocol {
     locationView.contentView.stackViewAnimationSafeIsHidden = inOverlayMode
     shieldsRewardsStack.stackViewAnimationSafeIsHidden = inOverlayMode
 
-    let selectedShortcut: WidgetShortcut? = Preferences.General.toolbarShortcutButton.value.flatMap(
-      WidgetShortcut.init
-    )
+    let selectedShortcut: WidgetShortcut? = {
+      let shortcut = Preferences.General.toolbarShortcutButton.value.flatMap(WidgetShortcut.init)
+      if let delegate, let shortcut,
+        !delegate.topToolbarAvailableShortcutButtons(self).contains(shortcut)
+      {
+        return nil
+      }
+      return shortcut
+    }()
     shortcutButton.stackViewAnimationSafeIsHidden = selectedShortcut != nil ? inOverlayMode : true
     if let selectedShortcut {
       shortcutButton.setImage(selectedShortcut.image, for: .normal)

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShortcutButtonPickerView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShortcutButtonPickerView.swift
@@ -3,9 +3,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import BraveCore
 import BraveStrings
 import BraveWidgetsModels
 import DesignSystem
+import OrderedCollections
 import Preferences
 import Strings
 import SwiftUI
@@ -14,12 +16,19 @@ struct ShortcutButtonPickerView: View {
   @ObservedObject private var selectedShortcut = Preferences.General.toolbarShortcutButton
   @Environment(\.dismiss) var dismiss
 
+  var prefs: any PrefService
+  var isWalletAvailable: Bool
+
   var body: some View {
+    let eligibleShortcuts = WidgetShortcut.eligibleButtonShortcuts(
+      prefs: prefs,
+      isWalletAvailable: isWalletAvailable
+    )
     Form {
       Picker("", selection: $selectedShortcut.value) {
         Label(Strings.ShortcutButton.hideButtonTitle, braveSystemImage: "leo.eye.off")
           .tag(Int?.none)
-        ForEach(WidgetShortcut.eligibleButtonShortcuts, id: \.self) { shortcut in
+        ForEach(eligibleShortcuts, id: \.self) { shortcut in
           Label(shortcut.displayString, braveSystemImage: shortcut.braveSystemImageName ?? "")
             .tag(Int?.some(shortcut.rawValue))
         }

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/SettingsViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/SettingsViewController.swift
@@ -1205,9 +1205,16 @@ class SettingsViewController: TableViewController, BraveAccountAuthenticationObs
       Row(
         text: Strings.ShortcutButton.shortcutButtonTitle,
         selection: { [weak self] in
-          let controller = UIHostingController(rootView: ShortcutButtonPickerView())
+          guard let self else { return }
+          let isWalletAvailable = braveCore.braveWalletAPI.isAllowed
+          let controller = UIHostingController(
+            rootView: ShortcutButtonPickerView(
+              prefs: braveCore.profile.prefs,
+              isWalletAvailable: isWalletAvailable
+            )
+          )
           controller.navigationItem.title = Strings.ShortcutButton.shortcutButtonTitle
-          self?.navigationController?.pushViewController(controller, animated: true)
+          navigationController?.pushViewController(controller, animated: true)
         },
         image: UIImage(braveSystemNamed: "leo.launch"),
         accessory: .disclosureIndicator,


### PR DESCRIPTION
This updates hides both the options that are disabled in the shortcut button picker as well as the shortcut button itself if the option was selected prior to disabling the feature with Origin

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/55006

### Test
- Set the shortcut button to an Origin feature such as Leo
- Verify shortcut button list is typical prior to purchasing Brave Origin
- Purchase Origin and keep all features disabled
- Verify shortcut button disappears from toolbar since it was originally set to Leo
- Re-enable Leo in Origin settings and re-launch
- Verify shortcut button appears again with Leo
- Long press shortcut button in toolbar and verify only enabled features are listed
- Visit Shortcut Button picker in settings and verify only enabled features are listed