### PR TITLE
Uplift fixes to 1.91.x

### DIFF
--- a/browser/BUILD.gn
+++ b/browser/BUILD.gn
@@ -30,6 +30,7 @@ source_set("browser_process") {
   sources = [ "brave_browser_process.h" ]
 
   deps = [
+    "//brave/browser/brave_stats:buildflags",
     "//brave/components/brave_ads/buildflags",
     "//brave/components/brave_vpn/common/buildflags",
     "//brave/components/local_ai/core",

--- a/browser/brave_browser_main_extra_parts.cc
+++ b/browser/brave_browser_main_extra_parts.cc
@@ -79,8 +79,10 @@ void BraveBrowserMainExtraParts::PreProfileInit() {
   g_brave_browser_process->ads_brave_stats_helper();
 #endif  // BUILDFLAG(ENABLE_BRAVE_ADS)
 
+#if BUILDFLAG(ENABLE_BRAVE_STATS_UPDATER)
   // Early initialize brave stats
   g_brave_browser_process->brave_stats_updater();
+#endif
 }
 
 void BraveBrowserMainExtraParts::PostBrowserStart() {

--- a/browser/brave_browser_process.h
+++ b/browser/brave_browser_process.h
@@ -11,6 +11,7 @@
 #ifndef BRAVE_BROWSER_BRAVE_BROWSER_PROCESS_H_
 #define BRAVE_BROWSER_BRAVE_BROWSER_PROCESS_H_
 
+#include "brave/browser/brave_stats/buildflags.h"
 #include "brave/components/brave_ads/buildflags/buildflags.h"
 #include "brave/components/brave_vpn/common/buildflags/buildflags.h"
 #include "brave/components/request_otr/common/buildflags/buildflags.h"
@@ -38,9 +39,11 @@ namespace brave_shields {
 class AdBlockService;
 }  // namespace brave_shields
 
+#if BUILDFLAG(ENABLE_BRAVE_STATS_UPDATER)
 namespace brave_stats {
 class BraveStatsUpdater;
 }  // namespace brave_stats
+#endif
 
 namespace debounce {
 class DebounceComponentInstaller;
@@ -109,7 +112,9 @@ class BraveBrowserProcess {
 #endif
   virtual p3a::P3AService* p3a_service() = 0;
   virtual brave::BraveReferralsService* brave_referrals_service() = 0;
+#if BUILDFLAG(ENABLE_BRAVE_STATS_UPDATER)
   virtual brave_stats::BraveStatsUpdater* brave_stats_updater() = 0;
+#endif
 #if BUILDFLAG(ENABLE_BRAVE_ADS)
   virtual brave_ads::BraveStatsHelper* ads_brave_stats_helper() = 0;
   virtual brave_ads::ResourceComponent* resource_component() = 0;

--- a/browser/brave_browser_process_impl.cc
+++ b/browser/brave_browser_process_impl.cc
@@ -17,7 +17,7 @@
 #include "brave/browser/brave_origin/brave_origin_service_factory.h"
 #include "brave/browser/brave_referrals/referrals_service_delegate.h"
 #include "brave/browser/brave_shields/ad_block_subscription_download_manager_getter.h"
-#include "brave/browser/brave_stats/brave_stats_updater.h"
+#include "brave/browser/brave_stats/buildflags.h"
 #include "brave/browser/brave_stats/first_run_util.h"
 #include "brave/browser/component_updater/brave_component_updater_configurator.h"
 #include "brave/browser/misc_metrics/process_misc_metrics.h"
@@ -59,6 +59,10 @@
 #include "content/public/browser/child_process_security_policy.h"
 #include "services/network/public/cpp/resource_request.h"
 #include "services/network/public/cpp/shared_url_loader_factory.h"
+
+#if BUILDFLAG(ENABLE_BRAVE_STATS_UPDATER)
+#include "brave/browser/brave_stats/brave_stats_updater.h"
+#endif
 
 #if BUILDFLAG(ENABLE_EXTENSIONS_CORE)
 #include "chrome/browser/extensions/chrome_component_extension_resource_manager.h"
@@ -243,7 +247,9 @@ void BraveBrowserProcessImpl::StartTearDown() {
 #if BUILDFLAG(ENABLE_BRAVE_ADS)
   brave_stats_helper_.reset();
 #endif  // BUILDFLAG(ENABLE_BRAVE_ADS)
+#if BUILDFLAG(ENABLE_BRAVE_STATS_UPDATER)
   brave_stats_updater_.reset();
+#endif
   brave_referrals_service_.reset();
   if (ntp_background_images_service_) {
     ntp_background_images_service_->StartTearDown();
@@ -488,6 +494,7 @@ BraveBrowserProcessImpl::brave_referrals_service() {
   return brave_referrals_service_.get();
 }
 
+#if BUILDFLAG(ENABLE_BRAVE_STATS_UPDATER)
 brave_stats::BraveStatsUpdater* BraveBrowserProcessImpl::brave_stats_updater() {
   if (!brave_stats_updater_) {
     brave_stats_updater_ = std::make_unique<brave_stats::BraveStatsUpdater>(
@@ -495,6 +502,7 @@ brave_stats::BraveStatsUpdater* BraveBrowserProcessImpl::brave_stats_updater() {
   }
   return brave_stats_updater_.get();
 }
+#endif  // BUILDFLAG(ENABLE_BRAVE_STATS_UPDATER)
 
 #if BUILDFLAG(ENABLE_BRAVE_ADS)
 brave_ads::BraveStatsHelper* BraveBrowserProcessImpl::ads_brave_stats_helper() {

--- a/browser/brave_browser_process_impl.h
+++ b/browser/brave_browser_process_impl.h
@@ -39,9 +39,11 @@ namespace https_upgrade_exceptions {
 class HttpsUpgradeExceptionsService;
 }  // namespace https_upgrade_exceptions
 
+#if BUILDFLAG(ENABLE_BRAVE_STATS_UPDATER)
 namespace brave_stats {
 class BraveStatsUpdater;
 }  // namespace brave_stats
+#endif
 
 namespace debounce {
 class DebounceComponentInstaller;
@@ -127,7 +129,9 @@ class BraveBrowserProcessImpl : public BraveBrowserProcess,
 #endif
   p3a::P3AService* p3a_service() override;
   brave::BraveReferralsService* brave_referrals_service() override;
+#if BUILDFLAG(ENABLE_BRAVE_STATS_UPDATER)
   brave_stats::BraveStatsUpdater* brave_stats_updater() override;
+#endif
 #if BUILDFLAG(ENABLE_BRAVE_ADS)
   brave_ads::BraveStatsHelper* ads_brave_stats_helper() override;
   brave_ads::ResourceComponent* resource_component() override;
@@ -188,7 +192,9 @@ class BraveBrowserProcessImpl : public BraveBrowserProcess,
 #endif
   std::unique_ptr<brave::URLSanitizerComponentInstaller>
       url_sanitizer_component_installer_;
+#if BUILDFLAG(ENABLE_BRAVE_STATS_UPDATER)
   std::unique_ptr<brave_stats::BraveStatsUpdater> brave_stats_updater_;
+#endif
   std::unique_ptr<brave::BraveReferralsService> brave_referrals_service_;
 #if BUILDFLAG(ENABLE_TOR)
   std::unique_ptr<tor::BraveTorClientUpdater> tor_client_updater_;

--- a/browser/brave_local_state_prefs.cc
+++ b/browser/brave_local_state_prefs.cc
@@ -8,7 +8,7 @@
 #include <string>
 
 #include "base/values.h"
-#include "brave/browser/brave_stats/brave_stats_updater.h"
+#include "brave/browser/brave_stats/buildflags.h"
 #include "brave/browser/metrics/buildflags/buildflags.h"
 #include "brave/browser/metrics/metrics_reporting_util.h"
 #include "brave/browser/misc_metrics/process_misc_metrics.h"
@@ -47,6 +47,10 @@
 #include "components/prefs/pref_registry_simple.h"
 #include "components/webui/chrome_urls/pref_names.h"
 #include "third_party/widevine/cdm/buildflags.h"
+
+#if BUILDFLAG(ENABLE_BRAVE_STATS_UPDATER)
+#include "brave/browser/brave_stats/brave_stats_updater.h"
+#endif
 
 #if BUILDFLAG(ENABLE_PLAYLIST)
 #include "brave/browser/playlist/playlist_service_factory.h"
@@ -136,7 +140,9 @@ void RegisterLocalStatePrefsForMigration(PrefRegistrySimple* registry) {
 #endif
   brave_search_conversion::p3a::RegisterLocalStatePrefsForMigration(registry);
   brave_shields::RegisterPrefsForAdBlockServiceForMigration(registry);
+#if BUILDFLAG(ENABLE_BRAVE_STATS_UPDATER)
   brave_stats::RegisterLocalStatePrefsForMigration(registry);
+#endif
   p3a::MetricLogStore::RegisterLocalStatePrefsForMigration(registry);
   p3a::RotationScheduler::RegisterLocalStatePrefsForMigration(registry);
 
@@ -154,7 +160,15 @@ void RegisterLocalStatePrefsForMigration(PrefRegistrySimple* registry) {
 
 void RegisterLocalStatePrefs(PrefRegistrySimple* registry) {
   brave_shields::RegisterPrefsForAdBlockService(registry);
+  // `kStatsReportingEnabled` is the user/policy-facing opt-in for anonymous
+  // usage pings. It is read by other systems (privacy settings UI, policy
+  // map, referrals service, SERP tab helper, Brave Origin service) that
+  // remain compiled in even when the stats updater itself is excluded, so
+  // it must always be registered.
+  registry->RegisterBooleanPref(kStatsReportingEnabled, true);
+#if BUILDFLAG(ENABLE_BRAVE_STATS_UPDATER)
   brave_stats::RegisterLocalStatePrefs(registry);
+#endif
   brave_origin::RegisterLocalStatePrefs(registry);
   ntp_background_images::RegisterLocalStatePrefs(registry);
   RegisterPrefsForBraveReferralsService(registry);

--- a/browser/brave_origin/BUILD.gn
+++ b/browser/brave_origin/BUILD.gn
@@ -5,6 +5,7 @@
 
 import("//brave/components/ai_chat/core/common/buildflags/buildflags.gni")
 import("//brave/components/brave_news/common/buildflags/buildflags.gni")
+import("//brave/components/brave_rewards/core/buildflags/buildflags.gni")
 import("//brave/components/brave_talk/buildflags/buildflags.gni")
 import("//brave/components/brave_vpn/common/buildflags/buildflags.gni")
 import("//brave/components/brave_wallet/common/buildflags/buildflags.gni")
@@ -32,6 +33,7 @@ source_set("brave_origin") {
     "//brave/components/brave_news/common/buildflags",
     "//brave/components/brave_policy",
     "//brave/components/brave_rewards/core",
+    "//brave/components/brave_rewards/core/buildflags",
     "//brave/components/brave_talk/buildflags",
     "//brave/components/brave_vpn/common/buildflags",
     "//brave/components/brave_wallet/common/buildflags",
@@ -107,6 +109,7 @@ source_set("unit_tests") {
     "//brave/browser/ui/brave_origin",
     "//brave/components/brave_origin",
     "//brave/components/brave_rewards/core",
+    "//brave/components/brave_rewards/core/buildflags",
     "//brave/components/constants",
     "//brave/components/p3a",
     "//chrome/browser/profiles",

--- a/browser/brave_origin/brave_origin_service_factory.cc
+++ b/browser/brave_origin/brave_origin_service_factory.cc
@@ -19,7 +19,7 @@
 #include "brave/components/brave_origin/brave_origin_policy_manager.h"
 #include "brave/components/brave_origin/brave_origin_service.h"
 #include "brave/components/brave_origin/profile_id.h"
-#include "brave/components/brave_rewards/core/pref_names.h"
+#include "brave/components/brave_rewards/core/buildflags/buildflags.h"
 #include "brave/components/brave_talk/buildflags/buildflags.h"
 #include "brave/components/brave_wallet/common/buildflags/buildflags.h"
 #include "brave/components/brave_wayback_machine/pref_names.h"
@@ -46,6 +46,10 @@
 
 #if BUILDFLAG(ENABLE_AI_CHAT)
 #include "brave/components/ai_chat/core/common/pref_names.h"
+#endif
+
+#if BUILDFLAG(ENABLE_BRAVE_REWARDS)
+#include "brave/components/brave_rewards/core/pref_names.h"
 #endif
 
 #if BUILDFLAG(ENABLE_BRAVE_NEWS)
@@ -130,11 +134,13 @@ constexpr auto kBraveOriginProfileMetadata =
              false,
              /*user_settable=*/true)},
 
+#if BUILDFLAG(ENABLE_BRAVE_REWARDS)
         // Brave Rewards preferences
         {brave_rewards::prefs::kDisabledByPolicy,
          BraveOriginServiceFactory::BraveOriginPrefMetadata(
              true,
              /*user_settable=*/false)},
+#endif
 
 #if BUILDFLAG(ENABLE_BRAVE_WALLET)
         // Brave Wallet preferences

--- a/browser/brave_origin/brave_origin_service_factory_unittest.cc
+++ b/browser/brave_origin/brave_origin_service_factory_unittest.cc
@@ -8,7 +8,8 @@
 #include "base/containers/map_util.h"
 #include "brave/browser/policy/brave_simple_policy_map.h"
 #include "brave/components/brave_origin/brave_origin_policy_info.h"
-#include "brave/components/brave_rewards/core/pref_names.h"
+#include "brave/components/brave_origin/buildflags/buildflags.h"
+#include "brave/components/brave_rewards/core/buildflags/buildflags.h"
 #include "brave/components/constants/pref_names.h"
 #include "brave/components/p3a/pref_names.h"
 #include "chrome/test/base/testing_browser_process.h"
@@ -17,6 +18,10 @@
 #include "components/policy/policy_constants.h"
 #include "content/public/test/browser_task_environment.h"
 #include "testing/gtest/include/gtest/gtest.h"
+
+#if BUILDFLAG(ENABLE_BRAVE_REWARDS)
+#include "brave/components/brave_rewards/core/pref_names.h"
+#endif
 
 #if BUILDFLAG(ENABLE_TOR)
 #include "brave/components/tor/pref_names.h"
@@ -59,10 +64,12 @@ TEST(BraveOriginServiceFactoryTest,
   EXPECT_EQ(tor_info->brave_origin_pref_key, tor::prefs::kTorDisabled);
 #endif
 
+#if BUILDFLAG(ENABLE_BRAVE_REWARDS)
   // Test that profile-level policies are NOT in browser definitions
   EXPECT_FALSE(
       browser_policy_definitions.contains(policy::key::kBraveRewardsDisabled))
       << "Profile-level policy should not be in browser definitions";
+#endif
 }
 
 TEST(BraveOriginServiceFactoryTest,
@@ -70,6 +77,7 @@ TEST(BraveOriginServiceFactoryTest,
   auto profile_policy_definitions =
       BraveOriginServiceFactory::GetProfilePolicyDefinitions();
 
+#if BUILDFLAG(ENABLE_BRAVE_REWARDS)
   // Test that Brave Rewards disabled policy is correctly built (profile-level)
   const auto* rewards_info = base::FindOrNull(
       profile_policy_definitions, policy::key::kBraveRewardsDisabled);
@@ -80,6 +88,7 @@ TEST(BraveOriginServiceFactoryTest,
   EXPECT_EQ(rewards_info->user_settable, false);
   EXPECT_EQ(rewards_info->brave_origin_pref_key,
             brave_rewards::prefs::kDisabledByPolicy);
+#endif
 
   // Test that browser-level policies are NOT in profile definitions
   EXPECT_FALSE(
@@ -145,9 +154,13 @@ TEST(BraveOriginServiceFactoryTest,
   EXPECT_GE(browser_policy_definitions.size(), 2u)
       << "Should have at least P3A and Stats browser policies";
 
-  // Verify that we have profile-level policies
+  // Verify that we have profile-level policies. On Brave Origin builds the
+  // features that contribute profile policies (Rewards, Wallet, Wayback, etc.)
+  // are all compiled out, so the intersection is legitimately empty there.
+#if !BUILDFLAG(IS_BRAVE_ORIGIN_BRANDED)
   EXPECT_GT(profile_policy_definitions.size(), 0u)
       << "Should have at least some profile policies";
+#endif
 }
 
 // Verifies that every policy claimed by Brave Origin is actually enforceable

--- a/browser/brave_stats/BUILD.gn
+++ b/browser/brave_stats/BUILD.gn
@@ -10,13 +10,14 @@ import("//build/buildflag_header.gni")
 
 buildflag_header("buildflags") {
   header = "buildflags.h"
-  flags = [ "BRAVE_USAGE_SERVER=\"$brave_stats_updater_url\"" ]
+  flags = [
+    "BRAVE_USAGE_SERVER=\"$brave_stats_updater_url\"",
+    "ENABLE_BRAVE_STATS_UPDATER=$enable_brave_stats_updater",
+  ]
 }
 
 source_set("brave_stats") {
   sources = [
-    "//brave/browser/brave_stats/brave_stats_updater.cc",
-    "//brave/browser/brave_stats/brave_stats_updater.h",
     "//brave/browser/brave_stats/brave_stats_updater_params.cc",
     "//brave/browser/brave_stats/brave_stats_updater_params.h",
     "//brave/browser/brave_stats/features.cc",
@@ -26,12 +27,21 @@ source_set("brave_stats") {
     "//brave/browser/brave_stats/switches.h",
   ]
 
-  public_deps = [ "//brave/components/brave_stats/browser" ]
+  if (enable_brave_stats_updater) {
+    sources += [
+      "//brave/browser/brave_stats/brave_stats_updater.cc",
+      "//brave/browser/brave_stats/brave_stats_updater.h",
+    ]
+  }
+
+  public_deps = [
+    "//brave/browser/brave_stats:buildflags",
+    "//brave/components/brave_stats/browser",
+  ]
 
   deps = [
     "//base",
     "//brave/browser:browser_process",
-    "//brave/browser/brave_stats:buildflags",
     "//brave/browser/misc_metrics",
     "//brave/browser/serp_metrics",
     "//brave/common",
@@ -74,7 +84,12 @@ source_set("brave_stats") {
 source_set("browser_tests") {
   testonly = true
 
-  sources = [ "//brave/browser/brave_stats/brave_stats_updater_browsertest.cc" ]
+  sources = []
+
+  if (enable_brave_stats_updater) {
+    sources +=
+        [ "//brave/browser/brave_stats/brave_stats_updater_browsertest.cc" ]
+  }
 
   deps = [
     "//brave/browser/brave_stats",
@@ -89,10 +104,11 @@ source_set("browser_tests") {
 source_set("unit_tests") {
   testonly = true
 
-  sources = [
-    "//brave/browser/brave_stats/brave_stats_updater_unittest.cc",
-    "//brave/browser/brave_stats/first_run_util_unittest.cc",
-  ]
+  sources = [ "//brave/browser/brave_stats/first_run_util_unittest.cc" ]
+
+  if (enable_brave_stats_updater) {
+    sources += [ "//brave/browser/brave_stats/brave_stats_updater_unittest.cc" ]
+  }
 
   deps = [
     "//brave/browser/brave_stats",

--- a/browser/brave_stats/brave_stats_updater.cc
+++ b/browser/brave_stats/brave_stats_updater.cc
@@ -404,7 +404,6 @@ void BraveStatsUpdater::SendServerPing() {
 
 void RegisterLocalStatePrefs(PrefRegistrySimple* registry) {
   registry->RegisterBooleanPref(kFirstCheckMade, false);
-  registry->RegisterBooleanPref(kStatsReportingEnabled, true);
   registry->RegisterIntegerPref(kLastCheckWOY, 0);
   registry->RegisterIntegerPref(kLastCheckMonth, 0);
   registry->RegisterStringPref(kLastCheckYMD, std::string());

--- a/browser/brave_stats/brave_stats_updater.h
+++ b/browser/brave_stats/brave_stats_updater.h
@@ -14,11 +14,17 @@
 #include "base/memory/scoped_refptr.h"
 #include "base/memory/weak_ptr.h"
 #include "base/scoped_observation.h"
+#include "brave/browser/brave_stats/buildflags.h"
 #include "brave/components/brave_origin/brave_origin_policy_manager.h"
 #include "brave/components/brave_policy/brave_policy_observer.h"
 #include "chrome/browser/profiles/profile_manager_observer.h"
 #include "services/network/public/cpp/shared_url_loader_factory.h"
 #include "url/gurl.h"
+
+static_assert(BUILDFLAG(ENABLE_BRAVE_STATS_UPDATER),
+              "BraveStatsUpdater must not be used when "
+              "enable_brave_stats_updater is false (e.g. Brave Origin "
+              "branded builds).");
 
 class BraveStatsUpdaterBrowserTest;
 class PrefChangeRegistrar;

--- a/browser/brave_stats/brave_stats_updater_unittest.cc
+++ b/browser/brave_stats/brave_stats_updater_unittest.cc
@@ -83,6 +83,8 @@ class BraveStatsUpdaterTest : public testing::Test {
     task_environment_.AdvanceClock(base::Minutes(30));
 
     brave_stats::RegisterLocalStatePrefs(testing_local_state_.registry());
+    testing_local_state_.registry()->RegisterBooleanPref(kStatsReportingEnabled,
+                                                         true);
     misc_metrics::GeneralBrowserUsage::RegisterPrefs(
         testing_local_state_.registry());
     brave::RegisterPrefsForBraveReferralsService(

--- a/browser/brave_stats/buildflags.gni
+++ b/browser/brave_stats/buildflags.gni
@@ -3,10 +3,14 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import("//brave/components/brave_origin/buildflags/buildflags.gni")
+
 declare_args() {
   brave_stats_updater_url = ""
+
+  enable_brave_stats_updater = !is_brave_origin_branded
 }
 
-if (is_official_build) {
+if (is_official_build && enable_brave_stats_updater) {
   assert(brave_stats_updater_url != "")
 }

--- a/browser/policy/BUILD.gn
+++ b/browser/policy/BUILD.gn
@@ -5,6 +5,7 @@
 
 import("//brave/components/ai_chat/core/common/buildflags/buildflags.gni")
 import("//brave/components/brave_news/common/buildflags/buildflags.gni")
+import("//brave/components/brave_rewards/core/buildflags/buildflags.gni")
 import("//brave/components/brave_talk/buildflags/buildflags.gni")
 import("//brave/components/brave_vpn/common/buildflags/buildflags.gni")
 import("//brave/components/brave_wallet/common/buildflags/buildflags.gni")
@@ -23,6 +24,7 @@ source_set("brave_simple_policy_map") {
     "//brave/components/ai_chat/core/common/buildflags",
     "//brave/components/brave_news/common/buildflags",
     "//brave/components/brave_rewards/core",
+    "//brave/components/brave_rewards/core/buildflags",
     "//brave/components/brave_shields/core/common",
     "//brave/components/brave_sync:prefs",
     "//brave/components/brave_talk/buildflags",

--- a/browser/policy/brave_simple_policy_map.h
+++ b/browser/policy/brave_simple_policy_map.h
@@ -8,7 +8,7 @@
 
 #include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
 #include "brave/components/brave_news/common/buildflags/buildflags.h"
-#include "brave/components/brave_rewards/core/pref_names.h"
+#include "brave/components/brave_rewards/core/buildflags/buildflags.h"
 #include "brave/components/brave_shields/core/common/pref_names.h"
 #include "brave/components/brave_sync/brave_sync_prefs.h"
 #include "brave/components/brave_talk/buildflags/buildflags.h"
@@ -31,6 +31,10 @@
 
 #if BUILDFLAG(ENABLE_AI_CHAT)
 #include "brave/components/ai_chat/core/common/pref_names.h"
+#endif
+
+#if BUILDFLAG(ENABLE_BRAVE_REWARDS)
+#include "brave/components/brave_rewards/core/pref_names.h"
 #endif
 
 #if BUILDFLAG(ENABLE_TOR)
@@ -72,8 +76,10 @@
 namespace policy {
 
 inline constexpr PolicyToPreferenceMapEntry kBraveSimplePolicyMap[] = {
+#if BUILDFLAG(ENABLE_BRAVE_REWARDS)
     {policy::key::kBraveRewardsDisabled,
      brave_rewards::prefs::kDisabledByPolicy, base::Value::Type::BOOLEAN},
+#endif
 #if BUILDFLAG(ENABLE_BRAVE_WALLET)
     {policy::key::kBraveWalletDisabled,
      brave_wallet::kBraveWalletDisabledByPolicy, base::Value::Type::BOOLEAN},

--- a/browser/resources/settings/br/settings_main.ts
+++ b/browser/resources/settings/br/settings_main.ts
@@ -77,10 +77,10 @@ RegisterPolymerTemplateModifications({
     switcher.appendChild(
       html`
         <template is="dom-if" if="[[showPage_(pageVisibility_.origin)]]">
-          <div slot="view" id="origin" class="cr-centered-card-container">
+          <div slot="view" id="origin">
             <template is="dom-if" if="[[renderPlugin_(
           routes_.ORIGIN, lastRoute_, inSearchMode_)]]">
-              <settings-brave-origin-page
+              <settings-brave-origin-page class="cr-centered-card-container"
                 prefs="{{prefs}}"
                 in-search-mode="[[inSearchMode_]]">
               </settings-brave-origin-page>

--- a/browser/ui/commands/accelerator_service.cc
+++ b/browser/ui/commands/accelerator_service.cc
@@ -453,10 +453,12 @@ bool AcceleratorService::IsCommandDisabledByPolicy(int command_id) const {
     case IDC_SHOW_BRAVE_REWARDS:
     case IDC_OFFERS_AND_REWARDS_FOR_PAGE:
       return pref_service_->GetBoolean(brave_rewards::prefs::kDisabledByPolicy);
-#if BUILDFLAG(ENABLE_AI_CHAT)
     case IDC_TOGGLE_AI_CHAT:
     case IDC_OPEN_FULL_PAGE_CHAT:
+#if BUILDFLAG(ENABLE_AI_CHAT)
       return !pref_service_->GetBoolean(ai_chat::prefs::kEnabledByPolicy);
+#else
+      return true;  // AI Chat not compiled in, always disabled
 #endif
     case IDC_NEW_OFFTHERECORD_WINDOW_TOR:
     case IDC_NEW_TOR_CONNECTION_FOR_SITE:

--- a/browser/ui/views/brave_actions/brave_rewards_action_view.cc
+++ b/browser/ui/views/brave_actions/brave_rewards_action_view.cc
@@ -16,6 +16,7 @@
 #include "brave/browser/ui/brave_icon_with_badge_image_source.h"
 #include "brave/browser/ui/page_info/features.h"
 #include "brave/browser/ui/webui/brave_rewards/rewards_page_top_ui.h"
+#include "brave/browser/ui/webui/brave_rewards/rewards_web_ui_utils.h"
 #include "brave/components/brave_rewards/content/rewards_p3a.h"
 #include "brave/components/brave_rewards/content/rewards_service.h"
 #include "brave/components/brave_rewards/core/pref_names.h"
@@ -406,6 +407,15 @@ void BraveRewardsActionView::ToggleRewardsPanel() {
   if (IsPanelOpen()) {
     DCHECK(bubble_manager_);
     bubble_manager_->CloseBubble();
+    return;
+  }
+
+  // If the Rewards WebUI has just been disabled (e.g. via Brave Origin or
+  // enterprise policy) but the browser has not yet been restarted, the WebUI
+  // config has been unregistered. Attempting to show the bubble in that state
+  // would dereference a null `TopChromeWebUIConfig` and crash.
+  if (brave_rewards::ShouldBlockRewardsWebUI(
+          browser_window_interface_->GetProfile(), GURL(kRewardsPageTopURL))) {
     return;
   }
 

--- a/chromium_src/chrome/browser/prefs/browser_prefs.cc
+++ b/chromium_src/chrome/browser/prefs/browser_prefs.cc
@@ -6,7 +6,7 @@
 #include "base/check.h"
 #include "brave/browser/brave_local_state_prefs.h"
 #include "brave/browser/brave_profile_prefs.h"
-#include "brave/browser/brave_stats/brave_stats_updater.h"
+#include "brave/browser/brave_stats/buildflags.h"
 #include "brave/browser/misc_metrics/uptime_monitor_impl.h"
 #include "brave/browser/translate/brave_translate_prefs_migration.h"
 #include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
@@ -39,6 +39,10 @@
 #include "components/translate/core/browser/translate_prefs.h"
 #include "extensions/buildflags/buildflags.h"
 #include "third_party/widevine/cdm/buildflags.h"
+
+#if BUILDFLAG(ENABLE_BRAVE_STATS_UPDATER)
+#include "brave/browser/brave_stats/brave_stats_updater.h"
+#endif
 
 #if BUILDFLAG(ENABLE_AI_CHAT)
 #include "brave/components/ai_chat/core/browser/model_service.h"
@@ -289,7 +293,9 @@ void MigrateObsoleteLocalStatePrefs(PrefService* local_state) {
   misc_metrics::UptimeMonitorImpl::MigrateObsoletePrefs(local_state);
   brave_search_conversion::p3a::MigrateObsoleteLocalStatePrefs(local_state);
   brave_shields::MigrateObsoletePrefsForAdBlockService(local_state);
+#if BUILDFLAG(ENABLE_BRAVE_STATS_UPDATER)
   brave_stats::MigrateObsoleteLocalStatePrefs(local_state);
+#endif
   brave_l10n::MigrateObsoleteLocalStatePrefs(local_state);
   p3a::MetricLogStore::MigrateObsoleteLocalStatePrefs(local_state);
   p3a::RotationScheduler::MigrateObsoleteLocalStatePrefs(local_state);

--- a/chromium_src/chrome/browser/prefs/sources.gni
+++ b/chromium_src/chrome/browser/prefs/sources.gni
@@ -7,6 +7,7 @@ import("//brave/components/brave_wallet/common/buildflags/buildflags.gni")
 import("//third_party/widevine/cdm/widevine.gni")
 
 brave_chromium_src_chrome_browser_prefs_deps = [
+  "//brave/browser/brave_stats:buildflags",
   "//brave/components/brave_ads/buildflags",
   "//brave/components/brave_news/common/buildflags",
   "//brave/components/brave_shields/core/common",

--- a/components/brave_origin/brave_origin_service.cc
+++ b/components/brave_origin/brave_origin_service.cc
@@ -13,6 +13,7 @@
 #include "base/json/json_reader.h"
 #include "base/logging.h"
 #include "base/strings/string_util.h"
+#include "base/task/sequenced_task_runner.h"
 #include "brave/brave_domains/service_domains.h"
 #include "brave/components/brave_origin/brave_origin_policy_manager.h"
 #include "brave/components/brave_origin/brave_origin_utils.h"
@@ -262,7 +263,6 @@ void BraveOriginService::OnCredentialSummary(
   }
 #endif
 
-  LOG(ERROR) << "-----------OnCredentiaSummary Set Purchased: " << purchased;
   BraveOriginPolicyManager::GetInstance()->SetPurchased(purchased);
 
   // Persist enforcement state so NeedsRestart() can detect first-purchase
@@ -276,15 +276,30 @@ void BraveOriginService::OnCredentialSummary(
   // On first purchase detection in the upgrade case, open the settings page
   // so the user can configure Origin policies and restart. Branded builds
   // handle the post-purchase flow via the startup dialog instead.
+  // Post the call instead of invoking it inline: this runs from a mojo
+  // CredentialSummary reply triggered by the account.brave.com Refresh
+  // button, and opening a settings tab synchronously from inside that
+  // callback (which also fires policy/pref reload via SetPurchased above)
+  // has produced dangling raw_ptr crashes during the transition.
   if (purchased && !was_previously_purchased && delegate_ &&
       !did_open_origin_settings_) {
-    delegate_->OpenOriginSettings();
     did_open_origin_settings_ = true;
+    base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
+        FROM_HERE, base::BindOnce(&BraveOriginService::OpenOriginSettings,
+                                  weak_ptr_factory_.GetWeakPtr()));
   }
 #endif
 
   std::move(callback).Run(purchased);
 }
+
+#if !BUILDFLAG(IS_BRAVE_ORIGIN_BRANDED)
+void BraveOriginService::OpenOriginSettings() {
+  if (delegate_) {
+    delegate_->OpenOriginSettings();
+  }
+}
+#endif
 
 bool BraveOriginService::EnsureSkusConnected() {
   if (!skus_service_) {

--- a/components/brave_origin/brave_origin_service.cc
+++ b/components/brave_origin/brave_origin_service.cc
@@ -262,6 +262,7 @@ void BraveOriginService::OnCredentialSummary(
   }
 #endif
 
+  LOG(ERROR) << "-----------OnCredentiaSummary Set Purchased: " << purchased;
   BraveOriginPolicyManager::GetInstance()->SetPurchased(purchased);
 
   // Persist enforcement state so NeedsRestart() can detect first-purchase

--- a/components/brave_origin/brave_origin_service.h
+++ b/components/brave_origin/brave_origin_service.h
@@ -106,6 +106,9 @@ class BraveOriginService : public KeyedService {
                            skus::mojom::SkusResultPtr summary);
   void OnSkusStateChanged();
   bool EnsureSkusConnected();
+#if !BUILDFLAG(IS_BRAVE_ORIGIN_BRANDED)
+  void OpenOriginSettings();
+#endif
 
   mojo::Remote<skus::mojom::SkusService> skus_service_;
   std::string origin_sku_domain_;

--- a/components/brave_origin/brave_origin_service_unittest.cc
+++ b/components/brave_origin/brave_origin_service_unittest.cc
@@ -807,10 +807,11 @@ TEST_F(BraveOriginServiceWithSkusTest, FirstPurchaseDetection_CallsDelegate) {
   EXPECT_TRUE(result.Get());
 #if BUILDFLAG(IS_BRAVE_ORIGIN_BRANDED)
   // Branded builds handle the post-purchase flow via the startup dialog,
-  // not by opening the settings page.
+  // not by opening the settings page. No PostTask is scheduled on this
+  // path, so checking immediately after the callback resolves is safe.
   EXPECT_FALSE(delegate_called);
 #else
-  EXPECT_TRUE(delegate_called);
+  ASSERT_TRUE(base::test::RunUntil([&] { return delegate_called; }));
 #endif
 }
 
@@ -863,12 +864,15 @@ TEST_F(BraveOriginServiceWithSkusTest, DelegateIsOneShot_OnlyFiresOnce) {
   service_->CheckPurchaseState(result1.GetCallback());
   EXPECT_TRUE(result1.Get());
 #if BUILDFLAG(IS_BRAVE_ORIGIN_BRANDED)
+  // Branded builds never schedule the delegate task.
   EXPECT_FALSE(delegate_called);
 #else
-  EXPECT_TRUE(delegate_called);
+  ASSERT_TRUE(base::test::RunUntil([&] { return delegate_called; }));
 #endif
 
-  // Reset the flag and verify the delegate is not called again.
+  // Reset the flag and verify the delegate is not called again. After the
+  // first purchase, did_open_origin_settings_ is set, so no new task is
+  // posted; checking immediately is safe.
   delegate_called = false;
   base::test::TestFuture<bool> result2;
   service_->CheckPurchaseState(result2.GetCallback());
@@ -910,9 +914,10 @@ TEST_F(BraveOriginServiceWithSkusTest,
 
   ASSERT_TRUE(base::test::RunUntil([&] { return service_->IsPurchased(); }));
 #if BUILDFLAG(IS_BRAVE_ORIGIN_BRANDED)
+  // Branded builds never schedule the delegate task.
   EXPECT_FALSE(delegate_called);
 #else
-  EXPECT_TRUE(delegate_called);
+  ASSERT_TRUE(base::test::RunUntil([&] { return delegate_called; }));
 #endif
 }
 

--- a/test/base/testing_brave_browser_process.cc
+++ b/test/base/testing_brave_browser_process.cc
@@ -124,10 +124,12 @@ TestingBraveBrowserProcess::brave_referrals_service() {
   return nullptr;
 }
 
+#if BUILDFLAG(ENABLE_BRAVE_STATS_UPDATER)
 brave_stats::BraveStatsUpdater*
 TestingBraveBrowserProcess::brave_stats_updater() {
   return nullptr;
 }
+#endif  // BUILDFLAG(ENABLE_BRAVE_STATS_UPDATER)
 
 #if BUILDFLAG(ENABLE_BRAVE_ADS)
 brave_ads::BraveStatsHelper*

--- a/test/base/testing_brave_browser_process.h
+++ b/test/base/testing_brave_browser_process.h
@@ -69,7 +69,9 @@ class TestingBraveBrowserProcess : public BraveBrowserProcess {
 #endif
   p3a::P3AService* p3a_service() override;
   brave::BraveReferralsService* brave_referrals_service() override;
+#if BUILDFLAG(ENABLE_BRAVE_STATS_UPDATER)
   brave_stats::BraveStatsUpdater* brave_stats_updater() override;
+#endif
 #if BUILDFLAG(ENABLE_BRAVE_ADS)
   brave_ads::BraveStatsHelper* ads_brave_stats_helper() override;
   brave_ads::ResourceComponent* resource_component() override;


### PR DESCRIPTION
Uplift of #36547
Uplift of #36630
Uplift of #36687
Uplift of #36587
Uplift of #36705
Uplift of #36742
Resolves brave/brave-browser#55595
Resolves brave/brave-browser#55718
Resolves brave/brave-browser#55596
Resolves brave/brave-browser#55558
Resolves brave/brave-browser#55632
Resolves brave/brave-browser#55843
Resolves https://github.com/brave/brave-browser/issues/55647

## Included PRs
- #36547 - Skip stats usage pings on Brave Origin branded builds
- #36630 - Fix crash when opening Rewards panel after disabling via Brave Origin
- #36687 - Hide Leo AI keyboard shortcuts in Brave Origin branded builds
- #36587 - Gate BraveRewardsDisabled policy on ENABLE_BRAVE_REWARDS
- #36705 - Defer OpenOriginSettings out of CredentialSummary callback
- #36742 - Fix Brave Origin overlay on other settings pages during search

Pre-approval checklist:
- [x] You have tested your change on Nightly.
- [ ] This contains text which needs to be translated.
    - [ ] There are more than 7 days before the release.
    - [ ] I've notified folks in #l10n on Slack that translations are needed.
- [x] The PR milestones match the branch they are landing to.


Pre-merge checklist:
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.

Post-merge checklist:
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.
