### PR TITLE
Refactor non-client hit test helper for extensibility

### DIFF
--- a/browser/ui/browser_window/internal/browser_window_features.cc
+++ b/browser/ui/browser_window/internal/browser_window_features.cc
@@ -14,6 +14,7 @@
 #include "brave/browser/ui/sidebar/sidebar_controller.h"
 #include "brave/browser/ui/sidebar/sidebar_utils.h"
 #include "brave/browser/ui/tabs/brave_browser_tab_menu_model_delegate.h"
+#include "brave/browser/ui/views/frame/brave_non_client_hit_test_helper.h"
 #include "brave/browser/ui/views/page_info/brave_shields_ui_contents_cache.h"
 #include "brave/components/brave_rewards/core/buildflags/buildflags.h"
 #include "brave/components/brave_vpn/common/buildflags/buildflags.h"
@@ -97,6 +98,9 @@ void BrowserWindowFeatures::Init(BrowserWindowInterface* browser) {
           browser->GetSessionID(), profile, app_browser_controller_.get(),
           tab_groups::TabGroupSyncServiceFactory::GetForProfile(profile),
           browser);
+
+  brave_non_client_hit_test_helper_ =
+      std::make_unique<BraveNonClientHitTestHelper>();
 }
 
 void BrowserWindowFeatures::InitPostBrowserViewConstruction(

--- a/browser/ui/browser_window/public/browser_window_features.h
+++ b/browser/ui/browser_window/public/browser_window_features.h
@@ -12,6 +12,7 @@
 #include "brave/components/playlist/core/common/buildflags/buildflags.h"
 
 class BraveShieldsUIContentsCache;
+class BraveNonClientHitTestHelper;
 class BraveVPNController;
 class FocusModeController;
 class PlaylistSidePanelCoordinator;
@@ -76,6 +77,10 @@ class BrowserWindowFeatures : public BrowserWindowFeatures_ChromiumImpl {
     return brave_shields_ui_contents_cache_.get();
   }
 
+  BraveNonClientHitTestHelper* brave_non_client_hit_test_helper() {
+    return brave_non_client_hit_test_helper_.get();
+  }
+
  private:
   std::unique_ptr<sidebar::SidebarController> sidebar_controller_;
   std::unique_ptr<BraveVPNController> brave_vpn_controller_;
@@ -91,6 +96,8 @@ class BrowserWindowFeatures : public BrowserWindowFeatures_ChromiumImpl {
 #endif
   std::unique_ptr<FocusModeController> focus_mode_controller_;
   std::unique_ptr<BraveShieldsUIContentsCache> brave_shields_ui_contents_cache_;
+  std::unique_ptr<BraveNonClientHitTestHelper>
+      brave_non_client_hit_test_helper_;
 };
 
 #endif  // BRAVE_BROWSER_UI_BROWSER_WINDOW_PUBLIC_BROWSER_WINDOW_FEATURES_H_

--- a/browser/ui/views/frame/brave_browser_frame_view_mac.mm
+++ b/browser/ui/views/frame/brave_browser_frame_view_mac.mm
@@ -14,6 +14,7 @@
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/browser_window/public/browser_window_features.h"
 #include "chrome/browser/ui/fullscreen_util_mac.h"
 #include "chrome/browser/ui/layout_constants.h"
 #include "chrome/browser/ui/tabs/features.h"
@@ -158,9 +159,13 @@ int BraveBrowserFrameViewMac::NonClientHitTest(const gfx::Point& point) {
   // widget, violating brave::NonClientHitTest's precondition that the toolbar
   // and browser view share the same widget. Skip it while immersive mode is
   // active.
-  if (!ImmersiveModeController::From(GetBrowserView()->browser())
-           ->IsEnabled()) {
-    if (auto res = brave::NonClientHitTest(GetBrowserView(), point);
+  auto* browser_view = GetBrowserView();
+  auto* browser = browser_view->browser();
+  if (!ImmersiveModeController::From(browser)->IsEnabled()) {
+    auto* non_client_hit_test_helper =
+        browser->browser_window_features()->brave_non_client_hit_test_helper();
+    if (auto res =
+            non_client_hit_test_helper->NonClientHitTest(browser_view, point);
         res != HTNOWHERE) {
       return res;
     }

--- a/browser/ui/views/frame/brave_browser_frame_view_win.cc
+++ b/browser/ui/views/frame/brave_browser_frame_view_win.cc
@@ -118,7 +118,10 @@ int BraveBrowserFrameViewWin::NonClientHitTest(const gfx::Point& point) {
     }
   }
 
-  if (auto overridden_result = brave::NonClientHitTest(GetBrowserView(), point);
+  auto* browser = GetBrowserView()->browser();
+  if (auto overridden_result = browser->browser_window_features()
+                                   ->brave_non_client_hit_test_helper()
+                                   ->NonClientHitTest(GetBrowserView(), point);
       overridden_result != HTNOWHERE) {
     return overridden_result;
   }

--- a/browser/ui/views/frame/brave_non_client_hit_test_helper.cc
+++ b/browser/ui/views/frame/brave_non_client_hit_test_helper.cc
@@ -5,45 +5,63 @@
 
 #include "brave/browser/ui/views/frame/brave_non_client_hit_test_helper.h"
 
+#include "base/check_deref.h"
 #include "base/check_op.h"
-#include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
-#include "chrome/browser/ui/views/toolbar/toolbar_view.h"
 #include "ui/base/hit_test.h"
 #include "ui/views/window/hit_test_utils.h"
 
-namespace brave {
+BraveNonClientHitTestHelper::BraveNonClientHitTestHelper() = default;
+BraveNonClientHitTestHelper::~BraveNonClientHitTestHelper() = default;
 
-int NonClientHitTest(BrowserView* browser_view,
-                     const gfx::Point& point_in_widget) {
+int BraveNonClientHitTestHelper::NonClientHitTest(
+    BrowserView* browser_view,
+    const gfx::Point& point_in_widget) {
   if (!browser_view) {
     return HTNOWHERE;
   }
 
-  if (!browser_view->toolbar() || !browser_view->toolbar()->GetVisible()) {
+  auto get_hit_test_component = [&](const raw_ptr<views::View>& view) {
+    if (!CHECK_DEREF(view).GetVisible()) {
+      return HTNOWHERE;
+    }
+
+    // The view must live in the same widget as the browser view to make
+    // this method work properly. If it has been reparented to a different
+    // widget (e.g. overlay_widget_ during macOS immersive fullscreen),
+    // GetHitTestComponent() will convert |point_in_widget| using the wrong
+    // widget's coordinate space, producing spurious HTCAPTION results.
+    // Callers must guard against this before calling NonClientHitTest().
+    CHECK_EQ(view->GetWidget(), browser_view->GetWidget());
+
+#if BUILDFLAG(IS_WIN)
+    auto hit_test_result = views::GetHitTestComponent(view, point_in_widget);
+#else
+    HitTestCompat hit_test_result = static_cast<HitTestCompat>(
+        views::GetHitTestComponent(view, point_in_widget));
+#endif
+
+    if (hit_test_result == HTNOWHERE || hit_test_result == HTCLIENT) {
+      // The |point_in_widget| is out of toolbar or on toolbar's sub views.
+      return hit_test_result;
+    }
+
+    return HTCAPTION;
+  };
+
+  // Find if any view returned HTCAPTION
+  auto caption_view =
+      std::ranges::find_if(observation_.sources(), [&](const auto& view) {
+        return get_hit_test_component(view) == HTCAPTION;
+      });
+
+  if (caption_view == observation_.sources().end()) {
     return HTNOWHERE;
   }
 
-  // The toolbar must live in the same widget as the browser view to make
-  // this method work properly. If it has been reparented to a different widget
-  // (e.g. overlay_widget_ during macOS immersive fullscreen),
-  // GetHitTestComponent() will convert |point_in_widget| using the wrong
-  // widget's coordinate space, producing spurious HTCAPTION results. Callers
-  // must guard against this before calling NonClientHitTest().
-  CHECK_EQ(browser_view->toolbar()->GetWidget(), browser_view->GetWidget());
-
-  int hit_test_result =
-      views::GetHitTestComponent(browser_view->toolbar(), point_in_widget);
-  if (hit_test_result == HTNOWHERE || hit_test_result == HTCLIENT) {
-    // The |point_in_widget| is out of toolbar or on toolbar's sub views.
-    return hit_test_result;
-  }
-
-  DCHECK_EQ(hit_test_result, HTCAPTION);
-  // Users are interacting with empty area in toolbar. Check if the area should
-  // be resize area for the window.
+  // Now we check if HTCAPTION is considered as resize area for the window
   if (!browser_view->CanResize()) {
-    return hit_test_result;
+    return HTCAPTION;
   }
 
   constexpr int kResizableArea = 8;
@@ -52,22 +70,16 @@ int NonClientHitTest(BrowserView* browser_view,
   auto non_resizable_area = widget_bounds;
   non_resizable_area.Inset(kResizableArea);
   if (non_resizable_area.Contains(point_in_widget)) {
-    return hit_test_result;
-  }
-
-  // Below checking is only for dragging with tab when vertical tab is
-  // enabled and title is hidden.
-  if (!tabs::utils::ShouldShowBraveVerticalTabs(browser_view->browser())) {
-    return HTNOWHERE;
+    return HTCAPTION;
   }
 
   // Don't need to give resize area when maximized.
   // Having resize area prevents window dragging by grab top border.
   if (browser_view->IsMaximized()) {
-    return hit_test_result;
+    return HTCAPTION;
   }
 
-  // Now we have only resizable areas.
+  // Now we check if the point is which side of resize area.
   if (point_in_widget.x() <= kResizableArea &&
       point_in_widget.y() <= kResizableArea) {
     return HTTOPLEFT;
@@ -85,4 +97,20 @@ int NonClientHitTest(BrowserView* browser_view,
   return HTNOWHERE;
 }
 
-}  // namespace brave
+void BraveNonClientHitTestHelper::RegisterCaptionArea(views::View* view) {
+  views::SetHitTestComponent(view, HTCAPTION);
+  observation_.AddObservation(view);
+
+  for (auto& child : view->children()) {
+    OnChildViewAdded(view, child);
+  }
+}
+
+void BraveNonClientHitTestHelper::OnChildViewAdded(views::View* observed_view,
+                                                   views::View* child) {
+  views::SetHitTestComponent(child, HTCLIENT);
+}
+
+void BraveNonClientHitTestHelper::OnViewIsDeleting(views::View* observed_view) {
+  observation_.RemoveObservation(observed_view);
+}

--- a/browser/ui/views/frame/brave_non_client_hit_test_helper.h
+++ b/browser/ui/views/frame/brave_non_client_hit_test_helper.h
@@ -6,20 +6,42 @@
 #ifndef BRAVE_BROWSER_UI_VIEWS_FRAME_BRAVE_NON_CLIENT_HIT_TEST_HELPER_H_
 #define BRAVE_BROWSER_UI_VIEWS_FRAME_BRAVE_NON_CLIENT_HIT_TEST_HELPER_H_
 
+#include "base/scoped_multi_source_observation.h"
+#include "ui/views/view_observer.h"
+
 namespace gfx {
 class Point;
 }  // namespace gfx
 
+namespace views {
+class View;
+}  // namespace views
+
 class BrowserView;
 
-namespace brave {
+// Helper class to set additional draggable area in client view.
+// Returns HTNOWHERE if the point is not what we're interested in.
+class BraveNonClientHitTestHelper : public views::ViewObserver {
+ public:
+  BraveNonClientHitTestHelper();
+  ~BraveNonClientHitTestHelper() override;
 
-// Helper function to set additional draggable area in client view.
-// Returns HTNOWHERE if the point is not what we're interested in. In that
-// case, caller should depend on the default behavior.
-int NonClientHitTest(BrowserView* browser_view,
-                     const gfx::Point& point_in_widget);
+  int NonClientHitTest(BrowserView* browser_view,
+                       const gfx::Point& point_in_widget);
 
-}  // namespace brave
+  // Calling this will register the given `view` as a caption area so that users
+  // can drag the window by dragging the view. Note that the children of the
+  // given `view` will not be considered as caption areas.
+  void RegisterCaptionArea(views::View* view);
+
+  // views::ViewObserver:
+  void OnChildViewAdded(views::View* observed_view,
+                        views::View* child) override;
+  void OnViewIsDeleting(views::View* observed_view) override;
+
+ private:
+  base::ScopedMultiSourceObservation<views::View, views::ViewObserver>
+      observation_{this};
+};
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_FRAME_BRAVE_NON_CLIENT_HIT_TEST_HELPER_H_

--- a/browser/ui/views/frame/brave_opaque_browser_frame_view.cc
+++ b/browser/ui/views/frame/brave_opaque_browser_frame_view.cc
@@ -72,7 +72,11 @@ int BraveOpaqueBrowserFrameView::NonClientHitTest(const gfx::Point& point) {
     }
   }
 
-  if (auto res = brave::NonClientHitTest(GetBrowserView(), point);
+  if (auto res = GetBrowserView()
+                     ->browser()
+                     ->browser_window_features()
+                     ->brave_non_client_hit_test_helper()
+                     ->NonClientHitTest(GetBrowserView(), point);
       res != HTNOWHERE) {
     return res;
   }

--- a/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.cc
@@ -49,6 +49,7 @@
 #include "chrome/grit/generated_resources.h"
 #include "components/prefs/pref_service.h"
 #include "ui/base/cursor/cursor.h"
+#include "ui/base/hit_test.h"
 #include "ui/base/l10n/l10n_util.h"
 #include "ui/base/metadata/metadata_impl_macros.h"
 #include "ui/compositor/compositor.h"
@@ -68,6 +69,7 @@
 #include "ui/views/layout/flex_layout.h"
 #include "ui/views/layout/layout_types.h"
 #include "ui/views/view_utils.h"
+#include "ui/views/window/hit_test_utils.h"
 
 #if BUILDFLAG(IS_WIN)
 #include "ui/views/win/hwnd_util.h"

--- a/browser/ui/views/toolbar/brave_toolbar_view.cc
+++ b/browser/ui/views/toolbar/brave_toolbar_view.cc
@@ -10,6 +10,7 @@
 #include <utility>
 
 #include "base/check.h"
+#include "base/check_deref.h"
 #include "base/check_op.h"
 #include "base/functional/bind.h"
 #include "base/i18n/rtl.h"
@@ -17,6 +18,7 @@
 #include "brave/app/vector_icons/vector_icons.h"
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
 #include "brave/browser/ui/views/frame/brave_browser_view.h"
+#include "brave/browser/ui/views/frame/brave_non_client_hit_test_helper.h"
 #include "brave/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.h"
 #include "brave/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_widget_delegate_view.h"
 #include "brave/browser/ui/views/location_bar/brave_location_bar_view.h"
@@ -195,7 +197,10 @@ void BraveToolbarView::Init() {
 
   // This will allow us to move this window by dragging toolbar.
   // See brave_non_client_hit_test_helper.h
-  views::SetHitTestComponent(this, HTCAPTION);
+  CHECK_DEREF(browser())
+      .browser_window_features()
+      ->brave_non_client_hit_test_helper()
+      ->RegisterCaptionArea(this);
 
   // For non-normal mode, we don't have to do any more work.
   if (display_mode_ != DisplayMode::kNormal) {
@@ -525,17 +530,6 @@ void BraveToolbarView::VisibilityChanged(views::View* starting_from,
   if (visible) {
     // Ink drop highlight is cleared whenever visibility changes, so re-apply.
     UpdateVerticalTabToggleState();
-  }
-}
-
-void BraveToolbarView::ViewHierarchyChanged(
-    const views::ViewHierarchyChangedDetails& details) {
-  ToolbarView::ViewHierarchyChanged(details);
-
-  if (details.is_add && details.parent == this) {
-    // Mark children of the toolbar view as client area so that they are not
-    // perceived as caption area. See brave_non_client_hit_test_helper.h
-    views::SetHitTestComponent(details.child, HTCLIENT);
   }
 }
 

--- a/browser/ui/views/toolbar/brave_toolbar_view.h
+++ b/browser/ui/views/toolbar/brave_toolbar_view.h
@@ -65,8 +65,6 @@ class BraveToolbarView : public ToolbarView,
   void OnShowBookmarksButtonChanged();
   void ShowBookmarkBubble(const GURL& url, bool already_bookmarked) override;
   void VisibilityChanged(views::View* starting_from, bool visible) override;
-  void ViewHierarchyChanged(
-      const views::ViewHierarchyChangedDetails& details) override;
 
  private:
   FRIEND_TEST_ALL_PREFIXES(BraveToolbarViewTest, ToolbarCornerRadiusTest);


### PR DESCRIPTION
In order to make it easier to register draggable areas, we move the non-client hit test helper to the browser window features. The new BraveNonClientHitTestHelper will manage the registration of draggable areas and provide a non-client hit test helper for the frame views.

Part of https://github.com/brave/brave-browser/issues/30011
Will be used in https://github.com/brave/brave-core/pull/36468

Covered by existing test - brave_non_client_hittest_helper_browsertest.cc

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
