### PR TITLE
Filter inapplicable variations from chrome://version on Brave Origin

### DIFF
--- a/chromium_src/components/webui/version/version_handler_helper.cc
+++ b/chromium_src/components/webui/version/version_handler_helper.cc
@@ -5,11 +5,56 @@
 
 #define GetVariationsList GetVariationsList_ChromiumImpl
 #include "base/strings/string_util.h"
+#include "brave/components/brave_origin/buildflags/buildflags.h"
 
 #include <components/webui/version/version_handler_helper.cc>
 #undef GetVariationsList
 
 namespace version_ui {
+
+namespace {
+
+#if BUILDFLAG(IS_BRAVE_ORIGIN_BRANDED)
+// Trial-name prefixes for studies that target features which are stripped from
+// Brave Origin builds at compile time (see is_brave_origin_branded gating in
+// //brave/components/*/buildflags). The variations seed is shared across all
+// Brave builds, so these studies still register field-trial groups, but the
+// underlying features are not compiled in and the studies have no effect.
+// Filter them from chrome://version so the page reflects what actually ships.
+constexpr std::string_view kBraveOriginInapplicableTrialPrefixes[] = {
+    "AIChat",                    // enable_ai_chat
+    "BraveAds",                  // enable_brave_ads
+    "BraveNTPBrandedWallpaper",  // enable_brave_ads (NTP sponsored images)
+    "BraveNTPSponsored",         // enable_brave_ads (NTP sponsored images)
+    "BraveNews",                 // enable_brave_news
+    "BraveRewards",              // enable_brave_rewards
+    "BraveTalk",                 // enable_brave_talk
+    "BraveVPN",                  // enable_brave_vpn
+    "BraveVpn",                  // enable_brave_vpn (alternate casing)
+    "BraveWallet",               // enable_brave_wallet
+    "BraveWaybackMachine",       // enable_brave_wayback_machine
+    "BraveWebDiscovery",         // enable_web_discovery
+    "EmailAliases",              // enable_email_aliases
+    "Leo",                       // alias for AI Chat
+    "Playlist",                  // enable_playlist
+    "Psst",                      // enable_psst
+    "Speedreader",               // enable_speedreader
+    "Tor",                       // enable_tor
+    "WebDiscovery",              // enable_web_discovery
+    "ZCash",                     // enable_brave_wallet (ZCash sub-feature)
+};
+
+bool IsBraveOriginInapplicableTrial(const std::string& trial_name) {
+  for (std::string_view prefix : kBraveOriginInapplicableTrialPrefixes) {
+    if (base::StartsWith(trial_name, prefix)) {
+      return true;
+    }
+  }
+  return false;
+}
+#endif  // BUILDFLAG(IS_BRAVE_ORIGIN_BRANDED)
+
+}  // namespace
 
 // Brave always shows full variations names instead of hashes.
 base::ListValue GetVariationsList() {
@@ -21,6 +66,11 @@ base::ListValue GetVariationsList() {
   const std::string kNonBreakingHyphenUTF8String(
       reinterpret_cast<const char*>(kNonBreakingHyphenUTF8));
   for (const auto& group : active_groups) {
+#if BUILDFLAG(IS_BRAVE_ORIGIN_BRANDED)
+    if (IsBraveOriginInapplicableTrial(group.trial_name)) {
+      continue;
+    }
+#endif
     std::string line = group.trial_name + ":" + group.group_name;
     base::ReplaceChars(line, "-", kNonBreakingHyphenUTF8String, &line);
     variations.push_back(line);


### PR DESCRIPTION
## Summary

Resolves brave/brave-browser#55034.

`chrome://version` on Brave Origin builds was listing active variations for features that are not part of the product (e.g. `AIChatCodeExecutionTool_Nightly`, `BraveNTPBrandedWallpaperStudy`, `ZCashStudy_*`).

Brave Origin is a branded build (`is_brave_origin_branded=true`) that strips many feature components at compile time (AI Chat, News, Rewards, Wallet, Ads, Talk, Tor, SpeedReader, Email Aliases, PSST, Web Discovery, VPN, Wayback Machine, Playlist, NTP branded wallpaper). The variations seed is shared across all Brave channels, so studies targeting those features still register field-trial groups — they just have no effect because the underlying features aren't compiled in. The groups still appeared on `chrome://version`, which was confusing.

This PR filters those groups out of `GetVariationsList()` in the existing chromium_src override, gated by `BUILDFLAG(IS_BRAVE_ORIGIN_BRANDED)`. Non-Origin builds are unchanged. `GetVariationsCommandLine()` (the `--force-fieldtrials=...` debug copy) is intentionally left intact so the dump remains a faithful reproduction string.

## Test plan

- [ ] Build with `is_brave_origin_branded=true`; load `chrome://version`; confirm trials with names starting with `AIChat`, `BraveAds`, `BraveNTPBrandedWallpaper`, `BraveNTPSponsored`, `BraveNews`, `BraveRewards`, `BraveTalk`, `BraveVPN`/`BraveVpn`, `BraveWallet`, `BraveWaybackMachine`, `BraveWebDiscovery`, `EmailAliases`, `Leo`, `Playlist`, `Psst`, `Speedreader`, `Tor`, `WebDiscovery`, `ZCash` are absent from the Variations list.
- [ ] Build with `is_brave_origin_branded=false` (default); confirm `chrome://version` still shows all variations as before (no behavior change).
- [ ] Confirm seed-version line and remaining variations still render correctly.