### PR TITLE
[Origin] Honor BraveRewardsDisabled policy when starting Rewards engine

### DIFF
--- a/browser/brave_rewards/BUILD.gn
+++ b/browser/brave_rewards/BUILD.gn
@@ -41,6 +41,7 @@ source_set("brave_rewards_impl") {
   deps = [
     ":util",
     "//base",
+    "//brave/components/brave_policy:policy_initialization_waiter",
     "//brave/components/brave_rewards/content",
     "//brave/components/brave_rewards/core",
     "//brave/components/brave_rewards/core:features",
@@ -52,6 +53,7 @@ source_set("brave_rewards_impl") {
     "//chrome/browser/profiles",
     "//chrome/browser/ui",
     "//components/keyed_service/content",
+    "//components/policy/core/common",
     "//components/prefs",
     "//components/sessions",
   ]

--- a/browser/brave_rewards/rewards_service_factory.cc
+++ b/browser/brave_rewards/rewards_service_factory.cc
@@ -10,6 +10,7 @@
 
 #include "base/no_destructor.h"
 #include "brave/browser/brave_rewards/rewards_util.h"
+#include "brave/components/brave_policy/policy_initialization_waiter.h"
 #include "brave/components/brave_rewards/content/rewards_notification_service_observer.h"
 #include "brave/components/brave_rewards/content/rewards_service.h"
 #include "brave/components/brave_rewards/content/rewards_service_impl.h"
@@ -19,9 +20,11 @@
 #include "chrome/browser/bitmap_fetcher/bitmap_fetcher_service_factory.h"
 #include "chrome/browser/browser_process.h"
 #include "chrome/browser/favicon/favicon_service_factory.h"
+#include "chrome/browser/policy/profile_policy_connector.h"
 #include "chrome/browser/profiles/incognito_helpers.h"
 #include "chrome/browser/profiles/profile.h"
 #include "components/keyed_service/content/browser_context_dependency_manager.h"
+#include "components/policy/core/common/policy_service.h"
 #include "content/public/browser/storage_partition.h"
 
 #if BUILDFLAG(ENABLE_BRAVE_WALLET)
@@ -93,12 +96,21 @@ RewardsServiceFactory::BuildServiceInstanceForBrowserContext(
       },
       profile);
 
+  policy::PolicyService* policy_service = nullptr;
+  if (auto* policy_connector = profile->GetProfilePolicyConnector()) {
+    policy_service = policy_connector->policy_service();
+  }
+  auto policy_initialization_waiter =
+      std::make_unique<brave_policy::PolicyInitializationWaiter>(
+          policy_service);
+
   std::unique_ptr<RewardsServiceImpl> rewards_service =
       std::make_unique<RewardsServiceImpl>(
           profile->GetPrefs(), profile->GetPath(),
           FaviconServiceFactory::GetForProfile(
               profile, ServiceAccessType::EXPLICIT_ACCESS),
-          g_browser_process->os_crypt_async(), request_image_callback,
+          g_browser_process->os_crypt_async(),
+          std::move(policy_initialization_waiter), request_image_callback,
           cancel_request_image_callback, profile->GetDefaultStoragePartition()
 #if BUILDFLAG(ENABLE_BRAVE_WALLET)
                                              ,

--- a/browser/sources.gni
+++ b/browser/sources.gni
@@ -818,6 +818,17 @@ if (enable_brave_ads) {
   ]
 }
 
+# `rewards_service_factory.cc` includes `chrome/browser/policy/
+# profile_policy_connector.h`, which lives in the `//chrome/browser:browser`
+# monolith. Since `:browser` already depends on `:brave_rewards_impl` (added
+# above), the include can only resolve via a circular-include allowance.
+# Drop this entry once the header is componentized upstream
+# (crbug.com/353332589).
+if (enable_brave_rewards) {
+  brave_chrome_browser_allow_circular_includes_from +=
+      [ "//brave/browser/brave_rewards:brave_rewards_impl" ]
+}
+
 if (toolkit_views) {
   brave_chrome_browser_deps += [
     "//brave/browser/ui/sidebar:sidebar_impl",

--- a/components/brave_rewards/content/BUILD.gn
+++ b/components/brave_rewards/content/BUILD.gn
@@ -37,6 +37,7 @@ static_library("content") {
     "//brave/brave_domains:urls",
     "//brave/components/api_request_helper",
     "//brave/components/brave_ads/buildflags",
+    "//brave/components/brave_policy:policy_initialization_waiter",
     "//brave/components/brave_rewards/core",
     "//brave/components/brave_rewards/core:features",
     "//brave/components/brave_rewards/core/buildflags",

--- a/components/brave_rewards/content/rewards_service_impl.cc
+++ b/components/brave_rewards/content/rewards_service_impl.cc
@@ -277,9 +277,6 @@ bool RewardsServiceImpl::IsInitialized() {
 
 void RewardsServiceImpl::Init() {
   AddObserver(notification_service_.get());
-
-  // Must be active regardless of whether the engine starts so that
-  // pref-driven changes are observed.
   InitPrefChangeRegistrar();
 
   // Defer the boot-time engine-start gate until the policy bundle has been
@@ -341,13 +338,9 @@ void RewardsServiceImpl::OnPreferenceChanged(const std::string& key) {
 }
 
 void RewardsServiceImpl::CheckPreferences() {
-  // Bail when Rewards is not supported for this profile (managed
-  // `BraveRewardsDisabled` policy, Android feature flag off, or OFAC-sanctioned
-  // region). The factory already gates `GetForProfile`, but `Init()` is
-  // deferred behind `policy_initialization_waiter_` so the managed pref may
-  // have become visible since the factory built the service -- re-check here
-  // before any Ads → Rewards force-enable so the engine never starts and no
-  // Rewards endpoints are pinged.
+  // Re-check support after `policy_initialization_waiter_` fires; managed
+  // `prefs::kDisabledByPolicy` may not have been visible when the factory ran
+  // its `IsSupported` gate.
   if (!IsSupported(prefs_)) {
     return;
   }

--- a/components/brave_rewards/content/rewards_service_impl.cc
+++ b/components/brave_rewards/content/rewards_service_impl.cc
@@ -35,6 +35,7 @@
 #include "brave/brave_domains/urls.h"
 #include "brave/components/api_request_helper/api_request_helper.h"
 #include "brave/components/brave_ads/buildflags/buildflags.h"
+#include "brave/components/brave_policy/policy_initialization_waiter.h"
 #include "brave/components/brave_rewards/content/diagnostic_log.h"
 #include "brave/components/brave_rewards/content/logging.h"
 #include "brave/components/brave_rewards/content/rewards_notification_service.h"
@@ -208,6 +209,8 @@ RewardsServiceImpl::RewardsServiceImpl(
     const base::FilePath& profile_path,
     favicon::FaviconService* favicon_service,
     os_crypt_async::OSCryptAsync* os_crypt,
+    std::unique_ptr<brave_policy::PolicyInitializationWaiter>
+        policy_initialization_waiter,
     RequestImageCallback request_image_callback,
     CancelImageRequestCallback cancel_image_request_callback,
     content::StoragePartition* storage_partition
@@ -239,7 +242,10 @@ RewardsServiceImpl::RewardsServiceImpl(
       rewards_database_(file_task_runner_),
       creator_prefix_store_(file_task_runner_),
       notification_service_(new RewardsNotificationServiceImpl(prefs)),
+      policy_initialization_waiter_(std::move(policy_initialization_waiter)),
       conversion_monitor_(prefs) {
+  CHECK(policy_initialization_waiter_);
+
   ready_ = std::make_unique<base::OneShotEvent>();
 
   if (base::FeatureList::IsEnabled(features::kVerboseLoggingFeature)) {
@@ -271,8 +277,16 @@ bool RewardsServiceImpl::IsInitialized() {
 
 void RewardsServiceImpl::Init() {
   AddObserver(notification_service_.get());
-  CheckPreferences();
+
+  // Must be active regardless of whether the engine starts so that
+  // pref-driven changes are observed.
   InitPrefChangeRegistrar();
+
+  // Defer the boot-time engine-start gate until the policy bundle has been
+  // merged into the managed pref store, so that `BraveRewardsDisabled` (which
+  // writes `prefs::kDisabledByPolicy`) is visible when the gate evaluates.
+  policy_initialization_waiter_->Wait(
+      base::BindOnce(&RewardsServiceImpl::CheckPreferences, AsWeakPtr()));
 }
 
 void RewardsServiceImpl::InitPrefChangeRegistrar() {
@@ -327,6 +341,17 @@ void RewardsServiceImpl::OnPreferenceChanged(const std::string& key) {
 }
 
 void RewardsServiceImpl::CheckPreferences() {
+  // Bail when Rewards is not supported for this profile (managed
+  // `BraveRewardsDisabled` policy, Android feature flag off, or OFAC-sanctioned
+  // region). The factory already gates `GetForProfile`, but `Init()` is
+  // deferred behind `policy_initialization_waiter_` so the managed pref may
+  // have become visible since the factory built the service -- re-check here
+  // before any Ads → Rewards force-enable so the engine never starts and no
+  // Rewards endpoints are pinged.
+  if (!IsSupported(prefs_)) {
+    return;
+  }
+
 #if BUILDFLAG(ENABLE_BRAVE_ADS)
   if (prefs_->GetBoolean(brave_ads::prefs::kOptedInToNotificationAds)) {
     // If the user has enabled Ads, but the "enabled" pref is missing, set the

--- a/components/brave_rewards/content/rewards_service_impl.h
+++ b/components/brave_rewards/content/rewards_service_impl.h
@@ -95,10 +95,6 @@ using CancelImageRequestCallback = base::RepeatingCallback<void(int)>;
 class RewardsServiceImpl final : public RewardsService,
                                  public mojom::RewardsEngineClient {
  public:
-  // `policy_initialization_waiter` defers the boot-time engine-start gate
-  // (`CheckPreferences()` in `Init()`) until the policy bundle has been merged
-  // into the managed pref store, so that `BraveRewardsDisabled` takes effect
-  // before the gate evaluates.
   RewardsServiceImpl(PrefService* prefs,
                      const base::FilePath& profile_path,
                      favicon::FaviconService* favicon_service,

--- a/components/brave_rewards/content/rewards_service_impl.h
+++ b/components/brave_rewards/content/rewards_service_impl.h
@@ -61,6 +61,10 @@ namespace os_crypt_async {
 class OSCryptAsync;
 }  // namespace os_crypt_async
 
+namespace brave_policy {
+class PolicyInitializationWaiter;
+}  // namespace brave_policy
+
 #if BUILDFLAG(ENABLE_BRAVE_WALLET)
 namespace brave_wallet {
 class BraveWalletService;
@@ -91,10 +95,16 @@ using CancelImageRequestCallback = base::RepeatingCallback<void(int)>;
 class RewardsServiceImpl final : public RewardsService,
                                  public mojom::RewardsEngineClient {
  public:
+  // `policy_initialization_waiter` defers the boot-time engine-start gate
+  // (`CheckPreferences()` in `Init()`) until the policy bundle has been merged
+  // into the managed pref store, so that `BraveRewardsDisabled` takes effect
+  // before the gate evaluates.
   RewardsServiceImpl(PrefService* prefs,
                      const base::FilePath& profile_path,
                      favicon::FaviconService* favicon_service,
                      os_crypt_async::OSCryptAsync* os_crypt,
+                     std::unique_ptr<brave_policy::PolicyInitializationWaiter>
+                         policy_initialization_waiter,
                      RequestImageCallback request_image_callback,
                      CancelImageRequestCallback cancel_image_request_callback,
                      content::StoragePartition* storage_partition
@@ -485,6 +495,8 @@ class RewardsServiceImpl final : public RewardsService,
   SimpleURLLoaderList url_loaders_;
   std::map<std::string, int> current_media_fetchers_;
   PrefChangeRegistrar profile_pref_change_registrar_;
+  std::unique_ptr<brave_policy::PolicyInitializationWaiter>
+      policy_initialization_waiter_;
 
   bool engine_for_testing_ = false;
   bool resetting_rewards_ = false;


### PR DESCRIPTION
Defer `RewardsServiceImpl::CheckPreferences()` -- the gate that decides whether to spin up the Rewards engine process -- behind a `brave_policy::PolicyInitializationWaiter` so that the managed `brave_rewards::prefs::kDisabledByPolicy` pref is visible by the time the gate evaluates. Without this, `Init()` runs before the policy bundle has been merged into the managed pref store and the engine starts -- pinging `/v1/parameters` and `/v4/wallets/...` -- even when Brave Origin has disabled Rewards via `BraveRewardsDisabled`.

Resolves: https://github.com/brave/brave-browser/issues/55696

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
