### PR TITLE
Refactor BraveMultiContentsView inset zeroing

### DIFF
--- a/browser/ui/views/frame/split_view/brave_multi_contents_view.cc
+++ b/browser/ui/views/frame/split_view/brave_multi_contents_view.cc
@@ -35,8 +35,6 @@ BraveMultiContentsView::BraveMultiContentsView(
   // Use rounded corners margin as resize area's width.
   resize_area_->SetPreferredSize(
       gfx::Size(BraveContentsViewUtil::kMarginThickness, 0));
-  start_contents_view_inset_ = gfx::Insets();
-  end_contents_view_inset_ = gfx::Insets();
 }
 
 BraveMultiContentsView::~BraveMultiContentsView() = default;

--- a/browser/ui/views/split_view/split_view_browsertest.cc
+++ b/browser/ui/views/split_view/split_view_browsertest.cc
@@ -275,6 +275,15 @@ IN_PROC_BROWSER_TEST_F(SideBySideEnabledBrowserTest,
   EXPECT_FALSE(
       multi_contents_view->background_view_for_testing()->GetVisible());
 
+  // Brave zeroes kSplitViewContentInset via chromium_src so that
+  // MultiContentsView doesn't add insets — padding is handled by Brave's
+  // rounded corners feature instead. Content panes must fill the full height.
+  EXPECT_EQ(0, MultiContentsView::kSplitViewContentInset);
+  EXPECT_EQ(multi_contents_view->height(),
+            start_contents_container_view->height());
+  EXPECT_EQ(multi_contents_view->height(),
+            end_contents_container_view->height());
+
   FullscreenController* fullscreen_controller = browser()
                                                     ->GetFeatures()
                                                     .exclusive_access_manager()

--- a/chromium_src/chrome/browser/ui/views/frame/multi_contents_view.h
+++ b/chromium_src/chrome/browser/ui/views/frame/multi_contents_view.h
@@ -29,8 +29,16 @@
   GetContentsContainerViewFor_UnUsed(); \
   virtual ContentsContainerView* GetContentsContainerViewFor
 
+// kSplitViewContentInset is used both inside and outside MultiContentsView,
+// so override the constant to 0 rather than zeroing the inset fields in the
+// constructor. Brave controls padding via the rounded corners feature instead.
+#define kSplitViewContentInset \
+  kSplitViewContentInset = 0;  \
+  static constexpr int kSplitViewContentInset_UnUsed
+
 #include <chrome/browser/ui/views/frame/multi_contents_view.h>  // IWYU pragma: export
 
+#undef kSplitViewContentInset
 #undef GetContentsContainerViewFor
 #undef GetActiveContentsView
 #undef GetActiveContentsContainerView


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/55710

This PR doesn't change any behavior. Just simple refactoring.

`kSplitViewContentInset` is now referenced both inside and outside `MultiContentsView`
(as of cr149). The previous approach of zeroing `start_contents_view_inset_` /
`end_contents_view_inset_` in the `BraveMultiContentsView` constructor only covered the
inset fields, not the constant itself.

This PR overrides `kSplitViewContentInset = 0` via a `chromium_src` macro, so any usage
site — inside or outside `MultiContentsView` — sees zero. Brave controls split-view
padding through its own rounded corners feature, not via Chromium's default 8px insets.
 
## Changes

- Remove the explicit inset zeroing from `BraveMultiContentsView` constructor
- Add `chromium_src` constant override for `kSplitViewContentInset = 0`
- Add inset checks to `BraveMultiContentsViewTest` verifying the constant is 0 and content panes fill the full height

## Test plan

- [ ] `BraveMultiContentsViewTest` passes (new assertions: `kSplitViewContentInset == 0`, content panes fill full height)
- [ ] Split view opens and displays correctly with no unexpected insets

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
