### PR TITLE
Fix flags missing spaces

### DIFF
--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -1293,8 +1293,8 @@ constexpr flags_ui::FeatureEntry::Choice kVerticalTabCollapseDelayChoices[] = {
           "learn more about the server implementation in the repository link " \
           "mentioned below. "                                                  \
           "Note: Only HTTPS URLs are supported by default. HTTP URLs are "     \
-          "only allowed for potentially trustworthy origins like localhost."   \
-          "Insecure URLs that don't meet these requirements will be ignored"   \
+          "only allowed for potentially trustworthy origins like localhost. "  \
+          "Insecure URLs that don't meet these requirements will be ignored "  \
           "in favor of the official Brave-hosted server",                      \
           kOsAll,                                                              \
           ORIGIN_LIST_VALUE_TYPE(syncer::kSyncServiceURL, ""),                 \
@@ -1340,7 +1340,7 @@ constexpr flags_ui::FeatureEntry::Choice kVerticalTabCollapseDelayChoices[] = {
           "brave-request-info-unique-ptr",                                     \
           "BraveRequestInfo unique_ptr",                                       \
           "Enable experimental use of unique_ptr/WeakPtr instead of "          \
-          "shared_ptr"                                                         \
+          "shared_ptr "                                                        \
           "for BraveRequestInfo",                                              \
           kOsAll,                                                              \
           FEATURE_VALUE_TYPE(features::kBraveRequestInfoUniquePtr),            \


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/55347

A couple lines of text were missing spaces, causing words to run together.

<img width="1110" height="250" alt="image" src="https://github.com/user-attachments/assets/3dd5ce75-4f0a-4c00-9dc2-490de3e5e3ca" />
