### PR TITLE
[plaster][android] Migrate `AUTOPLAY` patches

### DIFF
--- a/patches/chrome-android-java-src-org-chromium-chrome-browser-contextmenu-ChromeContextMenuItem.java.patch
+++ b/patches/chrome-android-java-src-org-chromium-chrome-browser-contextmenu-ChromeContextMenuItem.java.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/contextmenu/ChromeContextMenuItem.java b/chrome/android/java/src/org/chromium/chrome/browser/contextmenu/ChromeContextMenuItem.java
-index 0e7032634735c6f32404e69e3f302170bd66cb47..1b99751fb6ae7578d43de5dca1f01f561d9264b6 100644
+index 0e7032634735c6f32404e69e3f302170bd66cb47..5bba71b4fbf6f9e0bcf0de3b0ce55b0eecfa0cdf 100644
 --- a/chrome/android/java/src/org/chromium/chrome/browser/contextmenu/ChromeContextMenuItem.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/contextmenu/ChromeContextMenuItem.java
 @@ -78,6 +78,7 @@ class ChromeContextMenuItem {
@@ -10,16 +10,18 @@ index 0e7032634735c6f32404e69e3f302170bd66cb47..1b99751fb6ae7578d43de5dca1f01f56
      })
      @Retention(RetentionPolicy.SOURCE)
      public @interface Item {
-@@ -136,7 +137,7 @@ class ChromeContextMenuItem {
+@@ -135,8 +136,9 @@ class ChromeContextMenuItem {
+         // Developer Group
          int VIEW_PAGE_SOURCE = 41;
          int INSPECT_ELEMENT = 42;
++        int COPY_CLEAN_LINK = 43;
          // ALWAYS UPDATE!
 -        int NUM_ENTRIES = 43;
-+        int COPY_CLEAN_LINK = 43;int NUM_ENTRIES = 44;
++        int NUM_ENTRIES = COPY_CLEAN_LINK + 1;
      }
  
      /** Mapping from {@link Item} to the ID found in the ids.xml. */
-@@ -184,6 +185,7 @@ class ChromeContextMenuItem {
+@@ -184,6 +186,7 @@ class ChromeContextMenuItem {
          R.id.contextmenu_print_page, // Item.PRINT_PAGE
          R.id.contextmenu_view_page_source, // Item.VIEW_PAGE_SOURCE
          R.id.contextmenu_inspect_element, // Item.INSPECT_ELEMENT
@@ -27,7 +29,7 @@ index 0e7032634735c6f32404e69e3f302170bd66cb47..1b99751fb6ae7578d43de5dca1f01f56
      };
  
      /** Mapping from {@link Item} to the ID of the string that describes the action of the item. */
-@@ -231,6 +233,7 @@ class ChromeContextMenuItem {
+@@ -231,6 +234,7 @@ class ChromeContextMenuItem {
          R.string.contextmenu_print_page, // Item.PRINT_PAGE
          R.string.contextmenu_view_page_source, // Item.VIEW_PAGE_SOURCE
          R.string.contextmenu_inspect_element, // Item.INSPECT_ELEMENT

--- a/patches/chrome-android-java-src-org-chromium-chrome-browser-contextmenu-ChromeContextMenuPopulator.java.patch
+++ b/patches/chrome-android-java-src-org-chromium-chrome-browser-contextmenu-ChromeContextMenuPopulator.java.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/contextmenu/ChromeContextMenuPopulator.java b/chrome/android/java/src/org/chromium/chrome/browser/contextmenu/ChromeContextMenuPopulator.java
-index 5b16f302936cb92ebed8a0e0d4c7dc5bf05ceab1..f69e7abb9fceb76fd96874cbc563c7265499bbff 100644
+index 5b16f302936cb92ebed8a0e0d4c7dc5bf05ceab1..295c8ada54fdad817f69036a0d7f49336620f5ce 100644
 --- a/chrome/android/java/src/org/chromium/chrome/browser/contextmenu/ChromeContextMenuPopulator.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/contextmenu/ChromeContextMenuPopulator.java
 @@ -245,6 +245,7 @@ public class ChromeContextMenuPopulator implements ContextMenuPopulator {
@@ -10,16 +10,17 @@ index 5b16f302936cb92ebed8a0e0d4c7dc5bf05ceab1..f69e7abb9fceb76fd96874cbc563c726
          })
          @Retention(RetentionPolicy.SOURCE)
          public @interface Action {
-@@ -301,7 +302,7 @@ public class ChromeContextMenuPopulator implements ContextMenuPopulator {
+@@ -301,7 +302,8 @@ public class ChromeContextMenuPopulator implements ContextMenuPopulator {
              int EXIT_PICTURE_IN_PICTURE = 50;
              int OPEN_IN_INCOGNITO_WINDOW = 51;
              int VIEW_PAGE_SOURCE = 52;
 -            int NUM_ENTRIES = 53;
-+            int COPY_CLEAN_LINK = 53;int NUM_ENTRIES = 54;
++            int COPY_CLEAN_LINK = 53;
++            int NUM_ENTRIES = COPY_CLEAN_LINK + 1;
          }
  
          // LINT.ThenChange(/tools/metrics/histograms/enums.xml:ContextMenuOptionAndroid)
-@@ -539,6 +540,7 @@ public class ChromeContextMenuPopulator implements ContextMenuPopulator {
+@@ -539,6 +541,7 @@ public class ChromeContextMenuPopulator implements ContextMenuPopulator {
              if (!MailTo.isMailTo(mParams.getLinkUrl().getSpec())
                      && !UrlUtilities.isTelScheme(mParams.getLinkUrl())) {
                  linkGroup.add(createListItem(Item.COPY_LINK_ADDRESS));

--- a/patches/components-browser_ui-site_settings-android-java-src-org-chromium-components-browser_ui-site_settings-SiteSettingsCategory.java.patch
+++ b/patches/components-browser_ui-site_settings-android-java-src-org-chromium-components-browser_ui-site_settings-SiteSettingsCategory.java.patch
@@ -1,21 +1,26 @@
 diff --git a/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/SiteSettingsCategory.java b/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/SiteSettingsCategory.java
-index d335c6e2ea9edc45acd7af8e25d2d356a0063e30..0778c602f8a0d3c1b8de4c9e3eac01c7c8cfacdc 100644
+index d335c6e2ea9edc45acd7af8e25d2d356a0063e30..9735dd0da81be01ddcbc4b6c58fffbfc7018b237 100644
 --- a/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/SiteSettingsCategory.java
 +++ b/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/SiteSettingsCategory.java
-@@ -83,6 +83,7 @@ public class SiteSettingsCategory {
+@@ -83,6 +83,8 @@ public class SiteSettingsCategory {
          Type.AUTO_PICTURE_IN_PICTURE,
          Type.LOCAL_NETWORK,
          Type.LOOPBACK_NETWORK,
-+        Type.AUTOPLAY, Type.BRAVE_GOOGLE_SIGN_IN,
++        Type.AUTOPLAY,
++        Type.BRAVE_GOOGLE_SIGN_IN,
          Type.NUM_ENTRIES
      })
      @Retention(RetentionPolicy.SOURCE)
-@@ -130,7 +131,7 @@ public class SiteSettingsCategory {
+@@ -128,9 +130,11 @@ public class SiteSettingsCategory {
+         int AUTO_PICTURE_IN_PICTURE = 36;
+         int LOCAL_NETWORK = 37;
          int LOOPBACK_NETWORK = 38;
++        int AUTOPLAY = 39;
++        int BRAVE_GOOGLE_SIGN_IN = AUTOPLAY + 1;
  
          /** Number of handled categories used for calculating array sizes. */
 -        int NUM_ENTRIES = 39;
-+        int AUTOPLAY = 39; int BRAVE_GOOGLE_SIGN_IN = 40; int NUM_ENTRIES = 41;
++        int NUM_ENTRIES = BRAVE_GOOGLE_SIGN_IN + 1;
      }
  
      private final BrowserContextHandle mBrowserContextHandle;

--- a/rewrite/chrome/android/java/src/org/chromium/chrome/browser/contextmenu/ChromeContextMenuItem.java.toml
+++ b/rewrite/chrome/android/java/src/org/chromium/chrome/browser/contextmenu/ChromeContextMenuItem.java.toml
@@ -1,0 +1,45 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+[[substitution]]
+description = 'Register COPY_CLEAN_LINK at the end of the @IntDef list'
+re_pattern = '(@IntDef\(\{.+?),?(\n\s*\}\))'
+re_flags = ['DOTALL']
+replace = '''\1,
+        Item.COPY_CLEAN_LINK,\2'''
+
+[[substitution]]
+description = '''Define COPY_CLEAN_LINK at the end of @interface Item
+
+A `// ALWAYS UPDATE!` comment sits between the last upstream entry and the
+sentinel, so we capture it separately (`\2`) and keep it adjacent to
+`NUM_ENTRIES`. The indent before `NUM_ENTRIES` is captured into `\3` and
+reused for the inserted line, instead of hardcoding it.
+
+```
+int COPY_CLEAN_LINK = 43;
+// ALWAYS UPDATE!
+int NUM_ENTRIES = COPY_CLEAN_LINK + 1;
+```
+
+Notice that the value for `COPY_CLEAN_LINK` is being whatever was the value for
+`NUM_ENTRIES`, which allows us to take over the end of the list.
+'''
+re_pattern = '(@interface Item \{.+;\n)(.+?\n)(\s+)int NUM_ENTRIES = (\d+);'
+re_flags = ['DOTALL']
+replace = '''\1\3int COPY_CLEAN_LINK = \4;
+\2\3int NUM_ENTRIES = COPY_CLEAN_LINK + 1;'''
+
+[[substitution]]
+description = 'Append COPY_CLEAN_LINK at the end of the MENU_IDS array'
+re_pattern = '(int\[\] MENU_IDS = \{[^}]+\n)([^}]+\};)'
+replace = '''\1        R.id.contextmenu_copy_clean_link, // Item.COPY_CLEAN_LINK
+\2'''
+
+[[substitution]]
+description = 'Append COPY_CLEAN_LINK at the end of the STRING_IDS array'
+re_pattern = '(int\[\] STRING_IDS = \{[^}]+\n)([^}]+\};)'
+replace = '''\1        R.string.contextmenu_copy_clean_link, // Item.COPY_CLEAN_LINK
+\2'''

--- a/rewrite/chrome/android/java/src/org/chromium/chrome/browser/contextmenu/ChromeContextMenuPopulator.java.toml
+++ b/rewrite/chrome/android/java/src/org/chromium/chrome/browser/contextmenu/ChromeContextMenuPopulator.java.toml
@@ -1,0 +1,28 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+[[substitution]]
+description = 'Register COPY_CLEAN_LINK at the end of the Action @IntDef list'
+re_pattern = '(@IntDef\(\{[^}]*Action\..+?),?(\n\s*\}\))'
+re_flags = ['DOTALL']
+replace = '''\1,
+            Action.COPY_CLEAN_LINK,\2'''
+
+[[substitution]]
+description = '''Define COPY_CLEAN_LINK at the end of @interface Action
+
+Notice that the value for `COPY_CLEAN_LINK` is being whatever was the value for
+`NUM_ENTRIES`, which allows us to take over the end of the list.
+'''
+re_pattern = '(@interface Action \{.+?;\n)(\s+)int NUM_ENTRIES = (\d+);'
+re_flags = ['DOTALL']
+replace = '''\1\2int COPY_CLEAN_LINK = \3;
+\2int NUM_ENTRIES = COPY_CLEAN_LINK + 1;'''
+
+[[substitution]]
+description = 'Append the COPY_CLEAN_LINK list item after COPY_LINK_ADDRESS'
+pattern = 'linkGroup.add(createListItem(Item.COPY_LINK_ADDRESS));'
+replace = '''linkGroup.add(createListItem(Item.COPY_LINK_ADDRESS));
+                linkGroup.add(createListItem(Item.COPY_CLEAN_LINK));'''

--- a/rewrite/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/SiteSettingsCategory.java.toml
+++ b/rewrite/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/SiteSettingsCategory.java.toml
@@ -1,0 +1,29 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+[[substitution]]
+description = 'Register AUTOPLAY and BRAVE_GOOGLE_SIGN_IN in the @IntDef list'
+re_pattern = '(@IntDef\(\{.+,)(.+?\}\))'
+re_flags = ['DOTALL']
+replace = '''\1
+        Type.AUTOPLAY,
+        Type.BRAVE_GOOGLE_SIGN_IN,\2'''
+
+[[substitution]]
+description = '''Define AUTOPLAY and BRAVE_GOOGLE_SIGN_IN at the end of Type
+
+A javadoc comment describing NUM_ENTRIES sits between the last upstream entry
+and the sentinel, so we capture it separately (`\2`) and keep it adjacent to
+`NUM_ENTRIES`. The indent before `NUM_ENTRIES` is captured into `\3` and
+reused for the inserted lines, instead of hardcoding it.
+
+The prior value of `NUM_ENTRIES` is replaced to cascade over the keys we are
+inserting.
+'''
+re_pattern = '(@interface Type \{.+;\n)(.+?\n)(\s+)int NUM_ENTRIES = (\d+);'
+re_flags = ['DOTALL']
+replace = '''\1\3int AUTOPLAY = \4;
+\3int BRAVE_GOOGLE_SIGN_IN = AUTOPLAY + 1;
+\2\3int NUM_ENTRIES = BRAVE_GOOGLE_SIGN_IN + 1;'''


### PR DESCRIPTION
This PR migrates several java patches for `AUTOPLAY` to plaster. It uses
the same previous techniques, where we match the enum block and add at
the end.

The only innovation in this PR as an approach for plaster is the
replacement of the value `NUM_ENTRIES` with `+1` for whatever keys we
are inserting, while at the same time using the previous value of
`NUM_ENTRIES` as the starting value for the first key.

Resolved https://github.com/brave/brave-browser/issues/55385
