### PR TITLE
[farbling] Add WebGLExtensionHandler to handle extensions related calls

### DIFF
--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -257,6 +257,7 @@ test("brave_unit_tests") {
     "//brave/mojo/brave_ast_patcher:unit_tests",
     "//brave/net:unit_tests",
     "//brave/third_party/blink/renderer",
+    "//brave/third_party/blink/renderer/bindings/core/webgl:unit_tests",
     "//brave/vendor/brave_base",
     "//chrome:dependencies",
     "//chrome:resources",

--- a/third_party/blink/renderer/bindings/core/webgl/BUILD.gn
+++ b/third_party/blink/renderer/bindings/core/webgl/BUILD.gn
@@ -1,0 +1,17 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+source_set("unit_tests") {
+  testonly = true
+
+  sources = [ "webgl_extension_handler_unittest.cc" ]
+
+  deps = [
+    "//base/test:test_support",
+    "//testing/gtest",
+    "//third_party/blink/public/common",
+    "//third_party/blink/renderer/core",
+  ]
+}

--- a/third_party/blink/renderer/bindings/core/webgl/DEPS
+++ b/third_party/blink/renderer/bindings/core/webgl/DEPS
@@ -1,0 +1,7 @@
+# Inline upstream rules.
+from brave_chromium_utils import inline_file
+inline_file('//third_party/blink/renderer/bindings/core/DEPS', globals(), locals())
+
+include_rules += [
+    "+third_party/blink/public/common/features.h",
+]

--- a/third_party/blink/renderer/bindings/core/webgl/webgl_extension_handler.cc
+++ b/third_party/blink/renderer/bindings/core/webgl/webgl_extension_handler.cc
@@ -1,0 +1,161 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/third_party/blink/renderer/bindings/core/webgl/webgl_extension_handler.h"
+
+#include <array>
+#include <optional>
+
+#include "base/check.h"
+#include "base/check_is_test.h"
+#include "base/feature_list.h"
+#include "base/no_destructor.h"
+#include "third_party/blink/public/common/features.h"
+#include "third_party/blink/renderer/bindings/core/v8/script_value.h"
+#include "third_party/blink/renderer/platform/bindings/v8_binding.h"
+#include "third_party/blink/renderer/platform/wtf/text/ascii_ctype.h"
+#include "third_party/blink/renderer/platform/wtf/text/string_builder.h"
+#include "third_party/blink/renderer/platform/wtf/text/wtf_string.h"
+
+namespace blink {
+
+namespace {
+// The below *fake* extension names are inspired from existing names (see
+// https://registry.khronos.org/webgl/extensions/). This fake list serves to
+// defuse any automated fingerprinting scripts that relies on a hash based
+// approach. Through farbling, we will inject one of the fake values below to
+// the result of the getSupportedExtensions call which would be consistent
+// across that eTLD+1 session. A different session would pseudo-randomly yield a
+// different list resulting in a different hash. Hence the two call sites can't
+// link it's the same user via the hash based approach.
+//
+// The list below is a flat representation of the two sets {texture, expanded,
+// polygon, circle, triangle, blend, draw} and {sampler, blender, compressor}.
+const std::array<String, kFakeExtensionsSize> GetFakeSupportedExtensions() {
+  static const base::NoDestructor<std::array<String, kFakeExtensionsSize>>
+      fake_values({{
+          {"EXT_texture_sampler"},     {"EXT_texture_compressor"},
+          {"EXT_texture_blender"},     {"EXT_expanded_sampler"},
+          {"EXT_expanded_compressor"}, {"EXT_expanded_blender"},
+          {"EXT_polygon_sampler"},     {"EXT_polygon_compressor"},
+          {"EXT_polygon_blender"},     {"EXT_circle_sampler"},
+          {"EXT_circle_compressor"},   {"EXT_circle_blender"},
+          {"EXT_triangle_sampler"},    {"EXT_triangle_compressor"},
+          {"EXT_triangle_blender"},    {"EXT_blend_sampler"},
+          {"EXT_blend_compressor"},    {"EXT_blend_blender"},
+          {"EXT_draw_sampler"},        {"EXT_draw_compressor"},
+          {"EXT_draw_blender"},
+      }});
+  return *fake_values;
+}
+
+// Converts an extension name like "EXT_draw_compressor" to a CamelCase class
+// name like "ExtDrawCompressor".
+String ToExtensionClassName(const String& name) {
+  StringBuilder result;
+  bool capitalize_next = true;
+  for (unsigned i = 0; i < name.length(); ++i) {
+    const UChar c = name[i];
+    if (c == '_') {
+      capitalize_next = true;
+    } else if (capitalize_next) {
+      result.Append(static_cast<UChar>(ToAsciiUpper(c)));
+      capitalize_next = false;
+    } else {
+      result.Append(static_cast<UChar>(ToAsciiLower(c)));
+    }
+  }
+  return result.ToString();
+}
+
+}  // namespace
+
+WebGLExtensionHandler::WebGLExtensionHandler(
+    const ExtensionVector& supported_extensions,
+    std::optional<size_t> fake_index)
+    : supported_extensions_(supported_extensions), fake_index_(fake_index) {}
+
+WebGLExtensionHandler::~WebGLExtensionHandler() = default;
+
+ExtensionVector WebGLExtensionHandler::GetSupportedExtensions() const {
+  return supported_extensions_;
+}
+
+// TODO(https://github.com/brave/brave-browser/issues/55858): Cover testing this
+// in browser_tests as it's not straightforward to test it as unittest due to
+// various v8 dependencies.
+ScriptObject WebGLExtensionHandler::GetExtension(
+    ScriptState* script_state,
+    const String& name,
+    const ScriptObject* real_extension) {
+  // Create and return a fake object if the extension was farbled.
+  if (IsExtensionFarbled(name)) {
+    v8::Isolate* isolate = script_state->GetIsolate();
+    v8::Local<v8::Context> context = script_state->GetContext();
+    v8::Local<v8::FunctionTemplate> tmpl = v8::FunctionTemplate::New(isolate);
+    tmpl->SetClassName(V8String(isolate, ToExtensionClassName(name)));
+    v8::Local<v8::Object> obj = tmpl->GetFunction(context)
+                                    .ToLocalChecked()
+                                    ->NewInstance(context)
+                                    .ToLocalChecked();
+    return ScriptObject(isolate, obj);
+  }
+
+  // If extension is part of the supported list return the real extension.
+  if (supported_extensions_.Contains(name)) {
+    CHECK(real_extension);
+    return *real_extension;
+  }
+
+  return ScriptObject::CreateNull(script_state->GetIsolate());
+}
+
+bool WebGLExtensionHandler::IsExtensionFarbled(const String& name) const {
+  if (!fake_index_.has_value()) {
+    return false;
+  }
+  const auto& fake_extension_list = GetFakeSupportedExtensions();
+  return fake_extension_list[fake_index_.value()] == name;
+}
+
+std::unique_ptr<WebGLExtensionHandler> CreateOffHandler(
+    const ExtensionVector& real_extensions) {
+  return std::make_unique<WebGLExtensionHandler>(real_extensions);
+}
+
+std::unique_ptr<WebGLExtensionHandler> CreateBalancedHandler(
+    const ExtensionVector& real_extensions,
+    size_t seed) {
+  if (!base::FeatureList::IsEnabled(
+          features::kWebGLBalancedFingerprintingProtection)) {
+    return std::make_unique<WebGLExtensionHandler>(real_extensions);
+  }
+
+  ExtensionVector modified_extensions = real_extensions;
+  const auto& fake_extension_list = GetFakeSupportedExtensions();
+  const size_t fake_index = seed % fake_extension_list.size();
+  modified_extensions.push_back(fake_extension_list[fake_index]);
+
+  // The fake_index is now stable across the lifetime of the current
+  // eTLD+1 session. The index would be reset when the owner destroys the
+  // handler.
+  return std::make_unique<WebGLExtensionHandler>(modified_extensions,
+                                                 fake_index);
+}
+
+std::unique_ptr<WebGLExtensionHandler> CreateMaximumHandler(
+    const ExtensionVector& real_extensions) {
+  if (real_extensions.Contains("WEBGL_debug_renderer_info")) {
+    return std::make_unique<WebGLExtensionHandler>(
+        ExtensionVector{"WEBGL_debug_renderer_info"});
+  }
+  return std::make_unique<WebGLExtensionHandler>(ExtensionVector{});
+}
+
+std::array<String, kFakeExtensionsSize> GetFakeSupportedExtensionsForTesting() {
+  CHECK_IS_TEST();
+  return GetFakeSupportedExtensions();
+}
+}  // namespace blink

--- a/third_party/blink/renderer/bindings/core/webgl/webgl_extension_handler.cc
+++ b/third_party/blink/renderer/bindings/core/webgl/webgl_extension_handler.cc
@@ -15,67 +15,62 @@
 #include "third_party/blink/public/common/features.h"
 #include "third_party/blink/renderer/bindings/core/v8/script_value.h"
 #include "third_party/blink/renderer/platform/bindings/v8_binding.h"
-#include "third_party/blink/renderer/platform/wtf/text/ascii_ctype.h"
-#include "third_party/blink/renderer/platform/wtf/text/string_builder.h"
 #include "third_party/blink/renderer/platform/wtf/text/wtf_string.h"
 
-namespace blink {
+namespace webgl {
 
 namespace {
-// The below *fake* extension names are inspired from existing names (see
+// The size of the fake extension list.
+inline constexpr size_t kFakeExtensionsSize = 21;
+
+// The following *fake* extension names are inspired from existing names (see
 // https://registry.khronos.org/webgl/extensions/). This fake list serves to
 // defuse any automated fingerprinting scripts that relies on a hash based
-// approach. Through farbling, we will inject one of the fake values below to
-// the result of the getSupportedExtensions call which would be consistent
+// approach. Through farbling, we will inject one of the following fake values
+// to the result of the getSupportedExtensions call which would be consistent
 // across that eTLD+1 session. A different session would pseudo-randomly yield a
 // different list resulting in a different hash. Hence the two call sites can't
 // link it's the same user via the hash based approach.
 //
 // The list below is a flat representation of the two sets {texture, expanded,
 // polygon, circle, triangle, blend, draw} and {sampler, blender, compressor}.
-const std::array<String, kFakeExtensionsSize> GetFakeSupportedExtensions() {
-  static const base::NoDestructor<std::array<String, kFakeExtensionsSize>>
+const std::array<FakeExtensionType, kFakeExtensionsSize>&
+GetFakeSupportedExtensions() {
+  static const base::NoDestructor<
+      std::array<FakeExtensionType, kFakeExtensionsSize>>
       fake_values({{
-          {"EXT_texture_sampler"},     {"EXT_texture_compressor"},
-          {"EXT_texture_blender"},     {"EXT_expanded_sampler"},
-          {"EXT_expanded_compressor"}, {"EXT_expanded_blender"},
-          {"EXT_polygon_sampler"},     {"EXT_polygon_compressor"},
-          {"EXT_polygon_blender"},     {"EXT_circle_sampler"},
-          {"EXT_circle_compressor"},   {"EXT_circle_blender"},
-          {"EXT_triangle_sampler"},    {"EXT_triangle_compressor"},
-          {"EXT_triangle_blender"},    {"EXT_blend_sampler"},
-          {"EXT_blend_compressor"},    {"EXT_blend_blender"},
-          {"EXT_draw_sampler"},        {"EXT_draw_compressor"},
-          {"EXT_draw_blender"},
+          {"EXT_texture_sampler", "ExtTextureSampler"},
+          {"EXT_texture_compressor", "ExtTextureCompressor"},
+          {"EXT_texture_blender", "ExtTextureBlender"},
+          {"EXT_expanded_sampler", "ExtExpandedSampler"},
+          {"EXT_expanded_compressor", "ExtExpandedCompressor"},
+          {"EXT_expanded_blender", "ExtExpandedBlender"},
+          {"EXT_polygon_sampler", "ExtPolygonSampler"},
+          {"EXT_polygon_compressor", "ExtPolygonCompressor"},
+          {"EXT_polygon_blender", "ExtPolygonBlender"},
+          {"EXT_circle_sampler", "ExtCircleSampler"},
+          {"EXT_circle_compressor", "ExtCircleCompressor"},
+          {"EXT_circle_blender", "ExtCircleBlender"},
+          {"EXT_triangle_sampler", "ExtTriangleSampler"},
+          {"EXT_triangle_compressor", "ExtTriangleCompressor"},
+          {"EXT_triangle_blender", "ExtTriangleBlender"},
+          {"EXT_blend_sampler", "ExtBlendSampler"},
+          {"EXT_blend_compressor", "ExtBlendCompressor"},
+          {"EXT_blend_blender", "ExtBlendBlender"},
+          {"EXT_draw_sampler", "ExtDrawSampler"},
+          {"EXT_draw_compressor", "ExtDrawCompressor"},
+          {"EXT_draw_blender", "ExtDrawBlender"},
       }});
   return *fake_values;
-}
-
-// Converts an extension name like "EXT_draw_compressor" to a CamelCase class
-// name like "ExtDrawCompressor".
-String ToExtensionClassName(const String& name) {
-  StringBuilder result;
-  bool capitalize_next = true;
-  for (unsigned i = 0; i < name.length(); ++i) {
-    const UChar c = name[i];
-    if (c == '_') {
-      capitalize_next = true;
-    } else if (capitalize_next) {
-      result.Append(static_cast<UChar>(ToAsciiUpper(c)));
-      capitalize_next = false;
-    } else {
-      result.Append(static_cast<UChar>(ToAsciiLower(c)));
-    }
-  }
-  return result.ToString();
 }
 
 }  // namespace
 
 WebGLExtensionHandler::WebGLExtensionHandler(
     const ExtensionVector& supported_extensions,
-    std::optional<size_t> fake_index)
-    : supported_extensions_(supported_extensions), fake_index_(fake_index) {}
+    std::optional<FakeExtensionType> fake_extension)
+    : supported_extensions_(supported_extensions),
+      fake_extension_(fake_extension) {}
 
 WebGLExtensionHandler::~WebGLExtensionHandler() = default;
 
@@ -86,21 +81,21 @@ ExtensionVector WebGLExtensionHandler::GetSupportedExtensions() const {
 // TODO(https://github.com/brave/brave-browser/issues/55858): Cover testing this
 // in browser_tests as it's not straightforward to test it as unittest due to
 // various v8 dependencies.
-ScriptObject WebGLExtensionHandler::GetExtension(
-    ScriptState* script_state,
-    const String& name,
-    const ScriptObject* real_extension) {
+blink::ScriptObject WebGLExtensionHandler::GetExtension(
+    blink::ScriptState* script_state,
+    const blink::String& name,
+    const blink::ScriptObject* real_extension) {
   // Create and return a fake object if the extension was farbled.
   if (IsExtensionFarbled(name)) {
     v8::Isolate* isolate = script_state->GetIsolate();
     v8::Local<v8::Context> context = script_state->GetContext();
     v8::Local<v8::FunctionTemplate> tmpl = v8::FunctionTemplate::New(isolate);
-    tmpl->SetClassName(V8String(isolate, ToExtensionClassName(name)));
+    tmpl->SetClassName(V8String(isolate, fake_extension_->script_object_name));
     v8::Local<v8::Object> obj = tmpl->GetFunction(context)
                                     .ToLocalChecked()
                                     ->NewInstance(context)
                                     .ToLocalChecked();
-    return ScriptObject(isolate, obj);
+    return blink::ScriptObject(isolate, obj);
   }
 
   // If extension is part of the supported list return the real extension.
@@ -109,15 +104,12 @@ ScriptObject WebGLExtensionHandler::GetExtension(
     return *real_extension;
   }
 
-  return ScriptObject::CreateNull(script_state->GetIsolate());
+  return blink::ScriptObject::CreateNull(script_state->GetIsolate());
 }
 
-bool WebGLExtensionHandler::IsExtensionFarbled(const String& name) const {
-  if (!fake_index_.has_value()) {
-    return false;
-  }
-  const auto& fake_extension_list = GetFakeSupportedExtensions();
-  return fake_extension_list[fake_index_.value()] == name;
+bool WebGLExtensionHandler::IsExtensionFarbled(
+    const blink::String& name) const {
+  return fake_extension_.has_value() && fake_extension_.value().name == name;
 }
 
 std::unique_ptr<WebGLExtensionHandler> CreateOffHandler(
@@ -127,22 +119,21 @@ std::unique_ptr<WebGLExtensionHandler> CreateOffHandler(
 
 std::unique_ptr<WebGLExtensionHandler> CreateBalancedHandler(
     const ExtensionVector& real_extensions,
-    size_t seed) {
+    const size_t seed) {
   if (!base::FeatureList::IsEnabled(
-          features::kWebGLBalancedFingerprintingProtection)) {
+          blink::features::kWebGLBalancedFingerprintingProtection)) {
     return std::make_unique<WebGLExtensionHandler>(real_extensions);
   }
 
   ExtensionVector modified_extensions = real_extensions;
   const auto& fake_extension_list = GetFakeSupportedExtensions();
   const size_t fake_index = seed % fake_extension_list.size();
-  modified_extensions.push_back(fake_extension_list[fake_index]);
+  const FakeExtensionType& fake_extension = fake_extension_list[fake_index];
+  modified_extensions.emplace_back(fake_extension.name);
 
-  // The fake_index is now stable across the lifetime of the current
-  // eTLD+1 session. The index would be reset when the owner destroys the
-  // handler.
+  // The fake_extension_name is now stable until the lifetime of the handler.
   return std::make_unique<WebGLExtensionHandler>(modified_extensions,
-                                                 fake_index);
+                                                 fake_extension);
 }
 
 std::unique_ptr<WebGLExtensionHandler> CreateMaximumHandler(
@@ -154,8 +145,8 @@ std::unique_ptr<WebGLExtensionHandler> CreateMaximumHandler(
   return std::make_unique<WebGLExtensionHandler>(ExtensionVector{});
 }
 
-std::array<String, kFakeExtensionsSize> GetFakeSupportedExtensionsForTesting() {
+base::span<const FakeExtensionType> GetFakeSupportedExtensionsForTesting() {
   CHECK_IS_TEST();
-  return GetFakeSupportedExtensions();
+  return base::span(GetFakeSupportedExtensions());
 }
-}  // namespace blink
+}  // namespace webgl

--- a/third_party/blink/renderer/bindings/core/webgl/webgl_extension_handler.h
+++ b/third_party/blink/renderer/bindings/core/webgl/webgl_extension_handler.h
@@ -1,0 +1,81 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_THIRD_PARTY_BLINK_RENDERER_BINDINGS_CORE_WEBGL_WEBGL_EXTENSION_HANDLER_H_
+#define BRAVE_THIRD_PARTY_BLINK_RENDERER_BINDINGS_CORE_WEBGL_WEBGL_EXTENSION_HANDLER_H_
+
+#include <array>
+#include <memory>
+#include <optional>
+
+#include "third_party/blink/renderer/core/core_export.h"
+#include "third_party/blink/renderer/platform/wtf/vector.h"
+
+namespace blink {
+class String;
+class ScriptObject;
+class ScriptState;
+
+using ExtensionVector = Vector<String>;
+
+constexpr size_t kFakeExtensionsSize = 21;
+
+// Handler for returning information around the available webgl extensions.
+// This handler automatically takes into consideration any farbling when the
+// brave shields are up.
+// TODO(https://github.com/brave/brave-browser/issues/55858): Add the
+// integration with the BraveSessionCache.
+class CORE_EXPORT WebGLExtensionHandler {
+ public:
+  WebGLExtensionHandler(const ExtensionVector& supported_extensions,
+                        std::optional<size_t> fake_index = std::nullopt);
+  ~WebGLExtensionHandler();
+
+  // Returns a vector of supported extensions which could also include a farbled
+  // extension.
+  ExtensionVector GetSupportedExtensions() const;
+
+  // Returns a ScriptObject which is either |real_extension| or a
+  // dummy ScriptObject with the internal value set to the farbled extension
+  // |name|. If |name| doesn't exists in |supported_extensions_| then it returns
+  // an ScriptObject with null value.
+  ScriptObject GetExtension(ScriptState* script_state,
+                            const String& name,
+                            const ScriptObject* real_extension);
+
+ private:
+  // Returns true if |extension_name| is a farbled value, false otherwise.
+  bool IsExtensionFarbled(const String& extension_name) const;
+
+  // The list of the supported webgl extensions including any farbled extension.
+  const ExtensionVector supported_extensions_;
+  // Points to an index in the fake supported extensions array.
+  std::optional<size_t> fake_index_;
+};
+
+// Returns the default handler without any farbling logic.
+// |real_extensions| is the set of the actual supported WebGL extensions by the
+// machine.
+CORE_EXPORT std::unique_ptr<WebGLExtensionHandler> CreateOffHandler(
+    const ExtensionVector& real_extensions);
+
+// Returns a handler with default fingerprinting protections.
+// |real_extensions| is the set of actual supported WebGL extensions.
+// |seed| is derived from the current brave::FarblingToken for the session.
+CORE_EXPORT std::unique_ptr<WebGLExtensionHandler> CreateBalancedHandler(
+    const ExtensionVector& real_extensions,
+    const size_t seed);
+
+// Return a handler which maximum fingerprinting protections.
+// |real_extensions| is the set of actual supported WebGL extensions.
+CORE_EXPORT std::unique_ptr<WebGLExtensionHandler> CreateMaximumHandler(
+    const ExtensionVector& real_extensions);
+
+// A test only method to fetch the list of fake extensions.
+CORE_EXPORT std::array<String, kFakeExtensionsSize>
+GetFakeSupportedExtensionsForTesting();
+}  // namespace blink
+
+#endif  // BRAVE_THIRD_PARTY_BLINK_RENDERER_BINDINGS_CORE_WEBGL_WEBGL_EXTENSION_HANDLER_H_

--- a/third_party/blink/renderer/bindings/core/webgl/webgl_extension_handler.h
+++ b/third_party/blink/renderer/bindings/core/webgl/webgl_extension_handler.h
@@ -6,21 +6,32 @@
 #ifndef BRAVE_THIRD_PARTY_BLINK_RENDERER_BINDINGS_CORE_WEBGL_WEBGL_EXTENSION_HANDLER_H_
 #define BRAVE_THIRD_PARTY_BLINK_RENDERER_BINDINGS_CORE_WEBGL_WEBGL_EXTENSION_HANDLER_H_
 
-#include <array>
+#include <base/containers/span.h>
+
 #include <memory>
 #include <optional>
 
 #include "third_party/blink/renderer/core/core_export.h"
-#include "third_party/blink/renderer/platform/wtf/vector.h"
+#include "third_party/blink/renderer/platform/wtf/text/wtf_string.h"
 
 namespace blink {
-class String;
 class ScriptObject;
 class ScriptState;
+}  // namespace blink
 
-using ExtensionVector = Vector<String>;
+namespace webgl {
 
-constexpr size_t kFakeExtensionsSize = 21;
+using ExtensionVector = blink::Vector<blink::String>;
+
+// Internal data type of the fake WebGL extensions array.
+struct FakeExtensionType {
+  // The real name of the fake extension returned by the getSupportedExtension
+  // call when farbled. For example: EXT_texture_sampler.
+  blink::String name;
+  // The underlying name of the script object which is returned by the
+  // getExtension call when farbled.
+  blink::String script_object_name;
+};
 
 // Handler for returning information around the available webgl extensions.
 // This handler automatically takes into consideration any farbling when the
@@ -29,8 +40,9 @@ constexpr size_t kFakeExtensionsSize = 21;
 // integration with the BraveSessionCache.
 class CORE_EXPORT WebGLExtensionHandler {
  public:
-  WebGLExtensionHandler(const ExtensionVector& supported_extensions,
-                        std::optional<size_t> fake_index = std::nullopt);
+  WebGLExtensionHandler(
+      const ExtensionVector& supported_extensions,
+      std::optional<FakeExtensionType> fake_extension = std::nullopt);
   ~WebGLExtensionHandler();
 
   // Returns a vector of supported extensions which could also include a farbled
@@ -40,19 +52,20 @@ class CORE_EXPORT WebGLExtensionHandler {
   // Returns a ScriptObject which is either |real_extension| or a
   // dummy ScriptObject with the internal value set to the farbled extension
   // |name|. If |name| doesn't exists in |supported_extensions_| then it returns
-  // an ScriptObject with null value.
-  ScriptObject GetExtension(ScriptState* script_state,
-                            const String& name,
-                            const ScriptObject* real_extension);
+  // an ScriptObject with null value. |real_extension| must be non-null when
+  // |name| is in |supported_extensions_|.
+  blink::ScriptObject GetExtension(blink::ScriptState* script_state,
+                                   const blink::String& name,
+                                   const blink::ScriptObject* real_extension);
 
  private:
   // Returns true if |extension_name| is a farbled value, false otherwise.
-  bool IsExtensionFarbled(const String& extension_name) const;
+  bool IsExtensionFarbled(const blink::String& extension_name) const;
 
   // The list of the supported webgl extensions including any farbled extension.
   const ExtensionVector supported_extensions_;
-  // Points to an index in the fake supported extensions array.
-  std::optional<size_t> fake_index_;
+  // The fake extension.
+  std::optional<FakeExtensionType> fake_extension_;
 };
 
 // Returns the default handler without any farbling logic.
@@ -74,8 +87,8 @@ CORE_EXPORT std::unique_ptr<WebGLExtensionHandler> CreateMaximumHandler(
     const ExtensionVector& real_extensions);
 
 // A test only method to fetch the list of fake extensions.
-CORE_EXPORT std::array<String, kFakeExtensionsSize>
+CORE_EXPORT base::span<const FakeExtensionType>
 GetFakeSupportedExtensionsForTesting();
-}  // namespace blink
+}  // namespace webgl
 
 #endif  // BRAVE_THIRD_PARTY_BLINK_RENDERER_BINDINGS_CORE_WEBGL_WEBGL_EXTENSION_HANDLER_H_

--- a/third_party/blink/renderer/bindings/core/webgl/webgl_extension_handler_unittest.cc
+++ b/third_party/blink/renderer/bindings/core/webgl/webgl_extension_handler_unittest.cc
@@ -12,13 +12,14 @@
 #include "third_party/blink/public/common/features.h"
 #include "third_party/blink/renderer/platform/wtf/text/wtf_string.h"
 
-namespace blink {
+namespace webgl {
 
 namespace {
 
-bool IsKnownFakeExtension(const String& name) {
+bool IsKnownFakeExtension(const blink::String& name) {
   const auto fake_extensions = GetFakeSupportedExtensionsForTesting();
-  return std::ranges::find(fake_extensions, name) != fake_extensions.end();
+  return std::ranges::any_of(
+      fake_extensions, [&name](const auto& ext) { return ext.name == name; });
 }
 
 }  // namespace
@@ -40,7 +41,7 @@ TEST(WebGLExtensionHandlerTest,
   auto handler = CreateMaximumHandler(real);
   const auto extensions = handler->GetSupportedExtensions();
   ASSERT_EQ(extensions.size(), 1u);
-  EXPECT_EQ(extensions[0], String("WEBGL_debug_renderer_info"));
+  EXPECT_EQ(extensions[0], blink::String("WEBGL_debug_renderer_info"));
 }
 
 TEST(WebGLExtensionHandlerTest,
@@ -62,7 +63,7 @@ TEST(WebGLExtensionHandlerTest,
      BalancedHandler_FeatureDisabled_ReturnsSameExtensions) {
   base::test::ScopedFeatureList feature_list;
   feature_list.InitAndDisableFeature(
-      features::kWebGLBalancedFingerprintingProtection);
+      blink::features::kWebGLBalancedFingerprintingProtection);
 
   auto real = ExtensionVector({"OES_texture_float", "WEBGL_lose_context"});
   auto handler = CreateBalancedHandler(real, /*seed=*/0);
@@ -74,7 +75,7 @@ TEST(WebGLExtensionHandlerTest,
 TEST(WebGLExtensionHandlerTest, BalancedHandler_FeatureEnabled) {
   base::test::ScopedFeatureList feature_list;
   feature_list.InitAndEnableFeature(
-      features::kWebGLBalancedFingerprintingProtection);
+      blink::features::kWebGLBalancedFingerprintingProtection);
 
   auto real = ExtensionVector({"OES_texture_float", "WEBGL_lose_context"});
   auto handler = CreateBalancedHandler(real, /*seed=*/0);
@@ -82,8 +83,8 @@ TEST(WebGLExtensionHandlerTest, BalancedHandler_FeatureEnabled) {
   ASSERT_FALSE(extensions.empty());
 
   EXPECT_EQ(extensions.size(), real.size() + 1u);
-  EXPECT_EQ(extensions[0], String("OES_texture_float"));
-  EXPECT_EQ(extensions[1], String("WEBGL_lose_context"));
+  EXPECT_EQ(extensions[0], blink::String("OES_texture_float"));
+  EXPECT_EQ(extensions[1], blink::String("WEBGL_lose_context"));
   EXPECT_TRUE(IsKnownFakeExtension(extensions.back()))
       << "Injected extension not from known fake set: " << extensions.back();
 }
@@ -92,55 +93,53 @@ TEST(WebGLExtensionHandlerTest,
      BalancedHandler_FeatureEnabled_SeedDeterminesInjectedExtension) {
   base::test::ScopedFeatureList feature_list;
   feature_list.InitAndEnableFeature(
-      features::kWebGLBalancedFingerprintingProtection);
+      blink::features::kWebGLBalancedFingerprintingProtection);
 
   auto real = ExtensionVector({"OES_texture_float"});
   auto fake = GetFakeSupportedExtensionsForTesting();
 
-  // seed=0  → index 0  → "EXT_texture_sampler"
   auto handler0 = CreateBalancedHandler(real,
                                         /*seed=*/0);
   const auto ext0 = handler0->GetSupportedExtensions();
   ASSERT_EQ(ext0.size(), 2u);
-  EXPECT_EQ(ext0.back(), fake[0]);
+  EXPECT_EQ(ext0.back(), fake[0].name);
 
-  // seed=1  → index 1  → "EXT_texture_compressor"
   auto handler1 = CreateBalancedHandler(real,
                                         /*seed=*/1);
   const auto ext1 = handler1->GetSupportedExtensions();
   ASSERT_EQ(ext1.size(), 2u);
-  EXPECT_EQ(ext1.back(), fake[1]);
+  EXPECT_EQ(ext1.back(), fake[1].name);
 
-  // seed=20 → index 20 → "EXT_draw_blender"
   auto handler20 = CreateBalancedHandler(real,
                                          /*seed=*/20);
   const auto ext20 = handler20->GetSupportedExtensions();
   ASSERT_EQ(ext20.size(), 2u);
-  EXPECT_EQ(ext20.back(), fake[20]);
+  EXPECT_EQ(ext20.back(), fake[20].name);
 }
 
 TEST(WebGLExtensionHandlerTest,
      BalancedHandler_FeatureEnabled_SeedModuloWrapsAround) {
   base::test::ScopedFeatureList feature_list;
   feature_list.InitAndEnableFeature(
-      features::kWebGLBalancedFingerprintingProtection);
+      blink::features::kWebGLBalancedFingerprintingProtection);
 
   auto real = ExtensionVector({"OES_texture_float"});
+  auto fake = GetFakeSupportedExtensionsForTesting();
 
   // seed=0 and seed=kFakeListSize both map to index 0.
   auto handler0 = CreateBalancedHandler(real,
                                         /*seed=*/0);
-  auto handler21 = CreateBalancedHandler(real,
-                                         /*seed=*/kFakeExtensionsSize);
+  auto handler_last = CreateBalancedHandler(real,
+                                            /*seed=*/fake.size());
   EXPECT_EQ(handler0->GetSupportedExtensions().back(),
-            handler21->GetSupportedExtensions().back());
+            handler_last->GetSupportedExtensions().back());
 }
 
 TEST(WebGLExtensionHandlerTest,
      BalancedHandler_FeatureEnabled_EmptyRealExtensions_OneEntryAdded) {
   base::test::ScopedFeatureList feature_list;
   feature_list.InitAndEnableFeature(
-      features::kWebGLBalancedFingerprintingProtection);
+      blink::features::kWebGLBalancedFingerprintingProtection);
 
   auto handler = CreateBalancedHandler(ExtensionVector{},
                                        /*seed=*/3);
@@ -149,4 +148,4 @@ TEST(WebGLExtensionHandlerTest,
   EXPECT_TRUE(IsKnownFakeExtension(extensions[0]));
 }
 
-}  // namespace blink
+}  // namespace webgl

--- a/third_party/blink/renderer/bindings/core/webgl/webgl_extension_handler_unittest.cc
+++ b/third_party/blink/renderer/bindings/core/webgl/webgl_extension_handler_unittest.cc
@@ -1,0 +1,152 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/third_party/blink/renderer/bindings/core/webgl/webgl_extension_handler.h"
+
+#include <algorithm>
+
+#include "base/test/scoped_feature_list.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "third_party/blink/public/common/features.h"
+#include "third_party/blink/renderer/platform/wtf/text/wtf_string.h"
+
+namespace blink {
+
+namespace {
+
+bool IsKnownFakeExtension(const String& name) {
+  const auto fake_extensions = GetFakeSupportedExtensionsForTesting();
+  return std::ranges::find(fake_extensions, name) != fake_extensions.end();
+}
+
+}  // namespace
+
+// CreateOffHandler
+
+TEST(WebGLExtensionHandlerTest, OffHandler_ReturnsSameExtensions) {
+  auto real = ExtensionVector({"OES_texture_float", "WEBGL_lose_context"});
+  auto handler = CreateOffHandler(real);
+  EXPECT_EQ(handler->GetSupportedExtensions(), real);
+}
+
+// CreateFarblingHandler (Maximum)
+
+TEST(WebGLExtensionHandlerTest,
+     MaximumHandler_WithDebugRendererInfo_ReturnsOnlyDebugInfo) {
+  auto real = ExtensionVector(
+      {"OES_texture_float", "WEBGL_debug_renderer_info", "WEBGL_lose_context"});
+  auto handler = CreateMaximumHandler(real);
+  const auto extensions = handler->GetSupportedExtensions();
+  ASSERT_EQ(extensions.size(), 1u);
+  EXPECT_EQ(extensions[0], String("WEBGL_debug_renderer_info"));
+}
+
+TEST(WebGLExtensionHandlerTest,
+     MaximumHandler_WithoutDebugRendererInfo_ReturnsEmptyList) {
+  auto real = ExtensionVector({"OES_texture_float", "WEBGL_lose_context"});
+  auto handler = CreateMaximumHandler(real);
+  EXPECT_TRUE(handler->GetSupportedExtensions().empty());
+}
+
+TEST(WebGLExtensionHandlerTest,
+     MaximumHandler_EmptyRealExtensions_ReturnsEmpty) {
+  auto handler = CreateMaximumHandler({});
+  EXPECT_TRUE(handler->GetSupportedExtensions().empty());
+}
+
+// CreateBalancedHandler with feature disabled.
+
+TEST(WebGLExtensionHandlerTest,
+     BalancedHandler_FeatureDisabled_ReturnsSameExtensions) {
+  base::test::ScopedFeatureList feature_list;
+  feature_list.InitAndDisableFeature(
+      features::kWebGLBalancedFingerprintingProtection);
+
+  auto real = ExtensionVector({"OES_texture_float", "WEBGL_lose_context"});
+  auto handler = CreateBalancedHandler(real, /*seed=*/0);
+  EXPECT_EQ(handler->GetSupportedExtensions(), real);
+}
+
+// CreateBalancedHandler with feature enabled.
+
+TEST(WebGLExtensionHandlerTest, BalancedHandler_FeatureEnabled) {
+  base::test::ScopedFeatureList feature_list;
+  feature_list.InitAndEnableFeature(
+      features::kWebGLBalancedFingerprintingProtection);
+
+  auto real = ExtensionVector({"OES_texture_float", "WEBGL_lose_context"});
+  auto handler = CreateBalancedHandler(real, /*seed=*/0);
+  const auto extensions = handler->GetSupportedExtensions();
+  ASSERT_FALSE(extensions.empty());
+
+  EXPECT_EQ(extensions.size(), real.size() + 1u);
+  EXPECT_EQ(extensions[0], String("OES_texture_float"));
+  EXPECT_EQ(extensions[1], String("WEBGL_lose_context"));
+  EXPECT_TRUE(IsKnownFakeExtension(extensions.back()))
+      << "Injected extension not from known fake set: " << extensions.back();
+}
+
+TEST(WebGLExtensionHandlerTest,
+     BalancedHandler_FeatureEnabled_SeedDeterminesInjectedExtension) {
+  base::test::ScopedFeatureList feature_list;
+  feature_list.InitAndEnableFeature(
+      features::kWebGLBalancedFingerprintingProtection);
+
+  auto real = ExtensionVector({"OES_texture_float"});
+  auto fake = GetFakeSupportedExtensionsForTesting();
+
+  // seed=0  → index 0  → "EXT_texture_sampler"
+  auto handler0 = CreateBalancedHandler(real,
+                                        /*seed=*/0);
+  const auto ext0 = handler0->GetSupportedExtensions();
+  ASSERT_EQ(ext0.size(), 2u);
+  EXPECT_EQ(ext0.back(), fake[0]);
+
+  // seed=1  → index 1  → "EXT_texture_compressor"
+  auto handler1 = CreateBalancedHandler(real,
+                                        /*seed=*/1);
+  const auto ext1 = handler1->GetSupportedExtensions();
+  ASSERT_EQ(ext1.size(), 2u);
+  EXPECT_EQ(ext1.back(), fake[1]);
+
+  // seed=20 → index 20 → "EXT_draw_blender"
+  auto handler20 = CreateBalancedHandler(real,
+                                         /*seed=*/20);
+  const auto ext20 = handler20->GetSupportedExtensions();
+  ASSERT_EQ(ext20.size(), 2u);
+  EXPECT_EQ(ext20.back(), fake[20]);
+}
+
+TEST(WebGLExtensionHandlerTest,
+     BalancedHandler_FeatureEnabled_SeedModuloWrapsAround) {
+  base::test::ScopedFeatureList feature_list;
+  feature_list.InitAndEnableFeature(
+      features::kWebGLBalancedFingerprintingProtection);
+
+  auto real = ExtensionVector({"OES_texture_float"});
+
+  // seed=0 and seed=kFakeListSize both map to index 0.
+  auto handler0 = CreateBalancedHandler(real,
+                                        /*seed=*/0);
+  auto handler21 = CreateBalancedHandler(real,
+                                         /*seed=*/kFakeExtensionsSize);
+  EXPECT_EQ(handler0->GetSupportedExtensions().back(),
+            handler21->GetSupportedExtensions().back());
+}
+
+TEST(WebGLExtensionHandlerTest,
+     BalancedHandler_FeatureEnabled_EmptyRealExtensions_OneEntryAdded) {
+  base::test::ScopedFeatureList feature_list;
+  feature_list.InitAndEnableFeature(
+      features::kWebGLBalancedFingerprintingProtection);
+
+  auto handler = CreateBalancedHandler(ExtensionVector{},
+                                       /*seed=*/3);
+  const auto extensions = handler->GetSupportedExtensions();
+  ASSERT_EQ(extensions.size(), 1u);
+  EXPECT_TRUE(IsKnownFakeExtension(extensions[0]));
+}
+
+}  // namespace blink

--- a/third_party/blink/renderer/includes.gni
+++ b/third_party/blink/renderer/includes.gni
@@ -28,6 +28,8 @@ brave_blink_renderer_core_public_deps = [
 ]
 
 brave_blink_renderer_core_sources = [
+  "//brave/third_party/blink/renderer/bindings/core/webgl/webgl_extension_handler.cc",
+  "//brave/third_party/blink/renderer/bindings/core/webgl/webgl_extension_handler.h",
   "//brave/third_party/blink/renderer/core/farbling/brave_session_cache.cc",
   "//brave/third_party/blink/renderer/core/farbling/brave_session_cache.h",
   "//brave/third_party/blink/renderer/core/resource_pool_limiter/resource_pool_limiter.cc",


### PR DESCRIPTION
This change adds a dedicated `WebGLExtensionHandler` handler to handle farbling around WebGL's `getSupportedExtensions` and `getExtension` calls. The  handler is instantiated taking into account different levels of fingerprinting protections as follows:

#### 1) Balanced fingerprinting protections:
  - [WebGLBalancedFingerprintingProtection](https://sourcegraph.com/r/github.com/brave/brave-core/-/blob/chromium_src/third_party/blink/common/features.cc?L63) **enabled**:  calls to `getSupportedExtensions` will injects a fake extension to the list and will keep this new list consistent till the lifetime of that handler. Calls to getExtension on the fake extension would return a fake `ScriptObject` with the name of the fake extension in CamelCase.
  - [WebGLBalancedFingerprintingProtection](https://sourcegraph.com/r/github.com/brave/brave-core/-/blob/chromium_src/third_party/blink/common/features.cc?L63) **disabled**: No change in behaviour i.e we don't farble and return the true list of supported extensions. 
  
 #### 2) Maximum fingerprinting protections:
 - No change in behaviour i.e we continue to return a single entry for the getSupportedExtensions call viz. WEBGL_debug_renderer_info. 
 
 #### 3) No fingerprinting protections:
 - No change in behaviour. We return the true list of supported extensions. 

Please note that this is part of the change from the bigger [PR](https://github.com/brave/brave-core/pull/36605). The `WebGLExtensionHandler` would later be created by [BraveSessionCache](https://sourcegraph.com/r/github.com/brave/brave-core/-/blob/third_party/blink/renderer/core/farbling/brave_session_cache.h). This integration with `BraveSessionCache` and then with `WebGLRenderingContextBase` would be followed in later CLs.  

This change also adds unit_tests for the same. Browser tests would be followed up later once we have the full integration complete. 

<!-- Add brave-browser issue below that this PR will resolve -->
Related https://github.com/brave/brave-browser/issues/55858

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
