### PR TITLE
Fix search query concatenation with + symbols instead of spaces

### DIFF
--- a/android/java/org/chromium/chrome/browser/BraveIntentHandler.java
+++ b/android/java/org/chromium/chrome/browser/BraveIntentHandler.java
@@ -86,15 +86,67 @@ public class BraveIntentHandler {
             return url;
         }
 
-        final Uri.Builder builder = parsedUrl.buildUpon().clearQuery();
-        for (String name : parsedUrl.getQueryParameterNames()) {
-            for (String value : parsedUrl.getQueryParameters(name)) {
-                builder.appendQueryParameter(
-                        name,
-                        SOURCE.equals(name) && ANDROID.equals(value) ? ANDROID_WIDGET : value);
+        // Rewrite only the `source` parameter on the raw encoded query, so
+        // every other parameter's bytes pass through completely untouched.
+        //
+        // We can't safely decode and re-encode the query through
+        // Uri.getQueryParameters() / appendQueryParameter(), because the two
+        // sides use different encodings:
+        //
+        //   - Search URLs use application/x-www-form-urlencoded, where ' '
+        //     is encoded as '+' and a literal '+' as '%2B'.
+        //   - Android's Uri follows RFC 3986, where ' ' is '%20' and '+' is
+        //     a literal.
+        //
+        // getQueryParameters() percent-decodes '%2B' to '+' but leaves a
+        // form-encoded '+' (meaning space) alone. After that step, a
+        // literal '+' and an encoded space are indistinguishable, so any
+        // attempt to re-encode the value corrupts the query.
+        //
+        // For example, a widget search for "C++ tutorial" arrives as
+        // "q=C%2B%2B+tutorial". getQueryParameters() would return "C+++tutorial"
+        // (three '+' chars, origin unknown). If those were then re-encoded
+        // and the '+' chars converted back to spaces, the server would
+        // receive "C   tutorial"; if they were left as '+', the server
+        // would receive a literal "C+++tutorial". Either way the query is
+        // broken.
+        final String encodedQuery = parsedUrl.getEncodedQuery();
+        if (encodedQuery == null) {
+            return url;
+        }
+
+        final StringBuilder newQuery = new StringBuilder(encodedQuery.length());
+        // Walk each name=value pair in encoded form. We intentionally do not
+        // use Uri.getQueryParameters() here. See the comment above for why
+        // decoding and re-encoding through it is lossy.
+        for (String pair : encodedQuery.split("&")) {
+            // Restore the '&' separator between pairs (skipped before the
+            // first pair).
+            //noinspection SizeReplaceableByIsEmpty
+            if (newQuery.length() > 0) {
+                newQuery.append('&');
+            }
+            // Locate the name/value split.
+            final int eq = pair.indexOf('=');
+            // Decode only for the comparison, the original encoded bytes are
+            // what we actually write back out below.
+            if (eq >= 0
+                    && SOURCE.equals(Uri.decode(pair.substring(0, eq)))
+                    && ANDROID.equals(Uri.decode(pair.substring(eq + 1)))) {
+                // Keep the original "source=" prefix (preserving any
+                // encoding the caller used in the name) and substitute just
+                // the value. Uri.encode() percent-encodes ANDROID_WIDGET
+                // safely, though "android-widget" has no chars that need it.
+                newQuery.append(pair, 0, eq + 1).append(Uri.encode(ANDROID_WIDGET));
+            } else {
+                // Any other parameter including the search query `q`
+                // passes through untouched, byte-for-byte.
+                newQuery.append(pair);
             }
         }
-        return builder.build().toString();
+        // encodedQuery() tells Uri.Builder our string is
+        // already encoded and must not be re-encoded.
+        return parsedUrl.buildUpon().encodedQuery(newQuery.toString()).build().toString();
     }
 
     @Nullable

--- a/android/junit/src/org/chromium/chrome/browser/BraveIntentHandlerUnitTest.java
+++ b/android/junit/src/org/chromium/chrome/browser/BraveIntentHandlerUnitTest.java
@@ -96,37 +96,32 @@ public class BraveIntentHandlerUnitTest {
         String result = BraveIntentHandler.extractUrlFromIntent(intent);
 
         assertEquals(
-                "https://search.brave.com/search?q=C%2B%2B+tutorial&source=android-widget",
-                result);
+                "https://search.brave.com/search?q=C%2B%2B+tutorial&source=android-widget", result);
     }
 
     @Test
     @SmallTest
     public void extractUrlFromIntent_widgetSearch_preservesFormEncodedSpaceInQuery() {
         Intent intent = new Intent(Intent.ACTION_VIEW);
-        intent.setData(
-                Uri.parse("https://search.brave.com/search?q=hello+world&source=android"));
+        intent.setData(Uri.parse("https://search.brave.com/search?q=hello+world&source=android"));
         intent.putExtra(SearchWidgetProvider.EXTRA_FROM_SEARCH_WIDGET, true);
 
         String result = BraveIntentHandler.extractUrlFromIntent(intent);
 
-        assertEquals(
-                "https://search.brave.com/search?q=hello+world&source=android-widget", result);
+        assertEquals("https://search.brave.com/search?q=hello+world&source=android-widget", result);
     }
 
     @Test
     @SmallTest
     public void extractUrlFromIntent_widgetSearch_preservesPercentEncodedSpaceInQuery() {
         Intent intent = new Intent(Intent.ACTION_VIEW);
-        intent.setData(
-                Uri.parse("https://search.brave.com/search?q=hello%20world&source=android"));
+        intent.setData(Uri.parse("https://search.brave.com/search?q=hello%20world&source=android"));
         intent.putExtra(SearchWidgetProvider.EXTRA_FROM_SEARCH_WIDGET, true);
 
         String result = BraveIntentHandler.extractUrlFromIntent(intent);
 
         assertEquals(
-                "https://search.brave.com/search?q=hello%20world&source=android-widget",
-                result);
+                "https://search.brave.com/search?q=hello%20world&source=android-widget", result);
     }
 
     @Test
@@ -209,15 +204,12 @@ public class BraveIntentHandlerUnitTest {
         // sender as %26 and %3D. They must survive untouched, otherwise the
         // server would re-split the query and misinterpret it.
         Intent intent = new Intent(Intent.ACTION_VIEW);
-        intent.setData(
-                Uri.parse(
-                        "https://search.brave.com/search?q=a%26b%3Dc&source=android"));
+        intent.setData(Uri.parse("https://search.brave.com/search?q=a%26b%3Dc&source=android"));
         intent.putExtra(SearchWidgetProvider.EXTRA_FROM_SEARCH_WIDGET, true);
 
         String result = BraveIntentHandler.extractUrlFromIntent(intent);
 
-        assertEquals(
-                "https://search.brave.com/search?q=a%26b%3Dc&source=android-widget", result);
+        assertEquals("https://search.brave.com/search?q=a%26b%3Dc&source=android-widget", result);
     }
 
     @Test

--- a/android/junit/src/org/chromium/chrome/browser/BraveIntentHandlerUnitTest.java
+++ b/android/junit/src/org/chromium/chrome/browser/BraveIntentHandlerUnitTest.java
@@ -82,6 +82,146 @@ public class BraveIntentHandlerUnitTest {
 
     @Test
     @SmallTest
+    public void extractUrlFromIntent_widgetSearch_preservesLiteralPlusInQuery() {
+        // Regression: a search for "C++ tutorial" arrives as
+        // "q=C%2B%2B+tutorial". Going through Uri.getQueryParameters() /
+        // appendQueryParameter() conflates the literal '+' (%2B) with the
+        // form-encoded space ('+'), corrupting the query. The encoded query
+        // bytes must pass through unchanged.
+        Intent intent = new Intent(Intent.ACTION_VIEW);
+        intent.setData(
+                Uri.parse("https://search.brave.com/search?q=C%2B%2B+tutorial&source=android"));
+        intent.putExtra(SearchWidgetProvider.EXTRA_FROM_SEARCH_WIDGET, true);
+
+        String result = BraveIntentHandler.extractUrlFromIntent(intent);
+
+        assertEquals(
+                "https://search.brave.com/search?q=C%2B%2B+tutorial&source=android-widget",
+                result);
+    }
+
+    @Test
+    @SmallTest
+    public void extractUrlFromIntent_widgetSearch_preservesFormEncodedSpaceInQuery() {
+        Intent intent = new Intent(Intent.ACTION_VIEW);
+        intent.setData(
+                Uri.parse("https://search.brave.com/search?q=hello+world&source=android"));
+        intent.putExtra(SearchWidgetProvider.EXTRA_FROM_SEARCH_WIDGET, true);
+
+        String result = BraveIntentHandler.extractUrlFromIntent(intent);
+
+        assertEquals(
+                "https://search.brave.com/search?q=hello+world&source=android-widget", result);
+    }
+
+    @Test
+    @SmallTest
+    public void extractUrlFromIntent_widgetSearch_preservesPercentEncodedSpaceInQuery() {
+        Intent intent = new Intent(Intent.ACTION_VIEW);
+        intent.setData(
+                Uri.parse("https://search.brave.com/search?q=hello%20world&source=android"));
+        intent.putExtra(SearchWidgetProvider.EXTRA_FROM_SEARCH_WIDGET, true);
+
+        String result = BraveIntentHandler.extractUrlFromIntent(intent);
+
+        assertEquals(
+                "https://search.brave.com/search?q=hello%20world&source=android-widget",
+                result);
+    }
+
+    @Test
+    @SmallTest
+    public void extractUrlFromIntent_widgetSearch_preservesUnicodeInQuery() {
+        // %E6%97%A5%E6%9C%AC%E8%AA%9E is UTF-8 percent-encoded "日本語".
+        Intent intent = new Intent(Intent.ACTION_VIEW);
+        intent.setData(
+                Uri.parse(
+                        "https://search.brave.com/search"
+                                + "?q=%E6%97%A5%E6%9C%AC%E8%AA%9E&source=android"));
+        intent.putExtra(SearchWidgetProvider.EXTRA_FROM_SEARCH_WIDGET, true);
+
+        String result = BraveIntentHandler.extractUrlFromIntent(intent);
+
+        assertEquals(
+                "https://search.brave.com/search"
+                        + "?q=%E6%97%A5%E6%9C%AC%E8%AA%9E&source=android-widget",
+                result);
+    }
+
+    @Test
+    @SmallTest
+    public void extractUrlFromIntent_widgetSearch_sourceBeforeQuery_rewritesOnlySource() {
+        Intent intent = new Intent(Intent.ACTION_VIEW);
+        intent.setData(Uri.parse("https://search.brave.com/search?source=android&q=test"));
+        intent.putExtra(SearchWidgetProvider.EXTRA_FROM_SEARCH_WIDGET, true);
+
+        String result = BraveIntentHandler.extractUrlFromIntent(intent);
+
+        assertEquals("https://search.brave.com/search?source=android-widget&q=test", result);
+    }
+
+    @Test
+    @SmallTest
+    public void extractUrlFromIntent_widgetSearch_multipleParams_rewritesOnlySource() {
+        Intent intent = new Intent(Intent.ACTION_VIEW);
+        intent.setData(
+                Uri.parse(
+                        "https://search.brave.com/search"
+                                + "?q=test&source=android&tf=pw&safesearch=moderate"));
+        intent.putExtra(SearchWidgetProvider.EXTRA_FROM_SEARCH_WIDGET, true);
+
+        String result = BraveIntentHandler.extractUrlFromIntent(intent);
+
+        assertEquals(
+                "https://search.brave.com/search"
+                        + "?q=test&source=android-widget&tf=pw&safesearch=moderate",
+                result);
+    }
+
+    @Test
+    @SmallTest
+    public void extractUrlFromIntent_widgetSearch_sourceNotAndroid_isUnchanged() {
+        Intent intent = new Intent(Intent.ACTION_VIEW);
+        intent.setData(Uri.parse("https://search.brave.com/search?q=test&source=web"));
+        intent.putExtra(SearchWidgetProvider.EXTRA_FROM_SEARCH_WIDGET, true);
+
+        String result = BraveIntentHandler.extractUrlFromIntent(intent);
+
+        assertEquals("https://search.brave.com/search?q=test&source=web", result);
+    }
+
+    @Test
+    @SmallTest
+    public void extractUrlFromIntent_widgetSearch_noSourceParam_isUnchanged() {
+        Intent intent = new Intent(Intent.ACTION_VIEW);
+        intent.setData(Uri.parse("https://search.brave.com/search?q=test"));
+        intent.putExtra(SearchWidgetProvider.EXTRA_FROM_SEARCH_WIDGET, true);
+
+        String result = BraveIntentHandler.extractUrlFromIntent(intent);
+
+        assertEquals("https://search.brave.com/search?q=test", result);
+    }
+
+    @Test
+    @SmallTest
+    public void extractUrlFromIntent_widgetSearch_reservedCharsInQuery_passThrough() {
+        // Ampersand and equals inside the q value are percent-encoded by the
+        // sender as %26 and %3D. They must survive untouched, otherwise the
+        // server would re-split the query and misinterpret it.
+        Intent intent = new Intent(Intent.ACTION_VIEW);
+        intent.setData(
+                Uri.parse(
+                        "https://search.brave.com/search?q=a%26b%3Dc&source=android"));
+        intent.putExtra(SearchWidgetProvider.EXTRA_FROM_SEARCH_WIDGET, true);
+
+        String result = BraveIntentHandler.extractUrlFromIntent(intent);
+
+        assertEquals(
+                "https://search.brave.com/search?q=a%26b%3Dc&source=android-widget", result);
+    }
+
+    @Test
+    @SmallTest
     public void intentHasUnsafeInternalScheme_braveScheme_isBlocked() {
         Intent intent = new Intent(Intent.ACTION_VIEW);
         intent.addCategory(Intent.CATEGORY_BROWSABLE);


### PR DESCRIPTION
## Resolves https://github.com/brave/brave-browser/issues/55802

Fix widget initiated Brave searches whose queries contain literal + characters (e.g. C++ tutorial) being corrupted by `maybeReplaceWidgetSearchSource` in `BraveIntentHandler`.

When a search is launched from the Search widget, `maybeReplaceWidgetSearchSource` rewrites the source query parameter from `android` to `android-widget` so the backend can attribute the request correctly. The previous implementation did this by walking every parameter through `Uri.getQueryParameters()` and emitting it again via `Uri.Builder.appendQueryParameter()`.

That decoding and encoding cycle is lossy for search URLs, because the two APIs use different encodings:

Search URLs use `application/x-www-form-urlencoded`, where ` ` is `+` and a literal `+` is `%2B`.
Android's Uri follows RFC 3986, where ` ` is `%20` and `+` is a literal.
`getQueryParameters()` decodes `%2B` to `+` but leaves a form encoded `+` (meaning space) alone. After that step a literal `+` and an encoded space are indistinguishable, and encoding the value again with `appendQueryParameter()` (which encodes `+` as `%2B`) corrupts the query.

### Concrete example

A widget search for `C++ tutorial` arrives as: `?q=C%2B%2B+tutorial&source=android`
`getQueryParameters("q")` returns the string `C+++tutorial`. 

Appending that again produces: `?q=C%2B%2B%2Btutorial&source=android-widget`
Which the server interprets as the literal string `C+++tutorial`.

### Fix
Operate on the raw encoded query via `Uri.getEncodedQuery()`, split on `&`, and rewrite only the `source=android` pair. Every other parameter, including `q`, passes through byte for byte, so whatever encoding the widget produced reaches the server intact. The substituted query is written back via `Uri.Builder.encodedQuery()` and not `query()` to prevent encoding it again.

Extensive inline comments document the encoding mismatch and explain why `Uri.getQueryParameters()` and `appendQueryParameter()` are not used.


## Test Plan

### Core regression case (the bug being fixed)

- Type `C++ tutorial` into the widget and submit.
- Confirm the rendered results page is for `C++ tutorial`, not `C tutorial` and not `C+++tutorial`.
- Confirm source=android-widget is present.

### Plain query (no special chars)
- Type `hello world` into the widget and submit.
- Confirm the rendered results page is for `hello world`.
- Confirm source=android-widget is present.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
