### PR TITLE
`MockToolProvider` broken on `master`

### DIFF
--- a/components/ai_chat/core/browser/tools/mock_tool_provider.h
+++ b/components/ai_chat/core/browser/tools/mock_tool_provider.h
@@ -27,7 +27,6 @@ class MockToolProvider : public ToolProvider {
   MockToolProvider();
   ~MockToolProvider() override;
 
-  MOCK_METHOD(void, OnNewGenerationLoop, (), (override));
   MOCK_METHOD(void, OnGenerationCompleteWithNoToolsToHandle, (), (override));
   MOCK_METHOD(void, StopAllTasks, (), (override));
 


### PR DESCRIPTION
The implementation on master is mocking `OnNewGenerationLoop`, but this
function doesn't exist.
