### PR TITLE
[Ads][Origin] Defer ads service start until policy service is initialized (uplift to 1.91.x)

### DIFF
--- a/browser/brave_ads/ads_service_factory.cc
+++ b/browser/brave_ads/ads_service_factory.cc
@@ -28,9 +28,11 @@
 #include "chrome/browser/history/history_service_factory.h"
 #include "chrome/browser/notifications/notification_display_service.h"
 #include "chrome/browser/notifications/notification_display_service_factory.h"
+#include "chrome/browser/policy/profile_policy_connector.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/profiles/profile_manager.h"
 #include "components/keyed_service/content/browser_context_dependency_manager.h"
+#include "components/policy/core/common/policy_service.h"
 #include "content/public/browser/browser_context.h"
 #include "content/public/browser/storage_partition.h"
 #include "services/network/public/cpp/network_context_getter.h"
@@ -109,6 +111,11 @@ AdsServiceFactory::BuildServiceInstanceForBrowserContext(
       brave_adaptive_captcha::BraveAdaptiveCaptchaServiceFactory::GetForProfile(
           profile);
 
+  policy::PolicyService* policy_service = nullptr;
+  if (auto* policy_connector = profile->GetProfilePolicyConnector()) {
+    policy_service = policy_connector->policy_service();
+  }
+
   auto delegate = std::make_unique<AdsServiceDelegate>(
       *profile, *local_state, brave_adaptive_captcha_service);
 
@@ -133,7 +140,8 @@ AdsServiceFactory::BuildServiceInstanceForBrowserContext(
   CHECK(profile_manager);
 
   return std::make_unique<AdsServiceImpl>(
-      std::move(delegate), *prefs, *local_state, std::move(http_client),
+      std::move(delegate), *prefs, *local_state, policy_service,
+      std::move(http_client),
       std::make_unique<VirtualPrefProviderDelegate>(
           *profile, profile_manager->GetProfileAttributesStorage()),
       brave::GetChannelName(), profile->GetPath(), CreateAdsTooltipsDelegate(),

--- a/components/brave_ads/browser/BUILD.gn
+++ b/components/brave_ads/browser/BUILD.gn
@@ -52,6 +52,7 @@ static_library("browser") {
     "//brave/components/brave_ads/core/mojom",
     "//brave/components/services/bat_ads/public/interfaces",
     "//components/keyed_service/core",
+    "//components/policy/core/common",
     "//mojo/public/cpp/bindings",
   ]
 

--- a/components/brave_ads/browser/DEPS
+++ b/components/brave_ads/browser/DEPS
@@ -4,6 +4,7 @@ include_rules = [
   "+components/content_settings",
   "+components/metrics",
   "+components/history",
+  "+components/policy/core/common",
   "+components/prefs",
   "+components/variations",
   "+content/public/browser",

--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -143,6 +143,7 @@ AdsServiceImpl::AdsServiceImpl(
           std::move(virtual_pref_provider_delegate))),
       http_client_(std::move(http_client)),
       channel_name_(channel_name),
+      resource_component_(resource_component),
       history_service_(history_service),
       host_content_settings_map_(host_content_settings_map),
       ads_tooltips_delegate_(std::move(ads_tooltips_delegate)),
@@ -152,70 +153,55 @@ AdsServiceImpl::AdsServiceImpl(
           {base::MayBlock(), base::TaskPriority::USER_VISIBLE,
            base::TaskShutdownBehavior::BLOCK_SHUTDOWN})),
       ads_service_path_(profile_path.AppendASCII("ads_service")),
+#if BUILDFLAG(ENABLE_BRAVE_REWARDS)
+      rewards_service_(rewards_service),
+#endif
       bat_ads_client_associated_receiver_(this) {
   CHECK(device_id_);
   CHECK(bat_ads_service_factory_);
 
-  if (!history_service_) {
+  if (!http_client_ || !history_service_ || !host_content_settings_map_ ||
+      !resource_component_) {
     CHECK_IS_TEST();
   }
 
-  if (host_content_settings_map) {
-    host_content_settings_map_observation_.Observe(host_content_settings_map);
-  } else {
-    CHECK_IS_TEST();
-  }
-
-#if BUILDFLAG(ENABLE_BRAVE_REWARDS)
-  if (rewards_service) {
-    rewards_service_observation_.Observe(rewards_service);
-  }
-#endif
-
-  if (CanStartBatAdsService()) {
-    bat_ads_client_notifier_pending_receiver_ =
-        bat_ads_client_notifier_remote_.BindNewPipeAndPassReceiver();
-  }
-
+  // Must run before the pref change registrars to keep prefs consistent across
+  // upgrades regardless of whether the service is eligible to start.
   Migrate();
 
-  InitializeNotificationsForCurrentProfile();
+  // Must be active regardless of whether the service starts so that
+  // pref-driven eligibility changes are always observed.
+  InitializeLocalStatePrefChangeRegistrar();
+  InitializePrefChangeRegistrar();
 
-  GetDeviceIdAndMaybeStartBatAdsService();
-
-  if (resource_component) {
-    resource_component_observation_.Observe(resource_component);
-  } else {
-    CHECK_IS_TEST();
-  }
+  MaybeStartBatAdsService();
 }
 
 AdsServiceImpl::~AdsServiceImpl() = default;
 
 ///////////////////////////////////////////////////////////////////////////////
 
-bool AdsServiceImpl::IsBatAdsServiceBound() const {
-  return bat_ads_service_remote_.is_bound();
-}
 
 void AdsServiceImpl::RegisterResourceComponents() {
-  RegisterResourceComponentsForCurrentCountryCode();
+  RegisterCountryResourceComponent();
 
   if (UserHasOptedInToNotificationAds()) {
     // Only utilized for text classification, which requires the user to have
     // joined Brave Rewards and opted into notification ads.
-    RegisterResourceComponentsForDefaultLanguageCode();
+    RegisterLanguageResourceComponent();
   }
 }
 
 void AdsServiceImpl::Migrate() {
-  int64_t ads_per_hour =
+  // Added 08/2023.
+  const int64_t ads_per_hour =
       prefs_->GetInt64(prefs::kMaximumNotificationAdsPerHour);
   if (ads_per_hour == 0) {
     prefs_->ClearPref(prefs::kMaximumNotificationAdsPerHour);
     prefs_->SetBoolean(prefs::kOptedInToNotificationAds, false);
   }
 
+  // Added 10/2025.
   if (!local_state_->HasPrefPath(prefs::kFirstRunAt)) {
     base::Time first_run_at =
         local_state_->HasPrefPath(metrics::prefs::kInstallDate)
@@ -227,18 +213,16 @@ void AdsServiceImpl::Migrate() {
   }
 }
 
-void AdsServiceImpl::RegisterResourceComponentsForCurrentCountryCode() {
-  if (resource_component_observation_.IsObserving()) {
-    resource_component_observation_.GetSource()
-        ->RegisterComponentForCountryCode(
-            delegate_->GetVariationsCountryCode());
+void AdsServiceImpl::RegisterCountryResourceComponent() {
+  if (resource_component_) {
+    resource_component_->RegisterCountryComponent(
+        delegate_->GetVariationsCountryCode());
   }
 }
 
-void AdsServiceImpl::RegisterResourceComponentsForDefaultLanguageCode() {
-  if (resource_component_observation_.IsObserving()) {
-    resource_component_observation_.GetSource()
-        ->RegisterComponentForLanguageCode(CurrentLanguageCode());
+void AdsServiceImpl::RegisterLanguageResourceComponent() {
+  if (resource_component_) {
+    resource_component_->RegisterLanguageComponent(CurrentLanguageCode());
   }
 }
 
@@ -260,26 +244,6 @@ bool AdsServiceImpl::UserHasOptedInToNotificationAds() const {
 
 bool AdsServiceImpl::UserHasOptedInToSearchResultAds() const {
   return prefs_->GetBoolean(prefs::kOptedInToSearchResultAds);
-}
-
-void AdsServiceImpl::InitializeNotificationsForCurrentProfile() {
-  delegate_->MaybeInitNotificationHelper();
-}
-
-void AdsServiceImpl::GetDeviceIdAndMaybeStartBatAdsService() {
-  device_id_->GetDeviceId(base::BindOnce(
-      &AdsServiceImpl::GetDeviceIdAndMaybeStartBatAdsServiceCallback,
-      weak_ptr_factory_.GetWeakPtr()));
-}
-
-void AdsServiceImpl::GetDeviceIdAndMaybeStartBatAdsServiceCallback(
-    std::string device_id) {
-  sys_info_.device_id = std::move(device_id);
-
-  InitializeLocalStatePrefChangeRegistrar();
-  InitializePrefChangeRegistrar();
-
-  MaybeStartBatAdsService();
 }
 
 bool AdsServiceImpl::CanStartBatAdsService() const {
@@ -305,7 +269,7 @@ void AdsServiceImpl::MaybeStartBatAdsService() {
   // `is_shutting_down_` is set permanently when `KeyedService::Shutdown` is
   // called and the profile begins tearing down. There is no recovery from that
   // state, so any subsequent attempt to restart the service must be suppressed.
-  if (is_shutting_down_ || IsBatAdsServiceBound()) {
+  if (is_shutting_down_ || bat_ads_service_remote_.is_bound()) {
     return;
   }
 
@@ -314,17 +278,34 @@ void AdsServiceImpl::MaybeStartBatAdsService() {
     return;
   }
 
+  if (!cached_device_id_) {
+    // Fetch and cache the device ID; startup resumes in the callback.
+    device_id_->GetDeviceId(base::BindOnce(
+        &AdsServiceImpl::GetDeviceIdAndMaybeStartBatAdsServiceCallback,
+        weak_ptr_factory_.GetWeakPtr()));
+    return;
+  }
+
   StartBatAdsService();
 }
 
+void AdsServiceImpl::GetDeviceIdAndMaybeStartBatAdsServiceCallback(
+    std::string device_id) {
+  cached_device_id_ = std::move(device_id);
+  sys_info_.device_id = *cached_device_id_;
+
+  // Re-run all eligibility guards before proceeding; a pref change may have
+  // made the service ineligible while the device ID fetch was in flight.
+  MaybeStartBatAdsService();
+}
+
 void AdsServiceImpl::StartBatAdsService() {
-  CHECK(!IsBatAdsServiceBound());
+  CHECK(!bat_ads_service_remote_.is_bound());
 
   bat_ads_service_remote_ = bat_ads_service_factory_->Launch();
   bat_ads_service_remote_.set_disconnect_handler(base::BindOnce(
       &AdsServiceImpl::DisconnectHandler, weak_ptr_factory_.GetWeakPtr()));
-
-  CHECK(IsBatAdsServiceBound());
+  CHECK(bat_ads_service_remote_.is_bound());
 
   if (!bat_ads_client_notifier_remote_.is_bound()) {
     bat_ads_client_notifier_pending_receiver_ =
@@ -355,7 +336,7 @@ void AdsServiceImpl::BatAdsServiceCreatedCallback() {
   // Guaranteed by `bat_ads_service_weak_ptr_factory_`. This callback is only
   // reachable while the service is alive, and `ShutdownAdsService` resets
   // `bat_ads_service_remote_` before invalidating the factory.
-  CHECK(IsBatAdsServiceBound());
+  CHECK(bat_ads_service_remote_.is_bound());
 
   SetSysInfo();
 
@@ -384,8 +365,8 @@ void AdsServiceImpl::InitializeBasePathDirectoryCallback(bool success) {
 
 void AdsServiceImpl::InitializeRewardsWallet() {
 #if BUILDFLAG(ENABLE_BRAVE_REWARDS)
-  if (rewards_service_observation_.IsObserving()) {
-    rewards_service_observation_.GetSource()->GetRewardsWallet(
+  if (rewards_service_) {
+    rewards_service_->GetRewardsWallet(
         base::BindOnce(&AdsServiceImpl::InitializeRewardsWalletCallback,
                        bat_ads_service_weak_ptr_factory_.GetWeakPtr()));
   } else {
@@ -441,7 +422,24 @@ void AdsServiceImpl::InitializeBatAdsCallback(bool success) {
 
   is_bat_ads_initialized_ = true;
 
+  delegate_->MaybeInitNotificationHelper();
+
   RegisterResourceComponents();
+
+  if (resource_component_) {
+    resource_component_observation_.Observe(resource_component_.get());
+  }
+
+  if (host_content_settings_map_) {
+    host_content_settings_map_observation_.Observe(
+        host_content_settings_map_.get());
+  }
+
+#if BUILDFLAG(ENABLE_BRAVE_REWARDS)
+  if (rewards_service_) {
+    rewards_service_observation_.Observe(rewards_service_.get());
+  }
+#endif
 
   application_state_monitor_observation_.Observe(
       ApplicationStateMonitor::GetInstance());
@@ -602,12 +600,7 @@ void AdsServiceImpl::SetCommandLineSwitches() {
 }
 
 void AdsServiceImpl::SetContentSettings() {
-  if (!bat_ads_associated_remote_.is_bound()) {
-    return;
-  }
-
-  if (!host_content_settings_map_) {
-    CHECK_IS_TEST();
+  if (!bat_ads_associated_remote_.is_bound() || !host_content_settings_map_) {
     return;
   }
 
@@ -737,17 +730,18 @@ void AdsServiceImpl::InitializeSearchResultAdsPrefChangeRegistrar() {
 
 void AdsServiceImpl::OnAdsPrefChanged(const std::string& path) {
   if (!CanStartBatAdsService()) {
+    // The pref change made the service ineligible to run, so tear it down.
     return ShutdownAdsService();
   }
 
-  if (IsBatAdsServiceBound() && UserHasOptedInToNotificationAds() &&
+  if (bat_ads_service_remote_.is_bound() && UserHasOptedInToNotificationAds() &&
       path == prefs::kOptedInToNotificationAds) {
     // Register language resource components if the user has joined Brave
     // Rewards, opted into notification ads, and the Bat Ads Service has
     // already started.
-    RegisterResourceComponentsForDefaultLanguageCode();
+    RegisterLanguageResourceComponent();
 
-    InitializeNotificationsForCurrentProfile();
+    delegate_->MaybeInitNotificationHelper();
   }
 
   MaybeStartBatAdsService();
@@ -756,10 +750,9 @@ void AdsServiceImpl::OnAdsPrefChanged(const std::string& path) {
 }
 
 void AdsServiceImpl::OnVariationsCountryPrefChanged() {
-  if (!IsBatAdsServiceBound()) {
-    return;
+  if (bat_ads_service_remote_.is_bound()) {
+    RegisterCountryResourceComponent();
   }
-  RegisterResourceComponentsForCurrentCountryCode();
 }
 
 void AdsServiceImpl::NotifyPrefChanged(const std::string& path) const {
@@ -770,13 +763,11 @@ void AdsServiceImpl::NotifyPrefChanged(const std::string& path) const {
 
 #if BUILDFLAG(ENABLE_BRAVE_REWARDS)
 void AdsServiceImpl::GetRewardsWallet() {
-  if (!rewards_service_observation_.IsObserving()) {
-    return;
+  if (rewards_service_) {
+    rewards_service_->GetRewardsWallet(
+        base::BindOnce(&AdsServiceImpl::NotifyRewardsWalletDidUpdate,
+                       weak_ptr_factory_.GetWeakPtr()));
   }
-
-  rewards_service_observation_.GetSource()->GetRewardsWallet(
-      base::BindOnce(&AdsServiceImpl::NotifyRewardsWalletDidUpdate,
-                     weak_ptr_factory_.GetWeakPtr()));
 }
 
 void AdsServiceImpl::NotifyRewardsWalletDidUpdate(
@@ -1026,6 +1017,14 @@ void AdsServiceImpl::ShutdownAdsService() {
   idle_state_timer_.Stop();
 
   notification_ad_timers_.clear();
+
+  resource_component_observation_.Reset();
+
+  host_content_settings_map_observation_.Reset();
+
+#if BUILDFLAG(ENABLE_BRAVE_REWARDS)
+  rewards_service_observation_.Reset();
+#endif
 
   application_state_monitor_observation_.Reset();
 
@@ -1498,12 +1497,12 @@ void AdsServiceImpl::LoadResourceComponent(
     const std::string& id,
     int version,
     LoadResourceComponentCallback callback) {
-  if (!resource_component_observation_.IsObserving()) {
+  if (!resource_component_) {
     return std::move(callback).Run({});
   }
 
   std::optional<base::FilePath> file_path =
-      resource_component_observation_.GetSource()->MaybeGetPath(id, version);
+      resource_component_->MaybeGetPath(id, version);
   if (!file_path) {
     return std::move(callback).Run({});
   }
@@ -1612,9 +1611,8 @@ void AdsServiceImpl::Log(const std::string& file,
                          int32_t verbose_level,
                          const std::string& message) {
 #if BUILDFLAG(ENABLE_BRAVE_REWARDS)
-  if (rewards_service_observation_.IsObserving()) {
-    rewards_service_observation_.GetSource()->WriteDiagnosticLog(
-        file, line, verbose_level, message);
+  if (rewards_service_) {
+    rewards_service_->WriteDiagnosticLog(file, line, verbose_level, message);
   }
 #endif  // BUILDFLAG(ENABLE_BRAVE_REWARDS)
 

--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <memory>
 #include <optional>
+#include <sstream>
 #include <utility>
 
 #include "base/base64.h"
@@ -55,6 +56,7 @@
 #include "components/content_settings/core/common/content_settings.h"
 #include "components/content_settings/core/common/content_settings_pattern.h"
 #include "components/metrics/metrics_pref_names.h"
+#include "components/policy/core/common/policy_service.h"
 #include "components/prefs/pref_service.h"
 #include "components/variations/pref_names.h"
 #include "content/public/browser/browser_context.h"
@@ -68,6 +70,25 @@
 #endif
 
 namespace brave_ads {
+
+// `LAZY_BLOG` mirrors `BLOG` from
+// `brave/components/brave_ads/core/internal/common/logging_util.h`, but with
+// the level check pulled out so the stream isn't built when the
+// `*/brave_ads/*` vmodule pattern isn't set. We can't use `VLOG` here: in
+// official Android release builds `base/logging.h` returns `-1` from the
+// templated `GetVlogLevel()` as a constexpr, which lets the compiler
+// dead-code-strip every `VLOG` site (including its string literals) for
+// binary-size reasons. `Log()` (the `AdsServiceImpl` member) routes through
+// `GetVlogLevelHelper` directly, so this macro fires whenever the
+// "Verbose Logs for Ad-Rewards" QA preference toggle is on.
+#define LAZY_BLOG(verbose_level, stream)                             \
+  do {                                                               \
+    if ((verbose_level) <=                                           \
+        ::logging::GetVlogLevelHelper(__FILE__, sizeof(__FILE__))) { \
+      Log(__FILE__, __LINE__, (verbose_level),                       \
+          (std::ostringstream() << stream).str());                   \
+    }                                                                \
+  } while (false)
 
 namespace {
 
@@ -120,6 +141,7 @@ AdsServiceImpl::AdsServiceImpl(
     std::unique_ptr<Delegate> delegate,
     PrefService& prefs,
     PrefService& local_state,
+    policy::PolicyService* policy_service,
     std::unique_ptr<HttpClient> http_client,
     std::unique_ptr<VirtualPrefProvider::Delegate>
         virtual_pref_provider_delegate,
@@ -174,10 +196,40 @@ AdsServiceImpl::AdsServiceImpl(
   InitializeLocalStatePrefChangeRegistrar();
   InitializePrefChangeRegistrar();
 
-  MaybeStartBatAdsService();
+  // Defer the initial start until the policy bundle has been merged into
+  // the managed pref store, so that BraveRewardsDisabled (and any other
+  // policy that gates ads eligibility) takes effect before the gate
+  // evaluates. If the service is already initialized, start immediately;
+  // otherwise observe and wait for `OnPolicyServiceInitialized`.
+  const bool has_policy_service = policy_service != nullptr;
+  const bool policy_init_complete =
+      has_policy_service &&
+      policy_service->IsInitializationComplete(policy::POLICY_DOMAIN_CHROME);
+  LAZY_BLOG(1,
+            "[AdsGate] AdsServiceImpl ctor"
+                << " has_policy_service=" << has_policy_service
+                << " policy_init_complete=" << policy_init_complete
+                << " is_managed="
+                << prefs_->IsManagedPreference(
+                       brave_rewards::prefs::kDisabledByPolicy)
+                << " disabled_by_policy="
+                << prefs_->GetBoolean(brave_rewards::prefs::kDisabledByPolicy));
+
+  if (!has_policy_service || policy_init_complete) {
+    LAZY_BLOG(1, "[AdsGate] starting immediately at ctor");
+    MaybeStartBatAdsService();
+  } else {
+    LAZY_BLOG(1, "[AdsGate] deferring start, observing PolicyService");
+    policy_service->AddObserver(policy::POLICY_DOMAIN_CHROME, this);
+    observed_policy_service_ = policy_service;
+  }
 }
 
-AdsServiceImpl::~AdsServiceImpl() = default;
+AdsServiceImpl::~AdsServiceImpl() {
+  // Defensive: in normal `KeyedService` lifecycle `Shutdown()` already removed
+  // the observer. This covers tests that destruct without calling `Shutdown`.
+  StopObservingPolicyService();
+}
 
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -266,6 +318,16 @@ bool AdsServiceImpl::CanStartBatAdsService() const {
 }
 
 void AdsServiceImpl::MaybeStartBatAdsService() {
+  LAZY_BLOG(1,
+            "[AdsGate] MaybeStartBatAdsService"
+                << " bound=" << bat_ads_service_remote_.is_bound()
+                << " shutting_down=" << is_shutting_down_
+                << " can_start=" << CanStartBatAdsService() << " is_managed="
+                << prefs_->IsManagedPreference(
+                       brave_rewards::prefs::kDisabledByPolicy)
+                << " disabled_by_policy="
+                << prefs_->GetBoolean(brave_rewards::prefs::kDisabledByPolicy));
+
   // `is_shutting_down_` is set permanently when `KeyedService::Shutdown` is
   // called and the profile begins tearing down. There is no recovery from that
   // state, so any subsequent attempt to restart the service must be suppressed.
@@ -729,6 +791,15 @@ void AdsServiceImpl::InitializeSearchResultAdsPrefChangeRegistrar() {
 }
 
 void AdsServiceImpl::OnAdsPrefChanged(const std::string& path) {
+  LAZY_BLOG(1,
+            "[AdsGate] OnAdsPrefChanged path="
+                << path << " can_start=" << CanStartBatAdsService() << " bound="
+                << bat_ads_service_remote_.is_bound() << " is_managed="
+                << prefs_->IsManagedPreference(
+                       brave_rewards::prefs::kDisabledByPolicy)
+                << " disabled_by_policy="
+                << prefs_->GetBoolean(brave_rewards::prefs::kDisabledByPolicy));
+
   if (!CanStartBatAdsService()) {
     // The pref change made the service ineligible to run, so tear it down.
     return ShutdownAdsService();
@@ -1045,6 +1116,8 @@ void AdsServiceImpl::Shutdown() {
   // The profile is being destroyed and the service must never start again, so
   // this is never reset to false.
   is_shutting_down_ = true;
+
+  StopObservingPolicyService();
 
   ShutdownAdsService();
 }
@@ -1696,6 +1769,26 @@ void AdsServiceImpl::OnContentSettingChanged(
   if (content_type_set.Contains(ContentSettingsType::JAVASCRIPT)) {
     SetContentSettings();
   }
+}
+
+void AdsServiceImpl::OnPolicyServiceInitialized(policy::PolicyDomain domain) {
+  LAZY_BLOG(1, "[AdsGate] OnPolicyServiceInitialized domain="
+                   << domain << " is_chrome_domain="
+                   << (domain == policy::POLICY_DOMAIN_CHROME));
+  if (domain != policy::POLICY_DOMAIN_CHROME) {
+    return;
+  }
+  StopObservingPolicyService();
+  LAZY_BLOG(1, "[AdsGate] deferred start firing now");
+  MaybeStartBatAdsService();
+}
+
+void AdsServiceImpl::StopObservingPolicyService() {
+  if (!observed_policy_service_) {
+    return;
+  }
+  observed_policy_service_->RemoveObserver(policy::POLICY_DOMAIN_CHROME, this);
+  observed_policy_service_ = nullptr;
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/browser/ads_service_impl.h
+++ b/components/brave_ads/browser/ads_service_impl.h
@@ -115,11 +115,10 @@ class AdsServiceImpl : public AdsService,
 
  private:
   friend class BraveAdsAdsServiceImplTest;
-  bool IsBatAdsServiceBound() const;
 
   void RegisterResourceComponents();
-  void RegisterResourceComponentsForCurrentCountryCode();
-  void RegisterResourceComponentsForDefaultLanguageCode();
+  void RegisterCountryResourceComponent();
+  void RegisterLanguageResourceComponent();
 
   void Migrate();
 
@@ -128,13 +127,9 @@ class AdsServiceImpl : public AdsService,
   bool UserHasOptedInToNotificationAds() const;
   bool UserHasOptedInToSearchResultAds() const;
 
-  void InitializeNotificationsForCurrentProfile();
-
-  void GetDeviceIdAndMaybeStartBatAdsService();
-  void GetDeviceIdAndMaybeStartBatAdsServiceCallback(std::string device_id);
-
   bool CanStartBatAdsService() const;
   void MaybeStartBatAdsService();
+  void GetDeviceIdAndMaybeStartBatAdsServiceCallback(std::string device_id);
   void StartBatAdsService();
   void DisconnectHandler();
   void BatAdsServiceCreatedCallback();
@@ -408,6 +403,8 @@ class AdsServiceImpl : public AdsService,
 
   mojom::SysInfo sys_info_;
 
+  std::optional<std::string> cached_device_id_;
+
   base::RepeatingTimer idle_state_timer_;
   ui::IdleState last_idle_state_ = ui::IdleState::IDLE_STATE_ACTIVE;
   base::TimeDelta last_idle_time_;
@@ -429,6 +426,7 @@ class AdsServiceImpl : public AdsService,
 
   const std::string channel_name_;
 
+  const raw_ptr<ResourceComponent> resource_component_;  // Not owned.
   base::ScopedObservation<ResourceComponent, ResourceComponentObserver>
       resource_component_observation_{this};
 
@@ -450,6 +448,7 @@ class AdsServiceImpl : public AdsService,
   const base::FilePath ads_service_path_;
 
 #if BUILDFLAG(ENABLE_BRAVE_REWARDS)
+  const raw_ptr<brave_rewards::RewardsService> rewards_service_;  // Not owned.
   base::ScopedObservation<brave_rewards::RewardsService,
                           brave_rewards::RewardsServiceObserver>
       rewards_service_observation_{this};

--- a/components/brave_ads/browser/ads_service_impl.h
+++ b/components/brave_ads/browser/ads_service_impl.h
@@ -40,6 +40,7 @@
 #include "components/content_settings/core/browser/content_settings_type_set.h"
 #include "components/content_settings/core/common/content_settings_pattern.h"
 #include "components/history/core/browser/history_service.h"
+#include "components/policy/core/common/policy_service.h"
 #include "components/prefs/pref_change_registrar.h"
 #include "mojo/public/cpp/bindings/associated_receiver.h"
 #include "mojo/public/cpp/bindings/associated_remote.h"
@@ -77,15 +78,20 @@ class AdsServiceImpl : public AdsService,
 #if BUILDFLAG(ENABLE_BRAVE_REWARDS)
                        public brave_rewards::RewardsServiceObserver,
 #endif
-                       public content_settings::Observer {
+                       public content_settings::Observer,
+                       public policy::PolicyService::Observer {
  public:
   // `http_client`, `resource_component`, `history_service`, and
   // `host_content_settings` can be `nullptr` in tests. `rewards_service`
   // can be `nullptr` when Rewards is unsupported or disabled by policy.
+  // `policy_service` can be `nullptr` in tests; when null, the initial
+  // ads-eligibility gate is evaluated synchronously instead of waiting
+  // for `OnPolicyServiceInitialized`.
   explicit AdsServiceImpl(
       std::unique_ptr<Delegate> delegate,
       PrefService& prefs,
       PrefService& local_state,
+      policy::PolicyService* policy_service,
       std::unique_ptr<HttpClient> http_client,
       std::unique_ptr<VirtualPrefProvider::Delegate>
           virtual_pref_provider_delegate,
@@ -389,6 +395,13 @@ class AdsServiceImpl : public AdsService,
       const ContentSettingsPattern& secondary_pattern,
       ContentSettingsTypeSet content_type_set) override;
 
+  // policy::PolicyService::Observer:
+  void OnPolicyServiceInitialized(policy::PolicyDomain domain) override;
+
+  // No-op if not observing. Called from `OnPolicyServiceInitialized`,
+  // `Shutdown`, and the destructor; whichever runs first wins.
+  void StopObservingPolicyService();
+
   bool is_ineligible_to_start_ = false;
 
   bool is_bat_ads_initialized_ = false;
@@ -455,6 +468,8 @@ class AdsServiceImpl : public AdsService,
 #endif  // BUILDFLAG(ENABLE_BRAVE_REWARDS)
   base::ScopedObservation<ApplicationStateMonitor, ApplicationStateObserver>
       application_state_monitor_observation_{this};
+
+  raw_ptr<policy::PolicyService> observed_policy_service_ = nullptr;
 
   mojo::Receiver<bat_ads::mojom::BatAdsObserver> bat_ads_observer_receiver_{
       this};

--- a/components/brave_ads/browser/ads_service_impl_unittest.cc
+++ b/components/brave_ads/browser/ads_service_impl_unittest.cc
@@ -80,7 +80,7 @@ class BraveAdsAdsServiceImplTest : public testing::Test {
 
     ads_service_ = std::make_unique<AdsServiceImpl>(
         std::make_unique<test::FakeAdsServiceDelegate>(), prefs_, local_state_,
-        /*http_client=*/nullptr,
+        /*policy_service=*/nullptr, /*http_client=*/nullptr,
         std::make_unique<test::FakeVirtualPrefProviderDelegate>(),
         /*channel_name=*/"foo", profile_dir_.GetPath(),
         std::make_unique<test::FakeAdsTooltipsDelegate>(), std::move(device_id),

--- a/components/brave_ads/browser/component_updater/resource_component.cc
+++ b/components/brave_ads/browser/component_updater/resource_component.cc
@@ -64,12 +64,12 @@ void ResourceComponent::RemoveObserver(ResourceComponentObserver* observer) {
   observers_.RemoveObserver(observer);
 }
 
-void ResourceComponent::RegisterComponentForCountryCode(
+void ResourceComponent::RegisterCountryComponent(
     const std::string& country_code) {
   country_resource_component_registrar_.RegisterResourceComponent(country_code);
 }
 
-void ResourceComponent::RegisterComponentForLanguageCode(
+void ResourceComponent::RegisterLanguageComponent(
     const std::string& language_code) {
   language_resource_component_registrar_.RegisterResourceComponent(
       language_code);

--- a/components/brave_ads/browser/component_updater/resource_component.h
+++ b/components/brave_ads/browser/component_updater/resource_component.h
@@ -37,8 +37,8 @@ class ResourceComponent final : public ResourceComponentRegistrarDelegate {
   void AddObserver(ResourceComponentObserver* observer);
   void RemoveObserver(ResourceComponentObserver* observer);
 
-  void RegisterComponentForCountryCode(const std::string& country_code);
-  void RegisterComponentForLanguageCode(const std::string& language_code);
+  void RegisterCountryComponent(const std::string& country_code);
+  void RegisterLanguageComponent(const std::string& language_code);
 
   std::optional<base::FilePath> MaybeGetPath(const std::string& id,
                                              int version);


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/36015
Uplift of https://github.com/brave/brave-core/pull/36151
Resolves https://github.com/brave/brave-browser/issues/55228
Resolves https://github.com/brave/brave-browser/issues/54991

### Test plan
Test plan is specified in PRs description:
* https://github.com/brave/brave-core/pull/36015
* https://github.com/brave/brave-core/pull/36151
