### PR TITLE
Fix NTT on restored tab is not triggering viewed event after restart

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/NewTabPage/NewTabPageViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/NewTabPage/NewTabPageViewController.swift
@@ -291,9 +291,12 @@ class NewTabPageViewController: UIViewController {
 
       let isTabVisible = viewIfLoaded?.window != nil
       setupBackgroundVideoIfNeeded(shouldCreatePlayer: isTabVisible)
-      // Load the video asset here, as viewDidAppear is not called when the view
-      // is already visible
       if isTabVisible {
+        // `viewDidAppear` is not called when the view is already visible, so
+        // report the viewed impression event and load the video asset here
+        // if needed.
+        reportSponsoredBackgroundViewedEventIfNeeded()
+
         videoAdPlayer?.loadAndAutoplayVideoAssetIfNeeded(
           shouldAutoplay: false
         )
@@ -430,11 +433,7 @@ class NewTabPageViewController: UIViewController {
   override func viewDidAppear(_ animated: Bool) {
     super.viewDidAppear(animated)
 
-    // Only record a sponsored background viewed impression when the NTP
-    // background is not covered by the URL bar overlay.
-    if delegate?.isURLBarInOverlayMode() == false {
-      reportSponsoredBackgroundViewedEventIfNeeded()
-    }
+    reportSponsoredBackgroundViewedEventIfNeeded()
 
     videoAdPlayer?.loadAndAutoplayVideoAssetIfNeeded(
       shouldAutoplay: shouldShowBackgroundVideo()
@@ -690,6 +689,12 @@ class NewTabPageViewController: UIViewController {
   // MARK: - Sponsored background events
 
   private func reportSponsoredBackgroundViewedEventIfNeeded() {
+    // Only record a sponsored background viewed impression when the NTP
+    // background is not covered by the URL bar overlay.
+    if delegate?.isURLBarInOverlayMode() == true {
+      return
+    }
+
     guard case .sponsoredMedia(_, let newTabPageAd) = background.currentBackground else {
       return
     }


### PR DESCRIPTION
After NTT began being served on demand, the NTT content can arrive while the NTP view is already visible. The viewed impression was only fired in viewDidAppear, so asynchronously delivered NTT never triggered the event.
To fix that the PR adds triggering of the event to `NewTabPageBackground` `changed()` callback.

## Test plan

### Test case 1
Check that issue from https://github.com/brave/brave-browser/issues/55464 is fixed.

### Test case 2
* Start the browser 
* Open new NTPs until NTT is shown
EXPECTATION: Viewed impression is triggered.

### Test case 3
* Start the browser
* Enable `Auto-Open Keyboard` from settings
* Open NTPs until NTT is served
* Close the Overlay by tapping `Cancel`
EXPECTATION: Viewed impression is triggered.


<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/55464

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
