### PR TITLE
Fix TabStripModelBrowserTest.TestCloseTabDuringMoveOperation failure on Linux nightly

### DIFF
--- a/chromium_src/chrome/browser/ui/tabs/tab_strip_model_browsertest.cc
+++ b/chromium_src/chrome/browser/ui/tabs/tab_strip_model_browsertest.cc
@@ -1,0 +1,23 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "base/dcheck_is_on.h"
+
+// In official builds without DCHECKs, CHECK() discards its log message
+// (base/check.h CHECK_WILL_STREAM is false). The death test for
+// TestCloseTabDuringMoveOperation expects "Check failed" in the subprocess
+// stderr, which never appears, causing the regex match to fail.
+// We disable it by pre-defining the token that the upstream MAYBE_ macro
+// resolves to on non-ChromeOS builds so the two-step expansion produces
+// DISABLED_TestCloseTabDuringMoveOperation instead.
+#if defined(OFFICIAL_BUILD) && !DCHECK_IS_ON()
+#define TestCloseTabDuringMoveOperation DISABLED_TestCloseTabDuringMoveOperation
+#endif
+
+#include <chrome/browser/ui/tabs/tab_strip_model_browsertest.cc>  // IWYU pragma: export
+
+#if defined(OFFICIAL_BUILD) && !DCHECK_IS_ON()
+#undef TestCloseTabDuringMoveOperation
+#endif


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Issue: https://github.com/brave/brave-browser/issues/55769

#### What the failure log means

```
../../chrome/browser/ui/tabs/tab_strip_model_browsertest.cc:524: Failure
Death test: tab_strip_model->MoveWebContentsAt(0, 1, false)
    Result: died but not with expected error.
  Expected: contains regular expression "Check failed"
Actual msg:
[  DEATH   ] [3153726:3153726:WARNING:base/test/test_suite.cc:760] Test launcher output path /tmp/scoped_diruV2G2X/resultsKAi4yl/test_results.xml exists. Not adding test launcher result printer.
[  DEATH   ] [3153766:3153766:0523/060137.391404:WARNING:sandbox/policy/linux/sandbox_linux.cc:404] InitializeSandbox() called with multiple threads in process gpu-process.
[  DEATH   ] [3153766:3153766:0523/060137.393185:WARNING:ui/gfx/linux/gbm_support_x11.cc:48] dri3 extension not supported.
[  DEATH   ] [3153726:3153726:0523/060137.481532:WARNING:ui/base/idle/idle_linux.cc:111] None of the known D-Bus ScreenSaver services could be used.
[  DEATH   ] [3153726:3153726:0523/060137.487955:ERROR:dbus/object_proxy.cc:572] Failed to call method: org.freedesktop.DBus.Properties.Get: object_path= /org/freedesktop/portal/desktop: org.freedesktop.DBus.Error.InvalidArgs: No such interface “org.freedesktop.portal.FileChooser”
[  DEATH   ] [0523/060137.496102:ERROR:third_party/crashpad/crashpad/snapshot/elf/elf_dynamic_array_reader.h:64] tag not found
[  DEATH   ] [0523/060137.504234:ERROR:third_party/crashpad/crashpad/util/file/file_io_posix.cc:145] open /sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq: No such file or directory (2)
[  DEATH   ] [0523/060137.504251:ERROR:third_party/crashpad/crashpad/util/file/file_io_posix.cc:145] open /sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq: No such file or directory (2)
[  DEATH   ] 
```

  EXPECT_DEATH_IF_SUPPORTED forks a subprocess to run the expression and regex-matches its stderr against "Check failed". The subprocess did crash (crashpad took over, a stack trace is present), but it produced no
  "Check failed" text — only standard browser-startup log lines, crashpad diagnostics, and a raw stack trace. That mismatch is the failure.

####  Why it happens

The test is checking that calling `CloseWebContentsAt` from inside a `TabStripModelObserver::OnTabStripModelChanged(kMoved)` callback triggers the reentrancy guard:

```
  // tab_strip_model.cc
  void TabStripModel::CloseWebContentsAt(int index, uint32_t close_types) {
    ReentrancyCheck::ValidateNotReentrant(&reentrancy_guard_);  // ← should CHECK-fail
    ...
  }
```

Normally CHECK(!*guard_flag) prints "Check failed: !*guard_flag." to stderr and then aborts. But Chromium's base/check.h has two implementations of CHECK:

```
  // base/check.h:248-265
  #if defined(OFFICIAL_BUILD) && !DCHECK_IS_ON()
    // Strip log strings entirely to reduce binary size.
    #define CHECK_WILL_STREAM() false
    [[noreturn]] void CheckFailure() { base::ImmediateCrash(); }
    #define CHECK_INTERNAL_IMPL(cond) \
      DISCARDING_CHECK_FUNCTION_IMPL(::logging::CheckFailure(), cond)
  #else
    // Log "Check failed: <cond>" then abort.
    #define CHECK_WILL_STREAM() true
    #define CHECK_INTERNAL_IMPL(cond) \
      LOGGING_CHECK_FUNCTION_IMPL(::logging::CheckNoreturnError::Check(#cond), cond)
  #endif
```

  In Brave's nightly Linux release build:
  - is_official_build = true → OFFICIAL_BUILD is defined
  - is_debug = false → NDEBUG is defined
  - dcheck_always_on is not set for release builds (build/config/dcheck_always_on.gni: dcheck_always_on = build_with_chromium && !is_official_build) → DCHECK_IS_ON() is false

  So the condition defined(OFFICIAL_BUILD) && !DCHECK_IS_ON() is true, and CHECK becomes a bare ImmediateCrash() — a ud2/SIGTRAP with no log output at all. The subprocess crashes but its stderr is empty of "Check failed", so the death-test regex fails.

Upstream already knew about this: tab_strip_model_browsertest.cc disables the test on GOOGLE_CHROME_BRANDING && IS_CHROMEOS (Chrome's linux-chromeos-chrome bot, which has the same official+no-dcheck configuration). It didn't cover Brave's Linux nightly.

 ### Fix

Add a chromium_src override that pre-defines the test name token to its DISABLED_ variant when OFFICIAL_BUILD && !DCHECK_IS_ON().

  The upstream code is:
```
  #if BUILDFLAG(GOOGLE_CHROME_BRANDING) && BUILDFLAG(IS_CHROMEOS)
  #define MAYBE_TestCloseTabDuringMoveOperation DISABLED_TestCloseTabDuringMoveOperation
  #else
  #define MAYBE_TestCloseTabDuringMoveOperation TestCloseTabDuringMoveOperation  // ← resolves here on Brave Linux
  #endif
  IN_PROC_BROWSER_TEST_F(TabStripModelBrowserTest, MAYBE_TestCloseTabDuringMoveOperation)
```
  Our override pre-defines TestCloseTabDuringMoveOperation → DISABLED_TestCloseTabDuringMoveOperation before including the upstream file. The preprocessor then chains the two expansions:

  MAYBE_TestCloseTabDuringMoveOperation
    → TestCloseTabDuringMoveOperation        (upstream #else branch)
    → DISABLED_TestCloseTabDuringMoveOperation  (our pre-define)

  Using defined(OFFICIAL_BUILD) && !DCHECK_IS_ON() (not just !DCHECK_IS_ON()) is intentional — it matches exactly the CHECK_WILL_STREAM() == false condition in base/check.h. Non-official release builds (e.g. local
  component builds with is_debug=false) still have CHECK_WILL_STREAM() == true, so the test remains enabled and useful there and on PR builders.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
