### PR TITLE
[iOS] Hide URL bar correctly when find-in-page is active

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Keyboard.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Keyboard.swift
@@ -17,8 +17,11 @@ extension BrowserViewController: KeyboardHelperDelegate {
     // show is because the active web content presented it.
     let isKeyboardActiveForWebContent =
       tabManager.selectedTab?.webViewProxy?.isKeyboardVisible == true
+    let isKeyboardActiveForFindInPage = tabManager.selectedTab?.isFindNavigatorVisible == true
     let isBraveOriginatedKeyboard = state.isLocal
-    if isKeyboardActiveForWebContent, isBraveOriginatedKeyboard, isUsingBottomBar {
+    if isKeyboardActiveForWebContent || isKeyboardActiveForFindInPage, isBraveOriginatedKeyboard,
+      isUsingBottomBar
+    {
       UIView.animate(withDuration: 0.1) { [self] in
         // We can't actually set the toolbar state to collapsed since bar collapsing/expanding is
         // based on many web view traits such as content size and such so we will just use the

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -1614,7 +1614,8 @@ public class BrowserViewController: UIViewController {
 
     func shouldShowTabBar() -> Bool {
       let isKeyboardActive =
-        tabManager.selectedTab?.webViewProxy?.isKeyboardVisible == true
+        (tabManager.selectedTab?.webViewProxy?.isKeyboardVisible == true
+          || tabManager.selectedTab?.isFindNavigatorVisible == true)
         && keyboardState?.isLocal == true
       if isUsingBottomBar, topToolbar.inOverlayMode || isKeyboardActive {
         return false

--- a/ios/brave-ios/Sources/Web/AnyTabState.swift
+++ b/ios/brave-ios/Sources/Web/AnyTabState.swift
@@ -166,6 +166,10 @@ public class AnyTabState: TabState {
     try await tab.createFullPagePDF()
   }
 
+  public var isFindNavigatorVisible: Bool {
+    tab.isFindNavigatorVisible
+  }
+
   public func presentFindInteraction(with text: String) {
     tab.presentFindInteraction(with: text)
   }

--- a/ios/brave-ios/Sources/Web/Chromium/ChromiumTabState.swift
+++ b/ios/brave-ios/Sources/Web/Chromium/ChromiumTabState.swift
@@ -439,6 +439,10 @@ class ChromiumTabState: TabState, TabStateImpl {
     return await webView?.createFullPagePDF()
   }
 
+  var isFindNavigatorVisible: Bool {
+    webView?.isFindNavigatorVisible ?? false
+  }
+
   func presentFindInteraction(with text: String) {
     webView?.findInPageController.findString(inPage: text)
   }

--- a/ios/brave-ios/Sources/Web/TabState.swift
+++ b/ios/brave-ios/Sources/Web/TabState.swift
@@ -210,6 +210,8 @@ public protocol TabState: AnyObject {
   func takeSnapshot(rect: CGRect, handler: @escaping (UIImage?) -> Void)
   /// Creates a full page PDF of the web contents
   func createFullPagePDF() async throws -> Data?
+  /// Whether or not find in page is currently visible
+  var isFindNavigatorVisible: Bool { get }
   /// Presents the find in page interaction using the provided text as an initial search query
   func presentFindInteraction(with text: String)
   /// Dismisses any active find in page interactions

--- a/ios/brave-ios/Sources/Web/Test/FakeTabState.swift
+++ b/ios/brave-ios/Sources/Web/Test/FakeTabState.swift
@@ -81,6 +81,7 @@ public final class FakeTabState: TabState {
   public var canTakeSnapshot: Bool { false }
   public func takeSnapshot(rect: CGRect, handler: @escaping (UIImage?) -> Void) { handler(nil) }
   public func createFullPagePDF() async throws -> Data? { nil }
+  public var isFindNavigatorVisible: Bool { false }
   public func presentFindInteraction(with text: String) {}
   public func dismissFindInteraction() {}
   public func evaluateJavaScriptUnsafe(_ javascript: String) {}

--- a/ios/web_view/internal/cwv_web_view_extras.mm
+++ b/ios/web_view/internal/cwv_web_view_extras.mm
@@ -14,6 +14,7 @@
 #include "ios/web/js_messaging/web_frame_internal.h"
 #include "ios/web/js_messaging/web_view_js_utils.h"
 #include "ios/web/public/favicon/favicon_status.h"
+#include "ios/web/public/find_in_page/crw_find_interaction.h"
 #include "ios/web/public/js_messaging/web_frames_manager.h"
 #include "ios/web/public/ui/crw_web_view_proxy.h"
 #include "ios/web/web_state/ui/crw_web_controller.h"
@@ -197,6 +198,10 @@ const CWVUserAgentType CWVUserAgentTypeDesktop =
 
 - (UIViewPrintFormatter*)viewPrintFormatter {
   return [self.webState->GetView() viewPrintFormatter];
+}
+
+- (BOOL)isFindNavigatorVisible {
+  return self.webState->GetFindInteraction().findNavigatorVisible;
 }
 
 @end

--- a/ios/web_view/public/cwv_web_view_extras.h
+++ b/ios/web_view/public/cwv_web_view_extras.h
@@ -66,6 +66,9 @@ CWV_EXPORT
 /// The current favicon status of the web state
 @property(readonly, nullable) CWVFaviconStatus* faviconStatus;
 
+/// Whether or not find in page is visible
+@property(readonly, getter=isFindNavigatorVisible) BOOL findNavigatorVisible;
+
 #pragma mark -
 
 /// Creates a PDF of the current page


### PR DESCRIPTION
This fixes a regression where the URL bar wouldn't hide/collapse correctly while find-in-page was active

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/54973
