### PR TITLE
[ads] Refactor ApplicationStateMonitor as AdsServiceImpl member

### DIFF
--- a/browser/brave_ads/BUILD.gn
+++ b/browser/brave_ads/BUILD.gn
@@ -106,6 +106,8 @@ source_set("impl") {
     sources += [
       "application_state/application_state_monitor/application_state_monitor_android.cc",
       "application_state/application_state_monitor/application_state_monitor_android.h",
+      "application_state/application_state_util_android.cc",
+      "application_state/application_state_util_android.h",
       "application_state/notification_helper/notification_helper_impl_android.cc",
       "application_state/notification_helper/notification_helper_impl_android.h",
     ]

--- a/browser/brave_ads/ads_service_factory.cc
+++ b/browser/brave_ads/ads_service_factory.cc
@@ -21,6 +21,7 @@
 #include "brave/browser/brave_browser_process.h"
 #include "brave/common/brave_channel_info.h"
 #include "brave/components/brave_ads/browser/ads_service_impl.h"
+#include "brave/components/brave_ads/browser/application_state/application_state_monitor.h"
 #include "brave/components/brave_ads/core/browser/service/ads_service.h"
 #include "brave/components/brave_ads/core/public/ads_util.h"
 #include "brave/components/brave_policy/policy_initialization_waiter.h"
@@ -152,6 +153,7 @@ AdsServiceFactory::BuildServiceInstanceForBrowserContext(
       brave::GetChannelName(), profile->GetPath(), CreateAdsTooltipsDelegate(),
       std::make_unique<DeviceIdImpl>(),
       std::make_unique<BatAdsServiceFactoryImpl>(),
+      ApplicationStateMonitor::Create(),
       CHECK_DEREF(g_brave_browser_process->resource_component()),
       history_service,
 #if BUILDFLAG(ENABLE_BRAVE_REWARDS)

--- a/browser/brave_ads/application_state/application_state_monitor/application_state_monitor_android.cc
+++ b/browser/brave_ads/application_state/application_state_monitor/application_state_monitor_android.cc
@@ -5,16 +5,17 @@
 
 #include "brave/browser/brave_ads/application_state/application_state_monitor/application_state_monitor_android.h"
 
+#include <memory>
+
 #include "base/functional/bind.h"
 #include "base/functional/callback.h"
-#include "base/no_destructor.h"
+#include "brave/browser/brave_ads/application_state/application_state_util_android.h"
 
 namespace brave_ads {
 
 // static
-ApplicationStateMonitor* ApplicationStateMonitor::GetInstance() {
-  static base::NoDestructor<ApplicationStateMonitorAndroid> instance;
-  return instance.get();
+std::unique_ptr<ApplicationStateMonitor> ApplicationStateMonitor::Create() {
+  return std::make_unique<ApplicationStateMonitorAndroid>();
 }
 
 ApplicationStateMonitorAndroid::ApplicationStateMonitorAndroid() {
@@ -29,8 +30,7 @@ ApplicationStateMonitorAndroid::ApplicationStateMonitorAndroid() {
 ApplicationStateMonitorAndroid::~ApplicationStateMonitorAndroid() = default;
 
 bool ApplicationStateMonitorAndroid::IsBrowserActive() const {
-  return base::android::ApplicationStatusListener::GetState() ==
-         base::android::APPLICATION_STATE_HAS_RUNNING_ACTIVITIES;
+  return IsApplicationInForeground();
 }
 
 void ApplicationStateMonitorAndroid::OnApplicationStateChange(

--- a/browser/brave_ads/application_state/application_state_monitor/application_state_monitor_linux.cc
+++ b/browser/brave_ads/application_state/application_state_monitor/application_state_monitor_linux.cc
@@ -17,8 +17,9 @@
 #include "ui/base/x/x11_util.h"
 // clang-format on
 
+#include <memory>
+
 #include "base/functional/bind.h"
-#include "base/no_destructor.h"
 #include "base/task/sequenced_task_runner.h"
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/browser_window.h"
@@ -31,9 +32,8 @@
 namespace brave_ads {
 
 // static
-ApplicationStateMonitor* ApplicationStateMonitor::GetInstance() {
-  static base::NoDestructor<ApplicationStateMonitorLinux> instance;
-  return instance.get();
+std::unique_ptr<ApplicationStateMonitor> ApplicationStateMonitor::Create() {
+  return std::make_unique<ApplicationStateMonitorLinux>();
 }
 
 ApplicationStateMonitorLinux::ApplicationStateMonitorLinux() {
@@ -88,10 +88,6 @@ void ApplicationStateMonitorLinux::OnBrowserDeactivated(
       base::BindOnce(
           &ApplicationStateMonitorLinux::NotifyBrowserDidResignActive,
           weak_ptr_factory_.GetWeakPtr()));
-}
-
-void ApplicationStateMonitorLinux::Reset() {
-  browser_collection_observation_.Reset();
 }
 
 }  // namespace brave_ads

--- a/browser/brave_ads/application_state/application_state_monitor/application_state_monitor_linux.h
+++ b/browser/brave_ads/application_state/application_state_monitor/application_state_monitor_linux.h
@@ -26,8 +26,6 @@ class ApplicationStateMonitorLinux final : public ApplicationStateMonitor,
 
   ~ApplicationStateMonitorLinux() override;
 
-  void Reset() override;
-
  private:
   // BrowserCollectionObserver:
   void OnBrowserActivated(BrowserWindowInterface* browser) override;

--- a/browser/brave_ads/application_state/application_state_monitor/application_state_monitor_mac.mm
+++ b/browser/brave_ads/application_state/application_state_monitor/application_state_monitor_mac.mm
@@ -7,11 +7,12 @@
 
 #import <Cocoa/Cocoa.h>
 
+#include <memory>
+
 #include "base/apple/foundation_util.h"
 #include "base/apple/osstatus_logging.h"
 #include "base/mac/mac_util.h"
 #include "base/memory/raw_ptr.h"
-#include "base/no_destructor.h"
 
 @interface ApplicationStateMonitorDelegateMac : NSObject {
  @private
@@ -71,9 +72,8 @@ class ApplicationStateMonitorMac::Delegate {
 };
 
 // static
-ApplicationStateMonitor* ApplicationStateMonitor::GetInstance() {
-  static base::NoDestructor<ApplicationStateMonitorMac> instance;
-  return instance.get();
+std::unique_ptr<ApplicationStateMonitor> ApplicationStateMonitor::Create() {
+  return std::make_unique<ApplicationStateMonitorMac>();
 }
 
 ApplicationStateMonitorMac::ApplicationStateMonitorMac() {

--- a/browser/brave_ads/application_state/application_state_monitor/application_state_monitor_win.cc
+++ b/browser/brave_ads/application_state/application_state_monitor/application_state_monitor_win.cc
@@ -7,8 +7,9 @@
 
 #include <windows.h>
 
+#include <memory>
+
 #include "base/functional/bind.h"
-#include "base/no_destructor.h"
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/browser_window.h"
 #include "chrome/browser/ui/browser_window/public/browser_window_interface_iterator.h"
@@ -18,9 +19,8 @@
 namespace brave_ads {
 
 // static
-ApplicationStateMonitor* ApplicationStateMonitor::GetInstance() {
-  static base::NoDestructor<ApplicationStateMonitorWin> instance;
-  return instance.get();
+std::unique_ptr<ApplicationStateMonitor> ApplicationStateMonitor::Create() {
+  return std::make_unique<ApplicationStateMonitorWin>();
 }
 
 ApplicationStateMonitorWin::ApplicationStateMonitorWin() {

--- a/browser/brave_ads/application_state/application_state_util_android.cc
+++ b/browser/brave_ads/application_state/application_state_util_android.cc
@@ -1,0 +1,17 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/brave_ads/application_state/application_state_util_android.h"
+
+#include "base/android/application_status_listener.h"
+
+namespace brave_ads {
+
+bool IsApplicationInForeground() {
+  return base::android::ApplicationStatusListener::GetState() ==
+         base::android::APPLICATION_STATE_HAS_RUNNING_ACTIVITIES;
+}
+
+}  // namespace brave_ads

--- a/browser/brave_ads/application_state/application_state_util_android.h
+++ b/browser/brave_ads/application_state/application_state_util_android.h
@@ -1,0 +1,15 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_BRAVE_ADS_APPLICATION_STATE_APPLICATION_STATE_UTIL_ANDROID_H_
+#define BRAVE_BROWSER_BRAVE_ADS_APPLICATION_STATE_APPLICATION_STATE_UTIL_ANDROID_H_
+
+namespace brave_ads {
+
+bool IsApplicationInForeground();
+
+}  // namespace brave_ads
+
+#endif  // BRAVE_BROWSER_BRAVE_ADS_APPLICATION_STATE_APPLICATION_STATE_UTIL_ANDROID_H_

--- a/browser/brave_ads/application_state/notification_helper/notification_helper_impl_android.cc
+++ b/browser/brave_ads/application_state/notification_helper/notification_helper_impl_android.cc
@@ -9,8 +9,8 @@
 #include "base/system/sys_info.h"
 #include "brave/browser/brave_ads/android/jni_headers/BraveAdsSignupDialog_jni.h"
 #include "brave/browser/brave_ads/android/jni_headers/BraveAds_jni.h"
+#include "brave/browser/brave_ads/application_state/application_state_util_android.h"
 #include "brave/build/android/jni_headers/BraveSiteChannelsManagerBridge_jni.h"
-#include "brave/components/brave_ads/browser/application_state/application_state_monitor.h"
 #include "chrome/browser/notifications/jni_headers/NotificationSystemStatusUtil_jni.h"
 #include "chrome/browser/notifications/notification_channels_provider_android.h"
 
@@ -68,8 +68,7 @@ bool NotificationHelperImplAndroid::CanShowNotifications() {
       (status == kAppNotificationsStatusEnabled ||
        status == kAppNotificationStatusUndeterminable);
 
-  const bool is_foreground =
-      ApplicationStateMonitor::GetInstance()->IsBrowserActive();
+  const bool is_foreground = IsApplicationInForeground();
 
   const bool is_notification_channel_enabled =
       IsBraveAdsNotificationChannelEnabled(is_foreground);

--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -149,6 +149,7 @@ AdsServiceImpl::AdsServiceImpl(
     std::unique_ptr<AdsTooltipsDelegate> ads_tooltips_delegate,
     std::unique_ptr<DeviceId> device_id,
     std::unique_ptr<BatAdsServiceFactory> bat_ads_service_factory,
+    std::unique_ptr<ApplicationStateMonitor> application_state_monitor,
     ResourceComponent& resource_component,
     history::HistoryService* history_service,
 #if BUILDFLAG(ENABLE_BRAVE_REWARDS)
@@ -177,10 +178,12 @@ AdsServiceImpl::AdsServiceImpl(
 #if BUILDFLAG(ENABLE_BRAVE_REWARDS)
       rewards_service_(rewards_service),
 #endif
+      application_state_monitor_(std::move(application_state_monitor)),
       policy_initialization_waiter_(std::move(policy_initialization_waiter)),
       bat_ads_client_associated_receiver_(this) {
   CHECK(device_id_);
   CHECK(bat_ads_service_factory_);
+  CHECK(application_state_monitor_);
   CHECK(policy_initialization_waiter_);
 
   if (!http_client_ || !history_service_ || !host_content_settings_map_) {
@@ -468,7 +471,7 @@ void AdsServiceImpl::InitializeBatAdsCallback(bool success) {
 #endif
 
   application_state_monitor_observation_.Observe(
-      ApplicationStateMonitor::GetInstance());
+      application_state_monitor_.get());
 
   MaybeShowOnboardingNotification();
 
@@ -1087,11 +1090,6 @@ void AdsServiceImpl::Shutdown() {
   policy_initialization_waiter_.reset();
 
   ShutdownAdsService();
-
-  // ApplicationStateMonitor is only used by this service, it needs to be reset
-  // to let go of the BrowserCollectionObserver before GlobalFeatures object is
-  // destoryed.
-  ApplicationStateMonitor::GetInstance()->Reset();
 }
 
 void AdsServiceImpl::AddBatAdsObserver(
@@ -1438,8 +1436,7 @@ void AdsServiceImpl::IsNetworkConnectionAvailable(
 }
 
 void AdsServiceImpl::IsBrowserActive(IsBrowserActiveCallback callback) {
-  std::move(callback).Run(
-      ApplicationStateMonitor::GetInstance()->IsBrowserActive());
+  std::move(callback).Run(application_state_monitor_->IsBrowserActive());
 }
 
 void AdsServiceImpl::IsBrowserInFullScreenMode(

--- a/components/brave_ads/browser/ads_service_impl.h
+++ b/components/brave_ads/browser/ads_service_impl.h
@@ -116,6 +116,7 @@ class AdsServiceImpl : public AdsService,
       std::unique_ptr<AdsTooltipsDelegate> ads_tooltips_delegate,
       std::unique_ptr<DeviceId> device_id,
       std::unique_ptr<BatAdsServiceFactory> bat_ads_service_factory,
+      std::unique_ptr<ApplicationStateMonitor> application_state_monitor,
       ResourceComponent& resource_component,
       history::HistoryService* history_service,
 #if BUILDFLAG(ENABLE_BRAVE_REWARDS)
@@ -477,6 +478,8 @@ class AdsServiceImpl : public AdsService,
                           brave_rewards::RewardsServiceObserver>
       rewards_service_observation_{this};
 #endif  // BUILDFLAG(ENABLE_BRAVE_REWARDS)
+
+  std::unique_ptr<ApplicationStateMonitor> application_state_monitor_;
   base::ScopedObservation<ApplicationStateMonitor, ApplicationStateObserver>
       application_state_monitor_observation_{this};
 

--- a/components/brave_ads/browser/ads_service_impl_unittest.cc
+++ b/components/brave_ads/browser/ads_service_impl_unittest.cc
@@ -93,7 +93,8 @@ class BraveAdsAdsServiceImplTest : public testing::Test {
         std::make_unique<test::FakeVirtualPrefProviderDelegate>(),
         /*channel_name=*/"foo", profile_dir_.GetPath(),
         std::make_unique<test::FakeAdsTooltipsDelegate>(), std::move(device_id),
-        std::move(bat_ads_service_factory), mock_resource_component_,
+        std::move(bat_ads_service_factory),
+        std::make_unique<ApplicationStateMonitor>(), mock_resource_component_,
         /*history_service=*/nullptr,
 #if BUILDFLAG(ENABLE_BRAVE_REWARDS)
         &rewards_service_,

--- a/components/brave_ads/browser/application_state/application_state_monitor.h
+++ b/components/brave_ads/browser/application_state/application_state_monitor.h
@@ -6,6 +6,8 @@
 #ifndef BRAVE_COMPONENTS_BRAVE_ADS_BROWSER_APPLICATION_STATE_APPLICATION_STATE_MONITOR_H_
 #define BRAVE_COMPONENTS_BRAVE_ADS_BROWSER_APPLICATION_STATE_APPLICATION_STATE_MONITOR_H_
 
+#include <memory>
+
 #include "base/observer_list.h"
 #include "brave/components/brave_ads/browser/application_state/application_state_observer.h"
 
@@ -23,17 +25,14 @@ class ApplicationStateMonitor {
 
   virtual ~ApplicationStateMonitor();
 
-  // Returns the singleton instance.
-  static ApplicationStateMonitor* GetInstance();
+  // Creates a platform specific instance.
+  static std::unique_ptr<ApplicationStateMonitor> Create();
 
   void AddObserver(ApplicationStateObserver* observer);
   void RemoveObserver(ApplicationStateObserver* observer);
 
   // Returns whether the browser is currently active.
   virtual bool IsBrowserActive() const;
-
-  // Lifecycle
-  virtual void Reset() {}
 
  protected:
   // Notifies observers that the browser became active.


### PR DESCRIPTION
The singleton `ApplicationStateMonitor` caused a dangling pointer on Linux because `BrowserCollection` could be destroyed before the `ApplicationStateMonitor` singleton instance. To fix that the temporary `Reset()` workaround was introduced in cr149 bump. The PR changes `ApplicationStateMonitor` to be owned by `AdsServiceImpl` eliminating browser shutdown issues cause by singletons.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/55645

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
