### PR TITLE
Resets visibility and clip path when horizontal scrolling is disabled.

### DIFF
--- a/browser/ui/views/tabs/brave_tab_container.cc
+++ b/browser/ui/views/tabs/brave_tab_container.cc
@@ -750,7 +750,19 @@ void BraveTabContainer::OnScrollableHorizontalTabStripPrefChanged() {
 
   if (!IsHorizontalScrollableTabStripEnabled()) {
     SetScrollOffset(0);
+
+    // No matter scroll offset has changed or not, we should force re-layout
+    // and re-evaluating visibility of all. i.e. ScrollOffset hasn't changed,
+    // we should still force all slot views to be visible and ideal bounds of
+    // them to be recalculated.
+    last_layout_size_ = std::nullopt;
+    InvalidateIdealBounds();
+    UpdateIdealBounds();
+    SetTabSlotVisibility();
+    UpdateClipPathForSlotViews();
+    return;
   }
+
   InvalidateIdealBounds();
   InvalidateLayout();
 }
@@ -1622,9 +1634,9 @@ void BraveTabContainer::ClampScrollOffset() {
 }
 
 void BraveTabContainer::UpdateClipPathForSlotViews() {
-  if (!GetScrollDirection()) {
-    return;
-  }
+  // We don't check scroll direction here, as UpdateClipPathForChildren() will
+  // check it and it'll decide to set clip or clear clip based on the scroll
+  // direction.
   const int pinned_tabs_area_boundary = GetPinnedTabsAreaBoundary();
   int tab_count = GetTabCount();
   for (int i = 0; i < tab_count; ++i) {

--- a/browser/ui/views/tabs/brave_tab_container.cc
+++ b/browser/ui/views/tabs/brave_tab_container.cc
@@ -1666,7 +1666,8 @@ void BraveTabContainer::UpdateClipPathForChildren(
     int pinned_tabs_area_boundary) {
   auto direction = GetScrollDirection();
   if (!view->parent() || !direction) {
-    // The |view| is detached so we just clear clip path.
+    // The |view| is detached or the scroll feature is disabled. In this case,
+    // we should clear clip path so that the view is not clipped.
     view->SetClipPath({});
     return;
   }

--- a/browser/ui/views/tabs/brave_tab_container_browsertest.cc
+++ b/browser/ui/views/tabs/brave_tab_container_browsertest.cc
@@ -76,7 +76,9 @@ class HorizontalScrollableTabStripBrowserTest : public InProcessBrowserTest {
     browser_root_view()->OnMouseWheel(wheel_event);
   }
 
-  void StopAnimatingAndLayout() {
+  void StopAnimatingAndLayout(
+      base::Location location = base::Location::Current()) {
+    SCOPED_TRACE(location.ToString());
     auto* tab_strip = views::AsViewClass<BraveTabStrip>(
         browser_view()->horizontal_tab_strip_for_testing());
     tab_strip->StopAnimating();

--- a/browser/ui/views/tabs/brave_tab_container_browsertest.cc
+++ b/browser/ui/views/tabs/brave_tab_container_browsertest.cc
@@ -77,7 +77,14 @@ class HorizontalScrollableTabStripBrowserTest : public InProcessBrowserTest {
   }
 
   void StopAnimatingAndLayout() {
-    browser_view()->horizontal_tab_strip_for_testing()->StopAnimating();
+    auto* tab_strip = views::AsViewClass<BraveTabStrip>(
+        browser_view()->horizontal_tab_strip_for_testing());
+    tab_strip->StopAnimating();
+    BraveTabContainer* container = views::AsViewClass<BraveTabContainer>(
+        tab_strip->GetTabContainerForTesting());
+    ASSERT_TRUE(container);
+    // In order to reset the last layout size cache, call InvalidateLayout()
+    container->InvalidateLayout();
     RunScheduledLayouts();
   }
 
@@ -650,6 +657,81 @@ IN_PROC_BROWSER_TEST_F(HorizontalScrollableTabStripBrowserTest,
   // released event didn't happen - when button is disabled, event won't be
   // delivered to the button.
   EXPECT_FALSE(region->IsRepeatingEventForTesting(back));
+}
+
+// Regression test: when horizontal scrolling is disabled via pref, every tab
+// must be visible (not clipped away or hidden by a scroll offset) and must
+// have its clip path cleared.  The key code under test is
+// BraveTabContainer::OnScrollableHorizontalTabStripPrefChanged().
+IN_PROC_BROWSER_TEST_F(HorizontalScrollableTabStripBrowserTest,
+                       WhenScrollingDisabledAllTabsVisibleAndClipsCleared) {
+  auto* tab_strip = views::AsViewClass<BraveTabStrip>(
+      browser_view()->horizontal_tab_strip_for_testing());
+  BraveTabContainer* container = views::AsViewClass<BraveTabContainer>(
+      tab_strip->GetTabContainerForTesting());
+  ASSERT_TRUE(container);
+  GrowHorizontalStripUntilMaxOffsetAtLeastNTimesStep(container, 2);
+
+  // We need at least one pinned tab to have a clip path, so that the area
+  // intersected with pinned area can be clipped for tabs.
+  auto* model = browser()->tab_strip_model();
+  model->SetTabPinned(0, true);
+
+  // Scroll to the maximum offset.
+  const int max_offset = container->GetMaxScrollOffsetForTesting();
+  ASSERT_GT(max_offset, 0);
+  container->SetScrollOffsetForTesting(max_offset);
+  StopAnimatingAndLayout();
+
+  // ---- "before" sanity check ----
+  // With scrolling on and it overflows, there must be at least one tab that
+  // has a clip path.
+  bool any_clipped = false;
+  for (int i = 0; i < model->count(); ++i) {
+    Tab* tab = tab_strip->tab_at(i);
+    ASSERT_TRUE(tab);
+    if (!tab->data().pinned && !tab->clip_path().isEmpty()) {
+      any_clipped = true;
+      break;
+    }
+  }
+  ASSERT_TRUE(any_clipped)
+      << "Expected at least one unpinned tab to have a clip path while "
+         "horizontal scrolling is enabled with a pinned tab present.";
+
+  // When scrolling on and it's overflows a lot, a tab that is completely out of
+  // viewport bounds should be invisible
+  bool any_invisible = false;
+  for (int i = 0; i < model->count(); ++i) {
+    Tab* tab = tab_strip->tab_at(i);
+    ASSERT_TRUE(tab);
+    if (!tab->GetVisible()) {
+      any_invisible = true;
+      break;
+    }
+  }
+  ASSERT_TRUE(any_invisible)
+      << "Expected at least one tab to be invisible while horizontal scrolling "
+         "is enabled with a pinned tab present.";
+
+  // ---- Disable horizontal scrolling ----
+  // OnScrollableHorizontalTabStripPrefChanged() fires synchronously and
+  // must clear all clip paths and make all tabs visible.
+  browser()->profile()->GetPrefs()->SetBoolean(
+      brave_tabs::kScrollableHorizontalTabStrip, false);
+  StopAnimatingAndLayout();
+
+  // ---- "after" assertions ----
+  // Every tab must be visible and must have no clip path.
+  for (int i = 0; i < model->count(); ++i) {
+    Tab* tab = tab_strip->tab_at(i);
+    ASSERT_TRUE(tab);
+    EXPECT_TRUE(tab->GetVisible())
+        << "Tab " << i << " should be visible after scrolling is disabled.";
+    EXPECT_TRUE(tab->clip_path().isEmpty())
+        << "Tab " << i
+        << " should have an empty clip path after scrolling is disabled.";
+  }
 }
 
 IN_PROC_BROWSER_TEST_F(HorizontalScrollableTabStripBrowserTest,


### PR DESCRIPTION
When horizontal scrolling is disabled, we should reset the visibility and clip path of all tabs to make them visible and have no clip path.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/55340

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
