### PR TITLE
[AI Chat]: Fix bug where you couldn't remove the current tab in global side panel mode

### DIFF
--- a/components/ai_chat/resources/page/state/conversation_context.test.tsx
+++ b/components/ai_chat/resources/page/state/conversation_context.test.tsx
@@ -1,0 +1,270 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import * as React from 'react'
+import { renderHook, act } from '@testing-library/react'
+import { clearAllDataForTesting } from '$web-common/api'
+import * as Mojom from '../../common/mojom'
+import { defaultConversationState } from '../api/mock_interfaces'
+import { useAIChat } from './ai_chat_context'
+import { useConversation } from './conversation_context'
+import { MockContext } from './mock_context'
+
+const CONVERSATION_UUID = defaultConversationState.conversationUuid
+
+const tab = (contentId: number): Mojom.TabData => ({
+  id: contentId,
+  contentId,
+  title: `Tab ${contentId}`,
+  url: { url: `https://example.com/${contentId}` },
+})
+
+const stagedContent = (contentId: number): Mojom.AssociatedContent => ({
+  uuid: `assoc-${contentId}`,
+  contentType: Mojom.ContentType.PageContent,
+  title: `Tab ${contentId}`,
+  contentId,
+  url: { url: `https://example.com/${contentId}` },
+  contentUsedPercentage: 0,
+  conversationTurnUuid: undefined,
+})
+
+const committedContent = (
+  contentId: number,
+  turnUuid: string,
+): Mojom.AssociatedContent => ({
+  ...stagedContent(contentId),
+  conversationTurnUuid: turnUuid,
+})
+
+interface RenderOverrides {
+  associateTab?: jest.Mock
+  disassociateContent?: jest.Mock
+}
+
+const renderConversation = (overrides: RenderOverrides = {}) =>
+  renderHook(
+    () => ({
+      conversation: useConversation(),
+      aiChat: useAIChat(),
+    }),
+    {
+      wrapper: ({ children }: { children: React.ReactNode }) => (
+        <MockContext
+          uiHandler={{
+            associateTab: overrides.associateTab ?? jest.fn(),
+            disassociateContent: overrides.disassociateContent ?? jest.fn(),
+          }}
+          initialState={{ isStandalone: false }}
+        >
+          {children}
+        </MockContext>
+      ),
+    },
+  )
+
+// Drives the state the effect needs:
+// - conversationUuid populated (the effect bails out without it; the mock's
+//   getState() resolves asynchronously, so we wait for it)
+// - tabsData populated (so the contentId can resolve to a TabData)
+// - defaultTabContentId emitted (the trigger)
+const setUpAttached = async (
+  rendered: ReturnType<typeof renderConversation>,
+  contentId: number,
+) => {
+  await act(async () => {
+    await rendered.result.current.conversation.api.getState.fetch()
+  })
+  await act(async () => {
+    rendered.result.current.aiChat.api.tabs.update([tab(contentId)])
+  })
+  await act(async () => {
+    rendered.result.current.aiChat.api.emitEvent('onNewDefaultConversation', [
+      contentId,
+    ])
+  })
+  await act(async () => rendered.rerender())
+}
+
+describe('useProvideConversationContext default tab attachment', () => {
+  beforeEach(() => {
+    clearAllDataForTesting()
+  })
+
+  it('attaches the default tab once everything it needs is ready', async () => {
+    const associateTab = jest.fn()
+    const rendered = renderConversation({ associateTab })
+
+    await setUpAttached(rendered, 10)
+
+    expect(associateTab).toHaveBeenCalledTimes(1)
+    expect(associateTab).toHaveBeenCalledWith(tab(10), CONVERSATION_UUID)
+  })
+
+  // Regression test for the global side panel "can't remove the current tab"
+  // bug: after the user disassociates the default tab, associatedContent
+  // changes, but that must not cause the attach effect to fire again.
+  it('does not re-attach the default tab after the user removes it', async () => {
+    const associateTab = jest.fn()
+    const rendered = renderConversation({ associateTab })
+    const { result } = rendered
+
+    await setUpAttached(rendered, 10)
+
+    expect(associateTab).toHaveBeenCalledTimes(1)
+    associateTab.mockClear()
+
+    // Backend confirms the staged attachment.
+    await act(async () => {
+      result.current.conversation.api.getState.update({
+        ...defaultConversationState,
+        associatedContent: [stagedContent(10)],
+      })
+    })
+
+    // User removes the tab — backend reflects empty associated content.
+    await act(async () => {
+      result.current.conversation.api.getState.update({
+        ...defaultConversationState,
+        associatedContent: [],
+      })
+    })
+
+    expect(associateTab).not.toHaveBeenCalled()
+  })
+
+  // Also part of the same regression: tabsData updating (e.g. tab title
+  // changes) must not undo the user's removal.
+  it('does not re-attach when tabsData updates after the user removes the tab', async () => {
+    const associateTab = jest.fn()
+    const rendered = renderConversation({ associateTab })
+    const { result } = rendered
+
+    await setUpAttached(rendered, 10)
+
+    expect(associateTab).toHaveBeenCalledTimes(1)
+    associateTab.mockClear()
+
+    await act(async () => {
+      result.current.conversation.api.getState.update({
+        ...defaultConversationState,
+        associatedContent: [],
+      })
+    })
+
+    await act(async () => {
+      result.current.aiChat.api.tabs.update([
+        { ...tab(10), title: 'Tab 10 (renamed)' },
+      ])
+    })
+
+    expect(associateTab).not.toHaveBeenCalled()
+  })
+
+  it('attaches once tabsData catches up after the default tab event', async () => {
+    const associateTab = jest.fn()
+    const rendered = renderConversation({ associateTab })
+    const { result } = rendered
+
+    await act(async () => {
+      await result.current.conversation.api.getState.fetch()
+    })
+
+    // OnNewDefaultConversation arrives before tabsData reflects the new tab.
+    await act(async () => {
+      result.current.aiChat.api.emitEvent('onNewDefaultConversation', [20])
+    })
+    await act(async () => rendered.rerender())
+
+    expect(associateTab).not.toHaveBeenCalled()
+
+    await act(async () => {
+      result.current.aiChat.api.tabs.update([tab(20)])
+    })
+    await act(async () => rendered.rerender())
+
+    expect(associateTab).toHaveBeenCalledTimes(1)
+    expect(associateTab).toHaveBeenCalledWith(tab(20), CONVERSATION_UUID)
+  })
+
+  // When the user navigates from an attachable page (e.g. https://) to one
+  // that can't be associated (e.g. chrome://), defaultTabContentId becomes
+  // undefined. All staged content should be cleared; committed content (tied
+  // to a conversation turn) must be preserved.
+  it('clears staged content when defaultTabContentId becomes undefined', async () => {
+    const disassociateContent = jest.fn()
+    const rendered = renderConversation({ disassociateContent })
+    const { result } = rendered
+
+    await setUpAttached(rendered, 10)
+
+    const stagedDefault = stagedContent(10)
+    const stagedOther = stagedContent(99)
+    const committed = committedContent(7, 'turn-1')
+    await act(async () => {
+      result.current.conversation.api.getState.update({
+        ...defaultConversationState,
+        associatedContent: [stagedDefault, stagedOther, committed],
+      })
+    })
+
+    disassociateContent.mockClear()
+
+    await act(async () => {
+      result.current.aiChat.api.emitEvent('onNewDefaultConversation', [])
+    })
+    await act(async () => rendered.rerender())
+
+    expect(disassociateContent).toHaveBeenCalledWith(
+      stagedDefault,
+      CONVERSATION_UUID,
+    )
+    expect(disassociateContent).toHaveBeenCalledWith(
+      stagedOther,
+      CONVERSATION_UUID,
+    )
+    expect(disassociateContent).not.toHaveBeenCalledWith(
+      committed,
+      CONVERSATION_UUID,
+    )
+  })
+
+  it('clears staged content and attaches the new tab when the default changes', async () => {
+    const associateTab = jest.fn()
+    const disassociateContent = jest.fn()
+    const rendered = renderConversation({
+      associateTab,
+      disassociateContent,
+    })
+    const { result } = rendered
+
+    await setUpAttached(rendered, 10)
+
+    await act(async () => {
+      result.current.conversation.api.getState.update({
+        ...defaultConversationState,
+        associatedContent: [stagedContent(10)],
+      })
+    })
+
+    associateTab.mockClear()
+    disassociateContent.mockClear()
+
+    await act(async () => {
+      result.current.aiChat.api.tabs.update([tab(10), tab(20)])
+    })
+    await act(async () => {
+      result.current.aiChat.api.emitEvent('onNewDefaultConversation', [20])
+    })
+    await act(async () => rendered.rerender())
+
+    expect(disassociateContent).toHaveBeenCalledWith(
+      stagedContent(10),
+      CONVERSATION_UUID,
+    )
+    expect(associateTab).toHaveBeenCalledTimes(1)
+    expect(associateTab).toHaveBeenCalledWith(tab(20), CONVERSATION_UUID)
+  })
+})

--- a/components/ai_chat/resources/page/state/conversation_context.tsx
+++ b/components/ai_chat/resources/page/state/conversation_context.tsx
@@ -309,12 +309,10 @@ export function useProvideConversationContext(props: ConversationContextProps) {
   const prevDefaultTabContentIdRef = React.useRef<number | undefined>(undefined)
   React.useEffect(() => {
     if (aiChat.isStandalone !== false || props.isTabAssociated) return
+    if (!conversationState.conversationUuid) return
 
     const prevContentId = prevDefaultTabContentIdRef.current
     const newContentId = aiChat.defaultTabContentId
-    prevDefaultTabContentIdRef.current = newContentId
-
-    if (!conversationState.conversationUuid) return
     if (prevContentId === newContentId) return
 
     // Clear all staged content (not yet committed to a conversation turn).
@@ -327,16 +325,29 @@ export function useProvideConversationContext(props: ConversationContextProps) {
       )
     }
 
-    // Attach the new tab. If tabsData isn't current yet (e.g. mid-navigation),
-    // the associateDefaultContent effect below will fire once tabsData updates.
     const newTab = tabsData?.find((t) => t.contentId === newContentId)
+
+    // If there's no new tab to attach, but the tabsData doesn't have it yet wait for the effect to re-run.
+    if (!newTab && newContentId) {
+      return
+    }
+
+    // We have up to date tabsData, so we can set the previousDefaultTabContentId to the new content id.
+    prevDefaultTabContentIdRef.current = newContentId
+
     if (newTab) {
       aiChat.api.uiHandler.associateTab(
         newTab,
         conversationState.conversationUuid,
       )
     }
-  }, [aiChat.defaultTabContentId, conversationState.conversationUuid])
+  }, [
+    aiChat.defaultTabContentId,
+    aiChat.isStandalone,
+    props.isTabAssociated,
+    conversationState.conversationUuid,
+    tabsData,
+  ])
 
   const associateDefaultContent = React.useMemo(() => {
     const existingAttachedContent = conversationState.associatedContent.find(
@@ -361,13 +372,6 @@ export function useProvideConversationContext(props: ConversationContextProps) {
     conversationState.associatedContent,
     conversationState.conversationUuid,
   ])
-
-  // Fallback: if tabsData wasn't ready when the tab changed (e.g. mid-navigation),
-  // attach as soon as it becomes available.
-  React.useEffect(() => {
-    if (aiChat.isStandalone !== false || props.isTabAssociated) return
-    associateDefaultContent?.()
-  }, [aiChat.isStandalone, props.isTabAssociated, associateDefaultContent])
 
   const handleResetError = async () => {
     const turn = await api.clearErrorAndGetFailedMessage()


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/55400

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
