### PR TITLE
[Rewards] Do not enter panel loading state on update (uplift to 1.91.x)

### DIFF
--- a/components/brave_rewards/resources/rewards_page/webui/browser_app_store.ts
+++ b/components/brave_rewards/resources/rewards_page/webui/browser_app_store.ts
@@ -348,7 +348,6 @@ export function createAppStore(): AppStore {
     // should be wrapped with this decorator.
     const inBackground = (promise: Promise<unknown>) => null
 
-    store.update({ loading: true })
     loadTimer.start(3000, () => store.update({ loading: false }))
 
     await Promise.all([
@@ -388,7 +387,10 @@ export function createAppStore(): AppStore {
       'visibilitychange',
       debounce(() => {
         if (document.visibilityState === 'visible') {
-          store.update({ openTime: Date.now() })
+          store.update({
+            loading: true,
+            openTime: Date.now(),
+          })
           loadData()
         }
       }, 60),


### PR DESCRIPTION
Uplift of #36004
Resolves https://github.com/brave/brave-browser/issues/55050

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.