### PR TITLE
[iOS] Add media backgrounding JavaScriptFeature

### DIFF
--- a/ios/browser/web/BUILD.gn
+++ b/ios/browser/web/BUILD.gn
@@ -34,6 +34,7 @@ source_set("web") {
     "//brave/ios/browser/web/document_fetch",
     "//brave/ios/browser/web/force_paste",
     "//brave/ios/browser/web/logins",
+    "//brave/ios/browser/web/media",
     "//brave/ios/browser/web/navigator",
     "//brave/ios/browser/web/night_mode",
     "//brave/ios/browser/web/page_metadata",

--- a/ios/browser/web/brave_web_client.mm
+++ b/ios/browser/web/brave_web_client.mm
@@ -27,6 +27,7 @@
 #include "brave/ios/browser/web/document_fetch/document_fetch_javascript_feature.h"
 #include "brave/ios/browser/web/force_paste/force_paste_javascript_feature.h"
 #include "brave/ios/browser/web/logins/logins_javascript_feature.h"
+#include "brave/ios/browser/web/media/media_backgrounding_javascript_feature.h"
 #include "brave/ios/browser/web/navigator/brave_navigator_javascript_feature.h"
 #include "brave/ios/browser/web/night_mode/night_mode_javascript_feature.h"
 #include "brave/ios/browser/web/page_metadata/page_metadata_javascript_feature.h"
@@ -147,6 +148,8 @@ std::vector<web::JavaScriptFeature*> BraveWebClient::GetJavaScriptFeatures(
     features.push_back(DeAmpJavaScriptFeature::GetInstance());
     features.push_back(DocumentFetchJavaScriptFeature::GetInstance());
     features.push_back(ForcePasteJavaScriptFeature::GetInstance());
+    features.push_back(
+        MediaBackgroundingJavaScriptFeature::FromBrowserState(browser_state));
     features.push_back(NightModeJavaScriptFeature::GetInstance());
     features.push_back(PageMetadataJavaScriptFeature::GetInstance());
     features.push_back(brave::ReaderModeJavaScriptFeature::GetInstance());

--- a/ios/browser/web/media/BUILD.gn
+++ b/ios/browser/web/media/BUILD.gn
@@ -1,0 +1,31 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import("//ios/web/public/js_messaging/optimize_ts.gni")
+
+source_set("media") {
+  sources = [
+    "media_backgrounding_javascript_feature.h",
+    "media_backgrounding_javascript_feature.mm",
+  ]
+  deps = [
+    ":media_backgrounding_js",
+    "//brave/ios/browser/shared/prefs",
+    "//components/prefs",
+    "//ios/chrome/browser/shared/model/profile",
+    "//ios/web/public",
+    "//ios/web/web_state/ui:wk_web_view_configuration_provider_header",
+  ]
+  public_deps = [
+    "//base",
+    "//ios/web/public/js_messaging",
+  ]
+}
+
+optimize_ts("media_backgrounding_js") {
+  visibility = [ ":media" ]
+  sources = [ "resources/media_backgrounding.ts" ]
+  deps = [ "//ios/web/public/js_messaging:gcrweb" ]
+}

--- a/ios/browser/web/media/media_backgrounding_javascript_feature.h
+++ b/ios/browser/web/media/media_backgrounding_javascript_feature.h
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_IOS_BROWSER_WEB_MEDIA_MEDIA_BACKGROUNDING_JAVASCRIPT_FEATURE_H_
+#define BRAVE_IOS_BROWSER_WEB_MEDIA_MEDIA_BACKGROUNDING_JAVASCRIPT_FEATURE_H_
+
+#include "base/memory/raw_ptr.h"
+#include "base/supports_user_data.h"
+#include "components/prefs/pref_change_registrar.h"
+#include "ios/web/public/js_messaging/java_script_feature.h"
+
+namespace web {
+class BrowserState;
+}  // namespace web
+
+class ProfileIOS;
+
+class MediaBackgroundingJavaScriptFeature
+    : public web::JavaScriptFeature,
+      public base::SupportsUserData::Data {
+ public:
+  ~MediaBackgroundingJavaScriptFeature() override;
+
+  static MediaBackgroundingJavaScriptFeature* FromBrowserState(
+      web::BrowserState* browser_state);
+
+  // web::JavaScriptFeature
+  std::vector<web::JavaScriptFeature::FeatureScript> GetScripts()
+      const override;
+
+ private:
+  PrefChangeRegistrar prefs_change_registrar_;
+  raw_ptr<ProfileIOS> profile_;
+
+  void OnPrefUpdated();
+
+  explicit MediaBackgroundingJavaScriptFeature(ProfileIOS* profile);
+};
+
+#endif  // BRAVE_IOS_BROWSER_WEB_MEDIA_MEDIA_BACKGROUNDING_JAVASCRIPT_FEATURE_H_

--- a/ios/browser/web/media/media_backgrounding_javascript_feature.mm
+++ b/ios/browser/web/media/media_backgrounding_javascript_feature.mm
@@ -1,0 +1,84 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/ios/browser/web/media/media_backgrounding_javascript_feature.h"
+
+#include "base/functional/bind.h"
+#include "base/memory/ptr_util.h"
+#include "base/values.h"
+#include "brave/ios/browser/shared/prefs/pref_names.h"
+#include "components/prefs/pref_service.h"
+#include "ios/chrome/browser/shared/model/profile/profile_ios.h"
+#include "ios/web/public/browser_state.h"
+#include "ios/web/public/js_messaging/java_script_feature.h"
+#include "ios/web/public/js_messaging/web_frame.h"
+#include "ios/web/public/js_messaging/web_frames_manager.h"
+#include "ios/web/public/web_state.h"
+#include "ios/web/web_state/ui/wk_web_view_configuration_provider.h"
+
+namespace {
+constexpr char kMediaBackgroundingJavaScriptFeatureKeyName[] =
+    "media_backgrounding_java_script_feature";
+constexpr char kScriptName[] = "media_backgrounding";
+}  // namespace
+
+MediaBackgroundingJavaScriptFeature::MediaBackgroundingJavaScriptFeature(
+    ProfileIOS* profile)
+    : JavaScriptFeature(web::ContentWorld::kPageContentWorld,
+                        /*feature_scripts=*/{}),
+      profile_(profile) {
+  prefs_change_registrar_.Init(profile_->GetPrefs());
+  prefs_change_registrar_.Add(
+      prefs::kMediaBackgroundingEnabled,
+      base::BindRepeating(&MediaBackgroundingJavaScriptFeature::OnPrefUpdated,
+                          base::Unretained(this)));
+}
+
+MediaBackgroundingJavaScriptFeature::~MediaBackgroundingJavaScriptFeature() =
+    default;
+
+// static
+MediaBackgroundingJavaScriptFeature*
+MediaBackgroundingJavaScriptFeature::FromBrowserState(
+    web::BrowserState* browser_state) {
+  DCHECK(browser_state);
+  MediaBackgroundingJavaScriptFeature* feature =
+      static_cast<MediaBackgroundingJavaScriptFeature*>(
+          browser_state->GetUserData(
+              kMediaBackgroundingJavaScriptFeatureKeyName));
+  if (!feature) {
+    feature = new MediaBackgroundingJavaScriptFeature(
+        ProfileIOS::FromBrowserState(browser_state));
+    browser_state->SetUserData(kMediaBackgroundingJavaScriptFeatureKeyName,
+                               base::WrapUnique(feature));
+  }
+  return feature;
+}
+
+void MediaBackgroundingJavaScriptFeature::OnPrefUpdated() {
+  // Feature scripts must be explicitly updated after this pref changes.
+  web::WKWebViewConfigurationProvider& config_provider =
+      web::WKWebViewConfigurationProvider::FromBrowserState(profile_);
+  config_provider.UpdateScripts();
+}
+
+std::vector<web::JavaScriptFeature::FeatureScript>
+MediaBackgroundingJavaScriptFeature::GetScripts() const {
+  bool is_media_backgrounding_enabled =
+      profile_->GetPrefs()->GetBoolean(prefs::kMediaBackgroundingEnabled);
+  return {FeatureScript::CreateWithFilename(
+      kScriptName, FeatureScript::InjectionTime::kDocumentStart,
+      FeatureScript::TargetFrames::kAllFrames,
+      FeatureScript::ReinjectionBehavior::kInjectOncePerWindow,
+      base::BindRepeating(
+          [](bool is_media_backgrounding_enabled)
+              -> FeatureScript::PlaceholderReplacements {
+            return @{
+              @"window.gCrWebPlaceholderMediaBackgroundingEnabled" :
+                      is_media_backgrounding_enabled ? @"true" : @"false"
+            };
+          },
+          is_media_backgrounding_enabled))};
+}

--- a/ios/browser/web/media/resources/media_backgrounding.ts
+++ b/ios/browser/web/media/resources/media_backgrounding.ts
@@ -1,0 +1,116 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+function enable(): void {
+  const descriptor = Object.getOwnPropertyDescriptor(
+    Document.prototype, 'visibilityState'
+  )!;
+  const visibilityStateGet = descriptor.get!;
+
+  Object.defineProperty(Document.prototype, 'visibilityState', {
+    enumerable: descriptor.enumerable,
+    configurable: descriptor.configurable,
+    get() {
+      const result = visibilityStateGet.call(this);
+      if (result !== 'visible') {
+        return 'visible';
+      }
+      return result;
+    }
+  });
+
+  const pauseControl = HTMLVideoElement.prototype.pause;
+  HTMLVideoElement.prototype.pause = function(): void {
+    (this as any).userHitPause = true;
+    pauseControl.call(this);
+  };
+
+  const playControl = HTMLVideoElement.prototype.play;
+  HTMLVideoElement.prototype.play = function(): Promise<void> {
+    (this as any).userHitPause = false;
+    return playControl.call(this);
+  };
+
+  function addListeners(element: HTMLVideoElement): void {
+    if (!(element as any).pauseListener) {
+      (element as any).pauseListener = true;
+      (element as any).visibilityState = visibilityStateGet.call(document);
+
+      document.addEventListener('visibilitychange', function() {
+        (element as any).visibilityState = visibilityStateGet.call(document);
+      }, false);
+
+      element.addEventListener('pause', function() {
+        if (!(element as any).userHitPause &&
+            visibilityStateGet.call(document) === 'visible') {
+          const onVisibilityChanged = () => {
+            document.removeEventListener(
+              'visibilitychange', onVisibilityChanged
+            );
+            if (visibilityStateGet.call(document) !== 'visible' &&
+                !element.ended) {
+              playControl.call(element);
+            }
+          };
+          document.addEventListener('visibilitychange', onVisibilityChanged);
+          setTimeout(function() {
+            document.removeEventListener(
+              'visibilitychange', onVisibilityChanged
+            );
+          }, 2000);
+        } else {
+          if (!(element as any).userHitPause &&
+              (element as any).visibilityState === 'visible' &&
+              !element.ended) {
+            playControl.call(element);
+          }
+        }
+      }, false);
+    }
+
+    if (!(element as any).presentationModeListener) {
+      (element as any).presentationModeListener = true;
+      element.addEventListener('webkitpresentationmodechanged', function(e) {
+        e.stopPropagation();
+      }, true);
+    }
+  }
+
+  const queue: MutationRecord[] = [];
+  function onMutation(): void {
+    for (const mutation of queue) {
+      mutation.addedNodes.forEach(function(node: Node) {
+        if (node instanceof HTMLVideoElement) {
+          addListeners(node);
+        }
+      });
+    }
+    queue.length = 0;
+  }
+
+  const observer = new MutationObserver(function(mutations: MutationRecord[]) {
+    if (!queue.length) {
+      requestAnimationFrame(onMutation);
+    }
+    queue.push(...mutations);
+  });
+
+  document.querySelectorAll('video').forEach(
+    (v) => addListeners(v as HTMLVideoElement)
+  );
+
+  observer.observe(document, {
+    childList: true,
+    attributes: false,
+    characterData: false,
+    subtree: true,
+    attributeOldValue: false,
+    characterDataOldValue: false
+  });
+}
+
+if ((window as any).gCrWebPlaceholderMediaBackgroundingEnabled) {
+  enable();
+}


### PR DESCRIPTION
This adds a new JavaScriptFeature that enables background audio for videos when the `UseProfileWebViewConfiguration` feature flag is enabled.

This script diverges slightly from its original in that it exposes an API to call instead of being dynamically injected based on the preference. By doing this we also change it to be injected into the main frame only and use the document end injection timing.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/55274

## Test
- Enable the `UseProfileWebViewConfiguration` feature flag
- Enable the "Enable Background Audio" setting under Media
- Load up YouTube and visit a video page
- Background the app and verify audio continues playing
- Disable the "Enable Background Audio" setting under Media
- Background the app and verify audio pauses