### PR TITLE
[plaster][brockit] `PlasterFile` does not handle errors

### DIFF
--- a/tools/cr/alias/follow_renames.py
+++ b/tools/cr/alias/follow_renames.py
@@ -239,7 +239,9 @@ def _repair_plaster_files(old_chromium: Path,
                              patch_name_for(new_chromium))
                 if new_patch.exists():
                     repository.brave.run_git('add', str(new_patch))
-        except (Exception, SystemExit) as e:
+        # TODO(https://github.com/brave/brave-browser/issues/55370): Eventually
+        # we should better constrain this to only catch plaster exceptions.
+        except Exception as e:
             logging.warning('plaster failed to apply %s: %s', new_toml, e)
 
 

--- a/tools/cr/alias/mv.py
+++ b/tools/cr/alias/mv.py
@@ -226,5 +226,7 @@ def _step5_plaster(file_pairs: list[_FilePair], no_git: bool,
                         new_chromium_path)
                     if new_patch.exists():
                         repository.brave.run_git('add', str(new_patch))
-            except (Exception, SystemExit) as e:
+            # TODO(https://github.com/brave/brave-browser/issues/55370): Eventually
+            # we should better constrain this to only catch plaster exceptions.
+            except Exception as e:
                 logging.warning('plaster failed to apply %s: %s', new_file, e)

--- a/tools/cr/patchfile.py
+++ b/tools/cr/patchfile.py
@@ -206,6 +206,8 @@ class Patchfile:
                                     self.source.as_posix())
             PlasterFile(repository.BRAVE_CORE_PATH / self.plaster).apply()
             return self.ApplyStatus.PLASTER_FIXED
+        # TODO(https://github.com/brave/brave-browser/issues/55370): Eventually
+        # we should better constrain this to only catch plaster exceptions.
         except Exception:
             return self.ApplyStatus.PLASTER_BROKEN
 

--- a/tools/cr/plaster.py
+++ b/tools/cr/plaster.py
@@ -322,11 +322,7 @@ class PlasterFile:
             errors.append(f'Invalid regex: {e} in {self.path}')
 
         if errors:
-            print('\n\nThere were errors attempting to apply the patches:',
-                  file=sys.stderr)
-            for error in errors:
-                print(f'{error}', file=sys.stderr)
-            sys.exit(1)
+            raise PlasterApplyError(errors)
 
         has_changed = info.save_source_if_changed(contents, dry_run=dry_run)
         has_changed = info.save_patch_if_changed(
@@ -339,8 +335,22 @@ class PlasterFile:
             info.save_patchinfo_if_changed()
 
 
-class PlasterFileNeedsRegen(Exception):
+class PlasterError(Exception):
+    """Base class for errors reported by the plaster tool."""
+
+
+class PlasterFileNeedsRegen(PlasterError):
     pass
+
+
+class PlasterApplyError(PlasterError):
+    """Raised when applying a plaster file produces substitution errors."""
+
+    def __init__(self, errors: list[str]):
+        self.errors = errors
+        super().__init__(
+            'There were errors attempting to apply the patches:\n' +
+            '\n'.join(errors))
 
 
 def get_plaster_files(
@@ -394,17 +404,10 @@ def check(args):
     """Checks whether plaster files need to be reapplied.
     """
     plaster_files = get_plaster_files(getattr(args, 'filepaths', None))
-
-    has_failure = False
     for plaster_file in plaster_files:
-        try:
-            logging.debug('Checking plaster file: %s', plaster_file.path)
-            plaster_file.apply(dry_run=True)
-        except PlasterFileNeedsRegen as e:
-            print(e, file=sys.stderr)
-            has_failure = True
-
-    return 1 if has_failure else 0
+        logging.debug('Checking plaster file: %s', plaster_file.path)
+        plaster_file.apply(dry_run=True)
+    return 0
 
 
 def main():
@@ -445,7 +448,11 @@ def main():
         format='%(message)s',
         handlers=[IncendiaryErrorHandler(markup=True, rich_tracebacks=True)])
 
-    return args.func(args)
+    try:
+        return args.func(args)
+    except PlasterError as e:
+        print(e, file=sys.stderr)
+        return 1
 
 
 if __name__ == '__main__':

--- a/tools/cr/plaster_test.py
+++ b/tools/cr/plaster_test.py
@@ -7,11 +7,8 @@
 import unittest
 from pathlib import Path
 import hashlib
-import io
 import json
 import time
-from unittest.mock import patch
-import sys
 
 import plaster
 
@@ -183,7 +180,7 @@ class PlasterTest(unittest.TestCase):
             # Apply the rewrite so files are up-to-date
             plaster_file = plaster.PlasterFile(rewrite_path)
             plaster_file.apply()
-        # Now check should succeed (no sys.exit(1))
+        # Now check should succeed without raising.
         class DummyArgs:
 
             def __init__(self):
@@ -239,13 +236,10 @@ class PlasterTest(unittest.TestCase):
           re_pattern = 'foo2'
           replace = 'DIFFERENT'
         ''')
-        # Now check should fail and print the file on stderr
-        stderr = io.StringIO()
-        with patch('sys.stderr', stderr):
-            result = plaster.check(args)
-            self.assertEqual(result, 1)
-            output = stderr.getvalue()
-            self.assertIn(str(changed_path), output)
+        # Now check should raise PlasterFileNeedsRegen with the path included.
+        with self.assertRaises(plaster.PlasterFileNeedsRegen) as context:
+            plaster.check(args)
+        self.assertIn(str(changed_path), str(context.exception))
 
     def test_regex_flags_array_works(self):
         """Test that multiple flags in array are passed through correctly."""
@@ -354,7 +348,7 @@ class PlasterTest(unittest.TestCase):
         self.assertEqual(result, 'Content with CHROMIUM and Brave words.')
 
     def test_invalid_regex_fails(self):
-        """Test that invalid regex patterns output errors with sys.exit(1)."""
+        """Test that invalid regex patterns raise PlasterApplyError."""
         test_file_chromium = Path(
             'chrome/common/extensions/api/test_invalid_regex.idl')
 
@@ -388,14 +382,11 @@ class PlasterTest(unittest.TestCase):
                 ''')
 
                 plaster_file = plaster.PlasterFile(plaster_path)
-                stderr = io.StringIO()
-                with patch('sys.stderr',
-                           stderr), patch('sys.exit') as mock_exit:
+                with self.assertRaises(plaster.PlasterApplyError) as context:
                     plaster_file.apply()
-                    mock_exit.assert_called_once_with(1)
-                    output = stderr.getvalue()
-                    self.assertIn('Invalid regex:', output)
-                    self.assertIn(str(plaster_path), output)
+                message = str(context.exception)
+                self.assertIn('Invalid regex:', message)
+                self.assertIn(str(plaster_path), message)
 
     def test_pattern_validation_failures(self):
         """Test various pattern validation failures."""
@@ -571,7 +562,7 @@ class PlasterTest(unittest.TestCase):
         self.assertEqual(result2, 'Text with {braces} and (parentheses).')
 
     def test_count_mismatch_fails(self):
-        """Test that count mismatch causes sys.exit(1) with error output."""
+        """Test that count mismatch raises PlasterApplyError."""
         # Test case: more matches than expected
         test_file_chromium = Path(
             'chrome/common/extensions/api/test_file1.idl')
@@ -597,13 +588,11 @@ class PlasterTest(unittest.TestCase):
 
         # Should fail because there are 3 matches but count expects 2
         plaster_file = plaster.PlasterFile(plaster_path)
-        stderr = io.StringIO()
-        with patch('sys.stderr', stderr), patch('sys.exit') as mock_exit:
+        with self.assertRaises(plaster.PlasterApplyError) as context:
             plaster_file.apply()
-            mock_exit.assert_called_once_with(1)
-            output = stderr.getvalue()
-            self.assertIn('Unexpected number of matches (3 vs 2)', output)
-            self.assertIn(str(plaster_path), output)
+        message = str(context.exception)
+        self.assertIn('Unexpected number of matches (3 vs 2)', message)
+        self.assertIn(str(plaster_path), message)
 
     def test_default_count(self):
         """Test default count=1 behavior."""
@@ -657,13 +646,11 @@ class PlasterTest(unittest.TestCase):
 
         # Should fail because there are 2 matches but default expects 1
         plaster_file_incorrect = plaster.PlasterFile(plaster_path_incorrect)
-        stderr = io.StringIO()
-        with patch('sys.stderr', stderr), patch('sys.exit') as mock_exit:
+        with self.assertRaises(plaster.PlasterApplyError) as context:
             plaster_file_incorrect.apply()
-            mock_exit.assert_called_once_with(1)
-            output = stderr.getvalue()
-            self.assertIn('Unexpected number of matches (2 vs 1)', output)
-            self.assertIn(str(plaster_path_incorrect), output)
+        message = str(context.exception)
+        self.assertIn('Unexpected number of matches (2 vs 1)', message)
+        self.assertIn(str(plaster_path_incorrect), message)
 
     def test_count_zero_replaces_all(self):
         """


### PR DESCRIPTION
This change removes uses of `sys.exit(1)` and error message prints from
`PlasterFile`, as this interferes with other tools using this class,
like `cr-mv`, `cr-follow-renames`, and `brockit`.
