### PR TITLE
Restore NTB padding when scroll buttons are hidden

### DIFF
--- a/browser/ui/views/frame/brave_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/brave_tab_strip_region_view.cc
@@ -315,13 +315,19 @@ void BraveHorizontalTabStripRegionView::Layout(PassKey) {
     //  .ChildrenAreFlushWithTopOfTabStripRegionView` green — while still
     // letting compact mode nudge the button up to stay centred against the
     // shorter tab pills.
-    if (new_tab_button_ && tab_scroll_next_button_ &&
-        tab_scroll_next_button_->GetVisible()) {
-      const gfx::Size button_size = new_tab_button_->GetPreferredSize();
-      const int x = tab_scroll_next_button_->bounds().right() +
-                    GetLayoutConstant(LayoutConstant::kTabStripPadding) +
-                    GetLayoutConstant(LayoutConstant::kToolbarDividerSpacing);
-      new_tab_button_->SetBoundsRect(gfx::Rect(gfx::Point(x, 0), button_size));
+    if (new_tab_button_) {
+      if (tab_scroll_next_button_ && tab_scroll_next_button_->GetVisible()) {
+        const gfx::Size button_size = new_tab_button_->GetPreferredSize();
+        const int x = tab_scroll_next_button_->bounds().right() +
+                      GetLayoutConstant(LayoutConstant::kTabStripPadding) +
+                      GetLayoutConstant(LayoutConstant::kToolbarDividerSpacing);
+        new_tab_button_->SetBoundsRect(
+            gfx::Rect(gfx::Point(x, 0), button_size));
+      } else {
+        new_tab_button_->SetX(
+            tab_strip_->bounds().right() +
+            GetLayoutConstant(LayoutConstant::kTabStripPadding));
+      }
     }
     if (new_tab_button_ &&
         tabs::ShouldUseCompactHorizontalTabsForNonTouchUI()) {

--- a/browser/ui/views/tabs/brave_tab_container_browsertest.cc
+++ b/browser/ui/views/tabs/brave_tab_container_browsertest.cc
@@ -21,6 +21,7 @@
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/browser_commands.h"
 #include "chrome/browser/ui/browser_tabstrip.h"
+#include "chrome/browser/ui/layout_constants.h"
 #include "chrome/browser/ui/tabs/features.h"
 #include "chrome/browser/ui/tabs/tab_strip_model.h"
 #include "chrome/browser/ui/views/frame/browser_root_view.h"
@@ -356,6 +357,73 @@ IN_PROC_BROWSER_TEST_F(HorizontalScrollableTabStripBrowserTest,
   ASSERT_TRUE(region);
   ASSERT_TRUE(region->tab_scroll_previous_for_testing());
   EXPECT_FALSE(region->tab_scroll_previous_for_testing()->GetVisible());
+}
+
+// Regression tests for brave/brave-browser#54971 and #54988: when horizontal
+// scroll controls exist but are hidden (no overflow), the new tab button must
+// still sit to the right of the tab strip with kTabStripPadding; when they are
+// visible, it must follow the trailing scroll button with padding + divider
+// spacing.
+IN_PROC_BROWSER_TEST_F(HorizontalScrollableTabStripBrowserTest,
+                       NewTabButtonTrailingGapWhenScrollButtonsHidden) {
+  auto* tab_strip = views::AsViewClass<BraveTabStrip>(
+      browser_view()->horizontal_tab_strip_for_testing());
+  BraveTabContainer* container = views::AsViewClass<BraveTabContainer>(
+      tab_strip->GetTabContainerForTesting());
+  ASSERT_TRUE(container);
+
+  browser()->profile()->GetPrefs()->SetBoolean(
+      brave_tabs::kShowHorizontalTabScrollButtons, true);
+  StopAnimatingAndLayout();
+
+  ASSERT_EQ(0, container->GetMaxScrollOffsetForTesting())
+      << "Need few tabs so trailing scroll stays hidden";
+
+  BraveHorizontalTabStripRegionView* region = tab_strip_region();
+  ASSERT_TRUE(region);
+  ASSERT_TRUE(region->tab_scroll_next_for_testing());
+  ASSERT_FALSE(region->tab_scroll_next_for_testing()->GetVisible());
+
+  views::View* ntb = region->new_tab_button_for_testing();
+  ASSERT_TRUE(ntb);
+
+  const int pad = GetLayoutConstant(LayoutConstant::kTabStripPadding);
+  EXPECT_EQ(ntb->x(), tab_strip->bounds().right() + pad)
+      << "ntb->x()=" << ntb->x()
+      << " tab_strip->bounds().right()=" << tab_strip->bounds().right();
+}
+
+IN_PROC_BROWSER_TEST_F(HorizontalScrollableTabStripBrowserTest,
+                       NewTabButtonTrailingGapWhenScrollButtonsVisible) {
+  browser()->profile()->GetPrefs()->SetBoolean(
+      brave_tabs::kShowHorizontalTabScrollButtons, true);
+
+  auto* tab_strip = views::AsViewClass<BraveTabStrip>(
+      browser_view()->horizontal_tab_strip_for_testing());
+  BraveTabContainer* container = views::AsViewClass<BraveTabContainer>(
+      tab_strip->GetTabContainerForTesting());
+  ASSERT_TRUE(container);
+
+  while (container->GetMaxScrollOffsetForTesting() == 0) {
+    AppendTab();
+    StopAnimatingAndLayout();
+  }
+
+  BraveHorizontalTabStripRegionView* region = tab_strip_region();
+  ASSERT_TRUE(region);
+  TabStripControlButton* next = region->tab_scroll_next_for_testing();
+  ASSERT_TRUE(next);
+  ASSERT_TRUE(next->GetVisible());
+
+  views::View* ntb = region->new_tab_button_for_testing();
+  ASSERT_TRUE(ntb);
+
+  const int pad = GetLayoutConstant(LayoutConstant::kTabStripPadding);
+  const int divider = GetLayoutConstant(LayoutConstant::kToolbarDividerSpacing);
+  EXPECT_EQ(ntb->x(), next->bounds().right() + pad + divider)
+      << "ntb->x()=" << ntb->x()
+      << " next->bounds().right()=" << next->bounds().right() << " pad=" << pad
+      << " divider=" << divider;
 }
 
 IN_PROC_BROWSER_TEST_F(HorizontalScrollableTabStripBrowserTest,


### PR DESCRIPTION
This was broken by the scroll button padding changes. We need gap between the last tab and the NTB when the scroll buttons are hidden.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/54971
Resolves https://github.com/brave/brave-browser/issues/54988

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
