### PR TITLE
[cr149][brockit] `@latest-{channel}` latest version for all platforms

### DIFF
--- a/tools/cr/brockit.py
+++ b/tools/cr/brockit.py
@@ -545,6 +545,7 @@ class ActionNeededException(Exception):
         super().__init__(message)
         console.log(message)
 
+
 class Task:
     """ Base class for all tasks in brockit.
 
@@ -686,6 +687,7 @@ class Regen(Versioned):
             self._save_rebased_l10n()
 
         self._save_gnrt_rerun(dry_run=dry_run)
+
 
 class GitHubIssue(Versioned):
     """Creates a GitHub issue for the upgrade.
@@ -1603,7 +1605,6 @@ class Upgrade(Versioned):
                 f'Conflict-resolved patches from Chromium {self.base_version} '
                 f'to Chromium {self.target_version}.')
 
-
         self._save_updated_patches()
         # Run init again to make sure nothing is missing after updating
         # patches.
@@ -2024,7 +2025,6 @@ class Rebase(Task):
                              encoding='utf-8',
                              newline='')
 
-
     @staticmethod
     def fix_squash_commit_messages(todo_file: Path):
         """Fixes the commit messages during rebase squash.
@@ -2229,13 +2229,24 @@ class Reassign(Task):
             allows_empty=True,
             no_verify=True)
 
-def fetch_chromium_dash_version(channel: str, target_platform: str) -> Version:
-    """Fetches the latest version from the Chromium Dash.
+
+def fetch_chromium_dash_version(channel: str) -> Version:
+    """Fetches the highest latest version across all platforms for a channel.
+
+    For the canary channel, the ASAN variant on Windows is also considered.
     """
-    response = requests.get(CHROMIUMDASH_LATEST_RELEASE.format(
-        channel=channel, platform=target_platform),
-                            timeout=10)
-    return Version(response.json()[0].get('version'))
+
+    def _fetch(channel: str, target_platform: str) -> Version:
+        response = requests.get(CHROMIUMDASH_LATEST_RELEASE.format(
+            channel=channel, platform=target_platform),
+                                timeout=10)
+        return Version(response.json()[0].get('version'))
+
+    platforms = ('Windows', 'Linux', 'Android', 'Mac', 'ios')
+    versions = [_fetch(channel, platform) for platform in platforms]
+    if channel == 'canary':
+        versions.append(_fetch('canary_asan', target_platform='Windows'))
+    return max(versions)
 
 
 def _fetch_chromium_tag(to: str) -> Version:
@@ -2296,24 +2307,7 @@ def _fetch_chromium_tag(to: str) -> Version:
                 f'Invalid @latest channel: "{channel}". '
                 'Valid options: canary, beta, dev, stable.')
 
-        if channel == 'canary':
-            # The canary branch has two versions, the regular and the ASAN
-            # version, and we want the highest of the two.
-            canary_version = fetch_chromium_dash_version(
-                'canary', target_platform='Windows')
-            canary_asan_version = fetch_chromium_dash_version(
-                'canary_asan', target_platform='Windows')
-            linux_version = fetch_chromium_dash_version(
-                channel='canary', target_platform='Linux')
-            adroid_version = fetch_chromium_dash_version(
-                channel='canary', target_platform='Android')
-            mac_version = fetch_chromium_dash_version(channel='canary',
-                                                      target_platform='Mac')
-            ios_verion = fetch_chromium_dash_version(channel='canary',
-                                                     target_platform='ios')
-            return max(canary_version, canary_asan_version, linux_version,
-                       adroid_version, ios_verion, mac_version)
-        return fetch_chromium_dash_version(channel, target_platform='Windows')
+        return fetch_chromium_dash_version(channel)
 
     raise InvalidInputException(
         f'Unknown label: "{to}". '
@@ -2344,6 +2338,7 @@ def show(args: argparse.Namespace):
     if args.chromium_version_label is not None:
         console.print('version: %s' %
                       _fetch_chromium_tag(args.chromium_version_label))
+
 
 def main():
     # This is a global parser with arguments that apply to every function.


### PR DESCRIPTION
This channge makes the label `@latest-{channel}` to return the latest
version in all platforms, for all channels, not only `canary`.
