### PR TITLE
Fix UBSAN error in BraveTabStyleViews

### DIFF
--- a/browser/ui/views/tabs/brave_tab_style_views.inc.cc
+++ b/browser/ui/views/tabs/brave_tab_style_views.inc.cc
@@ -14,6 +14,7 @@
 #include "chrome/browser/ui/browser_window/public/browser_window_features.h"
 #include "chrome/browser/ui/layout_constants.h"
 #include "ui/gfx/geometry/skia_conversions.h"
+#include "ui/views/view_utils.h"
 
 namespace {
 
@@ -297,7 +298,13 @@ gfx::Insets BraveVerticalTabStyle::GetContentsInsets() const {
   };
 
   auto add_left_padding_for_accent_icon = [&](gfx::Insets& insets) {
-    auto* brave_tab = static_cast<const BraveTab*>(tab());
+    auto* brave_tab = views::AsViewClass<BraveTab>(tab());
+    if (!brave_tab) {
+      // During startup tab could be in partially constructed state and BraveTab
+      // could be null during startup.
+      return;
+    }
+
     if (brave_tab->ShouldPaintTabAccent() &&
         brave_tab->ShouldShowLargeAccentIcon()) {
       insets.set_left(BraveTab::kTabAccentIconAreaWidth + insets.left());
@@ -428,8 +435,13 @@ int BraveVerticalTabStyle::GetStrokeThickness(
 }
 
 void BraveVerticalTabStyle::PaintTab(gfx::Canvas* canvas) const {
-  const auto* brave_tab = static_cast<const BraveTab*>(tab());
-  CHECK(brave_tab);
+  const auto* brave_tab = views::AsViewClass<BraveTab>(tab());
+  if (!brave_tab) {
+    // During startup tab could be in partially constructed state and BraveTab
+    // could be null during startup.
+    return;
+  }
+
   if (ShouldShowVerticalTabs()) {
     // For vertical tabs, bypass the upstream logic to paint theme backgrounds,
     // as this can cause crashes due to the vertical tabstrip living in a
@@ -483,8 +495,12 @@ void BraveVerticalTabStyle::PaintTab(gfx::Canvas* canvas) const {
 
 void BraveVerticalTabStyle::PaintTabAccentBackground(
     gfx::Canvas* canvas) const {
-  const auto* brave_tab = static_cast<const BraveTab*>(tab());
-  CHECK(brave_tab);
+  const auto* brave_tab = views::AsViewClass<BraveTab>(tab());
+  if (!brave_tab) {
+    // During startup tab could be in partially constructed state and BraveTab
+    // could be null during startup.
+    return;
+  }
 
   auto accent_colors = brave_tab->GetTabAccentColors();
   if (!accent_colors.has_value()) {
@@ -513,8 +529,12 @@ void BraveVerticalTabStyle::PaintTabAccentBackground(
 }
 
 void BraveVerticalTabStyle::PaintTabAccentBorder(gfx::Canvas* canvas) const {
-  const auto* brave_tab = static_cast<const BraveTab*>(tab());
-  CHECK(brave_tab);
+  const auto* brave_tab = views::AsViewClass<BraveTab>(tab());
+  if (!brave_tab) {
+    // During startup tab could be in partially constructed state and BraveTab
+    // could be null during startup.
+    return;
+  }
 
   auto accent_colors = brave_tab->GetTabAccentColors();
   if (!accent_colors.has_value()) {
@@ -536,7 +556,12 @@ void BraveVerticalTabStyle::PaintTabAccentBorder(gfx::Canvas* canvas) const {
 }
 
 void BraveVerticalTabStyle::PaintTabAccentIcon(gfx::Canvas* canvas) const {
-  auto* brave_tab = static_cast<const BraveTab*>(tab());
+  auto* brave_tab = views::AsViewClass<BraveTab>(tab());
+  if (!brave_tab) {
+    // During startup tab could be in partially constructed state and BraveTab
+    // could be null during startup.
+    return;
+  }
   auto accent_icon = brave_tab->GetTabAccentIcon();
 
   // getBounds() call to find the actual border bounds.
@@ -613,9 +638,14 @@ SkColor BraveVerticalTabStyle::GetCurrentTabBackgroundColor(
 gfx::RectF BraveVerticalTabStyle::InsetAlignedBoundsForTabAccent(
     const gfx::RectF& bounds,
     float scale) const {
+  const auto* brave_tab = views::AsViewClass<BraveTab>(tab());
+  if (!brave_tab) {
+    // During startup tab could be in partially constructed state and BraveTab
+    // could be null during startup.
+    return bounds;
+  }
+
   auto processed_bounds = bounds;
-  const auto* brave_tab = static_cast<const BraveTab*>(tab());
-  CHECK(brave_tab);
   if (brave_tab->ShouldPaintTabAccent() &&
       brave_tab->ShouldShowLargeAccentIcon()) {
     // Add left inset for tab accent icon area if tab should have accent icon.
@@ -638,10 +668,16 @@ std::optional<SkColor> BraveVerticalTabStyle::GetTargetTabBackgroundColor(
 
   // We have tab_background_color override for inactive tabs with accent in case
   // it's hovered
+  auto* brave_tab = views::AsViewClass<BraveTab>(tab());
+  if (!brave_tab) {
+    // During startup tab could be in partially constructed state and BraveTab
+    // could be null during startup.
+    return gfx::kPlaceholderColor;
+  }
+
   if (selection_state == TabStyle::TabSelectionState::kInactive && hovered &&
-      static_cast<const BraveTab*>(tab())->ShouldPaintTabAccent()) {
-    auto accent_colors =
-        static_cast<const BraveTab*>(tab())->GetTabAccentColors();
+      brave_tab->ShouldPaintTabAccent()) {
+    auto accent_colors = brave_tab->GetTabAccentColors();
     if (accent_colors &&
         accent_colors->override_tab_background_color != SK_ColorTRANSPARENT) {
       return accent_colors->override_tab_background_color;

--- a/browser/ui/views/tabs/tab_style_views_unittest.cc
+++ b/browser/ui/views/tabs/tab_style_views_unittest.cc
@@ -8,9 +8,9 @@
 #include <memory>
 #include <vector>
 
+#include "brave/browser/ui/views/tabs/brave_tab.h"
 #include "chrome/browser/ui/layout_constants.h"
 #include "chrome/browser/ui/views/tabs/fake_tab_slot_controller.h"
-#include "chrome/browser/ui/views/tabs/tab.h"
 #include "chrome/test/views/chrome_views_test_base.h"
 #include "components/tabs/public/tab_interface.h"
 #include "testing/gtest/include/gtest/gtest.h"
@@ -69,7 +69,8 @@ class BraveTabStyleIsHoveringTest : public ChromeViewsTestBase {
 
   // Creates a tab and adds it to the container for testing.
   Tab* CreateTab(int id) {
-    auto tab = std::make_unique<Tab>(tabs::TabHandle(id), controller_.get());
+    auto tab =
+        std::make_unique<BraveTab>(tabs::TabHandle(id), controller_.get());
     return container_->AddChildView(std::move(tab));
   }
 


### PR DESCRIPTION
During startup tab could be in partially constructed state and BraveTab could be null during startup.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/internal/issues/1719

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
