### PR TITLE
[ads] Unregister resource components on shutdown and opt-out

### DIFF
--- a/components/brave_ads/browser/BUILD.gn
+++ b/components/brave_ads/browser/BUILD.gn
@@ -113,6 +113,7 @@ source_set("test_support") {
     "//brave/components/services/bat_ads/public/interfaces",
     "//components/prefs",
     "//mojo/public/cpp/bindings",
+    "//testing/gmock",
     "//ui/base/idle",
     "//url",
   ]
@@ -137,6 +138,10 @@ source_set("unit_tests") {
     "ads_service_impl_unittest.cc",
     "application_state/application_state_monitor_unittest.cc",
     "component_updater/resource_component_registrar_unittest.cc",
+    "test/fake_component_updater_delegate.cc",
+    "test/fake_component_updater_delegate.h",
+    "test/mock_resource_component.cc",
+    "test/mock_resource_component.h",
   ]
 
   deps = [

--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -192,8 +192,8 @@ AdsServiceImpl::AdsServiceImpl(
   // upgrades regardless of whether the service is eligible to start.
   Migrate();
 
-  // Must be active regardless of whether the service starts so that
-  // pref-driven eligibility changes are always observed.
+  // Always registered to observe eligibility pref changes even when the
+  // service is not running.
   InitializeLocalStatePrefChangeRegistrar();
   InitializePrefChangeRegistrar();
 
@@ -209,15 +209,7 @@ AdsServiceImpl::~AdsServiceImpl() = default;
 
 ///////////////////////////////////////////////////////////////////////////////
 
-void AdsServiceImpl::RegisterResourceComponents() {
-  RegisterCountryResourceComponent();
 
-  if (UserHasOptedInToNotificationAds()) {
-    // Only utilized for text classification, which requires the user to have
-    // joined Brave Rewards and opted into notification ads.
-    RegisterLanguageResourceComponent();
-  }
-}
 
 void AdsServiceImpl::Migrate() {
   // Added 08/2023.
@@ -240,11 +232,25 @@ void AdsServiceImpl::Migrate() {
   }
 }
 
+void AdsServiceImpl::RegisterResourceComponents() {
+  RegisterCountryResourceComponent();
+
+  if (UserHasOptedInToNotificationAds()) {
+    // Only utilized for text classification, which requires the user to have
+    // joined Brave Rewards and opted into notification ads.
+    RegisterLanguageResourceComponent();
+  }
+}
+
 void AdsServiceImpl::RegisterCountryResourceComponent() {
   if (resource_component_) {
     resource_component_->RegisterCountryComponent(
         delegate_->GetVariationsCountryCode());
   }
+}
+
+void AdsServiceImpl::UnregisterCountryResourceComponent() {
+  resource_component_->UnregisterCountryComponent();
 }
 
 void AdsServiceImpl::RegisterLanguageResourceComponent() {
@@ -253,7 +259,15 @@ void AdsServiceImpl::RegisterLanguageResourceComponent() {
   }
 }
 
+void AdsServiceImpl::UnregisterLanguageResourceComponent() {
+  resource_component_->UnregisterLanguageComponent();
+}
+
 bool AdsServiceImpl::UserHasJoinedBraveRewards() const {
+  if (prefs_->IsManagedPreference(brave_rewards::prefs::kDisabledByPolicy) &&
+      prefs_->GetBoolean(brave_rewards::prefs::kDisabledByPolicy)) {
+    return false;
+  }
   return prefs_->GetBoolean(brave_rewards::prefs::kEnabled);
 }
 
@@ -699,6 +713,11 @@ void AdsServiceImpl::InitializePrefChangeRegistrar() {
 
 void AdsServiceImpl::InitializeBraveRewardsPrefChangeRegistrar() {
   pref_change_registrar_.Add(
+      brave_rewards::prefs::kDisabledByPolicy,
+      base::BindRepeating(&AdsServiceImpl::OnAdsPrefChanged,
+                          base::Unretained(this)));
+
+  pref_change_registrar_.Add(
       brave_rewards::prefs::kEnabled,
       base::BindRepeating(&AdsServiceImpl::NotifyPrefChanged,
                           base::Unretained(this),
@@ -757,18 +776,24 @@ void AdsServiceImpl::InitializeSearchResultAdsPrefChangeRegistrar() {
 
 void AdsServiceImpl::OnAdsPrefChanged(const std::string& path) {
   if (!CanStartBatAdsService()) {
-    // The pref change made the service ineligible to run, so tear it down.
+    // The pref change made the service ineligible to run, so tear it down and
+    // release resource components that are no longer needed.
+    UnregisterCountryResourceComponent();
+    UnregisterLanguageResourceComponent();
     return ShutdownAdsService();
   }
 
-  if (bat_ads_service_remote_.is_bound() && UserHasOptedInToNotificationAds() &&
+  if (bat_ads_service_remote_.is_bound() &&
       path == prefs::kOptedInToNotificationAds) {
-    // Register language resource components if the user has joined Brave
-    // Rewards, opted into notification ads, and the Bat Ads Service has
-    // already started.
-    RegisterLanguageResourceComponent();
+    if (UserHasOptedInToNotificationAds()) {
+      // Register now that the user has opted in.
+      RegisterLanguageResourceComponent();
 
-    delegate_->MaybeInitNotificationHelper();
+      delegate_->MaybeInitNotificationHelper();
+    } else {
+      // Unregister now that the user has opted out.
+      UnregisterLanguageResourceComponent();
+    }
   }
 
   MaybeStartBatAdsService();

--- a/components/brave_ads/browser/ads_service_impl.h
+++ b/components/brave_ads/browser/ads_service_impl.h
@@ -97,11 +97,11 @@ class AdsServiceImpl : public AdsService,
 #endif
                        public content_settings::Observer {
  public:
-  // `http_client`, `resource_component`, `history_service`, and
-  // `host_content_settings` can be `nullptr` in tests. `rewards_service`
-  // can be `nullptr` when Rewards is unsupported or disabled by policy.
-  // `policy_initialization_waiter` defers the initial ads-eligibility gate
-  // until the policy bundle has been merged into the managed pref store.
+  // `http_client`, `history_service`, and `host_content_settings` can be
+  // `nullptr` in tests. `rewards_service` can be `nullptr` when Rewards is
+  // unsupported or disabled by policy. `policy_initialization_waiter` defers
+  // the initial ads-eligibility gate until the policy bundle has been merged
+  // into the managed pref store.
   explicit AdsServiceImpl(
       std::unique_ptr<Delegate> delegate,
       PrefService& prefs,
@@ -138,11 +138,13 @@ class AdsServiceImpl : public AdsService,
  private:
   friend class BraveAdsAdsServiceImplTest;
 
+  void Migrate();
+
   void RegisterResourceComponents();
   void RegisterCountryResourceComponent();
+  void UnregisterCountryResourceComponent();
   void RegisterLanguageResourceComponent();
-
-  void Migrate();
+  void UnregisterLanguageResourceComponent();
 
   bool UserHasJoinedBraveRewards() const;
   bool UserHasOptedInToNewTabPageAds() const;

--- a/components/brave_ads/browser/ads_service_impl_unittest.cc
+++ b/components/brave_ads/browser/ads_service_impl_unittest.cc
@@ -22,6 +22,7 @@
 #include "brave/components/brave_ads/browser/test/fake_bat_ads_service_factory.h"
 #include "brave/components/brave_ads/browser/test/fake_device_id.h"
 #include "brave/components/brave_ads/browser/test/fake_virtual_pref_provider_delegate.h"
+#include "brave/components/brave_ads/browser/test/mock_resource_component.h"
 #include "brave/components/brave_ads/core/public/prefs/pref_names.h"
 #include "brave/components/brave_ads/core/public/prefs/pref_registry.h"
 #include "brave/components/brave_policy/policy_initialization_waiter.h"
@@ -92,7 +93,7 @@ class BraveAdsAdsServiceImplTest : public testing::Test {
         std::make_unique<test::FakeVirtualPrefProviderDelegate>(),
         /*channel_name=*/"foo", profile_dir_.GetPath(),
         std::make_unique<test::FakeAdsTooltipsDelegate>(), std::move(device_id),
-        std::move(bat_ads_service_factory), /*resource_component=*/nullptr,
+        std::move(bat_ads_service_factory), &mock_resource_component_,
         /*history_service=*/nullptr,
 #if BUILDFLAG(ENABLE_BRAVE_REWARDS)
         &rewards_service_,
@@ -138,6 +139,8 @@ class BraveAdsAdsServiceImplTest : public testing::Test {
 #if BUILDFLAG(ENABLE_BRAVE_REWARDS)
   test::FakeRewardsService rewards_service_;
 #endif  // BUILDFLAG(ENABLE_BRAVE_REWARDS)
+
+  testing::NiceMock<test::MockResourceComponent> mock_resource_component_;
 
   std::unique_ptr<AdsServiceImpl> ads_service_;
 };
@@ -635,5 +638,60 @@ TEST_F(BraveAdsAdsServiceImplTest,
   // Assert
   EXPECT_THAT(prefs_.GetList(prefs::kNotificationAds), testing::IsEmpty());
 }
+
+#if BUILDFLAG(ENABLE_BRAVE_REWARDS)
+TEST_F(BraveAdsAdsServiceImplTest,
+       RegistersLanguageResourceComponentWhenUserOptsInToNotificationAds) {
+  // Arrange: start the service via search result ads and wait for
+  // initialization so `bat_ads_service_remote_` is bound.
+  prefs_.SetBoolean(prefs::kOptedInToSearchResultAds, true);
+  prefs_.SetBoolean(brave_rewards::prefs::kEnabled, true);
+  prefs_.SetBoolean(prefs::kOptedInToNotificationAds, false);
+  Startup();
+  ASSERT_TRUE(base::test::RunUntil(
+      [&] { return bat_ads_service_factory_->initialize_count() == 1U; }));
+
+  EXPECT_CALL(mock_resource_component_, RegisterLanguageComponent);
+
+  // Act
+  prefs_.SetBoolean(prefs::kOptedInToNotificationAds, true);
+}
+
+TEST_F(BraveAdsAdsServiceImplTest,
+       UnregistersLanguageResourceComponentWhenUserOptsOutOfNotificationAds) {
+  // Arrange: start with notification ads opted in so the language component
+  // is already registered; service must be running before opting out.
+  prefs_.SetBoolean(prefs::kOptedInToSearchResultAds, true);
+  prefs_.SetBoolean(brave_rewards::prefs::kEnabled, true);
+  prefs_.SetBoolean(prefs::kOptedInToNotificationAds, true);
+  Startup();
+  ASSERT_TRUE(base::test::RunUntil(
+      [&] { return bat_ads_service_factory_->initialize_count() == 1U; }));
+
+  EXPECT_CALL(mock_resource_component_, UnregisterLanguageComponent());
+
+  // Act
+  prefs_.SetBoolean(prefs::kOptedInToNotificationAds, false);
+}
+#endif  // BUILDFLAG(ENABLE_BRAVE_REWARDS)
+
+#if !BUILDFLAG(IS_ANDROID)
+TEST_F(BraveAdsAdsServiceImplTest,
+       UnregistersResourceComponentsWhenServiceBecomesIneligible) {
+  // Arrange: start the service so resource components are registered; then
+  // disable ads via policy to trigger unregistration.
+  prefs_.SetBoolean(prefs::kOptedInToSearchResultAds, true);
+  Startup();
+  ASSERT_TRUE(base::test::RunUntil(
+      [&] { return bat_ads_service_factory_->initialize_count() == 1U; }));
+
+  EXPECT_CALL(mock_resource_component_, UnregisterCountryComponent());
+  EXPECT_CALL(mock_resource_component_, UnregisterLanguageComponent());
+
+  // Act
+  prefs_.SetManagedPref(brave_rewards::prefs::kDisabledByPolicy,
+                        base::Value(true));
+}
+#endif  // !BUILDFLAG(IS_ANDROID)
 
 }  // namespace brave_ads

--- a/components/brave_ads/browser/component_updater/resource_component.cc
+++ b/components/brave_ads/browser/component_updater/resource_component.cc
@@ -76,10 +76,18 @@ void ResourceComponent::RegisterCountryComponent(
   country_resource_component_registrar_.RegisterResourceComponent(country_code);
 }
 
+void ResourceComponent::UnregisterCountryComponent() {
+  country_resource_component_registrar_.UnregisterResourceComponent();
+}
+
 void ResourceComponent::RegisterLanguageComponent(
     const std::string& language_code) {
   language_resource_component_registrar_.RegisterResourceComponent(
       language_code);
+}
+
+void ResourceComponent::UnregisterLanguageComponent() {
+  language_resource_component_registrar_.UnregisterResourceComponent();
 }
 
 std::optional<base::FilePath> ResourceComponent::MaybeGetPath(
@@ -127,8 +135,6 @@ void ResourceComponent::OnResourceComponentUnregistered(
 void ResourceComponent::LoadManifestCallback(const std::string& component_id,
                                              const base::FilePath& install_dir,
                                              const std::string& json) {
-  VLOG(8) << "Manifest JSON: " << json;
-
   std::optional<base::DictValue> dict =
       base::JSONReader::ReadDict(json, base::JSON_PARSE_RFC);
   if (!dict) {
@@ -155,8 +161,6 @@ void ResourceComponent::LoadResourceCallback(
     const std::string& component_id,
     const base::FilePath& install_dir,
     const std::string& json) {
-  VLOG(8) << "Resource JSON: " << json;
-
   std::optional<base::DictValue> root =
       base::JSONReader::ReadDict(json, base::JSON_PARSE_RFC);
   if (!root) {

--- a/components/brave_ads/browser/component_updater/resource_component.h
+++ b/components/brave_ads/browser/component_updater/resource_component.h
@@ -28,7 +28,7 @@ static_assert(BUILDFLAG(ENABLE_BRAVE_ADS));
 
 namespace brave_ads {
 
-class ResourceComponent final : public ResourceComponentRegistrarDelegate {
+class ResourceComponent : public ResourceComponentRegistrarDelegate {
  public:
   explicit ResourceComponent(
       brave_component_updater::BraveComponent::Delegate* delegate);
@@ -41,8 +41,10 @@ class ResourceComponent final : public ResourceComponentRegistrarDelegate {
   void AddObserver(ResourceComponentObserver* observer);
   void RemoveObserver(ResourceComponentObserver* observer);
 
-  void RegisterCountryComponent(const std::string& country_code);
-  void RegisterLanguageComponent(const std::string& language_code);
+  virtual void RegisterCountryComponent(const std::string& country_code);
+  virtual void UnregisterCountryComponent();
+  virtual void RegisterLanguageComponent(const std::string& language_code);
+  virtual void UnregisterLanguageComponent();
 
   std::optional<base::FilePath> MaybeGetPath(const std::string& id,
                                              int version);

--- a/components/brave_ads/browser/component_updater/resource_component_registrar.cc
+++ b/components/brave_ads/browser/component_updater/resource_component_registrar.cc
@@ -68,6 +68,17 @@ void ResourceComponentRegistrar::RegisterResourceComponent(
   }
 }
 
+void ResourceComponentRegistrar::UnregisterResourceComponent() {
+  if (!resource_component_id_) {
+    return;
+  }
+
+  Unregister();
+  OnComponentUnregistered(*resource_component_id_);
+  last_install_dir_.reset();
+  resource_component_id_.reset();
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 
 void ResourceComponentRegistrar::OnComponentReady(

--- a/components/brave_ads/browser/component_updater/resource_component_registrar.h
+++ b/components/brave_ads/browser/component_updater/resource_component_registrar.h
@@ -32,6 +32,7 @@ class ResourceComponentRegistrar final
   ~ResourceComponentRegistrar() override;
 
   void RegisterResourceComponent(const std::string& resource_id);
+  void UnregisterResourceComponent();
 
  private:
   // brave_component_updater::BraveComponent:

--- a/components/brave_ads/browser/test/fake_component_updater_delegate.cc
+++ b/components/brave_ads/browser/test/fake_component_updater_delegate.cc
@@ -1,0 +1,44 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_ads/browser/test/fake_component_updater_delegate.h"
+
+#include "base/strings/string_util.h"
+
+namespace brave_ads::test {
+
+FakeComponentUpdaterDelegate::FakeComponentUpdaterDelegate() = default;
+
+FakeComponentUpdaterDelegate::~FakeComponentUpdaterDelegate() = default;
+
+void FakeComponentUpdaterDelegate::Register(
+    const std::string& /*component_name*/,
+    const std::string& /*component_base64_public_key*/,
+    base::OnceClosure registered_callback,
+    brave_component_updater::BraveComponent::ReadyCallback /*ready_callback*/) {
+  if (registered_callback) {
+    std::move(registered_callback).Run();
+  }
+}
+
+bool FakeComponentUpdaterDelegate::Unregister(
+    const std::string& /*component_id*/) {
+  return true;
+}
+
+scoped_refptr<base::SequencedTaskRunner>
+FakeComponentUpdaterDelegate::GetTaskRunner() {
+  return nullptr;
+}
+
+const std::string& FakeComponentUpdaterDelegate::locale() const {
+  return base::EmptyString();
+}
+
+PrefService* FakeComponentUpdaterDelegate::local_state() {
+  return nullptr;
+}
+
+}  // namespace brave_ads::test

--- a/components/brave_ads/browser/test/fake_component_updater_delegate.h
+++ b/components/brave_ads/browser/test/fake_component_updater_delegate.h
@@ -1,0 +1,59 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_ADS_BROWSER_TEST_FAKE_COMPONENT_UPDATER_DELEGATE_H_
+#define BRAVE_COMPONENTS_BRAVE_ADS_BROWSER_TEST_FAKE_COMPONENT_UPDATER_DELEGATE_H_
+
+#include <string>
+
+#include "base/functional/callback.h"
+#include "base/memory/scoped_refptr.h"
+#include "base/task/sequenced_task_runner.h"
+#include "brave/components/brave_component_updater/browser/brave_component.h"
+
+class PrefService;
+
+namespace brave_ads::test {
+
+// Minimal no-op `BraveComponent::Delegate` for use in unit tests that need a
+// `ResourceComponent` without a real component updater.
+class FakeComponentUpdaterDelegate final
+    : public brave_component_updater::BraveComponent::Delegate {
+ public:
+  FakeComponentUpdaterDelegate();
+
+  FakeComponentUpdaterDelegate(const FakeComponentUpdaterDelegate&) = delete;
+  FakeComponentUpdaterDelegate& operator=(const FakeComponentUpdaterDelegate&) =
+      delete;
+
+  ~FakeComponentUpdaterDelegate() override;
+
+  void Register(const std::string& /*component_name*/,
+                const std::string& /*component_base64_public_key*/,
+                base::OnceClosure registered_callback,
+                brave_component_updater::BraveComponent::ReadyCallback
+                /*ready_callback*/) override;
+
+  bool Unregister(const std::string& /*component_id*/) override;
+
+  void EnsureInstalled(const std::string& /*component_id*/) override {}
+
+  void AddObserver(brave_component_updater::BraveComponent::ComponentObserver*
+                   /*observer*/) override {}
+
+  void RemoveObserver(
+      brave_component_updater::BraveComponent::ComponentObserver*
+      /*observer*/) override {}
+
+  scoped_refptr<base::SequencedTaskRunner> GetTaskRunner() override;
+
+  const std::string& locale() const override;
+
+  PrefService* local_state() override;
+};
+
+}  // namespace brave_ads::test
+
+#endif  // BRAVE_COMPONENTS_BRAVE_ADS_BROWSER_TEST_FAKE_COMPONENT_UPDATER_DELEGATE_H_

--- a/components/brave_ads/browser/test/fake_rewards_service.cc
+++ b/components/brave_ads/browser/test/fake_rewards_service.cc
@@ -288,7 +288,10 @@ void FakeRewardsService::GetEventLogs(
 
 void FakeRewardsService::GetRewardsWallet(
     brave_rewards::GetRewardsWalletCallback callback) {
-  std::move(callback).Run(nullptr);
+  auto wallet = brave_rewards::mojom::RewardsWallet::New();
+  wallet->payment_id = "foo";
+  wallet->recovery_seed = std::vector<uint8_t>(32, 0);
+  std::move(callback).Run(std::move(wallet));
 }
 
 void FakeRewardsService::GetEnvironment(

--- a/components/brave_ads/browser/test/mock_resource_component.cc
+++ b/components/brave_ads/browser/test/mock_resource_component.cc
@@ -1,0 +1,15 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_ads/browser/test/mock_resource_component.h"
+
+namespace brave_ads::test {
+
+MockResourceComponent::MockResourceComponent()
+    : ResourceComponent(&fake_component_updater_delegate_) {}
+
+MockResourceComponent::~MockResourceComponent() = default;
+
+}  // namespace brave_ads::test

--- a/components/brave_ads/browser/test/mock_resource_component.h
+++ b/components/brave_ads/browser/test/mock_resource_component.h
@@ -1,0 +1,43 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_ADS_BROWSER_TEST_MOCK_RESOURCE_COMPONENT_H_
+#define BRAVE_COMPONENTS_BRAVE_ADS_BROWSER_TEST_MOCK_RESOURCE_COMPONENT_H_
+
+#include <string>
+
+#include "brave/components/brave_ads/browser/component_updater/resource_component.h"
+#include "brave/components/brave_ads/browser/test/fake_component_updater_delegate.h"
+#include "testing/gmock/include/gmock/gmock.h"
+
+namespace brave_ads::test {
+
+class MockResourceComponent : public ResourceComponent {
+ public:
+  MockResourceComponent();
+
+  MockResourceComponent(const MockResourceComponent&) = delete;
+  MockResourceComponent& operator=(const MockResourceComponent&) = delete;
+
+  ~MockResourceComponent() override;
+
+  MOCK_METHOD(void,
+              RegisterCountryComponent,
+              (const std::string& country_code),
+              (override));
+  MOCK_METHOD(void, UnregisterCountryComponent, (), (override));
+  MOCK_METHOD(void,
+              RegisterLanguageComponent,
+              (const std::string& language_code),
+              (override));
+  MOCK_METHOD(void, UnregisterLanguageComponent, (), (override));
+
+ private:
+  FakeComponentUpdaterDelegate fake_component_updater_delegate_;
+};
+
+}  // namespace brave_ads::test
+
+#endif  // BRAVE_COMPONENTS_BRAVE_ADS_BROWSER_TEST_MOCK_RESOURCE_COMPONENT_H_


### PR DESCRIPTION
Resource components were registered with the component updater but never explicitly unregistered, causing it to keep downloading updates for country and language models even after the ads service shut down or the user opted out of notification ads. Components are now unregistered in OnPrefChanged when the service becomes ineligible, and the language component is additionally unregistered immediately when the user opts out of notification ads while the service is still running.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/55868

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
