### PR TITLE
Hide Leo AI keyboard shortcuts in Brave Origin branded builds

### DIFF
--- a/browser/ui/commands/accelerator_service.cc
+++ b/browser/ui/commands/accelerator_service.cc
@@ -453,10 +453,12 @@ bool AcceleratorService::IsCommandDisabledByPolicy(int command_id) const {
     case IDC_SHOW_BRAVE_REWARDS:
     case IDC_OFFERS_AND_REWARDS_FOR_PAGE:
       return pref_service_->GetBoolean(brave_rewards::prefs::kDisabledByPolicy);
-#if BUILDFLAG(ENABLE_AI_CHAT)
     case IDC_TOGGLE_AI_CHAT:
     case IDC_OPEN_FULL_PAGE_CHAT:
+#if BUILDFLAG(ENABLE_AI_CHAT)
       return !pref_service_->GetBoolean(ai_chat::prefs::kEnabledByPolicy);
+#else
+      return true;  // AI Chat not compiled in, always disabled
 #endif
     case IDC_NEW_OFFTHERECORD_WINDOW_TOR:
     case IDC_NEW_TOR_CONNECTION_FOR_SITE:


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/55596

In Brave Origin branded builds `enable_ai_chat` is false, so the AI Chat policy check in `AcceleratorService::IsCommandDisabledByPolicy` was compiled out and the Toggle Leo AI / Open AI Chat shortcuts fell through to the default "not disabled" branch. Mirror the pattern used by other features (News, Talk, VPN, Wallet) and return `true` when the feature is not compiled in.