### PR TITLE
[FocusMode] Add FocusModeTitleBar

### DIFF
--- a/browser/ui/views/frame/BUILD.gn
+++ b/browser/ui/views/frame/BUILD.gn
@@ -7,6 +7,7 @@ source_set("frame") {
   sources = [
     "brave_contents_view_util.h",
     "brave_side_panel_shadow_overlay_view.h",
+    "focus_mode_title_bar_view.h",
     "layout/brave_browser_view_layout_delegate_impl.cc",
     "layout/brave_browser_view_layout_delegate_impl.h",
     "layout/brave_browser_view_tabbed_layout_impl.cc",
@@ -16,6 +17,7 @@ source_set("frame") {
 
   public_deps = [
     "//base",
+    "//components/tabs:public",
     "//ui/views",
   ]
 
@@ -32,6 +34,7 @@ source_set("frame_impl") {
   sources = [
     "brave_contents_view_util.cc",
     "brave_side_panel_shadow_overlay_view.cc",
+    "focus_mode_title_bar_view.cc",
     "tab_strip_placement_coordinator.cc",
   ]
 
@@ -46,13 +49,16 @@ source_set("frame_impl") {
     "//chrome/common:constants",
     "//components/prefs",
     "//components/split_tabs",
-    "//components/tabs:public",
   ]
 }
 
 source_set("unit_tests") {
   testonly = true
-  sources = [ "layout/brave_browser_view_tabbed_layout_impl_unittest.cc" ]
+
+  sources = [
+    "focus_mode_title_bar_view_unittest.cc",
+    "layout/brave_browser_view_tabbed_layout_impl_unittest.cc",
+  ]
 
   if (is_linux) {
     sources += [ "browser_frame_view_layout_linux_unittest.cc" ]
@@ -60,11 +66,19 @@ source_set("unit_tests") {
 
   deps = [
     ":frame",
+    ":frame_impl",
     "//base",
     "//base/test:test_support",
     "//chrome/browser/ui",
+    "//chrome/test:test_support",
+    "//components/tabs:test_support",
+    "//content/test:test_support",
     "//testing/gmock",
     "//testing/gtest",
+    "//ui/base",
+    "//ui/gfx",
+    "//ui/views:test_support",
+    "//url",
   ]
 }
 

--- a/browser/ui/views/frame/focus_mode_title_bar_view.cc
+++ b/browser/ui/views/frame/focus_mode_title_bar_view.cc
@@ -1,0 +1,143 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/views/frame/focus_mode_title_bar_view.h"
+
+#include <string>
+
+#include "base/functional/bind.h"
+#include "brave/browser/ui/brave_scheme_utils.h"
+#include "brave/ui/color/nala/nala_color_id.h"
+#include "chrome/browser/ui/color/chrome_color_id.h"
+#include "chrome/browser/ui/tab_ui_helper.h"
+#include "components/url_formatter/url_formatter.h"
+#include "ui/base/metadata/metadata_impl_macros.h"
+#include "ui/base/models/image_model.h"
+#include "ui/color/color_provider.h"
+#include "ui/gfx/font_list.h"
+#include "ui/gfx/geometry/size.h"
+#include "ui/gfx/image/image_skia_operations.h"
+#include "ui/views/background.h"
+#include "ui/views/controls/image_view.h"
+#include "ui/views/controls/label.h"
+#include "ui/views/layout/box_layout.h"
+#include "url/gurl.h"
+
+namespace {
+
+constexpr int kTitleBarHeight = 20;
+constexpr int kFaviconSize = 12;
+constexpr int kFaviconLabelSpacing = 4;
+constexpr int kLabelFontSize = 11;
+
+gfx::FontList GetLabelFont() {
+  const gfx::FontList base;
+  return base.DeriveWithSizeDelta(kLabelFontSize - base.GetFontSize());
+}
+
+}  // namespace
+
+FocusModeTitleBarView::FocusModeTitleBarView() {
+  auto* layout = SetLayoutManager(std::make_unique<views::BoxLayout>(
+      views::BoxLayout::Orientation::kHorizontal, gfx::Insets(),
+      kFaviconLabelSpacing));
+  SetBackground(views::CreateSolidBackground(kColorToolbar));
+
+  layout->set_main_axis_alignment(views::BoxLayout::MainAxisAlignment::kCenter);
+  layout->set_cross_axis_alignment(
+      views::BoxLayout::CrossAxisAlignment::kCenter);
+
+  SetPreferredSize(gfx::Size(0, kTitleBarHeight));
+
+  favicon_image_ = AddChildView(std::make_unique<views::ImageView>());
+  favicon_image_->SetImageSize(gfx::Size(kFaviconSize, kFaviconSize));
+  favicon_image_->SetVisible(false);
+
+  domain_label_ = AddChildView(std::make_unique<views::Label>(
+      u"", views::Label::CustomFont(GetLabelFont())));
+  domain_label_->SetDirectionalityMode(
+      gfx::DirectionalityMode::DIRECTIONALITY_AS_URL);
+  domain_label_->SetElideBehavior(gfx::ELIDE_TAIL);
+  domain_label_->SetEnabledColor(nala::kColorTextTertiary);
+  domain_label_->SetAutoColorReadabilityEnabled(false);
+}
+
+FocusModeTitleBarView::~FocusModeTitleBarView() = default;
+
+void FocusModeTitleBarView::SetTab(tabs::TabInterface* tab) {
+  tab_ui_updated_subscription_ = {};
+  tab_will_detach_subscription_ = {};
+  tab_ = tab;
+
+  if (tab_) {
+    tab_will_detach_subscription_ =
+        tab_->RegisterWillDetach(base::BindRepeating(
+            &FocusModeTitleBarView::OnTabWillDetach, base::Unretained(this)));
+    if (auto* helper = TabUIHelper::From(tab_)) {
+      tab_ui_updated_subscription_ =
+          helper->AddTabUIChangeCallback(base::BindRepeating(
+              &FocusModeTitleBarView::Update, base::Unretained(this)));
+    }
+  }
+
+  Update();
+}
+
+bool FocusModeTitleBarView::IsFaviconVisibleForTesting() const {
+  return favicon_image_->GetVisible();
+}
+
+void FocusModeTitleBarView::Update() {
+  auto* tab_ui_helper = tab_ ? TabUIHelper::From(tab_) : nullptr;
+  if (!tab_ui_helper) {
+    favicon_image_->SetImage(ui::ImageModel());
+    favicon_image_->SetVisible(false);
+    domain_label_->SetText(u"");
+    return;
+  }
+
+  GURL domain_url = tab_ui_helper->GetVisibleURL();
+  std::u16string domain;
+  if (tab_ui_helper->ShouldDisplayURL()) {
+    domain = url_formatter::FormatUrl(
+        domain_url,
+        (url_formatter::kFormatUrlOmitDefaults &
+         ~url_formatter::kFormatUrlOmitHTTP) |
+            url_formatter::kFormatUrlOmitTrivialSubdomains |
+            url_formatter::kFormatUrlOmitHTTPS |
+            url_formatter::kFormatUrlTrimAfterHost,
+        base::UnescapeRule::SPACES, nullptr, nullptr, nullptr);
+    brave_utils::ReplaceChromeToBraveScheme(domain);
+  }
+
+  domain_label_->SetText(domain);
+
+  if (ui::ImageModel favicon = tab_ui_helper->GetFavicon();
+      !favicon.IsEmpty() && !domain.empty()) {
+    bool themify_favicon = tab_ui_helper->ShouldThemifyFavicon();
+    if (auto* provider = GetColorProvider(); provider && themify_favicon) {
+      SkColor favicon_color = provider->GetColor(kColorBookmarkFavicon);
+      if (favicon_color != SK_ColorTRANSPARENT) {
+        favicon = ui::ImageModel::FromImageSkia(
+            gfx::ImageSkiaOperations::CreateColorMask(
+                favicon.Rasterize(provider), favicon_color));
+      }
+    }
+    favicon_image_->SetImage(favicon);
+    favicon_image_->SetVisible(true);
+  } else {
+    favicon_image_->SetImage(ui::ImageModel());
+    favicon_image_->SetVisible(false);
+  }
+}
+
+void FocusModeTitleBarView::OnTabWillDetach(
+    tabs::TabInterface* tab,
+    tabs::TabInterface::DetachReason reason) {
+  SetTab(nullptr);
+}
+
+BEGIN_METADATA(FocusModeTitleBarView)
+END_METADATA

--- a/browser/ui/views/frame/focus_mode_title_bar_view.h
+++ b/browser/ui/views/frame/focus_mode_title_bar_view.h
@@ -1,0 +1,53 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_VIEWS_FRAME_FOCUS_MODE_TITLE_BAR_VIEW_H_
+#define BRAVE_BROWSER_UI_VIEWS_FRAME_FOCUS_MODE_TITLE_BAR_VIEW_H_
+
+#include "base/callback_list.h"
+#include "base/memory/raw_ptr.h"
+#include "components/tabs/public/tab_interface.h"
+#include "ui/base/metadata/metadata_header_macros.h"
+#include "ui/gfx/text_constants.h"
+#include "ui/views/view.h"
+
+namespace views {
+class ImageView;
+class Label;
+}  // namespace views
+
+// Small title bar shown at the top of the browser window when Focus Mode is
+// enabled. Displays the active tab's favicon followed by the formatted host
+// (omits https://, trivial subdomains, and trims after the host).
+class FocusModeTitleBarView : public views::View {
+  METADATA_HEADER(FocusModeTitleBarView, views::View)
+
+ public:
+  FocusModeTitleBarView();
+  FocusModeTitleBarView(const FocusModeTitleBarView&) = delete;
+  FocusModeTitleBarView& operator=(const FocusModeTitleBarView&) = delete;
+  ~FocusModeTitleBarView() override;
+
+  // Points this view at the given tab. `tab` may be null, in which case the
+  // display is cleared. The view automatically clears itself if `tab` is
+  // destroyed.
+  void SetTab(tabs::TabInterface* tab);
+
+  bool IsFaviconVisibleForTesting() const;
+  const views::Label* domain_label_for_testing() const { return domain_label_; }
+
+ private:
+  void Update();
+  void OnTabWillDetach(tabs::TabInterface* tab,
+                       tabs::TabInterface::DetachReason reason);
+
+  base::CallbackListSubscription tab_will_detach_subscription_;
+  base::CallbackListSubscription tab_ui_updated_subscription_;
+  raw_ptr<views::ImageView> favicon_image_ = nullptr;
+  raw_ptr<views::Label> domain_label_ = nullptr;
+  raw_ptr<tabs::TabInterface> tab_ = nullptr;
+};
+
+#endif  // BRAVE_BROWSER_UI_VIEWS_FRAME_FOCUS_MODE_TITLE_BAR_VIEW_H_

--- a/browser/ui/views/frame/focus_mode_title_bar_view_unittest.cc
+++ b/browser/ui/views/frame/focus_mode_title_bar_view_unittest.cc
@@ -1,0 +1,164 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/views/frame/focus_mode_title_bar_view.h"
+
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "base/callback_list.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/ui/tab_ui_helper.h"
+#include "chrome/browser/ui/tabs/public/tab_features.h"
+#include "chrome/browser/ui/views/chrome_layout_provider.h"
+#include "chrome/test/base/testing_profile.h"
+#include "chrome/test/views/chrome_views_test_base.h"
+#include "components/tabs/public/mock_tab_interface.h"
+#include "components/tabs/public/tab_interface.h"
+#include "content/public/browser/web_contents.h"
+#include "content/public/test/test_renderer_host.h"
+#include "content/public/test/web_contents_tester.h"
+#include "testing/gmock/include/gmock/gmock.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "ui/base/unowned_user_data/unowned_user_data_host.h"
+#include "ui/gfx/geometry/size.h"
+#include "ui/gfx/text_constants.h"
+#include "ui/views/controls/label.h"
+#include "ui/views/test/views_test_utils.h"
+#include "url/gurl.h"
+
+namespace {
+
+class FakeTab : public tabs::MockTabInterface {
+ public:
+  explicit FakeTab(Profile* profile)
+      : tab_features_(std::make_unique<tabs::TabFeatures>()),
+        contents_(content::WebContentsTester::CreateTestWebContents(profile,
+                                                                    nullptr)) {
+    using ::testing::Return;
+    using ::testing::ReturnRef;
+
+    ON_CALL(*this, GetContents()).WillByDefault(Return(contents_.get()));
+    ON_CALL(*this, GetTabFeatures()).WillByDefault(Return(tab_features_.get()));
+    ON_CALL(*this, GetUnownedUserDataHost()).WillByDefault(ReturnRef(host_));
+    ON_CALL(*this, RegisterWillDetach(::testing::_))
+        .WillByDefault([this](tabs::TabInterface::WillDetach callback) {
+          return will_detach_callbacks_.Add(std::move(callback));
+        });
+
+    tab_features_->SetTabUIHelperForTesting(
+        std::make_unique<TabUIHelper>(*this));
+  }
+
+  ~FakeTab() override {
+    will_detach_callbacks_.Notify(this,
+                                  tabs::TabInterface::DetachReason::kDelete);
+  }
+
+  void NavigateAndCommit(const GURL& url) {
+    content::WebContentsTester::For(contents_.get())->NavigateAndCommit(url);
+  }
+
+ private:
+  ui::UnownedUserDataHost host_;
+  std::unique_ptr<tabs::TabFeatures> tab_features_;
+  std::unique_ptr<content::WebContents> contents_;
+  base::RepeatingCallbackList<void(tabs::TabInterface*,
+                                   tabs::TabInterface::DetachReason)>
+      will_detach_callbacks_;
+};
+
+class FocusModeTitleBarViewTest : public ChromeViewsTestBase {
+ public:
+  void SetUp() override {
+    ChromeViewsTestBase::SetUp();
+    view_ = std::make_unique<FocusModeTitleBarView>();
+  }
+
+  void TearDown() override {
+    view_.reset();
+    ChromeViewsTestBase::TearDown();
+  }
+
+ protected:
+  std::unique_ptr<FakeTab> AddTab(const GURL& url) {
+    auto tab = std::make_unique<FakeTab>(&profile_);
+    tab->NavigateAndCommit(url);
+    return tab;
+  }
+
+  std::u16string_view GetDomainText() {
+    return view_->domain_label_for_testing()->GetText();
+  }
+
+  std::u16string_view AddTabAndGetDomainText(const GURL& gurl) {
+    auto tab = AddTab(gurl);
+    view_->SetTab(tab.get());
+    return GetDomainText();
+  }
+
+  std::unique_ptr<FocusModeTitleBarView> view_;
+  TestingProfile profile_;
+  content::RenderViewHostTestEnabler render_view_host_test_enabler_;
+};
+
+TEST_F(FocusModeTitleBarViewTest, UpdatesOnNavigation) {
+  auto tab = AddTab(GURL("https://www.example.com/some/path?q=1"));
+  view_->SetTab(tab.get());
+  EXPECT_EQ(GetDomainText(), u"example.com");
+
+  tab->NavigateAndCommit(GURL("https://docs.example.com/title1.html"));
+  EXPECT_EQ(GetDomainText(), u"docs.example.com");
+
+  tab->NavigateAndCommit(GURL("http://insecure.example.com/"));
+  EXPECT_EQ(GetDomainText(), u"http://insecure.example.com");
+
+  tab->NavigateAndCommit(GURL("chrome://abc"));
+  EXPECT_EQ(GetDomainText(), u"brave://abc");
+
+  tab->NavigateAndCommit(GURL("chrome-untrusted://print"));
+  EXPECT_EQ(GetDomainText(), u"chrome-untrusted://print");
+}
+
+TEST_F(FocusModeTitleBarViewTest, ClearsWhenTabDetaches) {
+  auto tab = AddTab(GURL("https://www.example.com/title1.html"));
+  view_->SetTab(tab.get());
+  ASSERT_EQ(GetDomainText(), u"example.com");
+
+  tab.reset();
+  EXPECT_TRUE(GetDomainText().empty());
+  EXPECT_FALSE(view_->IsFaviconVisibleForTesting());
+}
+
+TEST_F(FocusModeTitleBarViewTest, ElidesDomainFromTail) {
+  auto tab = AddTab(GURL("https://very-very-long-name.example.com/"));
+  view_->SetTab(tab.get());
+  ASSERT_EQ(GetDomainText(), u"very-very-long-name.example.com");
+
+  view_->SetSize(gfx::Size(60, 20));
+  views::test::RunScheduledLayout(view_.get());
+
+  std::u16string_view displayed =
+      view_->domain_label_for_testing()->GetDisplayTextForTesting();
+  EXPECT_TRUE(displayed.ends_with(u"\u2026"));
+  EXPECT_TRUE(displayed.starts_with(u"very"));
+}
+
+TEST_F(FocusModeTitleBarViewTest, UpdatesOnTabSwitch) {
+  auto first = AddTab(GURL("https://first.test/title1.html"));
+  view_->SetTab(first.get());
+  EXPECT_EQ(GetDomainText(), u"first.test");
+
+  auto second = AddTab(GURL("https://second.test/title1.html"));
+  view_->SetTab(second.get());
+  EXPECT_EQ(GetDomainText(), u"second.test");
+
+  view_->SetTab(nullptr);
+  EXPECT_TRUE(GetDomainText().empty());
+  EXPECT_FALSE(view_->IsFaviconVisibleForTesting());
+}
+
+}  // namespace


### PR DESCRIPTION
Small title bar shown at the top of the browser window in Focus Mode. Displays the active tab's favicon and a formatted host string sourced from `TabUIHelper`.

<!-- Add brave-browser issue below that this PR will resolve -->
Subtask of https://github.com/brave/brave-browser/issues/54369

Security review: https://github.com/brave/reviews/issues/2215

<img width="940" height="722" alt="Screenshot 2026-05-07 at 6 57 37 PM" src="https://github.com/user-attachments/assets/f8dcfaca-53e2-4b9a-bdc4-1761ab8129dd" />


<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
