### PR TITLE
Disabling PDF Save To Drive

### DIFF
--- a/build/args/brave_defaults.gni
+++ b/build/args/brave_defaults.gni
@@ -27,3 +27,6 @@ enable_pseudolocales = false
 
 # Our copy of signature_generator.py doesn't support --ignore_missing_cert:
 ignore_missing_widevine_signing_cert = false
+
+# Disabling this feature completely, as it is broken in Brave anyway.
+enable_pdf_save_to_drive = false

--- a/components/ai_chat/content/browser/pdf_text_helper_unittest.cc
+++ b/components/ai_chat/content/browser/pdf_text_helper_unittest.cc
@@ -39,11 +39,6 @@ class FakePdfListener : public pdf::mojom::PdfListener {
               GetMostVisiblePageIndex,
               (GetMostVisiblePageIndexCallback),
               (override));
-  MOCK_METHOD(void,
-              GetSaveDataBufferHandlerForDrive,
-              (pdf::mojom::SaveRequestType,
-               GetSaveDataBufferHandlerForDriveCallback),
-              (override));
 };
 
 class TestPdfDocumentHelperClient : public pdf::PDFDocumentHelperClient {


### PR DESCRIPTION
This PR disables this feature with the existing buildflag. This may
change in the future.

This feature is showing to users when they browse to a pdf addres, but
it is not working anyway.

Resolves https://github.com/brave/brave-browser/issues/55531
Resolves https://github.com/brave/brave-browser/issues/54852
