### PR TITLE
Fix errors in macOS .pkg postinstall script

### DIFF
--- a/build/mac/BUILD.gn
+++ b/build/mac/BUILD.gn
@@ -7,6 +7,7 @@ import("//brave/build/config.gni")
 import("//brave/build/mac/config.gni")
 import("//brave/updater/config.gni")
 import("//build/util/branding.gni")
+import("//build/util/process_version.gni")
 import("//chrome/common/features.gni")
 import("//chrome/updater/branding.gni")
 import("//chrome/version.gni")
@@ -279,9 +280,17 @@ if (install_omaha4_with_pkg) {
     sources = [ "pkg-scripts/preinstall" ]
     outputs = [ preinstall_script ]
   }
-  copy("copy_postinstall") {
-    sources = [ "pkg-scripts/postinstall" ]
-    outputs = [ postinstall_script ]
+  process_version("copy_postinstall") {
+    process_only = true
+    template_file = "pkg-scripts/postinstall"
+    output = postinstall_script
+    executable = true
+    extra_args = [
+      "-e",
+      "APP_BUNDLE=\"$brave_exe\"",
+      "-e",
+      "PRODUCT_DIR_NAME=\"$brave_product_dir_name\"",
+    ]
   }
 }
 

--- a/build/mac/pkg-scripts/postinstall
+++ b/build/mac/pkg-scripts/postinstall
@@ -23,18 +23,9 @@ if [[ $installerPath =~ $installerPathPromoCodeRegex ]]; then
   fi
 fi
 
-# Get a channel-safe version of the application name (based on the
-# .pkg file name)
-if [ "$promoCode" == "" ]; then
-  appName=$(basename "$1" | sed "s/.pkg//" | sed "s/ /\-/g")
-else
-  appName=$(basename "$1" | sed "s/.pkg//" | sed "s/ /\-/g" | perl -ple "s/-${promoCode}//i")
-fi
-
-appNameNoDash=$(echo $appName | sed "s/-/ /g")
-installationAppPath="$installationPath/${appNameNoDash}.app"
-userDataDir="$HOME/Library/Application Support/BraveSoftware"
-appDataDir="$userDataDir/${appName}"
+# The bundle name and user-data subdirectory come from GN at build time.
+installationAppPath="$installationPath/@APP_BUNDLE@"
+appDataDir="$HOME/Library/Application Support/@PRODUCT_DIR_NAME@"
 promoCodePath="$appDataDir/promoCode"
 
 # pkg runs this script as root so we need to get current username
@@ -57,8 +48,9 @@ if [ "$promoCode" != "" ]; then
   echo "Writing to user data directory at: $promoCodePath"
   mkdir -p "$appDataDir"
   echo "$promoCode" > "$promoCodePath"
-  # fix permissions
-  sudo chown -R "$userName" "$userDataDir"
+  # mkdir -p above may have created the parent directory as root; chown
+  # it (and everything below) so the installing user can write here.
+  sudo chown -R "$userName" "$(dirname "$appDataDir")"
 fi
 
 exit 0


### PR DESCRIPTION
Eg. when installing from Brave-Browser-universal.pkg, the previous implementation gave the following `postinstall` errors in `/var/log/install.log`:

chmod: /Applications/Brave Browser universal.app: No such file or directory
chown: /Applications/Brave Browser universal.app: No such file or directory
chgrp: /Applications/Brave Browser universal.app: No such file or directory

Resolves https://github.com/brave/brave-browser/issues/39567.

# Test plan

1. Please check that the bug (as described in the issue) no longer appears.
2. Please check that Brave and Origin's PKG installers still work, especially when they have suffixes such as `-universal.pkg` or `-arm64.pkg`.
3. When you install Brave from a PKG with a suffix that ends with three capital letters and three numbers, then that suffix should be written into the `promoCode` field in the user data directory. For example: `Brave-Browser-Nightly-BRV001.pkg` should produce `~/Library/Application Support/BraveSoftware/Brave-Browser-Nightly/promoCode` with content `BRV001`.