### PR TITLE
[Wallet]: Prioritize Native Asset in Select Token Modal

### DIFF
--- a/components/brave_wallet_ui/page/screens/composer_ui/select_token_modal/select_token_modal.tsx
+++ b/components/brave_wallet_ui/page/screens/composer_ui/select_token_modal/select_token_modal.tsx
@@ -42,7 +42,7 @@ import {
   getTokenPriceFromRegistry,
   getPriceRequestsForTokens,
 } from '../../../../utils/pricing-utils'
-import { getAssetIdKey } from '../../../../utils/asset-utils'
+import { getAssetIdKey, isNativeAsset } from '../../../../utils/asset-utils'
 import {
   getEntitiesListFromEntityState, //
 } from '../../../../utils/entities.utils'
@@ -406,7 +406,30 @@ export const SelectTokenModal = React.forwardRef<HTMLDivElement, Props>(
           token: a,
         })
 
-        return bFiatBalance.minus(aFiatBalance).toNumber()
+        // Primary order: higher owned fiat value first.
+        const fiatCompare = bFiatBalance.minus(aFiatBalance).toNumber()
+        if (fiatCompare !== 0) {
+          return fiatCompare
+        }
+
+        // When fiat ties (often $0 for zero balance), put native chain assets
+        // (e.g. ETH, SOL) above other tokens that also have zero balance so
+        // users still see gas / network currency first in the list.
+        const aBalanceIsZero = new Amount(aBalance).isZero()
+        const bBalanceIsZero = new Amount(bBalance).isZero()
+        if (aBalanceIsZero && bBalanceIsZero) {
+          const aIsNative = isNativeAsset(a)
+          const bIsNative = isNativeAsset(b)
+          if (aIsNative && !bIsNative) {
+            return -1
+          }
+          if (!aIsNative && bIsNative) {
+            return 1
+          }
+        }
+
+        // Same fiat tier and no native-vs-non-native tie to break.
+        return 0
       })
     }, [tokensBySelectedComposerOption, userTokenBalances, spotPrices])
 


### PR DESCRIPTION
## Description 

Will now prioritize `Native` assets at the top of the `Not owned` section in the `Select Token` modal

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/55500>

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

## Test plan:
1. Open the `Wallet` and navigate to the `Swap` or `Bride` screen
2. Select a token to swap from and then open the `Select Token` modal to swap to
3. If you have a `zero` balance for the `native` asset in the list, it should be at the top of the `Not owned` section of the list.

https://github.com/user-attachments/assets/9e9a3f24-47e1-4b1a-9dee-44d4ecf859d6
