### PR TITLE
[DO-NO-SUBMIT][gerrit] Use our deps mirror for `chromium/src/`

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
         "dir": "src",
         "tag": "148.0.7778.60",
         "repository": {
-          "url": "https://chromium.googlesource.com/chromium/src.git"
+          "url": "https://gerrit.brave.com/googlesource/chromium"
         },
         "custom_deps": {
           "src/testing/libfuzzer/fuzzers/wasm_corpus": null,


### PR DESCRIPTION
This is just an experiment to see what happens in CI.
