### PR TITLE
[iOS] [CodeHealth] Use native API to pause media playback

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -2472,12 +2472,6 @@ extension BrowserViewController: TabsBarViewControllerDelegate {
 }
 
 extension BrowserViewController: TabMiscDelegate {
-  func stopMediaPlayback(_ tab: some TabState) {
-    tabManager.allTabs.forEach({
-      PlaylistScriptHandler.stopPlayback(tab: $0)
-    })
-  }
-
   func showWalletNotification(_ tab: some TabState, origin: URLOrigin) {
     // only display notification when BVC is front and center
     guard presentedViewController == nil,

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/TabBrowserData.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/TabBrowserData.swift
@@ -25,7 +25,6 @@ extension TabDataValues {
 }
 
 protocol TabMiscDelegate {
-  func stopMediaPlayback(_ tab: some TabState)
   func showWalletNotification(_ tab: some TabState, origin: URLOrigin)
   func updateURLBarWalletButton()
 }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Playlist/ManagersAndCache/PlaylistCoordinator.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Playlist/ManagersAndCache/PlaylistCoordinator.swift
@@ -99,7 +99,7 @@ public class PlaylistCoordinator: NSObject {
     // Even if another controller is presented and even when PIP is enabled in playlist.
     // Therefore we need to stop the page/tab from playing when using playlist.
     // On iPad, media will continue to play with or without the background play setting.
-    tab?.stopMediaPlayback()
+    tab?.pauseAllMediaPlayback()
 
     let mediaStreamer = PlaylistMediaStreamer(
       playerView: browserController!.view,

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/TabExtensions.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/TabExtensions.swift
@@ -109,10 +109,6 @@ extension TabState {
     }
   }
 
-  func stopMediaPlayback() {
-    data.browserData?.miscDelegate?.stopMediaPlayback(self)
-  }
-
   var containsWebPage: Bool {
     if let url = visibleURL {
       return url.isWebPage()

--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/PlaylistScriptHandler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/PlaylistScriptHandler.swift
@@ -52,7 +52,6 @@ class PlaylistScriptHandler: NSObject, TabContentScript, TabObserver {
   static let playlistLongPressed = "playlistLongPressed_\(uniqueID)"
   static let playlistProcessDocumentLoad = "playlistProcessDocumentLoad_\(uniqueID)"
   static let mediaCurrentTimeFromTag = "mediaCurrentTimeFromTag_\(uniqueID)"
-  static let stopMediaPlayback = "stopMediaPlayback_\(uniqueID)"
 
   static let scriptName = "PlaylistScript"
   static let scriptId = UUID().uuidString
@@ -72,7 +71,6 @@ class PlaylistScriptHandler: NSObject, TabContentScript, TabObserver {
           "$<playlistLongPressed>": playlistLongPressed,
           "$<playlistProcessDocumentLoad>": playlistProcessDocumentLoad,
           "$<mediaCurrentTimeFromTag>": mediaCurrentTimeFromTag,
-          "$<stopMediaPlayback>": stopMediaPlayback,
         ],
         securityToken: scriptId,
         script: script
@@ -256,23 +254,6 @@ extension PlaylistScriptHandler {
         } else {
           completion(0.0)
         }
-      }
-    }
-  }
-
-  static func stopPlayback(tab: (any TabState)?) {
-    guard let tab = tab else { return }
-
-    tab.evaluateJavaScript(
-      functionName: "window.__firefox__.\(stopMediaPlayback)",
-      args: [Self.scriptId],
-      contentWorld: Self.scriptSandbox,
-      asFunction: true
-    ) { value, error in
-      if let error = error {
-        Logger.module.error(
-          "Error Retrieving Stopping Media Playback: \(error.localizedDescription)"
-        )
       }
     }
   }

--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Paged/PlaylistScript.js
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Paged/PlaylistScript.js
@@ -453,28 +453,6 @@ window.__firefox__.includeOnce("Playlist", function($) {
           return 0.0;
         }
       });
-
-      Object.defineProperty(window.__firefox__, '$<stopMediaPlayback>', {
-          enumerable: false,
-          configurable: false,
-          writable: false,
-          value:
-          function(token) {
-            if (token != SECURITY_TOKEN) {
-              return;
-            }
-
-            for (element of getAllVideoElements()) {
-              element.pause();
-            }
-
-            for (element of getAllAudioElements()) {
-              element.pause();
-            }
-
-            return 0.0;
-          }
-      });
   }
 
   // MARK: -----------------------------

--- a/ios/brave-ios/Sources/Web/AnyTabState.swift
+++ b/ios/brave-ios/Sources/Web/AnyTabState.swift
@@ -207,6 +207,14 @@ public class AnyTabState: TabState {
     tab.clearBackForwardList()
   }
 
+  public func pauseAllMediaPlayback() {
+    tab.pauseAllMediaPlayback()
+  }
+
+  public func requestMediaPlaybackState() async -> MediaPlaybackState {
+    await tab.requestMediaPlaybackState()
+  }
+
   public func updateScripts() {
     tab.updateScripts()
   }

--- a/ios/brave-ios/Sources/Web/Chromium/ChromiumTabState.swift
+++ b/ios/brave-ios/Sources/Web/Chromium/ChromiumTabState.swift
@@ -518,6 +518,21 @@ class ChromiumTabState: TabState, TabStateImpl {
     }
   }
 
+  func pauseAllMediaPlayback() {
+    webView?.internalWebView?.pauseAllMediaPlayback()
+  }
+
+  func requestMediaPlaybackState() async -> MediaPlaybackState {
+    let state = await webView?.internalWebView?.requestMediaPlaybackState() ?? .none
+    return switch state {
+    case .none: .none
+    case .paused: .paused
+    case .playing: .playing
+    case .suspended: .suspended
+    @unknown default: .none
+    }
+  }
+
   func clearBackForwardList() {
     webView?.internalWebView?.backForwardList.clear()
   }

--- a/ios/brave-ios/Sources/Web/TabState.swift
+++ b/ios/brave-ios/Sources/Web/TabState.swift
@@ -25,6 +25,13 @@ public enum SecureContentState {
   case mixedContent
 }
 
+public enum MediaPlaybackState {
+  case none
+  case paused
+  case playing
+  case suspended
+}
+
 public class TabStateFactory {
   public struct CreateTabParams {
     public var id: UUID
@@ -259,6 +266,10 @@ public protocol TabState: AnyObject {
   var viewScale: CGFloat { get set }
   /// Clears the back forward list of the WKWebView
   func clearBackForwardList()
+  /// Pauses playback of all media in the web view
+  func pauseAllMediaPlayback()
+  /// Requests the playback status of media in the web view.
+  func requestMediaPlaybackState() async -> MediaPlaybackState
 
   // MARK: - Chromium specific
   func updateScripts()

--- a/ios/brave-ios/Sources/Web/Test/FakeTabState.swift
+++ b/ios/brave-ios/Sources/Web/Test/FakeTabState.swift
@@ -109,6 +109,10 @@ public final class FakeTabState: TabState {
   public var sampledPageTopColor: UIColor? { nil }
   public var viewScale: CGFloat = 1.0
   public func clearBackForwardList() {}
+  public func pauseAllMediaPlayback() {}
+  public func requestMediaPlaybackState() async -> MediaPlaybackState {
+    return .none
+  }
 
   // MARK: - Chromium specific
 


### PR DESCRIPTION
Adds TabState APIs to access playback state and pause playback and remove the exposed JS method from the Playlist script

## Test
- Visit YT and play a video
- Open Playlist
- Video on the page should pause like before