### PR TITLE
[Origin] Disable brave://getting-started in Brave Origin branded builds

### DIFF
--- a/brave_paks.gni
+++ b/brave_paks.gni
@@ -4,6 +4,7 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import("//brave/components/ai_chat/core/common/buildflags/buildflags.gni")
+import("//brave/components/brave_education/buildflags.gni")
 import("//brave/components/brave_origin/buildflags/buildflags.gni")
 import("//brave/components/brave_rewards/core/buildflags/buildflags.gni")
 import("//brave/components/psst/buildflags/buildflags.gni")
@@ -69,13 +70,15 @@ template("brave_extra_paks") {
 
     if (!is_android) {
       sources += [
-        "$root_gen_dir/brave/brave_education_resources.pak",
         "$root_gen_dir/brave/brave_generated_resources.pak",
         "$root_gen_dir/brave/brave_unscaled_resources.pak",
         "$root_gen_dir/brave/browser/resources/brave_new_tab_page_refresh/brave_new_tab_page_refresh_generated.pak",
         "$root_gen_dir/brave/browser/resources/brave_welcome_page/brave_welcome_page_generated.pak",
         "$root_gen_dir/brave/browser/resources/settings/brave_settings_resources.pak",
       ]
+      if (enable_brave_education) {
+        sources += [ "$root_gen_dir/brave/brave_education_resources.pak" ]
+      }
     }
 
     deps = [ "//brave/components/resources" ]
@@ -84,12 +87,14 @@ template("brave_extra_paks") {
       deps += [
         "//brave/app:brave_generated_resources_grit",
         "//brave/app/theme:brave_unscaled_resources",
-        "//brave/browser/resources/brave_education:resources_grit",
         "//brave/browser/resources/brave_new_tab_page_refresh:generated_resources",
         "//brave/browser/resources/brave_welcome_page:generated_resources",
         "//brave/browser/resources/settings:resources",
         "//brave/components/resources:strings",
       ]
+      if (enable_brave_education) {
+        deps += [ "//brave/browser/resources/brave_education:resources_grit" ]
+      }
     }
 
     if (enable_brave_ai_chat_agent_profile) {

--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -409,6 +409,8 @@ source_set("ui") {
       "//brave/components/brave_account",
       "//brave/components/brave_account:features",
       "//brave/components/brave_account/mojom",
+      "//brave/components/brave_education",
+      "//brave/components/brave_education:buildflags",
       "//brave/components/brave_wayback_machine/buildflags",
       "//brave/components/constants",
       "//brave/components/email_aliases/buildflags",

--- a/browser/ui/config.gni
+++ b/browser/ui/config.gni
@@ -5,6 +5,7 @@
 
 import("//brave/components/ai_chat/core/common/buildflags/buildflags.gni")
 import("//brave/components/brave_ads/buildflags/buildflags.gni")
+import("//brave/components/brave_education/buildflags.gni")
 import("//brave/components/brave_news/common/buildflags/buildflags.gni")
 import("//brave/components/containers/buildflags/buildflags.gni")
 import("//brave/components/email_aliases/buildflags/buildflags.gni")
@@ -25,11 +26,14 @@ if (!is_android) {
   brave_ui_allow_circular_includes_from += [
     "//brave/browser/ui/browser_window/internal",
     "//brave/browser/ui/tabs:tabs_public",
-    "//brave/browser/ui/webui/brave_education",
     "//brave/browser/ui/webui/brave_new_tab_page_refresh",
     "//brave/browser/ui/webui/side_panel/customize_chrome",
     "//brave/browser/ui/tabs:tab_strip",
   ]
+  if (enable_brave_education) {
+    brave_ui_allow_circular_includes_from +=
+        [ "//brave/browser/ui/webui/brave_education" ]
+  }
   if (enable_brave_news) {
     brave_ui_allow_circular_includes_from +=
         [ "//brave/browser/ui/webui/brave_news_internals" ]

--- a/browser/ui/webui/welcome_page/welcome_dom_handler.cc
+++ b/browser/ui/webui/welcome_page/welcome_dom_handler.cc
@@ -16,8 +16,7 @@
 #include "base/values.h"
 #include "brave/browser/brave_browser_features.h"
 #include "brave/common/importer/importer_constants.h"
-#include "brave/components/brave_education/education_urls.h"
-#include "brave/components/brave_education/features.h"
+#include "brave/components/brave_education/buildflags.h"
 #include "brave/components/constants/pref_names.h"
 #include "brave/components/p3a/pref_names.h"
 #include "brave/components/web_discovery/buildflags/buildflags.h"
@@ -32,6 +31,11 @@
 #include "components/prefs/pref_service.h"
 #include "extensions/buildflags/buildflags.h"
 #include "ui/base/l10n/l10n_util.h"
+
+#if BUILDFLAG(ENABLE_BRAVE_EDUCATION)
+#include "brave/components/brave_education/education_urls.h"
+#include "brave/components/brave_education/features.h"
+#endif
 
 namespace {
 
@@ -69,17 +73,23 @@ bool IsChromeDev(const std::u16string& browser_name) {
          browser_name == kChromeDevLinuxBrowserName;
 }
 
+#if BUILDFLAG(ENABLE_BRAVE_EDUCATION)
 bool ShouldRedirectToGettingStartedPage() {
   return base::FeatureList::IsEnabled(
       brave_education::features::kShowGettingStartedPage);
 }
+#endif  // BUILDFLAG(ENABLE_BRAVE_EDUCATION)
 
 }  // namespace
 
 WelcomeDOMHandler::WelcomeDOMHandler(Profile* profile)
-    : profile_(profile),
+    : profile_(profile)
+#if BUILDFLAG(ENABLE_BRAVE_EDUCATION)
+      ,
       brave_education_server_checker_(*profile->GetPrefs(),
-                                      profile->GetURLLoaderFactory()) {
+                                      profile->GetURLLoaderFactory())
+#endif  // BUILDFLAG(ENABLE_BRAVE_EDUCATION)
+{
   base::MakeRefCounted<shell_integration::DefaultSchemeClientWorker>(
       GURL("https://browser-education.brave.com"))
       ->StartCheckIsDefaultAndGetDefaultClientName(
@@ -200,6 +210,7 @@ void WelcomeDOMHandler::HandleGetWelcomeCompleteURL(
   CHECK_EQ(1U, args.size());
   const auto& callback_id = args[0].GetString();
   AllowJavascript();
+#if BUILDFLAG(ENABLE_BRAVE_EDUCATION)
   if (!ShouldRedirectToGettingStartedPage()) {
     OnGettingStartedServerCheck(callback_id, /* available */ false);
     return;
@@ -208,6 +219,9 @@ void WelcomeDOMHandler::HandleGetWelcomeCompleteURL(
       brave_education::EducationPageType::kGettingStarted,
       base::BindOnce(&WelcomeDOMHandler::OnGettingStartedServerCheck,
                      weak_ptr_factory_.GetWeakPtr(), callback_id));
+#else
+  OnGettingStartedServerCheck(callback_id, /* available */ false);
+#endif  // BUILDFLAG(ENABLE_BRAVE_EDUCATION)
 }
 
 void WelcomeDOMHandler::OnGettingStartedServerCheck(
@@ -217,12 +231,16 @@ void WelcomeDOMHandler::OnGettingStartedServerCheck(
     return;
   }
   GURL url;
+#if BUILDFLAG(ENABLE_BRAVE_EDUCATION)
   if (available) {
     url = brave_education::GetEducationPageBrowserURL(
         brave_education::EducationPageType::kGettingStarted);
   } else {
     url = GURL(chrome::kChromeUINewTabURL);
   }
+#else
+  url = GURL(chrome::kChromeUINewTabURL);
+#endif  // BUILDFLAG(ENABLE_BRAVE_EDUCATION)
   ResolveJavascriptCallback(base::Value(callback_id), base::Value(url.spec()));
 }
 

--- a/browser/ui/webui/welcome_page/welcome_dom_handler.h
+++ b/browser/ui/webui/welcome_page/welcome_dom_handler.h
@@ -11,9 +11,13 @@
 
 #include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
-#include "brave/browser/ui/webui/brave_education/brave_education_server_checker.h"
+#include "brave/components/brave_education/buildflags.h"
 #include "chrome/browser/shell_integration.h"
 #include "content/public/browser/web_ui_message_handler.h"
+
+#if BUILDFLAG(ENABLE_BRAVE_EDUCATION)
+#include "brave/browser/ui/webui/brave_education/brave_education_server_checker.h"
+#endif
 
 class Profile;
 class Browser;
@@ -55,7 +59,9 @@ class WelcomeDOMHandler : public content::WebUIMessageHandler {
   size_t last_onboarding_phase_ = 0;
   std::u16string default_browser_name_;
   raw_ptr<Profile> profile_ = nullptr;
+#if BUILDFLAG(ENABLE_BRAVE_EDUCATION)
   brave_education::BraveEducationServerChecker brave_education_server_checker_;
+#endif
   base::WeakPtrFactory<WelcomeDOMHandler> weak_ptr_factory_{this};
 };
 

--- a/components/brave_education/buildflags.gni
+++ b/components/brave_education/buildflags.gni
@@ -3,6 +3,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import("//brave/components/brave_origin/buildflags/buildflags.gni")
+
 declare_args() {
-  enable_brave_education = is_win || is_mac || is_linux
+  enable_brave_education =
+      (is_win || is_mac || is_linux) && !is_brave_origin_branded
 }


### PR DESCRIPTION
Most features promoted on `brave://getting-started` don't apply to Brave Origin/

Defaults `enable_brave_education` to off when `is_brave_origin_branded` is true, matching other buidl flags.

Resolves https://github.com/brave/brave-browser/issues/55035

## Test plan

- [ ] brave://getting-started should be available in normal builds
- [ ] brave://getting-started should NOT be available in Brave Origin builds