### PR TITLE
Fix NTT on restored tab is not triggering viewed event after restart (uplift to 1.90.x)

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/NewTabPage/NewTabPageViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/NewTabPage/NewTabPageViewController.swift
@@ -287,9 +287,12 @@ class NewTabPageViewController: UIViewController {
 
       let isTabVisible = viewIfLoaded?.window != nil
       setupBackgroundVideoIfNeeded(shouldCreatePlayer: isTabVisible)
-      // Load the video asset here, as viewDidAppear is not called when the view
-      // is already visible
       if isTabVisible {
+        // `viewDidAppear` is not called when the view is already visible, so
+        // report the viewed impression event and load the video asset here
+        // if needed.
+        reportSponsoredBackgroundViewedEventIfNeeded()
+
         videoAdPlayer?.loadAndAutoplayVideoAssetIfNeeded(
           shouldAutoplay: false
         )
@@ -426,11 +429,7 @@ class NewTabPageViewController: UIViewController {
   override func viewDidAppear(_ animated: Bool) {
     super.viewDidAppear(animated)
 
-    // Only record a sponsored background viewed impression when the NTP
-    // background is not covered by the URL bar overlay.
-    if delegate?.isURLBarInOverlayMode() == false {
-      reportSponsoredBackgroundViewedEventIfNeeded()
-    }
+    reportSponsoredBackgroundViewedEventIfNeeded()
 
     videoAdPlayer?.loadAndAutoplayVideoAssetIfNeeded(
       shouldAutoplay: shouldShowBackgroundVideo()
@@ -686,6 +685,12 @@ class NewTabPageViewController: UIViewController {
   // MARK: - Sponsored background events
 
   private func reportSponsoredBackgroundViewedEventIfNeeded() {
+    // Only record a sponsored background viewed impression when the NTP
+    // background is not covered by the URL bar overlay.
+    if delegate?.isURLBarInOverlayMode() == true {
+      return
+    }
+
     guard case .sponsoredMedia(_, let newTabPageAd) = background.currentBackground else {
       return
     }


### PR DESCRIPTION
Uplift of #36373
Resolves https://github.com/brave/brave-browser/issues/55464

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.