### PR TITLE
Remove BS-012 (redundant with gn check and CS-001)

### DIFF
--- a/docs/best-practices/build-system.md
+++ b/docs/best-practices/build-system.md
@@ -126,20 +126,6 @@ See `brave/components/brave_rewards/resources/brave_rewards_static_resources.grd
 
 ---
 
-<a id="BS-012"></a>
-
-## ✅ Always Double-Check Dependencies
-
-**Always verify you have deps for all includes and used symbols.** Missing deps can work by accident through transitive dependencies but will break when those transitive deps change.
-
-```gn
-# Check for deps matching your includes:
-# #include "url/gurl.h" -> needs dep "//url"
-# #include "extensions/browser/..." -> needs dep "//extensions/browser/..."
-```
-
----
-
 <a id="BS-013"></a>
 
 ## ✅ Use `//brave/` Deps Instead of Modifying Visibility Lists


### PR DESCRIPTION
Drop the BS-012 best practice. gn check already enforces correct deps, and CS-001 already covers the C++ include-what-you-use side.