### PR TITLE
[Wallet] Remove buildflag guard to fix notreached crash for iOS (uplift to 1.90.x)

### DIFF
--- a/components/brave_wallet/browser/brave_wallet_service.cc
+++ b/components/brave_wallet/browser/brave_wallet_service.cc
@@ -2080,12 +2080,6 @@ void BraveWalletService::SetTransactionSimulationOptInStatus(
 
 void BraveWalletService::WriteToClipboard(const std::string& text,
                                           bool is_sensitive) {
-  // We manually disable the iOS builds here because of an upstream bug in how
-  // Chromium is adding sources to the clipboard component. It only
-  // conditionally adds the iOS sources when use_blink=true, which unfortunately
-  // leads to a whole slew of unresolved symbols during linking.
-  // https://source.chromium.org/chromium/chromium/src/+/066b9c51bfb0a1eddcfefa7aa809348ea181f8ac:ui/base/clipboard/BUILD.gn;l=21-27
-#if !BUILDFLAG(IS_IOS)
   ui::ScopedClipboardWriter scw(ui::ClipboardBuffer::kCopyPaste);
   std::u16string out;
   base::UTF8ToUTF16(text.data(), text.size(), &out);
@@ -2093,9 +2087,6 @@ void BraveWalletService::WriteToClipboard(const std::string& text,
   if (is_sensitive) {
     scw.MarkAsConfidential();
   }
-#else
-  NOTREACHED();
-#endif
 }
 
 base::CallbackListSubscription


### PR DESCRIPTION
Uplift of #36003
Resolves https://github.com/brave/brave-browser/issues/55085

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.