### PR TITLE
[iOS] [Origin] Initialize policy manager before profile creation

### DIFF
--- a/components/brave_policy/brave_profile_policy_provider.cc
+++ b/components/brave_policy/brave_profile_policy_provider.cc
@@ -53,23 +53,15 @@ void BraveProfilePolicyProvider::RefreshPolicies(
 bool BraveProfilePolicyProvider::IsInitializationComplete(
     policy::PolicyDomain domain) const {
   auto* manager = brave_origin::BraveOriginPolicyManager::GetInstance();
-#if !BUILDFLAG(IS_IOS)
-  // Desktop/Android only: short-circuit when our factory has not been
-  // registered in this process. This is the case for upstream unit tests
-  // (e.g. `ProfilePolicyConnectorTest`) that build `ProfilePolicyConnector`
-  // directly without going through Brave's keyed-service-factory startup --
-  // those tests have no Brave Origin source to wait for, so we report
-  // ready and let the upstream `OnPolicyServiceInitialized` signal fire
-  // normally.
-  //
-  // iOS does not run these upstream unit tests, and its own keyed-service
-  // startup always constructs `BraveOriginServiceFactory` (which lazily
-  // initializes `BraveOriginPolicyManager`). The gate below works there
-  // without the flag check.
+  // Short-circuit when the factory has not been registered in this process.
+  // This is the case for upstream unit tests (e.g.
+  // `ProfilePolicyConnectorTest`) that build `ProfilePolicyConnector` directly
+  // without going through Brave's keyed-service-factory startup -- those tests
+  // have no Brave Origin source to wait for, so we report ready and let the
+  // upstream `OnPolicyServiceInitialized` signal fire normally.
   if (!manager->IsExpectedToBeInitialized()) {
     return true;
   }
-#endif  // !BUILDFLAG(IS_IOS)
   // We observe both `BraveOriginPolicyManager` and
   // `AdBlockOnlyModePolicyManager` but they initialise on different schedules:
   // `AdBlockOnlyModePolicyManager` is initialised synchronously at process

--- a/ios/browser/brave_origin/brave_origin_service_factory.mm
+++ b/ios/browser/brave_origin/brave_origin_service_factory.mm
@@ -182,20 +182,19 @@ BraveOriginServiceFactory::BraveOriginServiceFactory()
                                     ServiceCreation::kCreateWithProfile,
                                     TestingCreation::kNoServiceForTests) {
   DependsOn(skus::SkusServiceFactory::GetInstance());
+  auto* policy_manager = BraveOriginPolicyManager::GetInstance();
+  policy_manager->SetExpectedToBeInitialized();
+  if (!policy_manager->IsInitialized()) {
+    policy_manager->Init(GetBrowserPolicyDefinitions(),
+                         GetProfilePolicyDefinitions(),
+                         GetApplicationContext()->GetLocalState());
+  }
 }
 
 BraveOriginServiceFactory::~BraveOriginServiceFactory() = default;
 
 std::unique_ptr<KeyedService>
 BraveOriginServiceFactory::BuildServiceInstanceFor(ProfileIOS* profile) const {
-  // Lazy initialization of BraveOriginPolicyManager
-  auto* policy_manager = BraveOriginPolicyManager::GetInstance();
-  if (!policy_manager->IsInitialized()) {
-    policy_manager->Init(GetBrowserPolicyDefinitions(),
-                         GetProfilePolicyDefinitions(),
-                         GetApplicationContext()->GetLocalState());
-  }
-
   auto skus_service_getter =
       base::BindRepeating(&skus::SkusServiceFactory::GetForProfile, profile);
 


### PR DESCRIPTION
This fixes a deadlock in which the Profile never completes its initialization so the app never shows the browser window
