### PR TITLE
[Shields]: Fix host display bidi reordering for trailing special characters

### DIFF
--- a/components/brave_shields/resources/panel/components/main-panel/index.tsx
+++ b/components/brave_shields/resources/panel/components/main-panel/index.tsx
@@ -195,7 +195,7 @@ function MainPanel () {
         <S.FavIconBox>
           <img key={siteBlockInfo?.faviconUrl.url} src={siteBlockInfo?.faviconUrl.url} />
         </S.FavIconBox>
-        <S.SiteTitle>&lrm;{siteBlockInfo?.host}</S.SiteTitle>
+        <S.SiteTitle>{'\u2068'}{siteBlockInfo?.host}{'\u2069'}</S.SiteTitle>
       </S.SiteTitleBox>
       <S.CountBox>
         <S.BlockNote>

--- a/components/brave_shields/resources/panel/components/main-panel/style.ts
+++ b/components/brave_shields/resources/panel/components/main-panel/style.ts
@@ -60,7 +60,7 @@ export const SiteTitle = styled.h1`
   margin: 0;
   overflow: hidden;
   text-align: left;
-  // We truncate long site titles to the left
+  unicode-bidi: isolate;
   direction: rtl;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/components/brave_shields/resources/panel/components/tree-list/index.tsx
+++ b/components/brave_shields/resources/panel/components/tree-list/index.tsx
@@ -102,7 +102,7 @@ function SidePanel (props: {
           <S.FavIconBox>
             <img src={siteBlockInfo?.faviconUrl.url} />
           </S.FavIconBox>
-          <S.SiteTitle>&lrm;{siteBlockInfo?.host}</S.SiteTitle>
+          <S.SiteTitle>{'\u2068'}{siteBlockInfo?.host}{'\u2069'}</S.SiteTitle>
         </S.SiteTitleBox>
       </S.HeaderBox>
       <S.Scroller>

--- a/components/brave_shields/resources/panel/components/tree-list/index.tsx
+++ b/components/brave_shields/resources/panel/components/tree-list/index.tsx
@@ -123,7 +123,7 @@ function SidePanel (props: {
 }
 
 function TreeList (props: Props) {
-  const allowedList = props.allowedList ?? [];
+  const allowedList = React.useMemo(() => props.allowedList ?? [], [props.allowedList])
   const allowedScriptsByOrigin = React.useMemo(() =>
     groupByOrigin(allowedList), [allowedList])
 

--- a/components/brave_shields/resources/panel/components/tree-list/style.ts
+++ b/components/brave_shields/resources/panel/components/tree-list/style.ts
@@ -98,6 +98,7 @@ export const SiteTitle = styled.span`
   font-size: 14px;
   font-weight: 500;
   overflow: hidden;
+  unicode-bidi: isolate;
   direction: rtl;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/components/brave_shields/resources/panel_new/components/app.style.ts
+++ b/components/brave_shields/resources/panel_new/components/app.style.ts
@@ -106,6 +106,7 @@ style.passthrough.css`
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    unicode-bidi: isolate;
 
     &:dir(ltr) {
       direction: rtl;

--- a/components/brave_shields/resources/panel_new/components/details_header.tsx
+++ b/components/brave_shields/resources/panel_new/components/details_header.tsx
@@ -37,7 +37,11 @@ export function DetailsHeader(props: Props) {
         </Button>
         <div className='text'>
           <h4>{props.title}</h4>
-          <div className='host overflow-ellipsis-start'>{'\u2068'}{host}{'\u2069'}</div>
+          <div className='host overflow-ellipsis-start'>
+            {'\u2068'}
+            {host}
+            {'\u2069'}
+          </div>
           {props.children}
         </div>
       </div>

--- a/components/brave_shields/resources/panel_new/components/details_header.tsx
+++ b/components/brave_shields/resources/panel_new/components/details_header.tsx
@@ -37,7 +37,7 @@ export function DetailsHeader(props: Props) {
         </Button>
         <div className='text'>
           <h4>{props.title}</h4>
-          <div className='host overflow-ellipsis-start'>&lrm;{host}</div>
+          <div className='host overflow-ellipsis-start'>{'\u2068'}{host}{'\u2069'}</div>
           {props.children}
         </div>
       </div>

--- a/components/brave_shields/resources/panel_new/components/main_card.tsx
+++ b/components/brave_shields/resources/panel_new/components/main_card.tsx
@@ -66,7 +66,9 @@ export function MainCard() {
             className='overflow-ellipsis-start'
             title={siteHost}
           >
-            {'\u2068'}{siteHost}{'\u2069'}
+            {'\u2068'}
+            {siteHost}
+            {'\u2069'}
           </h3>
           <div className='shields-status'>
             {formatString(

--- a/components/brave_shields/resources/panel_new/components/main_card.tsx
+++ b/components/brave_shields/resources/panel_new/components/main_card.tsx
@@ -66,7 +66,7 @@ export function MainCard() {
             className='overflow-ellipsis-start'
             title={siteHost}
           >
-            &lrm;{siteHost}
+            {'\u2068'}{siteHost}{'\u2069'}
           </h3>
           <div className='shields-status'>
             {formatString(


### PR DESCRIPTION
Fixes brave/brave-browser#54975

The &lrm; fix in PR #35446 addresses numerical subdomains but does
not fully isolate the host string from Unicode bidi processing.
Trailing special characters (underscore, dash, dot) and combinations
still reorder on Nightly v1.91.111. and Brave 1.89.143

Examples still reproducing after PR #35446:
- https://google.attacker.com_/ → _google.attacker.com
- https://google.attacker.com-/ → -google.attacker.com
- https://google.attacker.com./ → .google.attacker.com
- https://google.attacker.com_-/ → -_google.attacker.com (order reversed)
- https://secure.paypal.attacker.com_/→ ....paypal.attacker.com
  (trailing underscore moves to front, then gets hidden by left-side
  truncation leaving only "paypal" visible)
  
<img width="1478" height="892" alt="Screenshot_2026-04-27_073125" src="https://github.com/user-attachments/assets/5f4c7a91-a5b4-4a50-8e83-8c7fd73a0aff" /> 

<img width="1212" height="501" alt="Screenshot 2026-04-28 062807" src="https://github.com/user-attachments/assets/59357332-e011-4996-a466-34f9f6a3aa1a" />

Replaces &lrm; with FSI (U+2068) / PDI (U+2069) in all 4 affected
TSX files and adds unicode-bidi: isolate to the host display elements
in the corresponding style files, while preserving direction: rtl for
correct left-side ellipsis truncation.

@fallaciousreasoning  @ShivanKaul 