### PR TITLE
[AI Chat] Disable chromium Actor UI Task Button

### DIFF
--- a/browser/ai_chat/ai_chat_conversation_task_browsertest.cc
+++ b/browser/ai_chat/ai_chat_conversation_task_browsertest.cc
@@ -34,6 +34,11 @@
 #include "chrome/browser/glic/actor/glic_actor_policy_checker.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/browser_element_identifiers.h"
+#include "chrome/browser/ui/views/frame/browser_view.h"
+#include "chrome/browser/ui/views/interaction/browser_elements_views.h"
+#include "chrome/browser/ui/views/tabs/tab_strip_action_container.h"
+#include "chrome/browser/ui/views/toolbar/toolbar_view.h"
 #include "components/grit/brave_components_strings.h"
 #include "content/public/test/browser_test.h"
 #include "testing/gmock/include/gmock/gmock.h"
@@ -611,6 +616,57 @@ IN_PROC_BROWSER_TEST_F(AIChatConversationTaskBrowserTest, TaskUI) {
   // bubble no longer reads "Paused".
   EXPECT_TRUE(VerifyConversationFrameElementText("progress-bubble-description",
                                                  complete_label));
+}
+
+// Verify that the upstream GlicAndActorButtonsContainer is not constructed in
+// either the toolbar or the tab strip of a window that is executing a task.
+// The container has been the source of crashes; Brave disables it by
+// overriding the `kGlicActorUiTaskIcon` feature param to false (see
+// chromium_src/chrome/common/chrome_features.cc). This test guards against
+// regressions of that override.
+IN_PROC_BROWSER_TEST_F(AIChatConversationTaskBrowserTest,
+                       NoUpstreamGlicAndActorButtonsContainer) {
+  CreateConversationWithMockEngine();
+  std::string uuid = conversation_handler_->get_conversation_uuid();
+  NavigateToConversationUI(uuid);
+
+  // Drive the conversation into a running task state via a tool use event.
+  {
+    auto generate_future = SetupMockGenerateAssistantResponse();
+    conversation_handler_->SubmitHumanConversationEntry(
+        "Navigate to example.com", std::nullopt);
+    auto callbacks = generate_future->Take();
+    GURL test_url = embedded_https_test_server().GetURL("/actor/link.html");
+    callbacks.data_callback.Run(EngineConsumer::GenerationResultData(
+        mojom::ConversationEntryEvent::NewToolUseEvent(
+            CreateNavigateToolUseEvent("tool_id_1", test_url)),
+        std::nullopt));
+    std::move(callbacks.completed_callback)
+        .Run(base::ok(
+            EngineConsumer::GenerationResultData(nullptr, std::nullopt)));
+  }
+  ASSERT_TRUE(base::test::RunUntil([this]() {
+    return GetConversationState()->tool_use_task_state ==
+           mojom::TaskState::kRunning;
+  }));
+
+  // The toolbar must not contain the upstream glic actor task icon.
+  BrowserView* agent_browser_view =
+      BrowserView::GetBrowserViewForBrowser(agent_browser_window_);
+  ASSERT_TRUE(agent_browser_view);
+  EXPECT_EQ(agent_browser_view->toolbar()->glic_actor_task_icon(), nullptr);
+
+  // The tab strip's action container must not contain the upstream glic actor
+  // button container. The container itself may be absent depending on the
+  // window's tab strip configuration; if so, there is nothing to verify.
+  auto* tab_strip_action_container =
+      BrowserElementsViews::From(agent_browser_window_)
+          ->GetViewAs<TabStripActionContainer>(
+              kTabStripActionContainerElementId);
+  if (tab_strip_action_container) {
+    EXPECT_EQ(tab_strip_action_container->glic_actor_button_container(),
+              nullptr);
+  }
 }
 
 #endif  // BUILDFLAG(ENABLE_BRAVE_AI_CHAT_AGENT_PROFILE)

--- a/chromium_src/chrome/common/chrome_features.cc
+++ b/chromium_src/chrome/common/chrome_features.cc
@@ -26,8 +26,8 @@ OVERRIDE_FEATURE_DEFAULT_STATES({{
 }});
 
 // Disable this feature because we it includes google-specific branding and
-// causes a crash when interacted with. Brave will make its own version, or fix the Chromium
-// version and remove this feature override.
+// causes a crash when interacted with. Brave will make its own version, or
+// fix the Chromium version and remove this feature override.
 const base::FeatureParam<bool> kGlicActorUiTaskIcon{
     &kGlicActorUi, kGlicActorUiTaskIconName, false};
 

--- a/chromium_src/chrome/common/chrome_features.cc
+++ b/chromium_src/chrome/common/chrome_features.cc
@@ -7,7 +7,9 @@
 
 #include "base/feature_override.h"
 
+#define kGlicActorUiTaskIcon kGlicActorUiTaskIcon_ChromiumImpl
 #include <chrome/common/chrome_features.cc>
+#undef kGlicActorUiTaskIcon
 
 namespace features {
 
@@ -22,5 +24,11 @@ OVERRIDE_FEATURE_DEFAULT_STATES({{
     {kTrustSafetySentimentSurveyV2, base::FEATURE_DISABLED_BY_DEFAULT},
 #endif
 }});
+
+// Disable this feature because we it includes google-specific branding and
+// causes a crash when interacted with. Brave will make its own version, or fix the Chromium
+// version and remove this feature override.
+const base::FeatureParam<bool> kGlicActorUiTaskIcon{
+    &kGlicActorUi, kGlicActorUiTaskIconName, false};
 
 }  // namespace features


### PR DESCRIPTION
When an actor framework task is invoked, the button shows due to `kGlicActorUiTaskIcon` feature param being `true` by default. Interacting with this button causes a crash.

First we will disable the button entirely, via this PR.

Then we will bring the functionality either in a custom Brave button and menu, or fix the upstream one.

- Fix https://github.com/brave/brave-browser/issues/55566

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
