### PR TITLE
[plaster][History Embeddings] Hide omnibox thumbs up/down and fix disclaimer trailing space

### DIFF
--- a/patches/components-omnibox-browser-featured_search_provider.cc.patch
+++ b/patches/components-omnibox-browser-featured_search_provider.cc.patch
@@ -1,14 +1,14 @@
 diff --git a/components/omnibox/browser/featured_search_provider.cc b/components/omnibox/browser/featured_search_provider.cc
-index 766588861b85c3a4ef69ed85522761aaf41cb620..8543840c0640d303ddd2b59934a743551480604c 100644
+index 766588861b85c3a4ef69ed85522761aaf41cb620..2cf5c1a4b3b24f47fca2fc6a469ec31952b73f44 100644
 --- a/components/omnibox/browser/featured_search_provider.cc
 +++ b/components/omnibox/browser/featured_search_provider.cc
-@@ -611,10 +611,10 @@ bool FeaturedSearchProvider::ShouldShowHistoryEmbeddingsDisclaimerIphMatch()
+@@ -611,10 +611,9 @@ bool FeaturedSearchProvider::ShouldShowHistoryEmbeddingsDisclaimerIphMatch()
  
  void FeaturedSearchProvider::AddHistoryEmbeddingsDisclaimerIphMatch() {
    std::u16string text =
 -      l10n_util::GetStringUTF16(IDS_OMNIBOX_HISTORY_EMBEDDINGS_DISCLAIMER_IPH) +
-+      l10n_util::GetStringUTF16(IDS_BRAVE_OMNIBOX_HISTORY_EMBEDDINGS_DISCLAIMER_IPH) +
-       u" ";
+-      u" ";
++      l10n_util::GetStringUTF16(IDS_BRAVE_OMNIBOX_HISTORY_EMBEDDINGS_DISCLAIMER_IPH);
    std::u16string link_text = l10n_util::GetStringUTF16(
 -      IDS_OMNIBOX_HISTORY_EMBEDDINGS_DISCLAIMER_IPH_LINK_TEXT);
 +      IDS_BRAVE_EMPTY_STRING);

--- a/patches/components-omnibox-browser-omnibox_popup_selection.cc.patch
+++ b/patches/components-omnibox-browser-omnibox_popup_selection.cc.patch
@@ -1,0 +1,13 @@
+diff --git a/components/omnibox/browser/omnibox_popup_selection.cc b/components/omnibox/browser/omnibox_popup_selection.cc
+index 85ecfaced51d2956aaa20d7e24eb5a7adf2ab97c..0bc63aa39f779e545aca225df611413926ca8cb2 100644
+--- a/components/omnibox/browser/omnibox_popup_selection.cc
++++ b/components/omnibox/browser/omnibox_popup_selection.cc
+@@ -68,7 +68,7 @@ bool OmniboxPopupSelection::IsControlPresentOnMatch(
+     }
+     case FOCUSED_BUTTON_THUMBS_UP:
+     case FOCUSED_BUTTON_THUMBS_DOWN:
+-      return match.type == AutocompleteMatchType::HISTORY_EMBEDDINGS;
++      return false;
+     case FOCUSED_BUTTON_REMOVE_SUGGESTION:
+       return match.SupportsDeletion();
+     case FOCUSED_IPH_LINK:

--- a/rewrite/components/omnibox/browser/featured_search_provider.cc.toml
+++ b/rewrite/components/omnibox/browser/featured_search_provider.cc.toml
@@ -16,6 +16,11 @@ re_pattern = '\bIDS_OMNIBOX_HISTORY_EMBEDDINGS_DISCLAIMER_IPH_LINK_TEXT\b'
 replace = 'IDS_BRAVE_EMPTY_STRING'
 
 [[substitution]]
+description = 'Drop the upstream " " separator appended after the disclaimer text. With the trailing link text swapped to IDS_BRAVE_EMPTY_STRING, the separator would leave match.contents with a trailing space that fails AutocompleteMatch::SanitizeString in AutocompleteResult::AppendMatches.'
+re_pattern = '(IDS_OMNIBOX_HISTORY_EMBEDDINGS_DISCLAIMER_IPH\))\s*\+\s*u" "'
+replace = '\1'
+
+[[substitution]]
 description = 'Swap IDS_OMNIBOX_HISTORY_EMBEDDINGS_DISCLAIMER_IPH to the Brave-owned string.'
 re_pattern = '\bIDS_OMNIBOX_HISTORY_EMBEDDINGS_DISCLAIMER_IPH\b'
 replace = 'IDS_BRAVE_OMNIBOX_HISTORY_EMBEDDINGS_DISCLAIMER_IPH'

--- a/rewrite/components/omnibox/browser/omnibox_popup_selection.cc.toml
+++ b/rewrite/components/omnibox/browser/omnibox_popup_selection.cc.toml
@@ -1,0 +1,18 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+# Brave's history semantic search runs entirely on-device and never sends
+# data anywhere. Suppress the omnibox thumbs up/down feedback buttons that
+# upstream attaches to HISTORY_EMBEDDINGS matches so no feedback UI is
+# reachable from the URL bar. With these selections never available,
+# OmniboxResultView::UpdateFeedbackButtonsVisibility keeps the buttons
+# hidden and keyboard/selection traversal skips over them.
+
+[[substitution]]
+description = 'Never expose thumbs up/down feedback buttons on omnibox HISTORY_EMBEDDINGS matches.'
+re_pattern = 'case FOCUSED_BUTTON_THUMBS_UP:\s+case FOCUSED_BUTTON_THUMBS_DOWN:\s+return match\.type == AutocompleteMatchType::HISTORY_EMBEDDINGS;'
+replace = '''case FOCUSED_BUTTON_THUMBS_UP:
+    case FOCUSED_BUTTON_THUMBS_DOWN:
+      return false;'''

--- a/tools/cr/plaster.py
+++ b/tools/cr/plaster.py
@@ -413,6 +413,7 @@ def main():
         '🩹 A tool to generate patches into Chromium using plaster files.')
     parser.add_argument('--verbose',
                         action='store_true',
+                        default=True,
                         help='Enable verbose logging')
     parser.add_argument('--infra-mode',
                         action='store_true',


### PR DESCRIPTION
Follow-up to #35813 / brave-browser#54798. The previous PR removed the
WebUI feedback buttons on chrome://history and the side panel, but the
native Views omnibox still surfaced thumbs up/down on HISTORY_EMBEDDINGS
matches when the user typed `@history`
(brave-browser#55178).

- Plaster `OmniboxPopupSelection::IsControlPresentOnMatch` to return
  false for FOCUSED_BUTTON_THUMBS_UP/DOWN. With the selection never
  available, OmniboxResultView::UpdateFeedbackButtonsVisibility keeps
  the buttons hidden, keyboard traversal skips them, and the
  feedback page can no longer be reached from the omnibox.

- Extend the existing featured_search_provider.cc plaster to drop the
  upstream `+ u\" \"` separator appended after the disclaimer text.
  With the link text already swapped to IDS_BRAVE_EMPTY_STRING, the
  separator left match.contents with a trailing space that tripped the
  AutocompleteMatch::SanitizeString DCHECK in
  AutocompleteResult::AppendMatches.
