### PR TITLE
[History Embeddings] Hide omnibox thumbs up/down and fix disclaimer trailing space

### DIFF
--- a/patches/components-omnibox-browser-featured_search_provider.cc.patch
+++ b/patches/components-omnibox-browser-featured_search_provider.cc.patch
@@ -1,14 +1,14 @@
 diff --git a/components/omnibox/browser/featured_search_provider.cc b/components/omnibox/browser/featured_search_provider.cc
-index 766588861b85c3a4ef69ed85522761aaf41cb620..8543840c0640d303ddd2b59934a743551480604c 100644
+index 766588861b85c3a4ef69ed85522761aaf41cb620..2cf5c1a4b3b24f47fca2fc6a469ec31952b73f44 100644
 --- a/components/omnibox/browser/featured_search_provider.cc
 +++ b/components/omnibox/browser/featured_search_provider.cc
-@@ -611,10 +611,10 @@ bool FeaturedSearchProvider::ShouldShowHistoryEmbeddingsDisclaimerIphMatch()
+@@ -611,10 +611,9 @@ bool FeaturedSearchProvider::ShouldShowHistoryEmbeddingsDisclaimerIphMatch()
  
  void FeaturedSearchProvider::AddHistoryEmbeddingsDisclaimerIphMatch() {
    std::u16string text =
 -      l10n_util::GetStringUTF16(IDS_OMNIBOX_HISTORY_EMBEDDINGS_DISCLAIMER_IPH) +
-+      l10n_util::GetStringUTF16(IDS_BRAVE_OMNIBOX_HISTORY_EMBEDDINGS_DISCLAIMER_IPH) +
-       u" ";
+-      u" ";
++      l10n_util::GetStringUTF16(IDS_BRAVE_OMNIBOX_HISTORY_EMBEDDINGS_DISCLAIMER_IPH);
    std::u16string link_text = l10n_util::GetStringUTF16(
 -      IDS_OMNIBOX_HISTORY_EMBEDDINGS_DISCLAIMER_IPH_LINK_TEXT);
 +      IDS_BRAVE_EMPTY_STRING);

--- a/patches/components-omnibox-browser-omnibox_popup_selection.cc.patch
+++ b/patches/components-omnibox-browser-omnibox_popup_selection.cc.patch
@@ -1,0 +1,12 @@
+diff --git a/components/omnibox/browser/omnibox_popup_selection.cc b/components/omnibox/browser/omnibox_popup_selection.cc
+index 85ecfaced51d2956aaa20d7e24eb5a7adf2ab97c..f3dc8de9287953035b6e5de9e3d99315f37039dc 100644
+--- a/components/omnibox/browser/omnibox_popup_selection.cc
++++ b/components/omnibox/browser/omnibox_popup_selection.cc
+@@ -68,6 +68,7 @@ bool OmniboxPopupSelection::IsControlPresentOnMatch(
+     }
+     case FOCUSED_BUTTON_THUMBS_UP:
+     case FOCUSED_BUTTON_THUMBS_DOWN:
++      if ((true)) return false;
+       return match.type == AutocompleteMatchType::HISTORY_EMBEDDINGS;
+     case FOCUSED_BUTTON_REMOVE_SUGGESTION:
+       return match.SupportsDeletion();

--- a/patches/components-omnibox-browser-omnibox_popup_selection_unittest.cc.patch
+++ b/patches/components-omnibox-browser-omnibox_popup_selection_unittest.cc.patch
@@ -1,0 +1,24 @@
+diff --git a/components/omnibox/browser/omnibox_popup_selection_unittest.cc b/components/omnibox/browser/omnibox_popup_selection_unittest.cc
+index 5e3d551798e75ce06ed1843b6a141e27d7e83e9f..38ef3c51ee9f75a3cb5b3b6116edf9a88b02522f 100644
+--- a/components/omnibox/browser/omnibox_popup_selection_unittest.cc
++++ b/components/omnibox/browser/omnibox_popup_selection_unittest.cc
+@@ -88,15 +88,15 @@ TEST_F(OmniboxPopupSelectionTest, SelectionWithKeywordMode) {
+   next = OmniboxPopupSelection(2u).GetNextSelection(
+       input, result, client.GetTemplateURLService(), aim_button_visible,
+       Direction::kForward, Step::kStateOrLine);
+-  EXPECT_EQ(next.line, 2u);
+-  EXPECT_EQ(next.state, LineState::FOCUSED_BUTTON_THUMBS_UP);
++  EXPECT_EQ(next.line, 0u);
++  EXPECT_EQ(next.state, LineState::NORMAL);
+ 
+   next = OmniboxPopupSelection(2u, LineState::FOCUSED_BUTTON_THUMBS_UP)
+              .GetNextSelection(input, result, client.GetTemplateURLService(),
+                                aim_button_visible, Direction::kForward,
+                                Step::kStateOrLine);
+-  EXPECT_EQ(next.line, 2u);
+-  EXPECT_EQ(next.state, LineState::FOCUSED_BUTTON_THUMBS_DOWN);
++  EXPECT_EQ(next.line, 0u);
++  EXPECT_EQ(next.state, LineState::NORMAL);
+ 
+   next = OmniboxPopupSelection(2u, LineState::FOCUSED_BUTTON_THUMBS_DOWN)
+              .GetNextSelection(input, result, client.GetTemplateURLService(),

--- a/rewrite/components/omnibox/browser/featured_search_provider.cc.toml
+++ b/rewrite/components/omnibox/browser/featured_search_provider.cc.toml
@@ -16,6 +16,14 @@ re_pattern = '\bIDS_OMNIBOX_HISTORY_EMBEDDINGS_DISCLAIMER_IPH_LINK_TEXT\b'
 replace = 'IDS_BRAVE_EMPTY_STRING'
 
 [[substitution]]
-description = 'Swap IDS_OMNIBOX_HISTORY_EMBEDDINGS_DISCLAIMER_IPH to the Brave-owned string.'
-re_pattern = '\bIDS_OMNIBOX_HISTORY_EMBEDDINGS_DISCLAIMER_IPH\b'
-replace = 'IDS_BRAVE_OMNIBOX_HISTORY_EMBEDDINGS_DISCLAIMER_IPH'
+description = '''Swap IDS_OMNIBOX_HISTORY_EMBEDDINGS_DISCLAIMER_IPH to the
+Brave-owned string and drop the upstream " " separator that follows.
+
+Without dropping the separator, match.contents would have a trailing
+space (the link text was swapped to IDS_BRAVE_EMPTY_STRING above) that
+fails AutocompleteMatch::SanitizeString in
+AutocompleteResult::AppendMatches.
+'''
+re_pattern = 'IDS_OMNIBOX_HISTORY_EMBEDDINGS_DISCLAIMER_IPH(\))\s*\+\s*u" "'
+replace = 'IDS_BRAVE_OMNIBOX_HISTORY_EMBEDDINGS_DISCLAIMER_IPH\1'
+count = 1

--- a/rewrite/components/omnibox/browser/omnibox_popup_selection.cc.toml
+++ b/rewrite/components/omnibox/browser/omnibox_popup_selection.cc.toml
@@ -1,0 +1,24 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+# Brave's history semantic search runs entirely on-device and never sends
+# data anywhere. Suppress the omnibox thumbs up/down feedback buttons that
+# upstream attaches to HISTORY_EMBEDDINGS matches so no feedback UI is
+# reachable from the URL bar. With these selections never available,
+# OmniboxResultView::UpdateFeedbackButtonsVisibility keeps the buttons
+# hidden and keyboard/selection traversal skips over them.
+
+[[substitution]]
+description = '''Never expose thumbs up/down feedback buttons on omnibox
+HISTORY_EMBEDDINGS matches.
+
+Inject a short-circuit `return false;` immediately after the case
+labels so we don't depend on the exact form of the upstream return
+expression. This keeps the plaster resilient if Chromium tweaks the
+condition (e.g. swaps the match type check or refactors the body).
+'''
+re_pattern = '(case FOCUSED_BUTTON_THUMBS_DOWN:\n)(\s+)return'
+replace = '\1\2if ((true)) return false;\n\2return'
+count = 1

--- a/rewrite/components/omnibox/browser/omnibox_popup_selection_unittest.cc.toml
+++ b/rewrite/components/omnibox/browser/omnibox_popup_selection_unittest.cc.toml
@@ -1,0 +1,26 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+[[substitution]]
+description = '''Update the two EXPECT_EQ pairs that assert thumbs up/down
+selections are reachable.
+
+Brave hides those buttons unconditionally on HISTORY_EMBEDDINGS matches
+(see omnibox_popup_selection.cc.toml), so the popup selection traversal
+wraps to (line=0, NORMAL) instead of stepping into a thumbs button.
+The surrounding test structure — including the third sub-block that
+starts from FOCUSED_BUTTON_THUMBS_DOWN and already expects (0, NORMAL)
+— is left intact, so the test continues to cover keyword-mode and
+state traversal end-to-end.
+
+The pattern only matches `EXPECT_EQ(next.line, 2u);` immediately
+followed by an `EXPECT_EQ(next.state, ...THUMBS_UP|THUMBS_DOWN);`, so
+it tolerates whitespace/line-wrap changes and is unaffected by edits
+to the surrounding `next = ...` assignments.
+'''
+re_pattern = 'EXPECT_EQ\(next\.line, 2u\);\s+EXPECT_EQ\(next\.state, LineState::FOCUSED_BUTTON_THUMBS_(?:UP|DOWN)\);'
+replace = '''EXPECT_EQ(next.line, 0u);
+  EXPECT_EQ(next.state, LineState::NORMAL);'''
+count = 2


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/55178

Follow-up to #35813 (brave-browser#54798). The previous PR stripped the WebUI feedback buttons on `chrome://history` and the history side panel, but missed the native Views omnibox: thumbs up/down still appeared on `HISTORY_EMBEDDINGS` matches when the user typed `@history`.

## Summary

- **Hide omnibox thumbs up/down.** Plaster `OmniboxPopupSelection::IsControlPresentOnMatch` to inject a short-circuit `if ((true)) return false;` immediately after the `FOCUSED_BUTTON_THUMBS_UP` / `FOCUSED_BUTTON_THUMBS_DOWN` case labels. Matching only the case labels (not the existing return expression) keeps the plaster resilient if Chromium tweaks the body. With these selections never available, `OmniboxResultView::UpdateFeedbackButtonsVisibility` keeps the buttons hidden, keyboard traversal skips them, and `OmniboxEditModel::UpdateFeedbackOnMatch` / `ChromeOmniboxClient::ShowFeedbackPage` are unreachable from the omnibox.
- **Fix disclaimer DCHECK crash.** Combine the existing `featured_search_provider.cc` IDS swap with a drop of the upstream `+ u" "` separator into a single plaster substitution. With the link text already swapped to `IDS_BRAVE_EMPTY_STRING` in #35813, the separator left `match.contents` with a trailing space that tripped `AutocompleteMatch::SanitizeString` in `AutocompleteResult::AppendMatches`.

```
[FATAL:autocomplete_result.cc:287] DCHECK failed:
  AutocompleteMatch::SanitizeString(match.contents) == match.contents
```

## Test plan

1. Enable `brave://flags/#brave-history-embeddings` and relaunch.
2. Browse a few pages so history has matchable content.
3. Focus the URL bar, type `@history` and a query that matches.
4. Confirm:
   - No thumbs up/down buttons appear on the result row (hover and keyboard-tab through the row).
   - The disclaimer IPH renders as the last row with no trailing whitespace and no DCHECK crash.
5. Repeat in `chrome://history` semantic search to confirm #35813 behavior is unchanged.
