### PR TITLE
Set minimum size for Brave Origin startup dialog

### DIFF
--- a/browser/ui/views/brave_origin/brave_origin_startup_view.cc
+++ b/browser/ui/views/brave_origin/brave_origin_startup_view.cc
@@ -210,6 +210,11 @@ void BraveOriginStartupView::Init(Profile* profile) {
 
   web_view_ = std::make_unique<views::WebView>(profile);
 
+  // Sets the widget's minimum size to match the initial dialog dimensions, so
+  // users cannot resize below the designed layout. View::GetMinimumSize()
+  // defaults to GetPreferredSize() when no layout manager is set.
+  web_view_->SetPreferredSize(gfx::Size(kDialogWidth, kDialogHeight));
+
   // GetWebContents() creates the WebContents if it doesn't already exist.
   web_view_->GetWebContents()->SetDelegate(this);
   Observe(web_view_->web_contents());


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/55554

## Summary

The Brave Origin startup dialog had no minimum size, so users could resize it down to a tiny window. This constrains the minimum size to match the dialog's initial dimensions (`540x500`, or `540x600` on Linux).

Implementation: setting the `WebView` contents view's preferred size makes `View::GetMinimumSize()` return the same value by default, which `NonClientView`/`ClientView` propagate up to the widget. `Widget::GetMinimumSize()` then prevents the user from resizing below that.

## Test plan

- [ ] Launch a Brave Origin branded build (pre-purchase) so the startup dialog appears.
- [ ] Attempt to resize the dialog window smaller than the initial size. It should refuse to shrink below `540x500` (`540x600` on Linux).
- [ ] Verify the dialog still opens at its original initial size and remains centered.
- [ ] Sanity check on macOS, Windows, and Linux (Linux has a different default height).