### PR TITLE
Keep container identity of a tab after a discard.

### DIFF
--- a/browser/containers/container_tab_tracker.cc
+++ b/browser/containers/container_tab_tracker.cc
@@ -7,6 +7,7 @@
 
 #include "base/memory/ptr_util.h"
 #include "brave/browser/containers/containers_service_factory.h"
+#include "brave/components/containers/content/browser/containers_web_contents_user_data.h"
 #include "brave/components/containers/content/browser/storage_partition_utils.h"
 #include "brave/components/containers/core/browser/containers_service.h"
 #include "chrome/browser/profiles/profile.h"
@@ -37,6 +38,8 @@ void ContainerTabTracker::OnDiscardContents(
     tabs::TabInterface* tab,
     content::WebContents* old_contents,
     content::WebContents* new_contents) {
+  ContainersWebContentsUserData::CopyContainerStateForDiscardedContents(
+      old_contents, new_contents);
   tracked_ = false;
   tabs::ContentsObservingTabFeature::OnDiscardContents(tab, old_contents,
                                                        new_contents);

--- a/browser/ui/tabs/containers_tab_menu_model_delegate.cc
+++ b/browser/ui/tabs/containers_tab_menu_model_delegate.cc
@@ -55,14 +55,12 @@ ContainersTabMenuModelDelegate::GetCurrentContainerIds() {
       continue;
     }
 
-    auto storage_partition_config = contents->GetSiteInstance()
-                                        ->GetSecurityPrincipal()
-                                        .GetStoragePartitionConfig();
-    if (!containers::IsContainersStoragePartition(storage_partition_config)) {
+    auto container_id = containers::GetContainerIdForWebContents(contents);
+    if (container_id.empty()) {
       continue;
     }
 
-    container_ids.insert(storage_partition_config.partition_name());
+    container_ids.insert(container_id);
   }
 
   return container_ids;

--- a/chromium_src/chrome/browser/renderer_context_menu/render_view_context_menu.cc
+++ b/chromium_src/chrome/browser/renderer_context_menu/render_view_context_menu.cc
@@ -772,14 +772,13 @@ void RenderViewContextMenu::OnNewTemporaryContainerSelected() {
 base::flat_set<std::string> RenderViewContextMenu::GetCurrentContainerIds() {
   CHECK(base::FeatureList::IsEnabled(containers::features::kContainers));
 
-  const auto& storage_partition_config = source_web_contents_->GetSiteInstance()
-                                             ->GetSecurityPrincipal()
-                                             .GetStoragePartitionConfig();
-  if (!containers::IsContainersStoragePartition(storage_partition_config)) {
+  auto container_id =
+      containers::GetContainerIdForWebContents(source_web_contents_);
+  if (container_id.empty()) {
     return {};
   }
 
-  return {storage_partition_config.partition_name()};
+  return {container_id};
 }
 #endif  // BUILDFLAG(ENABLE_CONTAINERS)
 

--- a/components/containers/content/browser/BUILD.gn
+++ b/components/containers/content/browser/BUILD.gn
@@ -14,6 +14,8 @@ component("browser") {
   defines = [ "IS_CONTAINERS_CONTENT_BROWSER_IMPL" ]
 
   sources = [
+    "containers_web_contents_user_data.cc",
+    "containers_web_contents_user_data.h",
     "session_utils.cc",
     "session_utils.h",
     "storage_partition_utils.cc",

--- a/components/containers/content/browser/containers_web_contents_user_data.cc
+++ b/components/containers/content/browser/containers_web_contents_user_data.cc
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/components/containers/content/browser/containers_web_contents_user_data.h"
+
+#include <utility>
+
+#include "brave/components/containers/content/browser/storage_partition_utils.h"
+#include "content/public/browser/security_principal.h"
+#include "content/public/browser/site_instance.h"
+#include "content/public/browser/web_contents.h"
+
+namespace containers {
+
+WEB_CONTENTS_USER_DATA_KEY_IMPL(ContainersWebContentsUserData);
+
+ContainersWebContentsUserData::ContainersWebContentsUserData(
+    content::WebContents* web_contents,
+    std::string container_id)
+    : content::WebContentsUserData<ContainersWebContentsUserData>(
+          *web_contents),
+      container_id_(std::move(container_id)) {}
+
+ContainersWebContentsUserData::~ContainersWebContentsUserData() = default;
+
+// static
+void ContainersWebContentsUserData::CopyContainerStateForDiscardedContents(
+    content::WebContents* old_contents,
+    content::WebContents* new_contents) {
+  if (!old_contents || !new_contents) {
+    return;
+  }
+
+  std::string container_id;
+  const auto& config = old_contents->GetSiteInstance()
+                           ->GetSecurityPrincipal()
+                           .GetStoragePartitionConfig();
+  if (IsContainersStoragePartition(config)) {
+    container_id = config.partition_name();
+  } else if (const ContainersWebContentsUserData* const old_user_data =
+                 ContainersWebContentsUserData::FromWebContents(old_contents)) {
+    container_id = old_user_data->container_id();
+  }
+
+  if (container_id.empty()) {
+    return;
+  }
+
+  CreateForWebContents(new_contents, std::move(container_id));
+}
+
+}  // namespace containers

--- a/components/containers/content/browser/containers_web_contents_user_data.h
+++ b/components/containers/content/browser/containers_web_contents_user_data.h
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_COMPONENTS_CONTAINERS_CONTENT_BROWSER_CONTAINERS_WEB_CONTENTS_USER_DATA_H_
+#define BRAVE_COMPONENTS_CONTAINERS_CONTENT_BROWSER_CONTAINERS_WEB_CONTENTS_USER_DATA_H_
+
+#include <string>
+
+#include "base/component_export.h"
+#include "content/public/browser/web_contents_user_data.h"
+
+namespace content {
+class WebContents;
+}  // namespace content
+
+namespace containers {
+
+// Persists the container id on a WebContents when SiteInstance does not yet
+// reflect the Containers storage partition (e.g. stub contents after discard).
+class COMPONENT_EXPORT(CONTAINERS_CONTENT_BROWSER) ContainersWebContentsUserData
+    : public content::WebContentsUserData<ContainersWebContentsUserData> {
+ public:
+  ~ContainersWebContentsUserData() override;
+
+  const std::string& container_id() const { return container_id_; }
+
+  // Copies resolved container state from |old_contents| onto |new_contents|
+  // when the tab's WebContents was replaced (e.g. memory-saver discard).
+  static void CopyContainerStateForDiscardedContents(
+      content::WebContents* old_contents,
+      content::WebContents* new_contents);
+
+ private:
+  friend content::WebContentsUserData<ContainersWebContentsUserData>;
+
+  explicit ContainersWebContentsUserData(content::WebContents* web_contents,
+                                         std::string container_id);
+
+  std::string container_id_;
+
+  WEB_CONTENTS_USER_DATA_KEY_DECL();
+};
+
+}  // namespace containers
+
+#endif  // BRAVE_COMPONENTS_CONTAINERS_CONTENT_BROWSER_CONTAINERS_WEB_CONTENTS_USER_DATA_H_

--- a/components/containers/content/browser/storage_partition_utils.cc
+++ b/components/containers/content/browser/storage_partition_utils.cc
@@ -8,6 +8,7 @@
 #include <algorithm>
 
 #include "base/strings/string_util.h"
+#include "brave/components/containers/content/browser/containers_web_contents_user_data.h"
 #include "brave/components/containers/core/common/features.h"
 #include "content/public/browser/security_principal.h"
 #include "content/public/browser/site_instance.h"
@@ -58,11 +59,18 @@ std::string GetContainerIdForWebContents(content::WebContents* web_contents) {
   const auto& config = web_contents->GetSiteInstance()
                            ->GetSecurityPrincipal()
                            .GetStoragePartitionConfig();
-  if (!IsContainersStoragePartition(config)) {
-    return std::string();
+  if (IsContainersStoragePartition(config)) {
+    return config.partition_name();
   }
 
-  return config.partition_name();
+  const ContainersWebContentsUserData* user_data =
+      ContainersWebContentsUserData::FromWebContents(web_contents);
+  if (user_data &&
+      IsValidStoragePartitionKeyComponent(user_data->container_id())) {
+    return user_data->container_id();
+  }
+
+  return std::string();
 }
 
 }  // namespace containers

--- a/components/containers/content/browser/storage_partition_utils.h
+++ b/components/containers/content/browser/storage_partition_utils.h
@@ -47,10 +47,11 @@ std::optional<content::StoragePartitionConfig> MaybeInheritStoragePartition(
     base::optional_ref<const content::StoragePartitionConfig>
         storage_partition_config);
 
-// Gets the storage partition config from |web_contents|, checks internally if
-// it is a Containers storage partition, and returns the container ID if so.
-// Returns an empty string if |web_contents| is null, or if the tab is not in
-// a Containers storage partition.
+// Returns the container ID for |web_contents|: first from SiteInstance when it
+// identifies a Containers storage partition; otherwise from WebContentsUserData
+// attached after tab discard when the stub WebContents does not yet have the
+// correct SiteInstance. Returns an empty string if |web_contents| is null, or
+// if neither source yields a valid Containers partition.
 COMPONENT_EXPORT(CONTAINERS_CONTENT_BROWSER)
 std::string GetContainerIdForWebContents(content::WebContents* web_contents);
 

--- a/components/containers/content/browser/storage_partition_utils_unittest.cc
+++ b/components/containers/content/browser/storage_partition_utils_unittest.cc
@@ -7,10 +7,16 @@
 
 #include "base/test/scoped_feature_list.h"
 #include "base/types/optional_ref.h"
+#include "brave/components/containers/content/browser/containers_web_contents_user_data.h"
 #include "brave/components/containers/core/common/features.h"
+#include "content/public/browser/site_instance.h"
 #include "content/public/browser/storage_partition_config.h"
+#include "content/public/test/browser_task_environment.h"
+#include "content/public/test/test_browser_context.h"
 #include "content/test/storage_partition_test_helpers.h"
+#include "content/test/test_web_contents.h"
 #include "testing/gtest/include/gtest/gtest.h"
+#include "url/gurl.h"
 
 namespace containers {
 
@@ -132,6 +138,110 @@ TEST_F(ContainersStoragePartitionUtilsTest,
   auto result = MaybeInheritStoragePartition(config);
 
   EXPECT_FALSE(result.has_value());
+}
+
+class ContainersStoragePartitionUtilsWebContentsTest : public testing::Test {
+ public:
+  ContainersStoragePartitionUtilsWebContentsTest() {
+    scoped_feature_list_.InitAndEnableFeature(features::kContainers);
+  }
+
+ protected:
+  base::test::ScopedFeatureList scoped_feature_list_;
+  content::BrowserTaskEnvironment task_environment_;
+  content::TestBrowserContext browser_context_;
+};
+
+TEST_F(ContainersStoragePartitionUtilsWebContentsTest,
+       GetContainerIdForWebContents_FromContainersSiteInstance) {
+  auto config = content::CreateStoragePartitionConfigForTesting(
+      /*in_memory=*/false,
+      /*partition_domain=*/kContainersStoragePartitionDomain,
+      /*partition_name=*/"site-instance-container");
+
+  scoped_refptr<content::SiteInstance> site =
+      content::SiteInstance::CreateForFixedStoragePartition(
+          &browser_context_, GURL("https://example.com/"), config);
+  std::unique_ptr<content::TestWebContents> contents =
+      content::TestWebContents::Create(&browser_context_, site);
+
+  EXPECT_EQ(GetContainerIdForWebContents(contents.get()),
+            "site-instance-container");
+}
+
+TEST_F(ContainersStoragePartitionUtilsWebContentsTest,
+       GetContainerIdForWebContents_FromUserDataWhenStubSiteInstance) {
+  scoped_refptr<content::SiteInstance> site =
+      content::SiteInstance::Create(&browser_context_);
+  std::unique_ptr<content::TestWebContents> contents =
+      content::TestWebContents::Create(&browser_context_, site);
+
+  ContainersWebContentsUserData::CreateForWebContents(contents.get(),
+                                                      "stub-user-data-id");
+
+  EXPECT_EQ(GetContainerIdForWebContents(contents.get()), "stub-user-data-id");
+}
+
+TEST_F(ContainersStoragePartitionUtilsWebContentsTest,
+       GetContainerIdForWebContents_SiteInstancePrecedesUserData) {
+  auto config = content::CreateStoragePartitionConfigForTesting(
+      /*in_memory=*/false,
+      /*partition_domain=*/kContainersStoragePartitionDomain,
+      /*partition_name=*/"site-wins");
+
+  scoped_refptr<content::SiteInstance> site =
+      content::SiteInstance::CreateForFixedStoragePartition(
+          &browser_context_, GURL("https://example.com/"), config);
+  std::unique_ptr<content::TestWebContents> contents =
+      content::TestWebContents::Create(&browser_context_, site);
+
+  ContainersWebContentsUserData::CreateForWebContents(contents.get(),
+                                                      "user-data-stale");
+
+  EXPECT_EQ(GetContainerIdForWebContents(contents.get()), "site-wins");
+}
+
+TEST_F(ContainersStoragePartitionUtilsWebContentsTest,
+       CopyContainerStateForDiscardedContents_FromSiteInstance) {
+  auto config = content::CreateStoragePartitionConfigForTesting(
+      /*in_memory=*/false,
+      /*partition_domain=*/kContainersStoragePartitionDomain,
+      /*partition_name=*/"discarded-copy");
+
+  scoped_refptr<content::SiteInstance> container_site =
+      content::SiteInstance::CreateForFixedStoragePartition(
+          &browser_context_, GURL("https://example.com/"), config);
+  std::unique_ptr<content::TestWebContents> old_contents =
+      content::TestWebContents::Create(&browser_context_, container_site);
+
+  scoped_refptr<content::SiteInstance> default_site =
+      content::SiteInstance::Create(&browser_context_);
+  std::unique_ptr<content::TestWebContents> new_contents =
+      content::TestWebContents::Create(&browser_context_, default_site);
+
+  ContainersWebContentsUserData::CopyContainerStateForDiscardedContents(
+      old_contents.get(), new_contents.get());
+
+  EXPECT_EQ(GetContainerIdForWebContents(new_contents.get()), "discarded-copy");
+}
+
+TEST_F(ContainersStoragePartitionUtilsWebContentsTest,
+       CopyContainerStateForDiscardedContents_FromOldUserData) {
+  scoped_refptr<content::SiteInstance> default_site =
+      content::SiteInstance::Create(&browser_context_);
+  std::unique_ptr<content::TestWebContents> old_contents =
+      content::TestWebContents::Create(&browser_context_, default_site);
+  ContainersWebContentsUserData::CreateForWebContents(old_contents.get(),
+                                                      "chained-user-data");
+
+  std::unique_ptr<content::TestWebContents> new_contents =
+      content::TestWebContents::Create(&browser_context_, default_site);
+
+  ContainersWebContentsUserData::CopyContainerStateForDiscardedContents(
+      old_contents.get(), new_contents.get());
+
+  EXPECT_EQ(GetContainerIdForWebContents(new_contents.get()),
+            "chained-user-data");
 }
 
 }  // namespace containers


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Add container id tracking during a tab discard to keep container identity when a contained web contents is discarded.

Resolves https://github.com/brave/brave-browser/issues/55115

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
