### PR TITLE
[Android] Surface Play in-app messages for subscription events

### DIFF
--- a/android/java/org/chromium/chrome/browser/app/BraveActivity.java
+++ b/android/java/org/chromium/chrome/browser/app/BraveActivity.java
@@ -446,6 +446,12 @@ public abstract class BraveActivity extends ChromeActivity
                 mMiscAndroidMetrics.recordIntentUrl(resumeIntent.getData().toString());
             }
         }
+
+        Profile profile = mTabModelProfileSupplier.get();
+        if (profile != null) {
+            InAppPurchaseWrapper.getInstance()
+                    .maybeShowSubscriptionInAppMessages(BraveActivity.this, profile);
+        }
     }
 
     @Override

--- a/android/java/org/chromium/chrome/browser/billing/InAppPurchaseWrapper.java
+++ b/android/java/org/chromium/chrome/browser/billing/InAppPurchaseWrapper.java
@@ -22,12 +22,15 @@ import com.android.billingclient.api.BillingClientStateListener;
 import com.android.billingclient.api.BillingFlowParams;
 import com.android.billingclient.api.BillingResult;
 import com.android.billingclient.api.ConsumeParams;
+import com.android.billingclient.api.InAppMessageParams;
 import com.android.billingclient.api.ProductDetails;
 import com.android.billingclient.api.Purchase;
 import com.android.billingclient.api.PurchasesUpdatedListener;
 import com.android.billingclient.api.QueryProductDetailsParams;
 import com.android.billingclient.api.QueryPurchasesParams;
 
+import org.chromium.base.ApplicationState;
+import org.chromium.base.ApplicationStatus;
 import org.chromium.base.ContextUtils;
 import org.chromium.base.Log;
 import org.chromium.base.ThreadUtils;
@@ -181,6 +184,8 @@ public class InAppPurchaseWrapper {
     }
 
     private boolean mSuppressToasts;
+    private boolean mInAppMessagesShownThisForeground;
+    private boolean mAppStateListenerRegistered;
 
     private InAppPurchaseWrapper() {}
 
@@ -716,6 +721,77 @@ public class InAppPurchaseWrapper {
         return productIds.contains(ORIGIN_PERPETUAL_PURCHASE)
                 || productIds.contains(ORIGIN_NIGHTLY_PERPETUAL_PURCHASE)
                 || productIds.contains(ORIGIN_BETA_PERPETUAL_PURCHASE);
+    }
+
+    /**
+     * Asks Play to surface any pending in-app messages for the user's subscriptions (failed
+     * renewals, opt-in price-rise consent). Gated on the user having an active Play subscription to
+     * VPN or Leo, and throttled to one call per foreground session. The throttle is reset
+     * automatically when the app is fully backgrounded; callers do not need to manage it.
+     */
+    public void maybeShowSubscriptionInAppMessages(Activity activity, Profile profile) {
+        if (mInAppMessagesShownThisForeground) {
+            return;
+        }
+        boolean hasVpnSubscription = BraveVpnPrefUtils.isSubscriptionPurchase();
+        boolean hasLeoSubscription = BraveLeoPrefUtils.getIsSubscriptionActive(profile);
+        if (!hasVpnSubscription && !hasLeoSubscription) {
+            return;
+        }
+        // Register the throttle-reset listener lazily, only after confirming
+        // this user actually has a subscription. Non-subscribers never pay any
+        // listener cost.
+        ensureAppStateListenerRegistered();
+        mInAppMessagesShownThisForeground = true;
+        showInAppMessages(activity);
+    }
+
+    private void ensureAppStateListenerRegistered() {
+        if (mAppStateListenerRegistered) {
+            return;
+        }
+        mAppStateListenerRegistered = true;
+        // Clear the per-foreground throttle only when *all* activities are
+        // stopped, i.e. the app is truly backgrounded. In-app navigation
+        // (BraveActivity -> Settings -> back) stays in HAS_RUNNING_ACTIVITIES
+        // and must not re-trigger a Play call.
+        ApplicationStatus.registerApplicationStateListener(
+                state -> {
+                    if ((state == ApplicationState.HAS_STOPPED_ACTIVITIES
+                                    || state == ApplicationState.HAS_DESTROYED_ACTIVITIES)
+                            && mInAppMessagesShownThisForeground) {
+                        mInAppMessagesShownThisForeground = false;
+                    }
+                });
+    }
+
+    /**
+     * Surfaces Play in-app messages for subscription-related events: declined payment methods
+     * (account hold / grace period) and opt-in price-rise consent. Play renders any pending message
+     * as a dialog above {@code activity}; if there is nothing to show the callback returns
+     * NO_ACTION_NEEDED and the user sees nothing. Only SUBS products are eligible — Origin (INAPP)
+     * is excluded by Play.
+     */
+    private void showInAppMessages(Activity activity) {
+        InAppMessageParams params =
+                InAppMessageParams.newBuilder()
+                        .addInAppMessageCategoryToShow(
+                                InAppMessageParams.InAppMessageCategoryId.TRANSACTIONAL)
+                        .build();
+
+        MutableLiveData<Boolean> _billingConnectionState = new MutableLiveData<>();
+        LiveData<Boolean> billingConnectionState = _billingConnectionState;
+        startBillingServiceConnection(_billingConnectionState);
+        LiveDataUtil.observeOnce(
+                billingConnectionState,
+                isConnected -> {
+                    if (isConnected && mBillingClient != null) {
+                        mBillingClient.showInAppMessages(
+                                activity, params, result -> endConnection());
+                    } else {
+                        endConnection();
+                    }
+                });
     }
 
     private PurchasesUpdatedListener getPurchasesUpdatedListener(Context context) {


### PR DESCRIPTION
Calls `BillingClient.showInAppMessages` on app foreground so the Play Store can render its recovery dialog (declined payment, opt-in price change) on top of Brave. Gated on the user having an active VPN or Leo subscription, throttled to one call per real foreground session via an `ApplicationStatus` listener that resets only on `HAS_STOPPED_ACTIVITIES` / `HAS_DESTROYED_ACTIVITIES` — in-app navigation does not re-trigger.

Resolves: https://github.com/brave/brave-browser/issues/55735

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

I didn't find any way how to test that unfortunately, that's why I put `QA/No` label on the issue. I checked the flow via logs and the thing is that if we don't any real event(price change/card decline and so on) the dialog just isn't shown. I checked that we call the function and everything is fine. So we need a real event to check that to confirm it works.