### PR TITLE
Playlist: Remove the ability to add homepage and search result page as playlist items

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/PlaylistScriptHandler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/PlaylistScriptHandler.swift
@@ -130,11 +130,24 @@ class PlaylistScriptHandler: NSObject, TabContentScript, TabObserver {
       return
     }
 
-    // Copy the item but use the web-view's title and location instead, if available
-    // This is due to a iFrames security
-    item.pageSrc = tab.visibleURL?.absoluteString ?? item.pageSrc
+    // The script reports `window.top.location.href` for same-origin frames (which already equals `tab.visibleURL`)
+    // and falls back to the iframe's own URL when blocked by SOP. We only want to override in that cross-origin case so
+    // the stored `pageSrc` matches the page the user thinks they added the item from, instead of an opaque embedder URL.
+    if let visibleURL = tab.visibleURL,
+      let pageURL = URL(string: item.pageSrc),
+      pageURL.host != visibleURL.host
+    {
+      item.pageSrc = visibleURL.absoluteString
+    }
     item.pageTitle = tab.title ?? item.pageTitle
     item.lastPlayedOffset = 0.0
+
+    guard Self.canResolvePageSrcLater(item.pageSrc) else {
+      DispatchQueue.main.async {
+        handler.delegate?.updatePlaylistURLBar(tab: tab, state: .none, item: nil)
+      }
+      return
+    }
 
     Self.queue.async { [weak handler] in
       guard let handler = handler else { return }
@@ -165,6 +178,31 @@ class PlaylistScriptHandler: NSObject, TabContentScript, TabObserver {
           }
         }
       }
+    }
+  }
+
+  /// Returns `true` when `pageSrc` is the kind of URL we can reasonably re-resolve later by re-loading it in a `LivePlaylistWebLoader`.
+  /// For known sites whose feed/home/search pages have no stable `<video>` element to extract from, returns `false` so we don't capture
+  /// items that are guaranteed to fail resolution. Unknown sites fall through and are trusted; we only special-case sites we have evidence for.
+  private static func canResolvePageSrcLater(_ pageSrc: String) -> Bool {
+    guard let url = URL(string: pageSrc), let baseDomain = url.baseDomain else {
+      return true
+    }
+    let path = url.path
+    switch baseDomain {
+    case "youtube.com":
+      // Only watch/shorts/embed pages have a stable video at a stable URL. Homepage,
+      // search results (`/results`), feed (`/feed/*`), channel (`/@handle`, `/c/*`,
+      // `/channel/*`, `/user/*`) and similar listings do not.
+      return path.hasPrefix("/watch")
+        || path.hasPrefix("/shorts/")
+        || path.hasPrefix("/embed/")
+        || path.hasPrefix("/v/")
+    case "youtu.be":
+      // Short links of the form `youtu.be/<videoId>`.
+      return url.pathComponents.count >= 2 && !url.pathComponents[1].isEmpty
+    default:
+      return true
     }
   }
 

--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/PlaylistScriptHandler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/PlaylistScriptHandler.swift
@@ -182,8 +182,9 @@ class PlaylistScriptHandler: NSObject, TabContentScript, TabObserver {
   }
 
   /// Returns `true` when `pageSrc` is the kind of URL we can reasonably re-resolve later by re-loading it in a `LivePlaylistWebLoader`.
-  /// For known sites whose feed/home/search pages have no stable `<video>` element to extract from, returns `false` so we don't capture
-  /// items that are guaranteed to fail resolution. Unknown sites fall through and are trusted; we only special-case sites we have evidence for.
+  /// For `youtube.com` we use a **denylist** of listing/feed surfaces where reload rarely reproduces the same watchable item; all other paths on
+  /// that domain are trusted (new watch URL shapes from YouTube can work without an app update). Unknown sites fall through and are trusted;
+  /// we only special-case domains we have evidence for.
   private static func canResolvePageSrcLater(_ pageSrc: String) -> Bool {
     guard let url = URL(string: pageSrc), let baseDomain = url.baseDomain else {
       return true
@@ -191,13 +192,19 @@ class PlaylistScriptHandler: NSObject, TabContentScript, TabObserver {
     let path = url.path
     switch baseDomain {
     case "youtube.com":
-      // Only watch/shorts/embed pages have a stable video at a stable URL. Homepage,
-      // search results (`/results`), feed (`/feed/*`), channel (`/@handle`, `/c/*`,
-      // `/channel/*`, `/user/*`) and similar listings do not.
-      return path.hasPrefix("/watch")
-        || path.hasPrefix("/shorts/")
-        || path.hasPrefix("/embed/")
-        || path.hasPrefix("/v/")
+      // Homepage, search, feeds, channel listings, playlist index, etc.
+      if path.isEmpty || path == "/"
+        || path.hasPrefix("/results")
+        || path.hasPrefix("/feed")
+        || path.hasPrefix("/channel/")
+        || path.hasPrefix("/c/")
+        || path.hasPrefix("/user/")
+        || path.hasPrefix("/@")
+        || path.hasPrefix("/playlist")
+      {
+        return false
+      }
+      return true
     case "youtu.be":
       // Short links of the form `youtu.be/<videoId>`.
       return url.pathComponents[safe: 1]?.isEmpty == false

--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/PlaylistScriptHandler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/PlaylistScriptHandler.swift
@@ -200,7 +200,7 @@ class PlaylistScriptHandler: NSObject, TabContentScript, TabObserver {
         || path.hasPrefix("/v/")
     case "youtu.be":
       // Short links of the form `youtu.be/<videoId>`.
-      return url.pathComponents.count >= 2 && !url.pathComponents[1].isEmpty
+      return url.pathComponents[safe: 1]?.isEmpty == false
     default:
       return true
     }


### PR DESCRIPTION
## Summary
Updates `PlaylistScriptHandler` so playlist items store a `pageSrc` that `LivePlaylistWebLoader` can reload, and avoids offering captures that would persist as broken entries on YouTube listing-style URLs.

## Problem
Adding to Playlist from contexts where **`pageSrc` was wrong or not reloadable** (always forcing the visible tab URL when the script already reported the correct page, or allowing captures from YouTube feeds/search/home where there is no stable video page to resolve later) produced **playlist items that could not be played back reliably**.

## Testplan

| # | Steps | Expected result |
|---|---------------|-----------------|
| 1 | Visit YouTube home page that contains feed  | The top video in view should begin playing. **Note** that there is no add playlist button in the address bar. |
| 2 | Select any video to go to its page. | The add playlist button is visible and enabled. |
| 3 | Add the video to the playlist. If onboarding hasn't happened yet, follow the instructions to add the playlist. | The video is added to the playlist and is playable. The thumbnail is filled in with a frame from the video |

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves  https://github.com/brave/brave-browser/issues/55010

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
