### PR TITLE
[Origin] Initialize BraveOriginPolicyManager before profile builds

### DIFF
--- a/browser/brave_browser_process_impl.cc
+++ b/browser/brave_browser_process_impl.cc
@@ -14,6 +14,7 @@
 #include "base/memory/scoped_refptr.h"
 #include "base/path_service.h"
 #include "base/task/thread_pool.h"
+#include "brave/browser/brave_origin/brave_origin_service_factory.h"
 #include "brave/browser/brave_referrals/referrals_service_delegate.h"
 #include "brave/browser/brave_shields/ad_block_subscription_download_manager_getter.h"
 #include "brave/browser/brave_stats/buildflags.h"
@@ -214,6 +215,21 @@ void BraveBrowserProcessImpl::Init() {
   // Lazy initialization of AdBlockOnlyModePolicyManager
   brave_policy::AdBlockOnlyModePolicyManager::GetInstance()->Init(
       local_state());
+
+  // Initialize BraveOriginPolicyManager here so its managed prefs are merged
+  // into local state before any profile's policy connector polls
+  // `BraveProfilePolicyProvider::IsInitializationComplete`. Without this,
+  // profile pref-store init can deadlock waiting for the gate while the gate
+  // is waiting for `BuildServiceInstanceForBrowserContext` (gated on profile
+  // build) to run `Init` -- manifests as "stuck on profile selection."
+  auto* origin_policy_manager =
+      brave_origin::BraveOriginPolicyManager::GetInstance();
+  if (!origin_policy_manager->IsInitialized()) {
+    origin_policy_manager->Init(
+        brave_origin::BraveOriginServiceFactory::GetBrowserPolicyDefinitions(),
+        brave_origin::BraveOriginServiceFactory::GetProfilePolicyDefinitions(),
+        local_state());
+  }
 }
 
 void BraveBrowserProcessImpl::PreMainMessageLoopRun() {


### PR DESCRIPTION
`BraveOriginPolicyManager::Init` was only called lazily from `BraveOriginServiceFactory::BuildServiceInstanceForBrowserContext`, which runs during profile keyed-service build. Profile pref-store init waits on `PolicyService::IsInitializationComplete`, which waits on `BraveProfilePolicyProvider::IsInitializationComplete`, which gates on `manager->IsInitialized()` -- and that's only flipped by the lazy call that itself is gated on profile build. Cycle manifests as "stuck on profile selection screen" for some users.

Initialize the manager eagerly at the end of `BraveBrowserProcessImpl::Init()`, right next to the existing `AdBlockOnlyModePolicyManager::Init` call. The factory's lazy `if (!IsInitialized()) Init(...)` block stays as a backstop for tests that bypass `BraveBrowserProcessImpl`.

Resolves: https://github.com/brave/brave-browser/issues/55733

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
