### PR TITLE
[iOS] Fix AI Chat fetching web content from the incorrect tab for history & bookmarks (uplift to 1.91.x)

### DIFF
--- a/ios/brave-ios/Sources/AIChat/WebUI/AIChatWebUIHelper.swift
+++ b/ios/brave-ios/Sources/AIChat/WebUI/AIChatWebUIHelper.swift
@@ -30,6 +30,7 @@ public class AIChatWebUIHelper: NSObject, TabObserver, AIChatUIHandler,
   public var tabsForPrivateMode: (_ isPrivate: Bool) -> [any TabState] = { _ in [] }
   public var profileController: BraveProfileController
   public var attachPrivacySensitiveTabHelpers: ((any TabState, any Profile) -> Void)?
+  public var webDelegateForTab: ((any TabState) -> AIChatWebDelegate?)?
 
   public init?(
     tab: some TabState,
@@ -122,7 +123,7 @@ public class AIChatWebUIHelper: NSObject, TabObserver, AIChatUIHandler,
     guard
       let childHelper = AIChatWebUIHelper(
         tab: tab,
-        webDelegate: webDelegate,
+        webDelegate: webDelegateForTab?(tab) ?? webDelegate,
         braveTalkJavascript: braveTalkJavascript,
         profileController: profileController
       ),

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabManagerDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabManagerDelegate.swift
@@ -62,6 +62,11 @@ extension BrowserViewController: TabManagerDelegate {
       guard let self, !isPrivate else { return [] }
       return tabManager.allTabs.filter { !$0.isPrivate }
     }
+    tab.aiChatWebUIHelper?.webDelegateForTab = { detachedTab in
+      /// If AIChat created a hidden tab for history or bookmarks, we need to
+      /// use it's `AIChatWebDelegate` to fetch content from.
+      detachedTab.leoTabHelper
+    }
     tab.walletWebUIHelper = .init(
       tab: tab,
       showApprovePanelUIHandler: { [weak self] tab in


### PR DESCRIPTION
Uplift of #36665
Resolves https://github.com/brave/brave-browser/issues/55736

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.