### PR TITLE
[Android] Respect system rotation lock during video fullscreen

### DIFF
--- a/android/java/org/chromium/chrome/browser/app/BraveActivity.java
+++ b/android/java/org/chromium/chrome/browser/app/BraveActivity.java
@@ -15,12 +15,14 @@ import android.content.Intent;
 import android.content.IntentSender;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.OnSharedPreferenceChangeListener;
+import android.content.pm.ActivityInfo;
 import android.content.pm.PackageManager;
 import android.content.res.Configuration;
 import android.graphics.Rect;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
+import android.provider.Settings;
 import android.text.Editable;
 import android.text.TextUtils;
 import android.text.TextWatcher;
@@ -2714,6 +2716,47 @@ public abstract class BraveActivity extends ChromeActivity
         if (mSearchWidgetPromoPanel != null && mSearchWidgetPromoPanel.isShowing()) {
             showWidgetPromoPanel();
         }
+    }
+
+    /**
+     * Overrides the default orientation request to respect the system rotation lock.
+     *
+     * <p>On Android, web content (e.g. YouTube's fullscreen player) can call the
+     * screen.orientation.lock() JavaScript API which eventually reaches this method and forces the
+     * device into landscape mode — even when the user has locked rotation in system quick settings.
+     * This does not happen on iOS because Safari ignores web orientation lock requests when the
+     * system lock is active.
+     *
+     * <p>This override mirrors the iOS behavior: if the user has locked rotation via the system
+     * setting (accelerometer_rotation == 0), any web-initiated landscape orientation request is
+     * silently ignored. The app's own legitimate portrait locks (e.g. onboarding screens, wallet)
+     * are unaffected because they use portrait or unspecified constants, not landscape ones.
+     */
+    @Override
+    public void setRequestedOrientation(int requestedOrientation) {
+        if (isSystemRotationLocked() && isLandscapeOrientation(requestedOrientation)) {
+            // Silently ignore the landscape request — respect the user's rotation lock.
+            return;
+        }
+        super.setRequestedOrientation(requestedOrientation);
+    }
+
+    /** Returns true if the user has locked screen rotation in system quick settings. */
+    private boolean isSystemRotationLocked() {
+        return Settings.System.getInt(
+                        getContentResolver(), Settings.System.ACCELEROMETER_ROTATION, 1)
+                == 0;
+    }
+
+    /**
+     * Returns true if the given orientation constant would force the screen into landscape.
+     * Covers all landscape variants defined in {@link ActivityInfo}.
+     */
+    private boolean isLandscapeOrientation(int orientation) {
+        return orientation == ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
+                || orientation == ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
+                || orientation == ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE
+                || orientation == ActivityInfo.SCREEN_ORIENTATION_USER_LANDSCAPE;
     }
 
     private void hideWidgetPromoPanel() {


### PR DESCRIPTION
## Problem

When a user locks screen rotation via Android quick settings (portrait lock) and enters fullscreen on a video — for example, tapping the fullscreen button on YouTube — Brave forces the device into landscape mode, ignoring the user's explicit preference.

This happens because web content can call the `screen.orientation.lock('landscape')` JavaScript API, which propagates through Chromium's `ScreenOrientationProvider` and ultimately calls `Activity.setRequestedOrientation()` with a landscape constant. Brave currently passes this through unconditionally.

**This bug does not exist on iOS** — Safari respects the system orientation lock and ignores web-initiated orientation requests when rotation is locked.

Verified on Pixel 10 Pro XL (Android 17, Brave 1.90.125): system `accelerometer_rotation=0` (locked), yet entering YouTube fullscreen triggers a full `ROTATION_0 → ROTATION_90 → ROTATION_0` cycle.

## Solution

Override `setRequestedOrientation()` in `BraveActivity` to check `Settings.System.ACCELEROMETER_ROTATION` before passing landscape-forcing requests to the system. If the user has locked rotation, landscape requests are silently dropped — mirroring iOS/Safari behavior.

The app's own internal portrait locks (wallet activities, onboarding screens) use `SCREEN_ORIENTATION_PORTRAIT` / `SCREEN_ORIENTATION_UNSPECIFIED` constants and are **not affected** by this change.

## Changes

- `android/java/org/chromium/chrome/browser/app/BraveActivity.java`
  - Override `setRequestedOrientation()` with system rotation lock check
  - Add `isSystemRotationLocked()` helper (reads `ACCELEROMETER_ROTATION` setting)
  - Add `isLandscapeOrientation()` helper (covers all 4 landscape `ActivityInfo` constants)

## Test Plan

- [ ] Lock screen rotation in Android quick settings (portrait lock)
- [ ] Open Brave → navigate to YouTube → play any video → tap fullscreen
- [ ] Verify phone **stays in portrait** and does not rotate to landscape
- [ ] Unlock screen rotation → repeat above → verify phone **does** rotate to landscape (normal behavior preserved)
- [ ] Open Brave Wallet — verify it still locks to portrait correctly
- [ ] Open Brave onboarding — verify orientation behavior is unchanged