### PR TITLE
[iOS] Avoid tab retain cycle in NTP section setup

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/NewTabPage/NewTabPageViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/NewTabPage/NewTabPageViewController.swift
@@ -200,7 +200,8 @@ class NewTabPageViewController: UIViewController {
       StatsSectionProvider(
         isPrivateBrowsing: tab.isPrivate,
         openPrivacyHubPressed: { [weak self] in
-          if self?.privateBrowsingManager.isPrivateBrowsing == true {
+          guard let self, let tab = browserTab else { return }
+          if privateBrowsingManager.isPrivateBrowsing == true {
             return
           }
 
@@ -231,7 +232,7 @@ class NewTabPageViewController: UIViewController {
             )
           }
 
-          self?.present(host, animated: true)
+          present(host, animated: true)
         },
         hidePrivacyHubPressed: { [weak self] in
           self?.hidePrivacyHub()


### PR DESCRIPTION
Fixes a regression in #35937 which caused a TabState leak by accessing `tab` inside of the setup closure

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/55300
