### PR TITLE
[Android] Apply IntentHandler internal-scheme guard to brave://

### DIFF
--- a/android/brave_java_sources.gni
+++ b/android/brave_java_sources.gni
@@ -32,6 +32,7 @@ brave_java_sources = [
   "../../brave/android/java/org/chromium/chrome/browser/BraveFeatureUtil.java",
   "../../brave/android/java/org/chromium/chrome/browser/BraveHelper.java",
   "../../brave/android/java/org/chromium/chrome/browser/BraveIntentHandler.java",
+  "../../brave/android/java/org/chromium/chrome/browser/BraveIntentHandlerInternal.java",
   "../../brave/android/java/org/chromium/chrome/browser/BraveLaunchIntentDispatcher.java",
   "../../brave/android/java/org/chromium/chrome/browser/BraveLocalState.java",
   "../../brave/android/java/org/chromium/chrome/browser/BraveRelaunchUtils.java",

--- a/android/java/apk_for_test.flags
+++ b/android/java/apk_for_test.flags
@@ -701,6 +701,7 @@
     *** getUrlForWebapp(...);
     *** isJavascriptSchemeOrInvalidUrl(...);
     *** extractUrlFromIntent(...);
+    *** intentHasUnsafeInternalScheme(...);
 }
 
 -keep class org.chromium.chrome.browser.BraveIntentHandler {

--- a/android/java/org/chromium/chrome/browser/BraveIntentHandler.java
+++ b/android/java/org/chromium/chrome/browser/BraveIntentHandler.java
@@ -20,11 +20,14 @@ import org.chromium.chrome.browser.search_engines.TemplateUrlServiceFactory;
 import org.chromium.chrome.browser.searchwidget.SearchWidgetProvider;
 import org.chromium.content_public.browser.BrowserStartupController;
 
+import java.util.Locale;
 import java.util.concurrent.Callable;
 
 @NullMarked
 public class BraveIntentHandler {
     private static final String TAG = "BraveIntentHandler";
+
+    private static final String BRAVE_SCHEME = "brave";
 
     /** An extra to indicate that the intent was triggered from an app widget Leo button. */
     public static final String EXTRA_INVOKED_FROM_APP_WIDGET_LEO =
@@ -145,5 +148,23 @@ public class BraveIntentHandler {
     private static boolean isJavascriptSchemeOrInvalidUrl(String unused_url) {
         assert false;
         return false;
+    }
+
+    /**
+     * Bytecode-redirected from {@link IntentHandler#intentHasUnsafeInternalScheme}. Defers to the
+     * upstream check (which handles chrome://, chrome-native://, devtools://, distiller://,
+     * about://) and additionally blocks brave://, since it is a display alias for chrome:// and
+     * gets rewritten to chrome:// deeper in the navigation stack — too late to protect this guard.
+     */
+    public static boolean intentHasUnsafeInternalScheme(
+            @Nullable String scheme, @Nullable String url, Intent intent) {
+        if (BraveIntentHandlerInternal.intentHasUnsafeInternalScheme(scheme, url, intent)) {
+            return true;
+        }
+        return scheme != null
+                && BRAVE_SCHEME.equals(scheme.toLowerCase(Locale.US))
+                && (intent.hasCategory(Intent.CATEGORY_BROWSABLE)
+                        || intent.hasCategory(Intent.CATEGORY_DEFAULT)
+                        || intent.getCategories() == null);
     }
 }

--- a/android/java/org/chromium/chrome/browser/BraveIntentHandlerInternal.java
+++ b/android/java/org/chromium/chrome/browser/BraveIntentHandlerInternal.java
@@ -1,0 +1,28 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.chromium.chrome.browser;
+
+import android.content.Intent;
+
+import org.chromium.build.annotations.NullMarked;
+import org.chromium.build.annotations.Nullable;
+
+/**
+ * Holds same-named stubs that bytecode-redirect to private members of {@link IntentHandler}, so
+ * {@link BraveIntentHandler} can back-call them despite Java visibility rules. The stub bodies are
+ * never executed: {@code BraveIntentHandlerClassAdapter} rewrites each call site to invoke the
+ * upstream method (which it also bumps to public at bytecode time).
+ */
+@NullMarked
+final class BraveIntentHandlerInternal {
+    private BraveIntentHandlerInternal() {}
+
+    static boolean intentHasUnsafeInternalScheme(
+            @Nullable String scheme, @Nullable String url, Intent intent) {
+        assert false;
+        return false;
+    }
+}

--- a/android/javatests/org/chromium/chrome/browser/BytecodeTest.java
+++ b/android/javatests/org/chromium/chrome/browser/BytecodeTest.java
@@ -810,6 +810,15 @@ public class BytecodeTest {
                         Intent.class));
         Assert.assertTrue(
                 methodExists(
+                        "org/chromium/chrome/browser/IntentHandler",
+                        "intentHasUnsafeInternalScheme",
+                        MethodModifier.STATIC,
+                        boolean.class,
+                        String.class,
+                        String.class,
+                        Intent.class));
+        Assert.assertTrue(
+                methodExists(
                         "org/chromium/chrome/browser/download/dialogs/DownloadLocationDialogCoordinator", // presubmit: ignore-long-line
                         "onDirectoryOptionsRetrieved",
                         MethodModifier.REGULAR,

--- a/android/junit/src/org/chromium/chrome/browser/BraveIntentHandlerUnitTest.java
+++ b/android/junit/src/org/chromium/chrome/browser/BraveIntentHandlerUnitTest.java
@@ -6,6 +6,8 @@
 package org.chromium.chrome.browser;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import android.content.Intent;
 import android.net.Uri;
@@ -56,5 +58,35 @@ public class BraveIntentHandlerUnitTest {
         String result = BraveIntentHandler.extractUrlFromIntent(intent);
 
         assertEquals("https://example.com/search?q=test&source=android", result);
+    }
+
+    @Test
+    @SmallTest
+    public void intentHasUnsafeInternalScheme_braveScheme_isBlocked() {
+        Intent intent = new Intent(Intent.ACTION_VIEW);
+        intent.addCategory(Intent.CATEGORY_BROWSABLE);
+        assertTrue(
+                BraveIntentHandler.intentHasUnsafeInternalScheme(
+                        "brave", "brave://flags/", intent));
+    }
+
+    @Test
+    @SmallTest
+    public void intentHasUnsafeInternalScheme_braveScheme_mixedCase_isBlocked() {
+        Intent intent = new Intent(Intent.ACTION_VIEW);
+        intent.addCategory(Intent.CATEGORY_DEFAULT);
+        assertTrue(
+                BraveIntentHandler.intentHasUnsafeInternalScheme(
+                        "Brave", "Brave://flags/", intent));
+    }
+
+    @Test
+    @SmallTest
+    public void intentHasUnsafeInternalScheme_httpsScheme_isAllowed() {
+        Intent intent = new Intent(Intent.ACTION_VIEW);
+        intent.addCategory(Intent.CATEGORY_BROWSABLE);
+        assertFalse(
+                BraveIntentHandler.intentHasUnsafeInternalScheme(
+                        "https", "https://example.com/", intent));
     }
 }

--- a/build/android/bytecode/java/org/brave/bytecode/BraveIntentHandlerClassAdapter.java
+++ b/build/android/bytecode/java/org/brave/bytecode/BraveIntentHandlerClassAdapter.java
@@ -10,6 +10,8 @@ import org.objectweb.asm.ClassVisitor;
 public class BraveIntentHandlerClassAdapter extends BraveClassVisitor {
     static String sIntentHandlerClassName = "org/chromium/chrome/browser/IntentHandler";
     static String sBraveIntentHandlerClassName = "org/chromium/chrome/browser/BraveIntentHandler";
+    static String sBraveIntentHandlerInternalClassName =
+            "org/chromium/chrome/browser/BraveIntentHandlerInternal";
 
     public BraveIntentHandlerClassAdapter(ClassVisitor visitor) {
         super(visitor);
@@ -27,5 +29,15 @@ public class BraveIntentHandlerClassAdapter extends BraveClassVisitor {
 
         changeMethodOwner(
                 sIntentHandlerClassName, "extractUrlFromIntent", sBraveIntentHandlerClassName);
+
+        makePublicMethod(sIntentHandlerClassName, "intentHasUnsafeInternalScheme");
+        changeMethodOwner(
+                sIntentHandlerClassName,
+                "intentHasUnsafeInternalScheme",
+                sBraveIntentHandlerClassName);
+        changeMethodOwner(
+                sBraveIntentHandlerInternalClassName,
+                "intentHasUnsafeInternalScheme",
+                sIntentHandlerClassName);
     }
 }


### PR DESCRIPTION
Aligns `brave://` with `chrome://` in `IntentHandler.intentHasUnsafeInternalScheme`. The upstream guard is unaware of the Brave alias because the `brave://` → `chrome://` rewrite happens after the intent layer.

`BraveIntentHandlerClassAdapter` redirects the upstream call site through `BraveIntentHandler.intentHasUnsafeInternalScheme`. The Brave method defers to upstream first, then additionally rejects `brave://` under the same category guard upstream uses. A new `BraveIntentHandlerInternal` helper holds the bytecode stub used to back-call the (private) upstream method.

Resolves: https://github.com/brave/brave-browser/issues/55473

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
