### PR TITLE
[ads] Fix AdsClientNotifier observer list reentrancy in tests

### DIFF
--- a/components/brave_ads/core/internal/account/user_rewards/user_rewards_util_unittest.cc
+++ b/components/brave_ads/core/internal/account/user_rewards/user_rewards_util_unittest.cc
@@ -6,6 +6,7 @@
 #include "brave/components/brave_ads/core/internal/account/user_rewards/user_rewards_util.h"
 
 #include "base/scoped_observation.h"
+#include "base/test/run_until.h"
 #include "brave/components/brave_ads/core/internal/account/issuers/issuers_info.h"
 #include "brave/components/brave_ads/core/internal/account/issuers/issuers_util.h"
 #include "brave/components/brave_ads/core/internal/account/issuers/test/issuers_test_util.h"
@@ -35,15 +36,18 @@ class BraveAdsUserRewardsUtilTest : public test::TestBase {
 
 TEST_F(BraveAdsUserRewardsUtilTest, UpdateIssuers) {
   // Arrange
+  bool issuers_notified = false;
   EXPECT_CALL(ads_client_notifier_observer_mock_,
               OnNotifyPrefDidChange(prefs::kIssuerPing));
   EXPECT_CALL(ads_client_notifier_observer_mock_,
-              OnNotifyPrefDidChange(prefs::kIssuers));
+              OnNotifyPrefDidChange(prefs::kIssuers))
+      .WillOnce([&](const std::string&) { issuers_notified = true; });
 
   const IssuersInfo issuers = test::BuildIssuers();
 
   // Act
   UpdateIssuers(issuers);
+  EXPECT_TRUE(base::test::RunUntil([&] { return issuers_notified; }));
 
   // Assert
   EXPECT_TRUE(HasIssuers());

--- a/components/brave_ads/core/internal/common/subdivision/subdivision_unittest.cc
+++ b/components/brave_ads/core/internal/common/subdivision/subdivision_unittest.cc
@@ -8,6 +8,7 @@
 #include <string>
 
 #include "brave/components/brave_ads/core/internal/common/subdivision/test/subdivision_observer_mock.h"
+#include "brave/components/brave_ads/core/internal/common/subdivision/test/test_subdivision_observer.h"
 #include "brave/components/brave_ads/core/internal/common/subdivision/url_request/subdivision_url_request_builder_util.h"
 #include "brave/components/brave_ads/core/internal/common/subdivision/url_request/test/subdivision_url_request_test_util.h"
 #include "brave/components/brave_ads/core/internal/common/test/mock_test_util.h"
@@ -72,10 +73,12 @@ TEST_F(BraveAdsSubdivisionTest, FetchIfUserJoinsBraveRewards) {
 
   MockHttpOkUrlResponse(/*country_code=*/"US", /*subdivision_code=*/"CA");
 
-  EXPECT_CALL(subdivision_observer_mock_, OnDidUpdateSubdivision);
+  TestSubdivisionObserver subdivision_observer(
+      subdivision_.get(), /*expected_subdivision=*/"US-CA");
 
   // Act & Assert
   SetProfileBooleanPref(brave_rewards::prefs::kEnabled, true);
+  EXPECT_TRUE(subdivision_observer.WaitForDidUpdateSubdivision());
 }
 
 TEST_F(BraveAdsSubdivisionTest, DoNotFetchIfUserHasNotJoinedBraveRewards) {
@@ -104,10 +107,12 @@ TEST_F(BraveAdsSubdivisionTest, FetchWhenOptingInToNotificationAds) {
 
   MockHttpOkUrlResponse(/*country_code=*/"US", /*subdivision_code=*/"CA");
 
-  EXPECT_CALL(subdivision_observer_mock_, OnDidUpdateSubdivision);
+  TestSubdivisionObserver subdivision_observer(
+      subdivision_.get(), /*expected_subdivision=*/"US-CA");
 
   // Act & Assert
   SetProfileBooleanPref(prefs::kOptedInToNotificationAds, true);
+  EXPECT_TRUE(subdivision_observer.WaitForDidUpdateSubdivision());
 }
 
 TEST_F(BraveAdsSubdivisionTest, DoNotFetchWhenOptingOutOfNewTabPageAds) {

--- a/components/brave_ads/core/internal/common/subdivision/test/test_subdivision_observer.cc
+++ b/components/brave_ads/core/internal/common/subdivision/test/test_subdivision_observer.cc
@@ -1,0 +1,33 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_ads/core/internal/common/subdivision/test/test_subdivision_observer.h"
+
+// Allows tests to synchronously wait for `Subdivision` to notify
+// `OnDidUpdateSubdivision` without polling or manual futures.
+
+namespace brave_ads {
+
+TestSubdivisionObserver::TestSubdivisionObserver(
+    Subdivision* subdivision,
+    std::string expected_subdivision)
+    : expected_subdivision_(std::move(expected_subdivision)) {
+  scoped_observation_.Observe(subdivision);
+}
+
+TestSubdivisionObserver::~TestSubdivisionObserver() = default;
+
+bool TestSubdivisionObserver::WaitForDidUpdateSubdivision() {
+  return did_update_subdivision_future_.Wait();
+}
+
+void TestSubdivisionObserver::OnDidUpdateSubdivision(
+    const std::string& subdivision) {
+  if (subdivision == expected_subdivision_) {
+    did_update_subdivision_future_.GetCallback().Run();
+  }
+}
+
+}  // namespace brave_ads

--- a/components/brave_ads/core/internal/common/subdivision/test/test_subdivision_observer.h
+++ b/components/brave_ads/core/internal/common/subdivision/test/test_subdivision_observer.h
@@ -1,0 +1,42 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_ADS_CORE_INTERNAL_COMMON_SUBDIVISION_TEST_TEST_SUBDIVISION_OBSERVER_H_
+#define BRAVE_COMPONENTS_BRAVE_ADS_CORE_INTERNAL_COMMON_SUBDIVISION_TEST_TEST_SUBDIVISION_OBSERVER_H_
+
+#include <string>
+
+#include "base/scoped_observation.h"
+#include "base/test/test_future.h"
+#include "brave/components/brave_ads/core/internal/common/subdivision/subdivision.h"
+#include "brave/components/brave_ads/core/internal/common/subdivision/subdivision_observer.h"
+
+namespace brave_ads {
+
+class TestSubdivisionObserver final : public SubdivisionObserver {
+ public:
+  TestSubdivisionObserver(Subdivision* subdivision,
+                          std::string expected_subdivision);
+
+  TestSubdivisionObserver(const TestSubdivisionObserver&) = delete;
+  TestSubdivisionObserver& operator=(const TestSubdivisionObserver&) = delete;
+
+  ~TestSubdivisionObserver() override;
+
+  bool WaitForDidUpdateSubdivision();
+
+ private:
+  // SubdivisionObserver:
+  void OnDidUpdateSubdivision(const std::string& subdivision) override;
+
+  const std::string expected_subdivision_;
+  base::test::TestFuture<void> did_update_subdivision_future_;
+  base::ScopedObservation<Subdivision, SubdivisionObserver> scoped_observation_{
+      this};
+};
+
+}  // namespace brave_ads
+
+#endif  // BRAVE_COMPONENTS_BRAVE_ADS_CORE_INTERNAL_COMMON_SUBDIVISION_TEST_TEST_SUBDIVISION_OBSERVER_H_

--- a/components/brave_ads/core/internal/common/test/internal/mock_test_util_internal.cc
+++ b/components/brave_ads/core/internal/common/test/internal/mock_test_util_internal.cc
@@ -12,6 +12,8 @@
 #include "base/check.h"
 #include "base/files/file.h"
 #include "base/files/file_util.h"
+#include "base/functional/bind.h"
+#include "base/task/sequenced_task_runner.h"
 #include "base/values.h"
 #include "brave/components/brave_ads/core/internal/common/test/file_path_test_util.h"
 #include "brave/components/brave_ads/core/internal/common/test/internal/local_state_pref_storage_test_util_internal.h"
@@ -139,7 +141,12 @@ void MockSetProfilePref(const AdsClientMock& ads_client_mock,
       .WillByDefault(
           [&ads_client_notifier](const std::string& path, base::Value value) {
             SetProfilePrefValue(path, std::move(value));
-            ads_client_notifier.NotifyPrefDidChange(path);
+            // Run `NotifyPrefDidChange` asynchronously to match production
+            // behavior where `NotifyPrefDidChange` arrives via Mojo channel.
+            base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
+                FROM_HERE,
+                base::BindOnce(&AdsClientNotifier::NotifyPrefDidChange,
+                               base::Unretained(&ads_client_notifier), path));
           });
 }
 
@@ -176,7 +183,12 @@ void MockSetLocalStatePref(const AdsClientMock& ads_client_mock,
       .WillByDefault(
           [&ads_client_notifier](const std::string& path, base::Value value) {
             SetLocalStatePrefValue(path, std::move(value));
-            ads_client_notifier.NotifyPrefDidChange(path);
+            // Run `NotifyPrefDidChange` asynchronously to match production
+            // behavior where `NotifyPrefDidChange` arrives via Mojo channel.
+            base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
+                FROM_HERE,
+                base::BindOnce(&AdsClientNotifier::NotifyPrefDidChange,
+                               base::Unretained(&ads_client_notifier), path));
           });
 }
 

--- a/components/brave_ads/core/internal/serving/new_tab_page_ad_serving_unittest.cc
+++ b/components/brave_ads/core/internal/serving/new_tab_page_ad_serving_unittest.cc
@@ -5,6 +5,7 @@
 
 #include "brave/components/brave_ads/core/internal/serving/new_tab_page_ad_serving.h"
 
+#include <memory>
 #include <utility>
 
 #include "base/run_loop.h"
@@ -28,16 +29,23 @@ namespace brave_ads {
 
 class BraveAdsNewTabPageAdServingTest : public test::TestBase {
  protected:
+  void SetUp() override {
+    test::TestBase::SetUp();
+
+    subdivision_targeting_ = std::make_unique<SubdivisionTargeting>();
+    anti_targeting_resource_ = std::make_unique<AntiTargetingResource>();
+  }
+
   void MaybeServeAd(MaybeServeNewTabPageAdCallback callback) {
-    SubdivisionTargeting subdivision_targeting;
-    AntiTargetingResource anti_targeting_resource;
     ad_serving_ = std::make_unique<NewTabPageAdServing>(
-        subdivision_targeting, anti_targeting_resource);
+        *subdivision_targeting_, *anti_targeting_resource_);
     ad_serving_->SetDelegate(&delegate_mock_);
 
     ad_serving_->MaybeServeAd(std::move(callback));
   }
 
+  std::unique_ptr<SubdivisionTargeting> subdivision_targeting_;
+  std::unique_ptr<AntiTargetingResource> anti_targeting_resource_;
   ::testing::StrictMock<NewTabPageAdServingDelegateMock> delegate_mock_;
   std::unique_ptr<NewTabPageAdServing> ad_serving_;
 };

--- a/components/brave_ads/core/internal/serving/notification_ad_serving_unittest.cc
+++ b/components/brave_ads/core/internal/serving/notification_ad_serving_unittest.cc
@@ -31,18 +31,21 @@ class BraveAdsNotificationAdServingTest : public test::TestBase {
     ads_client_notifier_.NotifyBrowserDidBecomeActive();
 
     ads_client_notifier_.NotifyDidInitializeAds();
+
+    subdivision_targeting_ = std::make_unique<SubdivisionTargeting>();
+    anti_targeting_resource_ = std::make_unique<AntiTargetingResource>();
   }
 
   void MaybeServeAd() {
-    SubdivisionTargeting subdivision_targeting;
-    AntiTargetingResource anti_targeting_resource;
     ad_serving_ = std::make_unique<NotificationAdServing>(
-        subdivision_targeting, anti_targeting_resource);
+        *subdivision_targeting_, *anti_targeting_resource_);
     ad_serving_->SetDelegate(&delegate_mock_);
 
     ad_serving_->MaybeServeAd();
   }
 
+  std::unique_ptr<SubdivisionTargeting> subdivision_targeting_;
+  std::unique_ptr<AntiTargetingResource> anti_targeting_resource_;
   ::testing::StrictMock<NotificationAdServingDelegateMock> delegate_mock_;
   std::unique_ptr<NotificationAdServing> ad_serving_;
 };

--- a/components/brave_ads/core/internal/targeting/contextual/text_classification/resource/text_classification_resource_unittest.cc
+++ b/components/brave_ads/core/internal/targeting/contextual/text_classification/resource/text_classification_resource_unittest.cc
@@ -155,7 +155,7 @@ TEST_F(BraveAdsTextClassificationResourceTest,
   SetProfileBooleanPref(prefs::kOptedInToNotificationAds, true);
 
   // Assert
-  EXPECT_TRUE(resource_->IsLoaded());
+  EXPECT_TRUE(base::test::RunUntil([this] { return resource_->IsLoaded(); }));
 }
 
 TEST_F(BraveAdsTextClassificationResourceTest,

--- a/components/brave_ads/core/internal/targeting/geographical/subdivision/subdivision_targeting_unittest.cc
+++ b/components/brave_ads/core/internal/targeting/geographical/subdivision/subdivision_targeting_unittest.cc
@@ -9,6 +9,7 @@
 #include <string>
 
 #include "brave/components/brave_ads/core/internal/common/subdivision/subdivision.h"
+#include "brave/components/brave_ads/core/internal/common/subdivision/test/test_subdivision_observer.h"
 #include "brave/components/brave_ads/core/internal/common/subdivision/url_request/subdivision_url_request_builder_util.h"
 #include "brave/components/brave_ads/core/internal/common/subdivision/url_request/test/subdivision_url_request_test_util.h"
 #include "brave/components/brave_ads/core/internal/common/test/mock_test_util.h"
@@ -56,8 +57,12 @@ TEST_F(BraveAdsSubdivisionTargetingTest,
 
   ads_client_notifier_.NotifyDidInitializeAds();
 
+  TestSubdivisionObserver subdivision_observer(
+      subdivision_.get(), /*expected_subdivision=*/"US-CA");
+
   // Act
   SetProfileBooleanPref(prefs::kOptedInToNotificationAds, true);
+  EXPECT_TRUE(subdivision_observer.WaitForDidUpdateSubdivision());
 
   // Assert
   EXPECT_TRUE(SubdivisionTargeting::ShouldAllow());

--- a/components/brave_ads/core/test/BUILD.gn
+++ b/components/brave_ads/core/test/BUILD.gn
@@ -293,6 +293,8 @@ source_set("brave_ads_unit_tests") {
     "//brave/components/brave_ads/core/internal/common/subdivision/test/subdivision_observer_mock.h",
     "//brave/components/brave_ads/core/internal/common/subdivision/test/subdivision_test_util.cc",
     "//brave/components/brave_ads/core/internal/common/subdivision/test/subdivision_test_util.h",
+    "//brave/components/brave_ads/core/internal/common/subdivision/test/test_subdivision_observer.cc",
+    "//brave/components/brave_ads/core/internal/common/subdivision/test/test_subdivision_observer.h",
     "//brave/components/brave_ads/core/internal/common/subdivision/url_request/subdivision_url_request_builder_unittest.cc",
     "//brave/components/brave_ads/core/internal/common/subdivision/url_request/subdivision_url_request_builder_util_unittest.cc",
     "//brave/components/brave_ads/core/internal/common/subdivision/url_request/subdivision_url_request_json_reader_util_unittest.cc",


### PR DESCRIPTION
The test mock for SetProfilePref and SetLocalStatePref called NotifyPrefDidChange synchronously from within a pref change handler, causing reentrant observer notifications. The changes post the notification asynchronously and update affected tests to wait for async delivery matching production behavior.

IMPORTANT: The PR is in draft and needs additional changes because some tests can now pass without expectation verification.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/55314

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
