### PR TITLE
Import passwords from Brave when importing into Brave Origin for Linux and macOS

### DIFF
--- a/browser/importer/BUILD.gn
+++ b/browser/importer/BUILD.gn
@@ -23,6 +23,7 @@ if (!is_android) {
       "brave_external_process_importer_host_unittest.cc",
       "brave_importer_p3a_unittest.cc",
       "brave_importer_type_unittest.cc",
+      "brave_password_importer_unittest.cc",
     ]
 
     deps = [
@@ -31,13 +32,23 @@ if (!is_android) {
       "//base/test:test_support",
       "//brave/common/importer",
       "//chrome/browser",
+      "//chrome/browser/password_manager/factories",
       "//chrome/common",
       "//chrome/test:test_support",
+      "//components/keyed_service/core",
+      "//components/os_crypt/async/browser:test_support",
+      "//components/os_crypt/async/common",
+      "//components/password_manager/core/browser:test_support",
+      "//components/password_manager/core/browser/password_store:password_store_impl",
+      "//components/password_manager/core/browser/password_store:password_store_interface",
+      "//components/password_manager/core/browser/password_store:test_support",
       "//components/user_data_importer/common",
       "//components/value_store:test_support",
+      "//content/test:test_support",
       "//extensions/browser",
       "//extensions/common:common_constants",
       "//testing/gtest",
+      "//url",
     ]
   }
 

--- a/browser/importer/brave_external_process_importer_host.cc
+++ b/browser/importer/brave_external_process_importer_host.cc
@@ -5,19 +5,44 @@
 
 #include "brave/browser/importer/brave_external_process_importer_host.h"
 
+#include <utility>
+
 #include "base/check.h"
+#include "base/logging.h"
 #include "brave/browser/importer/brave_importer_p3a.h"
 #include "brave/browser/importer/extensions_import_helpers.h"
 #include "brave/grit/brave_generated_resources.h"
+#include "build/build_config.h"
 #include "chrome/browser/importer/importer_lock_dialog.h"
+#include "components/user_data_importer/common/importer_data_types.h"
+#include "components/user_data_importer/common/importer_type.h"
 
 BraveExternalProcessImporterHost::BraveExternalProcessImporterHost()
     : weak_ptr_factory_(this) {}
 BraveExternalProcessImporterHost::~BraveExternalProcessImporterHost() = default;
 
 void BraveExternalProcessImporterHost::NotifyImportEnded() {
-  if (!cancelled_) {
+  // Guard against re-recording: this method is re-entered to continue the
+  // import lifecycle after browser-process steps (password and extension
+  // import), and P3A must be recorded only once per import.
+  if (!cancelled_ && !p3a_recorded_) {
+    p3a_recorded_ = true;
     RecordImporterP3A(source_profile_.importer_type);
+  }
+
+  // Passwords are imported in the browser process (not the utility process) so
+  // OSCryptAsync can decrypt the source's `Login Data`. `password_importer_` is
+  // created lazily here and reset in OnPasswordsImported(), which re-enters
+  // this method to continue the lifecycle.
+  if (NeedToImportPasswords() && !password_import_started_) {
+    password_import_started_ = true;
+    password_importer_ = std::make_unique<BravePasswordImporter>();
+    NotifyImportItemStarted(user_data_importer::PASSWORDS);
+    password_importer_->StartImport(
+        source_profile_.source_path, profile_,
+        base::BindOnce(&BraveExternalProcessImporterHost::OnPasswordsImported,
+                       weak_ptr_factory_.GetWeakPtr()));
+    return;
   }
 
   // If user chooses extension importing, start importing extensions.
@@ -40,6 +65,42 @@ void BraveExternalProcessImporterHost::NotifyImportEnded() {
 
   // Otherwise, notifying here and importing is finished.
   ExternalProcessImporterHost::NotifyImportEnded();
+}
+
+bool BraveExternalProcessImporterHost::NeedToImportPasswords() const {
+#if BUILDFLAG(IS_MAC) || BUILDFLAG(IS_LINUX)
+  // Only Brave-to-Brave imports share the OS keychain entry needed to decrypt
+  // the source's `Login Data`.
+  return !cancelled_ &&
+         (items_ & user_data_importer::PASSWORDS) ==
+             user_data_importer::PASSWORDS &&
+         source_profile_.importer_type == user_data_importer::TYPE_BRAVE;
+#else
+  return false;
+#endif
+}
+
+void BraveExternalProcessImporterHost::OnPasswordsImported(
+    BravePasswordImporter::Result result,
+    size_t /*submitted*/) {
+  password_importer_.reset();
+
+  if (result == BravePasswordImporter::Result::kSuccess) {
+    // Only report the item as ended on success; reporting it on failure would
+    // mark the overall import as succeeded. A successful import of zero
+    // credentials just means the source had no saved passwords.
+    NotifyImportItemEnded(user_data_importer::PASSWORDS);
+  } else {
+    // Failures are logged so they are not lost, since the import UI has no
+    // per-item failure state.
+    LOG(ERROR) << "Brave password import failed, result="
+               << static_cast<int>(result);
+  }
+
+  // Continue the remainder of the import lifecycle (extensions, if any, then
+  // the final "ended" notification) by re-entering NotifyImportEnded() now
+  // that `password_importer_` has been cleared.
+  NotifyImportEnded();
 }
 
 void BraveExternalProcessImporterHost::LaunchImportIfReady() {

--- a/browser/importer/brave_external_process_importer_host.h
+++ b/browser/importer/brave_external_process_importer_host.h
@@ -6,11 +6,13 @@
 #ifndef BRAVE_BROWSER_IMPORTER_BRAVE_EXTERNAL_PROCESS_IMPORTER_HOST_H_
 #define BRAVE_BROWSER_IMPORTER_BRAVE_EXTERNAL_PROCESS_IMPORTER_HOST_H_
 
+#include <cstddef>
 #include <memory>
 #include <string>
 
 #include "base/gtest_prod_util.h"
 #include "base/memory/weak_ptr.h"
+#include "brave/browser/importer/brave_password_importer.h"
 #include "chrome/browser/importer/external_process_importer_host.h"
 #include "extensions/buildflags/buildflags.h"
 
@@ -45,6 +47,18 @@ class BraveExternalProcessImporterHost : public ExternalProcessImporterHost {
   // ExternalProcessImporterHost overrides:
   void NotifyImportEnded() override;
   void LaunchImportIfReady() override;
+
+  // Passwords from another Brave installation are imported in the browser
+  // process (not the utility process) so we can use OSCryptAsync to decrypt
+  // the source's `Login Data`. Supported on macOS and Linux only; see
+  // `BravePasswordImporter`.
+  bool NeedToImportPasswords() const;
+  void OnPasswordsImported(BravePasswordImporter::Result result,
+                           size_t submitted);
+
+  std::unique_ptr<BravePasswordImporter> password_importer_;
+  bool password_import_started_ = false;
+  bool p3a_recorded_ = false;
 
 #if BUILDFLAG(ENABLE_EXTENSIONS)
   bool NeedToImportExtensions() const;

--- a/browser/importer/brave_external_process_importer_host_unittest.cc
+++ b/browser/importer/brave_external_process_importer_host_unittest.cc
@@ -5,9 +5,11 @@
 
 #include "brave/browser/importer/brave_external_process_importer_host.h"
 
+#include <map>
 #include <memory>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "base/command_line.h"
 #include "base/files/file_util.h"
@@ -15,15 +17,29 @@
 #include "base/functional/callback.h"
 #include "base/path_service.h"
 #include "base/test/bind.h"
+#include "base/test/metrics/histogram_tester.h"
+#include "base/test/test_future.h"
 #include "base/threading/thread_restrictions.h"
 #include "brave/browser/importer/extensions_import_helpers.h"
 #include "brave/common/importer/importer_constants.h"
 #include "brave/components/constants/brave_paths.h"
+#include "build/build_config.h"
 #include "chrome/browser/extensions/test_extension_system.h"
 #include "chrome/browser/importer/importer_progress_observer.h"
+#include "chrome/browser/password_manager/factories/profile_password_store_factory.h"
+#include "chrome/test/base/testing_browser_process.h"
 #include "chrome/test/base/testing_profile.h"
+#include "components/keyed_service/core/service_access_type.h"
+#include "components/os_crypt/async/browser/os_crypt_async.h"
+#include "components/os_crypt/async/common/encryptor.h"
+#include "components/password_manager/core/browser/password_manager_test_utils.h"
+#include "components/password_manager/core/browser/password_store/login_database.h"
+#include "components/password_manager/core/browser/password_store/test_password_store.h"
+#include "components/user_data_importer/common/importer_data_types.h"
+#include "components/user_data_importer/common/importer_type.h"
 #include "components/value_store/test_value_store_factory.h"
 #include "components/value_store/value_store.h"
+#include "content/public/browser/browser_context.h"
 #include "content/public/test/browser_task_environment.h"
 #include "extensions/browser/extension_registrar.h"
 #include "extensions/browser/extension_system.h"
@@ -31,6 +47,7 @@
 #include "extensions/common/constants.h"
 #include "extensions/common/extension_builder.h"
 #include "testing/gtest/include/gtest/gtest.h"
+#include "url/gurl.h"
 
 namespace {
 
@@ -40,25 +57,50 @@ constexpr const char* kExtensions[] = {
 
 class ImportEndedObserver : public importer::ImporterProgressObserver {
  public:
+  ImportEndedObserver() = default;
   explicit ImportEndedObserver(base::OnceClosure callback)
       : callback_(std::move(callback)) {}
   ~ImportEndedObserver() override = default;
+
+  void set_quit_closure(base::OnceClosure callback) {
+    callback_ = std::move(callback);
+  }
 
   // Invoked when the import begins.
   void ImportStarted() override {}
 
   // Invoked when data for the specified item is about to be collected.
-  void ImportItemStarted(user_data_importer::ImportItem item) override {}
+  void ImportItemStarted(user_data_importer::ImportItem item) override {
+    ++item_started_count_[item];
+  }
 
   // Invoked when data for the specified item has been collected from the
   // source profile and is now ready for further processing.
-  void ImportItemEnded(user_data_importer::ImportItem item) override {}
+  void ImportItemEnded(user_data_importer::ImportItem item) override {
+    ++item_ended_count_[item];
+  }
 
   // Invoked when the source profile has been imported.
-  void ImportEnded() override { std::move(callback_).Run(); }
+  void ImportEnded() override {
+    ++import_ended_count_;
+    if (callback_) {
+      std::move(callback_).Run();
+    }
+  }
+
+  int import_ended_count() const { return import_ended_count_; }
+  int item_started_count(user_data_importer::ImportItem item) {
+    return item_started_count_[item];
+  }
+  int item_ended_count(user_data_importer::ImportItem item) {
+    return item_ended_count_[item];
+  }
 
  protected:
   base::OnceClosure callback_;
+  int import_ended_count_ = 0;
+  std::map<user_data_importer::ImportItem, int> item_started_count_;
+  std::map<user_data_importer::ImportItem, int> item_ended_count_;
 };
 
 void CreateTestingStore(const base::FilePath& path, const std::string& id) {
@@ -163,6 +205,53 @@ class BraveExternalProcessImporterHostUnitTest : public testing::Test {
     return ReadStore(GetExtensionLocalSettingsPath("Brave", id), id);
   }
 
+#if BUILDFLAG(IS_MAC) || BUILDFLAG(IS_LINUX)
+  // Installs a TestPasswordStore on the target profile and writes a source
+  // `Login Data` file (encrypted with the same OSCryptAsync the importer will
+  // decrypt with) into the given source profile directory.
+  void SetUpPasswordImport(const base::FilePath& source_path) {
+    ProfilePasswordStoreFactory::GetInstance()->SetTestingFactoryAndUse(
+        GetProfile(),
+        base::BindRepeating(
+            &password_manager::BuildPasswordStore<
+                content::BrowserContext, password_manager::TestPasswordStore>));
+
+    base::test::TestFuture<scoped_refptr<os_crypt_async::Encryptor>> future;
+    TestingBrowserProcess::GetGlobal()->os_crypt_async()->GetInstance(
+        future.GetCallback());
+    scoped_refptr<os_crypt_async::Encryptor> encryptor = future.Take();
+
+    ASSERT_TRUE(base::CreateDirectory(source_path));
+    password_manager::LoginDatabase database(
+        source_path.Append(FILE_PATH_LITERAL("Login Data")),
+        password_manager::IsAccountStore(false));
+    ASSERT_TRUE(database.Init(base::NullCallback(), std::move(encryptor)));
+    password_manager::StoredCredential cred;
+    cred.url = GURL("https://example.com/");
+    cred.signon_realm = "https://example.com/";
+    cred.username_value = u"alice";
+    cred.password_value = u"secret";
+    cred.in_store = password_manager::PasswordForm::Store::kProfileStore;
+    ASSERT_FALSE(database.AddLogin(std::move(cred)).empty());
+  }
+
+  // Drives a password import to completion, populating `observer`.
+  void LaunchPasswordImportAndWait(
+      user_data_importer::SourceProfile source_profile,
+      ImportEndedObserver* observer) {
+    base::RunLoop loop;
+    observer->set_quit_closure(loop.QuitClosure());
+
+    // BraveExternalProcessImporterHost uses `delete this`.
+    auto* external_process_host = new BraveExternalProcessImporterHost();
+    external_process_host->DoNotLaunchImportForTesting();
+    external_process_host->set_observer(observer);
+    external_process_host->StartImportSettings(
+        source_profile, GetProfile(), user_data_importer::PASSWORDS, nullptr);
+    loop.Run();
+  }
+#endif  // BUILDFLAG(IS_MAC) || BUILDFLAG(IS_LINUX)
+
   std::string ReadTargetIndexedDB(const std::string& id,
                                   const std::string& type) {
     base::ScopedAllowBlockingForTesting allow_io;
@@ -219,3 +308,27 @@ TEST_F(BraveExternalProcessImporterHostUnitTest, ImportEtensionsSettings) {
   EXPECT_TRUE(ReadTargetIndexedDB(kExtensions[3], "blob").empty());
   EXPECT_TRUE(ReadTargetIndexedDB(kExtensions[3], "leveldb").empty());
 }
+
+#if BUILDFLAG(IS_MAC) || BUILDFLAG(IS_LINUX)
+// Exercises the browser-process password import lifecycle: `ImportEnded` must
+// fire exactly once and the item start/end notifications must each fire once
+// for PASSWORDS, and P3A must be recorded once (the guard against the
+// NotifyImportEnded() re-entry).
+TEST_F(BraveExternalProcessImporterHostUnitTest, ImportPasswordsLifecycle) {
+  base::HistogramTester histogram_tester;
+
+  user_data_importer::SourceProfile source_profile;
+  source_profile.source_path = GetProductProfilePath("Brave");
+  source_profile.importer_type = user_data_importer::TYPE_BRAVE;
+  source_profile.services_supported = user_data_importer::PASSWORDS;
+  ASSERT_NO_FATAL_FAILURE(SetUpPasswordImport(source_profile.source_path));
+
+  ImportEndedObserver observer;
+  LaunchPasswordImportAndWait(source_profile, &observer);
+
+  EXPECT_EQ(1, observer.import_ended_count());
+  EXPECT_EQ(1, observer.item_started_count(user_data_importer::PASSWORDS));
+  EXPECT_EQ(1, observer.item_ended_count(user_data_importer::PASSWORDS));
+  histogram_tester.ExpectTotalCount("Brave.Importer.ImporterSource.2", 1);
+}
+#endif  // BUILDFLAG(IS_MAC) || BUILDFLAG(IS_LINUX)

--- a/browser/importer/brave_password_importer.cc
+++ b/browser/importer/brave_password_importer.cc
@@ -1,0 +1,161 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/importer/brave_password_importer.h"
+
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+#include "base/check.h"
+#include "base/files/file_util.h"
+#include "base/functional/bind.h"
+#include "base/logging.h"
+#include "base/memory/weak_ptr.h"
+#include "base/task/thread_pool.h"
+#include "brave/common/importer/scoped_copy_file.h"
+#include "chrome/browser/browser_process.h"
+#include "chrome/browser/password_manager/factories/profile_password_store_factory.h"
+#include "components/keyed_service/core/service_access_type.h"
+#include "components/os_crypt/async/browser/os_crypt_async.h"
+#include "components/password_manager/core/browser/password_store/login_database.h"
+#include "components/password_manager/core/browser/password_store/password_store_interface.h"
+#include "components/password_manager/core/browser/password_store/stored_credential.h"
+
+namespace {
+
+struct ReadResult {
+  ReadResult() = default;
+  ReadResult(ReadResult&&) = default;
+  ReadResult& operator=(ReadResult&&) = default;
+  ~ReadResult() = default;
+
+  BravePasswordImporter::Result result =
+      BravePasswordImporter::Result::kReadFailed;
+  std::vector<password_manager::StoredCredential> credentials;
+};
+
+// Runs on a background thread. Copies the source `Login Data` to a temporary
+// location (to avoid conflicting with a possibly-running source browser),
+// opens it with the destination's `encryptor`, and returns the outcome and
+// decrypted credentials.
+ReadResult ReadCredentialsFromLoginData(
+    const base::FilePath& login_data_path,
+    scoped_refptr<os_crypt_async::Encryptor> encryptor) {
+  ReadResult read_result;
+  if (!base::PathExists(login_data_path)) {
+    read_result.result = BravePasswordImporter::Result::kLoginDataNotFound;
+    return read_result;
+  }
+
+  ScopedCopyFile copy_login_data(login_data_path);
+  if (!copy_login_data.copy_success()) {
+    LOG(ERROR) << "Failed to copy Login Data for password import";
+    read_result.result = BravePasswordImporter::Result::kCopyFailed;
+    return read_result;
+  }
+
+  password_manager::LoginDatabase database(
+      copy_login_data.copied_file_path(),
+      password_manager::IsAccountStore(false));
+  if (!database.Init(
+          /*on_undecryptable_passwords_removed=*/base::NullCallback(),
+          std::move(encryptor))) {
+    LOG(ERROR) << "LoginDatabase Init() failed for password import";
+    read_result.result = BravePasswordImporter::Result::kDatabaseInitFailed;
+    return read_result;
+  }
+
+  // GetAllLogins returns a FormRetrievalResult, letting us distinguish a
+  // decryption/key failure from an empty database. This is the same call the
+  // password store backend uses.
+  password_manager::FormRetrievalResult retrieval_result =
+      database.GetAllLogins(&read_result.credentials);
+  if (retrieval_result != password_manager::FormRetrievalResult::kSuccess &&
+      retrieval_result != password_manager::FormRetrievalResult::
+                              kEncryptionServiceFailureWithPartialData) {
+    LOG(ERROR) << "Failed to read logins for password import, result="
+               << static_cast<int>(retrieval_result);
+    read_result.credentials.clear();
+    read_result.result = BravePasswordImporter::Result::kReadFailed;
+    return read_result;
+  }
+
+  // PasswordStore::AddLogins CHECKs that blocklisted entries carry no username
+  // or password. A source `Login Data` may violate that, so normalize here.
+  for (auto& credential : read_result.credentials) {
+    if (credential.blocked_by_user) {
+      credential.username_value.clear();
+      credential.password_value.clear();
+    }
+  }
+
+  read_result.result = BravePasswordImporter::Result::kSuccess;
+  return read_result;
+}
+
+}  // namespace
+
+BravePasswordImporter::BravePasswordImporter() = default;
+BravePasswordImporter::~BravePasswordImporter() = default;
+
+void BravePasswordImporter::StartImport(const base::FilePath& source_path,
+                                        Profile* destination_profile,
+                                        CompletionCallback callback) {
+  CHECK(destination_profile);
+  CHECK(callback);
+  source_path_ = source_path;
+  callback_ = std::move(callback);
+  password_store_ = ProfilePasswordStoreFactory::GetForProfile(
+      destination_profile, ServiceAccessType::EXPLICIT_ACCESS);
+  if (!password_store_) {
+    std::move(callback_).Run(Result::kNoPasswordStore, 0);
+    return;
+  }
+
+  auto* os_crypt = g_browser_process->os_crypt_async();
+  if (!os_crypt) {
+    std::move(callback_).Run(Result::kNoEncryptor, 0);
+    return;
+  }
+  os_crypt->GetInstance(base::BindOnce(&BravePasswordImporter::OnEncryptorReady,
+                                       weak_factory_.GetWeakPtr()));
+}
+
+void BravePasswordImporter::OnEncryptorReady(
+    scoped_refptr<os_crypt_async::Encryptor> encryptor) {
+  base::FilePath login_data_path = source_path_.Append(
+      base::FilePath::StringType(FILE_PATH_LITERAL("Login Data")));
+  base::ThreadPool::PostTaskAndReplyWithResult(
+      FROM_HERE, {base::MayBlock(), base::TaskPriority::USER_VISIBLE},
+      base::BindOnce(&ReadCredentialsFromLoginData, login_data_path,
+                     std::move(encryptor)),
+      base::BindOnce(
+          [](base::WeakPtr<BravePasswordImporter> importer,
+             ReadResult read_result) {
+            if (importer) {
+              importer->OnCredentialsRead(read_result.result,
+                                          std::move(read_result.credentials));
+            }
+          },
+          weak_factory_.GetWeakPtr()));
+}
+
+void BravePasswordImporter::OnCredentialsRead(
+    Result result,
+    std::vector<password_manager::StoredCredential> credentials) {
+  if (result != Result::kSuccess || !password_store_) {
+    std::move(callback_).Run(result, 0);
+    return;
+  }
+  if (credentials.empty()) {
+    std::move(callback_).Run(Result::kSuccess, 0);
+    return;
+  }
+  const size_t count = credentials.size();
+  password_store_->AddLogins(
+      std::move(credentials),
+      base::BindOnce(std::move(callback_), Result::kSuccess, count));
+}

--- a/browser/importer/brave_password_importer.cc
+++ b/browser/importer/brave_password_importer.cc
@@ -12,8 +12,9 @@
 #include "base/check.h"
 #include "base/files/file_util.h"
 #include "base/functional/bind.h"
+#include "base/location.h"
 #include "base/logging.h"
-#include "base/memory/weak_ptr.h"
+#include "base/task/sequenced_task_runner.h"
 #include "base/task/thread_pool.h"
 #include "brave/common/importer/scoped_copy_file.h"
 #include "chrome/browser/browser_process.h"
@@ -24,25 +25,16 @@
 #include "components/password_manager/core/browser/password_store/password_store_interface.h"
 #include "components/password_manager/core/browser/password_store/stored_credential.h"
 
-namespace {
+BravePasswordImporter::ReadResult::ReadResult() = default;
+BravePasswordImporter::ReadResult::ReadResult(ReadResult&&) = default;
+BravePasswordImporter::ReadResult& BravePasswordImporter::ReadResult::operator=(
+    ReadResult&&) = default;
+BravePasswordImporter::ReadResult::~ReadResult() = default;
 
-struct ReadResult {
-  ReadResult() = default;
-  ReadResult(ReadResult&&) = default;
-  ReadResult& operator=(ReadResult&&) = default;
-  ~ReadResult() = default;
-
-  BravePasswordImporter::Result result =
-      BravePasswordImporter::Result::kReadFailed;
-  std::vector<password_manager::StoredCredential> credentials;
-};
-
-// Runs on a background thread. Copies the source `Login Data` to a temporary
-// location (to avoid conflicting with a possibly-running source browser),
-// opens it with the destination's `encryptor`, and returns the outcome and
-// decrypted credentials.
-ReadResult ReadCredentialsFromLoginData(
-    const base::FilePath& login_data_path,
+// static
+BravePasswordImporter::ReadResult
+BravePasswordImporter::ReadCredentialsFromLoginData(
+    base::FilePath login_data_path,
     scoped_refptr<os_crypt_async::Encryptor> encryptor) {
   ReadResult read_result;
   if (!base::PathExists(login_data_path)) {
@@ -96,8 +88,6 @@ ReadResult ReadCredentialsFromLoginData(
   return read_result;
 }
 
-}  // namespace
-
 BravePasswordImporter::BravePasswordImporter() = default;
 BravePasswordImporter::~BravePasswordImporter() = default;
 
@@ -111,17 +101,24 @@ void BravePasswordImporter::StartImport(const base::FilePath& source_path,
   password_store_ = ProfilePasswordStoreFactory::GetForProfile(
       destination_profile, ServiceAccessType::EXPLICIT_ACCESS);
   if (!password_store_) {
-    std::move(callback_).Run(Result::kNoPasswordStore, 0);
+    RunCallbackAsync(Result::kNoPasswordStore, 0);
     return;
   }
 
   auto* os_crypt = g_browser_process->os_crypt_async();
   if (!os_crypt) {
-    std::move(callback_).Run(Result::kNoEncryptor, 0);
+    RunCallbackAsync(Result::kNoEncryptor, 0);
     return;
   }
   os_crypt->GetInstance(base::BindOnce(&BravePasswordImporter::OnEncryptorReady,
                                        weak_factory_.GetWeakPtr()));
+}
+
+void BravePasswordImporter::RunCallbackAsync(Result result, size_t submitted) {
+  // Always complete asynchronously so callers never see the callback run
+  // within StartImport()'s stack frame.
+  base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
+      FROM_HERE, base::BindOnce(std::move(callback_), result, submitted));
 }
 
 void BravePasswordImporter::OnEncryptorReady(
@@ -130,32 +127,23 @@ void BravePasswordImporter::OnEncryptorReady(
       base::FilePath::StringType(FILE_PATH_LITERAL("Login Data")));
   base::ThreadPool::PostTaskAndReplyWithResult(
       FROM_HERE, {base::MayBlock(), base::TaskPriority::USER_VISIBLE},
-      base::BindOnce(&ReadCredentialsFromLoginData, login_data_path,
-                     std::move(encryptor)),
-      base::BindOnce(
-          [](base::WeakPtr<BravePasswordImporter> importer,
-             ReadResult read_result) {
-            if (importer) {
-              importer->OnCredentialsRead(read_result.result,
-                                          std::move(read_result.credentials));
-            }
-          },
-          weak_factory_.GetWeakPtr()));
+      base::BindOnce(&BravePasswordImporter::ReadCredentialsFromLoginData,
+                     login_data_path, std::move(encryptor)),
+      base::BindOnce(&BravePasswordImporter::OnCredentialsRead,
+                     weak_factory_.GetWeakPtr()));
 }
 
-void BravePasswordImporter::OnCredentialsRead(
-    Result result,
-    std::vector<password_manager::StoredCredential> credentials) {
-  if (result != Result::kSuccess || !password_store_) {
-    std::move(callback_).Run(result, 0);
+void BravePasswordImporter::OnCredentialsRead(ReadResult read_result) {
+  if (read_result.result != Result::kSuccess || !password_store_) {
+    std::move(callback_).Run(read_result.result, 0);
     return;
   }
-  if (credentials.empty()) {
+  if (read_result.credentials.empty()) {
     std::move(callback_).Run(Result::kSuccess, 0);
     return;
   }
-  const size_t count = credentials.size();
+  const size_t count = read_result.credentials.size();
   password_store_->AddLogins(
-      std::move(credentials),
+      std::move(read_result.credentials),
       base::BindOnce(std::move(callback_), Result::kSuccess, count));
 }

--- a/browser/importer/brave_password_importer.h
+++ b/browser/importer/brave_password_importer.h
@@ -68,10 +68,29 @@ class BravePasswordImporter {
                    CompletionCallback callback);
 
  private:
+  // Outcome of the background read of the source `Login Data`.
+  struct ReadResult {
+    ReadResult();
+    ReadResult(ReadResult&&);
+    ReadResult& operator=(ReadResult&&);
+    ~ReadResult();
+
+    Result result = Result::kReadFailed;
+    std::vector<password_manager::StoredCredential> credentials;
+  };
+
+  // Runs on a background thread. Copies the source `Login Data`, opens it with
+  // the destination's `encryptor`, and returns the outcome and credentials.
+  static ReadResult ReadCredentialsFromLoginData(
+      base::FilePath login_data_path,
+      scoped_refptr<os_crypt_async::Encryptor> encryptor);
+
+  // Posts `callback_` to the current sequence so early-failure paths complete
+  // asynchronously, matching the async success path.
+  void RunCallbackAsync(Result result, size_t submitted);
+
   void OnEncryptorReady(scoped_refptr<os_crypt_async::Encryptor> encryptor);
-  void OnCredentialsRead(
-      Result result,
-      std::vector<password_manager::StoredCredential> credentials);
+  void OnCredentialsRead(ReadResult read_result);
 
   base::FilePath source_path_;
   scoped_refptr<password_manager::PasswordStoreInterface> password_store_;

--- a/browser/importer/brave_password_importer.h
+++ b/browser/importer/brave_password_importer.h
@@ -1,0 +1,82 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_IMPORTER_BRAVE_PASSWORD_IMPORTER_H_
+#define BRAVE_BROWSER_IMPORTER_BRAVE_PASSWORD_IMPORTER_H_
+
+#include <vector>
+
+#include "base/files/file_path.h"
+#include "base/functional/callback.h"
+#include "base/memory/scoped_refptr.h"
+#include "base/memory/weak_ptr.h"
+
+class Profile;
+
+namespace os_crypt_async {
+class Encryptor;
+}  // namespace os_crypt_async
+
+namespace password_manager {
+struct StoredCredential;
+class PasswordStoreInterface;
+}  // namespace password_manager
+
+// Reads encrypted credentials from a source Brave profile's `Login Data`
+// SQLite database and writes them to the destination profile's password
+// store. The destination's OSCryptAsync instance is used to decrypt the
+// source's data, which works for Brave-to-Brave imports on macOS and Linux
+// because both installations share the same OS keychain entry. This is not
+// supported on Windows, where each installation stores its own randomly
+// generated key (DPAPI-encrypted) in its own Local State, so the destination
+// key cannot decrypt the source's data.
+class BravePasswordImporter {
+ public:
+  // Outcome of an import attempt, reported so callers can log the exact cause
+  // rather than guessing from an empty result.
+  enum class Result {
+    kSuccess,
+    kNoPasswordStore,
+    kNoEncryptor,
+    kLoginDataNotFound,
+    kCopyFailed,
+    kDatabaseInitFailed,
+    kReadFailed,
+  };
+
+  // Callback fired on the UI thread with the outcome and the number of
+  // credentials submitted to the password store (0 unless `result` is
+  // `kSuccess`). This is the count handed to `AddLogins`; the store may reject
+  // individual entries (e.g. duplicates), so it is an upper bound on the
+  // number actually persisted, not an exact added count.
+  using CompletionCallback =
+      base::OnceCallback<void(Result result, size_t submitted)>;
+
+  BravePasswordImporter();
+  ~BravePasswordImporter();
+
+  BravePasswordImporter(const BravePasswordImporter&) = delete;
+  BravePasswordImporter& operator=(const BravePasswordImporter&) = delete;
+
+  // `source_path` is the source Brave profile directory (containing the
+  // `Login Data` file). `destination_profile` receives the imported
+  // credentials.
+  void StartImport(const base::FilePath& source_path,
+                   Profile* destination_profile,
+                   CompletionCallback callback);
+
+ private:
+  void OnEncryptorReady(scoped_refptr<os_crypt_async::Encryptor> encryptor);
+  void OnCredentialsRead(
+      Result result,
+      std::vector<password_manager::StoredCredential> credentials);
+
+  base::FilePath source_path_;
+  scoped_refptr<password_manager::PasswordStoreInterface> password_store_;
+  CompletionCallback callback_;
+  base::WeakPtrFactory<BravePasswordImporter> weak_factory_{this};
+};
+
+#endif  // BRAVE_BROWSER_IMPORTER_BRAVE_PASSWORD_IMPORTER_H_

--- a/browser/importer/brave_password_importer_unittest.cc
+++ b/browser/importer/brave_password_importer_unittest.cc
@@ -1,0 +1,225 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/importer/brave_password_importer.h"
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "base/files/file_path.h"
+#include "base/files/file_util.h"
+#include "base/files/scoped_temp_dir.h"
+#include "base/functional/bind.h"
+#include "base/functional/callback_helpers.h"
+#include "base/memory/scoped_refptr.h"
+#include "base/test/test_future.h"
+#include "build/build_config.h"
+#include "chrome/browser/password_manager/factories/profile_password_store_factory.h"
+#include "chrome/test/base/testing_browser_process.h"
+#include "chrome/test/base/testing_profile.h"
+#include "components/keyed_service/core/service_access_type.h"
+#include "components/os_crypt/async/browser/os_crypt_async.h"
+#include "components/os_crypt/async/browser/test_utils.h"
+#include "components/os_crypt/async/common/encryptor.h"
+#include "components/password_manager/core/browser/password_manager_test_utils.h"
+#include "components/password_manager/core/browser/password_store/login_database.h"
+#include "components/password_manager/core/browser/password_store/password_store_interface.h"
+#include "components/password_manager/core/browser/password_store/stored_credential.h"
+#include "components/password_manager/core/browser/password_store/test_password_store.h"
+#include "content/public/browser/browser_context.h"
+#include "content/public/test/browser_task_environment.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "url/gurl.h"
+
+namespace {
+
+// Blocks until `g_browser_process->os_crypt_async()` produces an Encryptor.
+scoped_refptr<os_crypt_async::Encryptor> GetEncryptorSync() {
+  base::test::TestFuture<scoped_refptr<os_crypt_async::Encryptor>> future;
+  TestingBrowserProcess::GetGlobal()->os_crypt_async()->GetInstance(
+      future.GetCallback());
+  return future.Take();
+}
+
+password_manager::StoredCredential MakeCredential(
+    const std::string& signon_realm,
+    const std::u16string& username,
+    const std::u16string& password) {
+  password_manager::StoredCredential cred;
+  cred.url = GURL(signon_realm);
+  cred.signon_realm = signon_realm;
+  cred.username_value = username;
+  cred.password_value = password;
+  cred.in_store = password_manager::PasswordForm::Store::kProfileStore;
+  return cred;
+}
+
+}  // namespace
+
+class BravePasswordImporterTest : public testing::Test {
+ protected:
+  void SetUp() override {
+    ASSERT_TRUE(temp_dir_.CreateUniqueTempDir());
+    // The source profile directory holds the `Login Data` file we will import
+    // from.
+    source_path_ = temp_dir_.GetPath().AppendASCII("source");
+    ASSERT_TRUE(base::CreateDirectory(source_path_));
+
+    profile_ = TestingProfile::Builder().Build();
+    ProfilePasswordStoreFactory::GetInstance()->SetTestingFactoryAndUse(
+        profile_.get(),
+        base::BindRepeating(
+            &password_manager::BuildPasswordStore<
+                content::BrowserContext, password_manager::TestPasswordStore>));
+    ASSERT_TRUE(password_store());
+  }
+
+  // Fetches the store from the factory on demand rather than caching a raw
+  // pointer. The store is a RefcountedKeyedService owned by the profile; the
+  // factory keeps it alive, and letting `profile_` destruct before
+  // `task_environment_` drains its backend without a dangling pointer.
+  password_manager::TestPasswordStore* password_store() {
+    return static_cast<password_manager::TestPasswordStore*>(
+        ProfilePasswordStoreFactory::GetForProfile(
+            profile_.get(), ServiceAccessType::EXPLICIT_ACCESS)
+            .get());
+  }
+
+  // Writes `credentials` into a `Login Data` SQLite store inside the source
+  // profile directory. By default it encrypts with the same OSCryptAsync
+  // instance the importer will later decrypt with; pass a different
+  // `encryptor` to simulate a key mismatch between the source and destination
+  // installations.
+  void WriteLoginData(
+      const std::vector<password_manager::StoredCredential>& credentials,
+      scoped_refptr<os_crypt_async::Encryptor> encryptor = nullptr) {
+    if (!encryptor) {
+      encryptor = GetEncryptorSync();
+    }
+    base::FilePath login_data_path =
+        source_path_.Append(FILE_PATH_LITERAL("Login Data"));
+    password_manager::LoginDatabase database(
+        login_data_path, password_manager::IsAccountStore(false));
+    ASSERT_TRUE(database.Init(base::NullCallback(), std::move(encryptor)));
+    for (const auto& cred : credentials) {
+      ASSERT_FALSE(
+          database.AddLogin(password_manager::CloneStoredCredential(cred))
+              .empty());
+    }
+  }
+
+  // Runs an import and returns the (result, submitted-count) pair.
+  std::pair<BravePasswordImporter::Result, size_t> RunImport() {
+    BravePasswordImporter importer;
+    base::test::TestFuture<BravePasswordImporter::Result, size_t> future;
+    importer.StartImport(source_path_, profile_.get(), future.GetCallback());
+    return {future.Get<0>(), future.Get<1>()};
+  }
+
+  content::BrowserTaskEnvironment task_environment_;
+  base::ScopedTempDir temp_dir_;
+  base::FilePath source_path_;
+  std::unique_ptr<TestingProfile> profile_;
+};
+
+TEST_F(BravePasswordImporterTest, ImportsAutofillableCredentials) {
+  std::vector<password_manager::StoredCredential> credentials;
+  credentials.push_back(
+      MakeCredential("https://example.com/", u"alice", u"secret1"));
+  credentials.push_back(
+      MakeCredential("https://test.org/", u"bob", u"secret2"));
+  ASSERT_NO_FATAL_FAILURE(WriteLoginData(credentials));
+
+  EXPECT_EQ(RunImport(),
+            std::make_pair(BravePasswordImporter::Result::kSuccess, 2u));
+
+  auto stored = password_manager::GetAllLoginsSync(password_store());
+  EXPECT_EQ(2u, stored.size());
+  ASSERT_TRUE(stored.contains("https://example.com/"));
+  EXPECT_EQ(u"alice", stored.at("https://example.com/")[0].username_value);
+  EXPECT_EQ(u"secret1", stored.at("https://example.com/")[0].password_value);
+  ASSERT_TRUE(stored.contains("https://test.org/"));
+  EXPECT_EQ(u"bob", stored.at("https://test.org/")[0].username_value);
+}
+
+TEST_F(BravePasswordImporterTest, ImportsBlocklistedEntries) {
+  password_manager::StoredCredential blocked = MakeCredential(
+      "https://noprompt.com/", std::u16string(), std::u16string());
+  blocked.blocked_by_user = true;
+  std::vector<password_manager::StoredCredential> credentials;
+  credentials.push_back(std::move(blocked));
+  WriteLoginData(credentials);
+
+  EXPECT_EQ(RunImport(),
+            std::make_pair(BravePasswordImporter::Result::kSuccess, 1u));
+  EXPECT_TRUE(password_manager::GetAllLoginsSync(password_store())
+                  .contains("https://noprompt.com/"));
+}
+
+// A blocklisted entry in the source `Login Data` may carry a username and/or
+// password, but PasswordStore::AddLogins CHECKs that blocklisted entries have
+// neither. The importer must normalize them to empty before adding.
+TEST_F(BravePasswordImporterTest, BlocklistedEntryWithCredentialsIsNormalized) {
+  password_manager::StoredCredential blocked =
+      MakeCredential("https://noprompt.com/", u"leftover", u"leftover");
+  blocked.blocked_by_user = true;
+  std::vector<password_manager::StoredCredential> credentials;
+  credentials.push_back(std::move(blocked));
+  WriteLoginData(credentials);
+
+  // Must not crash the AddLogins CHECK, and the stored blocklist entry must
+  // have empty username/password.
+  EXPECT_EQ(RunImport(),
+            std::make_pair(BravePasswordImporter::Result::kSuccess, 1u));
+  auto stored = password_manager::GetAllLoginsSync(password_store());
+  ASSERT_TRUE(stored.contains("https://noprompt.com/"));
+  const auto& entry = stored.at("https://noprompt.com/")[0];
+  EXPECT_TRUE(entry.blocked_by_user);
+  EXPECT_TRUE(entry.username_value.empty());
+  EXPECT_TRUE(entry.password_value.empty());
+}
+
+TEST_F(BravePasswordImporterTest, MissingLoginDataReportsNotFound) {
+  // No `Login Data` file was written to the source path.
+  EXPECT_EQ(
+      RunImport(),
+      std::make_pair(BravePasswordImporter::Result::kLoginDataNotFound, 0u));
+  EXPECT_TRUE(password_manager::GetAllLoginsSync(password_store()).empty());
+}
+
+TEST_F(BravePasswordImporterTest, EmptyLoginDataReportsZero) {
+  WriteLoginData({});
+  EXPECT_EQ(RunImport(),
+            std::make_pair(BravePasswordImporter::Result::kSuccess, 0u));
+  EXPECT_TRUE(password_manager::GetAllLoginsSync(password_store()).empty());
+}
+
+// When the source `Login Data` was encrypted with a different key than the
+// destination's (e.g. a keychain item was deleted and regenerated, or the
+// profile was copied from another machine), decryption must fail and no
+// credentials may leak into the destination store.
+TEST_F(BravePasswordImporterTest, KeyMismatchImportsNothing) {
+  std::vector<password_manager::StoredCredential> credentials;
+  credentials.push_back(
+      MakeCredential("https://example.com/", u"alice", u"secret1"));
+  // A fresh test Encryptor uses a random key distinct from the destination's.
+  ASSERT_NO_FATAL_FAILURE(WriteLoginData(
+      credentials, os_crypt_async::GetTestEncryptorForTesting()));
+
+  auto [result, submitted] = RunImport();
+  // The exact Result is platform-dependent. On macOS undecryptable logins are
+  // cleared on read (kClearUndecryptablePasswords is enabled by default), so
+  // the read succeeds with nothing decrypted; on Linux they are not, so the
+  // read reports a failure. Either way, no credential may be submitted or leak.
+#if BUILDFLAG(IS_MAC)
+  EXPECT_EQ(BravePasswordImporter::Result::kSuccess, result);
+#else
+  EXPECT_EQ(BravePasswordImporter::Result::kReadFailed, result);
+#endif
+  EXPECT_EQ(0u, submitted);
+  EXPECT_TRUE(password_manager::GetAllLoginsSync(password_store()).empty());
+}

--- a/browser/importer/brave_password_importer_unittest.cc
+++ b/browser/importer/brave_password_importer_unittest.cc
@@ -17,7 +17,6 @@
 #include "base/functional/callback_helpers.h"
 #include "base/memory/scoped_refptr.h"
 #include "base/test/test_future.h"
-#include "build/build_config.h"
 #include "chrome/browser/password_manager/factories/profile_password_store_factory.h"
 #include "chrome/test/base/testing_browser_process.h"
 #include "chrome/test/base/testing_profile.h"
@@ -211,15 +210,14 @@ TEST_F(BravePasswordImporterTest, KeyMismatchImportsNothing) {
       credentials, os_crypt_async::GetTestEncryptorForTesting()));
 
   auto [result, submitted] = RunImport();
-  // The exact Result is platform-dependent. On macOS undecryptable logins are
-  // cleared on read (kClearUndecryptablePasswords is enabled by default), so
-  // the read succeeds with nothing decrypted; on Linux they are not, so the
-  // read reports a failure. Either way, no credential may be submitted or leak.
-#if BUILDFLAG(IS_MAC)
-  EXPECT_EQ(BravePasswordImporter::Result::kSuccess, result);
-#else
-  EXPECT_EQ(BravePasswordImporter::Result::kReadFailed, result);
-#endif
+  // The exact Result depends on how password_manager handles undecryptable
+  // rows: it may drop them and report success with nothing decrypted, or
+  // report a read failure. That internal behavior is not something this
+  // importer controls, so accept either. What must always hold is that no
+  // credential is submitted to the store or leaks into it.
+  EXPECT_TRUE(result == BravePasswordImporter::Result::kSuccess ||
+              result == BravePasswordImporter::Result::kReadFailed)
+      << "unexpected result=" << static_cast<int>(result);
   EXPECT_EQ(0u, submitted);
   EXPECT_TRUE(password_manager::GetAllLoginsSync(password_store()).empty());
 }

--- a/browser/importer/sources.gni
+++ b/browser/importer/sources.gni
@@ -11,8 +11,10 @@ brave_browser_importer_impl_sources = []
 brave_browser_importer_impl_deps = []
 
 if (!is_android) {
-  brave_browser_importer_sources +=
-      [ "//brave/browser/importer/brave_external_process_importer_host.h" ]
+  brave_browser_importer_sources += [
+    "//brave/browser/importer/brave_external_process_importer_host.h",
+    "//brave/browser/importer/brave_password_importer.h",
+  ]
   brave_browser_importer_public_deps += [
     "//base",
     "//chrome/common/extensions",
@@ -24,6 +26,7 @@ if (!is_android) {
     "//brave/browser/importer/brave_external_process_importer_host.cc",
     "//brave/browser/importer/brave_in_process_importer_bridge.cc",
     "//brave/browser/importer/brave_in_process_importer_bridge.h",
+    "//brave/browser/importer/brave_password_importer.cc",
   ]
   if (enable_extensions) {
     brave_browser_importer_impl_sources += [
@@ -43,8 +46,16 @@ if (!is_android) {
     "//base",
     "//brave/app:brave_generated_resources_grit_grit",
     "//brave/browser/importer",
+    "//brave/common/importer",
     "//brave/common/importer:interfaces",
     "//brave/components/brave_origin/buildflags",
+    "//chrome/browser:browser_process",
+    "//chrome/browser/password_manager/factories",
+    "//components/keyed_service/core",
+    "//components/os_crypt/async/browser",
+    "//components/os_crypt/async/common",
+    "//components/password_manager/core/browser/password_store:password_store_impl",
+    "//components/password_manager/core/browser/password_store:password_store_interface",
     "//content/public/browser",
     "//extensions/buildflags",
     "//mojo/public/cpp/bindings",

--- a/browser/ui/webui/settings/brave_import_data_handler.cc
+++ b/browser/ui/webui/settings/brave_import_data_handler.cc
@@ -94,6 +94,8 @@ void BraveImportDataHandler::StartImportImpl(
     import_observers_.erase(source_profile.source_path);
   }
 
+  import_did_succeed_ = false;
+
   FireWebUIListener("import-data-status-changed", base::Value("inProgress"));
 
   // Using weak pointers because it destroys itself when finshed.

--- a/common/importer/chrome_importer_utils.cc
+++ b/common/importer/chrome_importer_utils.cc
@@ -149,6 +149,19 @@ bool CanImportPasswordsForType(user_data_importer::ImporterType type) {
   }
 #endif
 
+  // Brave-to-Brave password import relies on both installations sharing the
+  // same OS keychain entry, which only holds on macOS and Linux. On Windows
+  // each installation instead stores its own random key in its own Local
+  // State, encrypted with DPAPI (so DPAPI is still in use, just not the way
+  // older versions used it as the shared key directly). Because that per-key
+  // is unique per installation, the destination cannot decrypt the source's
+  // `Login Data`.
+#if BUILDFLAG(IS_WIN)
+  if (type == user_data_importer::TYPE_BRAVE) {
+    return false;
+  }
+#endif
+
   return true;
 }
 

--- a/common/importer/chrome_importer_utils_unittest.cc
+++ b/common/importer/chrome_importer_utils_unittest.cc
@@ -14,6 +14,7 @@
 #include "base/test/values_test_util.h"
 #include "brave/common/importer/importer_constants.h"
 #include "brave/components/constants/brave_paths.h"
+#include "build/build_config.h"
 #include "components/user_data_importer/common/importer_data_types.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
@@ -151,11 +152,21 @@ TEST_F(BraveChromeImporterUtilsTest, BraveImporterCanImportPasswords) {
   base::WriteFile(GetTestProfilePath().AppendASCII("Login Data"), "dummy");
   uint16_t services_supported = user_data_importer::NONE;
 
-  // TYPE_BRAVE should support password import.
+  // TYPE_BRAVE supports password import on macOS and Linux, where both
+  // installations share the same OS keychain entry. On Windows each install
+  // has its own key, so password import is not offered and (with only Login
+  // Data present) ChromeImporterCanImport returns false.
+#if BUILDFLAG(IS_WIN)
+  EXPECT_FALSE(ChromeImporterCanImport(GetTestProfilePath(),
+                                       user_data_importer::TYPE_BRAVE,
+                                       &services_supported));
+  EXPECT_FALSE(services_supported & user_data_importer::PASSWORDS);
+#else
   EXPECT_TRUE(ChromeImporterCanImport(GetTestProfilePath(),
                                       user_data_importer::TYPE_BRAVE,
                                       &services_supported));
   EXPECT_TRUE(services_supported & user_data_importer::PASSWORDS);
+#endif
 
   // TYPE_CHROME should NOT support password import (app-bound encryption).
   // With only Login Data present and no other importable data,
@@ -181,7 +192,12 @@ TEST_F(BraveChromeImporterUtilsTest, BraveImporterCanImportAllDataTypes) {
                                       &services_supported));
   EXPECT_TRUE(services_supported & user_data_importer::FAVORITES);
   EXPECT_TRUE(services_supported & user_data_importer::HISTORY);
+#if BUILDFLAG(IS_WIN)
+  // Password import from Brave is not offered on Windows (per-install keys).
+  EXPECT_FALSE(services_supported & user_data_importer::PASSWORDS);
+#else
   EXPECT_TRUE(services_supported & user_data_importer::PASSWORDS);
+#endif
   EXPECT_TRUE(services_supported & user_data_importer::EXTENSIONS);
 }
 


### PR DESCRIPTION
- Adds `BravePasswordImporter` which runs in the browser process and uses `OSCryptAsync` to decrypt the source Brave  `Login Data` SQLite store; decrypted credentials are written to the destination profile's `PasswordStore`.
- Brave Origin and Standard Brave share the same OS-level encryption key

note: Windows is not included because it uses a different key

note 2: Right now you can only import Brave from Brave Origin. If you are using a Brave build you can't use this.

Fixes https://github.com/brave/brave-browser/issues/55631

## Test plan

If testing with a dev build, then use `--use_real_keychain`

1. Have a Brave profile with some passwords in it
2. Quit the application
3. Start a new install of Brave Origin
4. On `brave://welcome`, click Skip, then import from Brave.
5. Open `brave://password-manager/passwords` in Brave Origin (in one of the imported profiles) and verify the passwords are present.
6. Repeat the process with brave://settings "Import bookmarks and settings" option.  It should list passwords only on Linux and macOS and import only when selected. 