### PR TITLE
Restore NTB padding when scroll buttons are hidden (uplift to 1.91.x)

### DIFF
--- a/browser/ui/views/frame/brave_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/brave_tab_strip_region_view.cc
@@ -306,13 +306,19 @@ void BraveHorizontalTabStripRegionView::Layout(PassKey) {
     // constants (same family as toolbar spacing). That can overlap the combo's
     // flex slot; we paint NTB above the combo in GetChildrenInZOrder so it
     // stays clickable.
-    if (new_tab_button_ && tab_scroll_next_button_ &&
-        tab_scroll_next_button_->GetVisible()) {
-      const gfx::Size button_size = new_tab_button_->GetPreferredSize();
-      const int x = tab_scroll_next_button_->bounds().right() +
-                    GetLayoutConstant(LayoutConstant::kTabStripPadding) +
-                    GetLayoutConstant(LayoutConstant::kToolbarDividerSpacing);
-      new_tab_button_->SetBoundsRect(gfx::Rect(gfx::Point(x, 0), button_size));
+    if (new_tab_button_) {
+      if (tab_scroll_next_button_ && tab_scroll_next_button_->GetVisible()) {
+        const gfx::Size button_size = new_tab_button_->GetPreferredSize();
+        const int x = tab_scroll_next_button_->bounds().right() +
+                      GetLayoutConstant(LayoutConstant::kTabStripPadding) +
+                      GetLayoutConstant(LayoutConstant::kToolbarDividerSpacing);
+        new_tab_button_->SetBoundsRect(
+            gfx::Rect(gfx::Point(x, 0), button_size));
+      } else {
+        new_tab_button_->SetX(
+            tab_strip_->bounds().right() +
+            GetLayoutConstant(LayoutConstant::kTabStripPadding));
+      }
     }
     return;
   }

--- a/browser/ui/views/tabs/brave_tab_container_browsertest.cc
+++ b/browser/ui/views/tabs/brave_tab_container_browsertest.cc
@@ -21,6 +21,7 @@
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/browser_commands.h"
 #include "chrome/browser/ui/browser_tabstrip.h"
+#include "chrome/browser/ui/layout_constants.h"
 #include "chrome/browser/ui/tabs/features.h"
 #include "chrome/browser/ui/tabs/tab_strip_model.h"
 #include "chrome/browser/ui/views/frame/browser_root_view.h"
@@ -356,6 +357,73 @@ IN_PROC_BROWSER_TEST_F(HorizontalScrollableTabStripBrowserTest,
   ASSERT_TRUE(region);
   ASSERT_TRUE(region->tab_scroll_previous_for_testing());
   EXPECT_FALSE(region->tab_scroll_previous_for_testing()->GetVisible());
+}
+
+// Regression tests for brave/brave-browser#54971 and #54988: when horizontal
+// scroll controls exist but are hidden (no overflow), the new tab button must
+// still sit to the right of the tab strip with kTabStripPadding; when they are
+// visible, it must follow the trailing scroll button with padding + divider
+// spacing.
+IN_PROC_BROWSER_TEST_F(HorizontalScrollableTabStripBrowserTest,
+                       NewTabButtonTrailingGapWhenScrollButtonsHidden) {
+  auto* tab_strip = views::AsViewClass<BraveTabStrip>(
+      browser_view()->horizontal_tab_strip_for_testing());
+  BraveTabContainer* container = views::AsViewClass<BraveTabContainer>(
+      tab_strip->GetTabContainerForTesting());
+  ASSERT_TRUE(container);
+
+  browser()->profile()->GetPrefs()->SetBoolean(
+      brave_tabs::kShowHorizontalTabScrollButtons, true);
+  StopAnimatingAndLayout();
+
+  ASSERT_EQ(0, container->GetMaxScrollOffsetForTesting())
+      << "Need few tabs so trailing scroll stays hidden";
+
+  BraveHorizontalTabStripRegionView* region = tab_strip_region();
+  ASSERT_TRUE(region);
+  ASSERT_TRUE(region->tab_scroll_next_for_testing());
+  ASSERT_FALSE(region->tab_scroll_next_for_testing()->GetVisible());
+
+  views::View* ntb = region->new_tab_button_for_testing();
+  ASSERT_TRUE(ntb);
+
+  const int pad = GetLayoutConstant(LayoutConstant::kTabStripPadding);
+  EXPECT_EQ(ntb->x(), tab_strip->bounds().right() + pad)
+      << "ntb->x()=" << ntb->x()
+      << " tab_strip->bounds().right()=" << tab_strip->bounds().right();
+}
+
+IN_PROC_BROWSER_TEST_F(HorizontalScrollableTabStripBrowserTest,
+                       NewTabButtonTrailingGapWhenScrollButtonsVisible) {
+  browser()->profile()->GetPrefs()->SetBoolean(
+      brave_tabs::kShowHorizontalTabScrollButtons, true);
+
+  auto* tab_strip = views::AsViewClass<BraveTabStrip>(
+      browser_view()->horizontal_tab_strip_for_testing());
+  BraveTabContainer* container = views::AsViewClass<BraveTabContainer>(
+      tab_strip->GetTabContainerForTesting());
+  ASSERT_TRUE(container);
+
+  while (container->GetMaxScrollOffsetForTesting() == 0) {
+    AppendTab();
+    StopAnimatingAndLayout();
+  }
+
+  BraveHorizontalTabStripRegionView* region = tab_strip_region();
+  ASSERT_TRUE(region);
+  TabStripControlButton* next = region->tab_scroll_next_for_testing();
+  ASSERT_TRUE(next);
+  ASSERT_TRUE(next->GetVisible());
+
+  views::View* ntb = region->new_tab_button_for_testing();
+  ASSERT_TRUE(ntb);
+
+  const int pad = GetLayoutConstant(LayoutConstant::kTabStripPadding);
+  const int divider = GetLayoutConstant(LayoutConstant::kToolbarDividerSpacing);
+  EXPECT_EQ(ntb->x(), next->bounds().right() + pad + divider)
+      << "ntb->x()=" << ntb->x()
+      << " next->bounds().right()=" << next->bounds().right() << " pad=" << pad
+      << " divider=" << divider;
 }
 
 IN_PROC_BROWSER_TEST_F(HorizontalScrollableTabStripBrowserTest,


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/36037
Resolves https://github.com/brave/brave-browser/issues/54971
Resolves https://github.com/brave/brave-browser/issues/54988

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.