### PR TITLE
Gate brave://ads-internals on Brave Rewards policy

### DIFF
--- a/browser/brave_rewards/test/rewards_policy_browsertest.cc
+++ b/browser/brave_rewards/test/rewards_policy_browsertest.cc
@@ -128,6 +128,17 @@ IN_PROC_BROWSER_TEST_P(BraveRewardsPolicyTest, RewardsPagesAccess) {
   }
 }
 
+#if BUILDFLAG(ENABLE_BRAVE_ADS)
+// Verify that brave://ads-internals isn't reachable when Brave Rewards are
+// disabled by policy.
+IN_PROC_BROWSER_TEST_P(BraveRewardsPolicyTest, AdsInternalsPageAccess) {
+  auto* rfh =
+      ui_test_utils::NavigateToURL(browser(), GURL("chrome://ads-internals"));
+  EXPECT_TRUE(rfh);
+  EXPECT_EQ(IsBraveRewardsDisabledTest(), rfh->IsErrorDocument());
+}
+#endif  // BUILDFLAG(ENABLE_BRAVE_ADS)
+
 // Verify that Brave Rewards icon is not shown in the location bar when Brave
 // Rewards are disabled by policy.
 IN_PROC_BROWSER_TEST_P(BraveRewardsPolicyTest, RewardsIconIsHidden) {

--- a/browser/ui/webui/brave_web_ui_controller_factory.cc
+++ b/browser/ui/webui/brave_web_ui_controller_factory.cc
@@ -93,6 +93,10 @@
 #include "brave/browser/ui/webui/brave_rewards_internals_ui.h"
 #endif
 
+#if BUILDFLAG(ENABLE_BRAVE_ADS)
+#include "brave/components/brave_rewards/core/pref_names.h"
+#endif
+
 using content::WebUI;
 using content::WebUIController;
 
@@ -111,7 +115,9 @@ WebUIController* NewWebUI(WebUI* web_ui, const GURL& url) {
   if (host == kSkusInternalsHost) {
     return new SkusInternalsUI(web_ui, url.host());
 #if BUILDFLAG(ENABLE_BRAVE_ADS)
-  } else if (host == kAdsInternalsHost) {
+  } else if (host == kAdsInternalsHost &&
+             !profile->GetPrefs()->GetBoolean(
+                 brave_rewards::prefs::kDisabledByPolicy)) {
     return new AdsInternalsUI(
         web_ui, url.host(),
         brave_ads::AdsServiceFactory::GetForProfile(profile),
@@ -227,7 +233,9 @@ WebUIFactoryFunction GetWebUIFactoryFunction(WebUI* web_ui,
       url.host() == kRewardsPageHost || url.host() == kRewardsInternalsHost ||
 #endif
 #if BUILDFLAG(ENABLE_BRAVE_ADS)
-      (url.host() == kAdsInternalsHost && !profile->IsIncognitoProfile()) ||
+      (url.host() == kAdsInternalsHost && !profile->IsIncognitoProfile() &&
+       !profile->GetPrefs()->GetBoolean(
+           brave_rewards::prefs::kDisabledByPolicy)) ||
 #endif  // BUILDFLAG(ENABLE_BRAVE_ADS)
       (url.host() == kSkusInternalsHost &&
        base::FeatureList::IsEnabled(skus::features::kSkusFeature))) {


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/55434

## Summary

- Block access to `brave://ads-internals` when Brave Rewards are disabled by enterprise policy (`brave_rewards::prefs::kDisabledByPolicy`), matching the existing gating for `brave://rewards` and `brave://rewards-internals`.
- Add an `AdsInternalsPageAccess` browser test to the existing parameterized `BraveRewardsPolicyTest` fixture, asserting `IsErrorDocument()` matches the policy state in both directions.

## Test plan
- [x] (Dev only) `brave_browser_tests --gtest_filter='*BraveRewardsPolicyTest*AdsInternalsPageAccess*'` passes for both `BraveRewards_DisabledByPolicy` and `BraveRewards_NotDisabledByPolicy` parameter values.
- [x] With the `BraveRewardsDisabled` policy set to true, `brave://ads-internals` shows the error page.
- [x] With the policy unset/false, `brave://ads-internals` loads as before.
- [x] Brave Origin upgrades and separate builds do not have this page (But this PR only fixes the former)