### PR TITLE
Fix horizontal tab strip height regression on Linux

### DIFF
--- a/browser/ui/views/frame/BUILD.gn
+++ b/browser/ui/views/frame/BUILD.gn
@@ -82,8 +82,11 @@ source_set("browser_tests") {
     sources += [ "//brave/browser/ui/views/frame/brave_browser_frame_view_linux_browsertest.cc" ]
 
     deps += [
+      "//base/test:test_support",
       "//brave/browser/ui:brave_tab_prefs",
       "//chrome/browser/themes",
+      "//chrome/browser/ui:layout_constants",
+      "//chrome/browser/ui/tabs:features",
       "//chrome/browser/ui/views/frame",
       "//components/prefs",
       "//ui/linux:test_support",

--- a/browser/ui/views/frame/brave_browser_frame_view_linux_browsertest.cc
+++ b/browser/ui/views/frame/brave_browser_frame_view_linux_browsertest.cc
@@ -7,13 +7,17 @@
 
 #include "base/memory/raw_ptr.h"
 #include "base/memory/raw_ref.h"
+#include "base/test/scoped_feature_list.h"
 #include "brave/browser/ui/browser_commands.h"
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
 #include "brave/browser/ui/views/frame/brave_browser_frame_view_linux_native.h"
+#include "brave/browser/ui/views/frame/brave_opaque_browser_frame_view.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/themes/theme_service.h"
 #include "chrome/browser/themes/theme_service_factory.h"
 #include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/layout_constants.h"
+#include "chrome/browser/ui/tabs/features.h"
 #include "chrome/browser/ui/views/frame/browser_frame_view.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
 #include "chrome/browser/ui/views/frame/custom_corners_background.h"
@@ -212,3 +216,70 @@ IN_PROC_BROWSER_TEST_F(
   EXPECT_EQ(window_corners.upper_right(), tc_radii->upper_right());
   EXPECT_EQ(window_corners.upper_left(), tc_radii->upper_left());
 }
+
+// Parameterized fixture: bool param = compact mode enabled.
+// Enables #brave-compact-horizontal-tabs in the constructor so the layout
+// constants are in effect when the browser window is created.
+class BraveBrowserFrameViewTabStripHeightTest
+    : public BraveBrowserFrameViewTest,
+      public testing::WithParamInterface<bool> {
+ public:
+  BraveBrowserFrameViewTabStripHeightTest() {
+    if (GetParam()) {
+      features_.InitAndEnableFeature(tabs::kBraveCompactHorizontalTabs);
+    }
+  }
+
+ private:
+  base::test::ScopedFeatureList features_;
+};
+
+// Verifies the horizontal tab strip height equals kTabStripHeight for both
+// default and compact modes when BraveOpaqueBrowserFrameView is active.
+//
+// Regression: PR #35778 substituted GetHorizontalTabControlsDelta() (negative)
+// for kTabstripToolbarOverlap (positive) in GetTopAreaHeight(), adding extra
+// pixels to the tab strip: 41→45 px (default, delta=-4) and 38→43 px
+// (compact, delta=-5). The fix restores
+// OpaqueBrowserFrameView::GetTopAreaHeight().
+IN_PROC_BROWSER_TEST_P(BraveBrowserFrameViewTabStripHeightTest,
+                       TabStripHeightMatchesLayoutConstant) {
+  if (!views::AsViewClass<BraveOpaqueBrowserFrameView>(frame_view())) {
+    GTEST_SKIP() << "Not using BraveOpaqueBrowserFrameView";
+  }
+
+  RunScheduledLayouts();
+
+  // Default: 32 (height) + 2*4 (spacing) + 1 (overlap) = 41
+  // Compact: 26 (height) + 2*2 (spacing) + 8 (overlap) = 38
+  const int expected_height = GetParam() ? 38 : 41;
+  EXPECT_EQ(expected_height, GetLayoutConstant(LayoutConstant::kTabStripHeight))
+      << "kTabStripHeight constant is wrong for "
+      << (GetParam() ? "compact" : "default") << " mode";
+  EXPECT_EQ(GetLayoutConstant(LayoutConstant::kTabStripHeight),
+            browser_view()->tab_strip_view()->height())
+      << "Tab strip rendered height ("
+      << browser_view()->tab_strip_view()->height()
+      << ") does not match kTabStripHeight ("
+      << GetLayoutConstant(LayoutConstant::kTabStripHeight) << ") in "
+      << (GetParam() ? "compact" : "default") << " mode";
+
+  // Verify the overlap is applied correctly: toolbar top must be exactly
+  // kTabstripToolbarOverlap pixels above the tab strip bottom.
+  const int overlap =
+      GetLayoutConstant(LayoutConstant::kTabstripToolbarOverlap);
+  EXPECT_EQ(
+      browser_view()->tab_strip_view()->GetBoundsInScreen().bottom() - overlap,
+      browser_view()->toolbar()->GetBoundsInScreen().y())
+      << "Toolbar y (" << browser_view()->toolbar()->GetBoundsInScreen().y()
+      << ") should be tab strip bottom ("
+      << browser_view()->tab_strip_view()->GetBoundsInScreen().bottom()
+      << ") minus overlap (" << overlap << ")";
+}
+
+INSTANTIATE_TEST_SUITE_P(,
+                         BraveBrowserFrameViewTabStripHeightTest,
+                         testing::Bool(),
+                         [](const testing::TestParamInfo<bool>& info) {
+                           return info.param ? "Compact" : "Default";
+                         });

--- a/browser/ui/views/frame/brave_opaque_browser_frame_view.cc
+++ b/browser/ui/views/frame/brave_opaque_browser_frame_view.cc
@@ -15,7 +15,6 @@
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/color/chrome_color_id.h"
-#include "chrome/browser/ui/layout_constants.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
 #include "chrome/browser/ui/views/frame/opaque_browser_frame_view_layout.h"
 #include "ui/base/hit_test.h"
@@ -143,13 +142,7 @@ int BraveOpaqueBrowserFrameView::GetTopAreaHeight() const {
     return layout_->NonClientTopHeight(false);
   }
 
-  const bool is_tabbed = GetBrowserView()->GetIsNormalType();
-  const auto info = GetClientFrameElementInfo();
-  const int frame_height = FrameBorderInsets(false).top();
-  const int top_height = layout_->NonClientTopHeight(false);
-  return std::max(frame_height + info.toolbar_minimum_height,
-                  top_height + info.tabstrip_preferred_height -
-                      (is_tabbed ? tabs::GetHorizontalTabControlsDelta() : 0));
+  return OpaqueBrowserFrameView::GetTopAreaHeight();
 }
 
 bool BraveOpaqueBrowserFrameView::ShouldShowVerticalTabs() const {


### PR DESCRIPTION
BraveOpaqueBrowserFrameView::GetTopAreaHeight() was changed in
99c62155d to use tabs::GetHorizontalTabControlsDelta() (-4 in default
mode, -5 in compact) instead of kTabstripToolbarOverlap (1 in default,                                                                                     
8 in compact). Subtracting a negative value adds to the height, so the                                                                                     
tab strip grew from 41px to 45px (default) instead of shrinking.                                                                                           
                                                                                                                                                             
The fix reverts GetTopAreaHeight() to delegate to the upstream                                                                                             
OpaqueBrowserFrameView::GetTopAreaHeight(), which already picks up                                                                                         
Brave's kTabstripToolbarOverlap override via GetBraveLayoutConstant()                                                                                      
and handles both default and compact modes correctly.                                                                                                      
                                                                                                                                                           
Adds a parameterized browser test covering default and compact modes                                                                                       
that asserts the rendered tab strip height matches kTabStripHeight and
that the toolbar is positioned correctly relative to the tab strip.

TEST=BraveBrowserFrameViewTabStripHeightTest

Default:
<img width="927" height="530" alt="image" src="https://github.com/user-attachments/assets/ecfd3c97-1eaf-41ea-abe1-55033596d099" />

Compact:
<img width="927" height="530" alt="image" src="https://github.com/user-attachments/assets/11dcb87a-3337-48b3-bbf7-09df1658f93e" />


<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/55167

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
