### PR TITLE
Hide Tor toggle when managed by Brave Origin policy

### DIFF
--- a/browser/resources/settings/brave_tor_page/brave_tor_subpage.html
+++ b/browser/resources/settings/brave_tor_page/brave_tor_subpage.html
@@ -34,11 +34,13 @@
 </style>
 
 <settings-section page-title="$i18n{braveTor}">
-  <settings-toggle-button id="torEnabled" class="cr-row" pref="[[torEnabledPref_]]" label="$i18n{torEnabledLabel}"
-    sub-label="$i18n{torEnabledDesc}" disabled="[[disableTorOption_]]"
-    learn-more-url="https://support.brave.app/hc/en-us/articles/360018121491-What-is-a-Private-Window-with-Tor-Connectivity-"
-    on-settings-boolean-control-change="onTorEnabledChange_">
-  </settings-toggle-button>
+  <template is="dom-if" if="[[!isTorManaged_]]">
+    <settings-toggle-button id="torEnabled" class="cr-row" pref="[[torEnabledPref_]]" label="$i18n{torEnabledLabel}"
+      sub-label="$i18n{torEnabledDesc}"
+      learn-more-url="https://support.brave.app/hc/en-us/articles/360018121491-What-is-a-Private-Window-with-Tor-Connectivity-"
+      on-settings-boolean-control-change="onTorEnabledChange_">
+    </settings-toggle-button>
+  </template>
   <settings-toggle-button id="onionOnlyInTorWindows" pref="{{prefs.tor.onion_only_in_tor_windows}}" class="cr-row" label="$i18n{onionOnlyInTorWindowsLabel}"
     sub-label="$i18n{onionOnlyInTorWindowsDesc}">
   </settings-toggle-button>

--- a/browser/resources/settings/brave_tor_page/brave_tor_subpage.ts
+++ b/browser/resources/settings/brave_tor_page/brave_tor_subpage.ts
@@ -123,7 +123,7 @@ class SettingsBraveTorPageElement extends SettingBraveTorPageElementBase {
         computed: 'computeProvidedBridgesPlaceholder_(useBridges_, providedBridges_)'
       },
 
-      disableTorOption_: Boolean,
+      isTorManaged_: Boolean,
 
       torEnabledPref_: {
         type: Object,
@@ -180,7 +180,7 @@ class SettingsBraveTorPageElement extends SettingBraveTorPageElementBase {
   private declare shouldShowBridgesGroup_: boolean
   private declare requestedBridgesPlaceholder_: string
   private declare providedBridgesPlaceholder_: string
-  private declare disableTorOption_: boolean
+  private declare isTorManaged_: boolean
   private declare torEnabledPref_: chrome.settingsPrivate.PrefObject
   private declare torSnowflakeExtensionEnabledPref_: chrome.settingsPrivate.PrefObject
   private declare torSnowflakeExtensionAllowed_: boolean
@@ -221,7 +221,7 @@ class SettingsBraveTorPageElement extends SettingBraveTorPageElementBase {
       this.setTorEnabledPref_(enabled)
     })
     this.browserProxy_.isTorManaged().then((managed: boolean) => {
-      this.disableTorOption_ = managed
+      this.isTorManaged_ = managed
     })
 
     if (loadTimeData.getBoolean('enable_extensions')) {

--- a/browser/tor/test/brave_tor_browsertest.cc
+++ b/browser/tor/test/brave_tor_browsertest.cc
@@ -371,6 +371,13 @@ IN_PROC_BROWSER_TEST_F(BraveTorWithCustomProfileBrowserTest, Incognito) {
         .ExtractBool();
   };
 
+  const auto does_element_exist = [&](const char* id) {
+    return EvalJs(web_contents,
+                  base::StrCat({"!!window.testing.torSubpage.getElementById('",
+                                id, "')"}))
+        .ExtractBool();
+  };
+
   // Disable incognito mode for this profile.
   IncognitoModePrefs::SetAvailability(
       browser()->profile()->GetPrefs(),
@@ -383,7 +390,9 @@ IN_PROC_BROWSER_TEST_F(BraveTorWithCustomProfileBrowserTest, Incognito) {
                                            GURL("brave://settings/privacy")));
   web_contents = browser()->tab_strip_model()->GetActiveWebContents();
 
-  EXPECT_FALSE(is_element_enabled("torEnabled"));
+  // When Tor is managed the toggle is hidden (not stamped) rather than just
+  // disabled.
+  EXPECT_FALSE(does_element_exist("torEnabled"));
   EXPECT_FALSE(is_element_enabled("useBridges"));
   EXPECT_TRUE(is_element_enabled("onionOnlyInTorWindows"));
   EXPECT_TRUE(is_element_enabled("torSnowflake"));
@@ -412,6 +421,8 @@ IN_PROC_BROWSER_TEST_F(BraveTorWithCustomProfileBrowserTest, Incognito) {
   ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(),
                                            GURL("brave://settings/privacy")));
   web_contents = browser()->tab_strip_model()->GetActiveWebContents();
+  // No longer managed: the toggle is stamped again and enabled.
+  EXPECT_TRUE(does_element_exist("torEnabled"));
   EXPECT_TRUE(is_element_enabled("torEnabled"));
   EXPECT_TRUE(is_element_enabled("useBridges"));
   EXPECT_TRUE(is_element_enabled("onionOnlyInTorWindows"));


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/55684

When the Tor pref is managed by policy (e.g. controlled via Brave Origin), the "Private window with Tor" toggle is now hidden entirely matching the pattern used by other Brave Origin top-level toggles. Previously the toggle appeared partially enabled and non interactive.