### PR TITLE
[iOS] Add Skus JavaScriptFeature

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -577,6 +577,17 @@ public class BrowserViewController: UIViewController {
       BraveWebView.didResetConfiguration = { profile, configuration in
         configuration.prepareBraveConfiguration()
       }
+      let configuration = BraveWebViewConfiguration(profile: profileController.profile)
+      configuration.setSkusCredentialsFetchedCallback { [weak self] domain, message in
+        guard let self,
+          let skusService = Skus.SkusServiceFactory.get(profile: profileController.profile)
+        else {
+          return
+        }
+        Task {
+          await skusService.updatePreferences(for: domain, summaryData: Data(message.utf8))
+        }
+      }
     }
 
     Task { @MainActor in

--- a/ios/browser/api/web_view/BUILD.gn
+++ b/ios/browser/api/web_view/BUILD.gn
@@ -43,6 +43,7 @@ source_set("web_view") {
     "//brave/ios/browser/brave_search",
     "//brave/ios/browser/favicon",
     "//brave/ios/browser/serp_metrics",
+    "//brave/ios/browser/skus",
     "//brave/ios/browser/ui/web_view:features",
     "//brave/ios/browser/ui/webui/brave_wallet",
     "//brave/ios/browser/web/document_fetch",

--- a/ios/browser/api/web_view/brave_web_view_configuration.h
+++ b/ios/browser/api/web_view/brave_web_view_configuration.h
@@ -39,6 +39,15 @@ CWV_EXPORT
 
 @end
 
+CWV_EXPORT
+@interface BraveWebViewConfiguration (SkusJS)
+// Set a closure to be executed when a Brave Account page requests a SKUs
+// credential summary for a given domain. `message` is the result from the skus
+// service.
+- (void)setSkusCredentialsFetchedCallback:(void (^)(NSString* domain,
+                                                    NSString* message))callback;
+@end
+
 NS_ASSUME_NONNULL_END
 
 #endif  // BRAVE_IOS_BROWSER_API_WEB_VIEW_BRAVE_WEB_VIEW_CONFIGURATION_H_

--- a/ios/browser/api/web_view/brave_web_view_configuration.mm
+++ b/ios/browser/api/web_view/brave_web_view_configuration.mm
@@ -7,9 +7,14 @@
 
 #include <WebKit/WebKit.h>
 
+#include <string>
+
 #include "base/apple/foundation_util.h"
+#include "base/functional/bind.h"
+#include "base/strings/sys_string_conversions.h"
 #include "brave/ios/browser/api/profile/profile_bridge_impl.h"
 #include "brave/ios/browser/api/web_view/brave_web_view_configuration_provider.h"
+#include "brave/ios/browser/skus/skus_javascript_feature.h"
 #include "brave/ios/browser/ui/web_view/features.h"
 #include "components/autofill/core/browser/data_manager/personal_data_manager.h"
 #include "components/keyed_service/core/service_access_type.h"
@@ -75,6 +80,20 @@
       base::apple::ObjCCastStrict<ProfileBridgeImpl>(profileBridge).profile;
   return BraveWebViewConfigurationProvider::FromBrowserState(profile)
       .GetConfiguration();
+}
+
+@end
+
+@implementation BraveWebViewConfiguration (SkusJS)
+
+- (void)setSkusCredentialsFetchedCallback:
+    (void (^)(NSString* domain, NSString* message))callback {
+  skus::SkusJavaScriptFeature::FromBrowserState(self.browserState)
+      ->SetCredentialSummaryFetched(base::BindRepeating(
+          ^(const std::string domain, const std::string message) {
+            callback(base::SysUTF8ToNSString(domain),
+                     base::SysUTF8ToNSString(message));
+          }));
 }
 
 @end

--- a/ios/browser/skus/BUILD.gn
+++ b/ios/browser/skus/BUILD.gn
@@ -3,17 +3,21 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import("//ios/web/public/js_messaging/optimize_ts.gni")
+
 source_set("skus") {
   sources = [
+    "skus_javascript_feature.h",
+    "skus_javascript_feature.mm",
     "skus_sdk_factory_wrappers.h",
     "skus_sdk_factory_wrappers.mm",
     "skus_service_factory.h",
     "skus_service_factory.mm",
   ]
   deps = [
+    ":skus_helper_js",
     "//brave/components/skus/browser",
     "//brave/components/skus/common",
-    "//brave/components/skus/common:mojom",
     "//brave/ios/browser/api/skus:skus_mojom_wrappers",
     "//brave/ios/browser/keyed_service",
     "//components/keyed_service/core",
@@ -21,8 +25,22 @@ source_set("skus") {
     "//ios/chrome/browser/shared/model/application_context",
     "//ios/chrome/browser/shared/model/profile",
     "//ios/chrome/browser/shared/model/profile:profile_keyed_service_factory",
-    "//ios/web/public",
-    "//mojo/public/cpp/bindings",
     "//services/network/public/cpp",
+    "//url",
   ]
+  public_deps = [
+    "//base",
+    "//brave/components/skus/common:mojom",
+    "//ios/web/public",
+    "//ios/web/public/js_messaging",
+    "//mojo/public/cpp/bindings",
+  ]
+}
+
+optimize_ts("skus_helper_js") {
+  visibility = [ ":skus" ]
+
+  sources = [ "resources/skus_helper.ts" ]
+
+  deps = [ "//ios/web/public/js_messaging:util_scripts" ]
 }

--- a/ios/browser/skus/resources/skus_helper.ts
+++ b/ios/browser/skus/resources/skus_helper.ts
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { sendWebKitMessageWithReply } from '//ios/web/public/js_messaging/resources/utils.js'
+
+const sendMessage = (methodId: string, data: object): Promise<any> => {
+  return sendWebKitMessageWithReply('BraveSkusMessageHandler', {
+    method_id: methodId,
+    data: data,
+  })
+}
+
+// Setup a window.chrome object if it doesn't exist
+if (!(window as any).chrome) {
+  ;(window as any).chrome = {}
+}
+
+Object.defineProperty((window as any).chrome, 'braveSkus', {
+  enumerable: false,
+  configurable: false,
+  writable: false,
+  value: {
+    refresh_order(orderId: string): Promise<any> {
+      return sendMessage('refreshOrder', { orderId: orderId })
+    },
+
+    fetch_order_credentials(orderId: string): Promise<any> {
+      return sendMessage('fetchOrderCredentials', { orderId: orderId })
+    },
+
+    prepare_credentials_presentation(
+      domain: string,
+      path: string,
+    ): Promise<any> {
+      return sendMessage('prepareCredentialsPresentation', {
+        domain: domain,
+        path: path,
+      })
+    },
+
+    credential_summary(domain: string): Promise<any> {
+      return sendMessage('credentialsSummary', { domain: domain })
+    },
+  },
+})

--- a/ios/browser/skus/skus_javascript_feature.h
+++ b/ios/browser/skus/skus_javascript_feature.h
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_IOS_BROWSER_SKUS_SKUS_JAVASCRIPT_FEATURE_H_
+#define BRAVE_IOS_BROWSER_SKUS_SKUS_JAVASCRIPT_FEATURE_H_
+
+#include <optional>
+#include <string>
+
+#include "base/functional/callback_forward.h"
+#include "base/memory/raw_ptr.h"
+#include "base/supports_user_data.h"
+#include "brave/components/skus/common/skus_sdk.mojom.h"
+#include "ios/web/public/js_messaging/java_script_feature.h"
+#include "mojo/public/cpp/bindings/remote.h"
+
+namespace web {
+class BrowserState;
+class WebState;
+}  // namespace web
+
+class ProfileIOS;
+
+namespace skus {
+
+// A JavaScriptFeature that exposes a `window.chrome.braveSkus` API to the
+// Brave accounts website (account.brave.com and its staging / dev
+// counterparts) so the SKUs SDK on the page can ask the browser to refresh
+// orders, fetch credentials, and prepare them for presentation. Calls are
+// forwarded over mojo to a profile-scoped SkusService.
+class SkusJavaScriptFeature : public web::JavaScriptFeature,
+                              public base::SupportsUserData::Data {
+ public:
+  ~SkusJavaScriptFeature() override;
+
+  using CredentialSummaryFetchedCallback =
+      base::RepeatingCallback<void(const std::string domain,
+                                   const std::string message)>;
+
+  static SkusJavaScriptFeature* FromBrowserState(
+      web::BrowserState* browser_state);
+
+  void SetCredentialSummaryFetched(CredentialSummaryFetchedCallback callback);
+
+  // web::JavaScriptFeature:
+  bool GetFeatureRepliesToMessages() const override;
+  std::optional<std::string> GetScriptMessageHandlerName() const override;
+  void ScriptMessageReceivedWithReply(
+      web::WebState* web_state,
+      const web::ScriptMessage& message,
+      ScriptMessageReplyCallback callback) override;
+
+ private:
+  explicit SkusJavaScriptFeature(ProfileIOS* profile);
+
+  // Lazily binds `skus_service_` to a fresh remote for `profile_`. After this
+  // call `skus_service_` is bound iff the SKUs service is available for the
+  // profile.
+  void EnsureMojoConnected();
+  void OnMojoConnectionError();
+  void OnCredentialSummary(const std::string domain,
+                           ScriptMessageReplyCallback callback,
+                           mojom::SkusResultPtr response);
+
+  CredentialSummaryFetchedCallback credential_summary_fetched_;
+  raw_ptr<ProfileIOS> profile_;
+  mojo::Remote<mojom::SkusService> skus_service_;
+};
+
+}  // namespace skus
+
+#endif  // BRAVE_IOS_BROWSER_SKUS_SKUS_JAVASCRIPT_FEATURE_H_

--- a/ios/browser/skus/skus_javascript_feature.mm
+++ b/ios/browser/skus/skus_javascript_feature.mm
@@ -1,0 +1,234 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/ios/browser/skus/skus_javascript_feature.h"
+
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+
+#include "base/check.h"
+#include "base/containers/fixed_flat_set.h"
+#include "base/functional/bind.h"
+#include "base/json/json_reader.h"
+#include "base/memory/ptr_util.h"
+#include "base/values.h"
+#include "brave/ios/browser/skus/skus_service_factory.h"
+#include "ios/chrome/browser/shared/model/profile/profile_ios.h"
+#include "ios/web/public/browser_state.h"
+#include "ios/web/public/js_messaging/origin_filter.h"
+#include "ios/web/public/js_messaging/script_message.h"
+#include "ios/web/public/web_state.h"
+#include "mojo/public/cpp/bindings/pending_remote.h"
+#include "url/gurl.h"
+#include "url/url_constants.h"
+
+namespace skus {
+
+namespace {
+
+constexpr char kSkusJavaScriptFeatureKeyName[] =
+    "brave_skus_javascript_feature";
+constexpr char kScriptName[] = "skus_helper";
+constexpr char kScriptHandlerName[] = "BraveSkusMessageHandler";
+
+constexpr char kMethodIdKey[] = "method_id";
+constexpr char kDataKey[] = "data";
+constexpr char kOrderIdKey[] = "orderId";
+constexpr char kDomainKey[] = "domain";
+constexpr char kPathKey[] = "path";
+
+constexpr char kMethodRefreshOrder[] = "refreshOrder";
+constexpr char kMethodFetchOrderCredentials[] = "fetchOrderCredentials";
+constexpr char kMethodPrepareCredentialsPresentation[] =
+    "prepareCredentialsPresentation";
+constexpr char kMethodCredentialsSummary[] = "credentialsSummary";
+
+using ScriptMessageReplyCallback =
+    base::OnceCallback<void(const base::Value* reply, NSString* error)>;
+
+// Resolves `callback` with `response->message` parsed as JSON, or with null if
+// parsing fails.
+void ReplyWithJsonResult(ScriptMessageReplyCallback callback,
+                         mojom::SkusResultPtr response) {
+  std::optional<base::Value> parsed = base::JSONReader::Read(
+      response->message, base::JSON_PARSE_CHROMIUM_EXTENSIONS |
+                             base::JSONParserOptions::JSON_PARSE_RFC);
+  if (!parsed) {
+    std::move(callback).Run(nullptr, nil);
+    return;
+  }
+  std::move(callback).Run(&*parsed, nil);
+}
+
+// Resolves `callback` with `response->message` as a raw string.
+void ReplyWithStringResult(ScriptMessageReplyCallback callback,
+                           mojom::SkusResultPtr response) {
+  base::Value value(response->message);
+  std::move(callback).Run(&value, nil);
+}
+
+}  // namespace
+
+SkusJavaScriptFeature::SkusJavaScriptFeature(ProfileIOS* profile)
+    : JavaScriptFeature(
+          web::ContentWorld::kPageContentWorld,
+          {FeatureScript::CreateWithFilename(
+              kScriptName,
+              FeatureScript::InjectionTime::kDocumentStart,
+              FeatureScript::TargetFrames::kMainFrame,
+              FeatureScript::ReinjectionBehavior::kInjectOncePerWindow,
+              FeatureScript::PlaceholderReplacementsCallback(),
+              web::OriginFilter::kBraveAccount)},
+          /*dependent_feature=*/{},
+          web::OriginFilter::kBraveAccount),
+      profile_(profile) {}
+
+SkusJavaScriptFeature::~SkusJavaScriptFeature() = default;
+
+// static
+SkusJavaScriptFeature* SkusJavaScriptFeature::FromBrowserState(
+    web::BrowserState* browser_state) {
+  DCHECK(browser_state);
+  SkusJavaScriptFeature* feature = static_cast<SkusJavaScriptFeature*>(
+      browser_state->GetUserData(kSkusJavaScriptFeatureKeyName));
+  if (!feature) {
+    feature =
+        new SkusJavaScriptFeature(ProfileIOS::FromBrowserState(browser_state));
+    browser_state->SetUserData(kSkusJavaScriptFeatureKeyName,
+                               base::WrapUnique(feature));
+  }
+  return feature;
+}
+
+bool SkusJavaScriptFeature::GetFeatureRepliesToMessages() const {
+  return true;
+}
+
+std::optional<std::string> SkusJavaScriptFeature::GetScriptMessageHandlerName()
+    const {
+  return kScriptHandlerName;
+}
+
+void SkusJavaScriptFeature::SetCredentialSummaryFetched(
+    CredentialSummaryFetchedCallback callback) {
+  credential_summary_fetched_ = std::move(callback);
+}
+
+void SkusJavaScriptFeature::EnsureMojoConnected() {
+  if (skus_service_.is_bound()) {
+    return;
+  }
+  mojo::PendingRemote<mojom::SkusService> pending =
+      SkusServiceFactory::GetForProfile(profile_);
+  if (!pending) {
+    return;
+  }
+  skus_service_.Bind(std::move(pending));
+  skus_service_.set_disconnect_handler(base::BindOnce(
+      &SkusJavaScriptFeature::OnMojoConnectionError, base::Unretained(this)));
+}
+
+void SkusJavaScriptFeature::OnMojoConnectionError() {
+  skus_service_.reset();
+}
+
+void SkusJavaScriptFeature::OnCredentialSummary(
+    const std::string domain,
+    ScriptMessageReplyCallback callback,
+    mojom::SkusResultPtr response) {
+  if (credential_summary_fetched_) {
+    credential_summary_fetched_.Run(domain, response->message);
+  }
+  ReplyWithJsonResult(std::move(callback), std::move(response));
+}
+
+void SkusJavaScriptFeature::ScriptMessageReceivedWithReply(
+    web::WebState* web_state,
+    const web::ScriptMessage& message,
+    ScriptMessageReplyCallback callback) {
+  GURL request_url = message.request_url().value_or(GURL());
+  if (!message.is_main_frame() || !request_url.is_valid()) {
+    std::move(callback).Run(nullptr, nil);
+    return;
+  }
+
+  const base::DictValue* body =
+      message.body() ? message.body()->GetIfDict() : nullptr;
+  if (!body) {
+    std::move(callback).Run(nullptr, nil);
+    return;
+  }
+
+  const std::string* method_id = body->FindString(kMethodIdKey);
+  const base::DictValue* data = body->FindDict(kDataKey);
+  if (!method_id || !data) {
+    std::move(callback).Run(nullptr, nil);
+    return;
+  }
+
+  EnsureMojoConnected();
+  if (!skus_service_.is_bound()) {
+    std::move(callback).Run(nullptr, nil);
+    return;
+  }
+
+  const std::string host = request_url.GetHost();
+
+  if (*method_id == kMethodRefreshOrder) {
+    const std::string* order_id = data->FindString(kOrderIdKey);
+    if (!order_id) {
+      std::move(callback).Run(nullptr, nil);
+      return;
+    }
+    skus_service_->RefreshOrder(
+        host, *order_id,
+        base::BindOnce(&ReplyWithJsonResult, std::move(callback)));
+    return;
+  }
+
+  if (*method_id == kMethodFetchOrderCredentials) {
+    const std::string* order_id = data->FindString(kOrderIdKey);
+    if (!order_id) {
+      std::move(callback).Run(nullptr, nil);
+      return;
+    }
+    skus_service_->FetchOrderCredentials(
+        host, *order_id,
+        base::BindOnce(&ReplyWithStringResult, std::move(callback)));
+    return;
+  }
+
+  if (*method_id == kMethodPrepareCredentialsPresentation) {
+    const std::string* domain = data->FindString(kDomainKey);
+    const std::string* path = data->FindString(kPathKey);
+    if (!domain || !path) {
+      std::move(callback).Run(nullptr, nil);
+      return;
+    }
+    skus_service_->PrepareCredentialsPresentation(
+        *domain, *path,
+        base::BindOnce(&ReplyWithStringResult, std::move(callback)));
+    return;
+  }
+
+  if (*method_id == kMethodCredentialsSummary) {
+    const std::string* domain = data->FindString(kDomainKey);
+    if (!domain) {
+      std::move(callback).Run(nullptr, nil);
+      return;
+    }
+    skus_service_->CredentialSummary(
+        *domain,
+        base::BindOnce(&SkusJavaScriptFeature::OnCredentialSummary,
+                       base::Unretained(this), *domain, std::move(callback)));
+    return;
+  }
+
+  std::move(callback).Run(nullptr, nil);
+}
+
+}  // namespace skus

--- a/ios/browser/web/BUILD.gn
+++ b/ios/browser/web/BUILD.gn
@@ -31,6 +31,7 @@ source_set("web") {
     "//brave/ios/browser/brave_shields",
     "//brave/ios/browser/component_updater:zxcvbn_data_component_installer",
     "//brave/ios/browser/global_privacy_control",
+    "//brave/ios/browser/skus",
     "//brave/ios/browser/ui/web_view:features",
     "//brave/ios/browser/web/de_amp",
     "//brave/ios/browser/web/document_fetch",

--- a/ios/browser/web/brave_web_client.mm
+++ b/ios/browser/web/brave_web_client.mm
@@ -23,6 +23,7 @@
 #include "brave/ios/browser/brave_search/brave_search_make_default_javascript_feature.h"
 #include "brave/ios/browser/brave_shields/cookie_control_javascript_feature.h"
 #include "brave/ios/browser/global_privacy_control/gpc_javascript_feature.h"
+#include "brave/ios/browser/skus/skus_javascript_feature.h"
 #include "brave/ios/browser/ui/web_view/features.h"
 #include "brave/ios/browser/web/brave_web_main_parts.h"
 #include "brave/ios/browser/web/de_amp/de_amp_javascript_feature.h"
@@ -158,6 +159,8 @@ std::vector<web::JavaScriptFeature*> BraveWebClient::GetJavaScriptFeatures(
     features.push_back(NightModeJavaScriptFeature::GetInstance());
     features.push_back(PageMetadataJavaScriptFeature::GetInstance());
     features.push_back(brave::ReaderModeJavaScriptFeature::GetInstance());
+    features.push_back(
+        skus::SkusJavaScriptFeature::FromBrowserState(browser_state));
     features.push_back(youtube::YouTubeQualityJavaScriptFeature::GetInstance());
     if (!base::FeatureList::IsEnabled(
             brave::features::kUseChromiumWebViewsAutofill)) {


### PR DESCRIPTION
Adds a JavaScriptFeature to handle the Brave Account premium shim layer with the SKUs service when the `UseProfileWebViewConfiguration` feature flag is enabled

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/55561
 