### PR TITLE
Hide Brave Account UI if Email Aliases is disabled by policy.

### DIFF
--- a/browser/ui/webui/brave_settings_ui.cc
+++ b/browser/ui/webui/brave_settings_ui.cc
@@ -289,20 +289,28 @@ void BraveSettingsUI::AddResources(content::WebUIDataSource* html_source,
   html_source->AddBoolean(
       "isSharedPinnedTabsEnabled",
       base::FeatureList::IsEnabled(tabs::kBraveSharedPinnedTabs));
-#if BUILDFLAG(ENABLE_EMAIL_ALIASES)
-  html_source->AddBoolean(
-      "isEmailAliasesEnabled",
-      email_aliases::features::IsEmailAliasesEnabled() &&
-          email_aliases::EmailAliasesServiceFactory::GetServiceForProfile(
-              profile));
-#endif
 #if BUILDFLAG(ENABLE_CONTAINERS)
   html_source->AddBoolean(
       "isContainersEnabled",
       base::FeatureList::IsEnabled(containers::features::kContainers));
 #endif
-  html_source->AddBoolean("isBraveAccountEnabled",
-                          brave_account::features::IsBraveAccountEnabled());
+  bool is_brave_account_enabled =
+      brave_account::features::IsBraveAccountEnabled();
+#if BUILDFLAG(ENABLE_EMAIL_ALIASES)
+  const bool is_email_aliases_enabled =
+      email_aliases::features::IsEmailAliasesEnabled() &&
+      email_aliases::EmailAliasesServiceFactory::GetServiceForProfile(profile);
+
+  if (!brave_account::features::IsBraveAccountExplicitlyEnabled()) {
+    // If BraveAccount feature is not explicitly enabled then it means that
+    // Brave Account available because the Email Aliases depends on it, we
+    // have to hide Brave Account's UI if Email Aliases is disabled by the pref
+    // toggle.
+    is_brave_account_enabled = is_email_aliases_enabled;
+  }
+  html_source->AddBoolean("isEmailAliasesEnabled", is_email_aliases_enabled);
+#endif
+  html_source->AddBoolean("isBraveAccountEnabled", is_brave_account_enabled);
   html_source->AddBoolean("isBraveOriginBrandedBuild",
                           BUILDFLAG(IS_BRAVE_ORIGIN_BRANDED));
   html_source->AddBoolean("isBraveOriginPurchased",

--- a/components/brave_account/features.cc
+++ b/components/brave_account/features.cc
@@ -17,11 +17,16 @@ namespace {
 BASE_FEATURE(kBraveAccount, base::FEATURE_DISABLED_BY_DEFAULT);
 }  // namespace
 
+// Checks that kBraveAccount feature flag is explicitly enabled (dev/testing)
+bool IsBraveAccountExplicitlyEnabled() {
+  return base::FeatureList::IsEnabled(kBraveAccount);
+}
+
 // Brave Account is enabled when:
 // - the explicit kBraveAccount feature flag is enabled (dev/testing), OR
 // - a dependent feature (e.g. Email Aliases) requires it
 bool IsBraveAccountEnabled() {
-  return base::FeatureList::IsEnabled(kBraveAccount)
+  return IsBraveAccountExplicitlyEnabled()
 #if BUILDFLAG(ENABLE_EMAIL_ALIASES)
          || email_aliases::features::IsEmailAliasesEnabled()
 #endif

--- a/components/brave_account/features.h
+++ b/components/brave_account/features.h
@@ -10,6 +10,8 @@
 
 namespace brave_account::features {
 
+bool IsBraveAccountExplicitlyEnabled();
+
 bool IsBraveAccountEnabled();
 
 const base::Feature& BraveAccountFeatureForTesting();


### PR DESCRIPTION
We don't want to show the Brave Account UI in Brave Origin if BA feature is not explicitly enabled and Email Aliases is turned off by the preference toggle