### PR TITLE
Fix SERP metrics tests flakiness

### DIFF
--- a/browser/serp_metrics/serp_metrics_all_profiles_aggregator_unittest.cc
+++ b/browser/serp_metrics/serp_metrics_all_profiles_aggregator_unittest.cc
@@ -31,6 +31,14 @@ class SerpMetricsAllProfilesAggregatorTest : public ::testing::Test {
   ~SerpMetricsAllProfilesAggregatorTest() override = default;
 
   void SetUp() override {
+    // Advance to a specific time so tests have a predictable starting point
+    // to avoid MOCK_TIME starting near Unix epoch, where times serialize to
+    // 0.0 via `InSecondsFSinceUnixEpoch` and deserialize back as null rather
+    // than UnixEpoch, causing a DCHECK in `UTCMidnight`.
+    base::Time time;
+    CHECK(base::Time::FromUTCString("2050-01-04 12:35:56", &time));
+    task_environment_.AdvanceClock(time - base::Time::Now());
+
     local_state_.registry()->RegisterStringPref(kLastCheckYMD,
                                                 "");  // Never checked.
     local_state_.registry()->RegisterTimePref(

--- a/browser/serp_metrics/serp_metrics_migration_unittest.cc
+++ b/browser/serp_metrics/serp_metrics_migration_unittest.cc
@@ -50,6 +50,14 @@ class SerpMetricsMigrationTest : public testing::Test {
   ~SerpMetricsMigrationTest() override = default;
 
   void SetUp() override {
+    // Advance to a specific time so tests have a predictable starting point
+    // to avoid MOCK_TIME starting near Unix epoch, where times serialize to
+    // 0.0 via `InSecondsFSinceUnixEpoch` and deserialize back as null rather
+    // than UnixEpoch, causing a DCHECK in `UTCMidnight`.
+    base::Time time;
+    CHECK(base::Time::FromUTCString("2050-01-04 12:35:56", &time));
+    task_environment_.AdvanceClock(time - base::Time::Now());
+
     local_state_.registry()->RegisterStringPref(kLastCheckYMD,
                                                 "");  // Never checked.
     local_state_.registry()->RegisterTimePref(


### PR DESCRIPTION
The PR advances time in `SERP metrics` tests to a fixed date so they have a predictable starting point regardless of what time MOCK_TIME sets on any given machine. When MOCK_TIME starts near Unix epoch on January 1, 1970, calling UTCMidnight causes InSecondsFSinceUnixEpoch to serialize the result to 0.0. Deserializing that value via FromSecondsSinceUnixEpoch produces a null Time rather than UnixEpoch, and calling UTCMidnight on null hits a DCHECK.

The PR fixes `SERP metrics` tests failure on CI happened for @supermassive:
```
AggregateStalePeriodRecordedMetricsForMultipleProfiles
AggregateStalePeriodRecordedMetricsForSingleProfile
AggregateYesterdayRecordedMetricsForMultipleProfiles
AggregateYesterdayRecordedMetricsForSingleProfile
DoubleMigrationIsNoOp
MigrateFromNonEmptySerpMetrics
MigrateFromNonEmptySerpMetricsAndRecordNextDay

[ RUN      ] SerpMetricsAllProfilesAggregatorTest.AggregateStalePeriodRecordedMetricsForMultipleProfiles
[12526:806593:FATAL:base/time/time.cc:124] DCHECK failed: is_local.
0   brave_unit_tests                    0x00000001086a1cb4 base::debug::CollectStackTrace(base::span<void const*, 18446744073709551615ul, void const**>) + 28
1   brave_unit_tests                    0x00000001086907d8 base::debug::StackTrace::StackTrace(unsigned long) + 224
2   brave_unit_tests                    0x00000001085a5104 logging::LogMessage::Flush() + 152
3   brave_unit_tests                    0x00000001085a4fe4 logging::LogMessage::~LogMessage() + 36
4   brave_unit_tests                    0x000000010858d490 logging::(anonymous namespace)::DCheckLogMessage::~DCheckLogMessage() + 76
5   brave_unit_tests                    0x000000010858cd58 logging::CheckError::~CheckError() + 44
6   brave_unit_tests                    0x000000010858cd98 logging::CheckError::~CheckError() + 12
7   brave_unit_tests                    0x0000000108679c74 base::Time::Midnight(bool) const + 116
8   brave_unit_tests                    0x00000001117317ac serp_metrics::SerpMetricsTimePeriodStorage::Load() + 424
9   brave_unit_tests                    0x0000000111731a10 serp_metrics::SerpMetricsTimePeriodStorage::SerpMetricsTimePeriodStorage(std::__Cr::unique_ptr<serp_metrics::SerpMetricsTimePeriodStore, std::__Cr::default_delete<serp_metrics::SerpMetricsTimePeriodStore>>, unsigned long) + 48
10  brave_unit_tests                    0x000000011172fc1c serp_metrics::SerpMetrics::SerpMetrics(PrefService*, serp_metrics::SerpMetricsTimePeriodStoreFactory const&) + 228
11  brave_unit_tests                    0x000000011172e3c4 serp_metrics::SerpMetricsAllProfilesAggregator::SerpMetricsAllProfilesAggregator(PrefService*, ProfileAttributesStorage&) + 228
12  brave_unit_tests                    0x0000000100f53168 serp_metrics::SerpMetricsAllProfilesAggregatorTest_AggregateStalePeriodRecordedMetricsForMultipleProfiles_Test::TestBody() + 856
13  brave_unit_tests                    0x000000010849d8bc testing::Test::Run() + 252
14  brave_unit_tests                    0x000000010849e680 testing::TestInfo::Run() + 400
15  brave_unit_tests                    0x000000010849f3a8 testing::TestSuite::Run() + 956
16  brave_unit_tests                    0x00000001084ad0cc testing::internal::UnitTestImpl::RunAllTests() + 1720
17  brave_unit_tests                    0x00000001084ac9ac testing::UnitTest::Run() + 228
18  brave_unit_tests                    0x0000000108705658 base::TestSuite::Run() + 244
19  brave_unit_tests                    0x000000010130d4f8 base::OnceCallback<std::__Cr::unique_ptr<std::__Cr::vector<scoped_refptr<extensions::Action>, std::__Cr::allocator<scoped_refptr<extensions::Action>>>, std::__Cr::default_delete<std::__Cr::vector<scoped_refptr<extensions::Action>, std::__Cr::allocator<scoped_refptr<extensions::Action>>>>> ()>::Run() && + 112
20  brave_unit_tests                    0x000000010871f508 base::(anonymous namespace)::LaunchUnitTestsInternal(base::OnceCallback<int ()>, unsigned long, int, unsigned long, bool, base::RepeatingCallback<void ()>, base::OnceCallback<void ()>) + 640
21  brave_unit_tests                    0x000000010871f264 base::LaunchUnitTests(int, char**, base::OnceCallback<int ()>, unsigned long) + 236
22  brave_unit_tests                    0x0000000108589dfc main + 348
23  dyld                                0x00000001995ceb98 start + 6076

```

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
