### PR TITLE
[toolchain] Checkout the tag manually on the rust WASM builder

### DIFF
--- a/tools/cr/post_presubmit.py
+++ b/tools/cr/post_presubmit.py
@@ -18,6 +18,8 @@ Notice: Keep this script as *standalone*, with no deps to `tools/cr` code, so
 we can have no room for deps if downloaded and run on its own.
 """
 
+from __future__ import annotations
+
 import argparse
 import logging
 from pathlib import Path
@@ -26,6 +28,40 @@ import json
 import sys
 import hashlib
 from typing import Any
+
+
+def _check_call(*command,
+                capture_stdout: bool = False,
+                stdin: bytes | None = None) -> str | None:
+    """Run *command* as a subprocess, logging the invocation.
+
+    Logs the full command string at INFO level before executing it.  Stderr
+    is inherited from the parent process so subprocess output streams
+    directly to the terminal.
+
+    Args:
+        *command: The program and its arguments (passed as positional args,
+            not as a list).
+        capture_stdout: When `True`, capture the child's stdout and return it
+            as a UTF-8 decoded string.  When `False` (default), stdout is
+            inherited from the parent and the function returns `None`.
+        stdin: Optional bytes to send to the child's stdin.
+
+    Returns:
+        The decoded stdout if `capture_stdout=True`, otherwise `None`.
+
+    Raises:
+        subprocess.CalledProcessError: If the process exits with a non-zero
+            return code.
+    """
+    logging.info(' >>>> %s', ' '.join(str(a) for a in command))
+    result = subprocess.run(command,
+                            check=True,
+                            input=stdin,
+                            stdout=subprocess.PIPE if capture_stdout else None)
+    if capture_stdout:
+        return result.stdout.decode('utf-8', errors='replace')
+    return None
 
 
 def post_comments(presubmit_entries: dict[str, list[dict[str, Any]]],
@@ -41,12 +77,14 @@ def post_comments(presubmit_entries: dict[str, list[dict[str, Any]]],
             The pull request number where the comments will be posted.
     """
     # Get a list of existing comments for this PR
-    comments_response = subprocess.check_output([
-        'gh', 'api', f'repos/brave/brave-core/issues/{pr_number}/comments',
-        '--paginate', '--jq', '[.[] | {id: .id, body: .body}]'
-    ],
-                                                text=True,
-                                                stderr=subprocess.PIPE)
+    comments_response = _check_call(
+        'gh',
+        'api',
+        f'repos/brave/brave-core/issues/{pr_number}/comments',
+        '--paginate',
+        '--jq',
+        '[.[] | {id: .id, body: .body}]',
+        capture_stdout=True)
     logging.debug('Existing comments response: %s', comments_response)
     existing_comments: list[dict[str, Any]] = []
     for line in comments_response.splitlines():
@@ -121,14 +159,14 @@ def post_comments(presubmit_entries: dict[str, list[dict[str, Any]]],
 
             body_content += f'\n\n{comment_hash}'
 
-            subprocess.run([
-                'gh', 'api',
-                f'repos/brave/brave-core/issues/{pr_number}/comments', '-X',
-                'POST', '-F', 'body=@-'
-            ],
-                           input=body_content.encode('utf-8'),
-                           stderr=subprocess.PIPE,
-                           check=True)
+            _check_call('gh',
+                        'api',
+                        f'repos/brave/brave-core/issues/{pr_number}/comments',
+                        '-X',
+                        'POST',
+                        '-F',
+                        'body=@-',
+                        stdin=body_content.encode('utf-8'))
 
     # Now we delete the old comments that the hashes didn't come up.
     for comment in existing_comments:
@@ -140,12 +178,10 @@ def post_comments(presubmit_entries: dict[str, list[dict[str, Any]]],
         if comment_hash not in active_report_hashes:
             logging.info('Deleting comment with id %s, hash %s', comment["id"],
                          comment_hash)
-            subprocess.check_call([
+            _check_call(
                 'gh', 'api',
                 f'repos/brave/brave-core/issues/comments/{comment["id"]}',
-                '-X', 'DELETE'
-            ],
-                                  stderr=subprocess.PIPE)
+                '-X', 'DELETE')
 
 
 def validate_pr_number(value: str) -> str:
@@ -181,16 +217,7 @@ def main() -> int:
         logging.info('No presubmit entries found.')
         return 0
 
-    try:
-        post_comments(presubmit_entries, args.pr)
-    except subprocess.CalledProcessError as exception:
-        stderr = exception.stderr
-        if isinstance(stderr, bytes):
-            stderr = stderr.decode('utf-8', errors='replace')
-        logging.error(
-            'Subprocess command failed (return code %s): %s\nStderr: %s',
-            exception.returncode, exception.cmd, stderr if stderr else '')
-        raise
+    post_comments(presubmit_entries, args.pr)
 
     return 0
 

--- a/tools/cr/toolchain/build_rust_toolchain.py
+++ b/tools/cr/toolchain/build_rust_toolchain.py
@@ -69,6 +69,7 @@ import logging
 from pathlib import Path, PurePath
 import os
 import platform
+import re
 import shutil
 import subprocess
 import sys
@@ -414,12 +415,36 @@ class ToolchainBuilder:
                 'https://vhemnu34de4lf5cj6bx2wwshyy0egdxk.lambda-url.us-west-'
                 '2.on.aws/windows-hermetic-toolchain/')
 
+        if re.fullmatch(r'\d+\.\d+\.\d+\.\d+', ref):
+            # Chromium release tag (e.g. `150.0.7850.1`): fetch it as a tag so
+            # it lands at `refs/tags/<ref>` in the local repo.
+            _check_call('git',
+                        'fetch',
+                        '--no-tags',
+                        'origin',
+                        f'refs/tags/{ref}:refs/tags/{ref}',
+                        cwd=self.chromium_src)
+        else:
+            _check_call('git', 'fetch', 'origin', ref, cwd=self.chromium_src)
+
+        # We are doing a `git checkout --force` rather than just using
+        # `gclient sync -r {ref}`, as there is a an gclient bug that lurks
+        # around which is not clear if we are hitting on the window bot, so for
+        # the sake of preventing that to beging with, we do the checkout
+        # manually.
+        #
+        # For details see:
+        #   https://github.com/brave/brave-browser/issues/44921
+        _check_call('git',
+                    'checkout',
+                    '--force',
+                    'FETCH_HEAD',
+                    cwd=self.chromium_src)
+
         _check_call('gclient',
                     'sync',
                     '--force',
                     '-D',
-                    '-r',
-                    f'src@{ref}',
                     cwd=self.chromium_src)
         _check_call('git',
                     'log',
@@ -462,7 +487,6 @@ class ToolchainBuilder:
         self.chromium_src.parent.mkdir(parents=True, exist_ok=True)
         _check_call('fetch',
                     '--nohooks',
-                    '--nohistory',
                     'chromium',
                     cwd=self.chromium_src.parent)
 

--- a/tools/cr/toolchain/build_xcode_toolchain.py
+++ b/tools/cr/toolchain/build_xcode_toolchain.py
@@ -97,11 +97,11 @@ PACKAGE_DOWNLOAD_URL_BASE = (
 def _check_call(*command,
                 cwd=None,
                 capture_stdout: bool = False) -> str | None:
-    """Run *command* as a subprocess, logging the invocation and any stderr.
+    """Run *command* as a subprocess, logging the invocation.
 
-    Logs the full command string at INFO level before executing it.  If the
-    process exits with a non-zero return code, any captured stderr is logged
-    at WARNING level before the `CalledProcessError` is re-raised.
+    Logs the full command string at INFO level before executing it.  Stderr
+    is inherited from the parent process so subprocess output streams
+    directly to the terminal.
 
     Args:
         *command: The program and its arguments (passed as positional args,
@@ -121,17 +121,10 @@ def _check_call(*command,
     """
     logging.info(' >>>> %s', ' '.join(str(a) for a in command))
 
-    try:
-        result = subprocess.run(
-            command,
-            cwd=cwd,
-            check=True,
-            stdout=subprocess.PIPE if capture_stdout else None,
-            stderr=subprocess.PIPE)
-    except subprocess.CalledProcessError as e:
-        if e.stderr:
-            logging.warning(e.stderr.decode('utf-8', errors='replace').strip())
-        raise
+    result = subprocess.run(command,
+                            cwd=cwd,
+                            check=True,
+                            stdout=subprocess.PIPE if capture_stdout else None)
 
     if capture_stdout:
         return result.stdout.decode('utf-8', errors='replace')


### PR DESCRIPTION
This PR changes how the checkout works in the rust toolchain WASM
builder, to avoid the use of `gclient sync -r {ref}`. It is not clear if
we are having issues with it exactly, but the Windows pipeline keeps
hanging, and this particular long standing `gclient` issue has caused
pipeline issues before.

This PR also follows up on the work done by the previous one, and
updates all the other scripts to output the `stderr` the same way the
rust builder is doing.

Bug: https://github.com/brave/brave-browser/issues/44921
