### PR TITLE
[Wallet] Fix Solana signMessage transaction guard bypass

### DIFF
--- a/browser/brave_wallet/solana_provider_impl_unittest.cc
+++ b/browser/brave_wallet/solana_provider_impl_unittest.cc
@@ -835,6 +835,13 @@ TEST_F(SolanaProviderImplUnitTest, SignMessage) {
   Connect(std::nullopt, &error, &error_message);
   ASSERT_TRUE(IsConnected());
 
+  // Non-UTF-8 binary payload should be rejected (matches Phantom behavior).
+  signature =
+      SignMessage({0xFF, 0xFE, 0xFD}, std::nullopt, &error, &error_message);
+  EXPECT_TRUE(signature.empty());
+  EXPECT_EQ(error, mojom::SolanaProviderError::kUnauthorized);
+  EXPECT_EQ(error_message, l10n_util::GetStringUTF8(IDS_WALLET_NOT_AUTHED));
+
   // User rejected.
   signature = SignMessage({1, 2, 3, 4}, std::nullopt, &error, &error_message,
                           true, false /* approve */);

--- a/components/brave_wallet/browser/solana_instruction.cc
+++ b/components/brave_wallet/browser/solana_instruction.cc
@@ -13,6 +13,7 @@
 
 #include "base/base64.h"
 #include "base/containers/span.h"
+#include "base/numerics/checked_math.h"
 #include "base/values.h"
 #include "brave/components/brave_wallet/browser/solana_compiled_instruction.h"
 #include "brave/components/brave_wallet/browser/solana_instruction_data_decoder.h"
@@ -99,16 +100,22 @@ std::optional<SolanaInstruction> SolanaInstruction::FromCompiledInstruction(
     const std::vector<SolanaMessageAddressTableLookup>& addr_table_lookups,
     uint8_t num_of_write_indexes,
     uint8_t num_of_read_indexes) {
-  int num_writable_signed_accounts =
+  const auto checked_writable_signed =
+      base::CheckedNumeric<int>(message_header.num_required_signatures) -
+      message_header.num_readonly_signed_accounts;
+  const auto checked_writable_unsigned =
+      base::CheckedNumeric<int>(static_accounts.size()) -
       message_header.num_required_signatures -
-      message_header.num_readonly_signed_accounts;
-  int num_writable_unsigned_accounts =
-      static_accounts.size() - message_header.num_required_signatures -
-      message_header.num_readonly_signed_accounts;
-  if (num_writable_signed_accounts < 0 ||
-      num_writable_unsigned_accounts < 0) {  // invalid message header
+      message_header.num_readonly_unsigned_accounts;
+  if (!checked_writable_signed.IsValid() ||
+      !checked_writable_unsigned.IsValid() ||
+      checked_writable_signed.ValueOrDie() < 0 ||
+      checked_writable_unsigned.ValueOrDie() < 0) {  // invalid message header
     return std::nullopt;
   }
+  const int num_writable_signed_accounts = checked_writable_signed.ValueOrDie();
+  const int num_writable_unsigned_accounts =
+      checked_writable_unsigned.ValueOrDie();
 
   // Program ID of compiled_instruction should be in static accounts.
   // https://docs.rs/solana-program/1.14.12/src/solana_program/message/versions/v0/mod.rs.html#72-73

--- a/components/brave_wallet/browser/solana_instruction.cc
+++ b/components/brave_wallet/browser/solana_instruction.cc
@@ -101,20 +101,19 @@ std::optional<SolanaInstruction> SolanaInstruction::FromCompiledInstruction(
     uint8_t num_of_write_indexes,
     uint8_t num_of_read_indexes) {
   const auto checked_writable_signed =
-      base::CheckedNumeric<int>(message_header.num_required_signatures) -
+      base::CheckedNumeric<uint8_t>(message_header.num_required_signatures) -
       message_header.num_readonly_signed_accounts;
   const auto checked_writable_unsigned =
-      base::CheckedNumeric<int>(static_accounts.size()) -
+      base::CheckedNumeric<uint8_t>(static_accounts.size()) -
       message_header.num_required_signatures -
       message_header.num_readonly_unsigned_accounts;
   if (!checked_writable_signed.IsValid() ||
-      !checked_writable_unsigned.IsValid() ||
-      checked_writable_signed.ValueOrDie() < 0 ||
-      checked_writable_unsigned.ValueOrDie() < 0) {  // invalid message header
+      !checked_writable_unsigned.IsValid()) {
     return std::nullopt;
   }
-  const int num_writable_signed_accounts = checked_writable_signed.ValueOrDie();
-  const int num_writable_unsigned_accounts =
+  const uint8_t num_writable_signed_accounts =
+      checked_writable_signed.ValueOrDie();
+  const uint8_t num_writable_unsigned_accounts =
       checked_writable_unsigned.ValueOrDie();
 
   // Program ID of compiled_instruction should be in static accounts.

--- a/components/brave_wallet/browser/solana_instruction_unittest.cc
+++ b/components/brave_wallet/browser/solana_instruction_unittest.cc
@@ -138,6 +138,50 @@ TEST(SolanaInstructionUnitTest, FromToCompiledInstruction) {
   EXPECT_EQ(compiled_ins2, *compiled_ins_from_ins2);
 }
 
+// Regression test: FromCompiledInstruction must use
+// num_readonly_unsigned_accounts (not num_readonly_signed_accounts) when
+// computing num_writable_unsigned_accounts. A crafted transaction with header
+// [num_req_sig=5, ro_signed=4, ro_unsigned=1] and 8 accounts is valid per
+// Solana (8-5-1=2 writable unsigned), but the typo causes Brave to compute
+// 8-5-4=-1 and return nullopt, bypassing the signMessage transaction guard that
+// rejects blobs which successfully deserialize as transactions.
+TEST(SolanaInstructionUnitTest,
+     FromCompiledInstructionUsesReadonlyUnsignedForWritableUnsignedCount) {
+  // 8 accounts: [0] writable signer, [1..4] readonly signers,
+  //             [5..6] writable unsigned, [7] readonly unsigned (program)
+  std::vector<SolanaAddress> accounts = {
+      *SolanaAddress::FromBase58(kAccount1),
+      *SolanaAddress::FromBase58(kAccount2),
+      *SolanaAddress::FromBase58(kAccount3),
+      *SolanaAddress::FromBase58(kAccount4),
+      *SolanaAddress::FromBase58(kAccount5),
+      *SolanaAddress::FromBase58(kAccount1),
+      *SolanaAddress::FromBase58(kAccount2),
+      *SolanaAddress::FromBase58(mojom::kSolanaSystemProgramId),
+  };
+
+  // header(5, 4, 1): 5 required signers, 4 readonly signed, 1 readonly unsigned
+  // Correct: num_writable_unsigned = 8 - 5 - 1 = 2 (valid)
+  // Buggy:   num_writable_unsigned = 8 - 5 - 4 = -1 (returns nullopt, bypasses
+  // guard)
+  SolanaMessageHeader header(5, 4, 1);
+
+  // program_id = index 7 (kSolanaSystemProgramId), account = index 0
+  // (kAccount1)
+  SolanaCompiledInstruction compiled_ins(7, {0}, {});
+
+  auto result = SolanaInstruction::FromCompiledInstruction(compiled_ins, header,
+                                                           accounts, {}, 0, 0);
+  ASSERT_TRUE(result.has_value());
+
+  // Account [0]: is_signer=true (0 < 5), is_writable=true (0 <
+  // num_writable_signed=1)
+  ASSERT_EQ(result->GetAccounts().size(), 1u);
+  EXPECT_EQ(result->GetAccounts()[0].pubkey, kAccount1);
+  EXPECT_TRUE(result->GetAccounts()[0].is_signer);
+  EXPECT_TRUE(result->GetAccounts()[0].is_writable);
+}
+
 TEST(SolanaInstructionUnitTest, FromToValue) {
   std::string from_account = "3Lu176FQzbQJCc8iL9PnmALbpMPhZeknoturApnXRDJw";
   std::string to_account = from_account;

--- a/components/brave_wallet/browser/solana_instruction_unittest.cc
+++ b/components/brave_wallet/browser/solana_instruction_unittest.cc
@@ -140,15 +140,9 @@ TEST(SolanaInstructionUnitTest, FromToCompiledInstruction) {
 
 // Regression test: FromCompiledInstruction must use
 // num_readonly_unsigned_accounts (not num_readonly_signed_accounts) when
-// computing num_writable_unsigned_accounts. A crafted transaction with header
-// [num_req_sig=5, ro_signed=4, ro_unsigned=1] and 8 accounts is valid per
-// Solana (8-5-1=2 writable unsigned), but the typo causes Brave to compute
-// 8-5-4=-1 and return nullopt, bypassing the signMessage transaction guard that
-// rejects blobs which successfully deserialize as transactions.
+// computing num_writable_unsigned_accounts.
 TEST(SolanaInstructionUnitTest,
      FromCompiledInstructionUsesReadonlyUnsignedForWritableUnsignedCount) {
-  // 8 accounts: [0] writable signer, [1..4] readonly signers,
-  //             [5..6] writable unsigned, [7] readonly unsigned (program)
   std::vector<SolanaAddress> accounts = {
       *SolanaAddress::FromBase58(kAccount1),
       *SolanaAddress::FromBase58(kAccount2),
@@ -161,21 +155,14 @@ TEST(SolanaInstructionUnitTest,
   };
 
   // header(5, 4, 1): 5 required signers, 4 readonly signed, 1 readonly unsigned
-  // Correct: num_writable_unsigned = 8 - 5 - 1 = 2 (valid)
-  // Buggy:   num_writable_unsigned = 8 - 5 - 4 = -1 (returns nullopt, bypasses
-  // guard)
   SolanaMessageHeader header(5, 4, 1);
 
-  // program_id = index 7 (kSolanaSystemProgramId), account = index 0
-  // (kAccount1)
   SolanaCompiledInstruction compiled_ins(7, {0}, {});
 
   auto result = SolanaInstruction::FromCompiledInstruction(compiled_ins, header,
                                                            accounts, {}, 0, 0);
   ASSERT_TRUE(result.has_value());
 
-  // Account [0]: is_signer=true (0 < 5), is_writable=true (0 <
-  // num_writable_signed=1)
   ASSERT_EQ(result->GetAccounts().size(), 1u);
   EXPECT_EQ(result->GetAccounts()[0].pubkey, kAccount1);
   EXPECT_TRUE(result->GetAccounts()[0].is_signer);

--- a/components/brave_wallet/browser/solana_provider_impl.cc
+++ b/components/brave_wallet/browser/solana_provider_impl.cc
@@ -15,6 +15,7 @@
 #include "base/notreached.h"
 #include "base/strings/strcat.h"
 #include "base/strings/string_number_conversions.h"
+#include "base/strings/string_util.h"
 #include "base/values.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_provider_delegate.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_service.h"
@@ -645,6 +646,14 @@ void SolanaProviderImpl::SignMessage(
   }
   // Prevent transaction payload from being signed
   if (SolanaMessage::Deserialize(blob_msg)) {
+    std::move(callback).Run(mojom::SolanaProviderError::kUnauthorized,
+                            l10n_util::GetStringUTF8(IDS_WALLET_NOT_AUTHED),
+                            base::DictValue());
+    return;
+  }
+  // Reject non-UTF-8 binary payloads; signMessage is for plain text only.
+  const std::string blob_str(blob_msg.begin(), blob_msg.end());
+  if (!base::IsStringUTF8(blob_str)) {
     std::move(callback).Run(mojom::SolanaProviderError::kUnauthorized,
                             l10n_util::GetStringUTF8(IDS_WALLET_NOT_AUTHED),
                             base::DictValue());


### PR DESCRIPTION
closes https://github.com/brave/internal/issues/1750

## Summary
Prevent the submission of a solana transaction being able to be signed to match phantom behavior of rejecting


## Test Plan
See the issue for testing page