### PR TITLE
Android: Disable the PrerenderHostRegistry memory pressure listener (uplift to 1.91.x)

### DIFF
--- a/patches/base-memory-memory_pressure_listener_registry.cc.patch
+++ b/patches/base-memory-memory_pressure_listener_registry.cc.patch
@@ -1,0 +1,24 @@
+diff --git a/base/memory/memory_pressure_listener_registry.cc b/base/memory/memory_pressure_listener_registry.cc
+index 16e260e4f5a3c5fbb3a330d4593fec7197c653d3..312cde252ae30a6b2bee4feedbee6c613848e814 100644
+--- a/base/memory/memory_pressure_listener_registry.cc
++++ b/base/memory/memory_pressure_listener_registry.cc
+@@ -21,7 +21,8 @@ namespace {
+ MemoryPressureListenerRegistry* g_memory_pressure_listener_registry = nullptr;
+ 
+ BASE_FEATURE(kSuppressMemoryListeners,
+-#if BUILDFLAG(IS_MAC) || BUILDFLAG(IS_WIN) || BUILDFLAG(IS_CHROMEOS)
++#if BUILDFLAG(IS_MAC) || BUILDFLAG(IS_WIN) || BUILDFLAG(IS_CHROMEOS) || \
++    BUILDFLAG(IS_ANDROID)
+              FEATURE_ENABLED_BY_DEFAULT
+ #else
+              FEATURE_DISABLED_BY_DEFAULT
+@@ -36,6 +37,9 @@ BASE_FEATURE_PARAM(std::string,
+                    "0200200202220200020020020002020020000002000000020"
+ #elif BUILDFLAG(IS_CHROMEOS)
+                    "0000000200000200000000000000000000000000000000000"
++#elif BUILDFLAG(IS_ANDROID)
++                   // Only disable PrerenderHostRegistry.
++                   "0000000000000000000000000000000000000000200000000"
+ #else
+                    ""
+ #endif

--- a/patches/content-browser-preloading-prerender-prerender_browsertest.cc.patch
+++ b/patches/content-browser-preloading-prerender-prerender_browsertest.cc.patch
@@ -1,0 +1,22 @@
+diff --git a/content/browser/preloading/prerender/prerender_browsertest.cc b/content/browser/preloading/prerender/prerender_browsertest.cc
+index 6caa757890083a6fc0b6f8642c1afdf617e9d967..3769b6fff245c3bfe9ef90ade8653144219515c4 100644
+--- a/content/browser/preloading/prerender/prerender_browsertest.cc
++++ b/content/browser/preloading/prerender/prerender_browsertest.cc
+@@ -12986,6 +12986,9 @@ class MultiplePrerendersWithLimitedMemoryBrowserTest
+   base::test::ScopedFeatureList feature_list_;
+ };
+ 
++// Memory pressure notifications to PrerenderHostRegistry are disabled on
++// Android only.
++#if !BUILDFLAG(IS_ANDROID)
+ // Tests that moderate-level memory pressure doesn't cancel prerendering on
+ // trigger.
+ IN_PROC_BROWSER_TEST_F(MultiplePrerendersBrowserTest,
+@@ -13094,6 +13097,7 @@ IN_PROC_BROWSER_TEST_F(MultiplePrerendersBrowserTest,
+       PrerenderFinalStatus::kMemoryPressureAfterTriggered,
+       prerender_urls.size());
+ }
++#endif  // !BUILDFLAG(IS_ANDROID)
+ 
+ // Tests that PrerenderHostRegistry only starts prerender speculation rules
+ // up to `max_num_of_running_speculation_rules` defined by a Finch param.


### PR DESCRIPTION
Uplift of #36450
Resolves https://github.com/brave/brave-browser/issues/55529

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.