### PR TITLE
[iOS] Remove Recent Searches when Shredding if shredding history

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/TabManager.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/TabManager.swift
@@ -999,6 +999,7 @@ class TabManager: NSObject {
 
     if Preferences.Shields.shredHistoryItems.value {
       RecentlyClosed.remove(baseDomains: baseDomains)
+      RecentSearch.remove(baseDomains: baseDomains)
     }
 
     for url in urls {

--- a/ios/brave-ios/Sources/Data/models/RecentSearches.swift
+++ b/ios/brave-ios/Sources/Data/models/RecentSearches.swift
@@ -128,7 +128,7 @@ final public class RecentSearch: NSManagedObject, CRUD {
         guard let websiteUrlString = recentSearchItem.websiteUrl,
           let url = URL(string: websiteUrlString),
           let baseDomain = url.baseDomain,
-          baseDomains.contains(where: { $0 == baseDomain })
+          baseDomains.contains(baseDomain)
         else {
           // eTLD of the url does not match
           continue

--- a/ios/brave-ios/Sources/Data/models/RecentSearches.swift
+++ b/ios/brave-ios/Sources/Data/models/RecentSearches.swift
@@ -108,6 +108,37 @@ final public class RecentSearch: NSManagedObject, CRUD {
     )
   }
 
+  /// Removes the `RecentSearch` objects whose url belongs to one of the `baseDomains` provided.
+  public class func remove(baseDomains: Set<String>) {
+    DataController.perform { context in
+      // Filter down CoreData db as much as we can
+      let predicates = baseDomains.map { baseDomain in
+        NSPredicate(format: "websiteUrl CONTAINS[c] %@", baseDomain)
+      }
+      let predicate = NSCompoundPredicate(orPredicateWithSubpredicates: predicates)
+      guard let itemsContainingBaseDomains = self.all(where: predicate, context: context) else {
+        return
+      }
+      // Above we filter for RecentSearch items where the websiteUrl contains
+      // the baseDomain, but this does not verify it's the actual domain (ex.
+      // could be in a query param). Verify each item's eTLD matches before
+      // we remove from RecentSearch.
+      for recentSearchItem in itemsContainingBaseDomains {
+        // validate baseDomain matches
+        guard let websiteUrlString = recentSearchItem.websiteUrl,
+          let url = URL(string: websiteUrlString),
+          let baseDomain = url.baseDomain,
+          baseDomains.contains(where: { $0 == baseDomain })
+        else {
+          // eTLD of the url does not match
+          continue
+        }
+        // eTLD matches
+        recentSearchItem.delete(context: .existing(context))
+      }
+    }
+  }
+
   public static func removeAll() {
     RecentSearch.deleteAll()
   }

--- a/ios/brave-ios/Sources/Data/models/RecentlyClosed.swift
+++ b/ios/brave-ios/Sources/Data/models/RecentlyClosed.swift
@@ -82,7 +82,7 @@ public final class RecentlyClosed: NSManagedObject, CRUD {
         // validate baseDomain matches
         guard let url = URL(string: recentlyClosedTabItem.url),
           let baseDomain = url.baseDomain,
-          baseDomains.contains(where: { $0 == baseDomain })
+          baseDomains.contains(baseDomain)
         else {
           // eTLD of the url does not match
           continue


### PR DESCRIPTION

Resolves https://github.com/brave/brave-browser/issues/55148

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

### Testplan

1. In Settings > Search Engines, enable `Show Recent Searches`
2. In Settings > Shields & Privacy > Shred, disable `Shred Removes History`
3. Enter a search query in the omnibox
4. Tap on a search engine button in the quick search bar (ex. Duck Duck Go)
5. Tap again on omnibox, you should see a listing under `Recent Search` for your query tying it to a specific search engine. ex. `Brave on duckduckgo.com`
6. On the search engine site, shred site data
7. Tap omnibox, you should still see the recent search listed.
8. In Settings > Shields & Privacy > Shred, enable `Shred Removes History`
9. On the search engine site, shred site data
10. Tap omnibox, verify the Recent Search is removed / not displayed.