### PR TITLE
[toolchain][brockit] Adding `update-xcode-toolchain`

### DIFF
--- a/tools/cr/brockit.py
+++ b/tools/cr/brockit.py
@@ -170,6 +170,26 @@ away all minor bumps in a branch down to a single one. This is useful when
 when running a cr branch, as it is common to have multiple minor daily bumps
 in a branch.
 
+### `brockit.py update-xcode-toolchain`
+The hermetic toolchain is generated in CI, and at the end of it, a download URL
+is provided for the generated toolchain. The URL is usually printed in the logs
+as:
+
+```
+Download URL: https://....tar.gz
+```
+
+To create a commit updating the hermetic toolchain, simply pass this URL to the
+command:
+
+```sh
+tools/cr/brockit.py update-xcode-toolchain <URL>
+```
+
+Pass `--culprit=<hash>` to provide a specific culprit for the toolchain update.
+If none is provided, `brockit` will trying to determine the culprit by looking
+for the last commit updating the toolchain in Chromium.
+
 ### `brockit.py reassign`
 This command is used to change the authorship of a given commit in the branch.
 It generates an empty commit with the message `reassign! {original_subject}`
@@ -246,6 +266,15 @@ GOOGLESOURCE_COMMIT_LINK = f'{versioning.GOOGLESOURCE_LINK}' '/+/{commit}'
 # A basic url to the rust toolchain that can be used to check for the toolchain
 # availability for a given version.
 RUST_TOOLCHAIN_URL = 'https://brave-build-deps-public.s3.brave.com/rust-toolchain-aux/linux-x64-rust-toolchain-{revision}.tar.xz'
+
+# Brave-side script that pins the hermetic Xcode toolchain. Its
+# `XCODE_VERSION` / `XCODE_BUILD_VERSION` / `MAC_SDK_*` constants are the only
+# thing `update-xcode-toolchain` edits.
+HERMETIC_XCODE_SCRIPT = 'build/mac/download_hermetic_xcode.py'
+
+# Chromium-side file pinning the macOS SDK that we cross-reference to find the
+# upstream commit that triggered this toolchain bump.
+CHROMIUM_MAC_SDK_GNI = 'build/config/mac/mac_sdk.gni'
 
 # Google dash link used to check the latest version for a given channel
 CHROMIUMDASH_LATEST_RELEASE = 'https://chromiumdash.appspot.com/fetch_releases?channel={channel}&platform={platform}&num=1'
@@ -1429,10 +1458,12 @@ class Upgrade(Versioned):
                 'MacOS SDK has been updated. '
                 f'{result["current"]} ➜ {result["target"]}')
             result['advice'] = (
-                'Contact DevOps regarding the new macOS SDK for the hermetic '
-                'toolchain. Update `XCODE_VERSION` and `XCODE_VERSION` values '
-                'in build/mac/download_hermetic_xcode.py for the new download '
-                'URL.')
+                'Contact DevOps to ask for an updated MacOS toolchain node to '
+                'be used to generate a new toolchain, then generate the new '
+                'toolchain in https://ci.brave.com/view/toolchains/. Once the '
+                'new toolchain is generated, call '
+                '`brockit.py update-xcode-toolchain <url>` with the URL in the '
+                '"Download URL:" line printed in CI.')
         return result
 
     def _check_rust_toolchain(self) -> dict | None:
@@ -1486,7 +1517,8 @@ class Upgrade(Versioned):
             'current': get_rust_clang_revision(self.working_version),
             'target': updated_version,
             'description': 'The rust toolchain has been updated.',
-            'advice': 'Run the jobs in https://ci.brave.com/view/rust to generate a new Rust toolchain.',
+            'advice': ('Run the jobs in https://ci.brave.com/view/toolchains/ '
+                       'to generate a new Rust toolchain.'),
             'commit': {
                 'hash': commit_hash,
                 'message': commit_message
@@ -1504,7 +1536,8 @@ class Upgrade(Versioned):
         * The rust toolchain has been updated.
             CL: Roll clang+rust llvmorg-21-init-1655-g7b473dfe-1 : llvmorg-2...
                 https://chromium.googlesource.com/chromium/src/+/f9fada98083846
-            Run the jobs in https://ci.brave.com/view/rust to generate a new...
+            Run the jobs in https://ci.brave.com/view/toolchains/ to generate
+            a new...
 
     Returns:
         True if all checks pass, and False otherwise.
@@ -2230,6 +2263,136 @@ class Reassign(Task):
             no_verify=True)
 
 
+class UpdateXcodeToolchain(Task):
+    """Pins `build/mac/download_hermetic_xcode.py` to a freshly built archive.
+
+    This is a convenience command to update the URL for downloading the hermetic
+    Xcode toolchain.
+    """
+
+    # Filename pattern emitted by tools/cr/toolchain/build_xcode_toolchain.py.
+    # The six dash-separated tokens map 1:1 onto the six constants in
+    # `HERMETIC_XCODE_SCRIPT`.
+    _TOOLCHAIN_URL_RE = re.compile(
+        r'xcode-hermetic-toolchain'
+        r'-(?P<xcode_version>[^-/]+)'
+        r'-(?P<xcode_build_version>[^-/]+)'
+        r'-(?P<mac_sdk_official_version>[^-/]+)'
+        r'-(?P<mac_sdk_official_build_version>[^-/]+)'
+        r'-for-upstream'
+        r'-(?P<mac_sdk_upstream_version>[^-/]+)'
+        r'-(?P<mac_sdk_upstream_build_version>[^-/]+)'
+        r'\.tar\.gz')
+
+    def status_message(self):
+        return "Updating Apple toolchain..."
+
+    @staticmethod
+    def _replace_constant(text: str, name: str, value: str) -> str:
+        """Rewrites a single `<name> = '<value>'` assignment in *text*.
+
+        Anchored at line start and matches both single- and double-quoted
+        existing values so it stays robust if the script ever switches quote
+        style.
+        """
+        pattern = re.compile(rf"^({re.escape(name)}\s*=\s*)(['\"])[^'\"]*\2",
+                             re.MULTILINE)
+        new_text, count = pattern.subn(rf"\1'{value}'", text, count=1)
+        if count != 1:
+            raise InvalidInputException(
+                f'Could not find assignment for {name} in '
+                f'{HERMETIC_XCODE_SCRIPT}')
+        return new_text
+
+    def _rewrite_hermetic_xcode_script(self, tokens: dict[str, str]) -> bool:
+        """Pins the six toolchain constants to the values parsed from the URL.
+
+        Returns True if the on-disk file actually changed, False when every
+        constant was already set to the requested value (so the caller can
+        skip committing).
+        """
+        script_path = repository.brave.root / HERMETIC_XCODE_SCRIPT
+        original = script_path.read_bytes().decode('utf-8')
+        updated = original
+        mapping = (
+            ('XCODE_VERSION', tokens['xcode_version']),
+            ('XCODE_BUILD_VERSION', tokens['xcode_build_version']),
+            ('MAC_SDK_OFFICIAL_VERSION', tokens['mac_sdk_official_version']),
+            ('MAC_SDK_OFFICIAL_BUILD_VERSION',
+             tokens['mac_sdk_official_build_version']),
+            ('MAC_SDK_UPSTREAM_VERSION', tokens['mac_sdk_upstream_version']),
+            ('MAC_SDK_UPSTREAM_BUILD_VERSION',
+             tokens['mac_sdk_upstream_build_version']),
+        )
+        for name, value in mapping:
+            updated = self._replace_constant(updated, name, value)
+
+        if updated == original:
+            return False
+
+        script_path.write_text(updated, encoding='utf-8', newline='')
+        return True
+
+    def _resolve_chromium_commit(self, tokens: dict[str, str]) -> str:
+        """Finds the Chromium commit that pinned the upstream macOS SDK.
+
+        We attempt to find the last commit that introduced one of the values
+        indicated as the upstream toolchain numbers.
+        """
+        version = re.escape(tokens['mac_sdk_upstream_version'])
+        build = re.escape(tokens['mac_sdk_upstream_build_version'])
+        regex = (f'mac_sdk_official_version = "{version}"'
+                 f'|mac_sdk_official_build_version = "{build}"')
+        commit_hash = repository.chromium.run_git('log', '--extended-regexp',
+                                                  '-G', regex, '--pretty=%H',
+                                                  '-1', '--',
+                                                  CHROMIUM_MAC_SDK_GNI)
+        if not commit_hash:
+            raise InvalidInputException(
+                f'Could not find a Chromium commit setting '
+                '`mac_sdk_official_version = '
+                f'"{tokens["mac_sdk_upstream_version"]}"` '
+                'or '
+                '`mac_sdk_official_build_version = '
+                f'"{tokens["mac_sdk_upstream_build_version"]}"` '
+                f'in {CHROMIUM_MAC_SDK_GNI}. Pass [bold cyan]--culprit[/] to '
+                'point at it explicitly.')
+        return commit_hash
+
+    def execute(self, url: str, culprit: str | None):
+        # Regex breaking each part of the url in different groups.
+        status = GitStatus()
+        if status.has_staged_files():
+            raise InvalidInputException(
+                'Staged files detected. Please commit or unstage changes '
+                'before generating a toolchain update:\n%s' %
+                '\n'.join(status.get_all_staged_entries()))
+
+        match = self._TOOLCHAIN_URL_RE.search(url)
+        if match is None:
+            raise InvalidInputException(
+                f'URL does not match the xcode-hermetic-toolchain pattern: '
+                f'{url}')
+        tokens = match.groupdict()
+
+        if not self._rewrite_hermetic_xcode_script(tokens):
+            raise InvalidInputException(
+                f'{HERMETIC_XCODE_SCRIPT} is already pinned to these values; '
+                'nothing to commit.')
+
+        commit_hash = culprit or self._resolve_chromium_commit(tokens)
+
+        title = (f'Switch to Xcode {tokens["xcode_version"]} '
+                 f'{tokens["xcode_build_version"]}')
+        repository.brave.run_git('add', HERMETIC_XCODE_SCRIPT)
+        repository.brave.git_commit(title,
+                                    env={
+                                        **os.environ,
+                                        'tags': 'toolchain',
+                                        'culprit': commit_hash,
+                                    })
+
+
 def fetch_chromium_dash_version(channel: str) -> Version:
     """Fetches the highest latest version across all platforms for a channel.
 
@@ -2497,6 +2660,25 @@ def main():
         'change',
         help='The commit reference to reassign (hash, HEAD~N, etc.).')
 
+    update_xcode_parser = subparsers.add_parser(
+        'update-xcode-toolchain',
+        parents=[global_parser],
+        help='Pins build/mac/download_hermetic_xcode.py to a freshly built '
+        'hermetic Xcode toolchain archive.')
+    update_xcode_parser.add_argument(
+        'url',
+        help=
+        'Archive URL emitted by tools/cr/toolchain/build_xcode_toolchain.py '
+        '(filename must follow the xcode-hermetic-toolchain-<...>.tar.gz '
+        'pattern).')
+    update_xcode_parser.add_argument(
+        '--culprit',
+        default=None,
+        help='Chromium commit hash to reference in the commit body. Defaults '
+        'to auto-detecting the commit that pinned the upstream macOS SDK in '
+        f'{CHROMIUM_MAC_SDK_GNI}.',
+        dest='culprit')
+
     subparsers.add_parser('reference',
                           help='Detailed documentation for this tool.')
     args = parser.parse_args()
@@ -2554,6 +2736,8 @@ def main():
             GitHubIssue(resolve_version_with_from_ref_arg()).run()
         if args.command == 'reassign':
             Reassign().run(change=args.change)
+        if args.command == 'update-xcode-toolchain':
+            UpdateXcodeToolchain().run(url=args.url, culprit=args.culprit)
         if args.command == 'reference':
             console.print(Markdown(__doc__))
         if args.command == 'show':

--- a/tools/cr/repository.py
+++ b/tools/cr/repository.py
@@ -120,7 +120,10 @@ class Repository:
         """
         return Path(p).resolve().relative_to(self.root.resolve())
 
-    def run_git(self, *cmd, no_trim=False) -> str:
+    def run_git(self,
+                *cmd,
+                no_trim=False,
+                env: dict[str, str] | None = None) -> str:
         """Runs a git command on this repository.
 
         Strongly preferred over calling `terminal.run_git` directly because
@@ -131,11 +134,19 @@ class Repository:
         resolved against the repo root, not against the caller's cwd. If a
         command needs paths relative to cwd, call `terminal.run_git` directly
         instead.
+
+        `env` is forwarded to `terminal.run_git`, which merges it on top of
+        `os.environ` for this invocation (useful for the commit-msg hook's
+        `tags` / `culprit` vars).
         """
         if self.root == Path('.'):
-            return terminal.run_git(*cmd, no_trim=no_trim)
+            return terminal.run_git(*cmd, no_trim=no_trim, env=env)
 
-        return terminal.run_git('-C', self.from_brave(), *cmd, no_trim=no_trim)
+        return terminal.run_git('-C',
+                                self.from_brave(),
+                                *cmd,
+                                no_trim=no_trim,
+                                env=env)
 
     def unstage_all_changes(self):
         """Unstages all changes in the repository.
@@ -154,8 +165,10 @@ class Repository:
 
     def _git_commit_internal(self,
                              args: list[str],
+                             *,
                              allows_empty: bool,
-                             no_verify: bool = False):
+                             no_verify: bool = False,
+                             env: dict[str, str] | None = None):
         """Shared implementation for git commit operations.
 
         Args:
@@ -165,6 +178,9 @@ class Repository:
             Whether to allow empty commits.
         no_verify:
             Whether to skip pre-commit and commit-msg hooks.
+        env:
+            Optional environment variables to be forwarded to
+            `terminal.run_git`.
         """
         has_staged_changes = self.has_staged_changes()
         if not allows_empty and not has_staged_changes:
@@ -180,7 +196,7 @@ class Repository:
             args.append('--allow-empty')
         if no_verify:
             args.append('--no-verify')
-        self.run_git('commit', *args)
+        self.run_git('commit', *args, env=env)
 
         commit = self.run_git('log', '-1', '--pretty=oneline',
                               '--abbrev-commit')
@@ -188,8 +204,10 @@ class Repository:
 
     def git_commit(self,
                    message: str,
+                   *,
                    allows_empty: bool = False,
-                   no_verify: bool = False):
+                   no_verify: bool = False,
+                   env: dict[str, str] | None = None):
         """Commits the current staged changes.
 
     This function calls `git commit` and prints a user friendly message as a
@@ -203,10 +221,15 @@ class Repository:
             Whether to allow empty commits.
         no_verify:
             Whether to skip pre-commit and commit-msg hooks.
+        env:
+            Optional environment variables to be forwarded to `terminal.run`.
         """
-        self._git_commit_internal(['-m', message], allows_empty, no_verify)
+        self._git_commit_internal(['-m', message],
+                                  allows_empty=allows_empty,
+                                  no_verify=no_verify,
+                                  env=env)
 
-    def git_commit_fixup(self, commit: str, allows_empty: bool = False):
+    def git_commit_fixup(self, commit: str, *, allows_empty: bool = False):
         """Commits the current staged changes as a fixup for a given commit.
 
     This function calls `git commit --fixup` and prints a user friendly message
@@ -219,7 +242,8 @@ class Repository:
         allows_empty:
             Whether to allow empty commits.
         """
-        self._git_commit_internal(['--fixup', commit], allows_empty)
+        self._git_commit_internal(['--fixup', commit],
+                                  allows_empty=allows_empty)
 
     def is_valid_git_reference(self, reference: str) -> bool:
         """Checks if a name is a valid git branch name or hash.

--- a/tools/cr/repository_test.py
+++ b/tools/cr/repository_test.py
@@ -255,8 +255,9 @@ class RepositoryTest(unittest.TestCase):
                               return_value='abcd123 msg') as mock_run_git:
             repository.chromium.git_commit_fixup('deadbeef')
 
-        self.assertIn(unittest.mock.call('commit', '--fixup', 'deadbeef'),
-                      mock_run_git.mock_calls)
+        self.assertIn(
+            unittest.mock.call('commit', '--fixup', 'deadbeef', env=None),
+            mock_run_git.mock_calls)
 
     def test_git_commit_no_verify(self):
         """Test git_commit passes --no-verify when no_verify=True."""
@@ -269,8 +270,33 @@ class RepositoryTest(unittest.TestCase):
                                            no_verify=True)
 
         self.assertIn(
-            unittest.mock.call('commit', '-m', 'Commit with no verify',
-                               '--no-verify'), mock_run_git.mock_calls)
+            unittest.mock.call('commit',
+                               '-m',
+                               'Commit with no verify',
+                               '--no-verify',
+                               env=None), mock_run_git.mock_calls)
+
+    def test_git_commit_env_plumbed_to_run_git(self):
+        """Test git_commit forwards `env` down to run_git."""
+        with patch.object(Repository, 'has_staged_changes',
+                          return_value=True), patch.object(
+                              Repository,
+                              'run_git',
+                              return_value='abcd123 msg') as mock_run_git:
+            repository.chromium.git_commit('Toolchain bump',
+                                           env={
+                                               'tags': 'toolchain',
+                                               'culprit': 'deadbeef',
+                                           })
+
+        self.assertIn(
+            unittest.mock.call('commit',
+                               '-m',
+                               'Toolchain bump',
+                               env={
+                                   'tags': 'toolchain',
+                                   'culprit': 'deadbeef',
+                               }), mock_run_git.mock_calls)
 
     def test_is_valid_git_reference(self):
         """Test is_valid_git_reference using the chromium repository."""

--- a/tools/cr/terminal.py
+++ b/tools/cr/terminal.py
@@ -196,6 +196,11 @@ class Terminal:
         spawning editors, pagers, or anything else that needs to take
         over the tty. The returned `CompletedProcess.stdout` /
         `.stderr` are `None` in that case (nothing is captured).
+
+        `env` follows the same semantics as `subprocess.run`: `None` inherits
+        the parent's environment, a dict fully replaces it. If you want to
+        add a few keys on top of `os.environ`, copy it first
+        (`env={**os.environ, ...}`).
         """
         # Convert all arguments to strings, to avoid issues with `PurePath`
         # being passed arguments
@@ -258,7 +263,10 @@ class Terminal:
 
         return result
 
-    def run_git(self, *cmd, no_trim=False) -> str:
+    def run_git(self,
+                *cmd,
+                no_trim=False,
+                env: dict[str, str] | None = None) -> str:
         """Runs a git command with the arguments provided.
 
     This function returns a proper utf8 string in success, otherwise it allows
@@ -268,13 +276,14 @@ class Terminal:
         *cmd: The command to run, with any arguments.
         no_trim: If True, the output will not be trimmed. This is usually rare
         but preferred when producing the contents of a file.
+        env: Optional environment variables to be forwarded to `terminal.run`.
     e.g:
         self.run_git('add', '-u', '*.patch')
     """
         cmd = ['git'] + list(cmd)
         if no_trim:
-            return self.run(cmd).stdout
-        return self.run(cmd).stdout.strip()
+            return self.run(cmd, env=env).stdout
+        return self.run(cmd, env=env).stdout.strip()
 
     def log_task(self, message):
         """Logs a task to the console using common decorators

--- a/tools/cr/update_xcode_toolchain_test.py
+++ b/tools/cr/update_xcode_toolchain_test.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env vpython3
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Tests for `brockit.UpdateXcodeToolchain`.
+
+The file is split in two layers, matching `rebase_v2_test.py`'s shape:
+
+* `ReplaceConstantTest` exercises the pure file-content transform used to
+  rewrite `build/mac/download_hermetic_xcode.py`. No git involved.
+
+* `UpdateXcodeToolchainExecuteTest` drives
+  `UpdateXcodeToolchain.execute` end-to-end against a `FakeChromiumRepo`,
+  with the commit-msg hook installed so the `tags=toolchain` /
+  `culprit=<hash>` env wiring is validated through the same pipeline that
+  ships in production.
+"""
+
+from __future__ import annotations
+
+import shutil
+import stat
+import subprocess
+import unittest
+from pathlib import Path
+
+import brockit
+import repository
+from test.fake_chromium_repo import FakeChromiumRepo
+
+# Source of the commit-msg hook. The integration tests symlink this into
+# `.git/hooks/commit-msg` so the `tags` / `culprit` env vars are interpreted
+# exactly the way they are in production.
+HOOK_SOURCE: Path = (Path(__file__).resolve().parent / 'alias' /
+                     'commit-msg.py')
+
+# A representative archive URL emitted by
+# `tools/cr/toolchain/build_xcode_toolchain.py`. The six dash-separated tokens
+# in the filename are what `UpdateXcodeToolchain.execute` consumes.
+TOOLCHAIN_URL = (
+    'https://example.invalid/xcode-hermetic-toolchain/'
+    'xcode-hermetic-toolchain-26.5-17F42-26.5-25F70-for-upstream-26.5-25F70'
+    '.tar.gz')
+
+# The starting on-disk content of `build/mac/download_hermetic_xcode.py`
+# before the bump. Kept minimal -- the six constants are the only thing
+# `UpdateXcodeToolchain.execute` rewrites.
+HERMETIC_XCODE_SCRIPT_INITIAL = """\
+# Sample header.
+
+XCODE_VERSION = '26.4'
+XCODE_BUILD_VERSION = '17E192'
+
+MAC_SDK_OFFICIAL_VERSION = '26.4'
+MAC_SDK_OFFICIAL_BUILD_VERSION = '25E236'
+
+MAC_SDK_UPSTREAM_VERSION = '26.4'
+MAC_SDK_UPSTREAM_BUILD_VERSION = '25E236'
+"""
+
+# The starting content of `build/config/mac/mac_sdk.gni` on the chromium
+# side, before the upstream switch. The first commit that introduces the
+# matching upstream build number is what `_resolve_chromium_commit`'s
+# pickaxe is supposed to find.
+MAC_SDK_GNI_INITIAL = """\
+mac_sdk_official_version = "26.4"
+mac_sdk_official_build_version = "25E236"
+"""
+
+MAC_SDK_GNI_BUMPED = """\
+mac_sdk_official_version = "26.5"
+mac_sdk_official_build_version = "25F70"
+"""
+
+
+class ReplaceConstantTest(unittest.TestCase):
+    """Tests for `UpdateXcodeToolchain._replace_constant`."""
+
+    SAMPLE = ("XCODE_VERSION = '26.4'\n"
+              "XCODE_BUILD_VERSION = '17E192'\n"
+              'MAC_SDK_OFFICIAL_VERSION = "26.4"\n')
+
+    def test_rewrites_single_quoted_value(self):
+        result = brockit.UpdateXcodeToolchain._replace_constant(
+            self.SAMPLE, 'XCODE_VERSION', '26.5')
+        self.assertIn("XCODE_VERSION = '26.5'", result)
+        # Untouched lines pass through unchanged.
+        self.assertIn("XCODE_BUILD_VERSION = '17E192'", result)
+        self.assertIn('MAC_SDK_OFFICIAL_VERSION = "26.4"', result)
+
+    def test_rewrites_double_quoted_value(self):
+        """Double-quoted assignments are matched and normalised to
+        single-quoted output (matching the script's existing style)."""
+        result = brockit.UpdateXcodeToolchain._replace_constant(
+            self.SAMPLE, 'MAC_SDK_OFFICIAL_VERSION', '26.5')
+        self.assertIn("MAC_SDK_OFFICIAL_VERSION = '26.5'", result)
+
+    def test_replaces_only_first_occurrence(self):
+        """The pattern is anchored at line start with `count=1`. A bare
+        substring match elsewhere in the file (e.g. a comment that
+        mentions `XCODE_VERSION`) does not get rewritten."""
+        text = ("# XCODE_VERSION = '???' is the constant below.\n"
+                "XCODE_VERSION = '26.4'\n")
+        result = brockit.UpdateXcodeToolchain._replace_constant(
+            text, 'XCODE_VERSION', '26.5')
+        self.assertEqual(
+            result, "# XCODE_VERSION = '???' is the constant below.\n"
+            "XCODE_VERSION = '26.5'\n")
+
+    def test_missing_constant_raises(self):
+        """A constant that doesn't exist in the file at all surfaces as an
+        `InvalidInputException` rather than silently leaving the file
+        unchanged."""
+        with self.assertRaises(brockit.InvalidInputException):
+            brockit.UpdateXcodeToolchain._replace_constant(
+                self.SAMPLE, 'NOT_A_REAL_CONSTANT', '26.5')
+
+
+class UpdateXcodeToolchainExecuteTest(unittest.TestCase):
+    """End-to-end tests for `UpdateXcodeToolchain.execute`.
+
+    Each test seeds the fake brave repo with a starting
+    `build/mac/download_hermetic_xcode.py`, optionally seeds the fake
+    chromium repo with a `build/config/mac/mac_sdk.gni` bump, installs the
+    commit-msg hook so the env-var plumbing is exercised end-to-end, and
+    then drives `UpdateXcodeToolchain.execute` directly.
+    """
+
+    def setUp(self):
+        self.repo = FakeChromiumRepo()
+        self.repo.setup()
+        self.addCleanup(self.repo.cleanup)
+        self._checkout_cr_branch()
+        self._install_commit_msg_hook()
+
+    # -- fixture helpers ----------------------------------------------------
+
+    def _checkout_cr_branch(self, name: str = 'cr150') -> None:
+        """Switches the fake brave repo onto a `cr{N}` branch.
+
+        The commit-msg hook keys off the current branch name to inject the
+        `[cr{N}]` prefix into the final commit message, so every
+        integration test runs on a branch that matches that pattern.
+        """
+        self.repo._run_git_command(['checkout', '-b', name], self.repo.brave)
+
+    def _install_commit_msg_hook(self) -> None:
+        """Copies `tools/cr/alias/commit-msg.py` into the fake brave repo's
+        `.git/hooks/commit-msg` and marks it executable.
+
+        Using a copy (rather than a symlink) keeps the fixture
+        self-contained -- the hook keeps working even after the source
+        worktree the test was launched from has been wiped by other test
+        cleanup.
+        """
+        hooks_dir = self.repo.brave / '.git' / 'hooks'
+        hooks_dir.mkdir(exist_ok=True)
+        dest = hooks_dir / 'commit-msg'
+        if dest.exists() or dest.is_symlink():
+            dest.unlink()
+        shutil.copy2(HOOK_SOURCE, dest)
+        dest.chmod(dest.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP
+                   | stat.S_IXOTH)
+
+    def _seed_hermetic_xcode_script(
+            self, content: str = HERMETIC_XCODE_SCRIPT_INITIAL) -> None:
+        """Writes `build/mac/download_hermetic_xcode.py` into fake brave
+        with the supplied content and commits it.
+
+        Commits via the hook-bypass path (`--no-verify`) so this fixture
+        commit doesn't try to invoke the hook before we've seeded any
+        culprit history.
+        """
+        script_path = self.repo.brave / brockit.HERMETIC_XCODE_SCRIPT
+        script_path.parent.mkdir(parents=True, exist_ok=True)
+        script_path.write_text(content, encoding='utf-8', newline='')
+        self.repo._run_git_command(['add', str(script_path)], self.repo.brave)
+        self.repo._run_git_command(
+            ['commit', '--no-verify', '-m', 'Seed hermetic xcode script'],
+            self.repo.brave)
+
+    def _seed_mac_sdk_bump(self,
+                           initial: str = MAC_SDK_GNI_INITIAL,
+                           bumped: str | None = MAC_SDK_GNI_BUMPED) -> str:
+        """Lays down `build/config/mac/mac_sdk.gni` on fake chromium with
+        two commits: the initial pin, then the bump.
+
+        Returns the hash of the *bump* commit -- that's what the pickaxe
+        in `_resolve_chromium_commit` is supposed to find. When `bumped`
+        is `None`, only the initial commit is created (used to test the
+        unresolvable-commit failure path).
+        """
+        gni = self.repo.chromium / 'build' / 'config' / 'mac' / 'mac_sdk.gni'
+        gni.parent.mkdir(parents=True, exist_ok=True)
+        gni.write_text(initial, encoding='utf-8', newline='')
+        self.repo._run_git_command(['add', str(gni)], self.repo.chromium)
+        self.repo._run_git_command(['commit', '-m', 'mac: initial SDK pin'],
+                                   self.repo.chromium)
+
+        if bumped is None:
+            return ''
+
+        gni.write_text(bumped, encoding='utf-8', newline='')
+        self.repo._run_git_command(['add', str(gni)], self.repo.chromium)
+        self.repo._run_git_command(['commit', '-m', 'mac: Switch to SDK 26.5'],
+                                   self.repo.chromium)
+        return self.repo._run_git_command(['rev-parse', 'HEAD'],
+                                          self.repo.chromium)
+
+    def _last_brave_commit_message(self) -> str:
+        return self.repo._run_git_command(['log', '-1', '--format=%B'],
+                                          self.repo.brave)
+
+    def _last_brave_subject(self) -> str:
+        return self.repo._run_git_command(['log', '-1', '--format=%s'],
+                                          self.repo.brave)
+
+    def _read_hermetic_xcode_script(self) -> str:
+        return (self.repo.brave /
+                brockit.HERMETIC_XCODE_SCRIPT).read_text(encoding='utf-8')
+
+    # -- tests --------------------------------------------------------------
+
+    def test_constants_rewritten_and_committed(self):
+        """Happy path: every constant takes its value from the URL, the
+        edit lands on disk, and the commit-msg hook stamps the final
+        message with `[cr150][toolchain]` plus the chromium culprit
+        body."""
+        self._seed_hermetic_xcode_script()
+        culprit = self._seed_mac_sdk_bump()
+
+        brockit.UpdateXcodeToolchain().execute(url=TOOLCHAIN_URL, culprit=None)
+
+        script = self._read_hermetic_xcode_script()
+        self.assertIn("XCODE_VERSION = '26.5'", script)
+        self.assertIn("XCODE_BUILD_VERSION = '17F42'", script)
+        self.assertIn("MAC_SDK_OFFICIAL_VERSION = '26.5'", script)
+        self.assertIn("MAC_SDK_OFFICIAL_BUILD_VERSION = '25F70'", script)
+        self.assertIn("MAC_SDK_UPSTREAM_VERSION = '26.5'", script)
+        self.assertIn("MAC_SDK_UPSTREAM_BUILD_VERSION = '25F70'", script)
+
+        message = self._last_brave_commit_message()
+        # The hook must have stamped both tags. The relative order between
+        # `[cr150]` and `[toolchain]` comes from set iteration in
+        # `commit-msg.py`, so just assert both are present in the
+        # subject.
+        subject = message.splitlines()[0]
+        self.assertIn('[cr150]', subject)
+        self.assertIn('[toolchain]', subject)
+        self.assertIn('Switch to Xcode 26.5 17F42', subject)
+
+        # The culprit body the hook appends includes the link and the
+        # full `git log -1 <hash>` payload from chromium.
+        self.assertIn(
+            f'https://chromium.googlesource.com/chromium/src/+/{culprit}',
+            message)
+        self.assertIn('mac: Switch to SDK 26.5', message)
+
+    def test_culprit_override_skips_auto_detection(self):
+        """An explicit `culprit=<hash>` bypasses the mac_sdk.gni pickaxe
+        entirely. We prove this by passing a hash that the auto-detector
+        would never have produced -- a commit on the chromium master
+        branch that doesn't touch `mac_sdk.gni` at all."""
+        self._seed_hermetic_xcode_script()
+        # Seed an unrelated chromium commit so we have a real hash to
+        # reference.
+        self.repo.write_and_stage_file('docs/unrelated.txt', 'noise\n',
+                                       self.repo.chromium)
+        override_hash = self.repo.commit('Unrelated chromium change',
+                                         self.repo.chromium)
+        # Seed mac_sdk.gni only with the initial state; a successful run
+        # here means the auto-detector was never asked.
+        self._seed_mac_sdk_bump(bumped=None)
+
+        brockit.UpdateXcodeToolchain().execute(url=TOOLCHAIN_URL,
+                                               culprit=override_hash)
+
+        message = self._last_brave_commit_message()
+        self.assertIn(
+            f'https://chromium.googlesource.com/chromium/src/+/{override_hash}',
+            message)
+        self.assertIn('Unrelated chromium change', message)
+
+    def test_already_pinned_raises(self):
+        """When `build/mac/download_hermetic_xcode.py` already carries the
+        URL's six tokens, the regex substitutions are all no-ops and the
+        task aborts instead of producing an empty commit."""
+        self._seed_hermetic_xcode_script(
+            content=("XCODE_VERSION = '26.5'\n"
+                     "XCODE_BUILD_VERSION = '17F42'\n"
+                     "MAC_SDK_OFFICIAL_VERSION = '26.5'\n"
+                     "MAC_SDK_OFFICIAL_BUILD_VERSION = '25F70'\n"
+                     "MAC_SDK_UPSTREAM_VERSION = '26.5'\n"
+                     "MAC_SDK_UPSTREAM_BUILD_VERSION = '25F70'\n"))
+        self._seed_mac_sdk_bump()
+        head_before = self.repo._run_git_command(['rev-parse', 'HEAD'],
+                                                 self.repo.brave)
+
+        with self.assertRaises(brockit.InvalidInputException):
+            brockit.UpdateXcodeToolchain().execute(url=TOOLCHAIN_URL,
+                                                   culprit=None)
+
+        # No commit was produced.
+        head_after = self.repo._run_git_command(['rev-parse', 'HEAD'],
+                                                self.repo.brave)
+        self.assertEqual(head_before, head_after)
+
+    def test_bad_url_raises(self):
+        """A URL whose filename doesn't fit the
+        `xcode-hermetic-toolchain-<...>.tar.gz` shape is rejected before
+        any disk state is touched."""
+        self._seed_hermetic_xcode_script()
+        self._seed_mac_sdk_bump()
+        original = self._read_hermetic_xcode_script()
+
+        with self.assertRaises(brockit.InvalidInputException):
+            brockit.UpdateXcodeToolchain().execute(
+                url='https://example.invalid/some-other-archive.tar.gz',
+                culprit=None)
+
+        self.assertEqual(self._read_hermetic_xcode_script(), original)
+
+    def test_unresolvable_chromium_commit_raises(self):
+        """When `mac_sdk.gni` has never carried the URL's upstream build
+        number, the pickaxe returns nothing and the task points the user
+        at `--culprit` to recover."""
+        self._seed_hermetic_xcode_script()
+        # Seed mac_sdk.gni without ever introducing the URL's build
+        # number, so `git log -S 25F70 -- build/config/mac/mac_sdk.gni`
+        # comes back empty.
+        self._seed_mac_sdk_bump(bumped=None)
+        head_before = self.repo._run_git_command(['rev-parse', 'HEAD'],
+                                                 self.repo.brave)
+
+        with self.assertRaises(brockit.InvalidInputException):
+            brockit.UpdateXcodeToolchain().execute(url=TOOLCHAIN_URL,
+                                                   culprit=None)
+
+        # The script edit happens before the chromium lookup, so the
+        # working tree may be dirty. What we care about here is that no
+        # commit slipped through.
+        head_after = self.repo._run_git_command(['rev-parse', 'HEAD'],
+                                                self.repo.brave)
+        self.assertEqual(head_before, head_after)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This is a new `brockit` subcommand that takes care in creating the
commit updating the Xcode toolchain in brave-core.

```sh
brockit.py update-xcode-toolchain --culprit=[optional] <url>
```

The URL in question is printed by CI when generating a new toolchain,
with the label `Download URL: <url>`

Bug: https://github.com/brave/brave-browser/issues/55528
