### PR TITLE
[Android] Fix shred button spacing from screen edge in tab switcher (uplift to 1.91.x)

### DIFF
--- a/browser/hub/internal/android/java/src/org/chromium/chrome/browser/hub/BraveHubToolbarView.java
+++ b/browser/hub/internal/android/java/src/org/chromium/chrome/browser/hub/BraveHubToolbarView.java
@@ -10,6 +10,7 @@ import android.content.Context;
 import android.content.res.Configuration;
 import android.util.AttributeSet;
 import android.view.View;
+import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.FrameLayout;
 
@@ -87,6 +88,21 @@ public class BraveHubToolbarView extends HubToolbarView {
 
         mActionButton.setVisibility(shouldHideButtons ? View.GONE : View.VISIBLE);
         mMenuButton.setVisibility(shouldHideButtons ? View.GONE : View.VISIBLE);
+
+        // When the menu button is GONE the shred button becomes the rightmost child of
+        // menu_button_container; give it an end margin matching the toolbar's start
+        // inset so the shred icon doesn't sit flush against the screen edge.
+        if (shouldHideButtons) {
+            ViewGroup.MarginLayoutParams shredLp =
+                    (ViewGroup.MarginLayoutParams) mShredButton.getLayoutParams();
+            int endMargin =
+                    getResources()
+                            .getDimensionPixelSize(R.dimen.hub_toolbar_action_button_start_margin);
+            if (shredLp.getMarginEnd() != endMargin) {
+                shredLp.setMarginEnd(endMargin);
+                mShredButton.setLayoutParams(shredLp);
+            }
+        }
 
         final boolean shouldShowShredButton =
                 ChromeFeatureList.isEnabled(BraveFeatureList.BRAVE_SHRED);


### PR DESCRIPTION
Uplift of #36065
Resolves https://github.com/brave/brave-browser/issues/55012

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.