### PR TITLE
Remove padding around container page action icon and text

### DIFF
--- a/browser/ui/views/page_action/page_action_view_unittest.cc
+++ b/browser/ui/views/page_action/page_action_view_unittest.cc
@@ -266,4 +266,26 @@ TEST_F(PageActionViewTest, OverrideBackgroundColorReturnsModelValue) {
   EXPECT_EQ(page_action_view()->GetBackgroundColor(), SK_ColorRED);
 }
 
+TEST_F(PageActionViewTest, OverrideBorderReturnsModelValue) {
+  EXPECT_CALL(*model(), GetOverrideBorder())
+      .WillRepeatedly(
+          Return(std::optional<gfx::Insets>(gfx::Insets::TLBR(1, 2, 3, 4))));
+
+  page_action_view()->OnPageActionModelChanged(*model());
+
+  EXPECT_EQ(page_action_view()->GetBorder()->GetInsets(),
+            gfx::Insets::TLBR(1, 2, 3, 4));
+
+  testing::Mock::VerifyAndClearExpectations(model());
+
+  // Even empty border should be respected
+  EXPECT_CALL(*model(), GetOverrideBorder())
+      .WillRepeatedly(Return(std::optional<gfx::Insets>(gfx::Insets())));
+
+  page_action_view()->OnPageActionModelChanged(*model());
+
+  EXPECT_EQ(page_action_view()->GetBorder()->GetInsets(),
+            gfx::Insets::TLBR(0, 0, 0, 0));
+}
+
 }  // namespace page_actions

--- a/browser/ui/views/page_action/partitioned_storage_page_action_controller.cc
+++ b/browser/ui/views/page_action/partitioned_storage_page_action_controller.cc
@@ -178,6 +178,7 @@ void PartitionedStoragePageActionController::UpdatePageAction() {
     page_action_controller_->ClearOverrideHeight(kActionShowPartitionedStorage);
     page_action_controller_->SetOverrideTriggerableEvent(
         kActionShowPartitionedStorage, std::nullopt);
+    page_action_controller_->ClearOverrideBorder(kActionShowPartitionedStorage);
     return;
   }
 
@@ -207,6 +208,10 @@ void PartitionedStoragePageActionController::UpdatePageAction() {
   page_action_controller_->SetOverrideHeight(kActionShowPartitionedStorage, 20);
   page_action_controller_->SetOverrideTriggerableEvent(
       kActionShowPartitionedStorage, ui::EF_RIGHT_MOUSE_BUTTON);
+  // Sets empty insets so that we can get rid of additional padding around icon
+  // and text.
+  page_action_controller_->SetOverrideBorder(kActionShowPartitionedStorage,
+                                             gfx::Insets());
 }
 
 void PartitionedStoragePageActionController::OnPartitionedStorageMenuClosed() {

--- a/chromium_src/chrome/browser/ui/page_actions/page_action_controller.cc
+++ b/chromium_src/chrome/browser/ui/page_actions/page_action_controller.cc
@@ -52,6 +52,16 @@ void PageActionControllerImpl::SetOverrideTriggerableEvent(
       PageActionPassKey(), event_flags);
 }
 
+void PageActionControllerImpl::SetOverrideBorder(actions::ActionId action_id,
+                                                 const gfx::Insets& border) {
+  FindPageActionModel(action_id).SetOverrideBorder(PassKey(), border);
+}
+
+void PageActionControllerImpl::ClearOverrideBorder(
+    actions::ActionId action_id) {
+  FindPageActionModel(action_id).SetOverrideBorder(PassKey(), std::nullopt);
+}
+
 std::unique_ptr<PageActionModelInterface> PageActionControllerImpl::CreateModel(
     actions::ActionId action_id,
     bool is_ephemeral) {

--- a/chromium_src/chrome/browser/ui/page_actions/page_action_controller.cc
+++ b/chromium_src/chrome/browser/ui/page_actions/page_action_controller.cc
@@ -54,12 +54,13 @@ void PageActionControllerImpl::SetOverrideTriggerableEvent(
 
 void PageActionControllerImpl::SetOverrideBorder(actions::ActionId action_id,
                                                  const gfx::Insets& border) {
-  FindPageActionModel(action_id).SetOverrideBorder(PassKey(), border);
+  FindPageActionModel(action_id).SetOverrideBorder(PageActionPassKey(), border);
 }
 
 void PageActionControllerImpl::ClearOverrideBorder(
     actions::ActionId action_id) {
-  FindPageActionModel(action_id).SetOverrideBorder(PassKey(), std::nullopt);
+  FindPageActionModel(action_id).SetOverrideBorder(PageActionPassKey(),
+                                                   std::nullopt);
 }
 
 std::unique_ptr<PageActionModelInterface> PageActionControllerImpl::CreateModel(

--- a/chromium_src/chrome/browser/ui/page_actions/page_action_controller.h
+++ b/chromium_src/chrome/browser/ui/page_actions/page_action_controller.h
@@ -6,6 +6,10 @@
 #ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_PAGE_ACTIONS_PAGE_ACTION_CONTROLLER_H_
 #define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_PAGE_ACTIONS_PAGE_ACTION_CONTROLLER_H_
 
+namespace gfx {
+class Insets;
+}  // namespace gfx
+
 namespace page_actions {
 class PageActionControllerImpl;
 }  // namespace page_actions
@@ -32,6 +36,9 @@ class PageActionControllerImpl
   void ClearOverrideHeight(actions::ActionId action_id);
   void SetOverrideTriggerableEvent(actions::ActionId action_id,
                                    std::optional<int> event_flags);
+  void SetOverrideBorder(actions::ActionId action_id,
+                         const gfx::Insets& border);
+  void ClearOverrideBorder(actions::ActionId action_id);
 
   // chromium_impl::PageActionControllerImpl:
   std::unique_ptr<PageActionModelInterface> CreateModel(

--- a/chromium_src/chrome/browser/ui/page_actions/page_action_model.cc
+++ b/chromium_src/chrome/browser/ui/page_actions/page_action_model.cc
@@ -69,7 +69,7 @@ std::optional<int> PageActionModel::GetOverrideTriggerableEvent() const {
   return override_triggerable_event_flags_;
 }
 
-void PageActionModel::SetOverrideBorder(base::PassKey<PageActionController>,
+void PageActionModel::SetOverrideBorder(PageActionPassKey,
                                         std::optional<gfx::Insets> border) {
   if (override_border_ == border) {
     return;

--- a/chromium_src/chrome/browser/ui/page_actions/page_action_model.cc
+++ b/chromium_src/chrome/browser/ui/page_actions/page_action_model.cc
@@ -69,4 +69,18 @@ std::optional<int> PageActionModel::GetOverrideTriggerableEvent() const {
   return override_triggerable_event_flags_;
 }
 
+void PageActionModel::SetOverrideBorder(
+    base::PassKey<PageActionController>,
+    const std::optional<gfx::Insets>& border) {
+  if (override_border_ == border) {
+    return;
+  }
+  override_border_ = border;
+  NotifyChange(Property::kOverrideBorder);
+}
+
+std::optional<gfx::Insets> PageActionModel::GetOverrideBorder() const {
+  return override_border_;
+}
+
 }  // namespace page_actions

--- a/chromium_src/chrome/browser/ui/page_actions/page_action_model.cc
+++ b/chromium_src/chrome/browser/ui/page_actions/page_action_model.cc
@@ -69,9 +69,8 @@ std::optional<int> PageActionModel::GetOverrideTriggerableEvent() const {
   return override_triggerable_event_flags_;
 }
 
-void PageActionModel::SetOverrideBorder(
-    base::PassKey<PageActionController>,
-    const std::optional<gfx::Insets>& border) {
+void PageActionModel::SetOverrideBorder(base::PassKey<PageActionController>,
+                                        std::optional<gfx::Insets> border) {
   if (override_border_ == border) {
     return;
   }

--- a/chromium_src/chrome/browser/ui/page_actions/page_action_model.h
+++ b/chromium_src/chrome/browser/ui/page_actions/page_action_model.h
@@ -6,6 +6,8 @@
 #ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_PAGE_ACTIONS_PAGE_ACTION_MODEL_H_
 #define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_PAGE_ACTIONS_PAGE_ACTION_MODEL_H_
 
+#include "ui/gfx/geometry/insets.h"
+
 namespace page_actions {
 class PageActionModel;
 }  // namespace page_actions
@@ -32,11 +34,14 @@ class PageActionModel : public chromium_impl::PageActionModel {
                          std::optional<int> height_px) override;
   void SetOverrideTriggerableEvent(PageActionPassKey,
                                    std::optional<int> event_flags) override;
+  void SetOverrideBorder(base::PassKey<PageActionController>,
+                         const std::optional<gfx::Insets>& border) override;
   std::optional<SkColor> GetOverrideBackgroundColor() const override;
   std::optional<SkColor> GetOverrideForegroundColor() const override;
   bool GetAlwaysShowLabel() const override;
   std::optional<int> GetOverrideHeight() const override;
   std::optional<int> GetOverrideTriggerableEvent() const override;
+  std::optional<gfx::Insets> GetOverrideBorder() const override;
 
  private:
   std::optional<SkColor> override_background_color_;
@@ -44,6 +49,7 @@ class PageActionModel : public chromium_impl::PageActionModel {
   bool always_show_label_ = false;
   std::optional<int> override_height_;
   std::optional<int> override_triggerable_event_flags_;
+  std::optional<gfx::Insets> override_border_;
 };
 
 }  // namespace page_actions

--- a/chromium_src/chrome/browser/ui/page_actions/page_action_model.h
+++ b/chromium_src/chrome/browser/ui/page_actions/page_action_model.h
@@ -35,7 +35,7 @@ class PageActionModel : public chromium_impl::PageActionModel {
   void SetOverrideTriggerableEvent(PageActionPassKey,
                                    std::optional<int> event_flags) override;
   void SetOverrideBorder(base::PassKey<PageActionController>,
-                         const std::optional<gfx::Insets>& border) override;
+                         std::optional<gfx::Insets> border) override;
   std::optional<SkColor> GetOverrideBackgroundColor() const override;
   std::optional<SkColor> GetOverrideForegroundColor() const override;
   bool GetAlwaysShowLabel() const override;

--- a/chromium_src/chrome/browser/ui/page_actions/page_action_model.h
+++ b/chromium_src/chrome/browser/ui/page_actions/page_action_model.h
@@ -34,7 +34,7 @@ class PageActionModel : public chromium_impl::PageActionModel {
                          std::optional<int> height_px) override;
   void SetOverrideTriggerableEvent(PageActionPassKey,
                                    std::optional<int> event_flags) override;
-  void SetOverrideBorder(base::PassKey<PageActionController>,
+  void SetOverrideBorder(PageActionPassKey,
                          std::optional<gfx::Insets> border) override;
   std::optional<SkColor> GetOverrideBackgroundColor() const override;
   std::optional<SkColor> GetOverrideForegroundColor() const override;

--- a/chromium_src/chrome/browser/ui/page_actions/test_support/mock_page_action_model.h
+++ b/chromium_src/chrome/browser/ui/page_actions/test_support/mock_page_action_model.h
@@ -48,8 +48,7 @@ class MockPageActionModel : public MockPageActionModel_Chromium {
               (const, override));
   MOCK_METHOD(void,
               SetOverrideBorder,
-              (base::PassKey<PageActionController>,
-               const std::optional<gfx::Insets>&),
+              (PageActionPassKey, std::optional<gfx::Insets>),
               (override));
   MOCK_METHOD(std::optional<gfx::Insets>,
               GetOverrideBorder,

--- a/chromium_src/chrome/browser/ui/page_actions/test_support/mock_page_action_model.h
+++ b/chromium_src/chrome/browser/ui/page_actions/test_support/mock_page_action_model.h
@@ -46,6 +46,15 @@ class MockPageActionModel : public MockPageActionModel_Chromium {
               GetOverrideTriggerableEvent,
               (),
               (const, override));
+  MOCK_METHOD(void,
+              SetOverrideBorder,
+              (base::PassKey<PageActionController>,
+               const std::optional<gfx::Insets>&),
+              (override));
+  MOCK_METHOD(std::optional<gfx::Insets>,
+              GetOverrideBorder,
+              (),
+              (const, override));
 };
 
 }  // namespace page_actions

--- a/chromium_src/chrome/browser/ui/views/page_action/page_action_view.cc
+++ b/chromium_src/chrome/browser/ui/views/page_action/page_action_view.cc
@@ -15,16 +15,30 @@
 #include "ui/views/style/platform_style.h"
 #include "ui/views/view_class_properties.h"
 
+namespace {
+
+void MaybeOverrideBorder(const page_actions::PageActionModelInterface* source,
+                         gfx::Insets& border_insets) {
+  if (source && source->GetOverrideBorder().has_value()) {
+    border_insets = source->GetOverrideBorder().value();
+  }
+}
+
+}  // namespace
+
 #define GetMinimumSize GetMinimumSize_Chromium
 #define OnNewActiveController OnNewActiveController_Chromium
 #define OnPageActionModelChanged OnPageActionModelChanged_Chromium
-#define UpdateBorder UpdateBorder_Chromium
+#define BRAVE_PAGE_ACTION_VIEW_UPDATE_BORDER                           \
+  MaybeOverrideBorder(                                                 \
+      observation_.IsObserving() ? observation_.GetSource() : nullptr, \
+      border_insets);
 
 // Want to use default color even it's expanded.
 #define SetUseTonalColorsWhenExpanded(...) SetUseTonalColorsWhenExpanded(false)
 #include <chrome/browser/ui/views/page_action/page_action_view.cc>
 
-#undef UpdateBorder
+#undef BRAVE_PAGE_ACTION_VIEW_UPDATE_BORDER
 #undef SetUseTonalColorsWhenExpanded
 #undef OnPageActionModelChanged
 #undef OnNewActiveController
@@ -158,15 +172,6 @@ void PageActionView::OnPageActionModelChanged(
         ui::EF_LEFT_MOUSE_BUTTON));
   }
   UpdateBorder();
-}
-
-void PageActionView::UpdateBorder() {
-  const PageActionModelInterface* source = observation_.GetSource();
-  if (source && source->GetOverrideBorder().has_value()) {
-    SetBorder(views::CreateEmptyBorder(source->GetOverrideBorder().value()));
-  } else {
-    UpdateBorder_Chromium();
-  }
 }
 
 }  // namespace page_actions

--- a/chromium_src/chrome/browser/ui/views/page_action/page_action_view.cc
+++ b/chromium_src/chrome/browser/ui/views/page_action/page_action_view.cc
@@ -18,11 +18,13 @@
 #define GetMinimumSize GetMinimumSize_Chromium
 #define OnNewActiveController OnNewActiveController_Chromium
 #define OnPageActionModelChanged OnPageActionModelChanged_Chromium
+#define UpdateBorder UpdateBorder_Chromium
 
 // Want to use default color even it's expanded.
 #define SetUseTonalColorsWhenExpanded(...) SetUseTonalColorsWhenExpanded(false)
 #include <chrome/browser/ui/views/page_action/page_action_view.cc>
 
+#undef UpdateBorder
 #undef SetUseTonalColorsWhenExpanded
 #undef OnPageActionModelChanged
 #undef OnNewActiveController
@@ -71,6 +73,8 @@ void PageActionView::OnPageActionModelVisualRefresh(
   } else {
     ClearProperty(views::kCrossAxisAlignmentKey);
   }
+
+  UpdateBorder();
 }
 
 gfx::Size PageActionView::GetSizeForLabelWidth(int label_width) const {
@@ -152,6 +156,16 @@ void PageActionView::OnPageActionModelChanged(
     // class.
     SetTriggerableEventFlags(source->GetOverrideTriggerableEvent().value_or(
         ui::EF_LEFT_MOUSE_BUTTON));
+  }
+  UpdateBorder();
+}
+
+void PageActionView::UpdateBorder() {
+  const PageActionModelInterface* source = observation_.GetSource();
+  if (source && source->GetOverrideBorder().has_value()) {
+    SetBorder(views::CreateEmptyBorder(source->GetOverrideBorder().value()));
+  } else {
+    UpdateBorder_Chromium();
   }
 }
 

--- a/chromium_src/chrome/browser/ui/views/page_action/page_action_view.cc
+++ b/chromium_src/chrome/browser/ui/views/page_action/page_action_view.cc
@@ -29,16 +29,11 @@ void MaybeOverrideBorder(const page_actions::PageActionModelInterface* source,
 #define GetMinimumSize GetMinimumSize_Chromium
 #define OnNewActiveController OnNewActiveController_Chromium
 #define OnPageActionModelChanged OnPageActionModelChanged_Chromium
-#define BRAVE_PAGE_ACTION_VIEW_UPDATE_BORDER                           \
-  MaybeOverrideBorder(                                                 \
-      observation_.IsObserving() ? observation_.GetSource() : nullptr, \
-      border_insets);
 
 // Want to use default color even it's expanded.
 #define SetUseTonalColorsWhenExpanded(...) SetUseTonalColorsWhenExpanded(false)
 #include <chrome/browser/ui/views/page_action/page_action_view.cc>
 
-#undef BRAVE_PAGE_ACTION_VIEW_UPDATE_BORDER
 #undef SetUseTonalColorsWhenExpanded
 #undef OnPageActionModelChanged
 #undef OnNewActiveController

--- a/chromium_src/chrome/browser/ui/views/page_action/page_action_view.h
+++ b/chromium_src/chrome/browser/ui/views/page_action/page_action_view.h
@@ -47,14 +47,8 @@
   OnNewActiveController_Chromium(__VA_ARGS__); \
   void OnNewActiveController(__VA_ARGS__)
 
-// Wrapper for UpdateBorder()
-#define UpdateBorder()     \
-  UpdateBorder_Chromium(); \
-  void UpdateBorder()
-
 #include <chrome/browser/ui/views/page_action/page_action_view.h>  // IWYU pragma: export
 
-#undef UpdateBorder
 #undef OnNewActiveController
 #undef GetMinimumSize
 #undef OnPageActionModelChanged

--- a/chromium_src/chrome/browser/ui/views/page_action/page_action_view.h
+++ b/chromium_src/chrome/browser/ui/views/page_action/page_action_view.h
@@ -47,8 +47,14 @@
   OnNewActiveController_Chromium(__VA_ARGS__); \
   void OnNewActiveController(__VA_ARGS__)
 
+// Wrapper for UpdateBorder()
+#define UpdateBorder()     \
+  UpdateBorder_Chromium(); \
+  void UpdateBorder()
+
 #include <chrome/browser/ui/views/page_action/page_action_view.h>  // IWYU pragma: export
 
+#undef UpdateBorder
 #undef OnNewActiveController
 #undef GetMinimumSize
 #undef OnPageActionModelChanged

--- a/patches/chrome-browser-ui-page_actions-page_action_model.h.patch
+++ b/patches/chrome-browser-ui-page_actions-page_action_model.h.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/ui/page_actions/page_action_model.h b/chrome/browser/ui/page_actions/page_action_model.h
-index 7dacb805a0c88fc8d78095f29550e70375639634..28a79f70b714d67e22db2432c93735f45b6269c5 100644
+index 7dacb805a0c88fc8d78095f29550e70375639634..a8bb1e8007b1bf5ed6fc755084cc6e21bae7058e 100644
 --- a/chrome/browser/ui/page_actions/page_action_model.h
 +++ b/chrome/browser/ui/page_actions/page_action_model.h
 @@ -118,9 +118,28 @@ class PageActionModelInterface {
@@ -16,7 +16,7 @@ index 7dacb805a0c88fc8d78095f29550e70375639634..28a79f70b714d67e22db2432c93735f4
 +                                 std::optional<int> height) = 0;
 +  virtual void SetOverrideTriggerableEvent(PageActionPassKey,
 +                                           std::optional<int> event_flags) = 0;
-+  virtual void SetOverrideBorder(base::PassKey<PageActionController>,
++  virtual void SetOverrideBorder(PageActionPassKey,
 +                                 std::optional<gfx::Insets> border) = 0;
 +  virtual std::optional<SkColor> GetOverrideBackgroundColor() const = 0;
 +  virtual std::optional<SkColor> GetOverrideForegroundColor() const = 0;

--- a/patches/chrome-browser-ui-page_actions-page_action_model.h.patch
+++ b/patches/chrome-browser-ui-page_actions-page_action_model.h.patch
@@ -16,11 +16,14 @@ index 7dacb805a0c88fc8d78095f29550e70375639634..3924212242cd280f61a77fe97bf2c833
 +                                 std::optional<int> height) = 0;
 +  virtual void SetOverrideTriggerableEvent(PageActionPassKey,
 +                                           std::optional<int> event_flags) = 0;
++  virtual void SetOverrideBorder(base::PassKey<PageActionController>,
++                                 const std::optional<gfx::Insets>& border) = 0;
 +  virtual std::optional<SkColor> GetOverrideBackgroundColor() const = 0;
 +  virtual std::optional<SkColor> GetOverrideForegroundColor() const = 0;
 +  virtual bool GetAlwaysShowLabel() const = 0;
 +  virtual std::optional<int> GetOverrideHeight() const = 0;
 +  virtual std::optional<int> GetOverrideTriggerableEvent() const = 0;
++  virtual std::optional<gfx::Insets> GetOverrideBorder() const = 0;
  };
  
  // PageActionModel represents the page action's state, scoped to a single tab.
@@ -45,7 +48,8 @@ index 7dacb805a0c88fc8d78095f29550e70375639634..3924212242cd280f61a77fe97bf2c833
 +    kOverrideChipColors,
 +    kOverrideHeight,
 +    kOverrideTriggerableEvent,
-+    kMaxValue = kOverrideTriggerableEvent,
++    kOverrideBorder,
++    kMaxValue = kOverrideBorder,
    };
    using PropertySet =
        base::EnumSet<Property, Property::kShowRequested, Property::kMaxValue>;

--- a/patches/chrome-browser-ui-page_actions-page_action_model.h.patch
+++ b/patches/chrome-browser-ui-page_actions-page_action_model.h.patch
@@ -1,8 +1,8 @@
 diff --git a/chrome/browser/ui/page_actions/page_action_model.h b/chrome/browser/ui/page_actions/page_action_model.h
-index 7dacb805a0c88fc8d78095f29550e70375639634..3924212242cd280f61a77fe97bf2c83353aff35b 100644
+index 7dacb805a0c88fc8d78095f29550e70375639634..28a79f70b714d67e22db2432c93735f45b6269c5 100644
 --- a/chrome/browser/ui/page_actions/page_action_model.h
 +++ b/chrome/browser/ui/page_actions/page_action_model.h
-@@ -118,9 +118,25 @@ class PageActionModelInterface {
+@@ -118,9 +118,28 @@ class PageActionModelInterface {
    virtual PageActionColorSource GetColorSource() const = 0;
  
    virtual bool IsEphemeral() const = 0;
@@ -17,7 +17,7 @@ index 7dacb805a0c88fc8d78095f29550e70375639634..3924212242cd280f61a77fe97bf2c833
 +  virtual void SetOverrideTriggerableEvent(PageActionPassKey,
 +                                           std::optional<int> event_flags) = 0;
 +  virtual void SetOverrideBorder(base::PassKey<PageActionController>,
-+                                 const std::optional<gfx::Insets>& border) = 0;
++                                 std::optional<gfx::Insets> border) = 0;
 +  virtual std::optional<SkColor> GetOverrideBackgroundColor() const = 0;
 +  virtual std::optional<SkColor> GetOverrideForegroundColor() const = 0;
 +  virtual bool GetAlwaysShowLabel() const = 0;
@@ -31,7 +31,7 @@ index 7dacb805a0c88fc8d78095f29550e70375639634..3924212242cd280f61a77fe97bf2c833
  class PageActionModel : public PageActionModelInterface {
   public:
    explicit PageActionModel(actions::ActionId action_id,
-@@ -217,6 +233,7 @@ class PageActionModel : public PageActionModelInterface {
+@@ -217,6 +236,7 @@ class PageActionModel : public PageActionModelInterface {
    bool IsEphemeral() const override;
  
   private:
@@ -39,7 +39,7 @@ index 7dacb805a0c88fc8d78095f29550e70375639634..3924212242cd280f61a77fe97bf2c833
    // Identifies which property triggered a NotifyChange call, used for
    // per-property reentrancy checks.
    enum class Property {
-@@ -239,7 +256,11 @@ class PageActionModel : public PageActionModelInterface {
+@@ -239,7 +259,12 @@ class PageActionModel : public PageActionModelInterface {
      kAnchoredMessageActionIcon,
      kIsAnchoredMessageShowing,
      kAnchoredMessageIcon,
@@ -53,7 +53,7 @@ index 7dacb805a0c88fc8d78095f29550e70375639634..3924212242cd280f61a77fe97bf2c833
    };
    using PropertySet =
        base::EnumSet<Property, Property::kShowRequested, Property::kMaxValue>;
-@@ -339,6 +360,7 @@ class PageActionModel : public PageActionModelInterface {
+@@ -339,6 +364,7 @@ class PageActionModel : public PageActionModelInterface {
  
    base::ObserverList<PageActionModelObserver> observer_list_;
  };

--- a/patches/chrome-browser-ui-views-page_action-page_action_view.cc.patch
+++ b/patches/chrome-browser-ui-views-page_action-page_action_view.cc.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/ui/views/page_action/page_action_view.cc b/chrome/browser/ui/views/page_action/page_action_view.cc
-index 271f5b9adba10ee60aa45b4c00e1bfb541fd05fd..1a20372af0948f87a8d94a99ea287c039e10d126 100644
+index 271f5b9adba10ee60aa45b4c00e1bfb541fd05fd..a6f93e9b26b636b5aaf16555a6487500b9ecb33e 100644
 --- a/chrome/browser/ui/views/page_action/page_action_view.cc
 +++ b/chrome/browser/ui/views/page_action/page_action_view.cc
 @@ -167,7 +167,7 @@ void PageActionView::OnPageActionModelChanged(
@@ -11,3 +11,11 @@ index 271f5b9adba10ee60aa45b4c00e1bfb541fd05fd..1a20372af0948f87a8d94a99ea287c03
      if (model.GetShouldAnimateChipIn()) {
        AnimateIn(/*string_id=*/std::nullopt);
      } else {
+@@ -232,6 +232,7 @@ void PageActionView::UpdateBorder() {
+       !observation_.GetSource()->GetImage().IsVectorIcon()) {
+     border_insets = GetInsetsForNonVectorIcon();
+   }
++  BRAVE_PAGE_ACTION_VIEW_UPDATE_BORDER
+   SetBorder(views::CreateEmptyBorder(border_insets));
+ }
+ 

--- a/patches/chrome-browser-ui-views-page_action-page_action_view.cc.patch
+++ b/patches/chrome-browser-ui-views-page_action-page_action_view.cc.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/ui/views/page_action/page_action_view.cc b/chrome/browser/ui/views/page_action/page_action_view.cc
-index 271f5b9adba10ee60aa45b4c00e1bfb541fd05fd..a6f93e9b26b636b5aaf16555a6487500b9ecb33e 100644
+index 271f5b9adba10ee60aa45b4c00e1bfb541fd05fd..8051adc18865ad5e5d465de28336e51545b45ab8 100644
 --- a/chrome/browser/ui/views/page_action/page_action_view.cc
 +++ b/chrome/browser/ui/views/page_action/page_action_view.cc
 @@ -167,7 +167,7 @@ void PageActionView::OnPageActionModelChanged(
@@ -15,7 +15,7 @@ index 271f5b9adba10ee60aa45b4c00e1bfb541fd05fd..a6f93e9b26b636b5aaf16555a6487500
        !observation_.GetSource()->GetImage().IsVectorIcon()) {
      border_insets = GetInsetsForNonVectorIcon();
    }
-+  BRAVE_PAGE_ACTION_VIEW_UPDATE_BORDER
++  MaybeOverrideBorder(observation_.GetSource(), border_insets);
    SetBorder(views::CreateEmptyBorder(border_insets));
  }
  

--- a/rewrite/chrome/browser/ui/page_actions/page_action_model.h.toml
+++ b/rewrite/chrome/browser/ui/page_actions/page_action_model.h.toml
@@ -26,7 +26,7 @@ replace = '''\1
                                  std::optional<int> height) = 0;
   virtual void SetOverrideTriggerableEvent(PageActionPassKey,
                                            std::optional<int> event_flags) = 0;
-  virtual void SetOverrideBorder(base::PassKey<PageActionController>,
+  virtual void SetOverrideBorder(PageActionPassKey,
                                  std::optional<gfx::Insets> border) = 0;
   virtual std::optional<SkColor> GetOverrideBackgroundColor() const = 0;
   virtual std::optional<SkColor> GetOverrideForegroundColor() const = 0;

--- a/rewrite/chrome/browser/ui/page_actions/page_action_model.h.toml
+++ b/rewrite/chrome/browser/ui/page_actions/page_action_model.h.toml
@@ -27,7 +27,7 @@ replace = '''\1
   virtual void SetOverrideTriggerableEvent(PageActionPassKey,
                                            std::optional<int> event_flags) = 0;
   virtual void SetOverrideBorder(base::PassKey<PageActionController>,
-                                 const std::optional<gfx::Insets>& border) = 0;
+                                 std::optional<gfx::Insets> border) = 0;
   virtual std::optional<SkColor> GetOverrideBackgroundColor() const = 0;
   virtual std::optional<SkColor> GetOverrideForegroundColor() const = 0;
   virtual bool GetAlwaysShowLabel() const = 0;

--- a/rewrite/chrome/browser/ui/page_actions/page_action_model.h.toml
+++ b/rewrite/chrome/browser/ui/page_actions/page_action_model.h.toml
@@ -26,11 +26,14 @@ replace = '''\1
                                  std::optional<int> height) = 0;
   virtual void SetOverrideTriggerableEvent(PageActionPassKey,
                                            std::optional<int> event_flags) = 0;
+  virtual void SetOverrideBorder(base::PassKey<PageActionController>,
+                                 const std::optional<gfx::Insets>& border) = 0;
   virtual std::optional<SkColor> GetOverrideBackgroundColor() const = 0;
   virtual std::optional<SkColor> GetOverrideForegroundColor() const = 0;
   virtual bool GetAlwaysShowLabel() const = 0;
   virtual std::optional<int> GetOverrideHeight() const = 0;
-  virtual std::optional<int> GetOverrideTriggerableEvent() const = 0;\2'''
+  virtual std::optional<int> GetOverrideTriggerableEvent() const = 0;
+  virtual std::optional<gfx::Insets> GetOverrideBorder() const = 0;\2'''
 
 [[substitution]]
 description = '''
@@ -46,7 +49,8 @@ replace = '''\1    kAlwaysShowLabel,
     kOverrideChipColors,
     kOverrideHeight,
     kOverrideTriggerableEvent,
-    kMaxValue = kOverrideTriggerableEvent,'''
+    kOverrideBorder,
+    kMaxValue = kOverrideBorder,'''
 
 [[substitution]]
 description = '''Wrap PageActionModel in a chromium_impl namespace.

--- a/rewrite/chrome/browser/ui/views/page_action/page_action_view.cc.toml
+++ b/rewrite/chrome/browser/ui/views/page_action/page_action_view.cc.toml
@@ -7,3 +7,12 @@
 description = 'Adding code to force show the label if it should be always shown in OnPageActionModelChanged()'
 re_pattern = 'else if \((model.ShouldShowSuggestionChip\(\))\)'
 replace = 'else if (\1 || model.GetAlwaysShowLabel())'
+
+[[substitution]]
+description = '''
+Adding BRAVE_PAGE_ACTION_VIEW_UPDATE_BORDER in UpdateBorder() right before
+SetBorder() call in it.
+'''
+re_pattern = '(void PageActionView::UpdateBorder\(\)[\s\S]*?)(SetBorder\()'
+replace = '''\1BRAVE_PAGE_ACTION_VIEW_UPDATE_BORDER
+  \2'''

--- a/rewrite/chrome/browser/ui/views/page_action/page_action_view.cc.toml
+++ b/rewrite/chrome/browser/ui/views/page_action/page_action_view.cc.toml
@@ -10,9 +10,10 @@ replace = 'else if (\1 || model.GetAlwaysShowLabel())'
 
 [[substitution]]
 description = '''
-Adding BRAVE_PAGE_ACTION_VIEW_UPDATE_BORDER in UpdateBorder() right before
-SetBorder() call in it.
+Call MaybeOverrideBorder() in UpdateBorder() right before the SetBorder() call
+in it.
 '''
-re_pattern = '(void PageActionView::UpdateBorder\(\)[\s\S]*?)(SetBorder\()'
-replace = '''\1BRAVE_PAGE_ACTION_VIEW_UPDATE_BORDER
+re_pattern = '(void PageActionView::UpdateBorder\(\).*?)(SetBorder\()'
+re_flags = ['DOTALL']
+replace = '''\1MaybeOverrideBorder(observation_.GetSource(), border_insets);
   \2'''


### PR DESCRIPTION
We don't need theses padding on the chip for partitioned storage page action.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/55407

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
