### PR TITLE
[iOS] Avoid continuation misuse in Leo WebUI photo picker

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+AIChat.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+AIChat.swift
@@ -197,6 +197,7 @@ extension BrowserViewController {
       var continuation: CheckedContinuation<[PHPickerResult], Never>?
       func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
         continuation?.resume(returning: results)
+        continuation = nil
         picker.dismiss(animated: true)
       }
     }


### PR DESCRIPTION
This is a speculative fix for the Photos picker calling the `didFinishPicking` delegate method more than once by ensuring that the continuation is niled out after a single use.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/55032