### PR TITLE
Fix Omaha 4 updates for non-std .app dir on macOS

### DIFF
--- a/patches/chrome-updater-mac-.install.sh.patch
+++ b/patches/chrome-updater-mac-.install.sh.patch
@@ -1,0 +1,13 @@
+diff --git a/chrome/updater/mac/.install.sh b/chrome/updater/mac/.install.sh
+index 3b1874d09fca0cf88e361927dfea7c4273790030..598b668ee141a0fe97fa65807755ee866a1fe6b6 100755
+--- a/chrome/updater/mac/.install.sh
++++ b/chrome/updater/mac/.install.sh
+@@ -337,7 +337,7 @@ main() {
+   # The update to install.
+ 
+   # update_app is the path to the new version of the .app.
+-  local update_app="${update_dmg_mount_point}/${APP_DIR}"
++  local update_app="${update_dmg_mount_point}/${PRODUCT_NAME}.app"
+   note "update_app = ${update_app}"
+ 
+   # Make sure that it's an absolute path.

--- a/rewrite/chrome/updater/mac/.install.sh.toml
+++ b/rewrite/chrome/updater/mac/.install.sh.toml
@@ -1,0 +1,20 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+# Upstream's variable `update_app` contains the path to the new browser
+# version's .app directory. As of this writing, it is computed as:
+#     update_app="${update_dmg_mount_point}/${APP_DIR}"
+# where
+#     APP_DIR="$(basename "${installed_app_path}")"
+# This fails when the browser's installation directory has a non-standard name.
+# For example: If the browser is installed in /Applications/Brave.app instead of
+# /Applications/Brave Browser.app, then `update_app` tries to read Brave.app
+# from the DMG, when it should read Brave Browser.app. The substitution below
+# fixes this.
+
+[[substitution]]
+description = 'Use PRODUCT_NAME instead of APP_DIR for update app path'
+pattern = '${update_dmg_mount_point}/${APP_DIR}'
+replace = '${update_dmg_mount_point}/${PRODUCT_NAME}.app'


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/55023.