### PR TITLE
[Do not submit] WkWV configuration provider via FromWebState attempt.

### DIFF
--- a/chromium_src/ios/web/js_messaging/java_script_content_world.h
+++ b/chromium_src/ios/web/js_messaging/java_script_content_world.h
@@ -1,0 +1,25 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_IOS_WEB_JS_MESSAGING_JAVA_SCRIPT_CONTENT_WORLD_H_
+#define BRAVE_CHROMIUM_SRC_IOS_WEB_JS_MESSAGING_JAVA_SCRIPT_CONTENT_WORLD_H_
+
+namespace web {
+class BraveJavaScriptFeatureManager;
+}  // namespace web
+
+// `JavaScriptContentWorld` looks up `user_content_controller_` in its
+// constructor from the *profile-level* `WKWebViewConfigurationProvider`. To
+// make the per-tab `BraveJavaScriptFeatureManager` install scripts on the
+// per-tab controller we give it friend access so it can overwrite the field
+// right after construction. The friend declaration is injected on the private
+// `user_content_controller_` field.
+#define user_content_controller_ \
+  user_content_controller_;      \
+  friend class BraveJavaScriptFeatureManager
+#include <ios/web/js_messaging/java_script_content_world.h>  // IWYU pragma: export
+#undef user_content_controller_
+
+#endif  // BRAVE_CHROMIUM_SRC_IOS_WEB_JS_MESSAGING_JAVA_SCRIPT_CONTENT_WORLD_H_

--- a/chromium_src/ios/web/js_messaging/java_script_feature_manager.h
+++ b/chromium_src/ios/web/js_messaging/java_script_feature_manager.h
@@ -1,0 +1,95 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_IOS_WEB_JS_MESSAGING_JAVA_SCRIPT_FEATURE_MANAGER_H_
+#define BRAVE_CHROMIUM_SRC_IOS_WEB_JS_MESSAGING_JAVA_SCRIPT_FEATURE_MANAGER_H_
+
+#include <map>
+#include <memory>
+
+#include "base/memory/raw_ptr.h"
+#include "ios/web/public/web_state_id.h"
+
+@class WKUserContentController;
+
+namespace web {
+class WebState;
+}  // namespace web
+
+// Support for subclassing `JavaScriptFeatureManager`:
+// - Inject a friend declaration so `BraveJavaScriptFeatureManager` can call
+//   the private base constructor and access the private `page_content_world_`
+//   and `isolated_world_` fields.
+// - Make `ConfigureFeatures` virtual so Brave can override it.
+// - Rename upstream `FromBrowserState` to `FromBrowserState_ChromiumImpl` and
+//   declare a new `FromBrowserState` + `FromWebState` entry point.
+#define browser_state_ \
+  browser_state_;      \
+  friend class BraveJavaScriptFeatureManager
+#define ConfigureFeatures virtual ConfigureFeatures
+#define FromBrowserState(...)                                     \
+  FromBrowserState_ChromiumImpl(__VA_ARGS__);                     \
+  static JavaScriptFeatureManager* FromBrowserState(__VA_ARGS__); \
+  static JavaScriptFeatureManager* FromWebState(web::WebState* web_state)
+#include <ios/web/js_messaging/java_script_feature_manager.h>  // IWYU pragma: export
+#undef FromBrowserState
+#undef ConfigureFeatures
+#undef browser_state_
+
+namespace web {
+
+// Per-tab subclass. Holds a pointer to its owning WebState and the
+// `WKUserContentController` for that tab, so the overridden
+// `ConfigureFeatures` can install scripts and script-message handlers on the
+// per-tab controller instead of the shared profile-level one.
+//
+// The per-tab controller is set explicitly by
+// `BraveWKWebViewConfigurationProvider::UpdateScripts` just before it calls
+// `ConfigureFeatures` on us. We don't look it up ourselves via
+// `WKWebViewConfigurationProvider::FromWebState` because that call path would
+// re-enter `UpdateScripts` -> `ConfigureFeatures` recursively on first use.
+class BraveJavaScriptFeatureManager : public JavaScriptFeatureManager {
+ public:
+  BraveJavaScriptFeatureManager(BrowserState* browser_state,
+                                WebState* web_state);
+  ~BraveJavaScriptFeatureManager() override;
+
+  WebState* GetWebState() const { return web_state_; }
+
+  void set_user_content_controller(WKUserContentController* controller) {
+    user_content_controller_ = controller;
+  }
+
+  void ConfigureFeatures(std::vector<JavaScriptFeature*> features) override;
+
+ private:
+  raw_ptr<WebState> web_state_;
+  WKUserContentController* user_content_controller_ = nil;
+};
+
+// Per-BrowserState map of `WebStateID` -> `JavaScriptFeatureManager`, owned by
+// the BrowserState through `SupportsUserData`. Parallels
+// `BraveWKWebViewConfigurationProviderMap`.
+class BraveJavaScriptFeatureManagerMap : public base::SupportsUserData::Data {
+ public:
+  BraveJavaScriptFeatureManagerMap();
+  ~BraveJavaScriptFeatureManagerMap() override;
+
+  BraveJavaScriptFeatureManagerMap(const BraveJavaScriptFeatureManagerMap&) =
+      delete;
+  BraveJavaScriptFeatureManagerMap& operator=(
+      const BraveJavaScriptFeatureManagerMap&) = delete;
+
+  JavaScriptFeatureManager* GetOrCreate(BrowserState* browser_state,
+                                        WebState* web_state);
+  void Erase(WebStateID id);
+
+ private:
+  std::map<WebStateID, std::unique_ptr<JavaScriptFeatureManager>> map_;
+};
+
+}  // namespace web
+
+#endif  // BRAVE_CHROMIUM_SRC_IOS_WEB_JS_MESSAGING_JAVA_SCRIPT_FEATURE_MANAGER_H_

--- a/chromium_src/ios/web/js_messaging/java_script_feature_manager.mm
+++ b/chromium_src/ios/web/js_messaging/java_script_feature_manager.mm
@@ -1,0 +1,131 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "ios/web/js_messaging/java_script_feature_manager.h"
+
+#import <WebKit/WebKit.h>
+
+#include <memory>
+#include <utility>
+
+#include "base/check.h"
+#include "base/memory/ptr_util.h"
+#include "base/notreached.h"
+#include "ios/web/js_messaging/java_script_content_world.h"
+#include "ios/web/public/browser_state.h"
+#include "ios/web/public/js_messaging/content_world.h"
+#include "ios/web/public/js_messaging/java_script_feature.h"
+#include "ios/web/public/web_state.h"
+#include "ios/web/web_state/ui/wk_web_view_configuration_provider.h"
+
+#include <ios/web/js_messaging/java_script_feature_manager.mm>
+
+namespace web {
+
+namespace {
+
+constexpr char kBraveJavaScriptFeatureManagerMapKey[] =
+    "brave_java_script_feature_manager_map";
+
+}  // namespace
+
+BraveJavaScriptFeatureManager::BraveJavaScriptFeatureManager(
+    BrowserState* browser_state,
+    WebState* web_state)
+    : JavaScriptFeatureManager(browser_state), web_state_(web_state) {}
+
+BraveJavaScriptFeatureManager::~BraveJavaScriptFeatureManager() = default;
+
+// Mirrors upstream `JavaScriptFeatureManager::ConfigureFeatures` but replaces
+// the content worlds' `user_content_controller_` with the per-tab one before
+// calling `AddFeature`, so that all user scripts and script-message handlers
+// land on the tab's controller (which is what the tab's WKWebView actually
+// uses) rather than the profile-level one.
+//
+// The caller (`BraveWKWebViewConfigurationProvider::UpdateScripts`) must have
+// called `set_user_content_controller` before invoking this method. If it
+// hasn't, we preserve upstream behavior.
+void BraveJavaScriptFeatureManager::ConfigureFeatures(
+    std::vector<JavaScriptFeature*> features) {
+  if (!user_content_controller_) {
+    JavaScriptFeatureManager::ConfigureFeatures(std::move(features));
+    return;
+  }
+
+  page_content_world_ = std::make_unique<JavaScriptContentWorld>(
+      browser_state_, WKContentWorld.pageWorld);
+  isolated_world_ = std::make_unique<JavaScriptContentWorld>(
+      browser_state_, WKContentWorld.defaultClientWorld);
+
+  // Overwrite the controller the ctor picked up from the profile-level
+  // provider. Access granted by `friend class BraveJavaScriptFeatureManager`
+  // in the Brave `java_script_content_world.h` override.
+  page_content_world_->user_content_controller_ = user_content_controller_;
+  isolated_world_->user_content_controller_ = user_content_controller_;
+
+  for (JavaScriptFeature* feature : features) {
+    switch (feature->GetSupportedContentWorld()) {
+      case ContentWorld::kAllContentWorlds:
+        isolated_world_->AddFeature(feature);
+        page_content_world_->AddFeature(feature);
+        break;
+      case ContentWorld::kIsolatedWorld:
+        isolated_world_->AddFeature(feature);
+        break;
+      case ContentWorld::kPageContentWorld:
+        page_content_world_->AddFeature(feature);
+        break;
+    }
+  }
+}
+
+BraveJavaScriptFeatureManagerMap::BraveJavaScriptFeatureManagerMap() = default;
+
+BraveJavaScriptFeatureManagerMap::~BraveJavaScriptFeatureManagerMap() = default;
+
+JavaScriptFeatureManager* BraveJavaScriptFeatureManagerMap::GetOrCreate(
+    BrowserState* browser_state,
+    WebState* web_state) {
+  DCHECK(web_state);
+  WebStateID id = web_state->GetUniqueIdentifier();
+  auto it = map_.find(id);
+  if (it == map_.end()) {
+    it = map_.emplace(id, std::make_unique<BraveJavaScriptFeatureManager>(
+                              browser_state, web_state))
+             .first;
+  }
+  return it->second.get();
+}
+
+void BraveJavaScriptFeatureManagerMap::Erase(WebStateID id) {
+  map_.erase(id);
+}
+
+// static
+// Per-tab entry point. Returns a `JavaScriptFeatureManager` keyed by the
+// WebState's unique identifier.
+JavaScriptFeatureManager* JavaScriptFeatureManager::FromWebState(
+    WebState* web_state) {
+  DCHECK(web_state);
+  BrowserState* browser_state = web_state->GetBrowserState();
+  auto* map = static_cast<BraveJavaScriptFeatureManagerMap*>(
+      browser_state->GetUserData(kBraveJavaScriptFeatureManagerMapKey));
+  if (!map) {
+    auto owned = std::make_unique<BraveJavaScriptFeatureManagerMap>();
+    map = owned.get();
+    browser_state->SetUserData(kBraveJavaScriptFeatureManagerMapKey,
+                               std::move(owned));
+  }
+  return map->GetOrCreate(browser_state, web_state);
+}
+
+// static
+// Fallback for callers without a WebState.
+JavaScriptFeatureManager* JavaScriptFeatureManager::FromBrowserState(
+    BrowserState* browser_state) {
+  return FromBrowserState_ChromiumImpl(browser_state);
+}
+
+}  // namespace web

--- a/chromium_src/ios/web/web_state/ui/crw_web_controller.mm
+++ b/chromium_src/ios/web/web_state/ui/crw_web_controller.mm
@@ -10,6 +10,14 @@
 #include "net/base/apple/url_conversions.h"
 #include "url/gurl.h"
 
+// Pre-include Brave chromium_src overrides that have their own
+// `FromBrowserState` macro dance so those dances complete before the
+// redirection macro below is defined. Otherwise, if the upstream
+// `crw_web_controller.mm` (re-)includes any of these transitively while our
+// macro is active, the `FromBrowserState` macros collide.
+#include "ios/web/js_messaging/java_script_feature_manager.h"
+#include "ios/web/web_state/ui/wk_web_view_configuration_provider.h"
+
 // Replace the underlying CRWWKNavigationHandler with our subclass
 #define _navigationHandler                                         \
   _navigationHandler =                                             \
@@ -18,7 +26,11 @@
   auto* _
 // Support for tab sync
 #define webViewNavigationProxy webViewNavigationProxy_ChromiumImpl
+// Redirect to getting the configs from a web state instead.
+#define FromBrowserState(browser_state) \
+  FromWebState(((void)(browser_state), self.webStateImpl))
 #include <ios/web/web_state/ui/crw_web_controller.mm>
+#undef FromBrowserState
 #undef webViewNavigationProxy
 #undef _navigationHandler
 

--- a/chromium_src/ios/web/web_state/ui/wk_web_view_configuration_provider.h
+++ b/chromium_src/ios/web/web_state/ui/wk_web_view_configuration_provider.h
@@ -6,26 +6,90 @@
 #ifndef BRAVE_CHROMIUM_SRC_IOS_WEB_WEB_STATE_UI_WK_WEB_VIEW_CONFIGURATION_PROVIDER_H_
 #define BRAVE_CHROMIUM_SRC_IOS_WEB_WEB_STATE_UI_WK_WEB_VIEW_CONFIGURATION_PROVIDER_H_
 
+#include <map>
+#include <memory>
+
+#include "base/memory/raw_ptr.h"
+#include "ios/web/public/web_state_id.h"
+
+namespace web {
+class WebState;
+}  // namespace web
+
 // Support for subclassing WKWebViewConfigurationProvider:
-// - Add a friend class as the subclass needs access to private fields
-// (`configuration_` in this case)
-// - Make `ResetWithWebViewConfiguration` virtual so that we can override it
+// - `browser_state_` gets a friend declaration so the Brave subclass can
+//   access the protected field (and the private base constructor).
+// - `ResetWithWebViewConfiguration` and `UpdateScripts` become virtual so the
+//   Brave subclass can override them.
+// - `FromBrowserState` is renamed to `FromBrowserState_ChromiumImpl` in the
+//   base and a new `FromBrowserState` + `FromWebState` are declared so Brave
+//   can return per-tab providers.
 #define browser_state_ \
   browser_state_;      \
   friend class BraveWKWebViewConfigurationProvider
 #define ResetWithWebViewConfiguration virtual ResetWithWebViewConfiguration
+#define UpdateScripts virtual UpdateScripts
+#define FromBrowserState(...)                                                \
+  FromBrowserState_ChromiumImpl(__VA_ARGS__);                                \
+  static web::WKWebViewConfigurationProvider& FromBrowserState(__VA_ARGS__); \
+  static web::WKWebViewConfigurationProvider& FromWebState(                  \
+      web::WebState* web_state)
 #include <ios/web/web_state/ui/wk_web_view_configuration_provider.h>  // IWYU pragma: export
+#undef FromBrowserState
+#undef UpdateScripts
 #undef ResetWithWebViewConfiguration
 #undef browser_state_
 
 namespace web {
+
+// Per-tab subclass. Stores a pointer back to its owning `WebState` so its
+// overridden `UpdateScripts()` can route to the per-tab
+// `JavaScriptFeatureManager`.
 class BraveWKWebViewConfigurationProvider
     : public WKWebViewConfigurationProvider {
-  using WKWebViewConfigurationProvider::WKWebViewConfigurationProvider;
+ public:
+  BraveWKWebViewConfigurationProvider(BrowserState* browser_state,
+                                      WebState* web_state);
+  ~BraveWKWebViewConfigurationProvider() override;
+
+  WebState* GetWebState() const { return web_state_; }
 
   void ResetWithWebViewConfiguration(
       WKWebViewConfiguration* configuration) override;
+  void UpdateScripts() override;
+
+ private:
+  // Non-owning. The WebState owns this provider transitively through its
+  // BrowserState, so the WebState outlives... actually the WebState can be
+  // destroyed before the BrowserState. See `Erase` below — the map should
+  // drop the entry on WebState destruction. Until that's wired up this is
+  // a lifetime bet: consult the WebState only while it is known to be alive
+  // (inside `UpdateScripts`, which is called while the tab is loading).
+  raw_ptr<WebState> web_state_;
 };
+
+// Per-BrowserState map of `WebStateID` -> `WKWebViewConfigurationProvider`.
+// Owned by the BrowserState via `SupportsUserData` so the providers are torn
+// down with the profile.
+class BraveWKWebViewConfigurationProviderMap
+    : public base::SupportsUserData::Data {
+ public:
+  BraveWKWebViewConfigurationProviderMap();
+  ~BraveWKWebViewConfigurationProviderMap() override;
+
+  BraveWKWebViewConfigurationProviderMap(
+      const BraveWKWebViewConfigurationProviderMap&) = delete;
+  BraveWKWebViewConfigurationProviderMap& operator=(
+      const BraveWKWebViewConfigurationProviderMap&) = delete;
+
+  WKWebViewConfigurationProvider& GetOrCreate(BrowserState* browser_state,
+                                              WebState* web_state);
+  void Erase(WebStateID id);
+
+ private:
+  std::map<WebStateID, std::unique_ptr<WKWebViewConfigurationProvider>> map_;
+};
+
 }  // namespace web
 
 #endif  // BRAVE_CHROMIUM_SRC_IOS_WEB_WEB_STATE_UI_WK_WEB_VIEW_CONFIGURATION_PROVIDER_H_

--- a/chromium_src/ios/web/web_state/ui/wk_web_view_configuration_provider.mm
+++ b/chromium_src/ios/web/web_state/ui/wk_web_view_configuration_provider.mm
@@ -5,19 +5,101 @@
 
 #include "ios/web/web_state/ui/wk_web_view_configuration_provider.h"
 
-#include "base/notreached.h"
-#include "base/supports_user_data.h"
-#include "ios/web/public/web_client.h"
+#include <memory>
+#include <utility>
+#include <vector>
 
-// Replace the `WKWebViewConfigurationProvider` constructor call with the Brave
-// subclass inside of `WKWebViewConfigurationProvider::FromBrowserState`
+#include "base/check.h"
+#include "base/memory/ptr_util.h"
+#include "base/notreached.h"
+// Note: `java_script_feature_manager.h` resolves to Brave's chromium_src
+// override via `-iquote`, which exposes `BraveJavaScriptFeatureManager`.
+#include "ios/web/js_messaging/java_script_feature_manager.h"
+#include "ios/web/js_messaging/java_script_feature_util_impl.h"
+#include "ios/web/js_messaging/web_frames_manager_java_script_feature.h"
+#include "ios/web/public/browser_state.h"
+#include "ios/web/public/js_messaging/java_script_feature.h"
+#include "ios/web/public/web_client.h"
+#include "ios/web/public/web_state.h"
+
+// Replace the `WKWebViewConfigurationProvider` constructor call inside the
+// upstream `FromBrowserState_ChromiumImpl` with the Brave subclass. The
+// fallback path goes through this constructor with a null `WebState*` — it is
+// only used by callers that don't have a tab (cookie utilities, JS content
+// world init, tests, etc.).
 #define SetUserData(key, ...)                                                \
   SetUserData(key, base::WrapUnique(new BraveWKWebViewConfigurationProvider( \
-                       browser_state)));
+                       browser_state, /*web_state=*/nullptr)));
 #include <ios/web/web_state/ui/wk_web_view_configuration_provider.mm>
 #undef SetUserData
 
 namespace web {
+
+namespace {
+
+constexpr char kBraveWKWebViewConfigProviderMapKey[] =
+    "brave_wk_web_view_config_provider_map";
+
+}  // namespace
+
+BraveWKWebViewConfigurationProvider::BraveWKWebViewConfigurationProvider(
+    BrowserState* browser_state,
+    WebState* web_state)
+    : WKWebViewConfigurationProvider(browser_state), web_state_(web_state) {}
+
+BraveWKWebViewConfigurationProvider::~BraveWKWebViewConfigurationProvider() =
+    default;
+
+BraveWKWebViewConfigurationProviderMap::
+    BraveWKWebViewConfigurationProviderMap() = default;
+
+BraveWKWebViewConfigurationProviderMap::
+    ~BraveWKWebViewConfigurationProviderMap() = default;
+
+WKWebViewConfigurationProvider&
+BraveWKWebViewConfigurationProviderMap::GetOrCreate(BrowserState* browser_state,
+                                                    WebState* web_state) {
+  DCHECK(web_state);
+  WebStateID id = web_state->GetUniqueIdentifier();
+  auto it = map_.find(id);
+  if (it == map_.end()) {
+    it = map_.emplace(id, std::make_unique<BraveWKWebViewConfigurationProvider>(
+                              browser_state, web_state))
+             .first;
+  }
+  return *it->second;
+}
+
+void BraveWKWebViewConfigurationProviderMap::Erase(WebStateID id) {
+  map_.erase(id);
+}
+
+// static
+// Per-tab entry point. Returns a `WKWebViewConfigurationProvider` keyed by the
+// WebState's unique identifier so each tab has its own configuration.
+WKWebViewConfigurationProvider& WKWebViewConfigurationProvider::FromWebState(
+    WebState* web_state) {
+  DCHECK(web_state);
+  BrowserState* browser_state = web_state->GetBrowserState();
+  auto* map = static_cast<BraveWKWebViewConfigurationProviderMap*>(
+      browser_state->GetUserData(kBraveWKWebViewConfigProviderMapKey));
+  if (!map) {
+    auto owned = std::make_unique<BraveWKWebViewConfigurationProviderMap>();
+    map = owned.get();
+    browser_state->SetUserData(kBraveWKWebViewConfigProviderMapKey,
+                               std::move(owned));
+  }
+  return map->GetOrCreate(browser_state, web_state);
+}
+
+// static
+// Fallback for callers without a WebState (JS content world init, cookie
+// utilities, browsing-data removal, tests, etc.). Returns the shared
+// per-BrowserState provider that upstream creates.
+WKWebViewConfigurationProvider&
+WKWebViewConfigurationProvider::FromBrowserState(BrowserState* browser_state) {
+  return FromBrowserState_ChromiumImpl(browser_state);
+}
 
 void BraveWKWebViewConfigurationProvider::ResetWithWebViewConfiguration(
     WKWebViewConfiguration* configuration) {
@@ -35,22 +117,22 @@ void BraveWKWebViewConfigurationProvider::ResetWithWebViewConfiguration(
   WKWebViewConfigurationProvider::ResetWithWebViewConfiguration(configuration);
 
   // Adjusts the underlying WKWebViewConfiguration for settings we don't want
-  // to inherit from Chromium
+  // to inherit from Chromium.
 
-  // Restore WKWebView long press
+  // Restore WKWebView long press.
   @try {
     [configuration_ setValue:@YES forKey:@"longPressActionsEnabled"];
   } @catch (NSException* exception) {
     NOTREACHED() << "Error setting value for longPressActionsEnabled";
   }
 
-  // Restore Apple's safe browsing implementation
+  // Restore Apple's safe browsing implementation.
   [[configuration_ preferences] setFraudulentWebsiteWarningEnabled:YES];
 
-  // Reset fullscreen to default as it wasn't set in Brave
+  // Reset fullscreen to default as it wasn't set in Brave.
   [[configuration_ preferences] setElementFullscreenEnabled:NO];
 
-  // Add Brave-specific adjustments to the WKWebViewConfiguration here
+  // Add Brave-specific adjustments to the WKWebViewConfiguration here.
 
   configuration_.dataDetectorTypes = WKDataDetectorTypePhoneNumber;
 
@@ -65,6 +147,45 @@ void BraveWKWebViewConfigurationProvider::ResetWithWebViewConfiguration(
   //   `WKWebViewConfiguration.upgradeKnownHostsToHTTPS`
   //   https://github.com/brave/brave-browser/issues/53030
   GetWebClient()->DidResetConfiguration(browser_state_, configuration_);
+}
+
+// Mirrors upstream `WKWebViewConfigurationProvider::UpdateScripts()` but routes
+// through the per-tab `JavaScriptFeatureManager` when this provider is owned
+// by a tab. The per-tab `WKUserContentController` is pushed into the feature
+// manager up front so its `ConfigureFeatures` doesn't have to re-enter the
+// provider to look it up (which would recurse back into this method).
+void BraveWKWebViewConfigurationProvider::UpdateScripts() {
+  [configuration_.userContentController removeAllUserScripts];
+
+  JavaScriptFeatureManager* java_script_feature_manager =
+      web_state_ ? JavaScriptFeatureManager::FromWebState(web_state_)
+                 : JavaScriptFeatureManager::FromBrowserState(browser_state_);
+
+  if (web_state_) {
+    // `FromWebState` always returns a `BraveJavaScriptFeatureManager`.
+    static_cast<BraveJavaScriptFeatureManager*>(java_script_feature_manager)
+        ->set_user_content_controller(configuration_.userContentController);
+  }
+
+  std::vector<JavaScriptFeature*> features;
+  for (JavaScriptFeature* feature :
+       java_script_features::GetBuiltInJavaScriptFeatures(browser_state_)) {
+    features.push_back(feature);
+  }
+  for (JavaScriptFeature* feature :
+       GetWebClient()->GetJavaScriptFeatures(browser_state_)) {
+    features.push_back(feature);
+  }
+  java_script_feature_manager->ConfigureFeatures(features);
+
+  WKUserContentController* user_content_controller =
+      GetWebViewConfiguration().userContentController;
+  auto web_frames_manager_features = WebFramesManagerJavaScriptFeature::
+      AllContentWorldFeaturesFromBrowserState(browser_state_);
+  for (WebFramesManagerJavaScriptFeature* feature :
+       web_frames_manager_features) {
+    feature->ConfigureHandlers(user_content_controller);
+  }
 }
 
 }  // namespace web

--- a/ios/browser/api/sync/brave_sync_api.mm
+++ b/ios/browser/api/sync/brave_sync_api.mm
@@ -21,7 +21,6 @@
 #include "brave/components/brave_sync/crypto/crypto.h"
 #include "brave/components/brave_sync/qr_code_validator.h"
 #include "brave/components/brave_sync/time_limited_words.h"
-#include "brave/components/sync_device_info/brave_device_info.h"
 #include "brave/ios/browser/api/sync/brave_sync_worker.h"
 #include "components/sync/engine/sync_protocol_error.h"
 #include "components/sync/service/sync_service.h"

--- a/ios/web_view/internal/cwv_web_view_extras.mm
+++ b/ios/web_view/internal/cwv_web_view_extras.mm
@@ -60,8 +60,7 @@ const CWVUserAgentType CWVUserAgentTypeDesktop =
   // all Brave JavaScript features are ported over to actual Chromium
   // JavascriptFeature types and added to BraveWebClient
   web::WKWebViewConfigurationProvider& config_provider =
-      web::WKWebViewConfigurationProvider::FromBrowserState(
-          self.webState->GetBrowserState());
+      web::WKWebViewConfigurationProvider::FromWebState(self.webState);
   config_provider.UpdateScripts();
 }
 
@@ -114,8 +113,7 @@ const CWVUserAgentType CWVUserAgentTypeDesktop =
     return;
   }
   web::WebFrameInternal* webFrame = mainFrame->GetWebFrameInternal();
-  auto worlds = web::JavaScriptFeatureManager::FromBrowserState(
-                    self.configuration.browserState)
+  auto worlds = web::JavaScriptFeatureManager::FromWebState(self.webState)
                     ->GetAllContentWorlds();
 
   auto jsContentWorld =


### PR DESCRIPTION
Warning: This code is 90% Claude Opus 4.7 generated and not tested!!! Only verification done is that the code compiles and builds on Debug. 

The model was instructed and guided a little to update the current architecture to build a WkWebViewConfiguration on a per tab basis / rather than on browser state.  The core idea was to introduce a static FromWebState method in both the `wk_web_view_configuration_provider.h` and `java_script_feature_manager.h` which stashes the `WkWebviewConfigurationProvider` in the UserData, keyed by the WebStateId. This map from WebStateId -> config is handled by `BraveWKWebViewConfigurationProviderMap`. A similar map exists for the JavaScriptFeatureManager.

It seems that the change relies on the fact that the core entry point `crw_web_controller.mm` already contains a member |webStateImpl| which it then uses to hook into the WkWebViewConfiguration::FromWebState.  From there any successive elements which needed the WebState, then holds a raw pointer to it (the new map may contain dangling reference to webstateid also when its destroyed, so we should probably add observers to it..). 

In the non-tab cases the code seems to hook into the default FromBrowserState but not sure if there could be any issues.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
