### PR TITLE
[iOS] Update Shred settings UI to display descriptions for each option

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/ShredSettingsView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/ShredSettingsView.swift
@@ -14,25 +14,31 @@ struct ShredSettingsView: View {
 
   var body: some View {
     Form {
-      FormPicker(selection: $settings.shredLevel) {
-        ForEach(SiteShredLevel.allCases) { level in
-          Text(level.localizedTitle)
-            .foregroundColor(Color(.secondaryBraveLabel))
+      Section {
+        Picker(selection: $settings.shredLevel) {
+          ForEach(SiteShredLevel.allCases) { level in
+            LabelView(
+              title: level.localizedTitle,
+              subtitle: level.localizedDescription
+            )
             .tag(level)
+          }
+        } label: {
+          EmptyView()
         }
-      } label: {
-        LabelView(
-          title: Strings.Shields.autoShred,
-          subtitle: nil
-        )
+        .pickerStyle(.inline)
+        .listRowBackground(Color(.secondaryBraveGroupedBackground))
+      } header: {
+        Text(Strings.Shields.autoShredSectionTitle)
       }
-      .listRowBackground(Color(.secondaryBraveGroupedBackground))
-      ToggleView(
-        title: Strings.Shields.shredHistoryRowTitle,
-        subtitle: Strings.Shields.shredHistoryRowDescription,
-        toggle: $settings.shredHistoryItems
-      )
-      .listRowBackground(Color(.secondaryBraveGroupedBackground))
+      Section {
+        ToggleView(
+          title: Strings.Shields.shredHistoryRowTitle,
+          subtitle: Strings.Shields.shredHistoryRowDescription,
+          toggle: $settings.shredHistoryItems
+        )
+        .listRowBackground(Color(.secondaryBraveGroupedBackground))
+      }
     }
     .scrollContentBackground(.hidden)
     .background(Color(UIColor.braveGroupedBackground))

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/ShredSiteSettingsView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/ShredSiteSettingsView.swift
@@ -99,4 +99,15 @@ extension SiteShredLevel: Identifiable {
       return Strings.Shields.shredOnAppClose
     }
   }
+
+  var localizedDescription: String {
+    switch self {
+    case .never:
+      return Strings.Shields.shredNeverDescription
+    case .whenSiteClosed:
+      return Strings.Shields.shredOnSiteTabsClosedDescription
+    case .appExit:
+      return Strings.Shields.shredOnAppCloseDescription
+    }
+  }
 }

--- a/ios/brave-ios/Sources/BraveShields/ShieldStrings.swift
+++ b/ios/brave-ios/Sources/BraveShields/ShieldStrings.swift
@@ -388,6 +388,15 @@ extension Strings.Shields {
     comment: "An option setting for never automatically shreding site data"
   )
 
+  /// The description for never automatically shreding site data
+  public static let shredNeverDescription = NSLocalizedString(
+    "ShredNeverDescription",
+    tableName: "BraveShared",
+    bundle: .module,
+    value: "Browsing data is never shred automatically",
+    comment: "The description for never automatically shreding site data"
+  )
+
   /// An option setting for shredding when the site is closed
   public static let shredOnSiteTabsClosed = NSLocalizedString(
     "ShredOnSiteTabsClosed",
@@ -397,6 +406,15 @@ extension Strings.Shields {
     comment: "An option setting for automatically shredding when the site is closed"
   )
 
+  /// The description for shredding when the site is closed
+  public static let shredOnSiteTabsClosedDescription = NSLocalizedString(
+    "ShredOnSiteTabsClosedDescription",
+    tableName: "BraveShared",
+    bundle: .module,
+    value: "Browsing data is automatically shredded when all tabs open to a site are closed",
+    comment: "The description for shredding when the site is closed"
+  )
+
   /// An option setting for shredding when the app is closed
   public static let shredOnAppClose = NSLocalizedString(
     "ShredOnAppClose",
@@ -404,6 +422,24 @@ extension Strings.Shields {
     bundle: .module,
     value: "App Close",
     comment: "An option setting for automatically shredding only when the app is closed"
+  )
+
+  /// The description for shredding when the app is closed
+  public static let shredOnAppCloseDescription = NSLocalizedString(
+    "ShredOnAppCloseDescription",
+    tableName: "BraveShared",
+    bundle: .module,
+    value: "Browsing data is automatically shredded when the Brave app is closed / restarted",
+    comment: "The description for shredding when the app is closed"
+  )
+
+  /// The title for the auto shred section in settings
+  public static let autoShredSectionTitle = NSLocalizedString(
+    "AutoShredSectionTitle",
+    tableName: "BraveShared",
+    bundle: .module,
+    value: "Automatically Shred Browsing Data",
+    comment: "The description for shredding when the app is closed"
   )
 
   /// A title for a confirmation window that appears when a user clicks on 'Shred Data'


### PR DESCRIPTION
- Update the Shred main settings UI to use an inline picker for Auto Shred displaying descriptions of each auto shred method.

Resolves https://github.com/brave/brave-browser/issues/55004

<img width="300" alt="Shred UI Update" src="https://github.com/user-attachments/assets/29a01ca7-c34a-467b-81ab-30dcbfded158" />

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

### Testplan

- Verify updated UI includes Auto Shred descriptions in Settings > Shields & Privacy > Shred
- Verify the setting still works (select a non-default option, check shields panel for any random website, check setting is persisted).