### PR TITLE
[gerrit] `refresh_mirrors.py` for mirror CI pipeline

### DIFF
--- a/tools/cr/refresh_mirrors.py
+++ b/tools/cr/refresh_mirrors.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Refresh git mirrors from upstream sources into our Gerrit instance.
+
+This script fetches each configured upstream repository and pushes it to its
+corresponding Gerrit mirror. It is designed to run standalone in CI without
+any third-party dependencies.
+
+Usage:
+    python3 refresh_mirrors.py --mirrors-path=./mirrors [--verbose]
+
+Or directly from GitHub:
+    curl -sSLf \\
+        "https://raw.githubusercontent.com/brave/brave-core/master/tools/cr/refresh_mirrors.py" \\
+        | python3 - --mirrors-path=./mirrors
+"""
+
+import argparse
+import logging
+import subprocess
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import List, Optional
+
+BRAVE_GERRIT_URL = 'ssh://{username}gerrit.brave.com:29418'
+
+
+def _query(*command: str,
+           cwd: Optional[Path] = None) -> subprocess.CompletedProcess:
+    """Run command and return its result without raising on non-zero exit.
+
+    Use this for read-only queries where a non-zero exit is an expected,
+    handled condition (e.g. checking whether a git remote exists).
+
+    Args:
+        *command: Program and its arguments.
+        cwd: Optional working directory for the subprocess.
+    """
+    logging.info('>>> %s', ' '.join(command))
+    return subprocess.run(list(command),
+                          cwd=cwd,
+                          capture_output=True,
+                          text=True,
+                          check=False)
+
+
+def _run(*command: str, cwd: Optional[Path] = None) -> None:
+    """Run command, printing it first; log stderr and raise on failure.
+
+    Args:
+        *command: Program and its arguments.
+        cwd: Optional working directory for the subprocess.
+
+    Raises:
+        subprocess.CalledProcessError: If the command exits non-zero.
+    """
+    logging.info('>>> %s', ' '.join(command))
+    subprocess.run(list(command), cwd=cwd, check=True)
+
+
+@dataclass
+class Mirror:
+    """A git mirror pairing an upstream source with a Gerrit destination.
+
+    Encapsulates all operations needed to keep a Gerrit mirror in sync:
+    initialising the local bare repository, configuring remotes, fetching
+    from upstream, and pushing to Gerrit.
+
+    The static fields (mirror, upstream, refs) describe what to mirror.
+    The runtime fields (mirrors_path, gerrit_url) are set once via
+    dataclasses.replace() in main() before any operation is called.
+    """
+    # URI path component of the Gerrit repository, e.g. "googlesource/chromium".
+    mirror: str
+    # Upstream git URL to fetch from.
+    upstream: str
+    # Refspecs to sync, e.g. ["refs/heads/*:refs/heads/*"].
+    refs: List[str]
+    # Root directory under which mirror repos are stored; set at runtime.
+    mirrors_path: Optional[Path] = None
+    # Gerrit base URL, e.g. "ssh://gerrit.brave.com:29418"; set at runtime.
+    gerrit_url: Optional[str] = None
+
+    def local_path(self) -> Path:
+        """Return the local bare repo path for this mirror."""
+        return self.mirrors_path / self.mirror
+
+    def _ensure_remote(self, path: Path, name: str, url: str) -> None:
+        """Ensure a git remote exists and points to the expected URL.
+
+        Adds the remote if absent; updates it if the URL has drifted.
+
+        Args:
+            path: Local bare repo directory.
+            name: Remote name, either 'upstream' or 'mirror'.
+            url: Expected remote URL.
+        """
+        result = _query('git', 'remote', 'get-url', name, cwd=path)
+        if result.returncode != 0:
+            _run('git', 'remote', 'add', name, url, cwd=path)
+        elif result.stdout.strip() != url:
+            logging.info('Updating remote %s from %s to %s', name,
+                         result.stdout.strip(), url)
+            _run('git', 'remote', 'set-url', name, url, cwd=path)
+
+    def _setup(self) -> None:
+        """Initialise the local bare repo and configure remotes.
+
+        Creates the bare repo under mirrors_path if it does not already exist.
+        For existing repos the remotes are verified and updated if they have
+        drifted from the values stored in this Mirror.
+        """
+        path = self.local_path()
+        mirror_url = f'{self.gerrit_url}/{self.mirror}'
+        if not path.exists():
+            path.mkdir(parents=True)
+            _run('git', 'init', '--bare', str(path))
+            _run('git', 'remote', 'add', 'upstream', self.upstream, cwd=path)
+            _run('git', 'remote', 'add', 'mirror', mirror_url, cwd=path)
+        else:
+            self._ensure_remote(path, 'upstream', self.upstream)
+            self._ensure_remote(path, 'mirror', mirror_url)
+
+    def fetch(self) -> None:
+        """Fetch configured refs from upstream into the local bare repo.
+
+        Raises:
+            subprocess.CalledProcessError: If the fetch fails.
+        """
+        _run('git',
+             'fetch',
+             'upstream',
+             '--no-tags',
+             '--prune',
+             '--prune-tags',
+             *self.refs,
+             cwd=self.local_path())
+
+    def push(self) -> None:
+        """Push configured refs from the local bare repo to the Gerrit mirror.
+
+        Raises:
+            subprocess.CalledProcessError: If the push fails.
+        """
+        _run('git',
+             'push',
+             'mirror',
+             '--prune',
+             *self.refs,
+             cwd=self.local_path())
+
+    def sync(self) -> None:
+        """Set up, fetch, and push this mirror.
+
+        Raises:
+            subprocess.CalledProcessError: On any git failure; propagates to
+                the caller so it can decide whether to continue with other
+                mirrors.
+        """
+        self._setup()
+        self.fetch()
+        self.push()
+
+
+MIRRORS: List[Mirror] = [
+    Mirror(
+        mirror='googlesource/chromium',
+        upstream='https://chromium.googlesource.com/chromium/src',
+        refs=[
+            'refs/heads/*:refs/heads/*',
+            'refs/tags/*:refs/tags/*',
+        ],
+    ),
+]
+
+
+def main() -> None:
+    """Parse arguments and sync all configured mirrors."""
+    parser = argparse.ArgumentParser(
+        description='Refresh git mirrors from upstream sources into Gerrit.')
+    parser.add_argument('--mirrors-path',
+                        required=True,
+                        help='Root directory under which mirrors are stored.')
+    parser.add_argument('--user',
+                        default='',
+                        help='Gerrit SSH username, e.g. "cdesouza". When '
+                        'omitted the push URL has no user prefix.')
+    parser.add_argument('--verbose',
+                        action='store_true',
+                        help='Enable debug logging.')
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.DEBUG if args.verbose else logging.INFO)
+
+    username = f'{args.user}@' if args.user else ''
+    gerrit_url = BRAVE_GERRIT_URL.format(username=username)
+
+    mirrors_path = Path(args.mirrors_path).expanduser()
+    mirrors_path.mkdir(parents=True, exist_ok=True)
+
+    for mirror in MIRRORS:
+        try:
+            replace(mirror, mirrors_path=mirrors_path,
+                    gerrit_url=gerrit_url).sync()
+        except subprocess.CalledProcessError:
+            logging.error('Mirror %s failed; skipping.', mirror.mirror)
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/cr/refresh_mirrors_test.py
+++ b/tools/cr/refresh_mirrors_test.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Tests for refresh_mirrors.py.
+
+Tests use real git repositories in temporary directories so that all git
+operations are exercised end-to-end rather than mocked.
+"""
+
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+from refresh_mirrors import BRAVE_GERRIT_URL, Mirror
+
+
+def _git(*cmd: str, cwd: Path) -> str:
+    """Run a git command and return stdout, raising on non-zero exit."""
+    result = subprocess.run(['git', *cmd],
+                            cwd=cwd,
+                            capture_output=True,
+                            text=True,
+                            check=True)
+    return result.stdout.strip()
+
+
+class TestMirrorLocalPath(unittest.TestCase):
+    """Unit tests for local path derivation from the mirror particle."""
+
+    def test_local_path_joins_correctly(self):
+        m = Mirror(mirror='googlesource/chromium',
+                   upstream='https://example.com/up',
+                   refs=[],
+                   mirrors_path=Path('/mirrors'),
+                   gerrit_url=BRAVE_GERRIT_URL)
+        self.assertEqual(m.local_path(),
+                         Path('/mirrors/googlesource/chromium'))
+
+
+class TestMirrorSetup(unittest.TestCase):
+    """Tests for bare repository creation and remote configuration."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmp = Path(self._tmp.name)
+        self.mirrors_path = self.tmp / 'mirrors'
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _make_mirror(self, upstream: str = 'https://example.com/up') -> Mirror:
+        return Mirror(mirror='test/repo',
+                      upstream=upstream,
+                      refs=['refs/heads/*:refs/heads/*'],
+                      mirrors_path=self.mirrors_path,
+                      gerrit_url=BRAVE_GERRIT_URL)
+
+    def test_setup_creates_bare_repo(self):
+        self._make_mirror()._setup()
+        repo = self.mirrors_path / 'test/repo'
+        self.assertTrue((repo / 'HEAD').exists())
+
+    def test_setup_creates_intermediate_directories(self):
+        self._make_mirror()._setup()
+        self.assertTrue((self.mirrors_path / 'test').is_dir())
+
+    def test_setup_configures_upstream_remote(self):
+        self._make_mirror('https://example.com/upstream')._setup()
+        url = _git('remote',
+                   'get-url',
+                   'upstream',
+                   cwd=self.mirrors_path / 'test/repo')
+        self.assertEqual(url, 'https://example.com/upstream')
+
+    def test_setup_configures_mirror_remote(self):
+        self._make_mirror()._setup()
+        url = _git('remote',
+                   'get-url',
+                   'mirror',
+                   cwd=self.mirrors_path / 'test/repo')
+        self.assertEqual(url, f'{BRAVE_GERRIT_URL}/test/repo')
+
+    def test_setup_updates_stale_upstream_remote(self):
+        # Initial setup with one URL, then update to a new one.
+        Mirror(mirror='test/repo',
+               upstream='https://example.com/old',
+               refs=[],
+               mirrors_path=self.mirrors_path,
+               gerrit_url=BRAVE_GERRIT_URL)._setup()
+        Mirror(mirror='test/repo',
+               upstream='https://example.com/new',
+               refs=[],
+               mirrors_path=self.mirrors_path,
+               gerrit_url=BRAVE_GERRIT_URL)._setup()
+        url = _git('remote',
+                   'get-url',
+                   'upstream',
+                   cwd=self.mirrors_path / 'test/repo')
+        self.assertEqual(url, 'https://example.com/new')
+
+    def test_setup_is_idempotent(self):
+        m = self._make_mirror()
+        m._setup()
+        m._setup()
+        url = _git('remote',
+                   'get-url',
+                   'upstream',
+                   cwd=self.mirrors_path / 'test/repo')
+        self.assertEqual(url, 'https://example.com/up')
+
+
+class TestMirrorFetchPush(unittest.TestCase):
+    """Integration tests for fetch/push using real local git repositories."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmp = Path(self._tmp.name)
+        self.mirrors_path = self.tmp / 'mirrors'
+
+        # Upstream: a normal repo with an initial commit.
+        self.upstream = self.tmp / 'upstream'
+        self.upstream.mkdir()
+        subprocess.run(['git', 'init', str(self.upstream)],
+                       check=True,
+                       capture_output=True)
+        subprocess.run([
+            'git', '-C',
+            str(self.upstream), 'config', 'user.email', 'test@example.com'
+        ],
+                       check=True,
+                       capture_output=True)
+        subprocess.run(
+            ['git', '-C',
+             str(self.upstream), 'config', 'user.name', 'Test'],
+            check=True,
+            capture_output=True)
+        (self.upstream / 'README').write_text('hello')
+        subprocess.run(
+            ['git', '-C', str(self.upstream), 'add', '.'],
+            check=True,
+            capture_output=True)
+        subprocess.run(
+            ['git', '-C',
+             str(self.upstream), 'commit', '-m', 'initial'],
+            check=True,
+            capture_output=True)
+        self.branch = _git('rev-parse',
+                           '--abbrev-ref',
+                           'HEAD',
+                           cwd=self.upstream)
+
+        # Mirror target: a bare repo that receives pushes.
+        self.mirror_target = self.tmp / 'mirror_target'
+        subprocess.run(['git', 'init', '--bare',
+                        str(self.mirror_target)],
+                       check=True,
+                       capture_output=True)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _setup_mirror(self) -> Mirror:
+        """Create and set up a Mirror, then redirect its mirror remote to the
+        local mirror_target so pushes work without a real Gerrit server."""
+        mirror = Mirror(mirror='test/repo',
+                        upstream=str(self.upstream),
+                        refs=['refs/heads/*:refs/heads/*'],
+                        mirrors_path=self.mirrors_path,
+                        gerrit_url=BRAVE_GERRIT_URL)
+        mirror._setup()
+        subprocess.run(
+            ['git', 'remote', 'set-url', 'mirror',
+             str(self.mirror_target)],
+            cwd=mirror.local_path(),
+            check=True,
+            capture_output=True)
+        return mirror
+
+    def test_fetch_and_push_sync_refs(self):
+        mirror = self._setup_mirror()
+        mirror.fetch()
+        mirror.push()
+
+        upstream_sha = _git('rev-parse', 'HEAD', cwd=self.upstream)
+        mirror_sha = _git('rev-parse',
+                          f'refs/heads/{self.branch}',
+                          cwd=self.mirror_target)
+        self.assertEqual(upstream_sha, mirror_sha)
+
+    def test_sync_fetch_failure_raises_and_skips_push(self):
+        """When fetch fails, sync raises CalledProcessError."""
+        mirror = Mirror(mirror='test/repo',
+                        upstream=str(self.tmp / 'no_such_repo'),
+                        refs=['refs/heads/*:refs/heads/*'],
+                        mirrors_path=self.mirrors_path,
+                        gerrit_url=BRAVE_GERRIT_URL)
+
+        with self.assertRaises(subprocess.CalledProcessError):
+            mirror.sync()
+
+        # Push was never called so the mirror target must have no refs.
+        result = subprocess.run(
+            ['git', '-C', str(self.mirror_target), 'show-ref'],
+            capture_output=True,
+            text=True,
+            check=False)
+        self.assertEqual(result.stdout.strip(), '')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This script will be used in the pipeline for sync gerrit mirrors. This
is a very basic script that merely creates `bare` repos to serve as a
trampoline to push things into gerrit.

This first implementation only contains settings for `chromium/src/`.

```sh
python3 refresh_mirrors.py --mirrors-path=./mirrors [--verbose]
```

Bug: https://github.com/brave/brave-browser/issues/55044
