### PR TITLE
[Sidebar V2] Suppress animation when switching between panels

### DIFF
--- a/browser/ui/sidebar/sidebar_browsertest.cc
+++ b/browser/ui/sidebar/sidebar_browsertest.cc
@@ -2223,6 +2223,101 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest,
       << "No-border resize area width should equal kNoBorderResizeAreaWidth";
 }
 
+class ScopedSidePanelUIForTesting {
+ public:
+  ScopedSidePanelUIForTesting(SidebarController* controller, SidePanelUI* ui)
+      : controller_(controller) {
+    controller_->SetSidePanelUIForTesting(ui);
+  }
+  ~ScopedSidePanelUIForTesting() {
+    controller_->SetSidePanelUIForTesting(nullptr);
+  }
+
+ private:
+  raw_ptr<SidebarController> controller_;
+};
+
+class MockSidePanelUI : public SidePanelUI {
+ public:
+  MOCK_METHOD(void,
+              Show,
+              (SidePanelEntryId, std::optional<SidePanelOpenTrigger>, bool),
+              (override));
+  MOCK_METHOD(void,
+              Show,
+              (SidePanelEntryKey, std::optional<SidePanelOpenTrigger>, bool),
+              (override));
+  MOCK_METHOD(void, ShowFrom, (SidePanelEntryKey, gfx::Rect), (override));
+  MOCK_METHOD(void,
+              Close,
+              (SidePanelEntry::PanelType, SidePanelEntryHideReason, bool),
+              (override));
+  MOCK_METHOD(void,
+              Toggle,
+              (SidePanelEntryKey, SidePanelOpenTrigger),
+              (override));
+  MOCK_METHOD(std::optional<SidePanelEntryId>,
+              GetCurrentEntryId,
+              (SidePanelEntry::PanelType),
+              (const, override));
+  MOCK_METHOD(int,
+              GetCurrentEntryDefaultContentWidth,
+              (SidePanelEntry::PanelType),
+              (const, override));
+  MOCK_METHOD(bool,
+              IsSidePanelShowing,
+              (SidePanelEntry::PanelType),
+              (const, override));
+  MOCK_METHOD(bool,
+              IsSidePanelEntryShowing,
+              (const SidePanelEntryKey&),
+              (const, override));
+  MOCK_METHOD(bool,
+              IsSidePanelEntryShowing,
+              (const SidePanelEntry::Key&, bool),
+              (const, override));
+  MOCK_METHOD(base::CallbackListSubscription,
+              RegisterSidePanelShown,
+              (SidePanelEntry::PanelType, ShownCallback),
+              (override));
+  MOCK_METHOD(void,
+              OnActiveTabChanged,
+              (content::WebContents*, content::WebContents*, bool),
+              (override));
+  MOCK_METHOD(content::WebContents*,
+              GetWebContentsForTest,
+              (SidePanelEntryId),
+              (override));
+  MOCK_METHOD(void, DisableAnimationsForTesting, (), (override));
+  MOCK_METHOD(void, SetNoDelaysForTesting, (bool), (override));
+};
+
+// Verify suppress_animations is false when opening from a closed state and
+// true when switching panels while one is already active.
+IN_PROC_BROWSER_TEST_F(SidebarBrowserTest,
+                       SidebarV2ActivatePanelItemSuppressAnimation) {
+  MockSidePanelUI mock_ui;
+  ScopedSidePanelUIForTesting scoped_ui(controller(), &mock_ui);
+
+  // No active panel: opening should animate (suppress_animations=false).
+  ASSERT_FALSE(model()->active_index().has_value())
+      << "Expected no active panel before first ActivatePanelItem call";
+  EXPECT_CALL(mock_ui,
+              Show(testing::An<SidePanelEntryId>(), testing::Eq(std::nullopt),
+                   /*suppress_animations=*/false));
+  controller()->ActivatePanelItem(SidebarItem::BuiltInItemType::kBookmarks);
+  testing::Mock::VerifyAndClearExpectations(&mock_ui);
+  controller()->UpdateActiveItemState(SidebarItem::BuiltInItemType::kBookmarks);
+
+  // Active panel present: switching panels should suppress animations.
+  ASSERT_TRUE(model()->active_index().has_value())
+      << "Expected active panel after UpdateActiveItemState";
+  EXPECT_CALL(mock_ui,
+              Show(testing::An<SidePanelEntryId>(), testing::Eq(std::nullopt),
+                   /*suppress_animations=*/true));
+  controller()->ActivatePanelItem(SidebarItem::BuiltInItemType::kReadingList);
+}
+
 #endif  // BUILDFLAG(ENABLE_SIDEBAR_V2)
 
 }  // namespace sidebar

--- a/browser/ui/sidebar/sidebar_controller.cc
+++ b/browser/ui/sidebar/sidebar_controller.cc
@@ -10,6 +10,7 @@
 
 #include "base/check.h"
 #include "base/check_op.h"
+#include "brave/browser/ui/sidebar/buildflags/buildflags.h"
 #include "brave/browser/ui/sidebar/sidebar.h"
 #include "brave/browser/ui/sidebar/sidebar_model.h"
 #include "brave/browser/ui/sidebar/sidebar_service_factory.h"
@@ -150,17 +151,25 @@ void SidebarController::ActivateItemAt(std::optional<size_t> index,
 void SidebarController::ActivatePanelItem(
     SidebarItem::BuiltInItemType panel_item) {
   // For panel item activation, SidePanelUI is the single source of truth.
-  auto* side_panel_ui = browser_->GetFeatures().side_panel_ui();
-  if (!side_panel_ui) {
-    return;
-  }
+  auto* side_panel_ui = side_panel_ui_for_testing_
+                            ? side_panel_ui_for_testing_.get()
+                            : browser_->GetFeatures().side_panel_ui();
   CHECK(side_panel_ui);
   if (panel_item == SidebarItem::BuiltInItemType::kNone) {
     side_panel_ui->Close(SidePanelEntry::PanelType::kContent);
     return;
   }
 
+#if BUILDFLAG(ENABLE_SIDEBAR_V2)
+  // Suppress opening animation when we have active item.
+  // When opening another panel while other panel is visible,
+  // we don't need to open new panel with animation.
+  const bool suppress_animations = sidebar_model_->active_index().has_value();
+  side_panel_ui->Show(sidebar::SidePanelIdFromSideBarItemType(panel_item),
+                      /*open_trigger*/ std::nullopt, suppress_animations);
+#else
   side_panel_ui->Show(sidebar::SidePanelIdFromSideBarItemType(panel_item));
+#endif
 }
 
 void SidebarController::DeactivateCurrentPanel() {

--- a/browser/ui/sidebar/sidebar_controller.h
+++ b/browser/ui/sidebar/sidebar_controller.h
@@ -19,6 +19,7 @@
 class Browser;
 class GURL;
 class Profile;
+class SidePanelUI;
 class TabStripModel;
 
 namespace sidebar {
@@ -63,6 +64,10 @@ class SidebarController : public SidebarService::Observer {
   void ActivatePanelItem(SidebarItem::BuiltInItemType panel_item);
   void DeactivateCurrentPanel();
 
+  void SetSidePanelUIForTesting(SidePanelUI* side_panel_ui) {
+    side_panel_ui_for_testing_ = side_panel_ui;
+  }
+
   // If current browser doesn't have a tab for |url|, active tab will load
   // |url|. Otherwise, existing tab will be activated.
   // ShowSingletonTab() has similar functionality but it loads url in the
@@ -99,6 +104,7 @@ class SidebarController : public SidebarService::Observer {
   raw_ptr<Profile> profile_ = nullptr;
   raw_ptr<Browser> browser_ = nullptr;
   raw_ptr<Sidebar> sidebar_ = nullptr;
+  raw_ptr<SidePanelUI> side_panel_ui_for_testing_ = nullptr;
 
   std::unique_ptr<SidebarModel> sidebar_model_;
   std::unique_ptr<SidebarWebPanelController> web_panel_controller_;


### PR DESCRIPTION
Add suppress_animations=true when ActivatePanelItem is called while a panel is already active. 

TEST=SidebarBrowserTest.SidebarV2ActivatePanelItemSuppressAnimation

[Screencast from 2026-05-06 16-26-39.webm](https://github.com/user-attachments/assets/e5b64f25-08a9-468c-92ea-f637d2ae8668)


<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/55285

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
