### PR TITLE
[plaster] Remove `count = 1` lines

### DIFF
--- a/rewrite/chrome/android/java/src/org/chromium/chrome/browser/toolbar/ToolbarManager.java.toml
+++ b/rewrite/chrome/android/java/src/org/chromium/chrome/browser/toolbar/ToolbarManager.java.toml
@@ -9,4 +9,3 @@
 description = 'Remove NTP check from toolbar longpress condition'
 re_pattern = '(private boolean shouldSuppressToolbarLongPress\(\)[\s\S]+?)\|\| \(getNewTabPageForCurrentTab\(\) != null\);'
 replace = '\1;'
-count = 1

--- a/rewrite/chrome/browser/enterprise/connectors/device_trust/key_management/browser/metrics_utils.cc.toml
+++ b/rewrite/chrome/browser/enterprise/connectors/device_trust/key_management/browser/metrics_utils.cc.toml
@@ -7,6 +7,5 @@
 description = '''Add ECDSA_SHA384 to the EC key case in `AlgorithmToType`.'''
 re_pattern = '(AlgorithmToType\([^)]*\).*?)(\n\s*return DTKeyType::kEc;)'
 re_flags = ['DOTALL']
-count = 1
 replace = '''\1
     case crypto::SignatureVerifier::ECDSA_SHA384:\2'''

--- a/rewrite/chrome/browser/enterprise/connectors/device_trust/key_management/core/network/key_upload_request.cc.toml
+++ b/rewrite/chrome/browser/enterprise/connectors/device_trust/key_management/core/network/key_upload_request.cc.toml
@@ -7,6 +7,5 @@
 description = 'Add ECDSA_SHA384 to the EC_KEY case in `AlgorithmToType`'
 re_pattern = '(AlgorithmToType\([^)]*\).*?)(\n\s*return BPKUR::EC_KEY;)'
 re_flags = ['DOTALL']
-count = 1
 replace = '''\1
     case crypto::SignatureVerifier::ECDSA_SHA384:\2'''

--- a/rewrite/chrome/browser/ui/views/download/bubble/download_toolbar_ui_controller.cc.toml
+++ b/rewrite/chrome/browser/ui/views/download/bubble/download_toolbar_ui_controller.cc.toml
@@ -12,11 +12,9 @@ re_pattern = '(DownloadToolbarUIController::UpdateIcon\(.*?\n)^\}'
 replace = '''\1  UpdateIcon_BraveImpl(browser_view_, action_item_);
 }'''
 re_flags = ['MULTILINE', 'DOTALL']
-count = 1
 
 [[substitution]]
 description = 'Override for the icon colour.'
 re_pattern = '^(\s*)action_item_->SetImage'
 replace = '\1icon_color = GetIconColor(state_, active_, browser_view_->GetColorProvider());\1action_item_->SetImage'
 re_flags = ['MULTILINE']
-count = 1

--- a/rewrite/chrome/browser/ui/views/frame/horizontal_tab_strip_region_view.cc.toml
+++ b/rewrite/chrome/browser/ui/views/frame/horizontal_tab_strip_region_view.cc.toml
@@ -7,4 +7,3 @@
 description = "Replace TabStrip construction with BraveTabStrip"
 pattern = "std::make_unique<TabStrip>"
 replace = "std::make_unique<BraveTabStrip>"
-count = 1

--- a/rewrite/chrome/browser/ui/views/tabs/tab.cc.toml
+++ b/rewrite/chrome/browser/ui/views/tabs/tab.cc.toml
@@ -7,13 +7,11 @@
 description = 'Check if tab can be closed via middle mouse button click based on prefs'
 pattern = 'if (event.IsOnlyMiddleMouseButton())'
 replace = 'if (event.IsOnlyMiddleMouseButton() && controller_->CanCloseTabViaMiddleButtonClick())'
-count = 1
 
 [[substitution]]
 description = 'Add BRAVE_UI_VIEWS_TABS_TAB_LAYOUT_ADJUST_ICON_POSITION'
 re_pattern = '(gfx::Rect favicon_bounds\(start, contents_rect\.y\(\), 0, 0\);\s+if \(showing_icon_\) \{\n)'
 replace = '\1    BRAVE_UI_VIEWS_TABS_TAB_LAYOUT_ADJUST_ICON_POSITION\n'
-count = 1
 
 [[substitution]]
 description = 'Add BRAVE_UI_VIEWS_TABS_TAB_ALERT_INDICATOR_POSITION'

--- a/rewrite/chrome/browser/ui/webui/unexportable_keys_internals/unexportable_keys_internals_handler.cc.toml
+++ b/rewrite/chrome/browser/ui/webui/unexportable_keys_internals/unexportable_keys_internals_handler.cc.toml
@@ -10,7 +10,6 @@ Returns the literal string "ECDSA_SHA384" for display in the internals WebUI.
 '''
 re_pattern = '(GetAlgorithmName\([^)]*\)\s*\{.*?\n\s*switch[^{]*\{.*?)(\n\s*\})'
 re_flags = ['DOTALL']
-count = 1
 replace = '''\1
     case crypto::SignatureVerifier::SignatureAlgorithm::ECDSA_SHA384:
       return "ECDSA_SHA384";\2'''

--- a/rewrite/components/browser_ui/settings/android/java/src/org/chromium/components/browser_ui/settings/SettingsUtils.java.toml
+++ b/rewrite/components/browser_ui/settings/android/java/src/org/chromium/components/browser_ui/settings/SettingsUtils.java.toml
@@ -10,4 +10,3 @@
 description = 'Make addVisiblePreferences package-private to call it at BraveSettingsUtils.getVisiblePreferences override'
 pattern = 'private static void addVisiblePreferences('
 replace = 'static void addVisiblePreferences('
-count = 1

--- a/rewrite/components/enterprise/client_certificates/core/key_upload_client.cc.toml
+++ b/rewrite/components/enterprise/client_certificates/core/key_upload_client.cc.toml
@@ -11,6 +11,5 @@ signature algorithm.
 '''
 re_pattern = '(AlgorithmToType\([^)]*\).*?)(\n\s*return BPKUR::EC_KEY;)'
 re_flags = ['DOTALL']
-count = 1
 replace = '''\1
     case crypto::SignatureVerifier::ECDSA_SHA384:\2'''

--- a/rewrite/components/enterprise/connectors/core/connectors_internals_utils.cc.toml
+++ b/rewrite/components/enterprise/connectors/core/connectors_internals_utils.cc.toml
@@ -11,6 +11,5 @@ signature algorithm.
 '''
 re_pattern = '(AlgorithmToType\([^)]*\).*?)(\n\s*return connectors_internals::mojom::KeyType::EC;)'
 re_flags = ['DOTALL']
-count = 1
 replace = '''\1
     case crypto::SignatureVerifier::ECDSA_SHA384:\2'''

--- a/rewrite/components/omnibox/browser/featured_search_provider.cc.toml
+++ b/rewrite/components/omnibox/browser/featured_search_provider.cc.toml
@@ -26,4 +26,3 @@ AutocompleteResult::AppendMatches.
 '''
 re_pattern = 'IDS_OMNIBOX_HISTORY_EMBEDDINGS_DISCLAIMER_IPH(\))\s*\+\s*u" "'
 replace = 'IDS_BRAVE_OMNIBOX_HISTORY_EMBEDDINGS_DISCLAIMER_IPH\1'
-count = 1

--- a/rewrite/components/omnibox/browser/omnibox_popup_selection.cc.toml
+++ b/rewrite/components/omnibox/browser/omnibox_popup_selection.cc.toml
@@ -21,4 +21,3 @@ condition (e.g. swaps the match type check or refactors the body).
 '''
 re_pattern = '(case FOCUSED_BUTTON_THUMBS_DOWN:\n)(\s+)return'
 replace = '\1\2if ((true)) return false;\n\2return'
-count = 1

--- a/rewrite/components/permissions/request_type.cc.toml
+++ b/rewrite/components/permissions/request_type.cc.toml
@@ -13,7 +13,6 @@
 description = 'Brave mappings for `ContentSettingsType` -> `RequestType`'
 re_pattern = '(ContentSettingsTypeToRequestTypeIfExists\([^)]*\)\s*\{.*?\n\s*switch[^{]*\{.*?)(\n\s*default:)'
 re_flags = ['DOTALL']
-count = 1
 replace = '''\1
 #if BUILDFLAG(ENABLE_BRAVE_WALLET)
     case ContentSettingsType::BRAVE_ETHEREUM:
@@ -34,7 +33,6 @@ replace = '''\1
 description = 'Add Brave permission types to `GetIconIdAndroid`'
 re_pattern = '(GetIconIdAndroid\([^)]*\)\s*\{.*?\n\s*switch[^{]*\{.*?)(\n\s*\})'
 re_flags = ['DOTALL']
-count = 1
 replace = '''\1
     case RequestType::kWidevine:
     case RequestType::kBraveEthereum:
@@ -48,7 +46,6 @@ replace = '''\1
 description = 'Add Brave permission types to `GetIconIdDesktop`'
 re_pattern = '(GetIconIdDesktop\([^)]*\)\s*\{.*?\n\s*switch[^{]*\{.*?)(\n\s*\})'
 re_flags = ['DOTALL']
-count = 1
 replace = '''\1
     case RequestType::kWidevine:
     case RequestType::kBraveEthereum:
@@ -61,7 +58,6 @@ replace = '''\1
 [[substitution]]
 description = 'Brave mappings for `RequestType` -> `ContentSettingsType`'
 re_pattern = '(RequestTypeToContentSettingsType\([^)]*\)\s*\{.*?\n\s*switch[^{]*\{.*?)(\n\s*default:)'
-count = 1
 re_flags = ['DOTALL']
 replace = '''\1
     case RequestType::kBraveGoogleSignInPermission:
@@ -81,7 +77,6 @@ replace = '''\1
 description = 'Brave mappings for `RequestType` to permission key'
 re_pattern = '(PermissionKeyForRequestType\([^)]*\)\s*\{.*?\n\s*switch[^{]*\{.*?)(\n\s*\})'
 re_flags = ['DOTALL']
-count = 1
 replace = '''\1
     case permissions::RequestType::kWidevine:
       return "widevine";

--- a/rewrite/components/signin/public/base/session_binding_utils.cc.toml
+++ b/rewrite/components/signin/public/base/session_binding_utils.cc.toml
@@ -10,7 +10,6 @@ Returns "SHA384" to identify the hash algorithm used for ECDSA_SHA384 keys.
 '''
 re_pattern = '(SignatureAlgorithmToString\([^)]*\)\s*\{.*?\n\s*switch[^{]*\{.*?)(\n\s*\})'
 re_flags = ['DOTALL']
-count = 1
 replace = '''\1
     case crypto::SignatureVerifier::ECDSA_SHA384:
       return "SHA384";\2'''

--- a/rewrite/components/sync_device_info/device_info.cc.toml
+++ b/rewrite/components/sync_device_info/device_info.cc.toml
@@ -13,7 +13,6 @@ re_pattern = '(DeviceInfo::DeviceInfo\(.*?)(\)\n\s+:)'
 re_flags = ['DOTALL']
 replace = '''\1,
     bool is_self_delete_supported\2'''
-count = 1
 
 [[substitution]]
 description = '''Initialize `is_self_delete_supported_` in the constructor
@@ -24,4 +23,3 @@ re_pattern = '(DeviceInfo::DeviceInfo\(.*?)( \{\})'
 re_flags = ['DOTALL']
 replace = '''\1,
       is_self_delete_supported_(is_self_delete_supported)\2'''
-count = 1

--- a/rewrite/components/sync_device_info/device_info.h.toml
+++ b/rewrite/components/sync_device_info/device_info.h.toml
@@ -17,7 +17,6 @@ re_pattern = '(DeviceInfo\((?=[^)]*std::string).*?)(\);)'
 re_flags = ['DOTALL']
 replace = '''\1,
              bool is_self_delete_supported = false\2'''
-count = 1
 
 [[substitution]]
 description = '''Add Brave-specific methods to DeviceInfo public interface
@@ -39,7 +38,6 @@ replace = '''\1
   // Converts the DeviceInfo values to a JS friendly DictionaryValue,
   // which extension APIs can expose to third party apps.
   base::DictValue ToValue() const;'''
-count = 1
 
 [[substitution]]
 description = '''Add is_self_delete_supported_ as last member of DeviceInfo
@@ -51,4 +49,3 @@ re_pattern = '(class DeviceInfo \{.*)(\n\};)'
 re_flags = ['DOTALL']
 replace = '''\1
   bool is_self_delete_supported_;\2'''
-count = 1

--- a/rewrite/crypto/signature_verifier.cc.toml
+++ b/rewrite/crypto/signature_verifier.cc.toml
@@ -10,7 +10,6 @@ Sets EVP_PKEY_EC with SHA-384 digest, mirroring the ECDSA_SHA256 case.
 '''
 re_pattern = '(VerifyInit\([^)]*\)\s*\{.*?\n\s*switch[^{]*\{.*?)(\n\s*\})'
 re_flags = ['DOTALL']
-count = 1
 replace = '''\1
     case ECDSA_SHA384:
       pkey_type = EVP_PKEY_EC;

--- a/rewrite/crypto/signature_verifier.h.toml
+++ b/rewrite/crypto/signature_verifier.h.toml
@@ -12,6 +12,5 @@ value independently.
 '''
 re_pattern = '(enum SignatureAlgorithm\s*\{.*?)(\n\s*\})'
 re_flags = ['DOTALL']
-count = 1
 replace = '''\1
     ECDSA_SHA384,\2'''

--- a/rewrite/crypto/unexportable_key_metrics.cc.toml
+++ b/rewrite/crypto/unexportable_key_metrics.cc.toml
@@ -10,7 +10,6 @@ Ensures ECDSA_SHA384 is exercised alongside ECDSA_SHA256 in TPM metrics.
 '''
 re_pattern = '(kAllAlgorithms\[\]\s*=\s*\{.*?)(\n\s*\})'
 re_flags = ['DOTALL']
-count = 1
 replace = '''\1
     SignatureVerifier::SignatureAlgorithm::ECDSA_SHA384,\2'''
 
@@ -21,7 +20,6 @@ Treats ECDSA_SHA384 as ECDSA for virtual TPM support classification.
 '''
 re_pattern = '(MeasureVirtualTpmOperations\([^)]*\).*?)(\n\s*supported_virtual_algo)'
 re_flags = ['DOTALL']
-count = 1
 replace = '''\1
       case SignatureVerifier::SignatureAlgorithm::ECDSA_SHA384:\2'''
 
@@ -32,7 +30,6 @@ Treats ECDSA_SHA384 as ECDSA for hardware TPM support classification.
 '''
 re_pattern = '(MeasureTpmOperationsInternal\([^)]*\).*?)(\n\s*supported_algo)'
 re_flags = ['DOTALL']
-count = 1
 replace = '''\1
       case SignatureVerifier::SignatureAlgorithm::ECDSA_SHA384:\2'''
 
@@ -43,7 +40,6 @@ ECDSA_SHA384 keys are reported under the same "ECDSA" histogram bucket.
 '''
 re_pattern = '(AlgorithmToString\([^)]*\)\s*\{.*?\n\s*switch[^{]*\{.*?)(\n\s*\})'
 re_flags = ['DOTALL']
-count = 1
 replace = '''\1
     case SignatureVerifier::SignatureAlgorithm::ECDSA_SHA384:
       return "ECDSA";\2'''

--- a/rewrite/net/device_bound_sessions/session_binding_utils.cc.toml
+++ b/rewrite/net/device_bound_sessions/session_binding_utils.cc.toml
@@ -10,7 +10,6 @@ Returns "SHA384" to identify the hash algorithm used for ECDSA_SHA384 keys.
 '''
 re_pattern = '(SignatureAlgorithmToString\([^)]*\)\s*\{.*?\n\s*switch[^{]*\{.*?)(\n\s*\})'
 re_flags = ['DOTALL']
-count = 1
 replace = '''\1
     case crypto::SignatureVerifier::ECDSA_SHA384:
       return "SHA384";\2'''


### PR DESCRIPTION
Removing these lines so we can introduce `count` value checks to steer
users towards fixed counts only when needed, and away from `count=0`. At
the moment removing these as they are redundant.
