### PR TITLE
[brockit] Simplify `Patchfile` determination of underlying source

### DIFF
--- a/tools/cr/brockit.py
+++ b/tools/cr/brockit.py
@@ -199,7 +199,7 @@ from datetime import datetime
 import json
 import logging
 import os
-from pathlib import Path, PurePath
+from pathlib import Path
 import pickle
 import platform
 import re
@@ -320,9 +320,9 @@ def _is_gh_cli_logged_in():
     return False
 
 
-def _get_apply_patches_list():
+def _get_apply_patches_list() -> dict[Repository, list[Patchfile]] | None:
     """Retrieves the list of patches to be applied by running
-    `npm run apply_patches`
+    `npm run apply_patches`, grouped by repository.
     """
 
     try:
@@ -334,7 +334,19 @@ def _get_apply_patches_list():
         match = re.search(r'\[\s*{.*?}\s*\]', e.stdout, re.DOTALL)
         if match is None:
             return None
-        return json.loads(match.group(0))
+        entries = json.loads(match.group(0))
+        patch_paths = [Path(entry['patchPath']) for entry in entries]
+        patch_stats = repository.brave.get_patch_stats(*patch_paths)
+        patch_files: dict[Repository, list[Patchfile]] = {}
+        for patch_path in patch_paths:
+            sources = patch_stats[patch_path]
+            if len(sources) != 1:
+                raise ValueError(
+                    f'Expected exactly one source for {patch_path}, '
+                    f'got {sources}.') from e
+            patchfile = Patchfile(path=patch_path, source=sources[0])
+            patch_files.setdefault(patchfile.repository, []).append(patchfile)
+        return patch_files
 
     return None
 
@@ -354,7 +366,7 @@ class ApplyPatchesRecord:
     patches_to_deleted_files: list[Patchfile] = field(default_factory=list)
 
     # A list of files that require manual conflict resolution before continuing.
-    files_with_conflicts: list[str] = field(default_factory=list)
+    files_with_conflicts: list[Path] = field(default_factory=list)
 
     # A list of patches that fail entirely when running apply with `--3way`.
     broken_patches: list[Patchfile] = field(default_factory=list)
@@ -382,12 +394,12 @@ class ApplyPatchesRecord:
                 If set to True, deleted files will be ignored, and not staged.
         """
         for _, patches in self.patch_files.items():
-            for patch in patches:
-                if not Path(patch.path).exists():
+            for patchfile in patches:
+                if not patchfile.path.exists():
                     # Skip deleted files.
                     continue
 
-                repository.brave.run_git('add', patch.path)
+                repository.brave.run_git('add', patchfile.path)
 
 
 @dataclass(frozen=True)
@@ -960,67 +972,41 @@ class Upgrade(Versioned):
         When running brockit in a vscode terminal, this method will open any
         files that need attention in the editor session.
         """
-        # A dictionary that holds a list for all patch files affected, by
-        # repository.
-        patch_files = {}
-
-        # This is a flat of list of patches that cannot be applied due to their
+        # This is a flat list of patches that cannot be applied due to their
         # source file being deleted.
-        patches_to_deleted_files = []
+        patches_to_deleted_files: list[Patchfile] = []
 
         # A list of files that require manual conflict resolution before
         # continuing.
-        files_with_conflicts = []
+        files_with_conflicts: list[Path] = []
 
         # These are patches that fail entirely when running apply with `--3way`.
-        broken_patches = []
+        broken_patches: list[Patchfile] = []
 
-        if patch_files:
-            raise NotImplementedError(
-                'unreachable: 3way apply should happen only once.')
-
-        # the raw list of patches that failed to apply.
-        patch_failures = _get_apply_patches_list()
-        if patch_failures is None:
-            raise ValueError(
-                'Apply patches failed to provide a list of patches.')
-
-        for entry in patch_failures:
-            patch = Patchfile(path=PurePath(entry['patchPath']),
-                              provided_source=entry.get('path'))
-
-            if entry['reason'] == 'SRC_REMOVED':
-                # Skip patches that can't apply as the source is gone.
-                patches_to_deleted_files.append(patch)
-                continue
-
-            # Grouping patch files by their repositories, so to allow us to
-            # iterate through them, applying them in their repo paths.
-            patch_files.setdefault(patch.repository, []).append(patch)
+        # A list of all patchfiles that failed to apply, grouped by repository.
+        patch_files = _get_apply_patches_list()
+        if patch_files is None:
+            raise ValueError('Apply patches had no failed patches.')
 
         if patch_files:
             terminal.log_task(
                 '[bold]Reapplying patch files with --3way:\n[/]%s' %
                 '\n'.join(f'    * {file}' for file in [
-                    patch.path for patch_list in patch_files.values()
-                    for patch in patch_list
+                    patchfile.path for patch_list in patch_files.values()
+                    for patchfile in patch_list
                 ]))
 
-        vscode_files = []
+        vscode_files: list[Path] = []
         for repo, patches in patch_files.items():
-            for patch in patches:
-                apply_result = patch.apply()
-                if apply_result.patch:
-                    # Let's use the updated patchfile instance.
-                    patch = apply_result.patch
+            for patchfile in patches:
+                status: Patchfile.ApplyStatus = patchfile.apply()
 
-                if apply_result.status == Patchfile.ApplyStatus.CONFLICT:
-                    files_with_conflicts.append(
-                        patch.source_from_brave().as_posix())
-                elif apply_result.status == Patchfile.ApplyStatus.BROKEN:
-                    broken_patches.append(patch)
-                elif apply_result.status == Patchfile.ApplyStatus.DELETED:
-                    patches_to_deleted_files.append(patch)
+                if status == Patchfile.ApplyStatus.CONFLICT:
+                    files_with_conflicts.append(patchfile.source_from_brave())
+                elif status == Patchfile.ApplyStatus.BROKEN:
+                    broken_patches.append(patchfile)
+                elif status == Patchfile.ApplyStatus.DELETED:
+                    patches_to_deleted_files.append(patchfile)
 
         for repo, patches in patch_files.items():
             # Resetting any staged states from apply patches as that can cause
@@ -1039,33 +1025,34 @@ class Upgrade(Versioned):
             # This set will hold the information about the deleted patches
             # in a way that they can be grouped around the chang that caused
             # their removal.
-            deletion_report = {}
+            deletion_report: dict[str, dict[Patchfile,
+                                            Patchfile.SourceStatus]] = {}
 
-            for patch in patches_to_deleted_files:
-                # Make sure we have an correct file source for the patch.
-                patch = patch.fetch_source_from_git()
+            for patchfile in patches_to_deleted_files:
                 # Finding the culptrit commit hash.
-                commit = patch.get_last_commit_for_source()
+                commit = patchfile.get_last_commit_for_source()
                 deletion_report.setdefault(
                     commit,
-                    {})[patch] = patch.get_source_removal_status(commit)
+                    {})[patchfile] = patchfile.get_source_removal_status(
+                        commit)
 
             for commit, patches in deletion_report.items():
-                for patch, status in patches.items():
+                for patchfile, status in patches.items():
                     if status.status == 'D':
                         console.log(
-                            Padding(f'✘ {patch.source()} [red bold](deleted)',
-                                    (0, 4)))
-                        vscode_files.append(patch.path)
+                            Padding(
+                                f'✘ {patchfile.source} [red bold](deleted)',
+                                (0, 4)))
+                        vscode_files.append(patchfile.path)
                     elif status.status == 'R':
-                        renamed_to = patch.repository.from_brave(
-                        ) / status.renamed_to
+                        renamed_to = Path(patchfile.repository.from_brave() /
+                                          status.renamed_to)
                         console.log(
                             Padding(
-                                f'✘ {patch.source_from_brave()}\n    '
+                                f'✘ {patchfile.source_from_brave()}\n    '
                                 f'([yellow bold]renamed to[/] {renamed_to})',
                                 (0, 4)))
-                        vscode_files += [patch.path, renamed_to]
+                        vscode_files += [patchfile.path, renamed_to]
 
             # Printing the commmit message for the grouped changes.
             console.log(
@@ -1078,10 +1065,10 @@ class Upgrade(Versioned):
                 '[bold]Broken patches that fail to apply entirely '
                 f'{ACTION_NEEDED_DECORATOR}:[/]')
 
-            for patch in broken_patches:
-                source = patch.source_from_brave()
-                console.log(Padding(f'✘ {patch.path} ➜ {source}', (0, 4)))
-                vscode_files += [patch.path, source]
+            for patchfile in broken_patches:
+                source = patchfile.source_from_brave()
+                console.log(Padding(f'✘ {patchfile.path} ➜ {source}', (0, 4)))
+                vscode_files += [patchfile.path, source]
 
         if files_with_conflicts:
             vscode_files += files_with_conflicts
@@ -1180,7 +1167,7 @@ class Upgrade(Versioned):
         for patch in modified_patches:
             hunks_before = count_hunks(repository.brave.read_file(patch))
             hunks_after = count_hunks(
-                Path(repository.brave.path / patch).read_text())
+                (repository.brave.path / patch).read_text())
             if hunks_before != hunks_after:
                 patches_with_hunk_changes.append(
                     (patch, hunks_before, hunks_after))
@@ -1797,7 +1784,7 @@ class Rebase(Task):
         return "Rebasing current branch..."
 
     @staticmethod
-    def discard_regen_changes_from_rebase_plan(todo_file: PurePath):
+    def discard_regen_changes_from_rebase_plan(todo_file: Path):
         """Removes regen changes from the rebase plan.
 
     This function removes all lines that contain the string `Update patches`
@@ -1814,7 +1801,7 @@ class Rebase(Task):
                     file.write(line)
 
     @staticmethod
-    def recommit_in_rebase_plan(todo_file: PurePath):
+    def recommit_in_rebase_plan(todo_file: Path):
         """Recommits the first commit in the rebase plan.
 
     This function replaces the first `pick` in the rebase plan with `edit`,
@@ -1828,7 +1815,7 @@ class Rebase(Task):
             file.write(contents)
 
     @staticmethod
-    def squash_minor_bumps_from_rebase_plan(todo_file: PurePath):
+    def squash_minor_bumps_from_rebase_plan(todo_file: Path):
         """Squashes minor bumps from the rebase plan.
 
     This function groups all commmit lines that start with "Update from
@@ -1944,7 +1931,7 @@ class Rebase(Task):
 
 
     @staticmethod
-    def fix_squash_commit_messages(todo_file: PurePath):
+    def fix_squash_commit_messages(todo_file: Path):
         """Fixes the commit messages during rebase squash.
 
     This function handles rebase squashes to correct the commit messages. It
@@ -2460,14 +2447,13 @@ if __name__ == '__main__':
         # Special flags used to carry out some of the rebase tasks fed by git
         # during rebase --interactive mode.
         if '--internal-rebase-remove-regen-changes' in sys.argv:
-            Rebase.discard_regen_changes_from_rebase_plan(
-                PurePath(sys.argv[-1]))
+            Rebase.discard_regen_changes_from_rebase_plan(Path(sys.argv[-1]))
         if '--internal-rebase-recommit' in sys.argv:
-            Rebase.recommit_in_rebase_plan(PurePath(sys.argv[-1]))
+            Rebase.recommit_in_rebase_plan(Path(sys.argv[-1]))
         if '--internal-rebase-squash-minor-bumps' in sys.argv:
-            Rebase.squash_minor_bumps_from_rebase_plan(PurePath(sys.argv[-1]))
+            Rebase.squash_minor_bumps_from_rebase_plan(Path(sys.argv[-1]))
         if '--internal-rebase-squash-commit-message' in sys.argv:
-            Rebase.fix_squash_commit_messages(PurePath(sys.argv[-1]))
+            Rebase.fix_squash_commit_messages(Path(sys.argv[-1]))
         sys.exit(0)
 
     sys.exit(main())

--- a/tools/cr/brockit_test.py
+++ b/tools/cr/brockit_test.py
@@ -188,20 +188,23 @@ class BrockitTest(unittest.TestCase):
                     brockit.Patchfile(path=self.fake_chromium_src.
                                       get_patchfile_path_for_source(
                                           self.fake_chromium_src.chromium,
-                                          test_file_chromium))
+                                          test_file_chromium),
+                                      source=test_file_chromium)
                 ],
                 self.fake_chromium_src.chromium / 'v8': [
                     brockit.Patchfile(path=self.fake_chromium_src.
                                       get_patchfile_path_for_source(
                                           self.fake_chromium_src.chromium /
-                                          'v8', test_file_v8))
+                                          'v8', test_file_v8),
+                                      source=test_file_v8)
                 ],
                 self.fake_chromium_src.chromium / 'third_party/test1': [
-                    brockit.Patchfile(
-                        path=self.fake_chromium_src.
-                        get_patchfile_path_for_source(
-                            self.fake_chromium_src.chromium /
-                            'third_party/test1', test_file_third_party))
+                    brockit.Patchfile(path=self.fake_chromium_src.
+                                      get_patchfile_path_for_source(
+                                          self.fake_chromium_src.chromium /
+                                          'third_party/test1',
+                                          test_file_third_party),
+                                      source=test_file_third_party)
                 ],
             })
 

--- a/tools/cr/patchfile.py
+++ b/tools/cr/patchfile.py
@@ -3,13 +3,13 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, field
 from enum import Enum, auto
 import logging
-from pathlib import PurePath, Path
+from pathlib import Path
 import re
 import subprocess
-from typing import Optional, NamedTuple
+from typing import Optional
 
 from repository import Repository
 import repository
@@ -26,16 +26,11 @@ class Patchfile:
 
     # A patch's path and file name, from `patchPath`.
     # e.g. "patchPath":"patches/build-android-gyp-dex.py.patch"
-    path: PurePath
+    path: Path
 
-    # This field holds the name of the source file as provided by
-    # `update_patches`, which is not a primary source.
-    # e.g. "path":"build/android/gyp/dex.py"
-    provided_source: Optional[str] = field(default=None)
-
-    # This field holds the most reliable resolution to the source file name,
-    # as its value is assigned from a git operation.
-    source_from_git: Optional[str] = field(default=None)
+    # The source file this patch targets, relative to the patch's repository.
+    # e.g. "build/android/gyp/dex.py"
+    source: Path
 
     # The repository the patch file is targeting to patch.
     repository: Repository = field(init=False)
@@ -43,17 +38,6 @@ class Patchfile:
     def __post_init__(self):
         object.__setattr__(self, 'repository',
                            self.get_repository_from_patch_name())
-
-        if (not self.repository.is_chromium and self.provided_source
-                and self.provided_source.startswith(
-                    self.repository.relative_to_chromium.as_posix())):
-            # The report produced by `apply_patches` provides the source as a
-            # full path relative to chromium's src/ directory, therefore it is
-            # necessary to strip the repository path from the source path.
-            object.__setattr__(
-                self, 'provided_source',
-                PurePath(self.provided_source).relative_to(
-                    self.repository.relative_to_chromium).as_posix())
 
     def get_repository_from_patch_name(self) -> Repository:
         """Gets the repository for the patch file.
@@ -86,15 +70,6 @@ class Patchfile:
         # The patch failed as broken.
         BROKEN = auto()
 
-    class ApplyResult(NamedTuple):
-        """The result of applying the patch.
-        """
-        # The status of the patch operation
-        status: "ApplyStatus"
-
-        # A copy of the patch file data, with updated information.
-        patch: Optional["Patchfile"]
-
     @dataclass
     class SourceStatus:
         """The status of the source file in a given commit.
@@ -122,66 +97,27 @@ class Patchfile:
         """
         return self.path.name[:-len(".patch")].replace('-', '/')
 
-    def source(self) -> PurePath:
-        """The source file name for the patch file.
-
-        Tries to use the most reliable source file name, going from git, to the
-        one provide by `apply_patches`, to finally deducing from the name.
-        """
-        if self.source_from_git is not None:
-            return self.source_from_git
-        if self.provided_source is not None:
-            return self.provided_source
-        return self.source_name_from_patch_naming()
-
-    def source_from_brave(self) -> PurePath:
+    def source_from_brave(self) -> Path:
         """The source file path relative to the `brave/` directory.
         """
-        return self.repository.from_brave() / self.source()
+        return self.repository.from_brave() / self.source
 
-    def path_from_repo(self) -> PurePath:
+    def path_from_repo(self) -> Path:
         """The patch path relative to the repository source belongs.
         """
         return self.repository.to_brave() / self.path
 
-    def apply(self) -> ApplyResult:
+    def apply(self) -> ApplyStatus:
         """Applies the patch file with `git apply --3way`.
-
-        This function applies the patch file with `git apply --3way` to the
-        repository, and it returns the status of the operation.
-
-        Returns:
-            The result of the patch application, and an updated patch instance
-            with the source file name, if any is provided by git.
         """
-
         try:
             self.repository.run_git('apply', '--3way', '--ignore-space-change',
                                     '--ignore-whitespace',
                                     self.path_from_repo().as_posix())
-            return self.ApplyResult(status=self.ApplyStatus.CLEAN, patch=None)
+            return self.ApplyStatus.CLEAN
         except subprocess.CalledProcessError as e:
-            # If the process fails, we need to collect the files that failed to
-            # apply for manual conflict resolution.
             if 'with conflicts' in e.stderr:
-                # Output in this case should look like:
-                #   Applied patch to 'build/android/gyp/dex.py' with conflicts.
-                #   U build/android/gyp/dex.py
-                # Find the line starting with 'U ' to get the conflicted file
-                # path from.
-                conflict_line = next(
-                    (line for line in e.stderr.strip().splitlines()
-                     if line.startswith('U ')), None)
-                if conflict_line:
-                    conflicted_file = conflict_line.split()[-1]
-                else:
-                    raise NotImplementedError(
-                        'Could not find conflicted file in error '
-                        f'output: {e.stderr}') from e
-                return self.ApplyResult(status=self.ApplyStatus.CONFLICT,
-                                        patch=replace(
-                                            self,
-                                            source_from_git=conflicted_file))
+                return self.ApplyStatus.CONFLICT
             error_line = next(
                 (l for l in e.stderr.splitlines() if l.startswith('error:')),
                 None)
@@ -199,11 +135,7 @@ class Patchfile:
                         'Patch with missing file detected during --3way apply,'
                         ' which may indicate a bad sync state before starting '
                         'to upgrade. %s', self.path)
-                    return self.ApplyResult(
-                        status=self.ApplyStatus.DELETED,
-                        patch=replace(self,
-                                      source_from_git=reason.split(': ',
-                                                                   2)[0]))
+                    return self.ApplyStatus.DELETED
                 if ('No such file or directory' in reason
                         and self.path.as_posix() in reason):
                     # This should never occur as it indicates that the patch
@@ -221,33 +153,11 @@ class Patchfile:
                         'Patch being flagged as broken, but with unexpected '
                         'reason: %s %s', self.path, reason)
 
-                return self.ApplyResult(status=self.ApplyStatus.BROKEN,
-                                        patch=None)
+                return self.ApplyStatus.BROKEN
 
-        # We snould not reach this point. Failures to apply that fail like this
+        # We should not reach this point. Failures to apply that fail like this
         # must be investigated with `--verbose`, and fixed.
         raise NotImplementedError()
-
-    def fetch_source_from_git(self) -> "Patchfile":
-        """Gets the source file name from git.
-
-        This function uses git to get the source file name for the patch file,
-        but only if such name has not been retrieved yet from git.
-
-        Returns:
-            A patch instance with the source file name from git.
-        """
-
-        if self.source_from_git is not None:
-            return self
-
-        # The command below has an output similar to:
-        # 8	0  base/some_file.cc
-        return replace(
-            self,
-            source_from_git=self.repository.run_git(
-                'apply', '--numstat', '-z',
-                self.path_from_repo().as_posix()).strip().split()[2][:-1])
 
     def get_last_commit_for_source(self) -> str:
         """Gets the last commit where the source file was mentioned.
@@ -260,7 +170,7 @@ class Patchfile:
             The commit hash with the last mention for the source.
         """
         return self.repository.run_git('log', '--full-history', '--pretty=%h',
-                                       '-1', '--', self.source())
+                                       '-1', '--', self.source.as_posix())
 
     def get_source_removal_status(self, commit: str) -> SourceStatus:
         """Gets the status of the source file in a given commit.
@@ -299,7 +209,8 @@ class Patchfile:
 
         # let's look for the line about the source we care about.
         status_line = next(
-            (s for s in all_status.splitlines() if str(self.source()) in s),
+            (s
+             for s in all_status.splitlines() if self.source.as_posix() in s),
             None)
         status_code = status_line[0]
 

--- a/tools/cr/patchfile_test.py
+++ b/tools/cr/patchfile_test.py
@@ -5,7 +5,7 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import unittest
-from pathlib import PurePath, Path
+from pathlib import Path
 from patchfile import Patchfile
 import repository
 from repository import Repository
@@ -27,17 +27,20 @@ class PatchfileTest(unittest.TestCase):
     def test_get_repository_from_patch_name(self):
         """Test the result of get_repository_from_patch_name"""
         patchfile = Patchfile(
-            path=PurePath("patches/build-android-gyp-dex.py.patch"))
+            path=Path("patches/build-android-gyp-dex.py.patch"),
+            source=Path("build/android/gyp/dex.py"))
         self.assertEqual(patchfile.get_repository_from_patch_name(),
                          repository.chromium)
 
         patchfile = Patchfile(
-            path=PurePath("patches/v8/build-android-gyp-dex.py.patch"))
+            path=Path("patches/v8/build-android-gyp-dex.py.patch"),
+            source=Path("build/android/gyp/dex.py"))
         self.assertEqual(patchfile.get_repository_from_patch_name(),
                          Repository(self.fake_chromium_src.chromium / 'v8'))
 
-        patchfile = Patchfile(path=PurePath(
-            "patches/third_party/test1/build-android-gyp-dex.py.patch"))
+        patchfile = Patchfile(path=Path(
+            "patches/third_party/test1/build-android-gyp-dex.py.patch"),
+                              source=Path("build/android/gyp/dex.py"))
         self.assertEqual(
             patchfile.get_repository_from_patch_name(),
             Repository(self.fake_chromium_src.chromium / 'third_party/test1'))
@@ -45,17 +48,20 @@ class PatchfileTest(unittest.TestCase):
     def test_source_name_from_patch_naming(self):
         """Test patched file name name heuristics."""
         patchfile = Patchfile(
-            path=PurePath("patches/build-android-gyp-dex.py.patch"))
+            path=Path("patches/build-android-gyp-dex.py.patch"),
+            source=Path("build/android/gyp/dex.py"))
         self.assertEqual(patchfile.source_name_from_patch_naming(),
                          "build/android/gyp/dex.py")
 
         patchfile = Patchfile(
-            path=PurePath("patches/v8/build-android-gyp-dex.py.patch"))
+            path=Path("patches/v8/build-android-gyp-dex.py.patch"),
+            source=Path("build/android/gyp/dex.py"))
         self.assertEqual(patchfile.source_name_from_patch_naming(),
                          "build/android/gyp/dex.py")
 
-        patchfile = Patchfile(path=PurePath(
-            "patches/third_party/test1/build-android-gyp-dex.py.patch"))
+        patchfile = Patchfile(path=Path(
+            "patches/third_party/test1/build-android-gyp-dex.py.patch"),
+                              source=Path("build/android/gyp/dex.py"))
         self.assertEqual(patchfile.source_name_from_patch_naming(),
                          "build/android/gyp/dex.py")
 
@@ -84,7 +90,7 @@ class PatchfileTest(unittest.TestCase):
         self.fake_chromium_src.commit('Add developer_private.idl',
                                       self.fake_chromium_src.chromium)
 
-        # Let's create a patch for it
+        # Let's create a patch for it
         target_file = self.fake_chromium_src.chromium / test_idl
         target_file.write_text(target_file.read_text().replace(
             'FROM_STORE', 'FROM_STORE,\n    FROM_BRAVE_STORE'))
@@ -109,17 +115,10 @@ class PatchfileTest(unittest.TestCase):
         self.assertNotIn('FROM_BRAVE_STORE', target_file.read_text())
         patchfile = Patchfile(
             path=self.fake_chromium_src.get_patchfile_path_for_source(
-                self.fake_chromium_src.chromium, test_idl))
-        applied = patchfile.apply()
-        self.assertEqual(applied.status, Patchfile.ApplyStatus.CONFLICT)
-
-        # Check that in the case of conflict it returns an updated patchfile
-        # instance with an updated source from git.
-        self.assertTrue(applied.patch)
-        self.assertEqual(applied.patch.path, patchfile.path)
-        self.assertFalse(patchfile.source_from_git)
-        self.assertTrue(applied.patch.source_from_git)
-        self.assertEqual(applied.patch.source_from_git, test_idl.as_posix())
+                self.fake_chromium_src.chromium, test_idl),
+            source=test_idl)
+        status = patchfile.apply()
+        self.assertEqual(status, Patchfile.ApplyStatus.CONFLICT)
 
     def test_apply_conflict_with_whitespace_error(self):
         """Tests the behavior when applying a patch with whitespace errors."""
@@ -148,12 +147,12 @@ class PatchfileTest(unittest.TestCase):
         self.fake_chromium_src.commit('Add developer_private.idl',
                                       self.fake_chromium_src.chromium)
 
-        # Let's create a patch for it
+        # Let's create a patch for it
         target_file = self.fake_chromium_src.chromium / test_idl
         target_file.write_text(target_file.read_text().replace(
             'FROM_STORE', 'FROM_STORE,\n    FROM_BRAVE_STORE'))
 
-        # Let's create a patch with trailing spaces
+        # Let's create a patch with trailing spaces
         target_file.write_text(target_file.read_text().replace(
             'UNKNOWN', 'UNKNOWN,\n    ANOTHER '))
 
@@ -178,17 +177,10 @@ class PatchfileTest(unittest.TestCase):
         self.assertNotIn('FROM_BRAVE_STORE', target_file.read_text())
         patchfile = Patchfile(
             path=self.fake_chromium_src.get_patchfile_path_for_source(
-                self.fake_chromium_src.chromium, test_idl))
-        applied = patchfile.apply()
-        self.assertEqual(applied.status, Patchfile.ApplyStatus.CONFLICT)
-
-        # Check that in the case of conflict it returns an updated patchfile
-        # instance with an updated source from git.
-        self.assertTrue(applied.patch)
-        self.assertEqual(applied.patch.path, patchfile.path)
-        self.assertFalse(patchfile.source_from_git)
-        self.assertTrue(applied.patch.source_from_git)
-        self.assertEqual(applied.patch.source_from_git, test_idl.as_posix())
+                self.fake_chromium_src.chromium, test_idl),
+            source=test_idl)
+        status = patchfile.apply()
+        self.assertEqual(status, Patchfile.ApplyStatus.CONFLICT)
 
     def test_apply_clean(self):
         test_idl = Path('chrome/common/extensions/api/developer_private.idl')
@@ -215,7 +207,7 @@ class PatchfileTest(unittest.TestCase):
         self.fake_chromium_src.commit('Add developer_private.idl',
                                       self.fake_chromium_src.chromium)
 
-        # Let's create a patch for it
+        # Let's create a patch for it
         target_file = self.fake_chromium_src.chromium / test_idl
         target_file.write_text(target_file.read_text().replace(
             'FROM_STORE', 'FROM_STORE,\n    FROM_BRAVE_STORE'))
@@ -261,10 +253,10 @@ class PatchfileTest(unittest.TestCase):
         self.assertNotIn('FROM_BRAVE_STORE', target_file.read_text())
         patchfile = Patchfile(
             path=self.fake_chromium_src.get_patchfile_path_for_source(
-                self.fake_chromium_src.chromium, test_idl))
-        applied = patchfile.apply()
-        self.assertEqual(applied.status, Patchfile.ApplyStatus.CLEAN)
-        self.assertFalse(applied.patch)
+                self.fake_chromium_src.chromium, test_idl),
+            source=test_idl)
+        status = patchfile.apply()
+        self.assertEqual(status, Patchfile.ApplyStatus.CLEAN)
         self.assertIn('FROM_BRAVE_STORE', target_file.read_text())
 
     def test_apply_broken(self):
@@ -287,10 +279,10 @@ class PatchfileTest(unittest.TestCase):
 
         patchfile = Patchfile(
             path=self.fake_chromium_src.get_patchfile_path_for_source(
-                self.fake_chromium_src.chromium, test_idl))
-        applied = patchfile.apply()
-        self.assertEqual(applied.status, Patchfile.ApplyStatus.CLEAN)
-        self.assertFalse(applied.patch)
+                self.fake_chromium_src.chromium, test_idl),
+            source=test_idl)
+        status = patchfile.apply()
+        self.assertEqual(status, Patchfile.ApplyStatus.CLEAN)
         self.assertIn('last line', target_file.read_text())
 
         self.fake_chromium_src._run_git_command(
@@ -305,10 +297,10 @@ class PatchfileTest(unittest.TestCase):
 
         patchfile = Patchfile(
             path=self.fake_chromium_src.get_patchfile_path_for_source(
-                self.fake_chromium_src.chromium, test_idl))
-        applied = patchfile.apply()
-        self.assertEqual(applied.status, Patchfile.ApplyStatus.BROKEN)
-        self.assertFalse(applied.patch)
+                self.fake_chromium_src.chromium, test_idl),
+            source=test_idl)
+        status = patchfile.apply()
+        self.assertEqual(status, Patchfile.ApplyStatus.BROKEN)
 
     def test_apply_on_deleted(self):
         '''Tests the behavior when applying a patch to a deleted file.'''
@@ -330,10 +322,10 @@ class PatchfileTest(unittest.TestCase):
 
         patchfile = Patchfile(
             path=self.fake_chromium_src.get_patchfile_path_for_source(
-                self.fake_chromium_src.chromium, test_idl))
-        applied = patchfile.apply()
-        self.assertEqual(applied.status, Patchfile.ApplyStatus.CLEAN)
-        self.assertFalse(applied.patch)
+                self.fake_chromium_src.chromium, test_idl),
+            source=test_idl)
+        status = patchfile.apply()
+        self.assertEqual(status, Patchfile.ApplyStatus.CLEAN)
         self.assertIn('last line', target_file.read_text())
 
         self.fake_chromium_src._run_git_command(
@@ -348,15 +340,10 @@ class PatchfileTest(unittest.TestCase):
 
         patchfile = Patchfile(
             path=self.fake_chromium_src.get_patchfile_path_for_source(
-                self.fake_chromium_src.chromium, test_idl))
-        applied = patchfile.apply()
-        self.assertEqual(applied.status, Patchfile.ApplyStatus.DELETED)
-        # A deleted patch should also provide an updated patchfile instance.
-        self.assertTrue(applied.patch)
-        self.assertEqual(applied.patch.path, patchfile.path)
-        self.assertFalse(patchfile.source_from_git)
-        self.assertTrue(applied.patch.source_from_git)
-        self.assertEqual(applied.patch.source_from_git, test_idl.as_posix())
+                self.fake_chromium_src.chromium, test_idl),
+            source=test_idl)
+        status = patchfile.apply()
+        self.assertEqual(status, Patchfile.ApplyStatus.DELETED)
 
     def test_apply_on_deleted_with_whitespace_error(self):
         '''Tests DELETED status when stderr has whitespace warnings before the
@@ -382,9 +369,10 @@ class PatchfileTest(unittest.TestCase):
         # Sanity-check: patch applies cleanly before we delete the file.
         patchfile = Patchfile(
             path=self.fake_chromium_src.get_patchfile_path_for_source(
-                self.fake_chromium_src.chromium, test_idl))
-        applied = patchfile.apply()
-        self.assertEqual(applied.status, Patchfile.ApplyStatus.CLEAN)
+                self.fake_chromium_src.chromium, test_idl),
+            source=test_idl)
+        status = patchfile.apply()
+        self.assertEqual(status, Patchfile.ApplyStatus.CLEAN)
         self.assertIn('last line', target_file.read_text())
 
         self.fake_chromium_src._run_git_command(
@@ -399,95 +387,47 @@ class PatchfileTest(unittest.TestCase):
 
         patchfile = Patchfile(
             path=self.fake_chromium_src.get_patchfile_path_for_source(
-                self.fake_chromium_src.chromium, test_idl))
-        applied = patchfile.apply()
-        self.assertEqual(applied.status, Patchfile.ApplyStatus.DELETED)
-        self.assertTrue(applied.patch)
-        self.assertEqual(applied.patch.path, patchfile.path)
-        self.assertFalse(patchfile.source_from_git)
-        self.assertTrue(applied.patch.source_from_git)
-        self.assertEqual(applied.patch.source_from_git, test_idl.as_posix())
+                self.fake_chromium_src.chromium, test_idl),
+            source=test_idl)
+        status = patchfile.apply()
+        self.assertEqual(status, Patchfile.ApplyStatus.DELETED)
 
     def test_source_from_brave(self):
         """Tests the source_from_brave method of Patchfile."""
         self.assertEqual(
-            Patchfile(path=PurePath('patches/v8/build-android-gyp-dex.py.patch'
-                                    )).source_from_brave().as_posix(),
-            '../v8/build/android/gyp/dex.py')
+            Patchfile(path=Path('patches/v8/build-android-gyp-dex.py.patch'),
+                      source=Path('build/android/gyp/dex.py')).
+            source_from_brave().as_posix(), '../v8/build/android/gyp/dex.py')
         self.assertEqual(
-            Patchfile(path=PurePath('patches/build-android-gyp-dex.py.patch')).
+            Patchfile(path=Path('patches/build-android-gyp-dex.py.patch'),
+                      source=Path('build/android/gyp/dex.py')).
             source_from_brave().as_posix(), '../build/android/gyp/dex.py')
 
         _devtools_patch = (
             'patches/third_party/devtools-frontend/src/'
             'front_end-panels-timeline-components-LiveMetricsView.ts.patch')
         _devtools_source = (
-            '../third_party/devtools-frontend/src/'
             'front_end/panels/timeline/components/LiveMetricsView.ts')
         self.assertEqual(
             Patchfile(
-                path=PurePath(_devtools_patch)).source_from_brave().as_posix(),
-            _devtools_source)
-
-        # Checking that we can handle the source path provided by the report
-        # produced by `npm run apply_patches`, which uses relative paths from
-        # src/ when listing source files that failed to apply.
-        self.assertEqual(
-            Patchfile(path=PurePath(_devtools_patch),
-                      provided_source=_devtools_source[3:]).source_from_brave(
-                      ).as_posix(), _devtools_source)
-
+                path=Path(_devtools_patch),
+                source=Path(_devtools_source)).source_from_brave().as_posix(),
+            '../third_party/devtools-frontend/src/' + _devtools_source)
 
     def test_path_from_repo(self):
         """Tests the path_from_repo method of Patchfile."""
         self.assertEqual(
-            Patchfile(path=PurePath('patches/v8/build-android-gyp-dex.py.patch'
-                                    )).path_from_repo().as_posix(),
+            Patchfile(
+                path=Path('patches/v8/build-android-gyp-dex.py.patch'),
+                source=Path(
+                    'build/android/gyp/dex.py')).path_from_repo().as_posix(),
             '../brave/patches/v8/build-android-gyp-dex.py.patch')
         self.assertEqual(
-            Patchfile(path=PurePath('patches/build-android-gyp-dex.py.patch')
-                      ).path_from_repo().as_posix(),
+            Patchfile(
+                path=Path('patches/build-android-gyp-dex.py.patch'),
+                source=Path(
+                    'build/android/gyp/dex.py')).path_from_repo().as_posix(),
             'brave/patches/build-android-gyp-dex.py.patch')
-
-    def test_fetch_source_from_git(self):
-        """Test fetch_source_from_git with renamed patch file."""
-        test_idl = Path('chrome/common/extensions/api/developer_private.idl')
-        self.fake_chromium_src.write_and_stage_file(
-            test_idl, """
-                enum ExtensionType {
-                    HOSTED_APP,
-                    PLATFORM_APP,
-                    LEGACY_PACKAGED_APP,
-                    EXTENSION,
-                    THEME,
-                    SHARED_MODULE
-                  };
-                """, self.fake_chromium_src.chromium)
-
-        self.fake_chromium_src.commit('Add developer_private.idl',
-                                      self.fake_chromium_src.chromium)
-
-        # Create a patch for the file
-        target_file = self.fake_chromium_src.chromium / test_idl
-        target_file.write_text(target_file.read_text().replace(
-            'HOSTED_APP', 'HOSTED_APP,\n    NEW_TYPE'))
-        self.fake_chromium_src.run_update_patches()
-
-        # Rename the patch file
-        original_patch_path = (
-            self.fake_chromium_src.get_patchfile_path_for_source(
-                self.fake_chromium_src.chromium, test_idl))
-        renamed_patch_path = original_patch_path.with_name(
-            'renamed_developer_private.idl.patch')
-        (self.fake_chromium_src.brave / original_patch_path).rename(
-            self.fake_chromium_src.brave / renamed_patch_path)
-
-        # Fetch the source from the renamed patch file
-        patchfile = Patchfile(path=renamed_patch_path)
-
-        # Verify the source file path matches the original file
-        self.assertEqual(patchfile.fetch_source_from_git().source_from_git,
-                         test_idl.as_posix())
 
     def test_get_last_commit_for_source(self):
         """Test get_last_commit_for_source method."""
@@ -523,7 +463,7 @@ class PatchfileTest(unittest.TestCase):
         # Verify the last commit for the source matches the initial commit hash
         patchfile_path = self.fake_chromium_src.get_patchfile_path_for_source(
             self.fake_chromium_src.chromium, test_file)
-        patchfile = Patchfile(path=patchfile_path)
+        patchfile = Patchfile(path=patchfile_path, source=test_file)
         self.assertEqual(patchfile.get_last_commit_for_source(),
                          initial_commit_hash)
 
@@ -541,7 +481,7 @@ class PatchfileTest(unittest.TestCase):
                                             self.fake_chromium_src.chromium)
 
         # Get the patch file path
-        patchfile = Patchfile(path=patchfile_path)
+        patchfile = Patchfile(path=patchfile_path, source=test_file)
 
         # Verify the last commit for the source matches the delete commit hash
         self.assertEqual(patchfile.get_last_commit_for_source(),
@@ -587,7 +527,7 @@ class PatchfileTest(unittest.TestCase):
         # Get the patch file path
         patchfile_path = self.fake_chromium_src.get_patchfile_path_for_source(
             self.fake_chromium_src.chromium, test_file)
-        patchfile = Patchfile(path=patchfile_path)
+        patchfile = Patchfile(path=patchfile_path, source=test_file)
 
         # Add a few more empty commits
         self.fake_chromium_src.commit_empty('Empty commit 3',
@@ -647,7 +587,7 @@ class PatchfileTest(unittest.TestCase):
         # Get the patch file path
         patchfile_path = self.fake_chromium_src.get_patchfile_path_for_source(
             self.fake_chromium_src.chromium, test_file)
-        patchfile = Patchfile(path=patchfile_path)
+        patchfile = Patchfile(path=patchfile_path, source=test_file)
 
         # Add a few more empty commits
         self.fake_chromium_src.commit_empty('Empty commit 3',

--- a/tools/cr/repository.py
+++ b/tools/cr/repository.py
@@ -4,7 +4,7 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
 from dataclasses import dataclass
-from pathlib import Path, PurePath
+from pathlib import Path
 import subprocess
 from typing import Optional
 from rich.markup import escape
@@ -12,7 +12,7 @@ from rich.markup import escape
 from terminal import terminal
 
 # The path to the brave/ directory.
-BRAVE_CORE_PATH = next(brave for brave in PurePath(__file__).parents
+BRAVE_CORE_PATH = next(brave for brave in Path(__file__).parents
                        if brave.name == 'brave')
 
 # The path to chromium's src/ directory.
@@ -31,7 +31,7 @@ class Repository:
     # The repository path. This path is extracted from the subdirectory section
     # of a patch file, with chromium/src being ''.
     # e.g. "third_party/search_engines_data/resources"
-    path: PurePath
+    path: Path
 
     @property
     def is_chromium(self) -> bool:
@@ -46,30 +46,30 @@ class Repository:
         return self.path == BRAVE_CORE_PATH
 
     @property
-    def relative_to_chromium(self) -> PurePath:
+    def relative_to_chromium(self) -> Path:
         """ Returns the path relative to src/.
         """
         if self.is_chromium:
-            return PurePath('')
+            return Path('')
         return self.path.relative_to(CHROMIUM_SRC_PATH)
 
-    def to_brave(self) -> PurePath:
+    def to_brave(self) -> Path:
         """ Returns the path from the repository to brave/.
         """
         if self.is_chromium:
             return BRAVE_CORE_PATH.relative_to(CHROMIUM_SRC_PATH)
-        return PurePath(
+        return Path(
             len(self.path.relative_to(CHROMIUM_SRC_PATH).parts) *
             '../') / BRAVE_CORE_PATH.relative_to(CHROMIUM_SRC_PATH)
 
-    def from_brave(self, source: Optional[PurePath] = None) -> PurePath:
+    def from_brave(self, source: Optional[Path] = None) -> Path:
         """ Returns the path from brave/ to the repository.
         """
         if source:
-            return PurePath('..') / self.path.relative_to(
+            return Path('..') / self.path.relative_to(
                 CHROMIUM_SRC_PATH) / source
 
-        return PurePath('..') / self.path.relative_to(CHROMIUM_SRC_PATH)
+        return Path('..') / self.path.relative_to(CHROMIUM_SRC_PATH)
 
     def run_git(self, *cmd, no_trim=False) -> str:
         """Runs a git command on the repository.
@@ -202,6 +202,21 @@ class Repository:
             *[f'{commit}:{Path(file).as_posix()}' for file in files],
             no_trim=True)
 
+    def get_patch_stats(self, *patches: Path) -> dict[Path, list[Path]]:
+        """Returns the files affected by each patch, keyed by patch path.
+
+        Uses --numstat for unabbreviated paths. Each patch is queried
+        individually so that file lists map cleanly to their patch key.
+        """
+        return {
+            patch: [
+                Path(line.split('\t')[2]) for line in self.run_git(
+                    'apply', '--numstat', patch.as_posix()).splitlines()
+                if '\t' in line
+            ]
+            for patch in patches
+        }
+
     def current_branch(self) -> str:
         """Gets the current branch name, or HEAD if not in any branch.
         """
@@ -209,7 +224,7 @@ class Repository:
 
 
 # An instance to the chromium repository.
-chromium = Repository(PurePath(CHROMIUM_SRC_PATH))
+chromium = Repository(CHROMIUM_SRC_PATH)
 
 # An instance to the brave repository.
-brave = Repository(PurePath(BRAVE_CORE_PATH))
+brave = Repository(BRAVE_CORE_PATH)

--- a/tools/cr/repository_test.py
+++ b/tools/cr/repository_test.py
@@ -4,7 +4,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
-from pathlib import PurePath
+from pathlib import Path
 import unittest
 
 import repository
@@ -26,49 +26,47 @@ class RepositoryTest(unittest.TestCase):
 
     def test_chromium_repository(self):
         self.assertEqual(repository.chromium.path,
-                         PurePath(self.fake_chromium_src.chromium))
+                         self.fake_chromium_src.chromium)
         self.assertTrue(repository.chromium.is_chromium)
         self.assertFalse(repository.chromium.is_brave)
 
     def test_brave_repository(self):
-        self.assertEqual(repository.brave.path,
-                         PurePath(self.fake_chromium_src.brave))
+        self.assertEqual(repository.brave.path, self.fake_chromium_src.brave)
         self.assertTrue(repository.brave.is_brave)
         self.assertFalse(repository.brave.is_chromium)
 
     def test_to_brave(self):
         self.assertEqual(
             Repository(self.fake_chromium_src.chromium).to_brave(),
-            PurePath('brave'))
+            Path('brave'))
         self.assertEqual(
             Repository(self.fake_chromium_src.brave).to_brave(),
-            PurePath('../brave'))
+            Path('../brave'))
         self.assertEqual(
             Repository(self.fake_chromium_src.chromium / 'v8').to_brave(),
-            PurePath('../brave'))
+            Path('../brave'))
         self.assertEqual(
             Repository(self.fake_chromium_src.chromium /
-                       'third_party/test1').to_brave(),
-            PurePath('../../brave'))
+                       'third_party/test1').to_brave(), Path('../../brave'))
 
     def test_from_brave(self):
         self.assertEqual(
             Repository(self.fake_chromium_src.chromium).from_brave(),
-            PurePath('../'))
+            Path('../'))
         self.assertEqual(
             Repository(self.fake_chromium_src.brave).from_brave(),
-            PurePath('../brave'))
+            Path('../brave'))
         self.assertEqual(
             Repository(self.fake_chromium_src.chromium / 'v8').from_brave(),
-            PurePath('../v8'))
+            Path('../v8'))
         self.assertEqual(
             Repository(self.fake_chromium_src.chromium /
                        'third_party/test1').from_brave(),
-            PurePath('../third_party/test1'))
+            Path('../third_party/test1'))
         self.assertEqual(
             Repository(self.fake_chromium_src.chromium /
-                       'third_party/test1').from_brave('test_file.txt'),
-            PurePath('../third_party/test1/test_file.txt'))
+                       'third_party/test1').from_brave(Path('test_file.txt')),
+            Path('../third_party/test1/test_file.txt'))
 
     def test_run_git(self):
         """Test Repository.run_git by verifying the hash of the last commit."""
@@ -346,6 +344,82 @@ class RepositoryTest(unittest.TestCase):
         content_file3 = repository.chromium.read_file("file3.txt",
                                                       commit=commit3)
         self.assertEqual(content_file3, "Content with trailing newline\n\n")
+
+    def test_get_patch_stats_single(self):
+        """Test get_patch_stats with a single patch returns its affected
+        file."""
+        test_file = Path('chrome/browser/ui/page_actions/action_ids.h')
+        self.fake_chromium_src.write_and_stage_file(
+            test_file, 'line1\nline2\nline3\n',
+            self.fake_chromium_src.chromium)
+        self.fake_chromium_src.commit('Add action_ids.h',
+                                      self.fake_chromium_src.chromium)
+
+        (self.fake_chromium_src.chromium /
+         test_file).write_text('line1\nline2\nline3\nbrave_line\n')
+        self.fake_chromium_src.run_update_patches()
+
+        patch_path = Path('brave') / self.fake_chromium_src \
+            .get_patchfile_path_for_source(self.fake_chromium_src.chromium,
+                                           test_file)
+
+        stats = repository.chromium.get_patch_stats(patch_path)
+
+        self.assertEqual(list(stats.keys()), [patch_path])
+        self.assertEqual(stats[patch_path], [test_file])
+
+    def test_get_patch_stats_multiple(self):
+        """Test get_patch_stats with several patches returns each in order."""
+        file1 = Path('chrome/browser/ui/page_actions/action_ids.h')
+        file2 = Path(
+            'chrome/browser/ui/views/page_action/page_action_controller.h')
+
+        for test_file in [file1, file2]:
+            self.fake_chromium_src.write_and_stage_file(
+                test_file, 'line1\nline2\nline3\n',
+                self.fake_chromium_src.chromium)
+        self.fake_chromium_src.commit('Add header files',
+                                      self.fake_chromium_src.chromium)
+
+        for test_file in [file1, file2]:
+            target = self.fake_chromium_src.chromium / test_file
+            target.write_text(target.read_text() + 'brave_line\n')
+        self.fake_chromium_src.run_update_patches()
+
+        patch_paths = [
+            Path('brave') /
+            self.fake_chromium_src.get_patchfile_path_for_source(
+                self.fake_chromium_src.chromium, f) for f in [file1, file2]
+        ]
+
+        stats = repository.chromium.get_patch_stats(*patch_paths)
+
+        self.assertEqual(list(stats.keys()), patch_paths)
+        self.assertEqual(stats[patch_paths[0]], [file1])
+        self.assertEqual(stats[patch_paths[1]], [file2])
+
+    def test_get_patch_stats_multiple_sources_in_patch(self):
+        """Test get_patch_stats with a patch covering several source files."""
+        file1 = Path('chrome/browser/ui/page_actions/action_ids.h')
+        file2 = Path('base/feature_list.cc')
+
+        for test_file, content in [(file1, 'line1\nline2\n'),
+                                   (file2, 'func() {}\n')]:
+            self.fake_chromium_src.write_and_stage_file(
+                test_file, content, self.fake_chromium_src.chromium)
+        self.fake_chromium_src.commit('Add two source files',
+                                      self.fake_chromium_src.chromium)
+
+        patch_filename = self.fake_chromium_src._run_git_command(
+            ['format-patch', '-1', 'HEAD'], self.fake_chromium_src.chromium)
+        patch_path = self.fake_chromium_src.chromium / patch_filename
+
+        stats = repository.chromium.get_patch_stats(patch_path)
+
+        self.assertEqual(list(stats.keys()), [patch_path])
+        self.assertIn(file1, stats[patch_path])
+        self.assertIn(file2, stats[patch_path])
+        self.assertEqual(len(stats[patch_path]), 2)
 
     def test_current_branch(self):
         """Test current_branch using the chromium repository."""

--- a/tools/cr/vscode.py
+++ b/tools/cr/vscode.py
@@ -20,7 +20,7 @@ class _VsCodeIpcConnectionBase(http.client.HTTPConnection):
         super().__init__('vscode')
         self._socket_path = os.environ.get(env_var, '')
 
-    def open_file(self, files: list) -> None:
+    def open_file(self, files: list[Path]) -> None:
         """Opens files in the VS Code window that owns this terminal.
 
         Communicates directly with the IPC socket rather than spawning
@@ -30,7 +30,7 @@ class _VsCodeIpcConnectionBase(http.client.HTTPConnection):
         """
         if not self._socket_path or not files:
             return
-        file_uris = [Path(str(f)).resolve().as_uri() for f in files]
+        file_uris = [f.resolve().as_uri() for f in files]
         body = json.dumps({
             'type': 'open',
             'fileURIs': file_uris,

--- a/tools/cr/vscode_test.py
+++ b/tools/cr/vscode_test.py
@@ -11,6 +11,7 @@ import platform
 import socket
 import tempfile
 import unittest
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from vscode import (VsCodeIpcConnection, _NamedPipeSocket,
@@ -78,7 +79,7 @@ class PosixVsCodeIpcConnectionTest(unittest.TestCase):
             mock_response.read.return_value = b''
             with patch.object(conn, 'request') as mock_request, \
                  patch.object(conn, 'getresponse', return_value=mock_response):
-                conn.open_file(['/path/to/file.cc'])
+                conn.open_file([Path('/path/to/file.cc')])
                 mock_request.assert_called_once()
                 method, path, body, headers = mock_request.call_args[0]
                 self.assertEqual(method, 'POST')
@@ -98,7 +99,7 @@ class PosixVsCodeIpcConnectionTest(unittest.TestCase):
                               'request',
                               side_effect=ConnectionRefusedError('refused')):
                 with self.assertLogs(level='WARNING') as captured:
-                    conn.open_file(['/path/to/file.cc'])
+                    conn.open_file([Path('/path/to/file.cc')])
                 self.assertTrue(
                     any('Could not open files in VS Code window' in line
                         for line in captured.output))
@@ -201,7 +202,7 @@ class WinVsCodeIpcConnectionTest(unittest.TestCase):
             mock_response.read.return_value = b''
             with patch.object(conn, 'request') as mock_request, \
                  patch.object(conn, 'getresponse', return_value=mock_response):
-                conn.open_file(['/path/to/file.cc'])
+                conn.open_file([Path('/path/to/file.cc')])
                 mock_request.assert_called_once()
                 method, path, body, headers = mock_request.call_args[0]
                 self.assertEqual(method, 'POST')
@@ -221,7 +222,7 @@ class WinVsCodeIpcConnectionTest(unittest.TestCase):
                               'request',
                               side_effect=ConnectionRefusedError('refused')):
                 with self.assertLogs(level='WARNING') as captured:
-                    conn.open_file(['/path/to/file.cc'])
+                    conn.open_file([Path('/path/to/file.cc')])
                 self.assertTrue(
                     any('Could not open files in VS Code window' in line
                         for line in captured.output))


### PR DESCRIPTION
This change simplifies a lot of the code around `Patchfile`, but
expecting instances of `Patchfile` to be provided with the expected
`source` value for the source file to be patched. This eliminates a lot
of the creative ways how we were detecting that information.

We can use a single git call to retrieve the underlying source for all
patches, which this change does.

Additionally, there is some sprucing up of the codebase, to make
consitent uses of `Path`. The use of `PurePath` creates the need for a
lot of conversions, so we are making this more consistent.

Resolves https://github.com/brave/brave-browser/issues/55177
