### PR TITLE
Fix Brave Origin overlay on other settings pages during search

### DIFF
--- a/browser/resources/settings/br/settings_main.ts
+++ b/browser/resources/settings/br/settings_main.ts
@@ -77,10 +77,10 @@ RegisterPolymerTemplateModifications({
     switcher.appendChild(
       html`
         <template is="dom-if" if="[[showPage_(pageVisibility_.origin)]]">
-          <div slot="view" id="origin" class="cr-centered-card-container">
+          <div slot="view" id="origin">
             <template is="dom-if" if="[[renderPlugin_(
           routes_.ORIGIN, lastRoute_, inSearchMode_)]]">
-              <settings-brave-origin-page
+              <settings-brave-origin-page class="cr-centered-card-container"
                 prefs="{{prefs}}"
                 in-search-mode="[[inSearchMode_]]">
               </settings-brave-origin-page>


### PR DESCRIPTION
The `slot=view` div for the origin section had `class=cr-centered-card-container`, which forced `display:block` and `position:relative` onto it. Those rules won over cr-view-manager's `:host ::slotted([slot=view])` hiding rules

Test plan is in the issue.

Fix https://github.com/brave/brave-browser/issues/55843
