### PR TITLE
[brockit] Support for `git apply` for renamed patches

### DIFF
--- a/tools/cr/brockit.py
+++ b/tools/cr/brockit.py
@@ -972,10 +972,6 @@ class Upgrade(Versioned):
         When running brockit in a vscode terminal, this method will open any
         files that need attention in the editor session.
         """
-        # This is a flat list of patches that cannot be applied due to their
-        # source file being deleted.
-        patches_to_deleted_files: list[Patchfile] = []
-
         # A list of files that require manual conflict resolution before
         # continuing.
         files_with_conflicts: list[Path] = []
@@ -996,69 +992,79 @@ class Upgrade(Versioned):
                     for patchfile in patch_list
                 ]))
 
+        # Patches that cannot be applied because their source was removed,
+        # grouped by the commit hash that caused the removal, so we can print
+        # them together.
+        deletion_report: dict[str, dict[Patchfile, Patchfile.ApplyResult]] = {}
+
         vscode_files: list[Path] = []
         for repo, patches in patch_files.items():
             for patchfile in patches:
-                status: Patchfile.ApplyStatus = patchfile.apply()
+                result: Patchfile.ApplyResult = patchfile.apply()
 
-                if status == Patchfile.ApplyStatus.CONFLICT:
+                if result.apply_status == Patchfile.ApplyStatus.CONFLICT:
                     files_with_conflicts.append(patchfile.source_from_brave())
-                elif status == Patchfile.ApplyStatus.BROKEN:
+                elif result.apply_status == Patchfile.ApplyStatus.BROKEN:
                     broken_patches.append(patchfile)
-                elif status == Patchfile.ApplyStatus.DELETED:
-                    patches_to_deleted_files.append(patchfile)
+                elif result.apply_status == Patchfile.ApplyStatus.DELETED:
+                    if (result.rename_apply_status ==
+                            Patchfile.ApplyStatus.CONFLICT):
+                        files_with_conflicts.append(
+                            patchfile.repository.from_brave() /
+                            result.source_status.renamed_to)
+                    deletion_report.setdefault(
+                        result.source_status.commit_hash,
+                        {})[patchfile] = result
 
         for repo, patches in patch_files.items():
             # Resetting any staged states from apply patches as that can cause
             # issues when generating patches.
             repo.unstage_all_changes()
 
-        if patches_to_deleted_files:
+        if deletion_report:
             # The goal in this this section is print a report for listing every
             # patch that cannot apply anymore because the source file is gone,
             # fetching from git the commit and the reason why exactly the file
             # is not there anymore (e.g. renamed, deleted).
 
-            terminal.log_task('[bold]Files that cannot be patched anymore '
-                              f'{ACTION_NEEDED_DECORATOR}:[/]')
+            terminal.log_task('[bold]Deleted and renamed source '
+                              f'files {ACTION_NEEDED_DECORATOR}:[/]')
 
-            # This set will hold the information about the deleted patches
-            # in a way that they can be grouped around the chang that caused
-            # their removal.
-            deletion_report: dict[str, dict[Patchfile,
-                                            Patchfile.SourceStatus]] = {}
-
-            for patchfile in patches_to_deleted_files:
-                # Finding the culptrit commit hash.
-                commit = patchfile.get_last_commit_for_source()
-                deletion_report.setdefault(
-                    commit,
-                    {})[patchfile] = patchfile.get_source_removal_status(
-                        commit)
-
-            for commit, patches in deletion_report.items():
-                for patchfile, status in patches.items():
-                    if status.status == 'D':
+            for _commit_hash, patches in deletion_report.items():
+                for patchfile, result in patches.items():
+                    status = result.source_status
+                    if status.status_code == 'D':
                         console.log(
                             Padding(
                                 f'✘ {patchfile.source} [red bold](deleted)',
                                 (0, 4)))
                         vscode_files.append(patchfile.path)
-                    elif status.status == 'R':
+                    elif status.status_code == 'R':
                         renamed_to = Path(patchfile.repository.from_brave() /
                                           status.renamed_to)
+                        rename_apply_status = result.rename_apply_status
+                        if (rename_apply_status ==
+                                Patchfile.ApplyStatus.CONFLICT):
+                            apply_indicator = ' [yellow bold](has conflicts)[/]'
+                        elif (rename_apply_status ==
+                              Patchfile.ApplyStatus.BROKEN):
+                            apply_indicator = ' [red bold](failed to apply)[/]'
+                            vscode_files += [renamed_to, patchfile.path]
+                        else:
+                            apply_indicator = ' [green bold](applies cleanly)[/]'
                         console.log(
                             Padding(
                                 f'✘ {patchfile.source_from_brave()}\n    '
-                                f'([yellow bold]renamed to[/] {renamed_to})',
-                                (0, 4)))
-                        vscode_files += [patchfile.path, renamed_to]
+                                f'([yellow bold]renamed to[/] {renamed_to})'
+                                f'{apply_indicator}', (0, 4)))
 
-            # Printing the commmit message for the grouped changes.
-            console.log(
-                Padding(f'{next(iter(patches.items()))[1].commit_details}\n',
-                        (0, 8),
-                        style="dim"))
+                # Printing the commit message for the grouped changes. Nex here
+                # picks up on the first entry, as they all have the same
+                # culprit.
+                commit_details = (next(iter(
+                    patches.values())).source_status.commit_details)
+                console.log(Padding(f'{commit_details}\n', (0, 8),
+                                    style="dim"))
 
         if broken_patches:
             terminal.log_task(
@@ -1083,7 +1089,10 @@ class Upgrade(Versioned):
         # the process has to be continued later.
         apply_record = ApplyPatchesRecord(
             patch_files=patch_files,
-            patches_to_deleted_files=patches_to_deleted_files,
+            patches_to_deleted_files=[
+                patchfile for patches in deletion_report.values()
+                for patchfile in patches
+            ],
             files_with_conflicts=files_with_conflicts,
             broken_patches=broken_patches)
 

--- a/tools/cr/patchfile.py
+++ b/tools/cr/patchfile.py
@@ -76,13 +76,33 @@ class Patchfile:
         """
 
         # A code for the status of the source file. (e.g 'R', 'M', 'D')
-        status: str
+        status_code: str
+
+        # The commit hash where this source file status was recorded.
+        commit_hash: str
 
         # The commit details for this source file status.
         commit_details: str
 
         # The name the source may have been renamed to.
         renamed_to: Optional[str] = None
+
+    @dataclass(frozen=True)
+    class ApplyResult:
+        """The result of applying a patch file.
+        """
+
+        # The status of the patch application.
+        apply_status: 'Patchfile.ApplyStatus'
+
+        # The status of the source file, populated only when the patch cannot
+        # be applied because the source file is missing.
+        source_status: Optional['Patchfile.SourceStatus'] = None
+
+        # The result of re-applying the patch against a renamed source,
+        # populated only when the source was renamed. CLEAN means the patch
+        # applied successfully at the new location; BROKEN means it did not.
+        rename_apply_status: Optional['Patchfile.ApplyStatus'] = None
 
     def source_name_from_patch_naming(self) -> str:
         """Source file name according to the patch file name.
@@ -107,17 +127,17 @@ class Patchfile:
         """
         return self.repository.to_brave() / self.path
 
-    def apply(self) -> ApplyStatus:
+    def apply(self) -> ApplyResult:
         """Applies the patch file with `git apply --3way`.
         """
         try:
             self.repository.run_git('apply', '--3way', '--ignore-space-change',
                                     '--ignore-whitespace',
                                     self.path_from_repo().as_posix())
-            return self.ApplyStatus.CLEAN
+            return self.ApplyResult(apply_status=self.ApplyStatus.CLEAN)
         except subprocess.CalledProcessError as e:
             if 'with conflicts' in e.stderr:
-                return self.ApplyStatus.CONFLICT
+                return self.ApplyResult(apply_status=self.ApplyStatus.CONFLICT)
             error_line = next(
                 (l for l in e.stderr.splitlines() if l.startswith('error:')),
                 None)
@@ -125,17 +145,52 @@ class Patchfile:
                 [_, reason] = error_line.strip().split(': ', 1)
 
                 if 'does not exist in index' in reason:
-                    # This type of detection could occur in certain cases when
-                    # `npm run init` or `sync` were not run for the working
-                    # branch. It may be useful to warn.
+                    # This block handles patches that do not apply anymore
+                    # because the source file has been deleted.
                     #
                     # It is also of notice that this error can also occur when
                     # `apply` is run twice for the same patch with conflicts.
-                    logging.warning(
-                        'Patch with missing file detected during --3way apply,'
-                        ' which may indicate a bad sync state before starting '
-                        'to upgrade. %s', self.path)
-                    return self.ApplyStatus.DELETED
+                    source_status = self.get_source_removal_status(
+                        self.get_last_commit_for_source())
+
+                    rename_apply_status = None
+                    if source_status.status_code == 'R':
+                        # The source was renamed — try re-applying with the
+                        # new path substituted in to see if the patch still
+                        # applies cleanly at the renamed location.
+                        patch_content = Path(
+                            repository.BRAVE_CORE_PATH /
+                            self.path).read_text(encoding='utf-8')
+                        # The path substitution is a bit hacky, but we assume
+                        # that there are only 4 occurrences of the source name
+                        # in the patch file. Throwing if that's not the case.
+                        if patch_content.count(self.source.as_posix()) != 4:
+                            raise NotImplementedError(
+                                f'Unexpected patch format with more than 4 '
+                                f'occurrences of the source path: {self.path}'
+                            ) from None
+                        try:
+                            self.repository.run_git(
+                                'apply',
+                                '--3way',
+                                '--ignore-space-change',
+                                '--ignore-whitespace',
+                                stdin=patch_content.replace(
+                                    self.source.as_posix(),
+                                    source_status.renamed_to))
+                            rename_apply_status = self.ApplyStatus.CLEAN
+                        except subprocess.CalledProcessError as rename_e:
+                            rename_apply_status = (self.ApplyStatus.CONFLICT
+                                                   if 'with conflicts'
+                                                   in rename_e.stderr else
+                                                   self.ApplyStatus.BROKEN)
+                    # Although reapplying the patch may have been succesful,
+                    # this patch is still considered as DELETED as the user has
+                    # to commit the rename/deletion with a culprit.
+                    return self.ApplyResult(
+                        apply_status=self.ApplyStatus.DELETED,
+                        source_status=source_status,
+                        rename_apply_status=rename_apply_status)
                 if ('No such file or directory' in reason
                         and self.path.as_posix() in reason):
                     # This should never occur as it indicates that the patch
@@ -153,7 +208,7 @@ class Patchfile:
                         'Patch being flagged as broken, but with unexpected '
                         'reason: %s %s', self.path, reason)
 
-                return self.ApplyStatus.BROKEN
+                return self.ApplyResult(apply_status=self.ApplyStatus.BROKEN)
 
         # We should not reach this point. Failures to apply that fail like this
         # must be investigated with `--verbose`, and fixed.
@@ -215,12 +270,14 @@ class Patchfile:
         status_code = status_line[0]
 
         if status_code == 'D':
-            return self.SourceStatus(status=status_code,
+            return self.SourceStatus(status_code=status_code,
+                                     commit_hash=commit,
                                      commit_details=commit_details)
         if status_code == 'R':
             # For renames the output looks something like:
             # R100       base/some_file.cc       base/renamed_to_file.cc
-            return self.SourceStatus(status=status_code,
+            return self.SourceStatus(status_code=status_code,
+                                     commit_hash=commit,
                                      commit_details=commit_details,
                                      renamed_to=status_line.split()[-1])
 

--- a/tools/cr/patchfile_test.py
+++ b/tools/cr/patchfile_test.py
@@ -117,8 +117,8 @@ class PatchfileTest(unittest.TestCase):
             path=self.fake_chromium_src.get_patchfile_path_for_source(
                 self.fake_chromium_src.chromium, test_idl),
             source=test_idl)
-        status = patchfile.apply()
-        self.assertEqual(status, Patchfile.ApplyStatus.CONFLICT)
+        result = patchfile.apply()
+        self.assertEqual(result.apply_status, Patchfile.ApplyStatus.CONFLICT)
 
     def test_apply_conflict_with_whitespace_error(self):
         """Tests the behavior when applying a patch with whitespace errors."""
@@ -179,8 +179,8 @@ class PatchfileTest(unittest.TestCase):
             path=self.fake_chromium_src.get_patchfile_path_for_source(
                 self.fake_chromium_src.chromium, test_idl),
             source=test_idl)
-        status = patchfile.apply()
-        self.assertEqual(status, Patchfile.ApplyStatus.CONFLICT)
+        result = patchfile.apply()
+        self.assertEqual(result.apply_status, Patchfile.ApplyStatus.CONFLICT)
 
     def test_apply_clean(self):
         test_idl = Path('chrome/common/extensions/api/developer_private.idl')
@@ -255,8 +255,8 @@ class PatchfileTest(unittest.TestCase):
             path=self.fake_chromium_src.get_patchfile_path_for_source(
                 self.fake_chromium_src.chromium, test_idl),
             source=test_idl)
-        status = patchfile.apply()
-        self.assertEqual(status, Patchfile.ApplyStatus.CLEAN)
+        result = patchfile.apply()
+        self.assertEqual(result.apply_status, Patchfile.ApplyStatus.CLEAN)
         self.assertIn('FROM_BRAVE_STORE', target_file.read_text())
 
     def test_apply_broken(self):
@@ -281,8 +281,8 @@ class PatchfileTest(unittest.TestCase):
             path=self.fake_chromium_src.get_patchfile_path_for_source(
                 self.fake_chromium_src.chromium, test_idl),
             source=test_idl)
-        status = patchfile.apply()
-        self.assertEqual(status, Patchfile.ApplyStatus.CLEAN)
+        result = patchfile.apply()
+        self.assertEqual(result.apply_status, Patchfile.ApplyStatus.CLEAN)
         self.assertIn('last line', target_file.read_text())
 
         self.fake_chromium_src._run_git_command(
@@ -299,8 +299,8 @@ class PatchfileTest(unittest.TestCase):
             path=self.fake_chromium_src.get_patchfile_path_for_source(
                 self.fake_chromium_src.chromium, test_idl),
             source=test_idl)
-        status = patchfile.apply()
-        self.assertEqual(status, Patchfile.ApplyStatus.BROKEN)
+        result = patchfile.apply()
+        self.assertEqual(result.apply_status, Patchfile.ApplyStatus.BROKEN)
 
     def test_apply_on_deleted(self):
         '''Tests the behavior when applying a patch to a deleted file.'''
@@ -324,8 +324,8 @@ class PatchfileTest(unittest.TestCase):
             path=self.fake_chromium_src.get_patchfile_path_for_source(
                 self.fake_chromium_src.chromium, test_idl),
             source=test_idl)
-        status = patchfile.apply()
-        self.assertEqual(status, Patchfile.ApplyStatus.CLEAN)
+        result = patchfile.apply()
+        self.assertEqual(result.apply_status, Patchfile.ApplyStatus.CLEAN)
         self.assertIn('last line', target_file.read_text())
 
         self.fake_chromium_src._run_git_command(
@@ -342,8 +342,9 @@ class PatchfileTest(unittest.TestCase):
             path=self.fake_chromium_src.get_patchfile_path_for_source(
                 self.fake_chromium_src.chromium, test_idl),
             source=test_idl)
-        status = patchfile.apply()
-        self.assertEqual(status, Patchfile.ApplyStatus.DELETED)
+        result = patchfile.apply()
+        self.assertEqual(result.apply_status, Patchfile.ApplyStatus.DELETED)
+        self.assertIsNone(result.rename_apply_status)
 
     def test_apply_on_deleted_with_whitespace_error(self):
         '''Tests DELETED status when stderr has whitespace warnings before the
@@ -371,8 +372,8 @@ class PatchfileTest(unittest.TestCase):
             path=self.fake_chromium_src.get_patchfile_path_for_source(
                 self.fake_chromium_src.chromium, test_idl),
             source=test_idl)
-        status = patchfile.apply()
-        self.assertEqual(status, Patchfile.ApplyStatus.CLEAN)
+        result = patchfile.apply()
+        self.assertEqual(result.apply_status, Patchfile.ApplyStatus.CLEAN)
         self.assertIn('last line', target_file.read_text())
 
         self.fake_chromium_src._run_git_command(
@@ -389,8 +390,85 @@ class PatchfileTest(unittest.TestCase):
             path=self.fake_chromium_src.get_patchfile_path_for_source(
                 self.fake_chromium_src.chromium, test_idl),
             source=test_idl)
-        status = patchfile.apply()
-        self.assertEqual(status, Patchfile.ApplyStatus.DELETED)
+        result = patchfile.apply()
+        self.assertEqual(result.apply_status, Patchfile.ApplyStatus.DELETED)
+        self.assertIsNone(result.rename_apply_status)
+
+    def _setup_patch_for_rename_tests(self):
+        """Shared setup: creates a patched file ready for rename scenarios.
+
+        Returns (test_idl, renamed_idl, patchfile_path) after:
+          - committing the original file,
+          - making a brave patch that adds 'NEW_TYPE' after 'HOSTED_APP',
+          - resetting the working tree to a clean state.
+        """
+        test_idl = Path('chrome/common/extensions/api/developer_private.idl')
+        renamed_idl = Path('chrome/common/extensions/api/renamed_private.idl')
+        chromium = self.fake_chromium_src.chromium
+
+        self.fake_chromium_src.write_and_stage_file(
+            test_idl, 'HOSTED_APP\nPLATFORM_APP\nFROM_STORE\n', chromium)
+        self.fake_chromium_src.commit('Add developer_private.idl', chromium)
+
+        (chromium / test_idl).write_text(
+            (chromium / test_idl).read_text().replace('HOSTED_APP',
+                                                      'HOSTED_APP\nNEW_TYPE'))
+        self.fake_chromium_src.run_update_patches()
+
+        self.fake_chromium_src._run_git_command(['checkout', '.'], chromium)
+        self.assertNotIn('NEW_TYPE', (chromium / test_idl).read_text())
+
+        patchfile_path = self.fake_chromium_src.get_patchfile_path_for_source(
+            chromium, test_idl)
+        return test_idl, renamed_idl, patchfile_path
+
+    def test_apply_on_renamed_clean(self):
+        """Patch applies cleanly to the renamed location."""
+        test_idl, renamed_idl, patchfile_path = (
+            self._setup_patch_for_rename_tests())
+        chromium = self.fake_chromium_src.chromium
+
+        # Rename the file upstream without modifying its content.
+        (chromium / test_idl).rename(chromium / renamed_idl)
+        self.fake_chromium_src._run_git_command(['add', '-A'], chromium)
+        self.fake_chromium_src.commit(
+            'Rename developer_private.idl to renamed_private.idl', chromium)
+
+        result = Patchfile(path=patchfile_path, source=test_idl).apply()
+
+        self.assertEqual(result.apply_status, Patchfile.ApplyStatus.DELETED)
+        self.assertEqual(result.rename_apply_status,
+                         Patchfile.ApplyStatus.CLEAN)
+        self.assertEqual(result.source_status.status_code, 'R')
+        self.assertEqual(result.source_status.renamed_to,
+                         renamed_idl.as_posix())
+        self.assertIn('NEW_TYPE', (chromium / renamed_idl).read_text())
+
+    def test_apply_on_renamed_conflict(self):
+        """Patch conflicts at the renamed location due to an upstream change
+        to the same area."""
+        test_idl, renamed_idl, patchfile_path = (
+            self._setup_patch_for_rename_tests())
+        chromium = self.fake_chromium_src.chromium
+
+        # Rename the file and introduce a conflicting change to the same line
+        # that the brave patch modifies.
+        renamed_path = chromium / renamed_idl
+        renamed_path.parent.mkdir(parents=True, exist_ok=True)
+        renamed_path.write_text(
+            (chromium / test_idl).read_text().replace('HOSTED_APP',
+                                                      'HOSTED_APP\nUPSTREAM'))
+        (chromium / test_idl).unlink()
+        self.fake_chromium_src._run_git_command(['add', '-A'], chromium)
+        self.fake_chromium_src.commit(
+            'Rename and modify developer_private.idl', chromium)
+
+        result = Patchfile(path=patchfile_path, source=test_idl).apply()
+
+        self.assertEqual(result.apply_status, Patchfile.ApplyStatus.DELETED)
+        self.assertEqual(result.rename_apply_status,
+                         Patchfile.ApplyStatus.CONFLICT)
+        self.assertEqual(result.source_status.status_code, 'R')
 
     def test_source_from_brave(self):
         """Tests the source_from_brave method of Patchfile."""
@@ -538,7 +616,9 @@ class PatchfileTest(unittest.TestCase):
         # Verify the source removal status
         removal_status = patchfile.get_source_removal_status(
             delete_commit_hash)
-        self.assertEqual(removal_status.status, 'D')  # 'D' indicates deletion
+        self.assertEqual(removal_status.status_code,
+                         'D')  # 'D' indicates deletion
+        self.assertEqual(removal_status.commit_hash, delete_commit_hash)
         self.assertIn('Delete developer_private.idl',
                       removal_status.commit_details)
         self.assertIsNone(removal_status.renamed_to)
@@ -597,7 +677,9 @@ class PatchfileTest(unittest.TestCase):
 
         # Verify the source rename status
         rename_status = patchfile.get_source_removal_status(rename_commit_hash)
-        self.assertEqual(rename_status.status, 'R')  # 'R' indicates rename
+        self.assertEqual(rename_status.status_code,
+                         'R')  # 'R' indicates rename
+        self.assertEqual(rename_status.commit_hash, rename_commit_hash)
         self.assertIn('Rename developer_private.idl to renamed_private.idl',
                       rename_status.commit_details)
         self.assertEqual(rename_status.renamed_to, renamed_file.as_posix())

--- a/tools/cr/repository.py
+++ b/tools/cr/repository.py
@@ -71,13 +71,17 @@ class Repository:
 
         return Path('..') / self.path.relative_to(CHROMIUM_SRC_PATH)
 
-    def run_git(self, *cmd, no_trim=False) -> str:
+    def run_git(self, *cmd, no_trim=False, stdin: Optional[str] = None) -> str:
         """Runs a git command on the repository.
         """
         if self.is_brave:
-            return terminal.run_git(*cmd, no_trim=no_trim)
+            return terminal.run_git(*cmd, no_trim=no_trim, stdin=stdin)
 
-        return terminal.run_git('-C', self.from_brave(), *cmd, no_trim=no_trim)
+        return terminal.run_git('-C',
+                                self.from_brave(),
+                                *cmd,
+                                no_trim=no_trim,
+                                stdin=stdin)
 
     def unstage_all_changes(self):
         """Unstages all changes in the repository.

--- a/tools/cr/repository_test.py
+++ b/tools/cr/repository_test.py
@@ -100,12 +100,16 @@ class RepositoryTest(unittest.TestCase):
         with patch("terminal.terminal.run_git") as mock_run_git:
             # Call run_git with no_trim=True for brave repository
             repository.brave.run_git("log", no_trim=True)
-            mock_run_git.assert_called_once_with("log", no_trim=True)
+            mock_run_git.assert_called_once_with("log",
+                                                 no_trim=True,
+                                                 stdin=None)
 
             # Reset mock and call run_git with no_trim=False
             mock_run_git.reset_mock()
             repository.brave.run_git("log", no_trim=False)
-            mock_run_git.assert_called_once_with("log", no_trim=False)
+            mock_run_git.assert_called_once_with("log",
+                                                 no_trim=False,
+                                                 stdin=None)
 
     def test_unstage_all_changes(self):
         """Test unstage_all_changes and has_staged_changes."""

--- a/tools/cr/terminal.py
+++ b/tools/cr/terminal.py
@@ -119,7 +119,11 @@ class Terminal:
             status.stop()
             self.status = None
 
-    def run(self, cmd, env: Optional[Dict[str, str]] = None, cwd=None):
+    def run(self,
+            cmd,
+            env: Optional[Dict[str, str]] = None,
+            cwd=None,
+            stdin: Optional[str] = None):
         """Runs a command on the terminal.
         """
         # Convert all arguments to strings, to avoid issues with `PurePath`
@@ -162,7 +166,8 @@ class Terminal:
                                     check=True,
                                     encoding='utf-8',
                                     env=env,
-                                    cwd=cwd)
+                                    cwd=cwd,
+                                    input=stdin)
         except subprocess.CalledProcessError as e:
             logging.debug('❯ %s', e.stderr.strip())
             raise e
@@ -173,7 +178,7 @@ class Terminal:
 
         return result
 
-    def run_git(self, *cmd, no_trim=False) -> str:
+    def run_git(self, *cmd, no_trim=False, stdin: Optional[str] = None) -> str:
         """Runs a git command with the arguments provided.
 
     This function returns a proper utf8 string in success, otherwise it allows
@@ -188,8 +193,8 @@ class Terminal:
     """
         cmd = ['git'] + list(cmd)
         if no_trim:
-            return self.run(cmd).stdout
-        return self.run(cmd).stdout.strip()
+            return self.run(cmd, stdin=stdin).stdout
+        return self.run(cmd, stdin=stdin).stdout.strip()
 
     def log_task(self, message):
         """Logs a task to the console using common decorators


### PR DESCRIPTION
This change adds a modest support to have `git apply --3way` attempted
to patches that have been renamed. The user report has been updated to
provide clues about the result of the attempt, and the routine
differentiates between a applying cleanly, conflicts, and broken
apply, and handles them accordingly.

A second pass on this feature may simplify things by instantiating a
`Patchfile` for the reapply operation.

Resolves https://github.com/brave/brave-browser/issues/55188
