### PR TITLE
[ads] Disable survey panelist when NTP sponsored images are disabled

### DIFF
--- a/components/brave_ads/core/browser/virtual_pref/virtual_pref_provider.cc
+++ b/components/brave_ads/core/browser/virtual_pref/virtual_pref_provider.cc
@@ -125,6 +125,14 @@ bool IsSurveyPanelist(const PrefService& prefs) {
   if (prefs.GetBoolean(brave_rewards::prefs::kDisabledByPolicy)) {
     return false;
   }
+
+  if (!prefs.GetBoolean(
+          ntp_background_images::prefs::kNewTabPageShowBackgroundImage) ||
+      !prefs.GetBoolean(ntp_background_images::prefs::
+                            kNewTabPageShowSponsoredImagesBackgroundImage)) {
+    return false;
+  }
+
   return prefs.GetBoolean(
       ntp_background_images::prefs::kNewTabPageSponsoredImagesSurveyPanelist);
 }

--- a/components/brave_ads/core/browser/virtual_pref/virtual_pref_provider_unittest.cc
+++ b/components/brave_ads/core/browser/virtual_pref/virtual_pref_provider_unittest.cc
@@ -33,6 +33,12 @@ class BraveAdsVirtualPrefProviderTest : public ::testing::Test {
         ntp_background_images::prefs::kNewTabPageSponsoredImagesSurveyPanelist,
         true);
     prefs_.registry()->RegisterBooleanPref(
+        ntp_background_images::prefs::kNewTabPageShowBackgroundImage, true);
+    prefs_.registry()->RegisterBooleanPref(
+        ntp_background_images::prefs::
+            kNewTabPageShowSponsoredImagesBackgroundImage,
+        true);
+    prefs_.registry()->RegisterBooleanPref(
         brave_rewards::prefs::kDisabledByPolicy, false);
     local_state_.registry()->RegisterDictionaryPref(skus::prefs::kSkusState);
 
@@ -131,6 +137,24 @@ TEST_F(BraveAdsVirtualPrefProviderTest, IsSurveyPanelist) {
   // Assert
   EXPECT_TRUE(
       virtual_prefs.FindBoolByDottedPath("[virtual]:is_survey_panelist"));
+}
+
+TEST_F(BraveAdsVirtualPrefProviderTest,
+       IsNotSurveyPanelistWhenOptedOutOfNewTabPageAds) {
+  // Arrange
+  prefs_.SetBoolean(
+      ntp_background_images::prefs::kNewTabPageShowBackgroundImage, false);
+  prefs_.SetBoolean(ntp_background_images::prefs::
+                        kNewTabPageShowSponsoredImagesBackgroundImage,
+                    false);
+
+  // Act
+  const base::DictValue virtual_prefs = GetVirtualPrefs();
+
+  // Assert
+  EXPECT_THAT(
+      virtual_prefs.FindBoolByDottedPath("[virtual]:is_survey_panelist"),
+      testing::Optional(false));
 }
 
 TEST_F(BraveAdsVirtualPrefProviderTest, SearchEngineDefaultName) {

--- a/components/brave_ads/core/internal/settings/settings.cc
+++ b/components/brave_ads/core/internal/settings/settings.cc
@@ -62,6 +62,11 @@ bool UserHasOptedInToSurveyPanelist() {
   if (GetProfileBooleanPref(brave_rewards::prefs::kDisabledByPolicy)) {
     return false;
   }
+
+  if (!UserHasOptedInToNewTabPageAds()) {
+    return false;
+  }
+
   return GetProfileBooleanPref(
       ntp_background_images::prefs::kNewTabPageSponsoredImagesSurveyPanelist);
 }

--- a/components/brave_ads/core/internal/settings/settings_unittest.cc
+++ b/components/brave_ads/core/internal/settings/settings_unittest.cc
@@ -11,6 +11,8 @@
 #include "brave/components/brave_ads/core/internal/settings/test/settings_test_util.h"
 #include "brave/components/brave_ads/core/public/ad_units/notification_ad/notification_ad_feature.h"
 #include "brave/components/brave_ads/core/public/prefs/pref_names.h"
+#include "brave/components/brave_rewards/core/pref_names.h"
+#include "brave/components/ntp_background_images/common/pref_names.h"
 
 // npm run test -- brave_unit_tests --filter=BraveAds*
 
@@ -105,6 +107,48 @@ TEST_F(BraveAdsSettingsTest, UserHasNotOptedInToSearchResultAds) {
 
   // Act & Assert
   EXPECT_FALSE(UserHasOptedInToSearchResultAds());
+}
+
+TEST_F(BraveAdsSettingsTest, UserHasOptedInToSurveyPanelist) {
+  // Arrange
+  test::SetProfileBooleanPrefValue(
+      ntp_background_images::prefs::kNewTabPageSponsoredImagesSurveyPanelist,
+      true);
+
+  // Act & Assert
+  EXPECT_TRUE(UserHasOptedInToSurveyPanelist());
+}
+
+TEST_F(BraveAdsSettingsTest, UserHasNotOptedInToSurveyPanelist) {
+  // Arrange
+  test::SetProfileBooleanPrefValue(
+      ntp_background_images::prefs::kNewTabPageSponsoredImagesSurveyPanelist,
+      false);
+
+  // Act & Assert
+  EXPECT_FALSE(UserHasOptedInToSurveyPanelist());
+}
+
+TEST_F(BraveAdsSettingsTest,
+       UserHasNotOptedInToSurveyPanelistWhenOptedOutOfNewTabPageAds) {
+  // Arrange
+  test::OptOutOfNewTabPageAds();
+
+  // Act & Assert
+  EXPECT_FALSE(UserHasOptedInToSurveyPanelist());
+}
+
+TEST_F(BraveAdsSettingsTest,
+       UserHasNotOptedInToSurveyPanelistWhenRewardsDisabledByPolicy) {
+  // Arrange
+  test::SetProfileBooleanPrefValue(
+      ntp_background_images::prefs::kNewTabPageSponsoredImagesSurveyPanelist,
+      true);
+  test::SetProfileBooleanPrefValue(brave_rewards::prefs::kDisabledByPolicy,
+                                   true);
+
+  // Act & Assert
+  EXPECT_FALSE(UserHasOptedInToSurveyPanelist());
 }
 
 }  // namespace brave_ads


### PR DESCRIPTION
Disable survey panelist for users who have disabled NTP sponsored images.

Part of https://github.com/brave/brave-browser/issues/54917

<!-- Add brave-browser issue below that this PR will resolve -->

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
