### PR TITLE
Harden Brave News display ad targets to https only

### DIFF
--- a/components/brave_new_tab_ui/components/default/braveNews/cards/displayAd/index.tsx
+++ b/components/brave_new_tab_ui/components/default/braveNews/cards/displayAd/index.tsx
@@ -22,6 +22,14 @@ type Props = {
   onViewedDisplayAd: OnViewedDisplayAd
 }
 
+function getHttpsUrlOrUndefined(url: string): string | undefined {
+  try {
+    return new URL(url).protocol === 'https:' ? url : undefined
+  } catch {
+    return undefined
+  }
+}
+
 export default function CardDisplayAd (props: Props) {
   // Content is retrieved when the element is close to the viewport
   const [content, setContent] = React.useState<DisplayAd | undefined | null>(undefined)
@@ -68,7 +76,7 @@ export default function CardDisplayAd (props: Props) {
       <Styles.BatAdLabel href='chrome://rewards'>
         {getLocale('braveNewsDisplayAdLabel')}
       </Styles.BatAdLabel>
-      <a onClick={onClick} href={content.targetUrl.url} ref={cardRef}>
+      <a onClick={onClick} href={getHttpsUrlOrUndefined(content.targetUrl.url)} ref={cardRef}>
         <CardImage
           imageUrl={imageUrl}
           isPromoted={true}

--- a/components/brave_new_tab_ui/components/default/braveNews/useReadArticleClickHandler.test.tsx
+++ b/components/brave_new_tab_ui/components/default/braveNews/useReadArticleClickHandler.test.tsx
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import * as React from 'react'
+import { renderHook } from '@testing-library/react'
+import { useVisitDisplayAdClickHandler } from './useReadArticleClickHandler'
+
+describe('useVisitDisplayAdClickHandler', () => {
+  const makePayload = (url: string) => ({
+    ad: {
+      targetUrl: { url },
+    },
+  }) as any
+
+  const makeEvent = (overrides?: Partial<React.MouseEvent>) => ({
+    preventDefault: jest.fn(),
+    ctrlKey: false,
+    metaKey: false,
+    ...overrides,
+  }) as React.MouseEvent
+
+  it('dispatches for https ad target URLs', () => {
+    const action = jest.fn()
+    const payload = makePayload('https://brave.com')
+    const { result } = renderHook(() => useVisitDisplayAdClickHandler(action, payload))
+
+    const event = makeEvent({ ctrlKey: true })
+    result.current(event)
+
+    expect(event.preventDefault).toHaveBeenCalledTimes(1)
+    expect(action).toHaveBeenCalledTimes(1)
+    expect(action).toHaveBeenCalledWith({
+      ...payload,
+      openInNewTab: true,
+    })
+  })
+
+  it.each([
+    'http://example.com',
+    'chrome://settings',
+    'brave://settings',
+    'file:///tmp/example.txt',
+    'javascript:alert(1)',
+  ])('rejects non-https ad target URL: %s', (url) => {
+    const action = jest.fn()
+    const payload = makePayload(url)
+    const { result } = renderHook(() => useVisitDisplayAdClickHandler(action, payload))
+
+    const event = makeEvent()
+    expect(() => result.current(event)).toThrow('Unsupported scheme')
+    expect(action).not.toHaveBeenCalled()
+  })
+})

--- a/components/brave_new_tab_ui/components/default/braveNews/useReadArticleClickHandler.ts
+++ b/components/brave_new_tab_ui/components/default/braveNews/useReadArticleClickHandler.ts
@@ -4,8 +4,11 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import * as React from 'react'
+import { validateScheme } from '$web-common/SecureLink'
 import { ReadFeedItemPayload, VisitDisplayAdPayload } from '../../../actions/today_actions'
 import { OnReadFeedItem, OnVisitDisplayAd } from './'
+
+const displayAdTargetAllowedSchemes = ['https:']
 
 export default function useReadArticleClickHandler (action: OnReadFeedItem, payloadData: ReadFeedItemPayload) {
   return React.useCallback((e: React.MouseEvent) => {
@@ -21,6 +24,9 @@ export function useVisitDisplayAdClickHandler (action: OnVisitDisplayAd, payload
     if (!payloadData) {
       return
     }
+
+    validateScheme(payloadData.ad.targetUrl.url, displayAdTargetAllowedSchemes)
+
     const shouldOpenInNewTab = detectShouldOpenInNewTab(e)
     action({ ...payloadData, openInNewTab: shouldOpenInNewTab })
   }, [action, payloadData])

--- a/components/brave_news/browser/resources/feed/Ad.tsx
+++ b/components/brave_news/browser/resources/feed/Ad.tsx
@@ -71,7 +71,7 @@ export const useVisibleFor = (callback: () => void, timeout: number) => {
   }
 }
 
-const adTargetUrlAllowedSchemes = ['https:', 'chrome:', 'brave:']
+const adTargetUrlAllowedSchemes = ['https:']
 
 export default function Advert(props: Props) {
   const [advert, setAdvert] = React.useState<DisplayAd | null | undefined>(undefined)

--- a/components/brave_news/browser/resources/feed/Card.test.ts
+++ b/components/brave_news/browser/resources/feed/Card.test.ts
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import * as React from 'react'
+import { braveNewsCardClickHandler } from './Card'
+
+jest.mock('../shared/configurationCache', () => ({
+  ConfigurationCachingWrapper: {
+    getInstance: () => ({
+      value: {
+        openArticlesInNewTab: false,
+      },
+    }),
+  },
+}))
+
+describe('braveNewsCardClickHandler', () => {
+  const makeEvent = (overrides?: Partial<React.MouseEvent>) => ({
+    ctrlKey: false,
+    metaKey: false,
+    buttons: 0,
+    ...overrides,
+  }) as React.MouseEvent
+
+  it('allows https ad targets when https is allowlisted', () => {
+    const openSpy = jest.spyOn(window, 'open').mockImplementation(() => null)
+
+    const handler = braveNewsCardClickHandler('https://brave.com', ['https:'])
+    handler(makeEvent({ ctrlKey: true }))
+
+    expect(openSpy).toHaveBeenCalledWith(
+      'https://brave.com',
+      '_blank',
+      'noopener noreferrer'
+    )
+  })
+
+  it.each([
+    'http://example.com',
+    'chrome://settings',
+    'brave://settings',
+    'file:///tmp/example.txt',
+    'javascript:alert(1)',
+  ])('rejects disallowed ad target scheme: %s', (url) => {
+    const handler = braveNewsCardClickHandler(url, ['https:'])
+
+    expect(() => handler(makeEvent())).toThrow('Unsupported scheme')
+  })
+})


### PR DESCRIPTION
## Summary
- restrict Brave News display ad payload targets to `https:` in modern feed ads
- harden legacy New Tab display-ad click path by validating ad payload URL scheme before dispatch
- keep internal rewards badge link behavior separate from ad payload URL handling

## Why
Display ads should not be able to drive arbitrary internal browser URLs (`chrome:`/`brave:`) via ad payload data. This change narrows ad payload navigation to `https:` only.

## Linked issue
- Fixes brave/brave-browser#55393

## Scope fence (anti-slop)
- changed only ad-target scheme handling and direct tests for that behavior
- no refactors of adjacent ad rendering/tracking code
- no API shape changes

## Tests
- added unit test: `components/brave_news/browser/resources/feed/Card.test.ts`
  - allows `https:` when explicitly allowlisted
  - rejects `http:`, `chrome:`, `brave:`, `file:`, `javascript:`
- added unit test: `components/brave_new_tab_ui/components/default/braveNews/useReadArticleClickHandler.test.tsx`
  - dispatches visit action for `https:` payload URL
  - rejects non-`https:` payload URLs

## Manual verification status
- Local automated test execution is currently blocked in this checkout (`jest: command not found`).
- VS Code diagnostics on touched files show no errors.
