### PR TITLE
Broaden uplift skill scope and auto-create tracking issues

### DIFF
--- a/.claude/skills/uplift/SKILL.md
+++ b/.claude/skills/uplift/SKILL.md
@@ -1,16 +1,22 @@
 ---
 name: uplift
-description: "Create an uplift PR that cherry-picks intermittent test fixes and crash fixes from closed PRs into a target branch (beta or release). Triggers on: /uplift, create uplift, uplift PRs."
-argument-hint: [github-username] [beta|release] [all|<num>d|PR1,PR2,PR3]
+description: "Create an uplift PR that cherry-picks merged PRs from a contributor into a target branch (beta or release). Defaults to broad eligibility; the scope can be narrowed via a free-form description (e.g. 'only automated test and crash fixes'). Triggers on: /uplift, create uplift, uplift PRs."
+argument-hint: [github-username] [beta|release] [all|<num>d|PR1,PR2,PR3] [<scope description in English>]
 disable-model-invocation: true
 allowed-tools: Bash, Read, WebFetch, Grep, Glob
 ---
 
 # Uplift PR Creator
 
-Create an uplift pull request that cherry-picks intermittent test fixes and
-crash fixes from a contributor's recently closed/merged PRs into a target
-channel branch.
+Create an uplift pull request that cherry-picks merged PRs from a contributor
+into a target channel branch.
+
+By default, eligibility is broad: any merged PR that is a reasonable uplift
+candidate is included (bug fixes, correctness fixes, crash fixes, intermittent
+test fixes, test filter updates, minor polish). The caller can narrow the scope
+by appending a free-form English description as the final argument — for
+example `only automated test fixes and crash fixes`, which restores the
+previous restrictive behavior.
 
 ## Inputs
 
@@ -33,22 +39,40 @@ channel branch.
       individually with
       `gh pr view <number> --repo brave/brave-core --json number,title,mergedAt,mergeCommit,labels,body,url`.
     - If omitted, defaults to the recent 50 closed PRs (current behavior).
+  - Remaining arguments (optional): **Scope description** — any remaining
+    text after the filter is treated as a free-form English description of
+    what to include or exclude. Apply your judgment when classifying PRs in
+    Step 2. If absent, use the default broad eligibility.
 
-Parse the arguments by splitting `$ARGUMENTS` on whitespace. Examples:
+Parse the arguments by splitting `$ARGUMENTS` on whitespace for the first
+three positional arguments. Everything after the third token (if any) is the
+free-form scope description and should be kept intact as a single string. The
+first token is always the username. The second token, if it equals `beta` or
+`release`, is the channel; otherwise it is treated as the filter and the
+channel defaults to `beta`. The third token, if present, is the filter;
+otherwise filter defaults to recent 50.
 
-- `/uplift netzenbot` → username=`netzenbot`, channel=`beta`, filter=recent 50
+Examples:
+
+- `/uplift netzenbot` → username=`netzenbot`, channel=`beta`, filter=recent 50,
+  scope=default broad
 - `/uplift netzenbot beta` → username=`netzenbot`, channel=`beta`, filter=recent
-  50
+  50, scope=default broad
 - `/uplift netzenbot release` → username=`netzenbot`, channel=`release`,
-  filter=recent 50
+  filter=recent 50, scope=default broad
 - `/uplift netzenbot beta all` → username=`netzenbot`, channel=`beta`,
-  filter=all PRs (past 30 days)
+  filter=all PRs (past 30 days), scope=default broad
 - `/uplift netzenbot beta 10d` → username=`netzenbot`, channel=`beta`,
-  filter=all PRs (past 10 days)
+  filter=all PRs (past 10 days), scope=default broad
 - `/uplift netzenbot release 60d` → username=`netzenbot`, channel=`release`,
-  filter=all PRs (past 60 days)
+  filter=all PRs (past 60 days), scope=default broad
 - `/uplift netzenbot release 33534,33547,33580` → username=`netzenbot`,
-  channel=`release`, filter=only those 3 PRs
+  channel=`release`, filter=only those 3 PRs, scope=default broad
+- `/uplift netzenbot beta 30d only automated test fixes and crash fixes` →
+  username=`netzenbot`, channel=`beta`, filter=30d, scope=restrict to
+  intermittent test fixes, test filter updates, and crash fixes only
+- `/uplift netzenbot beta all exclude UI changes, include all bug fixes` →
+  username=`netzenbot`, channel=`beta`, filter=all, scope=as described
 
 ---
 
@@ -92,26 +116,53 @@ Run these in parallel:
 
 ## Step 2: Classify PRs
 
-Review each **merged** PR (skip any where `mergedAt` is null) and classify it as
-either **include** or **exclude** for the uplift:
+Review each **merged** PR (skip any where `mergedAt` is null) and classify it
+as either **include** or **exclude** for the uplift.
 
-**INCLUDE** if the PR is any of:
+**Always EXCLUDE** (regardless of scope):
 
-- Intermittent/flaky test fix (titles often contain "Fix flaky", "Fix test:",
-  "Fix intermittent", "Disable flaky")
-- Crash fix (titles mention "crash", "null dereference",
-  "EXCEPTION_ACCESS_VIOLATION", etc.)
-- Test filter updates (disabling broken upstream tests, updating stale filter
-  entries)
-
-**EXCLUDE** if the PR is:
-
-- A feature addition (not a fix)
-- A refactor unrelated to test stability or crashes
-- Already has the uplift label for the target channel (check the `labels` array
-  in the PR JSON for `uplift/beta` or `uplift/release` depending on the target
-  channel)
 - Not merged (`mergedAt` is null)
+- Already has the uplift label for the target channel (check the `labels`
+  array in the PR JSON for `uplift/beta` or `uplift/release` depending on the
+  target channel)
+
+**If a scope description was provided** in the arguments, follow it. Use the
+PR title and body to judge whether each PR matches the described scope. When
+in doubt, prefer to exclude and note the reason in the summary so the caller
+can override.
+
+A common scope description is restricting to automated test and crash fixes
+only — in that case use this classification:
+
+- **INCLUDE**:
+  - Intermittent/flaky test fix (titles often contain "Fix flaky",
+    "Fix test:", "Fix intermittent", "Disable flaky")
+  - Crash fix (titles mention "crash", "null dereference",
+    "EXCEPTION_ACCESS_VIOLATION", etc.)
+  - Test filter updates (disabling broken upstream tests, updating stale
+    filter entries)
+- **EXCLUDE**: feature additions, refactors, anything else unrelated to test
+  stability or crashes.
+
+**If no scope description was provided**, use broad default eligibility:
+
+- **INCLUDE** any merged PR that is a reasonable uplift candidate:
+  - Bug fixes and correctness fixes
+  - Crash fixes
+  - Intermittent/flaky test fixes and test filter updates
+  - Small UX polish or visible defect fixes
+  - Localization / string fixes
+  - Build / packaging fixes that affect the channel
+- **EXCLUDE**:
+  - New feature additions (not fixes)
+  - Large refactors with no behavior change
+  - Risky changes that the author or reviewers would likely not want
+    auto-uplifted (e.g., security-sensitive rewrites, schema migrations);
+    when uncertain, exclude and note the reason
+
+When in doubt about a PR, exclude it and explain the reasoning in the
+summary; the caller can re-run the skill with an explicit scope or PR list to
+include it.
 
 ---
 
@@ -174,11 +225,18 @@ summary but proceed with the uplift.
 Generate the title dynamically based on the categories of PRs actually included:
 
 - If the uplift contains **only** intermittent/flaky test fixes and test filter
-  updates (no crash fixes): `Uplift intermittent test fixes to <target-branch>`
-- If the uplift contains **only** crash fixes (no test fixes):
+  updates (no crash fixes, no other PRs):
+  `Uplift intermittent test fixes to <target-branch>`
+- If the uplift contains **only** crash fixes (no test fixes, no other PRs):
   `Uplift crash fixes to <target-branch>`
-- If the uplift contains **both** test fixes and crash fixes:
+- If the uplift contains **only** test fixes and crash fixes (no other PRs):
   `Uplift intermittent test fixes and crash fixes to <target-branch>`
+- If the uplift contains a **single** PR outside the test/crash categories,
+  mirror that PR's title with an `(uplift to <target-branch>)` suffix —
+  e.g., `Fix Foo on Linux (uplift to 1.88.x)`.
+- Otherwise (a mix of categories or multiple non-test/non-crash PRs), use a
+  short summary title appropriate for the contents, ending with
+  `to <target-branch>` — e.g., `Uplift fixes to <target-branch>`.
 
 ### Body Format
 
@@ -245,7 +303,70 @@ Do this for every PR that was successfully cherry-picked and included.
 
 ---
 
-## Step 7: Summary
+## Step 7: Ensure each included PR has a linked issue
+
+Brave's post-merge checklist requires the associated issue milestone be set to
+the smallest version the change landed on. PRs uplifted without a linked
+issue make that step impossible, so create and close a tracking issue for any
+included PR that does not already have one.
+
+For **each PR included in the uplift**:
+
+1. **Check for an existing linked issue**:
+   ```bash
+   gh pr view <PR_NUMBER> --repo brave/brave-core --json closingIssuesReferences
+   ```
+   Also inspect the PR body for closing keywords (`Fixes`, `Resolves`,
+   `Closes` followed by `#NNN` or `brave/brave-browser#NNN`). If either
+   surfaces an issue, no new issue is needed — skip this PR.
+
+2. **Create a new tracking issue** in `brave/brave-browser` (Brave's
+   convention is that issues live in `brave-browser` while code lives in
+   `brave-core`). Mirror the original PR's title and reference both PRs in
+   the body so the relationship is discoverable from either direction.
+
+   ```bash
+   gh issue create --repo brave/brave-browser \
+     --title "<original PR title>" \
+     --body "$(cat <<'EOF'
+   Tracking issue created retroactively for an uplift that lacked a linked
+   issue.
+
+   - Original PR: brave/brave-core#<PR_NUMBER>
+   - Uplift PR: brave/brave-core#<UPLIFT_PR_NUMBER> (to <target-branch>)
+   EOF
+   )"
+   ```
+
+   Capture the new issue number from the URL returned by `gh issue create`.
+
+3. **Close the new issue** (the original PR has already merged, so the work
+   the issue describes is complete):
+   ```bash
+   gh issue close <ISSUE_NUMBER> --repo brave/brave-browser \
+     --comment "Closing — work landed in brave/brave-core#<PR_NUMBER>. Uplifted in brave/brave-core#<UPLIFT_PR_NUMBER>."
+   ```
+
+4. **Cross-link from the PRs**: post one short comment on the original PR
+   and one on the uplift PR pointing at the new issue, so future readers of
+   either PR can find the tracking issue.
+   ```bash
+   gh pr comment <PR_NUMBER> --repo brave/brave-core \
+     --body "Tracking issue: brave/brave-browser#<ISSUE_NUMBER> (created for uplift to <target-branch>)."
+   gh pr comment <UPLIFT_PR_NUMBER> --repo brave/brave-core \
+     --body "Tracking issue for #<PR_NUMBER>: brave/brave-browser#<ISSUE_NUMBER>."
+   ```
+
+The uplift PR itself remains open — only the newly created tracking issue is
+closed.
+
+If issue creation fails for any reason (e.g., permission issues or rate
+limits), record the failure in the summary and continue rather than aborting
+the rest of the run.
+
+---
+
+## Step 8: Summary
 
 After creating the PR, output a clear summary to the user:
 
@@ -257,7 +378,14 @@ List each included PR with its number, title, and merge commit SHA.
 
 List each excluded PR with its number, title, and the reason it was excluded
 (e.g., "not merged", "already uplifted (has uplift label)", "already in target
-branch", "not a test fix or crash fix", "cherry-pick conflict").
+branch", "outside requested scope", "cherry-pick conflict").
+
+### Tracking Issues Created:
+
+For each included PR that lacked a linked issue, list the original PR
+number and the new tracking issue number (e.g., `#34501 → brave-browser#52310,
+closed`). If no new issues were needed, say so explicitly. If any issue
+creation failed, list the PR and the reason.
 
 ### PR Link:
 


### PR DESCRIPTION
Default eligibility now covers any reasonable uplift candidate. A trailing free-form English argument narrows the scope (e.g. `only automated test fixes and crash fixes` restores the prior behavior). For each uplifted PR without a linked issue, the skill creates a tracking issue in brave-browser, cross-links it on both PRs, and closes it.