### PR TITLE
[AI Chat] Add Learn more link to Tab Focus default model setting

### DIFF
--- a/app/brave_settings_strings.grdp
+++ b/app/brave_settings_strings.grdp
@@ -1623,6 +1623,9 @@
   <message name="IDS_SETTINGS_LEO_ASSISTANT_TAB_ORGANIZATION_MODEL_LABEL" desc="The label for the tab organization model selection dropdown">
     Default model for tab focus
   </message>
+  <message name="IDS_SETTINGS_LEO_ASSISTANT_TAB_ORGANIZATION_MODEL_DESC" desc="The description for the tab organization model selection dropdown, with a link to a support page about Tab Focus Mode">
+    The model used to organize your tabs in Tab Focus Mode. <ph name="BEGIN_LINK">&lt;a target="_blank" href="$1"&gt;</ph>Learn more<ph name="END_LINK">&lt;/a&gt;</ph>
+  </message>
   <message name="IDS_SETTINGS_LEO_ASSISTANT_SHOW_SUGGESTED_PROMPTS_LABEL" desc="The text for settings option">
     Show suggested prompts in the conversation
   </message>

--- a/browser/resources/settings/brave_leo_assistant_page/personalization.html
+++ b/browser/resources/settings/brave_leo_assistant_page/personalization.html
@@ -36,6 +36,7 @@ You can obtain one at https://mozilla.org/MPL/2.0/. -->
   <div class="settings-box">
     <div class="flex cr-padded-text">
       <div>$i18n{braveLeoAssistantTabOrganizationModelLabel}</div>
+      <div class="secondary">$i18nRaw{braveLeoAssistantTabOrganizationModelDesc}</div>
     </div>
     <leo-model-selector
       class="cr-padded-text"

--- a/browser/ui/webui/settings/brave_settings_localized_strings_provider.cc
+++ b/browser/ui/webui/settings/brave_settings_localized_strings_provider.cc
@@ -1129,6 +1129,12 @@ void BraveAddCommonStrings(content::WebUIDataSource* html_source,
                              IDS_SETTINGS_LEO_ASSISTANT_TAB_ORGANIZATION_DESC,
                              kTabOrganizationLearnMoreURL));
 
+  html_source->AddString(
+      "braveLeoAssistantTabOrganizationModelDesc",
+      l10n_util::GetStringFUTF16(
+          IDS_SETTINGS_LEO_ASSISTANT_TAB_ORGANIZATION_MODEL_DESC,
+          kTabOrganizationLearnMoreURL));
+
   html_source->AddString("braveLeoAssistantTabOrganizationLearnMoreURL",
                          kTabOrganizationLearnMoreURL);
 


### PR DESCRIPTION
Helps users discover Tab Focus Mode by linking to the support page from the "Default model for tab focus" setting in brave://settings/leo-ai.

Resolves https://github.com/brave/brave-browser/issues/55094

<img width="699" height="331" alt="Screenshot 2026-04-29 at 11 44 40 AM" src="https://github.com/user-attachments/assets/9f2854ed-b42f-4c34-8434-4edae832221c" />
Learn more point to https://support.brave.app/hc/en-us/articles/35200007195917-How-to-use-Tab-Focus-Mode