### PR TITLE
[VPN 2.0] Add BraveVpnService stub v2 implementation and finalize split

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -3,8 +3,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import(
-    "//brave/browser/brave_vpn/win/brave_vpn_wireguard_service/allowlist.gni")
 import("//brave/build/config.gni")
 import("//brave/build/redirect_cc.gni")
 import("//brave/components/brave_vpn/common/buildflags/buildflags.gni")
@@ -22,6 +20,11 @@ import("//ui/base/ui_features.gni")
 
 if (enable_library_cdms) {
   import("//media/cdm/library_cdm/cdm_paths.gni")
+}
+
+if (enable_brave_vpn && enable_brave_vpn_v1) {
+  import(
+      "//brave/browser/brave_vpn/win/brave_vpn_wireguard_service/allowlist.gni")
 }
 
 if (!is_ios) {
@@ -771,7 +774,7 @@ if (is_win && enable_resource_allowlist_generation) {
   # Merge chrome_resource_allowlist and wireguard resources allowlist to keep
   # wireguard resources in pak files. When VPN is disabled, just copy the chrome
   # allowlist.
-  if (enable_brave_vpn) {
+  if (enable_brave_vpn && enable_brave_vpn_v1) {
     action("merge_allowlists") {
       deps = [
         "//brave/browser/brave_vpn/win/brave_vpn_wireguard_service:wireguard_resource_allowlist",

--- a/browser/DEPS
+++ b/browser/DEPS
@@ -134,6 +134,9 @@ specific_include_rules = {
     "!brave/components/l10n/common/locale_util.h",
     "!brave/components/l10n/common/ofac_sanction_util.h",
   ],
+  "brave_vpn_service_factory\.cc": [
+    "+brave/components/brave_vpn/v2/browser/brave_vpn_service_impl.h",
+  ],
   "brave_browser_process_impl\.cc": [
     "+brave/components/brave_component_updater/browser/brave_component_updater_delegate.h",
     "+brave/components/brave_component_updater/browser/local_data_files_service.h",

--- a/browser/brave_browser_process.h
+++ b/browser/brave_browser_process.h
@@ -25,7 +25,7 @@ class BraveReferralsService;
 class URLSanitizerComponentInstaller;
 }  // namespace brave
 
-#if BUILDFLAG(ENABLE_BRAVE_VPN)
+#if BUILDFLAG(ENABLE_BRAVE_VPN) && BUILDFLAG(ENABLE_BRAVE_VPN_V1)
 namespace brave_vpn {
 class BraveVPNConnectionManager;
 }  // namespace brave_vpn
@@ -125,7 +125,7 @@ class BraveBrowserProcess {
   virtual speedreader::SpeedreaderRewriterService*
   speedreader_rewriter_service() = 0;
 #endif
-#if BUILDFLAG(ENABLE_BRAVE_VPN)
+#if BUILDFLAG(ENABLE_BRAVE_VPN) && BUILDFLAG(ENABLE_BRAVE_VPN_V1)
   virtual brave_vpn::BraveVPNConnectionManager*
   brave_vpn_connection_manager() = 0;
 #endif

--- a/browser/brave_browser_process_impl.cc
+++ b/browser/brave_browser_process_impl.cc
@@ -107,8 +107,8 @@
 #include "brave/components/request_otr/common/features.h"
 #endif
 
-#if BUILDFLAG(ENABLE_BRAVE_VPN)
-#include "brave/browser/brave_vpn/vpn_utils.h"
+#if BUILDFLAG(ENABLE_BRAVE_VPN) && BUILDFLAG(ENABLE_BRAVE_VPN_V1)
+#include "brave/browser/brave_vpn/vpn_connection_manager_utils.h"
 #include "brave/components/brave_vpn/browser/connection/brave_vpn_connection_manager.h"
 #endif
 
@@ -531,7 +531,7 @@ BraveBrowserProcessImpl::speedreader_rewriter_service() {
 }
 #endif  // BUILDFLAG(ENABLE_SPEEDREADER)
 
-#if BUILDFLAG(ENABLE_BRAVE_VPN)
+#if BUILDFLAG(ENABLE_BRAVE_VPN) && BUILDFLAG(ENABLE_BRAVE_VPN_V1)
 brave_vpn::BraveVPNConnectionManager*
 BraveBrowserProcessImpl::brave_vpn_connection_manager() {
   if (brave_vpn_connection_manager_) {

--- a/browser/brave_browser_process_impl.h
+++ b/browser/brave_browser_process_impl.h
@@ -142,7 +142,7 @@ class BraveBrowserProcessImpl : public BraveBrowserProcess,
   speedreader::SpeedreaderRewriterService* speedreader_rewriter_service()
       override;
 #endif
-#if BUILDFLAG(ENABLE_BRAVE_VPN)
+#if BUILDFLAG(ENABLE_BRAVE_VPN) && BUILDFLAG(ENABLE_BRAVE_VPN_V1)
   brave_vpn::BraveVPNConnectionManager* brave_vpn_connection_manager() override;
 #endif
   misc_metrics::ProcessMiscMetrics* process_misc_metrics() override;
@@ -216,7 +216,7 @@ class BraveBrowserProcessImpl : public BraveBrowserProcess,
       speedreader_rewriter_service_;
 #endif
 
-#if BUILDFLAG(ENABLE_BRAVE_VPN)
+#if BUILDFLAG(ENABLE_BRAVE_VPN) && BUILDFLAG(ENABLE_BRAVE_VPN_V1)
   std::unique_ptr<brave_vpn::BraveVPNConnectionManager>
       brave_vpn_connection_manager_;
 #endif

--- a/browser/brave_vpn/BUILD.gn
+++ b/browser/brave_vpn/BUILD.gn
@@ -7,17 +7,32 @@ import("//brave/components/brave_vpn/common/buildflags/buildflags.gni")
 
 assert(enable_brave_vpn)
 
-source_set("brave_vpn") {
+source_set("shared") {
   sources = [
     "vpn_utils.cc",
     "vpn_utils.h",
   ]
 
   deps = [
-    "//brave/components/brave_vpn/browser/connection:api",
     "//brave/components/brave_vpn/common",
     "//brave/components/brave_vpn/common/buildflags",
     "//chrome/browser/profiles:profile",
+    "//components/prefs",
+    "//components/user_prefs",
+  ]
+}
+
+source_set("brave_vpn") {
+  sources = [
+    "vpn_connection_manager_utils.cc",
+    "vpn_connection_manager_utils.h",
+  ]
+
+  public_deps = [ ":shared" ]
+
+  deps = [
+    "//brave/components/brave_vpn/browser/connection:api",
+    "//brave/components/brave_vpn/common",
     "//chrome/common:channel_info",
     "//components/prefs",
     "//components/user_prefs",

--- a/browser/brave_vpn/brave_vpn_service_factory.cc
+++ b/browser/brave_vpn/brave_vpn_service_factory.cc
@@ -7,48 +7,60 @@
 
 #include <utility>
 
-#include "base/feature_list.h"
 #include "base/no_destructor.h"
-#include "brave/browser/brave_browser_process.h"
 #include "brave/browser/brave_vpn/vpn_utils.h"
-#include "brave/browser/misc_metrics/process_misc_metrics.h"
-#include "brave/browser/misc_metrics/uptime_monitor_impl.h"
 #include "brave/browser/skus/skus_service_factory.h"
 #include "brave/components/brave_vpn/browser/brave_vpn_service.h"
-#include "brave/components/brave_vpn/browser/brave_vpn_service_impl.h"
 #include "brave/components/brave_vpn/common/brave_vpn_utils.h"
-#include "brave/components/skus/common/features.h"
+#include "brave/components/brave_vpn/common/buildflags/buildflags.h"
 #include "build/build_config.h"
-#include "chrome/browser/browser_process.h"
-#include "chrome/browser/profiles/incognito_helpers.h"
 #include "chrome/browser/profiles/profile.h"
 #include "components/keyed_service/content/browser_context_dependency_manager.h"
-#include "components/user_prefs/user_prefs.h"
 #include "content/public/browser/browser_context.h"
-#include "content/public/browser/storage_partition.h"
 
+#if BUILDFLAG(ENABLE_BRAVE_VPN_V1)
+#include "base/functional/bind.h"
+#include "base/memory/weak_ptr.h"
+#include "brave/browser/brave_browser_process.h"
+#include "brave/browser/misc_metrics/process_misc_metrics.h"
+#include "brave/browser/misc_metrics/uptime_monitor_impl.h"
+#include "brave/components/brave_vpn/browser/brave_vpn_service_impl.h"
+#include "chrome/browser/browser_process.h"
+#include "components/user_prefs/user_prefs.h"
+#include "content/public/browser/storage_partition.h"
 #if BUILDFLAG(IS_WIN)
 #include "brave/browser/brave_vpn/dns/brave_vpn_dns_observer_factory_win.h"
 #include "brave/browser/brave_vpn/dns/brave_vpn_dns_observer_service_win.h"
 #include "brave/browser/brave_vpn/win/brave_vpn_service_delegate_win.h"
 #include "brave/browser/brave_vpn/win/brave_vpn_wireguard_observer_factory_win.h"
 #include "brave/browser/brave_vpn/win/brave_vpn_wireguard_observer_service_win.h"
-#endif
+#endif  // BUILDFLAG(IS_WIN)
+#endif  // BUILDFLAG(ENABLE_BRAVE_VPN_V1)
+
+#if BUILDFLAG(ENABLE_BRAVE_VPN_V2)
+#include "brave/components/brave_vpn/v2/browser/brave_vpn_service_impl.h"
+#endif  // BUILDFLAG(ENABLE_BRAVE_VPN_V2)
 
 namespace brave_vpn {
 namespace {
 
-std::unique_ptr<KeyedService> BuildVpnService(
-    content::BrowserContext* context) {
-  if (!brave_vpn::IsAllowedForContext(context)) {
-    return nullptr;
-  }
+#if BUILDFLAG(ENABLE_BRAVE_VPN_V2)
 
+std::unique_ptr<KeyedService> BuildVpnService_V2(
+    content::BrowserContext* context) {
+  // Return stub implementation.
+  return std::make_unique<v2::BraveVpnServiceImpl>();
+}
+
+#elif BUILDFLAG(ENABLE_BRAVE_VPN_V1)
+
+std::unique_ptr<KeyedService> BuildVpnService_V1(
+    content::BrowserContext* context) {
 #if !BUILDFLAG(IS_ANDROID)
   if (!g_brave_browser_process->brave_vpn_connection_manager()) {
     return nullptr;
   }
-#endif
+#endif  // !BUILDFLAG(IS_ANDROID)
 
   auto* default_storage_partition = context->GetDefaultStoragePartition();
   auto shared_url_loader_factory =
@@ -88,11 +100,26 @@ std::unique_ptr<KeyedService> BuildVpnService(
               ->GetServiceForContext(context)) {
     dns_observer_service->Observe(vpn_service.get());
   }
-#endif
+#endif  // BUILDFLAG(IS_WIN)
 
   return vpn_service;
 }
 
+#endif  // BUILDFLAG(ENABLE_BRAVE_VPN_V1)
+
+std::unique_ptr<KeyedService> BuildVpnService(
+    content::BrowserContext* context) {
+  if (!brave_vpn::IsAllowedForContext(context)) {
+    return nullptr;
+  }
+#if BUILDFLAG(ENABLE_BRAVE_VPN_V2)
+  return BuildVpnService_V2(context);
+#elif BUILDFLAG(ENABLE_BRAVE_VPN_V1)
+  return BuildVpnService_V1(context);
+#else
+  NOTREACHED() << "No VPN implementation enabled";
+#endif
+}
 }  // namespace
 
 // static
@@ -138,10 +165,10 @@ BraveVpnServiceFactory::BraveVpnServiceFactory()
           "BraveVpnService",
           BrowserContextDependencyManager::GetInstance()) {
   DependsOn(skus::SkusServiceFactory::GetInstance());
-#if BUILDFLAG(IS_WIN)
-  DependsOn(brave_vpn::BraveVpnWireguardObserverFactory::GetInstance());
-  DependsOn(brave_vpn::BraveVpnDnsObserverFactory::GetInstance());
-#endif
+#if BUILDFLAG(ENABLE_BRAVE_VPN_V1) && BUILDFLAG(IS_WIN)
+  DependsOn(BraveVpnWireguardObserverFactory::GetInstance());
+  DependsOn(BraveVpnDnsObserverFactory::GetInstance());
+#endif  // BUILDFLAG(ENABLE_BRAVE_VPN_V1) && BUILDFLAG(IS_WIN)
 }
 
 BraveVpnServiceFactory::~BraveVpnServiceFactory() = default;

--- a/browser/brave_vpn/sources.gni
+++ b/browser/brave_vpn/sources.gni
@@ -43,6 +43,7 @@ if (enable_brave_vpn) {
     "//base",
     "//brave/browser/brave_vpn",
     "//brave/components/brave_vpn/browser",
+    "//brave/components/brave_vpn/v2/browser",
     "//chrome/browser/profiles:profile",
     "//components/keyed_service/content",
     "//components/user_prefs",

--- a/browser/brave_vpn/vpn_connection_manager_utils.cc
+++ b/browser/brave_vpn/vpn_connection_manager_utils.cc
@@ -1,0 +1,82 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/brave_vpn/vpn_connection_manager_utils.h"
+
+#include "base/functional/bind.h"
+#include "base/memory/scoped_refptr.h"
+#include "base/notreached.h"
+#include "brave/components/brave_vpn/browser/connection/brave_vpn_connection_manager.h"
+#include "brave/components/brave_vpn/common/brave_vpn_utils.h"
+#include "build/build_config.h"
+#include "chrome/common/channel_info.h"
+#include "components/prefs/pref_service.h"
+#include "components/user_prefs/user_prefs.h"
+#include "services/network/public/cpp/shared_url_loader_factory.h"
+
+#if BUILDFLAG(IS_WIN)
+#include "brave/browser/brave_vpn/win/vpn_utils_win.h"
+#include "brave/browser/brave_vpn/win/wireguard_connection_api_impl_win.h"
+#include "brave/components/brave_vpn/browser/connection/ikev2/win/ras_connection_api_impl_win.h"
+#endif
+
+#if BUILDFLAG(IS_MAC)
+#include "brave/browser/brave_vpn/mac/vpn_utils_mac.h"
+#endif
+
+namespace brave_vpn {
+namespace {
+
+#if !BUILDFLAG(IS_ANDROID)
+std::unique_ptr<ConnectionAPIImpl> CreateConnectionAPIImpl(
+    BraveVPNConnectionManager* manager,
+    scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
+    bool wireguard_enabled) {
+#if BUILDFLAG(IS_MAC)
+  return CreateConnectionAPIImplMac(manager, url_loader_factory);
+#elif BUILDFLAG(IS_WIN)
+  if (wireguard_enabled) {
+    return std::make_unique<WireguardConnectionAPIImplWin>(manager,
+                                                           url_loader_factory);
+  }
+  return std::make_unique<RasConnectionAPIImplWin>(manager, url_loader_factory);
+#else
+  // VPN is not supported on other platforms.
+  NOTREACHED();
+#endif
+}
+#endif  // !BUILDFLAG(IS_ANDROID)
+
+}  // namespace
+
+std::unique_ptr<BraveVPNConnectionManager> CreateBraveVPNConnectionManager(
+    scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
+    PrefService* local_prefs) {
+#if BUILDFLAG(IS_ANDROID)
+  // Android doesn't use connection api.
+  return nullptr;
+#else
+  // Currently, service installer only used on Windows.
+  // Installs registers IKEv2 service (for DNS) and our WireGuard impl.
+  // NOTE: Install only happens if person has purchased the product.
+  auto service_installer =
+#if BUILDFLAG(IS_WIN)
+      base::BindRepeating(&brave_vpn::InstallVpnSystemServices);
+#else
+      base::NullCallback();
+#endif
+
+  auto manager = std::make_unique<BraveVPNConnectionManager>(
+      url_loader_factory, local_prefs, service_installer);
+  manager->set_target_vpn_entry_name(
+      brave_vpn::GetBraveVPNEntryName(chrome::GetChannel()));
+  manager->set_connection_api_impl_getter(
+      base::BindRepeating(&CreateConnectionAPIImpl));
+  manager->UpdateConnectionAPIImpl();
+  return manager;
+#endif
+}
+
+}  // namespace brave_vpn

--- a/browser/brave_vpn/vpn_connection_manager_utils.h
+++ b/browser/brave_vpn/vpn_connection_manager_utils.h
@@ -1,0 +1,29 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_BRAVE_VPN_VPN_CONNECTION_MANAGER_UTILS_H_
+#define BRAVE_BROWSER_BRAVE_VPN_VPN_CONNECTION_MANAGER_UTILS_H_
+
+#include <memory>
+
+#include "base/memory/scoped_refptr.h"
+
+namespace network {
+class SharedURLLoaderFactory;
+}  // namespace network
+
+class PrefService;
+
+namespace brave_vpn {
+
+class BraveVPNConnectionManager;
+
+std::unique_ptr<BraveVPNConnectionManager> CreateBraveVPNConnectionManager(
+    scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
+    PrefService* local_prefs);
+
+}  // namespace brave_vpn
+
+#endif  // BRAVE_BROWSER_BRAVE_VPN_VPN_CONNECTION_MANAGER_UTILS_H_

--- a/browser/brave_vpn/vpn_utils.cc
+++ b/browser/brave_vpn/vpn_utils.cc
@@ -5,84 +5,13 @@
 
 #include "brave/browser/brave_vpn/vpn_utils.h"
 
-#include "base/functional/bind.h"
-#include "base/memory/scoped_refptr.h"
-#include "base/notreached.h"
-#include "brave/components/brave_vpn/browser/connection/brave_vpn_connection_manager.h"
 #include "brave/components/brave_vpn/common/brave_vpn_utils.h"
-#include "brave/components/brave_vpn/common/buildflags/buildflags.h"
 #include "build/build_config.h"
 #include "chrome/browser/profiles/profile.h"
-#include "chrome/common/channel_info.h"
 #include "components/prefs/pref_service.h"
 #include "components/user_prefs/user_prefs.h"
-#include "services/network/public/cpp/shared_url_loader_factory.h"
-
-#if BUILDFLAG(IS_WIN)
-#include "brave/browser/brave_vpn/win/vpn_utils_win.h"
-#include "brave/browser/brave_vpn/win/wireguard_connection_api_impl_win.h"
-#include "brave/components/brave_vpn/browser/connection/ikev2/win/ras_connection_api_impl_win.h"
-#endif
-
-#if BUILDFLAG(IS_MAC)
-#include "brave/browser/brave_vpn/mac/vpn_utils_mac.h"
-#endif
 
 namespace brave_vpn {
-
-namespace {
-
-#if !BUILDFLAG(IS_ANDROID)
-std::unique_ptr<ConnectionAPIImpl> CreateConnectionAPIImpl(
-    BraveVPNConnectionManager* manager,
-    scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
-    bool wireguard_enabled) {
-#if BUILDFLAG(IS_MAC)
-  return CreateConnectionAPIImplMac(manager, url_loader_factory);
-#endif
-
-#if BUILDFLAG(IS_WIN)
-  if (wireguard_enabled) {
-    return std::make_unique<WireguardConnectionAPIImplWin>(manager,
-                                                           url_loader_factory);
-  }
-  return std::make_unique<RasConnectionAPIImplWin>(manager, url_loader_factory);
-#endif
-
-  // VPN is not supported on other platforms.
-  NOTREACHED();
-}
-#endif
-
-}  // namespace
-
-std::unique_ptr<BraveVPNConnectionManager> CreateBraveVPNConnectionManager(
-    scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
-    PrefService* local_prefs) {
-#if BUILDFLAG(IS_ANDROID)
-  // Android doesn't use connection api.
-  return nullptr;
-#else
-  // Currently, service installer only used on Windows.
-  // Installs registers IKEv2 service (for DNS) and our WireGuard impl.
-  // NOTE: Install only happens if person has purchased the product.
-  auto service_installer =
-#if BUILDFLAG(IS_WIN)
-      base::BindRepeating(&brave_vpn::InstallVpnSystemServices);
-#else
-      base::NullCallback();
-#endif
-
-  auto manager = std::make_unique<BraveVPNConnectionManager>(
-      url_loader_factory, local_prefs, service_installer);
-  manager->set_target_vpn_entry_name(
-      brave_vpn::GetBraveVPNEntryName(chrome::GetChannel()));
-  manager->set_connection_api_impl_getter(
-      base::BindRepeating(&CreateConnectionAPIImpl));
-  manager->UpdateConnectionAPIImpl();
-  return manager;
-#endif
-}
 
 bool IsAllowedForContext(content::BrowserContext* context) {
   return Profile::FromBrowserContext(context)->IsRegularProfile() &&

--- a/browser/brave_vpn/vpn_utils.h
+++ b/browser/brave_vpn/vpn_utils.h
@@ -6,29 +6,14 @@
 #ifndef BRAVE_BROWSER_BRAVE_VPN_VPN_UTILS_H_
 #define BRAVE_BROWSER_BRAVE_VPN_VPN_UTILS_H_
 
-#include <memory>
-
-#include "base/memory/scoped_refptr.h"
-
 namespace content {
 class BrowserContext;
 }  // namespace content
 
-namespace network {
-class SharedURLLoaderFactory;
-}  // namespace network
-
-class PrefService;
-
 namespace brave_vpn {
-
-class BraveVPNConnectionManager;
 
 bool IsBraveVPNEnabled(content::BrowserContext* context);
 bool IsAllowedForContext(content::BrowserContext* context);
-std::unique_ptr<BraveVPNConnectionManager> CreateBraveVPNConnectionManager(
-    scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
-    PrefService* local_prefs);
 
 }  // namespace brave_vpn
 

--- a/browser/sources.gni
+++ b/browser/sources.gni
@@ -545,14 +545,22 @@ if (enable_web_discovery_native) {
 
 if (enable_brave_vpn) {
   brave_chrome_browser_deps += [
-    "//brave/components/brave_vpn/browser",
-    "//brave/components/brave_vpn/browser/connection",
+    "//brave/components/brave_vpn/browser:shared",
     "//brave/components/brave_vpn/browser/connection:api",
     "//brave/components/brave_vpn/common",
   ]
+  if (enable_brave_vpn_v1) {
+    brave_chrome_browser_deps += [
+      "//brave/components/brave_vpn/browser",
+      "//brave/components/brave_vpn/browser/connection",
+    ]
+  }
+  if (enable_brave_vpn_v2) {
+    brave_chrome_browser_deps += [ "//brave/components/brave_vpn/v2/browser" ]
+  }
 }
 
-if (enable_brave_vpn2_deps) {
+if (enable_brave_vpn_v2_deps) {
   brave_chrome_browser_deps += [ "//brave/third_party/boringtun" ]
 }
 

--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -743,10 +743,11 @@ source_set("ui") {
           "webui/settings/brave_vpn/brave_vpn_handler.h",
         ]
 
-        deps += [
-          "//brave/browser/brave_vpn/win:wireguard_utils",
-          "//chrome/browser:flags",
-        ]
+        deps += [ "//chrome/browser:flags" ]
+
+        if (enable_brave_vpn_v1) {
+          deps += [ "//brave/browser/brave_vpn/win:wireguard_utils" ]
+        }
       }
       sources += [ "brave_vpn/brave_vpn_controller.cc" ]
     }
@@ -981,16 +982,22 @@ source_set("ui") {
 
   if (enable_brave_vpn) {
     deps += [
-      "//brave/browser/brave_vpn",
-      "//brave/components/brave_vpn/browser",
+      "//brave/browser/brave_vpn:shared",
+      "//brave/components/brave_vpn/browser:shared",
       "//brave/components/brave_vpn/browser/connection:api",
       "//brave/components/brave_vpn/common",
     ]
-    if (is_win) {
-      deps += [
-        "//brave/components/brave_vpn/common/win",
-        "//brave/components/brave_vpn/common/wireguard",
-      ]
+    if (enable_brave_vpn_v1) {
+      deps += [ "//brave/components/brave_vpn/browser" ]
+      if (is_win) {
+        deps += [
+          "//brave/components/brave_vpn/common/win",
+          "//brave/components/brave_vpn/common/wireguard",
+        ]
+      }
+    }
+    if (enable_brave_vpn_v2) {
+      deps += [ "//brave/components/brave_vpn/v2/browser" ]
     }
   }
 

--- a/browser/ui/browser_commands.cc
+++ b/browser/ui/browser_commands.cc
@@ -116,10 +116,10 @@
 #include "brave/components/brave_vpn/common/brave_vpn_utils.h"
 #include "brave/components/brave_vpn/common/pref_names.h"
 
-#if BUILDFLAG(IS_WIN)
+#if BUILDFLAG(ENABLE_BRAVE_VPN_V1) && BUILDFLAG(IS_WIN)
 #include "brave/browser/brave_vpn/win/storage_utils.h"
 #include "brave/browser/brave_vpn/win/wireguard_utils_win.h"
-#endif  // BUILDFLAG(ENABLE_BRAVE_VPN)
+#endif  // BUILDFLAG(ENABLE_BRAVE_VPN_V1) && BUILDFLAG(IS_WIN)
 
 #endif  // BUILDFLAG(ENABLE_BRAVE_VPN)
 
@@ -283,7 +283,8 @@ void ShowBraveVPNBubble(Browser* browser) {
 }
 
 void ToggleBraveVPNTrayIcon() {
-#if BUILDFLAG(ENABLE_BRAVE_VPN) && BUILDFLAG(IS_WIN)
+#if BUILDFLAG(ENABLE_BRAVE_VPN) && BUILDFLAG(ENABLE_BRAVE_VPN_V1) && \
+    BUILDFLAG(IS_WIN)
   brave_vpn::EnableVPNTrayIcon(!brave_vpn::IsVPNTrayIconEnabled());
   if (brave_vpn::IsVPNTrayIconEnabled()) {
     brave_vpn::wireguard::ShowBraveVpnStatusTrayIcon();

--- a/browser/ui/views/toolbar/brave_vpn_button_unittest.cc
+++ b/browser/ui/views/toolbar/brave_vpn_button_unittest.cc
@@ -13,9 +13,6 @@
 #include "base/run_loop.h"
 #include "brave/browser/brave_vpn/brave_vpn_service_factory.h"
 #include "brave/components/brave_vpn/browser/brave_vpn_service.h"
-#include "brave/components/brave_vpn/browser/connection/brave_vpn_connection_manager.h"
-#include "brave/components/brave_vpn/browser/connection/connection_api_impl.h"
-#include "brave/components/brave_vpn/browser/connection/ikev2/connection_api_impl_sim.h"
 #include "brave/components/skus/browser/skus_utils.h"
 #include "brave/test/base/testing_brave_browser_process.h"
 #include "chrome/browser/prefs/browser_prefs.h"
@@ -30,6 +27,12 @@
 #include "services/network/public/cpp/weak_wrapper_shared_url_loader_factory.h"
 #include "services/network/test/test_url_loader_factory.h"
 #include "testing/gtest/include/gtest/gtest.h"
+
+#if BUILDFLAG(ENABLE_BRAVE_VPN_V1)
+#include "brave/components/brave_vpn/browser/connection/brave_vpn_connection_manager.h"
+#include "brave/components/brave_vpn/browser/connection/connection_api_impl.h"
+#include "brave/components/brave_vpn/browser/connection/ikev2/connection_api_impl_sim.h"
+#endif  // BUILDFLAG(ENABLE_BRAVE_VPN_V1)
 
 namespace brave_vpn {
 
@@ -66,6 +69,7 @@ class BraveVpnButtonUnitTest : public testing::Test {
     shared_url_loader_factory_ =
         base::MakeRefCounted<network::WeakWrapperSharedURLLoaderFactory>(
             &url_loader_factory_);
+#if BUILDFLAG(ENABLE_BRAVE_VPN_V1)
     auto manager = std::make_unique<BraveVPNConnectionManager>(
         shared_url_loader_factory_,
         TestingBrowserProcess::GetGlobal()->GetTestingLocalState(),
@@ -75,6 +79,7 @@ class BraveVpnButtonUnitTest : public testing::Test {
                                                shared_url_loader_factory_));
     TestingBraveBrowserProcess::GetGlobal()
         ->SetBraveVPNConnectionManagerForTesting(std::move(manager));
+#endif  // BUILDFLAG(ENABLE_BRAVE_VPN_V1)
     ASSERT_TRUE(brave_vpn::BraveVpnServiceFactory::GetForProfile(
         GetBrowser()->profile()));
     ASSERT_TRUE(ThemeServiceFactory::GetForProfile(profile()));
@@ -87,8 +92,10 @@ class BraveVpnButtonUnitTest : public testing::Test {
 
     // BraveVPNConnectionManager should be reset after profile is destoryed
     // and before local_state is gone as it uses local_state.
+#if BUILDFLAG(ENABLE_BRAVE_VPN_V1)
     TestingBraveBrowserProcess::GetGlobal()
         ->SetBraveVPNConnectionManagerForTesting(nullptr);
+#endif  // BUILDFLAG(ENABLE_BRAVE_VPN_V1)
 
     base::RunLoop().RunUntilIdle();
   }

--- a/browser/ui/webui/brave_new_tab_page_refresh/BUILD.gn
+++ b/browser/ui/webui/brave_new_tab_page_refresh/BUILD.gn
@@ -125,7 +125,7 @@ source_set("brave_new_tab_page_refresh") {
   if (enable_brave_vpn) {
     deps += [
       "//brave/browser/ui/brave_vpn",
-      "//brave/components/brave_vpn/browser",
+      "//brave/components/brave_vpn/browser:shared",
       "//brave/components/brave_vpn/common",
     ]
   }

--- a/browser/ui/webui/side_panel/customize_chrome/BUILD.gn
+++ b/browser/ui/webui/side_panel/customize_chrome/BUILD.gn
@@ -63,7 +63,7 @@ source_set("customize_chrome") {
 
   if (enable_brave_vpn_panel) {
     deps += [
-      "//brave/browser/brave_vpn",
+      "//brave/browser/brave_vpn:shared",
       "//brave/components/brave_vpn/common",
     ]
   }
@@ -140,7 +140,7 @@ source_set("unit_tests") {
 
   if (enable_brave_vpn_panel) {
     deps += [
-      "//brave/browser/brave_vpn",
+      "//brave/browser/brave_vpn:shared",
       "//brave/components/brave_vpn/common",
     ]
   }

--- a/browser/ui/webui/skus_internals_ui.cc
+++ b/browser/ui/webui/skus_internals_ui.cc
@@ -38,11 +38,12 @@
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
 #include "brave/browser/brave_vpn/brave_vpn_service_factory.h"
 #include "brave/components/brave_vpn/browser/brave_vpn_service.h"
-#include "brave/components/brave_vpn/browser/brave_vpn_service_helper.h"
-#include "brave/components/brave_vpn/browser/connection/brave_vpn_connection_manager.h"
 #include "brave/components/brave_vpn/common/brave_vpn_utils.h"
 #include "brave/components/brave_vpn/common/pref_names.h"
-#endif
+#if BUILDFLAG(ENABLE_BRAVE_VPN_V1)
+#include "brave/components/brave_vpn/browser/connection/brave_vpn_connection_manager.h"
+#endif  // BUILDFLAG(ENABLE_BRAVE_VPN_V1)
+#endif  // BUILDFLAG(ENABLE_BRAVE_VPN)
 
 namespace {
 
@@ -229,7 +230,7 @@ void SkusInternalsUI::FileSelectionCanceled() {
 
 std::string SkusInternalsUI::GetLastVPNConnectionError() const {
   std::string error;
-#if BUILDFLAG(ENABLE_BRAVE_VPN)
+#if BUILDFLAG(ENABLE_BRAVE_VPN) && BUILDFLAG(ENABLE_BRAVE_VPN_V1)
   auto* manager = g_brave_browser_process->brave_vpn_connection_manager();
   CHECK(manager);
   error = manager->GetLastConnectionError();

--- a/browser/ui/webui/sources.gni
+++ b/browser/ui/webui/sources.gni
@@ -32,7 +32,7 @@ if (enable_playlist_webui) {
 
 if (enable_brave_vpn) {
   brave_browser_ui_webui_configs_deps +=
-      [ "//brave/components/brave_vpn/browser" ]
+      [ "//brave/components/brave_vpn/browser:shared" ]
 }
 
 if (enable_brave_education) {

--- a/build/win/BUILD.gn
+++ b/build/win/BUILD.gn
@@ -11,7 +11,7 @@ group("brave") {
     ":copy_exe",
     ":copy_pdb",
   ]
-  if (enable_brave_vpn) {
+  if (enable_brave_vpn && enable_brave_vpn_v1) {
     deps = [
       "//brave/browser/brave_vpn/win/brave_vpn_helper",
       "//brave/browser/brave_vpn/win/brave_vpn_wireguard_service:wireguard_service",

--- a/chromium_src/chrome/browser/sources.gni
+++ b/chromium_src/chrome/browser/sources.gni
@@ -26,7 +26,7 @@ if (!is_android) {
 
 if (enable_brave_vpn) {
   brave_chromium_src_chrome_browser_deps +=
-      [ "//brave/components/brave_vpn/browser" ]
+      [ "//brave/components/brave_vpn/common" ]
 }
 
 if (toolkit_views) {

--- a/chromium_src/chrome/elevation_service/elevator.cc
+++ b/chromium_src/chrome/elevation_service/elevator.cc
@@ -15,7 +15,7 @@
 #include "brave/components/brave_vpn/common/buildflags/buildflags.h"
 #include "third_party/abseil-cpp/absl/cleanup/cleanup.h"
 
-#if BUILDFLAG(ENABLE_BRAVE_VPN)
+#if BUILDFLAG(ENABLE_BRAVE_VPN) && BUILDFLAG(ENABLE_BRAVE_VPN_V1)
 #include "brave/browser/brave_vpn/win/brave_vpn_helper/brave_vpn_helper_utils.h"
 
 #if BUILDFLAG(ENABLE_BRAVE_VPN_WIREGUARD)
@@ -60,7 +60,7 @@ HRESULT Elevator::InstallVPNServices() {
   }
   // End of trusted source check
 
-#if BUILDFLAG(ENABLE_BRAVE_VPN)
+#if BUILDFLAG(ENABLE_BRAVE_VPN) && BUILDFLAG(ENABLE_BRAVE_VPN_V1)
   if (!brave_vpn::IsBraveVPNHelperServiceInstalled()) {
     auto success = brave_vpn::InstallBraveVPNHelperService(
         base::PathService::CheckedGet(base::DIR_ASSETS));

--- a/chromium_src/chrome/installer/setup/install_worker.cc
+++ b/chromium_src/chrome/installer/setup/install_worker.cc
@@ -37,7 +37,7 @@
 // clang-format on
 #endif
 
-#if BUILDFLAG(ENABLE_BRAVE_VPN)
+#if BUILDFLAG(ENABLE_BRAVE_VPN) && BUILDFLAG(ENABLE_BRAVE_VPN_V1)
 #include "brave/browser/brave_vpn/win/brave_vpn_helper/brave_vpn_helper_constants.h"
 #include "brave/browser/brave_vpn/win/brave_vpn_helper/brave_vpn_helper_utils.h"
 #include "brave/browser/brave_vpn/win/brave_vpn_wireguard_service/install_utils.h"
@@ -185,7 +185,7 @@ void UpdateBraveVpn(const base::FilePath& target_path,
   UpdateBraveVpn(target_path, new_version, install_list); \
   AddUpdateDowngradeVersionItem
 
-#endif  // BUILDFLAG(ENABLE_BRAVE_VPN)
+#endif  // BUILDFLAG(ENABLE_BRAVE_VPN) && BUILDFLAG(ENABLE_BRAVE_VPN_V1)
 
 // The code in BRAVE_ADD_INSTALLER_COPY_TASKS and
 // BRAVE_MAYBE_ABORT_ADD_CHROME_WORK_ITEMS used to be upstream and had to be
@@ -209,9 +209,9 @@ void UpdateBraveVpn(const base::FilePath& target_path,
 #include <chrome/installer/setup/install_worker.cc>
 #undef BRAVE_MAYBE_ABORT_ADD_CHROME_WORK_ITEMS
 #undef BRAVE_ADD_INSTALLER_COPY_TASKS
-#if BUILDFLAG(ENABLE_BRAVE_VPN)
+#if BUILDFLAG(ENABLE_BRAVE_VPN) && BUILDFLAG(ENABLE_BRAVE_VPN_V1)
 #undef AddUpdateDowngradeVersionItem
-#endif  // BUILDFLAG(ENABLE_BRAVE_VPN)
+#endif  // BUILDFLAG(ENABLE_BRAVE_VPN) && BUILDFLAG(ENABLE_BRAVE_VPN_V1)
 #if defined(OFFICIAL_BUILD)
 #include "chrome/install_static/brave_restore_google_update_integration.h"
 #endif

--- a/chromium_src/chrome/installer/setup/test/BUILD.gn
+++ b/chromium_src/chrome/installer/setup/test/BUILD.gn
@@ -5,7 +5,7 @@
 
 import("//brave/components/brave_vpn/common/buildflags/buildflags.gni")
 
-if (enable_brave_vpn && is_win) {
+if (enable_brave_vpn && enable_brave_vpn_v1_tests && is_win) {
   source_set("vpn_unit_tests") {
     testonly = true
     sources = [ "install_worker_vpn_unittest.cc" ]

--- a/chromium_src/chrome/installer/setup/uninstall.cc
+++ b/chromium_src/chrome/installer/setup/uninstall.cc
@@ -16,7 +16,7 @@
 #include "chrome/installer/util/util_constants.h"
 #include "chrome/installer/util/work_item.h"
 
-#if BUILDFLAG(ENABLE_BRAVE_VPN)
+#if BUILDFLAG(ENABLE_BRAVE_VPN) && BUILDFLAG(ENABLE_BRAVE_VPN_V1)
 #include "brave/browser/brave_vpn/win/brave_vpn_helper/brave_vpn_helper_constants.h"
 #include "brave/browser/brave_vpn/win/brave_vpn_helper/brave_vpn_helper_utils.h"
 #include "brave/browser/brave_vpn/win/brave_vpn_wireguard_service/install_utils.h"
@@ -85,7 +85,7 @@ InstallStatus UninstallProduct(const ModifyParams& modify_params,
        ShellUtil::QuickIsChromeRegisteredInHKLM(chrome_exe, suffix))) {
     DeleteBraveFileKeys(HKEY_LOCAL_MACHINE);
   }
-#if BUILDFLAG(ENABLE_BRAVE_VPN)
+#if BUILDFLAG(ENABLE_BRAVE_VPN) && BUILDFLAG(ENABLE_BRAVE_VPN_V1)
   if (installer_state->system_install()) {
     // TODO(bsclifton): move this to a method
     if (!InstallServiceWorkItem::DeleteService(

--- a/components/brave_vpn/browser/BUILD.gn
+++ b/components/brave_vpn/browser/BUILD.gn
@@ -7,20 +7,37 @@ import("//brave/components/brave_vpn/common/buildflags/buildflags.gni")
 
 assert(enable_brave_vpn)
 
+# Browser sources shared between v1 and v2 implementations.
+static_library("shared") {
+  sources = [
+    "brave_vpn_service.cc",
+    "brave_vpn_service.h",
+    "brave_vpn_service_observer.cc",
+    "brave_vpn_service_observer.h",
+  ]
+
+  public_deps = [
+    "//base",
+    "//brave/components/brave_vpn/common/mojom",
+    "//brave/components/skus/browser",
+    "//components/keyed_service/core",
+  ]
+
+  deps = [ "//brave/components/brave_vpn/common" ]
+}
+
 static_library("browser") {
   sources = [
     "brave_vpn_metrics.cc",
     "brave_vpn_metrics.h",
-    "brave_vpn_service.cc",
-    "brave_vpn_service.h",
     "brave_vpn_service_delegate.h",
     "brave_vpn_service_helper.cc",
     "brave_vpn_service_helper.h",
     "brave_vpn_service_impl.cc",
     "brave_vpn_service_impl.h",
-    "brave_vpn_service_observer.cc",
-    "brave_vpn_service_observer.h",
   ]
+
+  public_deps = [ ":shared" ]
 
   deps = [
     "api",
@@ -39,7 +56,6 @@ static_library("browser") {
     "//brave/components/time_period_storage",
     "//brave/components/version_info",
     "//build:buildflag_header_h",
-    "//components/keyed_service/core",
     "//components/pref_registry",
     "//components/prefs",
     "//components/version_info",
@@ -52,20 +68,17 @@ static_library("browser") {
 source_set("unit_tests") {
   testonly = true
 
-  sources = [
-    "brave_vpn_metrics_unittest.cc",
-    "brave_vpn_service_impl_unittest.cc",
-    "brave_vpn_service_unittest.cc",
-  ]
+  sources = [ "brave_vpn_service_unittest.cc" ]
+  if (enable_brave_vpn_v1_tests) {
+    sources += [
+      "brave_vpn_metrics_unittest.cc",
+      "brave_vpn_service_impl_unittest.cc",
+    ]
+  }
 
   deps = [
-    ":browser",
-    "api",
-    "api:unit_tests",
+    ":shared",
     "//base",
-    "//brave/components/brave_vpn/browser/connection:api",
-    "//brave/components/brave_vpn/browser/connection:common",
-    "//brave/components/brave_vpn/browser/connection/wireguard/credentials:unit_tests",
     "//brave/components/brave_vpn/common",
     "//brave/components/brave_vpn/common/mojom",
     "//brave/components/constants",
@@ -80,10 +93,23 @@ source_set("unit_tests") {
     "//testing/gmock",
     "//testing/gtest",
   ]
-  if (!is_android) {
+  if (enable_brave_vpn_v1_tests) {
     deps += [
-      "connection:unit_tests",
-      "//brave/components/brave_vpn/browser/connection/ikev2:sim",
+      ":browser",
+      "api",
+      "api:unit_tests",
+      "//brave/components/brave_vpn/browser/connection:api",
+      "//brave/components/brave_vpn/browser/connection:common",
+      "//brave/components/brave_vpn/browser/connection/wireguard/credentials:unit_tests",
     ]
+  }
+
+  if (!is_android) {
+    if (enable_brave_vpn_v1_tests) {
+      deps += [
+        "connection:unit_tests",
+        "//brave/components/brave_vpn/browser/connection/ikev2:sim",
+      ]
+    }
   }
 }

--- a/components/brave_vpn/browser/DEPS
+++ b/components/brave_vpn/browser/DEPS
@@ -1,4 +1,5 @@
 include_rules = [
+  "-components/brave_vpn/v2",
   "+components/grit/brave_components_strings.h",
   "+components/keyed_service",
   "+components/prefs",

--- a/components/brave_vpn/browser/brave_vpn_service_helper.cc
+++ b/components/brave_vpn/browser/brave_vpn_service_helper.cc
@@ -70,10 +70,6 @@ void SetSubscriberCredential(PrefService* local_prefs,
                        std::move(cred_dict));
 }
 
-void ClearSubscriberCredential(PrefService* local_prefs) {
-  local_prefs->ClearPref(prefs::kBraveVPNSubscriberCredential);
-}
-
 void SetSkusCredential(PrefService* local_prefs,
                        const std::string& skus_credential,
                        const base::Time& expiration_time) {

--- a/components/brave_vpn/browser/brave_vpn_service_helper.h
+++ b/components/brave_vpn/browser/brave_vpn_service_helper.h
@@ -29,7 +29,6 @@ std::optional<base::Time> GetExpirationTime(PrefService* local_prefs);
 void SetSubscriberCredential(PrefService* local_prefs,
                              const std::string& subscriber_credential,
                              const base::Time& expiration_time);
-void ClearSubscriberCredential(PrefService* local_prefs);
 void SetSkusCredential(PrefService* local_prefs,
                        const std::string& skus_credential,
                        const base::Time& expiration_time);

--- a/components/brave_vpn/common/DEPS
+++ b/components/brave_vpn/common/DEPS
@@ -1,4 +1,5 @@
 include_rules = [
+  "-components/brave_vpn/v2",
   "+components/pref_registry",
   "+components/prefs",
   "+components/sync_preferences/testing_pref_service_syncable.h",

--- a/components/brave_vpn/common/brave_vpn_utils.cc
+++ b/components/brave_vpn/common/brave_vpn_utils.cc
@@ -317,6 +317,10 @@ void MigrateLocalStatePrefs(PrefService* local_prefs) {
 #endif
 }
 
+void ClearSubscriberCredential(PrefService* local_prefs) {
+  local_prefs->ClearPref(prefs::kBraveVPNSubscriberCredential);
+}
+
 bool HasValidSubscriberCredential(PrefService* local_prefs) {
   const base::DictValue& sub_cred_dict =
       local_prefs->GetDict(prefs::kBraveVPNSubscriberCredential);

--- a/components/brave_vpn/common/brave_vpn_utils.h
+++ b/components/brave_vpn/common/brave_vpn_utils.h
@@ -36,6 +36,7 @@ void RegisterLocalStatePrefsForMigration(PrefRegistrySimple* registry);
 void MigrateLocalStatePrefs(PrefService* local_prefs);
 void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry);
 void RegisterAndroidProfilePrefs(PrefRegistrySimple* registry);
+void ClearSubscriberCredential(PrefService* local_prefs);
 bool HasValidSubscriberCredential(PrefService* local_prefs);
 std::string GetSubscriberCredential(PrefService* local_prefs);
 bool HasValidSkusCredential(PrefService* local_prefs);

--- a/components/brave_vpn/common/buildflags/BUILD.gn
+++ b/components/brave_vpn/common/buildflags/BUILD.gn
@@ -10,6 +10,8 @@ buildflag_header("buildflags") {
   header = "buildflags.h"
   flags = [
     "ENABLE_BRAVE_VPN=$enable_brave_vpn",
+    "ENABLE_BRAVE_VPN_V1=$enable_brave_vpn_v1",
+    "ENABLE_BRAVE_VPN_V2=$enable_brave_vpn_v2",
     "ENABLE_BRAVE_VPN_WIREGUARD=$enable_brave_vpn_wireguard",
   ]
 }

--- a/components/brave_vpn/common/buildflags/buildflags.gni
+++ b/components/brave_vpn/common/buildflags/buildflags.gni
@@ -20,6 +20,21 @@ declare_args() {
 }
 
 declare_args() {
-  # vpn 2.0 build flags
-  enable_brave_vpn2_deps = false
+  # Build with Brave VPN architecture 1.0 support.
+  enable_brave_vpn_v1 = true
+
+  # Build with Brave VPN architecture 2.0 support.
+  enable_brave_vpn_v2 = false
 }
+
+assert(!enable_brave_vpn || enable_brave_vpn_v1 || enable_brave_vpn_v2,
+       "If Brave VPN is enabled, at least one VPN architecture must be enabled")
+
+# Build Brave VPN 2.0 deps only if VPN is enabled and architecture 2.0 is supported.
+enable_brave_vpn_v2_deps = enable_brave_vpn && enable_brave_vpn_v2
+
+# Enable Brave VPN 1.0 architecture specific unit tests - turn off for debugging only.
+enable_brave_vpn_v1_tests = true
+
+# Enable Brave VPN 2.0 architecture specific unit tests - turn off for debugging only.
+enable_brave_vpn_v2_tests = true

--- a/components/brave_vpn/v2/DEPS
+++ b/components/brave_vpn/v2/DEPS
@@ -1,0 +1,9 @@
+include_rules = [
+  "-brave/components/brave_vpn/browser",
+  "-brave/components/brave_vpn/common",
+  "+brave/components/brave_vpn/browser/brave_vpn_service.h",
+  "+brave/components/brave_vpn/common/brave_vpn_constants.h",
+  "+brave/components/brave_vpn/common/brave_vpn_utils.h",
+  "+brave/components/brave_vpn/common/buildflags",
+  "+brave/components/brave_vpn/common/mojom",
+]

--- a/components/brave_vpn/v2/README.md
+++ b/components/brave_vpn/v2/README.md
@@ -1,0 +1,14 @@
+# Brave VPN 2.0 Architecture
+
+This directory contains the implementation of Brave VPN 2.0 architecture.
+More information in the spec: 
+https://docs.google.com/document/d/1X6EWWqrFGeSXUBXW9mn0o5bsFyeOzZvmuMTcWdvJ_dc
+
+## Key Files
+
+- **`brave_vpn_service_impl.{h,cc}`** - Main service implementation for V2.
+
+## Related Files
+
+- **`browser/brave_vpn/brave_vpn_service_factory.{h,cc}`** - Brave VPN service
+  factory that creates an implementation based on the enabled buildflags.

--- a/components/brave_vpn/v2/browser/BUILD.gn
+++ b/components/brave_vpn/v2/browser/BUILD.gn
@@ -1,0 +1,46 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import("//brave/components/brave_vpn/common/buildflags/buildflags.gni")
+
+assert(enable_brave_vpn)
+
+static_library("browser") {
+  sources = [
+    "brave_vpn_service_impl.cc",
+    "brave_vpn_service_impl.h",
+  ]
+
+  public_deps = [
+    "//brave/components/brave_vpn/browser:shared",
+    "//brave/components/skus/browser",
+    "//brave/components/skus/common:mojom",
+  ]
+
+  deps = [
+    "//base",
+    "//brave/components/brave_vpn/common",
+  ]
+}
+
+source_set("unit_tests") {
+  testonly = true
+
+  sources = [ "brave_vpn_service_impl_unittest.cc" ]
+
+  deps = [
+    ":browser",
+    "//base",
+    "//brave/components/brave_vpn/browser:shared",
+    "//brave/components/brave_vpn/common",
+    "//brave/components/brave_vpn/common/mojom",
+    "//brave/components/constants",
+    "//brave/components/skus/browser",
+    "//brave/components/skus/common",
+    "//brave/components/skus/common:mojom",
+    "//testing/gmock",
+    "//testing/gtest",
+  ]
+}

--- a/components/brave_vpn/v2/browser/brave_vpn_service_impl.cc
+++ b/components/brave_vpn/v2/browser/brave_vpn_service_impl.cc
@@ -1,0 +1,204 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/v2/browser/brave_vpn_service_impl.h"
+
+#include "brave/components/brave_vpn/common/brave_vpn_constants.h"
+#include "brave/components/brave_vpn/common/brave_vpn_utils.h"
+
+namespace brave_vpn {
+namespace v2 {
+
+BraveVpnServiceImpl::BraveVpnServiceImpl()
+    : connection_state_(mojom::ConnectionState::DISCONNECTED),
+      purchased_state_(mojom::PurchasedState::NOT_PURCHASED) {}
+
+BraveVpnServiceImpl::~BraveVpnServiceImpl() = default;
+
+bool BraveVpnServiceImpl::IsBraveVPNEnabled() const {
+  return true;
+}
+
+bool BraveVpnServiceImpl::IsPurchased() const {
+  return purchased_state_ == mojom::PurchasedState::PURCHASED;
+}
+
+void BraveVpnServiceImpl::ReloadPurchasedState() {}
+
+std::string BraveVpnServiceImpl::GetCurrentEnvironment() const {
+  return skus::kEnvProduction;
+}
+
+#if !BUILDFLAG(IS_ANDROID)
+
+bool BraveVpnServiceImpl::IsConnected() const {
+  return connection_state_ == mojom::ConnectionState::CONNECTED &&
+         IsPurchased();
+}
+
+void BraveVpnServiceImpl::ToggleConnection() {}
+
+mojom::ConnectionState BraveVpnServiceImpl::GetConnectionState() const {
+  return connection_state_;
+}
+
+void BraveVpnServiceImpl::RecordWidgetUsageMetrics(bool new_usage) {}
+
+#endif  // !BUILDFLAG(IS_ANDROID)
+
+void BraveVpnServiceImpl::GetPurchasedState(
+    GetPurchasedStateCallback callback) {
+  std::move(callback).Run(
+      mojom::PurchasedInfo::New(purchased_state_, std::nullopt));
+}
+
+void BraveVpnServiceImpl::LoadPurchasedState(const std::string& domain) {}
+
+void BraveVpnServiceImpl::GetAllRegions(GetAllRegionsCallback callback) {
+  std::move(callback).Run({});
+}
+
+#if !BUILDFLAG(IS_ANDROID)
+
+void BraveVpnServiceImpl::GetConnectionState(
+    GetConnectionStateCallback callback) {
+  std::move(callback).Run(connection_state_);
+}
+
+void BraveVpnServiceImpl::Connect() {}
+
+void BraveVpnServiceImpl::Disconnect() {}
+
+void BraveVpnServiceImpl::GetSelectedRegion(
+    GetSelectedRegionCallback callback) {
+  std::move(callback).Run({});
+}
+
+void BraveVpnServiceImpl::SetSelectedRegion(mojom::RegionPtr region) {}
+
+void BraveVpnServiceImpl::ClearSelectedRegion() {}
+
+void BraveVpnServiceImpl::GetProductUrls(GetProductUrlsCallback callback) {
+  std::move(callback).Run(mojom::ProductUrls::New(
+      kFeedbackUrl, kAboutUrl, GetManageUrl(GetCurrentEnvironment())));
+}
+
+void BraveVpnServiceImpl::CreateSupportTicket(
+    const std::string& email,
+    const std::string& subject,
+    const std::string& body,
+    CreateSupportTicketCallback callback) {
+  std::move(callback).Run(false, {});
+}
+
+void BraveVpnServiceImpl::GetSupportData(GetSupportDataCallback callback) {
+  std::move(callback).Run({}, {}, {}, {});
+}
+
+void BraveVpnServiceImpl::ResetConnectionState() {}
+
+void BraveVpnServiceImpl::EnableOnDemand(bool /*enable*/) {}
+
+void BraveVpnServiceImpl::GetOnDemandState(GetOnDemandStateCallback callback) {
+  std::move(callback).Run(false, false);
+}
+
+void BraveVpnServiceImpl::EnableSmartProxyRouting(bool /*enable*/) {}
+
+void BraveVpnServiceImpl::GetSmartProxyRoutingState(
+    GetSmartProxyRoutingStateCallback callback) {
+  std::move(callback).Run(false);
+}
+
+#else  // !BUILDFLAG(IS_ANDROID)
+
+void BraveVpnServiceImpl::GetPurchaseToken(GetPurchaseTokenCallback callback) {
+  std::move(callback).Run({});
+}
+
+#endif  // !BUILDFLAG(IS_ANDROID)
+
+#if BUILDFLAG(IS_ANDROID)
+
+void BraveVpnServiceImpl::GetTimezonesForRegions(ResponseCallback callback) {}
+
+void BraveVpnServiceImpl::GetHostnamesForRegion(
+    ResponseCallback callback,
+    const std::string& region,
+    const std::string& region_precision) {}
+
+void BraveVpnServiceImpl::GetProfileCredentials(
+    ResponseCallback callback,
+    const std::string& subscriber_credential,
+    const std::string& hostname) {}
+
+void BraveVpnServiceImpl::GetWireguardProfileCredentials(
+    ResponseCallback callback,
+    const std::string& subscriber_credential,
+    const std::string& public_key,
+    const std::string& hostname) {}
+
+void BraveVpnServiceImpl::VerifyCredentials(
+    ResponseCallback callback,
+    const std::string& hostname,
+    const std::string& client_id,
+    const std::string& subscriber_credential,
+    const std::string& api_auth_token) {}
+
+void BraveVpnServiceImpl::InvalidateCredentials(
+    ResponseCallback callback,
+    const std::string& hostname,
+    const std::string& client_id,
+    const std::string& subscriber_credential,
+    const std::string& api_auth_token) {}
+
+void BraveVpnServiceImpl::VerifyPurchaseToken(ResponseCallback callback,
+                                              const std::string& purchase_token,
+                                              const std::string& product_id,
+                                              const std::string& product_type,
+                                              const std::string& bundle_id) {}
+
+void BraveVpnServiceImpl::GetSubscriberCredential(
+    ResponseCallback callback,
+    const std::string& product_type,
+    const std::string& product_id,
+    const std::string& validation_method,
+    const std::string& purchase_token,
+    const std::string& bundle_id) {}
+
+void BraveVpnServiceImpl::GetSubscriberCredentialV12(
+    ResponseCallback callback) {}
+
+void BraveVpnServiceImpl::RecordAllMetrics() {}
+
+void BraveVpnServiceImpl::RecordAndroidBackgroundP3A(
+    int64_t session_start_time_ms,
+    int64_t session_end_time_ms) {}
+
+#endif  // BUILDFLAG(IS_ANDROID)
+
+void BraveVpnServiceImpl::Shutdown() {
+  BraveVpnService::Shutdown();
+}
+
+#if !BUILDFLAG(IS_ANDROID)
+
+void BraveVpnServiceImpl::SetConnectionStateForTesting(  // IN-TEST
+    mojom::ConnectionState state) {
+  connection_state_ = state;
+  NotifyConnectionStateChanged(state);
+}
+
+void BraveVpnServiceImpl::SetPurchasedStateForTesting(  // IN-TEST
+    const std::string& env,
+    mojom::PurchasedState state) {
+  purchased_state_ = state;
+  NotifyPurchasedStateChanged(state, std::nullopt);
+}
+
+#endif  // !BUILDFLAG(IS_ANDROID)
+
+}  // namespace v2
+}  // namespace brave_vpn

--- a/components/brave_vpn/v2/browser/brave_vpn_service_impl.h
+++ b/components/brave_vpn/v2/browser/brave_vpn_service_impl.h
@@ -1,0 +1,124 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_VPN_V2_BROWSER_BRAVE_VPN_SERVICE_IMPL_H_
+#define BRAVE_COMPONENTS_BRAVE_VPN_V2_BROWSER_BRAVE_VPN_SERVICE_IMPL_H_
+
+#include "brave/components/brave_vpn/browser/brave_vpn_service.h"
+#include "build/build_config.h"
+#include "mojo/public/cpp/bindings/pending_remote.h"
+#include "mojo/public/cpp/bindings/remote_set.h"
+
+namespace brave_vpn {
+namespace v2 {
+
+class BraveVpnServiceImpl : public BraveVpnService {
+ public:
+  BraveVpnServiceImpl();
+  ~BraveVpnServiceImpl() override;
+
+  BraveVpnServiceImpl(const BraveVpnServiceImpl&) = delete;
+  BraveVpnServiceImpl& operator=(const BraveVpnServiceImpl&) = delete;
+
+  // BraveVpnService overrides:
+  // Implementation of public interface exposed to other components.
+  bool IsBraveVPNEnabled() const override;
+  bool IsPurchased() const override;
+  void ReloadPurchasedState() override;
+  std::string GetCurrentEnvironment() const override;
+#if !BUILDFLAG(IS_ANDROID)
+  bool IsConnected() const override;
+  void ToggleConnection() override;
+  mojom::ConnectionState GetConnectionState() const override;
+  void RecordWidgetUsageMetrics(bool new_usage) override;
+#endif  // !BUILDFLAG(IS_ANDROID)
+
+  // mojom::ServiceHandler overrides:
+  void GetPurchasedState(GetPurchasedStateCallback callback) override;
+  void LoadPurchasedState(const std::string& domain) override;
+  void GetAllRegions(GetAllRegionsCallback callback) override;
+#if !BUILDFLAG(IS_ANDROID)
+  void GetConnectionState(GetConnectionStateCallback callback) override;
+  void Connect() override;
+  void Disconnect() override;
+  void GetSelectedRegion(GetSelectedRegionCallback callback) override;
+  void SetSelectedRegion(mojom::RegionPtr region) override;
+  void ClearSelectedRegion() override;
+  void GetProductUrls(GetProductUrlsCallback callback) override;
+  void CreateSupportTicket(const std::string& email,
+                           const std::string& subject,
+                           const std::string& body,
+                           CreateSupportTicketCallback callback) override;
+  void GetSupportData(GetSupportDataCallback callback) override;
+  void ResetConnectionState() override;
+  void EnableOnDemand(bool enable) override;
+  void GetOnDemandState(GetOnDemandStateCallback callback) override;
+  void EnableSmartProxyRouting(bool enable) override;
+  void GetSmartProxyRoutingState(
+      GetSmartProxyRoutingStateCallback callback) override;
+#else   // !BUILDFLAG(IS_ANDROID)
+  void GetPurchaseToken(GetPurchaseTokenCallback callback) override;
+#endif  // !BUILDFLAG(IS_ANDROID)
+
+#if BUILDFLAG(IS_ANDROID)
+  // Implementation of public interface for Android native worker.
+  void GetTimezonesForRegions(ResponseCallback callback) override;
+  void GetHostnamesForRegion(ResponseCallback callback,
+                             const std::string& region,
+                             const std::string& region_precision) override;
+  void GetProfileCredentials(ResponseCallback callback,
+                             const std::string& subscriber_credential,
+                             const std::string& hostname) override;
+  void GetWireguardProfileCredentials(ResponseCallback callback,
+                                      const std::string& subscriber_credential,
+                                      const std::string& public_key,
+                                      const std::string& hostname) override;
+  void VerifyCredentials(ResponseCallback callback,
+                         const std::string& hostname,
+                         const std::string& client_id,
+                         const std::string& subscriber_credential,
+                         const std::string& api_auth_token) override;
+  void InvalidateCredentials(ResponseCallback callback,
+                             const std::string& hostname,
+                             const std::string& client_id,
+                             const std::string& subscriber_credential,
+                             const std::string& api_auth_token) override;
+  void VerifyPurchaseToken(ResponseCallback callback,
+                           const std::string& purchase_token,
+                           const std::string& product_id,
+                           const std::string& product_type,
+                           const std::string& bundle_id) override;
+  void GetSubscriberCredential(ResponseCallback callback,
+                               const std::string& product_type,
+                               const std::string& product_id,
+                               const std::string& validation_method,
+                               const std::string& purchase_token,
+                               const std::string& bundle_id) override;
+  void GetSubscriberCredentialV12(ResponseCallback callback) override;
+  void RecordAllMetrics() override;
+  void RecordAndroidBackgroundP3A(int64_t session_start_time_ms,
+                                  int64_t session_end_time_ms) override;
+#endif  // BUILDFLAG(IS_ANDROID)
+
+ private:
+  // KeyedService overrides:
+  void Shutdown() override;
+
+  // BraveVpnService overrides:
+#if !BUILDFLAG(IS_ANDROID)
+  void SetConnectionStateForTesting(mojom::ConnectionState state) override;
+  void SetPurchasedStateForTesting(const std::string& env,
+                                   mojom::PurchasedState state) override;
+#endif  // !BUILDFLAG(IS_ANDROID)
+
+ private:
+  [[maybe_unused]] mojom::ConnectionState connection_state_;
+  mojom::PurchasedState purchased_state_;
+};
+
+}  // namespace v2
+}  // namespace brave_vpn
+
+#endif  // BRAVE_COMPONENTS_BRAVE_VPN_V2_BROWSER_BRAVE_VPN_SERVICE_IMPL_H_

--- a/components/brave_vpn/v2/browser/brave_vpn_service_impl_unittest.cc
+++ b/components/brave_vpn/v2/browser/brave_vpn_service_impl_unittest.cc
@@ -1,0 +1,23 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/v2/browser/brave_vpn_service_impl.h"
+
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace brave_vpn {
+namespace v2 {
+
+TEST(BraveVpnServiceImplTest, CompilesAndIsPurchasedReturnsFalse) {
+  // This test just verifies that the test fixture compiles and links correctly
+  // with the real BraveVpnServiceImpl implementation.
+  BraveVpnServiceImpl service;
+
+  // Service is not purchased by default.
+  EXPECT_FALSE(service.IsPurchased());
+}
+
+}  // namespace v2
+}  // namespace brave_vpn

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -415,16 +415,23 @@ test("brave_unit_tests") {
     deps += [
       "//brave/components/brave_vpn/browser:unit_tests",
       "//brave/components/brave_vpn/common:unit_tests",
-      "//brave/components/brave_vpn/common/wireguard:unit_tests",
       "//brave/components/skus/browser:unit_tests",
     ]
-    if (is_win) {
-      deps += [
-        "//brave/browser/brave_vpn/dns:unit_tests",
-        "//brave/browser/brave_vpn/win:unit_tests",
-        "//brave/browser/brave_vpn/win/brave_vpn_helper:unit_tests",
-        "//brave/browser/brave_vpn/win/brave_vpn_wireguard_service:unit_tests",
-      ]
+
+    if (enable_brave_vpn_v1_tests) {
+      deps += [ "//brave/components/brave_vpn/common/wireguard:unit_tests" ]
+      if (is_win) {
+        deps += [
+          "//brave/browser/brave_vpn/dns:unit_tests",
+          "//brave/browser/brave_vpn/win:unit_tests",
+          "//brave/browser/brave_vpn/win/brave_vpn_helper:unit_tests",
+          "//brave/browser/brave_vpn/win/brave_vpn_wireguard_service:unit_tests",
+        ]
+      }
+    }
+
+    if (enable_brave_vpn_v2_tests) {
+      deps += [ "//brave/components/brave_vpn/v2/browser:unit_tests" ]
     }
   }
   if (toolkit_views) {
@@ -710,7 +717,7 @@ if (!is_android) {
         "//testing/gtest",
       ]
 
-      if (enable_brave_vpn) {
+      if (enable_brave_vpn && enable_brave_vpn_v1_tests) {
         deps += [
           "//brave/chromium_src/chrome/installer/setup/test:vpn_unit_tests",
         ]
@@ -1259,9 +1266,12 @@ test("brave_browser_tests") {
 
   if (enable_brave_vpn) {
     deps += [
-      "//brave/components/brave_vpn/browser",
+      "//brave/components/brave_vpn/browser:shared",
       "//brave/components/brave_vpn/common",
     ]
+    if (enable_brave_vpn_v1_tests) {
+      deps += [ "//brave/components/brave_vpn/browser" ]
+    }
   }
   if (is_android) {
     deps += [ "//brave/components/brave_mobile_subscription/renderer/android:browser_tests" ]

--- a/test/base/testing_brave_browser_process.cc
+++ b/test/base/testing_brave_browser_process.cc
@@ -18,7 +18,7 @@
 #include "brave/components/brave_vpn/common/buildflags/buildflags.h"
 #include "brave/components/tor/buildflags/buildflags.h"
 
-#if BUILDFLAG(ENABLE_BRAVE_VPN)
+#if BUILDFLAG(ENABLE_BRAVE_VPN) && BUILDFLAG(ENABLE_BRAVE_VPN_V1)
 #include "brave/components/brave_vpn/browser/connection/brave_vpn_connection_manager.h"
 #endif
 namespace tor {
@@ -154,7 +154,7 @@ TestingBraveBrowserProcess::speedreader_rewriter_service() {
 }
 #endif
 
-#if BUILDFLAG(ENABLE_BRAVE_VPN)
+#if BUILDFLAG(ENABLE_BRAVE_VPN) && BUILDFLAG(ENABLE_BRAVE_VPN_V1)
 brave_vpn::BraveVPNConnectionManager*
 TestingBraveBrowserProcess::brave_vpn_connection_manager() {
   return brave_vpn_connection_manager_.get();

--- a/test/base/testing_brave_browser_process.h
+++ b/test/base/testing_brave_browser_process.h
@@ -82,7 +82,7 @@ class TestingBraveBrowserProcess : public BraveBrowserProcess {
   speedreader::SpeedreaderRewriterService* speedreader_rewriter_service()
       override;
 #endif
-#if BUILDFLAG(ENABLE_BRAVE_VPN)
+#if BUILDFLAG(ENABLE_BRAVE_VPN) && BUILDFLAG(ENABLE_BRAVE_VPN_V1)
   brave_vpn::BraveVPNConnectionManager* brave_vpn_connection_manager() override;
   void SetBraveVPNConnectionManagerForTesting(
       std::unique_ptr<brave_vpn::BraveVPNConnectionManager> manager);
@@ -103,7 +103,7 @@ class TestingBraveBrowserProcess : public BraveBrowserProcess {
 
   std::unique_ptr<brave_shields::AdBlockService> ad_block_service_;
 
-#if BUILDFLAG(ENABLE_BRAVE_VPN)
+#if BUILDFLAG(ENABLE_BRAVE_VPN) && BUILDFLAG(ENABLE_BRAVE_VPN_V1)
   std::unique_ptr<brave_vpn::BraveVPNConnectionManager>
       brave_vpn_connection_manager_;
 #endif

--- a/third_party/boringtun/BUILD.gn
+++ b/third_party/boringtun/BUILD.gn
@@ -8,7 +8,7 @@ import("//build/config/clang/clang.gni")
 import("//build/config/rust.gni")
 import("//build/config/sysroot.gni")
 
-assert(enable_brave_vpn2_deps,
+assert(enable_brave_vpn_v2_deps,
        "BoringTun is only buildable when Brave VPN 2.0 deps are enabled")
 
 action("boringtun") {


### PR DESCRIPTION
To add a new BraveVpnService implementation based on Architecture 2.0, which must co-exist with Architecture 1.0 for quite a while, we need to split service's interface and implementation. All the external components will keep accessing VPN service via the BraveVpnService interface, but the implementation mostly goes into BraveVpnServiceImpl.

This change adds the second "stub" BraveVpnService implementation based on the Architecture 2.0, under `brave_vpn::v2` namespace. The instantiation of v2 implementation is preferred when both are enabled, but v2 implementation compiled out by default (based on the GN flags).

The following combinations of BraveVpnService implementations are allowed:
1. BraveVpnServiceImpl v1 only.
2. BraveVpnServiceImpl v2 only.
3. Both BraveVpnServiceImpl v1 and v2 - the factory instantiates v2 (preparation for future runtime selection).
If neither BraveVpnServiceImpl v1 or v2 is enabled, then build fails.

In addition, GN flags controlling architecture-specific unit tests are added. These are supposed to be used in local testing only. In the CI runs, both architectures should be unit-tested, regardless of the implementation build flag settings.

In the change, browser and test GN targets were updated to include v1 and v2 dependencies conditionally, to eliminate any unwanted architecture-specific dependencies.

Resolves https://github.com/brave/brave-browser/issues/54597

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
