### PR TITLE
[iOS] [Origin] Dont show sponsored images when rewards is unavailable (uplift to 1.91.x)

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -300,7 +300,8 @@ public class BrowserViewController: UIViewController {
     feedDataSource.historyAPI = profileController.historyAPI
     backgroundDataSource = .init(
       service: profileController.backgroundImagesService,
-      rewards: rewards,
+      rewards: BraveRewards.isSupported(prefService: profileController.profile.prefs)
+        ? rewards : nil,
       privateBrowsingManager: privateBrowsingManager
     )
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/Display/NewTabPageSettingsView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/Display/NewTabPageSettingsView.swift
@@ -9,6 +9,7 @@ import Preferences
 import SwiftUI
 
 struct NewTabPageSettingsView: View {
+  var isSponsoredBackgroundsSupported: Bool
   var shouldShowSponsoredImagesAndVideosSetting: Bool
   var linkTapped: ((URLRequest) -> Void)?
 
@@ -25,7 +26,7 @@ struct NewTabPageSettingsView: View {
       Section {
         Toggle(Strings.NTP.settingsBackgroundImages, isOn: $backgroundImages.value)
           .listRowBackground(Color(.secondaryBraveGroupedBackground))
-        if backgroundImages.value {
+        if backgroundImages.value, isSponsoredBackgroundsSupported {
           NavigationLink {
             BackgroundMediaTypePicker(
               shouldShowSponsoredImagesAndVideosSetting: shouldShowSponsoredImagesAndVideosSetting,
@@ -132,6 +133,7 @@ class NTPTableViewController: UIHostingController<NewTabPageSettingsView> {
   init(rewards: BraveRewards?, linkTapped: ((URLRequest) -> Void)?) {
     super.init(
       rootView: .init(
+        isSponsoredBackgroundsSupported: rewards != nil,
         shouldShowSponsoredImagesAndVideosSetting:
           rewards?.ads.shouldShowSponsoredImagesAndVideosSetting() == true,
         linkTapped: linkTapped

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/SettingsViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/SettingsViewController.swift
@@ -1126,7 +1126,8 @@ class SettingsViewController: TableViewController {
         selection: { [unowned self] in
           self.navigationController?.pushViewController(
             NTPTableViewController(
-              rewards: rewards,
+              rewards: BraveRewards.isSupported(prefService: braveCore.profile.prefs)
+                ? rewards : nil,
               linkTapped: { [unowned self] request in
                 self.tabManager.addTabAndSelect(
                   request,


### PR DESCRIPTION
Uplift of #36613
Resolves https://github.com/brave/brave-browser/issues/55703

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.