### PR TITLE
[FocusMode] Feature prototype

### DIFF
--- a/browser/ui/views/frame/BUILD.gn
+++ b/browser/ui/views/frame/BUILD.gn
@@ -8,6 +8,8 @@ source_set("frame") {
     "brave_contents_view_util.h",
     "brave_side_panel_shadow_overlay_view.h",
     "focus_mode_title_bar_view.h",
+    "focus_mode_top_overlay.cc",
+    "focus_mode_top_overlay.h",
     "layout/brave_browser_view_layout_delegate_impl.cc",
     "layout/brave_browser_view_layout_delegate_impl.h",
     "layout/brave_browser_view_tabbed_layout_impl.cc",
@@ -17,6 +19,7 @@ source_set("frame") {
 
   public_deps = [
     "//base",
+    "//brave/browser/ui/views/frame/edge_reveal",
     "//components/tabs:public",
     "//ui/views",
   ]
@@ -88,6 +91,7 @@ source_set("browser_tests") {
 
   sources = [
     "//brave/browser/ui/views/frame/brave_browser_view_browsertest.cc",
+    "//brave/browser/ui/views/frame/focus_mode_top_overlay_browsertest.cc",
     "//brave/browser/ui/views/frame/tab_strip_placement_coordinator_browsertest.cc",
   ]
 
@@ -95,6 +99,7 @@ source_set("browser_tests") {
     ":frame",
     ":frame_impl",
     "//base",
+    "//brave/browser/ui/focus_mode",
     "//brave/browser/ui/sidebar:sidebar_impl",
     "//brave/browser/ui/views/frame/vertical_tabs",
     "//brave/browser/ui/views/sidebar",

--- a/browser/ui/views/frame/BUILD.gn
+++ b/browser/ui/views/frame/BUILD.gn
@@ -7,6 +7,7 @@ source_set("frame") {
   sources = [
     "brave_contents_view_util.h",
     "brave_side_panel_shadow_overlay_view.h",
+    "focus_mode_title_bar_view.h",
     "layout/brave_browser_view_layout_delegate_impl.cc",
     "layout/brave_browser_view_layout_delegate_impl.h",
     "layout/brave_browser_view_tabbed_layout_impl.cc",
@@ -16,6 +17,7 @@ source_set("frame") {
 
   public_deps = [
     "//base",
+    "//components/tabs:public",
     "//ui/views",
   ]
 
@@ -32,6 +34,7 @@ source_set("frame_impl") {
   sources = [
     "brave_contents_view_util.cc",
     "brave_side_panel_shadow_overlay_view.cc",
+    "focus_mode_title_bar_view.cc",
     "tab_strip_placement_coordinator.cc",
   ]
 
@@ -46,13 +49,16 @@ source_set("frame_impl") {
     "//chrome/common:constants",
     "//components/prefs",
     "//components/split_tabs",
-    "//components/tabs:public",
   ]
 }
 
 source_set("unit_tests") {
   testonly = true
-  sources = [ "layout/brave_browser_view_tabbed_layout_impl_unittest.cc" ]
+
+  sources = [
+    "focus_mode_title_bar_view_unittest.cc",
+    "layout/brave_browser_view_tabbed_layout_impl_unittest.cc",
+  ]
 
   if (is_linux) {
     sources += [ "browser_frame_view_layout_linux_unittest.cc" ]
@@ -60,11 +66,19 @@ source_set("unit_tests") {
 
   deps = [
     ":frame",
+    ":frame_impl",
     "//base",
     "//base/test:test_support",
     "//chrome/browser/ui",
+    "//chrome/test:test_support",
+    "//components/tabs:test_support",
+    "//content/test:test_support",
     "//testing/gmock",
     "//testing/gtest",
+    "//ui/base",
+    "//ui/gfx",
+    "//ui/views:test_support",
+    "//url",
   ]
 }
 

--- a/browser/ui/views/frame/brave_browser_frame_view_mac.h
+++ b/browser/ui/views/frame/brave_browser_frame_view_mac.h
@@ -8,11 +8,16 @@
 
 #include <memory>
 
+#include "base/callback_list.h"
+#include "base/memory/weak_ptr.h"
+#include "base/scoped_observation.h"
+#include "brave/browser/ui/focus_mode/focus_mode_controller.h"
 #include "chrome/browser/ui/views/frame/browser_frame_view_mac.h"
 
 class BraveWindowFrameGraphic;
 
-class BraveBrowserFrameViewMac : public BrowserFrameViewMac {
+class BraveBrowserFrameViewMac : public BrowserFrameViewMac,
+                                 public FocusModeController::Observer {
  public:
   BraveBrowserFrameViewMac(BrowserWidget* browser_widget,
                            BrowserView* browser_view);
@@ -25,6 +30,9 @@ class BraveBrowserFrameViewMac : public BrowserFrameViewMac {
   // BrowserFrameView:
   void OnFullscreenStateChanged() override;
 
+  // FocusModeController::Observer:
+  void OnFocusModeToggled(bool enabled) override;
+
  private:
   class ScopedFocusModeDisable;
 
@@ -32,6 +40,9 @@ class BraveBrowserFrameViewMac : public BrowserFrameViewMac {
   void UpdateWindowTitleVisibility();
   void UpdateWindowTitleAndControls();
   void UpdateWindowTitleColor();
+  void UpdateWindowControlsOpacity();
+  void OnTopOverlayRevealFractionChanged(double reveal_fraction);
+  void ResetWindowControlsPosition();
 
   // BrowserFrameViewMac overrides:
   gfx::Rect GetBoundsForClientView() const override;
@@ -49,6 +60,10 @@ class BraveBrowserFrameViewMac : public BrowserFrameViewMac {
   BooleanPrefMember compact_horizontal_tabs_;
 
   std::unique_ptr<ScopedFocusModeDisable> scoped_focus_mode_disable_;
+  base::ScopedObservation<FocusModeController, FocusModeController::Observer>
+      focus_mode_observation_{this};
+  base::CallbackListSubscription overlay_reveal_subscription_;
+  base::WeakPtrFactory<BraveBrowserFrameViewMac> weak_factory_{this};
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_FRAME_BRAVE_BROWSER_FRAME_VIEW_MAC_H_

--- a/browser/ui/views/frame/brave_browser_frame_view_mac.h
+++ b/browser/ui/views/frame/brave_browser_frame_view_mac.h
@@ -22,7 +22,12 @@ class BraveBrowserFrameViewMac : public BrowserFrameViewMac {
   BraveBrowserFrameViewMac& operator=(const BraveBrowserFrameViewMac&) = delete;
   gfx::Size GetMinimumSize() const override;
 
+  // BrowserFrameView:
+  void OnFullscreenStateChanged() override;
+
  private:
+  class ScopedFocusModeDisable;
+
   bool ShouldShowWindowTitleForVerticalTabs() const;
   void UpdateWindowTitleVisibility();
   void UpdateWindowTitleAndControls();
@@ -42,6 +47,8 @@ class BraveBrowserFrameViewMac : public BrowserFrameViewMac {
   BooleanPrefMember show_vertical_tabs_;
   BooleanPrefMember show_title_bar_on_vertical_tabs_;
   BooleanPrefMember compact_horizontal_tabs_;
+
+  std::unique_ptr<ScopedFocusModeDisable> scoped_focus_mode_disable_;
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_FRAME_BRAVE_BROWSER_FRAME_VIEW_MAC_H_

--- a/browser/ui/views/frame/brave_browser_frame_view_mac.mm
+++ b/browser/ui/views/frame/brave_browser_frame_view_mac.mm
@@ -5,14 +5,20 @@
 
 #include "brave/browser/ui/views/frame/brave_browser_frame_view_mac.h"
 
+#import <AppKit/AppKit.h>
+
+#include <algorithm>
 #include <memory>
 
 #include "base/check_deref.h"
+#include "base/functional/bind.h"
 #include "base/memory/raw_ref.h"
 #include "brave/browser/ui/focus_mode/focus_mode_controller.h"
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
+#include "brave/browser/ui/views/frame/brave_browser_view.h"
 #include "brave/browser/ui/views/frame/brave_non_client_hit_test_helper.h"
 #include "brave/browser/ui/views/frame/brave_window_frame_graphic.h"
+#include "brave/browser/ui/views/frame/focus_mode_top_overlay.h"
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 #include "chrome/browser/browser_process.h"
 #include "chrome/browser/profiles/profile.h"
@@ -29,6 +35,18 @@
 #include "ui/gfx/geometry/outsets_f.h"
 #include "ui/gfx/geometry/rect.h"
 #include "ui/gfx/scoped_canvas.h"
+#include "ui/views/window/non_client_view.h"
+
+namespace {
+
+FocusModeTopOverlay* GetFocusModeTopOverlay(BrowserView* browser_view) {
+  if (!browser_view) {
+    return nullptr;
+  }
+  return BraveBrowserView::From(browser_view)->focus_mode_top_overlay();
+}
+
+}  // namespace
 
 class BraveBrowserFrameViewMac::ScopedFocusModeDisable {
  public:
@@ -69,6 +87,16 @@ BraveBrowserFrameViewMac::BraveBrowserFrameViewMac(
         base::BindRepeating(
             &BraveBrowserFrameViewMac::UpdateWindowTitleVisibility,
             base::Unretained(this)));
+  }
+
+  if (auto* controller = browser->GetFeatures().focus_mode_controller()) {
+    focus_mode_observation_.Observe(controller);
+    if (auto* overlay = GetFocusModeTopOverlay(browser_view)) {
+      overlay_reveal_subscription_ =
+          overlay->RegisterRevealFractionChanged(base::BindRepeating(
+              &BraveBrowserFrameViewMac::OnTopOverlayRevealFractionChanged,
+              base::Unretained(this)));
+    }
   }
 
   compact_horizontal_tabs_.Init(
@@ -167,6 +195,46 @@ void BraveBrowserFrameViewMac::UpdateWindowTitleColor() {
       GetCaptionColor(BrowserFrameActiveState::kUseCurrent));
 }
 
+void BraveBrowserFrameViewMac::UpdateWindowControlsOpacity() {
+  auto* widget = GetWidget();
+  if (!widget) {
+    return;
+  }
+
+  auto* window = widget->GetNativeWindow().GetNativeNSWindow();
+  if (!window) {
+    return;
+  }
+
+  double reveal_fraction = 1.0;
+  if (auto* overlay = GetFocusModeTopOverlay(GetBrowserView())) {
+    reveal_fraction = overlay->GetRevealFraction();
+  }
+
+  // Hold the buttons hidden while the overlay is mostly closed, then fade
+  // them in linearly across the last (1 - kFadeStart) of the reveal so the
+  // lights "pop in" near the end of the slide rather than tracking it
+  // continuously.
+  constexpr double kFadeStart = 0.7;
+  const double alpha =
+      std::clamp((reveal_fraction - kFadeStart) / (1.0 - kFadeStart), 0.0, 1.0);
+
+  for (NSWindowButton kind :
+       {NSWindowCloseButton, NSWindowMiniaturizeButton, NSWindowZoomButton}) {
+    [[window standardWindowButton:kind] setAlphaValue:alpha];
+  }
+}
+
+void BraveBrowserFrameViewMac::OnTopOverlayRevealFractionChanged(
+    double reveal_fraction) {
+  UpdateWindowControlsOpacity();
+}
+
+void BraveBrowserFrameViewMac::ResetWindowControlsPosition() {
+  browser_widget()->ResetWindowControlsPosition();
+  UpdateWindowControlsOpacity();
+}
+
 int BraveBrowserFrameViewMac::NonClientHitTest(const gfx::Point& point) {
   // During window teardown or fullscreen transitions on Mac, AppKit can trigger
   // hit tests via windowDidBecomeKey:/makeKeyAndOrderFront: while the widget is
@@ -205,8 +273,9 @@ void BraveBrowserFrameViewMac::UpdateWindowTitleAndControls() {
   // In case title visibility wasn't changed and only vertical tab strip enabled
   // state changed, we should reset controls positions manually.
   base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
-      FROM_HERE, base::BindOnce(&views::Widget::ResetWindowControlsPosition,
-                                browser_widget()->GetWeakPtr()));
+      FROM_HERE,
+      base::BindOnce(&BraveBrowserFrameViewMac::ResetWindowControlsPosition,
+                     weak_factory_.GetWeakPtr()));
 }
 
 gfx::Size BraveBrowserFrameViewMac::GetMinimumSize() const {
@@ -242,6 +311,11 @@ void BraveBrowserFrameViewMac::OnFullscreenStateChanged() {
     scoped_focus_mode_disable_.reset();
   }
   BrowserFrameViewMac::OnFullscreenStateChanged();
+}
+
+void BraveBrowserFrameViewMac::OnFocusModeToggled(bool enabled) {
+  UpdateWindowTitleAndControls();
+  UpdateWindowControlsOpacity();
 }
 
 bool BraveBrowserFrameViewMac::ShouldHideTopUIInFullscreen() const {

--- a/browser/ui/views/frame/brave_browser_frame_view_mac.mm
+++ b/browser/ui/views/frame/brave_browser_frame_view_mac.mm
@@ -7,6 +7,9 @@
 
 #include <memory>
 
+#include "base/check_deref.h"
+#include "base/memory/raw_ref.h"
+#include "brave/browser/ui/focus_mode/focus_mode_controller.h"
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
 #include "brave/browser/ui/views/frame/brave_non_client_hit_test_helper.h"
 #include "brave/browser/ui/views/frame/brave_window_frame_graphic.h"
@@ -26,6 +29,25 @@
 #include "ui/gfx/geometry/outsets_f.h"
 #include "ui/gfx/geometry/rect.h"
 #include "ui/gfx/scoped_canvas.h"
+
+class BraveBrowserFrameViewMac::ScopedFocusModeDisable {
+ public:
+  explicit ScopedFocusModeDisable(FocusModeController* controller)
+      : controller_(CHECK_DEREF(controller)),
+        was_enabled_(controller->IsEnabled()) {
+    controller_->SetEnabled(false);
+  }
+
+  ~ScopedFocusModeDisable() {
+    if (was_enabled_) {
+      controller_->SetEnabled(true);
+    }
+  }
+
+ private:
+  const raw_ref<FocusModeController> controller_;
+  bool was_enabled_;
+};
 
 BraveBrowserFrameViewMac::BraveBrowserFrameViewMac(
     BrowserWidget* browser_widget,
@@ -199,6 +221,27 @@ gfx::Size BraveBrowserFrameViewMac::GetMinimumSize() const {
   }
 
   return BrowserFrameViewMac::GetMinimumSize();
+}
+
+void BraveBrowserFrameViewMac::OnFullscreenStateChanged() {
+  // When entering fullscreen ensure that focus mode is disabled. Focus mode and
+  // immersive fullscreen on MacOS have conflicting presentation requirements,
+  // and both modes want to move the tabstrip into different parent views.
+  // Disabling focus mode before immersive mode is enabled ensures that the
+  // tabstrip view is returned to the expected placement before the immersive
+  // controller attempts to reparent it.
+  if (GetBrowserView()->IsFullscreen()) {
+    if (!scoped_focus_mode_disable_) {
+      auto* browser = GetBrowserView()->browser();
+      if (auto* controller = browser->GetFeatures().focus_mode_controller()) {
+        scoped_focus_mode_disable_ =
+            std::make_unique<ScopedFocusModeDisable>(controller);
+      }
+    }
+  } else {
+    scoped_focus_mode_disable_.reset();
+  }
+  BrowserFrameViewMac::OnFullscreenStateChanged();
 }
 
 bool BraveBrowserFrameViewMac::ShouldHideTopUIInFullscreen() const {

--- a/browser/ui/views/frame/brave_browser_frame_view_win.cc
+++ b/browser/ui/views/frame/brave_browser_frame_view_win.cc
@@ -5,9 +5,12 @@
 
 #include "brave/browser/ui/views/frame/brave_browser_frame_view_win.h"
 
+#include "base/functional/bind.h"
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
+#include "brave/browser/ui/views/frame/brave_browser_view.h"
 #include "brave/browser/ui/views/frame/brave_non_client_hit_test_helper.h"
 #include "brave/browser/ui/views/frame/brave_window_frame_graphic.h"
+#include "brave/browser/ui/views/frame/focus_mode_top_overlay.h"
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 #include "brave/browser/ui/views/toolbar/brave_toolbar_view.h"
 #include "chrome/browser/profiles/profile.h"
@@ -21,17 +24,30 @@
 #include "ui/compositor/layer.h"
 #include "ui/gfx/geometry/insets.h"
 #include "ui/gfx/geometry/rect.h"
+#include "ui/gfx/geometry/transform.h"
 #include "ui/gfx/scoped_canvas.h"
+
+namespace {
+
+FocusModeTopOverlay* GetFocusModeTopOverlay(BrowserView* browser_view) {
+  if (!browser_view) {
+    return nullptr;
+  }
+  return BraveBrowserView::From(browser_view)->focus_mode_top_overlay();
+}
+
+}  // namespace
 
 BraveBrowserFrameViewWin::BraveBrowserFrameViewWin(
     BrowserWidget* browser_widget,
     BrowserView* browser_view)
     : BrowserFrameViewWin(browser_widget, browser_view) {
-  frame_graphic_.reset(
-      new BraveWindowFrameGraphic(browser_view->browser()->profile()));
+  auto* browser = browser_view->browser();
+  DCHECK(browser);
+  frame_graphic_ =
+      std::make_unique<BraveWindowFrameGraphic>(browser->profile());
 
-  DCHECK(browser_view->browser());
-  auto* prefs = browser_view->browser()->profile()->GetPrefs();
+  auto* prefs = browser->profile()->GetPrefs();
   using_vertical_tabs_.Init(
       brave_tabs::kVerticalTabsEnabled, prefs,
       base::BindRepeating(&BraveBrowserFrameViewWin::OnVerticalTabsPrefsChanged,
@@ -40,6 +56,16 @@ BraveBrowserFrameViewWin::BraveBrowserFrameViewWin(
       brave_tabs::kVerticalTabsShowTitleOnWindow, prefs,
       base::BindRepeating(&BraveBrowserFrameViewWin::OnVerticalTabsPrefsChanged,
                           base::Unretained(this)));
+
+  if (auto* controller = browser->GetFeatures().focus_mode_controller()) {
+    focus_mode_observation_.Observe(controller);
+    if (auto* overlay = GetFocusModeTopOverlay(browser_view)) {
+      overlay_reveal_subscription_ =
+          overlay->RegisterRevealFractionChanged(base::BindRepeating(
+              &BraveBrowserFrameViewWin::OnTopOverlayRevealFractionChanged,
+              base::Unretained(this)));
+    }
+  }
 }
 
 BraveBrowserFrameViewWin::~BraveBrowserFrameViewWin() = default;
@@ -99,6 +125,21 @@ int BraveBrowserFrameViewWin::GetTopInset(bool restored) const {
 }
 
 int BraveBrowserFrameViewWin::NonClientHitTest(const gfx::Point& point) {
+  if (caption_button_container_) {
+    if (auto* overlay = GetFocusModeTopOverlay(GetBrowserView());
+        overlay && overlay->active()) {
+      gfx::Point local_point = point;
+      ConvertPointToTarget(parent(), caption_button_container_, &local_point);
+      if (caption_button_container_->HitTestPoint(local_point)) {
+        // While the overlay is mid-animation, swallow the area as HTCAPTION so
+        // the user can't half-click a sliding button. Once fully revealed, hand
+        // it to client-area routing so Views can hover and click the buttons
+        // even though they overlay the web-contents surface.
+        return overlay->GetRevealFraction() == 1.0 ? HTCLIENT : HTCAPTION;
+      }
+    }
+  }
+
   auto result = BrowserFrameViewWin::NonClientHitTest(point);
   if (result != HTCLIENT) {
     return result;
@@ -127,6 +168,17 @@ int BraveBrowserFrameViewWin::NonClientHitTest(const gfx::Point& point) {
   }
 
   return result;
+}
+
+void BraveBrowserFrameViewWin::OnTopOverlayRevealFractionChanged(
+    double reveal_fraction) {
+  if (!caption_button_container_ || !caption_button_container_->layer()) {
+    return;
+  }
+
+  const int height = caption_button_container_->height();
+  caption_button_container_->layer()->SetTransform(
+      gfx::Transform::MakeTranslation(0, -height * (1.0 - reveal_fraction)));
 }
 
 bool BraveBrowserFrameViewWin::ShouldShowWindowTitle(TitlebarType type) const {
@@ -198,6 +250,20 @@ int BraveBrowserFrameViewWin::FrameTopBorderThickness(bool restored) const {
   }
 
   return BrowserFrameViewWin::FrameTopBorderThickness(restored);
+}
+
+void BraveBrowserFrameViewWin::OnFocusModeToggled(bool enabled) {
+  if (!caption_button_container_) {
+    return;
+  }
+  if (enabled) {
+    if (!caption_button_container_->layer()) {
+      caption_button_container_->SetPaintToLayer();
+      caption_button_container_->layer()->SetFillsBoundsOpaquely(false);
+    }
+  } else if (caption_button_container_->layer()) {
+    caption_button_container_->DestroyLayer();
+  }
 }
 
 BEGIN_METADATA(BraveBrowserFrameViewWin)

--- a/browser/ui/views/frame/brave_browser_frame_view_win.h
+++ b/browser/ui/views/frame/brave_browser_frame_view_win.h
@@ -8,15 +8,16 @@
 
 #include <memory>
 
+#include "brave/browser/ui/focus_mode/focus_mode_controller.h"
 #include "chrome/browser/ui/views/frame/browser_frame_view_win.h"
 #include "components/prefs/pref_member.h"
 #include "ui/base/metadata/metadata_header_macros.h"
 
 class BraveWindowFrameGraphic;
 
-class BraveBrowserFrameViewWin : public BrowserFrameViewWin {
+class BraveBrowserFrameViewWin : public BrowserFrameViewWin,
+                                 public FocusModeController::Observer {
   METADATA_HEADER(BraveBrowserFrameViewWin, BrowserFrameViewWin)
-
  public:
   BraveBrowserFrameViewWin(BrowserWidget* browser_widget,
                            BrowserView* browser_view);
@@ -29,6 +30,7 @@ class BraveBrowserFrameViewWin : public BrowserFrameViewWin {
 
  private:
   void OnVerticalTabsPrefsChanged();
+  void OnTopOverlayRevealFractionChanged(double reveal_fraction);
 
   // BraveBrowserFrameViewWin overrides:
   void OnPaint(gfx::Canvas* canvas) override;
@@ -38,10 +40,17 @@ class BraveBrowserFrameViewWin : public BrowserFrameViewWin {
   void LayoutCaptionButtons() override;
   int FrameTopBorderThickness(bool restored) const override;
 
+  // FocusModeController::Observer:
+  void OnFocusModeToggled(bool enabled) override;
+
   std::unique_ptr<BraveWindowFrameGraphic> frame_graphic_;
 
   BooleanPrefMember using_vertical_tabs_;
   BooleanPrefMember showing_window_title_for_vertical_tabs_;
+
+  base::ScopedObservation<FocusModeController, FocusModeController::Observer>
+      focus_mode_observation_{this};
+  base::CallbackListSubscription overlay_reveal_subscription_;
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_FRAME_BRAVE_BROWSER_FRAME_VIEW_WIN_H_

--- a/browser/ui/views/frame/brave_browser_view.cc
+++ b/browser/ui/views/frame/brave_browser_view.cc
@@ -35,6 +35,7 @@
 #include "brave/browser/ui/views/frame/brave_contents_layout_manager.h"
 #include "brave/browser/ui/views/frame/brave_contents_view_util.h"
 #include "brave/browser/ui/views/frame/brave_side_panel_shadow_overlay_view.h"
+#include "brave/browser/ui/views/frame/focus_mode_title_bar_view.h"
 #include "brave/browser/ui/views/frame/focus_mode_top_overlay.h"
 #include "brave/browser/ui/views/frame/split_view/brave_contents_container_view.h"
 #include "brave/browser/ui/views/frame/split_view/brave_multi_contents_view.h"
@@ -287,6 +288,11 @@ BraveBrowserView* BraveBrowserView::From(BrowserView* view) {
   return static_cast<BraveBrowserView*>(view);
 }
 
+// static
+const BraveBrowserView* BraveBrowserView::From(const BrowserView* view) {
+  return static_cast<const BraveBrowserView*>(view);
+}
+
 bool BraveBrowserView::ShouldUseBraveWebViewRoundedCornersForContents(
     const Browser* browser) {
   if (!browser->is_type_normal()) {
@@ -395,6 +401,10 @@ BraveBrowserView::BraveBrowserView(Browser* browser) : BrowserView(browser) {
     auto* controller = browser_->GetFeatures().focus_mode_controller();
     CHECK(controller);
     focus_mode_observation_.Observe(controller);
+
+    focus_mode_title_bar_view_ =
+        AddChildView(std::make_unique<FocusModeTitleBarView>());
+    focus_mode_title_bar_view_->SetVisible(false);
 
     focus_mode_top_overlay_ =
         AddChildView(std::make_unique<FocusModeTopOverlay>(
@@ -792,6 +802,11 @@ void BraveBrowserView::AddedToWidget() {
         vertical_tab_strip_host_view_.get());
   }
 
+  if (focus_mode_title_bar_view_) {
+    GetBrowserViewLayout()->set_focus_mode_title_bar(
+        focus_mode_title_bar_view_);
+  }
+
   UpdateFocusModeState();
   EnsureFindBarHostViewIsLastChild();
 }
@@ -869,6 +884,14 @@ void BraveBrowserView::OnTabStripModelChanged(
   if (selection.active_tab_changed() && brave_help_bubble_host_view_ &&
       brave_help_bubble_host_view_->GetVisible()) {
     brave_help_bubble_host_view_->Hide();
+  }
+
+  if (selection.active_tab_changed()) {
+    if (focus_mode_title_bar_view_ &&
+        focus_mode_title_bar_view_->GetVisible()) {
+      focus_mode_title_bar_view_->SetTab(
+          browser()->tab_strip_model()->GetActiveTab());
+    }
   }
 }
 
@@ -989,13 +1012,9 @@ void BraveBrowserView::OnWidgetWindowModalVisibilityChanged(
   // parent class to make the scrim view visible
 }
 
-bool BraveBrowserView::IsBraveWebViewRoundedCornersEnabled() {
-  return browser_->profile()->GetPrefs()->GetBoolean(kWebViewRoundedCorners) &&
-         browser_->is_type_normal();
-}
-
 void BraveBrowserView::UpdateContentsShadowVisibility() {
-  bool show_contents_shadow = IsBraveWebViewRoundedCornersEnabled();
+  bool show_contents_shadow =
+      ShouldUseBraveWebViewRoundedCornersForContents(browser_.get());
 
   // With SideBySide, we use chromium's mini toolbar.
   // Unfortunately, it's not rendered well with contents shadow.
@@ -1465,6 +1484,12 @@ void BraveBrowserView::UpdateFocusModeState() {
     }
     EnsureFindBarHostViewIsLastChild();
     InvalidateLayout();
+  }
+
+  if (focus_mode_title_bar_view_) {
+    focus_mode_title_bar_view_->SetVisible(enabled);
+    focus_mode_title_bar_view_->SetTab(
+        enabled ? browser()->tab_strip_model()->GetActiveTab() : nullptr);
   }
 }
 

--- a/browser/ui/views/frame/brave_browser_view.cc
+++ b/browser/ui/views/frame/brave_browser_view.cc
@@ -23,6 +23,8 @@
 #include "brave/browser/ui/color/brave_color_id.h"
 #include "brave/browser/ui/commands/accelerator_service.h"
 #include "brave/browser/ui/commands/accelerator_service_factory.h"
+#include "brave/browser/ui/focus_mode/focus_mode_features.h"
+#include "brave/browser/ui/focus_mode/focus_mode_utils.h"
 #include "brave/browser/ui/page_info/features.h"
 #include "brave/browser/ui/sidebar/sidebar_controller.h"
 #include "brave/browser/ui/sidebar/sidebar_utils.h"
@@ -33,6 +35,7 @@
 #include "brave/browser/ui/views/frame/brave_contents_layout_manager.h"
 #include "brave/browser/ui/views/frame/brave_contents_view_util.h"
 #include "brave/browser/ui/views/frame/brave_side_panel_shadow_overlay_view.h"
+#include "brave/browser/ui/views/frame/focus_mode_top_overlay.h"
 #include "brave/browser/ui/views/frame/split_view/brave_contents_container_view.h"
 #include "brave/browser/ui/views/frame/split_view/brave_multi_contents_view.h"
 #include "brave/browser/ui/views/frame/tab_strip_placement_coordinator.h"
@@ -87,6 +90,7 @@
 #include "chrome/browser/ui/web_applications/app_browser_controller.h"
 #include "chrome/common/pref_names.h"
 #include "components/javascript_dialogs/tab_modal_dialog_manager.h"
+#include "components/omnibox/browser/location_bar_model.h"
 #include "components/permissions/permission_request_manager.h"
 #include "components/web_modal/web_contents_modal_dialog_manager.h"
 #include "content/public/browser/page_navigator.h"
@@ -387,8 +391,14 @@ BraveBrowserView::BraveBrowserView(Browser* browser) : BrowserView(browser) {
         views::CreateSolidBackground(kColorToolbar));
   }
 
-  if (!supports_vertical_tabs && !can_have_sidebar) {
-    return;
+  if (BrowserSupportsFocusMode(browser_)) {
+    auto* controller = browser_->GetFeatures().focus_mode_controller();
+    CHECK(controller);
+    focus_mode_observation_.Observe(controller);
+
+    focus_mode_top_overlay_ =
+        AddChildView(std::make_unique<FocusModeTopOverlay>(
+            base::PassKey<BraveBrowserView>(), this));
   }
 
   EnsureFindBarHostViewIsLastChild();
@@ -739,6 +749,10 @@ void BraveBrowserView::OnAcceleratorsChanged(
   }
 }
 
+void BraveBrowserView::OnFocusModeToggled(bool enabled) {
+  UpdateFocusModeState();
+}
+
 #if BUILDFLAG(ENABLE_BRAVE_WALLET)
 void BraveBrowserView::CreateWalletBubble() {
   DCHECK(GetWalletButton());
@@ -774,10 +788,17 @@ void BraveBrowserView::AddedToWidget() {
     vertical_tab_strip_container_view_ =
         AddChildView(std::make_unique<BraveVerticalTabStripContainerView>(
             this, vertical_tab_strip_host_view_));
-    EnsureFindBarHostViewIsLastChild();
     GetBrowserViewLayout()->set_vertical_tab_strip_host(
         vertical_tab_strip_host_view_.get());
   }
+
+  UpdateFocusModeState();
+  EnsureFindBarHostViewIsLastChild();
+}
+
+void BraveBrowserView::RemovedFromWidget() {
+  focus_mode_observation_.Reset();
+  BrowserView::RemovedFromWidget();
 }
 
 bool BraveBrowserView::ShowBraveHelpBubbleView(const std::string& text) {
@@ -1015,7 +1036,8 @@ void BraveBrowserView::HideSplitView() {
 }
 
 void BraveBrowserView::ReparentTopContainerForEndOfImmersive() {
-  if (tabs::utils::ShouldShowBraveVerticalTabs(browser())) {
+  if (tabs::utils::ShouldShowBraveVerticalTabs(browser()) ||
+      IsFocusModeEnabled(browser())) {
     return;
   }
 
@@ -1143,7 +1165,20 @@ void BraveBrowserView::OnActiveTabChanged(content::WebContents* old_contents,
                                           content::WebContents* new_contents,
                                           int index,
                                           int reason) {
+  bool tab_change_in_split_view =
+      IsTabChangeInSplitView(old_contents, new_contents);
+
   BrowserView::OnActiveTabChanged(old_contents, new_contents, index, reason);
+
+  // Switching between tabs may change state that is relevant for focus mode
+  // (e.g. when switching between an https tab and an http tab).
+  UpdateFocusModeState();
+
+  // In focus mode, when switching between tabs that aren't split-view pairs
+  // temporarily reveal the location bar.
+  if (focus_mode_top_overlay_ && !tab_change_in_split_view) {
+    focus_mode_top_overlay_->RevealTemporarily(base::Seconds(2));
+  }
 
   // Update UI after active tab changing is handled because
   // ShouldUseBraveWebViewRoundedCornersForContents() check split view UI for
@@ -1193,6 +1228,14 @@ void BraveBrowserView::OnActiveTabChanged(content::WebContents* old_contents,
     CHECK(tab_modal_dialog_manager);
     tab_modal_dialog_manager->OnTabActiveStateChanged();
   }
+}
+
+bool BraveBrowserView::UpdateToolbarSecurityState() {
+  bool state_changed = BrowserView::UpdateToolbarSecurityState();
+  if (state_changed) {
+    UpdateFocusModeState();
+  }
+  return state_changed;
 }
 
 bool BraveBrowserView::AcceleratorPressed(const ui::Accelerator& accelerator) {
@@ -1286,6 +1329,22 @@ ClientFrameElementInfo BraveBrowserView::GetFrameElementInfo() const {
 #endif
   }
   return info;
+}
+
+void BraveBrowserView::OnImmersiveFullscreenExited() {
+  BrowserView::OnImmersiveFullscreenExited();
+  tab_strip_placement_->UpdatePlacement();
+}
+
+void BraveBrowserView::OnImmersiveModeControllerDestroyed() {
+  // When the immersive mode controller is destroyed during browser teardown,
+  // ensure that top-reveal views are returned to their original and expected
+  // placement in order to avoid violating view heirarchy assumptions in the
+  // immersive fullscreen controller.
+  if (focus_mode_top_overlay_) {
+    focus_mode_top_overlay_->Deactivate();
+  }
+  BrowserView::OnImmersiveModeControllerDestroyed();
 }
 
 bool BraveBrowserView::IsSidebarVisible() const {
@@ -1384,6 +1443,43 @@ void BraveBrowserView::UpdateWebViewRoundedCorners() {
                          contents_container_view->devtools_docked_placement(),
                          corners);
   }
+}
+
+void BraveBrowserView::UpdateFocusModeState() {
+  bool enabled = IsFocusModeEnabled(browser());
+
+  // If the location bar is showing a warning (e.g. http, cert errors, etc.),
+  // configure the browser view as if Focus Mode is not enabled.
+  if (enabled && IsLocationBarShowingWarning()) {
+    enabled = false;
+  }
+
+  if (focus_mode_top_overlay_) {
+    if (enabled) {
+      // Ensure that the overlay is at the end of the child list for correct
+      // z-order rendering.
+      ReorderChildView(focus_mode_top_overlay_, -1);
+      focus_mode_top_overlay_->Activate();
+    } else {
+      focus_mode_top_overlay_->Deactivate();
+    }
+    EnsureFindBarHostViewIsLastChild();
+    InvalidateLayout();
+  }
+}
+
+bool BraveBrowserView::IsLocationBarShowingWarning() const {
+  auto* location_bar = GetLocationBar();
+  if (!location_bar) {
+    return false;
+  }
+  auto* model = location_bar->GetLocationBarModel();
+  if (!model) {
+    return false;
+  }
+  auto level = model->GetSecurityLevel();
+  return level != security_state::SecurityLevel::NONE &&
+         level != security_state::SecurityLevel::SECURE;
 }
 
 void BraveBrowserView::Layout(PassKey) {

--- a/browser/ui/views/frame/brave_browser_view.h
+++ b/browser/ui/views/frame/brave_browser_view.h
@@ -70,6 +70,7 @@ class BraveShieldsToolbarButton;
 class BraveHelpBubbleHostView;
 class BraveMultiContentsView;
 class ContentsLayoutManager;
+class FocusModeTitleBarView;
 class FocusModeTopOverlay;
 class SidebarContainerView;
 class SidePanelEntry;
@@ -92,6 +93,7 @@ class BraveBrowserView : public BrowserView,
   ~BraveBrowserView() override;
 
   static BraveBrowserView* From(BrowserView* view);
+  static const BraveBrowserView* From(const BrowserView* view);
 
   // We use rounded corners even rounded corners setting is disabled.
   // Call this when we want to know
@@ -260,7 +262,6 @@ class BraveBrowserView : public BrowserView,
   bool ShouldDrawTabStrokes() const override;
 
   void HandleBrowserWindowMouseEvent(const ui::MouseEvent& event);
-  bool IsBraveWebViewRoundedCornersEnabled();
   void UpdateContentsShadowVisibility();
   void StopTabCycling();
   void UpdateSearchTabsButtonState();
@@ -304,6 +305,7 @@ class BraveBrowserView : public BrowserView,
   raw_ptr<views::View> vertical_tab_strip_host_view_ = nullptr;
   raw_ptr<BraveVerticalTabStripContainerView>
       vertical_tab_strip_container_view_ = nullptr;
+  raw_ptr<FocusModeTitleBarView> focus_mode_title_bar_view_ = nullptr;
   raw_ptr<FocusModeTopOverlay> focus_mode_top_overlay_ = nullptr;
 
 #if defined(USE_AURA)

--- a/browser/ui/views/frame/brave_browser_view.h
+++ b/browser/ui/views/frame/brave_browser_view.h
@@ -17,6 +17,7 @@
 #include "base/memory/weak_ptr.h"
 #include "base/scoped_observation.h"
 #include "brave/browser/ui/commands/accelerator_service.h"
+#include "brave/browser/ui/focus_mode/focus_mode_controller.h"
 #include "brave/browser/ui/tabs/brave_tab_strip_model.h"
 #include "brave/components/brave_vpn/common/buildflags/buildflags.h"
 #include "brave/components/brave_wallet/common/buildflags/buildflags.h"
@@ -69,6 +70,7 @@ class BraveShieldsToolbarButton;
 class BraveHelpBubbleHostView;
 class BraveMultiContentsView;
 class ContentsLayoutManager;
+class FocusModeTopOverlay;
 class SidebarContainerView;
 class SidePanelEntry;
 class TabStripPlacementCoordinator;
@@ -80,7 +82,8 @@ class WalletButton;
 #endif
 
 class BraveBrowserView : public BrowserView,
-                         public commands::AcceleratorService::Observer {
+                         public commands::AcceleratorService::Observer,
+                         public FocusModeController::Observer {
   METADATA_HEADER(BraveBrowserView, BrowserView)
  public:
   explicit BraveBrowserView(Browser* browser);
@@ -132,11 +135,15 @@ class BraveBrowserView : public BrowserView,
                           content::WebContents* new_contents,
                           int index,
                           int reason) override;
+  bool UpdateToolbarSecurityState() override;
   bool AcceleratorPressed(const ui::Accelerator& accelerator) override;
   bool IsInTabDragging() const override;
   void ReadyToListenFullscreenChanges() override;
   bool IsWebPanelContents(content::WebContents* contents) override;
   ClientFrameElementInfo GetFrameElementInfo() const override;
+
+  void OnImmersiveFullscreenExited() override;
+  void OnImmersiveModeControllerDestroyed() override;
 
 #if defined(USE_AURA)
   views::View* sidebar_host_view() { return sidebar_host_view_; }
@@ -154,6 +161,9 @@ class BraveBrowserView : public BrowserView,
   void OnAcceleratorsChanged(
       const commands::AcceleratorPrefManager::Accelerators& changed) override;
 
+  // FocusModeController::Observer:
+  void OnFocusModeToggled(bool enabled) override;
+
   BraveMultiContentsView* GetBraveMultiContentsView() const;
   void UpdateRoundedCornersUI();
   void UpdateVerticalTabStripBorder();
@@ -170,6 +180,10 @@ class BraveBrowserView : public BrowserView,
 
   TabStripPlacementCoordinator* tab_strip_placement_coordinator() {
     return tab_strip_placement_.get();
+  }
+
+  FocusModeTopOverlay* focus_mode_top_overlay() {
+    return focus_mode_top_overlay_;
   }
 
   views::View* top_container_separator_for_testing() const {
@@ -223,6 +237,7 @@ class BraveBrowserView : public BrowserView,
 
   // BrowserView overrides:
   void AddedToWidget() override;
+  void RemovedFromWidget() override;
   void LoadAccelerators() override;
   void OnTabStripModelChanged(
       TabStripModel* tab_strip_model,
@@ -254,6 +269,8 @@ class BraveBrowserView : public BrowserView,
   void OnWindowClosingConfirmResponse(bool allowed_to_close);
   BraveBrowser* GetBraveBrowser() const;
   void UpdateWebViewRoundedCorners();
+  void UpdateFocusModeState();
+  bool IsLocationBarShowingWarning() const;
 
   // FindBarHost is anchored to |find_bar_host_view_|; it must remain the last
   // child of BrowserView for correct z-order. Call when a child is added after
@@ -287,6 +304,7 @@ class BraveBrowserView : public BrowserView,
   raw_ptr<views::View> vertical_tab_strip_host_view_ = nullptr;
   raw_ptr<BraveVerticalTabStripContainerView>
       vertical_tab_strip_container_view_ = nullptr;
+  raw_ptr<FocusModeTopOverlay> focus_mode_top_overlay_ = nullptr;
 
 #if defined(USE_AURA)
   raw_ptr<views::View> sidebar_host_view_ = nullptr;
@@ -314,6 +332,8 @@ class BraveBrowserView : public BrowserView,
   base::ScopedObservation<commands::AcceleratorService,
                           commands::AcceleratorService::Observer>
       accelerators_observation_{this};
+  base::ScopedObservation<FocusModeController, FocusModeController::Observer>
+      focus_mode_observation_{this};
 
   base::WeakPtrFactory<BraveBrowserView> weak_ptr_{this};
 };

--- a/browser/ui/views/frame/brave_opaque_browser_frame_view.cc
+++ b/browser/ui/views/frame/brave_opaque_browser_frame_view.cc
@@ -8,8 +8,12 @@
 #include <memory>
 
 #include "base/check.h"
+#include "base/functional/bind.h"
+#include "brave/browser/ui/focus_mode/focus_mode_utils.h"
+#include "brave/browser/ui/views/frame/brave_browser_view.h"
 #include "brave/browser/ui/views/frame/brave_non_client_hit_test_helper.h"
 #include "brave/browser/ui/views/frame/brave_window_frame_graphic.h"
+#include "brave/browser/ui/views/frame/focus_mode_top_overlay.h"
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 #include "brave/browser/ui/views/toolbar/brave_toolbar_view.h"
 #include "chrome/browser/profiles/profile.h"
@@ -22,15 +26,40 @@
 #include "ui/compositor/layer.h"
 #include "ui/gfx/geometry/insets.h"
 #include "ui/gfx/geometry/rect.h"
+#include "ui/gfx/geometry/transform.h"
 #include "ui/gfx/scoped_canvas.h"
+#include "ui/views/controls/button/button.h"
+
+namespace {
+
+FocusModeTopOverlay* GetFocusModeTopOverlay(BrowserView* browser_view) {
+  if (!browser_view) {
+    return nullptr;
+  }
+  return BraveBrowserView::From(browser_view)->focus_mode_top_overlay();
+}
+
+}  // namespace
 
 BraveOpaqueBrowserFrameView::BraveOpaqueBrowserFrameView(
     BrowserWidget* frame,
     BrowserView* browser_view,
     OpaqueBrowserFrameViewLayout* layout)
     : OpaqueBrowserFrameView(frame, browser_view, layout) {
-  frame_graphic_ = std::make_unique<BraveWindowFrameGraphic>(
-      browser_view->browser()->profile());
+  auto* browser = browser_view->browser();
+  DCHECK(browser);
+  frame_graphic_ =
+      std::make_unique<BraveWindowFrameGraphic>(browser->profile());
+
+  if (auto* controller = browser->GetFeatures().focus_mode_controller()) {
+    focus_mode_observation_.Observe(controller);
+    if (auto* overlay = GetFocusModeTopOverlay(browser_view)) {
+      overlay_reveal_subscription_ =
+          overlay->RegisterRevealFractionChanged(base::BindRepeating(
+              &BraveOpaqueBrowserFrameView::OnTopOverlayRevealFractionChanged,
+              base::Unretained(this)));
+    }
+  }
 }
 
 BraveOpaqueBrowserFrameView::~BraveOpaqueBrowserFrameView() = default;
@@ -51,7 +80,13 @@ void BraveOpaqueBrowserFrameView::OnPaint(gfx::Canvas* canvas) {
 }
 
 int BraveOpaqueBrowserFrameView::NonClientHitTest(const gfx::Point& point) {
-  if (tabs::utils::ShouldShowBraveVerticalTabs(GetBrowserView()->browser())) {
+  bool captions_fully_revealed = true;
+  if (auto* overlay = GetFocusModeTopOverlay(GetBrowserView())) {
+    captions_fully_revealed = overlay->GetRevealFraction() == 1.0;
+  }
+
+  if (tabs::utils::ShouldShowBraveVerticalTabs(GetBrowserView()->browser()) &&
+      captions_fully_revealed) {
     auto hit_test_caption_button = [](views::Button* button,
                                       const gfx::Point& point) {
       return button && button->GetVisible() &&
@@ -81,38 +116,71 @@ int BraveOpaqueBrowserFrameView::NonClientHitTest(const gfx::Point& point) {
     return res;
   }
 
-  return OpaqueBrowserFrameView::NonClientHitTest(point);
+  int result = OpaqueBrowserFrameView::NonClientHitTest(point);
+
+  if (!captions_fully_revealed) {
+    if (result == HTMINBUTTON || result == HTMAXBUTTON || result == HTCLOSE) {
+      result = HTCAPTION;
+    }
+  }
+
+  return result;
+}
+
+bool BraveOpaqueBrowserFrameView::ShouldCaptionButtonsPaintToLayer() const {
+  auto* browser = GetBrowserView()->browser();
+  if (IsFocusModeEnabled(browser)) {
+    return true;
+  }
+  return tabs::utils::ShouldShowBraveVerticalTabs(browser) &&
+         !tabs::utils::ShouldShowWindowTitleForVerticalTabs(browser);
+}
+
+void BraveOpaqueBrowserFrameView::RefreshCaptionButtonLayers() {
+  const bool paint_to_layer = ShouldCaptionButtonsPaintToLayer();
+
+  for (views::Button* button :
+       {close_button_.get(), restore_button_.get(), maximize_button_.get(),
+        minimize_button_.get()}) {
+    if (!button) {
+      continue;
+    }
+
+    if (paint_to_layer) {
+      if (!button->layer()) {
+        button->SetPaintToLayer();
+        button->layer()->SetFillsBoundsOpaquely(false);
+      }
+    } else if (button->layer()) {
+      button->DestroyLayer();
+    }
+  }
+}
+
+void BraveOpaqueBrowserFrameView::OnFocusModeToggled(bool enabled) {
+  RefreshCaptionButtonLayers();
+}
+
+void BraveOpaqueBrowserFrameView::OnTopOverlayRevealFractionChanged(
+    double reveal_fraction) {
+  for (views::Button* button :
+       {close_button_.get(), restore_button_.get(), maximize_button_.get(),
+        minimize_button_.get()}) {
+    if (!button || !button->layer()) {
+      continue;
+    }
+
+    const int height = button->height();
+    button->layer()->SetTransform(
+        gfx::Transform::MakeTranslation(0, -height * (1.0 - reveal_fraction)));
+  }
 }
 
 void BraveOpaqueBrowserFrameView::
     UpdateCaptionButtonPlaceholderContainerBackground() {
   OpaqueBrowserFrameView::UpdateCaptionButtonPlaceholderContainerBackground();
 
-  DCHECK(GetBrowserView());
-  auto* browser = GetBrowserView()->browser();
-  DCHECK(browser);
-  const bool should_window_caption_buttons_overlap_toolbar =
-      tabs::utils::ShouldShowBraveVerticalTabs(browser) &&
-      !tabs::utils::ShouldShowWindowTitleForVerticalTabs(browser);
-
-  for (auto& button :
-       {close_button_, restore_button_, maximize_button_, minimize_button_}) {
-    if (!button) {
-      continue;
-    }
-
-    if (should_window_caption_buttons_overlap_toolbar) {
-      auto* cp = GetColorProvider();
-      DCHECK(cp);
-
-      button->SetPaintToLayer();
-      button->layer()->SetFillsBoundsOpaquely(false);
-    } else {
-      if (button->layer()) {
-        button->DestroyLayer();
-      }
-    }
-  }
+  RefreshCaptionButtonLayers();
 
   // Notify toolbar view that caption button's width changed so that it can
   // make space for caption buttons.

--- a/browser/ui/views/frame/brave_opaque_browser_frame_view.h
+++ b/browser/ui/views/frame/brave_opaque_browser_frame_view.h
@@ -8,12 +8,14 @@
 
 #include <memory>
 
+#include "brave/browser/ui/focus_mode/focus_mode_controller.h"
 #include "chrome/browser/ui/views/frame/opaque_browser_frame_view.h"
 #include "ui/base/metadata/metadata_header_macros.h"
 
 class BraveWindowFrameGraphic;
 
-class BraveOpaqueBrowserFrameView : public OpaqueBrowserFrameView {
+class BraveOpaqueBrowserFrameView : public OpaqueBrowserFrameView,
+                                    public FocusModeController::Observer {
   METADATA_HEADER(BraveOpaqueBrowserFrameView, OpaqueBrowserFrameView)
  public:
   BraveOpaqueBrowserFrameView(BrowserWidget* frame,
@@ -34,9 +36,19 @@ class BraveOpaqueBrowserFrameView : public OpaqueBrowserFrameView {
   int GetTopAreaHeight() const override;
   void Layout(PassKey) override;
 
+  // FocusModeController::Observer:
+  void OnFocusModeToggled(bool enabled) override;
+
  private:
   bool ShouldShowVerticalTabs() const;
+  bool ShouldCaptionButtonsPaintToLayer() const;
+  void RefreshCaptionButtonLayers();
+  void OnTopOverlayRevealFractionChanged(double reveal_fraction);
+
   std::unique_ptr<BraveWindowFrameGraphic> frame_graphic_;
+  base::ScopedObservation<FocusModeController, FocusModeController::Observer>
+      focus_mode_observation_{this};
+  base::CallbackListSubscription overlay_reveal_subscription_;
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_FRAME_BRAVE_OPAQUE_BROWSER_FRAME_VIEW_H_

--- a/browser/ui/views/frame/brave_system_menu_model_builder.cc
+++ b/browser/ui/views/frame/brave_system_menu_model_builder.cc
@@ -10,6 +10,7 @@
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 #include "brave/grit/brave_generated_resources.h"
 #include "chrome/app/chrome_command_ids.h"
+#include "chrome/browser/ui/views/frame/immersive_mode_controller.h"
 #include "ui/menus/simple_menu_model.h"
 
 BraveSystemMenuModelBuilder::~BraveSystemMenuModelBuilder() = default;
@@ -35,9 +36,11 @@ void BraveSystemMenuModelBuilder::InsertBraveSystemMenuForBrowserWindow(
   }
 
   if (BrowserSupportsFocusMode(browser())) {
-    if (auto pos = get_next_position()) {
-      model->InsertCheckItemWithStringIdAt(pos.value(), IDC_TOGGLE_FOCUS_MODE,
-                                           IDS_SYSTEM_MENU_FOCUS_MODE);
+    if (!ImmersiveModeController::From(browser())->IsEnabled()) {
+      if (auto pos = get_next_position()) {
+        model->InsertCheckItemWithStringIdAt(pos.value(), IDC_TOGGLE_FOCUS_MODE,
+                                             IDS_SYSTEM_MENU_FOCUS_MODE);
+      }
     }
   }
 }

--- a/browser/ui/views/frame/focus_mode_title_bar_view.cc
+++ b/browser/ui/views/frame/focus_mode_title_bar_view.cc
@@ -1,0 +1,143 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/views/frame/focus_mode_title_bar_view.h"
+
+#include <string>
+
+#include "base/functional/bind.h"
+#include "brave/browser/ui/brave_scheme_utils.h"
+#include "brave/ui/color/nala/nala_color_id.h"
+#include "chrome/browser/ui/color/chrome_color_id.h"
+#include "chrome/browser/ui/tab_ui_helper.h"
+#include "components/url_formatter/url_formatter.h"
+#include "ui/base/metadata/metadata_impl_macros.h"
+#include "ui/base/models/image_model.h"
+#include "ui/color/color_provider.h"
+#include "ui/gfx/font_list.h"
+#include "ui/gfx/geometry/size.h"
+#include "ui/gfx/image/image_skia_operations.h"
+#include "ui/views/background.h"
+#include "ui/views/controls/image_view.h"
+#include "ui/views/controls/label.h"
+#include "ui/views/layout/box_layout.h"
+#include "url/gurl.h"
+
+namespace {
+
+constexpr int kTitleBarHeight = 20;
+constexpr int kFaviconSize = 12;
+constexpr int kFaviconLabelSpacing = 4;
+constexpr int kLabelFontSize = 11;
+
+gfx::FontList GetLabelFont() {
+  const gfx::FontList base;
+  return base.DeriveWithSizeDelta(kLabelFontSize - base.GetFontSize());
+}
+
+}  // namespace
+
+FocusModeTitleBarView::FocusModeTitleBarView() {
+  auto* layout = SetLayoutManager(std::make_unique<views::BoxLayout>(
+      views::BoxLayout::Orientation::kHorizontal, gfx::Insets(),
+      kFaviconLabelSpacing));
+  SetBackground(views::CreateSolidBackground(kColorToolbar));
+
+  layout->set_main_axis_alignment(views::BoxLayout::MainAxisAlignment::kCenter);
+  layout->set_cross_axis_alignment(
+      views::BoxLayout::CrossAxisAlignment::kCenter);
+
+  SetPreferredSize(gfx::Size(0, kTitleBarHeight));
+
+  favicon_image_ = AddChildView(std::make_unique<views::ImageView>());
+  favicon_image_->SetImageSize(gfx::Size(kFaviconSize, kFaviconSize));
+  favicon_image_->SetVisible(false);
+
+  domain_label_ = AddChildView(std::make_unique<views::Label>(
+      u"", views::Label::CustomFont(GetLabelFont())));
+  domain_label_->SetDirectionalityMode(
+      gfx::DirectionalityMode::DIRECTIONALITY_AS_URL);
+  domain_label_->SetElideBehavior(gfx::ELIDE_TAIL);
+  domain_label_->SetEnabledColor(nala::kColorTextTertiary);
+  domain_label_->SetAutoColorReadabilityEnabled(false);
+}
+
+FocusModeTitleBarView::~FocusModeTitleBarView() = default;
+
+void FocusModeTitleBarView::SetTab(tabs::TabInterface* tab) {
+  tab_ui_updated_subscription_ = {};
+  tab_will_detach_subscription_ = {};
+  tab_ = tab;
+
+  if (tab_) {
+    tab_will_detach_subscription_ =
+        tab_->RegisterWillDetach(base::BindRepeating(
+            &FocusModeTitleBarView::OnTabWillDetach, base::Unretained(this)));
+    if (auto* helper = TabUIHelper::From(tab_)) {
+      tab_ui_updated_subscription_ =
+          helper->AddTabUIChangeCallback(base::BindRepeating(
+              &FocusModeTitleBarView::Update, base::Unretained(this)));
+    }
+  }
+
+  Update();
+}
+
+bool FocusModeTitleBarView::IsFaviconVisibleForTesting() const {
+  return favicon_image_->GetVisible();
+}
+
+void FocusModeTitleBarView::Update() {
+  auto* tab_ui_helper = tab_ ? TabUIHelper::From(tab_) : nullptr;
+  if (!tab_ui_helper) {
+    favicon_image_->SetImage(ui::ImageModel());
+    favicon_image_->SetVisible(false);
+    domain_label_->SetText(u"");
+    return;
+  }
+
+  GURL domain_url = tab_ui_helper->GetVisibleURL();
+  std::u16string domain;
+  if (tab_ui_helper->ShouldDisplayURL()) {
+    domain = url_formatter::FormatUrl(
+        domain_url,
+        (url_formatter::kFormatUrlOmitDefaults &
+         ~url_formatter::kFormatUrlOmitHTTP) |
+            url_formatter::kFormatUrlOmitTrivialSubdomains |
+            url_formatter::kFormatUrlOmitHTTPS |
+            url_formatter::kFormatUrlTrimAfterHost,
+        base::UnescapeRule::SPACES, nullptr, nullptr, nullptr);
+    brave_utils::ReplaceChromeToBraveScheme(domain);
+  }
+
+  domain_label_->SetText(domain);
+
+  if (ui::ImageModel favicon = tab_ui_helper->GetFavicon();
+      !favicon.IsEmpty() && !domain.empty()) {
+    bool themify_favicon = tab_ui_helper->ShouldThemifyFavicon();
+    if (auto* provider = GetColorProvider(); provider && themify_favicon) {
+      SkColor favicon_color = provider->GetColor(kColorBookmarkFavicon);
+      if (favicon_color != SK_ColorTRANSPARENT) {
+        favicon = ui::ImageModel::FromImageSkia(
+            gfx::ImageSkiaOperations::CreateColorMask(
+                favicon.Rasterize(provider), favicon_color));
+      }
+    }
+    favicon_image_->SetImage(favicon);
+    favicon_image_->SetVisible(true);
+  } else {
+    favicon_image_->SetImage(ui::ImageModel());
+    favicon_image_->SetVisible(false);
+  }
+}
+
+void FocusModeTitleBarView::OnTabWillDetach(
+    tabs::TabInterface* tab,
+    tabs::TabInterface::DetachReason reason) {
+  SetTab(nullptr);
+}
+
+BEGIN_METADATA(FocusModeTitleBarView)
+END_METADATA

--- a/browser/ui/views/frame/focus_mode_title_bar_view.h
+++ b/browser/ui/views/frame/focus_mode_title_bar_view.h
@@ -1,0 +1,53 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_VIEWS_FRAME_FOCUS_MODE_TITLE_BAR_VIEW_H_
+#define BRAVE_BROWSER_UI_VIEWS_FRAME_FOCUS_MODE_TITLE_BAR_VIEW_H_
+
+#include "base/callback_list.h"
+#include "base/memory/raw_ptr.h"
+#include "components/tabs/public/tab_interface.h"
+#include "ui/base/metadata/metadata_header_macros.h"
+#include "ui/gfx/text_constants.h"
+#include "ui/views/view.h"
+
+namespace views {
+class ImageView;
+class Label;
+}  // namespace views
+
+// Small title bar shown at the top of the browser window when Focus Mode is
+// enabled. Displays the active tab's favicon followed by the formatted host
+// (omits https://, trivial subdomains, and trims after the host).
+class FocusModeTitleBarView : public views::View {
+  METADATA_HEADER(FocusModeTitleBarView, views::View)
+
+ public:
+  FocusModeTitleBarView();
+  FocusModeTitleBarView(const FocusModeTitleBarView&) = delete;
+  FocusModeTitleBarView& operator=(const FocusModeTitleBarView&) = delete;
+  ~FocusModeTitleBarView() override;
+
+  // Points this view at the given tab. `tab` may be null, in which case the
+  // display is cleared. The view automatically clears itself if `tab` is
+  // destroyed.
+  void SetTab(tabs::TabInterface* tab);
+
+  bool IsFaviconVisibleForTesting() const;
+  const views::Label* domain_label_for_testing() const { return domain_label_; }
+
+ private:
+  void Update();
+  void OnTabWillDetach(tabs::TabInterface* tab,
+                       tabs::TabInterface::DetachReason reason);
+
+  base::CallbackListSubscription tab_will_detach_subscription_;
+  base::CallbackListSubscription tab_ui_updated_subscription_;
+  raw_ptr<views::ImageView> favicon_image_ = nullptr;
+  raw_ptr<views::Label> domain_label_ = nullptr;
+  raw_ptr<tabs::TabInterface> tab_ = nullptr;
+};
+
+#endif  // BRAVE_BROWSER_UI_VIEWS_FRAME_FOCUS_MODE_TITLE_BAR_VIEW_H_

--- a/browser/ui/views/frame/focus_mode_title_bar_view_unittest.cc
+++ b/browser/ui/views/frame/focus_mode_title_bar_view_unittest.cc
@@ -1,0 +1,164 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/views/frame/focus_mode_title_bar_view.h"
+
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "base/callback_list.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/ui/tab_ui_helper.h"
+#include "chrome/browser/ui/tabs/public/tab_features.h"
+#include "chrome/browser/ui/views/chrome_layout_provider.h"
+#include "chrome/test/base/testing_profile.h"
+#include "chrome/test/views/chrome_views_test_base.h"
+#include "components/tabs/public/mock_tab_interface.h"
+#include "components/tabs/public/tab_interface.h"
+#include "content/public/browser/web_contents.h"
+#include "content/public/test/test_renderer_host.h"
+#include "content/public/test/web_contents_tester.h"
+#include "testing/gmock/include/gmock/gmock.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "ui/base/unowned_user_data/unowned_user_data_host.h"
+#include "ui/gfx/geometry/size.h"
+#include "ui/gfx/text_constants.h"
+#include "ui/views/controls/label.h"
+#include "ui/views/test/views_test_utils.h"
+#include "url/gurl.h"
+
+namespace {
+
+class FakeTab : public tabs::MockTabInterface {
+ public:
+  explicit FakeTab(Profile* profile)
+      : tab_features_(std::make_unique<tabs::TabFeatures>()),
+        contents_(content::WebContentsTester::CreateTestWebContents(profile,
+                                                                    nullptr)) {
+    using ::testing::Return;
+    using ::testing::ReturnRef;
+
+    ON_CALL(*this, GetContents()).WillByDefault(Return(contents_.get()));
+    ON_CALL(*this, GetTabFeatures()).WillByDefault(Return(tab_features_.get()));
+    ON_CALL(*this, GetUnownedUserDataHost()).WillByDefault(ReturnRef(host_));
+    ON_CALL(*this, RegisterWillDetach(::testing::_))
+        .WillByDefault([this](tabs::TabInterface::WillDetach callback) {
+          return will_detach_callbacks_.Add(std::move(callback));
+        });
+
+    tab_features_->SetTabUIHelperForTesting(
+        std::make_unique<TabUIHelper>(*this));
+  }
+
+  ~FakeTab() override {
+    will_detach_callbacks_.Notify(this,
+                                  tabs::TabInterface::DetachReason::kDelete);
+  }
+
+  void NavigateAndCommit(const GURL& url) {
+    content::WebContentsTester::For(contents_.get())->NavigateAndCommit(url);
+  }
+
+ private:
+  ui::UnownedUserDataHost host_;
+  std::unique_ptr<tabs::TabFeatures> tab_features_;
+  std::unique_ptr<content::WebContents> contents_;
+  base::RepeatingCallbackList<void(tabs::TabInterface*,
+                                   tabs::TabInterface::DetachReason)>
+      will_detach_callbacks_;
+};
+
+class FocusModeTitleBarViewTest : public ChromeViewsTestBase {
+ public:
+  void SetUp() override {
+    ChromeViewsTestBase::SetUp();
+    view_ = std::make_unique<FocusModeTitleBarView>();
+  }
+
+  void TearDown() override {
+    view_.reset();
+    ChromeViewsTestBase::TearDown();
+  }
+
+ protected:
+  std::unique_ptr<FakeTab> AddTab(const GURL& url) {
+    auto tab = std::make_unique<FakeTab>(&profile_);
+    tab->NavigateAndCommit(url);
+    return tab;
+  }
+
+  std::u16string_view GetDomainText() {
+    return view_->domain_label_for_testing()->GetText();
+  }
+
+  std::u16string_view AddTabAndGetDomainText(const GURL& gurl) {
+    auto tab = AddTab(gurl);
+    view_->SetTab(tab.get());
+    return GetDomainText();
+  }
+
+  std::unique_ptr<FocusModeTitleBarView> view_;
+  TestingProfile profile_;
+  content::RenderViewHostTestEnabler render_view_host_test_enabler_;
+};
+
+TEST_F(FocusModeTitleBarViewTest, UpdatesOnNavigation) {
+  auto tab = AddTab(GURL("https://www.example.com/some/path?q=1"));
+  view_->SetTab(tab.get());
+  EXPECT_EQ(GetDomainText(), u"example.com");
+
+  tab->NavigateAndCommit(GURL("https://docs.example.com/title1.html"));
+  EXPECT_EQ(GetDomainText(), u"docs.example.com");
+
+  tab->NavigateAndCommit(GURL("http://insecure.example.com/"));
+  EXPECT_EQ(GetDomainText(), u"http://insecure.example.com");
+
+  tab->NavigateAndCommit(GURL("chrome://abc"));
+  EXPECT_EQ(GetDomainText(), u"brave://abc");
+
+  tab->NavigateAndCommit(GURL("chrome-untrusted://print"));
+  EXPECT_EQ(GetDomainText(), u"chrome-untrusted://print");
+}
+
+TEST_F(FocusModeTitleBarViewTest, ClearsWhenTabDetaches) {
+  auto tab = AddTab(GURL("https://www.example.com/title1.html"));
+  view_->SetTab(tab.get());
+  ASSERT_EQ(GetDomainText(), u"example.com");
+
+  tab.reset();
+  EXPECT_TRUE(GetDomainText().empty());
+  EXPECT_FALSE(view_->IsFaviconVisibleForTesting());
+}
+
+TEST_F(FocusModeTitleBarViewTest, ElidesDomainFromTail) {
+  auto tab = AddTab(GURL("https://very-very-long-name.example.com/"));
+  view_->SetTab(tab.get());
+  ASSERT_EQ(GetDomainText(), u"very-very-long-name.example.com");
+
+  view_->SetSize(gfx::Size(60, 20));
+  views::test::RunScheduledLayout(view_.get());
+
+  std::u16string_view displayed =
+      view_->domain_label_for_testing()->GetDisplayTextForTesting();
+  EXPECT_TRUE(displayed.ends_with(u"\u2026"));
+  EXPECT_TRUE(displayed.starts_with(u"very"));
+}
+
+TEST_F(FocusModeTitleBarViewTest, UpdatesOnTabSwitch) {
+  auto first = AddTab(GURL("https://first.test/title1.html"));
+  view_->SetTab(first.get());
+  EXPECT_EQ(GetDomainText(), u"first.test");
+
+  auto second = AddTab(GURL("https://second.test/title1.html"));
+  view_->SetTab(second.get());
+  EXPECT_EQ(GetDomainText(), u"second.test");
+
+  view_->SetTab(nullptr);
+  EXPECT_TRUE(GetDomainText().empty());
+  EXPECT_FALSE(view_->IsFaviconVisibleForTesting());
+}
+
+}  // namespace

--- a/browser/ui/views/frame/focus_mode_top_overlay.cc
+++ b/browser/ui/views/frame/focus_mode_top_overlay.cc
@@ -1,0 +1,300 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/views/frame/focus_mode_top_overlay.h"
+
+#include <algorithm>
+#include <utility>
+
+#include "base/check.h"
+#include "base/check_deref.h"
+#include "brave/browser/ui/views/frame/brave_browser_view.h"
+#include "brave/browser/ui/views/frame/edge_reveal/edge_hover_detector.h"
+#include "brave/browser/ui/views/frame/tab_strip_placement_coordinator.h"
+#include "chrome/browser/ui/views/frame/top_container_view.h"
+#include "third_party/skia/include/core/SkColor.h"
+#include "ui/base/metadata/metadata_impl_macros.h"
+#include "ui/compositor/layer.h"
+#include "ui/views/focus/focus_manager.h"
+#include "ui/views/view_tracker.h"
+#include "ui/views/widget/widget.h"
+
+namespace {
+
+constexpr int kHotZoneThickness = 16;
+constexpr base::TimeDelta kRevealAnimationDuration = base::Milliseconds(200);
+
+constexpr ViewShadow::ShadowParameters kShadow{
+    .offset_x = 0,
+    .offset_y = 2,
+    .blur_radius = 8,
+    .shadow_color = SkColorSetA(SK_ColorBLACK, 0.15 * 255)};
+
+gfx::Rect GetTopHotZone(const gfx::Rect& window_bounds) {
+  gfx::Rect rect(window_bounds);
+  rect.set_height(kHotZoneThickness);
+  return rect;
+}
+
+TabStripPlacementCoordinator* GetTabStripPlacementCoordinator(
+    BrowserView& browser_view) {
+  return BraveBrowserView::From(&browser_view)
+      ->tab_strip_placement_coordinator();
+}
+
+void UpdateTabStripPlacement(BrowserView& browser_view) {
+  if (auto* coordinator = GetTabStripPlacementCoordinator(browser_view)) {
+    coordinator->UpdatePlacement();
+  }
+}
+
+// Captures the focused view on construction and re-focuses it on destruction,
+// provided it still lives under `parent`. Used to preserve keyboard focus
+// when reparenting a view, which otherwise can clear focus. The instance must
+// remain in scope until the destination subtree is visible.
+class ScopedFocusRestore {
+ public:
+  explicit ScopedFocusRestore(views::View* parent) : parent_(parent) {
+    CHECK(parent_);
+    if (auto* focus_manager = parent_.view()->GetFocusManager()) {
+      focused_.SetView(focus_manager->GetFocusedView());
+    }
+  }
+
+  ScopedFocusRestore(const ScopedFocusRestore&) = delete;
+  ScopedFocusRestore& operator=(const ScopedFocusRestore&) = delete;
+
+  ~ScopedFocusRestore() {
+    if (focused_ && parent_ && parent_.view()->Contains(focused_.view())) {
+      focused_.view()->RequestFocus();
+    }
+  }
+
+ private:
+  views::ViewTracker parent_;
+  views::ViewTracker focused_;
+};
+
+}  // namespace
+
+FocusModeTopOverlay::FocusModeTopOverlay(base::PassKey<BraveBrowserView>,
+                                         BrowserView* browser_view)
+    : browser_view_(CHECK_DEREF(browser_view)),
+      shadow_(this, gfx::RoundedCornersF(0), kShadow) {
+  SetPaintToLayer();
+  layer()->SetFillsBoundsOpaquely(true);
+
+  auto* coordinator = GetTabStripPlacementCoordinator(browser_view_.get());
+  CHECK(coordinator);
+  coordinator->SetPlacement(TabStripPlacementKind::kTopContainer,
+                            browser_view_->top_container(), 0);
+
+  animation_.SetSlideDuration(kRevealAnimationDuration);
+  animation_.Reset(1.0);
+
+  SetVisible(false);
+}
+
+FocusModeTopOverlay::~FocusModeTopOverlay() {
+  if (active_) {
+    StopRevealing();
+  }
+}
+
+void FocusModeTopOverlay::Activate() {
+  if (active_) {
+    return;
+  }
+
+  CHECK(GetWidget());
+
+  active_ = true;
+
+  // Move tab strip into top container.
+  UpdateTabStripPlacement(browser_view_.get());
+
+  // Move top container into overlay.
+  auto* top_container = browser_view_->top_container();
+  CHECK(top_container);
+  ScopedFocusRestore focus_restore(top_container);
+  top_container_index_ = browser_view_->GetIndexOf(top_container);
+  AddChildView(top_container);
+
+  top_container_observation_.Observe(top_container);
+
+  hover_detector_ = std::make_unique<EdgeHoverDetector>(
+      GetWidget(),
+      base::BindRepeating(&FocusModeTopOverlay::IsHoverPoint,
+                          base::Unretained(this)),
+      base::BindRepeating(&FocusModeTopOverlay::OnHoverStateChanged,
+                          base::Unretained(this)));
+
+  reveal_watcher_ = std::make_unique<EdgeRevealWatcher>(
+      GetWidget(),
+      base::BindRepeating(&FocusModeTopOverlay::EdgeContainsView,
+                          base::Unretained(this)),
+      base::BindRepeating(&FocusModeTopOverlay::OnRevealReasonsChanged,
+                          base::Unretained(this)));
+
+  animation_.Reset(1.0);
+  SetVisible(true);
+  UpdateBounds();
+  NotifyRevealFractionChanged();
+  UpdateRevealState();
+}
+
+void FocusModeTopOverlay::Deactivate() {
+  if (!active_) {
+    return;
+  }
+
+  active_ = false;
+  StopRevealing();
+
+  // Restore top container placement.
+  if (auto* top_container = top_container_observation_.GetSource()) {
+    size_t max_index = browser_view_->children().size();
+    ScopedFocusRestore focus_restore(top_container);
+    browser_view_->AddChildViewAt(
+        top_container,
+        std::min(top_container_index_.value_or(max_index), max_index));
+    top_container_observation_.Reset();
+  }
+
+  // Restore tab strip placement.
+  UpdateTabStripPlacement(browser_view_.get());
+
+  SetVisible(false);
+  NotifyRevealFractionChanged();
+}
+
+void FocusModeTopOverlay::RevealTemporarily(base::TimeDelta duration) {
+  temporary_reveal_timer_.Start(
+      FROM_HERE, duration,
+      base::BindRepeating(&FocusModeTopOverlay::UpdateRevealState,
+                          base::Unretained(this)));
+  UpdateRevealState();
+}
+
+double FocusModeTopOverlay::GetRevealFraction() const {
+  return animation_.GetCurrentValue();
+}
+
+base::CallbackListSubscription
+FocusModeTopOverlay::RegisterRevealFractionChanged(
+    RevealFractionChangedCallback callback) {
+  return reveal_fraction_changed_callbacks_.Add(std::move(callback));
+}
+
+void FocusModeTopOverlay::StopRevealing() {
+  hover_detector_.reset();
+  reveal_watcher_.reset();
+  temporary_reveal_timer_.Stop();
+  animation_.Reset(1.0);
+}
+
+bool FocusModeTopOverlay::ShouldReveal() const {
+  if (!hover_detector_ || !reveal_watcher_) {
+    return false;
+  }
+
+  constexpr EdgeRevealWatcher::RevealReasons kForceRevealReasons = {
+      EdgeRevealWatcher::RevealReason::kFocus,
+      EdgeRevealWatcher::RevealReason::kAnchoredBubble};
+
+  return hover_detector_->hovering() || temporary_reveal_timer_.IsRunning() ||
+         reveal_watcher_->reasons().HasAny(kForceRevealReasons) ||
+         ShouldRevealForChildWidget();
+}
+
+bool FocusModeTopOverlay::ShouldRevealForChildWidget() const {
+  CHECK(reveal_watcher_);
+  bool has_visible_child_widget = reveal_watcher_->reasons().Has(
+      EdgeRevealWatcher::RevealReason::kVisibleChildWidget);
+
+  // Some child widgets (e.g. the application menu) are not anchored to the
+  // overlay, but should nevertheless keep the overlay in a revealed state. To
+  // accommodate this, keep the overlay open, but only if it is already fully
+  // revealed.
+  return has_visible_child_widget && GetRevealFraction() == 1.0;
+}
+
+bool FocusModeTopOverlay::IsHoverPoint(const gfx::Point& screen_point) const {
+  gfx::Rect hot_zone = GetTopHotZone(GetWidget()->GetWindowBoundsInScreen());
+  if (hot_zone.Contains(screen_point)) {
+    return true;
+  }
+  if (GetRevealFraction() == 0.0) {
+    return false;
+  }
+  return GetBoundsInScreen().Contains(screen_point);
+}
+
+void FocusModeTopOverlay::OnHoverStateChanged(bool hovering) {
+  UpdateRevealState();
+}
+
+bool FocusModeTopOverlay::EdgeContainsView(const views::View* view) const {
+  return Contains(view);
+}
+
+void FocusModeTopOverlay::OnRevealReasonsChanged(
+    EdgeRevealWatcher::RevealReasons reasons) {
+  UpdateRevealState();
+}
+
+void FocusModeTopOverlay::UpdateRevealState() {
+  if (!active_) {
+    return;
+  }
+  if (ShouldReveal()) {
+    animation_.Show();
+  } else {
+    animation_.Hide();
+  }
+}
+
+void FocusModeTopOverlay::UpdateBounds() {
+  auto* top_container = top_container_observation_.GetSource();
+  if (!top_container || !parent()) {
+    return;
+  }
+  int height = top_container->bounds().height();
+  double reveal_fraction = GetRevealFraction();
+  int y_offset = -static_cast<int>((1.0 - reveal_fraction) * height);
+  SetBoundsRect(gfx::Rect(0, y_offset, parent()->width(), height));
+  shadow_.SetVisible(reveal_fraction > 0.0);
+}
+
+void FocusModeTopOverlay::NotifyRevealFractionChanged() {
+  reveal_fraction_changed_callbacks_.Notify(GetRevealFraction());
+}
+
+void FocusModeTopOverlay::OnViewBoundsChanged(views::View* observed_view) {
+  UpdateBounds();
+}
+
+void FocusModeTopOverlay::OnViewIsDeleting(views::View* observed_view) {
+  top_container_observation_.Reset();
+}
+
+void FocusModeTopOverlay::AnimationProgressed(const gfx::Animation* animation) {
+  UpdateBounds();
+  NotifyRevealFractionChanged();
+}
+
+void FocusModeTopOverlay::AnimationEnded(const gfx::Animation* animation) {
+  UpdateBounds();
+  NotifyRevealFractionChanged();
+
+  // After the overlay slide has finished, the hover state may have changed
+  // without mouse input. Manually trigger hover state detection.
+  if (hover_detector_) {
+    hover_detector_->DetectHoverState();
+  }
+}
+
+BEGIN_METADATA(FocusModeTopOverlay)
+END_METADATA

--- a/browser/ui/views/frame/focus_mode_top_overlay.h
+++ b/browser/ui/views/frame/focus_mode_top_overlay.h
@@ -1,0 +1,125 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_VIEWS_FRAME_FOCUS_MODE_TOP_OVERLAY_H_
+#define BRAVE_BROWSER_UI_VIEWS_FRAME_FOCUS_MODE_TOP_OVERLAY_H_
+
+#include <memory>
+#include <optional>
+
+#include "base/callback_list.h"
+#include "base/functional/callback.h"
+#include "base/memory/raw_ref.h"
+#include "base/scoped_observation.h"
+#include "base/timer/timer.h"
+#include "base/types/pass_key.h"
+#include "brave/browser/ui/views/frame/edge_reveal/edge_reveal_watcher.h"
+#include "brave/browser/ui/views/view_shadow.h"
+#include "ui/base/metadata/metadata_header_macros.h"
+#include "ui/gfx/animation/animation_delegate.h"
+#include "ui/gfx/animation/slide_animation.h"
+#include "ui/views/view.h"
+#include "ui/views/view_observer.h"
+
+class BraveBrowserView;
+class BrowserView;
+class EdgeHoverDetector;
+
+// An auto-reveal overlay view anchored to the top edge of the browser frame.
+// While active, the overlay hosts the browser's top container (and, when in
+// horizontal tab mode, the horizontal tab strip nested inside it) as direct
+// children, and animates its own y-offset based on hover, focus, and
+// anchored bubbles. When deactivated, views are returned to their original
+// placements.
+//
+// Layout
+// ======
+//
+// The overlay deliberately has no layout manager of its own. Once the top
+// container has been reparented as a child of this view, upstream's
+// `BrowserViewLayoutImpl::Layout` detects this and runs its "top container
+// parented elsewhere" branch, which sizes the top container (and lays out its
+// children) inside its new parent. This is the same code path used by macOS
+// immersive fullscreen, where the top container is reparented onto a separate
+// overlay widget. The overlay's own bounds are derived from the top container's
+// bounds via `UpdateBounds()`, kept in sync through `views::ViewObserver`.
+class FocusModeTopOverlay : public views::View,
+                            public views::ViewObserver,
+                            public gfx::AnimationDelegate {
+  METADATA_HEADER(FocusModeTopOverlay, views::View)
+
+ public:
+  using RevealFractionChangedCallback = base::RepeatingCallback<void(double)>;
+
+  // Constructs the overlay. Instances are intended to be created and owned only
+  // by a BrowserView instance.
+  FocusModeTopOverlay(base::PassKey<BraveBrowserView>,
+                      BrowserView* browser_view);
+
+  FocusModeTopOverlay(const FocusModeTopOverlay&) = delete;
+  FocusModeTopOverlay& operator=(const FocusModeTopOverlay&) = delete;
+  ~FocusModeTopOverlay() override;
+
+  // Begins hosting the top container and hides the overlay with an animation.
+  void Activate();
+
+  // Restores the top container views to their previous placements and hides the
+  // overlay.
+  void Deactivate();
+
+  // Returns a value indicating whether the overlay is currently hosting the
+  // top container views.
+  bool active() const { return active_; }
+
+  // Forces a full reveal for `duration`, then resumes state-driven behavior.
+  void RevealTemporarily(base::TimeDelta duration);
+
+  // Returns a value in [0, 1], where 1 indicates fully revealed.
+  double GetRevealFraction() const;
+
+  // Registers `callback` to be invoked whenever the reveal fraction changes.
+  // The callback remains registered for the lifetime of the returned
+  // subscription.
+  base::CallbackListSubscription RegisterRevealFractionChanged(
+      RevealFractionChangedCallback callback);
+
+ private:
+  void StopRevealing();
+  bool ShouldReveal() const;
+  bool ShouldRevealForChildWidget() const;
+  bool IsHoverPoint(const gfx::Point& screen_point) const;
+  void OnHoverStateChanged(bool hovering);
+  bool EdgeContainsView(const views::View* view) const;
+  void OnRevealReasonsChanged(EdgeRevealWatcher::RevealReasons reasons);
+  void UpdateRevealState();
+  void UpdateBounds();
+  void NotifyRevealFractionChanged();
+
+  // views::ViewObserver:
+  void OnViewBoundsChanged(views::View* observed_view) override;
+  void OnViewIsDeleting(View* observed_view) override;
+
+  // gfx::AnimationDelegate:
+  void AnimationProgressed(const gfx::Animation* animation) override;
+  void AnimationEnded(const gfx::Animation* animation) override;
+
+  const raw_ref<BrowserView> browser_view_;
+  ViewShadow shadow_;
+
+  std::optional<size_t> top_container_index_;
+  bool active_ = false;
+
+  gfx::SlideAnimation animation_{this};
+  base::OneShotTimer temporary_reveal_timer_;
+  std::unique_ptr<EdgeHoverDetector> hover_detector_;
+  std::unique_ptr<EdgeRevealWatcher> reveal_watcher_;
+
+  base::ScopedObservation<views::View, views::ViewObserver>
+      top_container_observation_{this};
+
+  base::RepeatingCallbackList<void(double)> reveal_fraction_changed_callbacks_;
+};
+
+#endif  // BRAVE_BROWSER_UI_VIEWS_FRAME_FOCUS_MODE_TOP_OVERLAY_H_

--- a/browser/ui/views/frame/focus_mode_top_overlay_browsertest.cc
+++ b/browser/ui/views/frame/focus_mode_top_overlay_browsertest.cc
@@ -1,0 +1,245 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/views/frame/focus_mode_top_overlay.h"
+
+#include "base/test/run_until.h"
+#include "base/test/scoped_feature_list.h"
+#include "brave/browser/ui/focus_mode/focus_mode_controller.h"
+#include "brave/browser/ui/focus_mode/focus_mode_features.h"
+#include "brave/browser/ui/views/frame/brave_browser_view.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/browser_commands.h"
+#include "chrome/browser/ui/browser_window/public/browser_window_features.h"
+#include "chrome/browser/ui/tabs/tab_strip_model.h"
+#include "chrome/browser/ui/views/frame/browser_view.h"
+#include "chrome/browser/ui/views/frame/top_container_view.h"
+#include "chrome/browser/ui/views/location_bar/location_bar_view.h"
+#include "chrome/browser/ui/views/tabs/tab_strip.h"
+#include "chrome/browser/ui/views/toolbar/toolbar_view.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "chrome/test/base/ui_test_utils.h"
+#include "content/public/browser/web_contents.h"
+#include "content/public/test/browser_test.h"
+#include "content/public/test/browser_test_utils.h"
+#include "net/dns/mock_host_resolver.h"
+#include "net/test/embedded_test_server/embedded_test_server.h"
+#include "ui/gfx/geometry/rect.h"
+#include "ui/gfx/scoped_animation_duration_scale_mode.h"
+#include "ui/views/focus/focus_manager.h"
+#include "ui/views/view.h"
+
+class FocusModeTopOverlayBrowserTest : public InProcessBrowserTest {
+ protected:
+  FocusModeTopOverlayBrowserTest()
+      : https_server_(net::EmbeddedTestServer::TYPE_HTTPS),
+        https_server_expired_(net::EmbeddedTestServer::TYPE_HTTPS) {
+    feature_list_.InitAndEnableFeature(features::kBraveFocusMode);
+  }
+
+  void SetUpOnMainThread() override {
+    InProcessBrowserTest::SetUpOnMainThread();
+
+    // Resolve all hosts to the test servers so that non-localhost hostnames
+    // (used to obtain a "Not Secure" security level over HTTP) work.
+    host_resolver()->AddRule("*", "127.0.0.1");
+
+    embedded_test_server()->ServeFilesFromSourceDirectory("chrome/test/data");
+    ASSERT_TRUE(embedded_test_server()->Start());
+
+    https_server_.SetSSLConfig(net::EmbeddedTestServer::CERT_OK);
+    https_server_.ServeFilesFromSourceDirectory("chrome/test/data");
+    ASSERT_TRUE(https_server_.Start());
+
+    https_server_expired_.SetSSLConfig(net::EmbeddedTestServer::CERT_EXPIRED);
+    https_server_expired_.ServeFilesFromSourceDirectory("chrome/test/data");
+    ASSERT_TRUE(https_server_expired_.Start());
+  }
+
+  BraveBrowserView* browser_view() {
+    return BraveBrowserView::From(
+        BrowserView::GetBrowserViewForBrowser(browser()));
+  }
+
+  FocusModeController* focus_mode_controller() {
+    return browser()->GetFeatures().focus_mode_controller();
+  }
+
+  content::WebContents* active_web_contents() {
+    return browser()->tab_strip_model()->GetActiveWebContents();
+  }
+
+  bool WaitForOverlayRevealed() {
+    auto* overlay = browser_view()->focus_mode_top_overlay();
+    return base::test::RunUntil(
+        [&]() { return overlay->GetRevealFraction() == 1.0; });
+  }
+
+  bool WaitForOverlayHidden() {
+    auto* overlay = browser_view()->focus_mode_top_overlay();
+    return base::test::RunUntil(
+        [&]() { return overlay->GetRevealFraction() == 0.0; });
+  }
+
+  bool WaitForOverlayActive(bool active) {
+    auto* overlay = browser_view()->focus_mode_top_overlay();
+    return base::test::RunUntil([&]() { return overlay->active() == active; });
+  }
+
+  net::EmbeddedTestServer https_server_;
+  net::EmbeddedTestServer https_server_expired_;
+
+ private:
+  base::test::ScopedFeatureList feature_list_;
+  gfx::ScopedAnimationDurationScaleMode zero_duration_mode_{
+      gfx::ScopedAnimationDurationScaleMode::ZERO_DURATION};
+};
+
+IN_PROC_BROWSER_TEST_F(FocusModeTopOverlayBrowserTest,
+                       FocusModeActivatesOverlay) {
+  auto* overlay = browser_view()->focus_mode_top_overlay();
+  ASSERT_TRUE(overlay);
+  EXPECT_FALSE(overlay->active());
+
+  auto* top_container = browser_view()->top_container();
+  ASSERT_TRUE(top_container);
+  EXPECT_EQ(top_container->parent(), browser_view());
+
+  // Activate Focus Mode and wait for slide-out.
+  focus_mode_controller()->SetEnabled(true);
+  EXPECT_TRUE(overlay->active());
+  ASSERT_TRUE(WaitForOverlayHidden());
+
+  // Verify that the top container and tabstrip are reparented correctly.
+  EXPECT_EQ(top_container->parent(), overlay);
+  EXPECT_TRUE(
+      overlay->Contains(browser_view()->horizontal_tab_strip_for_testing()));
+  EXPECT_TRUE(overlay->Contains(browser_view()->toolbar()));
+
+  // Activating Focus Mode moves the overlay to the end of the child list so
+  // that it renders above its siblings, while the find bar host view remains
+  // the last child to keep the find bar widget on top of the overlay.
+  auto& browser_view_children = browser_view()->children();
+  ASSERT_GT(browser_view_children.size(), 1ul);
+  ASSERT_EQ(browser_view_children.back(), browser_view()->find_bar_host_view());
+  EXPECT_EQ(browser_view_children[browser_view_children.size() - 2], overlay);
+
+  // When hidden, the overlay is slid completely out of the window bounds.
+  EXPECT_EQ(overlay->bounds().bottom(), 0);
+  EXPECT_EQ(overlay->width(), browser_view()->width());
+
+  // Verify that `RevealTemporarily` reveals the overlay.
+  overlay->RevealTemporarily(base::Milliseconds(100));
+  ASSERT_TRUE(WaitForOverlayRevealed());
+
+  // When revealed, the overlay sits at the top edge, spans the browser width,
+  // and is as tall as the top container.
+  EXPECT_EQ(overlay->bounds().y(), 0);
+  EXPECT_EQ(overlay->width(), browser_view()->width());
+  EXPECT_EQ(overlay->height(), top_container->height());
+
+  ASSERT_TRUE(WaitForOverlayHidden());
+
+  // Deactivate Focus Mode.
+  focus_mode_controller()->SetEnabled(false);
+  EXPECT_FALSE(overlay->active());
+  EXPECT_EQ(top_container->parent(), browser_view());
+}
+
+IN_PROC_BROWSER_TEST_F(FocusModeTopOverlayBrowserTest,
+                       PreservesFocusWhenReparenting) {
+  auto* overlay = browser_view()->focus_mode_top_overlay();
+  ASSERT_TRUE(overlay);
+  auto* top_container = browser_view()->top_container();
+  ASSERT_TRUE(top_container);
+  auto* focus_manager = browser_view()->GetFocusManager();
+  ASSERT_TRUE(focus_manager);
+
+  // Focus the location bar (omnibox), which lives inside the top container.
+  chrome::FocusLocationBar(browser());
+  views::View* focused = focus_manager->GetFocusedView();
+  ASSERT_TRUE(focused);
+  ASSERT_TRUE(top_container->Contains(focused));
+
+  // Activating Focus Mode reparents the top container into the overlay. Focus
+  // should travel with it.
+  focus_mode_controller()->SetEnabled(true);
+  ASSERT_TRUE(overlay->active());
+  EXPECT_EQ(focus_manager->GetFocusedView(), focused);
+  EXPECT_TRUE(overlay->Contains(focused));
+
+  // Deactivating reparents the top container back into the browser view. Focus
+  // should again be preserved.
+  focus_mode_controller()->SetEnabled(false);
+  ASSERT_FALSE(overlay->active());
+  EXPECT_EQ(focus_manager->GetFocusedView(), focused);
+  EXPECT_TRUE(top_container->Contains(focused));
+}
+
+IN_PROC_BROWSER_TEST_F(FocusModeTopOverlayBrowserTest,
+                       InsecurePagesDeactivateOverlay) {
+  auto* overlay = browser_view()->focus_mode_top_overlay();
+  ASSERT_TRUE(overlay);
+  auto* top_container = browser_view()->top_container();
+  ASSERT_TRUE(top_container);
+
+  focus_mode_controller()->SetEnabled(true);
+
+  // Secure page: the overlay is active and hosts the top container.
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(
+      browser(), https_server_.GetURL("/empty.html")));
+  ASSERT_TRUE(WaitForOverlayActive(true));
+  ASSERT_EQ(top_container->parent(), overlay);
+
+  // Plain HTTP page ("Not Secure"): the overlay deactivates.
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(
+      browser(),
+      embedded_test_server()->GetURL("insecure.test", "/empty.html")));
+  EXPECT_TRUE(WaitForOverlayActive(false));
+  EXPECT_EQ(top_container->parent(), browser_view());
+
+  // Returning to a secure page re-activates the overlay.
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(
+      browser(), https_server_.GetURL("/empty.html")));
+  ASSERT_TRUE(WaitForOverlayActive(true));
+  ASSERT_EQ(top_container->parent(), overlay);
+
+  // Certificate error page (interstitial commits at the requested URL): the
+  // overlay deactivates.
+  ui_test_utils::NavigateToURLBlockUntilNavigationsComplete(
+      browser(), https_server_expired_.GetURL("/empty.html"), 1);
+  EXPECT_TRUE(WaitForOverlayActive(false));
+  EXPECT_EQ(top_container->parent(), browser_view());
+}
+
+IN_PROC_BROWSER_TEST_F(FocusModeTopOverlayBrowserTest,
+                       PermissionPromptRevealsOverlay) {
+  auto* overlay = browser_view()->focus_mode_top_overlay();
+  ASSERT_TRUE(overlay);
+
+  // A secure context is required both to keep Focus Mode active and to request
+  // geolocation.
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(
+      browser(), https_server_.GetURL("/empty.html")));
+  focus_mode_controller()->SetEnabled(true);
+  ASSERT_TRUE(overlay->active());
+
+  // With nothing holding it open, the overlay slides out of view.
+  ASSERT_TRUE(WaitForOverlayHidden());
+
+  // Requesting a permission shows an anchored prompt, which should reveal the
+  // overlay.
+  content::ExecuteScriptAsync(
+      active_web_contents(),
+      "navigator.geolocation.getCurrentPosition(() => {}, () => {});");
+  ASSERT_TRUE(WaitForOverlayRevealed());
+
+  // The origin-bearing location bar is now visible within the overlay.
+  auto* location_bar = browser_view()->GetLocationBarView();
+  ASSERT_TRUE(location_bar);
+  EXPECT_TRUE(overlay->Contains(location_bar));
+  EXPECT_TRUE(location_bar->IsDrawn());
+  EXPECT_EQ(overlay->bounds().y(), 0);
+}

--- a/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl.cc
+++ b/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl.cc
@@ -58,6 +58,17 @@ void BraveBrowserViewTabbedLayoutImpl::ConfigureTopContainerBackground(
     background->SetCorners(corners);
   }
 #endif  // BUILDFLAG(IS_LINUX)
+
+  // In focus mode, the horizontal tab strip is reparented into the top
+  // container. Since the tab strip does not paint its own background, the top
+  // container background must be set to the frame color instead of the toolbar
+  // background color.
+  if (IsParentedTo(views().horizontal_tab_strip_region_view,
+                   views().top_container)) {
+    if (!delegate().ShouldShowVerticalTabs()) {
+      background->SetPrimaryColor(ui::kColorFrameActive);
+    }
+  }
 }
 
 // static
@@ -325,6 +336,16 @@ void BraveBrowserViewTabbedLayoutImpl::CalculateBraveVerticalTabStripLayout(
   // Compute the top edge based on the proposed bounds of bookmark/infobar/top
   // container, not the current view bounds.
   auto get_vertical_tabs_top = [&]() -> int {
+    // In focus mode the top chrome slides over the contents area rather than
+    // pushing it down. Anchor the vertical tab strip to the top of the
+    // contents bounds so it stays full-height and the revealed top views
+    // overlay it.
+    if (!IsParentedTo(views().top_container, views().browser_view)) {
+      auto* contents_layout = layout.GetLayoutFor(views().contents_container);
+      CHECK(contents_layout);
+      return contents_layout->bounds.y();
+    }
+
     if (ShouldPushBookmarkBarForVerticalTabs()) {
       CHECK(views().bookmark_bar);
       auto* bookmark_layout = layout.GetLayoutFor(views().bookmark_bar);
@@ -341,9 +362,11 @@ void BraveBrowserViewTabbedLayoutImpl::CalculateBraveVerticalTabStripLayout(
     }
 
     CHECK(views().top_container);
-    auto* top_container_layout = layout.GetLayoutFor(views().top_container);
-    CHECK(top_container_layout);
-    return top_container_layout->bounds.bottom() - GetContentsMargins().top();
+    if (auto* top_layout = layout.GetLayoutFor(views().top_container)) {
+      return top_layout->bounds.bottom() - GetContentsMargins().top();
+    }
+
+    return GetContentsMargins().top();
   };
 
   gfx::Rect vertical_tab_strip_bounds = views().browser_view->GetLocalBounds();
@@ -575,10 +598,24 @@ gfx::Insets BraveBrowserViewTabbedLayoutImpl::GetContentsMargins() const {
 
   gfx::Insets margins(kRoundedCornersContentsViewMargin);
 
-  // If there is a visible view above the contents container, then there is no
-  // need for a top margin.
-  if (delegate().ShouldDrawTabStrip() || delegate().IsToolbarVisible() ||
-      delegate().IsBookmarkBarVisible() || delegate().IsInfobarVisible()) {
+  auto contents_at_top_edge = [&]() {
+    if (delegate().IsInfobarVisible()) {
+      return false;
+    }
+    // In focus mode the top container is reparented out of the browser view, so
+    // the top chrome no longer pushes the contents down. Only treat top UI as
+    // occupying the top edge when the top container is still a child of the
+    // browser view.
+    if (IsParentedTo(views().top_container, views().browser_view)) {
+      if (delegate().ShouldDrawTabStrip() || delegate().IsToolbarVisible() ||
+          delegate().IsBookmarkBarVisible()) {
+        return false;
+      }
+    }
+    return true;
+  };
+
+  if (!contents_at_top_edge()) {
     margins.set_top(0);
   }
 
@@ -589,6 +626,13 @@ bool BraveBrowserViewTabbedLayoutImpl::ShouldPushBookmarkBarForVerticalTabs()
     const {
   CHECK(views().vertical_tab_strip_host)
       << "This method is used only when vertical tab strip host is set";
+
+  // In focus mode, the top container (and the bookmark view within it) has been
+  // parented to the top overlay and the bookmark bar does not need to be
+  // repositioned.
+  if (!IsParentedTo(views().top_container, views().browser_view)) {
+    return false;
+  }
 
   // This can happen when bookmarks bar is visible on NTP. In this case
   // we should lay out vertical tab strip next to bookmarks bar so that

--- a/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl.cc
+++ b/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl.cc
@@ -178,6 +178,17 @@ BraveBrowserViewTabbedLayoutImpl::CalculateProposedLayout(
   ProposedLayout layout =
       BrowserViewTabbedLayoutImpl::CalculateProposedLayout(params);
 
+  if (auto title_bar = views().focus_mode_title_bar) {
+    gfx::Rect title_bar_bounds;
+    if (title_bar->GetVisible()) {
+      auto& client_area = params.visual_client_area;
+      title_bar_bounds =
+          gfx::Rect(client_area.x(), client_area.y(), client_area.width(),
+                    title_bar->GetPreferredSize().height());
+    }
+    layout.AddChild(title_bar, title_bar_bounds);
+  }
+
   // Retrieve contents container proposed bounds.
   auto* contents_layout = layout.GetLayoutFor(views().contents_container);
   CHECK(contents_layout);
@@ -269,6 +280,21 @@ gfx::Rect BraveBrowserViewTabbedLayoutImpl::CalculateTopContainerLayout(
   }
 
   return bounds;
+}
+
+void BraveBrowserViewTabbedLayoutImpl::DoPreLayoutComputations(
+    const BrowserLayoutParams& params) {
+  BrowserLayoutParams browser_params = params;
+
+  // In FocusMode, the titlebar appears at the top of the browser view. Before
+  // starting layout, adjust the layout top downward by the titlebar height.
+  if (auto title_bar = views().focus_mode_title_bar) {
+    if (title_bar->GetVisible()) {
+      browser_params.SetTop(title_bar->GetPreferredSize().height());
+    }
+  }
+
+  BrowserViewTabbedLayoutImpl::DoPreLayoutComputations(browser_params);
 }
 
 void BraveBrowserViewTabbedLayoutImpl::DoPostLayoutVisualAdjustments(
@@ -601,6 +627,11 @@ gfx::Insets BraveBrowserViewTabbedLayoutImpl::GetContentsMargins() const {
   auto contents_at_top_edge = [&]() {
     if (delegate().IsInfobarVisible()) {
       return false;
+    }
+    if (auto focus_mode_title_bar = views().focus_mode_title_bar) {
+      if (focus_mode_title_bar->GetVisible()) {
+        return false;
+      }
     }
     // In focus mode the top container is reparented out of the browser view, so
     // the top chrome no longer pushes the contents down. Only treat top UI as

--- a/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl.h
+++ b/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl.h
@@ -78,6 +78,7 @@ class BraveBrowserViewTabbedLayoutImpl : public BrowserViewTabbedLayoutImpl {
   void ConfigureTopContainerBackground(
       const BrowserLayoutParams& params,
       CustomCornersBackground* background) override;
+  void DoPreLayoutComputations(const BrowserLayoutParams& params) override;
   void DoPostLayoutVisualAdjustments(
       const BrowserLayoutParams& params) override;
   // SeparatorInfo is the upstream's private nested type. Friend access (added

--- a/browser/ui/views/tabs/vertical_tab_utils.cc
+++ b/browser/ui/views/tabs/vertical_tab_utils.cc
@@ -9,6 +9,7 @@
 #include "base/check_is_test.h"
 #include "base/command_line.h"
 #include "base/numerics/safe_conversions.h"
+#include "brave/browser/ui/focus_mode/focus_mode_utils.h"
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
 #include "brave/browser/ui/views/tabs/switches.h"
 #include "build/build_config.h"
@@ -63,6 +64,10 @@ bool ShouldShowBraveVerticalTabs(const BrowserWindowInterface* browser) {
 bool ShouldShowWindowTitleForVerticalTabs(
     const BrowserWindowInterface* browser) {
   if (!ShouldShowBraveVerticalTabs(browser)) {
+    return false;
+  }
+
+  if (IsFocusModeEnabled(browser)) {
     return false;
   }
 

--- a/browser/ui/views/toolbar/brave_toolbar_view.cc
+++ b/browser/ui/views/toolbar/brave_toolbar_view.cc
@@ -16,6 +16,7 @@
 #include "base/i18n/rtl.h"
 #include "brave/app/brave_command_ids.h"
 #include "brave/app/vector_icons/vector_icons.h"
+#include "brave/browser/ui/focus_mode/focus_mode_utils.h"
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
 #include "brave/browser/ui/views/frame/brave_browser_view.h"
 #include "brave/browser/ui/views/frame/brave_non_client_hit_test_helper.h"
@@ -35,6 +36,7 @@
 #include "chrome/browser/profiles/profile_manager.h"
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/browser_commands.h"
+#include "chrome/browser/ui/browser_window/public/browser_window_features.h"
 #include "chrome/browser/ui/layout_constants.h"
 #include "chrome/browser/ui/ui_features.h"
 #include "chrome/browser/ui/views/bookmarks/bookmark_bubble_view.h"
@@ -228,6 +230,11 @@ void BraveToolbarView::Init() {
     profile_observer_.Observe(
         &g_browser_process->profile_manager()->GetProfileAttributesStorage());
   }
+
+  if (auto* controller = browser_->GetFeatures().focus_mode_controller()) {
+    focus_mode_observation_.Observe(controller);
+  }
+
   // track changes in bookmarks enabled setting
   edit_bookmarks_enabled_.Init(
       bookmarks::prefs::kEditBookmarksEnabled, profile->GetPrefs(),
@@ -469,6 +476,10 @@ void BraveToolbarView::OnProfileWasRemoved(const base::FilePath& profile_path,
   Update(nullptr);
 }
 
+void BraveToolbarView::OnFocusModeToggled(bool enabled) {
+  UpdateHorizontalPadding();
+}
+
 void BraveToolbarView::LoadImages() {
   ToolbarView::LoadImages();
   if (bookmark_) {
@@ -516,7 +527,8 @@ void BraveToolbarView::UpdateHorizontalPadding() {
   }
 
   if (!tabs::utils::ShouldShowBraveVerticalTabs(browser()) ||
-      tabs::utils::ShouldShowWindowTitleForVerticalTabs(browser())) {
+      tabs::utils::ShouldShowWindowTitleForVerticalTabs(browser()) ||
+      IsFocusModeEnabled(browser())) {
     SetBorder(nullptr);
     return;
   }

--- a/browser/ui/views/toolbar/brave_toolbar_view.h
+++ b/browser/ui/views/toolbar/brave_toolbar_view.h
@@ -9,6 +9,7 @@
 #include "base/gtest_prod_util.h"
 #include "base/memory/raw_ptr.h"
 #include "base/scoped_observation.h"
+#include "brave/browser/ui/focus_mode/focus_mode_controller.h"
 #include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
 #include "brave/components/brave_vpn/common/buildflags/buildflags.h"
 #include "chrome/browser/profiles/profile_attributes_storage.h"
@@ -31,7 +32,8 @@ class ToolbarButton;
 class WalletButton;
 
 class BraveToolbarView : public ToolbarView,
-                         public ProfileAttributesStorage::Observer {
+                         public ProfileAttributesStorage::Observer,
+                         public FocusModeController::Observer {
   METADATA_HEADER(BraveToolbarView, ToolbarView)
  public:
   class LayoutGuard;
@@ -86,6 +88,9 @@ class BraveToolbarView : public ToolbarView,
   void OnProfileWasRemoved(const base::FilePath& profile_path,
                            const std::u16string& profile_name) override;
 
+  // FocusModeController::Observer:
+  void OnFocusModeToggled(bool enabled) override;
+
 #if BUILDFLAG(ENABLE_AI_CHAT)
   void UpdateAIChatButtonVisibility();
 #endif
@@ -138,6 +143,8 @@ class BraveToolbarView : public ToolbarView,
   base::ScopedObservation<ProfileAttributesStorage,
                           ProfileAttributesStorage::Observer>
       profile_observer_{this};
+  base::ScopedObservation<FocusModeController, FocusModeController::Observer>
+      focus_mode_observation_{this};
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_TOOLBAR_BRAVE_TOOLBAR_VIEW_H_

--- a/chromium_src/chrome/browser/ui/views/frame/layout/browser_view_layout.h
+++ b/chromium_src/chrome/browser/ui/views/frame/layout/browser_view_layout.h
@@ -22,6 +22,7 @@ class SidebarContainerView;
   top_container_separator;                                \
   raw_ptr<views::View> contents_background = nullptr;     \
   raw_ptr<views::View> vertical_tab_strip_host = nullptr; \
+  raw_ptr<views::View> focus_mode_title_bar = nullptr;    \
   raw_ptr<SidebarContainerView> sidebar_container
 
 // Add setters for the new members to BrowserViewLayout.
@@ -31,6 +32,9 @@ class SidebarContainerView;
   }                                                                        \
   void set_vertical_tab_strip_host(views::View* vertical_tab_strip_host) { \
     views_.vertical_tab_strip_host = vertical_tab_strip_host;              \
+  }                                                                        \
+  void set_focus_mode_title_bar(views::View* focus_mode_title_bar) {       \
+    views_.focus_mode_title_bar = focus_mode_title_bar;                    \
   }                                                                        \
   void set_sidebar_container(SidebarContainerView* sidebar_container) {    \
     views_.sidebar_container = sidebar_container;                          \

--- a/chromium_src/chrome/browser/ui/views/frame/system_menu_model_delegate.cc
+++ b/chromium_src/chrome/browser/ui/views/frame/system_menu_model_delegate.cc
@@ -8,7 +8,7 @@
 #include <string>
 
 #include "brave/app/brave_command_ids.h"
-#include "brave/browser/ui/focus_mode/focus_mode_controller.h"
+#include "brave/browser/ui/focus_mode/focus_mode_utils.h"
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 #include "chrome/browser/ui/browser_window/public/browser_window_features.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
@@ -27,8 +27,7 @@ bool SystemMenuModelDelegate::IsCommandIdChecked(int command_id) const {
     return tabs::utils::ShouldShowBraveVerticalTabs(browser_);
   }
   if (command_id == IDC_TOGGLE_FOCUS_MODE) {
-    auto* controller = browser_->GetFeatures().focus_mode_controller();
-    return controller && controller->IsEnabled();
+    return IsFocusModeEnabled(browser_);
   }
   return IsCommandIdChecked_ChromiumImpl(command_id);
 }


### PR DESCRIPTION
# Focus Mode Implementation Overview

## Feature Description

Focus Mode is a window layout toggle that collapses the top chrome (tab strip, toolbar, bookmark bar, infobar, etc.) into an auto-hiding overlay anchored to the top edge of the window. In its place sits a small (20px) title bar showing the active tab's favicon and formatted host. Web contents expand into the freed vertical space.

The overlay slides into view when the user hovers near the top edge, when focus enters the top chrome, when a bubble anchored to the top chrome is shown, or when other window UI (autocomplete popup, menus) appears. It slides out again when none of those conditions hold. Active-tab changes briefly reveal it.

The feature is gated by `features::kBraveFocusMode` (disabled by default) and only applies to normal browser windows.

## Prior Art: ImmersiveMode

Upstream's immersive fullscreen is used as inspiration. In immersive mode the top container is detached from `BrowserView` and hosted somewhere else, then auto-revealed by hover/focus/etc. On macOS, "somewhere else" is an AppKit `NSTitlebarAccessoryViewController` whose `NSWindow` is the actual overlay host. The toolbar's pin/auto-hide state is driven by AppKit plus a Mojo-piped reveal-lock count. On ChromeOS the controller runs in-process and drives a `gfx::SlideAnimation`. On Win/Linux it is a stub.

Importantly, when the top container is reparented away, upstream's`BrowserViewLayoutImpl::Layout` falls into a separate "top container parented elsewhere" branch that re-runs `CalculateTopContainerLayout` against the new parent. That branch is the foothold Focus Mode reuses (see Layout below).

### Why ImmersiveMode isn't directly usable

- **Fullscreen-only.** All immersive entry points are gated on entering fullscreen. Focus Mode is a windowed-mode feature.
- **Not portable.** The Mac implementation is tied to AppKit (`NSTitlebarAccessoryViewController`, `fullScreenMinHeight`, Mojo to `remote_cocoa`). ChromeOS has its own implementation. Win/Linux have nothing to share, and Focus Mode needs to work on all desktop platforms.

We do, however, reuse the *layout* branch immersive introduced.

## Architecture Overview

```
  BrowserWindowFeatures
          │
          ▼
  FocusModeController         (observable bool)
          │
          │ Observer
          ▼
  BraveBrowserView
      │       │
      │       ├──── FocusModeTitleBarView   (favicon + host)
      │       │
      │       └──── FocusModeTopOverlay     (slide host)
      │                  │
      │                  ├── EdgeHoverDetector
      │                  ├── EdgeRevealWatcher
      │                  └── hosts: top_container (reparented)
      │
      └── TabStripPlacementCoordinator       (reparents tab strip)
```

`FocusModeController` is a tiny per-window state holder created by `BrowserWindowFeatures` when the feature flag is enabled.

`BraveBrowserView` observes the controller; on toggle it activates or deactivates `FocusModeTopOverlay`, shows or hides `FocusModeTitleBarView`, and asks `TabStripPlacementCoordinator` to recompute tab-strip parenting (so the horizontal tab strip ends up inside `top_container`, which the overlay then hosts).

The Mac/Win/Opaque frame views also observe the controller and subscribe to the overlay's reveal-fraction callback so window controls (traffic lights, caption buttons) animate in sync with the slide.

## Major Components

### `FocusModeController`

"Enabled" boolean + observer list, owned by `BrowserWindowFeatures`. Views observe it and react.

### `FocusModeTopOverlay`

A `views::View` that, while active, hosts `top_container` (and through it the reparented horizontal tab strip) as a direct child and animates its own y-offset based on a `gfx::SlideAnimation`. `Activate()` performs the reparent, installs the hover detector / reveal watcher, and starts hidden. `Deactivate()` returns `top_container` to its original index under `BrowserView` and tears the helpers down.

The "should I be revealed?" decision is in `ShouldReveal()`:

- The mouse is hovering over the edge or overlay (`EdgeHoverDetector::hovering()`)
- `RevealTemporarily()` timer is running (used on active-tab change)
- `EdgeRevealWatcher` reports focus inside the edge or an anchored bubble
- a non-bubble child widget is visible and the overlay is already fully revealed (so menus etc. don't dismiss the overlay from under themselves).

`RegisterRevealFractionChanged()` lets the frame views ride the same animation curve (see "Layout" below).

### `FocusModeTitleBarView`

Twenty-DIP high view, centered favicon + host label.

### `EdgeRevealWatcher`

Watches a host widget and reports the current `RevealReasons` set:

* `kFocus`
* `kAnchoredBubble`
* `kVisibleChildWidget`

Driven by `FocusManager` focus changes plus `WidgetObserver` add/remove events. Designed to be future-reusable for other edge-mounted auto-hiding UI. Loosely inspired by the ChromeOS-only `ImmersiveFocusWatcher`.

### `EdgeHoverDetector`

A `views::EventMonitor` on the host widget's native window listening for `kMouseMoved` / `kMouseExited`. Hover state is debounced to avoid flapping when the cursor grazes the top edge. The hot zone is owned by the consumer (`FocusModeTopOverlay::IsHoverPoint`).

## Layout (The Reparenting Trick)

The overlay deliberately has no layout manager of its own. Once `top_container` is added as a child of the overlay, upstream's `BrowserViewLayoutImpl::Layout` detects that `top_container->parent() != browser_view` and runs:

```cpp
// chrome/browser/ui/views/frame/layout/browser_view_layout_impl.cc
if (views().top_container &&
    views().top_container->parent() != views().browser_view) {
  ProposedLayout top_container_layout;
  const gfx::Rect top_container_local_bounds =
      CalculateTopContainerLayout(top_container_layout, params, true);
  std::move(top_container_layout).ApplyLayout(views().top_container, …);
  views().top_container->SetBoundsRect(
      GetTopContainerBoundsInParent(top_container_local_bounds, params));
}
```

This is the same branch macOS immersive uses to size its overlay-hosted top container. Focus Mode gets correct internal layout of the toolbar, tab strip, and bookmark bar for free.

The overlay then mirrors `top_container`'s bounds and applies a vertical offset for the slide animation:

```cpp
// FocusModeTopOverlay::UpdateBounds
int height = top_container->bounds().height();
int y_offset = -static_cast<int>((1.0 - reveal_fraction) * height);
SetBoundsRect(gfx::Rect(0, y_offset, parent()->width(), height));
```

The Brave layout impl handles everything that's not the top container: `BraveBrowserViewTabbedLayoutImpl::AdjustLayoutForFocusMode` positions the title bar at the very top of the window, slides the infobar down below it, and outsets the contents container upward so the web view fills the space the top chrome used to occupy.

Frame-view caption buttons follow the same curve via `RegisterRevealFractionChanged`:

- **Mac**: fades traffic-light alpha from `[0.7, 1.0]` of the reveal fraction, so they "pop in" near the end of the slide rather than tracking it continuously.
- **Windows / Opaque**: translate the caption-button layer by `-height * (1 - reveal_fraction)`.

### Mutually exclusive with ImmersiveMode

Focus Mode and immersive fullscreen both want exclusive ownership of `top_container`'s parent. They cannot be active simultaneously. The interaction points:

- **macOS, entering fullscreen:** `BraveBrowserFrameViewMac::OnFullscreenStateChanged` installs a `ScopedFocusModeDisable` RAII handle that calls `FocusModeController::SetEnabled(false)` before the immersive controller starts. On exit, the handle restores the previous enabled state. This guarantees `Deactivate()` has returned `top_container` to `BrowserView` before immersive tries to reparent it onto the AppKit overlay widget.
- **End of immersive:** Upstream's `BrowserView::ReparentTopContainerForEndOfImmersive` would unconditionally reparent back to `BrowserView`. `BraveBrowserView` short-circuits this when Focus Mode (or vertical tabs) is in charge of placement.
- **Teardown:** `OnImmersiveModeControllerDestroyed` calls `FocusModeTopOverlay::Deactivate()` so the overlay never outlives the parent state machine.
