### PR TITLE
[toolchain] Rust build script under rebase tooling

### DIFF
--- a/tools/cr/toolchain/README.md
+++ b/tools/cr/toolchain/README.md
@@ -1,0 +1,38 @@
+# Browser Toolchain Scripts
+
+This directory contains scripts for generating browser toolchains (compilers,
+linkers, standard libraries, etc.) used by the Brave build.
+
+## Design rules
+
+Scripts here are designed to be launched with a single `curl` one-liner,
+so they must be **self-contained in a single source file** with **no
+dependencies outside the Python standard library** (or the platform's
+default tooling such as `git`). Do not split logic across helper modules or
+add third-party imports.
+
+Example invocation pattern:
+
+```sh
+curl -sL \
+    https://raw.githubusercontent.com/brave/brave-core/refs/heads/master/tools/cr/toolchain/<script>.py \
+    | python3 - [args...]
+```
+
+## Scripts
+
+### `build_rust_toolchain.py`
+
+Builds and packages a minimal Rust toolchain subset for Chromium: the
+`rust-lld` linker and the `wasm32-unknown-unknown` stage-1 standard-library
+sysroot. The output is a `.tar.xz` archive ready for upload to GCS.
+
+```sh
+curl -sL \
+    https://raw.githubusercontent.com/brave/brave-core/refs/heads/master/tools/cr/toolchain/build_rust_toolchain.py \
+    | python3 - \
+        --out-dir=./out/ \
+        --chromium-src=~/dev/chromium/src/
+```
+
+Pass `--help` for the full list of options.

--- a/tools/cr/toolchain/build_rust_toolchain.py
+++ b/tools/cr/toolchain/build_rust_toolchain.py
@@ -12,7 +12,7 @@ To use this straight from Github just call:
 
 ```sh
 curl -sL \
-    https://raw.githubusercontent.com/brave/brave-core/refs/heads/master/tools/rust/build_rust_toolchain_standalone.py \
+    https://raw.githubusercontent.com/brave/brave-core/refs/heads/master/tools/cr/toolchain/build_rust_toolchain.py \
     | python3 - \
         --out-dir=./out/ \
         --chromium-src=~/dev/chromium/src/
@@ -22,7 +22,7 @@ If you do not have a Chromium checkout yet, pass `--clone-chromium` together
 with `--use-ref` to have the script fetch one automatically:
 
 ```sh
-python3 build_rust_toolchain_standalone.py \
+python3 build_rust_toolchain.py \
     --out-dir=./out/ \
     --chromium-src=~/dev/chromium/src/ \
     --clone-chromium \
@@ -111,6 +111,7 @@ if sys.platform == 'win32':
     # Path to Git's sh.exe on Windows, which is used by
     # `tools/rust/build_rust.py` to build the toolchain on Windows.`
     GIT_SH_PRESUMED_BIN_PATH = Path(r'C:\Program Files\Git\bin\sh.exe')
+
 
 def _check_call(*command, cwd=None):
     """Run *command* as a subprocess, logging the invocation and any stderr.
@@ -208,7 +209,6 @@ class ToolchainBuilder:
 
         # Module for tools/rust/package_rust.py. Initialised by `run()`.
         self.package_rust_module: Optional[ModuleType] = None
-
 
     @contextlib.contextmanager
     def _temporary_config_toml_template_edits(self):


### PR DESCRIPTION
This change moves the script used to generate the rust WASM toolchain
under `tools/cr/toolchains`, as tooling packaging is a Chromium rebase
concern, and it is better kept under the rebase's team purview. A
separate PR has been submitted to fix CI.
