### PR TITLE
[Android] Fix for the shields layout in a certain configs

### DIFF
--- a/android/java/brave-res/layout/brave_toolbar.xml
+++ b/android/java/brave-res/layout/brave_toolbar.xml
@@ -56,7 +56,7 @@
   <FrameLayout android:id="@+id/brave_shields_button_layout"
       android:layout_width="45dp"
       android:orientation="vertical"
-      android:background="@drawable/modern_toolbar_background_grey_middle_segment"
+      android:background="@drawable/modern_toolbar_background_grey_end_segment"
       android:layout_height="match_parent" >
 
       <ImageButton android:id="@+id/brave_shields_button"

--- a/android/java/org/chromium/chrome/browser/toolbar/top/BraveToolbarLayoutImpl.java
+++ b/android/java/org/chromium/chrome/browser/toolbar/top/BraveToolbarLayoutImpl.java
@@ -1757,9 +1757,12 @@ public abstract class BraveToolbarLayoutImpl extends ToolbarLayout
     }
 
     /**
-     * Hides the rewards layout if the toolbar width is less than the minimum tablet width and the
-     * rewards icon should be shown. Uses the same threshold as the existing toolbar button
-     * visibility logic in ToolbarTablet.
+     * Updates the rewards layout visibility on tablet. The layout is shown only when all of the
+     * following are true: the current tab is not incognito, the toolbar width is at least the
+     * minimum tablet width (same threshold as the existing toolbar button visibility logic in
+     * ToolbarTablet), rewards are not disabled by policy, and the native rewards worker is
+     * available and reports rewards as supported. Also updates the shields layout background to
+     * match the resulting rewards layout visibility.
      */
     private void maybeHideRewardsLayout(int width) {
         // Only hide the rewards layout on tablet devices, like it is done in the upstream code.

--- a/android/java/org/chromium/chrome/browser/toolbar/top/BraveToolbarLayoutImpl.java
+++ b/android/java/org/chromium/chrome/browser/toolbar/top/BraveToolbarLayoutImpl.java
@@ -1773,13 +1773,17 @@ public abstract class BraveToolbarLayoutImpl extends ToolbarLayout
 
         Tab tab = getToolbarDataProvider().getTab();
         Profile profile = tab != null ? Profile.fromWebContents(tab.getWebContents()) : null;
-        mRewardsLayout.setVisibility(
-                width >= DeviceFormFactor.getNonMultiDisplayMinimumTabletWidthPx(getContext())
-                                && !BraveRewardsPolicy.isDisabledByPolicy(profile)
-                        ? View.VISIBLE
-                        : View.GONE);
+        boolean shouldShowRewards =
+                !isIncognito()
+                        && width
+                                >= DeviceFormFactor.getNonMultiDisplayMinimumTabletWidthPx(
+                                        getContext())
+                        && !BraveRewardsPolicy.isDisabledByPolicy(profile)
+                        && mBraveRewardsNativeWorker != null
+                        && mBraveRewardsNativeWorker.isSupported();
+        mRewardsLayout.setVisibility(shouldShowRewards ? View.VISIBLE : View.GONE);
         // Update the shields layout background to match the rewards layout visibility.
-        updateShieldsLayoutBackground(mRewardsLayout.getVisibility() == View.GONE);
+        updateShieldsLayoutBackground(!shouldShowRewards);
     }
 
     public void maybeShowTermsOfServiceUpdateRequiredBadge() {


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/54268

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
