### PR TITLE
[toolchain] fix-rust-wasm-picking-up-installed-build-tools

### DIFF
--- a/components/common/rust_to_wasm.gni
+++ b/components/common/rust_to_wasm.gni
@@ -4,6 +4,7 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import("//brave/build/host_os_constants.gni")
+import("//brave/tools/crates/cargo_env.gni")
 
 template("rust_to_wasm") {
   assert(defined(invoker.rust_packages),
@@ -45,8 +46,9 @@ template("rust_to_wasm") {
     # or via `cargo install`, which:
     # - causes a race condition between the processes (that action_foreach forks) for wasm-pack's cache directory (if wasm-pack is run for the first time),
     # - makes our approach less self-contained.
-    response_file_contents = [
-      "PATH=./" + host_path_sep + getenv("PATH"),
+    response_file_contents = [ "PATH=./" + host_path_sep + getenv("PATH") ]
+    response_file_contents += cargo_hermetic_env
+    response_file_contents += [
       rebase_path("$root_build_dir/wasm-pack$host_exe_suffix"),
       "--log-level",
       "warn",
@@ -65,6 +67,31 @@ template("rust_to_wasm") {
       "--quiet",
       "--config",
       rebase_path("//{{source_root_relative_dir}}/.cargo/config.toml"),
+
+      # Pin the wasm32 linker to the `rust-lld` shipped by our toolchain
+      # archive (see tools/cr/toolchain/build_rust_toolchain.py).  Without
+      # this, rustc only finds `rust-lld` if the archive's unpack step
+      # places it at the canonical sysroot `lib/rustlib/<host>/bin/`
+      # location.  Pinning explicitly keeps the wasm link step working
+      # regardless of unpack layout.
+      "--config",
+      "target.wasm32-unknown-unknown.linker=\"" +
+          rebase_path(
+              "//third_party/rust-toolchain/bin/rust-lld$host_exe_suffix") +
+          "\"",
+    ]
+
+    # Pin the host linker + rustflags for build scripts / proc-macros that
+    # cargo compiles for HOST during this wasm32 cross-compile.  Without
+    # these, rustc on the host side falls back to system `ld` via `xcrun`,
+    # which fails on builders that don't have the command-line developer
+    # tools fully populated (notably the iOS CI agents).  See cargo_env.gni
+    # for why env-var-set CARGO_TARGET_<HOST>_RUSTFLAGS doesn't reach host
+    # artifacts during cross-compile and why we route this through inline
+    # `--config` instead.
+    response_file_contents += cargo_host_config_args
+
+    response_file_contents += [
       "--target-dir",
       rebase_path(
           "$root_gen_dir/{{source_root_relative_dir}}/$wasm_pack_target/target"),

--- a/tools/crates/build_crate.gni
+++ b/tools/crates/build_crate.gni
@@ -4,6 +4,7 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import("//brave/build/host_os_constants.gni")
+import("//brave/tools/crates/cargo_env.gni")
 
 template("build_crate") {
   if (defined(invoker["crates"])) {
@@ -58,6 +59,9 @@ template("build_crate") {
       "PATH=" +
           rebase_path("//third_party/rust-toolchain/bin", root_build_dir) +
           host_path_sep + getenv("PATH"),
+    ]
+    response_file_contents += cargo_hermetic_env
+    response_file_contents += [
       rebase_path(cargo_exe),
       "build",
       "--quiet",

--- a/tools/crates/cargo_env.gni
+++ b/tools/crates/cargo_env.gni
@@ -1,0 +1,311 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+# Hermetic environment for cargo invocations driven by the Brave build.
+#
+# Both //brave/tools/crates/build_crate.gni (host CLI tools like wasm-pack)
+# and //brave/components/common/rust_to_wasm.gni (the actual wasm-pack -> cargo
+# build of WASM packages) shell out to cargo, which in turn invokes build
+# scripts that compile native code via the `cc-rs` crate.  Without explicit
+# pinning, `cc-rs` falls through to whatever cc/c++/ar/ld it finds on PATH,
+# which on macOS routes via `xcrun` and breaks under the hermetic Xcode
+# tarball, and on Linux/Windows picks up the system toolchain rather than the
+# Chromium-bundled one.
+#
+# This file builds a `cargo_hermetic_env` list of "KEY=VALUE" strings that
+# both callers append to their `response_file_contents` before the cargo
+# command itself.  Mirrors the env block in tools/rust/build_rust.py's
+# `XPy.__init__`, scaled down to consumers of the prebuilt rust toolchain
+# (we pin to clang_base_path rather than RUST_HOST_LLVM_INSTALL_DIR, which
+# only exists on toolchain builders).
+
+import("//brave/build/host_os_constants.gni")
+import("//build/config/clang/clang.gni")
+
+# `mac_sdk.gni` itself asserts that it's only imported from a context where
+# the Mac SDK is meaningful — i.e. mac targets, the default toolchain, or
+# Android-on-mac builds.  We can be re-imported from contexts that violate
+# that assertion (e.g. an iOS app-extension toolchain pulling in
+# typescript.gni -> rust_to_wasm.gni -> this file), so mirror the same gate
+# here and skip the mac SDK env block when it doesn't apply.  `cargo_hermetic_env`
+# only actually gets *used* in host_toolchain — anywhere else it's just
+# imported-but-unused, so emitting an env without mac-SDK paths is harmless.
+_have_mac_sdk = false
+if (host_os == "mac" &&
+    (current_os == "mac" || current_toolchain == default_toolchain ||
+     target_os == "android")) {
+  import("//build/config/mac/mac_sdk.gni")
+  _have_mac_sdk = true
+}
+
+# Compute the Linux *host* sysroot path explicitly rather than reading the
+# `sysroot` variable from //build/config/sysroot.gni.  That file resolves
+# `sysroot` based on target-side `current_os`/`current_cpu` — so when
+# cargo_env.gni is evaluated in an Android (or any non-linux) toolchain
+# context, `sysroot` points at e.g. the Android NDK sysroot, which is the
+# wrong tree for our host build scripts (which compile for
+# x86_64-unknown-linux-gnu and need glibc).  Hardcoding the
+# Debian-bullseye path off `host_cpu` is what gives us a stable host-side
+# sysroot independent of the target.
+_linux_host_sysroot = ""
+if (host_os == "linux") {
+  if (host_cpu == "x64") {
+    _linux_host_sysroot = "//build/linux/debian_bullseye_amd64-sysroot"
+  } else if (host_cpu == "x86") {
+    _linux_host_sysroot = "//build/linux/debian_bullseye_i386-sysroot"
+  } else if (host_cpu == "arm64") {
+    _linux_host_sysroot = "//build/linux/debian_bullseye_arm64-sysroot"
+  } else if (host_cpu == "arm") {
+    _linux_host_sysroot = "//build/linux/debian_bullseye_armhf-sysroot"
+  }
+
+  # Guard against builders that haven't run the install-sysroot.py gclient
+  # hook (or have it disabled).  If the dir isn't there, fall through to no
+  # `--sysroot=` flag — the build script link will probably still fail, but
+  # at least with a clear "missing libc" error rather than a confusing
+  # wrong-sysroot one.
+  if (_linux_host_sysroot != "" && !path_exists(_linux_host_sysroot)) {
+    _linux_host_sysroot = ""
+  }
+}
+
+_clang_bin = rebase_path("$clang_base_path/bin")
+
+# rustc's default linker on linux/mac is `cc`, and on Windows it's `link.exe`.
+# Neither is what we want — we want the Chromium-bundled clang/lld-link.  Pin
+# the linker via `CARGO_TARGET_<HOST_TRIPLE>_LINKER`, which cargo translates
+# into `-C linker=…` *only* for builds to that triple.  Scoping to the host
+# triple keeps this from leaking into the wasm32 build inside rust_to_wasm.gni
+# (where the linker is pinned to `rust-lld` via --config).
+#
+# The triple is built from host_os/host_cpu rather than e.g. probing rustc,
+# because both must be statically resolvable at GN-time.
+if (host_os == "linux") {
+  if (host_cpu == "x64") {
+    _host_triple_env = "X86_64_UNKNOWN_LINUX_GNU"
+    _host_triple_canon = "x86_64-unknown-linux-gnu"
+  } else if (host_cpu == "arm64") {
+    _host_triple_env = "AARCH64_UNKNOWN_LINUX_GNU"
+    _host_triple_canon = "aarch64-unknown-linux-gnu"
+  } else {
+    assert(false, "Unsupported host_cpu '$host_cpu' on linux")
+  }
+} else if (host_os == "mac") {
+  if (host_cpu == "x64") {
+    _host_triple_env = "X86_64_APPLE_DARWIN"
+    _host_triple_canon = "x86_64-apple-darwin"
+  } else if (host_cpu == "arm64") {
+    _host_triple_env = "AARCH64_APPLE_DARWIN"
+    _host_triple_canon = "aarch64-apple-darwin"
+  } else {
+    assert(false, "Unsupported host_cpu '$host_cpu' on mac")
+  }
+} else if (host_os == "win") {
+  if (host_cpu == "x64") {
+    _host_triple_env = "X86_64_PC_WINDOWS_MSVC"
+    _host_triple_canon = "x86_64-pc-windows-msvc"
+  } else if (host_cpu == "arm64") {
+    _host_triple_env = "AARCH64_PC_WINDOWS_MSVC"
+    _host_triple_canon = "aarch64-pc-windows-msvc"
+  } else {
+    assert(false, "Unsupported host_cpu '$host_cpu' on win")
+  }
+} else {
+  assert(false, "Unsupported host_os '$host_os'")
+}
+
+# Per-host link args, gathered as a list and joined into the final
+# `CARGO_TARGET_<HOST>_RUSTFLAGS` env var below.  rustc doesn't read
+# LDFLAGS/SYSROOT for its own link step, so anything the link needs must be
+# passed through as `-Clink-arg=...`.  Scoping via `CARGO_TARGET_<HOST>_*`
+# (rather than global `RUSTFLAGS`) keeps these flags out of the wasm32 link
+# step, which is driven by `rust-lld` directly and wouldn't understand
+# GCC-driver-style flags like `-fuse-ld=lld` or `--sysroot=`.
+_host_link_args = []
+
+if (host_os == "win") {
+  _host_linker = "$_clang_bin/lld-link.exe"
+  # lld-link.exe is a drop-in replacement for MSVC's link.exe, so rustc can
+  # invoke it directly with no clang driver wrapper and no -fuse-ld dispatch.
+} else {
+  _host_linker = "$_clang_bin/clang"
+  _host_link_args += [ "-Clink-arg=-fuse-ld=lld" ]
+}
+
+if (_linux_host_sysroot != "") {
+  # Inject the Debian sysroot into the clang-driven link.  Without this, lld
+  # pulls in libpthread.so/librt.so/libdl.so linker scripts from the sysroot
+  # but resolves their absolute paths to libc.so.6 against the host's glibc,
+  # which doesn't carry the matching @GLIBC_PRIVATE symbols.
+  _host_link_args +=
+      [ "-Clink-arg=--sysroot=" + rebase_path(_linux_host_sysroot) ]
+}
+
+if (host_os == "win") {
+  # cc-rs's `envflags` *concatenates* every variant of an env var that is
+  # set, walking the precedence chain (see tools/crates/vendor/cc/src/lib.rs
+  # :3915-3935 — note the comment "Collect from all environment variables").
+  # That means if we set `CFLAGS` and `CFLAGS_<target>` and `TARGET_CFLAGS`
+  # all to the same value, our flags get added 3x to the compile command.
+  #
+  # Trick: cc-rs treats an empty-string value as "set but contributes no
+  # tokens".  So put the real flags on the generic `<VAR>` slot, and set
+  # every target-specific / TARGET_<VAR> variant to empty.  The empty
+  # variants neutralize anything siso/ninja might have populated for the
+  # Chromium C++ build (which is what was originally leaking
+  # `-Wunsafe-buffer-usage` and the unsafe-buffers plugin args into cc-rs's
+  # clang-cl invocation — vendored third-party C in tools/crates/vendor/
+  # isn't subject to Chromium's warning policy and is exempted from the
+  # GN-driven build via //build/config/unsafe_buffers_paths.txt).
+  _win_flags = "--no-default-config -w"
+
+  # C++ extras: clang-cl on Windows leaves exceptions disabled by default
+  # (matching MSVC), and cc-rs doesn't add `/EHsc` itself for the
+  # MSVC-style driver.  Binaryen (wasm-opt-sys) uses `throw`, so we need
+  # to enable C++ exceptions explicitly.
+  _win_cxxflags = "$_win_flags /EHsc"
+  cargo_hermetic_env = [
+    "CC=$_clang_bin/clang-cl.exe",
+    "CXX=$_clang_bin/clang-cl.exe",
+
+    # Chromium's Windows clang package strips both `llvm-ar.exe` and
+    # `llvm-lib.exe` (see tools/clang/scripts/package.py), so neither is
+    # available as a standalone MSVC librarian via `clang_base_path`.  As a
+    # workaround we use the shipped `lld-link.exe` and rely on the
+    # `ARFLAGS=-lib` env var below to prepend `-lib` to cc-rs's invocation —
+    # lld-link enters MSVC librarian mode when its first arg is `-lib`/`/lib`.
+    # See tools/crates/vendor/cc/src/lib.rs:2712-2723 + :3287-3290: the MSVC
+    # archiver pattern is `<AR> <ARFLAGS...> -out:<dst> <objs...>`, which
+    # puts ARFLAGS in exactly the right slot.
+    #
+    # Renaming `lld-link.exe` to `lib.exe` does NOT work: LLD dispatches its
+    # flavor on argv[0] basename and only recognizes
+    # `lld-link`/`ld.lld`/`ld64.lld`/`wasm-ld`/`lld` — `lib` falls through
+    # to the generic-driver error ("lld is a generic driver…").
+    #
+    # TODO: once a rust-toolchain archive built with the updated
+    # tools/cr/toolchain/build_rust_toolchain.py has been deployed (it now
+    # ships `llvm-lib.exe` on Windows alongside `rust-lld`), simplify this
+    # block by replacing the AR line with
+    #   "AR=" + rebase_path("//third_party/rust-toolchain/bin/llvm-lib.exe"),
+    # and dropping the `ARFLAGS=-lib` line plus the four `ARFLAGS_*` empty
+    # clobbers further below.  cc-rs's standard MSVC archiver invocation
+    # works against `llvm-lib.exe` natively (it's a real lib.exe-compatible
+    # tool, not an LLD alias).  Mirrors what upstream
+    # tools/rust/config.toml.template already does for the rust bootstrap.
+    "AR=$_clang_bin/lld-link.exe",
+    "LD=$_clang_bin/lld-link.exe",
+
+    # Real flag values on the generic slot; target-specific and TARGET_*
+    # variants emptied to absorb any siso/ninja leaks without duplicating.
+    #
+    # TODO: drop `ARFLAGS=-lib` and the three `ARFLAGS_*`/`TARGET_ARFLAGS`
+    # clobbers below when AR is switched to point at the bundled
+    # `llvm-lib.exe` (see the TODO on the AR line above).
+    "CFLAGS=$_win_flags",
+    "CXXFLAGS=$_win_cxxflags",
+    "ARFLAGS=-lib",
+    "CFLAGS_x86_64-pc-windows-msvc=",
+    "CFLAGS_x86_64_pc_windows_msvc=",
+    "CXXFLAGS_x86_64-pc-windows-msvc=",
+    "CXXFLAGS_x86_64_pc_windows_msvc=",
+    "ARFLAGS_x86_64-pc-windows-msvc=",
+    "ARFLAGS_x86_64_pc_windows_msvc=",
+    "TARGET_CFLAGS=",
+    "TARGET_CXXFLAGS=",
+    "TARGET_ARFLAGS=",
+
+    # MSVC-style env vars read by clang-cl itself.
+    "CL=",
+    "_CL_=",
+  ]
+} else {
+  cargo_hermetic_env = [
+    "CC=$_clang_bin/clang",
+    "CXX=$_clang_bin/clang++",
+    "AR=$_clang_bin/llvm-ar",
+    "LD=$_clang_bin/clang",
+  ]
+}
+
+# For non-cross-compile cargo invocations (build_crate.gni — HOST == TARGET),
+# `CARGO_TARGET_<HOST>_LINKER` and `CARGO_TARGET_<HOST>_RUSTFLAGS` env vars
+# work — cargo applies them to everything it builds.
+cargo_hermetic_env +=
+    [ "CARGO_TARGET_${_host_triple_env}_LINKER=$_host_linker" ]
+if (_host_link_args != []) {
+  cargo_hermetic_env += [ "CARGO_TARGET_${_host_triple_env}_RUSTFLAGS=" +
+                          string_join(" ", _host_link_args) ]
+}
+
+# For cross-compile invocations (rust_to_wasm.gni — TARGET=wasm32-unknown-unknown
+# but build scripts and proc-macros still build for HOST), the env-var and
+# `[target.<host>]` routes don't reach host-side *rustflags*.  cargo's
+# rustflags lookup is keyed on the cargo invocation's `--target` argument
+# (wasm32), not on each artifact's compilation target — so during cross-
+# compile, `[target.<host>].rustflags` is never consulted for host build
+# scripts.  (The `linker` lookup *is* per-artifact-compilation-target, which
+# is why our CARGO_TARGET_<HOST>_LINKER env var does reach host scripts.)
+#
+# The only knob cargo has for "rustflags applied specifically to host
+# artifacts in cross-compile" is the `[host]` table, gated behind
+# `-Z host-config`.  Our rust-toolchain is built from
+# `channel = "nightly"` (see tools/rust/config.toml.template), so `-Z` flags
+# are accepted.  rust_to_wasm.gni splices these into the cargo arg list
+# after `--`.
+cargo_host_config_args = [
+  # `-Z host-config` requires `-Z target-applies-to-host` to also be set —
+  # cargo rejects host-config-without-target-applies-to-host as an error.
+  "-Z",
+  "host-config",
+  "-Z",
+  "target-applies-to-host",
+  "--config",
+  "host.linker=\"$_host_linker\"",
+]
+if (_host_link_args != []) {
+  _host_rustflags_quoted = []
+  foreach(_flag, _host_link_args) {
+    _host_rustflags_quoted += [ "\"$_flag\"" ]
+  }
+  cargo_host_config_args += [
+    "--config",
+    "host.rustflags=[" + string_join(",", _host_rustflags_quoted) + "]",
+  ]
+}
+
+if (_have_mac_sdk) {
+  # The Chromium-bundled clang lives outside any Xcode layout, so it can't
+  # auto-detect an SDK — true under *both* `use_system_xcode = true` (which
+  # is what external builders and the iOS bots use) and the depot_tools
+  # hermetic Xcode mode (Brave-internal CI).  Point both rustc and `cc-rs`
+  # build scripts at whichever SDK //build/config/mac/mac_sdk.gni resolved
+  # to.  Without `-isysroot`, the ring/wasm-opt-sys cc-rs build scripts
+  # fail to find `<TargetConditionals.h>` and other Apple SDK headers.
+  # SDKROOT also satisfies `xcrun` fallbacks inside dependent crates'
+  # build scripts.
+  _sdk = rebase_path(mac_sdk_path)
+  cargo_hermetic_env += [
+    "SDKROOT=$_sdk",
+    "CFLAGS=-isysroot $_sdk",
+    "CXXFLAGS=-isysroot $_sdk",
+    "LDFLAGS=-isysroot $_sdk",
+  ]
+}
+
+if (_linux_host_sysroot != "") {
+  # Same shape as XPy.__init__ on linux: inject --sysroot into the C/C++/link
+  # flag set so build-script-compiled native code links against the pinned
+  # Debian sysroot rather than the host glibc, and steer pkg-config at the
+  # sysroot's libs.
+  _sys = rebase_path(_linux_host_sysroot)
+  cargo_hermetic_env += [
+    "CFLAGS=--sysroot=$_sys",
+    "CXXFLAGS=--sysroot=$_sys",
+    "LDFLAGS=--sysroot=$_sys",
+    "PKG_CONFIG_SYSROOT_DIR=$_sys",
+    "PKG_CONFIG_LIBDIR=$_sys/usr/lib/pkgconfig",
+  ]
+}


### PR DESCRIPTION
This change introduces //brave/tools/crates/cargo_env.gni, a single GN
file that owns "the hermetic cargo environment" for Brave's two
cargo-driven build paths:

  * //brave/tools/crates/build_crate.gni — builds host CLI tools
    (wasm-bindgen, wasm-opt, wasm-pack, cargo-audit) by invoking
    `cargo build` directly.  HOST == TARGET.
  * //brave/components/common/rust_to_wasm.gni — wraps `wasm-pack
    build` to compile Brave's in-tree WASM rust crates.  Cross-compile,
    HOST != wasm32-unknown-unknown.

Both go through brave/build/gn_run_rsp.py, which augments (not
replaces) the parent siso/ninja env before exec'ing cargo.

== Why this is needed ==

Previously cargo invocations inherited whatever C/C++ toolchain
siso/ninja happened to have on PATH, plus Chromium's GN-driven CFLAGS
on Windows (which set `-Wunsafe-buffer-usage` and loaded the
unsafe-buffers clang plugin).  This caused a series of failures
depending on the build host:

  * macOS: clang fell through to /usr/bin/cc -> xcrun, which then
    couldn't find a compiler under the hermetic Xcode bundle and asked
    to install the command-line developer tools (the original
    user-reported bug).
  * Linux: rustc invoked system gcc as the linker, which used a
    different glibc than the GLIBC_PRIVATE symbols in the Debian
    bullseye sysroot's libpthread.so / libdl.so / librt.so linker
    scripts, producing "undefined reference: __libc_dlopen_mode
    @GLIBC_PRIVATE" et al.
  * Windows: clang-cl picked up Chromium's `-Wunsafe-buffer-usage` and
    plugin args from the inherited CFLAGS, applying them to vendored
    third-party C in tools/crates/vendor/ring (which has its own
    warning policy and is explicitly exempted from Chromium's check via
    //build/config/unsafe_buffers_paths.txt — except that exemption
    only applies to the GN-driven C++ build, not cc-rs subprocess
    invocations).
  * iOS: rust_to_wasm.gni was re-imported into the
    ios_clang_x64_app_ext toolchain via the typescript.gni ->
    rust_to_wasm.gni chain in brave_sync/BUILD.gn:buildflags, and
    mac_sdk.gni's `assert(current_os == "mac" || current_toolchain ==
    default_toolchain || target_os == "android")` rejected the import.
  * iOS host-side build scripts during the WASM cross-compile (Mac
    arm64 host -> wasm32): rustc invoked clang without -fuse-ld=lld,
    clang then tried to find `ld` via xcrun, xcrun failed (some iOS
    CI agents have an incomplete xcode-select setup).

The duplication of fix logic was also a maintenance hazard — every
incarnation of "I'm shelling out to cargo from GN" had to independently
remember every platform subtlety.

== High-level architecture ==

cargo_env.gni exposes three lists for callers to splice into their
response files:

  (1) cargo_hermetic_env — list of "KEY=VALUE" env-var strings.
      Pins CC/CXX/AR/LD to Chromium's bundled clang, sets
      CFLAGS/CXXFLAGS/LDFLAGS for SDK/sysroot, neutralizes siso's
      Windows CFLAGS leaks, and configures cargo's per-target linker
      via CARGO_TARGET_<HOST>_LINKER.  Used by *both* build_crate.gni
      and rust_to_wasm.gni.

  (2) cargo_host_config_args — list of cargo CLI args, specifically
      `-Z host-config -Z target-applies-to-host --config
      'host.linker=...' --config 'host.rustflags=[...]'`.  Used *only*
      by rust_to_wasm.gni to pin host-artifact linker/rustflags during
      cross-compile (see "Cross-compile rustflags gotcha" below).
      build_crate.gni doesn't need this since its host == target.

  (3) (Implicitly exposed) _host_triple_env and _host_triple_canon —
      private but conceptually part of the interface; computed from
      host_os/host_cpu, used in both env vars and inline --config
      values.

== Per-platform details ==

Linux:
  * CC=$clang_base_path/bin/clang, CXX=clang++, AR=llvm-ar, LD=clang.
  * Pins host Debian sysroot at //build/linux/debian_bullseye_<arch>
    -sysroot via:
      - CFLAGS=--sysroot=$sys (for cc-rs build-script C compiles).
      - rustflags -Clink-arg=--sysroot=$sys (for rustc's link step).
      - PKG_CONFIG_SYSROOT_DIR + PKG_CONFIG_LIBDIR for build scripts
        that probe via pkg-config.
  * CRITICAL: the sysroot path is hardcoded based on `host_cpu`, NOT
    read from //build/config/sysroot.gni's `sysroot` var.  Reason:
    sysroot.gni's resolution is target-keyed (current_os/current_cpu),
    so during an Android-on-Linux build it resolves to the Android NDK
    sysroot, not the Debian host sysroot.  Hardcoding makes the
    host-side lookup independent of target-side toolchain context.
  * Guarded by path_exists() in case the install-sysroot.py gclient
    hook didn't run.

Mac:
  * Same compiler pinning as Linux.
  * SDKROOT=$mac_sdk_path, plus -isysroot $sdk in CFLAGS/CXXFLAGS/
    LDFLAGS.
  * mac_sdk_path resolution handles both the depot_tools hermetic
    Xcode mode (Brave-internal CI) and `use_system_xcode = true`
    (external builders + iOS CI).  Importantly, the SDK env block now
    runs in BOTH modes — the prior `!use_system_xcode` gate was wrong
    because Chromium's bundled clang doesn't auto-discover an SDK
    regardless of which Xcode lives where.
  * mac_sdk.gni import gated on the same condition mac_sdk.gni itself
    asserts (current_os == "mac" || current_toolchain ==
    default_toolchain || target_os == "android") to survive re-imports
    from iOS non-default toolchains via the typescript.gni chain.

Windows:
  * CC/CXX=clang-cl.exe, AR=lld-link.exe (see below), LD=lld-link.exe.
  * CFLAGS/CXXFLAGS clobbered with "--no-default-config -w" (plus
    "/EHsc" for CXX — wasm-opt-sys/Binaryen uses `throw` and clang-cl
    follows MSVC's exceptions-off default).  This neutralizes siso's
    -Wunsafe-buffer-usage / unsafe-buffers plugin leak.
  * ARFLAGS=-lib WORKAROUND: Chromium's distributed clang package
    strips both llvm-ar.exe and llvm-lib.exe on Windows (see
    tools/clang/scripts/package.py:279-284).  cc-rs's MSVC archiver
    pattern is `<AR> <ARFLAGS...> -out:<dst> <objs...>` (see
    tools/crates/vendor/cc/src/lib.rs:2712-2723 and :3287-3290), so
    we point AR at the shipped lld-link.exe and inject `-lib` via
    ARFLAGS to put lld-link into MSVC librarian mode.
    Renaming lld-link.exe to lib.exe does NOT work: LLD dispatches its
    flavor on argv[0] basename and only recognizes lld-link / ld.lld /
    ld64.lld / wasm-ld / lld — `lib` falls through to the
    generic-driver error ("lld is a generic driver…").
  * THIS CHANGE also updates tools/cr/toolchain/build_rust_toolchain.py
    to pack llvm-lib.exe (the proper standalone librarian) into the
    rust-toolchain archive on Windows.  Once a fresh archive is rolled
    out, the cargo_env.gni Windows block can be simplified by pointing
    AR straight at //third_party/rust-toolchain/bin/llvm-lib.exe and
    dropping the ARFLAGS gymnastics — search for the two "TODO" blocks
    in cargo_env.gni's Windows section that spell out the simplification.
  * CL= and _CL_= cleared so any MSVC-style env-var pre-/post-flags
    from siso don't sneak into clang-cl.
  * CFLAGS/CXXFLAGS/ARFLAGS variants: see "envflags concatenation
    gotcha" below.

== Cross-compile rustflags gotcha (the iOS/wasm32 puzzle) ==

cargo distinguishes between rustflags applied to *target* artifacts
(the wasm32 module) and *host* artifacts (build scripts, proc-macros)
during a cross-compile.  Counterintuitively:

  * `linker` lookup is per-artifact-compilation-target: cargo reads
    [target.<artifact-triple>].linker for whatever rustc invocation
    it's about to make.  So CARGO_TARGET_<HOST>_LINKER reaches host
    build scripts during cross-compile.

  * `rustflags` lookup is per-cargo-invocation-target (--target value):
    cargo only reads [target.<cargo-build-target>].rustflags.  During
    `cargo build --target wasm32-unknown-unknown`, only
    [target.wasm32].rustflags is consulted — [target.<host>].rustflags
    is NEVER read, by env or by --config.

This explains why on iOS we saw clang as the linker (CARGO_TARGET_
<HOST>_LINKER honored) but no -fuse-ld=lld flag (CARGO_TARGET_<HOST>_
RUSTFLAGS not honored, even as inline --config).

The only knob cargo has for "rustflags keyed on is-this-a-host-
artifact" is the [host] table.  It's gated behind `-Z host-config`,
which in turn requires `-Z target-applies-to-host`.  Both are
unstable cargo features, but Brave's rust toolchain is built from
`channel = "nightly"` (per tools/rust/config.toml.template), so the -Z
flags are accepted.

cargo_host_config_args therefore emits:

    -Z host-config
    -Z target-applies-to-host
    --config 'host.linker="<chromium-clang>"'
    --config 'host.rustflags=["-Clink-arg=-fuse-ld=lld", ...]'

rust_to_wasm.gni splices this between its existing wasm32 linker pin
and its --target-dir arg.  build_crate.gni doesn't need it (host ==
target there, so CARGO_TARGET_<HOST>_* env vars suffice).

== envflags concatenation gotcha (the Windows triplication) ==

tools/crates/vendor/cc/src/lib.rs:3915-3935's `envflags` function does
NOT implement "first match wins" across CFLAGS / CFLAGS_<target> /
TARGET_CFLAGS variants.  Per the comment at line 3916 ("Collect from
all environment variables..."), it concatenates *every* set variant,
walking the precedence chain in reverse so the most-specific variant
ends up last on the command line.

When we initially set CFLAGS and CFLAGS_x86_64-pc-windows-msvc and
TARGET_CFLAGS all to the same value to be defensive, our
`--no-default-config -w` got added 3-4x to every C compile.

Current shape: actual flag values live on the generic CFLAGS /
CXXFLAGS / ARFLAGS slot; target-specific and TARGET_* variants are set
to empty strings.  cc-rs treats empty strings as "set but contributes
no tokens", so they neutralize any siso/ninja leak without duplicating
our content.

== Outstanding TODOs (search for "TODO:" in cargo_env.gni) ==

  1. Switch Windows AR to point at //third_party/rust-toolchain/bin/
     llvm-lib.exe once a fresh rust-toolchain archive (built with this
     CL's build_rust_toolchain.py changes) is deployed.  Drops
     `ARFLAGS=-lib` plus its 3 empty-variant clobbers.

  2. INCLUDE/LIB on Windows are *not* set by cargo_env.gni — we
     inherit whatever the parent siso/ninja env had.  On Brave-internal
     CI that's the depot_tools hermetic Win toolchain bundle env; on
     external builders it's a system Visual Studio install.  If a
     future build error references missing <windows.h> or system libs,
     this is where to look (probably needs to import //build/toolchain
     /win/win_toolchain_data.gni and key off the appropriate
     hermetic-vs-system mode, in a way that works for both
     Brave-internal and external builders).

== Future direction (not in this CL) ==

The same architecture should serve //third_party/boringtun/, which
today duplicates a fair amount of "wire up cargo to Chromium's
toolchain" logic and risks drifting out of sync on the same
SDK-availability subtleties.  The migration shape would be:

  * Rename `cargo_hermetic_env` -> `cargo_host_env`, and
    `cargo_host_config_args` -> the same name (already correct).
  * Add parallel `cargo_target_env` / `cargo_target_config_args` for
    builds that compile FOR the GN target rather than the GN host
    (boringtun's case).  Same shape, but reads current_os/current_cpu
    and target-keyed sysroot from //build/config/sysroot.gni.
  * Migrate //third_party/boringtun/ to consume the target variants
    and delete its independent toolchain plumbing.

The main risk in that future work is widening the toolchain-context
safety gates — cargo_env.gni is currently only *consumed* in
host_toolchain (with rust_to_wasm.gni doing dep handoff to host via
($host_toolchain)), but boringtun would consume it from arbitrary
target toolchains.  Every conditional import / declare_args dependency
would need re-checking against that broader call surface.

== Build profile (not changed by this CL, but worth knowing) ==

Both cargo invocations are hardcoded to `cargo_profile = "release"`
(build_crate.gni:22) and wasm-pack's default profile (release).  GN's
is_debug is NOT consulted.  This is intentional: the host CLI tools
don't need debug variants, and wasm-pack's debug mode produces output
that doesn't help typical Rust-source debugging (which needs wasm
source maps wired up separately).  If contributors need to debug a
WASM crate, the lever is wasm-pack's `--dev` flag passed per-crate,
not a global is_debug flip.

== Files touched ==

  * tools/crates/cargo_env.gni — new; the consolidated hermetic env.
  * tools/crates/build_crate.gni — imports cargo_env.gni; splices
    cargo_hermetic_env into its response file.
  * components/common/rust_to_wasm.gni — imports cargo_env.gni;
    splices cargo_hermetic_env, adds the wasm32 linker --config pin,
    splices cargo_host_config_args for host-side rustflags during
    cross-compile.
  * tools/cr/toolchain/build_rust_toolchain.py — packs llvm-lib.exe
    into the rust-toolchain archive on Windows (preparing for the
    cargo_env.gni AR-simplification TODO).  No-op on Linux/Mac.