### PR TITLE
[AI Chat]: Make sure we add content when navigating from an non-associable page to https://

### DIFF
--- a/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
+++ b/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
@@ -475,13 +475,9 @@ void AIChatUIPageHandler::OnTabStripModelChanged(
 
   auto* new_contents = selection.new_contents.get();
   if (new_contents) {
-    // Note: We treat not being allowed to associate the content the same as not
-    // having content.
     auto* active_chat_tab_helper =
         ai_chat::AIChatTabHelper::FromWebContents(new_contents);
-    if (active_chat_tab_helper &&
-        ai_chat::CanAssociateContent(
-            &active_chat_tab_helper->web_contents_content())) {
+    if (active_chat_tab_helper) {
       active_chat_tab_helper_ = active_chat_tab_helper;
       associated_content_delegate_observation_.Observe(
           &active_chat_tab_helper_->web_contents_content());

--- a/browser/ui/webui/ai_chat/ai_chat_ui_page_handler_unittest.cc
+++ b/browser/ui/webui/ai_chat/ai_chat_ui_page_handler_unittest.cc
@@ -10,23 +10,34 @@
 
 #include "base/memory/raw_ptr.h"
 #include "base/strings/utf_string_conversions.h"
+#include "base/test/scoped_feature_list.h"
 #include "base/test/test_future.h"
 #include "brave/browser/ai_chat/ai_chat_service_factory.h"
 #include "brave/browser/brave_shields/brave_shields_web_contents_observer.h"
 #include "brave/browser/ephemeral_storage/ephemeral_storage_tab_helper.h"
+#include "brave/components/ai_chat/content/browser/ai_chat_tab_helper.h"
 #include "brave/components/ai_chat/content/browser/associated_url_content.h"
 #include "brave/components/ai_chat/core/browser/ai_chat_service.h"
 #include "brave/components/ai_chat/core/browser/conversation_handler.h"
+#include "brave/components/ai_chat/core/common/features.h"
 #include "brave/components/ai_chat/core/common/mojom/ai_chat.mojom.h"
 #include "brave/components/ai_chat/core/common/mojom/common.mojom.h"
+#include "build/build_config.h"
 #include "chrome/test/base/chrome_render_view_host_test_harness.h"
 #include "content/public/test/web_contents_tester.h"
+#include "mojo/public/cpp/bindings/pending_remote.h"
+#include "mojo/public/cpp/bindings/receiver.h"
 #include "pdf/buildflags.h"
 #include "services/data_decoder/public/cpp/test_support/in_process_data_decoder.h"
 #include "testing/gtest/include/gtest/gtest.h"
 #include "ui/gfx/codec/png_codec.h"
 #include "ui/gfx/image/image_unittest_util.h"
 #include "url/gurl.h"
+
+#if !BUILDFLAG(IS_ANDROID)
+#include "chrome/browser/ui/tabs/tab_strip_model_observer.h"
+#include "content/public/test/navigation_simulator.h"
+#endif
 
 namespace ai_chat {
 
@@ -214,5 +225,127 @@ TEST_F(AIChatUIPageHandlerTest, ProcessPdfFile_LooksLikePdfRejection) {
   }
 }
 #endif  // BUILDFLAG(ENABLE_PDF)
+
+#if !BUILDFLAG(IS_ANDROID)
+
+namespace {
+
+class FakeChatUI : public mojom::ChatUI {
+ public:
+  void OnNewDefaultConversation(std::optional<int32_t> content_id) override {
+    last_content_id_ = content_id;
+    call_count_++;
+  }
+  void OnChildFrameBound(
+      mojo::PendingReceiver<mojom::ParentUIFrame> receiver) override {}
+
+  std::optional<int32_t> last_content_id_;
+  int call_count_ = 0;
+};
+
+}  // namespace
+
+// Fixture that exercises the global side panel mode of the page handler so
+// that OnTabStripModelChanged runs end-to-end. The page handler is constructed
+// without a TabStripModel and the test invokes OnTabStripModelChanged directly
+// via the TabStripModelObserver interface.
+class AIChatUIPageHandlerGlobalSidePanelTest
+    : public ChromeRenderViewHostTestHarness {
+ public:
+  AIChatUIPageHandlerGlobalSidePanelTest() {
+    scoped_feature_list_.InitAndEnableFeature(
+        features::kAIChatGlobalSidePanelEverywhere);
+  }
+
+  void SetUp() override {
+    ChromeRenderViewHostTestHarness::SetUp();
+
+    ASSERT_TRUE(
+        AIChatServiceFactory::GetForBrowserContext(GetBrowserContext()));
+
+    // The constructor expects an AIChatTabHelper on chat_context_web_contents.
+    AIChatTabHelper::CreateForWebContents(web_contents(), nullptr);
+
+    mojo::PendingReceiver<mojom::AIChatUIHandler> receiver;
+    page_handler_ = std::make_unique<AIChatUIPageHandler>(
+        web_contents(), web_contents(),
+        Profile::FromBrowserContext(GetBrowserContext()), std::move(receiver));
+  }
+
+  void TearDown() override {
+    page_handler_.reset();
+    ChromeRenderViewHostTestHarness::TearDown();
+  }
+
+ protected:
+  FakeChatUI& BindFakeChatUI() {
+    mojo::PendingRemote<mojom::ChatUI> pending_remote;
+    fake_chat_ui_receiver_.emplace(
+        &fake_chat_ui_, pending_remote.InitWithNewPipeAndPassReceiver());
+    base::test::TestFuture<bool> future;
+    page_handler_->SetChatUI(std::move(pending_remote), future.GetCallback());
+    EXPECT_TRUE(future.Wait());
+    fake_chat_ui_receiver_->FlushForTesting();
+    return fake_chat_ui_;
+  }
+
+  void FlushChatUI() { fake_chat_ui_receiver_->FlushForTesting(); }
+
+  AIChatUIPageHandler* page_handler() { return page_handler_.get(); }
+
+ private:
+  base::test::ScopedFeatureList scoped_feature_list_;
+  std::unique_ptr<AIChatUIPageHandler> page_handler_;
+  FakeChatUI fake_chat_ui_;
+  std::optional<mojo::Receiver<mojom::ChatUI>> fake_chat_ui_receiver_;
+};
+
+// Regression test: switching to a tab whose current page is not associable
+// (e.g. about:blank) must still set up observation of the tab's AIChatTabHelper
+// so that a subsequent navigation to an https:// page notifies the frontend.
+TEST_F(AIChatUIPageHandlerGlobalSidePanelTest,
+       SwitchToNonAssociableTabThenNavigateToHttpsNotifiesFrontend) {
+  auto& fake_chat_ui = BindFakeChatUI();
+
+  // Create a new tab WebContents at a non-associable URL (about:blank) with
+  // an AIChatTabHelper attached.
+  std::unique_ptr<content::WebContents> new_tab =
+      content::WebContentsTester::CreateTestWebContents(GetBrowserContext(),
+                                                        nullptr);
+  AIChatTabHelper::CreateForWebContents(new_tab.get(), nullptr);
+
+  // Simulate the active tab changing to |new_tab|.
+  TabStripSelectionChange selection;
+  selection.old_contents = web_contents();
+  selection.new_contents = new_tab.get();
+  ASSERT_TRUE(selection.active_tab_changed());
+
+  TabStripModelChange empty_change;
+  static_cast<TabStripModelObserver*>(page_handler())
+      ->OnTabStripModelChanged(/*tab_strip_model=*/nullptr, empty_change,
+                               selection);
+  FlushChatUI();
+
+  // The tab switch itself notifies the frontend, but because the new tab's
+  // current URL is non-associable the content_id is null.
+  EXPECT_FALSE(fake_chat_ui.last_content_id_.has_value());
+  const int count_before_nav = fake_chat_ui.call_count_;
+
+  // Navigate the new tab to an associable https:// URL. Prior to the fix the
+  // handler would not have been observing |new_tab|'s helper because its
+  // initial page was not associable, so this navigation would have gone
+  // unnoticed.
+  content::NavigationSimulator::NavigateAndCommitFromBrowser(
+      new_tab.get(), GURL("https://example.com"));
+  FlushChatUI();
+
+  EXPECT_GT(fake_chat_ui.call_count_, count_before_nav)
+      << "Navigating a non-associable tab to https:// should notify the "
+         "frontend";
+  EXPECT_TRUE(fake_chat_ui.last_content_id_.has_value())
+      << "https:// page should produce a non-null content_id";
+}
+
+#endif  // !BUILDFLAG(IS_ANDROID)
 
 }  // namespace ai_chat


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/55702

This was an overzealous optimization - we need to be observing the WebContents to know when it navigates.

I've confirmed that the current tab is still detached when switching from https:// to chrome:// pages and navigating from a chrome:// page to a https:// page now attaches the content.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
