### PR TITLE
[Sidebar V2] Repurpose toolbar button as a temporary sidebar pin

### DIFF
--- a/browser/ui/sidebar/sidebar.h
+++ b/browser/ui/sidebar/sidebar.h
@@ -18,6 +18,7 @@ class Sidebar {
 
   // Update sidebar item's UI state.
   virtual void UpdateSidebarItemsState() = 0;
+  virtual void UpdateSidebarVisibility() = 0;
 
  protected:
   virtual ~Sidebar() {}

--- a/browser/ui/sidebar/sidebar.h
+++ b/browser/ui/sidebar/sidebar.h
@@ -18,6 +18,10 @@ class Sidebar {
 
   // Update sidebar item's UI state.
   virtual void UpdateSidebarItemsState() = 0;
+
+  // Re-evaluate sidebar visibility from the current pinned state and show
+  // option, and sync the toolbar button highlight to the pinned state.
+  // Called when the controller's pinned state toggles (V2 only).
   virtual void UpdateSidebarVisibility() = 0;
 
  protected:

--- a/browser/ui/sidebar/sidebar_browsertest.cc
+++ b/browser/ui/sidebar/sidebar_browsertest.cc
@@ -81,8 +81,11 @@
 #include "ui/display/test/test_screen.h"
 #include "ui/events/base_event_utils.h"
 #include "ui/events/event.h"
+#include "ui/events/test/event_generator.h"
 #include "ui/gfx/animation/animation_test_api.h"
 #include "ui/gfx/geometry/point.h"
+#include "ui/views/animation/ink_drop.h"
+#include "ui/views/widget/widget_utils.h"
 
 #if BUILDFLAG(ENABLE_AI_CHAT)
 #include "brave/components/ai_chat/core/common/features.h"
@@ -2331,6 +2334,127 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest,
               Show(testing::An<SidePanelEntryId>(), testing::Eq(std::nullopt),
                    /*suppress_animations=*/true));
   controller()->ActivatePanelItem(SidebarItem::BuiltInItemType::kReadingList);
+}
+
+// In V2, the toolbar SidePanelButton acts as a "temporal pin" for the sidebar
+// control view: clicking it toggles a session-only pinned state that forces
+// the sidebar visible regardless of show option. The pinned state must reset
+// when the show option changes. The button is hidden under kShowAlways
+// because the sidebar is already always visible.
+IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, SidebarV2ToolbarButtonPinning) {
+  auto* service = SidebarServiceFactory::GetForProfile(browser()->profile());
+  auto* sidebar_container = GetSidebarContainerView();
+  auto* button = GetSidePanelToolbarButton();
+  ASSERT_TRUE(button);
+  auto button_highlighted = [&]() {
+    return views::InkDrop::Get(button)->GetHighlighted();
+  };
+
+  // Park the mouse at the top of the toolbar — well outside the sidebar
+  // bounds — so that kShowOnMouseOver doesn't keep the sidebar visible due
+  // to an incidental hover. Without this the test is sensitive to wherever
+  // the OS leaves the cursor between runs.
+  auto* browser_view = BrowserView::GetBrowserViewForBrowser(browser());
+  ui::test::EventGenerator event_generator(
+      views::GetRootWindow(browser_view->GetWidget()),
+      browser_view->GetNativeWindow());
+  event_generator.MoveMouseTo(
+      browser_view->toolbar()->GetBoundsInScreen().CenterPoint());
+  ASSERT_FALSE(sidebar_container->IsMouseHovered())
+      << "Mouse should not be over the sidebar at test start";
+
+  // kShowAlways (the fixture default) → button is hidden because the sidebar
+  // is always visible.
+  ASSERT_EQ(SidebarService::ShowSidebarOption::kShowAlways,
+            service->GetSidebarShowOption());
+  EXPECT_FALSE(button->GetVisible())
+      << "Toolbar button must be hidden under kShowAlways";
+
+  // Switch to kShowNever so the button becomes visible and the sidebar hides.
+  service->SetSidebarShowOption(SidebarService::ShowSidebarOption::kShowNever);
+  EXPECT_TRUE(button->GetVisible())
+      << "Toolbar button must be visible under kShowNever";
+  ASSERT_TRUE(base::test::RunUntil([&]() {
+    return !sidebar_container->IsSidebarVisible();
+  })) << "Sidebar should hide after switching to kShowNever";
+  EXPECT_FALSE(controller()->sidebar_pinned())
+      << "Pinned state should start false under kShowNever";
+  EXPECT_FALSE(button_highlighted())
+      << "Button highlight should be off when not pinned";
+
+  // Pin: sidebar becomes visible immediately (no animation), pinned == true,
+  // button is highlighted.
+  controller()->ToggleSidebarPinning();
+  EXPECT_TRUE(controller()->sidebar_pinned())
+      << "Pinning under kShowNever should set pinned=true";
+  EXPECT_TRUE(sidebar_container->IsSidebarVisible())
+      << "Pinning should force sidebar visible regardless of kShowNever";
+  ASSERT_TRUE(base::test::RunUntil([&]() { return button_highlighted(); }))
+      << "Button highlight should reflect pinned=true (fade-in is immediate)";
+
+  // Unpin: sidebar hides (animated under kShowNever), button un-highlights
+  // (highlight fade-out is animated so wait for it).
+  controller()->ToggleSidebarPinning();
+  EXPECT_FALSE(controller()->sidebar_pinned())
+      << "Toggling again should set pinned=false";
+  ASSERT_TRUE(base::test::RunUntil([&]() { return !button_highlighted(); }))
+      << "Button highlight should fade off after unpin";
+  ASSERT_TRUE(base::test::RunUntil([&]() {
+    return !sidebar_container->IsSidebarVisible();
+  })) << "Sidebar should hide after unpin under kShowNever";
+
+  // Pin again, then change the show option → pinned must reset to false and
+  // the sidebar must follow the new option (kShowOnMouseOver, mouse not over
+  // the sidebar in tests → hidden). Button highlight follows pinned state.
+  controller()->ToggleSidebarPinning();
+  ASSERT_TRUE(controller()->sidebar_pinned())
+      << "Pinning again should set pinned=true (precondition for reset test)";
+  ASSERT_TRUE(sidebar_container->IsSidebarVisible())
+      << "Sidebar should be visible while pinned (precondition)";
+  ASSERT_TRUE(base::test::RunUntil([&]() { return button_highlighted(); }))
+      << "Button should be highlighted while pinned (precondition)";
+
+  service->SetSidebarShowOption(
+      SidebarService::ShowSidebarOption::kShowOnMouseOver);
+  EXPECT_FALSE(controller()->sidebar_pinned())
+      << "Changing show option must reset pinned state to false";
+  EXPECT_TRUE(button->GetVisible())
+      << "Toolbar button must be visible under kShowOnMouseOver";
+  ASSERT_TRUE(base::test::RunUntil([&]() { return !button_highlighted(); }))
+      << "Button highlight should fade off after pinned reset";
+  ASSERT_TRUE(base::test::RunUntil([&]() {
+    return !sidebar_container->IsSidebarVisible();
+  })) << "Sidebar should hide once pinned is reset under kShowOnMouseOver "
+         "(mouse is not over sidebar in tests)";
+
+  // Toggle pin under kShowOnMouseOver: pin shows the sidebar and highlights
+  // the button; unpin hides it again because the mouse is not over the
+  // sidebar in tests.
+  controller()->ToggleSidebarPinning();
+  EXPECT_TRUE(controller()->sidebar_pinned())
+      << "Pinning under kShowOnMouseOver should set pinned=true";
+  EXPECT_TRUE(sidebar_container->IsSidebarVisible())
+      << "Pinning should force sidebar visible regardless of kShowOnMouseOver";
+  // EXPECT_TRUE(button_highlighted())
+  ASSERT_TRUE(base::test::RunUntil([&]() { return button_highlighted(); }))
+      << "Button highlight should reflect pinned=true under kShowOnMouseOver";
+
+  controller()->ToggleSidebarPinning();
+  EXPECT_FALSE(controller()->sidebar_pinned())
+      << "Toggling again should set pinned=false under kShowOnMouseOver";
+  ASSERT_TRUE(base::test::RunUntil([&]() { return !button_highlighted(); }))
+      << "Button highlight should fade off after unpin under kShowOnMouseOver";
+  ASSERT_TRUE(base::test::RunUntil([&]() {
+    return !sidebar_container->IsSidebarVisible();
+  })) << "Sidebar should hide after unpin under kShowOnMouseOver "
+         "(mouse not over sidebar in tests)";
+
+  // Switching back to kShowAlways re-hides the toolbar button.
+  service->SetSidebarShowOption(SidebarService::ShowSidebarOption::kShowAlways);
+  EXPECT_FALSE(button->GetVisible())
+      << "Toolbar button must be hidden again under kShowAlways";
+  EXPECT_FALSE(controller()->sidebar_pinned())
+      << "Pinned state must remain false after returning to kShowAlways";
 }
 
 #endif  // BUILDFLAG(ENABLE_SIDEBAR_V2)

--- a/browser/ui/sidebar/sidebar_browsertest.cc
+++ b/browser/ui/sidebar/sidebar_browsertest.cc
@@ -2363,6 +2363,38 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, SidebarV2ToolbarButtonPinning) {
   ASSERT_FALSE(sidebar_container->IsMouseHovered())
       << "Mouse should not be over the sidebar at test start";
 
+  // Pin → assert visible/highlighted; unpin → assert hidden/unhighlighted.
+  // Precondition: pinned=false, sidebar hidden. Used once per non-kShowAlways
+  // show option. SCOPED_TRACE makes failures point back to the caller.
+  auto verify_pin_cycle = [&]() {
+    ASSERT_FALSE(controller()->sidebar_pinned())
+        << "Precondition: pinned=false before pin";
+    ASSERT_FALSE(sidebar_container->IsSidebarVisible())
+        << "Precondition: sidebar hidden before pin";
+    ASSERT_FALSE(button_highlighted())
+        << "Precondition: button not highlighted before pin";
+
+    // Pin: sidebar snaps visible, button highlights (fade-in).
+    controller()->ToggleSidebarPinning();
+    EXPECT_TRUE(controller()->sidebar_pinned()) << "Pin should set pinned=true";
+    EXPECT_TRUE(sidebar_container->IsSidebarVisible())
+        << "Pin should force sidebar visible regardless of show option";
+    ASSERT_TRUE(base::test::RunUntil([&]() { return button_highlighted(); }))
+        << "Pin should highlight the toolbar button";
+
+    // Unpin: pinned flips immediately; button highlight + sidebar visibility
+    // unwind asynchronously (animations).
+    controller()->ToggleSidebarPinning();
+    EXPECT_FALSE(controller()->sidebar_pinned())
+        << "Unpin should set pinned=false";
+    ASSERT_TRUE(base::test::RunUntil([&]() { return !button_highlighted(); }))
+        << "Unpin should clear the button highlight";
+    ASSERT_TRUE(base::test::RunUntil([&]() {
+      return !sidebar_container->IsSidebarVisible();
+    })) << "Unpin should hide the sidebar (current show option doesn't keep "
+           "it visible without pin)";
+  };
+
   // kShowAlways (the fixture default) → button is hidden because the sidebar
   // is always visible.
   ASSERT_EQ(SidebarService::ShowSidebarOption::kShowAlways,
@@ -2377,35 +2409,15 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, SidebarV2ToolbarButtonPinning) {
   ASSERT_TRUE(base::test::RunUntil([&]() {
     return !sidebar_container->IsSidebarVisible();
   })) << "Sidebar should hide after switching to kShowNever";
-  EXPECT_FALSE(controller()->sidebar_pinned())
-      << "Pinned state should start false under kShowNever";
-  EXPECT_FALSE(button_highlighted())
-      << "Button highlight should be off when not pinned";
 
-  // Pin: sidebar becomes visible immediately (no animation), pinned == true,
-  // button is highlighted.
-  controller()->ToggleSidebarPinning();
-  EXPECT_TRUE(controller()->sidebar_pinned())
-      << "Pinning under kShowNever should set pinned=true";
-  EXPECT_TRUE(sidebar_container->IsSidebarVisible())
-      << "Pinning should force sidebar visible regardless of kShowNever";
-  ASSERT_TRUE(base::test::RunUntil([&]() { return button_highlighted(); }))
-      << "Button highlight should reflect pinned=true (fade-in is immediate)";
-
-  // Unpin: sidebar hides (animated under kShowNever), button un-highlights
-  // (highlight fade-out is animated so wait for it).
-  controller()->ToggleSidebarPinning();
-  EXPECT_FALSE(controller()->sidebar_pinned())
-      << "Toggling again should set pinned=false";
-  ASSERT_TRUE(base::test::RunUntil([&]() { return !button_highlighted(); }))
-      << "Button highlight should fade off after unpin";
-  ASSERT_TRUE(base::test::RunUntil([&]() {
-    return !sidebar_container->IsSidebarVisible();
-  })) << "Sidebar should hide after unpin under kShowNever";
+  {
+    SCOPED_TRACE("kShowNever");
+    verify_pin_cycle();
+  }
 
   // Pin again, then change the show option → pinned must reset to false and
-  // the sidebar must follow the new option (kShowOnMouseOver, mouse not over
-  // the sidebar in tests → hidden). Button highlight follows pinned state.
+  // the sidebar must follow the new option (kShowOnMouseOver, mouse parked
+  // outside sidebar → hidden).
   controller()->ToggleSidebarPinning();
   ASSERT_TRUE(controller()->sidebar_pinned())
       << "Pinning again should set pinned=true (precondition for reset test)";
@@ -2427,27 +2439,10 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, SidebarV2ToolbarButtonPinning) {
   })) << "Sidebar should hide once pinned is reset under kShowOnMouseOver "
          "(mouse is not over sidebar in tests)";
 
-  // Toggle pin under kShowOnMouseOver: pin shows the sidebar and highlights
-  // the button; unpin hides it again because the mouse is not over the
-  // sidebar in tests.
-  controller()->ToggleSidebarPinning();
-  EXPECT_TRUE(controller()->sidebar_pinned())
-      << "Pinning under kShowOnMouseOver should set pinned=true";
-  EXPECT_TRUE(sidebar_container->IsSidebarVisible())
-      << "Pinning should force sidebar visible regardless of kShowOnMouseOver";
-  // EXPECT_TRUE(button_highlighted())
-  ASSERT_TRUE(base::test::RunUntil([&]() { return button_highlighted(); }))
-      << "Button highlight should reflect pinned=true under kShowOnMouseOver";
-
-  controller()->ToggleSidebarPinning();
-  EXPECT_FALSE(controller()->sidebar_pinned())
-      << "Toggling again should set pinned=false under kShowOnMouseOver";
-  ASSERT_TRUE(base::test::RunUntil([&]() { return !button_highlighted(); }))
-      << "Button highlight should fade off after unpin under kShowOnMouseOver";
-  ASSERT_TRUE(base::test::RunUntil([&]() {
-    return !sidebar_container->IsSidebarVisible();
-  })) << "Sidebar should hide after unpin under kShowOnMouseOver "
-         "(mouse not over sidebar in tests)";
+  {
+    SCOPED_TRACE("kShowOnMouseOver");
+    verify_pin_cycle();
+  }
 
   // Switching back to kShowAlways re-hides the toolbar button.
   service->SetSidebarShowOption(SidebarService::ShowSidebarOption::kShowAlways);

--- a/browser/ui/sidebar/sidebar_controller.cc
+++ b/browser/ui/sidebar/sidebar_controller.cc
@@ -176,6 +176,11 @@ void SidebarController::DeactivateCurrentPanel() {
   ActivatePanelItem(SidebarItem::BuiltInItemType::kNone);
 }
 
+void SidebarController::ToggleSidebarPinning() {
+  sidebar_pinned_ = !sidebar_pinned_;
+  sidebar_->UpdateSidebarVisibility();
+}
+
 bool SidebarController::ActiveTabFromOtherBrowsersForHost(const GURL& url) {
   const std::vector<Browser*> browsers =
       chrome::FindAllTabbedBrowsersWithProfile(profile_);
@@ -242,6 +247,7 @@ void SidebarController::LoadAtTab(const GURL& url) {
 void SidebarController::OnShowSidebarOptionChanged(
     SidebarService::ShowSidebarOption option) {
   CHECK(sidebar_);
+  sidebar_pinned_ = false;
   sidebar_->SetSidebarShowOption(option);
 }
 

--- a/browser/ui/sidebar/sidebar_controller.h
+++ b/browser/ui/sidebar/sidebar_controller.h
@@ -64,6 +64,9 @@ class SidebarController : public SidebarService::Observer {
   void ActivatePanelItem(SidebarItem::BuiltInItemType panel_item);
   void DeactivateCurrentPanel();
 
+  void ToggleSidebarPinning();
+  bool sidebar_pinned() const { return sidebar_pinned_; }
+
   void SetSidePanelUIForTesting(SidePanelUI* side_panel_ui) {
     side_panel_ui_for_testing_ = side_panel_ui;
   }
@@ -100,6 +103,8 @@ class SidebarController : public SidebarService::Observer {
   // and activate it if found.
   bool ActiveTabFromOtherBrowsersForHost(const GURL& url);
 
+  // Sidebar is visible when pinned regardless of show option.
+  bool sidebar_pinned_ = false;
   raw_ptr<TabStripModel> tab_strip_model_ = nullptr;
   raw_ptr<Profile> profile_ = nullptr;
   raw_ptr<Browser> browser_ = nullptr;

--- a/browser/ui/sidebar/sidebar_controller.h
+++ b/browser/ui/sidebar/sidebar_controller.h
@@ -64,6 +64,11 @@ class SidebarController : public SidebarService::Observer {
   void ActivatePanelItem(SidebarItem::BuiltInItemType panel_item);
   void DeactivateCurrentPanel();
 
+  // Toggles a session-only "pin" that forces the sidebar control view
+  // visible regardless of the current show option. Pinned state is cleared
+  // when the show option changes (via OnShowSidebarOptionChanged) and when
+  // the browser window closes; it is not persisted. V2 only — invoked by
+  // the toolbar SidePanelButton when V2 is enabled.
   void ToggleSidebarPinning();
   bool sidebar_pinned() const { return sidebar_pinned_; }
 

--- a/browser/ui/views/side_panel/brave_side_panel_coordinator.cc
+++ b/browser/ui/views/side_panel/brave_side_panel_coordinator.cc
@@ -154,6 +154,9 @@ BraveSidePanelCoordinator::GetLastActiveEntryKey() const {
 
 void BraveSidePanelCoordinator::UpdateToolbarButtonHighlight(
     bool side_panel_visible) {
+  // In V2, we don't highlight sidebar toolbar button when panel
+  // is opened.
+#if !BUILDFLAG(ENABLE_SIDEBAR_V2)
   // Workaround to prevent crashing while window closing.
   // See https://github.com/brave/brave-browser/issues/34334
   if (!browser_view_ || !browser_view_->GetWidget() ||
@@ -169,6 +172,7 @@ void BraveSidePanelCoordinator::UpdateToolbarButtonHighlight(
         side_panel_visible ? IDS_TOOLTIP_SIDEBAR_HIDE
                            : IDS_TOOLTIP_SIDEBAR_SHOW));
   }
+#endif
 }
 
 void BraveSidePanelCoordinator::PopulateSidePanel(

--- a/browser/ui/views/sidebar/sidebar_container_view.cc
+++ b/browser/ui/views/sidebar/sidebar_container_view.cc
@@ -17,6 +17,7 @@
 #include "base/time/time.h"
 #include "brave/browser/ui/brave_browser.h"
 #include "brave/browser/ui/color/brave_color_id.h"
+#include "brave/browser/ui/sidebar/buildflags/buildflags.h"
 #include "brave/browser/ui/sidebar/features.h"
 #include "brave/browser/ui/sidebar/sidebar_controller.h"
 #include "brave/browser/ui/sidebar/sidebar_model.h"
@@ -297,14 +298,12 @@ void SidebarContainerView::SetSidebarShowOption(ShowSidebarOption show_option) {
   show_sidebar_option_ = show_option;
 
   if (base::FeatureList::IsEnabled(sidebar::features::kSidebarV2)) {
-    // When panel is visible, option change doesn't affect current UI status.
-    if (IsSidePanelShowing()) {
-      return;
-    }
+    // Toolbar button visibility depends on show options.
+    UpdateToolbarButtonVisibility();
 
     if (show_sidebar_option_ == ShowSidebarOption::kShowAlways) {
       if (!IsSidebarVisible()) {
-        ShowSidebarControlView();
+        ShowSidebar(false, true);
       }
       return;
     }
@@ -345,6 +344,23 @@ void SidebarContainerView::SetSidebarShowOption(ShowSidebarOption show_option) {
 void SidebarContainerView::UpdateSidebarItemsState() {
   // control view has items.
   sidebar_control_view_->Update();
+}
+
+void SidebarContainerView::UpdateSidebarVisibility() {
+#if BUILDFLAG(ENABLE_SIDEBAR_V2)
+  UpdateToolbarButtonHighlight();
+
+  // Pinning is an explicit user gesture, not a hover — snap to visible
+  // without animation, mirroring kShowAlways above. Otherwise, fall through
+  // and follow the current show option.
+  if (browser_->GetFeatures().sidebar_controller()->sidebar_pinned()) {
+    ShowSidebar(false, true);
+  } else {
+    // Refresh sidebar visibility with current show option.
+    SetSidebarShowOption(
+        GetSidebarService(GetBraveBrowser())->GetSidebarShowOption());
+  }
+#endif
 }
 
 void SidebarContainerView::MenuClosed() {
@@ -496,10 +512,15 @@ bool SidebarContainerView::IsSidePanelShowing() const {
 }
 
 bool SidebarContainerView::ShouldForceShowSidebar() const {
+#if BUILDFLAG(ENABLE_SIDEBAR_V2)
+  // In V2, don't hide sidebar when it's pinned.
+  return browser_->GetFeatures().sidebar_controller()->sidebar_pinned() ||
+#else
   // It is more reliable to check whether coordinator has current entry rather
   // than checking if side_panel_ is visible.
   return side_panel_coordinator_->GetCurrentEntryId(
              SidePanelEntry::PanelType::kContent) ||
+#endif
          sidebar_control_view_->IsItemReorderingInProgress() ||
          sidebar_control_view_->IsBubbleWidgetVisible();
 }
@@ -627,7 +648,8 @@ void SidebarContainerView::ShowSidebarControlView() {
   ShowSidebar(false);
 }
 
-void SidebarContainerView::ShowSidebar(bool show_side_panel) {
+void SidebarContainerView::ShowSidebar(bool show_side_panel,
+                                       bool suppress_animation) {
   DVLOG(1) << __func__ << ": show panel: " << show_side_panel;
 
   if (base::FeatureList::IsEnabled(sidebar::features::kSidebarV2)) {
@@ -645,7 +667,7 @@ void SidebarContainerView::ShowSidebar(bool show_side_panel) {
 
     sidebar_control_view_->SetVisible(true);
 
-    if (ShouldUseAnimation()) {
+    if (ShouldUseAnimation() && !suppress_animation) {
       width_animation_.Show();
     } else {
       PreferredSizeChanged();
@@ -867,18 +889,42 @@ bool SidebarContainerView::ShouldUseAnimation() {
 }
 
 void SidebarContainerView::UpdateToolbarButtonVisibility() {
+  auto* browser_view = BrowserView::GetBrowserViewForBrowser(browser_);
+  auto* brave_toolbar = static_cast<BraveToolbarView*>(browser_view->toolbar());
+  if (!brave_toolbar) {
+    return;
+  }
+#if BUILDFLAG(ENABLE_SIDEBAR_V2)
+  // In V2, we hide button when show always as pinning doesn't make sense
+  // when always visible.
+  if (auto* button = brave_toolbar->side_panel_button()) {
+    button->SetVisible(show_side_panel_button_.GetValue() &&
+                       show_sidebar_option_ != ShowSidebarOption::kShowAlways);
+  }
+  UpdateToolbarButtonHighlight();
+#else
   // Coordinate sidebar toolbar button visibility based on
   // whether there are any sibar items with a sidepanel.
   // This is similar to how chromium's side_panel_coordinator View
   // also has some control on the toolbar button.
   auto has_panel_item =
       GetSidebarService(GetBraveBrowser())->GetDefaultPanelItem().has_value();
-  auto* browser_view = BrowserView::GetBrowserViewForBrowser(browser_);
-  auto* brave_toolbar = static_cast<BraveToolbarView*>(browser_view->toolbar());
   if (brave_toolbar && brave_toolbar->side_panel_button()) {
     brave_toolbar->side_panel_button()->SetVisible(
         has_panel_item && show_side_panel_button_.GetValue());
   }
+#endif
+}
+
+void SidebarContainerView::UpdateToolbarButtonHighlight() {
+#if BUILDFLAG(ENABLE_SIDEBAR_V2)
+  auto* browser_view = BrowserView::GetBrowserViewForBrowser(browser_);
+  auto* brave_toolbar = static_cast<BraveToolbarView*>(browser_view->toolbar());
+  if (brave_toolbar && brave_toolbar->side_panel_button()) {
+    brave_toolbar->side_panel_button()->SetHighlighted(
+        browser_->GetFeatures().sidebar_controller()->sidebar_pinned());
+  }
+#endif
 }
 
 void SidebarContainerView::StartBrowserWindowEventMonitoring() {

--- a/browser/ui/views/sidebar/sidebar_container_view.cc
+++ b/browser/ui/views/sidebar/sidebar_container_view.cc
@@ -303,7 +303,7 @@ void SidebarContainerView::SetSidebarShowOption(ShowSidebarOption show_option) {
 
     if (show_sidebar_option_ == ShowSidebarOption::kShowAlways) {
       if (!IsSidebarVisible()) {
-        ShowSidebar(false, true);
+        ShowSidebar(false, AnimationStyle::kImmediate);
       }
       return;
     }
@@ -354,7 +354,7 @@ void SidebarContainerView::UpdateSidebarVisibility() {
   // without animation, mirroring kShowAlways above. Otherwise, fall through
   // and follow the current show option.
   if (browser_->GetFeatures().sidebar_controller()->sidebar_pinned()) {
-    ShowSidebar(false, true);
+    ShowSidebar(false, AnimationStyle::kImmediate);
   } else {
     // Refresh sidebar visibility with current show option.
     SetSidebarShowOption(
@@ -649,7 +649,7 @@ void SidebarContainerView::ShowSidebarControlView() {
 }
 
 void SidebarContainerView::ShowSidebar(bool show_side_panel,
-                                       bool suppress_animation) {
+                                       AnimationStyle animation) {
   DVLOG(1) << __func__ << ": show panel: " << show_side_panel;
 
   if (base::FeatureList::IsEnabled(sidebar::features::kSidebarV2)) {
@@ -667,7 +667,7 @@ void SidebarContainerView::ShowSidebar(bool show_side_panel,
 
     sidebar_control_view_->SetVisible(true);
 
-    if (ShouldUseAnimation() && !suppress_animation) {
+    if (ShouldUseAnimation() && animation == AnimationStyle::kAnimated) {
       width_animation_.Show();
     } else {
       PreferredSizeChanged();
@@ -890,6 +890,11 @@ bool SidebarContainerView::ShouldUseAnimation() {
 
 void SidebarContainerView::UpdateToolbarButtonVisibility() {
   auto* browser_view = BrowserView::GetBrowserViewForBrowser(browser_);
+  // BraveToolbarView and SidebarContainerView are sibling children of
+  // BrowserView; their construction/destruction order is not strictly
+  // coordinated, so the toolbar pointer (or its side_panel_button child) may
+  // be null during early init or window teardown when this is invoked from
+  // pref/observer callbacks.
   auto* brave_toolbar = static_cast<BraveToolbarView*>(browser_view->toolbar());
   if (!brave_toolbar) {
     return;
@@ -919,6 +924,8 @@ void SidebarContainerView::UpdateToolbarButtonVisibility() {
 void SidebarContainerView::UpdateToolbarButtonHighlight() {
 #if BUILDFLAG(ENABLE_SIDEBAR_V2)
   auto* browser_view = BrowserView::GetBrowserViewForBrowser(browser_);
+  // See UpdateToolbarButtonVisibility() for why brave_toolbar /
+  // side_panel_button() may be null here.
   auto* brave_toolbar = static_cast<BraveToolbarView*>(browser_view->toolbar());
   if (brave_toolbar && brave_toolbar->side_panel_button()) {
     brave_toolbar->side_panel_button()->SetHighlighted(

--- a/browser/ui/views/sidebar/sidebar_container_view.h
+++ b/browser/ui/views/sidebar/sidebar_container_view.h
@@ -139,13 +139,17 @@ class SidebarContainerView : public sidebar::Sidebar,
 
   class BrowserWindowEventObserver;
 
+  // Whether the show transition should slide in or snap immediately.
+  enum class AnimationStyle { kAnimated, kImmediate };
+
   void AddChildViews();
   void UpdateBackground();
   bool ShouldUseAnimation();
   void ShowSidebarControlView();
 
   // Show control view. panel's visibility depends on |show_side_panel|.
-  void ShowSidebar(bool show_side_panel, bool suppress_animation = false);
+  void ShowSidebar(bool show_side_panel,
+                   AnimationStyle animation = AnimationStyle::kAnimated);
 
   // Show all (panel + control view).
   void ShowSidebarAll();

--- a/browser/ui/views/sidebar/sidebar_container_view.h
+++ b/browser/ui/views/sidebar/sidebar_container_view.h
@@ -94,6 +94,7 @@ class SidebarContainerView : public sidebar::Sidebar,
   void SetSidebarShowOption(
       sidebar::SidebarService::ShowSidebarOption show_option) override;
   void UpdateSidebarItemsState() override;
+  void UpdateSidebarVisibility() override;
 
   // SidebarControlView::Delegate overrides:
   void MenuClosed() override;
@@ -144,7 +145,7 @@ class SidebarContainerView : public sidebar::Sidebar,
   void ShowSidebarControlView();
 
   // Show control view. panel's visibility depends on |show_side_panel|.
-  void ShowSidebar(bool show_side_panel);
+  void ShowSidebar(bool show_side_panel, bool suppress_animation = false);
 
   // Show all (panel + control view).
   void ShowSidebarAll();
@@ -163,6 +164,7 @@ class SidebarContainerView : public sidebar::Sidebar,
   bool IsSidePanelShowing() const;
   bool ShouldForceShowSidebar() const;
   void UpdateToolbarButtonVisibility();
+  void UpdateToolbarButtonHighlight();
 
   // true when fullscreen is initiated by tab. (Ex, fullscreen mode in youtube)
   bool IsFullscreenByTab() const;

--- a/browser/ui/views/toolbar/side_panel_button.cc
+++ b/browser/ui/views/toolbar/side_panel_button.cc
@@ -8,6 +8,8 @@
 #include <memory>
 
 #include "brave/app/vector_icons/vector_icons.h"
+#include "brave/browser/ui/sidebar/buildflags/buildflags.h"
+#include "brave/browser/ui/sidebar/sidebar_controller.h"
 #include "brave/components/constants/pref_names.h"
 #include "brave/grit/brave_generated_resources.h"
 #include "chrome/browser/profiles/profile.h"
@@ -81,7 +83,12 @@ SidePanelButton::SidePanelButton(Browser* browser)
 SidePanelButton::~SidePanelButton() = default;
 
 void SidePanelButton::ButtonPressed() {
+  // Different behavior in v1 and v2.
+#if BUILDFLAG(ENABLE_SIDEBAR_V2)
+  browser_->GetFeatures().sidebar_controller()->ToggleSidebarPinning();
+#else
   browser_->GetFeatures().side_panel_ui()->Toggle();
+#endif
 }
 
 void SidePanelButton::UpdateToolbarButtonIcon() {


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/55282

In V2, the sidebar toolbar button no longer toggles the side panel; it
controls only sidebar visibility, acting as a session-only pin.
  
Behavior:
  - kShowAlways: button is hidden — pinning has no meaning when the
    sidebar is always visible.
  - kShowOnMouseOver / kShowNever: button is visible. Clicking it pins
    the sidebar visible regardless of the show option. Clicking again,
    changing the show option, or closing the browser window clears the
    pinned state.
  - Button is highlighted while pinned. Highlight is driven by the
    controller's pinned state via UpdateSidebarVisibility() (on toggle)
    and UpdateToolbarButtonVisibility() (on show-option change), so it
    stays in sync regardless of which path triggered the update.

  Implementation:
  - SidebarController: adds session-only sidebar_pinned_ state and
    ToggleSidebarPinning(); OnShowSidebarOptionChanged() resets pinned.
  - Sidebar: new UpdateSidebarVisibility() interface entry point.
  - SidebarContainerView: pinned takes priority over kShowOnMouseOver /
    kShowNever and ShouldForceShowSidebar(); ShowSidebar() gains a
    suppress_animation flag so pin/unpin snaps without sliding (mirrors
    kShowAlways).
  - BraveSidePanelCoordinator::UpdateToolbarButtonHighlight is gated off
    in V2 so panel open/close no longer fights the pinned highlight.
  - SidePanelButton::ButtonPressed: V2 calls ToggleSidebarPinning()
    instead of side_panel_ui()->Toggle().

TEST=SidebarBrowserTest.SidebarV2ToolbarButtonPinning

[Screencast from 2026-05-06 22-36-40.webm](https://github.com/user-attachments/assets/94fc614c-7294-41c7-897e-c7c28855784b)

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
