### PR TITLE
[Origin] Honor BraveRewardsDisabled policy when starting Rewards engine (uplift to 1.91.x)

### DIFF
--- a/browser/brave_rewards/BUILD.gn
+++ b/browser/brave_rewards/BUILD.gn
@@ -41,6 +41,7 @@ source_set("brave_rewards_impl") {
   deps = [
     ":util",
     "//base",
+    "//brave/components/brave_policy:policy_initialization_waiter",
     "//brave/components/brave_rewards/content",
     "//brave/components/brave_rewards/core",
     "//brave/components/brave_rewards/core:features",
@@ -52,6 +53,7 @@ source_set("brave_rewards_impl") {
     "//chrome/browser/profiles",
     "//chrome/browser/ui",
     "//components/keyed_service/content",
+    "//components/policy/core/common",
     "//components/prefs",
     "//components/sessions",
   ]

--- a/browser/brave_rewards/rewards_service_factory.cc
+++ b/browser/brave_rewards/rewards_service_factory.cc
@@ -10,6 +10,7 @@
 
 #include "base/no_destructor.h"
 #include "brave/browser/brave_rewards/rewards_util.h"
+#include "brave/components/brave_policy/policy_initialization_waiter.h"
 #include "brave/components/brave_rewards/content/rewards_notification_service_observer.h"
 #include "brave/components/brave_rewards/content/rewards_service.h"
 #include "brave/components/brave_rewards/content/rewards_service_impl.h"
@@ -19,9 +20,11 @@
 #include "chrome/browser/bitmap_fetcher/bitmap_fetcher_service_factory.h"
 #include "chrome/browser/browser_process.h"
 #include "chrome/browser/favicon/favicon_service_factory.h"
+#include "chrome/browser/policy/profile_policy_connector.h"
 #include "chrome/browser/profiles/incognito_helpers.h"
 #include "chrome/browser/profiles/profile.h"
 #include "components/keyed_service/content/browser_context_dependency_manager.h"
+#include "components/policy/core/common/policy_service.h"
 #include "content/public/browser/storage_partition.h"
 
 #if BUILDFLAG(ENABLE_BRAVE_WALLET)
@@ -93,12 +96,21 @@ RewardsServiceFactory::BuildServiceInstanceForBrowserContext(
       },
       profile);
 
+  policy::PolicyService* policy_service = nullptr;
+  if (auto* policy_connector = profile->GetProfilePolicyConnector()) {
+    policy_service = policy_connector->policy_service();
+  }
+  auto policy_initialization_waiter =
+      std::make_unique<brave_policy::PolicyInitializationWaiter>(
+          policy_service);
+
   std::unique_ptr<RewardsServiceImpl> rewards_service =
       std::make_unique<RewardsServiceImpl>(
           profile->GetPrefs(), profile->GetPath(),
           FaviconServiceFactory::GetForProfile(
               profile, ServiceAccessType::EXPLICIT_ACCESS),
-          g_browser_process->os_crypt_async(), request_image_callback,
+          g_browser_process->os_crypt_async(),
+          std::move(policy_initialization_waiter), request_image_callback,
           cancel_request_image_callback, profile->GetDefaultStoragePartition()
 #if BUILDFLAG(ENABLE_BRAVE_WALLET)
                                              ,

--- a/browser/sources.gni
+++ b/browser/sources.gni
@@ -811,6 +811,17 @@ if (enable_brave_ads) {
   ]
 }
 
+# `rewards_service_factory.cc` includes `chrome/browser/policy/
+# profile_policy_connector.h`, which lives in the `//chrome/browser:browser`
+# monolith. Since `:browser` already depends on `:brave_rewards_impl` (added
+# above), the include can only resolve via a circular-include allowance.
+# Drop this entry once the header is componentized upstream
+# (crbug.com/353332589).
+if (enable_brave_rewards) {
+  brave_chrome_browser_allow_circular_includes_from +=
+      [ "//brave/browser/brave_rewards:brave_rewards_impl" ]
+}
+
 if (toolkit_views) {
   brave_chrome_browser_deps += [
     "//brave/browser/ui/sidebar:sidebar_impl",

--- a/components/brave_rewards/content/BUILD.gn
+++ b/components/brave_rewards/content/BUILD.gn
@@ -37,6 +37,7 @@ static_library("content") {
     "//brave/brave_domains:urls",
     "//brave/components/api_request_helper",
     "//brave/components/brave_ads/buildflags",
+    "//brave/components/brave_policy:policy_initialization_waiter",
     "//brave/components/brave_rewards/core",
     "//brave/components/brave_rewards/core:features",
     "//brave/components/brave_rewards/core/buildflags",

--- a/components/brave_rewards/content/rewards_service_impl.cc
+++ b/components/brave_rewards/content/rewards_service_impl.cc
@@ -35,6 +35,7 @@
 #include "brave/brave_domains/urls.h"
 #include "brave/components/api_request_helper/api_request_helper.h"
 #include "brave/components/brave_ads/buildflags/buildflags.h"
+#include "brave/components/brave_policy/policy_initialization_waiter.h"
 #include "brave/components/brave_rewards/content/diagnostic_log.h"
 #include "brave/components/brave_rewards/content/logging.h"
 #include "brave/components/brave_rewards/content/rewards_notification_service.h"
@@ -208,6 +209,8 @@ RewardsServiceImpl::RewardsServiceImpl(
     const base::FilePath& profile_path,
     favicon::FaviconService* favicon_service,
     os_crypt_async::OSCryptAsync* os_crypt,
+    std::unique_ptr<brave_policy::PolicyInitializationWaiter>
+        policy_initialization_waiter,
     RequestImageCallback request_image_callback,
     CancelImageRequestCallback cancel_image_request_callback,
     content::StoragePartition* storage_partition
@@ -239,7 +242,10 @@ RewardsServiceImpl::RewardsServiceImpl(
       rewards_database_(file_task_runner_),
       creator_prefix_store_(file_task_runner_),
       notification_service_(new RewardsNotificationServiceImpl(prefs)),
+      policy_initialization_waiter_(std::move(policy_initialization_waiter)),
       conversion_monitor_(prefs) {
+  CHECK(policy_initialization_waiter_);
+
   ready_ = std::make_unique<base::OneShotEvent>();
 
   if (base::FeatureList::IsEnabled(features::kVerboseLoggingFeature)) {
@@ -271,8 +277,13 @@ bool RewardsServiceImpl::IsInitialized() {
 
 void RewardsServiceImpl::Init() {
   AddObserver(notification_service_.get());
-  CheckPreferences();
   InitPrefChangeRegistrar();
+
+  // Defer the boot-time engine-start gate until the policy bundle has been
+  // merged into the managed pref store, so that `BraveRewardsDisabled` (which
+  // writes `prefs::kDisabledByPolicy`) is visible when the gate evaluates.
+  policy_initialization_waiter_->Wait(
+      base::BindOnce(&RewardsServiceImpl::CheckPreferences, AsWeakPtr()));
 }
 
 void RewardsServiceImpl::InitPrefChangeRegistrar() {
@@ -327,6 +338,13 @@ void RewardsServiceImpl::OnPreferenceChanged(const std::string& key) {
 }
 
 void RewardsServiceImpl::CheckPreferences() {
+  // Re-check support after `policy_initialization_waiter_` fires; managed
+  // `prefs::kDisabledByPolicy` may not have been visible when the factory ran
+  // its `IsSupported` gate.
+  if (!IsSupported(prefs_)) {
+    return;
+  }
+
 #if BUILDFLAG(ENABLE_BRAVE_ADS)
   if (prefs_->GetBoolean(brave_ads::prefs::kOptedInToNotificationAds)) {
     // If the user has enabled Ads, but the "enabled" pref is missing, set the

--- a/components/brave_rewards/content/rewards_service_impl.h
+++ b/components/brave_rewards/content/rewards_service_impl.h
@@ -61,6 +61,10 @@ namespace os_crypt_async {
 class OSCryptAsync;
 }  // namespace os_crypt_async
 
+namespace brave_policy {
+class PolicyInitializationWaiter;
+}  // namespace brave_policy
+
 #if BUILDFLAG(ENABLE_BRAVE_WALLET)
 namespace brave_wallet {
 class BraveWalletService;
@@ -95,6 +99,8 @@ class RewardsServiceImpl final : public RewardsService,
                      const base::FilePath& profile_path,
                      favicon::FaviconService* favicon_service,
                      os_crypt_async::OSCryptAsync* os_crypt,
+                     std::unique_ptr<brave_policy::PolicyInitializationWaiter>
+                         policy_initialization_waiter,
                      RequestImageCallback request_image_callback,
                      CancelImageRequestCallback cancel_image_request_callback,
                      content::StoragePartition* storage_partition
@@ -485,6 +491,8 @@ class RewardsServiceImpl final : public RewardsService,
   SimpleURLLoaderList url_loaders_;
   std::map<std::string, int> current_media_fetchers_;
   PrefChangeRegistrar profile_pref_change_registrar_;
+  std::unique_ptr<brave_policy::PolicyInitializationWaiter>
+      policy_initialization_waiter_;
 
   bool engine_for_testing_ = false;
   bool resetting_rewards_ = false;


### PR DESCRIPTION
Uplift of #36629
Resolves https://github.com/brave/brave-browser/issues/55696

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.