### PR TITLE
[Rewards] Split buildflags header

### DIFF
--- a/components/brave_adaptive_captcha/BUILD.gn
+++ b/components/brave_adaptive_captcha/BUILD.gn
@@ -24,6 +24,7 @@ source_set("brave_adaptive_captcha") {
     "//brave/components/api_request_helper",
     "//brave/components/brave_rewards/core",
     "//brave/components/brave_rewards/core/buildflags",
+    "//brave/components/brave_rewards/core/buildflags:endpoint_buildflags",
     "//components/keyed_service/core",
     "//components/prefs",
     "//net",

--- a/components/brave_adaptive_captcha/server_util.cc
+++ b/components/brave_adaptive_captcha/server_util.cc
@@ -6,7 +6,7 @@
 #include "brave/components/brave_adaptive_captcha/server_util.h"
 
 #include "base/check.h"
-#include "brave/components/brave_rewards/core/buildflags/buildflags.h"
+#include "brave/components/brave_rewards/core/buildflags/endpoint_buildflags.h"
 #include "brave/components/brave_rewards/core/rewards_flags.h"
 
 namespace brave_adaptive_captcha {

--- a/components/brave_rewards/content/BUILD.gn
+++ b/components/brave_rewards/content/BUILD.gn
@@ -40,6 +40,7 @@ static_library("content") {
     "//brave/components/brave_rewards/core",
     "//brave/components/brave_rewards/core:features",
     "//brave/components/brave_rewards/core/buildflags",
+    "//brave/components/brave_rewards/core/buildflags:endpoint_buildflags",
     "//brave/components/brave_rewards/core/engine",
     "//brave/components/brave_wallet/common/buildflags",
     "//brave/components/ntp_background_images/common",

--- a/components/brave_rewards/content/rewards_protocol_navigation_throttle.cc
+++ b/components/brave_rewards/content/rewards_protocol_navigation_throttle.cc
@@ -18,7 +18,7 @@
 #include "base/strings/string_split.h"
 #include "base/strings/string_util.h"
 #include "brave/brave_domains/urls.h"
-#include "brave/components/brave_rewards/core/buildflags/buildflags.h"
+#include "brave/components/brave_rewards/core/buildflags/endpoint_buildflags.h"
 #include "brave/components/brave_rewards/core/pref_names.h"
 #include "components/prefs/pref_service.h"
 #include "components/user_prefs/user_prefs.h"

--- a/components/brave_rewards/core/buildflags/BUILD.gn
+++ b/components/brave_rewards/core/buildflags/BUILD.gn
@@ -8,9 +8,12 @@ import("//build/buildflag_header.gni")
 
 buildflag_header("buildflags") {
   header = "buildflags.h"
-  flags = [
-    "ENABLE_BRAVE_REWARDS=$enable_brave_rewards",
+  flags = [ "ENABLE_BRAVE_REWARDS=$enable_brave_rewards" ]
+}
 
+buildflag_header("endpoint_buildflags") {
+  header = "endpoint_buildflags.h"
+  flags = [
     "BITFLYER_PRODUCTION_FEE_ADDRESS=\"$bitflyer_production_fee_address\"",
     "BITFLYER_PRODUCTION_URL=\"$bitflyer_production_url\"",
     "BITFLYER_SANDBOX_FEE_ADDRESS=\"$bitflyer_sandbox_fee_address\"",

--- a/components/brave_rewards/core/engine/BUILD.gn
+++ b/components/brave_rewards/core/engine/BUILD.gn
@@ -335,7 +335,7 @@ static_library("engine") {
     "//brave/components/brave_private_cdn",
     "//brave/components/brave_rewards/core",
     "//brave/components/brave_rewards/core:features",
-    "//brave/components/brave_rewards/core/buildflags",
+    "//brave/components/brave_rewards/core/buildflags:endpoint_buildflags",
     "//brave/components/brave_rewards/core/mojom:engine",
     "//brave/components/challenge_bypass_ristretto",
     "//brave/components/constants",

--- a/components/brave_rewards/core/engine/util/environment_config.cc
+++ b/components/brave_rewards/core/engine/util/environment_config.cc
@@ -10,7 +10,7 @@
 
 #include "base/check.h"
 #include "base/strings/strcat.h"
-#include "brave/components/brave_rewards/core/buildflags/buildflags.h"
+#include "brave/components/brave_rewards/core/buildflags/endpoint_buildflags.h"
 #include "brave/components/constants/brave_services_key.h"
 #include "brave/components/constants/network_constants.h"
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Extract `.env` provided strings to `endpoint_buildflags.h`. 

Developers tend to have arbitrary filler strings for buildflags like `bitflyer_sandbox_url`. Having them in freqently included `brave_rewards/core/buildflags/buildflags.h` reduces cache hits in cloud siso cache. 

So now `brave_rewards/core/buildflags/endpoint_buildflags.h` provides these buldflags and is included only by some .cc files and files depending on `brave_rewards/core/buildflags/buildflags.h` are more likely to be already built in cloud.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
