### PR TITLE
[Origin] Don't start ads service when Rewards is disabled by Origin policy

### DIFF
--- a/components/brave_ads/browser/BUILD.gn
+++ b/components/brave_ads/browser/BUILD.gn
@@ -31,6 +31,7 @@ static_library("browser") {
     "//base",
     "//brave/components/brave_adaptive_captcha",
     "//brave/components/brave_component_updater/browser",
+    "//brave/components/brave_origin",
     "//brave/components/brave_rewards/core/buildflags",
     "//brave/components/brave_rewards/core/mojom",
     "//brave/components/l10n/common",

--- a/components/brave_ads/browser/DEPS
+++ b/components/brave_ads/browser/DEPS
@@ -4,6 +4,7 @@ include_rules = [
   "+components/content_settings",
   "+components/metrics",
   "+components/history",
+  "+components/policy",
   "+components/prefs",
   "+components/variations",
   "+content/public/browser",

--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -44,6 +44,8 @@
 #include "brave/components/brave_ads/core/public/history/site_history.h"
 #include "brave/components/brave_ads/core/public/prefs/pref_names.h"
 #include "brave/components/brave_ads/core/public/user_attention/user_idle_detection/user_idle_detection_feature.h"
+#include "brave/components/brave_origin/brave_origin_policy_manager.h"
+#include "brave/components/brave_origin/profile_id.h"
 #include "brave/components/brave_rewards/core/buildflags/buildflags.h"
 #include "brave/components/brave_rewards/core/mojom/rewards.mojom.h"
 #include "brave/components/brave_rewards/core/pref_names.h"
@@ -55,6 +57,7 @@
 #include "components/content_settings/core/common/content_settings.h"
 #include "components/content_settings/core/common/content_settings_pattern.h"
 #include "components/metrics/metrics_pref_names.h"
+#include "components/policy/policy_constants.h"
 #include "components/prefs/pref_service.h"
 #include "components/variations/pref_names.h"
 #include "content/public/browser/browser_context.h"
@@ -153,6 +156,7 @@ AdsServiceImpl::AdsServiceImpl(
           {base::MayBlock(), base::TaskPriority::USER_VISIBLE,
            base::TaskShutdownBehavior::BLOCK_SHUTDOWN})),
       ads_service_path_(profile_path.AppendASCII("ads_service")),
+      profile_id_(brave_origin::GetProfileId(profile_path)),
 #if BUILDFLAG(ENABLE_BRAVE_REWARDS)
       rewards_service_(rewards_service),
 #endif
@@ -247,6 +251,22 @@ bool AdsServiceImpl::UserHasOptedInToSearchResultAds() const {
 }
 
 bool AdsServiceImpl::CanStartBatAdsService() const {
+  // TEMPORARY WORKAROUND: read the BraveOrigin Rewards-disabled policy directly
+  // from local state via `BraveOriginPolicyManager::GetEnforcedPolicyValue`,
+  // because the chromium policy → managed-pref propagation races against eager
+  // AdsService construction at profile init, so `brave_rewards::IsSupported()`
+  // below may not yet reflect the policy. The proper fix is to defer the
+  // bat_ads launch until `policy::PolicyService::IsInitializationComplete`
+  // fires; see the helper's header comment for details. Remove this block
+  // when that restructuring lands.
+  const std::optional<bool> rewards_disabled_by_origin =
+      brave_origin::BraveOriginPolicyManager::GetInstance()
+          ->GetEnforcedPolicyValue(policy::key::kBraveRewardsDisabled,
+                                   profile_id_);
+  if (rewards_disabled_by_origin.value_or(false)) {
+    return false;
+  }
+
   if (!brave_rewards::IsSupported(&*prefs_)) {
     // Never start if Rewards is disabled by policy, feature flag, or
     // unsupported region, regardless of which ad unit the user has opted into.

--- a/components/brave_ads/browser/ads_service_impl.h
+++ b/components/brave_ads/browser/ads_service_impl.h
@@ -447,6 +447,10 @@ class AdsServiceImpl : public AdsService,
 
   const base::FilePath ads_service_path_;
 
+  // Stable identifier for this profile, used to look up the BraveOrigin
+  // policy values stored in local state.
+  const std::string profile_id_;
+
 #if BUILDFLAG(ENABLE_BRAVE_REWARDS)
   const raw_ptr<brave_rewards::RewardsService> rewards_service_;  // Not owned.
   base::ScopedObservation<brave_rewards::RewardsService,

--- a/components/brave_origin/brave_origin_policy_manager.cc
+++ b/components/brave_origin/brave_origin_policy_manager.cc
@@ -71,6 +71,18 @@ std::optional<bool> BraveOriginPolicyManager::GetPolicyValue(
                                 policies_dict, profile_id);
 }
 
+std::optional<bool> BraveOriginPolicyManager::GetEnforcedPolicyValue(
+    std::string_view policy_key,
+    std::optional<std::string_view> profile_id) const {
+  if (!initialized_ || !local_state_) {
+    return std::nullopt;
+  }
+  if (!local_state_->GetBoolean(kOriginPoliciesWereEnforced)) {
+    return std::nullopt;
+  }
+  return GetPolicyValue(policy_key, profile_id);
+}
+
 bool BraveOriginPolicyManager::IsBrowserPolicy(
     std::string_view policy_key) const {
   return browser_policy_definitions_.contains(policy_key);

--- a/components/brave_origin/brave_origin_policy_manager.h
+++ b/components/brave_origin/brave_origin_policy_manager.h
@@ -46,6 +46,25 @@ class BraveOriginPolicyManager {
       std::string_view policy_key,
       std::optional<std::string_view> profile_id = std::nullopt) const;
 
+  // TEMPORARY WORKAROUND. Returns the BraveOrigin policy value read directly
+  // from local state, but only when Origin is currently enforcing policies on
+  // this install (`kOriginPoliciesWereEnforced` is true). Returns nullopt
+  // otherwise — including when the manager is not yet initialized, the local
+  // state is unavailable, or Origin is not in effect.
+  //
+  // This bypasses the chromium policy framework → managed pref propagation,
+  // which races against eager keyed-service construction during profile init
+  // (services like AdsServiceImpl are constructed before Origin policies have
+  // landed as managed prefs). The proper fix is for any service that takes
+  // irreversible action at construction to observe `policy::PolicyService` and
+  // wait for `IsInitializationComplete(POLICY_DOMAIN_CHROME)`. See
+  // chrome/browser/extensions/forced_extensions/force_installed_tracker.cc for
+  // the upstream pattern. Once such services are restructured to defer their
+  // startup work, this helper should be removed.
+  std::optional<bool> GetEnforcedPolicyValue(
+      std::string_view policy_key,
+      std::optional<std::string_view> profile_id = std::nullopt) const;
+
   // Get browser-level policy key-value pairs (policy values from local state or
   // defaults)
   PoliciesEnabledMap GetAllBrowserPolicies() const;


### PR DESCRIPTION
## Summary

Fixes ads service starting (and showing NTP ads / ad notifications) for Brave Origin users despite Rewards being policy-disabled.

The chromium policy → managed-pref pipeline races against eager AdsService construction at profile init: `bat_ads` launches before `BraveRewardsDisabled` lands as a managed pref, and the existing `brave_rewards::IsSupported()` check sees the pref unmanaged.

Wallet and AI Chat are not affected by the same race because their factory-level gate is re-evaluated on every `GetForBrowserContext()` call. AdsService is unique in committing to a launched utility process at construction without re-checking.

## Fix

Read the Origin policy directly from local state (`kBraveOriginPolicies` dict via `BraveOriginPolicyManager`) at the top of `CanStartBatAdsService()`. The dict honors user overrides (e.g. user toggled Rewards back on under Origin), so the gate respects both the policy default and the override.

## Test plan

- [ ] Brave Origin purchased, default: ads service does not start.
- [ ] Brave Origin purchased, user toggles Rewards back on: ads service starts.
- [ ] Non-Origin user, no Rewards opt-in: ads service starts (NTP/SearchResult branch).
- [ ] Non-Origin user, opted into Rewards: ads service starts (joined-Rewards branch).
- [ ] Same matrix on Android.