### PR TITLE
Fix flicker dragging tabs into a collapsed vertical strip across windows

### DIFF
--- a/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.cc
@@ -568,7 +568,8 @@ void BraveVerticalTabStripRegionView::UpdateStateAfterDragAndDropFinished(
 }
 
 BraveVerticalTabStripRegionView::ScopedStateResetter
-BraveVerticalTabStripRegionView::ExpandTabStripForDragging() {
+BraveVerticalTabStripRegionView::ExpandTabStripForDragging(
+    bool snap_to_expanded) {
   if (state_ == State::kExpanded) {
     return {};
   }
@@ -578,6 +579,16 @@ BraveVerticalTabStripRegionView::ExpandTabStripForDragging() {
       weak_factory_.GetWeakPtr(), state_));
 
   SetState(State::kExpanded);
+  if (snap_to_expanded && width_animation_.is_animating()) {
+    // Skip the slide animation so the strip immediately takes its full
+    // expanded width. Otherwise the animation drives per-frame widget bounds
+    // changes that re-trigger tab container layout (see OnBoundsChanged), and
+    // an in-flight drag-and-drop session sees the dragged tab's insertion
+    // index recomputed every frame -- visible as flicker when a tab is
+    // dropped into a previously collapsed strip from another window.
+    width_animation_.Reset(1);
+    width_animation_.Stop();
+  }
   // In this case, we dont' wait for the widget bounds to be changed so that
   // tab drag controller can layout tabs properly.
   SetSize(GetPreferredSize());

--- a/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.h
+++ b/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.h
@@ -81,9 +81,14 @@ class BraveVerticalTabStripRegionView : public views::View,
 
   // Expand vertical tabstrip temporarily. When the returned
   // ScopedCallbackRunner is destroyed, the state will be restored to the
-  // previous state.
+  // previous state. When |snap_to_expanded| is true, the width animation is
+  // stopped and the strip immediately takes its full expanded width, so that
+  // a concurrent tab drag-and-drop session doesn't observe per-frame bounds
+  // changes (which cause flicker when dragging a tab into a previously
+  // collapsed strip from another window).
   using ScopedStateResetter = std::unique_ptr<base::ScopedClosureRunner>;
-  [[nodiscard]] ScopedStateResetter ExpandTabStripForDragging();
+  [[nodiscard]] ScopedStateResetter ExpandTabStripForDragging(
+      bool snap_to_expanded = false);
 
   int GetAvailableWidthForTabContainer();
 

--- a/browser/ui/views/tabs/dragging/tab_drag_controller.cc
+++ b/browser/ui/views/tabs/dragging/tab_drag_controller.cc
@@ -189,7 +189,13 @@ void BraveTabDragController::DetachAndAttachToNewContext(
 
   auto* region_view = get_region_view();
 
-  vertical_tab_state_resetter_ = region_view->ExpandTabStripForDragging();
+  // Snap the newly attached strip to its expanded width so the upcoming
+  // ForceLayout() (and subsequent drag positioning) sees the final bounds
+  // immediately. If we let the width animation run, OnBoundsChanged would
+  // fire each frame and re-layout the tab container under the active drag,
+  // producing visible flicker in the destination window.
+  vertical_tab_state_resetter_ =
+      region_view->ExpandTabStripForDragging(/*snap_to_expanded=*/true);
   // Relayout tabs with expanded bounds.
   attached_context_->GetPositioningDelegate()->ForceLayout();
 }


### PR DESCRIPTION
When a tab is dragged from one window into another whose vertical tab strip is collapsed, ExpandTabStripForDragging arms a 200ms width animation (collapsed -> expanded) and tries to snap the strip via SetSize(GetPreferredSize()). But GetPreferredSize() interpolates against the in-flight animation and returns ~collapsed width on the first call, so the snap is silently a no-op. For the next ~200ms, every animation frame triggers OnBoundsChanged which force-relayouts the tab container under the active drag, recomputing the dragged-tab insertion index against a different width each frame -- the visible flicker.

When the destination is already expanded ExpandTabStripForDragging returns early, which is why the bug is invisible in that case.

Add a snap_to_expanded parameter to ExpandTabStripForDragging that, when true, resets the width animation to its end value before SetSize so it actually lands at the full expanded width. The destination call in DetachAndAttachToNewContext passes true so the strip snaps in a single frame. The source-side call keeps the default false; its existing micro-animation is immediately reversed by the resetter destruction and is invisible.

**THIS PR WAS MADE WITH THE HELP OF AI, I JUST WANT THE BUG TO GET FIXED**

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/32932

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
