### PR TITLE
Gate BraveRewardsDisabled policy on ENABLE_BRAVE_REWARDS

### DIFF
--- a/browser/brave_origin/BUILD.gn
+++ b/browser/brave_origin/BUILD.gn
@@ -5,6 +5,7 @@
 
 import("//brave/components/ai_chat/core/common/buildflags/buildflags.gni")
 import("//brave/components/brave_news/common/buildflags/buildflags.gni")
+import("//brave/components/brave_rewards/core/buildflags/buildflags.gni")
 import("//brave/components/brave_talk/buildflags/buildflags.gni")
 import("//brave/components/brave_vpn/common/buildflags/buildflags.gni")
 import("//brave/components/brave_wallet/common/buildflags/buildflags.gni")
@@ -33,6 +34,7 @@ source_set("brave_origin") {
     "//brave/components/brave_news/common/buildflags",
     "//brave/components/brave_policy",
     "//brave/components/brave_rewards/core",
+    "//brave/components/brave_rewards/core/buildflags",
     "//brave/components/brave_talk/buildflags",
     "//brave/components/brave_vpn/common/buildflags",
     "//brave/components/brave_wallet/common/buildflags",
@@ -116,6 +118,7 @@ source_set("unit_tests") {
     "//brave/browser/ui/brave_origin",
     "//brave/components/brave_origin",
     "//brave/components/brave_rewards/core",
+    "//brave/components/brave_rewards/core/buildflags",
     "//brave/components/constants",
     "//brave/components/p3a",
     "//chrome/browser/profiles",

--- a/browser/brave_origin/brave_origin_service_factory.cc
+++ b/browser/brave_origin/brave_origin_service_factory.cc
@@ -19,7 +19,7 @@
 #include "brave/components/brave_origin/brave_origin_policy_manager.h"
 #include "brave/components/brave_origin/brave_origin_service.h"
 #include "brave/components/brave_origin/profile_id.h"
-#include "brave/components/brave_rewards/core/pref_names.h"
+#include "brave/components/brave_rewards/core/buildflags/buildflags.h"
 #include "brave/components/brave_talk/buildflags/buildflags.h"
 #include "brave/components/brave_wallet/common/buildflags/buildflags.h"
 #include "brave/components/brave_wayback_machine/pref_names.h"
@@ -47,6 +47,10 @@
 
 #if BUILDFLAG(ENABLE_AI_CHAT)
 #include "brave/components/ai_chat/core/common/pref_names.h"
+#endif
+
+#if BUILDFLAG(ENABLE_BRAVE_REWARDS)
+#include "brave/components/brave_rewards/core/pref_names.h"
 #endif
 
 #if BUILDFLAG(ENABLE_BRAVE_NEWS)
@@ -135,11 +139,13 @@ constexpr auto kBraveOriginProfileMetadata =
              false,
              /*user_settable=*/true)},
 
+#if BUILDFLAG(ENABLE_BRAVE_REWARDS)
         // Brave Rewards preferences
         {brave_rewards::prefs::kDisabledByPolicy,
          BraveOriginServiceFactory::BraveOriginPrefMetadata(
              true,
              /*user_settable=*/false)},
+#endif
 
 #if BUILDFLAG(ENABLE_BRAVE_WALLET)
         // Brave Wallet preferences

--- a/browser/brave_origin/brave_origin_service_factory_unittest.cc
+++ b/browser/brave_origin/brave_origin_service_factory_unittest.cc
@@ -8,7 +8,8 @@
 #include "base/containers/map_util.h"
 #include "brave/browser/policy/brave_simple_policy_map.h"
 #include "brave/components/brave_origin/brave_origin_policy_info.h"
-#include "brave/components/brave_rewards/core/pref_names.h"
+#include "brave/components/brave_origin/buildflags/buildflags.h"
+#include "brave/components/brave_rewards/core/buildflags/buildflags.h"
 #include "brave/components/constants/pref_names.h"
 #include "brave/components/p3a/pref_names.h"
 #include "chrome/test/base/testing_browser_process.h"
@@ -17,6 +18,10 @@
 #include "components/policy/policy_constants.h"
 #include "content/public/test/browser_task_environment.h"
 #include "testing/gtest/include/gtest/gtest.h"
+
+#if BUILDFLAG(ENABLE_BRAVE_REWARDS)
+#include "brave/components/brave_rewards/core/pref_names.h"
+#endif
 
 #if BUILDFLAG(ENABLE_TOR)
 #include "brave/components/tor/pref_names.h"
@@ -59,10 +64,12 @@ TEST(BraveOriginServiceFactoryTest,
   EXPECT_EQ(tor_info->brave_origin_pref_key, tor::prefs::kTorDisabled);
 #endif
 
+#if BUILDFLAG(ENABLE_BRAVE_REWARDS)
   // Test that profile-level policies are NOT in browser definitions
   EXPECT_FALSE(
       browser_policy_definitions.contains(policy::key::kBraveRewardsDisabled))
       << "Profile-level policy should not be in browser definitions";
+#endif
 }
 
 TEST(BraveOriginServiceFactoryTest,
@@ -70,6 +77,7 @@ TEST(BraveOriginServiceFactoryTest,
   auto profile_policy_definitions =
       BraveOriginServiceFactory::GetProfilePolicyDefinitions();
 
+#if BUILDFLAG(ENABLE_BRAVE_REWARDS)
   // Test that Brave Rewards disabled policy is correctly built (profile-level)
   const auto* rewards_info = base::FindOrNull(
       profile_policy_definitions, policy::key::kBraveRewardsDisabled);
@@ -80,6 +88,7 @@ TEST(BraveOriginServiceFactoryTest,
   EXPECT_EQ(rewards_info->user_settable, false);
   EXPECT_EQ(rewards_info->brave_origin_pref_key,
             brave_rewards::prefs::kDisabledByPolicy);
+#endif
 
   // Test that browser-level policies are NOT in profile definitions
   EXPECT_FALSE(
@@ -145,9 +154,13 @@ TEST(BraveOriginServiceFactoryTest,
   EXPECT_GE(browser_policy_definitions.size(), 2u)
       << "Should have at least P3A and Stats browser policies";
 
-  // Verify that we have profile-level policies
+  // Verify that we have profile-level policies. On Brave Origin builds the
+  // features that contribute profile policies (Rewards, Wallet, Wayback, etc.)
+  // are all compiled out, so the intersection is legitimately empty there.
+#if !BUILDFLAG(IS_BRAVE_ORIGIN_BRANDED)
   EXPECT_GT(profile_policy_definitions.size(), 0u)
       << "Should have at least some profile policies";
+#endif
 }
 
 // Verifies that every policy claimed by Brave Origin is actually enforceable

--- a/browser/policy/BUILD.gn
+++ b/browser/policy/BUILD.gn
@@ -5,6 +5,7 @@
 
 import("//brave/components/ai_chat/core/common/buildflags/buildflags.gni")
 import("//brave/components/brave_news/common/buildflags/buildflags.gni")
+import("//brave/components/brave_rewards/core/buildflags/buildflags.gni")
 import("//brave/components/brave_talk/buildflags/buildflags.gni")
 import("//brave/components/brave_vpn/common/buildflags/buildflags.gni")
 import("//brave/components/brave_wallet/common/buildflags/buildflags.gni")
@@ -24,6 +25,7 @@ source_set("brave_simple_policy_map") {
     "//brave/components/ai_chat/core/common/buildflags",
     "//brave/components/brave_news/common/buildflags",
     "//brave/components/brave_rewards/core",
+    "//brave/components/brave_rewards/core/buildflags",
     "//brave/components/brave_shields/core/common",
     "//brave/components/brave_sync:prefs",
     "//brave/components/brave_talk/buildflags",

--- a/browser/policy/brave_simple_policy_map.h
+++ b/browser/policy/brave_simple_policy_map.h
@@ -8,7 +8,7 @@
 
 #include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
 #include "brave/components/brave_news/common/buildflags/buildflags.h"
-#include "brave/components/brave_rewards/core/pref_names.h"
+#include "brave/components/brave_rewards/core/buildflags/buildflags.h"
 #include "brave/components/brave_shields/core/common/pref_names.h"
 #include "brave/components/brave_sync/brave_sync_prefs.h"
 #include "brave/components/brave_talk/buildflags/buildflags.h"
@@ -32,6 +32,10 @@
 
 #if BUILDFLAG(ENABLE_AI_CHAT)
 #include "brave/components/ai_chat/core/common/pref_names.h"
+#endif
+
+#if BUILDFLAG(ENABLE_BRAVE_REWARDS)
+#include "brave/components/brave_rewards/core/pref_names.h"
 #endif
 
 #if BUILDFLAG(ENABLE_TOR)
@@ -77,8 +81,10 @@
 namespace policy {
 
 inline constexpr PolicyToPreferenceMapEntry kBraveSimplePolicyMap[] = {
+#if BUILDFLAG(ENABLE_BRAVE_REWARDS)
     {policy::key::kBraveRewardsDisabled,
      brave_rewards::prefs::kDisabledByPolicy, base::Value::Type::BOOLEAN},
+#endif
 #if BUILDFLAG(ENABLE_BRAVE_WALLET)
     {policy::key::kBraveWalletDisabled,
      brave_wallet::kBraveWalletDisabledByPolicy, base::Value::Type::BOOLEAN},

--- a/components/brave_origin/brave_origin_service.cc
+++ b/components/brave_origin/brave_origin_service.cc
@@ -262,6 +262,7 @@ void BraveOriginService::OnCredentialSummary(
   }
 #endif
 
+  LOG(ERROR) << "-----------OnCredentiaSummary Set Purchased: " << purchased;
   BraveOriginPolicyManager::GetInstance()->SetPurchased(purchased);
 
   // Persist enforcement state so NeedsRestart() can detect first-purchase


### PR DESCRIPTION
## Summary

- Brave Origin builds set `enable_brave_rewards = !is_brave_origin_branded`, so Rewards is compiled out — but `BraveRewardsDisabled` was still registered in `kBraveSimplePolicyMap` unconditionally, so it appeared on `brave://policy`.
- Wrap the `BraveRewardsDisabled` entry in `kBraveSimplePolicyMap` and the matching `kBraveOriginProfileMetadata` entry in `#if BUILDFLAG(ENABLE_BRAVE_REWARDS)`, mirroring how Wallet, Talk, AI Chat, etc. are already gated.
- Unit test assertions and BUILD.gn rewards deps move under the same buildflag.

Fixes https://github.com/brave/brave-browser/issues/55558

## Test plan

- [x] Build a Brave Origin branded build; visit `brave://policy` and confirm `BraveRewardsDisabled` is no longer listed.
- [x] Build a regular (non-Brave-Origin) Brave; visit `brave://policy` and confirm `BraveRewardsDisabled` still appears and works as before.