### PR TITLE
[ads] Fixes iOS video NTT does not autoplay when opening a new tab

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabManagerDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabManagerDelegate.swift
@@ -369,8 +369,11 @@ extension BrowserViewController: TabManagerDelegate {
       searchResultAdClickedInfoBar = nil
     }
 
-    newTabTakeoverInfoBar?.dismiss(false)
-    newTabTakeoverInfoBar = nil
+    let isNewTabURL = tabManager.selectedTab?.visibleURL?.isNewTabURL
+    if isNewTabURL != true {
+      newTabTakeoverInfoBar?.dismiss(false)
+      newTabTakeoverInfoBar = nil
+    }
   }
 
   func tabManagerDidRemoveAllTabs(_ tabManager: TabManager, toast: ButtonToast?) {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/NewTabPage/NewTabPageViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/NewTabPage/NewTabPageViewController.swift
@@ -148,6 +148,7 @@ class NewTabPageViewController: UIViewController {
   private let feedDataSource: FeedDataSource
   private let feedOverlayView = NewTabPageFeedOverlayView()
   private var preventReloadOnBraveNewsEnabledChange = false
+  private var didAttemptBackgroundVideoAutoplay = false
 
   private let notifications: NewTabPageNotifications
   private var cancellables: Set<AnyCancellable> = []
@@ -281,9 +282,7 @@ class NewTabPageViewController: UIViewController {
         // if needed.
         reportSponsoredBackgroundViewedEventIfNeeded()
 
-        videoAdPlayer?.loadAndAutoplayVideoAssetIfNeeded(
-          shouldAutoplay: false
-        )
+        loadAndAutoplayBackgroundVideoAdIfNeeded()
       }
     }
 
@@ -419,9 +418,7 @@ class NewTabPageViewController: UIViewController {
 
     reportSponsoredBackgroundViewedEventIfNeeded()
 
-    videoAdPlayer?.loadAndAutoplayVideoAssetIfNeeded(
-      shouldAutoplay: shouldShowBackgroundVideo()
-    )
+    loadAndAutoplayBackgroundVideoAdIfNeeded()
 
     presentNotification()
 
@@ -583,6 +580,20 @@ class NewTabPageViewController: UIViewController {
     videoAdPlayer?.didPlay25PercentEvent = { [weak self] in
       self?.reportSponsoredBackgroundEvent(.media25)
     }
+  }
+
+  private func loadAndAutoplayBackgroundVideoAdIfNeeded() {
+    guard background.currentBackground != nil else { return }
+    let shouldAutoplay =
+      shouldShowBackgroundVideo()
+      && delegate?.isURLBarInOverlayMode() != true
+      && !didAttemptBackgroundVideoAutoplay
+    videoAdPlayer?.loadAndAutoplayVideoAssetIfNeeded(
+      shouldAutoplay: shouldAutoplay
+    )
+    // Autoplay is only attempted once per tab open to avoid background changes
+    // triggering autoplay when the tab is already in use.
+    didAttemptBackgroundVideoAutoplay = true
   }
 
   private func shouldShowBackgroundVideo() -> Bool {


### PR DESCRIPTION
The PR fixes regression introduced in v1.90 when the video NTT on iOS does not autoplay when opening a new tab. The fix ensures autoplay fires on the first video NTT delivery in a tab and ignores subsequent tab background changes.

## Test plan

### Test case 1

1. Fresh install on iOS
2. Bypass NTT grace period (maybe use staging CRX components)
3. Trigger NTT
EXPECTATION: New Tab Takeover infobar is shown
4. Trigger 4 more NTTs
EXPECTATION: New Tab Takeover infobar is shown 4 times
5. Trigger one more NTT
EXPECTATION: New Tab Takeover infobar is NOT shown

### Test case 2

1. Fresh install on iOS
2. Bypass NTT grace period (maybe use staging CRX components)
3. Trigger NTT
EXPECTATION: New Tab Takeover infobar is shown
4. Close NTT infobar by tapping cross button (X)
5. Trigger one more NTT
EXPECTATION: New Tab Takeover infobar is NOT shown

### Test case 3

1. Fresh install on iOS
2. Bypass NTT grace period (maybe use staging CRX campaign)
3. Trigger NTT
EXPECTATION: New Tab Takeover infobar is shown
4. Tap `Learn More` link
EXPECTATION: New Tab Takeover infobar is closed
5. Trigger one more NTT
EXPECTATION: New Tab Takeover infobar is NOT shown

### Test case 4

1. Fresh install on iOS
2. Setup iOS device to use staging CRX components
3. Connect VPN to a country where `NTT Video Test - iOS only` staging campaign is served
4. Trigger video NTT
EXPECTATION: video NTT is autoplayed
5. Tap play button
EXPECTATION: video NTT entered full screen and starts playing

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/55760

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
