### PR TITLE
[AI Chat] Pass uploaded files through skill submission path

### DIFF
--- a/components/ai_chat/core/browser/conversation_handler.cc
+++ b/components/ai_chat/core/browser/conversation_handler.cc
@@ -72,6 +72,18 @@ using ai_chat::mojom::ConversationTurn;
 
 constexpr size_t kDefaultSuggestionsCount = 4;
 
+bool HasUploadedImageOrScreenshot(
+    const std::optional<std::vector<mojom::UploadedFilePtr>>& uploaded_files) {
+  if (!uploaded_files || uploaded_files->empty()) {
+    return false;
+  }
+  return std::ranges::any_of(
+      *uploaded_files, [](const mojom::UploadedFilePtr& file) {
+        return file->type == mojom::UploadedFileType::kImage ||
+               file->type == mojom::UploadedFileType::kScreenshot;
+      });
+}
+
 }  // namespace
 
 ConversationHandler::Suggestion::Suggestion(std::string title)
@@ -652,24 +664,28 @@ void ConversationHandler::SubmitHumanConversationEntryWithSkill(
   // Get Skill from prefs and convert to SkillEntry object
   auto skill = prefs::GetSkillFromPrefs(*prefs_, skill_id);
 
+  // Decide the intended target: skill's pinned model when set, else the
+  // current model. With an image attached, the target must support vision —
+  // fall back if it doesn't. Switch once if we're not already there.
+  std::string target = (skill && skill->model && !skill->model->empty())
+                           ? *skill->model
+                           : GetCurrentModel().key;
+  if (HasUploadedImageOrScreenshot(uploaded_files)) {
+    target = GetVisionCapableModelKey(target);
+  }
+  if (target != GetCurrentModel().key) {
+    ChangeModel(target);
+  }
+
   mojom::SkillEntryPtr skill_entry = nullptr;
 
   if (skill) {
-    // Switch model if specified and different from current model
-    if (skill->model && !skill->model->empty() &&
-        *skill->model != GetCurrentModel().key) {
-      ChangeModel(*skill->model);
-    }
-
     // Create Skill entry
     skill_entry = mojom::SkillEntry::New(skill->shortcut, skill->prompt);
 
     // Update last_used time
     prefs::UpdateSkillLastUsedInPrefs(skill_id, *prefs_);
   }
-
-  // Auto-switch to vision model if needed
-  MaybeSwitchToVisionModel(uploaded_files);
 
   mojom::ConversationTurnPtr turn = mojom::ConversationTurn::New(
       std::nullopt, CharacterType::HUMAN, mojom::ActionType::QUERY, input,
@@ -2352,23 +2368,28 @@ bool ConversationHandler::IsTemporaryChat() const {
   return metadata_->temporary;
 }
 
+std::string ConversationHandler::GetVisionCapableModelKey(
+    const std::string& model_key) const {
+  const auto* model = model_service_->GetModel(model_key);
+  if (model && model->vision_support) {
+    return model_key;
+  }
+  return ai_chat_service_->IsPremiumStatus()
+             ? features::kAIModelsPremiumVisionDefaultKey.Get()
+             : features::kAIModelsVisionDefaultKey.Get();
+}
+
 void ConversationHandler::MaybeSwitchToVisionModel(
     const std::optional<std::vector<mojom::UploadedFilePtr>>& uploaded_files) {
-  if (uploaded_files && !uploaded_files->empty() &&
-      std::ranges::any_of(
-          uploaded_files.value(), [](const mojom::UploadedFilePtr& file) {
-            return file->type == mojom::UploadedFileType::kImage ||
-                   file->type == mojom::UploadedFileType::kScreenshot;
-          })) {
-    auto* current_model =
-        model_service_->GetModel(metadata_->model_key.value_or("").empty()
-                                     ? model_service_->GetDefaultModelKey()
-                                     : metadata_->model_key.value());
-    if (!current_model->vision_support) {
-      ChangeModel(ai_chat_service_->IsPremiumStatus()
-                      ? features::kAIModelsPremiumVisionDefaultKey.Get()
-                      : features::kAIModelsVisionDefaultKey.Get());
-    }
+  if (!HasUploadedImageOrScreenshot(uploaded_files)) {
+    return;
+  }
+  std::string current_key = metadata_->model_key.value_or("").empty()
+                                ? model_service_->GetDefaultModelKey()
+                                : metadata_->model_key.value();
+  std::string target = GetVisionCapableModelKey(current_key);
+  if (target != current_key) {
+    ChangeModel(target);
   }
 }
 

--- a/components/ai_chat/core/browser/conversation_handler.cc
+++ b/components/ai_chat/core/browser/conversation_handler.cc
@@ -558,7 +558,7 @@ void ConversationHandler::SubmitHumanConversationEntry(
       << "than a single human conversation turn at a time.";
 
   // Auto-switch to vision model if needed
-  MaybeSwitchToVisionModel(uploaded_files);
+  MaybeSwitchModelForSubmission(uploaded_files);
 
   mojom::ConversationTurnPtr turn = mojom::ConversationTurn::New(
       std::nullopt, CharacterType::HUMAN, mojom::ActionType::QUERY, input,
@@ -664,18 +664,11 @@ void ConversationHandler::SubmitHumanConversationEntryWithSkill(
   // Get Skill from prefs and convert to SkillEntry object
   auto skill = prefs::GetSkillFromPrefs(*prefs_, skill_id);
 
-  // Decide the intended target: skill's pinned model when set, else the
-  // current model. With an image attached, the target must support vision —
-  // fall back if it doesn't. Switch once if we're not already there.
-  std::string target = (skill && skill->model && !skill->model->empty())
-                           ? *skill->model
-                           : GetCurrentModel().key;
-  if (HasUploadedImageOrScreenshot(uploaded_files)) {
-    target = GetVisionCapableModelKey(target);
+  std::optional<std::string> skill_model;
+  if (skill && skill->model && !skill->model->empty()) {
+    skill_model = *skill->model;
   }
-  if (target != GetCurrentModel().key) {
-    ChangeModel(target);
-  }
+  MaybeSwitchModelForSubmission(uploaded_files, skill_model);
 
   mojom::SkillEntryPtr skill_entry = nullptr;
 
@@ -2379,16 +2372,21 @@ std::string ConversationHandler::GetVisionCapableModelKey(
              : features::kAIModelsVisionDefaultKey.Get();
 }
 
-void ConversationHandler::MaybeSwitchToVisionModel(
-    const std::optional<std::vector<mojom::UploadedFilePtr>>& uploaded_files) {
-  if (!HasUploadedImageOrScreenshot(uploaded_files)) {
-    return;
+void ConversationHandler::MaybeSwitchModelForSubmission(
+    const std::optional<std::vector<mojom::UploadedFilePtr>>& uploaded_files,
+    const std::optional<std::string>& intended_model_key) {
+  std::string target;
+  if (intended_model_key && !intended_model_key->empty()) {
+    target = *intended_model_key;
+  } else {
+    target = metadata_->model_key.value_or("").empty()
+                 ? model_service_->GetDefaultModelKey()
+                 : metadata_->model_key.value();
   }
-  std::string current_key = metadata_->model_key.value_or("").empty()
-                                ? model_service_->GetDefaultModelKey()
-                                : metadata_->model_key.value();
-  std::string target = GetVisionCapableModelKey(current_key);
-  if (target != current_key) {
+  if (HasUploadedImageOrScreenshot(uploaded_files)) {
+    target = GetVisionCapableModelKey(target);
+  }
+  if (target != GetCurrentModel().key) {
     ChangeModel(target);
   }
 }
@@ -2423,7 +2421,7 @@ void ConversationHandler::OnAutoScreenshotsTaken(
     }
 
     // Auto-switch to vision model if needed
-    MaybeSwitchToVisionModel(screenshots);
+    MaybeSwitchModelForSubmission(screenshots);
 
     // Update the last conversation turn with the uploaded files
     if (!chat_history_.empty() &&

--- a/components/ai_chat/core/browser/conversation_handler.cc
+++ b/components/ai_chat/core/browser/conversation_handler.cc
@@ -643,7 +643,8 @@ void ConversationHandler::SubmitHumanConversationEntryWithAction(
 
 void ConversationHandler::SubmitHumanConversationEntryWithSkill(
     const std::string& input,
-    const std::string& skill_id) {
+    const std::string& skill_id,
+    std::optional<std::vector<mojom::UploadedFilePtr>> uploaded_files) {
   DCHECK(!is_request_in_progress_)
       << "Should not be able to submit more"
       << "than a single human conversation turn at a time.";
@@ -667,11 +668,14 @@ void ConversationHandler::SubmitHumanConversationEntryWithSkill(
     prefs::UpdateSkillLastUsedInPrefs(skill_id, *prefs_);
   }
 
+  // Auto-switch to vision model if needed
+  MaybeSwitchToVisionModel(uploaded_files);
+
   mojom::ConversationTurnPtr turn = mojom::ConversationTurn::New(
       std::nullopt, CharacterType::HUMAN, mojom::ActionType::QUERY, input,
       std::nullopt /* prompt */, std::nullopt /* selected_text */,
       std::nullopt /* events */, base::Time::Now(), std::nullopt /* edits */,
-      std::nullopt /* uploaded_files */, std::move(skill_entry), false,
+      std::move(uploaded_files), std::move(skill_entry), false,
       std::nullopt /* model_key */, nullptr /* near_verification_status */);
 
   SubmitHumanConversationEntry(std::move(turn));

--- a/components/ai_chat/core/browser/conversation_handler.cc
+++ b/components/ai_chat/core/browser/conversation_handler.cc
@@ -2375,18 +2375,17 @@ std::string ConversationHandler::GetVisionCapableModelKey(
 void ConversationHandler::MaybeSwitchModelForSubmission(
     const std::optional<std::vector<mojom::UploadedFilePtr>>& uploaded_files,
     const std::optional<std::string>& intended_model_key) {
-  std::string target;
-  if (intended_model_key && !intended_model_key->empty()) {
-    target = *intended_model_key;
-  } else {
-    target = metadata_->model_key.value_or("").empty()
-                 ? model_service_->GetDefaultModelKey()
-                 : metadata_->model_key.value();
-  }
+  const std::string current_model_key =
+      metadata_->model_key.value_or("").empty()
+          ? model_service_->GetDefaultModelKey()
+          : metadata_->model_key.value();
+  std::string target = (intended_model_key && !intended_model_key->empty())
+                           ? *intended_model_key
+                           : current_model_key;
   if (HasUploadedImageOrScreenshot(uploaded_files)) {
     target = GetVisionCapableModelKey(target);
   }
-  if (target != GetCurrentModel().key) {
+  if (target != current_model_key) {
     ChangeModel(target);
   }
 }

--- a/components/ai_chat/core/browser/conversation_handler.h
+++ b/components/ai_chat/core/browser/conversation_handler.h
@@ -431,6 +431,10 @@ class ConversationHandler : public mojom::ConversationHandler,
   // the current conversation state.
   std::vector<base::WeakPtr<Tool>> GetTools();
 
+  // Returns `model_key` if its model supports vision; otherwise returns the
+  // freemium/premium vision-default model key.
+  std::string GetVisionCapableModelKey(const std::string& model_key) const;
+
   // Helper method to switch to vision model if needed
   void MaybeSwitchToVisionModel(
       const std::optional<std::vector<mojom::UploadedFilePtr>>& uploaded_files);

--- a/components/ai_chat/core/browser/conversation_handler.h
+++ b/components/ai_chat/core/browser/conversation_handler.h
@@ -204,7 +204,9 @@ class ConversationHandler : public mojom::ConversationHandler,
       mojom::ActionType action_type) override;
   void SubmitHumanConversationEntryWithSkill(
       const std::string& input,
-      const std::string& skill_id) override;
+      const std::string& skill_id,
+      std::optional<std::vector<mojom::UploadedFilePtr>> uploaded_files)
+      override;
   void ModifyConversation(
       const std::string& entry_uuid,
       const std::string& new_text,

--- a/components/ai_chat/core/browser/conversation_handler.h
+++ b/components/ai_chat/core/browser/conversation_handler.h
@@ -435,9 +435,15 @@ class ConversationHandler : public mojom::ConversationHandler,
   // freemium/premium vision-default model key.
   std::string GetVisionCapableModelKey(const std::string& model_key) const;
 
-  // Helper method to switch to vision model if needed
-  void MaybeSwitchToVisionModel(
-      const std::optional<std::vector<mojom::UploadedFilePtr>>& uploaded_files);
+  // Resolves the model to use for an upcoming submission and switches to it
+  // at most once. The intended starting key (e.g. a skill's pinned model) is
+  // used as-is unless an image or screenshot is attached and the starting
+  // model lacks vision support — in which case the freemium/premium vision
+  // default is used. When `intended_model_key` is unset, the conversation's
+  // persisted model is the starting point.
+  void MaybeSwitchModelForSubmission(
+      const std::optional<std::vector<mojom::UploadedFilePtr>>& uploaded_files,
+      const std::optional<std::string>& intended_model_key = std::nullopt);
 
   std::unique_ptr<AssociatedContentManager> associated_content_manager_;
 

--- a/components/ai_chat/core/browser/conversation_handler_unittest.cc
+++ b/components/ai_chat/core/browser/conversation_handler_unittest.cc
@@ -5141,33 +5141,79 @@ TEST_F(ConversationHandlerUnitTest,
   EXPECT_EQ(conversation_handler_->GetCurrentModel().key, current_model);
 }
 
-TEST_F(ConversationHandlerUnitTest,
-       SubmitHumanConversationEntryWithSkill_WithUploadedFiles) {
+struct SkillImageUploadScenario {
+  const char* test_name;
+  const char* starting_model;
+  std::optional<const char*> skill_pinned_model;
+  const char* expected_final_model_key;
+  int expected_model_changes_during_submit;
+};
+
+class ConversationHandlerSkillImageUploadTest
+    : public ConversationHandlerUnitTest,
+      public testing::WithParamInterface<SkillImageUploadScenario> {};
+
+// Covers model resolution and file plumbing when a skill submission carries
+// an image attachment. Each case starts on a specific model and may have a
+// pinned skill model; the test asserts the final model key and the number
+// of ChangeModel calls during submit.
+TEST_P(ConversationHandlerSkillImageUploadTest, ResolvesModelAndPlumbsImage) {
+  const auto& tc = GetParam();
   conversation_handler_->associated_content_manager()->ClearContent();
 
+  NiceMock<MockConversationHandlerClient> client(conversation_handler_.get());
+
+  // Force a deterministic starting model.
+  base::RunLoop setup_loop;
+  EXPECT_CALL(client, OnModelDataChanged)
+      .WillOnce(testing::InvokeWithoutArgs(&setup_loop, &base::RunLoop::Quit));
+  conversation_handler_->ChangeModel(tc.starting_model);
+  setup_loop.Run();
+  testing::Mock::VerifyAndClearExpectations(&client);
+  conversation_handler_->SetEngineForTesting(
+      std::make_unique<NiceMock<MockEngineConsumer>>());
+  MockEngineConsumer* engine = static_cast<MockEngineConsumer*>(
+      conversation_handler_->GetEngineForTesting());
+
   // Add a skill to prefs
+  std::optional<std::string> pinned;
+  if (tc.skill_pinned_model) {
+    pinned = std::string(*tc.skill_pinned_model);
+  }
   prefs::AddSkillToPrefs("describe", "Describe what you see in this image",
-                         std::nullopt /* model */, prefs_);
+                         pinned, prefs_);
   auto skills = prefs::GetSkillsFromPrefs(prefs_);
   ASSERT_EQ(skills.size(), 1u);
   std::string skill_id = skills[0]->id;
 
-  MockEngineConsumer* engine = static_cast<MockEngineConsumer*>(
-      conversation_handler_->GetEngineForTesting());
-  NiceMock<MockConversationHandlerClient> client(conversation_handler_.get());
-
   base::RunLoop run_loop;
 
-  // Mock successful response
+  // Model change notification expectations during submit.
+  EXPECT_CALL(client, OnModelDataChanged)
+      .Times(tc.expected_model_changes_during_submit);
+
+  // Mock successful response. AtMost(1) because a ChangeModel inside submit
+  // replaces the mock engine, in which case the original mock never fires
+  // (see VisionModelSwitchOnScreenshots for the same pattern).
   EXPECT_CALL(*engine, GenerateAssistantResponse)
-      .WillOnce(testing::WithArg<7>(
-          [&run_loop](EngineConsumer::GenerationCompletedCallback callback) {
+      .Times(testing::AtMost(1))
+      .WillRepeatedly(testing::WithArg<7>(
+          [](EngineConsumer::GenerationCompletedCallback callback) {
             std::move(callback).Run(EngineConsumer::GenerationResultData(
                 mojom::ConversationEntryEvent::NewCompletionEvent(
                     mojom::CompletionEvent::New("I see a photo")),
                 std::nullopt));
-            run_loop.QuitWhenIdle();
           }));
+
+  // Quit once submission has reached the engine-call stage: by then the
+  // human turn is in history and any expected model changes have fired.
+  // Engine-independent so it works whether or not ChangeModel replaced the
+  // engine mid-flight.
+  EXPECT_CALL(client, OnAPIRequestInProgress(true))
+      .WillOnce(
+          testing::InvokeWithoutArgs(&run_loop, &base::RunLoop::QuitWhenIdle));
+  EXPECT_CALL(client, OnAPIRequestInProgress(false))
+      .Times(testing::AnyNumber());
 
   // Create uploaded files with an image
   auto uploaded_files = std::make_optional(
@@ -5178,9 +5224,18 @@ TEST_F(ConversationHandlerUnitTest,
 
   run_loop.Run();
 
-  // Verify conversation history contains both skill data and uploaded files
+  // Verify final model resolution and that vision support is guaranteed.
+  EXPECT_EQ(conversation_handler_->GetCurrentModel().key,
+            tc.expected_final_model_key);
+  EXPECT_TRUE(conversation_handler_->GetCurrentModel().vision_support);
+
+  // Verify conversation history contains both skill data and uploaded files.
+  // When ChangeModel replaces the engine mid-submit, the assistant turn
+  // never completes, so only the human turn is present in those cases.
   const auto& history = conversation_handler_->GetConversationHistory();
-  EXPECT_EQ(history.size(), 2u);
+  const size_t expected_size =
+      tc.expected_model_changes_during_submit > 0 ? 1u : 2u;
+  EXPECT_EQ(history.size(), expected_size);
   EXPECT_EQ(history[0]->text, "/describe photo");
   ASSERT_TRUE(history[0]->skill);
   EXPECT_EQ(history[0]->skill->shortcut, "describe");
@@ -5191,11 +5246,44 @@ TEST_F(ConversationHandlerUnitTest,
             mojom::UploadedFileType::kImage);
 }
 
+INSTANTIATE_TEST_SUITE_P(
+    All,
+    ConversationHandlerSkillImageUploadTest,
+    testing::Values(
+        // Unmodeled skill + image, starting non-vision: switch to vision.
+        SkillImageUploadScenario{"UnmodeledFromNonVision", "chat-basic",
+                                 std::nullopt, kClaudeHaikuModelKey, 1},
+        // Unmodeled skill + image, already on vision: no switch.
+        SkillImageUploadScenario{"UnmodeledFromVision", kClaudeHaikuModelKey,
+                                 std::nullopt, kClaudeHaikuModelKey, 0},
+        // Pinned non-vision + image, on vision: vision wins, no switch
+        // (validates the no-double-switch path).
+        SkillImageUploadScenario{"PinnedNonVisionFromVision",
+                                 kClaudeHaikuModelKey, "chat-basic",
+                                 kClaudeHaikuModelKey, 0},
+        // Pinned non-vision + image, on non-vision: switch once to vision
+        // (NOT to the pinned non-vision model).
+        SkillImageUploadScenario{"PinnedNonVisionFromNonVision", "chat-basic",
+                                 "chat-basic", kClaudeHaikuModelKey, 1},
+        // Pinned vision equals current + image: no switch.
+        SkillImageUploadScenario{"PinnedVisionEqualsCurrent",
+                                 kClaudeHaikuModelKey, kClaudeHaikuModelKey,
+                                 kClaudeHaikuModelKey, 0},
+        // Pinned vision different from current + image: switch to pin once.
+        SkillImageUploadScenario{"PinnedVisionDifferentFromCurrent",
+                                 "chat-basic", kClaudeHaikuModelKey,
+                                 kClaudeHaikuModelKey, 1}),
+    [](const testing::TestParamInfo<SkillImageUploadScenario>& info) {
+      return std::string(info.param.test_name);
+    });
+
 TEST_F(ConversationHandlerUnitTest,
-       SubmitHumanConversationEntryWithSkill_AutoSwitchesToVisionModel) {
+       SubmitHumanConversationEntryWithSkill_PdfFileNoVisionSwitch) {
+  // Non-image uploads (e.g. PDFs) should be plumbed through to the turn but
+  // must not trigger a vision auto-switch even when starting on a non-vision
+  // model.
   conversation_handler_->associated_content_manager()->ClearContent();
 
-  // Switch to a non-vision model before submitting.
   base::RunLoop loop_for_change_model;
   NiceMock<MockConversationHandlerClient> client(conversation_handler_.get());
   EXPECT_CALL(client, OnModelDataChanged)
@@ -5204,35 +5292,59 @@ TEST_F(ConversationHandlerUnitTest,
   conversation_handler_->ChangeModel("chat-basic");
   loop_for_change_model.Run();
   testing::Mock::VerifyAndClearExpectations(&client);
-
-  // Re-set the mock engine; ChangeModel replaces it.
   conversation_handler_->SetEngineForTesting(
       std::make_unique<NiceMock<MockEngineConsumer>>());
   MockEngineConsumer* engine = static_cast<MockEngineConsumer*>(
       conversation_handler_->GetEngineForTesting());
   ASSERT_FALSE(conversation_handler_->GetCurrentModel().vision_support);
 
-  // Add an unmodeled skill (no pinned model) so the auto-switch is what moves
-  // the model, not the skill's own model preference.
-  prefs::AddSkillToPrefs("describe", "Describe what you see in this image",
+  // Add a skill to prefs
+  prefs::AddSkillToPrefs("summarize", "Summarize the attached document",
                          std::nullopt /* model */, prefs_);
-  std::string skill_id = prefs::GetSkillsFromPrefs(prefs_)[0]->id;
+  auto skills = prefs::GetSkillsFromPrefs(prefs_);
+  ASSERT_EQ(skills.size(), 1u);
+  std::string skill_id = skills[0]->id;
 
   base::RunLoop run_loop;
-  EXPECT_CALL(client, OnModelDataChanged)
-      .WillOnce(base::test::RunClosure(base::BindLambdaForTesting([&]() {
-        EXPECT_TRUE(conversation_handler_->GetCurrentModel().vision_support);
-        run_loop.Quit();
-      })));
-  EXPECT_CALL(*engine, GenerateAssistantResponse).Times(testing::AnyNumber());
+
+  // Model must not change for a non-image upload.
+  EXPECT_CALL(client, OnModelDataChanged).Times(0);
+
+  // Mock successful response
+  EXPECT_CALL(*engine, GenerateAssistantResponse)
+      .WillOnce(testing::WithArg<7>(
+          [&run_loop](EngineConsumer::GenerationCompletedCallback callback) {
+            std::move(callback).Run(EngineConsumer::GenerationResultData(
+                mojom::ConversationEntryEvent::NewCompletionEvent(
+                    mojom::CompletionEvent::New("Summary")),
+                std::nullopt));
+            run_loop.QuitWhenIdle();
+          }));
+
+  // Create uploaded files with a PDF
+  auto uploaded_files = std::make_optional(
+      CreateSampleUploadedFiles(1, mojom::UploadedFileType::kPdf));
 
   conversation_handler_->SubmitHumanConversationEntryWithSkill(
-      "/describe photo", skill_id,
-      std::make_optional(
-          CreateSampleUploadedFiles(1, mojom::UploadedFileType::kImage)));
+      "/summarize report", skill_id, std::move(uploaded_files));
+
   run_loop.Run();
 
-  EXPECT_TRUE(conversation_handler_->GetCurrentModel().vision_support);
+  // Model stayed put — no vision switch for non-image uploads.
+  EXPECT_EQ(conversation_handler_->GetCurrentModel().key, "chat-basic");
+  EXPECT_FALSE(conversation_handler_->GetCurrentModel().vision_support);
+
+  // Verify conversation history contains both skill data and uploaded files
+  const auto& history = conversation_handler_->GetConversationHistory();
+  EXPECT_EQ(history.size(), 2u);
+  EXPECT_EQ(history[0]->text, "/summarize report");
+  ASSERT_TRUE(history[0]->skill);
+  EXPECT_EQ(history[0]->skill->shortcut, "summarize");
+  EXPECT_EQ(history[0]->skill->prompt, "Summarize the attached document");
+  ASSERT_TRUE(history[0]->uploaded_files);
+  EXPECT_EQ(history[0]->uploaded_files->size(), 1u);
+  EXPECT_EQ(history[0]->uploaded_files->at(0)->type,
+            mojom::UploadedFileType::kPdf);
 }
 
 TEST_F(ConversationHandlerUnitTest, PermissionChallenge) {

--- a/components/ai_chat/core/browser/conversation_handler_unittest.cc
+++ b/components/ai_chat/core/browser/conversation_handler_unittest.cc
@@ -5007,8 +5007,8 @@ TEST_F(ConversationHandlerUnitTest,
             run_loop.QuitWhenIdle();
           }));
 
-  conversation_handler_->SubmitHumanConversationEntryWithSkill("/playlist 2000",
-                                                               skill_id);
+  conversation_handler_->SubmitHumanConversationEntryWithSkill(
+      "/playlist 2000", skill_id, std::nullopt);
 
   run_loop.Run();
 
@@ -5052,7 +5052,7 @@ TEST_F(ConversationHandlerUnitTest,
           }));
 
   conversation_handler_->SubmitHumanConversationEntryWithSkill(
-      "Test input", "invalid-mode-id");
+      "Test input", "invalid-mode-id", std::nullopt);
 
   run_loop.Run();
 
@@ -5092,8 +5092,8 @@ TEST_F(ConversationHandlerUnitTest,
         run_loop.Quit();
       })));
 
-  conversation_handler_->SubmitHumanConversationEntryWithSkill("Test input",
-                                                               skill_id);
+  conversation_handler_->SubmitHumanConversationEntryWithSkill(
+      "Test input", skill_id, std::nullopt);
 
   run_loop.Run();
 }
@@ -5132,13 +5132,107 @@ TEST_F(ConversationHandlerUnitTest,
             run_loop.QuitWhenIdle();
           }));
 
-  conversation_handler_->SubmitHumanConversationEntryWithSkill("Test input",
-                                                               skill_id);
+  conversation_handler_->SubmitHumanConversationEntryWithSkill(
+      "Test input", skill_id, std::nullopt);
 
   run_loop.Run();
 
   // Verify model remained the same
   EXPECT_EQ(conversation_handler_->GetCurrentModel().key, current_model);
+}
+
+TEST_F(ConversationHandlerUnitTest,
+       SubmitHumanConversationEntryWithSkill_WithUploadedFiles) {
+  conversation_handler_->associated_content_manager()->ClearContent();
+
+  // Add a skill to prefs
+  prefs::AddSkillToPrefs("describe", "Describe what you see in this image",
+                         std::nullopt /* model */, prefs_);
+  auto skills = prefs::GetSkillsFromPrefs(prefs_);
+  ASSERT_EQ(skills.size(), 1u);
+  std::string skill_id = skills[0]->id;
+
+  MockEngineConsumer* engine = static_cast<MockEngineConsumer*>(
+      conversation_handler_->GetEngineForTesting());
+  NiceMock<MockConversationHandlerClient> client(conversation_handler_.get());
+
+  base::RunLoop run_loop;
+
+  // Mock successful response
+  EXPECT_CALL(*engine, GenerateAssistantResponse)
+      .WillOnce(testing::WithArg<7>(
+          [&run_loop](EngineConsumer::GenerationCompletedCallback callback) {
+            std::move(callback).Run(EngineConsumer::GenerationResultData(
+                mojom::ConversationEntryEvent::NewCompletionEvent(
+                    mojom::CompletionEvent::New("I see a photo")),
+                std::nullopt));
+            run_loop.QuitWhenIdle();
+          }));
+
+  // Create uploaded files with an image
+  auto uploaded_files = std::make_optional(
+      CreateSampleUploadedFiles(1, mojom::UploadedFileType::kImage));
+
+  conversation_handler_->SubmitHumanConversationEntryWithSkill(
+      "/describe photo", skill_id, std::move(uploaded_files));
+
+  run_loop.Run();
+
+  // Verify conversation history contains both skill data and uploaded files
+  const auto& history = conversation_handler_->GetConversationHistory();
+  EXPECT_EQ(history.size(), 2u);
+  EXPECT_EQ(history[0]->text, "/describe photo");
+  ASSERT_TRUE(history[0]->skill);
+  EXPECT_EQ(history[0]->skill->shortcut, "describe");
+  EXPECT_EQ(history[0]->skill->prompt, "Describe what you see in this image");
+  ASSERT_TRUE(history[0]->uploaded_files);
+  EXPECT_EQ(history[0]->uploaded_files->size(), 1u);
+  EXPECT_EQ(history[0]->uploaded_files->at(0)->type,
+            mojom::UploadedFileType::kImage);
+}
+
+TEST_F(ConversationHandlerUnitTest,
+       SubmitHumanConversationEntryWithSkill_AutoSwitchesToVisionModel) {
+  conversation_handler_->associated_content_manager()->ClearContent();
+
+  // Switch to a non-vision model before submitting.
+  base::RunLoop loop_for_change_model;
+  NiceMock<MockConversationHandlerClient> client(conversation_handler_.get());
+  EXPECT_CALL(client, OnModelDataChanged)
+      .WillOnce(testing::InvokeWithoutArgs(&loop_for_change_model,
+                                           &base::RunLoop::Quit));
+  conversation_handler_->ChangeModel("chat-basic");
+  loop_for_change_model.Run();
+  testing::Mock::VerifyAndClearExpectations(&client);
+
+  // Re-set the mock engine; ChangeModel replaces it.
+  conversation_handler_->SetEngineForTesting(
+      std::make_unique<NiceMock<MockEngineConsumer>>());
+  MockEngineConsumer* engine = static_cast<MockEngineConsumer*>(
+      conversation_handler_->GetEngineForTesting());
+  ASSERT_FALSE(conversation_handler_->GetCurrentModel().vision_support);
+
+  // Add an unmodeled skill (no pinned model) so the auto-switch is what moves
+  // the model, not the skill's own model preference.
+  prefs::AddSkillToPrefs("describe", "Describe what you see in this image",
+                         std::nullopt /* model */, prefs_);
+  std::string skill_id = prefs::GetSkillsFromPrefs(prefs_)[0]->id;
+
+  base::RunLoop run_loop;
+  EXPECT_CALL(client, OnModelDataChanged)
+      .WillOnce(base::test::RunClosure(base::BindLambdaForTesting([&]() {
+        EXPECT_TRUE(conversation_handler_->GetCurrentModel().vision_support);
+        run_loop.Quit();
+      })));
+  EXPECT_CALL(*engine, GenerateAssistantResponse).Times(testing::AnyNumber());
+
+  conversation_handler_->SubmitHumanConversationEntryWithSkill(
+      "/describe photo", skill_id,
+      std::make_optional(
+          CreateSampleUploadedFiles(1, mojom::UploadedFileType::kImage)));
+  run_loop.Run();
+
+  EXPECT_TRUE(conversation_handler_->GetCurrentModel().vision_support);
 }
 
 TEST_F(ConversationHandlerUnitTest, PermissionChallenge) {

--- a/components/ai_chat/core/browser/conversation_handler_unittest.cc
+++ b/components/ai_chat/core/browser/conversation_handler_unittest.cc
@@ -5146,7 +5146,7 @@ struct SkillImageUploadScenario {
   const char* starting_model;
   std::optional<const char*> skill_pinned_model;
   const char* expected_final_model_key;
-  int expected_model_changes_during_submit;
+  bool expects_model_change_during_submit;
 };
 
 class ConversationHandlerSkillImageUploadTest
@@ -5155,8 +5155,8 @@ class ConversationHandlerSkillImageUploadTest
 
 // Covers model resolution and file plumbing when a skill submission carries
 // an image attachment. Each case starts on a specific model and may have a
-// pinned skill model; the test asserts the final model key and the number
-// of ChangeModel calls during submit.
+// pinned skill model; the test asserts the final model key and whether a
+// ChangeModel call fired during submit.
 TEST_P(ConversationHandlerSkillImageUploadTest, ResolvesModelAndPlumbsImage) {
   const auto& tc = GetParam();
   conversation_handler_->associated_content_manager()->ClearContent();
@@ -5190,7 +5190,7 @@ TEST_P(ConversationHandlerSkillImageUploadTest, ResolvesModelAndPlumbsImage) {
 
   // Model change notification expectations during submit.
   EXPECT_CALL(client, OnModelDataChanged)
-      .Times(tc.expected_model_changes_during_submit);
+      .Times(tc.expects_model_change_during_submit ? 1 : 0);
 
   // Mock successful response. AtMost(1) because a ChangeModel inside submit
   // replaces the mock engine, in which case the original mock never fires
@@ -5233,8 +5233,7 @@ TEST_P(ConversationHandlerSkillImageUploadTest, ResolvesModelAndPlumbsImage) {
   // When ChangeModel replaces the engine mid-submit, the assistant turn
   // never completes, so only the human turn is present in those cases.
   const auto& history = conversation_handler_->GetConversationHistory();
-  const size_t expected_size =
-      tc.expected_model_changes_during_submit > 0 ? 1u : 2u;
+  const size_t expected_size = tc.expects_model_change_during_submit ? 1u : 2u;
   EXPECT_EQ(history.size(), expected_size);
   EXPECT_EQ(history[0]->text, "/describe photo");
   ASSERT_TRUE(history[0]->skill);
@@ -5252,27 +5251,27 @@ INSTANTIATE_TEST_SUITE_P(
     testing::Values(
         // Unmodeled skill + image, starting non-vision: switch to vision.
         SkillImageUploadScenario{"UnmodeledFromNonVision", "chat-basic",
-                                 std::nullopt, kClaudeHaikuModelKey, 1},
+                                 std::nullopt, kClaudeHaikuModelKey, true},
         // Unmodeled skill + image, already on vision: no switch.
         SkillImageUploadScenario{"UnmodeledFromVision", kClaudeHaikuModelKey,
-                                 std::nullopt, kClaudeHaikuModelKey, 0},
+                                 std::nullopt, kClaudeHaikuModelKey, false},
         // Pinned non-vision + image, on vision: vision wins, no switch
         // (validates the no-double-switch path).
         SkillImageUploadScenario{"PinnedNonVisionFromVision",
                                  kClaudeHaikuModelKey, "chat-basic",
-                                 kClaudeHaikuModelKey, 0},
+                                 kClaudeHaikuModelKey, false},
         // Pinned non-vision + image, on non-vision: switch once to vision
         // (NOT to the pinned non-vision model).
         SkillImageUploadScenario{"PinnedNonVisionFromNonVision", "chat-basic",
-                                 "chat-basic", kClaudeHaikuModelKey, 1},
+                                 "chat-basic", kClaudeHaikuModelKey, true},
         // Pinned vision equals current + image: no switch.
         SkillImageUploadScenario{"PinnedVisionEqualsCurrent",
                                  kClaudeHaikuModelKey, kClaudeHaikuModelKey,
-                                 kClaudeHaikuModelKey, 0},
+                                 kClaudeHaikuModelKey, false},
         // Pinned vision different from current + image: switch to pin once.
         SkillImageUploadScenario{"PinnedVisionDifferentFromCurrent",
                                  "chat-basic", kClaudeHaikuModelKey,
-                                 kClaudeHaikuModelKey, 1}),
+                                 kClaudeHaikuModelKey, true}),
     [](const testing::TestParamInfo<SkillImageUploadScenario>& info) {
       return std::string(info.param.test_name);
     });

--- a/components/ai_chat/core/browser/conversation_handler_unittest.cc
+++ b/components/ai_chat/core/browser/conversation_handler_unittest.cc
@@ -5158,7 +5158,7 @@ class ConversationHandlerSkillImageUploadTest
 // pinned skill model; the test asserts the final model key and whether a
 // ChangeModel call fired during submit.
 TEST_P(ConversationHandlerSkillImageUploadTest, ResolvesModelAndPlumbsImage) {
-  const auto& tc = GetParam();
+  const auto& test_params = GetParam();
   conversation_handler_->associated_content_manager()->ClearContent();
 
   NiceMock<MockConversationHandlerClient> client(conversation_handler_.get());
@@ -5167,7 +5167,7 @@ TEST_P(ConversationHandlerSkillImageUploadTest, ResolvesModelAndPlumbsImage) {
   base::RunLoop setup_loop;
   EXPECT_CALL(client, OnModelDataChanged)
       .WillOnce(testing::InvokeWithoutArgs(&setup_loop, &base::RunLoop::Quit));
-  conversation_handler_->ChangeModel(tc.starting_model);
+  conversation_handler_->ChangeModel(test_params.starting_model);
   setup_loop.Run();
   testing::Mock::VerifyAndClearExpectations(&client);
   conversation_handler_->SetEngineForTesting(
@@ -5177,8 +5177,8 @@ TEST_P(ConversationHandlerSkillImageUploadTest, ResolvesModelAndPlumbsImage) {
 
   // Add a skill to prefs
   std::optional<std::string> pinned;
-  if (tc.skill_pinned_model) {
-    pinned = std::string(*tc.skill_pinned_model);
+  if (test_params.skill_pinned_model) {
+    pinned = std::string(*test_params.skill_pinned_model);
   }
   prefs::AddSkillToPrefs("describe", "Describe what you see in this image",
                          pinned, prefs_);
@@ -5190,7 +5190,7 @@ TEST_P(ConversationHandlerSkillImageUploadTest, ResolvesModelAndPlumbsImage) {
 
   // Model change notification expectations during submit.
   EXPECT_CALL(client, OnModelDataChanged)
-      .Times(tc.expects_model_change_during_submit ? 1 : 0);
+      .Times(test_params.expects_model_change_during_submit ? 1 : 0);
 
   // Mock successful response. AtMost(1) because a ChangeModel inside submit
   // replaces the mock engine, in which case the original mock never fires
@@ -5226,14 +5226,15 @@ TEST_P(ConversationHandlerSkillImageUploadTest, ResolvesModelAndPlumbsImage) {
 
   // Verify final model resolution and that vision support is guaranteed.
   EXPECT_EQ(conversation_handler_->GetCurrentModel().key,
-            tc.expected_final_model_key);
+            test_params.expected_final_model_key);
   EXPECT_TRUE(conversation_handler_->GetCurrentModel().vision_support);
 
   // Verify conversation history contains both skill data and uploaded files.
   // When ChangeModel replaces the engine mid-submit, the assistant turn
   // never completes, so only the human turn is present in those cases.
   const auto& history = conversation_handler_->GetConversationHistory();
-  const size_t expected_size = tc.expects_model_change_during_submit ? 1u : 2u;
+  const size_t expected_size =
+      test_params.expects_model_change_during_submit ? 1u : 2u;
   EXPECT_EQ(history.size(), expected_size);
   EXPECT_EQ(history[0]->text, "/describe photo");
   ASSERT_TRUE(history[0]->skill);
@@ -6532,7 +6533,7 @@ TEST_F(ConversationHandlerUnitTest, ConversationCapabilities) {
     ConversationCapabilitySet expected_capabilities;
   };
 
-  const std::vector<TestCase> test_cases = {
+  const std::vector<TestCase> test_paramss = {
       {
           "Chat",
           /*is_content_agent_allowed=*/false,
@@ -6563,18 +6564,18 @@ TEST_F(ConversationHandlerUnitTest, ConversationCapabilities) {
       },
   };
 
-  for (const auto& test_case : test_cases) {
-    SCOPED_TRACE(test_case.name);
+  for (const auto& test_params : test_paramss) {
+    SCOPED_TRACE(test_params.name);
 
     base::test::ScopedFeatureList feature_list;
-    if (test_case.deep_research_enabled) {
+    if (test_params.deep_research_enabled) {
       feature_list.InitAndEnableFeature(features::kAIChatDeepResearch);
     } else {
       feature_list.InitAndDisableFeature(features::kAIChatDeepResearch);
     }
 
     ai_chat_service_->SetIsContentAgentAllowed(
-        test_case.is_content_agent_allowed);
+        test_params.is_content_agent_allowed);
 
     mock_tool_provider_ = nullptr;
     std::vector<std::unique_ptr<ToolProvider>> tool_providers;
@@ -6599,10 +6600,10 @@ TEST_F(ConversationHandlerUnitTest, ConversationCapabilities) {
         conversation_handler_->GetEngineForTesting());
 
     base::RunLoop run_loop;
-    EXPECT_CALL(
-        *engine,
-        GenerateAssistantResponse(
-            _, _, _, _, _, testing::Eq(test_case.expected_capabilities), _, _))
+    EXPECT_CALL(*engine,
+                GenerateAssistantResponse(
+                    _, _, _, _, _,
+                    testing::Eq(test_params.expected_capabilities), _, _))
         .WillOnce(testing::WithArg<7>(
             [&run_loop](EngineConsumer::GenerationCompletedCallback callback) {
               std::move(callback).Run(

--- a/components/ai_chat/core/common/mojom/ai_chat.mojom
+++ b/components/ai_chat/core/common/mojom/ai_chat.mojom
@@ -310,7 +310,8 @@ interface ConversationHandler {
   SubmitHumanConversationEntry(
       string input, array<UploadedFile>? uploaded_files);
   SubmitHumanConversationEntryWithAction(string input, ActionType action_type);
-  SubmitHumanConversationEntryWithSkill(string input, string skill_id);
+  SubmitHumanConversationEntryWithSkill(
+      string input, string skill_id, array<UploadedFile>? uploaded_files);
 
   // Get associated page information. If there is none then |associated_content|
   // will be empty.

--- a/components/ai_chat/resources/page/state/conversation_context.tsx
+++ b/components/ai_chat/resources/page/state/conversation_context.tsx
@@ -276,6 +276,7 @@ export function useProvideConversationContext(props: ConversationContextProps) {
       api.conversationHandler.submitHumanConversationEntryWithSkill(
         stringifyContent(inputText),
         selectedSkill.id,
+        pendingMessageFiles,
       )
     } else if (selectedActionType) {
       api.conversationHandler.submitHumanConversationEntryWithAction(


### PR DESCRIPTION
The skill submission path in the conversation UI never forwarded the pending uploaded files to the browser, so attaching an image and invoking a skill caused Leo to answer as if no image were present. Add an uploaded_files parameter to SubmitHumanConversationEntryWithSkill across the mojom interface and the handler, pass the staged files from the frontend, and run the existing vision-model auto-switch on this path so an unmodeled (or non-vision) skill upgrades to a vision model when an image is attached.

Resolves https://github.com/brave/brave-browser/issues/51185

Test plan:
1. Create a new skill /where with prompt "where is this photo taken"
2. Drag an image of a place into a conversation with Leo and type /where to invoke the skill
3. Submit /where skill with the image of a place
4. Leo should be able to tell the place of where this photo is taken.

<img width="754" height="905" alt="Screenshot 2026-04-29 at 2 22 42 PM" src="https://github.com/user-attachments/assets/744b10d2-9759-436a-898e-e2a8d3fc743f" />
