### PR TITLE
Improve brave_interactive_ui_tests target

### DIFF
--- a/chromium_src/chrome/test/base/interactive_ui_tests_main.cc
+++ b/chromium_src/chrome/test/base/interactive_ui_tests_main.cc
@@ -1,0 +1,12 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/test/base/brave_test_launcher_delegate.h"
+
+#define ChromeTestLauncherDelegate BraveTestLauncherDelegate
+
+#include <chrome/test/base/interactive_ui_tests_main.cc>
+
+#undef ChromeTestLauncherDelegate

--- a/chromium_src/chrome/test/base/interactive_ui_tests_main.cc
+++ b/chromium_src/chrome/test/base/interactive_ui_tests_main.cc
@@ -5,6 +5,9 @@
 
 #include "brave/test/base/brave_test_launcher_delegate.h"
 
+// Apply Brave-specific behavior change in the test launcher delegate.
+// * Suppress first run dialog (Mac/Linux).
+// * Suppress browser window closing dialog.
 #define ChromeTestLauncherDelegate BraveTestLauncherDelegate
 
 #include <chrome/test/base/interactive_ui_tests_main.cc>

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -760,6 +760,7 @@ if (!is_android) {
     sources = [ "//chrome/test/base/interactive_ui_tests_main.cc" ]
 
     deps = [
+      ":browser_test_support",
       "//brave:packed_resources",
       "//chrome:packed_resources",
       "//chrome/browser",
@@ -769,6 +770,10 @@ if (!is_android) {
       "//ui/base/interaction",
       "//ui/compositor",
     ]
+
+    if (is_win) {
+      deps += [ "//chrome/installer/util:strings" ]
+    }
 
     if (enable_commander) {
       deps += [ "//brave/browser/ui/commander:interactive_ui_tests" ]


### PR DESCRIPTION
* Added missing //chrome/installer/util:strings deps on Windows - some installer strings are used in admin user
* Used BraveTestLauncherDelegate

Failure log from Windows CI

```
01:09:59  	brave_interactive_ui_tests!base::debug::CollectStackTrace [0x7ff7acef712a+3a] (D:\ws\x64-nightly\src\base\debug\stack_trace_win.cc:383)
01:09:59  	brave_interactive_ui_tests!base::debug::StackTrace::StackTrace [0x7ff7acf1cb46+e6] (D:\ws\x64-nightly\src\base\debug\stack_trace.cc:275)
01:09:59  	brave_interactive_ui_tests!logging::LogMessage::Flush [0x7ff7ad1da6da+2fa] (D:\ws\x64-nightly\src\base\logging.cc:708)
01:09:59  	brave_interactive_ui_tests!logging::LogMessage::~LogMessage [0x7ff7ad1da279+39] (D:\ws\x64-nightly\src\base\logging.cc:698)
01:09:59  	brave_interactive_ui_tests!logging::`anonymous namespace'::NotReachedLogMessage::~NotReachedLogMessage [0x7ff7ad22cea3+b3] (D:\ws\x64-nightly\src\base\check.cc:160)
01:09:59  	brave_interactive_ui_tests!logging::NotReachedNoreturnError::~NotReachedNoreturnError [0x7ff7ad22becb+b] (D:\ws\x64-nightly\src\base\check.cc:363)
01:09:59  	brave_interactive_ui_tests!installer::GetLocalizedString [0x7ff7c3051095+b05] (D:\ws\x64-nightly\src\chrome\installer\util\l10n_string_util.cc:79)
01:09:59  	brave_interactive_ui_tests!installer::FirewallManager::Create [0x7ff7c3061863+133] (D:\ws\x64-nightly\src\chrome\installer\util\firewall_manager_win.cc:71)
01:09:59  	brave_interactive_ui_tests!ChromeTestLauncherDelegate::ScopedFirewallRules::ScopedFirewallRules [0x7ff7acbefe96+1d6] (D:\ws\x64-nightly\src\chrome\test\base\chrome_test_launcher.cc:118)
01:09:59  	brave_interactive_ui_tests!ChromeTestLauncherDelegate::PreSharding [0x7ff7acbeeaa0+3c0] (D:\ws\x64-nightly\src\chrome\test\base\chrome_test_launcher.cc:270)
01:09:59  	brave_interactive_ui_tests!InteractiveUITestLauncherDelegate::PreSharding [0x7ff7977419e9+9] (D:\ws\x64-nightly\src\chrome\test\base\interactive_ui_tests_main.cc:115)
01:09:59  	brave_interactive_ui_tests!content::LaunchTestsInternal [0x7ff7c709a894+a34] (D:\ws\x64-nightly\src\content\public\test\test_launcher.cc:458)
01:09:59  	brave_interactive_ui_tests!content::LaunchTests [0x7ff7c709b0da+21a] (D:\ws\x64-nightly\src\content\public\test\test_launcher.cc:518)
01:09:59  	brave_interactive_ui_tests!LaunchChromeTests [0x7ff7acbef02a+23a] (D:\ws\x64-nightly\src\chrome\test\base\chrome_test_launcher.cc:360)
01:09:59  	brave_interactive_ui_tests!main [0x7ff79774143f+1ff] (D:\ws\x64-nightly\src\chrome\test\base\interactive_ui_tests_main.cc:209)
01:09:59  	brave_interactive_ui_tests!__scrt_common_main_seh [0x7ff7c9393498+10c] (D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288)
01:09:59  	KERNEL32!BaseThreadInitThunk [0x7ff8d29ee8d7+17]
01:09:59  	ntdll!RtlUserThreadStart [0x7ff8d3cac53c+2c]
```

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves: F/U PR for https://github.com/brave/brave-core/pull/35617

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
