### PR TITLE
Skip stats usage pings on Brave Origin branded builds

### DIFF
--- a/browser/BUILD.gn
+++ b/browser/BUILD.gn
@@ -30,6 +30,7 @@ source_set("browser_process") {
   sources = [ "brave_browser_process.h" ]
 
   deps = [
+    "//brave/browser/brave_stats:buildflags",
     "//brave/components/brave_ads/buildflags",
     "//brave/components/brave_vpn/common/buildflags",
     "//brave/components/local_ai/core",

--- a/browser/brave_browser_main_extra_parts.cc
+++ b/browser/brave_browser_main_extra_parts.cc
@@ -78,8 +78,10 @@ void BraveBrowserMainExtraParts::PreProfileInit() {
   g_brave_browser_process->ads_brave_stats_helper();
 #endif  // BUILDFLAG(ENABLE_BRAVE_ADS)
 
+#if BUILDFLAG(ENABLE_BRAVE_STATS_UPDATER)
   // Early initialize brave stats
   g_brave_browser_process->brave_stats_updater();
+#endif
 }
 
 void BraveBrowserMainExtraParts::PostBrowserStart() {

--- a/browser/brave_browser_process.h
+++ b/browser/brave_browser_process.h
@@ -11,6 +11,7 @@
 #ifndef BRAVE_BROWSER_BRAVE_BROWSER_PROCESS_H_
 #define BRAVE_BROWSER_BRAVE_BROWSER_PROCESS_H_
 
+#include "brave/browser/brave_stats/buildflags.h"
 #include "brave/components/brave_ads/buildflags/buildflags.h"
 #include "brave/components/brave_vpn/common/buildflags/buildflags.h"
 #include "brave/components/request_otr/common/buildflags/buildflags.h"
@@ -38,9 +39,11 @@ namespace brave_shields {
 class AdBlockService;
 }  // namespace brave_shields
 
+#if BUILDFLAG(ENABLE_BRAVE_STATS_UPDATER)
 namespace brave_stats {
 class BraveStatsUpdater;
 }  // namespace brave_stats
+#endif
 
 namespace debounce {
 class DebounceComponentInstaller;
@@ -109,7 +112,9 @@ class BraveBrowserProcess {
 #endif
   virtual p3a::P3AService* p3a_service() = 0;
   virtual brave::BraveReferralsService* brave_referrals_service() = 0;
+#if BUILDFLAG(ENABLE_BRAVE_STATS_UPDATER)
   virtual brave_stats::BraveStatsUpdater* brave_stats_updater() = 0;
+#endif
 #if BUILDFLAG(ENABLE_BRAVE_ADS)
   virtual brave_ads::BraveStatsHelper* ads_brave_stats_helper() = 0;
   virtual brave_ads::ResourceComponent* resource_component() = 0;

--- a/browser/brave_browser_process_impl.cc
+++ b/browser/brave_browser_process_impl.cc
@@ -16,7 +16,7 @@
 #include "base/task/thread_pool.h"
 #include "brave/browser/brave_referrals/referrals_service_delegate.h"
 #include "brave/browser/brave_shields/ad_block_subscription_download_manager_getter.h"
-#include "brave/browser/brave_stats/brave_stats_updater.h"
+#include "brave/browser/brave_stats/buildflags.h"
 #include "brave/browser/brave_stats/first_run_util.h"
 #include "brave/browser/component_updater/brave_component_updater_configurator.h"
 #include "brave/browser/misc_metrics/process_misc_metrics.h"
@@ -58,6 +58,10 @@
 #include "content/public/browser/child_process_security_policy.h"
 #include "services/network/public/cpp/resource_request.h"
 #include "services/network/public/cpp/shared_url_loader_factory.h"
+
+#if BUILDFLAG(ENABLE_BRAVE_STATS_UPDATER)
+#include "brave/browser/brave_stats/brave_stats_updater.h"
+#endif
 
 #if BUILDFLAG(ENABLE_EXTENSIONS_CORE)
 #include "chrome/browser/extensions/chrome_component_extension_resource_manager.h"
@@ -227,7 +231,9 @@ void BraveBrowserProcessImpl::StartTearDown() {
 #if BUILDFLAG(ENABLE_BRAVE_ADS)
   brave_stats_helper_.reset();
 #endif  // BUILDFLAG(ENABLE_BRAVE_ADS)
+#if BUILDFLAG(ENABLE_BRAVE_STATS_UPDATER)
   brave_stats_updater_.reset();
+#endif
   brave_referrals_service_.reset();
   if (ntp_background_images_service_) {
     ntp_background_images_service_->StartTearDown();
@@ -472,6 +478,7 @@ BraveBrowserProcessImpl::brave_referrals_service() {
   return brave_referrals_service_.get();
 }
 
+#if BUILDFLAG(ENABLE_BRAVE_STATS_UPDATER)
 brave_stats::BraveStatsUpdater* BraveBrowserProcessImpl::brave_stats_updater() {
   if (!brave_stats_updater_) {
     brave_stats_updater_ = std::make_unique<brave_stats::BraveStatsUpdater>(
@@ -479,6 +486,7 @@ brave_stats::BraveStatsUpdater* BraveBrowserProcessImpl::brave_stats_updater() {
   }
   return brave_stats_updater_.get();
 }
+#endif  // BUILDFLAG(ENABLE_BRAVE_STATS_UPDATER)
 
 #if BUILDFLAG(ENABLE_BRAVE_ADS)
 brave_ads::BraveStatsHelper* BraveBrowserProcessImpl::ads_brave_stats_helper() {

--- a/browser/brave_browser_process_impl.h
+++ b/browser/brave_browser_process_impl.h
@@ -39,9 +39,11 @@ namespace https_upgrade_exceptions {
 class HttpsUpgradeExceptionsService;
 }  // namespace https_upgrade_exceptions
 
+#if BUILDFLAG(ENABLE_BRAVE_STATS_UPDATER)
 namespace brave_stats {
 class BraveStatsUpdater;
 }  // namespace brave_stats
+#endif
 
 namespace debounce {
 class DebounceComponentInstaller;
@@ -127,7 +129,9 @@ class BraveBrowserProcessImpl : public BraveBrowserProcess,
 #endif
   p3a::P3AService* p3a_service() override;
   brave::BraveReferralsService* brave_referrals_service() override;
+#if BUILDFLAG(ENABLE_BRAVE_STATS_UPDATER)
   brave_stats::BraveStatsUpdater* brave_stats_updater() override;
+#endif
 #if BUILDFLAG(ENABLE_BRAVE_ADS)
   brave_ads::BraveStatsHelper* ads_brave_stats_helper() override;
   brave_ads::ResourceComponent* resource_component() override;
@@ -188,7 +192,9 @@ class BraveBrowserProcessImpl : public BraveBrowserProcess,
 #endif
   std::unique_ptr<brave::URLSanitizerComponentInstaller>
       url_sanitizer_component_installer_;
+#if BUILDFLAG(ENABLE_BRAVE_STATS_UPDATER)
   std::unique_ptr<brave_stats::BraveStatsUpdater> brave_stats_updater_;
+#endif
   std::unique_ptr<brave::BraveReferralsService> brave_referrals_service_;
 #if BUILDFLAG(ENABLE_TOR)
   std::unique_ptr<tor::BraveTorClientUpdater> tor_client_updater_;

--- a/browser/brave_local_state_prefs.cc
+++ b/browser/brave_local_state_prefs.cc
@@ -8,7 +8,7 @@
 #include <string>
 
 #include "base/values.h"
-#include "brave/browser/brave_stats/brave_stats_updater.h"
+#include "brave/browser/brave_stats/buildflags.h"
 #include "brave/browser/metrics/buildflags/buildflags.h"
 #include "brave/browser/metrics/metrics_reporting_util.h"
 #include "brave/browser/misc_metrics/process_misc_metrics.h"
@@ -47,6 +47,10 @@
 #include "components/prefs/pref_registry_simple.h"
 #include "components/webui/chrome_urls/pref_names.h"
 #include "third_party/widevine/cdm/buildflags.h"
+
+#if BUILDFLAG(ENABLE_BRAVE_STATS_UPDATER)
+#include "brave/browser/brave_stats/brave_stats_updater.h"
+#endif
 
 #if BUILDFLAG(ENABLE_PLAYLIST)
 #include "brave/browser/playlist/playlist_service_factory.h"
@@ -136,7 +140,9 @@ void RegisterLocalStatePrefsForMigration(PrefRegistrySimple* registry) {
 #endif
   brave_search_conversion::p3a::RegisterLocalStatePrefsForMigration(registry);
   brave_shields::RegisterPrefsForAdBlockServiceForMigration(registry);
+#if BUILDFLAG(ENABLE_BRAVE_STATS_UPDATER)
   brave_stats::RegisterLocalStatePrefsForMigration(registry);
+#endif
   p3a::MetricLogStore::RegisterLocalStatePrefsForMigration(registry);
   p3a::RotationScheduler::RegisterLocalStatePrefsForMigration(registry);
 
@@ -154,7 +160,15 @@ void RegisterLocalStatePrefsForMigration(PrefRegistrySimple* registry) {
 
 void RegisterLocalStatePrefs(PrefRegistrySimple* registry) {
   brave_shields::RegisterPrefsForAdBlockService(registry);
+  // `kStatsReportingEnabled` is the user/policy-facing opt-in for anonymous
+  // usage pings. It is read by other systems (privacy settings UI, policy
+  // map, referrals service, SERP tab helper, Brave Origin service) that
+  // remain compiled in even when the stats updater itself is excluded, so
+  // it must always be registered.
+  registry->RegisterBooleanPref(kStatsReportingEnabled, true);
+#if BUILDFLAG(ENABLE_BRAVE_STATS_UPDATER)
   brave_stats::RegisterLocalStatePrefs(registry);
+#endif
   brave_origin::RegisterLocalStatePrefs(registry);
   ntp_background_images::RegisterLocalStatePrefs(registry);
   RegisterPrefsForBraveReferralsService(registry);

--- a/browser/brave_stats/BUILD.gn
+++ b/browser/brave_stats/BUILD.gn
@@ -10,13 +10,14 @@ import("//build/buildflag_header.gni")
 
 buildflag_header("buildflags") {
   header = "buildflags.h"
-  flags = [ "BRAVE_USAGE_SERVER=\"$brave_stats_updater_url\"" ]
+  flags = [
+    "BRAVE_USAGE_SERVER=\"$brave_stats_updater_url\"",
+    "ENABLE_BRAVE_STATS_UPDATER=$enable_brave_stats_updater",
+  ]
 }
 
 source_set("brave_stats") {
   sources = [
-    "//brave/browser/brave_stats/brave_stats_updater.cc",
-    "//brave/browser/brave_stats/brave_stats_updater.h",
     "//brave/browser/brave_stats/brave_stats_updater_params.cc",
     "//brave/browser/brave_stats/brave_stats_updater_params.h",
     "//brave/browser/brave_stats/features.cc",
@@ -26,12 +27,21 @@ source_set("brave_stats") {
     "//brave/browser/brave_stats/switches.h",
   ]
 
-  public_deps = [ "//brave/components/brave_stats/browser" ]
+  if (enable_brave_stats_updater) {
+    sources += [
+      "//brave/browser/brave_stats/brave_stats_updater.cc",
+      "//brave/browser/brave_stats/brave_stats_updater.h",
+    ]
+  }
+
+  public_deps = [
+    "//brave/browser/brave_stats:buildflags",
+    "//brave/components/brave_stats/browser",
+  ]
 
   deps = [
     "//base",
     "//brave/browser:browser_process",
-    "//brave/browser/brave_stats:buildflags",
     "//brave/browser/misc_metrics",
     "//brave/browser/serp_metrics",
     "//brave/common",
@@ -71,7 +81,12 @@ source_set("brave_stats") {
 source_set("browser_tests") {
   testonly = true
 
-  sources = [ "//brave/browser/brave_stats/brave_stats_updater_browsertest.cc" ]
+  sources = []
+
+  if (enable_brave_stats_updater) {
+    sources +=
+        [ "//brave/browser/brave_stats/brave_stats_updater_browsertest.cc" ]
+  }
 
   deps = [
     "//brave/browser/brave_stats",
@@ -87,10 +102,13 @@ source_set("unit_tests") {
   testonly = true
 
   sources = [
-    "//brave/browser/brave_stats/brave_stats_updater_unittest.cc",
     "//brave/browser/brave_stats/brave_stats_updater_util_unittest.cc",
     "//brave/browser/brave_stats/first_run_util_unittest.cc",
   ]
+
+  if (enable_brave_stats_updater) {
+    sources += [ "//brave/browser/brave_stats/brave_stats_updater_unittest.cc" ]
+  }
 
   deps = [
     "//brave/browser/brave_stats",

--- a/browser/brave_stats/brave_stats_updater.cc
+++ b/browser/brave_stats/brave_stats_updater.cc
@@ -374,7 +374,6 @@ void BraveStatsUpdater::SendServerPing() {
 
 void RegisterLocalStatePrefs(PrefRegistrySimple* registry) {
   registry->RegisterBooleanPref(kFirstCheckMade, false);
-  registry->RegisterBooleanPref(kStatsReportingEnabled, true);
   registry->RegisterIntegerPref(kLastCheckWOY, 0);
   registry->RegisterIntegerPref(kLastCheckMonth, 0);
   registry->RegisterStringPref(kLastCheckYMD, std::string());

--- a/browser/brave_stats/brave_stats_updater.h
+++ b/browser/brave_stats/brave_stats_updater.h
@@ -14,9 +14,15 @@
 #include "base/memory/scoped_refptr.h"
 #include "base/memory/weak_ptr.h"
 #include "base/scoped_observation.h"
+#include "brave/browser/brave_stats/buildflags.h"
 #include "chrome/browser/profiles/profile_manager_observer.h"
 #include "services/network/public/cpp/shared_url_loader_factory.h"
 #include "url/gurl.h"
+
+static_assert(BUILDFLAG(ENABLE_BRAVE_STATS_UPDATER),
+              "BraveStatsUpdater must not be used when "
+              "enable_brave_stats_updater is false (e.g. Brave Origin "
+              "branded builds).");
 
 class BraveStatsUpdaterBrowserTest;
 class PrefChangeRegistrar;

--- a/browser/brave_stats/brave_stats_updater_unittest.cc
+++ b/browser/brave_stats/brave_stats_updater_unittest.cc
@@ -83,6 +83,8 @@ class BraveStatsUpdaterTest : public testing::Test {
     task_environment_.AdvanceClock(base::Minutes(30));
 
     brave_stats::RegisterLocalStatePrefs(testing_local_state_.registry());
+    testing_local_state_.registry()->RegisterBooleanPref(kStatsReportingEnabled,
+                                                         true);
     misc_metrics::GeneralBrowserUsage::RegisterPrefs(
         testing_local_state_.registry());
     brave::RegisterPrefsForBraveReferralsService(

--- a/browser/brave_stats/buildflags.gni
+++ b/browser/brave_stats/buildflags.gni
@@ -3,10 +3,14 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import("//brave/components/brave_origin/buildflags/buildflags.gni")
+
 declare_args() {
   brave_stats_updater_url = ""
+
+  enable_brave_stats_updater = !is_brave_origin_branded
 }
 
-if (is_official_build) {
+if (is_official_build && enable_brave_stats_updater) {
   assert(brave_stats_updater_url != "")
 }

--- a/chromium_src/chrome/browser/prefs/browser_prefs.cc
+++ b/chromium_src/chrome/browser/prefs/browser_prefs.cc
@@ -6,7 +6,7 @@
 #include "base/check.h"
 #include "brave/browser/brave_local_state_prefs.h"
 #include "brave/browser/brave_profile_prefs.h"
-#include "brave/browser/brave_stats/brave_stats_updater.h"
+#include "brave/browser/brave_stats/buildflags.h"
 #include "brave/browser/misc_metrics/uptime_monitor_impl.h"
 #include "brave/browser/translate/brave_translate_prefs_migration.h"
 #include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
@@ -39,6 +39,10 @@
 #include "components/translate/core/browser/translate_prefs.h"
 #include "extensions/buildflags/buildflags.h"
 #include "third_party/widevine/cdm/buildflags.h"
+
+#if BUILDFLAG(ENABLE_BRAVE_STATS_UPDATER)
+#include "brave/browser/brave_stats/brave_stats_updater.h"
+#endif
 
 #if BUILDFLAG(ENABLE_AI_CHAT)
 #include "brave/components/ai_chat/core/browser/model_service.h"
@@ -289,7 +293,9 @@ void MigrateObsoleteLocalStatePrefs(PrefService* local_state) {
   misc_metrics::UptimeMonitorImpl::MigrateObsoletePrefs(local_state);
   brave_search_conversion::p3a::MigrateObsoleteLocalStatePrefs(local_state);
   brave_shields::MigrateObsoletePrefsForAdBlockService(local_state);
+#if BUILDFLAG(ENABLE_BRAVE_STATS_UPDATER)
   brave_stats::MigrateObsoleteLocalStatePrefs(local_state);
+#endif
   brave_l10n::MigrateObsoleteLocalStatePrefs(local_state);
   p3a::MetricLogStore::MigrateObsoleteLocalStatePrefs(local_state);
   p3a::RotationScheduler::MigrateObsoleteLocalStatePrefs(local_state);

--- a/chromium_src/chrome/browser/prefs/sources.gni
+++ b/chromium_src/chrome/browser/prefs/sources.gni
@@ -7,6 +7,7 @@ import("//brave/components/brave_wallet/common/buildflags/buildflags.gni")
 import("//third_party/widevine/cdm/widevine.gni")
 
 brave_chromium_src_chrome_browser_prefs_deps = [
+  "//brave/browser/brave_stats:buildflags",
   "//brave/components/brave_ads/buildflags",
   "//brave/components/brave_news/common/buildflags",
   "//brave/components/brave_shields/core/common",

--- a/test/base/testing_brave_browser_process.cc
+++ b/test/base/testing_brave_browser_process.cc
@@ -124,10 +124,12 @@ TestingBraveBrowserProcess::brave_referrals_service() {
   return nullptr;
 }
 
+#if BUILDFLAG(ENABLE_BRAVE_STATS_UPDATER)
 brave_stats::BraveStatsUpdater*
 TestingBraveBrowserProcess::brave_stats_updater() {
   return nullptr;
 }
+#endif  // BUILDFLAG(ENABLE_BRAVE_STATS_UPDATER)
 
 #if BUILDFLAG(ENABLE_BRAVE_ADS)
 brave_ads::BraveStatsHelper*

--- a/test/base/testing_brave_browser_process.h
+++ b/test/base/testing_brave_browser_process.h
@@ -69,7 +69,9 @@ class TestingBraveBrowserProcess : public BraveBrowserProcess {
 #endif
   p3a::P3AService* p3a_service() override;
   brave::BraveReferralsService* brave_referrals_service() override;
+#if BUILDFLAG(ENABLE_BRAVE_STATS_UPDATER)
   brave_stats::BraveStatsUpdater* brave_stats_updater() override;
+#endif
 #if BUILDFLAG(ENABLE_BRAVE_ADS)
   brave_ads::BraveStatsHelper* ads_brave_stats_helper() override;
   brave_ads::ResourceComponent* resource_component() override;


### PR DESCRIPTION
Early-return in `BraveStatsUpdater::Start()` under `BUILDFLAG(IS_BRAVE_ORIGIN_BRANDED)` so the startup and periodic ping timers are never scheduled on Brave Origin branded builds.

Resolves https://github.com/brave/brave-browser/issues/55595

## Test plan
- [ ] Build with `is_brave_origin_branded=true`, launch a fresh profile, observe (e.g. Fiddler) that no usage ping is sent on first launch or thereafter.
- [ ] Build a regular (non-Origin) build and confirm usage pings still fire as before.