### PR TITLE
[iOS] Re-land Disable measured pre-boot in test runner

### DIFF
--- a/patches/ios-build-bots-scripts-iossim_util.py.patch
+++ b/patches/ios-build-bots-scripts-iossim_util.py.patch
@@ -1,0 +1,12 @@
+diff --git a/ios/build/bots/scripts/iossim_util.py b/ios/build/bots/scripts/iossim_util.py
+index 5b03df72f0fdd181ad57f1ac92c66c971b1e4ab5..6ce9877a6413d0852a2d40cb6309b6c2596a9147 100644
+--- a/ios/build/bots/scripts/iossim_util.py
++++ b/ios/build/bots/scripts/iossim_util.py
+@@ -489,6 +489,7 @@ def update_dyld_shared_cache(runtime=None):
+ 
+ 
+ def ensure_simulator_fully_booted(sim_udid: str, path=None, num_attempts=1):
++  return False
+   """Ensures simulator of given udid is fully booted.
+ 
+   `xcrun simctl boot` launches only background processes and does not ensure the


### PR DESCRIPTION
Re-lands the patch made in https://github.com/brave/brave-core/pull/35181 to fix the iOS simulators hanging in CI runs (was accidentally removed in https://github.com/brave/brave-core/pull/34644/changes/71a73115fb674ad0a5d94a32f0f781e71fa02160)