### PR TITLE
[ads] Center New Tab Takeover CTA button for NTP refresh

### DIFF
--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -27,6 +27,7 @@
 #include "brave/components/debounce/core/common/features.h"
 #include "brave/components/email_aliases/buildflags/buildflags.h"
 #include "brave/components/google_sign_in_permission/features.h"
+#include "brave/components/ntp_background_images/browser/features.h"
 #include "brave/components/playlist/core/common/buildflags/buildflags.h"
 #include "brave/components/psst/buildflags/buildflags.h"
 #include "brave/components/request_otr/common/buildflags/buildflags.h"
@@ -830,6 +831,14 @@ constexpr flags_ui::FeatureEntry::Choice kVerticalTabCollapseDelayChoices[] = {
           "Enables searching directly from the New Tab Page",                  \
           kOsDesktop,                                                          \
           FEATURE_VALUE_TYPE(features::kBraveNtpSearchWidget),                 \
+      },                                                                       \
+      {                                                                        \
+          "center-ntt-cta-button",                                             \
+          "Center image NTT CTA button",                                       \
+          "Centers image NTT CTA button above the widget area",                \
+          kOsDesktop,                                                          \
+          FEATURE_VALUE_TYPE(                                                  \
+              ntp_background_images::features::kCenterNttCtaButton),           \
       },                                                                       \
       {                                                                        \
           "brave-filled-bookmark-folder-icon",                                 \

--- a/browser/resources/brave_new_tab_page_refresh/components/app.style.ts
+++ b/browser/resources/brave_new_tab_page_refresh/components/app.style.ts
@@ -224,6 +224,10 @@ export const style = scoped.css`
     margin-inline-end: 0;
   }
 
+  .caption-container:has(.centered-ntt-cta-button) {
+    position: static;
+  }
+
   .widget-container {
     --widget-height: 128px;
     --widget-min-width: 380px;

--- a/browser/resources/brave_new_tab_page_refresh/components/background/background_caption.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/background/background_caption.tsx
@@ -17,6 +17,7 @@ import {
   useCurrentBackground,
   useBackgroundActions,
 } from '../../context/background_context'
+import { useNewTabState } from '../../context/new_tab_context'
 
 import { style } from './background_caption.style'
 
@@ -62,6 +63,9 @@ interface SponsoredBackgroundLogoProps {
 
 function SponsoredBackgroundLogo(props: SponsoredBackgroundLogoProps) {
   const actions = useBackgroundActions()
+  const centerNttCtaButtonFeatureEnabled = useNewTabState(
+    (s) => s.centerNttCtaButtonFeatureEnabled,
+  )
   const { logo } = props.background
   if (!logo || !logo.imageUrl) {
     return null
@@ -69,7 +73,11 @@ function SponsoredBackgroundLogo(props: SponsoredBackgroundLogoProps) {
   return (
     <Link
       url={logo.destinationUrl}
-      className='sponsored-logo'
+      className={
+        centerNttCtaButtonFeatureEnabled
+          ? 'sponsored-logo centered-ntt-cta-button'
+          : 'sponsored-logo'
+      }
       onClick={() => actions.notifySponsoredImageLogoClicked()}
       onContextMenu={(e) => e.preventDefault()}
     >

--- a/browser/resources/brave_new_tab_page_refresh/state/browser_new_tab_store.ts
+++ b/browser/resources/brave_new_tab_page_refresh/state/browser_new_tab_store.ts
@@ -18,6 +18,9 @@ export function createNewTabStore() {
     newsFeatureEnabled: loadTimeData.getBoolean('newsFeatureEnabled'),
     talkFeatureEnabled,
     aiChatInputEnabled: loadTimeData.getBoolean('aiChatInputEnabled'),
+    centerNttCtaButtonFeatureEnabled: loadTimeData.getBoolean(
+      'centerNttCtaButtonFeatureEnabled',
+    ),
   })
 
   async function updateClockPrefs() {

--- a/browser/resources/brave_new_tab_page_refresh/state/new_tab_store.ts
+++ b/browser/resources/brave_new_tab_page_refresh/state/new_tab_store.ts
@@ -22,6 +22,7 @@ export interface NewTabState {
   talkFeatureEnabled: boolean
   newsFeatureEnabled: boolean
   aiChatInputEnabled: boolean
+  centerNttCtaButtonFeatureEnabled: boolean
   actions: NewTabActions
 }
 
@@ -38,6 +39,7 @@ export function defaultNewTabStore(): NewTabStore {
     talkFeatureEnabled: false,
     newsFeatureEnabled: false,
     aiChatInputEnabled: false,
+    centerNttCtaButtonFeatureEnabled: false,
     actions: {
       setShowClock(showClock) {},
       setClockFormat(format) {},

--- a/browser/ui/webui/brave_new_tab_page_refresh/new_tab_page_initializer.cc
+++ b/browser/ui/webui/brave_new_tab_page_refresh/new_tab_page_initializer.cc
@@ -25,6 +25,7 @@
 #include "brave/components/brave_vpn/common/buildflags/buildflags.h"
 #include "brave/components/constants/pref_names.h"
 #include "brave/components/constants/webui_url_constants.h"
+#include "brave/components/ntp_background_images/browser/features.h"
 #include "brave/components/ntp_background_images/browser/ntp_custom_images_source.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/regional_capabilities/regional_capabilities_service_factory.h"
@@ -190,6 +191,11 @@ void NewTabPageInitializer::AddLoadTimeValues() {
   source_->AddBoolean(
       "ntpSearchFeatureEnabled",
       base::FeatureList::IsEnabled(features::kBraveNtpSearchWidget));
+
+  source_->AddBoolean(
+      "centerNttCtaButtonFeatureEnabled",
+      base::FeatureList::IsEnabled(
+          ntp_background_images::features::kCenterNttCtaButton));
 
   source_->AddString(
       "ntpSearchDefaultHost",

--- a/components/ntp_background_images/browser/features.cc
+++ b/components/ntp_background_images/browser/features.cc
@@ -15,4 +15,6 @@ BASE_FEATURE(kBraveNTPBrandedWallpaperSurveyPanelist,
 BASE_FEATURE(kBraveNTPBrandedWallpaper,
              base::FEATURE_ENABLED_BY_DEFAULT);
 
+BASE_FEATURE(kCenterNttCtaButton, base::FEATURE_DISABLED_BY_DEFAULT);
+
 }  // namespace ntp_background_images::features

--- a/components/ntp_background_images/browser/features.h
+++ b/components/ntp_background_images/browser/features.h
@@ -16,6 +16,8 @@ BASE_DECLARE_FEATURE(kBraveNTPBrandedWallpaperSurveyPanelist);
 
 BASE_DECLARE_FEATURE(kBraveNTPBrandedWallpaper);
 
+BASE_DECLARE_FEATURE(kCenterNttCtaButton);
+
 // The branded wallpaper will initially be displayed on the nth new tab. The
 // minimum value is 1.
 inline constexpr base::FeatureParam<int> kInitialCountToBrandedWallpaper{


### PR DESCRIPTION
Centers the CTA button on New Tab Takeover sponsored image pages in the NTP refresh when the `brave://flags/#center-ntt-cta-button` flag is enabled. The flag is disabled by default.

<img width="500" alt="image" src="https://github.com/user-attachments/assets/b7912004-559b-45bd-b972-5237fabd0bc1" />

## Test plan

* Start the browser
* Trigger NTT
   EXPECTATION: CTA button is not centered
* Enable the flag on brave://flags/#center-ntt-cta-button
* Restart the browser
* Trigger NTT
   EXPECTATION: CTA button is centered

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/55316

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
