### PR TITLE
[infobar] BraveConfirmInfoBar (3/N): drop InfoBarView base class

### DIFF
--- a/browser/ui/views/infobars/BUILD.gn
+++ b/browser/ui/views/infobars/BUILD.gn
@@ -14,6 +14,12 @@ source_set("unit_tests") {
     "//brave/components/infobars/core",
     "//chrome/browser/ui",
     "//chrome/test:test_support",
+    "//components/infobars/core",
     "//testing/gtest",
+    "//ui/base",
+    "//ui/events",
+    "//ui/gfx",
+    "//ui/views",
+    "//ui/views:test_support",
   ]
 }

--- a/browser/ui/views/infobars/brave_confirm_infobar.cc
+++ b/browser/ui/views/infobars/brave_confirm_infobar.cc
@@ -11,6 +11,7 @@
 
 #include "base/check.h"
 #include "base/functional/bind.h"
+#include "base/memory/raw_ref.h"
 #include "chrome/browser/ui/color/chrome_color_id.h"
 #include "chrome/browser/ui/views/chrome_layout_provider.h"
 #include "chrome/grit/generated_resources.h"
@@ -39,6 +40,7 @@
 #include "ui/views/controls/image_view.h"
 #include "ui/views/controls/label.h"
 #include "ui/views/controls/link.h"
+#include "ui/views/focus/external_focus_tracker.h"
 #include "ui/views/style/typography.h"
 #include "ui/views/view_class_properties.h"
 #include "ui/views/widget/widget.h"
@@ -54,10 +56,35 @@ std::unique_ptr<infobars::InfoBar> CreateBraveConfirmInfoBar(
   return std::make_unique<BraveConfirmInfoBar>(std::move(delegate));
 }
 
+class BraveConfirmInfoBar::FocusTracker : public views::ExternalFocusTracker {
+ public:
+  explicit FocusTracker(BraveConfirmInfoBar& owner)
+      : views::ExternalFocusTracker(&owner, nullptr), owner_(owner) {}
+  FocusTracker(const FocusTracker&) = delete;
+  FocusTracker& operator=(const FocusTracker&) = delete;
+  ~FocusTracker() override = default;
+
+  // views::ExternalFocusTracker:
+  void OnWillChangeFocus(views::View* focused_before,
+                         views::View* focused_now) override {
+    views::ExternalFocusTracker::OnWillChangeFocus(focused_before, focused_now);
+    // Fire an accessibility alert when focus enters the infobar from outside
+    // so screen readers announce its contents.
+    if (focused_before && focused_now && !owner_->Contains(focused_before) &&
+        owner_->Contains(focused_now)) {
+      owner_->NotifyAccessibilityEventDeprecated(ax::mojom::Event::kAlert,
+                                                 true);
+    }
+  }
+
+ private:
+  const raw_ref<BraveConfirmInfoBar> owner_;
+};
+
 BraveConfirmInfoBar::BraveConfirmInfoBar(
     std::unique_ptr<BraveConfirmInfoBarDelegate> delegate)
     : infobars::InfoBar(std::move(delegate)),
-      views::ExternalFocusTracker(this, nullptr) {
+      focus_tracker_(std::make_unique<FocusTracker>(*this)) {
   // Drive the InfoBar animation off the compositor.
   SetNotifier(std::make_unique<
               gfx::AnimationDelegateNotifier<views::AnimationDelegateViews>>(
@@ -206,9 +233,6 @@ void BraveConfirmInfoBar::Layout(PassKey) {
             reserved_x + close_button_spacing.left(),
             width() - close_button_spacing.right() - close_button_->width()),
         OffsetY(close_button_)));
-
-    // For accessibility reasons, the close button should come last.
-    DCHECK_EQ(close_button_, children().back());
   }
 
   // Size the button content first so NonLabelWidth() reflects real widths.
@@ -249,6 +273,7 @@ void BraveConfirmInfoBar::Layout(PassKey) {
   place_button(ok_button_);
   place_button(cancel_button_);
 
+  // Place checkbox after latest button
   if (checkbox_) {
     checkbox_->SizeToPreferredSize();
     x += kCheckboxSpacing;
@@ -302,18 +327,6 @@ void BraveConfirmInfoBar::OnThemeChanged() {
   }
 }
 
-void BraveConfirmInfoBar::OnWillChangeFocus(View* focused_before,
-                                            View* focused_now) {
-  views::ExternalFocusTracker::OnWillChangeFocus(focused_before, focused_now);
-
-  // Trigger screen readers to announce the infobar's contents on focus
-  // entering.
-  if (focused_before && focused_now && !Contains(focused_before) &&
-      Contains(focused_now)) {
-    NotifyAccessibilityEventDeprecated(ax::mojom::Event::kAlert, true);
-  }
-}
-
 BraveConfirmInfoBarDelegate* BraveConfirmInfoBar::GetDelegate() {
   return static_cast<BraveConfirmInfoBarDelegate*>(delegate());
 }
@@ -325,14 +338,14 @@ const BraveConfirmInfoBarDelegate* BraveConfirmInfoBar::GetDelegate() const {
 void BraveConfirmInfoBar::PlatformSpecificShow(bool animate) {
   // Capture focus tracking once attached to a Widget so we can restore focus
   // on dismissal.
-  SetFocusManager(GetFocusManager());
+  focus_tracker_->SetFocusManager(GetFocusManager());
   NotifyAccessibilityEventDeprecated(ax::mojom::Event::kAlert, true);
 }
 
 void BraveConfirmInfoBar::PlatformSpecificHide(bool animate) {
   // Called twice (with animate=true then animate=false); the second
   // SetFocusManager(nullptr) is a silent no-op.
-  SetFocusManager(nullptr);
+  focus_tracker_->SetFocusManager(nullptr);
 
   if (!animate) {
     return;
@@ -341,7 +354,7 @@ void BraveConfirmInfoBar::PlatformSpecificHide(bool animate) {
   // Restore focus only if we're still in the active window.
   views::Widget* widget = GetWidget();
   if (!widget || widget->IsActive()) {
-    FocusLastFocusedExternalView();
+    focus_tracker_->FocusLastFocusedExternalView();
   }
 }
 

--- a/browser/ui/views/infobars/brave_confirm_infobar.cc
+++ b/browser/ui/views/infobars/brave_confirm_infobar.cc
@@ -6,22 +6,42 @@
 #include "brave/browser/ui/views/infobars/brave_confirm_infobar.h"
 
 #include <algorithm>
+#include <optional>
 #include <utility>
 
 #include "base/check.h"
 #include "base/functional/bind.h"
-#include "build/build_config.h"
+#include "chrome/browser/ui/color/chrome_color_id.h"
 #include "chrome/browser/ui/views/chrome_layout_provider.h"
+#include "chrome/grit/generated_resources.h"
+#include "components/strings/grit/components_strings.h"
+#include "components/vector_icons/vector_icons.h"
+#include "ui/accessibility/ax_enums.mojom.h"
+#include "ui/base/l10n/l10n_util.h"
 #include "ui/base/metadata/metadata_impl_macros.h"
-#include "ui/base/ui_base_features.h"
 #include "ui/base/window_open_disposition.h"
+#include "ui/base/window_open_disposition_utils.h"
+#include "ui/color/color_provider.h"
+#include "ui/compositor/layer.h"
+#include "ui/gfx/animation/animation_delegate_notifier.h"
+#include "ui/gfx/color_utils.h"
+#include "ui/gfx/geometry/insets.h"
+#include "ui/gfx/geometry/point.h"
+#include "ui/gfx/geometry/size.h"
 #include "ui/gfx/text_constants.h"
+#include "ui/views/accessibility/view_accessibility.h"
+#include "ui/views/background.h"
 #include "ui/views/controls/button/checkbox.h"
-#include "ui/views/controls/button/label_button.h"
+#include "ui/views/controls/button/image_button.h"
+#include "ui/views/controls/button/image_button_factory.h"
 #include "ui/views/controls/button/md_text_button.h"
+#include "ui/views/controls/highlight_path_generator.h"
+#include "ui/views/controls/image_view.h"
 #include "ui/views/controls/label.h"
 #include "ui/views/controls/link.h"
+#include "ui/views/style/typography.h"
 #include "ui/views/view_class_properties.h"
+#include "ui/views/widget/widget.h"
 
 namespace {
 
@@ -36,15 +56,45 @@ std::unique_ptr<infobars::InfoBar> CreateBraveConfirmInfoBar(
 
 BraveConfirmInfoBar::BraveConfirmInfoBar(
     std::unique_ptr<BraveConfirmInfoBarDelegate> delegate)
-    : InfoBarView(std::move(delegate)) {
+    : infobars::InfoBar(std::move(delegate)),
+      views::ExternalFocusTracker(this, nullptr) {
+  // Drive the InfoBar animation off the compositor.
+  SetNotifier(std::make_unique<
+              gfx::AnimationDelegateNotifier<views::AnimationDelegateViews>>(
+      this, this));
+
+  // infobars::InfoBar manages deletion of this view.
+  set_owned_by_client(OwnedByClientPassKey());
+
+  // Clip child layers so buttons render correctly during the slide-in/out
+  // animation.
+  SetPaintToLayer();
+  layer()->SetMasksToBounds(true);
+
   auto* delegate_ptr = GetDelegate();
   CHECK(delegate_ptr);
 
+  // Icon.
+  const ui::ImageModel& image = delegate_ptr->GetIcon();
+  if (!image.IsEmpty()) {
+    auto icon = std::make_unique<views::ImageView>();
+    icon->SetImage(image);
+    icon->SizeToPreferredSize();
+    icon->SetProperty(
+        views::kMarginsKey,
+        gfx::Insets::VH(ChromeLayoutProvider::Get()->GetDistanceMetric(
+                            DISTANCE_TOAST_LABEL_VERTICAL),
+                        0));
+    icon_ = AddChildView(std::move(icon));
+  }
+
+  // Message label.
   label_ = AddChildView(CreateLabel(delegate_ptr->GetMessageText()));
   label_->SetMultiLine(delegate_ptr->ShouldSupportMultiLine());
   label_->SetMaxLines(delegate_ptr->GetMaxLines());
   label_->SetElideBehavior(delegate_ptr->GetMessageElideBehavior());
 
+  // Buttons.
   const auto create_button =
       [this](ConfirmInfoBarDelegate::InfoBarButton type,
              void (BraveConfirmInfoBar::*click_function)()) {
@@ -88,11 +138,13 @@ BraveConfirmInfoBar::BraveConfirmInfoBar(
         delegate_ptr->GetButtonTooltip(ConfirmInfoBarDelegate::BUTTON_CANCEL));
   }
 
+  // Link.
   link_ = AddChildView(CreateLink(delegate_ptr->GetLinkText()));
   link_->SetMultiLine(delegate_ptr->ShouldSupportMultiLine());
   link_->SetMaxLines(delegate_ptr->GetMaxLines());
   link_->SetHorizontalAlignment(gfx::ALIGN_CENTER);
 
+  // Optional checkbox.
   if (delegate_ptr->HasCheckbox()) {
     checkbox_ = AddChildView(std::make_unique<views::Checkbox>(
         delegate_ptr->GetCheckboxText(),
@@ -100,40 +152,83 @@ BraveConfirmInfoBar::BraveConfirmInfoBar(
                             weak_ptr_factory_.GetWeakPtr())));
   }
 
-  // Upstream doesn't need this reorder because all other children
-  // except icon and close button are in |content_container_| that lives
-  // between both. It guarantees that close button is always the last
-  // children. However, we just add children directly instead of
-  // that container.
-  // TODO(https://github.com/brave/brave-browser/issues/48822): Add our children
-  // into content container.
-  if (close_button_) {
-    ReorderChildView(close_button_, children().size());
+  // Close button (always last for accessibility focus order).
+  if (delegate_ptr->IsCloseable()) {
+    auto close_button = views::CreateVectorImageButton(base::BindRepeating(
+        &BraveConfirmInfoBar::CloseButtonPressed, base::Unretained(this)));
+    views::SetImageFromVectorIconWithColor(
+        close_button.get(), vector_icons::kCloseChromeRefreshIcon,
+        {kColorInfoBarButtonIcon, kColorInfoBarForeground,
+         kColorInfoBarButtonIconHovered});
+    close_button->SetTooltipText(l10n_util::GetStringUTF16(IDS_ACCNAME_CLOSE));
+    close_button_ = AddChildView(std::move(close_button));
+
+    const gfx::Insets close_button_spacing = GetCloseButtonSpacing();
+    close_button_->SetProperty(
+        views::kMarginsKey,
+        gfx::Insets::TLBR(close_button_spacing.top(), 0,
+                          close_button_spacing.bottom(), 0));
+    views::InstallCircleHighlightPathGenerator(close_button_);
   }
+
+  SetTargetHeight(
+      ChromeLayoutProvider::Get()->GetDistanceMetric(DISTANCE_INFOBAR_HEIGHT));
+
+  GetViewAccessibility().SetRole(ax::mojom::Role::kAlertDialog);
+  GetViewAccessibility().SetName(l10n_util::GetStringUTF8(IDS_ACCNAME_INFOBAR));
+  GetViewAccessibility().SetKeyShortcuts("Alt+Shift+A");
 }
 
 BraveConfirmInfoBar::~BraveConfirmInfoBar() = default;
 
 void BraveConfirmInfoBar::Layout(PassKey) {
-  LayoutSuperclass<InfoBarView>(this);
+  const int spacing = GetElementSpacing();
 
+  int start_x = 0;
+  if (icon_) {
+    icon_->SetPosition(gfx::Point(spacing, OffsetY(icon_)));
+    start_x = icon_->bounds().right();
+  }
+
+  const int content_minimum_width = label_->GetMinimumSize().width() +
+                                    link_->GetMinimumSize().width() +
+                                    NonLabelWidth();
+  int reserved_x = start_x;
+  if (content_minimum_width > 0) {
+    reserved_x += spacing + content_minimum_width;
+  }
+
+  if (close_button_) {
+    const gfx::Insets close_button_spacing = GetCloseButtonSpacing();
+    close_button_->SizeToPreferredSize();
+    close_button_->SetPosition(gfx::Point(
+        std::max(
+            reserved_x + close_button_spacing.left(),
+            width() - close_button_spacing.right() - close_button_->width()),
+        OffsetY(close_button_)));
+
+    // For accessibility reasons, the close button should come last.
+    DCHECK_EQ(close_button_, children().back());
+  }
+
+  // Size the button content first so NonLabelWidth() reflects real widths.
   if (ok_button_) {
     ok_button_->SizeToPreferredSize();
   }
-
   if (cancel_button_) {
     cancel_button_->SizeToPreferredSize();
   }
 
+  // Distribute remaining width between label and link.
   int x = GetStartX();
-  Views views;
-  views.push_back(label_.get());
-  views.push_back(link_.get());
-  AssignWidths(&views, std::max(0, GetEndX() - x - NonLabelWidth()));
+  Views label_and_link;
+  label_and_link.push_back(label_.get());
+  label_and_link.push_back(link_.get());
+  AssignWidths(&label_and_link, std::max(0, GetEndX() - x - NonLabelWidth()));
 
   MaybeLayoutMultiLineLabelAndLink();
 
-  ChromeLayoutProvider* layout_provider = ChromeLayoutProvider::Get();
+  auto* layout_provider = ChromeLayoutProvider::Get();
 
   label_->SetPosition(gfx::Point(x, OffsetY(label_)));
   if (!label_->GetText().empty()) {
@@ -154,7 +249,6 @@ void BraveConfirmInfoBar::Layout(PassKey) {
   place_button(ok_button_);
   place_button(cancel_button_);
 
-  // Place checkbox after latest button
   if (checkbox_) {
     checkbox_->SizeToPreferredSize();
     x += kCheckboxSpacing;
@@ -164,84 +258,192 @@ void BraveConfirmInfoBar::Layout(PassKey) {
   link_->SetPosition(gfx::Point(GetEndX() - link_->width(), OffsetY(link_)));
 }
 
-void BraveConfirmInfoBar::MaybeLayoutMultiLineLabelAndLink() {
-  if (!GetDelegate()->ShouldSupportMultiLine()) {
-    return;
+gfx::Size BraveConfirmInfoBar::CalculatePreferredSize(
+    const views::SizeBounds& available_size) const {
+  int width = 0;
+  const int spacing = GetElementSpacing();
+  if (icon_) {
+    width += spacing + icon_->width();
   }
 
-  CHECK(label_);
-  CHECK(link_);
-
-  const int available_width = GetEndX() - GetStartX() - NonLabelWidth();
-  label_->SizeToFit(std::max(0, available_width - link_->width()));
-
-  // When label and link have different line counts, adjust their widths
-  // proportionally to their text lengths to maintain a balanced layout.
-  if (label_->GetRequiredLines() != link_->GetRequiredLines()) {
-    const size_t text_size = label_->GetText().size() + link_->GetText().size();
-    const int label_width =
-        available_width * label_->GetText().size() / text_size;
-    label_->SizeToFit(label_width);
-    link_->SizeToFit(available_width - label_width);
+  const int content_width = label_->GetMinimumSize().width() +
+                            link_->GetMinimumSize().width() + NonLabelWidth();
+  if (content_width > 0) {
+    width += spacing + content_width;
   }
 
-  const int max_height = std::max(label_->height(), link_->height());
-  const int target_height = std::max(
-      max_height,
-      ChromeLayoutProvider::Get()->GetDistanceMetric(DISTANCE_INFOBAR_HEIGHT));
-
-  // Don't call SetTargetHeight() as it causes another nested layout pass inside
-  // the layout. Instead, just set the target height and update the computed
-  // height.
-  BraveSetTargetHeight(target_height);
+  const int trailing_space =
+      close_button_ ? GetCloseButtonSpacing().width() + close_button_->width()
+                    : spacing;
+  return gfx::Size(width + trailing_space, computed_height());
 }
 
-void BraveConfirmInfoBar::CheckboxPressed() {
-  GetDelegate()->SetCheckboxChecked(checkbox_->GetChecked());
-}
+void BraveConfirmInfoBar::OnThemeChanged() {
+  views::View::OnThemeChanged();
+  const auto* cp = GetColorProvider();
+  const SkColor background_color = cp->GetColor(kColorInfoBarBackground);
+  SetBackground(views::CreateSolidBackground(background_color));
 
-void BraveConfirmInfoBar::CloseButtonPressed() {
-  if (GetDelegate()->InterceptClosing()) {
-    return;
+  const SkColor text_color = cp->GetColor(kColorInfoBarForeground);
+  if (label_) {
+    label_->SetBackgroundColor(background_color);
+    label_->SetEnabledColor(text_color);
+    label_->SetAutoColorReadabilityEnabled(false);
+  }
+  if (link_) {
+    link_->SetBackgroundColor(background_color);
   }
 
-  InfoBarView::CloseButtonPressed();
-}
-
-void BraveConfirmInfoBar::OkButtonPressed() {
-  if (!owner()) {
-    return;  // We're closing; don't call anything, it might access the owner.
-  }
-  if (GetDelegate()->Accept()) {
-    RemoveSelf();
+  // Set dark mode status so the delegate can pick a dark-mode-appropriate
+  // icon.
+  delegate()->set_dark_mode(color_utils::IsDark(background_color));
+  if (icon_) {
+    icon_->SetImage(delegate()->GetIcon());
   }
 }
 
-void BraveConfirmInfoBar::CancelButtonPressed() {
-  if (!owner()) {
-    return;  // We're closing; don't call anything, it might access the owner.
-  }
-  if (GetDelegate()->Cancel()) {
-    RemoveSelf();
+void BraveConfirmInfoBar::OnWillChangeFocus(View* focused_before,
+                                            View* focused_now) {
+  views::ExternalFocusTracker::OnWillChangeFocus(focused_before, focused_now);
+
+  // Trigger screen readers to announce the infobar's contents on focus
+  // entering.
+  if (focused_before && focused_now && !Contains(focused_before) &&
+      Contains(focused_now)) {
+    NotifyAccessibilityEventDeprecated(ax::mojom::Event::kAlert, true);
   }
 }
 
 BraveConfirmInfoBarDelegate* BraveConfirmInfoBar::GetDelegate() {
-  return reinterpret_cast<BraveConfirmInfoBarDelegate*>(delegate());
+  return static_cast<BraveConfirmInfoBarDelegate*>(delegate());
 }
 
 const BraveConfirmInfoBarDelegate* BraveConfirmInfoBar::GetDelegate() const {
-  return reinterpret_cast<const BraveConfirmInfoBarDelegate*>(delegate());
+  return static_cast<const BraveConfirmInfoBarDelegate*>(delegate());
 }
 
-int BraveConfirmInfoBar::GetContentMinimumWidth() const {
-  return label_->GetMinimumSize().width() + link_->GetMinimumSize().width() +
-         NonLabelWidth();
+void BraveConfirmInfoBar::PlatformSpecificShow(bool animate) {
+  // Capture focus tracking once attached to a Widget so we can restore focus
+  // on dismissal.
+  SetFocusManager(GetFocusManager());
+  NotifyAccessibilityEventDeprecated(ax::mojom::Event::kAlert, true);
+}
+
+void BraveConfirmInfoBar::PlatformSpecificHide(bool animate) {
+  // Called twice (with animate=true then animate=false); the second
+  // SetFocusManager(nullptr) is a silent no-op.
+  SetFocusManager(nullptr);
+
+  if (!animate) {
+    return;
+  }
+
+  // Restore focus only if we're still in the active window.
+  views::Widget* widget = GetWidget();
+  if (!widget || widget->IsActive()) {
+    FocusLastFocusedExternalView();
+  }
+}
+
+void BraveConfirmInfoBar::PlatformSpecificOnHeightRecalculated() {
+  InvalidateLayout();
+}
+
+std::unique_ptr<views::Label> BraveConfirmInfoBar::CreateLabel(
+    const std::u16string& text) const {
+  auto label = std::make_unique<views::Label>(
+      text, views::style::CONTEXT_DIALOG_BODY_TEXT);
+  SetLabelDetails(label.get());
+  return label;
+}
+
+std::unique_ptr<views::Link> BraveConfirmInfoBar::CreateLink(
+    const std::u16string& text) {
+  auto link = std::make_unique<views::Link>(
+      text, views::style::CONTEXT_DIALOG_BODY_TEXT);
+  SetLabelDetails(link.get());
+  link->SetCallback(base::BindRepeating(&BraveConfirmInfoBar::LinkClicked,
+                                        base::Unretained(this)));
+  return link;
+}
+
+void BraveConfirmInfoBar::SetLabelDetails(views::Label* label) const {
+  label->SizeToPreferredSize();
+  label->SetHorizontalAlignment(gfx::ALIGN_LEFT);
+  label->SetProperty(
+      views::kMarginsKey,
+      gfx::Insets::VH(ChromeLayoutProvider::Get()->GetDistanceMetric(
+                          DISTANCE_TOAST_LABEL_VERTICAL),
+                      0));
+}
+
+// static
+void BraveConfirmInfoBar::AssignWidths(Views* views, int available_width) {
+  std::sort(views->begin(), views->end(), [](views::View* a, views::View* b) {
+    return a->GetPreferredSize().width() > b->GetPreferredSize().width();
+  });
+  AssignWidthsSorted(views, available_width);
+}
+
+// static
+void BraveConfirmInfoBar::AssignWidthsSorted(Views* views,
+                                             int available_width) {
+  if (views->empty()) {
+    return;
+  }
+  gfx::Size back_view_size(views->back()->GetPreferredSize());
+  back_view_size.set_width(
+      std::min(back_view_size.width(),
+               available_width / static_cast<int>(views->size())));
+  views->back()->SetSize(back_view_size);
+  views->pop_back();
+  AssignWidthsSorted(views, available_width - back_view_size.width());
+}
+
+int BraveConfirmInfoBar::GetStartX() const {
+  // Don't return a value greater than GetEndX() — keeps callers safe when
+  // computing label/link widths as (GetEndX() - GetStartX()).
+  return std::min((icon_ ? icon_->bounds().right() : 0) + GetElementSpacing(),
+                  GetEndX());
+}
+
+int BraveConfirmInfoBar::GetEndX() const {
+  return close_button_ ? close_button_->x() - GetCloseButtonSpacing().left()
+                       : width() - GetElementSpacing();
+}
+
+int BraveConfirmInfoBar::OffsetY(views::View* view) const {
+  return std::max((target_height() - view->height()) / 2, 0) -
+         (target_height() - height());
+}
+
+gfx::Insets BraveConfirmInfoBar::GetCloseButtonSpacing() const {
+  auto* provider = ChromeLayoutProvider::Get();
+  // Match upstream's legacy close button spacing.
+  return gfx::Insets::TLBR(
+      provider->GetDistanceMetric(DISTANCE_TOAST_CONTROL_VERTICAL),
+      provider->GetDistanceMetric(views::DISTANCE_UNRELATED_CONTROL_HORIZONTAL),
+      provider->GetDistanceMetric(DISTANCE_TOAST_CONTROL_VERTICAL),
+      provider->GetDistanceMetric(
+          views::DISTANCE_UNRELATED_CONTROL_HORIZONTAL));
+}
+
+int BraveConfirmInfoBar::GetElementSpacing() const {
+  return ChromeLayoutProvider::Get()->GetDistanceMetric(
+      views::DISTANCE_UNRELATED_CONTROL_HORIZONTAL);
+}
+
+void BraveConfirmInfoBar::LinkClicked(const ui::Event& event) {
+  if (!owner()) {
+    return;  // We're closing; don't call anything, it might access the owner.
+  }
+  if (delegate()->LinkClicked(ui::DispositionFromEventFlags(event.flags()))) {
+    RemoveSelf();
+  }
 }
 
 int BraveConfirmInfoBar::NonLabelWidth() const {
-  ChromeLayoutProvider* layout_provider = ChromeLayoutProvider::Get();
-
+  auto* layout_provider = ChromeLayoutProvider::Get();
   const int label_spacing = layout_provider->GetDistanceMetric(
       views::DISTANCE_RELATED_LABEL_HORIZONTAL);
   const int button_spacing = layout_provider->GetDistanceMetric(
@@ -262,6 +464,70 @@ int BraveConfirmInfoBar::NonLabelWidth() const {
   }
 
   return width + ((link_->GetText().empty() || !width) ? 0 : label_spacing);
+}
+
+void BraveConfirmInfoBar::MaybeLayoutMultiLineLabelAndLink() {
+  if (!GetDelegate()->ShouldSupportMultiLine()) {
+    return;
+  }
+
+  CHECK(label_);
+  CHECK(link_);
+
+  const int available_width = GetEndX() - GetStartX() - NonLabelWidth();
+  label_->SizeToFit(std::max(0, available_width - link_->width()));
+
+  // When label and link have different line counts, share the row width
+  // proportionally to their text lengths for a balanced result.
+  if (label_->GetRequiredLines() != link_->GetRequiredLines()) {
+    const size_t text_size = label_->GetText().size() + link_->GetText().size();
+    const int label_width =
+        available_width * label_->GetText().size() / text_size;
+    label_->SizeToFit(label_width);
+    link_->SizeToFit(available_width - label_width);
+  }
+
+  const int max_height = std::max(label_->height(), link_->height());
+  const int target_height = std::max(
+      max_height,
+      ChromeLayoutProvider::Get()->GetDistanceMetric(DISTANCE_INFOBAR_HEIGHT));
+
+  // BraveSetTargetHeight sets both target_height_ and the computed height_
+  // without invalidating layout — avoids re-entering Layout() mid-pass.
+  BraveSetTargetHeight(target_height);
+}
+
+void BraveConfirmInfoBar::OkButtonPressed() {
+  if (!owner()) {
+    return;  // We're closing; don't call anything, it might access the owner.
+  }
+  if (GetDelegate()->Accept()) {
+    RemoveSelf();
+  }
+}
+
+void BraveConfirmInfoBar::CancelButtonPressed() {
+  if (!owner()) {
+    return;  // We're closing; don't call anything, it might access the owner.
+  }
+  if (GetDelegate()->Cancel()) {
+    RemoveSelf();
+  }
+}
+
+void BraveConfirmInfoBar::CloseButtonPressed() {
+  if (!owner()) {
+    return;  // We're closing; don't call anything, it might access the owner.
+  }
+  if (GetDelegate()->InterceptClosing()) {
+    return;
+  }
+  delegate()->InfoBarDismissed();
+  RemoveSelf();
+}
+
+void BraveConfirmInfoBar::CheckboxPressed() {
+  GetDelegate()->SetCheckboxChecked(checkbox_->GetChecked());
 }
 
 BEGIN_METADATA(BraveConfirmInfoBar)

--- a/browser/ui/views/infobars/brave_confirm_infobar.h
+++ b/browser/ui/views/infobars/brave_confirm_infobar.h
@@ -16,7 +16,6 @@
 #include "components/infobars/core/infobar.h"
 #include "ui/base/metadata/metadata_header_macros.h"
 #include "ui/views/controls/button/image_button.h"
-#include "ui/views/focus/external_focus_tracker.h"
 #include "ui/views/view.h"
 
 namespace gfx {
@@ -37,15 +36,13 @@ class MdTextButton;
 
 // An infobar that shows a message, up to two optional buttons, an optional
 // checkbox, and an optional right-aligned link. Commonly used for:
-//   "Would you like to do X?  [Yes]  [No]  [_Learn More_] [x]"
+//  "Would you like to do X?  [Yes]  [No]  [check] Remember  [_Learn More_] [x]"
 //
 // Unlike upstream's ConfirmInfoBar/InfoBarView, this class is self-contained:
 // it inherits directly from infobars::InfoBar + views::View instead of from
 // InfoBarView, so its layout doesn't change with features::kInfobarRefresh
 // and stays insulated from future upstream restructuring of InfoBarView.
-class BraveConfirmInfoBar : public infobars::InfoBar,
-                            public views::View,
-                            public views::ExternalFocusTracker {
+class BraveConfirmInfoBar : public infobars::InfoBar, public views::View {
   METADATA_HEADER(BraveConfirmInfoBar, views::View)
 
  public:
@@ -65,9 +62,6 @@ class BraveConfirmInfoBar : public infobars::InfoBar,
       const views::SizeBounds& available_size) const override;
   void OnThemeChanged() override;
 
-  // views::ExternalFocusTracker:
-  void OnWillChangeFocus(View* focused_before, View* focused_now) override;
-
   BraveConfirmInfoBarDelegate* GetDelegate();
   const BraveConfirmInfoBarDelegate* GetDelegate() const;
 
@@ -85,6 +79,10 @@ class BraveConfirmInfoBar : public infobars::InfoBar,
   views::View* close_button_for_testing() const { return close_button_.get(); }
 
  private:
+  // Tracks the previously focused external view so we can restore focus on
+  // dismissal; defined in the .cc.
+  class FocusTracker;
+
   // infobars::InfoBar:
   void PlatformSpecificShow(bool animate) override;
   void PlatformSpecificHide(bool animate) override;
@@ -118,6 +116,8 @@ class BraveConfirmInfoBar : public infobars::InfoBar,
   raw_ptr<views::Link> link_ = nullptr;
   raw_ptr<views::Checkbox> checkbox_ = nullptr;
   raw_ptr<views::ImageButton> close_button_ = nullptr;
+
+  std::unique_ptr<FocusTracker> focus_tracker_;
 
   base::WeakPtrFactory<BraveConfirmInfoBar> weak_ptr_factory_{this};
 };

--- a/browser/ui/views/infobars/brave_confirm_infobar.h
+++ b/browser/ui/views/infobars/brave_confirm_infobar.h
@@ -7,26 +7,50 @@
 #define BRAVE_BROWSER_UI_VIEWS_INFOBARS_BRAVE_CONFIRM_INFOBAR_H_
 
 #include <memory>
+#include <string>
+#include <vector>
 
-#include "base/gtest_prod_util.h"
 #include "base/memory/raw_ptr.h"
+#include "base/memory/weak_ptr.h"
 #include "brave/components/infobars/core/brave_confirm_infobar_delegate.h"
-#include "chrome/browser/ui/views/infobars/infobar_view.h"
+#include "components/infobars/core/infobar.h"
 #include "ui/base/metadata/metadata_header_macros.h"
 #include "ui/views/controls/button/image_button.h"
+#include "ui/views/focus/external_focus_tracker.h"
+#include "ui/views/view.h"
+
+namespace gfx {
+class Insets;
+}  // namespace gfx
+
+namespace ui {
+class Event;
+}  // namespace ui
 
 namespace views {
 class Checkbox;
+class ImageView;
 class Label;
+class Link;
 class MdTextButton;
 }  // namespace views
 
-// An infobar that shows a message, up to two optional buttons, and an optional,
-// right-aligned link.  This is commonly used to do things like:
-// "Would you like to do X?  [Yes]  [No]  [<custom button>]    _Learn More_ [x]"
-class BraveConfirmInfoBar : public InfoBarView {
-  METADATA_HEADER(BraveConfirmInfoBar, InfoBarView)
+// An infobar that shows a message, up to two optional buttons, an optional
+// checkbox, and an optional right-aligned link. Commonly used for:
+//   "Would you like to do X?  [Yes]  [No]  [_Learn More_] [x]"
+//
+// Unlike upstream's ConfirmInfoBar/InfoBarView, this class is self-contained:
+// it inherits directly from infobars::InfoBar + views::View instead of from
+// InfoBarView, so its layout doesn't change with features::kInfobarRefresh
+// and stays insulated from future upstream restructuring of InfoBarView.
+class BraveConfirmInfoBar : public infobars::InfoBar,
+                            public views::View,
+                            public views::ExternalFocusTracker {
+  METADATA_HEADER(BraveConfirmInfoBar, views::View)
+
  public:
+  using Views = std::vector<views::View*>;
+
   explicit BraveConfirmInfoBar(
       std::unique_ptr<BraveConfirmInfoBarDelegate> delegate);
 
@@ -35,36 +59,65 @@ class BraveConfirmInfoBar : public InfoBarView {
 
   ~BraveConfirmInfoBar() override;
 
-  // InfoBarView:
+  // views::View:
   void Layout(PassKey) override;
+  gfx::Size CalculatePreferredSize(
+      const views::SizeBounds& available_size) const override;
+  void OnThemeChanged() override;
+
+  // views::ExternalFocusTracker:
+  void OnWillChangeFocus(View* focused_before, View* focused_now) override;
 
   BraveConfirmInfoBarDelegate* GetDelegate();
   const BraveConfirmInfoBarDelegate* GetDelegate() const;
 
- private:
-  FRIEND_TEST_ALL_PREFIXES(BraveConfirmInfoBarTest, CloseButtonOrderTest);
-
-  // InfoBarView:
-  int GetContentMinimumWidth() const override;
-
-  void MaybeLayoutMultiLineLabelAndLink();
-
-  void OkButtonPressed();
-  void CancelButtonPressed();
-  void CloseButtonPressed() override;
-  void CheckboxPressed();
-
-  // Returns the width of all content other than the label and link.  Layout()
-  // uses this to determine how much space the label and link can take.
-  int NonLabelWidth() const;
-
+  // Testing accessors for layout verification.
+  views::ImageView* icon_for_testing() const { return icon_.get(); }
+  views::Label* label_for_testing() const { return label_.get(); }
+  views::MdTextButton* ok_button_for_testing() const {
+    return ok_button_.get();
+  }
+  views::MdTextButton* cancel_button_for_testing() const {
+    return cancel_button_.get();
+  }
+  views::Link* link_for_testing() const { return link_.get(); }
+  views::Checkbox* checkbox_for_testing() const { return checkbox_.get(); }
   views::View* close_button_for_testing() const { return close_button_.get(); }
 
+ private:
+  // infobars::InfoBar:
+  void PlatformSpecificShow(bool animate) override;
+  void PlatformSpecificHide(bool animate) override;
+  void PlatformSpecificOnHeightRecalculated() override;
+
+  // Layout helpers (adapted from InfoBarView).
+  std::unique_ptr<views::Label> CreateLabel(const std::u16string& text) const;
+  std::unique_ptr<views::Link> CreateLink(const std::u16string& text);
+  void SetLabelDetails(views::Label* label) const;
+  static void AssignWidths(Views* views, int available_width);
+  static void AssignWidthsSorted(Views* views, int available_width);
+  int GetStartX() const;
+  int GetEndX() const;
+  int OffsetY(views::View* view) const;
+  gfx::Insets GetCloseButtonSpacing() const;
+  int GetElementSpacing() const;
+  void LinkClicked(const ui::Event& event);
+
+  // Brave-specific.
+  int NonLabelWidth() const;
+  void MaybeLayoutMultiLineLabelAndLink();
+  void OkButtonPressed();
+  void CancelButtonPressed();
+  void CloseButtonPressed();
+  void CheckboxPressed();
+
+  raw_ptr<views::ImageView> icon_ = nullptr;
   raw_ptr<views::Label> label_ = nullptr;
   raw_ptr<views::MdTextButton> ok_button_ = nullptr;
   raw_ptr<views::MdTextButton> cancel_button_ = nullptr;
   raw_ptr<views::Link> link_ = nullptr;
   raw_ptr<views::Checkbox> checkbox_ = nullptr;
+  raw_ptr<views::ImageButton> close_button_ = nullptr;
 
   base::WeakPtrFactory<BraveConfirmInfoBar> weak_ptr_factory_{this};
 };

--- a/browser/ui/views/infobars/brave_confirm_infobar_unittest.cc
+++ b/browser/ui/views/infobars/brave_confirm_infobar_unittest.cc
@@ -5,37 +5,351 @@
 
 #include "brave/browser/ui/views/infobars/brave_confirm_infobar.h"
 
-#include "brave/components/infobars/core/brave_confirm_infobar_delegate.h"
-#include "chrome/test/views/chrome_views_test_base.h"
-#include "testing/gtest/include/gtest/gtest.h"
-#include "ui/views/view.h"
+#include <memory>
+#include <utility>
 
-using BraveConfirmInfoBarTest = ChromeViewsTestBase;
+#include "brave/components/infobars/core/brave_confirm_infobar_delegate.h"
+#include "chrome/browser/ui/views/chrome_layout_provider.h"
+#include "chrome/test/views/chrome_views_test_base.h"
+#include "components/infobars/core/confirm_infobar_delegate.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "third_party/skia/include/core/SkBitmap.h"
+#include "ui/base/models/image_model.h"
+#include "ui/events/base_event_utils.h"
+#include "ui/events/event.h"
+#include "ui/events/types/event_type.h"
+#include "ui/gfx/geometry/point.h"
+#include "ui/gfx/geometry/rect.h"
+#include "ui/gfx/image/image_skia.h"
+#include "ui/views/controls/button/checkbox.h"
+#include "ui/views/controls/button/image_button.h"
+#include "ui/views/controls/button/md_text_button.h"
+#include "ui/views/controls/image_view.h"
+#include "ui/views/controls/label.h"
+#include "ui/views/controls/link.h"
+#include "ui/views/test/button_test_api.h"
+#include "ui/views/test/views_test_utils.h"
+#include "ui/views/view.h"
 
 namespace {
 
+constexpr int kTestInfoBarWidth = 600;
+
+// Configurable test delegate; setters control which child views the infobar
+// creates and which delegate callbacks fire.
 class TestInfoBarDelegate : public BraveConfirmInfoBarDelegate {
  public:
   TestInfoBarDelegate() = default;
   ~TestInfoBarDelegate() override = default;
 
+  // Test setters.
+  void set_buttons(int buttons) { buttons_ = buttons; }
+  void set_message_text(std::u16string text) {
+    message_text_ = std::move(text);
+  }
+  void set_link_text(std::u16string text) { link_text_ = std::move(text); }
+  void set_icon(ui::ImageModel icon) { icon_ = std::move(icon); }
+  void set_closeable(bool c) { closeable_ = c; }
+  void set_has_checkbox(bool h) { has_checkbox_ = h; }
+  void set_checkbox_text(std::u16string text) {
+    checkbox_text_ = std::move(text);
+  }
+  void set_supports_multi_line(bool m) { multi_line_ = m; }
+  void set_intercept_closing(bool i) { intercept_closing_ = i; }
+
+  // Spy state.
+  bool checkbox_checked() const { return checkbox_checked_; }
+
   // BraveConfirmInfoBarDelegate:
   infobars::InfoBarDelegate::InfoBarIdentifier GetIdentifier() const override {
     return TEST_INFOBAR;
   }
+  ui::ImageModel GetIcon() const override { return icon_; }
+  std::u16string GetMessageText() const override { return message_text_; }
+  std::u16string GetLinkText() const override { return link_text_; }
+  int GetButtons() const override { return buttons_; }
+  bool IsCloseable() const override { return closeable_; }
+  bool HasCheckbox() const override { return has_checkbox_; }
+  std::u16string GetCheckboxText() const override { return checkbox_text_; }
+  void SetCheckboxChecked(bool c) override { checkbox_checked_ = c; }
+  bool ShouldSupportMultiLine() const override { return multi_line_; }
+  bool InterceptClosing() override { return intercept_closing_; }
 
-  int GetButtons() const override { return BUTTON_NONE; }
-
-  std::u16string GetMessageText() const override { return u""; }
+ private:
+  int buttons_ = BUTTON_NONE;
+  std::u16string message_text_;
+  std::u16string link_text_;
+  ui::ImageModel icon_;
+  bool closeable_ = true;
+  bool has_checkbox_ = false;
+  std::u16string checkbox_text_;
+  bool multi_line_ = false;
+  bool intercept_closing_ = false;
+  bool checkbox_checked_ = false;
 };
 
 }  // namespace
 
-// Check close button is always the last children.
+class BraveConfirmInfoBarTest : public ChromeViewsTestBase {
+ public:
+  std::unique_ptr<BraveConfirmInfoBar> CreateInfoBar(
+      std::unique_ptr<TestInfoBarDelegate> delegate) {
+    auto infobar = std::make_unique<BraveConfirmInfoBar>(std::move(delegate));
+    return infobar;
+  }
+
+  // Lay the infobar out at the standard test width so children acquire real
+  // bounds we can inspect.
+  void LayOut(BraveConfirmInfoBar* infobar) {
+    infobar->SetBounds(0, 0, kTestInfoBarWidth,
+                       ChromeLayoutProvider::Get()->GetDistanceMetric(
+                           DISTANCE_INFOBAR_HEIGHT));
+    views::test::RunScheduledLayout(infobar);
+  }
+};
+
+// ----- Child view presence -----
+
+TEST_F(BraveConfirmInfoBarTest, NoButtonsByDefault) {
+  auto infobar = CreateInfoBar(std::make_unique<TestInfoBarDelegate>());
+  EXPECT_FALSE(infobar->ok_button_for_testing());
+  EXPECT_FALSE(infobar->cancel_button_for_testing());
+}
+
+TEST_F(BraveConfirmInfoBarTest, OkButtonOnly) {
+  auto delegate = std::make_unique<TestInfoBarDelegate>();
+  delegate->set_buttons(ConfirmInfoBarDelegate::BUTTON_OK);
+  auto infobar = CreateInfoBar(std::move(delegate));
+  EXPECT_TRUE(infobar->ok_button_for_testing());
+  EXPECT_FALSE(infobar->cancel_button_for_testing());
+}
+
+TEST_F(BraveConfirmInfoBarTest, CancelButtonOnly) {
+  auto delegate = std::make_unique<TestInfoBarDelegate>();
+  delegate->set_buttons(ConfirmInfoBarDelegate::BUTTON_CANCEL);
+  auto infobar = CreateInfoBar(std::move(delegate));
+  EXPECT_FALSE(infobar->ok_button_for_testing());
+  EXPECT_TRUE(infobar->cancel_button_for_testing());
+}
+
+TEST_F(BraveConfirmInfoBarTest, BothButtons) {
+  auto delegate = std::make_unique<TestInfoBarDelegate>();
+  delegate->set_buttons(ConfirmInfoBarDelegate::BUTTON_OK |
+                        ConfirmInfoBarDelegate::BUTTON_CANCEL);
+  auto infobar = CreateInfoBar(std::move(delegate));
+  EXPECT_TRUE(infobar->ok_button_for_testing());
+  EXPECT_TRUE(infobar->cancel_button_for_testing());
+}
+
+TEST_F(BraveConfirmInfoBarTest, IconPresentWhenDelegateProvidesIt) {
+  auto delegate = std::make_unique<TestInfoBarDelegate>();
+  // Non-empty image model => icon view should be created.
+  SkBitmap bitmap;
+  bitmap.allocN32Pixels(16, 16);
+  delegate->set_icon(ui::ImageModel::FromImageSkia(
+      gfx::ImageSkia::CreateFrom1xBitmap(bitmap)));
+  auto infobar = CreateInfoBar(std::move(delegate));
+  EXPECT_TRUE(infobar->icon_for_testing());
+}
+
+TEST_F(BraveConfirmInfoBarTest, NoIconWhenDelegateReturnsEmpty) {
+  auto infobar = CreateInfoBar(std::make_unique<TestInfoBarDelegate>());
+  EXPECT_FALSE(infobar->icon_for_testing());
+}
+
+TEST_F(BraveConfirmInfoBarTest, CheckboxPresentWhenDelegateRequests) {
+  auto delegate = std::make_unique<TestInfoBarDelegate>();
+  delegate->set_has_checkbox(true);
+  delegate->set_checkbox_text(u"Stop showing");
+  auto infobar = CreateInfoBar(std::move(delegate));
+  EXPECT_TRUE(infobar->checkbox_for_testing());
+}
+
+TEST_F(BraveConfirmInfoBarTest, NoCheckboxByDefault) {
+  auto infobar = CreateInfoBar(std::make_unique<TestInfoBarDelegate>());
+  EXPECT_FALSE(infobar->checkbox_for_testing());
+}
+
+TEST_F(BraveConfirmInfoBarTest, NoCloseButtonWhenNotCloseable) {
+  auto delegate = std::make_unique<TestInfoBarDelegate>();
+  delegate->set_closeable(false);
+  auto infobar = CreateInfoBar(std::move(delegate));
+  EXPECT_FALSE(infobar->close_button_for_testing());
+}
+
+TEST_F(BraveConfirmInfoBarTest, LabelAndLinkAlwaysExist) {
+  auto infobar = CreateInfoBar(std::make_unique<TestInfoBarDelegate>());
+  EXPECT_TRUE(infobar->label_for_testing());
+  EXPECT_TRUE(infobar->link_for_testing());
+}
+
+// ----- Child order -----
+
+// Accessibility focus order requires the close button to be the last child.
 TEST_F(BraveConfirmInfoBarTest, CloseButtonOrderTest) {
-  auto infobar = std::make_unique<BraveConfirmInfoBar>(
-      (std::make_unique<TestInfoBarDelegate>()));
+  auto infobar = CreateInfoBar(std::make_unique<TestInfoBarDelegate>());
   auto* close_button = infobar->close_button_for_testing();
   ASSERT_TRUE(close_button);
   EXPECT_EQ(close_button, infobar->children().back());
+}
+
+// ----- Layout positioning -----
+
+TEST_F(BraveConfirmInfoBarTest, LayoutPlacesCloseButtonAtRightEdge) {
+  auto delegate = std::make_unique<TestInfoBarDelegate>();
+  delegate->set_message_text(u"hello");
+  auto infobar = CreateInfoBar(std::move(delegate));
+  LayOut(infobar.get());
+
+  auto* close = infobar->close_button_for_testing();
+  ASSERT_TRUE(close);
+  // Close button's right edge should align with (or be very close to) the
+  // infobar's right edge minus its trailing margin.
+  EXPECT_GT(close->x(), kTestInfoBarWidth / 2);
+  EXPECT_LE(close->bounds().right(), kTestInfoBarWidth);
+}
+
+TEST_F(BraveConfirmInfoBarTest, LayoutPlacesLinkAtRightEdge) {
+  auto delegate = std::make_unique<TestInfoBarDelegate>();
+  delegate->set_message_text(u"hello");
+  delegate->set_link_text(u"learn more");
+  auto infobar = CreateInfoBar(std::move(delegate));
+  LayOut(infobar.get());
+
+  auto* link = infobar->link_for_testing();
+  auto* close = infobar->close_button_for_testing();
+  ASSERT_TRUE(link);
+  ASSERT_TRUE(close);
+  // Link sits to the left of the close button.
+  EXPECT_LE(link->bounds().right(), close->x());
+  // And to the right of the horizontal midpoint (right-aligned).
+  EXPECT_GT(link->x(), kTestInfoBarWidth / 2);
+}
+
+TEST_F(BraveConfirmInfoBarTest, LayoutHorizontalOrdering) {
+  auto delegate = std::make_unique<TestInfoBarDelegate>();
+  delegate->set_message_text(u"Question");
+  delegate->set_buttons(ConfirmInfoBarDelegate::BUTTON_OK |
+                        ConfirmInfoBarDelegate::BUTTON_CANCEL);
+  delegate->set_link_text(u"learn more");
+  auto infobar = CreateInfoBar(std::move(delegate));
+  LayOut(infobar.get());
+
+  auto* label = infobar->label_for_testing();
+  auto* ok = infobar->ok_button_for_testing();
+  auto* cancel = infobar->cancel_button_for_testing();
+  auto* link = infobar->link_for_testing();
+  auto* close = infobar->close_button_for_testing();
+  ASSERT_TRUE(label);
+  ASSERT_TRUE(ok);
+  ASSERT_TRUE(cancel);
+  ASSERT_TRUE(link);
+  ASSERT_TRUE(close);
+
+  // label < ok < cancel along the x-axis.
+  EXPECT_LE(label->bounds().right(), ok->x());
+  EXPECT_LE(ok->bounds().right(), cancel->x());
+  // Link sits to the right of the cancel button.
+  EXPECT_LE(cancel->bounds().right(), link->x());
+  // Close button is at the very right.
+  EXPECT_LE(link->bounds().right(), close->x());
+}
+
+TEST_F(BraveConfirmInfoBarTest, LayoutPlacesCheckboxAfterButtons) {
+  auto delegate = std::make_unique<TestInfoBarDelegate>();
+  delegate->set_buttons(ConfirmInfoBarDelegate::BUTTON_OK);
+  delegate->set_has_checkbox(true);
+  delegate->set_checkbox_text(u"Don't show again");
+  auto infobar = CreateInfoBar(std::move(delegate));
+  LayOut(infobar.get());
+
+  auto* ok = infobar->ok_button_for_testing();
+  auto* checkbox = infobar->checkbox_for_testing();
+  ASSERT_TRUE(ok);
+  ASSERT_TRUE(checkbox);
+  EXPECT_LE(ok->bounds().right(), checkbox->x());
+}
+
+TEST_F(BraveConfirmInfoBarTest, LayoutVerticallyCentersChildren) {
+  auto delegate = std::make_unique<TestInfoBarDelegate>();
+  delegate->set_message_text(u"hello");
+  delegate->set_buttons(ConfirmInfoBarDelegate::BUTTON_OK);
+  delegate->set_link_text(u"learn more");
+  auto infobar = CreateInfoBar(std::move(delegate));
+  LayOut(infobar.get());
+
+  const int infobar_height = infobar->height();
+  ASSERT_GT(infobar_height, 0);
+
+  const auto vertical_center = [&](views::View* v) {
+    return v->y() + v->height() / 2;
+  };
+  // All laid-out children share roughly the same vertical center (within
+  // 1px tolerance for integer rounding).
+  const int expected_center = infobar_height / 2;
+  for (views::View* v :
+       {static_cast<views::View*>(infobar->label_for_testing()),
+        static_cast<views::View*>(infobar->ok_button_for_testing()),
+        static_cast<views::View*>(infobar->link_for_testing()),
+        infobar->close_button_for_testing()}) {
+    ASSERT_TRUE(v);
+    EXPECT_NEAR(vertical_center(v), expected_center, 2);
+  }
+}
+
+// ----- Multi-line height growth -----
+
+TEST_F(BraveConfirmInfoBarTest, MultiLineGrowsTargetHeight) {
+  auto delegate = std::make_unique<TestInfoBarDelegate>();
+  // Long message + supports_multi_line, link with text — both should wrap
+  // and trigger BraveSetTargetHeight to grow the infobar.
+  delegate->set_message_text(
+      u"This is a deliberately long message that should wrap across multiple "
+      u"lines when the infobar is narrow enough to force the layout to use "
+      u"multiple text lines.");
+  delegate->set_link_text(u"Learn more about this notice");
+  delegate->set_supports_multi_line(true);
+  auto infobar = CreateInfoBar(std::move(delegate));
+
+  const int default_height =
+      ChromeLayoutProvider::Get()->GetDistanceMetric(DISTANCE_INFOBAR_HEIGHT);
+  // Lay out at narrow width so the label/link actually need to wrap.
+  infobar->SetBounds(0, 0, 300, default_height);
+  views::test::RunScheduledLayout(infobar.get());
+
+  // After layout, BraveSetTargetHeight should have grown the target height
+  // beyond the single-line default to fit the wrapped content.
+  EXPECT_GT(infobar->target_height(), default_height);
+}
+
+TEST_F(BraveConfirmInfoBarTest, SingleLineKeepsDefaultHeight) {
+  auto delegate = std::make_unique<TestInfoBarDelegate>();
+  delegate->set_message_text(u"Short message");
+  // No multi-line — MaybeLayoutMultiLineLabelAndLink is a no-op.
+  auto infobar = CreateInfoBar(std::move(delegate));
+  LayOut(infobar.get());
+
+  EXPECT_EQ(
+      infobar->target_height(),
+      ChromeLayoutProvider::Get()->GetDistanceMetric(DISTANCE_INFOBAR_HEIGHT));
+}
+
+// ----- Interaction -----
+
+TEST_F(BraveConfirmInfoBarTest, CheckboxClickPropagatesToDelegate) {
+  auto delegate_owned = std::make_unique<TestInfoBarDelegate>();
+  delegate_owned->set_has_checkbox(true);
+  delegate_owned->set_checkbox_text(u"Don't show again");
+  auto* delegate = delegate_owned.get();
+  auto infobar = CreateInfoBar(std::move(delegate_owned));
+  LayOut(infobar.get());
+
+  auto* checkbox = infobar->checkbox_for_testing();
+  ASSERT_TRUE(checkbox);
+  EXPECT_FALSE(delegate->checkbox_checked());
+
+  views::test::ButtonTestApi(checkbox).NotifyClick(
+      ui::MouseEvent(ui::EventType::kMousePressed, gfx::Point(), gfx::Point(),
+                     ui::EventTimeForNow(), ui::EF_LEFT_MOUSE_BUTTON, 0));
+  EXPECT_TRUE(delegate->checkbox_checked());
 }

--- a/browser/ui/views/infobars/brave_confirm_infobar_unittest.cc
+++ b/browser/ui/views/infobars/brave_confirm_infobar_unittest.cc
@@ -185,12 +185,31 @@ TEST_F(BraveConfirmInfoBarTest, LabelAndLinkAlwaysExist) {
 
 // ----- Child order -----
 
-// Accessibility focus order requires the close button to be the last child.
+// Accessibility focus order requires the close button to be the last child,
+// regardless of how many other interactive children the infobar has (label,
+// buttons, checkbox, link).
 TEST_F(BraveConfirmInfoBarTest, CloseButtonOrderTest) {
-  auto infobar = CreateInfoBar(std::make_unique<TestInfoBarDelegate>());
-  auto* close_button = infobar->close_button_for_testing();
-  ASSERT_TRUE(close_button);
-  EXPECT_EQ(close_button, infobar->children().back());
+  // No buttons / no checkbox / no link.
+  {
+    auto infobar = CreateInfoBar(std::make_unique<TestInfoBarDelegate>());
+    auto* close_button = infobar->close_button_for_testing();
+    ASSERT_TRUE(close_button);
+    EXPECT_EQ(close_button, infobar->children().back());
+  }
+  // OK + Cancel + checkbox + link — close button still last.
+  {
+    auto delegate = std::make_unique<TestInfoBarDelegate>();
+    delegate->set_message_text(u"hello");
+    delegate->set_buttons(ConfirmInfoBarDelegate::BUTTON_OK |
+                          ConfirmInfoBarDelegate::BUTTON_CANCEL);
+    delegate->set_has_checkbox(true);
+    delegate->set_checkbox_text(u"Don't show again");
+    delegate->set_link_text(u"learn more");
+    auto infobar = CreateInfoBar(std::move(delegate));
+    auto* close_button = infobar->close_button_for_testing();
+    ASSERT_TRUE(close_button);
+    EXPECT_EQ(close_button, infobar->children().back());
+  }
 }
 
 // ----- Layout positioning -----

--- a/chromium_src/chrome/browser/ui/views/infobars/infobar_view.h
+++ b/chromium_src/chrome/browser/ui/views/infobars/infobar_view.h
@@ -12,7 +12,6 @@
 
 #define CloseButtonPressed              \
   CloseButtonPressed_Unused() {}        \
-  friend class BraveConfirmInfoBar;     \
   friend class WebDiscoveryInfoBarView; \
   virtual void CloseButtonPressed
 

--- a/chromium_src/ui/views/view.h
+++ b/chromium_src/ui/views/view.h
@@ -6,12 +6,19 @@
 #ifndef BRAVE_CHROMIUM_SRC_UI_VIEWS_VIEW_H_
 #define BRAVE_CHROMIUM_SRC_UI_VIEWS_VIEW_H_
 
+class BraveConfirmInfoBar;
 class SharedPinnedTabDummyView;
 
 // DO NOT ADD TO THIS LIST!
 // These existing cases are "grandfathered in", but there shouldn't be more.
 // See comments atop View class in ui/views/view.h.
+//
+// BraveConfirmInfoBar is added here for the same reason ::InfoBarView is on
+// upstream's list: it is an infobars::InfoBar implementation whose lifetime
+// is governed by infobars::InfoBarManager, not by its parent View.
+// Remove when upstream resolves ownership issue from ConfirmInfoBar.
 #define BRAVE_VIEW_OWNED_BY_CLIENT_PASS_KEY \
+  friend class ::BraveConfirmInfoBar;       \
   friend class ::SharedPinnedTabDummyView;
 
 #include <ui/views/view.h>  // IWYU pragma: export


### PR DESCRIPTION
BraveConfirmInfoBar used to inherit from InfoBarView, so its layout
changed with upstream's features::kInfobarRefresh — vertical centering,
label/link gaps, icon offset and multi-line height all shifted between
the flag-off and flag-on states.

As we're using BraveConfirmInfoBar for our specific info bar only,
we don't need to get suffer from upstream's view change over time.
We can go with our own custom view based on `infobars::InfoBar` interface.

Replace the base class with direct multi-inheritance from
infobars::InfoBar, views::View and views::ExternalFocusTracker, and
implement Layout / CalculatePreferredSize / OnThemeChanged /
PlatformSpecific* ourselves. The visual is now identical regardless of
the upstream flag and we no longer depend on InfoBarView's internal
structure.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves - subtask of https://github.com/brave/brave-browser/issues/48822

No regressions on existing infobars that uses BraveConfirmInfoBar.
infobar with multi-line:
<img width="1049" height="121" alt="image" src="https://github.com/user-attachments/assets/f675cbdc-b4ec-4a5f-9676-c66f81244b6a" />

infobar with checkbox:
<img width="1049" height="121" alt="image" src="https://github.com/user-attachments/assets/ca7cc69f-61ff-4f94-8211-05cefad6c37f" />

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
