### PR TITLE
Uplift intermittent test fixes to 1.91.x

### DIFF
--- a/test/filters/browser_tests.filter
+++ b/test/filters/browser_tests.filter
@@ -706,7 +706,13 @@
 -FileSystemAccessDeepScanningBrowserTest.WarnedWrite/*
 
 # These tests fail because of the Ephemeral Storage (they pass with
-# kBraveEphemeralStorage feature disabled).
+# kBraveEphemeralStorage feature disabled). The multi-navigation test design
+# causes late-arriving cookie access events that double-count UseCounter
+# features. Stable upstream (0.2% flake rate / 30d per LUCI Analysis).
+# Upstream deflake CL (chromium-review.googlesource.com/c/chromium/src/+/7694592)
+# landed after the Chromium 148 branch cut; will be picked up in a future roll.
+# https://github.com/brave/brave-browser/issues/55224
+-CookieUseCounterBrowserTest.HttpOnlyCookieShadowedByNonHttpOnlyPartitioned_BothAvailable
 -CookieUseCounterBrowserTest.HttpOnlyCookieShadowedByNonHttpOnlyPartitioned_NeitherAvailable
 -FirstPartySetsBrowserTestWithSiteLeavingSet.CookieDeleted
 -NativeUnpartitionedStorageTest/NativeUnpartitionedStorageAccessWhen3PCOff.CrossOriginsAccessWithCookieBlocking/0


### PR DESCRIPTION
Uplift of #36400
Resolves brave/brave-browser#55224

## Included PRs
- #36400 - Disable flaky CookieUseCounterBrowserTest.HttpOnlyCookieShadowedByNonHttpOnlyPartitioned_BothAvailable

Pre-approval checklist:
- [ ] You have tested your change on Nightly.
- [ ] This contains text which needs to be translated.
    - [ ] There are more than 7 days before the release.
    - [ ] I've notified folks in #l10n on Slack that translations are needed.
- [x] The PR milestones match the branch they are landing to.


Pre-merge checklist:
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.

Post-merge checklist:
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.