### PR TITLE
[Android][Search in Settings] Customize menu result

### DIFF
--- a/android/java/org/chromium/chrome/browser/settings/BraveMainPreferencesBase.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveMainPreferencesBase.java
@@ -766,6 +766,26 @@ public abstract class BraveMainPreferencesBase extends BravePreferenceFragment
                                 siteSettingsFrag,
                                 BraveSiteSettingsPreferencesBase.SOLANA_CONNECTED_SITES_KEY);
                     }
+                    // Replace the AppearancePreferences entry so that the search result opens
+                    // BraveCustomizeMenuPreferenceFragment directly with the last live bundle
+                    // (cached when the user opened Settings via the app menu). Only replace when
+                    // the bundle is available — avoids overwriting a valid cached entry with null
+                    // on sessions where populateBundle has not yet been called.
+                    @Nullable Bundle searchBundle = CustomizeBraveMenu.getBundleForSearchResults();
+                    if (searchBundle != null) {
+                        indexData.removeEntryForKey(
+                                AppearancePreferences.class.getName(),
+                                AppearancePreferences.PREF_BRAVE_CUSTOMIZE_MENU);
+                        indexData.addEntryForKey(
+                                MainSettings.class.getName(),
+                                AppearancePreferences.PREF_BRAVE_CUSTOMIZE_MENU,
+                                context.getString(R.string.customize_menu_title),
+                                null,
+                                searchBundle,
+                                org.chromium.brave.browser.customize_menu.settings
+                                        .BraveCustomizeMenuPreferenceFragment.class
+                                        .getName());
+                    }
                 }
             };
 }

--- a/browser/customize_menu/android/java/src/org/chromium/brave/browser/customize_menu/CustomizeBraveMenu.java
+++ b/browser/customize_menu/android/java/src/org/chromium/brave/browser/customize_menu/CustomizeBraveMenu.java
@@ -96,6 +96,11 @@ public class CustomizeBraveMenu {
     // settings screen when launched from Settings search, where no live app-menu context exists.
     private static @Nullable Bundle sLastKnownBundle;
 
+    @VisibleForTesting
+    public static void setLastKnownBundleForTesting(@Nullable Bundle bundle) {
+        sLastKnownBundle = bundle;
+    }
+
     /**
      * Static mapping of menu item IDs to their corresponding drawable resource IDs. Uses
      * SparseIntArray for optimal performance and memory efficiency on Android when mapping resource

--- a/browser/customize_menu/android/java/src/org/chromium/brave/browser/customize_menu/CustomizeBraveMenu.java
+++ b/browser/customize_menu/android/java/src/org/chromium/brave/browser/customize_menu/CustomizeBraveMenu.java
@@ -92,6 +92,10 @@ public class CustomizeBraveMenu {
     // Menu items initialized as hidden unless an explicit user preference already exists.
     private static final int[] MENU_IDS_INVISIBLE_BY_DEFAULT = {R.id.exit_id};
 
+    // Cached bundle from the last time the app menu was opened. Used to populate the Customize Menu
+    // settings screen when launched from Settings search, where no live app-menu context exists.
+    private static @Nullable Bundle sLastKnownBundle;
+
     /**
      * Static mapping of menu item IDs to their corresponding drawable resource IDs. Uses
      * SparseIntArray for optimal performance and memory efficiency on Android when mapping resource
@@ -272,6 +276,7 @@ public class CustomizeBraveMenu {
         // Add data list to fragment bundle.
         bundle.putParcelableArrayList(KEY_MAIN_MENU_ITEM_LIST, menuItemDataList);
         bundle.putParcelableArrayList(KEY_PAGE_ACTION_ITEM_LIST, pageActionDataList);
+        sLastKnownBundle = bundle;
         return bundle;
     }
 
@@ -491,5 +496,28 @@ public class CustomizeBraveMenu {
                             KEY_PAGE_ACTION_ITEM_LIST,
                             bundle.getParcelableArrayList(KEY_PAGE_ACTION_ITEM_LIST));
         }
+    }
+
+    /** Returns a copy of the last live bundle, or null if no app-menu session has occurred yet. */
+    public static @Nullable Bundle getBundleForSearchResults() {
+        return getBundleForSearchResults(sLastKnownBundle);
+    }
+
+    private static @Nullable Bundle getBundleForSearchResults(@Nullable final Bundle bundle) {
+        if (bundle == null) {
+            return null;
+        }
+        Bundle bundleForSearchResults = new Bundle();
+        if (bundle.containsKey(KEY_MAIN_MENU_ITEM_LIST)) {
+            bundleForSearchResults.putParcelableArrayList(
+                    KEY_MAIN_MENU_ITEM_LIST,
+                    bundle.getParcelableArrayList(KEY_MAIN_MENU_ITEM_LIST));
+        }
+        if (bundle.containsKey(KEY_PAGE_ACTION_ITEM_LIST)) {
+            bundleForSearchResults.putParcelableArrayList(
+                    KEY_PAGE_ACTION_ITEM_LIST,
+                    bundle.getParcelableArrayList(KEY_PAGE_ACTION_ITEM_LIST));
+        }
+        return bundleForSearchResults;
     }
 }

--- a/browser/customize_menu/android/java/src/org/chromium/brave/browser/customize_menu/settings/BraveCustomizeMenuPreferenceFragment.java
+++ b/browser/customize_menu/android/java/src/org/chromium/brave/browser/customize_menu/settings/BraveCustomizeMenuPreferenceFragment.java
@@ -77,7 +77,16 @@ public class BraveCustomizeMenuPreferenceFragment extends ChromeBaseSettingsFrag
         if (menuSection == null) {
             return;
         }
-        final List<MenuItemData> menuItems = bundle.getParcelableArrayList(keyMenuItemList);
+        List<MenuItemData> menuItems = bundle.getParcelableArrayList(keyMenuItemList);
+        if (menuItems == null) {
+            // SettingsIndexData serializes extras to JSON via RecentSearchQueue, which only
+            // supports simple types — Parcelable ArrayLists are stringified and lost. Fall back
+            // to the last live bundle from populateBundle.
+            Bundle fallback = CustomizeBraveMenu.getBundleForSearchResults();
+            if (fallback != null) {
+                menuItems = fallback.getParcelableArrayList(keyMenuItemList);
+            }
+        }
         if (menuItems != null) {
             for (MenuItemData menuItem : menuItems) {
                 ChromeSwitchPreference switchPreference = getSwitchPreference(menuItem);
@@ -136,10 +145,18 @@ public class BraveCustomizeMenuPreferenceFragment extends ChromeBaseSettingsFrag
         return true;
     }
 
-    // All menu item switches are added programmatically from a bundle; there are no static
-    // preferences to index.
+    // All menu item switches are added programmatically; there are no static preferences to index.
+    // This fragment is surfaced in search via BraveMainPreferencesBase.SEARCH_INDEX_DATA_PROVIDER.
+    // getExtras() returns the last live bundle so that if this provider is ever consulted directly,
+    // the correct extras are available.
     public static final BaseSearchIndexProvider SEARCH_INDEX_DATA_PROVIDER =
             new BaseSearchIndexProvider(
                     BraveCustomizeMenuPreferenceFragment.class.getName(),
-                    BaseSearchIndexProvider.INDEX_OPT_OUT);
+                    BaseSearchIndexProvider.INDEX_OPT_OUT) {
+                @Override
+                public Bundle getExtras() {
+                    Bundle bundle = CustomizeBraveMenu.getBundleForSearchResults();
+                    return bundle != null ? bundle : new Bundle();
+                }
+            };
 }

--- a/browser/customize_menu/android/java/src/org/chromium/brave/browser/customize_menu/settings/BraveCustomizeMenuPreferenceFragment.java
+++ b/browser/customize_menu/android/java/src/org/chromium/brave/browser/customize_menu/settings/BraveCustomizeMenuPreferenceFragment.java
@@ -11,6 +11,7 @@ import android.content.res.Resources;
 import android.os.Bundle;
 
 import androidx.annotation.DrawableRes;
+import androidx.annotation.VisibleForTesting;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceCategory;
 
@@ -29,6 +30,7 @@ import org.chromium.components.browser_ui.settings.SettingsUtils;
 import org.chromium.components.browser_ui.settings.search.BaseSearchIndexProvider;
 import org.chromium.ui.base.ViewUtils;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
@@ -77,7 +79,14 @@ public class BraveCustomizeMenuPreferenceFragment extends ChromeBaseSettingsFrag
         if (menuSection == null) {
             return;
         }
-        List<MenuItemData> menuItems = bundle.getParcelableArrayList(keyMenuItemList);
+        // Check the type first: SettingsIndexData's JSON serialization (via RecentSearchQueue)
+        // stores Parcelable ArrayLists as Strings. Calling getParcelableArrayList on a String
+        // value returns null on real Android (with a warning) but throws ClassCastException in
+        // Robolectric. The instanceof guard avoids both.
+        List<MenuItemData> menuItems =
+                bundle.get(keyMenuItemList) instanceof ArrayList
+                        ? bundle.getParcelableArrayList(keyMenuItemList)
+                        : null;
         if (menuItems == null) {
             // SettingsIndexData serializes extras to JSON via RecentSearchQueue, which only
             // supports simple types — Parcelable ArrayLists are stringified and lost. Fall back
@@ -143,6 +152,11 @@ public class BraveCustomizeMenuPreferenceFragment extends ChromeBaseSettingsFrag
     public boolean onPreferenceChange(Preference preference, Object newValue) {
         ChromeSharedPreferences.getInstance().writeBoolean(preference.getKey(), (Boolean) newValue);
         return true;
+    }
+
+    @VisibleForTesting
+    public static Bundle getSearchExtrasForTesting() {
+        return SEARCH_INDEX_DATA_PROVIDER.getExtras();
     }
 
     // All menu item switches are added programmatically; there are no static preferences to index.

--- a/browser/customize_menu/android/javatests/src/org/chromium/brave/browser/customize_menu/settings/BraveCustomizeMenuPreferenceFragmentTest.java
+++ b/browser/customize_menu/android/javatests/src/org/chromium/brave/browser/customize_menu/settings/BraveCustomizeMenuPreferenceFragmentTest.java
@@ -16,6 +16,7 @@ import android.os.Bundle;
 
 import androidx.fragment.app.testing.FragmentScenario;
 import androidx.preference.Preference;
+import androidx.preference.PreferenceCategory;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -23,9 +24,11 @@ import org.junit.runner.RunWith;
 import org.mockito.MockitoAnnotations;
 import org.robolectric.annotation.Config;
 
+import org.chromium.base.BraveFeatureList;
 import org.chromium.base.BravePreferenceKeys;
 import org.chromium.base.supplier.MonotonicObservableSupplier;
 import org.chromium.base.test.BaseRobolectricTestRunner;
+import org.chromium.base.test.util.Features.DisableFeatures;
 import org.chromium.brave.browser.customize_menu.CustomizeBraveMenu;
 import org.chromium.brave.browser.customize_menu.MenuItemData;
 import org.chromium.brave.browser.customize_menu.R;
@@ -150,6 +153,51 @@ public class BraveCustomizeMenuPreferenceFragmentTest {
                     // Fragment should be created successfully even with null bundle.
                     assertNotNull(fragment);
                 });
+    }
+
+    @Test
+    @DisableFeatures(BraveFeatureList.BRAVE_SHRED)
+    public void testGetExtras_NoCachedBundle_ReturnsEmptyBundle() {
+        CustomizeBraveMenu.setLastKnownBundleForTesting(null);
+
+        Bundle extras = BraveCustomizeMenuPreferenceFragment.getSearchExtrasForTesting();
+
+        assertNotNull(extras);
+        assertTrue(extras.isEmpty());
+    }
+
+    @Test
+    @DisableFeatures(BraveFeatureList.BRAVE_SHRED)
+    public void testFallback_WhenBundleHasStringValues_UsesLastKnownBundle() {
+        // Prime sLastKnownBundle (simulates a prior populateBundle call).
+        CustomizeBraveMenu.setLastKnownBundleForTesting(mTestBundle);
+
+        // Simulate JSON round-trip: SettingsIndexData serializes extras via RecentSearchQueue
+        // which only supports simple types — Parcelable ArrayLists become Strings.
+        Bundle corruptedBundle = new Bundle();
+        corruptedBundle.putString(CustomizeBraveMenu.KEY_MAIN_MENU_ITEM_LIST, "[stringified]");
+        corruptedBundle.putString(CustomizeBraveMenu.KEY_PAGE_ACTION_ITEM_LIST, "[stringified]");
+
+        FragmentScenario<BraveCustomizeMenuPreferenceFragment> scenario =
+                FragmentScenario.launchInContainer(
+                        BraveCustomizeMenuPreferenceFragment.class,
+                        corruptedBundle,
+                        R.style.Theme_Chromium_Settings);
+
+        scenario.onFragment(
+                fragment -> {
+                    PreferenceCategory mainSection = fragment.findPreference("main_menu_section");
+                    PreferenceCategory pageActionsSection =
+                            fragment.findPreference("page_actions_section");
+                    assertNotNull(mainSection);
+                    assertNotNull(pageActionsSection);
+                    // mTestBundle has 2 main menu items and 2 page action items.
+                    // page_actions_section also has 1 static summary Preference from XML.
+                    assertEquals(2, mainSection.getPreferenceCount());
+                    assertEquals(3, pageActionsSection.getPreferenceCount());
+                });
+
+        CustomizeBraveMenu.setLastKnownBundleForTesting(null);
     }
 
     @Test

--- a/browser/customize_menu/android/javatests/src/org/chromium/brave/browser/customize_menu/settings/BraveCustomizeMenuPreferenceFragmentTest.java
+++ b/browser/customize_menu/android/javatests/src/org/chromium/brave/browser/customize_menu/settings/BraveCustomizeMenuPreferenceFragmentTest.java
@@ -18,6 +18,7 @@ import androidx.fragment.app.testing.FragmentScenario;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceCategory;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -64,6 +65,11 @@ public class BraveCustomizeMenuPreferenceFragmentTest {
                 CustomizeBraveMenu.KEY_MAIN_MENU_ITEM_LIST, mainMenuItems);
         mTestBundle.putParcelableArrayList(
                 CustomizeBraveMenu.KEY_PAGE_ACTION_ITEM_LIST, pageActionItems);
+    }
+
+    @After
+    public void tearDown() {
+        CustomizeBraveMenu.setLastKnownBundleForTesting(null);
     }
 
     @Test
@@ -196,8 +202,6 @@ public class BraveCustomizeMenuPreferenceFragmentTest {
                     assertEquals(2, mainSection.getPreferenceCount());
                     assertEquals(3, pageActionsSection.getPreferenceCount());
                 });
-
-        CustomizeBraveMenu.setLastKnownBundleForTesting(null);
     }
 
     @Test


### PR DESCRIPTION
This PR fixes the issue when `Customize menu` after access from `Search in Settings` result were empty.

The key part of the fix is `private static @Nullable Bundle sLastKnownBundle;` 
at `CustomizeBraveMenu.java`
which caches the Bundle prepared when the app settings are open.
So it is used later for `Customize menu` search result at `BraveMainPreferencesBase`.

The separate case - access to `Customize menu`/`Appearance` search results from
`Recently Used` section. Chromium API caches the results and saves them at
`ChromePreferenceKeys.SETTINGS_RECENT_SEARCH_ENTRIES` pref at `RecentSearchQueue` class.
It is able to serialize only simple types and not `MenuItemData`, so to access
`Customize menu` results from `Recently Used` is still reused, see `Bundle fallback` 
at `BraveCustomizeMenuPreferenceFragment.addSwitchesFromBundle`.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/55088

### Test Plan

#### I. Normal flow

1. Enable `Search in Settings` at about:flags, restart app
2. Open main app settings and press `Search settings` search box
3. Type `Customize`
4. Press `Customize menu`
5. Ensure there are no empty entries
6. Press back, remove typed text and type `Appe`
7. Press `Appearance`
8. Press `Customize menu`
9. Ensure again are no empty entries

#### II. `Recently Used` results have no empty entries
1. `I. Normal flow` test was done
2. Restart app
3. Open main app settings
4. Press Search settings
5. Right away press `Customize menu` from `Recently Used` section - expected to have no empty entries
6. Press back and then press `Appearance` from `Recently Used` section, then press `Customize menu` expected to have no empty entries again.

### Videos

#### Normal flow


https://github.com/user-attachments/assets/6599edfe-e746-4aba-bd0e-0f5e8676115e



#### From Recently Used


https://github.com/user-attachments/assets/a2d11c6e-1c9e-4b46-b200-8f4210baae79



<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
