### PR TITLE
[Ads][Origin] Defer ads service start until policy service is initialized

### DIFF
--- a/browser/brave_ads/ads_service_factory.cc
+++ b/browser/brave_ads/ads_service_factory.cc
@@ -28,9 +28,11 @@
 #include "chrome/browser/history/history_service_factory.h"
 #include "chrome/browser/notifications/notification_display_service.h"
 #include "chrome/browser/notifications/notification_display_service_factory.h"
+#include "chrome/browser/policy/profile_policy_connector.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/profiles/profile_manager.h"
 #include "components/keyed_service/content/browser_context_dependency_manager.h"
+#include "components/policy/core/common/policy_service.h"
 #include "content/public/browser/browser_context.h"
 #include "content/public/browser/storage_partition.h"
 #include "services/network/public/cpp/network_context_getter.h"
@@ -109,6 +111,11 @@ AdsServiceFactory::BuildServiceInstanceForBrowserContext(
       brave_adaptive_captcha::BraveAdaptiveCaptchaServiceFactory::GetForProfile(
           profile);
 
+  policy::PolicyService* policy_service = nullptr;
+  if (auto* policy_connector = profile->GetProfilePolicyConnector()) {
+    policy_service = policy_connector->policy_service();
+  }
+
   auto delegate = std::make_unique<AdsServiceDelegate>(
       *profile, *local_state, brave_adaptive_captcha_service);
 
@@ -133,7 +140,8 @@ AdsServiceFactory::BuildServiceInstanceForBrowserContext(
   CHECK(profile_manager);
 
   return std::make_unique<AdsServiceImpl>(
-      std::move(delegate), *prefs, *local_state, std::move(http_client),
+      std::move(delegate), *prefs, *local_state, policy_service,
+      std::move(http_client),
       std::make_unique<VirtualPrefProviderDelegate>(
           *profile, profile_manager->GetProfileAttributesStorage()),
       brave::GetChannelName(), profile->GetPath(), CreateAdsTooltipsDelegate(),

--- a/components/brave_ads/browser/BUILD.gn
+++ b/components/brave_ads/browser/BUILD.gn
@@ -52,6 +52,7 @@ static_library("browser") {
     "//brave/components/brave_ads/core/mojom",
     "//brave/components/services/bat_ads/public/interfaces",
     "//components/keyed_service/core",
+    "//components/policy/core/common",
     "//mojo/public/cpp/bindings",
   ]
 

--- a/components/brave_ads/browser/DEPS
+++ b/components/brave_ads/browser/DEPS
@@ -4,6 +4,7 @@ include_rules = [
   "+components/content_settings",
   "+components/metrics",
   "+components/history",
+  "+components/policy/core/common",
   "+components/prefs",
   "+components/variations",
   "+content/public/browser",

--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -56,6 +56,7 @@
 #include "components/content_settings/core/common/content_settings.h"
 #include "components/content_settings/core/common/content_settings_pattern.h"
 #include "components/metrics/metrics_pref_names.h"
+#include "components/policy/core/common/policy_service.h"
 #include "components/prefs/pref_service.h"
 #include "components/variations/pref_names.h"
 #include "content/public/browser/browser_context.h"
@@ -228,14 +229,6 @@ AdsServiceImpl::~AdsServiceImpl() {
   // Defensive: in normal `KeyedService` lifecycle `Shutdown()` already removed
   // the observer. This covers tests that destruct without calling `Shutdown`.
   StopObservingPolicyService();
-}
-
-void AdsServiceImpl::StopObservingPolicyService() {
-  if (!observed_policy_service_) {
-    return;
-  }
-  observed_policy_service_->RemoveObserver(policy::POLICY_DOMAIN_CHROME, this);
-  observed_policy_service_ = nullptr;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1788,6 +1781,14 @@ void AdsServiceImpl::OnPolicyServiceInitialized(policy::PolicyDomain domain) {
   StopObservingPolicyService();
   LAZY_BLOG(1, "[AdsGate] deferred start firing now");
   MaybeStartBatAdsService();
+}
+
+void AdsServiceImpl::StopObservingPolicyService() {
+  if (!observed_policy_service_) {
+    return;
+  }
+  observed_policy_service_->RemoveObserver(policy::POLICY_DOMAIN_CHROME, this);
+  observed_policy_service_ = nullptr;
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <memory>
 #include <optional>
+#include <sstream>
 #include <utility>
 
 #include "base/base64.h"
@@ -69,6 +70,25 @@
 
 namespace brave_ads {
 
+// `LAZY_BLOG` mirrors `BLOG` from
+// `brave/components/brave_ads/core/internal/common/logging_util.h`, but with
+// the level check pulled out so the stream isn't built when the
+// `*/brave_ads/*` vmodule pattern isn't set. We can't use `VLOG` here: in
+// official Android release builds `base/logging.h` returns `-1` from the
+// templated `GetVlogLevel()` as a constexpr, which lets the compiler
+// dead-code-strip every `VLOG` site (including its string literals) for
+// binary-size reasons. `Log()` (the `AdsServiceImpl` member) routes through
+// `GetVlogLevelHelper` directly, so this macro fires whenever the
+// "Verbose Logs for Ad-Rewards" QA preference toggle is on.
+#define LAZY_BLOG(verbose_level, stream)                             \
+  do {                                                               \
+    if ((verbose_level) <=                                           \
+        ::logging::GetVlogLevelHelper(__FILE__, sizeof(__FILE__))) { \
+      Log(__FILE__, __LINE__, (verbose_level),                       \
+          (std::ostringstream() << stream).str());                   \
+    }                                                                \
+  } while (false)
+
 namespace {
 
 constexpr char kClearDataHistogramName[] = "Brave.Ads.ClearData";
@@ -120,6 +140,7 @@ AdsServiceImpl::AdsServiceImpl(
     std::unique_ptr<Delegate> delegate,
     PrefService& prefs,
     PrefService& local_state,
+    policy::PolicyService* policy_service,
     std::unique_ptr<HttpClient> http_client,
     std::unique_ptr<VirtualPrefProvider::Delegate>
         virtual_pref_provider_delegate,
@@ -174,10 +195,48 @@ AdsServiceImpl::AdsServiceImpl(
   InitializeLocalStatePrefChangeRegistrar();
   InitializePrefChangeRegistrar();
 
-  MaybeStartBatAdsService();
+  // Defer the initial start until the policy bundle has been merged into
+  // the managed pref store, so that BraveRewardsDisabled (and any other
+  // policy that gates ads eligibility) takes effect before the gate
+  // evaluates. If the service is already initialized, start immediately;
+  // otherwise observe and wait for `OnPolicyServiceInitialized`.
+  const bool has_policy_service = policy_service != nullptr;
+  const bool policy_init_complete =
+      has_policy_service &&
+      policy_service->IsInitializationComplete(policy::POLICY_DOMAIN_CHROME);
+  LAZY_BLOG(1,
+            "[AdsGate] AdsServiceImpl ctor"
+                << " has_policy_service=" << has_policy_service
+                << " policy_init_complete=" << policy_init_complete
+                << " is_managed="
+                << prefs_->IsManagedPreference(
+                       brave_rewards::prefs::kDisabledByPolicy)
+                << " disabled_by_policy="
+                << prefs_->GetBoolean(brave_rewards::prefs::kDisabledByPolicy));
+
+  if (!has_policy_service || policy_init_complete) {
+    LAZY_BLOG(1, "[AdsGate] starting immediately at ctor");
+    MaybeStartBatAdsService();
+  } else {
+    LAZY_BLOG(1, "[AdsGate] deferring start, observing PolicyService");
+    policy_service->AddObserver(policy::POLICY_DOMAIN_CHROME, this);
+    observed_policy_service_ = policy_service;
+  }
 }
 
-AdsServiceImpl::~AdsServiceImpl() = default;
+AdsServiceImpl::~AdsServiceImpl() {
+  // Defensive: in normal `KeyedService` lifecycle `Shutdown()` already removed
+  // the observer. This covers tests that destruct without calling `Shutdown`.
+  StopObservingPolicyService();
+}
+
+void AdsServiceImpl::StopObservingPolicyService() {
+  if (!observed_policy_service_) {
+    return;
+  }
+  observed_policy_service_->RemoveObserver(policy::POLICY_DOMAIN_CHROME, this);
+  observed_policy_service_ = nullptr;
+}
 
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -266,6 +325,16 @@ bool AdsServiceImpl::CanStartBatAdsService() const {
 }
 
 void AdsServiceImpl::MaybeStartBatAdsService() {
+  LAZY_BLOG(1,
+            "[AdsGate] MaybeStartBatAdsService"
+                << " bound=" << bat_ads_service_remote_.is_bound()
+                << " shutting_down=" << is_shutting_down_
+                << " can_start=" << CanStartBatAdsService() << " is_managed="
+                << prefs_->IsManagedPreference(
+                       brave_rewards::prefs::kDisabledByPolicy)
+                << " disabled_by_policy="
+                << prefs_->GetBoolean(brave_rewards::prefs::kDisabledByPolicy));
+
   // `is_shutting_down_` is set permanently when `KeyedService::Shutdown` is
   // called and the profile begins tearing down. There is no recovery from that
   // state, so any subsequent attempt to restart the service must be suppressed.
@@ -729,6 +798,15 @@ void AdsServiceImpl::InitializeSearchResultAdsPrefChangeRegistrar() {
 }
 
 void AdsServiceImpl::OnAdsPrefChanged(const std::string& path) {
+  LAZY_BLOG(1,
+            "[AdsGate] OnAdsPrefChanged path="
+                << path << " can_start=" << CanStartBatAdsService() << " bound="
+                << bat_ads_service_remote_.is_bound() << " is_managed="
+                << prefs_->IsManagedPreference(
+                       brave_rewards::prefs::kDisabledByPolicy)
+                << " disabled_by_policy="
+                << prefs_->GetBoolean(brave_rewards::prefs::kDisabledByPolicy));
+
   if (!CanStartBatAdsService()) {
     // The pref change made the service ineligible to run, so tear it down.
     return ShutdownAdsService();
@@ -1045,6 +1123,8 @@ void AdsServiceImpl::Shutdown() {
   // The profile is being destroyed and the service must never start again, so
   // this is never reset to false.
   is_shutting_down_ = true;
+
+  StopObservingPolicyService();
 
   ShutdownAdsService();
 }
@@ -1696,6 +1776,18 @@ void AdsServiceImpl::OnContentSettingChanged(
   if (content_type_set.Contains(ContentSettingsType::JAVASCRIPT)) {
     SetContentSettings();
   }
+}
+
+void AdsServiceImpl::OnPolicyServiceInitialized(policy::PolicyDomain domain) {
+  LAZY_BLOG(1, "[AdsGate] OnPolicyServiceInitialized domain="
+                   << domain << " is_chrome_domain="
+                   << (domain == policy::POLICY_DOMAIN_CHROME));
+  if (domain != policy::POLICY_DOMAIN_CHROME) {
+    return;
+  }
+  StopObservingPolicyService();
+  LAZY_BLOG(1, "[AdsGate] deferred start firing now");
+  MaybeStartBatAdsService();
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/browser/ads_service_impl.h
+++ b/components/brave_ads/browser/ads_service_impl.h
@@ -40,6 +40,7 @@
 #include "components/content_settings/core/browser/content_settings_type_set.h"
 #include "components/content_settings/core/common/content_settings_pattern.h"
 #include "components/history/core/browser/history_service.h"
+#include "components/policy/core/common/policy_service.h"
 #include "components/prefs/pref_change_registrar.h"
 #include "mojo/public/cpp/bindings/associated_receiver.h"
 #include "mojo/public/cpp/bindings/associated_remote.h"
@@ -77,7 +78,8 @@ class AdsServiceImpl : public AdsService,
 #if BUILDFLAG(ENABLE_BRAVE_REWARDS)
                        public brave_rewards::RewardsServiceObserver,
 #endif
-                       public content_settings::Observer {
+                       public content_settings::Observer,
+                       public policy::PolicyService::Observer {
  public:
   // `http_client`, `resource_component`, `history_service`, and
   // `host_content_settings` can be `nullptr` in tests. `rewards_service`
@@ -86,6 +88,7 @@ class AdsServiceImpl : public AdsService,
       std::unique_ptr<Delegate> delegate,
       PrefService& prefs,
       PrefService& local_state,
+      policy::PolicyService* policy_service,
       std::unique_ptr<HttpClient> http_client,
       std::unique_ptr<VirtualPrefProvider::Delegate>
           virtual_pref_provider_delegate,
@@ -389,6 +392,13 @@ class AdsServiceImpl : public AdsService,
       const ContentSettingsPattern& secondary_pattern,
       ContentSettingsTypeSet content_type_set) override;
 
+  // policy::PolicyService::Observer:
+  void OnPolicyServiceInitialized(policy::PolicyDomain domain) override;
+
+  // No-op if not observing. Called from `OnPolicyServiceInitialized`,
+  // `Shutdown`, and the destructor; whichever runs first wins.
+  void StopObservingPolicyService();
+
   bool is_ineligible_to_start_ = false;
 
   bool is_bat_ads_initialized_ = false;
@@ -455,6 +465,8 @@ class AdsServiceImpl : public AdsService,
 #endif  // BUILDFLAG(ENABLE_BRAVE_REWARDS)
   base::ScopedObservation<ApplicationStateMonitor, ApplicationStateObserver>
       application_state_monitor_observation_{this};
+
+  raw_ptr<policy::PolicyService> observed_policy_service_ = nullptr;
 
   mojo::Receiver<bat_ads::mojom::BatAdsObserver> bat_ads_observer_receiver_{
       this};

--- a/components/brave_ads/browser/ads_service_impl.h
+++ b/components/brave_ads/browser/ads_service_impl.h
@@ -84,6 +84,9 @@ class AdsServiceImpl : public AdsService,
   // `http_client`, `resource_component`, `history_service`, and
   // `host_content_settings` can be `nullptr` in tests. `rewards_service`
   // can be `nullptr` when Rewards is unsupported or disabled by policy.
+  // `policy_service` can be `nullptr` in tests; when null, the initial
+  // ads-eligibility gate is evaluated synchronously instead of waiting
+  // for `OnPolicyServiceInitialized`.
   explicit AdsServiceImpl(
       std::unique_ptr<Delegate> delegate,
       PrefService& prefs,

--- a/components/brave_ads/browser/ads_service_impl_unittest.cc
+++ b/components/brave_ads/browser/ads_service_impl_unittest.cc
@@ -80,7 +80,7 @@ class BraveAdsAdsServiceImplTest : public testing::Test {
 
     ads_service_ = std::make_unique<AdsServiceImpl>(
         std::make_unique<test::FakeAdsServiceDelegate>(), prefs_, local_state_,
-        /*http_client=*/nullptr,
+        /*policy_service=*/nullptr, /*http_client=*/nullptr,
         std::make_unique<test::FakeVirtualPrefProviderDelegate>(),
         /*channel_name=*/"foo", profile_dir_.GetPath(),
         std::make_unique<test::FakeAdsTooltipsDelegate>(), std::move(device_id),


### PR DESCRIPTION
The ads gate reads `kDisabledByPolicy` via `IsManagedPreference`, so if `AdsServiceImpl` is constructed before the BraveOrigin policy bundle has been merged into the managed pref store, the gate evaluates as unmanaged and the service starts. NTT ads can then serve despite `BraveRewardsDisabled` being active.

Defer the initial `MaybeStartBatAdsService()` call until `PolicyService::IsInitializationComplete(POLICY_DOMAIN_CHROME)` is true. Adds `[AdsGate]` diagnostics behind the existing "Verbose Logs for Ad-Rewards" QA toggle.

## Test cases

### Test case 1:
Make sure that following issue cannot be reproduced:
https://github.com/brave/brave-browser/issues/54991

### Test case 2:
1. Start the browser (non Brave Origin)
2. Make sure that NTTs can be served
3. Open any web page
4. Restart the browser
5. Open NTP (without much a delay)
EXPECTATION: NTT is displayed

### Test case 3:
1. Start the browser (non Brave Origin)
2. Enable Rewards
3. Open search.brave.com
4. Trigger a search result ad
5. Restart the browser
6. Click the "search result ad" on restored tab with SERP (without much a delay)
7. Open [brave://ads-internals](chrome://ads-internals/)
EXPECTATION: Search result ad clicked event is recorded.

Resolves: https://github.com/brave/brave-browser/issues/55228
Resolves: https://github.com/brave/brave-browser/issues/54991

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
