### PR TITLE
[fingerprinting] Handle device info leaks for WebGPU 

### DIFF
--- a/browser/farbling/BUILD.gn
+++ b/browser/farbling/BUILD.gn
@@ -25,6 +25,7 @@ if (!is_android) {
       "brave_speech_synthesis_farbling_browsertest.cc",
       "brave_webaudio_farbling_browsertest.cc",
       "brave_webgl_farbling_browsertest.cc",
+      "brave_webgpu_farbling_browsertest.cc",
     ]
 
     deps = [

--- a/browser/farbling/brave_webgpu_farbling_browsertest.cc
+++ b/browser/farbling/brave_webgpu_farbling_browsertest.cc
@@ -55,8 +55,8 @@ class BraveWebGPUFarblingBrowserTest : public InProcessBrowserTest {
     host_resolver()->AddRule("*", "127.0.0.1");
     content::SetupCrossSiteRedirector(embedded_test_server());
 
-    base::FilePath test_data_dir;
-    base::PathService::CheckedGet(brave::DIR_TEST_DATA, &test_data_dir);
+    base::FilePath test_data_dir =
+        base::PathService::CheckedGet(brave::DIR_TEST_DATA);
     test_data_dir = test_data_dir.AppendASCII(kEmbeddedTestServerDirectory);
     embedded_test_server()->ServeFilesFromDirectory(test_data_dir);
 

--- a/browser/farbling/brave_webgpu_farbling_browsertest.cc
+++ b/browser/farbling/brave_webgpu_farbling_browsertest.cc
@@ -1,0 +1,205 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "base/path_service.h"
+#include "base/test/scoped_feature_list.h"
+#include "brave/components/brave_shields/core/browser/brave_shields_utils.h"
+#include "brave/components/brave_shields/core/common/features.h"
+#include "brave/components/constants/brave_paths.h"
+#include "brave/components/webcompat/core/common/features.h"
+#include "chrome/browser/content_settings/host_content_settings_map_factory.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "chrome/test/base/ui_test_utils.h"
+#include "components/content_settings/core/browser/host_content_settings_map.h"
+#include "content/public/test/browser_test.h"
+#include "content/public/test/browser_test_utils.h"
+#include "net/dns/mock_host_resolver.h"
+#include "net/test/embedded_test_server/embedded_test_server.h"
+#include "third_party/blink/public/common/features.h"
+#include "url/gurl.h"
+
+using brave_shields::ControlType;
+
+namespace {
+
+constexpr char kEmbeddedTestServerDirectory[] = "webgpu";
+
+// Script to await the Promise set by the test HTML pages.
+constexpr char kGPUAdapterInfoScript[] =
+    "(async () => await window.gpuAdapterInfoPromise)()";
+
+// Expected result when all three adapter info fields (vendor, architecture,
+// device) are farbled to empty strings.
+constexpr char kEmptyAdapterInfo[] = ",,";
+
+}  // namespace
+
+class BraveWebGPUFarblingBrowserTest : public InProcessBrowserTest {
+ public:
+  BraveWebGPUFarblingBrowserTest() {
+    scoped_feature_list_.InitWithFeatures(
+        {
+            brave_shields::features::kBraveShowStrictFingerprintingMode,
+            webcompat::features::kBraveWebcompatExceptionsService,
+        },
+        {});
+  }
+
+  void SetUpOnMainThread() override {
+    InProcessBrowserTest::SetUpOnMainThread();
+
+    host_resolver()->AddRule("*", "127.0.0.1");
+    content::SetupCrossSiteRedirector(embedded_test_server());
+
+    base::FilePath test_data_dir;
+    base::PathService::CheckedGet(brave::DIR_TEST_DATA, &test_data_dir);
+    test_data_dir = test_data_dir.AppendASCII(kEmbeddedTestServerDirectory);
+    embedded_test_server()->ServeFilesFromDirectory(test_data_dir);
+
+    ASSERT_TRUE(embedded_test_server()->Start());
+  }
+
+  HostContentSettingsMap* content_settings() {
+    return HostContentSettingsMapFactory::GetForProfile(browser()->profile());
+  }
+
+  void AllowFingerprinting(const std::string& domain) {
+    brave_shields::SetFingerprintingControlType(
+        content_settings(), ControlType::ALLOW,
+        embedded_test_server()->GetURL(domain, "/"));
+  }
+
+  void BlockFingerprinting(const std::string& domain) {
+    brave_shields::SetFingerprintingControlType(
+        content_settings(), ControlType::BLOCK,
+        embedded_test_server()->GetURL(domain, "/"));
+  }
+
+  void SetFingerprintingDefault(const std::string& domain) {
+    brave_shields::SetFingerprintingControlType(
+        content_settings(), ControlType::DEFAULT,
+        embedded_test_server()->GetURL(domain, "/"));
+  }
+
+  content::WebContents* contents() {
+    return browser()->tab_strip_model()->GetActiveWebContents();
+  }
+
+ protected:
+  base::test::ScopedFeatureList scoped_feature_list_;
+};
+
+// Parameterized over whether kWebGLBalancedFingerprintingProtection is enabled,
+// which controls whether BALANCED farbling level scrubs WebGPU adapter info.
+class BraveWebGPUAdapterInfoTest : public BraveWebGPUFarblingBrowserTest,
+                                   public testing::WithParamInterface<bool> {
+ public:
+  BraveWebGPUAdapterInfoTest() {
+    if (GetParam()) {
+      gpu_feature_list_.InitWithFeatures(
+          {blink::features::kWebGLBalancedFingerprintingProtection}, {});
+    } else {
+      gpu_feature_list_.InitWithFeatures(
+          {}, {blink::features::kWebGLBalancedFingerprintingProtection});
+    }
+  }
+
+ private:
+  base::test::ScopedFeatureList gpu_feature_list_;
+};
+
+INSTANTIATE_TEST_SUITE_P(
+    /* no prefix */,
+    BraveWebGPUAdapterInfoTest,
+    testing::Bool(),
+    [](const testing::TestParamInfo<bool>& info) {
+      return info.param ? "WebGLBalancedFingerprintingProtection_Enabled"
+                        : "WebGLBalancedFingerprintingProtection_Disabled";
+    });
+
+// Tests that navigator.gpu.requestAdapter() → adapter.info fields (vendor,
+// architecture, device) are emptied under BALANCED (feature on) and MAXIMUM
+// farbling, and are returned as-is under OFF and BALANCED (feature off).
+IN_PROC_BROWSER_TEST_P(BraveWebGPUAdapterInfoTest, FarbleAdapterInfo) {
+  const std::string domain = "a.com";
+  const GURL url = embedded_test_server()->GetURL(domain, "/adapter-info.html");
+
+  // Farbling level: off — collect the real adapter info as a baseline.
+  AllowFingerprinting(domain);
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
+  const std::string actual_off =
+      EvalJs(contents(), kGPUAdapterInfoScript).ExtractString();
+
+  if (actual_off == "no-gpu" || actual_off == "no-adapter") {
+    GTEST_SKIP() << "WebGPU adapter not available in this environment";
+  }
+
+  // Farbling level: maximum (BlockFingerprinting → BraveFarblingLevel::MAXIMUM)
+  // All three adapter info fields must be empty regardless of the feature flag.
+  BlockFingerprinting(domain);
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
+  EXPECT_EQ(EvalJs(contents(), kGPUAdapterInfoScript).ExtractString(),
+            kEmptyAdapterInfo);
+
+  // Farbling level: balanced (SetFingerprintingDefault →
+  // BraveFarblingLevel::BALANCED). Behaviour depends on the feature flag.
+  SetFingerprintingDefault(domain);
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
+  const std::string actual_balanced =
+      EvalJs(contents(), kGPUAdapterInfoScript).ExtractString();
+
+  if (GetParam()) {
+    // kWebGLBalancedFingerprintingProtection enabled: fields must be empty.
+    EXPECT_EQ(actual_balanced, kEmptyAdapterInfo);
+  } else {
+    // kWebGLBalancedFingerprintingProtection disabled: fields must be real.
+    EXPECT_EQ(actual_balanced, actual_off);
+  }
+}
+
+// Tests that after adapter.requestDevice() the device.adapterInfo fields
+// (vendor, architecture, device) are emptied under BALANCED (feature on) and
+// MAXIMUM farbling, and are returned as-is under OFF and BALANCED (feature
+// off).
+IN_PROC_BROWSER_TEST_P(BraveWebGPUAdapterInfoTest, FarbleDeviceAdapterInfo) {
+  const std::string domain = "a.com";
+  const GURL url =
+      embedded_test_server()->GetURL(domain, "/device-adapter-info.html");
+
+  // Farbling level: off — collect the real adapter info as a baseline.
+  AllowFingerprinting(domain);
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
+  const std::string actual_off =
+      EvalJs(contents(), kGPUAdapterInfoScript).ExtractString();
+
+  if (actual_off == "no-gpu" || actual_off == "no-adapter" ||
+      actual_off == "no-device") {
+    GTEST_SKIP() << "WebGPU device not available in this environment";
+  }
+
+  // Farbling level: maximum (BlockFingerprinting → BraveFarblingLevel::MAXIMUM)
+  // All three adapter info fields must be empty regardless of the feature flag.
+  BlockFingerprinting(domain);
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
+  EXPECT_EQ(EvalJs(contents(), kGPUAdapterInfoScript).ExtractString(),
+            kEmptyAdapterInfo);
+
+  // Farbling level: balanced (SetFingerprintingDefault →
+  // BraveFarblingLevel::BALANCED). Behaviour depends on the feature flag.
+  SetFingerprintingDefault(domain);
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
+  const std::string actual_balanced =
+      EvalJs(contents(), kGPUAdapterInfoScript).ExtractString();
+
+  if (GetParam()) {
+    // kWebGLBalancedFingerprintingProtection enabled: fields must be empty.
+    EXPECT_EQ(actual_balanced, kEmptyAdapterInfo);
+  } else {
+    // kWebGLBalancedFingerprintingProtection disabled: fields must be real.
+    EXPECT_EQ(actual_balanced, actual_off);
+  }
+}

--- a/chromium_src/third_party/blink/public/common/features.h
+++ b/chromium_src/third_party/blink/public/common/features.h
@@ -20,6 +20,12 @@ BLINK_COMMON_EXPORT BASE_DECLARE_FEATURE(kBraveBlockScreenFingerprinting);
 BLINK_COMMON_EXPORT BASE_DECLARE_FEATURE(kBraveGlobalPrivacyControl);
 BLINK_COMMON_EXPORT BASE_DECLARE_FEATURE(kBraveRoundTimeStamps);
 BLINK_COMMON_EXPORT BASE_DECLARE_FEATURE(kRestrictEventSourcePool);
+// TODO(https://github.com/brave/brave-browser/issues/55927): This was
+// originally started with only WebGL fingerprinting protections, but it got
+// trickled over to WebGPU as well. Consider updating the name here to be
+// reflective of both webgl and webgpu protections, taking into account any
+// running experiments such as
+// https://github.com/brave/brave-variations/blob/main/studies/WebGLBalancedFingerprintingProtection.json5
 BLINK_COMMON_EXPORT BASE_DECLARE_FEATURE(
     kWebGLBalancedFingerprintingProtection);
 

--- a/chromium_src/third_party/blink/renderer/modules/webgpu/gpu_adapter.cc
+++ b/chromium_src/third_party/blink/renderer/modules/webgpu/gpu_adapter.cc
@@ -5,15 +5,21 @@
 
 #include "brave/third_party/blink/renderer/core/farbling/brave_session_cache.h"
 #include "third_party/blink/public/common/features.h"
+#include "third_party/blink/renderer/platform/wtf/text/wtf_string.h"
 
 namespace blink {
 
+namespace {
+// This class allows to scrub the various device identifiers in the
+// GPUAdapterInfo depending on the farbling level.
 class BraveScrubWebGpuAdapterInfo {
  public:
   BraveScrubWebGpuAdapterInfo(ExecutionContext* context,
                               String& vendor,
                               String& architecture,
                               String& device) {
+    // TODO(https://github.com/brave/brave-browser/issues/55927): Update
+    // BRAVE_WEBCOMPAT_WEBGL to BRAVE_WEBCOMPAT_WEBGPU when we have the support.
     BraveFarblingLevel level = brave::GetBraveFarblingLevelFor(
         context, ContentSettingsType::BRAVE_WEBCOMPAT_WEBGL,
         BraveFarblingLevel::OFF);
@@ -38,6 +44,7 @@ class BraveScrubWebGpuAdapterInfo {
 
   ~BraveScrubWebGpuAdapterInfo() = default;
 };
+}  // namespace
 
 }  // namespace blink
 

--- a/chromium_src/third_party/blink/renderer/modules/webgpu/gpu_adapter.cc
+++ b/chromium_src/third_party/blink/renderer/modules/webgpu/gpu_adapter.cc
@@ -11,43 +11,44 @@ namespace blink {
 
 namespace {
 
-String ApplyFarbling(ExecutionContext* context, const String& s) {
-  // TODO(https://github.com/brave/brave-browser/issues/55927): Update
-  // BRAVE_WEBCOMPAT_WEBGL to BRAVE_WEBCOMPAT_WEBGPU when we have the support.
-  BraveFarblingLevel level = brave::GetBraveFarblingLevelFor(
-      context, ContentSettingsType::BRAVE_WEBCOMPAT_WEBGL,
-      BraveFarblingLevel::OFF);
-
-  switch (level) {
-    case BraveFarblingLevel::OFF:
-      return s;
-    case BraveFarblingLevel::BALANCED:
-      return base::FeatureList::IsEnabled(
-                 blink::features::kWebGLBalancedFingerprintingProtection)
-                 ? String()
-                 : s;
-    case BraveFarblingLevel::MAXIMUM:
-      return String();
-  }
-  return s;
-}
-
 // This class allows to scrub the various device identifiers in the
 // GPUAdapterInfo depending on the farbling level.
+// TODO(https://github.com/brave/brave-browser/issues/55927): Update
+// BRAVE_WEBCOMPAT_WEBGL to BRAVE_WEBCOMPAT_WEBGPU when we have the support.
 class BraveScrubWebGpuAdapterInfo {
  public:
   BraveScrubWebGpuAdapterInfo(ExecutionContext* context,
                               String& vendor,
                               String& architecture,
                               String& device)
-      : reset_vendor_(&vendor, ApplyFarbling(context, vendor)),
+      : farbling_level_(brave::GetBraveFarblingLevelFor(
+            context,
+            ContentSettingsType::BRAVE_WEBCOMPAT_WEBGL,
+            BraveFarblingLevel::OFF)),
+        reset_vendor_(&vendor, ApplyFarbling(farbling_level_, vendor)),
         reset_architecture_(&architecture,
-                            ApplyFarbling(context, architecture)),
-        reset_device_(&device, ApplyFarbling(context, device)) {}
+                            ApplyFarbling(farbling_level_, architecture)),
+        reset_device_(&device, ApplyFarbling(farbling_level_, device)) {}
 
   ~BraveScrubWebGpuAdapterInfo() = default;
 
+  String ApplyFarbling(const BraveFarblingLevel level, const String& s) {
+    switch (level) {
+      case BraveFarblingLevel::OFF:
+        return s;
+      case BraveFarblingLevel::BALANCED:
+        return base::FeatureList::IsEnabled(
+                   blink::features::kWebGLBalancedFingerprintingProtection)
+                   ? String()
+                   : s;
+      case BraveFarblingLevel::MAXIMUM:
+        return String();
+    }
+    return s;
+  }
+
  private:
+  const BraveFarblingLevel farbling_level_;
   const base::AutoReset<String> reset_vendor_;
   const base::AutoReset<String> reset_architecture_;
   const base::AutoReset<String> reset_device_;

--- a/chromium_src/third_party/blink/renderer/modules/webgpu/gpu_adapter.cc
+++ b/chromium_src/third_party/blink/renderer/modules/webgpu/gpu_adapter.cc
@@ -1,0 +1,36 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/third_party/blink/renderer/core/farbling/brave_session_cache.h"
+#include "third_party/blink/public/common/features.h"
+
+// clang-format off
+#define BRAVE_CREATE_WEBGPU_ADAPTER_IMPL                                       \
+  ExecutionContext* context = gpu_->GetExecutionContext();                     \
+  BraveFarblingLevel level = brave::GetBraveFarblingLevelFor(                  \
+      context, ContentSettingsType::BRAVE_WEBCOMPAT_WEBGL,                     \
+      BraveFarblingLevel::OFF);                                                \
+  auto farble = [&](const String& s) -> String {                               \
+    switch (level) {                                                           \
+      case BraveFarblingLevel::OFF:                                            \
+        return s;                                                              \
+      case BraveFarblingLevel::BALANCED:                                       \
+        return base::FeatureList::IsEnabled(                                   \
+                   blink::features::kWebGLBalancedFingerprintingProtection)    \
+                   ? String()                                                  \
+                   : s;                                                        \
+      case BraveFarblingLevel::MAXIMUM:                                        \
+        return String();                                                       \
+    }                                                                          \
+    return s;                                                                  \
+  };                                                                           \
+  base::AutoReset<String> reset_vendor(&vendor_, farble(vendor_));             \
+  base::AutoReset<String> reset_arch(&architecture_, farble(architecture_));   \
+  base::AutoReset<String> reset_device(&device_, farble(device_));
+// clang-format on
+
+#include <third_party/blink/renderer/modules/webgpu/gpu_adapter.cc>
+
+#undef BRAVE_CREATE_WEBGPU_ADAPTER_IMPL

--- a/chromium_src/third_party/blink/renderer/modules/webgpu/gpu_adapter.cc
+++ b/chromium_src/third_party/blink/renderer/modules/webgpu/gpu_adapter.cc
@@ -25,15 +25,15 @@ class BraveScrubWebGpuAdapterInfo {
             context,
             ContentSettingsType::BRAVE_WEBCOMPAT_WEBGL,
             BraveFarblingLevel::OFF)),
-        reset_vendor_(&vendor, ApplyFarbling(farbling_level_, vendor)),
-        reset_architecture_(&architecture,
-                            ApplyFarbling(farbling_level_, architecture)),
-        reset_device_(&device, ApplyFarbling(farbling_level_, device)) {}
+        reset_vendor_(&vendor, ApplyFarbling(vendor)),
+        reset_architecture_(&architecture, ApplyFarbling(architecture)),
+        reset_device_(&device, ApplyFarbling(device)) {}
 
   ~BraveScrubWebGpuAdapterInfo() = default;
 
-  String ApplyFarbling(const BraveFarblingLevel level, const String& s) {
-    switch (level) {
+ private:
+  String ApplyFarbling(const String& s) {
+    switch (farbling_level_) {
       case BraveFarblingLevel::OFF:
         return s;
       case BraveFarblingLevel::BALANCED:
@@ -47,7 +47,6 @@ class BraveScrubWebGpuAdapterInfo {
     return s;
   }
 
- private:
   const BraveFarblingLevel farbling_level_;
   const base::AutoReset<String> reset_vendor_;
   const base::AutoReset<String> reset_architecture_;

--- a/chromium_src/third_party/blink/renderer/modules/webgpu/gpu_adapter.cc
+++ b/chromium_src/third_party/blink/renderer/modules/webgpu/gpu_adapter.cc
@@ -6,30 +6,44 @@
 #include "brave/third_party/blink/renderer/core/farbling/brave_session_cache.h"
 #include "third_party/blink/public/common/features.h"
 
-// clang-format off
-#define BRAVE_SCRUB_WEBGPU_ADAPTER_INFO                                       \
-  ExecutionContext* context = gpu_->GetExecutionContext();                     \
-  BraveFarblingLevel level = brave::GetBraveFarblingLevelFor(                  \
-      context, ContentSettingsType::BRAVE_WEBCOMPAT_WEBGL,                     \
-      BraveFarblingLevel::OFF);                                                \
-  auto farble = [&](const String& s) -> String {                               \
-    switch (level) {                                                           \
-      case BraveFarblingLevel::OFF:                                            \
-        return s;                                                              \
-      case BraveFarblingLevel::BALANCED:                                       \
-        return base::FeatureList::IsEnabled(                                   \
-                   blink::features::kWebGLBalancedFingerprintingProtection)    \
-                   ? String()                                                  \
-                   : s;                                                        \
-      case BraveFarblingLevel::MAXIMUM:                                        \
-        return String();                                                       \
-    }                                                                          \
-    return s;                                                                  \
-  };                                                                           \
-  base::AutoReset<String> reset_vendor(&vendor_, farble(vendor_));             \
-  base::AutoReset<String> reset_arch(&architecture_, farble(architecture_));   \
-  base::AutoReset<String> reset_device(&device_, farble(device_));
-// clang-format on
+namespace blink {
+
+class BraveScrubWebGpuAdapterInfo {
+ public:
+  BraveScrubWebGpuAdapterInfo(ExecutionContext* context,
+                              String& vendor,
+                              String& architecture,
+                              String& device) {
+    BraveFarblingLevel level = brave::GetBraveFarblingLevelFor(
+        context, ContentSettingsType::BRAVE_WEBCOMPAT_WEBGL,
+        BraveFarblingLevel::OFF);
+    auto farble = [&](const String& s) -> String {
+      switch (level) {
+        case BraveFarblingLevel::OFF:
+          return s;
+        case BraveFarblingLevel::BALANCED:
+          return base::FeatureList::IsEnabled(
+                     blink::features::kWebGLBalancedFingerprintingProtection)
+                     ? String()
+                     : s;
+        case BraveFarblingLevel::MAXIMUM:
+          return String();
+      }
+      return s;
+    };
+    vendor = farble(vendor);
+    architecture = farble(architecture);
+    device = farble(device);
+  }
+
+  ~BraveScrubWebGpuAdapterInfo() = default;
+};
+
+}  // namespace blink
+
+#define BRAVE_SCRUB_WEBGPU_ADAPTER_INFO                             \
+  BraveScrubWebGpuAdapterInfo(gpu_->GetExecutionContext(), vendor_, \
+                              architecture_, device_);
 
 #include <third_party/blink/renderer/modules/webgpu/gpu_adapter.cc>
 

--- a/chromium_src/third_party/blink/renderer/modules/webgpu/gpu_adapter.cc
+++ b/chromium_src/third_party/blink/renderer/modules/webgpu/gpu_adapter.cc
@@ -7,7 +7,7 @@
 #include "third_party/blink/public/common/features.h"
 
 // clang-format off
-#define BRAVE_CREATE_WEBGPU_ADAPTER_IMPL                                       \
+#define BRAVE_SCRUB_WEBGPU_ADAPTER_INFO                                       \
   ExecutionContext* context = gpu_->GetExecutionContext();                     \
   BraveFarblingLevel level = brave::GetBraveFarblingLevelFor(                  \
       context, ContentSettingsType::BRAVE_WEBCOMPAT_WEBGL,                     \
@@ -33,4 +33,4 @@
 
 #include <third_party/blink/renderer/modules/webgpu/gpu_adapter.cc>
 
-#undef BRAVE_CREATE_WEBGPU_ADAPTER_IMPL
+#undef BRAVE_SCRUB_WEBGPU_ADAPTER_INFO

--- a/chromium_src/third_party/blink/renderer/modules/webgpu/gpu_adapter.cc
+++ b/chromium_src/third_party/blink/renderer/modules/webgpu/gpu_adapter.cc
@@ -10,6 +10,28 @@
 namespace blink {
 
 namespace {
+
+String ApplyFarbling(ExecutionContext* context, const String& s) {
+  // TODO(https://github.com/brave/brave-browser/issues/55927): Update
+  // BRAVE_WEBCOMPAT_WEBGL to BRAVE_WEBCOMPAT_WEBGPU when we have the support.
+  BraveFarblingLevel level = brave::GetBraveFarblingLevelFor(
+      context, ContentSettingsType::BRAVE_WEBCOMPAT_WEBGL,
+      BraveFarblingLevel::OFF);
+
+  switch (level) {
+    case BraveFarblingLevel::OFF:
+      return s;
+    case BraveFarblingLevel::BALANCED:
+      return base::FeatureList::IsEnabled(
+                 blink::features::kWebGLBalancedFingerprintingProtection)
+                 ? String()
+                 : s;
+    case BraveFarblingLevel::MAXIMUM:
+      return String();
+  }
+  return s;
+}
+
 // This class allows to scrub the various device identifiers in the
 // GPUAdapterInfo depending on the farbling level.
 class BraveScrubWebGpuAdapterInfo {
@@ -17,32 +39,18 @@ class BraveScrubWebGpuAdapterInfo {
   BraveScrubWebGpuAdapterInfo(ExecutionContext* context,
                               String& vendor,
                               String& architecture,
-                              String& device) {
-    // TODO(https://github.com/brave/brave-browser/issues/55927): Update
-    // BRAVE_WEBCOMPAT_WEBGL to BRAVE_WEBCOMPAT_WEBGPU when we have the support.
-    BraveFarblingLevel level = brave::GetBraveFarblingLevelFor(
-        context, ContentSettingsType::BRAVE_WEBCOMPAT_WEBGL,
-        BraveFarblingLevel::OFF);
-    auto farble = [&](const String& s) -> String {
-      switch (level) {
-        case BraveFarblingLevel::OFF:
-          return s;
-        case BraveFarblingLevel::BALANCED:
-          return base::FeatureList::IsEnabled(
-                     blink::features::kWebGLBalancedFingerprintingProtection)
-                     ? String()
-                     : s;
-        case BraveFarblingLevel::MAXIMUM:
-          return String();
-      }
-      return s;
-    };
-    vendor = farble(vendor);
-    architecture = farble(architecture);
-    device = farble(device);
-  }
+                              String& device)
+      : reset_vendor_(&vendor, ApplyFarbling(context, vendor)),
+        reset_architecture_(&architecture,
+                            ApplyFarbling(context, architecture)),
+        reset_device_(&device, ApplyFarbling(context, device)) {}
 
   ~BraveScrubWebGpuAdapterInfo() = default;
+
+ private:
+  const base::AutoReset<String> reset_vendor_;
+  const base::AutoReset<String> reset_architecture_;
+  const base::AutoReset<String> reset_device_;
 };
 }  // namespace
 

--- a/patches/third_party-blink-renderer-modules-webgpu-gpu_adapter.cc.patch
+++ b/patches/third_party-blink-renderer-modules-webgpu-gpu_adapter.cc.patch
@@ -2,15 +2,6 @@ diff --git a/third_party/blink/renderer/modules/webgpu/gpu_adapter.cc b/third_pa
 index 4e4ca8dcb4febd1fc8eb132e24cbf1d98b41aef7..c0750443df1c5dbadd5ea2b3d568e6a0b61c5496 100644
 --- a/third_party/blink/renderer/modules/webgpu/gpu_adapter.cc
 +++ b/third_party/blink/renderer/modules/webgpu/gpu_adapter.cc
-@@ -45,7 +45,7 @@ GPUSupportedFeatures* MakeFeatureNameSet(wgpu::Adapter adapter) {
-     if (feature_name_enum_optional) {
-       features->AddFeatureName(
-           V8GPUFeatureName(feature_name_enum_optional.value()));
--      }
-+    }
-   }
-   return features;
- }
 @@ -124,7 +124,8 @@ GPUAdapter::GPUAdapter(
  
  GPUAdapterInfo* GPUAdapter::CreateAdapterInfoForAdapter() {

--- a/patches/third_party-blink-renderer-modules-webgpu-gpu_adapter.cc.patch
+++ b/patches/third_party-blink-renderer-modules-webgpu-gpu_adapter.cc.patch
@@ -1,13 +1,12 @@
 diff --git a/third_party/blink/renderer/modules/webgpu/gpu_adapter.cc b/third_party/blink/renderer/modules/webgpu/gpu_adapter.cc
-index 4e4ca8dcb4febd1fc8eb132e24cbf1d98b41aef7..c0750443df1c5dbadd5ea2b3d568e6a0b61c5496 100644
+index 4e4ca8dcb4febd1fc8eb132e24cbf1d98b41aef7..b0a3567bb556e8dc45a80ff86b9cce9628b9ca53 100644
 --- a/third_party/blink/renderer/modules/webgpu/gpu_adapter.cc
 +++ b/third_party/blink/renderer/modules/webgpu/gpu_adapter.cc
-@@ -124,7 +124,8 @@ GPUAdapter::GPUAdapter(
- 
- GPUAdapterInfo* GPUAdapter::CreateAdapterInfoForAdapter() {
-   bool is_fallback_adapter = adapter_type_ == wgpu::AdapterType::CPU;
-+  BRAVE_CREATE_WEBGPU_ADAPTER_IMPL
- 
-   GPUAdapterInfo* info;
-   if (RuntimeEnabledFeatures::WebGPUDeveloperFeaturesEnabled()) {
-     // If WebGPU developer features have been enabled then provide all available
+@@ -143,6 +143,7 @@ GPUAdapterInfo* GPUAdapter::CreateAdapterInfoForAdapter() {
+       info->AppendMemoryHeapInfo(MakeGarbageCollected<GPUMemoryHeapInfo>(m));
+     }
+   } else {
++    BRAVE_SCRUB_WEBGPU_ADAPTER_INFO
+     info = MakeGarbageCollected<GPUAdapterInfo>(
+         vendor_, architecture_, subgroup_min_size_, subgroup_max_size_,
+         is_fallback_adapter);

--- a/patches/third_party-blink-renderer-modules-webgpu-gpu_adapter.cc.patch
+++ b/patches/third_party-blink-renderer-modules-webgpu-gpu_adapter.cc.patch
@@ -1,0 +1,22 @@
+diff --git a/third_party/blink/renderer/modules/webgpu/gpu_adapter.cc b/third_party/blink/renderer/modules/webgpu/gpu_adapter.cc
+index 4e4ca8dcb4febd1fc8eb132e24cbf1d98b41aef7..c0750443df1c5dbadd5ea2b3d568e6a0b61c5496 100644
+--- a/third_party/blink/renderer/modules/webgpu/gpu_adapter.cc
++++ b/third_party/blink/renderer/modules/webgpu/gpu_adapter.cc
+@@ -45,7 +45,7 @@ GPUSupportedFeatures* MakeFeatureNameSet(wgpu::Adapter adapter) {
+     if (feature_name_enum_optional) {
+       features->AddFeatureName(
+           V8GPUFeatureName(feature_name_enum_optional.value()));
+-      }
++    }
+   }
+   return features;
+ }
+@@ -124,7 +124,8 @@ GPUAdapter::GPUAdapter(
+ 
+ GPUAdapterInfo* GPUAdapter::CreateAdapterInfoForAdapter() {
+   bool is_fallback_adapter = adapter_type_ == wgpu::AdapterType::CPU;
++  BRAVE_CREATE_WEBGPU_ADAPTER_IMPL
+ 
+   GPUAdapterInfo* info;
+   if (RuntimeEnabledFeatures::WebGPUDeveloperFeaturesEnabled()) {
+     // If WebGPU developer features have been enabled then provide all available

--- a/test/data/webgpu/adapter-info.html
+++ b/test/data/webgpu/adapter-info.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>WebGPU adapter info test</title>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <script>
+      window.gpuAdapterInfoPromise = (async () => {
+        if (!navigator.gpu) {
+          return 'no-gpu';
+        }
+        const adapter = await navigator.gpu.requestAdapter({
+          featureLevel: 'compatibility',
+        });
+        if (!adapter) {
+          return 'no-adapter';
+        }
+        const info = adapter.info;
+        return info.vendor + ',' + info.architecture + ',' + info.device;
+      })();
+    </script>
+  </body>
+</html>

--- a/test/data/webgpu/device-adapter-info.html
+++ b/test/data/webgpu/device-adapter-info.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>WebGPU device adapter info test</title>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <script>
+      window.gpuAdapterInfoPromise = (async () => {
+        if (!navigator.gpu) {
+          return 'no-gpu';
+        }
+        const adapter = await navigator.gpu.requestAdapter({
+          featureLevel: 'compatibility',
+        });
+        if (!adapter) {
+          return 'no-adapter';
+        }
+        const device = await adapter.requestDevice();
+        if (!device) {
+          return 'no-device';
+        }
+        const info = device.adapterInfo;
+        return info.vendor + ',' + info.architecture + ',' + info.device;
+      })();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
This change scrubs the device related info from [GPUAdapterInfo](https://developer.mozilla.org/en-US/docs/Web/API/GPUAdapterInfo) namely `vendor`, `architecture` and `device`.  

This change adds a patch to the upstream [gpu_adapter.cc](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/modules/webgpu/gpu_adapter.cc;l=125) to intercept right before the moment we create the gpu adapter info, to scrub out these attributes. It was not possible to do it in [gpu_adapter_info.cc](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/modules/webgpu/gpu_adapter_info.cc;) as it lacked any context around `ExecutionContext` which was needed to get the farbling level. 

Below are the final behaviour with different farbling levels after this change:

#### Farbling "off"
- No change in behaviour i.e no scrubbing will occur. 

#### Farbling "balanced" with [WebGLBalancedFingerprintingProtection](https://sourcegraph.com/r/github.com/brave/brave-core/-/blob/chromium_src/third_party/blink/common/features.cc?L63) **enabled**
- Scrub the device related info from GPUAdapterInfo. 

#### Farbling "balanced" with [WebGLBalancedFingerprintingProtection](https://sourcegraph.com/r/github.com/brave/brave-core/-/blob/chromium_src/third_party/blink/common/features.cc?L63) **disabled**
-  No change in behaviour i.e no scrubbing will occur. 

#### Farbling "maximum": 
- Scrub the device related info from GPUAdapterInfo. **Note** that this is a new behaviour and not to tied to any feature flag. For maximum farbling it makes sense to have the maximum protection. 

### Demo

https://github.com/user-attachments/assets/536fa971-f1e0-4c4e-9b93-cebf93347441

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/55677

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
