### PR TITLE
[cr150][brockit] Rebase-v2 terminal needs to be interactive

### DIFF
--- a/tools/cr/brockit.py
+++ b/tools/cr/brockit.py
@@ -2207,16 +2207,19 @@ class Rebase(Task):
             ) == 'Windows' else 'true'
 
         try:
+            # `interactive=True` as we may need to open an editor if
+            # `EditorRecoverableFailure` is raised, so we can capture the pipes.
             terminal.run([
                 'git', 'rebase', '--interactive', '--autosquash',
                 '--empty=drop', '--onto', to_ref, from_ref, current_branch
             ],
-                         env=env)
+                         env=env,
+                         interactive=True)
             if recommit:
                 repository.brave.run_git('commit', '--amend', '--no-edit')
                 repository.brave.run_git('rebase', '--continue')
         except subprocess.CalledProcessError as e:
-            raise InvalidInputException(f'Rebase failed. {e.stderr}') from e
+            raise InvalidInputException('Rebase failed.') from e
 
 
 class Reassign(Task):

--- a/tools/cr/terminal.py
+++ b/tools/cr/terminal.py
@@ -229,7 +229,11 @@ class Terminal:
             self.update_status(truncate_on_max_length(" ".join(cmd)))
         logging.debug('λ %s', ' '.join(cmd))
 
-        if self.infra_mode:
+        # We don't want the keep alive messages to be printed when interactive
+        # is True, as we are delegating to the called command to provide its own
+        # feedback.
+        arm_keep_alive = self.infra_mode and not interactive
+        if arm_keep_alive:
             self.current_command_start_time = time.time()
             self.running_command = " ".join(cmd)
 
@@ -258,6 +262,12 @@ class Terminal:
                 'terminal.run(): `stdin=` is not supported with '
                 '`interactive=True` (the subprocess owns the tty).')
 
+        # The status spinner has to be stopped before running any commands in
+        # interactive mode, to not interfere with that process's output.
+        paused_status = self.status if interactive and self.status else None
+        if paused_status is not None:
+            paused_status.stop()
+
         try:
             result = subprocess.run(cmd,
                                     check=True,
@@ -271,7 +281,9 @@ class Terminal:
                 logging.debug('❯ %s', e.stderr.strip())
             raise e
         finally:
-            if self.infra_mode:
+            if paused_status is not None:
+                paused_status.start()
+            if arm_keep_alive:
                 self.current_command_start_time = None
                 self.running_command = None
 


### PR DESCRIPTION
This PR changes our `rebase --interactive` call to be use `terminal.run`
with `interactive=True`, so we don't capture the output of that command.
This will generate noise when running `brockit rebase`, however this is
necessary for the user to be able to use the editor opened due to
`EditorRecoverableFailure`.

There are also changes to `terminal`, to make sure we stop producing any
type of status update while `interactive=True` commands are ongoing.

Bug: https://github.com/brave/brave-browser/issues/55466
