### PR TITLE
[Wallet]: Handle More Permit Type Warnings

### DIFF
--- a/components/brave_wallet_ui/components/extension/sign-panel/index.tsx
+++ b/components/brave_wallet_ui/components/extension/sign-panel/index.tsx
@@ -17,6 +17,7 @@ import { BraveWallet, SignDataSteps } from '../../../constants/types'
 // Utils
 import { getLocale } from '../../../../common/locale'
 import { unicodeEscape, hasUnicode } from '../../../utils/string-utils'
+import { isPermitLikeEthSignTypedData } from '../../../utils/sign_utils'
 import {
   useGetIsTxSimulationOptInStatusQuery,
   useGetNetworkQuery,
@@ -189,7 +190,7 @@ export const SignPanel = (props: Props) => {
   React.useEffect(() => {
     if (
       showWarning
-      || ethSignTypedData?.primaryType === 'Permit'
+      || isPermitLikeEthSignTypedData(ethSignTypedData)
       || (cardanoSignTypedData && network?.coin === BraveWallet.CoinType.ADA)
     ) {
       setSignStep(SignDataSteps.SignRisk)

--- a/components/brave_wallet_ui/components/extension/sign-panel/sign_panel.test.tsx
+++ b/components/brave_wallet_ui/components/extension/sign-panel/sign_panel.test.tsx
@@ -4,6 +4,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import * as React from 'react'
+import '@testing-library/jest-dom'
 import { render, screen, waitFor } from '@testing-library/react'
 import { Provider } from 'react-redux'
 
@@ -15,7 +16,10 @@ import {
   mockCardanoAccount, //
 } from '../../../stories/mock-data/mock-wallet-accounts'
 import { mockOriginInfo } from '../../../stories/mock-data/mock-origin-info'
-import { mockSolanaAccount } from '../../../common/constants/mocks'
+import {
+  mockEthAccount,
+  mockSolanaAccount,
+} from '../../../common/constants/mocks'
 
 // Utils
 import BraveCoreThemeProvider from '../../../../common/BraveCoreThemeProvider'
@@ -23,6 +27,23 @@ import { createMockStore } from '../../../utils/test-utils'
 
 // Components
 import { SignPanel } from './index'
+
+function makeEthSignTypedData(
+  overrides: Partial<BraveWallet.EthSignTypedData>,
+): BraveWallet.EthSignTypedData {
+  return {
+    addressParam: '0x',
+    chainId: '1',
+    domainHash: [],
+    domainJson: '{}',
+    messageJson: '{}',
+    meta: undefined,
+    primaryHash: [],
+    primaryType: 'Person',
+    typesJson: '{}',
+    ...overrides,
+  }
+}
 
 const signCardanoMessageData: BraveWallet.SignMessageRequest = {
   id: 0,
@@ -53,6 +74,92 @@ const signSolanaMessageData: BraveWallet.SignMessageRequest = {
       message: 'Test Solana Sign Data',
       messageBytes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
     },
+    ethSiweData: undefined,
+    ethStandardSignData: undefined,
+    cardanoSignData: undefined,
+  },
+}
+
+const signEthPermitTypedDataRequest: BraveWallet.SignMessageRequest = {
+  id: 0,
+  accountId: mockEthAccount.accountId,
+  originInfo: mockOriginInfo,
+  coin: BraveWallet.CoinType.ETH,
+  chainId: BraveWallet.MAINNET_CHAIN_ID,
+  signData: {
+    ethSignTypedData: makeEthSignTypedData({
+      primaryType: 'Permit',
+      typesJson: '{}',
+    }),
+    solanaSignData: undefined,
+    ethSiweData: undefined,
+    ethStandardSignData: undefined,
+    cardanoSignData: undefined,
+  },
+}
+
+const signEthTransferWithAuthorizationRequest: BraveWallet.SignMessageRequest =
+  {
+    id: 0,
+    accountId: mockEthAccount.accountId,
+    originInfo: mockOriginInfo,
+    coin: BraveWallet.CoinType.ETH,
+    chainId: BraveWallet.MAINNET_CHAIN_ID,
+    signData: {
+      ethSignTypedData: makeEthSignTypedData({
+        primaryType: 'TransferWithAuthorization',
+        typesJson: '{}',
+      }),
+      solanaSignData: undefined,
+      ethSiweData: undefined,
+      ethStandardSignData: undefined,
+      cardanoSignData: undefined,
+    },
+  }
+
+const signEthNestedPermit2Request: BraveWallet.SignMessageRequest = {
+  id: 0,
+  accountId: mockEthAccount.accountId,
+  originInfo: mockOriginInfo,
+  coin: BraveWallet.CoinType.ETH,
+  chainId: BraveWallet.MAINNET_CHAIN_ID,
+  signData: {
+    ethSignTypedData: makeEthSignTypedData({
+      primaryType: 'Nested',
+      typesJson: JSON.stringify({
+        Nested: [{ name: 'permit', type: 'PermitSingle' }],
+        PermitSingle: [
+          { name: 'details', type: 'PermitDetails' },
+          { name: 'spender', type: 'address' },
+          { name: 'sigDeadline', type: 'uint256' },
+        ],
+      }),
+    }),
+    solanaSignData: undefined,
+    ethSiweData: undefined,
+    ethStandardSignData: undefined,
+    cardanoSignData: undefined,
+  },
+}
+
+const signEthPermitShapeTypedDataRequest: BraveWallet.SignMessageRequest = {
+  id: 0,
+  accountId: mockEthAccount.accountId,
+  originInfo: mockOriginInfo,
+  coin: BraveWallet.CoinType.ETH,
+  chainId: BraveWallet.MAINNET_CHAIN_ID,
+  signData: {
+    ethSignTypedData: makeEthSignTypedData({
+      primaryType: 'CustomPermit',
+      typesJson: JSON.stringify({
+        CustomPermit: [
+          { name: 'owner', type: 'address' },
+          { name: 'spender', type: 'address' },
+          { name: 'value', type: 'uint256' },
+        ],
+      }),
+    }),
+    solanaSignData: undefined,
     ethSiweData: undefined,
     ethStandardSignData: undefined,
     cardanoSignData: undefined,
@@ -131,5 +238,101 @@ describe('SignTypedDataPanel', () => {
     expect(
       screen.getByText('braveWalletSignTransactionButton'),
     ).toBeInTheDocument()
+  })
+
+  it('Should show sign risk warning for EIP-712 Permit primary type', async () => {
+    const store = createMockStore({})
+    const { container } = render(
+      <Provider store={store}>
+        <BraveCoreThemeProvider>
+          <SignPanel
+            signMessageData={[signEthPermitTypedDataRequest]}
+            showWarning={false}
+          />
+        </BraveCoreThemeProvider>
+      </Provider>,
+    )
+
+    await waitFor(() => {
+      expect(container).toBeVisible()
+      expect(screen.getByText('Ethereum Mainnet')).toBeInTheDocument()
+      expect(
+        screen.getByText('braveWalletSignWarningTitle'),
+      ).toBeInTheDocument()
+      expect(screen.getByText('braveWalletSignWarning')).toBeInTheDocument()
+      expect(screen.getByText('braveWalletButtonContinue')).toBeInTheDocument()
+    })
+  })
+
+  it('Should show sign risk warning for EIP-3009 TransferWithAuthorization', async () => {
+    const store = createMockStore({})
+    const { container } = render(
+      <Provider store={store}>
+        <BraveCoreThemeProvider>
+          <SignPanel
+            signMessageData={[signEthTransferWithAuthorizationRequest]}
+            showWarning={false}
+          />
+        </BraveCoreThemeProvider>
+      </Provider>,
+    )
+
+    await waitFor(() => {
+      expect(container).toBeVisible()
+      expect(screen.getByText('Ethereum Mainnet')).toBeInTheDocument()
+      expect(
+        screen.getByText('braveWalletSignWarningTitle'),
+      ).toBeInTheDocument()
+      expect(screen.getByText('braveWalletSignWarning')).toBeInTheDocument()
+      expect(screen.getByText('braveWalletButtonContinue')).toBeInTheDocument()
+    })
+  })
+
+  it('Should show sign risk warning for permit-shaped EIP-712 message', async () => {
+    const store = createMockStore({})
+    const { container } = render(
+      <Provider store={store}>
+        <BraveCoreThemeProvider>
+          <SignPanel
+            signMessageData={[signEthPermitShapeTypedDataRequest]}
+            showWarning={false}
+          />
+        </BraveCoreThemeProvider>
+      </Provider>,
+    )
+
+    await waitFor(() => {
+      expect(container).toBeVisible()
+      expect(screen.getByText('Ethereum Mainnet')).toBeInTheDocument()
+      expect(
+        screen.getByText('braveWalletSignWarningTitle'),
+      ).toBeInTheDocument()
+      expect(screen.getByText('braveWalletSignWarning')).toBeInTheDocument()
+      expect(screen.getByText('braveWalletButtonContinue')).toBeInTheDocument()
+    })
+  })
+
+  it('Should show sign risk warning when permit2 is nested under benign primary type', async () => {
+    const store = createMockStore({})
+    const { container } = render(
+      <Provider store={store}>
+        <BraveCoreThemeProvider>
+          <SignPanel
+            signMessageData={[signEthNestedPermit2Request]}
+            showWarning={false}
+          />
+        </BraveCoreThemeProvider>
+      </Provider>,
+    )
+
+    await waitFor(() => {
+      expect(container).toBeVisible()
+      expect(screen.getByText('Ethereum Mainnet')).toBeInTheDocument()
+      expect(
+        screen.getByText('braveWalletSignWarningTitle'),
+      ).toBeInTheDocument()
+      expect(screen.getByText('braveWalletSignWarning')).toBeInTheDocument()
+      expect(screen.getByText('braveWalletButtonContinue')).toBeInTheDocument()
+    })
   })
 })

--- a/components/brave_wallet_ui/utils/sign_utils.test.ts
+++ b/components/brave_wallet_ui/utils/sign_utils.test.ts
@@ -1,0 +1,436 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { BraveWallet } from '../constants/types'
+
+// Utils
+import {
+  hasPermitShape,
+  isPermit2Domain,
+  isPermitLikeEthSignTypedData,
+  PERMIT2_ADDRESS,
+  PERMIT_LIKE,
+} from './sign_utils'
+
+function makeEthSignTypedData(
+  overrides: Partial<BraveWallet.EthSignTypedData>,
+): BraveWallet.EthSignTypedData {
+  return {
+    addressParam: '0x',
+    chainId: '1',
+    domainHash: [],
+    domainJson: '{}',
+    messageJson: '{}',
+    meta: undefined,
+    primaryHash: [],
+    primaryType: 'Person',
+    typesJson: '{}',
+    ...overrides,
+  }
+}
+
+function typesJsonForPrimary(
+  primaryType: string,
+  fields: { name: string; type: string }[],
+): string {
+  return JSON.stringify({ [primaryType]: fields })
+}
+
+describe('hasPermitShape', () => {
+  it('returns false when typesJson is empty', () => {
+    expect(
+      hasPermitShape(
+        makeEthSignTypedData({
+          primaryType: 'Foo',
+          typesJson: '',
+        }),
+      ),
+    ).toBe(false)
+  })
+
+  it('returns false when typesJson is invalid JSON', () => {
+    expect(
+      hasPermitShape(
+        makeEthSignTypedData({
+          primaryType: 'Foo',
+          typesJson: '{',
+        }),
+      ),
+    ).toBe(false)
+  })
+
+  it('returns true when permit shape is in a non-primary type definition', () => {
+    expect(
+      hasPermitShape(
+        makeEthSignTypedData({
+          primaryType: 'Nested',
+          typesJson: JSON.stringify({
+            Nested: [{ name: 'payload', type: 'Other' }],
+            Other: [
+              { name: 'spender', type: 'address' },
+              { name: 'value', type: 'uint256' },
+            ],
+          }),
+        }),
+      ),
+    ).toBe(true)
+  })
+
+  it('returns true when permit2 authorization is nested under a benign primary type', () => {
+    expect(
+      hasPermitShape(
+        makeEthSignTypedData({
+          primaryType: 'Nested',
+          typesJson: JSON.stringify({
+            Nested: [{ name: 'permit', type: 'PermitSingle' }],
+            PermitSingle: [
+              { name: 'details', type: 'PermitDetails' },
+              { name: 'spender', type: 'address' },
+              { name: 'sigDeadline', type: 'uint256' },
+            ],
+          }),
+        }),
+      ),
+    ).toBe(true)
+  })
+
+  it('returns false when spender is missing', () => {
+    expect(
+      hasPermitShape(
+        makeEthSignTypedData({
+          primaryType: 'Foo',
+          typesJson: typesJsonForPrimary('Foo', [
+            { name: 'owner', type: 'address' },
+            { name: 'value', type: 'uint256' },
+          ]),
+        }),
+      ),
+    ).toBe(false)
+  })
+
+  it('returns false when spender exists but no value, amount, or permit nested types', () => {
+    expect(
+      hasPermitShape(
+        makeEthSignTypedData({
+          primaryType: 'Foo',
+          typesJson: typesJsonForPrimary('Foo', [
+            { name: 'spender', type: 'address' },
+            { name: 'owner', type: 'address' },
+          ]),
+        }),
+      ),
+    ).toBe(false)
+  })
+
+  it('returns true for spender and value', () => {
+    expect(
+      hasPermitShape(
+        makeEthSignTypedData({
+          primaryType: 'CustomPermit',
+          typesJson: typesJsonForPrimary('CustomPermit', [
+            { name: 'owner', type: 'address' },
+            { name: 'spender', type: 'address' },
+            { name: 'value', type: 'uint256' },
+          ]),
+        }),
+      ),
+    ).toBe(true)
+  })
+
+  it('returns true for spender and amount', () => {
+    expect(
+      hasPermitShape(
+        makeEthSignTypedData({
+          primaryType: 'CustomPermit',
+          typesJson: typesJsonForPrimary('CustomPermit', [
+            { name: 'spender', type: 'address' },
+            { name: 'amount', type: 'uint256' },
+          ]),
+        }),
+      ),
+    ).toBe(true)
+  })
+
+  it('returns true for spender and PermitDetails field', () => {
+    expect(
+      hasPermitShape(
+        makeEthSignTypedData({
+          primaryType: 'PermitSingle',
+          typesJson: typesJsonForPrimary('PermitSingle', [
+            { name: 'details', type: 'PermitDetails' },
+            { name: 'spender', type: 'address' },
+            { name: 'sigDeadline', type: 'uint256' },
+          ]),
+        }),
+      ),
+    ).toBe(true)
+  })
+
+  it('returns true for spender and PermitDetails[] field', () => {
+    expect(
+      hasPermitShape(
+        makeEthSignTypedData({
+          primaryType: 'PermitBatch',
+          typesJson: typesJsonForPrimary('PermitBatch', [
+            { name: 'details', type: 'PermitDetails[]' },
+            { name: 'spender', type: 'address' },
+          ]),
+        }),
+      ),
+    ).toBe(true)
+  })
+
+  it('returns true for spender and TokenPermissions field', () => {
+    expect(
+      hasPermitShape(
+        makeEthSignTypedData({
+          primaryType: 'PermitTransferFrom',
+          typesJson: typesJsonForPrimary('PermitTransferFrom', [
+            { name: 'permitted', type: 'TokenPermissions' },
+            { name: 'spender', type: 'address' },
+          ]),
+        }),
+      ),
+    ).toBe(true)
+  })
+
+  it('returns true for spender and TokenPermissions[] field', () => {
+    expect(
+      hasPermitShape(
+        makeEthSignTypedData({
+          primaryType: 'PermitBatchTransferFrom',
+          typesJson: typesJsonForPrimary('PermitBatchTransferFrom', [
+            { name: 'permitted', type: 'TokenPermissions[]' },
+            { name: 'spender', type: 'address' },
+          ]),
+        }),
+      ),
+    ).toBe(true)
+  })
+
+  it('returns true for DAI-style spender and allowed(bool)', () => {
+    expect(
+      hasPermitShape(
+        makeEthSignTypedData({
+          primaryType: 'Permit',
+          typesJson: typesJsonForPrimary('Permit', [
+            { name: 'holder', type: 'address' },
+            { name: 'spender', type: 'address' },
+            { name: 'nonce', type: 'uint256' },
+            { name: 'expiry', type: 'uint256' },
+            { name: 'allowed', type: 'bool' },
+          ]),
+        }),
+      ),
+    ).toBe(true)
+  })
+
+  it('returns false when allowed is present but not bool', () => {
+    expect(
+      hasPermitShape(
+        makeEthSignTypedData({
+          primaryType: 'Permit',
+          typesJson: typesJsonForPrimary('Permit', [
+            { name: 'spender', type: 'address' },
+            { name: 'allowed', type: 'uint256' },
+          ]),
+        }),
+      ),
+    ).toBe(false)
+  })
+
+  it('returns true for EIP-3009 authorization field set', () => {
+    expect(
+      hasPermitShape(
+        makeEthSignTypedData({
+          primaryType: 'TransferWithAuthorization',
+          typesJson: typesJsonForPrimary('TransferWithAuthorization', [
+            { name: 'from', type: 'address' },
+            { name: 'to', type: 'address' },
+            { name: 'value', type: 'uint256' },
+            { name: 'validAfter', type: 'uint256' },
+            { name: 'validBefore', type: 'uint256' },
+            { name: 'nonce', type: 'bytes32' },
+          ]),
+        }),
+      ),
+    ).toBe(true)
+  })
+
+  it('returns false when EIP-3009 authorization fields are incomplete', () => {
+    expect(
+      hasPermitShape(
+        makeEthSignTypedData({
+          primaryType: 'TransferWithAuthorization',
+          typesJson: typesJsonForPrimary('TransferWithAuthorization', [
+            { name: 'from', type: 'address' },
+            { name: 'to', type: 'address' },
+            { name: 'value', type: 'uint256' },
+            { name: 'nonce', type: 'bytes32' },
+          ]),
+        }),
+      ),
+    ).toBe(false)
+  })
+})
+
+describe('isPermit2Domain', () => {
+  it('returns true when verifyingContract is the Permit2 contract', () => {
+    expect(
+      isPermit2Domain(
+        makeEthSignTypedData({
+          domainJson: JSON.stringify({
+            name: 'Permit2',
+            chainId: '1',
+            verifyingContract: PERMIT2_ADDRESS,
+          }),
+        }),
+      ),
+    ).toBe(true)
+  })
+
+  it('returns true for checksummed Permit2 address', () => {
+    expect(
+      isPermit2Domain(
+        makeEthSignTypedData({
+          domainJson: JSON.stringify({
+            verifyingContract: '0x000000000022D473030F116DDeE9F6b43ac78BA3',
+          }),
+        }),
+      ),
+    ).toBe(true)
+  })
+
+  it('returns false for other verifyingContract addresses', () => {
+    expect(
+      isPermit2Domain(
+        makeEthSignTypedData({
+          domainJson: JSON.stringify({
+            verifyingContract: '0x0000000000000000000000000000000000000001',
+          }),
+        }),
+      ),
+    ).toBe(false)
+  })
+
+  it('returns false when domainJson is invalid', () => {
+    expect(
+      isPermit2Domain(
+        makeEthSignTypedData({
+          domainJson: '{',
+        }),
+      ),
+    ).toBe(false)
+  })
+})
+
+describe('isPermitLikeEthSignTypedData', () => {
+  it('returns false for undefined', () => {
+    expect(isPermitLikeEthSignTypedData(undefined)).toBe(false)
+  })
+
+  it.each(PERMIT_LIKE)('returns true when primaryType is %s', (primaryType) => {
+    expect(
+      isPermitLikeEthSignTypedData(
+        makeEthSignTypedData({
+          primaryType,
+          typesJson: '{}',
+        }),
+      ),
+    ).toBe(true)
+  })
+
+  it('returns false for non-permit primary type and non-permit shape', () => {
+    expect(
+      isPermitLikeEthSignTypedData(
+        makeEthSignTypedData({
+          primaryType: 'Person',
+          typesJson: typesJsonForPrimary('Person', [
+            { name: 'name', type: 'string' },
+            { name: 'wallet', type: 'address' },
+          ]),
+        }),
+      ),
+    ).toBe(false)
+  })
+
+  it('returns true for permit-shaped message with unknown primary type name', () => {
+    expect(
+      isPermitLikeEthSignTypedData(
+        makeEthSignTypedData({
+          primaryType: 'VendorCustomPermit',
+          typesJson: typesJsonForPrimary('VendorCustomPermit', [
+            { name: 'owner', type: 'address' },
+            { name: 'spender', type: 'address' },
+            { name: 'value', type: 'uint256' },
+          ]),
+        }),
+      ),
+    ).toBe(true)
+  })
+
+  it('returns true for EIP-3009 shape with unknown primary type name', () => {
+    expect(
+      isPermitLikeEthSignTypedData(
+        makeEthSignTypedData({
+          primaryType: 'VendorTransferAuth',
+          typesJson: typesJsonForPrimary('VendorTransferAuth', [
+            { name: 'from', type: 'address' },
+            { name: 'to', type: 'address' },
+            { name: 'value', type: 'uint256' },
+            { name: 'validAfter', type: 'uint256' },
+            { name: 'validBefore', type: 'uint256' },
+            { name: 'nonce', type: 'bytes32' },
+          ]),
+        }),
+      ),
+    ).toBe(true)
+  })
+
+  it('returns false when primaryType is empty and shape does not match', () => {
+    expect(
+      isPermitLikeEthSignTypedData(
+        makeEthSignTypedData({
+          primaryType: '',
+          typesJson: '{}',
+        }),
+      ),
+    ).toBe(false)
+  })
+
+  it('returns true for nested permit2 type with benign primary type name', () => {
+    expect(
+      isPermitLikeEthSignTypedData(
+        makeEthSignTypedData({
+          primaryType: 'Nested',
+          typesJson: JSON.stringify({
+            Nested: [{ name: 'permit', type: 'PermitSingle' }],
+            PermitSingle: [
+              { name: 'details', type: 'PermitDetails' },
+              { name: 'spender', type: 'address' },
+              { name: 'sigDeadline', type: 'uint256' },
+            ],
+          }),
+        }),
+      ),
+    ).toBe(true)
+  })
+
+  it('returns true when domain verifyingContract is Permit2', () => {
+    expect(
+      isPermitLikeEthSignTypedData(
+        makeEthSignTypedData({
+          primaryType: 'Person',
+          typesJson: typesJsonForPrimary('Person', [
+            { name: 'name', type: 'string' },
+          ]),
+          domainJson: JSON.stringify({
+            verifyingContract: PERMIT2_ADDRESS,
+          }),
+        }),
+      ),
+    ).toBe(true)
+  })
+})

--- a/components/brave_wallet_ui/utils/sign_utils.ts
+++ b/components/brave_wallet_ui/utils/sign_utils.ts
@@ -1,0 +1,132 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { BraveWallet } from '../constants/types'
+
+export const PERMIT_LIKE: readonly string[] = [
+  // ERC-2612 and DAI-style
+  'Permit',
+
+  // Uniswap Permit2 (AllowanceTransfer)
+  'PermitSingle',
+  'PermitBatch',
+
+  // Uniswap Permit2 (SignatureTransfer)
+  'PermitTransferFrom',
+  'PermitBatchTransferFrom',
+  'PermitWitnessTransferFrom',
+  'PermitBatchWitnessTransferFrom',
+
+  // EIP-3009 (USDC and for x402 support)
+  'TransferWithAuthorization',
+  'ReceiveWithAuthorization',
+  'CancelAuthorization',
+]
+
+export const PERMIT2_ADDRESS = '0x000000000022D473030F116DDeE9F6b43ac78BA3'
+
+type TypedDataField = { name: string; type: string }
+
+type EthSignTypedDataDomain = {
+  verifyingContract?: string
+}
+
+function parseTypesJson(
+  typesJson: string | undefined,
+): Record<string, TypedDataField[]> | undefined {
+  if (!typesJson) {
+    return undefined
+  }
+  try {
+    return JSON.parse(typesJson) as Record<string, TypedDataField[]>
+  } catch {
+    return undefined
+  }
+}
+
+function parseDomain(
+  domainJson: string | undefined,
+): EthSignTypedDataDomain | undefined {
+  if (!domainJson) {
+    return undefined
+  }
+  try {
+    return JSON.parse(domainJson) as EthSignTypedDataDomain
+  } catch {
+    return undefined
+  }
+}
+
+export function isPermit2Domain(td: BraveWallet.EthSignTypedData): boolean {
+  const domain = parseDomain(td.domainJson)
+  return (
+    domain?.verifyingContract?.toLowerCase() === PERMIT2_ADDRESS.toLowerCase()
+  )
+}
+
+function fieldsMatchPermitShape(fields: TypedDataField[]): boolean {
+  const names = new Set(fields.map((f) => f.name))
+
+  const isPermitStyle =
+    names.has('spender')
+    && (names.has('value')
+      || names.has('amount')
+      || fields.some(
+        (f) =>
+          f.type === 'PermitDetails'
+          || f.type === 'PermitDetails[]'
+          || f.type === 'TokenPermissions'
+          || f.type === 'TokenPermissions[]',
+      ))
+
+  // DAI-style: holder + spender + allowed(bool)
+  const isDaiStyle =
+    names.has('spender')
+    && names.has('allowed')
+    && fields.some((f) => f.name === 'allowed' && f.type === 'bool')
+
+  // EIP-3009: from + to + value + validAfter + validBefore + nonce
+  const isAuthorizationStyle =
+    names.has('from')
+    && names.has('to')
+    && names.has('value')
+    && names.has('validAfter')
+    && names.has('validBefore')
+    && names.has('nonce')
+
+  return isPermitStyle || isDaiStyle || isAuthorizationStyle
+}
+
+function hasPermitShapeInTypes(
+  types: Record<string, TypedDataField[]>,
+): boolean {
+  return Object.entries(types).some(([typeName, fields]) => {
+    if (typeName === 'EIP712Domain' || !Array.isArray(fields)) {
+      return false
+    }
+    return fieldsMatchPermitShape(fields)
+  })
+}
+
+export function hasPermitShape(td: BraveWallet.EthSignTypedData): boolean {
+  const types = parseTypesJson(td.typesJson)
+  if (!types) {
+    return false
+  }
+  return hasPermitShapeInTypes(types)
+}
+
+export function isPermitLikeEthSignTypedData(
+  td: BraveWallet.EthSignTypedData | undefined,
+): boolean {
+  if (!td) {
+    return false
+  }
+  return (
+    (!!td.primaryType && PERMIT_LIKE.includes(td.primaryType))
+    || hasPermitShape(td)
+    || isPermit2Domain(td)
+  )
+}


### PR DESCRIPTION
## Description 

Will now handle more `Permit` like warning in the `Sign` panel

Primary Types Covered:

```
[
  'Permit',
  'PermitSingle',
  'PermitBatch',
  'PermitTransferFrom',
  'PermitWitnessTransferFrom',
]
```

Permit Shapes Covered:

```
    names.has('spender')
    && (names.has('value')
      || names.has('amount')
      || t.some(
        (f) =>
          f.type === 'PermitDetails'
          || f.type === 'PermitDetails[]'
          || f.type === 'TokenPermissions',
      ))
```

<!-- Add brave-browser issue below that this PR will resolve -->

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

https://github.com/user-attachments/assets/7fdb4382-0f03-4153-a944-ff886f7858d1
