### PR TITLE
[VPN 2.0] Split BraveVPNService into interface and implementation

### DIFF
--- a/browser/brave_vpn/android/brave_vpn_native_worker.cc
+++ b/browser/brave_vpn/android/brave_vpn_native_worker.cc
@@ -12,18 +12,18 @@
 #include "base/json/json_writer.h"
 #include "base/values.h"
 #include "brave/browser/brave_vpn/brave_vpn_service_factory.h"
-#include "brave/components/brave_vpn/browser/brave_vpn_service_impl.h"
+#include "brave/components/brave_vpn/browser/brave_vpn_service.h"
 #include "brave/components/l10n/common/locale_util.h"
 #include "brave/components/l10n/common/ofac_sanction_util.h"
 #include "chrome/android/chrome_jni_headers/BraveVpnNativeWorker_jni.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/profiles/profile_manager.h"
 
-using brave_vpn::BraveVpnServiceImpl;
+using brave_vpn::BraveVpnService;
 
 namespace {
 
-BraveVpnServiceImpl* GetBraveVpnService() {
+BraveVpnService* GetBraveVpnService() {
   return brave_vpn::BraveVpnServiceFactory::GetForProfile(
       ProfileManager::GetActiveUserProfile()->GetOriginalProfile());
 }
@@ -249,7 +249,7 @@ void BraveVpnNativeWorker::OnVerifyPurchaseToken(
 jboolean BraveVpnNativeWorker::IsPurchasedUser(JNIEnv* env) {
   auto* brave_vpn_service = GetBraveVpnService();
   if (brave_vpn_service) {
-    return brave_vpn_service->is_purchased_user();
+    return brave_vpn_service->IsPurchased();
   }
 
   return false;
@@ -271,7 +271,7 @@ void BraveVpnNativeWorker::ReportForegroundP3A(JNIEnv* env) {
   auto* brave_vpn_service = GetBraveVpnService();
   if (brave_vpn_service) {
     // Reporting a new session to P3A functions.
-    brave_vpn_service->brave_vpn_metrics()->RecordAllMetrics(true);
+    brave_vpn_service->RecordAllMetrics();
   }
 }
 

--- a/browser/brave_vpn/brave_vpn_service_factory.cc
+++ b/browser/brave_vpn/brave_vpn_service_factory.cc
@@ -14,6 +14,7 @@
 #include "brave/browser/misc_metrics/process_misc_metrics.h"
 #include "brave/browser/misc_metrics/uptime_monitor_impl.h"
 #include "brave/browser/skus/skus_service_factory.h"
+#include "brave/components/brave_vpn/browser/brave_vpn_service.h"
 #include "brave/components/brave_vpn/browser/brave_vpn_service_impl.h"
 #include "brave/components/brave_vpn/common/brave_vpn_utils.h"
 #include "brave/components/skus/common/features.h"
@@ -104,7 +105,7 @@ BraveVpnServiceFactory* BraveVpnServiceFactory::GetInstance() {
 // static
 mojo::PendingRemote<brave_vpn::mojom::ServiceHandler>
 BraveVpnServiceFactory::GetRemoteForProfile(Profile* profile) {
-  auto* service = static_cast<BraveVpnServiceImpl*>(
+  auto* service = static_cast<BraveVpnService*>(
       GetInstance()->GetServiceForBrowserContext(profile, true));
 
   if (!service) {
@@ -116,8 +117,8 @@ BraveVpnServiceFactory::GetRemoteForProfile(Profile* profile) {
 #endif  // BUILDFLAG(IS_ANDROID)
 
 // static
-BraveVpnServiceImpl* BraveVpnServiceFactory::GetForProfile(Profile* profile) {
-  return static_cast<BraveVpnServiceImpl*>(
+BraveVpnService* BraveVpnServiceFactory::GetForProfile(Profile* profile) {
+  return static_cast<BraveVpnService*>(
       GetInstance()->GetServiceForBrowserContext(profile, true));
 }
 
@@ -125,7 +126,7 @@ BraveVpnServiceImpl* BraveVpnServiceFactory::GetForProfile(Profile* profile) {
 void BraveVpnServiceFactory::BindForContext(
     content::BrowserContext* context,
     mojo::PendingReceiver<brave_vpn::mojom::ServiceHandler> receiver) {
-  auto* service = static_cast<BraveVpnServiceImpl*>(
+  auto* service = static_cast<BraveVpnService*>(
       GetInstance()->GetServiceForBrowserContext(context, true));
   if (service) {
     service->BindInterface(std::move(receiver));

--- a/browser/brave_vpn/brave_vpn_service_factory.h
+++ b/browser/brave_vpn/brave_vpn_service_factory.h
@@ -24,11 +24,11 @@ class NoDestructor;
 
 namespace brave_vpn {
 
-class BraveVpnServiceImpl;
+class BraveVpnService;
 
 class BraveVpnServiceFactory : public BrowserContextKeyedServiceFactory {
  public:
-  static BraveVpnServiceImpl* GetForProfile(Profile* profile);
+  static BraveVpnService* GetForProfile(Profile* profile);
 #if BUILDFLAG(IS_ANDROID)
   static mojo::PendingRemote<brave_vpn::mojom::ServiceHandler>
   GetRemoteForProfile(Profile* profile);

--- a/browser/ui/brave_browser_command_controller.cc
+++ b/browser/ui/brave_browser_command_controller.cc
@@ -64,7 +64,7 @@
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
 #include "brave/browser/brave_vpn/brave_vpn_service_factory.h"
 #include "brave/browser/brave_vpn/vpn_utils.h"
-#include "brave/components/brave_vpn/browser/brave_vpn_service_impl.h"
+#include "brave/components/brave_vpn/browser/brave_vpn_service.h"
 #include "brave/components/brave_vpn/common/pref_names.h"
 #endif
 
@@ -459,9 +459,8 @@ void BraveBrowserCommandController::UpdateCommandForBraveVPN() {
   if (auto* vpn_service = brave_vpn::BraveVpnServiceFactory::GetForProfile(
           browser_->profile())) {
     // Only show vpn sub menu for purchased user.
-    UpdateCommandEnabled(IDC_BRAVE_VPN_MENU, vpn_service->is_purchased_user());
-    UpdateCommandEnabled(IDC_TOGGLE_BRAVE_VPN,
-                         vpn_service->is_purchased_user());
+    UpdateCommandEnabled(IDC_BRAVE_VPN_MENU, vpn_service->IsPurchased());
+    UpdateCommandEnabled(IDC_TOGGLE_BRAVE_VPN, vpn_service->IsPurchased());
   }
 #endif
 }

--- a/browser/ui/brave_browser_command_controller_browsertest.cc
+++ b/browser/ui/brave_browser_command_controller_browsertest.cc
@@ -58,7 +58,7 @@
 
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
 #include "brave/browser/brave_vpn/brave_vpn_service_factory.h"
-#include "brave/components/brave_vpn/browser/brave_vpn_service_impl.h"
+#include "brave/components/brave_vpn/browser/brave_vpn_service.h"
 #include "brave/components/brave_vpn/common/brave_vpn_utils.h"
 #include "brave/components/brave_vpn/common/features.h"
 #include "brave/components/brave_vpn/common/pref_names.h"
@@ -125,7 +125,8 @@ class BraveBrowserCommandControllerTest : public InProcessBrowserTest {
     auto target_state = purchased
                             ? brave_vpn::mojom::PurchasedState::PURCHASED
                             : brave_vpn::mojom::PurchasedState::NOT_PURCHASED;
-    service->SetPurchasedState(skus::GetDefaultEnvironment(), target_state);
+    service->SetPurchasedStateForTesting(skus::GetDefaultEnvironment(),
+                                         target_state);
     // Call explicitely to update vpn commands status because mojo works in
     // async way.
     static_cast<chrome::BraveBrowserCommandController*>(

--- a/browser/ui/brave_vpn/brave_vpn_controller.cc
+++ b/browser/ui/brave_vpn/brave_vpn_controller.cc
@@ -7,7 +7,7 @@
 
 #include "brave/browser/brave_vpn/brave_vpn_service_factory.h"
 #include "brave/browser/ui/views/frame/brave_browser_view.h"
-#include "brave/components/brave_vpn/browser/brave_vpn_service_impl.h"
+#include "brave/components/brave_vpn/browser/brave_vpn_service.h"
 #include "brave/components/brave_vpn/common/brave_vpn_utils.h"
 #include "chrome/browser/ui/singleton_tabs.h"
 #include "url/gurl.h"

--- a/browser/ui/browser_commands.cc
+++ b/browser/ui/browser_commands.cc
@@ -110,7 +110,7 @@
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
 #include "brave/browser/brave_vpn/brave_vpn_service_factory.h"
 #include "brave/browser/ui/brave_vpn/brave_vpn_controller.h"
-#include "brave/components/brave_vpn/browser/brave_vpn_service_impl.h"
+#include "brave/components/brave_vpn/browser/brave_vpn_service.h"
 #include "brave/components/brave_vpn/common/brave_vpn_constants.h"
 #include "brave/components/brave_vpn/common/brave_vpn_utils.h"
 #include "brave/components/brave_vpn/common/pref_names.h"

--- a/browser/ui/toolbar/brave_app_menu_model_browsertest.cc
+++ b/browser/ui/toolbar/brave_app_menu_model_browsertest.cc
@@ -37,7 +37,7 @@
 
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
 #include "brave/browser/brave_vpn/brave_vpn_service_factory.h"
-#include "brave/components/brave_vpn/browser/brave_vpn_service_impl.h"
+#include "brave/components/brave_vpn/browser/brave_vpn_service.h"
 #include "brave/components/brave_vpn/common/features.h"
 #endif
 
@@ -62,7 +62,8 @@ class BraveAppMenuModelBrowserTest : public InProcessBrowserTest {
     auto target_state = purchased
                             ? brave_vpn::mojom::PurchasedState::PURCHASED
                             : brave_vpn::mojom::PurchasedState::NOT_PURCHASED;
-    service->SetPurchasedState(skus::GetDefaultEnvironment(), target_state);
+    service->SetPurchasedStateForTesting(skus::GetDefaultEnvironment(),
+                                         target_state);
     // Call explicitely to update vpn commands status because mojo works in
     // async way.
     static_cast<chrome::BraveBrowserCommandController*>(

--- a/browser/ui/views/toolbar/brave_app_menu_browsertest.cc
+++ b/browser/ui/views/toolbar/brave_app_menu_browsertest.cc
@@ -30,7 +30,7 @@
 
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
 #include "brave/browser/brave_vpn/brave_vpn_service_factory.h"
-#include "brave/components/brave_vpn/browser/brave_vpn_service_impl.h"
+#include "brave/components/brave_vpn/browser/brave_vpn_service.h"
 #include "brave/components/brave_vpn/common/features.h"
 #endif
 
@@ -59,7 +59,8 @@ class BraveAppMenuBrowserTest : public InProcessBrowserTest {
     auto target_state = purchased
                             ? brave_vpn::mojom::PurchasedState::PURCHASED
                             : brave_vpn::mojom::PurchasedState::NOT_PURCHASED;
-    service->SetPurchasedState(skus::GetDefaultEnvironment(), target_state);
+    service->SetPurchasedStateForTesting(skus::GetDefaultEnvironment(),
+                                         target_state);
     // Call explicitely to update vpn commands status because mojo works in
     // async way.
     static_cast<chrome::BraveBrowserCommandController*>(

--- a/browser/ui/views/toolbar/brave_vpn_button.cc
+++ b/browser/ui/views/toolbar/brave_vpn_button.cc
@@ -16,7 +16,7 @@
 #include "brave/browser/ui/color/brave_color_id.h"
 #include "brave/browser/ui/color/color_palette.h"
 #include "brave/browser/ui/views/brave_actions/brave_icon_with_badge_image_source.h"
-#include "brave/components/brave_vpn/browser/brave_vpn_service_impl.h"
+#include "brave/components/brave_vpn/browser/brave_vpn_service.h"
 #include "brave/components/vector_icons/vector_icons.h"
 #include "brave/grit/brave_generated_resources.h"
 #include "chrome/browser/ui/browser.h"
@@ -79,7 +79,7 @@ class VPNButtonMenuModel : public ui::SimpleMenuModel,
             browser_->profile())) {
     CHECK(service_);
     Observe(service_);
-    Build(service_->is_purchased_user());
+    Build(service_->IsPurchased());
   }
 
   ~VPNButtonMenuModel() override = default;
@@ -97,7 +97,7 @@ class VPNButtonMenuModel : public ui::SimpleMenuModel,
       brave_vpn::mojom::PurchasedState state,
       const std::optional<std::string>& description) override {
     // Rebuild menu items based on purchased state change.
-    Build(service_->is_purchased_user());
+    Build(service_->IsPurchased());
   }
 
   void Build(bool purchased) {
@@ -117,7 +117,7 @@ class VPNButtonMenuModel : public ui::SimpleMenuModel,
   }
 
   raw_ptr<Browser, DanglingUntriaged> browser_ = nullptr;
-  raw_ptr<brave_vpn::BraveVpnServiceImpl, DanglingUntriaged> service_ = nullptr;
+  raw_ptr<brave_vpn::BraveVpnService, DanglingUntriaged> service_ = nullptr;
 };
 
 const ui::ColorProvider* GetColorProviderForView(
@@ -367,7 +367,7 @@ bool BraveVPNButton::IsConnectError() const {
 }
 
 bool BraveVPNButton::IsPurchased() const {
-  return service_->is_purchased_user();
+  return service_->IsPurchased();
 }
 void BraveVPNButton::OnButtonPressed(const ui::Event& event) {
   chrome::ExecuteCommand(browser_, IDC_SHOW_BRAVE_VPN_PANEL);

--- a/browser/ui/views/toolbar/brave_vpn_button.h
+++ b/browser/ui/views/toolbar/brave_vpn_button.h
@@ -17,7 +17,7 @@
 #include "ui/views/controls/button/menu_button_controller.h"
 
 namespace brave_vpn {
-class BraveVpnServiceImpl;
+class BraveVpnService;
 class BraveVpnButtonUnitTest;
 }  // namespace brave_vpn
 
@@ -75,7 +75,7 @@ class BraveVPNButton : public ToolbarButton,
   std::optional<brave_vpn::mojom::ConnectionState>
       connection_state_for_testing_;
   raw_ptr<Browser, DanglingUntriaged> browser_ = nullptr;
-  raw_ptr<brave_vpn::BraveVpnServiceImpl, DanglingUntriaged> service_ = nullptr;
+  raw_ptr<brave_vpn::BraveVpnService, DanglingUntriaged> service_ = nullptr;
   raw_ptr<views::MenuButtonController> menu_button_controller_ = nullptr;
   base::WeakPtrFactory<BraveVPNButton> weak_ptr_factory_{this};
 };

--- a/browser/ui/views/toolbar/brave_vpn_button_unittest.cc
+++ b/browser/ui/views/toolbar/brave_vpn_button_unittest.cc
@@ -12,7 +12,7 @@
 #include "base/memory/scoped_refptr.h"
 #include "base/run_loop.h"
 #include "brave/browser/brave_vpn/brave_vpn_service_factory.h"
-#include "brave/components/brave_vpn/browser/brave_vpn_service_impl.h"
+#include "brave/components/brave_vpn/browser/brave_vpn_service.h"
 #include "brave/components/brave_vpn/browser/connection/brave_vpn_connection_manager.h"
 #include "brave/components/brave_vpn/browser/connection/connection_api_impl.h"
 #include "brave/components/brave_vpn/browser/connection/ikev2/connection_api_impl_sim.h"
@@ -104,13 +104,11 @@ class BraveVpnButtonUnitTest : public testing::Test {
   bool DoesButtonHaveConnectedState() const { return button_->is_connected_; }
 
   void SetPurchasedState(const std::string& env, mojom::PurchasedState state) {
-    button_->service_->SetPurchasedState(env, state);
+    button_->service_->SetPurchasedStateForTesting(env, state);
   }
 
   void SetConnectionState(mojom::ConnectionState state) {
-    ASSERT_TRUE(button_->service_->connection_manager_->connection_api_impl_);
-    button_->service_->connection_manager_->connection_api_impl_
-        ->SetConnectionStateForTesting(state);
+    button_->service_->SetConnectionStateForTesting(state);
   }
 
   bool IsOsVpnConnected() const {

--- a/browser/ui/views/toolbar/brave_vpn_status_label.cc
+++ b/browser/ui/views/toolbar/brave_vpn_status_label.cc
@@ -10,7 +10,7 @@
 #include "base/check.h"
 #include "brave/browser/brave_vpn/brave_vpn_service_factory.h"
 #include "brave/browser/ui/color/brave_color_id.h"
-#include "brave/components/brave_vpn/browser/brave_vpn_service_impl.h"
+#include "brave/components/brave_vpn/browser/brave_vpn_service.h"
 #include "brave/grit/brave_generated_resources.h"
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"

--- a/browser/ui/views/toolbar/brave_vpn_status_label.h
+++ b/browser/ui/views/toolbar/brave_vpn_status_label.h
@@ -12,7 +12,7 @@
 #include "ui/views/controls/label.h"
 
 namespace brave_vpn {
-class BraveVpnServiceImpl;
+class BraveVpnService;
 }  // namespace brave_vpn
 
 class Browser;
@@ -36,7 +36,7 @@ class BraveVPNStatusLabel : public views::Label,
 
   int longest_state_string_id_ = -1;
   raw_ptr<Browser> browser_ = nullptr;
-  raw_ptr<brave_vpn::BraveVpnServiceImpl> service_ = nullptr;
+  raw_ptr<brave_vpn::BraveVpnService> service_ = nullptr;
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_TOOLBAR_BRAVE_VPN_STATUS_LABEL_H_

--- a/browser/ui/views/toolbar/brave_vpn_toggle_button.cc
+++ b/browser/ui/views/toolbar/brave_vpn_toggle_button.cc
@@ -10,7 +10,7 @@
 #include "base/check.h"
 #include "base/functional/bind.h"
 #include "brave/browser/brave_vpn/brave_vpn_service_factory.h"
-#include "brave/components/brave_vpn/browser/brave_vpn_service_impl.h"
+#include "brave/components/brave_vpn/browser/brave_vpn_service.h"
 #include "brave/grit/brave_generated_resources.h"
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"

--- a/browser/ui/views/toolbar/brave_vpn_toggle_button.h
+++ b/browser/ui/views/toolbar/brave_vpn_toggle_button.h
@@ -12,7 +12,7 @@
 #include "ui/views/controls/button/toggle_button.h"
 
 namespace brave_vpn {
-class BraveVpnServiceImpl;
+class BraveVpnService;
 }  // namespace brave_vpn
 
 class Browser;
@@ -36,7 +36,7 @@ class BraveVPNToggleButton : public views::ToggleButton,
   void UpdateState();
 
   raw_ptr<Browser> browser_ = nullptr;
-  raw_ptr<brave_vpn::BraveVpnServiceImpl> service_ = nullptr;
+  raw_ptr<brave_vpn::BraveVpnService> service_ = nullptr;
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_TOOLBAR_BRAVE_VPN_TOGGLE_BUTTON_H_

--- a/browser/ui/webui/brave_new_tab_page_refresh/brave_new_tab_page_ui.cc
+++ b/browser/ui/webui/brave_new_tab_page_refresh/brave_new_tab_page_ui.cc
@@ -60,7 +60,7 @@
 
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
 #include "brave/browser/brave_vpn/brave_vpn_service_factory.h"
-#include "brave/components/brave_vpn/browser/brave_vpn_service_impl.h"
+#include "brave/components/brave_vpn/browser/brave_vpn_service.h"
 #endif
 
 #if BUILDFLAG(ENABLE_BRAVE_REWARDS)

--- a/browser/ui/webui/brave_new_tab_page_refresh/vpn_facade.cc
+++ b/browser/ui/webui/brave_new_tab_page_refresh/vpn_facade.cc
@@ -13,7 +13,7 @@
 
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
 #include "brave/browser/ui/brave_vpn/brave_vpn_controller.h"
-#include "brave/components/brave_vpn/browser/brave_vpn_service_impl.h"
+#include "brave/components/brave_vpn/browser/brave_vpn_service.h"
 #endif
 
 namespace brave_new_tab_page_refresh {
@@ -21,7 +21,7 @@ namespace brave_new_tab_page_refresh {
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
 
 VPNFacade::VPNFacade(content::WebContents& web_contents,
-                     brave_vpn::BraveVpnServiceImpl* vpn_service)
+                     brave_vpn::BraveVpnService* vpn_service)
     : web_contents_(web_contents), vpn_service_(vpn_service) {}
 
 VPNFacade::~VPNFacade() = default;
@@ -46,7 +46,7 @@ void VPNFacade::OpenAccountPage(brave_vpn::mojom::ManageURLType url_type) {
 
 void VPNFacade::RecordWidgetUsage() {
   if (vpn_service_) {
-    vpn_service_->brave_vpn_metrics()->RecordWidgetUsage(true);
+    vpn_service_->RecordWidgetUsageMetrics(true);
   }
 }
 

--- a/browser/ui/webui/brave_new_tab_page_refresh/vpn_facade.h
+++ b/browser/ui/webui/brave_new_tab_page_refresh/vpn_facade.h
@@ -20,7 +20,7 @@ class WebContents;
 
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
 namespace brave_vpn {
-class BraveVpnServiceImpl;
+class BraveVpnService;
 }
 
 class BraveVPNController;
@@ -36,7 +36,7 @@ namespace brave_new_tab_page_refresh {
 class VPNFacade {
  public:
   VPNFacade(content::WebContents& web_contents,
-            brave_vpn::BraveVpnServiceImpl* vpn_service);
+            brave_vpn::BraveVpnService* vpn_service);
   ~VPNFacade();
 
   VPNFacade(const VPNFacade&) = delete;
@@ -52,7 +52,7 @@ class VPNFacade {
   BraveVPNController* GetBraveVPNController();
 
   raw_ref<content::WebContents> web_contents_;
-  raw_ptr<brave_vpn::BraveVpnServiceImpl> vpn_service_;
+  raw_ptr<brave_vpn::BraveVpnService> vpn_service_;
 };
 
 #else

--- a/browser/ui/webui/brave_settings_ui.cc
+++ b/browser/ui/webui/brave_settings_ui.cc
@@ -94,7 +94,7 @@
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
 #include "brave/browser/brave_vpn/brave_vpn_service_factory.h"
 #include "brave/browser/brave_vpn/vpn_utils.h"
-#include "brave/components/brave_vpn/browser/brave_vpn_service_impl.h"
+#include "brave/components/brave_vpn/browser/brave_vpn_service.h"
 #if BUILDFLAG(IS_WIN)
 #include "brave/browser/ui/webui/settings/brave_vpn/brave_vpn_handler.h"
 #endif

--- a/browser/ui/webui/brave_vpn/vpn_panel_handler.cc
+++ b/browser/ui/webui/brave_vpn/vpn_panel_handler.cc
@@ -10,7 +10,7 @@
 #include "base/check.h"
 #include "brave/browser/brave_vpn/brave_vpn_service_factory.h"
 #include "brave/browser/ui/webui/brave_vpn/vpn_panel_ui.h"
-#include "brave/components/brave_vpn/browser/brave_vpn_service_impl.h"
+#include "brave/components/brave_vpn/browser/brave_vpn_service.h"
 #include "brave/components/brave_vpn/common/brave_vpn_constants.h"
 #include "brave/components/brave_vpn/common/brave_vpn_utils.h"
 #include "chrome/browser/ui/browser.h"

--- a/browser/ui/webui/brave_vpn/vpn_panel_ui.h
+++ b/browser/ui/webui/brave_vpn/vpn_panel_ui.h
@@ -10,7 +10,7 @@
 #include <string>
 
 #include "brave/browser/ui/webui/brave_vpn/vpn_panel_handler.h"
-#include "brave/components/brave_vpn/browser/brave_vpn_service_impl.h"
+#include "brave/components/brave_vpn/browser/brave_vpn_service.h"
 #include "brave/components/brave_vpn/common/mojom/brave_vpn.mojom.h"
 #include "chrome/browser/ui/webui/top_chrome/top_chrome_web_ui_controller.h"
 #include "chrome/browser/ui/webui/top_chrome/top_chrome_webui_config.h"

--- a/browser/ui/webui/new_tab_page/brave_new_tab_page_handler.cc
+++ b/browser/ui/webui/new_tab_page/brave_new_tab_page_handler.cc
@@ -58,7 +58,7 @@
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
 #include "brave/browser/brave_vpn/brave_vpn_service_factory.h"
 #include "brave/browser/ui/brave_vpn/brave_vpn_controller.h"
-#include "brave/components/brave_vpn/browser/brave_vpn_service_impl.h"
+#include "brave/components/brave_vpn/browser/brave_vpn_service.h"
 #endif
 
 namespace {
@@ -363,7 +363,7 @@ void BraveNewTabPageHandler::OpenVPNAccountPage(
 void BraveNewTabPageHandler::ReportVPNWidgetUsage() {
   auto* vpn_service =
       brave_vpn::BraveVpnServiceFactory::GetForProfile(profile_);
-  vpn_service->brave_vpn_metrics()->RecordWidgetUsage(true);
+  vpn_service->RecordWidgetUsageMetrics(true);
 }
 #endif
 

--- a/browser/ui/webui/new_tab_page/brave_new_tab_ui.cc
+++ b/browser/ui/webui/new_tab_page/brave_new_tab_ui.cc
@@ -63,7 +63,7 @@
 
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
 #include "brave/browser/brave_vpn/brave_vpn_service_factory.h"
-#include "brave/components/brave_vpn/browser/brave_vpn_service_impl.h"
+#include "brave/components/brave_vpn/browser/brave_vpn_service.h"
 #include "brave/components/brave_vpn/common/brave_vpn_utils.h"
 #endif
 

--- a/browser/ui/webui/settings/brave_vpn/brave_vpn_handler.cc
+++ b/browser/ui/webui/settings/brave_vpn/brave_vpn_handler.cc
@@ -18,7 +18,7 @@
 #include "brave/browser/brave_vpn/win/service_details.h"
 #include "brave/browser/brave_vpn/win/storage_utils.h"
 #include "brave/browser/brave_vpn/win/wireguard_utils_win.h"
-#include "brave/components/brave_vpn/browser/brave_vpn_service_impl.h"
+#include "brave/components/brave_vpn/browser/brave_vpn_service.h"
 #include "brave/components/brave_vpn/common/brave_vpn_utils.h"
 #include "brave/components/brave_vpn/common/pref_names.h"
 #include "chrome/browser/browser_process.h"

--- a/browser/ui/webui/skus_internals_ui.cc
+++ b/browser/ui/webui/skus_internals_ui.cc
@@ -37,8 +37,8 @@
 
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
 #include "brave/browser/brave_vpn/brave_vpn_service_factory.h"
+#include "brave/components/brave_vpn/browser/brave_vpn_service.h"
 #include "brave/components/brave_vpn/browser/brave_vpn_service_helper.h"
-#include "brave/components/brave_vpn/browser/brave_vpn_service_impl.h"
 #include "brave/components/brave_vpn/browser/connection/brave_vpn_connection_manager.h"
 #include "brave/components/brave_vpn/common/brave_vpn_utils.h"
 #include "brave/components/brave_vpn/common/pref_names.h"

--- a/browser/ui/webui/webcompat_reporter/webcompat_reporter_ui.cc
+++ b/browser/ui/webui/webcompat_reporter/webcompat_reporter_ui.cc
@@ -57,7 +57,7 @@
 
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
 #include "brave/browser/brave_vpn/brave_vpn_service_factory.h"
-#include "brave/components/brave_vpn/browser/brave_vpn_service_impl.h"
+#include "brave/components/brave_vpn/browser/brave_vpn_service.h"
 #endif
 
 namespace webcompat_reporter {

--- a/components/brave_vpn/browser/BUILD.gn
+++ b/components/brave_vpn/browser/BUILD.gn
@@ -11,6 +11,8 @@ static_library("browser") {
   sources = [
     "brave_vpn_metrics.cc",
     "brave_vpn_metrics.h",
+    "brave_vpn_service.cc",
+    "brave_vpn_service.h",
     "brave_vpn_service_delegate.h",
     "brave_vpn_service_helper.cc",
     "brave_vpn_service_helper.h",
@@ -53,6 +55,7 @@ source_set("unit_tests") {
   sources = [
     "brave_vpn_metrics_unittest.cc",
     "brave_vpn_service_impl_unittest.cc",
+    "brave_vpn_service_unittest.cc",
   ]
 
   deps = [

--- a/components/brave_vpn/browser/brave_vpn_metrics.cc
+++ b/components/brave_vpn/browser/brave_vpn_metrics.cc
@@ -142,7 +142,7 @@ void BraveVpnMetrics::ReportVPNConnectedDuration() {
   }
 
 #if !BUILDFLAG(IS_ANDROID)
-  if (delegate_->IsConnected() && uptime_monitor_->IsInUse()) {
+  if (delegate_->is_connected_vpn() && uptime_monitor_->IsInUse()) {
     RecordVPNConnectedInterval();
   }
 #endif

--- a/components/brave_vpn/browser/brave_vpn_metrics.h
+++ b/components/brave_vpn/browser/brave_vpn_metrics.h
@@ -40,7 +40,7 @@ class BraveVpnMetrics {
     virtual bool is_purchased_user() const = 0;
 
 #if !BUILDFLAG(IS_ANDROID)
-    virtual bool IsConnected() const = 0;
+    virtual bool is_connected_vpn() const = 0;
 #endif
   };
 

--- a/components/brave_vpn/browser/brave_vpn_metrics_unittest.cc
+++ b/components/brave_vpn/browser/brave_vpn_metrics_unittest.cc
@@ -52,7 +52,7 @@ class BraveVpnMetricsTest : public testing::Test {
     // BraveVpnMetrics::Delegate implementation
     bool is_purchased_user() const override { return is_purchased; }
 #if !BUILDFLAG(IS_ANDROID)
-    bool IsConnected() const override { return is_connected; }
+    bool is_connected_vpn() const override { return is_connected; }
 #endif
 
     bool is_purchased = true;

--- a/components/brave_vpn/browser/brave_vpn_service.cc
+++ b/components/brave_vpn/browser/brave_vpn_service.cc
@@ -1,0 +1,76 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/browser/brave_vpn_service.h"
+
+namespace brave_vpn {
+
+BraveVpnService::BraveVpnService() = default;
+
+BraveVpnService::~BraveVpnService() = default;
+
+void BraveVpnService::AddObserver(
+    mojo::PendingRemote<mojom::ServiceObserver> observer) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  observers_.Add(std::move(observer));
+}
+
+void BraveVpnService::BindInterface(
+    mojo::PendingReceiver<mojom::ServiceHandler> receiver) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  receivers_.Add(this, std::move(receiver));
+}
+
+#if BUILDFLAG(IS_ANDROID)
+mojo::PendingRemote<brave_vpn::mojom::ServiceHandler>
+BraveVpnService::MakeRemote() {
+  mojo::PendingRemote<brave_vpn::mojom::ServiceHandler> remote;
+  receivers_.Add(this, remote.InitWithNewPipeAndPassReceiver());
+  return remote;
+}
+#endif  // BUILDFLAG(IS_ANDROID)
+
+void BraveVpnService::Shutdown() {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  observers_.Clear();
+#if !BUILDFLAG(IS_ANDROID)
+  receivers_.Clear();
+#endif  // !BUILDFLAG(IS_ANDROID)
+}
+
+void BraveVpnService::NotifyPurchasedStateChanged(
+    mojom::PurchasedState state,
+    const std::optional<std::string>& description) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  for (const auto& obs : observers_) {
+    obs->OnPurchasedStateChanged(state, description);
+  }
+}
+
+#if !BUILDFLAG(IS_ANDROID)
+void BraveVpnService::NotifyConnectionStateChanged(
+    mojom::ConnectionState state) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  for (const auto& obs : observers_) {
+    obs->OnConnectionStateChanged(state);
+  }
+}
+
+void BraveVpnService::NotifySelectedRegionChanged(mojom::RegionPtr region) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  for (const auto& obs : observers_) {
+    obs->OnSelectedRegionChanged(region.Clone());
+  }
+}
+
+void BraveVpnService::NotifySmartProxyRoutingStateChanged(bool enabled) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  for (const auto& obs : observers_) {
+    obs->OnSmartProxyRoutingStateChanged(enabled);
+  }
+}
+#endif  // !BUILDFLAG(IS_ANDROID)
+
+}  // namespace brave_vpn

--- a/components/brave_vpn/browser/brave_vpn_service.h
+++ b/components/brave_vpn/browser/brave_vpn_service.h
@@ -1,0 +1,149 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_BRAVE_VPN_SERVICE_H_
+#define BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_BRAVE_VPN_SERVICE_H_
+
+#include <optional>
+#include <string>
+
+#include "base/functional/callback.h"
+#include "base/sequence_checker.h"
+#include "brave/components/brave_vpn/common/mojom/brave_vpn.mojom.h"
+#include "brave/components/skus/browser/skus_utils.h"
+#include "build/build_config.h"
+#include "components/keyed_service/core/keyed_service.h"
+#include "mojo/public/cpp/bindings/pending_receiver.h"
+#include "mojo/public/cpp/bindings/pending_remote.h"
+#include "mojo/public/cpp/bindings/receiver_set.h"
+#include "mojo/public/cpp/bindings/remote_set.h"
+
+#if !BUILDFLAG(IS_ANDROID)
+class BraveAppMenuBrowserTest;
+class BraveAppMenuModelBrowserTest;
+class BraveBrowserCommandControllerTest;
+#endif  // !BUILDFLAG(IS_ANDROID)
+
+namespace brave_vpn {
+
+// Base class for Brave VPN keyed service, which implements the basic mojo
+// interface and observer management. It also declares virtual functions used by
+// external code. The implementation is in BraveVpnServiceImpl, which is
+// different for Architecture 1.0 and Architecture 2.0.
+
+// This class is used by desktop and Android. However, it includes desktop
+// specific implementations, and it's hidden by IS_ANDROID buildflag.
+
+class BraveVpnService : public mojom::ServiceHandler, public KeyedService {
+ public:
+  using ResponseCallback =
+      base::OnceCallback<void(const std::string&, bool success)>;
+#if !BUILDFLAG(IS_ANDROID)
+  using mojom::ServiceHandler::GetConnectionState;
+#endif  // !BUILDFLAG(IS_ANDROID)
+
+  BraveVpnService();
+  ~BraveVpnService() override;
+
+  BraveVpnService(const BraveVpnService&) = delete;
+  BraveVpnService& operator=(const BraveVpnService&) = delete;
+
+  // mojom::ServiceHandler overrides:
+  void AddObserver(mojo::PendingRemote<mojom::ServiceObserver> observer) final;
+
+  // Public interface exposed to other components.
+  virtual bool IsBraveVPNEnabled() const = 0;
+  virtual bool IsPurchased() const = 0;
+  virtual void ReloadPurchasedState() = 0;
+  virtual std::string GetCurrentEnvironment() const = 0;
+#if !BUILDFLAG(IS_ANDROID)
+  // Public interface for desktop components.
+  virtual bool IsConnected() const = 0;
+  virtual void ToggleConnection() = 0;
+  virtual mojom::ConnectionState GetConnectionState() const = 0;
+  virtual void RecordWidgetUsageMetrics(bool new_usage) = 0;
+#else   //  !BUILDFLAG(IS_ANDROID)
+  // Public interface for Android native worker.
+  virtual void GetTimezonesForRegions(ResponseCallback callback) = 0;
+  virtual void GetHostnamesForRegion(ResponseCallback callback,
+                                     const std::string& region,
+                                     const std::string& region_precision) = 0;
+  virtual void GetProfileCredentials(ResponseCallback callback,
+                                     const std::string& subscriber_credential,
+                                     const std::string& hostname) = 0;
+  virtual void GetWireguardProfileCredentials(
+      ResponseCallback callback,
+      const std::string& subscriber_credential,
+      const std::string& public_key,
+      const std::string& hostname) = 0;
+  virtual void VerifyCredentials(ResponseCallback callback,
+                                 const std::string& hostname,
+                                 const std::string& client_id,
+                                 const std::string& subscriber_credential,
+                                 const std::string& api_auth_token) = 0;
+  virtual void InvalidateCredentials(ResponseCallback callback,
+                                     const std::string& hostname,
+                                     const std::string& client_id,
+                                     const std::string& subscriber_credential,
+                                     const std::string& api_auth_token) = 0;
+  virtual void VerifyPurchaseToken(ResponseCallback callback,
+                                   const std::string& purchase_token,
+                                   const std::string& product_id,
+                                   const std::string& product_type,
+                                   const std::string& bundle_id) = 0;
+  virtual void GetSubscriberCredential(ResponseCallback callback,
+                                       const std::string& product_type,
+                                       const std::string& product_id,
+                                       const std::string& validation_method,
+                                       const std::string& purchase_token,
+                                       const std::string& bundle_id) = 0;
+  virtual void GetSubscriberCredentialV12(ResponseCallback callback) = 0;
+  virtual void RecordAllMetrics() = 0;
+  virtual void RecordAndroidBackgroundP3A(int64_t session_start_time_ms,
+                                          int64_t session_end_time_ms) = 0;
+#endif  // !BUILDFLAG(IS_ANDROID)
+
+  void BindInterface(mojo::PendingReceiver<mojom::ServiceHandler> receiver);
+#if BUILDFLAG(IS_ANDROID)
+  mojo::PendingRemote<brave_vpn::mojom::ServiceHandler> MakeRemote();
+#endif  // BUILDFLAG(IS_ANDROID)
+
+ protected:
+  // KeyedService overrides:
+  void Shutdown() override;
+
+  // Observer notification functions.
+  void NotifyPurchasedStateChanged(
+      mojom::PurchasedState state,
+      const std::optional<std::string>& description);
+#if !BUILDFLAG(IS_ANDROID)
+  void NotifyConnectionStateChanged(mojom::ConnectionState state);
+  void NotifySelectedRegionChanged(mojom::RegionPtr region);
+  void NotifySmartProxyRoutingStateChanged(bool enabled);
+#endif  // !BUILDFLAG(IS_ANDROID)
+
+  SEQUENCE_CHECKER(sequence_checker_);
+
+ private:
+  friend class BraveVpnButtonUnitTest;
+#if !BUILDFLAG(IS_ANDROID)
+  friend class ::BraveAppMenuBrowserTest;
+  friend class ::BraveAppMenuModelBrowserTest;
+  friend class ::BraveBrowserCommandControllerTest;
+#endif  // !BUILDFLAG(IS_ANDROID)
+
+#if !BUILDFLAG(IS_ANDROID)
+  virtual void SetConnectionStateForTesting(mojom::ConnectionState state) = 0;
+  virtual void SetPurchasedStateForTesting(const std::string& env,
+                                           mojom::PurchasedState state) = 0;
+#endif  // !BUILDFLAG(IS_ANDROID)
+
+  mojo::RemoteSet<mojom::ServiceObserver> observers_;
+  mojo::ReceiverSet<mojom::ServiceHandler> receivers_;
+};
+
+}  // namespace brave_vpn
+
+#endif  // BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_BRAVE_VPN_SERVICE_H_

--- a/components/brave_vpn/browser/brave_vpn_service_impl.cc
+++ b/components/brave_vpn/browser/brave_vpn_service_impl.cc
@@ -117,17 +117,18 @@ void BraveVpnServiceImpl::CheckInitialState() {
   }
 }
 
-#if BUILDFLAG(IS_ANDROID)
-mojo::PendingRemote<brave_vpn::mojom::ServiceHandler>
-BraveVpnServiceImpl::MakeRemote() {
-  mojo::PendingRemote<brave_vpn::mojom::ServiceHandler> remote;
-  receivers_.Add(this, remote.InitWithNewPipeAndPassReceiver());
-  return remote;
-}
-#endif  // BUILDFLAG(IS_ANDROID)
-
 std::string BraveVpnServiceImpl::GetCurrentEnvironment() const {
   return local_prefs_->GetString(prefs::kBraveVPNEnvironment);
+}
+
+#if !BUILDFLAG(IS_ANDROID)
+void BraveVpnServiceImpl::RecordWidgetUsageMetrics(bool new_usage) {
+  brave_vpn_metrics_.RecordWidgetUsage(new_usage);
+}
+#endif  // !BUILDFLAG(IS_ANDROID)
+
+bool BraveVpnServiceImpl::IsPurchased() const {
+  return is_purchased_user();
 }
 
 bool BraveVpnServiceImpl::is_purchased_user() const {
@@ -136,12 +137,6 @@ bool BraveVpnServiceImpl::is_purchased_user() const {
 
 void BraveVpnServiceImpl::ReloadPurchasedState() {
   LoadPurchasedState(skus::GetDomain("vpn", GetCurrentEnvironment()));
-}
-
-void BraveVpnServiceImpl::BindInterface(
-    mojo::PendingReceiver<mojom::ServiceHandler> receiver) {
-  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-  receivers_.Add(this, std::move(receiver));
 }
 
 #if !BUILDFLAG(IS_ANDROID)
@@ -177,9 +172,7 @@ void BraveVpnServiceImpl::OnConnectionStateChanged(
     brave_vpn_metrics_.RecordAllMetrics(true);
   }
 
-  for (const auto& obs : observers_) {
-    obs->OnConnectionStateChanged(state);
-  }
+  NotifyConnectionStateChanged(state);
 }
 
 void BraveVpnServiceImpl::OnRegionDataReady(bool success) {
@@ -206,9 +199,7 @@ void BraveVpnServiceImpl::OnSelectedRegionChanged(
   const auto region_ptr = GetRegionPtrWithNameFromRegionList(
       region_name, connection_manager_->GetRegionDataManager().GetRegions());
   region_ptr->is_automatic = IsCurrentRegionSelectedAutomatically(region_ptr);
-  for (const auto& obs : observers_) {
-    obs->OnSelectedRegionChanged(region_ptr.Clone());
-  }
+  NotifySelectedRegionChanged(region_ptr.Clone());
 }
 
 void BraveVpnServiceImpl::OnInstallSystemServicesCompleted(bool success) {
@@ -230,6 +221,10 @@ bool BraveVpnServiceImpl::IsConnected() const {
   }
 
   return GetConnectionState() == ConnectionState::CONNECTED;
+}
+
+bool BraveVpnServiceImpl::is_connected_vpn() const {
+  return IsConnected();
 }
 
 void BraveVpnServiceImpl::Connect() {
@@ -390,9 +385,7 @@ void BraveVpnServiceImpl::OnPreferenceChanged(const std::string& pref_name) {
 
   if (pref_name == prefs::kBraveVPNSmartProxyRoutingEnabled) {
     const bool enabled = smart_proxy_routing_enabled_.GetValue();
-    for (const auto& obs : observers_) {
-      obs->OnSmartProxyRoutingStateChanged(enabled);
-    }
+    NotifySmartProxyRoutingStateChanged(enabled);
     return;
   }
 }
@@ -556,12 +549,6 @@ void BraveVpnServiceImpl::GetPurchaseToken(GetPurchaseTokenCallback callback) {
   std::move(callback).Run(base::Base64Encode(response_json));
 }
 #endif  // BUILDFLAG(IS_ANDROID)
-
-void BraveVpnServiceImpl::AddObserver(
-    mojo::PendingRemote<mojom::ServiceObserver> observer) {
-  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-  observers_.Add(std::move(observer));
-}
 
 mojom::PurchasedInfo BraveVpnServiceImpl::GetPurchasedInfoSync() const {
   return purchased_state_.value_or(
@@ -894,9 +881,7 @@ void BraveVpnServiceImpl::SetPurchasedState(
   VLOG(2) << __func__ << " : " << state;
   purchased_state_ = mojom::PurchasedInfo(state, description);
 
-  for (const auto& obs : observers_) {
-    obs->OnPurchasedStateChanged(state, description);
-  }
+  NotifyPurchasedStateChanged(state, description);
 
 #if !BUILDFLAG(IS_ANDROID)
   if (state == PurchasedState::PURCHASED) {
@@ -932,15 +917,17 @@ void BraveVpnServiceImpl::Shutdown() {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
 
   skus_service_.reset();
-  observers_.Clear();
   api_request_.reset();
   subs_cred_refresh_timer_.Stop();
 
 #if !BUILDFLAG(IS_ANDROID)
   observed_.Reset();
-  receivers_.Clear();
 #endif  // !BUILDFLAG(IS_ANDROID)
+
+  BraveVpnService::Shutdown();
 }
+
+#if BUILDFLAG(IS_ANDROID)
 
 void BraveVpnServiceImpl::GetTimezonesForRegions(ResponseCallback callback) {
   api_request_->GetTimezonesForRegions(std::move(callback));
@@ -1019,5 +1006,24 @@ void BraveVpnServiceImpl::GetSubscriberCredentialV12(
   std::move(callback).Run(::brave_vpn::GetSubscriberCredential(local_prefs_),
                           HasValidSubscriberCredential(local_prefs_));
 }
+
+void BraveVpnServiceImpl::RecordAllMetrics() {
+  brave_vpn_metrics_.RecordAllMetrics(true);
+}
+
+#else  // BUILDFLAG(IS_ANDROID)
+
+void BraveVpnServiceImpl::SetConnectionStateForTesting(  // IN-TEST
+    mojom::ConnectionState state) {
+  connection_manager_->SetConnectionStateForTesting(state);  // IN-TEST
+}
+
+void BraveVpnServiceImpl::SetPurchasedStateForTesting(  // IN-TEST
+    const std::string& env,
+    mojom::PurchasedState state) {
+  SetPurchasedState(env, state);
+}
+
+#endif  // BUILDFLAG(IS_ANDROID)
 
 }  // namespace brave_vpn

--- a/components/brave_vpn/browser/brave_vpn_service_impl.h
+++ b/components/brave_vpn/browser/brave_vpn_service_impl.h
@@ -16,24 +16,20 @@
 #include "base/memory/scoped_refptr.h"
 #include "base/memory/weak_ptr.h"
 #include "base/scoped_observation.h"
-#include "base/sequence_checker.h"
 #include "base/timer/timer.h"
 #include "base/values.h"
 #include "brave/components/brave_vpn/browser/api/brave_vpn_api_request.h"
 #include "brave/components/brave_vpn/browser/brave_vpn_metrics.h"
+#include "brave/components/brave_vpn/browser/brave_vpn_service.h"
 #include "brave/components/brave_vpn/browser/brave_vpn_service_delegate.h"
 #include "brave/components/brave_vpn/browser/connection/brave_vpn_connection_manager.h"
 #include "brave/components/brave_vpn/common/brave_vpn_data_types.h"
-#include "brave/components/brave_vpn/common/mojom/brave_vpn.mojom.h"
 #include "brave/components/skus/browser/skus_utils.h"
 #include "brave/components/skus/common/skus_sdk.mojom.h"
 #include "build/build_config.h"
-#include "components/keyed_service/core/keyed_service.h"
 #include "components/prefs/pref_change_registrar.h"
 #include "components/prefs/pref_member.h"
 #include "mojo/public/cpp/bindings/pending_remote.h"
-#include "mojo/public/cpp/bindings/receiver_set.h"
-#include "mojo/public/cpp/bindings/remote_set.h"
 #include "services/network/public/cpp/shared_url_loader_factory.h"
 
 namespace network {
@@ -46,26 +42,17 @@ class UptimeMonitor;
 
 class PrefService;
 
-#if !BUILDFLAG(IS_ANDROID)
-class BraveAppMenuBrowserTest;
-class BraveAppMenuModelBrowserTest;
-class BraveBrowserCommandControllerTest;
-#endif  // !BUILDFLAG(IS_ANDROID)
-
 namespace brave_vpn {
 
 class BraveVPNServiceDelegate;
 
-// This class is used by desktop and android.
-// However, it includes desktop specific impls and it's hidden
-// by IS_ANDROID ifdef.
-class BraveVpnServiceImpl :
+// The original Brave VPN service implementation, which is used in
+// Architecture 1.0.
+class BraveVpnServiceImpl : public BraveVpnService,
 #if !BUILDFLAG(IS_ANDROID)
-    public BraveVPNConnectionManager::Observer,
+                            public BraveVPNConnectionManager::Observer,
 #endif
-    public mojom::ServiceHandler,
-    public KeyedService,
-    public BraveVpnMetrics::Delegate {
+                            public BraveVpnMetrics::Delegate {
  public:
   BraveVpnServiceImpl(
       BraveVPNConnectionManager* connection_manager,
@@ -80,21 +67,24 @@ class BraveVpnServiceImpl :
   BraveVpnServiceImpl(const BraveVpnServiceImpl&) = delete;
   BraveVpnServiceImpl& operator=(const BraveVpnServiceImpl&) = delete;
 
-#if BUILDFLAG(IS_ANDROID)
-  mojo::PendingRemote<brave_vpn::mojom::ServiceHandler> MakeRemote();
-#endif  // BUILDFLAG(IS_ANDROID)
-
-  std::string GetCurrentEnvironment() const;
-  bool is_purchased_user() const override;
-  void BindInterface(mojo::PendingReceiver<mojom::ServiceHandler> receiver);
-  void ReloadPurchasedState();
-  bool IsBraveVPNEnabled() const;
+  // BraveVpnService overrides:
+  // Implementation of public interface exposed to other components.
+  bool IsBraveVPNEnabled() const override;
+  bool IsPurchased() const override;
+  void ReloadPurchasedState() override;
+  std::string GetCurrentEnvironment() const override;
 #if !BUILDFLAG(IS_ANDROID)
-  void ToggleConnection();
-  mojom::ConnectionState GetConnectionState() const;
   bool IsConnected() const override;
+  void ToggleConnection() override;
+  mojom::ConnectionState GetConnectionState() const override;
+  void RecordWidgetUsageMetrics(bool new_usage) override;
+#endif  // !BUILDFLAG(IS_ANDROID)
 
-  // mojom::vpn::ServiceHandler
+  // mojom::ServiceHandler overrides:
+  void GetPurchasedState(GetPurchasedStateCallback callback) override;
+  void LoadPurchasedState(const std::string& domain) override;
+  void GetAllRegions(GetAllRegionsCallback callback) override;
+#if !BUILDFLAG(IS_ANDROID)
   void GetConnectionState(GetConnectionStateCallback callback) override;
   void Connect() override;
   void Disconnect() override;
@@ -113,79 +103,66 @@ class BraveVpnServiceImpl :
   void EnableSmartProxyRouting(bool enable) override;
   void GetSmartProxyRoutingState(
       GetSmartProxyRoutingStateCallback callback) override;
-#else
-  // mojom::vpn::ServiceHandler
+#else   // !BUILDFLAG(IS_ANDROID)
   void GetPurchaseToken(GetPurchaseTokenCallback callback) override;
-  void OnFetchRegionList(GetAllRegionsCallback callback,
-                         const std::string& region_list,
-                         bool success);
 #endif  // !BUILDFLAG(IS_ANDROID)
 
-  using ResponseCallback =
-      base::OnceCallback<void(const std::string&, bool success)>;
+  // BraveVpnMetrics::Delegate
+  bool is_purchased_user() const override;
+#if !BUILDFLAG(IS_ANDROID)
+  bool is_connected_vpn() const override;
+#endif  //! BUILDFLAG(IS_ANDROID)
 
-  // mojom::vpn::ServiceHandler
-  void AddObserver(
-      mojo::PendingRemote<mojom::ServiceObserver> observer) override;
-  void GetPurchasedState(GetPurchasedStateCallback callback) override;
-  void LoadPurchasedState(const std::string& domain) override;
-
-  void GetAllRegions(GetAllRegionsCallback callback) override;
-
-  void GetTimezonesForRegions(ResponseCallback callback);
+#if BUILDFLAG(IS_ANDROID)
+  // Implementation of public interface for Android native worker.
+  void GetTimezonesForRegions(ResponseCallback callback) override;
   void GetHostnamesForRegion(ResponseCallback callback,
                              const std::string& region,
-                             const std::string& region_precision);
+                             const std::string& region_precision) override;
   void GetProfileCredentials(ResponseCallback callback,
                              const std::string& subscriber_credential,
-                             const std::string& hostname);
+                             const std::string& hostname) override;
   void GetWireguardProfileCredentials(ResponseCallback callback,
                                       const std::string& subscriber_credential,
                                       const std::string& public_key,
-                                      const std::string& hostname);
+                                      const std::string& hostname) override;
   void VerifyCredentials(ResponseCallback callback,
                          const std::string& hostname,
                          const std::string& client_id,
                          const std::string& subscriber_credential,
-                         const std::string& api_auth_token);
+                         const std::string& api_auth_token) override;
   void InvalidateCredentials(ResponseCallback callback,
                              const std::string& hostname,
                              const std::string& client_id,
                              const std::string& subscriber_credential,
-                             const std::string& api_auth_token);
+                             const std::string& api_auth_token) override;
+  void VerifyPurchaseToken(ResponseCallback callback,
+                           const std::string& purchase_token,
+                           const std::string& product_id,
+                           const std::string& product_type,
+                           const std::string& bundle_id) override;
   void GetSubscriberCredential(ResponseCallback callback,
                                const std::string& product_type,
                                const std::string& product_id,
                                const std::string& validation_method,
                                const std::string& purchase_token,
-                               const std::string& bundle_id);
-  void VerifyPurchaseToken(ResponseCallback callback,
-                           const std::string& purchase_token,
-                           const std::string& product_id,
-                           const std::string& product_type,
-                           const std::string& bundle_id);
-  void GetSubscriberCredentialV12(ResponseCallback callback);
+                               const std::string& bundle_id) override;
+  void GetSubscriberCredentialV12(ResponseCallback callback) override;
+  void RecordAllMetrics() override;
+  void RecordAndroidBackgroundP3A(int64_t session_start_time_ms,
+                                  int64_t session_end_time_ms) override;
+#endif  // BUILDFLAG(IS_ANDROID)
 
   void set_delegate(std::unique_ptr<BraveVPNServiceDelegate> delegate) {
     delegate_ = std::move(delegate);
   }
 
-#if BUILDFLAG(IS_ANDROID)
-  void RecordAndroidBackgroundP3A(int64_t session_start_time_ms,
-                                  int64_t session_end_time_ms);
-#endif
-
   BraveVpnMetrics* brave_vpn_metrics() { return &brave_vpn_metrics_; }
 
  private:
-  friend class BraveVPNServiceTest;
-  friend class BraveVpnButtonUnitTest;
+  friend class BraveVpnServiceImplV1Test;
 
 #if !BUILDFLAG(IS_ANDROID)
-  friend class ::BraveAppMenuBrowserTest;
-  friend class ::BraveAppMenuModelBrowserTest;
-  friend class ::BraveBrowserCommandControllerTest;
-
   // BraveVPNConnectionManager::Observer overrides:
   void OnConnectionStateChanged(mojom::ConnectionState state) override;
   void OnRegionDataReady(bool success) override;
@@ -201,10 +178,21 @@ class BraveVpnServiceImpl :
   void UpdatePurchasedStateForSessionExpired(const std::string& env);
   bool IsCurrentRegionSelectedAutomatically(
       const brave_vpn::mojom::RegionPtr& region);
+#else   // !BUILDFLAG(IS_ANDROID)
+  void OnFetchRegionList(GetAllRegionsCallback callback,
+                         const std::string& region_list,
+                         bool success);
 #endif  // !BUILDFLAG(IS_ANDROID)
 
   // KeyedService overrides:
   void Shutdown() override;
+
+  // BraveVpnService overrides:
+#if !BUILDFLAG(IS_ANDROID)
+  void SetConnectionStateForTesting(mojom::ConnectionState state) override;
+  void SetPurchasedStateForTesting(const std::string& env,
+                                   mojom::PurchasedState state) override;
+#endif  // !BUILDFLAG(IS_ANDROID)
 
   mojom::PurchasedInfo GetPurchasedInfoSync() const;
   void SetPurchasedState(
@@ -240,16 +228,12 @@ class BraveVpnServiceImpl :
   PrefChangeRegistrar policy_pref_change_registrar_;
 #endif  // !BUILDFLAG(IS_ANDROID)
 
-  SEQUENCE_CHECKER(sequence_checker_);
-
   raw_ptr<PrefService> local_prefs_ = nullptr;
   raw_ptr<PrefService> profile_prefs_ = nullptr;
-  mojo::ReceiverSet<mojom::ServiceHandler> receivers_;
   base::RepeatingCallback<mojo::PendingRemote<skus::mojom::SkusService>()>
       skus_service_getter_;
   mojo::Remote<skus::mojom::SkusService> skus_service_;
   std::optional<mojom::PurchasedInfo> purchased_state_;
-  mojo::RemoteSet<mojom::ServiceObserver> observers_;
   std::unique_ptr<BraveVpnAPIRequest> api_request_;
   std::unique_ptr<BraveVPNServiceDelegate> delegate_;
   base::OneShotTimer subs_cred_refresh_timer_;

--- a/components/brave_vpn/browser/brave_vpn_service_impl_unittest.cc
+++ b/components/brave_vpn/browser/brave_vpn_service_impl_unittest.cc
@@ -210,9 +210,9 @@ class TestBraveVPNServiceObserver : public BraveVPNServiceObserver {
   mojo::Receiver<mojom::ServiceObserver> observer_receiver_{this};
 };
 
-class BraveVPNServiceTest : public testing::Test {
+class BraveVpnServiceImplV1Test : public testing::Test {
  public:
-  BraveVPNServiceTest()
+  BraveVpnServiceImplV1Test()
       : task_environment_(base::test::TaskEnvironment::TimeSource::MOCK_TIME) {
     scoped_feature_list_.InitWithFeatures(
         {skus::features::kSkusFeature, features::kBraveVPN}, {});
@@ -230,7 +230,7 @@ class BraveVPNServiceTest : public testing::Test {
         base::MakeRefCounted<network::WeakWrapperSharedURLLoaderFactory>(
             &url_loader_factory_);
     url_loader_factory_.SetInterceptor(base::BindRepeating(
-        &BraveVPNServiceTest::Interceptor, base::Unretained(this)));
+        &BraveVpnServiceImplV1Test::Interceptor, base::Unretained(this)));
     // Setup required for SKU (dependency of VPN)
     skus_service_ = std::make_unique<skus::SkusServiceImpl>(
         &local_pref_service_, url_loader_factory_.GetSafeWeakWrapper());
@@ -282,7 +282,7 @@ class BraveVPNServiceTest : public testing::Test {
 #endif
         url_loader_factory_.GetSafeWeakWrapper(), &local_pref_service_,
         &profile_pref_service_, nullptr,
-        base::BindRepeating(&BraveVPNServiceTest::GetSkusService,
+        base::BindRepeating(&BraveVpnServiceImplV1Test::GetSkusService,
                             base::Unretained(this)));
   }
 
@@ -405,7 +405,7 @@ class BraveVPNServiceTest : public testing::Test {
   }
 
   void SetConnectionStateForTesting(ConnectionState state) {
-    GetConnectionAPIImpl()->SetConnectionStateForTesting(state);
+    GetConnectionAPIImpl()->UpdateAndNotifyConnectionStateChange(state);
   }
 
   ConnectionState GetConnectionState() {
@@ -594,7 +594,7 @@ class BraveVPNServiceTest : public testing::Test {
     EXPECT_EQ(observer->GetPurchasedState().value(), state);
   }
 
-  void GetAllRegions(BraveVpnServiceImpl::ResponseCallback callback) {
+  void GetAllRegions(BraveVpnService::ResponseCallback callback) {
     service_->api_request_->GetServerRegions(
         std::move(callback), brave_vpn::mojom::kRegionPrecisionCityByCountry);
   }
@@ -613,7 +613,7 @@ class BraveVPNServiceTest : public testing::Test {
   scoped_refptr<network::SharedURLLoaderFactory> shared_url_loader_factory_;
 };
 
-TEST_F(BraveVPNServiceTest, ResponseSanitizingTest) {
+TEST_F(BraveVpnServiceImplV1Test, ResponseSanitizingTest) {
   // Give invalid json data as a server response and check sanitized(empty
   // string) result is returned.
   SetInterceptorResponse("{'invalid json':");
@@ -629,7 +629,7 @@ TEST_F(BraveVPNServiceTest, ResponseSanitizingTest) {
 }
 
 #if !BUILDFLAG(IS_ANDROID)
-TEST_F(BraveVPNServiceTest, SkusCredentialCacheTest) {
+TEST_F(BraveVpnServiceImplV1Test, SkusCredentialCacheTest) {
   std::string env = skus::GetDefaultEnvironment();
   std::string domain = skus::GetDomain("vpn", env);
 
@@ -652,7 +652,7 @@ TEST_F(BraveVPNServiceTest, SkusCredentialCacheTest) {
   EXPECT_TRUE(HasValidSubscriberCredential(&local_pref_service_));
 }
 
-TEST_F(BraveVPNServiceTest, LoadPurchasedStateSessionExpiredTest) {
+TEST_F(BraveVpnServiceImplV1Test, LoadPurchasedStateSessionExpiredTest) {
   std::string env = skus::GetDefaultEnvironment();
   std::string domain = skus::GetDomain("vpn", env);
 
@@ -702,7 +702,7 @@ TEST_F(BraveVPNServiceTest, LoadPurchasedStateSessionExpiredTest) {
   EXPECT_TRUE(session_expired_time.is_null());
 }
 
-TEST_F(BraveVPNServiceTest, LoadPurchasedStateOutOfCredentialsTest) {
+TEST_F(BraveVpnServiceImplV1Test, LoadPurchasedStateOutOfCredentialsTest) {
   std::string env = skus::GetDefaultEnvironment();
   std::string domain = skus::GetDomain("vpn", env);
 
@@ -718,7 +718,7 @@ TEST_F(BraveVPNServiceTest, LoadPurchasedStateOutOfCredentialsTest) {
   EXPECT_EQ(PurchasedState::OUT_OF_CREDENTIALS, GetPurchasedInfoSync());
 }
 
-TEST_F(BraveVPNServiceTest, LoadPurchasedStateTest) {
+TEST_F(BraveVpnServiceImplV1Test, LoadPurchasedStateTest) {
   std::string env = skus::GetDefaultEnvironment();
   std::string domain = skus::GetDomain("vpn", env);
   // Service try loading
@@ -788,7 +788,7 @@ TEST_F(BraveVPNServiceTest, LoadPurchasedStateTest) {
   EXPECT_EQ(GetPurchasedInfoSync(), PurchasedState::FAILED);
 }
 
-TEST_F(BraveVPNServiceTest, ResetConnectionStateTest) {
+TEST_F(BraveVpnServiceImplV1Test, ResetConnectionStateTest) {
   // Set failed state before setting observer.
   SetConnectionStateForTesting(ConnectionState::CONNECT_FAILED);
 
@@ -808,7 +808,7 @@ TEST_F(BraveVPNServiceTest, ResetConnectionStateTest) {
   EXPECT_EQ(ConnectionState::DISCONNECTED, observer.GetConnectionState());
 }
 
-TEST_F(BraveVPNServiceTest, ConnectionStateUpdateWithPurchasedStateTest) {
+TEST_F(BraveVpnServiceImplV1Test, ConnectionStateUpdateWithPurchasedStateTest) {
   TestBraveVPNServiceObserver observer;
   AddObserver(observer.GetReceiver());
   std::string env = skus::GetDefaultEnvironment();
@@ -820,7 +820,7 @@ TEST_F(BraveVPNServiceTest, ConnectionStateUpdateWithPurchasedStateTest) {
   EXPECT_EQ(ConnectionState::CONNECTED, observer.GetConnectionState());
 }
 
-TEST_F(BraveVPNServiceTest, IsConnectedWithPurchasedStateTest) {
+TEST_F(BraveVpnServiceImplV1Test, IsConnectedWithPurchasedStateTest) {
   TestBraveVPNServiceObserver observer;
   AddObserver(observer.GetReceiver());
   std::string env = skus::GetDefaultEnvironment();
@@ -842,7 +842,7 @@ TEST_F(BraveVPNServiceTest, IsConnectedWithPurchasedStateTest) {
   EXPECT_FALSE(service_->IsConnected());
 }
 
-TEST_F(BraveVPNServiceTest, DisconnectedIfDisabledByPolicy) {
+TEST_F(BraveVpnServiceImplV1Test, DisconnectedIfDisabledByPolicy) {
   TestBraveVPNServiceObserver observer;
   AddObserver(observer.GetReceiver());
   std::string env = skus::GetDefaultEnvironment();
@@ -855,7 +855,7 @@ TEST_F(BraveVPNServiceTest, DisconnectedIfDisabledByPolicy) {
   EXPECT_EQ(ConnectionState::DISCONNECTED, observer.GetConnectionState());
 }
 
-TEST_F(BraveVPNServiceTest, SelectedRegionChangedUpdateTest) {
+TEST_F(BraveVpnServiceImplV1Test, SelectedRegionChangedUpdateTest) {
   TestBraveVPNServiceObserver observer;
   AddObserver(observer.GetReceiver());
 
@@ -866,7 +866,7 @@ TEST_F(BraveVPNServiceTest, SelectedRegionChangedUpdateTest) {
   loop.Run();
 }
 
-TEST_F(BraveVPNServiceTest, ClearSelectedRegionTest) {
+TEST_F(BraveVpnServiceImplV1Test, ClearSelectedRegionTest) {
   TestBraveVPNServiceObserver observer;
   AddObserver(observer.GetReceiver());
 
@@ -898,7 +898,8 @@ TEST_F(BraveVPNServiceTest, ClearSelectedRegionTest) {
 
 // Check SetSelectedRegion is called when default device region is set.
 // We use default device region as an initial selected region.
-TEST_F(BraveVPNServiceTest, SelectedRegionChangedUpdateWithDeviceRegionTest) {
+TEST_F(BraveVpnServiceImplV1Test,
+       SelectedRegionChangedUpdateWithDeviceRegionTest) {
   TestBraveVPNServiceObserver observer;
   AddObserver(observer.GetReceiver());
 
@@ -910,7 +911,7 @@ TEST_F(BraveVPNServiceTest, SelectedRegionChangedUpdateWithDeviceRegionTest) {
   loop.Run();
 }
 
-TEST_F(BraveVPNServiceTest, GetProperRegionFromTimeZoneTest) {
+TEST_F(BraveVpnServiceImplV1Test, GetProperRegionFromTimeZoneTest) {
   // For initial region list, "us-central" is used for "America/Havana"
   // timezone.
   SetTestTimezone("America/Havana");
@@ -933,7 +934,7 @@ TEST_F(BraveVPNServiceTest, GetProperRegionFromTimeZoneTest) {
   EXPECT_EQ("na-usa", GetSelectedRegion());
 }
 
-TEST_F(BraveVPNServiceTest, LoadPurchasedStateForAnotherEnvFailed) {
+TEST_F(BraveVpnServiceImplV1Test, LoadPurchasedStateForAnotherEnvFailed) {
   auto development = SetupTestingStoreForEnv(skus::GetDefaultEnvironment());
   EXPECT_EQ(skus::GetEnvironmentForDomain(development),
             skus::GetDefaultEnvironment());
@@ -1000,7 +1001,7 @@ TEST_F(BraveVPNServiceTest, LoadPurchasedStateForAnotherEnvFailed) {
   EXPECT_EQ(GetPurchasedInfoSync(), PurchasedState::PURCHASED);
 }
 
-TEST_F(BraveVPNServiceTest, CheckInitialPurchasedStateTest) {
+TEST_F(BraveVpnServiceImplV1Test, CheckInitialPurchasedStateTest) {
   // Purchased state is not checked for fresh user.
   EXPECT_EQ(PurchasedState::NOT_PURCHASED, GetPurchasedInfoSync());
 
@@ -1019,7 +1020,7 @@ TEST_F(BraveVPNServiceTest, CheckInitialPurchasedStateTest) {
   EXPECT_EQ(PurchasedState::LOADING, GetPurchasedInfoSync());
 }
 
-TEST_F(BraveVPNServiceTest, SubscribedCredentialsWithTokenNoLongerValid) {
+TEST_F(BraveVpnServiceImplV1Test, SubscribedCredentialsWithTokenNoLongerValid) {
   std::string env = skus::GetDefaultEnvironment();
 
   SetPurchasedState(env, PurchasedState::LOADING);
@@ -1038,7 +1039,7 @@ TEST_F(BraveVPNServiceTest, SubscribedCredentialsWithTokenNoLongerValid) {
 }
 
 // Test connection check is asked only when purchased state.
-TEST_F(BraveVPNServiceTest, CheckConnectionStateAfterPurchased) {
+TEST_F(BraveVpnServiceImplV1Test, CheckConnectionStateAfterPurchased) {
   std::string env = skus::GetDefaultEnvironment();
   auto* test_api = GetConnectionAPIImpl();
   EXPECT_FALSE(test_api->IsConnectionChecked());
@@ -1050,7 +1051,7 @@ TEST_F(BraveVPNServiceTest, CheckConnectionStateAfterPurchased) {
 
 #endif
 
-TEST_F(BraveVPNServiceTest, GetPurchasedInfoSync) {
+TEST_F(BraveVpnServiceImplV1Test, GetPurchasedInfoSync) {
   std::string env = skus::GetDefaultEnvironment();
   EXPECT_EQ(mojom::PurchasedState::NOT_PURCHASED, GetPurchasedInfoSync());
 
@@ -1067,7 +1068,7 @@ TEST_F(BraveVPNServiceTest, GetPurchasedInfoSync) {
   EXPECT_EQ(PurchasedState::NOT_PURCHASED, GetPurchasedInfoSync());
 }
 
-TEST_F(BraveVPNServiceTest, SetPurchasedState) {
+TEST_F(BraveVpnServiceImplV1Test, SetPurchasedState) {
   std::string env = skus::GetDefaultEnvironment();
   TestBraveVPNServiceObserver observer;
   AddObserver(observer.GetReceiver());
@@ -1089,7 +1090,7 @@ TEST_F(BraveVPNServiceTest, SetPurchasedState) {
   EXPECT_FALSE(observer.GetPurchasedState().has_value());
 }
 
-TEST_F(BraveVPNServiceTest, LoadPurchasedStateNotifications) {
+TEST_F(BraveVpnServiceImplV1Test, LoadPurchasedStateNotifications) {
   std::string env = skus::GetDefaultEnvironment();
   std::string domain = skus::GetDomain("vpn", env);
   TestBraveVPNServiceObserver observer;
@@ -1136,7 +1137,7 @@ TEST_F(BraveVPNServiceTest, LoadPurchasedStateNotifications) {
   SetAndExpectPurchasedStateChange(&observer, env, PurchasedState::PURCHASED);
 }
 
-TEST_F(BraveVPNServiceTest, LoadPurchasedStateForAnotherEnv) {
+TEST_F(BraveVpnServiceImplV1Test, LoadPurchasedStateForAnotherEnv) {
   auto development = SetupTestingStoreForEnv(skus::GetDefaultEnvironment());
   EXPECT_EQ(skus::GetEnvironmentForDomain(development),
             skus::GetDefaultEnvironment());
@@ -1164,11 +1165,11 @@ TEST_F(BraveVPNServiceTest, LoadPurchasedStateForAnotherEnv) {
 }
 
 #if BUILDFLAG(IS_WIN)
-class BraveVPNServiceSystemInstallTest
-    : public BraveVPNServiceTest,
+class BraveVPNServiceImplSystemInstallTest
+    : public BraveVpnServiceImplV1Test,
       public testing::WithParamInterface<bool> {};
 
-TEST_P(BraveVPNServiceSystemInstallTest,
+TEST_P(BraveVPNServiceImplSystemInstallTest,
        ReportsInstallSystemServicesCompleted) {
   base::RunLoop run_loop;
   std::string env = skus::GetDefaultEnvironment();
@@ -1185,16 +1186,16 @@ TEST_P(BraveVPNServiceSystemInstallTest,
 
   base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
       FROM_HERE,
-      base::BindOnce(&BraveVPNServiceSystemInstallTest::SetPurchasedState,
+      base::BindOnce(&BraveVPNServiceImplSystemInstallTest::SetPurchasedState,
                      base::Unretained(this), env, PurchasedState::PURCHASED));
   run_loop.Run();
 }
 
 INSTANTIATE_TEST_SUITE_P(,
-                         BraveVPNServiceSystemInstallTest,
+                         BraveVPNServiceImplSystemInstallTest,
                          testing::Values(false, true));
 
-TEST_F(BraveVPNServiceSystemInstallTest,
+TEST_F(BraveVPNServiceImplSystemInstallTest,
        ReportsInstallSystemServicesCompletedMultipleTimes) {
   std::string env = skus::GetDefaultEnvironment();
   DestroyVpnService();
@@ -1208,7 +1209,7 @@ TEST_F(BraveVPNServiceSystemInstallTest,
     base::RunLoop loop;
     base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
         FROM_HERE,
-        base::BindOnce(&BraveVPNServiceSystemInstallTest::SetPurchasedState,
+        base::BindOnce(&BraveVPNServiceImplSystemInstallTest::SetPurchasedState,
                        base::Unretained(this), env, PurchasedState::PURCHASED));
     observer.WaitPurchasedStateChange(loop.QuitClosure());
     loop.Run();
@@ -1218,7 +1219,7 @@ TEST_F(BraveVPNServiceSystemInstallTest,
     base::RunLoop loop;
     base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
         FROM_HERE,
-        base::BindOnce(&BraveVPNServiceSystemInstallTest::SetPurchasedState,
+        base::BindOnce(&BraveVPNServiceImplSystemInstallTest::SetPurchasedState,
                        base::Unretained(this), env,
                        PurchasedState::NOT_PURCHASED));
     observer.WaitPurchasedStateChange(loop.QuitClosure());
@@ -1229,7 +1230,7 @@ TEST_F(BraveVPNServiceSystemInstallTest,
     base::RunLoop loop;
     base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
         FROM_HERE,
-        base::BindOnce(&BraveVPNServiceSystemInstallTest::SetPurchasedState,
+        base::BindOnce(&BraveVPNServiceImplSystemInstallTest::SetPurchasedState,
                        base::Unretained(this), env, PurchasedState::PURCHASED));
     observer.WaitPurchasedStateChange(loop.QuitClosure());
     loop.Run();

--- a/components/brave_vpn/browser/brave_vpn_service_observer.cc
+++ b/components/brave_vpn/browser/brave_vpn_service_observer.cc
@@ -7,7 +7,7 @@
 
 #include <utility>
 
-#include "brave/components/brave_vpn/browser/brave_vpn_service_impl.h"
+#include "brave/components/brave_vpn/browser/brave_vpn_service.h"
 #include "brave/components/brave_vpn/common/brave_vpn_utils.h"
 
 namespace brave_vpn {
@@ -16,7 +16,7 @@ BraveVPNServiceObserver::BraveVPNServiceObserver() = default;
 
 BraveVPNServiceObserver::~BraveVPNServiceObserver() = default;
 
-void BraveVPNServiceObserver::Observe(BraveVpnServiceImpl* service) {
+void BraveVPNServiceObserver::Observe(BraveVpnService* service) {
   if (!service)
     return;
 

--- a/components/brave_vpn/browser/brave_vpn_service_observer.h
+++ b/components/brave_vpn/browser/brave_vpn_service_observer.h
@@ -15,7 +15,7 @@
 
 namespace brave_vpn {
 
-class BraveVpnServiceImpl;
+class BraveVpnService;
 
 class BraveVPNServiceObserver : public mojom::ServiceObserver {
  public:
@@ -24,7 +24,7 @@ class BraveVPNServiceObserver : public mojom::ServiceObserver {
   BraveVPNServiceObserver(const BraveVPNServiceObserver&) = delete;
   BraveVPNServiceObserver& operator=(const BraveVPNServiceObserver&) = delete;
 
-  void Observe(BraveVpnServiceImpl* service);
+  void Observe(BraveVpnService* service);
 
   // mojom::ServiceObserver overrides:
   void OnPurchasedStateChanged(

--- a/components/brave_vpn/browser/brave_vpn_service_unittest.cc
+++ b/components/brave_vpn/browser/brave_vpn_service_unittest.cc
@@ -1,0 +1,499 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/browser/brave_vpn_service.h"
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "base/functional/callback.h"
+#include "base/run_loop.h"
+#include "base/test/task_environment.h"
+#include "brave/components/brave_vpn/common/mojom/brave_vpn.mojom.h"
+#include "build/build_config.h"
+#include "mojo/public/cpp/bindings/pending_remote.h"
+#include "mojo/public/cpp/bindings/receiver.h"
+#include "mojo/public/cpp/bindings/remote.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace brave_vpn {
+
+namespace {
+
+// Concrete test subclass providing stub implementations for BraveVpnService's
+// pure virtual methods. Allows exercising the base-class behavior (observer
+// management, notification dispatch, shutdown, mojo binding) in isolation.
+class TestBraveVpnService : public BraveVpnService {
+ public:
+  TestBraveVpnService() = default;
+  ~TestBraveVpnService() override = default;
+
+  // BraveVpnService:
+  bool IsBraveVPNEnabled() const override { return true; }
+  bool IsPurchased() const override { return true; }
+  void ReloadPurchasedState() override {}
+  std::string GetCurrentEnvironment() const override { return "production"; }
+
+#if !BUILDFLAG(IS_ANDROID)
+  bool IsConnected() const override { return false; }
+  void ToggleConnection() override {}
+  mojom::ConnectionState GetConnectionState() const override {
+    return mojom::ConnectionState::DISCONNECTED;
+  }
+  void RecordWidgetUsageMetrics(bool new_usage) override {}
+#else
+  void GetTimezonesForRegions(ResponseCallback callback) override {}
+  void GetHostnamesForRegion(ResponseCallback callback,
+                             const std::string& region,
+                             const std::string& region_precision) override {}
+  void GetProfileCredentials(ResponseCallback callback,
+                             const std::string& subscriber_credential,
+                             const std::string& hostname) override {}
+  void GetWireguardProfileCredentials(ResponseCallback callback,
+                                      const std::string& subscriber_credential,
+                                      const std::string& public_key,
+                                      const std::string& hostname) override {}
+  void VerifyCredentials(ResponseCallback callback,
+                         const std::string& hostname,
+                         const std::string& client_id,
+                         const std::string& subscriber_credential,
+                         const std::string& api_auth_token) override {}
+  void InvalidateCredentials(ResponseCallback callback,
+                             const std::string& hostname,
+                             const std::string& client_id,
+                             const std::string& subscriber_credential,
+                             const std::string& api_auth_token) override {}
+  void VerifyPurchaseToken(ResponseCallback callback,
+                           const std::string& purchase_token,
+                           const std::string& product_id,
+                           const std::string& product_type,
+                           const std::string& bundle_id) override {}
+  void GetSubscriberCredential(ResponseCallback callback,
+                               const std::string& product_type,
+                               const std::string& product_id,
+                               const std::string& validation_method,
+                               const std::string& purchase_token,
+                               const std::string& bundle_id) override {}
+  void GetSubscriberCredentialV12(ResponseCallback callback) override {}
+  void RecordAllMetrics() override {}
+  void RecordAndroidBackgroundP3A(int64_t session_start_time_ms,
+                                  int64_t session_end_time_ms) override {}
+#endif
+
+#if !BUILDFLAG(IS_ANDROID)
+  void SetConnectionStateForTesting(mojom::ConnectionState state) override {}
+  void SetPurchasedStateForTesting(const std::string& env,
+                                   mojom::PurchasedState state) override {}
+#endif
+
+  // Re-expose the protected notification helpers and Shutdown for tests.
+  using BraveVpnService::NotifyPurchasedStateChanged;
+  using BraveVpnService::Shutdown;
+#if !BUILDFLAG(IS_ANDROID)
+  using BraveVpnService::NotifyConnectionStateChanged;
+  using BraveVpnService::NotifySelectedRegionChanged;
+  using BraveVpnService::NotifySmartProxyRoutingStateChanged;
+#endif
+
+  // mojom::ServiceHandler
+  void GetPurchasedState(GetPurchasedStateCallback callback) override {}
+  void LoadPurchasedState(const std::string& domain) override {}
+  void GetAllRegions(GetAllRegionsCallback callback) override {}
+#if !BUILDFLAG(IS_ANDROID)
+  void GetConnectionState(GetConnectionStateCallback callback) override {}
+  void Connect() override {}
+  void Disconnect() override {}
+  void GetSelectedRegion(GetSelectedRegionCallback callback) override {}
+  void SetSelectedRegion(mojom::RegionPtr region) override {}
+  void ClearSelectedRegion() override {}
+  void GetProductUrls(GetProductUrlsCallback callback) override {}
+  void CreateSupportTicket(const std::string& email,
+                           const std::string& subject,
+                           const std::string& body,
+                           CreateSupportTicketCallback callback) override {}
+  void GetSupportData(GetSupportDataCallback callback) override {}
+  void ResetConnectionState() override {}
+  void EnableOnDemand(bool enable) override {}
+  void GetOnDemandState(GetOnDemandStateCallback callback) override {}
+  void EnableSmartProxyRouting(bool enable) override {}
+  void GetSmartProxyRoutingState(
+      GetSmartProxyRoutingStateCallback callback) override {}
+#else   // !BUILDFLAG(IS_ANDROID)
+  void GetPurchaseToken(GetPurchaseTokenCallback callback) override {}
+#endif  // !BUILDFLAG(IS_ANDROID)
+};
+
+// Test observer that records all callbacks delivered over the mojo pipe and
+// optionally fires a one-shot closure for synchronization with RunLoop.
+class TestServiceObserver : public mojom::ServiceObserver {
+ public:
+  struct PurchasedStateCall {
+    mojom::PurchasedState state;
+    std::optional<std::string> description;
+  };
+
+  TestServiceObserver() = default;
+  ~TestServiceObserver() override = default;
+
+  mojo::PendingRemote<mojom::ServiceObserver> BindAndGetRemote() {
+    return receiver_.BindNewPipeAndPassRemote();
+  }
+
+  void ResetReceiver() { receiver_.reset(); }
+
+  void set_disconnect_handler(base::OnceClosure handler) {
+    receiver_.set_disconnect_handler(std::move(handler));
+  }
+
+  // mojom::ServiceObserver:
+  void OnPurchasedStateChanged(
+      mojom::PurchasedState state,
+      const std::optional<std::string>& description) override {
+    purchased_state_calls_.push_back({state, description});
+    MaybeQuit(purchased_state_quit_);
+  }
+
+#if !BUILDFLAG(IS_ANDROID)
+  void OnConnectionStateChanged(mojom::ConnectionState state) override {
+    connection_state_calls_.push_back(state);
+    MaybeQuit(connection_state_quit_);
+  }
+
+  void OnSelectedRegionChanged(mojom::RegionPtr region) override {
+    selected_region_calls_.push_back(std::move(region));
+    MaybeQuit(selected_region_quit_);
+  }
+
+  void OnSmartProxyRoutingStateChanged(bool enabled) override {
+    smart_proxy_calls_.push_back(enabled);
+    MaybeQuit(smart_proxy_quit_);
+  }
+#endif
+
+  const std::vector<PurchasedStateCall>& purchased_state_calls() const {
+    return purchased_state_calls_;
+  }
+
+  void WaitForNextPurchasedStateCall() {
+    base::RunLoop loop;
+    purchased_state_quit_ = loop.QuitClosure();
+    loop.Run();
+  }
+
+#if !BUILDFLAG(IS_ANDROID)
+  const std::vector<mojom::ConnectionState>& connection_state_calls() const {
+    return connection_state_calls_;
+  }
+  const std::vector<mojom::RegionPtr>& selected_region_calls() const {
+    return selected_region_calls_;
+  }
+  const std::vector<bool>& smart_proxy_calls() const {
+    return smart_proxy_calls_;
+  }
+
+  void WaitForNextConnectionStateCall() {
+    base::RunLoop loop;
+    connection_state_quit_ = loop.QuitClosure();
+    loop.Run();
+  }
+  void WaitForNextSelectedRegionCall() {
+    base::RunLoop loop;
+    selected_region_quit_ = loop.QuitClosure();
+    loop.Run();
+  }
+  void WaitForNextSmartProxyCall() {
+    base::RunLoop loop;
+    smart_proxy_quit_ = loop.QuitClosure();
+    loop.Run();
+  }
+#endif
+
+ private:
+  static void MaybeQuit(base::OnceClosure& quit) {
+    if (quit) {
+      std::move(quit).Run();
+    }
+  }
+
+  mojo::Receiver<mojom::ServiceObserver> receiver_{this};
+
+  std::vector<PurchasedStateCall> purchased_state_calls_;
+  base::OnceClosure purchased_state_quit_;
+
+#if !BUILDFLAG(IS_ANDROID)
+  std::vector<mojom::ConnectionState> connection_state_calls_;
+  std::vector<mojom::RegionPtr> selected_region_calls_;
+  std::vector<bool> smart_proxy_calls_;
+  base::OnceClosure connection_state_quit_;
+  base::OnceClosure selected_region_quit_;
+  base::OnceClosure smart_proxy_quit_;
+#endif
+};
+
+}  // namespace
+
+class BraveVpnServiceTest : public testing::Test {
+ public:
+  BraveVpnServiceTest() = default;
+  ~BraveVpnServiceTest() override = default;
+
+  void SetUp() override { service_ = std::make_unique<TestBraveVpnService>(); }
+
+  void TearDown() override { service_.reset(); }
+
+  TestBraveVpnService* service() { return service_.get(); }
+
+ protected:
+  base::test::SingleThreadTaskEnvironment task_environment_;
+  std::unique_ptr<TestBraveVpnService> service_;
+};
+
+// AddObserver should register the observer such that subsequent
+// NotifyPurchasedStateChanged calls reach it with the exact state and
+// description payload.
+TEST_F(BraveVpnServiceTest, AddObserverReceivesPurchasedStateNotification) {
+  TestServiceObserver observer;
+  service()->AddObserver(observer.BindAndGetRemote());
+
+  service()->NotifyPurchasedStateChanged(mojom::PurchasedState::PURCHASED,
+                                         "purchased-from-test");
+  observer.WaitForNextPurchasedStateCall();
+
+  ASSERT_EQ(observer.purchased_state_calls().size(), 1u);
+  EXPECT_EQ(observer.purchased_state_calls()[0].state,
+            mojom::PurchasedState::PURCHASED);
+  ASSERT_TRUE(observer.purchased_state_calls()[0].description.has_value());
+  EXPECT_EQ(*observer.purchased_state_calls()[0].description,
+            "purchased-from-test");
+}
+
+// The optional description argument should round-trip a std::nullopt value
+// unchanged (i.e. arrive at the observer as an empty optional, not an empty
+// string).
+TEST_F(BraveVpnServiceTest, PurchasedStateNotificationPreservesNullopt) {
+  TestServiceObserver observer;
+  service()->AddObserver(observer.BindAndGetRemote());
+
+  service()->NotifyPurchasedStateChanged(mojom::PurchasedState::NOT_PURCHASED,
+                                         std::nullopt);
+  observer.WaitForNextPurchasedStateCall();
+
+  ASSERT_EQ(observer.purchased_state_calls().size(), 1u);
+  EXPECT_EQ(observer.purchased_state_calls()[0].state,
+            mojom::PurchasedState::NOT_PURCHASED);
+  EXPECT_FALSE(observer.purchased_state_calls()[0].description.has_value());
+}
+
+// All registered observers should fan-out receive notifications.
+TEST_F(BraveVpnServiceTest, NotificationFansOutToAllObservers) {
+  TestServiceObserver observer1;
+  TestServiceObserver observer2;
+  TestServiceObserver observer3;
+
+  service()->AddObserver(observer1.BindAndGetRemote());
+  service()->AddObserver(observer2.BindAndGetRemote());
+  service()->AddObserver(observer3.BindAndGetRemote());
+
+  service()->NotifyPurchasedStateChanged(mojom::PurchasedState::PURCHASED,
+                                         std::nullopt);
+
+  observer1.WaitForNextPurchasedStateCall();
+  observer2.WaitForNextPurchasedStateCall();
+  observer3.WaitForNextPurchasedStateCall();
+
+  EXPECT_EQ(observer1.purchased_state_calls().size(), 1u);
+  EXPECT_EQ(observer2.purchased_state_calls().size(), 1u);
+  EXPECT_EQ(observer3.purchased_state_calls().size(), 1u);
+}
+
+// When an observer's mojo pipe is closed, the service should drop it from the
+// RemoteSet and stop delivering notifications to it, while continuing to
+// deliver to the remaining live observers.
+TEST_F(BraveVpnServiceTest, DisconnectedObserverStopsReceivingNotifications) {
+  TestServiceObserver observer1;
+  TestServiceObserver observer2;
+  service()->AddObserver(observer1.BindAndGetRemote());
+  service()->AddObserver(observer2.BindAndGetRemote());
+
+  // Close observer1's end of the pipe. Regardless of whether the RemoteSet
+  // has processed the disconnect by the time we notify, mojo drops messages
+  // sent on a Remote whose receiver is gone, so observer1 cannot be reached.
+  observer1.ResetReceiver();
+
+  service()->NotifyPurchasedStateChanged(mojom::PurchasedState::PURCHASED,
+                                         std::nullopt);
+  observer2.WaitForNextPurchasedStateCall();
+
+  EXPECT_TRUE(observer1.purchased_state_calls().empty());
+  EXPECT_EQ(observer2.purchased_state_calls().size(), 1u);
+}
+
+// Shutdown must clear all registered observers so that subsequent notifies
+// become no-ops. (This holds on every platform.)
+TEST_F(BraveVpnServiceTest, ShutdownClearsObservers) {
+  TestServiceObserver observer;
+  service()->AddObserver(observer.BindAndGetRemote());
+
+  // Shutdown destroys every Remote in the RemoteSet, closing each pipe. The
+  // receiver on the other end then observes a disconnect — use that callback
+  // as our explicit "Shutdown has fully propagated" signal.
+  base::RunLoop disconnect_loop;
+  observer.set_disconnect_handler(disconnect_loop.QuitClosure());
+
+  service()->Shutdown();
+  disconnect_loop.Run();
+
+  // observers_ was cleared synchronously by Shutdown, so this notify finds an
+  // empty set and is a no-op — no message is ever placed on any pipe.
+  service()->NotifyPurchasedStateChanged(mojom::PurchasedState::PURCHASED,
+                                         std::nullopt);
+
+  EXPECT_TRUE(observer.purchased_state_calls().empty());
+}
+
+// BindInterface should let a caller drive the service over a real mojo pipe;
+// AddObserver invoked on that remote must reach the underlying service.
+TEST_F(BraveVpnServiceTest, BindInterfaceAcceptsRemoteAddObserverCall) {
+  mojo::Remote<mojom::ServiceHandler> handler_remote;
+  service()->BindInterface(handler_remote.BindNewPipeAndPassReceiver());
+
+  TestServiceObserver observer;
+  handler_remote->AddObserver(observer.BindAndGetRemote());
+  handler_remote.FlushForTesting();
+
+  service()->NotifyPurchasedStateChanged(mojom::PurchasedState::PURCHASED,
+                                         std::nullopt);
+  observer.WaitForNextPurchasedStateCall();
+
+  EXPECT_EQ(observer.purchased_state_calls().size(), 1u);
+}
+
+// BindInterface should support multiple independent receivers, and a single
+// notify call must reach observers added through any of them.
+TEST_F(BraveVpnServiceTest, BindInterfaceSupportsMultipleReceivers) {
+  mojo::Remote<mojom::ServiceHandler> remote_a;
+  mojo::Remote<mojom::ServiceHandler> remote_b;
+  service()->BindInterface(remote_a.BindNewPipeAndPassReceiver());
+  service()->BindInterface(remote_b.BindNewPipeAndPassReceiver());
+
+  TestServiceObserver observer_a;
+  TestServiceObserver observer_b;
+  remote_a->AddObserver(observer_a.BindAndGetRemote());
+  remote_b->AddObserver(observer_b.BindAndGetRemote());
+  remote_a.FlushForTesting();
+  remote_b.FlushForTesting();
+
+  service()->NotifyPurchasedStateChanged(mojom::PurchasedState::PURCHASED,
+                                         std::nullopt);
+  observer_a.WaitForNextPurchasedStateCall();
+  observer_b.WaitForNextPurchasedStateCall();
+
+  EXPECT_EQ(observer_a.purchased_state_calls().size(), 1u);
+  EXPECT_EQ(observer_b.purchased_state_calls().size(), 1u);
+}
+
+#if !BUILDFLAG(IS_ANDROID)
+
+// Connection-state changes must propagate the exact enum value to observers.
+TEST_F(BraveVpnServiceTest, NotifyConnectionStateChangedDeliversState) {
+  TestServiceObserver observer;
+  service()->AddObserver(observer.BindAndGetRemote());
+
+  service()->NotifyConnectionStateChanged(mojom::ConnectionState::CONNECTED);
+  observer.WaitForNextConnectionStateCall();
+
+  service()->NotifyConnectionStateChanged(mojom::ConnectionState::DISCONNECTED);
+  observer.WaitForNextConnectionStateCall();
+
+  ASSERT_EQ(observer.connection_state_calls().size(), 2u);
+  EXPECT_EQ(observer.connection_state_calls()[0],
+            mojom::ConnectionState::CONNECTED);
+  EXPECT_EQ(observer.connection_state_calls()[1],
+            mojom::ConnectionState::DISCONNECTED);
+}
+
+// NotifySelectedRegionChanged should deliver region data to observers and must
+// clone (rather than consume) the region for each observer, so multiple
+// observers all receive a non-null region. If the implementation were to
+// std::move() instead of Clone() inside the loop, the second observer would
+// receive a null RegionPtr and this test would fail.
+TEST_F(BraveVpnServiceTest, NotifySelectedRegionChangedClonesPerObserver) {
+  TestServiceObserver observer1;
+  TestServiceObserver observer2;
+  service()->AddObserver(observer1.BindAndGetRemote());
+  service()->AddObserver(observer2.BindAndGetRemote());
+
+  auto region = mojom::Region::New();
+  service()->NotifySelectedRegionChanged(std::move(region));
+
+  observer1.WaitForNextSelectedRegionCall();
+  observer2.WaitForNextSelectedRegionCall();
+
+  ASSERT_EQ(observer1.selected_region_calls().size(), 1u);
+  ASSERT_EQ(observer2.selected_region_calls().size(), 1u);
+  EXPECT_TRUE(observer1.selected_region_calls()[0]);
+  EXPECT_TRUE(observer2.selected_region_calls()[0]);
+}
+
+// Smart-proxy routing state changes should propagate the boolean unchanged in
+// both directions.
+TEST_F(BraveVpnServiceTest,
+       NotifySmartProxyRoutingStateChangedDeliversBothStates) {
+  TestServiceObserver observer;
+  service()->AddObserver(observer.BindAndGetRemote());
+
+  service()->NotifySmartProxyRoutingStateChanged(true);
+  observer.WaitForNextSmartProxyCall();
+  service()->NotifySmartProxyRoutingStateChanged(false);
+  observer.WaitForNextSmartProxyCall();
+
+  ASSERT_EQ(observer.smart_proxy_calls().size(), 2u);
+  EXPECT_TRUE(observer.smart_proxy_calls()[0]);
+  EXPECT_FALSE(observer.smart_proxy_calls()[1]);
+}
+
+// On desktop, Shutdown clears bound receivers, which must disconnect the
+// remote on the other end of the pipe.
+TEST_F(BraveVpnServiceTest, ShutdownDisconnectsReceiversOnDesktop) {
+  mojo::Remote<mojom::ServiceHandler> handler_remote;
+  service()->BindInterface(handler_remote.BindNewPipeAndPassReceiver());
+  handler_remote.FlushForTesting();
+  ASSERT_TRUE(handler_remote.is_connected());
+
+  base::RunLoop disconnect_loop;
+  handler_remote.set_disconnect_handler(disconnect_loop.QuitClosure());
+
+  service()->Shutdown();
+  disconnect_loop.Run();
+
+  EXPECT_FALSE(handler_remote.is_connected());
+}
+
+#else  // BUILDFLAG(IS_ANDROID)
+
+// MakeRemote returns a fresh PendingRemote whose receiver end is registered
+// with the service, so calls on it must reach the service.
+TEST_F(BraveVpnServiceTest, MakeRemoteProducesUsableHandler) {
+  mojo::Remote<mojom::ServiceHandler> handler_remote(service()->MakeRemote());
+  handler_remote.FlushForTesting();
+  ASSERT_TRUE(handler_remote.is_connected());
+
+  TestServiceObserver observer;
+  handler_remote->AddObserver(observer.BindAndGetRemote());
+  handler_remote.FlushForTesting();
+
+  service()->NotifyPurchasedStateChanged(mojom::PurchasedState::PURCHASED,
+                                         std::nullopt);
+  observer.WaitForNextPurchasedStateCall();
+
+  EXPECT_EQ(observer.purchased_state_calls().size(), 1u);
+}
+
+#endif  // !BUILDFLAG(IS_ANDROID)
+
+}  // namespace brave_vpn

--- a/components/brave_vpn/browser/connection/brave_vpn_connection_manager.h
+++ b/components/brave_vpn/browser/connection/brave_vpn_connection_manager.h
@@ -104,9 +104,14 @@ class BraveVPNConnectionManager {
     target_vpn_entry_name_ = name;
   }
 
+  void SetConnectionStateForTesting(mojom::ConnectionState state) {
+    DCHECK(connection_api_impl_);
+    connection_api_impl_->UpdateAndNotifyConnectionStateChange(state);
+  }
+
  private:
   friend class BraveVpnButtonUnitTest;
-  friend class BraveVPNServiceTest;
+  friend class BraveVpnServiceImplV1Test;
   friend class BraveVPNWireguardConnectionAPIUnitTest;
   friend class SystemVPNConnectionAPIUnitTest;
   FRIEND_TEST_ALL_PREFIXES(BraveVPNWireguardConnectionAPIUnitTest,

--- a/components/brave_vpn/browser/connection/brave_vpn_region_data_manager.h
+++ b/components/brave_vpn/browser/connection/brave_vpn_region_data_manager.h
@@ -51,7 +51,7 @@ class BraveVPNRegionDataManager {
   std::string GetRegionPrecisionForName(const std::string& name) const;
 
  private:
-  friend class BraveVPNServiceTest;
+  friend class BraveVpnServiceImplV1Test;
   friend class SystemVPNConnectionAPIUnitTest;
 
   std::string GetCountryRegionNameFrom(const std::string& country_iso) const;

--- a/components/brave_vpn/browser/connection/connection_api_impl.cc
+++ b/components/brave_vpn/browser/connection/connection_api_impl.cc
@@ -201,9 +201,4 @@ void ConnectionAPIImpl::UpdateAndNotifyConnectionStateChange(
   manager_->NotifyConnectionStateChanged(connection_state_);
 }
 
-void ConnectionAPIImpl::SetConnectionStateForTesting(
-    mojom::ConnectionState state) {
-  UpdateAndNotifyConnectionStateChange(state);
-}
-
 }  // namespace brave_vpn

--- a/components/brave_vpn/browser/connection/connection_api_impl.h
+++ b/components/brave_vpn/browser/connection/connection_api_impl.h
@@ -82,8 +82,6 @@ class ConnectionAPIImpl
   const raw_ref<BraveVPNConnectionManager> manager_;  // owner
 
  private:
-  friend class BraveVpnButtonUnitTest;
-  friend class BraveVPNServiceTest;
   FRIEND_TEST_ALL_PREFIXES(SystemVPNConnectionAPIUnitTest, NeedsConnectTest);
   FRIEND_TEST_ALL_PREFIXES(SystemVPNConnectionAPIUnitTest, HostnamesTest);
   FRIEND_TEST_ALL_PREFIXES(SystemVPNConnectionAPIUnitTest, ConnectionInfoTest);
@@ -99,8 +97,6 @@ class ConnectionAPIImpl
                            CreateOSVPNEntryWithInvalidInfoTest);
   FRIEND_TEST_ALL_PREFIXES(BraveVPNWireguardConnectionAPIUnitTest,
                            SetSelectedRegion);
-
-  void SetConnectionStateForTesting(mojom::ConnectionState state);
 
   std::unique_ptr<Hostname> hostname_;
   std::string last_connection_error_;

--- a/components/brave_vpn/browser/connection/ikev2/system_vpn_connection_api_unittest.cc
+++ b/components/brave_vpn/browser/connection/ikev2/system_vpn_connection_api_unittest.cc
@@ -590,7 +590,8 @@ TEST_F(SystemVPNConnectionAPIUnitTest,
        IgnoreDisconnectedStateWhileConnecting) {
   auto* test_api = GetConnectionAPI();
 
-  test_api->SetConnectionStateForTesting(mojom::ConnectionState::CONNECTING);
+  test_api->UpdateAndNotifyConnectionStateChange(
+      mojom::ConnectionState::CONNECTING);
   test_api->UpdateAndNotifyConnectionStateChange(
       mojom::ConnectionState::DISCONNECTED);
   EXPECT_EQ(mojom::ConnectionState::CONNECTING, test_api->GetConnectionState());


### PR DESCRIPTION
To add a new BraveVPNService implementation based on Architecture 2.0, which must co-exist with Architecture 1.0 for quite a while, we need to split service's interface and implementation. All the external components will keep accessing VPN service via the BraveVPNService interface, but the implementation mostly goes into BraveVPNServiceImpl.

BraveVPNService is a concrete base that implements bookkeeping shared by both architectures: mojo remote creation and observer management. The lion's share of functionality is kept in the implementation; if it becomes duplicated eventually, we can move it to the base later.

This change is a preparatory step to introduce the second (Arch 2.0) implementation of BraveVPNServiceImpl, which could be selected at compile time, or (later) at runtime too.

**There are no changes to Brave VPN logic, only code restructuring**

Other notable changes:
- Revised and moved the public VPN service API to BraveVPNService.
- BraveVPNService base is comprehensively covered by unit tests.
- Minor refactoring of unit test APIs to reduce dependencies.
- Removed a BraveVpnMetrics::Delegate method dependency in external components.

Implements part of https://github.com/brave/brave-browser/issues/54597

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
