### PR TITLE
[cr150][plaster] `PageInfoViewFactory::CreateSubpageHeader` migration

### DIFF
--- a/chromium_src/chrome/browser/ui/views/page_info/page_info_view_factory.cc
+++ b/chromium_src/chrome/browser/ui/views/page_info/page_info_view_factory.cc
@@ -4,13 +4,10 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "chrome/browser/ui/views/page_info/page_info_view_factory.h"
+
 #include "brave/components/vector_icons/vector_icons.h"
 
-#define BRAVE_PAGE_INFO_VIEW_FACTORY_GET_PERMISSION_ICON \
-  case ContentSettingsType::AUTOPLAY:                    \
-    icon = &kAutoplayStatusIcon;                         \
-    break;
+// This shadow source is being used merely to include `kAutoplayStatusIcon`, to
+// be used in `PageInfoViewFactory::GetPermissionIcon()`.
 
 #include <chrome/browser/ui/views/page_info/page_info_view_factory.cc>
-
-#undef BRAVE_PAGE_INFO_VIEW_FACTORY_GET_PERMISSION_ICON

--- a/patches/chrome-browser-ui-views-page_info-page_info_view_factory.cc.patch
+++ b/patches/chrome-browser-ui-views-page_info-page_info_view_factory.cc.patch
@@ -1,12 +1,14 @@
 diff --git a/chrome/browser/ui/views/page_info/page_info_view_factory.cc b/chrome/browser/ui/views/page_info/page_info_view_factory.cc
-index 85c3a34c5ec00e28983502a276b9853fa897c4d7..6141f29f01d9b588cd113d7eacf2effbf74e6cc2 100644
+index 85c3a34c5ec00e28983502a276b9853fa897c4d7..1b7c573e2c8139039050a7ece602adb12a0d9ef7 100644
 --- a/chrome/browser/ui/views/page_info/page_info_view_factory.cc
 +++ b/chrome/browser/ui/views/page_info/page_info_view_factory.cc
-@@ -487,6 +487,7 @@ const ui::ImageModel PageInfoViewFactory::GetPermissionIcon(
+@@ -487,6 +487,9 @@ const ui::ImageModel PageInfoViewFactory::GetPermissionIcon(
  
    icon = &gfx::VectorIcon::EmptyIcon();
    switch (permission.type) {
-+    BRAVE_PAGE_INFO_VIEW_FACTORY_GET_PERMISSION_ICON
++    case ContentSettingsType::AUTOPLAY:
++      icon = &kAutoplayStatusIcon;
++      break;
      case ContentSettingsType::COOKIES:
        icon = &vector_icons::kDatabaseIcon;
        break;

--- a/rewrite/chrome/browser/ui/views/page_info/page_info_view_factory.cc.yaml
+++ b/rewrite/chrome/browser/ui/views/page_info/page_info_view_factory.cc.yaml
@@ -1,0 +1,28 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+substitutions:
+  - description: |
+      Add AUTOPLAY handling to the fallback `switch (permission.type)`
+      in `PageInfoViewFactory::GetPermissionIcon`.
+
+      Brave introduces its own `AUTOPLAY` content setting and renders it
+      with `kAutoplayStatusIcon`. The icon symbol is brought into scope
+      by the chromium_src shadow file's
+      `brave/components/vector_icons/vector_icons.h` include — keeping
+      this plaster to the in-function insertion that cannot be expressed
+      at file scope.
+
+      The anchor pairs `icon = &gfx::VectorIcon::EmptyIcon();` with the
+      following `switch (permission.type)` to single out the fallback
+      switch (the function also has an earlier switch on the same
+      variable).
+    re_pattern:
+      '(icon = &gfx::VectorIcon::EmptyIcon\(\);\s+switch \(permission\.type\)
+      \{\n)'
+    replace: |
+      \1    case ContentSettingsType::AUTOPLAY:
+            icon = &kAutoplayStatusIcon;
+            break;


### PR DESCRIPTION
This override was causing conflicts during rebases. This change moves
this to a plaster.

Chromium changes:
https://chromium.googlesource.com/chromium/src/+/c0cdefbd7861d69f114f24a8a14f54d044dd84e3

commit c0cdefbd7861d69f114f24a8a14f54d044dd84e3
Author: Emily Shack <emshack@chromium.org>
Date:   Thu May 21 12:50:25 2026 -0700

    [GlowUp] Create rounded components/vector_icons/ icons

    Adds new .icon files to components/vector_icons/ which match
    go/icons naming, and flag-guards their usage behind kRoundedIcons. See
    go/chrome-icon-modernization-dd and go/chrome-lsc-icon-renaming

    BYPASS_RECITATION_REASON=The code segment in question is the contents of
    an icon file, which is taken from go/icons and cannot be modified.
    once the feature flag is removed along with the old icons.

    Binary-Size: Increase is temporary, due to new icon files. Will go down
    Bug: 506506555
    Change-Id: I7de94c024e01e3c1abaae3d7a1974b57f4b36dee
    Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7860920
    Reviewed-by: Mickey Burks <mickeyburks@chromium.org>
    Owners-Override: Emily Shack <emshack@chromium.org>
    Commit-Queue: Emily Shack <emshack@chromium.org>
    SLSA-Policy-Verified: SLSA Policy Verification Service <devtools-gerritcodereview-exitgate@google.com>
    Auto-Submit: Emily Shack <emshack@chromium.org>
    Cr-Commit-Position: refs/heads/main@{#1634474}

Bug: https://github.com/brave/brave-browser/issues/55302
