### PR TITLE
[plaster] Apply on change

### DIFF
--- a/tools/cr/plaster.py
+++ b/tools/cr/plaster.py
@@ -84,13 +84,111 @@ class PathChecksumPair:
         return True
 
 
-@dataclass
-class PatchInfo:
-    """ Manages a .patchinfo file contents.
+@dataclass(frozen=True)
+class Patchinfo:
+    """In-memory representation of a parsed .patchinfo file.
+    """
 
-    This class is used to manage the patchfile metadata, known as .patchinfo,
-    which are used by our machinery when applying patches to determine if a file
-    needs to be updated or not.
+    @dataclass(frozen=True)
+    class Entry:
+        """A single path/checksum pair from a .patchinfo file."""
+
+        # Path of the file the entry refers to. Stored as a string because
+        # that is how it is serialized in JSON.
+        path: str
+
+        # SHA-256 checksum (hex) of the file at `path`.
+        checksum: str
+
+    # Schema version of the patchinfo file format.
+    schema_version: int
+
+    # SHA-256 checksum (hex) of the .patch file.
+    patch_checksum: str
+
+    # The file the patch applies to, paired with its post-patch checksum.
+    # JSON stores this under "appliesTo" as an array, but in practice we only
+    # ever produce and accept a single entry.
+    applies_to: Entry
+
+    # The plaster .toml file that produced this patchinfo.
+    plaster: Entry
+
+    @staticmethod
+    def from_json(content: str) -> Patchinfo | None:
+        """Parse the JSON content of a .patchinfo file.
+
+        Returns None if the content is not valid JSON, if any required
+        path/checksum pair is missing, if any field has the wrong type, or
+        if "appliesTo" does not contain exactly one entry.
+        """
+        try:
+            data = json.loads(content)
+        except json.JSONDecodeError:
+            return None
+        if not isinstance(data, dict):
+            return None
+
+        schema_version = data.get('schemaVersion')
+        if not isinstance(schema_version, int):
+            return None
+        patch_checksum = data.get('patchChecksum')
+        if not isinstance(patch_checksum, str):
+            return None
+
+        applies_to_raw = data.get('appliesTo')
+        if not isinstance(applies_to_raw, list) or len(applies_to_raw) != 1:
+            return None
+        entry = applies_to_raw[0]
+        if not isinstance(entry, dict):
+            return None
+        applies_path = entry.get('path')
+        applies_checksum = entry.get('checksum')
+        if (not isinstance(applies_path, str)
+                or not isinstance(applies_checksum, str)):
+            return None
+
+        plaster_raw = data.get('plaster')
+        if not isinstance(plaster_raw, dict):
+            return None
+        plaster_path = plaster_raw.get('path')
+        plaster_checksum = plaster_raw.get('checksum')
+        if (not isinstance(plaster_path, str)
+                or not isinstance(plaster_checksum, str)):
+            return None
+
+        return Patchinfo(
+            schema_version=schema_version,
+            patch_checksum=patch_checksum,
+            applies_to=Patchinfo.Entry(path=applies_path,
+                                       checksum=applies_checksum),
+            plaster=Patchinfo.Entry(path=plaster_path,
+                                    checksum=plaster_checksum),
+        )
+
+    def to_json(self) -> str:
+        """Serialize this Patchinfo to the .patchinfo JSON representation."""
+        return json.dumps({
+            'schemaVersion': self.schema_version,
+            'patchChecksum': self.patch_checksum,
+            'appliesTo': [{
+                'path': self.applies_to.path,
+                'checksum': self.applies_to.checksum,
+            }],
+            'plaster': {
+                'path': self.plaster.path,
+                'checksum': self.plaster.checksum,
+            },
+        })
+
+
+@dataclass
+class PatchinfoBuilder:
+    """ Builds a .patchinfo file's contents for a given plaster.
+
+    A builder for the patchfile metadata, known as .patchinfo, which is used
+    by our machinery when applying patches to determine if a file needs to be
+    updated or not.
 
     patchinfo files are not committted to the repository. These files have the
     same name as the patch file, but with a .patchinfo extension. They usually
@@ -106,8 +204,9 @@ class PatchInfo:
       ]
     }
 
-    This class extends the contents of patchinfo files to include the details
-    of the plaster file, including path and checksum, under the "plaster" key.
+    This builder extends the contents of patchinfo files to include the
+    details of the plaster file, including path and checksum, under the
+    "plaster" key.
     {
       "schemaVersion": 1,
       "patchChecksum": "78cb50920870416befe307fa4272bb6076e5000ba25dfbcac2cf00",
@@ -123,10 +222,10 @@ class PatchInfo:
       }
     }
 
-    This class is used to generate a patchinfo file, and with its hash data,
-    determine if we should make changes to the source, patch, and patchinfo
-    files. These three files are supposed to be changed only when the resulting
-    new content is different from what is in disk.
+    It produces a patchinfo file and, with its hash data, decides whether
+    changes need to be persisted to the source, patch, and patchinfo files.
+    These three files are supposed to be changed only when the resulting new
+    content is different from what is in disk.
 
     The new additions to .patchinfo are not known yet to `apply_patches`, but
     this may change in the future.
@@ -156,7 +255,7 @@ class PatchInfo:
     patchinfo: PathChecksumPair = field(init=False)
 
     def __post_init__(self):
-        """Initializes the PatchInfo data with checksums and paths."""
+        """Initializes the PatchinfoBuilder data with checksums and paths."""
         self.plaster_contents = self.plaster_file.read_bytes().decode('utf-8')
         self.plaster_checksum = hashlib.sha256(
             self.plaster_contents.encode()).hexdigest()
@@ -215,18 +314,18 @@ class PatchInfo:
 
     def save_patchinfo_if_changed(self):
         """Save the patchinfo metadata JSON only if it has changed."""
-        content = json.dumps({
-            'schemaVersion': 1,
-            'patchChecksum': self.patch.checksum,
-            'appliesTo': [{
-                'path': str(self.source),
-                'checksum': self.source_with_checksum.checksum,
-            }],
-            'plaster': {
-                'path': str(self.plaster_file),
-                'checksum': self.plaster_checksum,
-            },
-        })
+        content = Patchinfo(
+            schema_version=1,
+            patch_checksum=self.patch.checksum,
+            applies_to=Patchinfo.Entry(
+                path=str(self.source),
+                checksum=self.source_with_checksum.checksum,
+            ),
+            plaster=Patchinfo.Entry(
+                path=str(self.plaster_file),
+                checksum=self.plaster_checksum,
+            ),
+        ).to_json()
         self.patchinfo.save_if_changed(content)
 
 
@@ -255,8 +354,56 @@ class PlasterFile:
 
         return plaster_files
 
+    def needs_apply(self) -> bool:
+        """Returns True if this plaster file needs to be re-applied.
+
+        The basics of this function is that it checks if a given plaster file
+        or its source last change occurred after the last change for
+        `.pathcinfo`. If that's the case, then it means something changed in
+        these files, since the last time the patch was applied with our
+        tooling, which warrent checksum checks for all of them, and at that
+        point if any of the checksum values don't match, we do return True.
+        """
+        source_relative = self.path.relative_to(
+            PLASTER_FILES_PATH).with_suffix('')
+        source_path = Path(repository.chromium.from_brave(source_relative))
+        patch_stem = source_relative.as_posix().replace('/', '-')
+        patch_path = PATCHES_PATH / f'{patch_stem}.patch'
+        patchinfo_path = PATCHES_PATH / f'{patch_stem}.patchinfo'
+
+        # Only the plaster toml is guaranteed to exist here; any of the
+        # other files may be missing and that is by itself a reason to
+        # re-apply.
+        if (not patchinfo_path.exists() or not patch_path.exists()
+                or not source_path.exists()):
+            return True
+
+        patchinfo_mtime = patchinfo_path.stat().st_mtime
+        plaster_mtime = self.path.stat().st_mtime
+        patch_mtime = patch_path.stat().st_mtime
+        source_mtime = source_path.stat().st_mtime
+
+        if (patchinfo_mtime >= plaster_mtime
+                and patchinfo_mtime >= source_mtime
+                and patchinfo_mtime >= patch_mtime):
+            return False
+
+        try:
+            content = patchinfo_path.read_bytes().decode('utf-8')
+        except OSError:
+            return True
+
+        info = Patchinfo.from_json(content)
+        if info is None:
+            return True
+
+        return (
+            PathChecksumPair(source_path).checksum != info.applies_to.checksum
+            or PathChecksumPair(self.path).checksum != info.plaster.checksum
+            or PathChecksumPair(patch_path).checksum != info.patch_checksum)
+
     def apply(self, dry_run=False):
-        info = PatchInfo(self.path)
+        info = PatchinfoBuilder(self.path)
         plaster_file = tomllib.loads(info.plaster_contents)
         contents = repository.chromium.read_file(info.source)
         errors = []
@@ -389,10 +536,25 @@ def get_plaster_files(filepaths: list[str] | None = None) -> list[PlasterFile]:
 
 def apply(args):
     """Applies plaster files to brave.
+
+    This function default mode, meaning no arguments were provided when calling
+    `plaster apply` will cause a `needs_apply` check to be used before applying
+    a plaster, which is a way to make calling plaster inexpensive.
+
+    When `--all` is passed, this causes all plaster files to be reapplied. When
+    specific plaster file paths or patch file paths are passed, only those are
+    run.
     """
+    filepaths = getattr(args, 'filepaths', None)
+    apply_all = getattr(args, 'all', False)
+    skip_up_to_date = not apply_all and not filepaths
+
     with terminal.with_status('Applying plaster files'):
-        plaster_files = get_plaster_files(getattr(args, 'filepaths', None))
+        plaster_files = get_plaster_files(filepaths)
         for plaster_file in plaster_files:
+            if skip_up_to_date and not plaster_file.needs_apply():
+                logging.debug('Up-to-date, skipping: %s', plaster_file.path)
+                continue
             console.log(f'Applying plaster file: {plaster_file.path}')
             plaster_file.apply()
     return 0
@@ -423,6 +585,11 @@ def main():
     # Add the 'apply' subparser
     apply_parser = subparsers.add_parser(
         'apply', help='Apply all plaster files to the sources in brave-core')
+    apply_parser.add_argument(
+        '--all',
+        action='store_true',
+        help='Re-apply every plaster file unconditionally, even if the '
+        'patchinfo indicates it is already up-to-date.')
     apply_parser.add_argument('filepaths',
                               nargs='*',
                               help='Filepaths to apply')

--- a/tools/cr/plaster_test.py
+++ b/tools/cr/plaster_test.py
@@ -8,6 +8,7 @@ import unittest
 from pathlib import Path
 import hashlib
 import json
+import os
 import time
 
 import plaster
@@ -96,7 +97,7 @@ class PlasterTest(unittest.TestCase):
             'Initial content for Plaster file.')
 
         # Checking for the creation of the patchinfo file
-        patchinfo = plaster.PatchInfo(plaster_path)
+        patchinfo = plaster.PatchinfoBuilder(plaster_path)
         patchinfo_from_disk = json.loads(
             patchinfo.patchinfo.path.read_text(encoding='utf-8'))
 
@@ -112,7 +113,7 @@ class PlasterTest(unittest.TestCase):
             hashlib.sha256(
                 (self.fake_chromium_src.chromium /
                  test_file_chromium).read_text().encode()).hexdigest())
-        # PatchInfo normalizes plaster path to be relative to brave root.
+        # PatchinfoBuilder normalizes plaster path to be relative to brave root.
         self.assertEqual(patchinfo_from_disk['plaster']['path'],
                          str(patchinfo.plaster_file))
         self.assertEqual(
@@ -738,6 +739,316 @@ class PlasterTest(unittest.TestCase):
             result,
             'Brave application and Firefox application and Safari application.'
         )
+
+    def _setup_applied_plaster(self, test_file: Path,
+                               initial_content: str) -> plaster.PlasterFile:
+        """Stages a chromium source, writes a plaster toml, and applies it."""
+        self.fake_chromium_src.write_and_stage_file(
+            test_file, initial_content, self.fake_chromium_src.chromium)
+        self.fake_chromium_src.commit(f'Add {test_file.name}',
+                                      self.fake_chromium_src.chromium)
+        plaster_path = plaster.PLASTER_FILES_PATH / (str(test_file) + '.toml')
+        plaster_path.parent.mkdir(parents=True, exist_ok=True)
+        plaster_path.write_text('''
+          [[substitution]]
+          description = 'Replace Chromium with Brave'
+          re_pattern = 'Chromium'
+          replace = 'Brave'
+        ''')
+        plaster_file = plaster.PlasterFile(plaster_path)
+        plaster_file.apply()
+        return plaster_file
+
+    def test_needs_apply_false_after_fresh_apply(self):
+        """needs_apply returns False immediately after a successful apply."""
+        plaster_file = self._setup_applied_plaster(
+            Path('chrome/common/extensions/api/needs_apply_fresh.idl'),
+            'Initial Chromium content.')
+        self.assertFalse(plaster_file.needs_apply())
+
+    def test_needs_apply_true_after_source_change(self):
+        """needs_apply returns True when the source file is modified."""
+        test_file = Path(
+            'chrome/common/extensions/api/needs_apply_source_change.idl')
+        plaster_file = self._setup_applied_plaster(
+            test_file, 'Initial Chromium content.')
+        source_path = self.fake_chromium_src.chromium / test_file
+        later = source_path.stat().st_mtime + 10
+        source_path.write_text('Tampered Brave content.')
+        os.utime(source_path, (later, later))
+        self.assertTrue(plaster_file.needs_apply())
+
+    def test_needs_apply_true_after_toml_change(self):
+        """needs_apply returns True when the plaster toml is modified."""
+        test_file = Path(
+            'chrome/common/extensions/api/needs_apply_toml_change.idl')
+        plaster_file = self._setup_applied_plaster(
+            test_file, 'Initial Chromium content.')
+        later = plaster_file.path.stat().st_mtime + 10
+        plaster_file.path.write_text('''
+          [[substitution]]
+          description = 'A different rule'
+          re_pattern = 'Brave'
+          replace = 'Lion'
+        ''')
+        os.utime(plaster_file.path, (later, later))
+        self.assertTrue(plaster_file.needs_apply())
+
+    def test_needs_apply_true_when_patchinfo_missing(self):
+        """needs_apply returns True when the patchinfo file does not exist."""
+        plaster_file = self._setup_applied_plaster(
+            Path('chrome/common/extensions/api/needs_apply_no_patchinfo.idl'),
+            'Initial Chromium content.')
+        plaster.PatchinfoBuilder(plaster_file.path).patchinfo.path.unlink()
+        self.assertTrue(plaster_file.needs_apply())
+
+    def test_needs_apply_true_when_patchinfo_missing_fields(self):
+        """needs_apply returns True when patchinfo lacks required pairs."""
+        plaster_file = self._setup_applied_plaster(
+            Path('chrome/common/extensions/api/needs_apply_incomplete_info.idl'
+                 ), 'Initial Chromium content.')
+        patchinfo_path = plaster.PatchinfoBuilder(
+            plaster_file.path).patchinfo.path
+        # Schema-only patchinfo: no appliesTo, plaster, or patchChecksum.
+        patchinfo_path.write_text('{"schemaVersion": 1}',
+                                  encoding='utf-8',
+                                  newline='')
+        # Backdate patchinfo so the mtime check trips and the field check
+        # runs.
+        older = patchinfo_path.stat().st_mtime - 100
+        os.utime(patchinfo_path, (older, older))
+        self.assertTrue(plaster_file.needs_apply())
+
+    def test_needs_apply_true_after_patch_change(self):
+        """needs_apply returns True when the patch file is modified."""
+        test_file = Path(
+            'chrome/common/extensions/api/needs_apply_patch_change.idl')
+        plaster_file = self._setup_applied_plaster(
+            test_file, 'Initial Chromium content.')
+        patch_path = plaster.PatchinfoBuilder(plaster_file.path).patch.path
+        later = patch_path.stat().st_mtime + 10
+        patch_path.write_text('tampered patch contents\n')
+        os.utime(patch_path, (later, later))
+        self.assertTrue(plaster_file.needs_apply())
+
+    def test_needs_apply_true_when_patch_missing(self):
+        """needs_apply returns True when the patch file does not exist."""
+        plaster_file = self._setup_applied_plaster(
+            Path('chrome/common/extensions/api/needs_apply_no_patch.idl'),
+            'Initial Chromium content.')
+        plaster.PatchinfoBuilder(plaster_file.path).patch.path.unlink()
+        self.assertTrue(plaster_file.needs_apply())
+
+    def test_needs_apply_true_when_source_missing(self):
+        """needs_apply returns True when the chromium source is missing."""
+        test_file = Path(
+            'chrome/common/extensions/api/needs_apply_no_source.idl')
+        plaster_file = self._setup_applied_plaster(
+            test_file, 'Initial Chromium content.')
+        (self.fake_chromium_src.chromium / test_file).unlink()
+        self.assertTrue(plaster_file.needs_apply())
+
+    def test_needs_apply_false_when_stale_mtime_but_checksums_match(self):
+        """needs_apply returns False when mtime is stale but checksums match.
+        """
+        plaster_file = self._setup_applied_plaster(
+            Path('chrome/common/extensions/api/needs_apply_stale_mtime.idl'),
+            'Initial Chromium content.')
+        patchinfo_path = plaster.PatchinfoBuilder(
+            plaster_file.path).patchinfo.path
+        older = patchinfo_path.stat().st_mtime - 100
+        os.utime(patchinfo_path, (older, older))
+        self.assertFalse(plaster_file.needs_apply())
+
+
+class PatchinfoTest(unittest.TestCase):
+    """Tests for Patchinfo and Patchinfo.parse."""
+
+    _VALID_JSON = '''{
+      "schemaVersion": 1,
+      "patchChecksum": "cff50e7ef57149c15b3550204e6ed5beadb14d9ede81a0d1d9e0c2fa89a3708f",
+      "appliesTo": [
+        {
+          "path": "chrome/updater/mac/.install.sh",
+          "checksum": "aef9cc2e118501527bab9f46a652ba8c28009ea46771af219de45a680a4157ad"
+        }
+      ],
+      "plaster": {
+        "path": "rewrite/chrome/updater/mac/.install.sh.toml",
+        "checksum": "c8335aa0242a7f4426bb8e870239585063d20c2e3c1bfbe07a3060f003bd2a31"
+      }
+    }'''
+
+    def test_from_json_happy_path(self):
+        """from_json populates every field from a well-formed patchinfo."""
+        info = plaster.Patchinfo.from_json(self._VALID_JSON)
+        self.assertIsNotNone(info)
+        self.assertEqual(info.schema_version, 1)
+        self.assertEqual(
+            info.patch_checksum,
+            'cff50e7ef57149c15b3550204e6ed5beadb14d9ede81a0d1d9e0c2fa89a3708f')
+        self.assertIsInstance(info.applies_to, plaster.Patchinfo.Entry)
+        self.assertEqual(info.applies_to.path,
+                         'chrome/updater/mac/.install.sh')
+        self.assertEqual(
+            info.applies_to.checksum,
+            'aef9cc2e118501527bab9f46a652ba8c28009ea46771af219de45a680a4157ad')
+        self.assertIsInstance(info.plaster, plaster.Patchinfo.Entry)
+        self.assertEqual(info.plaster.path,
+                         'rewrite/chrome/updater/mac/.install.sh.toml')
+        self.assertEqual(
+            info.plaster.checksum,
+            'c8335aa0242a7f4426bb8e870239585063d20c2e3c1bfbe07a3060f003bd2a31')
+
+    def test_from_json_rejects_invalid_input(self):
+        """from_json returns None for malformed JSON, wrong types, or missing
+        required fields."""
+        valid_entry = {'path': 'x', 'checksum': 'h'}
+        valid_plaster = {'path': 'p', 'checksum': 'hp'}
+        base = {
+            'schemaVersion': 1,
+            'patchChecksum': 'a',
+            'appliesTo': [valid_entry],
+            'plaster': valid_plaster,
+        }
+
+        cases: list[tuple[str, str]] = [
+            ('not JSON at all', 'not json'),
+            ('list root', '[]'),
+            ('int root', '42'),
+            ('string root', '"hello"'),
+            ('missing schemaVersion',
+             json.dumps({
+                 k: v
+                 for k, v in base.items() if k != 'schemaVersion'
+             })),
+            ('wrong schemaVersion type',
+             json.dumps({
+                 **base, 'schemaVersion': '1'
+             })),
+            ('missing patchChecksum',
+             json.dumps({
+                 k: v
+                 for k, v in base.items() if k != 'patchChecksum'
+             })),
+            ('wrong patchChecksum type',
+             json.dumps({
+                 **base, 'patchChecksum': 123
+             })),
+            ('missing appliesTo',
+             json.dumps({
+                 k: v
+                 for k, v in base.items() if k != 'appliesTo'
+             })),
+            ('empty appliesTo', json.dumps({
+                **base, 'appliesTo': []
+            })),
+            ('more than one appliesTo entry',
+             json.dumps({
+                 **base, 'appliesTo': [valid_entry, valid_entry]
+             })),
+            ('non-list appliesTo',
+             json.dumps({
+                 **base, 'appliesTo': valid_entry
+             })),
+            ('appliesTo entry missing path',
+             json.dumps({
+                 **base, 'appliesTo': [{
+                     'checksum': 'h'
+                 }]
+             })),
+            ('appliesTo entry missing checksum',
+             json.dumps({
+                 **base, 'appliesTo': [{
+                     'path': 'x'
+                 }]
+             })),
+            ('appliesTo entry wrong path type',
+             json.dumps({
+                 **base, 'appliesTo': [{
+                     'path': 1,
+                     'checksum': 'h'
+                 }]
+             })),
+            ('missing plaster',
+             json.dumps({
+                 k: v
+                 for k, v in base.items() if k != 'plaster'
+             })),
+            ('non-dict plaster', json.dumps({
+                **base, 'plaster': 'oops'
+            })),
+            ('plaster missing path',
+             json.dumps({
+                 **base, 'plaster': {
+                     'checksum': 'hp'
+                 }
+             })),
+            ('plaster missing checksum',
+             json.dumps({
+                 **base, 'plaster': {
+                     'path': 'p'
+                 }
+             })),
+            ('plaster wrong checksum type',
+             json.dumps({
+                 **base, 'plaster': {
+                     'path': 'p',
+                     'checksum': 7
+                 }
+             })),
+        ]
+
+        for name, content in cases:
+            with self.subTest(case=name):
+                self.assertIsNone(plaster.Patchinfo.from_json(content))
+
+    def test_parsed_instance_is_frozen(self):
+        """Patchinfo and Patchinfo.Entry both reject attribute assignment."""
+        from dataclasses import FrozenInstanceError
+        info = plaster.Patchinfo.from_json(self._VALID_JSON)
+        self.assertIsNotNone(info)
+        with self.assertRaises(FrozenInstanceError):
+            info.schema_version = 99
+        with self.assertRaises(FrozenInstanceError):
+            info.applies_to.path = 'other'
+
+    def test_parsed_instance_equality_and_hashable(self):
+        """Two patchinfos parsed from identical JSON compare equal and hash
+        equal."""
+        a = plaster.Patchinfo.from_json(self._VALID_JSON)
+        b = plaster.Patchinfo.from_json(self._VALID_JSON)
+        self.assertEqual(a, b)
+        self.assertEqual(hash(a), hash(b))
+
+    def test_to_json_matches_schema(self):
+        """to_json emits exactly the keys/structure of a .patchinfo file."""
+        info = plaster.Patchinfo(
+            schema_version=1,
+            patch_checksum='pc',
+            applies_to=plaster.Patchinfo.Entry(path='src.cc', checksum='sc'),
+            plaster=plaster.Patchinfo.Entry(path='r.toml', checksum='rc'),
+        )
+        self.assertEqual(
+            json.loads(info.to_json()), {
+                'schemaVersion': 1,
+                'patchChecksum': 'pc',
+                'appliesTo': [{
+                    'path': 'src.cc',
+                    'checksum': 'sc'
+                }],
+                'plaster': {
+                    'path': 'r.toml',
+                    'checksum': 'rc'
+                },
+            })
+
+    def test_json_roundtrip(self):
+        """from_json(x.to_json()) == x for any well-formed Patchinfo."""
+        original = plaster.Patchinfo.from_json(self._VALID_JSON)
+        self.assertIsNotNone(original)
+        roundtripped = plaster.Patchinfo.from_json(original.to_json())
+        self.assertEqual(original, roundtripped)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR introduces a check mechanism to `plaster` that will allow it by
default to just reapply patches for the plasters who are not up-to-date.
This is being implemented with a simple approach:

 * Check if the `.patchinfo` timestamp older than the plaster file,
   patch, or upstream source.
 * If `.patchinfo` is newer than any of these, we go on to check if the
   checksums are matching with what is in the `.patchinfo`.
 * If any of the checksum chcks fail, we reapply the patch.

This is very lightweight, and will make most of the uses of `apply`
reliable for reruns while working on a feature.

Resolves https://github.com/brave/brave-browser/issues/45057
