### PR TITLE
Fix crash when opening Rewards panel after disabling via Brave Origin

### DIFF
--- a/browser/ui/views/brave_actions/brave_rewards_action_view.cc
+++ b/browser/ui/views/brave_actions/brave_rewards_action_view.cc
@@ -16,6 +16,7 @@
 #include "brave/browser/ui/page_info/features.h"
 #include "brave/browser/ui/views/brave_actions/brave_icon_with_badge_image_source.h"
 #include "brave/browser/ui/webui/brave_rewards/rewards_page_top_ui.h"
+#include "brave/browser/ui/webui/brave_rewards/rewards_web_ui_utils.h"
 #include "brave/components/brave_rewards/content/rewards_p3a.h"
 #include "brave/components/brave_rewards/content/rewards_service.h"
 #include "brave/components/brave_rewards/core/pref_names.h"
@@ -406,6 +407,15 @@ void BraveRewardsActionView::ToggleRewardsPanel() {
   if (IsPanelOpen()) {
     DCHECK(bubble_manager_);
     bubble_manager_->CloseBubble();
+    return;
+  }
+
+  // If the Rewards WebUI has just been disabled (e.g. via Brave Origin or
+  // enterprise policy) but the browser has not yet been restarted, the WebUI
+  // config has been unregistered. Attempting to show the bubble in that state
+  // would dereference a null `TopChromeWebUIConfig` and crash.
+  if (brave_rewards::ShouldBlockRewardsWebUI(
+          browser_window_interface_->GetProfile(), GURL(kRewardsPageTopURL))) {
     return;
   }
 


### PR DESCRIPTION
## Summary

- Resolves https://github.com/brave/brave-browser/issues/55718

When the user disables Brave Rewards via `brave://settings/origin` (or via enterprise policy), the `brave_rewards::prefs::kDisabledByPolicy` pref is set immediately. This causes `RewardsPageTopUIConfig::IsWebUIEnabled()` to return `false`, which unregisters the WebUI config from the `WebUIConfigMap`. However, the BAT location bar button remains visible until the user restarts. Clicking it before restart caused a null deref in `WebUIContentsWrapperT<T>`'s constructor, where `TopChromeWebUIConfig::From(profile, webui_url)->ShouldAutoResizeHost()` was called on a null config.

This bails out of `BraveRewardsActionView::ToggleRewardsPanel()` when the Rewards WebUI is blocked, using the same `ShouldBlockRewardsWebUI` helper already used in `BraveWebUIControllerFactory`.

## Test plan

- [ ] Install/launch a Brave channel that supports Brave Origin
- [ ] Upgrade profile to Origin and enable Rewards, relaunching as required
- [ ] Join Rewards and view at least one notification ad
- [ ] Go to `brave://settings/origin`, toggle Rewards off (or "Reset to defaults"), do **not** restart
- [ ] Click the BAT logo in the URL bar -> verify no crash (panel simply doesn't open)
- [ ] Restart and verify the BAT logo is hidden and Rewards is fully disabled