### PR TITLE
[toolchain] Disabling unused Mac toolchain downloads

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -56,7 +56,7 @@ hooks = [
     # Download hermetic xcode for goma
     'name': 'download_hermetic_xcode',
     'pattern': '.',
-    'condition': 'checkout_mac or checkout_ios',
+    'condition': 'checkout_mac',
     'action': ['vpython3', 'build/mac/download_hermetic_xcode.py'],
   },
   {

--- a/patches/DEPS.patch
+++ b/patches/DEPS.patch
@@ -1,0 +1,13 @@
+diff --git a/DEPS b/DEPS
+index 7a48657a32953f29537ad73b126b371856fe2270..d4d95afefc2c6acbeb8e2a4659ab9227e8fcb7e5 100644
+--- a/DEPS
++++ b/DEPS
+@@ -4262,7 +4262,7 @@ hooks = [
+     # Update the Mac toolchain if necessary.
+     'name': 'mac_toolchain',
+     'pattern': '.',
+-    'condition': 'checkout_mac or checkout_ios',
++    'condition': 'False',
+     'action': ['python3', 'src/build/mac_toolchain.py'],
+   },
+   {

--- a/rewrite/DEPS.yaml
+++ b/rewrite/DEPS.yaml
@@ -1,0 +1,17 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+substitutions:
+  - description: |
+      Disable the mac_toolchain hook by neutralising its condition.
+
+      Brave has its own script to download the hermetic toolchain,
+      brave/build/mac/download_hermetic_xcode.py, so it is okay to disable the
+      upstream hook as it causes confusing output to be printed to the user.
+    re_pattern: |-
+      ('name': 'mac_toolchain',.+?'condition':\s*)'checkout_mac or checkout_ios'
+    re_flags: [DOTALL]
+    replace: |-
+      \1'False'


### PR DESCRIPTION
This PR disables the hook for downloading the Mac toolchain, that can be
only used by Google employees, as that hook own output was quit
confusing, as it preceeded our own hook being run.

We are also disabling downloading the hermetic toolchain for ios
checkouts. IOS builds do not use the hermetic tooolchain, and recently
we've run into significant issues in CI relating to that.

https://github.com/brave/brave-browser/issues/55812
