### PR TITLE
[AI Chat] Address review nits on Conversation API client

### DIFF
--- a/components/ai_chat/core/browser/engine/conversation_api_client.cc
+++ b/components/ai_chat/core/browser/engine/conversation_api_client.cc
@@ -41,7 +41,6 @@
 #include "net/http/http_status_code.h"
 #include "net/traffic_annotation/network_traffic_annotation.h"
 #include "services/network/public/cpp/shared_url_loader_factory.h"
-#include "third_party/abseil-cpp/absl/functional/overload.h"
 
 namespace ai_chat {
 

--- a/components/ai_chat/core/browser/engine/engine_consumer_conversation_api.cc
+++ b/components/ai_chat/core/browser/engine/engine_consumer_conversation_api.cc
@@ -121,6 +121,10 @@ void EngineConsumerConversationAPI::GenerateRewriteSuggestion(
                        std::move(completed_callback));
 }
 
+void EngineConsumerConversationAPI::SanitizeInput(std::string& input) {
+  // Handle by server.
+}
+
 void EngineConsumerConversationAPI::ClearAllQueries() {
   api_->ClearAllQueries();
 }

--- a/components/ai_chat/core/browser/engine/engine_consumer_conversation_api.h
+++ b/components/ai_chat/core/browser/engine/engine_consumer_conversation_api.h
@@ -77,7 +77,7 @@ class EngineConsumerConversationAPI : public EngineConsumer {
       const ConversationHistory& conversation_history,
       GenerationCompletedCallback completed_callback) override;
 
-  void SanitizeInput(std::string& input) override {}  // Handle by server.
+  void SanitizeInput(std::string& input) override;
   void ClearAllQueries() override;
   bool SupportsDeltaTextResponses() const override;
   bool RequiresClientSideTitleGeneration() const override;


### PR DESCRIPTION
Address review nits from https://github.com/brave/brave-core/pull/36767 on our current code.

- Drop unused absl/functional/overload.h include in conversation_api_client.cc (IWYU / CS-001).
- Move EngineConsumerConversationAPI::SanitizeInput out of the header into the .cc file (CS-013).

No issue created as it's just a small follow-up for nit fixes.