### PR TITLE
[Android] Fix: Sync is impossible to set up without Google Play Services

### DIFF
--- a/android/java/org/chromium/chrome/browser/qrreader/QRCodeCameraManager.java
+++ b/android/java/org/chromium/chrome/browser/qrreader/QRCodeCameraManager.java
@@ -61,6 +61,7 @@ public class QRCodeCameraManager
     private @Nullable CameraSourcePreview mCameraSourcePreview;
     private @Nullable DisplayManager mDisplayManager;
     private int mLastRotation = INITIAL_ROTATION;
+    private boolean mErrorShown;
     private final Callback mCallback;
     private final HostProvider mHostProvider;
 
@@ -212,7 +213,11 @@ public class QRCodeCameraManager
                 if (mCallback.onPlayServicesUnavailable(dlg)) {
                     return false;
                 }
+                if (mErrorShown) {
+                    return false;
+                }
                 if (dlg != null) {
+                    mErrorShown = true;
                     dlg.show();
                 }
             }

--- a/android/java/org/chromium/chrome/browser/qrreader/QRCodeCameraManager.java
+++ b/android/java/org/chromium/chrome/browser/qrreader/QRCodeCameraManager.java
@@ -61,7 +61,7 @@ public class QRCodeCameraManager
     private @Nullable CameraSourcePreview mCameraSourcePreview;
     private @Nullable DisplayManager mDisplayManager;
     private int mLastRotation = INITIAL_ROTATION;
-    private boolean mErrorShown;
+    private boolean mGooglePlayServicesUnavailableDialogShown;
     private final Callback mCallback;
     private final HostProvider mHostProvider;
 
@@ -213,11 +213,11 @@ public class QRCodeCameraManager
                 if (mCallback.onPlayServicesUnavailable(dlg)) {
                     return false;
                 }
-                if (mErrorShown) {
+                if (mGooglePlayServicesUnavailableDialogShown) {
                     return false;
                 }
                 if (dlg != null) {
-                    mErrorShown = true;
+                    mGooglePlayServicesUnavailableDialogShown = true;
                     dlg.show();
                 }
             }


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves brave/brave-browser#11477

Fix setting up Sync by QRcode without Google Play Services

Before: the error dialog was popping up repeatedly, making it impossible to set up Sync.
Now: only show the error dialog once, making it possible to set up Sync by code words.

Tested manually on my LineageOS 19 device.
<img width="216" height="384" alt="1" src="https://github.com/user-attachments/assets/6910970e-27b8-412c-9a25-b239f1bd7326" /> <img width="216" height="384" alt="2" src="https://github.com/user-attachments/assets/44956c34-57e9-49e6-8543-6273e473721b" />