### PR TITLE
Fix intermittent iPad Remember Browsing Mode

### DIFF
--- a/ios/brave-ios/App/iOS/Delegates/SceneDelegate.swift
+++ b/ios/brave-ios/App/iOS/Delegates/SceneDelegate.swift
@@ -214,6 +214,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
   }
 
   func sceneWillResignActive(_ scene: UIScene) {
+    persistSessionStateOnBackground(for: scene)
     Preferences.AppState.backgroundedCleanly.value = true
     Preferences.AppState.shouldDeferPromotedPurchase.value = false
     scene.userActivity?.resignCurrent()
@@ -221,7 +222,14 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
   }
 
   func sceneDidEnterBackground(_ scene: UIScene) {
+    persistSessionStateOnBackground(for: scene)
+    Preferences.AppState.backgroundedCleanly.value = true
     BraveVPN.sendVPNWorksInBackgroundNotification()
+  }
+
+  private func persistSessionStateOnBackground(for scene: UIScene) {
+    guard let windowScene = scene as? UIWindowScene else { return }
+    windowScene.browserViewController?.persistSessionStateOnBackground(scene: scene)
   }
 
   func scene(_ scene: UIScene, openURLContexts contexts: Set<UIOpenURLContext>) {
@@ -728,49 +736,31 @@ extension SceneDelegate {
     let isPrivate: Bool
     let urlToOpen: URL?
 
-    if UIApplication.shared.supportsMultipleScenes {
-      var windowInfo: BrowserState.SessionState
-      if let userActivity = userActivity {
-        windowInfo = BrowserState.getNewWindowInfo(from: userActivity)
-      } else {
-        windowInfo = .init(
-          windowId: BrowserState.getWindowId(from: scene.session),
-          isPrivate: Preferences.Privacy.privateBrowsingOnly.value
-        )
-      }
+    let activeWindow = SessionWindow.getActiveWindow(context: DataController.swiftUIContext)
+    windowId = resolveCanonicalWindowId(
+      session: scene.session,
+      userActivity: userActivity,
+      activeWindow: activeWindow
+    )
 
-      if let existingWindowId = windowInfo.windowId,
-        let windowUUID = UUID(uuidString: existingWindowId)
-      {
-        // Restore the scene from the User-Info WindowID
-        windowId = windowUUID
-        let isPrivateFromActivity = windowInfo.isPrivate
-        isPrivate =
-          isPrivateFromActivity
-          || self.shouldLaunchInPrivateMode(windowId: windowUUID)
-        privateBrowsingManager.isPrivateBrowsing = isPrivate
-        urlToOpen = windowInfo.openURL
-
-        // Create a new session window if it does not already exist
-        SessionWindow.createWindow(isSelected: true, uuid: windowId)
-        Logger.module.info("[SCENE] - SESSION RESTORED")
-      } else {
-        // Try to restore active window
-        let windowInfo = restoreOrCreateWindow()
-        windowId = windowInfo.windowId
-        isPrivate = windowInfo.isPrivate
-        privateBrowsingManager.isPrivateBrowsing = windowInfo.isPrivate
-        urlToOpen = nil
-      }
-    } else {
-      // iPhones don't care about user-activity or session info since it will always have one window anyway
-      let windowInfo = restoreOrCreateWindow()
-      windowId = windowInfo.windowId
-      isPrivate = windowInfo.isPrivate
-      privateBrowsingManager.isPrivateBrowsing = windowInfo.isPrivate
-      urlToOpen = nil
+    if isSingleWindowBrowserSession {
+      consolidateSessionTabs(to: windowId)
     }
 
+    isPrivate = resolveLaunchIsPrivate(
+      windowId: windowId,
+      userActivity: userActivity,
+      session: scene.session
+    )
+    privateBrowsingManager.isPrivateBrowsing = isPrivate
+
+    urlToOpen = userActivity.flatMap { BrowserState.getNewWindowInfo(from: $0).openURL }
+
+    SessionWindow.createWindow(isSelected: true, uuid: windowId)
+    Logger.module.info("[SCENE] - SESSION WINDOW RESOLVED")
+
+    // Only persist windowId on launch; browsing mode is written on background to avoid
+    // overwriting a previously saved private mode when launch resolution is wrong.
     scene.userActivity = BrowserState.userActivity(for: windowId.uuidString)
     BrowserState.setWindowId(for: scene.session, windowId: windowId.uuidString)
 
@@ -834,64 +824,145 @@ extension SceneDelegate {
     return browserViewController
   }
 
-  private func restoreOrCreateWindow() -> (windowId: UUID, isPrivate: Bool, urlToOpen: URL?) {
-    // Find active windows/sessions
-    let activeWindow = SessionWindow.getActiveWindow(context: DataController.swiftUIContext)
-    let activeSession = UIApplication.shared.openSessions
-      .compactMap({ BrowserState.getWindowId(from: $0) })
-      .first(where: { $0 == activeWindow?.windowId.uuidString })
-    var isPrivate = Preferences.Privacy.privateBrowsingOnly.value
-
-    if activeSession != nil {
-      if !UIApplication.shared.supportsMultipleScenes {
-        // iPhones should not create new windows
-        if let activeWindow = activeWindow {
-          // If there's no active window, fall through and create one
-          isPrivate = self.shouldLaunchInPrivateMode(windowId: activeWindow.windowId)
-          return (activeWindow.windowId, isPrivate, nil)
-        }
-      }
-
-      // An existing window is already active on screen
-      // So create a new window
-      let windowId = UUID()
-      SessionWindow.createWindow(isSelected: true, uuid: windowId)
-      Logger.module.info("[SCENE] - CREATED NEW WINDOW")
-      return (windowId, isPrivate, nil)
-    }
-
-    // Restore the active window if possible
-    let windowId: UUID
+  private var isSingleWindowBrowserSession: Bool {
     if !UIApplication.shared.supportsMultipleScenes {
-      // iPhones don't have multi-window so we can restore the active window OR first window found
-      windowId = activeWindow?.windowId ?? SessionWindow.all().first?.windowId ?? UUID()
-    } else {
-      windowId = activeWindow?.windowId ?? UUID()
+      return true
     }
-
-    // When "Keep private tabs" is enabled, launch in private mode if the restored window has persistent private tabs
-    isPrivate = self.shouldLaunchInPrivateMode(windowId: windowId)
-
-    // Create a new session window if it does not already exist
-    SessionWindow.createWindow(isSelected: true, uuid: windowId)
-    Logger.module.info("[SCENE] - RESTORING ACTIVE WINDOW OR CREATING A NEW WINDOW")
-    return (windowId, isPrivate, nil)
+    let browserScenes = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }
+      .filter { $0.browserViewController != nil }
+    return browserScenes.count <= 1
   }
 
-  /// When "Keep private tabs" and "Reopen browser in private mode" are enabled, returns whether the window should launch in Private mode.
-  /// Returns the default (privateBrowsingOnly) when the preferences don't apply (e.g. no persistent private tabs to restore).
-  private func shouldLaunchInPrivateMode(windowId: UUID) -> Bool {
-    guard Preferences.Privacy.persistentPrivateBrowsing.value,
-      Preferences.Privacy.rememberBrowsingMode.value
-    else {
-      return Preferences.Privacy.privateBrowsingOnly.value
+  private func resolveCanonicalWindowId(
+    session: UISceneSession,
+    userActivity: NSUserActivity?,
+    activeWindow: SessionWindow?
+  ) -> UUID {
+    if isSingleWindowBrowserSession,
+      let persisted = Preferences.Privacy.lastSessionWindowId.value.flatMap(UUID.init)
+    {
+      return persisted
     }
 
-    let windowTabs = SessionTab.all().filter { $0.sessionWindow?.windowId == windowId }
-    let privateTabs = windowTabs.filter { $0.isPrivate }
+    return resolveWindowId(
+      activeWindow: activeWindow,
+      session: session,
+      userActivity: userActivity
+    )
+  }
+
+  private func consolidateSessionTabs(to windowId: UUID) {
+    SessionWindow.createWindow(isSelected: true, uuid: windowId)
+    for tab in SessionTab.all() where tab.sessionWindow?.windowId != windowId {
+      SessionTab.move(tab: tab.tabId, toWindow: windowId)
+    }
+
+    // Keep tab selection stable across launches even when stale window IDs existed in Core Data.
+    let windowIdString = windowId.uuidString
+    var lastSelectedByWindow = Preferences.Privacy.lastSelectedTabIdByWindow.value
+    if let selectedTabId = lastSelectedByWindow.values.first(where: { candidateId in
+      SessionTab.all().contains(where: { $0.tabId.uuidString == candidateId })
+    }) {
+      lastSelectedByWindow = [windowIdString: selectedTabId]
+      Preferences.Privacy.lastSelectedTabIdByWindow.value = lastSelectedByWindow
+    } else if lastSelectedByWindow.count > 1 {
+      lastSelectedByWindow = lastSelectedByWindow.filter { $0.key == windowIdString }
+      Preferences.Privacy.lastSelectedTabIdByWindow.value = lastSelectedByWindow
+    }
+  }
+
+  /// Resolves the window ID to restore, falling back to scene session state or windows with saved tabs.
+  private func resolveWindowId(
+    activeWindow: SessionWindow?,
+    session: UISceneSession,
+    userActivity: NSUserActivity? = nil
+  ) -> UUID {
+    if isSingleWindowBrowserSession,
+      let persisted = Preferences.Privacy.lastSessionWindowId.value.flatMap(UUID.init)
+    {
+      return persisted
+    }
+
+    if let activeWindow {
+      return activeWindow.windowId
+    }
+
+    if let persisted = Preferences.Privacy.lastSessionWindowId.value.flatMap(UUID.init) {
+      return persisted
+    }
+
+    if let windowWithTabs = SessionWindow.all().max(by: {
+      ($0.sessionTabs?.count ?? 0) < ($1.sessionTabs?.count ?? 0)
+    }), (windowWithTabs.sessionTabs?.count ?? 0) > 0 {
+      return windowWithTabs.windowId
+    }
+
+    if let activityWindowId = userActivity.flatMap({
+      BrowserState.getNewWindowInfo(from: $0).windowId
+    }).flatMap(UUID.init) {
+      return activityWindowId
+    }
+
+    if let sessionWindowId = BrowserState.getWindowId(from: session).flatMap(UUID.init) {
+      return sessionWindowId
+    }
+
+    return SessionWindow.all().first?.windowId ?? UUID()
+  }
+
+  /// Resolves whether the window should launch in private mode, using persisted scene state when available.
+  private func resolveLaunchIsPrivate(
+    windowId: UUID,
+    userActivity: NSUserActivity?,
+    session: UISceneSession
+  ) -> Bool {
+    guard rememberBrowsingModeIsEnabled else {
+      return defaultLaunchBrowsingModeIsPrivate()
+    }
+
+    if Preferences.Privacy.lastPrivateBrowsingMode.value {
+      return true
+    }
+
+    guard hasPrivateTabsForRestore(windowId: windowId) else {
+      return defaultLaunchBrowsingModeIsPrivate()
+    }
+
+    if shouldLaunchInPrivateModeFromTabs(windowId: windowId) {
+      return true
+    }
+
+    if let userActivity, BrowserState.getNewWindowInfo(from: userActivity).isPrivate {
+      return true
+    }
+
+    if BrowserState.getSessionState(from: session).isPrivate {
+      return true
+    }
+
+    return false
+  }
+
+  private var rememberBrowsingModeIsEnabled: Bool {
+    Preferences.Privacy.persistentPrivateBrowsing.value
+      && Preferences.Privacy.rememberBrowsingMode.value
+  }
+
+  private func defaultLaunchBrowsingModeIsPrivate() -> Bool {
+    Preferences.Privacy.privateBrowsingOnly.value
+  }
+
+  private func hasPrivateTabsForRestore(windowId: UUID) -> Bool {
+    SessionTab.all().contains(where: \.isPrivate)
+  }
+
+  /// Infers private launch mode from saved tab selection when no persisted browsing mode is available.
+  private func shouldLaunchInPrivateModeFromTabs(windowId: UUID) -> Bool {
+    let windowTabs = SessionTab.all()
+    let privateTabs = windowTabs.filter(\.isPrivate)
 
     guard !privateTabs.isEmpty else {
-      return Preferences.Privacy.privateBrowsingOnly.value
+      return false
     }
 
     // Launch in private mode if the selected tab is private, or if the window has only private tabs.

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -738,7 +738,33 @@ public class BrowserViewController: UIViewController {
   }
 
   @objc func appWillTerminateNotification() {
-    tabManager.saveAllTabs(synchronously: true)
+    persistSessionStateOnBackground()
+  }
+
+  /// Persists tabs, selection, window id, and browsing mode before suspend or termination.
+  public func persistSessionStateOnBackground(scene: UIScene? = nil) {
+    tabManager.persistSessionOnBackground()
+
+    if let tabId = tabManager.selectedTab?.id {
+      SessionTab.setSelected(tabId: tabId, synchronously: true)
+    }
+
+    Preferences.Privacy.lastSessionWindowId.value = windowId.uuidString
+
+    let isPrivate = BrowserState.browsingModeToPersistOnBackground(
+      isCurrentlyPrivate: privateBrowsingManager.isPrivateBrowsing
+    )
+    let sceneForPersistence = scene ?? currentScene
+    if let sceneForPersistence {
+      BrowserState.persistRememberedBrowsingMode(
+        isPrivate: isPrivate,
+        session: sceneForPersistence.session,
+        userActivity: sceneForPersistence.userActivity,
+        windowId: windowId.uuidString
+      )
+    } else {
+      BrowserState.persistRememberedBrowsingMode(isPrivate: isPrivate)
+    }
   }
 
   @objc private func tappedCollapsedURLBar() {
@@ -754,11 +780,15 @@ public class BrowserViewController: UIViewController {
   }
 
   @objc func sceneWillResignActiveNotification(_ notification: NSNotification) {
+    if let scene = notification.object as? UIScene {
+      persistSessionStateOnBackground(scene: scene)
+    } else {
+      persistSessionStateOnBackground()
+    }
+
     guard let scene = notification.object as? UIScene, scene == currentScene else {
       return
     }
-
-    tabManager.saveAllTabs()
 
     // If we are displaying a private tab, hide any elements in the tab that we wouldn't want shown
     // when the app is in the home switcher
@@ -1160,6 +1190,10 @@ public class BrowserViewController: UIViewController {
   private func setupTabs() {
     let noTabsAdded = self.tabManager.tabsForCurrentMode.isEmpty
 
+    if noTabsAdded && BrowserState.shouldRestorePrivateBrowsingMode {
+      privateBrowsingManager.isPrivateBrowsing = true
+    }
+
     var tabToSelect: (any TabState)?
 
     if noTabsAdded {
@@ -1177,6 +1211,7 @@ public class BrowserViewController: UIViewController {
       }
     }
     self.tabManager.selectTab(tabToSelect)
+    self.tabManager.finishTabRestore()
 
     // Shred Domain's with SiteShieldLevel.appExit
     self.tabManager.forgetDataOnAppExitDomains()

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -746,7 +746,7 @@ public class BrowserViewController: UIViewController {
     tabManager.persistSessionOnBackground()
 
     if let tabId = tabManager.selectedTab?.id {
-      SessionTab.setSelected(tabId: tabId, synchronously: true)
+      SessionTab.setSelected(tabId: tabId)
     }
 
     Preferences.Privacy.lastSessionWindowId.value = windowId.uuidString

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/TabManager.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/TabManager.swift
@@ -614,7 +614,7 @@ class TabManager: NSObject {
     saveTabOrder()
   }
 
-  private func saveTabOrder(synchronously: Bool = false) {
+  private func saveTabOrder() {
     if Preferences.Privacy.privateBrowsingOnly.value
       || (privateBrowsingManager.isPrivateBrowsing
         && !Preferences.Privacy.persistentPrivateBrowsing.value)
@@ -622,7 +622,7 @@ class TabManager: NSObject {
       return
     }
     let allTabIds = allTabs.compactMap { $0.id }
-    SessionTab.saveTabOrder(tabIds: allTabIds, synchronously: synchronously)
+    SessionTab.saveTabOrder(tabIds: allTabIds)
   }
 
   @MainActor func configureTab(
@@ -701,7 +701,7 @@ class TabManager: NSObject {
     }
   }
 
-  func saveAllTabs(synchronously: Bool = false) {
+  func saveAllTabs() {
     if Preferences.Privacy.privateBrowsingOnly.value
       || (privateBrowsingManager.isPrivateBrowsing
         && !Preferences.Privacy.persistentPrivateBrowsing.value)
@@ -711,40 +711,24 @@ class TabManager: NSObject {
 
     let tabs =
       Preferences.Privacy.persistentPrivateBrowsing.value ? allTabs : tabs(isPrivate: false)
-    if synchronously {
-      SessionTab.persistTabs(
-        windowId: windowId,
-        tabs: tabs.map {
-          (
-            $0.id,
-            $0.sessionData ?? Data(),
-            $0.title ?? "",
-            $0.visibleURL ?? TabManager.ntpInteralURL,
-            $0.isPrivate
-          )
-        },
-        synchronously: true
-      )
-    } else {
-      SessionTab.updateAll(
-        synchronously: false,
-        tabs: tabs.map {
-          (
-            $0.id,
-            $0.sessionData ?? Data(),
-            $0.title ?? "",
-            $0.visibleURL ?? TabManager.ntpInteralURL
-          )
-        }
-      )
-    }
+    SessionTab.persistTabs(
+      windowId: windowId,
+      tabs: tabs.map {
+        (
+          $0.id,
+          $0.sessionData ?? Data(),
+          $0.title ?? "",
+          $0.visibleURL ?? TabManager.ntpInteralURL,
+          $0.isPrivate
+        )
+      }
+    )
   }
 
   /// Persists tab session data and tab order when the app backgrounds.
   func persistSessionOnBackground() {
-    SessionWindow.createWindow(isSelected: true, uuid: windowId)
-    saveAllTabs(synchronously: true)
-    saveTabOrder(synchronously: true)
+    saveAllTabs()
+    saveTabOrder()
   }
 
   func saveTab(_ tab: some TabState, saveOrder: Bool = false) {
@@ -1359,8 +1343,9 @@ class TabManager: NSObject {
     }
   }
 
-  @MainActor private func resolveRestoredTabSelection(from savedTabs: [SessionTab]) -> (any TabState)?
-  {
+  @MainActor private func resolveRestoredTabSelection(
+    from savedTabs: [SessionTab]
+  ) -> (any TabState)? {
     let isPrivate = privateBrowsingManager.isPrivateBrowsing
 
     if let lastId = Preferences.Privacy.lastSelectedTabIdByWindow.value[windowId.uuidString]

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/TabManager.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/TabManager.swift
@@ -325,8 +325,15 @@ class TabManager: NSObject {
     if previous === tab {
       return
     }
-    // Convert the global mode to normal/private
-    privateBrowsingManager.isPrivateBrowsing = tab?.isPrivate == true
+    // Convert the global mode to normal/private, but preserve the launch mode during tab restore
+    // when "Remember Browsing Mode" is enabled.
+    let shouldPreserveBrowsingMode =
+      isRestoring
+      && Preferences.Privacy.persistentPrivateBrowsing.value
+      && Preferences.Privacy.rememberBrowsingMode.value
+    if !shouldPreserveBrowsingMode {
+      privateBrowsingManager.isPrivateBrowsing = tab?.isPrivate == true
+    }
 
     // Make sure to wipe the private tabs if the user has the pref turned on
     if tab?.isPrivate == false
@@ -359,6 +366,7 @@ class TabManager: NSObject {
 
     if let tabId = tab?.id {
       SessionTab.setSelected(tabId: tabId)
+      persistLastSelectedTabId(tabId)
     }
 
     UIImpactFeedbackGenerator(style: .light).vibrate()
@@ -606,7 +614,7 @@ class TabManager: NSObject {
     saveTabOrder()
   }
 
-  private func saveTabOrder() {
+  private func saveTabOrder(synchronously: Bool = false) {
     if Preferences.Privacy.privateBrowsingOnly.value
       || (privateBrowsingManager.isPrivateBrowsing
         && !Preferences.Privacy.persistentPrivateBrowsing.value)
@@ -614,7 +622,7 @@ class TabManager: NSObject {
       return
     }
     let allTabIds = allTabs.compactMap { $0.id }
-    SessionTab.saveTabOrder(tabIds: allTabIds)
+    SessionTab.saveTabOrder(tabIds: allTabIds, synchronously: synchronously)
   }
 
   @MainActor func configureTab(
@@ -703,15 +711,40 @@ class TabManager: NSObject {
 
     let tabs =
       Preferences.Privacy.persistentPrivateBrowsing.value ? allTabs : tabs(isPrivate: false)
-    SessionTab.updateAll(
-      synchronously: synchronously,
-      tabs: tabs.compactMap({
-        if let sessionData = $0.sessionData {
-          return ($0.id, sessionData, $0.title ?? "", $0.visibleURL ?? TabManager.ntpInteralURL)
+    if synchronously {
+      SessionTab.persistTabs(
+        windowId: windowId,
+        tabs: tabs.map {
+          (
+            $0.id,
+            $0.sessionData ?? Data(),
+            $0.title ?? "",
+            $0.visibleURL ?? TabManager.ntpInteralURL,
+            $0.isPrivate
+          )
+        },
+        synchronously: true
+      )
+    } else {
+      SessionTab.updateAll(
+        synchronously: false,
+        tabs: tabs.map {
+          (
+            $0.id,
+            $0.sessionData ?? Data(),
+            $0.title ?? "",
+            $0.visibleURL ?? TabManager.ntpInteralURL
+          )
         }
-        return nil
-      })
-    )
+      )
+    }
+  }
+
+  /// Persists tab session data and tab order when the app backgrounds.
+  func persistSessionOnBackground() {
+    SessionWindow.createWindow(isSelected: true, uuid: windowId)
+    saveAllTabs(synchronously: true)
+    saveTabOrder(synchronously: true)
   }
 
   func saveTab(_ tab: some TabState, saveOrder: Bool = false) {
@@ -1058,6 +1091,12 @@ class TabManager: NSObject {
 
     SessionTab.delete(tabId: tab.id)
 
+    var lastSelectedByWindow = Preferences.Privacy.lastSelectedTabIdByWindow.value
+    if lastSelectedByWindow[windowId.uuidString] == tab.id.uuidString {
+      lastSelectedByWindow.removeValue(forKey: windowId.uuidString)
+      Preferences.Privacy.lastSelectedTabIdByWindow.value = lastSelectedByWindow
+    }
+
     currentTabs = tabs(isPrivate: tab.isPrivate)
 
     // Let's select the tab to be selected next.
@@ -1304,6 +1343,55 @@ class TabManager: NSObject {
     SessionTab.updateScreenshot(tabId: tab.id, screenshot: screenshot)
   }
 
+  @MainActor private func savedTabsForRestore(from allSaved: [SessionTab]? = nil) -> [SessionTab] {
+    if let allSaved {
+      return allSaved.sorted { $0.index < $1.index }
+    }
+    return SessionTab.all()
+  }
+
+  @MainActor private func reorderAllTabs(toMatch savedTabs: [SessionTab]) {
+    let tabIdOrder = savedTabs.map(\.tabId)
+    allTabs.sort {
+      let left = tabIdOrder.firstIndex(of: $0.id) ?? Int.max
+      let right = tabIdOrder.firstIndex(of: $1.id) ?? Int.max
+      return left < right
+    }
+  }
+
+  @MainActor private func resolveRestoredTabSelection(from savedTabs: [SessionTab]) -> (any TabState)?
+  {
+    let isPrivate = privateBrowsingManager.isPrivateBrowsing
+
+    if let lastId = Preferences.Privacy.lastSelectedTabIdByWindow.value[windowId.uuidString]
+      .flatMap(UUID.init),
+      let tab = getTabForID(lastId),
+      tab.isPrivate == isPrivate
+    {
+      return tab
+    }
+
+    if let selectedSaved = savedTabs.first(where: { $0.isSelected && $0.isPrivate == isPrivate }),
+      let tab = getTabForID(selectedSaved.tabId)
+    {
+      return tab
+    }
+
+    if let recentlyUsed = savedTabs.filter({ $0.isPrivate == isPrivate }).max(by: {
+      $0.lastUpdated < $1.lastUpdated
+    }), let tab = getTabForID(recentlyUsed.tabId) {
+      return tab
+    }
+
+    return tabsForCurrentMode.last
+  }
+
+  private func persistLastSelectedTabId(_ tabId: UUID) {
+    var lastSelectedByWindow = Preferences.Privacy.lastSelectedTabIdByWindow.value
+    lastSelectedByWindow[windowId.uuidString] = tabId.uuidString
+    Preferences.Privacy.lastSelectedTabIdByWindow.value = lastSelectedByWindow
+  }
+
   @MainActor fileprivate var restoreTabsInternal: (any TabState)? {
     var savedTabs = [SessionTab]()
 
@@ -1314,11 +1402,11 @@ class TabManager: NSObject {
       // then delete old tabs(background thread context)
       savedTabs = SessionTab.all(noOlderThan: autocloseTime)
       SessionTab.deleteAll(olderThan: autocloseTime)
+      savedTabs = savedTabsForRestore(from: savedTabs)
     } else {
-      savedTabs = SessionTab.all()
+      savedTabs = savedTabsForRestore()
     }
 
-    savedTabs = savedTabs.filter({ $0.sessionWindow?.windowId == windowId })
     if savedTabs.isEmpty { return nil }
 
     /// Cache on if we should shred a given domain.
@@ -1353,7 +1441,7 @@ class TabManager: NSObject {
       return shouldShredTab
     }
 
-    var tabToSelect: (any TabState)?
+    var restoredTabCount = 0
     for savedTab in savedTabs {
       if let tabURL = savedTab.url {
         // Provide an empty request to prevent a new tab from loading the home screen
@@ -1384,11 +1472,7 @@ class TabManager: NSObject {
         Task { @MainActor in
           tab.browserData?.setScreenshot(savedTab.screenshot)
         }
-
-        // Select the tab if it was selected and matches current mode (private vs regular)
-        if savedTab.isSelected && savedTab.isPrivate == privateBrowsingManager.isPrivateBrowsing {
-          tabToSelect = tab
-        }
+        restoredTabCount += 1
       } else {
         let tab = addTab(
           nil,
@@ -1400,26 +1484,19 @@ class TabManager: NSObject {
 
         tab.lastTitle = savedTab.title
         tab.browserData?.setScreenshot(savedTab.screenshot)
-
-        // Select the tab if it was selected and matches current mode (private vs regular)
-        if savedTab.isSelected && savedTab.isPrivate == privateBrowsingManager.isPrivateBrowsing {
-          tabToSelect = tab
-        }
+        restoredTabCount += 1
       }
     }
 
-    if let tabToSelect = tabToSelect ?? tabsForCurrentMode.last {
-      // Only tell our delegates that we restored tabs if we actually restored something
+    reorderAllTabs(toMatch: savedTabs)
+
+    if restoredTabCount > 0 {
       delegates.forEach {
         $0.get()?.tabManagerDidRestoreTabs(self)
       }
-
-      // No tab selection, since this is unfamiliar with launch timings (e.g. compiling blocklists)
-
-      // Must return inside this `if` to potentially return the conditional fallback
-      return tabToSelect
     }
-    return nil
+
+    return resolveRestoredTabSelection(from: savedTabs) ?? tabsForCurrentMode.last
   }
 
   func restoreTab(_ tab: some TabState) {
@@ -1467,12 +1544,15 @@ class TabManager: NSObject {
 
     isRestoring = true
     let tabToSelect = self.restoreTabsInternal
-    isRestoring = false
 
     // Always make sure there is at least one tab.
     let isPrivate =
       privateBrowsingManager.isPrivateBrowsing || Preferences.Privacy.privateBrowsingOnly.value
     return tabToSelect ?? self.addTab(isPrivate: isPrivate)
+  }
+
+  @MainActor func finishTabRestore() {
+    isRestoring = false
   }
 
   func restoreDeletedTabs(_ savedTabs: [any TabState]) {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Tabs/TabGrid/TabGridPrivateTabsSettingsView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Tabs/TabGrid/TabGridPrivateTabsSettingsView.swift
@@ -16,6 +16,8 @@ struct TabGridPrivateTabsSettings: View {
   @Environment(\.dismiss) private var dismiss
   @ObservedObject private var persistentPrivateBrowsing = Preferences.Privacy
     .persistentPrivateBrowsing
+  @ObservedObject private var rememberBrowsingMode = Preferences.Privacy
+    .rememberBrowsingMode
   @ObservedObject private var privateBrowsingLock = Preferences.Privacy.privateBrowsingLock
 
   private var authenticationKind: LABiometryType? {
@@ -62,7 +64,30 @@ struct TabGridPrivateTabsSettings: View {
               .foregroundStyle(Color(braveSystemName: .iconDefault))
           }
         }
+        .tint(Color.accentColor)
+        if persistentPrivateBrowsing.value {
+          Toggle(isOn: $rememberBrowsingMode.value) {
+            Label {
+              Text(Strings.TabsSettings.rememberBrowsingModeTitle)
         .tint(Color(braveSystemName: .primitivePrimary40))
+              Text(Strings.TabsSettings.rememberBrowsingModeDescription)
+                .foregroundStyle(Color(braveSystemName: .textSecondary))
+                .font(.footnote)
+            } icon: {
+              Image(braveSystemName: "leo.product.private-window")
+                .foregroundStyle(Color(braveSystemName: .iconDefault))
+            }
+          }
+          .onChange(of: rememberBrowsingMode.value) { _, newValue in
+            if newValue {
+              BrowserState.persistRememberedBrowsingMode(isPrivate: viewModel.isPrivateBrowsing)
+            } else {
+              Preferences.Privacy.lastPrivateBrowsingMode.value = false
+            }
+          }
+          .tint(Color.accentColor)
+          .listRowBackground(Color(uiColor: .secondaryBraveGroupedBackground))
+        }
 
         if let authenticationKind {
           Toggle(isOn: privateBrowsingLockBinding) {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Tabs/TabGrid/TabGridPrivateTabsSettingsView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Tabs/TabGrid/TabGridPrivateTabsSettingsView.swift
@@ -69,7 +69,7 @@ struct TabGridPrivateTabsSettings: View {
           Toggle(isOn: $rememberBrowsingMode.value) {
             Label {
               Text(Strings.TabsSettings.rememberBrowsingModeTitle)
-        .tint(Color(braveSystemName: .primitivePrimary40))
+                .tint(Color(braveSystemName: .primitivePrimary40))
               Text(Strings.TabsSettings.rememberBrowsingModeDescription)
                 .foregroundStyle(Color(braveSystemName: .textSecondary))
                 .font(.footnote)
@@ -86,7 +86,6 @@ struct TabGridPrivateTabsSettings: View {
             }
           }
           .tint(Color.accentColor)
-          .listRowBackground(Color(uiColor: .secondaryBraveGroupedBackground))
         }
 
         if let authenticationKind {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Tabs/TabGrid/TabGridViewModel.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Tabs/TabGrid/TabGridViewModel.swift
@@ -269,6 +269,9 @@ class TabGridViewModel {
 
   private func browsingModeDidSwitch(from oldValue: Bool) {
     tabManager.privateBrowsingManager.isPrivateBrowsing = isPrivateBrowsing
+    // Update UserDefaults immediately so a fast relaunch sees the correct mode.
+    // Session/userActivity state is persisted on background from BrowserViewController.
+    BrowserState.persistRememberedBrowsingMode(isPrivate: isPrivateBrowsing)
     if isPrivateTabsLocked {
       tabs = []
       return

--- a/ios/brave-ios/Sources/Brave/Frontend/ClientPreferences.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/ClientPreferences.swift
@@ -250,6 +250,23 @@ extension Preferences {
       key: "privacy.remember-browsing-mode",
       default: false
     )
+    /// Last browsing mode when the app was backgrounded (used to restore private mode on relaunch).
+    public static let lastPrivateBrowsingMode = Option<Bool>(
+      key: "privacy.last-private-browsing-mode",
+      default: false
+    )
+    /// Last selected tab per window (used to restore tab selection on relaunch).
+    public static let lastSelectedTabIdByWindow = Option<[String: String]>(
+      key: "privacy.last-selected-tab-id-by-window",
+      default: [:]
+    )
+    /// Canonical session window id for single-window restore (prevents tab/window id drift).
+    public static let lastSessionWindowId = Option<String?>(
+      key: "privacy.last-session-window-id",
+      default: nil
+    )
+    /// Blocks all cookies and access to local storage
+    static let blockAllCookies = Option<Bool>(key: "privacy.block-all-cookies", default: false)
     /// The toggles states for clear private data screen
     static let clearPrivateDataToggles = Option<[Bool]>(
       key: "privacy.clear-data-toggles",

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/Tabs/PrivateTabsView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/Tabs/PrivateTabsView.swift
@@ -18,6 +18,7 @@ struct PrivateTabsView: View {
 
   @ObservedObject var privateBrowsingOnly = Preferences.Privacy.privateBrowsingOnly
   @ObservedObject var persistentPrivateBrowsing = Preferences.Privacy.persistentPrivateBrowsing
+  @ObservedObject var rememberBrowsingMode = Preferences.Privacy.rememberBrowsingMode
   @ObservedObject var privateBrowsingLock = Preferences.Privacy.privateBrowsingLock
 
   var tabManager: TabManager?
@@ -79,7 +80,30 @@ struct PrivateTabsView: View {
             if newValue {
               tabManager?.saveAllTabs()
             } else {
+              Preferences.Privacy.lastPrivateBrowsingMode.value = false
               tabManager?.removeAllTabsForPrivateMode(isPrivate: true, isActiveTabIncluded: true)
+            }
+          }
+
+          if persistentPrivateBrowsing.value {
+            Toggle(isOn: $rememberBrowsingMode.value) {
+              VStack(alignment: .leading, spacing: 4) {
+                Text(Strings.TabsSettings.rememberBrowsingModeTitle)
+                  .foregroundStyle(Color(braveSystemName: .textPrimary))
+                Text(Strings.TabsSettings.rememberBrowsingModeDescription)
+                  .foregroundStyle(Color(braveSystemName: .textSecondary))
+                  .font(.footnote)
+              }
+            }
+            .toggleStyle(SwitchToggleStyle(tint: .accentColor))
+            .onChange(of: rememberBrowsingMode.value) { _, newValue in
+              if newValue {
+                BrowserState.persistRememberedBrowsingMode(
+                  isPrivate: tabManager?.privateBrowsingManager.isPrivateBrowsing == true
+                )
+              } else {
+                Preferences.Privacy.lastPrivateBrowsingMode.value = false
+              }
             }
           }
         }

--- a/ios/brave-ios/Sources/Brave/States/BrowserState.swift
+++ b/ios/brave-ios/Sources/Brave/States/BrowserState.swift
@@ -3,7 +3,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import Data
 import Foundation
+import Preferences
 import UIKit
 
 public class BrowserState {
@@ -38,25 +40,38 @@ public class BrowserState {
   }
 
   public static func userActivity(
-    for windowId: String
+    for windowId: String,
+    isPrivate: Bool? = nil
   ) -> NSUserActivity {
     return NSUserActivity(activityType: sceneId).then {
       $0.targetContentIdentifier = windowId
-      $0.addUserInfoEntries(from: [
+      var userInfo: [String: Any] = [
         SessionState.windowIDKey: windowId
-      ])
+      ]
+      if let isPrivate {
+        userInfo[SessionState.isPrivateKey] = isPrivate
+      }
+      $0.addUserInfoEntries(from: userInfo)
     }
   }
 
-  public static func setWindowId(for activity: NSUserActivity, windowId: String) {
+  public static func setWindowId(
+    for activity: NSUserActivity,
+    windowId: String,
+    isPrivate: Bool? = nil
+  ) {
     if activity.userInfo == nil {
       activity.userInfo = [:]
     }
 
     activity.targetContentIdentifier = windowId
-    activity.addUserInfoEntries(from: [
+    var userInfo: [String: Any] = [
       SessionState.windowIDKey: windowId
-    ])
+    ]
+    if let isPrivate {
+      userInfo[SessionState.isPrivateKey] = isPrivate
+    }
+    activity.addUserInfoEntries(from: userInfo)
   }
 
   public static func getWindowId(from session: UISceneSession) -> String? {
@@ -78,15 +93,88 @@ public class BrowserState {
     )
   }
 
-  public static func setWindowId(for session: UISceneSession, windowId: String) {
-    let userInfo: [String: Any] = [
+  public static func setWindowId(
+    for session: UISceneSession,
+    windowId: String,
+    isPrivate: Bool? = nil
+  ) {
+    var userInfo: [String: Any] = [
       SessionState.windowIDKey: windowId
     ]
+    if let isPrivate {
+      userInfo[SessionState.isPrivateKey] = isPrivate
+    }
 
     if session.userInfo == nil {
       session.userInfo = userInfo
     } else {
       session.userInfo?.merge(with: userInfo)
+    }
+  }
+
+  public static func getSessionState(from session: UISceneSession) -> SessionState {
+    guard let userInfo = session.userInfo else {
+      return SessionState(windowId: nil, isPrivate: false, openURL: nil)
+    }
+
+    return SessionState(
+      windowId: userInfo[SessionState.windowIDKey] as? String,
+      isPrivate: userInfo[SessionState.isPrivateKey] as? Bool == true,
+      openURL: nil
+    )
+  }
+
+  /// True when the user opted to remember private mode and private tabs are still on disk.
+  public static var shouldRestorePrivateBrowsingMode: Bool {
+    Preferences.Privacy.persistentPrivateBrowsing.value
+      && Preferences.Privacy.rememberBrowsingMode.value
+      && Preferences.Privacy.lastPrivateBrowsingMode.value
+      && SessionTab.all().contains(where: \.isPrivate)
+  }
+
+  /// Persists the browsing mode for scene restoration when "Remember Browsing Mode" is enabled.
+  public static func persistBrowsingMode(
+    session: UISceneSession,
+    userActivity: NSUserActivity?,
+    windowId: String,
+    isPrivate: Bool
+  ) {
+    setWindowId(for: session, windowId: windowId, isPrivate: isPrivate)
+    if let userActivity {
+      setWindowId(for: userActivity, windowId: windowId, isPrivate: isPrivate)
+    }
+  }
+
+  /// Browsing mode to persist when backgrounding with "Remember Browsing Mode" enabled.
+  public static func browsingModeToPersistOnBackground(isCurrentlyPrivate: Bool) -> Bool {
+    if isCurrentlyPrivate {
+      return true
+    }
+    return shouldRestorePrivateBrowsingMode
+  }
+
+  /// Persists the current browsing mode for relaunch when "Remember Browsing Mode" is enabled.
+  public static func persistRememberedBrowsingMode(
+    isPrivate: Bool,
+    session: UISceneSession? = nil,
+    userActivity: NSUserActivity? = nil,
+    windowId: String? = nil
+  ) {
+    guard Preferences.Privacy.persistentPrivateBrowsing.value,
+      Preferences.Privacy.rememberBrowsingMode.value
+    else {
+      return
+    }
+
+    Preferences.Privacy.lastPrivateBrowsingMode.value = isPrivate
+
+    if let session, let windowId {
+      persistBrowsingMode(
+        session: session,
+        userActivity: userActivity,
+        windowId: windowId,
+        isPrivate: isPrivate
+      )
     }
   }
 

--- a/ios/brave-ios/Sources/Data/models/SessionTab.swift
+++ b/ios/brave-ios/Sources/Data/models/SessionTab.swift
@@ -156,8 +156,8 @@ extension SessionTab {
 
   /// Marks the specified tab as selected
   /// Since only one tab can be active at a time, all other tabs are marked as deselected
-  public static func setSelected(tabId: UUID) {
-    DataController.perform { context in
+  public static func setSelected(tabId: UUID, synchronously: Bool = false) {
+    let update: (NSManagedObjectContext) -> Void = { context in
       guard let tab = Self.from(tabId: tabId, in: context) else { return }
 
       let predicate = NSPredicate(format: "isSelected == true")
@@ -166,6 +166,16 @@ extension SessionTab {
       }
 
       tab.isSelected = true
+
+      if synchronously, context.hasChanges {
+        try? context.save()
+      }
+    }
+
+    if synchronously {
+      DataController.performOnMainContext(task: update)
+    } else {
+      DataController.perform { update($0) }
     }
   }
 
@@ -195,8 +205,8 @@ extension SessionTab {
     }
   }
 
-  public static func saveTabOrder(tabIds: [UUID]) {
-    DataController.perform { context in
+  public static func saveTabOrder(tabIds: [UUID], synchronously: Bool = false) {
+    let update: (NSManagedObjectContext) -> Void = { context in
       for (index, tabId) in tabIds.enumerated() {
         guard let tab = Self.from(tabId: tabId, in: context) else {
           Logger.module.error("Error: SessionTab.updateScreenshot missing managed object")
@@ -204,6 +214,15 @@ extension SessionTab {
         }
         tab.index = Int32(index)
       }
+      if synchronously, context.hasChanges {
+        try? context.save()
+      }
+    }
+
+    if synchronously {
+      DataController.performOnMainContext(task: update)
+    } else {
+      DataController.perform { update($0) }
     }
   }
 
@@ -222,10 +241,72 @@ extension SessionTab {
         sessionTab.interactionState = tab.interactionState
         sessionTab.title = tab.title
         sessionTab.url = tab.url
+        sessionTab.lastUpdated = .now
       }
       if synchronously {
         try? context.save()
       }
+    }
+  }
+
+  /// Creates or updates session tabs for the given window
+  public static func persistTabs(
+    windowId: UUID,
+    tabs: [(
+      tabId: UUID,
+      interactionState: Data,
+      title: String,
+      url: URL,
+      isPrivate: Bool
+    )],
+    synchronously: Bool = true
+  ) {
+    let update: (NSManagedObjectContext) -> Void = { context in
+      guard let window = SessionWindow.ensureWindow(
+        windowId: windowId,
+        isSelected: true,
+        in: context
+      )
+      else {
+        Logger.module.error("Error: SessionTab.persistTabs missing session window")
+        return
+      }
+
+      for (index, tab) in tabs.enumerated() {
+        if let sessionTab = Self.from(tabId: tab.tabId, in: context) {
+          sessionTab.interactionState = tab.interactionState
+          sessionTab.title = tab.title
+          sessionTab.url = tab.url
+          sessionTab.lastUpdated = .now
+          sessionTab.index = Int32(index)
+          sessionTab.sessionWindow = window
+        } else {
+          _ = SessionTab(
+            context: context,
+            sessionWindow: window,
+            sessionTabGroup: nil,
+            index: Int32(index),
+            interactionState: tab.interactionState,
+            isPrivate: tab.isPrivate,
+            isSelected: false,
+            lastUpdated: .now,
+            screenshotData: Data(),
+            title: tab.title,
+            url: tab.url,
+            tabId: tab.tabId
+          )
+        }
+      }
+
+      if context.hasChanges {
+        try? context.save()
+      }
+    }
+
+    if synchronously {
+      DataController.performOnMainContext(task: update)
+    } else {
+      DataController.perform { update($0) }
     }
   }
 

--- a/ios/brave-ios/Sources/Data/models/SessionTab.swift
+++ b/ios/brave-ios/Sources/Data/models/SessionTab.swift
@@ -156,8 +156,8 @@ extension SessionTab {
 
   /// Marks the specified tab as selected
   /// Since only one tab can be active at a time, all other tabs are marked as deselected
-  public static func setSelected(tabId: UUID, synchronously: Bool = false) {
-    let update: (NSManagedObjectContext) -> Void = { context in
+  public static func setSelected(tabId: UUID) {
+    DataController.perform { context in
       guard let tab = Self.from(tabId: tabId, in: context) else { return }
 
       let predicate = NSPredicate(format: "isSelected == true")
@@ -166,16 +166,6 @@ extension SessionTab {
       }
 
       tab.isSelected = true
-
-      if synchronously, context.hasChanges {
-        try? context.save()
-      }
-    }
-
-    if synchronously {
-      DataController.performOnMainContext(task: update)
-    } else {
-      DataController.perform { update($0) }
     }
   }
 
@@ -205,8 +195,8 @@ extension SessionTab {
     }
   }
 
-  public static func saveTabOrder(tabIds: [UUID], synchronously: Bool = false) {
-    let update: (NSManagedObjectContext) -> Void = { context in
+  public static func saveTabOrder(tabIds: [UUID]) {
+    DataController.perform { context in
       for (index, tabId) in tabIds.enumerated() {
         guard let tab = Self.from(tabId: tabId, in: context) else {
           Logger.module.error("Error: SessionTab.updateScreenshot missing managed object")
@@ -214,25 +204,13 @@ extension SessionTab {
         }
         tab.index = Int32(index)
       }
-      if synchronously, context.hasChanges {
-        try? context.save()
-      }
-    }
-
-    if synchronously {
-      DataController.performOnMainContext(task: update)
-    } else {
-      DataController.perform { update($0) }
     }
   }
 
   public static func updateAll(
-    synchronously: Bool,
     tabs: [(tabId: UUID, interactionState: Data, title: String, url: URL)]
   ) {
-    DataController.perform(
-      context: synchronously ? .existing(DataController.viewContext) : .new(inMemory: false)
-    ) { context in
+    DataController.perform { context in
       for tab in tabs {
         guard let sessionTab = Self.from(tabId: tab.tabId, in: context) else {
           Logger.module.error("Error: SessionTab.updateAll missing managed object")
@@ -242,9 +220,6 @@ extension SessionTab {
         sessionTab.title = tab.title
         sessionTab.url = tab.url
         sessionTab.lastUpdated = .now
-      }
-      if synchronously {
-        try? context.save()
       }
     }
   }
@@ -258,15 +233,15 @@ extension SessionTab {
       title: String,
       url: URL,
       isPrivate: Bool
-    )],
-    synchronously: Bool = true
+    )]
   ) {
-    let update: (NSManagedObjectContext) -> Void = { context in
-      guard let window = SessionWindow.ensureWindow(
-        windowId: windowId,
-        isSelected: true,
-        in: context
-      )
+    DataController.perform { context in
+      guard
+        let window = SessionWindow.ensureWindow(
+          windowId: windowId,
+          isSelected: true,
+          in: context
+        )
       else {
         Logger.module.error("Error: SessionTab.persistTabs missing session window")
         return
@@ -297,16 +272,6 @@ extension SessionTab {
           )
         }
       }
-
-      if context.hasChanges {
-        try? context.save()
-      }
-    }
-
-    if synchronously {
-      DataController.performOnMainContext(task: update)
-    } else {
-      DataController.perform { update($0) }
     }
   }
 

--- a/ios/brave-ios/Sources/Data/models/SessionWindow.swift
+++ b/ios/brave-ios/Sources/Data/models/SessionWindow.swift
@@ -96,31 +96,39 @@ extension SessionWindow {
 
   public static func createWindow(isSelected: Bool, uuid: UUID) {
     DataController.performOnMainContext { context in
-      if let sessionWindow = SessionWindow.from(windowId: uuid, in: context) {
-        Self.all().forEach {
-          $0.isSelected = false
-        }
-
-        sessionWindow.isSelected = isSelected
-        return
-      }
-
-      let count = SessionWindow.count(context: context) ?? 0
-      let window = SessionWindow(
-        context: context,
-        index: Int32(count),
-        isSelected: isSelected
-      )
-      window.windowId = uuid
-
-      do {
-        try context.save()
-      } catch {
-        Logger.module.error(
-          "performTask save error: \(error.localizedDescription, privacy: .public)"
-        )
+      _ = ensureWindow(windowId: uuid, isSelected: isSelected, in: context)
+      if context.hasChanges {
+        try? context.save()
       }
     }
+  }
+
+  /// Returns an existing window or creates one with the given id in the supplied context.
+  @discardableResult
+  static func ensureWindow(
+    windowId: UUID,
+    isSelected: Bool,
+    in context: NSManagedObjectContext
+  ) -> SessionWindow? {
+    if let sessionWindow = SessionWindow.from(windowId: windowId, in: context) {
+      if isSelected {
+        let predicate = NSPredicate(format: "isSelected == true")
+        all(where: predicate, context: context)?.forEach {
+          $0.isSelected = false
+        }
+        sessionWindow.isSelected = true
+      }
+      return sessionWindow
+    }
+
+    let count = SessionWindow.count(context: context) ?? 0
+    let window = SessionWindow(
+      context: context,
+      index: Int32(count),
+      isSelected: isSelected
+    )
+    window.windowId = windowId
+    return window
   }
 
   /// Marks the specified window as selected


### PR DESCRIPTION
## Summary

There was a data race condition that occurred on consecutive iPad relaunches, private mode was inferred from Core Data tab state and scene restoration data that often hadn’t been flushed yet, and a failed launch could overwrite the saved private-mode flag before the next relaunch — the setting stayed enabled, but the app sometimes reopened in regular mode instead of private.

- Persist browsing mode reliably via a new `lastPrivateBrowsingMode` preference, scene session state, and synchronous tab/selection saves on background
- Improve launch resolution with `resolveLaunchIsPrivate()` and better `windowId` fallback when session state is stale
- Prevent launch-time state from overwriting saved private mode, and preserve browsing mode during tab restore when "Remember Browsing Mode" is enabled

## Root cause

On consecutive relaunches, private mode was inferred from Core Data tab selection and scene restoration state that often wasn't flushed yet. A failed launch could also write `isPrivate: false` back into scene state, breaking the next relaunch.

https://github.com/user-attachments/assets/d22935c1-5525-4468-9053-17a7074cc307

## Test plan

### Setup

- [ ] Use an **iPad** (simulator or device)
- [ ] Go to **Settings → Tabs → Private Tabs**
- [ ] Enable **Keep Private Tabs**
- [ ] Enable **Remember Browsing Mode**
- [ ] Open one or more **private tabs** and browse to a real page (not just NTP)

### Consecutive relaunch — private mode (primary repro)

- [ ] Confirm you are in **private browsing mode**
- [ ] Quit Brave (Home gesture / app switcher)
- [ ] Relaunch Brave immediately
- [ ] Confirm Brave reopens in **private mode** with private tabs restored
- [ ] Repeat background → relaunch **5–10 times in a row**, as quickly as possible
- [ ] Each relaunch should consistently reopen in **private mode**

### Consecutive relaunch — after mode switch

- [ ] Start in **private mode** with private tabs open
- [ ] Open tab grid and switch to **regular mode**
- [ ] Quit Brave and relaunch
- [ ] Confirm Brave reopens in **regular mode**
- [ ] Switch back to **private mode**, background, and relaunch 3–5 times
- [ ] Confirm Brave reopens in **private mode** each time

### Mixed tabs

- [ ] With both **regular and private tabs** open, select a **private tab**
- [ ] Quit and relaunch 3–5 times consecutively
- [ ] Confirm Brave reopens in **private mode** with the private tab(s) available

### Settings unchanged

- [ ] After several consecutive relaunches, open **Settings → Tabs → Private Tabs**
- [ ] Confirm **Keep Private Tabs** and **Remember Browsing Mode** are still **enabled**

### Regression — Remember Browsing Mode off

- [ ] Disable **Remember Browsing Mode** (keep **Keep Private Tabs** on)
- [ ] Open private tabs, quit, and relaunch
- [ ] Confirm app reopens in **regular mode**, but private tabs are still restorable via tab switcher

### Private Browsing Lock

- [ ] Enable **Private Browsing Lock**
- [ ] Relaunch from private mode and complete/cancel auth as appropriate
- [ ] Confirm behaviour matches lock setting (auth failure will fall back to regular mode by design)

### iPhone Regression Test
- [ ] Repeat the tests for iPhone
- [ ] Confirm behaviour is unchanged. Both iPad and iPhone now match.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/55515

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
