### PR TITLE
Use channel-specific icons for Brave Origin Linux packages

### DIFF
--- a/patches/chrome-installer-linux-common-installer.py.patch
+++ b/patches/chrome-installer-linux-common-installer.py.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/installer/linux/common/installer.py b/chrome/installer/linux/common/installer.py
-index 3c780c375fb9dddc93eeba12734f882abbf1aef0..62924e2c2c9a58ccf1dc35aaa8982f97c96f6313 100644
+index 3c780c375fb9dddc93eeba12734f882abbf1aef0..31dbbe9a5569cd2bc174b74a28038f0ddc56d546 100644
 --- a/chrome/installer/linux/common/installer.py
 +++ b/chrome/installer/linux/common/installer.py
 @@ -193,6 +193,8 @@ def gen_changelog(config: "InstallerConfig",
@@ -23,7 +23,7 @@ index 3c780c375fb9dddc93eeba12734f882abbf1aef0..62924e2c2c9a58ccf1dc35aaa8982f97
                  icon_suffix = "_dev"
              elif self.channel == "canary":
                  icon_suffix = "_canary"
-+        icon_suffix = {"beta": "_beta", "dev": "_dev", "nightly": "_nightly", "unstable": "_dev"}.get(self.channel, "") if self.branding == "brave" else ""
++        icon_suffix = {"beta": "_beta", "dev": "_dev", "nightly": "_nightly", "unstable": "_dev"}.get(self.channel, "") if self.branding in ("brave", "brave_origin") else ""
  
          icon_sizes = [16, 24, 32, 48, 64, 128, 256]
          logo_resources_png = []


### PR DESCRIPTION
## Summary

- The `icon_suffix` lookup in `InstallerConfig.get_icon_artifacts()` only matched `branding == "brave"`, so Brave Origin Linux packages always staged the stable `product_logo_*.png` files regardless of channel.
- As a result Brave Origin nightly ended up registering the stable Origin icon under the `brave-origin-nightly` icon name, leaving nightly visually indistinguishable from stable Origin (and easily confusable with regular Brave) in desktop environments.
- The brave_origin theme directory already ships `_beta`/`_nightly`/`_development` variants — this change just lets Brave Origin select them.

Fix brave/brave-browser#54734

## Test plan

- [ ] Install on Debian based systems and make sure the icons look correct for Brave Origin (I don't have the setup locally unfortunately)