### PR TITLE
[iOS] Fix missing script injection in AI Chat Associated Content for history & bookmarks

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/DetachedTabPrivacyHelper.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/DetachedTabPrivacyHelper.swift
@@ -74,12 +74,86 @@ class DetachedTabPrivacyHelper: TabPolicyDecider {
     shouldAllowRequest request: URLRequest,
     requestInfo: WebRequestInfo
   ) async -> WebPolicyDecision {
-    if let mainDocumentURL = request.mainDocumentURL {
-      let pageData = PageData(mainFrameURL: mainDocumentURL)
-      if mainDocumentURL != tab.currentPageData?.mainFrameURL {
-        tab.currentPageData = pageData
-      }
+    guard let mainDocumentURL = request.mainDocumentURL else { return .allow }
 
+    let pageData = PageData(mainFrameURL: mainDocumentURL)
+    if mainDocumentURL != tab.currentPageData?.mainFrameURL {
+      tab.currentPageData = pageData
+    }
+
+    let isAdBlockEnabled =
+      tab.braveShieldsHelper?.shieldLevel(
+        for: mainDocumentURL,
+        considerAllShieldsOption: true
+      ).isEnabled ?? true
+    let isBlockFingerprintingEnabled =
+      tab.braveShieldsHelper?.isShieldExpected(
+        for: mainDocumentURL,
+        shield: .fpProtection,
+        considerAllShieldsOption: true
+      ) ?? true
+
+    if requestInfo.isMainFrame {
+      tab.browserData?.setScripts(scripts: [
+        // Add de-amp script
+        // The user script manager will take care to not reload scripts if this value doesn't change
+        .deAmp: deAmpPrefs.isDeAmpEnabled,
+
+        // Add request blocking script
+        // This script will block certian `xhr` and `window.fetch()` requests
+        .requestBlocking: mainDocumentURL.isWebPage(includeDataURIs: false)
+          && isAdBlockEnabled,
+
+        // The tracker protection script
+        // This script will track what is blocked and increase stats
+        .trackerProtectionStats: mainDocumentURL.isWebPage(includeDataURIs: false)
+          && isAdBlockEnabled,
+      ])
+    }
+
+    let scriptTypes =
+      await tab.currentPageData?.makeUserScriptTypes(
+        isDeAmpEnabled: deAmpPrefs.isDeAmpEnabled,
+        isAdBlockEnabled: isAdBlockEnabled,
+        isBlockFingerprintingEnabled: isBlockFingerprintingEnabled,
+        isGPCEnabled: tab.profile.prefs.boolean(forPath: kGlobalPrivacyControlEnabled)
+      ) ?? []
+    tab.browserData?.setCustomUserScript(scripts: scriptTypes)
+
+    if !requestInfo.isNewWindow, let requestURL = request.url {
+      // Check if custom user scripts must be added to or removed from the web view.
+      tab.currentPageData?.addSubframeURL(
+        forRequestURL: requestURL,
+        isForMainFrame: requestInfo.isMainFrame
+      )
+      let scriptTypes =
+        await tab.currentPageData?.makeUserScriptTypes(
+          isDeAmpEnabled: deAmpPrefs.isDeAmpEnabled,
+          isAdBlockEnabled: isAdBlockEnabled,
+          isBlockFingerprintingEnabled: isBlockFingerprintingEnabled,
+          isGPCEnabled: tab.profile.prefs.boolean(
+            forPath: kGlobalPrivacyControlEnabled
+          )
+        ) ?? []
+      tab.browserData?.setCustomUserScript(scripts: scriptTypes)
+    }
+
+    return .allow
+  }
+
+  func tab(
+    _ tab: some TabState,
+    shouldAllowResponse response: URLResponse,
+    responseInfo: WebResponseInfo
+  ) async -> WebPolicyDecision {
+    // Check if we upgraded to https and if so we need to update the url of frame evaluations
+    if let responseURL = response.url,
+      let pageData = tab.currentPageData,
+      tab.currentPageData?.upgradeFrameURL(
+        forResponseURL: responseURL,
+        isForMainFrame: responseInfo.isForMainFrame
+      ) == true
+    {
       let scriptTypes =
         await tab.currentPageData?.makeUserScriptTypes(
           isDeAmpEnabled: deAmpPrefs.isDeAmpEnabled,
@@ -92,7 +166,9 @@ class DetachedTabPrivacyHelper: TabPolicyDecider {
             shield: .fpProtection,
             considerAllShieldsOption: true
           ) ?? true,
-          isGPCEnabled: tab.profile.prefs.boolean(forPath: kGlobalPrivacyControlEnabled)
+          isGPCEnabled: tab.profile.prefs.boolean(
+            forPath: kGlobalPrivacyControlEnabled
+          )
         ) ?? []
       tab.browserData?.setCustomUserScript(scripts: scriptTypes)
     }


### PR DESCRIPTION
- Scriptlets were not being injected because we were not adding sub-frames to `PageData` so the scriptlets were not being generated
    - A [follow-up brave-browser#55801](https://github.com/brave/brave-browser/issues/55801) was created to update `PageData` to contain the logic. This is being done as a follow up so that this fix can be uplifted and only affect the AI Chat associated context; the follow up would affect all tabs / web views so the changes can be tested further before release.
- Request blocking and tracking stats scripts were not being injected, though content blocker may still prevent some loads.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/55800

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

### Testplan

1. Add these to custom rules in Settings > Shields & Privacy > Content Blocking
```
stephenheaps.github.io/$first-party
kylehickinson.com##+js(rpnt, H1, /Kyle Hickinson/, Scriptlet Injected)
```
2. Visit https://stephenheaps.github.io/ai-chat/test.html
3. Close the tab
4. Open Leo AI Chat WebUI
5. Tap the attachment button, then tap history and select `https://stephenheaps.github.io/ai-chat/test.html`.
6. Ask Leo AI to summarize this page (result doesn't matter, but this triggers the webview to load).
7. Open Safari Web Inspector on macOS, you should see the hidden web view for `https://stephenheaps.github.io/ai-chat/test.html`:
<img width="608" height="276" alt="Image" src="https://github.com/user-attachments/assets/d4663e98-a118-408b-9e18-34c9d72b8b44" />

8. Scriptlets in iframes are working as it now shows `Scriptlet Injected` in `body > section > h1`::
<img width="1131" height="757" alt="Image" src="https://github.com/user-attachments/assets/c66b1f28-e698-4645-a6e8-7a63373057a0" />

9. Switch to console tab in Safari Web Inspector, then tap reload button.
10. Verify request blocking blocks the request to `./request-blocking.txt` as it shows `Brave prevented frame displaying <...> from loading a resource from <...>/request-blocking.txt`: 

<img width="1131" height="757" alt="Image" src="https://github.com/user-attachments/assets/669d7237-9810-4cba-8072-5e6a74ae89c6" />