### PR TITLE
Remove constexpr from struct initialization in test.

### DIFF
--- a/browser/containers/containers_browsertest.cc
+++ b/browser/containers/containers_browsertest.cc
@@ -2111,11 +2111,11 @@ IN_PROC_BROWSER_TEST_F(ContainersBrowserTest,
   const GURL worker_url("https://a.test/containers/container_worker.js");
   const std::string scope = "https://a.test/containers/";
 
-  constexpr PartitionSiteData kDefaultData = {"default_cookie", "default_value",
-                                              "default_key", "default_value"};
-  constexpr PartitionSiteData kContainerData = {
-      "container_cookie", "container_value", "container_key",
-      "container_value"};
+  const PartitionSiteData default_data = {"default_cookie", "default_value",
+                                          "default_key", "default_value"};
+  const PartitionSiteData container_data = {"container_cookie",
+                                            "container_value", "container_key",
+                                            "container_value"};
 
   std::vector<mojom::ContainerPtr> synced;
   synced.push_back(MakeContainer(kTestContainerId, "Test"));
@@ -2124,23 +2124,23 @@ IN_PROC_BROWSER_TEST_F(ContainersBrowserTest,
   ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
   content::WebContents* default_web_contents =
       browser()->tab_strip_model()->GetActiveWebContents();
-  SetPartitionSiteData(default_web_contents, kDefaultData, worker_url, scope);
-  ExpectPartitionSiteDataPresent(default_web_contents, kDefaultData, scope);
+  SetPartitionSiteData(default_web_contents, default_data, worker_url, scope);
+  ExpectPartitionSiteDataPresent(default_web_contents, default_data, scope);
 
   content::WebContents* container_web_contents =
       OpenUrlInContainerTab(url, kTestContainerId);
-  SetPartitionSiteData(container_web_contents, kContainerData, worker_url,
+  SetPartitionSiteData(container_web_contents, container_data, worker_url,
                        scope);
-  ExpectPartitionSiteDataPresent(container_web_contents, kContainerData, scope);
+  ExpectPartitionSiteDataPresent(container_web_contents, container_data, scope);
 
   RemoveSiteDataAndWait();
 
   // Nested container-partition removes are started asynchronously (same as
   // IWA).
-  ExpectPartitionSiteDataClearedEventually(default_web_contents, kDefaultData,
+  ExpectPartitionSiteDataClearedEventually(default_web_contents, default_data,
                                            scope);
   ExpectPartitionSiteDataClearedEventually(container_web_contents,
-                                           kContainerData, scope);
+                                           container_data, scope);
 }
 
 IN_PROC_BROWSER_TEST_F(ContainersBrowserTest,


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves in windows-x86 release build
```
../../brave/browser/containers/containers_browsertest.cc(2114,31): error: constexpr variable 'kDefaultData' must be initialized by a constant expression
2114 |   constexpr PartitionSiteData kDefaultData = {"default_cookie", "default_value",
      |                               ^              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 2115 |                                               "default_key", "default_value"};
```

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
