### PR TITLE
[Sidebar V2] Update panel border and resize strip positioning

### DIFF
--- a/browser/ui/sidebar/BUILD.gn
+++ b/browser/ui/sidebar/BUILD.gn
@@ -105,6 +105,7 @@ source_set("browser_tests") {
     "//chrome/browser/profiles:profile",
     "//chrome/browser/search_engines",
     "//chrome/browser/ui",
+    "//chrome/browser/ui:layout_constants",
     "//chrome/browser/ui:ui_features",
     "//chrome/browser/ui/browser_window",
     "//chrome/browser/ui/side_panel:side_panel_views_dependent",

--- a/browser/ui/sidebar/sidebar_browsertest.cc
+++ b/browser/ui/sidebar/sidebar_browsertest.cc
@@ -2179,10 +2179,10 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, SidebarV2BraveHeaderTest) {
 }
 
 // Verify that the resize area is positioned correctly for both border states.
-// With border: the resize area sits inside the border inset strip (its width
-// equals the border inset and it starts at x=0).
-// Without border: the resize area is a narrow kNoBorderResizeAreaWidth strip
-// placed at the inner edge facing the web content.
+// In both cases the strip starts at the panel's outer edge with width
+// kResizeStripWidth. Border state only affects z-order: without rounded
+// corners the strip is reordered to the top so it wins the hit-test over
+// the overlapping content edge.
 IN_PROC_BROWSER_TEST_F(SidebarBrowserTest,
                        SidebarV2ResizeAreaPositionMatchesBorderState) {
   auto* panel_ui = browser()->GetFeatures().side_panel_ui();
@@ -2200,48 +2200,42 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest,
   auto* resize_area = side_panel->resize_area_for_testing();
   ASSERT_TRUE(resize_area);
 
-  // --- Border case (rounded corners ON) ---
-  prefs->SetBoolean(kWebViewRoundedCorners, true);
-  RunScheduledLayouts();
-  EXPECT_GT(side_panel->GetInsets().width(), 0)
-      << "panel should have left/right insets";
-
-  // In the bordered case the resize strip sits in the gap between the panel
-  // edge and the content, at the left edge (panel is on the right in LTR).
-  // Check resize area and panel's screen bounds.origin().
-  EXPECT_EQ(resize_area->GetBoundsInScreen().origin(),
-            side_panel->GetBoundsInScreen().origin())
-      << "Bordered resize area right edge should align with content origin";
-  EXPECT_EQ(resize_area->width(), side_panel->GetInsets().left())
-      << "Bordered resize area width should match the left border inset";
-  EXPECT_EQ(side_panel->GetIndexOf(resize_area),
-            side_panel->children().size() - 1)
-      << "resize area should be the top-most view";
-
-  // --- No-border case (rounded corners OFF) ---
-  prefs->SetBoolean(kWebViewRoundedCorners, false);
-  RunScheduledLayouts();
-  EXPECT_EQ(0, side_panel->GetInsets().width());
-
-  // Shared assertions for the no-border state after a panel switch.
-  auto verify_no_border_state = [&](const base::Location& loc) {
+  // Verifies resize strip position, width, z-order, and panel insets for the
+  // given border mode. Panel is on the right in LTR, so the content-facing
+  // edge is left and the outer edge is right.
+  auto verify_state = [&](const base::Location& loc, bool rounded_corners) {
     SCOPED_TRACE(loc.ToString());
-    EXPECT_EQ(0, side_panel->GetInsets().width())
-        << "Border insets' width should stay empty after switching panels "
-           "(border OFF)";
+    if (rounded_corners) {
+      EXPECT_EQ(0, side_panel->GetInsets().left())
+          << "rounded: no content-side inset (content view owns its margin)";
+      EXPECT_EQ(kRoundedCornersContentsViewMargin,
+                side_panel->GetInsets().right())
+          << "rounded: outer-side gap for visual separation from window chrome";
+    } else {
+      EXPECT_EQ(1, side_panel->GetInsets().left())
+          << "plain: 1px separator on the content-facing side";
+      EXPECT_EQ(0, side_panel->GetInsets().right())
+          << "plain: no outer-side inset";
+    }
     EXPECT_EQ(resize_area->GetBoundsInScreen().origin(),
               side_panel->GetBoundsInScreen().origin())
-        << "No-border resize area should be placed at the inner edge of "
-           "content";
+        << "resize strip should sit at the panel's outer edge";
     EXPECT_EQ(resize_area->width(),
-              views::BraveSidePanelResizeArea::kNoBorderResizeAreaWidth)
-        << "No-border resize area width should equal kNoBorderResizeAreaWidth";
+              views::BraveSidePanelResizeArea::kResizeStripWidth)
+        << "resize strip width should equal kResizeStripWidth";
     EXPECT_EQ(side_panel->GetIndexOf(resize_area),
               side_panel->children().size() - 1)
-        << "resize area should be the top-most view";
+        << "resize strip should be the top-most child view";
   };
 
-  // --- Panel-switch: border OFF must survive switching panels ---
+  prefs->SetBoolean(kWebViewRoundedCorners, true);
+  RunScheduledLayouts();
+  verify_state(FROM_HERE, /*rounded_corners=*/true);
+
+  prefs->SetBoolean(kWebViewRoundedCorners, false);
+  RunScheduledLayouts();
+  verify_state(FROM_HERE, /*rounded_corners=*/false);
+
   // Switch to another panel that has brave panel header.
   panel_ui->Show(SidePanelEntryId::kBookmarks);
   ASSERT_TRUE(base::test::RunUntil([&]() {
@@ -2249,7 +2243,7 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest,
         SidePanelEntry::Key(SidePanelEntryId::kBookmarks));
   }));
   RunScheduledLayouts();
-  verify_no_border_state(FROM_HERE);
+  verify_state(FROM_HERE, /*rounded_corners=*/false);
 
   // Switch to another panel that doesn't have brave panel header.
   panel_ui->Show(SidePanelEntryId::kCustomizeChrome);
@@ -2258,7 +2252,7 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest,
         SidePanelEntry::Key(SidePanelEntryId::kCustomizeChrome));
   }));
   RunScheduledLayouts();
-  verify_no_border_state(FROM_HERE);
+  verify_state(FROM_HERE, /*rounded_corners=*/false);
 }
 
 // Regression test: the top container separator must remain visible when a side

--- a/browser/ui/sidebar/sidebar_browsertest.cc
+++ b/browser/ui/sidebar/sidebar_browsertest.cc
@@ -2204,7 +2204,8 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest,
   // Verifies resize strip position, width, z-order, and panel insets for the
   // given border mode. Panel is on the right in LTR, so the content-facing
   // edge is left and the outer edge is right.
-  auto verify_state = [&](const base::Location& loc, bool rounded_corners) {
+  auto verify_state = [&](bool rounded_corners,
+                          const base::Location& loc = FROM_HERE) {
     SCOPED_TRACE(loc.ToString());
     if (rounded_corners) {
       EXPECT_EQ(0, side_panel->GetInsets().left())
@@ -2231,11 +2232,11 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest,
 
   prefs->SetBoolean(kWebViewRoundedCorners, true);
   RunScheduledLayouts();
-  verify_state(FROM_HERE, /*rounded_corners=*/true);
+  verify_state(true);
 
   prefs->SetBoolean(kWebViewRoundedCorners, false);
   RunScheduledLayouts();
-  verify_state(FROM_HERE, /*rounded_corners=*/false);
+  verify_state(false);
 
   // Switch to another panel that has brave panel header.
   panel_ui->Show(SidePanelEntryId::kBookmarks);
@@ -2244,7 +2245,7 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest,
         SidePanelEntry::Key(SidePanelEntryId::kBookmarks));
   }));
   RunScheduledLayouts();
-  verify_state(FROM_HERE, /*rounded_corners=*/false);
+  verify_state(false);
 
   // Switch to another panel that doesn't have brave panel header.
   panel_ui->Show(SidePanelEntryId::kCustomizeChrome);
@@ -2253,7 +2254,7 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest,
         SidePanelEntry::Key(SidePanelEntryId::kCustomizeChrome));
   }));
   RunScheduledLayouts();
-  verify_state(FROM_HERE, /*rounded_corners=*/false);
+  verify_state(false);
 }
 
 // Verify that the panel border insets follow the sidebar's horizontal
@@ -2275,8 +2276,8 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest,
 
   // When right-aligned the content-facing edge is the left and the outer edge
   // is the right; when left-aligned the two are mirrored.
-  auto verify_state = [&](const base::Location& loc, bool right_aligned,
-                          bool rounded_corners) {
+  auto verify_state = [&](bool right_aligned, bool rounded_corners,
+                          const base::Location& loc = FROM_HERE) {
     SCOPED_TRACE(loc.ToString());
     const gfx::Insets insets = side_panel->GetInsets();
     const int content_side = right_aligned ? insets.left() : insets.right();
@@ -2297,11 +2298,11 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest,
   ASSERT_TRUE(side_panel->IsRightAligned());
   prefs->SetBoolean(kWebViewRoundedCorners, true);
   RunScheduledLayouts();
-  verify_state(FROM_HERE, /*right_aligned=*/true, /*rounded_corners=*/true);
+  verify_state(/*right_aligned=*/true, /*rounded_corners=*/true);
 
   prefs->SetBoolean(kWebViewRoundedCorners, false);
   RunScheduledLayouts();
-  verify_state(FROM_HERE, /*right_aligned=*/true, /*rounded_corners=*/false);
+  verify_state(/*right_aligned=*/true, /*rounded_corners=*/false);
 
   // Flip to left-aligned while visible. This drives
   // UpdateSideBarHorizontalAlignment() -> SidePanel::UpdateBorder().
@@ -2310,18 +2311,18 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest,
 
   prefs->SetBoolean(kWebViewRoundedCorners, true);
   RunScheduledLayouts();
-  verify_state(FROM_HERE, /*right_aligned=*/false, /*rounded_corners=*/true);
+  verify_state(/*right_aligned=*/false, /*rounded_corners=*/true);
 
   prefs->SetBoolean(kWebViewRoundedCorners, false);
   RunScheduledLayouts();
-  verify_state(FROM_HERE, /*right_aligned=*/false, /*rounded_corners=*/false);
+  verify_state(/*right_aligned=*/false, /*rounded_corners=*/false);
 
   // Flip back to right-aligned while visible to exercise the reverse
   // transition.
   prefs->SetBoolean(prefs::kSidePanelHorizontalAlignment, true);
   ASSERT_TRUE(side_panel->IsRightAligned());
   RunScheduledLayouts();
-  verify_state(FROM_HERE, /*right_aligned=*/true, /*rounded_corners=*/false);
+  verify_state(/*right_aligned=*/true, /*rounded_corners=*/false);
 }
 
 // Regression test: the top container separator must remain visible when a side

--- a/browser/ui/sidebar/sidebar_browsertest.cc
+++ b/browser/ui/sidebar/sidebar_browsertest.cc
@@ -58,6 +58,7 @@
 #include "chrome/browser/ui/browser_finder.h"
 #include "chrome/browser/ui/browser_window.h"
 #include "chrome/browser/ui/browser_window/public/browser_window_features.h"
+#include "chrome/browser/ui/layout_constants.h"
 #include "chrome/browser/ui/side_panel/side_panel_entry.h"
 #include "chrome/browser/ui/side_panel/side_panel_registry.h"
 #include "chrome/browser/ui/side_panel/side_panel_ui.h"
@@ -2253,6 +2254,74 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest,
   }));
   RunScheduledLayouts();
   verify_state(FROM_HERE, /*rounded_corners=*/false);
+}
+
+// Verify that the panel border insets follow the sidebar's horizontal
+// alignment. Flipping kSidePanelHorizontalAlignment runs through
+// BraveBrowserView::UpdateSideBarHorizontalAlignment(), which calls
+// SidePanel::UpdateBorder(). The content-facing edge owns the separator/margin
+// and the outer edge owns the rounded-corner gap, so left alignment is the
+// mirror image of the default right alignment.
+IN_PROC_BROWSER_TEST_F(SidebarBrowserTest,
+                       SidebarV2BorderInsetsFollowAlignment) {
+  auto* panel_ui = browser()->GetFeatures().side_panel_ui();
+  auto* browser_view = BrowserView::GetBrowserViewForBrowser(browser());
+  auto* side_panel = browser_view->side_panel();
+  side_panel->DisableAnimationsForTesting();
+  auto* prefs = browser()->profile()->GetPrefs();
+
+  panel_ui->Toggle();
+  ASSERT_TRUE(base::test::RunUntil([&]() { return side_panel->GetVisible(); }));
+
+  // When right-aligned the content-facing edge is the left and the outer edge
+  // is the right; when left-aligned the two are mirrored.
+  auto verify_state = [&](const base::Location& loc, bool right_aligned,
+                          bool rounded_corners) {
+    SCOPED_TRACE(loc.ToString());
+    const gfx::Insets insets = side_panel->GetInsets();
+    const int content_side = right_aligned ? insets.left() : insets.right();
+    const int outer_side = right_aligned ? insets.right() : insets.left();
+    if (rounded_corners) {
+      EXPECT_EQ(0, content_side)
+          << "rounded: no content-side inset (content view owns its margin)";
+      EXPECT_EQ(kRoundedCornersContentsViewMargin, outer_side)
+          << "rounded: outer-side gap for visual separation from window chrome";
+    } else {
+      EXPECT_EQ(1, content_side)
+          << "plain: 1px separator on the content-facing side";
+      EXPECT_EQ(0, outer_side) << "plain: no outer-side inset";
+    }
+  };
+
+  // Default: right-aligned.
+  ASSERT_TRUE(side_panel->IsRightAligned());
+  prefs->SetBoolean(kWebViewRoundedCorners, true);
+  RunScheduledLayouts();
+  verify_state(FROM_HERE, /*right_aligned=*/true, /*rounded_corners=*/true);
+
+  prefs->SetBoolean(kWebViewRoundedCorners, false);
+  RunScheduledLayouts();
+  verify_state(FROM_HERE, /*right_aligned=*/true, /*rounded_corners=*/false);
+
+  // Flip to left-aligned while visible. This drives
+  // UpdateSideBarHorizontalAlignment() -> SidePanel::UpdateBorder().
+  prefs->SetBoolean(prefs::kSidePanelHorizontalAlignment, false);
+  ASSERT_FALSE(side_panel->IsRightAligned());
+
+  prefs->SetBoolean(kWebViewRoundedCorners, true);
+  RunScheduledLayouts();
+  verify_state(FROM_HERE, /*right_aligned=*/false, /*rounded_corners=*/true);
+
+  prefs->SetBoolean(kWebViewRoundedCorners, false);
+  RunScheduledLayouts();
+  verify_state(FROM_HERE, /*right_aligned=*/false, /*rounded_corners=*/false);
+
+  // Flip back to right-aligned while visible to exercise the reverse
+  // transition.
+  prefs->SetBoolean(prefs::kSidePanelHorizontalAlignment, true);
+  ASSERT_TRUE(side_panel->IsRightAligned());
+  RunScheduledLayouts();
+  verify_state(FROM_HERE, /*right_aligned=*/true, /*rounded_corners=*/false);
 }
 
 // Regression test: the top container separator must remain visible when a side

--- a/browser/ui/views/frame/brave_browser_view.cc
+++ b/browser/ui/views/frame/brave_browser_view.cc
@@ -437,6 +437,11 @@ void BraveBrowserView::UpdateSideBarHorizontalAlignment() {
   const bool on_left = !GetProfile()->GetPrefs()->GetBoolean(
       prefs::kSidePanelHorizontalAlignment);
 
+#if BUILDFLAG(ENABLE_SIDEBAR_V2)
+  // Panel has different border per horizontal alignment.
+  side_panel_->UpdateBorder();
+#endif
+
   sidebar_container_view_->SetSidebarOnLeft(on_left);
 
   if (multi_contents_view_ &&

--- a/browser/ui/views/frame/brave_browser_view.cc
+++ b/browser/ui/views/frame/brave_browser_view.cc
@@ -440,7 +440,7 @@ void BraveBrowserView::UpdateSideBarHorizontalAlignment() {
 #if BUILDFLAG(ENABLE_SIDEBAR_V2)
   // Panel has different border per horizontal alignment.
   side_panel_->UpdateBorder();
-#endif
+#endif  // BUILDFLAG(ENABLE_SIDEBAR_V2)
 
   sidebar_container_view_->SetSidebarOnLeft(on_left);
 

--- a/browser/ui/views/side_panel/brave_side_panel_resize_area.cc
+++ b/browser/ui/views/side_panel/brave_side_panel_resize_area.cc
@@ -13,41 +13,28 @@ namespace views {
 
 BraveSidePanelResizeArea::~BraveSidePanelResizeArea() = default;
 
-gfx::Rect BraveSidePanelResizeArea::GetNoBorderResizeBounds(
+gfx::Rect BraveSidePanelResizeArea::GetResizeStripBounds(
     bool panel_on_right,
     const gfx::Rect& panel_bounds) const {
   if (panel_on_right) {
-    // Panel is on the right → resize strip sits at the left (inner) edge.
-    return gfx::Rect(panel_bounds.x(), panel_bounds.y(),
-                     kNoBorderResizeAreaWidth, panel_bounds.height());
+    // Panel is on the right → strip sits at the left (content-facing) edge.
+    return gfx::Rect(panel_bounds.x(), panel_bounds.y(), kResizeStripWidth,
+                     panel_bounds.height());
   }
-  // Panel is on the left → resize strip sits at the right (inner) edge.
-  return gfx::Rect(panel_bounds.right() - kNoBorderResizeAreaWidth,
-                   panel_bounds.y(), kNoBorderResizeAreaWidth,
-                   panel_bounds.height());
+  // Panel is on the left → strip sits at the right (content-facing) edge.
+  return gfx::Rect(panel_bounds.right() - kResizeStripWidth, panel_bounds.y(),
+                   kResizeStripWidth, panel_bounds.height());
 }
 
 void BraveSidePanelResizeArea::Layout(PassKey) {
-  // Upstream puts resize area over the left or right border.
-  // If it doesn't have left or right border, we should put over the contents.
-  // Check only horizontal insets — top insets may be non-zero when a panel
-  // header is present, so IsEmpty() would incorrectly treat a header-only inset
-  // as a side border.
-  if (side_panel_->GetInsets().width() != 0) {
-    // Parent has a border: resize area sits in the border gap between the
-    // panel edge and the content area. Delegate entirely to upstream.
-    LayoutSuperclass<SidePanelResizeArea>(this);
-    return;
-  }
-
-  // No border: content fills the full panel. Position this view as a
-  // narrow strip at the inner edge of the panel so it overlaps the content
-  // and can capture mouse events.
+  // Upstream puts resize strip over the padding but we don't have enough
+  // padding for it. Put resize strip over the local bound at the fixed
+  // position.
   const bool panel_on_right =
       (side_panel_->IsRightAligned() && !base::i18n::IsRTL()) ||
       (!side_panel_->IsRightAligned() && base::i18n::IsRTL());
   SetBoundsRect(
-      GetNoBorderResizeBounds(panel_on_right, side_panel_->GetLocalBounds()));
+      GetResizeStripBounds(panel_on_right, side_panel_->GetLocalBounds()));
 }
 
 BEGIN_METADATA(BraveSidePanelResizeArea)

--- a/browser/ui/views/side_panel/brave_side_panel_resize_area.h
+++ b/browser/ui/views/side_panel/brave_side_panel_resize_area.h
@@ -11,8 +11,9 @@
 
 namespace views {
 
-// Custom SidePanelResizeArea to adjust its position based on the presence
-// of panel border.
+// Overrides SidePanelResizeArea to always place the resize strip at the
+// panel's local edge, overlapping the content rather than occupying a
+// dedicated border gap.
 class BraveSidePanelResizeArea : public SidePanelResizeArea {
   METADATA_HEADER(BraveSidePanelResizeArea, SidePanelResizeArea)
 
@@ -20,15 +21,15 @@ class BraveSidePanelResizeArea : public SidePanelResizeArea {
   using SidePanelResizeArea::SidePanelResizeArea;
   ~BraveSidePanelResizeArea() override;
 
-  // Width of the resize strip when the panel has no border.
-  static constexpr int kNoBorderResizeAreaWidth = 5;
+  // Width of the resize strip.
+  static constexpr int kResizeStripWidth = 5;
 
-  // Returns the resize area bounds for the no-border case.
+  // Returns the bounds for the resize strip within `panel_bounds`.
   // `panel_on_right` is true when the panel appears on the right side of the
-  // screen (right-aligned LTR or left-aligned RTL), which puts the resize
-  // strip at the left edge so it faces the web content.
-  gfx::Rect GetNoBorderResizeBounds(bool panel_on_right,
-                                    const gfx::Rect& panel_bounds) const;
+  // screen (right-aligned LTR or left-aligned RTL), which puts the strip at
+  // the left edge so it faces the web content.
+  gfx::Rect GetResizeStripBounds(bool panel_on_right,
+                                 const gfx::Rect& panel_bounds) const;
 
   // views::SidePanelResizeArea:
   void Layout(PassKey) override;

--- a/browser/ui/views/side_panel/sources.gni
+++ b/browser/ui/views/side_panel/sources.gni
@@ -3,5 +3,12 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import("//brave/browser/ui/sidebar/buildflags/buildflags.gni")
+
 brave_browser_ui_views_side_panel_deps =
     [ "//brave/browser/ui/sidebar/buildflags" ]
+
+if (enable_sidebar_v2) {
+  brave_browser_ui_views_side_panel_deps +=
+      [ "//chrome/browser/ui:layout_constants" ]
+}

--- a/chromium_src/chrome/browser/ui/views/side_panel/side_panel.cc
+++ b/chromium_src/chrome/browser/ui/views/side_panel/side_panel.cc
@@ -7,6 +7,7 @@
 #include "build/buildflag.h"
 
 #if BUILDFLAG(ENABLE_SIDEBAR_V2)
+#include "chrome/browser/ui/color/chrome_color_id.h"
 #include "chrome/browser/ui/layout_constants.h"
 #include "chrome/browser/ui/views/side_panel/side_panel.h"
 

--- a/chromium_src/chrome/browser/ui/views/side_panel/side_panel.cc
+++ b/chromium_src/chrome/browser/ui/views/side_panel/side_panel.cc
@@ -7,10 +7,7 @@
 #include "build/buildflag.h"
 
 #if BUILDFLAG(ENABLE_SIDEBAR_V2)
-// Include the Brave-overridden header first, WITHOUT the rename macros below
-// active, so that the class declaration keeps the original Open name and the
-// include guard prevents the header from being re-processed when the upstream
-// .cc pulls it in.
+#include "chrome/browser/ui/layout_constants.h"
 #include "chrome/browser/ui/views/side_panel/side_panel.h"
 
 // Rename the upstream Add/RemoveHeaderView implementation so we can provide
@@ -30,9 +27,9 @@
 void SidePanel::SetResizeArea(std::unique_ptr<views::View> resize_area) {
   CHECK(resize_area);
   auto old_resize_area = RemoveChildViewT(resize_area_);
-  // Add at the end so the resize area is above content_parent_view_ in z-order.
-  // This is required for the no-border case where the resize strip overlaps
-  // the content edge and must win the hit-test.
+  // Add at the end so the resize area is above content_parent_view_ in
+  // z-order. The strip always overlaps the content edge and must win the
+  // hit-test to receive drag events.
   resize_area_ = AddChildView(std::move(resize_area));
   resize_area_->InsertBeforeInFocusList(content_parent_view_);
 }
@@ -50,20 +47,34 @@ void SidePanel::SetRoundedBorderEnabled(bool enabled) {
 }
 
 void SidePanel::UpdateBorder() {
-  // When a Brave header is attached, reserve top inset for it so the header
-  // paints over the border strip without overlapping content.
   const int header_top_inset =
       header_view_ ? header_view_->GetPreferredSize().height() : 0;
+  gfx::Insets insets;
+  insets.set_top(header_top_inset);
 
+  // With rounded corners the content view owns its own margins, so only add an
+  // outer-side gap for visual separation from the window chrome.
   if (rounded_border_enabled_) {
-    // Upstream GetBorderInsets() has a negative top to overlap the toolbar;
-    // Brave doesn't need that overlap.
-    SetBorder(
-        views::CreateEmptyBorder(GetBorderInsets().set_top(header_top_inset)));
-  } else {
-    SetBorder(
-        views::CreateEmptyBorder(gfx::Insets::TLBR(header_top_inset, 0, 0, 0)));
+    insets.set_bottom(kRoundedCornersContentsViewMargin);
+    if (IsRightAligned()) {
+      insets.set_right(kRoundedCornersContentsViewMargin);
+    } else {
+      insets.set_left(kRoundedCornersContentsViewMargin);
+    }
+    SetBorder(views::CreateEmptyBorder(insets));
+    return;
   }
+
+  // Without rounded corners, draw a 1px vertical separator between content and
+  // panel.
+  constexpr int kBorderThickness = 1;
+  if (IsRightAligned()) {
+    insets.set_left(kBorderThickness);
+  } else {
+    insets.set_right(kBorderThickness);
+  }
+  SetBorder(
+      views::CreateSolidSidedBorder(insets, kColorToolbarContentAreaSeparator));
 }
 
 void SidePanel::AddHeaderView(std::unique_ptr<views::View> view) {
@@ -71,11 +82,8 @@ void SidePanel::AddHeaderView(std::unique_ptr<views::View> view) {
   UpdateBorder();
 
   // The resize area overlaps other views (contents, header), so it must be
-  // top-most to receive drag events. With rounded corners, it sits over the
-  // border area instead and doesn't overlap other views, so no reorder needed.
-  if (!rounded_border_enabled_) {
-    ReorderChildView(resize_area_, children().size());
-  }
+  // top-most to receive drag events.
+  ReorderChildView(resize_area_, children().size());
 }
 
 void SidePanel::RemoveHeaderView() {

--- a/chromium_src/chrome/browser/ui/views/side_panel/side_panel.cc
+++ b/chromium_src/chrome/browser/ui/views/side_panel/side_panel.cc
@@ -47,6 +47,10 @@ void SidePanel::SetRoundedBorderEnabled(bool enabled) {
 }
 
 void SidePanel::UpdateBorder() {
+  // To make sure |horizontal_alignemnt_| refreshed before using
+  // IsRightAligned().
+  UpdateHorizontalAlignment();
+
   const int header_top_inset =
       header_view_ ? header_view_->GetPreferredSize().height() : 0;
   gfx::Insets insets;


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves no issue - use umbrella issue (https://github.com/brave/brave-browser/issues/51462)

With rounded corners, draw an empty border with kRoundedCornersContentsViewMargin
on the outer side and bottom (content view owns its own margins). Without rounded
corners, draw a 1px solid separator on the content-facing side using
kColorToolbarContentAreaSeparator.

Previously, we put resize strip over the border when rounded corners enabled.
But, no border anymore on content-facing side.
Put resize strip over the local bound at the fixed position(0, 0) always.

TEST=SidebarBrowserTest.SidebarV2ResizeAreaPositionMatchesBorderState

<img width="459" height="1031" alt="image" src="https://github.com/user-attachments/assets/09f71b97-bb67-4672-b8bc-06129930291a" />


<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
