### PR TITLE
[iOS] Fix AI Chat fetching web content from the incorrect tab for history & bookmarks

### DIFF
--- a/ios/brave-ios/Sources/AIChat/WebUI/AIChatWebUIHelper.swift
+++ b/ios/brave-ios/Sources/AIChat/WebUI/AIChatWebUIHelper.swift
@@ -29,6 +29,7 @@ public class AIChatWebUIHelper: NSObject, TabObserver, AIChatUIHandler,
   public var tabsForPrivateMode: (_ isPrivate: Bool) -> [any TabState] = { _ in [] }
   public var profileController: BraveProfileController
   public var attachPrivacySensitiveTabHelpers: ((any TabState, any Profile) -> Void)?
+  public var webDelegateForTab: ((any TabState) -> AIChatWebDelegate?)?
 
   public init?(
     tab: some TabState,
@@ -121,7 +122,7 @@ public class AIChatWebUIHelper: NSObject, TabObserver, AIChatUIHandler,
     guard
       let childHelper = AIChatWebUIHelper(
         tab: tab,
-        webDelegate: webDelegate,
+        webDelegate: webDelegateForTab?(tab) ?? webDelegate,
         braveTalkJavascript: braveTalkJavascript,
         profileController: profileController
       ),

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabManagerDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabManagerDelegate.swift
@@ -62,6 +62,11 @@ extension BrowserViewController: TabManagerDelegate {
       guard let self, !isPrivate else { return [] }
       return tabManager.allTabs.filter { !$0.isPrivate }
     }
+    tab.aiChatWebUIHelper?.webDelegateForTab = { detachedTab in
+      /// If AIChat created a hidden tab for history or bookmarks, we need to
+      /// use it's `AIChatWebDelegate` to fetch content from.
+      detachedTab.leoTabHelper
+    }
     tab.walletWebUIHelper = .init(
       tab: tab,
       showApprovePanelUIHandler: { [weak self] tab in


### PR DESCRIPTION
The child helper for associated context was being given the `brave://leo-ai` TabState's `AIChatWebDelegate` so it was fetching web contents from the wrong tab's web view.

Resolves https://github.com/brave/brave-browser/issues/55736

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

### Testplan

1. Open any website
2. Close the tab
3. Open `brave://leo-ai`
4. Tap attachments button
5. Select history
6. Select website from step 1
7. Ask Leo to summarize the page
8. Verify it summarizes the page from history and not the `brave://leo-ai` tab itself.