### PR TITLE
[iOS] Add Brave Origin deep link route

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Origin.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Origin.swift
@@ -1,0 +1,98 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import BraveCore
+import BraveStore
+import Onboarding
+import Origin
+import Preferences
+import Shared
+import SwiftUI
+
+extension BrowserViewController {
+  // Execute any additional code to be executed after an Origin purchase completes
+  func handleOriginPurchaseCompleted() {
+    PrivacyReportsManager.cancelNotification()
+    BrowserViewController.cancelScheduleDefaultBrowserNotification()
+  }
+
+  func presentBraveOriginDeepLink() {
+    // Ensure Onboarding is complete before handling this
+    if Preferences.Onboarding.basicOnboardingCompleted.value != OnboardingState.completed.rawValue {
+      return
+    }
+
+    Task {
+      guard FeatureList.kBraveOrigin.enabled,
+        let originService = BraveOriginServiceFactory.get(profile: profileController.profile),
+        let skusService = Skus.SkusServiceFactory.get(profile: profileController.profile)
+      else {
+        return
+      }
+      let isPurchased = await originService.checkPurchaseState()
+      let originSettingsController: () -> UIViewController = {
+        // Origin settings is typically presented from inside settings, so we need to:
+        //   1. Set up a UINavigationController container
+        //   2. Add a done button to the toolbar
+        let controller = UIHostingController(
+          rootView: OriginSettingsView(
+            viewModel: .init(
+              service: originService,
+              storeSDK: BraveStoreSDK(skusService: skusService)
+            )
+          )
+          .environment(
+            \.openURL,
+            OpenURLAction { [weak self] url in
+              guard let self else { return .handled }
+              openURLInNewTab(
+                url,
+                isPrivate: privateBrowsingManager.isPrivateBrowsing,
+                isPrivileged: url.scheme == InternalURL.scheme
+              )
+              dismiss(animated: true)
+              return .handled
+            }
+          )
+        )
+        controller.title = Strings.Origin.originProductName  // Not Translated
+        controller.navigationItem.rightBarButtonItem = .init(
+          systemItem: .done,
+          primaryAction: .init(handler: { [unowned self] _ in
+            dismiss(animated: true)
+          })
+        )
+        return UINavigationController(rootViewController: controller)
+      }
+      if isPurchased {
+        present(originSettingsController(), animated: true)
+      } else {
+        let controller = UIHostingController(
+          rootView: OriginPaywallView(
+            viewModel: .init(store: .init(skusService: skusService)),
+            didPurchase: { [weak self] in
+              guard let self else { return }
+              handleOriginPurchaseCompleted()
+              present(originSettingsController(), animated: true)
+            }
+          )
+          .environment(
+            \.openURL,
+            OpenURLAction { [weak self] url in
+              guard let self else { return .handled }
+              openURLInNewTab(
+                url,
+                isPrivate: privateBrowsingManager.isPrivateBrowsing,
+                isPrivileged: url.scheme == InternalURL.scheme
+              )
+              return .handled
+            }
+          )
+        )
+        present(controller, animated: true)
+      }
+    }
+  }
+}

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -2328,6 +2328,10 @@ extension BrowserViewController: SettingsDelegate {
     self.tabManager.addTabsForURLs(urls, isPrivate: tabIsPrivate)
   }
 
+  func settingsDidCompleteOriginPurchase() {
+    handleOriginPurchaseCompleted()
+  }
+
   // QA Stuff
   func settingsCreateFakeTabs() {
     let urls = (0..<1000).map { URL(string: "https://search.brave.com/search?q=\($0)")! }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/NavigationRouter.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/NavigationRouter.swift
@@ -17,6 +17,7 @@ public enum DeepLink: String {
   case browserMenu = "menu"
   case setDefaultBrowser = "set-default"
   case importData = "import-data"
+  case originPromo = "origin_promo"
 }
 
 // The root navigation for the Router. Look at the tests to see a complete URL
@@ -101,6 +102,8 @@ public enum NavigationPath: Equatable {
       bvc.presentDefaultBrowserScreenCallout(skipSafeGuards: true)
     case .importData:
       bvc.presentDataImporter()
+    case .originPromo:
+      bvc.presentBraveOriginDeepLink()
     }
   }
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/SettingsViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/SettingsViewController.swift
@@ -52,6 +52,7 @@ extension Preferences.AutoCloseTabsOption: RepresentableOptionType {
 protocol SettingsDelegate: AnyObject {
   func settingsOpenURLInNewTab(_ url: URL)
   func settingsOpenURLs(_ urls: [URL], loadImmediately: Bool)
+  func settingsDidCompleteOriginPurchase()
 
   func settingsCreateFakeTabs()
   func settingsCreateFakeBookmarks()
@@ -889,9 +890,9 @@ class SettingsViewController: TableViewController {
                 rootView: OriginPaywallView(
                   viewModel: .init(store: .init(skusService: skusService)),
                   didPurchase: { [weak self] in
-                    PrivacyReportsManager.cancelNotification()
-                    BrowserViewController.cancelScheduleDefaultBrowserNotification()
-                    self?.navigationController?.pushViewController(
+                    guard let self else { return }
+                    settingsDelegate?.settingsDidCompleteOriginPurchase()
+                    navigationController?.pushViewController(
                       originSettingsController(),
                       animated: true
                     )


### PR DESCRIPTION
This adds a deep link route for presenting the Brave Origin paywall (or settings if already purchased)

Resolves https://github.com/brave/brave-browser/issues/55137

### Test
- Open the app via `brave://deep-link?path=origin_promo`
- Verify the paywall opens and that all flows in the paywall work as usual
- Verify after purchase Origin settings is presented still
- Dismiss the open settings and open the app again via `brave://deep-link?path=origin_promo`
- Verify Origin settings are presented instead of the paywall since its already purchased
