### PR TITLE
[Brave Origin] Add switch to skip startup dialog on Linux

### DIFF
--- a/browser/ui/views/brave_origin/BUILD.gn
+++ b/browser/ui/views/brave_origin/BUILD.gn
@@ -18,6 +18,7 @@ source_set("brave_origin") {
     "//brave/brave_domains",
     "//brave/browser/ui/webui/brave_origin_startup",
     "//brave/components/brave_origin:pref_names",
+    "//brave/components/brave_origin:switches",
     "//brave/components/brave_origin/buildflags",
     "//brave/components/resources:strings_grit",
     "//brave/components/skus/browser",
@@ -70,7 +71,9 @@ source_set("unit_tests") {
   deps = [
     ":brave_origin",
     "//base",
+    "//base/test:test_support",
     "//brave/components/brave_origin:pref_names",
+    "//brave/components/brave_origin:switches",
     "//brave/components/skus/browser",
     "//components/prefs:test_support",
     "//testing/gtest",

--- a/browser/ui/views/brave_origin/brave_origin_startup_view.cc
+++ b/browser/ui/views/brave_origin/brave_origin_startup_view.cc
@@ -36,6 +36,10 @@
 #include "url/gurl.h"
 #include "url/url_constants.h"
 
+#if BUILDFLAG(IS_LINUX)
+#include "brave/components/brave_origin/switches.h"
+#endif
+
 namespace {
 
 constexpr int kDialogWidth = 540;
@@ -85,6 +89,12 @@ bool BraveOriginStartupView::ShouldShowDialog(PrefService* local_state) {
   }
 
 #if BUILDFLAG(IS_LINUX)
+  if (base::CommandLine::ForCurrentProcess()->HasSwitch(
+          brave_origin::switches::kSkipOriginStartupDialog)) {
+    // Persist acceptance so future launches without the switch also skip
+    // the dialog.
+    local_state->SetBoolean(brave_origin::kOriginFreeTierAccepted, true);
+  }
   if (local_state->GetBoolean(brave_origin::kOriginFreeTierAccepted)) {
     return false;
   }

--- a/browser/ui/views/brave_origin/brave_origin_startup_view_unittest.cc
+++ b/browser/ui/views/brave_origin/brave_origin_startup_view_unittest.cc
@@ -18,6 +18,11 @@
 #include "components/prefs/testing_pref_service.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
+#if BUILDFLAG(IS_LINUX)
+#include "base/test/scoped_command_line.h"
+#include "brave/components/brave_origin/switches.h"
+#endif
+
 class BraveOriginStartupViewTest : public testing::Test {
  public:
   void SetUp() override {
@@ -138,6 +143,18 @@ TEST_F(BraveOriginStartupViewTest, ShouldShowDialogWhenItemsDictMissing) {
   SetSkuCredentials("production", R"({"credentials": {"not_items": "value"}})");
   EXPECT_TRUE(BraveOriginStartupView::ShouldShowDialog(&local_state_));
 }
+
+#if BUILDFLAG(IS_LINUX)
+TEST_F(BraveOriginStartupViewTest,
+       ShouldNotShowDialogWhenSkipSwitchPresentOnLinux) {
+  base::test::ScopedCommandLine scoped_cl;
+  scoped_cl.GetProcessCommandLine()->AppendSwitch(
+      brave_origin::switches::kSkipOriginStartupDialog);
+  EXPECT_FALSE(BraveOriginStartupView::ShouldShowDialog(&local_state_));
+  // Switch persists acceptance so future launches without it also skip.
+  EXPECT_TRUE(local_state_.GetBoolean(brave_origin::kOriginFreeTierAccepted));
+}
+#endif  // BUILDFLAG(IS_LINUX)
 
 // --- SetShouldShowDialogForTesting tests ---
 

--- a/components/brave_origin/BUILD.gn
+++ b/components/brave_origin/BUILD.gn
@@ -27,6 +27,10 @@ source_set("pref_names") {
   ]
 }
 
+source_set("switches") {
+  sources = [ "switches.h" ]
+}
+
 static_library("brave_origin") {
   sources = [
     "brave_origin_policy_info.cc",

--- a/components/brave_origin/switches.h
+++ b/components/brave_origin/switches.h
@@ -1,0 +1,17 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_ORIGIN_SWITCHES_H_
+#define BRAVE_COMPONENTS_BRAVE_ORIGIN_SWITCHES_H_
+
+namespace brave_origin::switches {
+
+// Skips the Brave Origin startup dialog. Only honored on Linux, where
+// Brave Origin can be used without a purchase.
+inline constexpr char kSkipOriginStartupDialog[] = "skip-origin-startup-dialog";
+
+}  // namespace brave_origin::switches
+
+#endif  // BRAVE_COMPONENTS_BRAVE_ORIGIN_SWITCHES_H_


### PR DESCRIPTION
## Summary

- Adds a new `--skip-origin-startup-dialog` command-line switch.
- Honored only on Linux (where Brave Origin is free), where it makes `BraveOriginStartupView::ShouldShowDialog()` return false so the donation/startup dialog is bypassed.
- Useful for automation and scripted launches where the dialog would otherwise block startup, as discussed in the linked issue.

Resolves https://github.com/brave/brave-browser/issues/55151

## Test plan

- [x] On a Linux is_brave_origin_branded build with a fresh profile (dialog would normally appear), launch with `--skip-origin-startup-dialog` and confirm the browser starts directly without showing the dialog.
- [x] Launch the same build without the switch and confirm the dialog still appears as before.
- [x] On macOS / Windows is_brave_origin_branded builds, confirm the switch has no effect (dialog still appears since payment is required).
- [x] Run `brave_unit_tests --gtest_filter=BraveOriginStartupViewTest.*` and verify the new `ShouldNotShowDialogWhenSkipSwitchPresentOnLinux` test passes on Linux.