### PR TITLE
[History Embeddings] Move model lifecycle into controller, renderer-side into BatchEmbedder

### DIFF
--- a/browser/history_embeddings/BUILD.gn
+++ b/browser/history_embeddings/BUILD.gn
@@ -39,6 +39,7 @@ source_set("batch_passage_embedder") {
 
   public_deps = [
     "//base",
+    "//brave/components/local_ai/core",
     "//brave/components/local_ai/core:mojom",
     "//mojo/public/cpp/bindings",
     "//services/passage_embeddings/public/mojom",

--- a/browser/history_embeddings/README.md
+++ b/browser/history_embeddings/README.md
@@ -75,19 +75,20 @@ without touching the upstream header (see
   implementation of `passage_embeddings::mojom::PassageEmbeddingsService`
   (and `local_ai::mojom::LocalAIService` for renderer binding).
   Exposes a direct `BindPassageEmbedder(...)` entry point used by the
-  controller. Owns the guest-OTR background WebContents, the
-  `PassageEmbedderFactory` registration, and a
-  `BraveBatchPassageEmbedder` that translates upstream's batch mojom
-  to the renderer's one-passage-at-a-time interface. Also hosts the
-  static `WebContents*` → bind-callback registry used by
-  `UntrustedLocalAIUI::BindInterface`.
+  controller. Owns the guest-OTR background WebContents and the
+  `PassageEmbedderFactory` registration; hands the factory remote and
+  loaded model files off to a `BraveBatchPassageEmbedder` once both
+  are ready. Also hosts the static `WebContents*` → bind-callback
+  registry used by `UntrustedLocalAIUI::BindInterface`.
 
 - **`brave_batch_passage_embedder.{h,cc}`** — In-process
-  implementation of `passage_embeddings::mojom::PassageEmbedder` that
-  wraps a renderer-side `local_ai::mojom::PassageEmbedder`. Translates
-  the upstream batch mojom to the renderer's single-passage interface,
-  processing passages sequentially so callbacks resolve with all
-  embeddings in order.
+  implementation of `passage_embeddings::mojom::PassageEmbedder`.
+  Owns the per-load lifecycle: drives `factory_->Init` on
+  construction, binds the renderer-side `local_ai::mojom::PassageEmbedder`
+  on success, and signals load success/failure plus disconnect back
+  to the service. Translates upstream's batch mojom to the renderer's
+  one-passage-at-a-time interface, processing passages sequentially so
+  callbacks resolve with embeddings in order.
 
 - **`brave_passage_embeddings_service_controller.{h,cc}`** — Singleton
   subclass of `PassageEmbeddingsServiceController`. Overrides

--- a/browser/history_embeddings/README.md
+++ b/browser/history_embeddings/README.md
@@ -72,23 +72,28 @@ without touching the upstream header (see
 ## Key Files
 
 - **`brave_passage_embeddings_service.{h,cc}`** — In-process
-  implementation of `passage_embeddings::mojom::PassageEmbeddingsService`
-  (and `local_ai::mojom::LocalAIService` for renderer binding).
+  implementation of `passage_embeddings::mojom::PassageEmbeddingsService`.
   Exposes a direct `BindPassageEmbedder(...)` entry point used by the
-  controller. Owns the guest-OTR background WebContents and the
-  `PassageEmbedderFactory` registration; hands the factory remote and
-  loaded model files off to a `BraveBatchPassageEmbedder` once both
-  are ready. Also hosts the static `WebContents*` → bind-callback
-  registry used by `UntrustedLocalAIUI::BindInterface`.
+  controller. Reads the five EmbeddingGemma model files from disk in
+  response to `LocalModelsUpdaterState` notifications and hands them
+  to `BraveBatchPassageEmbedder` via `SetModelFiles`. Also hosts the
+  static `WebContents*` → bind-callback registry used by
+  `UntrustedLocalAIUI::BindInterface` (the registered callback routes
+  to the active `BraveBatchPassageEmbedder`).
 
 - **`brave_batch_passage_embedder.{h,cc}`** — In-process
-  implementation of `passage_embeddings::mojom::PassageEmbedder`.
-  Owns the per-load lifecycle: drives `factory_->Init` on
-  construction, binds the renderer-side `local_ai::mojom::PassageEmbedder`
-  on success, and signals load success/failure plus disconnect back
-  to the service. Translates upstream's batch mojom to the renderer's
-  one-passage-at-a-time interface, processing passages sequentially so
-  callbacks resolve with embeddings in order.
+  implementation of `passage_embeddings::mojom::PassageEmbedder` and
+  `local_ai::mojom::LocalAIService`. Owns the full renderer-side
+  lifecycle for a single load: the guest-OTR background WebContents
+  that hosts the WASM worker, the `LocalAIService` receiver set the
+  WASM page uses to register its `PassageEmbedderFactory`, and the
+  `factory->Init` + `factory->Bind` handshake. Initialization is gated
+  on an explicit `LoadPhase` (`kCreatingContents → kAwaitingPrereqs →
+  kInitializing → kReady`); Init runs once the renderer registers its
+  factory and the service hands over loaded model files. Translates
+  upstream's batch mojom to the renderer's one-passage-at-a-time
+  interface, processing passages sequentially so callbacks resolve
+  with embeddings in order.
 
 - **`brave_passage_embeddings_service_controller.{h,cc}`** — Singleton
   subclass of `PassageEmbeddingsServiceController`. Overrides
@@ -139,8 +144,10 @@ PageContentAnnotationsWebContentsObserver (upstream)
         → SchedulingEmbedder (upstream; queues, reorders by priority)
           → BravePassageEmbeddingsServiceController::GetEmbeddings
             → service_->BindPassageEmbedder (first time, in-process)
-              → PassageEmbedderFactory::Init (loads WASM model)
-                → BraveBatchPassageEmbedder bound to embedder_remote_
+              → BraveBatchPassageEmbedder created; creates background
+                WebContents and waits for factory registration + model files
+                → PassageEmbedderFactory::Init (loads WASM model)
+                  → renderer-side PassageEmbedder bound; embedder_remote_ ready
             → embedder_remote_->GenerateEmbeddings (subsequent batches)
               → WASM renderer (EmbeddingGemma, one passage at a time)
                 → HistoryEmbeddingsService (stores passages + embeddings)

--- a/browser/history_embeddings/README.md
+++ b/browser/history_embeddings/README.md
@@ -73,10 +73,9 @@ without touching the upstream header (see
 
 - **`brave_passage_embeddings_service.{h,cc}`** — In-process
   implementation of `passage_embeddings::mojom::PassageEmbeddingsService`.
-  Exposes a direct `BindPassageEmbedder(...)` entry point used by the
-  controller. Reads the five EmbeddingGemma model files from disk in
-  response to `LocalModelsUpdaterState` notifications and hands them
-  to `BraveBatchPassageEmbedder` via `SetModelFiles`. Also hosts the
+  Exposes a direct `BindPassageEmbedder(receiver, model_files, cb)`
+  entry point used by the controller; constructs a
+  `BraveBatchPassageEmbedder` around the supplied files. Also hosts the
   static `WebContents*` → bind-callback registry used by
   `UntrustedLocalAIUI::BindInterface` (the registered callback routes
   to the active `BraveBatchPassageEmbedder`).
@@ -88,21 +87,25 @@ without touching the upstream header (see
   that hosts the WASM worker, the `LocalAIService` receiver set the
   WASM page uses to register its `PassageEmbedderFactory`, and the
   `factory->Init` + `factory->Bind` handshake. Initialization is gated
-  on an explicit `LoadPhase` (`kCreatingContents → kAwaitingPrereqs →
-  kInitializing → kReady`); Init runs once the renderer registers its
-  factory and the service hands over loaded model files. Translates
+  on an explicit `LoadPhase` (`kCreatingContents → kAwaitingFactory →
+  kInitializing → kReady`); the model files arrive via the ctor, and
+  Init runs as soon as the renderer registers its factory. Translates
   upstream's batch mojom to the renderer's one-passage-at-a-time
   interface, processing passages sequentially so callbacks resolve
   with embeddings in order.
 
 - **`brave_passage_embeddings_service_controller.{h,cc}`** — Singleton
-  subclass of `PassageEmbeddingsServiceController`. Overrides
-  `MaybeLaunchService()`/`ResetServiceRemote()` to construct/destroy
-  the in-process service, `EmbedderReady()`/`GetEmbedderMetadata()`
-  to report static metadata, and `GetEmbeddings()` to call
-  `service_->BindPassageEmbedder()` directly and route batches to the
-  bound `embedder_remote_`. Fires the initial
-  `EmbedderMetadataUpdated` notification in its constructor.
+  subclass of `PassageEmbeddingsServiceController`. Observes
+  `LocalModelsUpdaterState` so it knows when the EmbeddingGemma
+  component is installed; `EmbedderReady()` returns true iff the
+  component is present, and `OnLocalModelsReady` fires
+  `EmbedderMetadataUpdated` on observer_list_ so SchedulingEmbedder
+  retries. Overrides `MaybeLaunchService()`/`ResetServiceRemote()`
+  to construct/destroy the in-process service, and
+  `GetEmbeddings()` to short-circuit with `kModelUnavailable` when not
+  ready, otherwise post the disk read for the five EmbeddingGemma
+  files and hand them to `service_->BindPassageEmbedder()` once
+  loaded.
 
 ## Related Files
 
@@ -143,11 +146,16 @@ PageContentAnnotationsWebContentsObserver (upstream)
       → PageEmbeddingsService (chunks text into passages)
         → SchedulingEmbedder (upstream; queues, reorders by priority)
           → BravePassageEmbeddingsServiceController::GetEmbeddings
-            → service_->BindPassageEmbedder (first time, in-process)
-              → BraveBatchPassageEmbedder created; creates background
-                WebContents and waits for factory registration + model files
-                → PassageEmbedderFactory::Init (loads WASM model)
-                  → renderer-side PassageEmbedder bound; embedder_remote_ ready
+            → !EmbedderReady() → kModelUnavailable (SchedulingEmbedder
+              retries on the next EmbedderMetadataUpdated)
+            → PostTask: read five EmbeddingGemma files from disk
+              → service_->BindPassageEmbedder(receiver, model_files, cb)
+                → BraveBatchPassageEmbedder created with files in hand;
+                  creates background WebContents and waits for factory
+                  registration
+                  → PassageEmbedderFactory::Init (loads WASM model)
+                    → renderer-side PassageEmbedder bound; embedder_remote_
+                      ready
             → embedder_remote_->GenerateEmbeddings (subsequent batches)
               → WASM renderer (EmbeddingGemma, one passage at a time)
                 → HistoryEmbeddingsService (stores passages + embeddings)

--- a/browser/history_embeddings/brave_batch_passage_embedder.cc
+++ b/browser/history_embeddings/brave_batch_passage_embedder.cc
@@ -28,14 +28,11 @@ BraveBatchPassageEmbedder::BraveBatchPassageEmbedder(
     base::OnceClosure on_disconnect)
     : background_web_contents_factory_(
           std::move(background_web_contents_factory)),
-      receiver_(this, std::move(receiver)),
+      pending_receiver_(std::move(receiver)),
       model_files_(std::move(model_files)),
       load_callback_(std::move(load_callback)),
       on_disconnect_(std::move(on_disconnect)) {
   CHECK(model_files_);
-  receiver_.set_disconnect_handler(
-      base::BindOnce(&BraveBatchPassageEmbedder::OnDisconnected,
-                     weak_ptr_factory_.GetWeakPtr()));
   background_web_contents_factory_.Run(
       this,
       base::BindOnce(&BraveBatchPassageEmbedder::OnBackgroundContentsCreated,
@@ -147,6 +144,13 @@ void BraveBatchPassageEmbedder::OnInitDone(bool success) {
   renderer_embedder_.set_disconnect_handler(
       base::BindOnce(&BraveBatchPassageEmbedder::OnDisconnected,
                      weak_ptr_factory_.GetWeakPtr()));
+  // Now that the renderer-side pipe is up, bind the caller-side
+  // receiver. Any GenerateEmbeddings calls already on the wire drain
+  // here.
+  receiver_.Bind(std::move(pending_receiver_));
+  receiver_.set_disconnect_handler(
+      base::BindOnce(&BraveBatchPassageEmbedder::OnDisconnected,
+                     weak_ptr_factory_.GetWeakPtr()));
   phase_ = LoadPhase::kReady;
   DVLOG(3) << "Factory Init succeeded; signaling load success";
   std::move(load_callback_).Run(true);
@@ -160,12 +164,9 @@ void BraveBatchPassageEmbedder::ProcessNext() {
   current_batch_.emplace(std::move(pending_batches_.front()));
   pending_batches_.pop_front();
 
-  if (!renderer_embedder_.is_bound()) {
-    DVLOG(1) << "Renderer embedder not bound; failing batch of "
-             << current_batch_->passages.size() << " passage(s)";
-    FailCurrentBatch();
-    return;
-  }
+  // GenerateEmbeddings can only be delivered after OnInitDone bound
+  // receiver_, which also binds renderer_embedder_.
+  CHECK(renderer_embedder_.is_bound());
   DVLOG(3) << "ProcessNext: dispatching passage "
            << current_batch_->next_index + 1 << "/"
            << current_batch_->passages.size();

--- a/browser/history_embeddings/brave_batch_passage_embedder.cc
+++ b/browser/history_embeddings/brave_batch_passage_embedder.cc
@@ -22,17 +22,23 @@ BraveBatchPassageEmbedder::Batch& BraveBatchPassageEmbedder::Batch::operator=(
 
 BraveBatchPassageEmbedder::BraveBatchPassageEmbedder(
     mojo::PendingReceiver<mojom::PassageEmbedder> receiver,
-    mojo::PendingRemote<local_ai::mojom::PassageEmbedder> renderer_embedder,
+    mojo::Remote<local_ai::mojom::PassageEmbedderFactory> factory,
+    local_ai::mojom::ModelFilesPtr model_files,
+    base::OnceCallback<void(bool)> load_callback,
     base::OnceClosure on_disconnect)
     : receiver_(this, std::move(receiver)),
-      renderer_embedder_(std::move(renderer_embedder)),
+      factory_(std::move(factory)),
+      load_callback_(std::move(load_callback)),
       on_disconnect_(std::move(on_disconnect)) {
   receiver_.set_disconnect_handler(
       base::BindOnce(&BraveBatchPassageEmbedder::OnDisconnected,
                      weak_ptr_factory_.GetWeakPtr()));
-  renderer_embedder_.set_disconnect_handler(
+  factory_.set_disconnect_handler(
       base::BindOnce(&BraveBatchPassageEmbedder::OnDisconnected,
                      weak_ptr_factory_.GetWeakPtr()));
+  factory_->Init(std::move(model_files),
+                 base::BindOnce(&BraveBatchPassageEmbedder::OnInitDone,
+                                weak_ptr_factory_.GetWeakPtr()));
 }
 
 BraveBatchPassageEmbedder::~BraveBatchPassageEmbedder() = default;
@@ -54,6 +60,20 @@ void BraveBatchPassageEmbedder::GenerateEmbeddings(
   if (!current_batch_) {
     ProcessNext();
   }
+}
+
+void BraveBatchPassageEmbedder::OnInitDone(bool success) {
+  if (!success) {
+    DVLOG(1) << "Factory Init failed";
+    OnDisconnected();
+    return;
+  }
+  factory_->Bind(renderer_embedder_.BindNewPipeAndPassReceiver());
+  renderer_embedder_.set_disconnect_handler(
+      base::BindOnce(&BraveBatchPassageEmbedder::OnDisconnected,
+                     weak_ptr_factory_.GetWeakPtr()));
+  DVLOG(3) << "Factory Init succeeded; signaling load success";
+  std::move(load_callback_).Run(true);
 }
 
 void BraveBatchPassageEmbedder::ProcessNext() {
@@ -132,6 +152,11 @@ void BraveBatchPassageEmbedder::FailCurrentBatch() {
 }
 
 void BraveBatchPassageEmbedder::OnDisconnected() {
+  // If Init hasn't replied yet, fail the outstanding load.
+  if (load_callback_) {
+    std::move(load_callback_).Run(false);
+  }
+
   std::deque<Batch> to_fail = std::move(pending_batches_);
   if (current_batch_) {
     to_fail.push_front(std::move(*current_batch_));

--- a/browser/history_embeddings/brave_batch_passage_embedder.cc
+++ b/browser/history_embeddings/brave_batch_passage_embedder.cc
@@ -22,26 +22,56 @@ BraveBatchPassageEmbedder::Batch& BraveBatchPassageEmbedder::Batch::operator=(
 
 BraveBatchPassageEmbedder::BraveBatchPassageEmbedder(
     mojo::PendingReceiver<mojom::PassageEmbedder> receiver,
-    mojo::Remote<local_ai::mojom::PassageEmbedderFactory> factory,
-    local_ai::mojom::ModelFilesPtr model_files,
+    BackgroundWebContentsFactory background_web_contents_factory,
     base::OnceCallback<void(bool)> load_callback,
     base::OnceClosure on_disconnect)
-    : receiver_(this, std::move(receiver)),
-      factory_(std::move(factory)),
+    : background_web_contents_factory_(
+          std::move(background_web_contents_factory)),
+      receiver_(this, std::move(receiver)),
       load_callback_(std::move(load_callback)),
       on_disconnect_(std::move(on_disconnect)) {
   receiver_.set_disconnect_handler(
       base::BindOnce(&BraveBatchPassageEmbedder::OnDisconnected,
                      weak_ptr_factory_.GetWeakPtr()));
-  factory_.set_disconnect_handler(
-      base::BindOnce(&BraveBatchPassageEmbedder::OnDisconnected,
+  background_web_contents_factory_.Run(
+      this,
+      base::BindOnce(&BraveBatchPassageEmbedder::OnBackgroundContentsCreated,
                      weak_ptr_factory_.GetWeakPtr()));
-  factory_->Init(std::move(model_files),
-                 base::BindOnce(&BraveBatchPassageEmbedder::OnInitDone,
-                                weak_ptr_factory_.GetWeakPtr()));
 }
 
-BraveBatchPassageEmbedder::~BraveBatchPassageEmbedder() = default;
+BraveBatchPassageEmbedder::~BraveBatchPassageEmbedder() {
+  // Owner is destroying us — fail any still-pending load before we go
+  // away. Don't fire on_disconnect_; the owner already knows.
+  if (load_callback_) {
+    std::move(load_callback_).Run(false);
+  }
+}
+
+void BraveBatchPassageEmbedder::SetModelFiles(
+    local_ai::mojom::ModelFilesPtr model_files) {
+  CHECK(model_files);
+  // A re-fire of LocalModelsUpdaterState::OnLocalModelsReady can drive
+  // the service to post another file-load after Init has already
+  // started/completed. The original files were moved into
+  // factory_->Init at that point; ignore the late reload.
+  if (phase_ != LoadPhase::kCreatingContents &&
+      phase_ != LoadPhase::kAwaitingPrereqs) {
+    DVLOG(1) << "SetModelFiles ignored in phase=" << static_cast<int>(phase_);
+    return;
+  }
+  pending_model_files_ = std::move(model_files);
+  MaybeStartInit();
+}
+
+void BraveBatchPassageEmbedder::BindLocalAIReceiver(
+    mojo::PendingReceiver<local_ai::mojom::LocalAIService> receiver) {
+  local_ai_receivers_.Add(this, std::move(receiver));
+}
+
+base::WeakPtr<BraveBatchPassageEmbedder>
+BraveBatchPassageEmbedder::GetWeakPtr() {
+  return weak_ptr_factory_.GetWeakPtr();
+}
 
 void BraveBatchPassageEmbedder::GenerateEmbeddings(
     const std::vector<std::string>& passages,
@@ -62,7 +92,66 @@ void BraveBatchPassageEmbedder::GenerateEmbeddings(
   }
 }
 
+void BraveBatchPassageEmbedder::RegisterPassageEmbedderFactory(
+    mojo::PendingRemote<local_ai::mojom::PassageEmbedderFactory> factory) {
+  // A buggy or compromised renderer could call this twice without first
+  // triggering a disconnect, or call it after the renderer-side
+  // PassageEmbedder pipe is already up. mojo::Remote::Bind CHECKs when
+  // already bound; the phase guard rejects any call past
+  // kAwaitingPrereqs so duplicates can't crash the browser.
+  if (phase_ != LoadPhase::kAwaitingPrereqs || factory_.is_bound()) {
+    DVLOG(1) << "Ignoring RegisterPassageEmbedderFactory in phase="
+             << static_cast<int>(phase_);
+    return;
+  }
+  factory_.Bind(std::move(factory));
+  factory_.set_disconnect_handler(
+      base::BindOnce(&BraveBatchPassageEmbedder::OnDisconnected,
+                     weak_ptr_factory_.GetWeakPtr()));
+  MaybeStartInit();
+}
+
+void BraveBatchPassageEmbedder::OnBackgroundContentsDestroyed(
+    local_ai::BackgroundWebContents::DestroyReason reason) {
+  DVLOG(1) << "Background contents destroyed unexpectedly, reason="
+           << static_cast<int>(reason);
+  background_web_contents_.reset();
+  OnDisconnected();
+}
+
+void BraveBatchPassageEmbedder::OnBackgroundContentsCreated(
+    std::unique_ptr<local_ai::BackgroundWebContents> contents) {
+  if (phase_ != LoadPhase::kCreatingContents) {
+    DVLOG(1) << "OnBackgroundContentsCreated ignored in phase="
+             << static_cast<int>(phase_);
+    return;
+  }
+  if (!contents) {
+    DVLOG(1) << "Background contents creation failed";
+    OnDisconnected();
+    return;
+  }
+  background_web_contents_ = std::move(contents);
+  phase_ = LoadPhase::kAwaitingPrereqs;
+  MaybeStartInit();
+}
+
+void BraveBatchPassageEmbedder::MaybeStartInit() {
+  if (phase_ != LoadPhase::kAwaitingPrereqs || !factory_.is_bound() ||
+      !pending_model_files_) {
+    return;
+  }
+  phase_ = LoadPhase::kInitializing;
+  factory_->Init(std::move(pending_model_files_),
+                 base::BindOnce(&BraveBatchPassageEmbedder::OnInitDone,
+                                weak_ptr_factory_.GetWeakPtr()));
+}
+
 void BraveBatchPassageEmbedder::OnInitDone(bool success) {
+  if (phase_ != LoadPhase::kInitializing) {
+    DVLOG(1) << "OnInitDone ignored in phase=" << static_cast<int>(phase_);
+    return;
+  }
   if (!success) {
     DVLOG(1) << "Factory Init failed";
     OnDisconnected();
@@ -72,6 +161,7 @@ void BraveBatchPassageEmbedder::OnInitDone(bool success) {
   renderer_embedder_.set_disconnect_handler(
       base::BindOnce(&BraveBatchPassageEmbedder::OnDisconnected,
                      weak_ptr_factory_.GetWeakPtr()));
+  phase_ = LoadPhase::kReady;
   DVLOG(3) << "Factory Init succeeded; signaling load success";
   std::move(load_callback_).Run(true);
 }

--- a/browser/history_embeddings/brave_batch_passage_embedder.cc
+++ b/browser/history_embeddings/brave_batch_passage_embedder.cc
@@ -23,13 +23,16 @@ BraveBatchPassageEmbedder::Batch& BraveBatchPassageEmbedder::Batch::operator=(
 BraveBatchPassageEmbedder::BraveBatchPassageEmbedder(
     mojo::PendingReceiver<mojom::PassageEmbedder> receiver,
     BackgroundWebContentsFactory background_web_contents_factory,
+    local_ai::mojom::ModelFilesPtr model_files,
     base::OnceCallback<void(bool)> load_callback,
     base::OnceClosure on_disconnect)
     : background_web_contents_factory_(
           std::move(background_web_contents_factory)),
       receiver_(this, std::move(receiver)),
+      model_files_(std::move(model_files)),
       load_callback_(std::move(load_callback)),
       on_disconnect_(std::move(on_disconnect)) {
+  CHECK(model_files_);
   receiver_.set_disconnect_handler(
       base::BindOnce(&BraveBatchPassageEmbedder::OnDisconnected,
                      weak_ptr_factory_.GetWeakPtr()));
@@ -45,22 +48,6 @@ BraveBatchPassageEmbedder::~BraveBatchPassageEmbedder() {
   if (load_callback_) {
     std::move(load_callback_).Run(false);
   }
-}
-
-void BraveBatchPassageEmbedder::SetModelFiles(
-    local_ai::mojom::ModelFilesPtr model_files) {
-  CHECK(model_files);
-  // A re-fire of LocalModelsUpdaterState::OnLocalModelsReady can drive
-  // the service to post another file-load after Init has already
-  // started/completed. The original files were moved into
-  // factory_->Init at that point; ignore the late reload.
-  if (phase_ != LoadPhase::kCreatingContents &&
-      phase_ != LoadPhase::kAwaitingPrereqs) {
-    DVLOG(1) << "SetModelFiles ignored in phase=" << static_cast<int>(phase_);
-    return;
-  }
-  pending_model_files_ = std::move(model_files);
-  MaybeStartInit();
 }
 
 void BraveBatchPassageEmbedder::BindLocalAIReceiver(
@@ -98,8 +85,8 @@ void BraveBatchPassageEmbedder::RegisterPassageEmbedderFactory(
   // triggering a disconnect, or call it after the renderer-side
   // PassageEmbedder pipe is already up. mojo::Remote::Bind CHECKs when
   // already bound; the phase guard rejects any call past
-  // kAwaitingPrereqs so duplicates can't crash the browser.
-  if (phase_ != LoadPhase::kAwaitingPrereqs || factory_.is_bound()) {
+  // kAwaitingFactory so duplicates can't crash the browser.
+  if (phase_ != LoadPhase::kAwaitingFactory || factory_.is_bound()) {
     DVLOG(1) << "Ignoring RegisterPassageEmbedderFactory in phase="
              << static_cast<int>(phase_);
     return;
@@ -132,17 +119,16 @@ void BraveBatchPassageEmbedder::OnBackgroundContentsCreated(
     return;
   }
   background_web_contents_ = std::move(contents);
-  phase_ = LoadPhase::kAwaitingPrereqs;
+  phase_ = LoadPhase::kAwaitingFactory;
   MaybeStartInit();
 }
 
 void BraveBatchPassageEmbedder::MaybeStartInit() {
-  if (phase_ != LoadPhase::kAwaitingPrereqs || !factory_.is_bound() ||
-      !pending_model_files_) {
+  if (phase_ != LoadPhase::kAwaitingFactory || !factory_.is_bound()) {
     return;
   }
   phase_ = LoadPhase::kInitializing;
-  factory_->Init(std::move(pending_model_files_),
+  factory_->Init(std::move(model_files_),
                  base::BindOnce(&BraveBatchPassageEmbedder::OnInitDone,
                                 weak_ptr_factory_.GetWeakPtr()));
 }

--- a/browser/history_embeddings/brave_batch_passage_embedder.h
+++ b/browser/history_embeddings/brave_batch_passage_embedder.h
@@ -31,12 +31,10 @@ namespace passage_embeddings {
 // to register its PassageEmbedderFactory, and the factory->Init +
 // factory->Bind handshake.
 //
-// Construction kicks off background contents creation. Initialization
-// proceeds once both halves are present: the renderer registers its
-// PassageEmbedderFactory via RegisterPassageEmbedderFactory, and the
-// owner (BravePassageEmbeddingsService) hands over loaded model files
-// via SetModelFiles. The embedder then drives factory->Init and
-// binds the per-embedder renderer pipe.
+// The owner (BravePassageEmbeddingsService) constructs this with the
+// loaded model files already in hand. Construction kicks off the
+// background WebContents; init proceeds once the renderer registers
+// its PassageEmbedderFactory via RegisterPassageEmbedderFactory.
 //
 // Disconnect handling (renderer crash, factory drop, caller drop, or
 // background contents teardown) routes through OnDisconnected, which
@@ -61,6 +59,7 @@ class BraveBatchPassageEmbedder
   BraveBatchPassageEmbedder(
       mojo::PendingReceiver<mojom::PassageEmbedder> receiver,
       BackgroundWebContentsFactory background_web_contents_factory,
+      local_ai::mojom::ModelFilesPtr model_files,
       base::OnceCallback<void(bool)> load_callback,
       base::OnceClosure on_disconnect);
   ~BraveBatchPassageEmbedder() override;
@@ -68,11 +67,6 @@ class BraveBatchPassageEmbedder
   BraveBatchPassageEmbedder(const BraveBatchPassageEmbedder&) = delete;
   BraveBatchPassageEmbedder& operator=(const BraveBatchPassageEmbedder&) =
       delete;
-
-  // Hands the loaded model files in. Drives factory->Init if the
-  // renderer factory is already registered; otherwise stashes the files
-  // until RegisterPassageEmbedderFactory arrives.
-  void SetModelFiles(local_ai::mojom::ModelFilesPtr model_files);
 
   // Adds a renderer-facing LocalAIService receiver. Installed as the
   // BindCallback in the static registry on BravePassageEmbeddingsService
@@ -132,22 +126,20 @@ class BraveBatchPassageEmbedder
   mojo::Remote<local_ai::mojom::PassageEmbedderFactory> factory_;
   mojo::Remote<local_ai::mojom::PassageEmbedder> renderer_embedder_;
 
-  // Stashed until both factory_ and pending_model_files_ are present;
-  // moved into factory_->Init when the handshake starts.
-  local_ai::mojom::ModelFilesPtr pending_model_files_;
+  // Held from ctor until factory_->Init consumes them.
+  local_ai::mojom::ModelFilesPtr model_files_;
 
   // Load sequence:
   //   kCreatingContents  -> ctor invoked the BackgroundWebContentsFactory
   //                         and is waiting for OnBackgroundContentsCreated.
-  //   kAwaitingPrereqs   -> background contents up; waiting for the
-  //                         renderer to RegisterPassageEmbedderFactory and
-  //                         the owner to call SetModelFiles.
-  //   kInitializing      -> both prereqs present; factory_->Init in flight.
+  //   kAwaitingFactory   -> background contents up; waiting for the
+  //                         renderer to RegisterPassageEmbedderFactory.
+  //   kInitializing      -> factory registered; factory_->Init in flight.
   //   kReady             -> Init succeeded and the renderer-side
   //                         PassageEmbedder pipe is bound; batches flow.
   enum class LoadPhase {
     kCreatingContents,
-    kAwaitingPrereqs,
+    kAwaitingFactory,
     kInitializing,
     kReady,
   };

--- a/browser/history_embeddings/brave_batch_passage_embedder.h
+++ b/browser/history_embeddings/brave_batch_passage_embedder.h
@@ -15,7 +15,6 @@
 #include "base/memory/weak_ptr.h"
 #include "brave/components/local_ai/core/local_ai.mojom.h"
 #include "mojo/public/cpp/bindings/pending_receiver.h"
-#include "mojo/public/cpp/bindings/pending_remote.h"
 #include "mojo/public/cpp/bindings/receiver.h"
 #include "mojo/public/cpp/bindings/remote.h"
 #include "services/passage_embeddings/public/mojom/passage_embeddings.mojom.h"
@@ -23,15 +22,27 @@
 namespace passage_embeddings {
 
 // In-process implementation of passage_embeddings::mojom::PassageEmbedder
-// that wraps a renderer-side local_ai PassageEmbedder. Upstream's
-// SchedulingEmbedder speaks this mojom; we translate its batch calls to
-// the renderer's single-passage interface, processing passages
-// sequentially so callbacks resolve with all embeddings in order.
+// that wraps a renderer-side local_ai PassageEmbedder.
+//
+// Owns the full renderer-side lifecycle for a single LoadModels call:
+// it receives the PassageEmbedderFactory remote + loaded ModelFiles
+// from BravePassageEmbeddingsService, drives factory->Init on
+// construction, binds the per-embedder renderer pipe on success, and
+// self-signals disconnect so the service can reset and accept a new
+// load request. This mirrors upstream's PassageEmbedder, which
+// similarly self-manages receiver, model load, and disconnect.
+//
+// Upstream's SchedulingEmbedder speaks mojom::PassageEmbedder in
+// batches; we translate to the renderer's single-passage interface,
+// processing passages sequentially so callbacks resolve with all
+// embeddings in order.
 class BraveBatchPassageEmbedder : public mojom::PassageEmbedder {
  public:
   BraveBatchPassageEmbedder(
       mojo::PendingReceiver<mojom::PassageEmbedder> receiver,
-      mojo::PendingRemote<local_ai::mojom::PassageEmbedder> renderer_embedder,
+      mojo::Remote<local_ai::mojom::PassageEmbedderFactory> factory,
+      local_ai::mojom::ModelFilesPtr model_files,
+      base::OnceCallback<void(bool)> load_callback,
       base::OnceClosure on_disconnect);
   ~BraveBatchPassageEmbedder() override;
 
@@ -57,6 +68,7 @@ class BraveBatchPassageEmbedder : public mojom::PassageEmbedder {
     size_t next_index = 0;
   };
 
+  void OnInitDone(bool success);
   void ProcessNext();
   void OnOneEmbedding(const std::vector<double>& embedding);
   void FailCurrentBatch();
@@ -69,7 +81,11 @@ class BraveBatchPassageEmbedder : public mojom::PassageEmbedder {
   std::deque<Batch> pending_batches_;
 
   mojo::Receiver<mojom::PassageEmbedder> receiver_;
+  mojo::Remote<local_ai::mojom::PassageEmbedderFactory> factory_;
   mojo::Remote<local_ai::mojom::PassageEmbedder> renderer_embedder_;
+  // Run exactly once with true on successful Init+Bind or false on any
+  // failure path (Init error, early disconnect before Init replies).
+  base::OnceCallback<void(bool)> load_callback_;
   base::OnceClosure on_disconnect_;
 
   base::WeakPtrFactory<BraveBatchPassageEmbedder> weak_ptr_factory_{this};

--- a/browser/history_embeddings/brave_batch_passage_embedder.h
+++ b/browser/history_embeddings/brave_batch_passage_embedder.h
@@ -122,7 +122,13 @@ class BraveBatchPassageEmbedder
   std::optional<Batch> current_batch_;
   std::deque<Batch> pending_batches_;
 
-  mojo::Receiver<mojom::PassageEmbedder> receiver_;
+  // Held unbound until OnInitDone(true) binds receiver_ to it. Callers
+  // dispatch GenerateEmbeddings through embedder_remote_ immediately
+  // after BindPassageEmbedder; mojo queues those messages on the pipe
+  // until the receiver actually binds, so by the time GenerateEmbeddings
+  // is delivered to this object renderer_embedder_ is guaranteed bound.
+  mojo::PendingReceiver<mojom::PassageEmbedder> pending_receiver_;
+  mojo::Receiver<mojom::PassageEmbedder> receiver_{this};
   mojo::Remote<local_ai::mojom::PassageEmbedderFactory> factory_;
   mojo::Remote<local_ai::mojom::PassageEmbedder> renderer_embedder_;
 

--- a/browser/history_embeddings/brave_batch_passage_embedder.h
+++ b/browser/history_embeddings/brave_batch_passage_embedder.h
@@ -7,41 +7,60 @@
 #define BRAVE_BROWSER_HISTORY_EMBEDDINGS_BRAVE_BATCH_PASSAGE_EMBEDDER_H_
 
 #include <deque>
+#include <memory>
 #include <optional>
 #include <string>
 #include <vector>
 
 #include "base/functional/callback.h"
 #include "base/memory/weak_ptr.h"
+#include "brave/components/local_ai/core/background_web_contents.h"
 #include "brave/components/local_ai/core/local_ai.mojom.h"
 #include "mojo/public/cpp/bindings/pending_receiver.h"
 #include "mojo/public/cpp/bindings/receiver.h"
+#include "mojo/public/cpp/bindings/receiver_set.h"
 #include "mojo/public/cpp/bindings/remote.h"
 #include "services/passage_embeddings/public/mojom/passage_embeddings.mojom.h"
 
 namespace passage_embeddings {
 
 // In-process implementation of passage_embeddings::mojom::PassageEmbedder
-// that wraps a renderer-side local_ai PassageEmbedder.
+// that owns the full renderer-side lifecycle for a single load:
+// the background WebContents that hosts the WASM worker, the
+// renderer-facing LocalAIService receiver set used by the WASM page
+// to register its PassageEmbedderFactory, and the factory->Init +
+// factory->Bind handshake.
 //
-// Owns the full renderer-side lifecycle for a single LoadModels call:
-// it receives the PassageEmbedderFactory remote + loaded ModelFiles
-// from BravePassageEmbeddingsService, drives factory->Init on
-// construction, binds the per-embedder renderer pipe on success, and
-// self-signals disconnect so the service can reset and accept a new
-// load request. This mirrors upstream's PassageEmbedder, which
-// similarly self-manages receiver, model load, and disconnect.
+// Construction kicks off background contents creation. Initialization
+// proceeds once both halves are present: the renderer registers its
+// PassageEmbedderFactory via RegisterPassageEmbedderFactory, and the
+// owner (BravePassageEmbeddingsService) hands over loaded model files
+// via SetModelFiles. The embedder then drives factory->Init and
+// binds the per-embedder renderer pipe.
 //
-// Upstream's SchedulingEmbedder speaks mojom::PassageEmbedder in
-// batches; we translate to the renderer's single-passage interface,
-// processing passages sequentially so callbacks resolve with all
-// embeddings in order.
-class BraveBatchPassageEmbedder : public mojom::PassageEmbedder {
+// Disconnect handling (renderer crash, factory drop, caller drop, or
+// background contents teardown) routes through OnDisconnected, which
+// fires on_disconnect so the owner can drop this instance and accept
+// a new load.
+//
+// Upstream's SchedulingEmbedder (kept in the controller) speaks
+// mojom::PassageEmbedder in batches; we translate to the renderer's
+// single-passage interface, processing passages sequentially so
+// callbacks resolve with all embeddings in order.
+class BraveBatchPassageEmbedder
+    : public mojom::PassageEmbedder,
+      public local_ai::mojom::LocalAIService,
+      public local_ai::BackgroundWebContents::Delegate {
  public:
+  using BackgroundWebContentsCreatedCallback = base::OnceCallback<void(
+      std::unique_ptr<local_ai::BackgroundWebContents>)>;
+  using BackgroundWebContentsFactory = base::RepeatingCallback<void(
+      local_ai::BackgroundWebContents::Delegate* delegate,
+      BackgroundWebContentsCreatedCallback)>;
+
   BraveBatchPassageEmbedder(
       mojo::PendingReceiver<mojom::PassageEmbedder> receiver,
-      mojo::Remote<local_ai::mojom::PassageEmbedderFactory> factory,
-      local_ai::mojom::ModelFilesPtr model_files,
+      BackgroundWebContentsFactory background_web_contents_factory,
       base::OnceCallback<void(bool)> load_callback,
       base::OnceClosure on_disconnect);
   ~BraveBatchPassageEmbedder() override;
@@ -50,10 +69,32 @@ class BraveBatchPassageEmbedder : public mojom::PassageEmbedder {
   BraveBatchPassageEmbedder& operator=(const BraveBatchPassageEmbedder&) =
       delete;
 
+  // Hands the loaded model files in. Drives factory->Init if the
+  // renderer factory is already registered; otherwise stashes the files
+  // until RegisterPassageEmbedderFactory arrives.
+  void SetModelFiles(local_ai::mojom::ModelFilesPtr model_files);
+
+  // Adds a renderer-facing LocalAIService receiver. Installed as the
+  // BindCallback in the static registry on BravePassageEmbeddingsService
+  // when the controller creates the background WebContents.
+  void BindLocalAIReceiver(
+      mojo::PendingReceiver<local_ai::mojom::LocalAIService> receiver);
+
+  base::WeakPtr<BraveBatchPassageEmbedder> GetWeakPtr();
+
   // mojom::PassageEmbedder:
   void GenerateEmbeddings(const std::vector<std::string>& passages,
                           mojom::PassagePriority priority,
                           GenerateEmbeddingsCallback callback) override;
+
+  // local_ai::mojom::LocalAIService:
+  void RegisterPassageEmbedderFactory(
+      mojo::PendingRemote<local_ai::mojom::PassageEmbedderFactory> factory)
+      override;
+
+  // local_ai::BackgroundWebContents::Delegate:
+  void OnBackgroundContentsDestroyed(
+      local_ai::BackgroundWebContents::DestroyReason reason) override;
 
  private:
   struct Batch {
@@ -68,6 +109,9 @@ class BraveBatchPassageEmbedder : public mojom::PassageEmbedder {
     size_t next_index = 0;
   };
 
+  void OnBackgroundContentsCreated(
+      std::unique_ptr<local_ai::BackgroundWebContents> contents);
+  void MaybeStartInit();
   void OnInitDone(bool success);
   void ProcessNext();
   void OnOneEmbedding(const std::vector<double>& embedding);
@@ -77,14 +121,41 @@ class BraveBatchPassageEmbedder : public mojom::PassageEmbedder {
   static std::optional<std::vector<float>> ToFloatEmbedding(
       const std::vector<double>& embedding);
 
+  std::unique_ptr<local_ai::BackgroundWebContents> background_web_contents_;
+  BackgroundWebContentsFactory background_web_contents_factory_;
+  mojo::ReceiverSet<local_ai::mojom::LocalAIService> local_ai_receivers_;
+
   std::optional<Batch> current_batch_;
   std::deque<Batch> pending_batches_;
 
   mojo::Receiver<mojom::PassageEmbedder> receiver_;
   mojo::Remote<local_ai::mojom::PassageEmbedderFactory> factory_;
   mojo::Remote<local_ai::mojom::PassageEmbedder> renderer_embedder_;
+
+  // Stashed until both factory_ and pending_model_files_ are present;
+  // moved into factory_->Init when the handshake starts.
+  local_ai::mojom::ModelFilesPtr pending_model_files_;
+
+  // Load sequence:
+  //   kCreatingContents  -> ctor invoked the BackgroundWebContentsFactory
+  //                         and is waiting for OnBackgroundContentsCreated.
+  //   kAwaitingPrereqs   -> background contents up; waiting for the
+  //                         renderer to RegisterPassageEmbedderFactory and
+  //                         the owner to call SetModelFiles.
+  //   kInitializing      -> both prereqs present; factory_->Init in flight.
+  //   kReady             -> Init succeeded and the renderer-side
+  //                         PassageEmbedder pipe is bound; batches flow.
+  enum class LoadPhase {
+    kCreatingContents,
+    kAwaitingPrereqs,
+    kInitializing,
+    kReady,
+  };
+  LoadPhase phase_ = LoadPhase::kCreatingContents;
+
   // Run exactly once with true on successful Init+Bind or false on any
-  // failure path (Init error, early disconnect before Init replies).
+  // failure path (Init error, early disconnect before Init replies,
+  // owner-side teardown before the load completes).
   base::OnceCallback<void(bool)> load_callback_;
   base::OnceClosure on_disconnect_;
 

--- a/browser/history_embeddings/brave_batch_passage_embedder_unittest.cc
+++ b/browser/history_embeddings/brave_batch_passage_embedder_unittest.cc
@@ -11,11 +11,13 @@
 #include <vector>
 
 #include "base/functional/bind.h"
+#include "base/memory/raw_ptr.h"
+#include "base/test/run_until.h"
 #include "base/test/task_environment.h"
 #include "base/test/test_future.h"
 #include "brave/components/local_ai/core/local_ai.mojom.h"
 #include "mojo/public/cpp/bindings/pending_receiver.h"
-#include "mojo/public/cpp/bindings/pending_remote.h"
+#include "mojo/public/cpp/bindings/receiver.h"
 #include "mojo/public/cpp/bindings/receiver_set.h"
 #include "mojo/public/cpp/bindings/remote.h"
 #include "services/passage_embeddings/public/mojom/passage_embeddings.mojom.h"
@@ -38,8 +40,8 @@ std::vector<float> AsFloatVector(const double (&arr)[3]) {
 }
 
 // Renderer-side fake. By default returns kEmbeddingA for every passage;
-// queue per-call canned responses to simulate empty / out-of-range
-// returns.
+// configurable to return per-call canned values, an empty embedding, or
+// an out-of-float-range value.
 class FakeRendererEmbedder : public local_ai::mojom::PassageEmbedder {
  public:
   void GenerateEmbeddings(const std::string& text,
@@ -54,10 +56,9 @@ class FakeRendererEmbedder : public local_ai::mojom::PassageEmbedder {
     std::move(callback).Run(AsVector(kEmbeddingA));
   }
 
-  mojo::PendingRemote<local_ai::mojom::PassageEmbedder> BindNewRemote() {
-    mojo::PendingRemote<local_ai::mojom::PassageEmbedder> remote;
-    receivers_.Add(this, remote.InitWithNewPipeAndPassReceiver());
-    return remote;
+  void AddReceiver(
+      mojo::PendingReceiver<local_ai::mojom::PassageEmbedder> receiver) {
+    receivers_.Add(this, std::move(receiver));
   }
 
   void QueueResponse(std::vector<double> response) {
@@ -73,15 +74,68 @@ class FakeRendererEmbedder : public local_ai::mojom::PassageEmbedder {
   mojo::ReceiverSet<local_ai::mojom::PassageEmbedder> receivers_;
 };
 
+// Factory fake. Init replies asynchronously with init_success_; Bind
+// forwards the receiver to the renderer worker.
+class FakePassageEmbedderFactory
+    : public local_ai::mojom::PassageEmbedderFactory {
+ public:
+  explicit FakePassageEmbedderFactory(FakeRendererEmbedder* worker)
+      : worker_(worker) {}
+
+  void Init(local_ai::mojom::ModelFilesPtr model_files,
+            InitCallback callback) override {
+    ++init_count_;
+    if (defer_init_reply_) {
+      pending_init_callback_ = std::move(callback);
+      return;
+    }
+    std::move(callback).Run(init_success_);
+  }
+
+  void Bind(mojo::PendingReceiver<local_ai::mojom::PassageEmbedder> receiver)
+      override {
+    ++bind_count_;
+    worker_->AddReceiver(std::move(receiver));
+  }
+
+  mojo::Remote<local_ai::mojom::PassageEmbedderFactory> BindRemote() {
+    mojo::Remote<local_ai::mojom::PassageEmbedderFactory> remote;
+    receiver_.Bind(remote.BindNewPipeAndPassReceiver());
+    return remote;
+  }
+
+  void ResetReceiver() { receiver_.reset(); }
+
+  void set_init_success(bool success) { init_success_ = success; }
+  void set_defer_init_reply(bool defer) { defer_init_reply_ = defer; }
+  void RunDeferredInit(bool success) {
+    ASSERT_TRUE(pending_init_callback_);
+    std::move(pending_init_callback_).Run(success);
+  }
+
+  int init_count() const { return init_count_; }
+  int bind_count() const { return bind_count_; }
+
+ private:
+  raw_ptr<FakeRendererEmbedder> worker_;
+  bool init_success_ = true;
+  bool defer_init_reply_ = false;
+  InitCallback pending_init_callback_;
+  int init_count_ = 0;
+  int bind_count_ = 0;
+  mojo::Receiver<local_ai::mojom::PassageEmbedderFactory> receiver_{this};
+};
+
 }  // namespace
 
 class BraveBatchPassageEmbedderTest : public testing::Test {
  protected:
-  // Constructs the embedder under test wired to fake_worker_.
+  // Constructs the embedder under test; populates load_success_ via
+  // load_callback and disconnect_called_ via on_disconnect.
   void CreateEmbedder() {
     embedder_ = std::make_unique<BraveBatchPassageEmbedder>(
-        embedder_remote_.BindNewPipeAndPassReceiver(),
-        fake_worker_.BindNewRemote(),
+        embedder_remote_.BindNewPipeAndPassReceiver(), factory_.BindRemote(),
+        local_ai::mojom::ModelFiles::New(), load_success_.GetCallback(),
         base::BindOnce(
             [](base::test::TestFuture<void>* future) { future->SetValue(); },
             &disconnect_called_));
@@ -89,13 +143,37 @@ class BraveBatchPassageEmbedderTest : public testing::Test {
 
   base::test::TaskEnvironment task_environment_;
   FakeRendererEmbedder fake_worker_;
+  FakePassageEmbedderFactory factory_{&fake_worker_};
   mojo::Remote<mojom::PassageEmbedder> embedder_remote_;
+  base::test::TestFuture<bool> load_success_;
   base::test::TestFuture<void> disconnect_called_;
   std::unique_ptr<BraveBatchPassageEmbedder> embedder_;
 };
 
+TEST_F(BraveBatchPassageEmbedderTest, InitSuccessSignalsLoadAndBinds) {
+  CreateEmbedder();
+  EXPECT_TRUE(load_success_.Get());
+  // factory_->Bind is fired from OnInitDone before load_success runs;
+  // wait for the message to reach FakePassageEmbedderFactory.
+  ASSERT_TRUE(base::test::RunUntil([&] { return factory_.bind_count() > 0; }));
+  EXPECT_EQ(1, factory_.init_count());
+  EXPECT_EQ(1, factory_.bind_count());
+  EXPECT_FALSE(disconnect_called_.IsReady());
+}
+
+TEST_F(BraveBatchPassageEmbedderTest,
+       InitFailureSignalsLoadFalseAndDisconnect) {
+  factory_.set_init_success(false);
+  CreateEmbedder();
+  EXPECT_FALSE(load_success_.Get());
+  EXPECT_TRUE(disconnect_called_.Wait());
+  EXPECT_EQ(0, factory_.bind_count());
+}
+
 TEST_F(BraveBatchPassageEmbedderTest, EmptyPassagesShortCircuit) {
   CreateEmbedder();
+  ASSERT_TRUE(load_success_.Get());
+
   base::test::TestFuture<std::vector<mojom::PassageEmbeddingsResultPtr>> result;
   embedder_remote_->GenerateEmbeddings({}, mojom::PassagePriority::kPassive,
                                        result.GetCallback());
@@ -105,6 +183,8 @@ TEST_F(BraveBatchPassageEmbedderTest, EmptyPassagesShortCircuit) {
 
 TEST_F(BraveBatchPassageEmbedderTest, BatchReturnsResultsInOrder) {
   CreateEmbedder();
+  ASSERT_TRUE(load_success_.Get());
+
   fake_worker_.QueueResponse(AsVector(kEmbeddingA));
   fake_worker_.QueueResponse(AsVector(kEmbeddingB));
 
@@ -122,6 +202,8 @@ TEST_F(BraveBatchPassageEmbedderTest, BatchReturnsResultsInOrder) {
 
 TEST_F(BraveBatchPassageEmbedderTest, ConcurrentBatchesAreSerialized) {
   CreateEmbedder();
+  ASSERT_TRUE(load_success_.Get());
+
   base::test::TestFuture<std::vector<mojom::PassageEmbeddingsResultPtr>> a;
   base::test::TestFuture<std::vector<mojom::PassageEmbeddingsResultPtr>> b;
   embedder_remote_->GenerateEmbeddings({"a"}, mojom::PassagePriority::kPassive,
@@ -136,6 +218,8 @@ TEST_F(BraveBatchPassageEmbedderTest, ConcurrentBatchesAreSerialized) {
 
 TEST_F(BraveBatchPassageEmbedderTest, EmptyEmbeddingFailsBatch) {
   CreateEmbedder();
+  ASSERT_TRUE(load_success_.Get());
+
   fake_worker_.QueueResponse(AsVector(kEmbeddingA));
   fake_worker_.QueueResponse({});  // second passage returns empty
 
@@ -148,6 +232,8 @@ TEST_F(BraveBatchPassageEmbedderTest, EmptyEmbeddingFailsBatch) {
 
 TEST_F(BraveBatchPassageEmbedderTest, OutOfRangeFloatFailsBatch) {
   CreateEmbedder();
+  ASSERT_TRUE(load_success_.Get());
+
   // Value above max float overflows on cast.
   fake_worker_.QueueResponse({std::numeric_limits<double>::max()});
 
@@ -157,15 +243,36 @@ TEST_F(BraveBatchPassageEmbedderTest, OutOfRangeFloatFailsBatch) {
   EXPECT_TRUE(result.Get().empty());
 }
 
+TEST_F(BraveBatchPassageEmbedderTest, FactoryDisconnectBeforeInitFailsLoad) {
+  factory_.set_defer_init_reply(true);
+  CreateEmbedder();
+  EXPECT_FALSE(load_success_.IsReady());
+
+  factory_.ResetReceiver();
+
+  EXPECT_FALSE(load_success_.Get());
+  EXPECT_TRUE(disconnect_called_.Wait());
+}
+
 TEST_F(BraveBatchPassageEmbedderTest, RendererDisconnectFiresOnDisconnect) {
   CreateEmbedder();
+  ASSERT_TRUE(load_success_.Get());
+  // Ensure factory_->Bind has reached the worker before we reset its
+  // receiver set; otherwise ResetReceivers runs before AddReceiver and
+  // the disconnect we drive below never happens.
+  ASSERT_TRUE(base::test::RunUntil([&] { return factory_.bind_count() > 0; }));
+
   fake_worker_.ResetReceivers();
   EXPECT_TRUE(disconnect_called_.Wait());
 }
 
 TEST_F(BraveBatchPassageEmbedderTest, ReceiverDisconnectFiresOnDisconnect) {
   CreateEmbedder();
+  ASSERT_TRUE(load_success_.Get());
+
+  // Drop the caller-side remote; the embedder's receiver disconnects.
   embedder_remote_.reset();
+
   EXPECT_TRUE(disconnect_called_.Wait());
 }
 

--- a/browser/history_embeddings/brave_batch_passage_embedder_unittest.cc
+++ b/browser/history_embeddings/brave_batch_passage_embedder_unittest.cc
@@ -6,6 +6,7 @@
 #include "brave/browser/history_embeddings/brave_batch_passage_embedder.h"
 
 #include <limits>
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
@@ -15,6 +16,7 @@
 #include "base/test/run_until.h"
 #include "base/test/task_environment.h"
 #include "base/test/test_future.h"
+#include "brave/components/local_ai/core/background_web_contents.h"
 #include "brave/components/local_ai/core/local_ai.mojom.h"
 #include "mojo/public/cpp/bindings/pending_receiver.h"
 #include "mojo/public/cpp/bindings/receiver.h"
@@ -39,9 +41,6 @@ std::vector<float> AsFloatVector(const double (&arr)[3]) {
           static_cast<float>(arr[2])};
 }
 
-// Renderer-side fake. By default returns kEmbeddingA for every passage;
-// configurable to return per-call canned values, an empty embedding, or
-// an out-of-float-range value.
 class FakeRendererEmbedder : public local_ai::mojom::PassageEmbedder {
  public:
   void GenerateEmbeddings(const std::string& text,
@@ -74,8 +73,6 @@ class FakeRendererEmbedder : public local_ai::mojom::PassageEmbedder {
   mojo::ReceiverSet<local_ai::mojom::PassageEmbedder> receivers_;
 };
 
-// Factory fake. Init replies asynchronously with init_success_; Bind
-// forwards the receiver to the renderer worker.
 class FakePassageEmbedderFactory
     : public local_ai::mojom::PassageEmbedderFactory {
  public:
@@ -98,10 +95,8 @@ class FakePassageEmbedderFactory
     worker_->AddReceiver(std::move(receiver));
   }
 
-  mojo::Remote<local_ai::mojom::PassageEmbedderFactory> BindRemote() {
-    mojo::Remote<local_ai::mojom::PassageEmbedderFactory> remote;
-    receiver_.Bind(remote.BindNewPipeAndPassReceiver());
-    return remote;
+  mojo::PendingRemote<local_ai::mojom::PassageEmbedderFactory> BindRemote() {
+    return receiver_.BindNewPipeAndPassRemote();
   }
 
   void ResetReceiver() { receiver_.reset(); }
@@ -126,45 +121,127 @@ class FakePassageEmbedderFactory
   mojo::Receiver<local_ai::mojom::PassageEmbedderFactory> receiver_{this};
 };
 
+class FakeBackgroundWebContents : public local_ai::BackgroundWebContents {
+ public:
+  FakeBackgroundWebContents(Delegate* delegate, base::OnceClosure on_destroyed)
+      : delegate_(delegate), on_destroyed_(std::move(on_destroyed)) {}
+  ~FakeBackgroundWebContents() override {
+    if (on_destroyed_) {
+      std::move(on_destroyed_).Run();
+    }
+  }
+
+  void SimulateDestroyed() {
+    delegate_->OnBackgroundContentsDestroyed(DestroyReason::kRendererGone);
+  }
+
+ private:
+  raw_ptr<Delegate> delegate_;
+  base::OnceClosure on_destroyed_;
+};
+
 }  // namespace
 
 class BraveBatchPassageEmbedderTest : public testing::Test {
  protected:
-  // Constructs the embedder under test; populates load_success_ via
-  // load_callback and disconnect_called_ via on_disconnect.
   void CreateEmbedder() {
+    auto bg_factory = base::BindRepeating(
+        &BraveBatchPassageEmbedderTest::CreateFakeWebContents,
+        base::Unretained(this));
     embedder_ = std::make_unique<BraveBatchPassageEmbedder>(
-        embedder_remote_.BindNewPipeAndPassReceiver(), factory_.BindRemote(),
-        local_ai::mojom::ModelFiles::New(), load_success_.GetCallback(),
+        embedder_remote_.BindNewPipeAndPassReceiver(), std::move(bg_factory),
+        load_success_.GetCallback(),
         base::BindOnce(
             [](base::test::TestFuture<void>* future) { future->SetValue(); },
             &disconnect_called_));
   }
 
+  // Drives the renderer-side half: opens a LocalAIService pipe to the
+  // embedder and registers the fake factory. Caller must
+  // optionally call HandModelFiles() to complete the load.
+  void RegisterFactory() {
+    ASSERT_TRUE(last_created_web_contents_);
+    mojo::Remote<local_ai::mojom::LocalAIService> local_ai_remote;
+    embedder_->BindLocalAIReceiver(
+        local_ai_remote.BindNewPipeAndPassReceiver());
+    local_ai_remote->RegisterPassageEmbedderFactory(factory_.BindRemote());
+    local_ai_remote.FlushForTesting();
+  }
+
+  void HandModelFiles() {
+    embedder_->SetModelFiles(local_ai::mojom::ModelFiles::New());
+  }
+
+  // Brings the embedder into a Ready state via the standard
+  // RegisterFactory + SetModelFiles + load_success path.
+  void DriveLoadToReady() {
+    RegisterFactory();
+    HandModelFiles();
+    ASSERT_TRUE(load_success_.Get());
+    ASSERT_TRUE(
+        base::test::RunUntil([&] { return factory_.bind_count() > 0; }));
+  }
+
+  void CreateFakeWebContents(
+      local_ai::BackgroundWebContents::Delegate* delegate,
+      BraveBatchPassageEmbedder::BackgroundWebContentsCreatedCallback
+          callback) {
+    auto contents = std::make_unique<FakeBackgroundWebContents>(
+        delegate,
+        base::BindOnce(
+            [](raw_ptr<FakeBackgroundWebContents>* ref) { *ref = nullptr; },
+            &last_created_web_contents_));
+    last_created_web_contents_ = contents.get();
+    std::move(callback).Run(std::move(contents));
+  }
+
   base::test::TaskEnvironment task_environment_;
   FakeRendererEmbedder fake_worker_;
   FakePassageEmbedderFactory factory_{&fake_worker_};
+  raw_ptr<FakeBackgroundWebContents> last_created_web_contents_ = nullptr;
   mojo::Remote<mojom::PassageEmbedder> embedder_remote_;
   base::test::TestFuture<bool> load_success_;
   base::test::TestFuture<void> disconnect_called_;
   std::unique_ptr<BraveBatchPassageEmbedder> embedder_;
 };
 
+TEST_F(BraveBatchPassageEmbedderTest, CtorCreatesBackgroundContents) {
+  CreateEmbedder();
+  EXPECT_TRUE(last_created_web_contents_);
+  EXPECT_FALSE(load_success_.IsReady());
+}
+
 TEST_F(BraveBatchPassageEmbedderTest, InitSuccessSignalsLoadAndBinds) {
   CreateEmbedder();
+  RegisterFactory();
+  HandModelFiles();
   EXPECT_TRUE(load_success_.Get());
-  // factory_->Bind is fired from OnInitDone before load_success runs;
-  // wait for the message to reach FakePassageEmbedderFactory.
   ASSERT_TRUE(base::test::RunUntil([&] { return factory_.bind_count() > 0; }));
   EXPECT_EQ(1, factory_.init_count());
   EXPECT_EQ(1, factory_.bind_count());
   EXPECT_FALSE(disconnect_called_.IsReady());
 }
 
+TEST_F(BraveBatchPassageEmbedderTest, InitWaitsForBothFactoryAndModelFiles) {
+  CreateEmbedder();
+
+  // Files alone don't start init.
+  HandModelFiles();
+  EXPECT_FALSE(load_success_.IsReady());
+  EXPECT_EQ(0, factory_.init_count());
+
+  // Factory registration completes the prerequisites; init runs.
+  RegisterFactory();
+  EXPECT_TRUE(load_success_.Get());
+  EXPECT_EQ(1, factory_.init_count());
+}
+
 TEST_F(BraveBatchPassageEmbedderTest,
        InitFailureSignalsLoadFalseAndDisconnect) {
   factory_.set_init_success(false);
   CreateEmbedder();
+  RegisterFactory();
+  HandModelFiles();
   EXPECT_FALSE(load_success_.Get());
   EXPECT_TRUE(disconnect_called_.Wait());
   EXPECT_EQ(0, factory_.bind_count());
@@ -172,7 +249,7 @@ TEST_F(BraveBatchPassageEmbedderTest,
 
 TEST_F(BraveBatchPassageEmbedderTest, EmptyPassagesShortCircuit) {
   CreateEmbedder();
-  ASSERT_TRUE(load_success_.Get());
+  DriveLoadToReady();
 
   base::test::TestFuture<std::vector<mojom::PassageEmbeddingsResultPtr>> result;
   embedder_remote_->GenerateEmbeddings({}, mojom::PassagePriority::kPassive,
@@ -183,7 +260,7 @@ TEST_F(BraveBatchPassageEmbedderTest, EmptyPassagesShortCircuit) {
 
 TEST_F(BraveBatchPassageEmbedderTest, BatchReturnsResultsInOrder) {
   CreateEmbedder();
-  ASSERT_TRUE(load_success_.Get());
+  DriveLoadToReady();
 
   fake_worker_.QueueResponse(AsVector(kEmbeddingA));
   fake_worker_.QueueResponse(AsVector(kEmbeddingB));
@@ -202,7 +279,7 @@ TEST_F(BraveBatchPassageEmbedderTest, BatchReturnsResultsInOrder) {
 
 TEST_F(BraveBatchPassageEmbedderTest, ConcurrentBatchesAreSerialized) {
   CreateEmbedder();
-  ASSERT_TRUE(load_success_.Get());
+  DriveLoadToReady();
 
   base::test::TestFuture<std::vector<mojom::PassageEmbeddingsResultPtr>> a;
   base::test::TestFuture<std::vector<mojom::PassageEmbeddingsResultPtr>> b;
@@ -218,10 +295,10 @@ TEST_F(BraveBatchPassageEmbedderTest, ConcurrentBatchesAreSerialized) {
 
 TEST_F(BraveBatchPassageEmbedderTest, EmptyEmbeddingFailsBatch) {
   CreateEmbedder();
-  ASSERT_TRUE(load_success_.Get());
+  DriveLoadToReady();
 
   fake_worker_.QueueResponse(AsVector(kEmbeddingA));
-  fake_worker_.QueueResponse({});  // second passage returns empty
+  fake_worker_.QueueResponse({});
 
   base::test::TestFuture<std::vector<mojom::PassageEmbeddingsResultPtr>> result;
   embedder_remote_->GenerateEmbeddings({"first", "second"},
@@ -232,9 +309,8 @@ TEST_F(BraveBatchPassageEmbedderTest, EmptyEmbeddingFailsBatch) {
 
 TEST_F(BraveBatchPassageEmbedderTest, OutOfRangeFloatFailsBatch) {
   CreateEmbedder();
-  ASSERT_TRUE(load_success_.Get());
+  DriveLoadToReady();
 
-  // Value above max float overflows on cast.
   fake_worker_.QueueResponse({std::numeric_limits<double>::max()});
 
   base::test::TestFuture<std::vector<mojom::PassageEmbeddingsResultPtr>> result;
@@ -246,6 +322,8 @@ TEST_F(BraveBatchPassageEmbedderTest, OutOfRangeFloatFailsBatch) {
 TEST_F(BraveBatchPassageEmbedderTest, FactoryDisconnectBeforeInitFailsLoad) {
   factory_.set_defer_init_reply(true);
   CreateEmbedder();
+  RegisterFactory();
+  HandModelFiles();
   EXPECT_FALSE(load_success_.IsReady());
 
   factory_.ResetReceiver();
@@ -254,13 +332,22 @@ TEST_F(BraveBatchPassageEmbedderTest, FactoryDisconnectBeforeInitFailsLoad) {
   EXPECT_TRUE(disconnect_called_.Wait());
 }
 
+TEST_F(BraveBatchPassageEmbedderTest, FactoryDropBeforeInitStartsFailsLoad) {
+  // Factory registers, then drops before model files arrive — never
+  // reaches Init. The early-disconnect handler still has to fail the
+  // load.
+  CreateEmbedder();
+  RegisterFactory();
+  factory_.ResetReceiver();
+
+  EXPECT_FALSE(load_success_.Get());
+  EXPECT_TRUE(disconnect_called_.Wait());
+  EXPECT_EQ(0, factory_.init_count());
+}
+
 TEST_F(BraveBatchPassageEmbedderTest, RendererDisconnectFiresOnDisconnect) {
   CreateEmbedder();
-  ASSERT_TRUE(load_success_.Get());
-  // Ensure factory_->Bind has reached the worker before we reset its
-  // receiver set; otherwise ResetReceivers runs before AddReceiver and
-  // the disconnect we drive below never happens.
-  ASSERT_TRUE(base::test::RunUntil([&] { return factory_.bind_count() > 0; }));
+  DriveLoadToReady();
 
   fake_worker_.ResetReceivers();
   EXPECT_TRUE(disconnect_called_.Wait());
@@ -268,12 +355,41 @@ TEST_F(BraveBatchPassageEmbedderTest, RendererDisconnectFiresOnDisconnect) {
 
 TEST_F(BraveBatchPassageEmbedderTest, ReceiverDisconnectFiresOnDisconnect) {
   CreateEmbedder();
-  ASSERT_TRUE(load_success_.Get());
+  DriveLoadToReady();
 
-  // Drop the caller-side remote; the embedder's receiver disconnects.
   embedder_remote_.reset();
 
   EXPECT_TRUE(disconnect_called_.Wait());
+}
+
+TEST_F(BraveBatchPassageEmbedderTest,
+       BackgroundContentsDestroyedFiresOnDisconnect) {
+  CreateEmbedder();
+  ASSERT_TRUE(last_created_web_contents_);
+  last_created_web_contents_->SimulateDestroyed();
+  EXPECT_TRUE(disconnect_called_.Wait());
+  EXPECT_FALSE(load_success_.Get());
+}
+
+TEST_F(BraveBatchPassageEmbedderTest,
+       DuplicateRegisterPassageEmbedderFactoryIgnored) {
+  CreateEmbedder();
+  RegisterFactory();
+
+  // Second registration must not crash. mojo::Remote::Bind CHECKs when
+  // already bound, so without the duplicate guard this would crash.
+  mojo::Remote<local_ai::mojom::LocalAIService> local_ai_remote;
+  embedder_->BindLocalAIReceiver(local_ai_remote.BindNewPipeAndPassReceiver());
+  mojo::PendingRemote<local_ai::mojom::PassageEmbedderFactory> dummy;
+  std::ignore = dummy.InitWithNewPipeAndPassReceiver();
+  local_ai_remote->RegisterPassageEmbedderFactory(std::move(dummy));
+  local_ai_remote.FlushForTesting();
+
+  // First factory still in effect: load completes once model files
+  // arrive.
+  HandModelFiles();
+  EXPECT_TRUE(load_success_.Get());
+  EXPECT_EQ(1, factory_.init_count());
 }
 
 }  // namespace passage_embeddings

--- a/browser/history_embeddings/brave_batch_passage_embedder_unittest.cc
+++ b/browser/history_embeddings/brave_batch_passage_embedder_unittest.cc
@@ -150,15 +150,15 @@ class BraveBatchPassageEmbedderTest : public testing::Test {
         base::Unretained(this));
     embedder_ = std::make_unique<BraveBatchPassageEmbedder>(
         embedder_remote_.BindNewPipeAndPassReceiver(), std::move(bg_factory),
-        load_success_.GetCallback(),
+        local_ai::mojom::ModelFiles::New(), load_success_.GetCallback(),
         base::BindOnce(
             [](base::test::TestFuture<void>* future) { future->SetValue(); },
             &disconnect_called_));
   }
 
   // Drives the renderer-side half: opens a LocalAIService pipe to the
-  // embedder and registers the fake factory. Caller must
-  // optionally call HandModelFiles() to complete the load.
+  // embedder and registers the fake factory. Completes the load
+  // unless the factory is configured to defer or fail Init.
   void RegisterFactory() {
     ASSERT_TRUE(last_created_web_contents_);
     mojo::Remote<local_ai::mojom::LocalAIService> local_ai_remote;
@@ -168,15 +168,10 @@ class BraveBatchPassageEmbedderTest : public testing::Test {
     local_ai_remote.FlushForTesting();
   }
 
-  void HandModelFiles() {
-    embedder_->SetModelFiles(local_ai::mojom::ModelFiles::New());
-  }
-
   // Brings the embedder into a Ready state via the standard
-  // RegisterFactory + SetModelFiles + load_success path.
+  // RegisterFactory + load_success path.
   void DriveLoadToReady() {
     RegisterFactory();
-    HandModelFiles();
     ASSERT_TRUE(load_success_.Get());
     ASSERT_TRUE(
         base::test::RunUntil([&] { return factory_.bind_count() > 0; }));
@@ -214,7 +209,6 @@ TEST_F(BraveBatchPassageEmbedderTest, CtorCreatesBackgroundContents) {
 TEST_F(BraveBatchPassageEmbedderTest, InitSuccessSignalsLoadAndBinds) {
   CreateEmbedder();
   RegisterFactory();
-  HandModelFiles();
   EXPECT_TRUE(load_success_.Get());
   ASSERT_TRUE(base::test::RunUntil([&] { return factory_.bind_count() > 0; }));
   EXPECT_EQ(1, factory_.init_count());
@@ -222,15 +216,12 @@ TEST_F(BraveBatchPassageEmbedderTest, InitSuccessSignalsLoadAndBinds) {
   EXPECT_FALSE(disconnect_called_.IsReady());
 }
 
-TEST_F(BraveBatchPassageEmbedderTest, InitWaitsForBothFactoryAndModelFiles) {
+TEST_F(BraveBatchPassageEmbedderTest, InitWaitsForFactoryRegistration) {
   CreateEmbedder();
-
-  // Files alone don't start init.
-  HandModelFiles();
+  // No factory yet: init is gated on RegisterPassageEmbedderFactory.
   EXPECT_FALSE(load_success_.IsReady());
   EXPECT_EQ(0, factory_.init_count());
 
-  // Factory registration completes the prerequisites; init runs.
   RegisterFactory();
   EXPECT_TRUE(load_success_.Get());
   EXPECT_EQ(1, factory_.init_count());
@@ -241,7 +232,6 @@ TEST_F(BraveBatchPassageEmbedderTest,
   factory_.set_init_success(false);
   CreateEmbedder();
   RegisterFactory();
-  HandModelFiles();
   EXPECT_FALSE(load_success_.Get());
   EXPECT_TRUE(disconnect_called_.Wait());
   EXPECT_EQ(0, factory_.bind_count());
@@ -323,26 +313,12 @@ TEST_F(BraveBatchPassageEmbedderTest, FactoryDisconnectBeforeInitFailsLoad) {
   factory_.set_defer_init_reply(true);
   CreateEmbedder();
   RegisterFactory();
-  HandModelFiles();
   EXPECT_FALSE(load_success_.IsReady());
 
   factory_.ResetReceiver();
 
   EXPECT_FALSE(load_success_.Get());
   EXPECT_TRUE(disconnect_called_.Wait());
-}
-
-TEST_F(BraveBatchPassageEmbedderTest, FactoryDropBeforeInitStartsFailsLoad) {
-  // Factory registers, then drops before model files arrive — never
-  // reaches Init. The early-disconnect handler still has to fail the
-  // load.
-  CreateEmbedder();
-  RegisterFactory();
-  factory_.ResetReceiver();
-
-  EXPECT_FALSE(load_success_.Get());
-  EXPECT_TRUE(disconnect_called_.Wait());
-  EXPECT_EQ(0, factory_.init_count());
 }
 
 TEST_F(BraveBatchPassageEmbedderTest, RendererDisconnectFiresOnDisconnect) {
@@ -373,6 +349,9 @@ TEST_F(BraveBatchPassageEmbedderTest,
 
 TEST_F(BraveBatchPassageEmbedderTest,
        DuplicateRegisterPassageEmbedderFactoryIgnored) {
+  // Defer the init reply so the first factory stays in flight while
+  // we issue the duplicate registration.
+  factory_.set_defer_init_reply(true);
   CreateEmbedder();
   RegisterFactory();
 
@@ -385,9 +364,8 @@ TEST_F(BraveBatchPassageEmbedderTest,
   local_ai_remote->RegisterPassageEmbedderFactory(std::move(dummy));
   local_ai_remote.FlushForTesting();
 
-  // First factory still in effect: load completes once model files
-  // arrive.
-  HandModelFiles();
+  // First factory still in effect: complete its deferred init.
+  factory_.RunDeferredInit(true);
   EXPECT_TRUE(load_success_.Get());
   EXPECT_EQ(1, factory_.init_count());
 }

--- a/browser/history_embeddings/brave_passage_embeddings_service.cc
+++ b/browser/history_embeddings/brave_passage_embeddings_service.cc
@@ -12,6 +12,7 @@
 #include "base/feature_list.h"
 #include "base/files/file.h"
 #include "base/functional/bind.h"
+#include "base/functional/callback_helpers.h"
 #include "base/logging.h"
 #include "base/no_destructor.h"
 #include "base/task/thread_pool.h"
@@ -92,9 +93,6 @@ local_ai::mojom::ModelFilesPtr LoadLocalModelFilesFromDisk(
 
 }  // namespace
 
-////////////////////////////////////////////////////////////////////////////////
-// BravePassageEmbeddingsService
-
 BravePassageEmbeddingsService::PendingLoad::PendingLoad() = default;
 BravePassageEmbeddingsService::PendingLoad::~PendingLoad() = default;
 BravePassageEmbeddingsService::PendingLoad::PendingLoad(
@@ -156,16 +154,24 @@ BravePassageEmbeddingsService::GetWeakPtr() {
 void BravePassageEmbeddingsService::BindPassageEmbedder(
     mojo::PendingReceiver<mojom::PassageEmbedder> receiver,
     base::OnceCallback<void(bool)> callback) {
-  MaybeCreateBackgroundContents();
+  // Upstream's controller binds one embedder at a time — the base
+  // class gates on `!embedder_remote_`. If we see a second Bind while
+  // a load is in flight or an embedder is already active, fail the
+  // extra request defensively.
+  if (pending_load_ || batch_embedder_) {
+    DVLOG(1) << "BindPassageEmbedder called while a load is already in flight "
+                "or a BatchEmbedder is already bound; failing";
+    std::move(callback).Run(false);
+    return;
+  }
 
   PendingLoad load;
   load.receiver = std::move(receiver);
   load.callback = std::move(callback);
-  pending_loads_.push_back(std::move(load));
+  pending_load_ = std::move(load);
 
-  if (phase_ == LoadPhase::kReady) {
-    FulfillPendingLoads();
-  }
+  MaybeCreateBackgroundContents();
+  MaybeLoadLocalModelFiles();
 }
 
 void BravePassageEmbeddingsService::LoadModels(
@@ -197,7 +203,7 @@ void BravePassageEmbeddingsService::RegisterPassageEmbedderFactory(
   }
   factory_.Bind(std::move(factory));
   factory_.set_disconnect_handler(
-      base::BindOnce(&BravePassageEmbeddingsService::OnFactoryDisconnected,
+      base::BindOnce(&BravePassageEmbeddingsService::OnEarlyFactoryDisconnected,
                      weak_ptr_factory_.GetWeakPtr()));
   MaybeLoadLocalModelFiles();
 }
@@ -226,14 +232,19 @@ void BravePassageEmbeddingsService::MaybeCreateBackgroundContents() {
 
 void BravePassageEmbeddingsService::OnBackgroundContentsCreated(
     std::unique_ptr<local_ai::BackgroundWebContents> contents) {
-  if (background_web_contents_ || !contents) {
+  // If CloseBackgroundContents ran while the factory was in flight,
+  // pending_load_ has already been failed and reset; drop the late
+  // contents instead of installing an orphan renderer that nothing
+  // will drive or tear down until the next BindPassageEmbedder.
+  if (background_web_contents_ || !contents || !pending_load_) {
     return;
   }
   background_web_contents_ = std::move(contents);
 }
 
 void BravePassageEmbeddingsService::CloseBackgroundContents() {
-  DVLOG(3) << "CloseBackgroundContents (pending_loads=" << pending_loads_.size()
+  DVLOG(3) << "CloseBackgroundContents (pending_load="
+           << (pending_load_ ? "set" : "null")
            << " batch_embedder=" << (batch_embedder_ ? "set" : "null")
            << " factory_bound=" << factory_.is_bound()
            << " phase=" << static_cast<int>(phase_)
@@ -245,6 +256,9 @@ void BravePassageEmbeddingsService::CloseBackgroundContents() {
 
 void BravePassageEmbeddingsService::MaybeLoadLocalModelFiles() {
   if (phase_ != LoadPhase::kWaiting) {
+    return;
+  }
+  if (!pending_load_) {
     return;
   }
   if (updater_state_->GetInstallDir().empty() || !factory_.is_bound()) {
@@ -260,7 +274,7 @@ void BravePassageEmbeddingsService::MaybeLoadLocalModelFiles() {
   base::FilePath config_path = updater_state_->GetEmbeddingGemmaConfig();
 
   if (updater_state_->GetEmbeddingGemmaModelDir().empty()) {
-    OnFactoryInitDone(false);
+    ResetEmbedderState();
     return;
   }
 
@@ -272,100 +286,72 @@ void BravePassageEmbeddingsService::MaybeLoadLocalModelFiles() {
                      weights_dense1_path, weights_dense2_path, tokenizer_path,
                      config_path),
       base::BindOnce(&BravePassageEmbeddingsService::OnLocalModelFilesLoaded,
-                     weak_ptr_factory_.GetWeakPtr()));
+                     load_weak_factory_.GetWeakPtr()));
 }
 
 void BravePassageEmbeddingsService::OnLocalModelFilesLoaded(
     local_ai::mojom::ModelFilesPtr model_files) {
-  if (!model_files || !factory_.is_bound()) {
-    OnFactoryInitDone(false);
-    return;
-  }
-  phase_ = LoadPhase::kInitializing;
-  factory_->Init(
-      std::move(model_files),
-      base::BindOnce(&BravePassageEmbeddingsService::OnFactoryInitDone,
+  // Any early exit below fails the pending load and re-arms phase_;
+  // ScopedClosureRunner keeps that cleanup in one place.
+  base::ScopedClosureRunner reset_on_fail(
+      base::BindOnce(&BravePassageEmbeddingsService::ResetEmbedderState,
                      weak_ptr_factory_.GetWeakPtr()));
-}
 
-void BravePassageEmbeddingsService::OnFactoryInitDone(bool success) {
-  if (!success) {
-    DVLOG(1) << "Factory Init failed, failing " << pending_loads_.size()
-             << " pending load(s)";
-    phase_ = LoadPhase::kFailed;
-    // CloseBackgroundContents runs FailPendingLoads internally and
-    // tears down the rest of the state, matching LocalAIService's
-    // old OnPassageEmbedderReady(false) behavior.
-    CloseBackgroundContents();
+  if (!model_files) {
+    DVLOG(1) << "Model files load failed";
     return;
   }
-  DVLOG(3) << "Factory Init succeeded, fulfilling " << pending_loads_.size()
-           << " pending load(s)";
+  if (!factory_.is_bound()) {
+    DVLOG(1) << "Factory disconnected while files were loading";
+    return;
+  }
+  if (!pending_load_) {
+    DVLOG(1) << "No pending load by the time files loaded";
+    return;
+  }
+
+  // Success path — hand everything to the BatchEmbedder.
+  std::ignore = reset_on_fail.Release();
+
+  PendingLoad load = std::move(*pending_load_);
+  pending_load_.reset();
   phase_ = LoadPhase::kReady;
-  FulfillPendingLoads();
+  batch_embedder_ = std::make_unique<BraveBatchPassageEmbedder>(
+      std::move(load.receiver), std::move(factory_), std::move(model_files),
+      std::move(load.callback),
+      base::BindOnce(
+          &BravePassageEmbeddingsService::OnBatchEmbedderDisconnected,
+          weak_ptr_factory_.GetWeakPtr()));
+  DVLOG(3) << "BatchEmbedder created; load flow complete";
 }
 
-void BravePassageEmbeddingsService::FulfillPendingLoads() {
-  if (phase_ != LoadPhase::kReady || pending_loads_.empty()) {
-    return;
-  }
-
-  if (!batch_embedder_) {
-    // Bind a renderer-side single-passage PassageEmbedder via the
-    // factory, then wrap it in a BraveBatchPassageEmbedder that serves
-    // the upstream batch receiver.
-    mojo::PendingRemote<local_ai::mojom::PassageEmbedder> renderer_remote;
-    factory_->Bind(renderer_remote.InitWithNewPipeAndPassReceiver());
-
-    // The first pending load owns the batch receiver; subsequent loads
-    // are unexpected since upstream's controller binds one embedder at
-    // a time, but handle them defensively below.
-    PendingLoad first = std::move(pending_loads_.front());
-    pending_loads_.erase(pending_loads_.begin());
-    batch_embedder_ = std::make_unique<BraveBatchPassageEmbedder>(
-        std::move(first.receiver), std::move(renderer_remote),
-        base::BindOnce(
-            &BravePassageEmbeddingsService::OnBatchEmbedderDisconnected,
-            weak_ptr_factory_.GetWeakPtr()));
-    std::move(first.callback).Run(true);
-  }
-
-  // Any additional pending loads fail: upstream expects one active
-  // embedder remote at a time. The controller gates BindPassageEmbedder
-  // behind `!embedder_remote_`, so this branch should only fire if
-  // something else races a second binding in.
-  DVLOG_IF(1, !pending_loads_.empty())
-      << "BraveBatchPassageEmbedder already bound; failing "
-      << pending_loads_.size() << " extra pending load(s)";
-  for (auto& load : pending_loads_) {
-    std::move(load.callback).Run(false);
-  }
-  pending_loads_.clear();
+void BravePassageEmbeddingsService::OnBatchEmbedderDisconnected() {
+  DVLOG(3) << "BraveBatchPassageEmbedder disconnected; tearing down";
+  // An Init failure or post-init renderer disconnect (e.g. WASM
+  // worker crash) means the WASM page is no longer trustworthy;
+  // close the background contents so the next BindPassageEmbedder
+  // call gets a fresh renderer. CloseBackgroundContents runs
+  // ResetEmbedderState internally.
+  CloseBackgroundContents();
 }
 
-void BravePassageEmbeddingsService::FailPendingLoads() {
-  for (auto& load : pending_loads_) {
-    std::move(load.callback).Run(false);
-  }
-  pending_loads_.clear();
+void BravePassageEmbeddingsService::OnEarlyFactoryDisconnected() {
+  DVLOG(1) << "Renderer factory pipe disconnected before BatchEmbedder owned "
+              "it; resetting";
+  ResetEmbedderState();
 }
 
 void BravePassageEmbeddingsService::ResetEmbedderState() {
   batch_embedder_.reset();
   factory_.reset();
-  FailPendingLoads();
+  if (pending_load_) {
+    std::move(pending_load_->callback).Run(false);
+    pending_load_.reset();
+  }
+  // Cancel any in-flight file load reply so it doesn't land after we
+  // returned phase_ to kWaiting.
+  load_weak_factory_.InvalidateWeakPtrs();
   phase_ = LoadPhase::kWaiting;
-}
-
-void BravePassageEmbeddingsService::OnFactoryDisconnected() {
-  DVLOG(1) << "Renderer factory pipe disconnected; embeddings unavailable "
-              "until the background WebContents reloads";
-  ResetEmbedderState();
-}
-
-void BravePassageEmbeddingsService::OnBatchEmbedderDisconnected() {
-  DVLOG(3) << "BraveBatchPassageEmbedder disconnected; resetting";
-  batch_embedder_.reset();
 }
 
 }  // namespace passage_embeddings

--- a/browser/history_embeddings/brave_passage_embeddings_service.cc
+++ b/browser/history_embeddings/brave_passage_embeddings_service.cc
@@ -5,6 +5,7 @@
 
 #include "brave/browser/history_embeddings/brave_passage_embeddings_service.h"
 
+#include <optional>
 #include <utility>
 
 #include "base/check.h"
@@ -12,11 +13,9 @@
 #include "base/feature_list.h"
 #include "base/files/file.h"
 #include "base/functional/bind.h"
-#include "base/functional/callback_helpers.h"
 #include "base/logging.h"
 #include "base/no_destructor.h"
 #include "base/task/thread_pool.h"
-#include "brave/browser/history_embeddings/brave_batch_passage_embedder.h"
 #include "components/history_embeddings/core/history_embeddings_features.h"
 #include "content/public/browser/web_contents.h"
 #include "mojo/public/cpp/base/big_buffer.h"
@@ -93,14 +92,6 @@ local_ai::mojom::ModelFilesPtr LoadLocalModelFilesFromDisk(
 
 }  // namespace
 
-BravePassageEmbeddingsService::PendingLoad::PendingLoad() = default;
-BravePassageEmbeddingsService::PendingLoad::~PendingLoad() = default;
-BravePassageEmbeddingsService::PendingLoad::PendingLoad(
-    PendingLoad&&) noexcept = default;
-BravePassageEmbeddingsService::PendingLoad&
-BravePassageEmbeddingsService::PendingLoad::operator=(PendingLoad&&) noexcept =
-    default;
-
 BravePassageEmbeddingsService::BravePassageEmbeddingsService(
     BackgroundWebContentsFactory background_web_contents_factory,
     local_ai::LocalModelsUpdaterState* updater_state)
@@ -114,7 +105,6 @@ BravePassageEmbeddingsService::BravePassageEmbeddingsService(
 
 BravePassageEmbeddingsService::~BravePassageEmbeddingsService() {
   updater_state_->RemoveObserver(this);
-  CloseBackgroundContents();
 }
 
 // static
@@ -141,36 +131,26 @@ void BravePassageEmbeddingsService::BindForWebContents(
   }
 }
 
-void BravePassageEmbeddingsService::BindLocalAIReceiver(
-    mojo::PendingReceiver<local_ai::mojom::LocalAIService> receiver) {
-  local_ai_receivers_.Add(this, std::move(receiver));
-}
-
-base::WeakPtr<BravePassageEmbeddingsService>
-BravePassageEmbeddingsService::GetWeakPtr() {
-  return weak_ptr_factory_.GetWeakPtr();
-}
-
 void BravePassageEmbeddingsService::BindPassageEmbedder(
     mojo::PendingReceiver<mojom::PassageEmbedder> receiver,
     base::OnceCallback<void(bool)> callback) {
-  // Upstream's controller binds one embedder at a time — the base
-  // class gates on `!embedder_remote_`. If we see a second Bind while
-  // a load is in flight or an embedder is already active, fail the
-  // extra request defensively.
-  if (pending_load_ || batch_embedder_) {
-    DVLOG(1) << "BindPassageEmbedder called while a load is already in flight "
-                "or a BatchEmbedder is already bound; failing";
+  // Upstream's controller binds one embedder at a time — the base class
+  // gates on `!embedder_remote_`. If we see a second Bind while a load
+  // is in flight or an embedder is already active, fail the extra
+  // request defensively.
+  if (batch_embedder_) {
+    DVLOG(1) << "BindPassageEmbedder called while a BatchEmbedder is already "
+                "bound; failing";
     std::move(callback).Run(false);
     return;
   }
 
-  PendingLoad load;
-  load.receiver = std::move(receiver);
-  load.callback = std::move(callback);
-  pending_load_ = std::move(load);
-
-  MaybeCreateBackgroundContents();
+  batch_embedder_ = std::make_unique<BraveBatchPassageEmbedder>(
+      std::move(receiver), background_web_contents_factory_,
+      std::move(callback),
+      base::BindOnce(
+          &BravePassageEmbeddingsService::OnBatchEmbedderDisconnected,
+          weak_ptr_factory_.GetWeakPtr()));
   MaybeLoadLocalModelFiles();
 }
 
@@ -186,172 +166,54 @@ void BravePassageEmbeddingsService::LoadModels(
   BindPassageEmbedder(std::move(model), std::move(callback));
 }
 
-void BravePassageEmbeddingsService::RegisterPassageEmbedderFactory(
-    mojo::PendingRemote<local_ai::mojom::PassageEmbedderFactory> factory) {
-  if (!background_web_contents_) {
-    DVLOG(1) << "RegisterPassageEmbedderFactory without background contents";
-    return;
-  }
-  if (factory_.is_bound()) {
-    // A buggy or compromised renderer could call this twice without
-    // first triggering a disconnect. mojo::Remote::Bind CHECKs when
-    // already bound; ignore the duplicate registration so the second
-    // call doesn't crash the browser.
-    DVLOG(1) << "RegisterPassageEmbedderFactory while factory_ already "
-                "bound; ignoring duplicate registration.";
-    return;
-  }
-  factory_.Bind(std::move(factory));
-  factory_.set_disconnect_handler(
-      base::BindOnce(&BravePassageEmbeddingsService::OnEarlyFactoryDisconnected,
-                     weak_ptr_factory_.GetWeakPtr()));
-  MaybeLoadLocalModelFiles();
-}
-
 void BravePassageEmbeddingsService::OnLocalModelsReady(
     const base::FilePath& install_dir) {
   MaybeLoadLocalModelFiles();
 }
 
-void BravePassageEmbeddingsService::OnBackgroundContentsDestroyed(
-    local_ai::BackgroundWebContents::DestroyReason reason) {
-  DVLOG(1) << "Background contents destroyed unexpectedly, reason="
-           << static_cast<int>(reason);
-  CloseBackgroundContents();
-}
-
-void BravePassageEmbeddingsService::MaybeCreateBackgroundContents() {
-  if (background_web_contents_) {
-    return;
-  }
-  background_web_contents_factory_.Run(
-      this, base::BindOnce(
-                &BravePassageEmbeddingsService::OnBackgroundContentsCreated,
-                weak_ptr_factory_.GetWeakPtr()));
-}
-
-void BravePassageEmbeddingsService::OnBackgroundContentsCreated(
-    std::unique_ptr<local_ai::BackgroundWebContents> contents) {
-  // If CloseBackgroundContents ran while the factory was in flight,
-  // pending_load_ has already been failed and reset; drop the late
-  // contents instead of installing an orphan renderer that nothing
-  // will drive or tear down until the next BindPassageEmbedder.
-  if (background_web_contents_ || !contents || !pending_load_) {
-    return;
-  }
-  background_web_contents_ = std::move(contents);
-}
-
-void BravePassageEmbeddingsService::CloseBackgroundContents() {
-  DVLOG(3) << "CloseBackgroundContents (pending_load="
-           << (pending_load_ ? "set" : "null")
-           << " batch_embedder=" << (batch_embedder_ ? "set" : "null")
-           << " factory_bound=" << factory_.is_bound()
-           << " phase=" << static_cast<int>(phase_)
-           << " bg_contents=" << (background_web_contents_ ? "set" : "null")
-           << ")";
-  ResetEmbedderState();
-  background_web_contents_.reset();
-}
-
 void BravePassageEmbeddingsService::MaybeLoadLocalModelFiles() {
-  if (phase_ != LoadPhase::kWaiting) {
+  if (file_load_in_flight_ || !batch_embedder_) {
     return;
   }
-  if (!pending_load_) {
-    return;
-  }
-  if (updater_state_->GetInstallDir().empty() || !factory_.is_bound()) {
-    return;
-  }
-  phase_ = LoadPhase::kLoading;
-  base::FilePath weights_path = updater_state_->GetEmbeddingGemmaModel();
-  base::FilePath weights_dense1_path =
-      updater_state_->GetEmbeddingGemmaDense1();
-  base::FilePath weights_dense2_path =
-      updater_state_->GetEmbeddingGemmaDense2();
-  base::FilePath tokenizer_path = updater_state_->GetEmbeddingGemmaTokenizer();
-  base::FilePath config_path = updater_state_->GetEmbeddingGemmaConfig();
-
   if (updater_state_->GetEmbeddingGemmaModelDir().empty()) {
-    ResetEmbedderState();
     return;
   }
-
+  file_load_in_flight_ = true;
   base::ThreadPool::PostTaskAndReplyWithResult(
       FROM_HERE,
       {base::MayBlock(), base::TaskPriority::USER_VISIBLE,
        base::TaskShutdownBehavior::SKIP_ON_SHUTDOWN},
-      base::BindOnce(&LoadLocalModelFilesFromDisk, weights_path,
-                     weights_dense1_path, weights_dense2_path, tokenizer_path,
-                     config_path),
+      base::BindOnce(&LoadLocalModelFilesFromDisk,
+                     updater_state_->GetEmbeddingGemmaModel(),
+                     updater_state_->GetEmbeddingGemmaDense1(),
+                     updater_state_->GetEmbeddingGemmaDense2(),
+                     updater_state_->GetEmbeddingGemmaTokenizer(),
+                     updater_state_->GetEmbeddingGemmaConfig()),
       base::BindOnce(&BravePassageEmbeddingsService::OnLocalModelFilesLoaded,
-                     load_weak_factory_.GetWeakPtr()));
+                     weak_ptr_factory_.GetWeakPtr()));
 }
 
 void BravePassageEmbeddingsService::OnLocalModelFilesLoaded(
     local_ai::mojom::ModelFilesPtr model_files) {
-  // Any early exit below fails the pending load and re-arms phase_;
-  // ScopedClosureRunner keeps that cleanup in one place.
-  base::ScopedClosureRunner reset_on_fail(
-      base::BindOnce(&BravePassageEmbeddingsService::ResetEmbedderState,
-                     weak_ptr_factory_.GetWeakPtr()));
-
+  file_load_in_flight_ = false;
+  if (!batch_embedder_) {
+    return;
+  }
   if (!model_files) {
-    DVLOG(1) << "Model files load failed";
+    DVLOG(1) << "Model files load failed; resetting BatchEmbedder";
+    batch_embedder_.reset();
     return;
   }
-  if (!factory_.is_bound()) {
-    DVLOG(1) << "Factory disconnected while files were loading";
-    return;
-  }
-  if (!pending_load_) {
-    DVLOG(1) << "No pending load by the time files loaded";
-    return;
-  }
-
-  // Success path — hand everything to the BatchEmbedder.
-  std::ignore = reset_on_fail.Release();
-
-  PendingLoad load = std::move(*pending_load_);
-  pending_load_.reset();
-  phase_ = LoadPhase::kReady;
-  batch_embedder_ = std::make_unique<BraveBatchPassageEmbedder>(
-      std::move(load.receiver), std::move(factory_), std::move(model_files),
-      std::move(load.callback),
-      base::BindOnce(
-          &BravePassageEmbeddingsService::OnBatchEmbedderDisconnected,
-          weak_ptr_factory_.GetWeakPtr()));
-  DVLOG(3) << "BatchEmbedder created; load flow complete";
+  batch_embedder_->SetModelFiles(std::move(model_files));
 }
 
 void BravePassageEmbeddingsService::OnBatchEmbedderDisconnected() {
   DVLOG(3) << "BraveBatchPassageEmbedder disconnected; tearing down";
-  // An Init failure or post-init renderer disconnect (e.g. WASM
-  // worker crash) means the WASM page is no longer trustworthy;
-  // close the background contents so the next BindPassageEmbedder
-  // call gets a fresh renderer. CloseBackgroundContents runs
-  // ResetEmbedderState internally.
-  CloseBackgroundContents();
-}
-
-void BravePassageEmbeddingsService::OnEarlyFactoryDisconnected() {
-  DVLOG(1) << "Renderer factory pipe disconnected before BatchEmbedder owned "
-              "it; resetting";
-  ResetEmbedderState();
-}
-
-void BravePassageEmbeddingsService::ResetEmbedderState() {
   batch_embedder_.reset();
-  factory_.reset();
-  if (pending_load_) {
-    std::move(pending_load_->callback).Run(false);
-    pending_load_.reset();
-  }
-  // Cancel any in-flight file load reply so it doesn't land after we
-  // returned phase_ to kWaiting.
-  load_weak_factory_.InvalidateWeakPtrs();
-  phase_ = LoadPhase::kWaiting;
+  // Cancel any in-flight file load reply so it doesn't land after the
+  // embedder is gone.
+  weak_ptr_factory_.InvalidateWeakPtrs();
+  file_load_in_flight_ = false;
 }
 
 }  // namespace passage_embeddings

--- a/browser/history_embeddings/brave_passage_embeddings_service.cc
+++ b/browser/history_embeddings/brave_passage_embeddings_service.cc
@@ -5,46 +5,20 @@
 
 #include "brave/browser/history_embeddings/brave_passage_embeddings_service.h"
 
-#include <optional>
 #include <utility>
 
 #include "base/check.h"
 #include "base/containers/flat_map.h"
 #include "base/feature_list.h"
-#include "base/files/file.h"
 #include "base/functional/bind.h"
 #include "base/logging.h"
 #include "base/no_destructor.h"
-#include "base/task/thread_pool.h"
 #include "components/history_embeddings/core/history_embeddings_features.h"
 #include "content/public/browser/web_contents.h"
-#include "mojo/public/cpp/base/big_buffer.h"
 
 namespace passage_embeddings {
 
 namespace {
-
-// Reads a file directly into BigBuffer storage. For files >64KB
-// BigBuffer uses shared memory.
-std::optional<mojo_base::BigBuffer> ReadFileToBigBuffer(
-    const base::FilePath& path) {
-  base::File file(path, base::File::FLAG_OPEN | base::File::FLAG_READ);
-  if (!file.IsValid()) {
-    DVLOG(0) << "Failed to open: " << path;
-    return std::nullopt;
-  }
-  int64_t size = file.GetLength();
-  if (size <= 0) {
-    DVLOG(0) << "Empty or unreadable: " << path;
-    return std::nullopt;
-  }
-  mojo_base::BigBuffer buffer(static_cast<size_t>(size));
-  if (!file.ReadAndCheck(0, base::span<uint8_t>(buffer))) {
-    DVLOG(0) << "Failed to read: " << path;
-    return std::nullopt;
-  }
-  return buffer;
-}
 
 using BindRegistry =
     base::flat_map<content::WebContents*,
@@ -55,57 +29,16 @@ BindRegistry& GetBindRegistry() {
   return *registry;
 }
 
-local_ai::mojom::ModelFilesPtr LoadLocalModelFilesFromDisk(
-    const base::FilePath& weights_path,
-    const base::FilePath& weights_dense1_path,
-    const base::FilePath& weights_dense2_path,
-    const base::FilePath& tokenizer_path,
-    const base::FilePath& config_path) {
-  auto weights = ReadFileToBigBuffer(weights_path);
-  if (!weights) {
-    return nullptr;
-  }
-  auto weights_dense1 = ReadFileToBigBuffer(weights_dense1_path);
-  if (!weights_dense1) {
-    return nullptr;
-  }
-  auto weights_dense2 = ReadFileToBigBuffer(weights_dense2_path);
-  if (!weights_dense2) {
-    return nullptr;
-  }
-  auto tokenizer = ReadFileToBigBuffer(tokenizer_path);
-  if (!tokenizer) {
-    return nullptr;
-  }
-  auto config = ReadFileToBigBuffer(config_path);
-  if (!config) {
-    return nullptr;
-  }
-  auto model_files = local_ai::mojom::ModelFiles::New();
-  model_files->weights = std::move(*weights);
-  model_files->weights_dense1 = std::move(*weights_dense1);
-  model_files->weights_dense2 = std::move(*weights_dense2);
-  model_files->tokenizer = std::move(*tokenizer);
-  model_files->config = std::move(*config);
-  return model_files;
-}
-
 }  // namespace
 
 BravePassageEmbeddingsService::BravePassageEmbeddingsService(
-    BackgroundWebContentsFactory background_web_contents_factory,
-    local_ai::LocalModelsUpdaterState* updater_state)
+    BackgroundWebContentsFactory background_web_contents_factory)
     : background_web_contents_factory_(
-          std::move(background_web_contents_factory)),
-      updater_state_(updater_state) {
+          std::move(background_web_contents_factory)) {
   CHECK(base::FeatureList::IsEnabled(history_embeddings::kHistoryEmbeddings));
-  CHECK(updater_state_);
-  updater_state_->AddObserver(this);
 }
 
-BravePassageEmbeddingsService::~BravePassageEmbeddingsService() {
-  updater_state_->RemoveObserver(this);
-}
+BravePassageEmbeddingsService::~BravePassageEmbeddingsService() = default;
 
 // static
 void BravePassageEmbeddingsService::SetBindCallbackForWebContents(
@@ -133,7 +66,9 @@ void BravePassageEmbeddingsService::BindForWebContents(
 
 void BravePassageEmbeddingsService::BindPassageEmbedder(
     mojo::PendingReceiver<mojom::PassageEmbedder> receiver,
+    local_ai::mojom::ModelFilesPtr model_files,
     base::OnceCallback<void(bool)> callback) {
+  CHECK(model_files);
   // Upstream's controller binds one embedder at a time — the base class
   // gates on `!embedder_remote_`. If we see a second Bind while a load
   // is in flight or an embedder is already active, fail the extra
@@ -147,11 +82,10 @@ void BravePassageEmbeddingsService::BindPassageEmbedder(
 
   batch_embedder_ = std::make_unique<BraveBatchPassageEmbedder>(
       std::move(receiver), background_web_contents_factory_,
-      std::move(callback),
+      std::move(model_files), std::move(callback),
       base::BindOnce(
           &BravePassageEmbeddingsService::OnBatchEmbedderDisconnected,
           weak_ptr_factory_.GetWeakPtr()));
-  MaybeLoadLocalModelFiles();
 }
 
 void BravePassageEmbeddingsService::LoadModels(
@@ -159,61 +93,18 @@ void BravePassageEmbeddingsService::LoadModels(
     mojom::PassageEmbedderParamsPtr params,
     mojo::PendingReceiver<mojom::PassageEmbedder> model,
     LoadModelsCallback callback) {
-  // Brave does not consume the upstream model file params — we use our
-  // own EmbeddingGemma model hosted by a WASM renderer. The params
-  // auto-destruct on return (closing any file handles); delegate the
-  // receiver to the in-process path.
-  BindPassageEmbedder(std::move(model), std::move(callback));
-}
-
-void BravePassageEmbeddingsService::OnLocalModelsReady(
-    const base::FilePath& install_dir) {
-  MaybeLoadLocalModelFiles();
-}
-
-void BravePassageEmbeddingsService::MaybeLoadLocalModelFiles() {
-  if (file_load_in_flight_ || !batch_embedder_) {
-    return;
-  }
-  if (updater_state_->GetEmbeddingGemmaModelDir().empty()) {
-    return;
-  }
-  file_load_in_flight_ = true;
-  base::ThreadPool::PostTaskAndReplyWithResult(
-      FROM_HERE,
-      {base::MayBlock(), base::TaskPriority::USER_VISIBLE,
-       base::TaskShutdownBehavior::SKIP_ON_SHUTDOWN},
-      base::BindOnce(&LoadLocalModelFilesFromDisk,
-                     updater_state_->GetEmbeddingGemmaModel(),
-                     updater_state_->GetEmbeddingGemmaDense1(),
-                     updater_state_->GetEmbeddingGemmaDense2(),
-                     updater_state_->GetEmbeddingGemmaTokenizer(),
-                     updater_state_->GetEmbeddingGemmaConfig()),
-      base::BindOnce(&BravePassageEmbeddingsService::OnLocalModelFilesLoaded,
-                     weak_ptr_factory_.GetWeakPtr()));
-}
-
-void BravePassageEmbeddingsService::OnLocalModelFilesLoaded(
-    local_ai::mojom::ModelFilesPtr model_files) {
-  file_load_in_flight_ = false;
-  if (!batch_embedder_) {
-    return;
-  }
-  if (!model_files) {
-    DVLOG(1) << "Model files load failed; resetting BatchEmbedder";
-    batch_embedder_.reset();
-    return;
-  }
-  batch_embedder_->SetModelFiles(std::move(model_files));
+  // The upstream mojom is shaped for tflite + sentencepiece; Brave's
+  // model files are not carried in this struct. The controller calls
+  // BindPassageEmbedder directly and never binds service_remote_, so
+  // this override is unreachable in practice. Fail defensively.
+  DVLOG(1) << "LoadModels called on BravePassageEmbeddingsService; "
+              "this path is unused. Failing.";
+  std::move(callback).Run(false);
 }
 
 void BravePassageEmbeddingsService::OnBatchEmbedderDisconnected() {
   DVLOG(3) << "BraveBatchPassageEmbedder disconnected; tearing down";
   batch_embedder_.reset();
-  // Cancel any in-flight file load reply so it doesn't land after the
-  // embedder is gone.
-  weak_ptr_factory_.InvalidateWeakPtrs();
-  file_load_in_flight_ = false;
 }
 
 }  // namespace passage_embeddings

--- a/browser/history_embeddings/brave_passage_embeddings_service.h
+++ b/browser/history_embeddings/brave_passage_embeddings_service.h
@@ -7,7 +7,7 @@
 #define BRAVE_BROWSER_HISTORY_EMBEDDINGS_BRAVE_PASSAGE_EMBEDDINGS_SERVICE_H_
 
 #include <memory>
-#include <vector>
+#include <optional>
 
 #include "base/files/file_path.h"
 #include "base/functional/callback.h"
@@ -37,11 +37,20 @@ class BraveBatchPassageEmbedder;
 // service_remote_ directly to an instance of this class, so no IPC hop
 // is involved.
 //
-// Owns:
+// Matches the shape of upstream's PassageEmbeddingsService: on
+// LoadModels we create a PassageEmbedder (here,
+// BraveBatchPassageEmbedder) and hand it the loaded model files plus
+// the factory remote. All init/bind/disconnect bookkeeping lives
+// inside the BatchEmbedder, which calls us back via on_disconnect when
+// it is torn down.
+//
+// This service still owns:
 //   - The guest-OTR BackgroundWebContents that hosts the WASM worker.
-//   - The renderer-registered PassageEmbedderFactory remote.
-//   - A BraveBatchPassageEmbedder that implements the upstream mojom
-//     PassageEmbedder by fanning batches to the renderer.
+//   - The PassageEmbedderFactory remote received via
+//     RegisterPassageEmbedderFactory (until it is moved into the
+//     BatchEmbedder on successful load).
+//   - The load phase used to gate file loading on component install
+//     and renderer factory registration.
 //
 // Also implements local_ai::mojom::LocalAIService so the renderer WASM
 // page can register its PassageEmbedderFactory back to us via
@@ -90,14 +99,14 @@ class BravePassageEmbeddingsService
   base::WeakPtr<BravePassageEmbeddingsService> GetWeakPtr();
 
   // Direct in-process equivalent of mojom::PassageEmbeddingsService::LoadModels
-  // — binds `receiver` to our BraveBatchPassageEmbedder and invokes
-  // `callback` once the WASM renderer is ready. The upstream mojom is
-  // shaped for a tflite + sentencepiece embedder in a sandboxed utility
-  // process; we run in-process with a five-file EmbeddingGemma model, so
-  // the struct doesn't fit and the mojo hop adds no isolation. The
-  // controller calls this directly and leaves service_remote_ unbound.
-  // Model files are delivered separately via PassageEmbedderFactory::Init
-  // as local_ai::mojom::ModelFiles BigBuffers. See README.md for details.
+  // — queues the receiver + callback as the pending load and drives
+  // the startup flow. The upstream mojom is shaped for a tflite +
+  // sentencepiece embedder in a sandboxed utility process; we run
+  // in-process with a five-file EmbeddingGemma model, so the struct
+  // doesn't fit and the mojo hop adds no isolation. The controller
+  // calls this directly and leaves service_remote_ unbound. Model
+  // files are delivered separately via PassageEmbedderFactory::Init as
+  // local_ai::mojom::ModelFiles BigBuffers. See README.md for details.
   void BindPassageEmbedder(
       mojo::PendingReceiver<mojom::PassageEmbedder> receiver,
       base::OnceCallback<void(bool)> callback);
@@ -121,7 +130,7 @@ class BravePassageEmbeddingsService
     PendingLoad& operator=(PendingLoad&&) noexcept;
 
     mojo::PendingReceiver<mojom::PassageEmbedder> receiver;
-    LoadModelsCallback callback;
+    base::OnceCallback<void(bool)> callback;
   };
 
   // LocalModelsUpdaterState::Observer:
@@ -137,42 +146,45 @@ class BravePassageEmbeddingsService
   void CloseBackgroundContents();
   void MaybeLoadLocalModelFiles();
   void OnLocalModelFilesLoaded(local_ai::mojom::ModelFilesPtr model_files);
-  void OnFactoryInitDone(bool success);
-  void FulfillPendingLoads();
-  void FailPendingLoads();
-  // Drops the renderer-facing embedder state (batch embedder, factory,
-  // pending loads) and resets the load phase to kWaiting. Shared by
-  // OnFactoryDisconnected and CloseBackgroundContents.
-  void ResetEmbedderState();
-  void OnFactoryDisconnected();
   void OnBatchEmbedderDisconnected();
+  // Handler installed on factory_ while the remote is held by the
+  // service (before it is moved into the BatchEmbedder). Once the
+  // BatchEmbedder owns the factory it installs its own disconnect
+  // handler.
+  void OnEarlyFactoryDisconnected();
+  // Drops batch_embedder_/factory_, fails any pending load, returns
+  // phase_ to kWaiting, and invalidates in-flight load callbacks.
+  void ResetEmbedderState();
 
   std::unique_ptr<local_ai::BackgroundWebContents> background_web_contents_;
   BackgroundWebContentsFactory background_web_contents_factory_;
   raw_ptr<local_ai::LocalModelsUpdaterState> updater_state_;
 
   mojo::ReceiverSet<local_ai::mojom::LocalAIService> local_ai_receivers_;
+  // Holds the renderer's factory remote from RegisterPassageEmbedderFactory
+  // until a successful load moves it into the BatchEmbedder.
   mojo::Remote<local_ai::mojom::PassageEmbedderFactory> factory_;
 
   std::unique_ptr<BraveBatchPassageEmbedder> batch_embedder_;
-  std::vector<PendingLoad> pending_loads_;
+  std::optional<PendingLoad> pending_load_;
 
   // Load sequence:
-  //   kWaiting       -> need updater_state_->GetInstallDir() non-empty
-  //                     && factory_.is_bound()
-  //   kLoading       -> ThreadPool task reading model files from disk
-  //   kInitializing  -> factory_->Init in flight
-  //   kReady         -> can fulfill pending loads
-  //   kFailed        -> teardown via ResetEmbedderState pending
+  //   kWaiting -> need updater_state_->GetInstallDir() non-empty
+  //               && factory_.is_bound() && pending_load_ set
+  //   kLoading -> ThreadPool task reading model files from disk
+  //   kReady   -> batch_embedder_ created; it owns Init internally
+  //               and reports disconnect via OnBatchEmbedderDisconnected.
   enum class LoadPhase {
     kWaiting,
     kLoading,
-    kInitializing,
     kReady,
-    kFailed,
   };
   LoadPhase phase_ = LoadPhase::kWaiting;
 
+  // Separate factory for the ThreadPool file-load reply so
+  // ResetEmbedderState can cancel an in-flight load without also
+  // invalidating the rest of the service's weak-bound callbacks.
+  base::WeakPtrFactory<BravePassageEmbeddingsService> load_weak_factory_{this};
   base::WeakPtrFactory<BravePassageEmbeddingsService> weak_ptr_factory_{this};
 };
 

--- a/browser/history_embeddings/brave_passage_embeddings_service.h
+++ b/browser/history_embeddings/brave_passage_embeddings_service.h
@@ -7,19 +7,15 @@
 #define BRAVE_BROWSER_HISTORY_EMBEDDINGS_BRAVE_PASSAGE_EMBEDDINGS_SERVICE_H_
 
 #include <memory>
-#include <optional>
 
 #include "base/files/file_path.h"
 #include "base/functional/callback.h"
 #include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
-#include "brave/components/local_ai/core/background_web_contents.h"
+#include "brave/browser/history_embeddings/brave_batch_passage_embedder.h"
 #include "brave/components/local_ai/core/local_ai.mojom.h"
 #include "brave/components/local_ai/core/local_models_updater.h"
 #include "mojo/public/cpp/bindings/pending_receiver.h"
-#include "mojo/public/cpp/bindings/pending_remote.h"
-#include "mojo/public/cpp/bindings/receiver_set.h"
-#include "mojo/public/cpp/bindings/remote.h"
 #include "services/passage_embeddings/public/mojom/passage_embeddings.mojom.h"
 
 namespace content {
@@ -28,8 +24,6 @@ class WebContents;
 
 namespace passage_embeddings {
 
-class BraveBatchPassageEmbedder;
-
 // In-process implementation of
 // passage_embeddings::mojom::PassageEmbeddingsService. Takes the place of
 // the utility-process PassageEmbeddingsService that upstream Chrome
@@ -37,35 +31,30 @@ class BraveBatchPassageEmbedder;
 // service_remote_ directly to an instance of this class, so no IPC hop
 // is involved.
 //
-// Matches the shape of upstream's PassageEmbeddingsService: on
-// LoadModels we create a PassageEmbedder (here,
-// BraveBatchPassageEmbedder) and hand it the loaded model files plus
-// the factory remote. All init/bind/disconnect bookkeeping lives
-// inside the BatchEmbedder, which calls us back via on_disconnect when
-// it is torn down.
+// The service is intentionally thin: its only responsibility is reading
+// the EmbeddingGemma model files from disk (driven by
+// LocalModelsUpdaterState component-updater notifications) and feeding
+// them to a BraveBatchPassageEmbedder, which owns the renderer-side
+// lifecycle (background WebContents, LocalAIService receiver set,
+// PassageEmbedderFactory remote, and the mojom::PassageEmbedder pipe
+// to the controller).
 //
-// This service still owns:
-//   - The guest-OTR BackgroundWebContents that hosts the WASM worker.
-//   - The PassageEmbedderFactory remote received via
-//     RegisterPassageEmbedderFactory (until it is moved into the
-//     BatchEmbedder on successful load).
-//   - The load phase used to gate file loading on component install
-//     and renderer factory registration.
+// On BindPassageEmbedder we construct an embedder eagerly, kick off
+// the file-load task on the ThreadPool, and hand the loaded files to
+// the embedder once they arrive. Disconnect of the embedder
+// (renderer crash, factory drop, caller drop, or background contents
+// teardown) routes back through OnBatchEmbedderDisconnected so the
+// service can drop the embedder and accept a new load.
 //
-// Also implements local_ai::mojom::LocalAIService so the renderer WASM
-// page can register its PassageEmbedderFactory back to us via
-// UntrustedLocalAIUI::BindInterface.
+// Also exposes the static WebContents -> BindCallback registry used by
+// UntrustedLocalAIUI::BindInterface to route renderer-side
+// LocalAIService bindings to the active embedder.
 class BravePassageEmbeddingsService
     : public mojom::PassageEmbeddingsService,
-      public local_ai::mojom::LocalAIService,
-      public local_ai::BackgroundWebContents::Delegate,
       public local_ai::LocalModelsUpdaterState::Observer {
  public:
-  using BackgroundWebContentsCreatedCallback = base::OnceCallback<void(
-      std::unique_ptr<local_ai::BackgroundWebContents>)>;
-  using BackgroundWebContentsFactory = base::RepeatingCallback<void(
-      local_ai::BackgroundWebContents::Delegate* delegate,
-      BackgroundWebContentsCreatedCallback)>;
+  using BackgroundWebContentsFactory =
+      BraveBatchPassageEmbedder::BackgroundWebContentsFactory;
 
   BravePassageEmbeddingsService(
       BackgroundWebContentsFactory background_web_contents_factory,
@@ -77,10 +66,10 @@ class BravePassageEmbeddingsService
       const BravePassageEmbeddingsService&) = delete;
 
   // Registry for routing mojo binding requests from the background
-  // WebContents (on guest OTR) back to the active service instance.
+  // WebContents (on guest OTR) back to the active embedder.
   // UntrustedLocalAIUI::BindInterface calls BindForWebContents; the
-  // service installs SetBindCallbackForWebContents when it creates its
-  // background contents.
+  // controller installs SetBindCallbackForWebContents when the
+  // embedder creates its background contents.
   using BindCallback = base::RepeatingCallback<void(
       mojo::PendingReceiver<local_ai::mojom::LocalAIService>)>;
   static void SetBindCallbackForWebContents(content::WebContents* web_contents,
@@ -91,22 +80,14 @@ class BravePassageEmbeddingsService
       content::WebContents* web_contents,
       mojo::PendingReceiver<local_ai::mojom::LocalAIService> receiver);
 
-  // Binds a renderer-facing receiver. Installed as the BindCallback by
-  // the controller when it creates the background contents.
-  void BindLocalAIReceiver(
-      mojo::PendingReceiver<local_ai::mojom::LocalAIService> receiver);
-
-  base::WeakPtr<BravePassageEmbeddingsService> GetWeakPtr();
-
   // Direct in-process equivalent of mojom::PassageEmbeddingsService::LoadModels
-  // — queues the receiver + callback as the pending load and drives
-  // the startup flow. The upstream mojom is shaped for a tflite +
+  // — constructs a embedder for the given receiver and starts the
+  // file-load task. The upstream mojom is shaped for a tflite +
   // sentencepiece embedder in a sandboxed utility process; we run
   // in-process with a five-file EmbeddingGemma model, so the struct
   // doesn't fit and the mojo hop adds no isolation. The controller
-  // calls this directly and leaves service_remote_ unbound. Model
-  // files are delivered separately via PassageEmbedderFactory::Init as
-  // local_ai::mojom::ModelFiles BigBuffers. See README.md for details.
+  // calls this directly and leaves service_remote_ unbound. See
+  // README.md for details.
   void BindPassageEmbedder(
       mojo::PendingReceiver<mojom::PassageEmbedder> receiver,
       base::OnceCallback<void(bool)> callback);
@@ -117,74 +98,21 @@ class BravePassageEmbeddingsService
                   mojo::PendingReceiver<mojom::PassageEmbedder> model,
                   LoadModelsCallback callback) override;
 
-  // local_ai::mojom::LocalAIService:
-  void RegisterPassageEmbedderFactory(
-      mojo::PendingRemote<local_ai::mojom::PassageEmbedderFactory> factory)
-      override;
-
  private:
-  struct PendingLoad {
-    PendingLoad();
-    ~PendingLoad();
-    PendingLoad(PendingLoad&&) noexcept;
-    PendingLoad& operator=(PendingLoad&&) noexcept;
-
-    mojo::PendingReceiver<mojom::PassageEmbedder> receiver;
-    base::OnceCallback<void(bool)> callback;
-  };
-
   // LocalModelsUpdaterState::Observer:
   void OnLocalModelsReady(const base::FilePath& install_dir) override;
 
-  // BackgroundWebContents::Delegate:
-  void OnBackgroundContentsDestroyed(
-      local_ai::BackgroundWebContents::DestroyReason reason) override;
-
-  void MaybeCreateBackgroundContents();
-  void OnBackgroundContentsCreated(
-      std::unique_ptr<local_ai::BackgroundWebContents> contents);
-  void CloseBackgroundContents();
   void MaybeLoadLocalModelFiles();
   void OnLocalModelFilesLoaded(local_ai::mojom::ModelFilesPtr model_files);
   void OnBatchEmbedderDisconnected();
-  // Handler installed on factory_ while the remote is held by the
-  // service (before it is moved into the BatchEmbedder). Once the
-  // BatchEmbedder owns the factory it installs its own disconnect
-  // handler.
-  void OnEarlyFactoryDisconnected();
-  // Drops batch_embedder_/factory_, fails any pending load, returns
-  // phase_ to kWaiting, and invalidates in-flight load callbacks.
-  void ResetEmbedderState();
 
-  std::unique_ptr<local_ai::BackgroundWebContents> background_web_contents_;
   BackgroundWebContentsFactory background_web_contents_factory_;
   raw_ptr<local_ai::LocalModelsUpdaterState> updater_state_;
 
-  mojo::ReceiverSet<local_ai::mojom::LocalAIService> local_ai_receivers_;
-  // Holds the renderer's factory remote from RegisterPassageEmbedderFactory
-  // until a successful load moves it into the BatchEmbedder.
-  mojo::Remote<local_ai::mojom::PassageEmbedderFactory> factory_;
-
   std::unique_ptr<BraveBatchPassageEmbedder> batch_embedder_;
-  std::optional<PendingLoad> pending_load_;
+  // True between PostTask and OnLocalModelFilesLoaded.
+  bool file_load_in_flight_ = false;
 
-  // Load sequence:
-  //   kWaiting -> need updater_state_->GetInstallDir() non-empty
-  //               && factory_.is_bound() && pending_load_ set
-  //   kLoading -> ThreadPool task reading model files from disk
-  //   kReady   -> batch_embedder_ created; it owns Init internally
-  //               and reports disconnect via OnBatchEmbedderDisconnected.
-  enum class LoadPhase {
-    kWaiting,
-    kLoading,
-    kReady,
-  };
-  LoadPhase phase_ = LoadPhase::kWaiting;
-
-  // Separate factory for the ThreadPool file-load reply so
-  // ResetEmbedderState can cancel an in-flight load without also
-  // invalidating the rest of the service's weak-bound callbacks.
-  base::WeakPtrFactory<BravePassageEmbeddingsService> load_weak_factory_{this};
   base::WeakPtrFactory<BravePassageEmbeddingsService> weak_ptr_factory_{this};
 };
 

--- a/browser/history_embeddings/brave_passage_embeddings_service.h
+++ b/browser/history_embeddings/brave_passage_embeddings_service.h
@@ -8,13 +8,10 @@
 
 #include <memory>
 
-#include "base/files/file_path.h"
 #include "base/functional/callback.h"
-#include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
 #include "brave/browser/history_embeddings/brave_batch_passage_embedder.h"
 #include "brave/components/local_ai/core/local_ai.mojom.h"
-#include "brave/components/local_ai/core/local_models_updater.h"
 #include "mojo/public/cpp/bindings/pending_receiver.h"
 #include "services/passage_embeddings/public/mojom/passage_embeddings.mojom.h"
 
@@ -31,34 +28,24 @@ namespace passage_embeddings {
 // service_remote_ directly to an instance of this class, so no IPC hop
 // is involved.
 //
-// The service is intentionally thin: its only responsibility is reading
-// the EmbeddingGemma model files from disk (driven by
-// LocalModelsUpdaterState component-updater notifications) and feeding
-// them to a BraveBatchPassageEmbedder, which owns the renderer-side
-// lifecycle (background WebContents, LocalAIService receiver set,
-// PassageEmbedderFactory remote, and the mojom::PassageEmbedder pipe
-// to the controller).
-//
-// On BindPassageEmbedder we construct an embedder eagerly, kick off
-// the file-load task on the ThreadPool, and hand the loaded files to
-// the embedder once they arrive. Disconnect of the embedder
-// (renderer crash, factory drop, caller drop, or background contents
-// teardown) routes back through OnBatchEmbedderDisconnected so the
-// service can drop the embedder and accept a new load.
+// The service is a thin factory: BravePassageEmbeddingsServiceController
+// owns the file-loading lifecycle and hands a fully populated
+// ModelFilesPtr to BindPassageEmbedder. The service constructs a
+// BraveBatchPassageEmbedder around it; the embedder owns the full
+// renderer-side lifecycle (background WebContents, LocalAIService
+// receiver set, PassageEmbedderFactory remote, and the
+// mojom::PassageEmbedder pipe back to the controller).
 //
 // Also exposes the static WebContents -> BindCallback registry used by
 // UntrustedLocalAIUI::BindInterface to route renderer-side
 // LocalAIService bindings to the active embedder.
-class BravePassageEmbeddingsService
-    : public mojom::PassageEmbeddingsService,
-      public local_ai::LocalModelsUpdaterState::Observer {
+class BravePassageEmbeddingsService : public mojom::PassageEmbeddingsService {
  public:
   using BackgroundWebContentsFactory =
       BraveBatchPassageEmbedder::BackgroundWebContentsFactory;
 
-  BravePassageEmbeddingsService(
-      BackgroundWebContentsFactory background_web_contents_factory,
-      local_ai::LocalModelsUpdaterState* updater_state);
+  explicit BravePassageEmbeddingsService(
+      BackgroundWebContentsFactory background_web_contents_factory);
   ~BravePassageEmbeddingsService() override;
 
   BravePassageEmbeddingsService(const BravePassageEmbeddingsService&) = delete;
@@ -81,8 +68,8 @@ class BravePassageEmbeddingsService
       mojo::PendingReceiver<local_ai::mojom::LocalAIService> receiver);
 
   // Direct in-process equivalent of mojom::PassageEmbeddingsService::LoadModels
-  // — constructs a embedder for the given receiver and starts the
-  // file-load task. The upstream mojom is shaped for a tflite +
+  // — constructs an embedder for the given receiver using the supplied
+  // model files. The upstream mojom is shaped for a tflite +
   // sentencepiece embedder in a sandboxed utility process; we run
   // in-process with a five-file EmbeddingGemma model, so the struct
   // doesn't fit and the mojo hop adds no isolation. The controller
@@ -90,6 +77,7 @@ class BravePassageEmbeddingsService
   // README.md for details.
   void BindPassageEmbedder(
       mojo::PendingReceiver<mojom::PassageEmbedder> receiver,
+      local_ai::mojom::ModelFilesPtr model_files,
       base::OnceCallback<void(bool)> callback);
 
   // mojom::PassageEmbeddingsService:
@@ -99,19 +87,10 @@ class BravePassageEmbeddingsService
                   LoadModelsCallback callback) override;
 
  private:
-  // LocalModelsUpdaterState::Observer:
-  void OnLocalModelsReady(const base::FilePath& install_dir) override;
-
-  void MaybeLoadLocalModelFiles();
-  void OnLocalModelFilesLoaded(local_ai::mojom::ModelFilesPtr model_files);
   void OnBatchEmbedderDisconnected();
 
   BackgroundWebContentsFactory background_web_contents_factory_;
-  raw_ptr<local_ai::LocalModelsUpdaterState> updater_state_;
-
   std::unique_ptr<BraveBatchPassageEmbedder> batch_embedder_;
-  // True between PostTask and OnLocalModelFilesLoaded.
-  bool file_load_in_flight_ = false;
 
   base::WeakPtrFactory<BravePassageEmbeddingsService> weak_ptr_factory_{this};
 };

--- a/browser/history_embeddings/brave_passage_embeddings_service_controller.cc
+++ b/browser/history_embeddings/brave_passage_embeddings_service_controller.cc
@@ -9,6 +9,7 @@
 
 #include "base/functional/bind.h"
 #include "base/logging.h"
+#include "brave/browser/history_embeddings/brave_batch_passage_embedder.h"
 #include "brave/components/local_ai/content/background_web_contents_impl.h"
 #include "brave/components/local_ai/core/local_models_updater.h"
 #include "brave/components/local_ai/core/url_constants.h"
@@ -36,11 +37,10 @@ mojom::PassagePriority ToMojom(PassagePriority priority) {
   }
 }
 
-void InstallBindCallback(
-    base::WeakPtr<BravePassageEmbeddingsService> weak_service,
-    content::WebContents* web_contents) {
+void InstallBindCallback(base::WeakPtr<BraveBatchPassageEmbedder> weak_embedder,
+                         content::WebContents* web_contents) {
   auto bind_cb = base::BindRepeating(
-      &BravePassageEmbeddingsService::BindLocalAIReceiver, weak_service);
+      &BraveBatchPassageEmbedder::BindLocalAIReceiver, weak_embedder);
   BravePassageEmbeddingsService::SetBindCallbackForWebContents(
       web_contents, std::move(bind_cb));
   task_manager::WebContentsTags::CreateForToolContents(
@@ -48,36 +48,34 @@ void InstallBindCallback(
 }
 
 void OnGuestProfileCreated(
-    base::WeakPtr<BravePassageEmbeddingsService> weak_service,
-    BravePassageEmbeddingsService::BackgroundWebContentsCreatedCallback
-        callback,
+    base::WeakPtr<BraveBatchPassageEmbedder> weak_embedder,
+    BraveBatchPassageEmbedder::BackgroundWebContentsCreatedCallback callback,
     Profile* guest_profile) {
   CHECK(guest_profile);
-  if (!weak_service) {
+  if (!weak_embedder) {
     return;
   }
   auto* otr = guest_profile->GetPrimaryOTRProfile(/*create_if_needed=*/true);
   // Register the OTR profile with the controller so we tear the service
   // down before the profile is destroyed on shutdown — otherwise the
-  // WebContents inside the service would outlive its BrowserContext.
+  // WebContents inside the embedder would outlive its BrowserContext.
   BravePassageEmbeddingsServiceController::Get()->ObserveGuestOTRProfile(otr);
   auto contents = std::make_unique<local_ai::BackgroundWebContentsImpl>(
-      otr, GURL(local_ai::kUntrustedLocalAIURL), weak_service.get(),
-      base::BindOnce(&InstallBindCallback, weak_service));
+      otr, GURL(local_ai::kUntrustedLocalAIURL), weak_embedder.get(),
+      base::BindOnce(&InstallBindCallback, weak_embedder));
   std::move(callback).Run(std::move(contents));
 }
 
 void CreateBackgroundWebContents(
     local_ai::BackgroundWebContents::Delegate* delegate,
-    BravePassageEmbeddingsService::BackgroundWebContentsCreatedCallback
-        callback) {
-  auto* service = static_cast<BravePassageEmbeddingsService*>(delegate);
-  auto weak_service = service->GetWeakPtr();
+    BraveBatchPassageEmbedder::BackgroundWebContentsCreatedCallback callback) {
+  auto* embedder = static_cast<BraveBatchPassageEmbedder*>(delegate);
+  auto weak_embedder = embedder->GetWeakPtr();
   auto* profile_manager = g_browser_process->profile_manager();
   CHECK(profile_manager);
   profile_manager->CreateProfileAsync(
       ProfileManager::GetGuestProfilePath(),
-      base::BindOnce(&OnGuestProfileCreated, std::move(weak_service),
+      base::BindOnce(&OnGuestProfileCreated, std::move(weak_embedder),
                      std::move(callback)));
 }
 

--- a/browser/history_embeddings/brave_passage_embeddings_service_controller.cc
+++ b/browser/history_embeddings/brave_passage_embeddings_service_controller.cc
@@ -5,10 +5,17 @@
 
 #include "brave/browser/history_embeddings/brave_passage_embeddings_service_controller.h"
 
+#include <optional>
 #include <utility>
 
+#include "base/check.h"
+#include "base/containers/span.h"
+#include "base/files/file.h"
+#include "base/files/file_path.h"
 #include "base/functional/bind.h"
 #include "base/logging.h"
+#include "base/task/task_traits.h"
+#include "base/task/thread_pool.h"
 #include "brave/browser/history_embeddings/brave_batch_passage_embedder.h"
 #include "brave/components/local_ai/content/background_web_contents_impl.h"
 #include "brave/components/local_ai/core/local_models_updater.h"
@@ -19,6 +26,8 @@
 #include "chrome/browser/profiles/profile_manager.h"
 #include "chrome/browser/task_manager/web_contents_tags.h"
 #include "components/passage_embeddings/core/passage_embeddings_features.h"
+#include "components/passage_embeddings/core/passage_embeddings_types.h"
+#include "mojo/public/cpp/base/big_buffer.h"
 #include "mojo/public/cpp/bindings/callback_helpers.h"
 
 namespace passage_embeddings {
@@ -79,6 +88,63 @@ void CreateBackgroundWebContents(
                      std::move(callback)));
 }
 
+// Reads a file directly into BigBuffer storage. For files >64KB
+// BigBuffer uses shared memory.
+std::optional<mojo_base::BigBuffer> ReadFileToBigBuffer(
+    const base::FilePath& path) {
+  base::File file(path, base::File::FLAG_OPEN | base::File::FLAG_READ);
+  if (!file.IsValid()) {
+    DVLOG(0) << "Failed to open: " << path;
+    return std::nullopt;
+  }
+  int64_t size = file.GetLength();
+  if (size <= 0) {
+    DVLOG(0) << "Empty or unreadable: " << path;
+    return std::nullopt;
+  }
+  mojo_base::BigBuffer buffer(static_cast<size_t>(size));
+  if (!file.ReadAndCheck(0, base::span<uint8_t>(buffer))) {
+    DVLOG(0) << "Failed to read: " << path;
+    return std::nullopt;
+  }
+  return buffer;
+}
+
+local_ai::mojom::ModelFilesPtr LoadLocalModelFilesFromDisk(
+    const base::FilePath& weights_path,
+    const base::FilePath& weights_dense1_path,
+    const base::FilePath& weights_dense2_path,
+    const base::FilePath& tokenizer_path,
+    const base::FilePath& config_path) {
+  auto weights = ReadFileToBigBuffer(weights_path);
+  if (!weights) {
+    return nullptr;
+  }
+  auto weights_dense1 = ReadFileToBigBuffer(weights_dense1_path);
+  if (!weights_dense1) {
+    return nullptr;
+  }
+  auto weights_dense2 = ReadFileToBigBuffer(weights_dense2_path);
+  if (!weights_dense2) {
+    return nullptr;
+  }
+  auto tokenizer = ReadFileToBigBuffer(tokenizer_path);
+  if (!tokenizer) {
+    return nullptr;
+  }
+  auto config = ReadFileToBigBuffer(config_path);
+  if (!config) {
+    return nullptr;
+  }
+  auto model_files = local_ai::mojom::ModelFiles::New();
+  model_files->weights = std::move(*weights);
+  model_files->weights_dense1 = std::move(*weights_dense1);
+  model_files->weights_dense2 = std::move(*weights_dense2);
+  model_files->tokenizer = std::move(*tokenizer);
+  model_files->config = std::move(*config);
+  return model_files;
+}
+
 }  // namespace
 
 // static
@@ -90,12 +156,11 @@ BravePassageEmbeddingsServiceController::Get() {
 
 BravePassageEmbeddingsServiceController::
     BravePassageEmbeddingsServiceController() {
-  // SchedulingEmbedder (owned by the base class) was added to
-  // observer_list_ during base construction. It's waiting for a
-  // metadata update before it dispatches any work. Our metadata is
-  // static, so fire the notification now.
-  observer_list_.Notify(&EmbedderMetadataObserver::EmbedderMetadataUpdated,
-                        GetEmbedderMetadata());
+  // AddObserver re-fires OnLocalModelsReady synchronously if the
+  // component is already installed; our handler sets model_dir_ready_
+  // and notifies observer_list_ via EmbedderMetadataUpdated.
+  updater_state_observation_.Observe(
+      local_ai::LocalModelsUpdaterState::GetInstance());
 }
 
 BravePassageEmbeddingsServiceController::
@@ -112,8 +177,7 @@ void BravePassageEmbeddingsServiceController::MaybeLaunchService() {
     return;
   }
   service_ = std::make_unique<BravePassageEmbeddingsService>(
-      base::BindRepeating(&CreateBackgroundWebContents),
-      local_ai::LocalModelsUpdaterState::GetInstance());
+      base::BindRepeating(&CreateBackgroundWebContents));
   // service_remote_ is intentionally left unbound:
   // BravePassageEmbeddingsService exposes an in-process BindPassageEmbedder()
   // that we call directly from GetEmbeddings() instead of routing LoadModels
@@ -149,7 +213,29 @@ void BravePassageEmbeddingsServiceController::OnProfileWillBeDestroyed(
 }
 
 bool BravePassageEmbeddingsServiceController::EmbedderReady() {
-  return true;
+  // Mirrors upstream's "do we have a model path to load from?" check
+  // — true once LocalModelsUpdaterState reports the component is
+  // installed. SchedulingEmbedder retries on the
+  // EmbedderMetadataUpdated notification fired in OnLocalModelsReady.
+  return model_dir_ready_;
+}
+
+void BravePassageEmbeddingsServiceController::OnLocalModelsReady(
+    const base::FilePath& install_dir) {
+  model_dir_ready_ = !install_dir.empty();
+  if (!model_dir_ready_) {
+    // Component uninstall (or test reset) cleared the dir. Tear the
+    // service down if any so it doesn't outlive the model files.
+    if (service_) {
+      ResetServiceRemote();
+    }
+    return;
+  }
+  // SchedulingEmbedder is the only observer and SubmitWorkToEmbedder()
+  // short-circuits if work is already in flight, so re-firing on
+  // repeated component-updater notifications is harmless.
+  observer_list_.Notify(&EmbedderMetadataObserver::EmbedderMetadataUpdated,
+                        GetEmbedderMetadata());
 }
 
 EmbedderMetadata
@@ -168,6 +254,12 @@ void BravePassageEmbeddingsServiceController::GetEmbeddings(
     return;
   }
 
+  if (!EmbedderReady()) {
+    DVLOG(1) << "GetEmbeddings called before model dir is ready";
+    std::move(callback).Run({}, ComputeEmbeddingsStatus::kModelUnavailable);
+    return;
+  }
+
   if (!embedder_remote_) {
     MaybeLaunchService();
     auto receiver = embedder_remote_.BindNewPipeAndPassReceiver();
@@ -181,13 +273,8 @@ void BravePassageEmbeddingsServiceController::GetEmbeddings(
         base::BindRepeating(
             &BravePassageEmbeddingsServiceController::ResetServiceRemote,
             base::Unretained(this)));
-    DVLOG(3) << "GetEmbeddings: binding new PassageEmbedder via service_";
-    service_->BindPassageEmbedder(
-        std::move(receiver), base::BindOnce([](bool success) {
-          DVLOG_IF(1, !success)
-              << "BravePassageEmbeddingsService reported BindPassageEmbedder "
-                 "failure; this batch will return an empty result";
-        }));
+    DVLOG(3) << "GetEmbeddings: posting model-file load for new embedder";
+    LoadModelFilesAndBind(std::move(receiver));
   }
 
   embedder_remote_->GenerateEmbeddings(
@@ -203,6 +290,46 @@ void BravePassageEmbeddingsServiceController::GetEmbeddings(
               },
               std::move(callback)),
           std::vector<mojom::PassageEmbeddingsResultPtr>()));
+}
+
+void BravePassageEmbeddingsServiceController::LoadModelFilesAndBind(
+    mojo::PendingReceiver<mojom::PassageEmbedder> receiver) {
+  auto* updater_state = local_ai::LocalModelsUpdaterState::GetInstance();
+  base::ThreadPool::PostTaskAndReplyWithResult(
+      FROM_HERE,
+      {base::MayBlock(), base::TaskPriority::USER_VISIBLE,
+       base::TaskShutdownBehavior::SKIP_ON_SHUTDOWN},
+      base::BindOnce(&LoadLocalModelFilesFromDisk,
+                     updater_state->GetEmbeddingGemmaModel(),
+                     updater_state->GetEmbeddingGemmaDense1(),
+                     updater_state->GetEmbeddingGemmaDense2(),
+                     updater_state->GetEmbeddingGemmaTokenizer(),
+                     updater_state->GetEmbeddingGemmaConfig()),
+      base::BindOnce(
+          &BravePassageEmbeddingsServiceController::OnLocalModelFilesLoaded,
+          weak_ptr_factory_.GetWeakPtr(), std::move(receiver)));
+}
+
+void BravePassageEmbeddingsServiceController::OnLocalModelFilesLoaded(
+    mojo::PendingReceiver<mojom::PassageEmbedder> receiver,
+    local_ai::mojom::ModelFilesPtr model_files) {
+  if (!service_) {
+    DVLOG(1) << "Service torn down before model files finished loading";
+    return;
+  }
+  if (!model_files) {
+    DVLOG(1) << "Model files load failed; tearing down service";
+    // Receiver pipe is dropped here; embedder_remote_'s disconnect
+    // handler will fire and call ResetServiceRemote.
+    return;
+  }
+  service_->BindPassageEmbedder(
+      std::move(receiver), std::move(model_files),
+      base::BindOnce([](bool success) {
+        DVLOG_IF(1, !success)
+            << "BravePassageEmbeddingsService reported BindPassageEmbedder "
+               "failure; this batch will return an empty result";
+      }));
 }
 
 }  // namespace passage_embeddings

--- a/browser/history_embeddings/brave_passage_embeddings_service_controller.h
+++ b/browser/history_embeddings/brave_passage_embeddings_service_controller.h
@@ -10,14 +10,19 @@
 #include <string>
 #include <vector>
 
+#include "base/files/file_path.h"
+#include "base/memory/weak_ptr.h"
 #include "base/no_destructor.h"
 #include "base/scoped_observation.h"
 #include "base/types/optional_ref.h"
 #include "brave/browser/history_embeddings/brave_passage_embeddings_service.h"
+#include "brave/components/local_ai/core/local_ai.mojom.h"
+#include "brave/components/local_ai/core/local_models_updater.h"
 #include "chrome/browser/passage_embeddings/chrome_passage_embeddings_service_controller.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/profiles/profile_observer.h"
 #include "components/optimization_guide/core/delivery/model_info.h"
+#include "mojo/public/cpp/bindings/pending_receiver.h"
 
 namespace passage_embeddings {
 
@@ -52,7 +57,8 @@ namespace passage_embeddings {
 // ChromePassageEmbeddingsServiceController::Get().
 class BravePassageEmbeddingsServiceController
     : public ChromePassageEmbeddingsServiceController,
-      public ProfileObserver {
+      public ProfileObserver,
+      public local_ai::LocalModelsUpdaterState::Observer {
  public:
   static BravePassageEmbeddingsServiceController* Get();
 
@@ -96,9 +102,32 @@ class BravePassageEmbeddingsServiceController
   // ProfileObserver:
   void OnProfileWillBeDestroyed(Profile* profile) override;
 
+  // local_ai::LocalModelsUpdaterState::Observer:
+  void OnLocalModelsReady(const base::FilePath& install_dir) override;
+
+  // Posts the disk read for the five EmbeddingGemma files. Wired to
+  // OnLocalModelFilesLoaded; the receiver waits on the mojo pipe until
+  // BindPassageEmbedder is invoked there.
+  void LoadModelFilesAndBind(
+      mojo::PendingReceiver<mojom::PassageEmbedder> receiver);
+  void OnLocalModelFilesLoaded(
+      mojo::PendingReceiver<mojom::PassageEmbedder> receiver,
+      local_ai::mojom::ModelFilesPtr model_files);
+
   std::unique_ptr<BravePassageEmbeddingsService> service_;
   base::ScopedObservation<Profile, ProfileObserver> otr_profile_observation_{
       this};
+  base::ScopedObservation<local_ai::LocalModelsUpdaterState,
+                          local_ai::LocalModelsUpdaterState::Observer>
+      updater_state_observation_{this};
+
+  // Set true when LocalModelsUpdaterState reports the EmbeddingGemma
+  // component is installed. Required for EmbedderReady() to return
+  // true.
+  bool model_dir_ready_ = false;
+
+  base::WeakPtrFactory<BravePassageEmbeddingsServiceController>
+      weak_ptr_factory_{this};
 };
 
 }  // namespace passage_embeddings

--- a/browser/history_embeddings/brave_passage_embeddings_service_unittest.cc
+++ b/browser/history_embeddings/brave_passage_embeddings_service_unittest.cc
@@ -9,8 +9,6 @@
 #include <utility>
 #include <vector>
 
-#include "base/files/file_util.h"
-#include "base/files/scoped_temp_dir.h"
 #include "base/functional/bind.h"
 #include "base/memory/raw_ptr.h"
 #include "base/test/bind.h"
@@ -21,7 +19,6 @@
 #include "brave/browser/history_embeddings/brave_batch_passage_embedder.h"
 #include "brave/components/local_ai/core/background_web_contents.h"
 #include "brave/components/local_ai/core/local_ai.mojom.h"
-#include "brave/components/local_ai/core/local_models_updater.h"
 #include "components/history_embeddings/core/history_embeddings_features.h"
 #include "mojo/public/cpp/bindings/receiver.h"
 #include "mojo/public/cpp/bindings/receiver_set.h"
@@ -121,18 +118,13 @@ class BravePassageEmbeddingsServiceTest : public testing::Test {
  protected:
   void SetUp() override {
     feature_list_.InitAndEnableFeature(history_embeddings::kHistoryEmbeddings);
-    service_ = std::make_unique<BravePassageEmbeddingsService>(
-        base::BindRepeating(
+    service_ =
+        std::make_unique<BravePassageEmbeddingsService>(base::BindRepeating(
             &BravePassageEmbeddingsServiceTest::CreateFakeWebContents,
-            base::Unretained(this)),
-        local_ai::LocalModelsUpdaterState::GetInstance());
+            base::Unretained(this)));
   }
 
-  void TearDown() override {
-    service_.reset();
-    local_ai::LocalModelsUpdaterState::GetInstance()->SetInstallDir(
-        base::FilePath());
-  }
+  void TearDown() override { service_.reset(); }
 
   void CreateFakeWebContents(
       local_ai::BackgroundWebContents::Delegate* delegate,
@@ -152,26 +144,7 @@ class BravePassageEmbeddingsServiceTest : public testing::Test {
                       },
                       &last_created_web_contents_, &last_delegate_));
     last_created_web_contents_ = web_contents.get();
-    if (defer_create_callback_) {
-      pending_create_callback_ =
-          base::BindOnce(std::move(callback), std::move(web_contents));
-      return;
-    }
     std::move(callback).Run(std::move(web_contents));
-  }
-
-  void RunDeferredCreate() {
-    ASSERT_TRUE(pending_create_callback_);
-    std::move(pending_create_callback_).Run();
-  }
-
-  void RecreateService() {
-    service_.reset();
-    service_ = std::make_unique<BravePassageEmbeddingsService>(
-        base::BindRepeating(
-            &BravePassageEmbeddingsServiceTest::CreateFakeWebContents,
-            base::Unretained(this)),
-        local_ai::LocalModelsUpdaterState::GetInstance());
   }
 
   // Drives the renderer-side half of the load: opens a LocalAIService
@@ -187,33 +160,6 @@ class BravePassageEmbeddingsServiceTest : public testing::Test {
     local_ai_remote.FlushForTesting();
   }
 
-  void SetUpModelFiles() {
-    ASSERT_TRUE(temp_dir_.CreateUniqueTempDir());
-    base::FilePath dir = temp_dir_.GetPath();
-    base::FilePath model_dir =
-        dir.AppendASCII(local_ai::kEmbeddingGemmaModelDir);
-    ASSERT_TRUE(base::CreateDirectory(model_dir));
-    ASSERT_TRUE(base::CreateDirectory(
-        model_dir.AppendASCII(local_ai::kEmbeddingGemmaDense1Dir)));
-    ASSERT_TRUE(base::CreateDirectory(
-        model_dir.AppendASCII(local_ai::kEmbeddingGemmaDense2Dir)));
-    ASSERT_TRUE(base::WriteFile(
-        model_dir.AppendASCII(local_ai::kEmbeddingGemmaModelFile), "w"));
-    ASSERT_TRUE(base::WriteFile(
-        model_dir.AppendASCII(local_ai::kEmbeddingGemmaDense1Dir)
-            .AppendASCII(local_ai::kEmbeddingGemmaDenseModelFile),
-        "d1"));
-    ASSERT_TRUE(base::WriteFile(
-        model_dir.AppendASCII(local_ai::kEmbeddingGemmaDense2Dir)
-            .AppendASCII(local_ai::kEmbeddingGemmaDenseModelFile),
-        "d2"));
-    ASSERT_TRUE(base::WriteFile(
-        model_dir.AppendASCII(local_ai::kEmbeddingGemmaTokenizerFile), "t"));
-    ASSERT_TRUE(base::WriteFile(
-        model_dir.AppendASCII(local_ai::kEmbeddingGemmaConfigFile), "c"));
-    local_ai::LocalModelsUpdaterState::GetInstance()->SetInstallDir(dir);
-  }
-
   struct LoadResult {
     base::test::TestFuture<bool> load_success;
     mojo::Remote<mojom::PassageEmbedder> embedder;
@@ -221,6 +167,7 @@ class BravePassageEmbeddingsServiceTest : public testing::Test {
   std::unique_ptr<LoadResult> IssueLoad() {
     auto result = std::make_unique<LoadResult>();
     service_->BindPassageEmbedder(result->embedder.BindNewPipeAndPassReceiver(),
+                                  local_ai::mojom::ModelFiles::New(),
                                   result->load_success.GetCallback());
     return result;
   }
@@ -232,9 +179,6 @@ class BravePassageEmbeddingsServiceTest : public testing::Test {
   FakePassageEmbedderFactory fake_factory_{&fake_worker_};
   raw_ptr<FakeBackgroundWebContents> last_created_web_contents_ = nullptr;
   raw_ptr<local_ai::BackgroundWebContents::Delegate> last_delegate_ = nullptr;
-  bool defer_create_callback_ = false;
-  base::OnceClosure pending_create_callback_;
-  base::ScopedTempDir temp_dir_;
 };
 
 TEST_F(BravePassageEmbeddingsServiceTest, BindCreatesBackgroundContents) {
@@ -243,13 +187,9 @@ TEST_F(BravePassageEmbeddingsServiceTest, BindCreatesBackgroundContents) {
   EXPECT_FALSE(load->load_success.IsReady());
 }
 
-TEST_F(BravePassageEmbeddingsServiceTest, BindWaitsForBothConditions) {
+TEST_F(BravePassageEmbeddingsServiceTest, BindCompletesOnFactoryRegistration) {
   auto load = IssueLoad();
   ASSERT_TRUE(last_created_web_contents_);
-
-  SetUpModelFiles();
-  EXPECT_FALSE(load->load_success.IsReady());
-  EXPECT_EQ(0, fake_factory_.init_count());
 
   RegisterFactory();
   ASSERT_TRUE(
@@ -259,7 +199,6 @@ TEST_F(BravePassageEmbeddingsServiceTest, BindWaitsForBothConditions) {
 
 TEST_F(BravePassageEmbeddingsServiceTest, EndToEndBatchGenerateEmbeddings) {
   auto load = IssueLoad();
-  SetUpModelFiles();
   RegisterFactory();
   ASSERT_TRUE(load->load_success.Get());
 
@@ -280,7 +219,6 @@ TEST_F(BravePassageEmbeddingsServiceTest, InitFailureFailsLoad) {
   fake_factory_.set_init_success(false);
 
   auto load = IssueLoad();
-  SetUpModelFiles();
   RegisterFactory();
 
   ASSERT_TRUE(
@@ -294,7 +232,6 @@ TEST_F(BravePassageEmbeddingsServiceTest, InitFailureFailsLoad) {
 
 TEST_F(BravePassageEmbeddingsServiceTest, BackgroundContentsDestroyedCloses) {
   auto load = IssueLoad();
-  SetUpModelFiles();
   RegisterFactory();
   ASSERT_TRUE(load->load_success.Get());
   ASSERT_TRUE(last_created_web_contents_);
@@ -330,34 +267,14 @@ TEST_F(BravePassageEmbeddingsServiceTest,
   local_ai_remote->RegisterPassageEmbedderFactory(std::move(dummy));
   local_ai_remote.FlushForTesting();
 
-  // The first factory is still in effect; the load completes once the
-  // model files become available.
-  SetUpModelFiles();
   ASSERT_TRUE(
       base::test::RunUntil([&] { return fake_factory_.init_count() > 0; }));
   EXPECT_TRUE(load->load_success.Get());
-}
-
-TEST_F(BravePassageEmbeddingsServiceTest,
-       PreInstalledModelDirCompletesLoadOnFactoryRegister) {
-  // Set install_dir before constructing the service. AddObserver
-  // re-fires OnLocalModelsReady synchronously when install_dir is
-  // already set; MaybeLoadLocalModelFiles is a no-op until
-  // BindPassageEmbedder creates the embedder.
-  SetUpModelFiles();
-  RecreateService();
-
-  auto load = IssueLoad();
-  RegisterFactory();
-  EXPECT_TRUE(load->load_success.Get());
-  // AddObserver's sync re-fire of OnLocalModelsReady plus the
-  // BindPassageEmbedder path must collapse to a single load.
   EXPECT_EQ(1, fake_factory_.init_count());
 }
 
 TEST_F(BravePassageEmbeddingsServiceTest, BindAgainAfterEmbedderRemoteReset) {
   auto load = IssueLoad();
-  SetUpModelFiles();
   RegisterFactory();
   ASSERT_TRUE(load->load_success.Get());
   ASSERT_TRUE(last_created_web_contents_);

--- a/browser/history_embeddings/brave_passage_embeddings_service_unittest.cc
+++ b/browser/history_embeddings/brave_passage_embeddings_service_unittest.cc
@@ -18,6 +18,7 @@
 #include "base/test/scoped_feature_list.h"
 #include "base/test/task_environment.h"
 #include "base/test/test_future.h"
+#include "brave/browser/history_embeddings/brave_batch_passage_embedder.h"
 #include "brave/components/local_ai/core/background_web_contents.h"
 #include "brave/components/local_ai/core/local_ai.mojom.h"
 #include "brave/components/local_ai/core/local_models_updater.h"
@@ -42,8 +43,6 @@ std::vector<float> TestEmbeddingFloat() {
   return {1.0f, 2.0f, 3.0f};
 }
 
-// Fake renderer-side PassageEmbedder. Returns kTestEmbeddingData for
-// every call.
 class FakeRendererEmbedder : public local_ai::mojom::PassageEmbedder {
  public:
   void GenerateEmbeddings(const std::string& text,
@@ -97,6 +96,10 @@ class FakePassageEmbedderFactory
   mojo::Receiver<local_ai::mojom::PassageEmbedderFactory> receiver_{this};
 };
 
+// Acts as the renderer-side LocalAIService consumer in the test:
+// receives a LocalAIService PendingReceiver from the embedder via
+// BindLocalAIReceiver and calls RegisterPassageEmbedderFactory back
+// through it.
 class FakeBackgroundWebContents : public local_ai::BackgroundWebContents {
  public:
   FakeBackgroundWebContents(Delegate* delegate, base::OnceClosure on_destroyed)
@@ -133,13 +136,21 @@ class BravePassageEmbeddingsServiceTest : public testing::Test {
 
   void CreateFakeWebContents(
       local_ai::BackgroundWebContents::Delegate* delegate,
-      BravePassageEmbeddingsService::BackgroundWebContentsCreatedCallback
+      BraveBatchPassageEmbedder::BackgroundWebContentsCreatedCallback
           callback) {
+    last_delegate_ = delegate;
+    // The delegate is the embedder which owns this BG contents — they
+    // die together. Clear both raw_ptrs from the destructor so neither is
+    // left dangling when the service drops batch_embedder_.
     auto web_contents = std::make_unique<FakeBackgroundWebContents>(
-        delegate,
-        base::BindOnce(
-            [](raw_ptr<FakeBackgroundWebContents>* ref) { *ref = nullptr; },
-            &last_created_web_contents_));
+        delegate, base::BindOnce(
+                      [](raw_ptr<FakeBackgroundWebContents>* contents_ref,
+                         raw_ptr<local_ai::BackgroundWebContents::Delegate>*
+                             delegate_ref) {
+                        *contents_ref = nullptr;
+                        *delegate_ref = nullptr;
+                      },
+                      &last_created_web_contents_, &last_delegate_));
     last_created_web_contents_ = web_contents.get();
     if (defer_create_callback_) {
       pending_create_callback_ =
@@ -163,9 +174,15 @@ class BravePassageEmbeddingsServiceTest : public testing::Test {
         local_ai::LocalModelsUpdaterState::GetInstance());
   }
 
+  // Drives the renderer-side half of the load: opens a LocalAIService
+  // pipe to the embedder (the way UntrustedLocalAIUI does in
+  // production) and registers the fake factory. Requires the
+  // embedder to have already created its background contents.
   void RegisterFactory() {
+    ASSERT_TRUE(last_delegate_);
+    auto* embedder = static_cast<BraveBatchPassageEmbedder*>(last_delegate_);
     mojo::Remote<local_ai::mojom::LocalAIService> local_ai_remote;
-    service_->BindLocalAIReceiver(local_ai_remote.BindNewPipeAndPassReceiver());
+    embedder->BindLocalAIReceiver(local_ai_remote.BindNewPipeAndPassReceiver());
     local_ai_remote->RegisterPassageEmbedderFactory(fake_factory_.BindRemote());
     local_ai_remote.FlushForTesting();
   }
@@ -197,9 +214,6 @@ class BravePassageEmbeddingsServiceTest : public testing::Test {
     local_ai::LocalModelsUpdaterState::GetInstance()->SetInstallDir(dir);
   }
 
-  // Issues BindPassageEmbedder via the direct in-process API and
-  // returns a TestFuture for the load result plus a Remote to the batch
-  // embedder. Caller drives the system and checks future.Get().
   struct LoadResult {
     base::test::TestFuture<bool> load_success;
     mojo::Remote<mojom::PassageEmbedder> embedder;
@@ -217,6 +231,7 @@ class BravePassageEmbeddingsServiceTest : public testing::Test {
   FakeRendererEmbedder fake_worker_;
   FakePassageEmbedderFactory fake_factory_{&fake_worker_};
   raw_ptr<FakeBackgroundWebContents> last_created_web_contents_ = nullptr;
+  raw_ptr<local_ai::BackgroundWebContents::Delegate> last_delegate_ = nullptr;
   bool defer_create_callback_ = false;
   base::OnceClosure pending_create_callback_;
   base::ScopedTempDir temp_dir_;
@@ -271,7 +286,10 @@ TEST_F(BravePassageEmbeddingsServiceTest, InitFailureFailsLoad) {
   ASSERT_TRUE(
       base::test::RunUntil([&] { return fake_factory_.init_count() > 0; }));
   EXPECT_FALSE(load->load_success.Get());
-  EXPECT_FALSE(last_created_web_contents_);
+  // Disconnect tears the embedder down, releasing its background
+  // contents.
+  ASSERT_TRUE(base::test::RunUntil(
+      [&] { return last_created_web_contents_ == nullptr; }));
 }
 
 TEST_F(BravePassageEmbeddingsServiceTest, BackgroundContentsDestroyedCloses) {
@@ -292,18 +310,21 @@ TEST_F(BravePassageEmbeddingsServiceTest,
        DuplicateRegisterPassageEmbedderFactoryIgnored) {
   // A buggy renderer that calls RegisterPassageEmbedderFactory twice
   // without first disconnecting must not crash the browser. The
-  // service should ignore the duplicate and keep the first factory.
+  // embedder should ignore the duplicate and keep the first
+  // factory.
   auto load = IssueLoad();
   ASSERT_TRUE(last_created_web_contents_);
 
-  // First registration: real fake_factory_ wired up.
   RegisterFactory();
 
   // Second registration: bind a throwaway remote and pass it in.
   // mojo::Remote::Bind CHECKs when already bound, so without the
   // duplicate guard this would crash the browser.
+  ASSERT_TRUE(last_delegate_);
+  auto* embedder =
+      static_cast<BraveBatchPassageEmbedder*>(last_delegate_.get());
   mojo::Remote<local_ai::mojom::LocalAIService> local_ai_remote;
-  service_->BindLocalAIReceiver(local_ai_remote.BindNewPipeAndPassReceiver());
+  embedder->BindLocalAIReceiver(local_ai_remote.BindNewPipeAndPassReceiver());
   mojo::PendingRemote<local_ai::mojom::PassageEmbedderFactory> dummy;
   std::ignore = dummy.InitWithNewPipeAndPassReceiver();
   local_ai_remote->RegisterPassageEmbedderFactory(std::move(dummy));
@@ -321,8 +342,8 @@ TEST_F(BravePassageEmbeddingsServiceTest,
        PreInstalledModelDirCompletesLoadOnFactoryRegister) {
   // Set install_dir before constructing the service. AddObserver
   // re-fires OnLocalModelsReady synchronously when install_dir is
-  // already set; MaybeLoadLocalModelFiles is a no-op until the factory
-  // registers because GetInstallDir() is read fresh on each call.
+  // already set; MaybeLoadLocalModelFiles is a no-op until
+  // BindPassageEmbedder creates the embedder.
   SetUpModelFiles();
   RecreateService();
 
@@ -330,7 +351,7 @@ TEST_F(BravePassageEmbeddingsServiceTest,
   RegisterFactory();
   EXPECT_TRUE(load->load_success.Get());
   // AddObserver's sync re-fire of OnLocalModelsReady plus the
-  // explicit factory-register path must collapse to a single load.
+  // BindPassageEmbedder path must collapse to a single load.
   EXPECT_EQ(1, fake_factory_.init_count());
 }
 
@@ -341,14 +362,14 @@ TEST_F(BravePassageEmbeddingsServiceTest, BindAgainAfterEmbedderRemoteReset) {
   ASSERT_TRUE(load->load_success.Get());
   ASSERT_TRUE(last_created_web_contents_);
 
-  // Drop the caller-side embedder remote. The BatchEmbedder's receiver
-  // disconnects, on_disconnect fires up to the service, and
-  // CloseBackgroundContents tears down the contents.
+  // Drop the caller-side embedder remote. The embedder's receiver
+  // disconnects, on_disconnect fires up to the service, and the
+  // service drops the embedder (which tears down its contents).
   load->embedder.reset();
   ASSERT_TRUE(base::test::RunUntil(
       [&] { return last_created_web_contents_ == nullptr; }));
 
-  // The factory pipe was reset along with the service state; the fake
+  // The factory pipe was reset along with the embedder; the fake
   // still holds a now-disconnected receiver, so reset it before
   // re-binding for the next cycle.
   fake_factory_.ResetReceiver();
@@ -359,29 +380,6 @@ TEST_F(BravePassageEmbeddingsServiceTest, BindAgainAfterEmbedderRemoteReset) {
   ASSERT_TRUE(
       base::test::RunUntil([&] { return fake_factory_.init_count() > 1; }));
   EXPECT_TRUE(load2->load_success.Get());
-}
-
-TEST_F(BravePassageEmbeddingsServiceTest,
-       LateContentsCreationDoesNotInstallOrphan) {
-  // Defer the factory callback so we can simulate destruction of the
-  // in-flight contents before OnBackgroundContentsCreated runs.
-  defer_create_callback_ = true;
-  auto load = IssueLoad();
-  ASSERT_TRUE(last_created_web_contents_);
-
-  // Simulate the in-flight contents being destroyed (e.g., renderer
-  // crash during profile setup). OnBackgroundContentsDestroyed →
-  // CloseBackgroundContents → ResetEmbedderState clears pending_load_
-  // and fails the load.
-  last_created_web_contents_->SimulateDestroyed();
-  EXPECT_FALSE(load->load_success.Get());
-
-  // The deferred factory callback finally arrives. The orphan guard
-  // sees pending_load_ is empty and drops the late contents instead
-  // of installing an orphan renderer.
-  RunDeferredCreate();
-  EXPECT_FALSE(last_created_web_contents_)
-      << "late contents must not be installed as background_web_contents_";
 }
 
 TEST_F(BravePassageEmbeddingsServiceTest, BindRegistryRoutesToService) {

--- a/browser/history_embeddings/brave_passage_embeddings_service_unittest.cc
+++ b/browser/history_embeddings/brave_passage_embeddings_service_unittest.cc
@@ -141,7 +141,17 @@ class BravePassageEmbeddingsServiceTest : public testing::Test {
             [](raw_ptr<FakeBackgroundWebContents>* ref) { *ref = nullptr; },
             &last_created_web_contents_));
     last_created_web_contents_ = web_contents.get();
+    if (defer_create_callback_) {
+      pending_create_callback_ =
+          base::BindOnce(std::move(callback), std::move(web_contents));
+      return;
+    }
     std::move(callback).Run(std::move(web_contents));
+  }
+
+  void RunDeferredCreate() {
+    ASSERT_TRUE(pending_create_callback_);
+    std::move(pending_create_callback_).Run();
   }
 
   void RecreateService() {
@@ -207,6 +217,8 @@ class BravePassageEmbeddingsServiceTest : public testing::Test {
   FakeRendererEmbedder fake_worker_;
   FakePassageEmbedderFactory fake_factory_{&fake_worker_};
   raw_ptr<FakeBackgroundWebContents> last_created_web_contents_ = nullptr;
+  bool defer_create_callback_ = false;
+  base::OnceClosure pending_create_callback_;
   base::ScopedTempDir temp_dir_;
 };
 
@@ -320,6 +332,56 @@ TEST_F(BravePassageEmbeddingsServiceTest,
   // AddObserver's sync re-fire of OnLocalModelsReady plus the
   // explicit factory-register path must collapse to a single load.
   EXPECT_EQ(1, fake_factory_.init_count());
+}
+
+TEST_F(BravePassageEmbeddingsServiceTest, BindAgainAfterEmbedderRemoteReset) {
+  auto load = IssueLoad();
+  SetUpModelFiles();
+  RegisterFactory();
+  ASSERT_TRUE(load->load_success.Get());
+  ASSERT_TRUE(last_created_web_contents_);
+
+  // Drop the caller-side embedder remote. The BatchEmbedder's receiver
+  // disconnects, on_disconnect fires up to the service, and
+  // CloseBackgroundContents tears down the contents.
+  load->embedder.reset();
+  ASSERT_TRUE(base::test::RunUntil(
+      [&] { return last_created_web_contents_ == nullptr; }));
+
+  // The factory pipe was reset along with the service state; the fake
+  // still holds a now-disconnected receiver, so reset it before
+  // re-binding for the next cycle.
+  fake_factory_.ResetReceiver();
+
+  auto load2 = IssueLoad();
+  ASSERT_TRUE(last_created_web_contents_);
+  RegisterFactory();
+  ASSERT_TRUE(
+      base::test::RunUntil([&] { return fake_factory_.init_count() > 1; }));
+  EXPECT_TRUE(load2->load_success.Get());
+}
+
+TEST_F(BravePassageEmbeddingsServiceTest,
+       LateContentsCreationDoesNotInstallOrphan) {
+  // Defer the factory callback so we can simulate destruction of the
+  // in-flight contents before OnBackgroundContentsCreated runs.
+  defer_create_callback_ = true;
+  auto load = IssueLoad();
+  ASSERT_TRUE(last_created_web_contents_);
+
+  // Simulate the in-flight contents being destroyed (e.g., renderer
+  // crash during profile setup). OnBackgroundContentsDestroyed →
+  // CloseBackgroundContents → ResetEmbedderState clears pending_load_
+  // and fails the load.
+  last_created_web_contents_->SimulateDestroyed();
+  EXPECT_FALSE(load->load_success.Get());
+
+  // The deferred factory callback finally arrives. The orphan guard
+  // sees pending_load_ is empty and drops the late contents instead
+  // of installing an orphan renderer.
+  RunDeferredCreate();
+  EXPECT_FALSE(last_created_web_contents_)
+      << "late contents must not be installed as background_web_contents_";
 }
 
 TEST_F(BravePassageEmbeddingsServiceTest, BindRegistryRoutesToService) {


### PR DESCRIPTION
Resolve https://github.com/brave/brave-browser/issues/54763

## Summary

`BravePassageEmbeddingsService` held the full embedder lifecycle — the background WebContents that hosts the WASM worker, the `local_ai::mojom::LocalAIService` receiver set, the renderer-side factory remote, a queue of pending loads, and a state machine that drove `factory_->Init` in addition to file loading — which made the set of reachable states hard to reason about and left room for the factory remote, the background contents, and the batch embedder to drift out of sync.

Restructure ownership to mirror upstream's `PassageEmbeddingsServiceController` / `PassageEmbeddingsService` split, where the controller owns the model lifecycle and the service is a thin factory.

**Renderer-side lifecycle into `BraveBatchPassageEmbedder`:**
* the background WebContents (delegate impl + owning ptr),
* the `LocalAIService` receiver set,
* the `PassageEmbedderFactory` remote and `RegisterPassageEmbedderFactory` handler (including the duplicate-registration guard),
* the `factory->Init` + `factory->Bind` handshake and the renderer-side `PassageEmbedder` pipe.

**Model-file loading into `BravePassageEmbeddingsServiceController`:**
The controller observes `LocalModelsUpdaterState` and posts the disk read for the five EmbeddingGemma files. `EmbedderReady()` returns true iff the component is installed; `OnLocalModelsReady` fires `EmbedderMetadataUpdated` so `SchedulingEmbedder` retries. `GetEmbeddings` short-circuits with `kModelUnavailable` when not ready, otherwise hands the loaded `ModelFilesPtr` to the service through `BindPassageEmbedder(receiver, files, cb)`.

**`BraveBatchPassageEmbedder` receives `ModelFilesPtr` in its ctor** and binds the caller-side `PassageEmbedder` receiver only from `OnInitDone(true)`. Mojo queues `GenerateEmbeddings` calls on the pipe until the receiver binds, mirroring upstream's utility-process embedder. The phase machine collapses to `kCreatingContents → kAwaitingFactory → kInitializing → kReady`; `ProcessNext`'s "renderer not bound" branch becomes a `CHECK`.

`BravePassageEmbeddingsService` shrinks to a thin factory: `BindPassageEmbedder(receiver, model_files, cb)` constructs a `BraveBatchPassageEmbedder` around the supplied files. No observer plumbing, no file-load state.

The static `BindForWebContents` registry stays on the service since `UntrustedLocalAIUI` uses it as a public API; the registered callback now points at `BraveBatchPassageEmbedder::BindLocalAIReceiver`.

Addresses [r3114149489](https://github.com/brave/brave-core/pull/32689#discussion_r3114149489) and [r3113112620](https://github.com/brave/brave-core/pull/32689#discussion_r3113112620) on the original PR. Together with #36228, also addresses [r3113855476](https://github.com/brave/brave-core/pull/32689#discussion_r3113855476).

## Stack

This PR is part 2 of 2 splitting the original follow-up (#35906):

1. #36228 — Extract \`BraveBatchPassageEmbedder\` to its own files
2. **This PR** — Move renderer-side lifecycle into \`BraveBatchPassageEmbedder\`

(#36124 — Replace model-load barrier with state machine — landed in master.)