### PR TITLE
[Sidebar V2] Fix side panel's resize area is not visible

### DIFF
--- a/browser/ui/sidebar/sidebar_browsertest.cc
+++ b/browser/ui/sidebar/sidebar_browsertest.cc
@@ -2194,44 +2194,61 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest,
   // --- Border case (rounded corners ON) ---
   prefs->SetBoolean(kWebViewRoundedCorners, true);
   RunScheduledLayouts();
-  EXPECT_FALSE(side_panel->GetInsets().IsEmpty());
+  EXPECT_GT(side_panel->GetInsets().width(), 0)
+      << "panel should have left/right insets";
 
   // In the bordered case the resize strip sits in the gap between the panel
   // edge and the content, at the left edge (panel is on the right in LTR).
-  const gfx::Rect bordered_bounds = resize_area->bounds();
-  EXPECT_EQ(bordered_bounds.top_right(),
-            side_panel->GetContentParentView()->origin())
+  // Check resize area and panel's screen bounds.origin().
+  EXPECT_EQ(resize_area->GetBoundsInScreen().origin(),
+            side_panel->GetBoundsInScreen().origin())
       << "Bordered resize area right edge should align with content origin";
-  EXPECT_EQ(bordered_bounds.width(), side_panel->GetInsets().left())
+  EXPECT_EQ(resize_area->width(), side_panel->GetInsets().left())
       << "Bordered resize area width should match the left border inset";
+  EXPECT_EQ(side_panel->GetIndexOf(resize_area),
+            side_panel->children().size() - 1)
+      << "resize area should be the top-most view";
 
   // --- No-border case (rounded corners OFF) ---
   prefs->SetBoolean(kWebViewRoundedCorners, false);
   RunScheduledLayouts();
-  EXPECT_TRUE(side_panel->GetInsets().IsEmpty());
+  EXPECT_EQ(0, side_panel->GetInsets().width());
+
+  // Shared assertions for the no-border state after a panel switch.
+  auto verify_no_border_state = [&]() {
+    EXPECT_EQ(0, side_panel->GetInsets().width())
+        << "Border insets' width should stay empty after switching panels "
+           "(border OFF)";
+    EXPECT_EQ(resize_area->GetBoundsInScreen().origin(),
+              side_panel->GetBoundsInScreen().origin())
+        << "No-border resize area should be placed at the inner edge of "
+           "content";
+    EXPECT_EQ(resize_area->width(),
+              views::BraveSidePanelResizeArea::kNoBorderResizeAreaWidth)
+        << "No-border resize area width should equal kNoBorderResizeAreaWidth";
+    EXPECT_EQ(side_panel->GetIndexOf(resize_area),
+              side_panel->children().size() - 1)
+        << "resize area should be the top-most view";
+  };
 
   // --- Panel-switch: border OFF must survive switching panels ---
+  // Switch to another panel that has brave panel header.
   panel_ui->Show(SidePanelEntryId::kBookmarks);
   ASSERT_TRUE(base::test::RunUntil([&]() {
     return panel_ui->IsSidePanelEntryShowing(
         SidePanelEntry::Key(SidePanelEntryId::kBookmarks));
   }));
+  RunScheduledLayouts();
+  verify_no_border_state();
+
+  // Switch to another panel that doesn't have brave panel header.
   panel_ui->Show(SidePanelEntryId::kCustomizeChrome);
   ASSERT_TRUE(base::test::RunUntil([&]() {
     return panel_ui->IsSidePanelEntryShowing(
         SidePanelEntry::Key(SidePanelEntryId::kCustomizeChrome));
   }));
   RunScheduledLayouts();
-  EXPECT_TRUE(side_panel->GetInsets().IsEmpty())
-      << "Border insets should stay empty after switching panels (border OFF)";
-
-  const gfx::Rect no_border_bounds = resize_area->bounds();
-  EXPECT_EQ(no_border_bounds.origin(),
-            side_panel->GetContentParentView()->origin())
-      << "No-border resize area should be placed at the inner edge of content";
-  EXPECT_EQ(no_border_bounds.width(),
-            views::BraveSidePanelResizeArea::kNoBorderResizeAreaWidth)
-      << "No-border resize area width should equal kNoBorderResizeAreaWidth";
+  verify_no_border_state();
 }
 
 class ScopedSidePanelUIForTesting {

--- a/browser/ui/sidebar/sidebar_browsertest.cc
+++ b/browser/ui/sidebar/sidebar_browsertest.cc
@@ -2215,7 +2215,8 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest,
   EXPECT_EQ(0, side_panel->GetInsets().width());
 
   // Shared assertions for the no-border state after a panel switch.
-  auto verify_no_border_state = [&]() {
+  auto verify_no_border_state = [&](const base::Location& loc) {
+    SCOPED_TRACE(loc.ToString());
     EXPECT_EQ(0, side_panel->GetInsets().width())
         << "Border insets' width should stay empty after switching panels "
            "(border OFF)";
@@ -2239,7 +2240,7 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest,
         SidePanelEntry::Key(SidePanelEntryId::kBookmarks));
   }));
   RunScheduledLayouts();
-  verify_no_border_state();
+  verify_no_border_state(FROM_HERE);
 
   // Switch to another panel that doesn't have brave panel header.
   panel_ui->Show(SidePanelEntryId::kCustomizeChrome);
@@ -2248,7 +2249,7 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest,
         SidePanelEntry::Key(SidePanelEntryId::kCustomizeChrome));
   }));
   RunScheduledLayouts();
-  verify_no_border_state();
+  verify_no_border_state(FROM_HERE);
 }
 
 class ScopedSidePanelUIForTesting {

--- a/browser/ui/views/side_panel/brave_side_panel_resize_area.cc
+++ b/browser/ui/views/side_panel/brave_side_panel_resize_area.cc
@@ -28,7 +28,11 @@ gfx::Rect BraveSidePanelResizeArea::GetNoBorderResizeBounds(
 }
 
 void BraveSidePanelResizeArea::Layout(PassKey) {
-  if (!side_panel_->GetInsets().IsEmpty()) {
+  // Upstream puts resize area over the left or right border.
+  // If it doesn't have left or right border, we should put over the contents.
+  // Don't check inset's emptiness because it can only have top insets due to
+  // panel header.
+  if (side_panel_->GetInsets().width() != 0) {
     // Parent has a border: resize area sits in the border gap between the
     // panel edge and the content area. Delegate entirely to upstream.
     LayoutSuperclass<SidePanelResizeArea>(this);

--- a/browser/ui/views/side_panel/brave_side_panel_resize_area.cc
+++ b/browser/ui/views/side_panel/brave_side_panel_resize_area.cc
@@ -30,8 +30,9 @@ gfx::Rect BraveSidePanelResizeArea::GetNoBorderResizeBounds(
 void BraveSidePanelResizeArea::Layout(PassKey) {
   // Upstream puts resize area over the left or right border.
   // If it doesn't have left or right border, we should put over the contents.
-  // Don't check inset's emptiness because it can only have top insets due to
-  // panel header.
+  // Check only horizontal insets — top insets may be non-zero when a panel
+  // header is present, so IsEmpty() would incorrectly treat a header-only inset
+  // as a side border.
   if (side_panel_->GetInsets().width() != 0) {
     // Parent has a border: resize area sits in the border gap between the
     // panel edge and the content area. Delegate entirely to upstream.

--- a/chromium_src/chrome/browser/ui/views/side_panel/side_panel.cc
+++ b/chromium_src/chrome/browser/ui/views/side_panel/side_panel.cc
@@ -70,8 +70,9 @@ void SidePanel::AddHeaderView(std::unique_ptr<views::View> view) {
   AddHeaderView_ChromiumImpl(std::move(view));
   UpdateBorder();
 
-  // Resize area is overlapped with other views such as contents and
-  // header view. Make it top-most view to get event for dragging.
+  // The resize area overlaps other views (contents, header), so it must be
+  // top-most to receive drag events. With rounded corners, it sits over the
+  // border area instead and doesn't overlap other views, so no reorder needed.
   if (!rounded_border_enabled_) {
     ReorderChildView(resize_area_, children().size());
   }

--- a/chromium_src/chrome/browser/ui/views/side_panel/side_panel.cc
+++ b/chromium_src/chrome/browser/ui/views/side_panel/side_panel.cc
@@ -69,6 +69,12 @@ void SidePanel::UpdateBorder() {
 void SidePanel::AddHeaderView(std::unique_ptr<views::View> view) {
   AddHeaderView_ChromiumImpl(std::move(view));
   UpdateBorder();
+
+  // Resize area is overlapped with other views such as contents and
+  // header view. Make it top-most view to get event for dragging.
+  if (!rounded_border_enabled_) {
+    ReorderChildView(resize_area_, children().size());
+  }
 }
 
 void SidePanel::RemoveHeaderView() {


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves no issue - use umbrella issue (https://github.com/brave/brave-browser/issues/51462)

F/U PR for https://github.com/brave/brave-core/pull/36472.
From https://github.com/brave/brave-core/pull/36472, we set side panel header.
So far,  `BraveSidePanelResizeArea` checks panel's inset emptiness to determine its position.
If empty, it's set over the panel contents. Otherwise, its set over the panel's side border area.
After header is used, panel has non-empty insets because it uses top inset to reserve header.
So, checking panel's inset emptiness is not valid anymore. It should check inset's width instead.

Also, resize area should be top-most child view. If not, can't grp around the header because
header is added later than resize area. So, reordered whenever header is added.

TEST=SidebarBrowserTest.SidebarV2ResizeAreaPositionMatchesBorderState

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
