### PR TITLE
[ads] Notification ad is not served due to browser window being inactive (uplift to 1.91.x)

### DIFF
--- a/components/brave_ads/core/internal/application_state/browser_manager.cc
+++ b/components/brave_ads/core/internal/application_state/browser_manager.cc
@@ -75,8 +75,11 @@ void BrowserManager::NotifyBrowserDidEnterBackground() {
 }
 
 void BrowserManager::InitializeBrowserBackgroundState() {
-  is_in_foreground_ = GetAdsClient().IsBrowserActive();
+  const bool is_active = GetAdsClient().IsBrowserActive();
+  is_active_ = is_active;
+  is_in_foreground_ = is_active;
 
+  LogBrowserActiveState();
   LogBrowserBackgroundState();
 }
 

--- a/components/brave_ads/core/internal/application_state/browser_manager_unittest.cc
+++ b/components/brave_ads/core/internal/application_state/browser_manager_unittest.cc
@@ -82,6 +82,7 @@ TEST_F(BraveAdsBrowserManagerTest,
   ads_client_notifier_.NotifyDidInitializeAds();
 
   // Assert
+  EXPECT_TRUE(BrowserManager::GetInstance().IsActive());
   EXPECT_TRUE(BrowserManager::GetInstance().IsInForeground());
 }
 
@@ -94,6 +95,7 @@ TEST_F(BraveAdsBrowserManagerTest,
   ads_client_notifier_.NotifyDidInitializeAds();
 
   // Assert
+  EXPECT_FALSE(BrowserManager::GetInstance().IsActive());
   EXPECT_FALSE(BrowserManager::GetInstance().IsInForeground());
 }
 


### PR DESCRIPTION
Uplift of #36383
Resolves https://github.com/brave/brave-browser/issues/55467

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.