### PR TITLE
[iOS] Add support for randomized message handlers in JavaScriptFeatures

### DIFF
--- a/ios/web/js_messaging/BUILD.gn
+++ b/ios/web/js_messaging/BUILD.gn
@@ -14,6 +14,7 @@ source_set("js_messaging") {
   ]
   deps = [
     ":message_handler_token",
+    ":randomized_message_handler_name",
     ":safe_builtins_js",
   ]
   public_deps = [ "//ios/web/public/js_messaging" ]
@@ -30,15 +31,30 @@ source_set("message_handler_token") {
   ]
 }
 
+source_set("randomized_message_handler_name") {
+  sources = [
+    "randomized_message_handler_name.h",
+    "randomized_message_handler_name.mm",
+  ]
+  public_deps = [
+    "//base",
+    "//ios/web/public/js_messaging",
+  ]
+}
+
 source_set("unittests") {
   testonly = true
   sources = [
     "message_handler_token_inttest.mm",
+    "randomized_message_handler_name_inttest.mm",
     "safe_builtins_javascript_test.mm",
   ]
   deps = [
+    ":js_messaging",
     ":message_handler_token",
     ":message_handler_token_test_api",
+    ":randomized_message_handler_name",
+    ":randomized_message_handler_test_api",
     ":safe_builtins_js",
     "//base",
     "//base/test:test_support",
@@ -74,6 +90,16 @@ optimize_js("safe_builtins_js") {
 optimize_ts("message_handler_token_test_api") {
   testonly = true
   sources = [ "resources/message_handler_token_test_api.ts" ]
+  deps = [
+    ":util_scripts",
+    "//ios/web/public/js_messaging:gcrweb",
+    "//ios/web/public/js_messaging:util_scripts",
+  ]
+}
+
+optimize_ts("randomized_message_handler_test_api") {
+  testonly = true
+  sources = [ "resources/randomized_message_handler_test_api.ts" ]
   deps = [
     ":util_scripts",
     "//ios/web/public/js_messaging:gcrweb",

--- a/ios/web/js_messaging/randomized_message_handler_name.h
+++ b/ios/web/js_messaging/randomized_message_handler_name.h
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_IOS_WEB_JS_MESSAGING_RANDOMIZED_MESSAGE_HANDLER_NAME_H_
+#define BRAVE_IOS_WEB_JS_MESSAGING_RANDOMIZED_MESSAGE_HANDLER_NAME_H_
+
+#include <string>
+
+#include "base/uuid.h"
+#include "ios/web/public/js_messaging/java_script_feature.h"
+
+namespace web {
+
+// Composable helper that generates a stable, per-instance randomized script
+// message handler name for use with JavaScriptFeature subclasses.
+//
+// Hold an instance as a member of a JavaScriptFeature and delegate
+// GetScriptMessageHandlerName() and the FeatureScript placeholder replacements
+// callback to it.
+//
+// To obtain the message handler name from JavaScript import
+// `messageHandlerName` from `//brave/ios/web/js_messaging/utils.js`.
+class RandomizedMessageHandlerName {
+ public:
+  using PlaceholderReplacements =
+      web::JavaScriptFeature::FeatureScript::PlaceholderReplacements;
+
+  // Returns the randomized message handler name for this instance.
+  std::string GetScriptMessageHandlerName() const;
+
+  // Returns the FeatureScript placeholder replacements map that substitutes
+  // the JavaScript-side placeholder (`gCrWebPlaceholderMessageHandlerName`)
+  // with the randomized name returned by GetScriptMessageHandlerName().
+  PlaceholderReplacements GetPlaceholderReplacements() const;
+
+ private:
+  base::Uuid handler_name_ = base::Uuid::GenerateRandomV4();
+};
+
+}  // namespace web
+
+#endif  // BRAVE_IOS_WEB_JS_MESSAGING_RANDOMIZED_MESSAGE_HANDLER_NAME_H_

--- a/ios/web/js_messaging/randomized_message_handler_name.mm
+++ b/ios/web/js_messaging/randomized_message_handler_name.mm
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/ios/web/js_messaging/randomized_message_handler_name.h"
+
+#include "base/strings/sys_string_conversions.h"
+
+namespace web {
+
+std::string RandomizedMessageHandlerName::GetScriptMessageHandlerName() const {
+  return handler_name_.AsLowercaseString();
+}
+
+web::JavaScriptFeature::FeatureScript::PlaceholderReplacements
+RandomizedMessageHandlerName::GetPlaceholderReplacements() const {
+  return @{
+    @"gCrWebPlaceholderMessageHandlerName" :
+        base::SysUTF8ToNSString(GetScriptMessageHandlerName())
+  };
+}
+
+}  // namespace web

--- a/ios/web/js_messaging/randomized_message_handler_name_inttest.mm
+++ b/ios/web/js_messaging/randomized_message_handler_name_inttest.mm
@@ -1,0 +1,100 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include <memory>
+#include <string>
+
+#include "base/functional/bind.h"
+#include "base/test/ios/wait_util.h"
+#include "brave/ios/web/js_messaging/randomized_message_handler_name.h"
+#include "ios/web/public/js_messaging/content_world.h"
+#include "ios/web/public/js_messaging/java_script_feature.h"
+#include "ios/web/public/js_messaging/script_message.h"
+#include "ios/web/public/test/fakes/fake_web_client.h"
+#include "ios/web/public/test/js_test_util.h"
+#include "ios/web/public/test/web_test_with_web_state.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace {
+
+// Test feature that composes a RandomizedMessageHandlerName and records
+// whether it has received a script message so tests can assert against it.
+class TestJavaScriptFeature : public web::JavaScriptFeature {
+ public:
+  TestJavaScriptFeature()
+      : JavaScriptFeature(
+            web::ContentWorld::kPageContentWorld,
+            {FeatureScript::CreateWithFilename(
+                "randomized_message_handler_test_api",
+                FeatureScript::InjectionTime::kDocumentStart,
+                FeatureScript::TargetFrames::kMainFrame,
+                FeatureScript::ReinjectionBehavior::kInjectOncePerWindow,
+                base::BindRepeating(&web::RandomizedMessageHandlerName::
+                                        GetPlaceholderReplacements,
+                                    base::Unretained(&handler_name_)))}) {}
+  ~TestJavaScriptFeature() override = default;
+
+  std::optional<std::string> GetScriptMessageHandlerName() const override {
+    return handler_name_.GetScriptMessageHandlerName();
+  }
+
+  bool message_received() const { return message_received_; }
+
+  void ScriptMessageReceived(web::WebState* web_state,
+                             const web::ScriptMessage& message) override {
+    message_received_ = true;
+  }
+
+ private:
+  web::RandomizedMessageHandlerName handler_name_;
+  bool message_received_ = false;
+};
+
+}  // namespace
+
+class RandomizedMessageHandlerFeatureTest : public web::WebTestWithWebState {
+ protected:
+  RandomizedMessageHandlerFeatureTest()
+      : web::WebTestWithWebState(std::make_unique<web::FakeWebClient>()) {}
+
+  void SetUp() override {
+    WebTestWithWebState::SetUp();
+
+    feature_ = std::make_unique<TestJavaScriptFeature>();
+    static_cast<web::FakeWebClient*>(GetWebClient())
+        ->SetJavaScriptFeatures({feature_.get()});
+    LoadHtml(@"<html></html>");
+  }
+
+  void TearDown() override {
+    feature_.reset();
+    WebTestWithWebState::TearDown();
+  }
+
+  std::unique_ptr<TestJavaScriptFeature> feature_;
+};
+
+// Tests that messages that use the imported message handler name are received
+// correctly by the JavaScriptFeature
+TEST_F(RandomizedMessageHandlerFeatureTest, TestMessageReceived) {
+  ASSERT_FALSE(feature_->message_received());
+  web::test::ExecuteJavaScriptForFeature(
+      web_state(),
+      @"__gCrWeb.callFunctionInGcrWeb('randomized_message_handler_tests', "
+      @"'sendWebKitMessage', [])",
+      feature_.get());
+  ASSERT_TRUE(base::test::ios::WaitUntilConditionOrTimeout(
+      base::test::ios::kWaitForJSCompletionTimeout, ^bool {
+        return feature_->message_received();
+      }));
+}
+
+// Tests that two instances of the same JavaScriptFeature do not share the same
+// randomized message handler name
+TEST_F(RandomizedMessageHandlerFeatureTest, DistinctMessageHandlerNames) {
+  auto other_feature = std::make_unique<TestJavaScriptFeature>();
+  EXPECT_NE(feature_->GetScriptMessageHandlerName(),
+            other_feature->GetScriptMessageHandlerName());
+}

--- a/ios/web/js_messaging/resources/randomized_message_handler_test_api.ts
+++ b/ios/web/js_messaging/resources/randomized_message_handler_test_api.ts
@@ -1,0 +1,16 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import {messageHandlerName} from "//brave/ios/web/js_messaging/resources/utils.js";
+import {CrWebApi, gCrWeb} from '//ios/web/public/js_messaging/resources/gcrweb.js';
+import {sendWebKitMessage} from "//ios/web/public/js_messaging/resources/utils.js";
+
+function send() {
+  sendWebKitMessage(messageHandlerName, {});
+}
+
+const testApi = new CrWebApi('randomized_message_handler_tests');
+testApi.addFunction('sendWebKitMessage', send);
+gCrWeb.registerApi(testApi);

--- a/ios/web/js_messaging/resources/utils.ts
+++ b/ios/web/js_messaging/resources/utils.ts
@@ -6,6 +6,10 @@
 import { gSafeBuiltins }
   from "//brave/ios/web/js_messaging/resources/safe_builtins.js";
 
+// The message handler name to use with sendWebKitMessage when your JavaScript
+// feature supports randomized message handler names.
+export const messageHandlerName: string = 'gCrWebPlaceholderMessageHandlerName';
+
 // A token to be used for validating communication with the browser
 const messageHandlerToken: string = 'gCrWebPlaceholderMessageHandlerToken';
 


### PR DESCRIPTION
This change adds a helper class `RandomizedMessageHandlerName` that can be used in JavaScriptFeature's to support randomizing message handler names. The randomized message handler is a UUIDv4 which is injected with the script itself via placeholder replacement.