### PR TITLE
[iOS] Construct reader mode CSP meta tags at page construction

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Reader/ReaderModeUtils.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Reader/ReaderModeUtils.swift
@@ -58,7 +58,13 @@ struct ReaderModeUtils {
       // PAGE UNESCAPED REPLACEMENTS MUST BE DONE AFTER THIS LINE
       .replacingOccurrences(
         of: "%READER-ORIGINAL-PAGE-META-TAGS%",
-        with: readabilityResult.cspMetaTags.joined(separator: "  \n")
+        with: readabilityResult.cspMetaTags
+          .map {
+            let content =
+              $0.javaScriptEscapedString?.unquotedIfNecessary ?? $0.htmlEntityEncodedString
+            return "<meta http-equiv=\"Content-Security-Policy\" content=\"\(content)\">"
+          }
+          .joined(separator: "\n")
       )
 
       // DO NOT DO ANY REPLACEMENTS AFTER THIS LINE

--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Sandboxed/MainFrame/AtDocumentStart/ReaderModeScript.js
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Sandboxed/MainFrame/AtDocumentStart/ReaderModeScript.js
@@ -80,12 +80,15 @@ function checkReadability() {
       }
 
       
-      // Preserve the CSP meta tag
+      // Extract only the CSP policy value; the native side constructs the
+      // meta tag to prevent raw HTML injection via a crafted tag.
       delete document.querySelector;
       delete document.querySelectorAll;
       let cspMetaTags = document.querySelectorAll("meta[http-equiv=\"Content-Security-Policy\"]");
       if (cspMetaTags) {
-        readabilityResult.cspMetaTags = [...cspMetaTags].map((e) => new XMLSerializer().serializeToString(e));
+        readabilityResult.cspMetaTags = [...cspMetaTags]
+          .map((e) => e.getAttribute("content") || "")
+          .filter(Boolean);
       }
       
       let documentLanguage = document.documentElement.lang || document.querySelector('meta[http-equiv="Content-Language"]')?.content || null;

--- a/ios/browser/web/reader_mode/resources/brave_reader_mode.ts
+++ b/ios/browser/web/reader_mode/resources/brave_reader_mode.ts
@@ -94,12 +94,15 @@ function checkReadability(): string|null {
 
   readabilityResult = result as ExtendedParseResult;
 
+  // Extract only the CSP policy value; the native side constructs the
+  // meta tag to prevent raw HTML injection via a crafted tag.
   const cspMetaTags = document.querySelectorAll(
       'meta[http-equiv="Content-Security-Policy"]');
   if (cspMetaTags.length > 0) {
     readabilityResult.cspMetaTags =
-        Array.from(cspMetaTags).map(
-            (e) => new XMLSerializer().serializeToString(e));
+        Array.from(cspMetaTags)
+            .map((e) => e.getAttribute('content') ?? '')
+            .filter(Boolean);
   }
 
   const documentLanguage =


### PR DESCRIPTION
This changes the reader mode scripts to send only the actual meta tag content to the browser so that the tag can be constructed securely during reader mode page construction rather than copied in as-is.

<!-- Add brave-browser issue below that this PR will resolve -->

Resolves https://github.com/brave/brave-browser/issues/55263
Resolves https://github.com/brave/internal/issues/1724

### Test
- Verify HO report
- Re-verify https://github.com/brave/brave-browser/issues/36259
