### PR TITLE
Add a workaround to fix build hangs because of upstream tsc/node issues.

### DIFF
--- a/build/config/siso/brave_siso_config.star
+++ b/build/config/siso/brave_siso_config.star
@@ -341,6 +341,7 @@ def __wrap_python_with_chromium_src_inputs_handler(ctx, rule, handlers):
         handlers[new_handler_name] = __create_handler([
             "brave/script/brave_chromium_utils.py",
             "brave/script/override_utils.py",
+            "brave/tools/typescript/tsc_timeout_retry.py",
         ])
 
     rule["handler"] = new_handler_name

--- a/chromium_src/third_party/devtools-frontend/src/scripts/build/typescript/ts_library.py
+++ b/chromium_src/third_party/devtools-frontend/src/scripts/build/typescript/ts_library.py
@@ -10,6 +10,15 @@ import re
 import brave_chromium_utils
 import override_utils
 
+with brave_chromium_utils.sys_path('//brave/tools/typescript'):
+    import tsc_timeout_retry
+
+
+@override_utils.override_function(globals())
+def main(original_function):
+    with tsc_timeout_retry.patch_subprocess_with_timeout_retry():
+        return original_function()
+
 
 def ensure_hardlink(src, dst):
     src = os.path.abspath(src) if not os.path.isabs(src) else src

--- a/chromium_src/tools/typescript/ts_library.py
+++ b/chromium_src/tools/typescript/ts_library.py
@@ -11,7 +11,11 @@ import shlex
 
 import override_utils
 
-from brave_chromium_utils import get_webui_overridden_but_referenced_files
+from brave_chromium_utils import get_webui_overridden_but_referenced_files, sys_path
+
+with sys_path('//brave/tools/typescript'):
+    import tsc_timeout_retry
+
 
 def is_gen_brave_dir(out_dir):
     GEN_BRAVE = 'gen/brave'
@@ -58,12 +62,14 @@ def main(original_function, argv):
             #
             # "error TS5055: Cannot write file '...' because it would overwrite
             # input file."
-            if args.root_dir != args.out_dir and is_gen_brave_dir(args.out_dir):
+            if args.root_dir != args.out_dir and is_gen_brave_dir(
+                    args.out_dir):
                 to_check = os.path.join(args.out_dir, pathname + '.d.ts')
                 if os.path.exists(to_check):
                     os.remove(to_check)
 
-    original_function(argv)
+    with tsc_timeout_retry.patch_subprocess_with_timeout_retry():
+        original_function(argv)
 
     manifest_path = os.path.join(args.gen_dir,
                                  f'{args.output_suffix}_manifest.json')

--- a/tools/typescript/tsc_timeout_retry.py
+++ b/tools/typescript/tsc_timeout_retry.py
@@ -1,0 +1,130 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+# Workaround for rare hangs in the TypeScript compiler (tsc) during GN build
+# actions. Both tools/typescript/ts_library.py and devtools-frontend's
+# ts_library.py invoke tsc via subprocess.Popen(...).communicate() with no
+# timeout, which can block the build indefinitely.
+#
+# patch_subprocess_with_timeout_retry() is used as a context manager in
+# chromium_src overrides of those scripts. While active, it replaces
+# subprocess.Popen with a wrapper that applies only to tsc invocations
+# (node running a path ending in /tsc). Other subprocess calls are unaffected.
+#
+# On timeout the hung process is killed and tsc is re-run from scratch. The
+# timeout doubles after each failed attempt. Defaults and retry count are
+# configurable via CHROMIUM_TSC_TIMEOUT_SEC and CHROMIUM_TSC_MAX_RETRIES.
+
+import contextlib
+import logging
+import os
+import subprocess
+import sys
+
+DEFAULT_TSC_TIMEOUT_SEC = int(os.environ.get('CHROMIUM_TSC_TIMEOUT_SEC', '90'))
+DEFAULT_TSC_MAX_RETRIES = int(os.environ.get('CHROMIUM_TSC_MAX_RETRIES', '2'))
+
+
+class _RetryPopen:
+    """Wraps subprocess.Popen with timeout and retry for hung tsc
+    invocations."""
+
+    def __init__(self, original_popen, popen_args, popen_kwargs, timeout_sec,
+                 max_retries):
+        self._original_popen = original_popen
+        self._popen_args = popen_args
+        self._popen_kwargs = popen_kwargs
+        self._timeout_sec = timeout_sec
+        self._max_retries = max_retries
+        self._cmd_repr = self._command_repr(popen_args, popen_kwargs)
+        self._process = original_popen(*popen_args, **popen_kwargs)
+
+    def _recreate_process(self):
+        self._process = self._original_popen(*self._popen_args,
+                                             **self._popen_kwargs)
+
+    def communicate(self, *args, **kwargs):
+        if 'timeout' in kwargs:
+            return self._process.communicate(*args, **kwargs)
+
+        communicate_kwargs = dict(kwargs, timeout=self._timeout_sec)
+        effective_timeout = self._timeout_sec
+        max_attempts = self._max_retries + 1
+        for attempt in range(1, max_attempts + 1):
+            try:
+                return self._process.communicate(*args, **communicate_kwargs)
+            except subprocess.TimeoutExpired as exc:
+                self._process.kill()
+                try:
+                    self._process.communicate()
+                except Exception:
+                    pass
+                if attempt >= max_attempts:
+                    raise RuntimeError(
+                        f'tsc timed out after {effective_timeout}s '
+                        f'({max_attempts} attempts): {self._cmd_repr}'
+                    ) from exc
+                logging.warning(
+                    'tsc timed out after %ss (attempt %d/%d), retrying: %s',
+                    effective_timeout, attempt, max_attempts, self._cmd_repr)
+                effective_timeout *= 2
+                communicate_kwargs['timeout'] = effective_timeout
+                self._recreate_process()
+
+        raise AssertionError('unreachable')
+
+    def __getattr__(self, name):
+        return getattr(self._process, name)
+
+    def __enter__(self):
+        self._process.__enter__()
+        return self
+
+    def __exit__(self, *args):
+        return self._process.__exit__(*args)
+
+    @staticmethod
+    def _command_from_popen_args(args, kwargs):
+        if args:
+            return args[0]
+        return kwargs.get('args', [])
+
+    @staticmethod
+    def _is_tsc_command(args, kwargs):
+        cmd = _RetryPopen._command_from_popen_args(args, kwargs)
+        if isinstance(cmd, str):
+            cmd = [cmd]
+        if len(cmd) < 2:
+            return False
+        return cmd[1].endswith('/tsc') or cmd[1].endswith('\\tsc')
+
+    @staticmethod
+    def _command_repr(args, kwargs):
+        cmd = _RetryPopen._command_from_popen_args(args, kwargs)
+        if isinstance(cmd, str):
+            return cmd
+        return ' '.join(cmd)
+
+
+def _make_popen(original_popen):
+
+    def popen(*args, **kwargs):
+        if _RetryPopen._is_tsc_command(args, kwargs):
+            return _RetryPopen(original_popen, args, kwargs,
+                               DEFAULT_TSC_TIMEOUT_SEC,
+                               DEFAULT_TSC_MAX_RETRIES)
+        return original_popen(*args, **kwargs)
+
+    return popen
+
+
+@contextlib.contextmanager
+def patch_subprocess_with_timeout_retry():
+    original_popen = subprocess.Popen
+    subprocess.Popen = _make_popen(original_popen)
+    try:
+        yield
+    finally:
+        subprocess.Popen = original_popen


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Add a workaround to restart upstream `tsc` calls on hang. Timeout is set to 90 seconds which increase x2 two times. In my tests existing `tsc` calls complete in less than 40 seconds, so 90 should be plenty to catch the actual hang.

This is a reoccurring issue that also exists in Chromium infra (see link in the issue). It becomes a bit annoying as builds randomly timeout (both PR and release ones). This is an attempt to workaround the problem.

Resolves https://github.com/brave/brave-browser/issues/54004

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
