### PR TITLE
Fix VisibilityTimer visibilitychange handling

### DIFF
--- a/components/common/visibilityTimer.test.ts
+++ b/components/common/visibilityTimer.test.ts
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import VisibilityTimer from './visibilityTimer'
+
+describe('VisibilityTimer', () => {
+  function setVisibilityState(state: DocumentVisibilityState) {
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      value: state,
+    })
+  }
+
+  beforeEach(() => {
+    jest.useFakeTimers()
+    setVisibilityState('visible')
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('does not fire while hidden and resumes after visible', () => {
+    const onTimerExpired = jest.fn()
+    const timer = new VisibilityTimer(onTimerExpired, 1000)
+
+    timer.startTracking()
+
+    setVisibilityState('hidden')
+    document.dispatchEvent(new Event('visibilitychange'))
+    jest.advanceTimersByTime(1500)
+    expect(onTimerExpired).not.toHaveBeenCalled()
+
+    setVisibilityState('visible')
+    document.dispatchEvent(new Event('visibilitychange'))
+    jest.advanceTimersByTime(999)
+    expect(onTimerExpired).not.toHaveBeenCalled()
+
+    jest.advanceTimersByTime(1)
+    expect(onTimerExpired).toHaveBeenCalledTimes(1)
+
+    timer.stopTracking()
+  })
+})

--- a/components/common/visibilityTimer.ts
+++ b/components/common/visibilityTimer.ts
@@ -32,7 +32,7 @@ export default class VisibilityTimer {
 
   startTracking () {
     document.addEventListener(
-      'visiblitychange',
+      'visibilitychange',
       this.handleVisibility
     )
     if (this.intersectionObserver && this.element) {
@@ -45,7 +45,7 @@ export default class VisibilityTimer {
     this.resetTimer()
     // Stop tracking visibility.
     document.removeEventListener(
-      'visiblitychange',
+      'visibilitychange',
       this.handleVisibility
     )
     if (this.intersectionObserver && this.element) {


### PR DESCRIPTION
## Summary
- fix typo in `VisibilityTimer` event listener from `visiblitychange` to `visibilitychange`
- add focused regression test to verify hidden state pauses timer and visible state resumes it

## Why
The typo prevented document visibility events from reaching `VisibilityTimer`, allowing view timers to continue while hidden.

## Linked issue
- Fixes brave/brave-browser#55394

## Scope fence (anti-slop)
- only listener event string and targeted unit test were changed
- no behavior refactor outside existing timer lifecycle
- no consumer-side changes in ad/article components

## Tests
- added unit test: `components/common/visibilityTimer.test.ts`
  - starts timer while visible
  - dispatches `visibilitychange` to hidden and verifies callback does not fire past threshold
  - dispatches `visibilitychange` back to visible and verifies timer resumes and callback fires

## Manual verification status
- Local automated test execution is currently blocked in this checkout (`jest: command not found`).
- VS Code diagnostics on touched files show no errors.
