### PR TITLE
Fix Windows caption button container height calc

### DIFF
--- a/browser/ui/views/frame/BUILD.gn
+++ b/browser/ui/views/frame/BUILD.gn
@@ -117,6 +117,7 @@ source_set("browser_tests") {
 
     deps += [
       "//base/test:test_support",
+      "//brave/browser/ui:brave_tab_prefs",
       "//chrome/browser/ui/tabs:features",
       "//chrome/browser/ui/views/frame",
     ]

--- a/browser/ui/views/frame/brave_browser_frame_view_win.cc
+++ b/browser/ui/views/frame/brave_browser_frame_view_win.cc
@@ -161,9 +161,42 @@ void BraveBrowserFrameViewWin::LayoutCaptionButtons() {
             : width() - caption_button_container_->width());
   }
 
+  if (auto* browser = GetBrowserView()->browser();
+      tabs::utils::ShouldShowBraveVerticalTabs(browser)) {
+    // Investigate why calculated container height is 1px longer than
+    // around.(ex, title bar or toolbar height).
+    int caption_button_container_height_delta = -1;
+
+    if (!tabs::utils::ShouldShowWindowTitleForVerticalTabs(browser)) {
+      // Upstream added 2px vertical padding but it doesn't fit with brave.
+      // See BrowserFrameViewWin::TitlebarMaximizedVisualHeight().
+      caption_button_container_height_delta += -2;
+    }
+    auto size = caption_button_container_->size();
+    size.Enlarge(0, caption_button_container_height_delta);
+    caption_button_container_->SetSize(size);
+  }
+
   // See the comment in BraveOpaqueBrowserFrameView::Layout().
   static_cast<BraveToolbarView*>(GetBrowserView()->toolbar())
       ->UpdateHorizontalPadding();
+}
+
+int BraveBrowserFrameViewWin::FrameTopBorderThickness(bool restored) const {
+  const bool is_fullscreen =
+      (browser_widget()->IsFullscreen() || IsMaximized()) && !restored;
+
+  if (is_fullscreen) {
+    return BrowserFrameViewWin::FrameTopBorderThickness(restored);
+  }
+
+  if (auto* browser = GetBrowserView()->browser();
+      tabs::utils::ShouldShowBraveVerticalTabs(browser) &&
+      !tabs::utils::ShouldShowWindowTitleForVerticalTabs(browser)) {
+    return 0;
+  }
+
+  return BrowserFrameViewWin::FrameTopBorderThickness(restored);
 }
 
 BEGIN_METADATA(BraveBrowserFrameViewWin)

--- a/browser/ui/views/frame/brave_browser_frame_view_win.cc
+++ b/browser/ui/views/frame/brave_browser_frame_view_win.cc
@@ -163,8 +163,9 @@ void BraveBrowserFrameViewWin::LayoutCaptionButtons() {
 
   if (auto* browser = GetBrowserView()->browser();
       tabs::utils::ShouldShowBraveVerticalTabs(browser)) {
-    // Investigate why calculated container height is 1px longer than
-    // around.(ex, title bar or toolbar height).
+    // TODO(https://github.com/brave/brave-browser/issues/55744): Investigate
+    // why calculated container height is 1px longer than around.(ex, title bar
+    // or toolbar height).
     int caption_button_container_height_delta = -1;
 
     if (!tabs::utils::ShouldShowWindowTitleForVerticalTabs(browser)) {

--- a/browser/ui/views/frame/brave_browser_frame_view_win.h
+++ b/browser/ui/views/frame/brave_browser_frame_view_win.h
@@ -36,6 +36,7 @@ class BraveBrowserFrameViewWin : public BrowserFrameViewWin {
   int NonClientHitTest(const gfx::Point& point) override;
   bool ShouldShowWindowTitle(TitlebarType type) const override;
   void LayoutCaptionButtons() override;
+  int FrameTopBorderThickness(bool restored) const override;
 
   std::unique_ptr<BraveWindowFrameGraphic> frame_graphic_;
 

--- a/browser/ui/views/frame/brave_browser_frame_view_win_browsertest.cc
+++ b/browser/ui/views/frame/brave_browser_frame_view_win_browsertest.cc
@@ -4,6 +4,8 @@
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #include "base/test/scoped_feature_list.h"
+#include "brave/browser/ui/tabs/brave_tab_prefs.h"
+#include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/tabs/features.h"
 #include "chrome/browser/ui/views/frame/browser_caption_button_container_win.h"
 #include "chrome/browser/ui/views/frame/browser_frame_view_win.h"
@@ -11,6 +13,7 @@
 #include "chrome/browser/ui/views/frame/top_container_view.h"
 #include "chrome/browser/win/titlebar_config.h"
 #include "chrome/test/base/in_process_browser_test.h"
+#include "components/prefs/pref_service.h"
 #include "content/public/test/browser_test.h"
 #include "ui/views/view_utils.h"
 
@@ -22,6 +25,12 @@
 // `BraveBrowserFrameViewWin::LayoutCaptionButtons()` applied an extra
 // `tabs::GetHorizontalTabControlsDelta()` Y-offset (negative in every mode)
 // that shifted the container upward and broke both alignments.
+//
+// Additional regression tests for vertical tab mode: when vertical tabs are
+// enabled, the caption button container spans from `WindowTopY()` below the
+// window top down to the web content area top (below the toolbar), matching
+// the height calc fix in `BraveBrowserFrameViewWin::LayoutCaptionButtons()`
+// and `BraveBrowserFrameViewWin::FrameTopBorderThickness()`.
 
 namespace {
 
@@ -104,6 +113,71 @@ INSTANTIATE_TEST_SUITE_P(,
                          testing::Bool(),
                          [](const testing::TestParamInfo<bool>& info) {
                            return info.param ? "Compact" : "Default";
+                         });
+
+// Parameterized fixture: bool param = show window title in vertical tab mode.
+class BraveBrowserFrameViewWinVerticalTabsLayoutTest
+    : public BraveBrowserFrameViewWinTest,
+      public testing::WithParamInterface<bool> {
+ public:
+  BraveBrowserFrameViewWinVerticalTabsLayoutTest() = default;
+};
+
+// Verifies that in vertical tab mode the caption button container:
+//   1. Has its top at window-top + WindowTopY().
+//   2. Has its bottom aligned with the web content area top (below toolbar).
+IN_PROC_BROWSER_TEST_P(BraveBrowserFrameViewWinVerticalTabsLayoutTest,
+                       CaptionButtonContainerAlignedWithTopContainerAndBorder) {
+  auto* frame = win_frame_view();
+  ASSERT_TRUE(frame) << "Expected BrowserFrameViewWin; wrong frame type";
+
+  if (!ShouldBrowserCustomDrawTitlebar(browser_view())) {
+    GTEST_SKIP() << "Custom titlebar not drawn (e.g. Mica enabled); "
+                    "caption button position is managed by the OS";
+  }
+
+  const bool show_title = GetParam();
+  auto* prefs = browser()->profile()->GetPrefs();
+  prefs->SetBoolean(brave_tabs::kVerticalTabsEnabled, true);
+  prefs->SetBoolean(brave_tabs::kVerticalTabsShowTitleOnWindow, show_title);
+  browser_view()->InvalidateLayout();
+  RunScheduledLayouts();
+
+  const auto* container = frame->caption_button_container_for_testing();
+  ASSERT_TRUE(container);
+
+  const gfx::Rect container_screen = container->GetBoundsInScreen();
+  const gfx::Rect window_screen = frame->GetWidget()->GetWindowBoundsInScreen();
+
+  const char* mode =
+      show_title ? "vertical tabs with title" : "vertical tabs without title";
+
+  // 1. Container top must be at window top + WindowTopY().
+  EXPECT_EQ(container_screen.y(), window_screen.y() + frame->WindowTopY())
+      << "Caption button container top (" << container_screen.y()
+      << ") must be window top (" << window_screen.y() << ") + WindowTopY ("
+      << frame->WindowTopY() << ") in " << mode;
+
+  // 2. Container bottom alignment depends on whether the window title is shown:
+  //    - With title: aligns with top_container top (toolbar row top)
+  //    - Without title: aligns with top_container bottom (content area top).
+  const gfx::Rect top_container_screen =
+      browser_view()->top_container()->GetBoundsInScreen();
+
+  // 1px overlapped.
+  const int expected_bottom = show_title ? top_container_screen.y()
+                                         : (top_container_screen.bottom() - 1);
+  EXPECT_EQ(container_screen.bottom(), expected_bottom)
+      << "Caption button container bottom (" << container_screen.bottom()
+      << ") must equal top_container " << (show_title ? "top" : "bottom")
+      << " (" << expected_bottom << ") in " << mode;
+}
+
+INSTANTIATE_TEST_SUITE_P(,
+                         BraveBrowserFrameViewWinVerticalTabsLayoutTest,
+                         testing::Bool(),
+                         [](const testing::TestParamInfo<bool>& info) {
+                           return info.param ? "WithTitle" : "WithoutTitle";
                          });
 
 }  // namespace

--- a/browser/ui/views/frame/brave_browser_view.cc
+++ b/browser/ui/views/frame/brave_browser_view.cc
@@ -1283,6 +1283,15 @@ ClientFrameElementInfo BraveBrowserView::GetFrameElementInfo() const {
   if (tabs::utils::ShouldShowBraveVerticalTabs(browser())) {
     // In case of Brave vertical tabs, we don't want to show the tabstrip.
     info.tabstrip_preferred_height = 0;
+
+#if BUILDFLAG(IS_WIN)
+    // On Windows, we need to set |toolbar_minimum_height| to calculate
+    // the correct caption button container height.
+    // See BrowserFrameViewWin::TitlebarMaximizedVisualHeight().
+    if (!tabs::utils::ShouldShowWindowTitleForVerticalTabs(browser())) {
+      info.toolbar_minimum_height = toolbar_->GetMinimumSize().height();
+    }
+#endif
   }
   return info;
 }

--- a/chromium_src/chrome/browser/ui/views/frame/browser_frame_view_win.h
+++ b/chromium_src/chrome/browser/ui/views/frame/browser_frame_view_win.h
@@ -13,9 +13,11 @@
   friend class BraveBrowserFrameViewWin
 #define ShouldShowWindowTitle virtual ShouldShowWindowTitle
 #define LayoutCaptionButtons virtual LayoutCaptionButtons
+#define FrameTopBorderThickness virtual FrameTopBorderThickness
 
 #include <chrome/browser/ui/views/frame/browser_frame_view_win.h>  // IWYU pragma: export
 
+#undef FrameTopBorderThickness
 #undef LayoutCaptionButtons
 #undef ShouldShowWindowTitle
 #undef client_view_bounds_


### PR DESCRIPTION
On Windows, `BrowserFrameViewWin` refers `ClientFrameElementInfo.toolbar_minimum_height`
when calculating caption button container's height.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/53074

<img width="321" height="117" alt="image" src="https://github.com/user-attachments/assets/3acbdf43-f626-4c53-a8a5-f81d2bdd4c0c" />
<img width="318" height="133" alt="image" src="https://github.com/user-attachments/assets/88cd3a64-49d4-495d-8686-12ac13c6c717" />
<img width="318" height="111" alt="image" src="https://github.com/user-attachments/assets/2678c718-d525-414d-a92d-2b00bfd073fd" />
<img width="305" height="129" alt="image" src="https://github.com/user-attachments/assets/3af69a32-02cd-4b63-9bd3-2bfd82f71aaa" />


<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
