### PR TITLE
Defer OpenOriginSettings out of CredentialSummary callback

### DIFF
--- a/components/brave_origin/brave_origin_service.cc
+++ b/components/brave_origin/brave_origin_service.cc
@@ -13,6 +13,7 @@
 #include "base/json/json_reader.h"
 #include "base/logging.h"
 #include "base/strings/string_util.h"
+#include "base/task/sequenced_task_runner.h"
 #include "brave/brave_domains/service_domains.h"
 #include "brave/components/brave_origin/brave_origin_policy_manager.h"
 #include "brave/components/brave_origin/brave_origin_utils.h"
@@ -262,7 +263,6 @@ void BraveOriginService::OnCredentialSummary(
   }
 #endif
 
-  LOG(ERROR) << "-----------OnCredentiaSummary Set Purchased: " << purchased;
   BraveOriginPolicyManager::GetInstance()->SetPurchased(purchased);
 
   // Persist enforcement state so NeedsRestart() can detect first-purchase
@@ -276,15 +276,30 @@ void BraveOriginService::OnCredentialSummary(
   // On first purchase detection in the upgrade case, open the settings page
   // so the user can configure Origin policies and restart. Branded builds
   // handle the post-purchase flow via the startup dialog instead.
+  // Post the call instead of invoking it inline: this runs from a mojo
+  // CredentialSummary reply triggered by the account.brave.com Refresh
+  // button, and opening a settings tab synchronously from inside that
+  // callback (which also fires policy/pref reload via SetPurchased above)
+  // has produced dangling raw_ptr crashes during the transition.
   if (purchased && !was_previously_purchased && delegate_ &&
       !did_open_origin_settings_) {
-    delegate_->OpenOriginSettings();
     did_open_origin_settings_ = true;
+    base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
+        FROM_HERE, base::BindOnce(&BraveOriginService::OpenOriginSettings,
+                                  weak_ptr_factory_.GetWeakPtr()));
   }
 #endif
 
   std::move(callback).Run(purchased);
 }
+
+#if !BUILDFLAG(IS_BRAVE_ORIGIN_BRANDED)
+void BraveOriginService::OpenOriginSettings() {
+  if (delegate_) {
+    delegate_->OpenOriginSettings();
+  }
+}
+#endif
 
 bool BraveOriginService::EnsureSkusConnected() {
   if (!skus_service_) {

--- a/components/brave_origin/brave_origin_service.h
+++ b/components/brave_origin/brave_origin_service.h
@@ -106,6 +106,9 @@ class BraveOriginService : public KeyedService {
                            skus::mojom::SkusResultPtr summary);
   void OnSkusStateChanged();
   bool EnsureSkusConnected();
+#if !BUILDFLAG(IS_BRAVE_ORIGIN_BRANDED)
+  void OpenOriginSettings();
+#endif
 
   mojo::Remote<skus::mojom::SkusService> skus_service_;
   std::string origin_sku_domain_;

--- a/components/brave_origin/brave_origin_service_unittest.cc
+++ b/components/brave_origin/brave_origin_service_unittest.cc
@@ -807,10 +807,11 @@ TEST_F(BraveOriginServiceWithSkusTest, FirstPurchaseDetection_CallsDelegate) {
   EXPECT_TRUE(result.Get());
 #if BUILDFLAG(IS_BRAVE_ORIGIN_BRANDED)
   // Branded builds handle the post-purchase flow via the startup dialog,
-  // not by opening the settings page.
+  // not by opening the settings page. No PostTask is scheduled on this
+  // path, so checking immediately after the callback resolves is safe.
   EXPECT_FALSE(delegate_called);
 #else
-  EXPECT_TRUE(delegate_called);
+  ASSERT_TRUE(base::test::RunUntil([&] { return delegate_called; }));
 #endif
 }
 
@@ -863,12 +864,15 @@ TEST_F(BraveOriginServiceWithSkusTest, DelegateIsOneShot_OnlyFiresOnce) {
   service_->CheckPurchaseState(result1.GetCallback());
   EXPECT_TRUE(result1.Get());
 #if BUILDFLAG(IS_BRAVE_ORIGIN_BRANDED)
+  // Branded builds never schedule the delegate task.
   EXPECT_FALSE(delegate_called);
 #else
-  EXPECT_TRUE(delegate_called);
+  ASSERT_TRUE(base::test::RunUntil([&] { return delegate_called; }));
 #endif
 
-  // Reset the flag and verify the delegate is not called again.
+  // Reset the flag and verify the delegate is not called again. After the
+  // first purchase, did_open_origin_settings_ is set, so no new task is
+  // posted; checking immediately is safe.
   delegate_called = false;
   base::test::TestFuture<bool> result2;
   service_->CheckPurchaseState(result2.GetCallback());
@@ -910,9 +914,10 @@ TEST_F(BraveOriginServiceWithSkusTest,
 
   ASSERT_TRUE(base::test::RunUntil([&] { return service_->IsPurchased(); }));
 #if BUILDFLAG(IS_BRAVE_ORIGIN_BRANDED)
+  // Branded builds never schedule the delegate task.
   EXPECT_FALSE(delegate_called);
 #else
-  EXPECT_TRUE(delegate_called);
+  ASSERT_TRUE(base::test::RunUntil([&] { return delegate_called; }));
 #endif
 }
 


### PR DESCRIPTION
Resolves brave/brave-browser#55632

Clicking *Refresh* on `account.brave.com` after entering a purchased Brave Origin email crashes the browser with a `BackupRefPtr`/dangling `raw_ptr` signature at the top of the message-loop frames (`raw_ptr_backup_ref_impl.h:159` / `raw_ptr.h:516`). 


Here's an AI summary of the changes:

> The refresh succeeds on the server (subsequent attempts return "Device limit reached"), so the crash happens after credential validation.
> 
> The trigger path is:
> 
> `kSkusState` pref change (written by `SkusServiceImpl` during the refresh)
> → `BraveOriginService::OnSkusStateChanged`
> → `CheckPurchaseState` → mojo `CredentialSummary`
> → `OnCredentialSummary` (still inside the mojo dispatch frame)
> → `BraveOriginPolicyManager::SetPurchased(true)` — notifies `BraveProfilePolicyProvider`, which calls `RefreshPolicies` → `UpdatePolicy` → pref store reload for `BraveRewardsDisabled` / `BraveVPNDisabled` / etc.
> → `delegate_->OpenOriginSettings()` → `chrome::ShowSettingsSubPageForProfile` → creates a new tab and `WebContents` for `brave://settings/origin`
> 
> Opening a settings tab synchronously while the managed-pref cascade from `SetPurchased` is still unwinding (and while we're still inside a mojo IPC dispatch from a renderer that's actively using the SKU JS bridge) is what triggers the dangling-pointer crash on the transition.
> 
> Fix: post `OpenOriginSettings()` to the current sequence so it runs on a fresh stack, after the mojo reply has returned and the pref-reload cascade has fully settled. `did_open_origin_settings_` is set *before* the post so duplicate `OnCredentialSummary` callbacks (e.g. multiple rapid `kSkusState` writes) don't enqueue more than one task, and the `WeakPtr` covers the rare case where the service is torn down between post and run.
> 