### PR TITLE
[cr150][plaster] `//chrome/common/extensions` 🩹🩹🩹🩹

### DIFF
--- a/patches/chrome-common-extensions-BUILD.gn.patch
+++ b/patches/chrome-common-extensions-BUILD.gn.patch
@@ -1,12 +1,44 @@
 diff --git a/chrome/common/extensions/BUILD.gn b/chrome/common/extensions/BUILD.gn
-index bb8c86103c906e102aaa7c1b77764623596b0eca..ed48d62c16f51194b147c8812c55000fff64cc9b 100644
+index bb8c86103c906e102aaa7c1b77764623596b0eca..75634f693f6f55f111b2723e44c3b676dfaae5c3 100644
 --- a/chrome/common/extensions/BUILD.gn
 +++ b/chrome/common/extensions/BUILD.gn
-@@ -116,6 +116,7 @@ source_set("extensions") {
+@@ -2,6 +2,7 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
  
-     sources += [ "api/file_system_provider_capabilities/file_system_provider_capabilities_handler.cc" ]
-   }
-+  import("//brave/common/extensions/sources.gni") public += brave_chrome_common_extensions_public sources += brave_chrome_common_extensions_sources deps += brave_chrome_common_extensions_deps public_deps += brave_chrome_common_extensions_public_deps
- }
++import("//brave/common/extensions/sources.gni")
+ import("//extensions/buildflags/buildflags.gni")
+ import("//tools/json_schema_compiler/json_features.gni")
  
- # TODO(zturner): Enable this on Windows. See
+@@ -27,6 +28,7 @@ source_set("extensions") {
+     "sync_helper.h",
+     "webstore_install_result.h",
+   ]
++  public += brave_chrome_common_extensions_public
+ 
+   # Files that can only be included from here.
+   sources = [
+@@ -52,6 +54,7 @@ source_set("extensions") {
+     "sync_helper.cc",
+     "webstore_install_result.cc",
+   ]
++  sources += brave_chrome_common_extensions_sources
+ 
+   public_deps = [
+     "//base",
+@@ -64,6 +67,7 @@ source_set("extensions") {
+     "//ui/gfx/geometry",
+     "//url",
+   ]
++  public_deps += brave_chrome_common_extensions_public_deps
+ 
+   deps = [
+     "//chrome/app:branded_strings",
+@@ -90,6 +94,7 @@ source_set("extensions") {
+     "//ui/message_center/public/cpp",
+     "//url",
+   ]
++  deps += brave_chrome_common_extensions_deps
+ 
+   # TODO(https://crbug.com/356905053): These sources do not currently build
+   # cleanly on the experimental desktop-android configuration. Gradually include

--- a/rewrite/chrome/common/extensions/BUILD.gn.yaml
+++ b/rewrite/chrome/common/extensions/BUILD.gn.yaml
@@ -1,0 +1,38 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+substitutions:
+  - description: |
+      Pull in the variable list shared between Brave and the upstream
+      `source_set("extensions")` target.
+
+      Anchored on the license header, so always on top.
+    re_pattern: '(# found in the LICENSE file\.\n\n)'
+    replace: |
+      \1import("//brave/common/extensions/sources.gni")
+
+  - description: |
+      Append Brave public headers to `source_set("extensions")`.
+    re_pattern: '(source_set\("extensions"\).*?\bpublic\s*=\s*\[.*?\])'
+    re_flags: [DOTALL]
+    replace: '\1\n  public += brave_chrome_common_extensions_public'
+
+  - description: |
+      Append Brave sources to `source_set("extensions")`.
+    re_pattern: '(source_set\("extensions"\).*?\bsources\s*=\s*\[.*?\])'
+    re_flags: [DOTALL]
+    replace: '\1\n  sources += brave_chrome_common_extensions_sources'
+
+  - description: |
+      Append Brave public_deps to `source_set("extensions")`.
+    re_pattern: '(source_set\("extensions"\).*?\bpublic_deps\s*=\s*\[.*?\])'
+    re_flags: [DOTALL]
+    replace: '\1\n  public_deps += brave_chrome_common_extensions_public_deps'
+
+  - description: |
+      Append Brave deps to `source_set("extensions")`.
+    re_pattern: '(source_set\("extensions"\).*?\bdeps\s*=\s*\[.*?\])'
+    re_flags: [DOTALL]
+    replace: '\1\n  deps += brave_chrome_common_extensions_deps'


### PR DESCRIPTION
This change migrates this particular `.gn` file, as it is one of those
cases that constantly break with patches.

Chromium changes:
https://chromium.googlesource.com/chromium/src/+/c2cdba108e94519b5fd306a086590de3ab34a902

commit c2cdba108e94519b5fd306a086590de3ab34a902
Author: James Cook <jamescook@chromium.org>
Date:   Tue May 26 15:49:38 2026 -0700

    extensions: Add chrome/common/extensions unit tests to desktop Android

    These tests were missed during desktop Android bring-up. They mostly
    pass without modification. A few exceptions:

    * Some used APIs that are not supported by Android as test data (e.g.
      bookmarkManagerPrivate is not supported because the bookmarks page
      on Android is native UI). I switched these to APIs that are supported
      on all platform (e.g. runtime).
    * One file tested browserAction, which is not supported in MV3. I
      skipped it and added a static_assert !IS_ANDROID.

    I also moved the unit test file references from chrome/test/BUILD.gn
    to chrome/common/extensions/BUILD.gn to be closer to the actual files.

    Finally I deleted a stale TODO about Windows support -- the comment it
    refers to doesn't exist anymore.

    Bug: 469417243
    Change-Id: Ic7f4077e32905a78be42f5fd83606b7937e18f3e
    Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7876930
    Reviewed-by: Michael Wojcicka <mwoj@google.com>
    Commit-Queue: James Cook <jamescook@chromium.org>
    Cr-Commit-Position: refs/heads/main@{#1636540}

Bug: https://github.com/brave/brave-browser/issues/55302
