### PR TITLE
[plaster][cr150] `NavigationRequest` 🩹🩹🩹

### DIFF
--- a/chromium_src/content/browser/renderer_host/navigation_request.cc
+++ b/chromium_src/content/browser/renderer_host/navigation_request.cc
@@ -33,19 +33,4 @@ GURL GetTopDocumentGURL(content::FrameTreeNode* frame_tree_node) {
 
 }  // namespace
 
-#define BRAVE_ONREQUESTREDIRECTED_MAYBEHIDEREFERRER                   \
-  BrowserContext* browser_context =                                   \
-      frame_tree_node_->navigator().controller().GetBrowserContext(); \
-  GetContentClient()->browser()->MaybeHideReferrer(                   \
-      browser_context, common_params_->url,                           \
-      GetTopDocumentGURL(frame_tree_node_), &common_params_->referrer);
-
-#define BRAVE_ONSTARTCHECKSCOMPLETE_MAYBEHIDEREFERRER                 \
-  GetContentClient()->browser()->MaybeHideReferrer(                   \
-      frame_tree_node_->navigator().controller().GetBrowserContext(), \
-      common_params_->url, GetTopDocumentGURL(frame_tree_node_),      \
-      &common_params_->referrer);
-
 #include <content/browser/renderer_host/navigation_request.cc>
-#undef BRAVE_ONSTARTCHECKSCOMPLETE_MAYBEHIDEREFERRER
-#undef BRAVE_ONREQUESTREDIRECTED_MAYBEHIDEREFERRER

--- a/patches/content-browser-renderer_host-navigation_request.cc.patch
+++ b/patches/content-browser-renderer_host-navigation_request.cc.patch
@@ -1,20 +1,26 @@
 diff --git a/content/browser/renderer_host/navigation_request.cc b/content/browser/renderer_host/navigation_request.cc
-index 9ec42c6dc1c2ce18e448d905087f6ae7fe96d94c..26e464a7d941ebf56e6caac018423a632dcc731d 100644
+index 9ec42c6dc1c2ce18e448d905087f6ae7fe96d94c..7979fd99332eca0968c83c29013b49a90ad5630a 100644
 --- a/content/browser/renderer_host/navigation_request.cc
 +++ b/content/browser/renderer_host/navigation_request.cc
-@@ -3783,6 +3783,7 @@ void NavigationRequest::OnRequestRedirected(
+@@ -3783,6 +3783,10 @@ void NavigationRequest::OnRequestRedirected(
    common_params_->url = redirect_info.new_url;
    common_params_->method = redirect_info.new_method;
    common_params_->referrer->url = GURL(redirect_info.new_referrer);
-+  BRAVE_ONREQUESTREDIRECTED_MAYBEHIDEREFERRER
++  GetContentClient()->browser()->MaybeHideReferrer(
++      frame_tree_node_->navigator().controller().GetBrowserContext(),
++      common_params_->url, GetTopDocumentGURL(frame_tree_node_),
++      &common_params_->referrer);
    common_params_->referrer = Referrer::SanitizeForRequest(
        common_params_->url, *common_params_->referrer);
  
-@@ -5688,6 +5689,7 @@ void NavigationRequest::OnStartChecksComplete(
+@@ -5687,6 +5691,10 @@ void NavigationRequest::OnStartChecksComplete(
+   headers.AddHeadersFromString(begin_params_->headers);
    headers.MergeFrom(TakeModifiedRequestHeaders());
    begin_params_->headers = headers.ToString();
++  GetContentClient()->browser()->MaybeHideReferrer(
++      frame_tree_node_->navigator().controller().GetBrowserContext(),
++      common_params_->url, GetTopDocumentGURL(frame_tree_node_),
++      &common_params_->referrer);
  
-+  BRAVE_ONSTARTCHECKSCOMPLETE_MAYBEHIDEREFERRER
    // TODO(clamy): Avoid cloning the navigation params and create the
    // ResourceRequest directly here.
-   std::vector<std::unique_ptr<NavigationLoaderInterceptor>> interceptor;

--- a/rewrite/content/browser/renderer_host/navigation_request.cc.yaml
+++ b/rewrite/content/browser/renderer_host/navigation_request.cc.yaml
@@ -1,0 +1,47 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+substitutions:
+  - description: |
+      Call `MaybeHideReferrer` on redirect in
+      `NavigationRequest::OnRequestRedirected`, after the redirect's new
+      referrer has been written to `common_params_->referrer->url` and
+      before `Referrer::SanitizeForRequest` runs on it.
+
+      The injected call relies on the `browser_context` local defined
+      earlier in the same function, and on `GetTopDocumentGURL` defined
+      in the chromium_src shadow file's anonymous namespace.
+    re_pattern:
+      '(common_params_->referrer->url = GURL\(redirect_info\.new_referrer\);\n)'
+    replace: |
+      \1  GetContentClient()->browser()->MaybeHideReferrer(
+            frame_tree_node_->navigator().controller().GetBrowserContext(),
+            common_params_->url, GetTopDocumentGURL(frame_tree_node_),
+            &common_params_->referrer);
+
+  - description: |
+      Call `MaybeHideReferrer` from
+      `NavigationRequest::OnStartChecksComplete`, after the embedder
+      header merge and before the navigation params are cloned.
+
+      Anchored on the two-line embedder-header merge sequence
+      (`headers.MergeFrom(TakeModifiedRequestHeaders());` followed by
+      `begin_params_->headers = headers.ToString();`). That pair is
+      unique to this location and conveys the intent of the injection —
+      run our referrer hiding right after upstream finishes computing
+      the outgoing headers. Both lines are matched at their current
+      2-space indent; an earlier shape of upstream wrapped this block in
+      an `if`, but that has since been flattened.
+
+      `GetTopDocumentGURL` comes from the chromium_src shadow file's
+      anonymous namespace.
+    re_pattern:
+      '(headers\.MergeFrom\(TakeModifiedRequestHeaders\(\)\);\n  begin_params_->headers
+      = headers\.ToString\(\);\n)'
+    replace: |
+      \1  GetContentClient()->browser()->MaybeHideReferrer(
+            frame_tree_node_->navigator().controller().GetBrowserContext(),
+            common_params_->url, GetTopDocumentGURL(frame_tree_node_),
+            &common_params_->referrer);


### PR DESCRIPTION
This broke in `cr150`. This change adds a plaster that would have been
resilient to the macro breakage encountered.

Chromium changes:
https://chromium.googlesource.com/chromium/src/+/b91bc19194d8d74a1e18600c2f67537e7c3d2bcf

commit b91bc19194d8d74a1e18600c2f67537e7c3d2bcf
Author: Vlad Krot <vkrot@google.com>
Date:   Fri May 22 11:08:23 2026 -0700

    [IWA] enforce headers on navigations and in workers.

    This CL makes sure that in Isolated Web Apps CSP, COEP, COOP, CORP
    headers are injected on navigation / shared worker main script load /
    dedicated worker main script load.

    Previously, the headers were only injected via
    components/webapps/isolated_web_apps/url_loading/url_loader_factory.h,
    however, that is not enough because ServiceWorker interception bypasses
    url_loader_factory and correct headers were not injected.

    Change-Id: Iad801ac9e59f225521de44bc3bd9aa9c025c2f93
    Fixed: 500475136
    Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7859854
    Reviewed-by: Andrew Rayskiy <greengrape@google.com>
    Commit-Queue: Vlad Krot <vkrot@google.com>
    Cr-Commit-Position: refs/heads/main@{#1635085}

Bug: https://github.com/brave/brave-browser/issues/55302
