### PR TITLE
Fix chrome url on restored tabs

### DIFF
--- a/chromium_src/content/browser/renderer_host/navigation_entry_impl.cc
+++ b/chromium_src/content/browser/renderer_host/navigation_entry_impl.cc
@@ -10,12 +10,32 @@
 #include "content/public/common/url_constants.h"
 
 #define SetVirtualURL SetVirtualURL_ChromiumImpl
+#define GetTitleForDisplay GetTitleForDisplay_ChromiumImpl
 
 #include <content/browser/renderer_host/navigation_entry_impl.cc>
 
+#undef GetTitleForDisplay
 #undef SetVirtualURL
 
 namespace content {
+
+const std::u16string& NavigationEntryImpl::GetTitleForDisplay() const {
+  const std::u16string& result = GetTitleForDisplay_ChromiumImpl();
+  // brave:// is a display-only scheme that maps to chrome:// internally. When
+  // the page title is empty, GetTitleForDisplay falls back to formatting the
+  // virtual URL as the display title. Since brave:// URLs are stored as
+  // chrome:// internally, that fallback shows "chrome://host" instead of
+  // "brave://host". Convert it for display.
+  if (title_.empty() && !cached_display_title_.empty()) {
+    static constexpr char16_t kChromePrefix[] = u"chrome://";
+    static constexpr char16_t kBravePrefix[] = u"brave://";
+    if (cached_display_title_.starts_with(kChromePrefix)) {
+      cached_display_title_.replace(0, std::size(kChromePrefix) - 1,
+                                    kBravePrefix);
+    }
+  }
+  return result;
+}
 
 // Virtual url should never be set to brave
 void NavigationEntryImpl::SetVirtualURL(const GURL& url) {

--- a/chromium_src/content/browser/renderer_host/navigation_entry_impl.h
+++ b/chromium_src/content/browser/renderer_host/navigation_entry_impl.h
@@ -16,6 +16,7 @@
                                                                            \
  private:                                                                  \
   void SetVirtualURL_ChromiumImpl(const GURL& url);                        \
+  const std::u16string& GetTitleForDisplay_ChromiumImpl() const;           \
   std::optional<std::pair<std::string, std::string>>                       \
       storage_partition_key_to_restore_;                                   \
                                                                            \

--- a/chromium_src/content/browser/renderer_host/navigation_entry_impl_unittest.cc
+++ b/chromium_src/content/browser/renderer_host/navigation_entry_impl_unittest.cc
@@ -63,8 +63,8 @@ TEST_F(BraveNavigationEntryTest,
   entry = CreateEntry(GURL("http://chrome.com"));
   EXPECT_EQ(u"chrome.com", entry->GetTitleForDisplay());
 
-  entry = CreateEntry(GURL("http://example.com?chrome://settings"));
-  EXPECT_EQ(u"example.com?chrome://settings", entry->GetTitleForDisplay());
+  entry = CreateEntry(GURL("http://example.com/?chrome://settings"));
+  EXPECT_EQ(u"example.com/?chrome://settings", entry->GetTitleForDisplay());
 }
 
 }  // namespace content

--- a/chromium_src/content/browser/renderer_host/navigation_entry_impl_unittest.cc
+++ b/chromium_src/content/browser/renderer_host/navigation_entry_impl_unittest.cc
@@ -1,0 +1,54 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "content/public/browser/navigation_controller.h"
+#include "content/public/browser/navigation_entry.h"
+#include "content/public/test/browser_task_environment.h"
+#include "content/public/test/test_browser_context.h"
+#include "services/network/public/cpp/shared_url_loader_factory.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace content {
+
+class BraveNavigationEntryTest : public testing::Test {
+ private:
+  BrowserTaskEnvironment task_environment_;
+  TestBrowserContext browser_context_;
+
+ protected:
+  std::unique_ptr<NavigationEntry> CreateEntry(const GURL& url) {
+    return NavigationController::CreateNavigationEntry(
+        url, Referrer(), /* initiator_origin= */ std::nullopt,
+        /* initiator_base_url= */ std::nullopt, ui::PAGE_TRANSITION_TYPED,
+        /* is_renderer_initiated= */ false, /* extra_headers= */ std::string(),
+        &browser_context_, /* blob_url_loader_factory= */ nullptr);
+  }
+};
+
+TEST_F(BraveNavigationEntryTest,
+       GetTitleForDisplayConvertsChromeSchemeToBrave) {
+  auto entry = CreateEntry(GURL("chrome://settings"));
+  EXPECT_EQ(u"brave://settings", entry->GetTitleForDisplay());
+
+  entry = CreateEntry(GURL("chrome://history"));
+  EXPECT_EQ(u"brave://history", entry->GetTitleForDisplay());
+
+  entry = CreateEntry(GURL("chrome://flags"));
+  EXPECT_EQ(u"brave://flags", entry->GetTitleForDisplay());
+}
+
+TEST_F(BraveNavigationEntryTest, GetTitleForDisplayPreservesExplicitTitle) {
+  auto entry = CreateEntry(GURL("chrome://settings"));
+  entry->SetTitle(u"Settings");
+  EXPECT_EQ(u"Settings", entry->GetTitleForDisplay());
+}
+
+TEST_F(BraveNavigationEntryTest,
+       GetTitleForDisplayDoesNotAffectNonChromeScheme) {
+  auto entry = CreateEntry(GURL("https://example.com"));
+  EXPECT_EQ(u"example.com", entry->GetTitleForDisplay());
+}
+
+}  // namespace content

--- a/chromium_src/content/browser/renderer_host/navigation_entry_impl_unittest.cc
+++ b/chromium_src/content/browser/renderer_host/navigation_entry_impl_unittest.cc
@@ -9,6 +9,7 @@
 #include "content/public/test/test_browser_context.h"
 #include "services/network/public/cpp/shared_url_loader_factory.h"
 #include "testing/gtest/include/gtest/gtest.h"
+#include "url/gurl.h"
 
 namespace content {
 
@@ -48,6 +49,18 @@ TEST_F(BraveNavigationEntryTest, GetTitleForDisplayPreservesExplicitTitle) {
 TEST_F(BraveNavigationEntryTest,
        GetTitleForDisplayDoesNotAffectNonChromeScheme) {
   auto entry = CreateEntry(GURL("https://example.com"));
+  EXPECT_EQ(u"example.com", entry->GetTitleForDisplay());
+
+  entry = CreateEntry(GURL("brave://settings"));
+  EXPECT_EQ(u"brave://settings", entry->GetTitleForDisplay());
+
+  entry = CreateEntry(GURL("chrome-blah://settings"));
+  EXPECT_EQ(u"chrome-blah://settings", entry->GetTitleForDisplay());
+
+  entry = CreateEntry(GURL("http://chrome.com"));
+  EXPECT_EQ(u"chrome.com", entry->GetTitleForDisplay());
+
+  entry = CreateEntry(GURL("http://example.com?chrome://settings"));
   EXPECT_EQ(u"example.com", entry->GetTitleForDisplay());
 }
 

--- a/chromium_src/content/browser/renderer_host/navigation_entry_impl_unittest.cc
+++ b/chromium_src/content/browser/renderer_host/navigation_entry_impl_unittest.cc
@@ -64,7 +64,7 @@ TEST_F(BraveNavigationEntryTest,
   EXPECT_EQ(u"chrome.com", entry->GetTitleForDisplay());
 
   entry = CreateEntry(GURL("http://example.com?chrome://settings"));
-  EXPECT_EQ(u"example.com", entry->GetTitleForDisplay());
+  EXPECT_EQ(u"example.com?chrome://settings", entry->GetTitleForDisplay());
 }
 
 }  // namespace content

--- a/chromium_src/content/browser/renderer_host/navigation_entry_impl_unittest.cc
+++ b/chromium_src/content/browser/renderer_host/navigation_entry_impl_unittest.cc
@@ -3,12 +3,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include <memory>
+#include <optional>
+#include <string>
+
 #include "content/public/browser/navigation_controller.h"
 #include "content/public/browser/navigation_entry.h"
+#include "content/public/common/referrer.h"
 #include "content/public/test/browser_task_environment.h"
 #include "content/public/test/test_browser_context.h"
 #include "services/network/public/cpp/shared_url_loader_factory.h"
 #include "testing/gtest/include/gtest/gtest.h"
+#include "ui/base/page_transition_types.h"
 #include "url/gurl.h"
 
 namespace content {
@@ -53,9 +59,6 @@ TEST_F(BraveNavigationEntryTest,
 
   entry = CreateEntry(GURL("brave://settings"));
   EXPECT_EQ(u"brave://settings", entry->GetTitleForDisplay());
-
-  entry = CreateEntry(GURL("chrome-blah://settings"));
-  EXPECT_EQ(u"chrome-blah://settings", entry->GetTitleForDisplay());
 
   entry = CreateEntry(GURL("http://chrome.com"));
   EXPECT_EQ(u"chrome.com", entry->GetTitleForDisplay());

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -118,6 +118,7 @@ test("brave_unit_tests") {
     "//brave/chromium_src/chrome/browser/signin/account_consistency_disabled_unittest.cc",
     "//brave/chromium_src/components/autofill/core/browser/studies/autofill_experiments_unittest.cc",
     "//brave/chromium_src/components/variations/service/field_trial_unittest.cc",
+    "//brave/chromium_src/content/browser/renderer_host/navigation_entry_impl_unittest.cc",
     "//brave/chromium_src/net/cookies/brave_canonical_cookie_unittest.cc",
     "//brave/common/brave_content_client_unittest.cc",
     "//brave/common/profiler/thread_profile_configuration_unittest.cc",

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -298,6 +298,7 @@ test("brave_unit_tests") {
     "//components/user_prefs",
     "//components/variations/service:buildflags",
     "//components/version_info",
+    "//content/public/browser",
     "//content/public/common",
     "//content/test:test_support",
     "//google_apis/gcm",


### PR DESCRIPTION
## Summary
- Override `NavigationEntryImpl::GetTitleForDisplay()` to convert `chrome://` to `brave://` in the display title fallback for restored but unloaded tabs

Resolves https://github.com/brave/brave-browser/issues/53821

## Root Cause
Brave uses `chrome://` URLs internally and converts to `brave://` in the UI layer (location bar, hover cards, etc.). When a restored tab hasn't loaded yet and has no saved page title, `GetTitleForDisplay()` falls back to formatting the virtual URL. Since the virtual URL is `chrome://settings` (not `brave://settings`), the tab displays "chrome://settings" to the user.

## Fix
Override `GetTitleForDisplay()` in Brave's existing `NavigationEntryImpl` chromium_src override. When the real title is empty (fallback path), check if the cached display title starts with `chrome://` and replace with `brave://`. This catches all display paths (tab strip, window title, back/forward menu, task manager, etc.) since they all go through `GetTitleForDisplay()`.

