### PR TITLE
[ads] Deduplicate NTP ad clicked events while DB write in progress

### DIFF
--- a/components/brave_ads/core/internal/user_engagement/ad_events/new_tab_page_ads/new_tab_page_ad_event_handler.cc
+++ b/components/brave_ads/core/internal/user_engagement/ad_events/new_tab_page_ads/new_tab_page_ad_event_handler.cc
@@ -10,9 +10,12 @@
 #include "base/debug/crash_logging.h"
 #include "base/functional/bind.h"
 #include "base/notreached.h"
+#include "base/time/time.h"
 #include "brave/components/brave_ads/core/internal/common/logging_util.h"
 #include "brave/components/brave_ads/core/internal/creatives/new_tab_page_ads/creative_new_tab_page_ad_info.h"
 #include "brave/components/brave_ads/core/internal/creatives/new_tab_page_ads/new_tab_page_ad_builder.h"
+#include "brave/components/brave_ads/core/internal/user_engagement/ad_events/ad_event_builder.h"
+#include "brave/components/brave_ads/core/internal/user_engagement/ad_events/ad_event_handler_util.h"
 #include "brave/components/brave_ads/core/internal/user_engagement/ad_events/new_tab_page_ads/new_tab_page_ad_event_factory.h"
 #include "brave/components/brave_ads/core/internal/user_engagement/ad_events/new_tab_page_ads/new_tab_page_ad_event_handler_util.h"
 #include "brave/components/brave_ads/core/public/ad_units/new_tab_page_ad/new_tab_page_ad_info.h"
@@ -104,13 +107,19 @@ void NewTabPageAdEventHandler::GetAdEventsCallback(
                              mojom_ad_event_type, std::move(callback));
   }
 
+  if (IsDuplicateOfPendingAdEvent(ad, mojom_ad_event_type)) {
+    return FailedToFireEvent(ad.placement_id, ad.creative_instance_id,
+                             mojom_ad_event_type, std::move(callback));
+  }
+  TrackPendingAdEvent(ad, mojom_ad_event_type);
+
   FireEvent(ad, mojom_ad_event_type, std::move(callback));
 }
 
 void NewTabPageAdEventHandler::FireEvent(
     const NewTabPageAdInfo& ad,
     mojom::NewTabPageAdEventType mojom_ad_event_type,
-    FireNewTabPageAdEventHandlerCallback callback) const {
+    FireNewTabPageAdEventHandlerCallback callback) {
   if (mojom_ad_event_type == mojom::NewTabPageAdEventType::kClicked) {
     // `RecordAdEvent` is asynchronous. Notifying the delegate before the write
     // ensures `last_clicked_ad` is set before any page navigation commits.
@@ -128,7 +137,9 @@ void NewTabPageAdEventHandler::FireEventCallback(
     const NewTabPageAdInfo& ad,
     mojom::NewTabPageAdEventType mojom_ad_event_type,
     FireNewTabPageAdEventHandlerCallback callback,
-    bool success) const {
+    bool success) {
+  UntrackPendingAdEvent(ad, mojom_ad_event_type);
+
   if (!success) {
     SCOPED_CRASH_KEY_NUMBER("Issue50267", "event_type",
                             static_cast<int>(mojom_ad_event_type));
@@ -168,6 +179,29 @@ void NewTabPageAdEventHandler::FailedToFireEvent(
                                       mojom_ad_event_type);
 
   std::move(callback).Run(/*success=*/false, placement_id, mojom_ad_event_type);
+}
+
+bool NewTabPageAdEventHandler::IsDuplicateOfPendingAdEvent(
+    const NewTabPageAdInfo& ad,
+    mojom::NewTabPageAdEventType mojom_ad_event_type) const {
+  return ShouldDeduplicateAdEvent(ad, pending_ad_events_, mojom_ad_event_type);
+}
+
+void NewTabPageAdEventHandler::TrackPendingAdEvent(
+    const NewTabPageAdInfo& ad,
+    mojom::NewTabPageAdEventType mojom_ad_event_type) {
+  pending_ad_events_.push_back(BuildAdEvent(
+      ad, ToMojomConfirmationType(mojom_ad_event_type), base::Time::Now()));
+}
+
+void NewTabPageAdEventHandler::UntrackPendingAdEvent(
+    const NewTabPageAdInfo& ad,
+    mojom::NewTabPageAdEventType mojom_ad_event_type) {
+  std::erase_if(pending_ad_events_, [&](const auto& pending_ad_event) {
+    return pending_ad_event.placement_id == ad.placement_id &&
+           pending_ad_event.confirmation_type ==
+               ToMojomConfirmationType(mojom_ad_event_type);
+  });
 }
 
 void NewTabPageAdEventHandler::NotifyWillFireNewTabPageAdClickedEvent(

--- a/components/brave_ads/core/internal/user_engagement/ad_events/new_tab_page_ads/new_tab_page_ad_event_handler.h
+++ b/components/brave_ads/core/internal/user_engagement/ad_events/new_tab_page_ads/new_tab_page_ad_event_handler.h
@@ -61,11 +61,11 @@ class NewTabPageAdEventHandler final : public NewTabPageAdEventHandlerDelegate {
 
   void FireEvent(const NewTabPageAdInfo& ad,
                  mojom::NewTabPageAdEventType mojom_ad_event_type,
-                 FireNewTabPageAdEventHandlerCallback callback) const;
+                 FireNewTabPageAdEventHandlerCallback callback);
   void FireEventCallback(const NewTabPageAdInfo& ad,
                          mojom::NewTabPageAdEventType mojom_ad_event_type,
                          FireNewTabPageAdEventHandlerCallback callback,
-                         bool success) const;
+                         bool success);
 
   void SuccessfullyFiredEvent(
       const NewTabPageAdInfo& ad,
@@ -85,11 +85,21 @@ class NewTabPageAdEventHandler final : public NewTabPageAdEventHandlerDelegate {
       const std::string& creative_instance_id,
       mojom::NewTabPageAdEventType mojom_ad_event_type) const;
 
+  bool IsDuplicateOfPendingAdEvent(
+      const NewTabPageAdInfo& ad,
+      mojom::NewTabPageAdEventType mojom_ad_event_type) const;
+  void TrackPendingAdEvent(const NewTabPageAdInfo& ad,
+                           mojom::NewTabPageAdEventType mojom_ad_event_type);
+  void UntrackPendingAdEvent(const NewTabPageAdInfo& ad,
+                             mojom::NewTabPageAdEventType mojom_ad_event_type);
+
   raw_ptr<NewTabPageAdEventHandlerDelegate> delegate_ = nullptr;  // Not owned.
 
   const database::table::CreativeNewTabPageAds creative_ads_database_table_;
 
   const database::table::AdEvents ad_events_database_table_;
+
+  AdEventList pending_ad_events_;
 
   base::WeakPtrFactory<NewTabPageAdEventHandler> weak_factory_{this};
 };

--- a/components/brave_ads/core/internal/user_engagement/ad_events/new_tab_page_ads/new_tab_page_ad_event_handler_for_non_rewards_unittest.cc
+++ b/components/brave_ads/core/internal/user_engagement/ad_events/new_tab_page_ads/new_tab_page_ad_event_handler_for_non_rewards_unittest.cc
@@ -231,6 +231,44 @@ TEST_F(BraveAdsNewTabPageAdEventHandlerIfUserHasNotJoinedBraveRewardsTest,
 }
 
 TEST_F(BraveAdsNewTabPageAdEventHandlerIfUserHasNotJoinedBraveRewardsTest,
+       DoNotFireDuplicateClickedEventWhileFireAdEventIsInProgress) {
+  // Arrange
+  const NewTabPageAdInfo ad =
+      test::BuildAndSaveNewTabPageAd(CreativeNewTabPageAdWallpaperType::kImage,
+                                     /*use_random_uuids=*/false);
+  test::RecordAdEvents(ad, {mojom::ConfirmationType::kServedImpression,
+                            mojom::ConfirmationType::kViewedImpression});
+
+  ::testing::InSequence seq;
+  EXPECT_CALL(delegate_mock_, OnWillFireNewTabPageAdClickedEvent(ad));
+  EXPECT_CALL(delegate_mock_, OnFailedToFireNewTabPageAdEvent(
+                                  ad.placement_id, ad.creative_instance_id,
+                                  mojom::NewTabPageAdEventType::kClicked));
+  EXPECT_CALL(delegate_mock_, OnDidFireNewTabPageAdClickedEvent(ad));
+
+  // Act
+  base::test::TestFuture<bool, std::string, mojom::NewTabPageAdEventType>
+      click_future;
+  event_handler_.FireEvent(
+      ad.placement_id, ad.creative_instance_id,
+      mojom::NewTabPageAdEventType::kClicked,
+      click_future.GetCallback<bool, const std::string&,
+                               mojom::NewTabPageAdEventType>());
+
+  base::test::TestFuture<bool, std::string, mojom::NewTabPageAdEventType>
+      duplicate_click_future;
+  event_handler_.FireEvent(
+      ad.placement_id, ad.creative_instance_id,
+      mojom::NewTabPageAdEventType::kClicked,
+      duplicate_click_future.GetCallback<bool, const std::string&,
+                                         mojom::NewTabPageAdEventType>());
+
+  // Assert
+  EXPECT_FALSE(duplicate_click_future.Get<bool>());
+  EXPECT_TRUE(click_future.Get<bool>());
+}
+
+TEST_F(BraveAdsNewTabPageAdEventHandlerIfUserHasNotJoinedBraveRewardsTest,
        DoNotFireEventWithInvalidPlacementId) {
   // Act & Assert
   base::RunLoop run_loop;

--- a/components/brave_ads/core/internal/user_engagement/ad_events/new_tab_page_ads/new_tab_page_ad_event_handler_for_rewards_unittest.cc
+++ b/components/brave_ads/core/internal/user_engagement/ad_events/new_tab_page_ads/new_tab_page_ad_event_handler_for_rewards_unittest.cc
@@ -224,6 +224,44 @@ TEST_F(BraveAdsNewTabPageAdEventHandlerForRewardsTest,
 }
 
 TEST_F(BraveAdsNewTabPageAdEventHandlerForRewardsTest,
+       DoNotFireDuplicateClickedEventWhileFireAdEventIsInProgress) {
+  // Arrange
+  const NewTabPageAdInfo ad =
+      test::BuildAndSaveNewTabPageAd(CreativeNewTabPageAdWallpaperType::kImage,
+                                     /*use_random_uuids=*/false);
+  test::RecordAdEvents(ad, {mojom::ConfirmationType::kServedImpression,
+                            mojom::ConfirmationType::kViewedImpression});
+
+  ::testing::InSequence seq;
+  EXPECT_CALL(delegate_mock_, OnWillFireNewTabPageAdClickedEvent(ad));
+  EXPECT_CALL(delegate_mock_, OnFailedToFireNewTabPageAdEvent(
+                                  ad.placement_id, ad.creative_instance_id,
+                                  mojom::NewTabPageAdEventType::kClicked));
+  EXPECT_CALL(delegate_mock_, OnDidFireNewTabPageAdClickedEvent(ad));
+
+  // Act
+  base::test::TestFuture<bool, std::string, mojom::NewTabPageAdEventType>
+      click_future;
+  event_handler_.FireEvent(
+      ad.placement_id, ad.creative_instance_id,
+      mojom::NewTabPageAdEventType::kClicked,
+      click_future.GetCallback<bool, const std::string&,
+                               mojom::NewTabPageAdEventType>());
+
+  base::test::TestFuture<bool, std::string, mojom::NewTabPageAdEventType>
+      duplicate_click_future;
+  event_handler_.FireEvent(
+      ad.placement_id, ad.creative_instance_id,
+      mojom::NewTabPageAdEventType::kClicked,
+      duplicate_click_future.GetCallback<bool, const std::string&,
+                                         mojom::NewTabPageAdEventType>());
+
+  // Assert
+  EXPECT_FALSE(duplicate_click_future.Get<bool>());
+  EXPECT_TRUE(click_future.Get<bool>());
+}
+
+TEST_F(BraveAdsNewTabPageAdEventHandlerForRewardsTest,
        DoNotFireEventWithInvalidPlacementId) {
   // Act & Assert
   base::RunLoop run_loop;

--- a/components/brave_ads/core/internal/user_engagement/ad_events/new_tab_page_ads/new_tab_page_ad_event_handler_util.cc
+++ b/components/brave_ads/core/internal/user_engagement/ad_events/new_tab_page_ads/new_tab_page_ad_event_handler_util.cc
@@ -38,4 +38,24 @@ bool ShouldFireAdEvent(const NewTabPageAdInfo& ad,
   return true;
 }
 
+mojom::ConfirmationType ToMojomConfirmationType(
+    mojom::NewTabPageAdEventType mojom_ad_event_type) {
+  switch (mojom_ad_event_type) {
+    case mojom::NewTabPageAdEventType::kServedImpression:
+      return mojom::ConfirmationType::kServedImpression;
+    case mojom::NewTabPageAdEventType::kViewedImpression:
+      return mojom::ConfirmationType::kViewedImpression;
+    case mojom::NewTabPageAdEventType::kClicked:
+      return mojom::ConfirmationType::kClicked;
+    case mojom::NewTabPageAdEventType::kInteraction:
+      return mojom::ConfirmationType::kInteraction;
+    case mojom::NewTabPageAdEventType::kMediaPlay:
+      return mojom::ConfirmationType::kMediaPlay;
+    case mojom::NewTabPageAdEventType::kMedia25:
+      return mojom::ConfirmationType::kMedia25;
+    case mojom::NewTabPageAdEventType::kMedia100:
+      return mojom::ConfirmationType::kMedia100;
+  }
+}
+
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/user_engagement/ad_events/new_tab_page_ads/new_tab_page_ad_event_handler_util.h
+++ b/components/brave_ads/core/internal/user_engagement/ad_events/new_tab_page_ads/new_tab_page_ad_event_handler_util.h
@@ -19,6 +19,9 @@ bool ShouldFireAdEvent(const NewTabPageAdInfo& ad,
                        const AdEventList& ad_events,
                        mojom::NewTabPageAdEventType mojom_ad_event_type);
 
+mojom::ConfirmationType ToMojomConfirmationType(
+    mojom::NewTabPageAdEventType mojom_ad_event_type);
+
 }  // namespace brave_ads
 
 #endif  // BRAVE_COMPONENTS_BRAVE_ADS_CORE_INTERNAL_USER_ENGAGEMENT_AD_EVENTS_NEW_TAB_PAGE_ADS_NEW_TAB_PAGE_AD_EVENT_HANDLER_UTIL_H_


### PR DESCRIPTION
Rapid double-clicks on a New Tab Page ad lead to a race condition and can trigger two confirmed clicked events because the deduplication check reads the database before the first click's DB write commits. Track pending events in memory to block duplicates for the same placement ID while the Ad Events database table write is in progress.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/55320

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
