### PR TITLE
Uplift Brave Origin Linux icon fix to 1.91.x

### DIFF
--- a/patches/chrome-installer-linux-common-installer.py.patch
+++ b/patches/chrome-installer-linux-common-installer.py.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/installer/linux/common/installer.py b/chrome/installer/linux/common/installer.py
-index 3c780c375fb9dddc93eeba12734f882abbf1aef0..62924e2c2c9a58ccf1dc35aaa8982f97c96f6313 100644
+index 3c780c375fb9dddc93eeba12734f882abbf1aef0..31dbbe9a5569cd2bc174b74a28038f0ddc56d546 100644
 --- a/chrome/installer/linux/common/installer.py
 +++ b/chrome/installer/linux/common/installer.py
 @@ -193,6 +193,8 @@ def gen_changelog(config: "InstallerConfig",
@@ -23,7 +23,7 @@ index 3c780c375fb9dddc93eeba12734f882abbf1aef0..62924e2c2c9a58ccf1dc35aaa8982f97
                  icon_suffix = "_dev"
              elif self.channel == "canary":
                  icon_suffix = "_canary"
-+        icon_suffix = {"beta": "_beta", "dev": "_dev", "nightly": "_nightly", "unstable": "_dev"}.get(self.channel, "") if self.branding == "brave" else ""
++        icon_suffix = {"beta": "_beta", "dev": "_dev", "nightly": "_nightly", "unstable": "_dev"}.get(self.channel, "") if self.branding in ("brave", "brave_origin") else ""
  
          icon_sizes = [16, 24, 32, 48, 64, 128, 256]
          logo_resources_png = []


### PR DESCRIPTION
Uplift of #36145
Resolves https://github.com/brave/brave-browser/issues/54734

## Included PRs
- #36145 - Use channel-specific icons for Brave Origin Linux packages

Pre-approval checklist:
- [ ] You have tested your change on Nightly.
- [ ] This contains text which needs to be translated.
    - [ ] There are more than 7 days before the release.
    - [ ] I've notified folks in #l10n on Slack that translations are needed.
- [x] The PR milestones match the branch they are landing to.


Pre-merge checklist:
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.

Post-merge checklist:
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.