### PR TITLE
[AI Chat] Do not accept duplicate tool use event IDs

### DIFF
--- a/components/ai_chat/core/browser/conversation_handler.cc
+++ b/components/ai_chat/core/browser/conversation_handler.cc
@@ -28,7 +28,6 @@
 #include "base/functional/callback.h"
 #include "base/logging.h"
 #include "base/memory/weak_ptr.h"
-#include "base/notreached.h"
 #include "base/numerics/safe_math.h"
 #include "base/rand_util.h"
 #include "base/strings/strcat.h"
@@ -1396,23 +1395,6 @@ void ConversationHandler::UpdateOrCreateLastAssistantEntry(
         for (const auto& existing : *entry->events) {
           if (existing->is_tool_use_event() &&
               existing->get_tool_use_event()->id == tool_use_event->id) {
-            // Dump the tool and model name until we figure out
-            // which tool / model combination is causing duplicate IDs.
-            // TODO(https://github.com/brave/brave-browser/issues/55439):
-            // Consider removing this once we have enough information to address
-            // the root cause of which model/tool is generating duplicate IDs.
-            SCOPED_CRASH_KEY_STRING1024("BraveAIChatToolName", "name",
-                                        tool_use_event->tool_name);
-            SCOPED_CRASH_KEY_STRING1024("BraveAIChatToolId", "id",
-                                        tool_use_event->id);
-            if (GetCurrentModel().options->is_leo_model_options()) {
-              SCOPED_CRASH_KEY_STRING1024("BraveAIChatModel", "key",
-                                          model_key_);
-            }
-            DUMP_WILL_BE_NOTREACHED()
-                << "Dropping tool_use event with duplicate id: "
-                << tool_use_event->id << " (tool: " << tool_use_event->tool_name
-                << ")";
             return;
           }
         }

--- a/components/ai_chat/core/browser/conversation_handler.cc
+++ b/components/ai_chat/core/browser/conversation_handler.cc
@@ -28,10 +28,12 @@
 #include "base/functional/callback.h"
 #include "base/logging.h"
 #include "base/memory/weak_ptr.h"
+#include "base/notreached.h"
 #include "base/numerics/safe_math.h"
 #include "base/rand_util.h"
 #include "base/strings/strcat.h"
 #include "base/strings/string_util.h"
+#include "base/task/bind_post_task.h"
 #include "base/time/time.h"
 #include "base/types/expected.h"
 #include "base/uuid.h"
@@ -1104,8 +1106,14 @@ void ConversationHandler::RespondToToolUseRequest(
 
   OnToolUseEventOutput(chat_history_.back().get(), tool_use);
 
-  // Run next tool, or perform generation with all the tools outputs
-  MaybeRespondToNextToolUseRequest();
+  // Run next tool, or perform generation with all the completed tools outputs.
+  // Run as Task to catch any reentrant issues.
+  base::BindPostTaskToCurrentDefault(
+      base::BindOnce(
+          base::IgnoreResult(
+              &ConversationHandler::MaybeRespondToNextToolUseRequest),
+          weak_ptr_factory_.GetWeakPtr()))
+      .Run();
 }
 
 void ConversationHandler::ProcessPermissionChallenge(
@@ -1375,6 +1383,39 @@ void ConversationHandler::UpdateOrCreateLastAssistantEntry(
         // Notify UI about the tool completion
         OnToolUseEventOutput(entry.get(), existing_tool_use_event);
         return;
+      }
+
+      // Drop tool_use events whose id collides with an existing tool_use
+      // event in this turn. ToolUseEvents in the engine APIs are keyed on 'id'
+      // (and in this class via GetToolUseEventForLastResponse). Internally, a
+      // duplicate id would route both completions to the same event, leave the
+      // second event's output unset, and cause MaybeRespondToNextToolUseRequest
+      // to execute the same pending tool indefinitely. And engine APIs will
+      // reject a request with duplicate tool use IDs.
+      if (!tool_use_event->id.empty()) {
+        for (const auto& existing : *entry->events) {
+          if (existing->is_tool_use_event() &&
+              existing->get_tool_use_event()->id == tool_use_event->id) {
+            // Dump the tool and model name until we figure out
+            // which tool / model combination is causing duplicate IDs.
+            // TODO(https://github.com/brave/brave-browser/issues/55439):
+            // Consider removing this once we have enough information to address
+            // the root cause of which model/tool is generating duplicate IDs.
+            SCOPED_CRASH_KEY_STRING1024("BraveAIChatToolName", "name",
+                                        tool_use_event->tool_name);
+            SCOPED_CRASH_KEY_STRING1024("BraveAIChatToolId", "id",
+                                        tool_use_event->id);
+            if (GetCurrentModel().options->is_leo_model_options()) {
+              SCOPED_CRASH_KEY_STRING1024("BraveAIChatModel", "key",
+                                          model_key_);
+            }
+            DUMP_WILL_BE_NOTREACHED()
+                << "Dropping tool_use event with duplicate id: "
+                << tool_use_event->id << " (tool: " << tool_use_event->tool_name
+                << ")";
+            return;
+          }
+        }
       }
     }
 

--- a/components/ai_chat/core/browser/conversation_handler_unittest.cc
+++ b/components/ai_chat/core/browser/conversation_handler_unittest.cc
@@ -3446,6 +3446,128 @@ TEST_F(ConversationHandlerUnitTest, ToolUseEvents_MultipleToolsCalled) {
                       mojom::TextContentBlock::New("Result from tool2")));
 }
 
+TEST_F(ConversationHandlerUnitTest, ToolUseEvents_DuplicateToolIds) {
+  // Regression test for https://github.com/brave/brave-browser/issues/55438:
+  // an assistant response that contained two tool_use events
+  // sharing the same `id` could cause infinite synchronous recursion through
+  // MaybeRespondToNextToolUseRequest -> RespondToToolUseRequest. The lookup
+  // helper GetToolUseEventForLastResponse returned the first event matching
+  // the id, so both completions resolved to the same event, the second
+  // event's output was never assigned, and the next iteration kept
+  // re-dispatching the same pending tool.
+  //
+  // The fix drops duplicate-id tool_use events at insertion time.
+  conversation_handler_->associated_content_manager()->ClearContent();
+  auto* engine = static_cast<MockEngineConsumer*>(
+      conversation_handler_->GetEngineForTesting());
+
+  auto tool = std::make_unique<NiceMock<MockTool>>("shared_tool", "Shared");
+  tool->set_requires_user_interaction_before_handling(false);
+
+  ON_CALL(*mock_tool_provider_, GetTools()).WillByDefault([&]() {
+    std::vector<base::WeakPtr<Tool>> tools;
+    tools.push_back(tool->GetWeakPtr());
+    return tools;
+  });
+
+  int use_tool_call_count = 0;
+  ON_CALL(*tool, UseTool(_, _))
+      .WillByDefault(
+          [&](const std::string& input_json, Tool::UseToolCallback callback) {
+            ++use_tool_call_count;
+            std::vector<mojom::ContentBlockPtr> result;
+            result.push_back(mojom::ContentBlock::NewTextContentBlock(
+                mojom::TextContentBlock::New("Result for " + input_json)));
+            std::move(callback).Run(std::move(result), {});
+          });
+
+  testing::Sequence seq;
+  // First engine response: emit two tool_use events that share the same id.
+  EXPECT_CALL(*engine, GenerateAssistantResponse)
+      .InSequence(seq)
+      .WillOnce(testing::DoAll(
+          testing::WithArg<6>(
+              [](EngineConsumer::GenerationDataCallback callback) {
+                callback.Run(EngineConsumer::GenerationResultData(
+                    mojom::ConversationEntryEvent::NewToolUseEvent(
+                        mojom::ToolUseEvent::New("shared_tool", "duplicate_id",
+                                                 "{\"call\":\"first\"}",
+                                                 std::nullopt, std::nullopt,
+                                                 nullptr, false)),
+                    std::nullopt));
+              }),
+          testing::WithArg<6>(
+              [](EngineConsumer::GenerationDataCallback callback) {
+                callback.Run(EngineConsumer::GenerationResultData(
+                    mojom::ConversationEntryEvent::NewToolUseEvent(
+                        mojom::ToolUseEvent::New("shared_tool", "duplicate_id",
+                                                 "{\"call\":\"second\"}",
+                                                 std::nullopt, std::nullopt,
+                                                 nullptr, false)),
+                    std::nullopt));
+              }),
+          testing::WithArg<7>(
+              [](EngineConsumer::GenerationCompletedCallback callback) {
+                std::move(callback).Run(
+                    base::ok(EngineConsumer::GenerationResultData(
+                        mojom::ConversationEntryEvent::NewCompletionEvent(
+                            mojom::CompletionEvent::New("")),
+                        std::nullopt)));
+              })));
+
+  // After the surviving tool completes, post-tool generation runs.
+  base::RunLoop run_loop;
+  EXPECT_CALL(*engine, GenerateAssistantResponse)
+      .InSequence(seq)
+      .WillOnce(testing::DoAll(
+          testing::WithArg<6>(
+              [](EngineConsumer::GenerationDataCallback callback) {
+                callback.Run(EngineConsumer::GenerationResultData(
+                    mojom::ConversationEntryEvent::NewCompletionEvent(
+                        mojom::CompletionEvent::New("Final response")),
+                    std::nullopt));
+              }),
+          testing::WithArg<7>(
+              [&](EngineConsumer::GenerationCompletedCallback callback) {
+                std::move(callback).Run(
+                    base::ok(EngineConsumer::GenerationResultData(
+                        mojom::ConversationEntryEvent::NewCompletionEvent(
+                            mojom::CompletionEvent::New("")),
+                        std::nullopt)));
+                run_loop.Quit();
+              })));
+
+  conversation_handler_->SubmitHumanConversationEntry("call the tool",
+                                                      std::nullopt);
+  run_loop.Run();
+
+  // Tool should be invoked exactly once: for the surviving (first) event.
+  // Higher counts indicate that duplicate ids re-dispatched the same pending
+  // event.
+  EXPECT_EQ(use_tool_call_count, 1);
+
+  const auto& history = conversation_handler_->GetConversationHistory();
+  // human + assistant with the surviving tool_use + assistant with final
+  // response.
+  ASSERT_EQ(history.size(), 3u);
+  auto& assistant_entry = history[1];
+  ASSERT_TRUE(assistant_entry->events.has_value());
+  auto& events = assistant_entry->events.value();
+  // The duplicate-id event is dropped at insertion time.
+  ASSERT_EQ(events.size(), 1u);
+
+  ASSERT_TRUE(events[0]->is_tool_use_event());
+  auto& tool_use = events[0]->get_tool_use_event();
+  EXPECT_EQ(tool_use->id, "duplicate_id");
+  EXPECT_EQ(tool_use->arguments_json, "{\"call\":\"first\"}");
+  ASSERT_TRUE(tool_use->output.has_value());
+  ASSERT_EQ(tool_use->output->size(), 1u);
+  EXPECT_EQ(tool_use->output->at(0)->get_text_content_block()->text,
+            "Result for {\"call\":\"first\"}");
+
+  EXPECT_EQ(history.back()->text, "Final response");
+}
+
 TEST_F(ConversationHandlerUnitTest,
        ToolUseEvents_RequiresUserInteractionBeforeHandling) {
   conversation_handler_->associated_content_manager()->ClearContent();


### PR DESCRIPTION
- Fix https://github.com/brave/brave-browser/issues/55438

~Also adds dump data for which tool / model combination are causing this duplication. Only dumps model name if not a custom model. We should figure out which piece of the engine is causing this:~
- https://github.com/brave/brave-browser/issues/55439
