### PR TITLE
[AI Chat]: Use module output

### DIFF
--- a/components/ai_chat/resources/BUILD.gn
+++ b/components/ai_chat/resources/BUILD.gn
@@ -10,7 +10,6 @@ import("//tools/grit/preprocess_if_expr.gni")
 assert(enable_ai_chat)
 
 transpile_web_ui("ai_chat_ui") {
-  output_module = false
   resource_name = "ai_chat_ui"
   entry_points = [
     [


### PR DESCRIPTION
This causes AI Chat to generate ESModule output. We were already importing with `type=module` so this is the only change required. 

Seems to be working great!