### PR TITLE
Add more Omaha 4 macOS update failure logging

### DIFF
--- a/patches/chrome-updater-mac-.install.sh.patch
+++ b/patches/chrome-updater-mac-.install.sh.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/updater/mac/.install.sh b/chrome/updater/mac/.install.sh
-index 3b1874d09fca0cf88e361927dfea7c4273790030..2957229bb05423ca6f5df9d3e8bb72ca522b785d 100755
+index 3b1874d09fca0cf88e361927dfea7c4273790030..b5abcdf22df138367cf2da8f3eb1cabfd796b6b8 100755
 --- a/chrome/updater/mac/.install.sh
 +++ b/chrome/updater/mac/.install.sh
 @@ -322,7 +322,7 @@ main() {
@@ -20,20 +20,38 @@ index 3b1874d09fca0cf88e361927dfea7c4273790030..2957229bb05423ca6f5df9d3e8bb72ca
    note "update_app = ${update_app}"
  
    # Make sure that it's an absolute path.
-@@ -455,6 +455,12 @@ main() {
+@@ -455,6 +455,30 @@ main() {
    # directory unusable even for an instant.
    if [[ -n "${update_versioned_dir}" ]]; then
      note "rsyncing versioned directory"
 +    local debug_flags=0
 +    if [[ ! -d "${new_versioned_dir}" ]]; then
 +      debug_flags=1
-+      mkdir -p "${new_versioned_dir}" && (( debug_flags |= 2 ))
++      local mkdir_stderr
++      if ! mkdir_stderr="$(mkdir -p "${new_versioned_dir}" 2>&1 1>/dev/null)"
++      then
++        case "${mkdir_stderr}" in
++          *"Read-only file system"*)
++            exit 90 ;;
++          *"No space left on device"*|*"Disc quota exceeded"*)
++            exit 91 ;;
++          *"Operation not permitted"*)
++            exit 92 ;;
++          *"Permission denied"*)
++            exit 93 ;;
++          *"File exists"*|*"Not a directory"*)
++            exit 94 ;;
++          *)
++            exit 95 ;;
++        esac
++      fi
++      debug_flags=$((debug_flags | 2))
 +      rm -rf "${new_versioned_dir}"
 +    fi
      if ! rsync ${RSYNC_FLAGS} --delete-before "${update_versioned_dir}/" \
                                                "${new_versioned_dir}"; then
        err "rsync of versioned directory failed, status ${PIPESTATUS[0]}"
-@@ -463,7 +469,9 @@ main() {
+@@ -463,7 +487,9 @@ main() {
        # The incomplete version would break code signature validation.
        note "cleaning up new_versioned_dir"
        rm -rf "${new_versioned_dir}"

--- a/rewrite/chrome/updater/mac/.install.sh.toml
+++ b/rewrite/chrome/updater/mac/.install.sh.toml
@@ -34,14 +34,43 @@ replace = 'RSYNC_FLAGS="--ignore-times --links $(if [[ ${EUID} -eq 0 ]]; then ec
 # script still fails even when one of the fixes is successful. The motivation
 # for this is that right now, we only want to know which of the fixes (if any)
 # can be successful. In a future change, only the effective fixes will be kept.
+# The new exit codes have the following meanings:
+#  90 mkdir of new versioned directory failed: read-only file system (EROFS).
+#  91 mkdir of new versioned directory failed: no space / quota (ENOSPC/EDQUOT).
+#  92 mkdir of new versioned directory failed: operation not permitted (EPERM,
+#     e.g. App Management gate on macOS 13+, or endpoint security software).
+#  93 mkdir of new versioned directory failed: permission denied (EACCES,
+#     e.g. POSIX ownership or ACL mismatch on the installed bundle).
+#  94 mkdir of new versioned directory failed: non-directory at path
+#     (EEXIST/ENOTDIR; stale entry or TOCTOU with another process).
+#  95 mkdir of new versioned directory failed: unclassified (see logged stderr).
+
 [[substitution]]
-description = 'Initialize variable debug_flags'
+description = 'Probe mkdir, classify the failure, initialize debug_flags'
 pattern = 'note "rsyncing versioned directory"'
 replace = '''note "rsyncing versioned directory"
     local debug_flags=0
     if [[ ! -d "${new_versioned_dir}" ]]; then
       debug_flags=1
-      mkdir -p "${new_versioned_dir}" && (( debug_flags |= 2 ))
+      local mkdir_stderr
+      if ! mkdir_stderr="$(mkdir -p "${new_versioned_dir}" 2>&1 1>/dev/null)"
+      then
+        case "${mkdir_stderr}" in
+          *"Read-only file system"*)
+            exit 90 ;;
+          *"No space left on device"*|*"Disc quota exceeded"*)
+            exit 91 ;;
+          *"Operation not permitted"*)
+            exit 92 ;;
+          *"Permission denied"*)
+            exit 93 ;;
+          *"File exists"*|*"Not a directory"*)
+            exit 94 ;;
+          *)
+            exit 95 ;;
+        esac
+      fi
+      debug_flags=$((debug_flags | 2))
       rm -rf "${new_versioned_dir}"
     fi'''
 


### PR DESCRIPTION
This PR has the same goal and test plan as #36480.

I see in remote logs that the `mkdir -p "${new_versioned_dir}"` call fails. This PR makes it so I can hopefully see exactly why it fails.