### PR TITLE
Uplift brave://ads-internals policy gating to 1.91.x

### DIFF
--- a/browser/brave_rewards/test/rewards_policy_browsertest.cc
+++ b/browser/brave_rewards/test/rewards_policy_browsertest.cc
@@ -128,6 +128,17 @@ IN_PROC_BROWSER_TEST_P(BraveRewardsPolicyTest, RewardsPagesAccess) {
   }
 }
 
+#if BUILDFLAG(ENABLE_BRAVE_ADS)
+// Verify that brave://ads-internals isn't reachable when Brave Rewards are
+// disabled by policy.
+IN_PROC_BROWSER_TEST_P(BraveRewardsPolicyTest, AdsInternalsPageAccess) {
+  auto* rfh =
+      ui_test_utils::NavigateToURL(browser(), GURL("chrome://ads-internals"));
+  EXPECT_TRUE(rfh);
+  EXPECT_EQ(IsBraveRewardsDisabledTest(), rfh->IsErrorDocument());
+}
+#endif  // BUILDFLAG(ENABLE_BRAVE_ADS)
+
 // Verify that Brave Rewards icon is not shown in the location bar when Brave
 // Rewards are disabled by policy.
 IN_PROC_BROWSER_TEST_P(BraveRewardsPolicyTest, RewardsIconIsHidden) {

--- a/browser/ui/webui/brave_web_ui_controller_factory.cc
+++ b/browser/ui/webui/brave_web_ui_controller_factory.cc
@@ -93,6 +93,10 @@
 #include "brave/browser/ui/webui/brave_rewards_internals_ui.h"
 #endif
 
+#if BUILDFLAG(ENABLE_BRAVE_ADS)
+#include "brave/components/brave_rewards/core/pref_names.h"
+#endif
+
 using content::WebUI;
 using content::WebUIController;
 
@@ -111,7 +115,9 @@ WebUIController* NewWebUI(WebUI* web_ui, const GURL& url) {
   if (host == kSkusInternalsHost) {
     return new SkusInternalsUI(web_ui, url.host());
 #if BUILDFLAG(ENABLE_BRAVE_ADS)
-  } else if (host == kAdsInternalsHost) {
+  } else if (host == kAdsInternalsHost &&
+             !profile->GetPrefs()->GetBoolean(
+                 brave_rewards::prefs::kDisabledByPolicy)) {
     return new AdsInternalsUI(
         web_ui, url.host(),
         brave_ads::AdsServiceFactory::GetForProfile(profile),
@@ -227,7 +233,9 @@ WebUIFactoryFunction GetWebUIFactoryFunction(WebUI* web_ui,
       url.host() == kRewardsPageHost || url.host() == kRewardsInternalsHost ||
 #endif
 #if BUILDFLAG(ENABLE_BRAVE_ADS)
-      (url.host() == kAdsInternalsHost && !profile->IsIncognitoProfile()) ||
+      (url.host() == kAdsInternalsHost && !profile->IsIncognitoProfile() &&
+       !profile->GetPrefs()->GetBoolean(
+           brave_rewards::prefs::kDisabledByPolicy)) ||
 #endif  // BUILDFLAG(ENABLE_BRAVE_ADS)
       (url.host() == kSkusInternalsHost &&
        base::FeatureList::IsEnabled(skus::features::kSkusFeature))) {


### PR DESCRIPTION
Uplift of #36223
Fix https://github.com/brave/brave-browser/issues/55434

## Included PRs
- #36223 - Gate brave://ads-internals on Brave Rewards policy

Pre-approval checklist:
- [x] You have tested your change on Nightly.
- [ ] This contains text which needs to be translated.
    - [ ] There are more than 7 days before the release.
    - [ ] I've notified folks in #l10n on Slack that translations are needed.
- [x] The PR milestones match the branch they are landing to.


Pre-merge checklist:
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.

Post-merge checklist:
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.