### PR TITLE
[Wallet]: Fix Duplicate Key Warning on Deposit Screen

### DIFF
--- a/components/brave_wallet_ui/components/desktop/views/portfolio/components/token-lists/virtualized-tokens-list.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/components/token-lists/virtualized-tokens-list.tsx
@@ -11,7 +11,10 @@ import AutoSizer from 'react-virtualized-auto-sizer'
 import { BraveWallet } from '../../../../../../constants/types'
 
 // Utils
-import { getAssetIdKey } from '../../../../../../utils/asset-utils'
+import {
+  dedupeAssetsByIdKey,
+  getAssetIdKey,
+} from '../../../../../../utils/asset-utils'
 
 // Styles
 import { listItemInitialHeight, AutoSizerStyle } from './token-list.style'
@@ -85,10 +88,16 @@ export const VirtualizedTokensList = React.memo(function <T extends any[]>({
   userAssetList,
   selectedAssetId,
 }: VirtualizedTokensListProps<T>) {
+  const dedupedUserAssetList = React.useMemo(
+    () =>
+      dedupeAssetsByIdKey(userAssetList as BraveWallet.BlockchainToken[]) as T,
+    [userAssetList],
+  )
+
   // Refs
   const listRef = React.useRef<List | null>(null)
   const itemSizes = React.useRef<number[]>(
-    new Array(userAssetList.length).fill(listItemInitialHeight),
+    new Array(dedupedUserAssetList.length).fill(listItemInitialHeight),
   )
 
   // Methods
@@ -102,7 +111,7 @@ export const VirtualizedTokensList = React.memo(function <T extends any[]>({
       }
       // Get selectedAssetId index
       if (listRef.current && selectedAssetId) {
-        const itemIndex = userAssetList.findIndex(
+        const itemIndex = dedupedUserAssetList.findIndex(
           (asset) => getAssetIdKey(asset) === selectedAssetId,
         )
         // Scroll selected asset into view
@@ -111,7 +120,7 @@ export const VirtualizedTokensList = React.memo(function <T extends any[]>({
         }
       }
     },
-    [listRef, selectedAssetId, userAssetList],
+    [listRef, selectedAssetId, dedupedUserAssetList],
   )
 
   const setSize = React.useCallback(
@@ -146,8 +155,8 @@ export const VirtualizedTokensList = React.memo(function <T extends any[]>({
             width={width}
             height={height}
             itemSize={getSize}
-            itemData={userAssetList}
-            itemCount={userAssetList.length}
+            itemData={dedupedUserAssetList}
+            itemCount={dedupedUserAssetList.length}
             overscanCount={10}
             itemKey={getItemKey}
             children={(itemProps) => (

--- a/components/brave_wallet_ui/page/screens/fund-wallet/deposit-funds.tsx
+++ b/components/brave_wallet_ui/page/screens/fund-wallet/deposit-funds.tsx
@@ -23,6 +23,7 @@ import {
 import { getLocale } from '../../../../common/locale'
 import { makeNetworkAsset } from '../../../options/asset-options'
 import {
+  dedupeAssetsByIdKey,
   getAssetIdKey,
   sortNativeAndAndBatAssetsToTop,
   tokenNameToNftCollectionName,
@@ -329,10 +330,12 @@ function AssetSelection() {
     const sortedFungibleAssets = sortNativeAndAndBatAssetsToTop(
       tokensList,
     ).filter((token) => token.contractAddress && !token.tokenId)
-    return mainnetNetworkAssetsList.concat(
-      sortedFungibleAssets,
-      testnetAssetsList,
-      nftCollectionAssets,
+    return dedupeAssetsByIdKey(
+      mainnetNetworkAssetsList.concat(
+        sortedFungibleAssets,
+        testnetAssetsList,
+        nftCollectionAssets,
+      ),
     )
   }, [
     mainnetNetworkAssetsList,

--- a/components/brave_wallet_ui/utils/asset-utils.test.ts
+++ b/components/brave_wallet_ui/utils/asset-utils.test.ts
@@ -15,6 +15,7 @@ import {
   checkIfTokenNeedsNetworkIcon,
   searchNftCollectionsAndGetTotalNftsFound,
   getTokenCollectionName,
+  dedupeAssetsByIdKey,
   getAssetIdKey,
   isTokenWatchOnly,
   getDoesCoinSupportSwap,
@@ -217,5 +218,40 @@ describe('getDoesCoinSupportBridge', () => {
   it('returns false for coins that do not support bridge', () => {
     expect(getDoesCoinSupportBridge(BraveWallet.CoinType.FIL)).toBe(false)
     expect(getDoesCoinSupportBridge(BraveWallet.CoinType.DOT)).toBe(false)
+  })
+})
+
+describe('dedupeAssetsByIdKey', () => {
+  it('returns an empty array when given no assets', () => {
+    expect(dedupeAssetsByIdKey([])).toEqual([])
+  })
+
+  it('returns all assets when there are no duplicates', () => {
+    const assets = [ethToken, batToken]
+    expect(dedupeAssetsByIdKey(assets)).toEqual(assets)
+  })
+
+  it('removes duplicate assets with the same asset id key', () => {
+    const duplicateBat = { ...batToken, name: 'Duplicate BAT' }
+    const assets = [ethToken, batToken, duplicateBat]
+
+    expect(dedupeAssetsByIdKey(assets)).toEqual([ethToken, batToken])
+    expect(getAssetIdKey(batToken)).toBe(getAssetIdKey(duplicateBat))
+  })
+
+  it('keeps the first occurrence when duplicates differ only by casing', () => {
+    const duplicateBat = {
+      ...batToken,
+      contractAddress: batToken.contractAddress.toUpperCase(),
+    }
+    const assets = [batToken, duplicateBat]
+
+    expect(dedupeAssetsByIdKey(assets)).toEqual([batToken])
+  })
+
+  it('keeps assets with different asset id keys', () => {
+    const assets = [nftTokenOne, nftTokenTwo, ethToken, batToken]
+
+    expect(dedupeAssetsByIdKey(assets)).toEqual(assets)
   })
 })

--- a/components/brave_wallet_ui/utils/asset-utils.ts
+++ b/components/brave_wallet_ui/utils/asset-utils.ts
@@ -177,6 +177,18 @@ export const getAssetIdKey = (
       : `${asset.coin}-${asset.contractAddress.toLowerCase()}-${asset.chainId}`
 }
 
+export const dedupeAssetsByIdKey = (assets: BraveWallet.BlockchainToken[]) => {
+  const seenIds = new Set<string>()
+  return assets.filter((asset) => {
+    const id = getAssetIdKey(asset)
+    if (seenIds.has(id)) {
+      return false
+    }
+    seenIds.add(id)
+    return true
+  })
+}
+
 export const findTokenByContractAddress = <
   T extends Pick<BraveWallet.BlockchainToken, 'contractAddress'>,
 >(


### PR DESCRIPTION
## Description 

Fixes a duplicate `Key` warning on the Wallet `Deposit` screen

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/55840>

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

## Test plan:
1. Open the `Wallet` and navigate to the `Deposit` screen
2. Open the `Console`, you should not see a warning for duplicate `Keys`


Before:

<img width="1494" height="1075" alt="Screenshot 28" src="https://github.com/user-attachments/assets/38af19f5-c17f-4c43-b7da-aaae3dcb0774" />

After:

<img width="1597" height="1086" alt="Screenshot 31" src="https://github.com/user-attachments/assets/b0173db6-1ef3-4305-8f58-3d2140d23bd0" />