### PR TITLE
[AI Chat] Fix empty title generation

### DIFF
--- a/components/ai_chat/core/browser/engine/oai_message_utils.cc
+++ b/components/ai_chat/core/browser/engine/oai_message_utils.cc
@@ -617,14 +617,26 @@ BuildOAIGenerateConversationTitleMessages(
         mojom::PageExcerptContentBlock::New(*first_turn->selected_text)));
   }
 
-  // Add a message for title generation.
-  // Use first assistant response as the content if files are uploaded (image,
-  // PDF), otherwise use the first human turn text.
+  // Use the first assistant response when it's non-empty as the title source
+  // when the user uploaded files (image, PDF) since it contains more useful
+  // context for title generation.
+  const bool use_assistant_text = first_turn->uploaded_files &&
+                                  !first_turn->uploaded_files->empty() &&
+                                  !assistant_turn->text.empty();
+  std::string title_text = use_assistant_text
+                               ? assistant_turn->text
+                               : EngineConsumer::GetPromptForEntry(first_turn);
+
+  // Withdraw the request entirely if we have nothing to summarize. Sending an
+  // empty title block wastes a server round-trip and cannot produce a useful
+  // title. Title errors are silently dropped in OnTitleGenerated, so the
+  // conversation simply keeps its placeholder title.
+  if (title_text.empty()) {
+    return std::nullopt;
+  }
+
   msg.content.push_back(mojom::ContentBlock::NewRequestTitleContentBlock(
-      mojom::RequestTitleContentBlock::New(
-          first_turn->uploaded_files
-              ? assistant_turn->text
-              : EngineConsumer::GetPromptForEntry(first_turn))));
+      mojom::RequestTitleContentBlock::New(std::move(title_text))));
 
   messages.push_back(std::move(msg));
   return messages;

--- a/components/ai_chat/core/browser/engine/oai_message_utils_unittest.cc
+++ b/components/ai_chat/core/browser/engine/oai_message_utils_unittest.cc
@@ -941,19 +941,17 @@ TEST_F(OAIMessageUtilsTest,
 TEST_F(OAIMessageUtilsTest,
        BuildOAIGenerateConversationTitleMessages_UploadFiles) {
   // Create a conversation history with 1 human turn including upload_files,
-  // and 1 assistant turn.
+  // and 1 assistant turn with non-empty completion text.
   // Tests one message with 1 kRequestTitle block with text set to assistant
   // turn's text is returned.
   PageContentsMap page_contents_map;
 
   auto history = CreateSampleChatHistory(1);
-
-  auto uploaded_file = mojom::UploadedFile::New();
-  uploaded_file->filename = "test.png";
-  uploaded_file->filesize = 1024;
-  uploaded_file->type = mojom::UploadedFileType::kImage;
-  history[0]->uploaded_files.emplace();
-  history[0]->uploaded_files->push_back(std::move(uploaded_file));
+  history[0]->uploaded_files =
+      CreateSampleUploadedFiles(1, mojom::UploadedFileType::kImage);
+  // CreateSampleChatHistory sets the assistant turn's text to "" by default;
+  // populate it so the assistant-text branch can be exercised.
+  history[1]->text = "The image shows a sunset over mountains.";
 
   auto messages = BuildOAIGenerateConversationTitleMessages(
       std::move(page_contents_map), history, 10000, [](std::string&) {});
@@ -967,8 +965,81 @@ TEST_F(OAIMessageUtilsTest,
   ASSERT_EQ(message.content.size(), 1u);
 
   // Request title block should use assistant response as the text when there
-  // are upload files.
+  // are upload files with content and the assistant produced completion text.
   VerifyRequestTitleBlock(FROM_HERE, message.content[0], history[1]->text);
+}
+
+TEST_F(
+    OAIMessageUtilsTest,
+    BuildOAIGenerateConversationTitleMessages_UploadedFilesEmptyVector_UseUserPrompt) {
+  auto history = CreateSampleChatHistory(1);
+  history[0]->uploaded_files = std::vector<mojom::UploadedFilePtr>{};
+  // Make the assistant text non-empty so a wrongly-taken assistant-text
+  // branch would be observable.
+  history[1]->text = "I'll search for that.";
+
+  auto messages = BuildOAIGenerateConversationTitleMessages(
+      PageContentsMap(), history, 10000, [](std::string&) {});
+
+  ASSERT_TRUE(messages);
+  ASSERT_EQ(messages->size(), 1u);
+  ASSERT_EQ(messages->at(0).content.size(), 1u);
+  // Title source must be the user prompt, not the assistant text.
+  VerifyRequestTitleBlock(FROM_HERE, messages->at(0).content[0],
+                          history[0]->text);
+}
+
+// Real files attached but the assistant turn has no text.
+// Fall back to the user prompt rather than picking empty assistant text.
+TEST_F(
+    OAIMessageUtilsTest,
+    BuildOAIGenerateConversationTitleMessages_UploadedFilesPresentEmptyAssistantText_UseUserPrompt) {
+  auto history = CreateSampleChatHistory(1);
+  history[0]->uploaded_files =
+      CreateSampleUploadedFiles(1, mojom::UploadedFileType::kImage);
+  history[1]->text = "";  // tool-only first response
+
+  auto messages = BuildOAIGenerateConversationTitleMessages(
+      PageContentsMap(), history, 10000, [](std::string&) {});
+
+  ASSERT_TRUE(messages);
+  ASSERT_EQ(messages->size(), 1u);
+  ASSERT_EQ(messages->at(0).content.size(), 1u);
+  VerifyRequestTitleBlock(FROM_HERE, messages->at(0).content[0],
+                          history[0]->text);
+}
+
+// Withdraw the request entirely when the resolved title text would be empty.
+TEST_F(
+    OAIMessageUtilsTest,
+    BuildOAIGenerateConversationTitleMessages_EmptyTitleText_ReturnsNullopt) {
+  // Sub-case a: no uploaded files, empty user text/prompt, empty assistant
+  // text. user-prompt branch resolves to empty.
+  {
+    auto history = CreateSampleChatHistory(1);
+    history[0]->text = "";
+    history[0]->prompt = std::nullopt;
+    history[1]->text = "";
+
+    auto messages = BuildOAIGenerateConversationTitleMessages(
+        PageContentsMap(), history, 10000, [](std::string&) {});
+    EXPECT_FALSE(messages);
+  }
+
+  // Sub-case b: real uploaded file but assistant text empty AND user
+  // text/prompt empty. Falls through user-prompt fallback, still empty.
+  {
+    auto history = CreateSampleChatHistory(1);
+    history[0]->text = "";
+    history[0]->prompt = std::nullopt;
+    history[0]->uploaded_files =
+        CreateSampleUploadedFiles(1, mojom::UploadedFileType::kImage);
+    history[1]->text = "";
+
+    auto messages = BuildOAIGenerateConversationTitleMessages(
+        PageContentsMap(), history, 10000, [](std::string&) {});
+    EXPECT_FALSE(messages);
+  }
 }
 
 TEST_F(OAIMessageUtilsTest,


### PR DESCRIPTION
We were seeing title generation requests with empty text from content
agent conversations (not always) and chart generation conversations.
The root cause of this is we unintentionally uses assistant response
when uploaded files is an empty vector, and when tool calling is
involved, sometimes LLM won't give us initial responses so assistant
response we used would be empty, which leads to a title generation
request with empty text.

This PR fixes the bug by:
1. Only use assistant response if there are non-empty uploaded files and
   non-empty assistant response.
2. Do not issue title generation requests when the text to be sent is
   empty.

Resolves https://github.com/brave/brave-browser/issues/55480

Test plan:
1. Starts browser with `--enable-features="AIChatCodeExecutionTool:charts/true"`
2. Create a new Leo conversation and send "chart fib n 1 to 10" using automatic model
3. Title should be generated (please make sure code execution tool was triggered)
<img width="1501" height="1229" alt="Screenshot 2026-05-12 at 4 03 15 PM" src="https://github.com/user-attachments/assets/f947aa7d-aace-4ce3-ad6e-95d24cc10730" />
