### PR TITLE
[plaster][cr150] `emptyList` 🩹🩹🩹

### DIFF
--- a/chromium_src/chrome/browser/ui/webui/bookmarks/bookmarks_ui.cc
+++ b/chromium_src/chrome/browser/ui/webui/bookmarks/bookmarks_ui.cc
@@ -4,23 +4,5 @@
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #include "brave/grit/brave_generated_resources.h"
-#include "chrome/browser/profiles/profile.h"
-#include "chrome/common/buildflags.h"
-#include "content/public/browser/web_ui_data_source.h"
-
-namespace {
-
-void BraveAddBookmarksResources(content::WebUIDataSource* source,
-                                Profile* profile) {
-  source->AddLocalizedString("emptyList",
-                             IDS_BRAVE_BOOKMARK_MANAGER_EMPTY_LIST);
-}
-
-}  // namespace
-
-#define BRAVE_CREATE_BOOKMARKS_UI_HTML_SOURCE \
-  BraveAddBookmarksResources(source, profile);
 
 #include <chrome/browser/ui/webui/bookmarks/bookmarks_ui.cc>
-
-#undef BRAVE_CREATE_BOOKMARKS_UI_HTML_SOURCE

--- a/patches/chrome-browser-ui-webui-bookmarks-bookmarks_ui.cc.patch
+++ b/patches/chrome-browser-ui-webui-bookmarks-bookmarks_ui.cc.patch
@@ -1,12 +1,13 @@
 diff --git a/chrome/browser/ui/webui/bookmarks/bookmarks_ui.cc b/chrome/browser/ui/webui/bookmarks/bookmarks_ui.cc
-index e78c6b1e873beaa596a4c75e0efe15cd9c362ed1..0bf32869e47e5f1ad75e15dd51eec6999324e56f 100644
+index e78c6b1e873beaa596a4c75e0efe15cd9c362ed1..937b72dd7d6437ffa2e8190156bee202b21e863c 100644
 --- a/chrome/browser/ui/webui/bookmarks/bookmarks_ui.cc
 +++ b/chrome/browser/ui/webui/bookmarks/bookmarks_ui.cc
-@@ -152,6 +152,7 @@ content::WebUIDataSource* CreateAndAddBookmarksUIHTMLSource(Profile* profile) {
-       "images/batch_upload_bookmarks_promo_dark.svg",
-       IDR_BOOKMARKS_IMAGES_BATCH_UPLOAD_BOOKMARKS_PROMO_DARK_SVG);
- 
-+  BRAVE_CREATE_BOOKMARKS_UI_HTML_SOURCE
-   return source;
- }
- 
+@@ -75,7 +75,7 @@ content::WebUIDataSource* CreateAndAddBookmarksUIHTMLSource(Profile* profile) {
+       {"editDialogInvalidUrl", IDS_BOOKMARK_MANAGER_INVALID_URL},
+       {"editDialogNameInput", IDS_BOOKMARK_MANAGER_NAME_INPUT_PLACE_HOLDER},
+       {"editDialogUrlInput", IDS_BOOKMARK_MANAGER_URL_INPUT_PLACE_HOLDER},
+-      {"emptyList", IDS_BOOKMARK_MANAGER_EMPTY_LIST},
++      {"emptyList", IDS_BRAVE_BOOKMARK_MANAGER_EMPTY_LIST},
+       {"emptyUnmodifiableList", IDS_BOOKMARK_MANAGER_EMPTY_UNMODIFIABLE_LIST},
+       {"folderLabel", IDS_BOOKMARK_MANAGER_FOLDER_LABEL},
+       {"importBegan", IDS_BOOKMARK_MANAGER_MENU_IMPORT_BEGAN},

--- a/rewrite/chrome/browser/ui/webui/bookmarks/bookmarks_ui.cc.toml
+++ b/rewrite/chrome/browser/ui/webui/bookmarks/bookmarks_ui.cc.toml
@@ -1,0 +1,9 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+[[substitution]]
+description = 'Swap `emptyList` with the a Brave ID.'
+pattern = 'IDS_BOOKMARK_MANAGER_EMPTY_LIST'
+replace = 'IDS_BRAVE_BOOKMARK_MANAGER_EMPTY_LIST'


### PR DESCRIPTION
This change introduces a plaster for a simple replacement that is done
for `IDS_BOOKMARK_MANAGER_EMPTY_LIST` which was being done in a very
convoluted manner due to how non-obvious `#define` code can be
sometimes.

Chromium changes:
https://chromium.googlesource.com/chromium/src/+/53e41d377f4fff70e2ba57eab58703fce7a7e45d

commit 53e41d377f4fff70e2ba57eab58703fce7a7e45d
Author: Mickey Burks <mickeyburks@chromium.org>
Date:   Fri May 8 07:40:25 2026 -0700

    [GlowUp] Use themed colors in Bookmarks

    Many of these styles may seem redundant, but they are necessary to
    override the specificity of some existing selectors.

    Change-Id: I256b2c7018012db66cf60e64d8a6a5c30996a500
    Fixed: 507037852
    Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7793819
    Commit-Queue: Mickey Burks <mickeyburks@chromium.org>
    Reviewed-by: Thomas Lukaszewicz <tluk@chromium.org>
    Reviewed-by: John Lee <johntlee@chromium.org>
    Cr-Commit-Position: refs/heads/main@{#1627642}

Bug: https://github.com/brave/brave-browser/issues/55302
