### PR TITLE
Fix motionmark cr148 regression (uplift to 1.90.x)

### DIFF
--- a/patches/third_party-blink-renderer-platform-graphics-canvas_resource_provider.cc.patch
+++ b/patches/third_party-blink-renderer-platform-graphics-canvas_resource_provider.cc.patch
@@ -1,0 +1,24 @@
+diff --git a/third_party/blink/renderer/platform/graphics/canvas_resource_provider.cc b/third_party/blink/renderer/platform/graphics/canvas_resource_provider.cc
+index 2db099a66275e6e5da3721d324a541600c18f17c..2a5f7eab63370e765c9ae798145958ef237d2250 100644
+--- a/third_party/blink/renderer/platform/graphics/canvas_resource_provider.cc
++++ b/third_party/blink/renderer/platform/graphics/canvas_resource_provider.cc
+@@ -194,6 +194,8 @@ BASE_FEATURE(kCanvas2DAutoFlushParams, base::FEATURE_DISABLED_BY_DEFAULT);
+ BASE_FEATURE(kCanvas2DReclaimUnusedResources,
+              base::FEATURE_DISABLED_BY_DEFAULT);
+ 
++BASE_FEATURE(kAppendCpuUsages, base::FEATURE_ENABLED_BY_DEFAULT);
++
+ // Controls whether we add SHARED_IMAGE_USAGE_WEBGPU_READ by default to shared
+ // image backed CanvasResources so that they can be imported into WebGPU without
+ // an intermediate copy. This could cause a different shared image backing type
+@@ -284,6 +286,10 @@ CanvasResourceProviderSharedImage::CanvasResourceProviderSharedImage(
+         // TODO(https://crbug.com/40280504): Add that usage flag back here once
+         // the issue is resolved.
+         buffer_usage = gfx::BufferUsage::SCANOUT_CPU_READ_WRITE;
++        if (base::FeatureList::IsEnabled(kAppendCpuUsages)) {
++          shared_image_usage_flags |= gpu::SHARED_IMAGE_USAGE_CPU_READ |
++                                      gpu::SHARED_IMAGE_USAGE_CPU_WRITE_ONLY;
++        }
+       }
+ 
+       gpu::ImageInfo image_info(size, format, shared_image_usage_flags,


### PR DESCRIPTION
Uplift of #36150
Resolves https://github.com/brave/brave-browser/issues/55223

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.