### PR TITLE
Fix adblock subscriptions for secondary profile startup

### DIFF
--- a/browser/brave_shields/ad_block_service_browsertest.cc
+++ b/browser/brave_shields/ad_block_service_browsertest.cc
@@ -16,6 +16,7 @@
 #include "base/check.h"
 #include "base/files/file_util.h"
 #include "base/functional/callback_helpers.h"
+#include "base/json/values_util.h"
 #include "base/memory/raw_ptr.h"
 #include "base/memory/scoped_refptr.h"
 #include "base/path_service.h"
@@ -54,13 +55,18 @@
 #include "chrome/browser/browser_process.h"
 #include "chrome/browser/content_settings/host_content_settings_map_factory.h"
 #include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/profiles/profile_manager.h"
+#include "chrome/browser/profiles/profile_test_util.h"
 #include "chrome/common/chrome_isolated_world_ids.h"
+#include "chrome/common/chrome_switches.h"
 #include "chrome/test/base/chrome_test_utils.h"
 #include "chrome/test/base/platform_browser_test.h"
 #include "components/prefs/pref_change_registrar.h"
 #include "components/prefs/pref_service.h"
+#include "components/prefs/scoped_user_pref_update.h"
 #include "content/public/test/browser_test.h"
 #include "content/public/test/browser_test_utils.h"
+#include "net/base/filename_util.h"
 #include "net/dns/mock_host_resolver.h"
 #include "net/test/embedded_test_server/embedded_test_server.h"
 #include "net/test/embedded_test_server/install_default_websocket_handlers.h"
@@ -123,6 +129,15 @@ using brave_shields::features::kBraveAdblockScriptletDebugLogs;
 using brave_shields::features::kCosmeticFilteringJsPerformance;
 
 namespace {
+
+#if !BUILDFLAG(IS_ANDROID)
+constexpr char kSecondaryProfileDir[] = "Profile 2";
+constexpr char kSubscriptionListForSecondaryProfileStartup[] =
+    "! Title: Test list\n"
+    "! Homepage: https://example.com/list.txt\n"
+    "! Expires: 3 days\n"
+    "||b.com^*logo.png^\n";
+#endif
 
 void WaitForSelectorBlocked(const content::ToRenderFrameHost& target,
                             const std::string& selector) {
@@ -837,6 +852,99 @@ class TestAdBlockSubscriptionServiceManagerObserver
   raw_ptr<brave_shields::AdBlockSubscriptionServiceManager>
       sub_service_manager_ = nullptr;
 };
+
+#if !BUILDFLAG(IS_ANDROID)
+class AdBlockServiceSecondaryProfileStartupTest : public AdBlockServiceTest {
+ public:
+  void SetUpCommandLine(base::CommandLine* command_line) override {
+    AdBlockServiceTest::SetUpCommandLine(command_line);
+    if (GetTestPreCount() == 0) {
+      command_line->AppendSwitchASCII(switches::kProfileDirectory,
+                                      kSecondaryProfileDir);
+    }
+  }
+};
+
+IN_PROC_BROWSER_TEST_F(AdBlockServiceSecondaryProfileStartupTest,
+                       PRE_LoadsCustomSubscriptionsWithOnlySecondaryProfile) {
+  auto* profile_manager = g_browser_process->profile_manager();
+  const base::FilePath secondary_profile_path =
+      profile_manager->user_data_dir().AppendASCII(kSecondaryProfileDir);
+  profiles::testing::CreateProfileSync(profile_manager, secondary_profile_path);
+
+  const GURL subscription_url =
+      embedded_test_server()->GetURL("lists.com", "/list.txt");
+  auto* subscription_service_manager =
+      g_brave_browser_process->ad_block_service()
+          ->subscription_service_manager();
+
+  base::FilePath list_path;
+  ASSERT_TRUE(net::FileURLToFilePath(
+      subscription_service_manager->GetListTextFileUrl(subscription_url),
+      &list_path));
+
+  {
+    base::ScopedAllowBlockingForTesting allow_blocking;
+    ASSERT_TRUE(base::CreateDirectory(list_path.DirName()));
+    ASSERT_TRUE(base::WriteFile(list_path,
+                                kSubscriptionListForSecondaryProfileStartup));
+  }
+
+  const base::Time now = base::Time::Now();
+  {
+    ScopedDictPrefUpdate update(
+        local_state(), brave_shields::prefs::kAdBlockListSubscriptions);
+    base::DictValue subscription_dict;
+    subscription_dict.Set("enabled", true);
+    subscription_dict.Set("last_update_attempt", base::TimeToValue(now));
+    subscription_dict.Set("last_successful_update_attempt",
+                          base::TimeToValue(now));
+    subscription_dict.Set("homepage", "https://example.com/list.txt");
+    subscription_dict.Set("title", "Test list");
+    subscription_dict.Set("expires", 3 * 24);
+    update.Get().Set(subscription_url.spec(), std::move(subscription_dict));
+  }
+
+  local_state()->CommitPendingWrite();
+  CloseAllBrowsers();
+}
+
+IN_PROC_BROWSER_TEST_F(AdBlockServiceSecondaryProfileStartupTest,
+                       LoadsCustomSubscriptionsWithOnlySecondaryProfile) {
+  auto* profile_manager = g_browser_process->profile_manager();
+  EXPECT_EQ(base::FilePath::FromASCII(kSecondaryProfileDir),
+            profile()->GetPath().BaseName());
+  EXPECT_EQ(nullptr, profile_manager->GetProfileByPath(
+                         profile_manager->user_data_dir().Append(
+                             ProfileManager::GetInitialProfileDir())));
+
+  auto* service = g_brave_browser_process->ad_block_service();
+  auto* subscription_service_manager = service->subscription_service_manager();
+
+  ASSERT_TRUE(base::test::RunUntil([&]() {
+    return subscription_service_manager->GetSubscriptions().size() == 1 &&
+           service->IsFilterListLoadedForTesting(false);
+  })) << "Timed out waiting for custom subscriptions to load";
+
+  const auto subscriptions = subscription_service_manager->GetSubscriptions();
+  ASSERT_EQ(1u, subscriptions.size());
+  EXPECT_TRUE(subscriptions[0].enabled);
+  EXPECT_EQ("lists.com", subscriptions[0].subscription_url.host());
+  EXPECT_EQ("/list.txt", subscriptions[0].subscription_url.path());
+
+  ASSERT_TRUE(brave_shields::WaitForAdBlockServiceThreads());
+
+  const GURL tab_url =
+      embedded_test_server()->GetURL("b.com", kAdBlockTestPage);
+  const GURL resource_url =
+      embedded_test_server()->GetURL("b.com", "/logo.png");
+  NavigateToURL(tab_url);
+  EXPECT_EQ(true, EvalJs(web_contents(),
+                         content::JsReplace("setExpectations(0, 0, 0, 1);"
+                                            "xhr($1)",
+                                            resource_url.spec())));
+}
+#endif  // !BUILDFLAG(IS_ANDROID)
 
 // Make sure a list added as a custom subscription works correctly
 // The download in this test fails intermittently with a network error code,

--- a/browser/brave_shields/ad_block_subscription_download_manager_getter.cc
+++ b/browser/brave_shields/ad_block_subscription_download_manager_getter.cc
@@ -71,15 +71,35 @@ class AdBlockSubscriptionDownloadManagerFactory
   }
 };
 
-AdBlockSubscriptionDownloadManager* MaybeGetDownloadManager() {
-  auto* profile_manager = g_browser_process->profile_manager();
-  auto* profile =
-      profile_manager->GetProfileByPath(profile_manager->user_data_dir().Append(
-          profile_manager->GetInitialProfileDir()));
-  if (profile) {
-    return AdBlockSubscriptionDownloadManagerFactory::GetInstance()->GetForKey(
+AdBlockSubscriptionDownloadManager* GetDownloadManagerForProfile(
+    Profile* profile) {
+  if (profile && profile->IsRegularProfile()) {
+    return AdBlockSubscriptionDownloadManagerFactory::GetForKey(
         profile->GetProfileKey());
   }
+  return nullptr;
+}
+
+AdBlockSubscriptionDownloadManager* MaybeGetDownloadManager() {
+  auto* profile_manager = g_browser_process->profile_manager();
+  if (auto* download_manager =
+          GetDownloadManagerForProfile(profile_manager->GetProfileByPath(
+              profile_manager->user_data_dir().Append(
+                  profile_manager->GetInitialProfileDir())))) {
+    return download_manager;
+  }
+
+  if (auto* download_manager = GetDownloadManagerForProfile(
+          ProfileManager::GetLastUsedProfileIfLoaded())) {
+    return download_manager;
+  }
+
+  for (auto* profile : profile_manager->GetLoadedProfiles()) {
+    if (auto* download_manager = GetDownloadManagerForProfile(profile)) {
+      return download_manager;
+    }
+  }
+
   return nullptr;
 }
 
@@ -97,7 +117,7 @@ class AdBlockSubscriptionDownloadManagerGetterImpl
 
  private:
   void OnProfileAdded(Profile* profile) override {
-    if (auto* download_manager = MaybeGetDownloadManager()) {
+    if (auto* download_manager = GetDownloadManagerForProfile(profile)) {
       std::move(callback_).Run(download_manager);
       OnProfileManagerDestroying();
     }


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/55623

## Summary

Fix custom adblock subscription loading when Brave starts directly with a secondary regular profile, without loading the initial/default profile.

Custom filter list subscriptions are stored globally in Local State, but loading them was gated on obtaining an `AdBlockSubscriptionDownloadManager`. The getter only looked up that manager from the initial profile directory. When Brave was launched directly with another regular profile directory, the initial profile was not loaded, so the service manager never loaded saved custom subscriptions.

This change keeps the existing global subscription semantics and cache location. It still prefers the initial/default profile when loaded, but falls back to an already-loaded regular profile and satisfies pending manager waits from a newly-added regular profile.

This PR does not change whether custom subscriptions are global or per-profile; it only fixes the startup-order bug where the global subscription service waited for the initial/default profile’s download manager.

## Test plan

- `git diff --check origin/master...HEAD` passed.
- `PATH=/home/suwa/oss/src/third_party/rust-toolchain/bin:/home/suwa/oss/src/third_party/depot_tools:$PATH PYTHONPATH=/home/suwa/oss/src/brave/script npm run build -- -C Component --target=brave,brave_browser_tests` passed.
- `../out/Component/brave_browser_tests --gtest_filter='AdBlockServiceSecondaryProfileStartupTest.*:AdBlockServiceTest.SubscribeTo404List:AdBlockServiceTest.SubscribeToListUrlTwice' --no-sandbox` passed.
- `../out/Component/brave_browser_tests --gtest_filter='AdBlockServiceTest.*:AdBlockServiceSecondaryProfileStartupTest.*' --no-sandbox` passed: 84/84 tests passed.

Manual verification performed with a local developer build:
1. Started Brave with a user data dir containing the initial/default profile and at least one other regular profile.
2. In the initial/default profile, added a custom list from `brave://settings/shields/filters`.
3. Confirmed the list blocked the expected test resource.
4. Quit Brave.
5. Relaunched Brave with only the secondary regular profile using `--profile-directory="<secondary profile directory>"`.
6. Confirmed the custom list still appeared in settings without opening the initial/default profile.
7. Confirmed the custom list still blocked the expected test resource.

Note: `<secondary profile directory>` is the profile directory name for the non-initial regular profile being tested. The exact value depends on the profile creation/deletion history.

## AI assistance disclosure

AI assistance was used to investigate the startup-order bug and draft parts of the localized fix and regression test. I understand the changes in this PR, reviewed the implementation myself, and manually verified the user-facing behavior locally as described above.
