### PR TITLE
[iOS] Fix local release builds with siso enabled

### DIFF
--- a/build/commands/lib/buildArgs.ts
+++ b/build/commands/lib/buildArgs.ts
@@ -345,7 +345,7 @@ export function getBuildArgs(config: Config) {
     // https://chromium.googlesource.com/chromium/src/+/master/docs/component_build.md
     args.is_component_build = false
 
-    if (!args.is_official_build) {
+    if (!config.isBraveReleaseBuild()) {
       // When building locally iOS needs dSYMs in order for Xcode to map source
       // files correctly since we are using a framework build
       args.enable_dsyms = true


### PR DESCRIPTION
We use `isBraveReleaseBuild` when disabling `enable_dsyms` but `is_official_build` when re-enabling them on iOS so local release builds were being built with `enable_dsyms = false` incorrectly

Resolves https://github.com/brave/brave-browser/issues/52142