### PR TITLE
Fix caption button overlap with toolbar in vertical tabs Qt theme

### DIFF
--- a/browser/ui/views/frame/brave_browser_frame_view_linux_browsertest.cc
+++ b/browser/ui/views/frame/brave_browser_frame_view_linux_browsertest.cc
@@ -5,6 +5,8 @@
 
 #include <optional>
 
+#include "base/functional/bind.h"
+#include "base/functional/callback_helpers.h"
 #include "base/memory/raw_ptr.h"
 #include "base/memory/raw_ref.h"
 #include "brave/browser/ui/browser_commands.h"
@@ -73,6 +75,8 @@ class FakeWindowFrameProvider : public ui::WindowFrameProvider {
 
 // LinuxUi that satisfies the factory's CreateNavButtonProvider() non-null
 // requirement and routes GetWindowFrameProvider() to a fake we can inspect.
+// GetNativeTheme() returns the real native UI theme so that frame recreation
+// triggered by UseSystemTheme() can build a valid ColorProviderKey.
 class FakeLinuxUiWithNavButtons : public ui::FakeLinuxUi {
  public:
   std::unique_ptr<ui::NavButtonProvider> CreateNavButtonProvider() override {
@@ -81,8 +85,6 @@ class FakeLinuxUiWithNavButtons : public ui::FakeLinuxUi {
   ui::WindowFrameProvider* GetWindowFrameProvider(bool, bool, bool) override {
     return &frame_provider_;
   }
-  // FakeLinuxUi returns nullptr; override to prevent null-dereference when
-  // UseSystemTheme() triggers frame recreation on existing browser windows.
   ui::NativeTheme* GetNativeTheme() const override {
     return ui::NativeTheme::GetInstanceForNativeUi();
   }
@@ -146,8 +148,24 @@ IN_PROC_BROWSER_TEST_F(BraveBrowserFrameViewTest,
                        VerticalTabsGtkTopAreaHeightIsPositive) {
   FakeLinuxUiWithNavButtons fake_linux_ui;
   FakeLinuxUiGetter fake_getter(fake_linux_ui);
-  ScopedLinuxUiGetter scoped_getter(&fake_getter);
 
+  // restore_default_theme is declared first so it destructs LAST (after
+  // scoped_getter).  UseDefaultTheme() therefore fires with the original null
+  // getter already restored, so frame recreation uses no linux-ui pointer —
+  // preventing UAF when fake_linux_ui destructs.
+  base::ScopedClosureRunner restore_default_theme(base::BindOnce(
+      [](Profile* p) {
+        ThemeServiceFactory::GetForProfile(p)->UseDefaultTheme();
+      },
+      browser()->profile()));
+
+  // Install the fake getter before UseSystemTheme().  UseSystemTheme()
+  // synchronously recreates the initial browser's frame (UpdateFrame()), which
+  // calls BraveBrowserWidget::GetColorProviderKey() → GetNativeTheme().  The
+  // FakeLinuxUiWithNavButtons::GetNativeTheme() override returns a real
+  // NativeTheme so this path does not crash.  UsingSystemTheme() == true is
+  // also required by the factory to create BraveBrowserFrameViewLinuxNative.
+  ScopedLinuxUiGetter scoped_getter(&fake_getter);
   ThemeServiceFactory::GetForProfile(browser()->profile())->UseSystemTheme();
 
   Browser* gtk_browser = CreateBrowser(browser()->profile());
@@ -178,9 +196,13 @@ IN_PROC_BROWSER_TEST_F(BraveBrowserFrameViewTest,
   EXPECT_GE(*fake_linux_ui.frame_provider().last_top_area_height(),
             toolbar->GetPreferredSize().height());
 
-  // Close before the fake objects go out of scope; the frame view holds a raw
+  // Close before fake objects go out of scope; the frame view holds a raw
   // pointer to fake_linux_ui via the frame-provider getter.
   CloseBrowserSynchronously(gtk_browser);
+  // scoped_getter destructs: fake getter uninstalled, original getter restored.
+  // restore_default_theme fires: UseDefaultTheme() with null getter rebuilds
+  // all browser frames as BraveOpaqueBrowserFrameView — no capture of
+  // &fake_linux_ui — so fake_linux_ui destructs safely.
 }
 
 // Verifies that with vertical tabs enabled and no title bar, both the toolbar

--- a/browser/ui/views/frame/brave_browser_frame_view_linux_native.cc
+++ b/browser/ui/views/frame/brave_browser_frame_view_linux_native.cc
@@ -5,11 +5,9 @@
 
 #include "brave/browser/ui/views/frame/brave_browser_frame_view_linux_native.h"
 
-#include <numeric>
 #include <string>
 
 #include "base/check.h"
-#include "base/check_op.h"
 #include "base/notreached.h"
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 #include "brave/browser/ui/views/toolbar/brave_toolbar_view.h"
@@ -17,11 +15,8 @@
 #include "chrome/browser/ui/layout_constants.h"
 #include "chrome/browser/ui/views/frame/browser_frame_view_layout_linux_native.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
-#include "chrome/common/pref_names.h"
 #include "ui/base/metadata/metadata_impl_macros.h"
 #include "ui/views/controls/button/image_button.h"
-#include "ui/views/window/caption_button_layout_constants.h"
-#include "ui/views/window/window_button_order_provider.h"
 
 namespace {
 
@@ -91,7 +86,6 @@ void BraveBrowserFrameViewLinuxNative::MaybeUpdateCachedFrameButtonImages() {
   if (!tabs::utils::ShouldShowBraveVerticalTabs(browser) ||
       tabs::utils::ShouldShowWindowTitleForVerticalTabs(browser)) {
     BrowserFrameViewLinuxNative::MaybeUpdateCachedFrameButtonImages();
-    UpdateLeadingTrailingCaptionButtonWidth();
     return;
   }
 
@@ -132,88 +126,11 @@ void BraveBrowserFrameViewLinuxNative::MaybeUpdateCachedFrameButtonImages() {
               type, ButtonStateToNavButtonProviderState(button_state))));
     }
   }
-
-  UpdateLeadingTrailingCaptionButtonWidth();
 }
 
 void BraveBrowserFrameViewLinuxNative::Layout(PassKey) {
   LayoutSuperclass<BrowserFrameViewLinuxNative>(this);
 
-  UpdateLeadingTrailingCaptionButtonWidth();
-}
-
-views::Button* BraveBrowserFrameViewLinuxNative::FrameButtonToButton(
-    views::FrameButton frame_button) {
-  switch (frame_button) {
-    case views::FrameButton::kMinimize:
-      return minimize_button();
-    case views::FrameButton::kMaximize:
-      return IsMaximized() ? restore_button() : maximize_button();
-    case views::FrameButton::kClose:
-      return close_button();
-  }
-  NOTREACHED();
-}
-
-void BraveBrowserFrameViewLinuxNative::
-    UpdateLeadingTrailingCaptionButtonWidth() {
-  auto* browser = GetBrowserView()->browser();
-  DCHECK(browser);
-  std::pair<int, int> new_leading_trailing_caption_button_width;
-  if (tabs::utils::ShouldShowBraveVerticalTabs(browser) &&
-      !tabs::utils::ShouldShowWindowTitleForVerticalTabs(browser)) {
-    auto* window_order_provider =
-        views::WindowButtonOrderProvider::GetInstance();
-    const auto leading_buttons = window_order_provider->leading_buttons();
-    const auto trailing_buttons = window_order_provider->trailing_buttons();
-
-    const auto leading_button_width = std::accumulate(
-        leading_buttons.begin(), leading_buttons.end(), 0,
-        [this](int max_right, auto frame_button) {
-          auto* button = FrameButtonToButton(frame_button);
-          if (!button || !button->GetVisible() || button->bounds().IsEmpty()) {
-            return max_right;
-          }
-
-          if (auto current_right = button->bounds().right();
-              current_right > max_right) {
-            return current_right;
-          }
-
-          return max_right;
-        });
-
-    const auto trailing_button_width =
-        width() -
-        std::accumulate(trailing_buttons.begin(), trailing_buttons.end(),
-                        width(), [this](int min_left, auto frame_button) {
-                          auto* button = FrameButtonToButton(frame_button);
-                          if (!button || !button->GetVisible() ||
-                              button->bounds().IsEmpty()) {
-                            return min_left;
-                          }
-
-                          if (int current_left = button->bounds().x();
-                              current_left < min_left) {
-                            return current_left;
-                          }
-
-                          return min_left;
-                        });
-    new_leading_trailing_caption_button_width = {leading_button_width,
-                                                 trailing_button_width};
-  }
-
-  if (leading_trailing_caption_button_width_ ==
-      new_leading_trailing_caption_button_width) {
-    return;
-  }
-
-  leading_trailing_caption_button_width_ =
-      new_leading_trailing_caption_button_width;
-
-  // Notify toolbar view that caption button's width changed so that it can
-  // make space for caption buttons.
   static_cast<BraveToolbarView*>(GetBrowserView()->toolbar())
       ->UpdateHorizontalPadding();
 }

--- a/browser/ui/views/frame/brave_browser_frame_view_linux_native.h
+++ b/browser/ui/views/frame/brave_browser_frame_view_linux_native.h
@@ -7,7 +7,6 @@
 #define BRAVE_BROWSER_UI_VIEWS_FRAME_BRAVE_BROWSER_FRAME_VIEW_LINUX_NATIVE_H_
 
 #include <memory>
-#include <utility>
 
 #include "chrome/browser/ui/views/frame/browser_frame_view_linux_native.h"
 
@@ -21,22 +20,10 @@ class BraveBrowserFrameViewLinuxNative : public BrowserFrameViewLinuxNative {
       std::unique_ptr<ui::NavButtonProvider> nav_button_provider);
   ~BraveBrowserFrameViewLinuxNative() override;
 
-  // Returns caption buttons width provided by GTK.
-  std::pair<int, int> leading_trailing_caption_button_width() const {
-    return leading_trailing_caption_button_width_;
-  }
-
   // BrowserFrameViewLinuxNative:
   void PaintRestoredFrameBorder(gfx::Canvas* canvas) const override;
   void MaybeUpdateCachedFrameButtonImages() override;
   void Layout(PassKey) override;
-
- private:
-  views::Button* FrameButtonToButton(views::FrameButton frame_button);
-
-  void UpdateLeadingTrailingCaptionButtonWidth();
-
-  std::pair<int, int> leading_trailing_caption_button_width_;
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_FRAME_BRAVE_BROWSER_FRAME_VIEW_LINUX_NATIVE_H_

--- a/browser/ui/views/frame/brave_browser_frame_view_win.cc
+++ b/browser/ui/views/frame/brave_browser_frame_view_win.cc
@@ -10,6 +10,7 @@
 #include "brave/browser/ui/views/frame/brave_win_caption_layout.h"
 #include "brave/browser/ui/views/frame/brave_window_frame_graphic.h"
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
+#include "brave/browser/ui/views/toolbar/brave_toolbar_view.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/layout_constants.h"
@@ -171,4 +172,8 @@ void BraveBrowserFrameViewWin::LayoutCaptionButtons() {
     caption_button_container_->SetY(caption_button_container_->y() +
                                     tabs::GetHorizontalTabControlsDelta());
   }
+
+  // See the comment in BraveOpaqueBrowserFrameView::Layout().
+  static_cast<BraveToolbarView*>(GetBrowserView()->toolbar())
+      ->UpdateHorizontalPadding();
 }

--- a/browser/ui/views/frame/brave_opaque_browser_frame_view.cc
+++ b/browser/ui/views/frame/brave_opaque_browser_frame_view.cc
@@ -117,6 +117,17 @@ void BraveOpaqueBrowserFrameView::
       ->UpdateHorizontalPadding();
 }
 
+void BraveOpaqueBrowserFrameView::Layout(PassKey key) {
+  LayoutSuperclass<OpaqueBrowserFrameView>(this);
+
+  // Why frame view should ask toolbar's padding update?
+  // This kind of exclusion should be handled by BrowserViewLayout.
+  // BraveBrowserFrameViewLinuxNative::Layout() does same thing.
+  // TODO(): Investigate what's happening.
+  static_cast<BraveToolbarView*>(GetBrowserView()->toolbar())
+      ->UpdateHorizontalPadding();
+}
+
 void BraveOpaqueBrowserFrameView::PaintClientEdge(gfx::Canvas* canvas) const {
   // Don't draw client edge next to toolbar when it's in vertical tab strip mode
   if (ShouldShowVerticalTabs()) {

--- a/browser/ui/views/frame/brave_opaque_browser_frame_view.cc
+++ b/browser/ui/views/frame/brave_opaque_browser_frame_view.cc
@@ -123,7 +123,8 @@ void BraveOpaqueBrowserFrameView::Layout(PassKey key) {
   // Why frame view should ask toolbar's padding update?
   // This kind of exclusion should be handled by BrowserViewLayout.
   // BraveBrowserFrameViewLinuxNative::Layout() does same thing.
-  // TODO(): Investigate what's happening.
+  // TODO(https://github.com/brave/brave-browser/issues/55209):
+  // Investigate what's happening.
   static_cast<BraveToolbarView*>(GetBrowserView()->toolbar())
       ->UpdateHorizontalPadding();
 }

--- a/browser/ui/views/frame/brave_opaque_browser_frame_view.h
+++ b/browser/ui/views/frame/brave_opaque_browser_frame_view.h
@@ -32,6 +32,7 @@ class BraveOpaqueBrowserFrameView : public OpaqueBrowserFrameView {
   void PaintClientEdge(gfx::Canvas* canvas) const override;
   int GetTopInset(bool restored) const override;
   int GetTopAreaHeight() const override;
+  void Layout(PassKey) override;
 
  private:
   bool ShouldShowVerticalTabs() const;

--- a/browser/ui/views/tabs/vertical_tab_utils.cc
+++ b/browser/ui/views/tabs/vertical_tab_utils.cc
@@ -95,7 +95,7 @@ std::pair<int, int> GetLeadingTrailingCaptionButtonWidth(
   if (!frame_view) {
     return {};
   }
-  const auto params = frame_view->GetBrowserLayoutParams();
+  const BrowserLayoutParams params = frame_view->GetBrowserLayoutParams();
   return {
       base::ClampCeil(params.leading_exclusion.ContentWithPadding().width()),
       base::ClampCeil(params.trailing_exclusion.ContentWithPadding().width())};

--- a/browser/ui/views/tabs/vertical_tab_utils.cc
+++ b/browser/ui/views/tabs/vertical_tab_utils.cc
@@ -16,28 +16,8 @@
 #include "chrome/browser/ui/browser_window/public/browser_window_features.h"
 #include "chrome/browser/ui/browser_window/public/browser_window_interface.h"
 #include "chrome/browser/ui/tabs/features.h"
-#include "chrome/browser/ui/views/frame/browser_native_widget.h"
 #include "components/prefs/pref_service.h"
 
-#if !BUILDFLAG(IS_MAC)
-#include "chrome/browser/ui/frame/window_frame_util.h"
-#include "chrome/browser/ui/views/frame/browser_view.h"
-#include "chrome/browser/ui/views/frame/opaque_browser_frame_view_layout.h"
-#include "ui/base/theme_provider.h"
-#include "ui/views/resources/grit/views_resources.h"
-#endif
-
-#if BUILDFLAG(IS_LINUX)
-#include "brave/browser/ui/views/frame/brave_browser_frame_view_linux_native.h"
-#include "chrome/browser/themes/theme_service.h"
-#include "chrome/browser/themes/theme_service_factory.h"
-#include "chrome/browser/ui/layout_constants.h"
-#include "chrome/common/pref_names.h"
-#include "ui/linux/linux_ui.h"
-#include "ui/views/view_utils.h"
-#include "ui/views/window/caption_button_layout_constants.h"
-#include "ui/views/window/window_button_order_provider.h"
-#endif
 
 namespace tabs::utils {
 
@@ -99,77 +79,6 @@ bool IsFloatingVerticalTabsEnabled(const BrowserWindowInterface* browser) {
 bool IsVerticalTabOnRight(const BrowserWindowInterface* browser) {
   return browser->GetProfile()->GetPrefs()->GetBoolean(
       brave_tabs::kVerticalTabsOnRight);
-}
-
-std::pair<int, int> GetLeadingTrailingCaptionButtonWidth(
-    const BrowserWidget* frame) {
-#if BUILDFLAG(IS_MAC)
-  // On Mac, window caption buttons are drawn by the system.
-  return {80, 0};
-#elif BUILDFLAG(IS_LINUX)
-  if (!frame->browser_native_widget()->UseCustomFrame()) {
-    // We're using system provided title bar and border. As we don't have our
-    // own window caption button at all, there's no caption button width.
-    return {};
-  }
-
-  auto* browser_view =
-      BrowserView::GetBrowserViewForNativeWindow(frame->GetNativeWindow());
-  if (!browser_view) {
-    // This can happen on startup
-    return {};
-  }
-
-  auto* profile = browser_view->browser()->profile();
-  auto* linux_ui_theme = ui::LinuxUiTheme::GetForProfile(profile);
-  auto* theme_service_factory = ThemeServiceFactory::GetForProfile(profile);
-  const bool using_gtk_caption_button =
-      linux_ui_theme && theme_service_factory->UsingSystemTheme();
-  if (!using_gtk_caption_button) {
-    auto* window_order_provider =
-        views::WindowButtonOrderProvider::GetInstance();
-    return {views::GetCaptionButtonWidth() *
-                window_order_provider->leading_buttons().size(),
-            views::GetCaptionButtonWidth() *
-                window_order_provider->trailing_buttons().size()};
-  }
-
-  // When using gtk-provided caption buttons, buttons' size and spacing is
-  // decided by system. So we can't help but peeking the actual caption button's
-  // position.
-  auto* frame_view = views::AsViewClass<BraveBrowserFrameViewLinuxNative>(
-      frame->GetFrameView());
-  if (!frame_view) {
-    // We could be in the middle of transition to GTK theme frame.
-    return {};
-  }
-  return frame_view->leading_trailing_caption_button_width();
-
-#elif BUILDFLAG(IS_WIN)
-  if (frame->ShouldUseNativeFrame()) {
-    // In this case, we use BrowserFrameViewWin. Native frame will be set to
-    // the HWND and BrowserFrameViewWin will draw frame and window caption
-    // button.
-    auto size = WindowFrameUtil::GetWindowsCaptionButtonAreaSize();
-    return {0, size.width()};
-  }
-
-  // In this case, we use OpaqueBrowserFrameView. OpaqueBrowserFrameView has
-  // two types of frame button per platform but on Windows, it uses image
-  // buttons. See OpaqueBrowserFrameView::GetFrameButtonStyle().
-  int width = 0;
-  // Uses image icons
-  const ui::ThemeProvider* tp = frame->GetThemeProvider();
-  DCHECK(tp);
-  for (auto image_id : {IDR_MINIMIZE, IDR_MAXIMIZE, IDR_CLOSE}) {
-    if (const gfx::ImageSkia* image = tp->GetImageSkiaNamed(image_id)) {
-      width += image->width();
-    }
-  }
-  return {0, width};
-#else
-#error "not handled platform"
-#endif
 }
 
 bool ShouldHideVerticalTabsCompletelyWhenCollapsed(

--- a/browser/ui/views/tabs/vertical_tab_utils.cc
+++ b/browser/ui/views/tabs/vertical_tab_utils.cc
@@ -8,16 +8,19 @@
 #include "base/check.h"
 #include "base/check_is_test.h"
 #include "base/command_line.h"
+#include "base/numerics/safe_conversions.h"
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
 #include "brave/browser/ui/views/tabs/switches.h"
+#include "build/build_config.h"
 #include "chrome/app/chrome_command_ids.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser_command_controller.h"
 #include "chrome/browser/ui/browser_window/public/browser_window_features.h"
 #include "chrome/browser/ui/browser_window/public/browser_window_interface.h"
 #include "chrome/browser/ui/tabs/features.h"
+#include "chrome/browser/ui/views/frame/browser_frame_view.h"
+#include "chrome/browser/ui/views/frame/browser_widget.h"
 #include "components/prefs/pref_service.h"
-
 
 namespace tabs::utils {
 
@@ -79,6 +82,26 @@ bool IsFloatingVerticalTabsEnabled(const BrowserWindowInterface* browser) {
 bool IsVerticalTabOnRight(const BrowserWindowInterface* browser) {
   return browser->GetProfile()->GetPrefs()->GetBoolean(
       brave_tabs::kVerticalTabsOnRight);
+}
+
+std::pair<int, int> GetLeadingTrailingCaptionButtonWidth(
+    const BrowserWidget* frame) {
+#if BUILDFLAG(IS_MAC)
+  // On Mac, frame_view->GetBrowserLayoutParams() gives more wider width than
+  // we want.
+  return {80, 0};
+#elif BUILDFLAG(IS_WIN) || BUILDFLAG(IS_LINUX)
+  auto* frame_view = frame->GetFrameView();
+  if (!frame_view) {
+    return {};
+  }
+  const auto params = frame_view->GetBrowserLayoutParams();
+  return {
+      base::ClampCeil(params.leading_exclusion.ContentWithPadding().width()),
+      base::ClampCeil(params.trailing_exclusion.ContentWithPadding().width())};
+#else
+#error "not handled platform"
+#endif
 }
 
 bool ShouldHideVerticalTabsCompletelyWhenCollapsed(

--- a/browser/ui/views/tabs/vertical_tab_utils.h
+++ b/browser/ui/views/tabs/vertical_tab_utils.h
@@ -6,6 +6,9 @@
 #ifndef BRAVE_BROWSER_UI_VIEWS_TABS_VERTICAL_TAB_UTILS_H_
 #define BRAVE_BROWSER_UI_VIEWS_TABS_VERTICAL_TAB_UTILS_H_
 
+#include <utility>
+
+class BrowserWidget;
 class BrowserWindowInterface;
 
 namespace tabs::utils {
@@ -35,6 +38,10 @@ bool ShouldHideVerticalTabsCompletelyWhenCollapsed(
 
 // Returns true when the vertical tab toggle should be enabled.
 bool IsVerticalTabToggleEnabled(BrowserWindowInterface* browser);
+
+// Returns window caption buttons' width based on the current platform
+std::pair<int, int> GetLeadingTrailingCaptionButtonWidth(
+    const BrowserWidget* frame);
 
 }  // namespace tabs::utils
 

--- a/browser/ui/views/tabs/vertical_tab_utils.h
+++ b/browser/ui/views/tabs/vertical_tab_utils.h
@@ -6,9 +6,6 @@
 #ifndef BRAVE_BROWSER_UI_VIEWS_TABS_VERTICAL_TAB_UTILS_H_
 #define BRAVE_BROWSER_UI_VIEWS_TABS_VERTICAL_TAB_UTILS_H_
 
-#include <utility>
-
-class BrowserWidget;
 class BrowserWindowInterface;
 
 namespace tabs::utils {
@@ -38,10 +35,6 @@ bool ShouldHideVerticalTabsCompletelyWhenCollapsed(
 
 // Returns true when the vertical tab toggle should be enabled.
 bool IsVerticalTabToggleEnabled(BrowserWindowInterface* browser);
-
-// Returns window caption buttons' width based on the current platform
-std::pair<int, int> GetLeadingTrailingCaptionButtonWidth(
-    const BrowserWidget* frame);
 
 }  // namespace tabs::utils
 

--- a/browser/ui/views/toolbar/brave_toolbar_view.cc
+++ b/browser/ui/views/toolbar/brave_toolbar_view.cc
@@ -12,7 +12,6 @@
 #include "base/check.h"
 #include "base/check_op.h"
 #include "base/functional/bind.h"
-#include "base/numerics/safe_conversions.h"
 #include "brave/app/brave_command_ids.h"
 #include "brave/app/vector_icons/vector_icons.h"
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
@@ -36,7 +35,6 @@
 #include "chrome/browser/ui/layout_constants.h"
 #include "chrome/browser/ui/ui_features.h"
 #include "chrome/browser/ui/views/bookmarks/bookmark_bubble_view.h"
-#include "chrome/browser/ui/views/frame/browser_frame_view.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
 #include "chrome/browser/ui/views/toolbar/toolbar_button.h"
 #include "chrome/browser/ui/views/toolbar/toolbar_divider.h"
@@ -501,19 +499,11 @@ void BraveToolbarView::UpdateHorizontalPadding() {
     return;
   }
 
-  auto* frame_view = browser_view_->browser_widget()->GetFrameView();
-  if (!frame_view) {
-    return;
-  }
-
   const gfx::Insets current_insets =
       container_view->GetBorder() ? container_view->GetBorder()->GetInsets()
                                   : gfx::Insets();
-  const auto params = frame_view->GetBrowserLayoutParams();
-  const int leading =
-      base::ClampCeil(params.leading_exclusion.ContentWithPadding().width());
-  const int trailing =
-      base::ClampCeil(params.trailing_exclusion.ContentWithPadding().width());
+  auto [leading, trailing] = tabs::utils::GetLeadingTrailingCaptionButtonWidth(
+      browser_view_->browser_widget());
 
   // Skip the SetBorder() call if insets are already correct. Layout triggers
   // this method and SetBorder() would invalidate layout again, causing a loop.

--- a/browser/ui/views/toolbar/brave_toolbar_view.cc
+++ b/browser/ui/views/toolbar/brave_toolbar_view.cc
@@ -12,6 +12,7 @@
 #include "base/check.h"
 #include "base/check_op.h"
 #include "base/functional/bind.h"
+#include "base/numerics/safe_conversions.h"
 #include "brave/app/brave_command_ids.h"
 #include "brave/app/vector_icons/vector_icons.h"
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
@@ -35,6 +36,7 @@
 #include "chrome/browser/ui/layout_constants.h"
 #include "chrome/browser/ui/ui_features.h"
 #include "chrome/browser/ui/views/bookmarks/bookmark_bubble_view.h"
+#include "chrome/browser/ui/views/frame/browser_frame_view.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
 #include "chrome/browser/ui/views/toolbar/toolbar_button.h"
 #include "chrome/browser/ui/views/toolbar/toolbar_divider.h"
@@ -496,13 +498,30 @@ void BraveToolbarView::UpdateHorizontalPadding() {
   if (!tabs::utils::ShouldShowBraveVerticalTabs(browser()) ||
       tabs::utils::ShouldShowWindowTitleForVerticalTabs(browser())) {
     container_view->SetBorder(nullptr);
-  } else {
-    auto [leading, trailing] =
-        tabs::utils::GetLeadingTrailingCaptionButtonWidth(
-            browser_view_->browser_widget());
-    container_view->SetBorder(views::CreateEmptyBorder(
-        gfx::Insets().set_left(leading).set_right(trailing)));
+    return;
   }
+
+  auto* frame_view = browser_view_->browser_widget()->GetFrameView();
+  if (!frame_view) {
+    return;
+  }
+
+  const gfx::Insets current_insets =
+      container_view->GetBorder() ? container_view->GetBorder()->GetInsets()
+                                  : gfx::Insets();
+  const auto params = frame_view->GetBrowserLayoutParams();
+  const int leading =
+      base::ClampCeil(params.leading_exclusion.ContentWithPadding().width());
+  const int trailing =
+      base::ClampCeil(params.trailing_exclusion.ContentWithPadding().width());
+
+  // Skip the SetBorder() call if insets are already correct. Layout triggers
+  // this method and SetBorder() would invalidate layout again, causing a loop.
+  if (current_insets.left() == leading && current_insets.right() == trailing) {
+    return;
+  }
+  container_view->SetBorder(views::CreateEmptyBorder(
+      gfx::Insets().set_left(leading).set_right(trailing)));
 }
 
 void BraveToolbarView::ShowBookmarkBubble(const GURL& url,

--- a/browser/ui/views/toolbar/brave_toolbar_view.cc
+++ b/browser/ui/views/toolbar/brave_toolbar_view.cc
@@ -499,9 +499,7 @@ void BraveToolbarView::UpdateHorizontalPadding() {
     return;
   }
 
-  const gfx::Insets current_insets =
-      container_view->GetBorder() ? container_view->GetBorder()->GetInsets()
-                                  : gfx::Insets();
+  const gfx::Insets current_insets = container_view->GetInsets();
   auto [leading, trailing] = tabs::utils::GetLeadingTrailingCaptionButtonWidth(
       browser_view_->browser_widget());
 

--- a/browser/ui/views/toolbar/brave_toolbar_view_browsertest.cc
+++ b/browser/ui/views/toolbar/brave_toolbar_view_browsertest.cc
@@ -8,12 +8,12 @@
 #include "base/check.h"
 #include "base/functional/callback_helpers.h"
 #include "base/memory/raw_ptr.h"
-#include "base/numerics/safe_conversions.h"
 #include "base/test/scoped_feature_list.h"
 #include "brave/browser/ui/tabs/brave_split_tab_menu_model.h"
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
 #include "brave/browser/ui/views/frame/brave_browser_view.h"
 #include "brave/browser/ui/views/location_bar/brave_location_bar_view.h"
+#include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 #include "brave/browser/ui/views/toolbar/bookmark_button.h"
 #include "brave/browser/ui/views/toolbar/side_panel_button.h"
 #include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
@@ -41,7 +41,6 @@
 #include "chrome/browser/ui/side_panel/side_panel_entry_key.h"
 #include "chrome/browser/ui/tabs/split_tab_menu_model.h"
 #include "chrome/browser/ui/tabs/tab_strip_model.h"
-#include "chrome/browser/ui/views/frame/browser_frame_view.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
 #include "chrome/browser/ui/views/frame/custom_corners_background.h"
 #include "chrome/browser/ui/views/frame/toolbar_button_provider.h"
@@ -609,15 +608,14 @@ IN_PROC_BROWSER_TEST_F(BraveToolbarViewTest,
 }
 
 // Verifies that UpdateHorizontalPadding() keeps the toolbar container border
-// in sync with BrowserFrameView::GetBrowserLayoutParams() across state changes.
+// in sync with GetLeadingTrailingCaptionButtonWidth() across state changes.
 // Guards against the Qt-theme regression where a fixed estimate was used
 // instead of real button bounds, causing caption buttons to overlap the
 // toolbar.
 IN_PROC_BROWSER_TEST_F(BraveToolbarViewTest,
                        ToolbarPaddingMatchesFrameLayoutParams) {
-  auto* frame_view = BrowserView::GetBrowserViewForBrowser(browser())
-                         ->browser_widget()
-                         ->GetFrameView();
+  auto* browser_widget =
+      BrowserView::GetBrowserViewForBrowser(browser())->browser_widget();
   auto* container_view = toolbar_view_->location_bar_view()->parent();
   auto* prefs = browser()->profile()->GetPrefs();
 
@@ -629,11 +627,8 @@ IN_PROC_BROWSER_TEST_F(BraveToolbarViewTest,
   prefs->SetBoolean(brave_tabs::kVerticalTabsShowTitleOnWindow, false);
   RunScheduledLayouts();
 
-  const auto params = frame_view->GetBrowserLayoutParams();
-  const int expected_left =
-      base::ClampCeil(params.leading_exclusion.ContentWithPadding().width());
-  const int expected_right =
-      base::ClampCeil(params.trailing_exclusion.ContentWithPadding().width());
+  auto [expected_left, expected_right] =
+      tabs::utils::GetLeadingTrailingCaptionButtonWidth(browser_widget);
 
   // If both exclusions are zero (headless / no caption buttons) the early-
   // return optimisation may leave the border as null — treat null as zero.

--- a/browser/ui/views/toolbar/brave_toolbar_view_browsertest.cc
+++ b/browser/ui/views/toolbar/brave_toolbar_view_browsertest.cc
@@ -8,6 +8,7 @@
 #include "base/check.h"
 #include "base/functional/callback_helpers.h"
 #include "base/memory/raw_ptr.h"
+#include "base/numerics/safe_conversions.h"
 #include "base/test/scoped_feature_list.h"
 #include "brave/browser/ui/tabs/brave_split_tab_menu_model.h"
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
@@ -40,6 +41,7 @@
 #include "chrome/browser/ui/side_panel/side_panel_entry_key.h"
 #include "chrome/browser/ui/tabs/split_tab_menu_model.h"
 #include "chrome/browser/ui/tabs/tab_strip_model.h"
+#include "chrome/browser/ui/views/frame/browser_frame_view.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
 #include "chrome/browser/ui/views/frame/custom_corners_background.h"
 #include "chrome/browser/ui/views/frame/toolbar_button_provider.h"
@@ -604,4 +606,50 @@ IN_PROC_BROWSER_TEST_F(BraveToolbarViewTest,
   // Disable vertical tabs - button should be hidden again.
   prefs->SetBoolean(brave_tabs::kVerticalTabsEnabled, false);
   EXPECT_FALSE(button->GetVisible());
+}
+
+// Verifies that UpdateHorizontalPadding() keeps the toolbar container border
+// in sync with BrowserFrameView::GetBrowserLayoutParams() across state changes.
+// Guards against the Qt-theme regression where a fixed estimate was used
+// instead of real button bounds, causing caption buttons to overlap the
+// toolbar.
+IN_PROC_BROWSER_TEST_F(BraveToolbarViewTest,
+                       ToolbarPaddingMatchesFrameLayoutParams) {
+  auto* frame_view = BrowserView::GetBrowserViewForBrowser(browser())
+                         ->browser_widget()
+                         ->GetFrameView();
+  auto* container_view = toolbar_view_->location_bar_view()->parent();
+  auto* prefs = browser()->profile()->GetPrefs();
+
+  // Default: vertical tabs disabled — no border.
+  EXPECT_FALSE(container_view->GetBorder());
+
+  // Enable vertical tabs, hide title bar.
+  prefs->SetBoolean(brave_tabs::kVerticalTabsEnabled, true);
+  prefs->SetBoolean(brave_tabs::kVerticalTabsShowTitleOnWindow, false);
+  RunScheduledLayouts();
+
+  const auto params = frame_view->GetBrowserLayoutParams();
+  const int expected_left =
+      base::ClampCeil(params.leading_exclusion.ContentWithPadding().width());
+  const int expected_right =
+      base::ClampCeil(params.trailing_exclusion.ContentWithPadding().width());
+
+  // If both exclusions are zero (headless / no caption buttons) the early-
+  // return optimisation may leave the border as null — treat null as zero.
+  const auto* border = container_view->GetBorder();
+  const gfx::Insets actual = border ? border->GetInsets() : gfx::Insets();
+  EXPECT_EQ(actual.left(), expected_left);
+  EXPECT_EQ(actual.right(), expected_right);
+
+  // Show title bar → padding cleared.
+  prefs->SetBoolean(brave_tabs::kVerticalTabsShowTitleOnWindow, true);
+  RunScheduledLayouts();
+  EXPECT_FALSE(container_view->GetBorder());
+
+  // Hide title bar again, then disable vertical tabs → padding cleared.
+  prefs->SetBoolean(brave_tabs::kVerticalTabsShowTitleOnWindow, false);
+  prefs->SetBoolean(brave_tabs::kVerticalTabsEnabled, false);
+  RunScheduledLayouts();
+  EXPECT_FALSE(container_view->GetBorder());
 }

--- a/browser/ui/views/toolbar/brave_toolbar_view_browsertest.cc
+++ b/browser/ui/views/toolbar/brave_toolbar_view_browsertest.cc
@@ -620,7 +620,8 @@ IN_PROC_BROWSER_TEST_F(BraveToolbarViewTest,
   auto* prefs = browser()->profile()->GetPrefs();
 
   // Default: vertical tabs disabled — no border.
-  EXPECT_FALSE(container_view->GetBorder());
+  EXPECT_FALSE(container_view->GetBorder())
+      << "default state (vertical tabs disabled)";
 
   // Enable vertical tabs, hide title bar.
   prefs->SetBoolean(brave_tabs::kVerticalTabsEnabled, true);
@@ -634,17 +635,20 @@ IN_PROC_BROWSER_TEST_F(BraveToolbarViewTest,
   // return optimisation may leave the border as null — treat null as zero.
   const auto* border = container_view->GetBorder();
   const gfx::Insets actual = border ? border->GetInsets() : gfx::Insets();
-  EXPECT_EQ(actual.left(), expected_left);
-  EXPECT_EQ(actual.right(), expected_right);
+  EXPECT_EQ(actual.left(), expected_left)
+      << "after enabling vertical tabs, hiding title bar";
+  EXPECT_EQ(actual.right(), expected_right)
+      << "after enabling vertical tabs, hiding title bar";
 
   // Show title bar → padding cleared.
   prefs->SetBoolean(brave_tabs::kVerticalTabsShowTitleOnWindow, true);
   RunScheduledLayouts();
-  EXPECT_FALSE(container_view->GetBorder());
+  EXPECT_FALSE(container_view->GetBorder())
+      << "after enabling vertical tabs, showing title bar";
 
   // Hide title bar again, then disable vertical tabs → padding cleared.
   prefs->SetBoolean(brave_tabs::kVerticalTabsShowTitleOnWindow, false);
   prefs->SetBoolean(brave_tabs::kVerticalTabsEnabled, false);
   RunScheduledLayouts();
-  EXPECT_FALSE(container_view->GetBorder());
+  EXPECT_FALSE(container_view->GetBorder()) << "after disabling vertical tabs";
 }


### PR DESCRIPTION
When vertical tabs with hidden title bar is enabled, window control buttons overlapped the toolbar on Linux with the Qt theme. GTK theme worked correctly.

The root cause was in GetLeadingTrailingCaptionButtonWidth(): it branched on UsingSystemTheme() which returns true for both GTK and Qt. The GTK path cast the frame view to BraveBrowserFrameViewLinuxNative to read actual button bounds. However, Qt doesn't use the native frame view (QtUi::CreateNavButtonProvider() returns nullptr), so the cast failed silently and returned zero-width exclusions, causing overlap.

Replace the custom GetLeadingTrailingCaptionButtonWidth() with upstream Chromium's BrowserFrameView::GetBrowserLayoutParams(), which reads actual button positions post-layout from whichever frame view is active. This works correctly for GTK, Qt, Classic, Windows, and macOS without platform-specific branching.

Also add a Layout(PassKey) override in BraveOpaqueBrowserFrameView to call UpdateHorizontalPadding() after buttons are positioned, fixing the overlap that occurred after theme switches before the next manual window resize.

Qt:
<img width="845" height="626" alt="image" src="https://github.com/user-attachments/assets/16d159a8-b0bf-4fc7-a127-2e1c4264fe52" />

Classic:
<img width="833" height="607" alt="image" src="https://github.com/user-attachments/assets/54306354-847c-46d4-8729-b4bf03211817" />

Gtk:
<img width="845" height="626" alt="image" src="https://github.com/user-attachments/assets/61745759-8082-4e07-bd80-c182c6ab2073" />

Windows:
<img width="840" alt="image" src="https://github.com/user-attachments/assets/c31f20db-d51a-4585-9021-23505b131f6d" />

macOS:
<img width="840" alt="image" src="https://github.com/user-attachments/assets/08ef3329-2ed6-4bbd-9748-1de2daec47c4" />

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/54471

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
