### PR TITLE
Fix settings menu overflow and layout width

### DIFF
--- a/browser/resources/settings/br/settings_menu.ts
+++ b/browser/resources/settings/br/settings_menu.ts
@@ -63,10 +63,15 @@ RegisterStyleOverride(
         position: sticky;
         top: var(--brave-settings-menu-margin-v);
         margin: 0 !important;
-        min-width: 172px;
-        max-width: 250px;
+        min-width: 0;
+        overflow-x: hidden;
         overflow-y: auto;
         padding: 12px 24px !important;
+      }
+      /* Chromium sets min-width: fit-content here, forcing overflow past width. */
+      #menu {
+        max-width: 100%;
+        min-width: 0;
       }
       .cr-nav-menu-item {
         min-height: 20px !important;

--- a/browser/resources/settings/br/settings_ui.ts
+++ b/browser/resources/settings/br/settings_ui.ts
@@ -77,8 +77,15 @@ RegisterStyleOverride(
       #container {
         /* menu and content next to each other in the horizontal center */
       }
+      /*
+       * Chromium uses flex: 1 1 0 on #left, so the column grows beyond
+       * --settings-menu-width; cap it so layout matches menu width exactly.
+       */
       #left {
-        max-width: 250px;
+        flex: 0 0 var(--settings-menu-width);
+        max-width: var(--settings-menu-width);
+        min-width: 0;
+        overflow-x: hidden;
       }
       #main {
         margin: 0 var(--leo-spacing-m) var(--leo-spacing-m) 0;


### PR DESCRIPTION
Prevent the settings sidebar from forcing horizontal overflow and ensure the left column matches the menu width. Remove fixed min/max widths, set min-width: 0 and overflow-x: hidden on menu and left column, and add a #menu rule to override Chromium's fit-content min-width. Change #left to flex: 0 0 var(--settings-menu-width) with max-width/min-width to cap growth so layout matches the menu exactly.



<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
