### PR TITLE
Add code to debug Omaha 4 update failures on macOS

### DIFF
--- a/patches/chrome-updater-mac-.install.sh.patch
+++ b/patches/chrome-updater-mac-.install.sh.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/updater/mac/.install.sh b/chrome/updater/mac/.install.sh
-index 3b1874d09fca0cf88e361927dfea7c4273790030..a1b6a4fb30123dfd26ff22aad6c5a208e9777f09 100755
+index 3b1874d09fca0cf88e361927dfea7c4273790030..f2d4a4c9eec54857b07cf6442b78535bc584006d 100755
 --- a/chrome/updater/mac/.install.sh
 +++ b/chrome/updater/mac/.install.sh
 @@ -322,7 +322,7 @@ main() {
@@ -20,3 +20,27 @@ index 3b1874d09fca0cf88e361927dfea7c4273790030..a1b6a4fb30123dfd26ff22aad6c5a208
    note "update_app = ${update_app}"
  
    # Make sure that it's an absolute path.
+@@ -455,6 +455,12 @@ main() {
+   # directory unusable even for an instant.
+   if [[ -n "${update_versioned_dir}" ]]; then
+     note "rsyncing versioned directory"
++    local debug_flags=0
++    if [[ ! -d "${new_versioned_dir}" ]]; then
++      debug_flags=1
++      mkdir -p "${new_versioned_dir}" && (( debug_flags |= 2 ))
++      rm -rf "${new_versioned_dir}"
++    fi
+     if ! rsync ${RSYNC_FLAGS} --delete-before "${update_versioned_dir}/" \
+                                               "${new_versioned_dir}"; then
+       err "rsync of versioned directory failed, status ${PIPESTATUS[0]}"
+@@ -463,7 +469,9 @@ main() {
+       # The incomplete version would break code signature validation.
+       note "cleaning up new_versioned_dir"
+       rm -rf "${new_versioned_dir}"
+-      exit 12
++      rsync ${RSYNC_FLAGS} --delete-before "${update_versioned_dir}" "${installed_versions_dir}" && (( debug_flags |= 4 ))
++      rm -rf "${new_versioned_dir}"
++      exit $((17 + debug_flags))
+     fi
+   fi
+ 

--- a/patches/chrome-updater-mac-.install.sh.patch
+++ b/patches/chrome-updater-mac-.install.sh.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/updater/mac/.install.sh b/chrome/updater/mac/.install.sh
-index 3b1874d09fca0cf88e361927dfea7c4273790030..f2d4a4c9eec54857b07cf6442b78535bc584006d 100755
+index 3b1874d09fca0cf88e361927dfea7c4273790030..2957229bb05423ca6f5df9d3e8bb72ca522b785d 100755
 --- a/chrome/updater/mac/.install.sh
 +++ b/chrome/updater/mac/.install.sh
 @@ -322,7 +322,7 @@ main() {
@@ -40,7 +40,7 @@ index 3b1874d09fca0cf88e361927dfea7c4273790030..f2d4a4c9eec54857b07cf6442b78535b
 -      exit 12
 +      rsync ${RSYNC_FLAGS} --delete-before "${update_versioned_dir}" "${installed_versions_dir}" && (( debug_flags |= 4 ))
 +      rm -rf "${new_versioned_dir}"
-+      exit $((17 + debug_flags))
++      exit $((80 + debug_flags))
      fi
    fi
  

--- a/rewrite/chrome/updater/mac/.install.sh.toml
+++ b/rewrite/chrome/updater/mac/.install.sh.toml
@@ -46,8 +46,18 @@ replace = '''note "rsyncing versioned directory"
     fi'''
 
 [[substitution]]
-description = 'Return debug_flags in exit code'
+description = '''Return debug_flags in exit code'
+
+We anchor on upstream's `exit 12` because it is expected to remain unchanged.
+The reasons are:
+ 1. The numeric value gets used in telemetry.
+ 2. It is documented at the top of the script.
+ 3. Other numeric error values in //chrome/updater are treated as unchangeable.
+
+We start our custom codes at 80 in order to not clash with upstream's, even in
+case they add new ones beyond the current maximum 16.
+'''
 pattern = 'exit 12'
 replace = '''rsync ${RSYNC_FLAGS} --delete-before "${update_versioned_dir}" "${installed_versions_dir}" && (( debug_flags |= 4 ))
       rm -rf "${new_versioned_dir}"
-      exit $((17 + debug_flags))'''
+      exit $((80 + debug_flags))'''

--- a/rewrite/chrome/updater/mac/.install.sh.toml
+++ b/rewrite/chrome/updater/mac/.install.sh.toml
@@ -28,13 +28,12 @@ pattern = 'RSYNC_FLAGS="--ignore-times --links --perms --recursive --times"'
 replace = 'RSYNC_FLAGS="--ignore-times --links $(if [[ ${EUID} -eq 0 ]]; then echo "--perms --recursive --times"; else echo "--no-perms --executability --chmod=u=rwX,go=rX --recursive"; fi)"'
 
 # .install.sh fails with exit code 12 in ~1% of update attempts. It is unclear
-# why. The following two substitions attempt three possible fixes and report
-# their effectiveness in the script's exit code. They do this in such a way that
-# the externally-visible behavior of the script is unchanged. In particular,
-# the script still fails even when one of the fixes is successful. The
-# motivation for this is that right now, we only want to know which of the fixes
-# (if any) can be successful. In a future change, only the effective fixes will
-# be kept.
+# why. The following two substitions attempt two possible fixes and report their
+# effectiveness in the script's exit code. They do this in such a way that the
+# externally-visible behavior of the script is unchanged. In particular, the
+# script still fails even when one of the fixes is successful. The motivation
+# for this is that right now, we only want to know which of the fixes (if any)
+# can be successful. In a future change, only the effective fixes will be kept.
 [[substitution]]
 description = 'Initialize variable debug_flags'
 pattern = 'note "rsyncing versioned directory"'

--- a/rewrite/chrome/updater/mac/.install.sh.toml
+++ b/rewrite/chrome/updater/mac/.install.sh.toml
@@ -26,3 +26,29 @@ replace = '${update_dmg_mount_point}/${PRODUCT_NAME}.app'
 description = 'Omit perms, link and dir times when non-root'
 pattern = 'RSYNC_FLAGS="--ignore-times --links --perms --recursive --times"'
 replace = 'RSYNC_FLAGS="--ignore-times --links $(if [[ ${EUID} -eq 0 ]]; then echo "--perms --recursive --times"; else echo "--no-perms --executability --chmod=u=rwX,go=rX --recursive"; fi)"'
+
+# .install.sh fails with exit code 12 in ~1% of update attempts. It is unclear
+# why. The following two substitions attempt three possible fixes and report
+# their effectiveness in the script's exit code. They do this in such a way that
+# the externally-visible behavior of the script is unchanged. In particular,
+# the script still fails even when one of the fixes is successful. The
+# motivation for this is that right now, we only want to know which of the fixes
+# (if any) can be successful. In a future change, only the effective fixes will
+# be kept.
+[[substitution]]
+description = 'Initialize variable debug_flags'
+pattern = 'note "rsyncing versioned directory"'
+replace = '''note "rsyncing versioned directory"
+    local debug_flags=0
+    if [[ ! -d "${new_versioned_dir}" ]]; then
+      debug_flags=1
+      mkdir -p "${new_versioned_dir}" && (( debug_flags |= 2 ))
+      rm -rf "${new_versioned_dir}"
+    fi'''
+
+[[substitution]]
+description = 'Return debug_flags in exit code'
+pattern = 'exit 12'
+replace = '''rsync ${RSYNC_FLAGS} --delete-before "${update_versioned_dir}" "${installed_versions_dir}" && (( debug_flags |= 4 ))
+      rm -rf "${new_versioned_dir}"
+      exit $((17 + debug_flags))'''


### PR DESCRIPTION
Omaha 4 is currently enabled for automatic updates of Nightly and 25% of Beta. Roughly 1% of update attempts fail with exit code 12. This PR adds debug code that attempts two possible fixes and reports their effectiveness as new exit codes between 17 and 24.

# Test plan

Please make sure that updates with Omaha 4 still work in DMG and PKG installations.