### PR TITLE
[ads] Fix AdsService init race in ViewCounterService

### DIFF
--- a/components/ntp_background_images/browser/BUILD.gn
+++ b/components/ntp_background_images/browser/BUILD.gn
@@ -118,6 +118,8 @@ source_set("test_support") {
   sources = [
     "ntp_background_images_service_waiter.cc",
     "ntp_background_images_service_waiter.h",
+    "test/fake_ntp_background_images_service.cc",
+    "test/fake_ntp_background_images_service.h",
   ]
 }
 
@@ -146,6 +148,7 @@ source_set("unit_tests") {
 
   deps = [
     ":browser",
+    ":test_support",
     "//base",
     "//base/test:test_support",
     "//brave/components/brave_rewards/core",

--- a/components/ntp_background_images/browser/test/fake_ntp_background_images_service.cc
+++ b/components/ntp_background_images/browser/test/fake_ntp_background_images_service.cc
@@ -1,0 +1,25 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/ntp_background_images/browser/test/fake_ntp_background_images_service.h"
+
+namespace ntp_background_images {
+
+FakeNTPBackgroundImagesService::FakeNTPBackgroundImagesService(
+    variations::VariationsService* variations_service,
+    component_updater::ComponentUpdateService* component_update_service,
+    PrefService* pref_service)
+    : NTPBackgroundImagesService(variations_service,
+                                 component_update_service,
+                                 pref_service) {}
+
+FakeNTPBackgroundImagesService::~FakeNTPBackgroundImagesService() = default;
+
+void FakeNTPBackgroundImagesService::RegisterSponsoredImagesComponent() {
+  NTPBackgroundImagesService::RegisterSponsoredImagesComponent();
+  ++register_sponsored_images_component_call_count_;
+}
+
+}  // namespace ntp_background_images

--- a/components/ntp_background_images/browser/test/fake_ntp_background_images_service.h
+++ b/components/ntp_background_images/browser/test/fake_ntp_background_images_service.h
@@ -1,0 +1,51 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_NTP_BACKGROUND_IMAGES_BROWSER_TEST_FAKE_NTP_BACKGROUND_IMAGES_SERVICE_H_
+#define BRAVE_COMPONENTS_NTP_BACKGROUND_IMAGES_BROWSER_TEST_FAKE_NTP_BACKGROUND_IMAGES_SERVICE_H_
+
+#include <cstddef>
+
+#include "brave/components/ntp_background_images/browser/ntp_background_images_service.h"
+
+class PrefService;
+
+namespace component_updater {
+class ComponentUpdateService;
+}  // namespace component_updater
+
+namespace variations {
+class VariationsService;
+}  // namespace variations
+
+namespace ntp_background_images {
+
+class FakeNTPBackgroundImagesService final : public NTPBackgroundImagesService {
+ public:
+  FakeNTPBackgroundImagesService(
+      variations::VariationsService* variations_service,
+      component_updater::ComponentUpdateService* component_update_service,
+      PrefService* pref_service);
+
+  FakeNTPBackgroundImagesService(const FakeNTPBackgroundImagesService&) =
+      delete;
+  FakeNTPBackgroundImagesService& operator=(
+      const FakeNTPBackgroundImagesService&) = delete;
+
+  ~FakeNTPBackgroundImagesService() override;
+
+  void RegisterSponsoredImagesComponent() override;
+
+  size_t register_sponsored_images_component_call_count() const {
+    return register_sponsored_images_component_call_count_;
+  }
+
+ private:
+  size_t register_sponsored_images_component_call_count_ = 0;
+};
+
+}  // namespace ntp_background_images
+
+#endif  // BRAVE_COMPONENTS_NTP_BACKGROUND_IMAGES_BROWSER_TEST_FAKE_NTP_BACKGROUND_IMAGES_SERVICE_H_

--- a/components/ntp_background_images/browser/view_counter_service.cc
+++ b/components/ntp_background_images/browser/view_counter_service.cc
@@ -72,6 +72,12 @@ ViewCounterService::ViewCounterService(
 
   if (ads_service_) {
     ads_service_->AddObserver(this);
+    if (ads_service_->IsInitialized()) {
+      // If `AdsService` was initialized before observer registration, the
+      // `ViewCounterService::OnDidInitializeAdsService` callback will not be
+      // called so we call it explicitly.
+      OnDidInitializeAdsService();
+    }
   }
 
   host_content_settings_map_->AddObserver(this);

--- a/components/ntp_background_images/browser/view_counter_service_unittest.cc
+++ b/components/ntp_background_images/browser/view_counter_service_unittest.cc
@@ -25,6 +25,7 @@
 #include "brave/components/ntp_background_images/browser/ntp_background_images_data.h"
 #include "brave/components/ntp_background_images/browser/ntp_background_images_service.h"
 #include "brave/components/ntp_background_images/browser/ntp_sponsored_images_data.h"
+#include "brave/components/ntp_background_images/browser/test/fake_ntp_background_images_service.h"
 #include "brave/components/ntp_background_images/browser/url_constants.h"
 #include "brave/components/ntp_background_images/browser/view_counter_model.h"
 #include "brave/components/ntp_background_images/buildflags/buildflags.h"
@@ -210,11 +211,10 @@ class ViewCounterServiceTest : public testing::Test {
         &prefs_, /* is_off_the_record=*/false, /*store_last_modified=*/false,
         /*restore_session=*/false, /*should_record_metrics=*/false);
 
-    background_images_service_ = std::make_unique<NTPBackgroundImagesService>(
-        /*variations_service=*/nullptr, /*component_updater_service=*/nullptr,
-        &local_state_);
-
-    BraveNTPCustomBackgroundService* custom_background_service = nullptr;
+    background_images_service_ =
+        std::make_unique<FakeNTPBackgroundImagesService>(
+            /*variations_service=*/nullptr,
+            /*component_updater_service=*/nullptr, &local_state_);
 
 #if BUILDFLAG(ENABLE_CUSTOM_BACKGROUND)
     auto custom_background_service_delegate =
@@ -224,17 +224,30 @@ class ViewCounterServiceTest : public testing::Test {
     custom_background_service_ =
         std::make_unique<BraveNTPCustomBackgroundService>(
             std::move(custom_background_service_delegate));
-
-    custom_background_service = custom_background_service_.get();
 #endif  // BUILDFLAG(ENABLE_CUSTOM_BACKGROUND)
 
+    ON_CALL(ads_service_mock_, IsInitialized)
+        .WillByDefault(testing::Return(false));
+
+    CreateViewCounterService();
+  }
+
+  void TearDown() override { host_content_settings_map_->ShutdownOnUIThread(); }
+
+  void SimulateAdsServiceInitialized() {
+    view_counter_service_->OnDidInitializeAdsService();
+  }
+
+  void CreateViewCounterService() {
+    BraveNTPCustomBackgroundService* custom_background_service = nullptr;
+#if BUILDFLAG(ENABLE_CUSTOM_BACKGROUND)
+    custom_background_service = custom_background_service_.get();
+#endif
     view_counter_service_ = std::make_unique<ViewCounterService>(
         host_content_settings_map_.get(), background_images_service_.get(),
         custom_background_service, &ads_service_mock_, &prefs_, &local_state_,
         /*is_supported_locale=*/true);
   }
-
-  void TearDown() override { host_content_settings_map_->ShutdownOnUIThread(); }
 
   void SetSponsoredImagesVisibility(bool should_show) {
     prefs_.SetBoolean(prefs::kNewTabPageShowSponsoredImagesBackgroundImage,
@@ -367,7 +380,7 @@ class ViewCounterServiceTest : public testing::Test {
 
   scoped_refptr<HostContentSettingsMap> host_content_settings_map_;
 
-  std::unique_ptr<NTPBackgroundImagesService> background_images_service_;
+  std::unique_ptr<FakeNTPBackgroundImagesService> background_images_service_;
 
 #if BUILDFLAG(ENABLE_CUSTOM_BACKGROUND)
   std::unique_ptr<BraveNTPCustomBackgroundService> custom_background_service_;
@@ -633,6 +646,28 @@ TEST_F(ViewCounterServiceTest, NewTabsCreatedDailyHistogram) {
   histogram_tester_.ExpectBucketCount(kNewTabsCreatedDailyHistogramName, 7, 1);
 
   histogram_tester_.ExpectTotalCount(kNewTabsCreatedDailyHistogramName, 25);
+}
+
+TEST_F(ViewCounterServiceTest,
+       RegistersSponsoredImagesComponentWhenAdsServiceIsAlreadyInitialized) {
+  EXPECT_EQ(0U, background_images_service_
+                    ->register_sponsored_images_component_call_count());
+
+  EXPECT_CALL(ads_service_mock_, IsInitialized).WillOnce(testing::Return(true));
+  CreateViewCounterService();
+
+  EXPECT_EQ(1U, background_images_service_
+                    ->register_sponsored_images_component_call_count());
+}
+
+TEST_F(ViewCounterServiceTest,
+       RegistersSponsoredImagesComponentWhenAdsServiceIsInitialized) {
+  EXPECT_EQ(0U, background_images_service_
+                    ->register_sponsored_images_component_call_count());
+
+  SimulateAdsServiceInitialized();
+  EXPECT_EQ(1U, background_images_service_
+                    ->register_sponsored_images_component_call_count());
 }
 
 }  // namespace ntp_background_images


### PR DESCRIPTION
If `AdsService` finishes initialization before `ViewCounterService` registers as an observer, the initialization callback never fires and the sponsored images component is never registered. Detect this condition after registering the observer and call the initialization handler explicitly when AdsService is already initialized.

## Test plan

* Fresh install
* Open brave://components
   EXPECTATION: `NTP Sponsored Images` is presented in the components list
* Restart the browser
* Open brave://components
   EXPECTATION: `NTP Sponsored Images` is presented in the components list

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/55707

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
