### PR TITLE
[History Embeddings] Guard against concurrent contents creation

### DIFF
--- a/browser/history_embeddings/brave_passage_embeddings_service.cc
+++ b/browser/history_embeddings/brave_passage_embeddings_service.cc
@@ -368,9 +368,10 @@ void BravePassageEmbeddingsService::OnBackgroundContentsDestroyed(
 }
 
 void BravePassageEmbeddingsService::MaybeCreateBackgroundContents() {
-  if (background_web_contents_) {
+  if (background_web_contents_ || background_web_contents_creating_) {
     return;
   }
+  background_web_contents_creating_ = true;
   background_web_contents_factory_.Run(
       this, base::BindOnce(
                 &BravePassageEmbeddingsService::OnBackgroundContentsCreated,
@@ -379,6 +380,7 @@ void BravePassageEmbeddingsService::MaybeCreateBackgroundContents() {
 
 void BravePassageEmbeddingsService::OnBackgroundContentsCreated(
     std::unique_ptr<local_ai::BackgroundWebContents> contents) {
+  background_web_contents_creating_ = false;
   if (background_web_contents_ || !contents) {
     return;
   }
@@ -394,6 +396,7 @@ void BravePassageEmbeddingsService::CloseBackgroundContents() {
            << ")";
   ResetEmbedderState();
   background_web_contents_.reset();
+  background_web_contents_creating_ = false;
 }
 
 void BravePassageEmbeddingsService::MaybeWaitForLocalModelFilesReady() {

--- a/browser/history_embeddings/brave_passage_embeddings_service.h
+++ b/browser/history_embeddings/brave_passage_embeddings_service.h
@@ -217,6 +217,10 @@ class BravePassageEmbeddingsService
   void OnBatchEmbedderDisconnected();
 
   std::unique_ptr<local_ai::BackgroundWebContents> background_web_contents_;
+  // Set while the factory callback is in flight so successive
+  // MaybeCreateBackgroundContents calls don't kick off duplicate
+  // creations before OnBackgroundContentsCreated runs.
+  bool background_web_contents_creating_ = false;
   BackgroundWebContentsFactory background_web_contents_factory_;
   raw_ptr<local_ai::LocalModelsUpdaterState> updater_state_;
 

--- a/browser/history_embeddings/brave_passage_embeddings_service_unittest.cc
+++ b/browser/history_embeddings/brave_passage_embeddings_service_unittest.cc
@@ -135,13 +135,24 @@ class BravePassageEmbeddingsServiceTest : public testing::Test {
       local_ai::BackgroundWebContents::Delegate* delegate,
       BravePassageEmbeddingsService::BackgroundWebContentsCreatedCallback
           callback) {
+    ++web_contents_create_count_;
     auto web_contents = std::make_unique<FakeBackgroundWebContents>(
         delegate,
         base::BindOnce(
             [](raw_ptr<FakeBackgroundWebContents>* ref) { *ref = nullptr; },
             &last_created_web_contents_));
     last_created_web_contents_ = web_contents.get();
+    if (defer_create_callback_) {
+      pending_create_callback_ =
+          base::BindOnce(std::move(callback), std::move(web_contents));
+      return;
+    }
     std::move(callback).Run(std::move(web_contents));
+  }
+
+  void RunDeferredCreate() {
+    ASSERT_TRUE(pending_create_callback_);
+    std::move(pending_create_callback_).Run();
   }
 
   void RegisterFactory() {
@@ -198,6 +209,9 @@ class BravePassageEmbeddingsServiceTest : public testing::Test {
   FakeRendererEmbedder fake_worker_;
   FakePassageEmbedderFactory fake_factory_{&fake_worker_};
   raw_ptr<FakeBackgroundWebContents> last_created_web_contents_ = nullptr;
+  size_t web_contents_create_count_ = 0;
+  bool defer_create_callback_ = false;
+  base::OnceClosure pending_create_callback_;
   base::ScopedTempDir temp_dir_;
 };
 
@@ -265,6 +279,27 @@ TEST_F(BravePassageEmbeddingsServiceTest, BackgroundContentsDestroyedCloses) {
   // A new load should recreate background contents.
   auto load2 = IssueLoad();
   EXPECT_TRUE(last_created_web_contents_);
+}
+
+TEST_F(BravePassageEmbeddingsServiceTest,
+       ConcurrentBindOnlyCreatesOneBackgroundContents) {
+  // While a BackgroundWebContents creation is in flight, a second
+  // BindPassageEmbedder call must not spawn a duplicate factory run.
+  // Defer the first creation callback so the in-flight flag is
+  // exercised before background_web_contents_ is set.
+  defer_create_callback_ = true;
+  auto load1 = IssueLoad();
+  EXPECT_EQ(1u, web_contents_create_count_);
+
+  auto load2 = IssueLoad();
+  // Second Bind sees background_web_contents_creating_ true and
+  // short-circuits — no new factory invocation.
+  EXPECT_EQ(1u, web_contents_create_count_);
+
+  // Letting the deferred callback run resolves the contents and
+  // clears the in-flight flag; no further creates fire.
+  RunDeferredCreate();
+  EXPECT_EQ(1u, web_contents_create_count_);
 }
 
 TEST_F(BravePassageEmbeddingsServiceTest, BindRegistryRoutesToService) {


### PR DESCRIPTION
Part of https://github.com/brave/brave-browser/issues/54763. Issue resolved by the final PR in the stack (#36107).

## Summary

`MaybeCreateBackgroundContents` had no in-flight flag, so successive `BindPassageEmbedder` calls before `OnBackgroundContentsCreated` fired would each kick off an additional factory run. Track the pending creation and short-circuit while it is outstanding.

Addresses [r3113112620](https://github.com/brave/brave-core/pull/32689#discussion_r3113112620) on the original PR.

## Stack

This PR is part 1 of 4 splitting the original follow-up (#35906):

1. **This PR** — Guard against concurrent contents creation
2. #36105 — Replace barrier with `base::OneShotEvent`s
3. #36106 — Move factory/init into `BraveBatchPassageEmbedder`
4. #36107 — Extract `BraveBatchPassageEmbedder` to its own files