### PR TITLE
[Android] Enforce Brave Origin policies for VPN, Leo AI and Playlist on Stable/Beta

### DIFF
--- a/browser/brave_origin/BUILD.gn
+++ b/browser/brave_origin/BUILD.gn
@@ -117,6 +117,7 @@ source_set("unit_tests") {
     "//brave/components/p3a",
     "//chrome/browser/profiles",
     "//chrome/test:test_support",
+    "//components/policy:generated",
     "//components/policy/core/common:test_support",
     "//content/test:test_support",
     "//testing/gtest",

--- a/browser/brave_origin/brave_origin_service_factory_unittest.cc
+++ b/browser/brave_origin/brave_origin_service_factory_unittest.cc
@@ -13,6 +13,7 @@
 #include "brave/components/p3a/pref_names.h"
 #include "chrome/test/base/testing_browser_process.h"
 #include "chrome/test/base/testing_profile_manager.h"
+#include "components/policy/core/common/policy_details.h"
 #include "components/policy/policy_constants.h"
 #include "content/public/test/browser_task_environment.h"
 #include "testing/gtest/include/gtest/gtest.h"
@@ -147,6 +148,58 @@ TEST(BraveOriginServiceFactoryTest,
   // Verify that we have profile-level policies
   EXPECT_GT(profile_policy_definitions.size(), 0u)
       << "Should have at least some profile policies";
+}
+
+// Verifies that every policy claimed by Brave Origin is actually enforceable
+// on the current build platform — i.e. its YAML lists the platform under
+// `supported_on:`, not `future_on:`.
+//
+// Future policies are dropped by `IsBlockedFuturePolicy`
+// (configuration_policy_handler_list.cc) on Stable and Beta channels, so a
+// future policy claimed by Brave Origin silently fails to manage its pref for
+// end users — even though debug/Nightly builds (where future policies are
+// allowed) make it look like it works. Direct admin policy via
+// `kBraveSimplePolicyMap` is allowed to be future on a given platform; this
+// invariant is specifically about Brave Origin's user-facing toggles.
+TEST(BraveOriginServiceFactoryTest, OriginPolicies_NotFutureOnThisPlatform) {
+  auto check = [](const BraveOriginPolicyMap& definitions) {
+    for (const auto& [policy_key, info] : definitions) {
+      const policy::PolicyDetails* details =
+          policy::GetChromePolicyDetails(policy_key);
+      ASSERT_NE(details, nullptr)
+          << "Unknown policy in Brave Origin definitions: " << policy_key;
+      EXPECT_FALSE(details->is_future)
+          << policy_key
+          << " is in Brave Origin metadata but its YAML lists the current "
+             "build platform under future_on:. On Stable/Beta channels the "
+             "policy is dropped by IsBlockedFuturePolicy before reaching the "
+             "SimplePolicyHandler, so when an Origin user toggles this "
+             "feature the pref never becomes managed. To fix, pick one:\n"
+             "\n"
+             "  (a) If the platform's runtime support is shipped, move it "
+             "from future_on: to supported_on: in the policy YAML at\n"
+             "      brave/components/policy/resources/templates/"
+             "policy_definitions/BraveSoftware/"
+          << policy_key
+          << ".yaml\n"
+             "      (e.g. add `- android:<milestone>-` to supported_on:, "
+             "drop the future_on: block).\n"
+             "\n"
+             "  (b) If the platform's runtime support is NOT shipped, "
+             "remove (or platform-gate) this policy's entry in the matching "
+             "metadata map (kBraveOriginBrowserMetadata or "
+             "kBraveOriginProfileMetadata) at\n"
+             "      brave/browser/brave_origin/"
+             "brave_origin_service_factory.cc\n"
+             "      so that Brave Origin no longer claims to enforce this "
+             "policy on the current platform.\n"
+             "\n"
+             "Either fix makes the YAML, the Brave Origin metadata, and the "
+             "runtime tell a consistent story.";
+    }
+  };
+  check(BraveOriginServiceFactory::GetBrowserPolicyDefinitions());
+  check(BraveOriginServiceFactory::GetProfilePolicyDefinitions());
 }
 
 // Test fixture for profile-related tests

--- a/components/policy/resources/templates/policy_definitions/BraveSoftware/BraveAIChatEnabled.yaml
+++ b/components/policy/resources/templates/policy_definitions/BraveSoftware/BraveAIChatEnabled.yaml
@@ -34,7 +34,6 @@ schema:
 supported_on:
 - ios:139-
 - chrome.*:121-
-future_on:
-- android
+- android:148-
 tags: []
 type: main

--- a/components/policy/resources/templates/policy_definitions/BraveSoftware/BravePlaylistEnabled.yaml
+++ b/components/policy/resources/templates/policy_definitions/BraveSoftware/BravePlaylistEnabled.yaml
@@ -34,7 +34,6 @@ schema:
 supported_on:
 - chrome.*:139-
 - ios:140-
-future_on:
-- android
+- android:148-
 tags: []
 type: main

--- a/components/policy/resources/templates/policy_definitions/BraveSoftware/BraveVPNDisabled.yaml
+++ b/components/policy/resources/templates/policy_definitions/BraveSoftware/BraveVPNDisabled.yaml
@@ -33,7 +33,6 @@ schema:
 supported_on:
 - ios:139-
 - chrome.*:112-
-future_on:
-- android
+- android:148-
 tags: []
 type: main


### PR DESCRIPTION
The policy YAMLs for `BraveVPNDisabled`, `BraveAIChatEnabled` and `BravePlaylistEnabled` listed Android only under `future_on`:, never under `supported_on`:. Codegen marks them `is_future` on Android, and `ConfigurationPolicyHandlerList::IsBlockedFuturePolicy` drops `is_future` policies from the bundle on Stable and Beta channels — so the matching managed prefs (`kManagedBraveVPNDisabled`, `ai_chat::prefs::kEnabledByPolicy`, `playlist::kPlaylistEnabledPref`) never become managed, and the Java hide checks in `BraveMainPreferencesBase.onResume() ` and the cross-platform `playlist::IsPlaylistAllowed()` never see the policy. Nightly and local debug builds (channel != Stable/Beta) bypass the gate, which is why this escaped pre-release.

Move android from `future_on`: to `supported_on: android:148-` in the three YAMLs, matching the existing pattern used for `BraveWalletDisabled` and `BraveNewsDisabled`.

Add `OriginPolicies_NotFutureOnThisPlatform` unit test that walks every entry in `BraveOriginServiceFactory::GetBrowserPolicyDefinitions()` and `GetProfilePolicyDefinitions()` and asserts `policy_details.is_future` is false. The test runs on every channel and target, so future regressions of the same shape — Brave Origin claiming to enforce a policy that the runtime gate will silently drop — surface in unit tests instead of in released Stable/Beta builds.

Resolves: https://github.com/brave/brave-browser/issues/55346

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
