### PR TITLE
[Wallet] Disable wallet autolock in tests to reduce flakiness

### DIFF
--- a/browser/brave_wallet/BUILD.gn
+++ b/browser/brave_wallet/BUILD.gn
@@ -184,6 +184,7 @@ source_set("unit_tests") {
   deps = [
     "//base/test:test_support",
     "//brave/browser/brave_wallet",
+    "//brave/browser/brave_wallet:brave_wallet_delegate",
     "//brave/browser/brave_wallet:tab_helper",
     "//brave/common",
     "//brave/components/brave_wallet/browser",

--- a/browser/brave_wallet/brave_wallet_service_delegate_base.cc
+++ b/browser/brave_wallet/brave_wallet_service_delegate_base.cc
@@ -5,11 +5,18 @@
 
 #include "brave/browser/brave_wallet/brave_wallet_service_delegate_base.h"
 
+#include "base/check_is_test.h"
+#include "base/command_line.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_constants.h"
 #include "brave/components/brave_wallet/browser/permission_utils.h"
 #include "brave/components/permissions/contexts/brave_wallet_permission_context.h"
 #include "chrome/browser/profiles/profile.h"
 #include "content/public/browser/browser_context.h"
+#include "content/public/common/content_switches.h"
+
+namespace {
+bool g_enable_autolock_commandline_check = true;
+}
 
 namespace brave_wallet {
 
@@ -72,6 +79,25 @@ base::FilePath BraveWalletServiceDelegateBase::GetWalletBaseDirectory() {
 
 bool BraveWalletServiceDelegateBase::IsPrivateWindow() {
   return is_private_window_;
+}
+
+bool BraveWalletServiceDelegateBase::IsAutolockEnabled() {
+  if (g_enable_autolock_commandline_check) {
+    if (base::CommandLine::ForCurrentProcess()->HasSwitch(
+            switches::kTestType)) {
+      CHECK_IS_TEST();
+      // We don't want autolock happening in most of the tests.
+      return false;
+    }
+  }
+
+  return true;
+}
+
+// static
+void BraveWalletServiceDelegateBase::EnableAutolockCommandlineCheckForTesting(
+    bool enable_commandline_check) {
+  g_enable_autolock_commandline_check = enable_commandline_check;
 }
 
 }  // namespace brave_wallet

--- a/browser/brave_wallet/brave_wallet_service_delegate_base.cc
+++ b/browser/brave_wallet/brave_wallet_service_delegate_base.cc
@@ -5,6 +5,7 @@
 
 #include "brave/browser/brave_wallet/brave_wallet_service_delegate_base.h"
 
+#include "base/auto_reset.h"
 #include "base/check_is_test.h"
 #include "base/command_line.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_constants.h"
@@ -95,9 +96,9 @@ bool BraveWalletServiceDelegateBase::IsAutolockEnabled() {
 }
 
 // static
-void BraveWalletServiceDelegateBase::EnableAutolockCommandlineCheckForTesting(
-    bool enable_commandline_check) {
-  g_enable_autolock_commandline_check = enable_commandline_check;
+base::AutoReset<bool>
+BraveWalletServiceDelegateBase::GetScopedEnableAutolockForTesting() {
+  return {&g_enable_autolock_commandline_check, false};
 }
 
 }  // namespace brave_wallet

--- a/browser/brave_wallet/brave_wallet_service_delegate_base.h
+++ b/browser/brave_wallet/brave_wallet_service_delegate_base.h
@@ -8,6 +8,7 @@
 
 #include <string>
 
+#include "base/auto_reset.h"
 #include "base/files/file_path.h"
 #include "base/memory/raw_ptr.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_service_delegate.h"
@@ -33,8 +34,9 @@ class BraveWalletServiceDelegateBase : public BraveWalletServiceDelegate {
       const BraveWalletServiceDelegateBase&) = delete;
   ~BraveWalletServiceDelegateBase() override;
 
-  static void EnableAutolockCommandlineCheckForTesting(
-      bool enable_commandline_check);
+  // Delegates created in scope of returned object will have wallet autolock
+  // enabled. Autolock is disabled in tests by default.
+  static base::AutoReset<bool> GetScopedEnableAutolockForTesting();
 
   bool HasPermission(mojom::CoinType coin,
                      const url::Origin& origin,

--- a/browser/brave_wallet/brave_wallet_service_delegate_base.h
+++ b/browser/brave_wallet/brave_wallet_service_delegate_base.h
@@ -33,6 +33,9 @@ class BraveWalletServiceDelegateBase : public BraveWalletServiceDelegate {
       const BraveWalletServiceDelegateBase&) = delete;
   ~BraveWalletServiceDelegateBase() override;
 
+  static void EnableAutolockCommandlineCheckForTesting(
+      bool enable_commandline_check);
+
   bool HasPermission(mojom::CoinType coin,
                      const url::Origin& origin,
                      const std::string& account) override;
@@ -44,7 +47,10 @@ class BraveWalletServiceDelegateBase : public BraveWalletServiceDelegate {
   void ResetAllPermissions() override;
 
   base::FilePath GetWalletBaseDirectory() override;
+
   bool IsPrivateWindow() override;
+
+  bool IsAutolockEnabled() override;
 
  protected:
   base::FilePath wallet_base_directory_;

--- a/browser/brave_wallet/brave_wallet_service_unittest.cc
+++ b/browser/brave_wallet/brave_wallet_service_unittest.cc
@@ -24,6 +24,7 @@
 #include "base/test/values_test_util.h"
 #include "base/time/time.h"
 #include "base/values.h"
+#include "brave/browser/brave_wallet/brave_wallet_service_delegate_base.h"
 #include "brave/browser/brave_wallet/brave_wallet_service_factory.h"
 #include "brave/components/brave_wallet/browser/bitcoin/bitcoin_test_utils.h"
 #include "brave/components/brave_wallet/browser/bitcoin/bitcoin_wallet_service.h"
@@ -38,7 +39,6 @@
 #include "brave/components/brave_wallet/browser/pref_names.h"
 #include "brave/components/brave_wallet/browser/test_utils.h"
 #include "brave/components/brave_wallet/browser/tx_service.h"
-#include "brave/components/brave_wallet/common/brave_wallet.mojom-forward.h"
 #include "brave/components/brave_wallet/common/brave_wallet.mojom.h"
 #include "brave/components/brave_wallet/common/features.h"
 #include "brave/components/brave_wallet/common/test_utils.h"
@@ -492,10 +492,12 @@ class BraveWalletServiceUnitTest : public testing::Test {
     return BlockchainRegistry::GetInstance();
   }
 
-  void SetupWallet() {
-    keyring_service_->CreateWalletInternal(kMnemonicDivideCruise,
-                                           kTestWalletPassword, false, false);
+  void SetupWallet(KeyringService* keyring_service) {
+    keyring_service->CreateWalletInternal(kMnemonicDivideCruise,
+                                          kTestWalletPassword, false, false);
   }
+
+  void SetupWallet() { SetupWallet(keyring_service_); }
 
   void SetInterceptors(std::map<GURL, std::string> responses) {
     url_loader_factory_.SetInterceptor(base::BindLambdaForTesting(
@@ -3502,6 +3504,30 @@ TEST_F(BraveWalletServiceUnitTest, DisplayTxNotification) {
     GetTxServiceObserverReceiver().FlushForTesting();
     testing::Mock::VerifyAndClearExpectations(delegate_ptr);
   }
+}
+
+TEST_F(BraveWalletServiceUnitTest, AutolockIsDisabledInTests) {
+  // Wallet autolock is turned off in tests by default.
+  EXPECT_FALSE(service_->keyring_service()->IsLockedSync());
+  task_environment_.FastForwardBy(base::Minutes(20));
+  EXPECT_FALSE(service_->keyring_service()->IsLockedSync());
+
+  BraveWalletServiceDelegateBase::EnableAutolockCommandlineCheckForTesting(
+      false);
+
+  auto another_wallet_service = std::make_unique<BraveWalletService>(
+      url_loader_factory_.GetSafeWeakWrapper(),
+      BraveWalletServiceDelegate::Create(profile_.get()), profile_->GetPrefs(),
+      &local_state_);
+  SetupWallet(another_wallet_service->keyring_service());
+
+  // Wallet is locked after some period which matches production behavior.
+  EXPECT_FALSE(another_wallet_service->keyring_service()->IsLockedSync());
+  task_environment_.FastForwardBy(base::Minutes(20));
+  EXPECT_TRUE(another_wallet_service->keyring_service()->IsLockedSync());
+
+  BraveWalletServiceDelegateBase::EnableAutolockCommandlineCheckForTesting(
+      true);
 }
 
 }  // namespace brave_wallet

--- a/browser/brave_wallet/brave_wallet_service_unittest.cc
+++ b/browser/brave_wallet/brave_wallet_service_unittest.cc
@@ -3512,8 +3512,8 @@ TEST_F(BraveWalletServiceUnitTest, AutolockIsDisabledInTests) {
   task_environment_.FastForwardBy(base::Minutes(20));
   EXPECT_FALSE(service_->keyring_service()->IsLockedSync());
 
-  BraveWalletServiceDelegateBase::EnableAutolockCommandlineCheckForTesting(
-      false);
+  auto scoped_enable_autolock =
+      BraveWalletServiceDelegateBase::GetScopedEnableAutolockForTesting();
 
   auto another_wallet_service = std::make_unique<BraveWalletService>(
       url_loader_factory_.GetSafeWeakWrapper(),
@@ -3525,9 +3525,6 @@ TEST_F(BraveWalletServiceUnitTest, AutolockIsDisabledInTests) {
   EXPECT_FALSE(another_wallet_service->keyring_service()->IsLockedSync());
   task_environment_.FastForwardBy(base::Minutes(20));
   EXPECT_TRUE(another_wallet_service->keyring_service()->IsLockedSync());
-
-  BraveWalletServiceDelegateBase::EnableAutolockCommandlineCheckForTesting(
-      true);
 }
 
 }  // namespace brave_wallet

--- a/browser/brave_wallet/brave_wallet_service_unittest.cc
+++ b/browser/brave_wallet/brave_wallet_service_unittest.cc
@@ -316,7 +316,8 @@ class MockBraveWalletServiceDelegate : public BraveWalletServiceDelegate {
                const GURL& tx_url),
               (override));
   MOCK_METHOD(base::FilePath, GetWalletBaseDirectory, (), (override));
-  MOCK_METHOD(bool, IsPrivateWindow, (), (override));
+  bool IsPrivateWindow() override { return false; }
+  bool IsAutolockEnabled() override { return false; }
 };
 
 class BraveWalletServiceUnitTest : public testing::Test {

--- a/components/brave_wallet/browser/brave_wallet_service.cc
+++ b/components/brave_wallet/browser/brave_wallet_service.cc
@@ -284,6 +284,7 @@ BraveWalletService::BraveWalletService(
 
   delegate_->AddObserver(this);
 
+  keyring_service_->SetAutolockEnabled(delegate_->IsAutolockEnabled());
   keyring_service_->set_wallet_reset_cb(base::BindRepeating(
       &BraveWalletService::OnWalletReset, weak_ptr_factory_.GetWeakPtr()));
   keyring_service_->AddObserver(

--- a/components/brave_wallet/browser/brave_wallet_service_delegate.h
+++ b/components/brave_wallet/browser/brave_wallet_service_delegate.h
@@ -87,6 +87,10 @@ class BraveWalletServiceDelegate {
                                      const std::string& tx_id,
                                      const GURL& tx_url);
 
+  // Must return true in production. Might return false in tests to disable
+  // autolock functionality.
+  virtual bool IsAutolockEnabled() = 0;
+
   static std::unique_ptr<BraveWalletServiceDelegate> Create(
       content::BrowserContext* browser_context);
 };

--- a/components/brave_wallet/browser/keyring_service.cc
+++ b/components/brave_wallet/browser/keyring_service.cc
@@ -87,6 +87,9 @@ constexpr char kSelectedAccountDeprecated[] = "selected_account";
 constexpr char kPasswordEncryptorNonceDeprecated[] = "password_encryptor_nonce";
 constexpr char kPasswordEncryptorSaltDeprecated[] = "password_encryptor_salt";
 
+// 7 days. Matches settings UI limit.
+constexpr int kMaxAutolockMinutes = 10080;
+
 base::RepeatingCallback<std::array<uint8_t, kEncryptorNonceSize>()>*
     g_create_nonce_callback_for_testing = nullptr;
 
@@ -2648,11 +2651,18 @@ void KeyringService::StopAutoLockTimer() {
 }
 
 void KeyringService::ResetAutoLockTimer() {
+  // Autolock is disabled in most of the tests.
+  if (!is_autolock_enabled_.value_or(false)) {
+    CHECK_IS_TEST();
+    return;
+  }
+
   if (auto_lock_timer_->IsRunning()) {
     auto_lock_timer_->Reset();
   } else {
-    size_t auto_lock_minutes =
-        (size_t)profile_prefs_->GetInteger(kBraveWalletAutoLockMinutes);
+    int auto_lock_minutes =
+        std::clamp(profile_prefs_->GetInteger(kBraveWalletAutoLockMinutes), 1,
+                   kMaxAutolockMinutes);
     auto_lock_timer_->Start(FROM_HERE, base::Minutes(auto_lock_minutes), this,
                             &KeyringService::OnAutoLockFired);
   }
@@ -3669,6 +3679,11 @@ void KeyringService::MaybeFixAccountSelection() {
     // selection.
     SetSelectedDappAccountInternal(mojom::CoinType::SOL, {});
   }
+}
+
+void KeyringService::SetAutolockEnabled(bool enabled) {
+  CHECK(!is_autolock_enabled_.has_value());
+  is_autolock_enabled_ = enabled;
 }
 
 void KeyringService::MaybeUnlockWithCommandLine() {

--- a/components/brave_wallet/browser/keyring_service.h
+++ b/components/brave_wallet/browser/keyring_service.h
@@ -310,6 +310,12 @@ class KeyringService : public mojom::KeyringService {
   SignMessageByPolkadotKeyring(const mojom::AccountIdPtr& account_id,
                                base::span<const uint8_t> message);
 
+  // Sets if autolock timer is enabled.
+  // Typically is set to false or left unset in tests to prevent auto-locking
+  // during tests.
+  // Must not be called more than once.
+  void SetAutolockEnabled(bool enabled);
+
   void set_wallet_reset_cb(base::RepeatingClosure cb) {
     wallet_reset_cb_ = std::move(cb);
   }
@@ -504,6 +510,8 @@ class KeyringService : public mojom::KeyringService {
   raw_ptr<PrefService> profile_prefs_ = nullptr;
   raw_ptr<PrefService> local_state_ = nullptr;
   bool request_unlock_pending_ = false;
+
+  std::optional<bool> is_autolock_enabled_;
 
   base::RepeatingClosure wallet_reset_cb_;
   mojo::RemoteSet<mojom::KeyringServiceObserver> observers_;

--- a/components/brave_wallet/browser/keyring_service_unittest.cc
+++ b/components/brave_wallet/browser/keyring_service_unittest.cc
@@ -2049,6 +2049,7 @@ TEST_F(KeyringServiceUnitTest, HardwareAccounts) {
 
 TEST_F(KeyringServiceUnitTest, AutoLock) {
   KeyringService service(json_rpc_service(), GetPrefs(), GetLocalState());
+  service.SetAutolockEnabled(true);
   std::optional<std::string> mnemonic = CreateWallet(&service, "brave");
   ASSERT_TRUE(mnemonic.has_value());
   ASSERT_FALSE(service.IsLockedSync());
@@ -2112,6 +2113,7 @@ TEST_F(KeyringServiceUnitTest, AutoLock) {
 
 TEST_F(KeyringServiceUnitTest, NotifyUserInteraction) {
   KeyringService service(json_rpc_service(), GetPrefs(), GetLocalState());
+  service.SetAutolockEnabled(true);
   ASSERT_TRUE(CreateWallet(&service, "brave"));
   ASSERT_FALSE(service.IsLockedSync());
 

--- a/components/brave_wallet/browser/test_utils.cc
+++ b/components/brave_wallet/browser/test_utils.cc
@@ -454,6 +454,10 @@ bool TestBraveWalletServiceDelegate::IsPrivateWindow() {
   return false;
 }
 
+bool TestBraveWalletServiceDelegate::IsAutolockEnabled() {
+  return false;  // Don't need autolock to trigger in tests.
+}
+
 // static
 std::unique_ptr<BraveWalletServiceDelegate>
 TestBraveWalletServiceDelegate::Create() {

--- a/components/brave_wallet/browser/test_utils.h
+++ b/components/brave_wallet/browser/test_utils.h
@@ -153,6 +153,7 @@ class TestBraveWalletServiceDelegate : public BraveWalletServiceDelegate {
 
   base::FilePath GetWalletBaseDirectory() override;
   bool IsPrivateWindow() override;
+  bool IsAutolockEnabled() override;
 
   static std::unique_ptr<BraveWalletServiceDelegate> Create();
 

--- a/ios/browser/brave_wallet/brave_wallet_service_factory.mm
+++ b/ios/browser/brave_wallet/brave_wallet_service_factory.mm
@@ -28,6 +28,7 @@ class BraveWalletServiceDelegateIos : public BraveWalletServiceDelegate {
     return wallet_base_directory_;
   }
   bool IsPrivateWindow() override { return is_private_window_; }
+  bool IsAutolockEnabled() override { return true; }
 
  protected:
   base::FilePath wallet_base_directory_;


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/55372

- Autolock is disabled in almost all tests.
- In some tests it is enabled explicitly.
- ~Fixed some polkadot code to correctly handle failed KeyringService calls.~


Flak example 
```
[ RUN      ] PolkadotTransactionStatusTaskUnitTest.FindExtrinsicSucceeds
  [17105:17105:FATAL:brave/components/brave_wallet/browser/polkadot/polkadot_transaction_status_task.cc:235] Check failed: pubkey.
  #0 0x5c660b297f02 base::debug::CollectStackTrace() [../../base/debug/stack_trace_posix.cc:1050:7]
  #1 0x5c660b2800b1 base::debug::StackTrace::StackTrace() [../../base/debug/stack_trace.cc:280:20]
  #2 0x5c660b186e87 logging::LogMessage::Flush() [../../base/logging.cc:708:29]
  #3 0x5c660b186d3c logging::LogMessage::~LogMessage() [../../base/logging.cc:697:3]
  #4 0x5c660b16e542 logging::(anonymous namespace)::CheckLogMessage::~CheckLogMessage() [../../base/check.cc:198:3]
  #5 0x5c660b16e22b logging::CheckNoreturnError::~CheckNoreturnError() [../../base/check.cc:363:16]
  #6 0x5c661263d6df brave_wallet::PolkadotTransactionStatusTask::OnGetEvents() [../../brave/components/brave_wallet/browser/polkadot/polkadot_transaction_status_task.cc:235:3]
  #7 0x5c661263dedf base::internal::DecayedFunctorTraits<>::Invoke<>() [../../base/functional/bind_internal.h:740:12]
  #8 0x5c6604727ec9 base::OnceCallback<>::Run() [../../base/functional/callback.h:155:12]
  #9 0x5c661263a572 brave_wallet::PolkadotSubstrateRpc::OnGetEvents() [../../brave/components/brave_wallet/browser/polkadot/polkadot_substrate_rpc.cc:850:23]
  #10 0x5c66124f99fe base::internal::DecayedFunctorTraits<>::Invoke<>() [../../base/functional/bind_internal.h:740:12]
  #11 0x5c6604727ec9 base::OnceCallback<>::Run() [../../base/functional/callback.h:155:12]
  #12 0x5c660b69aabf api_request_helper::APIRequestHelper::DeleteAndSendResult() [../../brave/components/api_request_helper/api_request_helper.cc:245:23]
  #13 0x5c660b69d102 base::internal::DecayedFunctorTraits<>::Invoke<>() [../../base/functional/bind_internal.h:740:12]
  #14 0x5c6604727ec9 base::OnceCallback<>::Run() [../../base/functional/callback.h:155:12]
  #15 0x5c660b69c8dc api_request_helper::APIRequestHelper::URLLoaderHandler::OnParseJsonResponse() [../../brave/components/api_request_helper/api_request_helper.cc:127:19]
  #16 0x5c660b69ddbe base::internal::DecayedFunctorTraits<>::Invoke<>() [../../base/functional/bind_internal.h:740:12]
  #17 0x5c6604727ec9 base::OnceCallback<>::Run() [../../base/functional/callback.h:155:12]
  #18 0x5c660b69db2c base::internal::Invoker<>::RunOnce() [../../brave/components/api_request_helper/api_request_helper.cc:59:35]
  #19 0x5c6604727ec9 base::OnceCallback<>::Run() [../../base/functional/callback.h:155:12]
  #20 0x5c660b69d78b base::internal::ReplyAdapter<>()::{lambda()#1}::operator()<>() [../../base/task/post_task_and_reply_with_result_internal.h:47:29]
  #21 0x5c660b69d606 base::internal::ReplyAdapter<>() [gen/third_party/libc++/src/include/__type_traits/invoke.h:90:27]
  #22 0x5c6604eb8176 base::internal::Invoker<>::RunOnce() [../../base/functional/bind_internal.h:673:12]
  #23 0x5c6604727f71 base::OnceCallback<>::Run() [../../base/functional/callback.h:155:12]
  #24 0x5c660b22fd86 base::internal::PostTaskAndReplyRelay::RunReply() [../../base/threading/post_task_and_reply_impl.h:63:29]
  #25 0x5c660b22fbf5 base::internal::Invoker<>::RunOnce() [../../base/functional/bind_internal.h:673:12]
  #26 0x5c6604727f71 base::OnceCallback<>::Run() [../../base/functional/callback.h:155:12]
  #27 0x5c660b1ed591 base::TaskAnnotator::RunTaskImpl() [../../base/task/common/task_annotator.cc:229:34]
  #28 0x5c660b22211e base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWorkImpl() [../../base/task/common/task_annotator.h:112:5]
  #29 0x5c660b22154b base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork() [../../base/task/sequence_manager/thread_controller_with_message_pump_impl.cc:340:40]
  #30 0x5c660b19b84a base::MessagePumpDefault::Run() [../../base/message_loop/message_pump_default.cc:42:55]
  #31 0x5c660b22325a base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run() [../../base/task/sequence_manager/thread_controller_with_message_pump_impl.cc:644:12]
  #32 0x5c660b1ca7b6 base::RunLoop::Run() [../../base/run_loop.cc:135:14]
  #33 0x5c6604723baf base::test::TestFuture<>::Wait() [../../base/test/test_future.h:249:10]
  #34 0x5c6604c4c986 _ZN4base4test10TestFutureIJNS_8expectedINSt4__Cr4pairIN12brave_wallet25PolkadotTransactionStatusENS3_8optionalIDU128_EEEENS3_12basic_stringIcNS3_11char_traitsIcEENS3_9allocatorIcEEEEEEEE9TakeTupleEv [../../base/test/test_future.h:563:20]
  #35 0x5c6604c40854 brave_wallet::PolkadotTransactionStatusTaskUnitTest_FindExtrinsicSucceeds_Test::TestBody() [../../base/test/test_future.h:474:24]
  #36 0x5c660626935b testing::Test::Run() [../../third_party/googletest/src/googletest/src/gtest.cc:5267:3]
  #37 0x5c660626a21f testing::TestInfo::Run() [../../third_party/googletest/src/googletest/src/gtest.cc:2892:11]
  #38 0x5c660626afc7 testing::TestSuite::Run() [../../third_party/googletest/src/googletest/src/gtest.cc:3070:30]
  #39 0x5c660627a127 testing::internal::UnitTestImpl::RunAllTests() [../../third_party/googletest/src/googletest/src/gtest.cc:6062:44]
  #40 0x5c66062798ff testing::UnitTest::Run() [../../third_party/googletest/src/googletest/src/gtest.cc:5267:3]
  #41 0x5c660ca6e478 base::TestSuite::Run() [../../base/test/test_suite.cc:440:16]
  #42 0x5c660e17ce8b content::UnitTestTestSuite::Run() [../../content/public/test/unittest_test_suite.cc:193:23]
  #43 0x5c660594ea91 base::OnceCallback<>::Run() [../../base/functional/callback.h:155:12]
  #44 0x5c660ca730ee base::(anonymous namespace)::LaunchUnitTestsInternal() [../../base/test/launcher/unit_test_launcher.cc:189:38]
  #45 0x5c660ca72e79 base::LaunchUnitTests() [../../base/test/launcher/unit_test_launcher.cc:337:10]
  #46 0x74b645429d90 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x29d8f)
  #47 0x74b645429e40 __libc_start_main
  #48 0x5c66046f102a _start
``` 



<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
