### PR TITLE
[Desktop NTP]: Fix high-resolution custom backgrounds not displaying and loading indefinitely

### DIFF
--- a/browser/ntp_background/custom_background_file_manager.cc
+++ b/browser/ntp_background/custom_background_file_manager.cc
@@ -173,7 +173,7 @@ void CustomBackgroundFileManager::DecodeImageInIsolatedProcess(
 
   data_decoder::DecodeImageIsolated(
       image_data_span, data_decoder::mojom::ImageCodec::kDefault,
-      /*shrink_to_fit=*/false,
+      /*shrink_to_fit=*/true,
       static_cast<uint64_t>(IPC::mojom::kChannelMaximumMessageSize),
       gfx::Size() /* No particular size desired. */,
       std::move(skbitmap_to_image).Then(std::move(on_decode)));

--- a/browser/ntp_background/custom_background_file_manager_browsertest.cc
+++ b/browser/ntp_background/custom_background_file_manager_browsertest.cc
@@ -21,12 +21,17 @@
 #include "content/public/test/browser_task_environment.h"
 #include "content/public/test/browser_test.h"
 #include "third_party/abseil-cpp/absl/strings/str_format.h"
+#include "third_party/skia/include/core/SkBitmap.h"
+#include "third_party/skia/include/core/SkPixmap.h"
+#include "ui/gfx/codec/png_codec.h"
 
 // CustomBackgroundFileManager requires data decoder which can't be initialized
 // in unit tests.
 class CustomBackgroundFileManagerBrowserTest : public InProcessBrowserTest {
  public:
   static constexpr char kTestImageName[] = "background.jpg";
+  static constexpr char kTestHighResolutionImageName[] =
+      "high_resolution_background.png";
 
   CustomBackgroundFileManagerBrowserTest() = default;
   ~CustomBackgroundFileManagerBrowserTest() override = default;
@@ -57,6 +62,36 @@ class CustomBackgroundFileManagerBrowserTest : public InProcessBrowserTest {
  protected:
   base::FilePath test_file() const {
     return profile()->GetPath().AppendASCII(kTestImageName);
+  }
+
+  bool CreateHighResolutionTestImage(base::FilePath* image_path) const {
+    constexpr int kWidth = 9216;
+    constexpr int kHeight = 5184;
+
+    SkBitmap bitmap;
+    if (!bitmap.tryAllocN32Pixels(kWidth, kHeight)) {
+      return false;
+    }
+
+    bitmap.eraseColor(SK_ColorRED);
+
+    SkPixmap pixmap;
+    if (!bitmap.peekPixels(&pixmap)) {
+      return false;
+    }
+
+    *image_path =
+        profile()->GetPath().AppendASCII(kTestHighResolutionImageName);
+
+    std::optional<std::vector<uint8_t>> encoded_png =
+        gfx::PNGCodec::EncodeBGRASkBitmap(bitmap,
+                                          /*discard_transparency=*/false);
+
+    if (!encoded_png) {
+      return false;
+    }
+
+    return base::WriteFile(*image_path, *encoded_png);
   }
 
   Profile* profile() { return browser()->profile(); }
@@ -110,6 +145,30 @@ IN_PROC_BROWSER_TEST_F(CustomBackgroundFileManagerBrowserTest,
       custom_file_manager().GetCustomBackgroundDirectory().AppendASCII(
           kTestImageName)));
   EXPECT_TRUE(base::PathExists(test_file()));
+}
+
+// Verifies that high-resolution images whose decoded bitmap would exceed the
+// Mojo IPC message size limit can still be saved after being scaled down by the
+// data decoder. See https://github.com/brave/brave-browser/issues/55551
+IN_PROC_BROWSER_TEST_F(CustomBackgroundFileManagerBrowserTest,
+                       SaveHighResolutionImageToCustomBackgroundDir) {
+  base::ScopedAllowBlockingForTesting allow_blocking_call;
+
+  base::FilePath high_resolution_image_path;
+  ASSERT_TRUE(CreateHighResolutionTestImage(&high_resolution_image_path));
+  ASSERT_TRUE(base::PathExists(high_resolution_image_path));
+
+  auto check_result = base::BindOnce([](const base::FilePath& path) {
+                        EXPECT_FALSE(path.empty());
+                      }).Then(run_loop_quit_closure());
+
+  custom_file_manager().SaveImage(high_resolution_image_path,
+                                  std::move(check_result));
+  Wait();
+
+  EXPECT_TRUE(base::PathExists(
+      custom_file_manager().GetCustomBackgroundDirectory().AppendASCII(
+          kTestHighResolutionImageName)));
 }
 
 IN_PROC_BROWSER_TEST_F(CustomBackgroundFileManagerBrowserTest,

--- a/browser/ntp_background/custom_background_file_manager_browsertest.cc
+++ b/browser/ntp_background/custom_background_file_manager_browsertest.cc
@@ -9,6 +9,7 @@
 
 #include "base/files/file_path.h"
 #include "base/files/file_util.h"
+#include "base/logging.h"
 #include "base/path_service.h"
 #include "base/test/bind.h"
 #include "base/test/task_environment.h"
@@ -64,34 +65,40 @@ class CustomBackgroundFileManagerBrowserTest : public InProcessBrowserTest {
     return profile()->GetPath().AppendASCII(kTestImageName);
   }
 
-  bool CreateHighResolutionTestImage(base::FilePath* image_path) const {
+  std::optional<base::FilePath> CreateHighResolutionTestImage() const {
     constexpr int kWidth = 9216;
     constexpr int kHeight = 5184;
 
     SkBitmap bitmap;
     if (!bitmap.tryAllocN32Pixels(kWidth, kHeight)) {
-      return false;
+      return std::nullopt;
     }
-
     bitmap.eraseColor(SK_ColorRED);
 
     SkPixmap pixmap;
     if (!bitmap.peekPixels(&pixmap)) {
-      return false;
+      return std::nullopt;
     }
 
-    *image_path =
-        profile()->GetPath().AppendASCII(kTestHighResolutionImageName);
-
+    // Encode the generated bitmap into a valid PNG image so it can be written
+    // to disk and used during the browser test.
     std::optional<std::vector<uint8_t>> encoded_png =
         gfx::PNGCodec::EncodeBGRASkBitmap(bitmap,
                                           /*discard_transparency=*/false);
 
     if (!encoded_png) {
-      return false;
+      LOG(ERROR) << "Failed to encode high-resolution image as PNG";
+      return std::nullopt;
     }
 
-    return base::WriteFile(*image_path, *encoded_png);
+    const base::FilePath image_path =
+        profile()->GetPath().AppendASCII(kTestHighResolutionImageName);
+
+    if (!base::WriteFile(image_path, *encoded_png)) {
+      return std::nullopt;
+    }
+
+    return image_path;
   }
 
   Profile* profile() { return browser()->profile(); }
@@ -154,16 +161,18 @@ IN_PROC_BROWSER_TEST_F(CustomBackgroundFileManagerBrowserTest,
                        SaveHighResolutionImageToCustomBackgroundDir) {
   base::ScopedAllowBlockingForTesting allow_blocking_call;
 
-  base::FilePath high_resolution_image_path;
-  ASSERT_TRUE(CreateHighResolutionTestImage(&high_resolution_image_path));
-  ASSERT_TRUE(base::PathExists(high_resolution_image_path));
+  std::optional<base::FilePath> high_resolution_image_path =
+      CreateHighResolutionTestImage();
+  ASSERT_TRUE(high_resolution_image_path.has_value());
+
+  const base::FilePath& image_path = high_resolution_image_path.value();
+  ASSERT_TRUE(base::PathExists(image_path));
 
   auto check_result = base::BindOnce([](const base::FilePath& path) {
                         EXPECT_FALSE(path.empty());
                       }).Then(run_loop_quit_closure());
 
-  custom_file_manager().SaveImage(high_resolution_image_path,
-                                  std::move(check_result));
+  custom_file_manager().SaveImage(image_path, std::move(check_result));
   Wait();
 
   EXPECT_TRUE(base::PathExists(

--- a/browser/ntp_background/custom_background_file_manager_browsertest.cc
+++ b/browser/ntp_background/custom_background_file_manager_browsertest.cc
@@ -9,6 +9,7 @@
 
 #include "base/files/file_path.h"
 #include "base/files/file_util.h"
+#include "base/location.h"
 #include "base/logging.h"
 #include "base/path_service.h"
 #include "base/test/bind.h"
@@ -65,40 +66,31 @@ class CustomBackgroundFileManagerBrowserTest : public InProcessBrowserTest {
     return profile()->GetPath().AppendASCII(kTestImageName);
   }
 
-  std::optional<base::FilePath> CreateHighResolutionTestImage() const {
+  void CreateHighResolutionTestImage(
+      base::FilePath* image_path_out,
+      const base::Location& location = FROM_HERE) const {
+    SCOPED_TRACE(location.ToString());
+
     constexpr int kWidth = 9216;
     constexpr int kHeight = 5184;
 
     SkBitmap bitmap;
-    if (!bitmap.tryAllocN32Pixels(kWidth, kHeight)) {
-      return std::nullopt;
-    }
+    ASSERT_TRUE(bitmap.tryAllocN32Pixels(kWidth, kHeight));
     bitmap.eraseColor(SK_ColorRED);
 
     SkPixmap pixmap;
-    if (!bitmap.peekPixels(&pixmap)) {
-      return std::nullopt;
-    }
+    ASSERT_TRUE(bitmap.peekPixels(&pixmap));
 
     // Encode the generated bitmap into a valid PNG image so it can be written
     // to disk and used during the browser test.
     std::optional<std::vector<uint8_t>> encoded_png =
         gfx::PNGCodec::EncodeBGRASkBitmap(bitmap,
                                           /*discard_transparency=*/false);
+    ASSERT_TRUE(encoded_png.has_value());
 
-    if (!encoded_png) {
-      LOG(ERROR) << "Failed to encode high-resolution image as PNG";
-      return std::nullopt;
-    }
-
-    const base::FilePath image_path =
+    *image_path_out =
         profile()->GetPath().AppendASCII(kTestHighResolutionImageName);
-
-    if (!base::WriteFile(image_path, *encoded_png)) {
-      return std::nullopt;
-    }
-
-    return image_path;
+    ASSERT_TRUE(base::WriteFile(*image_path_out, *encoded_png));
   }
 
   Profile* profile() { return browser()->profile(); }
@@ -161,11 +153,8 @@ IN_PROC_BROWSER_TEST_F(CustomBackgroundFileManagerBrowserTest,
                        SaveHighResolutionImageToCustomBackgroundDir) {
   base::ScopedAllowBlockingForTesting allow_blocking_call;
 
-  std::optional<base::FilePath> high_resolution_image_path =
-      CreateHighResolutionTestImage();
-  ASSERT_TRUE(high_resolution_image_path.has_value());
-
-  const base::FilePath& image_path = high_resolution_image_path.value();
+  base::FilePath image_path;
+  CreateHighResolutionTestImage(&image_path);
   ASSERT_TRUE(base::PathExists(image_path));
 
   auto check_result = base::BindOnce([](const base::FilePath& path) {


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/55551

### Description
High-resolution custom background images can fail to save on Desktop when the decoded bitmap is larger than the Mojo IPC maximum message size.

From my local testing and debugging:
Brave read the high-res image successfully, but `DecodeImageIsolated` returned an empty decoded image because the full decoded bitmap exceeded `kChannelMaximumMessageSize`. An empty decoded image then gets passed to the function `SaveImageAsPNG` and returned early with `base::FilePath()` because it is empty.

This PR enables `shrink_to_fit` when decoding custom background images, allowing large images to be downscaled before being returned from the decoder.

### Notes
- `kChannelMaximumMessageSize` is defined in `ipc/constants.mojom`.
- `shrink_to_fit` parameter is explained on `Services\data_decoder\public\mojom\image_decoder.mojom`

I tested this with 9216x5184 and 10k-resolution images, and both displayed correctly after the change.

Please let me know if I missed anything or there are any mistakes. Thanks.

### Demonstration to show that the issue is fixed
https://github.com/user-attachments/assets/c515cd96-23c9-4673-8b47-b52b6825ab07

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
