### PR TITLE
[Android] Deep link to Brave Origin payment screen for Play promo events

### DIFF
--- a/android/brave_java_sources.gni
+++ b/android/brave_java_sources.gni
@@ -91,6 +91,7 @@ brave_java_sources = [
   "../../brave/android/java/org/chromium/chrome/browser/brave_news/LinearLayoutManagerWrapper.java",
   "../../brave/android/java/org/chromium/chrome/browser/brave_news/models/FeedItemCard.java",
   "../../brave/android/java/org/chromium/chrome/browser/brave_news/models/FeedItemsCard.java",
+  "../../brave/android/java/org/chromium/chrome/browser/brave_origin/BraveOriginDeepLinkHandler.java",
   "../../brave/android/java/org/chromium/chrome/browser/brave_origin/BraveOriginPlansActivity.java",
   "../../brave/android/java/org/chromium/chrome/browser/brave_origin/BraveOriginSubscriptionPrefs.java",
   "../../brave/android/java/org/chromium/chrome/browser/brave_stats/BraveStatsBottomSheetDialogFragment.java",

--- a/android/java/AndroidManifest_intent_filters.xml
+++ b/android/java/AndroidManifest_intent_filters.xml
@@ -18,3 +18,15 @@
     <data android:scheme="https"
           android:host="brave.com" />
 </intent-filter>
+
+<!-- Path-specific declaration so Play Console's "Add web link" validator recognizes this URL
+     as a deep link target. The broad filter above already routes brave.com URLs to Brave at
+     runtime; this duplicate filter exists purely to satisfy Play Console submission tooling. -->
+<intent-filter android:autoVerify="true">
+    <action android:name="android.intent.action.VIEW" />
+    <category android:name="android.intent.category.DEFAULT" />
+    <category android:name="android.intent.category.BROWSABLE" />
+    <data android:scheme="https"
+          android:host="brave.com"
+          android:pathPrefix="/deeplink-android-origin-promo" />
+</intent-filter>

--- a/android/java/org/chromium/base/BravePreferenceKeys.java
+++ b/android/java/org/chromium/base/BravePreferenceKeys.java
@@ -53,10 +53,15 @@ public final class BravePreferenceKeys {
     public static final String BRAVE_DEFERRED_DEEPLINK_PLAYLIST =
             "brave_deferred_deeplink_playlist";
     public static final String BRAVE_DEFERRED_DEEPLINK_VPN = "brave_deferred_deeplink_vpn";
+    // Bridges Play Install Referrer attribution from WelcomeOnboardingActivity to BraveActivity
+    // for first-install users only. Existing users tap the App Link directly and are routed
+    // inline by maybeHandleUrlIntent without going through this pref.
+    public static final String BRAVE_DEFERRED_DEEPLINK_ORIGIN_PROMO =
+            "brave_deferred_deeplink_origin_promo";
     public static final String BRAVE_CLOSE_TABS_ON_EXIT = "close_tabs_on_exit";
     public static final String BRAVE_CLEAR_ON_EXIT = "clear_on_exit";
     public static final String BRAVE_QUICK_ACTION_SEARCH_AND_BOOKMARK_WIDGET_TILES =
-            "org.chromium.chrome.browser.widget.quickactionsearchandbookmark.QuickActionSearchAndBookmarkWidgetProvider.TILES";
+            "org.chromium.chrome.browser.widget.quickactionsearchandbookmark.QuickActionSearchAndBookmarkWidgetProvider.TILES"; // presubmit: ignore-long-line
     public static final String ENABLE_MULTI_WINDOWS = "enable_multi_windows";
     public static final String ENABLE_MULTI_WINDOWS_UPGRADE = "enable_multi_windows_upgrade";
 

--- a/android/java/org/chromium/chrome/browser/app/BraveActivity.java
+++ b/android/java/org/chromium/chrome/browser/app/BraveActivity.java
@@ -118,6 +118,7 @@ import org.chromium.chrome.browser.brave_leo.BraveLeoUtils;
 import org.chromium.chrome.browser.brave_leo.BraveLeoVoiceRecognitionHandler;
 import org.chromium.chrome.browser.brave_news.BraveNewsUtils;
 import org.chromium.chrome.browser.brave_news.models.FeedItemsCard;
+import org.chromium.chrome.browser.brave_origin.BraveOriginDeepLinkHandler;
 import org.chromium.chrome.browser.brave_origin.BraveOriginSubscriptionPrefs;
 import org.chromium.chrome.browser.brave_shields.BraveFirstPartyStorageCleanerUtils;
 import org.chromium.chrome.browser.brave_shields.FirstPartyStorageCleanerAnimationFragment;
@@ -995,10 +996,16 @@ public abstract class BraveActivity extends ChromeActivity
 
     @Override
     public void initializeState() {
+        Intent intent = getIntent();
+        boolean isOriginPromoDeepLink = BraveOriginDeepLinkHandler.consumeFromIntent(intent);
         if (BraveFreshNtpHelper.isEnabled()) {
             setForegroundSessionEndsTriggered();
         }
         super.initializeState();
+        if (isOriginPromoDeepLink) {
+            mIsDeepLink = true;
+            BraveOriginDeepLinkHandler.open(this);
+        }
         if (isNoRestoreState()) {
             CommandLine.getInstance().appendSwitch(ChromeSwitches.NO_RESTORE_STATE);
         }
@@ -1007,7 +1014,6 @@ public abstract class BraveActivity extends ChromeActivity
         setComesFromNewTab(false);
         setNewsItemsFeedCards(null);
         BraveSearchEngineUtils.initializeBraveSearchEngineStates(getTabModelSelector());
-        Intent intent = getIntent();
         if (intent != null
                 && intent.getBooleanExtra(BraveWalletActivity.RESTART_WALLET_ACTIVITY, false)) {
             openBraveWallet(
@@ -1403,6 +1409,9 @@ public abstract class BraveActivity extends ChromeActivity
             ChromeSharedPreferences.getInstance()
                     .writeBoolean(BravePreferenceKeys.BRAVE_DEFERRED_DEEPLINK_VPN, false);
             handleDeepLinkVpn();
+        } else if (BraveOriginDeepLinkHandler.consumeDeferred()) {
+            mIsDeepLink = true;
+            BraveOriginDeepLinkHandler.open(this);
         }
 
         // Added to reset app links settings for upgrade case
@@ -2365,7 +2374,12 @@ public abstract class BraveActivity extends ChromeActivity
 
     @Override
     public void onNewIntent(Intent intent) {
+        boolean isOriginPromoDeepLink = BraveOriginDeepLinkHandler.consumeFromIntent(intent);
         super.onNewIntent(intent);
+        if (isOriginPromoDeepLink) {
+            mIsDeepLink = true;
+            BraveOriginDeepLinkHandler.open(this);
+        }
         if (intent != null) {
             String openUrl = intent.getStringExtra(BraveActivity.OPEN_URL);
             if (!TextUtils.isEmpty(openUrl)) {

--- a/android/java/org/chromium/chrome/browser/brave_origin/BraveOriginDeepLinkHandler.java
+++ b/android/java/org/chromium/chrome/browser/brave_origin/BraveOriginDeepLinkHandler.java
@@ -1,0 +1,75 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.chromium.chrome.browser.brave_origin;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.net.Uri;
+
+import org.chromium.base.BravePreferenceKeys;
+import org.chromium.build.annotations.NullMarked;
+import org.chromium.build.annotations.Nullable;
+import org.chromium.chrome.browser.preferences.ChromeSharedPreferences;
+import org.chromium.chrome.browser.settings.BraveOriginPreferences;
+import org.chromium.chrome.browser.settings.SettingsNavigationFactory;
+
+/**
+ * Routes the Origin promo deep link (https://brave.com/deeplink-android-origin-promo) to the right
+ * in-app destination: - Active subscribers: Origin settings page. - Non-subscribers: Origin payment
+ * screen (BraveOriginPlansActivity).
+ */
+@NullMarked
+public final class BraveOriginDeepLinkHandler {
+    /** Path token used by both the App Link URL and the Play Install Referrer string. */
+    public static final String PATH_TOKEN = "deeplink-android-origin-promo";
+
+    private BraveOriginDeepLinkHandler() {}
+
+    /**
+     * If {@code intent} is the Origin promo deep link, neutralize its action/data so upstream URL
+     * handling skips it and return {@code true}. Caller should then call {@link #open}.
+     */
+    public static boolean consumeFromIntent(@Nullable Intent intent) {
+        if (intent == null || !Intent.ACTION_VIEW.equals(intent.getAction())) {
+            return false;
+        }
+        Uri data = intent.getData();
+        if (data == null || !PATH_TOKEN.equalsIgnoreCase(data.getLastPathSegment())) {
+            return false;
+        }
+        intent.setData(null);
+        intent.setAction(Intent.ACTION_MAIN);
+        return true;
+    }
+
+    /**
+     * Reads and clears the deferred pref written by the Play Install Referrer flow. Returns {@code
+     * true} if the pref was set. Caller should then call {@link #open}.
+     */
+    public static boolean consumeDeferred() {
+        if (!ChromeSharedPreferences.getInstance()
+                .readBoolean(BravePreferenceKeys.BRAVE_DEFERRED_DEEPLINK_ORIGIN_PROMO, false)) {
+            return false;
+        }
+        ChromeSharedPreferences.getInstance()
+                .writeBoolean(BravePreferenceKeys.BRAVE_DEFERRED_DEEPLINK_ORIGIN_PROMO, false);
+        return true;
+    }
+
+    /**
+     * Opens the Origin destination — settings for subscribers, payment screen for everyone else.
+     * The subscription cache is refreshed in {@code BraveActivity.finishNativeInitialization}, so
+     * it reflects the most recent known state.
+     */
+    public static void open(Activity activity) {
+        if (BraveOriginSubscriptionPrefs.getIsCredentialSummaryActiveCached()) {
+            SettingsNavigationFactory.createSettingsNavigation()
+                    .startSettings(activity, BraveOriginPreferences.class);
+        } else {
+            activity.startActivity(new Intent(activity, BraveOriginPlansActivity.class));
+        }
+    }
+}

--- a/android/java/org/chromium/chrome/browser/firstrun/WelcomeOnboardingActivity.java
+++ b/android/java/org/chromium/chrome/browser/firstrun/WelcomeOnboardingActivity.java
@@ -43,6 +43,7 @@ import org.chromium.build.annotations.Nullable;
 import org.chromium.chrome.R;
 import org.chromium.chrome.browser.BraveConfig;
 import org.chromium.chrome.browser.BraveLocalState;
+import org.chromium.chrome.browser.brave_origin.BraveOriginDeepLinkHandler;
 import org.chromium.chrome.browser.customtabs.CustomTabActivity;
 import org.chromium.chrome.browser.metrics.ChangeMetricsReportingStateCalledFrom;
 import org.chromium.chrome.browser.metrics.UmaSessionStats;
@@ -133,6 +134,13 @@ public class WelcomeOnboardingActivity extends FirstRunActivityBase
                                                 .writeBoolean(
                                                         BravePreferenceKeys
                                                                 .BRAVE_DEFERRED_DEEPLINK_VPN,
+                                                        true);
+                                    } else if (referrerUrl.equals(
+                                            BraveOriginDeepLinkHandler.PATH_TOKEN)) {
+                                        ChromeSharedPreferences.getInstance()
+                                                .writeBoolean(
+                                                        BravePreferenceKeys
+                                                                .BRAVE_DEFERRED_DEEPLINK_ORIGIN_PROMO, // presubmit: ignore-long-line
                                                         true);
                                     }
                                 } catch (RemoteException e) {

--- a/android/junit/BUILD.gn
+++ b/android/junit/BUILD.gn
@@ -85,6 +85,13 @@ if (is_android) {
     deps = [ "//chrome/android/junit:chrome_junit_tests_helper" ]
   }
 
+  robolectric_library(
+      "brave_junit_tests_org.chromium.chrome.browser.brave_origin") {
+    sources = [ "src/org/chromium/chrome/browser/brave_origin/BraveOriginDeepLinkHandlerTest.java" ]
+
+    deps = [ "//chrome/android/junit:chrome_junit_tests_helper" ]
+  }
+
   robolectric_library("brave_junit_tests_org.chromium.chrome.browser") {
     sources =
         [ "src/org/chromium/chrome/browser/BraveIntentHandlerUnitTest.java" ]

--- a/android/junit/src/org/chromium/chrome/browser/brave_origin/BraveOriginDeepLinkHandlerTest.java
+++ b/android/junit/src/org/chromium/chrome/browser/brave_origin/BraveOriginDeepLinkHandlerTest.java
@@ -1,0 +1,155 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.chromium.chrome.browser.brave_origin;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import android.content.Intent;
+import android.net.Uri;
+
+import androidx.test.filters.SmallTest;
+
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.chromium.base.BravePreferenceKeys;
+import org.chromium.base.test.BaseRobolectricTestRunner;
+import org.chromium.chrome.browser.preferences.ChromeSharedPreferences;
+
+/** Unit tests for {@link BraveOriginDeepLinkHandler}. */
+@RunWith(BaseRobolectricTestRunner.class)
+public class BraveOriginDeepLinkHandlerTest {
+    private static final String CANONICAL_URL =
+            "https://brave.com/" + BraveOriginDeepLinkHandler.PATH_TOKEN;
+
+    @After
+    public void tearDown() {
+        ChromeSharedPreferences.getInstance()
+                .writeBoolean(BravePreferenceKeys.BRAVE_DEFERRED_DEEPLINK_ORIGIN_PROMO, false);
+    }
+
+    // consumeFromIntent — happy path
+
+    @Test
+    @SmallTest
+    public void consumeFromIntent_canonicalUrl_returnsTrueAndNeutralizesIntent() {
+        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(CANONICAL_URL));
+
+        assertTrue(BraveOriginDeepLinkHandler.consumeFromIntent(intent));
+
+        // Action becomes MAIN and data is cleared so upstream URL handling skips this intent.
+        assertEquals(Intent.ACTION_MAIN, intent.getAction());
+        assertNull(intent.getData());
+    }
+
+    @Test
+    @SmallTest
+    public void consumeFromIntent_uppercasePath_returnsTrue() {
+        // Path matching is case-insensitive per the implementation.
+        Intent intent =
+                new Intent(
+                        Intent.ACTION_VIEW,
+                        Uri.parse("https://brave.com/DEEPLINK-ANDROID-ORIGIN-PROMO"));
+
+        assertTrue(BraveOriginDeepLinkHandler.consumeFromIntent(intent));
+    }
+
+    @Test
+    @SmallTest
+    public void consumeFromIntent_canonicalUrlWithQuery_returnsTrue() {
+        // Query parameters don't affect last path segment.
+        Intent intent =
+                new Intent(Intent.ACTION_VIEW, Uri.parse(CANONICAL_URL + "?utm_source=play"));
+
+        assertTrue(BraveOriginDeepLinkHandler.consumeFromIntent(intent));
+    }
+
+    // consumeFromIntent — rejection paths
+
+    @Test
+    @SmallTest
+    public void consumeFromIntent_nullIntent_returnsFalse() {
+        assertFalse(BraveOriginDeepLinkHandler.consumeFromIntent(null));
+    }
+
+    @Test
+    @SmallTest
+    public void consumeFromIntent_wrongAction_returnsFalse() {
+        Intent intent = new Intent(Intent.ACTION_SEND, Uri.parse(CANONICAL_URL));
+
+        assertFalse(BraveOriginDeepLinkHandler.consumeFromIntent(intent));
+        // Intent should not be mutated.
+        assertEquals(Intent.ACTION_SEND, intent.getAction());
+        assertEquals(Uri.parse(CANONICAL_URL), intent.getData());
+    }
+
+    @Test
+    @SmallTest
+    public void consumeFromIntent_nullData_returnsFalse() {
+        Intent intent = new Intent(Intent.ACTION_VIEW);
+
+        assertFalse(BraveOriginDeepLinkHandler.consumeFromIntent(intent));
+    }
+
+    @Test
+    @SmallTest
+    public void consumeFromIntent_unrelatedPath_returnsFalse() {
+        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse("https://brave.com/blog"));
+
+        assertFalse(BraveOriginDeepLinkHandler.consumeFromIntent(intent));
+    }
+
+    @Test
+    @SmallTest
+    public void consumeFromIntent_partialMatch_returnsFalse() {
+        // Last segment must be an exact (case-insensitive) match — substring matches don't count.
+        Intent intent =
+                new Intent(
+                        Intent.ACTION_VIEW,
+                        Uri.parse("https://brave.com/deeplink-android-origin-promo-something"));
+
+        assertFalse(BraveOriginDeepLinkHandler.consumeFromIntent(intent));
+    }
+
+    // consumeDeferred
+
+    @Test
+    @SmallTest
+    public void consumeDeferred_prefUnset_returnsFalse() {
+        ChromeSharedPreferences.getInstance()
+                .writeBoolean(BravePreferenceKeys.BRAVE_DEFERRED_DEEPLINK_ORIGIN_PROMO, false);
+
+        assertFalse(BraveOriginDeepLinkHandler.consumeDeferred());
+    }
+
+    @Test
+    @SmallTest
+    public void consumeDeferred_prefSet_returnsTrueAndClearsPref() {
+        ChromeSharedPreferences.getInstance()
+                .writeBoolean(BravePreferenceKeys.BRAVE_DEFERRED_DEEPLINK_ORIGIN_PROMO, true);
+
+        assertTrue(BraveOriginDeepLinkHandler.consumeDeferred());
+        // Pref should be cleared so subsequent drains don't double-fire.
+        assertFalse(
+                ChromeSharedPreferences.getInstance()
+                        .readBoolean(
+                                BravePreferenceKeys.BRAVE_DEFERRED_DEEPLINK_ORIGIN_PROMO, false));
+    }
+
+    @Test
+    @SmallTest
+    public void consumeDeferred_calledTwice_secondCallReturnsFalse() {
+        ChromeSharedPreferences.getInstance()
+                .writeBoolean(BravePreferenceKeys.BRAVE_DEFERRED_DEEPLINK_ORIGIN_PROMO, true);
+
+        assertTrue(BraveOriginDeepLinkHandler.consumeDeferred());
+        assertFalse(BraveOriginDeepLinkHandler.consumeDeferred());
+    }
+}

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -1674,6 +1674,7 @@ if (is_android) {
       "//brave/android/junit:brave_junit_tests_org.chromium.chrome.browser",
       "//brave/android/junit:brave_junit_tests_org.chromium.chrome.browser.app",
       "//brave/android/junit:brave_junit_tests_org.chromium.chrome.browser.autofill",
+      "//brave/android/junit:brave_junit_tests_org.chromium.chrome.browser.brave_origin",
       "//brave/android/junit:brave_junit_tests_org.chromium.chrome.browser.custom_search_engines",
       "//brave/android/junit:brave_junit_tests_org.chromium.chrome.browser.homepage",
       "//brave/android/junit:brave_junit_tests_org.chromium.chrome.browser.ntp",


### PR DESCRIPTION
Adds support for the `https://brave.com/deeplink-android-origin-promo` deep link so that Google Play promotional content events for Brave Origin can route users directly into the Origin payment screen (or settings page for existing subscribers).

Routing happens via the existing autoVerified brave.com App Link. `BraveActivity` catches the intent before upstream's URL handling in `initializeState` (cold start) and `onNewIntent` (warm start), and the Play Install Referrer flow continues to support deferred routing for first-install attribution.

Resolves: https://github.com/brave/brave-browser/issues/55654

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
