### PR TITLE
Remove extra top thickness when vertical tab is used on linux

### DIFF
--- a/browser/ui/views/frame/BUILD.gn
+++ b/browser/ui/views/frame/BUILD.gn
@@ -57,10 +57,6 @@ source_set("browser_tests") {
   sources =
       [ "//brave/browser/ui/views/frame/brave_browser_view_browsertest.cc" ]
 
-  if (is_linux) {
-    sources += [ "//brave/browser/ui/views/frame/brave_browser_frame_view_linux_browsertest.cc" ]
-  }
-
   deps = [
     ":frame",
     "//base",
@@ -83,6 +79,8 @@ source_set("browser_tests") {
   ]
 
   if (is_linux) {
+    sources += [ "//brave/browser/ui/views/frame/brave_browser_frame_view_linux_browsertest.cc" ]
+
     deps += [
       "//brave/browser/ui:brave_tab_prefs",
       "//chrome/browser/themes",

--- a/browser/ui/views/frame/BUILD.gn
+++ b/browser/ui/views/frame/BUILD.gn
@@ -35,6 +35,11 @@ source_set("frame") {
 source_set("unit_tests") {
   testonly = true
   sources = [ "layout/brave_browser_view_tabbed_layout_impl_unittest.cc" ]
+
+  if (is_linux) {
+    sources += [ "browser_frame_view_layout_linux_unittest.cc" ]
+  }
+
   deps = [
     ":frame",
     "//base",
@@ -51,6 +56,10 @@ source_set("browser_tests") {
 
   sources =
       [ "//brave/browser/ui/views/frame/brave_browser_view_browsertest.cc" ]
+
+  if (is_linux) {
+    sources += [ "//brave/browser/ui/views/frame/brave_browser_frame_view_linux_browsertest.cc" ]
+  }
 
   deps = [
     ":frame",
@@ -72,4 +81,15 @@ source_set("browser_tests") {
     "//content/test:test_support",
     "//ui/views",
   ]
+
+  if (is_linux) {
+    deps += [
+      "//brave/browser/ui:brave_tab_prefs",
+      "//chrome/browser/themes",
+      "//chrome/browser/ui/views/frame",
+      "//components/prefs",
+      "//ui/linux:test_support",
+      "//ui/native_theme",
+    ]
+  }
 }

--- a/browser/ui/views/frame/brave_browser_frame_view_linux_browsertest.cc
+++ b/browser/ui/views/frame/brave_browser_frame_view_linux_browsertest.cc
@@ -1,0 +1,195 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "base/memory/raw_ptr.h"
+#include "brave/browser/ui/browser_commands.h"
+#include "brave/browser/ui/tabs/brave_tab_prefs.h"
+#include "brave/browser/ui/views/frame/brave_browser_frame_view_linux_native.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/themes/theme_service.h"
+#include "chrome/browser/themes/theme_service_factory.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/views/frame/browser_frame_view.h"
+#include "chrome/browser/ui/views/frame/browser_view.h"
+#include "chrome/browser/ui/views/frame/custom_corners_background.h"
+#include "chrome/browser/ui/views/frame/top_container_view.h"
+#include "chrome/browser/ui/views/toolbar/toolbar_view.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "components/prefs/pref_service.h"
+#include "content/public/test/browser_test.h"
+#include "ui/gfx/canvas.h"
+#include "ui/linux/fake_linux_ui.h"
+#include "ui/linux/linux_ui_getter.h"
+#include "ui/linux/nav_button_provider.h"
+#include "ui/linux/window_frame_provider.h"
+#include "ui/native_theme/native_theme.h"
+#include "ui/views/view_utils.h"
+
+namespace {
+
+// Minimal NavButtonProvider: returns empty images; RedrawImages is a no-op.
+class FakeNavButtonProvider : public ui::NavButtonProvider {
+ public:
+  void RedrawImages(int, bool, bool) override {}
+  gfx::ImageSkia GetImage(FrameButtonDisplayType, ButtonState) const override {
+    return {};
+  }
+  gfx::Insets GetNavButtonMargin(FrameButtonDisplayType) const override {
+    return {};
+  }
+  gfx::Insets GetTopAreaSpacing() const override { return {}; }
+  int GetInterNavButtonSpacing() const override { return 0; }
+};
+
+// WindowFrameProvider that records the top_area_height argument of the most
+// recent PaintWindowFrame call.  The crash (CairoSurface zero-height) occurs
+// when top_area_height <= 0 reaches the real GTK provider; capturing the value
+// lets the test verify the fix without requiring a real GTK environment.
+class FakeWindowFrameProvider : public ui::WindowFrameProvider {
+ public:
+  int GetTopCornerRadiusDip() override { return 0; }
+  bool IsTopFrameTranslucent() override { return false; }
+  gfx::Insets GetFrameThicknessDip() override { return {}; }
+  void PaintWindowFrame(gfx::Canvas*,
+                        const gfx::Rect&,
+                        int top_area_height,
+                        bool,
+                        const gfx::Insets&) override {
+    last_top_area_height_ = top_area_height;
+  }
+  int last_top_area_height() const { return last_top_area_height_; }
+  void reset() { last_top_area_height_ = -1; }
+
+ private:
+  int last_top_area_height_ = -1;
+};
+
+// LinuxUi that satisfies the factory's CreateNavButtonProvider() non-null
+// requirement and routes GetWindowFrameProvider() to a fake we can inspect.
+class FakeLinuxUiWithNavButtons : public ui::FakeLinuxUi {
+ public:
+  std::unique_ptr<ui::NavButtonProvider> CreateNavButtonProvider() override {
+    return std::make_unique<FakeNavButtonProvider>();
+  }
+  ui::WindowFrameProvider* GetWindowFrameProvider(bool, bool, bool) override {
+    return &frame_provider_;
+  }
+  // FakeLinuxUi returns nullptr; override to prevent null-dereference when
+  // UseSystemTheme() triggers frame recreation on existing browser windows.
+  ui::NativeTheme* GetNativeTheme() const override {
+    return ui::NativeTheme::GetInstanceForNativeUi();
+  }
+  FakeWindowFrameProvider& frame_provider() { return frame_provider_; }
+
+ private:
+  FakeWindowFrameProvider frame_provider_;
+};
+
+// LinuxUiGetter that returns a fixed LinuxUiTheme for every window/profile.
+class FakeLinuxUiGetter : public ui::LinuxUiGetter {
+ public:
+  explicit FakeLinuxUiGetter(ui::LinuxUiTheme* theme) : theme_(theme) {}
+  ui::LinuxUiTheme* GetForWindow(aura::Window*) override { return theme_; }
+  ui::LinuxUiTheme* GetForProfile(Profile*) override { return theme_; }
+
+ private:
+  raw_ptr<ui::LinuxUiTheme> theme_;
+};
+
+}  // namespace
+
+class BraveBrowserFrameViewTest : public InProcessBrowserTest {
+ protected:
+  BrowserView* browser_view() {
+    return BrowserView::GetBrowserViewForBrowser(browser());
+  }
+
+  BrowserFrameView* frame_view() {
+    return browser_view()->browser_widget()->GetFrameView();
+  }
+
+  void ToggleVerticalTabStrip() {
+    brave::ToggleVerticalTabStrip(browser());
+    RunScheduledLayouts();
+  }
+};
+
+// Verifies that PaintRestoredFrameBorder passes a positive top_area_height to
+// the GTK frame provider when vertical tabs are active and no window title is
+// shown.  The crash (CairoSurface zero-height assert) happens when
+// top_area_height <= 0 reaches WindowFrameProviderGtk::PaintWindowFrame.
+// The fix adds the toolbar height to guarantee a positive value; the fake
+// provider captures the argument so we can assert it without needing real GTK.
+IN_PROC_BROWSER_TEST_F(BraveBrowserFrameViewTest,
+                       VerticalTabsGtkTopAreaHeightIsPositive) {
+  FakeLinuxUiWithNavButtons fake_linux_ui;
+  FakeLinuxUiGetter fake_getter(&fake_linux_ui);
+  auto* old_getter = ui::LinuxUiGetter::instance();
+  ui::LinuxUiGetter::set_instance(&fake_getter);
+
+  ThemeServiceFactory::GetForProfile(browser()->profile())->UseSystemTheme();
+
+  Browser* gtk_browser = CreateBrowser(browser()->profile());
+  auto* native_frame = views::AsViewClass<BraveBrowserFrameViewLinuxNative>(
+      BrowserView::GetBrowserViewForBrowser(gtk_browser)
+          ->browser_widget()
+          ->GetFrameView());
+  ASSERT_TRUE(native_frame) << "Expected BraveBrowserFrameViewLinuxNative; "
+                               "fake GTK not picked up by the factory";
+
+  // Enable vertical tabs with no title bar.  On Linux
+  // kVerticalTabsShowTitleOnWindow defaults to true, so explicitly disable it.
+  brave::ToggleVerticalTabStrip(gtk_browser);
+  gtk_browser->profile()->GetPrefs()->SetBoolean(
+      brave_tabs::kVerticalTabsShowTitleOnWindow, false);
+
+  {
+    gfx::Canvas canvas(native_frame->size(), 1.0f, false);
+    native_frame->PaintRestoredFrameBorder(&canvas);
+  }
+
+  // Before the fix only GetTopAreaHeight() (shadow-only, tiny) was passed to
+  // PaintWindowFrame; the fix adds the toolbar height.  Assert the captured
+  // value is at least the toolbar height to confirm the addition happened.
+  auto* toolbar = BrowserView::GetBrowserViewForBrowser(gtk_browser)->toolbar();
+  EXPECT_GE(fake_linux_ui.frame_provider().last_top_area_height(),
+            toolbar->GetPreferredSize().height());
+
+  // Close before the fake objects go out of scope; the frame view holds a raw
+  // pointer to fake_linux_ui via the frame-provider getter.
+  CloseBrowserSynchronously(gtk_browser);
+
+  ui::LinuxUiGetter::set_instance(old_getter);
+}
+
+// Verifies that with vertical tabs enabled and no title bar, both the toolbar
+// and top container use the window corner radius so the frame's rounded arc
+// shows through.
+IN_PROC_BROWSER_TEST_F(
+    BraveBrowserFrameViewTest,
+    VerticalTabsTopAreaCornerRadiusReflectsWindowAndTitleBarState) {
+  auto* toolbar_bg = static_cast<CustomCornersBackground*>(
+      browser_view()->toolbar()->background());
+  ASSERT_TRUE(toolbar_bg);
+  auto* top_container_bg = static_cast<CustomCornersBackground*>(
+      browser_view()->top_container()->background());
+  ASSERT_TRUE(top_container_bg);
+
+  // No title by default on linux.
+  EXPECT_FALSE(browser()->profile()->GetPrefs()->GetBoolean(
+      brave_tabs::kVerticalTabsShowTitleOnWindow));
+  ToggleVerticalTabStrip();
+
+  const auto window_corners = frame_view()->GetWindowRoundedCorners();
+  const auto toolbar_radii = toolbar_bg->GetRoundedCornerRadii();
+  ASSERT_TRUE(toolbar_radii.has_value());
+  EXPECT_EQ(window_corners.upper_right(), toolbar_radii->upper_right());
+  EXPECT_EQ(window_corners.upper_left(), toolbar_radii->upper_left());
+
+  const auto tc_radii = top_container_bg->GetRoundedCornerRadii();
+  ASSERT_TRUE(tc_radii.has_value());
+  EXPECT_EQ(window_corners.upper_right(), tc_radii->upper_right());
+  EXPECT_EQ(window_corners.upper_left(), tc_radii->upper_left());
+}

--- a/browser/ui/views/frame/brave_browser_frame_view_linux_browsertest.cc
+++ b/browser/ui/views/frame/brave_browser_frame_view_linux_browsertest.cc
@@ -3,7 +3,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include <optional>
+
 #include "base/memory/raw_ptr.h"
+#include "base/memory/raw_ref.h"
 #include "brave/browser/ui/browser_commands.h"
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
 #include "brave/browser/ui/views/frame/brave_browser_frame_view_linux_native.h"
@@ -59,11 +62,13 @@ class FakeWindowFrameProvider : public ui::WindowFrameProvider {
                         const gfx::Insets&) override {
     last_top_area_height_ = top_area_height;
   }
-  int last_top_area_height() const { return last_top_area_height_; }
-  void reset() { last_top_area_height_ = -1; }
+  std::optional<int> last_top_area_height() const {
+    return last_top_area_height_;
+  }
+  void reset() { last_top_area_height_.reset(); }
 
  private:
-  int last_top_area_height_ = -1;
+  std::optional<int> last_top_area_height_;
 };
 
 // LinuxUi that satisfies the factory's CreateNavButtonProvider() non-null
@@ -87,15 +92,30 @@ class FakeLinuxUiWithNavButtons : public ui::FakeLinuxUi {
   FakeWindowFrameProvider frame_provider_;
 };
 
+// RAII wrapper that installs a LinuxUiGetter for the duration of a scope and
+// restores the previous one on destruction, even if an assertion fires early.
+class ScopedLinuxUiGetter {
+ public:
+  explicit ScopedLinuxUiGetter(ui::LinuxUiGetter* new_getter)
+      : old_getter_(ui::LinuxUiGetter::instance()) {
+    ui::LinuxUiGetter::set_instance(new_getter);
+  }
+  ~ScopedLinuxUiGetter() { ui::LinuxUiGetter::set_instance(old_getter_); }
+
+ private:
+  // Maybe null if no getter was installed before this scope.
+  raw_ptr<ui::LinuxUiGetter> old_getter_ = nullptr;
+};
+
 // LinuxUiGetter that returns a fixed LinuxUiTheme for every window/profile.
 class FakeLinuxUiGetter : public ui::LinuxUiGetter {
  public:
-  explicit FakeLinuxUiGetter(ui::LinuxUiTheme* theme) : theme_(theme) {}
-  ui::LinuxUiTheme* GetForWindow(aura::Window*) override { return theme_; }
-  ui::LinuxUiTheme* GetForProfile(Profile*) override { return theme_; }
+  explicit FakeLinuxUiGetter(ui::LinuxUiTheme& theme) : theme_(theme) {}
+  ui::LinuxUiTheme* GetForWindow(aura::Window*) override { return &*theme_; }
+  ui::LinuxUiTheme* GetForProfile(Profile*) override { return &*theme_; }
 
  private:
-  raw_ptr<ui::LinuxUiTheme> theme_;
+  const raw_ref<ui::LinuxUiTheme> theme_;
 };
 
 }  // namespace
@@ -125,9 +145,8 @@ class BraveBrowserFrameViewTest : public InProcessBrowserTest {
 IN_PROC_BROWSER_TEST_F(BraveBrowserFrameViewTest,
                        VerticalTabsGtkTopAreaHeightIsPositive) {
   FakeLinuxUiWithNavButtons fake_linux_ui;
-  FakeLinuxUiGetter fake_getter(&fake_linux_ui);
-  auto* old_getter = ui::LinuxUiGetter::instance();
-  ui::LinuxUiGetter::set_instance(&fake_getter);
+  FakeLinuxUiGetter fake_getter(fake_linux_ui);
+  ScopedLinuxUiGetter scoped_getter(&fake_getter);
 
   ThemeServiceFactory::GetForProfile(browser()->profile())->UseSystemTheme();
 
@@ -154,14 +173,14 @@ IN_PROC_BROWSER_TEST_F(BraveBrowserFrameViewTest,
   // PaintWindowFrame; the fix adds the toolbar height.  Assert the captured
   // value is at least the toolbar height to confirm the addition happened.
   auto* toolbar = BrowserView::GetBrowserViewForBrowser(gtk_browser)->toolbar();
-  EXPECT_GE(fake_linux_ui.frame_provider().last_top_area_height(),
+  ASSERT_TRUE(
+      fake_linux_ui.frame_provider().last_top_area_height().has_value());
+  EXPECT_GE(*fake_linux_ui.frame_provider().last_top_area_height(),
             toolbar->GetPreferredSize().height());
 
   // Close before the fake objects go out of scope; the frame view holds a raw
   // pointer to fake_linux_ui via the frame-provider getter.
   CloseBrowserSynchronously(gtk_browser);
-
-  ui::LinuxUiGetter::set_instance(old_getter);
 }
 
 // Verifies that with vertical tabs enabled and no title bar, both the toolbar

--- a/browser/ui/views/frame/brave_browser_frame_view_linux_native.cc
+++ b/browser/ui/views/frame/brave_browser_frame_view_linux_native.cc
@@ -13,7 +13,9 @@
 #include "base/notreached.h"
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 #include "brave/browser/ui/views/toolbar/brave_toolbar_view.h"
+#include "build/build_config.h"
 #include "chrome/browser/ui/layout_constants.h"
+#include "chrome/browser/ui/views/frame/browser_frame_view_layout_linux_native.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
 #include "chrome/common/pref_names.h"
 #include "ui/base/metadata/metadata_impl_macros.h"
@@ -53,6 +55,34 @@ BraveBrowserFrameViewLinuxNative::BraveBrowserFrameViewLinuxNative(
                                   std::move(nav_button_provider)) {}
 
 BraveBrowserFrameViewLinuxNative::~BraveBrowserFrameViewLinuxNative() = default;
+
+void BraveBrowserFrameViewLinuxNative::PaintRestoredFrameBorder(
+    gfx::Canvas* canvas) const {
+  auto* browser = GetBrowserView()->browser();
+  CHECK(browser);
+
+  if (!tabs::utils::ShouldShowBraveVerticalTabs(browser) ||
+      tabs::utils::ShouldShowWindowTitleForVerticalTabs(browser)) {
+    BrowserFrameViewLinuxNative::PaintRestoredFrameBorder(canvas);
+    return;
+  }
+
+  // For Brave vertical tabs w/o title, GetTopAreaHeight() returns
+  // NonClientTopHeight(false) which equals only the shadow thickness F.
+  // PaintWindowFrame then computes top_area_height_px = ClampCeil(F * scale)
+  // - shadow_px = 0, producing a zero-height headerbar bitmap that crashes in
+  // CairoSurface::CairoSurface().
+  // Add the toolbar height here to avoid crashing from gtk's frame painting.
+  // As we don't need any visible rect above toolbar, maybe we don't need to
+  // call PaintHeaderbar but it crashed with zero-height.
+  int top_area_height = GetTopAreaHeight();
+  if (auto* const toolbar = GetBrowserView()->toolbar()) {
+    top_area_height += toolbar->GetPreferredSize().height();
+  }
+  layout_->GetFrameProvider()->PaintWindowFrame(
+      canvas, GetLocalBounds(), top_area_height, ShouldPaintAsActive(),
+      GetInputInsets());
+}
 
 void BraveBrowserFrameViewLinuxNative::MaybeUpdateCachedFrameButtonImages() {
   auto* browser = GetBrowserView()->browser();

--- a/browser/ui/views/frame/brave_browser_frame_view_linux_native.h
+++ b/browser/ui/views/frame/brave_browser_frame_view_linux_native.h
@@ -27,8 +27,8 @@ class BraveBrowserFrameViewLinuxNative : public BrowserFrameViewLinuxNative {
   }
 
   // BrowserFrameViewLinuxNative:
-  void MaybeUpdateCachedFrameButtonImages() override;
   void PaintRestoredFrameBorder(gfx::Canvas* canvas) const override;
+  void MaybeUpdateCachedFrameButtonImages() override;
   void Layout(PassKey) override;
 
  private:

--- a/browser/ui/views/frame/brave_browser_frame_view_linux_native.h
+++ b/browser/ui/views/frame/brave_browser_frame_view_linux_native.h
@@ -28,6 +28,7 @@ class BraveBrowserFrameViewLinuxNative : public BrowserFrameViewLinuxNative {
 
   // BrowserFrameViewLinuxNative:
   void MaybeUpdateCachedFrameButtonImages() override;
+  void PaintRestoredFrameBorder(gfx::Canvas* canvas) const override;
   void Layout(PassKey) override;
 
  private:

--- a/browser/ui/views/frame/browser_frame_view_layout_linux_unittest.cc
+++ b/browser/ui/views/frame/browser_frame_view_layout_linux_unittest.cc
@@ -1,0 +1,98 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include <memory>
+#include <string>
+
+#include "chrome/browser/ui/views/frame/browser_frame_view_layout_linux_native.h"
+#include "chrome/browser/ui/views/frame/opaque_browser_frame_view_layout_delegate.h"
+#include "testing/gmock/include/gmock/gmock.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "ui/gfx/geometry/rect.h"
+#include "ui/gfx/geometry/size.h"
+
+namespace {
+
+class MockOpaqueLayoutDelegate : public OpaqueBrowserFrameViewLayoutDelegate {
+ public:
+  MOCK_METHOD(bool, ShouldShowWindowIcon, (), (const, override));
+  MOCK_METHOD(bool, ShouldShowWindowTitle, (), (const, override));
+  MOCK_METHOD(std::u16string, GetWindowTitle, (), (const, override));
+  MOCK_METHOD(int, GetIconSize, (), (const, override));
+  MOCK_METHOD(gfx::Size, GetBrowserViewMinimumSize, (), (const, override));
+  MOCK_METHOD(bool, ShouldShowCaptionButtons, (), (const, override));
+  MOCK_METHOD(bool, IsRegularOrGuestSession, (), (const, override));
+  MOCK_METHOD(bool, CanMaximize, (), (const, override));
+  MOCK_METHOD(bool, CanMinimize, (), (const, override));
+  MOCK_METHOD(bool, IsMaximized, (), (const, override));
+  MOCK_METHOD(bool, IsMinimized, (), (const, override));
+  MOCK_METHOD(bool, IsFullscreen, (), (const, override));
+  MOCK_METHOD(bool, GetBorderlessModeEnabled, (), (const, override));
+  MOCK_METHOD(bool, IsTabStripVisible, (), (const, override));
+  MOCK_METHOD(bool, IsToolbarVisible, (), (const, override));
+  MOCK_METHOD(int, GetTopAreaHeight, (), (const, override));
+  MOCK_METHOD(bool, UseCustomFrame, (), (const, override));
+  MOCK_METHOD(bool, IsFrameCondensed, (), (const, override));
+  MOCK_METHOD(void,
+              UpdateWindowControlsOverlay,
+              (const gfx::Rect&),
+              (override));
+  MOCK_METHOD(bool, ShouldDrawRestoredFrameShadow, (), (const, override));
+  MOCK_METHOD(bool, IsTiled, (), (const, override));
+  MOCK_METHOD(int, WebAppButtonHeight, (), (const, override));
+};
+
+// Exposes the protected NonClientExtraTopThickness() for testing.
+class TestBrowserFrameViewLayoutLinuxNative
+    : public BrowserFrameViewLayoutLinuxNative {
+ public:
+  using BrowserFrameViewLayoutLinuxNative::BrowserFrameViewLayoutLinuxNative;
+  using BrowserFrameViewLayoutLinuxNative::NonClientExtraTopThickness;
+};
+
+}  // namespace
+
+// Helper that creates a layout with a NiceMock delegate and returns
+// NonClientExtraTopThickness().
+static int ComputeExtraTopThickness(
+    testing::NiceMock<MockOpaqueLayoutDelegate>& mock) {
+  auto layout = std::make_unique<TestBrowserFrameViewLayoutLinuxNative>(
+      /*nav_button_provider=*/nullptr,
+      BrowserFrameViewLayoutLinuxNative::FrameProviderGetter());
+  layout->set_delegate(&mock);
+  return layout->NonClientExtraTopThickness();
+}
+
+// With Brave vertical tabs: IsTabStripVisible()=false but
+// IsToolbarVisible()=true. The 3px extra border must be suppressed so no
+// spurious strip appears above the toolbar.
+TEST(BrowserFrameViewLayoutLinuxTest,
+     NonClientExtraTopThicknessZeroWhenToolbarVisible) {
+  testing::NiceMock<MockOpaqueLayoutDelegate> mock;
+  ON_CALL(mock, IsTabStripVisible()).WillByDefault(testing::Return(false));
+  ON_CALL(mock, IsToolbarVisible()).WillByDefault(testing::Return(true));
+  EXPECT_EQ(0, ComputeExtraTopThickness(mock));
+}
+
+// Normal browser window: both tab strip and toolbar visible. Upstream already
+// returns 0 for this case; the brave override must not regress it.
+TEST(BrowserFrameViewLayoutLinuxTest,
+     NonClientExtraTopThicknessZeroWithTabStripAndToolbar) {
+  testing::NiceMock<MockOpaqueLayoutDelegate> mock;
+  ON_CALL(mock, IsTabStripVisible()).WillByDefault(testing::Return(true));
+  ON_CALL(mock, IsToolbarVisible()).WillByDefault(testing::Return(true));
+  EXPECT_EQ(0, ComputeExtraTopThickness(mock));
+}
+
+// Popup windows have neither a tab strip nor a toolbar.  Upstream returns
+// kExtraTopBorder (3) to provide a thin resize border; our override must
+// preserve that.
+TEST(BrowserFrameViewLayoutLinuxTest,
+     NonClientExtraTopThicknessThreeForPopupWindow) {
+  testing::NiceMock<MockOpaqueLayoutDelegate> mock;
+  ON_CALL(mock, IsTabStripVisible()).WillByDefault(testing::Return(false));
+  ON_CALL(mock, IsToolbarVisible()).WillByDefault(testing::Return(false));
+  EXPECT_EQ(3, ComputeExtraTopThickness(mock));
+}

--- a/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl.cc
+++ b/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl.cc
@@ -16,6 +16,7 @@
 #include "brave/browser/ui/views/frame/brave_contents_view_util.h"
 #include "brave/browser/ui/views/sidebar/sidebar_container_view.h"
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
+#include "build/build_config.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/browser_window/public/browser_window_features.h"
@@ -25,6 +26,7 @@
 #include "chrome/browser/ui/tabs/tab_style.h"
 #include "chrome/browser/ui/views/bookmarks/bookmark_bar_view.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
+#include "chrome/browser/ui/views/frame/custom_corners_background.h"
 #include "chrome/browser/ui/views/frame/layout/browser_view_layout_delegate.h"
 #include "chrome/browser/ui/views/infobars/infobar_container_view.h"
 #include "components/bookmarks/common/bookmark_pref_names.h"
@@ -40,6 +42,24 @@ BraveBrowserViewTabbedLayoutImpl::BraveBrowserViewTabbedLayoutImpl(
                                   std::move(views)) {}
 
 BraveBrowserViewTabbedLayoutImpl::~BraveBrowserViewTabbedLayoutImpl() = default;
+
+void BraveBrowserViewTabbedLayoutImpl::ConfigureTopContainerBackground(
+    const BrowserLayoutParams& params,
+    CustomCornersBackground* background) {
+  BrowserViewTabbedLayoutImpl::ConfigureTopContainerBackground(params,
+                                                               background);
+#if BUILDFLAG(IS_LINUX)
+  // Curve top container corners like window corner as it's top-most UI
+  // in vertical tabs.
+  if (delegate().ShouldShowVerticalTabs() &&
+      !delegate().ShouldShowWindowTitleForVerticalTabs()) {
+    CustomCornersBackground::Corners corners;
+    corners.upper_trailing = background->GetWindowCorner(/*upper=*/true);
+    corners.upper_leading = background->GetWindowCorner(/*upper=*/true);
+    background->SetCorners(corners);
+  }
+#endif  // BUILDFLAG(IS_LINUX)
+}
 
 // static
 gfx::Rect BraveBrowserViewTabbedLayoutImpl::ComputeSidebarBounds(
@@ -256,6 +276,21 @@ void BraveBrowserViewTabbedLayoutImpl::DoPostLayoutVisualAdjustments(
   auto* const toolbar_background =
       static_cast<CustomCornersBackground*>(views().toolbar->background());
   CustomCornersBackground::Corners toolbar_corners;
+
+#if BUILDFLAG(IS_LINUX)
+  if (delegate().ShouldShowVerticalTabs() &&
+      !delegate().ShouldShowWindowTitleForVerticalTabs()) {
+    // Curve toolbar corners like window corner as toolbar it's top-most UI in
+    // vertical tabs.
+    toolbar_corners.upper_trailing =
+        toolbar_background->GetWindowCorner(/*upper=*/true);
+    toolbar_corners.upper_leading =
+        toolbar_background->GetWindowCorner(/*upper=*/true);
+    toolbar_background->SetCorners(toolbar_corners);
+    return;
+  }
+#endif  // BUILDFLAG(IS_LINUX)
+
   toolbar_corners.upper_trailing.type =
       CustomCornersBackground::CornerType::kRoundedWithBackground;
   toolbar_corners.upper_leading.type =

--- a/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl.h
+++ b/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl.h
@@ -57,6 +57,9 @@ class BraveBrowserViewTabbedLayoutImpl : public BrowserViewTabbedLayoutImpl {
   gfx::Rect CalculateTopContainerLayout(ProposedLayout& layout,
                                         BrowserLayoutParams params,
                                         bool needs_exclusion) const override;
+  void ConfigureTopContainerBackground(
+      const BrowserLayoutParams& params,
+      CustomCornersBackground* background) override;
   void DoPostLayoutVisualAdjustments(
       const BrowserLayoutParams& params) override;
   TopSeparatorType GetTopSeparatorType() const override;

--- a/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl_unittest.cc
+++ b/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl_unittest.cc
@@ -68,6 +68,7 @@ class FakeBrowserViewLayoutDelegate : public BrowserViewLayoutDelegate {
   bool IsProjectsPanelVisible() const override { return false; }
 
   bool ShouldShowVerticalTabs() const override { return false; }
+  bool ShouldShowWindowTitleForVerticalTabs() const override { return false; }
   bool IsVerticalTabOnRight() const override { return false; }
   bool ShouldUseBraveWebViewRoundedCornersForContents() const override {
     return false;

--- a/chromium_src/chrome/browser/ui/views/frame/browser_frame_view_layout_linux.cc
+++ b/chromium_src/chrome/browser/ui/views/frame/browser_frame_view_layout_linux.cc
@@ -3,6 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include "chrome/browser/ui/views/frame/browser_frame_view_layout_linux.h"
+
 #include "base/check.h"
 #include "base/check_is_test.h"
 #include "base/check_op.h"
@@ -13,7 +15,24 @@
 #include "ui/views/window/caption_button_layout_constants.h"
 #include "ui/views/window/frame_caption_button.h"
 
+#define NonClientExtraTopThickness NonClientExtraTopThickness_ChromiumImpl
+
 #include <chrome/browser/ui/views/frame/browser_frame_view_layout_linux.cc>
+
+#undef NonClientExtraTopThickness
+
+int BrowserFrameViewLayoutLinux::NonClientExtraTopThickness() const {
+  // Upstream returns kExtraTopBorder (3px) whenever IsTabStripVisible() is
+  // false, intending to add a thin resize border for popup windows. With Brave
+  // vertical tabs, IsTabStripVisible() is also false even though the toolbar is
+  // present, producing a spurious 3px strip at the top. Suppress it when the
+  // toolbar is visible; only popup windows (no tab strip, no toolbar) need it.
+  if (delegate_->IsToolbarVisible()) {
+    return 0;
+  }
+
+  return NonClientExtraTopThickness_ChromiumImpl();
+}
 
 void BrowserFrameViewLayoutLinux::SetBoundsForButton(
     views::FrameButton button_id,

--- a/chromium_src/chrome/browser/ui/views/frame/browser_frame_view_layout_linux.h
+++ b/chromium_src/chrome/browser/ui/views/frame/browser_frame_view_layout_linux.h
@@ -12,6 +12,7 @@
   GetInputInsets_Unused();                                                     \
   void SetBoundsForButton(views::FrameButton button_id, views::Button* button, \
                           ButtonAlignment align) override;                     \
+  int NonClientExtraTopThickness_ChromiumImpl() const;                         \
   gfx::Insets GetInputInsets
 
 #include <chrome/browser/ui/views/frame/browser_frame_view_layout_linux.h>  // IWYU pragma: export

--- a/chromium_src/chrome/browser/ui/views/frame/layout/browser_view_layout_delegate.h
+++ b/chromium_src/chrome/browser/ui/views/frame/layout/browser_view_layout_delegate.h
@@ -10,6 +10,7 @@
 #define GetExtraInfobarOffset()                                            \
   GetExtraInfobarOffset() const = 0;                                       \
   virtual bool ShouldShowVerticalTabs() const = 0;                         \
+  virtual bool ShouldShowWindowTitleForVerticalTabs() const = 0;           \
   virtual bool IsVerticalTabOnRight() const = 0;                           \
   virtual bool ShouldUseBraveWebViewRoundedCornersForContents() const = 0; \
   virtual int GetRoundedCornersWebViewMargin() const = 0;                  \

--- a/chromium_src/chrome/browser/ui/views/frame/layout/browser_view_layout_delegate_impl.cc
+++ b/chromium_src/chrome/browser/ui/views/frame/layout/browser_view_layout_delegate_impl.cc
@@ -22,6 +22,13 @@ bool BrowserViewLayoutDelegateImpl::ShouldShowVerticalTabs() const {
          tabs::utils::ShouldShowBraveVerticalTabs(browser_view().browser());
 }
 
+bool BrowserViewLayoutDelegateImpl::ShouldShowWindowTitleForVerticalTabs()
+    const {
+  return browser_view().browser() &&
+         tabs::utils::ShouldShowWindowTitleForVerticalTabs(
+             browser_view().browser());
+}
+
 bool BrowserViewLayoutDelegateImpl::IsVerticalTabOnRight() const {
   return browser_view().browser() &&
          tabs::utils::IsVerticalTabOnRight(browser_view().browser());

--- a/chromium_src/chrome/browser/ui/views/frame/layout/browser_view_layout_delegate_impl.h
+++ b/chromium_src/chrome/browser/ui/views/frame/layout/browser_view_layout_delegate_impl.h
@@ -11,6 +11,7 @@
 #define GetExtraInfobarOffset()                                         \
   GetExtraInfobarOffset() const override;                               \
   bool ShouldShowVerticalTabs() const override;                         \
+  bool ShouldShowWindowTitleForVerticalTabs() const override;           \
   bool IsVerticalTabOnRight() const override;                           \
   bool ShouldUseBraveWebViewRoundedCornersForContents() const override; \
   int GetRoundedCornersWebViewMargin() const override;                  \


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/53632
Resolves https://github.com/brave/brave-browser/issues/54066
Resolves https://github.com/brave/brave-browser/issues/50162

On Linux with Brave vertical tabs enabled and no title bar, BrowserFrameViewLayoutLinux::NonClientExtraTopThickness() returned kExtraTopBorder (3 dips) whenever IsTabStripVisible() was false — producing a spurious 3px strip at the top of the window.
Fixed by returning 0 when the toolbar is visible instead.
                                                                                                                                           
Removing that strip exposed two side effects:

**1. Square frame corners**                  

The 3px strip was the only area where the frame background's rounded arc was visible above the toolbar. With the strip gone, BrowserView starts flush with the frame clip's top, and TopContainerView immediately covers it with opaque square corners — hiding the rounded arc entirely.
Fixed by overriding ConfigureTopContainerBackground and DoPostLayoutVisualAdjustments in BraveBrowserViewTabbedLayoutImpl to apply window-corner-radius (transparent) corners to both the top container and toolbar on Linux when vertical tabs are active with no title bar, letting the frame arc show through.

**2. GTK crash when painting the frame border**

The 3px strip also kept GetTopAreaHeight() above zero when passed to WindowFrameProviderGtk::PaintWindowFrame. Without it, GetTopAreaHeight() returns only the shadow thickness, which after GTK's scaling and shadow subtraction becomes zero — crashing inside CairoSurface::CairoSurface().                                                                                                            
Fixed by overriding PaintRestoredFrameBorder in BraveBrowserFrameViewLinuxNative to add the toolbar height to top_area_height when vertical tabs are active with no title bar, ensuring GTK always receives a positive value.
                                                                                                                                           
**Tests**
  - BraveBrowserFrameViewTest.VerticalTabsGtkTopAreaHeightIsPositive — verifies top_area_height passed to the frame provider includes the toolbar height in the vertical tabs / no title bar state
  - BraveBrowserFrameViewTest.VerticalTabsTopAreaCornerRadiusReflectsWindowAndTitleBarState — verifies toolbar and top container corner radii across all three states: horizontal tabs, vertical tabs without title bar, vertical tabs with title bar                            
  - BrowserFrameViewLayoutLinuxTest — unit tests for NonClientExtraTopThickness covering vertical tab and toolbar visibility combinations
                                                                                                                                           
  **Steps to manual test**   
                                                                                                                                           
  1. On Linux, open Brave and enable vertical tabs (right-click tab strip → "Use vertical tabs")                                           
  2. Confirm the spurious top border is gone
  3. Confirm the window has rounded top corners (not square)                                                                               
  4. Enable the title bar (vertical tabs settings → "Show title bar") — confirm corners revert to standard                                 
  5. Disable vertical tabs — confirm no regression in horizontal tab layout   

<img width="700" alt="image" src="https://github.com/user-attachments/assets/31e4db7d-ab81-4d40-8c93-08f90f7d52d2" />

<img width="700" alt="image" src="https://github.com/user-attachments/assets/55791270-7285-4f38-8306-32ad5567dc5a" />

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
