### PR TITLE
[Android] Fixed sorting on Appearance screen for some languages

### DIFF
--- a/android/java/org/chromium/chrome/browser/settings/AppearancePreferences.java
+++ b/android/java/org/chromium/chrome/browser/settings/AppearancePreferences.java
@@ -56,14 +56,16 @@ public class AppearancePreferences extends AppearanceSettingsFragment
     public static final String PREF_HIDE_BRAVE_REWARDS_ICON_MIGRATION =
             "hide_brave_rewards_icon_migration";
     public static final String PREF_SHOW_BRAVE_REWARDS_ICON = "show_brave_rewards_icon";
-    public static final String PREF_ADS_SWITCH = "ads_switch";
-    public static final String PREF_BRAVE_NIGHT_MODE_ENABLED = "brave_night_mode_enabled_key";
-    public static final String PREF_BRAVE_DISABLE_SHARING_HUB = "brave_disable_sharing_hub";
-    public static final String PREF_BRAVE_ENABLE_TAB_GROUPS = "brave_enable_tab_groups";
-    public static final String PREF_ENABLE_MULTI_WINDOWS = "enable_multi_windows";
-    public static final String PREF_SHOW_UNDO_WHEN_TABS_CLOSED = "show_undo_when_tabs_closed";
     public static final String PREF_ADDRESS_BAR = "address_bar";
-    static final String PREF_BRAVE_CUSTOMIZE_MENU = "brave_customize_menu";
+    /* package */ static final String PREF_ADS_SWITCH = "ads_switch";
+    /* package */ static final String PREF_BRAVE_NIGHT_MODE_ENABLED =
+            "brave_night_mode_enabled_key";
+    /* package */ static final String PREF_BRAVE_DISABLE_SHARING_HUB = "brave_disable_sharing_hub";
+    /* package */ static final String PREF_BRAVE_ENABLE_TAB_GROUPS = "brave_enable_tab_groups";
+    /* package */ static final String PREF_ENABLE_MULTI_WINDOWS = "enable_multi_windows";
+    /* package */ static final String PREF_SHOW_UNDO_WHEN_TABS_CLOSED =
+            "show_undo_when_tabs_closed";
+    /* package */ static final String PREF_BRAVE_CUSTOMIZE_MENU = "brave_customize_menu";
 
     private BraveRewardsNativeWorker mBraveRewardsNativeWorker;
 

--- a/android/java/org/chromium/chrome/browser/settings/AppearancePreferences.java
+++ b/android/java/org/chromium/chrome/browser/settings/AppearancePreferences.java
@@ -52,9 +52,6 @@ import java.util.Map;
 
 public class AppearancePreferences extends AppearanceSettingsFragment
         implements Preference.OnPreferenceChangeListener, BraveRewardsObserver {
-    public static final String PREF_HIDE_BRAVE_REWARDS_ICON = "hide_brave_rewards_icon";
-    public static final String PREF_HIDE_BRAVE_REWARDS_ICON_MIGRATION =
-            "hide_brave_rewards_icon_migration";
     public static final String PREF_SHOW_BRAVE_REWARDS_ICON = "show_brave_rewards_icon";
     public static final String PREF_ADDRESS_BAR = "address_bar";
     /* package */ static final String PREF_ADS_SWITCH = "ads_switch";

--- a/android/java/org/chromium/chrome/browser/settings/AppearancePreferences.java
+++ b/android/java/org/chromium/chrome/browser/settings/AppearancePreferences.java
@@ -63,7 +63,7 @@ public class AppearancePreferences extends AppearanceSettingsFragment
     public static final String PREF_ENABLE_MULTI_WINDOWS = "enable_multi_windows";
     public static final String PREF_SHOW_UNDO_WHEN_TABS_CLOSED = "show_undo_when_tabs_closed";
     public static final String PREF_ADDRESS_BAR = "address_bar";
-    private static final String PREF_BRAVE_CUSTOMIZE_MENU = "brave_customize_menu";
+    static final String PREF_BRAVE_CUSTOMIZE_MENU = "brave_customize_menu";
 
     private BraveRewardsNativeWorker mBraveRewardsNativeWorker;
 
@@ -97,10 +97,7 @@ public class AppearancePreferences extends AppearanceSettingsFragment
             removePreferenceIfPresent(PREF_ADDRESS_BAR);
         }
 
-        // Correct the order of the preferences.
-        setPreferenceOrder(AppearanceSettingsFragment.PREF_UI_THEME, 0);
-        setPreferenceOrder(PREF_BRAVE_CUSTOMIZE_MENU, 1);
-        setPreferenceOrder(PREF_ADDRESS_BAR, 2);
+        applyOrdering();
     }
 
     private void removePreferenceIfPresent(String key) {
@@ -358,6 +355,24 @@ public class AppearancePreferences extends AppearanceSettingsFragment
         if (preference != null) {
             preference.setSummary("");
         }
+    }
+
+    // Both XMLs (upstream and brave) independently assign sequential order values starting from 0,
+    // causing collisions. Setting all preferences to explicit unique values prevents alphabetical
+    // tie-breaking, which would otherwise produce language-dependent ordering.
+    private void applyOrdering() {
+        setPreferenceOrder(AppearanceSettingsFragment.PREF_UI_THEME, 0);
+        setPreferenceOrder(PREF_BRAVE_CUSTOMIZE_MENU, 1);
+        setPreferenceOrder(AppearanceSettingsFragment.PREF_TOOLBAR_SHORTCUT, 2);
+        setPreferenceOrder(PREF_ADDRESS_BAR, 3);
+        setPreferenceOrder(BravePreferenceKeys.BRAVE_BOTTOM_TOOLBAR_ENABLED_KEY, 4);
+        setPreferenceOrder(PREF_SHOW_BRAVE_REWARDS_ICON, 5);
+        setPreferenceOrder(PREF_ADS_SWITCH, 6);
+        setPreferenceOrder(PREF_BRAVE_NIGHT_MODE_ENABLED, 7);
+        setPreferenceOrder(PREF_BRAVE_DISABLE_SHARING_HUB, 8);
+        setPreferenceOrder(PREF_BRAVE_ENABLE_TAB_GROUPS, 9);
+        setPreferenceOrder(PREF_ENABLE_MULTI_WINDOWS, 10);
+        setPreferenceOrder(PREF_SHOW_UNDO_WHEN_TABS_CLOSED, 11);
     }
 
     private void setPreferenceOrder(String key, int order) {

--- a/android/javatests/org/chromium/chrome/browser/settings/BraveAppearancePreferencesTest.java
+++ b/android/javatests/org/chromium/chrome/browser/settings/BraveAppearancePreferencesTest.java
@@ -1,0 +1,92 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.chromium.chrome.browser.settings;
+
+import static org.junit.Assert.assertTrue;
+
+import android.os.Looper;
+
+import androidx.annotation.Nullable;
+import androidx.preference.Preference;
+import androidx.test.filters.SmallTest;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.chromium.base.BravePreferenceKeys;
+import org.chromium.base.test.util.DoNotBatch;
+import org.chromium.chrome.browser.appearance.settings.AppearanceSettingsFragment;
+import org.chromium.chrome.test.ChromeJUnit4ClassRunner;
+
+/** Test for {@link AppearancePreferences}. */
+@RunWith(ChromeJUnit4ClassRunner.class)
+@DoNotBatch(reason = "Tests cannot run batched because they launch a Settings activity.")
+public class BraveAppearancePreferencesTest {
+
+    @Rule
+    public final SettingsActivityTestRule<AppearancePreferences> mSettingsActivityTestRule =
+            new SettingsActivityTestRule<>(AppearancePreferences.class);
+
+    private AppearancePreferences mAppearancePreferences;
+
+    @Before
+    public void setup() {
+        Looper.prepare();
+    }
+
+    // Verifies that all appearance preferences appear in the correct order. When two preferences
+    // share the same order value the AndroidX Preference framework falls back to alphabetical title
+    // comparison, producing locale-dependent ordering. This test catches regressions in English;
+    // the test infrastructure does not support switching the app locale to reproduce e.g. French
+    // or Portuguese failures directly.
+    @Test
+    @SmallTest
+    public void testAppearancePreferencesOrder() {
+        startSettings();
+
+        // All keys from applyOrdering() listed in expected display order. Preferences that are
+        // conditionally absent (e.g. address_bar on older devices, toolbar_shortcut when adaptive
+        // toolbar is disabled, show_brave_rewards_icon when Rewards is unsupported) are skipped in
+        // the comparison when null.
+        final String[] sortedPrefKeys = {
+            AppearanceSettingsFragment.PREF_UI_THEME,
+            AppearancePreferences.PREF_BRAVE_CUSTOMIZE_MENU,
+            AppearanceSettingsFragment.PREF_TOOLBAR_SHORTCUT,
+            AppearancePreferences.PREF_ADDRESS_BAR,
+            BravePreferenceKeys.BRAVE_BOTTOM_TOOLBAR_ENABLED_KEY,
+            AppearancePreferences.PREF_SHOW_BRAVE_REWARDS_ICON,
+            AppearancePreferences.PREF_ADS_SWITCH,
+            AppearancePreferences.PREF_BRAVE_NIGHT_MODE_ENABLED,
+            AppearancePreferences.PREF_BRAVE_DISABLE_SHARING_HUB,
+            AppearancePreferences.PREF_BRAVE_ENABLE_TAB_GROUPS,
+            AppearancePreferences.PREF_ENABLE_MULTI_WINDOWS,
+            AppearancePreferences.PREF_SHOW_UNDO_WHEN_TABS_CLOSED,
+        };
+
+        @Nullable Preference prevPref = null;
+        for (String key : sortedPrefKeys) {
+            Preference pref = mAppearancePreferences.findPreference(key);
+            if (pref == null) continue;
+            if (prevPref == null) {
+                prevPref = pref;
+                continue;
+            }
+            assertTrue(
+                    "\"" + prevPref.getTitle() + "\" should precede \"" + pref.getTitle() + "\"",
+                    pref.getOrder() > prevPref.getOrder());
+            prevPref = pref;
+        }
+    }
+
+    private void startSettings() {
+        mSettingsActivityTestRule.startSettingsActivity();
+        mAppearancePreferences = mSettingsActivityTestRule.getFragment();
+        Assert.assertNotNull("SettingsActivity failed to launch.", mAppearancePreferences);
+    }
+}

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -1540,6 +1540,7 @@ if (is_android) {
       "//brave/android/javatests/org/chromium/chrome/browser/privacy/settings/BravePrivacySettingsTest.java",
       "//brave/android/javatests/org/chromium/chrome/browser/safe_browsing/settings/BraveSafeBrowsingSettingsFragmentTest.java",
       "//brave/android/javatests/org/chromium/chrome/browser/settings/BackgroundImagesPreferencesTest.java",
+      "//brave/android/javatests/org/chromium/chrome/browser/settings/BraveAppearancePreferencesTest.java",
       "//brave/android/javatests/org/chromium/chrome/browser/settings/BraveMainSettingsFragmentTest.java",
       "//brave/android/javatests/org/chromium/chrome/browser/sync/BraveManageSyncSettingsTest.java",
     ]


### PR DESCRIPTION
This PR fixes order on Appearance screen for soem languages as French and Portuguese.

The issue of original code was that after
```
        setPreferenceOrder(AppearanceSettingsFragment.PREF_UI_THEME, 0);
        setPreferenceOrder(PREF_BRAVE_CUSTOMIZE_MENU, 1);
        setPreferenceOrder(PREF_ADDRESS_BAR, 2);
```
the items were
```
key=address_bar order=2 title=Barre d'adresse
key=toolbar_shortcut order=1 title=Raccourci de la barre d'outils
key=brave_bottom_toolbar_enabled_key order=2 title=Activer la barre de navigation
```
So at French `address_bar` and `brave_bottom_toolbar_enabled_key` had the same order and sorting was done by the alphabet. 

`Activer la barre de navigation` < `Barre d'adresse` in french, so the order was broken.

In English the order was ok:
`Enable bottom navigation toolbar` > `Address bar`

The fix is to apply `setPreferenceOrder` for all prefs.

Resolves https://github.com/brave/brave-browser/issues/55281

### Screenshots
Before|After
--|--
<img width="1080" height="2498" alt="image" src="https://github.com/user-attachments/assets/74850c1b-5dab-4c4c-bc42-3db53e78115d" />|<img width="1080" height="2498" alt="image" src="https://github.com/user-attachments/assets/20a64f6f-eb34-4796-8eae-a15bd75ce1b0" />


<!-- Add brave-browser issue below that this PR will resolve -->


<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
