### PR TITLE
Remove re-entrant call to lazy initialize adblock service

### DIFF
--- a/chromium_src/chrome/browser/download/background_download_service_factory.cc
+++ b/chromium_src/chrome/browser/download/background_download_service_factory.cc
@@ -5,6 +5,7 @@
 
 #include "chrome/browser/download/background_download_service_factory.h"
 
+#include "base/functional/bind.h"
 #include "brave/browser/brave_browser_process.h"
 #include "brave/components/brave_shields/content/browser/ad_block_service.h"
 #include "brave/components/brave_shields/content/browser/ad_block_subscription_download_client.h"
@@ -16,11 +17,16 @@
 
 namespace {
 
+brave_shields::AdBlockSubscriptionServiceManager*
+GetAdBlockSubscriptionServiceManager() {
+  return g_brave_browser_process->ad_block_service()
+      ->subscription_service_manager();
+}
+
 std::unique_ptr<download::Client> CreateAdBlockSubscriptionDownloadClient(
     Profile* profile) {
   return std::make_unique<brave_shields::AdBlockSubscriptionDownloadClient>(
-      g_brave_browser_process->ad_block_service()
-          ->subscription_service_manager());
+      base::BindRepeating(&GetAdBlockSubscriptionServiceManager));
 }
 
 }  // namespace

--- a/components/brave_shields/content/browser/ad_block_subscription_download_client.cc
+++ b/components/brave_shields/content/browser/ad_block_subscription_download_client.cc
@@ -22,15 +22,17 @@
 namespace brave_shields {
 
 AdBlockSubscriptionDownloadClient::AdBlockSubscriptionDownloadClient(
-    AdBlockSubscriptionServiceManager* subscription_manager)
-    : subscription_manager_(subscription_manager) {}
+    SubscriptionServiceManagerGetter subscription_manager_getter)
+    : subscription_manager_getter_(std::move(subscription_manager_getter)) {}
 
 AdBlockSubscriptionDownloadClient::~AdBlockSubscriptionDownloadClient() =
     default;
 
 AdBlockSubscriptionDownloadManager*
 AdBlockSubscriptionDownloadClient::GetAdBlockSubscriptionDownloadManager() {
-  return subscription_manager_->download_manager();
+  auto* subscription_manager = subscription_manager_getter_.Run();
+  return subscription_manager ? subscription_manager->download_manager()
+                              : nullptr;
 }
 
 void AdBlockSubscriptionDownloadClient::OnServiceInitialized(

--- a/components/brave_shields/content/browser/ad_block_subscription_download_client.h
+++ b/components/brave_shields/content/browser/ad_block_subscription_download_client.h
@@ -9,7 +9,7 @@
 #include <string>
 #include <vector>
 
-#include "base/memory/raw_ptr.h"
+#include "base/functional/callback.h"
 #include "components/download/public/background_service/client.h"
 #include "components/download/public/background_service/download_metadata.h"
 
@@ -21,8 +21,11 @@ class AdBlockSubscriptionDownloadManager;
 
 class AdBlockSubscriptionDownloadClient : public download::Client {
  public:
+  using SubscriptionServiceManagerGetter =
+      base::RepeatingCallback<AdBlockSubscriptionServiceManager*()>;
+
   explicit AdBlockSubscriptionDownloadClient(
-      AdBlockSubscriptionServiceManager* subscription_manager);
+      SubscriptionServiceManagerGetter subscription_manager_getter);
   ~AdBlockSubscriptionDownloadClient() override;
   AdBlockSubscriptionDownloadClient(const AdBlockSubscriptionDownloadClient&) =
       delete;
@@ -49,8 +52,7 @@ class AdBlockSubscriptionDownloadClient : public download::Client {
   // Returns the AdBlockSubscriptionDownloadManager for the profile.
   AdBlockSubscriptionDownloadManager* GetAdBlockSubscriptionDownloadManager();
 
-  raw_ptr<AdBlockSubscriptionServiceManager> subscription_manager_ =
-      nullptr;  // NOT OWNED
+  SubscriptionServiceManagerGetter subscription_manager_getter_;
 };
 
 }  // namespace brave_shields


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
This fixes a problem that was surfaced by https://github.com/brave/brave-core/pull/36263, but technically it's a pre-existing issue that was just less likely to happen before it.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
