### PR TITLE
[iOS][Wallet] Display warnings for more eth sign typed data

### DIFF
--- a/ios/brave-ios/Sources/BraveWallet/Extensions/BraveWalletExtensions.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Extensions/BraveWalletExtensions.swift
@@ -859,3 +859,38 @@ extension BraveWallet.MeldCryptoCurrency {
     }
   }
 }
+
+extension BraveWallet.SignDataUnion {
+  var isWarningsNeeded: Bool {
+    if cardanoSignData != nil { return true }
+    if let ethSignTypedData {
+      let permitLikeTypes: [String] = [
+        "Permit",
+        "PermitSingle",
+        "PermitBatch",
+        "PermitTransferFrom",
+        "PermitWitnessTransferFrom",
+      ]
+      return permitLikeTypes.contains(ethSignTypedData.primaryType)
+        || ethSignTypedData.hasPermitShape
+    }
+    return false
+  }
+}
+
+extension BraveWallet.EthSignTypedData {
+  var hasPermitShape: Bool {
+    guard
+      let data = self.typesJson.data(using: .utf8),
+      let typeMap = try? JSONDecoder().decode([String: [[String: String]]].self, from: data),
+      let fields = typeMap[primaryType]
+    else { return false }
+    let fieldNames = Set(fields.compactMap { $0["name"] })
+    return fieldNames.contains("spender")
+      && (fieldNames.contains("value")
+        || fieldNames.contains("amount")
+        || fields.contains(where: {
+          ["PermitDetails", "PermitDetails[]", "TokenPermissions"].contains($0["type"])
+        }))
+  }
+}

--- a/ios/brave-ios/Sources/BraveWallet/Extensions/BraveWalletExtensions.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Extensions/BraveWalletExtensions.swift
@@ -871,6 +871,9 @@ extension BraveWallet.SignDataUnion {
 }
 
 extension BraveWallet.EthSignTypedData {
+  /// Uniswap Permit2 contract address
+  private static let permit2Address = "0x000000000022D473030F116DDeE9F6b43ac78BA3"
+
   private static let permitLikePrimaryTypes: [String] = [
     // ERC-2612 and DAI-style
     "Permit",
@@ -891,6 +894,10 @@ extension BraveWallet.EthSignTypedData {
   private struct TypedDataField: Decodable {
     let name: String
     let type: String
+  }
+
+  private struct EIP712Domain: Decodable {
+    let verifyingContract: String?
   }
 
   private static func fieldsMatchPermitShape(_ fields: [TypedDataField]) -> Bool {
@@ -918,6 +925,9 @@ extension BraveWallet.EthSignTypedData {
     return isPermitStyle || isDaiStyle || isAuthorizationStyle
   }
 
+  /// Returns true if any named type (across the entire type map, not just
+  /// `primaryType`) has a permit-like field shape. This catches smuggled
+  /// permits where a benign `primaryType` wraps a nested permit struct.
   private var hasPermitShape: Bool {
     guard let data = typesJson.data(using: .utf8),
       let types = try? JSONDecoder().decode([String: [TypedDataField]].self, from: data)
@@ -927,7 +937,18 @@ extension BraveWallet.EthSignTypedData {
     })
   }
 
+  /// Returns true if the domain's `verifyingContract` is the well-known
+  /// Uniswap Permit2 address, catching any interaction with that contract
+  /// regardless of the type structure used.
+  private var isPermit2Domain: Bool {
+    guard let data = domainJson.data(using: .utf8),
+      let domain = try? JSONDecoder().decode(EIP712Domain.self, from: data),
+      let verifyingContract = domain.verifyingContract
+    else { return false }
+    return verifyingContract.caseInsensitiveCompare(Self.permit2Address) == .orderedSame
+  }
+
   var isPermitLike: Bool {
-    Self.permitLikePrimaryTypes.contains(primaryType) || hasPermitShape
+    Self.permitLikePrimaryTypes.contains(primaryType) || hasPermitShape || isPermit2Domain
   }
 }

--- a/ios/brave-ios/Sources/BraveWallet/Extensions/BraveWalletExtensions.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Extensions/BraveWalletExtensions.swift
@@ -864,33 +864,70 @@ extension BraveWallet.SignDataUnion {
   var isWarningsNeeded: Bool {
     if cardanoSignData != nil { return true }
     if let ethSignTypedData {
-      let permitLikeTypes: [String] = [
-        "Permit",
-        "PermitSingle",
-        "PermitBatch",
-        "PermitTransferFrom",
-        "PermitWitnessTransferFrom",
-      ]
-      return permitLikeTypes.contains(ethSignTypedData.primaryType)
-        || ethSignTypedData.hasPermitShape
+      return ethSignTypedData.isPermitLike
     }
     return false
   }
 }
 
 extension BraveWallet.EthSignTypedData {
-  var hasPermitShape: Bool {
-    guard
-      let data = self.typesJson.data(using: .utf8),
-      let typeMap = try? JSONDecoder().decode([String: [[String: String]]].self, from: data),
-      let fields = typeMap[primaryType]
-    else { return false }
-    let fieldNames = Set(fields.compactMap { $0["name"] })
-    return fieldNames.contains("spender")
-      && (fieldNames.contains("value")
-        || fieldNames.contains("amount")
+  private static let permitLikePrimaryTypes: [String] = [
+    // ERC-2612 and DAI-style
+    "Permit",
+    // Uniswap Permit2 (AllowanceTransfer)
+    "PermitSingle",
+    "PermitBatch",
+    // Uniswap Permit2 (SignatureTransfer)
+    "PermitTransferFrom",
+    "PermitBatchTransferFrom",
+    "PermitWitnessTransferFrom",
+    "PermitBatchWitnessTransferFrom",
+    // EIP-3009 (USDC and for x402 support)
+    "TransferWithAuthorization",
+    "ReceiveWithAuthorization",
+    "CancelAuthorization",
+  ]
+
+  private struct TypedDataField: Decodable {
+    let name: String
+    let type: String
+  }
+
+  private static func fieldsMatchPermitShape(_ fields: [TypedDataField]) -> Bool {
+    let names = Set(fields.map(\.name))
+
+    let isPermitStyle =
+      names.contains("spender")
+      && (names.contains("value")
+        || names.contains("amount")
         || fields.contains(where: {
-          ["PermitDetails", "PermitDetails[]", "TokenPermissions"].contains($0["type"])
+          $0.type == "PermitDetails" || $0.type == "PermitDetails[]"
+            || $0.type == "TokenPermissions" || $0.type == "TokenPermissions[]"
         }))
+
+    let isDaiStyle =
+      names.contains("spender")
+      && names.contains("allowed")
+      && fields.contains(where: { $0.name == "allowed" && $0.type == "bool" })
+
+    let isAuthorizationStyle =
+      names.contains("from") && names.contains("to") && names.contains("value")
+      && names.contains("validAfter") && names.contains("validBefore")
+      && names.contains("nonce")
+
+    return isPermitStyle || isDaiStyle || isAuthorizationStyle
+  }
+
+  private var hasPermitShape: Bool {
+    guard let data = typesJson.data(using: .utf8),
+      let types = try? JSONDecoder().decode([String: [TypedDataField]].self, from: data)
+    else { return false }
+    return types.contains(where: { typeName, fields in
+      typeName != "EIP712Domain" && Self.fieldsMatchPermitShape(fields)
+    })
+  }
+
+  var isPermitLike: Bool {
+    Self.permitLikePrimaryTypes.contains(primaryType) || hasPermitShape
   }
 }

--- a/ios/brave-ios/Sources/BraveWallet/Panels/SignatureRequest/SignMessageRequestView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Panels/SignatureRequest/SignMessageRequestView.swift
@@ -127,9 +127,7 @@ struct SignMessageRequestView: View {
     }
     .navigationTitle(Strings.Wallet.signatureRequestTitle)
     .onAppear {
-      isWarningShown =
-        (request.signData.cardanoSignData != nil)
-        || request.signData.ethSignTypedData?.primaryType == "Permit"
+      isWarningShown = request.signData.isWarningsNeeded
     }
   }
 


### PR DESCRIPTION
No strict check on `primaryType` but check both `primaryType` and the shape of `EthSignTypedData .typesJson`

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/internal/issues/1733

Test:
1. visit PoC dApp: https://syarif07.my.id/wallet/permit.html
2. connect the dApp with wallet
3. tap each Test 1 to Test 6
4. each test will ask for sign 
5. verify the sign request screen shows warnings


https://github.com/user-attachments/assets/05acf71e-d179-4e67-babb-63ef7ce39610

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
