### PR TITLE
NTP: Auto-fill top site title from URL when adding a shortcut

### DIFF
--- a/browser/resources/brave_new_tab_page_refresh/components/top_sites/top_site_edit_modal.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/top_sites/top_site_edit_modal.tsx
@@ -8,6 +8,7 @@ import Button from '@brave/leo/react/button'
 import Input from '@brave/leo/react/input'
 
 import { getString } from '../../lib/strings'
+import { generateSiteNameFromUrl } from '../../lib/site_name_from_url'
 import { TopSite } from '../../state/top_sites_store'
 import { Modal } from '../common/modal'
 
@@ -41,11 +42,15 @@ interface Props {
 export function TopSiteEditModal(props: Props) {
   const [title, setTitle] = React.useState('')
   const [url, setURL] = React.useState('')
+  const [titleEdited, setTitleEdited] = React.useState(false)
 
   React.useEffect(() => {
     if (props.isOpen) {
       setTitle(props.topSite?.title ?? '')
       setURL(props.topSite?.url ?? '')
+      // When editing an existing site, treat its title as already user-defined
+      // so URL changes don't overwrite it.
+      setTitleEdited(props.topSite !== null)
     }
   }, [props.isOpen, props.topSite])
 
@@ -85,7 +90,10 @@ export function TopSiteEditModal(props: Props) {
         </h4>
         <Input
           value={title}
-          onInput={(detail) => setTitle(detail.value)}
+          onInput={(detail) => {
+            setTitleEdited(true)
+            setTitle(detail.value)
+          }}
         >
           <span className='label'>
             {getString(S.NEW_TAB_TOP_SITES_TITLE_LABEL)}
@@ -93,7 +101,18 @@ export function TopSiteEditModal(props: Props) {
         </Input>
         <Input
           value={url}
-          onInput={(detail) => setURL(detail.value)}
+          onInput={(detail) => {
+            const nextURL = detail.value
+            setURL(nextURL)
+            if (!titleEdited) {
+              const generatedTitle = generateSiteNameFromUrl(nextURL)
+              if (generatedTitle) {
+                setTitle(generatedTitle)
+              } else if (!nextURL.trim()) {
+                setTitle('')
+              }
+            }
+          }}
         >
           <span className='label'>
             {getString(S.NEW_TAB_TOP_SITES_URL_LABEL)}

--- a/browser/resources/brave_new_tab_page_refresh/lib/site_name_from_url.test.ts
+++ b/browser/resources/brave_new_tab_page_refresh/lib/site_name_from_url.test.ts
@@ -1,0 +1,174 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { generateSiteNameFromUrl } from './site_name_from_url'
+
+describe('generateSiteNameFromUrl', () => {
+  describe('empty and invalid input', () => {
+    test('returns empty string for empty input', () => {
+      expect(generateSiteNameFromUrl('')).toBe('')
+    })
+
+    test('returns empty string for whitespace-only input', () => {
+      expect(generateSiteNameFromUrl('   ')).toBe('')
+    })
+
+    test('returns empty string for text with no recognizable host', () => {
+      expect(generateSiteNameFromUrl('not a url!!!')).toBe('')
+    })
+  })
+
+  describe('special hosts', () => {
+    test('handles bare localhost', () => {
+      expect(generateSiteNameFromUrl('localhost')).toBe('Localhost')
+    })
+
+    test('handles localhost with port', () => {
+      expect(generateSiteNameFromUrl('localhost:3000')).toBe('Localhost')
+    })
+
+    test('handles localhost with scheme', () => {
+      expect(generateSiteNameFromUrl('http://localhost:8080')).toBe('Localhost')
+    })
+
+    test('returns raw host for IPv4 address', () => {
+      expect(generateSiteNameFromUrl('192.168.1.1')).toBe('192.168.1.1')
+    })
+
+    test('returns raw host for IPv4 with port', () => {
+      expect(generateSiteNameFromUrl('http://192.168.1.1:8080')).toBe('192.168.1.1')
+    })
+  })
+
+  describe('brand capitalization', () => {
+    test('returns GitHub for github.com', () => {
+      expect(generateSiteNameFromUrl('github.com')).toBe('GitHub')
+    })
+
+    test('returns YouTube for youtube.com', () => {
+      expect(generateSiteNameFromUrl('youtube.com')).toBe('YouTube')
+    })
+
+    test('returns LinkedIn for linkedin.com', () => {
+      expect(generateSiteNameFromUrl('linkedin.com')).toBe('LinkedIn')
+    })
+
+    test('returns OpenAI for openai.com', () => {
+      expect(generateSiteNameFromUrl('openai.com')).toBe('OpenAI')
+    })
+
+    test('returns LeetCode for leetcode.com', () => {
+      expect(generateSiteNameFromUrl('leetcode.com')).toBe('LeetCode')
+    })
+
+    test('returns Y Combinator for news.ycombinator.com', () => {
+      expect(generateSiteNameFromUrl('news.ycombinator.com')).toBe(
+        'Y Combinator',
+      )
+    })
+  })
+
+  describe('www prefix stripping', () => {
+    test('strips www. before applying brand capitalization', () => {
+      expect(generateSiteNameFromUrl('www.github.com')).toBe('GitHub')
+    })
+
+    test('strips www. before title-casing', () => {
+      expect(generateSiteNameFromUrl('https://www.example.com')).toBe('Example')
+    })
+  })
+
+  describe('title-cased names', () => {
+    test('title-cases a simple domain', () => {
+      expect(generateSiteNameFromUrl('example.com')).toBe('Example')
+    })
+
+    test('converts hyphens to spaces and title-cases each word', () => {
+      expect(generateSiteNameFromUrl('my-site.com')).toBe('My Site')
+    })
+
+    test('converts underscores to spaces and title-cases each word', () => {
+      expect(generateSiteNameFromUrl('my_blog.io')).toBe('My Blog')
+    })
+
+    test('handles multiple consecutive hyphens', () => {
+      expect(generateSiteNameFromUrl('foo--bar.dev')).toBe('Foo Bar')
+    })
+  })
+
+  describe('TLD stripping', () => {
+    test('strips .com', () => {
+      expect(generateSiteNameFromUrl('google.com')).toBe('Google')
+    })
+
+    test('strips .org', () => {
+      expect(generateSiteNameFromUrl('wikipedia.org')).toBe('Wikipedia')
+    })
+
+    test('strips .io', () => {
+      expect(generateSiteNameFromUrl('linear.io')).toBe('Linear')
+    })
+
+    test('strips .dev', () => {
+      expect(generateSiteNameFromUrl('web.dev')).toBe('Web')
+    })
+
+    test('strips .me', () => {
+      expect(generateSiteNameFromUrl('portfolio.me')).toBe('Portfolio')
+    })
+
+    test('strips .co.uk multi-part TLD', () => {
+      expect(generateSiteNameFromUrl('bbc.co.uk')).toBe('Bbc')
+    })
+
+    test('strips .com.au multi-part TLD', () => {
+      expect(generateSiteNameFromUrl('news.com.au')).toBe('News')
+    })
+
+    test('strips .co.in multi-part TLD', () => {
+      expect(generateSiteNameFromUrl('flipkart.co.in')).toBe('Flipkart')
+    })
+  })
+
+  describe('subdomain handling', () => {
+    test('ignores subdomains and uses the SLD as the base name', () => {
+      expect(generateSiteNameFromUrl('mail.google.com')).toBe('Google')
+    })
+
+    test('ignores deep subdomains', () => {
+      expect(generateSiteNameFromUrl('docs.support.example.com')).toBe('Example')
+    })
+  })
+
+  describe('URL variants', () => {
+    test('handles URL without scheme', () => {
+      expect(generateSiteNameFromUrl('github.com')).toBe('GitHub')
+    })
+
+    test('handles https URL', () => {
+      expect(generateSiteNameFromUrl('https://github.com')).toBe('GitHub')
+    })
+
+    test('handles http URL', () => {
+      expect(generateSiteNameFromUrl('http://github.com')).toBe('GitHub')
+    })
+
+    test('ignores URL path', () => {
+      expect(generateSiteNameFromUrl('https://github.com/user/repo')).toBe(
+        'GitHub',
+      )
+    })
+
+    test('ignores query string', () => {
+      expect(generateSiteNameFromUrl('https://example.com?q=test')).toBe(
+        'Example',
+      )
+    })
+
+    test('trims leading/trailing whitespace from input', () => {
+      expect(generateSiteNameFromUrl('  github.com  ')).toBe('GitHub')
+    })
+  })
+})

--- a/browser/resources/brave_new_tab_page_refresh/lib/site_name_from_url.ts
+++ b/browser/resources/brave_new_tab_page_refresh/lib/site_name_from_url.ts
@@ -1,0 +1,115 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// Brands where title-casing the domain label produces the wrong result.
+const brandCapitalization: Record<string, string> = {
+  github: 'GitHub',
+  youtube: 'YouTube',
+  linkedin: 'LinkedIn',
+  openai: 'OpenAI',
+  leetcode: 'LeetCode',
+  ycombinator: 'Y Combinator',
+}
+
+// Second-level TLD suffixes that require stripping two labels (e.g. co.uk).
+const multiPartTlds = new Set([
+  'co.in', 'co.uk', 'co.jp', 'co.nz', 'co.za', 'co.kr',
+  'com.au', 'com.br',
+  'org.uk',
+])
+
+// Single-label TLDs whose only purpose is to identify the TLD boundary.
+const singleTlds = new Set([
+  'com', 'org', 'net', 'io', 'dev', 'ai',
+  'in', 'uk', 'us', 'ca', 'de', 'fr', 'jp', 'au', 'br',
+  'edu', 'gov', 'me', 'app', 'co',
+])
+
+function parseInputUrl(input: string): URL | null {
+  if (!input) {
+    return null
+  }
+  // The URL spec allows bare words as scheme names (e.g. "localhost:3000"
+  // parses as scheme "localhost:" with an empty hostname). Only accept a
+  // parsed URL when it actually produced a hostname.
+  try {
+    const url = new URL(input)
+    if (url.hostname) {
+      return url
+    }
+  } catch {
+    // Fall through.
+  }
+  try {
+    return new URL(`https://${input}`)
+  } catch {
+    return null
+  }
+}
+
+function isIPv4Host(host: string) {
+  return /^\d{1,3}(?:\.\d{1,3}){3}$/.test(host)
+}
+
+function titleCaseWords(value: string) {
+  return value
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((word) => word[0].toUpperCase() + word.slice(1))
+    .join(' ')
+}
+
+function removeKnownTld(labels: string[]) {
+  if (labels.length < 2) {
+    return labels
+  }
+  const lastTwo = labels.slice(-2).join('.')
+  if (multiPartTlds.has(lastTwo)) {
+    return labels.slice(0, -2)
+  }
+  if (singleTlds.has(labels[labels.length - 1])) {
+    return labels.slice(0, -1)
+  }
+  return labels
+}
+
+export function generateSiteNameFromUrl(input: string): string {
+  const url = parseInputUrl(input.trim())
+  if (!url) {
+    return ''
+  }
+
+  const host = url.hostname.toLowerCase().replace(/^www\./, '')
+  if (!host) {
+    return ''
+  }
+
+  if (host === 'localhost') {
+    return 'Localhost'
+  }
+
+  // IPv6 addresses contain colons; return the raw host for both IPv4 and IPv6.
+  if (isIPv4Host(host) || host.includes(':')) {
+    return host
+  }
+
+  let labels = host.split('.').filter(Boolean)
+  if (labels.length === 0) {
+    return ''
+  }
+
+  labels = removeKnownTld(labels)
+  if (labels.length === 0) {
+    return ''
+  }
+
+  const baseLabel = labels[labels.length - 1]
+  const brandName = brandCapitalization[baseLabel]
+  if (brandName) {
+    return brandName
+  }
+
+  return titleCaseWords(baseLabel.replace(/[-_]+/g, ' '))
+}


### PR DESCRIPTION
### Summary

  When a user opens the **Add Top Site** modal and starts typing a URL, the title
  field now auto-populates with a human-readable name derived from the hostname.
  Auto-fill stops the moment the user manually edits the title field. When
  **editing** an existing top site, the existing title is always preserved —
  changing the URL never overwrites it.

  ### How it works

  A new pure utility module `lib/site_name_from_url.ts` handles name extraction:

  1. **Brand capitalization map** — for brands where title-casing the domain label
     produces the wrong result (e.g. `github` → `GitHub`, not `Github`). Only
     brands where casing genuinely differs are included; `Reddit`, `Discord` etc.
     are omitted since title-case already gives the right answer.
  2. **TLD stripping** — single-label TLDs (`com`, `org`, `io`, `dev`, `me`,
     `app`, `co`, country codes) and multi-part TLDs (`co.uk`, `com.au`,
     `co.jp`, …) are stripped before the name is extracted, so
     `mail.google.com` → `Google`, not `Com`.
  3. **Subdomain handling** — all subdomains are ignored; the second-level domain
     label is used as the base name.
  4. **Hyphen / underscore conversion** — `my-blog.io` → `My Blog`,
     `my_site.dev` → `My Site`.
  5. **Special cases** — `localhost` (with or without port), IPv4, and IPv6
     addresses are handled explicitly and returned as-is.
  6. **Lenient URL parsing** — bare hostnames like `github.com` are accepted
     alongside full URLs. The URL spec quirk where `localhost:3000` parses as a
     custom scheme (yielding an empty hostname) is correctly handled by falling
     back to an `https://` prefix.

  The modal change is minimal — a single `titleEdited` boolean tracks whether the
  user has manually touched the title field, so auto-fill is smart about when
  to run.

  ### Changes

  | File | Description |
  |---|---|
  | `lib/site_name_from_url.ts` | New utility module — `generateSiteNameFromUrl(input: string): string` |
  | `lib/site_name_from_url.test.ts` | 36 unit tests across 8 groups (empty/invalid input, special hosts, brand names, www stripping, title-casing, TLD stripping, subdomain handling, URL
  variants) |
  | `components/top_sites/top_site_edit_modal.tsx` | Wires auto-fill into the URL input; fixes `titleEdited` initial state so edit mode never overwrites an existing title |

  ### Test plan

  - [ ] Open **New Tab Page → Add top site** modal
  - [ ] Type `github.com` in the URL field → title auto-fills as `GitHub`
  - [ ] Type `my-portfolio.io` → title auto-fills as `My Portfolio`
  - [ ] Type `localhost:3000` → title auto-fills as `Localhost`
  - [ ] Type `192.168.1.1` → title auto-fills as `192.168.1.1`
  - [ ] Type a URL, then manually edit the title → further URL changes no longer touch the title
  - [ ] Open **Edit** on an existing top site, change the URL → existing title is not overwritten
  - [ ] Clear the URL field (with no manual title edit) → title clears too
  - [ ] `npm run test-unit -- lib/site_name_from_url.test.ts` → 36/36 pass

