### PR TITLE
[VPN 2.0] Move ClearSubscriberCredential from "browser" to "common"

### DIFF
--- a/browser/ui/webui/skus_internals_ui.cc
+++ b/browser/ui/webui/skus_internals_ui.cc
@@ -38,7 +38,6 @@
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
 #include "brave/browser/brave_vpn/brave_vpn_service_factory.h"
 #include "brave/components/brave_vpn/browser/brave_vpn_service.h"
-#include "brave/components/brave_vpn/browser/brave_vpn_service_helper.h"
 #include "brave/components/brave_vpn/browser/connection/brave_vpn_connection_manager.h"
 #include "brave/components/brave_vpn/common/brave_vpn_utils.h"
 #include "brave/components/brave_vpn/common/pref_names.h"

--- a/components/brave_vpn/browser/brave_vpn_service_helper.cc
+++ b/components/brave_vpn/browser/brave_vpn_service_helper.cc
@@ -70,10 +70,6 @@ void SetSubscriberCredential(PrefService* local_prefs,
                        std::move(cred_dict));
 }
 
-void ClearSubscriberCredential(PrefService* local_prefs) {
-  local_prefs->ClearPref(prefs::kBraveVPNSubscriberCredential);
-}
-
 void SetSkusCredential(PrefService* local_prefs,
                        const std::string& skus_credential,
                        const base::Time& expiration_time) {

--- a/components/brave_vpn/browser/brave_vpn_service_helper.h
+++ b/components/brave_vpn/browser/brave_vpn_service_helper.h
@@ -29,7 +29,6 @@ std::optional<base::Time> GetExpirationTime(PrefService* local_prefs);
 void SetSubscriberCredential(PrefService* local_prefs,
                              const std::string& subscriber_credential,
                              const base::Time& expiration_time);
-void ClearSubscriberCredential(PrefService* local_prefs);
 void SetSkusCredential(PrefService* local_prefs,
                        const std::string& skus_credential,
                        const base::Time& expiration_time);

--- a/components/brave_vpn/common/brave_vpn_utils.cc
+++ b/components/brave_vpn/common/brave_vpn_utils.cc
@@ -317,6 +317,10 @@ void MigrateLocalStatePrefs(PrefService* local_prefs) {
 #endif
 }
 
+void ClearSubscriberCredential(PrefService* local_prefs) {
+  local_prefs->ClearPref(prefs::kBraveVPNSubscriberCredential);
+}
+
 bool HasValidSubscriberCredential(PrefService* local_prefs) {
   const base::DictValue& sub_cred_dict =
       local_prefs->GetDict(prefs::kBraveVPNSubscriberCredential);

--- a/components/brave_vpn/common/brave_vpn_utils.h
+++ b/components/brave_vpn/common/brave_vpn_utils.h
@@ -36,6 +36,7 @@ void RegisterLocalStatePrefsForMigration(PrefRegistrySimple* registry);
 void MigrateLocalStatePrefs(PrefService* local_prefs);
 void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry);
 void RegisterAndroidProfilePrefs(PrefRegistrySimple* registry);
+void ClearSubscriberCredential(PrefService* local_prefs);
 bool HasValidSubscriberCredential(PrefService* local_prefs);
 std::string GetSubscriberCredential(PrefService* local_prefs);
 bool HasValidSkusCredential(PrefService* local_prefs);


### PR DESCRIPTION
To add a new BraveVpnService implementation based on Architecture 2.0, which must co-exist with Architecture 1.0 for quite a while, we need to split service's interface and implementation. All the external components will keep accessing VPN service via the BraveVpnService interface, but the implementation mostly goes into BraveVpnServiceImpl.

This change moves ClearSubscriberCredential from a helper located in a "browser" directory, to utils located in a "common" directory. This function is used outside of the Brave VPN targes, so an additional dependency on V1's "browser" there is unnecessary.

Implements part of https://github.com/brave/brave-browser/issues/54597

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
