### PR TITLE
[CodeHealth][plaster] Keep in `chromium_src` non-macro code

### DIFF
--- a/chromium_src/chrome/browser/ui/browser_tabrestore.cc
+++ b/chromium_src/chrome/browser/ui/browser_tabrestore.cc
@@ -1,0 +1,14 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "chrome/browser/ui/browser_tabrestore.h"
+
+#include "brave/components/containers/buildflags/buildflags.h"
+
+#if BUILDFLAG(ENABLE_CONTAINERS)
+#include "brave/components/containers/content/browser/tab_restore_utils.h"
+#endif  // BUILDFLAG(ENABLE_CONTAINERS)
+
+#include <chrome/browser/ui/browser_tabrestore.cc>

--- a/chromium_src/components/sessions/content/content_serialized_navigation_builder.cc
+++ b/chromium_src/components/sessions/content/content_serialized_navigation_builder.cc
@@ -1,0 +1,73 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "components/sessions/content/content_serialized_navigation_builder.h"
+
+#include "brave/components/containers/buildflags/buildflags.h"
+
+#if BUILDFLAG(ENABLE_CONTAINERS)
+#include "brave/components/containers/content/browser/session_utils.h"
+#include "brave/components/containers/core/common/features.h"
+#include "components/sessions/core/serialized_navigation_entry.h"
+#include "content/public/browser/navigation_entry.h"
+#endif  // BUILDFLAG(ENABLE_CONTAINERS)
+
+namespace {
+
+// Copies the storage partition key parsed from the SerializedNavigationEntry
+// into the NavigationEntry so it can be used later to create the correct
+// SiteInstance with the right StoragePartitionConfig.
+//
+// This runs AFTER ContentSerializedNavigationDriver::Sanitize() has already
+// parsed the virtual URL prefix and populated the storage_partition_key field.
+void MaybeRestoreStoragePartitionKey(
+    [[maybe_unused]] const sessions::SerializedNavigationEntry* navigation,
+    [[maybe_unused]] content::NavigationEntry* entry) {
+#if BUILDFLAG(ENABLE_CONTAINERS)
+  if (base::FeatureList::IsEnabled(containers::features::kContainers) &&
+      navigation->storage_partition_key().has_value()) {
+    entry->SetStoragePartitionKeyToRestore(
+        navigation->storage_partition_key().value());
+  }
+#endif  // BUILDFLAG(ENABLE_CONTAINERS)
+}
+
+// Stores the NavigationEntry's storage partition key on the
+// SerializedNavigationEntry when saving a session. The
+// SerializedNavigationEntry is then processed by
+// ContentSerializedNavigationDriver::GetSanitizedPageStateForPickle() which
+// adds the prefix to the PageState, and finally written to disk/sync with the
+// virtual_url_prefix embedded in the virtual_url field.
+void MaybeSaveStoragePartitionKey(
+    [[maybe_unused]] content::NavigationEntry* entry,
+    [[maybe_unused]] sessions::SerializedNavigationEntry* navigation) {
+#if BUILDFLAG(ENABLE_CONTAINERS)
+  if (!base::FeatureList::IsEnabled(containers::features::kContainers)) {
+    return;
+  }
+  auto storage_partition_key_to_restore =
+      entry->GetStoragePartitionKeyToRestore();
+  if (!storage_partition_key_to_restore) {
+    return;
+  }
+  // Generate the URL prefix (e.g., "containers+<uuid>:") if it's a valid
+  // container storage partition key.
+  auto url_prefix = containers::StoragePartitionKeyToUrlPrefix(
+      *storage_partition_key_to_restore);
+  if (!url_prefix) {
+    return;
+  }
+  // Store both the prefix and the raw partition key in the
+  // SerializedNavigationEntry. The prefix will be used by
+  // GetSanitizedPageStateForPickle() to modify the PageState, and both will be
+  // embedded in the virtual_url during final serialization.
+  navigation->set_virtual_url_prefix(*url_prefix);
+  navigation->set_storage_partition_key(*storage_partition_key_to_restore);
+#endif  // BUILDFLAG(ENABLE_CONTAINERS)
+}
+
+}  // namespace
+
+#include <components/sessions/content/content_serialized_navigation_builder.cc>

--- a/patches/chrome-browser-ui-browser_tabrestore.cc.patch
+++ b/patches/chrome-browser-ui-browser_tabrestore.cc.patch
@@ -1,21 +1,8 @@
 diff --git a/chrome/browser/ui/browser_tabrestore.cc b/chrome/browser/ui/browser_tabrestore.cc
-index dc253dfd33c5b63dfdbbc89bd3718a5244546cf6..8b59879728a69c31c4df5d8bb6f818f133a47a38 100644
+index dc253dfd33c5b63dfdbbc89bd3718a5244546cf6..beef94643fb7eeaca4e92bf6c7d953bc8ad5f805 100644
 --- a/chrome/browser/ui/browser_tabrestore.cc
 +++ b/chrome/browser/ui/browser_tabrestore.cc
-@@ -39,6 +39,12 @@
- #include "ui/gfx/geometry/size.h"
- #include "ui/gfx/range/range.h"
- 
-+#include "brave/components/containers/buildflags/buildflags.h"
-+
-+#if BUILDFLAG(ENABLE_CONTAINERS)
-+#include "brave/components/containers/content/browser/tab_restore_utils.h"
-+#endif  // BUILDFLAG(ENABLE_CONTAINERS)
-+
- using content::NavigationEntry;
- using content::RestoreType;
- using content::WebContents;
-@@ -72,7 +78,14 @@ std::unique_ptr<WebContents> CreateRestoredTab(
+@@ -72,7 +72,14 @@ std::unique_ptr<WebContents> CreateRestoredTab(
            browser->profile(), session_storage_namespace);
    WebContents::CreateParams create_params(
        browser->profile(),

--- a/patches/components-sessions-content-content_serialized_navigation_builder.cc.patch
+++ b/patches/components-sessions-content-content_serialized_navigation_builder.cc.patch
@@ -1,76 +1,20 @@
 diff --git a/components/sessions/content/content_serialized_navigation_builder.cc b/components/sessions/content/content_serialized_navigation_builder.cc
-index a19395e46299c7c4cba3da7c7f635a2ad63e94d7..6174abbac03a5815607f47d20d9309c77bb9ac23 100644
+index a19395e46299c7c4cba3da7c7f635a2ad63e94d7..b59028cc2b70f70207206ec54b40309e2f27c702 100644
 --- a/components/sessions/content/content_serialized_navigation_builder.cc
 +++ b/components/sessions/content/content_serialized_navigation_builder.cc
-@@ -22,6 +22,13 @@
- #include "services/network/public/cpp/shared_url_loader_factory.h"
- #include "third_party/blink/public/common/page_state/page_state.h"
- 
-+#include "brave/components/containers/buildflags/buildflags.h"
-+
-+#if BUILDFLAG(ENABLE_CONTAINERS)
-+#include "brave/components/containers/content/browser/session_utils.h"
-+#include "brave/components/containers/core/common/features.h"
-+#endif  // BUILDFLAG(ENABLE_CONTAINERS)
-+
- namespace sessions {
- 
- // static
-@@ -65,6 +72,35 @@ ContentSerializedNavigationBuilder::FromNavigationEntry(
+@@ -65,6 +65,7 @@ ContentSerializedNavigationBuilder::FromNavigationEntry(
        navigation.extended_info_map_[handler_entry.first] = value;
    }
  
-+#if BUILDFLAG(ENABLE_CONTAINERS)
-+  // This is called when saving a session (browser close, tab close, manual
-+  // session save, or sync). We add storage partition key information to the
-+  // serialized data.
-+  //
-+  // The SerializedNavigationEntry will then be processed by
-+  // ContentSerializedNavigationDriver::GetSanitizedPageStateForPickle() which
-+  // adds the prefix to the PageState, and finally written to disk/sync with the
-+  // virtual_url_prefix embedded in the virtual_url field.
-+  if (base::FeatureList::IsEnabled(containers::features::kContainers)) {
-+    if (auto storage_partition_key_to_restore =
-+            entry->GetStoragePartitionKeyToRestore()) {
-+      // Generate the URL prefix (e.g., "containers+<uuid>:") if it's a valid
-+      // container storage partition key.
-+      if (auto url_prefix = containers::StoragePartitionKeyToUrlPrefix(
-+              *storage_partition_key_to_restore)) {
-+        // Store both the prefix and the raw partition key in the
-+        // SerializedNavigationEntry. The prefix will be used by
-+        // GetSanitizedPageStateForPickle() to modify the PageState,
-+        // and both will be embedded in the virtual_url during
-+        // final serialization.
-+        navigation.set_virtual_url_prefix(*url_prefix);
-+        navigation.set_storage_partition_key(*storage_partition_key_to_restore);
-+      }
-+    }
-+  }
-+#endif  // BUILDFLAG(ENABLE_CONTAINERS)
-+
-+
++  MaybeSaveStoragePartitionKey(entry, &navigation);
    return navigation;
  }
  
-@@ -180,6 +216,21 @@ ContentSerializedNavigationBuilder::ToNavigationEntry(
+@@ -180,6 +181,7 @@ ContentSerializedNavigationBuilder::ToNavigationEntry(
    DCHECK_EQ(SerializedNavigationEntry::STATE_INVALID,
              navigation->blocked_state_);
  
-+#if BUILDFLAG(ENABLE_CONTAINERS)
-+  // If the SerializedNavigationEntry contains storage partition key information,
-+  // we copy it into the NavigationEntry so it can be used later to create the
-+  // correct SiteInstance with the right StoragePartitionConfig.
-+  //
-+  // This happens AFTER ContentSerializedNavigationDriver::Sanitize() has already
-+  // parsed the virtual URL prefix and populated the storage_partition_key field.
-+  if (base::FeatureList::IsEnabled(containers::features::kContainers) &&
-+      navigation->storage_partition_key().has_value()) {
-+    entry->SetStoragePartitionKeyToRestore(
-+        navigation->storage_partition_key().value());
-+  }
-+#endif  // BUILDFLAG(ENABLE_CONTAINERS)
-+
-+
++  MaybeRestoreStoragePartitionKey(navigation, entry.get());
    return entry;
  }
  

--- a/rewrite/chrome/browser/ui/browser_tabrestore.cc.toml
+++ b/rewrite/chrome/browser/ui/browser_tabrestore.cc.toml
@@ -4,18 +4,6 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
 [[substitution]]
-description = 'Add containers headers for tab restore'
-re_pattern = '(using content::NavigationEntry;\n)'
-replace = '''
-#include "brave/components/containers/buildflags/buildflags.h"
-
-#if BUILDFLAG(ENABLE_CONTAINERS)
-#include "brave/components/containers/content/browser/tab_restore_utils.h"
-#endif  // BUILDFLAG(ENABLE_CONTAINERS)
-
-\1'''
-
-[[substitution]]
 description = 'Pass containers storage partition config when restoring tabs'
 re_pattern = 'tab_util::GetSiteInstanceForNewTab\(([\s\S]*?)\)\)'
 replace = '''tab_util::GetSiteInstanceForNewTab(

--- a/rewrite/chrome/browser/ui/views/page_action/action_ids.h.toml
+++ b/rewrite/chrome/browser/ui/views/page_action/action_ids.h.toml
@@ -4,6 +4,7 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
 [[substitution]]
-description = 'Add kActionShowPartitionedStorage to the array'
-re_pattern = '(kActionIds = std::to_array<actions::ActionId>\(\{\s+?kActionAiMode,)'
-replace = '\1\n    kActionShowPartitionedStorage,'
+description = 'Add kActionShowPartitionedStorage as the second entry of kActionIds'
+re_pattern = '(kActionIds = std::to_array<actions::ActionId>\(\{\n[ \t]*\w+,\n)'
+replace = '''\1    kActionShowPartitionedStorage,
+'''

--- a/rewrite/components/sessions/content/content_serialized_navigation_builder.cc.toml
+++ b/rewrite/components/sessions/content/content_serialized_navigation_builder.cc.toml
@@ -3,72 +3,23 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
-[[substitution]]
-description = 'Add containers buildflag and feature headers for session restore'
-re_pattern = '(namespace sessions {\n)'
-replace = '''
-#include "brave/components/containers/buildflags/buildflags.h"
-
-#if BUILDFLAG(ENABLE_CONTAINERS)
-#include "brave/components/containers/content/browser/session_utils.h"
-#include "brave/components/containers/core/common/features.h"
-#endif  // BUILDFLAG(ENABLE_CONTAINERS)
-
-\1'''
+# Each substitution anchors on the target function's qualified name, scans
+# through its body with DOTALL, and inserts a call on the line just above the
+# function's closing `return ...;`. Leading whitespace before `return` and any
+# trailing content between `return` and the function's closing `}` are
+# captured loosely, so reformatting of the surrounding lines does not break
+# the match.
 
 [[substitution]]
 description = 'Restore storage partition key from SerializedNavigationEntry for containers'
-re_pattern = '(ContentSerializedNavigationBuilder::FromNavigationEntry[\s\S]*?)(\s+return entry;\s*^\})'
-re_flags = ['MULTILINE']
-replace = '''
-\1
-
-#if BUILDFLAG(ENABLE_CONTAINERS)
-  // If the SerializedNavigationEntry contains storage partition key information,
-  // we copy it into the NavigationEntry so it can be used later to create the
-  // correct SiteInstance with the right StoragePartitionConfig.
-  //
-  // This happens AFTER ContentSerializedNavigationDriver::Sanitize() has already
-  // parsed the virtual URL prefix and populated the storage_partition_key field.
-  if (base::FeatureList::IsEnabled(containers::features::kContainers) &&
-      navigation->storage_partition_key().has_value()) {
-    entry->SetStoragePartitionKeyToRestore(
-        navigation->storage_partition_key().value());
-  }
-#endif  // BUILDFLAG(ENABLE_CONTAINERS)
+re_pattern = '(ContentSerializedNavigationBuilder::ToNavigationEntry\b.*?\n)([ \t]*return entry;.*?\})'
+re_flags = ['DOTALL']
+replace = '''\1  MaybeRestoreStoragePartitionKey(navigation, entry.get());
 \2'''
 
 [[substitution]]
 description = 'Set virtual URL prefix and storage partition key for containers'
-re_pattern = '(ContentSerializedNavigationBuilder::FromNavigationEntry[\s\S]*?)(\s+return navigation;\s*^\})'
-re_flags = ['MULTILINE']
-replace = '''\1
-
-#if BUILDFLAG(ENABLE_CONTAINERS)
-  // This is called when saving a session (browser close, tab close, manual
-  // session save, or sync). We add storage partition key information to the
-  // serialized data.
-  //
-  // The SerializedNavigationEntry will then be processed by
-  // ContentSerializedNavigationDriver::GetSanitizedPageStateForPickle() which
-  // adds the prefix to the PageState, and finally written to disk/sync with the
-  // virtual_url_prefix embedded in the virtual_url field.
-  if (base::FeatureList::IsEnabled(containers::features::kContainers)) {
-    if (auto storage_partition_key_to_restore =
-            entry->GetStoragePartitionKeyToRestore()) {
-      // Generate the URL prefix (e.g., "containers+<uuid>:") if it's a valid
-      // container storage partition key.
-      if (auto url_prefix = containers::StoragePartitionKeyToUrlPrefix(
-              *storage_partition_key_to_restore)) {
-        // Store both the prefix and the raw partition key in the
-        // SerializedNavigationEntry. The prefix will be used by
-        // GetSanitizedPageStateForPickle() to modify the PageState,
-        // and both will be embedded in the virtual_url during
-        // final serialization.
-        navigation.set_virtual_url_prefix(*url_prefix);
-        navigation.set_storage_partition_key(*storage_partition_key_to_restore);
-      }
-    }
-  }
-#endif  // BUILDFLAG(ENABLE_CONTAINERS)
+re_pattern = '(ContentSerializedNavigationBuilder::FromNavigationEntry\b.*?\n)([ \t]*return navigation;.*?\})'
+re_flags = ['DOTALL']
+replace = '''\1  MaybeSaveStoragePartitionKey(entry, &navigation);
 \2'''


### PR DESCRIPTION
This PR moves to `chromium_src` code that can live in there, and does
with no need for `#define` macro uses. This keeps plaster files shorter,
which reduces the noise in them, and it also permits C++ code to live
in C++ sources, that can benefit from code formatting, and DEPS
validation.
