### PR TITLE
[Sync] Forbid screenshots of QR code / sync words

### DIFF
--- a/android/java/org/chromium/chrome/browser/settings/BraveSyncScreensPreference.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveSyncScreensPreference.java
@@ -1309,6 +1309,8 @@ public class BraveSyncScreensPreference extends BravePreferenceFragment
     private void setAddMobileDeviceLayout() {
         getActivity().setTitle(R.string.brave_sync_btn_mobile);
 
+        getActivity().getWindow().addFlags(WindowManager.LayoutParams.FLAG_SECURE);
+
         if (null != mScrollViewSyncInitial) {
             mScrollViewSyncInitial.setVisibility(View.GONE);
         }
@@ -1352,6 +1354,8 @@ public class BraveSyncScreensPreference extends BravePreferenceFragment
     private void setAddLaptopLayout() {
         getActivity().setTitle(R.string.brave_sync_btn_laptop);
 
+        getActivity().getWindow().addFlags(WindowManager.LayoutParams.FLAG_SECURE);
+
         if (null != mScrollViewSyncInitial) {
             mScrollViewSyncInitial.setVisibility(View.GONE);
         }
@@ -1389,6 +1393,8 @@ public class BraveSyncScreensPreference extends BravePreferenceFragment
     }
 
     private void setSyncDoneLayout() {
+        getActivity().getWindow().clearFlags(WindowManager.LayoutParams.FLAG_SECURE);
+
         if (!mDeviceInfoObserverSet) {
             BraveSyncDevices.get().addDeviceInfoChangedListener(this);
             mDeviceInfoObserverSet = true;


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/55701

This PR forbids taking screenshots of QR code / sync words at Sync screen.

<!-- Add brave-browser issue below that this PR will resolve -->

### Test Plan:
1. Create a Sync Chain
2. On devices list - it should be possible to make a screenshot
3. `Add New Device` => `Add a Mobile Device` => make a screenshot - should be black screen
4. `Code words`  => make a screenshot - should be black screen also
5. `Done` =>  it should be possible to make a screenshot


<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
