### PR TITLE
[Wallet]: Wrap Long RPC Urls in Add Switch Network Panels

### DIFF
--- a/components/brave_wallet_ui/components/extension/allow_add_change_network_panel/allow_add_change_network_panel.style.ts
+++ b/components/brave_wallet_ui/components/extension/allow_add_change_network_panel/allow_add_change_network_panel.style.ts
@@ -37,11 +37,15 @@ export const NetworkInfoBox = styled(Column)`
 export const NetworkInfoLabel = styled(Text)`
   font: ${leo.font.small.regular};
   letter-spacing: ${leo.typography.letterSpacing.small};
+  word-break: break-all;
+  text-align: left;
 `
 
 export const NetworkInfoText = styled(Text)`
   font: ${leo.font.default.semibold};
   letter-spacing: ${leo.typography.letterSpacing.default};
+  word-break: break-all;
+  text-align: left;
 `
 
 export const DividerWrapper = styled(Row)`

--- a/components/brave_wallet_ui/components/extension/network_info/network_info.style.ts
+++ b/components/brave_wallet_ui/components/extension/network_info/network_info.style.ts
@@ -22,4 +22,6 @@ export const SectionLabel = styled(Text)`
 export const SectionDetails = styled(Text)`
   font: ${leo.font.default.semibold};
   letter-spacing: ${leo.typography.letterSpacing.default};
+  word-break: break-all;
+  text-align: left;
 `


### PR DESCRIPTION
## Description 

Ensure that long `RPC` urls wrap in the `Add/Switch Networks` panels

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/55141>
Security <https://github.com/brave/internal/issues/1718>

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

Before:

<img width="415" height="678" alt="Screenshot 13" src="https://github.com/user-attachments/assets/9c6bcfbf-0f55-4f10-913f-4e26466b7a59" /> | <img width="419" height="680" alt="Screenshot 18" src="https://github.com/user-attachments/assets/cddbb170-9c44-4c2f-8dfc-17cf5e68be97" /> | <img width="417" height="680" alt="Screenshot 14" src="https://github.com/user-attachments/assets/3221d62e-d395-4f05-8daf-5e16350c1ab4" />
--|--|--

After:

<img width="417" height="673" alt="Screenshot 16" src="https://github.com/user-attachments/assets/e49464cb-4d7e-4fda-870e-89bddc61ecd8" /> | <img width="412" height="672" alt="Screenshot 17" src="https://github.com/user-attachments/assets/e699610e-b5e6-4b48-8e19-1487de0b5ce6" /> | <img width="417" height="678" alt="Screenshot 15" src="https://github.com/user-attachments/assets/e994c6c5-a9aa-4122-97e7-e3a010bdde43" />
--|--|--
