### PR TITLE
[plaster][cr150] `//third_party/blink/renderer/modules` 🩹🩹🩹🩹

### DIFF
--- a/patches/third_party-blink-renderer-modules-BUILD.gn.patch
+++ b/patches/third_party-blink-renderer-modules-BUILD.gn.patch
@@ -1,5 +1,5 @@
 diff --git a/third_party/blink/renderer/modules/BUILD.gn b/third_party/blink/renderer/modules/BUILD.gn
-index 842b7834acd9e53024de3570e42d701076c21a31..53aea84f2ed970438e6ae5fb7059dd7f09c8a68e 100644
+index 842b7834acd9e53024de3570e42d701076c21a31..f3d643dfaef282e60d1b4bfef686339e4bb12520 100644
 --- a/third_party/blink/renderer/modules/BUILD.gn
 +++ b/third_party/blink/renderer/modules/BUILD.gn
 @@ -20,6 +20,7 @@ if (is_ios) {
@@ -10,11 +10,11 @@ index 842b7834acd9e53024de3570e42d701076c21a31..53aea84f2ed970438e6ae5fb7059dd7f
  
  config("modules_implementation") {
    defines = [ "BLINK_MODULES_IMPLEMENTATION=1" ]
-@@ -172,6 +173,7 @@ component("modules") {
-   # generating the snapshot for android, blink is compiled with
-   # current_os="linux" and target_os="android". Using target_os is necessary as
-   # we need to compile in the same way as would happen when current_os="android".
+@@ -166,6 +167,7 @@ component("modules") {
+     "//third_party/blink/renderer/modules/worklet",
+     "//third_party/blink/renderer/modules/xr",
+   ]
 +  sub_modules += brave_blink_sub_modules
-   if (target_os_is_android) {
-     sub_modules += [ "//third_party/blink/renderer/modules/remote_objects" ]
-   } else {
+ 
+   # This uses target_os rather than current_os (which is what is_android is set
+   # from) for the case of generating the v8 context snapshot for android. When

--- a/rewrite/third_party/blink/renderer/modules/BUILD.gn.toml
+++ b/rewrite/third_party/blink/renderer/modules/BUILD.gn.toml
@@ -1,0 +1,27 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+[[substitution]]
+description = '''Extend the file-scope modules visibility with brave entries.
+'''
+re_pattern = '(^visibility = \[.*?\])'
+re_flags = ['DOTALL', 'MULTILINE']
+replace = '\1\nvisibility += brave_blink_renderer_modules_visibility'
+
+[[substitution]]
+description = '''brave_blink_sub_modules add to `component("modules")`.
+
+Anchored right after the initial `sub_modules = [ ... ]` assignment so that
+the brave entries are always part of `sub_modules` before it is consumed
+(via `public_deps = sub_modules` and `allow_circular_includes_from =
+sub_modules`), regardless of the order in which those consumers appear.
+Without this, brave sub modules never become public_deps of
+`component("modules")` and their symbols fail to link into
+libblink_modules.so.
+'''
+re_pattern = '(component\("modules"\) \{.*?sub_modules = \[.*?\])'
+re_flags = ['DOTALL']
+replace = '''\1
+  sub_modules += brave_blink_sub_modules'''


### PR DESCRIPTION
Migrating this patch as this was causing unnecessary merge conflicts.

Chromium changes:
https://chromium.googlesource.com/chromium/src/+/b676377adb9788d2b1788fe83e3b904db6c2225a

commit b676377adb9788d2b1788fe83e3b904db6c2225a
Author: Evan liu <evliu@google.com>
Date:   Fri May 15 16:30:29 2026 -0700

    Fix Web Speech API socket leak when using MediaStreamTrack

    When `SpeechRecognition::start(MediaStreamTrack*)` is called, a
    `SpeechRecognitionMediaStreamAudioSink` is created and registered to
    the track. However, this sink was never unregistered when the
    recognition session ended or aborted.

    Over multiple start/stop cycles, this caused a severe resource leak
    where sinks accumulated indefinitely, eventually exhausting Mojo IPC
    limits and causing persistent 'network' errors.

    This CL fixes the leak by tracking the audio sink in
    `SpeechRecognition` and properly unregistering and removing it from
    the `MediaStreamTrack` when `SpeechRecognition::Ended()` is called.

    Fixed: 497276218
    Change-Id: I4d8c5a98e7b5fe242a3caeb333585f5d1395c35b
    Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7850843
    Reviewed-by: Elad Alon <eladalon@chromium.org>
    Commit-Queue: Evan Liu <evliu@google.com>
    Cr-Commit-Position: refs/heads/main@{#1631628}

Bug: https://github.com/brave/brave-browser/issues/55302
