### PR TITLE
[Android] Fixed background outline when performing a password search (uplift to 1.90.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/password_manager/settings/PasswordSettings.java
+++ b/android/java/org/chromium/chrome/browser/password_manager/settings/PasswordSettings.java
@@ -563,6 +563,9 @@ public class PasswordSettings extends ChromeBaseSettingsFragment
                 displayPasswordNoResultScreenMessage();
             }
         }
+        // Notify SettingsActivity so it recalculates the containment decoration range to include
+        // all dynamically-added password items.
+        notifyPreferencesUpdated();
     }
 
     /**
@@ -619,6 +622,7 @@ public class PasswordSettings extends ChromeBaseSettingsFragment
             args.putInt(PASSWORD_LIST_ID, i);
             profileCategory.addPreference(preference);
         }
+        notifyPreferencesUpdated();
     }
 
     @Override


### PR DESCRIPTION
Uplift of #36132
Resolves https://github.com/brave/brave-browser/issues/55182

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.