### PR TITLE
[iOS] Handle all executions errors from simulator test runner summary

### DIFF
--- a/tools/test/chromium_to_junit_converter.py
+++ b/tools/test/chromium_to_junit_converter.py
@@ -52,8 +52,7 @@ class ChromiumToJUnitConverter:
         # Calculate totals
         total_passed = len(passed_tests)
         total_failed = len(failed_tests)
-        has_execution_error = bool(step_text
-                                   and 'TEST EXECUTE FAILED' in step_text)
+        has_execution_error = bool(step_text)
         total_tests = total_passed + total_failed + (1 if has_execution_error
                                                      else 0)
 


### PR DESCRIPTION
The `step_text` key is only ever set if an exception was raised while executing the iOS simulator test runners, we should ensure that all exceptions result in a failure to catch issues such as `AppLaunchError` which occurs when the test suite crashes and fails to run any tests
