### PR TITLE
Uplift of #36076 to 1.91.x: [Brave Origin] Add switch to skip startup dialog on Linux

### DIFF
--- a/browser/ui/views/brave_origin/BUILD.gn
+++ b/browser/ui/views/brave_origin/BUILD.gn
@@ -18,6 +18,7 @@ source_set("brave_origin") {
     "//brave/brave_domains",
     "//brave/browser/ui/webui/brave_origin_startup",
     "//brave/components/brave_origin:pref_names",
+    "//brave/components/brave_origin:switches",
     "//brave/components/brave_origin/buildflags",
     "//brave/components/resources:strings_grit",
     "//brave/components/skus/browser",
@@ -70,7 +71,9 @@ source_set("unit_tests") {
   deps = [
     ":brave_origin",
     "//base",
+    "//base/test:test_support",
     "//brave/components/brave_origin:pref_names",
+    "//brave/components/brave_origin:switches",
     "//brave/components/skus/browser",
     "//components/prefs:test_support",
     "//testing/gtest",

--- a/browser/ui/views/brave_origin/brave_origin_startup_view.cc
+++ b/browser/ui/views/brave_origin/brave_origin_startup_view.cc
@@ -36,6 +36,10 @@
 #include "url/gurl.h"
 #include "url/url_constants.h"
 
+#if BUILDFLAG(IS_LINUX)
+#include "brave/components/brave_origin/switches.h"
+#endif
+
 namespace {
 
 constexpr int kDialogWidth = 540;
@@ -85,6 +89,12 @@ bool BraveOriginStartupView::ShouldShowDialog(PrefService* local_state) {
   }
 
 #if BUILDFLAG(IS_LINUX)
+  if (base::CommandLine::ForCurrentProcess()->HasSwitch(
+          brave_origin::switches::kSkipOriginStartupDialog)) {
+    // Persist acceptance so future launches without the switch also skip
+    // the dialog.
+    local_state->SetBoolean(brave_origin::kOriginFreeTierAccepted, true);
+  }
   if (local_state->GetBoolean(brave_origin::kOriginFreeTierAccepted)) {
     return false;
   }

--- a/browser/ui/views/brave_origin/brave_origin_startup_view_unittest.cc
+++ b/browser/ui/views/brave_origin/brave_origin_startup_view_unittest.cc
@@ -18,6 +18,11 @@
 #include "components/prefs/testing_pref_service.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
+#if BUILDFLAG(IS_LINUX)
+#include "base/test/scoped_command_line.h"
+#include "brave/components/brave_origin/switches.h"
+#endif
+
 class BraveOriginStartupViewTest : public testing::Test {
  public:
   void SetUp() override {
@@ -138,6 +143,18 @@ TEST_F(BraveOriginStartupViewTest, ShouldShowDialogWhenItemsDictMissing) {
   SetSkuCredentials("production", R"({"credentials": {"not_items": "value"}})");
   EXPECT_TRUE(BraveOriginStartupView::ShouldShowDialog(&local_state_));
 }
+
+#if BUILDFLAG(IS_LINUX)
+TEST_F(BraveOriginStartupViewTest,
+       ShouldNotShowDialogWhenSkipSwitchPresentOnLinux) {
+  base::test::ScopedCommandLine scoped_cl;
+  scoped_cl.GetProcessCommandLine()->AppendSwitch(
+      brave_origin::switches::kSkipOriginStartupDialog);
+  EXPECT_FALSE(BraveOriginStartupView::ShouldShowDialog(&local_state_));
+  // Switch persists acceptance so future launches without it also skip.
+  EXPECT_TRUE(local_state_.GetBoolean(brave_origin::kOriginFreeTierAccepted));
+}
+#endif  // BUILDFLAG(IS_LINUX)
 
 // --- SetShouldShowDialogForTesting tests ---
 

--- a/components/brave_origin/BUILD.gn
+++ b/components/brave_origin/BUILD.gn
@@ -27,6 +27,10 @@ source_set("pref_names") {
   ]
 }
 
+source_set("switches") {
+  sources = [ "switches.h" ]
+}
+
 static_library("brave_origin") {
   sources = [
     "brave_origin_policy_info.cc",

--- a/components/brave_origin/switches.h
+++ b/components/brave_origin/switches.h
@@ -1,0 +1,17 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_ORIGIN_SWITCHES_H_
+#define BRAVE_COMPONENTS_BRAVE_ORIGIN_SWITCHES_H_
+
+namespace brave_origin::switches {
+
+// Skips the Brave Origin startup dialog. Only honored on Linux, where
+// Brave Origin can be used without a purchase.
+inline constexpr char kSkipOriginStartupDialog[] = "skip-origin-startup-dialog";
+
+}  // namespace brave_origin::switches
+
+#endif  // BRAVE_COMPONENTS_BRAVE_ORIGIN_SWITCHES_H_


### PR DESCRIPTION
Uplift of #36076
Resolves https://github.com/brave/brave-browser/issues/55151

## Included PRs
- #36076 - [Brave Origin] Add switch to skip startup dialog on Linux

Pre-approval checklist:
- [ ] You have tested your change on Nightly.
- [ ] This contains text which needs to be translated.
    - [ ] There are more than 7 days before the release.
    - [ ] I've notified folks in #l10n on Slack that translations are needed.
- [x] The PR milestones match the branch they are landing to.


Pre-merge checklist:
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.

Post-merge checklist:
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.