### PR TITLE
[plaster] Make `RequestType` insertions more generic

### DIFF
--- a/patches/components-permissions-request_type.h.patch
+++ b/patches/components-permissions-request_type.h.patch
@@ -1,11 +1,12 @@
 diff --git a/components/permissions/request_type.h b/components/permissions/request_type.h
-index 58cfbf485a12a3a3c5cc0bc5e4b822e88897a2a9..e047cafd23ad851ee75c9c22f84d35ef67a8c0a3 100644
+index 58cfbf485a12a3a3c5cc0bc5e4b822e88897a2a9..eb56617268aed770b715aaa11e18d63074eb6bcc 100644
 --- a/components/permissions/request_type.h
 +++ b/components/permissions/request_type.h
-@@ -64,6 +64,14 @@ enum class RequestType {
+@@ -72,7 +72,15 @@ enum class RequestType {
+   kWebPrinting,
  #endif
-   kSensors,
-   kStorageAccess,
+   kWindowManagement,
+-  kMaxValue = kWindowManagement
 +  kWidevine,
 +  kBraveEthereum,
 +  kBraveSolana,
@@ -14,6 +15,7 @@ index 58cfbf485a12a3a3c5cc0bc5e4b822e88897a2a9..e047cafd23ad851ee75c9c22f84d35ef
 +  kBraveCardano,
 +  kBraveMinValue = kWidevine,
 +  kBraveMaxValue = kBraveCardano,
-   kVrSession,
- #if !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_IOS)
-   kWebAppInstallation,
++  kMaxValue = kBraveCardano
+ };
+ 
+ #if BUILDFLAG(IS_ANDROID)

--- a/rewrite/components/permissions/request_type.h.toml
+++ b/rewrite/components/permissions/request_type.h.toml
@@ -4,9 +4,14 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
 [[substitution]]
-description = 'Add Brave-specific entries to `RequestType`'
-pattern = 'kStorageAccess,'
-replace = '''kStorageAccess,
+description = '''Append Brave-specific entries to `RequestType`
+
+This plaster is generic enough to guarantee that our entries are always last,
+and that they also become the new kMaxValue.
+'''
+re_pattern = '(enum class RequestType \{.+?,)(\s+)kMaxValue = \w+'
+re_flags = ['DOTALL']
+replace = '''\1
   kWidevine,
   kBraveEthereum,
   kBraveSolana,
@@ -14,4 +19,5 @@ replace = '''kStorageAccess,
   kBraveGoogleSignInPermission,
   kBraveCardano,
   kBraveMinValue = kWidevine,
-  kBraveMaxValue = kBraveCardano,'''
+  kBraveMaxValue = kBraveCardano,
+  kMaxValue = kBraveCardano'''


### PR DESCRIPTION
This PR changes the way we are patching `RequestType` to not have to
rely on any particular key, but just introduce our keys at the end of
the enum value. This technique allows for the replacemnt of `kMaxValue
to use the new value we provide.
