### PR TITLE
[History Embeddings] Replace model-load barrier with state machine

### DIFF
--- a/browser/history_embeddings/brave_passage_embeddings_service.cc
+++ b/browser/history_embeddings/brave_passage_embeddings_service.cc
@@ -7,7 +7,6 @@
 
 #include <utility>
 
-#include "base/barrier_closure.h"
 #include "base/check.h"
 #include "base/containers/flat_map.h"
 #include "base/feature_list.h"
@@ -16,6 +15,7 @@
 #include "base/logging.h"
 #include "base/no_destructor.h"
 #include "base/numerics/safe_math.h"
+#include "base/one_shot_event.h"
 #include "base/task/thread_pool.h"
 #include "components/history_embeddings/core/history_embeddings_features.h"
 #include "content/public/browser/web_contents.h"
@@ -266,10 +266,12 @@ BravePassageEmbeddingsService::BravePassageEmbeddingsService(
       updater_state_(updater_state) {
   CHECK(base::FeatureList::IsEnabled(history_embeddings::kHistoryEmbeddings));
   CHECK(updater_state_);
-  // Arm the barrier FIRST so CountComponentReadyOnce can route through
-  // it. AddObserver's immediate-notify (when install_dir is already
-  // set) will invoke OnLocalModelsReady synchronously; the flag guard
-  // inside CountComponentReadyOnce keeps that from counting twice.
+  // Arm the events FIRST so AddObserver's immediate-notify (when
+  // install_dir is already set) has a live component_ready_event_ to
+  // signal. OneShotEvent::Signal() is idempotent under the
+  // is_signaled() guard, so the sync install_dir check inside
+  // MaybeWaitForLocalModelFilesReady and the observer callback can
+  // both fire without double-counting.
   MaybeWaitForLocalModelFilesReady();
   updater_state_->AddObserver(this);
 }
@@ -359,14 +361,16 @@ void BravePassageEmbeddingsService::RegisterPassageEmbedderFactory(
   factory_.set_disconnect_handler(
       base::BindOnce(&BravePassageEmbeddingsService::OnFactoryDisconnected,
                      weak_ptr_factory_.GetWeakPtr()));
-  if (model_load_barrier_) {
-    model_load_barrier_.Run();
+  if (factory_registered_event_ && !factory_registered_event_->is_signaled()) {
+    factory_registered_event_->Signal();
   }
 }
 
 void BravePassageEmbeddingsService::OnLocalModelsReady(
     const base::FilePath& install_dir) {
-  CountComponentReadyOnce();
+  if (component_ready_event_ && !component_ready_event_->is_signaled()) {
+    component_ready_event_->Signal();
+  }
 }
 
 void BravePassageEmbeddingsService::OnBackgroundContentsDestroyed(
@@ -406,21 +410,30 @@ void BravePassageEmbeddingsService::CloseBackgroundContents() {
 }
 
 void BravePassageEmbeddingsService::MaybeWaitForLocalModelFilesReady() {
-  component_ready_counted_ = false;
-  model_load_barrier_ = base::BarrierClosure(
-      2, base::BindOnce(&BravePassageEmbeddingsService::LoadLocalModelFiles,
-                        weak_ptr_factory_.GetWeakPtr()));
+  component_ready_event_ = std::make_unique<base::OneShotEvent>();
+  factory_registered_event_ = std::make_unique<base::OneShotEvent>();
+  // Chain: once the component is ready, wait for the factory
+  // registration and then load the model files. OneShotEvent::Post
+  // runs the closure asynchronously whether the event is already
+  // signaled or signals later, matching the pre-existing barrier's
+  // fire-once semantics.
+  component_ready_event_->Post(
+      FROM_HERE,
+      base::BindOnce(&BravePassageEmbeddingsService::OnComponentReadyForLoad,
+                     weak_ptr_factory_.GetWeakPtr()));
   if (!updater_state_->GetInstallDir().empty()) {
-    CountComponentReadyOnce();
+    component_ready_event_->Signal();
   }
 }
 
-void BravePassageEmbeddingsService::CountComponentReadyOnce() {
-  if (component_ready_counted_ || !model_load_barrier_) {
+void BravePassageEmbeddingsService::OnComponentReadyForLoad() {
+  if (!factory_registered_event_) {
     return;
   }
-  component_ready_counted_ = true;
-  model_load_barrier_.Run();
+  factory_registered_event_->Post(
+      FROM_HERE,
+      base::BindOnce(&BravePassageEmbeddingsService::LoadLocalModelFiles,
+                     weak_ptr_factory_.GetWeakPtr()));
 }
 
 void BravePassageEmbeddingsService::LoadLocalModelFiles() {

--- a/browser/history_embeddings/brave_passage_embeddings_service.cc
+++ b/browser/history_embeddings/brave_passage_embeddings_service.cc
@@ -15,7 +15,6 @@
 #include "base/logging.h"
 #include "base/no_destructor.h"
 #include "base/numerics/safe_math.h"
-#include "base/one_shot_event.h"
 #include "base/task/thread_pool.h"
 #include "components/history_embeddings/core/history_embeddings_features.h"
 #include "content/public/browser/web_contents.h"
@@ -266,13 +265,6 @@ BravePassageEmbeddingsService::BravePassageEmbeddingsService(
       updater_state_(updater_state) {
   CHECK(base::FeatureList::IsEnabled(history_embeddings::kHistoryEmbeddings));
   CHECK(updater_state_);
-  // Arm the events FIRST so AddObserver's immediate-notify (when
-  // install_dir is already set) has a live component_ready_event_ to
-  // signal. OneShotEvent::Signal() is idempotent under the
-  // is_signaled() guard, so the sync install_dir check inside
-  // MaybeWaitForLocalModelFilesReady and the observer callback can
-  // both fire without double-counting.
-  MaybeWaitForLocalModelFilesReady();
   updater_state_->AddObserver(this);
 }
 
@@ -325,7 +317,7 @@ void BravePassageEmbeddingsService::BindPassageEmbedder(
   load.callback = std::move(callback);
   pending_loads_.push_back(std::move(load));
 
-  if (model_ready_ && factory_.is_bound()) {
+  if (phase_ == LoadPhase::kReady) {
     FulfillPendingLoads();
   }
 }
@@ -361,16 +353,12 @@ void BravePassageEmbeddingsService::RegisterPassageEmbedderFactory(
   factory_.set_disconnect_handler(
       base::BindOnce(&BravePassageEmbeddingsService::OnFactoryDisconnected,
                      weak_ptr_factory_.GetWeakPtr()));
-  if (factory_registered_event_ && !factory_registered_event_->is_signaled()) {
-    factory_registered_event_->Signal();
-  }
+  MaybeLoadLocalModelFiles();
 }
 
 void BravePassageEmbeddingsService::OnLocalModelsReady(
     const base::FilePath& install_dir) {
-  if (component_ready_event_ && !component_ready_event_->is_signaled()) {
-    component_ready_event_->Signal();
-  }
+  MaybeLoadLocalModelFiles();
 }
 
 void BravePassageEmbeddingsService::OnBackgroundContentsDestroyed(
@@ -402,41 +390,21 @@ void BravePassageEmbeddingsService::CloseBackgroundContents() {
   DVLOG(3) << "CloseBackgroundContents (pending_loads=" << pending_loads_.size()
            << " batch_embedder=" << (batch_embedder_ ? "set" : "null")
            << " factory_bound=" << factory_.is_bound()
-           << " model_ready=" << model_ready_
+           << " phase=" << static_cast<int>(phase_)
            << " bg_contents=" << (background_web_contents_ ? "set" : "null")
            << ")";
   ResetEmbedderState();
   background_web_contents_.reset();
 }
 
-void BravePassageEmbeddingsService::MaybeWaitForLocalModelFilesReady() {
-  component_ready_event_ = std::make_unique<base::OneShotEvent>();
-  factory_registered_event_ = std::make_unique<base::OneShotEvent>();
-  // Chain: once the component is ready, wait for the factory
-  // registration and then load the model files. OneShotEvent::Post
-  // runs the closure asynchronously whether the event is already
-  // signaled or signals later, matching the pre-existing barrier's
-  // fire-once semantics.
-  component_ready_event_->Post(
-      FROM_HERE,
-      base::BindOnce(&BravePassageEmbeddingsService::OnComponentReadyForLoad,
-                     weak_ptr_factory_.GetWeakPtr()));
-  if (!updater_state_->GetInstallDir().empty()) {
-    component_ready_event_->Signal();
-  }
-}
-
-void BravePassageEmbeddingsService::OnComponentReadyForLoad() {
-  if (!factory_registered_event_) {
+void BravePassageEmbeddingsService::MaybeLoadLocalModelFiles() {
+  if (phase_ != LoadPhase::kWaiting) {
     return;
   }
-  factory_registered_event_->Post(
-      FROM_HERE,
-      base::BindOnce(&BravePassageEmbeddingsService::LoadLocalModelFiles,
-                     weak_ptr_factory_.GetWeakPtr()));
-}
-
-void BravePassageEmbeddingsService::LoadLocalModelFiles() {
+  if (updater_state_->GetInstallDir().empty() || !factory_.is_bound()) {
+    return;
+  }
+  phase_ = LoadPhase::kLoading;
   base::FilePath weights_path = updater_state_->GetEmbeddingGemmaModel();
   base::FilePath weights_dense1_path =
       updater_state_->GetEmbeddingGemmaDense1();
@@ -467,6 +435,7 @@ void BravePassageEmbeddingsService::OnLocalModelFilesLoaded(
     OnFactoryInitDone(false);
     return;
   }
+  phase_ = LoadPhase::kInitializing;
   factory_->Init(
       std::move(model_files),
       base::BindOnce(&BravePassageEmbeddingsService::OnFactoryInitDone,
@@ -477,6 +446,7 @@ void BravePassageEmbeddingsService::OnFactoryInitDone(bool success) {
   if (!success) {
     DVLOG(1) << "Factory Init failed, failing " << pending_loads_.size()
              << " pending load(s)";
+    phase_ = LoadPhase::kFailed;
     // CloseBackgroundContents runs FailPendingLoads internally and
     // tears down the rest of the state, matching LocalAIService's
     // old OnPassageEmbedderReady(false) behavior.
@@ -485,12 +455,12 @@ void BravePassageEmbeddingsService::OnFactoryInitDone(bool success) {
   }
   DVLOG(3) << "Factory Init succeeded, fulfilling " << pending_loads_.size()
            << " pending load(s)";
-  model_ready_ = true;
+  phase_ = LoadPhase::kReady;
   FulfillPendingLoads();
 }
 
 void BravePassageEmbeddingsService::FulfillPendingLoads() {
-  if (!model_ready_ || !factory_.is_bound() || pending_loads_.empty()) {
+  if (phase_ != LoadPhase::kReady || pending_loads_.empty()) {
     return;
   }
 
@@ -538,8 +508,7 @@ void BravePassageEmbeddingsService::ResetEmbedderState() {
   batch_embedder_.reset();
   factory_.reset();
   FailPendingLoads();
-  model_ready_ = false;
-  MaybeWaitForLocalModelFilesReady();
+  phase_ = LoadPhase::kWaiting;
 }
 
 void BravePassageEmbeddingsService::OnFactoryDisconnected() {

--- a/browser/history_embeddings/brave_passage_embeddings_service.h
+++ b/browser/history_embeddings/brave_passage_embeddings_service.h
@@ -27,10 +27,6 @@
 #include "mojo/public/cpp/bindings/remote.h"
 #include "services/passage_embeddings/public/mojom/passage_embeddings.mojom.h"
 
-namespace base {
-class OneShotEvent;
-}
-
 namespace content {
 class WebContents;
 }
@@ -195,24 +191,14 @@ class BravePassageEmbeddingsService
   void OnBackgroundContentsCreated(
       std::unique_ptr<local_ai::BackgroundWebContents> contents);
   void CloseBackgroundContents();
-  // Arms a fresh pair of OneShotEvents that chain into
-  // LoadLocalModelFiles once both (1) the EmbeddingGemma component is
-  // installed (OnLocalModelsReady signals component_ready_event_, or
-  // install_dir is already non-empty at arm time) and (2) the
-  // renderer's PassageEmbedderFactory registers via
-  // RegisterPassageEmbedderFactory.
-  void MaybeWaitForLocalModelFilesReady();
-  // Posted on component_ready_event_. Chains through
-  // factory_registered_event_ to LoadLocalModelFiles.
-  void OnComponentReadyForLoad();
-  void LoadLocalModelFiles();
+  void MaybeLoadLocalModelFiles();
   void OnLocalModelFilesLoaded(local_ai::mojom::ModelFilesPtr model_files);
   void OnFactoryInitDone(bool success);
   void FulfillPendingLoads();
   void FailPendingLoads();
   // Drops the renderer-facing embedder state (batch embedder, factory,
-  // pending loads, model-ready flag) and re-arms the load barrier.
-  // Shared by OnFactoryDisconnected and CloseBackgroundContents.
+  // pending loads) and resets the load phase to kWaiting. Shared by
+  // OnFactoryDisconnected and CloseBackgroundContents.
   void ResetEmbedderState();
   void OnFactoryDisconnected();
   void OnBatchEmbedderDisconnected();
@@ -227,17 +213,21 @@ class BravePassageEmbeddingsService
   std::unique_ptr<BraveBatchPassageEmbedder> batch_embedder_;
   std::vector<PendingLoad> pending_loads_;
 
-  // Signaled when the EmbeddingGemma component is installed. When
-  // fired, OnComponentReadyForLoad chains to factory_registered_event_.
-  // Re-armed (new OneShotEvent instance) on each arm cycle by
-  // MaybeWaitForLocalModelFilesReady; Signal() is idempotent via the
-  // is_signaled() guard at each call site.
-  std::unique_ptr<base::OneShotEvent> component_ready_event_;
-  // Signaled when the renderer's PassageEmbedderFactory registers.
-  // LoadLocalModelFiles is posted on this event (after component is
-  // also ready) by OnComponentReadyForLoad.
-  std::unique_ptr<base::OneShotEvent> factory_registered_event_;
-  bool model_ready_ = false;
+  // Load sequence:
+  //   kWaiting       -> need updater_state_->GetInstallDir() non-empty
+  //                     && factory_.is_bound()
+  //   kLoading       -> ThreadPool task reading model files from disk
+  //   kInitializing  -> factory_->Init in flight
+  //   kReady         -> can fulfill pending loads
+  //   kFailed        -> teardown via ResetEmbedderState pending
+  enum class LoadPhase {
+    kWaiting,
+    kLoading,
+    kInitializing,
+    kReady,
+    kFailed,
+  };
+  LoadPhase phase_ = LoadPhase::kWaiting;
 
   base::WeakPtrFactory<BravePassageEmbeddingsService> weak_ptr_factory_{this};
 };

--- a/browser/history_embeddings/brave_passage_embeddings_service.h
+++ b/browser/history_embeddings/brave_passage_embeddings_service.h
@@ -27,6 +27,10 @@
 #include "mojo/public/cpp/bindings/remote.h"
 #include "services/passage_embeddings/public/mojom/passage_embeddings.mojom.h"
 
+namespace base {
+class OneShotEvent;
+}
+
 namespace content {
 class WebContents;
 }
@@ -191,19 +195,16 @@ class BravePassageEmbeddingsService
   void OnBackgroundContentsCreated(
       std::unique_ptr<local_ai::BackgroundWebContents> contents);
   void CloseBackgroundContents();
-  // Arms a fresh barrier that waits for two events before triggering
-  // LoadLocalModelFiles: (1) the EmbeddingGemma component is installed
-  // (OnLocalModelsReady fires, or install_dir is already non-empty
-  // at arm time) and (2) the renderer's PassageEmbedderFactory
-  // registers via RegisterPassageEmbedderFactory.
+  // Arms a fresh pair of OneShotEvents that chain into
+  // LoadLocalModelFiles once both (1) the EmbeddingGemma component is
+  // installed (OnLocalModelsReady signals component_ready_event_, or
+  // install_dir is already non-empty at arm time) and (2) the
+  // renderer's PassageEmbedderFactory registers via
+  // RegisterPassageEmbedderFactory.
   void MaybeWaitForLocalModelFilesReady();
-  // Counts the "component ready" half of the barrier exactly once per
-  // barrier lifetime. Both MaybeWaitForLocalModelFilesReady's sync
-  // check AND OnLocalModelsReady route through here, so AddObserver's
-  // immediate-notify (which fires OnLocalModelsReady synchronously
-  // when the component was already installed at AddObserver time)
-  // doesn't double-count the same signal.
-  void CountComponentReadyOnce();
+  // Posted on component_ready_event_. Chains through
+  // factory_registered_event_ to LoadLocalModelFiles.
+  void OnComponentReadyForLoad();
   void LoadLocalModelFiles();
   void OnLocalModelFilesLoaded(local_ai::mojom::ModelFilesPtr model_files);
   void OnFactoryInitDone(bool success);
@@ -226,15 +227,16 @@ class BravePassageEmbeddingsService
   std::unique_ptr<BraveBatchPassageEmbedder> batch_embedder_;
   std::vector<PendingLoad> pending_loads_;
 
-  // BarrierClosure that fires LoadLocalModelFiles once both halves
-  // (component-ready + factory-registered) have contributed their
-  // count. Re-armed on each arm cycle by MaybeWaitForLocalModelFilesReady.
-  base::RepeatingClosure model_load_barrier_;
-  // Prevents AddObserver's immediate OnLocalModelsReady notification
-  // from counting install_dir twice for the same barrier — once from
-  // MaybeWaitForLocalModelFilesReady's sync check and once from the
-  // observer callback.
-  bool component_ready_counted_ = false;
+  // Signaled when the EmbeddingGemma component is installed. When
+  // fired, OnComponentReadyForLoad chains to factory_registered_event_.
+  // Re-armed (new OneShotEvent instance) on each arm cycle by
+  // MaybeWaitForLocalModelFilesReady; Signal() is idempotent via the
+  // is_signaled() guard at each call site.
+  std::unique_ptr<base::OneShotEvent> component_ready_event_;
+  // Signaled when the renderer's PassageEmbedderFactory registers.
+  // LoadLocalModelFiles is posted on this event (after component is
+  // also ready) by OnComponentReadyForLoad.
+  std::unique_ptr<base::OneShotEvent> factory_registered_event_;
   bool model_ready_ = false;
 
   base::WeakPtrFactory<BravePassageEmbeddingsService> weak_ptr_factory_{this};

--- a/browser/history_embeddings/brave_passage_embeddings_service_unittest.cc
+++ b/browser/history_embeddings/brave_passage_embeddings_service_unittest.cc
@@ -144,6 +144,15 @@ class BravePassageEmbeddingsServiceTest : public testing::Test {
     std::move(callback).Run(std::move(web_contents));
   }
 
+  void RecreateService() {
+    service_.reset();
+    service_ = std::make_unique<BravePassageEmbeddingsService>(
+        base::BindRepeating(
+            &BravePassageEmbeddingsServiceTest::CreateFakeWebContents,
+            base::Unretained(this)),
+        local_ai::LocalModelsUpdaterState::GetInstance());
+  }
+
   void RegisterFactory() {
     mojo::Remote<local_ai::mojom::LocalAIService> local_ai_remote;
     service_->BindLocalAIReceiver(local_ai_remote.BindNewPipeAndPassReceiver());
@@ -294,6 +303,23 @@ TEST_F(BravePassageEmbeddingsServiceTest,
   ASSERT_TRUE(
       base::test::RunUntil([&] { return fake_factory_.init_count() > 0; }));
   EXPECT_TRUE(load->load_success.Get());
+}
+
+TEST_F(BravePassageEmbeddingsServiceTest,
+       PreInstalledModelDirCompletesLoadOnFactoryRegister) {
+  // Set install_dir before constructing the service. AddObserver
+  // re-fires OnLocalModelsReady synchronously when install_dir is
+  // already set, exercising the OneShotEvent's idempotent Signal()
+  // alongside the explicit signal in MaybeWaitForLocalModelFilesReady.
+  SetUpModelFiles();
+  RecreateService();
+
+  auto load = IssueLoad();
+  RegisterFactory();
+  EXPECT_TRUE(load->load_success.Get());
+  // AddObserver's sync re-fire of OnLocalModelsReady plus the
+  // explicit factory-register path must collapse to a single load.
+  EXPECT_EQ(1, fake_factory_.init_count());
 }
 
 TEST_F(BravePassageEmbeddingsServiceTest, BindRegistryRoutesToService) {

--- a/browser/history_embeddings/brave_passage_embeddings_service_unittest.cc
+++ b/browser/history_embeddings/brave_passage_embeddings_service_unittest.cc
@@ -309,8 +309,8 @@ TEST_F(BravePassageEmbeddingsServiceTest,
        PreInstalledModelDirCompletesLoadOnFactoryRegister) {
   // Set install_dir before constructing the service. AddObserver
   // re-fires OnLocalModelsReady synchronously when install_dir is
-  // already set, exercising the OneShotEvent's idempotent Signal()
-  // alongside the explicit signal in MaybeWaitForLocalModelFilesReady.
+  // already set; MaybeLoadLocalModelFiles is a no-op until the factory
+  // registers because GetInstallDir() is read fresh on each call.
   SetUpModelFiles();
   RecreateService();
 


### PR DESCRIPTION
Part of https://github.com/brave/brave-browser/issues/54763. Issue resolved by the final PR in the stack (#36107).

## Summary

Two signals gate the EmbeddingGemma model load: the component being installed and the renderer-side `PassageEmbedderFactory` registering. A `BarrierClosure(2)` paired with a `component_ready_counted_` flag was needed because `LocalModelsUpdaterState::AddObserver` synchronously re-fires `OnLocalModelsReady` when `install_dir` is already set, which would otherwise tick the barrier twice.

Replace the barrier with a `LoadPhase` state machine (`kWaiting → kLoading → kInitializing → kReady`) driven by a single `MaybeLoadLocalModelFiles` entry point, called from `OnLocalModelsReady`, `RegisterPassageEmbedderFactory`, and `BindPassageEmbedder`. It re-enters only when `phase_ == kWaiting` and both `factory_.is_bound()` and `updater_state_->GetInstallDir()` are present, so the `component_ready_counted_` guard disappears and `AddObserver`'s sync re-fire is naturally a no-op.

Addresses [r3114239143](https://github.com/brave/brave-core/pull/32689#discussion_r3114239143) and [r3113758418](https://github.com/brave/brave-core/pull/32689#discussion_r3113758418) on the original PR.

## Stack

This PR is part 1 of 3 splitting the original follow-up (#35906):

1. **This PR** — Replace model-load barrier with state machine
2. #36106 — Move factory/init into `BraveBatchPassageEmbedder` (with orphan-renderer guard)
3. #36107 — Extract `BraveBatchPassageEmbedder` to its own files

Related (not in stack): #36184 — Reject duplicate `RegisterPassageEmbedderFactory`.
(#36104 was closed as superseded — its in-flight flag was redundant with the fast-fail in part 2; an orphan-renderer guard now lives in part 2 instead.)