### PR TITLE
[cr149][Android][Sync] Migrate sync_everything option to per-type on Android

### DIFF
--- a/components/sync/service/brave_sync_service_impl.cc
+++ b/components/sync/service/brave_sync_service_impl.cc
@@ -363,11 +363,22 @@ void BraveSyncServiceImpl::OnEngineInitialized(
     VLOG(1) << "Forced set decryption passphrase result is "
             << set_passphrase_result;
   }
+
+#if BUILDFLAG(IS_ANDROID)
+  DCHECK(GetSyncAccountStateForPrefs() !=
+         SyncPrefs::SyncAccountState::kNotSignedIn);
+  MigrateAndroidSyncEverythingIfRequired();
+#endif
 }
 
 SyncServiceCrypto* BraveSyncServiceImpl::GetCryptoForTesting() {
   CHECK_IS_TEST();
   return &crypto_;
+}
+
+DataTypeManager* BraveSyncServiceImpl::GetDataTypeManagerForTesting() {
+  CHECK_IS_TEST();
+  return data_type_manager_.get();
 }
 
 void BraveSyncServiceImpl::SetInitializingForTesting() {
@@ -561,5 +572,22 @@ void BraveSyncServiceImpl::OnAccountsInCookieUpdated(
 
 void BraveSyncServiceImpl::OnPrimaryAccountChanged(
     const signin::PrimaryAccountChangeEvent& event_details) {}
+
+#if BUILDFLAG(IS_ANDROID)
+void BraveSyncServiceImpl::MigrateAndroidSyncEverythingIfRequired() {
+  if (!GetUserSettings()->IsSyncEverythingEnabled()) {
+    return;
+  }
+
+  syncer::UserSelectableTypeSet selected_types;
+  UserSelectableTypeSet registered_types =
+      GetUserSettings()->GetRegisteredSelectableTypes();
+  for (UserSelectableType type : registered_types) {
+    selected_types.Put(type);
+  }
+  GetUserSettings()->SetSelectedTypes(false, selected_types);
+  CHECK(!GetUserSettings()->IsSyncEverythingEnabled());
+}
+#endif
 
 }  // namespace syncer

--- a/components/sync/service/brave_sync_service_impl.cc
+++ b/components/sync/service/brave_sync_service_impl.cc
@@ -584,7 +584,6 @@ void BraveSyncServiceImpl::MaybeAndroidSyncEverythingIfRequired() {
     selected_types.Put(type);
   }
   GetUserSettings()->SetSelectedTypes(false, selected_types);
-  DCHECK(!GetUserSettings()->IsSyncEverythingEnabled());
 }
 #endif
 

--- a/components/sync/service/brave_sync_service_impl.cc
+++ b/components/sync/service/brave_sync_service_impl.cc
@@ -365,9 +365,7 @@ void BraveSyncServiceImpl::OnEngineInitialized(
   }
 
 #if BUILDFLAG(IS_ANDROID)
-  DCHECK(GetSyncAccountStateForPrefs() !=
-         SyncPrefs::SyncAccountState::kNotSignedIn);
-  MigrateAndroidSyncEverythingIfRequired();
+  MaybeAndroidSyncEverythingIfRequired();
 #endif
 }
 
@@ -574,7 +572,7 @@ void BraveSyncServiceImpl::OnPrimaryAccountChanged(
     const signin::PrimaryAccountChangeEvent& event_details) {}
 
 #if BUILDFLAG(IS_ANDROID)
-void BraveSyncServiceImpl::MigrateAndroidSyncEverythingIfRequired() {
+void BraveSyncServiceImpl::MaybeAndroidSyncEverythingIfRequired() {
   if (!GetUserSettings()->IsSyncEverythingEnabled()) {
     return;
   }
@@ -586,7 +584,7 @@ void BraveSyncServiceImpl::MigrateAndroidSyncEverythingIfRequired() {
     selected_types.Put(type);
   }
   GetUserSettings()->SetSelectedTypes(false, selected_types);
-  CHECK(!GetUserSettings()->IsSyncEverythingEnabled());
+  DCHECK(!GetUserSettings()->IsSyncEverythingEnabled());
 }
 #endif
 

--- a/components/sync/service/brave_sync_service_impl.h
+++ b/components/sync/service/brave_sync_service_impl.h
@@ -91,6 +91,7 @@ class BraveSyncServiceImpl : public SyncServiceImpl {
   SyncServiceCrypto* GetCryptoForTesting();
   bool SetSeedForTesting(const std::string& seed);
   void SetInitializingForTesting();
+  DataTypeManager* GetDataTypeManagerForTesting();
 
  private:
   friend class BraveSyncServiceImplGACookiesTest;
@@ -148,6 +149,10 @@ class BraveSyncServiceImpl : public SyncServiceImpl {
       const signin::PrimaryAccountChangeEvent& event_details) override;
 
   bool SetSeed(const std::string& seed);
+
+#if BUILDFLAG(IS_ANDROID)
+  void MigrateAndroidSyncEverythingIfRequired();
+#endif
 
   brave_sync::Prefs brave_sync_prefs_;
 

--- a/components/sync/service/brave_sync_service_impl.h
+++ b/components/sync/service/brave_sync_service_impl.h
@@ -90,8 +90,8 @@ class BraveSyncServiceImpl : public SyncServiceImpl {
   void RemoveAllPrefsChangeRegistrarForTesting();
   SyncServiceCrypto* GetCryptoForTesting();
   bool SetSeedForTesting(const std::string& seed);
-  void SetInitializingForTesting();
   DataTypeManager* GetDataTypeManagerForTesting();
+  void SetInitializingForTesting();
 
  private:
   friend class BraveSyncServiceImplGACookiesTest;
@@ -151,7 +151,7 @@ class BraveSyncServiceImpl : public SyncServiceImpl {
   bool SetSeed(const std::string& seed);
 
 #if BUILDFLAG(IS_ANDROID)
-  void MigrateAndroidSyncEverythingIfRequired();
+  void MaybeAndroidSyncEverythingIfRequired();
 #endif
 
   brave_sync::Prefs brave_sync_prefs_;

--- a/components/sync/service/brave_sync_service_impl_unittest.cc
+++ b/components/sync/service/brave_sync_service_impl_unittest.cc
@@ -16,6 +16,7 @@
 #include "base/test/bind.h"
 #include "base/test/gtest_util.h"
 #include "base/test/metrics/histogram_tester.h"
+#include "base/test/run_until.h"
 #include "base/test/scoped_feature_list.h"
 #include "base/test/task_environment.h"
 #include "base/time/default_clock.h"
@@ -357,7 +358,8 @@ TEST_F(BraveSyncServiceImplTest, ForcedSetDecryptionPassphrase) {
   // So we just make DataTypeManagerImpl::SetConfigurer requirements be
   // satisfied.
   // Related Chromium commit 7cdf92e9470fc73a09b871f99d14ff115edef652
-  brave_sync_service_impl()->data_type_manager_->Stop(KEEP_METADATA);
+  brave_sync_service_impl()->GetDataTypeManagerForTesting()->Stop(
+      KEEP_METADATA);
 
   // We have to cleanup SyncServiceCrypto.state_.engine with Reset
   // because on 2nd OnEngineInitialized call it is non-null and CHECK gets
@@ -371,7 +373,8 @@ TEST_F(BraveSyncServiceImplTest, ForcedSetDecryptionPassphrase) {
       KeyDerivationParams::CreateForPbkdf2(),
       MakeEncryptedData(kValidSyncCode,
                         KeyDerivationParams::CreateForPbkdf2()));
-  brave_sync_service_impl()->data_type_manager_->Stop(KEEP_METADATA);
+  brave_sync_service_impl()->GetDataTypeManagerForTesting()->Stop(
+      KEEP_METADATA);
 
   brave_sync_service_impl()->OnEngineInitialized(true, false);
   EXPECT_FALSE(
@@ -733,6 +736,55 @@ TEST_F(BraveSyncServiceImplTest, BookmarksAndPasswordsAfterSetup) {
   EXPECT_TRUE(selected_types.Has(UserSelectableType::kBookmarks));
   EXPECT_TRUE(selected_types.Has(UserSelectableType::kPasswords));
 }
+
+#if BUILDFLAG(IS_ANDROID)
+TEST_F(BraveSyncServiceImplTest,
+       MigrateAndroidSyncEverythingOnEngineInitialized) {
+  CreateSyncService();
+  EXPECT_FALSE(engine());
+
+  brave_sync_service_impl()->SetSyncCode(kValidSyncCode);
+  ASSERT_TRUE(base::test::RunUntil([&] { return engine() != nullptr; }));
+
+  // Complete setup so IsInitialSyncFeatureSetupComplete() returns true.
+  // OnEngineInitialized was already called above but exited early because
+  // setup was not yet complete at that point.
+  brave_sync_service_impl()
+      ->GetUserSettings()
+      ->SetInitialSyncFeatureSetupComplete();
+
+  // Simulate pre-cr149 device state: sync-everything was enabled.
+  {
+    auto setup_handle = brave_sync_service_impl()->GetSetupInProgressHandle();
+    UserSelectableTypeSet registered_types =
+        brave_sync_service_impl()
+            ->GetUserSettings()
+            ->GetRegisteredSelectableTypes();
+    brave_sync_service_impl()->GetUserSettings()->SetSelectedTypes(
+        /*keep_everything_synced=*/true, registered_types);
+  }
+  ASSERT_TRUE(
+      brave_sync_service_impl()->GetUserSettings()->IsSyncEverythingEnabled());
+
+  // Re-trigger OnEngineInitialized (simulating app restart with cr149).
+  // Stop the data type manager first — required by DataTypeManagerImpl's
+  // SetConfigurer. Reset crypto state to clear the engine pointer set during
+  // the first OnEngineInitialized call, otherwise a CHECK fires.
+  brave_sync_service_impl()->GetDataTypeManagerForTesting()->Stop(
+      KEEP_METADATA);
+  brave_sync_service_impl()->GetCryptoForTesting()->Reset();
+  brave_sync_service_impl()->OnEngineInitialized(true, false);
+
+  // After migration: sync_everything must be off, all registered types
+  // selected.
+  EXPECT_FALSE(
+      brave_sync_service_impl()->GetUserSettings()->IsSyncEverythingEnabled());
+  EXPECT_EQ(brave_sync_service_impl()->GetUserSettings()->GetSelectedTypes(),
+            brave_sync_service_impl()
+                ->GetUserSettings()
+                ->GetRegisteredSelectableTypes());
+}
+#endif  // BUILDFLAG(IS_ANDROID)
 
 TEST_F(BraveSyncServiceImplTest, P3aForHistoryThroughDelegate) {
   CreateSyncService(DataTypeSet({BOOKMARKS, HISTORY, PASSWORDS}));

--- a/components/sync/service/brave_sync_service_impl_unittest.cc
+++ b/components/sync/service/brave_sync_service_impl_unittest.cc
@@ -747,8 +747,8 @@ TEST_F(BraveSyncServiceImplTest,
   ASSERT_TRUE(base::test::RunUntil([&] { return engine() != nullptr; }));
 
   // Complete setup so IsInitialSyncFeatureSetupComplete() returns true.
-  // OnEngineInitialized was already called above but exited early because
-  // setup was not yet complete at that point.
+  // OnEngineInitialized was already called after we set the sync code, but
+  // exited early because setup was not yet complete at that point.
   brave_sync_service_impl()
       ->GetUserSettings()
       ->SetInitialSyncFeatureSetupComplete();


### PR DESCRIPTION
Starting from `cr149` there is no `Sync Everything` UI option on Android.
Android apps which had `Sync Everything` and were updated from cr148 to cr149 cannot modify any types, because of failure `DUMP_WILL_BE_CHECK(!IsSyncEverythingEnabled());` at `SyncUserSettingsImpl::SetSelectedType`.

So this PR migrates sync_everything option to per-type on Android.

Resolves https://github.com/brave/brave-browser/issues/55862

<!-- Add brave-browser issue below that this PR will resolve -->


<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
