### PR TITLE
[plaster] Introducing a 🩹 YAML frontend

### DIFF
--- a/docs/plaster.md
+++ b/docs/plaster.md
@@ -1,10 +1,10 @@
-# 🩹 Plaster and semantical patching
+# 🩹 _Plaster_ and semantical patching
 
-Plaster is an experimental tool being introduced in Brave to allow us to apply
-changes to upstream sources files, by relying on regex transformations for to
-search for patterns and apply substitutions.
+_Plaster_ is an experimental tool being introduced in Brave to allow us to apply
+changes to upstream sources files, by relying on regex transformations to search
+for patterns and apply substitutions.
 
-## Why 🩹 Plaster
+## Why 🩹 _Plaster_
 
 The two traditional approaches to introduce changes to Chromium have been `git`
 patches (i.e. `patches/`), and language overrides (i.e. `chromium_src/`). The
@@ -14,16 +14,19 @@ language overrides, although more flexible than patches, they tend to be
 invisible in the source code target, hard to interpret, and lead to many cases
 of unintended replacements.
 
-Using regexes, Plaster avoids the brittleness of patch files, while providing
+Using regexes, _Plaster_ avoids the brittleness of patch files, while providing
 matching mechanisms that are more flexible than the methods currently employed
 for macro replacement. This also means a language-agnostic way to approach
-source changes semantically, and in place. Plaster changes can be both seen in
-place, as well as audit as patch files.
+source changes semantically, and in place. _Plaster_ changes can be both seen in
+place, as well as audited as patch files.
 
 ## How does it work
 
-Plaster files are placed under `rewrite/`, using a `.toml` extension, and they
-are supposed to match the path for the file being plastered.
+_Plaster_ files are placed under `rewrite/`, using a `.yaml` extension, and they
+are supposed to match the path for the file being plastered. A deprecated
+`.toml` form is also accepted while existing plasters are being migrated — see
+[Legacy TOML format (deprecated)](#legacy-toml-format-deprecated) at the end of
+this document.
 
 > [!WARNING]
 >
@@ -33,63 +36,80 @@ are supposed to match the path for the file being plastered.
 Each plaster file will be used to apply changes into a given source, and then
 generate a patch for the effected changes.
 
-For example, imagine you want to add changes to
-`chrome/browser/autocomplete/autocomplete_classifier_factory.cc`. You would care
+For example, imagine you want to append Brave-specific entries to the upstream
+`RequestType` enum in `components/permissions/request_type.h`. You would care
 about the following files.
 
-- **Plaster file:**
-  `brave/rewrite/chrome/browser/autocomplete/autocomplete_classifier_factory.cc.toml`
-- **Source file:**
-  `chrome/browser/autocomplete/autocomplete_classifier_factory.cc`
-- **Patch file**
-  `brave/patches/chrome-browser-autocomplete-autocomplete_classifier_factory.cc.patch`
+- **Plaster file:** `brave/rewrite/components/permissions/request_type.h.yaml`
+- **Source file:** `components/permissions/request_type.h`
+- **Patch file:** `brave/patches/components-permissions-request_type.h.patch`
 
 ### Creating a plaster file
 
-A plaster file is a `toml` file used to list regexes operations to be applied in
-the corresponding source, based on its path. The following is plaster file to
-apply a few changes to
-`chrome/browser/autocomplete/autocomplete_classifier_factory.cc`.
+A plaster file is a YAML file that lists regex operations to be applied to the
+corresponding source, based on its path. The following plaster appends
+Brave-specific values to the upstream `RequestType` enum.
 
 Creating the source file with `vscode`:
 
 ```sh
-code rewrite/chrome/browser/autocomplete/autocomplete_classifier_factory.cc.toml
+code rewrite/components/permissions/request_type.h.yaml
 ```
 
-This file below has two substitutions to be applied on its source: The first
-adds a header to the list of headers in the source. The second one replaces all
-occurrences of `ChromeAutocompleteSchemeClassifier` with
-`BraveAutocompleteSchemeClassifier`.
+We can use a regex that anchors on the enum's outer braces and on the existing
+`kMaxValue = <something>` line, and then inserts the Brave entries plus a new
+`kMaxValue` just before the closing `}`:
 
-````toml
-# Copyright (c) 2025 The Brave Authors. All rights reserved.
+```yaml
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
-[[substitution]]
-description = 'Adding header for BraveAutocompleteSchemeClassifier'
-re_pattern = '(#include "[\s\S]*)'
-replace = '#include "brave/browser/autocomplete/brave_autocomplete_scheme_classifier.h"\n\1'
+substitutions:
+  - description: |
+      Append Brave-specific entries to `RequestType`
 
-[[substitution]]
-description = 'Patching in BraveAutocompleteSchemeClassifier'
-pattern = 'ChromeAutocompleteSchemeClassifier'
-replace = 'BraveAutocompleteSchemeClassifier'
+      This plaster is generic enough to guarantee that our entries are always last,
+      and that they also become the new kMaxValue.
+    re_pattern: '(enum class RequestType \{.+?,)(\s+)kMaxValue = \w+'
+    re_flags: [DOTALL]
+    replace: |-
+      \1
+        kWidevine,
+        kBraveEthereum,
+        kBraveSolana,
+        kBraveOpenAIChat,
+        kBraveGoogleSignInPermission,
+        kBraveCardano,
+        kBraveMinValue = kWidevine,
+        kBraveMaxValue = kBraveCardano,
+        kMaxValue = kBraveCardano
+```
 
-The basic format for a `[[substitution]]` entry is as follow:
+_Plaster_ substitutions are listed under `substitutions:`. _Plaster_ loads the
+contents of a source from `git`, as the source of truth, not from whatever is on
+disk, and then it applies each substitution cumulatively to the contents of the
+target source, updating the upstream source at the end.
 
-```toml
-[[substition]]
-description = ''
-# One of either pattern or re_pattern must be specified
-pattern = ''  # non-regex pattern (string will be escaped)
-re_pattern = ''  # regex pattern
-replace = ''
-re_flags = []  # These are traditional python regex flags.
-count = 1  # use 0 to ignore the match count and replace all
-````
+Each entry has the following format:
+
+```yaml
+substitutions:
+  - description: ''
+    # One of either pattern or re_pattern must be specified.
+    pattern: '' # non-regex pattern (string will be escaped)
+    re_pattern: '' # regex pattern
+    replace: ''
+    re_flags: [] # traditional Python `re` flag names, e.g. [DOTALL]
+    count: 1 # 1 is the default; 0 means no count, not advised.
+```
+
+Use YAML's `|` / `|-` block scalars when you need multi-line `replace` or
+`description` values — `|` keeps a trailing newline, `|-` strips it.
+Single-quoted YAML strings preserve backslashes literally, which is useful for
+regex patterns (`'\s'` stays as the two characters `\s`, not interpreted by
+YAML).
 
 To apply this plaster file, just run `plaster.py`:
 
@@ -97,42 +117,40 @@ To apply this plaster file, just run `plaster.py`:
 tools/cr/plaster.py apply
 ```
 
-Running `plaster.py` will cause the substitutions to be applied in
-`chrome/browser/autocomplete/autocomplete_classifier_factory.cc`, but it will
-cause the creation/update of the corresponding patch file for this source. For
-exmample, it may produce a diff file like this:
+Running `plaster.py` will cause the substitution to be applied in
+`components/permissions/request_type.h`, and trigger the creation or update of
+the corresponding patch file for this source. For example, it may produce a diff
+file like this:
 
-```
-diff --git a/patches/chrome-browser-autocomplete-autocomplete_classifier_factory.cc.patch b/patches/chrome-browser-autocomplete-autocomplete_classifier_factory.cc.patch
+```patch
+diff --git a/patches/components-permissions-request_type.h.patch b/patches/components-permissions-request_type.h.patch
 new file mode 100644
-index 00000000000..63703e6940b
+index 00000000000..bec88027991
 --- /dev/null
-+++ b/patches/chrome-browser-autocomplete-autocomplete_classifier_factory.cc.patch
-@@ -0,0 +1,21 @@
-+diff --git a/chrome/browser/autocomplete/autocomplete_classifier_factory.cc b/chrome/browser/autocomplete/autocomplete_classifier_factory.cc
-+index db73283fbc4f5146bb42e2a8abfcdfa4567ab252..f241c6c5f0611dcbcad3e468a7595be75324a8ba 100644
-+--- a/chrome/browser/autocomplete/autocomplete_classifier_factory.cc
-++++ b/chrome/browser/autocomplete/autocomplete_classifier_factory.cc
-+@@ -16,6 +16,7 @@
-+ #include "components/omnibox/browser/autocomplete_classifier.h"
-+ #include "components/omnibox/browser/autocomplete_controller.h"
-+ #include "extensions/buildflags/buildflags.h"
-++#include "brave/browser/autocomplete/brave_autocomplete_scheme_classifier.h"
-+
-+ #if BUILDFLAG(ENABLE_EXTENSIONS)
-+ #include "extensions/browser/extension_system_provider.h"
-+@@ -43,7 +44,7 @@ std::unique_ptr<KeyedService> AutocompleteClassifierFactory::BuildInstanceFor(
-+       std::make_unique<AutocompleteController>(
-+           std::make_unique<ChromeAutocompleteProviderClient>(profile),
-+           AutocompleteClassifier::DefaultOmniboxProviders()),
-+-      std::make_unique<ChromeAutocompleteSchemeClassifier>(profile));
-++      std::make_unique<BraveAutocompleteSchemeClassifier>(profile));
-+ }
-+
-+ AutocompleteClassifierFactory::AutocompleteClassifierFactory()
++++ b/patches/components-permissions-request_type.h.patch
+@@ -0,0 +1,20 @@
++diff --git a/components/permissions/request_type.h b/components/permissions/request_type.h
++--- a/components/permissions/request_type.h
+++++ b/components/permissions/request_type.h
++@@ -... @@ enum class RequestType {
++   ...,
++   kStorageAccess,
++   kWindowManagement,
++-  kMaxValue = kWindowManagement,
+++  kWidevine,
+++  kBraveEthereum,
+++  kBraveSolana,
+++  kBraveOpenAIChat,
+++  kBraveGoogleSignInPermission,
+++  kBraveCardano,
+++  kBraveMinValue = kWidevine,
+++  kBraveMaxValue = kBraveCardano,
+++  kMaxValue = kBraveCardano,
++ };
 ```
 
-The produced patch is supposed to be committed in the repository as usual.
+So at the end, you get a regular patch, and everything works as usual with how
+our Brave machinery handles patch files.
 
 ### Checking if files are up-to-date
 
@@ -149,3 +167,25 @@ This is the equivalent of a dry run of `plaster.py apply`.
 
 See
 https://github.com/brave-experiments/brave-core-tools/blob/master/docs/best-practices/plaster.md
+
+### Legacy TOML format (deprecated)
+
+> [!IMPORTANT]
+>
+> The `.toml` form is **deprecated** and kept only so existing plasters keep
+> working until they are migrated. New plasters must use `.yaml` while the
+> existing `.toml` ones are migrated. Migration progress is tracked in
+> [brave/brave-browser#55738](https://github.com/brave/brave-browser/issues/55738).
+
+Pre-existing plasters under `rewrite/` use a `.toml` file with the same fields
+as their YAML counterparts, written as TOML array-of-tables:
+
+```toml
+[[substitution]]
+description = ''
+re_pattern = ''
+pattern = ''
+replace = ''
+re_flags = []
+count = 1
+```

--- a/tools/cr/.vpython3
+++ b/tools/cr/.vpython3
@@ -41,3 +41,7 @@ wheel: <
   name: "infra/python/wheels/urllib3-py3"
   version: "version:2.1.0"
 >
+wheel: <
+  name: "infra/python/wheels/pyyaml-py3"
+  version: "version:6.0.1"
+>

--- a/tools/cr/alias/README.md
+++ b/tools/cr/alias/README.md
@@ -61,8 +61,9 @@ What it repairs after the rename:
   moved file.
 * Quoted GN root references (`"//path/to/file"`) and relative GN
   references in `.gn` / `.gni` files.
-* Plaster files (`rewrite/…/foo.h.toml`) and their associated patch files
-  in `patches/`. The new plaster file is re-applied so `patches/` is
+* Plaster files (`rewrite/…/foo.h.yaml`, or the deprecated
+  `rewrite/…/foo.h.toml`) and their associated patch files in
+  `patches/`. The new plaster file is re-applied so `patches/` is
   refreshed.
 
 ### `git cr follow-renames`
@@ -83,9 +84,10 @@ extra things:
 
 1. Move `chromium_src/<old>` to `chromium_src/<new>` and refresh its
    include guard and shadow `#include` line.
-2. Move `rewrite/<old>.toml` to `rewrite/<new>.toml`, delete the stale
-   `patches/…` patch file (and `.patchinfo`), then re-run plaster on the
-   new TOML so a fresh patch is produced.
+2. Move `rewrite/<old>.yaml` (or the deprecated `rewrite/<old>.toml`) to
+   `rewrite/<new>.yaml` (resp. `.toml`), delete the stale `patches/…`
+   patch file (and `.patchinfo`), then re-run plaster on the new
+   plaster file so a fresh patch is produced.
 3. Update every `#include`, `#import`, `// comment`, `BUILD.gn`, and `.gni`
    reference across `brave-core` (same logic as `git cr mv`).
 4. For any patch that is **not** managed by plaster, rewrite the patch's

--- a/tools/cr/alias/follow_renames.py
+++ b/tools/cr/alias/follow_renames.py
@@ -7,7 +7,7 @@
 For each file rename found in the Chromium git log for the given revision
 reference or range, updates every brave-core artefact that references the old
 path: chromium_src/ shadow files (move + shadow include + include guard),
-rewrite/ TOML files (move + patch deletion), and all cross-brave-core
+rewrite/ plaster files (move + patch deletion), and all cross-brave-core
 #include/#import/comment/BUILD.gn references.
 
 Usage
@@ -66,7 +66,7 @@ def cmd_follow_renames(args: list[str]) -> int:
     parser.add_argument('--no-run-plaster',
                         action='store_true',
                         dest='no_run_plaster',
-                        help='Skip running plaster after moving TOML files')
+                        help='Skip running plaster after moving plaster files')
     parser.add_argument(
         '--no-format',
         action='store_true',
@@ -193,22 +193,31 @@ def _repair_plaster_files(old_chromium: Path,
     """Moves the plaster file and deletes the corresponding patch file.
 
     Plaster file convention: chromium path A/foo.h lives at
-    rewrite/A/foo.h.toml. If no plaster file exists, this is a no-op.
-    The old patch file for that plaster gets automatically deleted.
+    rewrite/A/foo.h.yaml (or the deprecated rewrite/A/foo.h.toml). If no
+    plaster file exists, this is a no-op. The old patch file for that
+    plaster gets automatically deleted. The destination keeps the same
+    extension as the source.
     """
-    old_toml = (plaster.PLASTER_FILES_PATH / old_chromium.parent /
-                (old_chromium.name + '.toml'))
-    if not old_toml.exists():
-        return
+    old_dir = plaster.PLASTER_FILES_PATH / old_chromium.parent
+    new_dir = plaster.PLASTER_FILES_PATH / new_chromium.parent
+    old_plaster = old_dir / (old_chromium.name + '.yaml')
+    new_plaster = new_dir / (new_chromium.name + '.yaml')
+    if not old_plaster.exists():
+        # TODO(https://github.com/brave/brave-browser/issues/55738): Remove
+        # this entire fallback once every plaster under `rewrite/` has
+        # been migrated to YAML — only the `.yaml` lookup above should
+        # remain, returning when it does not exist.
+        old_plaster = old_dir / (old_chromium.name + '.toml')
+        new_plaster = new_dir / (new_chromium.name + '.toml')
+        if not old_plaster.exists():
+            return
 
-    new_toml = (plaster.PLASTER_FILES_PATH / new_chromium.parent /
-                (new_chromium.name + '.toml'))
-    new_toml.parent.mkdir(parents=True, exist_ok=True)
+    new_plaster.parent.mkdir(parents=True, exist_ok=True)
 
     if no_git:
-        old_toml.rename(new_toml)
+        old_plaster.rename(new_plaster)
     else:
-        terminal.run_git('mv', str(old_toml), str(new_toml))
+        terminal.run_git('mv', str(old_plaster), str(new_plaster))
 
     patch_file = (repository.brave.root / 'patches' /
                   patch_name_for(old_chromium))
@@ -227,7 +236,7 @@ def _repair_plaster_files(old_chromium: Path,
 
     if run_plaster:
         try:
-            PlasterFile(new_toml).apply()
+            PlasterFile(new_plaster).apply()
             if not no_git:
                 new_patch = (repository.brave.root / 'patches' /
                              patch_name_for(new_chromium))
@@ -236,7 +245,7 @@ def _repair_plaster_files(old_chromium: Path,
         # TODO(https://github.com/brave/brave-browser/issues/55370): Eventually
         # we should better constrain this to only catch plaster exceptions.
         except Exception as e:
-            logging.warning('plaster failed to apply %s: %s', new_toml, e)
+            logging.warning('plaster failed to apply %s: %s', new_plaster, e)
 
 
 def _repair_patch_files(old_chromium: Path, new_chromium: Path,

--- a/tools/cr/alias/mv.py
+++ b/tools/cr/alias/mv.py
@@ -7,7 +7,7 @@
 Performs the filesystem or git rename then updates every downstream artefact
 that depends on the old path: C++ include guards, chromium_src shadow-file
 includes, cross-tree #include/#import references, // comment references,
-BUILD.gn source-list entries, and plaster TOML patch files.
+BUILD.gn source-list entries, and plaster patch files.
 """
 
 from __future__ import annotations
@@ -57,7 +57,7 @@ def cmd_mv(args: list[str]) -> int:
     parser.add_argument('--no-run-plaster',
                         action='store_true',
                         dest='no_run_plaster',
-                        help='Skip running plaster after moving TOML files')
+                        help='Skip running plaster after moving plaster files')
     parser.add_argument('--no-format',
                         action='store_true',
                         dest='no_format',
@@ -186,12 +186,15 @@ def _step3_shadow_includes(file_pairs: list[_FilePair]) -> None:
 def _step5_plaster(file_pairs: list[_FilePair], no_git: bool,
                    run_plaster: bool) -> None:
     """Deletes stale patch files and optionally re-runs plaster for moved
-    TOMLs."""
+    plaster files (.yaml, or the deprecated .toml)."""
     rewrite_path = plaster.PLASTER_FILES_PATH.resolve()
     patches_path = repository.brave.root / 'patches'
 
     for old_file, new_file in file_pairs:
-        if old_file.suffix != '.toml':
+        # TODO(https://github.com/brave/brave-browser/issues/55738): Drop
+        # `'.toml'` from this tuple once every plaster under `rewrite/`
+        # has been migrated to YAML.
+        if old_file.suffix not in ('.yaml', '.toml'):
             continue
         if not old_file.is_relative_to(rewrite_path):
             continue

--- a/tools/cr/brockit.py
+++ b/tools/cr/brockit.py
@@ -431,9 +431,9 @@ class ApplyPatchesRecord:
         """Verifies all previously-broken plasters are now resolved.
 
         For each entry in plaster_broken_patches:
-        - If the plaster .toml still exists, runs a dry-run check to confirm
+        - If the plaster file still exists, runs a dry-run check to confirm
           the plaster output is up to date.
-        - If the plaster .toml is gone, verifies the corresponding .patch
+        - If the plaster file is gone, verifies the corresponding .patch
           file has also been removed.
 
         Raises InvalidInputException if any broken plaster is not yet resolved.

--- a/tools/cr/patchfile.py
+++ b/tools/cr/patchfile.py
@@ -37,9 +37,9 @@ class Patchfile:
     # The repository the patch file is targeting to patch.
     repository: Repository = field(init=False)
 
-    # Path to the plaster (.toml) file for this patch, expressed via
-    # `PLASTER_FILES_PATH` (i.e. cwd-relative, the same shape every other
-    # path in tools/cr uses).
+    # Path to the plaster file for this patch (`.yaml`, or the deprecated
+    # `.toml`), expressed via `PLASTER_FILES_PATH` (i.e. cwd-relative,
+    # the same shape every other path in tools/cr uses).
     plaster: Path | None = field(init=False)
 
     def __post_init__(self):
@@ -54,10 +54,18 @@ class Patchfile:
 
         plaster = None
         if self.repository.is_chromium:
-            candidate = (PLASTER_FILES_PATH / self.source.parent /
-                         (self.source.name + '.toml'))
+            plaster_dir = PLASTER_FILES_PATH / self.source.parent
+            candidate = plaster_dir / (self.source.name + '.yaml')
             if candidate.exists():
                 plaster = candidate
+            else:
+                # TODO(https://github.com/brave/brave-browser/issues/55738):
+                # Remove this entire `else` branch once every plaster under
+                # `rewrite/` has been migrated to YAML. Only the `.yaml`
+                # lookup above should remain.
+                candidate = plaster_dir / (self.source.name + '.toml')
+                if candidate.exists():
+                    plaster = candidate
         object.__setattr__(self, 'plaster', plaster)
 
     def get_repository_from_patch_name(self) -> Repository:

--- a/tools/cr/plaster.py
+++ b/tools/cr/plaster.py
@@ -15,7 +15,13 @@ import json
 import os
 import re
 import sys
+
+# TODO(https://github.com/brave/brave-browser/issues/55738): Remove all the
+# TOML-related code once every plaster under `rewrite/` has been migrated to
+# YAML.
 import tomllib
+
+import yaml
 
 from terminal import IncendiaryErrorHandler, console, is_verbose, terminal
 import repository
@@ -25,6 +31,19 @@ PLASTER_FILES_PATH = repository.brave.root / 'rewrite'
 
 # The path to the directory where patch files are stored in brave-core.
 PATCHES_PATH = repository.brave.root / 'patches'
+
+# Supported plaster file extensions.
+#
+# `.yaml` is the preferred format. `.toml` is the original syntax and is
+# **deprecated**.
+#
+# TODO(https://github.com/brave/brave-browser/issues/55738): Once every
+# plaster under `rewrite/` has been migrated to YAML, drop `'.toml'` from
+# this tuple and remove every other site tagged with the same issue
+# number (the `tomllib` import, `Substitution.from_toml`, and the
+# `.toml` branch in `PlasterFile.apply`).
+PLASTER_EXTENSIONS = ('.yaml', '.toml')
+
 
 @dataclass
 class PathChecksumPair:
@@ -111,7 +130,8 @@ class Patchinfo:
     # ever produce and accept a single entry.
     applies_to: Entry
 
-    # The plaster .toml file that produced this patchinfo.
+    # The plaster file that produced this patchinfo (`.yaml`, or the
+    # deprecated `.toml`).
     plaster: Entry
 
     @staticmethod
@@ -329,6 +349,191 @@ class PatchinfoBuilder:
         self.patchinfo.save_if_changed(content)
 
 
+@dataclass(frozen=True)
+class Substitution:
+    """A single substitution entry parsed from a plaster file.
+
+    `from_yaml` instantiates all the substitutions from a YAML plaster
+    file, and `from_toml` does the same for a (deprecated) TOML plaster
+    file.
+    """
+
+    # Human-readable description, used as a prefix in error messages.
+    description: str
+
+    # Regex pattern passed verbatim to `re.subn`. When the plaster entry
+    # uses the literal `pattern` form, this field holds its `re.escape`'d
+    # form.
+    re_pattern: str
+
+    # Replacement string passed to `re.subn`.
+    replace: str
+
+    # Expected number of substitutions. `0` means "replace all matches"
+    # and disables the count check.
+    expected_count: int = 1
+
+    # Combined bitmask of `re` flags built from the `re_flags` plaster
+    # field.
+    re_flags: int = 0
+
+    # Every key accepted on a substitution mapping. Anything else is
+    # rejected by `_from_dict` so typos surface immediately instead of
+    # being silently ignored.
+    _ALLOWED_KEYS = frozenset(('description', 'pattern', 're_pattern',
+                               'replace', 'count', 're_flags'))
+
+    class _NoDupSafeLoader(yaml.SafeLoader):
+        """`yaml.SafeLoader` that rejects duplicate mapping keys.
+
+        `yaml.safe_load` silently keeps the last value for a duplicate
+        key — which would let a typo'd substitution field shadow the
+        real one and apply the wrong patch. We surface those cases as
+        a `ValueError` instead.
+        """
+
+        @staticmethod
+        def _construct_mapping_strict(loader: yaml.SafeLoader,
+                                      node: yaml.MappingNode) -> dict:
+            """Construct a dict from `node`, raising on duplicate keys."""
+            loader.flatten_mapping(node)
+            seen: set = set()
+            duplicates: list = []
+            for key_node, _ in node.value:
+                key = loader.construct_object(key_node, deep=True)
+                if key in seen:
+                    duplicates.append(key)
+                else:
+                    seen.add(key)
+            if duplicates:
+                raise ValueError('Duplicate key(s) in YAML mapping: ' +
+                                 ', '.join(repr(k) for k in duplicates))
+            return loader.construct_mapping(node, deep=True)
+
+        # Install the strict constructor.
+        yaml_constructors = yaml.SafeLoader.yaml_constructors | {
+            'tag:yaml.org,2002:map': _construct_mapping_strict,
+        }
+
+    # TODO(https://github.com/brave/brave-browser/issues/55738): Remove
+    # `from_toml` (and its callers) once every plaster under `rewrite/`
+    # has been migrated to YAML.
+    @staticmethod
+    def from_toml(contents: str) -> list[Substitution]:
+        """Parse all substitutions from the contents of a TOML plaster file.
+
+        TOML plasters use `[[substitution]]` array-of-tables entries.
+        """
+        data = tomllib.loads(contents)
+        raw = data.get('substitution')
+        if raw is None:
+            raise ValueError(
+                'Plaster TOML is missing required `[[substitution]]` entries')
+        if not isinstance(raw, list):
+            raise ValueError('TOML `substitution` must be an array of tables')
+        if not raw:
+            raise ValueError(
+                'Plaster TOML must declare at least one `[[substitution]]`')
+        return [Substitution._from_dict(entry) for entry in raw]
+
+    @staticmethod
+    def from_yaml(contents: str) -> list[Substitution]:
+        """Parse all substitutions from the contents of a YAML plaster file.
+
+        YAML plasters use a top-level `substitutions:` list whose items
+        have the same field names as their TOML counterparts.
+        """
+        data = yaml.load(contents, Loader=Substitution._NoDupSafeLoader)
+        if data is None:
+            data = {}
+        if not isinstance(data, dict):
+            raise ValueError('Plaster YAML must be a mapping at the top level')
+        raw = data.get('substitutions')
+        if raw is None:
+            raise ValueError(
+                'Plaster YAML is missing required `substitutions:` key')
+        if not isinstance(raw, list):
+            raise ValueError('YAML `substitutions` must be a list')
+        if not raw:
+            raise ValueError(
+                'Plaster YAML `substitutions:` must contain at least one entry'
+            )
+        return [Substitution._from_dict(entry) for entry in raw]
+
+    @staticmethod
+    def _from_dict(data: object) -> Substitution:
+        """Validate a single substitution mapping and build a Substitution.
+
+        Both `from_toml` and `from_yaml` dispatch through this helper after
+        format-specific parsing produces a Python `dict` for each entry.
+
+        Raises:
+            ValueError: if required fields are missing, a field has the
+                wrong type, or `pattern` and `re_pattern` are both set.
+        """
+        if not isinstance(data, dict):
+            raise ValueError(f'substitution entry must be a mapping, got '
+                             f'{type(data).__name__}')
+
+        unknown = sorted(set(data.keys()) - Substitution._ALLOWED_KEYS)
+        if unknown:
+            raise ValueError('Unrecognised substitution key(s): '
+                             f'{", ".join(repr(k) for k in unknown)}')
+
+        description = data.get('description')
+        if not isinstance(description, str):
+            raise ValueError('No description specified for substitution entry')
+
+        pattern = data.get('pattern')
+        re_pattern = data.get('re_pattern')
+        if pattern is not None and re_pattern is not None:
+            raise ValueError(
+                f'Please specify either pattern or re_pattern, not both '
+                f'(in "{description}")')
+        if pattern is None and re_pattern is None:
+            raise ValueError(f'No pattern specified (in "{description}")')
+        if pattern is not None:
+            if not isinstance(pattern, str):
+                raise ValueError(
+                    f'pattern must be a string (in "{description}")')
+            re_pattern = re.escape(pattern)
+        elif not isinstance(re_pattern, str):
+            raise ValueError(
+                f're_pattern must be a string (in "{description}")')
+
+        replace = data.get('replace')
+        if not isinstance(replace, str):
+            raise ValueError(
+                f'No replace value specified (in "{description}")')
+
+        expected_count = data.get('count', 1)
+        # bool is a subclass of int; reject it explicitly.
+        if (not isinstance(expected_count, int)
+                or isinstance(expected_count, bool)):
+            raise ValueError(f'count must be an integer (in "{description}")')
+
+        flags_raw = data.get('re_flags', [])
+        if not isinstance(flags_raw, list):
+            raise ValueError(
+                f're_flags must be a list of strings (in "{description}")')
+        re_flags = 0
+        for flag in flags_raw:
+            if not isinstance(flag, str):
+                raise ValueError(
+                    f're_flags entries must be strings (in "{description}")')
+            if not (flag.isupper() and hasattr(re, flag)):
+                raise ValueError(f'Invalid re flag specified: {flag}')
+            re_flags |= getattr(re, flag)
+
+        return Substitution(
+            description=description,
+            re_pattern=re_pattern,
+            replace=replace,
+            expected_count=expected_count,
+            re_flags=re_flags,
+        )
+
+
 @dataclass
 class PlasterFile:
     """ Class representing an plaster file.
@@ -349,7 +554,7 @@ class PlasterFile:
 
         for root, _, files in os.walk(PLASTER_FILES_PATH):
             for file in files:
-                if file.endswith('.toml'):
+                if file.endswith(PLASTER_EXTENSIONS):
                     plaster_files.append(cls(Path(root) / file))
 
         return plaster_files
@@ -371,9 +576,9 @@ class PlasterFile:
         patch_path = PATCHES_PATH / f'{patch_stem}.patch'
         patchinfo_path = PATCHES_PATH / f'{patch_stem}.patchinfo'
 
-        # Only the plaster toml is guaranteed to exist here; any of the
-        # other files may be missing and that is by itself a reason to
-        # re-apply.
+        # Only the plaster file itself is guaranteed to exist here; any
+        # of the other files may be missing and that is by itself a
+        # reason to re-apply.
         if (not patchinfo_path.exists() or not patch_path.exists()
                 or not source_path.exists()):
             return True
@@ -403,66 +608,52 @@ class PlasterFile:
             or PathChecksumPair(patch_path).checksum != info.patch_checksum)
 
     def apply(self, dry_run=False):
+        suffix = self.path.suffix.lower()
+
+        # TODO(https://github.com/brave/brave-browser/issues/55738): Remove
+        # this collision check once every plaster under `rewrite/` has
+        # been migrated to YAML — only one extension will exist by then,
+        # so the twin can never appear.
+        if suffix in PLASTER_EXTENSIONS:
+            twin_ext = '.toml' if suffix == '.yaml' else '.yaml'
+            twin = self.path.with_suffix(twin_ext)
+            if twin.exists():
+                raise PlasterError(
+                    'Both `.yaml` and `.toml` plaster files exist for the '
+                    f'same source — remove one:\n  {self.path}\n  {twin}')
+
         info = PatchinfoBuilder(self.path)
-        plaster_file = tomllib.loads(info.plaster_contents)
+        if suffix == '.yaml':
+            substitutions = Substitution.from_yaml(info.plaster_contents)
+        elif suffix == '.toml':
+            # TODO(https://github.com/brave/brave-browser/issues/55738):
+            # Drop this entire `elif` branch once every plaster under
+            # `rewrite/` has been migrated to YAML.
+            substitutions = Substitution.from_toml(info.plaster_contents)
+        else:
+            raise ValueError(f'Unsupported plaster file extension: {suffix}')
         contents = repository.chromium.read_file(info.source)
         errors = []
 
         try:
-            for substitution in plaster_file.get('substitution'):
-                description = substitution.get('description')
-                re_pattern = substitution.get('re_pattern')
-                pattern = substitution.get('pattern')
-                replace = substitution.get('replace')
-                expected_count = substitution.get('count', 1)
-                flags = substitution.get('re_flags', [])
-
-                if description is None:
-                    raise ValueError(
-                        f'No description specified in {info.source}')
-
-                if re_pattern is not None and pattern is not None:
-                    raise ValueError(
-                        f'Please specify either pattern or re_pattern '
-                        f' in {info.source}')
-
-                if re_pattern is None:
-                    if pattern is None:
-                        raise ValueError(
-                            f'No pattern specified in {info.source}')
-                    re_pattern = re.escape(pattern)
-
-                if replace is None:
-                    raise ValueError(
-                        f'No replace value specified in {info.source}')
-
-                re_flags = 0
-                for flag in flags:
-                    # Only accept valid re flags
-                    if flag.isupper() and hasattr(re, flag):
-                        re_flags |= getattr(re, flag)
-                    else:
-                        raise ValueError(
-                            f'Invalid re flag specified: {flag} in '
-                            f'{info.source}')
-
+            for substitution in substitutions:
                 contents, num_changes = re.subn(
-                    re_pattern,
-                    replace,
+                    substitution.re_pattern,
+                    substitution.replace,
                     contents,
-                    flags=re_flags,
-                    # We dont't want to explicitly limit the number of matches
+                    flags=substitution.re_flags,
+                    # We don't want to explicitly limit the number of matches
                     # here, we want to control what matches using the match
                     # pattern and then ensure the output matches only what we
-                    # expected
+                    # expected.
                     count=0)
 
-                # count == 0 means "replace all matches" and bypass count
-                # validation
-                if expected_count not in (0, num_changes):
+                # count == 0 means "replace all matches" and bypasses count
+                # validation.
+                if substitution.expected_count not in (0, num_changes):
                     errors.append(
                         f'Unexpected number of matches ({num_changes} vs '
-                        f'{expected_count}) in {self.path}')
+                        f'{substitution.expected_count}) in {self.path}')
 
         except re.error as e:
             errors.append(f'Invalid regex: {e} in {self.path}')
@@ -512,10 +703,14 @@ def get_plaster_files(filepaths: list[str] | None = None) -> list[PlasterFile]:
         filepath = PurePath(filepath).as_posix()
         if filepath.startswith('patches/') and filepath.endswith('.patch'):
             base = filepath[len('patches/'):-len('.patch')]
-            plaster_relative = base.replace('-', '/') + '.toml'
-            plaster_path = f'rewrite/{plaster_relative}'
-            expected_plaster_files.add(plaster_path)
-        elif filepath.startswith('rewrite/') and filepath.endswith('.toml'):
+            stem = f'rewrite/{base.replace("-", "/")}'
+            # The patch file does not tell us which plaster format produced
+            # it, so seed candidates for every supported extension and let
+            # the existence filter below pick the real one.
+            for ext in PLASTER_EXTENSIONS:
+                expected_plaster_files.add(f'{stem}{ext}')
+        elif (filepath.startswith('rewrite/')
+              and filepath.endswith(PLASTER_EXTENSIONS)):
             expected_plaster_files.add(filepath)
         else:
             raise ValueError(f'Unexpected file path: {filepath}')

--- a/tools/cr/plaster_test.py
+++ b/tools/cr/plaster_test.py
@@ -150,6 +150,174 @@ class PlasterTest(unittest.TestCase):
         self.assertEqual(temp_file.read_text(), 'bar')
         temp_file.unlink()
 
+    def test_yaml_plaster_applies_like_toml(self):
+        """A .yaml plaster produces the same result as the equivalent .toml."""
+        test_file_chromium = Path(
+            'chrome/common/extensions/api/test_yaml_plaster.idl')
+
+        self.fake_chromium_src.write_and_stage_file(
+            test_file_chromium, 'Initial content for Chromium file.',
+            self.fake_chromium_src.chromium)
+        self.fake_chromium_src.commit('Add test_yaml_plaster.idl',
+                                      self.fake_chromium_src.chromium)
+
+        plaster_path = plaster.PLASTER_FILES_PATH / (str(test_file_chromium) +
+                                                     '.yaml')
+        plaster_path.parent.mkdir(parents=True, exist_ok=True)
+        plaster_path.write_text('substitutions:\n'
+                                '  - description: Simple yaml substitution\n'
+                                "    re_pattern: 'Chromium'\n"
+                                "    replace: 'Plaster'\n")
+
+        plaster.PlasterFile(plaster_path).apply()
+
+        self.assertEqual(
+            (self.fake_chromium_src.chromium / test_file_chromium).read_text(),
+            'Initial content for Plaster file.')
+
+        # The patch file is named after the source, not the plaster
+        # extension, so it should be a sibling of where the .toml patch
+        # would have landed.
+        patchinfo = plaster.PatchinfoBuilder(plaster_path)
+        self.assertTrue(patchinfo.patch.path.exists())
+        self.assertTrue(patchinfo.patchinfo.path.exists())
+
+    def test_yaml_plaster_validation_failures(self):
+        """YAML plasters surface the same validation errors as TOML."""
+        test_file_chromium = Path(
+            'chrome/common/extensions/api/test_yaml_validation.idl')
+
+        self.fake_chromium_src.write_and_stage_file(
+            test_file_chromium, 'Initial content for Chromium file.',
+            self.fake_chromium_src.chromium)
+        self.fake_chromium_src.commit('Add test_yaml_validation.idl',
+                                      self.fake_chromium_src.chromium)
+
+        cases = [
+            ('substitutions:\n'
+             '  - description: Both patterns specified\n'
+             "    pattern: 'Chromium'\n"
+             "    re_pattern: 'Chromium'\n"
+             "    replace: 'Plaster'\n",
+             'Please specify either pattern or re_pattern'),
+            ('substitutions:\n'
+             '  - description: No pattern specified\n'
+             "    replace: 'Plaster'\n", 'No pattern specified'),
+            ('substitutions:\n'
+             '  - description: No replace specified\n'
+             "    pattern: 'Chromium'\n", 'No replace value specified'),
+        ]
+
+        for yaml_content, expected_error in cases:
+            with self.subTest(error=expected_error):
+                plaster_path = plaster.PLASTER_FILES_PATH / (
+                    str(test_file_chromium) + '.yaml')
+                plaster_path.parent.mkdir(parents=True, exist_ok=True)
+                plaster_path.write_text(yaml_content)
+
+                plaster_file = plaster.PlasterFile(plaster_path)
+                with self.assertRaises(ValueError) as context:
+                    plaster_file.apply()
+                self.assertIn(expected_error, str(context.exception))
+
+    def test_yaml_and_toml_collision_is_rejected(self):
+        """Having both .yaml and .toml plasters for the same source errors."""
+        test_file_chromium = Path(
+            'chrome/common/extensions/api/test_collision.idl')
+
+        self.fake_chromium_src.write_and_stage_file(
+            test_file_chromium, 'Content with Chromium word.',
+            self.fake_chromium_src.chromium)
+        self.fake_chromium_src.commit('Add test_collision.idl',
+                                      self.fake_chromium_src.chromium)
+
+        plaster_stem = (plaster.PLASTER_FILES_PATH / str(test_file_chromium))
+        plaster_stem.parent.mkdir(parents=True, exist_ok=True)
+
+        yaml_path = plaster_stem.with_suffix(plaster_stem.suffix + '.yaml')
+        yaml_path.write_text('substitutions:\n'
+                             '  - description: yaml form\n'
+                             "    re_pattern: 'Chromium'\n"
+                             "    replace: 'Brave'\n")
+
+        toml_path = plaster_stem.with_suffix(plaster_stem.suffix + '.toml')
+        toml_path.write_text("[[substitution]]\n"
+                             "description = 'toml form'\n"
+                             "re_pattern = 'Chromium'\n"
+                             "replace = 'Brave'\n")
+
+        with self.assertRaises(plaster.PlasterError) as context:
+            plaster.PlasterFile(yaml_path).apply()
+        message = str(context.exception)
+        self.assertIn('Both `.yaml` and `.toml`', message)
+        self.assertIn(str(yaml_path), message)
+        self.assertIn(str(toml_path), message)
+
+        # And the other direction: starting from the .toml file.
+        with self.assertRaises(plaster.PlasterError):
+            plaster.PlasterFile(toml_path).apply()
+
+    def test_duplicate_yaml_keys_are_rejected(self):
+        """A YAML mapping with a duplicate key surfaces as a ValueError.
+
+        Without this guard, `yaml.safe_load` would silently keep the last
+        value for the repeated key, and a typo would shadow the real
+        field — applying a different patch than the author intended.
+        """
+        test_file_chromium = Path(
+            'chrome/common/extensions/api/test_duplicate_key.idl')
+
+        self.fake_chromium_src.write_and_stage_file(
+            test_file_chromium, 'Content with Chromium word.',
+            self.fake_chromium_src.chromium)
+        self.fake_chromium_src.commit('Add test_duplicate_key.idl',
+                                      self.fake_chromium_src.chromium)
+
+        plaster_path = plaster.PLASTER_FILES_PATH / (str(test_file_chromium) +
+                                                     '.yaml')
+        plaster_path.parent.mkdir(parents=True, exist_ok=True)
+        # `pattern` is declared twice; the second occurrence would
+        # silently win without the strict loader.
+        plaster_path.write_text('substitutions:\n'
+                                '  - description: Duplicate pattern key\n'
+                                "    pattern: 'Chromium'\n"
+                                "    pattern: 'Brave'\n"
+                                "    replace: 'Brave'\n")
+
+        plaster_file = plaster.PlasterFile(plaster_path)
+        with self.assertRaises(ValueError) as context:
+            plaster_file.apply()
+        message = str(context.exception)
+        self.assertIn('Duplicate key', message)
+        self.assertIn("'pattern'", message)
+
+    def test_unknown_substitution_key_is_rejected(self):
+        """Unrecognised substitution keys raise instead of being ignored."""
+        test_file_chromium = Path(
+            'chrome/common/extensions/api/test_unknown_key.idl')
+
+        self.fake_chromium_src.write_and_stage_file(
+            test_file_chromium, 'Content with Chromium word.',
+            self.fake_chromium_src.chromium)
+        self.fake_chromium_src.commit('Add test_unknown_key.idl',
+                                      self.fake_chromium_src.chromium)
+
+        plaster_path = plaster.PLASTER_FILES_PATH / (str(test_file_chromium) +
+                                                     '.yaml')
+        plaster_path.parent.mkdir(parents=True, exist_ok=True)
+        # Common typo: `replacement` (the field is `replace`).
+        plaster_path.write_text('substitutions:\n'
+                                '  - description: Typo in key name\n'
+                                "    pattern: 'Chromium'\n"
+                                "    replacement: 'Brave'\n")
+
+        plaster_file = plaster.PlasterFile(plaster_path)
+        with self.assertRaises(ValueError) as context:
+            plaster_file.apply()
+        message = str(context.exception)
+        self.assertIn('Unrecognised substitution key', message)
+        self.assertIn("'replacement'", message)
+
     def test_check_success_multiple_up_to_date(self):
         """Test plaster check succeeds for 3 up-to-date plaster files."""
         # Create 3 source files in chromium and matching .toml in brave/rewrite


### PR DESCRIPTION
This PR introduces the YAML frontend for plaster that is meant to
eventually become the only frontend, once all `.toml` Plaster files are
migrated.

This change covers all places where the assumption about `.toml` files
was being used, inclusing `brockit`, and `git-cr` tools.

Most of the code that should be deleted in the future is well guarded
with comments leading back to the issue tracking, so the TOML parser can
be dropped eventually.

With this change, a dependency to `pyyaml` has been introduced. This
dependency has wheels provided by `vpython`, which is already the
expected python runtime for Plaster.

**Rationale for this change**

We have experimented at length with `.toml` files, in order to
understand some of the shortcomings they have that would be addressed
with `.yaml` files.

  * `prettier` offers YAML formatting out-of-the-box. On the other hand,
    formatters for TOML files are not easy to find, as both `prettier`
    and `vpython` have their own challanges with the current options
  * YAML's sytanx works better with codeblocks, as it doesn't require
    quoting. This makes the content seen less noisy. Looking on some of
    the migrated plasters, the YAML substitutions look more readable.
  * YAML has better sytanx highlight support in some editors.

Bug: https://github.com/brave/brave-browser/issues/55738
