### PR TITLE
[iOS] [Origin] Remove subtitle shown when you re-enable features (uplift to 1.91.x)

### DIFF
--- a/ios/brave-ios/Sources/Origin/OriginSettingsView.swift
+++ b/ios/brave-ios/Sources/Origin/OriginSettingsView.swift
@@ -125,24 +125,16 @@ private struct OriginToggleStyle: ToggleStyle {
   func makeBody(configuration: Configuration) -> some View {
     Toggle(isOn: configuration.$isOn) {
       configuration.label
-        .labelStyle(_LabelStyle(isOn: configuration.isOn))
+        .labelStyle(_LabelStyle())
     }
     .tint(Color(braveSystemName: .primary40))
   }
 
   struct _LabelStyle: LabelStyle {
-    var isOn: Bool
     func makeBody(configuration: Configuration) -> some View {
       Label {
-        VStack(alignment: .leading) {
-          configuration.title
-            .foregroundStyle(Color(braveSystemName: .textPrimary))
-          if isOn {
-            Text(Strings.Origin.enabledFeatureNote)
-              .foregroundStyle(Color(braveSystemName: .textSecondary))
-              .font(.footnote)
-          }
-        }
+        configuration.title
+          .foregroundStyle(Color(braveSystemName: .textPrimary))
       } icon: {
         configuration.icon
           .foregroundStyle(Color(braveSystemName: .iconDefault))

--- a/ios/brave-ios/Sources/Origin/OriginStrings.swift
+++ b/ios/brave-ios/Sources/Origin/OriginStrings.swift
@@ -81,12 +81,6 @@ extension Strings {
       value: "Wallet",
       comment: "A toggle label for Brave Wallet feature"
     )
-    public static let enabledFeatureNote = NSLocalizedString(
-      "enabledFeatureNote",
-      bundle: .module,
-      value: "This feature is enabled because you opted into it",
-      comment: "A note that indicates a feature is enabled"
-    )
     public static let originFeatureDescription = NSLocalizedString(
       "featuresFooter",
       bundle: .module,


### PR DESCRIPTION
Uplift of #36052
Resolves https://github.com/brave/brave-browser/issues/55138

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.