### PR TITLE
[Origin] Brave News starts fetches when disabled by policy

### DIFF
--- a/browser/brave_news/brave_news_controller_factory.cc
+++ b/browser/brave_news/brave_news_controller_factory.cc
@@ -10,13 +10,16 @@
 #include "base/no_destructor.h"
 #include "brave/browser/brave_news/direct_feed_fetcher_delegate_impl.h"
 #include "brave/components/brave_news/browser/brave_news_controller.h"
+#include "brave/components/brave_policy/policy_initialization_waiter.h"
 #include "chrome/browser/content_settings/host_content_settings_map_factory.h"
 #include "chrome/browser/favicon/favicon_service_factory.h"
 #include "chrome/browser/history/history_service_factory.h"
+#include "chrome/browser/policy/profile_policy_connector.h"
 #include "chrome/browser/profiles/incognito_helpers.h"
 #include "chrome/browser/profiles/profile.h"
 #include "components/keyed_service/content/browser_context_dependency_manager.h"
 #include "components/keyed_service/core/service_access_type.h"
+#include "components/policy/core/common/policy_service.h"
 #include "content/public/browser/browser_context.h"
 
 namespace brave_news {
@@ -74,8 +77,18 @@ BraveNewsControllerFactory::BuildServiceInstanceForBrowserContext(
       profile, ServiceAccessType::EXPLICIT_ACCESS);
   auto* host_content_settings_map =
       HostContentSettingsMapFactory::GetForProfile(profile);
+
+  policy::PolicyService* policy_service = nullptr;
+  if (auto* policy_connector = profile->GetProfilePolicyConnector()) {
+    policy_service = policy_connector->policy_service();
+  }
+  auto policy_initialization_waiter =
+      std::make_unique<brave_policy::PolicyInitializationWaiter>(
+          policy_service);
+
   return std::make_unique<BraveNewsController>(
-      profile->GetPrefs(), history_service, profile->GetURLLoaderFactory(),
+      profile->GetPrefs(), std::move(policy_initialization_waiter),
+      history_service, profile->GetURLLoaderFactory(),
       std::make_unique<DirectFeedFetcherDelegateImpl>(
           host_content_settings_map));
 }

--- a/browser/brave_news/sources.gni
+++ b/browser/brave_news/sources.gni
@@ -25,9 +25,11 @@ if (enable_brave_news) {
     "//base",
     "//brave/components/brave_news/browser",
     "//brave/components/brave_news/common",
+    "//brave/components/brave_policy:policy_initialization_waiter",
     "//brave/components/brave_shields/content/browser",
     "//chrome/browser/profiles:profile",
     "//components/keyed_service/content",
+    "//components/policy/core/common",
     "//content/public/browser",
   ]
 }

--- a/components/brave_news/browser/BUILD.gn
+++ b/components/brave_news/browser/BUILD.gn
@@ -74,6 +74,7 @@ static_library("browser") {
     "//brave/brave_domains",
     "//brave/components/api_request_helper",
     "//brave/components/brave_news/api",
+    "//brave/components/brave_policy:policy_initialization_waiter",
     "//brave/components/brave_private_cdn",
     "//brave/components/brave_rewards/core",
     "//brave/components/l10n/common",

--- a/components/brave_news/browser/brave_news_controller.cc
+++ b/components/brave_news/browser/brave_news_controller.cc
@@ -43,6 +43,7 @@
 #include "brave/components/brave_news/common/locales_helper.h"
 #include "brave/components/brave_news/common/subscriptions_snapshot.h"
 #include "brave/components/brave_news/common/types.h"
+#include "brave/components/brave_policy/policy_initialization_waiter.h"
 #include "brave/components/brave_private_cdn/private_cdn_helper.h"
 #include "components/history/core/browser/history_service.h"
 #include "components/history/core/browser/history_types.h"
@@ -98,6 +99,8 @@ mojo::StructPtr<EventType> CreateChangeEvent(
 
 BraveNewsController::BraveNewsController(
     PrefService* prefs,
+    std::unique_ptr<brave_policy::PolicyInitializationWaiter>
+        policy_initialization_waiter,
     history::HistoryService* history_service,
     scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
     std::unique_ptr<DirectFeedFetcher::Delegate> direct_feed_fetcher_delegate)
@@ -109,6 +112,7 @@ BraveNewsController::BraveNewsController(
       history_service_(history_service),
       url_loader_factory_(url_loader_factory),
       direct_feed_fetcher_delegate_(std::move(direct_feed_fetcher_delegate)),
+      policy_initialization_waiter_(std::move(policy_initialization_waiter)),
       pref_manager_(*prefs),
       news_metrics_(prefs, pref_manager_),
       direct_feed_controller_(url_loader_factory,
@@ -125,15 +129,25 @@ BraveNewsController::BraveNewsController(
               // Unretained is safe here because |initialization_promise_| is
               // owned by BraveNewsController.
               base::Unretained(this))) {
+  CHECK(policy_initialization_waiter_);
+
   ResetEngine();
   net::NetworkChangeNotifier::AddNetworkChangeObserver(this);
 
   prefs_observation_.Observe(&pref_manager_);
 
   news_metrics_.RecordAtInit();
+
   // Monitor kBraveNewsSources and update feed / publisher cache
-  // Start timer of updating feeds, if applicable
-  ConditionallyStartOrStopTimer();
+  // Start timer of updating feeds, if applicable.
+  //
+  // Defer the initial timer/fetch decision until the policy bundle has been
+  // merged into the managed pref store, so that `BraveNewsDisabled` (which
+  // writes `prefs::kBraveNewsDisabledByPolicy`) is visible when
+  // `pref_manager_.IsEnabled()` is evaluated.
+  policy_initialization_waiter_->Wait(
+      base::BindOnce(&BraveNewsController::ConditionallyStartOrStopTimer,
+                     weak_ptr_factory_.GetWeakPtr()));
 }
 
 BraveNewsController::~BraveNewsController() {

--- a/components/brave_news/browser/brave_news_controller.h
+++ b/components/brave_news/browser/brave_news_controller.h
@@ -40,6 +40,10 @@ static_assert(BUILDFLAG(ENABLE_BRAVE_NEWS));
 
 class PrefService;
 
+namespace brave_policy {
+class PolicyInitializationWaiter;
+}  // namespace brave_policy
+
 namespace history {
 class HistoryService;
 }  // namespace history
@@ -59,6 +63,8 @@ class BraveNewsController
  public:
   BraveNewsController(
       PrefService* prefs,
+      std::unique_ptr<brave_policy::PolicyInitializationWaiter>
+          policy_initialization_waiter,
       history::HistoryService* history_service,
       scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
       std::unique_ptr<DirectFeedFetcher::Delegate>
@@ -172,6 +178,8 @@ class BraveNewsController
   scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory_;
 
   std::unique_ptr<DirectFeedFetcher::Delegate> direct_feed_fetcher_delegate_;
+  std::unique_ptr<brave_policy::PolicyInitializationWaiter>
+      policy_initialization_waiter_;
 
   BraveNewsPrefManager pref_manager_;
   SubscriptionsSnapshot last_subscriptions_;

--- a/components/brave_news/common/pref_names.cc
+++ b/components/brave_news/common/pref_names.cc
@@ -31,7 +31,8 @@ void RegisterProfilePrefs(PrefRegistrySimple* registry) {
 }  // namespace prefs
 
 bool IsEnabled(PrefService* prefs) {
-  if (prefs->GetBoolean(prefs::kBraveNewsDisabledByPolicy)) {
+  if (prefs->IsManagedPreference(prefs::kBraveNewsDisabledByPolicy) &&
+      prefs->GetBoolean(prefs::kBraveNewsDisabledByPolicy)) {
     return false;
   }
   return prefs->GetBoolean(prefs::kNewTabPageShowToday) &&


### PR DESCRIPTION
`BraveNewsController` is built eagerly with the profile and its ctor immediately calls `ConditionallyStartOrStopTimer()`. The gate reads `kBraveNewsDisabledByPolicy` before the policy bundle has been merged into the managed pref store, so the managed value isn't visible yet and News issues its usual feed / publisher fetches even when Brave Origin's `BraveNewsDisabled` policy is set.

Defer the initial `ConditionallyStartOrStopTimer()` call behind a `brave_policy::PolicyInitializationWaiter`, and tighten `brave_news::IsEnabled()` to require `IsManagedPreference`.

Resolves: https://github.com/brave/brave-browser/issues/55759

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
