### PR TITLE
[cr150][plaster] `//components/omnibox/browser` 🩹🩹🩹

### DIFF
--- a/patches/components-omnibox-browser-BUILD.gn.patch
+++ b/patches/components-omnibox-browser-BUILD.gn.patch
@@ -1,20 +1,36 @@
 diff --git a/components/omnibox/browser/BUILD.gn b/components/omnibox/browser/BUILD.gn
-index 86f0cccd5e086029ecdb7456f9216546059d73b0..b9e13685d549babeac2d2425e96c3e8957a9eff8 100644
+index 86f0cccd5e086029ecdb7456f9216546059d73b0..3f4244084f2ebec91aeeec2c1db09c31f51f39a3 100644
 --- a/components/omnibox/browser/BUILD.gn
 +++ b/components/omnibox/browser/BUILD.gn
-@@ -399,6 +399,7 @@ static_library("browser") {
+@@ -326,6 +326,7 @@ static_library("browser") {
+     "zero_suggest_verbatim_match_provider.cc",
+     "zero_suggest_verbatim_match_provider.h",
+   ]
++  sources += brave_components_omnibox_browser_sources
+ 
+   public_deps = [
+     ":aim_eligibility_service_features",
+@@ -354,6 +355,7 @@ static_library("browser") {
+     "//third_party/tflite_support:tflite_support_proto",
+     "//url",
+   ]
++  public_deps += brave_components_omnibox_browser_public_deps
+ 
+   deps = [
+     "//build:branding_buildflags",
+@@ -399,6 +401,7 @@ static_library("browser") {
      "//ui/base",
      "//ui/gfx",
    ]
-+  sources += brave_components_omnibox_browser_sources deps += brave_components_omnibox_browser_deps public_deps += brave_components_omnibox_browser_public_deps
++  deps += brave_components_omnibox_browser_deps
  
    configs += [ "//build/config/compiler:wexit_time_destructors" ]
  
-@@ -1032,6 +1033,7 @@ fuzzer_test("search_suggestion_parser_fuzzer") {
+@@ -1031,6 +1034,7 @@ fuzzer_test("search_suggestion_parser_fuzzer") {
+ }
  
  mojom("mojo_bindings") {
-   sources = [ "omnibox.mojom" ]
 +  generate_legacy_js_bindings = true
+   sources = [ "omnibox.mojom" ]
    if ((!is_android && !is_ios) || enable_webui_ntp) {
      sources += [ "searchbox.mojom" ]
-   }

--- a/rewrite/components/omnibox/browser/BUILD.gn.toml
+++ b/rewrite/components/omnibox/browser/BUILD.gn.toml
@@ -1,0 +1,32 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+[[substitution]]
+description = '''Enable legacy JS bindings generation for `mojo_bindings`.
+
+These bindings are used by `brave_new_tab_ui`. This plaster always adds the
+line at the beginning of the target.
+'''
+re_pattern = '(mojom\("mojo_bindings"\)\s*\{)'
+re_flags = ['DOTALL']
+replace = '\1\n  generate_legacy_js_bindings = true'
+
+[[substitution]]
+description = 'Append Brave sources right after sources declaration.'
+re_pattern = '(static_library\("browser"\).*?sources\s*=\s*\[.*?\])'
+re_flags = ['DOTALL']
+replace = '\1\n  sources += brave_components_omnibox_browser_sources'
+
+[[substitution]]
+description = 'Append Brave public deps right after public_deps'
+re_pattern = '(static_library\("browser"\).*?public_deps\s*=\s*\[.*?\])'
+re_flags = ['DOTALL']
+replace = '\1\n  public_deps += brave_components_omnibox_browser_public_deps'
+
+[[substitution]]
+description = 'Append Brave deps right after deps declaration.'
+re_pattern = '(static_library\("browser"\).*?\bdeps\s*=\s*\[.*?\])'
+re_flags = ['DOTALL']
+replace = '\1\n  deps += brave_components_omnibox_browser_deps'


### PR DESCRIPTION
This particular source is being migrated as it is a case of a frail
patch, that breaks easily on rebases, and can be easily managed by
plaster.

The new plaster has broken apart the patching of
`sources`/`deps`/`public_deps` into three substitutions, because this
has no additional cost to the plaster effectiveness, but it does help
with readability as each substitution is put next to what they are
changing.

Chromium changes:
https://chromium.googlesource.com/chromium/src/+/2a2d45627669d484a0fe282db436116cdfcc0c4c

commit 2a2d45627669d484a0fe282db436116cdfcc0c4c
Author: Wenyu Fu <wenyufu@chromium.org>
Date:   Fri May 8 13:24:42 2026 -0700

    [ContextualTasks] Migrate Desktop Composebox Handler to Android

    Migrate `ContextualTasksComposeboxHandler` to Android. This unifies the
    composebox and searchbox C++ backend logic for Contextual Tasks across
    Desktop and Android, enabling Desktop Composebox WebUI reuse on Android.

    This is made possible because `TabListInterface` is supported on Android
    via `TabModel`. Lens C++ dependencies which is not supported on Android
    isolated in this CL.

    Key changes:
    - Update `BUILD.gn` to compile the handler on Android and remove the
      stub.
    - Update `desktop_query_contextualizer_delegate.cc` to include the
      correct `tab_features.h` header depending on the platform.
    - Update `contextual_tasks_ui.cc` to instantiate the unified
      handler.
    - Guard out Desktop-only `new_tab_page:resources` and
      `sanitized_image_source` on Android to avoid pulling in the
      entire NTP frontend.

    The compose box does not render yet.

    Preview: https://screenshot.googleplex.com/6hpKQxwoBh6GpHv
    Binary-Size: Pulled in webUI component and resources, unavoidable.
    Bug: b:509722915
    Test: Compile and run chrome_apk
    Change-Id: I53b005f6fce4b05406f44154bfe3832ca84107a4
    Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7823561
    Reviewed-by: Paul Adedeji <pauladedeji@google.com>
    Reviewed-by: Jason Hu <hujasonx@google.com>
    Reviewed-by: John Lee <johntlee@chromium.org>
    Reviewed-by: Andrew Grieve <agrieve@chromium.org>
    Commit-Queue: Wenyu Fu <wenyufu@chromium.org>
    Cr-Commit-Position: refs/heads/main@{#1627880}

Bug: https://github.com/brave/brave-browser/issues/55302
