### PR TITLE
[AI Chat] Don't show Task UI when executing tools in a non-agent conversation

### DIFF
--- a/browser/ai_chat/BUILD.gn
+++ b/browser/ai_chat/BUILD.gn
@@ -351,6 +351,7 @@ source_set("browser_tests") {
       "ai_chat_browsertests.cc",
       "ai_chat_conversation_entries_browsertest.cc",
       "ai_chat_conversation_task_browsertest.cc",
+      "ai_chat_conversation_ui_browsertest.cc",
       "ai_chat_conversation_ui_browsertest_base.cc",
       "ai_chat_conversation_ui_browsertest_base.h",
       "ai_chat_metrics_browsertest.cc",

--- a/browser/ai_chat/ai_chat_conversation_task_browsertest.cc
+++ b/browser/ai_chat/ai_chat_conversation_task_browsertest.cc
@@ -127,7 +127,9 @@ class AIChatConversationTaskBrowserTest
   ConversationHandler* CreateConversationWithMockEngine() {
     AIChatConversationUIBrowserTestBase::CreateConversationWithMockEngine();
 
-    // Get the ContentAgentToolProvider from the conversation
+    // Get the ContentAgentToolProvider from the conversation.
+    // We won't use MockToolProvider since these tests need the real
+    // ContentAgentToolProvider to validate it performs its actions.
     auto* tool_provider =
         conversation_handler_->GetFirstToolProviderForTesting();
     EXPECT_TRUE(tool_provider);
@@ -164,12 +166,6 @@ class AIChatConversationTaskBrowserTest
     args.Set("website_url", url.spec());
     return mojom::ToolUseEvent::New("web_page_navigator", tool_id,
                                     *base::WriteJson(args), std::nullopt,
-                                    std::nullopt, nullptr, false);
-  }
-
-  mojom::ToolUseEventPtr CreateToolUseEvent(const std::string& tool_name,
-                                            const std::string& tool_id) {
-    return mojom::ToolUseEvent::New(tool_name, tool_id, "{}", std::nullopt,
                                     std::nullopt, nullptr, false);
   }
 

--- a/browser/ai_chat/ai_chat_conversation_ui_browsertest.cc
+++ b/browser/ai_chat/ai_chat_conversation_ui_browsertest.cc
@@ -28,9 +28,11 @@ class AIChatConversationUIBrowserTest
 };
 
 // Test that when executing a tool, the task UI is not shown for chat
-// conversations (should only be shown for content agent conversations, verified
-// in the task browser tests.
-IN_PROC_BROWSER_TEST_F(AIChatConversationUIBrowserTest, NoTaskStateActions) {
+// conversations (it should only be shown for content agent conversations,
+// which is verified in the task browser tests).
+IN_PROC_BROWSER_TEST_F(
+    AIChatConversationUIBrowserTest,
+    NonAgentConversationDoesNotShowTaskStateActionsWhileToolExecutes) {
   CreateConversationWithMockEngine();
   std::string uuid = conversation_handler_->get_conversation_uuid();
 
@@ -80,7 +82,7 @@ IN_PROC_BROWSER_TEST_F(AIChatConversationUIBrowserTest, NoTaskStateActions) {
   }
 
   // Wait for running state
-  EXPECT_TRUE(base::test::RunUntil([this]() {
+  ASSERT_TRUE(base::test::RunUntil([this]() {
     return GetConversationState()->tool_use_task_state ==
            mojom::TaskState::kRunning;
   }));

--- a/browser/ai_chat/ai_chat_conversation_ui_browsertest.cc
+++ b/browser/ai_chat/ai_chat_conversation_ui_browsertest.cc
@@ -1,0 +1,92 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include <memory>
+#include <string>
+
+#include "base/test/run_until.h"
+#include "base/types/expected.h"
+#include "brave/browser/ai_chat/ai_chat_conversation_ui_browsertest_base.h"
+#include "brave/components/ai_chat/core/browser/engine/engine_consumer.h"
+#include "brave/components/ai_chat/core/browser/tools/mock_tool.h"
+#include "brave/components/ai_chat/core/browser/tools/mock_tool_provider.h"
+#include "brave/components/ai_chat/core/browser/tools/tool_utils.h"
+#include "brave/components/ai_chat/core/common/mojom/ai_chat.mojom.h"
+#include "content/public/test/browser_test.h"
+#include "testing/gmock/include/gmock/gmock.h"
+
+namespace ai_chat {
+
+// Tests for general conversation UI rendering and interactions
+class AIChatConversationUIBrowserTest
+    : public AIChatConversationUIBrowserTestBase {
+ public:
+  AIChatConversationUIBrowserTest() = default;
+  ~AIChatConversationUIBrowserTest() override = default;
+};
+
+// Test that when executing a tool, the task UI is not shown for chat
+// conversations (should only be shown for content agent conversations, verified
+// in the task browser tests.
+IN_PROC_BROWSER_TEST_F(AIChatConversationUIBrowserTest, NoTaskStateActions) {
+  CreateConversationWithMockEngine();
+  std::string uuid = conversation_handler_->get_conversation_uuid();
+
+  NavigateToConversationUI(uuid);
+
+  // Inject a mock tool provider with a mock tool so that we can control when
+  // the tool execution completes and inspect the UI.
+  auto* mock_tool_provider = conversation_handler_->AddToolProviderForTesting(
+      std::make_unique<testing::NiceMock<MockToolProvider>>());
+  auto* mock_tool = mock_tool_provider->AddToolForTesting(
+      std::make_unique<testing::NiceMock<MockTool>>("mock_tool", "Mock tool"));
+
+  testing::Sequence tool_call_seq;
+  base::OnceClosure tool_execute;
+
+  // Submit first message
+  {
+    auto generate_future = SetupMockGenerateAssistantResponse(&tool_call_seq);
+    conversation_handler_->SubmitHumanConversationEntry("Do something",
+                                                        std::nullopt);
+    auto callbacks = generate_future->Take();
+
+    // Set up the mock tool to capture its callback so we control execution
+    // timing.
+    EXPECT_CALL(*mock_tool, UseTool)
+        .InSequence(tool_call_seq)
+        .WillOnce(testing::WithArg<1>([&](Tool::UseToolCallback callback) {
+          // Store the callback but don't call it yet so we can inspect the
+          // state whilst waiting for the tool execution to complete.
+          tool_execute = base::BindOnce(
+              [](Tool::UseToolCallback callback) {
+                std::move(callback).Run(
+                    CreateContentBlocksForText("tool result"), {});
+              },
+              std::move(callback));
+        }));
+
+    // Simulate tool use event
+    callbacks.data_callback.Run(EngineConsumer::GenerationResultData(
+        mojom::ConversationEntryEvent::NewToolUseEvent(
+            CreateToolUseEvent("mock_tool", "tool_id_1")),
+        std::nullopt));
+    // Complete first message response
+    std::move(callbacks.completed_callback)
+        .Run(base::ok(
+            EngineConsumer::GenerationResultData(nullptr, std::nullopt)));
+  }
+
+  // Wait for running state
+  EXPECT_TRUE(base::test::RunUntil([this]() {
+    return GetConversationState()->tool_use_task_state ==
+           mojom::TaskState::kRunning;
+  }));
+
+  // Task UI shouldn't appear
+  EXPECT_FALSE(VerifyElementState("task-state-actions", false));
+}
+
+}  // namespace ai_chat

--- a/browser/ai_chat/ai_chat_conversation_ui_browsertest_base.cc
+++ b/browser/ai_chat/ai_chat_conversation_ui_browsertest_base.cc
@@ -269,4 +269,11 @@ AIChatConversationUIBrowserTestBase::SetupMockGenerateAssistantResponse(
   return future;
 }
 
+mojom::ToolUseEventPtr AIChatConversationUIBrowserTestBase::CreateToolUseEvent(
+    const std::string& tool_name,
+    const std::string& tool_id) {
+  return mojom::ToolUseEvent::New(tool_name, tool_id, "{}", std::nullopt,
+                                  std::nullopt, nullptr, false);
+}
+
 }  // namespace ai_chat

--- a/browser/ai_chat/ai_chat_conversation_ui_browsertest_base.h
+++ b/browser/ai_chat/ai_chat_conversation_ui_browsertest_base.h
@@ -94,6 +94,10 @@ class AIChatConversationUIBrowserTestBase : public InProcessBrowserTest {
   std::unique_ptr<base::test::TestFuture<MockGenerateCallbacks>>
   SetupMockGenerateAssistantResponse(testing::Sequence* sequence = nullptr);
 
+  // Create mock tool use event
+  mojom::ToolUseEventPtr CreateToolUseEvent(const std::string& tool_name,
+                                            const std::string& tool_id);
+
   raw_ptr<content::RenderFrameHost> conversation_rfh_ = nullptr;
   raw_ptr<AIChatService> service_ = nullptr;
   raw_ptr<ConversationHandler> conversation_handler_ = nullptr;

--- a/components/ai_chat/core/browser/BUILD.gn
+++ b/components/ai_chat/core/browser/BUILD.gn
@@ -247,6 +247,8 @@ source_set("test_support") {
     "test_utils.h",
     "tools/mock_tool.cc",
     "tools/mock_tool.h",
+    "tools/mock_tool_provider.cc",
+    "tools/mock_tool_provider.h",
   ]
 
   deps = [

--- a/components/ai_chat/core/browser/conversation_handler.cc
+++ b/components/ai_chat/core/browser/conversation_handler.cc
@@ -19,6 +19,7 @@
 #include "base/check_op.h"
 #include "base/containers/fixed_flat_set.h"
 #include "base/containers/span.h"
+#include "base/containers/to_vector.h"
 #include "base/debug/crash_logging.h"
 #include "base/debug/dump_without_crashing.h"
 #include "base/files/file_path.h"
@@ -391,10 +392,6 @@ void ConversationHandler::GetState(GetStateCallback callback) {
   std::ranges::transform(suggestions_, std::back_inserter(suggestions),
                          [](const auto& s) { return s.title; });
 
-  // Build array of capabilities
-  std::vector<mojom::ConversationCapability> capabilities(
-      conversation_capabilities_.begin(), conversation_capabilities_.end());
-
   mojom::ConversationStatePtr state = mojom::ConversationState::New(
       metadata_->uuid, is_request_in_progress_, std::move(models_copy),
       model_key, default_model_key,
@@ -402,7 +399,8 @@ void ConversationHandler::GetState(GetStateCallback callback) {
       std::move(suggestions), suggestion_generation_status_,
 #endif
       associated_content_manager_->GetAssociatedContent(), current_error_,
-      metadata_->temporary, tool_use_task_state_, std::move(capabilities));
+      metadata_->temporary, tool_use_task_state_,
+      base::ToVector(conversation_capabilities_));
 
   std::move(callback).Run(std::move(state));
 }
@@ -2253,8 +2251,9 @@ bool ConversationHandler::MaybeRespondToNextToolUseRequest() {
       // this after checking for user interaction so that a tool requiring
       // only user-interaction won't trigger a Task pause/stop UI. If we want
       // the tool state to reset whenever there is a tool use that requires
-      // user interaction we should set it above before we `break` to kNone, or
-      // a new kWaitingForUser.
+      // user interaction we should set it in the permission-challenge and
+      // user-output branches before they `break` (to kNone, or a new
+      // kWaitingForUser).
       if (tool_use_task_state_ == mojom::TaskState::kNone) {
         tool_use_task_state_ = mojom::TaskState::kRunning;
         OnToolUseTaskStateChanged();

--- a/components/ai_chat/core/browser/conversation_handler.cc
+++ b/components/ai_chat/core/browser/conversation_handler.cc
@@ -391,6 +391,10 @@ void ConversationHandler::GetState(GetStateCallback callback) {
   std::ranges::transform(suggestions_, std::back_inserter(suggestions),
                          [](const auto& s) { return s.title; });
 
+  // Build array of capabilities
+  std::vector<mojom::ConversationCapability> capabilities(
+      conversation_capabilities_.begin(), conversation_capabilities_.end());
+
   mojom::ConversationStatePtr state = mojom::ConversationState::New(
       metadata_->uuid, is_request_in_progress_, std::move(models_copy),
       model_key, default_model_key,
@@ -398,7 +402,7 @@ void ConversationHandler::GetState(GetStateCallback callback) {
       std::move(suggestions), suggestion_generation_status_,
 #endif
       associated_content_manager_->GetAssociatedContent(), current_error_,
-      metadata_->temporary, tool_use_task_state_);
+      metadata_->temporary, tool_use_task_state_, std::move(capabilities));
 
   std::move(callback).Run(std::move(state));
 }
@@ -2166,13 +2170,6 @@ bool ConversationHandler::MaybeRespondToNextToolUseRequest() {
       has_pending_tool_use_request = true;
       has_only_completed_tool_use_events = false;
 
-      // Initialize the task state for this tool loop if not already set.
-      // PauseTask() may have already set it to kPaused before we get here.
-      if (tool_use_task_state_ == mojom::TaskState::kNone) {
-        tool_use_task_state_ = mojom::TaskState::kRunning;
-        OnToolUseTaskStateChanged();
-      }
-
       // Now check if we're allowed to execute tools.
       if (tool_use_task_state_ == mojom::TaskState::kPaused ||
           tool_use_task_state_ == mojom::TaskState::kStopped) {
@@ -2252,9 +2249,16 @@ bool ConversationHandler::MaybeRespondToNextToolUseRequest() {
 
       // No user interaction needed - execute tool
 
-      // At this point task state should be kRunning (not paused, stopped, or
-      // none) since we initialized it earlier and checked for pause/stop above.
-      CHECK_EQ(tool_use_task_state_, mojom::TaskState::kRunning);
+      // Initialize the task state for this tool loop if not already set. We do
+      // this after checking for user interaction so that a tool requiring
+      // only user-interaction won't trigger a Task pause/stop UI. If we want
+      // the tool state to reset whenever there is a tool use that requires
+      // user interaction we should set it above before we `break` to kNone, or
+      // a new kWaitingForUser.
+      if (tool_use_task_state_ == mojom::TaskState::kNone) {
+        tool_use_task_state_ = mojom::TaskState::kRunning;
+        OnToolUseTaskStateChanged();
+      }
 
       is_tool_use_in_progress_ = true;
       OnAPIRequestInProgressChanged();

--- a/components/ai_chat/core/browser/conversation_handler.h
+++ b/components/ai_chat/core/browser/conversation_handler.h
@@ -6,6 +6,7 @@
 #ifndef BRAVE_COMPONENTS_AI_CHAT_CORE_BROWSER_CONVERSATION_HANDLER_H_
 #define BRAVE_COMPONENTS_AI_CHAT_CORE_BROWSER_CONVERSATION_HANDLER_H_
 
+#include <concepts>
 #include <cstdint>
 #include <memory>
 #include <optional>
@@ -276,6 +277,18 @@ class ConversationHandler : public mojom::ConversationHandler,
       return nullptr;
     }
     return tool_providers_[0].get();
+  }
+
+  // Adds an extra tool provider to this conversation. Returns the added
+  // provider; ownership stays with this ConversationHandler and the pointer
+  // is valid for the conversation's lifetime.
+  template <typename T>
+    requires(std::derived_from<T, ToolProvider>)
+  T* AddToolProviderForTesting(std::unique_ptr<T> tool_provider) {
+    T* raw = tool_provider.get();
+    tool_provider->AddObserver(this);
+    tool_providers_.push_back(std::move(tool_provider));
+    return raw;
   }
 
   void SetChatHistoryForTesting(

--- a/components/ai_chat/core/browser/conversation_handler_unittest.cc
+++ b/components/ai_chat/core/browser/conversation_handler_unittest.cc
@@ -90,6 +90,8 @@ class MockAIChatCredentialManager : public AIChatCredentialManager {
               (override));
 };
 
+// TODO(https://github.com/brave/brave-browser/issues/55381): Use
+// MockToolProvider from mock_tool_provider.h.
 class MockToolProvider : public ToolProvider {
  public:
   MockToolProvider() = default;
@@ -3480,10 +3482,6 @@ TEST_F(ConversationHandlerUnitTest,
                 first_generation_loop.Quit();
               })));
 
-  // Tool should not be called since there is no explicit call via user
-  // interaction.
-  EXPECT_CALL(*tool1, UseTool).Times(0);
-
   // When the user instead decides to send a new human entry, before the tool
   // use request is handled, the tool use request should be discarded.
   base::RunLoop second_generation_loop;
@@ -3511,6 +3509,13 @@ TEST_F(ConversationHandlerUnitTest,
   conversation_handler_->SubmitHumanConversationEntry("First question",
                                                       std::nullopt);
   first_generation_loop.Run();
+
+  // Tool should not be called since there is no explicit call via user
+  // interaction.
+  EXPECT_CALL(*tool1, UseTool).Times(0);
+
+  // State should not be running, since we're waiting
+  EXPECT_EQ(GetState()->tool_use_task_state, mojom::TaskState::kNone);
 
   // Verify the tool use event exists and has no output
   const auto& history_before = conversation_handler_->GetConversationHistory();

--- a/components/ai_chat/core/browser/tools/mock_tool_provider.cc
+++ b/components/ai_chat/core/browser/tools/mock_tool_provider.cc
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/components/ai_chat/core/browser/tools/mock_tool_provider.h"
+
+#include "base/memory/weak_ptr.h"
+
+namespace ai_chat {
+
+MockToolProvider::MockToolProvider() = default;
+
+MockToolProvider::~MockToolProvider() = default;
+
+std::vector<base::WeakPtr<Tool>> MockToolProvider::GetTools() {
+  std::vector<base::WeakPtr<Tool>> result;
+  result.reserve(tools_.size());
+  for (const auto& tool : tools_) {
+    result.push_back(tool->GetWeakPtr());
+  }
+  return result;
+}
+
+void MockToolProvider::StartContentTask(int32_t tab_id) {
+  for (auto& observer : observers_) {
+    observer.OnContentTaskStarted(tab_id);
+  }
+}
+
+void MockToolProvider::SetIsPausedByUser(bool is_paused) {
+  is_paused_by_user_ = is_paused;
+  NotifyTaskStateChanged();
+}
+
+bool MockToolProvider::IsPausedByUser() {
+  return is_paused_by_user_;
+}
+
+}  // namespace ai_chat

--- a/components/ai_chat/core/browser/tools/mock_tool_provider.cc
+++ b/components/ai_chat/core/browser/tools/mock_tool_provider.cc
@@ -23,9 +23,7 @@ std::vector<base::WeakPtr<Tool>> MockToolProvider::GetTools() {
 }
 
 void MockToolProvider::StartContentTask(int32_t tab_id) {
-  for (auto& observer : observers_) {
-    observer.OnContentTaskStarted(tab_id);
-  }
+  observers_.Notify(&Observer::OnContentTaskStarted, tab_id);
 }
 
 void MockToolProvider::SetIsPausedByUser(bool is_paused) {

--- a/components/ai_chat/core/browser/tools/mock_tool_provider.h
+++ b/components/ai_chat/core/browser/tools/mock_tool_provider.h
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_COMPONENTS_AI_CHAT_CORE_BROWSER_TOOLS_MOCK_TOOL_PROVIDER_H_
+#define BRAVE_COMPONENTS_AI_CHAT_CORE_BROWSER_TOOLS_MOCK_TOOL_PROVIDER_H_
+
+#include <concepts>
+#include <cstdint>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "base/memory/weak_ptr.h"
+#include "brave/components/ai_chat/core/browser/tools/tool.h"
+#include "brave/components/ai_chat/core/browser/tools/tool_provider.h"
+#include "testing/gmock/include/gmock/gmock.h"
+
+namespace ai_chat {
+
+// A ToolProvider for tests. Tools added via AddToolForTesting() are owned by
+// the provider and returned from GetTools(), so tests don't need to wire up
+// any mock expectations for the common case.
+class MockToolProvider : public ToolProvider {
+ public:
+  MockToolProvider();
+  ~MockToolProvider() override;
+
+  MOCK_METHOD(void, OnNewGenerationLoop, (), (override));
+  MOCK_METHOD(void, OnGenerationCompleteWithNoToolsToHandle, (), (override));
+  MOCK_METHOD(void, StopAllTasks, (), (override));
+
+  // Returns weak pointers to all tools added via AddToolForTesting.
+  std::vector<base::WeakPtr<Tool>> GetTools() override;
+
+  // Adds a tool that this provider owns. Returns a pointer to the added tool;
+  // ownership stays with the provider and the pointer is valid for the
+  // provider's lifetime.
+  template <typename T>
+    requires(std::derived_from<T, Tool>)
+  T* AddToolForTesting(std::unique_ptr<T> tool) {
+    T* raw = tool.get();
+    tools_.push_back(std::move(tool));
+    return raw;
+  }
+
+  // Notifies observers that a content task has started on `tab_id`.
+  void StartContentTask(int32_t tab_id);
+
+  void SetIsPausedByUser(bool is_paused);
+  bool IsPausedByUser() override;
+
+ private:
+  std::vector<std::unique_ptr<Tool>> tools_;
+  bool is_paused_by_user_ = false;
+};
+
+}  // namespace ai_chat
+
+#endif  // BRAVE_COMPONENTS_AI_CHAT_CORE_BROWSER_TOOLS_MOCK_TOOL_PROVIDER_H_

--- a/components/ai_chat/core/common/mojom/ai_chat.mojom
+++ b/components/ai_chat/core/common/mojom/ai_chat.mojom
@@ -284,6 +284,9 @@ struct ConversationState {
 
   // State of the current task (tool execution loop)
   TaskState tool_use_task_state = kNone;
+
+  // Which of the available capabilities are enabled for this conversation
+  array<ConversationCapability> capabilities_enabled;
 };
 
 // Browser-side handler for a Conversation

--- a/components/ai_chat/resources/page/api/conversation_api.ts
+++ b/components/ai_chat/resources/page/api/conversation_api.ts
@@ -64,6 +64,7 @@ export default function createConversationApi(
             error: Mojom.APIError.None,
             temporary: false,
             toolUseTaskState: Mojom.TaskState.kNone,
+            capabilitiesEnabled: [Mojom.ConversationCapability.CHAT],
           } as Mojom.ConversationState,
         },
         getConversationHistory: {

--- a/components/ai_chat/resources/page/api/mock_interfaces.ts
+++ b/components/ai_chat/resources/page/api/mock_interfaces.ts
@@ -65,6 +65,7 @@ export const defaultConversationState: Mojom.ConversationState & {
   error: Mojom.APIError.None,
   temporary: false,
   toolUseTaskState: Mojom.TaskState.kNone,
+  capabilitiesEnabled: [Mojom.ConversationCapability.CHAT],
 }
 
 const emptyTurn: Mojom.ConversationTurn = {

--- a/components/ai_chat/resources/page/components/input_box/index.tsx
+++ b/components/ai_chat/resources/page/components/input_box/index.tsx
@@ -13,7 +13,10 @@ import { Url } from 'gen/url/mojom/url.mojom.m.js'
 import ActionTypeLabel from '../../../common/components/action_type_label'
 import * as Mojom from '../../../common/mojom'
 import { AIChatContext, useAIChat } from '../../state/ai_chat_context'
-import { ConversationContext } from '../../state/conversation_context'
+import {
+  ConversationContext,
+  useConversationState,
+} from '../../state/conversation_context'
 import styles from './style.module.scss'
 import AttachmentButtonMenu from '../attachment_button_menu'
 import {
@@ -30,6 +33,10 @@ import { stringifyContent } from './editable_content'
 const LEARN_MORE_CONTENT_AGENT_URL =
   'https://support.brave.app/hc/en-us/articles/41240379376909'
 
+/**
+ * @deprecated This component is no longer independent of ConversationContext
+ * and AIChatContext. Use those instead.
+ */
 type Props = Pick<
   ConversationContext,
   | 'attachFiles'
@@ -175,6 +182,7 @@ function AttachmentChips(props: {
 
 function InputBox(props: InputBoxProps) {
   const aiChatContext = useAIChat()
+  const conversationState = useConversationState()
   const querySubmitted = React.useRef(false)
 
   const handleSubmit = () => {
@@ -256,7 +264,10 @@ function InputBox(props: InputBoxProps) {
     (c) => !c.conversationTurnUuid,
   )
   const showTaskStateActions =
-    props.context.toolUseTaskState !== Mojom.TaskState.kNone
+    conversationState.capabilitiesEnabled.includes(
+      Mojom.ConversationCapability.CONTENT_AGENT,
+    )
+    && props.context.toolUseTaskState !== Mojom.TaskState.kNone
     && props.context.toolUseTaskState !== Mojom.TaskState.kStopped
   const isSendButtonDisabled =
     props.context.shouldDisableUserInput

--- a/components/ai_chat/resources/page/stories/components_panel.tsx
+++ b/components/ai_chat/resources/page/stories/components_panel.tsx
@@ -284,6 +284,7 @@ type CustomArgs = {
   initialized: boolean
   currentErrorState: keyof typeof Mojom.APIError
   toolUseTaskState: keyof typeof Mojom.TaskState
+  capabilitiesEnabled: Array<keyof typeof Mojom.ConversationCapability>
   model: string
   inputText: Content
   editingConversationId: string | null
@@ -331,6 +332,7 @@ const args: CustomArgs = {
   inputText: [
     `Write a Star Trek poem about Data's life on board the Enterprise`,
   ],
+  capabilitiesEnabled: ['CHAT'],
   conversationListCount: CONVERSATIONS.length,
   hasSuggestedQuestions: true,
   hasAssociatedContent: true,
@@ -392,6 +394,10 @@ const meta: Meta<CustomArgs> = {
     toolUseTaskState: {
       options: getKeysForMojomEnum(Mojom.TaskState),
       control: { type: 'select' },
+    },
+    capabilitiesEnabled: {
+      options: getKeysForMojomEnum(Mojom.ConversationCapability),
+      control: { type: 'multi-select' },
     },
     suggestionStatus: {
       options: getKeysForMojomEnum(Mojom.SuggestionGenerationStatus),
@@ -567,6 +573,9 @@ function StoryContext(
               temporary: argsRef.current.isTemporaryChat,
               toolUseTaskState:
                 Mojom.TaskState[argsRef.current.toolUseTaskState],
+              capabilitiesEnabled: argsRef.current.capabilitiesEnabled.map(
+                (value) => Mojom.ConversationCapability[value],
+              ),
             },
           })
         },
@@ -637,9 +646,9 @@ function StoryContext(
               canSubmitUserEntries: currentError === Mojom.APIError.None,
               allModels: MODELS,
               currentModelKey: currentModel?.key ?? '',
-              conversationCapabilities: [
-                Mojom.ConversationCapability.CONTENT_AGENT,
-              ],
+              conversationCapabilities: args.capabilitiesEnabled.map(
+                (value) => Mojom.ConversationCapability[value],
+              ),
             },
           }}
           overrides={{


### PR DESCRIPTION
It's a pretty cumbersome UI that is more suitable when the conversation is performing potentially disruptive actions, like using the browser.
- Send the current conversation capabilities to the UI (currently a static list, so does not need events to update)
- Test the UI is not shown for chat conversation (we already test that it does show for agent conversations)
- Don't set the ToolUseTaskState to RUNNING when we're waiting on user input (in the future we'll probably add a WAITING state)

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/55382

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
