### PR TITLE
Fix Brave Origin startup dialog showing generic taskbar icon on Linux

### DIFF
--- a/browser/ui/views/brave_origin/brave_origin_startup_view.cc
+++ b/browser/ui/views/brave_origin/brave_origin_startup_view.cc
@@ -230,6 +230,16 @@ void BraveOriginStartupView::Init(Profile* profile) {
       views::Widget::InitParams::CLIENT_OWNS_WIDGET,
       views::Widget::InitParams::TYPE_WINDOW);
   params.delegate = this;
+#if BUILDFLAG(IS_LINUX)
+  // Without these, the dialog's window has no WM_CLASS / app_id, so the Linux
+  // window manager can't match it to the Brave .desktop file and falls back to
+  // a generic icon in the taskbar. Mirrors ProfilePickerWidget. Routed through
+  // the delegate so this source set doesn't need to depend on //chrome/browser
+  // (which would create a dependency cycle).
+  params.wm_class_name = delegate_->GetLinuxWMClassName();
+  params.wm_class_class = delegate_->GetLinuxWMClassClass();
+  params.wayland_app_id = params.wm_class_class;
+#endif
 
   // Widget is freed in WidgetIsZombie() after the delegate is deleted.
   auto* widget = new views::Widget();

--- a/browser/ui/views/brave_origin/brave_origin_startup_view.h
+++ b/browser/ui/views/brave_origin/brave_origin_startup_view.h
@@ -12,10 +12,12 @@ static_assert(BUILDFLAG(IS_BRAVE_ORIGIN_BRANDED));
 
 #include <memory>
 #include <optional>
+#include <string>
 
 #include "base/functional/callback.h"
 #include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
+#include "build/build_config.h"
 #include "content/public/browser/web_contents_delegate.h"
 #include "content/public/browser/web_contents_observer.h"
 #include "ui/base/models/image_model.h"
@@ -64,6 +66,18 @@ class BraveOriginStartupView : public views::WidgetDelegate,
     // Asynchronously creates the default user profile and passes it to
     // |callback|.
     virtual void CreateDefaultProfile(ProfileCallback callback) = 0;
+
+#if BUILDFLAG(IS_LINUX)
+    // Returns the WM_CLASS res_name / res_class (and equivalent Wayland
+    // app_id) for the startup dialog's window. The window manager uses these
+    // to match the window to the Brave .desktop file and pick its icon; if
+    // they're empty the taskbar shows a generic icon. Implemented in the
+    // production delegate via shell_integration_linux. Routed through the
+    // delegate to avoid a dependency cycle from this source set to
+    // //chrome/browser.
+    virtual std::string GetLinuxWMClassName() = 0;
+    virtual std::string GetLinuxWMClassClass() = 0;
+#endif
   };
 
   // Returns true if the startup dialog should be shown (purchase not yet

--- a/browser/ui/views/brave_origin/brave_origin_startup_view_browsertest.cc
+++ b/browser/ui/views/brave_origin/brave_origin_startup_view_browsertest.cc
@@ -59,6 +59,13 @@ class TestDelegate : public BraveOriginStartupView::Delegate {
         std::move(callback));
   }
 
+#if BUILDFLAG(IS_LINUX)
+  // Test infrastructure doesn't display the dialog in a context where the
+  // WM_CLASS matters; empty values are fine.
+  std::string GetLinuxWMClassName() override { return std::string(); }
+  std::string GetLinuxWMClassClass() override { return std::string(); }
+#endif
+
  private:
   raw_ptr<bool> attempt_exit_flag_ = nullptr;
 };

--- a/chromium_src/chrome/browser/ui/startup/startup_browser_creator.cc
+++ b/chromium_src/chrome/browser/ui/startup/startup_browser_creator.cc
@@ -23,6 +23,9 @@
 #include "chrome/browser/platform_util.h"
 #include "chrome/browser/profiles/profile_manager.h"
 #include "components/prefs/pref_service.h"
+#if BUILDFLAG(IS_LINUX)
+#include "chrome/browser/shell_integration_linux.h"
+#endif
 #if BUILDFLAG(IS_MAC)
 // Defined in brave_app_controller_mac.mm. We can't include the ObjC header
 // from a .cc file, so declare the free function directly.
@@ -132,6 +135,19 @@ class StartupDialogDelegate : public BraveOriginStartupView::Delegate {
         g_browser_process->profile_manager()->GetLastUsedProfileDir(),
         std::move(callback));
   }
+
+#if BUILDFLAG(IS_LINUX)
+  // Provide the WM_CLASS name/class so the Linux window manager can match this
+  // window to the Brave .desktop file and display the correct taskbar icon
+  // instead of a generic one.
+  std::string GetLinuxWMClassName() override {
+    return shell_integration_linux::GetProgramClassName();
+  }
+
+  std::string GetLinuxWMClassClass() override {
+    return shell_integration_linux::GetProgramClassClass();
+  }
+#endif
 };
 
 }  // namespace


### PR DESCRIPTION
The dialog widget didn't set wm_class_name / wm_class_class / wayland_app_id on its InitParams, so the Linux window manager couldn't match it to the Brave .desktop file and fell back to a generic settings icon in the taskbar. 

This mirrors what ProfilePickerWidget does.

Fixes https://github.com/brave/brave-browser/issues/55614