### PR TITLE
[brockit] Provide logs for `temp_dir.cleanup()` failure

### DIFF
--- a/tools/cr/test/fake_chromium_repo.py
+++ b/tools/cr/test/fake_chromium_repo.py
@@ -6,6 +6,7 @@
 from pathlib import Path
 from typing import List, Dict
 import json
+import os
 import shutil
 import subprocess
 import tempfile
@@ -379,4 +380,18 @@ class FakeChromiumRepo:
 
     def cleanup(self) -> None:
         """Cleans up the temporary directory used for the fake repository."""
-        self.temp_dir.cleanup()
+        try:
+            self.temp_dir.cleanup()
+        except OSError:
+            print(f'Failed to clean up temp dir: {self.temp_dir.name}')
+            for dirpath, dirnames, filenames in os.walk(self.temp_dir.name):
+                for name in dirnames + filenames:
+                    full = os.path.join(dirpath, name)
+                    try:
+                        stat = os.stat(full)
+                        writable = os.access(full, os.W_OK)
+                        print(f'  {oct(stat.st_mode)} '
+                              f'{"rw" if writable else "ro"} {full}')
+                    except OSError as stat_err:
+                        print(f'  <stat error: {stat_err}> {full}')
+            raise

--- a/tools/cr/test/fake_chromium_src.py
+++ b/tools/cr/test/fake_chromium_src.py
@@ -33,8 +33,8 @@ class FakeChromiumSrc(FakeChromiumRepo):
         """Set up the fake repo and apply patches."""
         self.brave_patch.start()
         self.chromium_patch.start()
-        self.repository_chromium_patch.start(
-        )  # Start the global patch for chromium
+        # Start the global patch for chromium
+        self.repository_chromium_patch.start()
         self.repository_brave_patch.start()  # Start the global patch for brave
 
         # Re-initialize the global instances in the repository module
@@ -49,8 +49,8 @@ class FakeChromiumSrc(FakeChromiumRepo):
         """Clean up the fake repo, patches, and restore the working directory"""
         self.brave_patch.stop()
         self.chromium_patch.stop()
-        self.repository_chromium_patch.stop(
-        )  # Stop the global patch for chromium
+        # Stop the global patch for chromium
+        self.repository_chromium_patch.stop()
         self.repository_brave_patch.stop()  # Stop the global patch for brave
         if self.original_cwd:
             os.chdir(self.original_cwd)


### PR DESCRIPTION
This chnage is adding logs to this `temp_dir.cleanup()` call, to provide
more detailed errors when this call fails. This call has started failing
recently on TeamCity, and it is not very clear why.

Bug https://github.com/brave/brave-browser/issues/55013
