### PR TITLE
[Cleanup] Remove container concept from BraveToolbarView

### DIFF
--- a/browser/ui/views/toolbar/brave_toolbar_view.cc
+++ b/browser/ui/views/toolbar/brave_toolbar_view.cc
@@ -197,14 +197,6 @@ void BraveToolbarView::Init() {
   // See brave_non_client_hit_test_helper.h
   views::SetHitTestComponent(this, HTCAPTION);
 
-  DCHECK(location_bar_view_);
-  // Get ToolbarView's container_view as a parent of location_bar_view_ because
-  // container_view's type in ToolbarView is internal to toolbar_view.cc.
-  views::View* container_view = location_bar_view_->parent();
-  DCHECK(container_view);
-
-  views::SetHitTestComponent(container_view, HTCAPTION);
-
   // For non-normal mode, we don't have to do any more work.
   if (display_mode_ != DisplayMode::kNormal) {
     brave_initialized_ = true;
@@ -217,7 +209,7 @@ void BraveToolbarView::Init() {
   // buttons. Upstream conditionally creates |toolbar_divider_|, they check
   // whether it's null or not. So safe to make remove here.
   if (toolbar_divider_) {
-    auto view = container_view->RemoveChildViewT(toolbar_divider_.get());
+    auto view = RemoveChildViewT(toolbar_divider_.get());
     toolbar_divider_ = nullptr;
   }
 
@@ -303,12 +295,12 @@ void BraveToolbarView::Init() {
 
   // Add vertical tab toggle button to the left of the back button.
   if (tabs::utils::SupportsBraveVerticalTabs(browser_)) {
-    auto back_button_index = container_view->GetIndexOf(back_);
-    vertical_tab_toggle_ = container_view->AddChildViewAt(
-        std::make_unique<ToolbarButton>(
-            base::BindRepeating(&BraveToolbarView::OnVerticalTabTogglePressed,
-                                base::Unretained(this))),
-        back_button_index.value_or(0));
+    auto back_button_index = GetIndexOf(back_);
+    vertical_tab_toggle_ =
+        AddChildViewAt(std::make_unique<ToolbarButton>(base::BindRepeating(
+                           &BraveToolbarView::OnVerticalTabTogglePressed,
+                           base::Unretained(this))),
+                       back_button_index.value_or(0));
     vertical_tab_toggle_->SetVectorIcon(
         vertical_tabs_collapsed_.GetValue()
             ? kVerticalTabStripToggleCollapsedIcon
@@ -317,24 +309,23 @@ void BraveToolbarView::Init() {
     UpdateVerticalTabToggleState();
   }
 
-  bookmark_ = container_view->AddChildViewAt(
-      std::make_unique<BraveBookmarkButton>(
-          base::BindRepeating(callback, browser_, IDC_BOOKMARK_THIS_TAB)),
-      *container_view->GetIndexOf(location_bar_view_));
+  bookmark_ =
+      AddChildViewAt(std::make_unique<BraveBookmarkButton>(base::BindRepeating(
+                         callback, browser_, IDC_BOOKMARK_THIS_TAB)),
+                     *GetIndexOf(location_bar_view_));
   bookmark_->SetTriggerableEventFlags(ui::EF_LEFT_MOUSE_BUTTON |
                                       ui::EF_MIDDLE_MOUSE_BUTTON);
   bookmark_->UpdateImageAndText();
   SetBraveButtonFlexBehavior(bookmark_);
 
-  side_panel_ = container_view->AddChildViewAt(
-      std::make_unique<SidePanelButton>(browser()),
-      *container_view->GetIndexOf(GetAppMenuButton()) - 1);
+  side_panel_ = AddChildViewAt(std::make_unique<SidePanelButton>(browser()),
+                               *GetIndexOf(GetAppMenuButton()) - 1);
   SetBraveButtonFlexBehavior(side_panel_);
 
 #if BUILDFLAG(ENABLE_BRAVE_WALLET)
-  wallet_ = container_view->AddChildViewAt(
+  wallet_ = AddChildViewAt(
       std::make_unique<WalletButton>(GetAppMenuButton(), profile),
-      *container_view->GetIndexOf(GetAppMenuButton()) - 1);
+      *GetIndexOf(GetAppMenuButton()) - 1);
   wallet_->SetTriggerableEventFlags(ui::EF_LEFT_MOUSE_BUTTON |
                                     ui::EF_MIDDLE_MOUSE_BUTTON);
   wallet_->UpdateImageAndText();
@@ -347,9 +338,8 @@ void BraveToolbarView::Init() {
   // Don't check policy status since we're going to
   // setup a watcher for policy pref.
   if (ai_chat::IsAllowedForContext(browser_->profile(), false)) {
-    ai_chat_button_ = container_view->AddChildViewAt(
-        std::make_unique<AIChatButton>(browser()),
-        *container_view->GetIndexOf(GetAppMenuButton()) - 1);
+    ai_chat_button_ = AddChildViewAt(std::make_unique<AIChatButton>(browser()),
+                                     *GetIndexOf(GetAppMenuButton()) - 1);
     SetBraveButtonFlexBehavior(ai_chat_button_);
     show_ai_chat_button_.Init(
         ai_chat::prefs::kBraveAIChatShowToolbarButton,
@@ -366,9 +356,8 @@ void BraveToolbarView::Init() {
 
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
   if (brave_vpn::BraveVpnServiceFactory::GetForProfile(profile)) {
-    brave_vpn_ = container_view->AddChildViewAt(
-        std::make_unique<BraveVPNButton>(browser()),
-        *container_view->GetIndexOf(GetAppMenuButton()) - 1);
+    brave_vpn_ = AddChildViewAt(std::make_unique<BraveVPNButton>(browser()),
+                                *GetIndexOf(GetAppMenuButton()) - 1);
     SetBraveButtonFlexBehavior(brave_vpn_);
     show_brave_vpn_button_.Init(
         brave_vpn::prefs::kBraveVPNShowButton, profile->GetPrefs(),
@@ -384,8 +373,7 @@ void BraveToolbarView::Init() {
 
   // Make sure that avatar button should be located right before the app menu.
   if (auto* avatar = GetAvatarToolbarButton()) {
-    container_view->ReorderChildView(
-        avatar, *container_view->GetIndexOf(GetAppMenuButton()) - 1);
+    ReorderChildView(avatar, *GetIndexOf(GetAppMenuButton()) - 1);
   }
 
   if (tabs::utils::SupportsBraveVerticalTabs(browser_)) {
@@ -498,18 +486,13 @@ void BraveToolbarView::UpdateHorizontalPadding() {
     return;
   }
 
-  // Get ToolbarView's container_view as a parent of location_bar_view_ because
-  // container_view's type in ToolbarView is internal to toolbar_view.cc.
-  DCHECK(location_bar_view_ && location_bar_view_->parent());
-  views::View* container_view = location_bar_view_->parent();
-
   if (!tabs::utils::ShouldShowBraveVerticalTabs(browser()) ||
       tabs::utils::ShouldShowWindowTitleForVerticalTabs(browser())) {
-    container_view->SetBorder(nullptr);
+    SetBorder(nullptr);
     return;
   }
 
-  const gfx::Insets current_insets = container_view->GetInsets();
+  const gfx::Insets current_insets = GetInsets();
   auto [leading, trailing] = tabs::utils::GetLeadingTrailingCaptionButtonWidth(
       browser_view_->browser_widget());
 
@@ -518,7 +501,7 @@ void BraveToolbarView::UpdateHorizontalPadding() {
   if (current_insets.left() == leading && current_insets.right() == trailing) {
     return;
   }
-  container_view->SetBorder(views::CreateEmptyBorder(
+  SetBorder(views::CreateEmptyBorder(
       gfx::Insets().set_left(leading).set_right(trailing)));
 }
 
@@ -675,15 +658,10 @@ void BraveToolbarView::UpdateVerticalTabToggleVisibility() {
 void BraveToolbarView::UpdateVerticalTabTogglePlacement() {
   // Callers must gate on `SupportsBraveVerticalTabs(browser_)`, which both
   // ensures we're in `DisplayMode::kNormal` (other modes early-return from
-  // `Init()` before the toggle is created) and guarantees the toggle has
-  // been added as a child of `container_view`.
+  // `Init()` before the toggle is created).
   CHECK(vertical_tab_toggle_);
-  CHECK(location_bar_view_);
-  CHECK(location_bar_view_->parent());
-  views::View* container_view = location_bar_view_->parent();
 
-  const std::optional<size_t> toggle_idx =
-      container_view->GetIndexOf(vertical_tab_toggle_);
+  const std::optional<size_t> toggle_idx = GetIndexOf(vertical_tab_toggle_);
   CHECK(toggle_idx.has_value());
 
   // The vertical tab strip is placed by physical position and does not mirror
@@ -698,7 +676,7 @@ void BraveToolbarView::UpdateVerticalTabTogglePlacement() {
 
   size_t target_idx = 0;
   if (place_near_app_menu) {
-    const auto menu_idx = container_view->GetIndexOf(GetAppMenuButton());
+    const auto menu_idx = GetIndexOf(GetAppMenuButton());
     CHECK(menu_idx.has_value());
     CHECK_GT(*menu_idx, 0u);
     target_idx = *menu_idx - 1;
@@ -714,7 +692,7 @@ void BraveToolbarView::UpdateVerticalTabTogglePlacement() {
     return;
   }
 
-  container_view->ReorderChildView(vertical_tab_toggle_, target_idx);
+  ReorderChildView(vertical_tab_toggle_, target_idx);
 }
 
 void BraveToolbarView::UpdateVerticalTabToggleState() {

--- a/browser/ui/views/toolbar/brave_toolbar_view_browsertest.cc
+++ b/browser/ui/views/toolbar/brave_toolbar_view_browsertest.cc
@@ -510,12 +510,10 @@ IN_PROC_BROWSER_TEST_F(BraveToolbarViewTest,
   // Check avatar is positioned at the right before app menu button.
   views::View* avatar = toolbar_button_provider_->GetAvatarToolbarButton();
   ASSERT_TRUE(!!avatar);
-  views::View* container = avatar->parent();
-  ASSERT_TRUE(!!container);
   views::View* app_menu = toolbar_button_provider_->GetAppMenuButton();
   ASSERT_TRUE(!!app_menu);
-  EXPECT_EQ(container->GetIndexOf(avatar).value(),
-            container->GetIndexOf(app_menu).value() - 1ul);
+  EXPECT_EQ(toolbar_view_->GetIndexOf(avatar).value(),
+            toolbar_view_->GetIndexOf(app_menu).value() - 1ul);
 
   // Check avatar button's size.
   const int avatar_size =
@@ -614,34 +612,29 @@ IN_PROC_BROWSER_TEST_F(BraveToolbarViewTest,
                        VerticalTabTogglePlacementRespectsTabsOnRight) {
   auto* prefs = browser()->profile()->GetPrefs();
   prefs->SetBoolean(brave_tabs::kVerticalTabsEnabled, true);
-  views::View* container = toolbar_view_->location_bar_view()->parent();
-  ASSERT_TRUE(container);
 
   prefs->SetBoolean(brave_tabs::kVerticalTabsOnRight, false);
   RunScheduledLayouts();
   auto* toggle = toolbar_view_->vertical_tab_toggle_button();
   ASSERT_TRUE(toggle) << "vertical tabs enabled, kVerticalTabsOnRight=false";
-  const auto ix_left_side = container->GetIndexOf(toggle);
+  const auto ix_left_side = toolbar_view_->GetIndexOf(toggle);
   ASSERT_TRUE(ix_left_side.has_value())
-      << "toggle missing from toolbar container "
-         "(kVerticalTabsOnRight=false)";
+      << "toggle missing from toolbar (kVerticalTabsOnRight=false)";
   EXPECT_EQ(*ix_left_side, 0u)
       << "with kVerticalTabsOnRight=false, toggle should be pinned to child "
          "index 0 (leading toolbar edge), not derived from back button index";
 
   prefs->SetBoolean(brave_tabs::kVerticalTabsOnRight, true);
   RunScheduledLayouts();
-  const auto ix_on_right = container->GetIndexOf(toggle);
+  const auto ix_on_right = toolbar_view_->GetIndexOf(toggle);
   ASSERT_TRUE(ix_on_right.has_value())
-      << "toggle missing from toolbar container "
-         "(kVerticalTabsOnRight=true)";
+      << "toggle missing from toolbar (kVerticalTabsOnRight=true)";
 
   views::View* menu = toolbar_button_provider_->GetAppMenuButton();
   ASSERT_TRUE(menu);
-  const auto menu_ix = container->GetIndexOf(menu);
+  const auto menu_ix = toolbar_view_->GetIndexOf(menu);
   ASSERT_TRUE(menu_ix.has_value() && *menu_ix > 0)
-      << "app menu button must be a non-leading child of the toolbar "
-         "container";
+      << "app menu button must be a non-leading child of the toolbar ";
 
   EXPECT_EQ(*ix_on_right, *menu_ix - 1)
       << "with kVerticalTabsOnRight=true, toggle should sit immediately "
@@ -673,11 +666,9 @@ IN_PROC_BROWSER_TEST_F(BraveToolbarViewRTLTest,
 
   auto* prefs = browser()->profile()->GetPrefs();
   prefs->SetBoolean(brave_tabs::kVerticalTabsEnabled, true);
-  views::View* container = toolbar_view_->location_bar_view()->parent();
-  ASSERT_TRUE(container);
 
   // In RTL, the strip placed by kVerticalTabsOnRight=false is physically on
-  // the left; the toolbar container mirrors child indices, so a toggle that
+  // the left; the toolbar mirrors child indices, so a toggle that
   // should appear visually on the left needs to sit at the trailing logical
   // slot (just before the app menu).
   prefs->SetBoolean(brave_tabs::kVerticalTabsOnRight, false);
@@ -687,15 +678,14 @@ IN_PROC_BROWSER_TEST_F(BraveToolbarViewRTLTest,
 
   views::View* menu = toolbar_button_provider_->GetAppMenuButton();
   ASSERT_TRUE(menu);
-  const auto menu_ix_left = container->GetIndexOf(menu);
+  const auto menu_ix_left = toolbar_view_->GetIndexOf(menu);
   ASSERT_TRUE(menu_ix_left.has_value() && *menu_ix_left > 0)
       << "app menu button must be a non-leading child of the toolbar "
-         "container (RTL, on-left)";
+         "(RTL, on-left)";
 
-  const auto ix_rtl_on_left = container->GetIndexOf(toggle);
+  const auto ix_rtl_on_left = toolbar_view_->GetIndexOf(toggle);
   ASSERT_TRUE(ix_rtl_on_left.has_value())
-      << "toggle missing from toolbar container (RTL, "
-         "kVerticalTabsOnRight=false)";
+      << "toggle missing from toolbar (RTL, kVerticalTabsOnRight=false)";
   EXPECT_EQ(*ix_rtl_on_left, *menu_ix_left - 1)
       << "in RTL, on-left strip should map to toggle at app-menu-1 (toggle_ix="
       << *ix_rtl_on_left << ", menu_ix=" << *menu_ix_left << ")";
@@ -704,10 +694,9 @@ IN_PROC_BROWSER_TEST_F(BraveToolbarViewRTLTest,
   // right; logical child index 0 mirrors to the visual right edge.
   prefs->SetBoolean(brave_tabs::kVerticalTabsOnRight, true);
   RunScheduledLayouts();
-  const auto ix_rtl_on_right = container->GetIndexOf(toggle);
+  const auto ix_rtl_on_right = toolbar_view_->GetIndexOf(toggle);
   ASSERT_TRUE(ix_rtl_on_right.has_value())
-      << "toggle missing from toolbar container (RTL, "
-         "kVerticalTabsOnRight=true)";
+      << "toggle missing from toolbar (RTL, kVerticalTabsOnRight=true)";
   EXPECT_EQ(*ix_rtl_on_right, 0u)
       << "in RTL, on-right strip should map to toggle at leading logical "
          "index 0 (visual right edge), got "
@@ -718,7 +707,7 @@ IN_PROC_BROWSER_TEST_F(BraveToolbarViewRTLTest,
       << *ix_rtl_on_left << ", on_right_ix=" << *ix_rtl_on_right << ")";
 }
 
-// Verifies that UpdateHorizontalPadding() keeps the toolbar container border
+// Verifies that UpdateHorizontalPadding() keeps the toolbar border
 // in sync with GetLeadingTrailingCaptionButtonWidth() across state changes.
 // Guards against the Qt-theme regression where a fixed estimate was used
 // instead of real button bounds, causing caption buttons to overlap the
@@ -727,11 +716,10 @@ IN_PROC_BROWSER_TEST_F(BraveToolbarViewTest,
                        ToolbarPaddingMatchesFrameLayoutParams) {
   auto* browser_widget =
       BrowserView::GetBrowserViewForBrowser(browser())->browser_widget();
-  auto* container_view = toolbar_view_->location_bar_view()->parent();
   auto* prefs = browser()->profile()->GetPrefs();
 
   // Default: vertical tabs disabled — no border.
-  EXPECT_FALSE(container_view->GetBorder())
+  EXPECT_FALSE(toolbar_view_->GetBorder())
       << "default state (vertical tabs disabled)";
 
   // Enable vertical tabs, hide title bar.
@@ -744,7 +732,7 @@ IN_PROC_BROWSER_TEST_F(BraveToolbarViewTest,
 
   // If both exclusions are zero (headless / no caption buttons) the early-
   // return optimisation may leave the border as null — treat null as zero.
-  const auto* border = container_view->GetBorder();
+  const auto* border = toolbar_view_->GetBorder();
   const gfx::Insets actual = border ? border->GetInsets() : gfx::Insets();
   EXPECT_EQ(actual.left(), expected_left)
       << "after enabling vertical tabs, hiding title bar";
@@ -754,12 +742,12 @@ IN_PROC_BROWSER_TEST_F(BraveToolbarViewTest,
   // Show title bar → padding cleared.
   prefs->SetBoolean(brave_tabs::kVerticalTabsShowTitleOnWindow, true);
   RunScheduledLayouts();
-  EXPECT_FALSE(container_view->GetBorder())
+  EXPECT_FALSE(toolbar_view_->GetBorder())
       << "after enabling vertical tabs, showing title bar";
 
   // Hide title bar again, then disable vertical tabs → padding cleared.
   prefs->SetBoolean(brave_tabs::kVerticalTabsShowTitleOnWindow, false);
   prefs->SetBoolean(brave_tabs::kVerticalTabsEnabled, false);
   RunScheduledLayouts();
-  EXPECT_FALSE(container_view->GetBorder()) << "after disabling vertical tabs";
+  EXPECT_FALSE(toolbar_view_->GetBorder()) << "after disabling vertical tabs";
 }


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves - no issue. cleanup.

Container view was gone from `ToolbarView`.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
