### PR TITLE
Fix network-audit default args passing after commander.js bump. (uplift to 1.91.x)

### DIFF
--- a/build/commands/lib/test.js
+++ b/build/commands/lib/test.js
@@ -58,6 +58,18 @@ const buildTests = async (testsToRun, config) => {
   await util.buildTargets(config.buildTargets, config.defaultOptions)
 }
 
+const defaultTestSuiteArgs = (testSuite) => {
+  switch (testSuite) {
+    case 'brave_network_audit_tests':
+      return [
+        '--ui-test-action-timeout=320000',
+        '--test-launcher-timeout=2200000',
+      ]
+    default:
+      return []
+  }
+}
+
 const runTests = async (
   passthroughArgs,
   { suite, testsToRun },
@@ -136,6 +148,9 @@ const runTests = async (
 
     // Upstream tests expect to be run from the output directory
     runOptions.cwd = config.outputDir
+
+    // Prepend default test suite args
+    runArgs = defaultTestSuiteArgs(testSuite).concat(runArgs)
 
     // Set ASAN_OPTIONS (if not already set) only for test launching.
     // Note: other stages (like build) shouldn't set ASAN_OPTIONS to avoid

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "update_patches": "node ./build/commands/scripts/commands.js update_patches",
     "apply_patches": "node ./build/commands/scripts/commands.js apply_patches",
     "start": "node ./build/commands/scripts/commands.js start",
-    "network-audit": "npm run test brave_network_audit_tests -- --ui-test-action-timeout=320000 --test-launcher-timeout=2200000",
+    "network-audit": "node ./build/commands/scripts/commands.js test brave_network_audit_tests",
     "push_l10n": "node ./build/commands/scripts/commands.js push_l10n",
     "pull_l10n": "node ./build/commands/scripts/commands.js pull_l10n",
     "chromium_rebase_l10n": "node ./build/commands/scripts/commands.js chromium_rebase_l10n",


### PR DESCRIPTION
Uplift of #36002
Resolves https://github.com/brave/brave-browser/issues/54990

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.