### PR TITLE
[include-what-you-use][brave] `//brave/components/brave_account`

### DIFF
--- a/components/brave_account/android/brave_account_features_android.cc
+++ b/components/brave_account/android/brave_account_features_android.cc
@@ -3,9 +3,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-#include "base/android/jni_android.h"
 #include "brave/components/brave_account/android/features_jni_headers/BraveAccountFeatures_jni.h"
 #include "brave/components/brave_account/features.h"
+#include "third_party/jni_zero/jni_zero.h"
 
 namespace brave_account {
 

--- a/components/brave_account/brave_account_service.cc
+++ b/components/brave_account/brave_account_service.cc
@@ -6,6 +6,10 @@
 #include "brave/components/brave_account/brave_account_service.h"
 
 #include <concepts>
+#include <functional>
+#include <map>
+#include <ostream>
+#include <string_view>
 #include <type_traits>
 #include <utility>
 
@@ -15,20 +19,32 @@
 #include "base/check_is_test.h"
 #include "base/functional/bind.h"
 #include "base/functional/callback.h"
+#include "base/location.h"
+#include "base/memory/raw_ptr.h"
+#include "base/memory/raw_ref.h"
 #include "base/no_destructor.h"
-#include "base/notimplemented.h"
 #include "base/types/expected.h"
+#include "base/types/strong_alias.h"
+#include "base/values.h"
 #include "brave/components/brave_account/brave_account_service_constants.h"
 #include "brave/components/brave_account/brave_account_state_prefs.h"
 #include "brave/components/brave_account/brave_account_utils.h"
 #include "brave/components/brave_account/endpoint_client/client.h"
+#include "brave/components/brave_account/endpoint_client/request.h"
 #include "brave/components/brave_account/endpoint_client/with_headers.h"
 #include "brave/components/brave_account/endpoints/auth_logout.h"
 #include "brave/components/brave_account/endpoints/error_body.h"
+#include "brave/components/brave_account/endpoints/login_finalize_bodies.h"
+#include "brave/components/brave_account/endpoints/login_init_bodies.h"
+#include "brave/components/brave_account/endpoints/password_finalize_bodies.h"
+#include "brave/components/brave_account/endpoints/password_init_bodies.h"
+#include "brave/components/brave_account/endpoints/service_token_bodies.h"
+#include "brave/components/brave_account/endpoints/verify_complete_bodies.h"
 #include "brave/components/brave_account/endpoints/verify_delete.h"
+#include "brave/components/brave_account/endpoints/verify_resend_bodies.h"
 #include "components/os_crypt/async/browser/os_crypt_async.h"
-#include "components/prefs/pref_service.h"
-#include "net/http/http_request_headers.h"
+#include "mojo/public/cpp/bindings/pending_receiver.h"
+#include "mojo/public/cpp/bindings/pending_remote.h"
 #include "net/http/http_status_code.h"
 #include "net/traffic_annotation/network_traffic_annotation.h"
 #include "services/network/public/cpp/shared_url_loader_factory.h"

--- a/components/brave_account/brave_account_service.h
+++ b/components/brave_account/brave_account_service.h
@@ -13,6 +13,8 @@
 #include "base/functional/callback.h"
 #include "base/memory/scoped_refptr.h"
 #include "base/memory/weak_ptr.h"
+#include "base/numerics/clamped_math.h"
+#include "base/numerics/safe_conversions.h"
 #include "base/time/time.h"
 #include "base/timer/timer.h"
 #include "brave/components/brave_account/brave_account_state_prefs.h"
@@ -34,6 +36,11 @@
 #include "mojo/public/cpp/bindings/remote_set.h"
 
 class PrefService;
+
+namespace mojo {
+template <typename T>
+class PendingReceiver;
+}  // namespace mojo
 
 namespace network {
 class SharedURLLoaderFactory;

--- a/components/brave_account/brave_account_service_test.h
+++ b/components/brave_account/brave_account_service_test.h
@@ -8,6 +8,7 @@
 
 #include <memory>
 #include <string>
+#include <type_traits>
 #include <utility>
 
 #include "base/check_deref.h"
@@ -16,6 +17,7 @@
 #include "base/functional/callback_helpers.h"
 #include "base/json/json_writer.h"
 #include "base/memory/raw_ptr.h"
+#include "base/memory/scoped_refptr.h"
 #include "base/test/scoped_feature_list.h"
 #include "base/test/task_environment.h"
 #include "base/test/test_future.h"
@@ -25,6 +27,7 @@
 #include "brave/components/brave_account/endpoint_client/test_support.h"
 #include "brave/components/brave_account/features.h"
 #include "brave/components/brave_account/prefs.h"
+#include "components/os_crypt/async/browser/os_crypt_async.h"
 #include "components/os_crypt/async/browser/test_utils.h"
 #include "components/prefs/testing_pref_service.h"
 #include "net/http/http_status_code.h"
@@ -33,6 +36,10 @@
 #include "services/network/test/test_url_loader_factory.h"
 #include "services/network/test/test_utils.h"
 #include "testing/gtest/include/gtest/gtest.h"
+
+namespace base {
+class OneShotTimer;
+}  // namespace base
 
 namespace brave_account {
 

--- a/components/brave_account/brave_account_service_unittest.cc
+++ b/components/brave_account/brave_account_service_unittest.cc
@@ -7,10 +7,13 @@
 
 #include <optional>
 #include <string>
+#include <string_view>
+#include <utility>
 
 #include "base/base64.h"
 #include "base/functional/callback.h"
 #include "base/json/values_util.h"
+#include "base/memory/raw_ref.h"
 #include "base/no_destructor.h"
 #include "base/test/task_environment.h"
 #include "base/time/time.h"
@@ -20,17 +23,27 @@
 #include "brave/components/brave_account/brave_account_service_test.h"
 #include "brave/components/brave_account/brave_account_state_prefs.h"
 #include "brave/components/brave_account/endpoints/auth_validate.h"
+#include "brave/components/brave_account/endpoints/auth_validate_bodies.h"
+#include "brave/components/brave_account/endpoints/error_body.h"
 #include "brave/components/brave_account/endpoints/login_finalize.h"
+#include "brave/components/brave_account/endpoints/login_finalize_bodies.h"
 #include "brave/components/brave_account/endpoints/login_init.h"
+#include "brave/components/brave_account/endpoints/login_init_bodies.h"
 #include "brave/components/brave_account/endpoints/password_finalize.h"
+#include "brave/components/brave_account/endpoints/password_finalize_bodies.h"
 #include "brave/components/brave_account/endpoints/password_init.h"
+#include "brave/components/brave_account/endpoints/password_init_bodies.h"
 #include "brave/components/brave_account/endpoints/service_token.h"
+#include "brave/components/brave_account/endpoints/service_token_bodies.h"
+#include "brave/components/brave_account/endpoints/verify_complete_bodies.h"
 #include "brave/components/brave_account/endpoints/verify_resend.h"
+#include "brave/components/brave_account/endpoints/verify_resend_bodies.h"
 #include "brave/components/brave_account/mock_brave_account_authentication_observer.h"
 #include "brave/components/brave_account/mojom/brave_account.mojom.h"
 #include "brave/components/brave_account/pref_names.h"
 #include "components/prefs/pref_service.h"
 #include "components/prefs/scoped_user_pref_update.h"
+#include "net/base/net_errors.h"
 #include "net/http/http_status_code.h"
 #include "testing/gmock/include/gmock/gmock.h"
 #include "testing/gtest/include/gtest/gtest.h"

--- a/components/brave_account/brave_account_state_prefs.cc
+++ b/components/brave_account/brave_account_state_prefs.cc
@@ -5,6 +5,7 @@
 
 #include "brave/components/brave_account/brave_account_state_prefs.h"
 
+#include <compare>
 #include <optional>
 
 #include "base/check.h"

--- a/components/brave_account/brave_account_state_prefs.h
+++ b/components/brave_account/brave_account_state_prefs.h
@@ -8,11 +8,14 @@
 
 #include <concepts>
 #include <string>
+#include <string_view>
 #include <utility>
 
 #include "base/check_deref.h"
 #include "base/functional/callback.h"
+#include "base/memory/raw_ptr.h"
 #include "base/memory/raw_ref.h"
+#include "base/values.h"
 #include "brave/components/brave_account/mojom/brave_account.mojom.h"
 #include "brave/components/brave_account/pref_names.h"
 #include "components/prefs/pref_change_registrar.h"

--- a/components/brave_account/endpoint_client/client.h
+++ b/components/brave_account/endpoint_client/client.h
@@ -27,6 +27,7 @@
 #include "brave/components/brave_account/endpoint_client/request_handle.h"
 #include "brave/components/brave_account/endpoint_client/with_headers.h"
 #include "net/base/load_flags.h"
+#include "net/http/http_response_headers.h"
 #include "net/traffic_annotation/network_traffic_annotation.h"
 #include "services/network/public/cpp/resource_request.h"
 #include "services/network/public/cpp/shared_url_loader_factory.h"

--- a/components/brave_account/endpoint_client/client_unittest.cc
+++ b/components/brave_account/endpoint_client/client_unittest.cc
@@ -7,6 +7,7 @@
 
 #include <concepts>
 #include <optional>
+#include <ostream>
 #include <string>
 #include <string_view>
 #include <tuple>
@@ -15,8 +16,15 @@
 #include "base/check.h"
 #include "base/check_deref.h"
 #include "base/functional/bind.h"
+#include "base/functional/function_ref.h"
 #include "base/json/json_reader.h"
+#include "base/json/json_writer.h"
+#include "base/location.h"
+#include "base/memory/raw_ptr.h"
+#include "base/memory/raw_ref.h"
+#include "base/memory/weak_ptr.h"
 #include "base/no_destructor.h"
+#include "base/task/single_thread_task_runner.h"
 #include "base/test/run_until.h"
 #include "base/test/task_environment.h"
 #include "base/test/test_future.h"
@@ -38,6 +46,8 @@
 #include "net/http/http_request_headers.h"
 #include "net/http/http_response_headers.h"
 #include "net/http/http_status_code.h"
+#include "net/http/http_version.h"
+#include "services/network/public/cpp/header_util.h"
 #include "services/network/public/cpp/resource_request.h"
 #include "services/network/public/cpp/simple_url_loader.h"
 #include "services/network/public/cpp/url_loader_completion_status.h"
@@ -45,7 +55,6 @@
 #include "services/network/public/mojom/url_response_head.mojom.h"
 #include "services/network/test/test_url_loader_factory.h"
 #include "services/network/test/test_utils.h"
-#include "testing/gtest/include/gtest/gtest.h"
 #include "third_party/abseil-cpp/absl/strings/str_format.h"
 #include "url/gurl.h"
 

--- a/components/brave_account/endpoint_client/is_endpoint_unittest.cc
+++ b/components/brave_account/endpoint_client/is_endpoint_unittest.cc
@@ -13,7 +13,6 @@
 #include "brave/components/brave_account/endpoint_client/request_types.h"
 #include "brave/components/brave_account/endpoint_client/response.h"
 #include "testing/gtest/include/gtest/gtest.h"
-#include "url/gurl.h"
 
 namespace brave_account::endpoint_client {
 

--- a/components/brave_account/endpoint_client/is_request.h
+++ b/components/brave_account/endpoint_client/is_request.h
@@ -9,6 +9,16 @@
 #include "brave/components/brave_account/endpoint_client/is_request_body.h"
 #include "brave/components/brave_account/endpoint_client/request.h"
 
+namespace brave_account {
+namespace endpoint_client {
+namespace detail {
+enum class Method;
+template <IsRequestBody RequestBody, Method M>
+struct Request;
+}  // namespace detail
+}  // namespace endpoint_client
+}  // namespace brave_account
+
 namespace brave_account::endpoint_client::detail {
 
 template <typename>

--- a/components/brave_account/endpoint_client/is_request_body.h
+++ b/components/brave_account/endpoint_client/is_request_body.h
@@ -12,6 +12,12 @@
 #include "base/values.h"
 #include "google/protobuf/message_lite.h"
 
+namespace google {
+namespace protobuf {
+class MessageLite;
+}  // namespace protobuf
+}  // namespace google
+
 namespace brave_account::endpoint_client::detail {
 
 // A JSON request body provides a non-static ToValue()

--- a/components/brave_account/endpoint_client/is_request_body_unittest.cc
+++ b/components/brave_account/endpoint_client/is_request_body_unittest.cc
@@ -11,10 +11,6 @@
 #include "google/protobuf/message_lite.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
-namespace base {
-class DictValue;
-}  // namespace base
-
 namespace brave_account::endpoint_client::detail {
 
 namespace {

--- a/components/brave_account/endpoint_client/is_request_unittest.cc
+++ b/components/brave_account/endpoint_client/is_request_unittest.cc
@@ -5,6 +5,8 @@
 
 #include "brave/components/brave_account/endpoint_client/is_request.h"
 
+#include <string>
+
 #include "brave/components/brave_account/endpoint_client/json_test_endpoint_bodies.h"
 #include "brave/components/brave_account/endpoint_client/protobuf_test_endpoint_bodies.pb.h"
 #include "brave/components/brave_account/endpoint_client/request_types.h"

--- a/components/brave_account/endpoint_client/is_response.h
+++ b/components/brave_account/endpoint_client/is_response.h
@@ -9,6 +9,14 @@
 #include "brave/components/brave_account/endpoint_client/is_response_body.h"
 #include "brave/components/brave_account/endpoint_client/response.h"
 
+namespace brave_account {
+namespace endpoint_client {
+template <detail::IsResponseBody SuccessResponseBody,
+          detail::IsResponseBody ErrorResponseBody>
+struct Response;
+}  // namespace endpoint_client
+}  // namespace brave_account
+
 namespace brave_account::endpoint_client::detail {
 
 template <typename>

--- a/components/brave_account/endpoint_client/is_response_body.h
+++ b/components/brave_account/endpoint_client/is_response_body.h
@@ -12,6 +12,15 @@
 #include "base/values.h"
 #include "google/protobuf/message_lite.h"
 
+namespace base {
+class Value;
+}  // namespace base
+namespace google {
+namespace protobuf {
+class MessageLite;
+}  // namespace protobuf
+}  // namespace google
+
 namespace brave_account::endpoint_client::detail {
 
 // A JSON response body provides a static FromValue() taking

--- a/components/brave_account/endpoint_client/is_response_unittest.cc
+++ b/components/brave_account/endpoint_client/is_response_unittest.cc
@@ -5,6 +5,8 @@
 
 #include "brave/components/brave_account/endpoint_client/is_response.h"
 
+#include <string>
+
 #include "brave/components/brave_account/endpoint_client/json_test_endpoint_bodies.h"
 #include "brave/components/brave_account/endpoint_client/protobuf_test_endpoint_bodies.pb.h"
 #include "brave/components/brave_account/endpoint_client/response.h"

--- a/components/brave_account/endpoint_client/maybe_strip_with_headers.h
+++ b/components/brave_account/endpoint_client/maybe_strip_with_headers.h
@@ -12,6 +12,13 @@
 #include "brave/components/brave_account/endpoint_client/is_response.h"
 #include "brave/components/brave_account/endpoint_client/with_headers.h"
 
+namespace brave_account {
+namespace endpoint_client {
+template <typename T>
+struct WithHeaders;
+}  // namespace endpoint_client
+}  // namespace brave_account
+
 namespace brave_account::endpoint_client::detail {
 
 // Primary template: leaves types unchanged unless

--- a/components/brave_account/endpoint_client/maybe_strip_with_headers_unittest.cc
+++ b/components/brave_account/endpoint_client/maybe_strip_with_headers_unittest.cc
@@ -7,13 +7,18 @@
 
 #include <concepts>
 #include <optional>
+#include <string>
 #include <tuple>
 
-#include "base/values.h"
 #include "brave/components/brave_account/endpoint_client/request_types.h"
 #include "brave/components/brave_account/endpoint_client/response.h"
 #include "brave/components/brave_account/endpoint_client/with_headers.h"
 #include "testing/gtest/include/gtest/gtest.h"
+
+namespace base {
+class DictValue;
+class Value;
+}  // namespace base
 
 namespace brave_account::endpoint_client {
 

--- a/components/brave_account/endpoints/auth_logout.h
+++ b/components/brave_account/endpoints/auth_logout.h
@@ -9,6 +9,7 @@
 #include "brave/components/brave_account/endpoint_client/brave_endpoint.h"
 #include "brave/components/brave_account/endpoint_client/request_types.h"
 #include "brave/components/brave_account/endpoint_client/response.h"
+#include "brave/components/brave_account/endpoint_client/static_string.h"
 #include "brave/components/brave_account/endpoints/auth_logout_bodies.h"
 
 namespace brave_account::endpoints {

--- a/components/brave_account/endpoints/auth_logout_unittest.cc
+++ b/components/brave_account/endpoints/auth_logout_unittest.cc
@@ -6,7 +6,11 @@
 #include "brave/components/brave_account/endpoints/auth_logout.h"
 
 #include <optional>
+#include <ostream>
+#include <string>
 
+#include "base/memory/raw_ptr.h"
+#include "base/memory/raw_ref.h"
 #include "base/no_destructor.h"
 #include "base/types/expected.h"
 #include "brave/components/brave_account/endpoints/endpoint_test.h"

--- a/components/brave_account/endpoints/auth_validate.h
+++ b/components/brave_account/endpoints/auth_validate.h
@@ -9,6 +9,7 @@
 #include "brave/components/brave_account/endpoint_client/brave_endpoint.h"
 #include "brave/components/brave_account/endpoint_client/request_types.h"
 #include "brave/components/brave_account/endpoint_client/response.h"
+#include "brave/components/brave_account/endpoint_client/static_string.h"
 #include "brave/components/brave_account/endpoints/auth_validate_bodies.h"
 #include "brave/components/brave_account/endpoints/error_body.h"
 

--- a/components/brave_account/endpoints/auth_validate_unittest.cc
+++ b/components/brave_account/endpoints/auth_validate_unittest.cc
@@ -6,9 +6,14 @@
 #include "brave/components/brave_account/endpoints/auth_validate.h"
 
 #include <optional>
+#include <ostream>
+#include <string>
 
+#include "base/memory/raw_ptr.h"
+#include "base/memory/raw_ref.h"
 #include "base/no_destructor.h"
 #include "base/types/expected.h"
+#include "base/values.h"
 #include "brave/components/brave_account/endpoints/endpoint_test.h"
 #include "net/base/net_errors.h"
 #include "net/http/http_status_code.h"

--- a/components/brave_account/endpoints/login_finalize.h
+++ b/components/brave_account/endpoints/login_finalize.h
@@ -9,6 +9,7 @@
 #include "brave/components/brave_account/endpoint_client/brave_endpoint.h"
 #include "brave/components/brave_account/endpoint_client/request_types.h"
 #include "brave/components/brave_account/endpoint_client/response.h"
+#include "brave/components/brave_account/endpoint_client/static_string.h"
 #include "brave/components/brave_account/endpoints/error_body.h"
 #include "brave/components/brave_account/endpoints/login_finalize_bodies.h"
 

--- a/components/brave_account/endpoints/login_finalize_unittest.cc
+++ b/components/brave_account/endpoints/login_finalize_unittest.cc
@@ -6,9 +6,14 @@
 #include "brave/components/brave_account/endpoints/login_finalize.h"
 
 #include <optional>
+#include <ostream>
+#include <string>
 
+#include "base/memory/raw_ptr.h"
+#include "base/memory/raw_ref.h"
 #include "base/no_destructor.h"
 #include "base/types/expected.h"
+#include "base/values.h"
 #include "brave/components/brave_account/endpoints/endpoint_test.h"
 #include "net/base/net_errors.h"
 #include "net/http/http_status_code.h"

--- a/components/brave_account/endpoints/login_init.h
+++ b/components/brave_account/endpoints/login_init.h
@@ -9,6 +9,7 @@
 #include "brave/components/brave_account/endpoint_client/brave_endpoint.h"
 #include "brave/components/brave_account/endpoint_client/request_types.h"
 #include "brave/components/brave_account/endpoint_client/response.h"
+#include "brave/components/brave_account/endpoint_client/static_string.h"
 #include "brave/components/brave_account/endpoints/error_body.h"
 #include "brave/components/brave_account/endpoints/login_init_bodies.h"
 

--- a/components/brave_account/endpoints/login_init_unittest.cc
+++ b/components/brave_account/endpoints/login_init_unittest.cc
@@ -6,9 +6,14 @@
 #include "brave/components/brave_account/endpoints/login_init.h"
 
 #include <optional>
+#include <ostream>
+#include <string>
 
+#include "base/memory/raw_ptr.h"
+#include "base/memory/raw_ref.h"
 #include "base/no_destructor.h"
 #include "base/types/expected.h"
+#include "base/values.h"
 #include "brave/components/brave_account/endpoints/endpoint_test.h"
 #include "net/base/net_errors.h"
 #include "net/http/http_status_code.h"

--- a/components/brave_account/endpoints/password_finalize.h
+++ b/components/brave_account/endpoints/password_finalize.h
@@ -9,6 +9,7 @@
 #include "brave/components/brave_account/endpoint_client/brave_endpoint.h"
 #include "brave/components/brave_account/endpoint_client/request_types.h"
 #include "brave/components/brave_account/endpoint_client/response.h"
+#include "brave/components/brave_account/endpoint_client/static_string.h"
 #include "brave/components/brave_account/endpoints/error_body.h"
 #include "brave/components/brave_account/endpoints/password_finalize_bodies.h"
 

--- a/components/brave_account/endpoints/password_finalize_unittest.cc
+++ b/components/brave_account/endpoints/password_finalize_unittest.cc
@@ -6,9 +6,14 @@
 #include "brave/components/brave_account/endpoints/password_finalize.h"
 
 #include <optional>
+#include <ostream>
+#include <string>
 
+#include "base/memory/raw_ptr.h"
+#include "base/memory/raw_ref.h"
 #include "base/no_destructor.h"
 #include "base/types/expected.h"
+#include "base/values.h"
 #include "brave/components/brave_account/endpoints/endpoint_test.h"
 #include "net/base/net_errors.h"
 #include "net/http/http_status_code.h"

--- a/components/brave_account/endpoints/password_init.h
+++ b/components/brave_account/endpoints/password_init.h
@@ -9,6 +9,7 @@
 #include "brave/components/brave_account/endpoint_client/brave_endpoint.h"
 #include "brave/components/brave_account/endpoint_client/request_types.h"
 #include "brave/components/brave_account/endpoint_client/response.h"
+#include "brave/components/brave_account/endpoint_client/static_string.h"
 #include "brave/components/brave_account/endpoints/error_body.h"
 #include "brave/components/brave_account/endpoints/password_init_bodies.h"
 

--- a/components/brave_account/endpoints/password_init_unittest.cc
+++ b/components/brave_account/endpoints/password_init_unittest.cc
@@ -6,9 +6,14 @@
 #include "brave/components/brave_account/endpoints/password_init.h"
 
 #include <optional>
+#include <ostream>
+#include <string>
 
+#include "base/memory/raw_ptr.h"
+#include "base/memory/raw_ref.h"
 #include "base/no_destructor.h"
 #include "base/types/expected.h"
+#include "base/values.h"
 #include "brave/components/brave_account/endpoints/endpoint_test.h"
 #include "net/base/net_errors.h"
 #include "net/http/http_status_code.h"

--- a/components/brave_account/endpoints/service_token.h
+++ b/components/brave_account/endpoints/service_token.h
@@ -9,6 +9,7 @@
 #include "brave/components/brave_account/endpoint_client/brave_endpoint.h"
 #include "brave/components/brave_account/endpoint_client/request_types.h"
 #include "brave/components/brave_account/endpoint_client/response.h"
+#include "brave/components/brave_account/endpoint_client/static_string.h"
 #include "brave/components/brave_account/endpoints/error_body.h"
 #include "brave/components/brave_account/endpoints/service_token_bodies.h"
 

--- a/components/brave_account/endpoints/service_token_unittest.cc
+++ b/components/brave_account/endpoints/service_token_unittest.cc
@@ -6,9 +6,14 @@
 #include "brave/components/brave_account/endpoints/service_token.h"
 
 #include <optional>
+#include <ostream>
+#include <string>
 
+#include "base/memory/raw_ptr.h"
+#include "base/memory/raw_ref.h"
 #include "base/no_destructor.h"
 #include "base/types/expected.h"
+#include "base/values.h"
 #include "brave/components/brave_account/endpoints/endpoint_test.h"
 #include "net/base/net_errors.h"
 #include "net/http/http_status_code.h"

--- a/components/brave_account/endpoints/verify_complete.h
+++ b/components/brave_account/endpoints/verify_complete.h
@@ -9,6 +9,7 @@
 #include "brave/components/brave_account/endpoint_client/brave_endpoint.h"
 #include "brave/components/brave_account/endpoint_client/request_types.h"
 #include "brave/components/brave_account/endpoint_client/response.h"
+#include "brave/components/brave_account/endpoint_client/static_string.h"
 #include "brave/components/brave_account/endpoints/error_body.h"
 #include "brave/components/brave_account/endpoints/verify_complete_bodies.h"
 

--- a/components/brave_account/endpoints/verify_complete_unittest.cc
+++ b/components/brave_account/endpoints/verify_complete_unittest.cc
@@ -6,10 +6,15 @@
 #include "brave/components/brave_account/endpoints/verify_complete.h"
 
 #include <optional>
+#include <ostream>
+#include <string>
 #include <tuple>
 
+#include "base/memory/raw_ptr.h"
+#include "base/memory/raw_ref.h"
 #include "base/no_destructor.h"
 #include "base/types/expected.h"
+#include "base/values.h"
 #include "brave/components/brave_account/endpoints/endpoint_test.h"
 #include "net/base/net_errors.h"
 #include "net/http/http_status_code.h"

--- a/components/brave_account/endpoints/verify_delete.h
+++ b/components/brave_account/endpoints/verify_delete.h
@@ -9,6 +9,7 @@
 #include "brave/components/brave_account/endpoint_client/brave_endpoint.h"
 #include "brave/components/brave_account/endpoint_client/request_types.h"
 #include "brave/components/brave_account/endpoint_client/response.h"
+#include "brave/components/brave_account/endpoint_client/static_string.h"
 #include "brave/components/brave_account/endpoints/verify_delete_bodies.h"
 
 namespace brave_account::endpoints {

--- a/components/brave_account/endpoints/verify_delete_unittest.cc
+++ b/components/brave_account/endpoints/verify_delete_unittest.cc
@@ -6,7 +6,11 @@
 #include "brave/components/brave_account/endpoints/verify_delete.h"
 
 #include <optional>
+#include <ostream>
+#include <string>
 
+#include "base/memory/raw_ptr.h"
+#include "base/memory/raw_ref.h"
 #include "base/no_destructor.h"
 #include "base/types/expected.h"
 #include "brave/components/brave_account/endpoints/endpoint_test.h"

--- a/components/brave_account/endpoints/verify_init.h
+++ b/components/brave_account/endpoints/verify_init.h
@@ -9,6 +9,7 @@
 #include "brave/components/brave_account/endpoint_client/brave_endpoint.h"
 #include "brave/components/brave_account/endpoint_client/request_types.h"
 #include "brave/components/brave_account/endpoint_client/response.h"
+#include "brave/components/brave_account/endpoint_client/static_string.h"
 #include "brave/components/brave_account/endpoints/error_body.h"
 #include "brave/components/brave_account/endpoints/verify_init_bodies.h"
 

--- a/components/brave_account/endpoints/verify_init_unittest.cc
+++ b/components/brave_account/endpoints/verify_init_unittest.cc
@@ -6,9 +6,14 @@
 #include "brave/components/brave_account/endpoints/verify_init.h"
 
 #include <optional>
+#include <ostream>
+#include <string>
 
+#include "base/memory/raw_ptr.h"
+#include "base/memory/raw_ref.h"
 #include "base/no_destructor.h"
 #include "base/types/expected.h"
+#include "base/values.h"
 #include "brave/components/brave_account/endpoints/endpoint_test.h"
 #include "net/base/net_errors.h"
 #include "net/http/http_status_code.h"

--- a/components/brave_account/endpoints/verify_resend.h
+++ b/components/brave_account/endpoints/verify_resend.h
@@ -9,6 +9,7 @@
 #include "brave/components/brave_account/endpoint_client/brave_endpoint.h"
 #include "brave/components/brave_account/endpoint_client/request_types.h"
 #include "brave/components/brave_account/endpoint_client/response.h"
+#include "brave/components/brave_account/endpoint_client/static_string.h"
 #include "brave/components/brave_account/endpoints/error_body.h"
 #include "brave/components/brave_account/endpoints/verify_resend_bodies.h"
 

--- a/components/brave_account/endpoints/verify_resend_unittest.cc
+++ b/components/brave_account/endpoints/verify_resend_unittest.cc
@@ -6,9 +6,14 @@
 #include "brave/components/brave_account/endpoints/verify_resend.h"
 
 #include <optional>
+#include <ostream>
+#include <string>
 
+#include "base/memory/raw_ptr.h"
+#include "base/memory/raw_ref.h"
 #include "base/no_destructor.h"
 #include "base/types/expected.h"
+#include "base/values.h"
 #include "brave/components/brave_account/endpoints/endpoint_test.h"
 #include "net/base/net_errors.h"
 #include "net/http/http_status_code.h"

--- a/components/brave_account/features.cc
+++ b/components/brave_account/features.cc
@@ -5,6 +5,9 @@
 
 #include "brave/components/brave_account/features.h"
 
+#include "base/containers/span.h"
+#include "base/feature.h"
+#include "base/feature_list.h"
 #include "brave/components/email_aliases/buildflags/buildflags.h"
 
 #if BUILDFLAG(ENABLE_EMAIL_ALIASES)

--- a/components/brave_account/features.h
+++ b/components/brave_account/features.h
@@ -10,6 +10,10 @@
 
 class PrefService;
 
+namespace base {
+struct Feature;
+}  // namespace base
+
 namespace brave_account::features {
 
 bool IsBraveAccountEnabled();

--- a/components/brave_account/features_unittest.cc
+++ b/components/brave_account/features_unittest.cc
@@ -6,7 +6,9 @@
 #include "brave/components/brave_account/features.h"
 
 #include <string>
+#include <utility>
 
+#include "base/containers/flat_map.h"
 #include "base/test/scoped_feature_list.h"
 #include "brave/components/email_aliases/features.h"
 #include "testing/gtest/include/gtest/gtest.h"

--- a/components/brave_account/mock_brave_account_authentication.cc
+++ b/components/brave_account/mock_brave_account_authentication.cc
@@ -5,6 +5,8 @@
 
 #include "brave/components/brave_account/mock_brave_account_authentication.h"
 
+#include <ostream>
+
 namespace brave_account {
 
 MockBraveAccountAuthentication::MockBraveAccountAuthentication() = default;

--- a/components/brave_account/mock_brave_account_authentication_observer.cc
+++ b/components/brave_account/mock_brave_account_authentication_observer.cc
@@ -5,6 +5,8 @@
 
 #include "brave/components/brave_account/mock_brave_account_authentication_observer.h"
 
+#include <ostream>
+
 namespace brave_account {
 
 MockBraveAccountAuthenticationObserver::

--- a/components/brave_account/prefs.cc
+++ b/components/brave_account/prefs.cc
@@ -5,6 +5,8 @@
 
 #include "brave/components/brave_account/prefs.h"
 
+#include <string_view>
+
 #include "base/values.h"
 #include "brave/components/brave_account/features.h"
 #include "brave/components/brave_account/pref_names.h"


### PR DESCRIPTION
This PR is an experimental use of `include-what-you-use` for:

 - `components/brave_account`

Bug: https://github.com/brave/brave-browser/issues/42212
