### PR TITLE
[Ads] Defer bat_ads launch until PolicyService is initialized

### DIFF
--- a/browser/brave_ads/ads_service_factory.cc
+++ b/browser/brave_ads/ads_service_factory.cc
@@ -28,6 +28,7 @@
 #include "chrome/browser/history/history_service_factory.h"
 #include "chrome/browser/notifications/notification_display_service.h"
 #include "chrome/browser/notifications/notification_display_service_factory.h"
+#include "chrome/browser/policy/profile_policy_connector.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/profiles/profile_manager.h"
 #include "components/keyed_service/content/browser_context_dependency_manager.h"
@@ -132,6 +133,8 @@ AdsServiceFactory::BuildServiceInstanceForBrowserContext(
   ProfileManager* const profile_manager = g_browser_process->profile_manager();
   CHECK(profile_manager);
 
+  auto* profile_policy_connector = profile->GetProfilePolicyConnector();
+
   return std::make_unique<AdsServiceImpl>(
       std::move(delegate), *prefs, *local_state, std::move(http_client),
       std::make_unique<VirtualPrefProviderDelegate>(
@@ -143,7 +146,9 @@ AdsServiceFactory::BuildServiceInstanceForBrowserContext(
 #if BUILDFLAG(ENABLE_BRAVE_REWARDS)
       rewards_service,
 #endif
-      host_content_settings_map);
+      host_content_settings_map,
+      profile_policy_connector ? profile_policy_connector->policy_service()
+                               : nullptr);
 }
 
 bool AdsServiceFactory::ServiceIsNULLWhileTesting() const {

--- a/components/brave_ads/browser/BUILD.gn
+++ b/components/brave_ads/browser/BUILD.gn
@@ -38,6 +38,7 @@ static_library("browser") {
     "//brave/components/p3a_utils",
     "//brave/components/time_period_storage",
     "//components/content_settings/core/browser",
+    "//components/policy/core/common",
     "//components/pref_registry",
     "//components/prefs",
     "//components/sessions",

--- a/components/brave_ads/browser/DEPS
+++ b/components/brave_ads/browser/DEPS
@@ -4,6 +4,7 @@ include_rules = [
   "+components/content_settings",
   "+components/metrics",
   "+components/history",
+  "+components/policy",
   "+components/prefs",
   "+components/variations",
   "+content/public/browser",

--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -133,10 +133,12 @@ AdsServiceImpl::AdsServiceImpl(
 #if BUILDFLAG(ENABLE_BRAVE_REWARDS)
     brave_rewards::RewardsService* rewards_service,
 #endif
-    HostContentSettingsMap* host_content_settings_map)
+    HostContentSettingsMap* host_content_settings_map,
+    policy::PolicyService* policy_service)
     : AdsService(std::move(delegate)),
       prefs_(prefs),
       local_state_(local_state),
+      policy_service_(policy_service),
       virtual_pref_provider_(std::make_unique<VirtualPrefProvider>(
           prefs,
           local_state,
@@ -174,7 +176,20 @@ AdsServiceImpl::AdsServiceImpl(
   InitializeLocalStatePrefChangeRegistrar();
   InitializePrefChangeRegistrar();
 
-  MaybeStartBatAdsService();
+  // Defer the bat_ads launch until the PolicyService has finished loading
+  // policies for `POLICY_DOMAIN_CHROME`. Otherwise managed prefs that gate
+  // eligibility (e.g. `BraveRewardsDisabled` set by enterprise policy or by
+  // BraveOrigin) may not yet have propagated to the pref store, and bat_ads
+  // would launch even though it should be suppressed. Mirrors the upstream
+  // pattern in
+  // chrome/browser/extensions/forced_extensions/force_installed_tracker.cc.
+  if (!policy_service_ ||
+      policy_service_->IsInitializationComplete(policy::POLICY_DOMAIN_CHROME)) {
+    MaybeStartBatAdsService();
+  } else {
+    policy_service_->AddObserver(policy::POLICY_DOMAIN_CHROME, this);
+    is_observing_policy_service_ = true;
+  }
 }
 
 AdsServiceImpl::~AdsServiceImpl() = default;
@@ -1046,6 +1061,12 @@ void AdsServiceImpl::Shutdown() {
   // this is never reset to false.
   is_shutting_down_ = true;
 
+  if (is_observing_policy_service_) {
+    CHECK(policy_service_);
+    policy_service_->RemoveObserver(policy::POLICY_DOMAIN_CHROME, this);
+    is_observing_policy_service_ = false;
+  }
+
   ShutdownAdsService();
 }
 
@@ -1696,6 +1717,22 @@ void AdsServiceImpl::OnContentSettingChanged(
   if (content_type_set.Contains(ContentSettingsType::JAVASCRIPT)) {
     SetContentSettings();
   }
+}
+
+void AdsServiceImpl::OnPolicyServiceInitialized(policy::PolicyDomain domain) {
+  if (domain != policy::POLICY_DOMAIN_CHROME) {
+    return;
+  }
+  CHECK(policy_service_);
+  policy_service_->RemoveObserver(policy::POLICY_DOMAIN_CHROME, this);
+  is_observing_policy_service_ = false;
+
+  // Profile shutdown can race with this notification; respect it.
+  if (is_shutting_down_) {
+    return;
+  }
+
+  MaybeStartBatAdsService();
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/browser/ads_service_impl.h
+++ b/components/brave_ads/browser/ads_service_impl.h
@@ -40,6 +40,7 @@
 #include "components/content_settings/core/browser/content_settings_type_set.h"
 #include "components/content_settings/core/common/content_settings_pattern.h"
 #include "components/history/core/browser/history_service.h"
+#include "components/policy/core/common/policy_service.h"
 #include "components/prefs/pref_change_registrar.h"
 #include "mojo/public/cpp/bindings/associated_receiver.h"
 #include "mojo/public/cpp/bindings/associated_remote.h"
@@ -77,11 +78,13 @@ class AdsServiceImpl : public AdsService,
 #if BUILDFLAG(ENABLE_BRAVE_REWARDS)
                        public brave_rewards::RewardsServiceObserver,
 #endif
-                       public content_settings::Observer {
+                       public content_settings::Observer,
+                       public policy::PolicyService::Observer {
  public:
-  // `http_client`, `resource_component`, `history_service`, and
-  // `host_content_settings` can be `nullptr` in tests. `rewards_service`
-  // can be `nullptr` when Rewards is unsupported or disabled by policy.
+  // `http_client`, `resource_component`, `history_service`,
+  // `host_content_settings`, and `policy_service` can be `nullptr` in tests.
+  // `rewards_service` can be `nullptr` when Rewards is unsupported or disabled
+  // by policy.
   explicit AdsServiceImpl(
       std::unique_ptr<Delegate> delegate,
       PrefService& prefs,
@@ -99,7 +102,8 @@ class AdsServiceImpl : public AdsService,
 #if BUILDFLAG(ENABLE_BRAVE_REWARDS)
       brave_rewards::RewardsService* rewards_service,
 #endif
-      HostContentSettingsMap* host_content_settings);
+      HostContentSettingsMap* host_content_settings,
+      policy::PolicyService* policy_service);
 
   AdsServiceImpl(const AdsServiceImpl&) = delete;
   AdsServiceImpl& operator=(const AdsServiceImpl&) = delete;
@@ -389,6 +393,9 @@ class AdsServiceImpl : public AdsService,
       const ContentSettingsPattern& secondary_pattern,
       ContentSettingsTypeSet content_type_set) override;
 
+  // policy::PolicyService::Observer:
+  void OnPolicyServiceInitialized(policy::PolicyDomain domain) override;
+
   bool is_ineligible_to_start_ = false;
 
   bool is_bat_ads_initialized_ = false;
@@ -419,6 +426,14 @@ class AdsServiceImpl : public AdsService,
   const raw_ref<PrefService> prefs_;
 
   const raw_ref<PrefService> local_state_;
+
+  // Owned by the profile / browser process; may be `nullptr` in tests.
+  // When non-null, the service waits for this PolicyService to finish loading
+  // policies for `POLICY_DOMAIN_CHROME` before starting bat_ads, so that
+  // policy-driven prefs (e.g. `BraveRewardsDisabled`) are honored on first
+  // run instead of racing against eager service construction at profile init.
+  const raw_ptr<policy::PolicyService> policy_service_;
+  bool is_observing_policy_service_ = false;
 
   const std::unique_ptr<VirtualPrefProvider> virtual_pref_provider_;
 

--- a/components/brave_ads/browser/ads_service_impl_unittest.cc
+++ b/components/brave_ads/browser/ads_service_impl_unittest.cc
@@ -89,7 +89,8 @@ class BraveAdsAdsServiceImplTest : public testing::Test {
 #if BUILDFLAG(ENABLE_BRAVE_REWARDS)
         &rewards_service_,
 #endif  // BUILDFLAG(ENABLE_BRAVE_REWARDS)
-        /*host_content_settings_map=*/nullptr);
+        /*host_content_settings_map=*/nullptr,
+        /*policy_service=*/nullptr);
   }
 
   void TearDown() override {


### PR DESCRIPTION
## Summary

Make `AdsServiceImpl` observe `policy::PolicyService` and wait for `IsInitializationComplete(POLICY_DOMAIN_CHROME)` before launching the `bat_ads` utility process. Previously the constructor called `MaybeStartBatAdsService()` synchronously, which raced against the policy framework's managed-pref propagation at profile init — `bat_ads` would launch before policies that gate eligibility (e.g. `BraveRewardsDisabled` set by enterprise policy or by BraveOrigin) had landed in the pref store, so ads started for users where Rewards was policy-disabled.

Fixes both the desktop BraveOrigin race and the Android race (where Origin policies arrive even later, after JNI has requested the AdsService) with no BraveOrigin-specific knowledge in the ads code.

## Pattern

Mirrors [`chrome/browser/extensions/forced_extensions/force_installed_tracker.cc`](https://source.chromium.org/chromium/chromium/src/+/main:chrome/browser/extensions/forced_extensions/force_installed_tracker.cc): if the PolicyService is already initialized, run `MaybeStartBatAdsService` immediately; otherwise register an observer and proceed from `OnPolicyServiceInitialized`. Tests pass `nullptr` for `PolicyService`, falling back to immediate launch (matches prior behavior).

## Replaces

Supersedes the temporary workaround in #36276 (which read BraveOrigin local state directly to bypass the race). With this PR, the workaround is no longer needed because the gate now waits for the policy framework itself.

## Test plan

- [ ] Brave Origin purchased on desktop, default: ads service does not start.
- [ ] Brave Origin purchased, user toggles Rewards back on: ads service starts.
- [ ] Non-Origin user, no Rewards opt-in: ads service starts (NTP/SearchResult branch).
- [ ] Non-Origin user, opted into Rewards: ads service starts (joined-Rewards branch).
- [ ] Brave Origin purchased on Android: ads service does not start.
- [ ] Enterprise policy `BraveRewardsDisabled=true` on desktop: ads service does not start.