### PR TITLE
Fix Remember Browsing Mode on iPad after scene restore. (uplift to 1.91.x)

### DIFF
--- a/ios/brave-ios/App/iOS/Delegates/SceneDelegate.swift
+++ b/ios/brave-ios/App/iOS/Delegates/SceneDelegate.swift
@@ -756,8 +756,11 @@ extension SceneDelegate {
       {
         // Restore the scene from the User-Info WindowID
         windowId = windowUUID
-        isPrivate = windowInfo.isPrivate
-        privateBrowsingManager.isPrivateBrowsing = windowInfo.isPrivate
+        let isPrivateFromActivity = windowInfo.isPrivate
+        isPrivate =
+          isPrivateFromActivity
+          || self.shouldLaunchInPrivateMode(windowId: windowUUID)
+        privateBrowsingManager.isPrivateBrowsing = isPrivate
         urlToOpen = windowInfo.openURL
 
         // Create a new session window if it does not already exist


### PR DESCRIPTION
Uplift of #36476
Resolves https://github.com/brave/brave-browser/issues/55515

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.