### PR TITLE
[iOS] fix reader mode button disappears after coming back from an reader mode active page

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabObserver.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabObserver.swift
@@ -392,26 +392,19 @@ extension BrowserViewController: TabObserver {
     // reader mode page, most of the `TabObserver` methods are fired before
     // web main frame is ready,
     // For this case, we need to check readability after main frame did became available
-    guard frame.isMainFrame,
+    guard FeatureList.kUseProfileWebViewConfiguration.enabled,
+      frame.isMainFrame,
+      let readerMode = tab.readerMode,
       let url = tab.visibleURL,
       !url.isNewTabURL,
       !InternalURL.isValid(url: url) || url.isInternalURL(for: .readermode),
       !url.isFileURL
     else { return }
-    if FeatureList.kUseProfileWebViewConfiguration.enabled {
-      if let readerMode = tab.readerMode {
-        Task {
-          await readerMode.checkReadability()
-          if tabManager.selectedTab === tab {
-            topToolbar.updateReaderModeState(readerMode.state)
-          }
-        }
+    Task {
+      await readerMode.checkReadability()
+      if tabManager.selectedTab === tab {
+        topToolbar.updateReaderModeState(readerMode.state)
       }
-    } else {
-      tab.evaluateJavaScript(
-        functionName: "\(readerModeNamespace).checkReadability",
-        contentWorld: ReaderModeScriptHandler.scriptSandbox
-      )
     }
   }
 }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabObserver.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabObserver.swift
@@ -386,6 +386,34 @@ extension BrowserViewController: TabObserver {
       updateStatusBarOverlayColor()
     }
   }
+
+  public func tab(_ tab: some TabState, frameDidBecomeAvailable frame: WebFrame) {
+    // when user taps back button to go back to the previous page from an activated
+    // reader mode page, most of the `TabObserver` methods are fired before
+    // web main frame is ready,
+    // For this case, we need to check readability after main frame did became available
+    guard frame.isMainFrame,
+      let url = tab.visibleURL,
+      !url.isNewTabURL,
+      !InternalURL.isValid(url: url) || url.isInternalURL(for: .readermode),
+      !url.isFileURL
+    else { return }
+    if FeatureList.kUseProfileWebViewConfiguration.enabled {
+      if let readerMode = tab.readerMode {
+        Task {
+          await readerMode.checkReadability()
+          if tabManager.selectedTab === tab {
+            topToolbar.updateReaderModeState(readerMode.state)
+          }
+        }
+      }
+    } else {
+      tab.evaluateJavaScript(
+        functionName: "\(readerModeNamespace).checkReadability",
+        contentWorld: ReaderModeScriptHandler.scriptSandbox
+      )
+    }
+  }
 }
 
 extension BrowserViewController {


### PR DESCRIPTION
When using back/forward button to navigate page, WKWebView would using caches to restore pages which will make most CWV navigation callbacks very early/quick while the JavaScript execution context is reinitialized asynchronously. 
This will make the reader mode readability check returns wrong status since web main frame is not yet ready. 
The solution is to add another readability check when the main frame did become available. 

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/55309

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
