### PR TITLE
[VPN] Update server-status VPN API endpoint

### DIFF
--- a/components/brave_vpn/browser/connection/ikev2/mac/ikev2_connection_api_impl_mac.mm
+++ b/components/brave_vpn/browser/connection/ikev2/mac/ikev2_connection_api_impl_mac.mm
@@ -19,6 +19,7 @@
 #include "base/logging.h"
 #include "base/strings/sys_string_conversions.h"
 #include "brave/components/brave_vpn/browser/connection/brave_vpn_connection_manager.h"
+#include "brave/components/brave_vpn/common/brave_vpn_constants.h"
 #include "brave/components/brave_vpn/common/pref_names.h"
 #include "components/prefs/pref_service.h"
 #include "services/network/public/cpp/shared_url_loader_factory.h"
@@ -215,10 +216,11 @@ void IKEv2ConnectionAPIImplMac::CreateVPNConnectionImpl(
       vpn_server_connect_rule.interfaceTypeMatch =
           NEOnDemandRuleInterfaceTypeAny;
       vpn_server_connect_rule.probeURL = [NSURL
-          URLWithString:
-              [NSString
-                  stringWithFormat:@"https://%@/vpnsrv/api/server-status",
-                                   base::SysUTF8ToNSString(info.hostname())]];
+          URLWithString:[NSString stringWithFormat:@"https://%@/%@",
+                                                   base::SysUTF8ToNSString(
+                                                       info.hostname()),
+                                                   base::SysUTF8ToNSString(
+                                                       kServerStatus)]];
       [vpn_manager setOnDemandRules:@[ vpn_server_connect_rule ]];
     }
 

--- a/components/brave_vpn/common/brave_vpn_constants.h
+++ b/components/brave_vpn/common/brave_vpn_constants.h
@@ -53,6 +53,7 @@ inline constexpr char kCredential[] = "api/v1.3/device/";
 inline constexpr char kVerifyPurchaseToken[] = "api/v1.1/verify-purchase-token";
 inline constexpr char kCreateSubscriberCredentialV12[] =
     "api/v1.2/subscriber-credential/create";
+inline constexpr char kServerStatus[] = "api/v1.3/server-status";
 inline constexpr int kP3AIntervalHours = 24;
 
 inline constexpr char kSubscriberCredentialKey[] = "credential";


### PR DESCRIPTION
## Description

On Mac, we use a server-status endpoint for OnDemand VPN functionality. The change upgrades the old (current) API `/vpnsrv/api/server-status`, to the new one: `/api/v1.3/server-status`. The API responses are claimed by Guardian to be identical, zero behavioural change.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/55678

## Test plan
See https://github.com/brave/brave-browser/issues/55678

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
