### PR TITLE
[Android] Remove subtitle from Brave Origin toggles when enabled (uplift to 1.91.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/settings/BraveOriginPreferences.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveOriginPreferences.java
@@ -188,7 +188,6 @@ public class BraveOriginPreferences extends BravePreferenceFragment
         String key = preference.getKey();
         boolean isEnabled = (Boolean) newValue;
 
-        updateToggleDescription(preference, isEnabled);
         String policyKey = getPolicyKeyForPreference(key);
         if (policyKey == null || mBraveOriginSettingsHandler == null) {
             return false;
@@ -389,7 +388,6 @@ public class BraveOriginPreferences extends BravePreferenceFragment
             return;
         }
         preference.setOnPreferenceChangeListener(this);
-        updateToggleDescription(preference, preference.isChecked());
 
         // Initialize from policy service if available
         String policyKey = getPolicyKeyForPreference(key);
@@ -407,7 +405,6 @@ public class BraveOriginPreferences extends BravePreferenceFragment
                                         ? !value
                                         : value;
                         preference.setChecked(checkedValue);
-                        updateToggleDescription(preference, checkedValue);
                     }
                 });
     }
@@ -485,7 +482,6 @@ public class BraveOriginPreferences extends BravePreferenceFragment
                 continue;
             }
             pref.setChecked(false);
-            updateToggleDescription(pref, false);
             anyChanged = true;
 
             String policyKey = getPolicyKeyForPreference(key);
@@ -504,22 +500,6 @@ public class BraveOriginPreferences extends BravePreferenceFragment
 
         if (anyChanged) {
             showRestartSnackbar();
-        }
-    }
-
-    /**
-     * Updates the description of a toggle preference based on its enabled state. Shows "This
-     * feature is enabled because you opted into it" when enabled, removes the description when
-     * disabled.
-     *
-     * @param preference The preference to update
-     * @param isEnabled Whether the toggle is enabled
-     */
-    private void updateToggleDescription(Preference preference, boolean isEnabled) {
-        if (isEnabled) {
-            preference.setSummary(R.string.origin_toggle_enabled_description);
-        } else {
-            preference.setSummary(null);
         }
     }
 

--- a/browser/ui/android/strings/android_brave_strings.grd
+++ b/browser/ui/android/strings/android_brave_strings.grd
@@ -3278,9 +3278,6 @@ If you don't accept this request, VPN will not reconnect and your internet conne
     <message name="IDS_ORIGIN_RESET_TO_DEFAULTS" desc="Brave Origin reset to defaults preference title">
       Reset to defaults
     </message>
-    <message name="IDS_ORIGIN_TOGGLE_ENABLED_DESCRIPTION" desc="Description shown when a toggle is enabled in Brave Origin settings">
-      This feature is enabled because you opted into it
-    </message>
     <message name="IDS_ORIGIN_DESCRIPTION_TITLE" desc="Brave Origin description title">
       Customize your browser while still supporting Brave
     </message>


### PR DESCRIPTION
Uplift of #36055
Resolves https://github.com/brave/brave-browser/issues/55142

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.