### PR TITLE
[iOS] [CodeHealth] Cleanup SKUs related code

### DIFF
--- a/ios/brave-ios/App/iOS/Delegates/SceneDelegate.swift
+++ b/ios/brave-ios/App/iOS/Delegates/SceneDelegate.swift
@@ -516,7 +516,7 @@ extension SceneDelegate {
     Task { @MainActor in
       let isPrivateBrowsing =
         scene.browserViewController?.privateBrowsingManager.isPrivateBrowsing == true
-      await BraveSkusManager(isPrivateMode: isPrivateBrowsing)?.refreshVPNCredentials()
+      await Skus.SkusServiceFactory.get(privateMode: isPrivateBrowsing)?.refreshVPNCredentials()
     }
   }
 

--- a/ios/brave-ios/Sources/AIChat/Components/AIChatView.swift
+++ b/ios/brave-ios/Sources/AIChat/Components/AIChatView.swift
@@ -648,10 +648,14 @@ public struct AIChatView: View {
             if let skusService = Skus.SkusServiceFactory.get(privateMode: false),
               let orderId = Preferences.AIChat.subscriptionOrderId.value
             {
-              try? await skusService.fetchCredentials(orderId: orderId, for: .leo)
+              let result = await skusService.fetchOrderCredentials(
+                domain: BraveStoreProductGroup.leo.skusDomain,
+                orderId: orderId
+              )
+              if result.code == .ok {
+                model.retryLastRequest()
+              }
             }
-
-            model.retryLastRequest()
           }
         }
       } else {

--- a/ios/brave-ios/Sources/Brave/BraveSkus/BraveSkusServiceHelpers.swift
+++ b/ios/brave-ios/Sources/Brave/BraveSkus/BraveSkusServiceHelpers.swift
@@ -12,102 +12,37 @@ import Preferences
 import Shared
 import os.log
 
-public class BraveSkusManager {
-  private let sku: SkusSkusService
-
-  public init?(isPrivateMode: Bool) {
-    guard let skusService = Skus.SkusServiceFactory.get(privateMode: isPrivateMode) else {
-      assert(
-        isPrivateMode,
-        "[SkusManager] - SkusServiceFactory failed to intialize in regular mode, something is wrong."
-      )
-      return nil
-    }
-
-    self.sku = skusService
-  }
-
+extension SkusSkusService {
   @MainActor
   public func refreshVPNCredentials() async {
     if let domain = Preferences.VPN.skusCredentialDomain.value {
       // Always refresh credentials and trust the credentials from Brave-Core rather than cached credentials
-      _ = await credentialSummary(for: domain)
-    }
-  }
-
-  // MARK: - Handling SKU methods.
-
-  @MainActor
-  func refreshOrder(for orderId: String, domain: String) async -> Any? {
-    Logger.module.debug("[SkusManager] - RefreshOrder")
-    let order = await sku.refreshOrder(domain: domain, orderId: orderId).message
-    guard !order.isEmpty,
-      let data = order.data(using: .utf8),
-      let json = try? JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed)
-    else {
-      Logger.module.debug("[SkusManager] - Failed to Serialize Order")
-      return nil
-    }
-
-    return json
-  }
-
-  @MainActor
-  func fetchOrderCredentials(for orderId: String, domain: String) async -> String {
-    Logger.module.debug("[SkusManager] - FetchOrderCredentials")
-    return await sku.fetchOrderCredentials(domain: domain, orderId: orderId).message
-  }
-
-  @MainActor
-  func prepareCredentialsPresentation(for domain: String, path: String) async -> String? {
-    Logger.module.debug("[SkusManager] - PrepareCredentialsPresentation")
-
-    let credentialType = CredentialType.from(domain: domain)
-    let credential = await sku.prepareCredentialsPresentation(domain: domain, path: path).message
-    if !credential.isEmpty {
-      switch credentialType {
-      case .vpn:
-        if let vpnCredential = BraveSkusWebHelper.fetchVPNCredential(credential, domain: domain) {
-          Preferences.VPN.skusCredential.value = credential
-          BraveVPN.setCustomVPNCredential(vpnCredential)
-        }
-      case .leo, .origin:
-        break
-      case .unknown:
-        Logger.module.debug("[SkusManager] - Unknown Credentials")
-        break
+      let summary = await credentialSummary(domain: domain).message
+      if !summary.isEmpty, summary != "{}" {
+        await updatePreferences(for: domain, summaryData: Data(summary.utf8))
       }
     }
-
-    return credential
   }
 
   @MainActor
-  func credentialSummary(for domain: String) async -> Any? {
-    let summary = await sku.credentialSummary(domain: domain).message
-    guard !summary.isEmpty,
-      let data = summary.data(using: .utf8),
-      let json = try? JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed)
-    else {
-      Logger.module.debug("[SkusManager] - Failed to Serialize Credential Summary")
-      return nil
-    }
-
-    guard summary != "{}" else {
-      return json
-    }
-
+  func updatePreferences(for domain: String, summaryData: Data) async {
     do {
-      // Once we switch VPN over to the new Skus v2 APIs, the we can switch this to SkusCredentials from the SDK
-      // Not sure if VPN has CredentialSummary.order.id so leaving as is for now.
-      let credentialSummary = try CredentialSummary.from(data: data)
+      // Once we switch VPN over to the new Skus v2 APIs, the we can switch this to SkusCredentials
+      // from the SDK. Not sure if VPN has CredentialSummary.order.id so leaving as is for now.
+      let credentialSummary = try CredentialSummary.from(data: summaryData)
+      let credentialType = CredentialType.from(domain: domain)
       switch credentialSummary.state {
       case .valid:
-        let credentialType = CredentialType.from(domain: domain)
         switch credentialType {
         case .vpn:
           Logger.module.debug("[SkusManager] - Preparing VPN Credentials")
-          _ = await prepareCredentialsPresentation(for: domain, path: "*")
+          let credential = await prepareCredentialsPresentation(domain: domain, path: "*").message
+          if !credential.isEmpty,
+            let vpnCredential = BraveSkusWebHelper.fetchVPNCredential(credential, domain: domain)
+          {
+            Preferences.VPN.skusCredential.value = credential
+            BraveVPN.setCustomVPNCredential(vpnCredential)
+          }
 
           Preferences.VPN.skusCredentialDomain.value = domain
           Preferences.VPN.expirationDate.value = credentialSummary.expiresAt
@@ -119,7 +54,7 @@ public class BraveSkusManager {
 
           if Preferences.AIChat.subscriptionOrderId.value != nil {
             Logger.module.debug("[SkusManager] - Preparing Leo Credentials")
-            _ = await prepareCredentialsPresentation(for: domain, path: "*")
+            _ = await prepareCredentialsPresentation(domain: domain, path: "*")
 
             Preferences.AIChat.subscriptionExpirationDate.value = credentialSummary.expiresAt
           }
@@ -130,7 +65,7 @@ public class BraveSkusManager {
 
           if Preferences.BraveOrigin.purchaseOrderId.value != nil {
             Logger.module.debug("[SkusManager] - Preparing Origin Credentials")
-            _ = await prepareCredentialsPresentation(for: domain, path: "*")
+            _ = await prepareCredentialsPresentation(domain: domain, path: "*")
           }
         case .unknown:
           Logger.module.debug("[SkusManager] - Unknown Credentials")
@@ -148,41 +83,14 @@ public class BraveSkusManager {
         }
       case .sessionExpired:
         Logger.module.debug("[SkusManager] - This credential session has expired")
-        Self.keepShowingSessionExpiredState = true
+        if credentialType == .vpn {
+          BraveVPN.markSkusSessionExpired()
+        }
       }
     } catch {
       Logger.module.error("[SkusManager] - \(error)")
     }
 
-    return json
-  }
-
-  // MARK: - Session Expired state
-  /// An in-memory flag that will show a "session expired" prompt to the user in the current browsing session.
-  public static var keepShowingSessionExpiredState = false
-
-  public static func sessionExpiredStateAlert(
-    loginCallback: @escaping (UIAlertAction) -> Void
-  ) -> UIAlertController {
-    let alert = UIAlertController(
-      title: Strings.VPN.sessionExpiredTitle,
-      message: Strings.VPN.sessionExpiredDescription,
-      preferredStyle: .alert
-    )
-
-    let loginButton = UIAlertAction(
-      title: Strings.VPN.sessionExpiredLoginButton,
-      style: .default,
-      handler: loginCallback
-    )
-    let dismissButton = UIAlertAction(
-      title: Strings.VPN.sessionExpiredDismissButton,
-      style: .cancel
-    )
-    alert.addAction(loginButton)
-    alert.addAction(dismissButton)
-
-    return alert
   }
 }
 
@@ -263,33 +171,5 @@ private struct CredentialSummary {
       return date
     })
     return decoder
-  }
-}
-
-private struct CredentialCookie {
-  let expirationDate: Date
-  let cookie: String
-
-  static func from(credential: String, domain: String) -> CredentialCookie? {
-    guard let credential = credential.unescape(),
-      let cookieDomain = URL(string: "https://\(domain)")
-    else {
-      return nil
-    }
-
-    guard
-      let cookie = HTTPCookie.cookies(
-        withResponseHeaderFields: ["Set-Cookie": credential],
-        for: cookieDomain
-      ).first
-    else {
-      return nil
-    }
-
-    guard let expirationDate = cookie.expiresDate else {
-      return nil
-    }
-
-    return CredentialCookie(expirationDate: expirationDate, cookie: cookie.value)
   }
 }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Menu.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Menu.swift
@@ -332,11 +332,11 @@ extension BrowserViewController {
   }
 
   private var vpnMenuAction: Action {
-    func alertForExpiredState() -> UIAlertController? {
-      if !BraveSkusManager.keepShowingSessionExpiredState {
+    let alertForExpiredState: () -> UIAlertController? = { [unowned self] in
+      if !BraveVPN.isSkusCredentialSessionExpired {
         return nil
       }
-      return BraveSkusManager.sessionExpiredStateAlert(loginCallback: { _ in
+      return vpnSessionExpiredStateAlert(loginCallback: { _ in
         self.openURLInNewTab(
           .brave.account,
           isPrivate: self.privateBrowsingManager.isPrivateBrowsing,

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+VPN.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+VPN.swift
@@ -7,10 +7,34 @@ import BraveVPN
 import UIKit
 
 extension BrowserViewController {
+  public func vpnSessionExpiredStateAlert(
+    loginCallback: @escaping (UIAlertAction) -> Void
+  ) -> UIAlertController {
+    let alert = UIAlertController(
+      title: Strings.VPN.sessionExpiredTitle,
+      message: Strings.VPN.sessionExpiredDescription,
+      preferredStyle: .alert
+    )
+
+    let loginButton = UIAlertAction(
+      title: Strings.VPN.sessionExpiredLoginButton,
+      style: .default,
+      handler: loginCallback
+    )
+    let dismissButton = UIAlertAction(
+      title: Strings.VPN.sessionExpiredDismissButton,
+      style: .cancel
+    )
+    alert.addAction(loginButton)
+    alert.addAction(dismissButton)
+
+    return alert
+  }
+
   /// Shows a vpn screen based on vpn state.
   public func presentCorrespondingVPNViewController() {
-    if BraveSkusManager.keepShowingSessionExpiredState {
-      let alert = BraveSkusManager.sessionExpiredStateAlert(loginCallback: { [unowned self] _ in
+    if BraveVPN.isSkusCredentialSessionExpired {
+      let alert = vpnSessionExpiredStateAlert(loginCallback: { [unowned self] _ in
         self.openURLInNewTab(
           .brave.account,
           isPrivate: self.privateBrowsingManager.isPrivateBrowsing,

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -951,8 +951,10 @@ public class BrowserViewController: UIViewController {
     if profileController.profile.prefs.isBraveVPNAvailable {
       Task.delayed(bySeconds: 1.0) { @MainActor in
         // Refresh Skus VPN Credentials before loading VPN state
-        await BraveSkusManager(isPrivateMode: self.privateBrowsingManager.isPrivateBrowsing)?
-          .refreshVPNCredentials()
+        let skusService = Skus.SkusServiceFactory.get(
+          privateMode: self.privateBrowsingManager.isPrivateBrowsing
+        )
+        await skusService?.refreshVPNCredentials()
 
         self.vpnProductInfo.load()
         if let customCredential = Preferences.VPN.skusCredential.value,

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/TabExtensions.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/TabExtensions.swift
@@ -122,17 +122,6 @@ extension TabState {
   }
 }
 
-// MARK: - Brave SKU
-extension TabState {
-  func injectLocalStorageItem(key: String, value: String) {
-    self.evaluateJavaScript(
-      functionName: "localStorage.setItem",
-      args: [key, value],
-      contentWorld: BraveSkusScriptHandler.scriptSandbox
-    )
-  }
-}
-
 extension SecureContentState {
   public var shouldDisplayWarning: Bool {
     switch self {

--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/BraveSkusScriptHandler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/BraveSkusScriptHandler.swift
@@ -88,18 +88,21 @@ class BraveSkusScriptHandler: TabContentScript {
     method: Method,
     for skusDomain: String
   ) async throws -> Any? {
-    guard let skusManager = BraveSkusManager(isPrivateMode: tab.isPrivate) else {
+    guard let skusService = Skus.SkusServiceFactory.get(profile: tab.profile) else {
       return nil
     }
 
     switch method {
     case .refreshOrder:
       let order = try OrderMessage.from(message: message)
-      return await skusManager.refreshOrder(for: order.orderId, domain: skusDomain)
+      let message = await skusService.refreshOrder(domain: skusDomain, orderId: order.orderId)
+        .message
+      return try? JSONSerialization.jsonObject(with: Data(message.utf8))
 
     case .fetchOrderCredentials:
       let order = try OrderMessage.from(message: message)
-      return await skusManager.fetchOrderCredentials(for: order.orderId, domain: skusDomain)
+      return await skusService.fetchOrderCredentials(domain: skusDomain, orderId: order.orderId)
+        .message
 
     case .prepareCredentialsPresentation:
       Logger.module.error(
@@ -109,42 +112,19 @@ class BraveSkusScriptHandler: TabContentScript {
 
     case .credentialsSummary:
       let summary = try CredentialSummaryMessage.from(message: message)
-      return await skusManager.credentialSummary(for: summary.domain)
-
-    case .setLocalStorageReceipt:
-      let storeMessage = try StoreReceiptMessage.from(message: message)
-      if storeMessage.message == "vpn" {
-        if let vpnSubscriptionProductId = Preferences.VPN.subscriptionProductId.value,
-          let product = BraveStoreProduct(rawValue: vpnSubscriptionProductId)
-        {
-          let storageKey = product.localStorageKey
-          let receipt = try AppStoreReceipt.receipt(for: product)
-          return ["key": storageKey, "data": receipt]
-        }
+      let message = await skusService.credentialSummary(domain: summary.domain).message
+      guard !message.isEmpty,
+        let data = message.data(using: .utf8),
+        let json = try? JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed)
+      else {
+        Logger.module.debug("[SkusManager] - Failed to Serialize Credential Summary")
+        return nil
       }
-
-      if storeMessage.message == "leo" {
-        if let aiChatSubscriptionProductId = Preferences.AIChat.subscriptionProductId.value,
-          let orderId = Preferences.AIChat.subscriptionOrderId.value,
-          let product = BraveStoreProduct(rawValue: aiChatSubscriptionProductId)
-        {
-          let storageKey = product.localStorageKey
-          let receipt = try AppStoreReceipt.receipt(for: product)
-          return ["key": storageKey, "data": receipt, "braveLeo.orderId": orderId]
-        }
+      // Update credentials for VPN
+      if !message.isEmpty, message != "{}" {
+        await skusService.updatePreferences(for: summary.domain, summaryData: data)
       }
-
-      if storeMessage.message == "origin" {
-        if let originSubscriptionProductId = Preferences.BraveOrigin.purchaseProductId.value,
-          let orderId = Preferences.BraveOrigin.purchaseOrderId.value,
-          let product = BraveStoreProduct(rawValue: originSubscriptionProductId)
-        {
-          let storageKey = product.localStorageKey
-          let receipt = try AppStoreReceipt.receipt(for: product)
-          return ["key": storageKey, "data": receipt, "braveOrigin.orderId": orderId]
-        }
-      }
-      throw SkusWebMessageError.invalidFormat
+      return json
     }
   }
 }
@@ -155,7 +135,6 @@ extension BraveSkusScriptHandler {
     case fetchOrderCredentials
     case prepareCredentialsPresentation
     case credentialsSummary
-    case setLocalStorageReceipt
 
     static var map: [String: String] {
       var jsDict = [String: String]()

--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/DomainSpecific/Paged/BraveSkusScript.js
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/DomainSpecific/Paged/BraveSkusScript.js
@@ -17,44 +17,6 @@ window.__firefox__.includeOnce("BraveSkusScript", function($) {
   if (!window.chrome) {
     window.chrome = {};
   }
-  
-  // Request VPN Receipt
-  sendMessage('$<setLocalStorageReceipt>', { "message": "vpn" })
-  .then(function(jsonData) {
-    if (jsonData) {
-      window.localStorage.setItem(jsonData["key"], jsonData["data"]);
-    } else {
-      console.error("No VPN Subscription Data");
-    }
-  }).catch(function(err) {
-    console.error(`An error occurred setting the local storage receipt: ${err}`);
-  });
-  
-  // Request Leo Receipt
-  sendMessage('$<setLocalStorageReceipt>', { "message": "leo" })
-  .then(function(jsonData) {
-    if (jsonData) {
-      window.localStorage.setItem("braveLeo.orderId", jsonData["braveLeo.orderId"])
-      window.localStorage.setItem(jsonData["key"], jsonData["data"]);
-    } else {
-      console.error("No Leo Subscription Data");
-    }
-  }).catch(function(err) {
-    console.error(`An error occurred setting the local storage receipt: ${err}`);
-  });
-
-  // Request Origin Receipt
-  sendMessage('$<setLocalStorageReceipt>', { "message": "origin" })
-  .then(function(jsonData) {
-    if (jsonData) {
-      window.localStorage.setItem("braveOrigin.orderId", jsonData["braveOrigin.orderId"])
-      window.localStorage.setItem(jsonData["key"], jsonData["data"]);
-    } else {
-      console.error("No Origin Purchase Data");
-    }
-  }).catch(function(err) {
-    console.error(`An error occurred setting the local storage receipt: ${err}`);
-  });
 
   Object.defineProperty(window.chrome, 'braveSkus', {
     enumerable: false,

--- a/ios/brave-ios/Sources/BraveStore/Subscription/SDK/BraveStoreSDK.swift
+++ b/ios/brave-ios/Sources/BraveStore/Subscription/SDK/BraveStoreSDK.swift
@@ -507,41 +507,6 @@ public class BraveStoreSDK: AppStoreSDK {
     }
   }
 
-  /// Refreshes a Skus-SDK product order
-  /// - Throws: An exception if refreshing the order information fails
-  @MainActor
-  private func refreshOrder(for productGroup: BraveStoreProductGroup) async throws {
-    // This SDK currently only supports Leo
-    // until we update the VPN code to use it
-    if productGroup == .vpn {
-      return
-    }
-
-    guard let skusService else {
-      throw SkusError.skusServiceUnavailable
-    }
-
-    Logger.module.info("[BraveStoreSDK] - Refreshing Receipt")
-
-    // Attempt to update the Application Bundle's receipt, if necessary
-    try await AppStoreReceipt.sync()
-
-    // Create an order for the AppStore receipt
-    // If an order already exists, refreshes the order information
-    if let orderId = Preferences.AIChat.subscriptionOrderId.value, productGroup == .leo {
-      try await skusService.refreshOrder(orderId: orderId, for: productGroup)
-      return
-    }
-
-    if let orderId = Preferences.BraveOrigin.purchaseOrderId.value, productGroup == .origin {
-      try await skusService.refreshOrder(orderId: orderId, for: productGroup)
-      return
-    }
-
-    Logger.module.info("[BraveStoreSDK] - No Order To Refresh")
-    throw SkusError.cannotCreateOrder
-  }
-
   /// Updates the Skus-SDK credentials and order information
   /// - Parameter product: The product whose information to update
   /// - Throws: An exception if updating the purchase information fails
@@ -577,7 +542,16 @@ public class BraveStoreSDK: AppStoreSDK {
 
     // There is an order, and an expiry date, but no credentials
     // Fetch the credentials
-    try await skusService.fetchCredentials(orderId: orderId, for: product.group)
+    let skusResult = await skusService.fetchOrderCredentials(
+      domain: product.group.skusDomain,
+      orderId: orderId
+    )
+    if skusResult.code != .ok {
+      Logger.module.info(
+        "[SkusService] - Failed Fetching Credentials - \(skusResult.message, privacy: .public)"
+      )
+      throw SkusError.cannotFetchCredentials
+    }
 
     // Store the Order-ID
     switch product.group {

--- a/ios/brave-ios/Sources/BraveStore/Subscription/SDK/SkusStoreUtilities.swift
+++ b/ios/brave-ios/Sources/BraveStore/Subscription/SDK/SkusStoreUtilities.swift
@@ -167,7 +167,6 @@ extension JSONDecoder {
   }()
 }
 
-/// A group of helper methods built around BraveStoreProduct
 extension SkusSkusService {
   /// Creates an order from an AppStore Receipt
   /// If an order already exists, returns the existing Order-ID
@@ -200,30 +199,6 @@ extension SkusSkusService {
 
     Logger.module.info("[SkusService] - OrderID: \(orderId, privacy: .private(mask: .hash))")
     return orderId
-  }
-
-  /// Links an existing order to an AppStore Receipt
-  /// - Returns: The Order-ID associated with the AppStore receipt
-  /// - Parameter product: The purchased product to submit a receipt for
-  /// - Throws: An exception if the Order could not be linked with the receipt or if the Order already exists
-  @MainActor
-  public func submitReceipt(orderId: String, for product: BraveStoreProduct) async throws -> String
-  {
-    let receipt = try AppStoreReceipt.receipt(for: product)
-    let skusResult = await submitReceipt(
-      domain: product.group.skusDomain,
-      orderId: orderId,
-      receipt: receipt
-    )
-
-    if skusResult.code != Skus.SkusResultCode.ok {
-      Logger.module.info(
-        "[SkusService] - Failed to Submit Receipt - \(skusResult.message, privacy: .public)"
-      )
-      throw SkusError.cannotSubmitReceipt
-    }
-
-    return skusResult.message
   }
 
   /// Retrieves and refreshes the local cached order for the given Order-ID
@@ -294,76 +269,5 @@ extension SkusSkusService {
     }
 
     return try decode(skusResult.message)
-  }
-
-  /// Retrieves the Customer's Credentials for a specified Order
-  /// - Parameter orderId: The ID of the order whose credentials to retrieve
-  /// - Parameter group: The purchased product group whose credentials to fetch
-  /// - Throws: An exception if fetching credentials failed
-  @MainActor
-  public func fetchCredentials(orderId: String, for group: BraveStoreProductGroup) async throws {
-    Logger.module.info("[SkusService] - Fetching Order Credentials")
-    let skusResult = await fetchOrderCredentials(
-      domain: group.skusDomain,
-      orderId: orderId
-    )
-
-    if skusResult.code != Skus.SkusResultCode.ok {
-      Logger.module.info(
-        "[SkusService] - Failed Fetching Credentials - \(skusResult.message, privacy: .public)"
-      )
-      throw SkusError.cannotFetchCredentials
-    }
-
-    if !skusResult.message.isEmpty {
-      Logger.module.error(
-        "[SkusService] - Failed to Fetch Credentials: \(skusResult.message, privacy: .public)"
-      )
-      throw SkusError.cannotFetchCredentials
-    }
-  }
-
-  /// Retrieves the Customer's Credentials encoded as an HTTP-Cookie
-  /// - Parameter group: The purchased product group whose credentials to prepare
-  /// - Parameter path: Attribute that indicates a URL path that must exist in the requested URL in order to send the Cookie header.
-  /// - Returns: The Customer's Credentials Cookie.
-  ///            Example: `__Secure-sku#brave-product-premium=EncodedCookie;path=*;samesite=strict;expires=Tue, 06 Feb 2024 16:18:43 GMT;secure*`
-  @MainActor
-  public func prepareCredentials(
-    for group: BraveStoreProductGroup,
-    path: String = "*"
-  ) async throws -> String {
-    let skusResult = await prepareCredentialsPresentation(
-      domain: group.skusDomain,
-      path: path
-    )
-
-    if skusResult.code != Skus.SkusResultCode.ok {
-      Logger.module.info(
-        "[SkusService] - Failed Preparing Credentials - \(skusResult.message, privacy: .public)"
-      )
-      throw SkusError.cannotPrepareCredentials
-    }
-
-    return skusResult.message
-  }
-
-  @MainActor
-  public func testSkus() async throws {
-    let product = BraveStoreProduct.leoMonthly
-    let orderId = try await createOrder(for: product)
-    let order = try await refreshOrder(orderId: orderId, for: product.group)
-    assert(orderId == order.id, "Skus Order-Id Mismatch")
-
-    try await fetchCredentials(orderId: order.id, for: product.group)
-
-    let credentialsToken = try await prepareCredentials(for: product.group, path: "/")
-    assert(
-      credentialsToken.starts(with: "__Secure-sku#brave-leo-premium"),
-      "Invalid Skus Credentials"
-    )
-
-    let credentials = try await credentialsSummary(for: product.group)
-    assert(credentials.order.id == orderId, "Skus Credentials Mismatch")
   }
 }

--- a/ios/brave-ios/Sources/BraveVPN/BraveVPN.swift
+++ b/ios/brave-ios/Sources/BraveVPN/BraveVPN.swift
@@ -228,6 +228,13 @@ public class BraveVPN {
     }
   }
 
+  /// An in-memory flag that will show a "session expired" prompt to the user in the current browsing session.
+  public private(set) static var isSkusCredentialSessionExpired: Bool = false
+
+  public static func markSkusSessionExpired() {
+    Self.isSkusCredentialSessionExpired = true
+  }
+
   // MARK: - Actions
 
   /// Reconnects to the vpn.


### PR DESCRIPTION
- Removes `BraveSkusManager`, shifting majority of logic onto `SkusService` extension
- Removes `setLocalStorageReceipt` in SKUS user script since this data is already injected into the local storage in `BraveSkusAccountLink.injectLocalStorage` every navigation on valid domains
- Removes a number of unused functions/types
- Shifted VPN session expiration into `BraveVPN`
- Moves order ID preference update side-effects out of credential summary getter

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/55555

### Test
In general this change should be mostly removal of unused/unneeded code however it does deal with our premium products so a sanity test is probably warranted: 

- Sanity test Brave Account premium services linking (Account > Brave)
- Sanity test IAP/subscription based purchases (Apple)
- Sanity test IAP/subscription link to Brave Account (Brave/Apple > Account)
