### PR TITLE
[brockit] Adding 🩹 integration

### DIFF
--- a/tools/cr/brockit.py
+++ b/tools/cr/brockit.py
@@ -213,6 +213,8 @@ from typing import Optional, List, Dict
 from incendiary_error_handler import IncendiaryErrorHandler
 from git_status import GitStatus
 from patchfile import Patchfile
+import plaster
+from plaster import PlasterFile, PlasterFileNeedsRegen
 import repository
 from repository import Repository, CHROMIUM_SRC_PATH
 from terminal import console, terminal
@@ -225,6 +227,15 @@ PINSLIST_TIMESTAMP_FILE = (
     'chromium_src/net/tools/transport_security_state_generator/'
     'input_file_parsers.cc')
 VERSION_UPGRADE_FILE = Path('.version_upgrade')
+
+# Commit subject prefixes that identify brockit-managed upgrade commits.
+# Patches whose most recent branch commit carries one of these subjects are
+# NOT dev-cycle changes and therefore must NOT be turned into fixups.
+_UPGRADE_COMMIT_WITH_PATCHES_PREFIXES = (
+    'Conflict-resolved patches from Chromium ',
+    'Regen-fixed 🩹 patches from Chromium ',
+    'Update patches from Chromium ',
+)
 
 # The link to a specific commit in the Chromium source code.
 GOOGLESOURCE_COMMIT_LINK = f'{versioning.GOOGLESOURCE_LINK}' '/+/{commit}'
@@ -336,15 +347,9 @@ def _get_apply_patches_list() -> dict[Repository, list[Patchfile]] | None:
             return None
         entries = json.loads(match.group(0))
         patch_paths = [Path(entry['patchPath']) for entry in entries]
-        patch_stats = repository.brave.get_patch_stats(*patch_paths)
         patch_files: dict[Repository, list[Patchfile]] = {}
         for patch_path in patch_paths:
-            sources = patch_stats[patch_path]
-            if len(sources) != 1:
-                raise ValueError(
-                    f'Expected exactly one source for {patch_path}, '
-                    f'got {sources}.') from e
-            patchfile = Patchfile(path=patch_path, source=sources[0])
+            patchfile = Patchfile(path=patch_path)
             patch_files.setdefault(patchfile.repository, []).append(patchfile)
         return patch_files
 
@@ -371,6 +376,13 @@ class ApplyPatchesRecord:
     # A list of patches that fail entirely when running apply with `--3way`.
     broken_patches: list[Patchfile] = field(default_factory=list)
 
+    # A list of patches where the apply failure was resolved by plaster.
+    plaster_fixed_patches: list[Path] = field(default_factory=list)
+
+    # A list of patches where the apply failure could not be resolved by
+    # plaster.
+    plaster_broken_patches: list[Patchfile] = field(default_factory=list)
+
     def all_conflict_resolved_patches(self) -> list[Patchfile]:
         """Returns a flattened list of all conflict-resolved candidates."""
         return [p for patches in self.patch_files.values() for p in patches]
@@ -383,7 +395,33 @@ class ApplyPatchesRecord:
         to address any potential patch changes.
         """
         return (self.files_with_conflicts or self.patches_to_deleted_files
-                or self.broken_patches)
+                or self.broken_patches or self.plaster_broken_patches)
+
+    def check_broken_plasters_fixed(self) -> None:
+        """Verifies all previously-broken plasters are now resolved.
+
+        For each entry in plaster_broken_patches:
+        - If the plaster .toml still exists, runs a dry-run check to confirm
+          the plaster output is up to date.
+        - If the plaster .toml is gone, verifies the corresponding .patch
+          file has also been removed.
+
+        Raises InvalidInputException if any broken plaster is not yet resolved.
+        """
+        for patchfile in self.plaster_broken_patches:
+            plaster_path = repository.BRAVE_CORE_PATH / patchfile.plaster
+            if plaster_path.exists():
+                try:
+                    PlasterFile(plaster_path).apply(dry_run=True)
+                except PlasterFileNeedsRegen as e:
+                    raise InvalidInputException(
+                        'Plaster file has not been fixed and re-applied: '
+                        f'{patchfile.plaster}') from e
+            else:
+                if (repository.BRAVE_CORE_PATH / patchfile.path).exists():
+                    raise InvalidInputException(
+                        'Plaster file was deleted but patch still exists: '
+                        f'{patchfile.path}')
 
     def stage_all_patches(self):
         """Stages all patches that were applied, so they can be committed as
@@ -983,6 +1021,12 @@ class Upgrade(Versioned):
         # These are patches that fail entirely when running apply with `--3way`.
         broken_patches: list[Patchfile] = []
 
+        # Patches where the apply failure was resolved by plaster.
+        plaster_fixed_patches: list[Path] = []
+
+        # Patches where the apply failure could not be resolved by plaster.
+        plaster_broken_patches: list[Patchfile] = []
+
         # A list of all patchfiles that failed to apply, grouped by repository.
         patch_files = _get_apply_patches_list()
         if patch_files is None:
@@ -991,10 +1035,10 @@ class Upgrade(Versioned):
         if patch_files:
             terminal.log_task(
                 '[bold]Reapplying patch files with --3way:\n[/]%s' %
-                '\n'.join(f'    * {file}' for file in [
-                    patchfile.path for patch_list in patch_files.values()
-                    for patchfile in patch_list
-                ]))
+                '\n'.join(f'    * {patchfile.path}'
+                          f'{" 🩹" if patchfile.has_plaster else ""}'
+                          for patch_list in patch_files.values()
+                          for patchfile in patch_list))
 
         vscode_files: list[Path] = []
         for repo, patches in patch_files.items():
@@ -1007,6 +1051,10 @@ class Upgrade(Versioned):
                     broken_patches.append(patchfile)
                 elif status == Patchfile.ApplyStatus.DELETED:
                     patches_to_deleted_files.append(patchfile)
+                elif status == Patchfile.ApplyStatus.PLASTER_FIXED:
+                    plaster_fixed_patches.append(patchfile.path)
+                elif status == Patchfile.ApplyStatus.PLASTER_BROKEN:
+                    plaster_broken_patches.append(patchfile)
 
         for repo, patches in patch_files.items():
             # Resetting any staged states from apply patches as that can cause
@@ -1054,9 +1102,10 @@ class Upgrade(Versioned):
                                 (0, 4)))
                         vscode_files += [patchfile.path, renamed_to]
 
-            # Printing the commmit message for the grouped changes.
-            console.log(
-                Padding(f'{next(iter(patches.items()))[1].commit_details}\n',
+                # Printing the commmit message for the grouped changes.
+                console.log(
+                    Padding(
+                        f'{next(iter(patches.items()))[1].commit_details}\n',
                         (0, 8),
                         style="dim"))
 
@@ -1069,6 +1118,16 @@ class Upgrade(Versioned):
                 source = patchfile.source_from_brave()
                 console.log(Padding(f'✘ {patchfile.path} ➜ {source}', (0, 4)))
                 vscode_files += [patchfile.path, source]
+
+        if plaster_broken_patches:
+            terminal.log_task('[bold]Plaster failed to fix patches '
+                              f'{ACTION_NEEDED_DECORATOR}:[/]')
+
+            for patchfile in plaster_broken_patches:
+                source = patchfile.source_from_brave()
+                console.log(
+                    Padding(f'✘ {patchfile.plaster} ➜ {source}', (0, 4)))
+                vscode_files += [patchfile.plaster, source]
 
         if files_with_conflicts:
             vscode_files += files_with_conflicts
@@ -1085,7 +1144,9 @@ class Upgrade(Versioned):
             patch_files=patch_files,
             patches_to_deleted_files=patches_to_deleted_files,
             files_with_conflicts=files_with_conflicts,
-            broken_patches=broken_patches)
+            broken_patches=broken_patches,
+            plaster_fixed_patches=plaster_fixed_patches,
+            plaster_broken_patches=plaster_broken_patches)
 
         replace(ContinuationFile.load(target_version=self.target_version),
                 apply_record=apply_record).save()
@@ -1114,6 +1175,64 @@ class Upgrade(Versioned):
         repository.brave.git_commit(
             f'Update from Chromium {self.base_version} '
             f'to Chromium {self.target_version}.')
+
+    def _commit_pinned_patches_and_fixups(self,
+                                          patch_paths: set[str],
+                                          commit_message: str,
+                                          no_verify: bool = False) -> None:
+        """Commits patch paths, routing dev-cycle patches as fixups.
+
+        For major version upgrades, inspects each patch's branch history. If
+        the most-recent branch commit touching a patch is not a brockit upgrade
+        commit, the patch is committed as a fixup! for that dev-cycle commit
+        instead. The remaining patches are committed together under
+        commit_message.
+        """
+        if self.is_major():
+            up_to_git_ref = _solve_brave_ref('@previous-major')
+
+            fixup_groups: dict[str, list[str]] = {}
+            for patch_path in patch_paths:
+                commits = repository.brave.run_git('log', '--pretty=%H %s',
+                                                   f'{up_to_git_ref}..HEAD',
+                                                   '--', patch_path)
+
+                for line in commits.splitlines():
+                    commit_hash, subject = line.split(' ', 1)
+                    if not any(
+                            subject.startswith(p)
+                            for p in _UPGRADE_COMMIT_WITH_PATCHES_PREFIXES):
+                        fixup_groups.setdefault(commit_hash,
+                                                []).append(patch_path)
+                        break
+
+            fixup_patches: set[str] = set()
+            for fixup_target, fixup_patch_paths in fixup_groups.items():
+                for patch_path in fixup_patch_paths:
+                    repository.brave.run_git('add', patch_path)
+                    fixup_patches.add(patch_path)
+                repository.brave.git_commit_fixup(fixup_target)
+
+            patch_paths -= fixup_patches
+
+        if patch_paths:
+            repository.brave.run_git('add', *patch_paths)
+            repository.brave.git_commit(commit_message, no_verify=no_verify)
+
+    def _commit_plaster_fixed_patches(self, apply_record: ApplyPatchesRecord):
+        """Commits patches that were fixed by plaster."""
+        patch_paths = {
+            path.as_posix()
+            for path in apply_record.plaster_fixed_patches
+        }
+        # Adding no_verify to avoid issues if someone is using an old version
+        # of the commit-msg hook that has not included this name as an
+        # exception for the branch tag.
+        self._commit_pinned_patches_and_fixups(
+            patch_paths,
+            f'Regen-fixed 🩹 patches from Chromium {self.base_version} '
+            f'to Chromium {self.target_version}.',
+            no_verify=True)
 
     def _run_update_patches(self) -> GitStatus:
         """Runs update_patches and returns the resulting GitStatus.
@@ -1458,6 +1577,9 @@ class Upgrade(Versioned):
             apply_record = (ContinuationFile.load(
                 self.target_version).apply_record)
 
+        if apply_record:
+            apply_record.check_broken_plasters_fixed()
+
         update_status = self._run_update_patches()
 
         # `apply_records` is not guaranteed to exist for every continuation. In
@@ -1474,52 +1596,17 @@ class Upgrade(Versioned):
                 if patch.path.as_posix() in update_status.unstaged.modified
             }
 
-            if (self.is_major()):
-                # When doing incremental lifts in branch, there can be cases
-                # where a patch has been added/changed by a particular fix in
-                # the branch, and therefore at this stage, it is more
-                # appropriate to commit that patch as a fixup to the last
-                # change in the branch that touched it, otherwise it will cause
-                # conflicts when doing `rebase --squash-minor-bumps`, with the
-                # conflict-resolved commit being moved above the last change
-                # for that patch.
-                up_to_git_ref = _solve_brave_ref('@previous-major')
-
-                fixup_groups: dict[str, list[str]] = {}
-                for patch_path in conflict_resolved_patches:
-                    commits = repository.brave.run_git(
-                        'log', '--pretty=%H %s', f'{up_to_git_ref}..HEAD',
-                        '--', patch_path)
-
-                    for line in commits.splitlines():
-                        commit_hash, subject = line.split(' ', 1)
-                        if (not subject.startswith(
-                                'Conflict-resolved patches from Chromium ')
-                                and not subject.startswith(
-                                    'Update patches from Chromium ')):
-                            fixup_groups.setdefault(commit_hash,
-                                                    []).append(patch_path)
-                            break
-
-                # Commit patches grouped by the target commit to avoid multiple
-                # fixups for the same change.
-                fixup_patches: set[str] = set()
-                for fixup_target, patch_paths in fixup_groups.items():
-                    for patch_path in patch_paths:
-                        repository.brave.run_git('add', patch_path)
-                        fixup_patches.add(patch_path)
-                    repository.brave.git_commit_fixup(fixup_target)
-
-                conflict_resolved_patches -= fixup_patches
-
         if not conflict_resolved_patches and not no_conflict_continuation:
             raise InvalidInputException(
                 'Nothing has been staged to commit conflict-resolved patches. '
                 '(Did you mean to pass [bold cyan]--no-conflict-change[/]?)')
 
         if conflict_resolved_patches:
-            repository.brave.run_git('add', *conflict_resolved_patches)
-            repository.brave.git_commit(
+            # For major upgrades, patches last touched by dev-cycle commits
+            # are routed as fixup! commits to avoid rebase conflicts when
+            # running rebase --squash-minor-bumps.
+            self._commit_pinned_patches_and_fixups(
+                conflict_resolved_patches,
                 f'Conflict-resolved patches from Chromium {self.base_version} '
                 f'to Chromium {self.target_version}.')
 
@@ -1606,6 +1693,8 @@ class Upgrade(Versioned):
                     and 'Exiting as not all patches were successful!'
                     in e.stderr.splitlines()[-1]):
                 apply_record = self.apply_patches_3way()
+                if apply_record.plaster_fixed_patches:
+                    self._commit_plaster_fixed_patches(apply_record)
                 if apply_record.requires_conflict_resolution():
                     # Manual resolution required.
                     raise ActionNeededException(
@@ -1697,7 +1786,16 @@ class Upgrade(Versioned):
                         target_version=self.target_version
                         ).create_or_update_version_issue(with_pr=False)
 
-        self._save_gnrt_rerun()
+        try:
+            terminal.run([sys.executable, plaster.__file__, 'check'])
+        except subprocess.CalledProcessError:
+            terminal.log_task(
+                '[bold]❌[/] Plaster check. Please investigate it.')
+
+        try:
+            self._save_gnrt_rerun()
+        except subprocess.CalledProcessError:
+            terminal.log_task('[bold]❌[/] GNRT rerun. Please investigate it.')
 
 
 def _solve_brave_ref(from_ref: Optional[str]) -> str:
@@ -1830,6 +1928,7 @@ class Rebase(Task):
         gnrt = []
         iwyu = []
         others = []
+        plaster_reruns = []
         reassign = []
         for line in lines:
             # Empty lines and comment lines are not interesting when doing the
@@ -1858,6 +1957,9 @@ class Rebase(Task):
             if comment.startswith('Update from Chromium '):
                 version.append(
                     line if not version else line.replace('pick', 'squash'))
+            elif comment.startswith('Regen-fixed 🩹 patches from Chromium '):
+                plaster_reruns.append(line if not plaster_reruns else line.
+                                      replace('pick', 'squash'))
             elif comment.startswith(
                     'Conflict-resolved patches from Chromium '):
                 conflict.append(
@@ -1874,7 +1976,8 @@ class Rebase(Task):
                 others.append(line)
 
         # Merging all categories in the desired order.
-        new_todo_file = version + conflict + gnrt + iwyu + others
+        new_todo_file = (version + plaster_reruns + conflict + gnrt + iwyu +
+                         others)
 
         # Looking for every occurrence of lines starting with `reassign! `,
         # taking the commit message after it, and looking for the the first

--- a/tools/cr/brockit_test.py
+++ b/tools/cr/brockit_test.py
@@ -188,23 +188,20 @@ class BrockitTest(unittest.TestCase):
                     brockit.Patchfile(path=self.fake_chromium_src.
                                       get_patchfile_path_for_source(
                                           self.fake_chromium_src.chromium,
-                                          test_file_chromium),
-                                      source=test_file_chromium)
+                                          test_file_chromium))
                 ],
                 self.fake_chromium_src.chromium / 'v8': [
                     brockit.Patchfile(path=self.fake_chromium_src.
                                       get_patchfile_path_for_source(
                                           self.fake_chromium_src.chromium /
-                                          'v8', test_file_v8),
-                                      source=test_file_v8)
+                                          'v8', test_file_v8))
                 ],
                 self.fake_chromium_src.chromium / 'third_party/test1': [
-                    brockit.Patchfile(path=self.fake_chromium_src.
-                                      get_patchfile_path_for_source(
-                                          self.fake_chromium_src.chromium /
-                                          'third_party/test1',
-                                          test_file_third_party),
-                                      source=test_file_third_party)
+                    brockit.Patchfile(
+                        path=self.fake_chromium_src.
+                        get_patchfile_path_for_source(
+                            self.fake_chromium_src.chromium /
+                            'third_party/test1', test_file_third_party))
                 ],
             })
 

--- a/tools/cr/commit-msg.py
+++ b/tools/cr/commit-msg.py
@@ -65,6 +65,7 @@ import re
 
 PREFIXES_FOR_UPGRADE_COMMITS = [
     'Update from Chromium ',
+    'Regen-fixed 🩹 patches from Chromium ',
     'Conflict-resolved patches from Chromium ',
     'Update patches from Chromium ',
     'Updated strings for Chromium ',

--- a/tools/cr/git_cr_follow_renames.py
+++ b/tools/cr/git_cr_follow_renames.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import argparse
 import logging
 from pathlib import Path
+import subprocess
 
 from incendiary_error_handler import IncendiaryErrorHandler
 import plaster
@@ -89,6 +90,7 @@ def cmd_follow_renames(args: list[str]) -> int:
         _repair_plaster_files(old_chromium, new_chromium, parsed.no_git,
                               not parsed.no_run_plaster)
         update_references(old_chromium, new_chromium)
+        _repair_patch_files(old_chromium, new_chromium, parsed.no_git)
 
     console.log(f'[bold green]✔[/] {len(renames)} rename(s) processed')
     return 0
@@ -205,9 +207,67 @@ def _repair_plaster_files(old_chromium: Path,
             patch_file.unlink()
         else:
             repository.brave.run_git('rm', str(patch_file))
+        patchinfo_file = patch_file.with_suffix('.patchinfo')
+        if patchinfo_file.exists():
+            patchinfo_file.unlink()
 
     if run_plaster:
         try:
             PlasterFile(new_toml).apply()
+            if not no_git:
+                new_patch = (repository.BRAVE_CORE_PATH / 'patches' /
+                             patch_name_for(new_chromium))
+                if new_patch.exists():
+                    repository.brave.run_git('add', str(new_patch))
         except (Exception, SystemExit) as e:
             logging.warning('plaster failed to apply %s: %s', new_toml, e)
+
+
+def _repair_patch_files(old_chromium: Path, new_chromium: Path,
+                        no_git: bool) -> None:
+    """Renames and re-applies the .patch file for one upstream rename.
+
+    If no patch file exists at patches/patch_name_for(old_chromium), this is
+    a no-op. Patches already handled by _repair_plaster_files will have been
+    deleted before this runs, so they are naturally skipped.
+
+    The patch --- and +++ headers are updated to reference the new chromium
+    path, the file is renamed, then git apply --3way is attempted. A warning
+    is logged if the apply fails.
+    """
+    patches_path = repository.BRAVE_CORE_PATH / 'patches'
+    old_patch = patches_path / patch_name_for(old_chromium)
+    if not old_patch.exists():
+        return
+
+    new_patch = patches_path / patch_name_for(new_chromium)
+    new_patch.parent.mkdir(parents=True, exist_ok=True)
+
+    old_path_str = old_chromium.as_posix()
+    new_path_str = new_chromium.as_posix()
+    updated_lines = []
+    for line in old_patch.read_text(encoding='utf-8').splitlines(
+            keepends=True):
+        if (line.startswith('diff --git ') or line.startswith('--- ')
+                or line.startswith('+++ ')):
+            line = line.replace(old_path_str, new_path_str)
+        updated_lines.append(line)
+    updated_content = ''.join(updated_lines)
+
+    if no_git:
+        old_patch.rename(new_patch)
+    else:
+        repository.brave.run_git('mv', str(old_patch), str(new_patch))
+    new_patch.write_text(updated_content, encoding='utf-8')
+    if not no_git:
+        repository.brave.run_git('add', str(new_patch))
+
+    try:
+        repository.chromium.run_git('apply', '--3way', '--ignore-space-change',
+                                    '--ignore-whitespace', str(new_patch))
+    except subprocess.CalledProcessError as e:
+        logging.warning('Failed to apply %s after rename: %s', new_patch,
+                        e.stderr.strip() if e.stderr else str(e))
+    finally:
+        repository.chromium.run_git('reset', 'HEAD', '--',
+                                    new_chromium.as_posix())

--- a/tools/cr/git_cr_follow_renames_test.py
+++ b/tools/cr/git_cr_follow_renames_test.py
@@ -15,6 +15,7 @@ import repository
 from git_cr_follow_renames import (
     _collapse_renames,
     _get_chromium_renames,
+    _repair_patch_files,
     _repair_plaster_files,
     cmd_follow_renames,
 )
@@ -272,6 +273,21 @@ class TomlTest(_Base):
             (self._brave / 'rewrite' / 'A' / 'foo.h.toml').exists())
         self.assertFalse((self._brave / 'patches' / 'A-foo.h.patch').exists())
 
+    def test_patchinfo_deleted_with_patch(self) -> None:
+        """Sibling .patchinfo is removed when the patch is deleted."""
+        before = self._chromium_head()
+        self._chromium_commit('A/foo.h', '// src\n')
+        self._brave_commit('rewrite/A/foo.h.toml', '[substitution]\n')
+        self._brave_commit('patches/A-foo.h.patch', 'diff\n')
+        patchinfo = self._brave / 'patches' / 'A-foo.h.patchinfo'
+        patchinfo.write_text('{}', encoding='utf-8')
+        self._chromium_rename('A/foo.h', 'B/foo.h')
+
+        cmd_follow_renames([f'{before}..HEAD'])
+
+        self.assertFalse((self._brave / 'patches' / 'A-foo.h.patch').exists())
+        self.assertFalse(patchinfo.exists())
+
     def test_missing_patch_warns_no_error(self) -> None:
         """TOML exists but patch is absent: warning logged, TOML still moves."""
         before = self._chromium_head()
@@ -471,6 +487,8 @@ class PlasterApplyTest(_Base):
         content = new_patch.read_text(encoding='utf-8')
         self.assertIn('-void old_func() {}', content)
         self.assertIn('+void new_func() {}', content)
+        staged = repository.brave.run_git('diff', '--cached', '--name-only')
+        self.assertIn('patches/B-foo.cc.patch', staged)
 
     def test_no_run_plaster_skips_patch_creation(self) -> None:
         """--no-run-plaster: no new patch file is created after TOML move."""
@@ -483,6 +501,141 @@ class PlasterApplyTest(_Base):
         cmd_follow_renames(['--no-run-plaster', f'{before}..HEAD'])
 
         self.assertFalse((self._brave / 'patches' / 'B-foo.cc.patch').exists())
+
+
+# ---------------------------------------------------------------------------
+# .patch file repair tests
+# ---------------------------------------------------------------------------
+
+
+class PatchFileRepairTest(_Base):
+    """_repair_patch_files renames .patch files and attempts re-apply."""
+
+    _OLD_REL = 'A/foo.cc'
+    _NEW_REL = 'B/foo.cc'
+    _FILE_CONTENT = 'int x = 1;\n'
+    # Real brave patch format with diff --git header and index line.
+    _PATCH_TEMPLATE = ('diff --git a/{path} b/{path}\n'
+                       'index abc1234..def5678 100644\n'
+                       '--- a/{path}\n'
+                       '+++ b/{path}\n'
+                       '@@ -1 +1 @@\n'
+                       '-int x = 1;\n'
+                       '+int x = 2;\n')
+
+    def _setup_rename(self) -> str:
+        """Commits file + patch in their repos, renames in chromium."""
+        before = self._chromium_head()
+        self._chromium_commit(self._OLD_REL, self._FILE_CONTENT)
+        patch_content = self._PATCH_TEMPLATE.format(path=self._OLD_REL)
+        self._brave_commit('patches/A-foo.cc.patch', patch_content)
+        self._chromium_rename(self._OLD_REL, self._NEW_REL)
+        return before
+
+    def test_patch_renamed_to_new_path(self) -> None:
+        """Patch file is renamed from the old chromium name to the new one."""
+        before = self._setup_rename()
+
+        cmd_follow_renames([f'{before}..HEAD'])
+
+        self.assertFalse((self._brave / 'patches' / 'A-foo.cc.patch').exists())
+        self.assertTrue((self._brave / 'patches' / 'B-foo.cc.patch').exists())
+
+    def test_patch_headers_updated(self) -> None:
+        """diff --git, --- and +++ headers are rewritten to the new path."""
+        before = self._setup_rename()
+
+        cmd_follow_renames([f'{before}..HEAD'])
+
+        content = (self._brave / 'patches' /
+                   'B-foo.cc.patch').read_text(encoding='utf-8')
+        self.assertIn('diff --git a/B/foo.cc b/B/foo.cc', content)
+        self.assertIn('--- a/B/foo.cc', content)
+        self.assertIn('+++ b/B/foo.cc', content)
+        self.assertNotIn('A/foo.cc', content)
+
+    def test_patch_applied_and_unstaged(self) -> None:
+        """Patch is applied to the working tree but not left staged."""
+        before = self._setup_rename()
+
+        cmd_follow_renames([f'{before}..HEAD'])
+
+        # Working tree has the patched content.
+        content = (self._chromium / 'B' / 'foo.cc').read_text(encoding='utf-8')
+        self.assertIn('int x = 2;', content)
+        # The change must not be staged in chromium.
+        staged = repository.chromium.run_git('diff', '--cached', '--name-only')
+        self.assertEqual(staged, '')
+
+    def test_no_patch_is_noop(self) -> None:
+        """No patch for the renamed file → step is a no-op, no error."""
+        before = self._chromium_head()
+        self._chromium_commit(self._OLD_REL, self._FILE_CONTENT)
+        self._chromium_rename(self._OLD_REL, self._NEW_REL)
+
+        cmd_follow_renames([f'{before}..HEAD'])  # Must not raise.
+
+        self.assertFalse((self._brave / 'patches' / 'B-foo.cc.patch').exists())
+
+    def test_failed_apply_warns(self) -> None:
+        """A patch whose context doesn't match the file logs a warning."""
+        before = self._chromium_head()
+        self._chromium_commit(self._OLD_REL, 'completely_different\n')
+        patch_content = self._PATCH_TEMPLATE.format(path=self._OLD_REL)
+        self._brave_commit('patches/A-foo.cc.patch', patch_content)
+        self._chromium_rename(self._OLD_REL, self._NEW_REL)
+
+        with self.assertLogs(level=logging.WARNING):
+            cmd_follow_renames([f'{before}..HEAD'])
+
+        # Patch is still renamed even though apply failed.
+        self.assertTrue((self._brave / 'patches' / 'B-foo.cc.patch').exists())
+
+    def test_no_git_renames_without_staging(self) -> None:
+        """--no-git moves the patch via Path.rename; nothing is staged."""
+        before = self._setup_rename()
+
+        cmd_follow_renames(['--no-git', f'{before}..HEAD'])
+
+        self.assertFalse((self._brave / 'patches' / 'A-foo.cc.patch').exists())
+        self.assertTrue((self._brave / 'patches' / 'B-foo.cc.patch').exists())
+        staged = repository.brave.run_git('diff', '--cached', '--name-only')
+        self.assertNotIn('B-foo.cc.patch', staged)
+
+    def test_plaster_patch_not_double_processed(self) -> None:
+        """Patch deleted by _repair_plaster_files is not re-renamed here."""
+        _SUBST_TOML = ('[[substitution]]\n'
+                       'description = "test"\n'
+                       'pattern = "old_func"\n'
+                       'replace = "new_func"\n')
+        before = self._chromium_head()
+        self._chromium_commit(self._OLD_REL, 'void old_func() {}\n')
+        self._brave_commit('rewrite/A/foo.cc.toml', _SUBST_TOML)
+        self._brave_commit('patches/A-foo.cc.patch', 'stale patch\n')
+        self._chromium_rename(self._OLD_REL, self._NEW_REL)
+
+        cmd_follow_renames([f'{before}..HEAD'])
+
+        # Plaster created a proper patch; _repair_patch_files must not
+        # overwrite it with the stale content.
+        new_patch = self._brave / 'patches' / 'B-foo.cc.patch'
+        self.assertTrue(new_patch.exists())
+        content = new_patch.read_text(encoding='utf-8')
+        self.assertNotEqual(content, 'stale patch\n')
+
+    def test_repair_patch_files_direct_call(self) -> None:
+        """_repair_patch_files can be called directly."""
+        self._chromium_commit(self._OLD_REL, self._FILE_CONTENT)
+        patch_content = self._PATCH_TEMPLATE.format(path=self._OLD_REL)
+        self._brave_commit('patches/A-foo.cc.patch', patch_content)
+        self._chromium_rename(self._OLD_REL, self._NEW_REL)
+
+        _repair_patch_files(Path(self._OLD_REL),
+                            Path(self._NEW_REL),
+                            no_git=False)
+
+        self.assertFalse((self._brave / 'patches' / 'A-foo.cc.patch').exists())
+        self.assertTrue((self._brave / 'patches' / 'B-foo.cc.patch').exists())
 
 
 if __name__ == '__main__':

--- a/tools/cr/git_cr_mv.py
+++ b/tools/cr/git_cr_mv.py
@@ -192,9 +192,19 @@ def _step5_plaster(file_pairs: list[_FilePair], no_git: bool,
                 patch_file.unlink()
             else:
                 repository.brave.run_git('rm', str(patch_file))
+            patchinfo_file = patch_file.with_suffix('.patchinfo')
+            if patchinfo_file.exists():
+                patchinfo_file.unlink()
 
         if run_plaster:
             try:
                 PlasterFile(new_file).apply()
+                if not no_git:
+                    new_chromium_path = new_file.relative_to(
+                        rewrite_path).with_suffix('')
+                    new_patch = patches_path / patch_name_for(
+                        new_chromium_path)
+                    if new_patch.exists():
+                        repository.brave.run_git('add', str(new_patch))
             except (Exception, SystemExit) as e:
                 logging.warning('plaster failed to apply %s: %s', new_file, e)

--- a/tools/cr/git_cr_mv_test.py
+++ b/tools/cr/git_cr_mv_test.py
@@ -300,6 +300,18 @@ class PlasterTest(_Base):
         self.assertTrue(
             (self._brave / 'rewrite' / 'B' / 'foo.h.toml').exists())
 
+    def test_patchinfo_deleted_with_patch(self) -> None:
+        """Sibling .patchinfo is removed when the patch is deleted."""
+        self._commit('rewrite/A/foo.h.toml', '[substitution]\n')
+        self._commit('patches/A-foo.h.patch', 'diff --git a/foo\n')
+        patchinfo = self._brave / 'patches' / 'A-foo.h.patchinfo'
+        patchinfo.write_text('{}', encoding='utf-8')
+
+        cmd_mv(['--mkdir', 'rewrite/A/foo.h.toml', 'rewrite/B/foo.h.toml'])
+
+        self.assertFalse((self._brave / 'patches' / 'A-foo.h.patch').exists())
+        self.assertFalse(patchinfo.exists())
+
     def test_missing_patch_warns_no_error(self) -> None:
         """Moving a TOML whose patch is absent warns but does not raise."""
         self._commit('rewrite/A/foo.h.toml', '[substitution]\n')
@@ -452,6 +464,8 @@ class PlasterApplyTest(_Base):
         content = new_patch.read_text(encoding='utf-8')
         self.assertIn('-void old_func() {}', content)
         self.assertIn('+void new_func() {}', content)
+        staged = repository.brave.run_git('diff', '--cached', '--name-only')
+        self.assertIn('patches/B-foo.cc.patch', staged)
 
     def test_no_upstream_source_logs_warning(self) -> None:
         """Warning is logged when the chromium source for the new path is

--- a/tools/cr/patchfile.py
+++ b/tools/cr/patchfile.py
@@ -11,6 +11,7 @@ import re
 import subprocess
 from typing import Optional
 
+from plaster import PlasterFile
 from repository import Repository
 import repository
 
@@ -30,14 +31,32 @@ class Patchfile:
 
     # The source file this patch targets, relative to the patch's repository.
     # e.g. "build/android/gyp/dex.py"
-    source: Path
+    source: Path = field(init=False)
 
     # The repository the patch file is targeting to patch.
     repository: Repository = field(init=False)
 
+    # Path to the plaster (.toml) file for this patch, relative to the
+    # brave-core root.
+    plaster: Optional[Path] = field(init=False)
+
     def __post_init__(self):
         object.__setattr__(self, 'repository',
                            self.get_repository_from_patch_name())
+
+        sources = self.repository.get_patch_stats(self.path_from_repo())
+        if len(sources) != 1:
+            raise ValueError(
+                f'Expected exactly one source for {self.path}, got {sources}.')
+        object.__setattr__(self, 'source', sources[0])
+
+        plaster = None
+        if self.repository.is_chromium:
+            candidate = (Path('rewrite') / self.source.parent /
+                         (self.source.name + '.toml'))
+            if (repository.BRAVE_CORE_PATH / candidate).exists():
+                plaster = candidate
+        object.__setattr__(self, 'plaster', plaster)
 
     def get_repository_from_patch_name(self) -> Repository:
         """Gets the repository for the patch file.
@@ -70,6 +89,12 @@ class Patchfile:
         # The patch failed as broken.
         BROKEN = auto()
 
+        # The patch failed but plaster successfully resolved it.
+        PLASTER_FIXED = auto()
+
+        # The patch failed and plaster was unable to resolve it.
+        PLASTER_BROKEN = auto()
+
     @dataclass
     class SourceStatus:
         """The status of the source file in a given commit.
@@ -83,6 +108,11 @@ class Patchfile:
 
         # The name the source may have been renamed to.
         renamed_to: Optional[str] = None
+
+    @property
+    def has_plaster(self) -> bool:
+        """Whether this patch has an associated plaster file."""
+        return self.plaster is not None
 
     def source_name_from_patch_naming(self) -> str:
         """Source file name according to the patch file name.
@@ -117,6 +147,8 @@ class Patchfile:
             return self.ApplyStatus.CLEAN
         except subprocess.CalledProcessError as e:
             if 'with conflicts' in e.stderr:
+                if self.has_plaster:
+                    return self.plaster_apply()
                 return self.ApplyStatus.CONFLICT
             error_line = next(
                 (l for l in e.stderr.splitlines() if l.startswith('error:')),
@@ -131,10 +163,6 @@ class Patchfile:
                     #
                     # It is also of notice that this error can also occur when
                     # `apply` is run twice for the same patch with conflicts.
-                    logging.warning(
-                        'Patch with missing file detected during --3way apply,'
-                        ' which may indicate a bad sync state before starting '
-                        'to upgrade. %s', self.path)
                     return self.ApplyStatus.DELETED
                 if ('No such file or directory' in reason
                         and self.path.as_posix() in reason):
@@ -153,11 +181,33 @@ class Patchfile:
                         'Patch being flagged as broken, but with unexpected '
                         'reason: %s %s', self.path, reason)
 
+                if self.has_plaster:
+                    return self.plaster_apply()
                 return self.ApplyStatus.BROKEN
 
         # We should not reach this point. Failures to apply that fail like this
         # must be investigated with `--verbose`, and fixed.
         raise NotImplementedError()
+
+    def plaster_apply(self) -> ApplyStatus:
+        """Attempts to apply the associated plaster file.
+
+        Returns PLASTER_FIXED on success, PLASTER_BROKEN on any failure.
+        """
+        if not self.has_plaster:
+            raise NotImplementedError(f'No plaster file for {self.path}.')
+
+        try:
+            # A failed --3way apply leaves the file in unmerged conflict state
+            # in the index, which causes `git diff` inside PlasterFile.apply()
+            # to produce a combined diff --cc instead of a normal unified diff.
+            # Checking out HEAD resolves the index conflict first.
+            self.repository.run_git('checkout', 'HEAD', '--',
+                                    self.source.as_posix())
+            PlasterFile(repository.BRAVE_CORE_PATH / self.plaster).apply()
+            return self.ApplyStatus.PLASTER_FIXED
+        except Exception:
+            return self.ApplyStatus.PLASTER_BROKEN
 
     def get_last_commit_for_source(self) -> str:
         """Gets the last commit where the source file was mentioned.

--- a/tools/cr/patchfile_test.py
+++ b/tools/cr/patchfile_test.py
@@ -22,46 +22,65 @@ class PatchfileTest(unittest.TestCase):
         self.fake_chromium_src.setup()
         self.fake_chromium_src.add_dep('v8')
         self.fake_chromium_src.add_dep('third_party/test1')
+        self.fake_chromium_src.add_dep('third_party/devtools-frontend/src')
         self.addCleanup(self.fake_chromium_src.cleanup)
 
     def test_get_repository_from_patch_name(self):
         """Test the result of get_repository_from_patch_name"""
+        dex_py = Path('build/android/gyp/dex.py')
+        for repo in [
+                self.fake_chromium_src.chromium,
+                self.fake_chromium_src.chromium / 'v8',
+                self.fake_chromium_src.chromium / 'third_party/test1'
+        ]:
+            self.fake_chromium_src.write_and_stage_file(
+                dex_py, 'original\n', repo)
+            self.fake_chromium_src.commit('Add dex.py', repo)
+            (repo / dex_py).write_text('original\nbrave_change\n')
+        self.fake_chromium_src.run_update_patches()
+
         patchfile = Patchfile(
-            path=Path("patches/build-android-gyp-dex.py.patch"),
-            source=Path("build/android/gyp/dex.py"))
+            path=Path("patches/build-android-gyp-dex.py.patch"))
         self.assertEqual(patchfile.get_repository_from_patch_name(),
                          repository.chromium)
 
         patchfile = Patchfile(
-            path=Path("patches/v8/build-android-gyp-dex.py.patch"),
-            source=Path("build/android/gyp/dex.py"))
+            path=Path("patches/v8/build-android-gyp-dex.py.patch"))
         self.assertEqual(patchfile.get_repository_from_patch_name(),
                          Repository(self.fake_chromium_src.chromium / 'v8'))
 
         patchfile = Patchfile(path=Path(
-            "patches/third_party/test1/build-android-gyp-dex.py.patch"),
-                              source=Path("build/android/gyp/dex.py"))
+            "patches/third_party/test1/build-android-gyp-dex.py.patch"))
         self.assertEqual(
             patchfile.get_repository_from_patch_name(),
             Repository(self.fake_chromium_src.chromium / 'third_party/test1'))
 
     def test_source_name_from_patch_naming(self):
         """Test patched file name name heuristics."""
+        dex_py = Path('build/android/gyp/dex.py')
+        for repo in [
+                self.fake_chromium_src.chromium,
+                self.fake_chromium_src.chromium / 'v8',
+                self.fake_chromium_src.chromium / 'third_party/test1'
+        ]:
+            self.fake_chromium_src.write_and_stage_file(
+                dex_py, 'original\n', repo)
+            self.fake_chromium_src.commit('Add dex.py', repo)
+            (repo / dex_py).write_text('original\nbrave_change\n')
+        self.fake_chromium_src.run_update_patches()
+
         patchfile = Patchfile(
-            path=Path("patches/build-android-gyp-dex.py.patch"),
-            source=Path("build/android/gyp/dex.py"))
+            path=Path("patches/build-android-gyp-dex.py.patch"))
         self.assertEqual(patchfile.source_name_from_patch_naming(),
                          "build/android/gyp/dex.py")
 
         patchfile = Patchfile(
-            path=Path("patches/v8/build-android-gyp-dex.py.patch"),
-            source=Path("build/android/gyp/dex.py"))
+            path=Path("patches/v8/build-android-gyp-dex.py.patch"))
         self.assertEqual(patchfile.source_name_from_patch_naming(),
                          "build/android/gyp/dex.py")
 
         patchfile = Patchfile(path=Path(
-            "patches/third_party/test1/build-android-gyp-dex.py.patch"),
-                              source=Path("build/android/gyp/dex.py"))
+            "patches/third_party/test1/build-android-gyp-dex.py.patch"))
         self.assertEqual(patchfile.source_name_from_patch_naming(),
                          "build/android/gyp/dex.py")
 
@@ -115,8 +134,7 @@ class PatchfileTest(unittest.TestCase):
         self.assertNotIn('FROM_BRAVE_STORE', target_file.read_text())
         patchfile = Patchfile(
             path=self.fake_chromium_src.get_patchfile_path_for_source(
-                self.fake_chromium_src.chromium, test_idl),
-            source=test_idl)
+                self.fake_chromium_src.chromium, test_idl))
         status = patchfile.apply()
         self.assertEqual(status, Patchfile.ApplyStatus.CONFLICT)
 
@@ -177,8 +195,7 @@ class PatchfileTest(unittest.TestCase):
         self.assertNotIn('FROM_BRAVE_STORE', target_file.read_text())
         patchfile = Patchfile(
             path=self.fake_chromium_src.get_patchfile_path_for_source(
-                self.fake_chromium_src.chromium, test_idl),
-            source=test_idl)
+                self.fake_chromium_src.chromium, test_idl))
         status = patchfile.apply()
         self.assertEqual(status, Patchfile.ApplyStatus.CONFLICT)
 
@@ -253,8 +270,7 @@ class PatchfileTest(unittest.TestCase):
         self.assertNotIn('FROM_BRAVE_STORE', target_file.read_text())
         patchfile = Patchfile(
             path=self.fake_chromium_src.get_patchfile_path_for_source(
-                self.fake_chromium_src.chromium, test_idl),
-            source=test_idl)
+                self.fake_chromium_src.chromium, test_idl))
         status = patchfile.apply()
         self.assertEqual(status, Patchfile.ApplyStatus.CLEAN)
         self.assertIn('FROM_BRAVE_STORE', target_file.read_text())
@@ -279,8 +295,7 @@ class PatchfileTest(unittest.TestCase):
 
         patchfile = Patchfile(
             path=self.fake_chromium_src.get_patchfile_path_for_source(
-                self.fake_chromium_src.chromium, test_idl),
-            source=test_idl)
+                self.fake_chromium_src.chromium, test_idl))
         status = patchfile.apply()
         self.assertEqual(status, Patchfile.ApplyStatus.CLEAN)
         self.assertIn('last line', target_file.read_text())
@@ -295,10 +310,8 @@ class PatchfileTest(unittest.TestCase):
                             self.fake_chromium_src.chromium, test_idl))
         target_patch.write_text(target_patch.read_text().strip())
 
-        patchfile = Patchfile(
-            path=self.fake_chromium_src.get_patchfile_path_for_source(
-                self.fake_chromium_src.chromium, test_idl),
-            source=test_idl)
+        # apply() reads the patch from disk at call time, so the same
+        # Patchfile instance applies the now-broken patch.
         status = patchfile.apply()
         self.assertEqual(status, Patchfile.ApplyStatus.BROKEN)
 
@@ -322,8 +335,7 @@ class PatchfileTest(unittest.TestCase):
 
         patchfile = Patchfile(
             path=self.fake_chromium_src.get_patchfile_path_for_source(
-                self.fake_chromium_src.chromium, test_idl),
-            source=test_idl)
+                self.fake_chromium_src.chromium, test_idl))
         status = patchfile.apply()
         self.assertEqual(status, Patchfile.ApplyStatus.CLEAN)
         self.assertIn('last line', target_file.read_text())
@@ -340,8 +352,7 @@ class PatchfileTest(unittest.TestCase):
 
         patchfile = Patchfile(
             path=self.fake_chromium_src.get_patchfile_path_for_source(
-                self.fake_chromium_src.chromium, test_idl),
-            source=test_idl)
+                self.fake_chromium_src.chromium, test_idl))
         status = patchfile.apply()
         self.assertEqual(status, Patchfile.ApplyStatus.DELETED)
 
@@ -369,8 +380,7 @@ class PatchfileTest(unittest.TestCase):
         # Sanity-check: patch applies cleanly before we delete the file.
         patchfile = Patchfile(
             path=self.fake_chromium_src.get_patchfile_path_for_source(
-                self.fake_chromium_src.chromium, test_idl),
-            source=test_idl)
+                self.fake_chromium_src.chromium, test_idl))
         status = patchfile.apply()
         self.assertEqual(status, Patchfile.ApplyStatus.CLEAN)
         self.assertIn('last line', target_file.read_text())
@@ -387,46 +397,65 @@ class PatchfileTest(unittest.TestCase):
 
         patchfile = Patchfile(
             path=self.fake_chromium_src.get_patchfile_path_for_source(
-                self.fake_chromium_src.chromium, test_idl),
-            source=test_idl)
+                self.fake_chromium_src.chromium, test_idl))
         status = patchfile.apply()
         self.assertEqual(status, Patchfile.ApplyStatus.DELETED)
 
     def test_source_from_brave(self):
         """Tests the source_from_brave method of Patchfile."""
+        dex_py = Path('build/android/gyp/dex.py')
+        devtools_ts = Path(
+            'front_end/panels/timeline/components/LiveMetricsView.ts')
+        devtools_repo = (self.fake_chromium_src.chromium /
+                         'third_party/devtools-frontend/src')
+        for repo, source in [
+            (self.fake_chromium_src.chromium, dex_py),
+            (self.fake_chromium_src.chromium / 'v8', dex_py),
+            (devtools_repo, devtools_ts),
+        ]:
+            self.fake_chromium_src.write_and_stage_file(
+                source, 'original\n', repo)
+            self.fake_chromium_src.commit(f'Add {source.name}', repo)
+            (repo / source).write_text('original\nbrave_change\n')
+        self.fake_chromium_src.run_update_patches()
+
         self.assertEqual(
-            Patchfile(path=Path('patches/v8/build-android-gyp-dex.py.patch'),
-                      source=Path('build/android/gyp/dex.py')).
+            Patchfile(path=Path('patches/v8/build-android-gyp-dex.py.patch')).
             source_from_brave().as_posix(), '../v8/build/android/gyp/dex.py')
         self.assertEqual(
-            Patchfile(path=Path('patches/build-android-gyp-dex.py.patch'),
-                      source=Path('build/android/gyp/dex.py')).
+            Patchfile(path=Path('patches/build-android-gyp-dex.py.patch')).
             source_from_brave().as_posix(), '../build/android/gyp/dex.py')
 
-        _devtools_patch = (
-            'patches/third_party/devtools-frontend/src/'
-            'front_end-panels-timeline-components-LiveMetricsView.ts.patch')
+        _devtools_patch = ('patches/third_party/devtools-frontend/src/'
+                           'front_end-panels-timeline-components-'
+                           'LiveMetricsView.ts.patch')
         _devtools_source = (
             'front_end/panels/timeline/components/LiveMetricsView.ts')
         self.assertEqual(
             Patchfile(
-                path=Path(_devtools_patch),
-                source=Path(_devtools_source)).source_from_brave().as_posix(),
+                path=Path(_devtools_patch)).source_from_brave().as_posix(),
             '../third_party/devtools-frontend/src/' + _devtools_source)
 
     def test_path_from_repo(self):
         """Tests the path_from_repo method of Patchfile."""
+        dex_py = Path('build/android/gyp/dex.py')
+        for repo in [
+                self.fake_chromium_src.chromium,
+                self.fake_chromium_src.chromium / 'v8'
+        ]:
+            self.fake_chromium_src.write_and_stage_file(
+                dex_py, 'original\n', repo)
+            self.fake_chromium_src.commit('Add dex.py', repo)
+            (repo / dex_py).write_text('original\nbrave_change\n')
+        self.fake_chromium_src.run_update_patches()
+
         self.assertEqual(
-            Patchfile(
-                path=Path('patches/v8/build-android-gyp-dex.py.patch'),
-                source=Path(
-                    'build/android/gyp/dex.py')).path_from_repo().as_posix(),
+            Patchfile(path=Path('patches/v8/build-android-gyp-dex.py.patch')
+                      ).path_from_repo().as_posix(),
             '../brave/patches/v8/build-android-gyp-dex.py.patch')
         self.assertEqual(
-            Patchfile(
-                path=Path('patches/build-android-gyp-dex.py.patch'),
-                source=Path(
-                    'build/android/gyp/dex.py')).path_from_repo().as_posix(),
+            Patchfile(path=Path('patches/build-android-gyp-dex.py.patch')
+                      ).path_from_repo().as_posix(),
             'brave/patches/build-android-gyp-dex.py.patch')
 
     def test_get_last_commit_for_source(self):
@@ -463,7 +492,7 @@ class PatchfileTest(unittest.TestCase):
         # Verify the last commit for the source matches the initial commit hash
         patchfile_path = self.fake_chromium_src.get_patchfile_path_for_source(
             self.fake_chromium_src.chromium, test_file)
-        patchfile = Patchfile(path=patchfile_path, source=test_file)
+        patchfile = Patchfile(path=patchfile_path)
         self.assertEqual(patchfile.get_last_commit_for_source(),
                          initial_commit_hash)
 
@@ -481,7 +510,7 @@ class PatchfileTest(unittest.TestCase):
                                             self.fake_chromium_src.chromium)
 
         # Get the patch file path
-        patchfile = Patchfile(path=patchfile_path, source=test_file)
+        patchfile = Patchfile(path=patchfile_path)
 
         # Verify the last commit for the source matches the delete commit hash
         self.assertEqual(patchfile.get_last_commit_for_source(),
@@ -527,7 +556,7 @@ class PatchfileTest(unittest.TestCase):
         # Get the patch file path
         patchfile_path = self.fake_chromium_src.get_patchfile_path_for_source(
             self.fake_chromium_src.chromium, test_file)
-        patchfile = Patchfile(path=patchfile_path, source=test_file)
+        patchfile = Patchfile(path=patchfile_path)
 
         # Add a few more empty commits
         self.fake_chromium_src.commit_empty('Empty commit 3',
@@ -587,7 +616,7 @@ class PatchfileTest(unittest.TestCase):
         # Get the patch file path
         patchfile_path = self.fake_chromium_src.get_patchfile_path_for_source(
             self.fake_chromium_src.chromium, test_file)
-        patchfile = Patchfile(path=patchfile_path, source=test_file)
+        patchfile = Patchfile(path=patchfile_path)
 
         # Add a few more empty commits
         self.fake_chromium_src.commit_empty('Empty commit 3',
@@ -601,6 +630,174 @@ class PatchfileTest(unittest.TestCase):
         self.assertIn('Rename developer_private.idl to renamed_private.idl',
                       rename_status.commit_details)
         self.assertEqual(rename_status.renamed_to, renamed_file.as_posix())
+
+    def test_plaster_set_when_file_exists(self):
+        """Plaster path is set for a Chromium patch when the toml exists."""
+        test_file = Path('chrome/browser/foo.cc')
+        self.fake_chromium_src.write_and_stage_file(
+            test_file, 'original\n', self.fake_chromium_src.chromium)
+        self.fake_chromium_src.commit('Add foo.cc',
+                                      self.fake_chromium_src.chromium)
+        (self.fake_chromium_src.chromium /
+         test_file).write_text('original\nbrave_change\n')
+        self.fake_chromium_src.run_update_patches()
+
+        plaster_path = (self.fake_chromium_src.brave /
+                        'rewrite/chrome/browser/foo.cc.toml')
+        plaster_path.parent.mkdir(parents=True, exist_ok=True)
+        plaster_path.write_text('')
+
+        patchfile = Patchfile(
+            path=self.fake_chromium_src.get_patchfile_path_for_source(
+                self.fake_chromium_src.chromium, test_file))
+        self.assertEqual(patchfile.plaster,
+                         Path('rewrite/chrome/browser/foo.cc.toml'))
+
+    def test_plaster_none_when_file_missing(self):
+        """Plaster is None for a Chromium patch when no toml file exists."""
+        test_file = Path('chrome/browser/foo.cc')
+        self.fake_chromium_src.write_and_stage_file(
+            test_file, 'original\n', self.fake_chromium_src.chromium)
+        self.fake_chromium_src.commit('Add foo.cc',
+                                      self.fake_chromium_src.chromium)
+        (self.fake_chromium_src.chromium /
+         test_file).write_text('original\nbrave_change\n')
+        self.fake_chromium_src.run_update_patches()
+
+        patchfile = Patchfile(
+            path=self.fake_chromium_src.get_patchfile_path_for_source(
+                self.fake_chromium_src.chromium, test_file))
+        self.assertIsNone(patchfile.plaster)
+
+    def test_plaster_none_for_non_chromium_repo(self):
+        """Plaster is None for patches targeting a sub-repository."""
+        test_file = Path('src/foo.cc')
+        v8 = self.fake_chromium_src.chromium / 'v8'
+        self.fake_chromium_src.write_and_stage_file(test_file, 'original\n',
+                                                    v8)
+        self.fake_chromium_src.commit('Add foo.cc', v8)
+        (v8 / test_file).write_text('original\nbrave_change\n')
+        self.fake_chromium_src.run_update_patches()
+
+        # Create a toml file that would match if the repo check were absent.
+        plaster_path = self.fake_chromium_src.brave / 'rewrite/src/foo.cc.toml'
+        plaster_path.parent.mkdir(parents=True, exist_ok=True)
+        plaster_path.write_text('')
+
+        patchfile = Patchfile(
+            path=self.fake_chromium_src.get_patchfile_path_for_source(
+                v8, test_file))
+        self.assertIsNone(patchfile.plaster)
+
+
+class PatchfilePlasterApplyTest(unittest.TestCase):
+    """Tests for Patchfile.apply() when a plaster file is associated."""
+
+    _SOURCE_FILE = Path('chrome/browser/foo.cc')
+    _BASE_CONTENT = 'void old_func() {}\nstatic int x = 0;\n'
+    _BRAVE_CONTENT = 'void old_func() {}\nstatic int x = 1;\n'
+    _UPSTREAM_CONTENT = 'void old_func() {}\nstatic int x = 2;\n'
+
+    # count = 0 means "replace all matches, bypass count validation".
+    _WORKING_TOML = ('[[substitution]]\n'
+                     'description = "Replace old_func"\n'
+                     'pattern = "old_func"\n'
+                     'replace = "new_func"\n'
+                     'count = 0\n')
+
+    # No substitution key → TypeError iterating None → PLASTER_BROKEN.
+    _BROKEN_TOML = '# no substitution\n'
+
+    def setUp(self):
+        self.fake_chromium_src = FakeChromiumSrc()
+        self.fake_chromium_src.setup()
+        self.addCleanup(self.fake_chromium_src.cleanup)
+
+    def _write_plaster_toml(self, content: str) -> None:
+        toml_path = (self.fake_chromium_src.brave / 'rewrite' /
+                     self._SOURCE_FILE.parent /
+                     (self._SOURCE_FILE.name + '.toml'))
+        toml_path.parent.mkdir(parents=True, exist_ok=True)
+        toml_path.write_text(content)
+
+    def _setup_conflict_and_patchfile(self) -> Patchfile:
+        """Commits BASE_CONTENT, generates a brave patch (x=0→1), then commits
+        UPSTREAM_CONTENT (x=0→2) so that applying the patch hits the conflict
+        path in apply().
+
+        Must be called after _write_plaster_toml so the Patchfile constructor
+        finds the TOML and sets the plaster field.
+        """
+        chromium = self.fake_chromium_src.chromium
+        self.fake_chromium_src.write_and_stage_file(self._SOURCE_FILE,
+                                                    self._BASE_CONTENT,
+                                                    chromium)
+        self.fake_chromium_src.commit('Add foo.cc', chromium)
+
+        (chromium / self._SOURCE_FILE).write_text(self._BRAVE_CONTENT)
+        self.fake_chromium_src.run_update_patches()
+        self.fake_chromium_src._run_git_command(['checkout', '.'], chromium)
+
+        self.fake_chromium_src.write_and_stage_file(self._SOURCE_FILE,
+                                                    self._UPSTREAM_CONTENT,
+                                                    chromium)
+        self.fake_chromium_src.commit('Upstream change', chromium)
+
+        return Patchfile(
+            path=self.fake_chromium_src.get_patchfile_path_for_source(
+                chromium, self._SOURCE_FILE))
+
+    def _setup_broken_and_patchfile(self) -> tuple[Patchfile, Path]:
+        """Commits BASE_CONTENT and generates a valid brave patch.  Returns the
+        Patchfile and the absolute path to the patch file on disk.
+
+        Strip the patch file after this call to trigger the broken-patch path
+        in apply().  Must be called after _write_plaster_toml.
+        """
+        chromium = self.fake_chromium_src.chromium
+        self.fake_chromium_src.write_and_stage_file(self._SOURCE_FILE,
+                                                    self._BASE_CONTENT,
+                                                    chromium)
+        self.fake_chromium_src.commit('Add foo.cc', chromium)
+
+        (chromium / self._SOURCE_FILE).write_text(self._BRAVE_CONTENT)
+        self.fake_chromium_src.run_update_patches()
+        self.fake_chromium_src._run_git_command(['checkout', '.'], chromium)
+
+        patch_rel = self.fake_chromium_src.get_patchfile_path_for_source(
+            chromium, self._SOURCE_FILE)
+        return (Patchfile(path=patch_rel),
+                self.fake_chromium_src.brave / patch_rel)
+
+    def test_apply_conflict_plaster_fixed(self):
+        """Conflict path + working plaster → PLASTER_FIXED."""
+        self._write_plaster_toml(self._WORKING_TOML)
+        patchfile = self._setup_conflict_and_patchfile()
+        self.assertEqual(patchfile.apply(),
+                         Patchfile.ApplyStatus.PLASTER_FIXED)
+
+    def test_apply_conflict_plaster_broken(self):
+        """Conflict path + broken plaster → PLASTER_BROKEN."""
+        self._write_plaster_toml(self._BROKEN_TOML)
+        patchfile = self._setup_conflict_and_patchfile()
+        self.assertEqual(patchfile.apply(),
+                         Patchfile.ApplyStatus.PLASTER_BROKEN)
+
+    def test_apply_broken_patch_plaster_fixed(self):
+        """Broken patch path + working plaster → PLASTER_FIXED."""
+        self._write_plaster_toml(self._WORKING_TOML)
+        patchfile, patch_path = self._setup_broken_and_patchfile()
+        patch_path.write_text(patch_path.read_text().strip())
+        self.assertEqual(patchfile.apply(),
+                         Patchfile.ApplyStatus.PLASTER_FIXED)
+
+    def test_apply_broken_patch_plaster_broken(self):
+        """Broken patch path + broken plaster → PLASTER_BROKEN."""
+        self._write_plaster_toml(self._BROKEN_TOML)
+        patchfile, patch_path = self._setup_broken_and_patchfile()
+        patch_path.write_text(patch_path.read_text().strip())
+        self.assertEqual(patchfile.apply(),
+                         Patchfile.ApplyStatus.PLASTER_BROKEN)
 
 
 if __name__ == "__main__":

--- a/tools/cr/plaster.py
+++ b/tools/cr/plaster.py
@@ -387,6 +387,7 @@ def apply(args):
         for plaster_file in plaster_files:
             console.log(f'Applying plaster file: {plaster_file.path}')
             plaster_file.apply()
+    return 0
 
 
 def check(args):
@@ -403,8 +404,7 @@ def check(args):
             print(e, file=sys.stderr)
             has_failure = True
 
-    if has_failure:
-        sys.exit(1)
+    return 1 if has_failure else 0
 
 
 def main():
@@ -445,8 +445,7 @@ def main():
         format='%(message)s',
         handlers=[IncendiaryErrorHandler(markup=True, rich_tracebacks=True)])
 
-    args.func(args)
-    return 0
+    return args.func(args)
 
 
 if __name__ == '__main__':

--- a/tools/cr/plaster_test.py
+++ b/tools/cr/plaster_test.py
@@ -191,10 +191,7 @@ class PlasterTest(unittest.TestCase):
                 self.verbose = False
 
         args = DummyArgs()
-        # Should not call sys.exit at all
-        with patch('sys.exit') as mock_exit:
-            plaster.check(args)
-            mock_exit.assert_not_called()
+        self.assertEqual(plaster.check(args), 0)
 
     def test_check_fails_when_toml_changed(self):
         """Test plaster check fails when there's a mismatch."""
@@ -233,9 +230,7 @@ class PlasterTest(unittest.TestCase):
                 self.verbose = False
 
         args = DummyArgs()
-        with patch('sys.exit') as mock_exit:
-            plaster.check(args)
-            mock_exit.assert_not_called()
+        self.assertEqual(plaster.check(args), 0)
         # Now change one toml file to cause a failure
         changed_path = rewrite_paths[1]
         changed_path.write_text('''
@@ -246,9 +241,9 @@ class PlasterTest(unittest.TestCase):
         ''')
         # Now check should fail and print the file on stderr
         stderr = io.StringIO()
-        with patch('sys.stderr', stderr), patch('sys.exit') as mock_exit:
-            plaster.check(args)
-            mock_exit.assert_called_once_with(1)
+        with patch('sys.stderr', stderr):
+            result = plaster.check(args)
+            self.assertEqual(result, 1)
             output = stderr.getvalue()
             self.assertIn(str(changed_path), output)
 

--- a/tools/cr/repository.py
+++ b/tools/cr/repository.py
@@ -202,20 +202,16 @@ class Repository:
             *[f'{commit}:{Path(file).as_posix()}' for file in files],
             no_trim=True)
 
-    def get_patch_stats(self, *patches: Path) -> dict[Path, list[Path]]:
-        """Returns the files affected by each patch, keyed by patch path.
+    def get_patch_stats(self, patch: Path) -> list[Path]:
+        """Returns the files affected by the given patch.
 
-        Uses --numstat for unabbreviated paths. Each patch is queried
-        individually so that file lists map cleanly to their patch key.
+        Uses --numstat for unabbreviated paths.
         """
-        return {
-            patch: [
-                Path(line.split('\t')[2]) for line in self.run_git(
-                    'apply', '--numstat', patch.as_posix()).splitlines()
-                if '\t' in line
-            ]
-            for patch in patches
-        }
+        return [
+            Path(line.split('\t')[2]) for line in self.run_git(
+                'apply', '--numstat', patch.as_posix()).splitlines()
+            if '\t' in line
+        ]
 
     def current_branch(self) -> str:
         """Gets the current branch name, or HEAD if not in any branch.

--- a/tools/cr/repository_test.py
+++ b/tools/cr/repository_test.py
@@ -365,8 +365,7 @@ class RepositoryTest(unittest.TestCase):
 
         stats = repository.chromium.get_patch_stats(patch_path)
 
-        self.assertEqual(list(stats.keys()), [patch_path])
-        self.assertEqual(stats[patch_path], [test_file])
+        self.assertEqual(stats, [test_file])
 
     def test_get_patch_stats_multiple(self):
         """Test get_patch_stats with several patches returns each in order."""
@@ -392,11 +391,10 @@ class RepositoryTest(unittest.TestCase):
                 self.fake_chromium_src.chromium, f) for f in [file1, file2]
         ]
 
-        stats = repository.chromium.get_patch_stats(*patch_paths)
-
-        self.assertEqual(list(stats.keys()), patch_paths)
-        self.assertEqual(stats[patch_paths[0]], [file1])
-        self.assertEqual(stats[patch_paths[1]], [file2])
+        self.assertEqual(repository.chromium.get_patch_stats(patch_paths[0]),
+                         [file1])
+        self.assertEqual(repository.chromium.get_patch_stats(patch_paths[1]),
+                         [file2])
 
     def test_get_patch_stats_multiple_sources_in_patch(self):
         """Test get_patch_stats with a patch covering several source files."""
@@ -416,10 +414,9 @@ class RepositoryTest(unittest.TestCase):
 
         stats = repository.chromium.get_patch_stats(patch_path)
 
-        self.assertEqual(list(stats.keys()), [patch_path])
-        self.assertIn(file1, stats[patch_path])
-        self.assertIn(file2, stats[patch_path])
-        self.assertEqual(len(stats[patch_path]), 2)
+        self.assertIn(file1, stats)
+        self.assertIn(file2, stats)
+        self.assertEqual(len(stats), 2)
 
     def test_current_branch(self):
         """Test current_branch using the chromium repository."""

--- a/tools/cr/test/fake_chromium_repo.py
+++ b/tools/cr/test/fake_chromium_repo.py
@@ -91,6 +91,8 @@ class FakeChromiumRepo:
         self._run_git_command(['add', 'README.md'], path)
         self._run_git_command(['config', 'user.name', 'Fake User'], path)
         self._run_git_command(['config', 'user.email', 'fake@brave.com'], path)
+        # Prevent background gc from writing to objects/pack/ during cleanup.
+        self._run_git_command(['config', 'gc.auto', '0'], path)
         self._run_git_command(['commit', '-m', 'Initial commit'], path)
 
     def create_brave_remote(self) -> None:


### PR DESCRIPTION
This PR adds integration for `plaster` into `brockit`. This involves
primarily changes to how 3way apply works. With this change, whenever
3way apply fails due to conflicts or a broken patch, we take a next step
attempting to fix the issue by rerunning the plaster.

Why not rerun plaster always for any patch managed with a plaster?

It is important to maintain changes in a granular state that they can be
inspected. We don't want to do blanket `plaster` runs because that may
create a huge committable change, that would be harder to inspect and
specially harder to catch unintended plaster new interpretations based
in underlying Chromium changes.

This PR introduces a two step process for plaster:

1. The plaster re-run commit.

This commit is similar to the use of `Conflict-resolved` commits. It
will be commited with a message:

```
Re-run required 🩹 patches from Chromium VERSION to VERSION
```

This will be a pinned commit, and it will helps keep track of the
patches that did require a `plaster` rerun to apply again.

2. The introduction of `plaster check`

At the end of the lift, we run `plaster check`. For the vast majority of
the cases, what the plaster rerun would have generated is exactly what
we got with simply reapplying the patch. However, for cases where the
patch re-applied, and yet a plaster re-run would somehow produce
something different, we want to alert about that, and have that
investigated, and committed with a culprit, to make such a change
visible during review.

It is important to notice that `plaster check` also runs during the
`presubmit` step, so even if not caught at this stage, it would be
brought to someone's attention at some point.

Resolves https://github.com/brave/brave-browser/issues/55188
