### PR TITLE
[brockit] Rebase v2 foundation

### DIFF
--- a/tools/cr/brockit.py
+++ b/tools/cr/brockit.py
@@ -214,6 +214,8 @@ from git_status import GitStatus
 from patchfile import Patchfile
 import plaster
 from plaster import PlasterFile, PlasterFileNeedsRegen
+import rebase_v2
+from rebase_v2 import REASSIGN_COMMIT_MSG_PREFIX
 import repository
 from repository import Repository
 from terminal import IncendiaryErrorHandler, console, is_verbose, terminal
@@ -266,8 +268,6 @@ MINOR_VERSION_BUMP_ISSUE_TEMPLATE = """### Minor Chromium bump
 - No specific code changes in Brave (only line number changes in patches)
 """
 
-# This is a brockit specific prefix for commit messages, similar to `fixup!`.
-REASSIGN_COMMIT_MSG_PREFIX = 'reassign!'
 
 def _get_current_branch_upstream_name() -> Optional[str]:
     """Retrieves the name of the current branch's upstream.
@@ -2072,9 +2072,13 @@ class Rebase(Task):
         with open(todo_file, 'w') as file:
             file.writelines(content_to_write)
 
-    def execute(self, from_ref: Optional[str], to_ref: Optional[str],
-                recommit: bool, discard_regen_changes: bool,
-                squash_minor_bumps: bool) -> bool:
+    def execute(self,
+                from_ref: Optional[str],
+                to_ref: Optional[str],
+                recommit: bool,
+                discard_regen_changes: bool,
+                squash_minor_bumps: bool,
+                v2: bool = False) -> bool:
         """Rebases the current branch onto the provided ref.
 
     This function rebases the current branch onto the provided branch. It is
@@ -2124,19 +2128,44 @@ class Rebase(Task):
         # if that's desired. That's done by calling this script again with
         # special internal flags.
         env = os.environ.copy()
+        # Capture the user's preferred editors BEFORE we override
+        # `GIT_SEQUENCE_EDITOR` / `GIT_EDITOR` below -- v2's editor
+        # fallback flows through `--internal-rebase-crash-*-editor` and
+        # needs to know what the user originally configured.
+        crash_seq_editor = rebase_v2.get_git_editor('GIT_SEQUENCE_EDITOR')
+        crash_msg_editor = rebase_v2.get_git_editor()
         editor = [str(VPYTHON3_PATH), __file__]
+        # v2 plan-rewriting flags share the `--internal-rebase-v2-plan-`
+        # prefix so the dispatch can detect them with one check and
+        # consolidate both into a single `rewrite_plan` call.
+        discard_flag = ('--internal-rebase-v2-plan-discard-recyclable'
+                        if v2 else '--internal-rebase-remove-regen-changes')
+        squash_plan_flag = ('--internal-rebase-v2-plan-squash-pinned'
+                            if v2 else '--internal-rebase-squash-minor-bumps')
+        squash_msg_flag = ('--internal-rebase-v2-fix-message' if v2 else
+                           '--internal-rebase-squash-commit-message')
         if discard_regen_changes:
-            editor.append('--internal-rebase-remove-regen-changes')
+            editor.append(discard_flag)
         if recommit:
             editor.append('--internal-rebase-recommit')
         if squash_minor_bumps:
-            editor.append('--internal-rebase-squash-minor-bumps')
+            editor.append(squash_plan_flag)
 
             # Squashes will cause `GIT_EDITOR` also to open for the commit
             # message, so we need to handle those too.
-            env["GIT_EDITOR"] = (
-                f'{str(VPYTHON3_PATH)} '
-                f'{__file__} --internal-rebase-squash-commit-message')
+            msg_editor_cmd = (
+                f'{str(VPYTHON3_PATH)} {__file__} {squash_msg_flag}')
+            if v2:
+                msg_editor_cmd += (
+                    f' --internal-rebase-crash-msg-editor={crash_msg_editor}')
+            env["GIT_EDITOR"] = msg_editor_cmd
+
+        if v2 and len(editor) > 2:
+            # Pass the captured sequence-editor fallback alongside the
+            # v2 plan flags so the subprocess can hand off to it when
+            # `EditorRecoverableFailure` fires.
+            editor.append(
+                f'--internal-rebase-crash-sequence-editor={crash_seq_editor}')
 
         if len(editor) > 2:
             env["GIT_SEQUENCE_EDITOR"] = " ".join(editor)
@@ -2436,6 +2465,10 @@ def main():
         help=
         'Squashes all the minor bumps in-between the the last version and the '
         'previous upstream ref.')
+    rebase_parser.add_argument(
+        '--v2',
+        action='store_true',
+        help='Use the Rebase v2 code path (rebase_v2.py).')
 
     subparsers.add_parser(
         'update-version-issue',
@@ -2519,7 +2552,8 @@ def main():
                          to_ref=args.to_ref,
                          recommit=args.recommit,
                          discard_regen_changes=args.discard_regen_changes,
-                         squash_minor_bumps=args.squash_minor_bumps)
+                         squash_minor_bumps=args.squash_minor_bumps,
+                         v2=args.v2)
         if args.command == 'regen':
             Regen(
                 resolve_version_with_from_ref_arg()).run(dry_run=args.dry_run)
@@ -2549,6 +2583,55 @@ if __name__ == '__main__':
             Rebase.squash_minor_bumps_from_rebase_plan(Path(sys.argv[-1]))
         if '--internal-rebase-squash-commit-message' in sys.argv:
             Rebase.fix_squash_commit_messages(Path(sys.argv[-1]))
+
+        def _crash_editor_from_argv(flag_prefix: str) -> str:
+            """Pulls a `--<flag_prefix>=<editor>` value out of `sys.argv`.
+
+            Raises `NotImplementedError` when the flag is absent or its
+            value is empty -- `Rebase.execute` appends this flag
+            unconditionally for v2 rebase steps, so a missing value
+            means a wiring bug rather than something recoverable at
+            runtime.
+            """
+            prefix = f'{flag_prefix}='
+            for arg in sys.argv:
+                if arg.startswith(prefix):
+                    value = arg[len(prefix):]
+                    if value:
+                        return value
+                    break
+            raise NotImplementedError(
+                f'Expected --{flag_prefix}=<editor> in sys.argv but '
+                f'none was found (or it was empty). `Rebase.execute` '
+                f'should have appended it for this v2 dispatch.')
+
+        if any(a.startswith('--internal-rebase-v2-plan-') for a in sys.argv):
+            editor_path = Path(sys.argv[-1])
+            crash_editor = _crash_editor_from_argv(
+                '--internal-rebase-crash-sequence-editor')
+            try:
+                rebase_v2.rewrite_plan(
+                    todo_file=editor_path,
+                    discard_recyclable=(
+                        '--internal-rebase-v2-plan-discard-recyclable'
+                        in sys.argv),
+                    pinned_squashed=('--internal-rebase-v2-plan-squash-pinned'
+                                     in sys.argv))
+            except rebase_v2.EditorRecoverableFailure as e:
+                rebase_v2.hand_off_to_editor(editor_path,
+                                             reason=str(e),
+                                             editor=crash_editor)
+        if '--internal-rebase-v2-fix-message' in sys.argv:
+            editor_path = Path(sys.argv[-1])
+            crash_editor = _crash_editor_from_argv(
+                '--internal-rebase-crash-msg-editor')
+            try:
+                writer = rebase_v2.MessageWriter.parse(editor_path)
+                writer.rewrite_with_last_message()
+            except rebase_v2.EditorRecoverableFailure as e:
+                rebase_v2.hand_off_to_editor(editor_path,
+                                             reason=str(e),
+                                             editor=crash_editor)
         sys.exit(0)
 
     sys.exit(main())

--- a/tools/cr/rebase_v2.py
+++ b/tools/cr/rebase_v2.py
@@ -1,0 +1,830 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Rebase v2 -- an alternative `brockit rebase` code path.
+
+Wired behind `brockit.py rebase --v2`. The module exposes two
+file-in / file-out transforms that brockit hooks into git via the
+`GIT_SEQUENCE_EDITOR` and `GIT_EDITOR` env vars during a
+`git rebase --interactive`:
+
+* `rewrite_plan(todo_file, …)` -- reorders the rebase TODO produced by
+  `GIT_SEQUENCE_EDITOR`. Pinned commits get grouped to the top, recyclable
+  commits get optionally evicted, reassign commits get placed next to
+  their target.
+* `MessageWriter.parse(todo_file)` + `rewrite_with_last_message()` --
+  composes the squash commit message produced by `GIT_EDITOR`, picking
+  whichever surviving message corresponds to the kind of squash being
+  performed (`PINNED` or `REASSIGNMENT`).
+
+Whenever either step can't safely transform the file, it raises
+`EditorRecoverableFailure`. The brockit dispatch catches it and routes
+the file through `hand_off_to_editor`, which prepends the failure reason
+as a `#`-comment and opens the user's editor.
+
+Commit categories formalised here (see `EntryType`):
+
+* PINNED -- commits that should be unique in the history of the branch.
+  Multiple occurrences of the same pinned change are auto-squashed by
+  `brockit.py rebase --squash-minor-bumps`, and the resulting squash is
+  moved to the top of the branch history. Priority order is the entry
+  order in `PINNED_GROUPS`. Subjects that fit this category:
+
+    - Update from Chromium * to Chromium *.
+    - Apply-fixed 🩹 patches from Chromium * to Chromium *.
+    - Conflict-resolved patches from Chromium * to Chromium *.
+    - [cr*] `gnrt` run for Chromium *.
+    - [cr*] IWYU fixes.
+    - [cr*] Bump resource_ids.
+    - [cr*] Update Lit mangler snapshot.
+    - [cr*] Disable failing upstream tests.
+
+* RECYCLABLE -- commits we can always drop and regenerate with tooling.
+  They're discarded by `brockit.py rebase --discard-regen-changes`.
+  Subjects that fit this category:
+
+    - Update patches from Chromium * to Chromium *.
+    - Updated strings for Chromium *.
+
+* REASSIGNMENT -- `reassign!<hash>!` commits authored by
+  `brockit reassign`. Repositioned next to their target when
+  `pinned_squashed=True`.
+* DEFAULT -- everything else.
+"""
+
+from __future__ import annotations
+
+import enum
+import logging
+import os
+import re
+import shlex
+from dataclasses import dataclass
+from pathlib import Path
+
+from terminal import terminal
+
+# Brockit-specific prefix for commit messages, similar to `fixup!`.
+REASSIGN_COMMIT_MSG_PREFIX = 'reassign!'
+
+# Strips one or more leading bracketed tags whose first token starts with
+# `cr` followed by digits -- e.g. `[cr149] `, `[cr149][ios] `. Leaves
+# unrelated bracketed tags alone. This means branch tags are irrelevant
+# when determining the commit type.
+_CR_TAG_RE = re.compile(r'^(?:\[cr\d+\](?:\[[^\]]+\])*\s+)?')
+
+# Strips repeated leading autosquash prefixes like `fixup! `, `amend! `,
+# `squash! ` -- these stack when commits fix up an already-fixup commit
+# (e.g. `fixup! fixup! fixup! Conflict-resolved patches …`). Pre-stripping
+# them lets the pinned/recyclable regexes match the underlying subject
+# regardless of how many autosquash levels deep the user has gone.
+_AUTOSQUASH_PREFIX_RE = re.compile(r'^(?:(?:fixup|amend|squash)!\s+)+')
+
+# Chromium version shape: exactly four dot-separated numeric segments
+# (e.g. 149.0.7827.5).
+_CR_VERSION = r'\d+\.\d+\.\d+\.\d+'
+
+# Matches the contiguous `!`-separated subcommand prefix of a comment, e.g.
+# `reassign!hash!`, `amend!`, `fixup!`. Git already uses `amend!`, `fixup!`,
+# but brockit uses this format to make it a `!`-separated list for subcommands
+# (e.g `reassign!hash!` → `['reassign', 'hash']`).
+_SUBCOMMAND_RE = re.compile(r'^(?:[A-Za-z]\w*!)+')
+
+# Matches a `# <word>! <subject>` autosquash marker line inside a squash
+# editor block (e.g. `# amend! Update from Chromium …`). Group 1 captures
+# the marker word with its trailing `!`; group 2 captures the rest of
+# the line as the commit-subject suffix.
+_AUTOSQUASH_NOTE_RE = re.compile(r'#\s*(\w+!)\s*(.+)')
+
+
+def _strip_cr_tag(subject: str) -> str:
+    """Returns `subject` with any leading `[crNNN]` (or `[crNNN][...]…`)
+    tag and the trailing whitespace removed. A subject that doesn't
+    start with such a tag is returned unchanged."""
+    return _CR_TAG_RE.sub('', subject, count=1)
+
+
+def _strip_autosquash_prefixes(subject: str) -> str:
+    """Returns `subject` with any leading stack of `fixup! ` / `amend! `
+    / `squash! ` prefixes removed. Subjects without those prefixes are
+    returned unchanged."""
+    return _AUTOSQUASH_PREFIX_RE.sub('', subject)
+
+
+def _match(subject: str, pattern: re.Pattern) -> bool:
+    """True if `pattern` fully matches `subject` after stripping any
+    leading `fixup!` / `amend!` / `squash!` autosquash prefixes and any
+    `[crNNN]` tag. The stripped subject is also right-trimmed so a
+    trailing space in the original line doesn't break the fullmatch."""
+    cleaned = _strip_cr_tag(_strip_autosquash_prefixes(subject)).rstrip()
+    return pattern.fullmatch(cleaned) is not None
+
+
+# Ordered list of `(pinned-group-id, regex)` entries. The order *is* the
+# squash priority order: when multiple pinned groups are present in the
+# same rebase plan, they're emitted top-to-bottom in this order
+# (version → plaster_reruns → conflict → gnrt → IWYU →
+# resource_ids → lit_mangler → disable_tests). The regexes are
+# anchored fullmatches applied to the `[crNNN]`-stripped subject, so each
+# pattern matches both the tagged and the untagged form of the same commit.
+PINNED_GROUPS = [
+    ('version',
+     re.compile(rf'Update from Chromium {_CR_VERSION} to '
+                rf'Chromium {_CR_VERSION}\.?')),
+    ('plaster_reruns',
+     re.compile(rf'Apply-fixed 🩹 patches from Chromium {_CR_VERSION} to '
+                rf'Chromium {_CR_VERSION}\.?')),
+    ('conflict',
+     re.compile(rf'Conflict-resolved patches from Chromium {_CR_VERSION} to '
+                rf'Chromium {_CR_VERSION}\.?')),
+    ('gnrt', re.compile(rf'`gnrt` run for Chromium {_CR_VERSION}\.?')),
+    ('iwyu', re.compile(r'IWYU fixes\.?')),
+    ('resource_ids', re.compile(r'Bump resource_ids\.?')),
+    ('lit_mangler', re.compile(r'Update Lit mangler snapshot\.?')),
+    ('disable_tests', re.compile(r'Disable failing upstream tests\.?')),
+]
+
+# Subjects produced by `npm run update_patches` and string generation --
+# evicted when `discard_recyclable=True`.
+RECYCLABLE_PATTERNS = [
+    re.compile(rf'Update patches from Chromium {_CR_VERSION} to '
+               rf'Chromium {_CR_VERSION}\.?'),
+    re.compile(rf'Updated strings for Chromium {_CR_VERSION}\.?'),
+]
+
+
+def get_pinned_group_for_subject(subject: str) -> str | None:
+    """Returns the `PINNED_GROUPS` group id that `subject` matches
+    (e.g. `'version'`, `'iwyu'`), or `None` when no pattern matches.
+    Matching strips a leading `[crNNN]`-style tag, so the tagged and
+    untagged forms of the same subject return the same group id."""
+    for pinned_group, pattern in PINNED_GROUPS:
+        if _match(subject, pattern):
+            return pinned_group
+    return None
+
+
+def is_recyclable(subject: str) -> bool:
+    """Returns True when `subject` matches any `RECYCLABLE_PATTERNS`
+    entry -- i.e. the commit is auto-generated and can be regenerated
+    from the current source tree."""
+    return any(_match(subject, p) for p in RECYCLABLE_PATTERNS)
+
+
+def get_entry_type_for_subject(subject: str) -> 'EntryType':
+    """Classifies a bare commit subject (no TODO command/hash prefix)
+    into one of the four `EntryType` variants."""
+    if subject.startswith(REASSIGN_COMMIT_MSG_PREFIX):
+        return EntryType.REASSIGNMENT
+    if get_pinned_group_for_subject(subject) is not None:
+        return EntryType.PINNED
+    if is_recyclable(subject):
+        return EntryType.RECYCLABLE
+    return EntryType.DEFAULT
+
+
+def get_git_editor(primary_env: str = 'GIT_EDITOR') -> str:
+    """Returns the editor brockit should fall back to when a v2 rebase
+    step can't transform the file it was handed. Resolution order:
+
+    Must be called BEFORE the caller overrides `GIT_SEQUENCE_EDITOR` /
+    `GIT_EDITOR` (e.g. before `Rebase.execute` sets its own dispatch as
+    the editor).
+    """
+    fallbacks = [primary_env]
+    if primary_env != 'GIT_EDITOR':
+        fallbacks.append('GIT_EDITOR')
+    fallbacks.extend(['VISUAL', 'EDITOR'])
+    for env_name in fallbacks:
+        value = os.environ.get(env_name)
+        if not value:
+            continue
+        if 'brockit.py' in value and '--internal-rebase-' in value:
+            raise NotImplementedError(
+                f'${env_name} is already set to a brockit internal '
+                f'dispatch ({value!r}). `get_git_editor` must run '
+                f'BEFORE brockit overrides the env vars -- otherwise '
+                f'the editor fallback would loop on ourselves.')
+        return value
+    return 'vim'
+
+
+def hand_off_to_editor(todo_file: Path, reason: str, editor: str) -> None:
+    """Spawns `editor` on `todo_file` and waits for it.
+
+    `editor` is the caller-resolved editor command (typically the value
+    captured by `get_git_editor` and threaded through via
+    `--internal-rebase-crash-*-editor`). The caller is responsible for
+    making sure it's non-empty before getting here -- this function
+    has no env-var fallback of its own.
+
+    When `reason` is non-empty, each of its lines is prepended to the
+    file as a `#`-comment so the user sees why we couldn't rewrite the
+    message automatically. Lines starting with `#` already are passed
+    through unchanged.
+    """
+    if reason:
+        intro = ('# B🚀 has been unable to handle this rebase. Investigate '
+                 'why, and\n'
+                 '# file a bug. Failure reason below.\n')
+        prefix = intro + ''.join(
+            (line if line.startswith('#') else f'# {line}') + '\n'
+            for line in reason.splitlines())
+        todo_file.write_text(prefix + todo_file.read_bytes().decode('utf-8'),
+                             newline='')
+
+    # `editor` may be a multi-token command (e.g. `vim -X`,
+    # `code --wait`, `my_editor --feature="with space"`).
+    terminal.run(shlex.split(editor) + [str(todo_file)], interactive=True)
+
+
+class EntryType(enum.Enum):
+    """The type of a given change based on the subject line.
+
+    * `PINNED`       -- subject matches one of `PINNED_GROUPS`.
+    * `RECYCLABLE`   -- subject matches one of `RECYCLABLE_PATTERNS`.
+    * `REASSIGNMENT` -- subject (or autosquash subcommand) starts with
+                        `reassign!`.
+    * `DEFAULT`      -- none of the above; produced only by `EntryLine`.
+                        `MessageWriter.parse` never returns this value
+                        -- it raises `EditorRecoverableFailure` instead.
+    """
+    PINNED = 'pinned'
+    RECYCLABLE = 'recyclable'
+    REASSIGNMENT = 'reassignment'
+    DEFAULT = 'default'
+
+
+class EditorRecoverableFailure(Exception):
+    """Parsing failures during rebase that should be investigated manually.
+
+    This is used for cases where some unrecognised pattern is found and the
+    code we have doesn't know how to handle it. This shouldn't happen, but if
+    it does, we want to be able to inspect things, take over the process
+    manually, and even correct the issue later on in brockit.
+
+    The expected handling is for the actual editor to be launched for manual
+    intervention, with the failure reason prepended as a comment to the file.
+
+    This exception is *not* for actual violation of invariants. For those use
+    more appropriate, non-recoverable exceptions. This is also not for natural
+    user prompting. If anything like this is needed in the future, we should
+    have proper flows that do not involve the use of exceptions for control
+    flow.
+    """
+
+
+class EntryLine:
+    """A parsed line from a `git rebase --interactive` TODO file.
+    """
+
+    def __init__(
+            self,
+            *,
+            out: str,
+            command: str,
+            # Disabling pylint here as `hash` is an appropriate word.
+            hash: str,  # pylint: disable=redefined-builtin
+            message: str,
+            subcommand: list | None = None,
+            note: str | None = None):
+
+        # The text for the entry line in the file. This is loaded from the
+        # file, however it does get updated when fields in this class are
+        # updated.
+        self._out = out
+
+        # The rebase command word(s) before the hash: `pick`, `edit`,
+        # `squash`, `fixup`, `fixup -C`, etc. May contain spaces.
+        self._command = command
+
+        # The commit short-hash that follows the command.
+        self._hash = hash
+
+        # The `!`-separated autosquash prefix tokens, with the trailing
+        # empty segment dropped (e.g. `['reassign', 'c080270dd7e']`).
+        self._subcommand = subcommand
+
+        # The commit subject. The subcommand is already pilled off in this
+        # field, which means, no `fixup!`, `amend!`, `reassign!`, etc.
+        self._message = message
+
+        # The trailing ` # <note>` marker (e.g. `'empty'`), or `None`.
+        self._note = note
+
+        # Classification fields. `_entry_type` defaults to DEFAULT and
+        # is overridden below based on the subcommand/message; the
+        # result is read-only for the rest of this `EntryLine`'s
+        # lifetime.
+        self._pinned_group: str | None = None
+        self._entry_type: EntryType = EntryType.DEFAULT
+        if self._subcommand and self._subcommand[0] == 'reassign':
+            self._entry_type = EntryType.REASSIGNMENT
+        elif is_recyclable(self._message):
+            self._entry_type = EntryType.RECYCLABLE
+        else:
+            pinned_group = get_pinned_group_for_subject(self._message)
+            if pinned_group is not None:
+                self._pinned_group = pinned_group
+                self._entry_type = EntryType.PINNED
+
+    # ----- read-only properties ---------------------------------------------
+
+    @property
+    def out(self) -> str:
+        return self._out
+
+    @property
+    def hash(self) -> str:
+        return self._hash
+
+    @property
+    def message(self) -> str:
+        return self._message
+
+    @property
+    def subcommand(self) -> list | None:
+        return self._subcommand
+
+    @property
+    def note(self) -> str | None:
+        return self._note
+
+    @property
+    def pinned_group(self) -> str | None:
+        return self._pinned_group
+
+    @property
+    def entry_type(self) -> 'EntryType':
+        return self._entry_type
+
+    @property
+    def is_pinned(self) -> bool:
+        return self._entry_type is EntryType.PINNED
+
+    @property
+    def is_recyclable(self) -> bool:
+        return self._entry_type is EntryType.RECYCLABLE
+
+    @property
+    def is_reassignment(self) -> bool:
+        return self._entry_type is EntryType.REASSIGNMENT
+
+    @property
+    def reassign_target_hash(self) -> str | None:
+        """The target hash carried in the `reassign!<hash>!` prefix --
+        or `None` if the prefix has no hash. Raises
+        `NotImplementedError` on a non-reassignment commit (callers
+        should gate on `is_reassignment` first)."""
+        if not self.is_reassignment:
+            raise NotImplementedError(
+                'reassign_target_hash is only defined for reassignment '
+                'commits')
+        if self._subcommand and len(self._subcommand) >= 2:
+            return self._subcommand[1]
+        return None
+
+    # ----- the one mutable property -----------------------------------------
+
+    @property
+    def command(self) -> str:
+        """Assigning to this property also updates `out` so the emitted
+        line stays in sync."""
+        return self._command
+
+    @command.setter
+    def command(self, new_command: str) -> None:
+        self._command = new_command
+        self._refresh_out()
+
+    # ----- public methods ---------------------------------------------------
+
+    @staticmethod
+    def parse(line: str) -> 'EntryLine | None':
+        """Parses a TODO line into a `EntryLine`.
+
+        Returns `None` for blank or pure-comment lines. Raises
+        `EditorRecoverableFailure` for non-empty lines that don't match
+        the expected `<command> <hash> # <comment>` shape -- the caller
+        is expected to surface the failure via `hand_off_to_editor`.
+        """
+        if not line.strip() or line.lstrip().startswith('#'):
+            return None
+
+        # Split into at most three sections: command-part, comment, and an
+        # optional trailing ` # <note>` marker (e.g. ` # empty`). Capping
+        # the split keeps any `#` inside the comment itself intact.
+        parts = line.rstrip().split('#', maxsplit=2)
+        if len(parts) < 2:
+            raise EditorRecoverableFailure(
+                f'Cannot parse TODO line (no comment): {line!r}')
+
+        cmd_part = parts[0].rstrip()
+        comment = parts[1].strip()
+        note = (parts[2].strip() or None) if len(parts) == 3 else None
+
+        # The hash is the last whitespace-separated token of the command
+        # part; everything before it is the command (e.g. `pick`, `edit`,
+        # `fixup -C`).
+        comand_parts = cmd_part.rsplit(maxsplit=1)
+        if len(comand_parts) != 2:
+            raise EditorRecoverableFailure(
+                f'Cannot parse TODO line (no hash): {line!r}')
+        command, commit_hash = comand_parts
+
+        subcommand = None
+        sub_match = _SUBCOMMAND_RE.match(comment)
+        if sub_match:
+            subcommand = [tok for tok in sub_match.group(0).split('!') if tok]
+            message = comment[sub_match.end():].lstrip()
+        else:
+            message = comment
+
+        return EntryLine(out=line,
+                         command=command,
+                         hash=commit_hash,
+                         subcommand=subcommand,
+                         message=message,
+                         note=note)
+
+    # ----- private helpers --------------------------------------------------
+
+    def _refresh_out(self) -> None:
+        """Regenerates `_out` from the current field values in the
+        canonical `<command> <hash> # [<sub1>!<sub2>! ]<message>[ # <note>]`
+        form. Called automatically by the `command` setter."""
+        subcommand_prefix = (''.join(f'{tok}!' for tok in self._subcommand) +
+                             ' ' if self._subcommand else '')
+        line = (f'{self._command} {self._hash} # '
+                f'{subcommand_prefix}{self._message}')
+        if self._note:
+            line = f'{line} # {self._note}'
+        self._out = line
+
+
+def rewrite_plan(*,
+                 todo_file: Path,
+                 pinned_squashed: bool = False,
+                 discard_recyclable: bool = False) -> None:
+    """Rewrites a `git rebase --interactive` TODO file in place.
+
+    The two operations are independent and may be used alone or
+    combined. When both flags are `False` this is a no-op: the file is
+    neither read nor written.
+
+    Args:
+        todo_file: Path to the `git-rebase-todo` file that
+            `GIT_SEQUENCE_EDITOR` was invoked with.
+        pinned_squashed: When `True`, group pinned commits at the top
+            of the plan, in `PINNED_GROUPS` priority order. The first
+            commit in each group stays `pick`; subsequent ones become
+            `squash`. Reassign commits are repositioned to sit
+            immediately above their target (with the target rewritten
+            to `squash`). Defaults to `False`.
+        discard_recyclable: When `True`, drop recyclable commits from
+            the plan entirely. Defaults to `False`.
+
+    Raises:
+        EditorRecoverableFailure: Any TODO line that doesn't parse
+            (malformed shape, missing hash, etc.) bubbles up so the
+            caller can punt to `hand_off_to_editor`.
+    """
+
+    if not pinned_squashed and not discard_recyclable:
+        # Nothing to do -- use whatever plan git produced.
+        return
+
+    pinned_groups = {group: [] for group, _ in PINNED_GROUPS}
+    all_others = []
+
+    def add_reassign_before_target(reassign: EntryLine) -> None:
+        """Looks for `reassign`'s target in `all_others` and, if found,
+        inserts `reassign` immediately above it while rewriting the
+        target to `squash`. Reassignment targets are required to be
+        regular commits -- pinned and recyclable commits aren't
+        supported, so a reassign whose target is pinned (or got dropped
+        as recyclable) ends up orphaned and silently discarded."""
+
+        def find_target(predicate) -> tuple[EntryLine | None, int | None]:
+            """Walks `all_others` in reverse order and returns the first
+            entry that satisfies `predicate`, paired with its index. The
+            reverse walk is a small optimisation: a reassign's target is
+            usually the immediately-preceding entry_line, so the typical hit
+            is on the first iteration. Returns `(None, None)` when no
+            entry matches."""
+            return next(((c, i) for c, i in zip(
+                reversed(all_others), range(len(all_others) - 1, -1, -1))
+                         if predicate(c)), (None, None))
+
+        target, target_idx = None, None
+        if reassign.reassign_target_hash is not None:
+            target, target_idx = find_target(
+                lambda c: c.hash == reassign.reassign_target_hash)
+
+        if target is None:
+            # Fallback search by commit message. This is allowed.
+            target, target_idx = find_target(
+                lambda c: c.message == reassign.message)
+
+        if target is None:
+            # Reassignment is orphaned -- drop it and do nothing.
+            logging.warning('Dropping orphaned reassignment: %s',
+                            reassign.out.strip())
+            return
+
+        # The `target` becomes `squash` so its message/authorship is
+        # absorbed by the reassign; the reassign keeps its `pick` and
+        # slots in right above. The `command` setter on `EntryLine` keeps
+        # `out` in sync automatically.
+        target.command = 'squash'
+        all_others.insert(target_idx, reassign)
+
+    for line in todo_file.read_bytes().decode('utf-8').splitlines():
+        entry_line = EntryLine.parse(line)
+        if entry_line is None:
+            # Irrelevant line (blank or comment).
+            continue
+
+        # Dropping discardable commits if we don't need them.
+        if discard_recyclable and entry_line.is_recyclable:
+            continue
+
+        if pinned_squashed:
+            if entry_line.is_reassignment:
+                add_reassign_before_target(entry_line)
+                continue
+            if entry_line.pinned_group is not None:
+                # First commit in the group becomes `pick`; subsequent
+                # ones become `squash`. The setter keeps `out` in sync.
+                entry_line.command = (
+                    'pick' if not pinned_groups[entry_line.pinned_group] else
+                    'squash')
+                pinned_groups[entry_line.pinned_group].append(entry_line)
+                continue
+
+        all_others.append(entry_line)
+
+    new_plan = [
+        *(c.out for group in pinned_groups.values() for c in group),
+        *(c.out for c in all_others)
+    ]
+
+    todo_file.write_text('\n'.join(new_plan) + '\n', newline='')
+
+
+_COMMIT_MSG_HEADER_GUARDS = re.compile(
+    r'^# (This is the (?:1st|\d+(?:st|nd|rd|th)) commit message:|'
+    r'This is the commit message #\d+:|'
+    r'The commit message #\d+ will be skipped:)$')
+
+
+class MsgBlock:
+    """One commit-message block carved out of a `GIT_EDITOR` squash file.
+
+    When git squashes N commits, it builds a single editor file whose
+    body is the concatenation of each original commit's message, each
+    preceded by a `# This is …` header line that git itself inserts.
+    `MsgBlock` is the parsed unit for one of those sections.
+
+    Example (one squash combining three commits):
+
+        # This is a combination of 3 commits.
+        # This is the 1st commit message:
+
+        Update from Chromium 1.0.0.0 to Chromium 1.0.0.1
+
+        # This is the commit message #2:
+
+        # amend! Update from Chromium 1.0.0.0 to Chromium 1.0.0.1
+
+        Tweaked: dropped an extraneous header bump.
+
+        # The commit message #3 will be skipped:
+
+        # fixup! Update from Chromium 1.0.0.0 to Chromium 1.0.0.1
+
+        # Please enter the commit message for your changes. …
+
+    `MsgBlock.parse` walks the file and produces:
+
+    * Block 1 -- `full_message='Update from Chromium 1.0.0.0 to
+      Chromium 1.0.0.1'`, `note=None` (no autosquash marker).
+    * Block 2 -- `full_message='Tweaked: dropped an extraneous header
+      bump.'`, `note=OriginalCommitNote(command='amend!', first_line=...)`.
+    * Block 3 (the `will be skipped` block) is skipped by the parser and not
+      supported.
+    """
+
+    @dataclass(frozen=True)
+    class OriginalCommitNote:
+        """The autosquash marker line that git inserts inside some
+        commit-message blocks.
+        """
+
+        # The marker word including its trailing `!`. One of `'amend!'`,
+        # `'squash!'`, `'fixup!'`.
+        command: str
+
+        # The commit-subject suffix on the same line as the marker.
+        first_line: str
+
+        @staticmethod
+        def from_line(line: str) -> 'MsgBlock.OriginalCommitNote | None':
+            """Parses `line` as an autosquash marker. Returns an
+            `OriginalCommitNote` when it matches `# <word>! <subject>`,
+            `None` otherwise (e.g. a plain content line)."""
+            match = _AUTOSQUASH_NOTE_RE.match(line)
+            if match:
+                return MsgBlock.OriginalCommitNote(command=match.group(1),
+                                                   first_line=match.group(2))
+            return None
+
+    def __init__(self,
+                 *,
+                 full_message: str,
+                 note: 'MsgBlock.OriginalCommitNote | None' = None):
+
+        # The commit body for this block with `#`-comment lines removed
+        # and leading / trailing blanks trimmed.
+        self._full_message = full_message
+
+        # The autosquash marker that opened this block, or `None` when
+        # the block had no marker.
+        self._note = note
+
+    @property
+    def full_message(self) -> str:
+        return self._full_message
+
+    @property
+    def note(self) -> 'MsgBlock.OriginalCommitNote | None':
+        return self._note
+
+    def _extend_message(self, more: str) -> None:
+        """Appends `more` on a new line to `_full_message`. Used by
+        `parse` when merging a `# squash!` block into its predecessor;
+        kept private so external callers can't mutate a block's body
+        ad-hoc."""
+        self._full_message = f'{self._full_message}\n{more}'
+
+    @staticmethod
+    def parse(text: str) -> list['MsgBlock']:
+        """Splits `text` into a list of `MsgBlock`s, in source order.
+
+        This function goes over each block in the produced editor file and
+        extracts the commit messages for each case. Blocks for autosquash
+        changes are skipped. Blocks for `squash!` are merged into the previous
+        block. The rest are emitted as-is.
+
+        Raises `EditorRecoverableFailure` for malformed input (too few
+        lines for a valid block, an empty body, or a `squash!` pointing
+        at an empty previous block).
+        """
+
+        def get_message_blocks_ranges(lines: list[str]):
+            start_idx = None
+            for i, line in enumerate(lines):
+                # Stop at the Git boilerplate
+                if line.startswith("# Please enter the commit message"):
+                    if start_idx is not None:
+                        yield lines[start_idx:i]
+                    return  # Cleanly exit the generator
+
+                # When we hit a new header, yield the slice of the
+                # previous block.
+                if _COMMIT_MSG_HEADER_GUARDS.match(line):
+                    if start_idx is not None:
+                        yield lines[start_idx:i]
+                    start_idx = i  # Mark the start of the new block
+
+            # Yield the very last block if the loop finishes normally
+            if start_idx is not None:
+                yield lines[start_idx:]
+
+        blocks = []
+        for block_lines in get_message_blocks_ranges(text.splitlines()):
+            # A valid block is at minimum `header`, `<blank>`, `<subject>`
+            # -- three lines. Noted blocks (`# squash!`, `# amend!`,
+            # `# fixup!`) are longer; we detect the note at index 2 if
+            # enough lines are present.
+            if len(block_lines) < 3:
+                raise EditorRecoverableFailure(
+                    f'Unexpected block format: {block_lines}')
+
+            # `will be skipped` blocks aren't relevant for commit
+            # messages -- git already commented out their content.
+            # Example:
+            #   The commit message #4 will be skipped:
+            #
+            #   fixup! [cr149][brockit] `@latest-{channel}` latest
+            #          version for all platforms
+            #
+            if "will be skipped:" in block_lines[0]:
+                continue
+
+            # The commit note line only appears next to the header line,
+            # with an empty line in between. For example:
+            # This is the commit message #3:
+            #
+            # amend! [cr149][brockit] `@latest-{channel}` latest version for all
+            note = MsgBlock.OriginalCommitNote.from_line(block_lines[2])
+
+            if note:
+                # The note pushes the beginning of the message a few
+                # lines down.
+                message_lines = block_lines[4:]
+            else:
+                # With no note, the message starts immediately after the
+                # header and empty line.
+                message_lines = block_lines[2:]
+
+            msg = "\n".join(line.strip() for line in message_lines).strip()
+            if (note is not None and note.command == "squash!" and msg
+                    and blocks):
+                if not blocks[-1].full_message:
+                    raise EditorRecoverableFailure(
+                        'Unexpected empty message in previous block when '
+                        'processing a squash! block with a note. Previous '
+                        f'block lines: {blocks[-1].full_message}')
+                # For `# squash!`, append to the previous block's body
+                # and discard this block.
+                blocks[-1]._extend_message(msg)
+            elif msg:
+                blocks.append(MsgBlock(full_message=msg, note=note))
+            else:
+                raise EditorRecoverableFailure(
+                    f'Unexpected empty message in block. Block lines: '
+                    f'{block_lines}')
+
+        return blocks
+
+
+@dataclass
+class MessageWriter:
+    """Decides what to do with a `GIT_EDITOR` squash commit-message file.
+
+    Construct one via the `MessageWriter.parse` factory: it reads the
+    file, checks that the squash is recognisable (either a pinned
+    subject or a `reassign!`), and stores the parsed `MsgBlock`s.
+
+    Use `rewrite_with_last_message()` to write the surviving message back.
+
+    Anything we can't classify raises `EditorRecoverableFailure` and is left
+    for the user to edit.
+
+    This class only supports PINNED and REASSIGNMENT message editing, because
+    these are the changes we know what to do with. Changes of any other type
+    arriving in this class are a sign of something went wrong, and will result
+    in `EditorRecoverableFailure` being raised.
+    """
+
+    # The squash editor file we'll rewrite.
+    todo_file: Path
+    # Every commit-message block parsed out of `todo_file`, in source
+    # order. The `reassign!` first block (in the reassignment case) is
+    # retained here -- it's the *last* block that gets written back,
+    # not the first.
+    blocks: list[MsgBlock]
+
+    # The set of first-block entry types we know how to rewrite. Other
+    # classifications (RECYCLABLE, DEFAULT) are punted to the editor.
+    _HANDLED_ENTRY_TYPES = frozenset(
+        {EntryType.PINNED, EntryType.REASSIGNMENT})
+
+    def rewrite_with_last_message(self) -> None:
+        """Writes the trailing block's `full_message` (with a trailing
+        newline) back to `todo_file`. Always valid:
+        `MessageWriter.parse` only returns instances with at least one
+        block whose first-block content classifies as PINNED or
+        REASSIGNMENT."""
+        self.todo_file.write_text(self.blocks[-1].full_message + '\n',
+                                  newline='')
+
+    @staticmethod
+    def parse(todo_file: Path) -> 'MessageWriter':
+        """Reads `todo_file` and returns a `MessageWriter` provided the
+        first commit-message block's subject classifies as one of
+        `MessageWriter._HANDLED_ENTRY_TYPES` (currently `PINNED` and
+        `REASSIGNMENT`).
+
+        Any other first-block classification (RECYCLABLE, DEFAULT) and
+        any file that fails to parse / yields no blocks raises
+        `EditorRecoverableFailure`. The exception message names the
+        rejected `EntryType` so the user sees, in the editor, why the
+        rewrite was punted.
+        """
+        blocks = MsgBlock.parse(todo_file.read_bytes().decode('utf-8'))
+
+        if not blocks:
+            raise EditorRecoverableFailure(
+                'No commit-message blocks were parsed from the editor file.')
+
+        first_msg_line = blocks[0].full_message.splitlines()[0]
+        entry_type = get_entry_type_for_subject(first_msg_line)
+        if entry_type not in MessageWriter._HANDLED_ENTRY_TYPES:
+            raise EditorRecoverableFailure(
+                f'Cannot rewrite a squash commit message classified as '
+                f'{entry_type.value!r}. First content line: '
+                f'{first_msg_line!r}')
+        return MessageWriter(todo_file=todo_file, blocks=blocks)

--- a/tools/cr/rebase_v2_test.py
+++ b/tools/cr/rebase_v2_test.py
@@ -1,0 +1,998 @@
+#!/usr/bin/env vpython3
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Tests for `rebase_v2`.
+
+This file is organised in two layers:
+
+* Unit tests (`EntryLineParseTest`, `PatternMatchTest`, `RewritePlanTest`,
+  `MessageWriterTest`) exercise the pure file-in / file-out transforms
+  with no git involved.
+
+* `RebaseV2ExecuteTest` covers `brockit.Rebase.execute(..., v2=True)`
+  end-to-end against a real git tree built by `FakeChromiumRepo`, mirroring
+  the integration layer used by `rebase_test.RebaseExecuteTest`.
+"""
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import brockit
+import rebase_v2
+from test.fake_chromium_repo import FakeChromiumRepo
+
+
+class EntryLineParseTest(unittest.TestCase):
+    """Tests for `rebase_v2.EntryLine.parse`."""
+
+    def test_parse_simple_pick(self):
+        entry_line = rebase_v2.EntryLine.parse(
+            'pick aaa # [cr148] Feature A\n')
+        self.assertEqual(entry_line.command, 'pick')
+        self.assertEqual(entry_line.hash, 'aaa')
+        self.assertEqual(entry_line.message, '[cr148] Feature A')
+        self.assertIsNone(entry_line.subcommand)
+        self.assertIsNone(entry_line.note)
+
+    def test_parse_fixup_dash_c_multi_word_command(self):
+        """`fixup -C <hash>` keeps both tokens as the command."""
+        entry_line = rebase_v2.EntryLine.parse(
+            'fixup -C 2c334294014 # amend! [cr149] Permit cross-host\n')
+        self.assertEqual(entry_line.command, 'fixup -C')
+        self.assertEqual(entry_line.hash, '2c334294014')
+        self.assertEqual(entry_line.message, '[cr149] Permit cross-host')
+        self.assertEqual(entry_line.subcommand, ['amend'])
+
+    def test_parse_reassign_subcommand(self):
+        """`reassign!<hash>!` is captured as two subcommand tokens."""
+        entry_line = rebase_v2.EntryLine.parse(
+            'pick zzz # reassign!c080270dd7e! [cr149] Fix bookmark bar.\n')
+        self.assertEqual(entry_line.subcommand, ['reassign', 'c080270dd7e'])
+        self.assertEqual(entry_line.message, '[cr149] Fix bookmark bar.')
+
+    def test_parse_trailing_empty_note(self):
+        """A trailing ` # empty` marker is split into `note` and stripped
+        out of the comment portion."""
+        entry_line = rebase_v2.EntryLine.parse(
+            'pick zzz # reassign!bbb! [cr148] Feature B # empty\n')
+        self.assertEqual(entry_line.note, 'empty')
+        self.assertEqual(entry_line.message, '[cr148] Feature B')
+        self.assertEqual(entry_line.subcommand, ['reassign', 'bbb'])
+
+    def test_parse_blank_line_returns_none(self):
+        self.assertIsNone(rebase_v2.EntryLine.parse('\n'))
+        self.assertIsNone(rebase_v2.EntryLine.parse('   \n'))
+
+    def test_parse_pure_comment_returns_none(self):
+        self.assertIsNone(rebase_v2.EntryLine.parse('# Rebase plan\n'))
+        self.assertIsNone(rebase_v2.EntryLine.parse('   # indented\n'))
+
+    def test_parse_malformed_line_raises(self):
+        """A non-empty, non-comment line that doesn't fit the
+        `<cmd> <hash> # <msg>` shape raises `EditorRecoverableFailure`
+        so the caller can punt to the user editor."""
+        with self.assertRaises(rebase_v2.EditorRecoverableFailure):
+            rebase_v2.EntryLine.parse('garbage\n')
+        with self.assertRaises(rebase_v2.EditorRecoverableFailure):
+            rebase_v2.EntryLine.parse('pickonly # no hash\n')
+
+    def test_entry_type_classification_and_properties(self):
+        """`entry_type` is filled in by `EntryLine.__init__` during
+        construction;
+        the `is_*` properties are derived from it and stay mutually
+        exclusive."""
+        EntryType = rebase_v2.EntryType
+
+        pinned = rebase_v2.EntryLine.parse(
+            'pick aaa # Update from Chromium 1.0.0.0 to Chromium 1.0.0.1\n')
+        self.assertIs(pinned.entry_type, EntryType.PINNED)
+        self.assertTrue(pinned.is_pinned)
+        self.assertFalse(pinned.is_recyclable)
+        self.assertFalse(pinned.is_reassignment)
+        self.assertEqual(pinned.pinned_group, 'version')
+
+        recyclable = rebase_v2.EntryLine.parse(
+            'pick bbb # Update patches from Chromium 1.0.0.0 to '
+            'Chromium 1.0.0.1.\n')
+        self.assertIs(recyclable.entry_type, EntryType.RECYCLABLE)
+        self.assertTrue(recyclable.is_recyclable)
+
+        reassign = rebase_v2.EntryLine.parse(
+            'pick zzz # reassign!bbb! [cr148] Feature B\n')
+        self.assertIs(reassign.entry_type, EntryType.REASSIGNMENT)
+        self.assertTrue(reassign.is_reassignment)
+
+        regular = rebase_v2.EntryLine.parse('pick ccc # [cr148] Feature A\n')
+        self.assertIs(regular.entry_type, EntryType.DEFAULT)
+        self.assertFalse(regular.is_pinned)
+        self.assertFalse(regular.is_recyclable)
+        self.assertFalse(regular.is_reassignment)
+
+    def test_reassign_target_hash_property(self):
+        """`reassign_target_hash` returns the hash from `reassign!<hash>!`
+        for reassignment commits, `None` when the reassignment has no
+        hash, and raises `NotImplementedError` for non-reassignment
+        commits."""
+        full = rebase_v2.EntryLine.parse(
+            'pick zzz # reassign!c080270dd7e! [cr149] Fix bookmark bar.\n')
+        self.assertEqual(full.reassign_target_hash, 'c080270dd7e')
+
+        no_hash = rebase_v2.EntryLine.parse(
+            'pick zzz # reassign! [cr149] Some subject.\n')
+        self.assertTrue(no_hash.is_reassignment)
+        self.assertIsNone(no_hash.reassign_target_hash)
+
+        regular = rebase_v2.EntryLine.parse('pick aaa # [cr148] Feature A\n')
+        with self.assertRaises(NotImplementedError):
+            _ = regular.reassign_target_hash
+
+    def test_fixup_of_pinned_classified_as_pinned(self):
+        """A `fixup -C` whose `amend!` subject is pinned still ends up
+        `entry_type=PINNED` with the right `pinned_group`. The
+        autosquash marker is peeled off into `subcommand` by
+        `EntryLine.parse`, so the regular pinned classifier on the bare
+        subject does the work -- no special-case handling needed."""
+        entry_line = rebase_v2.EntryLine.parse(
+            'fixup -C bbb # amend! Update from Chromium 1.0.0.0 to '
+            'Chromium 1.0.0.1\n')
+        self.assertIs(entry_line.entry_type, rebase_v2.EntryType.PINNED)
+        self.assertTrue(entry_line.is_pinned)
+        self.assertEqual(entry_line.pinned_group, 'version')
+
+
+class PatternMatchTest(unittest.TestCase):
+    """Tests for the cr-tag stripper, pinned classifier, and recyclable
+    detector."""
+
+    def test_strip_cr_tag_removes_simple_tag(self):
+        self.assertEqual(rebase_v2._strip_cr_tag('[cr149] Foo'), 'Foo')
+
+    def test_strip_cr_tag_removes_chained_tags(self):
+        """`[cr149][ios] ` collapses into nothing."""
+        self.assertEqual(rebase_v2._strip_cr_tag('[cr149][ios] Foo'), 'Foo')
+        self.assertEqual(rebase_v2._strip_cr_tag('[cr149][ios][extra] Foo'),
+                         'Foo')
+
+    def test_strip_cr_tag_leaves_unrelated_tag(self):
+        """`[unrelated] ` is not a cr-tag; left in place."""
+        self.assertEqual(rebase_v2._strip_cr_tag('[unrelated] Foo'),
+                         '[unrelated] Foo')
+
+    def test_strip_cr_tag_noop_on_untagged(self):
+        self.assertEqual(
+            rebase_v2._strip_cr_tag('Update from Chromium 1.0.0.0 to '
+                                    'Chromium 1.0.0.1'),
+            'Update from Chromium 1.0.0.0 to Chromium 1.0.0.1')
+
+    def test_strip_autosquash_prefixes_handles_stacks(self):
+        """`fixup! ` / `amend! ` / `squash! ` prefixes can stack when a
+        commit fixes up an already-fixup commit. `_strip_autosquash_prefixes`
+        peels off any number of them at the start."""
+        self.assertEqual(
+            rebase_v2._strip_autosquash_prefixes(
+                'fixup! Conflict-resolved patches from Chromium 1.0.0.0 '
+                'to Chromium 1.0.0.1.'),
+            'Conflict-resolved patches from Chromium 1.0.0.0 to '
+            'Chromium 1.0.0.1.')
+        self.assertEqual(
+            rebase_v2._strip_autosquash_prefixes(
+                'fixup! fixup! fixup! Conflict-resolved patches from '
+                'Chromium 1.0.0.0 to Chromium 1.0.0.1.'),
+            'Conflict-resolved patches from Chromium 1.0.0.0 to '
+            'Chromium 1.0.0.1.')
+        # Mixed prefixes also strip cleanly.
+        self.assertEqual(
+            rebase_v2._strip_autosquash_prefixes(
+                'amend! fixup! squash! [cr149] IWYU fixes.'),
+            '[cr149] IWYU fixes.')
+        # Untagged subjects pass through unchanged.
+        self.assertEqual(
+            rebase_v2._strip_autosquash_prefixes('Just a plain subject'),
+            'Just a plain subject')
+
+    def test_pinned_match_survives_stacked_autosquash_prefixes(self):
+        """A pinned subject buried under stacked `fixup!` prefixes still
+        classifies via the autosquash-prefix stripping pre-pass."""
+        self.assertEqual(
+            rebase_v2.get_pinned_group_for_subject(
+                'fixup! fixup! Conflict-resolved patches from Chromium '
+                '1.0.0.0 to Chromium 1.0.0.1.'), 'conflict')
+        self.assertEqual(
+            rebase_v2.get_pinned_group_for_subject(
+                'fixup! [cr149] IWYU fixes.'), 'iwyu')
+        # Stripping is composable with `[crNNN]` -- the autosquash
+        # strip happens first, then `[crNNN]`.
+        self.assertEqual(
+            rebase_v2.get_pinned_group_for_subject(
+                'amend! [cr149] `gnrt` run for Chromium 149.0.7827.5'), 'gnrt')
+
+    def test_pinned_patterns_match_canonical_subjects(self):
+        """Every pinned pattern matches its canonical subject form, both
+        tagged and untagged where applicable."""
+        cases = [
+            ('version', 'Update from Chromium 1.0.0.0 to Chromium 1.0.0.1'),
+            ('plaster_reruns',
+             'Apply-fixed 🩹 patches from Chromium 1.0.0.0 to '
+             'Chromium 1.0.0.1.'),
+            ('conflict', 'Conflict-resolved patches from Chromium 1.0.0.0 to '
+             'Chromium 1.0.0.1.'),
+            ('gnrt', '[cr149] `gnrt` run for Chromium 149.0.7827.5'),
+            ('iwyu', '[cr149] IWYU fixes.'),
+            ('resource_ids', '[cr149] Bump resource_ids'),
+            ('lit_mangler', '[cr149] Update Lit mangler snapshot'),
+            ('disable_tests', '[cr149] Disable failing upstream tests'),
+        ]
+        for expected_id, subject in cases:
+            with self.subTest(subject=subject):
+                self.assertEqual(
+                    rebase_v2.get_pinned_group_for_subject(subject),
+                    expected_id)
+
+    def test_pinned_iwyu_untagged_form_also_matches(self):
+        """The `[cr*]`-tagged patterns must also match without the tag."""
+        self.assertEqual(rebase_v2.get_pinned_group_for_subject('IWYU fixes.'),
+                         'iwyu')
+        self.assertEqual(
+            rebase_v2.get_pinned_group_for_subject('Bump resource_ids'),
+            'resource_ids')
+
+    def test_pinned_rejects_near_misses(self):
+        """Near-miss subjects should not match any pinned pattern."""
+        self.assertIsNone(
+            rebase_v2.get_pinned_group_for_subject(
+                'Update from Chromium 1.0.0.0 to '
+                'Chromium 1.0.0.1 (revert pending)'))
+        self.assertIsNone(
+            rebase_v2.get_pinned_group_for_subject('[cr149] Feature work'))
+        self.assertIsNone(
+            rebase_v2.get_pinned_group_for_subject(
+                'Update from Chromium abc to '
+                'Chromium def'))
+
+    def test_pinned_rejects_non_four_segment_versions(self):
+        """Chromium versions must be exactly four dot-separated numeric
+        segments. Three-segment or five-segment shapes are rejected."""
+        self.assertIsNone(
+            rebase_v2.get_pinned_group_for_subject(
+                'Update from Chromium 1.0.0 to '
+                'Chromium 1.0.1'))
+        self.assertIsNone(
+            rebase_v2.get_pinned_group_for_subject(
+                'Update from Chromium 1.0.0.0.0 to '
+                'Chromium 1.0.0.0.1'))
+        self.assertIsNone(
+            rebase_v2.get_pinned_group_for_subject(
+                '`gnrt` run for Chromium 149.0.7827'))
+
+    def test_recyclable_matches_canonical(self):
+        self.assertTrue(
+            rebase_v2.is_recyclable('Update patches from Chromium 1.0.0.0 '
+                                    'to Chromium 1.0.0.1.'))
+        self.assertTrue(
+            rebase_v2.is_recyclable('Updated strings for Chromium 1.0.0.1.'))
+
+    def test_recyclable_rejects_near_misses(self):
+        self.assertFalse(
+            rebase_v2.is_recyclable('Update from Chromium 1.0.0.0 to '
+                                    'Chromium 1.0.0.1'))
+        self.assertFalse(rebase_v2.is_recyclable('[cr149] Feature work'))
+
+
+class RewritePlanTest(unittest.TestCase):
+    """Tests for `rebase_v2.rewrite_plan`.
+
+    Split along the `(pinned_squashed, discard_recyclable)` flag matrix.
+    """
+
+    def setUp(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self._tmp_root = Path(tmp.name)
+
+    def _todo(self, content: str) -> Path:
+        path = self._tmp_root / 'git-rebase-todo'
+        path.write_text(content)
+        return path
+
+    # ----- pinned_squashed=False, discard_recyclable=False ------------------
+
+    def test_identity_transform_keeps_everything_in_order(self):
+        """With no flags, `rewrite` is a no-op: the file is not parsed
+        and not rewritten. Useful as a fast-path for callers that pass
+        the flags through indiscriminately."""
+        path = self._todo(
+            'pick aaa # Update from Chromium 1.0.0.0 to Chromium 1.0.0.1\n'
+            'pick bbb # [cr148] Feature A\n'
+            'pick ccc # Update patches from Chromium 1.0.0.0 to '
+            'Chromium 1.0.0.1.\n'
+            'pick zzz # reassign!bbb! [cr148] Feature A\n')
+
+        rebase_v2.rewrite_plan(todo_file=path)
+
+        self.assertEqual(
+            path.read_text(),
+            'pick aaa # Update from Chromium 1.0.0.0 to Chromium 1.0.0.1\n'
+            'pick bbb # [cr148] Feature A\n'
+            'pick ccc # Update patches from Chromium 1.0.0.0 to '
+            'Chromium 1.0.0.1.\n'
+            'pick zzz # reassign!bbb! [cr148] Feature A\n')
+
+    def test_identity_drops_comments_and_blanks_when_parsing(self):
+        """When any flag forces a parse pass (here `discard_recyclable`),
+        comments and blank lines are filtered out. With no flags set
+        `rewrite` is a no-op (covered by
+        `test_identity_transform_keeps_everything_in_order`)."""
+        path = self._todo('# Rebase plan generated by git\n'
+                          '\n'
+                          'pick aaa # [cr148] Feature A\n'
+                          '\n')
+
+        rebase_v2.rewrite_plan(todo_file=path, discard_recyclable=True)
+
+        self.assertEqual(path.read_text(), 'pick aaa # [cr148] Feature A\n')
+
+    # ----- pinned_squashed=False, discard_recyclable=True -------------------
+
+    def test_discard_recyclable_drops_only_recyclable_lines(self):
+        """Recyclable lines are dropped; pinned, reassign, and regular
+        commits stay in their arrival order, untouched."""
+        path = self._todo(
+            'pick aaa # Update from Chromium 1.0.0.0 to Chromium 1.0.0.1\n'
+            'pick bbb # [cr148] Feature A\n'
+            'pick ccc # Update patches from Chromium 1.0.0.0 to '
+            'Chromium 1.0.0.1.\n'
+            'pick ddd # Updated strings for Chromium 1.0.0.1.\n'
+            'pick zzz # reassign!bbb! [cr148] Feature A\n')
+
+        rebase_v2.rewrite_plan(todo_file=path, discard_recyclable=True)
+
+        self.assertEqual(
+            path.read_text(),
+            'pick aaa # Update from Chromium 1.0.0.0 to Chromium 1.0.0.1\n'
+            'pick bbb # [cr148] Feature A\n'
+            'pick zzz # reassign!bbb! [cr148] Feature A\n')
+
+    # ----- pinned_squashed=True, discard_recyclable=False -------------------
+
+    def test_squashed_collapses_consecutive_version_bumps(self):
+        path = self._todo(
+            'pick aaa # Update from Chromium 1.0.0.0 to Chromium 1.0.0.1\n'
+            'pick bbb # Update from Chromium 1.0.0.1 to Chromium 1.0.0.2\n'
+            'pick ccc # Update from Chromium 1.0.0.2 to Chromium 1.0.0.3\n')
+
+        rebase_v2.rewrite_plan(todo_file=path, pinned_squashed=True)
+
+        self.assertEqual(
+            path.read_text(),
+            'pick aaa # Update from Chromium 1.0.0.0 to Chromium 1.0.0.1\n'
+            'squash bbb # Update from Chromium 1.0.0.1 to Chromium 1.0.0.2\n'
+            'squash ccc # Update from Chromium 1.0.0.2 to Chromium 1.0.0.3\n')
+
+    def test_squashed_reorders_pinned_groups_by_priority(self):
+        """Pinned groups emit in the priority order:
+        version → plaster_reruns → conflict → gnrt → iwyu → resource_ids
+        → lit_mangler → disable_tests, regardless of arrival order."""
+        path = self._todo(
+            'pick aaa # [cr148] Disable failing upstream tests\n'
+            'pick bbb # [cr148] Update Lit mangler snapshot\n'
+            'pick ccc # [cr148] Bump resource_ids\n'
+            'pick ddd # [cr148] IWYU fixes.\n'
+            'pick eee # [cr148] `gnrt` run for Chromium 1.0.0.1\n'
+            'pick fff # Conflict-resolved patches from Chromium 1.0.0.0 '
+            'to Chromium 1.0.0.1.\n'
+            'pick ggg # Apply-fixed 🩹 patches from Chromium 1.0.0.0 '
+            'to Chromium 1.0.0.1.\n'
+            'pick hhh # Update from Chromium 1.0.0.0 to Chromium 1.0.0.1\n')
+
+        rebase_v2.rewrite_plan(todo_file=path, pinned_squashed=True)
+
+        self.assertEqual(
+            path.read_text(),
+            'pick hhh # Update from Chromium 1.0.0.0 to Chromium 1.0.0.1\n'
+            'pick ggg # Apply-fixed 🩹 patches from Chromium 1.0.0.0 '
+            'to Chromium 1.0.0.1.\n'
+            'pick fff # Conflict-resolved patches from Chromium 1.0.0.0 '
+            'to Chromium 1.0.0.1.\n'
+            'pick eee # [cr148] `gnrt` run for Chromium 1.0.0.1\n'
+            'pick ddd # [cr148] IWYU fixes.\n'
+            'pick ccc # [cr148] Bump resource_ids\n'
+            'pick bbb # [cr148] Update Lit mangler snapshot\n'
+            'pick aaa # [cr148] Disable failing upstream tests\n')
+
+    def test_squashed_keeps_recyclable_lines_in_place(self):
+        """Recyclable lines are NOT grouped or moved with pinned commits.
+        They stay interleaved with regular commits in arrival order."""
+        path = self._todo(
+            'pick aaa # [cr148] Feature A\n'
+            'pick bbb # Update from Chromium 1.0.0.0 to Chromium 1.0.0.1\n'
+            'pick ccc # Update patches from Chromium 1.0.0.0 to '
+            'Chromium 1.0.0.1.\n'
+            'pick ddd # [cr148] Feature B\n')
+
+        rebase_v2.rewrite_plan(todo_file=path, pinned_squashed=True)
+
+        # Pinned (`bbb`) jumps to the top; recyclable (`ccc`) and regulars
+        # (`aaa`, `ddd`) keep their relative order in the tail.
+        self.assertEqual(
+            path.read_text(),
+            'pick bbb # Update from Chromium 1.0.0.0 to Chromium 1.0.0.1\n'
+            'pick aaa # [cr148] Feature A\n'
+            'pick ccc # Update patches from Chromium 1.0.0.0 to '
+            'Chromium 1.0.0.1.\n'
+            'pick ddd # [cr148] Feature B\n')
+
+    def test_squashed_groups_fixup_of_pinned_with_target(self):
+        """A `fixup -C` whose `amend!` subject matches a pinned pattern is
+        grouped with the pinned target, in arrival order."""
+        path = self._todo(
+            'pick aaa # Update from Chromium 1.0.0.0 to Chromium 1.0.0.1\n'
+            'fixup -C bbb # amend! Update from Chromium 1.0.0.0 to '
+            'Chromium 1.0.0.1\n'
+            'pick ccc # [cr148] Feature A\n')
+
+        rebase_v2.rewrite_plan(todo_file=path, pinned_squashed=True)
+
+        # The fixup line is in the version group as `squash`; its original
+        # `fixup -C` command is replaced by `squash` (it is no longer the
+        # first commit in the group).
+        self.assertEqual(
+            path.read_text(),
+            'pick aaa # Update from Chromium 1.0.0.0 to Chromium 1.0.0.1\n'
+            'squash bbb # amend! Update from Chromium 1.0.0.0 to '
+            'Chromium 1.0.0.1\n'
+            'pick ccc # [cr148] Feature A\n')
+
+    def test_squashed_groups_squash_autosquash_of_pinned(self):
+        """A `squash <hash> # squash! <pinned-subject>` line -- distinct
+        from `fixup`/`fixup -C` but the same intent -- is also grouped with
+        the pinned target. A `pick` line with the same autosquash marker
+        is not (it has to be a non-`pick` autosquash command)."""
+        path = self._todo(
+            'pick aaa # [cr148] `gnrt` run for Chromium 1.0.0.1\n'
+            'squash bbb # squash! [cr148] `gnrt` run for Chromium 1.0.0.1\n'
+            'pick ccc # [cr148] Feature A\n'
+            'pick ddd # squash! [cr148] `gnrt` run for Chromium 1.0.0.1\n')
+
+        rebase_v2.rewrite_plan(todo_file=path, pinned_squashed=True)
+
+        # `bbb` (squash autosquash) groups with `aaa`; `ddd` (pick command,
+        # despite the same marker) is treated as a regular pinned commit
+        # and also groups with `aaa` via its message. Both non-first
+        # entries in the group are forced to `squash`.
+        self.assertEqual(
+            path.read_text(),
+            'pick aaa # [cr148] `gnrt` run for Chromium 1.0.0.1\n'
+            'squash bbb # squash! [cr148] `gnrt` run for Chromium 1.0.0.1\n'
+            'squash ddd # squash! [cr148] `gnrt` run for Chromium 1.0.0.1\n'
+            'pick ccc # [cr148] Feature A\n')
+
+    def test_squashed_reassign_matched_by_hash(self):
+        """Reassign with hash `bbb` finds the `pick bbb` line and inserts
+        itself directly above it; target becomes `squash`."""
+        path = self._todo('pick aaa # [cr148] Feature A\n'
+                          'pick bbb # [cr148] Feature B\n'
+                          'pick zzz # reassign!bbb! [cr148] Feature B\n')
+
+        rebase_v2.rewrite_plan(todo_file=path, pinned_squashed=True)
+
+        self.assertEqual(
+            path.read_text(), 'pick aaa # [cr148] Feature A\n'
+            'pick zzz # reassign!bbb! [cr148] Feature B\n'
+            'squash bbb # [cr148] Feature B\n')
+
+    def test_squashed_reassign_falls_back_to_message_match(self):
+        """Non-matching hash, matching message: the hash lookup misses,
+        so the reassign falls back to matching by commit subject."""
+        path = self._todo('pick aaa # [cr148] Feature A\n'
+                          'pick bbb # [cr148] Feature B\n'
+                          'pick zzz # reassign!xxx! [cr148] Feature B\n')
+
+        rebase_v2.rewrite_plan(todo_file=path, pinned_squashed=True)
+
+        self.assertEqual(
+            path.read_text(), 'pick aaa # [cr148] Feature A\n'
+            'pick zzz # reassign!xxx! [cr148] Feature B\n'
+            'squash bbb # [cr148] Feature B\n')
+
+    def test_squashed_reassign_hash_match_wins_over_message_match(self):
+        """Matching hash, non-matching message: hash lookup has priority.
+        Even though the reassign's message also matches *another* commit
+        in the plan, the hash-matching commit is the one that gets
+        squashed."""
+        path = self._todo('pick aaa # Some completely different subject\n'
+                          'pick bbb # [cr148] Feature B\n'
+                          'pick zzz # reassign!aaa! [cr148] Feature B\n')
+
+        rebase_v2.rewrite_plan(todo_file=path, pinned_squashed=True)
+
+        # `aaa` matches the reassign's hash and is squashed; `bbb`
+        # (whose subject matches the reassign's message) is left
+        # untouched because hash-match took priority.
+        self.assertEqual(
+            path.read_text(), 'pick zzz # reassign!aaa! [cr148] Feature B\n'
+            'squash aaa # Some completely different subject\n'
+            'pick bbb # [cr148] Feature B\n')
+
+    def test_squashed_reassign_without_hash_uses_message_match_only(self):
+        """No-hash-in-subcommand (`reassign! <subject>` with a single
+        `!`): the hash lookup is skipped entirely and the reassign is
+        placed via message-based matching."""
+        path = self._todo('pick aaa # [cr148] Feature A\n'
+                          'pick bbb # [cr148] Feature B\n'
+                          'pick zzz # reassign! [cr148] Feature B\n')
+
+        # Sanity check: the parser sees only one subcommand token, so
+        # `reassign_target_hash` is None and the hash-lookup branch in
+        # `add_reassign_before_target` is skipped.
+        reassign = rebase_v2.EntryLine.parse(
+            'pick zzz # reassign! [cr148] Feature B')
+        self.assertEqual(reassign.subcommand, ['reassign'])
+        self.assertIsNone(reassign.reassign_target_hash)
+
+        rebase_v2.rewrite_plan(todo_file=path, pinned_squashed=True)
+
+        self.assertEqual(
+            path.read_text(), 'pick aaa # [cr148] Feature A\n'
+            'pick zzz # reassign! [cr148] Feature B\n'
+            'squash bbb # [cr148] Feature B\n')
+
+    def test_squashed_reassign_to_pinned_target_is_dropped(self):
+        """Reassignment of a pinned commit is not supported. The reassign
+        line is treated as orphaned and silently dropped; the pinned
+        commit is emitted normally."""
+        path = self._todo(
+            'pick aaa # [cr148] Feature A\n'
+            'pick bbb # Update from Chromium 1.0.0.0 to Chromium 1.0.0.1\n'
+            'pick zzz # reassign!bbb! Update from Chromium 1.0.0.0 to '
+            'Chromium 1.0.0.1\n')
+
+        rebase_v2.rewrite_plan(todo_file=path, pinned_squashed=True)
+
+        self.assertEqual(
+            path.read_text(),
+            'pick bbb # Update from Chromium 1.0.0.0 to Chromium 1.0.0.1\n'
+            'pick aaa # [cr148] Feature A\n')
+
+    def test_squashed_orphan_reassign_dropped(self):
+        """A reassign whose hash and subject both miss is silently
+        dropped."""
+        path = self._todo(
+            'pick aaa # [cr148] Feature A\n'
+            'pick zzz # reassign!xxx! [cr148] Completely unrelated subject\n')
+
+        rebase_v2.rewrite_plan(todo_file=path, pinned_squashed=True)
+
+        self.assertEqual(path.read_text(), 'pick aaa # [cr148] Feature A\n')
+
+    def test_squashed_reassign_with_empty_suffix(self):
+        """The ` # empty` suffix on a reassign must be stripped before the
+        message-based lookup."""
+        path = self._todo(
+            'pick aaa # [cr148] Feature A\n'
+            'pick bbb # [cr148] Feature B\n'
+            'pick zzz # reassign!xxx! [cr148] Feature B # empty\n')
+
+        rebase_v2.rewrite_plan(todo_file=path, pinned_squashed=True)
+
+        self.assertEqual(
+            path.read_text(), 'pick aaa # [cr148] Feature A\n'
+            'pick zzz # reassign!xxx! [cr148] Feature B # empty\n'
+            'squash bbb # [cr148] Feature B\n')
+
+    # ----- pinned_squashed=True, discard_recyclable=True --------------------
+
+    def test_combined_pinned_grouped_and_recyclable_dropped(self):
+        path = self._todo(
+            'pick aaa # [cr148] Feature A\n'
+            'pick bbb # Update from Chromium 1.0.0.0 to Chromium 1.0.0.1\n'
+            'pick ccc # Update patches from Chromium 1.0.0.0 to '
+            'Chromium 1.0.0.1.\n'
+            'pick ddd # [cr148] Feature B\n')
+
+        rebase_v2.rewrite_plan(todo_file=path,
+                               pinned_squashed=True,
+                               discard_recyclable=True)
+
+        self.assertEqual(
+            path.read_text(),
+            'pick bbb # Update from Chromium 1.0.0.0 to Chromium 1.0.0.1\n'
+            'pick aaa # [cr148] Feature A\n'
+            'pick ddd # [cr148] Feature B\n')
+
+    def test_combined_reassign_orphaned_when_target_is_dropped_recyclable(
+            self):
+        """A reassign targeting a recyclable that gets dropped becomes
+        orphaned in phase B."""
+        path = self._todo(
+            'pick aaa # [cr148] Feature A\n'
+            'pick ccc # Updated strings for Chromium 1.0.0.1.\n'
+            'pick zzz # reassign!ccc! Updated strings for Chromium 1.0.0.1.\n')
+
+        rebase_v2.rewrite_plan(todo_file=path,
+                               pinned_squashed=True,
+                               discard_recyclable=True)
+
+        self.assertEqual(path.read_text(), 'pick aaa # [cr148] Feature A\n')
+
+    # ----- Cross-cutting -----------------------------------------------------
+
+    def test_malformed_line_raises_editor_recoverable(self):
+        """A malformed line surfaces as `EditorRecoverableFailure` --
+        only when `rewrite` actually parses the file (i.e. at least one
+        flag is set). The brockit dispatch catches this and punts to the
+        editor with the failure reason prepended as a `#`-comment."""
+        path = self._todo('pick aaa # [cr148] Feature A\n'
+                          'totally malformed line without hash or hash\n')
+
+        with self.assertRaises(rebase_v2.EditorRecoverableFailure):
+            rebase_v2.rewrite_plan(todo_file=path, discard_recyclable=True)
+
+
+class MessageWriterTest(unittest.TestCase):
+    """Tests for `rebase_v2.MessageWriter`.
+
+    All fixtures use git's verbose squash-editor layout: each
+    `# This is the …` / `# The commit message #N will be skipped:` header
+    is followed by a blank line, then the content. This matches the file
+    git actually writes to `$GIT_EDITOR` during squash rebases.
+    """
+
+    def setUp(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self._tmp_root = Path(tmp.name)
+
+    def _file(self, content: str) -> Path:
+        path = self._tmp_root / 'COMMIT_EDITMSG'
+        path.write_text(content)
+        return path
+
+    @staticmethod
+    def _messages(writer: 'rebase_v2.MessageWriter') -> list:
+        return [block.full_message for block in writer.blocks]
+
+    def test_pinned_squash_writes_trailing_message(self):
+        """Block 1 is a version-bump subject; block 2 is the next bump.
+        Parse accepts (pinned first block); `rewrite_with_last_message`
+        writes the trailing block's message back to the file."""
+        path = self._file('# This is the 1st commit message:\n'
+                          '\n'
+                          'Update from Chromium 1.0.0.0 to Chromium 1.0.0.1\n'
+                          '\n'
+                          '# This is the commit message #2:\n'
+                          '\n'
+                          'Update from Chromium 1.0.0.1 to Chromium 1.0.0.2\n')
+
+        writer = rebase_v2.MessageWriter.parse(path)
+
+        self.assertEqual(self._messages(writer), [
+            'Update from Chromium 1.0.0.0 to Chromium 1.0.0.1',
+            'Update from Chromium 1.0.0.1 to Chromium 1.0.0.2',
+        ])
+
+        writer.rewrite_with_last_message()
+        self.assertEqual(path.read_text(),
+                         'Update from Chromium 1.0.0.1 to Chromium 1.0.0.2\n')
+
+    def test_reassignment_squash_writes_target_message(self):
+        """A `reassign!` first content line in block 1 is accepted by
+        parse. The reassign block stays in `blocks`, but it's block 2
+        (carrying the original commit's subject and body) that gets
+        written back -- because it's the last block."""
+        path = self._file('# This is the 1st commit message:\n'
+                          '\n'
+                          'reassign!bbb! [cr148] Feature B\n'
+                          '\n'
+                          '# This is the commit message #2:\n'
+                          '\n'
+                          '[cr148] Feature B\n'
+                          '\n'
+                          'Original body line.\n')
+
+        writer = rebase_v2.MessageWriter.parse(path)
+
+        self.assertEqual(self._messages(writer), [
+            'reassign!bbb! [cr148] Feature B',
+            '[cr148] Feature B\n\nOriginal body line.',
+        ])
+
+        writer.rewrite_with_last_message()
+        self.assertEqual(path.read_text(),
+                         '[cr148] Feature B\n\nOriginal body line.\n')
+
+    def test_unclassifiable_first_block_raises(self):
+        """Block 1 whose first content line is neither `reassign!` nor a
+        pinned pattern raises `EditorRecoverableFailure`. The exception
+        message names the offending content line so the caller can
+        surface it to the user."""
+        path = self._file('# This is the 1st commit message:\n'
+                          '\n'
+                          '[cr148] Some regular feature commit\n')
+
+        with self.assertRaises(rebase_v2.EditorRecoverableFailure) as ctx:
+            rebase_v2.MessageWriter.parse(path)
+        self.assertIn('[cr148] Some regular feature commit',
+                      str(ctx.exception))
+
+    def test_parse_failure_wrapped_in_cannot_classify(self):
+        """An empty file (no blocks parse out) also raises
+        `EditorRecoverableFailure`."""
+        path = self._file('')
+        with self.assertRaises(rebase_v2.EditorRecoverableFailure):
+            rebase_v2.MessageWriter.parse(path)
+
+    def test_squash_marker_merges_into_previous_block(self):
+        """A block whose autosquash note is `# squash! ...` is merged
+        into the previous block's `full_message` rather than becoming a
+        new block."""
+        path = self._file(
+            '# This is the 1st commit message:\n'
+            '\n'
+            'Update from Chromium 1.0.0.0 to Chromium 1.0.0.1\n'
+            '\n'
+            '# This is the commit message #2:\n'
+            '\n'
+            '# squash! Update from Chromium 1.0.0.0 to Chromium 1.0.0.1\n'
+            '\n'
+            'Some extra detail\n')
+
+        writer = rebase_v2.MessageWriter.parse(path)
+
+        # Single merged block: block 1's content with the squash content
+        # appended on a new line.
+        self.assertEqual(self._messages(writer), [
+            'Update from Chromium 1.0.0.0 to Chromium 1.0.0.1\n'
+            'Some extra detail',
+        ])
+
+    def test_will_be_skipped_block_contributes_nothing(self):
+        """The skipped-block header is treated as a pure delimiter; its
+        contents never reach `blocks` regardless of marker."""
+        path = self._file(
+            '# This is the 1st commit message:\n'
+            '\n'
+            'Update from Chromium 1.0.0.0 to Chromium 1.0.0.1\n'
+            '\n'
+            '# The commit message #2 will be skipped:\n'
+            '\n'
+            '# fixup! Update from Chromium 1.0.0.0 to Chromium 1.0.0.1\n'
+            '\n'
+            '# This is the commit message #3:\n'
+            '\n'
+            'Update from Chromium 1.0.0.1 to Chromium 1.0.0.2\n')
+
+        writer = rebase_v2.MessageWriter.parse(path)
+
+        self.assertEqual(self._messages(writer), [
+            'Update from Chromium 1.0.0.0 to Chromium 1.0.0.1',
+            'Update from Chromium 1.0.0.1 to Chromium 1.0.0.2',
+        ])
+
+    def test_git_footer_terminates_parsing(self):
+        """Anything after `# Please enter the commit message ...` is
+        ignored, including stale `# This is ...` lines from git's status
+        echo."""
+        path = self._file(
+            '# This is the 1st commit message:\n'
+            '\n'
+            'Update from Chromium 1.0.0.0 to Chromium 1.0.0.1\n'
+            '\n'
+            '# Please enter the commit message for your changes. Lines '
+            'starting\n'
+            '# with \'#\' will be ignored, and an empty message aborts the '
+            'commit.\n'
+            '#\n'
+            '# interactive rebase in progress; onto 5e0f42a4157\n')
+
+        writer = rebase_v2.MessageWriter.parse(path)
+
+        self.assertEqual(self._messages(writer),
+                         ['Update from Chromium 1.0.0.0 to Chromium 1.0.0.1'])
+
+    def test_hand_off_to_editor_invokes_supplied_editor(self):
+        """The caller-supplied `editor` is what gets spawned, via
+        `terminal.run(..., interactive=True)` so the editor inherits the
+        parent tty. `hand_off_to_editor` does not consult any env var
+        of its own -- editor resolution is the caller's job (typically
+        `rebase_v2.get_git_editor`)."""
+        path = self._file('original content\n')
+
+        with patch.object(rebase_v2.terminal, 'run') as mock_run:
+            rebase_v2.hand_off_to_editor(path, reason='', editor='nano')
+        mock_run.assert_called_once_with(['nano', str(path)], interactive=True)
+
+    def test_hand_off_to_editor_splits_multi_token_editor(self):
+        """A multi-token `editor` (e.g. `code --wait`, or a flag with
+        embedded whitespace inside quotes) is split via `shlex.split`
+        before being passed to `terminal.run`, so each token lands in
+        its own argv slot."""
+        path = self._file('original content\n')
+
+        with patch.object(rebase_v2.terminal, 'run') as mock_run:
+            rebase_v2.hand_off_to_editor(path, reason='', editor='code --wait')
+        mock_run.assert_called_once_with(
+            ['code', '--wait', str(path)], interactive=True)
+
+        with patch.object(rebase_v2.terminal, 'run') as mock_run:
+            rebase_v2.hand_off_to_editor(
+                path, reason='', editor='my_editor --feature="with space"')
+        mock_run.assert_called_once_with(
+            ['my_editor', '--feature=with space',
+             str(path)], interactive=True)
+
+    def test_hand_off_to_editor_prepends_reason_as_comment(self):
+        """When `reason` is supplied, every line is prepended to the
+        file as a `#`-comment. Lines that already start with `#` pass
+        through unchanged (no double-`#`)."""
+        path = self._file('original line 1\noriginal line 2\n')
+
+        with patch.object(rebase_v2.terminal, 'run'):
+            rebase_v2.hand_off_to_editor(
+                path,
+                reason='Cannot classify commit\nFix it manually',
+                editor='vim')
+
+        self.assertEqual(
+            path.read_text(),
+            '# B🚀 has been unable to handle this rebase. Investigate '
+            'why, and\n'
+            '# file a bug. Failure reason below.\n'
+            '# Cannot classify commit\n'
+            '# Fix it manually\n'
+            'original line 1\n'
+            'original line 2\n')
+
+    def test_hand_off_to_editor_no_reason_leaves_file_alone(self):
+        """With an empty `reason`, the file content is untouched -- only
+        the editor subprocess is invoked."""
+        path = self._file('original content\n')
+
+        with patch.object(rebase_v2.terminal, 'run'):
+            rebase_v2.hand_off_to_editor(path, reason='', editor='vim')
+
+        self.assertEqual(path.read_text(), 'original content\n')
+
+    def test_get_git_editor_raises_if_env_already_overridden(self):
+        """If the resolved env var holds a brockit `--internal-rebase-*`
+        dispatch, `get_git_editor` is being called too late and would
+        loop on itself; raise `NotImplementedError` instead."""
+        overridden = ('/path/to/vpython3 /path/to/brockit.py '
+                      '--internal-rebase-v2-plan-squash-pinned')
+        with patch.dict(os.environ, {'GIT_EDITOR': overridden}, clear=False):
+            with self.assertRaises(NotImplementedError):
+                rebase_v2.get_git_editor()
+
+
+class RebaseV2ExecuteTest(unittest.TestCase):
+    """End-to-end tests for `Rebase.execute(..., v2=True)`."""
+
+    def setUp(self):
+        self.repo = FakeChromiumRepo()
+        self.repo.setup()
+        self.addCleanup(self.repo.cleanup)
+        self.repo.create_brave_remote()
+        self._commit_counter = 0
+
+    def _seed_bump_branch(self) -> dict:
+        """Builds a small branch: v100 → v101 (master) → feature → v102
+        (master continues). Returns the relevant hashes."""
+        brave = self.repo.brave
+        v100 = self.repo.update_brave_version('1.0.0.0')
+        v101 = self.repo.update_brave_version('1.0.0.1')
+        self.repo._run_git_command(['checkout', '-b', 'feature-branch'], brave)
+        self.repo.write_and_stage_file('feature.txt', 'feature content\n',
+                                       brave)
+        feature = self.repo.commit('Add brave-only feature.txt', brave)
+        self.repo._run_git_command(
+            ['push', '--set-upstream', 'origin', 'feature-branch'], brave)
+        self.repo._run_git_command(['checkout', 'master'], brave)
+        v102 = self.repo.update_brave_version('1.0.0.2')
+        self.repo._run_git_command(['checkout', 'feature-branch'], brave)
+        return {'v100': v100, 'v101': v101, 'v102': v102, 'feature': feature}
+
+    def _git_log_subjects(self, ref: str = 'HEAD') -> list:
+        out = self.repo._run_git_command(
+            ['log', '--reverse', '--format=%s', ref], self.repo.brave)
+        return out.splitlines() if out else []
+
+    def _commit_with_file(self, message: str) -> str:
+        """Adds a small unique file and commits it -- a real change so
+        `--empty=drop` doesn't strip it."""
+        self._commit_counter += 1
+        self.repo.write_and_stage_file(f'gen-{self._commit_counter}.txt',
+                                       f'content {self._commit_counter}\n',
+                                       self.repo.brave)
+        return self.repo.commit(message, self.repo.brave)
+
+    def test_v2_no_flags_is_a_passthrough_rebase(self):
+        """`--v2` alone: no plan transform, history preserved on the new
+        target."""
+        scenario = self._seed_bump_branch()
+
+        brockit.Rebase().execute(from_ref=scenario['v101'],
+                                 to_ref=scenario['v102'],
+                                 recommit=False,
+                                 discard_regen_changes=False,
+                                 squash_minor_bumps=False,
+                                 v2=True)
+
+        self.assertEqual(self._git_log_subjects()[-1],
+                         'Add brave-only feature.txt')
+        parent = self.repo._run_git_command(['rev-parse', 'HEAD^'],
+                                            self.repo.brave)
+        self.assertEqual(parent, scenario['v102'])
+
+    def test_v2_discard_regen_changes_drops_recyclable(self):
+        scenario = self._seed_bump_branch()
+        self._commit_with_file(
+            'Update patches from Chromium 1.0.0.1 to Chromium 1.0.0.2.')
+        self._commit_with_file('Updated strings for Chromium 1.0.0.2.')
+        self._commit_with_file('[cr148] Another brave-only feature.')
+
+        brockit.Rebase().execute(from_ref=scenario['v101'],
+                                 to_ref=scenario['v102'],
+                                 recommit=False,
+                                 discard_regen_changes=True,
+                                 squash_minor_bumps=False,
+                                 v2=True)
+
+        subjects = self._git_log_subjects(scenario['v102'] + '..HEAD')
+        self.assertEqual(subjects, [
+            'Add brave-only feature.txt',
+            '[cr148] Another brave-only feature.',
+        ])
+
+    def test_v2_squash_minor_bumps_collapses_pinned(self):
+        """v2 squash groups version bumps at the top and keeps the
+        trailing message. Regular commits stay below in arrival order."""
+        scenario = self._seed_bump_branch()
+        self._commit_with_file(
+            'Update from Chromium 1.0.0.2 to Chromium 1.0.0.3')
+        self._commit_with_file('[cr148] Some unrelated feature commit')
+        self._commit_with_file(
+            'Update from Chromium 1.0.0.3 to Chromium 1.0.0.4')
+
+        brockit.Rebase().execute(from_ref=scenario['v101'],
+                                 to_ref=scenario['v102'],
+                                 recommit=False,
+                                 discard_regen_changes=False,
+                                 squash_minor_bumps=True,
+                                 v2=True)
+
+        subjects = self._git_log_subjects(scenario['v102'] + '..HEAD')
+        # Version bumps fold into the trailing message; the original
+        # feature commit and the unrelated feature stay in arrival order.
+        self.assertEqual(subjects, [
+            'Update from Chromium 1.0.0.3 to Chromium 1.0.0.4',
+            'Add brave-only feature.txt',
+            '[cr148] Some unrelated feature commit',
+        ])
+
+    def test_v2_recommit_amends_first_commit(self):
+        """`--recommit` is reused from v1 -- v2 doesn't change its
+        semantics, just confirms it still works when `v2=True`."""
+        scenario = self._seed_bump_branch()
+        before = self.repo._run_git_command(['rev-parse', 'HEAD'],
+                                            self.repo.brave)
+
+        brockit.Rebase().execute(from_ref=scenario['v101'],
+                                 to_ref=scenario['v102'],
+                                 recommit=True,
+                                 discard_regen_changes=False,
+                                 squash_minor_bumps=False,
+                                 v2=True)
+
+        after = self.repo._run_git_command(['rev-parse', 'HEAD'],
+                                           self.repo.brave)
+        self.assertNotEqual(after, before)
+        self.assertEqual(self._git_log_subjects()[-1],
+                         'Add brave-only feature.txt')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/cr/terminal.py
+++ b/tools/cr/terminal.py
@@ -184,8 +184,19 @@ class Terminal:
             status.stop()
             self.status = None
 
-    def run(self, cmd, env: Optional[Dict[str, str]] = None, cwd=None):
+    def run(self,
+            cmd,
+            *,
+            env: Optional[Dict[str, str]] = None,
+            cwd=None,
+            interactive: bool = False):
         """Runs a command on the terminal.
+
+        When `interactive=True`, the subprocess inherits the parent's
+        stdin/stdout/stderr instead of capturing them -- use this for
+        spawning editors, pagers, or anything else that needs to take
+        over the tty. The returned `CompletedProcess.stdout` /
+        `.stderr` are `None` in that case (nothing is captured).
         """
         # Convert all arguments to strings, to avoid issues with `PurePath`
         # being passed arguments
@@ -220,16 +231,26 @@ class Terminal:
             if resolved != cmd[0]:
                 cmd = [resolved] + cmd[1:]
 
+        # Captured mode pairs `capture_output` with text decoding so the
+        # `.stdout` / `.stderr` strings on the result are usable directly.
+        # Interactive mode skips both -- stdio is inherited from the parent,
+        # nothing is captured, and `text` / `encoding` are irrelevant.
+        capture_kwargs: Dict[str, object] = {}
+        if not interactive:
+            capture_kwargs.update(capture_output=True,
+                                  text=True,
+                                  encoding='utf-8')
+
         try:
             result = subprocess.run(cmd,
-                                    capture_output=True,
-                                    text=True,
                                     check=True,
-                                    encoding='utf-8',
                                     env=env,
-                                    cwd=cwd)
+                                    cwd=cwd,
+                                    **capture_kwargs)
         except subprocess.CalledProcessError as e:
-            logging.debug('❯ %s', e.stderr.strip())
+            if e.stderr:
+                # Only captured in non-interactive mode.
+                logging.debug('❯ %s', e.stderr.strip())
             raise e
         finally:
             if self.infra_mode:


### PR DESCRIPTION
This PR introduces the foundation for a new rebase routine to be used by
`brockit` when doing `brockit --rebase`. This routine is nearly feature
complete with the standard one, the only exception being the dropping of
support for `--recommit`, which was introduced but never really used in
CI.

This implementation aims at making the code around rebases cleaner, more
reliable, and easier to customise in the future. It is also already
taking steps towards us having an implementation for `--continue`
support.

An interesting feature this v2 code brings is taht when parsing
questions occur, we bubble up these issues to the use through exceptions
that launch the user editor to evaluate what's going on.

Bug: https://github.com/brave/brave-browser/issues/55466
