### PR TITLE
[Origin] Brave News starts fetches when disabled by policy (uplift to 1.91.x)

### DIFF
--- a/browser/brave_news/brave_news_controller_factory.cc
+++ b/browser/brave_news/brave_news_controller_factory.cc
@@ -10,13 +10,16 @@
 #include "base/no_destructor.h"
 #include "brave/browser/brave_news/direct_feed_fetcher_delegate_impl.h"
 #include "brave/components/brave_news/browser/brave_news_controller.h"
+#include "brave/components/brave_policy/policy_initialization_waiter.h"
 #include "chrome/browser/content_settings/host_content_settings_map_factory.h"
 #include "chrome/browser/favicon/favicon_service_factory.h"
 #include "chrome/browser/history/history_service_factory.h"
+#include "chrome/browser/policy/profile_policy_connector.h"
 #include "chrome/browser/profiles/incognito_helpers.h"
 #include "chrome/browser/profiles/profile.h"
 #include "components/keyed_service/content/browser_context_dependency_manager.h"
 #include "components/keyed_service/core/service_access_type.h"
+#include "components/policy/core/common/policy_service.h"
 #include "content/public/browser/browser_context.h"
 
 namespace brave_news {
@@ -74,8 +77,18 @@ BraveNewsControllerFactory::BuildServiceInstanceForBrowserContext(
       profile, ServiceAccessType::EXPLICIT_ACCESS);
   auto* host_content_settings_map =
       HostContentSettingsMapFactory::GetForProfile(profile);
+
+  policy::PolicyService* policy_service = nullptr;
+  if (auto* policy_connector = profile->GetProfilePolicyConnector()) {
+    policy_service = policy_connector->policy_service();
+  }
+  auto policy_initialization_waiter =
+      std::make_unique<brave_policy::PolicyInitializationWaiter>(
+          policy_service);
+
   return std::make_unique<BraveNewsController>(
-      profile->GetPrefs(), history_service, profile->GetURLLoaderFactory(),
+      profile->GetPrefs(), std::move(policy_initialization_waiter),
+      history_service, profile->GetURLLoaderFactory(),
       std::make_unique<DirectFeedFetcherDelegateImpl>(
           host_content_settings_map));
 }

--- a/browser/brave_news/sources.gni
+++ b/browser/brave_news/sources.gni
@@ -25,9 +25,11 @@ if (enable_brave_news) {
     "//base",
     "//brave/components/brave_news/browser",
     "//brave/components/brave_news/common",
+    "//brave/components/brave_policy:policy_initialization_waiter",
     "//brave/components/brave_shields/content/browser",
     "//chrome/browser/profiles:profile",
     "//components/keyed_service/content",
+    "//components/policy/core/common",
     "//content/public/browser",
   ]
 }

--- a/components/brave_news/browser/BUILD.gn
+++ b/components/brave_news/browser/BUILD.gn
@@ -74,6 +74,7 @@ static_library("browser") {
     "//brave/brave_domains",
     "//brave/components/api_request_helper",
     "//brave/components/brave_news/api",
+    "//brave/components/brave_policy:policy_initialization_waiter",
     "//brave/components/brave_private_cdn",
     "//brave/components/brave_rewards/core",
     "//brave/components/l10n/common",

--- a/components/brave_news/browser/brave_news_controller.cc
+++ b/components/brave_news/browser/brave_news_controller.cc
@@ -43,6 +43,7 @@
 #include "brave/components/brave_news/common/locales_helper.h"
 #include "brave/components/brave_news/common/subscriptions_snapshot.h"
 #include "brave/components/brave_news/common/types.h"
+#include "brave/components/brave_policy/policy_initialization_waiter.h"
 #include "brave/components/brave_private_cdn/private_cdn_helper.h"
 #include "components/history/core/browser/history_service.h"
 #include "components/history/core/browser/history_types.h"
@@ -98,6 +99,8 @@ mojo::StructPtr<EventType> CreateChangeEvent(
 
 BraveNewsController::BraveNewsController(
     PrefService* prefs,
+    std::unique_ptr<brave_policy::PolicyInitializationWaiter>
+        policy_initialization_waiter,
     history::HistoryService* history_service,
     scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
     std::unique_ptr<DirectFeedFetcher::Delegate> direct_feed_fetcher_delegate)
@@ -109,6 +112,7 @@ BraveNewsController::BraveNewsController(
       history_service_(history_service),
       url_loader_factory_(url_loader_factory),
       direct_feed_fetcher_delegate_(std::move(direct_feed_fetcher_delegate)),
+      policy_initialization_waiter_(std::move(policy_initialization_waiter)),
       pref_manager_(*prefs),
       news_metrics_(prefs, pref_manager_),
       direct_feed_controller_(url_loader_factory,
@@ -125,15 +129,25 @@ BraveNewsController::BraveNewsController(
               // Unretained is safe here because |initialization_promise_| is
               // owned by BraveNewsController.
               base::Unretained(this))) {
+  CHECK(policy_initialization_waiter_);
+
   ResetEngine();
   net::NetworkChangeNotifier::AddNetworkChangeObserver(this);
 
   prefs_observation_.Observe(&pref_manager_);
 
   news_metrics_.RecordAtInit();
+
   // Monitor kBraveNewsSources and update feed / publisher cache
-  // Start timer of updating feeds, if applicable
-  ConditionallyStartOrStopTimer();
+  // Start timer of updating feeds, if applicable.
+  //
+  // Defer the initial timer/fetch decision until the policy bundle has been
+  // merged into the managed pref store, so that `BraveNewsDisabled` (which
+  // writes `prefs::kBraveNewsDisabledByPolicy`) is visible when
+  // `pref_manager_.IsEnabled()` is evaluated.
+  policy_initialization_waiter_->Wait(
+      base::BindOnce(&BraveNewsController::ConditionallyStartOrStopTimer,
+                     weak_ptr_factory_.GetWeakPtr()));
 }
 
 BraveNewsController::~BraveNewsController() {

--- a/components/brave_news/browser/brave_news_controller.h
+++ b/components/brave_news/browser/brave_news_controller.h
@@ -40,6 +40,10 @@ static_assert(BUILDFLAG(ENABLE_BRAVE_NEWS));
 
 class PrefService;
 
+namespace brave_policy {
+class PolicyInitializationWaiter;
+}  // namespace brave_policy
+
 namespace history {
 class HistoryService;
 }  // namespace history
@@ -59,6 +63,8 @@ class BraveNewsController
  public:
   BraveNewsController(
       PrefService* prefs,
+      std::unique_ptr<brave_policy::PolicyInitializationWaiter>
+          policy_initialization_waiter,
       history::HistoryService* history_service,
       scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
       std::unique_ptr<DirectFeedFetcher::Delegate>
@@ -178,6 +184,8 @@ class BraveNewsController
   scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory_;
 
   std::unique_ptr<DirectFeedFetcher::Delegate> direct_feed_fetcher_delegate_;
+  std::unique_ptr<brave_policy::PolicyInitializationWaiter>
+      policy_initialization_waiter_;
 
   BraveNewsPrefManager pref_manager_;
   SubscriptionsSnapshot last_subscriptions_;

--- a/components/brave_news/common/pref_names.cc
+++ b/components/brave_news/common/pref_names.cc
@@ -31,7 +31,8 @@ void RegisterProfilePrefs(PrefRegistrySimple* registry) {
 }  // namespace prefs
 
 bool IsEnabled(PrefService* prefs) {
-  if (prefs->GetBoolean(prefs::kBraveNewsDisabledByPolicy)) {
+  if (prefs->IsManagedPreference(prefs::kBraveNewsDisabledByPolicy) &&
+      prefs->GetBoolean(prefs::kBraveNewsDisabledByPolicy)) {
     return false;
   }
   return prefs->GetBoolean(prefs::kNewTabPageShowToday) &&


### PR DESCRIPTION
Uplift of #36661
Resolves https://github.com/brave/brave-browser/issues/55759

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.