### PR TITLE
[iOS] Migrate Block All Cookies preference to Chromium profile prefs

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabPolicyDecider.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabPolicyDecider.swift
@@ -367,7 +367,7 @@ extension BrowserViewController: TabPolicyDecider {
       // Cookie Blocking code below
       tab.browserData?.setScript(
         script: .cookieBlocking,
-        enabled: Preferences.Privacy.blockAllCookies.value
+        enabled: tab.profile.prefs.boolean(forPath: kBlockAllCookiesEnabled)
       )
 
       // Reset the block alert bool on new host.

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -462,7 +462,6 @@ public class BrowserViewController: UIViewController {
     Preferences.General.tabBarVisibility.observe(from: self)
     Preferences.General.defaultPageZoomLevel.observe(from: self)
     Preferences.Shields.allShields.forEach { $0.observe(from: self) }
-    Preferences.Privacy.blockAllCookies.observe(from: self)
     Preferences.Rewards.hideRewardsIcon.observe(from: self)
     Preferences.Rewards.rewardsToggledOnce.observe(from: self)
     Preferences.Playlist.enablePlaylistURLBarButton.observe(from: self)
@@ -487,6 +486,22 @@ public class BrowserViewController: UIViewController {
         )
       ])
       tabManager.reloadSelectedTab()
+    }
+    prefsChangeRegistrar.addObserver(forPath: kBlockAllCookiesEnabled) { [weak self] _ in
+      guard let self else { return }
+      // All `block all cookies` toggle requires a hard reset of Webkit configuration.
+      tabManager.reset()
+      if !profileController.profile.prefs.boolean(forPath: kBlockAllCookiesEnabled) {
+        tabManager.reloadSelectedTab()
+        for tab in tabManager.allTabs where tab !== tabManager.selectedTab {
+          tab.createWebView()
+          if let url = tab.visibleURL {
+            tab.loadRequest(PrivilegedRequest(url: url) as URLRequest)
+          }
+        }
+      } else {
+        tabManager.reloadSelectedTab()
+      }
     }
 
     disconnectVPNIfDisabledByPolicy()
@@ -2900,21 +2915,10 @@ extension BrowserViewController: PreferencesObserver {
             ?? Preferences.General.defaultPageZoomLevel.value
         $0.viewScale = zoomLevel
       })
-    case Preferences.Privacy.blockAllCookies.key,
-      Preferences.Shields.googleSafeBrowsing.key:
-      // All `block all cookies` toggle requires a hard reset of Webkit configuration.
+    case Preferences.Shields.googleSafeBrowsing.key:
+      // Toggling Google safe browsing requires a hard reset of Webkit configuration.
       tabManager.reset()
-      if !Preferences.Privacy.blockAllCookies.value {
-        self.tabManager.reloadSelectedTab()
-        for tab in self.tabManager.allTabs where tab !== self.tabManager.selectedTab {
-          tab.createWebView()
-          if let url = tab.visibleURL {
-            tab.loadRequest(PrivilegedRequest(url: url) as URLRequest)
-          }
-        }
-      } else {
-        tabManager.reloadSelectedTab()
-      }
+      tabManager.reloadSelectedTab()
     case Preferences.Rewards.hideRewardsIcon.key,
       Preferences.Rewards.rewardsToggledOnce.key:
       updateRewardsButtonState()

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/TabBrowserData.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/TabBrowserData.swift
@@ -357,7 +357,7 @@ class TabBrowserData: NSObject, TabObserver {
 
   func tabDidCreateWebView(_ tab: some TabState) {
     let scriptPreferences: [UserScriptManager.ScriptType: Bool] = [
-      .cookieBlocking: Preferences.Privacy.blockAllCookies.value,
+      .cookieBlocking: tab.profile.prefs.boolean(forPath: kBlockAllCookiesEnabled),
       .mediaBackgroundPlay: tab.profile.prefs.boolean(forPath: kMediaBackgroundingEnabled),
       .braveTranslate: Preferences.Translate.translateEnabled.value != false,
     ]

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/LinkPreviewViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/LinkPreviewViewController.swift
@@ -66,7 +66,8 @@ class LinkPreviewViewController: UIViewController {
       let shieldLevel = braveShieldsTabHelper.shieldLevel(for: url, considerAllShieldsOption: true)
       let ruleLists = await AdBlockGroupsManager.shared.ruleLists(
         isBraveShieldsEnabled: isBraveShieldsEnabled,
-        shieldLevel: shieldLevel
+        shieldLevel: shieldLevel,
+        isBlockAllCookiesEnabled: tab.profile.prefs.boolean(forPath: kBlockAllCookiesEnabled)
       )
       for ruleList in ruleLists {
         currentTab.configuration?.userContentController.add(ruleList)

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Playlist/ManagersAndCache/PlaylistCacheLoader.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Playlist/ManagersAndCache/PlaylistCacheLoader.swift
@@ -351,7 +351,8 @@ extension LivePlaylistWebLoader: TabPolicyDecider {
       {
         let ruleLists = await AdBlockGroupsManager.shared.ruleLists(
           isBraveShieldsEnabled: true,
-          shieldLevel: .aggressive
+          shieldLevel: .aggressive,
+          isBlockAllCookiesEnabled: tab.profile.prefs.boolean(forPath: kBlockAllCookiesEnabled)
         )
         tab.contentBlocker?.set(ruleLists: ruleLists)
       }
@@ -359,7 +360,7 @@ extension LivePlaylistWebLoader: TabPolicyDecider {
       // Cookie Blocking code below
       tab.browserData?.setScript(
         script: .cookieBlocking,
-        enabled: Preferences.Privacy.blockAllCookies.value
+        enabled: tab.profile.prefs.boolean(forPath: kBlockAllCookiesEnabled)
       )
     }
     return .allow

--- a/ios/brave-ios/Sources/Brave/Frontend/ClientPreferences.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/ClientPreferences.swift
@@ -245,8 +245,6 @@ extension Preferences {
       key: "privacy.remember-browsing-mode",
       default: false
     )
-    /// Blocks all cookies and access to local storage
-    static let blockAllCookies = Option<Bool>(key: "privacy.block-all-cookies", default: false)
     /// The toggles states for clear private data screen
     static let clearPrivateDataToggles = Option<[Bool]>(
       key: "privacy.clear-data-toggles",

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/AdvancedShieldSettings.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/AdvancedShieldSettings.swift
@@ -71,6 +71,11 @@ import os
       prefs.set(isGPCEnabled, forPath: kGlobalPrivacyControlEnabled)
     }
   }
+  @Published var isBlockAllCookiesEnabled: Bool {
+    didSet {
+      prefs.set(isBlockAllCookiesEnabled, forPath: kBlockAllCookiesEnabled)
+    }
+  }
   @Published var adBlockAndTrackingPreventionLevel: ShieldLevel {
     didSet {
       guard oldValue != adBlockAndTrackingPreventionLevel else { return }
@@ -210,6 +215,7 @@ import os
     self.httpsUpgradeLevel = Preferences.Shields.httpsUpgradeLevel
     self.isDeAmpEnabled = deAmpPrefs.isDeAmpEnabled
     self.isGPCEnabled = prefs.boolean(forPath: kGlobalPrivacyControlEnabled)
+    self.isBlockAllCookiesEnabled = prefs.boolean(forPath: kBlockAllCookiesEnabled)
     self.isDebounceEnabled = debounceService?.isEnabled ?? false
     self.shredHistoryItems = Preferences.Shields.shredHistoryItems.value
     self.webcompatReporterHandler = webcompatReporterHandler
@@ -330,9 +336,10 @@ import os
       }
     }
 
+    let prefs = self.prefs
     @Sendable func _toggleFolderAccessForBlockCookies(locked: Bool) async {
       do {
-        if Preferences.Privacy.blockAllCookies.value,
+        if prefs.boolean(forPath: kBlockAllCookiesEnabled),
           try await AsyncFileManager.default.isWebDataLocked(atPath: .cookie) != locked
         {
           try await AsyncFileManager.default.setWebDataAccess(atPath: .cookie, lock: locked)

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/OtherPrivacySettingsSectionView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/OtherPrivacySettingsSectionView.swift
@@ -41,12 +41,12 @@ struct OtherPrivacySettingsSectionView: View {
         toggle: $settings.isGPCEnabled
       )
       if showBlockAllCookies || FeatureList.kBlockAllCookiesToggle.enabled
-        || Preferences.Privacy.blockAllCookies.value
+        || settings.isBlockAllCookiesEnabled
       {
-        OptionToggleView(
+        ToggleView(
           title: Strings.blockAllCookies,
           subtitle: Strings.blockAllCookiesDescription,
-          option: Preferences.Privacy.blockAllCookies,
+          toggle: $settings.isBlockAllCookiesEnabled,
           onChange: { newValue in
             if newValue {
               cookieAlertType = .confirm
@@ -74,7 +74,7 @@ struct OtherPrivacySettingsSectionView: View {
               secondaryButton: .cancel(
                 Text(Strings.cancelButtonTitle),
                 action: {
-                  Preferences.Privacy.blockAllCookies.value = false
+                  settings.isBlockAllCookiesEnabled = false
                 }
               )
             )
@@ -187,7 +187,7 @@ struct OtherPrivacySettingsSectionView: View {
       Text(Strings.otherPrivacySettingsSection)
     }
     .onAppear {
-      showBlockAllCookies = Preferences.Privacy.blockAllCookies.value
+      showBlockAllCookies = settings.isBlockAllCookiesEnabled
     }
   }
 
@@ -196,8 +196,8 @@ struct OtherPrivacySettingsSectionView: View {
       try await AsyncFileManager.default.setWebDataAccess(atPath: .cookie, lock: status)
       try await AsyncFileManager.default.setWebDataAccess(atPath: .websiteData, lock: status)
 
-      if Preferences.Privacy.blockAllCookies.value != status {
-        Preferences.Privacy.blockAllCookies.value = status
+      if settings.isBlockAllCookiesEnabled != status {
+        settings.isBlockAllCookiesEnabled = status
       }
     } catch {
       Logger.module.error("Failed to change web data access to \(status)")
@@ -206,8 +206,8 @@ struct OtherPrivacySettingsSectionView: View {
         try? await AsyncFileManager.default.setWebDataAccess(atPath: .cookie, lock: false)
         try? await AsyncFileManager.default.setWebDataAccess(atPath: .websiteData, lock: false)
 
-        if Preferences.Privacy.blockAllCookies.value != false {
-          Preferences.Privacy.blockAllCookies.value = false
+        if settings.isBlockAllCookiesEnabled != false {
+          settings.isBlockAllCookiesEnabled = false
         }
 
         cookieAlertType = .failed

--- a/ios/brave-ios/Sources/Brave/Frontend/Shields/BraveShieldsTabHelper+TabPolicyDecider.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Shields/BraveShieldsTabHelper+TabPolicyDecider.swift
@@ -3,6 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import BraveCore
 import BraveShields
 import Foundation
 import Web
@@ -40,7 +41,8 @@ extension BraveShieldsTabHelper: TabPolicyDecider {
     // Load rule lists
     let ruleLists = await AdBlockGroupsManager.shared.ruleLists(
       isBraveShieldsEnabled: isBraveShieldsEnabled,
-      shieldLevel: shieldLevel
+      shieldLevel: shieldLevel,
+      isBlockAllCookiesEnabled: tab.profile.prefs.boolean(forPath: kBlockAllCookiesEnabled)
     )
     tab.contentBlocker?.set(ruleLists: ruleLists)
     return .allow

--- a/ios/brave-ios/Sources/Brave/Frontend/Shields/SubmitReportView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Shields/SubmitReportView.swift
@@ -225,7 +225,8 @@ struct SubmitReportView: View {
         category: selectedCategory?.value,
         details: additionalDetails,
         contact: contactDetails,
-        cookiePolicy: Preferences.Privacy.blockAllCookies.value ? "block" : nil,
+        cookiePolicy: tab?.profile.prefs.boolean(forPath: kBlockAllCookiesEnabled) == true
+          ? "block" : nil,
         blockScripts: String(isBlockScriptsEnabled),
         adBlockComponentsVersion: nil,
         screenshotPng: nil,

--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/ContentBlockerScriptHandler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/ContentBlockerScriptHandler.swift
@@ -109,7 +109,8 @@ extension ContentBlockerHelper: TabContentScript {
           )
           let genericTypes = AdBlockGroupsManager.shared.contentBlockerManager.validGenericTypes(
             isShieldsEnabled: braveShieldsHelper.isBraveShieldsEnabled(for: currentTabURL),
-            isAdBlockEnabled: shieldLevel.isEnabled
+            isAdBlockEnabled: shieldLevel.isEnabled,
+            isBlockAllCookiesEnabled: tab.profile.prefs.boolean(forPath: kBlockAllCookiesEnabled)
           )
 
           let blockedType = await blockedTypes(

--- a/ios/brave-ios/Sources/Brave/Migration/Migration.swift
+++ b/ios/brave-ios/Sources/Brave/Migration/Migration.swift
@@ -30,6 +30,7 @@ public class BraveProfileMigrations {
     migrateYouTubeQualityPreference()
     migrateGPCPreference()
     migrateMediaBackgroundingPreference()
+    migrateBlockAllCookiesPreference()
   }
 
   private func migrateDefaultUserAgentPreferences() {
@@ -124,6 +125,12 @@ public class BraveProfileMigrations {
   private func migrateMediaBackgroundingPreference() {
     Preferences.DeprecatedPreferences.mediaAutoBackgrounding.migrate { value in
       profileController.profile.prefs.set(value, forPath: kMediaBackgroundingEnabled)
+    }
+  }
+
+  private func migrateBlockAllCookiesPreference() {
+    Preferences.DeprecatedPreferences.blockAllCookies.migrate { value in
+      profileController.profile.prefs.set(value, forPath: kBlockAllCookiesEnabled)
     }
   }
 }
@@ -369,6 +376,12 @@ extension Preferences {
     /// Controls whether or not media should continue playing in the background
     static let mediaAutoBackgrounding = Option<Bool>(
       key: "general.media-auto-backgrounding",
+      default: false
+    )
+
+    /// Blocks all cookies and access to local storage
+    static let blockAllCookies = Option<Bool>(
+      key: "privacy.block-all-cookies",
       default: false
     )
   }

--- a/ios/brave-ios/Sources/Brave/WebFilters/AdBlock/AdBlockGroupsManager.swift
+++ b/ios/brave-ios/Sources/Brave/WebFilters/AdBlock/AdBlockGroupsManager.swift
@@ -404,14 +404,16 @@ import os
     }
   }
 
-  /// Get all required rule lists for the given domain
+  /// Get all required rule lists for the given domain and prefs
   public func ruleLists(
     isBraveShieldsEnabled: Bool,
-    shieldLevel: ShieldLevel
+    shieldLevel: ShieldLevel,
+    isBlockAllCookiesEnabled: Bool
   ) async -> Set<WKContentRuleList> {
     let validBlocklistTypes = self.validBlocklistTypes(
       isBraveShieldsEnabled: isBraveShieldsEnabled,
-      shieldLevel: shieldLevel
+      shieldLevel: shieldLevel,
+      isBlockAllCookiesEnabled: isBlockAllCookiesEnabled
     )
 
     return await Set(
@@ -433,14 +435,16 @@ import os
   /// A list of all valid (enabled) blocklist types for the given domain
   private func validBlocklistTypes(
     isBraveShieldsEnabled: Bool,
-    shieldLevel: ShieldLevel
+    shieldLevel: ShieldLevel,
+    isBlockAllCookiesEnabled: Bool
   ) -> Set<(ContentBlockerManager.BlocklistType)> {
     guard isBraveShieldsEnabled else { return [] }
 
     // 1. Get the generic types
     let genericTypes = contentBlockerManager.validGenericTypes(
       isShieldsEnabled: isBraveShieldsEnabled,
-      isAdBlockEnabled: shieldLevel.isEnabled
+      isAdBlockEnabled: shieldLevel.isEnabled,
+      isBlockAllCookiesEnabled: isBlockAllCookiesEnabled
     ).filter { type in
       switch type {
       case .blockAds:

--- a/ios/brave-ios/Sources/Brave/WebFilters/ContentBlocker/ContentBlockerManager.swift
+++ b/ios/brave-ios/Sources/Brave/WebFilters/ContentBlocker/ContentBlockerManager.swift
@@ -571,7 +571,8 @@ import os.log
   /// Return the valid generic types for the given domain
   public func validGenericTypes(
     isShieldsEnabled: Bool,
-    isAdBlockEnabled: Bool
+    isAdBlockEnabled: Bool,
+    isBlockAllCookiesEnabled: Bool
   ) -> Set<GenericBlocklistType> {
     guard isShieldsEnabled else { return [] }
     var results = Set<GenericBlocklistType>()
@@ -582,7 +583,7 @@ import os.log
     }
 
     // Get global rule types
-    if Preferences.Privacy.blockAllCookies.value {
+    if isBlockAllCookiesEnabled {
       results.insert(.blockCookies)
     }
 

--- a/ios/browser/shared/prefs/browser_prefs_impl.mm
+++ b/ios/browser/shared/prefs/browser_prefs_impl.mm
@@ -92,6 +92,7 @@ void RegisterBrowserStatePrefs(user_prefs::PrefRegistrySyncable* registry) {
   registry->RegisterBooleanPref(
       global_privacy_control::kGlobalPrivacyControlEnabled, true);
   registry->RegisterBooleanPref(prefs::kMediaBackgroundingEnabled, false);
+  registry->RegisterBooleanPref(prefs::kBlockAllCookiesEnabled, false);
 }
 
 void RegisterLocalStatePrefs(PrefRegistrySimple* registry) {

--- a/ios/browser/shared/prefs/pref_names.h
+++ b/ios/browser/shared/prefs/pref_names.h
@@ -12,6 +12,10 @@ namespace prefs {
 inline constexpr char kMediaBackgroundingEnabled[] =
     "brave.media_backgrounding_enabled";
 
+// Whether or not to block all cookies and access to local storage
+inline constexpr char kBlockAllCookiesEnabled[] =
+    "brave.block_all_cookies_enabled";
+
 }  // namespace prefs
 
 #endif  // BRAVE_IOS_BROWSER_SHARED_PREFS_PREF_NAMES_H_

--- a/ios/browser/shared/prefs/shared_pref_names_bridge.h
+++ b/ios/browser/shared/prefs/shared_pref_names_bridge.h
@@ -11,6 +11,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 OBJC_EXPORT NSString* const kMediaBackgroundingEnabled;
+OBJC_EXPORT NSString* const kBlockAllCookiesEnabled;
 
 NS_ASSUME_NONNULL_END
 

--- a/ios/browser/shared/prefs/shared_pref_names_bridge.mm
+++ b/ios/browser/shared/prefs/shared_pref_names_bridge.mm
@@ -10,3 +10,6 @@
 
 NSString* const kMediaBackgroundingEnabled =
     base::SysUTF8ToNSString(prefs::kMediaBackgroundingEnabled);
+
+NSString* const kBlockAllCookiesEnabled =
+    base::SysUTF8ToNSString(prefs::kBlockAllCookiesEnabled);


### PR DESCRIPTION
This deprecates the Swift-side Preference for Block All Cookies and migrates it to PrefService, updating all usages and observations

## Test
- Verify preference correctly migrates: enable Block All Cookies prior to upgrading, upgrade, verify its still enabled
- Verify Block All Cookies functionality works correctly with the pref on and off