### PR TITLE
[iOS] Migrate GPC preference to profile pref

### DIFF
--- a/ios/BUILD.gn
+++ b/ios/BUILD.gn
@@ -132,6 +132,7 @@ brave_core_public_headers = [
   "//brave/ios/browser/brave_search/brave_search_make_default_tab_helper_bridge.h",
   "//ios/chrome/browser/web/model/print/print_handler.h",
   "//brave/ios/browser/youtube/youtube_pref_names_bridge.h",
+  "//brave/ios/browser/global_privacy_control/gpc_pref_names_bridge.h",
 ]
 
 brave_core_public_headers += ads_public_headers

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabPolicyDecider.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabPolicyDecider.swift
@@ -49,7 +49,10 @@ extension BrowserViewController: TabPolicyDecider {
             for: pageData.mainFrameURL,
             shield: .fpProtection,
             considerAllShieldsOption: true
-          ) ?? true
+          ) ?? true,
+          isGPCEnabled: profileController.profile.prefs.boolean(
+            forPath: kGlobalPrivacyControlEnabled
+          )
         ) ?? []
       tab.browserData?.setCustomUserScript(scripts: scriptTypes)
     }
@@ -321,7 +324,10 @@ extension BrowserViewController: TabPolicyDecider {
           await tab.currentPageData?.makeUserScriptTypes(
             isDeAmpEnabled: profileController.deAmpPrefs.isDeAmpEnabled,
             isAdBlockEnabled: isAdBlockEnabled,
-            isBlockFingerprintingEnabled: isBlockFingerprintingEnabled
+            isBlockFingerprintingEnabled: isBlockFingerprintingEnabled,
+            isGPCEnabled: profileController.profile.prefs.boolean(
+              forPath: kGlobalPrivacyControlEnabled
+            )
           ) ?? []
         tab.browserData?.setCustomUserScript(scripts: scriptTypes)
       }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/DetachedTabPrivacyHelper.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/DetachedTabPrivacyHelper.swift
@@ -91,7 +91,8 @@ class DetachedTabPrivacyHelper: TabPolicyDecider {
             for: pageData.mainFrameURL,
             shield: .fpProtection,
             considerAllShieldsOption: true
-          ) ?? true
+          ) ?? true,
+          isGPCEnabled: tab.profile.prefs.boolean(forPath: kGlobalPrivacyControlEnabled)
         ) ?? []
       tab.browserData?.setCustomUserScript(scripts: scriptTypes)
     }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/PageData.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/PageData.swift
@@ -80,7 +80,8 @@ import WebKit
   @MainActor func makeUserScriptTypes(
     isDeAmpEnabled: Bool,
     isAdBlockEnabled: Bool,
-    isBlockFingerprintingEnabled: Bool
+    isBlockFingerprintingEnabled: Bool,
+    isGPCEnabled: Bool
   ) async -> Set<UserScriptType> {
     if !mainFrameURL.isWebPage(includeDataURIs: false) {
       // Local application urls do not need page-specific user scripts injected
@@ -88,7 +89,7 @@ import WebKit
     }
 
     var userScriptTypes: Set<UserScriptType> = [
-      .siteStateListener, .gpc(Preferences.Shields.enableGPC.value),
+      .siteStateListener, .gpc(isGPCEnabled),
     ]
 
     // Handle dynamic domain level scripts on the main document.

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Playlist/ManagersAndCache/PlaylistCacheLoader.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Playlist/ManagersAndCache/PlaylistCacheLoader.swift
@@ -318,7 +318,8 @@ extension LivePlaylistWebLoader: TabPolicyDecider {
           await tab.currentPageData?.makeUserScriptTypes(
             isDeAmpEnabled: false,
             isAdBlockEnabled: true,  // enabled for playlist
-            isBlockFingerprintingEnabled: true
+            isBlockFingerprintingEnabled: true,
+            isGPCEnabled: true
           ) ?? []
         tab.browserData?.setCustomUserScript(scripts: scriptTypes)
       }

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/AdvancedShieldSettings.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/AdvancedShieldSettings.swift
@@ -67,6 +67,11 @@ import os
       debounceService?.isEnabled = isDebounceEnabled
     }
   }
+  @Published var isGPCEnabled: Bool {
+    didSet {
+      prefs.set(isGPCEnabled, forPath: kGlobalPrivacyControlEnabled)
+    }
+  }
   @Published var adBlockAndTrackingPreventionLevel: ShieldLevel {
     didSet {
       guard oldValue != adBlockAndTrackingPreventionLevel else { return }
@@ -155,6 +160,7 @@ import os
   @Published var clearableSettings: [ClearableSetting]
 
   private var subscriptions: [AnyCancellable] = []
+  private let prefs: any PrefService
   private let p3aUtilities: BraveP3AUtils
   private let deAmpPrefs: DeAmpPrefs
   private let debounceService: (any DebounceService)?
@@ -188,6 +194,7 @@ import os
     self.rewards = rewards
     self.clearDataCallback = clearDataCallback
     self.braveStats = braveStats
+    self.prefs = braveCore.profile.prefs
     if FeatureList.kBraveShieldsContentSettings.enabled {
       self.adBlockAndTrackingPreventionLevel =
         braveShieldsSettings?.defaultAdBlockMode.shieldLevel ?? .standard
@@ -203,6 +210,7 @@ import os
     }
     self.httpsUpgradeLevel = Preferences.Shields.httpsUpgradeLevel
     self.isDeAmpEnabled = deAmpPrefs.isDeAmpEnabled
+    self.isGPCEnabled = prefs.boolean(forPath: kGlobalPrivacyControlEnabled)
     self.isDebounceEnabled = debounceService?.isEnabled ?? false
     self.shredHistoryItems = Preferences.Shields.shredHistoryItems.value
     self.webcompatReporterHandler = webcompatReporterHandler

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/OtherPrivacySettingsSectionView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/OtherPrivacySettingsSectionView.swift
@@ -35,10 +35,10 @@ struct OtherPrivacySettingsSectionView: View {
 
   var body: some View {
     Section {
-      OptionToggleView(
+      ToggleView(
         title: Strings.Shields.enableGPCLabel,
         subtitle: Strings.Shields.enableGPCDescription,
-        option: Preferences.Shields.enableGPC
+        toggle: $settings.isGPCEnabled
       )
       if showBlockAllCookies || FeatureList.kBlockAllCookiesToggle.enabled
         || Preferences.Privacy.blockAllCookies.value

--- a/ios/brave-ios/Sources/Brave/Migration/Migration.swift
+++ b/ios/brave-ios/Sources/Brave/Migration/Migration.swift
@@ -28,6 +28,7 @@ public class BraveProfileMigrations {
     migrateSyncPasswordsDefault()
     migrateShieldsToContentSettings()
     migrateYouTubeQualityPreference()
+    migrateGPCPreference()
   }
 
   private func migrateDefaultUserAgentPreferences() {
@@ -110,6 +111,12 @@ public class BraveProfileMigrations {
           forPath: kYouTubeAutoQualityMode
         )
       }
+    }
+  }
+
+  private func migrateGPCPreference() {
+    Preferences.DeprecatedPreferences.enableGPC.migrate { value in
+      profileController.profile.prefs.set(value, forPath: kGlobalPrivacyControlEnabled)
     }
   }
 }
@@ -344,6 +351,12 @@ extension Preferences {
     static let youtubeHighQuality = Option<String>(
       key: "general.youtube-high-quality",
       default: DeprecatedYoutubeHighQualityPreference.off.rawValue
+    )
+
+    /// A boolean value inidicating if GPC is enabled
+    public static var enableGPC = Preferences.Option<Bool>(
+      key: "shields.enable-gpc",
+      default: true
     )
   }
 

--- a/ios/brave-ios/Sources/BraveShields/ShieldPreferences.swift
+++ b/ios/brave-ios/Sources/BraveShields/ShieldPreferences.swift
@@ -132,12 +132,6 @@ extension Preferences {
       }
     }
 
-    /// A boolean value inidicating if GPC is enabled
-    public static var enableGPC = Preferences.Option<Bool>(
-      key: "shields.enable-gpc",
-      default: true
-    )
-
     /// If Shred should also shred from user's history.
     public static var shredHistoryItems = Preferences.Option<Bool>(
       key: "shields.shred-history-items",

--- a/ios/brave-ios/Tests/ClientTests/PageDataTests.swift
+++ b/ios/brave-ios/Tests/ClientTests/PageDataTests.swift
@@ -46,7 +46,8 @@ final class PageDataTests: XCTestCase {
       let mainFrameRequestTypes = await pageData.makeUserScriptTypes(
         isDeAmpEnabled: false,
         isAdBlockEnabled: true,
-        isBlockFingerprintingEnabled: true
+        isBlockFingerprintingEnabled: true,
+        isGPCEnabled: true
       )
 
       // Then
@@ -54,7 +55,7 @@ final class PageDataTests: XCTestCase {
       // NOTE: If we were to add some engines we might see additional types
       let expectedMainFrameTypes: Set<UserScriptType> = [
         .siteStateListener, .farblingProtection(etld: "example.com"),
-        .gpc(Preferences.Shields.enableGPC.value),
+        .gpc(true),
       ]
       XCTAssertEqual(mainFrameRequestTypes, expectedMainFrameTypes)
 
@@ -63,7 +64,8 @@ final class PageDataTests: XCTestCase {
       let unchangedScriptTypes = await pageData.makeUserScriptTypes(
         isDeAmpEnabled: false,
         isAdBlockEnabled: true,
-        isBlockFingerprintingEnabled: true
+        isBlockFingerprintingEnabled: true,
+        isGPCEnabled: true
       )
 
       // Then
@@ -81,11 +83,12 @@ final class PageDataTests: XCTestCase {
       let addedSubFrameFrameRequestTypes = await pageData.makeUserScriptTypes(
         isDeAmpEnabled: false,
         isAdBlockEnabled: true,
-        isBlockFingerprintingEnabled: true
+        isBlockFingerprintingEnabled: true,
+        isGPCEnabled: true
       )
       let expectedMainAndSubFrameTypes: Set<UserScriptType> = [
         .siteStateListener, .farblingProtection(etld: "example.com"),
-        .gpc(Preferences.Shields.enableGPC.value),
+        .gpc(true),
       ]
       XCTAssertEqual(expectedMainAndSubFrameTypes, addedSubFrameFrameRequestTypes)
 
@@ -102,7 +105,8 @@ final class PageDataTests: XCTestCase {
       let upgradedMainFrameRequestTypes = await pageData.makeUserScriptTypes(
         isDeAmpEnabled: false,
         isAdBlockEnabled: true,
-        isBlockFingerprintingEnabled: true
+        isBlockFingerprintingEnabled: true,
+        isGPCEnabled: true
       )
       XCTAssertEqual(upgradedMainFrameRequestTypes, unchangedScriptTypes)
 
@@ -119,7 +123,8 @@ final class PageDataTests: XCTestCase {
       let upgradedSubFrameFrameRequestTypes = await pageData.makeUserScriptTypes(
         isDeAmpEnabled: false,
         isAdBlockEnabled: true,
-        isBlockFingerprintingEnabled: true
+        isBlockFingerprintingEnabled: true,
+        isGPCEnabled: true
       )
       XCTAssertEqual(upgradedSubFrameFrameRequestTypes, unchangedScriptTypes)
 
@@ -153,7 +158,8 @@ final class PageDataTests: XCTestCase {
       let mainFrameRequestTypes = await pageData.makeUserScriptTypes(
         isDeAmpEnabled: false,
         isAdBlockEnabled: true,
-        isBlockFingerprintingEnabled: true
+        isBlockFingerprintingEnabled: true,
+        isGPCEnabled: true
       )
 
       XCTAssertTrue(

--- a/ios/browser/BUILD.gn
+++ b/ios/browser/BUILD.gn
@@ -53,6 +53,7 @@ group("browser") {
     "//brave/ios/browser/brave_origin",
     "//brave/ios/browser/brave_vpn",
     "//brave/ios/browser/brave_wallet",
+    "//brave/ios/browser/global_privacy_control",
     "//brave/ios/browser/playlist",
     "//brave/ios/browser/policy",
     "//brave/ios/browser/profile/model",

--- a/ios/browser/DEPS
+++ b/ios/browser/DEPS
@@ -11,6 +11,7 @@ include_rules += [
   "+brave/components/query_filter/browser",
   "+brave/components/brave_wallet/browser",
   "+brave/components/brave_wallet/common/buildflags",
+  "+brave/components/global_privacy_control",
   "+brave/components/p3a",
   "+ios/chrome/browser",
   "+ios/web/web_state",

--- a/ios/browser/global_privacy_control/BUILD.gn
+++ b/ios/browser/global_privacy_control/BUILD.gn
@@ -1,0 +1,17 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import("//ios/web/public/js_messaging/optimize_ts.gni")
+
+source_set("global_privacy_control") {
+  sources = [
+    "gpc_pref_names_bridge.h",
+    "gpc_pref_names_bridge.mm",
+  ]
+  deps = [
+    "//base",
+    "//brave/components/global_privacy_control",
+  ]
+}

--- a/ios/browser/global_privacy_control/gpc_pref_names_bridge.h
+++ b/ios/browser/global_privacy_control/gpc_pref_names_bridge.h
@@ -1,0 +1,17 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_IOS_BROWSER_GLOBAL_PRIVACY_CONTROL_GPC_PREF_NAMES_BRIDGE_H_
+#define BRAVE_IOS_BROWSER_GLOBAL_PRIVACY_CONTROL_GPC_PREF_NAMES_BRIDGE_H_
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+OBJC_EXPORT NSString* const kGlobalPrivacyControlEnabled;
+
+NS_ASSUME_NONNULL_END
+
+#endif  // BRAVE_IOS_BROWSER_GLOBAL_PRIVACY_CONTROL_GPC_PREF_NAMES_BRIDGE_H_

--- a/ios/browser/global_privacy_control/gpc_pref_names_bridge.mm
+++ b/ios/browser/global_privacy_control/gpc_pref_names_bridge.mm
@@ -1,0 +1,12 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/ios/browser/global_privacy_control/gpc_pref_names_bridge.h"
+
+#include "base/strings/sys_string_conversions.h"
+#include "brave/components/global_privacy_control/pref_names.h"
+
+NSString* const kGlobalPrivacyControlEnabled = base::SysUTF8ToNSString(
+    global_privacy_control::kGlobalPrivacyControlEnabled);

--- a/ios/browser/shared/prefs/BUILD.gn
+++ b/ios/browser/shared/prefs/BUILD.gn
@@ -26,6 +26,7 @@ source_set("prefs") {
     "//brave/components/constants",
     "//brave/components/de_amp/common",
     "//brave/components/debounce/core/browser",
+    "//brave/components/global_privacy_control",
     "//brave/components/l10n/common",
     "//brave/components/ntp_background_images/browser",
     "//brave/components/ntp_background_images/common",

--- a/ios/browser/shared/prefs/browser_prefs_impl.mm
+++ b/ios/browser/shared/prefs/browser_prefs_impl.mm
@@ -22,6 +22,7 @@
 #include "brave/components/de_amp/common/pref_names.h"
 #include "brave/components/debounce/core/browser/debounce_service.h"
 #include "brave/components/decentralized_dns/core/utils.h"
+#include "brave/components/global_privacy_control/pref_names.h"
 #include "brave/components/l10n/common/prefs.h"
 #include "brave/components/ntp_background_images/browser/ntp_background_images_service.h"
 #include "brave/components/ntp_background_images/common/view_counter_pref_registry.h"
@@ -86,6 +87,9 @@ void RegisterBrowserStatePrefs(user_prefs::PrefRegistrySyncable* registry) {
 #endif
 
   registry->RegisterIntegerPref(youtube::prefs::kAutoQualityMode, 0);
+
+  registry->RegisterBooleanPref(
+      global_privacy_control::kGlobalPrivacyControlEnabled, true);
 }
 
 void RegisterLocalStatePrefs(PrefRegistrySimple* registry) {


### PR DESCRIPTION
This migrates and deprecates the current GPC pref we have in the Swift side and exposes a way to fetch the profile pref from the pref service

