### PR TITLE
[Sidebar V2] Fixed top separator is hidden when panel opens

### DIFF
--- a/browser/ui/sidebar/sidebar_browsertest.cc
+++ b/browser/ui/sidebar/sidebar_browsertest.cc
@@ -2234,6 +2234,32 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest,
       << "No-border resize area width should equal kNoBorderResizeAreaWidth";
 }
 
+// Regression test: the top container separator must remain visible when a side
+// panel opens. Upstream suppresses it (suppress_top_separator=true) when the
+// side panel is shown and GetTopSeparatorType() returns kTopContainer.
+// BraveBrowserViewTabbedLayoutImpl::CalculateTopContainerLayoutImpl resets the
+// flag to false for that case so the separator stays shown.
+// Rounded corners must be disabled: GetTopSeparatorType() only returns
+// kTopContainer (instead of kNone) when rounded corners are off.
+IN_PROC_BROWSER_TEST_F(SidebarBrowserTest,
+                       TopContainerSeparatorVisibleWhenPanelOpens) {
+  browser()->profile()->GetPrefs()->SetBoolean(kWebViewRoundedCorners, false);
+  RunScheduledLayouts();
+
+  auto* brave_view =
+      BraveBrowserView::From(BrowserView::GetBrowserViewForBrowser(browser()));
+  auto* separator = brave_view->top_container_separator_for_testing();
+  ASSERT_TRUE(separator);
+  EXPECT_TRUE(separator->GetVisible());
+
+  auto* panel_ui = browser()->GetFeatures().side_panel_ui();
+  panel_ui->Show(SidePanelEntryId::kBookmarks);
+  ASSERT_TRUE(
+      base::test::RunUntil([&]() { return panel_ui->IsSidePanelShowing(); }));
+
+  EXPECT_TRUE(separator->GetVisible());
+}
+
 class ScopedSidePanelUIForTesting {
  public:
   ScopedSidePanelUIForTesting(SidebarController* controller, SidePanelUI* ui)

--- a/browser/ui/views/frame/brave_browser_view.h
+++ b/browser/ui/views/frame/brave_browser_view.h
@@ -173,6 +173,10 @@ class BraveBrowserView : public BrowserView,
     return tab_strip_placement_.get();
   }
 
+  views::View* top_container_separator_for_testing() const {
+    return top_container_separator_;
+  }
+
 #if BUILDFLAG(ENABLE_EXTENSIONS)
   // Returns the PWA Shields toolbar button, if it exists. Note that this
   // returns valid pointer only when it's web app browser.
@@ -272,9 +276,6 @@ class BraveBrowserView : public BrowserView,
 #endif
 
   void UpdateSideBarHorizontalAlignment();
-  views::View* top_container_separator_for_testing() const {
-    return top_container_separator_;
-  }
 
   std::unique_ptr<TabStripPlacementCoordinator> tab_strip_placement_;
   std::unique_ptr<views::Widget> vertical_tab_strip_widget_;

--- a/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl.cc
+++ b/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl.cc
@@ -232,6 +232,15 @@ gfx::Rect BraveBrowserViewTabbedLayoutImpl::CalculateTopContainerLayoutImpl(
     BrowserLayoutParams params,
     bool needs_exclusion,
     bool suppress_top_separator) const {
+  // Upstream suppresses the top separator when the side panel is shown and
+  // GetTopSeparatorType() == kTopContainer. Brave always wants the separator
+  // visible in that case, so undo only that specific suppression.
+  // See suppress_top_separator var in
+  // BrowserViewTabbedLayoutImpl::CalculateProposedLayout().
+  if (GetTopSeparatorType() == TopSeparatorType::kTopContainer) {
+    suppress_top_separator = false;
+  }
+
   // Get base layout from parent
   gfx::Rect bounds =
       BrowserViewTabbedLayoutImpl::CalculateTopContainerLayoutImpl(


### PR DESCRIPTION
When a side panel opens(in Sidebar V2), the top separator was hidden. It's upstream's behavior.
In current sidebar, this doesn't happen because panel is wrapped inside the SidebarContainerView.
So, upstream think panel is not shown always.

Upstream sets `true` to `suppress_top_separator` when the side panel is shown.
We don't need to suppress top separator when we want to show it.
Fixed by reset `suppress_top_separator`.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves no issue - use umbrella issue (https://github.com/brave/brave-browser/issues/51462)

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
