### PR TITLE
Add best practice CS-070: Use *.mojom-forward.h in headers

### DIFF
--- a/docs/best-practices/coding-standards.md
+++ b/docs/best-practices/coding-standards.md
@@ -1139,3 +1139,40 @@ base::debug::ScopedCrashKeyString scoped_key(crash_key, state);
 ```
 
 See [Chromium C++ style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md).
+
+---
+
+<a id="CS-070"></a>
+
+## ✅ Use `*.mojom-forward.h` in Headers When Only Forward Declarations Are Needed
+
+**When a header only references mojom types as pointers, references, or function parameters, include the auto-generated `*.mojom-forward.h` instead of the full `*.mojom.h` bindings.** The forward header declares all types from the mojom file without pulling in the full bindings, which reduces compile times and transitive dependencies. Move the full `*.mojom.h` include to the `.cc` file where the types are actually used.
+
+```cpp
+// ❌ WRONG - full mojom bindings in header for forward-declared usage only
+// prefs_registration.h
+#include "brave/components/containers/core/mojom/containers.mojom.h"
+
+namespace containers {
+void RegisterProfilePrefs(
+    user_prefs::PrefRegistrySyncable* registry,
+    const std::vector<mojom::ContainerPtr>& default_containers);
+}
+
+// ✅ CORRECT - forward header in .h, full include in .cc
+// prefs_registration.h
+#include "brave/components/containers/core/mojom/containers.mojom-forward.h"
+
+namespace containers {
+void RegisterProfilePrefs(
+    user_prefs::PrefRegistrySyncable* registry,
+    const std::vector<mojom::ContainerPtr>& default_containers);
+}
+
+// prefs_registration.cc
+#include "brave/components/containers/core/mojom/containers.mojom.h"
+```
+
+This is a mojom-specific application of [CS-014](#CS-014). The `*.mojom-forward.h` is auto-generated alongside the full bindings — every mojom target produces it.
+
+---


### PR DESCRIPTION
## Summary
- Adds CS-070 to `docs/best-practices/coding-standards.md`: **Use `*.mojom-forward.h` in Headers When Only Forward Declarations Are Needed**
- A mojom-specific application of CS-014 — when a header only references mojom types as pointers, references, or function parameters, include the auto-generated `*.mojom-forward.h` instead of the full `*.mojom.h` bindings to reduce compile times and transitive dependencies.

## Source
Distilled from a review comment on #35622 ([discussion](https://github.com/brave/brave-core/pull/35622#discussion_r3102138009)) — the existing CS-014 covered the general forward-declaration principle but didn't surface the mojom-specific `*-forward.h` pattern, which is already widely used across brave-core (brave_news, brave_shields, brave_ads, etc.).

## Test plan
- [ ] `python3 ./script/manage-bp-ids.py --validate` — passes (593 headings, all unique IDs)
- [ ] Render `docs/best-practices/coding-standards.md` and confirm CS-070 anchor and code blocks display correctly