### PR TITLE
[brockit][sync] Avoiding `bool` in `DeviceInfo`

### DIFF
--- a/browser/sync/brave_sync_devices_android.cc
+++ b/browser/sync/brave_sync_devices_android.cc
@@ -79,7 +79,9 @@ base::ListValue BraveSyncDevicesAndroid::GetSyncDeviceList() {
     device_value.Set("isCurrentDevice", is_current_device);
     // DeviceInfo::ToValue doesn't put guid
     device_value.Set("guid", device->guid());
-    device_value.Set("supportsSelfDelete", device->is_self_delete_supported());
+    device_value.Set(
+        "supportsSelfDelete",
+        device->self_delete_support() == syncer::SelfDeleteSupport::kSupported);
     device_list.Append(std::move(device_value));
   }
 

--- a/browser/ui/webui/settings/brave_sync_handler.cc
+++ b/browser/ui/webui/settings/brave_sync_handler.cc
@@ -418,8 +418,10 @@ base::ListValue BraveSyncHandler::GetSyncDeviceList() {
         local_device_info && local_device_info->guid() == device->guid();
     device_value.Set("isCurrentDevice", is_current_device);
     device_value.Set("guid", device->guid());
-    device_value.Set("supportsSelfDelete",
-                     !is_current_device && device->is_self_delete_supported());
+    device_value.Set(
+        "supportsSelfDelete",
+        !is_current_device && device->self_delete_support() ==
+                                  syncer::SelfDeleteSupport::kSupported);
 
     device_list.Append(std::move(device_value));
   }

--- a/chromium_src/components/sync_device_info/device_info.h
+++ b/chromium_src/components/sync_device_info/device_info.h
@@ -8,7 +8,16 @@
 
 #include "base/values.h"
 
-// This header only exists to add `base/values.h` to the Chromium header.
+namespace syncer {
+
+// Whether a peer device supports being remotely told to delete itself.
+enum class SelfDeleteSupport {
+  kNotSupported,
+  kSupported,
+};
+
+}  // namespace syncer
+
 #include <components/sync_device_info/device_info.h>  // IWYU pragma: export
 
 #endif  // BRAVE_CHROMIUM_SRC_COMPONENTS_SYNC_DEVICE_INFO_DEVICE_INFO_H_

--- a/chromium_src/components/sync_device_info/device_info_sync_bridge.cc
+++ b/chromium_src/components/sync_device_info/device_info_sync_bridge.cc
@@ -44,6 +44,16 @@ namespace {
 
 constexpr int kFailedAttemtpsToAckDeviceDelete = 5;
 
+SelfDeleteSupport SpecificsToSelfDeleteSupport(
+    const DeviceInfoSpecifics& specifics) {
+  if (specifics.has_brave_fields() &&
+      specifics.brave_fields().has_is_self_delete_supported() &&
+      specifics.brave_fields().is_self_delete_supported()) {
+    return SelfDeleteSupport::kSupported;
+  }
+  return SelfDeleteSupport::kNotSupported;
+}
+
 std::unique_ptr<DeviceInfo> BraveSpecificsToModel(
     const DeviceInfoSpecifics& specifics) {
   DataTypeSet data_types;
@@ -77,9 +87,7 @@ std::unique_ptr<DeviceInfo> BraveSpecificsToModel(
       SpecificsToAutoSignOutLastSigninTimestamp(specifics),
       specifics.feature_fields().desktop_to_ios_promo_receiving_enabled(),
       SpecificsToDesktopToIOSPromoReceivingTypes(specifics),
-      specifics.has_brave_fields() &&
-          specifics.brave_fields().has_is_self_delete_supported() &&
-          specifics.brave_fields().is_self_delete_supported());
+      SpecificsToSelfDeleteSupport(specifics));
 }
 
 }  // namespace

--- a/ios/browser/api/sync/brave_sync_api.mm
+++ b/ios/browser/api/sync/brave_sync_api.mm
@@ -320,7 +320,9 @@ BraveSyncAPIWordsValidationStatus const
         local_device_info && local_device_info->guid() == device->guid();
     device_value.Set("isCurrentDevice", is_current_device);
     device_value.Set("guid", device->guid());
-    device_value.Set("supportsSelfDelete", device->is_self_delete_supported());
+    device_value.Set(
+        "supportsSelfDelete",
+        device->self_delete_support() == syncer::SelfDeleteSupport::kSupported);
     device_list_value.Append(base::Value(std::move(device_value)));
   }
 

--- a/patches/components-sync_device_info-device_info.cc.patch
+++ b/patches/components-sync_device_info-device_info.cc.patch
@@ -1,5 +1,5 @@
 diff --git a/components/sync_device_info/device_info.cc b/components/sync_device_info/device_info.cc
-index f828751332055e70fef223044da7dc6944f221a3..c578d1169cb46de6d8cfe3b18b717a7f20d3698c 100644
+index f828751332055e70fef223044da7dc6944f221a3..5ae8a20b5ffa20c2c05bc43cd2d8660a931182ba 100644
 --- a/components/sync_device_info/device_info.cc
 +++ b/components/sync_device_info/device_info.cc
 @@ -81,7 +81,8 @@ DeviceInfo::DeviceInfo(
@@ -8,7 +8,7 @@ index f828751332055e70fef223044da7dc6944f221a3..c578d1169cb46de6d8cfe3b18b717a7f
      const MobilePromoOnDesktopPromoTypeSet&
 -        desktop_to_ios_promo_receiving_types)
 +        desktop_to_ios_promo_receiving_types,
-+    bool is_self_delete_supported)
++    SelfDeleteSupport self_delete_support)
      : guid_(guid),
        client_name_(client_name),
        chrome_version_(chrome_version),
@@ -18,7 +18,7 @@ index f828751332055e70fef223044da7dc6944f221a3..c578d1169cb46de6d8cfe3b18b717a7f
        desktop_to_ios_promo_receiving_types_(
 -          desktop_to_ios_promo_receiving_types) {}
 +          desktop_to_ios_promo_receiving_types),
-+      is_self_delete_supported_(is_self_delete_supported) {}
++      self_delete_support_(self_delete_support) {}
  
  DeviceInfo::~DeviceInfo() = default;
  

--- a/patches/components-sync_device_info-device_info.h.patch
+++ b/patches/components-sync_device_info-device_info.h.patch
@@ -1,22 +1,25 @@
 diff --git a/components/sync_device_info/device_info.h b/components/sync_device_info/device_info.h
-index 0de973ef3cfb970cfdbc773cc8be98ae6d384750..ee4159c9b15a0661067646a5169f93c1691052bc 100644
+index 0de973ef3cfb970cfdbc773cc8be98ae6d384750..7605a23c9386910e5f8ed76616309a47e21fbcd2 100644
 --- a/components/sync_device_info/device_info.h
 +++ b/components/sync_device_info/device_info.h
-@@ -192,12 +192,24 @@ class DeviceInfo {
+@@ -192,12 +192,27 @@ class DeviceInfo {
               std::optional<base::Time> auto_sign_out_last_signin_timestamp,
               bool desktop_to_ios_promo_receiving_enabled,
               const MobilePromoOnDesktopPromoTypeSet&
 -                 desktop_to_ios_promo_receiving_types = {});
 +                 desktop_to_ios_promo_receiving_types = {},
-+             bool is_self_delete_supported = false);
++             SelfDeleteSupport self_delete_support =
++                 SelfDeleteSupport::kNotSupported);
  
    DeviceInfo(const DeviceInfo&) = delete;
    DeviceInfo& operator=(const DeviceInfo&) = delete;
  
    ~DeviceInfo();
-+  bool is_self_delete_supported() const { return is_self_delete_supported_; }
-+  void set_is_self_delete_supported(bool is_self_delete_supported) {
-+    is_self_delete_supported_ = is_self_delete_supported;
++  SelfDeleteSupport self_delete_support() const {
++    return self_delete_support_;
++  }
++  void set_self_delete_support(SelfDeleteSupport self_delete_support) {
++    self_delete_support_ = self_delete_support;
 +  }
 +  // Gets the OS in string form.
 +  std::string GetOSString() const;
@@ -28,11 +31,11 @@ index 0de973ef3cfb970cfdbc773cc8be98ae6d384750..ee4159c9b15a0661067646a5169f93c1
  
    // Sync specific unique identifier for the device. Note if a device
    // is wiped and sync is set up again this id WILL be different.
-@@ -372,6 +384,7 @@ class DeviceInfo {
+@@ -372,6 +387,7 @@ class DeviceInfo {
    // NOTE: when adding a member, don't forget to update
    // |StoredDeviceInfoStillAccurate| in device_info_sync_bridge.cc or else
    // changes in that member might not trigger uploads of updated DeviceInfos.
-+  bool is_self_delete_supported_;
++  SelfDeleteSupport self_delete_support_;
  };
  
  }  // namespace syncer

--- a/rewrite/components/sync_device_info/device_info.cc.toml
+++ b/rewrite/components/sync_device_info/device_info.cc.toml
@@ -4,22 +4,22 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
 [[substitution]]
-description = '''Add `is_self_delete_supported` to the ctor.
+description = '''Add `self_delete_support` to the ctor.
 
 This regex always adds the argument as the last one in the argument list. This
-is used to initialise `is_self_delete_supported_`.
+is used to initialise `self_delete_support_`.
 '''
 re_pattern = '(DeviceInfo::DeviceInfo\(.*?)(\)\n\s+:)'
 re_flags = ['DOTALL']
 replace = '''\1,
-    bool is_self_delete_supported\2'''
+    SelfDeleteSupport self_delete_support\2'''
 
 [[substitution]]
-description = '''Initialize `is_self_delete_supported_` in the constructor
+description = '''Initialize `self_delete_support_` in the constructor
 
-This always initialises `is_self_delete_supported_` as the last field.
+This always initialises `self_delete_support_` as the last field.
 '''
 re_pattern = '(DeviceInfo::DeviceInfo\(.*?)( \{\})'
 re_flags = ['DOTALL']
 replace = '''\1,
-      is_self_delete_supported_(is_self_delete_supported)\2'''
+      self_delete_support_(self_delete_support)\2'''

--- a/rewrite/components/sync_device_info/device_info.h.toml
+++ b/rewrite/components/sync_device_info/device_info.h.toml
@@ -4,19 +4,20 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
 [[substitution]]
-description = '''Add is_self_delete_supported to the ctor arg list
+description = '''Add self_delete_support to the ctor arg list
 
-Adding `is_self_delete_supported` so it can be used to initialise
-`is_self_delete_supported_`.
+Adding `self_delete_support` so it can be used to initialise
+`self_delete_support_`.
 
 This regex matches with the constructor declaration, by checking that there is
-a `std::string` somewhere in the list, and adds `is_self_delete_supported` as
-the last argument in the list.
+a `std::string` somewhere in the list, and adds `self_delete_support` as the
+last argument in the list.
 '''
 re_pattern = '(DeviceInfo\((?=[^)]*std::string).*?)(\);)'
 re_flags = ['DOTALL']
 replace = '''\1,
-             bool is_self_delete_supported = false\2'''
+             SelfDeleteSupport self_delete_support =
+                 SelfDeleteSupport::kNotSupported\2'''
 
 [[substitution]]
 description = '''Add Brave-specific methods to DeviceInfo public interface
@@ -27,9 +28,11 @@ Brave.
 '''
 re_pattern = '(~DeviceInfo\(\);)'
 replace = '''\1
-  bool is_self_delete_supported() const { return is_self_delete_supported_; }
-  void set_is_self_delete_supported(bool is_self_delete_supported) {
-    is_self_delete_supported_ = is_self_delete_supported;
+  SelfDeleteSupport self_delete_support() const {
+    return self_delete_support_;
+  }
+  void set_self_delete_support(SelfDeleteSupport self_delete_support) {
+    self_delete_support_ = self_delete_support;
   }
   // Gets the OS in string form.
   std::string GetOSString() const;
@@ -40,12 +43,12 @@ replace = '''\1
   base::DictValue ToValue() const;'''
 
 [[substitution]]
-description = '''Add is_self_delete_supported_ as last member of DeviceInfo
+description = '''Add self_delete_support_ as last member of DeviceInfo
 
-This replacement adds `is_self_delete_supported_` as the last member of
+This replacement adds `self_delete_support_` as the last member of
 `DeviceInfo`.
 '''
 re_pattern = '(class DeviceInfo \{.*)(\n\};)'
 re_flags = ['DOTALL']
 replace = '''\1
-  bool is_self_delete_supported_;\2'''
+  SelfDeleteSupport self_delete_support_;\2'''


### PR DESCRIPTION
The use of `bool` for `DeviceInfo` fields has led to bugs in the past.
This has been correct with plaster, however we should also convert the
field to an enum to make sure we follow the upstream practice of using
enums in this type.

Resolves https://github.com/brave/brave-browser/issues/55018
