### PR TITLE
[docs] Auto format `best-practices`

### DIFF
--- a/.claude/skills/add-best-practice/SKILL.md
+++ b/.claude/skills/add-best-practice/SKILL.md
@@ -234,7 +234,17 @@ If validation fails, fix the issue before proceeding.
 
 ---
 
-## Step 9: Commit and Offer to Branch + PR
+## Step 9: Format Markdown
+
+All created or modified docs MUST be formatted with `npm run format` before
+being committed — unformatted docs fail CI's presubmit step. ALWAYS `git add`
+any new (untracked) docs BEFORE calling `npm run format` — the formatter
+silently skips untracked files, so missing this step means the new doc ships
+unformatted and CI will reject it.
+
+---
+
+## Step 10: Commit and Offer to Branch + PR
 
 After successfully adding the best practice, commit all changes as a single
 atomic commit on the current branch. Use `--amend` to fold the ID assignment and
@@ -278,6 +288,9 @@ Report the PR URL if created.
 
 - **No Claude Code attribution** — do NOT include `Co-Authored-By`,
   `Generated with Claude Code`, or any other attribution in commits or PRs
+- **Always format with `npm run format`** — never hand-format markdown or use
+  another formatter. New (untracked) documents must be `git add`ed first, or the
+  formatter will skip them silently
 
 - **Never reuse old IDs** — the `manage-bp-ids.py --assign` script handles this
   automatically by incrementing from the highest existing number

--- a/.prettierignore
+++ b/.prettierignore
@@ -11,7 +11,6 @@
 /chromium_src/components/
 /chromium_src/third_party/
 /chromium_src/ui/
-/docs/best-practices/
 /ios
 /resources
 /test

--- a/docs/best-practices/android.md
+++ b/docs/best-practices/android.md
@@ -4,7 +4,10 @@
 
 ## ✅ Check `isActivityFinishingOrDestroyed()` Before UI Operations in Async Callbacks
 
-**Always check `isActivityFinishingOrDestroyed()` before performing UI operations (showing dialogs, starting activities, manipulating views) in async callbacks, animation listeners, or lambdas.** Activities can be destroyed between when a callback is scheduled and when it executes.
+**Always check `isActivityFinishingOrDestroyed()` before performing UI
+operations (showing dialogs, starting activities, manipulating views) in async
+callbacks, animation listeners, or lambdas.** Activities can be destroyed
+between when a callback is scheduled and when it executes.
 
 ```java
 // ❌ WRONG - no lifecycle check in async callback
@@ -35,7 +38,9 @@ animator.addListener(new AnimatorListenerAdapter() {
 
 ## ✅ Check Fragment Attachment Before Async UI Updates
 
-**When async callbacks update UI through a Fragment, verify the fragment is still added and its host Activity is available.** Fragments can be detached or their Activity destroyed while async work is in progress.
+**When async callbacks update UI through a Fragment, verify the fragment is
+still added and its host Activity is available.** Fragments can be detached or
+their Activity destroyed while async work is in progress.
 
 ```java
 // ❌ WRONG - no fragment state checks
@@ -52,7 +57,8 @@ void onServiceResult(Result result) {
 }
 ```
 
-This applies to any asynchronous path: service callbacks, `PostTask.postTask()`, Mojo responses, etc.
+This applies to any asynchronous path: service callbacks, `PostTask.postTask()`,
+Mojo responses, etc.
 
 ---
 
@@ -60,7 +66,9 @@ This applies to any asynchronous path: service callbacks, `PostTask.postTask()`,
 
 ## ✅ Disable Interactive UI During Async Operations
 
-**Disable buttons, preferences, and other interactive elements while an async operation is in progress to prevent double-clicks.** Re-enable when the callback completes.
+**Disable buttons, preferences, and other interactive elements while an async
+operation is in progress to prevent double-clicks.** Re-enable when the callback
+completes.
 
 ```java
 // ❌ WRONG - allows double-clicks during async operation
@@ -86,7 +94,9 @@ preference.setOnPreferenceClickListener(pref -> {
 
 ## ✅ Apply Null Checks Consistently
 
-**If a member field (e.g., a View reference) is checked for null in some code paths, check it in all code paths that use it.** Inconsistent null checking suggests some paths may crash.
+**If a member field (e.g., a View reference) is checked for null in some code
+paths, check it in all code paths that use it.** Inconsistent null checking
+suggests some paths may crash.
 
 ```java
 // ❌ WRONG - null check in some places but not others
@@ -113,7 +123,9 @@ private void hideSplash() {
 
 ## ✅ Add Null Checks for Services Unavailable in Incognito
 
-**Services accessed through bridges or native code may be null in incognito profiles.** Always add explicit null checks at the point of use, even if upstream logic theoretically handles this.
+**Services accessed through bridges or native code may be null in incognito
+profiles.** Always add explicit null checks at the point of use, even if
+upstream logic theoretically handles this.
 
 ```cpp
 // ❌ WRONG - assumes service is always available
@@ -135,7 +147,9 @@ void NTPBackgroundImagesBridge::GetCurrentWallpaperForDisplay() {
 
 ## ✅ Use LazyHolder Pattern for Singleton Factories
 
-**Use the LazyHolder idiom for singleton service factories instead of explicit `synchronized` blocks with a lock `Object`.** This is more compact and thread-safe by leveraging Java's class loading guarantees.
+**Use the LazyHolder idiom for singleton service factories instead of explicit
+`synchronized` blocks with a lock `Object`.** This is more compact and
+thread-safe by leveraging Java's class loading guarantees.
 
 ```java
 // ❌ WRONG - explicit lock-based singleton
@@ -172,7 +186,10 @@ public class BraveAccountServiceFactory {
 
 ## ✅ Resolve Theme Colors at Bind Time
 
-**When a custom Preference or view resolves colors from theme attributes, do so at `onBindViewHolder` time (or equivalent), not during construction.** This ensures colors update correctly when the user switches between light and dark themes without the view being recreated.
+**When a custom Preference or view resolves colors from theme attributes, do so
+at `onBindViewHolder` time (or equivalent), not during construction.** This
+ensures colors update correctly when the user switches between light and dark
+themes without the view being recreated.
 
 ```java
 // ❌ WRONG - resolve color during construction
@@ -202,7 +219,9 @@ public class MyPreference extends Preference {
 
 ## ✅ Use `app:isPreferenceVisible="false"` for Conditionally Shown Preferences
 
-**When a preference in XML will be programmatically removed or hidden based on a feature flag, set `app:isPreferenceVisible="false"` in XML to avoid a brief visual flash before the code hides it.**
+**When a preference in XML will be programmatically removed or hidden based on a
+feature flag, set `app:isPreferenceVisible="false"` in XML to avoid a brief
+visual flash before the code hides it.**
 
 ```xml
 <!-- ✅ Prevents flash of preference before programmatic removal -->
@@ -218,7 +237,10 @@ public class MyPreference extends Preference {
 
 ## ✅ Use `assert` Alongside `Log` for Validation
 
-**Pair defensive null/validation checks with `assert` statements.** Assertions crash in debug builds making problems immediately visible, while graceful handling still protects release builds. Log-only guards are easily missed in logcat output.
+**Pair defensive null/validation checks with `assert` statements.** Assertions
+crash in debug builds making problems immediately visible, while graceful
+handling still protects release builds. Log-only guards are easily missed in
+logcat output.
 
 ```java
 // ❌ WRONG - log-only guard, easily missed
@@ -242,9 +264,13 @@ if (contractAddress == null || contractAddress.length() < MIN_LENGTH) {
 
 ## ✅ Cache Expensive System Service Lookups
 
-**When a method internally fetches system services (e.g., `PackageManager`, `AppOpsManager`), avoid calling it repeatedly in a hot path.** Compute the value once and store it in a member variable.
+**When a method internally fetches system services (e.g., `PackageManager`,
+`AppOpsManager`), avoid calling it repeatedly in a hot path.** Compute the value
+once and store it in a member variable.
 
-**Exception:** Don't cache values that can change without notification in multi-window or configuration-change scenarios (e.g., PiP availability can change when a second app starts).
+**Exception:** Don't cache values that can change without notification in
+multi-window or configuration-change scenarios (e.g., PiP availability can
+change when a second app starts).
 
 ```java
 // ❌ WRONG - repeated expensive service lookup
@@ -268,7 +294,9 @@ public void onCreate() {
 
 ## ✅ Prefer Core/Native-Side Validation
 
-**Before implementing validation logic in Android/Java code, check whether unified validation exists on the core/native side.** Prefer core-side validation to avoid cross-platform inconsistencies between Android, iOS, and desktop.
+**Before implementing validation logic in Android/Java code, check whether
+unified validation exists on the core/native side.** Prefer core-side validation
+to avoid cross-platform inconsistencies between Android, iOS, and desktop.
 
 ---
 
@@ -276,7 +304,9 @@ public void onCreate() {
 
 ## ✅ Skip Native/JNI Checks in Robolectric Tests
 
-**Robolectric tests do not have native/JNI available.** When code paths hit JNI calls, use conditional checks (like `FeatureList.isNativeInitialized()`) to gracefully handle the test environment.
+**Robolectric tests do not have native/JNI available.** When code paths hit JNI
+calls, use conditional checks (like `FeatureList.isNativeInitialized()`) to
+gracefully handle the test environment.
 
 ```java
 // ✅ CORRECT - guard JNI calls for Robolectric compatibility
@@ -293,7 +323,10 @@ See `BraveDynamicColors.java` for an existing example of this pattern.
 
 ## ✅ Use Direct Java Patches When Bytecode Patching Fails
 
-**Bytecode (class adapter) patching fails when a class has two constructors.** In these cases, use direct `.java.patch` files instead. Also use direct `BUILD.gn` patches to add sources when circular dependencies prevent using `java_sources.gni`.
+**Bytecode (class adapter) patching fails when a class has two constructors.**
+In these cases, use direct `.java.patch` files instead. Also use direct
+`BUILD.gn` patches to add sources when circular dependencies prevent using
+`java_sources.gni`.
 
 ---
 
@@ -301,7 +334,11 @@ See `BraveDynamicColors.java` for an existing example of this pattern.
 
 ## ✅ `ProfileManager.getLastUsedRegularProfile()` Is Acceptable in Widgets
 
-**While the presubmit check flags `ProfileManager.getLastUsedRegularProfile()` as a banned pattern, it is acceptable in Android widget providers** (e.g., `QuickActionSearchAndBookmarkWidgetProvider`) where no Activity or WebContents context is available. This matches upstream Chromium's approach in their own widgets.
+**While the presubmit check flags `ProfileManager.getLastUsedRegularProfile()`
+as a banned pattern, it is acceptable in Android widget providers** (e.g.,
+`QuickActionSearchAndBookmarkWidgetProvider`) where no Activity or WebContents
+context is available. This matches upstream Chromium's approach in their own
+widgets.
 
 ---
 
@@ -309,7 +346,9 @@ See `BraveDynamicColors.java` for an existing example of this pattern.
 
 ## ✅ Remove Unused Interfaces and Dead Code
 
-**Do not leave unused interfaces, listener patterns, or helper methods in the codebase.** If scaffolded during development but never actually called, remove before merging.
+**Do not leave unused interfaces, listener patterns, or helper methods in the
+codebase.** If scaffolded during development but never actually called, remove
+before merging.
 
 ```java
 // ❌ WRONG - interface defined but never used
@@ -326,7 +365,9 @@ public interface OnAnimationCompleteListener {
 
 ## ❌ Don't Set `clickable`/`focusable` on Non-Interactive Views
 
-**Avoid setting `android:clickable="true"` or `android:focusable="true"` on purely decorative or display-only views** (like animation containers). These attributes affect accessibility and touch event handling.
+**Avoid setting `android:clickable="true"` or `android:focusable="true"` on
+purely decorative or display-only views** (like animation containers). These
+attributes affect accessibility and touch event handling.
 
 ---
 
@@ -334,7 +375,9 @@ public interface OnAnimationCompleteListener {
 
 ## ✅ Share Identical Assets Across Platforms
 
-**When Android and iOS use identical asset files (e.g., Lottie animation JSON), reference a single shared copy rather than maintaining duplicates.** This ensures future changes only need to be made once.
+**When Android and iOS use identical asset files (e.g., Lottie animation JSON),
+reference a single shared copy rather than maintaining duplicates.** This
+ensures future changes only need to be made once.
 
 ---
 
@@ -342,7 +385,9 @@ public interface OnAnimationCompleteListener {
 
 ## ✅ Group Feature-Specific Java Sources into Separate Build Targets
 
-**When Java sources for a specific feature (e.g., `crypto_wallet`) accumulate in `brave_java_sources.gni`, consider creating a separate build target.** This improves build isolation and dependency tracking.
+**When Java sources for a specific feature (e.g., `crypto_wallet`) accumulate in
+`brave_java_sources.gni`, consider creating a separate build target.** This
+improves build isolation and dependency tracking.
 
 ---
 
@@ -350,7 +395,9 @@ public interface OnAnimationCompleteListener {
 
 ## ✅ Prefer Early Returns Over Deep Nesting
 
-**When a condition check determines whether the rest of a method should execute, return early rather than wrapping logic in nested `if` blocks.** This reduces nesting depth and improves readability.
+**When a condition check determines whether the rest of a method should execute,
+return early rather than wrapping logic in nested `if` blocks.** This reduces
+nesting depth and improves readability.
 
 ```java
 // ❌ WRONG - deep nesting
@@ -376,7 +423,13 @@ private void handleState() {
 
 ## ✅ Bytecode Adapter Changes Require Bytecode Tests
 
-**When adding or modifying a bytecode class adapter (files in `build/android/bytecode/java/org/brave/bytecode/`), add a corresponding bytecode test** in `android/javatests/org/chromium/chrome/browser/BytecodeTest.java`. Tests should verify both class existence (in `testClassesExist`) and method existence with correct return types (in `testMethodsExist`). This ensures upstream refactors are caught at test time rather than causing silent runtime failures.
+**When adding or modifying a bytecode class adapter (files in
+`build/android/bytecode/java/org/brave/bytecode/`), add a corresponding bytecode
+test** in `android/javatests/org/chromium/chrome/browser/BytecodeTest.java`.
+Tests should verify both class existence (in `testClassesExist`) and method
+existence with correct return types (in `testMethodsExist`). This ensures
+upstream refactors are caught at test time rather than causing silent runtime
+failures.
 
 ---
 
@@ -385,10 +438,13 @@ private void handleState() {
 ## ✅ Proguard Rules: Separate Runtime vs Test Keep Rules
 
 **Proguard keep rules must go in the correct file:**
-- `android/java/proguard.flags` — Only for classes/methods accessed via reflection at runtime
+
+- `android/java/proguard.flags` — Only for classes/methods accessed via
+  reflection at runtime
 - `android/java/apk_for_test.flags` — For rules needed only during testing
 
-Putting test-only keep rules in `proguard.flags` unnecessarily increases the production APK size by preventing code shrinking.
+Putting test-only keep rules in `proguard.flags` unnecessarily increases the
+production APK size by preventing code shrinking.
 
 ---
 
@@ -396,7 +452,10 @@ Putting test-only keep rules in `proguard.flags` unnecessarily increases the pro
 
 ## ✅ Use `@VisibleForTesting` for Package-Private Test Accessors
 
-**When a field or method is made package-private solely for testing purposes, annotate it with `@VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)`.** This communicates intent to other developers and allows IDEs to flag improper usage from non-test code.
+**When a field or method is made package-private solely for testing purposes,
+annotate it with `@VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)`.**
+This communicates intent to other developers and allows IDEs to flag improper
+usage from non-test code.
 
 ---
 
@@ -404,7 +463,11 @@ Putting test-only keep rules in `proguard.flags` unnecessarily increases the pro
 
 ## ✅ Prefer Programmatic `addView` Over Full XML Layout Replacement
 
-**When customizing Android UI, prefer adding views programmatically (via `addView` in Java) over replacing entire upstream XML layout files.** Replacing full XML files creates maintenance burden during Chromium upgrades. However, if programmatic addition requires extending final classes or leads to equally invasive changes, document the trade-off and accept the XML replacement.
+**When customizing Android UI, prefer adding views programmatically (via
+`addView` in Java) over replacing entire upstream XML layout files.** Replacing
+full XML files creates maintenance burden during Chromium upgrades. However, if
+programmatic addition requires extending final classes or leads to equally
+invasive changes, document the trade-off and accept the XML replacement.
 
 ---
 
@@ -412,7 +475,12 @@ Putting test-only keep rules in `proguard.flags` unnecessarily increases the pro
 
 ## ✅ Brave Resources Go in `brave-res`, Not Upstream Folders
 
-**Brave-specific Android resources (drawables, layouts, etc.) should be placed in a dedicated `brave-res` folder, not copied into upstream Chromium resource directories.** The upstream resource directories should only be used when intentionally overriding an existing upstream resource. Adding new Brave-only resources to upstream folders creates confusion about whether a resource is a Brave addition or an upstream override.
+**Brave-specific Android resources (drawables, layouts, etc.) should be placed
+in a dedicated `brave-res` folder, not copied into upstream Chromium resource
+directories.** The upstream resource directories should only be used when
+intentionally overriding an existing upstream resource. Adding new Brave-only
+resources to upstream folders creates confusion about whether a resource is a
+Brave addition or an upstream override.
 
 ---
 
@@ -420,7 +488,11 @@ Putting test-only keep rules in `proguard.flags` unnecessarily increases the pro
 
 ## ✅ Comprehensively Clean Up All Artifacts When Removing a Feature
 
-**When removing a feature from Android, audit and remove all related artifacts:** bytecode class adapters, ProGuard rules, bytecode test entries, Java source files, resource files, JNI bindings, feature flags, and build system references. A feature removal PR should account for all integration points across the codebase.
+**When removing a feature from Android, audit and remove all related
+artifacts:** bytecode class adapters, ProGuard rules, bytecode test entries,
+Java source files, resource files, JNI bindings, feature flags, and build system
+references. A feature removal PR should account for all integration points
+across the codebase.
 
 ---
 
@@ -428,7 +500,9 @@ Putting test-only keep rules in `proguard.flags` unnecessarily increases the pro
 
 ## ✅ Remove Dead API-Level Checks Below Min SDK
 
-**Remove Android version checks for API levels below the app's minimum SDK version.** Dead code checking for Lollipop (API 21) or Marshmallow (API 23) should be cleaned up since Brave's minimum SDK is higher.
+**Remove Android version checks for API levels below the app's minimum SDK
+version.** Dead code checking for Lollipop (API 21) or Marshmallow (API 23)
+should be cleaned up since Brave's minimum SDK is higher.
 
 ---
 
@@ -436,7 +510,10 @@ Putting test-only keep rules in `proguard.flags` unnecessarily increases the pro
 
 ## ✅ Direct Patches: Add New Lines, Don't Modify Existing
 
-**When creating direct patches (non-chromium_src overrides), prefer adding entirely new lines rather than modifying existing upstream lines.** This reduces the risk of patch conflicts during Chromium version upgrades, because new lines have no upstream anchor that might change.
+**When creating direct patches (non-chromium_src overrides), prefer adding
+entirely new lines rather than modifying existing upstream lines.** This reduces
+the risk of patch conflicts during Chromium version upgrades, because new lines
+have no upstream anchor that might change.
 
 ---
 
@@ -444,7 +521,10 @@ Putting test-only keep rules in `proguard.flags` unnecessarily increases the pro
 
 ## ✅ Patches Are Acceptable for Anonymous Inner Classes
 
-**When the Brave override system cannot handle anonymous inner classes in upstream Chromium Java code, a `.patch` file is the accepted fallback.** Document the reason in the PR and link to the tracking issue for better override support.
+**When the Brave override system cannot handle anonymous inner classes in
+upstream Chromium Java code, a `.patch` file is the accepted fallback.**
+Document the reason in the PR and link to the tracking issue for better override
+support.
 
 ---
 
@@ -452,7 +532,10 @@ Putting test-only keep rules in `proguard.flags` unnecessarily increases the pro
 
 ## ✅ Verify Shared Resource Changes Don't Break Other UIs
 
-**When modifying shared Android resource values (colors, dimensions, styles in files like `brave_colors.xml`), verify the impact on ALL UIs that reference those resources.** Shared resources can affect multiple screens — always cross-check usages before modifying.
+**When modifying shared Android resource values (colors, dimensions, styles in
+files like `brave_colors.xml`), verify the impact on ALL UIs that reference
+those resources.** Shared resources can affect multiple screens — always
+cross-check usages before modifying.
 
 ---
 
@@ -460,7 +543,11 @@ Putting test-only keep rules in `proguard.flags` unnecessarily increases the pro
 
 ## ✅ Use Baseline Colors Over Java Code Patches for Theming
 
-**When fixing Android color/theming issues, prefer following upstream's approach of using baseline colors (XML color resources) for non-dynamic color states rather than patching Java code to programmatically set colors.** This is more maintainable and aligns with upstream's theming system. Always verify fixes work with the Dynamic Colors flag both enabled and disabled.
+**When fixing Android color/theming issues, prefer following upstream's approach
+of using baseline colors (XML color resources) for non-dynamic color states
+rather than patching Java code to programmatically set colors.** This is more
+maintainable and aligns with upstream's theming system. Always verify fixes work
+with the Dynamic Colors flag both enabled and disabled.
 
 ---
 
@@ -468,7 +555,11 @@ Putting test-only keep rules in `proguard.flags` unnecessarily increases the pro
 
 ## ❌ Don't Modify Upstream String Resource Files
 
-**Never modify upstream Chromium string resource files (e.g., `chrome_strings.grd`, upstream `strings.xml`).** Add Brave-specific strings to `android_brave_strings.grd` or the appropriate Brave-owned resource file instead. Modifying upstream files creates patch conflicts during Chromium upgrades.
+**Never modify upstream Chromium string resource files (e.g.,
+`chrome_strings.grd`, upstream `strings.xml`).** Add Brave-specific strings to
+`android_brave_strings.grd` or the appropriate Brave-owned resource file
+instead. Modifying upstream files creates patch conflicts during Chromium
+upgrades.
 
 ---
 
@@ -476,7 +567,9 @@ Putting test-only keep rules in `proguard.flags` unnecessarily increases the pro
 
 ## ✅ Match Upstream Nullability Annotations in Overridden Methods
 
-**When overriding upstream methods in Brave Java code, match the upstream nullability annotations (e.g., `@NullUnmarked`, `@Nullable`, `@NonNull`).** Mismatched annotations cause NullAway build failures and prevent merging.
+**When overriding upstream methods in Brave Java code, match the upstream
+nullability annotations (e.g., `@NullUnmarked`, `@Nullable`, `@NonNull`).**
+Mismatched annotations cause NullAway build failures and prevent merging.
 
 ```java
 // ❌ WRONG - upstream method has @NullUnmarked but override doesn't
@@ -495,7 +588,8 @@ public void onResult(Profile profile) { ... }
 
 ## ❌ Don't Repeat Class Name in Log TAG
 
-**Android Log TAG fields should use a short, descriptive string — not repeat the full class name when it adds no value.** Keep TAGs concise and informative.
+**Android Log TAG fields should use a short, descriptive string — not repeat the
+full class name when it adds no value.** Keep TAGs concise and informative.
 
 ```java
 // ❌ WRONG - redundant, TAG just repeats class name
@@ -511,7 +605,9 @@ private static final String TAG = "BraveVPN";
 
 ## ✅ Use Layout Shorthand Attributes
 
-**Use shorthand XML layout attributes (`paddingHorizontal`, `marginHorizontal`, `paddingVertical`, `marginVertical`) instead of setting start/end or top/bottom separately.** This reduces XML verbosity and improves readability.
+**Use shorthand XML layout attributes (`paddingHorizontal`, `marginHorizontal`,
+`paddingVertical`, `marginVertical`) instead of setting start/end or top/bottom
+separately.** This reduces XML verbosity and improves readability.
 
 ```xml
 <!-- ❌ WRONG - verbose -->
@@ -528,13 +624,20 @@ private static final String TAG = "BraveVPN";
 
 # NullAway (Java Null Safety)
 
-Chromium uses [NullAway](https://github.com/uber/NullAway) to enforce [JSpecify](https://jspecify.dev/docs/user-guide/)-style `@Nullable` annotations. NullAway is an [Error Prone](https://errorprone.info/) plugin that runs as a static analysis step for targets without `chromium_code = false`. Null checking is enabled only for classes annotated with `@NullMarked`. Migration progress: [crbug.com/389129271](https://crbug.com/389129271).
+Chromium uses [NullAway](https://github.com/uber/NullAway) to enforce
+[JSpecify](https://jspecify.dev/docs/user-guide/)-style `@Nullable` annotations.
+NullAway is an [Error Prone](https://errorprone.info/) plugin that runs as a
+static analysis step for targets without `chromium_code = false`. Null checking
+is enabled only for classes annotated with `@NullMarked`. Migration progress:
+[crbug.com/389129271](https://crbug.com/389129271).
 
 Key configuration facts:
+
 - JSpecify mode is enabled — `@Nullable` is `TYPE_USE`.
 - Non-annotated types default to non-null (no `@NonNull` needed).
 - Nullness of local variables is inferred automatically.
-- Annotations live under `org.chromium.build.annotations` (part of `//build/android:build_java`, a default dep).
+- Annotations live under `org.chromium.build.annotations` (part of
+  `//build/android:build_java`, a default dep).
 - Java collections and Guava's `Preconditions` are modeled directly in NullAway.
 - Android's `onCreate()` (and similar) methods are implicitly `@Initializer`.
 
@@ -544,7 +647,9 @@ Key configuration facts:
 
 ## ✅ Place `@Nullable` Immediately Before the Type
 
-**`@Nullable` is `TYPE_USE` in JSpecify mode — it must appear immediately before the type it annotates.** Placing it on a separate line or before modifiers does not compile. For nested types, the annotation goes before the inner type name.
+**`@Nullable` is `TYPE_USE` in JSpecify mode — it must appear immediately before
+the type it annotates.** Placing it on a separate line or before modifiers does
+not compile. For nested types, the annotation goes before the inner type name.
 
 ```java
 // ❌ WRONG - annotation on separate line
@@ -578,7 +683,9 @@ private @Nullable Callback<@Nullable String> mNullableCallbackOfNullableString;
 
 ## ✅ Use Method Annotations for Pre/Post Conditions
 
-**NullAway analyzes code per-method. Use `@RequiresNonNull`, `@EnsuresNonNull`, `@EnsuresNonNullIf`, and `@Contract` to communicate nullability conditions across method boundaries.**
+**NullAway analyzes code per-method. Use `@RequiresNonNull`, `@EnsuresNonNull`,
+`@EnsuresNonNullIf`, and `@Contract` to communicate nullability conditions
+across method boundaries.**
 
 ```java
 // @RequiresNonNull — only makes sense on private methods
@@ -617,7 +724,9 @@ private boolean isParamNonNull(@Nullable String foo) {
 }
 ```
 
-**Note:** NullAway's validation of `@Contract` correctness is buggy and disabled, but contracts still apply to callers (they are assumed to be true). See [NullAway#1104](https://github.com/uber/NullAway/issues/1104).
+**Note:** NullAway's validation of `@Contract` correctness is buggy and
+disabled, but contracts still apply to callers (they are assumed to be true).
+See [NullAway#1104](https://github.com/uber/NullAway/issues/1104).
 
 ---
 
@@ -625,7 +734,10 @@ private boolean isParamNonNull(@Nullable String foo) {
 
 ## ✅ Use `@MonotonicNonNull` for Late-Initialized Fields
 
-**When a field starts as null but must never be set back to null after initialization, use `@MonotonicNonNull` instead of `@Nullable`.** This allows NullAway to trust the field is non-null after its first assignment, even in lambdas.
+**When a field starts as null but must never be set back to null after
+initialization, use `@MonotonicNonNull` instead of `@Nullable`.** This allows
+NullAway to trust the field is non-null after its first assignment, even in
+lambdas.
 
 ```java
 private @MonotonicNonNull String mSomeValue;
@@ -646,7 +758,9 @@ public void doThing(String value) {
 
 ## ✅ Choose the Right Assert/Assume Pattern
 
-**Use the correct null assertion mechanism depending on whether you need a statement or expression and what safety guarantees you want.** Always use `import static` for `assumeNonNull` / `assertNonNull`.
+**Use the correct null assertion mechanism depending on whether you need a
+statement or expression and what safety guarantees you want.** Always use
+`import static` for `assumeNonNull` / `assertNonNull`.
 
 ```java
 import static org.chromium.build.NullUtil.assumeNonNull;
@@ -689,12 +803,12 @@ public String describe(@MyIntDef int validity) {
 }
 ```
 
-| Mechanism | Form | Crashes in prod? | Use when |
-|-----------|------|------------------|----------|
-| `assumeNonNull()` | Statement or expression | No | You're confident the value is non-null |
-| `assertNonNull()` | Expression | No (Canary only) | You need a non-null expression |
-| `assert x != null` | Statement | No (Canary only) | You're not dereferencing locally |
-| `Objects.requireNonNull()` | Expression | Yes | Null would cause worse problems later |
+| Mechanism                  | Form                    | Crashes in prod? | Use when                               |
+| -------------------------- | ----------------------- | ---------------- | -------------------------------------- |
+| `assumeNonNull()`          | Statement or expression | No               | You're confident the value is non-null |
+| `assertNonNull()`          | Expression              | No (Canary only) | You need a non-null expression         |
+| `assert x != null`         | Statement               | No (Canary only) | You're not dereferencing locally       |
+| `Objects.requireNonNull()` | Expression              | Yes              | Null would cause worse problems later  |
 
 ---
 
@@ -702,7 +816,8 @@ public String describe(@MyIntDef int validity) {
 
 ## ✅ Handle Object Destruction Correctly
 
-**For classes with `destroy()` methods that null out otherwise non-null fields, choose one of two strategies:**
+**For classes with `destroy()` methods that null out otherwise non-null fields,
+choose one of two strategies:**
 
 <a id="AND-053"></a>
 
@@ -745,7 +860,9 @@ public void destroy() {
 
 ## ✅ Use `assertBound()` for View Binders, Not `@Initializer`
 
-**Do not mark `onBindViewHolder()` with `@Initializer` — it is not called immediately after construction.** Instead, add an `assertBound()` helper that uses `@EnsuresNonNull` to verify fields are initialized.
+**Do not mark `onBindViewHolder()` with `@Initializer` — it is not called
+immediately after construction.** Instead, add an `assertBound()` helper that
+uses `@EnsuresNonNull` to verify fields are initialized.
 
 ```java
 // ❌ WRONG - onBindViewHolder is not a real initializer
@@ -775,7 +892,10 @@ private void updateView() {
 
 ## ✅ Initialize Struct-Like Class Fields via Constructor
 
-**NullAway has no special handling for classes with public fields — it warns on non-primitive, non-`@Nullable` public fields not set by a constructor.** Create a constructor that sets all fields. Use `/* paramName= */` comments if readability suffers.
+**NullAway has no special handling for classes with public fields — it warns on
+non-primitive, non-`@Nullable` public fields not set by a constructor.** Create
+a constructor that sets all fields. Use `/* paramName= */` comments if
+readability suffers.
 
 ```java
 // ❌ WRONG - NullAway warns about uninitialized public fields
@@ -805,7 +925,10 @@ new TabInfo(/* title= */ "Home", /* url= */ "https://brave.com");
 
 ## ✅ Use "Checked" Companion Methods for Effectively Non-Null Returns
 
-**Some methods are technically `@Nullable` but practically always non-null (e.g., `Activity.findViewById()`, `Context.getSystemService()`).** For Chromium-authored code, create a "Checked" companion instead of mis-annotating the return type.
+**Some methods are technically `@Nullable` but practically always non-null
+(e.g., `Activity.findViewById()`, `Context.getSystemService()`).** For
+Chromium-authored code, create a "Checked" companion instead of mis-annotating
+the return type.
 
 ```java
 // When you're not sure if the tab exists:
@@ -819,7 +942,9 @@ public Tab getTabByIdChecked(String tabId) {
 }
 ```
 
-Do not annotate `@Nullable` methods as `@NonNull` just because callers expect non-null — this hides real nullability and defeats the purpose of static analysis.
+Do not annotate `@Nullable` methods as `@NonNull` just because callers expect
+non-null — this hides real nullability and defeats the purpose of static
+analysis.
 
 ---
 
@@ -827,7 +952,8 @@ Do not annotate `@Nullable` methods as `@NonNull` just because callers expect no
 
 ## ✅ Handle Supplier Nullability Variance
 
-**`Supplier<T>` and `Supplier<@Nullable T>` are not assignment-compatible due to Java generics invariance.** Explicit casts or utilities are required.
+**`Supplier<T>` and `Supplier<@Nullable T>` are not assignment-compatible due to
+Java generics invariance.** Explicit casts or utilities are required.
 
 ```java
 // Passing Supplier<T> to Supplier<@Nullable T> — explicit cast required
@@ -844,7 +970,8 @@ void betterApproach(Supplier<@Nullable String> supplier) {
 }
 ```
 
-See [NullAway#1356](https://github.com/uber/NullAway/issues/1356) for background on why casts are necessary.
+See [NullAway#1356](https://github.com/uber/NullAway/issues/1356) for background
+on why casts are necessary.
 
 ---
 
@@ -852,7 +979,10 @@ See [NullAway#1356](https://github.com/uber/NullAway/issues/1356) for background
 
 ## ✅ Use `@Initializer` for Two-Phase Initialization
 
-**When a class uses two-phase initialization (e.g., `onCreate()`, `initialize()`), annotate the second-phase method with `@Initializer`.** NullAway will then validate non-null fields as if the initializer runs right after the constructor. Android's `onCreate()` is implicitly `@Initializer`.
+**When a class uses two-phase initialization (e.g., `onCreate()`,
+`initialize()`), annotate the second-phase method with `@Initializer`.**
+NullAway will then validate non-null fields as if the initializer runs right
+after the constructor. Android's `onCreate()` is implicitly `@Initializer`.
 
 ```java
 public class MyComponent {
@@ -869,7 +999,9 @@ public class MyComponent {
 }
 ```
 
-**Caveat:** NullAway does not verify that `@Initializer` methods are actually called. When multiple setters are always called together, prefer a single `initialize()` method.
+**Caveat:** NullAway does not verify that `@Initializer` methods are actually
+called. When multiple setters are always called together, prefer a single
+`initialize()` method.
 
 ---
 
@@ -877,14 +1009,17 @@ public class MyComponent {
 
 ## ✅ Understand `@SuppressWarnings("NullAway")` vs `@NullUnmarked`
 
-**Both suppress NullAway warnings, but they differ in how callers see the method's signature.**
+**Both suppress NullAway warnings, but they differ in how callers see the
+method's signature.**
 
-| Annotation | Method body | Callers see |
-|-----------|-------------|-------------|
-| `@SuppressWarnings("NullAway")` | Warnings suppressed | Method remains `@NullMarked` — callers get full null checking |
-| `@NullUnmarked` | Warnings suppressed | Parameters and return types have **unknown** nullability — callers also lose null checking |
+| Annotation                      | Method body         | Callers see                                                                                |
+| ------------------------------- | ------------------- | ------------------------------------------------------------------------------------------ |
+| `@SuppressWarnings("NullAway")` | Warnings suppressed | Method remains `@NullMarked` — callers get full null checking                              |
+| `@NullUnmarked`                 | Warnings suppressed | Parameters and return types have **unknown** nullability — callers also lose null checking |
 
-**Prefer `@SuppressWarnings("NullAway")`** when you want to silence a false positive inside a method without degrading the caller experience. Use `@NullUnmarked` only for classes/methods not yet migrated to null safety.
+**Prefer `@SuppressWarnings("NullAway")`** when you want to silence a false
+positive inside a method without degrading the caller experience. Use
+`@NullUnmarked` only for classes/methods not yet migrated to null safety.
 
 ---
 
@@ -892,7 +1027,8 @@ public class MyComponent {
 
 ## ❌ Don't Use Intermediate Booleans for Null Checks
 
-**NullAway cannot track nullness through intermediate boolean variables.** Always use the null check directly in the `if` condition.
+**NullAway cannot track nullness through intermediate boolean variables.**
+Always use the null check directly in the `if` condition.
 
 ```java
 // ❌ WRONG - NullAway loses track of nullness
@@ -907,7 +1043,8 @@ if (thing != null) {
 }
 ```
 
-This is a known NullAway limitation: [NullAway#98](https://github.com/uber/NullAway/issues/98).
+This is a known NullAway limitation:
+[NullAway#98](https://github.com/uber/NullAway/issues/98).
 
 ---
 
@@ -915,9 +1052,12 @@ This is a known NullAway limitation: [NullAway#98](https://github.com/uber/NullA
 
 ## ✅ JNI: `@CalledByNative` Skips Checks, Java-to-Native Is Checked
 
-**Nullness is not checked for `@CalledByNative` methods** ([crbug/389192501](https://crbug.com/389192501)). However, Java-to-Native method calls **are checked** via `assert` statements when `@NullMarked` is present.
+**Nullness is not checked for `@CalledByNative` methods**
+([crbug/389192501](https://crbug.com/389192501)). However, Java-to-Native method
+calls **are checked** via `assert` statements when `@NullMarked` is present.
 
-Ensure native-bound parameters have correct nullability annotations so that callers on the Java side are properly checked.
+Ensure native-bound parameters have correct nullability annotations so that
+callers on the Java side are properly checked.
 
 ---
 
@@ -925,7 +1065,9 @@ Ensure native-bound parameters have correct nullability annotations so that call
 
 ## ✅ Use JSpecify Annotations for Mirrored Code
 
-**For code that will be mirrored and built in other environments, use JSpecify annotations directly** instead of Chromium's copies under `org.chromium.build.annotations`. Configure the build target accordingly:
+**For code that will be mirrored and built in other environments, use JSpecify
+annotations directly** instead of Chromium's copies under
+`org.chromium.build.annotations`. Configure the build target accordingly:
 
 ```gn
 deps += [ "//third_party/android_deps:org_jspecify_jspecify_java" ]
@@ -943,8 +1085,21 @@ enable_errorprone = true
 
 ## ✅ Prefer Material Components Over Custom Reimplementations
 
-**When a Material component exists for the UI element, use it instead of building a custom version.** Material components carry built-in motion, accessibility, and theming that hand-rolled `View` subclasses almost always miss. Common cases: `MaterialSwitch` over custom toggles, `MaterialButton` over styled `Button`, `BottomSheetDialogFragment` over hand-rolled sheets, `MaterialAlertDialogBuilder` over custom modal views, `Snackbar`, `Chip`, `TextInputLayout`, `MaterialCardView`.
+**When a Material component exists for the UI element, use it instead of
+building a custom version.** Material components carry built-in motion,
+accessibility, and theming that hand-rolled `View` subclasses almost always
+miss. Common cases: `MaterialSwitch` over custom toggles, `MaterialButton` over
+styled `Button`, `BottomSheetDialogFragment` over hand-rolled sheets,
+`MaterialAlertDialogBuilder` over custom modal views, `Snackbar`, `Chip`,
+`TextInputLayout`, `MaterialCardView`.
 
-**Brave subclasses are fine, and often required.** A class like `BraveSettingsSwitch extends MaterialSwitch` is the correct pattern, not a violation — it's how Brave adds theming or telemetry on top of Material. If a Brave subclass exists in the module, callers should use it instead of the raw Material class.
+**Brave subclasses are fine, and often required.** A class like
+`BraveSettingsSwitch extends MaterialSwitch` is the correct pattern, not a
+violation — it's how Brave adds theming or telemetry on top of Material. If a
+Brave subclass exists in the module, callers should use it instead of the raw
+Material class.
 
-**Flag as `nit:` only, never a blocker.** Ask why Material wasn't used; the author may have a valid constraint that just isn't documented. Before flagging, verify the flagged class does **not** extend any `com.google.android.material.*` component (check the full class hierarchy, not just the file in the diff).
+**Flag as `nit:` only, never a blocker.** Ask why Material wasn't used; the
+author may have a valid constraint that just isn't documented. Before flagging,
+verify the flagged class does **not** extend any `com.google.android.material.*`
+component (check the full class hierarchy, not just the file in the diff).

--- a/docs/best-practices/architecture.md
+++ b/docs/best-practices/architecture.md
@@ -4,7 +4,8 @@
 
 ## Chromium Dependency Layer Hierarchy
 
-All Chromium code is organized into layers with strict downward-only dependencies. **Code in a lower layer must never depend on a higher layer.**
+All Chromium code is organized into layers with strict downward-only
+dependencies. **Code in a lower layer must never depend on a higher layer.**
 
 ```
 ┌─────────────────────────────────────────────────────┐
@@ -21,11 +22,16 @@ All Chromium code is organized into layers with strict downward-only dependencie
 ```
 
 **Key rules:**
+
 - Dependencies flow **downward only** — never upward
-- `//components` is for optional features shared across multiple embedders (Chrome, Android WebView, iOS, etc.)
-- Components may depend on `//content`, `//net`, `//base`, and other components — but never on embedder code (`//chrome`, `//android_webview`)
-- Components shared with iOS must either have **zero `//content` dependencies** or use a **layered component structure** (`core/` + `content/`)
-- In Brave: `brave/browser/` is the embedder layer, `brave/components/` is the components layer. The same downward-only rules apply.
+- `//components` is for optional features shared across multiple embedders
+  (Chrome, Android WebView, iOS, etc.)
+- Components may depend on `//content`, `//net`, `//base`, and other components
+  — but never on embedder code (`//chrome`, `//android_webview`)
+- Components shared with iOS must either have **zero `//content` dependencies**
+  or use a **layered component structure** (`core/` + `content/`)
+- In Brave: `brave/browser/` is the embedder layer, `brave/components/` is the
+  components layer. The same downward-only rules apply.
 
 ---
 
@@ -33,11 +39,15 @@ All Chromium code is organized into layers with strict downward-only dependencie
 
 ## ❌ No Layering Violations - Components Cannot Depend on Browser
 
-**Code in `components/` must never use `g_browser_process` or depend on `brave/browser/`.**
+**Code in `components/` must never use `g_browser_process` or depend on
+`brave/browser/`.**
 
-This is a Chromium layering violation. Components are lower-level and must not reference browser-layer code. Fix by passing dependencies via injection (constructor params, `Init()` methods, callbacks).
+This is a Chromium layering violation. Components are lower-level and must not
+reference browser-layer code. Fix by passing dependencies via injection
+(constructor params, `Init()` methods, callbacks).
 
 **BAD:**
+
 ```cpp
 // ❌ WRONG - components/ code using g_browser_process
 // In components/p3a/p3a_service.cc
@@ -48,6 +58,7 @@ void P3AService::Init() {
 ```
 
 **GOOD:**
+
 ```cpp
 // ✅ CORRECT - dependency injected via Init()
 // In components/p3a/p3a_service.cc
@@ -57,10 +68,13 @@ void P3AService::Init(
 }
 ```
 
-Similarly, code in `components/safe_browsing/` cannot have `brave/browser/` deps. Separate browser-dependent callbacks from component code.
+Similarly, code in `components/safe_browsing/` cannot have `brave/browser/`
+deps. Separate browser-dependent callbacks from component code.
 
 **Specific rules:**
-- Never use `Profile` in components - pass `PrefService` instead (use `user_prefs::UserPrefs::Get(browser_context)`)
+
+- Never use `Profile` in components - pass `PrefService` instead (use
+  `user_prefs::UserPrefs::Get(browser_context)`)
 - Never include `brave/browser/` or `chrome/browser/` from `components/`
 - Use `BrowserContext` instead of `Profile` in components
 
@@ -70,7 +84,10 @@ Similarly, code in `components/safe_browsing/` cannot have `brave/browser/` deps
 
 ## ✅ Pass the Most Specific Dependency, Not "Bag of Stuff" Objects
 
-**Always pass the most fundamental object a function actually needs, not a broader object it could extract it from.** This follows from the Chromium componentization cookbook: "Pass the most fundamental objects possible, rather than passing more complex 'everything' or 'bag of stuff' objects."
+**Always pass the most fundamental object a function actually needs, not a
+broader object it could extract it from.** This follows from the Chromium
+componentization cookbook: "Pass the most fundamental objects possible, rather
+than passing more complex 'everything' or 'bag of stuff' objects."
 
 ```cpp
 // ❌ WRONG - passing Profile when only prefs are needed
@@ -85,9 +102,11 @@ void MyComponent::Init(PrefService* prefs) {
 ```
 
 Common substitutions:
+
 - `Profile*` → `PrefService*` (when only prefs are needed)
 - `Profile*` → `BrowserContext*` (in components)
-- `BrowserContext*` → `scoped_refptr<URLLoaderFactory>` (when only network is needed)
+- `BrowserContext*` → `scoped_refptr<URLLoaderFactory>` (when only network is
+  needed)
 
 ---
 
@@ -95,11 +114,16 @@ Common substitutions:
 
 ## ✅ Prefer Internal Feature Guards Over External Ifdefs
 
-**Code should handle disabled features internally rather than requiring external `#ifdef` guards.**
+**Code should handle disabled features internally rather than requiring external
+`#ifdef` guards.**
 
-When a feature can be disabled, prefer making the factory/service return null or no-op when disabled, rather than requiring callers to wrap every usage in `#ifdef` guards. Scattered buildflags lead to missing deps and maintenance burden.
+When a feature can be disabled, prefer making the factory/service return null or
+no-op when disabled, rather than requiring callers to wrap every usage in
+`#ifdef` guards. Scattered buildflags lead to missing deps and maintenance
+burden.
 
 **BAD:**
+
 ```cpp
 // ❌ WRONG - external ifdef guards everywhere
 #if BUILDFLAG(BRAVE_REWARDS_ENABLED)
@@ -109,6 +133,7 @@ When a feature can be disabled, prefer making the factory/service return null or
 ```
 
 **GOOD:**
+
 ```cpp
 // ✅ CORRECT - factory handles disabled state internally
 auto* rewards_service = RewardsServiceFactory::GetForProfile(profile);
@@ -125,9 +150,12 @@ if (rewards_service) {  // Returns null when disabled
 
 **Don't use `shared_ptr` to take ownership of something you don't own.**
 
-Using `shared_ptr` on memory owned by another class causes crashes when the `shared_ptr` frees memory that is still referenced elsewhere. Avoid shared pointers unless there is a strong reason for shared ownership.
+Using `shared_ptr` on memory owned by another class causes crashes when the
+`shared_ptr` frees memory that is still referenced elsewhere. Avoid shared
+pointers unless there is a strong reason for shared ownership.
 
 **BAD:**
+
 ```cpp
 // ❌ WRONG - taking ownership of an unowned resource
 void Init(network::ResourceRequest& request) {
@@ -137,6 +165,7 @@ void Init(network::ResourceRequest& request) {
 ```
 
 **GOOD:**
+
 ```cpp
 // ✅ CORRECT - pass by reference or raw pointer for unowned resources
 void Init(const network::ResourceRequest& request) {
@@ -150,7 +179,9 @@ void Init(const network::ResourceRequest& request) {
 
 ## Thread Safety - Service Method Calls
 
-**Calling service methods from the wrong thread causes crashes.** Always verify which thread a method expects to be called on. This is especially important for ad-block and shields services.
+**Calling service methods from the wrong thread causes crashes.** Always verify
+which thread a method expects to be called on. This is especially important for
+ad-block and shields services.
 
 ---
 
@@ -158,7 +189,9 @@ void Init(const network::ResourceRequest& request) {
 
 ## ❌ Never Access Internal/Vendor Headers Directly
 
-**Never use `#include "brave/vendor/..."` to access internal headers.** Internal headers are not part of the public API and should not be accessed using full paths to bypass visibility.
+**Never use `#include "brave/vendor/..."` to access internal headers.** Internal
+headers are not part of the public API and should not be accessed using full
+paths to bypass visibility.
 
 ```cpp
 // ❌ WRONG - accessing internal vendor headers directly
@@ -174,7 +207,9 @@ void Init(const network::ResourceRequest& request) {
 
 ## ✅ Use Pref Change Registrar Instead of Custom Observers
 
-**Use the existing `pref_change_registrar_` pattern for observing pref changes.** Don't create custom observer interfaces when the pref change registrar already handles this.
+**Use the existing `pref_change_registrar_` pattern for observing pref
+changes.** Don't create custom observer interfaces when the pref change
+registrar already handles this.
 
 ```cpp
 // ❌ WRONG - custom observer for pref changes
@@ -188,7 +223,8 @@ pref_change_registrar_.Add(
     base::BindRepeating(&MyClass::OnPrefChanged, base::Unretained(this)));
 ```
 
-Also: check if the superclass already has a `pref_change_registrar_` before adding a new one.
+Also: check if the superclass already has a `pref_change_registrar_` before
+adding a new one.
 
 ---
 
@@ -196,7 +232,8 @@ Also: check if the superclass already has a `pref_change_registrar_` before addi
 
 ## ❌ Don't Duplicate Pref Storage
 
-**Don't cache pref values in member variables when you can just read the pref at call time.**
+**Don't cache pref values in member variables when you can just read the pref at
+call time.**
 
 ```cpp
 // ❌ WRONG - duplicating pref storage
@@ -218,7 +255,8 @@ bool IsOptedIn() { return prefs_->GetBoolean(kOptedIn); }
 
 ### ✅ Use DependsOn for Factory Dependencies
 
-**If your KeyedServiceFactory depends on other services, declare it with `DependsOn`.** This ensures proper initialization order.
+**If your KeyedServiceFactory depends on other services, declare it with
+`DependsOn`.** This ensures proper initialization order.
 
 ```cpp
 MyServiceFactory::MyServiceFactory()
@@ -232,13 +270,15 @@ MyServiceFactory::MyServiceFactory()
 
 ### ✅ Return Null for Incognito Profiles
 
-**If a service shouldn't be active in incognito, return null from `GetForProfile` rather than overriding `GetBrowserContextToUse`.**
+**If a service shouldn't be active in incognito, return null from
+`GetForProfile` rather than overriding `GetBrowserContextToUse`.**
 
 <a id="ARCH-013"></a>
 
 ### ❌ Components Don't Need Their Own Component Manager
 
-**Each component does not need its own component manager.** Use a component installer policy instead.
+**Each component does not need its own component manager.** Use a component
+installer policy instead.
 
 ---
 
@@ -246,7 +286,8 @@ MyServiceFactory::MyServiceFactory()
 
 ## ✅ Use Abstract Base Classes to Avoid Layering Violations
 
-**When browser-layer code needs to be accessed from components, create an abstract base class in components and implement it in browser.**
+**When browser-layer code needs to be accessed from components, create an
+abstract base class in components and implement it in browser.**
 
 ```cpp
 // ✅ In components/ - abstract interface
@@ -269,7 +310,10 @@ Then cast to the abstract type in components without a layering violation.
 
 ## ❌ Don't Initialize Services for Wrong Profile Types
 
-**Never initialize services for profile types they shouldn't support.** For example, never initialize Rewards service for incognito profiles. The `GetBrowserContextToUse` method in factories must correctly return null for unsupported profile types.
+**Never initialize services for profile types they shouldn't support.** For
+example, never initialize Rewards service for incognito profiles. The
+`GetBrowserContextToUse` method in factories must correctly return null for
+unsupported profile types.
 
 ```cpp
 // ❌ WRONG - returns the profile even for incognito
@@ -293,9 +337,12 @@ content::BrowserContext* GetBrowserContextToUse(
 
 ## ✅ Reuse Existing Services and Singletons
 
-**Check for existing services and singletons before creating new ones.** Don't create duplicate singletons for the same purpose (e.g., don't create a new locale helper when `brave_ads::LocaleHelper` already exists).
+**Check for existing services and singletons before creating new ones.** Don't
+create duplicate singletons for the same purpose (e.g., don't create a new
+locale helper when `brave_ads::LocaleHelper` already exists).
 
-**Use observers for decoupled notifications instead of adding direct cross-service calls.**
+**Use observers for decoupled notifications instead of adding direct
+cross-service calls.**
 
 ---
 
@@ -303,7 +350,8 @@ content::BrowserContext* GetBrowserContextToUse(
 
 ## ✅ Encapsulate Cleanup in the Owning Class
 
-**Cleanup logic (like deleting files) should be encapsulated in the class that owns the resource.** Don't spread cleanup code across multiple callers.
+**Cleanup logic (like deleting files) should be encapsulated in the class that
+owns the resource.** Don't spread cleanup code across multiple callers.
 
 ```cpp
 // ❌ WRONG - caller handles cleanup details
@@ -320,7 +368,8 @@ tor_client_updater()->Cleanup();
 
 ## ✅ File Organization by Component
 
-**Group files by component, not by platform.** For example, `brave_rewards/android/` is preferred over `android/rewards/`.
+**Group files by component, not by platform.** For example,
+`brave_rewards/android/` is preferred over `android/rewards/`.
 
 ```
 # ❌ WRONG
@@ -330,7 +379,8 @@ brave/browser/android/rewards/brave_rewards_native_worker.cc
 brave/browser/brave_rewards/android/brave_rewards_native_worker.cc
 ```
 
-This keeps related code together and is consistent with Chromium patterns like `chrome/browser/history/android/`.
+This keeps related code together and is consistent with Chromium patterns like
+`chrome/browser/history/android/`.
 
 ---
 
@@ -338,7 +388,8 @@ This keeps related code together and is consistent with Chromium patterns like `
 
 ## ✅ Exclude Entire Feature API from GN When Disabled
 
-**When a feature is disabled via buildflag, exclude the entire API from the build.** Don't leave API declarations with no implementation.
+**When a feature is disabled via buildflag, exclude the entire API from the
+build.** Don't leave API declarations with no implementation.
 
 ```gn
 # ❌ WRONG - API always built, implementation conditionally empty
@@ -360,9 +411,14 @@ if (brave_wallet_enabled) {
 
 ## ✅ Use Friend Class for Test/Private Access
 
-**When tests or other classes need access to private members, use `friend` declarations instead of making methods public or protected.** This rule is about bypassing access control for convenience. It does not apply to normal inheritance where a subclass calls inherited protected methods or exposes new public methods that delegate to them.
+**When tests or other classes need access to private members, use `friend`
+declarations instead of making methods public or protected.** This rule is about
+bypassing access control for convenience. It does not apply to normal
+inheritance where a subclass calls inherited protected methods or exposes new
+public methods that delegate to them.
 
-This rule does not apply to `*ForTesting()` methods, which are an accepted Chromium convention for exposing test-only accessors.
+This rule does not apply to `*ForTesting()` methods, which are an accepted
+Chromium convention for exposing test-only accessors.
 
 ```cpp
 // ❌ WRONG - making methods public just for testing
@@ -375,7 +431,9 @@ private:
   void InternalMethod();
 ```
 
-To add a friend declaration to an upstream class, use a `#define` in a chromium_src header override that piggybacks the friend declaration onto an existing method name:
+To add a friend declaration to an upstream class, use a `#define` in a
+chromium_src header override that piggybacks the friend declaration onto an
+existing method name:
 
 ```cpp
 // chromium_src/chrome/browser/extensions/component_loader.h
@@ -394,7 +452,9 @@ To add a friend declaration to an upstream class, use a `#define` in a chromium_
 
 ## ✅ Callbacks for Queries, Observers for State Changes
 
-**Observer methods should only be triggered by state changes (Set/Create/Delete), never by query responses (Get/Fetch).** Use callbacks for query responses.
+**Observer methods should only be triggered by state changes
+(Set/Create/Delete), never by query responses (Get/Fetch).** Use callbacks for
+query responses.
 
 ```cpp
 // ❌ WRONG - observer triggered by a query
@@ -424,7 +484,8 @@ void RewardsService::SetRecurringDonation(amount) {
 
 ## ❌ Don't Expose Internal Library Types in Public Headers
 
-**Never expose internal implementation types in public component headers.** Use the component's public API types (e.g., Mojo types) instead.
+**Never expose internal implementation types in public component headers.** Use
+the component's public API types (e.g., Mojo types) instead.
 
 ```cpp
 // ❌ WRONG - internal database types in public rewards header
@@ -442,7 +503,8 @@ void DoSomething(mojom::PublisherInfoPtr info);
 
 ## ✅ source_set Name Should Match Directory
 
-**GN source_set names should match their directory name.** This makes paths predictable and readable.
+**GN source_set names should match their directory name.** This makes paths
+predictable and readable.
 
 ```gn
 # ❌ WRONG
@@ -461,7 +523,10 @@ source_set("browser") { ... }
 
 ## ✅ Use `CHECK_IS_TEST` for Null Checks That Should Only Occur in Tests
 
-**When a pointer should never be null in production but may be null in certain test configurations, use `CHECK_IS_TEST()` before the null check.** This documents that the null case is test-only and prevents confusion about whether null is a valid production state.
+**When a pointer should never be null in production but may be null in certain
+test configurations, use `CHECK_IS_TEST()` before the null check.** This
+documents that the null case is test-only and prevents confusion about whether
+null is a valid production state.
 
 ```cpp
 // ❌ WRONG - ambiguous null check
@@ -481,7 +546,9 @@ if (!service) {
 
 ## ✅ Pass Dependencies via Constructors, Not Setter Callbacks
 
-**When a service needs a dependency, pass it through the constructor rather than using a separate `Set*Callback` method.** Constructor injection makes dependencies explicit and avoids confusing initialization ordering.
+**When a service needs a dependency, pass it through the constructor rather than
+using a separate `Set*Callback` method.** Constructor injection makes
+dependencies explicit and avoids confusing initialization ordering.
 
 ```cpp
 // ❌ WRONG - setting callback from an unrelated factory
@@ -502,7 +569,10 @@ BraveVPNConnectionManager::BraveVPNConnectionManager(
 
 ## ✅ Use `ServiceIsNULLWhileTesting` for Optional Keyed Services
 
-**When a `KeyedService` should not be created during unit tests that don't provide the required dependencies, override `ServiceIsNULLWhileTesting()` to return `true` in the factory.** This is cleaner than scattering null checks throughout the codebase.
+**When a `KeyedService` should not be created during unit tests that don't
+provide the required dependencies, override `ServiceIsNULLWhileTesting()` to
+return `true` in the factory.** This is cleaner than scattering null checks
+throughout the codebase.
 
 ```cpp
 // ❌ WRONG - null checks scattered everywhere
@@ -522,7 +592,9 @@ bool MyServiceFactory::ServiceIsNULLWhileTesting() const {
 
 ## ❌ Never Call `GetOriginalProfile()` to Bypass Factory Checks
 
-**Never call `GetOriginalProfile()` or similar methods to circumvent factory profile checks.** If a factory returns null for a given profile type, that profile is not supposed to use the service. Respect the factory's decision.
+**Never call `GetOriginalProfile()` or similar methods to circumvent factory
+profile checks.** If a factory returns null for a given profile type, that
+profile is not supposed to use the service. Respect the factory's decision.
 
 ```cpp
 // ❌ WRONG - circumventing factory profile checks
@@ -542,7 +614,10 @@ if (!service)
 
 ## ✅ Use `MaybeCreateForWebContents` for Conditional Tab Helpers
 
-**When a tab helper should not be attached to all web contents (e.g., skipped for incognito or when a feature is disabled), use a static `MaybeCreateForWebContents` method** with the appropriate guards instead of always creating and checking internally.
+**When a tab helper should not be attached to all web contents (e.g., skipped
+for incognito or when a feature is disabled), use a static
+`MaybeCreateForWebContents` method** with the appropriate guards instead of
+always creating and checking internally.
 
 ```cpp
 // ❌ WRONG - always create, check internally
@@ -566,7 +641,9 @@ static void MaybeCreateForWebContents(content::WebContents* web_contents) {
 
 ## ✅ Use `ProfileKeyedServiceFactory` for New Desktop Factories
 
-**New keyed service factories on desktop should inherit from `ProfileKeyedServiceFactory`** rather than the older `BrowserContextKeyedServiceFactory`. See the Brave keyed services documentation.
+**New keyed service factories on desktop should inherit from
+`ProfileKeyedServiceFactory`** rather than the older
+`BrowserContextKeyedServiceFactory`. See the Brave keyed services documentation.
 
 ---
 
@@ -574,13 +651,17 @@ static void MaybeCreateForWebContents(content::WebContents* web_contents) {
 
 ## ✅ Guard Significant or Experimental New Functionality Behind `base::Feature`
 
-**Significant new features and experimental functionality should be guarded behind a `base::Feature` flag** so they can be remotely disabled via Griffin if issues arise. Use judgment -- not every change needs a feature flag. Feature flags are most valuable for:
+**Significant new features and experimental functionality should be guarded
+behind a `base::Feature` flag** so they can be remotely disabled via Griffin if
+issues arise. Use judgment -- not every change needs a feature flag. Feature
+flags are most valuable for:
 
 - Large or complex features with broad impact
 - Experimental or risky functionality that may need to be rolled back
 - Features where remote disabling provides a meaningful safety net
 
-Small, self-contained changes and simple bug fixes typically do not need a runtime feature flag.
+Small, self-contained changes and simple bug fixes typically do not need a
+runtime feature flag.
 
 ```cpp
 // ❌ WRONG - no feature guard, crash can't be remotely disabled
@@ -602,7 +683,9 @@ service->DoSomething();
 
 ## ✅ Unify Platform-Specific Delegates
 
-**When implementing functionality for both Android and desktop, unify the code in a single delegate** rather than duplicating it across platforms. Extract only the platform-specific parts (like tab handling) into the delegate interface.
+**When implementing functionality for both Android and desktop, unify the code
+in a single delegate** rather than duplicating it across platforms. Extract only
+the platform-specific parts (like tab handling) into the delegate interface.
 
 ```cpp
 // ❌ WRONG - duplicated logic
@@ -622,7 +705,9 @@ class UnifiedDelegate {
 
 ## ❌ Don't Silently Fall Back on Unknown Types
 
-**When handling unknown/unsupported types, prefer an explicit error rather than silently falling back to a default.** Silent fallbacks mask bugs and make debugging harder.
+**When handling unknown/unsupported types, prefer an explicit error rather than
+silently falling back to a default.** Silent fallbacks mask bugs and make
+debugging harder.
 
 ```cpp
 // ❌ WRONG - silently treats unknown files as images
@@ -645,7 +730,9 @@ std::optional<FileType> GetFileType(const std::string& mime) {
 
 ## ✅ Separate Lifecycle Events from Data Change Events in Mojo
 
-**A Mojo `Changed` event should only fire when actual data changes occur.** Don't conflate lifecycle events (model loading, listener registration) with data mutation events. Provide separate events.
+**A Mojo `Changed` event should only fire when actual data changes occur.**
+Don't conflate lifecycle events (model loading, listener registration) with data
+mutation events. Provide separate events.
 
 ```cpp
 // ❌ WRONG - Changed fires on initialization, not actual change
@@ -666,7 +753,9 @@ interface BookmarksListener {
 
 ## ✅ Use `base::BarrierCallback` for Parallel Async Aggregation
 
-**Use `base::BarrierCallback` to aggregate results from multiple parallel async operations** rather than manually tracking completion counts. This simplifies multi-callback aggregation.
+**Use `base::BarrierCallback` to aggregate results from multiple parallel async
+operations** rather than manually tracking completion counts. This simplifies
+multi-callback aggregation.
 
 ```cpp
 // ❌ WRONG - manual tracking
@@ -691,7 +780,10 @@ service3->Fetch(barrier);
 
 ## ❌ Mojom Enums Must Be Top-Level When Targeting iOS
 
-**Mojom enums cannot be nested inside mojom structs when the target includes iOS.** The Objective-C++ code generator produces invalid code for nested enums (`common.mojom.objc.mm` build failure). Always define mojom enums at the top level of the `.mojom` file.
+**Mojom enums cannot be nested inside mojom structs when the target includes
+iOS.** The Objective-C++ code generator produces invalid code for nested enums
+(`common.mojom.objc.mm` build failure). Always define mojom enums at the top
+level of the `.mojom` file.
 
 ```mojom
 // ❌ WRONG - nested enum breaks iOS build
@@ -720,7 +812,10 @@ struct ModelConfig {
 
 ## ❌ No Content-Layer Dependencies for iOS-Targeted Components
 
-**Components that must build for iOS (like `brave_wallet`) cannot depend on content-layer types** (`content::WebContents`, `content::BrowserContext`). iOS uses WebKit, not Chromium's content layer. Pass specific dependencies (`PrefService*`, `URLLoaderFactory`) instead.
+**Components that must build for iOS (like `brave_wallet`) cannot depend on
+content-layer types** (`content::WebContents`, `content::BrowserContext`). iOS
+uses WebKit, not Chromium's content layer. Pass specific dependencies
+(`PrefService*`, `URLLoaderFactory`) instead.
 
 ---
 
@@ -728,7 +823,10 @@ struct ModelConfig {
 
 ## ✅ Use Layered Component Structure (`core/` + `content/`) for iOS-Compatible Components
 
-**When a component needs to work on both iOS and content-based platforms, use a layered component structure.** Split the component into `core/` (iOS-compatible, no `//content` dependency) and `content/` (uses `//content` APIs). This follows the Chromium componentization cookbook pattern.
+**When a component needs to work on both iOS and content-based platforms, use a
+layered component structure.** Split the component into `core/` (iOS-compatible,
+no `//content` dependency) and `content/` (uses `//content` APIs). This follows
+the Chromium componentization cookbook pattern.
 
 ```
 components/brave_shields/
@@ -742,6 +840,7 @@ components/brave_shields/
 ```
 
 **Rules:**
+
 - `core/` must never depend on `//content` or `content/` subdirectories
 - `content/` may depend on `core/` and `//content`
 - iOS builds only pull in `core/`
@@ -753,7 +852,10 @@ components/brave_shields/
 
 ## ❌ No Circular Dependencies Between Components
 
-**Component dependencies must form a strictly tree-shaped graph — no circular dependencies.** If component A depends on component B, then B must never depend on A (directly or transitively). Use delegate interfaces or observers to break cycles.
+**Component dependencies must form a strictly tree-shaped graph — no circular
+dependencies.** If component A depends on component B, then B must never depend
+on A (directly or transitively). Use delegate interfaces or observers to break
+cycles.
 
 ---
 
@@ -761,7 +863,9 @@ components/brave_shields/
 
 ## ✅ Service/Decoder Code Belongs in `services/` Not `components/.../browser/`
 
-**Mojo service implementations and data decoders should live in a `services/` directory**, not inside `components/.../browser/`. This follows Chromium conventions and keeps service code at the correct architectural layer.
+**Mojo service implementations and data decoders should live in a `services/`
+directory**, not inside `components/.../browser/`. This follows Chromium
+conventions and keeps service code at the correct architectural layer.
 
 ---
 
@@ -769,12 +873,17 @@ components/brave_shields/
 
 ## ❌ Utility Process Code Must Not Depend on Browser Process Code
 
-**Code that runs in the utility process must never depend on browser process code.** Any code shared between the browser process and the utility process must live in a `common/` directory, not a `browser/` directory.
+**Code that runs in the utility process must never depend on browser process
+code.** Any code shared between the browser process and the utility process must
+live in a `common/` directory, not a `browser/` directory.
 
-This is a multi-process architecture boundary. The utility process (where sandboxed services run) is a separate process from the browser process, and dependency direction must be respected:
+This is a multi-process architecture boundary. The utility process (where
+sandboxed services run) is a separate process from the browser process, and
+dependency direction must be respected:
 
 - `components/.../browser/` — browser process only
-- `components/.../common/` — shared between processes (browser, utility, renderer)
+- `components/.../common/` — shared between processes (browser, utility,
+  renderer)
 - `components/services/...` — utility process service implementations
 
 ```
@@ -791,7 +900,8 @@ deps = [
 ]
 ```
 
-When code needs to be used by both processes, move it from `browser/` to `common/`.
+When code needs to be used by both processes, move it from `browser/` to
+`common/`.
 
 ---
 
@@ -799,7 +909,10 @@ When code needs to be used by both processes, move it from `browser/` to `common
 
 ## ✅ Prefer Static Singleton Over KeyedService When No Profile Dependency
 
-**When a service has no per-profile state and doesn't depend on profile-specific data, use a static singleton with `base::NoDestructor` instead of a `KeyedService`.** KeyedService adds unnecessary complexity when there's no profile dependency.
+**When a service has no per-profile state and doesn't depend on profile-specific
+data, use a static singleton with `base::NoDestructor` instead of a
+`KeyedService`.** KeyedService adds unnecessary complexity when there's no
+profile dependency.
 
 ```cpp
 // ❌ WRONG - KeyedService for profile-independent data
@@ -821,7 +934,9 @@ class ModelListService {
 
 ## ✅ Flag Destructive Pref Operations for UX Review
 
-**Operations that delete user data (clearing preferences, wiping storage) must be flagged for UX review before implementation.** Silent data deletion is a poor user experience and may violate user expectations.
+**Operations that delete user data (clearing preferences, wiping storage) must
+be flagged for UX review before implementation.** Silent data deletion is a poor
+user experience and may violate user expectations.
 
 ---
 
@@ -829,7 +944,9 @@ class ModelListService {
 
 ## ✅ Use Pre-Allocated Vectors for Ordered Async Results
 
-**When aggregating results from multiple parallel async calls that must maintain order, pre-allocate a vector and insert results by index** rather than using a map and sorting later.
+**When aggregating results from multiple parallel async calls that must maintain
+order, pre-allocate a vector and insert results by index** rather than using a
+map and sorting later.
 
 ```cpp
 // ❌ WRONG - map loses original order
@@ -847,7 +964,10 @@ results_[request_index] = std::move(result);
 
 ## ✅ Use Existing Mojom Types Instead of Duplicating in C++
 
-**When mojom types already describe the data shape, use them directly in C++ instead of creating redundant C++ struct types.** Duplicating types creates a synchronization burden and increases the risk of the two definitions drifting apart.
+**When mojom types already describe the data shape, use them directly in C++
+instead of creating redundant C++ struct types.** Duplicating types creates a
+synchronization burden and increases the risk of the two definitions drifting
+apart.
 
 ```cpp
 // ❌ WRONG - redundant C++ struct
@@ -867,7 +987,9 @@ void RegisterTool(mojom::ToolConfigPtr config);
 
 ## ❌ Don't Expose Cache Keys in API Interfaces
 
-**Internal cache keys should not leak into public API interfaces.** Auto-generate unique cache keys internally rather than requiring callers to provide or manage them.
+**Internal cache keys should not leak into public API interfaces.**
+Auto-generate unique cache keys internally rather than requiring callers to
+provide or manage them.
 
 ```cpp
 // ❌ WRONG - caller must know about cache keys
@@ -885,7 +1007,10 @@ void FetchData(const std::string& url, Callback cb);
 
 ## ✅ Reorder Data for UI Presentation on Client Side
 
-**Data reordering for UI presentation (sorting, grouping, prioritizing) belongs in the client/UI layer, not in the core data layer or API response.** The backend should return data in its canonical order; the frontend transforms it for display.
+**Data reordering for UI presentation (sorting, grouping, prioritizing) belongs
+in the client/UI layer, not in the core data layer or API response.** The
+backend should return data in its canonical order; the frontend transforms it
+for display.
 
 ---
 
@@ -893,7 +1018,10 @@ void FetchData(const std::string& url, Callback cb);
 
 ## ✅ Mojom Interface Naming Should Be UI-Framework Agnostic
 
-**When defining Mojom interfaces that could be consumed by different UI frameworks (WebUI, native iOS, etc.), avoid framework-specific naming like "PageHandler".** Use more neutral naming like "UIHandler" to remain consistent and not imply a web-only interface.
+**When defining Mojom interfaces that could be consumed by different UI
+frameworks (WebUI, native iOS, etc.), avoid framework-specific naming like
+"PageHandler".** Use more neutral naming like "UIHandler" to remain consistent
+and not imply a web-only interface.
 
 ```mojom
 // ❌ WRONG - implies web-only
@@ -909,7 +1037,11 @@ interface HistoryUIHandler { ... };
 
 ## ✅ Use Mojo Interfaces for Trusted/Untrusted WebUI Communication
 
-**When communicating between trusted and untrusted WebUI frames, use a mojo interface rather than `postMessage`.** The Chromium documentation advises against `postMessage` across trust boundaries. Only avoid mojo when the frame intentionally executes untrusted code and reducing API surface is a deliberate security choice.
+**When communicating between trusted and untrusted WebUI frames, use a mojo
+interface rather than `postMessage`.** The Chromium documentation advises
+against `postMessage` across trust boundaries. Only avoid mojo when the frame
+intentionally executes untrusted code and reducing API surface is a deliberate
+security choice.
 
 ---
 
@@ -917,7 +1049,9 @@ interface HistoryUIHandler { ... };
 
 ## ✅ Gate UI Restrictions at UI Layer, Not in Core Utility Functions
 
-**UI-specific restrictions should be gated at the UI layer, not in core utility functions.** Coupling core logic (like `IsFeatureEnabled()`) to UI state (like WebUI availability) creates unexpected test failures and tight coupling.
+**UI-specific restrictions should be gated at the UI layer, not in core utility
+functions.** Coupling core logic (like `IsFeatureEnabled()`) to UI state (like
+WebUI availability) creates unexpected test failures and tight coupling.
 
 ```cpp
 // ❌ WRONG - core utility coupled to UI state
@@ -939,7 +1073,10 @@ bool IsZCashShieldedTransactionsEnabled() {
 
 ## ✅ Policy-Disabled Features: Hide UI Entirely
 
-**When a feature is disabled by admin policy with ENFORCED enforcement, hide the UI entirely** rather than just disabling/greying out controls. For RECOMMENDED policies, the UI should still be visible since the user can override. On macOS, `defaults write` creates RECOMMENDED level policies, not MANDATORY.
+**When a feature is disabled by admin policy with ENFORCED enforcement, hide the
+UI entirely** rather than just disabling/greying out controls. For RECOMMENDED
+policies, the UI should still be visible since the user can override. On macOS,
+`defaults write` creates RECOMMENDED level policies, not MANDATORY.
 
 ```cpp
 // ❌ WRONG - just disabling controls
@@ -960,7 +1097,9 @@ if (IsFeatureManaged() &&
 
 ## ✅ Check Value Changed Before Firing State Notifications
 
-**Before calling observer notification methods, check if the value actually changed.** Store the old value, update, then compare. This avoids unnecessary observer notifications and potential re-renders.
+**Before calling observer notification methods, check if the value actually
+changed.** Store the old value, update, then compare. This avoids unnecessary
+observer notifications and potential re-renders.
 
 ```cpp
 // ❌ WRONG - always notifies even when value unchanged
@@ -981,7 +1120,12 @@ if (old_value != visual_content_used_percentage_) {
 
 ## ❌ Avoid Cross-Feature Module Dependencies
 
-**Feature modules should not import classes from other unrelated feature modules.** For example, a VPN feature should not directly depend on classes from the Rewards or Wallet modules. If shared functionality is needed, extract it into a common utility or use an interface/abstraction layer. Cross-feature dependencies create tight coupling that makes features hard to modify or remove independently.
+**Feature modules should not import classes from other unrelated feature
+modules.** For example, a VPN feature should not directly depend on classes from
+the Rewards or Wallet modules. If shared functionality is needed, extract it
+into a common utility or use an interface/abstraction layer. Cross-feature
+dependencies create tight coupling that makes features hard to modify or remove
+independently.
 
 ---
 
@@ -989,7 +1133,11 @@ if (old_value != visual_content_used_percentage_) {
 
 ## ✅ Shared URL Constants Belong in `brave_domains`
 
-**When a URL constant or URL-building function (like a service endpoint) is shared across multiple components with no clear single owner, place it in the `brave_domains:urls` target.** Don't duplicate it in each component, and don't add it to the legacy `brave_constants.h`. For environment-aware URLs, use `GetServicesDomain()` from `brave_domains/service_domains.h`.
+**When a URL constant or URL-building function (like a service endpoint) is
+shared across multiple components with no clear single owner, place it in the
+`brave_domains:urls` target.** Don't duplicate it in each component, and don't
+add it to the legacy `brave_constants.h`. For environment-aware URLs, use
+`GetServicesDomain()` from `brave_domains/service_domains.h`.
 
 ```cpp
 // ❌ WRONG - duplicated across components
@@ -1008,7 +1156,9 @@ GURL GetGate3URL();  // environment-aware, uses GetServicesDomain()
 
 ## ✅ Prefer Non-Optional Arrays Over Optional Arrays in Mojom
 
-**In Mojom interface definitions, prefer a non-optional array (empty for "no items") over an optional array (`array<Type>?`).** Only use optional arrays when `null` has a distinct semantic meaning from "empty."
+**In Mojom interface definitions, prefer a non-optional array (empty for "no
+items") over an optional array (`array<Type>?`).** Only use optional arrays when
+`null` has a distinct semantic meaning from "empty."
 
 ```mojom
 // ❌ AVOID - unless null means something different from empty
@@ -1028,7 +1178,10 @@ struct SearchResult {
 
 ## ❌ Don't Add New Code to `components/l10n/`
 
-**The `components/l10n/` directory is deprecated.** Use Chromium's built-in localization functionality instead. Do not add new files or classes to this directory. If no Chromium equivalent exists for your use case, discuss alternatives before resorting to `components/l10n/`.
+**The `components/l10n/` directory is deprecated.** Use Chromium's built-in
+localization functionality instead. Do not add new files or classes to this
+directory. If no Chromium equivalent exists for your use case, discuss
+alternatives before resorting to `components/l10n/`.
 
 ---
 
@@ -1036,26 +1189,37 @@ struct SearchResult {
 
 ## ✅ Match Feature Scope to the Correct Ownership Primitive
 
-**Every feature must be scoped to exactly one of four ownership primitives: Tab, Browser Window, Profile, or Global.** Choose the narrowest scope that fits the feature's data and lifetime requirements. See [Chromium Browser Design Principles](https://chromium.googlesource.com/chromium/src/+/main/docs/chrome_browser_design_principles.md).
+**Every feature must be scoped to exactly one of four ownership primitives: Tab,
+Browser Window, Profile, or Global.** Choose the narrowest scope that fits the
+feature's data and lifetime requirements. See
+[Chromium Browser Design Principles](https://chromium.googlesource.com/chromium/src/+/main/docs/chrome_browser_design_principles.md).
 
-| Scope | Owner | Examples |
-|-------|-------|----------|
-| **Tab** | `TabFeatures` | Find-in-page, print preview, page actions |
-| **Browser Window** | `BrowserWindowFeatures` | Omnibox, bookmarks bar, vertical tabs |
-| **Profile** | `BrowserContextKeyedServiceFactory` | Rewards, Wallet, sync services |
-| **Global** | `GlobalFeatures` | Process-wide features spanning profiles |
+| Scope              | Owner                               | Examples                                  |
+| ------------------ | ----------------------------------- | ----------------------------------------- |
+| **Tab**            | `TabFeatures`                       | Find-in-page, print preview, page actions |
+| **Browser Window** | `BrowserWindowFeatures`             | Omnibox, bookmarks bar, vertical tabs     |
+| **Profile**        | `BrowserContextKeyedServiceFactory` | Rewards, Wallet, sync services            |
+| **Global**         | `GlobalFeatures`                    | Process-wide features spanning profiles   |
 
 **Rules:**
-- Tab-scoped features must not store browser-window state (tabs can move between windows)
-- Browser-window-scoped features must not store profile state (multiple windows can share a profile)
-- Profile-scoped features use `KeyedServiceFactory` with proper `DependsOn` declarations
+
+- Tab-scoped features must not store browser-window state (tabs can move between
+  windows)
+- Browser-window-scoped features must not store profile state (multiple windows
+  can share a profile)
+- Profile-scoped features use `KeyedServiceFactory` with proper `DependsOn`
+  declarations
 - Global features are rare; most features should be profile-scoped or narrower
 
 <a id="ARCH-066"></a>
 
 ## ✅ Swap-and-Process for Reentrancy Protection
 
-**When processing a queue of pending callbacks or items, swap the queue into a local variable before iterating.** This protects against reentrancy — if processing an item triggers code that adds new items to the queue, those new items won't be processed in the current iteration and won't cause infinite loops.
+**When processing a queue of pending callbacks or items, swap the queue into a
+local variable before iterating.** This protects against reentrancy — if
+processing an item triggers code that adds new items to the queue, those new
+items won't be processed in the current iteration and won't cause infinite
+loops.
 
 ```cpp
 // ❌ WRONG - reentrancy can corrupt the iteration
@@ -1077,9 +1241,12 @@ for (auto& callback : callbacks) {
 
 ## ❌ Don't Store Window-Scoped State on Tab-Scoped Objects
 
-**Tab-scoped features must never hold references to browser-window-level objects.** Tabs can move between browser windows (drag-and-drop, "move to new window"), so storing a `Browser*` or `BrowserWindowInterface*` on a tab feature causes use-after-free or stale-reference bugs.
+**Tab-scoped features must never hold references to browser-window-level
+objects.** Tabs can move between browser windows (drag-and-drop, "move to new
+window"), so storing a `Browser*` or `BrowserWindowInterface*` on a tab feature
+causes use-after-free or stale-reference bugs.
 
-```cpp
+````cpp
 // ❌ WRONG - tab feature holding a browser pointer
 class FooTabFeature {
   raw_ptr<Browser> browser_;  // Stale when tab moves to another window!
@@ -1110,7 +1277,7 @@ if (items.empty()) {
   return;
 }
 auto barrier = base::BarrierCallback<Result>(items.size(), std::move(done_callback));
-```
+````
 
 ---
 
@@ -1118,7 +1285,10 @@ auto barrier = base::BarrierCallback<Result>(items.size(), std::move(done_callba
 
 ## ❌ Avoid Lazy Instantiation of Features
 
-**Features should be eagerly created with explicit lifetime management, not lazily instantiated on first use.** Lazy instantiation causes inconsistent initialization order between production and tests, making bugs hard to reproduce.
+**Features should be eagerly created with explicit lifetime management, not
+lazily instantiated on first use.** Lazy instantiation causes inconsistent
+initialization order between production and tests, making bugs hard to
+reproduce.
 
 ```cpp
 // ❌ WRONG - lazy instantiation
@@ -1136,13 +1306,17 @@ class MyServiceFactory : public ProfileKeyedServiceFactory {
 };
 ```
 
-For tab/window features, create them in `TabFeatures::Init()` or `BrowserWindowFeatures::Init()` respectively.
+For tab/window features, create them in `TabFeatures::Init()` or
+`BrowserWindowFeatures::Init()` respectively.
 
 <a id="ARCH-068"></a>
 
 ## ✅ New P3A Metrics Require Privacy Review
 
-**When adding new p3a (privacy-preserving analytics) metrics, post a brief description of the new metrics in the p3a Slack channel for privacy review before merging.** P3A metrics have strict privacy requirements and must be reviewed by the analytics team.
+**When adding new p3a (privacy-preserving analytics) metrics, post a brief
+description of the new metrics in the p3a Slack channel for privacy review
+before merging.** P3A metrics have strict privacy requirements and must be
+reviewed by the analytics team.
 
 ---
 
@@ -1150,7 +1324,10 @@ For tab/window features, create them in `TabFeatures::Init()` or `BrowserWindowF
 
 ## ✅ Callback Execution Must Be Consistently Sync or Async
 
-**For a given callback, execution must be either always synchronous or always asynchronous — never sometimes one and sometimes the other.** Mixed sync/async execution creates subtle bugs because callers cannot reason about when their callback will run.
+**For a given callback, execution must be either always synchronous or always
+asynchronous — never sometimes one and sometimes the other.** Mixed sync/async
+execution creates subtle bugs because callers cannot reason about when their
+callback will run.
 
 ```cpp
 // ❌ WRONG - sometimes sync, sometimes async
@@ -1179,7 +1356,10 @@ void FetchData(Callback cb) {
 
 ## ❌ Avoid Re-entrancy; Localize Control Flow
 
-**Control flow should remain as localized as possible.** Pass all relevant state as parameters rather than querying non-local state mid-execution. Re-entrant code (where a callback triggers another call back into the same object) is error-prone and hard to reason about.
+**Control flow should remain as localized as possible.** Pass all relevant state
+as parameters rather than querying non-local state mid-execution. Re-entrant
+code (where a callback triggers another call back into the same object) is
+error-prone and hard to reason about.
 
 ```cpp
 // ❌ WRONG - querying non-local state mid-operation
@@ -1195,7 +1375,8 @@ void ProcessItem(const Item& item, const Config& config) {
 }
 ```
 
-If re-entrancy is unavoidable, document it clearly and use guards (e.g., `base::AutoReset`) to prevent infinite recursion.
+If re-entrancy is unavoidable, document it clearly and use guards (e.g.,
+`base::AutoReset`) to prevent infinite recursion.
 
 ---
 
@@ -1203,9 +1384,16 @@ If re-entrancy is unavoidable, document it clearly and use guards (e.g., `base::
 
 ## ✅ Every UI Feature Needs a CUJ Test
 
-**Every feature that adds or modifies user-visible UI should have at least one Critical User Journey (CUJ) test** using `InteractiveBrowserTest`. Do not use `BrowserWithTestWindowTest` — it forces `if (!browser_view)` test-only checks in production code. Use browser tests or unit tests with proper dependency injection instead.
+**Every feature that adds or modifies user-visible UI should have at least one
+Critical User Journey (CUJ) test** using `InteractiveBrowserTest`. Do not use
+`BrowserWithTestWindowTest` — it forces `if (!browser_view)` test-only checks in
+production code. Use browser tests or unit tests with proper dependency
+injection instead.
 
-This rule applies to features with UI changes (new views, buttons, dialogs, etc.). Non-UI components such as tab helpers, services, or background logic should be covered by unit tests or browser tests appropriate to the code — a CUJ test is not required when there is no user-visible interaction to validate.
+This rule applies to features with UI changes (new views, buttons, dialogs,
+etc.). Non-UI components such as tab helpers, services, or background logic
+should be covered by unit tests or browser tests appropriate to the code — a CUJ
+test is not required when there is no user-visible interaction to validate.
 
 ```cpp
 // ✅ CORRECT - CUJ test: validates user-visible behavior end-to-end
@@ -1223,7 +1411,11 @@ IN_PROC_BROWSER_TEST_F(MyFeatureInteractiveTest, UserCanToggleFeature) {
 
 ## ❌ Avoid Change Detector Tests
 
-**Avoid change detector tests.** A change detector test is easy to spot because the test logic mirrors the production logic — it just calls the same method and checks the obvious result. These tests break whenever the implementation changes but catch no real bugs. The purpose of a unit test is to validate behavior across common and edge cases for code that has many possible valid inputs.
+**Avoid change detector tests.** A change detector test is easy to spot because
+the test logic mirrors the production logic — it just calls the same method and
+checks the obvious result. These tests break whenever the implementation changes
+but catch no real bugs. The purpose of a unit test is to validate behavior
+across common and edge cases for code that has many possible valid inputs.
 
 ```cpp
 // ❌ WRONG - change detector test: test logic mirrors production logic
@@ -1262,7 +1454,9 @@ TEST(Math, CheckIsPrime) {
 
 ## ❌ Avoid Global Functions That Access Non-Global State
 
-**Global functions (free functions, static methods) should not access non-global state.** If a function needs profile-specific or window-specific data, it should receive that data as a parameter rather than reaching into global registries.
+**Global functions (free functions, static methods) should not access non-global
+state.** If a function needs profile-specific or window-specific data, it should
+receive that data as a parameter rather than reaching into global registries.
 
 ```cpp
 // ❌ WRONG - global function reaching into non-global state
@@ -1283,16 +1477,29 @@ bool IsFeatureReady(MyService* service) {
 
 ## ✅ Use Unowned User Data Pattern for Tab/Window Feature Retrieval When External Retrieval Is Needed
 
-Tab-scoped and browser-window-scoped features use one of two ownership patterns depending on whether external code needs to retrieve them. See the upstream [Chrome Browser Design Principles](https://chromium.googlesource.com/chromium/src/+/main/docs/chrome_browser_design_principles.md#architecture) for background.
+Tab-scoped and browser-window-scoped features use one of two ownership patterns
+depending on whether external code needs to retrieve them. See the upstream
+[Chrome Browser Design Principles](https://chromium.googlesource.com/chromium/src/+/main/docs/chrome_browser_design_principles.md#architecture)
+for background.
 
-**Simple `unique_ptr` member** — Use when the feature is **self-contained** (observes events internally, doesn't need to be looked up by other code). Owned as a `unique_ptr` member of `BraveTabFeatures` / `BraveBrowserWindowFeatures`. Upstream example: `JsOptimizationsPageActionController` takes its dependencies in the constructor and is simply instantiated in `TabFeatures::Init()`:
+**Simple `unique_ptr` member** — Use when the feature is **self-contained**
+(observes events internally, doesn't need to be looked up by other code). Owned
+as a `unique_ptr` member of `BraveTabFeatures` / `BraveBrowserWindowFeatures`.
+Upstream example: `JsOptimizationsPageActionController` takes its dependencies
+in the constructor and is simply instantiated in `TabFeatures::Init()`:
 
 ```cpp
 // In BraveTabFeatures:
 std::unique_ptr<MyTabFeature> my_tab_feature_;
 ```
 
-**Unowned User Data pattern** — Use when **external code needs to retrieve** the feature from a `TabInterface` or `BrowserWindowInterface` via a static `From()` method. This separates creation/lifetime management from retrieval. Upstream example: `CommerceUiTabHelper` is retrieved externally via `CommerceUiTabHelper::From(tab)` by UI code that needs to query commerce state for a given tab. See [Unowned User Data README](https://chromium.googlesource.com/chromium/src/+/main/ui/base/unowned_user_data/README.md).
+**Unowned User Data pattern** — Use when **external code needs to retrieve** the
+feature from a `TabInterface` or `BrowserWindowInterface` via a static `From()`
+method. This separates creation/lifetime management from retrieval. Upstream
+example: `CommerceUiTabHelper` is retrieved externally via
+`CommerceUiTabHelper::From(tab)` by UI code that needs to query commerce state
+for a given tab. See
+[Unowned User Data README](https://chromium.googlesource.com/chromium/src/+/main/ui/base/unowned_user_data/README.md).
 
 Example of external retrieval that motivates this pattern:
 
@@ -1352,7 +1559,10 @@ auto* feature = MyTabFeature::From(tab);
 
 ## ✅ Use Factory Overrides for Integration Testing of Unowned User Data Features
 
-**For integration tests that need mock features in a live browser, use `GetUserDataFactoryForTesting().AddOverrideForTesting()`** to substitute a mock before browser initialization. For unit tests, attach features directly to a mock interface's `UnownedUserDataHost`.
+**For integration tests that need mock features in a live browser, use
+`GetUserDataFactoryForTesting().AddOverrideForTesting()`** to substitute a mock
+before browser initialization. For unit tests, attach features directly to a
+mock interface's `UnownedUserDataHost`.
 
 **Unit test — attach to mock interface:**
 
@@ -1378,13 +1588,17 @@ auto override = tabs::TabFeatures::GetUserDataFactoryForTesting()
         }));
 ```
 
-This avoids `BrowserWithTestWindowTest` (which Chromium discourages for production features) and enables testing with real browser infrastructure.
+This avoids `BrowserWithTestWindowTest` (which Chromium discourages for
+production features) and enables testing with real browser infrastructure.
 
 <a id="ARCH-069"></a>
 
 ## ✅ Preference Keys Must Be Correct Before Shipping
 
-**Preference keys that get persisted to disk must be spelled correctly before the first release that includes them.** Changing a preference key after it ships requires a migration path to avoid losing user data. Double-check key strings during review.
+**Preference keys that get persisted to disk must be spelled correctly before
+the first release that includes them.** Changing a preference key after it ships
+requires a migration path to avoid losing user data. Double-check key strings
+during review.
 
 ---
 
@@ -1392,13 +1606,20 @@ This avoids `BrowserWithTestWindowTest` (which Chromium discourages for producti
 
 ## ✅ Keep PRs Focused on a Single Purpose
 
-**Each pull request should have one main purpose. Avoid bundling unrelated "ride-along" changes into the same PR.** If you notice something unrelated that needs fixing while working on a PR, make that fix in a separate PR instead.
+**Each pull request should have one main purpose. Avoid bundling unrelated
+"ride-along" changes into the same PR.** If you notice something unrelated that
+needs fixing while working on a PR, make that fix in a separate PR instead.
 
-Focused PRs are easier to review, easier to revert if something goes wrong, and produce a cleaner git history. Mixing unrelated changes obscures the intent of each change and makes bisecting regressions harder.
+Focused PRs are easier to review, easier to revert if something goes wrong, and
+produce a cleaner git history. Mixing unrelated changes obscures the intent of
+each change and makes bisecting regressions harder.
 
-Small, closely related cleanups in code you are already modifying are acceptable. Formatting changes required by the formatter or presubmit are also fine but should be in a separate commit within the same PR.
+Small, closely related cleanups in code you are already modifying are
+acceptable. Formatting changes required by the formatter or presubmit are also
+fine but should be in a separate commit within the same PR.
 
 Examples of ride-along changes to avoid:
+
 - Fixing a separate bug you noticed while implementing a feature
 - Adding unrelated refactoring alongside a behavioral change
 - Large-scale renaming or reformatting unrelated to your change
@@ -1410,9 +1631,14 @@ Examples of ride-along changes to avoid:
 
 ## ❌ No Browser-Process-Only APIs in `common/` Directories
 
-**Code under `components/.../common/` must not depend on APIs that only exist in the browser process** — `PrefService`, `content::BrowserContext`, `Profile`, `g_browser_process`, etc. `common/` is compiled into any process that links the component (browser, renderer, utility), so referencing browser-only types there is meaningless or unsafe for non-browser callers.
+**Code under `components/.../common/` must not depend on APIs that only exist in
+the browser process** — `PrefService`, `content::BrowserContext`, `Profile`,
+`g_browser_process`, etc. `common/` is compiled into any process that links the
+component (browser, renderer, utility), so referencing browser-only types there
+is meaningless or unsafe for non-browser callers.
 
-This is the inverse of the `common/` rule above: code moves *into* `common/` only when it is genuinely safe for every process.
+This is the inverse of the `common/` rule above: code moves _into_ `common/`
+only when it is genuinely safe for every process.
 
 ```cpp
 // ❌ WRONG - common/ helper that takes a PrefService
@@ -1439,12 +1665,16 @@ bool IsPlaylistEnabled(PrefService* prefs);
 ```
 
 **Directory rules:**
-- `common/` — deps must be safe for every process: `//base`, mojom, shared structs
-- `browser/` — browser process only; `PrefService`, `BrowserContext`, `Profile`, `g_browser_process`
+
+- `common/` — deps must be safe for every process: `//base`, mojom, shared
+  structs
+- `browser/` — browser process only; `PrefService`, `BrowserContext`, `Profile`,
+  `g_browser_process`
 - `renderer/` — renderer process only
 - `services/` — utility process services
 
-A new `+components/prefs` line (or similar) in a `common/DEPS` file is almost always a sign that the helper belongs in `browser/` instead.
+A new `+components/prefs` line (or similar) in a `common/DEPS` file is almost
+always a sign that the helper belongs in `browser/` instead.
 
 ---
 
@@ -1452,14 +1682,22 @@ A new `+components/prefs` line (or similar) in a `common/DEPS` file is almost al
 
 ## ✅ Factory Return Value Must Be Stable Across the Browser Session
 
-**A `KeyedServiceFactory` may only return `nullptr` (or skip service creation) based on attributes that are fixed for the entire browser session** — profile type, buildflags, and feature flags. Do not gate the result on user-modifiable prefs.
+**A `KeyedServiceFactory` may only return `nullptr` (or skip service creation)
+based on attributes that are fixed for the entire browser session** — profile
+type, buildflags, and feature flags. Do not gate the result on user-modifiable
+prefs.
 
 This rule applies to both places a factory can return null:
 
-1. `BuildServiceInstanceForBrowserContext` (returning `nullptr` skips creation), and
-2. The static `GetForProfile` / `GetForBrowserContext` accessor (returning `nullptr` before delegating to the base class).
+1. `BuildServiceInstanceForBrowserContext` (returning `nullptr` skips creation),
+   and
+2. The static `GetForProfile` / `GetForBrowserContext` accessor (returning
+   `nullptr` before delegating to the base class).
 
-If the null-vs-non-null result depends on a pref that can change at runtime, the service will be present or absent for the rest of the session regardless of subsequent toggles, forcing a browser restart to apply the user's choice. Callers also start to defensively null-check what should be a stable handle.
+If the null-vs-non-null result depends on a pref that can change at runtime, the
+service will be present or absent for the rest of the session regardless of
+subsequent toggles, forcing a browser restart to apply the user's choice.
+Callers also start to defensively null-check what should be a stable handle.
 
 ```cpp
 // ❌ WRONG - factory result depends on a runtime-toggleable pref
@@ -1493,13 +1731,19 @@ BraveWalletServiceFactory::BuildServiceInstanceForBrowserContext(
 ```
 
 **Valid bases for returning `nullptr` from a factory or its accessor:**
+
 - Profile type (incognito, guest, system) — see [ARCH-015](#ARCH-015)
 - `BUILDFLAG(ENABLE_*)` feature buildflags
 - `base::Feature` flags (stable for the session)
-- Managed/policy prefs that are documented to require a restart (short-term; ideally decouple)
+- Managed/policy prefs that are documented to require a restart (short-term;
+  ideally decouple)
 
 **Invalid bases:**
-- Any user-toggleable pref (e.g. `kPlaylistEnabledPref`, `kBraveWalletEnabledPref`)
+
+- Any user-toggleable pref (e.g. `kPlaylistEnabledPref`,
+  `kBraveWalletEnabledPref`)
 - Any state that can change while the browser is running
 
-If a feature must be fully disable-able at runtime, the service should remain instantiated and expose an `IsEnabled()` accessor, or callers should observe the pref directly.
+If a feature must be fully disable-able at runtime, the service should remain
+instantiated and expose an `IsEnabled()` accessor, or callers should observe the
+pref directly.

--- a/docs/best-practices/build-system.md
+++ b/docs/best-practices/build-system.md
@@ -4,7 +4,8 @@
 
 ## ✅ DEPS File - Use Commit Hashes
 
-**In DEPS files, always use commit hashes rather than branch names or tags.** Commit hashes are immutable and ensure reproducible builds.
+**In DEPS files, always use commit hashes rather than branch names or tags.**
+Commit hashes are immutable and ensure reproducible builds.
 
 ---
 
@@ -12,7 +13,9 @@
 
 ## ✅ Reuse Existing GN Config Args
 
-**Check for existing GN args before creating new ones.** Duplicating config arguments (e.g., creating `brave_android_keystore_path` when `android_keystore_path` already exists) adds confusion and maintenance burden.
+**Check for existing GN args before creating new ones.** Duplicating config
+arguments (e.g., creating `brave_android_keystore_path` when
+`android_keystore_path` already exists) adds confusion and maintenance burden.
 
 ---
 
@@ -23,7 +26,10 @@
 Python scripts used in the build system should follow these conventions:
 
 - **Use `argparse`** for command-line arguments, not `sys.argv` directly
-- **Use the standard `main()` pattern with `sys.exit(main())`** so scripts can either return explicit exit codes or rely on uncaught exceptions for non-zero exits:
+- **Use the standard `main()` pattern with `sys.exit(main())`** so scripts can
+  either return explicit exit codes or rely on uncaught exceptions for non-zero
+  exits:
+
   ```python
   import sys
 
@@ -40,7 +46,9 @@ Python scripts used in the build system should follow these conventions:
 
 ## ✅ Group Sources and Deps Together in BUILD.gn
 
-**Always group `sources` and `deps` in the same block.** Don't dump everything in one place - move files to separate BUILD.gn files when needed so it's clear which deps belong to which sources.
+**Always group `sources` and `deps` in the same block.** Don't dump everything
+in one place - move files to separate BUILD.gn files when needed so it's clear
+which deps belong to which sources.
 
 ```gn
 # ❌ WRONG - all deps in root BUILD.gn, hard to track
@@ -62,7 +70,9 @@ source_set("branded_wallpaper") {
 
 ## ❌ Never More Than One Guard Per Target
 
-**There should almost never be more than one of the same guard in any given BUILD.gn target.** If you find yourself repeating the same `if (enable_brave_foo)` block multiple times, consolidate.
+**There should almost never be more than one of the same guard in any given
+BUILD.gn target.** If you find yourself repeating the same
+`if (enable_brave_foo)` block multiple times, consolidate.
 
 ---
 
@@ -70,7 +80,9 @@ source_set("branded_wallpaper") {
 
 ## ✅ Use Buildflags Instead of OS Guards for Features
 
-**Use buildflags (`BUILDFLAG(ENABLE_FOO)`) instead of OS platform guards (`is_linux`, `is_win`) for feature-specific code.** Platform guards without buildflags are deprecated.
+**Use buildflags (`BUILDFLAG(ENABLE_FOO)`) instead of OS platform guards
+(`is_linux`, `is_win`) for feature-specific code.** Platform guards without
+buildflags are deprecated.
 
 ```gn
 # ❌ WRONG - deprecated OS guard
@@ -84,7 +96,9 @@ if (enable_tor) {
 }
 ```
 
-Also: only feature-specific header files should go inside feature guards. Don't put unrelated headers inside a feature guard block even if they're only currently used by that feature.
+Also: only feature-specific header files should go inside feature guards. Don't
+put unrelated headers inside a feature guard block even if they're only
+currently used by that feature.
 
 ---
 
@@ -92,7 +106,11 @@ Also: only feature-specific header files should go inside feature guards. Don't 
 
 ## ✅ Buildflag Naming Convention
 
-**Use `enable_brave_<feature>` as the naming convention for buildflags when the flag needs to be distinguished from a Chromium flag or is a top-level Brave feature.** The `enable_brave_` prefix is not required for flags that are clearly Brave-specific by context (e.g., a flag scoped within a Brave component's own buildflags file).
+**Use `enable_brave_<feature>` as the naming convention for buildflags when the
+flag needs to be distinguished from a Chromium flag or is a top-level Brave
+feature.** The `enable_brave_` prefix is not required for flags that are clearly
+Brave-specific by context (e.g., a flag scoped within a Brave component's own
+buildflags file).
 
 ```gn
 # ❌ WRONG - non-standard naming
@@ -112,7 +130,8 @@ enable_tab_management_tool = !is_android
 
 ## ❌ Don't Duplicate License Files
 
-**Never duplicate Chromium or other project license files.** Use special cases or references instead.
+**Never duplicate Chromium or other project license files.** Use special cases
+or references instead.
 
 ---
 
@@ -120,9 +139,12 @@ enable_tab_management_tool = !is_android
 
 ## ✅ JSON Resources Should Go in GRD Files
 
-**JSON data files should be packaged as resources in `.grd` files, not loaded from disk.** This allows the same data to be used from both C++ and JS.
+**JSON data files should be packaged as resources in `.grd` files, not loaded
+from disk.** This allows the same data to be used from both C++ and JS.
 
-See `brave/components/brave_rewards/resources/brave_rewards_static_resources.grd` for an example.
+See
+`brave/components/brave_rewards/resources/brave_rewards_static_resources.grd`
+for an example.
 
 ---
 
@@ -130,7 +152,10 @@ See `brave/components/brave_rewards/resources/brave_rewards_static_resources.grd
 
 ## ✅ Use `//brave/` Deps Instead of Modifying Visibility Lists
 
-**When adding deps from Chromium targets to Brave code, use high-level `//brave/` targets (e.g., `//brave/utility`) instead of modifying Chromium visibility lists.** Visibility lists exist to prevent exactly this kind of cross-boundary dependency.
+**When adding deps from Chromium targets to Brave code, use high-level
+`//brave/` targets (e.g., `//brave/utility`) instead of modifying Chromium
+visibility lists.** Visibility lists exist to prevent exactly this kind of
+cross-boundary dependency.
 
 ```gn
 # ❌ WRONG - modifying Chromium visibility list
@@ -146,7 +171,9 @@ deps += [ "//brave/utility" ]
 
 ## ✅ Add `#endif` Comments for Clarity
 
-**Add `#endif` comments to clarify what each `#endif` is closing.** See the "Refined Rule: `#endif` Comments Based on Block Length" section below for specific guidance on when to include vs omit these comments.
+**Add `#endif` comments to clarify what each `#endif` is closing.** See the
+"Refined Rule: `#endif` Comments Based on Block Length" section below for
+specific guidance on when to include vs omit these comments.
 
 ```cpp
 #if BUILDFLAG(ENABLE_SPELLCHECK)
@@ -160,9 +187,15 @@ deps += [ "//brave/utility" ]
 
 ## ✅ Keep Scripts Near Their Use
 
-**Build and utility scripts should live near the build target or configuration that uses them.** For example, if a script is only used by a GN `action()` in a specific directory, place the script in that directory. If a utility script is referenced from `DEPS`, place it near the related dependency or configuration instead of adding it to a shared `brave/script` directory.
+**Build and utility scripts should live near the build target or configuration
+that uses them.** For example, if a script is only used by a GN `action()` in a
+specific directory, place the script in that directory. If a utility script is
+referenced from `DEPS`, place it near the related dependency or configuration
+instead of adding it to a shared `brave/script` directory.
 
-**Avoid adding new build or utility scripts to `brave/script`.** Keep that directory for existing scripts and use a more local location for new script logic.
+**Avoid adding new build or utility scripts to `brave/script`.** Keep that
+directory for existing scripts and use a more local location for new script
+logic.
 
 ---
 
@@ -170,7 +203,9 @@ deps += [ "//brave/utility" ]
 
 ## ❌ Avoid Separate Repositories
 
-**Avoid creating separate repositories for Brave features.** Separate repos are harder to manage, code review, and maintain. Prefer keeping code within brave-core.
+**Avoid creating separate repositories for Brave features.** Separate repos are
+harder to manage, code review, and maintain. Prefer keeping code within
+brave-core.
 
 ---
 
@@ -178,7 +213,12 @@ deps += [ "//brave/utility" ]
 
 ## ✅ Add New URLs to the Network Audit Allowed List
 
-**When adding a new network endpoint URL that does not require user opt-in, it must be added to the network audit allowed list** in `brave/browser/net/brave_network_audit_allowed_lists.h`. Without this, the network audit check will fail. Endpoints that only make requests based on explicit user action (e.g., clicking a button) do not need to be added to the network auditor.
+**When adding a new network endpoint URL that does not require user opt-in, it
+must be added to the network audit allowed list** in
+`brave/browser/net/brave_network_audit_allowed_lists.h`. Without this, the
+network audit check will fail. Endpoints that only make requests based on
+explicit user action (e.g., clicking a button) do not need to be added to the
+network auditor.
 
 ---
 
@@ -186,7 +226,9 @@ deps += [ "//brave/utility" ]
 
 ## ❌ Don't Use OS Guards as Proxy for Feature Guards
 
-**Use the correct feature guard (`brave_wallet_enabled`, `enable_extensions`) instead of approximating with OS guards (`!is_android && !is_ios`).** OS guards can get out of sync with the actual feature flag logic.
+**Use the correct feature guard (`brave_wallet_enabled`, `enable_extensions`)
+instead of approximating with OS guards (`!is_android && !is_ios`).** OS guards
+can get out of sync with the actual feature flag logic.
 
 ```gn
 # ❌ WRONG - OS guard as proxy for feature
@@ -206,7 +248,11 @@ if (brave_wallet_enabled) {
 
 ## ✅ Use `use_blink` for Content-Layer Dependencies, Not `!is_ios`
 
-**Code that depends on the content layer (`//content/...`) must be guarded with `use_blink`, not `!is_ios`.** The `use_blink` flag is the correct way to detect content/Blink availability. Using `!is_ios` as a proxy is incorrect because `use_blink` is the actual flag that controls whether the content layer is built, and `!is_ios` may not always be equivalent.
+**Code that depends on the content layer (`//content/...`) must be guarded with
+`use_blink`, not `!is_ios`.** The `use_blink` flag is the correct way to detect
+content/Blink availability. Using `!is_ios` as a proxy is incorrect because
+`use_blink` is the actual flag that controls whether the content layer is built,
+and `!is_ios` may not always be equivalent.
 
 ```gn
 # ❌ WRONG - using !is_ios as proxy for content availability
@@ -240,7 +286,9 @@ if (use_blink) {
 
 ## ❌ Don't Have Both `BUILD.gn` and `sources.gni` in the Same Directory
 
-**A directory should contain either a `BUILD.gn` file (preferred) or a `sources.gni` file, but not both.** Having both creates confusion about which is authoritative and makes dependency tracking harder.
+**A directory should contain either a `BUILD.gn` file (preferred) or a
+`sources.gni` file, but not both.** Having both creates confusion about which is
+authoritative and makes dependency tracking harder.
 
 ---
 
@@ -248,7 +296,10 @@ if (use_blink) {
 
 ## ✅ Use `sources.gni` Only for Circular Dependencies with Upstream
 
-**Only use `sources.gni` when inserting source files into upstream Chromium targets with circular deps.** For all other cases, use normal `BUILD.gn` targets. Putting everything in `sources.gni` hurts incremental builds because changes trigger rebuilds of large upstream targets.
+**Only use `sources.gni` when inserting source files into upstream Chromium
+targets with circular deps.** For all other cases, use normal `BUILD.gn`
+targets. Putting everything in `sources.gni` hurts incremental builds because
+changes trigger rebuilds of large upstream targets.
 
 ---
 
@@ -256,7 +307,9 @@ if (use_blink) {
 
 ## ✅ Create Test Targets in Component BUILD.gn
 
-**Unit test files should have a test target in the component's `BUILD.gn`, not be individually listed in the top-level `test/BUILD.gn`.** The top-level test target should depend on the component's test target.
+**Unit test files should have a test target in the component's `BUILD.gn`, not
+be individually listed in the top-level `test/BUILD.gn`.** The top-level test
+target should depend on the component's test target.
 
 ```gn
 # ❌ WRONG - individual test files in top-level test/BUILD.gn
@@ -278,7 +331,10 @@ deps += [ "//brave/components/ai_chat/core:unit_tests" ]
 
 ## ✅ Create `test_support` Targets for Reusable Fakes/Mocks
 
-**When creating fake or mock implementations of services for testing, put them in a separate `test_support` BUILD.gn target rather than embedding them directly in a `unit_tests` target.** This allows multiple test targets across the codebase to reuse the same fakes.
+**When creating fake or mock implementations of services for testing, put them
+in a separate `test_support` BUILD.gn target rather than embedding them directly
+in a `unit_tests` target.** This allows multiple test targets across the
+codebase to reuse the same fakes.
 
 ```gn
 # ❌ WRONG - fake service only available to one test target
@@ -315,7 +371,8 @@ source_set("unit_tests") {
 
 ## ✅ Use `PlatformBrowserTest` for Cross-Platform Browser Tests
 
-**Browser tests that should run on both desktop and Android should use `PlatformBrowserTest` as the base class instead of `InProcessBrowserTest`.**
+**Browser tests that should run on both desktop and Android should use
+`PlatformBrowserTest` as the base class instead of `InProcessBrowserTest`.**
 
 ```cpp
 #if BUILDFLAG(IS_ANDROID)
@@ -337,7 +394,10 @@ class MyBrowserTest : public PlatformBrowserTest {};
 
 ## ✅ Use `public_deps` for Header-File Includes in BUILD.gn
 
-**When a dependency's headers are included in your target's header files (not just .cc files), that dependency must be listed in `public_deps`, not `deps`.** This ensures consumers of your target also get the transitive include paths they need.
+**When a dependency's headers are included in your target's header files (not
+just .cc files), that dependency must be listed in `public_deps`, not `deps`.**
+This ensures consumers of your target also get the transitive include paths they
+need.
 
 ```gn
 # ❌ WRONG - header-visible dependency in regular deps
@@ -360,7 +420,10 @@ source_set("my_service") {
 
 ## ✅ Utility Scripts Should Be Python, Not Node.js or Shell
 
-**Build and utility scripts in brave-core should be written in Python (using `vpython` from depot tools), not Node.js or shell scripts.** This follows Chromium conventions, avoids additional runtime dependencies, and works on all platforms including Windows.
+**Build and utility scripts in brave-core should be written in Python (using
+`vpython` from depot tools), not Node.js or shell scripts.** This follows
+Chromium conventions, avoids additional runtime dependencies, and works on all
+platforms including Windows.
 
 ---
 
@@ -368,7 +431,11 @@ source_set("my_service") {
 
 ## ✅ Unconditional Buildflags Deps with Conditional `deps +=`
 
-**When adding `deps +=` inside an `if(enable_feature)` block in GN, always add an unconditional `buildflags` dependency outside the conditional.** The buildflags header is needed even when the feature is disabled (for the `#if BUILDFLAG(...)` check itself). Run `gn check` with the buildflag disabled to verify.
+**When adding `deps +=` inside an `if(enable_feature)` block in GN, always add
+an unconditional `buildflags` dependency outside the conditional.** The
+buildflags header is needed even when the feature is disabled (for the
+`#if BUILDFLAG(...)` check itself). Run `gn check` with the buildflag disabled
+to verify.
 
 ```gn
 # ❌ WRONG - buildflags dep only inside conditional
@@ -394,7 +461,9 @@ if (enable_brave_rewards) {
 
 ## ✅ Use source_set Only for Internal Targets (with Restricted Visibility)
 
-**Public targets for a component should use `static_library` or `component`, not `source_set`.** Only internal deps should use `source_set`, and those must have restricted visibility to prevent external use.
+**Public targets for a component should use `static_library` or `component`, not
+`source_set`.** Only internal deps should use `source_set`, and those must have
+restricted visibility to prevent external use.
 
 ```gn
 # ❌ WRONG - internal source_set with default (public) visibility
@@ -415,7 +484,9 @@ source_set("internal_network") {
 
 ## ✅ Python File Writes: Use `newline='\n'`
 
-**When writing files from Python scripts, always specify `newline='\n'`** in `open()` to ensure consistent LF line endings across platforms (especially Windows).
+**When writing files from Python scripts, always specify `newline='\n'`** in
+`open()` to ensure consistent LF line endings across platforms (especially
+Windows).
 
 ```python
 # ❌ WRONG - platform-dependent line endings
@@ -433,7 +504,9 @@ with open(output_path, 'w', newline='\n') as f:
 
 ## ✅ Use `include_rules` for Common Includes, `specific_include_rules` for Edge Cases
 
-**In DEPS files, use `include_rules` for generally allowed includes across all files in a directory.** Reserve `specific_include_rules` for edge cases where an include should only be allowed in specific files.
+**In DEPS files, use `include_rules` for generally allowed includes across all
+files in a directory.** Reserve `specific_include_rules` for edge cases where an
+include should only be allowed in specific files.
 
 ```python
 # ❌ WRONG - using specific_include_rules for commonly needed includes
@@ -457,7 +530,8 @@ include_rules = [
 
 ## ✅ Bump `resource_ids.spec` by 5
 
-**When adding new resource IDs in `resource_ids.spec`, bump the next ID by 5 (not 1)** to leave room for additions without conflicting with adjacent entries.
+**When adding new resource IDs in `resource_ids.spec`, bump the next ID by 5
+(not 1)** to leave room for additions without conflicting with adjacent entries.
 
 ---
 
@@ -465,7 +539,9 @@ include_rules = [
 
 ## ✅ Use `component()` Not `static_library()` for Service GN Targets
 
-**Mojo service targets should use `component()` instead of `static_library()` in BUILD.gn.** Components support dynamic linking and are the correct target type for service implementations.
+**Mojo service targets should use `component()` instead of `static_library()` in
+BUILD.gn.** Components support dynamic linking and are the correct target type
+for service implementations.
 
 ---
 
@@ -473,7 +549,10 @@ include_rules = [
 
 ## ❌ Unit Tests for Components Must NOT Live in Browser
 
-**Unit tests for code in `//brave/components` must not be placed in `//brave/browser`.** Tests should live alongside the code they test. Use `content::RenderViewHostTestHarness` for component-level tests that need content layer support.
+**Unit tests for code in `//brave/components` must not be placed in
+`//brave/browser`.** Tests should live alongside the code they test. Use
+`content::RenderViewHostTestHarness` for component-level tests that need content
+layer support.
 
 ```gn
 # ❌ WRONG - component test in browser directory
@@ -493,9 +572,16 @@ source_set("unit_tests") {
 
 ## ✅ Place Includes Inside BUILDFLAG Guards When Only Used There
 
-**When an `#include` is only used inside a `#if BUILDFLAG(...)` block, the include must also be inside that guard.** An unconditional include for a conditionally-used header breaks builds when the feature is disabled.
+**When an `#include` is only used inside a `#if BUILDFLAG(...)` block, the
+include must also be inside that guard.** An unconditional include for a
+conditionally-used header breaks builds when the feature is disabled.
 
-**IMPORTANT: Only apply this rule when the BUILDFLAG actually exists.** Before suggesting that code be wrapped in a `#if BUILDFLAG(...)` guard, verify the buildflag is defined in the codebase (check `buildflags.gni` files or existing usage). Never fabricate or assume a buildflag name — if no buildflag exists for a feature, do not invent one. Instead, check if the feature uses `base::FeatureList` runtime checks or has no compile-time guard at all.
+**IMPORTANT: Only apply this rule when the BUILDFLAG actually exists.** Before
+suggesting that code be wrapped in a `#if BUILDFLAG(...)` guard, verify the
+buildflag is defined in the codebase (check `buildflags.gni` files or existing
+usage). Never fabricate or assume a buildflag name — if no buildflag exists for
+a feature, do not invent one. Instead, check if the feature uses
+`base::FeatureList` runtime checks or has no compile-time guard at all.
 
 ```cpp
 // ❌ WRONG - unconditional include for conditionally-used header
@@ -518,7 +604,8 @@ source_set("unit_tests") {
 
 ## ✅ Merge Consecutive Identical BUILDFLAG Blocks
 
-**When multiple consecutive code regions use the same `#if BUILDFLAG(...)` condition, merge them into a single guard block.**
+**When multiple consecutive code regions use the same `#if BUILDFLAG(...)`
+condition, merge them into a single guard block.**
 
 ```cpp
 // ❌ WRONG - redundant guards
@@ -543,7 +630,9 @@ namespace rewards { ... }
 
 ## ✅ DEPS Allowlist Paths Must Exactly Match Include Paths
 
-**DEPS file allowlist paths must exactly match the `#include` paths used in source files.** A mismatch (e.g., `common/` vs `core/`) means the DEPS check doesn't validate the right file.
+**DEPS file allowlist paths must exactly match the `#include` paths used in
+source files.** A mismatch (e.g., `common/` vs `core/`) means the DEPS check
+doesn't validate the right file.
 
 ---
 
@@ -551,7 +640,8 @@ namespace rewards { ... }
 
 ## ✅ Use `assert()` at Top of Entire-Feature BUILD.gn Files
 
-**If an entire BUILD.gn file belongs to a feature, use `assert(enable_feature)` at the top** rather than wrapping individual blocks in `if (enable_feature)`.
+**If an entire BUILD.gn file belongs to a feature, use `assert(enable_feature)`
+at the top** rather than wrapping individual blocks in `if (enable_feature)`.
 
 ```gn
 # ❌ WRONG - wrapping everything inside a conditional
@@ -574,10 +664,17 @@ source_set("wallet_tests") {
 
 ## ❌ Don't Confuse Feature Flags with Build Flags
 
-**Runtime feature flags (`base::FeatureList`) and compile-time build flags (`BUILDFLAG()`) are completely different mechanisms.** Do not confuse them in either direction: runtime feature flags cannot gate build-time deps, and buildflag-guarded code does not need a redundant runtime feature flag on top.
+**Runtime feature flags (`base::FeatureList`) and compile-time build flags
+(`BUILDFLAG()`) are completely different mechanisms.** Do not confuse them in
+either direction: runtime feature flags cannot gate build-time deps, and
+buildflag-guarded code does not need a redundant runtime feature flag on top.
 
-- **Build flags** (e.g., `enable_brave_wallet`, `BUILDFLAG(ENABLE_EXTENSIONS)`) are set at compile time via GN args. They can guard `deps`, `sources`, `#include` blocks, and code blocks.
-- **Feature flags** (e.g., `base::FeatureList::IsEnabled(kMyFeature)`) are checked at runtime. They can only guard code execution, not build-time dependency inclusion.
+- **Build flags** (e.g., `enable_brave_wallet`, `BUILDFLAG(ENABLE_EXTENSIONS)`)
+  are set at compile time via GN args. They can guard `deps`, `sources`,
+  `#include` blocks, and code blocks.
+- **Feature flags** (e.g., `base::FeatureList::IsEnabled(kMyFeature)`) are
+  checked at runtime. They can only guard code execution, not build-time
+  dependency inclusion.
 
 ```gn
 # ❌ WRONG - runtime feature flag cannot gate build-time deps
@@ -601,7 +698,9 @@ deps += [ "//brave/components/local_ai/resources" ]
 
 ## ✅ Add `static_assert` in Public Headers for Build Flag Guards
 
-**When introducing a build flag for a component, add `static_assert` in public-facing headers** to catch accidental inclusion when the feature is disabled.
+**When introducing a build flag for a component, add `static_assert` in
+public-facing headers** to catch accidental inclusion when the feature is
+disabled.
 
 ```cpp
 // In brave/components/brave_wallet/browser/brave_wallet_service.h
@@ -615,7 +714,9 @@ static_assert(BUILDFLAG(ENABLE_BRAVE_WALLET));
 
 ## ❌ Don't Use `nogncheck` - Fix the Underlying Dep Guard
 
-**Do not use `nogncheck` to suppress gn check failures.** Instead fix the underlying GN dependency to be correctly conditional. `nogncheck` is a code smell that masks real build dependency issues.
+**Do not use `nogncheck` to suppress gn check failures.** Instead fix the
+underlying GN dependency to be correctly conditional. `nogncheck` is a code
+smell that masks real build dependency issues.
 
 ```cpp
 // ❌ WRONG - suppressing the real problem
@@ -631,7 +732,9 @@ static_assert(BUILDFLAG(ENABLE_BRAVE_WALLET));
 
 ## ✅ GN Deps Guarded by Feature Flags Only, Not Platform Guards
 
-**Within a single GN target, deps should be added behind the relevant buildflags only, not nested inside platform guards.** GN and C++ guards should always match.
+**Within a single GN target, deps should be added behind the relevant buildflags
+only, not nested inside platform guards.** GN and C++ guards should always
+match.
 
 ```gn
 # ❌ WRONG - nested inside platform guard
@@ -653,7 +756,12 @@ if (enable_tor) {
 
 ## ❌ Don't Guard Deps with Unrelated Guards
 
-**A dep should only be placed inside a guard if the dep itself is specific to that guard condition.** If a dep is needed regardless of the guard condition, include it unconditionally. Putting unrelated deps inside guards (e.g., placing a general utility dep inside `if (use_blink)` or `if (!is_ios)` when it has nothing to do with blink/iOS) creates incorrect build configurations and can cause missing symbol errors on platforms where the guard evaluates to false.
+**A dep should only be placed inside a guard if the dep itself is specific to
+that guard condition.** If a dep is needed regardless of the guard condition,
+include it unconditionally. Putting unrelated deps inside guards (e.g., placing
+a general utility dep inside `if (use_blink)` or `if (!is_ios)` when it has
+nothing to do with blink/iOS) creates incorrect build configurations and can
+cause missing symbol errors on platforms where the guard evaluates to false.
 
 ```gn
 # ❌ WRONG - "//brave/components/constants" has nothing to do with blink
@@ -679,7 +787,9 @@ if (use_blink) {
 
 ## ✅ When Disabling a Feature, Compile Out Its Tests
 
-**When a build flag disables a feature, exclude the feature-specific test files from the build** using conditionals rather than trying to fix compilation errors by adjusting test dependencies.
+**When a build flag disables a feature, exclude the feature-specific test files
+from the build** using conditionals rather than trying to fix compilation errors
+by adjusting test dependencies.
 
 ```gn
 # ❌ WRONG - fixing deps to make disabled feature tests compile
@@ -697,7 +807,9 @@ if (enable_brave_rewards) {
 
 ## ✅ Build Flag Validation Requires Both States
 
-**When adding a build flag, run `gn_check`, unit tests, component tests, browser tests, and presubmit with the flag both enabled AND disabled.** Issues frequently only appear in the disabled state.
+**When adding a build flag, run `gn_check`, unit tests, component tests, browser
+tests, and presubmit with the flag both enabled AND disabled.** Issues
+frequently only appear in the disabled state.
 
 ---
 
@@ -705,12 +817,15 @@ if (enable_brave_rewards) {
 
 ## ✅ Use Chromium UI Preprocessor for Conditional WebUI Code
 
-**Use `// <if expr="enable_feature">` in JS and `<if expr="enable_feature">` in HTML to conditionally compile feature-specific WebUI code.** This completely removes the code from the build when the feature is disabled, rather than relying solely on runtime `loadTimeData` checks.
+**Use `// <if expr="enable_feature">` in JS and `<if expr="enable_feature">` in
+HTML to conditionally compile feature-specific WebUI code.** This completely
+removes the code from the build when the feature is disabled, rather than
+relying solely on runtime `loadTimeData` checks.
 
 ```js
 // ✅ CORRECT - code removed at build time when feature disabled
 // <if expr="enable_speedreader">
-import { SpeedreaderPage } from './speedreader_page.js';
+import { SpeedreaderPage } from './speedreader_page.js'
 // </if>
 ```
 
@@ -721,6 +836,7 @@ import { SpeedreaderPage } from './speedreader_page.js';
 ## ✅ Refined Rule: `#endif` Comments Based on Block Length
 
 **Clarification of the `#endif` comment rule:**
+
 - **Always add** for blocks > 3 lines
 - **Always add** when inside nested `#if` blocks
 - **Always add** when surrounding code already uses them (consistency)
@@ -732,7 +848,9 @@ import { SpeedreaderPage } from './speedreader_page.js';
 
 ## ✅ Assert Build Flag Dependencies Between Features
 
-**When Feature A depends on Feature B, assert Feature B's build flag is true when Feature A is enabled** rather than making Feature A work without Feature B for unsupported configurations.
+**When Feature A depends on Feature B, assert Feature B's build flag is true
+when Feature A is enabled** rather than making Feature A work without Feature B
+for unsupported configurations.
 
 ```gn
 # In brave/components/brave_rewards/BUILD.gn
@@ -746,7 +864,9 @@ assert(enable_brave_wallet,
 
 ## ✅ Share Constants via Common Headers
 
-**Shared constants (like limits, URLs, keys) should be defined in a common header** to avoid duplicate definitions across implementation, test, and other files.
+**Shared constants (like limits, URLs, keys) should be defined in a common
+header** to avoid duplicate definitions across implementation, test, and other
+files.
 
 ```cpp
 // ❌ WRONG - same constant in 3 files
@@ -768,7 +888,10 @@ inline constexpr char kOllamaEndpoint[] = "http://localhost:11434";
 
 ## ❌ Never Add Anything to `components/constants` (Deprecated)
 
-**The `components/constants` directory is not a real component — it is a deprecated legacy dumping ground that should be removed.** Never add new constants, headers, or targets there. Instead, place constants in a `common` target within the component that owns them.
+**The `components/constants` directory is not a real component — it is a
+deprecated legacy dumping ground that should be removed.** Never add new
+constants, headers, or targets there. Instead, place constants in a `common`
+target within the component that owns them.
 
 ```gn
 # ❌ WRONG - adding to the legacy catch-all
@@ -780,9 +903,11 @@ inline constexpr char kGate3OAuthUrl[] = "...";
 inline constexpr char kGate3OAuthUrl[] = "...";
 ```
 
-Do not add new `deps` on `//brave/components/constants` either — migrate existing usages to proper component-owned targets when you encounter them.
+Do not add new `deps` on `//brave/components/constants` either — migrate
+existing usages to proper component-owned targets when you encounter them.
 
-If a constant (especially a URL) is shared across multiple components with no clear owner, place it in a `brave_domains` target.
+If a constant (especially a URL) is shared across multiple components with no
+clear owner, place it in a `brave_domains` target.
 
 ---
 
@@ -790,7 +915,9 @@ If a constant (especially a URL) is shared across multiple components with no cl
 
 ## ✅ Forward Declarations Don't Need `BUILDFLAG` Guards
 
-**Only `#include` directives and actual usages need to be wrapped in `#if BUILDFLAG(...)` guards.** Forward declarations are harmless — they don't pull in dependencies and cost nothing at compile time if unused.
+**Only `#include` directives and actual usages need to be wrapped in
+`#if BUILDFLAG(...)` guards.** Forward declarations are harmless — they don't
+pull in dependencies and cost nothing at compile time if unused.
 
 ```cpp
 // ❌ UNNECESSARY - guarding a forward declaration
@@ -813,7 +940,11 @@ class HistoryTool;
 
 ## ❌ Don't Use Compound Buildflags (Channel + Platform + Official)
 
-**Do not create buildflags that combine channel, platform, and official_build conditions** (e.g., enabled only on nightly + desktop + official). These compound flags break during branch migration (nightly → beta → release) and create configurations that are nearly impossible to test locally. Use separate, independently testable flags instead.
+**Do not create buildflags that combine channel, platform, and official_build
+conditions** (e.g., enabled only on nightly + desktop + official). These
+compound flags break during branch migration (nightly → beta → release) and
+create configurations that are nearly impossible to test locally. Use separate,
+independently testable flags instead.
 
 ---
 
@@ -821,7 +952,10 @@ class HistoryTool;
 
 ## ❌ Don't Include Buildflag Headers in Conditionally-Compiled Files
 
-**If a file is only compiled when a buildflag is enabled (guarded by `if(enable_feature)` in BUILD.gn), that file should not `#include` the buildflag header or use `#if BUILDFLAG(...)` guards.** The file is never compiled when the flag is disabled, so checking the flag inside it is redundant and misleading.
+**If a file is only compiled when a buildflag is enabled (guarded by
+`if(enable_feature)` in BUILD.gn), that file should not `#include` the buildflag
+header or use `#if BUILDFLAG(...)` guards.** The file is never compiled when the
+flag is disabled, so checking the flag inside it is redundant and misleading.
 
 ```cpp
 // In brave/components/foo/foo_impl.cc
@@ -838,7 +972,10 @@ void DoFoo() { ... }
 void DoFoo() { ... }
 ```
 
-Note: Public headers may still benefit from a `static_assert(BUILDFLAG(...))` as a safety net against accidental inclusion (see BS-049). This rule applies to implementation files and internal headers that are strictly behind the BUILD.gn guard.
+Note: Public headers may still benefit from a `static_assert(BUILDFLAG(...))` as
+a safety net against accidental inclusion (see BS-049). This rule applies to
+implementation files and internal headers that are strictly behind the BUILD.gn
+guard.
 
 ---
 
@@ -846,7 +983,10 @@ Note: Public headers may still benefit from a `static_assert(BUILDFLAG(...))` as
 
 ## ✅ Use `public` to Restrict Header Visibility in Components
 
-**When a GN target exposes only a subset of its headers to consumers, explicitly list those headers in `public = [...]` to keep the rest internal.** This improves encapsulation — consumers can only include the declared public headers, preventing accidental coupling to implementation details.
+**When a GN target exposes only a subset of its headers to consumers, explicitly
+list those headers in `public = [...]` to keep the rest internal.** This
+improves encapsulation — consumers can only include the declared public headers,
+preventing accidental coupling to implementation details.
 
 ```gn
 # ❌ WRONG - all headers are implicitly public
@@ -873,7 +1013,9 @@ source_set("core") {
 }
 ```
 
-This is especially useful for `static_library` and `source_set` targets that contain both a public API and private implementation files. GN will enforce that only headers listed in `public` can be `#include`d by dependent targets.
+This is especially useful for `static_library` and `source_set` targets that
+contain both a public API and private implementation files. GN will enforce that
+only headers listed in `public` can be `#include`d by dependent targets.
 
 ---
 
@@ -881,4 +1023,8 @@ This is especially useful for `static_library` and `source_set` targets that con
 
 ## ✅ Add New Endpoints to the HSTS Pin List
 
-**When adding any new Brave endpoint, it must be added to the HSTS pin list** in `chromium_src/net/tools/transport_security_state_generator/input_file_parsers.cc`. New endpoints must be added to both the pins `"entries"` list and the HSTS `"entries"` list in that file. This applies to all new endpoints regardless of whether they require user opt-in.
+**When adding any new Brave endpoint, it must be added to the HSTS pin list** in
+`chromium_src/net/tools/transport_security_state_generator/input_file_parsers.cc`.
+New endpoints must be added to both the pins `"entries"` list and the HSTS
+`"entries"` list in that file. This applies to all new endpoints regardless of
+whether they require user opt-in.

--- a/docs/best-practices/chromium-src-overrides.md
+++ b/docs/best-practices/chromium-src-overrides.md
@@ -4,20 +4,29 @@
 
 ## ✅ Avoid Modifying Chromium Source When Possible
 
-**Changes to Chromium code in `src/` should be avoided whenever possible.** Implement features and fixes entirely within brave-core (`src/brave/`) using Brave's own code and APIs.
+**Changes to Chromium code in `src/` should be avoided whenever possible.**
+Implement features and fixes entirely within brave-core (`src/brave/`) using
+Brave's own code and APIs.
 
 When Chromium changes are unavoidable, follow this preference order:
 
-1. **chromium_src overrides** (strongly preferred) — Override files in `src/brave/chromium_src/` that replace or wrap upstream behavior at compile time. See the sections below for patterns and conventions.
+1. **chromium_src overrides** (strongly preferred) — Override files in
+   `src/brave/chromium_src/` that replace or wrap upstream behavior at compile
+   time. See the sections below for patterns and conventions.
 
-2. **Patches** (last resort) — When a chromium_src override is not feasible (e.g., you need to add a `virtual` keyword where `#define` tricks don't work, or modify a GN file), directly edit the files in `src/` and then generate patches:
+2. **Patches** (last resort) — When a chromium_src override is not feasible
+   (e.g., you need to add a `virtual` keyword where `#define` tricks don't work,
+   or modify a GN file), directly edit the files in `src/` and then generate
+   patches:
 
    ```bash
    cd src/brave
    npm run update_patches
    ```
 
-   This reads the changes you made to files in `src/` and updates the corresponding patch files in `src/brave/patches/`. Always keep patches minimal — one-line additions are ideal.
+   This reads the changes you made to files in `src/` and updates the
+   corresponding patch files in `src/brave/patches/`. Always keep patches
+   minimal — one-line additions are ideal.
 
 ---
 
@@ -25,7 +34,10 @@ When Chromium changes are unavoidable, follow this preference order:
 
 ## ❌ Don't Use chromium_src Overrides to Disable Tests
 
-**Never use `#define TestName DISABLED_TestName` in chromium_src overrides to disable upstream tests.** Use filter files in `test/filters/` instead, and move any Brave-specific replacement tests into the appropriate Brave test target (`brave_unit_tests`, `brave_browser_tests`, `brave_components_unittests`).
+**Never use `#define TestName DISABLED_TestName` in chromium_src overrides to
+disable upstream tests.** Use filter files in `test/filters/` instead, and move
+any Brave-specific replacement tests into the appropriate Brave test target
+(`brave_unit_tests`, `brave_browser_tests`, `brave_components_unittests`).
 
 ---
 
@@ -33,11 +45,13 @@ When Chromium changes are unavoidable, follow this preference order:
 
 ## ✅ Minimize Code Duplication in Overrides
 
-**When overriding Chromium code via `chromium_src/`, prefer wrapping only the changed section and falling back to `ChromiumImpl` for everything else.**
+**When overriding Chromium code via `chromium_src/`, prefer wrapping only the
+changed section and falling back to `ChromiumImpl` for everything else.**
 
 Don't duplicate entire functions when only part of the logic needs to change.
 
 **BAD:**
+
 ```cpp
 // ❌ WRONG - duplicating the entire function
 SkColor ChromeTypographyProvider::GetColor(...) {
@@ -47,6 +61,7 @@ SkColor ChromeTypographyProvider::GetColor(...) {
 ```
 
 **GOOD:**
+
 ```cpp
 // ✅ CORRECT - wrap only the changed section
 SkColor ChromeTypographyProvider::GetColor(...) {
@@ -63,7 +78,9 @@ SkColor ChromeTypographyProvider::GetColor(...) {
 
 ## ✅ Prefer chromium_src Overrides Over Patches
 
-**Always prefer a chromium_src override over adding a patch.** Patches are harder to maintain, more likely to conflict, and harder to review. Required header files should be added through chromium_src overrides, not patches.
+**Always prefer a chromium_src override over adding a patch.** Patches are
+harder to maintain, more likely to conflict, and harder to review. Required
+header files should be added through chromium_src overrides, not patches.
 
 ```cpp
 // ❌ WRONG - adding a patch to include a header
@@ -75,7 +92,8 @@ SkColor ChromeTypographyProvider::GetColor(...) {
 #include "brave/components/my_feature/my_header.h"
 ```
 
-When you need to add virtual to a method, add a class method, or intercept behavior, always use chromium_src overrides instead of patches.
+When you need to add virtual to a method, add a class method, or intercept
+behavior, always use chromium_src overrides instead of patches.
 
 ---
 
@@ -83,7 +101,9 @@ When you need to add virtual to a method, add a class method, or intercept behav
 
 ## ❌ Never Copy Entire Files or Methods
 
-**Never copy entire Chromium files or methods into chromium_src.** Only override the specific part that needs to change, and call the superclass for everything else.
+**Never copy entire Chromium files or methods into chromium_src.** Only override
+the specific part that needs to change, and call the superclass for everything
+else.
 
 ```cpp
 // ❌ WRONG - copying entire method (50+ lines) when only 3 lines differ
@@ -107,9 +127,11 @@ void SomeClass::LargeMethod() {
 
 ## ✅ Prefer Subclassing Over Patching
 
-**When possible, subclass Chromium classes using chromium_src overrides instead of patching.** This applies to both C++ and Java.
+**When possible, subclass Chromium classes using chromium_src overrides instead
+of patching.** This applies to both C++ and Java.
 
 **C++ example - changing a class via chromium_src:**
+
 ```cpp
 // ❌ WRONG - patching tab_strip.cc to change behavior
 +  BraveNewTabButton* new_tab_button = new BraveNewTabButton(...);
@@ -120,6 +142,7 @@ void SomeClass::LargeMethod() {
 ```
 
 **Java example - subclassing instead of patching:**
+
 ```java
 // ❌ WRONG - patching IncognitoNewTabPageView directly
 
@@ -127,7 +150,9 @@ void SomeClass::LargeMethod() {
 // Patch only changes the superclass reference
 ```
 
-Subclassing is better for long-term maintenance and makes changes easier to understand. One patch to change a superclass is better than multiple patches to modify individual methods.
+Subclassing is better for long-term maintenance and makes changes easier to
+understand. One patch to change a superclass is better than multiple patches to
+modify individual methods.
 
 ---
 
@@ -135,7 +160,8 @@ Subclassing is better for long-term maintenance and makes changes easier to unde
 
 ## ✅ Always Use Original Header Paths
 
-**In chromium_src overrides, always `#include` the original header path, not the chromium_src version.**
+**In chromium_src overrides, always `#include` the original header path, not the
+chromium_src version.**
 
 ```cpp
 // ❌ WRONG
@@ -151,7 +177,9 @@ Subclassing is better for long-term maintenance and makes changes easier to unde
 
 ## ✅ Replace Entire Classes with Dummy chromium_src Files
 
-**When you need to disable or replace a Chromium class entirely, create a minimal no-op dummy replacement in chromium_src for the `.h` and `.cc` files.** This avoids needing a patch and makes maintenance easier.
+**When you need to disable or replace a Chromium class entirely, create a
+minimal no-op dummy replacement in chromium_src for the `.h` and `.cc` files.**
+This avoids needing a patch and makes maintenance easier.
 
 ```cpp
 // ❌ WRONG - two patches to disable a class
@@ -173,7 +201,8 @@ class TranslateURLFetcher {
 
 ## ✅ Use `#define` to Add `virtual` Without Patches
 
-**When a Chromium method needs to be made virtual for override, use a `#define` in a chromium_src override of the header instead of a patch.**
+**When a Chromium method needs to be made virtual for override, use a `#define`
+in a chromium_src override of the header instead of a patch.**
 
 ```cpp
 // ❌ WRONG - patch to add virtual keyword
@@ -186,7 +215,8 @@ class TranslateURLFetcher {
 #undef SomeMethod
 ```
 
-Note: This technique does not work when the return type is a pointer or reference (e.g., `T* Method()`).
+Note: This technique does not work when the return type is a pointer or
+reference (e.g., `T* Method()`).
 
 ---
 
@@ -194,7 +224,10 @@ Note: This technique does not work when the return type is a pointer or referenc
 
 ## ❌ Never Use `#define final` to Remove the `final` Keyword
 
-**Redefining `final` via `#define` is undefined behavior per the C++ standard and is highly viral.** It can cause build failures in unrelated code that uses `final` in different contexts. Use a patch to remove `final` when subclassing is required, or find alternative approaches.
+**Redefining `final` via `#define` is undefined behavior per the C++ standard
+and is highly viral.** It can cause build failures in unrelated code that uses
+`final` in different contexts. Use a patch to remove `final` when subclassing is
+required, or find alternative approaches.
 
 ```cpp
 // ❌ WRONG - undefined behavior, viral side effects
@@ -212,9 +245,17 @@ Note: This technique does not work when the return type is a pointer or referenc
 
 ## ✅ Add Explanation Comments in chromium_src Override Files
 
-**When creating a chromium_src override, include comments explaining why the override is needed.** The override's purpose is not always self-evident from the code alone. Per-function comments explaining each overridden function are sufficient — a global file-level comment is not required if the per-function comments adequately explain the purpose.
+**When creating a chromium_src override, include comments explaining why the
+override is needed.** The override's purpose is not always self-evident from the
+code alone. Per-function comments explaining each overridden function are
+sufficient — a global file-level comment is not required if the per-function
+comments adequately explain the purpose.
 
-**Exception:** Do not request doc comments on method declarations injected inside `#define` macros (e.g., macros that add virtual methods to an upstream class). Comments cannot be practically added inside macro bodies. If documentation is needed, it belongs in the header file that defines the macro or in the implementation file, not inline in the macro expansion.
+**Exception:** Do not request doc comments on method declarations injected
+inside `#define` macros (e.g., macros that add virtual methods to an upstream
+class). Comments cannot be practically added inside macro bodies. If
+documentation is needed, it belongs in the header file that defines the macro or
+in the implementation file, not inline in the macro expansion.
 
 ```cpp
 // chromium_src/chrome/browser/ui/views/tabs/tab_view.cc
@@ -232,9 +273,13 @@ void TabView::BuildContextMenu() {
 
 ## ✅ Verify chromium_src Header GN Dependencies
 
-**When adding new `#include` directives in chromium_src override files, verify they have required GN dependencies.** The override file is compiled as part of the upstream target, which may not have deps on your Brave headers.
+**When adding new `#include` directives in chromium_src override files, verify
+they have required GN dependencies.** The override file is compiled as part of
+the upstream target, which may not have deps on your Brave headers.
 
-**How to verify:** Temporarily add the same headers to the original upstream file and run `gn check`. If it fails, the upstream target needs the dependency added (typically via a patch or `sources.gni`).
+**How to verify:** Temporarily add the same headers to the original upstream
+file and run `gn check`. If it fails, the upstream target needs the dependency
+added (typically via a patch or `sources.gni`).
 
 ```bash
 # Test: add the header to the original file temporarily, then:
@@ -248,7 +293,10 @@ gn check out/Default
 
 ## ❌ chromium_src Must Not Depend on Brave Component Targets
 
-**The chromium_src layer must never have GN dependencies on `//brave/components/` targets.** This prevents patch churn when upstream modularizes targets. Use forward declarations in chromium_src with implementations resolved at link time from other targets via `sources.gni`.
+**The chromium_src layer must never have GN dependencies on
+`//brave/components/` targets.** This prevents patch churn when upstream
+modularizes targets. Use forward declarations in chromium_src with
+implementations resolved at link time from other targets via `sources.gni`.
 
 ```cpp
 // ❌ WRONG - direct include from chromium_src to brave component
@@ -268,7 +316,9 @@ CreateBraveBrowserPolicyProvider();
 
 ## ✅ Add Comments for Non-Obvious nullptr Assignments in chromium_src
 
-**Add comments explaining non-obvious nullptr assignments in chromium_src overrides,** especially for dangling pointer prevention. Since chromium_src code is out of context from the original file, the intent is not always clear.
+**Add comments explaining non-obvious nullptr assignments in chromium_src
+overrides,** especially for dangling pointer prevention. Since chromium_src code
+is out of context from the original file, the intent is not always clear.
 
 ```cpp
 // ❌ WRONG - unclear why setting to nullptr
@@ -285,7 +335,9 @@ provider_ = nullptr;
 
 ## ✅ Use `static_assert` to Protect Against Upstream Enum Changes
 
-**When adding custom values after an upstream enum's last value, add a `static_assert`** to detect if upstream changes their enum count. This prevents value clashes when upstream adds new values.
+**When adding custom values after an upstream enum's last value, add a
+`static_assert`** to detect if upstream changes their enum count. This prevents
+value clashes when upstream adds new values.
 
 ```cpp
 // ✅ CORRECT - protected against upstream changes
@@ -300,7 +352,10 @@ static_assert(static_cast<int>(policy::POLICY_SOURCE_COUNT) <= kBravePolicySourc
 
 ## ✅ Use `runtime_enabled_features.override.json5` for Blink Features
 
-**When adding Brave-specific Blink runtime-enabled features, add them to `runtime_enabled_features.override.json5` instead of patching `runtime_enabled_features.json5`.** The override file is designed for downstream additions and never changes upstream, preventing patch conflicts.
+**When adding Brave-specific Blink runtime-enabled features, add them to
+`runtime_enabled_features.override.json5` instead of patching
+`runtime_enabled_features.json5`.** The override file is designed for downstream
+additions and never changes upstream, preventing patch conflicts.
 
 ```json5
 // ❌ WRONG - patching runtime_enabled_features.json5 (causes conflicts)
@@ -320,7 +375,11 @@ static_assert(static_cast<int>(policy::POLICY_SOURCE_COUNT) <= kBravePolicySourc
 
 ## ❌ `chromium_src` Overrides Cannot Handle Private Methods in `.cc` Files
 
-**The `chromium_src` override mechanism only works for symbols with external linkage.** Private (static or anonymous-namespace) methods in upstream `.cc` files cannot be overridden via `chromium_src` because they are not visible outside the translation unit. Use a direct `.patch` file for these cases instead.
+**The `chromium_src` override mechanism only works for symbols with external
+linkage.** Private (static or anonymous-namespace) methods in upstream `.cc`
+files cannot be overridden via `chromium_src` because they are not visible
+outside the translation unit. Use a direct `.patch` file for these cases
+instead.
 
 ```cpp
 // Upstream file: chrome/browser/feature.cc
@@ -337,7 +396,13 @@ void PrivateHelper() { ... }  // Cannot override via chromium_src
 
 ## ⚠️ Override Replacement Strings Must Have Compatible Placeholders
 
-**When creating a Brave replacement string that is substituted for an upstream string via `#undef`/`#define`, the replacement string must have compatible placeholders.** The upstream code calling the string supplies specific placeholder values (`$1`, `$2`, etc.). If your replacement string has fewer placeholders, extras are silently ignored. If it has more or different placeholders, it can cause runtime errors. Always check what placeholders the upstream caller provides and match them.
+**When creating a Brave replacement string that is substituted for an upstream
+string via `#undef`/`#define`, the replacement string must have compatible
+placeholders.** The upstream code calling the string supplies specific
+placeholder values (`$1`, `$2`, etc.). If your replacement string has fewer
+placeholders, extras are silently ignored. If it has more or different
+placeholders, it can cause runtime errors. Always check what placeholders the
+upstream caller provides and match them.
 
 ---
 
@@ -345,7 +410,11 @@ void PrivateHelper() { ... }  // Cannot override via chromium_src
 
 ## ✅ Guard Overridden String IDs with `#ifndef`/`#error`
 
-**When overriding an upstream string ID via `#undef`/`#define`, add a compile-time guard to detect if the upstream ID is removed or renamed during a rebase.** The `check_chromium_src.py` tool verifies symbols are still used in the overridden file, but a `#ifndef`/`#error` guard provides an additional safety net.
+**When overriding an upstream string ID via `#undef`/`#define`, add a
+compile-time guard to detect if the upstream ID is removed or renamed during a
+rebase.** The `check_chromium_src.py` tool verifies symbols are still used in
+the overridden file, but a `#ifndef`/`#error` guard provides an additional
+safety net.
 
 ```cpp
 // ✅ CORRECT - compile-time guard catches upstream removals
@@ -363,7 +432,10 @@ void PrivateHelper() { ... }  // Cannot override via chromium_src
 
 ## ✅ Fallback Methods Must Call the Correct Base Class
 
-**When overriding a chromium_src fallback method, ensure the fallback calls the correct base class method.** A common bug is calling the wrong superclass method (e.g., calling `ChromeTypographyProvider::Method()` when the override class uses a `#define` rename that changes the class hierarchy).
+**When overriding a chromium_src fallback method, ensure the fallback calls the
+correct base class method.** A common bug is calling the wrong superclass method
+(e.g., calling `ChromeTypographyProvider::Method()` when the override class uses
+a `#define` rename that changes the class hierarchy).
 
 ```cpp
 // ❌ WRONG - calls wrong base class (should be ChromiumImpl, not original)

--- a/docs/best-practices/coding-standards-apis.md
+++ b/docs/best-practices/coding-standards-apis.md
@@ -6,7 +6,8 @@
 
 ## ✅ Use Existing Utilities Instead of Custom Code
 
-**Always check for existing well-tested utilities before writing custom code.** Chromium and base have extensive libraries for common operations.
+**Always check for existing well-tested utilities before writing custom code.**
+Chromium and base have extensive libraries for common operations.
 
 ```cpp
 // ❌ WRONG - custom query string parsing
@@ -28,7 +29,10 @@ while (!it.IsAtEnd()) {
 
 ## ✅ Use base::OnceCallback and base::BindOnce
 
-**`base::Callback` and `base::Bind` are deprecated.** Use `base::OnceCallback`/`base::RepeatingCallback` and `base::BindOnce`/`base::BindRepeating`. Use `std::move` when passing or calling a `base::OnceCallback`.
+**`base::Callback` and `base::Bind` are deprecated.** Use
+`base::OnceCallback`/`base::RepeatingCallback` and
+`base::BindOnce`/`base::BindRepeating`. Use `std::move` when passing or calling
+a `base::OnceCallback`.
 
 ---
 
@@ -36,7 +40,9 @@ while (!it.IsAtEnd()) {
 
 ## ✅ Never Use std::time - Use base::Time
 
-**Always use `base::Time` and related classes instead of C-style `std::time`, `ctime`, or `time_t`.** The base library provides cross-platform, type-safe time utilities.
+**Always use `base::Time` and related classes instead of C-style `std::time`,
+`ctime`, or `time_t`.** The base library provides cross-platform, type-safe time
+utilities.
 
 ---
 
@@ -44,7 +50,9 @@ while (!it.IsAtEnd()) {
 
 ## ✅ Use `JSONValueConverter` for JSON/Type Conversion
 
-**When parsing JSON into C++ types, prefer `base::JSONValueConverter` over manual key-by-key parsing.** Manual parsing is verbose, error-prone, and results in duplicated boilerplate.
+**When parsing JSON into C++ types, prefer `base::JSONValueConverter` over
+manual key-by-key parsing.** Manual parsing is verbose, error-prone, and results
+in duplicated boilerplate.
 
 ```cpp
 // ❌ WRONG - manual JSON parsing
@@ -67,15 +75,23 @@ static void RegisterJSONConverter(
 
 ## ✅ Use the Right Associative Container
 
-**Chromium's container guidelines (`base/containers/README.md`) recommend specific containers for each use case.** `std::unordered_map`/`std::unordered_set` are banned.
+**Chromium's container guidelines (`base/containers/README.md`) recommend
+specific containers for each use case.**
+`std::unordered_map`/`std::unordered_set` are banned.
 
-**Default (unordered):** Use `absl::flat_hash_map` and `absl::flat_hash_set` for general-purpose needs. They provide the best all-around performance for both small and large datasets.
+**Default (unordered):** Use `absl::flat_hash_map` and `absl::flat_hash_set` for
+general-purpose needs. They provide the best all-around performance for both
+small and large datasets.
 
-**Sorted, write-once or small:** Use `base::flat_map`/`base::flat_set`. Good cache locality; O(n) mutations are fine for small collections or write-once containers.
+**Sorted, write-once or small:** Use `base::flat_map`/`base::flat_set`. Good
+cache locality; O(n) mutations are fine for small collections or write-once
+containers.
 
-**Sorted, large, frequently-mutated:** Use `std::map`/`std::set`. O(log n) mutations matter at scale.
+**Sorted, large, frequently-mutated:** Use `std::map`/`std::set`. O(log n)
+mutations matter at scale.
 
-**Compile-time lookup tables:** Use `base::MakeFixedFlatMap`/`base::MakeFixedFlatSet` (see [CSA-045](#CSA-045)).
+**Compile-time lookup tables:** Use
+`base::MakeFixedFlatMap`/`base::MakeFixedFlatSet` (see [CSA-045](#CSA-045)).
 
 ```cpp
 // ❌ WRONG - banned
@@ -91,7 +107,10 @@ base::flat_map<std::string, int> lookup_;
 std::map<std::string, int> large_mutable_lookup_;
 ```
 
-**Pointer stability:** If you need stable pointers to values, wrap them in `std::unique_ptr` inside an `absl::flat_hash_map`. If you need stable pointers to keys, use `absl::node_hash_map`/`absl::node_hash_set` (separate node allocation).
+**Pointer stability:** If you need stable pointers to values, wrap them in
+`std::unique_ptr` inside an `absl::flat_hash_map`. If you need stable pointers
+to keys, use `absl::node_hash_map`/`absl::node_hash_set` (separate node
+allocation).
 
 ```cpp
 // ✅ CORRECT - value pointer stability via unique_ptr wrapping
@@ -101,7 +120,9 @@ absl::flat_hash_map<Key, std::unique_ptr<Value>> stable_values;
 absl::node_hash_map<std::string, int> stable_keys;
 ```
 
-**Also banned:** `absl::btree_map`/`absl::btree_set` (significant code size penalties in Chromium). See [Chromium container guidelines](https://chromium.googlesource.com/chromium/src/+/HEAD/base/containers/README.md).
+**Also banned:** `absl::btree_map`/`absl::btree_set` (significant code size
+penalties in Chromium). See
+[Chromium container guidelines](https://chromium.googlesource.com/chromium/src/+/HEAD/base/containers/README.md).
 
 ---
 
@@ -109,7 +130,9 @@ absl::node_hash_map<std::string, int> stable_keys;
 
 ## ❌ Don't Use Deprecated `GetAs*` Methods on `base::Value`
 
-**The `GetAsString()`, `GetAsInteger()`, etc. methods on `base::Value` are deprecated.** Use the newer direct access methods like `GetString()`, `GetInt()`, `GetDouble()`.
+**The `GetAsString()`, `GetAsInteger()`, etc. methods on `base::Value` are
+deprecated.** Use the newer direct access methods like `GetString()`,
+`GetInt()`, `GetDouble()`.
 
 ```cpp
 // ❌ WRONG
@@ -126,7 +149,8 @@ const std::string& str = value->GetString();
 
 ## ✅ Use `GetIfBool`/`GetIfInt`/`GetIfString` for Safe `base::Value` Access
 
-**When extracting values from a `base::Value` where the type may not match, use `GetIf*` accessors instead of `Get*` which CHECK-fails on type mismatch.**
+**When extracting values from a `base::Value` where the type may not match, use
+`GetIf*` accessors instead of `Get*` which CHECK-fails on type mismatch.**
 
 ```cpp
 // ❌ WRONG - crashes if value is not a bool
@@ -142,7 +166,8 @@ if (value.GetIfBool().value_or(false)) { ... }
 
 ## ❌ Don't Use `std::to_string` - Use `base::NumberToString`
 
-**`std::to_string` is on Chromium's deprecated list.** Use `base::NumberToString` instead.
+**`std::to_string` is on Chromium's deprecated list.** Use
+`base::NumberToString` instead.
 
 ```cpp
 // ❌ WRONG
@@ -158,7 +183,8 @@ std::string port_str = base::NumberToString(port);
 
 ## ❌ Don't Use C-Style Casts
 
-**Chromium prohibits C-style casts.** Use C++ casts (`static_cast`, `reinterpret_cast`, etc.) which are safer and more explicit.
+**Chromium prohibits C-style casts.** Use C++ casts (`static_cast`,
+`reinterpret_cast`, etc.) which are safer and more explicit.
 
 ```cpp
 // ❌ WRONG
@@ -174,7 +200,10 @@ double result = static_cast<double>(integer_value) / total;
 
 ## ✅ Prefer std::move Over Clone
 
-**Use `std::move` instead of cloning when you don't need the original value anymore.** This avoids unnecessary copies. This is especially important when passing `std::vector` or other large objects to callback `.Run()` calls — forgetting `std::move` silently copies the entire buffer.
+**Use `std::move` instead of cloning when you don't need the original value
+anymore.** This avoids unnecessary copies. This is especially important when
+passing `std::vector` or other large objects to callback `.Run()` calls —
+forgetting `std::move` silently copies the entire buffer.
 
 ```cpp
 // ❌ WRONG - copies the entire vector into the callback
@@ -192,7 +221,8 @@ std::move(cb).Run(std::move(buffer), other_arg);
 
 ## ❌ Don't Create Unnecessary Wrapper Types
 
-**Don't create plural/container types when you can use arrays of the singular type.** Extra wrapper types add complexity without value.
+**Don't create plural/container types when you can use arrays of the singular
+type.** Extra wrapper types add complexity without value.
 
 ```cpp
 // ❌ WRONG - unnecessary plural type
@@ -210,7 +240,8 @@ std::vector<MonthlyStatement> GetMonthlyStatements();
 
 ## ✅ Use Pref Dict/List Values Directly
 
-**Don't serialize to JSON strings when storing structured data in prefs.** Use `SetDict`/`SetList` directly instead of `JSONWriter::Write` + `SetString`.
+**Don't serialize to JSON strings when storing structured data in prefs.** Use
+`SetDict`/`SetList` directly instead of `JSONWriter::Write` + `SetString`.
 
 ```cpp
 // ❌ WRONG - serializing to JSON string unnecessarily
@@ -229,7 +260,8 @@ prefs->SetList(prefs::kMyPref, std::move(list_value));
 
 ## ✅ Use `extern const char[]` Over `#define` for Strings
 
-**Use `extern const char[]` instead of `#define` for string constants to keep them namespaced.**
+**Use `extern const char[]` instead of `#define` for string constants to keep
+them namespaced.**
 
 ```cpp
 // ❌ WRONG - pollutes preprocessor namespace
@@ -249,7 +281,9 @@ Exception: use `#define` when you need to pass the value in from GN.
 
 ## ✅ Prefer Enum Types Over String Constants for Typed Values
 
-**When a value has a fixed set of valid options, use an enum with string conversion rather than passing raw strings.** This enables compiler-checked switch statements and prevents invalid values.
+**When a value has a fixed set of valid options, use an enum with string
+conversion rather than passing raw strings.** This enables compiler-checked
+switch statements and prevents invalid values.
 
 ```cpp
 // ❌ WRONG - raw strings
@@ -266,7 +300,8 @@ void SetWalletType(WalletType type);
 
 ## ❌ No C++ Exceptions in Third-Party Libraries
 
-**C++ exceptions are disallowed in Chromium.** When integrating third-party libraries, verify they build with exception support disabled.
+**C++ exceptions are disallowed in Chromium.** When integrating third-party
+libraries, verify they build with exception support disabled.
 
 ---
 
@@ -274,7 +309,9 @@ void SetWalletType(WalletType type);
 
 ## ✅ Use `base::EraseIf` / `std::erase_if` Instead of Manual Erase Loops
 
-**Prefer `base::EraseIf` (for `base::flat_*` containers) or `std::erase_if` (for standard containers) over manual iterator-based erase loops.** Cleaner and less error-prone.
+**Prefer `base::EraseIf` (for `base::flat_*` containers) or `std::erase_if` (for
+standard containers) over manual iterator-based erase loops.** Cleaner and less
+error-prone.
 
 ```cpp
 // ❌ WRONG - manual erase loop
@@ -298,7 +335,10 @@ std::erase_if(items, [](const auto& item) { return item.IsExpired(); });
 
 ## ✅ Use `base::span` at API Boundaries Instead of `const std::vector&`
 
-**Prefer `base::span<const T>` over `const std::vector<T>&` for function parameters that only read data.** Spans are lightweight, non-owning views that accept any contiguous container (`std::vector`, `base::HeapArray`, C arrays, `base::FixedArray`), making APIs more flexible.
+**Prefer `base::span<const T>` over `const std::vector<T>&` for function
+parameters that only read data.** Spans are lightweight, non-owning views that
+accept any contiguous container (`std::vector`, `base::HeapArray`, C arrays,
+`base::FixedArray`), making APIs more flexible.
 
 ```cpp
 // ❌ WRONG - forces callers to use std::vector
@@ -308,7 +348,8 @@ void ProcessBuffer(const std::vector<uint8_t>& data);
 void ProcessBuffer(base::span<const uint8_t> data);
 ```
 
-This is especially important for byte buffer APIs where the data source may be a `std::vector`, `base::HeapArray`, or a static array.
+This is especially important for byte buffer APIs where the data source may be a
+`std::vector`, `base::HeapArray`, or a static array.
 
 ---
 
@@ -316,7 +357,9 @@ This is especially important for byte buffer APIs where the data source may be a
 
 ## ✅ Use `base::FixedArray` Over `std::vector` for Known-Size Runtime Allocations
 
-**When the size is known at creation but not at compile time, use `base::FixedArray`.** It avoids heap allocation for small sizes and communicates immutable size.
+**When the size is known at creation but not at compile time, use
+`base::FixedArray`.** It avoids heap allocation for small sizes and communicates
+immutable size.
 
 ```cpp
 // ❌ WRONG - vector suggests dynamic resizing
@@ -332,7 +375,10 @@ base::FixedArray<uint8_t> out(size);
 
 ## ✅ Use `base::HeapArray<uint8_t>` for Fixed-Size Byte Buffers
 
-**When you need an owned byte buffer that won't be resized after creation, use `base::HeapArray<uint8_t>` instead of `std::vector<unsigned char>` or `std::vector<uint8_t>`.** `HeapArray` communicates that the size is fixed, provides bounds-checked indexing, and converts easily to `base::span`.
+**When you need an owned byte buffer that won't be resized after creation, use
+`base::HeapArray<uint8_t>` instead of `std::vector<unsigned char>` or
+`std::vector<uint8_t>`.** `HeapArray` communicates that the size is fixed,
+provides bounds-checked indexing, and converts easily to `base::span`.
 
 ```cpp
 // ❌ WRONG - vector implies the buffer may grow
@@ -344,9 +390,12 @@ auto dat_buffer = base::HeapArray<uint8_t>::WithSize(size);
 ProcessBuffer(dat_buffer.as_span());
 ```
 
-Use `HeapArray::Uninit(size)` for performance-sensitive paths where zero-initialization is unnecessary.
+Use `HeapArray::Uninit(size)` for performance-sensitive paths where
+zero-initialization is unnecessary.
 
-**Note:** When interfaces (e.g., Mojo, Rust FFI) require `std::vector`, you may need to keep using `std::vector` at those boundaries, but prefer `HeapArray` for internal buffer management.
+**Note:** When interfaces (e.g., Mojo, Rust FFI) require `std::vector`, you may
+need to keep using `std::vector` at those boundaries, but prefer `HeapArray` for
+internal buffer management.
 
 ---
 
@@ -354,7 +403,9 @@ Use `HeapArray::Uninit(size)` for performance-sensitive paths where zero-initial
 
 ## ✅ Use `base::ToVector` for Range-to-Vector Conversions
 
-**Use `base::ToVector(range)` instead of manual copy patterns when converting a range to a `std::vector`.** It handles `reserve()` and iteration automatically, and supports projections.
+**Use `base::ToVector(range)` instead of manual copy patterns when converting a
+range to a `std::vector`.** It handles `reserve()` and iteration automatically,
+and supports projections.
 
 ```cpp
 // ❌ WRONG - manual reserve + copy + back_inserter
@@ -376,7 +427,9 @@ auto names = base::ToVector(items, &Item::name);
 
 ## ✅ Prefer Contiguous Containers Over Linked Lists
 
-**Never use `std::list` for pure traversal — poor cache locality.** Use `std::list` only when stable iterators or frequent mid-container insert/remove is required. Prefer `std::vector` with `reserve()` for known sizes.
+**Never use `std::list` for pure traversal — poor cache locality.** Use
+`std::list` only when stable iterators or frequent mid-container insert/remove
+is required. Prefer `std::vector` with `reserve()` for known sizes.
 
 ---
 
@@ -384,7 +437,8 @@ auto names = base::ToVector(items, &Item::name);
 
 ## ✅ Use `std::optional` Instead of Sentinel Values
 
-**Never use empty string `""`, `-1`, or other magic values as sentinels for "no value".** Use `std::optional<T>`.
+**Never use empty string `""`, `-1`, or other magic values as sentinels for "no
+value".** Use `std::optional<T>`.
 
 ```cpp
 // ❌ WRONG - "" as sentinel for "no custom title"
@@ -400,7 +454,8 @@ void SetCustomTitle(std::optional<std::string> title);  // nullopt means "unset"
 
 ## ✅ Use `.emplace()` for `std::optional` Initialization Clarity
 
-**When engaging a `std::optional` member, prefer `.emplace()` for clarity about the intent.**
+**When engaging a `std::optional` member, prefer `.emplace()` for clarity about
+the intent.**
 
 ```cpp
 // Less clear
@@ -416,7 +471,8 @@ elapsed_timer_.emplace();
 
 ## ✅ Return `std::optional` Instead of `bool` + Out Parameter
 
-**When a function needs to return a value that may or may not exist, use `std::optional<T>` instead of returning `bool` with an out parameter.**
+**When a function needs to return a value that may or may not exist, use
+`std::optional<T>` instead of returning `bool` with an out parameter.**
 
 ```cpp
 // ❌ WRONG
@@ -432,7 +488,9 @@ std::optional<int> GetHistorySize();
 
 ## ✅ Use `constexpr` for Compile-Time Constants
 
-**Constants defined in anonymous namespaces should use `constexpr` instead of `const` when the value is known at compile time.** Place constants inside the component's namespace.
+**Constants defined in anonymous namespaces should use `constexpr` instead of
+`const` when the value is known at compile time.** Place constants inside the
+component's namespace.
 
 ```cpp
 // ❌ WRONG
@@ -454,7 +512,8 @@ constexpr int kMaxRetries = 3;
 
 ## ✅ Use Raw String Literals for Multiline Strings
 
-**When embedding multiline strings (JavaScript, SQL, etc.), use raw string literals (`R"()"`) instead of escaping each line.**
+**When embedding multiline strings (JavaScript, SQL, etc.), use raw string
+literals (`R"()"`) instead of escaping each line.**
 
 ```cpp
 // ❌ WRONG
@@ -477,7 +536,8 @@ const char kScript[] = R"(
 
 ## ❌ Don't Pass Primitive Types by `const` Reference
 
-**Primitive types (`int`, `bool`, `float`, pointers) should be passed by value, not by `const` reference.** Passing by reference adds unnecessary indirection.
+**Primitive types (`int`, `bool`, `float`, pointers) should be passed by value,
+not by `const` reference.** Passing by reference adds unnecessary indirection.
 
 ```cpp
 // ❌ WRONG
@@ -493,7 +553,8 @@ void ProcessItem(int id, bool enabled);
 
 ## ❌ Don't Add `DISALLOW_COPY_AND_ASSIGN` in New Code
 
-**The `DISALLOW_COPY_AND_ASSIGN` macro is deprecated.** Explicitly delete the copy constructor and copy assignment operator instead.
+**The `DISALLOW_COPY_AND_ASSIGN` macro is deprecated.** Explicitly delete the
+copy constructor and copy assignment operator instead.
 
 ```cpp
 // ❌ WRONG
@@ -516,7 +577,9 @@ class MyClass {
 
 ## ✅ Declare Move Operations as `noexcept`
 
-**When defining custom move constructors/assignment operators for structs used in `std::vector`, declare them `noexcept`.** Without `noexcept`, `std::vector` falls back to copying during reallocations.
+**When defining custom move constructors/assignment operators for structs used
+in `std::vector`, declare them `noexcept`.** Without `noexcept`, `std::vector`
+falls back to copying during reallocations.
 
 ```cpp
 // ❌ WRONG
@@ -533,7 +596,9 @@ Topic& operator=(Topic&&) noexcept = default;
 
 ## ❌ Avoid `std::optional<T>&` References
 
-**Never pass `std::optional<T>&` as a function parameter.** It's confusing and can cause hidden copies. Take by value if storing, or use `base::optional_ref<T>` for non-owning optional references.
+**Never pass `std::optional<T>&` as a function parameter.** It's confusing and
+can cause hidden copies. Take by value if storing, or use
+`base::optional_ref<T>` for non-owning optional references.
 
 ```cpp
 // ❌ WRONG - confusing, hidden copies
@@ -552,7 +617,9 @@ void Process(base::optional_ref<const std::string> value);
 
 ## ✅ Short-Circuit on Non-HTTP(S) URLs
 
-**In URL processing code (shields, debouncing, content settings), add an early return for non-HTTP/HTTPS URLs.** This prevents wasting time on irrelevant schemes and avoids edge cases.
+**In URL processing code (shields, debouncing, content settings), add an early
+return for non-HTTP/HTTPS URLs.** This prevents wasting time on irrelevant
+schemes and avoids edge cases.
 
 ```cpp
 // ✅ CORRECT - early exit
@@ -569,7 +636,10 @@ bool ShouldDebounce(const GURL& url) {
 
 ## ❌ Don't Narrow Integer Types in Setters or Parameters
 
-**Setter and function parameter types must match the underlying field type.** Accepting a narrower type (e.g., `uint32_t` when the field is `uint64_t`) silently truncates values. This is especially dangerous in security-sensitive code like wallet/crypto transactions.
+**Setter and function parameter types must match the underlying field type.**
+Accepting a narrower type (e.g., `uint32_t` when the field is `uint64_t`)
+silently truncates values. This is especially dangerous in security-sensitive
+code like wallet/crypto transactions.
 
 ```cpp
 // ❌ WRONG - parameter narrower than field, silent truncation
@@ -591,7 +661,9 @@ class Transaction {
 
 ## ✅ Deprecate Prefs Before Removing Them
 
-**When removing a preference that was previously stored in user profiles, first deprecate the pref (register it for clearing) in one release before fully removing it.** This ensures the old value is cleared from existing profiles.
+**When removing a preference that was previously stored in user profiles, first
+deprecate the pref (register it for clearing) in one release before fully
+removing it.** This ensures the old value is cleared from existing profiles.
 
 ---
 
@@ -599,11 +671,22 @@ class Transaction {
 
 ## ❌ Don't Modify Production Code Solely to Accommodate Tests
 
-**Test-specific workarounds should not affect production behavior.** Use test infrastructure like `kHostResolverRules` command line switches in `SetUpCommandLine` instead of adding production code paths only needed for tests.
+**Test-specific workarounds should not affect production behavior.** Use test
+infrastructure like `kHostResolverRules` command line switches in
+`SetUpCommandLine` instead of adding production code paths only needed for
+tests.
 
-**Only flag this rule when you are certain the code exists solely for tests.** Clear signals include `CHECK_IS_TEST()`, `#if defined(UNIT_TEST)`, `_for_testing` suffixes, or comments explicitly mentioning test support. Do NOT flag legitimate production logic such as handling empty/null/default values, reset paths, or cleanup behavior — these are normal defensive coding patterns, not test accommodations. When uncertain, do not flag.
+**Only flag this rule when you are certain the code exists solely for tests.**
+Clear signals include `CHECK_IS_TEST()`, `#if defined(UNIT_TEST)`,
+`_for_testing` suffixes, or comments explicitly mentioning test support. Do NOT
+flag legitimate production logic such as handling empty/null/default values,
+reset paths, or cleanup behavior — these are normal defensive coding patterns,
+not test accommodations. When uncertain, do not flag.
 
-**Exception:** Thin `ForTesting()` accessors that expose internalized features (e.g., `base::Feature`) are acceptable. These keep the feature internalized while providing a clean way for tests to reference it, and do not affect production behavior.
+**Exception:** Thin `ForTesting()` accessors that expose internalized features
+(e.g., `base::Feature`) are acceptable. These keep the feature internalized
+while providing a clean way for tests to reference it, and do not affect
+production behavior.
 
 ---
 
@@ -611,7 +694,9 @@ class Transaction {
 
 ## ✅ Use `url::kStandardSchemeSeparator` Instead of Hardcoded `"://"`
 
-**When constructing URLs, use `url::kStandardSchemeSeparator` instead of the hardcoded string `"://"`.** This is more maintainable and consistent with Chromium conventions.
+**When constructing URLs, use `url::kStandardSchemeSeparator` instead of the
+hardcoded string `"://"`.** This is more maintainable and consistent with
+Chromium conventions.
 
 ```cpp
 // ❌ WRONG
@@ -629,7 +714,8 @@ std::string url = base::StrCat({url::kHttpsScheme,
 
 ## ✅ Use `base::DoNothing()` for No-Op Callbacks
 
-**Use `base::DoNothing()` instead of empty lambdas when a no-op callback is needed.** It is the Chromium-idiomatic way and is more readable.
+**Use `base::DoNothing()` instead of empty lambdas when a no-op callback is
+needed.** It is the Chromium-idiomatic way and is more readable.
 
 ```cpp
 // ❌ WRONG - empty lambda
@@ -645,7 +731,10 @@ service->DoAsync(base::DoNothing());
 
 ## ✅ Use `base::StrAppend` Over `+= base::StrCat`
 
-**When appending to an existing string, use `base::StrAppend(&str, {...})` instead of `str += base::StrCat({...})`.** `StrCat` creates a temporary string that is then copied; `StrAppend` appends directly to the target, avoiding unnecessary allocation.
+**When appending to an existing string, use `base::StrAppend(&str, {...})`
+instead of `str += base::StrCat({...})`.** `StrCat` creates a temporary string
+that is then copied; `StrAppend` appends directly to the target, avoiding
+unnecessary allocation.
 
 ```cpp
 // ❌ WRONG - temporary string then copy
@@ -661,7 +750,8 @@ base::StrAppend(&result, {kOpenTag, "\n", "=== METADATA ===\n"});
 
 ## ✅ Use `base::Reversed()` for Reverse Iteration
 
-**Prefer `base::Reversed()` with range-based for loops over explicit reverse iterators.** Always add a comment explaining why reverse order is needed.
+**Prefer `base::Reversed()` with range-based for loops over explicit reverse
+iterators.** Always add a comment explaining why reverse order is needed.
 
 ```cpp
 // ❌ WRONG - explicit reverse iterators
@@ -682,7 +772,8 @@ for (const auto& entry : base::Reversed(history)) {
 
 ## ✅ Use `absl::StrFormat` Over `base::StringPrintf`
 
-**Prefer `absl::StrFormat` for formatted string construction.** `base::StringPrintf` is being deprecated in favor of `absl::StrFormat`.
+**Prefer `absl::StrFormat` for formatted string construction.**
+`base::StringPrintf` is being deprecated in favor of `absl::StrFormat`.
 
 ```cpp
 // ❌ WRONG - deprecated
@@ -698,7 +789,9 @@ std::string msg = absl::StrFormat("Error %d: %s", code, desc);
 
 ## ✅ Use `base::saturated_cast` for Safe Numeric Conversions
 
-**When converting between integer types, use `base::saturated_cast<TargetType>()` combined with `.value_or(default)` for safe, concise conversion of optional numeric values.**
+**When converting between integer types, use
+`base::saturated_cast<TargetType>()` combined with `.value_or(default)` for
+safe, concise conversion of optional numeric values.**
 
 ```cpp
 // ❌ WRONG - manual null-check and static_cast
@@ -716,7 +809,9 @@ result = base::saturated_cast<uint64_t>(value.value_or(0));
 
 ## ✅ Use `std::ranges` Algorithms Over Manual Loops
 
-**Prefer C++20 `std::ranges::any_of`, `std::ranges::all_of`, `std::ranges::find_if` over manual for-loops with break conditions.** The ranges versions are more concise and readable.
+**Prefer C++20 `std::ranges::any_of`, `std::ranges::all_of`,
+`std::ranges::find_if` over manual for-loops with break conditions.** The ranges
+versions are more concise and readable.
 
 ```cpp
 // ❌ WRONG - manual loop
@@ -739,7 +834,9 @@ bool found = std::ranges::any_of(items,
 
 ## ✅ Guard `substr()` with Size Check
 
-**Only call `substr()` when the content actually exceeds the limit.** For content within the limit, use the original string to avoid unnecessary memory allocation and copying.
+**Only call `substr()` when the content actually exceeds the limit.** For
+content within the limit, use the original string to avoid unnecessary memory
+allocation and copying.
 
 ```cpp
 // ❌ WRONG - always creates a substring
@@ -757,7 +854,9 @@ const std::string& truncated = (content.size() > max_length)
 
 ## ✅ Use `base::expected<T, E>` Over Optional + Error Out-Parameter
 
-**When a function can fail and needs to communicate error details, use `base::expected<T, E>` instead of `std::optional<T>` with a separate error out-parameter.** This bundles success and error into a single return value.
+**When a function can fail and needs to communicate error details, use
+`base::expected<T, E>` instead of `std::optional<T>` with a separate error
+out-parameter.** This bundles success and error into a single return value.
 
 ```cpp
 // ❌ WRONG - separate error out-parameter
@@ -773,7 +872,9 @@ base::expected<Result, std::string> Parse(const std::string& input);
 
 ## ✅ Use `base::MakeFixedFlatMap` for Static Enum-to-String Mappings
 
-**For compile-time constant mappings between enums and strings, use `base::MakeFixedFlatMap`.** It provides compile-time verification and is more maintainable than switch statements or runtime-built maps.
+**For compile-time constant mappings between enums and strings, use
+`base::MakeFixedFlatMap`.** It provides compile-time verification and is more
+maintainable than switch statements or runtime-built maps.
 
 ```cpp
 // ❌ WRONG - runtime map
@@ -795,7 +896,10 @@ constexpr auto kActionNames = base::MakeFixedFlatMap<ActionType, std::string_vie
 
 ## ✅ Use `base::JSONReader::ReadDict` for JSON Dictionary Parsing
 
-**When parsing a JSON string expected to be a dictionary, use `base::JSONReader::ReadDict()`** which returns `std::optional<base::Value::Dict>` directly, instead of `base::JSONReader::Read()` followed by manual `GetIfDict()` extraction.
+**When parsing a JSON string expected to be a dictionary, use
+`base::JSONReader::ReadDict()`** which returns
+`std::optional<base::Value::Dict>` directly, instead of
+`base::JSONReader::Read()` followed by manual `GetIfDict()` extraction.
 
 ```cpp
 // ❌ WRONG - manual extraction
@@ -814,7 +918,9 @@ if (!dict) return;
 
 ## ✅ Pass-by-Value for Sink Parameters (Google Style)
 
-**Per Google C++ Style Guide, use pass-by-value for parameters that will be moved into the callee** (sink parameters) instead of `T&&`. The caller uses `std::move()` either way, and pass-by-value is simpler.
+**Per Google C++ Style Guide, use pass-by-value for parameters that will be
+moved into the callee** (sink parameters) instead of `T&&`. The caller uses
+`std::move()` either way, and pass-by-value is simpler.
 
 ```cpp
 // ❌ WRONG - rvalue reference parameter
@@ -830,7 +936,9 @@ void SetName(std::string name) { name_ = std::move(name); }
 
 ## ✅ Annotate Obsolete Pref Migration Entries with Dates
 
-**When adding preference migration code that removes deprecated prefs, annotate the entry with the date it was added.** This makes it easy to identify and clean up old migration code later.
+**When adding preference migration code that removes deprecated prefs, annotate
+the entry with the date it was added.** This makes it easy to identify and clean
+up old migration code later.
 
 ```cpp
 // ❌ WRONG - no context for when this was added
@@ -846,7 +954,8 @@ profile_prefs->ClearPref(kOldFeaturePref);  // Added 2025-01 (safe to remove aft
 
 ## ✅ Use `base::FindOrNull()` for Map Lookups
 
-**Use `base::FindOrNull()` instead of the manual find-and-check-end pattern for map lookups.** It's more concise and less error-prone.
+**Use `base::FindOrNull()` instead of the manual find-and-check-end pattern for
+map lookups.** It's more concise and less error-prone.
 
 ```cpp
 // ❌ WRONG - verbose find + check
@@ -866,7 +975,8 @@ return base::FindOrNull(metric_configs_, metric_name);
 
 ## ✅ Use `base::Extend` for Appending Ranges to Vectors
 
-**Use `base::Extend(target, source)` instead of manual `insert(end, begin, end)` for appending one collection to another.**
+**Use `base::Extend(target, source)` instead of manual `insert(end, begin, end)`
+for appending one collection to another.**
 
 ```cpp
 // ❌ WRONG - verbose
@@ -883,7 +993,10 @@ base::Extend(accelerator_list, base::span(kBraveAcceleratorMap));
 
 ## ✅ Use `base::test::ParseJson` and `base::ExpectDict*` in Tests
 
-**Use `base::test::ParseJson()` for parsing JSON in tests, and `base::test::*` utilities from `base/test/values_test_util.h` for asserting dict contents.** These are more readable and produce better error messages than manual JSON parsing.
+**Use `base::test::ParseJson()` for parsing JSON in tests, and `base::test::*`
+utilities from `base/test/values_test_util.h` for asserting dict contents.**
+These are more readable and produce better error messages than manual JSON
+parsing.
 
 ```cpp
 // ❌ WRONG - manual JSON parsing in tests
@@ -905,7 +1018,8 @@ EXPECT_THAT(dict, base::test::DictHasValue("name", "test"));
 
 ## ✅ Use `kOsAll` for Cross-Platform Feature Flags
 
-**When registering feature flags in `about_flags.cc` that should be available on all platforms, use `kOsAll`** instead of listing individual platform constants.
+**When registering feature flags in `about_flags.cc` that should be available on
+all platforms, use `kOsAll`** instead of listing individual platform constants.
 
 ```cpp
 // ❌ WRONG - listing platforms individually
@@ -921,9 +1035,16 @@ EXPECT_THAT(dict, base::test::DictHasValue("name", "test"));
 
 ## ✅ Workaround Code Must Have Tracking Issues
 
-**Any temporary workaround or hack code must reference a tracking issue with a `TODO(https://github.com/brave/brave-browser/issues/<id>)` comment** explaining when and why it can be removed. Workarounds without tracking issues become permanent technical debt.
+**Any temporary workaround or hack code must reference a tracking issue with a
+`TODO(https://github.com/brave/brave-browser/issues/<id>)` comment** explaining
+when and why it can be removed. Workarounds without tracking issues become
+permanent technical debt.
 
-**This rule does NOT apply to permanent design decisions.** If a comment explains why an alternative API or approach was not used due to a known limitation, and the current code is the intended long-term solution (not something to revisit later), it is not a workaround -- it is a design rationale comment and does not need a tracking issue.
+**This rule does NOT apply to permanent design decisions.** If a comment
+explains why an alternative API or approach was not used due to a known
+limitation, and the current code is the intended long-term solution (not
+something to revisit later), it is not a workaround -- it is a design rationale
+comment and does not need a tracking issue.
 
 ```cpp
 // ❌ WRONG - unexplained workaround
@@ -948,7 +1069,9 @@ base::OneShotTimer idle_timer_;
 
 ## ✅ Use Named Constants for JSON Property Keys
 
-**When accessing JSON object properties in C++, define named constants for the key strings** rather than using inline string literals. This prevents typos and makes refactoring easier.
+**When accessing JSON object properties in C++, define named constants for the
+key strings** rather than using inline string literals. This prevents typos and
+makes refactoring easier.
 
 ```cpp
 // ❌ WRONG - inline string literals
@@ -968,7 +1091,10 @@ auto* url = dict.FindString(kEndpointUrl);
 
 ## ❌ Never Return `std::string_view` from Functions That Build Strings
 
-**Do not return `std::string_view` from a function that constructs or concatenates a string internally.** The view would point into a temporary string's buffer and become a dangling reference after the function returns. Return `std::string` or `std::optional<std::string>` instead.
+**Do not return `std::string_view` from a function that constructs or
+concatenates a string internally.** The view would point into a temporary
+string's buffer and become a dangling reference after the function returns.
+Return `std::string` or `std::optional<std::string>` instead.
 
 ```cpp
 // ❌ WRONG - dangling reference to temporary
@@ -989,7 +1115,8 @@ std::string BuildUrl(std::string_view host) {
 
 ## ✅ Prefer `constexpr int` Over Single-Value Enums
 
-**When a constant is just a single numeric value, use `constexpr int` rather than creating a single-value enum.** Enums are for sets of related values.
+**When a constant is just a single numeric value, use `constexpr int` rather
+than creating a single-value enum.** Enums are for sets of related values.
 
 ```cpp
 // ❌ WRONG - enum for a single value
@@ -1005,7 +1132,9 @@ constexpr int kBravePolicySource = 10;
 
 ## ✅ Use `base::FilePath` for File Path Parameters
 
-**Parameters representing file system paths should use `base::FilePath` instead of `std::string`.** This provides type safety, simplifies call sites, and makes APIs self-documenting.
+**Parameters representing file system paths should use `base::FilePath` instead
+of `std::string`.** This provides type safety, simplifies call sites, and makes
+APIs self-documenting.
 
 ```cpp
 // ❌ WRONG - generic string for a path
@@ -1021,7 +1150,9 @@ std::string GetProfileId(const base::FilePath& profile_path);
 
 ## ✅ Explicitly Assign Enum Values When Conditionally Compiling Out Members
 
-**When conditionally compiling out enum values behind a build flag, explicitly assign numeric values to remaining members.** This prevents value shifts that break serialization, persistence, or IPC.
+**When conditionally compiling out enum values behind a build flag, explicitly
+assign numeric values to remaining members.** This prevents value shifts that
+break serialization, persistence, or IPC.
 
 ```cpp
 // ❌ WRONG - values shift when kTalk is compiled out
@@ -1049,7 +1180,8 @@ enum class SidebarItem {
 
 ## ✅ Name All Function Parameters in Header Declarations
 
-**Always name function parameters in header declarations, especially when types alone are ambiguous.** Match the parameter names used in the `.cc` file.
+**Always name function parameters in header declarations, especially when types
+alone are ambiguous.** Match the parameter names used in the `.cc` file.
 
 ```cpp
 // ❌ WRONG - ambiguous parameters
@@ -1067,7 +1199,8 @@ void OnSubmitSignedExtrinsic(std::optional<std::string> transaction_hash,
 
 ## ✅ Struct Members: No Trailing Underscores
 
-**Plain struct members should not have trailing underscores.** The trailing underscore convention is for class member variables, not struct fields.
+**Plain struct members should not have trailing underscores.** The trailing
+underscore convention is for class member variables, not struct fields.
 
 ```cpp
 // ❌ WRONG
@@ -1091,9 +1224,14 @@ struct ContentSite {
 
 ## ❌ Don't Introduce New Uses of Deprecated APIs
 
-**When an API is marked deprecated, never introduce new uses.** Check headers for deprecation notices before using unfamiliar APIs.
+**When an API is marked deprecated, never introduce new uses.** Check headers
+for deprecation notices before using unfamiliar APIs.
 
-**Reviewer note:** To flag a violation of this rule, you MUST read the actual header file that declares the API and confirm a deprecation notice exists in the current source tree. Do not rely on memory or training data — APIs change across chromium upgrades and assumptions about what is or isn't deprecated are frequently wrong.
+**Reviewer note:** To flag a violation of this rule, you MUST read the actual
+header file that declares the API and confirm a deprecation notice exists in the
+current source tree. Do not rely on memory or training data — APIs change across
+chromium upgrades and assumptions about what is or isn't deprecated are
+frequently wrong.
 
 ```cpp
 // ❌ WRONG - base::Hash deprecated for 6+ years
@@ -1109,7 +1247,9 @@ uint32_t hash = base::FastHash(base::as_byte_span(str));
 
 ## ✅ Default-Initialize POD-Type Members in Headers
 
-**Plain old data (POD) type members in structs and classes declared in headers must have explicit default initialization.** Uninitialized POD members lead to undefined behavior when read before being written.
+**Plain old data (POD) type members in structs and classes declared in headers
+must have explicit default initialization.** Uninitialized POD members lead to
+undefined behavior when read before being written.
 
 ```cpp
 // ❌ WRONG
@@ -1131,7 +1271,9 @@ struct TopicArticle {
 
 ## ✅ Prefer `std::string_view` Over `const char*` for Parameters
 
-**Use `std::string_view` instead of `const char*` for function parameters that accept string data.** `std::string_view` is more flexible (accepts `std::string`, `const char*`, string literals) and carries size information.
+**Use `std::string_view` instead of `const char*` for function parameters that
+accept string data.** `std::string_view` is more flexible (accepts
+`std::string`, `const char*`, string literals) and carries size information.
 
 ```cpp
 // ❌ WRONG
@@ -1147,17 +1289,26 @@ std::string_view GetDomain(std::string_view env_from_switch);
 
 ## ⚠️ `std::string_view` Class Members — Know When They're Safe
 
-**Storing `std::string_view` as a class member is dangerous in general** because the referenced data must outlive the object. However, there are well-established safe patterns:
+**Storing `std::string_view` as a class member is dangerous in general** because
+the referenced data must outlive the object. However, there are well-established
+safe patterns:
 
 **Safe — no need to flag:**
-- Members initialized from `inline constexpr char[]` constants (e.g., pref keys like `kMyPrefName`), `kFeatureName` string literals, or other compile-time string constants with static storage duration
+
+- Members initialized from `inline constexpr char[]` constants (e.g., pref keys
+  like `kMyPrefName`), `kFeatureName` string literals, or other compile-time
+  string constants with static storage duration
 - Members initialized from string literals directly (`"some_string"`)
-- Members in short-lived stack objects where the caller's string clearly outlives the object
+- Members in short-lived stack objects where the caller's string clearly
+  outlives the object
 
 **Dangerous — flag these:**
+
 - Members initialized from `std::string` temporaries or function return values
-- Members in long-lived objects (singletons, services) initialized from non-static strings
-- Members where the constructor accepts `std::string_view` and the caller might pass a temporary
+- Members in long-lived objects (singletons, services) initialized from
+  non-static strings
+- Members where the constructor accepts `std::string_view` and the caller might
+  pass a temporary
 
 ```cpp
 // ✅ SAFE - pref keys are inline constexpr with static lifetime
@@ -1173,7 +1324,9 @@ class Config {
 };
 ```
 
-**When reviewing:** Check what the `string_view` member is actually initialized from before flagging. Pref key constants and string literals have static lifetime and are safe.
+**When reviewing:** Check what the `string_view` member is actually initialized
+from before flagging. Pref key constants and string literals have static
+lifetime and are safe.
 
 ---
 
@@ -1181,7 +1334,10 @@ class Config {
 
 ## ✅ Use `base::circular_deque` Over `std::deque`
 
-**Always use `base::circular_deque` (or `base::queue`/`base::stack`) instead of `std::deque` (or `std::queue`/`std::stack`).** The base versions have consistent memory usage across platforms and save code size. See [Chromium container guidelines](https://chromium.googlesource.com/chromium/src/+/HEAD/base/containers/README.md).
+**Always use `base::circular_deque` (or `base::queue`/`base::stack`) instead of
+`std::deque` (or `std::queue`/`std::stack`).** The base versions have consistent
+memory usage across platforms and save code size. See
+[Chromium container guidelines](https://chromium.googlesource.com/chromium/src/+/HEAD/base/containers/README.md).
 
 ```cpp
 // ❌ WRONG - platform-dependent behavior
@@ -1195,7 +1351,9 @@ base::queue<int> pending;
 base::stack<int> history;
 ```
 
-**Note:** `base::circular_deque` does not maintain stable iterators during mutations. Use `std::list` if stable iterators with constant-time insert/remove are required.
+**Note:** `base::circular_deque` does not maintain stable iterators during
+mutations. Use `std::list` if stable iterators with constant-time insert/remove
+are required.
 
 ---
 
@@ -1203,7 +1361,10 @@ base::stack<int> history;
 
 ## ✅ Use `size_t` for Sizes, Counts, and Indices
 
-**Use `size_t` for object sizes, allocation sizes, element counts, array offsets, and vector indices.** This prevents unnecessary casts with STL APIs. Public APIs should use `size_t` even if internals optimize with `uint32_t`. See [Chromium C++ style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md).
+**Use `size_t` for object sizes, allocation sizes, element counts, array
+offsets, and vector indices.** This prevents unnecessary casts with STL APIs.
+Public APIs should use `size_t` even if internals optimize with `uint32_t`. See
+[Chromium C++ style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md).
 
 ```cpp
 // ❌ WRONG - unnecessary casts
@@ -1221,7 +1382,10 @@ for (size_t i = 0; i < vec.size(); ++i) { ... }
 
 ## ✅ Use Transparent Comparisons for `base::flat_map` String Lookups
 
-**`base::flat_map` and `base::flat_set` support transparent comparisons, enabling lookups with `std::string_view` or `const char*` without constructing temporary `std::string` objects.** This avoids unnecessary heap allocations on lookups.
+**`base::flat_map` and `base::flat_set` support transparent comparisons,
+enabling lookups with `std::string_view` or `const char*` without constructing
+temporary `std::string` objects.** This avoids unnecessary heap allocations on
+lookups.
 
 ```cpp
 // ❌ WRONG - operator[] constructs a temporary std::string
@@ -1233,7 +1397,9 @@ base::flat_map<std::string, int> map;
 auto it = map.find("key");  // no temporary string created
 ```
 
-For `base::flat_set` of `std::unique_ptr`, use `base::UniquePtrComparator` for transparent lookups by raw pointer. See [Chromium container guidelines](https://chromium.googlesource.com/chromium/src/+/HEAD/base/containers/README.md).
+For `base::flat_set` of `std::unique_ptr`, use `base::UniquePtrComparator` for
+transparent lookups by raw pointer. See
+[Chromium container guidelines](https://chromium.googlesource.com/chromium/src/+/HEAD/base/containers/README.md).
 
 ---
 
@@ -1241,9 +1407,14 @@ For `base::flat_set` of `std::unique_ptr`, use `base::UniquePtrComparator` for t
 
 ## ❌ Don't Rely on Implicit `const char*` → `string_view` for Non-Null-Terminated Data
 
-**When constructing `std::string_view` from a byte buffer or `reinterpret_cast`'d pointer, always pass the size explicitly.** Implicit `string_view(const char*)` calls `strlen()`, which causes undefined behavior if the data is not null-terminated.
+**When constructing `std::string_view` from a byte buffer or
+`reinterpret_cast`'d pointer, always pass the size explicitly.** Implicit
+`string_view(const char*)` calls `strlen()`, which causes undefined behavior if
+the data is not null-terminated.
 
-This commonly occurs when migrating from `(const char* src, size_t src_len)` APIs to `string_view` APIs — dropping the size parameter silently changes the semantics.
+This commonly occurs when migrating from `(const char* src, size_t src_len)`
+APIs to `string_view` APIs — dropping the size parameter silently changes the
+semantics.
 
 ```cpp
 std::vector<uint8_t> data = GetBytes();
@@ -1263,11 +1434,16 @@ base::ReadUnicodeCharacter(
 
 ## ✅ String Usage in Rust/C++ FFI
 
-**Pick FFI string types by data flow (borrow vs. own) and payload size (standard vs. large).** Rust's `String`/`Vec` and C++'s `std::string`/`std::vector` use different allocators and memory layouts, so the wrong choice causes hidden copies, lifetime bugs, or container overhead. Sections below cover each case with examples.
+**Pick FFI string types by data flow (borrow vs. own) and payload size (standard
+vs. large).** Rust's `String`/`Vec` and C++'s `std::string`/`std::vector` use
+different allocators and memory layouts, so the wrong choice causes hidden
+copies, lifetime bugs, or container overhead. Sections below cover each case
+with examples.
 
 ### Rust → C++ read-only text — `&str` (maps to `rust::Str`)
 
-Zero-copy. Rust retains ownership; C++ reads as a view. Use for logging, printing, parsing.
+Zero-copy. Rust retains ownership; C++ reads as a view. Use for logging,
+printing, parsing.
 
 ```rust
 // ❌ WRONG - forces C++ container overhead for a borrow
@@ -1290,7 +1466,8 @@ void LogEvent(rust::Str name) {
 
 ### C++ → Rust read-only text — `&str` (maps to `rust::Str`)
 
-Zero-copy. Rust receives a native `&str` it can search, slice, or print immediately. Use for validation, key lookup.
+Zero-copy. Rust receives a native `&str` it can search, slice, or print
+immediately. Use for validation, key lookup.
 
 ```rust
 // ❌ WRONG - bridge type leaks into idiomatic Rust code
@@ -1308,7 +1485,9 @@ bool valid = ffi::is_valid_key(key_string_view);  // implicit conversion
 
 ### Rust → C++ ownership, standard text — `String` (maps to `rust::String`)
 
-Container move; no text copy. C++ owns the `rust::String` for the scope of the call. **Deep-copy into `std::string` to preserve past the function's return** — never store `rust::String` as a class member.
+Container move; no text copy. C++ owns the `rust::String` for the scope of the
+call. **Deep-copy into `std::string` to preserve past the function's return** —
+never store `rust::String` as a class member.
 
 ```rust
 // ✅ Return owned text by value
@@ -1339,7 +1518,9 @@ void Reporter::Refresh() {
 
 ### Rust → C++ ownership, MASSIVE payload — `Box<Vec<u8>>` (maps to `rust::Box<rust::Vec<uint8_t>>`)
 
-Zero-copy. Heap pointer moves to C++; C++ wraps bytes in `std::string_view` or `base::span`. Rust's allocator cleans up when `Box` drops. Use for file buffers, JSON blobs, streaming payloads.
+Zero-copy. Heap pointer moves to C++; C++ wraps bytes in `std::string_view` or
+`base::span`. Rust's allocator cleans up when `Box` drops. Use for file buffers,
+JSON blobs, streaming payloads.
 
 ```rust
 // ❌ WRONG - container copy through rust::String layout
@@ -1358,7 +1539,8 @@ void Consume(rust::Box<rust::Vec<uint8_t>> buf) {
 
 ### C++ → Rust ownership, standard text — `String` (maps to `rust::String`)
 
-Deep copy into Rust heap. C++ builds text, copies into `rust::String`, drops its local copy. Rust gains un-aliased control of an idiomatic container.
+Deep copy into Rust heap. C++ builds text, copies into `rust::String`, drops its
+local copy. Rust gains un-aliased control of an idiomatic container.
 
 ```rust
 // ❌ WRONG - borrowing CxxString into long-lived Rust state ties Rust's
@@ -1376,7 +1558,8 @@ ffi::store_name(rust::String(computed));  // deep copy into Rust heap
 
 ### C++ → Rust ownership, MASSIVE payload — `UniquePtr<CxxString>`
 
-Zero-copy pointer move. Allocation context stays C++-side; `cxx` invokes the C++ destructor when Rust drops the `UniquePtr`. Use for ingesting large blobs.
+Zero-copy pointer move. Allocation context stays C++-side; `cxx` invokes the C++
+destructor when Rust drops the `UniquePtr`. Use for ingesting large blobs.
 
 ```rust
 // ❌ WRONG - forces deep copy of large buffer
@@ -1393,7 +1576,8 @@ ffi::ingest(std::move(blob));  // ownership transfers to Rust
 
 ### Collections of strings
 
-Same borrow-vs-own split. `&CxxVector<CxxString>` is almost never the right answer.
+Same borrow-vs-own split. `&CxxVector<CxxString>` is almost never the right
+answer.
 
 **Rust → C++ read-only array — `&[&str]`**
 
@@ -1413,7 +1597,8 @@ unsafe extern "C++" {
 
 **C++ → Rust ownership, large — `UniquePtr<CxxVector<CxxString>>`**
 
-Container lifetime owned by Rust; strings readable without per-element conversion.
+Container lifetime owned by Rust; strings readable without per-element
+conversion.
 
 ```rust
 fn ingest(items: UniquePtr<CxxVector<CxxString>>);

--- a/docs/best-practices/coding-standards-memory.md
+++ b/docs/best-practices/coding-standards-memory.md
@@ -10,7 +10,8 @@
 
 ### ✅ Prefer unique_ptr Over new/delete
 
-**Avoid manual new/delete. Use unique_ptr, stack variables, or member initializer lists.**
+**Avoid manual new/delete. Use unique_ptr, stack variables, or member
+initializer lists.**
 
 ```cpp
 // ❌ WRONG - manual new/delete
@@ -28,7 +29,8 @@ void Init() {
 
 ### ❌ Don't Take Ownership of Unowned Resources
 
-If a class doesn't own a resource, don't create ownership wrappers for it. This is a common source of crashes (see also architecture.md on shared_ptr misuse).
+If a class doesn't own a resource, don't create ownership wrappers for it. This
+is a common source of crashes (see also architecture.md on shared_ptr misuse).
 
 ---
 
@@ -36,7 +38,9 @@ If a class doesn't own a resource, don't create ownership wrappers for it. This 
 
 ## ❌ `shared_ptr` Is Banned in Chromium Code
 
-**Do not use `std::shared_ptr` - it is on the Chromium banned features list.** Use `base::RefCounted` / `scoped_refptr` when shared ownership is truly needed, or restructure to use unique ownership.
+**Do not use `std::shared_ptr` - it is on the Chromium banned features list.**
+Use `base::RefCounted` / `scoped_refptr` when shared ownership is truly needed,
+or restructure to use unique ownership.
 
 ---
 
@@ -44,7 +48,8 @@ If a class doesn't own a resource, don't create ownership wrappers for it. This 
 
 ## ✅ Invalidate WeakPtrs During Teardown
 
-**Call `weak_factory_.InvalidateWeakPtrs()` at the start of shutdown/cleanup.** Without this, pending callbacks can fire on partially-destroyed objects.
+**Call `weak_factory_.InvalidateWeakPtrs()` at the start of shutdown/cleanup.**
+Without this, pending callbacks can fire on partially-destroyed objects.
 
 ```cpp
 // ❌ WRONG - teardown without invalidating
@@ -65,7 +70,8 @@ void MyClass::Shutdown() {
 
 ## ✅ Always Check WeakPtr Validity Before Use
 
-**Always check a `base::WeakPtr` is valid before dereferencing, especially after async operations.** Add thread checkers to methods using WeakPtrs.
+**Always check a `base::WeakPtr` is valid before dereferencing, especially after
+async operations.** Add thread checkers to methods using WeakPtrs.
 
 ```cpp
 // ❌ WRONG
@@ -88,7 +94,9 @@ void OnCallback() {
 
 ## ✅ Prefer `base::WeakPtrFactory` Over `SupportsWeakPtr`
 
-**Use `base::WeakPtrFactory<T>` as a member rather than inheriting from `base::SupportsWeakPtr<T>`.** WeakPtrFactory performs more safety checks and is the recommended pattern.
+**Use `base::WeakPtrFactory<T>` as a member rather than inheriting from
+`base::SupportsWeakPtr<T>`.** WeakPtrFactory performs more safety checks and is
+the recommended pattern.
 
 ```cpp
 // ❌ WRONG
@@ -106,7 +114,9 @@ class MyClass {
 
 ## ✅ WeakPtr - Bind to Member Function, Not Lambda Capture
 
-**When using WeakPtr with async callbacks, bind directly to a member function.** Don't capture a WeakPtr in a lambda — the weak_ptr could be invalidated before the lambda runs, and there's no automatic cancellation.
+**When using WeakPtr with async callbacks, bind directly to a member function.**
+Don't capture a WeakPtr in a lambda — the weak_ptr could be invalidated before
+the lambda runs, and there's no automatic cancellation.
 
 ```cpp
 // ❌ WRONG - weak_ptr captured in lambda, no automatic cancellation
@@ -130,7 +140,10 @@ rpc_->GetNetworkName(base::BindOnce(
 
 ## ❌ Never Use `base::Unretained` with Thread Pool
 
-**Never use `base::Unretained` when posting work to thread pools.** Instead, run OS-specific or blocking functions on the thread pool and handle results on the main thread via `PostTaskAndReplyWithResult` with a WeakPtr. Using `Unretained` across threads leads to use-after-free.
+**Never use `base::Unretained` when posting work to thread pools.** Instead, run
+OS-specific or blocking functions on the thread pool and handle results on the
+main thread via `PostTaskAndReplyWithResult` with a WeakPtr. Using `Unretained`
+across threads leads to use-after-free.
 
 ```cpp
 // ❌ WRONG - Unretained across threads causes UaF
@@ -149,7 +162,10 @@ base::ThreadPool::PostTaskAndReplyWithResult(
 
 ## ✅ Use `base::Unretained(this)` for Self-Owned Timer Callbacks
 
-**When a class owns a `base::RepeatingTimer` or `base::OneShotTimer`, prefer `base::Unretained(this)`.** The timer is destroyed with the class, so it can only fire while `this` is valid. Using `WeakPtr` adds unnecessary overhead but is not functionally wrong — it's a style preference, not a correctness issue.
+**When a class owns a `base::RepeatingTimer` or `base::OneShotTimer`, prefer
+`base::Unretained(this)`.** The timer is destroyed with the class, so it can
+only fire while `this` is valid. Using `WeakPtr` adds unnecessary overhead but
+is not functionally wrong — it's a style preference, not a correctness issue.
 
 ```cpp
 // ⚠️ AVOID - unnecessary overhead (but not a bug)
@@ -161,7 +177,10 @@ timer_.Start(FROM_HERE, delay,
     base::BindRepeating(&MyClass::OnTimer, base::Unretained(this)));
 ```
 
-**Key distinction:** This is the opposite of the "never use Unretained with thread pool" rule. The difference is ownership: you own the timer, so it cannot outlive you. If a developer prefers `WeakPtr` for defensive coding, that's a valid choice — do not insist on changing it.
+**Key distinction:** This is the opposite of the "never use Unretained with
+thread pool" rule. The difference is ownership: you own the timer, so it cannot
+outlive you. If a developer prefers `WeakPtr` for defensive coding, that's a
+valid choice — do not insist on changing it.
 
 ---
 
@@ -169,7 +188,11 @@ timer_.Start(FROM_HERE, delay,
 
 ## ✅ `base::Unretained(this)` Is Safe with Owned Mojo Endpoints
 
-**Using `base::Unretained(this)` in Mojo disconnect handlers and connection error handlers is safe when the class owns the `mojo::Remote`, `mojo::Receiver`, or `mojo::AssociatedRemote`.** The Mojo endpoint is destroyed with the class, so the callback can only fire while `this` is valid — the same ownership guarantee as timers.
+**Using `base::Unretained(this)` in Mojo disconnect handlers and connection
+error handlers is safe when the class owns the `mojo::Remote`, `mojo::Receiver`,
+or `mojo::AssociatedRemote`.** The Mojo endpoint is destroyed with the class, so
+the callback can only fire while `this` is valid — the same ownership guarantee
+as timers.
 
 ```cpp
 // ✅ SAFE - class owns the remote, so Unretained is fine
@@ -185,7 +208,10 @@ remote_.set_disconnect_handler(
     base::BindOnce(&MyClass::OnDisconnect, weak_factory_.GetWeakPtr()));
 ```
 
-**Do NOT flag `base::Unretained(this)` in Mojo disconnect/error handlers as unsafe.** This is a well-established safe pattern in Chromium. Only flag it if the binding crosses thread boundaries or if `this` does not own the Mojo endpoint.
+**Do NOT flag `base::Unretained(this)` in Mojo disconnect/error handlers as
+unsafe.** This is a well-established safe pattern in Chromium. Only flag it if
+the binding crosses thread boundaries or if `this` does not own the Mojo
+endpoint.
 
 ---
 
@@ -193,7 +219,9 @@ remote_.set_disconnect_handler(
 
 ## ✅ Place `raw_ptr<>` Members Last in Class Declarations
 
-**In class declarations, place unowned `raw_ptr<>` members after owning members** (like `std::unique_ptr<>`). This follows Chromium convention and makes ownership semantics visually clear.
+**In class declarations, place unowned `raw_ptr<>` members after owning
+members** (like `std::unique_ptr<>`). This follows Chromium convention and makes
+ownership semantics visually clear.
 
 ```cpp
 // ❌ WRONG - mixed ownership order
@@ -217,7 +245,9 @@ class MyService {
 
 ## ❌ Never Bind `std::vector<raw_ptr<T>>` in Callbacks
 
-**Never capture `std::vector<raw_ptr<T>>` in async callbacks.** The raw pointers may dangle by the time the callback runs. Use `std::vector<base::WeakPtr<T>>` instead.
+**Never capture `std::vector<raw_ptr<T>>` in async callbacks.** The raw pointers
+may dangle by the time the callback runs. Use `std::vector<base::WeakPtr<T>>`
+instead.
 
 ```cpp
 // ❌ WRONG - raw_ptrs may dangle
@@ -237,7 +267,9 @@ base::BindOnce(&OnComplete, std::move(weak_tabs));
 
 ## ✅ Use `SEQUENCE_CHECKER` Consistently - All Methods or None
 
-**If a class is single-threaded, either apply `DCHECK_CALLED_ON_VALID_SEQUENCE` to all methods or remove the sequence checker entirely.** Partial checking is misleading and makes correct code look unsafe.
+**If a class is single-threaded, either apply `DCHECK_CALLED_ON_VALID_SEQUENCE`
+to all methods or remove the sequence checker entirely.** Partial checking is
+misleading and makes correct code look unsafe.
 
 ---
 
@@ -245,7 +277,9 @@ base::BindOnce(&OnComplete, std::move(weak_tabs));
 
 ## ✅ Clean Up Resources in `KeyedService::Shutdown`
 
-**For `KeyedService` implementations, clean up owned resources in `Shutdown()`, not just the destructor.** The service graph has dependencies requiring orderly teardown.
+**For `KeyedService` implementations, clean up owned resources in `Shutdown()`,
+not just the destructor.** The service graph has dependencies requiring orderly
+teardown.
 
 ---
 
@@ -253,7 +287,10 @@ base::BindOnce(&OnComplete, std::move(weak_tabs));
 
 ## ✅ Unsubscribe Observers in `::Shutdown()` Even with `ScopedObservation`
 
-**`ScopedObservation` can still lead to use-after-free.** Always explicitly unsubscribe observers and pref registrars in `KeyedService::Shutdown()`. Event-triggered callbacks (like pref observers) can fire after your service's `Shutdown()` if another service triggers them during its own shutdown sequence.
+**`ScopedObservation` can still lead to use-after-free.** Always explicitly
+unsubscribe observers and pref registrars in `KeyedService::Shutdown()`.
+Event-triggered callbacks (like pref observers) can fire after your service's
+`Shutdown()` if another service triggers them during its own shutdown sequence.
 
 ```cpp
 // ❌ WRONG - relying solely on ScopedObservation destructor
@@ -274,7 +311,9 @@ void MyService::Shutdown() {
 
 ## ❌ Don't Pass `BrowserContext` to Component Services
 
-**Component-level services should take specific dependencies (`PrefService*`, `URLLoaderFactory`) rather than `BrowserContext`.** Passing `BrowserContext` prevents reuse on iOS and creates content-layer dependencies.
+**Component-level services should take specific dependencies (`PrefService*`,
+`URLLoaderFactory`) rather than `BrowserContext`.** Passing `BrowserContext`
+prevents reuse on iOS and creates content-layer dependencies.
 
 ```cpp
 // ❌ WRONG
@@ -291,7 +330,8 @@ MyFeatureService(PrefService* prefs,
 
 ## ✅ Add Thread Checks to `base::Bind` Callback Targets
 
-**Methods used as targets of `base::BindOnce` / `base::BindRepeating` should include `DCHECK_CALLED_ON_VALID_SEQUENCE` to ensure correct thread.**
+**Methods used as targets of `base::BindOnce` / `base::BindRepeating` should
+include `DCHECK_CALLED_ON_VALID_SEQUENCE` to ensure correct thread.**
 
 ---
 
@@ -299,7 +339,10 @@ MyFeatureService(PrefService* prefs,
 
 ## ✅ Use `base::NoDestructor` for Non-Trivial Static Objects
 
-**Chromium prohibits global objects with non-trivial destructors.** When you need a global/static container (like a map or vector), use `base::NoDestructor` inside a function as a local static. Use `constexpr` for simple arrays/values where possible.
+**Chromium prohibits global objects with non-trivial destructors.** When you
+need a global/static container (like a map or vector), use `base::NoDestructor`
+inside a function as a local static. Use `constexpr` for simple arrays/values
+where possible.
 
 ```cpp
 // ❌ WRONG - global map with non-trivial destructor
@@ -319,7 +362,10 @@ const std::map<std::string, int>& GetMyLookup() {
 
 ## ✅ Consider `base::SequenceBound` for Thread-Isolated Operations
 
-**When a class performs blocking or IO operations and needs to be accessed asynchronously from the UI thread, use `base::SequenceBound<T>`.** This binds the object to a specific task runner and automatically posts all calls to that sequence.
+**When a class performs blocking or IO operations and needs to be accessed
+asynchronously from the UI thread, use `base::SequenceBound<T>`.** This binds
+the object to a specific task runner and automatically posts all calls to that
+sequence.
 
 ```cpp
 // ❌ WRONG - manual thread management
@@ -339,7 +385,9 @@ scraper_.AsyncCall(&ContentScraper::Process).WithArgs(html);
 
 ## ✅ Explicitly Specify `base::TaskPriority` in Thread Pool Tasks
 
-**When posting tasks to the thread pool, explicitly specify `base::TaskPriority` and shutdown behavior** rather than relying on defaults. Use `BEST_EFFORT` for non-urgent work and `SKIP_ON_SHUTDOWN` when work can be safely abandoned.
+**When posting tasks to the thread pool, explicitly specify `base::TaskPriority`
+and shutdown behavior** rather than relying on defaults. Use `BEST_EFFORT` for
+non-urgent work and `SKIP_ON_SHUTDOWN` when work can be safely abandoned.
 
 ```cpp
 // ❌ WRONG - implicit priority
@@ -359,7 +407,9 @@ base::ThreadPool::PostTask(
 
 ## ❌ Don't Use Synchronous OSCrypt in New Code
 
-**New code must use the async OSCrypt interface, not the legacy synchronous one.** The sync interface is deprecated. See `components/os_crypt/sync/README.md`.
+**New code must use the async OSCrypt interface, not the legacy synchronous
+one.** The sync interface is deprecated. See
+`components/os_crypt/sync/README.md`.
 
 ```cpp
 // ❌ WRONG - deprecated sync interface
@@ -376,7 +426,10 @@ os_crypt_async_->GetInstance(
 
 ## ✅ Use Delegates Instead of Raw Callbacks for Cross-Layer Dependencies
 
-**When a component-level class needs platform-specific behavior, use a delegate pattern with a dedicated delegate class instead of passing raw callbacks.** Delegates provide cleaner interfaces, safer lifetime management, and better testability.
+**When a component-level class needs platform-specific behavior, use a delegate
+pattern with a dedicated delegate class instead of passing raw callbacks.**
+Delegates provide cleaner interfaces, safer lifetime management, and better
+testability.
 
 ```cpp
 // ❌ WRONG - raw callbacks for platform-specific behavior
@@ -400,7 +453,9 @@ class DefaultBrowserMonitor {
 
 ## ✅ Use `reset_on_disconnect()` for Simple Mojo Cleanup
 
-**For simple Mojo remote cleanup on disconnection (just resetting the remote), use `remote.reset_on_disconnect()`** instead of setting up a manual disconnect handler.
+**For simple Mojo remote cleanup on disconnection (just resetting the remote),
+use `remote.reset_on_disconnect()`** instead of setting up a manual disconnect
+handler.
 
 ```cpp
 // ❌ WRONG - manual disconnect handler just to reset
@@ -418,7 +473,10 @@ remote_.reset_on_disconnect();
 
 ## ✅ Use `tabs::TabHandle` Over Raw `WebContents*` for Stored References
 
-**When storing tab references, prefer `tabs::TabHandle` (integer identifiers) over raw `WebContents*` pointers.** TabHandles are guaranteed not to accidentally point to a different tab, unlike raw pointers which can become dangling and be reused for a different allocation.
+**When storing tab references, prefer `tabs::TabHandle` (integer identifiers)
+over raw `WebContents*` pointers.** TabHandles are guaranteed not to
+accidentally point to a different tab, unlike raw pointers which can become
+dangling and be reused for a different allocation.
 
 ```cpp
 // ❌ WRONG - raw pointer can dangle and point to wrong tab
@@ -435,9 +493,16 @@ std::vector<tabs::TabHandle> tabs_to_close_;
 
 ## ✅ Security Review for Unrestricted URL Inputs in Mojom
 
-**When creating mojom interfaces that accept URL parameters from less-privileged processes, consider restricting to an allowlist or enum** rather than accepting arbitrary URLs. An unrestricted URL parameter means the renderer can send requests to any endpoint.
+**When creating mojom interfaces that accept URL parameters from less-privileged
+processes, consider restricting to an allowlist or enum** rather than accepting
+arbitrary URLs. An unrestricted URL parameter means the renderer can send
+requests to any endpoint.
 
-**When NOT to flag:** If the implementation already validates or filters the URL downstream, do not request documentation comments about it. Before flagging, check whether similar patterns in surrounding code or elsewhere in the codebase have such comments — if they don't, your suggestion would introduce inconsistency and unnecessary verbosity.
+**When NOT to flag:** If the implementation already validates or filters the URL
+downstream, do not request documentation comments about it. Before flagging,
+check whether similar patterns in surrounding code or elsewhere in the codebase
+have such comments — if they don't, your suggestion would introduce
+inconsistency and unnecessary verbosity.
 
 ---
 
@@ -445,7 +510,8 @@ std::vector<tabs::TabHandle> tabs_to_close_;
 
 ## ✅ `base::DoNothing()` Doesn't Match `base::FunctionRef` Signatures
 
-**`base::DoNothing()` cannot be used where a `base::FunctionRef<void(T&)>` is expected.** In those cases, use an explicit no-op lambda instead.
+**`base::DoNothing()` cannot be used where a `base::FunctionRef<void(T&)>` is
+expected.** In those cases, use an explicit no-op lambda instead.
 
 ```cpp
 // ❌ WRONG - won't compile
@@ -461,7 +527,11 @@ service->ForEach([](Item&) {});
 
 ## ✅ Null-Check Return Values Before Dereferencing
 
-**Always null-check return values from methods that can return nullptr before dereferencing, even when the input argument seems valid.** A non-null ID or key does not guarantee the lookup will succeed — the underlying object may have been destroyed, removed, or never created. This is especially important for upstream Chromium APIs where lifecycle changes can happen without notice.
+**Always null-check return values from methods that can return nullptr before
+dereferencing, even when the input argument seems valid.** A non-null ID or key
+does not guarantee the lookup will succeed — the underlying object may have been
+destroyed, removed, or never created. This is especially important for upstream
+Chromium APIs where lifecycle changes can happen without notice.
 
 ```cpp
 // ❌ WRONG - GetTask() returns nullptr if task doesn't exist
@@ -477,7 +547,10 @@ if (!task_id_.is_null()) {
 }
 ```
 
-**Common Chromium APIs that return nullptr:** `GetTask()`, `FindWebContentsById()`, `FromWebContents()`, `FromBrowserContext()`, `GetTabById()`, `GetWindowById()`. When chaining method calls (`a->GetB()->DoC()`), always store the intermediate result and check it.
+**Common Chromium APIs that return nullptr:** `GetTask()`,
+`FindWebContentsById()`, `FromWebContents()`, `FromBrowserContext()`,
+`GetTabById()`, `GetWindowById()`. When chaining method calls
+(`a->GetB()->DoC()`), always store the intermediate result and check it.
 
 ---
 
@@ -485,7 +558,10 @@ if (!task_id_.is_null()) {
 
 ## ❌ Don't Use a Variable After `std::move()`
 
-**Never read or use a variable after it has been `std::move()`-d.** After a move, the source object is in a valid but unspecified state — using it is undefined behavior for most types and a bug for all types. This includes using the variable later in the same function, even if the move is inside a branch.
+**Never read or use a variable after it has been `std::move()`-d.** After a
+move, the source object is in a valid but unspecified state — using it is
+undefined behavior for most types and a bug for all types. This includes using
+the variable later in the same function, even if the move is inside a branch.
 
 ```cpp
 // ❌ WRONG - model_key used after move
@@ -501,7 +577,10 @@ if (auto event = ParseEvent(params)) {
 }
 ```
 
-**Watch for:** `std::move()` on strings, vectors, unique_ptrs, or any movable type where the variable appears again later in the function. Even if the move is inside an `if`/`else` branch, a future refactor could change control flow and expose the bug.
+**Watch for:** `std::move()` on strings, vectors, unique_ptrs, or any movable
+type where the variable appears again later in the function. Even if the move is
+inside an `if`/`else` branch, a future refactor could change control flow and
+expose the bug.
 
 ---
 
@@ -509,7 +588,11 @@ if (auto event = ParseEvent(params)) {
 
 ## ❌ Don't Pass Smart Pointers by Const Reference
 
-**Don't use `const std::unique_ptr<T>&` or `const scoped_refptr<T>&` as function parameters.** This forces heap allocation and couples callers to specific ownership semantics. Use a raw pointer (`T*`) or reference (`T&`) when the function doesn't modify ownership. See [Chromium smart pointer guidelines](https://www.chromium.org/developers/smart-pointer-guidelines/).
+**Don't use `const std::unique_ptr<T>&` or `const scoped_refptr<T>&` as function
+parameters.** This forces heap allocation and couples callers to specific
+ownership semantics. Use a raw pointer (`T*`) or reference (`T&`) when the
+function doesn't modify ownership. See
+[Chromium smart pointer guidelines](https://www.chromium.org/developers/smart-pointer-guidelines/).
 
 ```cpp
 // ❌ WRONG - forces callers to heap-allocate
@@ -522,7 +605,8 @@ void Process(Foo* foo);
 void Process(Foo& foo);
 ```
 
-**Exception:** Lambda functions in STL algorithms operating on containers of smart pointers may need this pattern.
+**Exception:** Lambda functions in STL algorithms operating on containers of
+smart pointers may need this pattern.
 
 ---
 
@@ -530,12 +614,17 @@ void Process(Foo& foo);
 
 ## ❌ Avoid Reference-Counted Objects — Prefer Redesign
 
-**Reference-counted objects (`base::RefCounted`/`scoped_refptr`) make ownership and destruction order difficult to reason about, especially with multiple threads.** Prefer redesigning to use single ownership (`std::unique_ptr`). See [Chromium smart pointer guidelines](https://www.chromium.org/developers/smart-pointer-guidelines/).
+**Reference-counted objects (`base::RefCounted`/`scoped_refptr`) make ownership
+and destruction order difficult to reason about, especially with multiple
+threads.** Prefer redesigning to use single ownership (`std::unique_ptr`). See
+[Chromium smart pointer guidelines](https://www.chromium.org/developers/smart-pointer-guidelines/).
 
 When refcounting seems necessary:
+
 - Restrict the class to a single thread/sequence
 - Use `PostTask()` to proxy calls to the correct thread
-- Use `base::BindOnce()` with `WeakPtr` for automatic cancellation on destruction
+- Use `base::BindOnce()` with `WeakPtr` for automatic cancellation on
+  destruction
 
 ---
 
@@ -543,7 +632,9 @@ When refcounting seems necessary:
 
 ## ❌ Don't Hold Pointers to `base::Value` From PrefService
 
-**It is not safe to store a pointer to a `base::Value` (or `base::Value::Dict`, etc.) returned from `PrefService`.** If the preference is later updated or the `PrefService` is destroyed, the pointer becomes dangling.
+**It is not safe to store a pointer to a `base::Value` (or `base::Value::Dict`,
+etc.) returned from `PrefService`.** If the preference is later updated or the
+`PrefService` is destroyed, the pointer becomes dangling.
 
 ```cpp
 // ❌ WRONG - pointer dangles if pref is updated
@@ -564,7 +655,9 @@ if (pref_service->GetDict(kMyPref).FindString("key")) { ... }
 
 ## ✅ Declare Members in Reverse Dependency Order for Safe Destruction
 
-**C++ destroys class members in reverse declaration order. If one member depends on another (e.g., a map of `string_view` pointing into a `deque<string>`), declare the depended-upon member first so it is destroyed last.**
+**C++ destroys class members in reverse declaration order. If one member depends
+on another (e.g., a map of `string_view` pointing into a `deque<string>`),
+declare the depended-upon member first so it is destroyed last.**
 
 ```cpp
 // ❌ WRONG - map_ holds string_views into strings_, but strings_ is destroyed first
@@ -586,15 +679,21 @@ class NameTable {
 
 ## ✅ Prefer `base::SequenceLocalStorageSlot` Over `thread_local`
 
-**For sequence-aware code, use `base::SequenceLocalStorageSlot` instead of `thread_local`.** It integrates with Chromium's task runner model and avoids the strict requirements of `thread_local`.
+**For sequence-aware code, use `base::SequenceLocalStorageSlot` instead of
+`thread_local`.** It integrates with Chromium's task runner model and avoids the
+strict requirements of `thread_local`.
 
 When `thread_local` is truly needed, Chromium requires:
-- Type must satisfy `std::is_trivially_destructible_v<T>` (`raw_ptr` is excluded)
+
+- Type must satisfy `std::is_trivially_destructible_v<T>` (`raw_ptr` is
+  excluded)
 - Cannot be exported via `COMPONENT_EXPORT`
 - Namespace/class scope requires `ABSL_CONST_INIT` annotation
 - Cannot be constructed in OOM handlers (POSIX construction may allocate)
 
-If these requirements cannot be met, use `base::ThreadLocalOwnedPointer` instead. See [Chromium C++ style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md).
+If these requirements cannot be met, use `base::ThreadLocalOwnedPointer`
+instead. See
+[Chromium C++ style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md).
 
 ---
 
@@ -602,7 +701,14 @@ If these requirements cannot be met, use `base::ThreadLocalOwnedPointer` instead
 
 ## ✅ Use `raw_ref<T>` for Fields That Must Never Be Null; `raw_ptr<T>` Otherwise
 
-**`raw_ptr<T>` is the default for non-owning fields. Choose `raw_ref<T>` when the field must never be null — it communicates that the referenced object is expected to outlive the holder, and the holder cannot function without it. Both types enforce that the pointee remains alive for as long as the field holds a reference to it: they detect use-after-free rather than silently operating on freed memory, and in doing so document the lifetime contract — whenever a field of either type holds a value, the expectation is that the memory it points to is alive.**
+**`raw_ptr<T>` is the default for non-owning fields. Choose `raw_ref<T>` when
+the field must never be null — it communicates that the referenced object is
+expected to outlive the holder, and the holder cannot function without it. Both
+types enforce that the pointee remains alive for as long as the field holds a
+reference to it: they detect use-after-free rather than silently operating on
+freed memory, and in doing so document the lifetime contract — whenever a field
+of either type holds a value, the expectation is that the memory it points to is
+alive.**
 
 ```cpp
 // raw_ptr<T> - default for non-owning fields (can be null or reassigned)
@@ -632,14 +738,27 @@ class MyService {
 };
 ```
 
-**Use `CHECK_DEREF` when a pointer-returning function result must be stored in a `raw_ref<T>` field.** It asserts non-null and converts to a reference, which is safer than `*ptr` (undefined behavior on null).
+**Use `CHECK_DEREF` when a pointer-returning function result must be stored in a
+`raw_ref<T>` field.** It asserts non-null and converts to a reference, which is
+safer than `*ptr` (undefined behavior on null).
 
 **`RAW_PTR_EXCLUSION` (per-field) is acceptable only for:**
-- Pointers to unprotected memory where BackupRefPtr provides no benefit: literals, stack allocations, `mmap`'d or shared memory, V8/Oilpan/Java heaps, TLS
-- Fields that won't compile with `raw_ptr<T>`: pointer fields in unions (prefer `std::variant`), pointer fields in classes/structs used as `global`, `static`, or `thread_local` variables
+
+- Pointers to unprotected memory where BackupRefPtr provides no benefit:
+  literals, stack allocations, `mmap`'d or shared memory, V8/Oilpan/Java heaps,
+  TLS
+- Fields that won't compile with `raw_ptr<T>`: pointer fields in unions (prefer
+  `std::variant`), pointer fields in classes/structs used as `global`, `static`,
+  or `thread_local` variables
 - (Very rare) cases with a measured, documented performance regression
-- (Very rare) cases where `raw_ptr<T>` causes runtime errors — add a comment and consult `base/memory/raw_ptr.md`
+- (Very rare) cases where `raw_ptr<T>` causes runtime errors — add a comment and
+  consult `base/memory/raw_ptr.md`
 
-Types not flagged by the Clang plugin — raw `T*` is fine, no annotation required: function pointers, ObjC pointers, `const char*`/`const wchar_t*` pointing to string literals (if they may point to heap-allocated objects, use `raw_ptr<const char>` for UaF safety).
+Types not flagged by the Clang plugin — raw `T*` is fine, no annotation
+required: function pointers, ObjC pointers, `const char*`/`const wchar_t*`
+pointing to string literals (if they may point to heap-allocated objects, use
+`raw_ptr<const char>` for UaF safety).
 
-Blink renderer code using Oilpan, and any other code whose objects are allocated outside PartitionAlloc (V8 heap, Java heap, etc.), cannot use `raw_ptr<T>` or `raw_ref<T>`.
+Blink renderer code using Oilpan, and any other code whose objects are allocated
+outside PartitionAlloc (V8 heap, Java heap, etc.), cannot use `raw_ptr<T>` or
+`raw_ref<T>`.

--- a/docs/best-practices/coding-standards.md
+++ b/docs/best-practices/coding-standards.md
@@ -6,7 +6,9 @@
 
 ## ✅ Always Include What You Use (IWYU)
 
-**Always include the headers for types you directly use.** Don't rely on transitive includes from other headers - they can change at any time and break your code.
+**Always include the headers for types you directly use.** Don't rely on
+transitive includes from other headers - they can change at any time and break
+your code.
 
 ```cpp
 // ❌ WRONG - relying on transitive includes
@@ -18,9 +20,12 @@
 #include "base/memory/ref_counted.h"
 ```
 
-Also remove includes you don't actually use. Double-check all includes in new files.
+Also remove includes you don't actually use. Double-check all includes in new
+files.
 
-**For type aliases:** include the header that declares the type alias, not the headers for the underlying types. Same principle as class inheritance — if class B inherits from A, include B's header, not A's.
+**For type aliases:** include the header that declares the type alias, not the
+headers for the underlying types. Same principle as class inheritance — if class
+B inherits from A, include B's header, not A's.
 
 ---
 
@@ -32,7 +37,8 @@ Also remove includes you don't actually use. Double-check all includes in new fi
 
 ### ✅ Use Positive Form for Booleans and Methods
 
-**Always use the positive form ("Enabled" not "Disabled") for readability and consistency.**
+**Always use the positive form ("Enabled" not "Disabled") for readability and
+consistency.**
 
 ```cpp
 // ❌ WRONG - negative form is confusing
@@ -48,7 +54,8 @@ pref: kTorEnabled
 
 ### ✅ Consistent Naming Across Layers
 
-**Use the same name for a concept everywhere - C++, JS, prefs, and UI.** Don't arbitrarily use different names in different places for the same thing.
+**Use the same name for a concept everywhere - C++, JS, prefs, and UI.** Don't
+arbitrarily use different names in different places for the same thing.
 
 ```cpp
 // ❌ WRONG - different names for same concept
@@ -98,7 +105,9 @@ bool IsBraveCommandId(int id);
 
 ## ✅ Naming: Only Use `Brave*` Prefix When Overriding Chromium
 
-**Only add the `Brave*` prefix to class names when overriding or subclassing Chromium classes.** For purely Brave-originated code, use the feature name directly.
+**Only add the `Brave*` prefix to class names when overriding or subclassing
+Chromium classes.** For purely Brave-originated code, use the feature name
+directly.
 
 ```cpp
 // ❌ WRONG - Brave prefix on a new Brave-only class
@@ -111,7 +120,8 @@ class WebcompatReporterService { ... };
 class BraveOmniboxClientImpl : public ChromeOmniboxClient { ... };
 ```
 
-Also: **filename should match the class name.** `WebcompatReporterService` -> `webcompat_reporter_service.h`.
+Also: **filename should match the class name.** `WebcompatReporterService` ->
+`webcompat_reporter_service.h`.
 
 ---
 
@@ -136,7 +146,8 @@ void MaybeHideReferrer();
 
 ## ✅ C++ Variable Naming - Underscores, Not camelCase
 
-**C++ variables use underscores (snake_case), not camelCase.** camelCase is only for class names and method names.
+**C++ variables use underscores (snake_case), not camelCase.** camelCase is only
+for class names and method names.
 
 ```cpp
 // ❌ WRONG
@@ -156,7 +167,8 @@ std::string user_name;
 
 - **Opening brace** goes at the end of the previous line (K&R style)
 - **Continuation lines** should be indented 4 spaces
-- **Do NOT enforce include order** — include ordering is handled by code formatting tools and lint, not by code review
+- **Do NOT enforce include order** — include ordering is handled by code
+  formatting tools and lint, not by code review
 
 ---
 
@@ -164,7 +176,9 @@ std::string user_name;
 
 ## ✅ Copyright Rules
 
-**Never copy a Chromium file and use Brave's copyright.** If you copy or derive from Chromium code, you must include their copyright notice. The original year should remain unchanged - don't bump existing copyright years.
+**Never copy a Chromium file and use Brave's copyright.** If you copy or derive
+from Chromium code, you must include their copyright notice. The original year
+should remain unchanged - don't bump existing copyright years.
 
 ---
 
@@ -172,7 +186,10 @@ std::string user_name;
 
 ## ✅ Copyright Year in New Files Must Be Current Year
 
-**New files must use the current year in the copyright header.** Always determine the current year from the system date (e.g., `date +%Y`), never from training data or memory — the training cutoff year is often outdated. Don't copy-paste old copyright years from other files.
+**New files must use the current year in the copyright header.** Always
+determine the current year from the system date (e.g., `date +%Y`), never from
+training data or memory — the training cutoff year is often outdated. Don't
+copy-paste old copyright years from other files.
 
 ---
 
@@ -180,7 +197,9 @@ std::string user_name;
 
 ## ❌ Don't Define Methods in Headers
 
-**Move method definitions to .cc files.** Headers should only contain declarations. Keep headers minimal - only include what's strictly required for the declarations.
+**Move method definitions to .cc files.** Headers should only contain
+declarations. Keep headers minimal - only include what's strictly required for
+the declarations.
 
 ```cpp
 // ❌ WRONG - method body in header
@@ -200,7 +219,8 @@ bool HandleRewardsProtocol(const GURL& url) {
 }
 ```
 
-Also: `static` has no meaning for free functions in C++ (it's a C holdover). Use anonymous namespaces instead.
+Also: `static` has no meaning for free functions in C++ (it's a C holdover). Use
+anonymous namespaces instead.
 
 ---
 
@@ -208,12 +228,19 @@ Also: `static` has no meaning for free functions in C++ (it's a C holdover). Use
 
 ## ✅ Use Forward Declarations in Headers, Include in `.cc`
 
-**Headers should use forward declarations instead of `#include` for types only used as pointers or references.** Move the full `#include` to the `.cc` file.
+**Headers should use forward declarations instead of `#include` for types only
+used as pointers or references.** Move the full `#include` to the `.cc` file.
 
 **Exceptions — do NOT suggest forward declarations when:**
-- The type is **not directly `#include`d** but comes transitively through a base class header that must be included anyway (e.g., `content::WebUI*` comes through `webui_config.h` or `mojo_web_ui_controller.h` — there's nothing to remove)
-- The type is **not actually used** in the file — verify the type appears in the file before suggesting a forward declaration
-- The `#include` is for a **base class** the current class inherits from — these cannot be forward-declared
+
+- The type is **not directly `#include`d** but comes transitively through a base
+  class header that must be included anyway (e.g., `content::WebUI*` comes
+  through `webui_config.h` or `mojo_web_ui_controller.h` — there's nothing to
+  remove)
+- The type is **not actually used** in the file — verify the type appears in the
+  file before suggesting a forward declaration
+- The `#include` is for a **base class** the current class inherits from — these
+  cannot be forward-declared
 
 ```cpp
 // ❌ WRONG - full include in header for pointer-only usage
@@ -240,7 +267,8 @@ namespace foo { class Bar; }
 
 ## ✅ `friend` Declarations Go Right After `private:`
 
-**In class declarations, `friend` statements should be placed immediately after the `private:` access specifier,** before any member variables or methods.
+**In class declarations, `friend` statements should be placed immediately after
+the `private:` access specifier,** before any member variables or methods.
 
 ```cpp
 // ❌ WRONG
@@ -265,7 +293,8 @@ class MyClass {
 
 ## ✅ Use Anonymous Namespaces for Internal Code
 
-**If a function or class is strictly internal to a .cc file, put it in an anonymous namespace.**
+**If a function or class is strictly internal to a .cc file, put it in an
+anonymous namespace.**
 
 ```cpp
 // ❌ WRONG - internal helper visible outside file
@@ -277,7 +306,8 @@ void InternalHelper() { ... }
 }  // namespace
 ```
 
-**No `static` on `constexpr` inside anonymous namespaces** — the namespace already provides internal linkage, so `static` is redundant.
+**No `static` on `constexpr` inside anonymous namespaces** — the namespace
+already provides internal linkage, so `static` is redundant.
 
 ```cpp
 // ❌ WRONG - redundant static
@@ -297,7 +327,8 @@ constexpr int kMaxRetries = 3;
 
 ## ✅ Function Ordering in `.cc` Should Match `.h`
 
-**Function definitions in `.cc` files should appear in the same order as their declarations in the corresponding `.h` file.**
+**Function definitions in `.cc` files should appear in the same order as their
+declarations in the corresponding `.h` file.**
 
 ---
 
@@ -305,7 +336,9 @@ constexpr int kMaxRetries = 3;
 
 ## ✅ Break Up Bloated Files
 
-**Don't keep dumping code into already-large files.** Encapsulate related functionality into smaller, focused helper files and targets. This improves readability, reduces rebase conflicts, and makes dependency tracking easier.
+**Don't keep dumping code into already-large files.** Encapsulate related
+functionality into smaller, focused helper files and targets. This improves
+readability, reduces rebase conflicts, and makes dependency tracking easier.
 
 ```cpp
 // ❌ WRONG - adding more P3A code to 5000-line RewardsServiceImpl
@@ -323,7 +356,10 @@ void RecordRewardsP3A(RewardsService* service);
 
 ## ✅ Comments Must Make Sense to Future Readers of the Codebase
 
-**Every comment should be meaningful to someone reading the code for the first time, with no knowledge of the PR or change history.** Do not add comments that reference removed code, prior behavior, or the change itself. Comments are part of the codebase, not a changelog.
+**Every comment should be meaningful to someone reading the code for the first
+time, with no knowledge of the PR or change history.** Do not add comments that
+reference removed code, prior behavior, or the change itself. Comments are part
+of the codebase, not a changelog.
 
 ```cpp
 // ❌ WRONG - references removed code / change history
@@ -350,7 +386,8 @@ base::flat_map<std::string, int> lookup_;
 
 ## ✅ Document Non-Obvious Failure Branches
 
-**When a function has multiple early-return failure branches, add a brief comment before each summarizing what it handles.**
+**When a function has multiple early-return failure branches, add a brief
+comment before each summarizing what it handles.**
 
 ```cpp
 // ❌ WRONG - unclear what each branch handles
@@ -373,7 +410,8 @@ if (!number) return std::nullopt;
 
 ## ✅ Feature Flag Comments Go in `.cc` Files
 
-**Comments explaining what a `base::Feature` does should be placed in the `.cc` file where the feature is defined, not in the `.h` file.**
+**Comments explaining what a `base::Feature` does should be placed in the `.cc`
+file where the feature is defined, not in the `.h` file.**
 
 ```cpp
 // ❌ WRONG - feature comment in .h
@@ -394,8 +432,10 @@ BASE_FEATURE(kBraveWorkaroundNewWindowFlash, ...);
 ## ✅ Document Upstream Workarounds with Issue Links
 
 **When adding a workaround for an upstream Chromium bug:**
+
 1. Add a link to the upstream issue in a code comment
-2. File details on the upstream issue explaining what's happening so they can fix it
+2. File details on the upstream issue explaining what's happening so they can
+   fix it
 
 This allows us to remove the workaround when the upstream fix lands.
 
@@ -412,7 +452,9 @@ if (!x) return;
 
 ## ❌ Don't Use Positional Terms in Code Comments
 
-**Do not use "above" or "below" in comments to reference other code.** Other developers may insert code between the comment and referenced item, breaking the meaning. Reference items explicitly by name or identifier instead.
+**Do not use "above" or "below" in comments to reference other code.** Other
+developers may insert code between the comment and referenced item, breaking the
+meaning. Reference items explicitly by name or identifier instead.
 
 ```cpp
 // ❌ WRONG - fragile positional reference
@@ -430,7 +472,8 @@ if (!x) return;
 
 ## ✅ Use CHECK for Impossible Conditions
 
-**Use `CHECK` (not `DCHECK`) for conditions that should never happen in any build.**
+**Use `CHECK` (not `DCHECK`) for conditions that should never happen in any
+build.**
 
 ```cpp
 // ❌ WRONG - DCHECK for something that should never happen
@@ -440,7 +483,8 @@ DCHECK(browser_context);
 CHECK(browser_context);  // should never be null
 ```
 
-Also: don't add unnecessary DCHECKs. For example, `DCHECK(g_browser_process)` is unnecessary because the browser wouldn't even be running without it.
+Also: don't add unnecessary DCHECKs. For example, `DCHECK(g_browser_process)` is
+unnecessary because the browser wouldn't even be running without it.
 
 ---
 
@@ -448,11 +492,20 @@ Also: don't add unnecessary DCHECKs. For example, `DCHECK(g_browser_process)` is
 
 ## ✅ `NOTREACHED`/`CHECK(false)` Only for Security-Critical Invariants
 
-**`NOTREACHED`/`CHECK(false)` should only crash the browser for security-critical invariants.** For non-security cases (like invalid enum values from data processing), prefer returning `std::optional`/`std::nullopt` or a default value.
+**`NOTREACHED`/`CHECK(false)` should only crash the browser for
+security-critical invariants.** For non-security cases (like invalid enum values
+from data processing), prefer returning `std::optional`/`std::nullopt` or a
+default value.
 
-**Important:** `NOTREACHED()` is now fatal in all builds and terminates control flow. The compiler treats code after `NOTREACHED()` as dead code. Do not place executable statements after it.
+**Important:** `NOTREACHED()` is now fatal in all builds and terminates control
+flow. The compiler treats code after `NOTREACHED()` as dead code. Do not place
+executable statements after it.
 
-**Gradual migration:** When migrating from `DCHECK` to fatal `NOTREACHED()`/`CHECK()`, you can use `NOTREACHED(base::NotFatalUntil::M140)` or `CHECK(cond, base::NotFatalUntil::M140)` to gather crash diagnostics before enforcing fatality. See [Chromium style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md).
+**Gradual migration:** When migrating from `DCHECK` to fatal
+`NOTREACHED()`/`CHECK()`, you can use `NOTREACHED(base::NotFatalUntil::M140)` or
+`CHECK(cond, base::NotFatalUntil::M140)` to gather crash diagnostics before
+enforcing fatality. See
+[Chromium style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md).
 
 ```cpp
 // ❌ WRONG - crashes browser for non-security enum mismatch
@@ -474,7 +527,9 @@ std::optional<mojom::AdType> ToMojomAdType(const std::string& type) {
 
 ## ✅ Use `CHECK` Only for Invariants Within Code's Control
 
-**Use `CHECK` only for conditions fully within the code's control.** For data from databases, user input, or external sources, use graceful error handling instead. `CHECK` failures crash the user's browser.
+**Use `CHECK` only for conditions fully within the code's control.** For data
+from databases, user input, or external sources, use graceful error handling
+instead. `CHECK` failures crash the user's browser.
 
 ```cpp
 // ❌ WRONG - crashes on external data
@@ -487,7 +542,8 @@ if (!db_value.has_value()) {
 }
 ```
 
-See also: [Chromium CHECK style guide](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/styleguide/c++/checks.md)
+See also:
+[Chromium CHECK style guide](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/styleguide/c++/checks.md)
 
 ---
 
@@ -495,7 +551,8 @@ See also: [Chromium CHECK style guide](https://chromium.googlesource.com/chromiu
 
 ## ✅ Use Result Codes, Not bool, for Error Reporting
 
-**Return result codes (enums) instead of `bool` for operations that can fail.** This allows providing additional error information and is more future-proof.
+**Return result codes (enums) instead of `bool` for operations that can fail.**
+This allows providing additional error information and is more future-proof.
 
 ---
 
@@ -503,7 +560,8 @@ See also: [Chromium CHECK style guide](https://chromium.googlesource.com/chromiu
 
 ## ✅ Don't Store Error State - Handle/Log and Store Only Success
 
-**When a field can hold either a success or error, handle/log the error immediately and store only the success type.**
+**When a field can hold either a success or error, handle/log the error
+immediately and store only the success type.**
 
 ```cpp
 // ❌ WRONG - storing error variant
@@ -519,7 +577,8 @@ std::optional<ChainMetadata> chain_metadata_;
 
 ## ❌ Don't Override Empty/No-Op Methods
 
-**If you're overriding a virtual method but not implementing any behavior, don't define it at all.**
+**If you're overriding a virtual method but not implementing any behavior, don't
+define it at all.**
 
 ```cpp
 // ❌ WRONG - pointless override
@@ -534,7 +593,9 @@ void OnSomethingHappened() override {}
 
 ## ✅ Combine Methods That Are Always Called Together
 
-**If two methods are always called in sequence (especially in patches), combine them into a single method.** This reduces patch size and prevents callers from forgetting one of the calls.
+**If two methods are always called in sequence (especially in patches), combine
+them into a single method.** This reduces patch size and prevents callers from
+forgetting one of the calls.
 
 ```cpp
 // ❌ WRONG - two methods always called together in a patch
@@ -551,7 +612,9 @@ void OnSomethingHappened() override {}
 
 ## ✅ Use Observer Pattern for UI Updates
 
-**Don't make service-layer queries to update UI directly.** Instead, trigger observer notifications and let the UI respond. See also [ARCH-021](architecture.md#ARCH-021) for when to use observers vs. callbacks.
+**Don't make service-layer queries to update UI directly.** Instead, trigger
+observer notifications and let the UI respond. See also
+[ARCH-021](architecture.md#ARCH-021) for when to use observers vs. callbacks.
 
 ```cpp
 // ❌ WRONG - service making UI queries
@@ -575,7 +638,9 @@ void RewardsService::SavePendingContribution(...) {
 
 ## ✅ Platform-Specific Code Splitting
 
-**When a method's implementation is completely different on a platform, split it into a separate file** like `my_class_android.cc` rather than filling the main file with `#if defined(OS_ANDROID)` blocks.
+**When a method's implementation is completely different on a platform, split it
+into a separate file** like `my_class_android.cc` rather than filling the main
+file with `#if defined(OS_ANDROID)` blocks.
 
 ---
 
@@ -583,7 +648,8 @@ void RewardsService::SavePendingContribution(...) {
 
 ## ✅ Use Feature Checks Over Platform Checks
 
-**Prefer feature checks over platform checks when the behavior is feature-dependent, not platform-dependent.**
+**Prefer feature checks over platform checks when the behavior is
+feature-dependent, not platform-dependent.**
 
 ```cpp
 // ❌ WRONG - platform check for feature behavior
@@ -603,9 +669,13 @@ if (IsDoNotDisturbEnabled()) {
 
 ## ✅ Consolidate Feature Flag Checks to Entry Points
 
-**Don't scatter `CHECK`/`DCHECK` for feature flag status in private helper functions.** Follow the upstream pattern: check at entry points only. Add comments on private helpers like "Only called when X is enabled".
+**Don't scatter `CHECK`/`DCHECK` for feature flag status in private helper
+functions.** Follow the upstream pattern: check at entry points only. Add
+comments on private helpers like "Only called when X is enabled".
 
-**Exception:** Public API functions that can be called independently from multiple callsites should keep their own `CHECK`/`DCHECK` guards — they are entry points themselves.
+**Exception:** Public API functions that can be called independently from
+multiple callsites should keep their own `CHECK`/`DCHECK` guards — they are
+entry points themselves.
 
 ```cpp
 // ❌ WRONG - CHECK in private helper called from a single entry point
@@ -633,7 +703,9 @@ bool StoragePartitionUtils::IsContainersStoragePartition(...) {
 
 ## ❌ Don't Use Static Variables for Per-Profile Settings
 
-**Never use static variables to store per-profile settings.** Static state is shared across all profiles and will cause incorrect behavior in multi-profile scenarios. Use `UserData` or profile-attached keyed services instead.
+**Never use static variables to store per-profile settings.** Static state is
+shared across all profiles and will cause incorrect behavior in multi-profile
+scenarios. Use `UserData` or profile-attached keyed services instead.
 
 ---
 
@@ -641,7 +713,8 @@ bool StoragePartitionUtils::IsContainersStoragePartition(...) {
 
 ## ❌ Don't Use Environment Variables for Configuration
 
-**Configuration should come from GN args, not environment variables.** For runtime overrides, use command line switches.
+**Configuration should come from GN args, not environment variables.** For
+runtime overrides, use command line switches.
 
 ```cpp
 // ❌ WRONG
@@ -659,7 +732,8 @@ std::string api_url = std::getenv("BRAVE_API_URL");
 
 ## ❌ Don't Duplicate Enum/Constant Values Across Languages
 
-**When values are defined in Mojo, use the generated bindings in C++, Java, and JS.** Don't manually duplicate constants - they easily drift out of sync.
+**When values are defined in Mojo, use the generated bindings in C++, Java, and
+JS.** Don't manually duplicate constants - they easily drift out of sync.
 
 ---
 
@@ -667,7 +741,8 @@ std::string api_url = std::getenv("BRAVE_API_URL");
 
 ## ❌ Don't Use rapidjson
 
-**Use base::JSONReader/JSONWriter, not rapidjson.** The base libraries are the standard in Chromium.
+**Use base::JSONReader/JSONWriter, not rapidjson.** The base libraries are the
+standard in Chromium.
 
 ---
 
@@ -675,7 +750,9 @@ std::string api_url = std::getenv("BRAVE_API_URL");
 
 ## VLOG Macros Handle Their Own Checks
 
-**Don't use `VLOG_IS_ON` before `VLOG` calls.** The VLOG macro already handles the level check internally and is smart enough to avoid evaluating inline expressions when the level is disabled.
+**Don't use `VLOG_IS_ON` before `VLOG` calls.** The VLOG macro already handles
+the level check internally and is smart enough to avoid evaluating inline
+expressions when the level is disabled.
 
 ```cpp
 // ❌ WRONG - unnecessary check
@@ -687,7 +764,8 @@ if (VLOG_IS_ON(2)) {
 VLOG(2) << "Some message";
 ```
 
-Also: be judicious with VLOG - make sure each log statement has a specific purpose and isn't leftover from debugging.
+Also: be judicious with VLOG - make sure each log statement has a specific
+purpose and isn't leftover from debugging.
 
 ---
 
@@ -695,7 +773,8 @@ Also: be judicious with VLOG - make sure each log statement has a specific purpo
 
 ## ✅ VLOG Component Name Should Match Directory
 
-**The component name used in VLOG messages should match the component directory name** (e.g., `policy` or `brave/components/brave_policy`).
+**The component name used in VLOG messages should match the component directory
+name** (e.g., `policy` or `brave/components/brave_policy`).
 
 ---
 
@@ -703,9 +782,16 @@ Also: be judicious with VLOG - make sure each log statement has a specific purpo
 
 ## ✅ Use `LOG(WARNING)` or `VLOG` Instead of `LOG(ERROR)` for Non-Critical Failures
 
-**`LOG(ERROR)` should be reserved for truly unexpected and serious failures.** For expected or non-critical failure cases (e.g., a bad user-supplied filter list, a failed parse of optional data), use `VLOG` for debug info or `LOG(WARNING)` for noteworthy but non-critical issues.
+**`LOG(ERROR)` should be reserved for truly unexpected and serious failures.**
+For expected or non-critical failure cases (e.g., a bad user-supplied filter
+list, a failed parse of optional data), use `VLOG` for debug info or
+`LOG(WARNING)` for noteworthy but non-critical issues.
 
-**Do not suggest lowering log severity for failures you haven't confirmed are non-critical.** The developer knows whether a failure is critical for their service better than a reviewer can infer from the code alone. For example, failing to load a model file may look non-critical in isolation but could be a critical failure for the keyed service that depends on it.
+**Do not suggest lowering log severity for failures you haven't confirmed are
+non-critical.** The developer knows whether a failure is critical for their
+service better than a reviewer can infer from the code alone. For example,
+failing to load a model file may look non-critical in isolation but could be a
+critical failure for the keyed service that depends on it.
 
 ```cpp
 // ❌ WRONG
@@ -721,7 +807,9 @@ VLOG(1) << "Failed to parse filter list";
 
 ## ✅ Use `DLOG(ERROR)` for Non-Critical Debug-Only Errors
 
-**Use `DLOG(ERROR)` instead of `LOG(ERROR)` for error conditions that are not critical in release builds.** This avoids polluting release build logs with non-actionable errors.
+**Use `DLOG(ERROR)` instead of `LOG(ERROR)` for error conditions that are not
+critical in release builds.** This avoids polluting release build logs with
+non-actionable errors.
 
 ```cpp
 // ❌ WRONG - release log noise for non-critical error
@@ -737,7 +825,8 @@ DLOG(ERROR) << "Failed to parse optional field";
 
 ## ✅ Add `SCOPED_UMA_HISTOGRAM_TIMER` for Performance-Sensitive Paths
 
-**When writing code that processes data on the UI thread or performs potentially slow operations, add `SCOPED_UMA_HISTOGRAM_TIMER` to measure performance.**
+**When writing code that processes data on the UI thread or performs potentially
+slow operations, add `SCOPED_UMA_HISTOGRAM_TIMER` to measure performance.**
 
 ```cpp
 void GetUrlCosmeticResourcesOnUI(const GURL& url) {
@@ -753,7 +842,9 @@ void GetUrlCosmeticResourcesOnUI(const GURL& url) {
 
 ## ✅ Emit Histograms from a Single Location
 
-**When recording UMA histograms, emit to each histogram from a single location.** Create a helper function rather than duplicating histogram emission across multiple call sites.
+**When recording UMA histograms, emit to each histogram from a single
+location.** Create a helper function rather than duplicating histogram emission
+across multiple call sites.
 
 ```cpp
 // ❌ WRONG - histogram emitted from multiple places
@@ -775,7 +866,8 @@ void RecordNTPCustomizeUsage(NTPCustomizeUsage usage) {
 
 ## ❌ Don't Log Sensitive Information
 
-**Never log sensitive data such as sync seeds, private keys, tokens, or credentials.** Even VLOG-level logging can expose data in debug builds.
+**Never log sensitive data such as sync seeds, private keys, tokens, or
+credentials.** Even VLOG-level logging can expose data in debug builds.
 
 ```cpp
 // ❌ WRONG
@@ -791,7 +883,9 @@ VLOG(1) << "Sync seed set successfully";
 
 ## ❌ Don't Use `public:` in Structs
 
-**Do not use `public:` labels in struct declarations since struct members are public by default.** Either remove the label or change `struct` to `class` if access control is intended.
+**Do not use `public:` labels in struct declarations since struct members are
+public by default.** Either remove the label or change `struct` to `class` if
+access control is intended.
 
 ```cpp
 // ❌ WRONG - redundant public label
@@ -814,7 +908,10 @@ struct TestData {
 
 ## ✅ Prefer `GlobalFeatures` Over `NoDestructor` for Global Services
 
-**For global/singleton services, prefer registering in `GlobalFeatures` (the Chromium replacement for `BrowserProcessImpl`) over `base::NoDestructor`.** `NoDestructor` makes testing difficult since you can't reset the instance between tests.
+**For global/singleton services, prefer registering in `GlobalFeatures` (the
+Chromium replacement for `BrowserProcessImpl`) over `base::NoDestructor`.**
+`NoDestructor` makes testing difficult since you can't reset the instance
+between tests.
 
 ```cpp
 // ❌ WRONG - hard to test
@@ -833,7 +930,9 @@ BraveOriginService* BraveOriginService::GetInstance() {
 
 ## ✅ Multiply Before Dividing in Integer Percentage Calculations
 
-**When computing percentages with integer arithmetic, multiply by 100 before dividing.** `(used * 100) / total` preserves precision, while `(used / total) * 100` truncates to 0 when `used < total`.
+**When computing percentages with integer arithmetic, multiply by 100 before
+dividing.** `(used * 100) / total` preserves precision, while
+`(used / total) * 100` truncates to 0 when `used < total`.
 
 ```cpp
 // ❌ WRONG - truncates to 0 for used < total
@@ -849,7 +948,8 @@ int pct = (used * 100) / total;
 
 ## ✅ Prefer Free Functions Over Complex Inline Lambdas
 
-**When a lambda is complex enough to make surrounding code harder to parse, extract it into a named free function in the anonymous namespace.**
+**When a lambda is complex enough to make surrounding code harder to parse,
+extract it into a named free function in the anonymous namespace.**
 
 ```cpp
 // ❌ WRONG - complex lambda obscures call site
@@ -872,9 +972,15 @@ DoSomething(base::BindOnce(&ProcessResult));
 
 ## ⚠️ Use `auto` Judiciously — Prefer Explicit Types When Short and Descriptive
 
-**Don't use `auto` merely to avoid writing a type name** when the explicit type is short and adds readability. Spell out types like `base::TimeDelta`, `base::Time`, etc. Per Google style guide: "Do not use [auto] merely to avoid the inconvenience of writing an explicit type."
+**Don't use `auto` merely to avoid writing a type name** when the explicit type
+is short and adds readability. Spell out types like `base::TimeDelta`,
+`base::Time`, etc. Per Google style guide: "Do not use [auto] merely to avoid
+the inconvenience of writing an explicit type."
 
-However, `auto` **is appropriate** when the explicit type is verbose/complex and doesn't improve readability (e.g., nested templates, long type names). This is a preference, not a hard rule — always prefix with `nit:` and do not insist if the developer declines.
+However, `auto` **is appropriate** when the explicit type is verbose/complex and
+doesn't improve readability (e.g., nested templates, long type names). This is a
+preference, not a hard rule — always prefix with `nit:` and do not insist if the
+developer declines.
 
 ```cpp
 // ❌ WRONG - auto hides a short, descriptive type
@@ -894,7 +1000,8 @@ auto weights_opt = base::ReadFileToBytes(weights_path);
 
 ## ✅ Member Initialization - Don't Add Default When Constructor Always Sets
 
-Per Chromium C++ dos and donts: "Initialize class members in their declarations, **except where a member's value is explicitly set by every constructor**."
+Per Chromium C++ dos and donts: "Initialize class members in their declarations,
+**except where a member's value is explicitly set by every constructor**."
 
 ```cpp
 // ❌ WRONG - misleading, constructor always sets this
@@ -916,7 +1023,9 @@ class TreeTabNode {
 
 ## ✅ Prefer Overloads Over Silently-Ignored Optional Parameters
 
-**Don't force callers to provide parameters that are silently ignored.** Use function overloads. Similarly, prefer overloads over `std::variant` for distinct call patterns.
+**Don't force callers to provide parameters that are silently ignored.** Use
+function overloads. Similarly, prefer overloads over `std::variant` for distinct
+call patterns.
 
 ```cpp
 // ❌ WRONG - body_value silently ignored for GET/HEAD
@@ -934,7 +1043,8 @@ void ApiFetch(const std::string& url, const base::Value& body, Callback cb);  //
 
 ## ✅ Use `observers_.Notify()` Instead of Manual Iteration
 
-**Use `observers_.Notify(&Observer::Method)` instead of manually iterating observer lists.**
+**Use `observers_.Notify(&Observer::Method)` instead of manually iterating
+observer lists.**
 
 ```cpp
 // ❌ WRONG - manual iteration
@@ -952,7 +1062,9 @@ observers_.Notify(&Observer::OnPoliciesChanged);
 
 ## ✅ Validate and Sanitize Data Before Injecting as JavaScript
 
-**When constructing JavaScript from C++ data for injection, use JSON serialization (`base::JSONWriter`) for safe encoding.** String concatenation can lead to injection vulnerabilities.
+**When constructing JavaScript from C++ data for injection, use JSON
+serialization (`base::JSONWriter`) for safe encoding.** String concatenation can
+lead to injection vulnerabilities.
 
 ```cpp
 // ❌ WRONG - string concatenation
@@ -970,7 +1082,8 @@ std::string script = "const selectors = " + json_selectors + ";";
 
 ## ✅ Use `EvalJs` Instead of Deprecated `ExecuteScriptAndExtract*`
 
-**In browser tests, use `EvalJs` and `ExecJs` instead of the deprecated `ExecuteScriptAndExtractBool/String/Int` functions.**
+**In browser tests, use `EvalJs` and `ExecJs` instead of the deprecated
+`ExecuteScriptAndExtractBool/String/Int` functions.**
 
 ```cpp
 // ❌ WRONG
@@ -988,7 +1101,9 @@ EXPECT_EQ(true, content::EvalJs(web_contents, "someCheck()"));
 
 ## ✅ Use `Profile::FromBrowserContext` for Conversion
 
-**When you have a `BrowserContext*` and need a `Profile*`, use `Profile::FromBrowserContext()`.** Don't use `static_cast` - the proper method includes safety checks.
+**When you have a `BrowserContext*` and need a `Profile*`, use
+`Profile::FromBrowserContext()`.** Don't use `static_cast` - the proper method
+includes safety checks.
 
 ```cpp
 // ❌ WRONG
@@ -1004,7 +1119,9 @@ Profile* profile = Profile::FromBrowserContext(browser_context);
 
 ## ✅ Validate URLs with `GURL::is_valid()` Before Use
 
-**Always check `GURL::is_valid()` before using a constructed URL.** Passing invalid or malformed URLs to network functions can cause crashes or unexpected behavior.
+**Always check `GURL::is_valid()` before using a constructed URL.** Passing
+invalid or malformed URLs to network functions can cause crashes or unexpected
+behavior.
 
 ```cpp
 // ❌ WRONG - no validity check
@@ -1024,7 +1141,9 @@ loader->DownloadUrl(url);
 
 ## ✅ Name Death Test Suites with `*DeathTest` Suffix
 
-**Per GoogleTest conventions, death test suite names must end with `DeathTest`.** GoogleTest uses this suffix to apply special threading behavior needed for death tests to work reliably.
+**Per GoogleTest conventions, death test suite names must end with
+`DeathTest`.** GoogleTest uses this suffix to apply special threading behavior
+needed for death tests to work reliably.
 
 ```cpp
 // ❌ WRONG - missing DeathTest suffix
@@ -1048,7 +1167,9 @@ TEST_F(MyFeatureDeathTest, CrashesOnNull) {
 
 ## ✅ Use `constexpr` for Compile-Time Constant `base::TimeDelta` Values
 
-**Declare time constants as `constexpr base::TimeDelta` rather than just `const`.** The `base::Milliseconds()`, `base::Seconds()`, and similar factory functions are constexpr-capable, so the value can be computed at compile time.
+**Declare time constants as `constexpr base::TimeDelta` rather than just
+`const`.** The `base::Milliseconds()`, `base::Seconds()`, and similar factory
+functions are constexpr-capable, so the value can be computed at compile time.
 
 ```cpp
 // ❌ WRONG - runtime initialization
@@ -1064,7 +1185,10 @@ constexpr base::TimeDelta kAnimationDuration = base::Milliseconds(200);
 
 ## ❌ Don't Commit Commented-Out Code
 
-**Remove commented-out code, dead `#include` lines, and development leftovers before merging.** Commented-out code adds noise, confuses future readers, and is never cleaned up. If the code might be needed later, it lives in version control history.
+**Remove commented-out code, dead `#include` lines, and development leftovers
+before merging.** Commented-out code adds noise, confuses future readers, and is
+never cleaned up. If the code might be needed later, it lives in version control
+history.
 
 ```cpp
 // ❌ WRONG - dead code left in
@@ -1080,7 +1204,10 @@ constexpr base::TimeDelta kAnimationDuration = base::Milliseconds(200);
 
 ## ✅ Migrate User Prefs When Removing or Renaming Features
 
-**When removing a feature, model, or preference key that users may have selected, add a migration step to reset affected prefs to a sensible default.** Otherwise users who had the removed option selected are left with a stale value that may cause errors or confusing behavior.
+**When removing a feature, model, or preference key that users may have
+selected, add a migration step to reset affected prefs to a sensible default.**
+Otherwise users who had the removed option selected are left with a stale value
+that may cause errors or confusing behavior.
 
 ```cpp
 // ❌ WRONG - just delete the model, users with it selected get broken state
@@ -1104,7 +1231,10 @@ void MigrateProfilePrefs(PrefService* prefs) {
 
 ## ✅ Clean Up All Dead Code When Removing Features
 
-**When removing a feature flag, model, or script, also remove all associated dead code:** unused helper functions, orphaned UI strings from `.grdp` files, related constants, and utility functions that were only referenced by the removed code. Leaving dead code behind creates maintenance burden and confusion.
+**When removing a feature flag, model, or script, also remove all associated
+dead code:** unused helper functions, orphaned UI strings from `.grdp` files,
+related constants, and utility functions that were only referenced by the
+removed code. Leaving dead code behind creates maintenance burden and confusion.
 
 ---
 
@@ -1112,7 +1242,11 @@ void MigrateProfilePrefs(PrefService* prefs) {
 
 ## ❌ Avoid Multiple Inheritance Beyond Interfaces
 
-**Multiple inheritance is permitted in Chromium but discouraged beyond interface-style patterns.** Prefer composition over deep multiple inheritance hierarchies. If you inherit from multiple concrete classes, explore whether composition achieves the same goal more cleanly. See [Chromium C++ style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md).
+**Multiple inheritance is permitted in Chromium but discouraged beyond
+interface-style patterns.** Prefer composition over deep multiple inheritance
+hierarchies. If you inherit from multiple concrete classes, explore whether
+composition achieves the same goal more cleanly. See
+[Chromium C++ style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md).
 
 ---
 
@@ -1120,9 +1254,12 @@ void MigrateProfilePrefs(PrefService* prefs) {
 
 ## ✅ Use `DVLOG(1)` for Retained Logging, `ScopedCrashKeyString` for Crash Diagnostics
 
-**Per the Chromium style guide, remove all logging before check-in.** When logging must remain (e.g., for rare bug investigation), use `DVLOG(1)` — it avoids release binary bloat and can be enabled via `--v=1` or `--vmodule=mod=1`.
+**Per the Chromium style guide, remove all logging before check-in.** When
+logging must remain (e.g., for rare bug investigation), use `DVLOG(1)` — it
+avoids release binary bloat and can be enabled via `--v=1` or `--vmodule=mod=1`.
 
-**For crash diagnostics, use `base::debug::ScopedCrashKeyString` instead of logs.** Crash keys attach data to crash reports without polluting logs.
+**For crash diagnostics, use `base::debug::ScopedCrashKeyString` instead of
+logs.** Crash keys attach data to crash reports without polluting logs.
 
 ```cpp
 // ❌ WRONG - LOG in production for diagnostics
@@ -1137,7 +1274,8 @@ static auto* crash_key = base::debug::AllocateCrashKeyString(
 base::debug::ScopedCrashKeyString scoped_key(crash_key, state);
 ```
 
-See [Chromium C++ style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md).
+See
+[Chromium C++ style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md).
 
 ---
 
@@ -1145,7 +1283,12 @@ See [Chromium C++ style guide](https://chromium.googlesource.com/chromium/src/+/
 
 ## ✅ Use `*.mojom-forward.h` in Headers When Only Forward Declarations Are Needed
 
-**When a header only references mojom types as pointers, references, or function parameters, include the auto-generated `*.mojom-forward.h` instead of the full `*.mojom.h` bindings.** The forward header declares all types from the mojom file without pulling in the full bindings, which reduces compile times and transitive dependencies. Move the full `*.mojom.h` include to the `.cc` file where the types are actually used.
+**When a header only references mojom types as pointers, references, or function
+parameters, include the auto-generated `*.mojom-forward.h` instead of the full
+`*.mojom.h` bindings.** The forward header declares all types from the mojom
+file without pulling in the full bindings, which reduces compile times and
+transitive dependencies. Move the full `*.mojom.h` include to the `.cc` file
+where the types are actually used.
 
 ```cpp
 // ❌ WRONG - full mojom bindings in header for forward-declared usage only
@@ -1172,6 +1315,8 @@ void RegisterProfilePrefs(
 #include "brave/components/containers/core/mojom/containers.mojom.h"
 ```
 
-This is a mojom-specific application of [CS-014](#CS-014). The `*.mojom-forward.h` is auto-generated alongside the full bindings — every mojom target produces it.
+This is a mojom-specific application of [CS-014](#CS-014). The
+`*.mojom-forward.h` is auto-generated alongside the full bindings — every mojom
+target produces it.
 
 ---

--- a/docs/best-practices/documentation.md
+++ b/docs/best-practices/documentation.md
@@ -4,7 +4,10 @@
 
 ## ✅ Update Documentation Alongside Code Changes
 
-**Documentation changes must accompany code modifications in the same changelist.** Don't create separate CLs for documentation updates — they tend to get forgotten or lose context. Updating docs in the same CL ensures accuracy and provides reviewers with context about the changes being made.
+**Documentation changes must accompany code modifications in the same
+changelist.** Don't create separate CLs for documentation updates — they tend to
+get forgotten or lose context. Updating docs in the same CL ensures accuracy and
+provides reviewers with context about the changes being made.
 
 ```
 # ❌ WRONG - code change in one CL, docs "later"
@@ -21,7 +24,9 @@ CL 1: Refactor RewardsService API + update README and method docs
 
 ## ✅ Delete Dead Documentation
 
-**Remove outdated documentation rather than letting it rot.** Obsolete docs mislead developers and erode trust in the codebase. When you encounter documentation that no longer matches the code, delete or update it.
+**Remove outdated documentation rather than letting it rot.** Obsolete docs
+mislead developers and erode trust in the codebase. When you encounter
+documentation that no longer matches the code, delete or update it.
 
 - Remove content you're certain is incorrect
 - Default toward removal when in doubt
@@ -45,7 +50,9 @@ void FetchData() { ... }
 
 ## ✅ Method Documentation Should Describe the Contract
 
-**Method API documentation should describe the contract: behavior, parameters, return values, gotchas, restrictions, and exceptions.** This is especially important for public methods in headers.
+**Method API documentation should describe the contract: behavior, parameters,
+return values, gotchas, restrictions, and exceptions.** This is especially
+important for public methods in headers.
 
 ```cpp
 // ❌ WRONG - vague or missing docs
@@ -66,7 +73,8 @@ std::optional<PublisherInfo> GetPublisherInfo(const std::string& id);
 
 ## ✅ README.md Files Should Orient New Readers
 
-**Each major directory should have a README.md that orients new developers.** A good README identifies:
+**Each major directory should have a README.md that orients new developers.** A
+good README identifies:
 
 - The purpose of the directory
 - Key files and their roles
@@ -77,9 +85,11 @@ Start with the simplest use case and build up to advanced usage.
 
 ```markdown
 # ❌ WRONG - no README, or an empty one
+
 (nothing)
 
 # ✅ CORRECT - orienting README
+
 # Brave Rewards Browser Integration
 
 This directory contains the browser-layer integration for Brave Rewards.
@@ -87,14 +97,15 @@ This directory contains the browser-layer integration for Brave Rewards.
 <a id="DOC-006"></a>
 
 ## Key Files
+
 - `rewards_service_impl.cc` - Main service implementation
 - `rewards_service_factory.cc` - Profile-keyed factory
 
 <a id="DOC-007"></a>
 
 ## Usage
-Get the service via the factory:
-RewardsServiceFactory::GetForProfile(profile)
+
+Get the service via the factory: RewardsServiceFactory::GetForProfile(profile)
 ```
 
 ---
@@ -103,7 +114,9 @@ RewardsServiceFactory::GetForProfile(profile)
 
 ## ✅ Don't Duplicate Documentation — Link to Canonical Sources
 
-**Link to existing documentation rather than creating duplicates.** Duplicate docs inevitably drift out of sync. If you need project-specific context, add a brief note and link to the canonical source.
+**Link to existing documentation rather than creating duplicates.** Duplicate
+docs inevitably drift out of sync. If you need project-specific context, add a
+brief note and link to the canonical source.
 
 ```markdown
 # ❌ WRONG - duplicating upstream docs
@@ -111,16 +124,19 @@ RewardsServiceFactory::GetForProfile(profile)
 <a id="DOC-009"></a>
 
 ## How to Add a Feature Flag
+
 1. Create a feature in features.h...
-2. Register in about_flags.cc...
-(copy of upstream instructions that will go stale)
+2. Register in about_flags.cc... (copy of upstream instructions that will go
+   stale)
 
 # ✅ CORRECT - link with context
 
 <a id="DOC-010"></a>
 
 ## How to Add a Feature Flag
-Follow the [Chromium feature flag guide](https://chromium.googlesource.com/chromium/src/+/main/docs/how_to_add_your_feature_flag.md).
+
+Follow the
+[Chromium feature flag guide](https://chromium.googlesource.com/chromium/src/+/main/docs/how_to_add_your_feature_flag.md).
 Brave-specific: also register in `brave/browser/about_flags.cc`.
 ```
 
@@ -130,7 +146,9 @@ Brave-specific: also register in `brave/browser/about_flags.cc`.
 
 ## ✅ Prefer Minimal, Fresh Documentation Over Comprehensive Stale Documentation
 
-**A small amount of accurate, up-to-date documentation is more valuable than extensive documentation in poor condition.** Treat documentation like a bonsai tree — alive but frequently trimmed.
+**A small amount of accurate, up-to-date documentation is more valuable than
+extensive documentation in poor condition.** Treat documentation like a bonsai
+tree — alive but frequently trimmed.
 
 - Don't write docs you won't maintain
 - Remove sections that nobody reads or updates

--- a/docs/best-practices/frontend.md
+++ b/docs/best-practices/frontend.md
@@ -4,7 +4,9 @@
 
 ## ❌ Don't Spread Args in Render Helpers or Components
 
-**Avoid spreading `...args` into `render()`, component props, or other React APIs.** Spreading arbitrary arguments can allow unexpected attributes to be injected, potentially leading to XSS. Pass explicit props instead.
+**Avoid spreading `...args` into `render()`, component props, or other React
+APIs.** Spreading arbitrary arguments can allow unexpected attributes to be
+injected, potentially leading to XSS. Pass explicit props instead.
 
 ```tsx
 // ❌ WRONG - spreading arbitrary args
@@ -21,7 +23,7 @@ async function renderMyComponent(
 // ✅ CORRECT - explicit props
 async function renderMyComponent(
   ui: React.ReactElement,
-  options?: RenderOptions
+  options?: RenderOptions,
 ): Promise<RenderResult> {
   let result: RenderResult
   await act(async () => {
@@ -37,22 +39,29 @@ async function renderMyComponent(
 
 ## ❌ Avoid Redundant React Keys
 
-**When a parent component already assigns a `key` prop to a child in a list, the child should not redundantly set its own key on inner elements for list-keying purposes.** Redundant keys suggest a misunderstanding of React's reconciliation boundary.
+**When a parent component already assigns a `key` prop to a child in a list, the
+child should not redundantly set its own key on inner elements for list-keying
+purposes.** Redundant keys suggest a misunderstanding of React's reconciliation
+boundary.
 
 ```tsx
 // ❌ WRONG - parent already provides key
-{items.map((item) => (
-  <AttachmentItem key={item.id}>
-    <div key={item.id}>{item.name}</div>  {/* Redundant! */}
-  </AttachmentItem>
-))}
+{
+  items.map((item) => (
+    <AttachmentItem key={item.id}>
+      <div key={item.id}>{item.name}</div> {/* Redundant! */}
+    </AttachmentItem>
+  ))
+}
 
 // ✅ CORRECT - key only on the list element
-{items.map((item) => (
-  <AttachmentItem key={item.id}>
-    <div>{item.name}</div>
-  </AttachmentItem>
-))}
+{
+  items.map((item) => (
+    <AttachmentItem key={item.id}>
+      <div>{item.name}</div>
+    </AttachmentItem>
+  ))
+}
 ```
 
 ---
@@ -61,7 +70,9 @@ async function renderMyComponent(
 
 ## ✅ Move Utility Functions to Dedicated Modules
 
-**Pure utility functions should live in dedicated utility modules (e.g., `utils/conversation_history_utils.ts`), not in React context/state files.** Context files should focus on state management, not data transformation logic.
+**Pure utility functions should live in dedicated utility modules (e.g.,
+`utils/conversation_history_utils.ts`), not in React context/state files.**
+Context files should focus on state management, not data transformation logic.
 
 ---
 
@@ -69,7 +80,9 @@ async function renderMyComponent(
 
 ## ✅ Merge Similar UI Components
 
-**When adding support for a new file type to an upload/attachment UI, merge similar components into a single generic one** rather than creating parallel components.
+**When adding support for a new file type to an upload/attachment UI, merge
+similar components into a single generic one** rather than creating parallel
+components.
 
 ```tsx
 // ❌ WRONG - separate components for each type
@@ -86,7 +99,8 @@ async function renderMyComponent(
 
 ## ❌ Don't Redefine Types from Generated Bindings
 
-**In TypeScript tests, import enum types from generated Mojo bindings or source files.** Do not redefine or duplicate them in test files.
+**In TypeScript tests, import enum types from generated Mojo bindings or source
+files.** Do not redefine or duplicate them in test files.
 
 ```tsx
 // ❌ WRONG - redefining enum from mojom
@@ -105,7 +119,9 @@ import { FileType } from 'gen/brave/components/ai_chat/core/common/mojom/ai_chat
 
 ## ❌ Avoid Unnecessary `useMemo` for Simple Property Access
 
-**Don't wrap simple property lookups in `useMemo`.** Accessing `array.length`, `obj.property`, or other trivial derivations is cheaper than React's memoization overhead.
+**Don't wrap simple property lookups in `useMemo`.** Accessing `array.length`,
+`obj.property`, or other trivial derivations is cheaper than React's memoization
+overhead.
 
 ```tsx
 // ❌ WRONG - useMemo for trivial access
@@ -121,18 +137,20 @@ const count = items.length
 
 ## ✅ Return Null from Components When No Data
 
-**React components should return `null` early when there's no data to render,** rather than rendering empty containers or placeholder markup that adds unnecessary DOM nodes.
+**React components should return `null` early when there's no data to render,**
+rather than rendering empty containers or placeholder markup that adds
+unnecessary DOM nodes.
 
 ```tsx
 // ❌ WRONG - renders empty container
 function UserInfo({ user }: Props) {
-  return <div className="user-info">{user ? user.name : ''}</div>
+  return <div className='user-info'>{user ? user.name : ''}</div>
 }
 
 // ✅ CORRECT - return null when no data
 function UserInfo({ user }: Props) {
   if (!user) return null
-  return <div className="user-info">{user.name}</div>
+  return <div className='user-info'>{user.name}</div>
 }
 ```
 
@@ -142,7 +160,9 @@ function UserInfo({ user }: Props) {
 
 ## ✅ Use `generateReactContext` for Mojo API Contexts
 
-**Use the `generateReactContext` helper from `$web-common/api/react_api`** for creating React context + provider pairs for Mojo API bindings. Don't write custom context boilerplate for each API.
+**Use the `generateReactContext` helper from `$web-common/api/react_api`** for
+creating React context + provider pairs for Mojo API bindings. Don't write
+custom context boilerplate for each API.
 
 ---
 
@@ -150,7 +170,9 @@ function UserInfo({ user }: Props) {
 
 ## ✅ Use Partial Value Updates Instead of Spread-Then-Modify
 
-**When updating state objects, prefer partial update functions over spreading the entire object and overriding one field.** This is more efficient and less error-prone.
+**When updating state objects, prefer partial update functions over spreading
+the entire object and overriding one field.** This is more efficient and less
+error-prone.
 
 ```tsx
 // ❌ WRONG - spread then override
@@ -166,7 +188,9 @@ setPartialState({ isLoading: true })
 
 ## ❌ Don't Provide Defaults for Leo CSS Variables
 
-**Never provide fallback/default values for Leo design system CSS custom properties.** Leo variables are guaranteed to be set by the design system; providing defaults can mask theming bugs and produce inconsistent styling.
+**Never provide fallback/default values for Leo design system CSS custom
+properties.** Leo variables are guaranteed to be set by the design system;
+providing defaults can mask theming bugs and produce inconsistent styling.
 
 ```css
 /* ❌ WRONG - default masks theming bugs */
@@ -182,7 +206,13 @@ color: var(--leo-color-text-primary);
 
 ## ✅ New UI Components Must Have Storybook Stories
 
-**New UI features should have Storybook stories that cover their primary visual states.** Stories serve as both documentation and visual regression baselines. A single integrated story that exercises multiple closely-coupled components together (e.g., a panel story that covers the full panel with all sub-components) is sufficient — individual per-component stories are not always necessary. This is a preference, not a requirement — do not insist if the developer considers existing story coverage adequate.
+**New UI features should have Storybook stories that cover their primary visual
+states.** Stories serve as both documentation and visual regression baselines. A
+single integrated story that exercises multiple closely-coupled components
+together (e.g., a panel story that covers the full panel with all
+sub-components) is sufficient — individual per-component stories are not always
+necessary. This is a preference, not a requirement — do not insist if the
+developer considers existing story coverage adequate.
 
 ---
 
@@ -190,7 +220,9 @@ color: var(--leo-color-text-primary);
 
 ## ❌ TS Mojom Bindings Generate Interfaces, Not Classes
 
-**TypeScript WebUI mojom bindings generate interfaces, not classes.** This means `instanceof` checks won't work on mojom types. Use type guards or discriminated unions instead.
+**TypeScript WebUI mojom bindings generate interfaces, not classes.** This means
+`instanceof` checks won't work on mojom types. Use type guards or discriminated
+unions instead.
 
 ```tsx
 // ❌ WRONG - instanceof on mojom-generated type
@@ -206,7 +238,9 @@ if ('text' in value && 'role' in value) { ... }
 
 ## ✅ WebUI Resource Files Must Be in Correct Top-Level Directory
 
-**WebUI resource files must be placed in the correct top-level directory under `resources/` matching the WebUI host name.** Misplaced resources won't be found at runtime.
+**WebUI resource files must be placed in the correct top-level directory under
+`resources/` matching the WebUI host name.** Misplaced resources won't be found
+at runtime.
 
 ---
 
@@ -214,9 +248,14 @@ if ('text' in value && 'role' in value) { ... }
 
 ## ✅ Prefer Semantic HTML Links Over Button+JS Navigation
 
-**When a UI element's only action is navigating to a URL, use a proper `<a>` link element instead of a `<button>` with JavaScript navigation.** This provides better accessibility (users can see the destination on hover) and follows semantic HTML principles.
+**When a UI element's only action is navigating to a URL, use a proper `<a>`
+link element instead of a `<button>` with JavaScript navigation.** This provides
+better accessibility (users can see the destination on hover) and follows
+semantic HTML principles.
 
-**Exception:** When a design system (e.g., Nala/Leo) provides styled button or link components, prefer using those for visual consistency with the design language. Design system consistency takes precedence over raw semantic HTML.
+**Exception:** When a design system (e.g., Nala/Leo) provides styled button or
+link components, prefer using those for visual consistency with the design
+language. Design system consistency takes precedence over raw semantic HTML.
 
 ```tsx
 // ❌ WRONG - button with JS navigation
@@ -235,7 +274,10 @@ if ('text' in value && 'role' in value) { ... }
 
 ## ❌ Avoid Unnecessary `waitFor` in React Tests
 
-**In React component tests, if you are using `rerender` to trigger updates, `waitFor` should not be needed** since `rerender` is synchronous. Similarly, wrapping DOM mutations in `act()` applies pending React updates. Using `waitFor` unnecessarily makes tests slower and can mask timing-related bugs.
+**In React component tests, if you are using `rerender` to trigger updates,
+`waitFor` should not be needed** since `rerender` is synchronous. Similarly,
+wrapping DOM mutations in `act()` applies pending React updates. Using `waitFor`
+unnecessarily makes tests slower and can mask timing-related bugs.
 
 ---
 
@@ -243,7 +285,10 @@ if ('text' in value && 'role' in value) { ... }
 
 ## ❌ Avoid Global State Assumptions for Component-Scoped Operations
 
-**When a function accesses global state (like `window.getSelection()`), consider what happens if multiple instances of the component exist on the page.** If the function is component-scoped, pass a ref to the specific component instance instead of relying on global state.
+**When a function accesses global state (like `window.getSelection()`), consider
+what happens if multiple instances of the component exist on the page.** If the
+function is component-scoped, pass a ref to the specific component instance
+instead of relying on global state.
 
 ---
 
@@ -251,7 +296,10 @@ if ('text' in value && 'role' in value) { ... }
 
 ## ✅ Document Exported TypeScript Types
 
-**Exported TypeScript types intended for use outside the component must have documentation comments** explaining their purpose. Complex union types and data shapes used as component APIs especially need explicit documentation for consumers.
+**Exported TypeScript types intended for use outside the component must have
+documentation comments** explaining their purpose. Complex union types and data
+shapes used as component APIs especially need explicit documentation for
+consumers.
 
 ---
 
@@ -259,7 +307,10 @@ if ('text' in value && 'role' in value) { ... }
 
 ## ✅ Documentation Code Examples Must Be Valid
 
-**Code examples in README files and documentation must be syntactically valid and compilable.** Developers copy-paste them. Invalid JSX (e.g., missing fragment wrappers for sibling elements, `onClick={fn()}` instead of `onClick={() => fn()}`) causes confusion and compile errors.
+**Code examples in README files and documentation must be syntactically valid
+and compilable.** Developers copy-paste them. Invalid JSX (e.g., missing
+fragment wrappers for sibling elements, `onClick={fn()}` instead of
+`onClick={() => fn()}`) causes confusion and compile errors.
 
 ```tsx
 // ❌ WRONG - invokes immediately, missing fragment wrapper
@@ -279,7 +330,10 @@ if ('text' in value && 'role' in value) { ... }
 
 ## ✅ Use TypeScript Entry Points Instead of Inline Scripts
 
-**When adding JavaScript to WebUI pages, always use compiled TypeScript entry points rather than inline `<script>` tags.** This gives you type checking, code analysis, and consistent bundling. Add additional entry points to the GN build configuration.
+**When adding JavaScript to WebUI pages, always use compiled TypeScript entry
+points rather than inline `<script>` tags.** This gives you type checking, code
+analysis, and consistent bundling. Add additional entry points to the GN build
+configuration.
 
 ```gn
 # ✅ CORRECT - additional entry point in GN
@@ -295,7 +349,10 @@ entry_points = [
 
 ## ✅ Prefer Functional Components Over Class Components
 
-**Write React components as functions, not classes.** Functional components with hooks are simpler, easier to test, and compose better. Class components require more boilerplate, have subtler lifecycle bugs, and are not compatible with hooks.
+**Write React components as functions, not classes.** Functional components with
+hooks are simpler, easier to test, and compose better. Class components require
+more boilerplate, have subtler lifecycle bugs, and are not compatible with
+hooks.
 
 ```tsx
 // ❌ WRONG - class component
@@ -306,14 +363,16 @@ class UserCard extends React.Component<Props, State> {
   }
 
   componentDidMount() {
-    fetchUser(this.props.id).then(user => this.setState({ user }))
+    fetchUser(this.props.id).then((user) => this.setState({ user }))
   }
 
   render() {
     return (
       <div>
         <span>{this.state.user?.name}</span>
-        <button onClick={() => this.setState({ isExpanded: !this.state.isExpanded })}>
+        <button
+          onClick={() => this.setState({ isExpanded: !this.state.isExpanded })}
+        >
           Toggle
         </button>
       </div>
@@ -333,13 +392,14 @@ function UserCard({ id }: Props) {
   return (
     <div>
       <span>{user?.name}</span>
-      <button onClick={() => setIsExpanded(e => !e)}>Toggle</button>
+      <button onClick={() => setIsExpanded((e) => !e)}>Toggle</button>
     </div>
   )
 }
 ```
 
-The only valid exception is `React.Component` error boundaries, which still require a class component (`componentDidCatch` has no hook equivalent).
+The only valid exception is `React.Component` error boundaries, which still
+require a class component (`componentDidCatch` has no hook equivalent).
 
 ---
 
@@ -347,7 +407,10 @@ The only valid exception is `React.Component` error boundaries, which still requ
 
 ## ⚠️ Beware `||=` Short-Circuit When Replacing `|=`
 
-**Never replace `|=` with `||=` when the right-hand side has side effects.** The `||=` operator short-circuits: once the left side is truthy, the right side is never evaluated. If the right side calls a function with side effects, those effects will be silently skipped.
+**Never replace `|=` with `||=` when the right-hand side has side effects.** The
+`||=` operator short-circuits: once the left side is truthy, the right side is
+never evaluated. If the right side calls a function with side effects, those
+effects will be silently skipped.
 
 ```typescript
 // ❌ WRONG - fn() won't be called once isDirty is true
@@ -360,7 +423,8 @@ isDirty = isDirty || updateFileTimestamps(file)
 isDirty = updateFileTimestamps(file) || isDirty
 ```
 
-Place the side-effecting call on the LEFT side of `||` to guarantee it always runs.
+Place the side-effecting call on the LEFT side of `||` to guarantee it always
+runs.
 
 ---
 
@@ -368,23 +432,39 @@ Place the side-effecting call on the LEFT side of `||` to guarantee it always ru
 
 ## ❌ Don't Replace Hardcoded Initial CSS With Design Tokens That Load Asynchronously
 
-**In WebUI HTML files, keep hardcoded initial background/foreground colors for the page body or root container.** Design tokens like `var(--leo-color-container-background)` are loaded asynchronously via JavaScript — replacing the hardcoded value causes a visible flash of unstyled content (FOUC) while the token loads.
+**In WebUI HTML files, keep hardcoded initial background/foreground colors for
+the page body or root container.** Design tokens like
+`var(--leo-color-container-background)` are loaded asynchronously via JavaScript
+— replacing the hardcoded value causes a visible flash of unstyled content
+(FOUC) while the token loads.
 
 ```html
 <!-- ❌ WRONG - Nala token isn't available yet at initial paint -->
-<style>body { background: var(--leo-color-container-background); }</style>
+<style>
+  body {
+    background: var(--leo-color-container-background);
+  }
+</style>
 
 <!-- ✅ CORRECT - hardcoded value matches the token's resolved value, avoids FOUC -->
-<style>body { background: #111114; }</style>
+<style>
+  body {
+    background: #111114;
+  }
+</style>
 ```
 
-Once the page's JavaScript loads and Leo tokens are initialized, the themed value takes over naturally. The hardcoded value is only visible during the brief initial paint.
+Once the page's JavaScript loads and Leo tokens are initialized, the themed
+value takes over naturally. The hardcoded value is only visible during the brief
+initial paint.
 
 <a id="FE-030"></a>
 
 ## ✅ Wrap `JSON.parse` in Try/Catch in React Render Paths
 
-**`JSON.parse` calls on external or server data in React render paths (including `useMemo`) must be wrapped in `try/catch`.** Malformed JSON will throw a `SyntaxError` that crashes the entire component tree if uncaught.
+**`JSON.parse` calls on external or server data in React render paths (including
+`useMemo`) must be wrapped in `try/catch`.** Malformed JSON will throw a
+`SyntaxError` that crashes the entire component tree if uncaught.
 
 ```tsx
 // ❌ WRONG - crashes component on malformed JSON
@@ -406,7 +486,9 @@ const config = useMemo(() => {
 
 ## ❌ Don't Use `render().toBeTruthy()` in React Tests
 
-**`render()` always returns a truthy object, so `expect(render(<Component />)).toBeTruthy()` always passes.** Assert on actual rendered content instead.
+**`render()` always returns a truthy object, so
+`expect(render(<Component />)).toBeTruthy()` always passes.** Assert on actual
+rendered content instead.
 
 ```tsx
 // ❌ WRONG - always passes, tests nothing
@@ -423,7 +505,10 @@ expect(getByText('Expected text')).toBeTruthy()
 
 ## ❌ Avoid `dangerouslySetInnerHTML` for External Content
 
-**Do not use `dangerouslySetInnerHTML` to render HTML from external or untrusted sources.** Instead, parse the data and render known safe elements using React components. If raw HTML rendering is unavoidable, sanitize it first and request a security review.
+**Do not use `dangerouslySetInnerHTML` to render HTML from external or untrusted
+sources.** Instead, parse the data and render known safe elements using React
+components. If raw HTML rendering is unavoidable, sanitize it first and request
+a security review.
 
 ---
 
@@ -431,7 +516,9 @@ expect(getByText('Expected text')).toBeTruthy()
 
 ## ✅ Clean Up Async Operations in React `useEffect`
 
-**Async operations started in `useEffect` must be properly cleaned up to prevent state updates on unmounted components.** Use `AbortController` or a ref-based cancellation flag.
+**Async operations started in `useEffect` must be properly cleaned up to prevent
+state updates on unmounted components.** Use `AbortController` or a ref-based
+cancellation flag.
 
 ```tsx
 // ❌ WRONG - no cleanup, state update on unmounted component
@@ -448,4 +535,3 @@ useEffect(() => {
 ```
 
 ---
-

--- a/docs/best-practices/ios.md
+++ b/docs/best-practices/ios.md
@@ -4,9 +4,13 @@
 
 ## ✅ Use `[weak self]` in Async Closures to Prevent Retain Cycles
 
-**Always capture `[weak self]` in closures that outlive the current scope** — network callbacks, notification handlers, animation completions, and stored closures. Use `[unowned self]` only when the closure's lifetime is guaranteed to be shorter than `self`.
+**Always capture `[weak self]` in closures that outlive the current scope** —
+network callbacks, notification handlers, animation completions, and stored
+closures. Use `[unowned self]` only when the closure's lifetime is guaranteed to
+be shorter than `self`.
 
-**Exception:** Fire-and-forget `Task {}` blocks that are **not** stored as a property do not need `[weak self]` because they don't create a retain cycle.
+**Exception:** Fire-and-forget `Task {}` blocks that are **not** stored as a
+property do not need `[weak self]` because they don't create a retain cycle.
 
 ```swift
 // ❌ WRONG - strong self capture in stored closure
@@ -35,7 +39,8 @@ fetchTask = Task { [weak self] in
 }
 ```
 
-**Apply `[weak self]` to the root/outermost closure**, not inner closures. Inner closures inherit the capture from the outer scope.
+**Apply `[weak self]` to the root/outermost closure**, not inner closures. Inner
+closures inherit the capture from the outer scope.
 
 ---
 
@@ -43,7 +48,9 @@ fetchTask = Task { [weak self] in
 
 ## ✅ Use `@Observable` Macro, Not `ObservableObject`
 
-**Prefer the `@Observable` macro (Observation framework) over `ObservableObject` (Combine).** `@Observable` is the modern replacement, requires less boilerplate, and integrates better with SwiftUI.
+**Prefer the `@Observable` macro (Observation framework) over `ObservableObject`
+(Combine).** `@Observable` is the modern replacement, requires less boilerplate,
+and integrates better with SwiftUI.
 
 ```swift
 // ❌ WRONG - legacy Combine pattern
@@ -64,7 +71,10 @@ class ViewModel {
 
 ## ✅ Use `@MainActor` to Ensure UI Work Runs on the Main Thread
 
-**Mark methods and types that perform UI work as `@MainActor`** so that async contexts are forced to await them. Note that Tasks inherit actor isolation from their enclosing context — adding `@MainActor` to a Task created inside an already-`@MainActor`-isolated context is redundant.
+**Mark methods and types that perform UI work as `@MainActor`** so that async
+contexts are forced to await them. Note that Tasks inherit actor isolation from
+their enclosing context — adding `@MainActor` to a Task created inside an
+already-`@MainActor`-isolated context is redundant.
 
 ```swift
 // ❌ WRONG - redundant @MainActor on Task inside @MainActor context
@@ -107,7 +117,9 @@ func updateUI() async {
 
 ## ✅ Use `#available` Compiler Checks
 
-**Use `#available` for API availability checks, not manual version comparisons.** The compiler enforces `#available` correctness and produces warnings when minimum deployment targets change.
+**Use `#available` for API availability checks, not manual version
+comparisons.** The compiler enforces `#available` correctness and produces
+warnings when minimum deployment targets change.
 
 ```swift
 // ❌ WRONG - manual version check
@@ -168,7 +180,8 @@ guard let a = optionalA, let b = optionalB else { return }
 
 ## ✅ Use `Set` for Membership Testing
 
-**Use `Set` instead of `Array` when the primary operation is membership testing (`contains`).** `Set.contains` is O(1) vs Array's O(n).
+**Use `Set` instead of `Array` when the primary operation is membership testing
+(`contains`).** `Set.contains` is O(1) vs Array's O(n).
 
 ```swift
 // ❌ WRONG - O(n) lookup
@@ -186,7 +199,9 @@ if allowedTypes.contains(type) { ... }
 
 ## ✅ Use `public` Not `open` Unless Subclassing Is Required
 
-**Default to `public` access control. Only use `open` when external modules need to subclass or override.** Using `open` unnecessarily exposes implementation details.
+**Default to `public` access control. Only use `open` when external modules need
+to subclass or override.** Using `open` unnecessarily exposes implementation
+details.
 
 ---
 
@@ -194,7 +209,8 @@ if allowedTypes.contains(type) { ... }
 
 ## ✅ Prefer Convenience Initializers on Enums Over Static Factory Methods
 
-**Use convenience initializers on enums instead of static factory methods.** This is more idiomatic Swift and integrates better with the type system.
+**Use convenience initializers on enums instead of static factory methods.**
+This is more idiomatic Swift and integrates better with the type system.
 
 ```swift
 // ❌ WRONG - static factory
@@ -218,7 +234,8 @@ extension TabType {
 
 ## ❌ No Default Values for Required Init Parameters
 
-**Don't provide default values for parameters that callers should always explicitly specify.** This prevents accidental use of incorrect defaults.
+**Don't provide default values for parameters that callers should always
+explicitly specify.** This prevents accidental use of incorrect defaults.
 
 ---
 
@@ -226,9 +243,11 @@ extension TabType {
 
 ## ✅ Use `let` Over `var` for Single-Assignment Properties
 
-**Use `let` for properties that are assigned once and never mutated.** The compiler enforces immutability, preventing accidental reassignment.
+**Use `let` for properties that are assigned once and never mutated.** The
+compiler enforces immutability, preventing accidental reassignment.
 
-**Exception:** Swift structs control mutability at the usage site via `let`/`var`, so `var` properties in structs are acceptable:
+**Exception:** Swift structs control mutability at the usage site via
+`let`/`var`, so `var` properties in structs are acceptable:
 
 ```swift
 struct Item {
@@ -245,9 +264,12 @@ var itemTwo = Item(name: "...") // itemTwo.name is mutable
 
 ## ❌ Avoid Implicitly Unwrapped Optionals for viewDidLoad Properties
 
-**Do not use implicitly unwrapped optionals (`!`) for properties initialized in `viewDidLoad`.** Use lazy properties, optional types with safe unwrapping, or initialize in the initializer.
+**Do not use implicitly unwrapped optionals (`!`) for properties initialized in
+`viewDidLoad`.** Use lazy properties, optional types with safe unwrapping, or
+initialize in the initializer.
 
-**Use `lazy var` only when** you need to defer creation to avoid work at init time, or when the initializer requires `self`.
+**Use `lazy var` only when** you need to defer creation to avoid work at init
+time, or when the initializer requires `self`.
 
 ```swift
 // ❌ WRONG - crash risk if accessed before viewDidLoad
@@ -263,7 +285,8 @@ lazy var tableView = UITableView()
 
 ## ✅ Use `withTaskCancellationHandler` When Bridging Callbacks to Async
 
-**When wrapping callback-based APIs with `withCheckedContinuation`, use `withTaskCancellationHandler` to propagate cancellation properly.**
+**When wrapping callback-based APIs with `withCheckedContinuation`, use
+`withTaskCancellationHandler` to propagate cancellation properly.**
 
 ```swift
 // ✅ CORRECT - cancellation-aware bridging
@@ -286,7 +309,9 @@ func fetchData() async throws -> Data {
 
 ## ✅ Always Call Completion Handlers on All Code Paths
 
-**When a function accepts a completion handler, always call it on every code path — including error and early-return paths.** Failing to call the completion handler leaks resources and may leave callers waiting indefinitely.
+**When a function accepts a completion handler, always call it on every code
+path — including error and early-return paths.** Failing to call the completion
+handler leaks resources and may leave callers waiting indefinitely.
 
 ```swift
 // ❌ WRONG - completion handler not called on error path
@@ -311,7 +336,9 @@ func fetchData(from url: URL, _ completionHandler: @escaping () -> Void) {
 
 ## ✅ Use `evaluateSafeJavaScript` Instead of Raw JS Evaluation
 
-**Use the `evaluateSafeJavaScript` wrapper instead of calling `callAsyncJavaScript` or `evaluateJavaScript` directly.** The wrapper provides proper error handling and security checks.
+**Use the `evaluateSafeJavaScript` wrapper instead of calling
+`callAsyncJavaScript` or `evaluateJavaScript` directly.** The wrapper provides
+proper error handling and security checks.
 
 ---
 
@@ -319,7 +346,9 @@ func fetchData(from url: URL, _ completionHandler: @escaping () -> Void) {
 
 ## ✅ Model Error States as Swift `Error` Types
 
-**Use Swift `Error` enums/structs for error representation, not integer error codes.** This provides type safety, exhaustive switch handling, and better debugging.
+**Use Swift `Error` enums/structs for error representation, not integer error
+codes.** This provides type safety, exhaustive switch handling, and better
+debugging.
 
 ```swift
 // ❌ WRONG - integer error codes
@@ -341,7 +370,8 @@ enum FetchError: Error {
 
 ## ✅ Delegate Methods Should Take Non-Optional Parameters
 
-**Delegate method parameters should be non-optional.** The delegate should not need to handle nil values from the delegating object.
+**Delegate method parameters should be non-optional.** The delegate should not
+need to handle nil values from the delegating object.
 
 ---
 
@@ -349,7 +379,9 @@ enum FetchError: Error {
 
 ## ✅ Use `_ = variable` to Silence "Wrote But Not Read" Warnings
 
-**When a variable is intentionally unused (e.g., the result of a side-effecting function), assign it to `_` explicitly.** This signals intent to future readers and silences compiler warnings.
+**When a variable is intentionally unused (e.g., the result of a side-effecting
+function), assign it to `_` explicitly.** This signals intent to future readers
+and silences compiler warnings.
 
 ---
 
@@ -357,7 +389,8 @@ enum FetchError: Error {
 
 ## ✅ Use `.clipShape` Instead of Deprecated `.cornerRadius()`
 
-**Use `.clipShape(.rect(cornerRadius:))` instead of the deprecated `.cornerRadius()` modifier.**
+**Use `.clipShape(.rect(cornerRadius:))` instead of the deprecated
+`.cornerRadius()` modifier.**
 
 ```swift
 // ❌ WRONG - deprecated modifier
@@ -375,7 +408,8 @@ Text("Hello")
 
 ## ✅ Use `.background(_:in:)` With Shape Parameter
 
-**Use the `.background(_:in:)` modifier with a shape parameter instead of layering `.background()` with `.clipShape()`.**
+**Use the `.background(_:in:)` modifier with a shape parameter instead of
+layering `.background()` with `.clipShape()`.**
 
 ```swift
 // ❌ WRONG - separate background and clip
@@ -394,7 +428,8 @@ Text("Hello")
 
 ## ✅ Use Stack Spacing Instead of Individual Padding
 
-**Use the `spacing` parameter on `VStack`/`HStack` instead of adding padding to each child element.** This is cleaner and more maintainable.
+**Use the `spacing` parameter on `VStack`/`HStack` instead of adding padding to
+each child element.** This is cleaner and more maintainable.
 
 ```swift
 // ❌ WRONG - padding on each child
@@ -420,7 +455,9 @@ VStack(spacing: 8) {
 
 ## ✅ Extract Inline SwiftUI Blocks Into Named Views
 
-**When an inline SwiftUI view builder block exceeds a few lines, extract it into a named `View` struct or computed property.** This improves readability and enables reuse.
+**When an inline SwiftUI view builder block exceeds a few lines, extract it into
+a named `View` struct or computed property.** This improves readability and
+enables reuse.
 
 ---
 
@@ -428,7 +465,9 @@ VStack(spacing: 8) {
 
 ## ✅ Use `UIHostingConfiguration` for SwiftUI in UITableViewCell
 
-**When using SwiftUI views inside `UITableViewCell` or `UICollectionViewCell`, use `UIHostingConfiguration` instead of manually embedding a `UIHostingController`.**
+**When using SwiftUI views inside `UITableViewCell` or `UICollectionViewCell`,
+use `UIHostingConfiguration` instead of manually embedding a
+`UIHostingController`.**
 
 ```swift
 // ✅ CORRECT - modern cell configuration
@@ -443,7 +482,9 @@ cell.contentConfiguration = UIHostingConfiguration {
 
 ## ❌ Never Modify Constraints in `layoutSubviews`
 
-**Do not create or modify Auto Layout constraints inside `layoutSubviews`.** This causes infinite layout loops. Use `updateViewConstraints` or set constraints once during setup.
+**Do not create or modify Auto Layout constraints inside `layoutSubviews`.**
+This causes infinite layout loops. Use `updateViewConstraints` or set
+constraints once during setup.
 
 ```swift
 // ❌ WRONG - constraints in layoutSubviews (infinite loop risk)
@@ -465,7 +506,9 @@ override func updateViewConstraints() {
 
 ## ✅ Use `setNeedsUpdateConstraints()` for Constraint Changes
 
-**When constraints need to change, call `setNeedsUpdateConstraints()`, not `setNeedsLayout()` + `layoutIfNeeded()`.** The constraint system handles layout invalidation.
+**When constraints need to change, call `setNeedsUpdateConstraints()`, not
+`setNeedsLayout()` + `layoutIfNeeded()`.** The constraint system handles layout
+invalidation.
 
 ---
 
@@ -473,7 +516,8 @@ override func updateViewConstraints() {
 
 ## ✅ Use `UIView.keyboardLayoutGuide` Instead of Manual Keyboard Height
 
-**Use `UIView.keyboardLayoutGuide` for keyboard-responsive layouts instead of manually observing keyboard notifications and adjusting insets.**
+**Use `UIView.keyboardLayoutGuide` for keyboard-responsive layouts instead of
+manually observing keyboard notifications and adjusting insets.**
 
 ```swift
 // ❌ WRONG - manual keyboard observation
@@ -492,9 +536,16 @@ bottomConstraint = view.bottomAnchor.constraint(
 
 ## ✅ Use Brave Design System Colors
 
-**Use `UIColor(braveSystemName:)` for colors, not hard-coded values or system colors.** This ensures consistency with the Brave design system and proper dark mode support.
+**Use `UIColor(braveSystemName:)` for colors, not hard-coded values or system
+colors.** This ensures consistency with the Brave design system and proper dark
+mode support.
 
-**Avoid deprecated legacy colors** such as `UIColor.braveBlurpleTint` / `Color(.braveBlurpleTint)` from [LegacyColors.swift](https://github.com/brave/brave-core/blob/00785ba10b5dea2f7ac4e1d66dafe0ddd6d1c0af/ios/brave-ios/Sources/DesignSystem/Colors/LegacyColors.swift). The only legacy colors still acceptable in the short-term are the "grouped" backgrounds: `braveGroupedBackground`, `secondaryBraveGroupedBackground`, `tertiaryBraveGroupedBackground`.
+**Avoid deprecated legacy colors** such as `UIColor.braveBlurpleTint` /
+`Color(.braveBlurpleTint)` from
+[LegacyColors.swift](https://github.com/brave/brave-core/blob/00785ba10b5dea2f7ac4e1d66dafe0ddd6d1c0af/ios/brave-ios/Sources/DesignSystem/Colors/LegacyColors.swift).
+The only legacy colors still acceptable in the short-term are the "grouped"
+backgrounds: `braveGroupedBackground`, `secondaryBraveGroupedBackground`,
+`tertiaryBraveGroupedBackground`.
 
 ```swift
 // ❌ WRONG - hard-coded color
@@ -513,7 +564,9 @@ view.backgroundColor = UIColor(braveSystemName: .primary20)
 
 ## ✅ Keep Tab Observer and Policy Decider Thin
 
-**Do not add feature-specific business logic directly in `BVC+TabObserver.swift` or `BVC+TabPolicyDecider.swift`.** These files should only contain thin delegation. Feature-specific logic belongs in `Tab` helpers.
+**Do not add feature-specific business logic directly in `BVC+TabObserver.swift`
+or `BVC+TabPolicyDecider.swift`.** These files should only contain thin
+delegation. Feature-specific logic belongs in `Tab` helpers.
 
 ---
 
@@ -521,7 +574,8 @@ view.backgroundColor = UIColor(braveSystemName: .primary20)
 
 ## ✅ Set Properties Before Dependent Setup in `viewDidLoad`
 
-**In `viewDidLoad`, set properties before calling setup methods that depend on them.** Ordering bugs here are common and hard to debug.
+**In `viewDidLoad`, set properties before calling setup methods that depend on
+them.** Ordering bugs here are common and hard to debug.
 
 ```swift
 // ❌ WRONG - setup uses property before it's set
@@ -545,7 +599,9 @@ override func viewDidLoad() {
 
 ## ✅ Wrap ObjC Headers With Nullability Annotations
 
-**All Objective-C headers should use `NS_ASSUME_NONNULL_BEGIN`/`NS_ASSUME_NONNULL_END` and explicitly annotate nullable parameters.**
+**All Objective-C headers should use
+`NS_ASSUME_NONNULL_BEGIN`/`NS_ASSUME_NONNULL_END` and explicitly annotate
+nullable parameters.**
 
 ```objc
 // ✅ CORRECT
@@ -564,7 +620,9 @@ NS_ASSUME_NONNULL_END
 
 ## ✅ Mark Static-Only ObjC Classes With `NS_UNAVAILABLE` Init
 
-**For Objective-C classes that should not be instantiated (only class methods), mark `init` as `NS_UNAVAILABLE`.** Marking `new` is not necessary since most Objective-C usage is from Swift, which does not call `new`.
+**For Objective-C classes that should not be instantiated (only class methods),
+mark `init` as `NS_UNAVAILABLE`.** Marking `new` is not necessary since most
+Objective-C usage is from Swift, which does not call `new`.
 
 ```objc
 @interface BraveUtils : NSObject
@@ -579,7 +637,8 @@ NS_ASSUME_NONNULL_END
 
 ## ✅ `OBJC_EXPORT` Goes on Headers Only
 
-**`OBJC_EXPORT` should only appear on the header declaration, not the implementation.**
+**`OBJC_EXPORT` should only appear on the header declaration, not the
+implementation.**
 
 ---
 
@@ -587,7 +646,9 @@ NS_ASSUME_NONNULL_END
 
 ## ✅ Use `NS_SWIFT_NAME` to Control Swift Method Naming
 
-**Use `NS_SWIFT_NAME` on Objective-C APIs to provide idiomatic Swift names.** This is especially important for factory methods and methods with C-style naming.
+**Use `NS_SWIFT_NAME` on Objective-C APIs to provide idiomatic Swift names.**
+This is especially important for factory methods and methods with C-style
+naming.
 
 ---
 
@@ -595,7 +656,8 @@ NS_ASSUME_NONNULL_END
 
 ## ✅ Use `isEqualToString:` for NSString Comparison
 
-**Never use `==` or `!=` for `NSString` comparison — use `isEqualToString:`.** The `==` operator compares pointer identity, not string contents.
+**Never use `==` or `!=` for `NSString` comparison — use `isEqualToString:`.**
+The `==` operator compares pointer identity, not string contents.
 
 ```objc
 // ❌ WRONG - pointer comparison
@@ -611,7 +673,9 @@ if ([string isEqualToString:@"expected"]) { ... }
 
 ## ✅ Use camelCase for Obj-C Variable Names Inside Obj-C Classes/Types
 
-**Objective-C variable naming must use camelCase inside Obj-C classes and types.** When Obj-C types are used inside C++ classes, follow C++ snake_case conventions instead.
+**Objective-C variable naming must use camelCase inside Obj-C classes and
+types.** When Obj-C types are used inside C++ classes, follow C++ snake_case
+conventions instead.
 
 ---
 
@@ -619,7 +683,8 @@ if ([string isEqualToString:@"expected"]) { ... }
 
 ## ✅ Weak/Strong Dance in Posted Tasks
 
-**When posting tasks from Objective-C++ that capture `self`, pass `weakSelf` as a closure parameter rather than capturing it directly.**
+**When posting tasks from Objective-C++ that capture `self`, pass `weakSelf` as
+a closure parameter rather than capturing it directly.**
 
 ```objc
 // ❌ WRONG - capturing weakSelf directly in block
@@ -643,7 +708,9 @@ dispatch_async(queue, ^{
 
 ## ✅ Ensure ObjC Collection Mutability Correctness
 
-**Use `copy` for immutable and `mutableCopy` for mutable collections.** Passing a mutable collection where an immutable one is expected (or vice versa) leads to subtle bugs.
+**Use `copy` for immutable and `mutableCopy` for mutable collections.** Passing
+a mutable collection where an immutable one is expected (or vice versa) leads to
+subtle bugs.
 
 ---
 
@@ -651,7 +718,8 @@ dispatch_async(queue, ^{
 
 ## ❌ No Singletons — Use Dependency Injection
 
-**Do not use singletons for service access.** Pass dependencies through initializers, method parameters, or the `Tab`/`TabHelper` extension pattern.
+**Do not use singletons for service access.** Pass dependencies through
+initializers, method parameters, or the `Tab`/`TabHelper` extension pattern.
 
 ```swift
 // ❌ WRONG - singleton access
@@ -670,7 +738,9 @@ init(rewardsController: BraveRewardsViewController) {
 
 ## ✅ Tab Helpers Must Use `TabDataValues` Extension Pattern
 
-**Tab-associated data should use the `TabDataValues` extension pattern, not stored properties or associated objects.** This ensures proper lifecycle management.
+**Tab-associated data should use the `TabDataValues` extension pattern, not
+stored properties or associated objects.** This ensures proper lifecycle
+management.
 
 ---
 
@@ -678,7 +748,9 @@ init(rewardsController: BraveRewardsViewController) {
 
 ## ❌ Do Not Add Feature Data to `TabState`
 
-**Do not add feature-related data directly to `TabState`.** Instead, use a Tab Helper with `TabDataValues` to store feature-specific state. `TabState` should remain a minimal model representing core tab state.
+**Do not add feature-related data directly to `TabState`.** Instead, use a Tab
+Helper with `TabDataValues` to store feature-specific state. `TabState` should
+remain a minimal model representing core tab state.
 
 ---
 
@@ -686,7 +758,8 @@ init(rewardsController: BraveRewardsViewController) {
 
 ## ❌ View Model Types Must Not Import SDK Singletons
 
-**View models must not import or reference SDK singletons directly.** Pass SDK dependencies through the initializer for testability.
+**View models must not import or reference SDK singletons directly.** Pass SDK
+dependencies through the initializer for testability.
 
 ---
 
@@ -694,7 +767,8 @@ init(rewardsController: BraveRewardsViewController) {
 
 ## ✅ Bind ProfileIOS Directly, Avoid `getLastUsedProfile`
 
-**Pass `ProfileIOS` explicitly into closures and initializers.** Do not call `getLastUsedProfile` at point of use — the last-used profile can change.
+**Pass `ProfileIOS` explicitly into closures and initializers.** Do not call
+`getLastUsedProfile` at point of use — the last-used profile can change.
 
 ---
 
@@ -702,7 +776,9 @@ init(rewardsController: BraveRewardsViewController) {
 
 ## ✅ Feature Flag Checks Gate Registration, Not Runtime
 
-**Feature flag checks should gate handler/observer registration, not runtime checks inside the handler.** This avoids unnecessary overhead when the feature is disabled.
+**Feature flag checks should gate handler/observer registration, not runtime
+checks inside the handler.** This avoids unnecessary overhead when the feature
+is disabled.
 
 ```swift
 // ❌ WRONG - checking flag at runtime inside handler
@@ -723,7 +799,8 @@ if FeatureFlags.isEnabled(.myFeature) {
 
 ## ❌ Feature-Specific Logic Does Not Belong in Generic Extensions
 
-**Do not add feature-specific logic to generic utility extensions.** Create feature-specific helpers instead.
+**Do not add feature-specific logic to generic utility extensions.** Create
+feature-specific helpers instead.
 
 ---
 
@@ -731,7 +808,8 @@ if FeatureFlags.isEnabled(.myFeature) {
 
 ## ✅ Register Prefs in `browser_prefs.mm` on iOS
 
-**iOS preference registration goes in `browser_prefs.mm`, not in arbitrary init methods.**
+**iOS preference registration goes in `browser_prefs.mm`, not in arbitrary init
+methods.**
 
 ---
 
@@ -739,7 +817,8 @@ if FeatureFlags.isEnabled(.myFeature) {
 
 ## ✅ Use `P3A.installationDate`, Not `DAU.installationDate`
 
-**`Preferences.DAU.installationDate` resets after 14 days. Use `Preferences.P3A.installationDate` for persistent installation dates.**
+**`Preferences.DAU.installationDate` resets after 14 days. Use
+`Preferences.P3A.installationDate` for persistent installation dates.**
 
 ---
 
@@ -747,7 +826,9 @@ if FeatureFlags.isEnabled(.myFeature) {
 
 ## ✅ Wire Complete Observer/Bridge Chains
 
-**When connecting C++ observers to Objective-C/Swift code, ensure the entire chain is wired: C++ observer → bridge object → Obj-C/Swift delegate.** Missing links in the chain are a common source of silent failures.
+**When connecting C++ observers to Objective-C/Swift code, ensure the entire
+chain is wired: C++ observer → bridge object → Obj-C/Swift delegate.** Missing
+links in the chain are a common source of silent failures.
 
 ---
 
@@ -755,7 +836,8 @@ if FeatureFlags.isEnabled(.myFeature) {
 
 ## ✅ Use `raw_ptr<T>` for Stored Pointers in C++ Classes
 
-**When a C++ class stores a pointer to another object, use `raw_ptr<T>` instead of raw `T*`.** This enables Chromium's pointer safety checks.
+**When a C++ class stores a pointer to another object, use `raw_ptr<T>` instead
+of raw `T*`.** This enables Chromium's pointer safety checks.
 
 ---
 
@@ -763,7 +845,9 @@ if FeatureFlags.isEnabled(.myFeature) {
 
 ## ✅ Use `NOTIMPLEMENTED()` for Potentially Reachable Code
 
-**`NOTREACHED()` crashes in release builds. Use `NOTIMPLEMENTED()` for code paths that may be reached but are not yet implemented.** Only use `NOTREACHED()` when the code path should truly never execute.
+**`NOTREACHED()` crashes in release builds. Use `NOTIMPLEMENTED()` for code
+paths that may be reached but are not yet implemented.** Only use `NOTREACHED()`
+when the code path should truly never execute.
 
 ---
 
@@ -771,7 +855,8 @@ if FeatureFlags.isEnabled(.myFeature) {
 
 ## ✅ Use Mojo `::Name_` Constants for Interface Registration
 
-**When registering Mojo interfaces, use the `::Name_` constant from the generated interface, not hard-coded strings.**
+**When registering Mojo interfaces, use the `::Name_` constant from the
+generated interface, not hard-coded strings.**
 
 ---
 
@@ -779,7 +864,8 @@ if FeatureFlags.isEnabled(.myFeature) {
 
 ## ❌ Do Not Rely on iOS Caches Directory for Persistent State
 
-**The iOS caches directory can be cleared by the system at any time.** Do not store state that must survive app restarts in the caches directory.
+**The iOS caches directory can be cleared by the system at any time.** Do not
+store state that must survive app restarts in the caches directory.
 
 ---
 
@@ -787,7 +873,8 @@ if FeatureFlags.isEnabled(.myFeature) {
 
 ## ✅ New Strings Go in `BraveStrings`, Not `SharedStrings.swift`
 
-**Add new user-facing strings to `BraveStrings`, not `SharedStrings.swift`.** SharedStrings is for legacy/shared strings only.
+**Add new user-facing strings to `BraveStrings`, not `SharedStrings.swift`.**
+SharedStrings is for legacy/shared strings only.
 
 ---
 
@@ -795,7 +882,9 @@ if FeatureFlags.isEnabled(.myFeature) {
 
 ## ❌ Do Not Add New Functionality to the Legacy `Shared` Module
 
-**The `Shared` module is legacy — do not add new functionality to it.** If you need a shared module for new code, create a new module instead. Existing `Shared` code can still be used but should not be extended.
+**The `Shared` module is legacy — do not add new functionality to it.** If you
+need a shared module for new code, create a new module instead. Existing
+`Shared` code can still be used but should not be extended.
 
 ---
 
@@ -803,7 +892,8 @@ if FeatureFlags.isEnabled(.myFeature) {
 
 ## ✅ Tests Mirror Source Modules
 
-**Test files should be organized to mirror the source module structure.** A class in `BraveCore/Wallet/` should have tests in `BraveCoreTests/Wallet/`.
+**Test files should be organized to mirror the source module structure.** A
+class in `BraveCore/Wallet/` should have tests in `BraveCoreTests/Wallet/`.
 
 ---
 
@@ -811,7 +901,9 @@ if FeatureFlags.isEnabled(.myFeature) {
 
 ## ✅ Export Pref Constants in Feature-Specific Headers
 
-**iOS pref constants should be exported in feature-specific headers, not in a shared `pref_names_bridge.h`.** This reduces coupling and makes dependencies explicit.
+**iOS pref constants should be exported in feature-specific headers, not in a
+shared `pref_names_bridge.h`.** This reduces coupling and makes dependencies
+explicit.
 
 ---
 
@@ -819,7 +911,9 @@ if FeatureFlags.isEnabled(.myFeature) {
 
 ## ✅ Mojom Wrappers Go in `ios/common`, Not `ios/browser`
 
-**Mojom wrapper types belong in `ios/common/` because they are shared between browser and renderer processes.** Placing them in `ios/browser/` creates unnecessary layering constraints.
+**Mojom wrapper types belong in `ios/common/` because they are shared between
+browser and renderer processes.** Placing them in `ios/browser/` creates
+unnecessary layering constraints.
 
 ---
 
@@ -827,7 +921,9 @@ if FeatureFlags.isEnabled(.myFeature) {
 
 ## ✅ Use `_bridge.h` for ObjC Wrappers, `_ios.h` for iOS Implementations
 
-**Use the `_bridge.h` suffix for plain Objective-C wrapper headers that expose C++ types to Swift.** Use `_ios.h` for iOS-specific implementations of cross-platform interfaces.
+**Use the `_bridge.h` suffix for plain Objective-C wrapper headers that expose
+C++ types to Swift.** Use `_ios.h` for iOS-specific implementations of
+cross-platform interfaces.
 
 ---
 
@@ -835,7 +931,9 @@ if FeatureFlags.isEnabled(.myFeature) {
 
 ## ✅ Use `Impl` Suffix for Concrete Implementations
 
-**Name concrete implementations with the `Impl` suffix, not a platform suffix like `_ios`.** For example: `BraveWalletServiceImpl`, not `BraveWalletServiceIOS`.
+**Name concrete implementations with the `Impl` suffix, not a platform suffix
+like `_ios`.** For example: `BraveWalletServiceImpl`, not
+`BraveWalletServiceIOS`.
 
 ---
 
@@ -843,7 +941,8 @@ if FeatureFlags.isEnabled(.myFeature) {
 
 ## ✅ Remove Dead Code and Debug Statements
 
-**Remove all debug `print` statements and dead code before submitting.** Use `Logger` instead of `print` for any logging that should remain.
+**Remove all debug `print` statements and dead code before submitting.** Use
+`Logger` instead of `print` for any logging that should remain.
 
 ---
 
@@ -851,7 +950,9 @@ if FeatureFlags.isEnabled(.myFeature) {
 
 ## ✅ Preserve Accessibility Labels
 
-**Always set accessibility labels on interactive elements.** VoiceOver users depend on these. When refactoring UI, verify that accessibility labels are preserved.
+**Always set accessibility labels on interactive elements.** VoiceOver users
+depend on these. When refactoring UI, verify that accessibility labels are
+preserved.
 
 ---
 
@@ -859,7 +960,9 @@ if FeatureFlags.isEnabled(.myFeature) {
 
 ## ✅ Use `UIImage.prepareThumbnail(of:)` for Thumbnailing
 
-**Use `UIImage.prepareThumbnail(of:)` for generating thumbnails instead of manual `UIGraphicsImageRenderer` resizing.** The system method is optimized for memory and performance.
+**Use `UIImage.prepareThumbnail(of:)` for generating thumbnails instead of
+manual `UIGraphicsImageRenderer` resizing.** The system method is optimized for
+memory and performance.
 
 ---
 
@@ -867,7 +970,8 @@ if FeatureFlags.isEnabled(.myFeature) {
 
 ## ✅ Prefer CSS `@media (prefers-color-scheme)` Over JS Class Toggling
 
-**For injected web content, use CSS `@media (prefers-color-scheme: dark)` for dark mode support instead of toggling CSS classes via JavaScript.**
+**For injected web content, use CSS `@media (prefers-color-scheme: dark)` for
+dark mode support instead of toggling CSS classes via JavaScript.**
 
 ---
 
@@ -875,7 +979,9 @@ if FeatureFlags.isEnabled(.myFeature) {
 
 ## ✅ Use `@_disfavoredOverload` + `@available(iOS, obsoleted:)` for Backporting
 
-**When backporting newer APIs, use `@_disfavoredOverload` combined with `@available(iOS, obsoleted:)` to create transparent fallbacks that automatically disappear when the deployment target is raised.**
+**When backporting newer APIs, use `@_disfavoredOverload` combined with
+`@available(iOS, obsoleted:)` to create transparent fallbacks that automatically
+disappear when the deployment target is raised.**
 
 ```swift
 // Backport API available in iOS 17+
@@ -895,7 +1001,9 @@ extension View {
 
 ## ✅ Artificial Delays Require Comments
 
-**Any use of `Task.sleep` or similar artificial delays must include a comment explaining why the delay is necessary.** Unexplained delays are a code smell and may hide race conditions.
+**Any use of `Task.sleep` or similar artificial delays must include a comment
+explaining why the delay is necessary.** Unexplained delays are a code smell and
+may hide race conditions.
 
 ```swift
 // ❌ WRONG - unexplained delay
@@ -913,7 +1021,8 @@ try await Task.sleep(nanoseconds: 500_000_000)
 
 ## ✅ Use `TimestampFormatStyle` for Duration Formatting
 
-**Use `TimestampFormatStyle` or `Duration.formatted()` for displaying durations instead of manual string formatting.**
+**Use `TimestampFormatStyle` or `Duration.formatted()` for displaying durations
+instead of manual string formatting.**
 
 ---
 
@@ -921,7 +1030,9 @@ try await Task.sleep(nanoseconds: 500_000_000)
 
 ## ✅ Prefer Local Variables for Short-Lived Cancellables
 
-**For Combine subscriptions that are only needed temporarily (e.g., waiting for a single value), use a local variable instead of storing the cancellable as a property.** This prevents accumulation of dead subscriptions.
+**For Combine subscriptions that are only needed temporarily (e.g., waiting for
+a single value), use a local variable instead of storing the cancellable as a
+property.** This prevents accumulation of dead subscriptions.
 
 ---
 
@@ -929,7 +1040,9 @@ try await Task.sleep(nanoseconds: 500_000_000)
 
 ## ✅ Check Delegate Before `withCheckedContinuation`
 
-**When using `withCheckedContinuation` that depends on a delegate callback, verify the delegate is set before entering the continuation.** Otherwise the continuation may never resume, hanging the task indefinitely.
+**When using `withCheckedContinuation` that depends on a delegate callback,
+verify the delegate is set before entering the continuation.** Otherwise the
+continuation may never resume, hanging the task indefinitely.
 
 ---
 
@@ -937,7 +1050,9 @@ try await Task.sleep(nanoseconds: 500_000_000)
 
 ## ✅ Match Button Shapes to Nala Design System
 
-**Buttons should use rounded rectangle shapes consistent with the Nala design system.** Do not use fully rounded (capsule) or sharp-cornered buttons unless the design specifically calls for it.
+**Buttons should use rounded rectangle shapes consistent with the Nala design
+system.** Do not use fully rounded (capsule) or sharp-cornered buttons unless
+the design specifically calls for it.
 
 ---
 
@@ -945,7 +1060,9 @@ try await Task.sleep(nanoseconds: 500_000_000)
 
 ## ✅ chromium_src iOS Overrides: Prefer Subclassing
 
-**When overriding iOS Chromium classes via chromium_src, prefer subclassing over code duplication.** Use the `#define`/`#include`/`#undef` pattern to substitute Brave subclasses.
+**When overriding iOS Chromium classes via chromium_src, prefer subclassing over
+code duplication.** Use the `#define`/`#include`/`#undef` pattern to substitute
+Brave subclasses.
 
 ```cpp
 // chromium_src/ios/chrome/browser/some_file.mm
@@ -956,7 +1073,8 @@ try await Task.sleep(nanoseconds: 500_000_000)
 #undef ChromeViewController
 ```
 
-**Always add blank lines around the `#define`/`#undef`-wrapped includes for readability.**
+**Always add blank lines around the `#define`/`#undef`-wrapped includes for
+readability.**
 
 ---
 
@@ -964,7 +1082,8 @@ try await Task.sleep(nanoseconds: 500_000_000)
 
 ## ✅ Use GN Build Args for Platform-Specific Feature Defaults
 
-**Use GN build arguments (not C++ source code) to set platform-specific feature defaults.** This allows build-time configuration and reduces `#ifdef` clutter.
+**Use GN build arguments (not C++ source code) to set platform-specific feature
+defaults.** This allows build-time configuration and reduces `#ifdef` clutter.
 
 ---
 
@@ -972,7 +1091,8 @@ try await Task.sleep(nanoseconds: 500_000_000)
 
 ## ✅ Include All iOS Test Targets in `brave_all_unit_tests`
 
-**Every new iOS test target must be included in `brave_all_unit_tests`.** Tests that are not included will never run on CI.
+**Every new iOS test target must be included in `brave_all_unit_tests`.** Tests
+that are not included will never run on CI.
 
 ---
 
@@ -980,7 +1100,9 @@ try await Task.sleep(nanoseconds: 500_000_000)
 
 ## ✅ Feature Flag Names Must Match C++ Feature Names
 
-**In iOS bridge headers, feature flag names must exactly match the C++ `base::Feature` names.** Mismatches cause silent failures where the flag appears to work but doesn't actually control the feature.
+**In iOS bridge headers, feature flag names must exactly match the C++
+`base::Feature` names.** Mismatches cause silent failures where the flag appears
+to work but doesn't actually control the feature.
 
 ---
 
@@ -988,7 +1110,9 @@ try await Task.sleep(nanoseconds: 500_000_000)
 
 ## ✅ Use `contentMode: .fill` or Size Constraints for Images
 
-**Set explicit `contentMode` or size constraints on `UIImageView` and SwiftUI `Image` views.** Without these, images may display at their natural size, causing layout issues.
+**Set explicit `contentMode` or size constraints on `UIImageView` and SwiftUI
+`Image` views.** Without these, images may display at their natural size,
+causing layout issues.
 
 ```swift
 // SwiftUI
@@ -1006,7 +1130,8 @@ imageView.contentMode = .scaleAspectFill
 
 ## ✅ Use `Label` for Icon-Only Buttons in SwiftUI
 
-**Always use `Label` with `.labelStyle(.iconOnly)` for icon-only buttons.** This ensures accessibility information is provided automatically.
+**Always use `Label` with `.labelStyle(.iconOnly)` for icon-only buttons.** This
+ensures accessibility information is provided automatically.
 
 ```swift
 // ❌ WRONG - no accessibility label
@@ -1031,7 +1156,9 @@ Button {
 
 ## ✅ Use Nala Design System Icons Over Apple's System Icons
 
-**Use `Image(braveSystemName:)` with Nala (Leo) icons instead of Apple's `Image(systemName:)`.** Nala icons ensure visual consistency with the Brave design system.
+**Use `Image(braveSystemName:)` with Nala (Leo) icons instead of Apple's
+`Image(systemName:)`.** Nala icons ensure visual consistency with the Brave
+design system.
 
 ```swift
 // ❌ WRONG - Apple system icon
@@ -1047,7 +1174,8 @@ Image(braveSystemName: "leo.trash")
 
 ## ✅ Size Nala Icons Using Fonts, Not Frame
 
-**Nala icons are custom SF Symbols and should be treated like font glyphs, not images.** Size them with `.font()`, not `.resizable().frame()`.
+**Nala icons are custom SF Symbols and should be treated like font glyphs, not
+images.** Size them with `.font()`, not `.resizable().frame()`.
 
 ```swift
 // ❌ WRONG - treating icon like an image
@@ -1066,7 +1194,9 @@ Image(braveSystemName: "leo.trash")
 
 ## ❌ Do Not Use Explicit Font Sizes
 
-**UI must adhere to the user's dynamic font sizing preferences.** Use semantic font styles (`.subheadline`, `.body`, etc.). If a custom value must be used, use `@ScaledMetric` in SwiftUI or `UIFontMetrics` in UIKit.
+**UI must adhere to the user's dynamic font sizing preferences.** Use semantic
+font styles (`.subheadline`, `.body`, etc.). If a custom value must be used, use
+`@ScaledMetric` in SwiftUI or `UIFontMetrics` in UIKit.
 
 ```swift
 // ❌ WRONG - fixed font size ignores user preferences
@@ -1089,7 +1219,9 @@ Text("Hello World")
 
 ## ❌ Do Not Initialize SwiftUI `@State` on `init`
 
-**Do not assign `@State` properties in `init` using `State(wrappedValue:)`.** This can cause undefined behavior on future body computations. Pass in the initial value and assign it using an `onAppear` or `task` modifier.
+**Do not assign `@State` properties in `init` using `State(wrappedValue:)`.**
+This can cause undefined behavior on future body computations. Pass in the
+initial value and assign it using an `onAppear` or `task` modifier.
 
 ```swift
 // ❌ WRONG - assigning @State in init

--- a/docs/best-practices/localization.md
+++ b/docs/best-practices/localization.md
@@ -1,12 +1,16 @@
 # Localization & String Resources
 
-Technical conventions for GRD/GRDP string resources, placeholders, and i18n patterns. For voice, capitalization, punctuation, product naming, and general writing style, see the [Brave Style Guide](./style-guide.md).
+Technical conventions for GRD/GRDP string resources, placeholders, and i18n
+patterns. For voice, capitalization, punctuation, product naming, and general
+writing style, see the [Brave Style Guide](./style-guide.md).
 
 <a id="L10N-001"></a>
 
 ## ❌ Don't Add `translateable="true"` on GRD Strings
 
-**In `.grdp` string resource files, `translateable="true"` is the default.** Never add it explicitly. The tooling only looks for `translateable="false"` when excluding strings from translation.
+**In `.grdp` string resource files, `translateable="true"` is the default.**
+Never add it explicitly. The tooling only looks for `translateable="false"` when
+excluding strings from translation.
 
 ---
 
@@ -14,7 +18,9 @@ Technical conventions for GRD/GRDP string resources, placeholders, and i18n patt
 
 ## ✅ Use Proper Ellipsis Characters in UI Strings
 
-**In user-facing strings, use the proper Unicode ellipsis character (`…`) instead of three periods (`...`).** This is a standard typographic convention for UI text.
+**In user-facing strings, use the proper Unicode ellipsis character (`…`)
+instead of three periods (`...`).** This is a standard typographic convention
+for UI text.
 
 ---
 
@@ -22,16 +28,29 @@ Technical conventions for GRD/GRDP string resources, placeholders, and i18n patt
 
 ## ✅ Provide Sufficient Context in Localization String Descriptions
 
-**Localization string descriptions should contain enough context for translators who only see the description.** For example, "History" alone might be ambiguous across languages (browser history vs. event history). Add specifics like "Title for the browser visits history section of a URL picker".
+**Localization string descriptions should contain enough context for translators
+who only see the description.** For example, "History" alone might be ambiguous
+across languages (browser history vs. event history). Add specifics like "Title
+for the browser visits history section of a URL picker".
 
-For simple, self-evident strings where the meaning is unambiguous in any language (e.g., "Summary", "Settings", "Cancel"), a brief description is fine — do not insist on verbose descriptions when the string speaks for itself.
+For simple, self-evident strings where the meaning is unambiguous in any
+language (e.g., "Summary", "Settings", "Cancel"), a brief description is fine —
+do not insist on verbose descriptions when the string speaks for itself.
 
 Additional requirements for `desc` attributes:
-- **Never leave `desc` empty** — every `<message>` element must have a non-empty description.
-- **Specify the UI element type** — include whether the string is a title, button label, description, tooltip, placeholder, menu item, etc. (e.g., `desc="Title for the about section"` not `desc="About section text"`).
-- **Disambiguate terms with multiple meanings** — words like "History" (browser vs. conversation), "Wallet" (crypto vs. payment), "Send" (where?) need qualification.
-- **Each description must be unique** — do not copy-paste the same `desc` across different strings that serve different purposes.
-- **Proofread descriptions** — typos in `desc` confuse translators and affect translation quality.
+
+- **Never leave `desc` empty** — every `<message>` element must have a non-empty
+  description.
+- **Specify the UI element type** — include whether the string is a title,
+  button label, description, tooltip, placeholder, menu item, etc. (e.g.,
+  `desc="Title for the about section"` not `desc="About section text"`).
+- **Disambiguate terms with multiple meanings** — words like "History" (browser
+  vs. conversation), "Wallet" (crypto vs. payment), "Send" (where?) need
+  qualification.
+- **Each description must be unique** — do not copy-paste the same `desc` across
+  different strings that serve different purposes.
+- **Proofread descriptions** — typos in `desc` confuse translators and affect
+  translation quality.
 
 ---
 
@@ -39,7 +58,9 @@ Additional requirements for `desc` attributes:
 
 ## ✅ Use `I18nMixinLit` for Localization in Lit Components
 
-**In Lit-based WebUI components, use `I18nMixinLit` instead of calling `loadTimeData.getString()` directly.** The mixin provides consistent i18n patterns and is the standard approach.
+**In Lit-based WebUI components, use `I18nMixinLit` instead of calling
+`loadTimeData.getString()` directly.** The mixin provides consistent i18n
+patterns and is the standard approach.
 
 ---
 
@@ -47,11 +68,19 @@ Additional requirements for `desc` attributes:
 
 ## ❌ Never Modify Upstream GRD/GRDP Files Directly
 
-**Never add or modify strings in upstream Chromium GRD/GRDP files** (e.g., `app/generated_resources.grd`, `app/settings_strings.grdp`, `components/browser_ui/strings/android/browser_ui_strings.grd`). These files are auto-replaced during every Chromium version bump, so any changes will be lost on the next rebase.
+**Never add or modify strings in upstream Chromium GRD/GRDP files** (e.g.,
+`app/generated_resources.grd`, `app/settings_strings.grdp`,
+`components/browser_ui/strings/android/browser_ui_strings.grd`). These files are
+auto-replaced during every Chromium version bump, so any changes will be lost on
+the next rebase.
 
 To customize an upstream string:
-1. Add a new string in the corresponding Brave GRD/GRDP file (e.g., `app/brave_generated_resources.grd`, `app/brave_settings_strings.grdp`, `browser/ui/android/strings/android_brave_strings.grd`).
-2. Create a `chromium_src` override that `#undef`s the upstream `IDS_` constant and `#define`s it to your Brave-specific `IDS_` constant.
+
+1. Add a new string in the corresponding Brave GRD/GRDP file (e.g.,
+   `app/brave_generated_resources.grd`, `app/brave_settings_strings.grdp`,
+   `browser/ui/android/strings/android_brave_strings.grd`).
+2. Create a `chromium_src` override that `#undef`s the upstream `IDS_` constant
+   and `#define`s it to your Brave-specific `IDS_` constant.
 
 ```cpp
 // chromium_src/chrome/browser/ui/webui/password_manager/password_manager_ui.cc
@@ -66,7 +95,11 @@ To customize an upstream string:
 
 ## ✅ Use `grd_string_replacements.py` for Simple Upstream Text Substitutions
 
-**For simple word/phrase substitutions across upstream strings in all locales, use `brave/script/lib/l10n/grd_string_replacements.py`** with `default_replacements` and run `npm run chromium_rebase_l10n`. This applies the replacement consistently across all localized versions without needing to manually edit GRD files or create chromium_src overrides.
+**For simple word/phrase substitutions across upstream strings in all locales,
+use `brave/script/lib/l10n/grd_string_replacements.py`** with
+`default_replacements` and run `npm run chromium_rebase_l10n`. This applies the
+replacement consistently across all localized versions without needing to
+manually edit GRD files or create chromium_src overrides.
 
 ---
 
@@ -74,7 +107,10 @@ To customize an upstream string:
 
 ## ✅ Include `formatter_data="webui=X"` Matching the WebUI Component
 
-**When adding strings to a WebUI GRDP file, include the `formatter_data="webui=ComponentName"` attribute.** The value must exactly match the WebUI component identifier so the build system generates the correct string constants for the right bundle.
+**When adding strings to a WebUI GRDP file, include the
+`formatter_data="webui=ComponentName"` attribute.** The value must exactly match
+the WebUI component identifier so the build system generates the correct string
+constants for the right bundle.
 
 ```xml
 <!-- ✅ CORRECT - matches the AI Chat WebUI component -->
@@ -92,7 +128,9 @@ To customize an upstream string:
 
 ## ✅ Use SCREAMING_SNAKE_CASE Placeholder Names with Example Tags
 
-**Placeholders in GRD/GRDP strings must have descriptive `name` attributes in SCREAMING_SNAKE_CASE and include `<ex>` example tags** showing translators what value will appear at runtime.
+**Placeholders in GRD/GRDP strings must have descriptive `name` attributes in
+SCREAMING_SNAKE_CASE and include `<ex>` example tags** showing translators what
+value will appear at runtime.
 
 ```xml
 <!-- ✅ CORRECT - descriptive name and example -->
@@ -118,7 +156,10 @@ To customize an upstream string:
 
 ## ✅ Capitalization Consistency Across Feature Strings
 
-**All strings within a single feature or UI surface must use a consistent capitalization style.** Do not mix title case ("Background Image") and sentence case ("Brave backgrounds") within the same group of UI controls at the same hierarchy level.
+**All strings within a single feature or UI surface must use a consistent
+capitalization style.** Do not mix title case ("Background Image") and sentence
+case ("Brave backgrounds") within the same group of UI controls at the same
+hierarchy level.
 
 - **Title case** for: page titles, section headers, button labels, menu items
 - **Sentence case** for: descriptions, body text, tooltips, helper text
@@ -131,12 +172,19 @@ To customize an upstream string:
 
 **Follow these conventions for user-facing string text:**
 
-- **Use "Brave's" instead of "our"** — e.g., "access Brave's premium products" not "access our premium products"
-- **Use "and more" instead of "etc."** — e.g., "bookmarks, passwords, and more" not "bookmarks, passwords, etc."
-- **Match established feature terminology** — e.g., Shields uses "up/down" not "on/off" (`"with Shields up"` not `"with Shields on"`). Check existing strings for a feature's vocabulary before adding new ones.
-- **Use natural word order around placeholders** — test by substituting an example value and reading the sentence aloud
-- **Avoid possessive constructions** — prefer "the content of this page" over "this page's contents" for better translatability
-- **Be explicit about data-sharing actions** — "send your tabs to Brave AI" not just "send your tabs" (where?)
+- **Use "Brave's" instead of "our"** — e.g., "access Brave's premium products"
+  not "access our premium products"
+- **Use "and more" instead of "etc."** — e.g., "bookmarks, passwords, and more"
+  not "bookmarks, passwords, etc."
+- **Match established feature terminology** — e.g., Shields uses "up/down" not
+  "on/off" (`"with Shields up"` not `"with Shields on"`). Check existing strings
+  for a feature's vocabulary before adding new ones.
+- **Use natural word order around placeholders** — test by substituting an
+  example value and reading the sentence aloud
+- **Avoid possessive constructions** — prefer "the content of this page" over
+  "this page's contents" for better translatability
+- **Be explicit about data-sharing actions** — "send your tabs to Brave AI" not
+  just "send your tabs" (where?)
 
 ---
 
@@ -144,7 +192,11 @@ To customize an upstream string:
 
 ## ❌ Never Add Unused Strings to GRD/GRDP Files
 
-**Only add strings to GRD/GRDP files when they are actively referenced in the codebase.** Every string in a GRD/GRDP file gets sent to translators and translated into all supported languages, which costs time and money. If a string is no longer used after a refactor, remove it. When reviewing string additions, verify the `IDS_` constant is actually used in the code.
+**Only add strings to GRD/GRDP files when they are actively referenced in the
+codebase.** Every string in a GRD/GRDP file gets sent to translators and
+translated into all supported languages, which costs time and money. If a string
+is no longer used after a refactor, remove it. When reviewing string additions,
+verify the `IDS_` constant is actually used in the code.
 
 ---
 
@@ -152,9 +204,13 @@ To customize an upstream string:
 
 ## ✅ Replace Upstream Product Names with Brave Equivalents During Rebases
 
-**During Chromium rebases, review all new strings in upstream GRD/GRDP files for Google product references** (Gemini, Google Pay, Chrome, etc.) that need to be replaced with Brave equivalents. New user-facing strings introduced by rebases should be reviewed to ensure they show correct Brave branding.
+**During Chromium rebases, review all new strings in upstream GRD/GRDP files for
+Google product references** (Gemini, Google Pay, Chrome, etc.) that need to be
+replaced with Brave equivalents. New user-facing strings introduced by rebases
+should be reviewed to ensure they show correct Brave branding.
 
-Also verify correct product name usage: "Brave Wallet" refers specifically to the cryptocurrency wallet, not general autofill/payment card features.
+Also verify correct product name usage: "Brave Wallet" refers specifically to
+the cryptocurrency wallet, not general autofill/payment card features.
 
 ---
 
@@ -162,7 +218,9 @@ Also verify correct product name usage: "Brave Wallet" refers specifically to th
 
 ## ❌ Avoid Dynamic String Key Construction in `getLocale()`
 
-**Never dynamically construct string keys for `getLocale()` calls.** This makes static analysis impossible, prevents dead string detection, and breaks if key formats change.
+**Never dynamically construct string keys for `getLocale()` calls.** This makes
+static analysis impossible, prevents dead string detection, and breaks if key
+formats change.
 
 ```tsx
 // ❌ WRONG - dynamic key construction
@@ -172,7 +230,7 @@ getLocale(`CHAT_UI_${model.key.toUpperCase().replaceAll('-', '_')}_SUBTITLE`)
 getLocale(S.CHAT_UI_CLAUDE_SUBTITLE)
 
 // ✅ ALSO CORRECT - data source provides the string or key
-model.description  // provided by server API / mojom struct
+model.description // provided by server API / mojom struct
 ```
 
 ---
@@ -181,7 +239,9 @@ model.description  // provided by server API / mojom struct
 
 ## ✅ Build Links in UI, Not in Localized Strings
 
-**When a localized string needs a clickable link, build the link element in the UI (TypeScript/HTML) and pass the URL separately** via `AddString` or a mojom constant. Do not embed URLs into localized strings via C++ string formatting.
+**When a localized string needs a clickable link, build the link element in the
+UI (TypeScript/HTML) and pass the URL separately** via `AddString` or a mojom
+constant. Do not embed URLs into localized strings via C++ string formatting.
 
 ```cpp
 // ❌ WRONG - URL embedded in localized string
@@ -212,13 +272,17 @@ html_source->AddString("learnMoreUrl", kLearnMoreURL);
 
 ## ✅ String Text Must Be Complete and Grammatically Correct
 
-**User-facing strings must be complete sentences (not truncated), grammatically correct, and use proper punctuation.** String reviewers verify:
+**User-facing strings must be complete sentences (not truncated), grammatically
+correct, and use proper punctuation.** String reviewers verify:
 
 - Sentences are not cut off mid-thought
-- Compound adjectives are hyphenated (e.g., "non-compatible" not "non compatible")
-- Prepositions are appropriate for context (e.g., "in" vs. "on" for UI locations)
+- Compound adjectives are hyphenated (e.g., "non-compatible" not "non
+  compatible")
+- Prepositions are appropriate for context (e.g., "in" vs. "on" for UI
+  locations)
 
-This matters because translators use the English source as a reference, and errors propagate to translations.
+This matters because translators use the English source as a reference, and
+errors propagate to translations.
 
 ---
 
@@ -226,8 +290,14 @@ This matters because translators use the English source as a reference, and erro
 
 ## ✅ Include UI Screenshots When Adding or Modifying Strings
 
-**When a PR adds or modifies user-facing strings, the developer must include a screenshot of the affected UI in the PR description.** This allows string reviewers to verify the string in context — checking for truncation, capitalization consistency, layout issues, and correct terminology. Screenshots should show the actual rendered UI, not just the GRD/GRDP diff.
+**When a PR adds or modifies user-facing strings, the developer must include a
+screenshot of the affected UI in the PR description.** This allows string
+reviewers to verify the string in context — checking for truncation,
+capitalization consistency, layout issues, and correct terminology. Screenshots
+should show the actual rendered UI, not just the GRD/GRDP diff.
 
-Do not add screenshots as inline code comments. Add them to the PR description body.
+Do not add screenshots as inline code comments. Add them to the PR description
+body.
 
-See also: [Brave Style Guide](./style-guide.md) for voice, capitalization, punctuation, and product naming rules that apply to all user-facing strings.
+See also: [Brave Style Guide](./style-guide.md) for voice, capitalization,
+punctuation, and product naming rules that apply to all user-facing strings.

--- a/docs/best-practices/nala.md
+++ b/docs/best-practices/nala.md
@@ -1,20 +1,22 @@
 # Nala / Leo Design System Best Practices
 
-<a id="NA-001"></a>
-<a id="NA-003"></a>
-<a id="NA-004"></a>
+<a id="NA-001"></a> <a id="NA-003"></a> <a id="NA-004"></a>
 
 ## ❌ Don't Add Custom Icons — Use Leo/Nala Icons
 
-**Always use the Leo/Nala icon system instead of adding new icon files.** Leo is the canonical icon source across all platforms. Bypassing it leads to inconsistency, duplicates, and maintenance burden.
+**Always use the Leo/Nala icon system instead of adding new icon files.** Leo is
+the canonical icon source across all platforms. Bypassing it leads to
+inconsistency, duplicates, and maintenance burden.
 
-> **Reviewer note:** Tag `@brave/nala-token-reviewers` when flagging this violation.
+> **Reviewer note:** Tag `@brave/nala-token-reviewers` when flagging this
+> violation.
 
 <a id="NA-009"></a>
 
 ### Android
 
-Add icons to `android/nala/icons.gni` instead of creating new drawable resources.
+Add icons to `android/nala/icons.gni` instead of creating new drawable
+resources.
 
 ```gn
 # ❌ WRONG - adding a new drawable file directly
@@ -33,11 +35,12 @@ nala_icons = [
 
 ### WebUI
 
-Add the icon name to the `leo_icons` array in `ui/webui/resources/BUILD.gn` instead of adding a new `.svg` file.
+Add the icon name to the `leo_icons` array in `ui/webui/resources/BUILD.gn`
+instead of adding a new `.svg` file.
 
 ```html
 <!-- ❌ WRONG - raw SVG file added to the WebUI directory -->
-<img src="my_icon.svg">
+<img src="my_icon.svg" />
 
 <!-- ✅ CORRECT - Leo icon component (icon added to leo_icons in ui/webui/resources/BUILD.gn) -->
 <leo-icon name="my-icon-name"></leo-icon>
@@ -47,7 +50,8 @@ Add the icon name to the `leo_icons` array in `ui/webui/resources/BUILD.gn` inst
 
 ### C++ browser UI
 
-Add to the `leo_icons` array in `components/vector_icons/BUILD.gn` instead of creating a new `.icon` file.
+Add to the `leo_icons` array in `components/vector_icons/BUILD.gn` instead of
+creating a new `.icon` file.
 
 ```gn
 # ❌ WRONG - new standalone vector icon file
@@ -67,9 +71,13 @@ leo_icons = [
 
 ## ❌ Don't Add New Android Color Tokens — Use Existing Nala Color Tokens
 
-**When adding color values on Android, use existing Nala/Leo color tokens instead of defining new color resources.** New color definitions in `res/values/colors.xml` or similar files bypass the design system and create inconsistency across themes and platforms.
+**When adding color values on Android, use existing Nala/Leo color tokens
+instead of defining new color resources.** New color definitions in
+`res/values/colors.xml` or similar files bypass the design system and create
+inconsistency across themes and platforms.
 
-> **Reviewer note:** Tag `@brave/nala-token-reviewers` when flagging this violation.
+> **Reviewer note:** Tag `@brave/nala-token-reviewers` when flagging this
+> violation.
 
 ```xml
 <!-- ❌ WRONG - defining a new color resource -->
@@ -82,92 +90,122 @@ leo_icons = [
 
 ---
 
-<a id="NA-005"></a>
-<a id="NA-006"></a>
+<a id="NA-005"></a> <a id="NA-006"></a>
 
 ## ❌ Don't Use HTML Elements or Custom Components When Leo Provides Them
 
-**In WebUI React code, use Leo components from `@brave/leo/react/*` instead of native HTML elements or custom re-implementations.** Leo components are design-system-approved, theme-aware, and accessible. Using raw HTML or hand-rolling equivalents produces visual inconsistency, bypasses Brave's design tokens, and requires manual accessibility work.
+**In WebUI React code, use Leo components from `@brave/leo/react/*` instead of
+native HTML elements or custom re-implementations.** Leo components are
+design-system-approved, theme-aware, and accessible. Using raw HTML or
+hand-rolling equivalents produces visual inconsistency, bypasses Brave's design
+tokens, and requires manual accessibility work.
 
-> **Reviewer note:** Tag `@brave/nala-token-reviewers` when flagging this violation.
+> **Reviewer note:** Tag `@brave/nala-token-reviewers` when flagging this
+> violation.
 
 <a id="NA-007"></a>
 
 ### Use Leo instead of native HTML elements
 
-| Instead of… | Use… |
-|---|---|
-| `<select>` | `Dropdown` from `@brave/leo/react/dropdown` |
-| `<button>` | `Button` from `@brave/leo/react/button` |
-| `<input type="text">` | `Input` from `@brave/leo/react/input` |
-| `<input type="checkbox">` | `Checkbox` from `@brave/leo/react/checkbox` |
-| `<input type="radio">` | `RadioButton` from `@brave/leo/react/radioButton` |
-| Toggle/switch UI | `Toggle` from `@brave/leo/react/toggle` |
-| `<dialog>` / modal | `Dialog` from `@brave/leo/react/dialog` |
+| Instead of…               | Use…                                              |
+| ------------------------- | ------------------------------------------------- |
+| `<select>`                | `Dropdown` from `@brave/leo/react/dropdown`       |
+| `<button>`                | `Button` from `@brave/leo/react/button`           |
+| `<input type="text">`     | `Input` from `@brave/leo/react/input`             |
+| `<input type="checkbox">` | `Checkbox` from `@brave/leo/react/checkbox`       |
+| `<input type="radio">`    | `RadioButton` from `@brave/leo/react/radioButton` |
+| Toggle/switch UI          | `Toggle` from `@brave/leo/react/toggle`           |
+| `<dialog>` / modal        | `Dialog` from `@brave/leo/react/dialog`           |
 
 ```tsx
 // ❌ WRONG - native HTML select
-<select value={value} onChange={e => setValue(e.target.value)}>
-  <option value="a">Option A</option>
-  <option value="b">Option B</option>
+;<select
+  value={value}
+  onChange={(e) => setValue(e.target.value)}
+>
+  <option value='a'>Option A</option>
+  <option value='b'>Option B</option>
 </select>
 
 // ✅ CORRECT - Leo Dropdown
 import Dropdown from '@brave/leo/react/dropdown'
-
-<Dropdown value={value} onChange={e => setValue(e.detail.value)}>
-  <leo-option value="a">Option A</leo-option>
-  <leo-option value="b">Option B</leo-option>
+;<Dropdown
+  value={value}
+  onChange={(e) => setValue(e.detail.value)}
+>
+  <leo-option value='a'>Option A</leo-option>
+  <leo-option value='b'>Option B</leo-option>
 </Dropdown>
 ```
 
 ```tsx
 // ❌ WRONG - native HTML button
-<button onClick={handleClick} disabled={isLoading}>Submit</button>
+;<button
+  onClick={handleClick}
+  disabled={isLoading}
+>
+  Submit
+</button>
 
 // ✅ CORRECT - Leo Button
 import Button from '@brave/leo/react/button'
-
-<Button onClick={handleClick} isDisabled={isLoading}>Submit</Button>
+;<Button
+  onClick={handleClick}
+  isDisabled={isLoading}
+>
+  Submit
+</Button>
 ```
 
 ```tsx
 // ❌ WRONG - native HTML input
-<input type="text" value={value} onChange={e => setValue(e.target.value)} />
+;<input
+  type='text'
+  value={value}
+  onChange={(e) => setValue(e.target.value)}
+/>
 
 // ✅ CORRECT - Leo Input
 import Input from '@brave/leo/react/input'
-
-<Input value={value} onInput={e => setValue(e.detail.value)} />
+;<Input
+  value={value}
+  onInput={(e) => setValue(e.detail.value)}
+/>
 ```
 
 <a id="NA-008"></a>
 
 ### Don't reinvent components that Leo already provides
 
-Before creating a custom React component, check whether Leo already provides it. Custom re-implementations add maintenance burden and are often less accessible than the Leo originals.
+Before creating a custom React component, check whether Leo already provides it.
+Custom re-implementations add maintenance burden and are often less accessible
+than the Leo originals.
 
-| Don't build a custom… | Use… |
-|---|---|
-| Button with a dropdown menu | `ButtonMenu` from `@brave/leo/react/buttonMenu` |
-| Tooltip / hover popover | `Tooltip` from `@brave/leo/react/tooltip` |
-| Segmented control / tab switcher | `SegmentedControl` + `SegmentedControlItem` from `@brave/leo/react/segmentedControl` / `@brave/leo/react/segmentedControlItem` |
-| Loading spinner / activity indicator | `ProgressRing` from `@brave/leo/react/progressRing` |
-| Dropdown/context menu | `Menu` from `@brave/leo/react/menu` |
-| Modal / overlay dialog | `Dialog` from `@brave/leo/react/dialog` |
-| Toast / notification banner | `Alert` from `@brave/leo/react/alert` |
-| Collapsible / accordion | `Collapse` from `@brave/leo/react/collapse` |
+| Don't build a custom…                | Use…                                                                                                                           |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------ |
+| Button with a dropdown menu          | `ButtonMenu` from `@brave/leo/react/buttonMenu`                                                                                |
+| Tooltip / hover popover              | `Tooltip` from `@brave/leo/react/tooltip`                                                                                      |
+| Segmented control / tab switcher     | `SegmentedControl` + `SegmentedControlItem` from `@brave/leo/react/segmentedControl` / `@brave/leo/react/segmentedControlItem` |
+| Loading spinner / activity indicator | `ProgressRing` from `@brave/leo/react/progressRing`                                                                            |
+| Dropdown/context menu                | `Menu` from `@brave/leo/react/menu`                                                                                            |
+| Modal / overlay dialog               | `Dialog` from `@brave/leo/react/dialog`                                                                                        |
+| Toast / notification banner          | `Alert` from `@brave/leo/react/alert`                                                                                          |
+| Collapsible / accordion              | `Collapse` from `@brave/leo/react/collapse`                                                                                    |
 
 ```tsx
 // ❌ WRONG - hand-rolled loading spinner
 function Spinner() {
-  return <div className="spinner" aria-label="Loading..." />
+  return (
+    <div
+      className='spinner'
+      aria-label='Loading...'
+    />
+  )
 }
 
 // ✅ CORRECT - Leo ProgressRing
 import ProgressRing from '@brave/leo/react/progressRing'
-
-<ProgressRing />
+;<ProgressRing />
 ```
 
 ```tsx
@@ -175,17 +213,19 @@ import ProgressRing from '@brave/leo/react/progressRing'
 function MyTooltip({ text, children }) {
   const [visible, setVisible] = React.useState(false)
   return (
-    <div onMouseEnter={() => setVisible(true)} onMouseLeave={() => setVisible(false)}>
+    <div
+      onMouseEnter={() => setVisible(true)}
+      onMouseLeave={() => setVisible(false)}
+    >
       {children}
-      {visible && <div className="tooltip">{text}</div>}
+      {visible && <div className='tooltip'>{text}</div>}
     </div>
   )
 }
 
 // ✅ CORRECT - Leo Tooltip
 import Tooltip from '@brave/leo/react/tooltip'
-
-<Tooltip text="Helpful hint">
+;<Tooltip text='Helpful hint'>
   <Button>Hover me</Button>
 </Tooltip>
 ```
@@ -194,8 +234,8 @@ import Tooltip from '@brave/leo/react/tooltip'
 // ❌ WRONG - bespoke segmented control
 function MySegmentedControl({ options, value, onChange }) {
   return (
-    <div className="segmented-control">
-      {options.map(opt => (
+    <div className='segmented-control'>
+      {options.map((opt) => (
         <button
           key={opt.value}
           className={value === opt.value ? 'active' : ''}
@@ -211,10 +251,12 @@ function MySegmentedControl({ options, value, onChange }) {
 // ✅ CORRECT - Leo SegmentedControl
 import SegmentedControl from '@brave/leo/react/segmentedControl'
 import SegmentedControlItem from '@brave/leo/react/segmentedControlItem'
-
-<SegmentedControl value={value} onChange={e => onChange(e.detail.value)}>
-  <SegmentedControlItem value="a">Option A</SegmentedControlItem>
-  <SegmentedControlItem value="b">Option B</SegmentedControlItem>
+;<SegmentedControl
+  value={value}
+  onChange={(e) => onChange(e.detail.value)}
+>
+  <SegmentedControlItem value='a'>Option A</SegmentedControlItem>
+  <SegmentedControlItem value='b'>Option B</SegmentedControlItem>
 </SegmentedControl>
 ```
 
@@ -224,7 +266,10 @@ import SegmentedControlItem from '@brave/leo/react/segmentedControlItem'
 
 ## ❌ Don't Create Intermediate Color Tokens — Use Nala Tokens Directly
 
-**When referencing Nala/Leo color tokens in C++ color mixers, use the Nala token directly at the call site instead of creating an intermediate `kColor*` token that just maps to it.** Extra indirection obscures the actual token being used and adds maintenance burden when the design system changes.
+**When referencing Nala/Leo color tokens in C++ color mixers, use the Nala token
+directly at the call site instead of creating an intermediate `kColor*` token
+that just maps to it.** Extra indirection obscures the actual token being used
+and adds maintenance burden when the design system changes.
 
 ```cpp
 // ❌ WRONG - unnecessary intermediate token

--- a/docs/best-practices/patches.md
+++ b/docs/best-practices/patches.md
@@ -1,12 +1,14 @@
 # Patches
 
-<a id="PATCH-001"></a>
-<a id="PATCH-002"></a>
-<a id="PATCH-003"></a>
+<a id="PATCH-001"></a> <a id="PATCH-002"></a> <a id="PATCH-003"></a>
 
 ## ❌ Patches Must Contain Only Functional Changes
 
-**Patches should contain only the minimal functional changes needed.** Never add comments, empty lines, whitespace changes, or any other non-functional modifications. Leave whitespace intact to minimize diff size. Unnecessary changes make patches harder to review and more likely to conflict during Chromium upgrades.
+**Patches should contain only the minimal functional changes needed.** Never add
+comments, empty lines, whitespace changes, or any other non-functional
+modifications. Leave whitespace intact to minimize diff size. Unnecessary
+changes make patches harder to review and more likely to conflict during
+Chromium upgrades.
 
 ---
 
@@ -14,7 +16,8 @@
 
 ## ❌ No Multiline Patches - Use Defines
 
-**Never create multiline patches. Use `#define` macros or chromium_src overrides instead.**
+**Never create multiline patches. Use `#define` macros or chromium_src overrides
+instead.**
 
 ---
 
@@ -22,7 +25,9 @@
 
 ## ✅ Use `include` for Extensible Patches
 
-**When a patch adds to a list or block, use an `include` directive to make the patch extensible.** This way additional items can be added in brave-core without modifying the patch.
+**When a patch adds to a list or block, use an `include` directive to make the
+patch extensible.** This way additional items can be added in brave-core without
+modifying the patch.
 
 ---
 
@@ -30,7 +35,8 @@
 
 ## ✅ Patches Should Use `define` for Extensibility
 
-**Patches should use `#define` macros to be extensible.** This allows adding behavior in brave-core without changing the patch.
+**Patches should use `#define` macros to be extensible.** This allows adding
+behavior in brave-core without changing the patch.
 
 ```cpp
 // ❌ WRONG - patching inline code directly
@@ -49,10 +55,14 @@ Convention for define names: `BRAVE_ALL_CAPS_ORIGINAL_METHOD_NAME`.
 
 ## Patch Style Guidelines
 
-- **Keep patches to one line** even if it violates lint character line limits (lint doesn't run on patched files)
-- **In XML patches, use HTML comments** (`<!-- -->`) instead of deleting lines to reduce the diff
-- **Minimize line modifications** - put additions on separate lines to avoid modifying existing lines
-- **Match existing code exactly** when possible so patches auto-resolve during updates
+- **Keep patches to one line** even if it violates lint character line limits
+  (lint doesn't run on patched files)
+- **In XML patches, use HTML comments** (`<!-- -->`) instead of deleting lines
+  to reduce the diff
+- **Minimize line modifications** - put additions on separate lines to avoid
+  modifying existing lines
+- **Match existing code exactly** when possible so patches auto-resolve during
+  updates
 
 ```xml
 <!-- ❌ WRONG - deleting XML elements -->
@@ -74,7 +84,8 @@ Convention for define names: `BRAVE_ALL_CAPS_ORIGINAL_METHOD_NAME`.
 
 ## ✅ Use `-=` for List Removal in Patches
 
-**When removing items from GN lists, use `-=` instead of modifying the original line.** This makes the patch an addition rather than a modification.
+**When removing items from GN lists, use `-=` instead of modifying the original
+line.** This makes the patch an addition rather than a modification.
 
 ```gn
 # ❌ WRONG - modifying the original deps line
@@ -90,7 +101,9 @@ Convention for define names: `BRAVE_ALL_CAPS_ORIGINAL_METHOD_NAME`.
 
 ## ✅ Use `deps +=` with a Variable for Extensible GN Patches
 
-**When a patch adds dependencies to a Chromium BUILD.gn target, define a variable in Brave code and patch only the variable reference.** This allows adding/removing deps without modifying the patch.
+**When a patch adds dependencies to a Chromium BUILD.gn target, define a
+variable in Brave code and patch only the variable reference.** This allows
+adding/removing deps without modifying the patch.
 
 ```gn
 # ❌ WRONG - patching inline deps
@@ -110,6 +123,11 @@ brave_browser_window_deps = [
 
 ## ❌ Don't Patch Python Build Scripts
 
-**Do not add patches to Python build scripts (e.g., `java_cpp_enum.py` or similar build tools).** These patches prevent correct incremental rebuilds and break remote `siso` build actions. Instead, prefer: (1) a `chromium_src` override, (2) a multiline header patch, or (3) a `#define`-based approach. For Java/C++ enums processed by upstream Python scripts, a multiline patch in the header file is acceptable as a pragmatic solution.
+**Do not add patches to Python build scripts (e.g., `java_cpp_enum.py` or
+similar build tools).** These patches prevent correct incremental rebuilds and
+break remote `siso` build actions. Instead, prefer: (1) a `chromium_src`
+override, (2) a multiline header patch, or (3) a `#define`-based approach. For
+Java/C++ enums processed by upstream Python scripts, a multiline patch in the
+header file is acceptable as a pragmatic solution.
 
 ---

--- a/docs/best-practices/plaster.md
+++ b/docs/best-practices/plaster.md
@@ -6,7 +6,10 @@
 
 ## ✅ Plaster Patch Patterns Should Match Specific Context
 
-**Plaster patch config `re_pattern` should generally match method names or other relevant context to ensure a single, targeted match.** Simple patterns can be used when the intention is to match all instances of a particular pattern in a file.
+**Plaster patch config `re_pattern` should generally match method names or other
+relevant context to ensure a single, targeted match.** Simple patterns can be
+used when the intention is to match all instances of a particular pattern in a
+file.
 
 ```yaml
 # ❌ WRONG - overly broad pattern that might match multiple locations
@@ -20,7 +23,9 @@ re_pattern: 'bool IsFeatureEnabled[\(\)\S\s\{\}]+?(return false);\s+^\}'
 re_pattern: 'kOldConstant'
 ```
 
-Matching specific context (method names, surrounding code) makes patches more maintainable and prevents accidental matches during Chromium updates. Use broad patterns only when you explicitly intend to replace all occurrences.
+Matching specific context (method names, surrounding code) makes patches more
+maintainable and prevents accidental matches during Chromium updates. Use broad
+patterns only when you explicitly intend to replace all occurrences.
 
 ---
 
@@ -28,7 +33,9 @@ Matching specific context (method names, surrounding code) makes patches more ma
 
 ## ✅ Use `pattern` for Simple Symbol Replacement, `re_pattern` for Context-Aware Matches
 
-**Only use `pattern` for simple matches—generally a single symbol name that you want to replace globally.** If you need more context (including whitespace), then `re_pattern` is more appropriate.
+**Only use `pattern` for simple matches—generally a single symbol name that you
+want to replace globally.** If you need more context (including whitespace),
+then `re_pattern` is more appropriate.
 
 ```yaml
 # ✅ CORRECT - simple symbol replacement with pattern for all instances of a constant
@@ -56,6 +63,8 @@ pattern: 'if (MyMethod() && my_bool) {'  # Breaks if upstream changes indentatio
 replace: 'if (BraveMethod() && my_bool) {'
 ```
 
-Using `pattern` for simple symbol names keeps configs readable and maintainable. Reserve `re_pattern` for when you need regex features like whitespace matching, character classes, or structural patterns.
+Using `pattern` for simple symbol names keeps configs readable and maintainable.
+Reserve `re_pattern` for when you need regex features like whitespace matching,
+character classes, or structural patterns.
 
 ---

--- a/docs/best-practices/style-guide.md
+++ b/docs/best-practices/style-guide.md
@@ -1,8 +1,11 @@
 # Brave Style Guide
 
-Best practices for all user-facing text in the Brave browser, derived from the Brave Style Guide. These rules apply to UI strings, settings, error messages, tooltips, notifications, and all other surfaces.
+Best practices for all user-facing text in the Brave browser, derived from the
+Brave Style Guide. These rules apply to UI strings, settings, error messages,
+tooltips, notifications, and all other surfaces.
 
-See also: [Localization & String Resources](./localization.md) for GRD/GRDP technical conventions.
+See also: [Localization & String Resources](./localization.md) for GRD/GRDP
+technical conventions.
 
 ---
 
@@ -10,12 +13,15 @@ See also: [Localization & String Resources](./localization.md) for GRD/GRDP tech
 
 ## ✅ Voice: Concise, Descriptive, Simple, Active
 
-**All user-facing text must use active voice, be concise, and aim for simplicity.**
+**All user-facing text must use active voice, be concise, and aim for
+simplicity.**
 
-- Write in active voice, not passive. Tell us who did something, not who it was done by.
+- Write in active voice, not passive. Tell us who did something, not who it was
+  done by.
 - Aim for a fifth-grade reading level in general product UI.
 - Be honest and friendly, but not jokey or whimsical.
-- Avoid jargon unless targeting a technical audience, and define terms at first usage.
+- Avoid jargon unless targeting a technical audience, and define terms at first
+  usage.
 
 ```
 ❌ "Your browsing history has been cleared by the system."
@@ -31,7 +37,8 @@ See also: [Localization & String Resources](./localization.md) for GRD/GRDP tech
 
 ## ✅ Use Contractions in UI Text
 
-**Use contractions where possible.** They're more conversational and save space in UI strings.
+**Use contractions where possible.** They're more conversational and save space
+in UI strings.
 
 ```
 ❌ "You cannot undo this action."
@@ -47,9 +54,11 @@ See also: [Localization & String Resources](./localization.md) for GRD/GRDP tech
 
 ## ❌ Avoid Colloquial Language, Idioms, and Slang
 
-**Do not use colloquial language, idioms, or slang in UI strings.** They can be confusing, offensive, or difficult to translate.
+**Do not use colloquial language, idioms, or slang in UI strings.** They can be
+confusing, offensive, or difficult to translate.
 
-Also avoid overused filler words like "basically," "obviously," "literally," or "frankly."
+Also avoid overused filler words like "basically," "obviously," "literally," or
+"frankly."
 
 ```
 ❌ "This ad looks creepy"
@@ -62,16 +71,19 @@ Also avoid overused filler words like "basically," "obviously," "literally," or 
 
 ## ✅ Use Second-Person Perspective; First-Person for User Actions
 
-**Address readers using second person (you, your). When a user is asked to take an action or give consent, use first person (I, me, my).**
+**Address readers using second person (you, your). When a user is asked to take
+an action or give consent, use first person (I, me, my).**
 
 ```
 ✅ "Log in to your Brave account"
 ✅ "I've read the Brave terms of service"
 ```
 
-Avoid repetition of "your" — e.g., "Log in to your Premium account to manage subscriptions" instead of "...to manage your subscription."
+Avoid repetition of "your" — e.g., "Log in to your Premium account to manage
+subscriptions" instead of "...to manage your subscription."
 
-When discussing legal, security, or data privacy, use "Brave" or "the Brave team" instead of "we" to avoid implying staff can access user data.
+When discussing legal, security, or data privacy, use "Brave" or "the Brave
+team" instead of "we" to avoid implying staff can access user data.
 
 ```
 ✅ "Brave can only access the following search data…"
@@ -84,7 +96,8 @@ When discussing legal, security, or data privacy, use "Brave" or "the Brave team
 
 ## ✅ Keep Sentences Short (15 Words or Fewer)
 
-**Aim for 15 words or fewer per sentence.** Break long sentences into two, or use bullet points. Test by reading aloud.
+**Aim for 15 words or fewer per sentence.** Break long sentences into two, or
+use bullet points. Test by reading aloud.
 
 ```
 ❌ "Are you sure you want to put Shields down for this page? Shields down may reduce your privacy."
@@ -98,9 +111,11 @@ When discussing legal, security, or data privacy, use "Brave" or "the Brave team
 
 ## ✅ Use Simple Present Tense by Default
 
-**Default to simple present tense when there's no negative impact.** Avoid progressive (-ing) and complex verb constructions.
+**Default to simple present tense when there's no negative impact.** Avoid
+progressive (-ing) and complex verb constructions.
 
-Check: if the verb is preceded by was/were, has/have, is/are, or be, or ends in -ing, it's not simple tense.
+Check: if the verb is preceded by was/were, has/have, is/are, or be, or ends in
+-ing, it's not simple tense.
 
 ```
 ❌ "Once you click 'Search default,' you'll see a list of search options"
@@ -116,7 +131,9 @@ Check: if the verb is preceded by was/were, has/have, is/are, or be, or ends in 
 
 ## ✅ Use Gender-Neutral Language
 
-**Rephrase sentences to avoid gendered pronouns. If unavoidable, default to they/their.** Also avoid gender-latent words like "policeman" or "stewardess" — use "police officer" or "flight attendant."
+**Rephrase sentences to avoid gendered pronouns. If unavoidable, default to
+they/their.** Also avoid gender-latent words like "policeman" or "stewardess" —
+use "police officer" or "flight attendant."
 
 ---
 
@@ -124,13 +141,15 @@ Check: if the verb is preceded by was/were, has/have, is/are, or be, or ends in 
 
 ## ✅ Sentence Case by Default; Title Case Only for Product Names
 
-**Default to sentence case in almost all contexts:** headlines, titles, buttons, email subject lines, Mac file system warnings, Windows warnings.
+**Default to sentence case in almost all contexts:** headlines, titles, buttons,
+email subject lines, Mac file system warnings, Windows warnings.
 
 **Never use ALL CAPS.**
 
 Title case is used only for branded product/plan names (see [SG-014](#SG-014)).
 
-Exception: iOS uses title case on UI copy and settings per Apple's platform rules, which override Brave's defaults.
+Exception: iOS uses title case on UI copy and settings per Apple's platform
+rules, which override Brave's defaults.
 
 ---
 
@@ -153,16 +172,27 @@ Exception: iOS uses title case on UI copy and settings per Apple's platform rule
 
 **Follow these punctuation conventions in all user-facing text:**
 
-- **Ampersands (&):** Don't use to replace "and." Exception: "Trackers & ads" is acceptable to highlight their close relationship.
-- **Bullet points:** No periods at end, unless any item has more than one sentence (then all items get periods).
+- **Ampersands (&):** Don't use to replace "and." Exception: "Trackers & ads" is
+  acceptable to highlight their close relationship.
+- **Bullet points:** No periods at end, unless any item has more than one
+  sentence (then all items get periods).
 - **Colons:** Capitalize after a colon only if a complete sentence follows.
-- **Ellipsis:** Use the Unicode character `…` (option-semicolon on Mac), not three periods.
+- **Ellipsis:** Use the Unicode character `…` (option-semicolon on Mac), not
+  three periods.
 - **Em dashes (—):** Use option-shift-hyphen. No spaces before or after.
-- **En dashes (–):** Use for date/time spans replacing "to." E.g., "Monday–Friday."
-- **Exclamation points:** Use sparingly, never more than one per view/post/email/article.
-- **Hyphens:** Hyphenate multi-word adjectives before a noun ("up-to-date browser"), not after ("browser is up to date"). Use hyphens for repeated-letter words ("re-enable"), but prefer writing around the usage.
-- **Periods:** Include at end of body copy and numbered list items. Do not include at end of titles, headings, subheads, bullet points, or buttons. One space after periods.
-- **Quotation marks:** Use double quotes when referring to UI copy in instructions (e.g., Click "Search options"). Commas, exclamation points, and periods go inside quotation marks.
+- **En dashes (–):** Use for date/time spans replacing "to." E.g.,
+  "Monday–Friday."
+- **Exclamation points:** Use sparingly, never more than one per
+  view/post/email/article.
+- **Hyphens:** Hyphenate multi-word adjectives before a noun ("up-to-date
+  browser"), not after ("browser is up to date"). Use hyphens for
+  repeated-letter words ("re-enable"), but prefer writing around the usage.
+- **Periods:** Include at end of body copy and numbered list items. Do not
+  include at end of titles, headings, subheads, bullet points, or buttons. One
+  space after periods.
+- **Quotation marks:** Use double quotes when referring to UI copy in
+  instructions (e.g., Click "Search options"). Commas, exclamation points, and
+  periods go inside quotation marks.
 
 ---
 
@@ -184,22 +214,28 @@ Exception: iOS uses title case on UI copy and settings per Apple's platform rule
 ```
 
 **Buttons:**
+
 - 3 words or fewer, sentence case (never all caps)
 - Lead with a verb describing the action
 - Omit articles (the, a, an)
 
 **Links:**
+
 - Never use "click here" by itself
 - Use "click" for desktop, "tap" for mobile apps
 - Use "Learn more" with context: "Learn more about Brave Rewards"
 
 **Settings toggles:**
+
 - Label the action in the positive: "Show Home button" not "Hide Home button"
 
 **Error messages:**
+
 - Always include what happened AND a solution or way to contact support
 - Never a dead end
-- Avoid: exclamations ("Whoopsie!"), apologies, "please," blame, technical jargon (server, fetch, abort, illegal, cache, invalid), empty promises, new concepts
+- Avoid: exclamations ("Whoopsie!"), apologies, "please," blame, technical
+  jargon (server, fetch, abort, illegal, cache, invalid), empty promises, new
+  concepts
 
 ```
 ✅ "This page failed to load. Try reloading, or setting Shields down."
@@ -207,6 +243,7 @@ Exception: iOS uses title case on UI copy and settings per Apple's platform rule
 ```
 
 **Confirmation modals:**
+
 - **Title:** State the action concisely with a question mark
 - **Body:** State the consequences concisely
 - **Button:** Repeat the action verb
@@ -223,7 +260,8 @@ Button: [Set as default]
 
 ## ✅ Descriptive Links for Accessibility
 
-**Never use "click here" as link text. Instead, describe what happens when clicked.** This is critical for screen reader users.
+**Never use "click here" as link text. Instead, describe what happens when
+clicked.** This is critical for screen reader users.
 
 ```
 ❌ "To unsubscribe from these emails, click here."
@@ -231,8 +269,11 @@ Button: [Set as default]
 ```
 
 Also:
-- Add descriptive text to images and visuals — don't rely solely on images/colors/animations
-- Avoid directional language ("to the right of," "above," "below") — include additional description when unavoidable
+
+- Add descriptive text to images and visuals — don't rely solely on
+  images/colors/animations
+- Avoid directional language ("to the right of," "above," "below") — include
+  additional description when unavoidable
 
 ---
 
@@ -242,17 +283,19 @@ Also:
 
 **Follow these formatting rules for numbers:**
 
-| Range | Marketing body | UI / headlines |
-|-------|---------------|----------------|
-| 0–9 | Spell out ("three") | Digits ("3") |
-| 10–999 | Digits everywhere | Digits everywhere |
-| 1,000+ | Digits with commas | Digits with commas |
+| Range  | Marketing body      | UI / headlines     |
+| ------ | ------------------- | ------------------ |
+| 0–9    | Spell out ("three") | Digits ("3")       |
+| 10–999 | Digits everywhere   | Digits everywhere  |
+| 1,000+ | Digits with commas  | Digits with commas |
 
 - Always spell out numbers that start a sentence
 - Percentages: digits + % with no space (e.g., "50%")
 - Measurement: space between number and unit (e.g., "1 TB", "100 GB")
-- Currency: use symbol for the country (e.g., "$9.99"), specify country outside US (e.g., "HK$9.99")
-- Dates: no ordinal numbers ("June 1" not "June 1st"), no numeric format ("6/1/21")
+- Currency: use symbol for the country (e.g., "$9.99"), specify country outside
+  US (e.g., "HK$9.99")
+- Dates: no ordinal numbers ("June 1" not "June 1st"), no numeric format
+  ("6/1/21")
 - Time: "6:00 am" / "12:15 pm" (lowercase, space before am/pm)
 - Fractions: always spell out "half"; others as x/y without ordinals
 
@@ -282,13 +325,16 @@ Also:
 - Ad-free Brave Search (or "ad-free Brave Search" mid-sentence)
 
 **Rules:**
+
 - "Brave browser" always lowercase "browser" (legacy convention)
 - On first usage or when referring to the branded feature, use the full name
-- For general/informal usage, lowercase is fine: "create a playlist," "check your news feed," "manage your rewards"
+- For general/informal usage, lowercase is fine: "create a playlist," "check
+  your news feed," "manage your rewards"
 - **Exception:** Shields is always capitalized, even in general usage
 - "Brave" is always capitalized except when referring to the URL "brave.com"
 - Never use "Brave" as an adjective (don't say "be brave" or "be Brave")
-- Use "Brave browser" instead of just "Brave" where possible to avoid associating the entire brand with just the browser
+- Use "Brave browser" instead of just "Brave" where possible to avoid
+  associating the entire brand with just the browser
 
 ---
 
@@ -298,20 +344,20 @@ Also:
 
 **Do not use these words/phrases in user-facing text:**
 
-| Don't use | Use instead |
-|-----------|-------------|
-| "Brave ads" / "private ads" (lowercase) | "Brave Ads" or "Brave Private Ads" |
-| "be brave" / "be Brave" | (avoid entirely) |
-| "donate" / "gift" / "give" / "pay" / "send" (for BAT contributions) | "contribute" or "support" |
-| "enable" / "disable" | "turn on" / "turn off" |
-| "watch" / "see" (for content) | "view" |
-| "annually" / "monthly" (for subscriptions) | "per month" / "per year" |
-| "tipping" (for Rewards) | "contributing" / "supporting" |
-| "download" / "save" (for Playlist) | "add" |
-| "e-mail" | "email" |
-| "emojis" (plural) | "emoji" |
-| "click here" | Descriptive link text |
-| "smartphone" | "phone" |
+| Don't use                                                           | Use instead                        |
+| ------------------------------------------------------------------- | ---------------------------------- |
+| "Brave ads" / "private ads" (lowercase)                             | "Brave Ads" or "Brave Private Ads" |
+| "be brave" / "be Brave"                                             | (avoid entirely)                   |
+| "donate" / "gift" / "give" / "pay" / "send" (for BAT contributions) | "contribute" or "support"          |
+| "enable" / "disable"                                                | "turn on" / "turn off"             |
+| "watch" / "see" (for content)                                       | "view"                             |
+| "annually" / "monthly" (for subscriptions)                          | "per month" / "per year"           |
+| "tipping" (for Rewards)                                             | "contributing" / "supporting"      |
+| "download" / "save" (for Playlist)                                  | "add"                              |
+| "e-mail"                                                            | "email"                            |
+| "emojis" (plural)                                                   | "emoji"                            |
+| "click here"                                                        | Descriptive link text              |
+| "smartphone"                                                        | "phone"                            |
 
 ---
 
@@ -319,19 +365,27 @@ Also:
 
 ## ✅ Privacy and Security Terminology
 
-**Privacy and security claims require specific, accurate language. Vague claims create legal and trust risks.**
+**Privacy and security claims require specific, accurate language. Vague claims
+create legal and trust risks.**
 
-- **"Private":** Describe specifically what data is private, how, and who has access.
+- **"Private":** Describe specifically what data is private, how, and who has
+  access.
 - **"Secure":** Describe specifically what has been secured and how.
-- **"Anonymous" / "Anonymity":** Almost never use. Get privacy team review. Reserve for cases where it's practically impossible for any adversary (including Brave) to identify a person.
-- **"Tor":** Never written as "TOR." Don't make privacy/security/anonymity claims about Tor windows without Security/Privacy team approval.
+- **"Anonymous" / "Anonymity":** Almost never use. Get privacy team review.
+  Reserve for cases where it's practically impossible for any adversary
+  (including Brave) to identify a person.
+- **"Tor":** Never written as "TOR." Don't make privacy/security/anonymity
+  claims about Tor windows without Security/Privacy team approval.
 
 **Never use:**
+
 - "Military-grade encryption" / "unbreakable encryption"
-- "Completely private" / "100% anonymous" / "totally secure" / "unhackable" / "hacker-proof"
+- "Completely private" / "100% anonymous" / "totally secure" / "unhackable" /
+  "hacker-proof"
 - Any superlative privacy/security claims
 
 **Preferred terms:**
+
 - "IP dropping server" or "proxy server" instead of "anonymizing server"
 
 ---
@@ -342,12 +396,17 @@ Also:
 
 **Write strings that translate well across languages:**
 
-- **Allow for text expansion** — translated text is often longer than English. Consider how the UI accommodates expanded text.
-- **Put the most important information first** — translations may be truncated. Avoid "Be sure to [verb]…"; just start with "[Verb]…"
-- **Avoid letters in icons** — characters like "Aa" don't translate across scripts (e.g., Arabic).
+- **Allow for text expansion** — translated text is often longer than English.
+  Consider how the UI accommodates expanded text.
+- **Put the most important information first** — translations may be truncated.
+  Avoid "Be sure to [verb]…"; just start with "[Verb]…"
+- **Avoid letters in icons** — characters like "Aa" don't translate across
+  scripts (e.g., Arabic).
 - **Add text labels to icons** — makes icons more translatable and accessible.
-- **Keep text and images separate** — avoid images containing readable text, since text must be translated separately.
-- **Avoid possessive constructions** — "the content of this page" translates better than "this page's contents."
+- **Keep text and images separate** — avoid images containing readable text,
+  since text must be translated separately.
+- **Avoid possessive constructions** — "the content of this page" translates
+  better than "this page's contents."
 
 ---
 
@@ -358,11 +417,13 @@ Also:
 **Follow these rules when referencing BAT:**
 
 - Spell out "Basic Attention Token (BAT)" on first usage, then use "BAT"
-- BAT is a "token" or "crypto asset" — never a "point," "currency," or "cryptocurrency"
+- BAT is a "token" or "crypto asset" — never a "point," "currency," or
+  "cryptocurrency"
 - BAT should not be discussed as having a cash value
 - Never accompany BAT with a currency symbol ($, €)
 - Format BAT balances to three decimal places: "80.000 BAT"
-- A number followed by BAT denotes the amount: "Tip 1 BAT" (Note: in Rewards context, use "contribute" instead of "tip")
+- A number followed by BAT denotes the amount: "Tip 1 BAT" (Note: in Rewards
+  context, use "contribute" instead of "tip")
 
 ---
 
@@ -372,8 +433,12 @@ Also:
 
 **Use the correct terminology when referring to user devices:**
 
-- **Mobile:** Use "phone or tablet" instead of "device" or "mobile device" on first reference. Use actual device names (iPhone, iPad, Android) in subheads. Don't repeat "phone or tablet" more than once per paragraph — switch to "your device."
-- **Desktop:** Use "computer" for non-mobile machines. Avoid "laptop," "PC," or "desktop" as they may exclude users on other form factors.
+- **Mobile:** Use "phone or tablet" instead of "device" or "mobile device" on
+  first reference. Use actual device names (iPhone, iPad, Android) in subheads.
+  Don't repeat "phone or tablet" more than once per paragraph — switch to "your
+  device."
+- **Desktop:** Use "computer" for non-mobile machines. Avoid "laptop," "PC," or
+  "desktop" as they may exclude users on other form factors.
 
 ---
 
@@ -384,29 +449,39 @@ Also:
 **When writing about Brave products, follow these messaging rules:**
 
 **Browser:**
-- Do: mention speed (up to 3x faster than Chrome), Chrome extension support, 60-second import
+
+- Do: mention speed (up to 3x faster than Chrome), Chrome extension support,
+  60-second import
 - Don't: say Brave blocks ALL ads and trackers
 
 **Rewards:**
+
 - Do: say "contributing" / "supporting" / "getting paid"
 - Don't: say "tipping" or "earning money"
 
 **Playlist:**
+
 - Do: say "add" files to a playlist, mention added media is ad-free
 - Don't: say "download" / "save," or claim it works for "any" video/audio
 
 **Search:**
-- Do: mention independent index, anonymous community contributions, Goggles, Discussions
+
+- Do: mention independent index, anonymous community contributions, Goggles,
+  Discussions
 - Don't: (no specific restrictions beyond general accuracy)
 
 **Talk:**
-- Do: free video calls for up to 4 people, no time limit, no tracking, no extension/app/account needed
+
+- Do: free video calls for up to 4 people, no time limit, no tracking, no
+  extension/app/account needed
 - Don't: say "E2E" or "end-to-end" encrypted
 
 **VPN:**
+
 - Do: access content on the go, free for 7 days, available on mobile and desktop
 - Don't: say you can use it to watch streaming sites
 
 **General:**
+
 - Do: position as alternative to "Big Tech" / "ad tech"
 - Don't: call out specific companies like Meta, or encourage activism

--- a/docs/best-practices/testing-async.md
+++ b/docs/best-practices/testing-async.md
@@ -10,9 +10,11 @@
 
 **DO NOT make changes that "fix" the test by altering execution timing.**
 
-These "fixes" may make the problem disappear locally, but the underlying race condition will inevitably return. This is the most common type of fake fix.
+These "fixes" may make the problem disappear locally, but the underlying race
+condition will inevitably return. This is the most common type of fake fix.
 
-**BANNED - Any change that works by altering timing rather than providing proper synchronization:**
+**BANNED - Any change that works by altering timing rather than providing proper
+synchronization:**
 
 ```cpp
 // ❌ WRONG - Adding logging to "fix" a race condition
@@ -41,13 +43,18 @@ ExtractMethodThatChangesWhenThingsRun();  // Same code, different timing
 // it's a fake fix that will eventually break
 ```
 
-**This list is not exhaustive.** The key principle: if your change works by altering when things execute rather than by adding proper synchronization, it's unacceptable.
+**This list is not exhaustive.** The key principle: if your change works by
+altering when things execute rather than by adding proper synchronization, it's
+unacceptable.
 
 **Why these "fixes" are unacceptable:**
+
 1. **They hide the problem, not solve it** - The race condition still exists
-2. **They're compiler/optimization dependent** - May work in debug but fail in release builds
+2. **They're compiler/optimization dependent** - May work in debug but fail in
+   release builds
 3. **They're platform dependent** - May work on your machine but fail in CI
-4. **They'll break again** - As soon as something else changes timing (new code, different CPU, etc.)
+4. **They'll break again** - As soon as something else changes timing (new code,
+   different CPU, etc.)
 
 <a id="TA-003"></a>
 
@@ -56,14 +63,18 @@ ExtractMethodThatChangesWhenThingsRun();  // Same code, different timing
 **REQUIRED approach for all test fixes:**
 
 1. **Identify the actual race condition:**
+
    - What two things are racing?
    - Which happens first? Which should happen first?
    - What's the synchronization mechanism (or lack thereof)?
 
 2. **Find the real synchronization point:**
-   - Use proper wait mechanisms (`base::test::RunUntil()`, `TestFuture`, observers)
+
+   - Use proper wait mechanisms (`base::test::RunUntil()`, `TestFuture`,
+     observers)
    - Wait for the actual condition you care about, not arbitrary time
-   - Use explicit synchronization primitives (callbacks, run loops with quit closures)
+   - Use explicit synchronization primitives (callbacks, run loops with quit
+     closures)
 
 3. **Verify the fix addresses the root cause:**
    - Can you explain WHY the test was flaky?
@@ -98,9 +109,11 @@ class MyObserver : public content::WebContentsObserver {
 
 ### Rule of Thumb
 
-**If removing your "fix" would make the test flaky again, but you can't explain WHY it fixes the race condition, it's not a real fix.**
+**If removing your "fix" would make the test flaky again, but you can't explain
+WHY it fixes the race condition, it's not a real fix.**
 
 Real fixes are:
+
 - Deterministic (work every time)
 - Explainable (you can describe the synchronization mechanism)
 - Robust (work across different timing conditions, platforms, and build types)
@@ -113,12 +126,15 @@ Real fixes are:
 
 **DO NOT use `RunLoop::RunUntilIdle()` for asynchronous testing.**
 
-This is explicitly forbidden by Chromium style guide because it causes flaky tests:
+This is explicitly forbidden by Chromium style guide because it causes flaky
+tests:
+
 - May run too long and timeout
 - May return too early if events depend on different task queues
 - Creates unreliable, non-deterministic tests
 
-**Reference:** [Chromium C++ Testing Best Practices](https://www.chromium.org/chromium-os/developer-library/guides/testing/cpp-writing-tests/)
+**Reference:**
+[Chromium C++ Testing Best Practices](https://www.chromium.org/chromium-os/developer-library/guides/testing/cpp-writing-tests/)
 
 ---
 
@@ -127,6 +143,7 @@ This is explicitly forbidden by Chromium style guide because it causes flaky tes
 ## ✅ Use base::test::RunUntil() for C++ Conditions
 
 **GOOD - When checking C++ state:**
+
 ```cpp
 ASSERT_TRUE(base::test::RunUntil([th]() {
   return speedreader::DistillStates::IsDistilled(th->PageDistillState());
@@ -134,6 +151,7 @@ ASSERT_TRUE(base::test::RunUntil([th]() {
 ```
 
 **GOOD - When checking object properties:**
+
 ```cpp
 ASSERT_TRUE(base::test::RunUntil([this]() {
   return tab_helper()->speedreader_bubble_view() != nullptr;
@@ -146,7 +164,8 @@ ASSERT_TRUE(base::test::RunUntil([this]() {
 
 ## General Rule: Avoid Nested Run Loops
 
-**Any operation that creates its own run loop should NOT be called inside `base::test::RunUntil()`:**
+**Any operation that creates its own run loop should NOT be called inside
+`base::test::RunUntil()`:**
 
 - ❌ `content::EvalJs()` - creates run loop
 - ❌ `content::ExecJs()` - creates run loop
@@ -161,7 +180,10 @@ ASSERT_TRUE(base::test::RunUntil([this]() {
 
 ## ✅ ALWAYS Use `base::test::TestFuture` Over RunLoop for Callbacks
 
-**REQUIRED for callback-based operations.** `TestFuture` is more concise and less error-prone than `RunLoop` patterns. Reviewers actively enforce this — PRs using `RunLoop` + `BindLambdaForTesting` + `Quit()` when `TestFuture` would work will receive review comments requesting changes.
+**REQUIRED for callback-based operations.** `TestFuture` is more concise and
+less error-prone than `RunLoop` patterns. Reviewers actively enforce this — PRs
+using `RunLoop` + `BindLambdaForTesting` + `Quit()` when `TestFuture` would work
+will receive review comments requesting changes.
 
 ```cpp
 // ❌ WRONG - verbose RunLoop + lambda pattern (will be flagged in review)
@@ -181,7 +203,10 @@ service->CheckPurchaseState(future.GetCallback());
 EXPECT_FALSE(future.Get());
 ```
 
-**Always use `TestFuture` when the async operation takes a `base::OnceCallback`.** The only exception is when you need manual run loop control that `TestFuture` cannot provide (e.g., testing timeout behavior or cancellation).
+**Always use `TestFuture` when the async operation takes a
+`base::OnceCallback`.** The only exception is when you need manual run loop
+control that `TestFuture` cannot provide (e.g., testing timeout behavior or
+cancellation).
 
 ---
 
@@ -189,7 +214,10 @@ EXPECT_FALSE(future.Get());
 
 ## ✅ Mojo Message Ordering for Test Synchronization
 
-**Mojo processes messages in order on a given interface.** Making a synchronous mojo call through an interface guarantees that all prior async messages on that same interface have been processed. This is a precise alternative to polling for cross-process test synchronization.
+**Mojo processes messages in order on a given interface.** Making a synchronous
+mojo call through an interface guarantees that all prior async messages on that
+same interface have been processed. This is a precise alternative to polling for
+cross-process test synchronization.
 
 ```cpp
 // ❌ WRONG - polling with arbitrary delay
@@ -210,6 +238,7 @@ EXPECT_EQ(true, content::EvalJs(web_contents,
 ## Alternative: QuitClosure() + Run()
 
 **For manual control when TestFuture doesn't fit:**
+
 ```cpp
 base::RunLoop run_loop;
 object_under_test.DoSomethingAsync(run_loop.QuitClosure());
@@ -222,7 +251,10 @@ run_loop.Run();  // Waits specifically for this closure
 
 ## ✅ Wait for Mojo Completion Before EvalJs Assertions
 
-**In browser tests, do not call `EvalJs` immediately after an async Mojo operation to check its effects.** The mojo message may not have been processed yet. Use polling (`RunUntil` with a C++ state check) or a `TestFuture` to synchronize on the mojo response before asserting via JavaScript.
+**In browser tests, do not call `EvalJs` immediately after an async Mojo
+operation to check its effects.** The mojo message may not have been processed
+yet. Use polling (`RunUntil` with a C++ state check) or a `TestFuture` to
+synchronize on the mojo response before asserting via JavaScript.
 
 ```cpp
 // ❌ WRONG - EvalJs races with pending mojo response

--- a/docs/best-practices/testing-isolation.md
+++ b/docs/best-practices/testing-isolation.md
@@ -5,11 +5,13 @@
 ## Test in Isolation with Fakes
 
 **Prefer fakes over real dependencies:**
+
 - Prevents cascading test failures
 - Produces more maintainable, modular code
 - Makes tests faster and more deterministic
 
 **Example: Use MockTool instead of real navigation tool:**
+
 ```cpp
 // ✅ GOOD - Control exact timing with MockTool
 auto mock_tool = std::make_unique<MockTool>();
@@ -30,17 +32,20 @@ std::move(tool_callback).Run(/* result */);
 ## Test the API, Not Implementation
 
 **Focus on public interfaces:**
+
 - Allows internal implementation changes without breaking tests
 - Provides accurate usage examples for other developers
 - Makes tests more maintainable
 
 **BAD:**
+
 ```cpp
 // ❌ Testing internal implementation details
 EXPECT_EQ(object->private_state_, 42);
 ```
 
 **GOOD:**
+
 ```cpp
 // ✅ Testing public API behavior
 EXPECT_TRUE(object->IsReady());
@@ -56,6 +61,7 @@ EXPECT_EQ(object->GetValue(), 42);
 When testing HTTP headers from pages with subresources, use per-domain maps:
 
 **BAD:**
+
 ```cpp
 // ❌ WRONG - Global expected value, race condition with subresources
 std::string expected_header_;
@@ -70,6 +76,7 @@ void OnRequest(const HttpRequest& request) {
 ```
 
 **GOOD:**
+
 ```cpp
 // ✅ CORRECT - Per-domain expected values
 std::map<std::string, std::string> expected_headers_;
@@ -84,7 +91,8 @@ void OnRequest(const HttpRequest& request) {
 }
 ```
 
-Subresource requests can arrive out-of-order, so per-resource expected values prevent race conditions.
+Subresource requests can arrive out-of-order, so per-resource expected values
+prevent race conditions.
 
 ---
 
@@ -92,9 +100,11 @@ Subresource requests can arrive out-of-order, so per-resource expected values pr
 
 ## Throttle Testing - Use Large Throttle Windows
 
-**Problem:** Throttle timers start when a fetch happens, not when test timing checks begin.
+**Problem:** Throttle timers start when a fetch happens, not when test timing
+checks begin.
 
 **BAD:**
+
 ```cpp
 // ❌ WRONG - 500ms throttle, but WaitForSelector might take 250ms!
 const int kThrottleMs = 500;
@@ -103,6 +113,7 @@ NonBlockingDelay(base::Milliseconds(250));  // Checking too early!
 ```
 
 **GOOD:**
+
 ```cpp
 // ✅ CORRECT - Large throttle window accounts for polling time
 const int kThrottleMs = 2000;
@@ -110,7 +121,8 @@ WaitForSelectorBlocked();  // Takes ~200-300ms
 NonBlockingDelay(base::Milliseconds(1000));  // Still well within throttle
 ```
 
-Polling-based waits consume time from the throttle window, so use throttle times much larger than expected polling durations.
+Polling-based waits consume time from the throttle window, so use throttle times
+much larger than expected polling durations.
 
 ---
 
@@ -122,14 +134,18 @@ Polling-based waits consume time from the throttle window, so use throttle times
 
 ### ✅ Search for Existing Chromium Patterns
 
-**Before implementing a fix for async/timing issues, search the Chromium codebase for similar patterns.**
+**Before implementing a fix for async/timing issues, search the Chromium
+codebase for similar patterns.**
 
-When you encounter a testing problem (flakiness, timing issues, async operations), ask:
+When you encounter a testing problem (flakiness, timing issues, async
+operations), ask:
+
 1. Does Chromium have tests with similar requirements?
 2. What patterns do they use to solve this?
 3. Is there a more deterministic, event-driven approach?
 
 **Research workflow:**
+
 1. Generate an initial fix proposal
 2. Search Chromium codebase for similar test scenarios
 3. Compare your approach to existing Chromium patterns
@@ -139,9 +155,11 @@ When you encounter a testing problem (flakiness, timing issues, async operations
 
 ### ✅ Include Chromium Code References
 
-**When following a Chromium pattern, include a reference in your code comments.**
+**When following a Chromium pattern, include a reference in your code
+comments.**
 
 **GOOD - Reference in code comment:**
+
 ```cpp
 // NOTE: Replace() is an IPC to the renderer that updates the DOM
 // asynchronously. We use a MutationObserver to wait for the DOM to update
@@ -153,6 +171,7 @@ static constexpr char kWaitForTextScript[] = R"(
 ```
 
 **GOOD - Reference in commit message:**
+
 ```
 Fix flaky RewriteInPlace_ContentEditable test
 
@@ -166,7 +185,9 @@ service_worker_internals_ui_browsertest.cc.
 
 ## ✅ Always Check `EvalJs` Results
 
-**When using `EvalJs` in tests, always check the result with `EXPECT_TRUE`/`EXPECT_EQ`.** An unchecked `EvalJs` call silently swallows errors - any gibberish expression would appear to "pass" the test.
+**When using `EvalJs` in tests, always check the result with
+`EXPECT_TRUE`/`EXPECT_EQ`.** An unchecked `EvalJs` call silently swallows
+errors - any gibberish expression would appear to "pass" the test.
 
 ```cpp
 // ❌ WRONG - unchecked EvalJs, silently ignores exceptions
@@ -183,7 +204,8 @@ EXPECT_EQ(true, content::EvalJs(web_contents,
 
 ## ❌ Don't Duplicate Test Constants - Expose via Header
 
-**Don't duplicate constants between production code and test code.** If both need the same value, expose it via a shared header file.
+**Don't duplicate constants between production code and test code.** If both
+need the same value, expose it via a shared header file.
 
 ```cpp
 // ❌ WRONG - same constant duplicated in test
@@ -203,7 +225,9 @@ inline constexpr base::TimeDelta kCleanupDelay = base::Seconds(30);
 
 ## ❌ Don't Depend on `//chrome` from Components Tests
 
-**Component-level unit tests must not depend on `//chrome`.** If you need objects typically created by Chrome infrastructure, create them manually in the test.
+**Component-level unit tests must not depend on `//chrome`.** If you need
+objects typically created by Chrome infrastructure, create them manually in the
+test.
 
 ```cpp
 // ❌ WRONG - depending on //chrome from components test
@@ -223,7 +247,9 @@ auto settings_map = base::MakeRefCounted<HostContentSettingsMap>(
 
 ## ✅ Prefer `*_for_testing()` Accessors Over `FRIEND_TEST`
 
-**When tests need access to a single private member, provide a `*_for_testing()` accessor** returning a reference instead of adding multiple `FRIEND_TEST` macros.
+**When tests need access to a single private member, provide a `*_for_testing()`
+accessor** returning a reference instead of adding multiple `FRIEND_TEST`
+macros.
 
 ```cpp
 // ❌ WRONG - proliferating FRIEND_TEST macros
@@ -247,7 +273,9 @@ class BraveTab {
 
 ## ✅ Verify Tests Actually Test What They Claim
 
-**When using test-only controls (globals, mocks, feature overrides), verify the test still exercises the code path it claims to test.** A test that disables the code under test proves nothing.
+**When using test-only controls (globals, mocks, feature overrides), verify the
+test still exercises the code path it claims to test.** A test that disables the
+code under test proves nothing.
 
 ```cpp
 // ❌ WRONG - test disables the code it claims to test
@@ -264,7 +292,8 @@ void SetUp() { g_disable_stats_for_testing = true; }
 
 ## ✅ Re-enable Test-Only Globals in `TearDown`
 
-**When a test disables functionality via a global in `SetUp()`, always re-enable it in `TearDown()`** to avoid leaking state to other tests.
+**When a test disables functionality via a global in `SetUp()`, always re-enable
+it in `TearDown()`** to avoid leaking state to other tests.
 
 ```cpp
 // ❌ WRONG - leaks state to other tests
@@ -281,7 +310,8 @@ void TearDown() { g_disable_auto_start = false; }
 
 ## ✅ Include Diagnostic State in Test Assertions
 
-**Test assertions should include diagnostic context using the `<<` operator** so failures are debuggable without re-running under a debugger.
+**Test assertions should include diagnostic context using the `<<` operator** so
+failures are debuggable without re-running under a debugger.
 
 ```cpp
 // ❌ WRONG - no context on failure
@@ -298,7 +328,9 @@ EXPECT_EQ(result.status, Status::kSuccess)
 
 ## ✅ Use `SCOPED_TRACE` with `base::Location` in Browser Test Helpers
 
-**Use `SCOPED_TRACE(base::Location::Current())` in browser test helper functions** to get file/line information in failure output. Without this, failures in helpers only show the helper's line, not the caller.
+**Use `SCOPED_TRACE(base::Location::Current())` in browser test helper
+functions** to get file/line information in failure output. Without this,
+failures in helpers only show the helper's line, not the caller.
 
 ```cpp
 // ❌ WRONG - failure points to helper, not caller
@@ -320,7 +352,9 @@ void VerifyTabCount(Browser* browser, int expected,
 
 ## ✅ Unit Tests Required for Bad/Invalid Input
 
-**Tool and handler implementations must have unit tests covering bad/invalid input scenarios,** not just happy paths. Test with malformed data, empty inputs, null values, and out-of-range parameters.
+**Tool and handler implementations must have unit tests covering bad/invalid
+input scenarios,** not just happy paths. Test with malformed data, empty inputs,
+null values, and out-of-range parameters.
 
 ---
 
@@ -328,7 +362,9 @@ void VerifyTabCount(Browser* browser, int expected,
 
 ## ✅ Relocate Test Checks When Refactoring
 
-**When refactoring removes a test check, that check must be relocated to the appropriate new location, not simply deleted.** Test coverage should never decrease during refactoring. If a check is no longer applicable, document why.
+**When refactoring removes a test check, that check must be relocated to the
+appropriate new location, not simply deleted.** Test coverage should never
+decrease during refactoring. If a check is no longer applicable, document why.
 
 ---
 
@@ -336,7 +372,10 @@ void VerifyTabCount(Browser* browser, int expected,
 
 ## ✅ Verify Ordering in Tests That Return Ordered Data
 
-**When testing functions that return ordered data, explicitly verify the order of results in the test,** not just the content. If the function is supposed to return results in a specific order (e.g., most recent first), the test should assert that order.
+**When testing functions that return ordered data, explicitly verify the order
+of results in the test,** not just the content. If the function is supposed to
+return results in a specific order (e.g., most recent first), the test should
+assert that order.
 
 ```cpp
 // ❌ WRONG - only checks content exists
@@ -357,7 +396,9 @@ EXPECT_EQ(results[2].url, "https://a.com");  // oldest
 
 ## ✅ Use `base::test::ParseJsonDict` for Test Comparisons
 
-**In tests comparing JSON values, use `base::test::ParseJsonDict()`** for simpler, more readable assertions. **Never use `testing::HasSubstr`** to validate JSON -- it is fragile and doesn't verify structure.
+**In tests comparing JSON values, use `base::test::ParseJsonDict()`** for
+simpler, more readable assertions. **Never use `testing::HasSubstr`** to
+validate JSON -- it is fragile and doesn't verify structure.
 
 ```cpp
 // ❌ WRONG - substring matching on JSON
@@ -380,7 +421,8 @@ EXPECT_EQ(actual, base::test::ParseJsonDict(
 
 ## ✅ Verify Negative Expectations in Tests
 
-**When testing error/failure paths, verify that side effects that should NOT occur are explicitly checked.** Don't only test the positive path.
+**When testing error/failure paths, verify that side effects that should NOT
+occur are explicitly checked.** Don't only test the positive path.
 
 ```cpp
 // ❌ WRONG - only checks the error is returned, doesn't verify no side effects
@@ -397,7 +439,9 @@ EXPECT_FALSE(result.has_value());
 
 ## ✅ Test All Fields in Serialization Tests
 
-**Verify ALL fields in serialization/deserialization tests, including secondary fields like favicon URLs.** Also always test deserialization of invalid/malformed input.
+**Verify ALL fields in serialization/deserialization tests, including secondary
+fields like favicon URLs.** Also always test deserialization of
+invalid/malformed input.
 
 ```cpp
 // ❌ WRONG - only checks primary fields
@@ -421,7 +465,8 @@ EXPECT_FALSE(bad_result.has_value());
 
 ## ✅ Use Parameterized Tests for Similar Scenarios
 
-**When testing multiple similar scenarios with different inputs/outputs, use parameterized tests instead of separate test functions.**
+**When testing multiple similar scenarios with different inputs/outputs, use
+parameterized tests instead of separate test functions.**
 
 ```cpp
 // ❌ WRONG - separate tests for each variation
@@ -457,7 +502,8 @@ TEST_F(MyTest, HandleAllTypes) {
 
 ## ✅ Extract Repetitive Test Assertions into Helpers
 
-**When tests repeat the same assertion blocks (e.g., checking content block types and fields), extract into reusable helper functions.**
+**When tests repeat the same assertion blocks (e.g., checking content block
+types and fields), extract into reusable helper functions.**
 
 ```cpp
 // ❌ WRONG - repeated assertion blocks
@@ -482,7 +528,8 @@ VerifyImageBlock(*blocks[1], "img.png");
 
 ## ✅ Use `ASSERT_TRUE` Before Accessing Optional Values
 
-**In tests, use `ASSERT_TRUE(optional.has_value())` before accessing an optional's value.** Do not use `value_or("")` as a fallback -- it hides bugs.
+**In tests, use `ASSERT_TRUE(optional.has_value())` before accessing an
+optional's value.** Do not use `value_or("")` as a fallback -- it hides bugs.
 
 ```cpp
 // ❌ WRONG - hides missing values
@@ -499,7 +546,9 @@ EXPECT_EQ(map[*entry->uuid], expected_content);
 
 ## ✅ Test Both Sides of Guard Conditions
 
-**When testing code with a guard condition (e.g., blocked during loading, enabled after), test both sides:** verify the behavior is blocked when the guard is active AND that it proceeds correctly when the guard is released.
+**When testing code with a guard condition (e.g., blocked during loading,
+enabled after), test both sides:** verify the behavior is blocked when the guard
+is active AND that it proceeds correctly when the guard is released.
 
 ```cpp
 // ❌ WRONG - only tests the happy path
@@ -524,7 +573,11 @@ TEST_F(MyTest, ActionSucceedsAfterLoad) {
 
 ## ❌ Don't Simulate Impossible Production States in Tests
 
-**Tests should not construct states that cannot occur in production.** If a test needs to set up a scenario, it should follow the same code path as production rather than directly manipulating internal state into an impossible configuration. Tests for impossible states prove nothing and can give false confidence.
+**Tests should not construct states that cannot occur in production.** If a test
+needs to set up a scenario, it should follow the same code path as production
+rather than directly manipulating internal state into an impossible
+configuration. Tests for impossible states prove nothing and can give false
+confidence.
 
 ---
 
@@ -532,7 +585,9 @@ TEST_F(MyTest, ActionSucceedsAfterLoad) {
 
 ## ✅ Use `WillOnce` Instead of `WillRepeatedly` for Single Calls
 
-**When a mock method is expected to be called exactly once, use `WillOnce` instead of `WillRepeatedly`.** `WillRepeatedly` hides bugs where the method is called more times than expected.
+**When a mock method is expected to be called exactly once, use `WillOnce`
+instead of `WillRepeatedly`.** `WillRepeatedly` hides bugs where the method is
+called more times than expected.
 
 ```cpp
 // ❌ WRONG - hides extra calls
@@ -548,7 +603,9 @@ EXPECT_CALL(mock, Fetch(_)).WillOnce(Return(result));
 
 ## ✅ Verify Observable Side Effects in Browser Tests
 
-**Browser tests should verify observable side effects** (e.g., a tab actually appeared, a URL actually loaded, a dialog was shown) rather than just checking return values. This catches integration issues that unit tests miss.
+**Browser tests should verify observable side effects** (e.g., a tab actually
+appeared, a URL actually loaded, a dialog was shown) rather than just checking
+return values. This catches integration issues that unit tests miss.
 
 ```cpp
 // ❌ WRONG - only checks return value
@@ -566,7 +623,9 @@ EXPECT_EQ(GetActiveWebContents()->GetURL(), url);
 
 ## ✅ Bug-Fix PRs Must Include Test Coverage
 
-**Every bug-fix PR should include a test that reproduces the specific bug scenario being fixed.** Without this, there's no guarantee the bug won't regress. The test should fail without the fix and pass with it.
+**Every bug-fix PR should include a test that reproduces the specific bug
+scenario being fixed.** Without this, there's no guarantee the bug won't
+regress. The test should fail without the fix and pass with it.
 
 ---
 
@@ -574,7 +633,9 @@ EXPECT_EQ(GetActiveWebContents()->GetURL(), url);
 
 ## ✅ When Fixing a Test, Run All Tests in the Same File
 
-**When fixing a flaky or failing test, run all tests in the same file across all test fixtures,** not just the single test being changed. This catches regressions or interactions between tests that share fixtures.
+**When fixing a flaky or failing test, run all tests in the same file across all
+test fixtures,** not just the single test being changed. This catches
+regressions or interactions between tests that share fixtures.
 
 ---
 
@@ -582,7 +643,10 @@ EXPECT_EQ(GetActiveWebContents()->GetURL(), url);
 
 ## ✅ Use ASSERT for Preconditions That Subsequent Code Depends On
 
-**When a test check guards state that later code depends on, use `ASSERT_*` (fatal) instead of `EXPECT_*` (non-fatal).** A failing `EXPECT` allows continued execution, which can crash on null dereferences or produce confusing secondary failures.
+**When a test check guards state that later code depends on, use `ASSERT_*`
+(fatal) instead of `EXPECT_*` (non-fatal).** A failing `EXPECT` allows continued
+execution, which can crash on null dereferences or produce confusing secondary
+failures.
 
 ```cpp
 // ❌ WRONG - EXPECT allows crash on null dereference
@@ -600,7 +664,11 @@ item->DoSomething();  // only reached if item is valid
 
 ## ✅ Use `DETACH_FROM_SEQUENCE()` in Database Constructors
 
-**Database classes that use `SEQUENCE_CHECKER` should call `DETACH_FROM_SEQUENCE(sequence_checker_)` in their constructor.** This allows the sequence checker to re-bind to whatever sequence first uses the object, which is essential for mock-based testing where objects may be created on a different sequence than they're used on.
+**Database classes that use `SEQUENCE_CHECKER` should call
+`DETACH_FROM_SEQUENCE(sequence_checker_)` in their constructor.** This allows
+the sequence checker to re-bind to whatever sequence first uses the object,
+which is essential for mock-based testing where objects may be created on a
+different sequence than they're used on.
 
 ```cpp
 // ❌ WRONG - sequence checker binds to construction thread
@@ -620,7 +688,10 @@ MyDatabase::MyDatabase() {
 
 ## ✅ Use `TEST()` Instead of `TEST_F()` for Empty Fixtures
 
-**When a test fixture class is empty (inherits from `testing::Test` with no added members, `SetUp()`, or `TearDown()`), use the plain `TEST()` macro.** `TEST_F` is only needed when the fixture provides shared state or configuration across tests.
+**When a test fixture class is empty (inherits from `testing::Test` with no
+added members, `SetUp()`, or `TearDown()`), use the plain `TEST()` macro.**
+`TEST_F` is only needed when the fixture provides shared state or configuration
+across tests.
 
 ```cpp
 // ❌ WRONG - empty fixture with TEST_F
@@ -642,7 +713,10 @@ TEST(MyUtilsTest, ParsesValidInput) {
 
 ## ✅ Use `NOTREACHED()` with Request Body in Test Mock Server Handlers
 
-**In test mock servers and URL interceptors, use `NOTREACHED() << request.content` (or equivalent) as the default handler to catch unhandled requests.** This makes test failures immediately obvious and includes the request body in the failure message for debugging.
+**In test mock servers and URL interceptors, use
+`NOTREACHED() << request.content` (or equivalent) as the default handler to
+catch unhandled requests.** This makes test failures immediately obvious and
+includes the request body in the failure message for debugging.
 
 ```cpp
 // ❌ WRONG - silently returns empty response for unhandled requests
@@ -665,7 +739,9 @@ std::unique_ptr<HttpResponse> HandleRequest(const HttpRequest& request) {
 
 ## ✅ Use Descriptive Test Method Names
 
-**Test method names should be long and descriptive enough to explain the scenario without reading the test body.** Do not sacrifice clarity to save characters. Long names are preferable to short, cryptic names.
+**Test method names should be long and descriptive enough to explain the
+scenario without reading the test body.** Do not sacrifice clarity to save
+characters. Long names are preferable to short, cryptic names.
 
 ```cpp
 // ❌ WRONG - too terse
@@ -683,9 +759,15 @@ TEST_F(WalletServiceTest, GetTokenBalances_HandlesNetworkTimeoutGracefully) { ..
 
 ## ✅ PRs Should Include Reasonable Test Coverage
 
-**Code that can be tested should be tested.** When reviewing or writing a PR, ensure that new logic, branches, and edge cases have corresponding tests. This applies to all PRs, not just bug fixes. Don't be overly strict — use judgment — but flag obvious gaps where meaningful test coverage is missing.
+**Code that can be tested should be tested.** When reviewing or writing a PR,
+ensure that new logic, branches, and edge cases have corresponding tests. This
+applies to all PRs, not just bug fixes. Don't be overly strict — use judgment —
+but flag obvious gaps where meaningful test coverage is missing.
 
-**If code is difficult to test, suggest refactors that improve testability** rather than accepting untested code. Common refactors include extracting logic into pure functions, adding dependency injection, or separating I/O from computation.
+**If code is difficult to test, suggest refactors that improve testability**
+rather than accepting untested code. Common refactors include extracting logic
+into pure functions, adding dependency injection, or separating I/O from
+computation.
 
 ```cpp
 // ❌ WRONG - new feature PR with no tests for core logic
@@ -704,7 +786,10 @@ TEST_F(WalletServiceTest, GetTokenBalances_HandlesNetworkTimeoutGracefully) { ..
 
 ## ✅ Use chromium_src Include Pattern to Test Upstream Overrides
 
-**When overriding upstream Chromium code via `chromium_src`, include the upstream test file and add Brave-specific tests after it.** This runs all upstream tests (catching regressions from your overrides) plus your new tests, with minimal effort.
+**When overriding upstream Chromium code via `chromium_src`, include the
+upstream test file and add Brave-specific tests after it.** This runs all
+upstream tests (catching regressions from your overrides) plus your new tests,
+with minimal effort.
 
 ```cpp
 // chromium_src/components/foo/foo_service_unittest.cc
@@ -723,6 +808,7 @@ TEST_F(FooServiceTest, BraveSpecificBehavior) {
 ```
 
 Good examples in the repo:
+
 - `chromium_src/components/sync/engine/sync_scheduler_impl_unittest.cc`
 - `chromium_src/components/ntp_tiles/most_visited_sites_unittest.cc`
 - `chromium_src/components/variations/service/variations_service_unittest.cc`
@@ -733,7 +819,10 @@ Good examples in the repo:
 
 ## ✅ Test All Feature Flag Combinations with Bitmask Parameterization
 
-**When testing a class affected by multiple `base::Feature` flags, use value-parameterized tests to cover all 2^N flag combinations.** Represent each combination as a bitmask where bit `i` enables feature `i`. This prevents regressions caused by unexpected flag interactions.
+**When testing a class affected by multiple `base::Feature` flags, use
+value-parameterized tests to cover all 2^N flag combinations.** Represent each
+combination as a bitmask where bit `i` enables feature `i`. This prevents
+regressions caused by unexpected flag interactions.
 
 ```cpp
 namespace {
@@ -764,7 +853,8 @@ TEST_P(MyFeatureTest, BehaviorIsCorrectForAllFlagCombinations) {
 }
 ```
 
-Place `kTestFeatures` in an unnamed namespace per Chromium C++ style. Use `int` instead of `size_t` for masks with more than 16 flags to avoid overflow.
+Place `kTestFeatures` in an unnamed namespace per Chromium C++ style. Use `int`
+instead of `size_t` for masks with more than 16 flags to avoid overflow.
 
-See [Chromium C++ Testing Best Practices](https://www.chromium.org/chromium-os/developer-library/guides/testing/cpp-writing-tests/).
-
+See
+[Chromium C++ Testing Best Practices](https://www.chromium.org/chromium-os/developer-library/guides/testing/cpp-writing-tests/).

--- a/docs/best-practices/testing-javascript.md
+++ b/docs/best-practices/testing-javascript.md
@@ -4,14 +4,18 @@
 
 ## ✅ Prefer Event-Driven JavaScript Over C++ Polling
 
-**When waiting for DOM changes, prefer JavaScript event-driven patterns (like MutationObserver) over C++ polling loops.**
+**When waiting for DOM changes, prefer JavaScript event-driven patterns (like
+MutationObserver) over C++ polling loops.**
 
 Event-driven patterns are:
+
 - More deterministic (respond immediately when the event occurs)
 - More efficient (no wasted CPU cycles polling)
-- Consistent with Chromium patterns (see `service_worker_internals_ui_browsertest.cc`)
+- Consistent with Chromium patterns (see
+  `service_worker_internals_ui_browsertest.cc`)
 
 **BEST - MutationObserver for DOM changes:**
+
 ```cpp
 // Pattern from Chromium's service_worker_internals_ui_browsertest.cc
 static constexpr char kWaitForTextScript[] = R"(
@@ -54,7 +58,8 @@ std::string updated_text =
 
 ## ✅ Manual Polling Loop (Fallback)
 
-**Use C++ polling only when JavaScript event-driven patterns aren't applicable** (e.g., checking for element existence, waiting for JS API readiness):
+**Use C++ polling only when JavaScript event-driven patterns aren't applicable**
+(e.g., checking for element existence, waiting for JS API readiness):
 
 ```cpp
 const base::TimeTicks deadline = base::TimeTicks::Now() + base::Seconds(10);
@@ -78,7 +83,8 @@ for (;;) {
 
 ## Use Isolated Worlds for Test Code
 
-When evaluating JavaScript in tests, use `ISOLATED_WORLD_ID_BRAVE_INTERNAL` to avoid interfering with page scripts:
+When evaluating JavaScript in tests, use `ISOLATED_WORLD_ID_BRAVE_INTERNAL` to
+avoid interfering with page scripts:
 
 ```cpp
 content::EvalJs(web_contents, "document.getElementById('foo')",
@@ -95,6 +101,7 @@ content::EvalJs(web_contents, "document.getElementById('foo')",
 **Problem:** Mojo binding completes before JavaScript event emitter setup.
 
 **Example (Solana provider):**
+
 ```cpp
 // ❌ WRONG - WaitForSolanaProviderBinding only waits for mojo, not JS
 WaitForSolanaProviderBinding();

--- a/docs/best-practices/testing-navigation.md
+++ b/docs/best-practices/testing-navigation.md
@@ -4,9 +4,11 @@
 
 ## Same-Document Navigation
 
-**DO NOT use `base::test::RunUntil()` polling for same-document (hash/fragment) navigations.**
+**DO NOT use `base::test::RunUntil()` polling for same-document (hash/fragment)
+navigations.**
 
-Standard `TestNavigationObserver` skips same-document navigations. Use a custom observer:
+Standard `TestNavigationObserver` skips same-document navigations. Use a custom
+observer:
 
 ```cpp
 class SameDocumentCommitObserver : public content::WebContentsObserver {
@@ -39,6 +41,7 @@ observer.Wait();
 ## Avoid Hardcoded JavaScript Timeouts
 
 **BAD:**
+
 ```cpp
 // ❌ WRONG - Unreliable hardcoded timeout
 content::EvalJs(web_contents, R"(
@@ -47,6 +50,7 @@ content::EvalJs(web_contents, R"(
 ```
 
 **GOOD:**
+
 ```cpp
 // ✅ CORRECT - Wait for actual condition in C++
 ASSERT_TRUE(base::test::RunUntil([&]() {
@@ -60,7 +64,8 @@ ASSERT_TRUE(base::test::RunUntil([&]() {
 
 ## Wait for Page Distillation
 
-When testing distilled content (Speedreader), always wait for distillation to complete:
+When testing distilled content (Speedreader), always wait for distillation to
+complete:
 
 ```cpp
 NavigateToPageSynchronously(url);

--- a/docs/best-practices/testing-upstream-failures.md
+++ b/docs/best-practices/testing-upstream-failures.md
@@ -4,9 +4,15 @@
 
 ## ❌ Never Use Patches to Disable Upstream Test Failures
 
-**Do not create patch files to disable upstream Chromium tests for intermittent failures.** Use filter files in `test/filters/` instead — they are the preferred way to disable flaky upstream tests and are trivially reversible.
+**Do not create patch files to disable upstream Chromium tests for intermittent
+failures.** Use filter files in `test/filters/` instead — they are the preferred
+way to disable flaky upstream tests and are trivially reversible.
 
-**Prefer disabling over fixing** intermittent failures in upstream Chromium test files. Modifying upstream test code via patches is fragile and maintenance-heavy; a well-documented filter file entry is the correct long-term solution for upstream flakes. Only fix the upstream test code if Brave's own `chromium_src` overrides or patches are responsible for the failure.
+**Prefer disabling over fixing** intermittent failures in upstream Chromium test
+files. Modifying upstream test code via patches is fragile and
+maintenance-heavy; a well-documented filter file entry is the correct long-term
+solution for upstream flakes. Only fix the upstream test code if Brave's own
+`chromium_src` overrides or patches are responsible for the failure.
 
 ---
 
@@ -14,7 +20,9 @@
 
 ## ✅ Check Upstream Flakiness Before Filtering a Test
 
-**Before adding an upstream Chromium test to a filter file, verify that Brave code is not responsible for the failure.** If a Brave override or patch is causing the test to fail, fix that code — don't hide it with a filter.
+**Before adding an upstream Chromium test to a filter file, verify that Brave
+code is not responsible for the failure.** If a Brave override or patch is
+causing the test to fail, fix that code — don't hide it with a filter.
 
 **Run the upstream flake check (from `src/brave`):**
 
@@ -29,19 +37,21 @@ python3 script/check-upstream-flake.py "TestSuite.TestMethod" --days 60
 python3 script/check-upstream-flake.py "TestSuite"
 ```
 
-The script queries Chromium's LUCI Analysis database and returns one of five verdicts:
+The script queries Chromium's LUCI Analysis database and returns one of five
+verdicts:
 
-| Verdict | Flake Rate | Action |
-|---|---|---|
-| **Known upstream flake** | ≥5% | Safe to filter. Document rate in filter comment. |
-| **Occasional upstream failures** | 1–5% | Prefer filtering. Document instability. |
-| **Stable upstream** | <1% | Investigate Brave-specific causes before filtering. |
-| **Insufficient data** | N/A (<10 verdicts) | Manual investigation needed. |
-| **Not found** | N/A | Test may be Brave-specific or use a different ID format. |
+| Verdict                          | Flake Rate         | Action                                                   |
+| -------------------------------- | ------------------ | -------------------------------------------------------- |
+| **Known upstream flake**         | ≥5%                | Safe to filter. Document rate in filter comment.         |
+| **Occasional upstream failures** | 1–5%               | Prefer filtering. Document instability.                  |
+| **Stable upstream**              | <1%                | Investigate Brave-specific causes before filtering.      |
+| **Insufficient data**            | N/A (<10 verdicts) | Manual investigation needed.                             |
+| **Not found**                    | N/A                | Test may be Brave-specific or use a different ID format. |
 
 **Flake rate** is calculated as `(failed + flaky) / (passed + failed + flaky)`.
 
 **Decision rule:**
+
 - **≥1% flake rate** → prefer adding to a filter file over attempting a fix
 - **<1% flake rate** → investigate Brave-specific causes:
   1. Check `src/brave/chromium_src/` for overrides in the test's directory tree
@@ -53,7 +63,9 @@ The script queries Chromium's LUCI Analysis database and returns one of five ver
 
 ## ✅ Filter Only Specific Flaky Parameterized Variants
 
-**Do not use wildcard filters that suppress stable variants alongside flaky ones.** Check LUCI Analysis data for each variant individually and only filter the specific variants that are actually flaky.
+**Do not use wildcard filters that suppress stable variants alongside flaky
+ones.** Check LUCI Analysis data for each variant individually and only filter
+the specific variants that are actually flaky.
 
 ```
 # ❌ WRONG - wildcard disables all variants including stable ones
@@ -72,9 +84,21 @@ The script queries Chromium's LUCI Analysis database and returns one of five ver
 
 ## ✅ Match Filter Specificity to Actual Failure Scope
 
-**Use the most specific/narrow filter approach, but only when the evidence supports it.** If a test only fails under ASAN on Linux and upstream LUCI Analysis shows no flakiness on non-ASAN builds, use a platform-and-sanitizer-specific filter file (e.g., `browser_tests-linux-asan.filter`) rather than an all-platform filter. Look at existing patterns in `build/commands/lib/testUtils.js` for how sanitizer-specific filters are loaded.
+**Use the most specific/narrow filter approach, but only when the evidence
+supports it.** If a test only fails under ASAN on Linux and upstream LUCI
+Analysis shows no flakiness on non-ASAN builds, use a
+platform-and-sanitizer-specific filter file (e.g.,
+`browser_tests-linux-asan.filter`) rather than an all-platform filter. Look at
+existing patterns in `build/commands/lib/testUtils.js` for how
+sanitizer-specific filters are loaded.
 
-**Do not place a filter in a sanitizer-specific file (e.g., `-asan`, `-msan`) if upstream LUCI Analysis data shows the test also fails on non-sanitizer builds.** LUCI Analysis aggregates across all build configs, so a non-zero upstream flake rate means the test can fail outside of sanitizer builds too. In that case, use a broader filter file (e.g., `browser_tests.filter` or `browser_tests-windows.filter`) to cover all environments where the failure may occur.
+**Do not place a filter in a sanitizer-specific file (e.g., `-asan`, `-msan`) if
+upstream LUCI Analysis data shows the test also fails on non-sanitizer builds.**
+LUCI Analysis aggregates across all build configs, so a non-zero upstream flake
+rate means the test can fail outside of sanitizer builds too. In that case, use
+a broader filter file (e.g., `browser_tests.filter` or
+`browser_tests-windows.filter`) to cover all environments where the failure may
+occur.
 
 ---
 
@@ -82,12 +106,14 @@ The script queries Chromium's LUCI Analysis database and returns one of five ver
 
 ## ✅ Filter File Entries Must Include a Descriptive Comment
 
-**Every disabled test entry in a filter file must be preceded by a comment that includes:**
+**Every disabled test entry in a filter file must be preceded by a comment that
+includes:**
 
 1. **Why** the test is disabled
 2. **What** specific condition causes the failure
 3. **Why** this filter file was chosen (if not obvious from the filename)
-4. **Upstream flakiness data** — flake rate and lookback period (for upstream Chromium tests)
+4. **Upstream flakiness data** — flake rate and lookback period (for upstream
+   Chromium tests)
 
 ```
 # ❌ WRONG - no explanation
@@ -106,7 +132,10 @@ The script queries Chromium's LUCI Analysis database and returns one of five ver
 
 ## ✅ Group Filter File Entries by Root Cause
 
-**In filter files, group disabled tests that share a root cause under a single comment section.** Tests with distinct root causes get their own section. Always leave a blank line before a new comment section — do not place a comment immediately after a test entry without a blank line.
+**In filter files, group disabled tests that share a root cause under a single
+comment section.** Tests with distinct root causes get their own section. Always
+leave a blank line before a new comment section — do not place a comment
+immediately after a test entry without a blank line.
 
 ```
 # ❌ WRONG - mixing causes under one comment, no blank lines

--- a/docs/best-practices/ui-views.md
+++ b/docs/best-practices/ui-views.md
@@ -6,7 +6,11 @@
 
 ## ✅ Use unique_ptr for View Child Add/Remove
 
-**Prefer the `unique_ptr` overload of `View::AddChildView()` and use `View::RemoveChildViewT()` when you need to remove a child from the hierarchy and then destroy it.** `RemoveChildView(View*)` does not delete the child; `RemoveChildViewT()` returns a `unique_ptr` so ownership and destruction are explicit.
+**Prefer the `unique_ptr` overload of `View::AddChildView()` and use
+`View::RemoveChildViewT()` when you need to remove a child from the hierarchy
+and then destroy it.** `RemoveChildView(View*)` does not delete the child;
+`RemoveChildViewT()` returns a `unique_ptr` so ownership and destruction are
+explicit.
 
 ```cpp
 // ❌ WRONG - raw pointer add; remove does not transfer ownership
@@ -26,9 +30,16 @@ std::unique_ptr<views::View> owned = parent->RemoveChildViewT(some_child);
 
 ## ✅ Do not manually call `RemoveObserver` when inheriting `TabStripModelObserver`
 
-**Do not call `TabStripModel::RemoveObserver(this)` from your subclass destructor, `Shutdown()`, or `OnTabStripModelDestroyed`.** `~TabStripModelObserver` copies every `TabStripModel*` in `observed_models_` and calls `RemoveObserver(this)` on each. Registration via `AddObserver` / `StartedObserving` is undone by that base destructor, so derived code must not duplicate it.
+**Do not call `TabStripModel::RemoveObserver(this)` from your subclass
+destructor, `Shutdown()`, or `OnTabStripModelDestroyed`.**
+`~TabStripModelObserver` copies every `TabStripModel*` in `observed_models_` and
+calls `RemoveObserver(this)` on each. Registration via `AddObserver` /
+`StartedObserving` is undone by that base destructor, so derived code must not
+duplicate it.
 
-When a `TabStripModel` is destroyed, it also notifies observers through `ModelDestroyed`, which removes the observer before `OnTabStripModelDestroyed`; explicit `RemoveObserver` there is redundant as well.
+When a `TabStripModel` is destroyed, it also notifies observers through
+`ModelDestroyed`, which removes the observer before `OnTabStripModelDestroyed`;
+explicit `RemoveObserver` there is redundant as well.
 
 ```cpp
 // ❌ WRONG - ~TabStripModelObserver already unregisters from every observed model
@@ -59,9 +70,17 @@ void MyView::OnTabStripModelDestroyed(TabStripModel* model) {
 
 ## ✅ Prefer `views::AsViewClass` and `views::IsViewClass` Over `static_cast<>` for View Downcasting
 
-**Use `views::AsViewClass<T>()` and `views::IsViewClass<T>()` instead of `static_cast<T*>()` when downcasting `views::View` pointers.**
+**Use `views::AsViewClass<T>()` and `views::IsViewClass<T>()` instead of
+`static_cast<T*>()` when downcasting `views::View` pointers.**
 
-Since Chromium disables RTTI, `dynamic_cast` is unavailable. `AsViewClass` and `IsViewClass` fill that role for the views hierarchy: they walk the metadata chain registered via `METADATA_HEADER` and catch — at compile time — target classes that have omitted `METADATA_HEADER` or left a metadata path unoverridden. At runtime, `AsViewClass` returns `nullptr` on a type mismatch, including for partially constructed views that have not yet installed their own class metadata. `static_cast` does none of this and silently produces a pointer whose dereference is undefined behaviour on a type mismatch.
+Since Chromium disables RTTI, `dynamic_cast` is unavailable. `AsViewClass` and
+`IsViewClass` fill that role for the views hierarchy: they walk the metadata
+chain registered via `METADATA_HEADER` and catch — at compile time — target
+classes that have omitted `METADATA_HEADER` or left a metadata path
+unoverridden. At runtime, `AsViewClass` returns `nullptr` on a type mismatch,
+including for partially constructed views that have not yet installed their own
+class metadata. `static_cast` does none of this and silently produces a pointer
+whose dereference is undefined behaviour on a type mismatch.
 
 ```cpp
 // ❌ WRONG - no type check; UB on dereference if type assumption is wrong.
@@ -87,4 +106,3 @@ if (views::IsViewClass<MyCustomView>(some_view)) {
 ```
 
 ---
-


### PR DESCRIPTION
This PR runs `prettier`'s formatting for all markdown documents under
best practices. This ia completely mechanical change. Additionally, we
also update the claude `add-best-practice` skill to be aware of the
auto-formatter.

Bug: N/A
