### PR TITLE
[iOS] Run JavaScript alert & prompt on MainActor

### DIFF
--- a/ios/brave-ios/Sources/Web/Chromium/TabCWVUIHandler.swift
+++ b/ios/brave-ios/Sources/Web/Chromium/TabCWVUIHandler.swift
@@ -103,7 +103,7 @@ class TabCWVUIHandler: NSObject, BraveWebViewUIDelegate {
       completionHandler()
       return
     }
-    Task {
+    Task { @MainActor in
       await tab.delegate?.tab(tab, runJavaScriptAlertPanelWithMessage: message, pageURL: url)
       completionHandler()
     }
@@ -140,7 +140,7 @@ class TabCWVUIHandler: NSObject, BraveWebViewUIDelegate {
       completionHandler(nil)
       return
     }
-    Task {
+    Task { @MainActor in
       let result = await delegate.tab(
         tab,
         runJavaScriptConfirmPanelWithPrompt: prompt,


### PR DESCRIPTION
This fixes a DCHECK that occurs when these methods are handled by Brave since they will execute as nonisolated and trigger a sequence checker in Chromium
