### PR TITLE
Uplift intermittent test fixes and crash fixes to 1.91.x

### DIFF
--- a/browser/brave_shields/ad_block_service_browsertest.cc
+++ b/browser/brave_shields/ad_block_service_browsertest.cc
@@ -166,14 +166,15 @@ void AdBlockServiceTest::PreRunTestOnMainThread() {
   PlatformBrowserTest::PreRunTestOnMainThread();
   ASSERT_TRUE(brave_shields::WaitForAdBlockServiceThreads());
 
-  // Wait for initial engine creation to complete, especially on slower
-  // platforms
+  // Wait for the initial engine creation reply to be fully processed on the
+  // UI thread. Using the UI-thread flag (set in OnEngineLoaded) instead of the
+  // cross-thread histogram avoids a race where RunUntil sees the histogram
+  // sample recorded on the background thread but returns before OnEngineLoaded
+  // dispatches OnFilterListLoaded on the UI thread, leaving a stale
+  // notification that the observer in InstallComponent can catch prematurely.
   ASSERT_TRUE(base::test::RunUntil([&]() {
-    auto counts = histogram_tester_.GetTotalCountsForPrefix(
-        "Brave.Adblock.MakeEngineWithRules.Default");
-    return counts.find("Brave.Adblock.MakeEngineWithRules.Default") !=
-               counts.end() &&
-           counts.at("Brave.Adblock.MakeEngineWithRules.Default") >= 1;
+    return g_brave_browser_process->ad_block_service()
+        ->IsFilterListLoadedForTesting(true);
   })) << "Timeout waiting for initial engine creation";
 
   histogram_tester_.ExpectTotalCount(

--- a/browser/email_aliases/email_aliases_browsertest.cc
+++ b/browser/email_aliases/email_aliases_browsertest.cc
@@ -175,6 +175,7 @@ class EmailAliasesBrowserTestBase : public InProcessBrowserTest {
   }
 
   void InjectHelpers(content::WebContents* contents) {
+    ASSERT_TRUE(content::WaitForLoadStop(contents));
     constexpr char kDeepQuery[] = R"js(
       function deepQuery(selector) {
         const query = (root, selector) =>{

--- a/browser/email_aliases/email_aliases_browsertest.cc
+++ b/browser/email_aliases/email_aliases_browsertest.cc
@@ -175,6 +175,10 @@ class EmailAliasesBrowserTestBase : public InProcessBrowserTest {
   }
 
   void InjectHelpers(content::WebContents* contents) {
+    ASSERT_TRUE(base::test::RunUntil([&]() {
+      return !contents->GetLastCommittedURL().is_empty() &&
+             !contents->GetLastCommittedURL().IsAboutBlank();
+    }));
     ASSERT_TRUE(content::WaitForLoadStop(contents));
     constexpr char kDeepQuery[] = R"js(
       function deepQuery(selector) {

--- a/browser/metrics/variations_browsertest.cc
+++ b/browser/metrics/variations_browsertest.cc
@@ -7,6 +7,7 @@
 #include "base/test/metrics/histogram_tester.h"
 #include "chrome/browser/browser_process.h"
 #include "chrome/test/base/platform_browser_test.h"
+#include "components/variations/seed_reader_writer.h"
 #include "components/variations/service/variations_field_trial_creator.h"
 #include "components/variations/variations_test_utils.h"
 #include "content/public/test/browser_test.h"
@@ -45,7 +46,12 @@ SignedSeedData GetBraveSignedSeedData() {
 
 class VariationsBrowserTest : public PlatformBrowserTest {
  public:
-  VariationsBrowserTest() { DisableTestingConfig(); }
+  VariationsBrowserTest() {
+    DisableTestingConfig();
+    // Force the SeedFileTrial to Default so seed loading reads from prefs
+    // (where WriteSeedData stores the test seed) rather than a seed file.
+    SetUpSeedFileTrial(kDefaultGroup);
+  }
   ~VariationsBrowserTest() override = default;
 
  protected:

--- a/browser/ui/views/tabs/brave_browser_tab_strip_controller.cc
+++ b/browser/ui/views/tabs/brave_browser_tab_strip_controller.cc
@@ -269,10 +269,11 @@ void BraveBrowserTabStripController::OnTreeTabChanged(
           created_change.node->GetTabs();
       for (const tabs::TabInterface* tab : tabs) {
         auto index = model_->GetIndexOfTab(tab);
-        // The tab may not yet have a model index when the deferred
-        // kNodeCreated notification fires during pin/unpin operations
-        // (e.g., the tab is still being moved between collections).
-        if (index == TabStripModel::kNoTab) {
+        // The deferred kNodeCreated notification (via PostTask) can fire
+        // while model and tab strip views are out of sync — the tab may
+        // have no model index, or the view at that index may not exist yet.
+        if (index == TabStripModel::kNoTab ||
+            index >= tabstrip_->GetTabCount()) {
           continue;
         }
         auto* tab_view = tabstrip_->tab_at(index);

--- a/chromium_src/components/browsing_data/content/browsing_data_test_util.cc
+++ b/chromium_src/components/browsing_data/content/browsing_data_test_util.cc
@@ -1,0 +1,40 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// Brave disables Chromium's cookie IPC cache optimization (because Ephemeral
+// Storage can switch the cookie backend at runtime), which means
+// document.cookie always uses IPC.  When a test sets a cookie via
+// document.cookie and immediately queries the backend cookie store through a
+// *different* Mojo pipe (CookieManager::GetAllCookies), there is no ordering
+// guarantee between the two pipes.  Upstream Chromium sees this as a ~0.6 %
+// flake; Brave amplifies it because every cookie read/write goes through IPC.
+//
+// Fix: after ExecJs("set<Type>()"), verify the data is accessible via
+// EvalJs("has<Type>()").  For cookies this forces a round-trip through
+// RestrictedCookieManager → CookieStore, serialising with the prior
+// SetCanonicalCookieAsync on the same CookieMonster task runner and
+// guaranteeing the cookie is committed before any subsequent GetAllCookies.
+
+#define SetDataForType SetDataForType_ChromiumImpl
+
+#include <components/browsing_data/content/browsing_data_test_util.cc>  // IWYU pragma: export
+
+#undef SetDataForType
+
+namespace browsing_data_test_util {
+
+void SetDataForType(const std::string& type,
+                    content::WebContents* web_contents) {
+  SetDataForType_ChromiumImpl(type, web_contents);
+  // Round-trip through RestrictedCookieManager to synchronise the CookieStore.
+  EXPECT_TRUE(HasDataForType(type, web_contents));
+}
+
+void SetDataForType(const std::string& type,
+                    content::RenderFrameHost* render_frame_host) {
+  SetDataForType_ChromiumImpl(type, render_frame_host);
+}
+
+}  // namespace browsing_data_test_util

--- a/components/brave_wallet/browser/blockchain_registry.cc
+++ b/components/brave_wallet/browser/blockchain_registry.cc
@@ -518,6 +518,20 @@ void BlockchainRegistry::ParseLists(const base::FilePath& install_dir,
       base::BindOnce(&UpdateRegistry, std::move(callback)));
 }
 
+BlockchainRegistry::ScopedRestrictedAddressesForTesting::
+    ScopedRestrictedAddressesForTesting(
+        std::vector<std::string> restricted_addresses) {
+  auto* registry = GetInstance();
+  previous_addresses_ = registry->restricted_addresses_;
+  registry->UpdateRestrictedAddressesList(std::move(restricted_addresses));
+}
+
+BlockchainRegistry::ScopedRestrictedAddressesForTesting::
+    ~ScopedRestrictedAddressesForTesting() {
+  auto* registry = GetInstance();
+  registry->restricted_addresses_ = std::move(previous_addresses_);
+}
+
 bool BlockchainRegistry::IsEmptyForTesting() {
   return coingecko_ids_map_.empty() && token_list_map_.empty() &&
          chain_list_.empty() && dapp_lists_.empty() &&

--- a/components/brave_wallet/browser/blockchain_registry.h
+++ b/components/brave_wallet/browser/blockchain_registry.h
@@ -95,6 +95,21 @@ class BlockchainRegistry : public mojom::BlockchainRegistry {
   bool IsRestrictedAddress(const std::string& address);
   void ParseLists(const base::FilePath& dir, base::OnceClosure callback);
 
+  class ScopedRestrictedAddressesForTesting {
+   public:
+    explicit ScopedRestrictedAddressesForTesting(
+        std::vector<std::string> restricted_addresses);
+    ~ScopedRestrictedAddressesForTesting();
+
+    ScopedRestrictedAddressesForTesting(
+        const ScopedRestrictedAddressesForTesting&) = delete;
+    ScopedRestrictedAddressesForTesting& operator=(
+        const ScopedRestrictedAddressesForTesting&) = delete;
+
+   private:
+    base::flat_set<std::string> previous_addresses_;
+  };
+
   bool IsEmptyForTesting();
   void ResetForTesting();
 

--- a/components/brave_wallet/browser/blockchain_registry_unittest.cc
+++ b/components/brave_wallet/browser/blockchain_registry_unittest.cc
@@ -925,7 +925,8 @@ TEST(BlockchainRegistryUnitTest, IsRestrictedAddress) {
   // After parsing the list, we should have some addresses;
   std::vector<std::string> input_list;
   input_list.push_back("0xb9ef770b6a5e12e45983c5d80545258aa38f3b78");
-  registry->UpdateRestrictedAddressesList(input_list);
+  BlockchainRegistry::ScopedRestrictedAddressesForTesting scoped_restricted(
+      input_list);
   EXPECT_TRUE(registry->IsRestrictedAddress(
       "0xb9ef770b6a5e12e45983c5d80545258aa38f3b78"));
   EXPECT_TRUE(registry->IsRestrictedAddress(

--- a/components/brave_wallet/browser/eth_tx_manager_unittest.cc
+++ b/components/brave_wallet/browser/eth_tx_manager_unittest.cc
@@ -605,8 +605,7 @@ TEST_F(EthTxManagerUnitTest, SomeSiteOrigin) {
 
 TEST_F(EthTxManagerUnitTest, RestrictedFromAddress) {
   const auto from_account = from();
-  auto* registry = BlockchainRegistry::GetInstance();
-  registry->UpdateRestrictedAddressesList(
+  BlockchainRegistry::ScopedRestrictedAddressesForTesting scoped_restricted(
       {base::ToLowerASCII(from_account->address)});
 
   // AddUnapprovedEvmTransaction should fail.
@@ -663,8 +662,6 @@ TEST_F(EthTxManagerUnitTest, RestrictedFromAddress) {
     EXPECT_TRUE(tx_meta_id.empty());
     EXPECT_EQ(error, WalletInternalErrorMessage());
   }
-
-  registry->UpdateRestrictedAddressesList({});
 }
 
 TEST_F(EthTxManagerUnitTest, AddUnapprovedTransactionWithoutGasLimit) {
@@ -2320,9 +2317,8 @@ TEST_F(EthTxManagerUnitTest, MakeERC721TransferFromDataTxType) {
   run_loop->Run();
 
   // Address on the restricted list should fail.
-  auto* registry = BlockchainRegistry::GetInstance();
-  registry->UpdateRestrictedAddressesList(
-      {"0xbfb30a082f650c2a15d0632f0e87be4f8e64460a"});
+  BlockchainRegistry::ScopedRestrictedAddressesForTesting
+      scoped_erc721_restricted({"0xbfb30a082f650c2a15d0632f0e87be4f8e64460a"});
   run_loop = std::make_unique<base::RunLoop>();
   eth_tx_manager()->MakeERC721TransferFromData(
       "0xBFb30a082f650C2A15D0632f0e87bE4F8e64460f",
@@ -2335,16 +2331,17 @@ TEST_F(EthTxManagerUnitTest, MakeERC721TransferFromDataTxType) {
 
 TEST_F(EthTxManagerUnitTest, MakeERC1155TransferFromData) {
   // Invalid if to_address is on restricted list
-  auto* registry = BlockchainRegistry::GetInstance();
-  registry->UpdateRestrictedAddressesList(
-      {"0xbfb30a082f650c2a15d0632f0e87be4f8e64460a"});
-  TestMakeERC1155TransferFromDataTxType(
-      "0xbfb30a082f650c2a15d0632f0e87be4f8e64460f", "", "0xf", "0x1",
-      "0x0d8775f648430679a709e98d2b0cb6250d2887ef", false,
-      mojom::TransactionType::Other);
+  {
+    BlockchainRegistry::ScopedRestrictedAddressesForTesting
+        scoped_erc1155_restricted(
+            {"0xbfb30a082f650c2a15d0632f0e87be4f8e64460a"});
+    TestMakeERC1155TransferFromDataTxType(
+        "0xbfb30a082f650c2a15d0632f0e87be4f8e64460f", "", "0xf", "0x1",
+        "0x0d8775f648430679a709e98d2b0cb6250d2887ef", false,
+        mojom::TransactionType::Other);
+  }
 
   // Valid
-  registry->UpdateRestrictedAddressesList({});
   TestMakeERC1155TransferFromDataTxType(
       "0xbfb30a082f650c2a15d0632f0e87be4f8e64460f",
       "0xbfb30a082f650c2a15d0632f0e87be4f8e64460a", "0xf", "0x1",

--- a/components/brave_wallet/browser/ethereum_keyring_unittest.cc
+++ b/components/brave_wallet/browser/ethereum_keyring_unittest.cc
@@ -413,15 +413,13 @@ TEST(EthereumKeyringUnitTest, AddNewHDAccount_RestrictedAddress) {
   EXPECT_TRUE(keyring.RemoveHDAccount(0));
 
   // Add address to restricted list.
-  registry->UpdateRestrictedAddressesList(
+  BlockchainRegistry::ScopedRestrictedAddressesForTesting scoped_restricted(
       {base::ToLowerASCII(address_to_restrict)});
 
   // Try to add account again - should fail because it generates the same
   // address.
   auto result = keyring.AddNewHDAccount(0);
   EXPECT_FALSE(result) << "Restricted Ethereum address should be rejected";
-
-  registry->UpdateRestrictedAddressesList({});
 }
 
 TEST(EthereumKeyringUnitTest, ImportAccount_RestrictedAddress) {
@@ -448,14 +446,12 @@ TEST(EthereumKeyringUnitTest, ImportAccount_RestrictedAddress) {
   EXPECT_TRUE(keyring.RemoveImportedAccount(*address));
 
   // Add address to restricted list.
-  registry->UpdateRestrictedAddressesList(
+  BlockchainRegistry::ScopedRestrictedAddressesForTesting scoped_restricted(
       {base::ToLowerASCII(address_to_restrict)});
 
   // Try to import account again - should fail.
   auto result = keyring.ImportAccount(private_key);
   EXPECT_FALSE(result) << "Restricted Ethereum address should be rejected";
-
-  registry->UpdateRestrictedAddressesList({});
 }
 
 }  // namespace brave_wallet

--- a/components/brave_wallet/browser/fil_tx_manager_unittest.cc
+++ b/components/brave_wallet/browser/fil_tx_manager_unittest.cc
@@ -78,7 +78,7 @@ class FilTxManagerUnitTest : public testing::Test {
         CreateTxStorageForTest(temp_dir_.GetPath()));
 
     GetAccountUtils().CreateWallet(kMnemonicDivideCruise, kTestWalletPassword);
-    GetAccountUtils().EnsureFilTestAccount(0);
+    ASSERT_TRUE(GetAccountUtils().EnsureFilTestAccount(0));
   }
 
   AccountUtils GetAccountUtils() {
@@ -86,7 +86,9 @@ class FilTxManagerUnitTest : public testing::Test {
   }
 
   mojom::AccountIdPtr FilTestAcc(size_t index) {
-    return GetAccountUtils().EnsureFilTestAccount(index)->account_id->Clone();
+    auto account = GetAccountUtils().EnsureFilTestAccount(index);
+    CHECK(account);
+    return account->account_id->Clone();
   }
 
   void SetInterceptor(const GURL& expected_url,
@@ -613,8 +615,7 @@ TEST_F(FilTxManagerUnitTest, ProcessHardwareSignatureError) {
 
 TEST_F(FilTxManagerUnitTest, RestrictedFromAddress) {
   const auto from_account = FilTestAcc(0);
-  auto* registry = BlockchainRegistry::GetInstance();
-  registry->UpdateRestrictedAddressesList(
+  BlockchainRegistry::ScopedRestrictedAddressesForTesting scoped_restricted(
       {base::ToLowerASCII(from_account->address)});
 
   auto fil_tx_data = mojom::FilTxData::New(
@@ -634,8 +635,6 @@ TEST_F(FilTxManagerUnitTest, RestrictedFromAddress) {
   EXPECT_FALSE(success);
   EXPECT_TRUE(tx_meta_id.empty());
   EXPECT_EQ(err_str, WalletInternalErrorMessage());
-
-  registry->UpdateRestrictedAddressesList({});
 }
 
 }  //  namespace brave_wallet

--- a/components/brave_wallet/browser/filecoin_keyring_unittest.cc
+++ b/components/brave_wallet/browser/filecoin_keyring_unittest.cc
@@ -223,15 +223,13 @@ TEST(FilecoinKeyring, AddNewHDAccount_RestrictedAddress) {
   EXPECT_TRUE(keyring.RemoveHDAccount(0));
 
   // Add address to restricted list.
-  registry->UpdateRestrictedAddressesList(
+  BlockchainRegistry::ScopedRestrictedAddressesForTesting scoped_restricted(
       {base::ToLowerASCII(address_to_restrict)});
 
   // Try to add account again - should fail because it generates the same
   // address.
   auto result = keyring.AddNewHDAccount(0);
   EXPECT_FALSE(result) << "Restricted Filecoin address should be rejected";
-
-  registry->UpdateRestrictedAddressesList({});
 }
 
 TEST(FilecoinKeyring, ImportAccount_SECP256K1_RestrictedAddress) {
@@ -262,16 +260,14 @@ TEST(FilecoinKeyring, ImportAccount_SECP256K1_RestrictedAddress) {
   EXPECT_TRUE(keyring.RemoveImportedAccount(*address));
 
   // Add address to restricted list.
-  registry->UpdateRestrictedAddressesList(
-      {base::ToLowerASCII(address_to_restrict)});
+  BlockchainRegistry::ScopedRestrictedAddressesForTesting
+      scoped_secp256k1_restricted({base::ToLowerASCII(address_to_restrict)});
 
   // Try to import account again - should fail.
   auto result = keyring.ImportFilecoinAccount(
       private_key, mojom::FilecoinAddressProtocol::SECP256K1);
   EXPECT_FALSE(result)
       << "Restricted Filecoin SECP256K1 address should be rejected";
-
-  registry->UpdateRestrictedAddressesList({});
 }
 
 TEST(FilecoinKeyring, ImportAccount_BLS_RestrictedAddress) {
@@ -304,14 +300,12 @@ TEST(FilecoinKeyring, ImportAccount_BLS_RestrictedAddress) {
   EXPECT_TRUE(keyring.RemoveImportedAccount(*address));
 
   // Add address to restricted list.
-  registry->UpdateRestrictedAddressesList(
+  BlockchainRegistry::ScopedRestrictedAddressesForTesting scoped_bls_restricted(
       {base::ToLowerASCII(address_to_restrict)});
 
   // Try to import account again - should fail.
   auto result = keyring.ImportFilecoinAccount(private_key, protocol);
   EXPECT_FALSE(result) << "Restricted Filecoin BLS address should be rejected";
-
-  registry->UpdateRestrictedAddressesList({});
 }
 
 }  // namespace brave_wallet

--- a/components/brave_wallet/browser/keyring_service_unittest.cc
+++ b/components/brave_wallet/browser/keyring_service_unittest.cc
@@ -2248,9 +2248,6 @@ TEST_F(KeyringServiceUnitTest, AddHardwareAccounts_RestrictedAddress) {
   AccountUtils(&keyring_service)
       .CreateWallet(kMnemonicDivideCruise, kPasswordBrave);
 
-  auto* registry = BlockchainRegistry::GetInstance();
-  CHECK(registry);
-
   const std::string restricted_eth_address =
       "0xb9ef770b6a5e12e45983c5d80545258aa38f3b78";
   const std::string restricted_sol_address =
@@ -2263,7 +2260,7 @@ TEST_F(KeyringServiceUnitTest, AddHardwareAccounts_RestrictedAddress) {
       "0x1111111111111111111111111111111111111111";
 
   // Update restricted list with restricted addresses
-  registry->UpdateRestrictedAddressesList({
+  BlockchainRegistry::ScopedRestrictedAddressesForTesting scoped_hw_restricted({
       base::ToLowerASCII(restricted_eth_address),
       base::ToLowerASCII(restricted_sol_address),
       base::ToLowerASCII(restricted_fil_address),
@@ -2341,17 +2338,12 @@ TEST_F(KeyringServiceUnitTest, AddHardwareAccounts_RestrictedAddress) {
     EXPECT_EQ(result.size(), 1u) << "Only valid address should be added";
     EXPECT_EQ(result[0]->address, valid_eth_address);
   }
-
-  // Clear restricted list
-  registry->UpdateRestrictedAddressesList({});
 }
 
 TEST_F(KeyringServiceUnitTest, ImportEthereumAccount_RestrictedAddress) {
   KeyringService keyring_service(json_rpc_service(), GetPrefs(),
                                  GetLocalState());
   ASSERT_TRUE(CreateWallet(&keyring_service, "brave"));
-
-  auto* registry = BlockchainRegistry::GetInstance();
 
   // Use a known private key that generates a known address from existing tests.
   const std::string known_private_key =
@@ -2368,8 +2360,8 @@ TEST_F(KeyringServiceUnitTest, ImportEthereumAccount_RestrictedAddress) {
                             "brave"));
 
   // Update restricted list with the address.
-  registry->UpdateRestrictedAddressesList(
-      {base::ToLowerASCII(address_to_restrict)});
+  BlockchainRegistry::ScopedRestrictedAddressesForTesting
+      scoped_eth_import_restricted({base::ToLowerASCII(address_to_restrict)});
 
   // Test: Import with Restricted address should fail.
   auto result = ImportEthereumAccount(&keyring_service, "Restricted Account",
@@ -2384,16 +2376,12 @@ TEST_F(KeyringServiceUnitTest, ImportEthereumAccount_RestrictedAddress) {
                                             valid_private_key);
   EXPECT_TRUE(valid_result)
       << "Non-restricted Ethereum address should be accepted";
-
-  registry->UpdateRestrictedAddressesList({});
 }
 
 TEST_F(KeyringServiceUnitTest, ImportSolanaAccount_RestrictedAddress) {
   KeyringService keyring_service(json_rpc_service(), GetPrefs(),
                                  GetLocalState());
   ASSERT_TRUE(CreateWallet(&keyring_service, "brave"));
-
-  auto* registry = BlockchainRegistry::GetInstance();
 
   // Use a known private key from existing tests.
   const std::string known_private_key =
@@ -2413,16 +2401,13 @@ TEST_F(KeyringServiceUnitTest, ImportSolanaAccount_RestrictedAddress) {
                             "brave"));
 
   // Update restricted list with the address
-  registry->UpdateRestrictedAddressesList(
-      {base::ToLowerASCII(address_to_restrict)});
+  BlockchainRegistry::ScopedRestrictedAddressesForTesting
+      scoped_sol_import_restricted({base::ToLowerASCII(address_to_restrict)});
 
   // Test: Import with Restricted address should fail
   auto result = ImportSolanaAccount(&keyring_service, "Restricted Account",
                                     known_private_key);
   EXPECT_FALSE(result) << "Restricted Solana address should be rejected";
-
-  // Clear restricted list
-  registry->UpdateRestrictedAddressesList({});
 }
 
 TEST_F(KeyringServiceUnitTest, ImportFilecoinAccount_RestrictedAddress) {
@@ -2430,7 +2415,6 @@ TEST_F(KeyringServiceUnitTest, ImportFilecoinAccount_RestrictedAddress) {
                                  GetLocalState());
   ASSERT_TRUE(CreateWallet(&keyring_service, "brave"));
 
-  auto* registry = BlockchainRegistry::GetInstance();
   const std::string restricted_address =
       "f1abjxfbp274xpdqcpuaykwkfb43omjotacm2p3za";
 
@@ -2453,21 +2437,14 @@ TEST_F(KeyringServiceUnitTest, ImportFilecoinAccount_RestrictedAddress) {
                             "brave"));
 
   // Update restricted list with the address.
-  registry->UpdateRestrictedAddressesList(
-      {base::ToLowerASCII(address_to_restrict)});
+  BlockchainRegistry::ScopedRestrictedAddressesForTesting
+      scoped_fil_import_restricted({base::ToLowerASCII(address_to_restrict)});
 
   // Test: Import with Restricted address should fail
   auto result =
       ImportFilecoinAccount(&keyring_service, "Restricted Account",
                             known_private_key, mojom::kFilecoinTestnet);
   EXPECT_FALSE(result) << "Restricted Filecoin address should be rejected";
-
-  // Test: Import with different network (mainnet) should work if address is
-  // different or use a different private key for a valid import For this test,
-  // we verify the restricted check works for the testnet address
-
-  // Clear restricted list
-  registry->UpdateRestrictedAddressesList({});
 }
 
 TEST_F(KeyringServiceUnitTest, ImportPolkadotAccount_RestrictedAddress) {
@@ -2476,8 +2453,6 @@ TEST_F(KeyringServiceUnitTest, ImportPolkadotAccount_RestrictedAddress) {
 
   KeyringService service(json_rpc_service(), GetPrefs(), GetLocalState());
   ASSERT_TRUE(CreateWallet(&service, "brave"));
-
-  auto* registry = BlockchainRegistry::GetInstance();
 
   auto hd_account =
       AddAccount(&service, mojom::CoinType::DOT,
@@ -2511,16 +2486,13 @@ TEST_F(KeyringServiceUnitTest, ImportPolkadotAccount_RestrictedAddress) {
                             kPasswordBrave));
 
   // Update restricted list with the address.
-  registry->UpdateRestrictedAddressesList(
-      {base::ToLowerASCII(*address_to_restrict)});
+  BlockchainRegistry::ScopedRestrictedAddressesForTesting
+      scoped_dot_import_restricted({base::ToLowerASCII(*address_to_restrict)});
 
   auto result =
       ImportPolkadotAccount(&service, "Imported Polkadot", *json_export,
                             "export_pwd", mojom::kPolkadotMainnet);
   EXPECT_FALSE(result);
-
-  // Clear restricted list
-  registry->UpdateRestrictedAddressesList({});
 }
 
 TEST_F(KeyringServiceUnitTest, CreateDefaultAccountsForSelectedNetworks) {
@@ -2567,8 +2539,7 @@ TEST_F(KeyringServiceUnitTest, CreateDefaultAccountsForSelectedNetworks) {
 TEST_F(KeyringServiceUnitTest, AddHDAccountForKeyring_RestrictedAddress) {
   base::test::ScopedFeatureList feature_list{
       features::kBraveWalletPolkadotFeature};
-  auto* registry = BlockchainRegistry::GetInstance();
-  registry->UpdateRestrictedAddressesList(
+  BlockchainRegistry::ScopedRestrictedAddressesForTesting scoped_hd_restricted(
       {base::ToLowerASCII("0xf81229FE54D8a20fBc1e1e2a3451D1c7489437Db"),
        base::ToLowerASCII("BrG44HdsEhzapvs8bEqzvkq4egwevS3fRE6ze2ENo6S8"),
        base::ToLowerASCII("f1qjidlytseoouzfhsgzczf3ettbhuaezorczeava"),
@@ -2584,8 +2555,6 @@ TEST_F(KeyringServiceUnitTest, AddHDAccountForKeyring_RestrictedAddress) {
                           mojom::KeyringId::kFilecoin, "Account 1"));
   EXPECT_FALSE(AddAccount(&service, mojom::CoinType::DOT,
                           mojom::KeyringId::kPolkadotMainnet, "Account 1"));
-
-  registry->UpdateRestrictedAddressesList({});
 }
 
 TEST_F(KeyringServiceUnitTest,
@@ -2593,10 +2562,11 @@ TEST_F(KeyringServiceUnitTest,
   base::test::ScopedFeatureList feature_list{
       features::kBraveWalletPolkadotFeature};
 
-  auto* registry = BlockchainRegistry::GetInstance();
-  registry->UpdateRestrictedAddressesList(
-      {base::ToLowerASCII("f1qjidlytseoouzfhsgzczf3ettbhuaezorczeava"),
-       base::ToLowerASCII("158HHeYTmEXMiMM1XufQt5bEe2CTia3EcVcfrpYBYcXA6bdb")});
+  BlockchainRegistry::ScopedRestrictedAddressesForTesting
+      scoped_default_restricted(
+          {base::ToLowerASCII("f1qjidlytseoouzfhsgzczf3ettbhuaezorczeava"),
+           base::ToLowerASCII(
+               "158HHeYTmEXMiMM1XufQt5bEe2CTia3EcVcfrpYBYcXA6bdb")});
 
   KeyringService service(json_rpc_service(), GetPrefs(), GetLocalState());
   NiceMock<TestKeyringServiceObserver> observer(service, task_environment_);
@@ -2632,8 +2602,6 @@ TEST_F(KeyringServiceUnitTest,
   EXPECT_TRUE(service.GetAllAccountInfos().empty());
   EXPECT_CALL(observer, WalletReset());
   observer.WaitAndVerify();
-
-  registry->UpdateRestrictedAddressesList({});
 }
 
 TEST_F(KeyringServiceUnitTest, SetSelectedAccount_CardanoEnabled) {

--- a/components/brave_wallet/browser/polkadot/polkadot_import_keyring_unittest.cc
+++ b/components/brave_wallet/browser/polkadot/polkadot_import_keyring_unittest.cc
@@ -217,7 +217,7 @@ TEST(PolkadotImportKeyringTest, AddAccount_RestrictedAddress) {
   const auto address_to_restrict = *address;
 
   // Add address to restricted list.
-  registry->UpdateRestrictedAddressesList(
+  BlockchainRegistry::ScopedRestrictedAddressesForTesting scoped_restricted(
       {base::ToLowerASCII(address_to_restrict)});
 
   ASSERT_TRUE(import_keyring.RemoveAccount(0));
@@ -225,9 +225,6 @@ TEST(PolkadotImportKeyringTest, AddAccount_RestrictedAddress) {
   EXPECT_FALSE(import_keyring.AddAccount(0, pkcs8_key));
   EXPECT_FALSE(import_keyring.RemoveAccount(0));
   EXPECT_TRUE(import_keyring.AddAccount(1, pkcs8_key1));
-
-  // Clear restricted list
-  registry->UpdateRestrictedAddressesList({});
 }
 
 }  // namespace brave_wallet

--- a/components/brave_wallet/browser/polkadot/polkadot_keyring_unittest.cc
+++ b/components/brave_wallet/browser/polkadot/polkadot_keyring_unittest.cc
@@ -417,35 +417,34 @@ TEST(PolkadotKeyring, AddNewHDAccount_RestrictedAddress) {
   ASSERT_TRUE(address);
   const std::string address_to_restrict = *address;
 
-  // Add address to restricted list.
-  registry->UpdateRestrictedAddressesList(
-      {base::ToLowerASCII(address_to_restrict)});
-
-  // Try to add account again - should fail because it generates the same
-  // address Note: PolkadotKeyring doesn't have RemoveHDAccount, so we test by
-  // trying to add at index 1, which should succeed, then try index 0 again.
-  auto result1 = keyring.AddNewHDAccount(1);
-  EXPECT_TRUE(result1) << "Non-restricted address should succeed";
-
-  // Now try to add at index 0 again - this should fail because the address
-  // at index 0 is already in the restricted list
-  // Actually, we can't test this directly because AddNewHDAccount doesn't
-  // allow adding at an index that's already been used. Instead, let's test
-  // by creating a new keyring and trying to add at index 0.
   PolkadotKeyring keyring2(
       base::span(seed).first<kPolkadotSeedSize>(),
       mojom::KeyringId::kPolkadotMainnet,
       base::BindLambdaForTesting([=](const std::string& address) {
         return !registry->IsRestrictedAddress(address);
       }));
-  auto result2 = keyring2.AddNewHDAccount(0);
-  EXPECT_FALSE(result2) << "Restricted Polkadot address should be rejected";
+  {
+    // Add address to restricted list.
+    BlockchainRegistry::ScopedRestrictedAddressesForTesting scoped_restricted(
+        {base::ToLowerASCII(address_to_restrict)});
 
-  // Clear restricted list
-  registry->UpdateRestrictedAddressesList({});
+    // Try to add account again - should fail because it generates the same
+    // address Note: PolkadotKeyring doesn't have RemoveHDAccount, so we test by
+    // trying to add at index 1, which should succeed, then try index 0 again.
+    auto result1 = keyring.AddNewHDAccount(1);
+    EXPECT_TRUE(result1) << "Non-restricted address should succeed";
+
+    // Now try to add at index 0 again - this should fail because the address
+    // at index 0 is already in the restricted list
+    // Actually, we can't test this directly because AddNewHDAccount doesn't
+    // allow adding at an index that's already been used. Instead, let's test
+    // by creating a new keyring and trying to add at index 0.
+    auto result2 = keyring2.AddNewHDAccount(0);
+    EXPECT_FALSE(result2) << "Restricted Polkadot address should be rejected";
+  }
 
   // Prove that we didn't leave any remnant phantom keypairs.
-  result2 = keyring2.AddNewHDAccount(0);
+  auto result2 = keyring2.AddNewHDAccount(0);
   EXPECT_TRUE(result2);
 }
 

--- a/components/brave_wallet/browser/polkadot/polkadot_tx_manager_unittest.cc
+++ b/components/brave_wallet/browser/polkadot/polkadot_tx_manager_unittest.cc
@@ -653,8 +653,7 @@ TEST_F(PolkadotTxManagerUnitTest, RetryTransaction) {
 }
 
 TEST_F(PolkadotTxManagerUnitTest, RestrictedFromAddress) {
-  auto* registry = BlockchainRegistry::GetInstance();
-  registry->UpdateRestrictedAddressesList(
+  BlockchainRegistry::ScopedRestrictedAddressesForTesting scoped_restricted(
       {base::ToLowerASCII(polkadot_mainnet_account_->address)});
 
   auto transaction_params = mojom::NewPolkadotTransactionParams::New(
@@ -672,7 +671,6 @@ TEST_F(PolkadotTxManagerUnitTest, RestrictedFromAddress) {
   EXPECT_FALSE(success);
   EXPECT_TRUE(tx_meta_id.empty());
   EXPECT_EQ(err_str, WalletInternalErrorMessage());
-  registry->UpdateRestrictedAddressesList({});
 }
 
 }  // namespace brave_wallet

--- a/components/brave_wallet/browser/solana_keyring_unittest.cc
+++ b/components/brave_wallet/browser/solana_keyring_unittest.cc
@@ -285,15 +285,13 @@ TEST(SolanaKeyringUnitTest, AddNewHDAccount_RestrictedAddress) {
   EXPECT_TRUE(keyring.RemoveHDAccount(0));
 
   // Add address to restricted list.
-  registry->UpdateRestrictedAddressesList(
+  BlockchainRegistry::ScopedRestrictedAddressesForTesting scoped_restricted(
       {base::ToLowerASCII(address_to_restrict)});
 
   // Try to add account again - should fail because it generates the same
   // address.
   auto result = keyring.AddNewHDAccount(0);
   EXPECT_FALSE(result) << "Restricted Solana address should be rejected";
-
-  registry->UpdateRestrictedAddressesList({});
 }
 
 TEST(SolanaKeyringUnitTest, ImportAccount_RestrictedAddress) {
@@ -321,14 +319,12 @@ TEST(SolanaKeyringUnitTest, ImportAccount_RestrictedAddress) {
   EXPECT_TRUE(keyring.RemoveImportedAccount(*address));
 
   // Add address to restricted list.
-  registry->UpdateRestrictedAddressesList(
-      {base::ToLowerASCII(address_to_restrict)});
+  BlockchainRegistry::ScopedRestrictedAddressesForTesting
+      scoped_import_restricted({base::ToLowerASCII(address_to_restrict)});
 
   // Try to import account again - should fail.
   auto result = keyring.ImportAccount(private_key);
   EXPECT_FALSE(result) << "Restricted Solana address should be rejected";
-
-  registry->UpdateRestrictedAddressesList({});
 }
 
 }  // namespace brave_wallet

--- a/components/brave_wallet/browser/solana_tx_manager_unittest.cc
+++ b/components/brave_wallet/browser/solana_tx_manager_unittest.cc
@@ -990,8 +990,8 @@ TEST_F(SolanaTxManagerUnitTest, RestrictedToAddress) {
   const auto& from = sol_account();
   const std::string restricted_to =
       "FepMPR8vahkJ98Fr22VKbfHU4f4PTAyi18PDZN2NooPb";
-  auto* registry = BlockchainRegistry::GetInstance();
-  registry->UpdateRestrictedAddressesList({base::ToLowerASCII(restricted_to)});
+  BlockchainRegistry::ScopedRestrictedAddressesForTesting scoped_restricted(
+      {base::ToLowerASCII(restricted_to)});
   TestMakeSystemProgramTransferTxData(
       from, restricted_to, 10000000, nullptr,
       mojom::SolanaProviderError::kInvalidParams, WalletInternalErrorMessage(),
@@ -1004,9 +1004,8 @@ TEST_F(SolanaTxManagerUnitTest, RestrictedFromAddress) {
 
   const auto from_account_info = GetAccountUtils().EnsureSolAccount(0);
 
-  auto* registry = BlockchainRegistry::GetInstance();
-  registry->UpdateRestrictedAddressesList(
-      {base::ToLowerASCII(from_account_info->address)});
+  BlockchainRegistry::ScopedRestrictedAddressesForTesting
+      scoped_from_restricted({base::ToLowerASCII(from_account_info->address)});
 
   mojom::SolanaTxDataPtr solana_tx_data = nullptr;
   TestMakeSystemProgramTransferTxData(from, to, 10000000, nullptr,
@@ -1045,8 +1044,6 @@ TEST_F(SolanaTxManagerUnitTest, RestrictedFromAddress) {
     EXPECT_TRUE(tx_meta_id.empty());
     EXPECT_EQ(err_str, WalletInternalErrorMessage());
   }
-
-  registry->UpdateRestrictedAddressesList({});
 }
 
 TEST_F(SolanaTxManagerUnitTest, WalletOrigin) {
@@ -1330,8 +1327,8 @@ TEST_P(TokenProgramTest, MakeTokenProgramTransferTxData) {
   // Test sending to restricted address.
   const std::string restricted_to =
       "FepMPR8vahkJ98Fr22VKbfHU4f4PTAyi18PDZN2NooPb";
-  auto* registry = BlockchainRegistry::GetInstance();
-  registry->UpdateRestrictedAddressesList({base::ToLowerASCII(restricted_to)});
+  BlockchainRegistry::ScopedRestrictedAddressesForTesting
+      scoped_token_restricted({base::ToLowerASCII(restricted_to)});
   TestMakeTokenProgramTransferTxData(
       FROM_HERE, mojom::kSolanaMainnet, spl_token_mint_address,
       from_wallet_address, restricted_to, 10000000,

--- a/test/filters/browser_tests-linux-msan.filter
+++ b/test/filters/browser_tests-linux-msan.filter
@@ -49,3 +49,13 @@
 # execution. No Brave modifications in chrome/browser/ui/waap/.
 # https://github.com/brave/brave-browser/issues/54031
 -InitialWebUIMetricsMappingBrowserTest.NormalRendererMetricsAreNotMapped
+
+# Upstream Chromium test. Stable upstream (0.2% flake rate over 30 days per
+# LUCI Analysis). The test captures a const reference to a
+# ServiceWorkerRunningInfo map entry, stops the service worker (removing the
+# entry from the map), then reads from the dangling reference. This
+# use-after-free is caught by MSan but does not crash in regular builds because
+# the freed memory typically still contains valid data. No Brave modifications
+# in chrome/browser/extensions/ for this test file.
+# https://github.com/brave/brave-browser/issues/54959
+-ServiceWorkerIdTrackingBrowserTest.WorkerNotStalledInStopping_RemovedByRenderStopNotificationFirst

--- a/test/filters/browser_tests-linux.filter
+++ b/test/filters/browser_tests-linux.filter
@@ -142,6 +142,18 @@
 # the Glic WebUI initialization flow. Stable upstream (0.3% flake rate).
 -GuestUtilBrowserTest.OnGuestAdded_Glic
 
+# Chromium test: ApplyDefaultSearchChangeForTesting(FROM_EXTENSION) on Linux
+# leaves default_search_provider_ null (extension DSEs unsupported on Linux)
+# while default_search_provider_source_ stays FROM_EXTENSION. Brave's
+# DefaultSearchManager override causes MaybeShowDialog() to record the
+# histogram twice with differing conditions (kControlledByPolicy and
+# kExtensionControlled), failing the ExpectUniqueSample assertion.
+# Already disabled on Windows in upstream source; upstream TODO crbug.com/429600559
+# acknowledges the broken extension DSE test setup.
+# Stable upstream: 0.3% flake rate over 30 days per LUCI Analysis.
+# https://github.com/brave/brave-browser/issues/54542
+-SearchEngineChoiceDialogBrowserTest.DialogDoesNotShowWithExtensionEnabledThatOverridesDSE
+
 # Tests below this point have not been diagnosed or had issues created yet.
 -AccessCodeCastHandlerBrowserTest.*
 -AdsPageLoadMetricsObserverBrowserTest.*

--- a/test/filters/browser_tests-linux.filter
+++ b/test/filters/browser_tests-linux.filter
@@ -104,6 +104,13 @@
 # before NetworkBecameIdle. 1% upstream flake rate over 30 days per LUCI Analysis.
 # https://github.com/brave/brave-browser/issues/54205
 -PageStabilityMetricsTest.NetworkAndMainThreadIdle
+# Same root cause as above: cosmetic filter polling prevents the
+# IdlenessDetector's 500ms quiet window. The Paint test path resolves the
+# network request after paint stability, so it also waits for
+# NetworkBecameIdle which never fires. 2.5% upstream flake rate over 30 days
+# per LUCI Analysis.
+# https://github.com/brave/brave-browser/issues/54503
+-PageStabilityMetricsTest.Paint
 
 # These tests fail on Linux because kPromptForDownload defaults to true,
 # triggering the GTK file chooser dialog which causes g_malloc leaks

--- a/test/filters/browser_tests.filter
+++ b/test/filters/browser_tests.filter
@@ -1944,10 +1944,12 @@
 # `kActionSendSharedTabGroupFeedback` ephemerally and triggers a CHECK.
 -VerticalTabViewDataSharingEnabledTest.LogsTabSwitchMetrics
 
-# Chromium test flaky - disabled on Windows upstream (crbug.com/413259587). Race
-# condition between JavaScript cookie set via document.cookie and backend
-# SiteDataCountingHelper query. Brave has no modifications to this code.
-# Upstream flake rate 0.5% (LUCI Analysis, 30-day lookback); amplified by MSAN.
+# Chromium test: BrowsingDataRemover BrowserContext destruction hangs in Brave.
+# BlockUntilCompletion() never returns after incognito profile is destroyed
+# during data removal (crbug.com/413259587).  Also hits a cookie IPC race
+# (GetSiteDataCount returns 0) that is fixed by the chromium_src override of
+# browsing_data_test_util.cc, but the hang remains.  Upstream flake rate 0.6%
+# (LUCI Analysis, 30-day lookback).
 -All/BrowsingDataRemoverBrowserTestP.BrowserContextDestructionVsCookieRemoval/*
 -All/BrowsingDataRemoverBrowserTestP.CookieIncognitoDeletion/*
 

--- a/test/filters/browser_tests.filter
+++ b/test/filters/browser_tests.filter
@@ -2518,6 +2518,10 @@
 -SiteEngagementHelperBrowserTest.*
 -SitePerProcessWebViewTest.*
 -SmartSessionRestoreTest.CorrectLoadingOrder
+# Known upstream flake: 5.8% rate (83k verdicts, 30d). TCP read() returns
+# partial data. Disabled on Windows by Chromium (crbug.com/1319604).
+# https://github.com/brave/brave-browser/issues/54922
+-SocketApiTest.SocketTCPExtension
 -SoundContentSettingObserverBrowserTest.*
 -SpellcheckServiceBrowserTest.*
 -SpellcheckServiceHostBrowserTest.*

--- a/test/filters/browser_tests.filter
+++ b/test/filters/browser_tests.filter
@@ -2648,3 +2648,12 @@
 # startup, so it captures stray samples and ExpectUniqueSample fails.
 # https://github.com/brave/brave-browser/issues/54247
 -UpdateMetricsProviderBrowserTest.RunInBackground
+
+# Chromium test: upstream flake (1.1% flake rate over 30 days, 83k+ verdicts).
+# PartitionedCookiePresentV3 UKM is recorded on every cookie access event
+# without per-page deduplication, so the test's delta check gets 2 instead of 1
+# when a prior navigation's UKM entry arrives late. Fixed upstream in
+# chromium-review.googlesource.com/c/chromium/src/+/7746704 but not yet in
+# Chromium 148. No Brave chromium_src overrides for cookie_utils.cc.
+# https://github.com/brave/brave-browser/issues/55020
+-CookieUseCounterBrowserTest.PartitionedCookiePresentV3_CountOnce

--- a/test/filters/unit_tests-windows.filter
+++ b/test/filters/unit_tests-windows.filter
@@ -20,6 +20,12 @@
 # to be stripped out because the resource is not used by chrome.dll"
 -DesktopMediaPickerViewsSingleTabPaneTest.AccessibleProperties
 
+# Upstream flake: 1.0% flake rate over 30 days per LUCI Analysis (182K verdicts).
+# FindNewCheckTime() can schedule past Now()+interval due to timezone-dependent
+# LocalMidnight() boundary. Already filtered on Linux.
+# https://github.com/brave/brave-browser/issues/54960
+-PasswordStatusCheckServiceBaseTest.PrefInitialized
+
 # Tests below this point have not been diagnosed or had issues created yet.
 -EnterpriseReportingPrivateGetContextInfoOSFirewallTest.*
 -ExtensionServiceTest.*


### PR DESCRIPTION
Uplift of #35836
Uplift of #36089
Uplift of #35722
Uplift of #36120
Uplift of #36133
Uplift of #36179
Uplift of #36178
Uplift of #36161
Uplift of #36125
Uplift of #36122
Uplift of #36170
Uplift of #36306
Uplift of #36305

## Included PRs
- #35836 - Fix intermittent FilTxManagerUnitTest crash from singleton state leak
- #36089 - Disable flaky CookieUseCounterBrowserTest.PartitionedCookiePresentV3_CountOnce
- #35722 - Fix intermittent VariationsBrowserTest.BraveSeedApplied failure
- #36120 - Disable SearchEngineChoiceDialogBrowserTest extension DSE test on Linux
- #36133 - Disable flaky Chromium test PageStabilityMetricsTest.Paint on Linux
- #36179 - Disable flaky ServiceWorkerIdTrackingBrowserTest on MSan
- #36178 - Disable flaky PasswordStatusCheckServiceBaseTest.PrefInitialized on Windows
- #36161 - Fix flaky EmailAliasesBrowserTest.ContextMenuAuthorized
- #36125 - Fix cookie IPC race in browsing data test utility
- #36122 - Fix crash in deferred kNodeCreated notification during tab pin
- #36170 - Disable flaky Chromium test SocketApiTest.SocketTCPExtension
- #36306 - Fix flaky EmailAliasesBrowserTest.ContextMenuAuthorizedManage
- #36305 - Fix race in AdBlockServiceTest initial engine wait

Pre-approval checklist:
- [ ] You have tested your change on Nightly.
- [ ] This contains text which needs to be translated.
    - [ ] There are more than 7 days before the release.
    - [ ] I've notified folks in #l10n on Slack that translations are needed.
- [x] The PR milestones match the branch they are landing to.


Pre-merge checklist:
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.

Post-merge checklist:
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.