### PR TITLE
[Origin] Defer policy init signal until BraveProfilePolicyProvider refreshes

### DIFF
--- a/browser/brave_origin/brave_origin_service_factory.cc
+++ b/browser/brave_origin/brave_origin_service_factory.cc
@@ -233,6 +233,29 @@ BraveOriginServiceFactory::BraveOriginServiceFactory()
           "BraveOriginService",
           ProfileSelections::BuildRedirectedInIncognito()) {
   DependsOn(skus::SkusServiceFactory::GetInstance());
+  // This factory owns the lazy initialization of `BraveOriginPolicyManager`
+  // (in `BuildServiceInstanceForBrowserContext`). Mark the manager as
+  // expected-to-be-initialized as soon as the factory is registered so that
+  // `BraveProfilePolicyProvider::IsInitializationComplete` knows to gate on
+  // the manager actually finishing initialization. Without this gate
+  // `BraveProvider`'s first `RefreshPolicies` (triggered by
+  // `AdBlockOnlyModePolicyManager`'s `OnBravePoliciesReady`, which fires at
+  // process start) would flip `first_policies_loaded_` to true with an
+  // empty Brave Origin bundle, and consumers of
+  // `PolicyService::OnPolicyServiceInitialized` (notably
+  // `AdsServiceImpl::MaybeStartBatAdsService`) would evaluate against a
+  // managed pref store that does not yet reflect `BraveRewardsDisabled`.
+  //
+  // Upstream unit tests build `ProfilePolicyConnector` directly without
+  // going through `EnsureBrowserContextKeyedServiceFactoriesBuilt()`, so this
+  // factory's `GetInstance()` is never called in those tests, the flag stays
+  // false, and `BraveProvider::IsInitializationComplete` short-circuits to
+  // true to avoid blocking the upstream tests forever. The affected tests
+  // are in `chrome/browser/policy/profile_policy_connector_unittest.cc`,
+  // primarily the `ProfilePolicyConnectorTest.AffiliationMetrics_*`,
+  // `LocalTestProviderUseAndRevert`, and `ChromeosPrimaryUserPoliciesProxied`
+  // cases that use `PolicyServiceInitializedWaiter`.
+  BraveOriginPolicyManager::GetInstance()->SetExpectedToBeInitialized();
 }
 
 BraveOriginServiceFactory::~BraveOriginServiceFactory() = default;

--- a/components/brave_origin/brave_origin_policy_manager.cc
+++ b/components/brave_origin/brave_origin_policy_manager.cc
@@ -167,6 +167,14 @@ bool BraveOriginPolicyManager::IsInitialized() const {
   return initialized_;
 }
 
+void BraveOriginPolicyManager::SetExpectedToBeInitialized() {
+  expected_to_be_initialized_ = true;
+}
+
+bool BraveOriginPolicyManager::IsExpectedToBeInitialized() const {
+  return expected_to_be_initialized_;
+}
+
 void BraveOriginPolicyManager::SetPurchased(bool purchased) {
   if (is_purchased_ == purchased) {
     return;
@@ -196,6 +204,7 @@ bool BraveOriginPolicyManager::IsPurchased() const {
 
 void BraveOriginPolicyManager::Shutdown() {
   initialized_ = false;
+  expected_to_be_initialized_ = false;
   is_purchased_ = false;
   browser_policy_definitions_.clear();
   profile_policy_definitions_.clear();

--- a/components/brave_origin/brave_origin_policy_manager.h
+++ b/components/brave_origin/brave_origin_policy_manager.h
@@ -69,6 +69,13 @@ class BraveOriginPolicyManager {
   // Check if the singleton has been initialized
   bool IsInitialized() const;
 
+  // Declares that `Init()` is expected to be called later in this process.
+  // Consumers gated on this manager use it to distinguish production startup
+  // (where lazy `Init()` will eventually run, so they should wait) from test
+  // contexts that never bootstrap us (where there is nothing to wait for).
+  void SetExpectedToBeInitialized();
+  bool IsExpectedToBeInitialized() const;
+
   // Set/get the purchase state. When the purchase state changes,
   // observers are notified to refresh policies.
   void SetPurchased(bool purchased);
@@ -97,6 +104,7 @@ class BraveOriginPolicyManager {
                               std::optional<std::string_view> profile_id) const;
 
   bool initialized_ = false;
+  bool expected_to_be_initialized_ = false;
   bool is_purchased_ = false;
   BraveOriginPolicyMap browser_policy_definitions_;
   BraveOriginPolicyMap profile_policy_definitions_;

--- a/components/brave_policy/BUILD.gn
+++ b/components/brave_policy/BUILD.gn
@@ -56,6 +56,7 @@ source_set("unit_tests") {
     ":policy_initialization_waiter",
     "//base",
     "//base/test:test_support",
+    "//brave/components/brave_origin",
     "//brave/components/resources:strings",
     "//components/enterprise",
     "//components/policy/core/browser",

--- a/components/brave_policy/brave_profile_policy_provider.cc
+++ b/components/brave_policy/brave_profile_policy_provider.cc
@@ -7,10 +7,10 @@
 
 #include <utility>
 
-#include "base/logging.h"
 #include "base/values.h"
 #include "brave/components/brave_origin/brave_origin_utils.h"
 #include "brave/components/brave_policy/ad_block_only_mode/ad_block_only_mode_policy_manager.h"
+#include "build/build_config.h"
 #include "components/policy/core/common/policy_bundle.h"
 #include "components/policy/core/common/policy_map.h"
 #include "components/policy/core/common/policy_namespace.h"
@@ -48,6 +48,39 @@ void BraveProfilePolicyProvider::RefreshPolicies(
   first_policies_loaded_ = true;
 
   UpdatePolicy(std::move(bundle));
+}
+
+bool BraveProfilePolicyProvider::IsInitializationComplete(
+    policy::PolicyDomain domain) const {
+  auto* manager = brave_origin::BraveOriginPolicyManager::GetInstance();
+#if !BUILDFLAG(IS_IOS)
+  // Desktop/Android only: short-circuit when our factory has not been
+  // registered in this process. This is the case for upstream unit tests
+  // (e.g. `ProfilePolicyConnectorTest`) that build `ProfilePolicyConnector`
+  // directly without going through Brave's keyed-service-factory startup --
+  // those tests have no Brave Origin source to wait for, so we report
+  // ready and let the upstream `OnPolicyServiceInitialized` signal fire
+  // normally.
+  //
+  // iOS does not run these upstream unit tests, and its own keyed-service
+  // startup always constructs `BraveOriginServiceFactory` (which lazily
+  // initializes `BraveOriginPolicyManager`). The gate below works there
+  // without the flag check.
+  if (!manager->IsExpectedToBeInitialized()) {
+    return true;
+  }
+#endif  // !BUILDFLAG(IS_IOS)
+  // We observe both `BraveOriginPolicyManager` and
+  // `AdBlockOnlyModePolicyManager` but they initialise on different schedules:
+  // `AdBlockOnlyModePolicyManager` is initialised synchronously at process
+  // start while `BraveOriginPolicyManager` is initialised lazily during
+  // profile keyed-service build. The first `RefreshPolicies` triggered by
+  // AdBlockOnlyMode's `OnBravePoliciesReady` produces a bundle without Brave
+  // Origin policies and would otherwise flip `first_policies_loaded_` to true
+  // prematurely. Gate on Brave Origin's `IsInitialized()` so consumers don't
+  // observe an empty managed pref store before Brave Origin policies (e.g.
+  // `BraveRewardsDisabled`) have been merged.
+  return first_policies_loaded_ && manager->IsInitialized();
 }
 
 bool BraveProfilePolicyProvider::IsFirstPolicyLoadComplete(

--- a/components/brave_policy/brave_profile_policy_provider.h
+++ b/components/brave_policy/brave_profile_policy_provider.h
@@ -34,6 +34,7 @@ class BraveProfilePolicyProvider : public policy::ConfigurationPolicyProvider,
   // ConfigurationPolicyProvider implementation.
   void Init(policy::SchemaRegistry* registry) override;
   void RefreshPolicies(policy::PolicyFetchReason reason) override;
+  bool IsInitializationComplete(policy::PolicyDomain domain) const override;
   bool IsFirstPolicyLoadComplete(policy::PolicyDomain domain) const override;
 
   // BravePolicyObserver implementation.

--- a/components/brave_policy/brave_profile_policy_provider_unittest.cc
+++ b/components/brave_policy/brave_profile_policy_provider_unittest.cc
@@ -8,6 +8,8 @@
 #include <memory>
 
 #include "base/test/task_environment.h"
+#include "brave/components/brave_origin/brave_origin_policy_manager.h"
+#include "brave/components/brave_origin/brave_origin_prefs.h"
 #include "components/policy/core/common/policy_bundle.h"
 #include "components/policy/core/common/policy_namespace.h"
 #include "components/policy/core/common/policy_types.h"
@@ -19,18 +21,23 @@ namespace brave_policy {
 
 class BraveProfilePolicyProviderTest : public ::testing::Test {
  public:
-  BraveProfilePolicyProviderTest() = default;
+  BraveProfilePolicyProviderTest() {
+    brave_origin::RegisterLocalStatePrefs(local_state_.registry());
+  }
   ~BraveProfilePolicyProviderTest() override = default;
 
   void TearDown() override {
-    if (provider_.IsInitializationComplete(policy::POLICY_DOMAIN_CHROME)) {
-      provider_.Shutdown();
-    }
+    provider_.Shutdown();
+    // Reset the process-wide singleton so its state does not leak between
+    // tests. `BraveOriginPolicyManager::Shutdown()` is safe to call even if
+    // `Init()` was never called.
+    brave_origin::BraveOriginPolicyManager::GetInstance()->Shutdown();
   }
 
  protected:
   base::test::TaskEnvironment task_environment_;
   policy::SchemaRegistry schema_registry_;
+  TestingPrefServiceSimple local_state_;
   BraveProfilePolicyProvider provider_;
 };
 
@@ -53,6 +60,39 @@ TEST_F(BraveProfilePolicyProviderTest, InitAndPolicyLoadComplete) {
   // Now policies should be loaded
   EXPECT_TRUE(
       provider_.IsFirstPolicyLoadComplete(policy::POLICY_DOMAIN_CHROME));
+}
+
+TEST_F(BraveProfilePolicyProviderTest, IsInitializationCompleteGated) {
+  auto* manager = brave_origin::BraveOriginPolicyManager::GetInstance();
+  // On desktop/Android the override short-circuits to true when the manager
+  // has not been declared as expected-to-initialize (see the `#if !IS_IOS`
+  // block in `IsInitializationComplete`). Set the flag so the gating path
+  // below is exercised on all platforms.
+  manager->SetExpectedToBeInitialized();
+
+  // Before the manager is initialized, the override gates initialisation on
+  // `IsInitialized()` so consumers do not observe an empty managed pref
+  // store before Brave Origin policies have been merged.
+  EXPECT_FALSE(provider_.IsInitializationComplete(policy::POLICY_DOMAIN_CHROME))
+      << "Before provider Init: manager not initialised, no refresh";
+
+  provider_.Init(&schema_registry_);
+  EXPECT_FALSE(provider_.IsInitializationComplete(policy::POLICY_DOMAIN_CHROME))
+      << "After provider Init: manager still not initialised";
+
+  // Initializing the manager flips `IsInitialized()` and synchronously
+  // notifies our observer, but `RefreshPolicies` is gated on a non-empty
+  // `profile_id_`, so `first_policies_loaded_` is still false.
+  manager->Init(/*browser_policy_definitions=*/{},
+                /*profile_policy_definitions=*/{}, &local_state_);
+  EXPECT_FALSE(provider_.IsInitializationComplete(policy::POLICY_DOMAIN_CHROME))
+      << "After manager Init: profile_id_ still empty, refresh has not run";
+
+  // Setting the profile ID drives the first refresh.
+  provider_.SetProfileID("test-profile-id");
+  EXPECT_TRUE(provider_.IsInitializationComplete(policy::POLICY_DOMAIN_CHROME))
+      << "After SetProfileID: first refresh has run and manager is "
+         "initialised";
 }
 
 TEST_F(BraveProfilePolicyProviderTest, EmptyPolicyBundle) {

--- a/components/brave_policy/policy_initialization_waiter.h
+++ b/components/brave_policy/policy_initialization_waiter.h
@@ -8,6 +8,7 @@
 
 #include "base/functional/callback.h"
 #include "base/memory/raw_ptr.h"
+#include "components/policy/core/common/policy_namespace.h"
 #include "components/policy/core/common/policy_service.h"
 
 namespace brave_policy {


### PR DESCRIPTION
`BraveProvider`'s first `RefreshPolicies` is triggered by `AdBlockOnlyModePolicyManager` (initialised at process start), well before `BraveOriginPolicyManager` (lazily initialised by `BraveOriginServiceFactory`) is ready. The resulting bundle lacks `BraveRewardsDisabled`, but the default `IsInitializationComplete` lets `PolicyService` report ready anyway. `AdsServiceImpl::MaybeStartBatAdsService` then evaluates a stale managed pref store and bat-ads starts despite the policy.

Override `IsInitializationComplete` to additionally gate on `BraveOriginPolicyManager::IsInitialized()`. Upstream unit tests
(`ProfilePolicyConnectorTest`) bypass our factory bootstrap, so add a `SetExpectedToBeInitialized` flag set from `BraveOriginServiceFactory`'s ctor; the override short-circuits when unset (desktop/Android only -- iOS doesn't run those tests).

Resolves: https://github.com/brave/brave-browser/issues/54962

<!-- Add brave-browser issue below that this PR will resolve -->

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
