### PR TITLE
[cherry-pick] Restrict background fetch from Service Worker context (uplift to 1.90.x)

### DIFF
--- a/patches/chrome-browser-background_fetch-background_fetch_browsertest.cc.patch
+++ b/patches/chrome-browser-background_fetch-background_fetch_browsertest.cc.patch
@@ -1,0 +1,105 @@
+diff --git a/chrome/browser/background_fetch/background_fetch_browsertest.cc b/chrome/browser/background_fetch/background_fetch_browsertest.cc
+index 3699485d0e66fbbd8773adcf19153a56a56230e3..9dbd783116ddacf7c034915fe1e60003e6a8b966 100644
+--- a/chrome/browser/background_fetch/background_fetch_browsertest.cc
++++ b/chrome/browser/background_fetch/background_fetch_browsertest.cc
+@@ -10,6 +10,7 @@
+ #include "base/memory/raw_ptr.h"
+ #include "base/run_loop.h"
+ #include "base/strings/string_util.h"
++#include "base/test/scoped_feature_list.h"
+ #include "build/build_config.h"
+ #include "chrome/browser/background_fetch/background_fetch_delegate_impl.h"
+ #include "chrome/browser/browser_process.h"
+@@ -43,6 +44,7 @@
+ #include "net/test/embedded_test_server/http_response.h"
+ #include "services/metrics/public/cpp/metrics_utils.h"
+ #include "services/metrics/public/cpp/ukm_builders.h"
++#include "third_party/blink/public/common/features.h"
+ #include "url/origin.h"
+ 
+ using offline_items_collection::ContentId;
+@@ -842,29 +844,6 @@ IN_PROC_BROWSER_TEST_F(BackgroundFetchBrowserTest,
+       "This origin does not have permission to start a fetch."));
+ }
+ 
+-IN_PROC_BROWSER_TEST_F(BackgroundFetchBrowserTest, FetchFromServiceWorker) {
+-  auto* settings_map =
+-      HostContentSettingsMapFactory::GetForProfile(browser()->profile());
+-  DCHECK(settings_map);
+-
+-  // Give the needed permissions.
+-  SetPermission(ContentSettingsType::AUTOMATIC_DOWNLOADS,
+-                CONTENT_SETTING_ALLOW);
+-
+-  // The fetch should succeed.
+-  offline_content_provider_observer_->ResumeOnNextUpdate();
+-  ASSERT_NO_FATAL_FAILURE(RunScriptAndCheckResultingMessage(
+-      "StartFetchFromServiceWorker()", "backgroundfetchsuccess"));
+-
+-  // Revoke Automatic Downloads permission.
+-  SetPermission(ContentSettingsType::AUTOMATIC_DOWNLOADS,
+-                CONTENT_SETTING_BLOCK);
+-
+-  // This should fail without the Automatic Downloads permission.
+-  ASSERT_NO_FATAL_FAILURE(RunScriptAndCheckResultingMessage(
+-      "StartFetchFromServiceWorker()", "permissionerror"));
+-}
+-
+ // TODO(crbug.com/40805915): Flaky on many platforms.
+ IN_PROC_BROWSER_TEST_F(BackgroundFetchBrowserTest,
+                        DISABLED_FetchFromServiceWorkerWithAsk) {
+@@ -1032,3 +1011,54 @@ IN_PROC_BROWSER_TEST_F(BackgroundFetchFencedFrameBrowserTest,
+           ukm::builders::BackgroundFetch::kEntryName);
+   ASSERT_EQ(0u, entries.size());
+ }
++
++class BackgroundFetchKillswitchBrowserTest
++    : public BackgroundFetchBrowserTest,
++      public testing::WithParamInterface<bool> {
++ public:
++  BackgroundFetchKillswitchBrowserTest() {
++    if (IsRestrictBackgroundFetchFromServiceWorkerEnabled()) {
++      scoped_feature_list_.InitAndEnableFeature(
++          blink::features::kRestrictBackgroundFetchFromServiceWorker);
++    } else {
++      scoped_feature_list_.InitAndDisableFeature(
++          blink::features::kRestrictBackgroundFetchFromServiceWorker);
++    }
++  }
++
++ protected:
++  bool IsRestrictBackgroundFetchFromServiceWorkerEnabled() {
++    return GetParam();
++  }
++
++ private:
++  base::test::ScopedFeatureList scoped_feature_list_;
++};
++
++INSTANTIATE_TEST_SUITE_P(All,
++                         BackgroundFetchKillswitchBrowserTest,
++                         testing::Bool());
++
++IN_PROC_BROWSER_TEST_P(BackgroundFetchKillswitchBrowserTest,
++                       FetchFromServiceWorker) {
++  SetPermission(ContentSettingsType::AUTOMATIC_DOWNLOADS,
++                CONTENT_SETTING_ALLOW);
++  if (IsRestrictBackgroundFetchFromServiceWorkerEnabled()) {
++    // If killswitch is enabled, the fetch should fail with a permission error.
++    ASSERT_NO_FATAL_FAILURE(RunScriptAndCheckResultingMessage(
++        "StartFetchFromServiceWorker()", "permissionerror"));
++  } else {
++    // If killswitch is disabled, the fetch should succeed.
++    offline_content_provider_observer_->ResumeOnNextUpdate();
++    ASSERT_NO_FATAL_FAILURE(RunScriptAndCheckResultingMessage(
++        "StartFetchFromServiceWorker()", "backgroundfetchsuccess"));
++
++    // Revoke Automatic Downloads permission.
++    SetPermission(ContentSettingsType::AUTOMATIC_DOWNLOADS,
++                  CONTENT_SETTING_BLOCK);
++
++    // This should fail without the Automatic Downloads permission.
++    ASSERT_NO_FATAL_FAILURE(RunScriptAndCheckResultingMessage(
++        "StartFetchFromServiceWorker()", "permissionerror"));
++  }
++}

--- a/patches/third_party-blink-common-features.cc.patch
+++ b/patches/third_party-blink-common-features.cc.patch
@@ -1,0 +1,19 @@
+diff --git a/third_party/blink/common/features.cc b/third_party/blink/common/features.cc
+index d6348e10bb171dae1ad6ec3b19b2ecfec2bd4c5c..97e1a092ffceea3d02af5671d07c227e4e672750 100644
+--- a/third_party/blink/common/features.cc
++++ b/third_party/blink/common/features.cc
+@@ -187,6 +187,14 @@ BASE_FEATURE_PARAM(bool,
+                    "background-code-cache-decoder-start",
+                    true);
+ 
++BASE_FEATURE(kRestrictBackgroundFetchFromServiceWorker,
++             base::FEATURE_ENABLED_BY_DEFAULT);
++BASE_FEATURE_PARAM(std::string,
++                   kBackgroundFetchFromServiceWorkerAllowListStr,
++                   &kRestrictBackgroundFetchFromServiceWorker,
++                   "allowlist",
++                   "");
++
+ // Redefine the oklab and oklch spaces to have gamut mapping baked into them.
+ // https://crbug.com/1508329
+ BASE_FEATURE(kBakedGamutMapping, base::FEATURE_DISABLED_BY_DEFAULT);

--- a/patches/third_party-blink-public-common-features.h.patch
+++ b/patches/third_party-blink-public-common-features.h.patch
@@ -1,0 +1,20 @@
+diff --git a/third_party/blink/public/common/features.h b/third_party/blink/public/common/features.h
+index 0345abb5a0cf14aacf9a87295d0226147440da55..a713b9b14a4d7923331fddb0a1a7acbdb8301246 100644
+--- a/third_party/blink/public/common/features.h
++++ b/third_party/blink/public/common/features.h
+@@ -154,6 +154,15 @@ BLINK_COMMON_EXPORT BASE_DECLARE_FEATURE_PARAM(
+     bool,
+     kBackgroundCodeCacheDecoderStart);
+ 
++// A kill switch to background fetch from the service worker environment. If
++// enabled, `backgroundFetch.fetch()` from the service worker will throw an
++// exception.
++BLINK_COMMON_EXPORT BASE_DECLARE_FEATURE(
++    kRestrictBackgroundFetchFromServiceWorker);
++BLINK_COMMON_EXPORT BASE_DECLARE_FEATURE_PARAM(
++    std::string,
++    kBackgroundFetchFromServiceWorkerAllowListStr);
++
+ BLINK_COMMON_EXPORT BASE_DECLARE_FEATURE(kBakedGamutMapping);
+ 
+ // Used to configure a per-origin allowlist of performance.mark events that are

--- a/patches/third_party-blink-renderer-modules-background_fetch-background_fetch_manager.cc.patch
+++ b/patches/third_party-blink-renderer-modules-background_fetch-background_fetch_manager.cc.patch
@@ -1,0 +1,92 @@
+diff --git a/third_party/blink/renderer/modules/background_fetch/background_fetch_manager.cc b/third_party/blink/renderer/modules/background_fetch/background_fetch_manager.cc
+index f032ce8303affc999b0d1e4e074aa9d4fb204c83..cd9fea05a0aac1d614c30863c72984b250beedb2 100644
+--- a/third_party/blink/renderer/modules/background_fetch/background_fetch_manager.cc
++++ b/third_party/blink/renderer/modules/background_fetch/background_fetch_manager.cc
+@@ -9,6 +9,7 @@
+ 
+ #include "base/memory/scoped_refptr.h"
+ #include "services/network/public/mojom/ip_address_space.mojom-blink.h"
++#include "third_party/blink/public/common/features.h"
+ #include "third_party/blink/renderer/bindings/core/v8/script_promise_resolver.h"
+ #include "third_party/blink/renderer/bindings/core/v8/v8_union_request_requestorusvstringsequence_usvstring.h"
+ #include "third_party/blink/renderer/bindings/core/v8/v8_union_request_usvstring.h"
+@@ -125,6 +126,34 @@ scoped_refptr<BlobDataHandle> ExtractBlobHandle(
+   return blob_handle;
+ }
+ 
++// Returns true if Background Fetch is permitted in the current execution
++// context. Usage within Service Worker contexts is restricted.
++bool IsBackgroundFetchAllowedForContext(ExecutionContext* execution_context) {
++  // If the context is not a Service Worker, or if the restriction feature
++  // is disabled, the restriction does not apply.
++  if (!execution_context->IsServiceWorkerGlobalScope() ||
++      !base::FeatureList::IsEnabled(
++          blink::features::kRestrictBackgroundFetchFromServiceWorker)) {
++    return true;
++  }
++
++  // Define a local storage wrapper to manage the one-time initialization
++  // and parsing of the allowlist origins.
++  struct ParsedAllowlist {
++    HashSet<scoped_refptr<const SecurityOrigin>> origins;
++    ParsedAllowlist() {
++      std::string allowlist_str =
++          blink::features::kBackgroundFetchFromServiceWorkerAllowListStr.Get();
++      origins = BackgroundFetchManager::ParseAllowlist(allowlist_str);
++    }
++  };
++  DEFINE_THREAD_SAFE_STATIC_LOCAL(ParsedAllowlist, parsed_allowlist, ());
++
++  // Check if the current context's origin is present in the list.
++  return parsed_allowlist.origins.Contains(
++      execution_context->GetSecurityOrigin());
++}
++
+ }  // namespace
+ 
+ BackgroundFetchManager::BackgroundFetchManager(
+@@ -135,6 +164,29 @@ BackgroundFetchManager::BackgroundFetchManager(
+   bridge_ = BackgroundFetchBridge::From(registration_);
+ }
+ 
++// static
++HashSet<scoped_refptr<const SecurityOrigin>>
++BackgroundFetchManager::ParseAllowlist(const std::string& allowlist_str) {
++  HashSet<scoped_refptr<const SecurityOrigin>> origins;
++  if (!allowlist_str.empty()) {
++    String blink_allowlist_str = String::FromUtf8(allowlist_str);
++    Vector<String> allowlist_origins =
++        blink_allowlist_str.SplitSkippingEmpty(',');
++    for (String origin_str : allowlist_origins) {
++      origin_str = origin_str.StripWhiteSpace();
++      if (origin_str.empty()) {
++        continue;
++      }
++      scoped_refptr<SecurityOrigin> origin =
++          SecurityOrigin::CreateFromString(origin_str);
++      if (origin && !origin->IsOpaque()) {
++        origins.insert(std::move(origin));
++      }
++    }
++  }
++  return origins;
++}
++
+ ScriptPromise<BackgroundFetchRegistration> BackgroundFetchManager::fetch(
+     ScriptState* script_state,
+     const String& id,
+@@ -155,6 +207,14 @@ ScriptPromise<BackgroundFetchRegistration> BackgroundFetchManager::fetch(
+     return EmptyPromise();
+   }
+ 
++  if (!IsBackgroundFetchAllowedForContext(execution_context)) {
++    exception_state.ThrowDOMException(
++        DOMExceptionCode::kNotAllowedError,
++        "backgroundFetch.fetch() is not allowed in service worker "
++        "environments.");
++    return EmptyPromise();
++  }
++
+   Vector<mojom::blink::FetchAPIRequestPtr> fetch_api_requests =
+       CreateFetchAPIRequestVector(script_state, requests, exception_state);
+   if (exception_state.HadException()) {

--- a/patches/third_party-blink-renderer-modules-background_fetch-background_fetch_manager.h.patch
+++ b/patches/third_party-blink-renderer-modules-background_fetch-background_fetch_manager.h.patch
@@ -1,0 +1,14 @@
+diff --git a/third_party/blink/renderer/modules/background_fetch/background_fetch_manager.h b/third_party/blink/renderer/modules/background_fetch/background_fetch_manager.h
+index f48fae6cc2eff86e6552eb61e9a93eada54a88b2..022d3e0ae21c9598c30dba5506e41305dcbe2831 100644
+--- a/third_party/blink/renderer/modules/background_fetch/background_fetch_manager.h
++++ b/third_party/blink/renderer/modules/background_fetch/background_fetch_manager.h
+@@ -56,6 +56,9 @@ class MODULES_EXPORT BackgroundFetchManager final
+   // ExecutionContextLifecycleObserver interface
+   void ContextDestroyed() override;
+ 
++  static HashSet<scoped_refptr<const SecurityOrigin>> ParseAllowlist(
++      const std::string& allowlist_str);
++
+  private:
+   friend class BackgroundFetchManagerTest;
+ 

--- a/patches/third_party-blink-renderer-modules-background_fetch-background_fetch_manager_test.cc.patch
+++ b/patches/third_party-blink-renderer-modules-background_fetch-background_fetch_manager_test.cc.patch
@@ -1,0 +1,51 @@
+diff --git a/third_party/blink/renderer/modules/background_fetch/background_fetch_manager_test.cc b/third_party/blink/renderer/modules/background_fetch/background_fetch_manager_test.cc
+index 499d6f996657f1202b26d07f61f14d1df0ccdd18..de8e8c78f0360b59b560db28a243768ef5832cd0 100644
+--- a/third_party/blink/renderer/modules/background_fetch/background_fetch_manager_test.cc
++++ b/third_party/blink/renderer/modules/background_fetch/background_fetch_manager_test.cc
+@@ -14,6 +14,7 @@
+ #include "third_party/blink/renderer/platform/bindings/script_state.h"
+ #include "third_party/blink/renderer/platform/blob/blob_data.h"
+ #include "third_party/blink/renderer/platform/testing/task_environment.h"
++#include "third_party/blink/renderer/platform/weborigin/security_origin.h"
+ 
+ namespace blink {
+ 
+@@ -184,4 +185,38 @@ TEST_F(BackgroundFetchManagerTest, BlobsExtracted) {
+   EXPECT_FALSE(fetch_api_requests[1]->blob);
+ }
+ 
++TEST_F(BackgroundFetchManagerTest, ParseAllowlistEmpty) {
++  auto origins = BackgroundFetchManager::ParseAllowlist("");
++  EXPECT_TRUE(origins.empty());
++}
++
++TEST_F(BackgroundFetchManagerTest, ParseAllowlistSingleOrigin) {
++  auto origins = BackgroundFetchManager::ParseAllowlist("https://example.com");
++  EXPECT_EQ(origins.size(), 1u);
++  scoped_refptr<const SecurityOrigin> expected =
++      SecurityOrigin::CreateFromString("https://example.com");
++  EXPECT_TRUE(origins.Contains(expected));
++}
++
++TEST_F(BackgroundFetchManagerTest, ParseAllowlistMultipleOrigins) {
++  auto origins = BackgroundFetchManager::ParseAllowlist(
++      "https://example.com, https://api.allowed-origin.org,http://loopback.ip");
++  EXPECT_EQ(origins.size(), 3u);
++
++  EXPECT_TRUE(origins.Contains(
++      SecurityOrigin::CreateFromString("https://example.com")));
++  EXPECT_TRUE(origins.Contains(
++      SecurityOrigin::CreateFromString("https://api.allowed-origin.org")));
++  EXPECT_TRUE(
++      origins.Contains(SecurityOrigin::CreateFromString("http://loopback.ip")));
++}
++
++TEST_F(BackgroundFetchManagerTest, ParseAllowlistInvalidAndOpaqueOrigins) {
++  auto origins = BackgroundFetchManager::ParseAllowlist(
++      "data:text/html,https://example.com,opaque");
++  EXPECT_EQ(origins.size(), 1u);
++  EXPECT_TRUE(origins.Contains(
++      SecurityOrigin::CreateFromString("https://example.com")));
++}
++
+ }  // namespace blink


### PR DESCRIPTION
Uplift of #36655
Resolves https://github.com/brave/brave-browser/issues/55755
Resolves https://github.com/brave/internal/issues/1749

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.