### PR TITLE
Move Brave Origin reset-to-defaults into the service

### DIFF
--- a/browser/resources/settings/brave_origin_page/brave_origin_page.ts
+++ b/browser/resources/settings/brave_origin_page/brave_origin_page.ts
@@ -142,21 +142,14 @@ export class SettingsBraveOriginPageElement
   }
 
   private async resetToDefaults_() {
-    // Query all origin-toggle-button elements
+    // The handler only resets profile-scoped policies for the current
+    // profile; browser-level policies (shared across all profiles) are
+    // left alone so that one profile's reset cannot silently change the
+    // settings other profiles see.
+    await this.braveOriginHandler_.resetToDefaults();
+
+    // Reload all toggle states so the UI reflects the new values.
     const toggles = this.shadowRoot!.querySelectorAll('origin-toggle-button');
-
-    // Turn off all toggles that are currently on
-    for (const toggle of toggles) {
-      const toggleElement = toggle as OriginToggleButtonElement;
-      if (toggleElement.checked) {
-        // Set to off (accounting for inverted toggles)
-        const valueToSet = toggleElement.inverted ? true : false;
-        await this.braveOriginHandler_.setPolicyValue(
-            toggleElement.policyKey, valueToSet);
-      }
-    }
-
-    // Reload all toggle states
     for (const toggle of toggles) {
       await (toggle as OriginToggleButtonElement).loadPolicyValue_();
     }

--- a/components/brave_origin/brave_origin_policy_manager.h
+++ b/components/brave_origin/brave_origin_policy_manager.h
@@ -66,6 +66,14 @@ class BraveOriginPolicyManager {
   // Determines if the policy is a profile-level policy
   bool IsProfilePolicy(std::string_view policy_key) const;
 
+  // Returns the policy definitions registered at Init() time.
+  const BraveOriginPolicyMap& GetBrowserPolicyDefinitions() const {
+    return browser_policy_definitions_;
+  }
+  const BraveOriginPolicyMap& GetProfilePolicyDefinitions() const {
+    return profile_policy_definitions_;
+  }
+
   // Check if the singleton has been initialized
   bool IsInitialized() const;
 

--- a/components/brave_origin/brave_origin_service.cc
+++ b/components/brave_origin/brave_origin_service.cc
@@ -182,6 +182,26 @@ std::optional<bool> BraveOriginService::GetPolicyValue(
   return std::nullopt;
 }
 
+void BraveOriginService::ResetToDefaults() {
+  if (!IsBraveOriginPurchased()) {
+    return;
+  }
+
+  // Resets every Brave Origin policy back to its default. Profile-level
+  // policies are scoped to this profile (keyed by `profile_id_`); browser-
+  // level policies live in shared local state and have no profile id, so
+  // resetting them is observable in every profile by design.
+  auto* manager = BraveOriginPolicyManager::GetInstance();
+  for (const auto& [policy_key, policy_info] :
+       manager->GetBrowserPolicyDefinitions()) {
+    SetPolicyValue(policy_key, policy_info.default_value);
+  }
+  for (const auto& [policy_key, policy_info] :
+       manager->GetProfilePolicyDefinitions()) {
+    SetPolicyValue(policy_key, policy_info.default_value);
+  }
+}
+
 void BraveOriginService::CheckPurchaseState(
     base::OnceCallback<void(bool)> callback) {
   if (!EnsureSkusConnected()) {

--- a/components/brave_origin/brave_origin_service.h
+++ b/components/brave_origin/brave_origin_service.h
@@ -69,6 +69,12 @@ class BraveOriginService : public KeyedService {
   // Get the current value of a BraveOrigin policy
   std::optional<bool> GetPolicyValue(std::string_view policy_key) const;
 
+  // Resets all Brave Origin policies back to their default values. Profile-
+  // level policies are scoped to this profile, but browser-level policies are
+  // stored in shared local state, so resetting them is observable in every
+  // profile by design.
+  void ResetToDefaults();
+
   // Asynchronously check purchase state via SKU credential summary.
   // The callback receives true if the user has a valid Origin purchase.
   void CheckPurchaseState(base::OnceCallback<void(bool)> callback);

--- a/components/brave_origin/brave_origin_settings_handler_impl.cc
+++ b/components/brave_origin/brave_origin_settings_handler_impl.cc
@@ -87,6 +87,12 @@ void BraveOriginSettingsHandlerImpl::SetPolicyValue(
   std::move(callback).Run(success);
 }
 
+void BraveOriginSettingsHandlerImpl::ResetToDefaults(
+    ResetToDefaultsCallback callback) {
+  brave_origin_service_->ResetToDefaults();
+  std::move(callback).Run();
+}
+
 void BraveOriginSettingsHandlerImpl::GetNeedsRestart(
     GetNeedsRestartCallback callback) {
   std::move(callback).Run(brave_origin_service_->NeedsRestart());

--- a/components/brave_origin/brave_origin_settings_handler_impl.h
+++ b/components/brave_origin/brave_origin_settings_handler_impl.h
@@ -39,6 +39,7 @@ class BraveOriginSettingsHandlerImpl
   void SetPolicyValue(const std::string& policy_key,
                       bool value,
                       SetPolicyValueCallback callback) override;
+  void ResetToDefaults(ResetToDefaultsCallback callback) override;
   void GetNeedsRestart(GetNeedsRestartCallback callback) override;
   void ProceedFree(ProceedFreeCallback callback) override;
 

--- a/components/brave_origin/mojom/brave_origin_settings.mojom
+++ b/components/brave_origin/mojom/brave_origin_settings.mojom
@@ -25,6 +25,11 @@ interface BraveOriginSettingsHandler {
   // Set the value of a Brave Origin controlled policy
   SetPolicyValue(string policy_key, bool value) => (bool success);
 
+  // Reset all Brave Origin policies back to their default values. Profile-
+  // level policies are scoped to the current profile; browser-level policies
+  // live in shared local state and reset for every profile by design.
+  ResetToDefaults() => ();
+
   // Check if any Brave Origin policy values have been changed since
   // browser startup, indicating a restart is needed.
   GetNeedsRestart() => (bool needs_restart);


### PR DESCRIPTION
Adds BraveOriginService::ResetToDefaults that iterates both browser- and profile-level Brave Origin policy definitions and resets each to its default via SetPolicyValue, replacing the WebUI loop that walked toggle elements and only reset ones that were currently checked.

Fixes https://github.com/brave/brave-browser/issues/55690