### PR TITLE
[VPN 2.0] Add GN buildflags for VPN Architectures 1.0 and 2.0

### DIFF
--- a/browser/brave_browser_process.h
+++ b/browser/brave_browser_process.h
@@ -25,7 +25,7 @@ class BraveReferralsService;
 class URLSanitizerComponentInstaller;
 }  // namespace brave
 
-#if BUILDFLAG(ENABLE_BRAVE_VPN)
+#if BUILDFLAG(ENABLE_BRAVE_VPN_V1)
 namespace brave_vpn {
 class BraveVPNConnectionManager;
 }  // namespace brave_vpn
@@ -125,7 +125,7 @@ class BraveBrowserProcess {
   virtual speedreader::SpeedreaderRewriterService*
   speedreader_rewriter_service() = 0;
 #endif
-#if BUILDFLAG(ENABLE_BRAVE_VPN)
+#if BUILDFLAG(ENABLE_BRAVE_VPN_V1)
   virtual brave_vpn::BraveVPNConnectionManager*
   brave_vpn_connection_manager() = 0;
 #endif

--- a/browser/brave_browser_process_impl.cc
+++ b/browser/brave_browser_process_impl.cc
@@ -108,7 +108,7 @@
 #include "brave/components/request_otr/common/features.h"
 #endif
 
-#if BUILDFLAG(ENABLE_BRAVE_VPN)
+#if BUILDFLAG(ENABLE_BRAVE_VPN_V1)
 #include "brave/browser/brave_vpn/vpn_connection_manager_utils.h"
 #include "brave/components/brave_vpn/browser/connection/brave_vpn_connection_manager.h"
 #endif
@@ -547,7 +547,7 @@ BraveBrowserProcessImpl::speedreader_rewriter_service() {
 }
 #endif  // BUILDFLAG(ENABLE_SPEEDREADER)
 
-#if BUILDFLAG(ENABLE_BRAVE_VPN)
+#if BUILDFLAG(ENABLE_BRAVE_VPN_V1)
 brave_vpn::BraveVPNConnectionManager*
 BraveBrowserProcessImpl::brave_vpn_connection_manager() {
   if (brave_vpn_connection_manager_) {

--- a/browser/brave_browser_process_impl.h
+++ b/browser/brave_browser_process_impl.h
@@ -142,7 +142,7 @@ class BraveBrowserProcessImpl : public BraveBrowserProcess,
   speedreader::SpeedreaderRewriterService* speedreader_rewriter_service()
       override;
 #endif
-#if BUILDFLAG(ENABLE_BRAVE_VPN)
+#if BUILDFLAG(ENABLE_BRAVE_VPN_V1)
   brave_vpn::BraveVPNConnectionManager* brave_vpn_connection_manager() override;
 #endif
   misc_metrics::ProcessMiscMetrics* process_misc_metrics() override;
@@ -216,7 +216,7 @@ class BraveBrowserProcessImpl : public BraveBrowserProcess,
       speedreader_rewriter_service_;
 #endif
 
-#if BUILDFLAG(ENABLE_BRAVE_VPN)
+#if BUILDFLAG(ENABLE_BRAVE_VPN_V1)
   std::unique_ptr<brave_vpn::BraveVPNConnectionManager>
       brave_vpn_connection_manager_;
 #endif

--- a/browser/sources.gni
+++ b/browser/sources.gni
@@ -546,13 +546,16 @@ if (enable_web_discovery_native) {
 if (enable_brave_vpn) {
   brave_chrome_browser_deps += [
     "//brave/components/brave_vpn/browser",
-    "//brave/components/brave_vpn/browser/connection",
     "//brave/components/brave_vpn/browser/connection:api",
     "//brave/components/brave_vpn/common",
   ]
+  if (enable_brave_vpn_v1) {
+    brave_chrome_browser_deps +=
+        [ "//brave/components/brave_vpn/browser/connection" ]
+  }
 }
 
-if (enable_brave_vpn2_deps) {
+if (enable_brave_vpn_v2) {
   brave_chrome_browser_deps += [ "//brave/third_party/boringtun" ]
 }
 

--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -743,10 +743,11 @@ source_set("ui") {
           "webui/settings/brave_vpn/brave_vpn_handler.h",
         ]
 
-        deps += [
-          "//brave/browser/brave_vpn/win:wireguard_utils",
-          "//chrome/browser:flags",
-        ]
+        deps += [ "//chrome/browser:flags" ]
+
+        if (enable_brave_vpn_v1) {
+          deps += [ "//brave/browser/brave_vpn/win:wireguard_utils" ]
+        }
       }
       sources += [ "brave_vpn/brave_vpn_controller.cc" ]
     }
@@ -986,7 +987,7 @@ source_set("ui") {
       "//brave/components/brave_vpn/browser/connection:api",
       "//brave/components/brave_vpn/common",
     ]
-    if (is_win) {
+    if (enable_brave_vpn_v1 && is_win) {
       deps += [
         "//brave/components/brave_vpn/common/win",
         "//brave/components/brave_vpn/common/wireguard",

--- a/browser/ui/browser_commands.cc
+++ b/browser/ui/browser_commands.cc
@@ -115,13 +115,12 @@
 #include "brave/components/brave_vpn/common/brave_vpn_constants.h"
 #include "brave/components/brave_vpn/common/brave_vpn_utils.h"
 #include "brave/components/brave_vpn/common/pref_names.h"
+#endif  // BUILDFLAG(ENABLE_BRAVE_VPN)
 
-#if BUILDFLAG(IS_WIN)
+#if BUILDFLAG(ENABLE_BRAVE_VPN_V1) && BUILDFLAG(IS_WIN)
 #include "brave/browser/brave_vpn/win/storage_utils.h"
 #include "brave/browser/brave_vpn/win/wireguard_utils_win.h"
-#endif  // BUILDFLAG(ENABLE_BRAVE_VPN)
-
-#endif  // BUILDFLAG(ENABLE_BRAVE_VPN)
+#endif  // BUILDFLAG(ENABLE_BRAVE_VPN_V1) && BUILDFLAG(IS_WIN)
 
 #if BUILDFLAG(ENABLE_COMMANDER)
 #include "brave/browser/ui/commander/commander_service.h"
@@ -283,7 +282,7 @@ void ShowBraveVPNBubble(Browser* browser) {
 }
 
 void ToggleBraveVPNTrayIcon() {
-#if BUILDFLAG(ENABLE_BRAVE_VPN) && BUILDFLAG(IS_WIN)
+#if BUILDFLAG(ENABLE_BRAVE_VPN_V1) && BUILDFLAG(IS_WIN)
   brave_vpn::EnableVPNTrayIcon(!brave_vpn::IsVPNTrayIconEnabled());
   if (brave_vpn::IsVPNTrayIconEnabled()) {
     brave_vpn::wireguard::ShowBraveVpnStatusTrayIcon();

--- a/browser/ui/views/toolbar/brave_vpn_button_unittest.cc
+++ b/browser/ui/views/toolbar/brave_vpn_button_unittest.cc
@@ -13,9 +13,6 @@
 #include "base/run_loop.h"
 #include "brave/browser/brave_vpn/brave_vpn_service_factory.h"
 #include "brave/components/brave_vpn/browser/brave_vpn_service.h"
-#include "brave/components/brave_vpn/browser/connection/brave_vpn_connection_manager.h"
-#include "brave/components/brave_vpn/browser/connection/connection_api_impl.h"
-#include "brave/components/brave_vpn/browser/connection/ikev2/connection_api_impl_sim.h"
 #include "brave/components/skus/browser/skus_utils.h"
 #include "brave/test/base/testing_brave_browser_process.h"
 #include "chrome/browser/prefs/browser_prefs.h"
@@ -30,6 +27,12 @@
 #include "services/network/public/cpp/weak_wrapper_shared_url_loader_factory.h"
 #include "services/network/test/test_url_loader_factory.h"
 #include "testing/gtest/include/gtest/gtest.h"
+
+#if BUILDFLAG(ENABLE_BRAVE_VPN_V1)
+#include "brave/components/brave_vpn/browser/connection/brave_vpn_connection_manager.h"
+#include "brave/components/brave_vpn/browser/connection/connection_api_impl.h"
+#include "brave/components/brave_vpn/browser/connection/ikev2/connection_api_impl_sim.h"
+#endif  // BUILDFLAG(ENABLE_BRAVE_VPN_V1)
 
 namespace brave_vpn {
 
@@ -66,6 +69,7 @@ class BraveVpnButtonUnitTest : public testing::Test {
     shared_url_loader_factory_ =
         base::MakeRefCounted<network::WeakWrapperSharedURLLoaderFactory>(
             &url_loader_factory_);
+#if BUILDFLAG(ENABLE_BRAVE_VPN_V1)
     auto manager = std::make_unique<BraveVPNConnectionManager>(
         shared_url_loader_factory_,
         TestingBrowserProcess::GetGlobal()->GetTestingLocalState(),
@@ -75,6 +79,7 @@ class BraveVpnButtonUnitTest : public testing::Test {
                                                shared_url_loader_factory_));
     TestingBraveBrowserProcess::GetGlobal()
         ->SetBraveVPNConnectionManagerForTesting(std::move(manager));
+#endif  // BUILDFLAG(ENABLE_BRAVE_VPN_V1)
     ASSERT_TRUE(brave_vpn::BraveVpnServiceFactory::GetForProfile(
         GetBrowser()->profile()));
     ASSERT_TRUE(ThemeServiceFactory::GetForProfile(profile()));
@@ -85,10 +90,12 @@ class BraveVpnButtonUnitTest : public testing::Test {
     browser_.reset();
     profile_.reset();
 
+#if BUILDFLAG(ENABLE_BRAVE_VPN_V1)
     // BraveVPNConnectionManager should be reset after profile is destoryed
     // and before local_state is gone as it uses local_state.
     TestingBraveBrowserProcess::GetGlobal()
         ->SetBraveVPNConnectionManagerForTesting(nullptr);
+#endif  // BUILDFLAG(ENABLE_BRAVE_VPN_V1)
 
     base::RunLoop().RunUntilIdle();
   }

--- a/browser/ui/webui/skus_internals_ui.cc
+++ b/browser/ui/webui/skus_internals_ui.cc
@@ -38,9 +38,12 @@
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
 #include "brave/browser/brave_vpn/brave_vpn_service_factory.h"
 #include "brave/components/brave_vpn/browser/brave_vpn_service.h"
-#include "brave/components/brave_vpn/browser/connection/brave_vpn_connection_manager.h"
 #include "brave/components/brave_vpn/common/brave_vpn_utils.h"
 #include "brave/components/brave_vpn/common/pref_names.h"
+#endif
+
+#if BUILDFLAG(ENABLE_BRAVE_VPN_V1)
+#include "brave/components/brave_vpn/browser/connection/brave_vpn_connection_manager.h"
 #endif
 
 namespace {
@@ -228,7 +231,7 @@ void SkusInternalsUI::FileSelectionCanceled() {
 
 std::string SkusInternalsUI::GetLastVPNConnectionError() const {
   std::string error;
-#if BUILDFLAG(ENABLE_BRAVE_VPN)
+#if BUILDFLAG(ENABLE_BRAVE_VPN_V1)
   auto* manager = g_brave_browser_process->brave_vpn_connection_manager();
   CHECK(manager);
   error = manager->GetLastConnectionError();

--- a/build/win/BUILD.gn
+++ b/build/win/BUILD.gn
@@ -11,7 +11,7 @@ group("brave") {
     ":copy_exe",
     ":copy_pdb",
   ]
-  if (enable_brave_vpn) {
+  if (enable_brave_vpn_v1) {
     deps = [
       "//brave/browser/brave_vpn/win/brave_vpn_helper",
       "//brave/browser/brave_vpn/win/brave_vpn_wireguard_service:wireguard_service",

--- a/chromium_src/chrome/browser/sources.gni
+++ b/chromium_src/chrome/browser/sources.gni
@@ -26,7 +26,7 @@ if (!is_android) {
 
 if (enable_brave_vpn) {
   brave_chromium_src_chrome_browser_deps +=
-      [ "//brave/components/brave_vpn/browser" ]
+      [ "//brave/components/brave_vpn/common" ]
 }
 
 if (toolkit_views) {

--- a/chromium_src/chrome/elevation_service/elevator.cc
+++ b/chromium_src/chrome/elevation_service/elevator.cc
@@ -15,7 +15,7 @@
 #include "brave/components/brave_vpn/common/buildflags/buildflags.h"
 #include "third_party/abseil-cpp/absl/cleanup/cleanup.h"
 
-#if BUILDFLAG(ENABLE_BRAVE_VPN)
+#if BUILDFLAG(ENABLE_BRAVE_VPN_V1)
 #include "brave/browser/brave_vpn/win/brave_vpn_helper/brave_vpn_helper_utils.h"
 
 #if BUILDFLAG(ENABLE_BRAVE_VPN_WIREGUARD)
@@ -60,7 +60,7 @@ HRESULT Elevator::InstallVPNServices() {
   }
   // End of trusted source check
 
-#if BUILDFLAG(ENABLE_BRAVE_VPN)
+#if BUILDFLAG(ENABLE_BRAVE_VPN_V1)
   if (!brave_vpn::IsBraveVPNHelperServiceInstalled()) {
     auto success = brave_vpn::InstallBraveVPNHelperService(
         base::PathService::CheckedGet(base::DIR_ASSETS));

--- a/chromium_src/chrome/installer/setup/install_worker.cc
+++ b/chromium_src/chrome/installer/setup/install_worker.cc
@@ -37,7 +37,7 @@
 // clang-format on
 #endif
 
-#if BUILDFLAG(ENABLE_BRAVE_VPN)
+#if BUILDFLAG(ENABLE_BRAVE_VPN_V1)
 #include "brave/browser/brave_vpn/win/brave_vpn_helper/brave_vpn_helper_constants.h"
 #include "brave/browser/brave_vpn/win/brave_vpn_helper/brave_vpn_helper_utils.h"
 #include "brave/browser/brave_vpn/win/brave_vpn_wireguard_service/install_utils.h"
@@ -185,7 +185,7 @@ void UpdateBraveVpn(const base::FilePath& target_path,
   UpdateBraveVpn(target_path, new_version, install_list); \
   AddUpdateDowngradeVersionItem
 
-#endif  // BUILDFLAG(ENABLE_BRAVE_VPN)
+#endif  // BUILDFLAG(ENABLE_BRAVE_VPN_V1)
 
 // The code in BRAVE_ADD_INSTALLER_COPY_TASKS and
 // BRAVE_MAYBE_ABORT_ADD_CHROME_WORK_ITEMS used to be upstream and had to be
@@ -209,9 +209,9 @@ void UpdateBraveVpn(const base::FilePath& target_path,
 #include <chrome/installer/setup/install_worker.cc>
 #undef BRAVE_MAYBE_ABORT_ADD_CHROME_WORK_ITEMS
 #undef BRAVE_ADD_INSTALLER_COPY_TASKS
-#if BUILDFLAG(ENABLE_BRAVE_VPN)
+#if BUILDFLAG(ENABLE_BRAVE_VPN_V1)
 #undef AddUpdateDowngradeVersionItem
-#endif  // BUILDFLAG(ENABLE_BRAVE_VPN)
+#endif  // BUILDFLAG(ENABLE_BRAVE_VPN_V1)
 #if defined(OFFICIAL_BUILD)
 #include "chrome/install_static/brave_restore_google_update_integration.h"
 #endif

--- a/chromium_src/chrome/installer/setup/uninstall.cc
+++ b/chromium_src/chrome/installer/setup/uninstall.cc
@@ -16,7 +16,7 @@
 #include "chrome/installer/util/util_constants.h"
 #include "chrome/installer/util/work_item.h"
 
-#if BUILDFLAG(ENABLE_BRAVE_VPN)
+#if BUILDFLAG(ENABLE_BRAVE_VPN_V1)
 #include "brave/browser/brave_vpn/win/brave_vpn_helper/brave_vpn_helper_constants.h"
 #include "brave/browser/brave_vpn/win/brave_vpn_helper/brave_vpn_helper_utils.h"
 #include "brave/browser/brave_vpn/win/brave_vpn_wireguard_service/install_utils.h"
@@ -85,7 +85,7 @@ InstallStatus UninstallProduct(const ModifyParams& modify_params,
        ShellUtil::QuickIsChromeRegisteredInHKLM(chrome_exe, suffix))) {
     DeleteBraveFileKeys(HKEY_LOCAL_MACHINE);
   }
-#if BUILDFLAG(ENABLE_BRAVE_VPN)
+#if BUILDFLAG(ENABLE_BRAVE_VPN_V1)
   if (installer_state->system_install()) {
     // TODO(bsclifton): move this to a method
     if (!InstallServiceWorkItem::DeleteService(

--- a/components/brave_vpn/common/buildflags/BUILD.gn
+++ b/components/brave_vpn/common/buildflags/BUILD.gn
@@ -10,6 +10,8 @@ buildflag_header("buildflags") {
   header = "buildflags.h"
   flags = [
     "ENABLE_BRAVE_VPN=$enable_brave_vpn",
+    "ENABLE_BRAVE_VPN_V1=$enable_brave_vpn_v1",
+    "ENABLE_BRAVE_VPN_V2=$enable_brave_vpn_v2",
     "ENABLE_BRAVE_VPN_WIREGUARD=$enable_brave_vpn_wireguard",
   ]
 }

--- a/components/brave_vpn/common/buildflags/buildflags.gni
+++ b/components/brave_vpn/common/buildflags/buildflags.gni
@@ -7,9 +7,18 @@ import("//brave/components/brave_origin/buildflags/buildflags.gni")
 
 declare_args() {
   # On macOS, vpn is not available w/o signing.
-  enable_brave_vpn =
+  # Build with Brave VPN architecture 1.0 support.
+  enable_brave_vpn_v1 =
       (is_win || is_android || is_mac || is_ios) && !is_brave_origin_branded
+
+  # Build with Brave VPN architecture 2.0 support.
+  enable_brave_vpn_v2 = false
 }
+
+# Brave VPN is enabled, if at least one VPN architecture is enabled.
+# Both architectures can be enabled at compile time; in that case, the
+# right architecture will be selected at runtime.
+enable_brave_vpn = enable_brave_vpn_v1 || enable_brave_vpn_v2
 
 declare_args() {
   # vpn panel is desktop specific UI.
@@ -17,9 +26,4 @@ declare_args() {
 
   # Wireguard is available only on Windows.
   enable_brave_vpn_wireguard = (is_mac || is_win) && enable_brave_vpn
-}
-
-declare_args() {
-  # vpn 2.0 build flags
-  enable_brave_vpn2_deps = false
 }

--- a/test/base/testing_brave_browser_process.cc
+++ b/test/base/testing_brave_browser_process.cc
@@ -18,7 +18,7 @@
 #include "brave/components/brave_vpn/common/buildflags/buildflags.h"
 #include "brave/components/tor/buildflags/buildflags.h"
 
-#if BUILDFLAG(ENABLE_BRAVE_VPN)
+#if BUILDFLAG(ENABLE_BRAVE_VPN_V1)
 #include "brave/components/brave_vpn/browser/connection/brave_vpn_connection_manager.h"
 #endif
 namespace tor {
@@ -154,7 +154,7 @@ TestingBraveBrowserProcess::speedreader_rewriter_service() {
 }
 #endif
 
-#if BUILDFLAG(ENABLE_BRAVE_VPN)
+#if BUILDFLAG(ENABLE_BRAVE_VPN_V1)
 brave_vpn::BraveVPNConnectionManager*
 TestingBraveBrowserProcess::brave_vpn_connection_manager() {
   return brave_vpn_connection_manager_.get();

--- a/test/base/testing_brave_browser_process.h
+++ b/test/base/testing_brave_browser_process.h
@@ -82,7 +82,7 @@ class TestingBraveBrowserProcess : public BraveBrowserProcess {
   speedreader::SpeedreaderRewriterService* speedreader_rewriter_service()
       override;
 #endif
-#if BUILDFLAG(ENABLE_BRAVE_VPN)
+#if BUILDFLAG(ENABLE_BRAVE_VPN_V1)
   brave_vpn::BraveVPNConnectionManager* brave_vpn_connection_manager() override;
   void SetBraveVPNConnectionManagerForTesting(
       std::unique_ptr<brave_vpn::BraveVPNConnectionManager> manager);
@@ -103,7 +103,7 @@ class TestingBraveBrowserProcess : public BraveBrowserProcess {
 
   std::unique_ptr<brave_shields::AdBlockService> ad_block_service_;
 
-#if BUILDFLAG(ENABLE_BRAVE_VPN)
+#if BUILDFLAG(ENABLE_BRAVE_VPN_V1)
   std::unique_ptr<brave_vpn::BraveVPNConnectionManager>
       brave_vpn_connection_manager_;
 #endif

--- a/third_party/boringtun/BUILD.gn
+++ b/third_party/boringtun/BUILD.gn
@@ -8,8 +8,8 @@ import("//build/config/clang/clang.gni")
 import("//build/config/rust.gni")
 import("//build/config/sysroot.gni")
 
-assert(enable_brave_vpn2_deps,
-       "BoringTun is only buildable when Brave VPN 2.0 deps are enabled")
+assert(enable_brave_vpn_v2,
+       "BoringTun is only buildable when Brave VPN 2.0 architecture is enabled")
 
 action("boringtun") {
   script = "build.py"


### PR DESCRIPTION
To add a new BraveVpnService implementation based on Architecture 2.0, which must co-exist with Architecture 1.0 for quite a while, we need to split service's interface and implementation. All the external components will keep accessing VPN service via the BraveVpnService interface, but the implementation mostly goes into BraveVpnServiceImpl.

This change revisits the approach how Brave VPN is enabled in GN. New flags are introduced: enable_brave_vpn_v1 and enable_brave_vpn_v2. Currently, only V1 architecture is implemented, hence, the GN flag enable_brave_vpn_v1 is enabled by default, and enable_brave_vpn_v2 is disabled by default. enable_brave_vpn becomes a dependent flag: it is enabled when either enable_brave_vpn_v1, or enable_brave_vpn_v2, or both are enabled.

Implements part of https://github.com/brave/brave-browser/issues/54597

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
