### PR TITLE
Skip opening origin settings on first purchase for branded builds

### DIFF
--- a/components/brave_origin/brave_origin_service.cc
+++ b/components/brave_origin/brave_origin_service.cc
@@ -16,6 +16,7 @@
 #include "brave/brave_domains/service_domains.h"
 #include "brave/components/brave_origin/brave_origin_policy_manager.h"
 #include "brave/components/brave_origin/brave_origin_utils.h"
+#include "brave/components/brave_origin/buildflags/buildflags.h"
 #include "brave/components/brave_origin/features.h"
 #include "brave/components/brave_origin/pref_names.h"
 #include "brave/components/skus/browser/pref_names.h"
@@ -244,10 +245,13 @@ void BraveOriginService::OnCredentialSummary(
     }
   }
 
+#if !BUILDFLAG(IS_BRAVE_ORIGIN_BRANDED)
   // Check if this is a first-time purchase (pref was false, now true).
-  // Must read the pref before SetPurchased() updates it.
+  // Must read the pref before SetPurchased() updates it. Only needed for
+  // the upgrade case below; branded builds drive post-purchase via dialog.
   const bool was_previously_purchased =
       local_state_ && local_state_->GetBoolean(kOriginPurchaseValidated);
+#endif
 
 #if BUILDFLAG(IS_LINUX)
   // On Linux, free tier acceptance overrides the SKU result so that
@@ -267,13 +271,16 @@ void BraveOriginService::OnCredentialSummary(
     local_state_->SetBoolean(kOriginPoliciesWereEnforced, true);
   }
 
-  // On first purchase detection, open the settings page so the user
-  // can configure Origin policies.
+#if !BUILDFLAG(IS_BRAVE_ORIGIN_BRANDED)
+  // On first purchase detection in the upgrade case, open the settings page
+  // so the user can configure Origin policies and restart. Branded builds
+  // handle the post-purchase flow via the startup dialog instead.
   if (purchased && !was_previously_purchased && delegate_ &&
       !did_open_origin_settings_) {
     delegate_->OpenOriginSettings();
     did_open_origin_settings_ = true;
   }
+#endif
 
   std::move(callback).Run(purchased);
 }

--- a/components/brave_origin/brave_origin_service.h
+++ b/components/brave_origin/brave_origin_service.h
@@ -16,6 +16,7 @@
 #include "base/memory/weak_ptr.h"
 #include "base/values.h"
 #include "brave/components/brave_origin/brave_origin_policy_info.h"
+#include "brave/components/brave_origin/buildflags/buildflags.h"
 #include "brave/components/skus/common/skus_sdk.mojom.h"
 #include "build/build_config.h"
 #include "components/keyed_service/core/keyed_service.h"
@@ -118,8 +119,11 @@ class BraveOriginService : public KeyedService {
   base::flat_map<std::string, bool> startup_browser_policies_;
   base::flat_map<std::string, bool> startup_profile_policies_;
 
+#if !BUILDFLAG(IS_BRAVE_ORIGIN_BRANDED)
   // Whether OpenOriginSettings() has already been called this session.
+  // Only used in the upgrade case; branded builds open the dialog at startup.
   bool did_open_origin_settings_ = false;
+#endif
 
   // Browser-layer delegate for actions like opening the settings page.
   std::unique_ptr<Delegate> delegate_;

--- a/components/brave_origin/brave_origin_service_unittest.cc
+++ b/components/brave_origin/brave_origin_service_unittest.cc
@@ -14,6 +14,7 @@
 #include "brave/components/brave_origin/brave_origin_policy_info.h"
 #include "brave/components/brave_origin/brave_origin_policy_manager.h"
 #include "brave/components/brave_origin/brave_origin_utils.h"
+#include "brave/components/brave_origin/buildflags/buildflags.h"
 #include "brave/components/brave_origin/features.h"
 #include "brave/components/brave_origin/pref_names.h"
 #include "brave/components/skus/browser/pref_names.h"
@@ -804,7 +805,13 @@ TEST_F(BraveOriginServiceWithSkusTest, FirstPurchaseDetection_CallsDelegate) {
   base::test::TestFuture<bool> result;
   service_->CheckPurchaseState(result.GetCallback());
   EXPECT_TRUE(result.Get());
+#if BUILDFLAG(IS_BRAVE_ORIGIN_BRANDED)
+  // Branded builds handle the post-purchase flow via the startup dialog,
+  // not by opening the settings page.
+  EXPECT_FALSE(delegate_called);
+#else
   EXPECT_TRUE(delegate_called);
+#endif
 }
 
 TEST_F(BraveOriginServiceWithSkusTest, AlreadyPurchased_DoesNotCallDelegate) {
@@ -855,7 +862,11 @@ TEST_F(BraveOriginServiceWithSkusTest, DelegateIsOneShot_OnlyFiresOnce) {
   base::test::TestFuture<bool> result1;
   service_->CheckPurchaseState(result1.GetCallback());
   EXPECT_TRUE(result1.Get());
+#if BUILDFLAG(IS_BRAVE_ORIGIN_BRANDED)
+  EXPECT_FALSE(delegate_called);
+#else
   EXPECT_TRUE(delegate_called);
+#endif
 
   // Reset the flag and verify the delegate is not called again.
   delegate_called = false;
@@ -898,7 +909,11 @@ TEST_F(BraveOriginServiceWithSkusTest,
                        base::DictValue().Set("trigger", true));
 
   ASSERT_TRUE(base::test::RunUntil([&] { return service_->IsPurchased(); }));
+#if BUILDFLAG(IS_BRAVE_ORIGIN_BRANDED)
+  EXPECT_FALSE(delegate_called);
+#else
   EXPECT_TRUE(delegate_called);
+#endif
 }
 
 // Test class for when BraveOrigin feature is disabled


### PR DESCRIPTION
On `is_brave_origin_branded=true` builds we should not open the settings page when Brave Origin is purchased. 

QA plan:
- Brave Origin branded build on startup after activating does NOT open the settings page
- Brave build being upgraded to Origin does open the settings page after purchase.

Fix https://github.com/brave/brave-browser/issues/55037