### PR TITLE
[iOS] Add Brave Search "Make Default" JavaScriptFeature

### DIFF
--- a/ios/BUILD.gn
+++ b/ios/BUILD.gn
@@ -129,6 +129,7 @@ brave_core_public_headers = [
   "$root_gen_dir/components/grit/brave_components_swift_strings.h",
   "//brave/ios/browser/web/logins/logins_tab_helper_bridge.h",
   "//brave/ios/browser/brave_talk/brave_talk_tab_helper_bridge.h",
+  "//brave/ios/browser/brave_search/brave_search_make_default_tab_helper_bridge.h",
   "//ios/chrome/browser/web/model/print/print_handler.h",
   "//brave/ios/browser/youtube/youtube_pref_names_bridge.h",
 ]

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabManagerDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabManagerDelegate.swift
@@ -111,7 +111,7 @@ extension BrowserViewController: TabManagerDelegate {
       }
     }
 
-    tab.braveSearch = .init(tab: tab, rewards: rewards)
+    tab.braveSearch = .init(tab: tab, rewards: rewards, searchEngines: profile.searchEngines)
     tab.braveSearch?.presentSearchResultClickedInfoBar = { [weak self] in
       guard let self else { return }
       let searchResultClickedInfobar = SearchResultAdClickedInfoBar(

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/BraveSearchTabHelper.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/BraveSearchTabHelper.swift
@@ -7,6 +7,7 @@ import BraveCore
 import BraveShields
 import Foundation
 import OSLog
+import Preferences
 @_spi(ChromiumWebViewAccess) import Web
 
 extension TabDataValues {
@@ -19,9 +20,10 @@ extension TabDataValues {
   }
 }
 
-class BraveSearchTabHelper: TabObserver, TabPolicyDecider {
+class BraveSearchTabHelper: TabObserver, TabPolicyDecider, BraveSearchMakeDefaultTabHelperBridge {
   private weak var tab: (any TabState)?
   private let rewards: BraveRewards
+  private let searchEngines: SearchEngines
 
   /// A helper property that handles native to Brave Search communication.
   private var braveSearchManager: BraveSearchManager?
@@ -31,9 +33,10 @@ class BraveSearchTabHelper: TabObserver, TabPolicyDecider {
 
   var presentSearchResultClickedInfoBar: (() -> Void)?
 
-  init(tab: some TabState, rewards: BraveRewards) {
+  init(tab: some TabState, rewards: BraveRewards, searchEngines: SearchEngines) {
     self.tab = tab
     self.rewards = rewards
+    self.searchEngines = searchEngines
 
     tab.addObserver(self)
     tab.addPolicyDecider(self)
@@ -44,7 +47,62 @@ class BraveSearchTabHelper: TabObserver, TabPolicyDecider {
     tab?.removePolicyDecider(self)
   }
 
+  // MARK: - Brave Search Default Prompts
+
+  /// Tracks how many in current browsing session the user has been prompted to set Brave Search as a default
+  /// while on one of Brave Search websites.
+  private static var canSetAsDefaultCounter = 0
+  /// How many times user should be shown the default browser prompt on Brave Search websites.
+  private static let maxCountOfDefaultBrowserPromptsPerSession = 3
+  /// How many times user is shown the default browser prompt in total, this does not reset between app launches.
+  private static let maxCountOfDefaultBrowserPromptsTotal = 10
+
+  func checkCanSetBraveSearchAsDefault() -> Bool {
+    guard let tab else { return false }
+    if tab.isPrivate {
+      Logger.module.debug("Private mode detected, skipping setting Brave Search as a default")
+      return false
+    }
+
+    let maximumPromptCount = Preferences.Search.braveSearchDefaultBrowserPromptCount
+    if Self.canSetAsDefaultCounter >= Self.maxCountOfDefaultBrowserPromptsPerSession
+      || maximumPromptCount.value >= Self.maxCountOfDefaultBrowserPromptsTotal
+    {
+      Logger.module.debug("Maximum number of tries of Brave Search website prompts reached")
+      return false
+    }
+
+    Self.canSetAsDefaultCounter += 1
+    maximumPromptCount.value += 1
+
+    let defaultEngine = searchEngines.defaultEngine(forType: .standard)?.shortName
+    return defaultEngine != OpenSearchEngine.EngineNames.brave
+  }
+
+  func setBraveSearchAsDefault() {
+    searchEngines.updateDefaultEngine(
+      OpenSearchEngine.EngineNames.brave,
+      forType: .standard
+    )
+  }
+
+  // MARK: - BraveSearchMakeDefaultTabHelperBridge
+
+  func getCanSetDefaultSearchProvider() -> Bool {
+    checkCanSetBraveSearchAsDefault()
+  }
+
+  func setIsDefaultSearchProvider() {
+    setBraveSearchAsDefault()
+  }
+
   // MARK: - TabObserver
+
+  func tabDidCreateWebView(_ tab: some TabState) {
+    if FeatureList.kUseProfileWebViewConfiguration.enabled {
+      BraveWebView.from(tab: tab)?.braveSearchHelper = self
+    }
+  }
 
   func tabDidFinishNavigation(_ tab: some TabState) {
     if FeatureList.kUseProfileWebViewConfiguration.enabled,

--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/BraveSearchScriptHandler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/BraveSearchScriptHandler.swift
@@ -83,7 +83,8 @@ class BraveSearchScriptHandler: TabContentScript {
     }
 
     guard let data = try? JSONSerialization.data(withJSONObject: message.body, options: []),
-      let method = try? JSONDecoder().decode(MethodModel.self, from: data).methodId
+      let method = try? JSONDecoder().decode(MethodModel.self, from: data).methodId,
+      let helper = tab.braveSearch
     else {
       Logger.module.error("Failed to retrieve method id")
       replyHandler(nil, nil)
@@ -92,46 +93,13 @@ class BraveSearchScriptHandler: TabContentScript {
 
     switch method {
     case Method.canSetBraveSearchAsDefault.rawValue:
-      handleCanSetBraveSearchAsDefault(tab: tab, replyHandler: replyHandler)
+      let canSetBraveSearchAsDefault = helper.checkCanSetBraveSearchAsDefault()
+      replyHandler(canSetBraveSearchAsDefault, nil)
     case Method.setBraveSearchDefault.rawValue:
-      handleSetBraveSearchDefault(replyHandler: replyHandler)
+      helper.setBraveSearchAsDefault()
+      replyHandler(nil, nil)
     default:
       break
     }
-  }
-
-  private func handleCanSetBraveSearchAsDefault(
-    tab: some TabState,
-    replyHandler: (Any?, String?) -> Void
-  ) {
-    if tab.isPrivate == true {
-      Logger.module.debug("Private mode detected, skipping setting Brave Search as a default")
-      replyHandler(false, nil)
-      return
-    }
-
-    let maximumPromptCount = Preferences.Search.braveSearchDefaultBrowserPromptCount
-    if Self.canSetAsDefaultCounter >= maxCountOfDefaultBrowserPromptsPerSession
-      || maximumPromptCount.value >= maxCountOfDefaultBrowserPromptsTotal
-    {
-      Logger.module.debug("Maximum number of tries of Brave Search website prompts reached")
-      replyHandler(false, nil)
-      return
-    }
-
-    Self.canSetAsDefaultCounter += 1
-    maximumPromptCount.value += 1
-
-    let defaultEngine = profile.searchEngines.defaultEngine(forType: .standard)?.shortName
-    let canSetAsDefault = defaultEngine != OpenSearchEngine.EngineNames.brave
-    replyHandler(canSetAsDefault, nil)
-  }
-
-  private func handleSetBraveSearchDefault(replyHandler: (Any?, String?) -> Void) {
-    profile.searchEngines.updateDefaultEngine(
-      OpenSearchEngine.EngineNames.brave,
-      forType: .standard
-    )
-    replyHandler(nil, nil)
   }
 }

--- a/ios/browser/api/web_view/brave_web_view.h
+++ b/ios/browser/api/web_view/brave_web_view.h
@@ -25,6 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol ProfileBridge;
 @protocol LoginsTabHelperBridge;
 @protocol BraveTalkTabHelperBridge;
+@protocol BraveSearchMakeDefaultTabHelperBridge;
 @protocol PrintHandler;
 
 typedef void (^ResetConfigurationCallback)(id<ProfileBridge>,
@@ -217,6 +218,13 @@ CWV_EXPORT
 @interface BraveWebView (BraveTalk)
 /// A bridge for handling Brave Talk tab features
 - (void)setBraveTalkHelper:(id<BraveTalkTabHelperBridge>)braveTalkHelper;
+@end
+
+CWV_EXPORT
+@interface BraveWebView (BraveSearchHelper)
+/// A bridge for handling Brave Search helper script messages
+@property(nonatomic, weak, nullable) id<BraveSearchMakeDefaultTabHelperBridge>
+    braveSearchHelper;
 @end
 
 CWV_EXPORT

--- a/ios/browser/api/web_view/brave_web_view.mm
+++ b/ios/browser/api/web_view/brave_web_view.mm
@@ -26,6 +26,8 @@
 #include "brave/ios/browser/api/web_view/passwords/brave_web_view_password_manager_client.h"
 #include "brave/ios/browser/brave_ads/ads_tab_helper.h"
 #include "brave/ios/browser/brave_search/brave_search_ad_results_javascript_feature.h"
+#include "brave/ios/browser/brave_search/brave_search_make_default_tab_helper.h"
+#include "brave/ios/browser/brave_search/brave_search_make_default_tab_helper_bridge.h"
 #include "brave/ios/browser/brave_talk/brave_talk_tab_helper_bridge.h"
 #include "brave/ios/browser/favicon/brave_ios_web_favicon_driver.h"
 #include "brave/ios/browser/serp_metrics/serp_metrics_tab_helper.h"
@@ -256,6 +258,8 @@ class FaviconDriverObserver : public favicon::FaviconDriverObserver {
 #if BUILDFLAG(ENABLE_BRAVE_TALK)
 @property(nonatomic, weak) id<BraveTalkTabHelperBridge> braveTalkHelper;
 #endif
+@property(nonatomic, weak) id<BraveSearchMakeDefaultTabHelperBridge>
+    braveSearchHelper;
 @property(nonatomic, weak) id<PrintHandler> printHandler;
 @end
 
@@ -368,6 +372,10 @@ class FaviconDriverObserver : public favicon::FaviconDriverObserver {
   BraveTalkTabHelper::FromWebState(self.webState)
       ->SetBridge(self.braveTalkHelper);
 #endif
+
+  BraveSearchMakeDefaultTabHelper::CreateForWebState(self.webState);
+  BraveSearchMakeDefaultTabHelper::FromWebState(self.webState)
+      ->SetBridge(self.braveSearchHelper);
 
   LoginsTabHelper::MaybeCreateForWebState(self.webState, _loginsHelper);
 
@@ -719,6 +727,19 @@ class FaviconDriverObserver : public favicon::FaviconDriverObserver {
   if (PrintTabHelper* tab_helper =
           PrintTabHelper::FromWebState(self.webState)) {
     tab_helper->set_printer(printHandler);
+  }
+}
+
+@end
+
+@implementation BraveWebView (BraveSearchHelper)
+
+- (void)setBraveSearchHelper:
+    (id<BraveSearchMakeDefaultTabHelperBridge>)braveSearchHelper {
+  _braveSearchHelper = braveSearchHelper;
+  if (BraveSearchMakeDefaultTabHelper* tab_helper =
+          BraveSearchMakeDefaultTabHelper::FromWebState(self.webState)) {
+    tab_helper->SetBridge(braveSearchHelper);
   }
 }
 

--- a/ios/browser/brave_search/BUILD.gn
+++ b/ios/browser/brave_search/BUILD.gn
@@ -9,13 +9,20 @@ source_set("brave_search") {
   sources = [
     "brave_search_ad_results_javascript_feature.h",
     "brave_search_ad_results_javascript_feature.mm",
+    "brave_search_make_default_javascript_feature.h",
+    "brave_search_make_default_javascript_feature.mm",
+    "brave_search_make_default_tab_helper.h",
+    "brave_search_make_default_tab_helper.mm",
+    "brave_search_make_default_tab_helper_bridge.h",
   ]
   deps = [
     ":brave_search_ad_results_js",
-    "//ios/web/public",
+    ":brave_search_make_default_helper_js",
+    "//url",
   ]
   public_deps = [
     "//base",
+    "//ios/web/public",
     "//ios/web/public/js_messaging",
   ]
 }
@@ -29,4 +36,12 @@ optimize_ts("brave_search_ad_results_js") {
     "//ios/web/public/js_messaging:gcrweb",
     "//ios/web/public/js_messaging:util_scripts",
   ]
+}
+
+optimize_ts("brave_search_make_default_helper_js") {
+  visibility = [ ":brave_search" ]
+
+  sources = [ "resources/brave_search_make_default_helper.ts" ]
+
+  deps = [ "//ios/web/public/js_messaging:util_scripts" ]
 }

--- a/ios/browser/brave_search/brave_search_make_default_javascript_feature.h
+++ b/ios/browser/brave_search/brave_search_make_default_javascript_feature.h
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_IOS_BROWSER_BRAVE_SEARCH_BRAVE_SEARCH_MAKE_DEFAULT_JAVASCRIPT_FEATURE_H_
+#define BRAVE_IOS_BROWSER_BRAVE_SEARCH_BRAVE_SEARCH_MAKE_DEFAULT_JAVASCRIPT_FEATURE_H_
+
+#include <optional>
+#include <string>
+
+#include "base/no_destructor.h"
+#include "ios/web/public/js_messaging/java_script_feature.h"
+
+namespace web {
+class WebState;
+}  // namespace web
+
+class BraveSearchMakeDefaultJavaScriptFeature : public web::JavaScriptFeature {
+ public:
+  static BraveSearchMakeDefaultJavaScriptFeature* GetInstance();
+
+  // JavaScriptFeature:
+  bool GetFeatureRepliesToMessages() const override;
+  std::optional<std::string> GetScriptMessageHandlerName() const override;
+  void ScriptMessageReceivedWithReply(
+      web::WebState* web_state,
+      const web::ScriptMessage& message,
+      ScriptMessageReplyCallback callback) override;
+
+ private:
+  friend class base::NoDestructor<BraveSearchMakeDefaultJavaScriptFeature>;
+
+  BraveSearchMakeDefaultJavaScriptFeature();
+  ~BraveSearchMakeDefaultJavaScriptFeature() override;
+
+  BraveSearchMakeDefaultJavaScriptFeature(
+      const BraveSearchMakeDefaultJavaScriptFeature&) = delete;
+  BraveSearchMakeDefaultJavaScriptFeature& operator=(
+      const BraveSearchMakeDefaultJavaScriptFeature&) = delete;
+};
+
+#endif  // BRAVE_IOS_BROWSER_BRAVE_SEARCH_BRAVE_SEARCH_MAKE_DEFAULT_JAVASCRIPT_FEATURE_H_

--- a/ios/browser/brave_search/brave_search_make_default_javascript_feature.mm
+++ b/ios/browser/brave_search/brave_search_make_default_javascript_feature.mm
@@ -1,0 +1,117 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/ios/browser/brave_search/brave_search_make_default_javascript_feature.h"
+
+#include <optional>
+#include <string>
+
+#include "base/containers/fixed_flat_set.h"
+#include "base/numerics/safe_conversions.h"
+#include "base/values.h"
+#include "brave/ios/browser/brave_search/brave_search_make_default_tab_helper.h"
+#include "ios/web/public/js_messaging/script_message.h"
+#include "ios/web/public/web_state.h"
+#include "url/gurl.h"
+#include "url/url_constants.h"
+
+namespace {
+
+constexpr char kScriptName[] = "brave_search_make_default_helper";
+constexpr char kScriptHandlerName[] = "BraveSearchMakeDefaultMessageHandler";
+constexpr char kMethodIdKey[] = "method_id";
+constexpr int kMethodGetCanSetDefault = 1;
+constexpr int kMethodSetDefault = 2;
+constexpr auto kAllowedHosts = base::MakeFixedFlatSet<std::string_view>({
+    "safesearch.brave.com",
+    "safesearch.brave.software",
+    "safesearch.bravesoftware.com",
+    "search-dev-local.brave.com",
+    "search.brave.com",
+    "search.brave.software",
+    "search.bravesoftware.com",
+});
+
+}  // namespace
+
+BraveSearchMakeDefaultJavaScriptFeature::
+    BraveSearchMakeDefaultJavaScriptFeature()
+    : JavaScriptFeature(
+          web::ContentWorld::kPageContentWorld,
+          {FeatureScript::CreateWithFilename(
+              kScriptName,
+              FeatureScript::InjectionTime::kDocumentStart,
+              FeatureScript::TargetFrames::kMainFrame,
+              FeatureScript::ReinjectionBehavior::kInjectOncePerWindow)}) {}
+
+BraveSearchMakeDefaultJavaScriptFeature::
+    ~BraveSearchMakeDefaultJavaScriptFeature() = default;
+
+// static
+BraveSearchMakeDefaultJavaScriptFeature*
+BraveSearchMakeDefaultJavaScriptFeature::GetInstance() {
+  static base::NoDestructor<BraveSearchMakeDefaultJavaScriptFeature> instance;
+  return instance.get();
+}
+
+bool BraveSearchMakeDefaultJavaScriptFeature::GetFeatureRepliesToMessages()
+    const {
+  return true;
+}
+
+std::optional<std::string>
+BraveSearchMakeDefaultJavaScriptFeature::GetScriptMessageHandlerName() const {
+  return kScriptHandlerName;
+}
+
+void BraveSearchMakeDefaultJavaScriptFeature::ScriptMessageReceivedWithReply(
+    web::WebState* web_state,
+    const web::ScriptMessage& message,
+    ScriptMessageReplyCallback callback) {
+  GURL request_url = message.request_url().value_or(GURL());
+
+  if (!message.is_main_frame() || !request_url.is_valid() ||
+      !request_url.SchemeIs(url::kHttpsScheme) ||
+      !kAllowedHosts.contains(request_url.host())) {
+    std::move(callback).Run(nullptr, nil);
+    return;
+  }
+
+  const base::DictValue* body =
+      message.body() ? message.body()->GetIfDict() : nullptr;
+  if (!body) {
+    std::move(callback).Run(nullptr, nil);
+    return;
+  }
+
+  // All numbers from the WKWebView JS bridge arrive as doubles regardless of
+  // their type on the JS side, so read as double and cast to int.
+  std::optional<double> method_id = body->FindDouble(kMethodIdKey);
+  if (!method_id) {
+    std::move(callback).Run(nullptr, nil);
+    return;
+  }
+
+  BraveSearchMakeDefaultTabHelper* tab_helper =
+      BraveSearchMakeDefaultTabHelper::FromWebState(web_state);
+  if (!tab_helper) {
+    std::move(callback).Run(nullptr, nil);
+    return;
+  }
+
+  switch (base::saturated_cast<int>(*method_id)) {
+    case kMethodGetCanSetDefault: {
+      const base::Value reply(tab_helper->GetCanSetDefaultSearchProvider());
+      std::move(callback).Run(&reply, nil);
+      return;
+    }
+    case kMethodSetDefault:
+      tab_helper->SetIsDefaultSearchProvider();
+      std::move(callback).Run(nullptr, nil);
+      return;
+    default:
+      std::move(callback).Run(nullptr, nil);
+  }
+}

--- a/ios/browser/brave_search/brave_search_make_default_tab_helper.h
+++ b/ios/browser/brave_search/brave_search_make_default_tab_helper.h
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_IOS_BROWSER_BRAVE_SEARCH_BRAVE_SEARCH_MAKE_DEFAULT_TAB_HELPER_H_
+#define BRAVE_IOS_BROWSER_BRAVE_SEARCH_BRAVE_SEARCH_MAKE_DEFAULT_TAB_HELPER_H_
+
+#include "ios/web/public/web_state_user_data.h"
+
+@protocol BraveSearchMakeDefaultTabHelperBridge;
+
+namespace web {
+class WebState;
+}  // namespace web
+
+class BraveSearchMakeDefaultTabHelper
+    : public web::WebStateUserData<BraveSearchMakeDefaultTabHelper> {
+ public:
+  ~BraveSearchMakeDefaultTabHelper() override;
+
+  void SetBridge(id<BraveSearchMakeDefaultTabHelperBridge> bridge);
+
+  bool GetCanSetDefaultSearchProvider();
+  void SetIsDefaultSearchProvider();
+
+ private:
+  friend class web::WebStateUserData<BraveSearchMakeDefaultTabHelper>;
+
+  explicit BraveSearchMakeDefaultTabHelper(web::WebState* web_state);
+
+  __weak id<BraveSearchMakeDefaultTabHelperBridge> bridge_;
+};
+
+#endif  // BRAVE_IOS_BROWSER_BRAVE_SEARCH_BRAVE_SEARCH_MAKE_DEFAULT_TAB_HELPER_H_

--- a/ios/browser/brave_search/brave_search_make_default_tab_helper.mm
+++ b/ios/browser/brave_search/brave_search_make_default_tab_helper.mm
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/ios/browser/brave_search/brave_search_make_default_tab_helper.h"
+
+#include "brave/ios/browser/brave_search/brave_search_make_default_tab_helper_bridge.h"
+
+BraveSearchMakeDefaultTabHelper::BraveSearchMakeDefaultTabHelper(
+    web::WebState* web_state) {}
+
+BraveSearchMakeDefaultTabHelper::~BraveSearchMakeDefaultTabHelper() = default;
+
+void BraveSearchMakeDefaultTabHelper::SetBridge(
+    id<BraveSearchMakeDefaultTabHelperBridge> bridge) {
+  bridge_ = bridge;
+}
+
+bool BraveSearchMakeDefaultTabHelper::GetCanSetDefaultSearchProvider() {
+  if (!bridge_) {
+    return false;
+  }
+  return static_cast<bool>([bridge_ getCanSetDefaultSearchProvider]);
+}
+
+void BraveSearchMakeDefaultTabHelper::SetIsDefaultSearchProvider() {
+  if (bridge_) {
+    [bridge_ setIsDefaultSearchProvider];
+  }
+}

--- a/ios/browser/brave_search/brave_search_make_default_tab_helper_bridge.h
+++ b/ios/browser/brave_search/brave_search_make_default_tab_helper_bridge.h
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_IOS_BROWSER_BRAVE_SEARCH_BRAVE_SEARCH_MAKE_DEFAULT_TAB_HELPER_BRIDGE_H_
+#define BRAVE_IOS_BROWSER_BRAVE_SEARCH_BRAVE_SEARCH_MAKE_DEFAULT_TAB_HELPER_BRIDGE_H_
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol BraveSearchMakeDefaultTabHelperBridge
+@required
+
+- (BOOL)getCanSetDefaultSearchProvider;
+- (void)setIsDefaultSearchProvider;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif  // BRAVE_IOS_BROWSER_BRAVE_SEARCH_BRAVE_SEARCH_MAKE_DEFAULT_TAB_HELPER_BRIDGE_H_

--- a/ios/browser/brave_search/resources/brave_search_make_default_helper.ts
+++ b/ios/browser/brave_search/resources/brave_search_make_default_helper.ts
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import {sendWebKitMessageWithReply} from
+    '//ios/web/public/js_messaging/resources/utils.js';
+
+const allowedOrigins = [
+  'https://safesearch.brave.com',
+  'https://safesearch.brave.software',
+  'https://safesearch.bravesoftware.com',
+  'https://search-dev-local.brave.com',
+  'https://search.brave.com',
+  'https://search.brave.software',
+  'https://search.bravesoftware.com',
+];
+
+if (allowedOrigins.includes(window.location.origin)) {
+  Object.defineProperty(window, 'brave', {
+    enumerable: false,
+    configurable: false,
+    writable: false,
+    value: {
+      getCanSetDefaultSearchProvider() {
+        return sendWebKitMessageWithReply(
+            'BraveSearchMakeDefaultMessageHandler', {method_id: 1});
+      },
+
+      setIsDefaultSearchProvider() {
+        return sendWebKitMessageWithReply(
+            'BraveSearchMakeDefaultMessageHandler', {method_id: 2});
+      }
+    }
+  });
+}

--- a/ios/browser/web/brave_web_client.mm
+++ b/ios/browser/web/brave_web_client.mm
@@ -20,6 +20,7 @@
 #include "brave/ios/browser/api/web_view/brave_web_view_internal.h"
 #include "brave/ios/browser/brave_ads/ads_media_reporting_javascript_feature.h"
 #include "brave/ios/browser/brave_search/brave_search_ad_results_javascript_feature.h"
+#include "brave/ios/browser/brave_search/brave_search_make_default_javascript_feature.h"
 #include "brave/ios/browser/ui/web_view/features.h"
 #include "brave/ios/browser/web/brave_web_main_parts.h"
 #include "brave/ios/browser/web/de_amp/de_amp_javascript_feature.h"
@@ -137,6 +138,7 @@ std::vector<web::JavaScriptFeature*> BraveWebClient::GetJavaScriptFeatures(
         brave_ads::AdsMediaReportingJavaScriptFeature::GetInstance());
     features.push_back(AIChatDistillerJavaScriptFeature::GetInstance());
     features.push_back(BraveSearchAdResultsJavaScriptFeature::GetInstance());
+    features.push_back(BraveSearchMakeDefaultJavaScriptFeature::GetInstance());
 #if BUILDFLAG(ENABLE_BRAVE_TALK)
     features.push_back(BraveTalkLauncherJavaScriptFeature::GetInstance());
 #endif


### PR DESCRIPTION
This adds support for `getCanSetDefaultSearchProvider` and `setIsDefaultSearchProvider` JS functions available to Brave Search to enable quick-Brave Search-default setting when the `UseProfileWebViewConfiguration` feature flag is enabled.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/55060

### Test
- Enable `UseProfileWebViewConfiguration` feature flag
- Switch your default search engine to something not Brave Search (e.g. Google/DDG)
- Visit `https://search.brave.com/search?q=test&action=makeDefault`
- Verify "Make Brave Search default" toast appears correctly, then tap "Set Default"
- Verify Brave Search is now your default search engine
- Close the tab and create a new one and submit the same Search URL in step 3
- Verify "Make Brave Search default" toast no longer appears on the results page

Toast for reference:
<img width="403" height="219" alt="image" src="https://github.com/user-attachments/assets/f123684b-9fd8-4a4e-939c-868f85580515" />
