### PR TITLE
[plaster][cr150] `DownloadBubbleQuickAction` 🩹🩹🩹🩹

### DIFF
--- a/chromium_src/chrome/browser/ui/download/download_bubble_info_utils.cc
+++ b/chromium_src/chrome/browser/ui/download/download_bubble_info_utils.cc
@@ -3,19 +3,28 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
+#include "chrome/browser/ui/download/download_bubble_info_utils.h"
+
+#include <vector>
+
 #include "brave/components/vector_icons/vector_icons.h"
 #include "chrome/browser/download/download_commands.h"
-#include "components/vector_icons/vector_icons.h"
+#include "chrome/grit/generated_resources.h"
+#include "ui/base/l10n/l10n_util.h"
 
-// Add an action to deleted local file in QuickActionsForDownload. This is added
-// only when the download can be opened. That's why we're defining
-// kLaunchChromeRefreshIcon.
-#define kLaunchChromeRefreshIcon kLaunchChromeRefreshIcon);           \
-  actions.emplace_back<DownloadCommands::Command>(                        \
-      DownloadCommands::Command(DownloadCommands::DELETE_LOCAL_FILE), \
-      l10n_util::GetStringUTF16(IDS_DOWNLOAD_BUBBLE_DELETE),   \
-      &kLeoTrashIcon
+namespace {
+
+// Appends a "Delete local file" quick action to `actions`. Invoked from
+// QuickActionsForDownload via a plaster substitution, since DELETE_LOCAL_FILE
+// is a Brave-only extension of DownloadCommands::Command and is shown only
+// alongside the upstream OPEN_WHEN_COMPLETE quick action.
+void AddDeleteLocalFileQuickAction(
+    std::vector<DownloadBubbleQuickAction>& actions) {
+  actions.emplace_back(DownloadCommands::DELETE_LOCAL_FILE,
+                       l10n_util::GetStringUTF16(IDS_DOWNLOAD_BUBBLE_DELETE),
+                       &kLeoTrashIcon);
+}
+
+}  // namespace
 
 #include <chrome/browser/ui/download/download_bubble_info_utils.cc>
-
-#undef kLaunchChromeRefreshIcon

--- a/patches/chrome-browser-ui-download-download_bubble_info_utils.cc.patch
+++ b/patches/chrome-browser-ui-download-download_bubble_info_utils.cc.patch
@@ -1,0 +1,12 @@
+diff --git a/chrome/browser/ui/download/download_bubble_info_utils.cc b/chrome/browser/ui/download/download_bubble_info_utils.cc
+index 8d65908660c254f5eb38989d8143bfd034263ab7..e5aedf27d2521f974d0ffa92b1ff63fc6e9848d2 100644
+--- a/chrome/browser/ui/download/download_bubble_info_utils.cc
++++ b/chrome/browser/ui/download/download_bubble_info_utils.cc
+@@ -332,6 +332,7 @@ std::vector<DownloadBubbleQuickAction> QuickActionsForDownload(
+         DownloadCommands::Command::OPEN_WHEN_COMPLETE,
+         l10n_util::GetStringUTF16(IDS_DOWNLOAD_BUBBLE_OPEN_QUICK_ACTION),
+         &vector_icons::kLaunchChromeRefreshIcon);
++    AddDeleteLocalFileQuickAction(actions);
+   }
+ 
+   return actions;

--- a/rewrite/chrome/browser/ui/download/download_bubble_info_utils.cc.toml
+++ b/rewrite/chrome/browser/ui/download/download_bubble_info_utils.cc.toml
@@ -1,0 +1,16 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+[[substitution]]
+description = '''Add a DELETE_LOCAL_FILE quick action after OPEN_WHEN_COMPLETE.
+
+DELETE_LOCAL_FILE is a Brave-only extension of DownloadCommands::Command, and
+the matching "Delete" quick action is shown alongside the upstream
+OPEN_WHEN_COMPLETE entry whenever the download can be opened.
+'''
+re_pattern = '(QuickActionsForDownload\([^)]*\)\s*\{[\s\S]*?Command::OPEN_WHEN_COMPLETE,[\s\S]*?\);)'
+re_flags = ['DOTALL']
+replace = '''\1
+    AddDeleteLocalFileQuickAction(actions);'''


### PR DESCRIPTION
This is now being migrated into a plaster, as the override was to frail,
and broad.

Chromium changes:
https://chromium.googlesource.com/chromium/src/+/c0cdefbd7861d69f114f24a8a14f54d044dd84e3

commit c0cdefbd7861d69f114f24a8a14f54d044dd84e3
Author: Emily Shack <emshack@chromium.org>
Date:   Thu May 21 12:50:25 2026 -0700

    [GlowUp] Create rounded components/vector_icons/ icons

    Adds new .icon files to components/vector_icons/ which match
    go/icons naming, and flag-guards their usage behind kRoundedIcons. See
    go/chrome-icon-modernization-dd and go/chrome-lsc-icon-renaming

    BYPASS_RECITATION_REASON=The code segment in question is the contents of
    an icon file, which is taken from go/icons and cannot be modified.
    once the feature flag is removed along with the old icons.

    Binary-Size: Increase is temporary, due to new icon files. Will go down
    Bug: 506506555
    Change-Id: I7de94c024e01e3c1abaae3d7a1974b57f4b36dee
    Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7860920
    Reviewed-by: Mickey Burks <mickeyburks@chromium.org>
    Owners-Override: Emily Shack <emshack@chromium.org>
    Commit-Queue: Emily Shack <emshack@chromium.org>
    SLSA-Policy-Verified: SLSA Policy Verification Service <devtools-gerritcodereview-exitgate@google.com>
    Auto-Submit: Emily Shack <emshack@chromium.org>
    Cr-Commit-Position: refs/heads/main@{#1634474}

Bug: https://github.com/brave/brave-browser/issues/55302
