### PR TITLE
[iOS] Add missing captive portal tab helper creation (uplift to 1.90.x)

### DIFF
--- a/chromium_src/ios/chrome/browser/ssl/model/captive_portal_tab_helper.h
+++ b/chromium_src/ios/chrome/browser/ssl/model/captive_portal_tab_helper.h
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_CHROMIUM_SRC_IOS_CHROME_BROWSER_SSL_MODEL_CAPTIVE_PORTAL_TAB_HELPER_H_
+#define BRAVE_CHROMIUM_SRC_IOS_CHROME_BROWSER_SSL_MODEL_CAPTIVE_PORTAL_TAB_HELPER_H_
+
+#include <ios/chrome/browser/ssl/model/captive_portal_tab_helper.h>  // IWYU pragma: export
+
+#include "ios/web/public/web_state_observer.h"
+
+// A custom captive portal tab helper that instead just loads the landing URL
+// directly into the current WebState instead of attempting to open it in a new
+// tab since we dont use WebStateList & its insertion agent on iOS
+class BraveCaptivePortalTabHelper
+    : public web::WebStateUserData<BraveCaptivePortalTabHelper>,
+      web::WebStateObserver {
+ public:
+  BraveCaptivePortalTabHelper(const BraveCaptivePortalTabHelper&) = delete;
+  BraveCaptivePortalTabHelper& operator=(const BraveCaptivePortalTabHelper&) =
+      delete;
+
+  ~BraveCaptivePortalTabHelper() override;
+
+  // Displays the Captive Portal Login page at `landing_url`.
+  void DisplayCaptivePortalLoginPage(GURL landing_url);
+
+  // WebObserver
+  void WebStateDestroyed(web::WebState* web_state) override;
+
+ private:
+  friend class web::WebStateUserData<BraveCaptivePortalTabHelper>;
+  explicit BraveCaptivePortalTabHelper(web::WebState* web_state);
+  raw_ptr<web::WebState> web_state_ = nullptr;
+};
+
+#endif  // BRAVE_CHROMIUM_SRC_IOS_CHROME_BROWSER_SSL_MODEL_CAPTIVE_PORTAL_TAB_HELPER_H_

--- a/chromium_src/ios/chrome/browser/ssl/model/captive_portal_tab_helper.mm
+++ b/chromium_src/ios/chrome/browser/ssl/model/captive_portal_tab_helper.mm
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "ios/chrome/browser/web/model/web_navigation_util.h"
+#include "ios/web/public/navigation/navigation_manager.h"
+#include "ios/web/public/web_state.h"
+
+#include <ios/chrome/browser/ssl/model/captive_portal_tab_helper.mm>
+
+BraveCaptivePortalTabHelper::BraveCaptivePortalTabHelper(
+    web::WebState* web_state)
+    : web_state_(web_state) {
+  web_state_->AddObserver(this);
+}
+
+BraveCaptivePortalTabHelper::~BraveCaptivePortalTabHelper() {
+  if (web_state_) {
+    web_state_->RemoveObserver(this);
+  }
+}
+
+// Displays the Captive Portal Login page at `landing_url`.
+void BraveCaptivePortalTabHelper::DisplayCaptivePortalLoginPage(
+    GURL landing_url) {
+  if (!web_state_) {
+    return;
+  }
+  web_state_->GetNavigationManager()->LoadURLWithParams(
+      web_navigation_util::CreateWebLoadParams(
+          landing_url, ui::PAGE_TRANSITION_TYPED, nullptr));
+}
+
+// WebObserver
+void BraveCaptivePortalTabHelper::WebStateDestroyed(web::WebState* web_state) {
+  DCHECK_EQ(web_state_, web_state);
+  web_state_->RemoveObserver(this);
+  web_state_ = nullptr;
+}

--- a/chromium_src/ios/chrome/browser/ssl/model/ios_captive_portal_blocking_page.mm
+++ b/chromium_src/ios/chrome/browser/ssl/model/ios_captive_portal_blocking_page.mm
@@ -3,58 +3,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-#include "base/check.h"
-#include "base/memory/raw_ptr.h"
 #include "ios/chrome/browser/ssl/model/captive_portal_tab_helper.h"
-#include "ios/chrome/browser/web/model/web_navigation_util.h"
-#include "ios/web/public/navigation/navigation_manager.h"
-#include "ios/web/public/web_state.h"
-#include "ios/web/public/web_state_observer.h"
-#include "ios/web/public/web_state_user_data.h"
 
-// A custom captive portal tab helper that instead just loads the landing URL
-// directly into the current WebState instead of attempting to open it in a new
-// tab since we dont use WebStateList & its insertion agent on iOS
-class BraveCaptivePortalTabHelper
-    : public web::WebStateUserData<BraveCaptivePortalTabHelper>,
-      web::WebStateObserver {
- public:
-  BraveCaptivePortalTabHelper(const BraveCaptivePortalTabHelper&) = delete;
-  BraveCaptivePortalTabHelper& operator=(const BraveCaptivePortalTabHelper&) =
-      delete;
-
-  ~BraveCaptivePortalTabHelper() override {
-    if (web_state_) {
-      web_state_->RemoveObserver(this);
-    }
-  }
-
-  // Displays the Captive Portal Login page at `landing_url`.
-  void DisplayCaptivePortalLoginPage(GURL landing_url) {
-    if (!web_state_) {
-      return;
-    }
-    web_state_->GetNavigationManager()->LoadURLWithParams(
-        web_navigation_util::CreateWebLoadParams(
-            landing_url, ui::PAGE_TRANSITION_TYPED, nullptr));
-  }
-
-  // WebObserver
-  void WebStateDestroyed(web::WebState* web_state) override {
-    DCHECK_EQ(web_state_, web_state);
-    web_state_->RemoveObserver(this);
-    web_state_ = nullptr;
-  }
-
- private:
-  friend class web::WebStateUserData<BraveCaptivePortalTabHelper>;
-  BraveCaptivePortalTabHelper(web::WebState* web_state)
-      : web_state_(web_state) {
-    web_state_->AddObserver(this);
-  }
-  raw_ptr<web::WebState> web_state_ = nullptr;
-};
-
+// Replace the Chrome CaptivePortalTabHelper with the Brave variant that doesn't
+// use WebStateList and its insertion agent
 #define CaptivePortalTabHelper BraveCaptivePortalTabHelper
 #include <ios/chrome/browser/ssl/model/ios_captive_portal_blocking_page.mm>
 #undef CaptivePortalTabHelper

--- a/chromium_src/ios/chrome/browser/tabs/model/tab_helper_util.mm
+++ b/chromium_src/ios/chrome/browser/tabs/model/tab_helper_util.mm
@@ -11,6 +11,7 @@
 #import "ios/chrome/browser/https_upgrades/model/https_upgrade_service_factory.h"
 #import "ios/chrome/browser/https_upgrades/model/typed_navigation_upgrade_tab_helper.h"
 #import "ios/chrome/browser/shared/model/profile/profile_ios.h"
+#include "ios/chrome/browser/ssl/model/captive_portal_tab_helper.h"
 #include "ios/chrome/browser/tabs/model/ios_chrome_synced_tab_delegate.h"
 #import "ios/components/security_interstitials/https_only_mode/https_only_mode_container.h"
 #import "ios/components/security_interstitials/ios_blocking_page_tab_helper.h"
@@ -20,4 +21,8 @@ void AttachTabHelpers(web::WebState* web_state, TabHelperFilter filter_flags) {
 
   security_interstitials::IOSBlockingPageTabHelper::CreateForWebState(
       web_state);
+
+  // Create Brave's version instead of Chromes as we replace its usage in
+  // ios_captive_portal_blocking_page.mm
+  BraveCaptivePortalTabHelper::CreateForWebState(web_state);
 }


### PR DESCRIPTION
Uplift of #35999
Resolves https://github.com/brave/brave-browser/issues/55084

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.