### PR TITLE
[VPN 2.0] Split VPN utils into shared and V1-only targets

### DIFF
--- a/browser/brave_browser_process_impl.cc
+++ b/browser/brave_browser_process_impl.cc
@@ -109,7 +109,7 @@
 #endif
 
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
-#include "brave/browser/brave_vpn/vpn_utils.h"
+#include "brave/browser/brave_vpn/vpn_connection_manager_utils.h"
 #include "brave/components/brave_vpn/browser/connection/brave_vpn_connection_manager.h"
 #endif
 

--- a/browser/brave_vpn/BUILD.gn
+++ b/browser/brave_vpn/BUILD.gn
@@ -14,10 +14,24 @@ source_set("brave_vpn") {
   ]
 
   deps = [
+    "//brave/components/brave_vpn/common",
+    "//chrome/browser/profiles:profile",
+    "//components/prefs",
+    "//components/user_prefs",
+  ]
+}
+
+source_set("v1_utils") {
+  sources = [
+    "vpn_connection_manager_utils.cc",
+    "vpn_connection_manager_utils.h",
+  ]
+
+  public_deps = [ "//base" ]
+
+  deps = [
     "//brave/components/brave_vpn/browser/connection:api",
     "//brave/components/brave_vpn/common",
-    "//brave/components/brave_vpn/common/buildflags",
-    "//chrome/browser/profiles:profile",
     "//chrome/common:channel_info",
     "//components/prefs",
     "//components/user_prefs",

--- a/browser/brave_vpn/sources.gni
+++ b/browser/brave_vpn/sources.gni
@@ -42,6 +42,7 @@ if (enable_brave_vpn) {
   brave_browser_brave_vpn_deps += [
     "//base",
     "//brave/browser/brave_vpn",
+    "//brave/browser/brave_vpn:v1_utils",
     "//brave/components/brave_vpn/browser",
     "//chrome/browser/profiles:profile",
     "//components/keyed_service/content",

--- a/browser/brave_vpn/vpn_connection_manager_utils.cc
+++ b/browser/brave_vpn/vpn_connection_manager_utils.cc
@@ -1,0 +1,82 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/brave_vpn/vpn_connection_manager_utils.h"
+
+#include "base/functional/bind.h"
+#include "base/memory/scoped_refptr.h"
+#include "base/notreached.h"
+#include "brave/components/brave_vpn/browser/connection/brave_vpn_connection_manager.h"
+#include "brave/components/brave_vpn/common/brave_vpn_utils.h"
+#include "build/build_config.h"
+#include "chrome/common/channel_info.h"
+#include "components/prefs/pref_service.h"
+#include "components/user_prefs/user_prefs.h"
+#include "services/network/public/cpp/shared_url_loader_factory.h"
+
+#if BUILDFLAG(IS_WIN)
+#include "brave/browser/brave_vpn/win/vpn_utils_win.h"
+#include "brave/browser/brave_vpn/win/wireguard_connection_api_impl_win.h"
+#include "brave/components/brave_vpn/browser/connection/ikev2/win/ras_connection_api_impl_win.h"
+#endif
+
+#if BUILDFLAG(IS_MAC)
+#include "brave/browser/brave_vpn/mac/vpn_utils_mac.h"
+#endif
+
+namespace brave_vpn {
+namespace {
+
+#if !BUILDFLAG(IS_ANDROID)
+std::unique_ptr<ConnectionAPIImpl> CreateConnectionAPIImpl(
+    BraveVPNConnectionManager* manager,
+    scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
+    bool wireguard_enabled) {
+#if BUILDFLAG(IS_MAC)
+  return CreateConnectionAPIImplMac(manager, url_loader_factory);
+#elif BUILDFLAG(IS_WIN)
+  if (wireguard_enabled) {
+    return std::make_unique<WireguardConnectionAPIImplWin>(manager,
+                                                           url_loader_factory);
+  }
+  return std::make_unique<RasConnectionAPIImplWin>(manager, url_loader_factory);
+#else
+  // VPN is not supported on other platforms.
+  NOTREACHED();
+#endif
+}
+#endif  // !BUILDFLAG(IS_ANDROID)
+
+}  // namespace
+
+std::unique_ptr<BraveVPNConnectionManager> CreateBraveVPNConnectionManager(
+    scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
+    PrefService* local_prefs) {
+#if BUILDFLAG(IS_ANDROID)
+  // Android doesn't use connection api.
+  return nullptr;
+#else
+  // Currently, service installer only used on Windows.
+  // Installs registers IKEv2 service (for DNS) and our WireGuard impl.
+  // NOTE: Install only happens if person has purchased the product.
+  auto service_installer =
+#if BUILDFLAG(IS_WIN)
+      base::BindRepeating(&brave_vpn::InstallVpnSystemServices);
+#else
+      base::NullCallback();
+#endif
+
+  auto manager = std::make_unique<BraveVPNConnectionManager>(
+      url_loader_factory, local_prefs, service_installer);
+  manager->set_target_vpn_entry_name(
+      brave_vpn::GetBraveVPNEntryName(chrome::GetChannel()));
+  manager->set_connection_api_impl_getter(
+      base::BindRepeating(&CreateConnectionAPIImpl));
+  manager->UpdateConnectionAPIImpl();
+  return manager;
+#endif
+}
+
+}  // namespace brave_vpn

--- a/browser/brave_vpn/vpn_connection_manager_utils.h
+++ b/browser/brave_vpn/vpn_connection_manager_utils.h
@@ -1,0 +1,29 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_BRAVE_VPN_VPN_CONNECTION_MANAGER_UTILS_H_
+#define BRAVE_BROWSER_BRAVE_VPN_VPN_CONNECTION_MANAGER_UTILS_H_
+
+#include <memory>
+
+#include "base/memory/scoped_refptr.h"
+
+namespace network {
+class SharedURLLoaderFactory;
+}  // namespace network
+
+class PrefService;
+
+namespace brave_vpn {
+
+class BraveVPNConnectionManager;
+
+std::unique_ptr<BraveVPNConnectionManager> CreateBraveVPNConnectionManager(
+    scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
+    PrefService* local_prefs);
+
+}  // namespace brave_vpn
+
+#endif  // BRAVE_BROWSER_BRAVE_VPN_VPN_CONNECTION_MANAGER_UTILS_H_

--- a/browser/brave_vpn/vpn_utils.cc
+++ b/browser/brave_vpn/vpn_utils.cc
@@ -5,84 +5,13 @@
 
 #include "brave/browser/brave_vpn/vpn_utils.h"
 
-#include "base/functional/bind.h"
-#include "base/memory/scoped_refptr.h"
-#include "base/notreached.h"
-#include "brave/components/brave_vpn/browser/connection/brave_vpn_connection_manager.h"
 #include "brave/components/brave_vpn/common/brave_vpn_utils.h"
-#include "brave/components/brave_vpn/common/buildflags/buildflags.h"
 #include "build/build_config.h"
 #include "chrome/browser/profiles/profile.h"
-#include "chrome/common/channel_info.h"
 #include "components/prefs/pref_service.h"
 #include "components/user_prefs/user_prefs.h"
-#include "services/network/public/cpp/shared_url_loader_factory.h"
-
-#if BUILDFLAG(IS_WIN)
-#include "brave/browser/brave_vpn/win/vpn_utils_win.h"
-#include "brave/browser/brave_vpn/win/wireguard_connection_api_impl_win.h"
-#include "brave/components/brave_vpn/browser/connection/ikev2/win/ras_connection_api_impl_win.h"
-#endif
-
-#if BUILDFLAG(IS_MAC)
-#include "brave/browser/brave_vpn/mac/vpn_utils_mac.h"
-#endif
 
 namespace brave_vpn {
-
-namespace {
-
-#if !BUILDFLAG(IS_ANDROID)
-std::unique_ptr<ConnectionAPIImpl> CreateConnectionAPIImpl(
-    BraveVPNConnectionManager* manager,
-    scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
-    bool wireguard_enabled) {
-#if BUILDFLAG(IS_MAC)
-  return CreateConnectionAPIImplMac(manager, url_loader_factory);
-#endif
-
-#if BUILDFLAG(IS_WIN)
-  if (wireguard_enabled) {
-    return std::make_unique<WireguardConnectionAPIImplWin>(manager,
-                                                           url_loader_factory);
-  }
-  return std::make_unique<RasConnectionAPIImplWin>(manager, url_loader_factory);
-#endif
-
-  // VPN is not supported on other platforms.
-  NOTREACHED();
-}
-#endif
-
-}  // namespace
-
-std::unique_ptr<BraveVPNConnectionManager> CreateBraveVPNConnectionManager(
-    scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
-    PrefService* local_prefs) {
-#if BUILDFLAG(IS_ANDROID)
-  // Android doesn't use connection api.
-  return nullptr;
-#else
-  // Currently, service installer only used on Windows.
-  // Installs registers IKEv2 service (for DNS) and our WireGuard impl.
-  // NOTE: Install only happens if person has purchased the product.
-  auto service_installer =
-#if BUILDFLAG(IS_WIN)
-      base::BindRepeating(&brave_vpn::InstallVpnSystemServices);
-#else
-      base::NullCallback();
-#endif
-
-  auto manager = std::make_unique<BraveVPNConnectionManager>(
-      url_loader_factory, local_prefs, service_installer);
-  manager->set_target_vpn_entry_name(
-      brave_vpn::GetBraveVPNEntryName(chrome::GetChannel()));
-  manager->set_connection_api_impl_getter(
-      base::BindRepeating(&CreateConnectionAPIImpl));
-  manager->UpdateConnectionAPIImpl();
-  return manager;
-#endif
-}
 
 bool IsAllowedForContext(content::BrowserContext* context) {
   return Profile::FromBrowserContext(context)->IsRegularProfile() &&

--- a/browser/brave_vpn/vpn_utils.h
+++ b/browser/brave_vpn/vpn_utils.h
@@ -6,29 +6,14 @@
 #ifndef BRAVE_BROWSER_BRAVE_VPN_VPN_UTILS_H_
 #define BRAVE_BROWSER_BRAVE_VPN_VPN_UTILS_H_
 
-#include <memory>
-
-#include "base/memory/scoped_refptr.h"
-
 namespace content {
 class BrowserContext;
 }  // namespace content
 
-namespace network {
-class SharedURLLoaderFactory;
-}  // namespace network
-
-class PrefService;
-
 namespace brave_vpn {
-
-class BraveVPNConnectionManager;
 
 bool IsBraveVPNEnabled(content::BrowserContext* context);
 bool IsAllowedForContext(content::BrowserContext* context);
-std::unique_ptr<BraveVPNConnectionManager> CreateBraveVPNConnectionManager(
-    scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
-    PrefService* local_prefs);
 
 }  // namespace brave_vpn
 


### PR DESCRIPTION
To add a new BraveVpnService implementation based on Architecture 2.0, which must co-exist with Architecture 1.0 for quite a while, we need to split service's interface and implementation. All the external components will keep accessing VPN service via the BraveVpnService interface, but the implementation mostly goes into BraveVpnServiceImpl.

This incremental change splits "brave_vpn" target into two:
- "brave_vpn" itself, shared between V1 and V2 implementations.
- "v1_utils", a strictly V1 target, currently containing the VPN connection manager utility code for Architecture 1.0.

Most existing targets will continue depending on the shared "brave_vpn"; "v1_utils" is used only in the specific place where V1 connection manager creation is done, and will be later gated by a buildflag.

Implements part of https://github.com/brave/brave-browser/issues/54597

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
