### PR TITLE
Disables kIPHAutofillAccountNameEmailSuggestionFeature. (uplift to 1.91.x)

### DIFF
--- a/app/feature_defaults_unittest.cc
+++ b/app/feature_defaults_unittest.cc
@@ -139,6 +139,7 @@ TEST(FeatureDefaultsTest, DisabledFeatures) {
       &extensions_features::kExtensionsManifestV3Only,
 #endif
 #if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_APPLE) || BUILDFLAG(IS_LINUX)
+      &feature_engagement::kIPHAutofillAccountNameEmailSuggestionFeature,
       &feature_engagement::kIPHDiscardRingFeature,
       &feature_engagement::kIPHGMCCastStartStopFeature,
       &feature_engagement::kIPHPasswordsManagementBubbleAfterSaveFeature,

--- a/chromium_src/components/feature_engagement/public/feature_constants.cc
+++ b/chromium_src/components/feature_engagement/public/feature_constants.cc
@@ -20,6 +20,8 @@ BASE_FEATURE(kIPHBraveShieldsInPageInfoFeature,
 
 OVERRIDE_FEATURE_DEFAULT_STATES({{
 #if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_APPLE) || BUILDFLAG(IS_LINUX)
+    {kIPHAutofillAccountNameEmailSuggestionFeature,
+     base::FEATURE_DISABLED_BY_DEFAULT},
     {kIPHDiscardRingFeature, base::FEATURE_DISABLED_BY_DEFAULT},
     {kIPHGMCCastStartStopFeature, base::FEATURE_DISABLED_BY_DEFAULT},
     {kIPHPasswordsManagementBubbleAfterSaveFeature,


### PR DESCRIPTION
Uplift of #36172
Resolves https://github.com/brave/brave-browser/issues/55261

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.