### PR TITLE
Optimize Energy Consumption in MACOS, IPHONE, Android

### DIFF
--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -855,8 +855,12 @@ void AdsServiceImpl::CheckIdleStateAfterDelay() {
 #if !BUILDFLAG(IS_ANDROID)
   idle_state_timer_.Stop();
 
-  idle_state_timer_.Start(FROM_HERE, base::Seconds(1), this,
-                          &AdsServiceImpl::CheckIdleState);
+  // Poll at the same interval as the idle threshold (default 5s) to reduce
+  // CPU wakeups while still detecting state changes promptly.
+  idle_state_timer_.Start(
+      FROM_HERE,
+      std::max(base::Seconds(5), kUserIdleDetectionThreshold.Get()), this,
+      &AdsServiceImpl::CheckIdleState);
 #endif
 }
 

--- a/components/brave_ads/core/internal/account/confirmations/confirmations_feature.h
+++ b/components/brave_ads/core/internal/account/confirmations/confirmations_feature.h
@@ -20,7 +20,7 @@ BASE_DECLARE_FEATURE(kConfirmationsFeature);
 inline constexpr base::FeatureParam<base::TimeDelta>
     kProcessConfirmationInitialBackoffDelay{
         &kConfirmationsFeature, "process_confirmation_initial_backoff_delay",
-        base::Seconds(15)};
+        base::Seconds(30)};
 
 inline constexpr base::FeatureParam<base::TimeDelta>
     kProcessConfirmationMaxBackoffDelay{

--- a/components/brave_ads/core/internal/account/confirmations/queue/queue_item/confirmation_queue_item_util_constants.h
+++ b/components/brave_ads/core/internal/account/confirmations/queue/queue_item/confirmation_queue_item_util_constants.h
@@ -11,7 +11,7 @@
 namespace brave_ads {
 
 inline constexpr base::TimeDelta
-    kMinimumDelayBeforeProcessingConfirmationQueueItem = base::Seconds(5);
+    kMinimumDelayBeforeProcessingConfirmationQueueItem = base::Seconds(15);
 
 }  // namespace brave_ads
 

--- a/components/brave_ads/core/internal/account/utility/refill_confirmation_tokens/refill_confirmation_tokens.cc
+++ b/components/brave_ads/core/internal/account/utility/refill_confirmation_tokens/refill_confirmation_tokens.cc
@@ -42,7 +42,7 @@
 namespace brave_ads {
 
 namespace {
-constexpr base::TimeDelta kRetryAfter = base::Seconds(15);
+constexpr base::TimeDelta kRetryAfter = base::Minutes(1);
 }  // namespace
 
 RefillConfirmationTokens::RefillConfirmationTokens() = default;

--- a/components/brave_news/browser/brave_news_controller.cc
+++ b/components/brave_news/browser/brave_news_controller.cc
@@ -683,7 +683,7 @@ void BraveNewsController::ConditionallyStartOrStopTimer() {
           &BraveNewsController::CheckForPublishersUpdate);
     }
     if (!timer_prefetch_.IsRunning()) {
-      timer_prefetch_.Start(FROM_HERE, base::Minutes(1), this,
+      timer_prefetch_.Start(FROM_HERE, base::Minutes(5), this,
                             &BraveNewsController::Prefetch);
     }
 

--- a/components/brave_wallet/browser/brave_wallet_constants.h
+++ b/components/brave_wallet/browser/brave_wallet_constants.h
@@ -1805,9 +1805,9 @@ inline constexpr char kBlowfishAPIVersion[] = "2023-06-05";
 inline constexpr char kNativeEVMAssetContractAddress[] =
     "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
 
-inline constexpr int64_t kBlockTrackerDefaultTimeInSeconds = 20;
-inline constexpr int64_t kLogTrackerDefaultTimeInSeconds = 20;
-inline constexpr int64_t kSolanaBlockTrackerTimeInSeconds = 2;
+inline constexpr int64_t kBlockTrackerDefaultTimeInSeconds = 30;
+inline constexpr int64_t kLogTrackerDefaultTimeInSeconds = 30;
+inline constexpr int64_t kSolanaBlockTrackerTimeInSeconds = 10;
 
 // Ankr constants
 inline constexpr char kAnkrAdvancedAPIBaseURL[] =

--- a/components/p3a/p3a_config.cc
+++ b/components/p3a/p3a_config.cc
@@ -22,7 +22,7 @@ namespace p3a {
 
 namespace {
 
-constexpr uint64_t kDefaultUploadIntervalSeconds = 60;  // 1 minute.
+constexpr uint64_t kDefaultUploadIntervalSeconds = 300;  // 5 minutes.
 constexpr char kConstellationCollectorHostPrefix[] = "collector.bsg";
 constexpr char kRandomnessHostPrefix[] = "star-randsrv.bsg";
 


### PR DESCRIPTION

Resolves




---

## AI Code Review Summary

### Changes Overview

| File | Old Value | New Value | Purpose |
|------|-----------|-----------|---------|
| `components/brave_ads/browser/ads_service_impl.cc` | 1 s | max(5 s, threshold) | Idle-state polling |
| `components/brave_ads/core/internal/account/confirmations/confirmations_feature.h` | 15 s | 30 s | Confirmation initial backoff |
| `components/brave_ads/core/internal/account/confirmations/queue/queue_item/confirmation_queue_item_util_constants.h` | 5 s | 15 s | Minimum confirmation queue delay |
| `components/brave_ads/core/internal/account/utility/refill_confirmation_tokens/refill_confirmation_tokens.cc` | 15 s | 1 min | Token refill retry |
| `components/brave_news/browser/brave_news_controller.cc` | 1 min | 5 min | News prefetch interval |
| `components/brave_wallet/browser/brave_wallet_constants.h` | 20 s / 20 s / 2 s | 30 s / 30 s / 10 s | Block/log/Solana trackers |
| `components/p3a/p3a_config.cc` | 60 s | 300 s | P3A telemetry upload |

### ✅ Strengths

1. Clear, focused objective — every change targets fewer timer wakeups.
2. Good use of `std::max` in `ads_service_impl.cc` to dynamically tie idle polling to the detection threshold.
3. Helpful inline comment explaining the idle-timer rationale.

### ⚠️ Issues Found

1. **Solana block tracker: 2 s → 10 s is a 5× increase** that may degrade wallet transaction confirmation UX. Solana has ~400 ms slot times; polling every 10 s means up to 25 blocks between checks. Consider a smaller bump (4–5 s) or adaptive polling (faster when a transaction is pending).
2. **P3A upload interval: 1 min → 5 min** — confirm with the P3A/data team that 5× higher telemetry latency is acceptable for dashboards and anomaly detection.
3. **No linked issue** — PR body says "Resolves" without an issue number. No benchmark data or energy profiling evidence provided.
4. **No test updates** — no new tests or benchmarks demonstrating energy savings or absence of functional regressions.
5. **PR title mentions "IPHONE"** but no iOS-specific code is changed.

### 💡 Suggestions

1. Add before/after energy profiling data (macOS Activity Monitor, Android Battery Historian).
2. Consider making intervals configurable via Feature flags for A/B testing.
3. Split PR by component (Ads, News, Wallet, P3A) for independent review by component owners.
4. Wallet: use different intervals for active polling (pending tx) vs. background polling.

### Overall Assessment

**Request Changes** — Intent is sound, but needs: linked issue with profiling data, component owner review (especially Wallet and P3A), reconsideration of Solana tracker interval, and ideally a per-component split.

---
*Review conducted by Copilot AI using Claude Opus/Sonnet 4.6 — 2026-05-11*
