### PR TITLE
[iOS] [Origin] Dont show sponsored images when rewards is unavailable

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -300,7 +300,8 @@ public class BrowserViewController: UIViewController {
     feedDataSource.historyAPI = profileController.historyAPI
     backgroundDataSource = .init(
       service: profileController.backgroundImagesService,
-      rewards: rewards,
+      rewards: BraveRewards.isSupported(prefService: profileController.profile.prefs)
+        ? rewards : nil,
       privateBrowsingManager: privateBrowsingManager
     )
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/Display/NewTabPageSettingsView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/Display/NewTabPageSettingsView.swift
@@ -9,6 +9,7 @@ import Preferences
 import SwiftUI
 
 struct NewTabPageSettingsView: View {
+  var isSponsoredBackgroundsSupported: Bool
   var shouldShowSponsoredImagesAndVideosSetting: Bool
   var linkTapped: ((URLRequest) -> Void)?
 
@@ -25,7 +26,7 @@ struct NewTabPageSettingsView: View {
       Section {
         Toggle(Strings.NTP.settingsBackgroundImages, isOn: $backgroundImages.value)
           .listRowBackground(Color(.secondaryBraveGroupedBackground))
-        if backgroundImages.value {
+        if backgroundImages.value, isSponsoredBackgroundsSupported {
           NavigationLink {
             BackgroundMediaTypePicker(
               shouldShowSponsoredImagesAndVideosSetting: shouldShowSponsoredImagesAndVideosSetting,
@@ -132,6 +133,7 @@ class NTPTableViewController: UIHostingController<NewTabPageSettingsView> {
   init(rewards: BraveRewards?, linkTapped: ((URLRequest) -> Void)?) {
     super.init(
       rootView: .init(
+        isSponsoredBackgroundsSupported: rewards != nil,
         shouldShowSponsoredImagesAndVideosSetting:
           rewards?.ads.shouldShowSponsoredImagesAndVideosSetting() == true,
         linkTapped: linkTapped

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/SettingsViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/SettingsViewController.swift
@@ -1167,7 +1167,8 @@ class SettingsViewController: TableViewController, BraveAccountAuthenticationObs
         selection: { [unowned self] in
           self.navigationController?.pushViewController(
             NTPTableViewController(
-              rewards: rewards,
+              rewards: BraveRewards.isSupported(prefService: braveCore.profile.prefs)
+                ? rewards : nil,
               linkTapped: { [unowned self] request in
                 self.tabManager.addTabAndSelect(
                   request,


### PR DESCRIPTION
This also hides the option from the NTP settings page

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/55703
 