### PR TITLE
[iOS] Refactor ReaderModeTabHelper as single source of truth for reader mode

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+P3A.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+P3A.swift
@@ -435,9 +435,6 @@ extension P3ATimedStorage where Value == Int {
   fileprivate static var braveVPNDaysInMonthUsedStorage: Self {
     .init(name: "vpn-days-in-month-used", lifetimeInDays: 30)
   }
-  internal static var readerModeActivated: Self {
-    .init(name: "reader-mode-activated", lifetimeInDays: 7)
-  }
   fileprivate static var navigationActionPerformedStorage: Self {
     .init(name: "navigation-action-performed", lifetimeInDays: 7)
   }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+P3A.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+P3A.swift
@@ -360,26 +360,6 @@ extension BrowserViewController {
     UmaHistogramEnumeration("Brave.General.BottomBarLocation", sample: answer)
   }
 
-  func recordTimeBasedNumberReaderModeUsedP3A(activated: Bool) {
-    var storage = P3ATimedStorage<Int>.readerModeActivated
-    if activated {
-      storage.add(value: 1, to: Date())
-    }
-
-    // Q102- How many times did you use reader mode in the last 7 days?
-    UmaHistogramRecordValueToBucket(
-      "Brave.ReaderMode.NumberReaderModeActivated",
-      buckets: [
-        0,
-        .r(1...5),
-        .r(5...20),
-        .r(20...50),
-        .r(51...),
-      ],
-      value: storage.combinedValue
-    )
-  }
-
   func recordAdsUsageType() {
     enum Answer: Int, CaseIterable {
       case none = 0
@@ -455,7 +435,7 @@ extension P3ATimedStorage where Value == Int {
   fileprivate static var braveVPNDaysInMonthUsedStorage: Self {
     .init(name: "vpn-days-in-month-used", lifetimeInDays: 30)
   }
-  fileprivate static var readerModeActivated: Self {
+  internal static var readerModeActivated: Self {
     .init(name: "reader-mode-activated", lifetimeInDays: 7)
   }
   fileprivate static var navigationActionPerformedStorage: Self {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ReaderMode.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ReaderMode.swift
@@ -11,37 +11,6 @@ import Storage
 import Web
 import WebKit
 
-// MARK: - ReaderModeDelegate
-
-extension BrowserViewController: ReaderModeScriptHandlerDelegate {
-  func readerMode(
-    _ readerMode: ReaderModeScriptHandler,
-    didChangeReaderModeState state: ReaderModeState,
-    forTab tab: some TabState
-  ) {
-    // If this reader mode availability state change is for the tab that we currently show, then update
-    // the button. Otherwise do nothing and the button will be updated when the tab is made active.
-    if tabManager.selectedTab === tab {
-      topToolbar.updateReaderModeState(state)
-    }
-  }
-
-  func readerMode(
-    _ readerMode: ReaderModeScriptHandler,
-    didDisplayReaderizedContentForTab tab: some TabState
-  ) {
-    if tabManager.selectedTab !== tab { return }
-    showReaderModeBar(animated: true)
-    tab.showContent(true)
-  }
-
-  func readerMode(
-    _ readerMode: ReaderModeScriptHandler,
-    didParseReadabilityResult readabilityResult: ReadabilityResult,
-    forTab tab: some TabState
-  ) {}
-}
-
 // MARK: - ReaderModeStyleViewControllerDelegate
 
 extension BrowserViewController: ReaderModeStyleViewControllerDelegate {
@@ -53,21 +22,7 @@ extension BrowserViewController: ReaderModeStyleViewControllerDelegate {
     Preferences.ReaderMode.style.value = style.encode()
     // Change the reader mode style on all tabs that have reader mode active
     for tabIndex in 0..<tabManager.count {
-      if let tab = tabManager[tabIndex] {
-        if FeatureList.kUseProfileWebViewConfiguration.enabled {
-          tab.readerMode?.setStyle(style)
-        } else {
-          if let readerMode = tab.browserData?.getContentScript(
-            name: ReaderModeScriptHandler.scriptName
-          )
-            as? ReaderModeScriptHandler
-          {
-            if readerMode.state == ReaderModeState.active {
-              readerMode.setStyle(style, in: tab)
-            }
-          }
-        }
-      }
+      tabManager[tabIndex]?.readerMode?.setStyle(style)
     }
   }
 }
@@ -126,100 +81,6 @@ extension BrowserViewController {
       readerModeBar.removeFromSuperview()
       self.readerModeBar = nil
       self.updateViewConstraints()
-    }
-  }
-
-  /// There are two ways we can enable reader mode. In the simplest case we open a URL to our internal reader mode
-  /// and be done with it. In the more complicated case, reader mode was already open for this page and we simply
-  /// navigated away from it. So we look to the left and right in the BackForwardList to see if a readerized version
-  /// of the current page is there. And if so, we go there.
-
-  func enableReaderMode() {
-    guard let tab = tabManager.selectedTab, let backForwardList = tab.backForwardList else {
-      return
-    }
-
-    let backList = backForwardList.backList
-    let forwardList = backForwardList.forwardList
-
-    guard let currentURL = backForwardList.currentItem?.url,
-      let headers = (tab.responses?[currentURL] as? HTTPURLResponse)?.allHeaderFields
-        as? [String: String],
-      let readerModeURL = currentURL.encodeEmbeddedInternalURL(for: .readermode, headers: headers)
-    else { return }
-
-    recordTimeBasedNumberReaderModeUsedP3A(activated: true)
-
-    let playlistItem = tab.playlistItem
-    let translationState = tab.translationState
-    if backList.count > 1 && backList.last?.url == readerModeURL {
-      tab.goToBackForwardListItem(backList.last!)
-      PlaylistScriptHandler.updatePlaylistTab(tab: tab, item: playlistItem)
-      self.updateTranslateURLBar(tab: tab, state: translationState)
-    } else if !forwardList.isEmpty && forwardList.first?.url == readerModeURL {
-      tab.goToBackForwardListItem(forwardList.first!)
-      PlaylistScriptHandler.updatePlaylistTab(tab: tab, item: playlistItem)
-      self.updateTranslateURLBar(tab: tab, state: translationState)
-    } else {
-      if FeatureList.kUseProfileWebViewConfiguration.enabled {
-        if let readabilityResult = tab.readerMode?.readabilityResult {
-          Task { @MainActor in
-            try? await self.readerModeCache.put(currentURL, readabilityResult)
-            tab.loadRequest(PrivilegedRequest(url: readerModeURL) as URLRequest)
-            PlaylistScriptHandler.updatePlaylistTab(tab: tab, item: playlistItem)
-            self.updateTranslateURLBar(tab: tab, state: translationState)
-          }
-        }
-      } else {
-        // Store the readability result in the cache and load it. This will later move to the ReadabilityHelper.
-        tab.evaluateJavaScript(
-          functionName: "\(readerModeNamespace).readerize",
-          contentWorld: ReaderModeScriptHandler.scriptSandbox
-        ) { (object, error) -> Void in
-          if let readabilityResult = ReadabilityResult(object: object as AnyObject?) {
-            let playlistItem = tab.playlistItem
-            let translationState = tab.translationState
-            Task { @MainActor in
-              try? await self.readerModeCache.put(currentURL, readabilityResult)
-              tab.loadRequest(PrivilegedRequest(url: readerModeURL) as URLRequest)
-              PlaylistScriptHandler.updatePlaylistTab(tab: tab, item: playlistItem)
-              self.updateTranslateURLBar(tab: tab, state: translationState)
-            }
-          }
-        }
-      }
-    }
-  }
-
-  /// Disabling reader mode can mean two things. In the simplest case we were opened from the reading list, which
-  /// means that there is nothing in the BackForwardList except the internal url for the reader mode page. In that
-  /// case we simply open a new page with the original url. In the more complicated page, the non-readerized version
-  /// of the page is either to the left or right in the BackForwardList. If that is the case, we navigate there.
-
-  func disableReaderMode() {
-    if let tab = tabManager.selectedTab, let backForwardList = tab.backForwardList {
-      let backList = backForwardList.backList
-      let forwardList = backForwardList.forwardList
-
-      if let currentURL = backForwardList.currentItem?.url {
-        if let originalURL = currentURL.decodeEmbeddedInternalURL(for: .readermode) {
-          let playlistItem = tab.playlistItem
-          let translationState = tab.translationState
-          if backList.count > 1 && backList.last?.url == originalURL {
-            tab.goToBackForwardListItem(backList.last!)
-            PlaylistScriptHandler.updatePlaylistTab(tab: tab, item: playlistItem)
-            self.updateTranslateURLBar(tab: tab, state: translationState)
-          } else if !forwardList.isEmpty && forwardList.first?.url == originalURL {
-            tab.goToBackForwardListItem(forwardList.first!)
-            PlaylistScriptHandler.updatePlaylistTab(tab: tab, item: playlistItem)
-            self.updateTranslateURLBar(tab: tab, state: translationState)
-          } else {
-            tab.loadRequest(URLRequest(url: originalURL))
-            PlaylistScriptHandler.updatePlaylistTab(tab: tab, item: playlistItem)
-            self.updateTranslateURLBar(tab: tab, state: translationState)
-          }
-        }
-      }
     }
   }
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ShareActivity.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ShareActivity.swift
@@ -86,9 +86,7 @@ extension BrowserViewController {
       activities.append(
         BasicMenuActivity(
           activityType: .toggleReaderMode,
-          callback: { [weak self] in
-            self?.toggleReaderMode()
-          }
+          callback: { tab.readerMode?.toggleReaderMode() }
         )
       )
     }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabManagerDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabManagerDelegate.swift
@@ -95,9 +95,19 @@ extension BrowserViewController: TabManagerDelegate {
     tab.addPolicyDecider(braveShieldsHelper)
     tab.logins = .init(tab: tab, passwordAPI: profileController.passwordAPI)
     tab.nightMode = .init(tab: tab)
-
-    if FeatureList.kUseProfileWebViewConfiguration.enabled {
-      tab.readerMode = .init(tab: tab)
+    // reader mode
+    tab.readerMode = .init(tab: tab, readerModeCache: ReaderModeScriptHandler.cache(for: tab))
+    tab.readerMode?.onStateChanged = { [weak self] in
+      guard let self, self.tabManager.selectedTab === tab else { return }
+      self.topToolbar.updateReaderModeState(tab.readerMode?.state ?? .unavailable)
+    }
+    tab.readerMode?.onReaderModeDisplayed = { [weak self] in
+      guard let self else { return }
+      self.showReaderModeBar(animated: true)
+      tab.showContent(true)
+    }
+    tab.readerMode?.updateTranslateURLBar = { [weak self] tab, state in
+      self?.updateTranslateURLBar(tab: tab, state: state)
     }
 
     tab.braveTalk = .init(tab: tab, coordinator: braveTalkJitsiCoordinator)
@@ -244,14 +254,7 @@ extension BrowserViewController: TabManagerDelegate {
     let shouldShowPlaylistURLBarButton = selected?.visibleURL?.isPlaylistSupportedSiteURL == true
 
     if !shouldShowPlaylistURLBarButton {
-      let readerModeState: ReaderModeState?
-      if FeatureList.kUseProfileWebViewConfiguration.enabled {
-        readerModeState = selected?.readerMode?.state
-      } else {
-        readerModeState =
-          (selected?.browserData?.getContentScript(name: ReaderModeScriptHandler.scriptName)
-          as? ReaderModeScriptHandler)?.state
-      }
+      let readerModeState = selected?.readerMode?.state
       if let readerModeState {
         topToolbar.updateReaderModeState(readerModeState)
         if readerModeState == .active {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabManagerDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabManagerDelegate.swift
@@ -101,8 +101,8 @@ extension BrowserViewController: TabManagerDelegate {
       guard let self, self.tabManager.selectedTab === tab else { return }
       self.topToolbar.updateReaderModeState(tab.readerMode?.state ?? .unavailable)
     }
-    tab.readerMode?.onReaderModeDisplayed = { [weak self] in
-      guard let self else { return }
+    tab.readerMode?.onReaderModeDisplayed = { [weak self, weak tab] in
+      guard let self, let tab else { return }
       self.showReaderModeBar(animated: true)
       tab.showContent(true)
     }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabManagerDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabManagerDelegate.swift
@@ -106,8 +106,9 @@ extension BrowserViewController: TabManagerDelegate {
       self.showReaderModeBar(animated: true)
       tab.showContent(true)
     }
-    tab.readerMode?.updateTranslateURLBar = { [weak self] tab, state in
-      self?.updateTranslateURLBar(tab: tab, state: state)
+    tab.readerMode?.onReaderModeToggled = { [weak self] tab in
+      PlaylistScriptHandler.updatePlaylistTab(tab: tab, item: tab.playlistItem)
+      self?.updateTranslateURLBar(tab: tab, state: tab.translationState)
     }
 
     tab.braveTalk = .init(tab: tab, coordinator: braveTalkJitsiCoordinator)

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabObserver.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabObserver.swift
@@ -387,33 +387,11 @@ extension BrowserViewController: TabObserver {
       updateStatusBarOverlayColor()
     }
   }
-
-  public func tab(_ tab: some TabState, frameDidBecomeAvailable frame: WebFrame) {
-    // when user taps back button to go back to the previous page from an activated
-    // reader mode page, most of the `TabObserver` methods are fired before
-    // web main frame is ready,
-    // For this case, we need to check readability after main frame did became available
-    guard FeatureList.kUseProfileWebViewConfiguration.enabled,
-      frame.isMainFrame,
-      let readerMode = tab.readerMode,
-      let url = tab.visibleURL,
-      !url.isNewTabURL,
-      !InternalURL.isValid(url: url) || url.isInternalURL(for: .readermode),
-      !url.isFileURL
-    else { return }
-    Task {
-      await readerMode.checkReadability()
-      if tabManager.selectedTab === tab {
-        topToolbar.updateReaderModeState(readerMode.state)
-      }
-    }
-  }
 }
 
 extension BrowserViewController {
   fileprivate func installContentScriptHandlers(in tab: some TabState) {
     var injectedScripts: [TabContentScript] = [
-      ReaderModeScriptHandler(),
       BlockedDomainScriptHandler(),
       HTTPBlockedScriptHandler(tabManager: tabManager),
       PrintScriptHandler(browserController: self),
@@ -487,9 +465,6 @@ extension BrowserViewController {
       )
     }
 
-    (tab.browserData?.getContentScript(name: ReaderModeScriptHandler.scriptName)
-      as? ReaderModeScriptHandler)?
-      .delegate = self
     (tab.browserData?.getContentScript(name: PlaylistScriptHandler.scriptName)
       as? PlaylistScriptHandler)?
       .delegate = self

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ToolbarDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ToolbarDelegate.swift
@@ -148,7 +148,7 @@ extension BrowserViewController: TopToolbarDelegate {
   }
 
   func topToolbarDidPressReaderMode(_ topToolbar: TopToolbarView) {
-    toggleReaderMode()
+    tabManager.selectedTab?.readerMode?.toggleReaderMode()
   }
 
   func topToolbarDidPressPlaylistButton(_ urlBar: TopToolbarView) {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -561,7 +561,7 @@ public class BrowserViewController: UIViewController {
     recordVPNUsageP3A(vpnEnabled: BraveVPN.isConnected)
     recordAccessibilityDisplayZoomEnabledP3A()
     recordAccessibilityDocumentsDirectorySizeP3A()
-    recordTimeBasedNumberReaderModeUsedP3A(activated: false)
+    ReaderModeTabHelper.recordTimeBasedNumberReaderModeUsedP3A(activated: false)
     recordGeneralBottomBarLocationP3A()
     PlaylistP3A.recordHistogram()
     recordAdsUsageType()
@@ -2130,26 +2130,6 @@ public class BrowserViewController: UIViewController {
       if !url.isNewTabURL, !InternalURL.isValid(url: url) || url.isInternalURL(for: .readermode),
         !url.isFileURL
       {
-        // Fire the readability check. This is here and not in the pageShow event handler in ReaderMode.js anymore
-        // because that event will not always fire due to unreliable page caching. This will either let us know that
-        // the currently loaded page can be turned into reading mode or if the page already is in reading mode. We
-        // ignore the result because we are being called back asynchronous when the readermode status changes.
-        if FeatureList.kUseProfileWebViewConfiguration.enabled {
-          if let readerMode = tab.readerMode {
-            Task {
-              await readerMode.checkReadability()
-              if tabManager.selectedTab === tab {
-                topToolbar.updateReaderModeState(readerMode.state)
-              }
-            }
-          }
-        } else {
-          tab.evaluateJavaScript(
-            functionName: "\(readerModeNamespace).checkReadability",
-            contentWorld: ReaderModeScriptHandler.scriptSandbox
-          )
-        }
-
         // Only add history of a url which is not a localhost url
         if !url.isInternalURL(for: .readermode) {
           if !tab.isPrivate {
@@ -2207,27 +2187,6 @@ public class BrowserViewController: UIViewController {
         UIAlertAction(title: Strings.scanQRCodeErrorOKButton, style: .default, handler: nil)
       )
       self.present(alert, animated: true, completion: nil)
-    }
-  }
-
-  func toggleReaderMode() {
-    guard let tab = tabManager.selectedTab else { return }
-    let readerModeState: ReaderModeState?
-    if FeatureList.kUseProfileWebViewConfiguration.enabled {
-      readerModeState = tab.readerMode?.state
-    } else {
-      readerModeState =
-        (tab.browserData?.getContentScript(name: ReaderModeScriptHandler.scriptName)
-        as? ReaderModeScriptHandler)?.state
-    }
-    guard let readerModeState else { return }
-    switch readerModeState {
-    case .available:
-      enableReaderMode()
-    case .active:
-      disableReaderMode()
-    case .unavailable:
-      break
     }
   }
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/ReaderModeTabHelper.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/ReaderModeTabHelper.swift
@@ -25,8 +25,7 @@ class ReaderModeTabHelper {
 
   var onStateChanged: (() -> Void)?
   var onReaderModeDisplayed: (() -> Void)?
-  var updateTranslateURLBar:
-    ((_ tab: TabState, _ state: TranslateURLBarButton.TranslateState) -> Void)?
+  var onReaderModeToggled: ((_ tab: TabState) -> Void)?
 
   init?(tab: some TabState, readerModeCache: any ReaderModeCache) {
     if !tab.isChromiumTab {
@@ -124,20 +123,9 @@ class ReaderModeTabHelper {
     }
   }
 
-  /// There are two ways we can enable reader mode. In the simplest case we open a URL to our internal reader mode
-  /// and be done with it. In the more complicated case, reader mode was already open for this page and we simply
-  /// navigated away from it. So we look to the left and right in the BackForwardList to see if a readerized version
-  /// of the current page is there. And if so, we go there.
-
   private func enableReaderMode() {
-    guard let tab, let backForwardList = tab.backForwardList else {
-      return
-    }
-
-    let backList = backForwardList.backList
-    let forwardList = backForwardList.forwardList
-
-    guard let currentURL = backForwardList.currentItem?.url,
+    guard let tab,
+      let currentURL = tab.lastCommittedURL,
       let headers = (tab.responses?[currentURL] as? HTTPURLResponse)?.allHeaderFields
         as? [String: String],
       let readerModeURL = currentURL.encodeEmbeddedInternalURL(for: .readermode, headers: headers)
@@ -145,58 +133,25 @@ class ReaderModeTabHelper {
 
     Self.recordTimeBasedNumberReaderModeUsedP3A(activated: true)
 
-    let playlistItem = tab.playlistItem
-    let translationState = tab.translationState
-    if backList.count > 1 && backList.last?.url == readerModeURL {
-      tab.goToBackForwardListItem(backList.last!)
-      PlaylistScriptHandler.updatePlaylistTab(tab: tab, item: playlistItem)
-      self.updateTranslateURLBar?(tab, translationState)
-    } else if !forwardList.isEmpty && forwardList.first?.url == readerModeURL {
-      tab.goToBackForwardListItem(forwardList.first!)
-      PlaylistScriptHandler.updatePlaylistTab(tab: tab, item: playlistItem)
-      self.updateTranslateURLBar?(tab, translationState)
-    } else {
-      if let readabilityResult {
-        Task { @MainActor in
-          try? await readerModeCache.put(currentURL, readabilityResult)
-          tab.loadRequest(PrivilegedRequest(url: readerModeURL) as URLRequest)
-          PlaylistScriptHandler.updatePlaylistTab(tab: tab, item: playlistItem)
-          self.updateTranslateURLBar?(tab, translationState)
-        }
+    if let readabilityResult {
+      Task { @MainActor in
+        try? await readerModeCache.put(currentURL, readabilityResult)
+        tab.loadRequest(PrivilegedRequest(url: readerModeURL) as URLRequest)
+        self.onReaderModeToggled?(tab)
       }
     }
   }
 
-  /// Disabling reader mode can mean two things. In the simplest case we were opened from the reading list, which
-  /// means that there is nothing in the BackForwardList except the internal url for the reader mode page. In that
-  /// case we simply open a new page with the original url. In the more complicated page, the non-readerized version
-  /// of the page is either to the left or right in the BackForwardList. If that is the case, we navigate there.
-
   private func disableReaderMode() {
-    if let tab, let backForwardList = tab.backForwardList {
-      let backList = backForwardList.backList
-      let forwardList = backForwardList.forwardList
-
-      if let currentURL = backForwardList.currentItem?.url {
-        if let originalURL = currentURL.decodeEmbeddedInternalURL(for: .readermode) {
-          let playlistItem = tab.playlistItem
-          let translationState = tab.translationState
-          if backList.count > 1 && backList.last?.url == originalURL {
-            tab.goToBackForwardListItem(backList.last!)
-            PlaylistScriptHandler.updatePlaylistTab(tab: tab, item: playlistItem)
-            self.updateTranslateURLBar?(tab, translationState)
-          } else if !forwardList.isEmpty && forwardList.first?.url == originalURL {
-            tab.goToBackForwardListItem(forwardList.first!)
-            PlaylistScriptHandler.updatePlaylistTab(tab: tab, item: playlistItem)
-            self.updateTranslateURLBar?(tab, translationState)
-          } else {
-            tab.loadRequest(URLRequest(url: originalURL))
-            PlaylistScriptHandler.updatePlaylistTab(tab: tab, item: playlistItem)
-            self.updateTranslateURLBar?(tab, translationState)
-          }
-        }
-      }
+    guard let tab,
+      let currentURL = tab.visibleURL,
+      let originalURL = currentURL.decodeEmbeddedInternalURL(for: .readermode)
+    else {
+      return
     }
+
+    tab.loadRequest(URLRequest(url: originalURL))
+    onReaderModeToggled?(tab)
   }
 }
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/ReaderModeTabHelper.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/ReaderModeTabHelper.swift
@@ -4,6 +4,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import BraveCore
+import Growth
 import Shared
 @_spi(ChromiumWebViewAccess) import Web
 
@@ -17,15 +18,22 @@ extension TabDataValues {
   }
 }
 
-class ReaderModeTabHelper: TabObserver {
+class ReaderModeTabHelper {
   private weak var tab: (any TabState)?
+  private let readerModeCache: any ReaderModeCache
   private(set) var readabilityResult: ReadabilityResult?
 
-  init?(tab: some TabState) {
+  var onStateChanged: (() -> Void)?
+  var onReaderModeDisplayed: (() -> Void)?
+  var updateTranslateURLBar:
+    ((_ tab: TabState, _ state: TranslateURLBarButton.TranslateState) -> Void)?
+
+  init?(tab: some TabState, readerModeCache: any ReaderModeCache) {
     if !tab.isChromiumTab {
       return nil
     }
     self.tab = tab
+    self.readerModeCache = readerModeCache
     tab.addObserver(self)
   }
 
@@ -43,39 +51,255 @@ class ReaderModeTabHelper: TabObserver {
   /// Checks the web views readability then assigns `readabilityResult`
   @MainActor
   func checkReadability() async {
-    guard let tab, let url = tab.lastCommittedURL, url.isWebPage(includeDataURIs: false),
-      let webView = BraveWebView.from(tab: tab)
+    guard let tab, let url = tab.lastCommittedURL, url.isWebPage(includeDataURIs: false)
     else {
       readabilityResult = nil
+      onStateChanged?()
       return
     }
-    guard let result = await webView.checkReadability() else {
-      // No Reader Mode
-      readabilityResult = nil
-      return
-    }
-    do {
-      let jsonObject = try JSONSerialization.jsonObject(with: Data(result.utf8)) as AnyObject
-      readabilityResult = ReadabilityResult(object: jsonObject)
-    } catch {
-      readabilityResult = nil
+
+    if FeatureList.kUseProfileWebViewConfiguration.enabled {
+      guard let webView = BraveWebView.from(tab: tab)
+      else {
+        readabilityResult = nil
+        onStateChanged?()
+        return
+      }
+      guard let result = await webView.checkReadability() else {
+        // No Reader Mode
+        readabilityResult = nil
+        onStateChanged?()
+        return
+      }
+      do {
+        let jsonObject = try JSONSerialization.jsonObject(with: Data(result.utf8)) as AnyObject
+        readabilityResult = ReadabilityResult(object: jsonObject)
+        onStateChanged?()
+      } catch {
+        readabilityResult = nil
+        onStateChanged?()
+      }
+    } else {
+      do {
+        try await tab.evaluateJavaScript(
+          functionName: "\(readerModeNamespace).checkReadability",
+          contentWorld: ReaderModeScriptHandler.scriptSandbox
+        )
+        // onStateChanged?() will gets fired in delegate method
+      } catch {
+        readabilityResult = nil
+        onStateChanged?()
+      }
     }
   }
 
   @MainActor func setStyle(_ style: ReaderModeStyle) {
-    guard let tab, state == .active, let webView = BraveWebView.from(tab: tab) else { return }
-    webView.setReaderModeTheme(
-      style.theme.rawValue,
-      fontType: style.fontType.rawValue,
-      fontSize: style.fontSize.rawValue
+    guard let tab, state == .active else { return }
+    if FeatureList.kUseProfileWebViewConfiguration.enabled,
+      let webView = BraveWebView.from(tab: tab)
+    {
+      webView.setReaderModeTheme(
+        style.theme.rawValue,
+        fontType: style.fontType.rawValue,
+        fontSize: style.fontSize.rawValue
+      )
+    } else {
+      tab.evaluateJavaScript(
+        functionName: "\(readerModeNamespace).setStyle",
+        args: [style.encode()],
+        contentWorld: ReaderModeScriptHandler.scriptSandbox,
+        escapeArgs: false
+      ) { _, _ in }
+    }
+  }
+
+  func toggleReaderMode() {
+    switch state {
+    case .available:
+      enableReaderMode()
+    case .active:
+      disableReaderMode()
+    case .unavailable:
+      break
+    }
+  }
+
+  /// There are two ways we can enable reader mode. In the simplest case we open a URL to our internal reader mode
+  /// and be done with it. In the more complicated case, reader mode was already open for this page and we simply
+  /// navigated away from it. So we look to the left and right in the BackForwardList to see if a readerized version
+  /// of the current page is there. And if so, we go there.
+
+  private func enableReaderMode() {
+    guard let tab, let backForwardList = tab.backForwardList else {
+      return
+    }
+
+    let backList = backForwardList.backList
+    let forwardList = backForwardList.forwardList
+
+    guard let currentURL = backForwardList.currentItem?.url,
+      let headers = (tab.responses?[currentURL] as? HTTPURLResponse)?.allHeaderFields
+        as? [String: String],
+      let readerModeURL = currentURL.encodeEmbeddedInternalURL(for: .readermode, headers: headers)
+    else { return }
+
+    Self.recordTimeBasedNumberReaderModeUsedP3A(activated: true)
+
+    let playlistItem = tab.playlistItem
+    let translationState = tab.translationState
+    if backList.count > 1 && backList.last?.url == readerModeURL {
+      tab.goToBackForwardListItem(backList.last!)
+      PlaylistScriptHandler.updatePlaylistTab(tab: tab, item: playlistItem)
+      self.updateTranslateURLBar?(tab, translationState)
+    } else if !forwardList.isEmpty && forwardList.first?.url == readerModeURL {
+      tab.goToBackForwardListItem(forwardList.first!)
+      PlaylistScriptHandler.updatePlaylistTab(tab: tab, item: playlistItem)
+      self.updateTranslateURLBar?(tab, translationState)
+    } else {
+      if let readabilityResult {
+        Task { @MainActor in
+          try? await readerModeCache.put(currentURL, readabilityResult)
+          tab.loadRequest(PrivilegedRequest(url: readerModeURL) as URLRequest)
+          PlaylistScriptHandler.updatePlaylistTab(tab: tab, item: playlistItem)
+          self.updateTranslateURLBar?(tab, translationState)
+        }
+      }
+    }
+  }
+
+  /// Disabling reader mode can mean two things. In the simplest case we were opened from the reading list, which
+  /// means that there is nothing in the BackForwardList except the internal url for the reader mode page. In that
+  /// case we simply open a new page with the original url. In the more complicated page, the non-readerized version
+  /// of the page is either to the left or right in the BackForwardList. If that is the case, we navigate there.
+
+  private func disableReaderMode() {
+    if let tab, let backForwardList = tab.backForwardList {
+      let backList = backForwardList.backList
+      let forwardList = backForwardList.forwardList
+
+      if let currentURL = backForwardList.currentItem?.url {
+        if let originalURL = currentURL.decodeEmbeddedInternalURL(for: .readermode) {
+          let playlistItem = tab.playlistItem
+          let translationState = tab.translationState
+          if backList.count > 1 && backList.last?.url == originalURL {
+            tab.goToBackForwardListItem(backList.last!)
+            PlaylistScriptHandler.updatePlaylistTab(tab: tab, item: playlistItem)
+            self.updateTranslateURLBar?(tab, translationState)
+          } else if !forwardList.isEmpty && forwardList.first?.url == originalURL {
+            tab.goToBackForwardListItem(forwardList.first!)
+            PlaylistScriptHandler.updatePlaylistTab(tab: tab, item: playlistItem)
+            self.updateTranslateURLBar?(tab, translationState)
+          } else {
+            tab.loadRequest(URLRequest(url: originalURL))
+            PlaylistScriptHandler.updatePlaylistTab(tab: tab, item: playlistItem)
+            self.updateTranslateURLBar?(tab, translationState)
+          }
+        }
+      }
+    }
+  }
+}
+
+// MARK: - TabObserver
+
+extension ReaderModeTabHelper: TabObserver {
+  func tabDidCreateWebView(_ tab: some TabState) {
+    // add content script for legacy reader mode only
+    guard let browserData = tab.browserData else { return }
+    let handler = ReaderModeScriptHandler()
+    browserData.addContentScript(
+      handler,
+      name: ReaderModeScriptHandler.scriptName,
+      contentWorld: ReaderModeScriptHandler.scriptSandbox
     )
+    handler.delegate = self
   }
 
   func tabDidStartNavigation(_ tab: some TabState) {
+    // Mirror BVC+TabObserver behavior: don't clear state when already on a reader mode page,
+    // since the reader mode page itself can trigger sub-navigations after activation.
+    if let url = tab.visibleURL, url.isInternalURL(for: .readermode) {
+      return
+    }
     readabilityResult = nil
+  }
+
+  func tabDidFinishNavigation(_ tab: some TabState) {
+    Task { @MainActor in
+      await checkReadability()
+    }
+  }
+
+  func tabDidChangeTitle(_ tab: some TabState) {
+    Task { @MainActor in
+      await checkReadability()
+    }
+  }
+
+  func tabDidUpdateURL(_ tab: some TabState) {
+    Task { @MainActor in
+      await checkReadability()
+    }
+  }
+
+  func tab(_ tab: some TabState, frameDidBecomeAvailable frame: WebFrame) {
+    Task { @MainActor in
+      await checkReadability()
+    }
   }
 
   func tabWillBeDestroyed(_ tab: some TabState) {
     tab.removeObserver(self)
+  }
+}
+
+// MARK: - ReaderModeScriptHandlerDelegate
+
+extension ReaderModeTabHelper: ReaderModeScriptHandlerDelegate {
+  func readerMode(
+    _ readerMode: ReaderModeScriptHandler,
+    didChangeReaderModeState state: ReaderModeState,
+    forTab tab: some TabState
+  ) {
+    onStateChanged?()
+  }
+
+  func readerMode(
+    _ readerMode: ReaderModeScriptHandler,
+    didDisplayReaderizedContentForTab tab: some TabState
+  ) {
+    onReaderModeDisplayed?()
+  }
+
+  func readerMode(
+    _ readerMode: ReaderModeScriptHandler,
+    didParseReadabilityResult readabilityResult: ReadabilityResult,
+    forTab tab: some TabState
+  ) {
+    self.readabilityResult = readabilityResult
+  }
+}
+
+// MARK: - P3A
+
+extension ReaderModeTabHelper {
+  static func recordTimeBasedNumberReaderModeUsedP3A(activated: Bool) {
+    var storage = P3ATimedStorage<Int>.readerModeActivated
+    if activated {
+      storage.add(value: 1, to: Date())
+    }
+
+    // Q102- How many times did you use reader mode in the last 7 days?
+    UmaHistogramRecordValueToBucket(
+      "Brave.ReaderMode.NumberReaderModeActivated",
+      buckets: [
+        0,
+        .r(1...5),
+        .r(5...20),
+        .r(20...50),
+        .r(51...),
+      ],
+      value: storage.combinedValue
+    )
   }
 }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/ReaderModeTabHelper.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/ReaderModeTabHelper.swift
@@ -204,15 +204,17 @@ class ReaderModeTabHelper {
 
 extension ReaderModeTabHelper: TabObserver {
   func tabDidCreateWebView(_ tab: some TabState) {
-    // add content script for legacy reader mode only
-    guard let browserData = tab.browserData else { return }
-    let handler = ReaderModeScriptHandler()
-    browserData.addContentScript(
-      handler,
-      name: ReaderModeScriptHandler.scriptName,
-      contentWorld: ReaderModeScriptHandler.scriptSandbox
-    )
-    handler.delegate = self
+    if !FeatureList.kUseProfileWebViewConfiguration.enabled {
+      // add content script for legacy reader mode only
+      guard let browserData = tab.browserData else { return }
+      let handler = ReaderModeScriptHandler()
+      browserData.addContentScript(
+        handler,
+        name: ReaderModeScriptHandler.scriptName,
+        contentWorld: ReaderModeScriptHandler.scriptSandbox
+      )
+      handler.delegate = self
+    }
   }
 
   func tabDidStartNavigation(_ tab: some TabState) {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/ReaderModeTabHelper.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/ReaderModeTabHelper.swift
@@ -239,6 +239,12 @@ extension ReaderModeTabHelper: ReaderModeScriptHandlerDelegate {
 
 // MARK: - P3A
 
+extension P3ATimedStorage where Value == Int {
+  fileprivate static var readerModeActivated: Self {
+    .init(name: "reader-mode-activated", lifetimeInDays: 7)
+  }
+}
+
 extension ReaderModeTabHelper {
   static func recordTimeBasedNumberReaderModeUsedP3A(activated: Bool) {
     var storage = P3ATimedStorage<Int>.readerModeActivated


### PR DESCRIPTION
Move all reader mode logic — readability checking, toggle/enable/disable, style updates, and P3A recording into ReaderModeTabHelper, removing the scattered flag-branching between kUseProfileWebViewConfiguration paths from BrowserViewController.
The helper now:
- Conforms to TabObserver directly, triggering readability checks on navigation events for both the JSFeature and legacy content script paths
- Conforms to ReaderModeScriptHandlerDelegate to handle legacy readability results and state change
-  Installs ReaderModeScriptHandler as a content script for the legacy path
-  Accepts ReaderModeCache as an init dependency to ensure cache writes complete before reader mode navigation is triggered
- Exposes onStateChanged, onReaderModeDisplayed and updateTranslateURLBar closures for BVC UI callbacks
- Exposes a static recordTimeBasedNumberReaderModeUsedP3A replacing the BVC instance method

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

Test:
Check reader mode flow is working as before with and without `kUseProfileWebViewConfiguration` enabled. 

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
