### PR TITLE
Respect vertical tabs on right for toggle placement

### DIFF
--- a/browser/ui/views/toolbar/brave_toolbar_view.cc
+++ b/browser/ui/views/toolbar/brave_toolbar_view.cc
@@ -674,9 +674,13 @@ void BraveToolbarView::UpdateVerticalTabTogglePlacement() {
     return;
   }
 
-  DCHECK(location_bar_view_ && location_bar_view_->parent());
+  CHECK(location_bar_view_);
+  CHECK(location_bar_view_->parent());
   views::View* container_view = location_bar_view_->parent();
 
+  // The toggle may not yet be parented to `container_view` during early
+  // initialization or if it was removed by another flow; bail out instead of
+  // reordering an unrelated view.
   const std::optional<size_t> toggle_idx =
       container_view->GetIndexOf(vertical_tab_toggle_);
   if (!toggle_idx.has_value()) {
@@ -685,12 +689,17 @@ void BraveToolbarView::UpdateVerticalTabTogglePlacement() {
 
   size_t target_idx = 0;
   if (tabs::utils::IsVerticalTabOnRight(browser_)) {
+    // Place the toggle just before the app menu. If the menu isn't in the
+    // container yet, or is already the first child, there is no valid slot
+    // to the left of it.
     const auto menu_idx = container_view->GetIndexOf(GetAppMenuButton());
     if (!menu_idx.has_value() || *menu_idx == 0) {
       return;
     }
     target_idx = *menu_idx - 1;
   } else {
+    // Place the toggle just before the back button. If back isn't a direct
+    // child of the container yet, defer placement until it is.
     const auto back_idx = container_view->GetIndexOf(back_);
     if (!back_idx.has_value()) {
       return;

--- a/browser/ui/views/toolbar/brave_toolbar_view.cc
+++ b/browser/ui/views/toolbar/brave_toolbar_view.cc
@@ -270,6 +270,7 @@ void BraveToolbarView::Init() {
                                  [](BraveToolbarView* self) {
                                    self->UpdateHorizontalPadding();
                                    self->UpdateVerticalTabToggleVisibility();
+                                   self->UpdateVerticalTabTogglePlacement();
                                  },
                                  base::Unretained(this)));
     show_title_bar_on_vertical_tabs_.Init(
@@ -280,6 +281,10 @@ void BraveToolbarView::Init() {
     vertical_tabs_collapsed_.Init(
         brave_tabs::kVerticalTabsCollapsed, profile->GetPrefs(),
         base::BindRepeating(&BraveToolbarView::UpdateVerticalTabToggleState,
+                            base::Unretained(this)));
+    vertical_tabs_on_right_.Init(
+        brave_tabs::kVerticalTabsOnRight, profile->GetPrefs(),
+        base::BindRepeating(&BraveToolbarView::UpdateVerticalTabTogglePlacement,
                             base::Unretained(this)));
 #if BUILDFLAG(IS_LINUX)
     use_custom_chrome_frame_.Init(
@@ -381,6 +386,8 @@ void BraveToolbarView::Init() {
     container_view->ReorderChildView(
         avatar, *container_view->GetIndexOf(GetAppMenuButton()) - 1);
   }
+
+  UpdateVerticalTabTogglePlacement();
 
   brave_initialized_ = true;
   UpdateHorizontalPadding();
@@ -660,6 +667,42 @@ void BraveToolbarView::UpdateVerticalTabToggleVisibility() {
 
   vertical_tab_toggle_->SetVisible(
       tabs::utils::ShouldShowBraveVerticalTabs(browser_));
+}
+
+void BraveToolbarView::UpdateVerticalTabTogglePlacement() {
+  if (!vertical_tab_toggle_ || display_mode_ != DisplayMode::kNormal) {
+    return;
+  }
+
+  DCHECK(location_bar_view_ && location_bar_view_->parent());
+  views::View* container_view = location_bar_view_->parent();
+
+  const std::optional<size_t> toggle_idx =
+      container_view->GetIndexOf(vertical_tab_toggle_);
+  if (!toggle_idx.has_value()) {
+    return;
+  }
+
+  size_t target_idx = 0;
+  if (tabs::utils::IsVerticalTabOnRight(browser_)) {
+    const auto menu_idx = container_view->GetIndexOf(GetAppMenuButton());
+    if (!menu_idx.has_value() || *menu_idx == 0) {
+      return;
+    }
+    target_idx = *menu_idx - 1;
+  } else {
+    const auto back_idx = container_view->GetIndexOf(back_);
+    if (!back_idx.has_value()) {
+      return;
+    }
+    target_idx = *back_idx > 0 ? *back_idx - 1 : 0;
+  }
+
+  if (*toggle_idx == target_idx) {
+    return;
+  }
+
+  container_view->ReorderChildView(vertical_tab_toggle_, target_idx);
 }
 
 void BraveToolbarView::UpdateVerticalTabToggleState() {

--- a/browser/ui/views/toolbar/brave_toolbar_view.cc
+++ b/browser/ui/views/toolbar/brave_toolbar_view.cc
@@ -692,9 +692,11 @@ void BraveToolbarView::UpdateVerticalTabTogglePlacement() {
     CHECK_GT(*menu_idx, 0u);
     target_idx = *menu_idx - 1;
   } else {
-    const auto back_idx = container_view->GetIndexOf(back_);
-    CHECK(back_idx.has_value());
-    target_idx = *back_idx > 0 ? *back_idx - 1 : 0;
+    // Pin index 0 for the leading edge so placement does not depend on the
+    // back button's child index (forward is pinnable today; back could become
+    // pinnable upstream). Computing `back_idx - 1` would risk CHECK failures or
+    // surprising order if navigation-button pinning changes.
+    target_idx = 0;
   }
 
   if (*toggle_idx == target_idx) {

--- a/browser/ui/views/toolbar/brave_toolbar_view.cc
+++ b/browser/ui/views/toolbar/brave_toolbar_view.cc
@@ -387,7 +387,9 @@ void BraveToolbarView::Init() {
         avatar, *container_view->GetIndexOf(GetAppMenuButton()) - 1);
   }
 
-  UpdateVerticalTabTogglePlacement();
+  if (tabs::utils::SupportsBraveVerticalTabs(browser_)) {
+    UpdateVerticalTabTogglePlacement();
+  }
 
   brave_initialized_ = true;
   UpdateHorizontalPadding();
@@ -670,40 +672,28 @@ void BraveToolbarView::UpdateVerticalTabToggleVisibility() {
 }
 
 void BraveToolbarView::UpdateVerticalTabTogglePlacement() {
-  if (!vertical_tab_toggle_ || display_mode_ != DisplayMode::kNormal) {
-    return;
-  }
-
+  // Callers must gate on `SupportsBraveVerticalTabs(browser_)`, which both
+  // ensures we're in `DisplayMode::kNormal` (other modes early-return from
+  // `Init()` before the toggle is created) and guarantees the toggle has
+  // been added as a child of `container_view`.
+  CHECK(vertical_tab_toggle_);
   CHECK(location_bar_view_);
   CHECK(location_bar_view_->parent());
   views::View* container_view = location_bar_view_->parent();
 
-  // The toggle may not yet be parented to `container_view` during early
-  // initialization or if it was removed by another flow; bail out instead of
-  // reordering an unrelated view.
   const std::optional<size_t> toggle_idx =
       container_view->GetIndexOf(vertical_tab_toggle_);
-  if (!toggle_idx.has_value()) {
-    return;
-  }
+  CHECK(toggle_idx.has_value());
 
   size_t target_idx = 0;
   if (tabs::utils::IsVerticalTabOnRight(browser_)) {
-    // Place the toggle just before the app menu. If the menu isn't in the
-    // container yet, or is already the first child, there is no valid slot
-    // to the left of it.
     const auto menu_idx = container_view->GetIndexOf(GetAppMenuButton());
-    if (!menu_idx.has_value() || *menu_idx == 0) {
-      return;
-    }
+    CHECK(menu_idx.has_value());
+    CHECK_GT(*menu_idx, 0u);
     target_idx = *menu_idx - 1;
   } else {
-    // Place the toggle just before the back button. If back isn't a direct
-    // child of the container yet, defer placement until it is.
     const auto back_idx = container_view->GetIndexOf(back_);
-    if (!back_idx.has_value()) {
-      return;
-    }
+    CHECK(back_idx.has_value());
     target_idx = *back_idx > 0 ? *back_idx - 1 : 0;
   }
 

--- a/browser/ui/views/toolbar/brave_toolbar_view.cc
+++ b/browser/ui/views/toolbar/brave_toolbar_view.cc
@@ -12,6 +12,7 @@
 #include "base/check.h"
 #include "base/check_op.h"
 #include "base/functional/bind.h"
+#include "base/i18n/rtl.h"
 #include "brave/app/brave_command_ids.h"
 #include "brave/app/vector_icons/vector_icons.h"
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
@@ -685,8 +686,18 @@ void BraveToolbarView::UpdateVerticalTabTogglePlacement() {
       container_view->GetIndexOf(vertical_tab_toggle_);
   CHECK(toggle_idx.has_value());
 
+  // The vertical tab strip is placed by physical position and does not mirror
+  // in RTL: `kVerticalTabsOnRight` means physically right regardless of UI
+  // direction. The toolbar container, however, lays out children with a
+  // horizontal `views::FlexLayout` which mirrors logical child indices in RTL
+  // (logical index 0 renders on the visual right). To keep the toggle on the
+  // same physical side as the strip, invert the placement choice when the UI
+  // is RTL.
+  const bool place_near_app_menu =
+      tabs::utils::IsVerticalTabOnRight(browser_) != base::i18n::IsRTL();
+
   size_t target_idx = 0;
-  if (tabs::utils::IsVerticalTabOnRight(browser_)) {
+  if (place_near_app_menu) {
     const auto menu_idx = container_view->GetIndexOf(GetAppMenuButton());
     CHECK(menu_idx.has_value());
     CHECK_GT(*menu_idx, 0u);

--- a/browser/ui/views/toolbar/brave_toolbar_view.h
+++ b/browser/ui/views/toolbar/brave_toolbar_view.h
@@ -77,6 +77,7 @@ class BraveToolbarView : public ToolbarView,
   void ResetBookmarkButtonBounds();
   void UpdateBookmarkVisibility();
   void UpdateVerticalTabToggleVisibility();
+  void UpdateVerticalTabTogglePlacement();
   void UpdateVerticalTabToggleState();
   void OnVerticalTabTogglePressed();
 
@@ -123,6 +124,7 @@ class BraveToolbarView : public ToolbarView,
   BooleanPrefMember show_vertical_tabs_;
   BooleanPrefMember show_title_bar_on_vertical_tabs_;
   BooleanPrefMember vertical_tabs_collapsed_;
+  BooleanPrefMember vertical_tabs_on_right_;
 #if BUILDFLAG(IS_LINUX)
   BooleanPrefMember use_custom_chrome_frame_;
 #endif  // BUILDFLAG(IS_LINUX)

--- a/browser/ui/views/toolbar/brave_toolbar_view_browsertest.cc
+++ b/browser/ui/views/toolbar/brave_toolbar_view_browsertest.cc
@@ -6,7 +6,10 @@
 #include "brave/browser/ui/views/toolbar/brave_toolbar_view.h"
 
 #include "base/check.h"
+#include "base/command_line.h"
 #include "base/functional/callback_helpers.h"
+#include "base/i18n/base_i18n_switches.h"
+#include "base/i18n/rtl.h"
 #include "base/memory/raw_ptr.h"
 #include "base/test/scoped_feature_list.h"
 #include "brave/browser/ui/tabs/brave_split_tab_menu_model.h"
@@ -648,6 +651,71 @@ IN_PROC_BROWSER_TEST_F(BraveToolbarViewTest,
       << "toggle should move to a higher index when switching from "
          "kVerticalTabsOnRight=false to true (left_ix="
       << *ix_left_side << ", right_ix=" << *ix_on_right << ")";
+}
+
+// Variant of BraveToolbarViewTest that forces the UI direction to RTL via
+// --force-ui-direction=rtl so we can verify that toggle placement stays on the
+// same physical side as the vertical tab strip when the toolbar's horizontal
+// FlexLayout mirrors child indices.
+class BraveToolbarViewRTLTest : public BraveToolbarViewTest {
+ public:
+  void SetUpCommandLine(base::CommandLine* command_line) override {
+    InProcessBrowserTest::SetUpCommandLine(command_line);
+    command_line->AppendSwitchASCII(::switches::kForceUIDirection,
+                                    ::switches::kForceDirectionRTL);
+  }
+};
+
+IN_PROC_BROWSER_TEST_F(BraveToolbarViewRTLTest,
+                       RtlInvertsVerticalTabTogglePlacement) {
+  ASSERT_TRUE(base::i18n::IsRTL())
+      << "--force-ui-direction=rtl should make IsRTL() true";
+
+  auto* prefs = browser()->profile()->GetPrefs();
+  prefs->SetBoolean(brave_tabs::kVerticalTabsEnabled, true);
+  views::View* container = toolbar_view_->location_bar_view()->parent();
+  ASSERT_TRUE(container);
+
+  // In RTL, the strip placed by kVerticalTabsOnRight=false is physically on
+  // the left; the toolbar container mirrors child indices, so a toggle that
+  // should appear visually on the left needs to sit at the trailing logical
+  // slot (just before the app menu).
+  prefs->SetBoolean(brave_tabs::kVerticalTabsOnRight, false);
+  RunScheduledLayouts();
+  auto* toggle = toolbar_view_->vertical_tab_toggle_button();
+  ASSERT_TRUE(toggle) << "vertical tabs enabled in RTL with on-left pref";
+
+  views::View* menu = toolbar_button_provider_->GetAppMenuButton();
+  ASSERT_TRUE(menu);
+  const auto menu_ix_left = container->GetIndexOf(menu);
+  ASSERT_TRUE(menu_ix_left.has_value() && *menu_ix_left > 0)
+      << "app menu button must be a non-leading child of the toolbar "
+         "container (RTL, on-left)";
+
+  const auto ix_rtl_on_left = container->GetIndexOf(toggle);
+  ASSERT_TRUE(ix_rtl_on_left.has_value())
+      << "toggle missing from toolbar container (RTL, "
+         "kVerticalTabsOnRight=false)";
+  EXPECT_EQ(*ix_rtl_on_left, *menu_ix_left - 1)
+      << "in RTL, on-left strip should map to toggle at app-menu-1 (toggle_ix="
+      << *ix_rtl_on_left << ", menu_ix=" << *menu_ix_left << ")";
+
+  // In RTL, the strip placed by kVerticalTabsOnRight=true is physically on the
+  // right; logical child index 0 mirrors to the visual right edge.
+  prefs->SetBoolean(brave_tabs::kVerticalTabsOnRight, true);
+  RunScheduledLayouts();
+  const auto ix_rtl_on_right = container->GetIndexOf(toggle);
+  ASSERT_TRUE(ix_rtl_on_right.has_value())
+      << "toggle missing from toolbar container (RTL, "
+         "kVerticalTabsOnRight=true)";
+  EXPECT_EQ(*ix_rtl_on_right, 0u)
+      << "in RTL, on-right strip should map to toggle at leading logical "
+         "index 0 (visual right edge), got "
+      << *ix_rtl_on_right;
+  EXPECT_LT(*ix_rtl_on_right, *ix_rtl_on_left)
+      << "in RTL, switching from on-left to on-right should *decrease* the "
+         "toggle's logical index (on_left_ix="
+      << *ix_rtl_on_left << ", on_right_ix=" << *ix_rtl_on_right << ")";
 }
 
 // Verifies that UpdateHorizontalPadding() keeps the toolbar container border

--- a/browser/ui/views/toolbar/brave_toolbar_view_browsertest.cc
+++ b/browser/ui/views/toolbar/brave_toolbar_view_browsertest.cc
@@ -617,22 +617,34 @@ IN_PROC_BROWSER_TEST_F(BraveToolbarViewTest,
   prefs->SetBoolean(brave_tabs::kVerticalTabsOnRight, false);
   RunScheduledLayouts();
   auto* toggle = toolbar_view_->vertical_tab_toggle_button();
-  ASSERT_TRUE(toggle);
+  ASSERT_TRUE(toggle) << "vertical tabs enabled, kVerticalTabsOnRight=false";
   const auto ix_left_side = container->GetIndexOf(toggle);
-  ASSERT_TRUE(ix_left_side.has_value());
+  ASSERT_TRUE(ix_left_side.has_value())
+      << "toggle missing from toolbar container "
+         "(kVerticalTabsOnRight=false)";
 
   prefs->SetBoolean(brave_tabs::kVerticalTabsOnRight, true);
   RunScheduledLayouts();
   const auto ix_on_right = container->GetIndexOf(toggle);
-  ASSERT_TRUE(ix_on_right.has_value());
+  ASSERT_TRUE(ix_on_right.has_value())
+      << "toggle missing from toolbar container "
+         "(kVerticalTabsOnRight=true)";
 
   views::View* menu = toolbar_button_provider_->GetAppMenuButton();
   ASSERT_TRUE(menu);
   const auto menu_ix = container->GetIndexOf(menu);
-  ASSERT_TRUE(menu_ix.has_value() && *menu_ix > 0);
+  ASSERT_TRUE(menu_ix.has_value() && *menu_ix > 0)
+      << "app menu button must be a non-leading child of the toolbar "
+         "container";
 
-  EXPECT_EQ(*ix_on_right, *menu_ix - 1);
-  EXPECT_LT(*ix_left_side, *ix_on_right);
+  EXPECT_EQ(*ix_on_right, *menu_ix - 1)
+      << "with kVerticalTabsOnRight=true, toggle should sit immediately "
+         "before the app menu (toggle_ix="
+      << *ix_on_right << ", menu_ix=" << *menu_ix << ")";
+  EXPECT_LT(*ix_left_side, *ix_on_right)
+      << "toggle should move to a higher index when switching from "
+         "kVerticalTabsOnRight=false to true (left_ix="
+      << *ix_left_side << ", right_ix=" << *ix_on_right << ")";
 }
 
 // Verifies that UpdateHorizontalPadding() keeps the toolbar container border

--- a/browser/ui/views/toolbar/brave_toolbar_view_browsertest.cc
+++ b/browser/ui/views/toolbar/brave_toolbar_view_browsertest.cc
@@ -622,6 +622,9 @@ IN_PROC_BROWSER_TEST_F(BraveToolbarViewTest,
   ASSERT_TRUE(ix_left_side.has_value())
       << "toggle missing from toolbar container "
          "(kVerticalTabsOnRight=false)";
+  EXPECT_EQ(*ix_left_side, 0u)
+      << "with kVerticalTabsOnRight=false, toggle should be pinned to child "
+         "index 0 (leading toolbar edge), not derived from back button index";
 
   prefs->SetBoolean(brave_tabs::kVerticalTabsOnRight, true);
   RunScheduledLayouts();

--- a/browser/ui/views/toolbar/brave_toolbar_view_browsertest.cc
+++ b/browser/ui/views/toolbar/brave_toolbar_view_browsertest.cc
@@ -607,6 +607,34 @@ IN_PROC_BROWSER_TEST_F(BraveToolbarViewTest,
   EXPECT_FALSE(button->GetVisible());
 }
 
+IN_PROC_BROWSER_TEST_F(BraveToolbarViewTest,
+                       VerticalTabTogglePlacementRespectsTabsOnRight) {
+  auto* prefs = browser()->profile()->GetPrefs();
+  prefs->SetBoolean(brave_tabs::kVerticalTabsEnabled, true);
+  views::View* container = toolbar_view_->location_bar_view()->parent();
+  ASSERT_TRUE(container);
+
+  prefs->SetBoolean(brave_tabs::kVerticalTabsOnRight, false);
+  RunScheduledLayouts();
+  auto* toggle = toolbar_view_->vertical_tab_toggle_button();
+  ASSERT_TRUE(toggle);
+  const auto ix_left_side = container->GetIndexOf(toggle);
+  ASSERT_TRUE(ix_left_side.has_value());
+
+  prefs->SetBoolean(brave_tabs::kVerticalTabsOnRight, true);
+  RunScheduledLayouts();
+  const auto ix_on_right = container->GetIndexOf(toggle);
+  ASSERT_TRUE(ix_on_right.has_value());
+
+  auto* menu = toolbar_view_->GetAppMenuButton();
+  ASSERT_TRUE(menu);
+  const auto menu_ix = container->GetIndexOf(menu);
+  ASSERT_TRUE(menu_ix.has_value() && *menu_ix > 0);
+
+  EXPECT_EQ(*ix_on_right, *menu_ix - 1);
+  EXPECT_LT(*ix_left_side, *ix_on_right);
+}
+
 // Verifies that UpdateHorizontalPadding() keeps the toolbar container border
 // in sync with GetLeadingTrailingCaptionButtonWidth() across state changes.
 // Guards against the Qt-theme regression where a fixed estimate was used

--- a/browser/ui/views/toolbar/brave_toolbar_view_browsertest.cc
+++ b/browser/ui/views/toolbar/brave_toolbar_view_browsertest.cc
@@ -626,7 +626,7 @@ IN_PROC_BROWSER_TEST_F(BraveToolbarViewTest,
   const auto ix_on_right = container->GetIndexOf(toggle);
   ASSERT_TRUE(ix_on_right.has_value());
 
-  auto* menu = toolbar_view_->GetAppMenuButton();
+  views::View* menu = toolbar_button_provider_->GetAppMenuButton();
   ASSERT_TRUE(menu);
   const auto menu_ix = container->GetIndexOf(menu);
   ASSERT_TRUE(menu_ix.has_value() && *menu_ix > 0);


### PR DESCRIPTION

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/55395


# Reposition vertical-tab expand/collapse toggle when tabs are shown on the right

## Summary

When Brave vertical tabs use **“Show on the right”** (`brave.tabs.vertical_tabs_on_right`), the toolbar control that expands/collapses the vertical tab strip is moved from the **leading edge** of the toolbar (pinned to **child index `0`** in the toolbar container) to the **trailing** cluster, **immediately before the app menu**, so it stays next to the strip and the main menu. In **RTL** UI (`--force-ui-direction=rtl`), the same physical-side rule applies — the placement choice is inverted so the toggle visually lines up with the strip, since the toolbar container's horizontal `views::FlexLayout` mirrors child indices but the strip is positioned by physical coordinates.

## Motivation

With the strip on the right edge of the window, keeping the toggle on the left felt disconnected from the feature. Placing it beside the menu aligns the control with the strip and matches how other trailing toolbar actions are grouped.

## Implementation

- **`BraveToolbarView`** (`browser/ui/views/toolbar/brave_toolbar_view.h`, `browser/ui/views/toolbar/brave_toolbar_view.cc`):
  - Observe **`kVerticalTabsOnRight`** via `BooleanPrefMember` and call **`UpdateVerticalTabTogglePlacement()`** when it changes (inside the existing **`SupportsBraveVerticalTabs(browser_)`** block).
  - **`show_vertical_tabs_`** callback also refreshes placement when vertical tabs mode is toggled (same guard).
  - **`UpdateVerticalTabTogglePlacement()`** uses `views::View::ReorderChildView` on the same `container_view` as the rest of the toolbar:
    - Decision: `place_near_app_menu = tabs::utils::IsVerticalTabOnRight(browser_) != base::i18n::IsRTL()`. The vertical tab strip is placed by physical position and does not mirror in RTL, while the toolbar's `FlexLayout` mirrors logical child indices — XOR'ing with RTL keeps the toggle on the same physical side as the strip across all four (LTR/RTL × left/right) combinations.
    - **Near app menu:** target index is **`GetIndexOf(GetAppMenuButton()) - 1`** (same slot strategy as other trailing controls and the avatar/menu ordering).
    - **Leading edge:** target index is **`0`**. This avoids depending on **`GetIndexOf(back_)`**: forward is already pinnable upstream and back could become pinnable later; tying placement to back's index risks **`CHECK`** failures or odd ordering when navigation-button pinning changes.
  - Run placement at the **end of `Init()`**, **after** the avatar is reordered before the app menu, **only when** `tabs::utils::SupportsBraveVerticalTabs(browser_)` (same condition under which the toggle is created), then set `brave_initialized_` so startup order matches runtime pref updates.
  - **`UpdateVerticalTabTogglePlacement()`** is assumed to run only when vertical tabs are supported and the toggle exists as a child of `container_view`; unexpected layout state is treated as a programming error via **`CHECK`** on the toggle, location bar parent, **`GetIndexOf`** for the toggle, and (when placing near the app menu) **`GetIndexOf`** for the app menu plus **`CHECK_GT`** on that index so `menu_idx - 1` cannot underflow.

- **Tests:** `browser/ui/views/toolbar/brave_toolbar_view_browsertest.cc`
  - **`VerticalTabTogglePlacementRespectsTabsOnRight`** (LTR) — asserts **`child index 0`** when **“show on the left”**, **`menu_index - 1`** when **“show on the right”**, that moving from left to right increases the toggle's index, and uses **`<<`** diagnostic context on assertions (TI-014).
  - **`BraveToolbarViewRTLTest.RtlInvertsVerticalTabTogglePlacement`** — adds `--force-ui-direction=rtl` via `SetUpCommandLine` and asserts the *inverted* indices: **`menu_index - 1`** when “show on the left”, **`0`** when “show on the right”, and that flipping the pref *decreases* the toggle's logical index (mirror of the LTR case).

## How to test manually

1. Enable **vertical tabs** and keep **“Show on the left”** — confirm the toggle stays at the **leading edge** of the toolbar (first control in the container in typical LTR layouts).
2. Switch to **“Show on the right”** — confirm the toggle appears **on the right**, **just left of the ≡ menu**.
3. Toggle vertical tabs off/on and flip left/right again — confirm placement updates without a restart.
4. Launch with `--force-ui-direction=rtl` and repeat 1–2: the toggle should follow the strip's *physical* side (visually left/right matches the strip), even though the toolbar's child order is mirrored.

## Related

- Preference: `brave.tabs.vertical_tabs_on_right` (`browser/ui/tabs/brave_tab_prefs.h`).
- Settings copy: “Show on the right” in the tabs appearance page.


### Actual result

<img width="1206" height="228" alt="Image" src="https://github.com/user-attachments/assets/c1437f04-ab43-43ed-ba3d-0e2f55cce2b8" />

### Expected result

Button should be on the right side of the toolbar

<img width="1494" height="321" alt="Image" src="https://github.com/user-attachments/assets/b1874b7d-7655-4b4a-af4d-9b974a11b3a9" />

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->