### PR TITLE
[Wallet]: Update Create Account Modal UI

### DIFF
--- a/components/brave_wallet_ui/components/desktop/popup-modals/add-account-modal/create-account-modal.tsx
+++ b/components/brave_wallet_ui/components/desktop/popup-modals/add-account-modal/create-account-modal.tsx
@@ -6,7 +6,7 @@
 import { assert } from 'chrome://resources/js/assert.js'
 import * as React from 'react'
 import { useHistory, useLocation, useParams } from 'react-router'
-import Input, { InputEventDetail } from '@brave/leo/react/input'
+import { InputEventDetail } from '@brave/leo/react/input'
 import Button from '@brave/leo/react/button'
 
 // utils
@@ -24,12 +24,8 @@ import {
 } from '../../../../constants/types'
 
 // components
-import { DividerLine } from '../../../../components/extension/divider/index'
 import PopupModal from '..'
 import { SelectAccountType } from './select-account-type'
-
-// style
-import { SubmitButtonWrapper, CreateAccountStyledWrapper } from './style'
 
 // selectors
 import { WalletSelectors } from '../../../../common/selectors'
@@ -43,6 +39,17 @@ import {
   useAddAccountMutation,
   useGetVisibleNetworksQuery,
 } from '../../../../common/slices/api.slice'
+
+// Styles
+import {
+  CreateAccountContent,
+  CreateAccountWrapper,
+  Input,
+  NetworkIcon,
+  NetworkName,
+  NetworkDescription,
+} from './style'
+import { Row } from '../../../shared/style'
 
 interface Params {
   accountTypeName: string
@@ -149,6 +156,10 @@ export const CreateAccountModal = () => {
     history.push(WalletRoutes.Accounts)
   }, [history])
 
+  const onClickBack = React.useCallback(() => {
+    history.goBack()
+  }, [history])
+
   const handleAccountNameChanged = React.useCallback(
     (detail: InputEventDetail) => {
       setFullLengthAccountName(detail.value)
@@ -211,11 +222,21 @@ export const CreateAccountModal = () => {
     <PopupModal
       title={modalTitle}
       onClose={onClickClose}
+      onBack={selectedAccountType ? onClickBack : undefined}
     >
       {selectedAccountType && (
-        <>
-          <DividerLine />
-          <CreateAccountStyledWrapper>
+        <CreateAccountWrapper width='100%'>
+          <CreateAccountContent
+            width='100%'
+            gap='16px'
+          >
+            <NetworkIcon src={selectedAccountType.icon} />
+            <NetworkName textColor='primary'>
+              {selectedAccountType.name}
+            </NetworkName>
+            <NetworkDescription textColor='tertiary'>
+              {selectedAccountType.description}
+            </NetworkDescription>
             <Input
               value={accountName}
               placeholder={getLocale('braveWalletAddAccountPlaceholder')}
@@ -224,23 +245,26 @@ export const CreateAccountModal = () => {
               showErrors={isDisabled}
               maxlength={BraveWallet.ACCOUNT_NAME_MAX_CHARACTER_LENGTH}
             >
-              {
-                // Label
-                getLocale('braveWalletAddAccountPlaceholder')
-              }
+              {getLocale('braveWalletAddAccountPlaceholder')}
             </Input>
+          </CreateAccountContent>
 
-            <SubmitButtonWrapper>
-              <Button
-                onClick={onClickCreateAccount}
-                isDisabled={isDisabled}
-                kind='filled'
-              >
-                {getLocale('braveWalletCreateAccountButton')}
-              </Button>
-            </SubmitButtonWrapper>
-          </CreateAccountStyledWrapper>
-        </>
+          <Row gap='16px'>
+            <Button
+              onClick={onClickClose}
+              kind='outline'
+            >
+              {getLocale('braveWalletButtonCancel')}
+            </Button>
+            <Button
+              onClick={onClickCreateAccount}
+              isDisabled={isDisabled}
+              kind='filled'
+            >
+              {getLocale('braveWalletCreateAccountButton')}
+            </Button>
+          </Row>
+        </CreateAccountWrapper>
       )}
 
       {!selectedAccountType && (

--- a/components/brave_wallet_ui/components/desktop/popup-modals/add-account-modal/style.ts
+++ b/components/brave_wallet_ui/components/desktop/popup-modals/add-account-modal/style.ts
@@ -5,9 +5,15 @@
 
 import styled from 'styled-components'
 import * as leo from '@brave/leo/tokens/css/variables'
+import LeoInput from '@brave/leo/react/input'
 import AlertReact from '@brave/leo/react/alert'
 
+// Assets
 import InfoLogo from '../../../../assets/svg-icons/info-icon.svg'
+
+// Shared Styles
+import { Column, Text } from '../../../shared/style'
+import { layoutPanelWidth } from '../../wallet-page-wrapper/wallet-page-wrapper.style'
 
 export const Alert = styled(AlertReact)`
   margin-bottom: 15px;
@@ -108,6 +114,35 @@ export const ErrorText = styled.span`
   color: ${leo.color.systemfeedback.errorText};
 `
 
-export const SubmitButtonWrapper = styled.div`
-  display: flex;
+export const CreateAccountWrapper = styled(Column)`
+  gap: 32px;
+  padding: 12px 32px 32px 32px;
+  @media screen and (max-width: ${layoutPanelWidth}px) {
+    gap: 20px;
+    padding: 0px 20px 20px 20px;
+  }
+`
+
+export const CreateAccountContent = styled(Column)`
+  max-width: 440px;
+`
+
+export const Input = styled(LeoInput)`
+  width: 100%;
+  color: ${leo.color.text.primary};
+`
+
+export const NetworkIcon = styled.img`
+  width: 45px;
+  height: 45px;
+`
+
+export const NetworkName = styled(Text)`
+  font: ${leo.font.default.semibold};
+  letter-spacing: ${leo.typography.letterSpacing.default};
+`
+
+export const NetworkDescription = styled(Text)`
+  font: ${leo.font.default.regular};
+  letter-spacing: ${leo.typography.letterSpacing.default};
 `

--- a/components/brave_wallet_ui/components/desktop/popup-modals/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/popup-modals/index.tsx
@@ -3,6 +3,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // you can obtain one at https://mozilla.org/MPL/2.0/.
 import * as React from 'react'
+import Button from '@brave/leo/react/button'
+import Icon from '@brave/leo/react/icon'
 
 // Styled Components
 import {
@@ -11,11 +13,11 @@ import {
   Title,
   HeaderButton,
   CloseIcon,
-  BackIcon,
   Modal,
   Divider,
   ModalContent,
 } from './style'
+import { Row } from '../../shared/style'
 
 export interface Props {
   children?: React.ReactNode
@@ -76,12 +78,22 @@ export const PopupModal = React.forwardRef<HTMLDivElement, Props>(
               headerPaddingHorizontal={headerPaddingHorizontal}
               headerPaddingVertical={headerPaddingVertical}
             >
-              {onBack && (
-                <HeaderButton onClick={onBack}>
-                  <BackIcon />
-                </HeaderButton>
-              )}
-              <Title>{title}</Title>
+              <Row
+                width='unset'
+                gap='16px'
+              >
+                {onBack && (
+                  <Button
+                    onClick={onBack}
+                    kind='outline'
+                    size='small'
+                    fab
+                  >
+                    <Icon name='arrow-left' />
+                  </Button>
+                )}
+                <Title>{title}</Title>
+              </Row>
               <HeaderButton onClick={onClose}>
                 <CloseIcon />
               </HeaderButton>

--- a/components/brave_wallet_ui/components/desktop/popup-modals/style.ts
+++ b/components/brave_wallet_ui/components/desktop/popup-modals/style.ts
@@ -100,13 +100,6 @@ export const CloseIcon = styled(Icon).attrs({
   color: ${leo.color.icon.default};
 `
 
-export const BackIcon = styled(Icon).attrs({
-  name: 'arrow-left',
-})`
-  --leo-icon-size: 24px;
-  color: ${leo.color.icon.default};
-`
-
 export const Divider = styled.div`
   display: flex;
   width: 100%;


### PR DESCRIPTION
## Description 

Updates the `Create Account Modal` UI to the new figma designs

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/55180>

<img width="667" height="509" alt="Screenshot 21" src="https://github.com/user-attachments/assets/be78b924-df46-46fe-bf1e-f915f1ba3de8" /> | <img width="771" height="591" alt="Screenshot 23" src="https://github.com/user-attachments/assets/10b42770-1b48-49fc-ac0b-7d96cf9e4461" />
--|--

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

## Test Plan:
1. Open the `Wallet` and navigate to the `Accounts` page
2. Click on the `Create Account` button
3. Select an account type and you should see the new UI
4. Should show the account type `Icon` along with the `description`
5. Test this for all account types

https://github.com/user-attachments/assets/c4760e36-e6a9-4c11-ade7-669175d3fbff