### PR TITLE
[iOS] Display toast on Origin settings after changing a feature state

### DIFF
--- a/ios/brave-ios/Sources/Origin/OriginSettingsView.swift
+++ b/ios/brave-ios/Sources/Origin/OriginSettingsView.swift
@@ -114,24 +114,23 @@ public struct OriginSettingsView: View {
     .navigationBarTitleDisplayMode(.inline)
     .scrollContentBackground(.hidden)
     .background(Color(.braveGroupedBackground))
-    .safeAreaInset(edge: .bottom) {
+    .overlay(alignment: .bottom) {
       if viewModel.isRestartToastVisible {
         FeatureEnabledToastView {
-          viewModel.isRestartToastVisible = false
+          withAnimation(.toast) {
+            viewModel.isRestartToastVisible = false
+          }
         }
-        .transition(.move(edge: .bottom).combined(with: .opacity))
+        .transition(.move(edge: .bottom).combined(with: .blurReplace))
       }
     }
-    .animation(
-      .spring(response: 0.3, dampingFraction: 0.725),
-      value: viewModel.isRestartToastVisible
-    )
   }
 
   private struct FeatureEnabledToastView: View {
     var dismiss: () -> Void
     @State private var dragOffset: CGFloat = 0
     @State private var height: CGFloat = 0
+    @AccessibilityFocusState(for: .voiceOver) private var isAccessibilityFocused: Bool
 
     var body: some View {
       HStack(alignment: .firstTextBaseline) {
@@ -177,6 +176,16 @@ public struct OriginSettingsView: View {
           }
       )
       .padding(8)
+      .dynamicTypeSize(.xSmall..<DynamicTypeSize.accessibility2)
+      .accessibilityElement(children: .combine)
+      .accessibilityAddTraits(.isModal)
+      .accessibilityFocused($isAccessibilityFocused)
+      .accessibilityAction {
+        dismiss()
+      }
+      .onAppear {
+        isAccessibilityFocused = true
+      }
     }
   }
 }
@@ -213,6 +222,12 @@ extension Bool {
   fileprivate var inversed: Bool {
     get { !self }
     set { self = !newValue }
+  }
+}
+
+extension Animation {
+  static var toast: Animation {
+    .spring(response: 0.3, dampingFraction: 0.725)
   }
 }
 

--- a/ios/brave-ios/Sources/Origin/OriginSettingsView.swift
+++ b/ios/brave-ios/Sources/Origin/OriginSettingsView.swift
@@ -114,6 +114,70 @@ public struct OriginSettingsView: View {
     .navigationBarTitleDisplayMode(.inline)
     .scrollContentBackground(.hidden)
     .background(Color(.braveGroupedBackground))
+    .safeAreaInset(edge: .bottom) {
+      if viewModel.isRestartToastVisible {
+        FeatureEnabledToastView {
+          viewModel.isRestartToastVisible = false
+        }
+        .transition(.move(edge: .bottom).combined(with: .opacity))
+      }
+    }
+    .animation(
+      .spring(response: 0.3, dampingFraction: 0.725),
+      value: viewModel.isRestartToastVisible
+    )
+  }
+
+  private struct FeatureEnabledToastView: View {
+    var dismiss: () -> Void
+    @State private var dragOffset: CGFloat = 0
+    @State private var height: CGFloat = 0
+
+    var body: some View {
+      HStack(alignment: .firstTextBaseline) {
+        VStack(alignment: .leading) {
+          Text(Strings.Origin.featureEnabledToastTitle)
+            .fontWeight(.semibold)
+          Text(Strings.Origin.featureEnabledToastMessage)
+        }
+        Spacer()
+        Button {
+          dismiss()
+        } label: {
+          Label(Strings.close, braveSystemImage: "leo.close")
+            .labelStyle(.iconOnly)
+            .foregroundStyle(Color(braveSystemName: .schemesPrimaryFixedDim))
+            .imageScale(.large)
+        }
+      }
+      .font(.subheadline)
+      .foregroundStyle(Color.white)
+      .padding(16)
+      .background(
+        Color(braveSystemName: .schemesOnPrimaryFixed)
+          .shadow(.drop(color: Color(braveSystemName: .elevationSecondary), radius: 2, y: 1))
+          .shadow(.drop(color: Color(braveSystemName: .elevationSecondary), radius: 3, y: 1)),
+        in: .rect(cornerRadius: 22, style: .continuous)
+      )
+      .onGeometryChange(for: CGFloat.self, of: \.size.height, action: { height = $0 })
+      .offset(y: max(0, dragOffset))
+      .gesture(
+        DragGesture()
+          .onChanged { value in
+            dragOffset = value.translation.height
+          }
+          .onEnded { value in
+            if value.predictedEndTranslation.height > height / 2 {
+              dismiss()
+            } else {
+              withAnimation(.snappy) {
+                dragOffset = 0
+              }
+            }
+          }
+      )
+      .padding(8)
+    }
   }
 }
 
@@ -178,5 +242,15 @@ private class MockOriginService: BraveOriginService {
       viewModel: .init(service: MockOriginService(), storeSDK: .init(skusService: nil))
     )
   }
+}
+#Preview {
+  Color.white
+    .sheet(isPresented: .constant(true)) {
+      NavigationStack {
+        OriginSettingsView(
+          viewModel: .init(service: MockOriginService(), storeSDK: .init(skusService: nil))
+        )
+      }
+    }
 }
 #endif

--- a/ios/brave-ios/Sources/Origin/OriginSettingsViewModel.swift
+++ b/ios/brave-ios/Sources/Origin/OriginSettingsViewModel.swift
@@ -31,6 +31,7 @@ struct OriginPolicyBooleanValue {
       instance.withMutation(keyPath: wrappedKeyPath) {
         _ = instance.service.setPolicyValue(key, value: newValue)
       }
+      instance.isRestartToastVisible = true
     }
   }
 }
@@ -48,6 +49,8 @@ public class OriginSettingsViewModel {
       await updatePurchaseStatus()
     }
   }
+
+  var isRestartToastVisible: Bool = false
 
   @ObservationIgnored
   @OriginPolicyBooleanValue(key: .rewardsDisabled)

--- a/ios/brave-ios/Sources/Origin/OriginSettingsViewModel.swift
+++ b/ios/brave-ios/Sources/Origin/OriginSettingsViewModel.swift
@@ -28,10 +28,14 @@ struct OriginPolicyBooleanValue {
     }
     set {
       let key = instance[keyPath: storageKeyPath].key
-      instance.withMutation(keyPath: wrappedKeyPath) {
-        _ = instance.service.setPolicyValue(key, value: newValue)
+      let result = instance.withMutation(keyPath: wrappedKeyPath) {
+        instance.service.setPolicyValue(key, value: newValue)
       }
-      instance.isRestartToastVisible = true
+      if result {
+        withAnimation(.toast) {
+          instance.isRestartToastVisible = true
+        }
+      }
     }
   }
 }

--- a/ios/brave-ios/Sources/Origin/OriginStrings.swift
+++ b/ios/brave-ios/Sources/Origin/OriginStrings.swift
@@ -98,6 +98,21 @@ extension Strings {
       value: "Reset to Defaults",
       comment: "A button label to reset all Origin settings to their default values"
     )
+    public static let featureEnabledToastTitle = NSLocalizedString(
+      "featureEnabledToastTitle",
+      bundle: .module,
+      value: "Changing Brave features",
+      comment:
+        "A title shown in a toast that appears after toggling a Brave feature on or off in Origin settings"
+    )
+    public static let featureEnabledToastMessage = NSLocalizedString(
+      "featureEnabledToastMessage",
+      bundle: .module,
+      value:
+        "Enabling or disabling a Brave feature requires a browser restart to apply changes. Please close (swipe up in the App Switcher) and then re-open Brave.",
+      comment:
+        "A message shown in a toast informing the user that enabling or disabling a Brave feature requires restarting the browser to take effect"
+    )
     public static let alreadyPurchasedTitle = NSLocalizedString(
       "alreadyPurchasedTitle",
       bundle: .module,


### PR DESCRIPTION
This adds a new toast that displays until the user dismisses it/swipes it away that explains to users that the app needs to be restarted in order to apply Origin changes

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/55313
