### PR TITLE
[Origin] Brave Stats startup ping races BraveStatsPingEnabled policy

### DIFF
--- a/browser/brave_stats/BUILD.gn
+++ b/browser/brave_stats/BUILD.gn
@@ -46,6 +46,8 @@ source_set("brave_stats") {
     "//brave/browser/serp_metrics",
     "//brave/common",
     "//brave/components/brave_ads/buildflags",
+    "//brave/components/brave_origin",
+    "//brave/components/brave_policy:brave_policy_observer",
     "//brave/components/brave_referrals/common",
     "//brave/components/brave_wallet/common/buildflags",
     "//brave/components/constants",

--- a/browser/brave_stats/brave_stats_updater.cc
+++ b/browser/brave_stats/brave_stats_updater.cc
@@ -152,6 +152,14 @@ BraveStatsUpdater::BraveStatsUpdater(PrefService* pref_service,
     : pref_service_(pref_service),
       profile_manager_(profile_manager),
       testing_url_loader_factory_(nullptr) {
+  // Observe `BraveOriginPolicyManager` so we can defer the boot ping until
+  // its policies have been merged into local state. `AddObserver` fires
+  // `OnBravePoliciesReady` immediately if the manager is already initialised,
+  // so construction order between this service and the manager doesn't
+  // matter.
+  policy_manager_observation_.Observe(
+      brave_origin::BraveOriginPolicyManager::GetInstance());
+
   const base::CommandLine& command_line =
       *base::CommandLine::ForCurrentProcess();
   if (command_line.HasSwitch(switches::kBraveStatsUpdaterServer)) {
@@ -337,6 +345,28 @@ void BraveStatsUpdater::OnReferralInitialization() {
 void BraveStatsUpdater::StartServerPingStartupTimer() {
   stats_preconditions_barrier_.Reset();
   stats_startup_complete_ = true;
+  MaybeStartStartupTimer();
+}
+
+void BraveStatsUpdater::OnBravePoliciesReady() {
+  // `AddObserver` may fire this synchronously (if the manager was already
+  // initialised when we attached), and `BraveOriginPolicyManager` may notify
+  // again later. The startup-timer path must run at most once.
+  if (brave_policies_ready_) {
+    return;
+  }
+  brave_policies_ready_ = true;
+  MaybeStartStartupTimer();
+}
+
+void BraveStatsUpdater::MaybeStartStartupTimer() {
+  // Both gates must have fired: referrals barrier resolved
+  // (`stats_startup_complete_`) and Brave Origin policies merged into local
+  // state (`brave_policies_ready_`). Whichever finishes last actually starts
+  // the timer.
+  if (!stats_startup_complete_ || !brave_policies_ready_) {
+    return;
+  }
   server_ping_startup_timer_->Start(
       FROM_HERE, base::Seconds(kUpdateServerStartupPingDelaySeconds), this,
       &BraveStatsUpdater::OnServerPingTimerFired);

--- a/browser/brave_stats/brave_stats_updater.h
+++ b/browser/brave_stats/brave_stats_updater.h
@@ -15,6 +15,8 @@
 #include "base/memory/weak_ptr.h"
 #include "base/scoped_observation.h"
 #include "brave/browser/brave_stats/buildflags.h"
+#include "brave/components/brave_origin/brave_origin_policy_manager.h"
+#include "brave/components/brave_policy/brave_policy_observer.h"
 #include "chrome/browser/profiles/profile_manager_observer.h"
 #include "services/network/public/cpp/shared_url_loader_factory.h"
 #include "url/gurl.h"
@@ -55,7 +57,8 @@ inline constexpr char kP3ADailyPingHistogramName[] = "Brave.Core.UsageDaily";
 
 class BraveStatsUpdaterParams;
 
-class BraveStatsUpdater : public ProfileManagerObserver {
+class BraveStatsUpdater : public ProfileManagerObserver,
+                          public brave_policy::BravePolicyObserver {
  public:
   BraveStatsUpdater(PrefService* pref_service, ProfileManager* profile_manager);
   BraveStatsUpdater(const BraveStatsUpdater&) = delete;
@@ -90,6 +93,11 @@ class BraveStatsUpdater : public ProfileManagerObserver {
   void OnReferralInitialization();
 
   void StartServerPingStartupTimer();
+  // Fires only when both `stats_startup_complete_` (referrals barrier
+  // resolved) and `brave_policies_ready_` (Brave Origin policies merged) are
+  // true. Either path is allowed to be first; the second one's call actually
+  // starts the timer.
+  void MaybeStartStartupTimer();
   void QueueServerPing();
   void SendServerPing();
 
@@ -97,6 +105,9 @@ class BraveStatsUpdater : public ProfileManagerObserver {
 
   // ProfileManagerObserver:
   void OnProfileAdded(Profile* profile) override;
+
+  // brave_policy::BravePolicyObserver:
+  void OnBravePoliciesReady() override;
 
   network::mojom::URLLoaderFactory* GetURLLoaderFactory();
 
@@ -115,6 +126,16 @@ class BraveStatsUpdater : public ProfileManagerObserver {
   scoped_refptr<network::SharedURLLoaderFactory> testing_url_loader_factory_;
 
   std::unique_ptr<misc_metrics::GeneralBrowserUsage> general_browser_usage_p3a_;
+
+  // True once `OnBravePoliciesReady` has been observed. `AddObserver` fires
+  // it synchronously when the manager is already initialised, so this can be
+  // true even before the ctor finishes. Subsequent firings are idempotent.
+  bool brave_policies_ready_ = false;
+
+  base::ScopedObservation<brave_origin::BraveOriginPolicyManager,
+                          brave_policy::BravePolicyObserver>
+      policy_manager_observation_{this};
+
   base::WeakPtrFactory<BraveStatsUpdater> weak_ptr_factory_{this};
 };
 


### PR DESCRIPTION
`BraveStatsUpdater` is a browser-process singleton; its 3-second startup timer reads `kStatsReportingEnabled` without synchronising against `BraveOriginPolicyManager`. Make the updater observe the manager directly and defer the timer behind a two-phase gate (referrals barrier + `OnBravePoliciesReady`), so the startup ping cannot fire before the policy bundle is merged into local state.

Resolves: https://github.com/brave/brave-browser/issues/55811

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
