### PR TITLE
[Wallet]: Add Min Width to Distribution Segment

### DIFF
--- a/components/brave_wallet_ui/components/desktop/views/portfolio/components/portfolio_overview_distribution/portfolio_overview_distribution.stories.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/components/portfolio_overview_distribution/portfolio_overview_distribution.stories.tsx
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import * as React from 'react'
+
+// Mocks
+import {
+  mockBtcToken,
+  mockEthToken,
+} from '../../../../../../stories/mock-data/mock-asset-options'
+
+// Components
+import {
+  WalletPageStory, //
+} from '../../../../../../stories/wrappers/wallet-page-story-wrapper'
+import { PortfolioOverviewDistribution } from './portfolio_overview_distribution'
+
+export const _PortfolioOverviewDistribution = {
+  render: () => {
+    return (
+      <WalletPageStory>
+        <PortfolioOverviewDistribution
+          data={[
+            {
+              kind: 'asset',
+              token: mockBtcToken,
+              value: 99,
+              fiatValue: '99',
+            },
+            {
+              kind: 'asset',
+              token: mockEthToken,
+              value: 1,
+              fiatValue: '1',
+            },
+          ]}
+        />
+      </WalletPageStory>
+    )
+  },
+}
+
+export default {
+  title: 'Wallet/Desktop/Components/Portfolio Overview Distribution',
+  component: PortfolioOverviewDistribution,
+}

--- a/components/brave_wallet_ui/components/desktop/views/portfolio/components/portfolio_overview_distribution/portfolio_overview_distribution.style.ts
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/components/portfolio_overview_distribution/portfolio_overview_distribution.style.ts
@@ -16,7 +16,7 @@ export const Title = styled(Text)`
 
 export const Segment = styled(Column)<{ $grow: number }>`
   flex: ${(p) => p.$grow} 1 0;
-  min-width: 0;
+  min-width: 46px;
   overflow: hidden;
 `
 


### PR DESCRIPTION
## Description 

Fixes a bug where `Segments` in the Wallet `Distribution` would get squished if the percentage was to small.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/55625>

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

### `Before` vs `After`

<img width="400" height="442" alt="Screenshot 7" src="https://github.com/user-attachments/assets/94867ef5-000d-4f07-acf6-a5bd429717e6" /> | <img width="400" height="444" alt="Screenshot 6" src="https://github.com/user-attachments/assets/fe43f839-e180-45e2-be64-aee0f6e48a97" />
--|--

<img width="462" height="703" alt="Screenshot 8" src="https://github.com/user-attachments/assets/54326eb8-6bbf-4870-a242-53c58a26b272" /> | <img width="461" height="697" alt="Screenshot 9" src="https://github.com/user-attachments/assets/01d0b953-2ef8-4ec7-8327-b40ad1bfc8b2" />
--|--