### PR TITLE
Register PWA file_handlers for .pdf on Windows

### DIFF
--- a/chromium_src/chrome/installer/util/shell_util.cc
+++ b/chromium_src/chrome/installer/util/shell_util.cc
@@ -45,9 +45,14 @@ int GetIconIndexForFileType() {
   GetProgIdEntries(app_info, entries);
 
 // Give BraveXXFile prog id for some file type.(ex, .pdf or .svg) instead of
-// BraveHTML.
+// BraveHTML. Only applies when registering Brave's own browser handler — must
+// not run for PWA file_handler registration, which calls
+// ShellUtil::AddFileAssociations with the PWA's own prog id and needs that
+// prog id (not BraveFile) written to `<ext>\OpenWithProgids` so the PWA
+// appears in the Windows "Open with" picker (fixes brave/brave-browser#55550).
 #define BRAVE_GET_APP_EXT_REGISTRATION_ENTRIES                         \
-  if (installer::ShouldUseFileTypeProgId(ext)) {                       \
+  if (installer::ShouldUseFileTypeProgId(ext) &&                       \
+      installer::IsBrowserProgId(prog_id)) {                           \
     entries->push_back(std::make_unique<RegistryEntry>(                \
         key_name, installer::GetProgIdForFileType(), std::wstring())); \
     return;                                                            \

--- a/installer/util/brave_shell_util.cc
+++ b/installer/util/brave_shell_util.cc
@@ -34,4 +34,11 @@ bool ShouldUseFileTypeProgId(std::wstring_view ext) {
   return (ext == L".pdf" || ext == L".svg");
 }
 
+bool IsBrowserProgId(std::wstring_view prog_id) {
+  const wchar_t* browser_prefix = install_static::GetBrowserProgIdPrefix();
+  const wchar_t* pdf_prefix = install_static::GetPDFProgIdPrefix();
+  return (browser_prefix && prog_id.starts_with(browser_prefix)) ||
+         (pdf_prefix && prog_id.starts_with(pdf_prefix));
+}
+
 }  // namespace installer

--- a/installer/util/brave_shell_util.h
+++ b/installer/util/brave_shell_util.h
@@ -13,6 +13,11 @@ namespace installer {
 std::wstring GetProgIdForFileType();
 bool ShouldUseFileTypeProgId(std::wstring_view ext);
 
+// Returns true if `prog_id` is one of Brave's main browser prog ids (the
+// HTML/PDF prog id for this install mode). PWA prog ids, which use the
+// `<base_app_id>.<hash>` format, never match.
+bool IsBrowserProgId(std::wstring_view prog_id);
+
 }  // namespace installer
 
 #endif  // BRAVE_INSTALLER_UTIL_BRAVE_SHELL_UTIL_H_


### PR DESCRIPTION
## Summary

Fix for [brave/brave-browser#55550](https://github.com/brave/brave-browser/issues/55550): on Windows, when a user installs a PWA whose manifest declares `file_handlers` for `application/pdf`, the PWA is not registered as an "Open with" choice for `.pdf` files. Other extensions are unaffected — only `.pdf` (and by the same code path, `.svg`).

## Root Cause

`brave/chromium_src/chrome/installer/util/shell_util.cc` defines the macro `BRAVE_GET_APP_EXT_REGISTRATION_ENTRIES`, which is spliced into upstream `GetAppExtRegistrationEntries`. The macro unconditionally substitutes `BraveFile` for any prog id when `ext` is `.pdf` or `.svg`, then `return`s before the upstream `entries->push_back(<key, prog_id, "">)` runs:

```cpp
#define BRAVE_GET_APP_EXT_REGISTRATION_ENTRIES                         \
  if (installer::ShouldUseFileTypeProgId(ext)) {                       \
    entries->push_back(std::make_unique<RegistryEntry>(                \
        key_name, installer::GetProgIdForFileType(), std::wstring())); \
    return;                                                            \
  }
```

That is correct for the Brave-browser install flow — callers in `GetChromeAppRegistrationEntries` pass `BraveHTML` / `BravePDF`, which we want collapsed to `BraveFile`. But `ShellUtil::AddFileAssociations` is also invoked from `chrome/browser/web_applications/os_integration/web_app_file_handler_registration_win.cc::RegisterFileHandlersWithOsTask` during PWA file_handler registration, with a per-PWA prog id (constructed by `web_app_handler_registration_utils_win.cc::GetProgId` as `<install_static::GetBaseAppId()>.<hash>`). The macro silently drops that PWA prog id and writes `BraveFile` instead, so the PWA's prog id never lands in `HKCU\Software\Classes\.pdf\OpenWithProgids` and the PWA never appears in the Windows "Open with" picker for `.pdf`.

## Fix

Gate the substitution on the prog id being one of Brave's main browser prog ids (HTML or PDF prefix for the current install mode). A new helper `installer::IsBrowserProgId` in `brave/installer/util/brave_shell_util.{h,cc}` returns true when `prog_id` starts with `install_static::GetBrowserProgIdPrefix()` or `GetPDFProgIdPrefix()` (e.g. `BraveHTML`, `BravePDF`, `BraveBHTML`, `BraveBPDF`, …). PWA prog ids use the `<base_app_id>.<hash>` format and never match either prefix, so they fall through to the upstream `entries->push_back` and the PWA is registered as a handler for `.pdf` / `.svg` in `OpenWithProgids`.

The browser-install flow is unchanged: `BraveHTML`/`BravePDF` callers still match `IsBrowserProgId` and still get substituted to `BraveFile`.

## Test Plan

- [ ] Manual verification on Windows: install a PWA whose manifest declares `file_handlers: [{ action: '/', name: 'PDF files', accept: { 'application/pdf': ['.pdf'] } }]`, then right-click a `.pdf` and confirm the PWA appears in the "Open with" list. (Cannot run locally — dev environment is macOS.)
- [ ] Verify Brave itself remains the default `.pdf` handler after the PWA is installed.
- [ ] Check that `HKEY_CURRENT_USER\SOFTWARE\Classes\.pdf\OpenWithProgids` contains both the Brave handler and the PWA's prog id after PWA install.
- [ ] CI passes cleanly.

Note: `npm run format` and `npm run presubmit` could not be run in this environment because the project scripts hit a Node.js 24 / `commander` ESM-vs-CJS import error (`SyntaxError: Named export 'program' not found`) that reproduces on master without any changes. CI will exercise these.