### PR TITLE
[Android][Sync] Fix for regression after OSCrypt migration

### DIFF
--- a/chromium_src/components/sync/service/sync_service_impl.h
+++ b/chromium_src/components/sync/service/sync_service_impl.h
@@ -22,7 +22,9 @@
                            OnAccountDeleted_FailureAndRetry);                  \
   FRIEND_TEST_ALL_PREFIXES(BraveSyncServiceImplTest, JoinDeletedChain);        \
   FRIEND_TEST_ALL_PREFIXES(BraveSyncServiceImplTest,                           \
-                           ForcedSetDecryptionPassphrase);
+                           ForcedSetDecryptionPassphrase);                     \
+  FRIEND_TEST_ALL_PREFIXES(BraveSyncServiceImplTest,                           \
+                           StopAndClearDoNotWipePrefsWhenIsInitializing);
 
 #define GetUserActionableError(...)                       \
   GetUserActionableError_ChromiumImpl(__VA_ARGS__) const; \

--- a/chromium_src/components/sync/service/sync_service_impl.h
+++ b/chromium_src/components/sync/service/sync_service_impl.h
@@ -23,8 +23,12 @@
   FRIEND_TEST_ALL_PREFIXES(BraveSyncServiceImplTest, JoinDeletedChain);        \
   FRIEND_TEST_ALL_PREFIXES(BraveSyncServiceImplTest,                           \
                            ForcedSetDecryptionPassphrase);                     \
-  FRIEND_TEST_ALL_PREFIXES(BraveSyncServiceImplTest,                           \
-                           StopAndClearDoNotWipePrefsWhenIsInitializing);
+  FRIEND_TEST_ALL_PREFIXES(                                                    \
+      BraveSyncServiceImplTest,                                                \
+      StopAndClearWithNotSignedInDoNotWipePrefsWhenIsInitializing);            \
+  FRIEND_TEST_ALL_PREFIXES(                                                    \
+      BraveSyncServiceImplTest,                                                \
+      StopAndClearWithoutNotSignedInDoesWipePrefsWhenIsInitializing);
 
 #define GetUserActionableError(...)                       \
   GetUserActionableError_ChromiumImpl(__VA_ARGS__) const; \

--- a/components/sync/service/brave_sync_service_impl.cc
+++ b/components/sync/service/brave_sync_service_impl.cc
@@ -202,14 +202,14 @@ bool BraveSyncServiceImpl::IsSetupInProgress() const {
 }
 
 void BraveSyncServiceImpl::StopAndClear(ResetEngineReason reset_engine_reason) {
-  if (!has_encryptor() || is_initializing_) {
-    // Skip when encryptor is not ready yet (desktop: async keychain fires after
-    // Initialize) or when Initialize() is still running (Android: encryptor
-    // fires synchronously but DeriveSigningKeys() hasn't run yet via PostTask).
-    // SyncServiceImpl::StopAndClear() unconditionally calls
+  if ((!has_encryptor() || is_initializing_) &&
+      reset_engine_reason == ResetEngineReason::kNotSignedIn) {
+    // kNotSignedIn fires during Initialize() because DeriveSigningKeys() hasn't
+    // run yet (desktop: encryptor not ready; Android: encryptor fires
+    // synchronously but DeriveSigningKeys() is still in the PostTask queue).
+    // SyncServiceImpl::StopAndClear() would call
     // ClearInitialSyncFeatureSetupComplete() and Prefs::Clear() would wipe the
-    // seed, destroying the sync chain. Skip entirely — OnEncryptorReady() will
-    // call DeriveSigningKeys() to establish the correct auth state.
+    // seed. Skip — OnEncryptorReady() will establish the correct auth state.
     return;
   }
   // StopAndClear is invoked during |SyncServiceImpl::Initialize| even if sync
@@ -368,6 +368,11 @@ void BraveSyncServiceImpl::OnEngineInitialized(
 SyncServiceCrypto* BraveSyncServiceImpl::GetCryptoForTesting() {
   CHECK_IS_TEST();
   return &crypto_;
+}
+
+void BraveSyncServiceImpl::SetInitializingForTesting() {
+  CHECK_IS_TEST();
+  is_initializing_ = true;
 }
 
 namespace {

--- a/components/sync/service/brave_sync_service_impl.cc
+++ b/components/sync/service/brave_sync_service_impl.cc
@@ -181,12 +181,17 @@ void BraveSyncServiceImpl::Initialize(
 }
 
 DataTypeSet BraveSyncServiceImpl::GetPreferredDataTypes() const {
-  if (!has_encryptor()) {
-    // Encryptor not ready yet. Return all types to prevent
+  if (!has_encryptor() || is_initializing_) {
+    // Encryptor not ready (desktop: async keychain) or Initialize() is still
+    // running (Android: encryptor fires synchronously but DeriveSigningKeys()
+    // hasn't been called yet via PostTask). Return all types to prevent
     // ClearMetadataWhileStoppedExceptFor() from wiping DeviceInfo metadata
-    // before DeriveSigningKeys() establishes the correct auth state.
-    // The engine cannot start without the encryptor so no sync is triggered.
-    return DataTypeSet::All();
+    // before the correct auth state is established.
+    const std::string& raw_seed = sync_client_->GetPrefService()->GetString(
+        brave_sync::Prefs::GetSeedPath());
+    if (!raw_seed.empty()) {
+      return DataTypeSet::All();
+    }
   }
   return SyncServiceImpl::GetPreferredDataTypes();
 }
@@ -197,13 +202,14 @@ bool BraveSyncServiceImpl::IsSetupInProgress() const {
 }
 
 void BraveSyncServiceImpl::StopAndClear(ResetEngineReason reset_engine_reason) {
-  if (!has_encryptor()) {
-    // Encryptor is not ready yet (OSCrypt async callback hasn't fired).
+  if (!has_encryptor() || is_initializing_) {
+    // Skip when encryptor is not ready yet (desktop: async keychain fires after
+    // Initialize) or when Initialize() is still running (Android: encryptor
+    // fires synchronously but DeriveSigningKeys() hasn't run yet via PostTask).
     // SyncServiceImpl::StopAndClear() unconditionally calls
-    // ClearInitialSyncFeatureSetupComplete() regardless of the reset reason,
-    // which would destroy the sync setup state and wipe the sync chain.
-    // Skip entirely — OnPrefsReady() will call DeriveSigningKeys() which
-    // establishes the correct auth state once the encryptor is available.
+    // ClearInitialSyncFeatureSetupComplete() and Prefs::Clear() would wipe the
+    // seed, destroying the sync chain. Skip entirely — OnEncryptorReady() will
+    // call DeriveSigningKeys() to establish the correct auth state.
     return;
   }
   // StopAndClear is invoked during |SyncServiceImpl::Initialize| even if sync

--- a/components/sync/service/brave_sync_service_impl.h
+++ b/components/sync/service/brave_sync_service_impl.h
@@ -90,6 +90,7 @@ class BraveSyncServiceImpl : public SyncServiceImpl {
   void RemoveAllPrefsChangeRegistrarForTesting();
   SyncServiceCrypto* GetCryptoForTesting();
   bool SetSeedForTesting(const std::string& seed);
+  void SetInitializingForTesting();
 
  private:
   friend class BraveSyncServiceImplGACookiesTest;

--- a/components/sync/service/brave_sync_service_impl_unittest.cc
+++ b/components/sync/service/brave_sync_service_impl_unittest.cc
@@ -484,12 +484,42 @@ TEST_F(BraveSyncServiceImplTest,
   CreateSyncService();
   EXPECT_FALSE(engine());
 
+  brave_sync_service_impl()->SetSeedForTesting(kValidSyncCode);
+
   brave_sync_service_impl()->ResetEncryptorForTesting();
 
   ASSERT_THAT(brave_sync_service_impl()->GetSeed().error(),
               Eq(GetSeedStatusEnum::kEncryptorIsNotSet));
   EXPECT_EQ(brave_sync_service_impl()->GetPreferredDataTypes(),
             DataTypeSet::All());
+}
+
+TEST_F(BraveSyncServiceImplTest,
+       GetPreferredDataTypesGivesAllWhenIsInitializing) {
+  CreateSyncService();
+  EXPECT_FALSE(engine());
+
+  brave_sync_service_impl()->SetSeedForTesting(kValidSyncCode);
+
+  brave_sync_service_impl()->SetInitializingForTesting();
+
+  EXPECT_EQ(brave_sync_service_impl()->GetPreferredDataTypes(),
+            DataTypeSet::All());
+}
+
+TEST_F(BraveSyncServiceImplTest, StopAndClearDoNotWipePrefsWhenIsInitializing) {
+  CreateSyncService();
+  EXPECT_FALSE(engine());
+
+  brave_sync_service_impl()->SetSeedForTesting(kValidSyncCode);
+
+  brave_sync_service_impl()->SetInitializingForTesting();
+
+  using ResetEngineReason = syncer::SyncServiceImpl::ResetEngineReason;
+  brave_sync_service_impl()->StopAndClear(ResetEngineReason::kNotSignedIn);
+
+  EXPECT_TRUE(brave_sync_service_impl()->GetSeed().has_value() &&
+              !brave_sync_service_impl()->GetSeed().value().empty());
 }
 
 TEST_F(BraveSyncServiceImplTest, PermanentlyDeleteAccount) {

--- a/components/sync/service/brave_sync_service_impl_unittest.cc
+++ b/components/sync/service/brave_sync_service_impl_unittest.cc
@@ -507,7 +507,8 @@ TEST_F(BraveSyncServiceImplTest,
             DataTypeSet::All());
 }
 
-TEST_F(BraveSyncServiceImplTest, StopAndClearDoNotWipePrefsWhenIsInitializing) {
+TEST_F(BraveSyncServiceImplTest,
+       StopAndClearWithNotSignedInDoNotWipePrefsWhenIsInitializing) {
   CreateSyncService();
   EXPECT_FALSE(engine());
 
@@ -518,8 +519,24 @@ TEST_F(BraveSyncServiceImplTest, StopAndClearDoNotWipePrefsWhenIsInitializing) {
   using ResetEngineReason = syncer::SyncServiceImpl::ResetEngineReason;
   brave_sync_service_impl()->StopAndClear(ResetEngineReason::kNotSignedIn);
 
-  EXPECT_TRUE(brave_sync_service_impl()->GetSeed().has_value() &&
-              !brave_sync_service_impl()->GetSeed().value().empty());
+  auto seed = brave_sync_service_impl()->GetSeed();
+  EXPECT_TRUE(seed.has_value() && !seed.value().empty());
+}
+
+TEST_F(BraveSyncServiceImplTest,
+       StopAndClearWithoutNotSignedInDoesWipePrefsWhenIsInitializing) {
+  CreateSyncService();
+  EXPECT_FALSE(engine());
+
+  brave_sync_service_impl()->SetSeedForTesting(kValidSyncCode);
+
+  brave_sync_service_impl()->SetInitializingForTesting();
+
+  using ResetEngineReason = syncer::SyncServiceImpl::ResetEngineReason;
+  brave_sync_service_impl()->StopAndClear(ResetEngineReason::kDisabledAccount);
+
+  auto seed = brave_sync_service_impl()->GetSeed();
+  EXPECT_TRUE(seed.has_value() && seed.value().empty());
 }
 
 TEST_F(BraveSyncServiceImplTest, PermanentlyDeleteAccount) {


### PR DESCRIPTION
This commit fixes situation when the Sync seed is wiped right after Android app restart

Resolves https://github.com/brave/brave-browser/issues/55359

<!-- Add brave-browser issue below that this PR will resolve -->


<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
