### PR TITLE
[AI Chat] Expose status and error code to user on server error

### DIFF
--- a/browser/ai_chat/ai_chat_render_view_context_menu_browsertest.cc
+++ b/browser/ai_chat/ai_chat_render_view_context_menu_browsertest.cc
@@ -83,7 +83,10 @@ class MockConversationHandlerClient : public mojom::ConversationUI {
 
   MOCK_METHOD(void, OnAPIRequestInProgress, (bool), (override));
 
-  MOCK_METHOD(void, OnAPIResponseError, (mojom::APIError, mojom::APIErrorDetailsPtr), (override));
+  MOCK_METHOD(void,
+              OnAPIResponseError,
+              (mojom::APIError, mojom::APIErrorDetailsPtr),
+              (override));
 
   MOCK_METHOD(void,
               OnTaskStateChanged,

--- a/browser/ai_chat/ai_chat_render_view_context_menu_browsertest.cc
+++ b/browser/ai_chat/ai_chat_render_view_context_menu_browsertest.cc
@@ -83,7 +83,7 @@ class MockConversationHandlerClient : public mojom::ConversationUI {
 
   MOCK_METHOD(void, OnAPIRequestInProgress, (bool), (override));
 
-  MOCK_METHOD(void, OnAPIResponseError, (mojom::APIError), (override));
+  MOCK_METHOD(void, OnAPIResponseError, (mojom::APIError, mojom::APIErrorDetailsPtr), (override));
 
   MOCK_METHOD(void,
               OnTaskStateChanged,

--- a/browser/ui/webui/ai_chat/ai_chat_ui_page_handler_browsertest.cc
+++ b/browser/ui/webui/ai_chat/ai_chat_ui_page_handler_browsertest.cc
@@ -393,7 +393,8 @@ class FakeConversationUI : public mojom::ConversationUI {
   void OnConversationHistoryUpdate(
       const mojom::ConversationTurnPtr entry) override {}
   void OnAPIRequestInProgress(bool in_progress) override {}
-  void OnAPIResponseError(mojom::APIError error) override {}
+  void OnAPIResponseError(mojom::APIError api_error,
+                          mojom::APIErrorDetailsPtr details) override {}
   void OnTaskStateChanged(mojom::TaskState task_state) override {}
   void OnModelDataChanged(const std::string& conversation_model_key,
                           const std::string& default_model_key,

--- a/chromium_src/chrome/browser/renderer_context_menu/render_view_context_menu.cc
+++ b/chromium_src/chrome/browser/renderer_context_menu/render_view_context_menu.cc
@@ -258,8 +258,7 @@ void OnRewriteSuggestionCompleted(
     base::WeakPtr<content::WebContents> web_contents,
     const std::string& selected_text,
     ai_chat::mojom::ActionType action_type,
-    base::expected<ai_chat::EngineConsumer::GenerationResultData,
-                   ai_chat::mojom::APIError> result) {
+    ai_chat::EngineConsumer::GenerationResult result) {
   if (!web_contents) {
     return;
   }
@@ -301,7 +300,7 @@ void OnRewriteSuggestionCompleted(
     ai_chat::OpenAIChatForTab(web_contents.get());
 
     conversation->AddSubmitSelectedTextError(selected_text, action_type,
-                                             result.error());
+                                             result.error().api_error);
   }
 
   web_contents->RemoveUserData(kAIChatRewriteDataKey);

--- a/components/ai_chat/core/browser/ai_chat_service_unittest.cc
+++ b/components/ai_chat/core/browser/ai_chat_service_unittest.cc
@@ -141,7 +141,10 @@ class MockConversationHandlerClient : public mojom::ConversationUI {
 
   MOCK_METHOD(void, OnAPIRequestInProgress, (bool), (override));
 
-  MOCK_METHOD(void, OnAPIResponseError, (mojom::APIError, mojom::APIErrorDetailsPtr), (override));
+  MOCK_METHOD(void,
+              OnAPIResponseError,
+              (mojom::APIError, mojom::APIErrorDetailsPtr),
+              (override));
 
   MOCK_METHOD(void,
               OnTaskStateChanged,
@@ -471,19 +474,20 @@ TEST_P(AIChatServiceUnitTest,
   // Function to call to finish generating the response.
   base::OnceClosure resolve;
   EXPECT_CALL(*engine, GenerateAssistantResponse)
-      .WillOnce(
-          [&resolve](PageContentsMap page_contents,
-                     const std::vector<mojom::ConversationTurnPtr>& history,
-                     bool is_temporary_chat,
-                     const std::vector<base::WeakPtr<Tool>>& tools,
-                     std::optional<std::string_view> preferred_tool_name,
-                     const ConversationCapabilitySet& conversation_capabilities,
-                     base::RepeatingCallback<void(
-                         EngineConsumer::GenerationResultData)> callback,
-                     base::OnceCallback<void(
-                         base::expected<EngineConsumer::GenerationResultData,
-                                        EngineConsumer::Error>)> done_callback) {
-            resolve = base::BindOnce(
+      .WillOnce([&resolve](
+                    PageContentsMap page_contents,
+                    const std::vector<mojom::ConversationTurnPtr>& history,
+                    bool is_temporary_chat,
+                    const std::vector<base::WeakPtr<Tool>>& tools,
+                    std::optional<std::string_view> preferred_tool_name,
+                    const ConversationCapabilitySet& conversation_capabilities,
+                    base::RepeatingCallback<void(
+                        EngineConsumer::GenerationResultData)> callback,
+                    base::OnceCallback<void(
+                        base::expected<EngineConsumer::GenerationResultData,
+                                       EngineConsumer::Error>)> done_callback) {
+        resolve =
+            base::BindOnce(
                 [](base::OnceCallback<void(
                        base::expected<EngineConsumer::GenerationResultData,
                                       EngineConsumer::Error>)> done_callback) {
@@ -494,7 +498,7 @@ TEST_P(AIChatServiceUnitTest,
                           std::nullopt /* model_key */)));
                 },
                 std::move(done_callback));
-          });
+      });
 
   // Conversation should exist in memory.
   EXPECT_EQ(ai_chat_service_->GetInMemoryConversationCountForTesting(), 1u);

--- a/components/ai_chat/core/browser/ai_chat_service_unittest.cc
+++ b/components/ai_chat/core/browser/ai_chat_service_unittest.cc
@@ -141,7 +141,7 @@ class MockConversationHandlerClient : public mojom::ConversationUI {
 
   MOCK_METHOD(void, OnAPIRequestInProgress, (bool), (override));
 
-  MOCK_METHOD(void, OnAPIResponseError, (mojom::APIError), (override));
+  MOCK_METHOD(void, OnAPIResponseError, (mojom::APIError, mojom::APIErrorDetailsPtr), (override));
 
   MOCK_METHOD(void,
               OnTaskStateChanged,
@@ -482,11 +482,11 @@ TEST_P(AIChatServiceUnitTest,
                          EngineConsumer::GenerationResultData)> callback,
                      base::OnceCallback<void(
                          base::expected<EngineConsumer::GenerationResultData,
-                                        mojom::APIError>)> done_callback) {
+                                        EngineConsumer::Error>)> done_callback) {
             resolve = base::BindOnce(
                 [](base::OnceCallback<void(
                        base::expected<EngineConsumer::GenerationResultData,
-                                      mojom::APIError>)> done_callback) {
+                                      EngineConsumer::Error>)> done_callback) {
                   std::move(done_callback)
                       .Run(base::ok(EngineConsumer::GenerationResultData(
                           mojom::ConversationEntryEvent::NewCompletionEvent(

--- a/components/ai_chat/core/browser/conversation_handler.cc
+++ b/components/ai_chat/core/browser/conversation_handler.cc
@@ -412,7 +412,9 @@ void ConversationHandler::GetState(GetStateCallback callback) {
 #if BUILDFLAG(IS_IOS)
       std::move(suggestions), suggestion_generation_status_,
 #endif
-      associated_content_manager_->GetAssociatedContent(), current_error_,
+      associated_content_manager_->GetAssociatedContent(),
+      current_error_.api_error,
+      current_error_.details ? current_error_.details->Clone() : nullptr,
       metadata_->temporary, tool_use_task_state_,
       base::ToVector(conversation_capabilities_));
 
@@ -1283,13 +1285,15 @@ void ConversationHandler::PerformPostToolAssistantGeneration() {
   PerformAssistantGenerationWithPossibleContent();
 }
 
-void ConversationHandler::SetAPIError(const mojom::APIError& error) {
-  current_error_ = error;
+void ConversationHandler::SetAPIError(EngineConsumer::Error error) {
+  current_error_ = std::move(error);
 
   OnStateForConversationEntriesChanged();
 
   for (auto& client : conversation_ui_handlers_) {
-    client->OnAPIResponseError(error);
+    client->OnAPIResponseError(
+        current_error_.api_error,
+        current_error_.details ? current_error_.details->Clone() : nullptr);
   }
 }
 
@@ -1674,7 +1678,7 @@ void ConversationHandler::OnEngineCompletionComplete(
     EngineConsumer::GenerationResult result) {
   // Handle failure
   if (!result.has_value()) {
-    if (result.error() != mojom::APIError::None) {
+    if (result.error().api_error != mojom::APIError::None) {
       DVLOG(2) << __func__ << ": With error";
       SetAPIError(std::move(result.error()));
     } else {
@@ -2054,7 +2058,9 @@ ConversationHandler::GetStateForConversationEntries() {
   entries_state->suggestion_status = suggestion_generation_status_;
 
   // API error
-  entries_state->current_error = current_error_;
+  entries_state->current_error = current_error_.api_error;
+  entries_state->current_error_details =
+      current_error_.details ? current_error_.details->Clone() : nullptr;
 
   // Temporary chat flag
   entries_state->is_temporary = metadata_->temporary;
@@ -2348,7 +2354,7 @@ bool ConversationHandler::should_send_page_contents() const {
 }
 
 mojom::APIError ConversationHandler::current_error() const {
-  return current_error_;
+  return current_error_.api_error;
 }
 
 void ConversationHandler::SetTemporary(bool temporary) {

--- a/components/ai_chat/core/browser/conversation_handler.h
+++ b/components/ai_chat/core/browser/conversation_handler.h
@@ -375,7 +375,7 @@ class ConversationHandler : public mojom::ConversationHandler,
   // send the results to the engine and wait for the next response for the loop.
   void PerformPostToolAssistantGeneration();
 
-  void SetAPIError(const mojom::APIError& error);
+  void SetAPIError(EngineConsumer::Error error);
   void UpdateOrCreateLastAssistantEntry(
       EngineConsumer::GenerationResultData result);
   void MaybeSeedOrClearSuggestions();
@@ -484,7 +484,7 @@ class ConversationHandler : public mojom::ConversationHandler,
   bool is_print_preview_fallback_requested_ = false;
 
   std::unique_ptr<EngineConsumer> engine_ = nullptr;
-  mojom::APIError current_error_ = mojom::APIError::None;
+  EngineConsumer::Error current_error_;
 
   // Tool providers for this conversation. This allows those providers or their
   // tools to optionally store state that is only for this conversation. If they

--- a/components/ai_chat/core/browser/conversation_handler_unittest.cc
+++ b/components/ai_chat/core/browser/conversation_handler_unittest.cc
@@ -143,7 +143,10 @@ class MockConversationHandlerClient : public mojom::ConversationUI {
 
   MOCK_METHOD(void, OnAPIRequestInProgress, (bool), (override));
 
-  MOCK_METHOD(void, OnAPIResponseError, (mojom::APIError, mojom::APIErrorDetailsPtr), (override));
+  MOCK_METHOD(void,
+              OnAPIResponseError,
+              (mojom::APIError, mojom::APIErrorDetailsPtr),
+              (override));
 
   MOCK_METHOD(void,
               OnTaskStateChanged,

--- a/components/ai_chat/core/browser/conversation_handler_unittest.cc
+++ b/components/ai_chat/core/browser/conversation_handler_unittest.cc
@@ -143,7 +143,7 @@ class MockConversationHandlerClient : public mojom::ConversationUI {
 
   MOCK_METHOD(void, OnAPIRequestInProgress, (bool), (override));
 
-  MOCK_METHOD(void, OnAPIResponseError, (mojom::APIError), (override));
+  MOCK_METHOD(void, OnAPIResponseError, (mojom::APIError, mojom::APIErrorDetailsPtr), (override));
 
   MOCK_METHOD(void,
               OnTaskStateChanged,

--- a/components/ai_chat/core/browser/engine/conversation_api_v2_client.cc
+++ b/components/ai_chat/core/browser/engine/conversation_api_v2_client.cc
@@ -130,6 +130,20 @@ std::string_view GetContentBlockTypeString(
   }
 }
 
+int32_t ParseErrorCode(const base::Value& body) {
+  if (body.is_dict()) {
+    if (auto* error_dict = body.GetDict().FindDict("error")) {
+      if (auto* type_str = error_dict->FindString("type")) {
+        int parsed;
+        if (base::StringToInt(*type_str, &parsed)) {
+          return static_cast<int32_t>(parsed);
+        }
+      }
+    }
+  }
+  return 0;
+}
+
 }  // namespace
 
 // static
@@ -426,20 +440,6 @@ void ConversationAPIV2Client::PerformRequestWithCredentials(
   }
 }
 
-void ConversationAPIV2Client::ParseErrorCode(const base::Value& body) {
-  if (!body.is_dict()) {
-    return;
-  }
-  if (auto* error_dict = body.GetDict().FindDict("error")) {
-    if (auto* type_str = error_dict->FindString("type")) {
-      int parsed;
-      if (base::StringToInt(*type_str, &parsed)) {
-        last_error_code_ = static_cast<int32_t>(parsed);
-      }
-    }
-  }
-}
-
 void ConversationAPIV2Client::OnQueryCompleted(
     std::optional<CredentialCacheEntry> credential,
     GenerationCompletedCallback callback,
@@ -447,7 +447,6 @@ void ConversationAPIV2Client::OnQueryCompleted(
   const bool success = result.Is2XXResponseCode();
   // Handle successful request
   if (success) {
-    last_error_code_ = std::nullopt;
     std::optional<bool> is_near_verified = std::nullopt;
     std::optional<std::string> model_key = std::nullopt;
     const auto& headers = result.headers();
@@ -491,14 +490,12 @@ void ConversationAPIV2Client::OnQueryCompleted(
     error = mojom::APIError::ConnectionIssue;
   }
 
-  ParseErrorCode(result.value_body());
-  auto details = mojom::APIErrorDetails::New(
-      static_cast<int32_t>(result.response_code()),
-      last_error_code_.value_or(0));
-  last_error_code_ = std::nullopt;
+  auto details =
+      mojom::APIErrorDetails::New(static_cast<int32_t>(result.response_code()),
+                                  ParseErrorCode(result.value_body()));
 
-  std::move(callback).Run(base::unexpected(
-      EngineConsumer::Error(error, std::move(details))));
+  std::move(callback).Run(
+      base::unexpected(EngineConsumer::Error(error, std::move(details))));
 }
 
 void ConversationAPIV2Client::OnQueryDataReceived(
@@ -507,8 +504,6 @@ void ConversationAPIV2Client::OnQueryDataReceived(
   if (!result.has_value() || !result->is_dict()) {
     return;
   }
-
-  ParseErrorCode(*result);
 
   auto& result_params = result->GetDict();
   std::optional<std::string> model_key =

--- a/components/ai_chat/core/browser/engine/conversation_api_v2_client.cc
+++ b/components/ai_chat/core/browser/engine/conversation_api_v2_client.cc
@@ -19,6 +19,7 @@
 #include "base/json/json_writer.h"
 #include "base/memory/scoped_refptr.h"
 #include "base/strings/strcat.h"
+#include "base/strings/string_number_conversions.h"
 #include "base/strings/string_util.h"
 #include "base/types/expected.h"
 #include "brave/components/ai_chat/core/browser/constants.h"
@@ -425,6 +426,20 @@ void ConversationAPIV2Client::PerformRequestWithCredentials(
   }
 }
 
+void ConversationAPIV2Client::ParseErrorCode(const base::Value& body) {
+  if (!body.is_dict()) {
+    return;
+  }
+  if (auto* error_dict = body.GetDict().FindDict("error")) {
+    if (auto* type_str = error_dict->FindString("type")) {
+      int parsed;
+      if (base::StringToInt(*type_str, &parsed)) {
+        last_error_code_ = static_cast<int32_t>(parsed);
+      }
+    }
+  }
+}
+
 void ConversationAPIV2Client::OnQueryCompleted(
     std::optional<CredentialCacheEntry> credential,
     GenerationCompletedCallback callback,
@@ -432,6 +447,7 @@ void ConversationAPIV2Client::OnQueryCompleted(
   const bool success = result.Is2XXResponseCode();
   // Handle successful request
   if (success) {
+    last_error_code_ = std::nullopt;
     std::optional<bool> is_near_verified = std::nullopt;
     std::optional<std::string> model_key = std::nullopt;
     const auto& headers = result.headers();
@@ -475,7 +491,14 @@ void ConversationAPIV2Client::OnQueryCompleted(
     error = mojom::APIError::ConnectionIssue;
   }
 
-  std::move(callback).Run(base::unexpected(std::move(error)));
+  ParseErrorCode(result.value_body());
+  auto details = mojom::APIErrorDetails::New(
+      static_cast<int32_t>(result.response_code()),
+      last_error_code_.value_or(0));
+  last_error_code_ = std::nullopt;
+
+  std::move(callback).Run(base::unexpected(
+      EngineConsumer::Error(error, std::move(details))));
 }
 
 void ConversationAPIV2Client::OnQueryDataReceived(
@@ -484,6 +507,8 @@ void ConversationAPIV2Client::OnQueryDataReceived(
   if (!result.has_value() || !result->is_dict()) {
     return;
   }
+
+  ParseErrorCode(*result);
 
   auto& result_params = result->GetDict();
   std::optional<std::string> model_key =

--- a/components/ai_chat/core/browser/engine/conversation_api_v2_client.cc
+++ b/components/ai_chat/core/browser/engine/conversation_api_v2_client.cc
@@ -130,18 +130,15 @@ std::string_view GetContentBlockTypeString(
   }
 }
 
-int32_t ParseErrorCode(const base::Value& body) {
+std::string ParseErrorCode(const base::Value& body) {
   if (body.is_dict()) {
     if (auto* error_dict = body.GetDict().FindDict("error")) {
       if (auto* type_str = error_dict->FindString("type")) {
-        int parsed;
-        if (base::StringToInt(*type_str, &parsed)) {
-          return static_cast<int32_t>(parsed);
-        }
+        return *type_str;
       }
     }
   }
-  return 0;
+  return std::string();
 }
 
 }  // namespace

--- a/components/ai_chat/core/browser/engine/conversation_api_v2_client.h
+++ b/components/ai_chat/core/browser/engine/conversation_api_v2_client.h
@@ -119,10 +119,13 @@ class ConversationAPIV2Client {
   std::optional<std::string> GetLeoModelKeyFromResponse(
       const base::DictValue& response);
 
+  void ParseErrorCode(const base::Value& body);
+
   const std::string model_name_;
   std::unique_ptr<api_request_helper::APIRequestHelper> api_request_helper_;
   raw_ptr<AIChatCredentialManager> credential_manager_;
   raw_ptr<ModelService> model_service_;
+  std::optional<int32_t> last_error_code_;
 
   base::WeakPtrFactory<ConversationAPIV2Client> weak_ptr_factory_{this};
 };

--- a/components/ai_chat/core/browser/engine/conversation_api_v2_client.h
+++ b/components/ai_chat/core/browser/engine/conversation_api_v2_client.h
@@ -119,13 +119,10 @@ class ConversationAPIV2Client {
   std::optional<std::string> GetLeoModelKeyFromResponse(
       const base::DictValue& response);
 
-  void ParseErrorCode(const base::Value& body);
-
   const std::string model_name_;
   std::unique_ptr<api_request_helper::APIRequestHelper> api_request_helper_;
   raw_ptr<AIChatCredentialManager> credential_manager_;
   raw_ptr<ModelService> model_service_;
-  std::optional<int32_t> last_error_code_;
 
   base::WeakPtrFactory<ConversationAPIV2Client> weak_ptr_factory_{this};
 };

--- a/components/ai_chat/core/browser/engine/conversation_api_v2_client_unittest.cc
+++ b/components/ai_chat/core/browser/engine/conversation_api_v2_client_unittest.cc
@@ -2140,4 +2140,91 @@ TEST_F(ConversationAPIV2ClientUnitTest, OnQueryDataReceived_CompletionChunk) {
   }
 }
 
+TEST_F(ConversationAPIV2ClientUnitTest, ErrorParsing_SSE) {
+  MockAPIRequestHelper* mock_request_helper =
+      client_->GetMockAPIRequestHelper();
+  testing::StrictMock<MockCallbacks> mock_callbacks;
+  base::RunLoop run_loop;
+
+  EXPECT_CALL(*mock_request_helper, RequestSSE(_, _, _, _, _, _, _, _))
+      .WillOnce([&](const std::string& method, const GURL& url,
+                    const std::string& body, const std::string& content_type,
+                    DataReceivedCallback data_received_callback,
+                    ResultCallback result_callback,
+                    const base::flat_map<std::string, std::string>& headers,
+                    const api_request_helper::APIRequestOptions& options) {
+        // Error body arrives via value_body() in the terminal APIRequestResult,
+        // populated by APIRequestHelper from the non-2xx SSE response body.
+        auto error_dict = base::test::ParseJsonDict(
+            R"({"error":{"type":"1234","message":"bad request"}})");
+        std::move(result_callback)
+            .Run(api_request_helper::APIRequestResult(
+                400, base::Value(std::move(error_dict)), {}, net::OK, GURL()));
+        return Ticket();
+      });
+
+  EXPECT_CALL(mock_callbacks, OnCompleted(_))
+      .WillOnce([&](EngineConsumer::GenerationResult result) {
+        ASSERT_FALSE(result.has_value());
+        EXPECT_EQ(result.error().api_error, mojom::APIError::ConnectionIssue);
+        ASSERT_TRUE(result.error().details);
+        EXPECT_EQ(result.error().details->status_code, 400);
+        EXPECT_EQ(result.error().details->error_code, 1234);
+        run_loop.Quit();
+      });
+
+  client_->PerformRequest(
+      GetMockMessagesAndExpectedMessagesJson().first, std::nullopt,
+      std::nullopt, {mojom::ConversationCapability::CHAT},
+      base::BindRepeating(&MockCallbacks::OnDataReceived,
+                          base::Unretained(&mock_callbacks)),
+      base::BindOnce(&MockCallbacks::OnCompleted,
+                     base::Unretained(&mock_callbacks)));
+
+  run_loop.Run();
+}
+
+TEST_F(ConversationAPIV2ClientUnitTest, ErrorParsing_NonSSE) {
+  MockAPIRequestHelper* mock_request_helper =
+      client_->GetMockAPIRequestHelper();
+  testing::StrictMock<MockCallbacks> mock_callbacks;
+  base::RunLoop run_loop;
+
+  EXPECT_CALL(*mock_request_helper, Request(_, _, _, _, _, _, _, _))
+      .WillOnce(
+          [&](const std::string& method, const GURL& url,
+              const std::string& body, const std::string& content_type,
+              ResultCallback result_callback,
+              const base::flat_map<std::string, std::string>& headers,
+              const api_request_helper::APIRequestOptions& options,
+              api_request_helper::APIRequestHelper::ResponseConversionCallback
+                  conversion_callback) {
+            auto error_dict = base::test::ParseJsonDict(
+                R"({"error":{"type":"5678","message":"rate limited"}})");
+            std::move(result_callback)
+                .Run(api_request_helper::APIRequestResult(
+                    429, base::Value(std::move(error_dict)), {}, net::OK,
+                    GURL()));
+            return Ticket();
+          });
+
+  EXPECT_CALL(mock_callbacks, OnCompleted(_))
+      .WillOnce([&](EngineConsumer::GenerationResult result) {
+        ASSERT_FALSE(result.has_value());
+        EXPECT_EQ(result.error().api_error, mojom::APIError::RateLimitReached);
+        ASSERT_TRUE(result.error().details);
+        EXPECT_EQ(result.error().details->status_code, 429);
+        EXPECT_EQ(result.error().details->error_code, 5678);
+        run_loop.Quit();
+      });
+
+  client_->PerformRequest(
+      GetMockMessagesAndExpectedMessagesJson().first, std::nullopt,
+      std::nullopt, {mojom::ConversationCapability::CHAT}, base::NullCallback(),
+      base::BindOnce(&MockCallbacks::OnCompleted,
+                     base::Unretained(&mock_callbacks)));
+
+  run_loop.Run();
+}
+
 }  // namespace ai_chat

--- a/components/ai_chat/core/browser/engine/conversation_api_v2_client_unittest.cc
+++ b/components/ai_chat/core/browser/engine/conversation_api_v2_client_unittest.cc
@@ -2169,7 +2169,7 @@ TEST_F(ConversationAPIV2ClientUnitTest, ErrorParsing_SSE) {
         EXPECT_EQ(result.error().api_error, mojom::APIError::ConnectionIssue);
         ASSERT_TRUE(result.error().details);
         EXPECT_EQ(result.error().details->status_code, 400);
-        EXPECT_EQ(result.error().details->error_code, 1234);
+        EXPECT_EQ(result.error().details->error_type, "1234");
         run_loop.Quit();
       });
 
@@ -2214,7 +2214,7 @@ TEST_F(ConversationAPIV2ClientUnitTest, ErrorParsing_NonSSE) {
         EXPECT_EQ(result.error().api_error, mojom::APIError::RateLimitReached);
         ASSERT_TRUE(result.error().details);
         EXPECT_EQ(result.error().details->status_code, 429);
-        EXPECT_EQ(result.error().details->error_code, 5678);
+        EXPECT_EQ(result.error().details->error_type, "5678");
         run_loop.Quit();
       });
 

--- a/components/ai_chat/core/browser/engine/engine_consumer.cc
+++ b/components/ai_chat/core/browser/engine/engine_consumer.cc
@@ -40,6 +40,18 @@ EngineConsumer::GenerationResultData::operator=(GenerationResultData&& other) =
 
 EngineConsumer::GenerationResultData::~GenerationResultData() = default;
 
+EngineConsumer::Error::~Error() = default;
+EngineConsumer::Error::Error() = default;
+EngineConsumer::Error::Error(Error&&) = default;
+EngineConsumer::Error& EngineConsumer::Error::operator=(Error&&) = default;
+
+EngineConsumer::Error::Error(mojom::APIError api_error)
+    : api_error(api_error) {}
+
+EngineConsumer::Error::Error(mojom::APIError api_error,
+                             mojom::APIErrorDetailsPtr details)
+    : api_error(api_error), details(std::move(details)) {}
+
 // static
 std::string EngineConsumer::GetPromptForEntry(
     const mojom::ConversationTurnPtr& entry) {
@@ -152,7 +164,7 @@ EngineConsumer::GetStrArrFromTabOrganizationResponses(
     // Fail the operation if server returns an error, such as rate limiting.
     // On the other hand, ignore the result which cannot be parsed as expected.
     if (!result.has_value()) {
-      error = result.error();
+      error = result.error().api_error;
       break;
     }
 

--- a/components/ai_chat/core/browser/engine/engine_consumer.h
+++ b/components/ai_chat/core/browser/engine/engine_consumer.h
@@ -67,7 +67,7 @@ class EngineConsumer {
     Error(Error&&);
     Error& operator=(Error&&);
 
-    Error(mojom::APIError api_error);
+    Error(mojom::APIError api_error);  // NOLINT(runtime/explicit)
     Error(mojom::APIError api_error, mojom::APIErrorDetailsPtr details);
 
     bool operator==(mojom::APIError api_error_val) const {
@@ -77,8 +77,7 @@ class EngineConsumer {
     mojom::APIErrorDetailsPtr details;
   };
 
-  using GenerationResult =
-      base::expected<GenerationResultData, Error>;
+  using GenerationResult = base::expected<GenerationResultData, Error>;
 
   using GenerationDataCallback =
       base::RepeatingCallback<void(GenerationResultData)>;

--- a/components/ai_chat/core/browser/engine/engine_consumer.h
+++ b/components/ai_chat/core/browser/engine/engine_consumer.h
@@ -60,8 +60,25 @@ class EngineConsumer {
     std::optional<bool> is_near_verified;
   };
 
+  struct Error {
+    ~Error();
+
+    Error();
+    Error(Error&&);
+    Error& operator=(Error&&);
+
+    Error(mojom::APIError api_error);
+    Error(mojom::APIError api_error, mojom::APIErrorDetailsPtr details);
+
+    bool operator==(mojom::APIError api_error_val) const {
+      return api_error == api_error_val;
+    }
+    mojom::APIError api_error = mojom::APIError::None;
+    mojom::APIErrorDetailsPtr details;
+  };
+
   using GenerationResult =
-      base::expected<GenerationResultData, mojom::APIError>;
+      base::expected<GenerationResultData, Error>;
 
   using GenerationDataCallback =
       base::RepeatingCallback<void(GenerationResultData)>;

--- a/components/ai_chat/core/browser/engine/engine_consumer.h
+++ b/components/ai_chat/core/browser/engine/engine_consumer.h
@@ -61,12 +61,15 @@ class EngineConsumer {
   };
 
   struct Error {
+    Error();
     ~Error();
 
-    Error();
     Error(Error&&);
     Error& operator=(Error&&);
 
+    // Implicit constructor exists to avoid having to change all existing
+    // result instantiation call sites to explicitly construct `Error` instead
+    // of `mojom::APIError`.
     Error(mojom::APIError api_error);  // NOLINT(runtime/explicit)
     Error(mojom::APIError api_error, mojom::APIErrorDetailsPtr details);
 

--- a/components/ai_chat/core/browser/engine/engine_consumer_conversation_api.cc
+++ b/components/ai_chat/core/browser/engine/engine_consumer_conversation_api.cc
@@ -171,7 +171,7 @@ void EngineConsumerConversationAPI::OnGenerateQuestionSuggestionsResponse(
     GenerationResult result) {
   if (!result.has_value()) {
     // Query resulted in error
-    std::move(callback).Run(base::unexpected(std::move(result.error())));
+    std::move(callback).Run(base::unexpected(result.error().api_error));
     return;
   }
 

--- a/components/ai_chat/core/browser/engine/engine_consumer_conversation_api_v2.cc
+++ b/components/ai_chat/core/browser/engine/engine_consumer_conversation_api_v2.cc
@@ -52,7 +52,7 @@ void EngineConsumerConversationAPIV2::OnGenerateQuestionSuggestionsResponse(
     GenerationResult result) {
   if (!result.has_value()) {
     // Query resulted in error
-    std::move(callback).Run(base::unexpected(std::move(result.error())));
+    std::move(callback).Run(base::unexpected(result.error().api_error));
     return;
   }
 

--- a/components/ai_chat/core/browser/engine/engine_consumer_oai.cc
+++ b/components/ai_chat/core/browser/engine/engine_consumer_oai.cc
@@ -126,7 +126,7 @@ void EngineConsumerOAIRemote::OnGenerateQuestionSuggestionsResponse(
     GenerationResult result) {
   if (!result.has_value()) {
     // Query resulted in error
-    std::move(callback).Run(base::unexpected(std::move(result.error())));
+    std::move(callback).Run(base::unexpected(result.error().api_error));
     return;
   }
 

--- a/components/ai_chat/core/common/mojom/ai_chat.mojom
+++ b/components/ai_chat/core/common/mojom/ai_chat.mojom
@@ -276,6 +276,7 @@ struct ConversationState {
 
   array<AssociatedContent> associated_content;
   APIError error;
+  APIErrorDetails? error_details;
   // Indicates whether the conversation is temporary which would be in-memory
   // only and not persisted in database.
   bool temporary = false;
@@ -365,7 +366,7 @@ interface ConversationUI {
 
   OnAPIRequestInProgress(bool is_request_in_progress);
 
-  OnAPIResponseError(APIError error);
+  OnAPIResponseError(APIError api_error, APIErrorDetails? details);
 
   OnTaskStateChanged(TaskState task_state);
 

--- a/components/ai_chat/core/common/mojom/common.mojom
+++ b/components/ai_chat/core/common/mojom/common.mojom
@@ -38,6 +38,11 @@ enum APIError {
   ServiceOverloaded
 };
 
+struct APIErrorDetails {
+  int32 status_code;
+  int32 error_code;
+};
+
 enum SuggestionGenerationStatus {
   None,
   CanGenerate,
@@ -697,6 +702,7 @@ struct ConversationEntriesState {
   SuggestionGenerationStatus suggestion_status;
   // Current API error state
   APIError current_error;
+  APIErrorDetails? current_error_details;
   // Whether this is a temporary (non-persisted) conversation
   bool is_temporary = false;
 };

--- a/components/ai_chat/core/common/mojom/common.mojom
+++ b/components/ai_chat/core/common/mojom/common.mojom
@@ -38,6 +38,7 @@ enum APIError {
   ServiceOverloaded
 };
 
+// TODO(https://github.com/brave/brave-browser/issues/55518): Add APIError to this struct
 struct APIErrorDetails {
   int32 status_code;
   string error_type;

--- a/components/ai_chat/core/common/mojom/common.mojom
+++ b/components/ai_chat/core/common/mojom/common.mojom
@@ -40,7 +40,7 @@ enum APIError {
 
 struct APIErrorDetails {
   int32 status_code;
-  int32 error_code;
+  string error_type;
 };
 
 enum SuggestionGenerationStatus {

--- a/components/ai_chat/ios/browser/conversation_client.h
+++ b/components/ai_chat/ios/browser/conversation_client.h
@@ -38,7 +38,8 @@ class ConversationClient : public mojom::ConversationUI,
   void OnConversationHistoryUpdate(mojom::ConversationTurnPtr entry) override;
   void OnAPIRequestInProgress(bool is_request_in_progress) override;
   void OnTaskStateChanged(mojom::TaskState task_state) override {}
-  void OnAPIResponseError(mojom::APIError error) override;
+  void OnAPIResponseError(mojom::APIError api_error,
+                          mojom::APIErrorDetailsPtr details) override;
   void OnModelDataChanged(
       const std::string& model_key,
       const std::string& default_model_key,

--- a/components/ai_chat/ios/browser/conversation_client.mm
+++ b/components/ai_chat/ios/browser/conversation_client.mm
@@ -46,8 +46,10 @@ void ConversationClient::OnAPIRequestInProgress(bool in_progress) {
   [bridge_ onAPIRequestInProgress:in_progress];
 }
 
-void ConversationClient::OnAPIResponseError(mojom::APIError error) {
-  [bridge_ onAPIResponseError:(AiChatAPIError)error];
+void ConversationClient::OnAPIResponseError(
+    mojom::APIError api_error,
+    mojom::APIErrorDetailsPtr details) {
+  [bridge_ onAPIResponseError:(AiChatAPIError)api_error];
 }
 
 void ConversationClient::OnModelDataChanged(

--- a/components/ai_chat/ios/browser/conversation_client.mm
+++ b/components/ai_chat/ios/browser/conversation_client.mm
@@ -46,9 +46,8 @@ void ConversationClient::OnAPIRequestInProgress(bool in_progress) {
   [bridge_ onAPIRequestInProgress:in_progress];
 }
 
-void ConversationClient::OnAPIResponseError(
-    mojom::APIError api_error,
-    mojom::APIErrorDetailsPtr details) {
+void ConversationClient::OnAPIResponseError(mojom::APIError api_error,
+                                            mojom::APIErrorDetailsPtr details) {
   [bridge_ onAPIResponseError:(AiChatAPIError)api_error];
 }
 

--- a/components/ai_chat/resources/page/api/conversation_api.ts
+++ b/components/ai_chat/resources/page/api/conversation_api.ts
@@ -62,6 +62,7 @@ export default function createConversationApi(
             // </if>
             associatedContent: [],
             error: Mojom.APIError.None,
+            errorDetails: undefined,
             temporary: false,
             toolUseTaskState: Mojom.TaskState.kNone,
             capabilitiesEnabled: [Mojom.ConversationCapability.CHAT],
@@ -142,8 +143,11 @@ export default function createConversationApi(
             }
           },
 
-          onAPIResponseError: (error) => {
-            api.getState.update({ error })
+          onAPIResponseError: (apiError, errorDetails) => {
+            api.getState.update({
+              error: apiError,
+              errorDetails: errorDetails ?? undefined,
+            })
           },
 
           onTaskStateChanged: (toolUseTaskState) => {

--- a/components/ai_chat/resources/page/api/mock_interfaces.ts
+++ b/components/ai_chat/resources/page/api/mock_interfaces.ts
@@ -63,6 +63,7 @@ export const defaultConversationState: Mojom.ConversationState & {
   // </if>
   associatedContent: [],
   error: Mojom.APIError.None,
+  errorDetails: undefined,
   temporary: false,
   toolUseTaskState: Mojom.TaskState.kNone,
   capabilitiesEnabled: [Mojom.ConversationCapability.CHAT],

--- a/components/ai_chat/resources/page/stories/components_panel.tsx
+++ b/components/ai_chat/resources/page/stories/components_panel.tsx
@@ -570,6 +570,7 @@ function StoryContext(
                   : new Mojom.AssociatedContent(),
               ],
               error: currentError,
+              errorDetails: undefined,
               temporary: argsRef.current.isTemporaryChat,
               toolUseTaskState:
                 Mojom.TaskState[argsRef.current.toolUseTaskState],

--- a/components/ai_chat/resources/untrusted_conversation_frame/api/mock_interfaces.ts
+++ b/components/ai_chat/resources/untrusted_conversation_frame/api/mock_interfaces.ts
@@ -38,6 +38,7 @@ export const defaultConversationEntriesState: Mojom.ConversationEntriesState = {
   suggestedQuestions: [],
   suggestionStatus: Mojom.SuggestionGenerationStatus.None,
   currentError: Mojom.APIError.None,
+  currentErrorDetails: undefined,
   isTemporary: false,
 }
 

--- a/components/ai_chat/resources/untrusted_conversation_frame/api/untrusted_conversation_api.ts
+++ b/components/ai_chat/resources/untrusted_conversation_frame/api/untrusted_conversation_api.ts
@@ -129,6 +129,7 @@ export default function createUntrustedConversationApi(
         suggestedQuestions: [],
         suggestionStatus: Mojom.SuggestionGenerationStatus.None,
         currentError: Mojom.APIError.None,
+        currentErrorDetails: undefined,
         isTemporary: false,
       }),
 

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/alerts/alerts.module.scss
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/alerts/alerts.module.scss
@@ -47,3 +47,9 @@
     color: var(--leo-color-text-primary);
   }
 }
+
+.errorDetails {
+  font: var(--leo-font-x-small-regular);
+  margin-block-start: 1em;
+  margin-block-end: 0;
+}

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/alerts/alerts.stories.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/alerts/alerts.stories.tsx
@@ -5,6 +5,8 @@
 
 import * as React from 'react'
 import { Meta } from '@storybook/react'
+import * as Mojom from '../../../common/mojom'
+import { InferControlsFromArgs } from '../../../../../../.storybook/utils'
 import UntrustedMockContext from '../../mock_untrusted_conversation_context'
 import ErrorConnection from './error_connection'
 import ErrorConversationEnd from './error_conversation_end'
@@ -16,16 +18,35 @@ import LongConversationInfo from './long_conversation_info'
 import WarningPremiumDisconnected from './warning_premium_disconnected'
 import styles from '../../../page/stories/style.module.scss'
 
+type Args = {
+  showErrorDetails: boolean
+}
+
+const args: Args = {
+  showErrorDetails: true,
+}
+
+const MOCK_ERROR_DETAILS: Mojom.APIErrorDetails = {
+  statusCode: 429,
+  errorType: '42901',
+}
+
 export default {
   title: 'AI Chat/Alerts',
+  argTypes: InferControlsFromArgs(args),
+  args,
 } as Meta
 
 export const _Alerts = {
-  render: () => {
+  render: (args: Args) => {
     return (
       <UntrustedMockContext>
         <div className={`${styles.container} ${styles.containerAlerts}`}>
-          <ErrorConnection />
+          <ErrorConnection
+            errorDetails={
+              args.showErrorDetails ? MOCK_ERROR_DETAILS : undefined
+            }
+          />
           <ErrorConversationEnd />
           <ErrorInvalidAPIKey />
           <ErrorInvalidEndpointURL />

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/alerts/error_connection.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/alerts/error_connection.tsx
@@ -6,18 +6,41 @@
 import * as React from 'react'
 import Alert from '@brave/leo/react/alert'
 import Button from '@brave/leo/react/button'
-import { getLocale } from '$web-common/locale'
+import { getLocale, formatLocale } from '$web-common/locale'
+import * as Mojom from '../../../common/mojom'
 import styles from './alerts.module.scss'
 
-interface PromptAutoSuggestionProps {
+interface Props {
   onRetry?: () => void
+  errorDetails?: Mojom.APIErrorDetails | null
 }
 
-function ErrorConnection(props: PromptAutoSuggestionProps) {
+function ErrorConnection(props: Props) {
+  const { errorDetails } = props
+
+  let detailsText: string | undefined
+  if (errorDetails) {
+    if (errorDetails.errorCode !== 0) {
+      detailsText = formatLocale(S.CHAT_UI_ERROR_NETWORK_DETAILS, {
+        $1: String(errorDetails.statusCode),
+        $2: String(errorDetails.errorCode),
+      })
+    } else {
+      detailsText = formatLocale(S.CHAT_UI_ERROR_NETWORK_STATUS_CODE, {
+        $1: String(errorDetails.statusCode),
+      })
+    }
+  }
+
   return (
     <div className={styles.alert}>
       <Alert type='error'>
         {getLocale(S.CHAT_UI_ERROR_NETWORK)}
+        {detailsText && (
+          <p className={styles.errorDetails}>
+            {detailsText}
+          </p>
+        )}
         <Button
           slot='actions'
           kind='filled'

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/alerts/error_connection.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/alerts/error_connection.tsx
@@ -36,11 +36,7 @@ function ErrorConnection(props: Props) {
     <div className={styles.alert}>
       <Alert type='error'>
         {getLocale(S.CHAT_UI_ERROR_NETWORK)}
-        {detailsText && (
-          <p className={styles.errorDetails}>
-            {detailsText}
-          </p>
-        )}
+        {detailsText && <p className={styles.errorDetails}>{detailsText}</p>}
         <Button
           slot='actions'
           kind='filled'

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/alerts/error_connection.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/alerts/error_connection.tsx
@@ -20,10 +20,10 @@ function ErrorConnection(props: Props) {
 
   let detailsText: string | undefined
   if (errorDetails) {
-    if (errorDetails.errorCode !== 0) {
+    if (errorDetails.errorType) {
       detailsText = formatLocale(S.CHAT_UI_ERROR_NETWORK_DETAILS, {
         $1: String(errorDetails.statusCode),
-        $2: String(errorDetails.errorCode),
+        $2: errorDetails.errorType,
       })
     } else {
       detailsText = formatLocale(S.CHAT_UI_ERROR_NETWORK_STATUS_CODE, {

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/conversation/index.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/conversation/index.tsx
@@ -104,6 +104,7 @@ function Conversation(props: ConversationProps) {
         currentErrorElement = (
           <ErrorConnection
             onRetry={() => context.conversationHandler.retryAPIRequest()}
+            errorDetails={state.currentErrorDetails}
           />
         )
         break

--- a/components/api_request_helper/api_request_helper.cc
+++ b/components/api_request_helper/api_request_helper.cc
@@ -359,7 +359,9 @@ void APIRequestHelper::URLLoaderHandler::RegisterURLLoader(
           }
           if (response_head.headers) {
             const auto code = response_head.headers->response_code();
-            handler->is_response_success_ = IsSuccessCode(code);
+            handler->is_response_fail_and_json_ =
+                !IsSuccessCode(code) &&
+                response_head.mime_type == "application/json";
           }
           if (handler->response_started_callback_) {
             std::move(handler->response_started_callback_)
@@ -398,10 +400,6 @@ void APIRequestHelper::URLLoaderHandler::OnDataReceived(
     base::OnceClosure resume) {
   DVLOG(2) << "[[" << __func__ << "]]" << " Chunk received";
   if (is_sse_) {
-    if (MaybeParseErrorBody(string_piece)) {
-      std::move(resume).Run();
-      return;
-    }
     ParseSSE(string_piece);
   } else {
     DVLOG(4) << "Chunk content: \n" << string_piece;
@@ -515,10 +513,7 @@ void APIRequestHelper::URLLoaderHandler::OnParseJsonResponse(
 
 bool APIRequestHelper::URLLoaderHandler::MaybeParseErrorBody(
     std::string_view string_piece) {
-  if (!is_response_success_.has_value() || *is_response_success_) {
-    return false;
-  }
-  if (!string_piece.starts_with('{') || !string_piece.ends_with('}')) {
+  if (!is_response_fail_and_json_.has_value() || !*is_response_fail_and_json_) {
     return false;
   }
   current_decoding_operation_count_++;

--- a/components/api_request_helper/api_request_helper.cc
+++ b/components/api_request_helper/api_request_helper.cc
@@ -38,6 +38,10 @@ namespace {
 
 const unsigned int kRetriesCountOnNetworkChange = 1;
 
+bool IsSuccessCode(int response_code) {
+  return response_code >= 200 && response_code <= 299;
+}
+
 void ParseJsonInWorkerTaskRunner(
     std::string json,
     base::SequencedTaskRunner* task_runner,
@@ -137,7 +141,7 @@ bool APIRequestResult::operator==(const APIRequestResult& other) const {
 }
 
 bool APIRequestResult::Is2XXResponseCode() const {
-  return response_code_ >= 200 && response_code_ <= 299;
+  return IsSuccessCode(response_code_);
 }
 
 bool APIRequestResult::IsResponseCodeValid() const {
@@ -353,6 +357,10 @@ void APIRequestHelper::URLLoaderHandler::RegisterURLLoader(
           if (response_head.mime_type == "text/event-stream") {
             handler->is_sse_ = true;
           }
+          if (response_head.headers) {
+            const auto code = response_head.headers->response_code();
+            handler->is_response_success_ = IsSuccessCode(code);
+          }
           if (handler->response_started_callback_) {
             std::move(handler->response_started_callback_)
                 .Run(final_url.spec(), response_head.content_length);
@@ -390,11 +398,19 @@ void APIRequestHelper::URLLoaderHandler::OnDataReceived(
     base::OnceClosure resume) {
   DVLOG(2) << "[[" << __func__ << "]]" << " Chunk received";
   if (is_sse_) {
+    if (MaybeParseErrorBody(string_piece)) {
+      std::move(resume).Run();
+      return;
+    }
     ParseSSE(string_piece);
   } else {
     DVLOG(4) << "Chunk content: \n" << string_piece;
     TRACE_EVENT0("brave", "APIRequestHelper_OnDataReceivedNoSSE");
     ScopedPerfTracker tracker("Brave.APIRequestHelper.OnDataReceivedNoSSE");
+    if (MaybeParseErrorBody(string_piece)) {
+      std::move(resume).Run();
+      return;
+    }
     data_received_callback_.Run(base::Value(string_piece));
   }
   // Get next chunk
@@ -497,6 +513,31 @@ void APIRequestHelper::URLLoaderHandler::OnParseJsonResponse(
   std::move(result_callback_).Run(std::move(result));
 }
 
+bool APIRequestHelper::URLLoaderHandler::MaybeParseErrorBody(
+    std::string_view string_piece) {
+  if (!is_response_success_.has_value() || *is_response_success_) {
+    return false;
+  }
+  if (!string_piece.starts_with('{') || !string_piece.ends_with('}')) {
+    return false;
+  }
+  current_decoding_operation_count_++;
+  ParseJsonImpl(
+      std::string(string_piece),
+      base::BindOnce(&APIRequestHelper::URLLoaderHandler::OnParseErrorBody,
+                     GetWeakPtr()));
+  return true;
+}
+
+void APIRequestHelper::URLLoaderHandler::OnParseErrorBody(
+    ValueOrError result_value) {
+  current_decoding_operation_count_--;
+  if (result_value.has_value() && result_value->is_dict()) {
+    error_value_ = std::move(*result_value);
+  }
+  MaybeSendResult();
+}
+
 void APIRequestHelper::URLLoaderHandler::MaybeSendResult() {
   // Verify that counting hasn't gone wrong - it should never be less than 0.
   DCHECK_LE(0, current_decoding_operation_count_);
@@ -508,7 +549,9 @@ void APIRequestHelper::URLLoaderHandler::MaybeSendResult() {
   const bool decoding_is_complete = (current_decoding_operation_count_ == 0);
 
   if (request_is_finished_ && decoding_is_complete) {
-    std::move(result_callback_).Run(ToAPIRequestResult(std::move(url_loader_)));
+    auto result = ToAPIRequestResult(std::move(url_loader_));
+    result.value_body_ = std::move(error_value_);
+    std::move(result_callback_).Run(std::move(result));
   } else if (decoding_is_complete) {
     VLOG(3) << "Did not run URLLoaderHandler completion handler, still have "
             << current_decoding_operation_count_

--- a/components/api_request_helper/api_request_helper.cc
+++ b/components/api_request_helper/api_request_helper.cc
@@ -517,7 +517,7 @@ void APIRequestHelper::URLLoaderHandler::OnParseJsonResponse(
 
 bool APIRequestHelper::URLLoaderHandler::MaybeAppendToErrorBodyBuffer(
     std::string_view string_piece) {
-  if (!is_response_fail_and_json_.has_value() || !*is_response_fail_and_json_) {
+  if (!is_response_fail_and_json_.value_or(false)) {
     return false;
   }
   error_body_buffer_.append(string_piece);

--- a/components/api_request_helper/api_request_helper.cc
+++ b/components/api_request_helper/api_request_helper.cc
@@ -405,7 +405,7 @@ void APIRequestHelper::URLLoaderHandler::OnDataReceived(
     DVLOG(4) << "Chunk content: \n" << string_piece;
     TRACE_EVENT0("brave", "APIRequestHelper_OnDataReceivedNoSSE");
     ScopedPerfTracker tracker("Brave.APIRequestHelper.OnDataReceivedNoSSE");
-    if (MaybeParseErrorBody(string_piece)) {
+    if (MaybeAppendToErrorBodyBuffer(string_piece)) {
       std::move(resume).Run();
       return;
     }
@@ -430,6 +430,10 @@ void APIRequestHelper::URLLoaderHandler::OnComplete(bool success) {
   // always end on a line boundary.
   sse_line_buffer_.clear();
   request_is_finished_ = true;
+
+  if (MaybeParseErrorBody()) {
+    return;
+  }
 
   // Delete now or when decoding operations are complete
   MaybeSendResult();
@@ -511,14 +515,21 @@ void APIRequestHelper::URLLoaderHandler::OnParseJsonResponse(
   std::move(result_callback_).Run(std::move(result));
 }
 
-bool APIRequestHelper::URLLoaderHandler::MaybeParseErrorBody(
+bool APIRequestHelper::URLLoaderHandler::MaybeAppendToErrorBodyBuffer(
     std::string_view string_piece) {
   if (!is_response_fail_and_json_.has_value() || !*is_response_fail_and_json_) {
     return false;
   }
-  current_decoding_operation_count_++;
+  error_body_buffer_.append(string_piece);
+  return true;
+}
+
+bool APIRequestHelper::URLLoaderHandler::MaybeParseErrorBody() {
+  if (error_body_buffer_.empty()) {
+    return false;
+  }
   ParseJsonImpl(
-      std::string(string_piece),
+      std::move(error_body_buffer_),
       base::BindOnce(&APIRequestHelper::URLLoaderHandler::OnParseErrorBody,
                      GetWeakPtr()));
   return true;
@@ -526,7 +537,6 @@ bool APIRequestHelper::URLLoaderHandler::MaybeParseErrorBody(
 
 void APIRequestHelper::URLLoaderHandler::OnParseErrorBody(
     ValueOrError result_value) {
-  current_decoding_operation_count_--;
   if (result_value.has_value() && result_value->is_dict()) {
     error_value_ = std::move(*result_value);
   }

--- a/components/api_request_helper/api_request_helper.h
+++ b/components/api_request_helper/api_request_helper.h
@@ -154,9 +154,14 @@ class APIRequestHelper {
 
     void OnParseErrorBody(ValueOrError result_value);
 
-    // If response is non-2xx and string_piece looks like JSON, kick off async
-    // parse into error_value_. Returns true if handled (caller should return).
-    bool MaybeParseErrorBody(std::string_view string_piece);
+    // If response is non-2xx, appends string_piece to error_body_buffer_.
+    // Returns true if handled (caller should skip normal data dispatch).
+    bool MaybeAppendToErrorBodyBuffer(std::string_view string_piece);
+
+    // If response is non-2xx and error_body_buffer_ looks like JSON, kick off
+    // async parse into error_value_. Returns true if handled (caller should
+    // return).
+    bool MaybeParseErrorBody();
 
     std::unique_ptr<network::SimpleURLLoader> url_loader_;
     raw_ptr<APIRequestHelper> api_request_helper_;
@@ -172,6 +177,10 @@ class APIRequestHelper {
 
     // Buffer for partial SSE lines across OnDataReceived calls.
     std::string sse_line_buffer_;
+
+    // Buffer for accumulating error response body chunks across OnDataReceived
+    // calls. Parsed in OnComplete via MaybeParseErrorBody.
+    std::string error_body_buffer_;
 
     // Keep track of number of in-progress data decoding operations
     // so that we can know if any are still in-progress when the request

--- a/components/api_request_helper/api_request_helper.h
+++ b/components/api_request_helper/api_request_helper.h
@@ -167,7 +167,7 @@ class APIRequestHelper {
     ResponseConversionCallback conversion_callback_;
 
     bool is_sse_ = false;
-    std::optional<bool> is_response_success_;
+    std::optional<bool> is_response_fail_and_json_;
     base::Value error_value_;
 
     // Buffer for partial SSE lines across OnDataReceived calls.

--- a/components/api_request_helper/api_request_helper.h
+++ b/components/api_request_helper/api_request_helper.h
@@ -152,6 +152,12 @@ class APIRequestHelper {
     void OnParseJsonResponse(APIRequestResult result,
                              ValueOrError result_value);
 
+    void OnParseErrorBody(ValueOrError result_value);
+
+    // If response is non-2xx and string_piece looks like JSON, kick off async
+    // parse into error_value_. Returns true if handled (caller should return).
+    bool MaybeParseErrorBody(std::string_view string_piece);
+
     std::unique_ptr<network::SimpleURLLoader> url_loader_;
     raw_ptr<APIRequestHelper> api_request_helper_;
 
@@ -161,6 +167,8 @@ class APIRequestHelper {
     ResponseConversionCallback conversion_callback_;
 
     bool is_sse_ = false;
+    std::optional<bool> is_response_success_;
+    base::Value error_value_;
 
     // Buffer for partial SSE lines across OnDataReceived calls.
     std::string sse_line_buffer_;

--- a/components/api_request_helper/api_request_helper_unittest.cc
+++ b/components/api_request_helper/api_request_helper_unittest.cc
@@ -61,10 +61,11 @@ class ApiRequestHelperUnitTest : public testing::Test {
   void SetInterceptor(const std::string& expected_method,
                       const GURL& expected_url,
                       const std::string& content_to_respond,
-                      bool enable_cache) {
+                      bool enable_cache,
+                      net::HttpStatusCode status = net::HTTP_OK) {
     url_loader_factory_.SetInterceptor(base::BindLambdaForTesting(
-        [&, expected_method, expected_url, content_to_respond,
-         enable_cache](const network::ResourceRequest& request) {
+        [&, expected_method, expected_url, content_to_respond, enable_cache,
+         status](const network::ResourceRequest& request) {
           url_loader_factory_.ClearResponses();
           EXPECT_EQ(request.url, expected_url);
           EXPECT_EQ(request.method, expected_method);
@@ -76,7 +77,7 @@ class ApiRequestHelperUnitTest : public testing::Test {
                                               net::LOAD_DISABLE_CACHE);
           }
           url_loader_factory_.AddResponse(request.url.spec(),
-                                          content_to_respond);
+                                          content_to_respond, status);
         }));
   }
 
@@ -371,6 +372,28 @@ TEST_F(ApiRequestHelperUnitTest, SSEJsonParsingEscapedDoubleLineBreaks) {
                            loop->Quit();
                          },
                          &run_loop));
+  run_loop.Run();
+}
+
+TEST_F(ApiRequestHelperUnitTest, SSE400WithJsonErrorBody) {
+  SetInterceptor("POST", GURL("http://localhost/"),
+                 R"({"error":{"type":1234,"message":"bad"}})", false,
+                 net::HTTP_BAD_REQUEST);
+
+  base::RunLoop run_loop;
+  api_request_helper_->RequestSSE(
+      "POST", GURL("http://localhost/"), "", "application/json",
+      base::BindRepeating([](ValueOrError) { ADD_FAILURE(); }),
+      base::BindLambdaForTesting([&](APIRequestResult result) {
+        EXPECT_FALSE(result.Is2XXResponseCode());
+        EXPECT_EQ(result.response_code(), 400);
+        ASSERT_TRUE(result.value_body().is_dict());
+        const auto* error = result.value_body().GetDict().FindDict("error");
+        ASSERT_TRUE(error);
+        EXPECT_EQ(error->FindInt("type"), std::optional<int>(1234));
+        run_loop.Quit();
+      }),
+      {}, {});
   run_loop.Run();
 }
 

--- a/components/api_request_helper/api_request_helper_unittest.cc
+++ b/components/api_request_helper/api_request_helper_unittest.cc
@@ -17,9 +17,13 @@
 #include "base/test/values_test_util.h"
 #include "base/values.h"
 #include "net/base/load_flags.h"
+#include "net/http/http_response_headers.h"
+#include "net/http/http_status_code.h"
 #include "net/traffic_annotation/network_traffic_annotation.h"
 #include "net/traffic_annotation/network_traffic_annotation_test_helper.h"
+#include "services/network/public/cpp/url_loader_completion_status.h"
 #include "services/network/public/cpp/weak_wrapper_shared_url_loader_factory.h"
+#include "services/network/public/mojom/url_response_head.mojom.h"
 #include "services/network/test/test_url_loader_factory.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
@@ -62,10 +66,11 @@ class ApiRequestHelperUnitTest : public testing::Test {
                       const GURL& expected_url,
                       const std::string& content_to_respond,
                       bool enable_cache,
-                      net::HttpStatusCode status = net::HTTP_OK) {
+                      net::HttpStatusCode status = net::HTTP_OK,
+                      std::optional<std::string> content_type = std::nullopt) {
     url_loader_factory_.SetInterceptor(base::BindLambdaForTesting(
         [&, expected_method, expected_url, content_to_respond, enable_cache,
-         status](const network::ResourceRequest& request) {
+         status, content_type](const network::ResourceRequest& request) {
           url_loader_factory_.ClearResponses();
           EXPECT_EQ(request.url, expected_url);
           EXPECT_EQ(request.method, expected_method);
@@ -76,8 +81,21 @@ class ApiRequestHelperUnitTest : public testing::Test {
                                               net::LOAD_BYPASS_CACHE |
                                               net::LOAD_DISABLE_CACHE);
           }
-          url_loader_factory_.AddResponse(request.url.spec(),
-                                          content_to_respond, status);
+          if (content_type) {
+            auto head = network::mojom::URLResponseHead::New();
+            head->headers = base::MakeRefCounted<net::HttpResponseHeaders>("");
+            head->headers->ReplaceStatusLine(
+                "HTTP/1.1 " + base::NumberToString(static_cast<int>(status)) +
+                " " + std::string(net::GetHttpReasonPhrase(status)));
+            head->headers->SetHeader("Content-Type", *content_type);
+            head->mime_type = *content_type;
+            url_loader_factory_.AddResponse(
+                request.url, std::move(head), content_to_respond,
+                network::URLLoaderCompletionStatus(net::OK));
+          } else {
+            url_loader_factory_.AddResponse(request.url.spec(),
+                                            content_to_respond, status);
+          }
         }));
   }
 
@@ -378,7 +396,7 @@ TEST_F(ApiRequestHelperUnitTest, SSEJsonParsingEscapedDoubleLineBreaks) {
 TEST_F(ApiRequestHelperUnitTest, SSE400WithJsonErrorBody) {
   SetInterceptor("POST", GURL("http://localhost/"),
                  R"({"error":{"type":1234,"message":"bad"}})", false,
-                 net::HTTP_BAD_REQUEST);
+                 net::HTTP_BAD_REQUEST, "application/json");
 
   base::RunLoop run_loop;
   api_request_helper_->RequestSSE(

--- a/components/resources/ai_chat_ui_strings.grdp
+++ b/components/resources/ai_chat_ui_strings.grdp
@@ -72,8 +72,14 @@
   <message name="IDS_CUSTOM_MODEL_ENDPOINT_INVALID_ERROR" desc="An error presented when the model endpoint is invalid" formatter_data="webui=AiChat">
     This model has an invalid endpoint. Please check your configuration and try again.
   </message>
-  <message name="IDS_CHAT_UI_ERROR_NETWORK" desc="An error presented when there is a network issue in the UI" formatter_data="webui=AiChat">
-     There was a network issue connecting to Leo, check your connection and try again.
+  <message name="IDS_CHAT_UI_ERROR_NETWORK" desc="An error presented when a request to Leo fails due to a network or server issue" formatter_data="webui=AiChat">
+     Something went wrong while communicating with Leo. Please try again.
+  </message>
+  <message name="IDS_CHAT_UI_ERROR_NETWORK_DETAILS" desc="Error details showing HTTP status code and API error code" formatter_data="webui=AiChat">
+    Status code: <ph name="STATUS_CODE">$1<ex>500</ex></ph>, error code: <ph name="ERROR_CODE">$2<ex>1234</ex></ph>
+  </message>
+  <message name="IDS_CHAT_UI_ERROR_NETWORK_STATUS_CODE" desc="Error details showing only HTTP status code when no API error code is available" formatter_data="webui=AiChat">
+    Status code: <ph name="STATUS_CODE">$1<ex>500</ex></ph>
   </message>
   <message name="IDS_CHAT_UI_ERROR_RATE_LIMIT" desc="An error presented when the user has exhausted the API request limit" formatter_data="webui=AiChat">
     You've reached the premium rate limit. Please try again in a few hours.


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/55483

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

[
<img width="378" height="314" alt="Screenshot-2026-05-12_20-14" src="https://github.com/user-attachments/assets/0d9689ae-672f-4212-b3c9-6ca80b475ace" />
](url)

## Test plan

Use a MITM proxy to intercept requests to ai-chat.bsg.brave.com. When the request is intercepted, modify the request body to contain invalid JSON. Release the request to the server and ensure you see a status code and error code in the error bubble.