### PR TITLE
Fix race condition in DAU ping on iOS

### DIFF
--- a/ios/brave-ios/Sources/Growth/DAU.swift
+++ b/ios/brave-ios/Sources/Growth/DAU.swift
@@ -9,6 +9,23 @@ import Preferences
 import Shared
 import os.log
 
+/// Abstracts `BraveStats` so tests can inject a fake implementation.
+// TODO(https://github.com/brave/brave-browser/issues/55105):
+// Change this to use a protocol exposed from the `BraveStats` bridge.
+public protocol BraveCoreStats: AnyObject {
+  /// Reads the `brave.stats.reporting_enabled` Chromium preference,
+  // so must be accessed on the main thread.
+  var isStatsReportingEnabled: Bool { get }
+  /// Reads the `brave.brave_ads.enabled` Chromium preference,
+  // so must be accessed on the main thread.
+  var isNotificationAdsEnabled: Bool { get }
+  /// Reads and writes the `brave.stats.last_check_ymd` Chromium preference,
+  // so must be accessed on the main thread.
+  var lastPingDate: Date? { get set }
+}
+
+extension BraveStats: BraveCoreStats {}
+
 public class DAU {
 
   /// Default installation date for legacy woi version.
@@ -65,11 +82,11 @@ public class DAU {
   }
 
   private let apiKey: String?
-  private let braveCoreStats: BraveStats?
+  private let braveCoreStats: (any BraveCoreStats)?
   private let serpMetrics: (any SerpMetrics)?
 
   public init(
-    braveCoreStats: BraveStats?,
+    braveCoreStats: (any BraveCoreStats)?,
     serpMetrics: (any SerpMetrics)?
   ) {
     self.braveCoreStats = braveCoreStats
@@ -149,24 +166,26 @@ public class DAU {
     }
 
     let task = URLSession.shared.dataTask(with: request) { [self] _, _, error in
-      defer {
-        self.processingPing = false
-      }
+      DispatchQueue.main.async {
+        defer {
+          self.processingPing = false
+        }
 
-      if let e = error {
-        Logger.module.error("status update error: \(e.localizedDescription)")
-        return
-      }
+        if let e = error {
+          Logger.module.error("status update error: \(e.localizedDescription)")
+          return
+        }
 
-      // Ping was successful, next ping should be sent with `first` parameter set to false.
-      // This preference is set for future DAU pings.
-      Preferences.DAU.firstPingParam.value = false
+        // Ping was successful, next ping should be sent with `first` parameter set to false.
+        // This preference is set for future DAU pings.
+        Preferences.DAU.firstPingParam.value = false
 
-      // Store the last ping date in local state so all platform components share one source of truth.
-      // Thread hop to main is required because `lastPingDate` sets `brave.stats.last_check_ymd`
-      // Chromium preference, which must be done from the main thread.
-      DispatchQueue.main.async { [weak self] in
-        self?.braveCoreStats?.lastPingDate = paramsAndPrefs.date
+        // Store the last ping date in local state so all platform components
+        // share one source of truth.
+        // Thread hop to main is required because `lastPingDate` sets
+        // `brave.stats.last_check_ymd` Chromium preference, which must be done
+        // from the main thread.
+        self.braveCoreStats?.lastPingDate = paramsAndPrefs.date
       }
     }
 
@@ -284,9 +303,9 @@ public class DAU {
     return URLQueryItem(name: "channel", value: channel.dauServerChannelParam)
   }
 
-  func braveCoreParams(for braveStats: BraveStats) -> [URLQueryItem] {
+  func braveCoreParams(for braveCoreStats: any BraveCoreStats) -> [URLQueryItem] {
     return [
-      .init(name: "ads_enabled", value: braveStats.isNotificationAdsEnabled ? "true" : "false")
+      .init(name: "ads_enabled", value: braveCoreStats.isNotificationAdsEnabled ? "true" : "false")
     ]
   }
 

--- a/ios/brave-ios/Tests/GrowthTests/DAUTests.swift
+++ b/ios/brave-ios/Tests/GrowthTests/DAUTests.swift
@@ -36,6 +36,39 @@ private class SerpMetricsMock: NSObject, SerpMetrics {
   func clearHistory() {}
 }
 
+private class BraveCoreStatsMock: BraveCoreStats {
+  var isStatsReportingEnabled: Bool = true
+  var isNotificationAdsEnabled: Bool = false
+  var lastPingDate: Date? = nil
+}
+
+private class MockURLProtocol: URLProtocol {
+  static var error: Error?
+  static var onComplete: (() -> Void)?
+
+  override func startLoading() {
+    if let error = MockURLProtocol.error {
+      client?.urlProtocol(self, didFailWithError: error)
+    } else {
+      client?.urlProtocol(
+        self,
+        didReceive: HTTPURLResponse(
+          url: request.url!,
+          statusCode: 200,
+          httpVersion: nil,
+          headerFields: nil
+        )!,
+        cacheStoragePolicy: .notAllowed
+      )
+      client?.urlProtocolDidFinishLoading(self)
+    }
+    MockURLProtocol.onComplete?()
+  }
+  override class func canInit(with request: URLRequest) -> Bool { true }
+  override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+  override func stopLoading() {}
+}
+
 class DAUTests: XCTestCase {
 
   var lastKnownPingDate: Date? = nil
@@ -46,6 +79,9 @@ class DAUTests: XCTestCase {
     Preferences.DAU.weekOfInstallation.reset()
     Preferences.DAU.firstPingParam.reset()
     Preferences.DAU.installationDate.reset()
+
+    MockURLProtocol.error = nil
+    MockURLProtocol.onComplete = nil
   }
 
   // 7-7-07 at 12noon GMT
@@ -520,6 +556,47 @@ class DAUTests: XCTestCase {
     XCTAssertFalse(params.queryParams.contains(where: { $0.name == "googleSearch" }))
     XCTAssertFalse(params.queryParams.contains(where: { $0.name == "otherSearch" }))
     XCTAssertFalse(params.queryParams.contains(where: { $0.name == "staleSearch" }))
+  }
+
+  func testSuccessfulPingSetsLastPingDateAndFirstPingParam() {
+    URLProtocol.registerClass(MockURLProtocol.self)
+    defer { URLProtocol.unregisterClass(MockURLProtocol.self) }
+
+    let mockStats = BraveCoreStatsMock()
+    Preferences.DAU.installationDate.value = Date()
+    let dau = DAU(braveCoreStats: mockStats, serpMetrics: nil)
+
+    dau.sendPingToServer()
+
+    expectation(
+      for: NSPredicate { _, _ in
+        !Preferences.DAU.firstPingParam.value && mockStats.lastPingDate != nil
+      },
+      evaluatedWith: nil
+    )
+    waitForExpectations(timeout: 2)
+
+    XCTAssertFalse(Preferences.DAU.firstPingParam.value)
+    XCTAssertNotNil(mockStats.lastPingDate)
+  }
+
+  func testFailedPingDoesNotSetLastPingDateOrFirstPingParam() {
+    URLProtocol.registerClass(MockURLProtocol.self)
+    defer { URLProtocol.unregisterClass(MockURLProtocol.self) }
+
+    MockURLProtocol.error = URLError(.notConnectedToInternet)
+    let networkFailed = expectation(description: "network failed")
+    MockURLProtocol.onComplete = { networkFailed.fulfill() }
+
+    let mockStats = BraveCoreStatsMock()
+    Preferences.DAU.installationDate.value = Date()
+    let dau = DAU(braveCoreStats: mockStats, serpMetrics: nil)
+
+    dau.sendPingToServer()
+    waitForExpectations(timeout: 2)
+
+    XCTAssertTrue(Preferences.DAU.firstPingParam.value)
+    XCTAssertNil(mockStats.lastPingDate)
   }
 
   // No longer valid outside of a hosted app


### PR DESCRIPTION
After a successful DAU ping, `processingPing`, `lastPingDate` flags and `lastPingDate` were written on different threads, creating a race condition where a new ping could start before the previous one's state was fully saved.
To fix this writes now happen together on the main thread.

This is a follow-up to https://github.com/brave/brave-core/pull/35385.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/55149

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
