### PR TITLE
Fix tab group title vertical alignment in horizontal and vertical tab modes

### DIFF
--- a/browser/ui/views/tabs/brave_tab_group_header.cc
+++ b/browser/ui/views/tabs/brave_tab_group_header.cc
@@ -73,20 +73,6 @@ void BraveTabGroupHeader::VisualsChanged() {
     title_chip_->SetBackground(nullptr);
   }
 
-  // When the title is empty, upstream (127) ignores the top value returned from
-  // `GetInsetsForHeaderChip`, which throws off the header size. Adjust the
-  // vertical layout to maintain the group header height.
-  if (!title_->GetText().empty()) {
-    const gfx::Insets title_chip_insets =
-        group_style_->GetInsetsForHeaderChip();
-    title_chip_->SetSize(
-        {title_chip_->width(), title_->height() + 2 * title_chip_insets.top()});
-    title_->SetY(title_chip_insets.top());
-    if (ShouldShowHeaderIcon()) {
-      sync_icon_->SetY(title_chip_insets.top());
-    }
-  }
-
   if (ShouldShowVerticalTabs()) {
     LayoutTitleChipForVerticalTabs();
   }
@@ -123,8 +109,10 @@ void BraveTabGroupHeader::LayoutTitleChipForVerticalTabs() {
   title_chip_->SetBoundsRect(title_bounds);
 
   // |title_| is a child view of |title_chip_| and there could be |sync_icon_|
-  // before |title_|. So expand |title_|'s width considering that.
-  title_->SetSize({title_bounds.width() - title_->x(), title_->height()});
+  // before |title_|. Expand |title_|'s width to fill the chip, and set its
+  // height to the chip height so the label centers text vertically.
+  title_->SetBounds(title_->x(), 0, title_bounds.width() - title_->x(),
+                    title_bounds.height());
 }
 
 SkColor BraveTabGroupHeader::GetGroupColor() const {


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/55049

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
