### PR TITLE
[Origin] Initialize BraveOriginPolicyManager before profile builds (uplift to 1.91.x)

### DIFF
--- a/browser/brave_browser_process_impl.cc
+++ b/browser/brave_browser_process_impl.cc
@@ -14,6 +14,7 @@
 #include "base/memory/scoped_refptr.h"
 #include "base/path_service.h"
 #include "base/task/thread_pool.h"
+#include "brave/browser/brave_origin/brave_origin_service_factory.h"
 #include "brave/browser/brave_referrals/referrals_service_delegate.h"
 #include "brave/browser/brave_shields/ad_block_subscription_download_manager_getter.h"
 #include "brave/browser/brave_stats/brave_stats_updater.h"
@@ -210,6 +211,21 @@ void BraveBrowserProcessImpl::Init() {
   // Lazy initialization of AdBlockOnlyModePolicyManager
   brave_policy::AdBlockOnlyModePolicyManager::GetInstance()->Init(
       local_state());
+
+  // Initialize BraveOriginPolicyManager here so its managed prefs are merged
+  // into local state before any profile's policy connector polls
+  // `BraveProfilePolicyProvider::IsInitializationComplete`. Without this,
+  // profile pref-store init can deadlock waiting for the gate while the gate
+  // is waiting for `BuildServiceInstanceForBrowserContext` (gated on profile
+  // build) to run `Init` -- manifests as "stuck on profile selection."
+  auto* origin_policy_manager =
+      brave_origin::BraveOriginPolicyManager::GetInstance();
+  if (!origin_policy_manager->IsInitialized()) {
+    origin_policy_manager->Init(
+        brave_origin::BraveOriginServiceFactory::GetBrowserPolicyDefinitions(),
+        brave_origin::BraveOriginServiceFactory::GetProfilePolicyDefinitions(),
+        local_state());
+  }
 }
 
 void BraveBrowserProcessImpl::PreMainMessageLoopRun() {


### PR DESCRIPTION
Uplift of #36740
Resolves https://github.com/brave/brave-browser/issues/55733

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.