### PR TITLE
[iOS] Avoid tab retain cycle in NTP section setup (uplift to 1.91.x)

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/NewTabPage/NewTabPageViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/NewTabPage/NewTabPageViewController.swift
@@ -200,7 +200,8 @@ class NewTabPageViewController: UIViewController {
       StatsSectionProvider(
         isPrivateBrowsing: tab.isPrivate,
         openPrivacyHubPressed: { [weak self] in
-          if self?.privateBrowsingManager.isPrivateBrowsing == true {
+          guard let self, let tab = browserTab else { return }
+          if privateBrowsingManager.isPrivateBrowsing == true {
             return
           }
 
@@ -231,7 +232,7 @@ class NewTabPageViewController: UIViewController {
             )
           }
 
-          self?.present(host, animated: true)
+          present(host, animated: true)
         },
         hidePrivacyHubPressed: { [weak self] in
           self?.hidePrivacyHub()


### PR DESCRIPTION
Uplift of #36212
Resolves https://github.com/brave/brave-browser/issues/55300

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.