### PR TITLE
[iOS] Avoid continuation misuse in Leo WebUI photo picker (uplift to 1.90.x)

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+AIChat.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+AIChat.swift
@@ -196,6 +196,7 @@ extension BrowserViewController {
       var continuation: CheckedContinuation<[PHPickerResult], Never>?
       func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
         continuation?.resume(returning: results)
+        continuation = nil
         picker.dismiss(animated: true)
       }
     }


### PR DESCRIPTION
Uplift of #35974
Resolves https://github.com/brave/brave-browser/issues/55032

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.