### PR TITLE
Partial Revert "[iOS]Restore private tabs when "Keep private tabs" is enabled (#34421)" (uplift to 1.91.x)

### DIFF
--- a/ios/brave-ios/App/iOS/Delegates/SceneDelegate.swift
+++ b/ios/brave-ios/App/iOS/Delegates/SceneDelegate.swift
@@ -156,25 +156,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         sceneState: sceneState
       )
 
-      // When launching in private mode with biometric/PIN lock enabled, authenticate before showing content.
-      // If auth fails or is cancelled, launch in regular mode instead.
-      if browserViewController.privateBrowsingManager.isPrivateBrowsing
-        && Preferences.Privacy.privateBrowsingLock.value
-      {
-        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-          windowProtection.presentAuthenticationForViewController(
-            determineLockWithPasscode: false,
-            viewType: .general
-          ) { success, error in
-            // Treat passcodeNotSet as success (user may have removed passcode)
-            if !success && error != .passcodeNotSet {
-              browserViewController.privateBrowsingManager.isPrivateBrowsing = false
-            }
-            continuation.resume()
-          }
-        }
-      }
-
       browserViewController.windowProtection = windowProtection
 
       let container = UINavigationController(rootViewController: browserViewController)


### PR DESCRIPTION
Uplift of #36783
Resolves https://github.com/brave/brave-browser/issues/55815

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.