### PR TITLE
[iOS] Add GPC JavaScriptFeature

### DIFF
--- a/ios/browser/global_privacy_control/BUILD.gn
+++ b/ios/browser/global_privacy_control/BUILD.gn
@@ -7,11 +7,27 @@ import("//ios/web/public/js_messaging/optimize_ts.gni")
 
 source_set("global_privacy_control") {
   sources = [
+    "gpc_javascript_feature.h",
+    "gpc_javascript_feature.mm",
     "gpc_pref_names_bridge.h",
     "gpc_pref_names_bridge.mm",
   ]
   deps = [
-    "//base",
+    ":gpc_js",
     "//brave/components/global_privacy_control",
+    "//ios/chrome/browser/shared/model/profile",
+    "//ios/web/public",
+    "//ios/web/web_state/ui:wk_web_view_configuration_provider",
   ]
+  public_deps = [
+    "//base",
+    "//components/prefs",
+    "//ios/web/public/js_messaging",
+  ]
+}
+
+optimize_ts("gpc_js") {
+  visibility = [ ":global_privacy_control" ]
+
+  sources = [ "resources/gpc.ts" ]
 }

--- a/ios/browser/global_privacy_control/gpc_javascript_feature.h
+++ b/ios/browser/global_privacy_control/gpc_javascript_feature.h
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_IOS_BROWSER_GLOBAL_PRIVACY_CONTROL_GPC_JAVASCRIPT_FEATURE_H_
+#define BRAVE_IOS_BROWSER_GLOBAL_PRIVACY_CONTROL_GPC_JAVASCRIPT_FEATURE_H_
+
+#include "base/memory/raw_ptr.h"
+#include "components/prefs/pref_change_registrar.h"
+#include "ios/web/public/js_messaging/java_script_feature.h"
+
+class ProfileIOS;
+
+class GPCJavaScriptFeature : public web::JavaScriptFeature,
+                             public base::SupportsUserData::Data {
+ public:
+  ~GPCJavaScriptFeature() override;
+
+  static GPCJavaScriptFeature* FromBrowserState(
+      web::BrowserState* browser_state);
+
+  // web::JavaScriptFeature
+  std::vector<web::JavaScriptFeature::FeatureScript> GetScripts()
+      const override;
+
+ private:
+  raw_ptr<ProfileIOS> profile_;
+  PrefChangeRegistrar prefs_change_registrar_;
+
+  void GPCPrefUpdated();
+
+  explicit GPCJavaScriptFeature(ProfileIOS* profile);
+};
+
+#endif  // BRAVE_IOS_BROWSER_GLOBAL_PRIVACY_CONTROL_GPC_JAVASCRIPT_FEATURE_H_

--- a/ios/browser/global_privacy_control/gpc_javascript_feature.mm
+++ b/ios/browser/global_privacy_control/gpc_javascript_feature.mm
@@ -1,0 +1,73 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/ios/browser/global_privacy_control/gpc_javascript_feature.h"
+
+#include "brave/components/global_privacy_control/pref_names.h"
+#include "components/prefs/pref_service.h"
+#include "ios/chrome/browser/shared/model/profile/profile_ios.h"
+#include "ios/web/public/browser_state.h"
+#include "ios/web/public/js_messaging/java_script_feature.h"
+#include "ios/web/public/js_messaging/web_frame.h"
+#include "ios/web/web_state/ui/wk_web_view_configuration_provider.h"
+
+namespace {
+constexpr char kGPCJavaScriptFeatureKeyName[] = "gpc_java_script_feature";
+constexpr char kScriptName[] = "gpc";
+}  // namespace
+
+GPCJavaScriptFeature::GPCJavaScriptFeature(ProfileIOS* profile)
+    : JavaScriptFeature(web::ContentWorld::kPageContentWorld,
+                        /*feature_scripts=*/{}),
+      profile_(profile) {
+  prefs_change_registrar_.Init(profile_->GetPrefs());
+  prefs_change_registrar_.Add(
+      global_privacy_control::kGlobalPrivacyControlEnabled,
+      base::BindRepeating(&GPCJavaScriptFeature::GPCPrefUpdated,
+                          base::Unretained(this)));
+}
+
+GPCJavaScriptFeature::~GPCJavaScriptFeature() = default;
+
+// static
+GPCJavaScriptFeature* GPCJavaScriptFeature::FromBrowserState(
+    web::BrowserState* browser_state) {
+  DCHECK(browser_state);
+
+  GPCJavaScriptFeature* feature = static_cast<GPCJavaScriptFeature*>(
+      browser_state->GetUserData(kGPCJavaScriptFeatureKeyName));
+  if (!feature) {
+    feature =
+        new GPCJavaScriptFeature(ProfileIOS::FromBrowserState(browser_state));
+    browser_state->SetUserData(kGPCJavaScriptFeatureKeyName,
+                               base::WrapUnique(feature));
+  }
+  return feature;
+}
+
+void GPCJavaScriptFeature::GPCPrefUpdated() {
+  // Feature scripts must be explicitly updated after this pref changes.
+  web::WKWebViewConfigurationProvider& config_provider =
+      web::WKWebViewConfigurationProvider::FromBrowserState(profile_);
+  config_provider.UpdateScripts();
+}
+
+std::vector<web::JavaScriptFeature::FeatureScript>
+GPCJavaScriptFeature::GetScripts() const {
+  bool is_gpc_enabled = profile_->GetPrefs()->GetBoolean(
+      global_privacy_control::kGlobalPrivacyControlEnabled);
+  return {FeatureScript::CreateWithFilename(
+      kScriptName, FeatureScript::InjectionTime::kDocumentStart,
+      FeatureScript::TargetFrames::kAllFrames,
+      FeatureScript::ReinjectionBehavior::kInjectOncePerWindow,
+      base::BindRepeating(
+          [](bool is_gpc_enabled) -> FeatureScript::PlaceholderReplacements {
+            return @{
+              @"window.gCrWebPlaceholderGPCEnabled" : is_gpc_enabled ? @"true"
+                                                                     : @"false"
+            };
+          },
+          is_gpc_enabled))};
+}

--- a/ios/browser/global_privacy_control/resources/gpc.ts
+++ b/ios/browser/global_privacy_control/resources/gpc.ts
@@ -1,0 +1,11 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+Object.defineProperty(navigator, 'globalPrivacyControl', {
+  enumerable: false,
+  configurable: false,
+  writable: false,
+  value: (window as any).gCrWebPlaceholderGPCEnabled
+})

--- a/ios/browser/web/BUILD.gn
+++ b/ios/browser/web/BUILD.gn
@@ -29,6 +29,7 @@ source_set("web") {
     "//brave/ios/browser/brave_ads",
     "//brave/ios/browser/brave_search",
     "//brave/ios/browser/component_updater:zxcvbn_data_component_installer",
+    "//brave/ios/browser/global_privacy_control",
     "//brave/ios/browser/ui/web_view:features",
     "//brave/ios/browser/web/de_amp",
     "//brave/ios/browser/web/document_fetch",

--- a/ios/browser/web/brave_web_client.mm
+++ b/ios/browser/web/brave_web_client.mm
@@ -21,6 +21,7 @@
 #include "brave/ios/browser/brave_ads/ads_media_reporting_javascript_feature.h"
 #include "brave/ios/browser/brave_search/brave_search_ad_results_javascript_feature.h"
 #include "brave/ios/browser/brave_search/brave_search_make_default_javascript_feature.h"
+#include "brave/ios/browser/global_privacy_control/gpc_javascript_feature.h"
 #include "brave/ios/browser/ui/web_view/features.h"
 #include "brave/ios/browser/web/brave_web_main_parts.h"
 #include "brave/ios/browser/web/de_amp/de_amp_javascript_feature.h"
@@ -148,6 +149,7 @@ std::vector<web::JavaScriptFeature*> BraveWebClient::GetJavaScriptFeatures(
     features.push_back(DeAmpJavaScriptFeature::GetInstance());
     features.push_back(DocumentFetchJavaScriptFeature::GetInstance());
     features.push_back(ForcePasteJavaScriptFeature::GetInstance());
+    features.push_back(GPCJavaScriptFeature::FromBrowserState(browser_state));
     features.push_back(
         MediaBackgroundingJavaScriptFeature::FromBrowserState(browser_state));
     features.push_back(NightModeJavaScriptFeature::GetInstance());


### PR DESCRIPTION
This adds a JavaScriptFeature that adds `navigator.globalPrivacyControl` to the page when the `UseProfileWebViewConfiguration` is enabled.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/55175

### Test
- Enable the `UseProfileWebViewConfiguration` feature flag
- Verify `navigator.globalPrivacyControl` is true on the page (through any test page or Safari web inspector)
- Go to settings > shields & privacy and disable Global Privacy Control 
- Refresh the page
- Verify `navigator.globalPrivacyControl` is false on the page (through any test page or Safari web inspector)

<details>
<summary>Personal Test Page</summary>

```
<!DOCTYPE html>
<html>
<head><title>GPC Check</title></head>
<body>
<div id="output"></div>
<script>
  const output = document.getElementById('output');
  const total = 100;
  const interval = 2000 / total;
  let attempt = 0;

  function check() {
    attempt++;
    const p = document.createElement('p');
    const ts = performance.now().toFixed(2);
    p.textContent = 'Attempt ' + attempt + ' [' + ts + 'ms]: navigator.globalPrivacyControl = ' + navigator.globalPrivacyControl;
    output.appendChild(p);
    if (attempt < total) setTimeout(check, interval);
  }

  check();
</script>
</body>
</html>
```

</details>