### PR TITLE
[git-cr] Introducing `git cr mv` and `git cr follow-renames`

### DIFF
--- a/tools/cr/git_cr.py
+++ b/tools/cr/git_cr.py
@@ -3,29 +3,48 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
-"""git_cr — git commit wrapper for brave-core.
+"""git_cr — brave-core git helper.
 
-Provides ergonomic flags for the brave-core commit-msg hook and manages hook
-installation.
+Subcommands
+-----------
+  git cr commit       Commit with brave-core hook flags
+  git cr mv           Move a file/directory and repair all artefacts
+  git cr follow-renames
+                      Repair artefacts after upstream Chromium renames
+  git cr install-hook Install commit-msg hook from tools/cr/commit-msg.py
+  git cr setup-alias  Register the git cr alias in .git/config
 
-Usage
------
+commit
+------
   git cr commit [--tagged TAG[,TAG…]] [--issue NUM[,NUM…]]
                 [--culprit HASH[,HASH…]] [<git-commit-args> …]
 
   git cr commit -m "Fix login button alignment"
   git cr commit --tagged WIP -m "Work in progress"
 
-  git cr install-hook   Install commit-msg hook from tools/cr/commit-msg.py
-  git cr setup-alias    Register the git cr alias in .git/config
+  Custom flags (forwarded to the commit-msg hook via environment variables):
+    --tagged    Comma-separated tags            → $tags
+    --issue     Comma-separated issue numbers   → $issue
+    --culprit   Comma-separated commit hashes   → $culprit
 
-Custom flags (forwarded to the commit-msg hook via environment variables)
--------------------------------------------------------------------------
-  --tagged    Comma-separated tags            → $tags
-  --issue     Comma-separated issue numbers   → $issue
-  --culprit   Comma-separated commit hashes   → $culprit
+  All other arguments are forwarded verbatim to git commit.
 
-All other arguments are forwarded verbatim to git commit.
+mv
+--
+  git cr mv [--mkdir] [--no-git] <source> <destination>
+
+  git cr mv foo/bar.h baz/bar.h
+  git cr mv --mkdir foo/bar.h new_dir/bar.h
+
+follow-renames
+--------------
+  git cr follow-renames [--no-git] <rev-range>
+
+  # All renames between two Chromium version tags (typical version bump):
+  git cr follow-renames 130.0.6723.58..131.0.6778.85
+
+  # Renames introduced by a single upstream commit:
+  git cr follow-renames abc123^..abc123
 
 Installing the alias
 --------------------
@@ -52,14 +71,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-
-class _UserError(Exception):
-    """Raised for user-facing validation failures.
-
-    The message is printed to stderr as-is by the top-level handler in main().
-    Raising this instead of printing-and-returning keeps command functions free
-    of error-reporting boilerplate.
-    """
+from user_validation_error import UserValidationError
 
 
 # Directory containing this script (brave-core/tools/cr/).
@@ -107,9 +119,10 @@ def _check_hooks_path() -> None:
                 _REPO_ROOT / configured).resolve()
     if resolved == _HOOK_DEST.parent.resolve():
         return  # Points at .git/hooks/ — our hook will still run.
-    raise _UserError(f'git_cr: core.hooksPath is set to "{configured}".\n'
-                     'git ignores .git/hooks/ while this is set.\n'
-                     'Unset core.hooksPath or point it to .git/hooks/.')
+    raise UserValidationError(
+        f'git_cr: core.hooksPath is set to "{configured}".\n'
+        'git ignores .git/hooks/ while this is set.\n'
+        'Unset core.hooksPath or point it to .git/hooks/.')
 
 
 def _check_hook_ready() -> None:
@@ -129,7 +142,7 @@ def _check_hook_ready() -> None:
         else:
             ready = bool(_HOOK_DEST.stat().st_mode & stat.S_IXUSR)
     if not ready:
-        raise _UserError(
+        raise UserValidationError(
             'git_cr: commit-msg hook is not installed or not executable.\n'
             'Run:    git cr install-hook')
 
@@ -222,9 +235,9 @@ def cmd_setup_alias() -> int:
         cwd=_REPO_ROOT,
     )
     if result.returncode != 0:
-        raise _UserError(f'git_cr: {result.stderr.strip()}')
+        raise UserValidationError(f'git_cr: {result.stderr.strip()}')
     print('Installed: git alias.cr')
-    print('Usage:     git cr -m "Your commit message"')
+    print('Run "git cr" for usage.')
     return 0
 
 
@@ -251,7 +264,13 @@ def main() -> int:
             return cmd_install_hook()
         if subcmd == 'setup-alias':
             return cmd_setup_alias()
-    except _UserError as e:
+        if subcmd == 'mv':
+            import git_cr_mv
+            return git_cr_mv.cmd_mv(rest)
+        if subcmd == 'follow-renames':
+            import git_cr_follow_renames
+            return git_cr_follow_renames.cmd_follow_renames(rest)
+    except UserValidationError as e:
         print(e, file=sys.stderr)
         return 1
 

--- a/tools/cr/git_cr_follow_renames.py
+++ b/tools/cr/git_cr_follow_renames.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env vpython3
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""git_cr follow-renames — repair brave-core artefacts after upstream renames.
+
+For each file rename found in the Chromium git log for the given revision
+reference or range, updates every brave-core artefact that references the old
+path: chromium_src/ shadow files (move + shadow include + include guard),
+rewrite/ TOML files (move + patch deletion), and all cross-brave-core
+#include/#import/comment/BUILD.gn references.
+
+Usage
+-----
+  git cr follow-renames [--no-git] [--verbose] <ref-or-range>
+
+  Both a single ref and a range are accepted natively.
+
+  # All renames between two Chromium version tags (typical version bump):
+  git cr follow-renames 130.0.6723.58..131.0.6778.85
+
+  # All renames in the last N commits of the Chromium repo:
+  git cr follow-renames HEAD~5..HEAD
+
+  # Renames introduced by a single upstream commit:
+  git cr follow-renames abc123
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+
+from incendiary_error_handler import IncendiaryErrorHandler
+import plaster
+from plaster import PlasterFile
+from terminal import console
+import repository
+from source_rewrite import (
+    CPP_EXTENSIONS,
+    compute_guard,
+    find_guard,
+    insert_guard,
+    patch_name_for,
+    rewrite_guard_in_file,
+    update_references,
+    update_shadow_include,
+)
+
+_RenamePair = tuple[Path, Path]
+
+
+def cmd_follow_renames(args: list[str]) -> int:
+    """Parse follow-renames arguments and process all upstream renames."""
+    parser = argparse.ArgumentParser(
+        prog='git cr follow-renames',
+        description=('Repair brave-core artefacts after upstream Chromium '
+                     'file renames.'),
+    )
+    parser.add_argument('--no-git',
+                        action='store_true',
+                        dest='no_git',
+                        help='Use filesystem ops instead of git mv/rm')
+    parser.add_argument('--no-run-plaster',
+                        action='store_true',
+                        dest='no_run_plaster',
+                        help='Skip running plaster after moving TOML files')
+    parser.add_argument('--verbose',
+                        action='store_true',
+                        help='Enable verbose logging')
+    parser.add_argument(
+        'ref_or_range',
+        help=('Git revision range or single ref in the Chromium repo. '
+              'A bare ref (e.g. HEAD or a tag) is treated as a single '
+              'commit; a range (e.g. old_tag..new_tag) is used as-is.'))
+    parsed = parser.parse_args(args)
+
+    logging.basicConfig(
+        level=logging.DEBUG if parsed.verbose else logging.INFO,
+        format='%(message)s',
+        handlers=[IncendiaryErrorHandler(markup=True, rich_tracebacks=True)])
+
+    renames = _get_chromium_renames(parsed.ref_or_range)
+
+    for old_chromium, new_chromium in renames:
+        _repair_chromium_src(old_chromium, new_chromium, parsed.no_git)
+        _repair_plaster_files(old_chromium, new_chromium, parsed.no_git,
+                              not parsed.no_run_plaster)
+        update_references(old_chromium, new_chromium)
+
+    console.log(f'[bold green]✔[/] {len(renames)} rename(s) processed')
+    return 0
+
+
+def _get_chromium_renames(ref_or_range: str) -> list[_RenamePair]:
+    """Returns net (original → final) rename pairs from the Chromium git log.
+
+    Runs git show --diff-filter=R --name-status in the Chromium repository.
+    Accepts both a single ref (e.g. "HEAD", a tag) and a range
+    (e.g. "old_tag..new_tag"); git show handles both forms natively.
+
+    For ranges, multi-step renames are collapsed: a→b→c becomes a→c, and
+    round-trips (a→b→a) are dropped entirely.
+    """
+    raw = repository.chromium.run_git('show', '--diff-filter=R',
+                                      '--name-status', '--format=',
+                                      ref_or_range)
+    renames: list[_RenamePair] = []
+    for line in raw.splitlines():
+        parts = line.split('\t')
+        if len(parts) == 3 and parts[0].startswith('R'):
+            renames.append((Path(parts[1]), Path(parts[2])))
+    return _collapse_renames(renames) if '..' in ref_or_range else renames
+
+
+def _collapse_renames(renames: list[_RenamePair]) -> list[_RenamePair]:
+    """Collapses chained renames into net (original → final) pairs.
+
+    git show outputs renames newest-first. Processing in reverse
+    (chronological) order lets us compose chains: if a→b was recorded
+    earlier and we now see b→c, we update the entry to a→c. Round-trips
+    (a→b→a) are dropped.
+    """
+    net: dict[Path, Path] = {}
+    for old, new in reversed(renames):
+        origin = next((k for k, v in net.items() if v == old), None)
+        if origin is not None:
+            if origin == new:
+                del net[origin]
+            else:
+                net[origin] = new
+        else:
+            net[old] = new
+    return list(net.items())
+
+
+def _repair_chromium_src(old_chromium: Path, new_chromium: Path,
+                         no_git: bool) -> None:
+    """Moves and repairs the chromium_src/ shadow file for one rename.
+
+    If no shadow file exists at chromium_src/old_chromium, this is a no-op.
+    For moved files: updates the shadow #include line (C++ files) and
+    regenerates the include guard (.h files only).
+    """
+    old_shadow = repository.BRAVE_CORE_PATH / 'chromium_src' / old_chromium
+    if not old_shadow.exists():
+        return
+
+    new_shadow = repository.BRAVE_CORE_PATH / 'chromium_src' / new_chromium
+    new_shadow.parent.mkdir(parents=True, exist_ok=True)
+
+    if no_git:
+        old_shadow.rename(new_shadow)
+    else:
+        repository.brave.run_git('mv', str(old_shadow), str(new_shadow))
+
+    if new_shadow.suffix.lower() in CPP_EXTENSIONS:
+        update_shadow_include(new_shadow, old_chromium, new_chromium)
+
+    if new_shadow.suffix == '.h':
+        new_guard = compute_guard(
+            new_shadow.relative_to(repository.CHROMIUM_SRC_PATH))
+        content = new_shadow.read_text(encoding='utf-8')
+        old_guard = find_guard(content)
+        if old_guard:
+            rewrite_guard_in_file(new_shadow, old_guard, new_guard)
+        else:
+            insert_guard(new_shadow, new_guard)
+
+
+def _repair_plaster_files(old_chromium: Path,
+                          new_chromium: Path,
+                          no_git: bool,
+                          run_plaster: bool = True) -> None:
+    """Moves the plaster file and deletes the corresponding patch file.
+
+    Plaster file convention: chromium path A/foo.h lives at
+    rewrite/A/foo.h.toml. If no plaster file exists, this is a no-op.
+    The old patch file for that plaster gets automatically deleted.
+    """
+    old_toml = (plaster.PLASTER_FILES_PATH / old_chromium.parent /
+                (old_chromium.name + '.toml'))
+    if not old_toml.exists():
+        return
+
+    new_toml = (plaster.PLASTER_FILES_PATH / new_chromium.parent /
+                (new_chromium.name + '.toml'))
+    new_toml.parent.mkdir(parents=True, exist_ok=True)
+
+    if no_git:
+        old_toml.rename(new_toml)
+    else:
+        repository.brave.run_git('mv', str(old_toml), str(new_toml))
+
+    patch_file = (repository.BRAVE_CORE_PATH / 'patches' /
+                  patch_name_for(old_chromium))
+    if not patch_file.exists():
+        logging.warning(
+            'Expected patch file not found: %s; skipping deletion.',
+            patch_file)
+    else:
+        if no_git:
+            patch_file.unlink()
+        else:
+            repository.brave.run_git('rm', str(patch_file))
+
+    if run_plaster:
+        try:
+            PlasterFile(new_toml).apply()
+        except (Exception, SystemExit) as e:
+            logging.warning('plaster failed to apply %s: %s', new_toml, e)

--- a/tools/cr/git_cr_follow_renames_test.py
+++ b/tools/cr/git_cr_follow_renames_test.py
@@ -1,0 +1,489 @@
+#!/usr/bin/env vpython3
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Tests for git_cr_follow_renames.py."""
+
+import logging
+import os
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import repository
+from git_cr_follow_renames import (
+    _collapse_renames,
+    _get_chromium_renames,
+    _repair_plaster_files,
+    cmd_follow_renames,
+)
+from test.fake_chromium_src import FakeChromiumSrc
+
+
+class _Base(unittest.TestCase):
+    """Shared fixture: a fresh fake brave-core + chromium repo per test."""
+
+    def setUp(self) -> None:
+        self._repo = FakeChromiumSrc()
+        self._repo.setup()
+        self.addCleanup(self._repo.cleanup)
+        # chromium_src/, rewrite/ created by FakeChromiumSrc.setup()
+
+    @property
+    def _brave(self) -> Path:
+        return self._repo.brave
+
+    @property
+    def _chromium(self) -> Path:
+        return self._repo.chromium
+
+    def _chromium_commit(self, rel: str, content: str) -> str:
+        """Write, stage, and commit a file in chromium. Returns HEAD hash."""
+        self._repo.write_and_stage_file(rel, content, self._chromium)
+        return self._repo.commit(f'Add {rel}', self._chromium)
+
+    def _chromium_rename(self, old_rel: str, new_rel: str) -> str:
+        """Rename a file in chromium via git mv + commit. Returns HEAD hash."""
+        new_path = self._chromium / new_rel
+        new_path.parent.mkdir(parents=True, exist_ok=True)
+        self._repo._run_git_command(['mv', old_rel, new_rel], self._chromium)
+        return self._repo.commit(f'Rename {old_rel} -> {new_rel}',
+                                 self._chromium)
+
+    def _chromium_head(self) -> str:
+        """Returns HEAD hash of the chromium repo."""
+        return self._repo._run_git_command(['rev-parse', 'HEAD'],
+                                           self._chromium)
+
+    def _brave_commit(self, rel: str, content: str) -> Path:
+        """Write, stage, and commit a file in brave. Returns absolute Path."""
+        self._repo.write_and_stage_file(rel, content, self._brave)
+        self._repo.commit(f'Add {rel}', self._brave)
+        return self._brave / rel
+
+    def _brave_write(self, rel: str, content: str) -> Path:
+        """Write a file in brave without staging (for --no-git tests)."""
+        path = self._brave / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding='utf-8')
+        return path
+
+
+# ---------------------------------------------------------------------------
+# Rename parsing tests
+# ---------------------------------------------------------------------------
+
+
+class ParseTest(_Base):
+    """_get_chromium_renames correctly parses git log output."""
+
+    def test_rename_parsed(self) -> None:
+        """A single rename commit yields one (old, new) pair."""
+        before = self._chromium_head()
+        self._chromium_commit('A/foo.h', '// header\n')
+        self._chromium_rename('A/foo.h', 'B/foo.h')
+
+        renames = _get_chromium_renames(f'{before}..HEAD')
+
+        self.assertEqual(renames, [(Path('A/foo.h'), Path('B/foo.h'))])
+
+    def test_empty_range_returns_empty_list(self) -> None:
+        """A range with no renames yields an empty list."""
+        before = self._chromium_head()
+        # No changes in chromium.
+        renames = _get_chromium_renames(f'{before}..HEAD')
+        self.assertEqual(renames, [])
+
+    def test_bare_ref_accepted(self) -> None:
+        """A bare ref (no '..') works as a single-commit reference."""
+        self._chromium_commit('A/foo.h', '// header\n')
+        self._chromium_rename('A/foo.h', 'B/foo.h')
+
+        renames = _get_chromium_renames('HEAD')
+
+        self.assertEqual(renames, [(Path('A/foo.h'), Path('B/foo.h'))])
+
+    def test_non_rename_commit_ignored(self) -> None:
+        """A range with only modifications (no renames) yields an empty list."""
+        before = self._chromium_head()
+        self._chromium_commit('A/foo.h', '// v1\n')
+        self._repo.write_and_stage_file('A/foo.h', '// v2\n', self._chromium)
+        self._repo.commit('Modify A/foo.h', self._chromium)
+
+        renames = _get_chromium_renames(f'{before}..HEAD')
+        self.assertEqual(renames, [])
+
+    def test_chained_renames_collapsed(self) -> None:
+        """a→b→c across two commits collapses to a single a→c pair."""
+        before = self._chromium_head()
+        self._chromium_commit('a.txt', 'content\n')
+        self._chromium_rename('a.txt', 'b.txt')
+        self._chromium_rename('b.txt', 'c.txt')
+
+        renames = _get_chromium_renames(f'{before}..HEAD')
+
+        self.assertEqual(renames, [(Path('a.txt'), Path('c.txt'))])
+
+    def test_round_trip_rename_dropped(self) -> None:
+        """a→b→a across two commits produces an empty list (no net change)."""
+        before = self._chromium_head()
+        self._chromium_commit('a.json', 'content\n')
+        self._chromium_rename('a.json', 'b.json')
+        self._chromium_rename('b.json', 'a.json')
+
+        renames = _get_chromium_renames(f'{before}..HEAD')
+
+        self.assertEqual(renames, [])
+
+
+# ---------------------------------------------------------------------------
+# _collapse_renames unit tests
+# ---------------------------------------------------------------------------
+
+
+class CollapseRenamesTest(unittest.TestCase):
+    """Unit tests for _collapse_renames (no git needed)."""
+
+    @staticmethod
+    def _p(s: str) -> Path:
+        return Path(s)
+
+    def test_single_rename_unchanged(self) -> None:
+        inp = [(self._p('a'), self._p('b'))]
+        self.assertEqual(_collapse_renames(inp),
+                         [(self._p('a'), self._p('b'))])
+
+    def test_chain_collapsed(self) -> None:
+        """Newest-first input a→b, b→c collapses to a→c."""
+        inp = [(self._p('b'), self._p('c')), (self._p('a'), self._p('b'))]
+        self.assertEqual(_collapse_renames(inp),
+                         [(self._p('a'), self._p('c'))])
+
+    def test_round_trip_dropped(self) -> None:
+        """a→b→a collapses to nothing."""
+        inp = [(self._p('b'), self._p('a')), (self._p('a'), self._p('b'))]
+        self.assertEqual(_collapse_renames(inp), [])
+
+    def test_independent_renames_preserved(self) -> None:
+        """Two unrelated renames are both kept."""
+        inp = [(self._p('x'), self._p('y')), (self._p('a'), self._p('b'))]
+        result = _collapse_renames(inp)
+        self.assertIn((self._p('a'), self._p('b')), result)
+        self.assertIn((self._p('x'), self._p('y')), result)
+        self.assertEqual(len(result), 2)
+
+
+# ---------------------------------------------------------------------------
+# chromium_src/ shadow-file repair tests
+# ---------------------------------------------------------------------------
+
+
+class ShadowFileTest(_Base):
+    """_repair_chromium_src moves and patches the brave shadow file."""
+
+    def test_shadow_h_file_moved_guard_updated(self) -> None:
+        """chromium_src/.h file moves and its include guard is rewritten."""
+        before = self._chromium_head()
+        self._chromium_commit('A/foo.h', '// src\n')
+        self._brave_commit('chromium_src/A/foo.h',
+                           ('#ifndef BRAVE_CHROMIUM_SRC_A_FOO_H_\n'
+                            '#define BRAVE_CHROMIUM_SRC_A_FOO_H_\n'
+                            '#endif  // BRAVE_CHROMIUM_SRC_A_FOO_H_\n'))
+        self._chromium_rename('A/foo.h', 'B/foo.h')
+
+        cmd_follow_renames([f'{before}..HEAD'])
+
+        new_path = self._brave / 'chromium_src' / 'B' / 'foo.h'
+        self.assertTrue(new_path.exists())
+        self.assertFalse(
+            (self._brave / 'chromium_src' / 'A' / 'foo.h').exists())
+        content = new_path.read_text(encoding='utf-8')
+        self.assertIn('BRAVE_CHROMIUM_SRC_B_FOO_H_', content)
+        self.assertNotIn('BRAVE_CHROMIUM_SRC_A_FOO_H_', content)
+
+    def test_shadow_include_line_updated(self) -> None:
+        """#include <A/foo.h> in the shadow file becomes #include <B/foo.h>."""
+        before = self._chromium_head()
+        self._chromium_commit('A/foo.h', '// src\n')
+        self._brave_commit('chromium_src/A/foo.h',
+                           ('#ifndef BRAVE_CHROMIUM_SRC_A_FOO_H_\n'
+                            '#define BRAVE_CHROMIUM_SRC_A_FOO_H_\n'
+                            '#include <A/foo.h>\n'
+                            '#endif  // BRAVE_CHROMIUM_SRC_A_FOO_H_\n'))
+        self._chromium_rename('A/foo.h', 'B/foo.h')
+
+        cmd_follow_renames([f'{before}..HEAD'])
+
+        content = (self._brave / 'chromium_src' / 'B' /
+                   'foo.h').read_text(encoding='utf-8')
+        self.assertIn('#include <B/foo.h>', content)
+        self.assertNotIn('#include <A/foo.h>', content)
+
+    def test_shadow_cc_moved_no_guard(self) -> None:
+        """A .cc shadow file moves but no include guard is inserted."""
+        before = self._chromium_head()
+        self._chromium_commit('A/foo.cc', '// impl\n')
+        original = '// implementation\nvoid foo() {}\n'
+        self._brave_commit('chromium_src/A/foo.cc', original)
+        self._chromium_rename('A/foo.cc', 'B/foo.cc')
+
+        cmd_follow_renames([f'{before}..HEAD'])
+
+        new_path = self._brave / 'chromium_src' / 'B' / 'foo.cc'
+        self.assertTrue(new_path.exists())
+        content = new_path.read_text(encoding='utf-8')
+        self.assertNotIn('#ifndef', content)
+
+    def test_no_shadow_file_is_noop(self) -> None:
+        """Chromium rename with no matching shadow file does not raise."""
+        before = self._chromium_head()
+        self._chromium_commit('A/foo.h', '// src\n')
+        self._chromium_rename('A/foo.h', 'B/foo.h')
+        # No brave chromium_src/A/foo.h created.
+
+        cmd_follow_renames([f'{before}..HEAD'])  # Must not raise.
+
+        self.assertFalse(
+            (self._brave / 'chromium_src' / 'B' / 'foo.h').exists())
+
+
+# ---------------------------------------------------------------------------
+# rewrite/ TOML and patch-file repair tests
+# ---------------------------------------------------------------------------
+
+
+class TomlTest(_Base):
+    """_repair_plaster_files moves the TOML and deletes the patch."""
+
+    def test_toml_moved_patch_deleted(self) -> None:
+        """rewrite/A/foo.h.toml moves to rewrite/B/foo.h.toml; patch deleted."""
+        before = self._chromium_head()
+        self._chromium_commit('A/foo.h', '// src\n')
+        self._brave_commit('rewrite/A/foo.h.toml', '[substitution]\n')
+        self._brave_commit('patches/A-foo.h.patch', 'diff\n')
+        self._chromium_rename('A/foo.h', 'B/foo.h')
+
+        cmd_follow_renames([f'{before}..HEAD'])
+
+        self.assertTrue(
+            (self._brave / 'rewrite' / 'B' / 'foo.h.toml').exists())
+        self.assertFalse(
+            (self._brave / 'rewrite' / 'A' / 'foo.h.toml').exists())
+        self.assertFalse((self._brave / 'patches' / 'A-foo.h.patch').exists())
+
+    def test_missing_patch_warns_no_error(self) -> None:
+        """TOML exists but patch is absent: warning logged, TOML still moves."""
+        before = self._chromium_head()
+        self._chromium_commit('A/foo.h', '// src\n')
+        self._brave_commit('rewrite/A/foo.h.toml', '[substitution]\n')
+        # No patches/A-foo.h.patch.
+        self._chromium_rename('A/foo.h', 'B/foo.h')
+
+        with self.assertLogs(level=logging.WARNING):
+            cmd_follow_renames([f'{before}..HEAD'])
+
+        self.assertTrue(
+            (self._brave / 'rewrite' / 'B' / 'foo.h.toml').exists())
+
+    def test_no_toml_is_noop(self) -> None:
+        """A Chromium rename with no TOML in rewrite/ does not raise."""
+        before = self._chromium_head()
+        self._chromium_commit('A/foo.h', '// src\n')
+        self._chromium_rename('A/foo.h', 'B/foo.h')
+
+        cmd_follow_renames([f'{before}..HEAD'])  # Must not raise.
+
+
+# ---------------------------------------------------------------------------
+# Cross-brave-core reference update tests
+# ---------------------------------------------------------------------------
+
+
+class ReferencesTest(_Base):
+    """update_references is called for every rename regardless of artefacts."""
+
+    def test_include_updated_even_without_shadow_file(self) -> None:
+        """Brave #include of a Chromium path updates with no shadow file."""
+        before = self._chromium_head()
+        self._chromium_commit('A/foo.h', '// src\n')
+        self._brave_commit('other/user.cc', '#include "A/foo.h"\n')
+        self._chromium_rename('A/foo.h', 'B/foo.h')
+
+        cmd_follow_renames([f'{before}..HEAD'])
+
+        content = (self._brave / 'other' /
+                   'user.cc').read_text(encoding='utf-8')
+        self.assertIn('#include "B/foo.h"', content)
+        self.assertNotIn('#include "A/foo.h"', content)
+
+
+# ---------------------------------------------------------------------------
+# Multiple renames in a single range
+# ---------------------------------------------------------------------------
+
+
+class MultipleRenamesTest(_Base):
+    """All renames in a rev range are processed in order."""
+
+    def test_two_renames_both_processed(self) -> None:
+        """Two separate rename commits in the range are both fully repaired."""
+        before = self._chromium_head()
+
+        # First rename: A/foo.h → B/foo.h
+        self._chromium_commit('A/foo.h', '// foo\n')
+        self._brave_commit('chromium_src/A/foo.h',
+                           ('#ifndef BRAVE_CHROMIUM_SRC_A_FOO_H_\n'
+                            '#define BRAVE_CHROMIUM_SRC_A_FOO_H_\n'
+                            '#endif  // BRAVE_CHROMIUM_SRC_A_FOO_H_\n'))
+        self._chromium_rename('A/foo.h', 'B/foo.h')
+
+        # Second rename: C/bar.h → D/bar.h
+        self._chromium_commit('C/bar.h', '// bar\n')
+        self._brave_commit('rewrite/C/bar.h.toml', '[substitution]\n')
+        self._brave_commit('patches/C-bar.h.patch', 'diff\n')
+        self._chromium_rename('C/bar.h', 'D/bar.h')
+
+        cmd_follow_renames([f'{before}..HEAD'])
+
+        # First rename: shadow file moved.
+        self.assertTrue(
+            (self._brave / 'chromium_src' / 'B' / 'foo.h').exists())
+        self.assertFalse(
+            (self._brave / 'chromium_src' / 'A' / 'foo.h').exists())
+
+        # Second rename: TOML moved, patch deleted.
+        self.assertTrue(
+            (self._brave / 'rewrite' / 'D' / 'bar.h.toml').exists())
+        self.assertFalse((self._brave / 'patches' / 'C-bar.h.patch').exists())
+
+
+# ---------------------------------------------------------------------------
+# --no-git flag tests
+# ---------------------------------------------------------------------------
+
+
+class NoGitTest(_Base):
+    """--no-git uses Path.rename/unlink instead of git mv/rm."""
+
+    def test_no_git_shadow_uses_rename(self) -> None:
+        """--no-git: shadow file moved via Path.rename, not staged in git."""
+        before = self._chromium_head()
+        self._chromium_commit('A/foo.h', '// src\n')
+        self._brave_commit('chromium_src/A/foo.h', '// shadow\n')
+        self._chromium_rename('A/foo.h', 'B/foo.h')
+
+        cmd_follow_renames(['--no-git', f'{before}..HEAD'])
+
+        self.assertTrue(
+            (self._brave / 'chromium_src' / 'B' / 'foo.h').exists())
+        self.assertFalse(
+            (self._brave / 'chromium_src' / 'A' / 'foo.h').exists())
+        # Nothing should be staged.
+        staged = repository.brave.run_git('diff', '--cached', '--name-only')
+        self.assertEqual(staged, '')
+
+    def test_no_git_toml_patch_uses_unlink(self) -> None:
+        """--no-git: patch deleted with Path.unlink, no git rm."""
+        before = self._chromium_head()
+        self._chromium_commit('A/foo.h', '// src\n')
+        # Stage + commit the TOML but only write (don't commit) the patch
+        # so that git rm would fail on it.
+        self._brave_commit('rewrite/A/foo.h.toml', '[substitution]\n')
+        patch_file = self._brave / 'patches' / 'A-foo.h.patch'
+        patch_file.write_text('dummy\n', encoding='utf-8')
+        self._chromium_rename('A/foo.h', 'B/foo.h')
+
+        (self._brave / 'rewrite' / 'B').mkdir(parents=True, exist_ok=True)
+        cmd_follow_renames(['--no-git', f'{before}..HEAD'])
+
+        self.assertFalse(patch_file.exists())
+
+
+# ---------------------------------------------------------------------------
+# Subdirectory CWD — patch deletion bug
+# ---------------------------------------------------------------------------
+
+
+class SubdirPatchDeletionTest(_Base):
+    """git rm for patch deletion must succeed when CWD is not brave root.
+
+    _repair_plaster_files passes str(patch_file.relative_to(brave_root)) to
+    `git rm`, but git runs from the Python process CWD (not brave root).  When
+    CWD is a brave subdirectory the path resolves to CWD/patches/… which does
+    not exist, so git rm exits 128 and raises CalledProcessError.
+
+    Note: the bug is unreachable through cmd_follow_renames from a subdirectory
+    because repository.chromium.run_git uses a CWD-relative '-C ..' path and
+    fails before _repair_plaster_files is reached.  The test calls the function
+    directly to keep the regression focused.
+    """
+
+    def test_patch_deleted_from_subdirectory(self) -> None:
+        self._brave_commit('rewrite/A/foo.h.toml', '[substitution]\n')
+        self._brave_commit('patches/A-foo.h.patch', 'diff\n')
+        (self._brave / 'rewrite' / 'B').mkdir(parents=True, exist_ok=True)
+
+        subdir = self._brave / 'chromium_src'
+        subdir.mkdir(exist_ok=True)
+        saved = os.getcwd()
+        try:
+            os.chdir(str(subdir))
+            # Must not raise; patch must be deleted.
+            _repair_plaster_files(Path('A/foo.h'),
+                                  Path('B/foo.h'),
+                                  no_git=False)
+        finally:
+            os.chdir(saved)
+
+        self.assertTrue(
+            (self._brave / 'rewrite' / 'B' / 'foo.h.toml').exists())
+        self.assertFalse((self._brave / 'patches' / 'A-foo.h.patch').exists())
+
+
+# ---------------------------------------------------------------------------
+# Plaster apply-after-move tests
+# ---------------------------------------------------------------------------
+
+
+class PlasterApplyTest(_Base):
+    """plaster.apply() is called after each TOML move by default."""
+
+    _SUBST_TOML = ('[[substitution]]\n'
+                   'description = "Replace old_func"\n'
+                   'pattern = "old_func"\n'
+                   'replace = "new_func"\n')
+
+    def test_patch_created_at_new_location(self) -> None:
+        """Plaster writes patches/B-foo.cc.patch after an upstream rename."""
+        before = self._chromium_head()
+        self._chromium_commit('A/foo.cc', 'void old_func() {}\n')
+        self._brave_commit('rewrite/A/foo.cc.toml', self._SUBST_TOML)
+        self._brave_commit('patches/A-foo.cc.patch', 'old patch\n')
+        self._chromium_rename('A/foo.cc', 'B/foo.cc')
+
+        cmd_follow_renames([f'{before}..HEAD'])
+
+        old_patch = self._brave / 'patches' / 'A-foo.cc.patch'
+        new_patch = self._brave / 'patches' / 'B-foo.cc.patch'
+        self.assertFalse(old_patch.exists())
+        self.assertTrue(new_patch.exists())
+        content = new_patch.read_text(encoding='utf-8')
+        self.assertIn('-void old_func() {}', content)
+        self.assertIn('+void new_func() {}', content)
+
+    def test_no_run_plaster_skips_patch_creation(self) -> None:
+        """--no-run-plaster: no new patch file is created after TOML move."""
+        before = self._chromium_head()
+        self._chromium_commit('A/foo.cc', 'void old_func() {}\n')
+        self._brave_commit('rewrite/A/foo.cc.toml', self._SUBST_TOML)
+        self._brave_commit('patches/A-foo.cc.patch', 'old patch\n')
+        self._chromium_rename('A/foo.cc', 'B/foo.cc')
+
+        cmd_follow_renames(['--no-run-plaster', f'{before}..HEAD'])
+
+        self.assertFalse((self._brave / 'patches' / 'B-foo.cc.patch').exists())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/cr/git_cr_mv.py
+++ b/tools/cr/git_cr_mv.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env vpython3
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""git_cr mv — move a file or directory in brave-core and repair artefacts.
+
+Performs the filesystem or git rename then updates every downstream artefact
+that depends on the old path: C++ include guards, chromium_src shadow-file
+includes, cross-tree #include/#import references, // comment references,
+BUILD.gn source-list entries, and plaster TOML patch files.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+
+from incendiary_error_handler import IncendiaryErrorHandler
+from terminal import console
+import repository
+import plaster
+from plaster import PlasterFile
+from source_rewrite import (
+    CPP_EXTENSIONS,
+    compute_guard,
+    find_guard,
+    insert_guard,
+    patch_name_for,
+    rewrite_guard_in_file,
+    update_references,
+    update_shadow_include,
+)
+from user_validation_error import UserValidationError
+
+# Only .h files receive include-guard processing (spec §1.2 Step 2).
+_HEADER_EXTENSIONS: frozenset[str] = frozenset({'.h'})
+
+_FilePair = tuple[Path, Path]
+
+
+def cmd_mv(args: list[str]) -> int:
+    """Parse mv arguments and perform the file move with all repair steps."""
+    parser = argparse.ArgumentParser(
+        prog='git cr mv',
+        description=
+        'Move a file or directory inside brave-core and repair artefacts.',
+    )
+    parser.add_argument('--mkdir',
+                        action='store_true',
+                        help='Create destination parent directory if missing')
+    parser.add_argument('--no-git',
+                        action='store_true',
+                        dest='no_git',
+                        help='Use filesystem rename instead of git mv')
+    parser.add_argument('--no-run-plaster',
+                        action='store_true',
+                        dest='no_run_plaster',
+                        help='Skip running plaster after moving TOML files')
+    parser.add_argument('--verbose',
+                        action='store_true',
+                        help='Enable verbose logging')
+    parser.add_argument('source', help='Source file or directory')
+    parser.add_argument('destination', help='Destination path')
+    parsed = parser.parse_args(args)
+
+    logging.basicConfig(
+        level=logging.DEBUG if parsed.verbose else logging.INFO,
+        format='%(message)s',
+        handlers=[IncendiaryErrorHandler(markup=True, rich_tracebacks=True)])
+
+    cwd = Path.cwd()
+    try:
+        cwd.relative_to(repository.BRAVE_CORE_PATH)
+    except ValueError:
+        raise UserValidationError(
+            'git cr mv: must be run from within the brave-core tree '
+            f'({repository.BRAVE_CORE_PATH})') from None
+
+    src = (cwd / parsed.source).resolve()
+    dest = (cwd / parsed.destination).resolve()
+
+    file_pairs = _step1_move(src, dest, parsed.mkdir, parsed.no_git)
+
+    _step2_guards(file_pairs)
+    _step3_shadow_includes(file_pairs)
+
+    for old_file, new_file in file_pairs:
+        old_rel = old_file.relative_to(repository.CHROMIUM_SRC_PATH)
+        new_rel = new_file.relative_to(repository.CHROMIUM_SRC_PATH)
+        update_references(old_rel, new_rel)
+
+    _step5_plaster(file_pairs, parsed.no_git, not parsed.no_run_plaster)
+
+    console.log(f'[bold green]✔[/] {parsed.source} → {parsed.destination}')
+    return 0
+
+
+def _step1_move(src: Path, dest: Path, mkdir: bool,
+                no_git: bool) -> list[_FilePair]:
+    """Validates paths and performs the move.
+
+    Returns a list of (old_abs, new_abs) pairs for every file moved.
+    All pairs are collected before the move so old paths are available
+    for later artefact repair steps.
+    """
+    rewrite_path = plaster.PLASTER_FILES_PATH
+
+    if not src.exists():
+        raise UserValidationError(f'git cr mv: source does not exist: {src}')
+
+    if dest.is_file():
+        raise UserValidationError(
+            f'git cr mv: destination already exists: {dest}')
+
+    if not dest.parent.exists():
+        if not mkdir:
+            raise UserValidationError(
+                f'git cr mv: destination parent does not exist: {dest.parent}\n'
+                'Pass --mkdir to create it automatically.')
+        dest.parent.mkdir(parents=True, exist_ok=True)
+
+    if (src.is_relative_to(rewrite_path)
+            and not dest.is_relative_to(rewrite_path)):
+        raise UserValidationError(
+            'git cr mv: cannot move a rewrite/ path to a destination outside '
+            f'rewrite/ ({rewrite_path})')
+
+    if src.is_dir():
+        file_pairs: list[_FilePair] = [(f, dest / f.relative_to(src))
+                                       for f in src.rglob('*') if f.is_file()]
+    else:
+        file_pairs = [(src, dest)]
+
+    if no_git:
+        src.rename(dest)
+    else:
+        repository.brave.run_git('mv', str(src), str(dest))
+
+    return file_pairs
+
+
+def _step2_guards(file_pairs: list[_FilePair]) -> None:
+    """Regenerates C++ include guards for every moved .h file."""
+    for _, new_file in file_pairs:
+        if new_file.suffix not in _HEADER_EXTENSIONS:
+            continue
+        new_guard = compute_guard(
+            new_file.relative_to(repository.CHROMIUM_SRC_PATH))
+        content = new_file.read_text(encoding='utf-8')
+        old_guard = find_guard(content)
+        if old_guard:
+            rewrite_guard_in_file(new_file, old_guard, new_guard)
+        else:
+            insert_guard(new_file, new_guard)
+
+
+def _step3_shadow_includes(file_pairs: list[_FilePair]) -> None:
+    """Updates the upstream angle-bracket include in moved shadow files."""
+    chromium_src_path = repository.BRAVE_CORE_PATH / 'chromium_src'
+    for old_file, new_file in file_pairs:
+        if not old_file.is_relative_to(chromium_src_path):
+            continue
+        if new_file.suffix.lower() not in CPP_EXTENSIONS:
+            continue
+        old_chromium = old_file.relative_to(chromium_src_path)
+        new_chromium = new_file.relative_to(chromium_src_path)
+        update_shadow_include(new_file, old_chromium, new_chromium)
+
+
+def _step5_plaster(file_pairs: list[_FilePair], no_git: bool,
+                   run_plaster: bool) -> None:
+    """Deletes stale patch files and optionally re-runs plaster for moved
+    TOMLs."""
+    rewrite_path = plaster.PLASTER_FILES_PATH
+    patches_path = repository.BRAVE_CORE_PATH / 'patches'
+
+    for old_file, new_file in file_pairs:
+        if old_file.suffix != '.toml':
+            continue
+        if not old_file.is_relative_to(rewrite_path):
+            continue
+        old_chromium_path = old_file.relative_to(rewrite_path).with_suffix('')
+        patch_file = patches_path / patch_name_for(old_chromium_path)
+        if not patch_file.exists():
+            logging.warning(
+                'Expected patch file not found: %s; skipping deletion.',
+                patch_file)
+        else:
+            if no_git:
+                patch_file.unlink()
+            else:
+                repository.brave.run_git('rm', str(patch_file))
+
+        if run_plaster:
+            try:
+                PlasterFile(new_file).apply()
+            except (Exception, SystemExit) as e:
+                logging.warning('plaster failed to apply %s: %s', new_file, e)

--- a/tools/cr/git_cr_mv_test.py
+++ b/tools/cr/git_cr_mv_test.py
@@ -1,0 +1,487 @@
+#!/usr/bin/env vpython3
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Tests for git_cr_mv.py — all cases from spec §6.2."""
+
+import logging
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+import repository
+from git_cr_mv import cmd_mv
+from test.fake_chromium_src import FakeChromiumSrc
+from user_validation_error import UserValidationError
+
+
+class _Base(unittest.TestCase):
+    """Shared fixture: a fresh fake brave-core repo for every test method."""
+
+    def setUp(self) -> None:
+        self._repo = FakeChromiumSrc()
+        self._repo.setup()
+        self.addCleanup(self._repo.cleanup)
+        # chromium_src/, rewrite/ created by FakeChromiumSrc.setup()
+        # patches/ is created by FakeChromiumRepo.__init__
+
+    @property
+    def _brave(self) -> Path:
+        return self._repo.brave
+
+    def _commit(self, rel: str, content: str) -> Path:
+        """Write, stage, and commit a file in the brave repo."""
+        self._repo.write_and_stage_file(rel, content, self._brave)
+        self._repo.commit(f'Add {rel}', self._brave)
+        return self._brave / rel
+
+    def _write(self, rel: str, content: str) -> Path:
+        """Write a file without staging (for --no-git tests)."""
+        path = self._brave / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding='utf-8')
+        return path
+
+
+# ---------------------------------------------------------------------------
+# Validation tests
+# ---------------------------------------------------------------------------
+
+
+class ValidationTest(_Base):
+    """Error conditions that must raise UserValidationError (spec §6.2)."""
+
+    def test_source_not_found(self) -> None:
+        with self.assertRaises(UserValidationError):
+            cmd_mv(['nonexistent.h', 'dest.h'])
+
+    def test_dest_parent_missing_no_mkdir(self) -> None:
+        self._commit('src.h', '// src\n')
+        with self.assertRaises(UserValidationError):
+            cmd_mv(['src.h', 'missing_dir/dest.h'])
+
+    def test_dest_parent_created_with_mkdir(self) -> None:
+        self._commit('src.h', '// src\n')
+        cmd_mv(['--mkdir', 'src.h', 'new_dir/dest.h'])
+        self.assertTrue((self._brave / 'new_dir' / 'dest.h').exists())
+        self.assertFalse((self._brave / 'src.h').exists())
+
+    def test_dest_exists_as_file(self) -> None:
+        self._commit('src.h', '// src\n')
+        self._commit('dest.h', '// dest\n')
+        with self.assertRaises(UserValidationError):
+            cmd_mv(['src.h', 'dest.h'])
+
+    def test_cwd_outside_brave_core(self) -> None:
+        saved = os.getcwd()
+        try:
+            os.chdir(tempfile.gettempdir())
+            with self.assertRaises(UserValidationError):
+                cmd_mv(['src.h', 'dest.h'])
+        finally:
+            os.chdir(saved)
+
+    def test_rewrite_toml_to_outside_rewrite(self) -> None:
+        self._commit('rewrite/A/foo.h.toml', '[substitution]\n')
+        with self.assertRaises(UserValidationError):
+            cmd_mv(['rewrite/A/foo.h.toml', 'other/foo.h.toml'])
+
+
+# ---------------------------------------------------------------------------
+# Include guard tests (Step 2)
+# ---------------------------------------------------------------------------
+
+
+class GuardTest(_Base):
+    """Include-guard behaviour for moved .h files (spec §6.2 Step 2)."""
+
+    def test_guard_updated_in_three_places(self) -> None:
+        """Moving a .h with a correct guard updates #ifndef, #define, #endif."""
+        self._commit('foo/bar.h', ('// Copyright\n'
+                                   '#ifndef BRAVE_FOO_BAR_H_\n'
+                                   '#define BRAVE_FOO_BAR_H_\n'
+                                   '\n'
+                                   'class Foo {};\n'
+                                   '\n'
+                                   '#endif  // BRAVE_FOO_BAR_H_\n'))
+        cmd_mv(['--mkdir', 'foo/bar.h', 'baz/bar.h'])
+        new_content = (self._brave / 'baz' /
+                       'bar.h').read_text(encoding='utf-8')
+        self.assertEqual(new_content.count('BRAVE_BAZ_BAR_H_'), 3)
+        self.assertNotIn('BRAVE_FOO_BAR_H_', new_content)
+
+    def test_guard_count_warning_but_file_written(self) -> None:
+        """Moving a .h with 4 guard occurrences warns but writes the file."""
+        # 4 occurrences: comment + ifndef + define + endif-comment
+        self._commit('foo/bar.h', ('// Ref: BRAVE_FOO_BAR_H_\n'
+                                   '#ifndef BRAVE_FOO_BAR_H_\n'
+                                   '#define BRAVE_FOO_BAR_H_\n'
+                                   '#endif  // BRAVE_FOO_BAR_H_\n'))
+        with self.assertLogs(level=logging.WARNING):
+            cmd_mv(['--mkdir', 'foo/bar.h', 'baz/bar.h'])
+        new_content = (self._brave / 'baz' /
+                       'bar.h').read_text(encoding='utf-8')
+        # The replacement ran (old guard gone, new guard present).
+        self.assertNotIn('BRAVE_FOO_BAR_H_', new_content)
+        self.assertIn('BRAVE_BAZ_BAR_H_', new_content)
+
+    def test_guard_inserted_when_absent(self) -> None:
+        """Moving a .h with no guard inserts a complete guard block."""
+        self._commit('foo/bar.h', ('// Copyright\n'
+                                   '\n'
+                                   'class Foo {};\n'))
+        cmd_mv(['--mkdir', 'foo/bar.h', 'baz/bar.h'])
+        new_content = (self._brave / 'baz' /
+                       'bar.h').read_text(encoding='utf-8')
+        self.assertIn('#ifndef BRAVE_BAZ_BAR_H_', new_content)
+        self.assertIn('#define BRAVE_BAZ_BAR_H_', new_content)
+        self.assertIn('#endif  // BRAVE_BAZ_BAR_H_', new_content)
+        # Original body still present.
+        self.assertIn('class Foo {};', new_content)
+        # Guard comes before the class.
+        guard_pos = new_content.index('#ifndef BRAVE_BAZ_BAR_H_')
+        class_pos = new_content.index('class Foo {};')
+        self.assertLess(guard_pos, class_pos)
+
+    def test_cc_file_gets_no_guard(self) -> None:
+        """Moving a .cc file does not touch include guards."""
+        original = '// Simple source\nvoid foo() {}\n'
+        self._commit('foo/bar.cc', original)
+        cmd_mv(['--mkdir', 'foo/bar.cc', 'baz/bar.cc'])
+        new_content = (self._brave / 'baz' /
+                       'bar.cc').read_text(encoding='utf-8')
+        self.assertNotIn('#ifndef', new_content)
+        self.assertNotIn('#define', new_content)
+
+
+# ---------------------------------------------------------------------------
+# Shadow include tests (Step 3)
+# ---------------------------------------------------------------------------
+
+
+class ShadowIncludeTest(_Base):
+    """chromium_src/ shadow-file include update (spec §6.2 Step 3)."""
+
+    def test_shadow_include_updated(self) -> None:
+        """Moving chromium_src/A/foo.h updates the upstream include."""
+        self._commit('chromium_src/A/foo.h',
+                     ('// Shadow\n'
+                      '#ifndef BRAVE_CHROMIUM_SRC_A_FOO_H_\n'
+                      '#define BRAVE_CHROMIUM_SRC_A_FOO_H_\n'
+                      '\n'
+                      '#include <A/foo.h>\n'
+                      '\n'
+                      '#endif  // BRAVE_CHROMIUM_SRC_A_FOO_H_\n'))
+        cmd_mv(['--mkdir', 'chromium_src/A/foo.h', 'chromium_src/B/foo.h'])
+        new_content = (self._brave / 'chromium_src' / 'B' /
+                       'foo.h').read_text(encoding='utf-8')
+        self.assertIn('#include <B/foo.h>', new_content)
+        self.assertNotIn('#include <A/foo.h>', new_content)
+
+    def test_no_shadow_include_when_absent(self) -> None:
+        """Moving a shadow file without the upstream include is a no-op."""
+        original = ('// No upstream include\n'
+                    '#ifndef BRAVE_CHROMIUM_SRC_A_BAR_H_\n'
+                    '#define BRAVE_CHROMIUM_SRC_A_BAR_H_\n'
+                    '// code\n'
+                    '#endif  // BRAVE_CHROMIUM_SRC_A_BAR_H_\n')
+        self._commit('chromium_src/A/bar.h', original)
+        cmd_mv(['--mkdir', 'chromium_src/A/bar.h', 'chromium_src/B/bar.h'])
+        new_content = (self._brave / 'chromium_src' / 'B' /
+                       'bar.h').read_text(encoding='utf-8')
+        # No angle-bracket include of A/bar.h should appear.
+        self.assertNotIn('#include <A/bar.h>', new_content)
+
+    def test_non_cpp_shadow_no_content_edit(self) -> None:
+        """Moving a non-C++ file under chromium_src/ does not edit content."""
+        original = '# Python script\nprint("hello")\n'
+        self._commit('chromium_src/A/script.py', original)
+        cmd_mv([
+            '--mkdir', 'chromium_src/A/script.py', 'chromium_src/B/script.py'
+        ])
+        new_content = (self._brave / 'chromium_src' / 'B' /
+                       'script.py').read_text(encoding='utf-8')
+        self.assertEqual(new_content, original)
+
+
+# ---------------------------------------------------------------------------
+# Cross-brave-core reference rewriting tests (Step 4)
+# ---------------------------------------------------------------------------
+
+
+class ReferencesTest(_Base):
+    """Reference rewriting across brave-core (spec §6.2 Step 4)."""
+
+    def _setup_source_file(self) -> None:
+        """Create and commit the file that will be moved."""
+        self._commit('foo/bar.h', '// moved header\n')
+
+    def test_quoted_include_in_h_and_cc_updated(self) -> None:
+        self._setup_source_file()
+        # Files that reference the moved file.
+        self._commit('other/user.h', '#include "brave/foo/bar.h"\n')
+        self._commit('other/user.cc', '#include "brave/foo/bar.h"\n')
+
+        cmd_mv(['--mkdir', 'foo/bar.h', 'baz/bar.h'])
+
+        h_content = (self._brave / 'other' /
+                     'user.h').read_text(encoding='utf-8')
+        cc_content = (self._brave / 'other' /
+                      'user.cc').read_text(encoding='utf-8')
+        self.assertIn('#include "brave/baz/bar.h"', h_content)
+        self.assertNotIn('#include "brave/foo/bar.h"', h_content)
+        self.assertIn('#include "brave/baz/bar.h"', cc_content)
+        self.assertNotIn('#include "brave/foo/bar.h"', cc_content)
+
+    def test_import_in_mm_updated(self) -> None:
+        self._setup_source_file()
+        self._commit('other/user.mm', '#import "brave/foo/bar.h"\n')
+
+        cmd_mv(['--mkdir', 'foo/bar.h', 'baz/bar.h'])
+
+        mm_content = (self._brave / 'other' /
+                      'user.mm').read_text(encoding='utf-8')
+        self.assertIn('#import "brave/baz/bar.h"', mm_content)
+        self.assertNotIn('#import "brave/foo/bar.h"', mm_content)
+
+    def test_comment_reference_updated(self) -> None:
+        self._setup_source_file()
+        self._commit('other/user.cc',
+                     '// See brave/foo/bar.h for details\nvoid f() {}\n')
+
+        cmd_mv(['--mkdir', 'foo/bar.h', 'baz/bar.h'])
+
+        cc_content = (self._brave / 'other' /
+                      'user.cc').read_text(encoding='utf-8')
+        self.assertIn('brave/baz/bar.h', cc_content)
+        self.assertNotIn('brave/foo/bar.h', cc_content)
+
+    def test_build_gn_entry_updated(self) -> None:
+        self._setup_source_file()
+        # BUILD.gn at brave_root — entry uses path relative to brave_root.
+        self._commit('BUILD.gn', 'sources = [\n  "foo/bar.h",\n]\n')
+
+        cmd_mv(['--mkdir', 'foo/bar.h', 'baz/bar.h'])
+
+        build_content = (self._brave / 'BUILD.gn').read_text(encoding='utf-8')
+        self.assertIn('"baz/bar.h"', build_content)
+        self.assertNotIn('"foo/bar.h"', build_content)
+
+    def test_angle_bracket_chromium_include_untouched(self) -> None:
+        self._setup_source_file()
+        self._commit('other/user.cc', '#include <base/feature_list.h>\n')
+
+        cmd_mv(['--mkdir', 'foo/bar.h', 'baz/bar.h'])
+
+        cc_content = (self._brave / 'other' /
+                      'user.cc').read_text(encoding='utf-8')
+        self.assertIn('#include <base/feature_list.h>', cc_content)
+
+
+# ---------------------------------------------------------------------------
+# Plaster TOML handling tests (Step 5)
+# ---------------------------------------------------------------------------
+
+
+class PlasterTest(_Base):
+    """Plaster TOML and patch-file handling (spec §6.2 Step 5)."""
+
+    def test_patch_deleted_on_toml_move(self) -> None:
+        """Moving rewrite/A/foo.h.toml deletes the corresponding patch."""
+        self._commit('rewrite/A/foo.h.toml', '[substitution]\n')
+        self._commit('patches/A-foo.h.patch', 'diff --git a/foo\n')
+
+        cmd_mv(['--mkdir', 'rewrite/A/foo.h.toml', 'rewrite/B/foo.h.toml'])
+
+        self.assertFalse((self._brave / 'patches' / 'A-foo.h.patch').exists())
+        self.assertTrue(
+            (self._brave / 'rewrite' / 'B' / 'foo.h.toml').exists())
+
+    def test_missing_patch_warns_no_error(self) -> None:
+        """Moving a TOML whose patch is absent warns but does not raise."""
+        self._commit('rewrite/A/foo.h.toml', '[substitution]\n')
+        # No patches/A-foo.h.patch created.
+        with self.assertLogs(level=logging.WARNING):
+            cmd_mv(['--mkdir', 'rewrite/A/foo.h.toml', 'rewrite/B/foo.h.toml'])
+        # Command completed; TOML is at new location.
+        self.assertTrue(
+            (self._brave / 'rewrite' / 'B' / 'foo.h.toml').exists())
+
+    def test_directory_move_handles_all_tomls(self) -> None:
+        """Moving a rewrite/ directory moves all TOMLs and deletes patches."""
+        self._commit('rewrite/A/foo.h.toml', '[substitution]\n')
+        self._commit('rewrite/A/bar.h.toml', '[substitution]\n')
+        self._commit('patches/A-foo.h.patch', 'diff\n')
+        self._commit('patches/A-bar.h.patch', 'diff\n')
+
+        cmd_mv(['rewrite/A', 'rewrite/B'])
+
+        self.assertFalse((self._brave / 'patches' / 'A-foo.h.patch').exists())
+        self.assertFalse((self._brave / 'patches' / 'A-bar.h.patch').exists())
+        self.assertTrue(
+            (self._brave / 'rewrite' / 'B' / 'foo.h.toml').exists())
+        self.assertTrue(
+            (self._brave / 'rewrite' / 'B' / 'bar.h.toml').exists())
+
+
+# ---------------------------------------------------------------------------
+# CWD-relative argument tests
+# ---------------------------------------------------------------------------
+
+
+class CwdRelativeTest(_Base):
+    """Source and destination resolved relative to CWD (spec §6.2)."""
+
+    def test_paths_resolved_from_subdirectory(self) -> None:
+        """Invoking from a subdirectory resolves paths relative to that dir."""
+        self._commit('foo/bar.h', '// header\n')
+        (self._brave / 'baz').mkdir(exist_ok=True)
+
+        saved = os.getcwd()
+        try:
+            os.chdir(str(self._brave / 'foo'))
+            cmd_mv(['bar.h', '../baz/bar.h'])
+        finally:
+            os.chdir(saved)
+
+        self.assertTrue((self._brave / 'baz' / 'bar.h').exists())
+        self.assertFalse((self._brave / 'foo' / 'bar.h').exists())
+
+
+# ---------------------------------------------------------------------------
+# --no-git flag tests
+# ---------------------------------------------------------------------------
+
+
+class NoGitTest(_Base):
+    """--no-git flag uses Path.rename/unlink instead of git mv/rm."""
+
+    def test_no_git_uses_rename_not_staged(self) -> None:
+        """--no-git moves the file without staging the change."""
+        self._commit('src.h', '// content\n')
+
+        cmd_mv(['--no-git', 'src.h', 'dst.h'])
+
+        self.assertTrue((self._brave / 'dst.h').exists())
+        self.assertFalse((self._brave / 'src.h').exists())
+        # Nothing should be staged.
+        staged = repository.brave.run_git('diff', '--cached', '--name-only')
+        self.assertEqual(staged, '')
+
+    def test_no_git_patch_deletion_uses_unlink(self) -> None:
+        """--no-git deletes the patch with Path.unlink() rather than git rm."""
+        self._commit('rewrite/A/foo.h.toml', '[substitution]\n')
+        # Patch written but not committed — git rm would fail on it.
+        patch_file = self._brave / 'patches' / 'A-foo.h.patch'
+        patch_file.write_text('dummy\n', encoding='utf-8')
+
+        (self._brave / 'rewrite' / 'B').mkdir(parents=True, exist_ok=True)
+        cmd_mv(['--no-git', 'rewrite/A/foo.h.toml', 'rewrite/B/foo.h.toml'])
+
+        self.assertFalse(patch_file.exists())
+
+
+# ---------------------------------------------------------------------------
+# Subdirectory CWD — patch deletion bug
+# ---------------------------------------------------------------------------
+
+
+class SubdirPatchDeletionTest(_Base):
+    """git rm for patch deletion must succeed when CWD is not brave root."""
+
+    def test_patch_deleted_from_subdirectory(self) -> None:
+        """Moving a TOML from a brave subdirectory deletes the patch file.
+
+        Regression for the bug where _step5_plaster passed a brave-root-relative
+        path to `git rm` but git ran from CWD (a subdirectory), causing git rm
+        to look for the file relative to the subdirectory and fail.
+        """
+        self._commit('rewrite/A/foo.h.toml', '[substitution]\n')
+        self._commit('patches/A-foo.h.patch', 'diff --git a/foo\n')
+        subdir = self._brave / 'chromium_src'
+        subdir.mkdir(exist_ok=True)
+
+        saved = os.getcwd()
+        try:
+            os.chdir(str(subdir))
+            # Must not raise; patch must be deleted.
+            cmd_mv([
+                '--mkdir', '../rewrite/A/foo.h.toml', '../rewrite/B/foo.h.toml'
+            ])
+        finally:
+            os.chdir(saved)
+
+        self.assertTrue(
+            (self._brave / 'rewrite' / 'B' / 'foo.h.toml').exists())
+        self.assertFalse((self._brave / 'patches' / 'A-foo.h.patch').exists())
+
+
+# ---------------------------------------------------------------------------
+# Plaster apply-after-move tests
+# ---------------------------------------------------------------------------
+
+
+class PlasterApplyTest(_Base):
+    """plaster.apply() is called after each TOML move by default."""
+
+    _SUBST_TOML = ('[[substitution]]\n'
+                   'description = "Replace old_func"\n'
+                   'pattern = "old_func"\n'
+                   'replace = "new_func"\n')
+
+    def _commit_chromium(self, rel: str, content: str) -> None:
+        self._repo.write_and_stage_file(rel, content, self._repo.chromium)
+        self._repo.commit(f'Add {rel}', self._repo.chromium)
+
+    def test_patch_created_at_new_location(self) -> None:
+        """After TOML move, plaster writes a new patch at
+        patches/B-foo.cc.patch."""
+        self._commit_chromium('B/foo.cc', 'void old_func() {}\n')
+        self._commit('rewrite/A/foo.cc.toml', self._SUBST_TOML)
+        self._commit('patches/A-foo.cc.patch', 'old patch\n')
+
+        cmd_mv(['--mkdir', 'rewrite/A/foo.cc.toml', 'rewrite/B/foo.cc.toml'])
+
+        old_patch = self._brave / 'patches' / 'A-foo.cc.patch'
+        new_patch = self._brave / 'patches' / 'B-foo.cc.patch'
+        self.assertFalse(old_patch.exists())
+        self.assertTrue(new_patch.exists())
+        content = new_patch.read_text(encoding='utf-8')
+        self.assertIn('-void old_func() {}', content)
+        self.assertIn('+void new_func() {}', content)
+
+    def test_no_upstream_source_logs_warning(self) -> None:
+        """Warning is logged when the chromium source for the new path is
+        absent."""
+        # No chromium file at B/foo.cc — plaster cannot read the source.
+        self._commit('rewrite/A/foo.cc.toml', self._SUBST_TOML)
+        self._commit('patches/A-foo.cc.patch', 'old patch\n')
+
+        with self.assertLogs(level=logging.WARNING) as cm:
+            cmd_mv(
+                ['--mkdir', 'rewrite/A/foo.cc.toml', 'rewrite/B/foo.cc.toml'])
+
+        self.assertTrue(any('plaster failed' in msg for msg in cm.output))
+        self.assertTrue(
+            (self._brave / 'rewrite' / 'B' / 'foo.cc.toml').exists())
+        self.assertFalse((self._brave / 'patches' / 'B-foo.cc.patch').exists())
+
+    def test_no_run_plaster_skips_patch_creation(self) -> None:
+        """--no-run-plaster: no new patch file is created after TOML move."""
+        self._commit_chromium('B/foo.cc', 'void old_func() {}\n')
+        self._commit('rewrite/A/foo.cc.toml', self._SUBST_TOML)
+        self._commit('patches/A-foo.cc.patch', 'old patch\n')
+
+        cmd_mv([
+            '--mkdir', '--no-run-plaster', 'rewrite/A/foo.cc.toml',
+            'rewrite/B/foo.cc.toml'
+        ])
+
+        self.assertFalse((self._brave / 'patches' / 'B-foo.cc.patch').exists())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/cr/plaster.py
+++ b/tools/cr/plaster.py
@@ -76,6 +76,7 @@ class PathChecksumPair:
             return False  # No change detected
         logging.debug('Saving: %s', self.path)
         if not dry_run:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
             # On Windows we checkout files in Linux mode, so we should make
             # sure not to use Windows newlines here.
             self.path.write_text(new_content, encoding='utf-8', newline='\n')

--- a/tools/cr/plaster_test.py
+++ b/tools/cr/plaster_test.py
@@ -26,10 +26,6 @@ class PlasterTest(unittest.TestCase):
         self.fake_chromium_src.setup()
         self.addCleanup(self.fake_chromium_src.cleanup)
 
-        # Override PLASTER_FILES_PATH to use the rewrite path in the fake Brave
-        # repo
-        plaster.PLASTER_FILES_PATH = self.fake_chromium_src.brave / 'rewrite'
-
     def test_original_expected_toml_rules(self):
         """Test applying all .toml files in the test/ folder."""
         test_folder = Path(__file__).parent / 'test/plasters'

--- a/tools/cr/source_rewrite.py
+++ b/tools/cr/source_rewrite.py
@@ -1,0 +1,299 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Shared utilities for rewriting source-file references after a rename.
+
+Used by git_cr_mv and git_cr_follow_renames.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from pathlib import Path
+
+import repository
+
+# File extensions that must be skipped during all search and rewrite operations.
+SEARCH_EXCLUDE_EXTENSIONS: frozenset[str] = frozenset({'.patchinfo'})
+
+# C++ file extensions for include/guard/shadow-include handling.
+CPP_EXTENSIONS: frozenset[str] = frozenset(
+    {'.h', '.hh', '.cc', '.mm', '.m', '.cpp'})
+
+# Extensions whose files may contain #include / #import directives.
+_INCLUDE_EXTENSIONS: frozenset[str] = CPP_EXTENSIONS | frozenset({'.mojom'})
+
+# Extensions whose files may contain // path references in comments.
+_COMMENT_EXTENSIONS: frozenset[str] = CPP_EXTENSIONS | frozenset(
+    {'.gni', '.gn'})
+
+# Walk filter rules, relative to the brave-core root.
+# Each entry is '+' (include) or '-' (exclude) followed by a path.
+# Bare-name patterns (no '/') match any directory component at any depth.
+# Path patterns match from the brave-core root as a prefix.
+# Longer (more specific) patterns take precedence over shorter ones.
+SEARCH_EXCLUDE_DIRS: tuple[str, ...] = (
+    '-__pycache__',
+    '-.git',
+    '-node_modules',
+    '-out',
+    '-third_party',
+    '+third_party/blink',
+    '+third_party/devtools-frontend',
+    '-tools/crates/vendor',
+    '-vendor',
+)
+
+# Pre-parsed: (include: bool, pattern: str) sorted longest-first for matching.
+_EXCLUDE_RULES: list[tuple[bool, str]] = sorted(
+    [(e[0] == '+', e[1:].rstrip('/')) for e in SEARCH_EXCLUDE_DIRS],
+    key=lambda r: -len(r[1]),
+)
+
+
+def _is_path_excluded(rel_posix: str) -> bool:
+    """Returns True if this brave-core-relative path is excluded by rules."""
+    for include, pattern in _EXCLUDE_RULES:
+        if '/' in pattern:
+            matched = rel_posix == pattern or rel_posix.startswith(pattern +
+                                                                   '/')
+        else:
+            matched = pattern in rel_posix.split('/')
+        if matched:
+            return not include
+    return False
+
+
+def _should_walk_dir(rel_posix: str) -> bool:
+    """Returns True if os.walk should descend into this directory.
+
+    Even if rel_posix is itself excluded, we must still walk it when a more
+    specific '+' rule applies to a sub-path inside it (e.g. '+third_party/blink'
+    requires walking into 'third_party').
+    """
+    if not _is_path_excluded(rel_posix):
+        return True
+    prefix = rel_posix + '/'
+    return any(include and pattern.startswith(prefix)
+               for include, pattern in _EXCLUDE_RULES if '/' in pattern)
+
+
+def compute_guard(src_relative_path: Path | str) -> str:
+    """Derives the #ifndef guard token from a path relative to src/.
+
+    E.g. "brave/chromium_src/crypto/aead.h"
+         -> "BRAVE_CHROMIUM_SRC_CRYPTO_AEAD_H_"
+    """
+    filename = Path(src_relative_path).as_posix()
+    guard = filename.upper() + '_'
+    for char in '/\\.+':
+        guard = guard.replace(char, '_')
+    return guard
+
+
+def find_guard(content: str) -> str | None:
+    """Returns the include guard token if a #ifndef/#define pair is found."""
+    m = re.search(r'^#ifndef\s+(\w+)\s*\n#define\s+\1\b', content,
+                  re.MULTILINE)
+    return m.group(1) if m else None
+
+
+def rewrite_guard_in_file(path: Path, old_guard: str, new_guard: str) -> None:
+    """Replaces every occurrence of old_guard with new_guard in path.
+
+    Logs a warning (does not raise) if the replacement count is not 3.
+    """
+    content = path.read_text(encoding='utf-8')
+    new_content = content.replace(old_guard, new_guard)
+    count = new_content.count(new_guard)
+    if count != 3:
+        logging.warning(
+            '%s: guard rewrite produced %d occurrence(s) of %s (expected 3); '
+            'inspect manually.', path, count, new_guard)
+    path.write_text(new_content, encoding='utf-8', newline='\n')
+
+
+def insert_guard(path: Path, new_guard: str) -> None:
+    """Inserts a complete #ifndef/#define/#endif guard block into path.
+
+    The opening lines are prepended before the first non-comment, non-blank
+    line; the closing #endif is appended at the end of the file.
+    """
+    lines = path.read_text(encoding='utf-8').splitlines(keepends=True)
+
+    insert_idx = len(lines)
+    in_block = False
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if in_block:
+            if '*/' in stripped:
+                in_block = False
+        elif not stripped or stripped.startswith('//'):
+            pass
+        elif stripped.startswith('/*'):
+            in_block = True
+        else:
+            insert_idx = i
+            break
+
+    new_lines = (lines[:insert_idx] + [
+        f'#ifndef {new_guard}\n',
+        f'#define {new_guard}\n',
+        '\n',
+    ] + lines[insert_idx:] + [
+        '\n',
+        f'#endif  // {new_guard}\n',
+    ])
+    path.write_text(''.join(new_lines), encoding='utf-8', newline='\n')
+
+
+def update_shadow_include(path: Path, old_chromium_path: Path,
+                          new_chromium_path: Path) -> None:
+    """Updates the upstream angle-bracket include inside a chromium_src/ file.
+
+    Replaces '#include <old_chromium_path>' with '#include <new_chromium_path>'.
+    No-op if the include is absent. Callers are responsible for verifying the
+    file extension is a C++ type before calling.
+    """
+    old_include = f'#include <{old_chromium_path.as_posix()}>'
+    content = path.read_text(encoding='utf-8')
+    if old_include not in content:
+        return
+    path.write_text(content.replace(
+        old_include, f'#include <{new_chromium_path.as_posix()}>'),
+                    encoding='utf-8',
+                    newline='\n')
+
+
+def update_references(old_path: Path, new_path: Path) -> None:
+    """Rewrites all references to old_path across the brave-core tree.
+
+    Handles:
+    - #include / #import directives (quoted and angle-bracket) in C++/.mojom
+    - // comment lines in C++ and build files
+    - BUILD.gn / .gni source-list entries in the ancestor chain of the old file
+    - For moved .mojom files: derived generated-header paths
+
+    Skips directories in SEARCH_EXCLUDE_DIRS and files in
+    SEARCH_EXCLUDE_EXTENSIONS.
+    """
+    old_posix = old_path.as_posix()
+    new_posix = new_path.as_posix()
+
+    include_re = re.compile(r'(#?(?:include|import)\s*[\"<])' +
+                            re.escape(old_posix) + r'([>\"])')
+    include_sub = r'\g<1>' + new_posix + r'\g<2>'
+
+    # For .mojom files, also rewrite derived generated-header paths.
+    mojom_rewrites: list[tuple[re.Pattern[str], str]] = []
+    if old_posix.endswith('.mojom'):
+        old_base = old_posix[:-len('.mojom')]
+        new_base = new_posix[:-len('.mojom')]
+        for suffix in ('.mojom.h', '.mojom-blink.h', '.mojom-shared.h',
+                       '.mojom-forward.h'):
+            pat = re.compile(r'(#?(?:include|import)\s*[\"<])' +
+                             re.escape(old_base + suffix) + r'([>\"])')
+            mojom_rewrites.append(
+                (pat, r'\g<1>' + new_base + suffix + r'\g<2>'))
+
+    for dirpath, dirnames, filenames in os.walk(repository.BRAVE_CORE_PATH):
+        rel_dir = Path(dirpath).relative_to(
+            repository.BRAVE_CORE_PATH).as_posix()
+        dirnames[:] = [
+            d for d in dirnames
+            if _should_walk_dir(d if rel_dir == '.' else f'{rel_dir}/{d}')
+        ]
+        if rel_dir != '.' and _is_path_excluded(rel_dir):
+            continue
+        for fname in filenames:
+            fpath = Path(dirpath) / fname
+            if fpath.suffix in SEARCH_EXCLUDE_EXTENSIONS:
+                continue
+
+            ext = fpath.suffix.lower()
+            do_includes = ext in _INCLUDE_EXTENSIONS
+            do_comments = ext in _COMMENT_EXTENSIONS
+            if not (do_includes or do_comments):
+                continue
+
+            content = fpath.read_text(encoding='utf-8')
+            new_content = content
+
+            if do_includes:
+                new_content = include_re.sub(include_sub, new_content)
+                for pat, sub in mojom_rewrites:
+                    new_content = pat.sub(sub, new_content)
+
+            if do_comments:
+                lines = new_content.splitlines(keepends=True)
+                new_lines = [
+                    line.replace(old_posix, new_posix)
+                    if line.lstrip().startswith('//') and old_posix in line
+                    else line for line in lines
+                ]
+                new_content = ''.join(new_lines)
+
+            if new_content != content:
+                fpath.write_text(new_content, encoding='utf-8', newline='\n')
+
+    # Update BUILD.gn / .gni source-list entries in the ancestor chain.
+    old_abs = repository.CHROMIUM_SRC_PATH / old_posix
+    if not old_abs.is_relative_to(repository.BRAVE_CORE_PATH):
+        return
+    new_abs = repository.CHROMIUM_SRC_PATH / new_posix
+    _update_build_ancestors(old_abs, new_abs, repository.BRAVE_CORE_PATH)
+
+
+def patch_name_for(chromium_path: Path | str) -> str:
+    """Converts a Chromium-relative path to the corresponding patch filename.
+
+    E.g. "components/sync_device_info/device_info.h"
+         -> "components-sync_device_info-device_info.h.patch"
+    """
+    return Path(chromium_path).as_posix().replace('/', '-') + '.patch'
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _update_build_ancestors(old_abs: Path, new_abs: Path,
+                            brave_root: Path) -> None:
+    """Updates BUILD.gn/.gni entries in the ancestor dirs of old_abs."""
+    cur = old_abs.parent
+    while True:
+        if cur.exists():
+            for build_file in cur.iterdir():
+                if not build_file.is_file():
+                    continue
+                name = build_file.name
+                ext = build_file.suffix
+                if name not in ('BUILD.gn', ) and ext not in ('.gni', '.gyp',
+                                                              '.gypi'):
+                    continue
+                _update_build_entries(build_file, cur, old_abs, new_abs)
+        if cur == brave_root:
+            break
+        parent = cur.parent
+        if not (parent == brave_root or parent.is_relative_to(brave_root)):
+            break
+        cur = parent
+
+
+def _update_build_entries(build_file: Path, build_dir: Path, old_abs: Path,
+                          new_abs: Path) -> None:
+    """Replaces the source-list entry for old_abs with new_abs in build_file."""
+    rel_old = os.path.relpath(old_abs, build_dir).replace('\\', '/')
+    rel_new = os.path.relpath(new_abs, build_dir).replace('\\', '/')
+    old_str = f'"{rel_old}"'
+    new_str = f'"{rel_new}"'
+    content = build_file.read_text(encoding='utf-8')
+    if old_str not in content:
+        return
+    build_file.write_text(content.replace(old_str, new_str),
+                          encoding='utf-8',
+                          newline='\n')

--- a/tools/cr/source_rewrite_test.py
+++ b/tools/cr/source_rewrite_test.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env vpython3
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Tests for source_rewrite.py — walk-filter rules and update_references."""
+
+import unittest
+from pathlib import Path
+
+from source_rewrite import (
+    _is_path_excluded,
+    _should_walk_dir,
+    update_references,
+)
+from test.fake_chromium_src import FakeChromiumSrc
+
+# ---------------------------------------------------------------------------
+# Unit tests: _is_path_excluded
+# ---------------------------------------------------------------------------
+
+
+class IsPathExcludedTest(unittest.TestCase):
+    """_is_path_excluded applies +/- rules in longest-first order."""
+
+    # --- explicitly excluded paths ---
+
+    def test_top_level_excluded_dir(self):
+        self.assertTrue(_is_path_excluded('third_party'))
+
+    def test_subpath_of_excluded_dir(self):
+        self.assertTrue(_is_path_excluded('third_party/foo'))
+
+    def test_deep_subpath_of_excluded_dir(self):
+        self.assertTrue(_is_path_excluded('third_party/foo/bar.h'))
+
+    def test_out_excluded(self):
+        self.assertTrue(_is_path_excluded('out'))
+
+    def test_out_subpath_excluded(self):
+        self.assertTrue(_is_path_excluded('out/Default'))
+
+    def test_node_modules_excluded(self):
+        self.assertTrue(_is_path_excluded('node_modules'))
+
+    def test_vendor_excluded(self):
+        self.assertTrue(_is_path_excluded('vendor'))
+
+    def test_tools_crates_vendor_excluded(self):
+        self.assertTrue(_is_path_excluded('tools/crates/vendor'))
+
+    # --- bare-name patterns match any depth ---
+
+    def test_bare_pycache_at_root(self):
+        self.assertTrue(_is_path_excluded('__pycache__'))
+
+    def test_bare_pycache_nested(self):
+        self.assertTrue(_is_path_excluded('foo/__pycache__'))
+
+    def test_bare_pycache_deep(self):
+        self.assertTrue(_is_path_excluded('foo/__pycache__/bar'))
+
+    def test_bare_git_nested(self):
+        self.assertTrue(_is_path_excluded('some/path/.git'))
+
+    # --- '+' override: third_party/blink is explicitly included ---
+
+    def test_blink_not_excluded(self):
+        self.assertFalse(_is_path_excluded('third_party/blink'))
+
+    def test_blink_subpath_not_excluded(self):
+        self.assertFalse(_is_path_excluded('third_party/blink/renderer'))
+
+    def test_blink_deep_not_excluded(self):
+        self.assertFalse(_is_path_excluded('third_party/blink/renderer/core'))
+
+    def test_devtools_frontend_not_excluded(self):
+        self.assertFalse(_is_path_excluded('third_party/devtools-frontend'))
+
+    def test_devtools_frontend_subpath_not_excluded(self):
+        self.assertFalse(
+            _is_path_excluded('third_party/devtools-frontend/src'))
+
+    # --- normal paths: not excluded ---
+
+    def test_normal_path_not_excluded(self):
+        self.assertFalse(_is_path_excluded('browser'))
+
+    def test_normal_subpath_not_excluded(self):
+        self.assertFalse(_is_path_excluded('browser/core/foo.cc'))
+
+    def test_tools_not_excluded(self):
+        self.assertFalse(_is_path_excluded('tools'))
+
+    def test_tools_crates_not_excluded(self):
+        # Only tools/crates/vendor is excluded, not tools/crates itself.
+        self.assertFalse(_is_path_excluded('tools/crates'))
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _should_walk_dir
+# ---------------------------------------------------------------------------
+
+
+class ShouldWalkDirTest(unittest.TestCase):
+    """_should_walk_dir returns True iff os.walk should descend into the dir."""
+
+    def test_normal_dir_walked(self):
+        self.assertTrue(_should_walk_dir('browser'))
+
+    def test_out_not_walked(self):
+        self.assertFalse(_should_walk_dir('out'))
+
+    def test_node_modules_not_walked(self):
+        self.assertFalse(_should_walk_dir('node_modules'))
+
+    def test_vendor_not_walked(self):
+        self.assertFalse(_should_walk_dir('vendor'))
+
+    def test_pycache_not_walked(self):
+        self.assertFalse(_should_walk_dir('__pycache__'))
+
+    def test_tools_crates_vendor_not_walked(self):
+        self.assertFalse(_should_walk_dir('tools/crates/vendor'))
+
+    def test_third_party_walked_for_blink(self):
+        # third_party is excluded, but +third_party/blink requires descending.
+        self.assertTrue(_should_walk_dir('third_party'))
+
+    def test_third_party_foo_not_walked(self):
+        # No '+' rule inside third_party/foo.
+        self.assertFalse(_should_walk_dir('third_party/foo'))
+
+    def test_third_party_blink_walked(self):
+        self.assertTrue(_should_walk_dir('third_party/blink'))
+
+    def test_third_party_blink_subdir_walked(self):
+        self.assertTrue(_should_walk_dir('third_party/blink/renderer'))
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: update_references respects the walk filter
+# ---------------------------------------------------------------------------
+
+
+class UpdateReferencesFilterTest(unittest.TestCase):
+    """update_references skips excluded dirs and processes included ones."""
+
+    def setUp(self):
+        self._repo = FakeChromiumSrc()
+        self._repo.setup()
+        self.addCleanup(self._repo.cleanup)
+
+    def _write(self, rel: str, content: str) -> Path:
+        path = self._repo.brave / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding='utf-8')
+        return path
+
+    def _read(self, rel: str) -> str:
+        return (self._repo.brave / rel).read_text(encoding='utf-8')
+
+    def test_normal_file_updated(self):
+        """A file outside excluded dirs has its #include updated."""
+        self._write('browser/test.cc', '#include "A/foo.h"\n')
+        update_references(Path('A/foo.h'), Path('B/foo.h'))
+        self.assertIn('#include "B/foo.h"', self._read('browser/test.cc'))
+
+    def test_third_party_file_not_updated(self):
+        """A file inside third_party (non-blink) is skipped."""
+        self._write('third_party/foo/test.cc', '#include "A/foo.h"\n')
+        update_references(Path('A/foo.h'), Path('B/foo.h'))
+        self.assertIn('#include "A/foo.h"',
+                      self._read('third_party/foo/test.cc'))
+
+    def test_blink_file_updated(self):
+        """A file inside third_party/blink IS updated (+blink override)."""
+        self._write('third_party/blink/renderer/test.cc',
+                    '#include "A/foo.h"\n')
+        update_references(Path('A/foo.h'), Path('B/foo.h'))
+        self.assertIn('#include "B/foo.h"',
+                      self._read('third_party/blink/renderer/test.cc'))
+
+    def test_out_file_not_updated(self):
+        """A file inside out/ is skipped."""
+        self._write('out/Default/gen/test.cc', '#include "A/foo.h"\n')
+        update_references(Path('A/foo.h'), Path('B/foo.h'))
+        self.assertIn('#include "A/foo.h"',
+                      self._read('out/Default/gen/test.cc'))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/cr/test/fake_chromium_src.py
+++ b/tools/cr/test/fake_chromium_src.py
@@ -3,11 +3,11 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
-from pathlib import PurePath
 import os
 from unittest.mock import patch
 from test.fake_chromium_repo import FakeChromiumRepo
 
+import plaster as plaster_module
 import repository
 
 
@@ -16,30 +16,32 @@ class FakeChromiumSrc(FakeChromiumRepo):
 
     def __init__(self):
         super().__init__()
-        self.brave_patch = patch('repository.BRAVE_CORE_PATH',
-                                 PurePath(self.brave))
+        self.brave_patch = patch('repository.BRAVE_CORE_PATH', self.brave)
         self.chromium_patch = patch('repository.CHROMIUM_SRC_PATH',
-                                    PurePath(self.chromium))
+                                    self.chromium)
         self.repository_chromium_patch = patch(
-            'repository.chromium',
-            repository.Repository(PurePath(
-                self.chromium)))  # Patch repository.chromium globally
-        self.repository_brave_patch = patch(
-            'repository.brave', repository.Repository(PurePath(
-                self.brave)))  # Patch repository.brave globally
+            'repository.chromium', repository.Repository(self.chromium))
+        self.repository_brave_patch = patch('repository.brave',
+                                            repository.Repository(self.brave))
+        self.plaster_files_path_patch = patch.object(plaster_module,
+                                                     'PLASTER_FILES_PATH',
+                                                     self.brave / 'rewrite')
         self.original_cwd = None
 
     def setup(self):
         """Set up the fake repo and apply patches."""
         self.brave_patch.start()
         self.chromium_patch.start()
-        # Start the global patch for chromium
         self.repository_chromium_patch.start()
-        self.repository_brave_patch.start()  # Start the global patch for brave
+        self.repository_brave_patch.start()
+        self.plaster_files_path_patch.start()
 
         # Re-initialize the global instances in the repository module
-        repository.chromium = repository.Repository(PurePath(self.chromium))
-        repository.brave = repository.Repository(PurePath(self.brave))
+        repository.chromium = repository.Repository(self.chromium)
+        repository.brave = repository.Repository(self.brave)
+
+        (self.brave / 'chromium_src').mkdir(exist_ok=True)
+        (self.brave / 'rewrite').mkdir(exist_ok=True)
 
         # Change the current working directory to the fake Chromium repo
         self.original_cwd = os.getcwd()
@@ -49,9 +51,9 @@ class FakeChromiumSrc(FakeChromiumRepo):
         """Clean up the fake repo, patches, and restore the working directory"""
         self.brave_patch.stop()
         self.chromium_patch.stop()
-        # Stop the global patch for chromium
         self.repository_chromium_patch.stop()
-        self.repository_brave_patch.stop()  # Stop the global patch for brave
+        self.repository_brave_patch.stop()
+        self.plaster_files_path_patch.stop()
         if self.original_cwd:
             os.chdir(self.original_cwd)
         super().cleanup()

--- a/tools/cr/user_validation_error.py
+++ b/tools/cr/user_validation_error.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+
+class UserValidationError(Exception):
+    """Raised for user-facing validation failures.
+
+    The message is printed to stderr as-is by the top-level handler.
+    Raising this instead of printing-and-returning keeps command functions
+    free of error-reporting boilerplate.
+    """


### PR DESCRIPTION
These are helpers for the rebase process, in particular involve file
renames. These helpers are supposed to be intuitive on their use. These
commands do something similar, and there's overlap between them, but
they are for different purposes.

What happens when you use `git cr mv`:

 * Move source to destination
 * Correct shadowed file inclusion for `chromium_src`
 * Corrects header guards for the new path
 * Corrects all references elsewhere for that file inclusion
 * Deletes stale patches if moving plasters.

What happens when you use `git cr follow-renames`:

Follow renames has a narrow purpose of taking git changes, checking
which files got renamed, and moving only those particular files to a new
location. It will do nearly everything else identical to `git cr mv`.

Resolves https://github.com/brave/brave-browser/issues/55189
