### PR TITLE
[ads] Fix AdsService init race in ViewCounterService (uplift to 1.91.x)

### DIFF
--- a/components/ntp_background_images/browser/BUILD.gn
+++ b/components/ntp_background_images/browser/BUILD.gn
@@ -118,6 +118,8 @@ source_set("test_support") {
   sources = [
     "ntp_background_images_service_waiter.cc",
     "ntp_background_images_service_waiter.h",
+    "test/fake_ntp_background_images_service.cc",
+    "test/fake_ntp_background_images_service.h",
   ]
 }
 
@@ -146,6 +148,7 @@ source_set("unit_tests") {
 
   deps = [
     ":browser",
+    ":test_support",
     "//base",
     "//base/test:test_support",
     "//brave/components/brave_rewards/core",

--- a/components/ntp_background_images/browser/test/fake_ntp_background_images_service.cc
+++ b/components/ntp_background_images/browser/test/fake_ntp_background_images_service.cc
@@ -1,0 +1,25 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/ntp_background_images/browser/test/fake_ntp_background_images_service.h"
+
+namespace ntp_background_images {
+
+FakeNTPBackgroundImagesService::FakeNTPBackgroundImagesService(
+    variations::VariationsService* variations_service,
+    component_updater::ComponentUpdateService* component_update_service,
+    PrefService* pref_service)
+    : NTPBackgroundImagesService(variations_service,
+                                 component_update_service,
+                                 pref_service) {}
+
+FakeNTPBackgroundImagesService::~FakeNTPBackgroundImagesService() = default;
+
+void FakeNTPBackgroundImagesService::RegisterSponsoredImagesComponent() {
+  NTPBackgroundImagesService::RegisterSponsoredImagesComponent();
+  ++register_sponsored_images_component_call_count_;
+}
+
+}  // namespace ntp_background_images

--- a/components/ntp_background_images/browser/test/fake_ntp_background_images_service.h
+++ b/components/ntp_background_images/browser/test/fake_ntp_background_images_service.h
@@ -1,0 +1,51 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_NTP_BACKGROUND_IMAGES_BROWSER_TEST_FAKE_NTP_BACKGROUND_IMAGES_SERVICE_H_
+#define BRAVE_COMPONENTS_NTP_BACKGROUND_IMAGES_BROWSER_TEST_FAKE_NTP_BACKGROUND_IMAGES_SERVICE_H_
+
+#include <cstddef>
+
+#include "brave/components/ntp_background_images/browser/ntp_background_images_service.h"
+
+class PrefService;
+
+namespace component_updater {
+class ComponentUpdateService;
+}  // namespace component_updater
+
+namespace variations {
+class VariationsService;
+}  // namespace variations
+
+namespace ntp_background_images {
+
+class FakeNTPBackgroundImagesService final : public NTPBackgroundImagesService {
+ public:
+  FakeNTPBackgroundImagesService(
+      variations::VariationsService* variations_service,
+      component_updater::ComponentUpdateService* component_update_service,
+      PrefService* pref_service);
+
+  FakeNTPBackgroundImagesService(const FakeNTPBackgroundImagesService&) =
+      delete;
+  FakeNTPBackgroundImagesService& operator=(
+      const FakeNTPBackgroundImagesService&) = delete;
+
+  ~FakeNTPBackgroundImagesService() override;
+
+  void RegisterSponsoredImagesComponent() override;
+
+  size_t register_sponsored_images_component_call_count() const {
+    return register_sponsored_images_component_call_count_;
+  }
+
+ private:
+  size_t register_sponsored_images_component_call_count_ = 0;
+};
+
+}  // namespace ntp_background_images
+
+#endif  // BRAVE_COMPONENTS_NTP_BACKGROUND_IMAGES_BROWSER_TEST_FAKE_NTP_BACKGROUND_IMAGES_SERVICE_H_

--- a/components/ntp_background_images/browser/view_counter_service.cc
+++ b/components/ntp_background_images/browser/view_counter_service.cc
@@ -72,6 +72,12 @@ ViewCounterService::ViewCounterService(
 
   if (ads_service_) {
     ads_service_->AddObserver(this);
+    if (ads_service_->IsInitialized()) {
+      // If `AdsService` was initialized before observer registration, the
+      // `ViewCounterService::OnDidInitializeAdsService` callback will not be
+      // called so we call it explicitly.
+      OnDidInitializeAdsService();
+    }
   }
 
   host_content_settings_map_->AddObserver(this);

--- a/components/ntp_background_images/browser/view_counter_service_unittest.cc
+++ b/components/ntp_background_images/browser/view_counter_service_unittest.cc
@@ -25,6 +25,7 @@
 #include "brave/components/ntp_background_images/browser/ntp_background_images_data.h"
 #include "brave/components/ntp_background_images/browser/ntp_background_images_service.h"
 #include "brave/components/ntp_background_images/browser/ntp_sponsored_images_data.h"
+#include "brave/components/ntp_background_images/browser/test/fake_ntp_background_images_service.h"
 #include "brave/components/ntp_background_images/browser/url_constants.h"
 #include "brave/components/ntp_background_images/browser/view_counter_model.h"
 #include "brave/components/ntp_background_images/buildflags/buildflags.h"
@@ -210,11 +211,10 @@ class ViewCounterServiceTest : public testing::Test {
         &prefs_, /* is_off_the_record=*/false, /*store_last_modified=*/false,
         /*restore_session=*/false, /*should_record_metrics=*/false);
 
-    background_images_service_ = std::make_unique<NTPBackgroundImagesService>(
-        /*variations_service=*/nullptr, /*component_updater_service=*/nullptr,
-        &local_state_);
-
-    BraveNTPCustomBackgroundService* custom_background_service = nullptr;
+    background_images_service_ =
+        std::make_unique<FakeNTPBackgroundImagesService>(
+            /*variations_service=*/nullptr,
+            /*component_updater_service=*/nullptr, &local_state_);
 
 #if BUILDFLAG(ENABLE_CUSTOM_BACKGROUND)
     auto custom_background_service_delegate =
@@ -224,17 +224,30 @@ class ViewCounterServiceTest : public testing::Test {
     custom_background_service_ =
         std::make_unique<BraveNTPCustomBackgroundService>(
             std::move(custom_background_service_delegate));
-
-    custom_background_service = custom_background_service_.get();
 #endif  // BUILDFLAG(ENABLE_CUSTOM_BACKGROUND)
 
+    ON_CALL(ads_service_mock_, IsInitialized)
+        .WillByDefault(testing::Return(false));
+
+    CreateViewCounterService();
+  }
+
+  void TearDown() override { host_content_settings_map_->ShutdownOnUIThread(); }
+
+  void SimulateAdsServiceInitialized() {
+    view_counter_service_->OnDidInitializeAdsService();
+  }
+
+  void CreateViewCounterService() {
+    BraveNTPCustomBackgroundService* custom_background_service = nullptr;
+#if BUILDFLAG(ENABLE_CUSTOM_BACKGROUND)
+    custom_background_service = custom_background_service_.get();
+#endif
     view_counter_service_ = std::make_unique<ViewCounterService>(
         host_content_settings_map_.get(), background_images_service_.get(),
         custom_background_service, &ads_service_mock_, &prefs_, &local_state_,
         /*is_supported_locale=*/true);
   }
-
-  void TearDown() override { host_content_settings_map_->ShutdownOnUIThread(); }
 
   void SetSponsoredImagesVisibility(bool should_show) {
     prefs_.SetBoolean(prefs::kNewTabPageShowSponsoredImagesBackgroundImage,
@@ -367,7 +380,7 @@ class ViewCounterServiceTest : public testing::Test {
 
   scoped_refptr<HostContentSettingsMap> host_content_settings_map_;
 
-  std::unique_ptr<NTPBackgroundImagesService> background_images_service_;
+  std::unique_ptr<FakeNTPBackgroundImagesService> background_images_service_;
 
 #if BUILDFLAG(ENABLE_CUSTOM_BACKGROUND)
   std::unique_ptr<BraveNTPCustomBackgroundService> custom_background_service_;
@@ -633,6 +646,28 @@ TEST_F(ViewCounterServiceTest, NewTabsCreatedDailyHistogram) {
   histogram_tester_.ExpectBucketCount(kNewTabsCreatedDailyHistogramName, 7, 1);
 
   histogram_tester_.ExpectTotalCount(kNewTabsCreatedDailyHistogramName, 25);
+}
+
+TEST_F(ViewCounterServiceTest,
+       RegistersSponsoredImagesComponentWhenAdsServiceIsAlreadyInitialized) {
+  EXPECT_EQ(0U, background_images_service_
+                    ->register_sponsored_images_component_call_count());
+
+  EXPECT_CALL(ads_service_mock_, IsInitialized).WillOnce(testing::Return(true));
+  CreateViewCounterService();
+
+  EXPECT_EQ(1U, background_images_service_
+                    ->register_sponsored_images_component_call_count());
+}
+
+TEST_F(ViewCounterServiceTest,
+       RegistersSponsoredImagesComponentWhenAdsServiceIsInitialized) {
+  EXPECT_EQ(0U, background_images_service_
+                    ->register_sponsored_images_component_call_count());
+
+  SimulateAdsServiceInitialized();
+  EXPECT_EQ(1U, background_images_service_
+                    ->register_sponsored_images_component_call_count());
 }
 
 }  // namespace ntp_background_images


### PR DESCRIPTION
Uplift of #36591
Resolves https://github.com/brave/brave-browser/issues/55707

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.