### PR TITLE
Uplift upstream CL: add URL-id filter to vector search

### DIFF
--- a/browser/ai_chat/tools/history_search_tool.cc
+++ b/browser/ai_chat/tools/history_search_tool.cc
@@ -249,7 +249,7 @@ void HistorySearchTool::UseTool(const std::string& input_json,
   // theoretical case of more than one fire.
   service->Search(
       /*previous_search_result=*/nullptr, *query, time_range_start, count,
-      /*skip_answering=*/true,
+      /*skip_answering=*/true, /*url_id_filter=*/{},
       base::BindRepeating(
           &HistorySearchTool::OnSearchResult, weak_ptr_factory_.GetWeakPtr(),
           base::Owned(std::make_unique<UseToolCallback>(std::move(callback))),

--- a/browser/ai_chat/tools/history_search_tool_browsertest.cc
+++ b/browser/ai_chat/tools/history_search_tool_browsertest.cc
@@ -70,6 +70,7 @@ class FakeHistoryEmbeddingsSearch
       std::optional<base::Time> time_range_start,
       size_t count,
       bool skip_answering,
+      std::vector<history::URLID> url_id_filter,
       history_embeddings::SearchResultCallback callback) override {
     last_query_ = query;
     last_time_range_start_ = time_range_start;

--- a/chromium_src/components/history_embeddings/content/history_embeddings_service_unittest.cc
+++ b/chromium_src/components/history_embeddings/content/history_embeddings_service_unittest.cc
@@ -72,7 +72,8 @@ TEST_F(HistoryEmbeddingsServiceTest,
 
   base::test::TestFuture<SearchResult> future;
   service_->Search(nullptr, "test passage", {}, 3,
-                   /*skip_answering=*/true, future.GetRepeatingCallback());
+                   /*skip_answering=*/true, /*url_id_filter=*/{},
+                   future.GetRepeatingCallback());
   SearchResult result = future.Take();
 
   // Brave: results must be preserved despite no visibility model.

--- a/patches/chrome-browser-ai-ai_data_keyed_service.cc.patch
+++ b/patches/chrome-browser-ai-ai_data_keyed_service.cc.patch
@@ -1,0 +1,13 @@
+diff --git a/chrome/browser/ai/ai_data_keyed_service.cc b/chrome/browser/ai/ai_data_keyed_service.cc
+index f232366924881e21584c50054eac298c5583f38a..7f5754e9dc818f69f909f8529ebd11ba144ee587 100644
+--- a/chrome/browser/ai/ai_data_keyed_service.cc
++++ b/chrome/browser/ai/ai_data_keyed_service.cc
+@@ -255,7 +255,7 @@ void GetHistoryQueryResultForModelPrototyping(
+                          .start_time()
+                          .seconds())),
+         history_query.num_history_visits(),
+-        /*skip_answering=*/true, history_search_callback);
++        /*skip_answering=*/true, /*url_id_filter=*/{}, history_search_callback);
+   }
+ }
+ 

--- a/patches/chrome-browser-history_embeddings-history_embeddings_service_browsertest.cc.patch
+++ b/patches/chrome-browser-history_embeddings-history_embeddings_service_browsertest.cc.patch
@@ -1,0 +1,91 @@
+diff --git a/chrome/browser/history_embeddings/history_embeddings_service_browsertest.cc b/chrome/browser/history_embeddings/history_embeddings_service_browsertest.cc
+index 34f6aeca524f5fb818f2361b5d2ac50d242522c7..a84126fb5b1d5eb6fb6f9e07eeb0d354c2ecfa5a 100644
+--- a/chrome/browser/history_embeddings/history_embeddings_service_browsertest.cc
++++ b/chrome/browser/history_embeddings/history_embeddings_service_browsertest.cc
+@@ -244,7 +244,7 @@ IN_PROC_BROWSER_TEST_F(HistoryEmbeddingsBrowserTest,
+   // Search for the passage.
+   base::test::TestFuture<SearchResult> search_future;
+   service()->Search(nullptr, "A B C D e f g", {}, 1, /*skip_answering=*/false,
+-                    search_future.GetRepeatingCallback());
++                    /*url_id_filter=*/{}, search_future.GetRepeatingCallback());
+   SearchResult result = search_future.Take();
+   ASSERT_EQ(result.scored_url_rows.size(), 1u);
+   EXPECT_EQ(result.scored_url_rows[0].GetBestPassage(), "A a B C b a 2 D");
+@@ -305,7 +305,7 @@ IN_PROC_BROWSER_TEST_F(HistoryEmbeddingsWithLowAggregationBrowserTest,
+   // Search for the passage.
+   base::test::TestFuture<SearchResult> search_future;
+   service()->Search(nullptr, "A B C", {}, 1, /*skip_answering=*/false,
+-                    search_future.GetRepeatingCallback());
++                    /*url_id_filter=*/{}, search_future.GetRepeatingCallback());
+   SearchResult result = search_future.Take();
+   ASSERT_EQ(result.scored_url_rows.size(), 1u);
+   EXPECT_EQ(result.scored_url_rows[0].GetBestPassage(),
+@@ -355,7 +355,7 @@ IN_PROC_BROWSER_TEST_F(
+   // Search for the passage.
+   base::test::TestFuture<SearchResult> search_future;
+   service()->Search(nullptr, "A B C D e f g", {}, 1, /*skip_answering=*/false,
+-                    search_future.GetRepeatingCallback());
++                    /*url_id_filter=*/{}, search_future.GetRepeatingCallback());
+   SearchResult result = search_future.Take();
+   EXPECT_TRUE(result.scored_url_rows.empty());
+ 
+@@ -384,7 +384,7 @@ IN_PROC_BROWSER_TEST_F(HistoryEmbeddingsBrowserTest,
+   // Search for the passage.
+   base::test::TestFuture<SearchResult> search_future;
+   service()->Search(nullptr, "A B C D e f g", {}, 1, /*skip_answering=*/false,
+-                    search_future.GetRepeatingCallback());
++                    /*url_id_filter=*/{}, search_future.GetRepeatingCallback());
+   SearchResult result = search_future.Take();
+   EXPECT_TRUE(result.scored_url_rows.empty());
+ 
+@@ -446,7 +446,7 @@ IN_PROC_BROWSER_TEST_F(HistoryEmbeddingsWithUrlFilterBrowserTest,
+   // Search for the passage, should return empty result because of the filter.
+   base::test::TestFuture<SearchResult> search_future;
+   service()->Search(nullptr, "A B C D e f g", {}, 1, /*skip_answering=*/false,
+-                    search_future.GetRepeatingCallback());
++                    /*url_id_filter=*/{}, search_future.GetRepeatingCallback());
+   SearchResult result = search_future.Take();
+   EXPECT_TRUE(result.scored_url_rows.empty());
+ 
+@@ -481,7 +481,7 @@ IN_PROC_BROWSER_TEST_F(HistoryEmbeddingsWithUrlFilterBrowserTest,
+   // Search for the passage; should have valid result since the URL is allowed.
+   base::test::TestFuture<SearchResult> search_future;
+   service()->Search(nullptr, "A B C D e f g", {}, 1, /*skip_answering=*/false,
+-                    search_future.GetRepeatingCallback());
++                    /*url_id_filter=*/{}, search_future.GetRepeatingCallback());
+   SearchResult result = search_future.Take();
+   ASSERT_EQ(result.scored_url_rows.size(), 1u);
+   EXPECT_EQ(result.scored_url_rows[0].GetBestPassage(), "A a B C b a 2 D");
+@@ -515,6 +515,7 @@ IN_PROC_BROWSER_TEST_F(HistoryEmbeddingsBrowserTest,
+     // Search with an answerable query by ending it with '?'.
+     base::test::TestFuture<SearchResult> search_future;
+     service()->Search(nullptr, "A B C D?", {}, 1, /*skip_answering=*/false,
++                      /*url_id_filter=*/{},
+                       search_future.GetRepeatingCallback());
+     SearchResult first_result = search_future.Take();
+     EXPECT_EQ(first_result.scored_url_rows.size(), 1u);
+@@ -544,6 +545,7 @@ IN_PROC_BROWSER_TEST_F(HistoryEmbeddingsBrowserTest,
+     // Search with a query that does not signal query intent (not answerable).
+     base::test::TestFuture<SearchResult> search_future;
+     service()->Search(nullptr, "A B C D", {}, 1, /*skip_answering=*/false,
++                      /*url_id_filter=*/{},
+                       search_future.GetRepeatingCallback());
+     SearchResult first_result = search_future.Take();
+     EXPECT_EQ(first_result.scored_url_rows.size(), 1u);
+@@ -581,7 +583,7 @@ IN_PROC_BROWSER_TEST_F(HistoryEmbeddingsRestrictedSigninBrowserTest,
+   // due to account restriction.
+   base::test::TestFuture<SearchResult> search_future;
+   service()->Search(nullptr, "A B C D?", {}, 1, /*skip_answering=*/false,
+-                    search_future.GetRepeatingCallback());
++                    /*url_id_filter=*/{}, search_future.GetRepeatingCallback());
+   SearchResult first_result = search_future.Take();
+   EXPECT_EQ(first_result.scored_url_rows.size(), 1u);
+   EXPECT_TRUE(first_result.AnswerText().empty());
+@@ -633,6 +635,7 @@ IN_PROC_BROWSER_TEST_F(HistoryEmbeddingsKillSwitchBrowserTest,
+   {
+     base::test::TestFuture<SearchResult> search_future;
+     service()->Search(nullptr, "A B C D e f g", {}, 1, /*skip_answering=*/false,
++                      /*url_id_filter=*/{},
+                       search_future.GetRepeatingCallback());
+     SearchResult result = search_future.Take();
+     ASSERT_EQ(result.scored_url_rows.size(), 1u);

--- a/patches/chrome-browser-ui-webui-cr_components-history_embeddings-history_embeddings_handler.cc.patch
+++ b/patches/chrome-browser-ui-webui-cr_components-history_embeddings-history_embeddings_handler.cc.patch
@@ -1,0 +1,13 @@
+diff --git a/chrome/browser/ui/webui/cr_components/history_embeddings/history_embeddings_handler.cc b/chrome/browser/ui/webui/cr_components/history_embeddings/history_embeddings_handler.cc
+index e9f543afcf74fdc4f2a3a9961676cb47fd94fcde..49f068500da627f33b11f76d009154266415c8ba 100644
+--- a/chrome/browser/ui/webui/cr_components/history_embeddings/history_embeddings_handler.cc
++++ b/chrome/browser/ui/webui/cr_components/history_embeddings/history_embeddings_handler.cc
+@@ -104,7 +104,7 @@ void HistoryEmbeddingsHandler::Search(
+   last_result_ = service->Search(
+       &last_result_, query->query, query->time_range_start,
+       history_embeddings::GetFeatureParameters().search_result_item_count,
+-      /*skip_answering=*/false,
++      /*skip_answering=*/false, /*url_id_filter=*/{},
+       base::BindRepeating(&HistoryEmbeddingsHandler::OnReceivedSearchResult,
+                           weak_ptr_factory_.GetWeakPtr()));
+   VLOG(3) << "HistoryEmbeddingsHandler::Search started for '"

--- a/patches/components-history_embeddings-content-history_embeddings_service.cc.patch
+++ b/patches/components-history_embeddings-content-history_embeddings_service.cc.patch
@@ -1,0 +1,20 @@
+diff --git a/components/history_embeddings/content/history_embeddings_service.cc b/components/history_embeddings/content/history_embeddings_service.cc
+index 8955b93243ea86ac6f118fe1afab867a1650d853..2ab7a36a93b9808816cedd20fad98e34c2cbdd6b 100644
+--- a/components/history_embeddings/content/history_embeddings_service.cc
++++ b/components/history_embeddings/content/history_embeddings_service.cc
+@@ -218,6 +218,7 @@ SearchResult HistoryEmbeddingsService::Search(
+     std::optional<base::Time> time_range_start,
+     size_t count,
+     bool skip_answering,
++    std::vector<history::URLID> url_id_filter,
+     SearchResultCallback callback) {
+   SearchResult result;
+ 
+@@ -269,6 +270,7 @@ SearchResult HistoryEmbeddingsService::Search(
+       GetFeatureParameters().word_match_max_term_count;
+   result.search_params.word_match_required_term_ratio =
+       GetFeatureParameters().word_match_required_term_ratio;
++  result.search_params.url_id_filter = std::move(url_id_filter);
+ 
+   if (QueryIsFiltered(query, result.search_params)) {
+     result.count = 0;

--- a/patches/components-history_embeddings-content-history_embeddings_service.h.patch
+++ b/patches/components-history_embeddings-content-history_embeddings_service.h.patch
@@ -1,0 +1,12 @@
+diff --git a/components/history_embeddings/content/history_embeddings_service.h b/components/history_embeddings/content/history_embeddings_service.h
+index eef58f7e78e406a3b9d30c4eb5513ede972cc0f1..ab573285c18933b0ddecb5115bb6091d6b72a4dd 100644
+--- a/components/history_embeddings/content/history_embeddings_service.h
++++ b/components/history_embeddings/content/history_embeddings_service.h
+@@ -109,6 +109,7 @@ class HistoryEmbeddingsService
+                       std::optional<base::Time> time_range_start,
+                       size_t count,
+                       bool skip_answering,
++                      std::vector<history::URLID> url_id_filter,
+                       SearchResultCallback callback) override;
+ 
+   // Weak `this` provider method.

--- a/patches/components-history_embeddings-content-history_embeddings_service_unittest.cc.patch
+++ b/patches/components-history_embeddings-content-history_embeddings_service_unittest.cc.patch
@@ -1,0 +1,273 @@
+diff --git a/components/history_embeddings/content/history_embeddings_service_unittest.cc b/components/history_embeddings/content/history_embeddings_service_unittest.cc
+index 1731f0c4fbb6ee4f5b3dc88260559a578fcfebe4..59cc1ae7ce13f78f9a238c2ba106ff61e81488ba 100644
+--- a/components/history_embeddings/content/history_embeddings_service_unittest.cc
++++ b/components/history_embeddings/content/history_embeddings_service_unittest.cc
+@@ -200,7 +200,7 @@ class HistoryEmbeddingsServiceTest : public testing::Test {
+     service_->storage_.PostTaskWithThisObject(base::BindLambdaForTesting(
+         [&](HistoryEmbeddingsServicePublic::Storage* storage) {
+           std::unique_ptr<SqlDatabase::UrlDataIterator> iterator =
+-              storage->sql_database.MakeUrlDataIterator({});
++              storage->sql_database.MakeUrlDataIterator({}, {});
+           if (!iterator) {
+             return;
+           }
+@@ -328,7 +328,7 @@ TEST_F(HistoryEmbeddingsServiceTest, SearchSetsValidSessionId) {
+   // Search results created by service search have new valid ID.
+   base::test::TestFuture<SearchResult> future;
+   service_->Search(nullptr, "", {}, 1, /*skip_answering=*/false,
+-                   future.GetRepeatingCallback());
++                   /*url_id_filter=*/{}, future.GetRepeatingCallback());
+   EXPECT_FALSE(future.Take().session_id.empty());
+ }
+ 
+@@ -388,7 +388,7 @@ TEST_F(HistoryEmbeddingsServiceTest, SearchReportsHistograms) {
+   base::test::TestFuture<SearchResult> future;
+   OverrideVisibilityScoresForTesting({{"", 0.99}});
+   service_->Search(nullptr, "", {}, 1, /*skip_answering=*/false,
+-                   future.GetRepeatingCallback());
++                   /*url_id_filter=*/{}, future.GetRepeatingCallback());
+   EXPECT_TRUE(future.Take().scored_url_rows.empty());
+ 
+   histogram_tester.ExpectUniqueSample("History.Embeddings.Search.Completed",
+@@ -406,7 +406,8 @@ TEST_F(HistoryEmbeddingsServiceTest, SearchIncrementsSessionIdSequenceNumber) {
+ 
+   // Specifying null produces a new random session_id with sequence number 0.
+   service_->Search(/*previous_search_result=*/nullptr, "", {}, 1,
+-                   /*skip_answering=*/false, future.GetRepeatingCallback());
++                   /*skip_answering=*/false, /*url_id_filter=*/{},
++                   future.GetRepeatingCallback());
+   token = *base::Token::FromString(future.Take().session_id);
+   EXPECT_NE(token.high(), 0u);
+   EXPECT_EQ(token.low() & HistoryEmbeddingsService::kSessionIdSequenceBitMask,
+@@ -415,7 +416,7 @@ TEST_F(HistoryEmbeddingsServiceTest, SearchIncrementsSessionIdSequenceNumber) {
+   // Likewise for first new result when previous result was empty.
+   SearchResult result;
+   service_->Search(&result, "", {}, 1, /*skip_answering=*/false,
+-                   future.GetRepeatingCallback());
++                   /*url_id_filter=*/{}, future.GetRepeatingCallback());
+   result = future.Take();
+   token = *base::Token::FromString(result.session_id);
+   EXPECT_NE(token.high(), 0u);
+@@ -427,7 +428,7 @@ TEST_F(HistoryEmbeddingsServiceTest, SearchIncrementsSessionIdSequenceNumber) {
+        i++) {
+     old_token = token;
+     service_->Search(&result, "", {}, 1, /*skip_answering=*/false,
+-                     future.GetRepeatingCallback());
++                     /*url_id_filter=*/{}, future.GetRepeatingCallback());
+     result = future.Take();
+     token = *base::Token::FromString(result.session_id);
+     EXPECT_EQ(token.high(), old_token.high());
+@@ -453,14 +454,14 @@ TEST_F(HistoryEmbeddingsServiceTest, SearchIncrementsSessionIdSequenceNumber) {
+   // Additional increments simply overflow into the next higher bits.
+   old_token = base::Token(old_token.high(), old_token.low() + 1);
+   service_->Search(&result, "", {}, 1, /*skip_answering=*/false,
+-                   future.GetRepeatingCallback());
++                   /*url_id_filter=*/{}, future.GetRepeatingCallback());
+   result = future.Take();
+   token = *base::Token::FromString(result.session_id);
+   EXPECT_EQ(old_token, token);
+ 
+   old_token = base::Token(old_token.high(), old_token.low() + 1);
+   service_->Search(&result, "", {}, 1, /*skip_answering=*/false,
+-                   future.GetRepeatingCallback());
++                   /*url_id_filter=*/{}, future.GetRepeatingCallback());
+   result = future.Take();
+   token = *base::Token::FromString(result.session_id);
+   EXPECT_EQ(old_token, token);
+@@ -565,7 +566,7 @@ TEST_F(HistoryEmbeddingsServiceTest, SearchFiltersLowScoringResults) {
+       {"test passage 6", 0.99},
+   });
+   service_->Search(nullptr, "test query", {}, 3, /*skip_answering=*/false,
+-                   future.GetRepeatingCallback());
++                   /*url_id_filter=*/{}, future.GetRepeatingCallback());
+   SearchResult result = future.Take();
+ 
+   EXPECT_EQ(result.query, "test query");
+@@ -620,7 +621,8 @@ TEST_F(HistoryEmbeddingsServiceTest, FilterWordsHashes) {
+   {
+     base::test::TestFuture<SearchResult> future;
+     service_->Search(nullptr, "query without terms", {}, 3,
+-                     /*skip_answering=*/false, future.GetRepeatingCallback());
++                     /*skip_answering=*/false, /*url_id_filter=*/{},
++                     future.GetRepeatingCallback());
+     SearchResult result = future.Take();
+     EXPECT_FALSE(result.session_id.empty());
+     EXPECT_EQ(result.query, "query without terms");
+@@ -629,7 +631,7 @@ TEST_F(HistoryEmbeddingsServiceTest, FilterWordsHashes) {
+   {
+     base::test::TestFuture<SearchResult> future;
+     service_->Search(nullptr, "query with inexact spe'cial in the middle", {},
+-                     3, /*skip_answering=*/false,
++                     3, /*skip_answering=*/false, /*url_id_filter=*/{},
+                      future.GetRepeatingCallback());
+     SearchResult result = future.Take();
+     EXPECT_FALSE(result.session_id.empty());
+@@ -639,7 +641,7 @@ TEST_F(HistoryEmbeddingsServiceTest, FilterWordsHashes) {
+   {
+     base::test::TestFuture<SearchResult> future;
+     service_->Search(nullptr, "query with non-ASCII ∅ character but no terms",
+-                     {}, 3, /*skip_answering=*/false,
++                     {}, 3, /*skip_answering=*/false, /*url_id_filter=*/{},
+                      future.GetRepeatingCallback());
+     SearchResult result = future.Take();
+     EXPECT_FALSE(result.session_id.empty());
+@@ -649,7 +651,8 @@ TEST_F(HistoryEmbeddingsServiceTest, FilterWordsHashes) {
+   {
+     base::test::TestFuture<SearchResult> future;
+     service_->Search(nullptr, "the word 'special' has its hash filtered", {}, 3,
+-                     /*skip_answering=*/false, future.GetRepeatingCallback());
++                     /*skip_answering=*/false, /*url_id_filter=*/{},
++                     future.GetRepeatingCallback());
+     SearchResult result = future.Take();
+     EXPECT_FALSE(result.session_id.empty());
+     EXPECT_EQ(result.query, "the word 'special' has its hash filtered");
+@@ -657,9 +660,10 @@ TEST_F(HistoryEmbeddingsServiceTest, FilterWordsHashes) {
+   }
+   {
+     base::test::TestFuture<SearchResult> future;
+-    service_->Search(
+-        nullptr, "the phrase 'something something' is also hash filtered", {},
+-        3, /*skip_answering=*/false, future.GetRepeatingCallback());
++    service_->Search(nullptr,
++                     "the phrase 'something something' is also hash filtered",
++                     {}, 3, /*skip_answering=*/false, /*url_id_filter=*/{},
++                     future.GetRepeatingCallback());
+     SearchResult result = future.Take();
+     EXPECT_FALSE(result.session_id.empty());
+     EXPECT_EQ(result.query,
+@@ -669,7 +673,7 @@ TEST_F(HistoryEmbeddingsServiceTest, FilterWordsHashes) {
+   {
+     base::test::TestFuture<SearchResult> future;
+     service_->Search(nullptr, "this    Hello,   World!   is also hash filtered",
+-                     {}, 3, /*skip_answering=*/false,
++                     {}, 3, /*skip_answering=*/false, /*url_id_filter=*/{},
+                      future.GetRepeatingCallback());
+     SearchResult result = future.Take();
+     EXPECT_FALSE(result.session_id.empty());
+@@ -680,7 +684,8 @@ TEST_F(HistoryEmbeddingsServiceTest, FilterWordsHashes) {
+     base::test::TestFuture<SearchResult> future;
+     service_->Search(
+         nullptr, "Hello | World is also filtered due to trimmed empty removal",
+-        {}, 3, /*skip_answering=*/false, future.GetRepeatingCallback());
++        {}, 3, /*skip_answering=*/false, /*url_id_filter=*/{},
++        future.GetRepeatingCallback());
+     SearchResult result = future.Take();
+     EXPECT_FALSE(result.session_id.empty());
+     EXPECT_EQ(result.query,
+@@ -691,7 +696,8 @@ TEST_F(HistoryEmbeddingsServiceTest, FilterWordsHashes) {
+     base::test::TestFuture<SearchResult> future;
+     service_->Search(
+         nullptr, "hellow orld is not filtered since its hash differs", {}, 3,
+-        /*skip_answering=*/false, future.GetRepeatingCallback());
++        /*skip_answering=*/false, /*url_id_filter=*/{},
++        future.GetRepeatingCallback());
+     SearchResult result = future.Take();
+     EXPECT_FALSE(result.session_id.empty());
+     EXPECT_EQ(result.query,
+@@ -761,7 +767,7 @@ TEST_F(HistoryEmbeddingsServiceTest, SearchDoesNotWordMatchBoostLongQueries) {
+   {
+     base::test::TestFuture<SearchResult> future;
+     service_->Search(/*previous_search_result=*/nullptr, "boosted test query",
+-                     {}, 1, /*skip_answering=*/false,
++                     {}, 1, /*skip_answering=*/false, /*url_id_filter=*/{},
+                      future.GetRepeatingCallback());
+     SearchResult result = future.Take();
+     EXPECT_EQ(result.scored_url_rows.size(), 1u);
+@@ -776,7 +782,8 @@ TEST_F(HistoryEmbeddingsServiceTest, SearchDoesNotWordMatchBoostLongQueries) {
+     service_->Search(
+         /*previous_search_result=*/nullptr,
+         "this very very very very very long test query isn't boosted", {}, 1,
+-        /*skip_answering=*/false, future.GetRepeatingCallback());
++        /*skip_answering=*/false, /*url_id_filter=*/{},
++        future.GetRepeatingCallback());
+     SearchResult result = future.Take();
+     EXPECT_EQ(result.scored_url_rows.size(), 1u);
+     const ScoredUrlRow& row = result.scored_url_rows[0];
+@@ -811,7 +818,7 @@ TEST_F(HistoryEmbeddingsServiceTest, NoWordMatchBoostForLowTermCountRatio) {
+     set_ratio(0.3f);
+     base::test::TestFuture<SearchResult> future;
+     service_->Search(/*previous_search_result=*/nullptr, "boosted test query",
+-                     {}, 1, /*skip_answering=*/false,
++                     {}, 1, /*skip_answering=*/false, /*url_id_filter=*/{},
+                      future.GetRepeatingCallback());
+     SearchResult result = future.Take();
+     EXPECT_EQ(result.scored_url_rows.size(), 1u);
+@@ -824,7 +831,7 @@ TEST_F(HistoryEmbeddingsServiceTest, NoWordMatchBoostForLowTermCountRatio) {
+     set_ratio(0.5f);
+     base::test::TestFuture<SearchResult> future;
+     service_->Search(/*previous_search_result=*/nullptr, "boosted test query",
+-                     {}, 1, /*skip_answering=*/false,
++                     {}, 1, /*skip_answering=*/false, /*url_id_filter=*/{},
+                      future.GetRepeatingCallback());
+     SearchResult result = future.Take();
+     EXPECT_EQ(result.scored_url_rows.size(), 1u);
+@@ -838,7 +845,7 @@ TEST_F(HistoryEmbeddingsServiceTest, NoWordMatchBoostForLowTermCountRatio) {
+     base::test::TestFuture<SearchResult> future;
+     service_->Search(/*previous_search_result=*/nullptr,
+                      "test passage one more", {}, 1, /*skip_answering=*/false,
+-                     future.GetRepeatingCallback());
++                     /*url_id_filter=*/{}, future.GetRepeatingCallback());
+     SearchResult result = future.Take();
+     EXPECT_EQ(result.scored_url_rows.size(), 1u);
+     const ScoredUrlRow& row = result.scored_url_rows[0];
+@@ -849,7 +856,7 @@ TEST_F(HistoryEmbeddingsServiceTest, NoWordMatchBoostForLowTermCountRatio) {
+     set_ratio(1.0f);
+     base::test::TestFuture<SearchResult> future;
+     service_->Search(/*previous_search_result=*/nullptr, "test passage one", {},
+-                     1, /*skip_answering=*/false,
++                     1, /*skip_answering=*/false, /*url_id_filter=*/{},
+                      future.GetRepeatingCallback());
+     SearchResult result = future.Take();
+     EXPECT_EQ(result.scored_url_rows.size(), 1u);
+@@ -861,7 +868,7 @@ TEST_F(HistoryEmbeddingsServiceTest, NoWordMatchBoostForLowTermCountRatio) {
+     set_ratio(1.0f);
+     base::test::TestFuture<SearchResult> future;
+     service_->Search(/*previous_search_result=*/nullptr, "test passage one two",
+-                     {}, 1, /*skip_answering=*/false,
++                     {}, 1, /*skip_answering=*/false, /*url_id_filter=*/{},
+                      future.GetRepeatingCallback());
+     SearchResult result = future.Take();
+     EXPECT_EQ(result.scored_url_rows.size(), 1u);
+@@ -905,7 +912,8 @@ TEST_F(HistoryEmbeddingsServiceTest, WordMatchBoostAddsLowScoredResultItems) {
+ 
+   base::test::TestFuture<SearchResult> future;
+   service_->Search(/*previous_search_result=*/nullptr, "boosted test query", {},
+-                   2, /*skip_answering=*/false, future.GetRepeatingCallback());
++                   2, /*skip_answering=*/false, /*url_id_filter=*/{},
++                   future.GetRepeatingCallback());
+   SearchResult result = future.Take();
+   EXPECT_EQ(result.scored_url_rows.size(), 2u);
+   EXPECT_GT(result.scored_url_rows[0].scored_url.score,
+@@ -1116,7 +1124,7 @@ TEST_F(HistoryEmbeddingsServiceTest, SearchGetsIfUrlIsKnownToSync) {
+   base::test::TestFuture<SearchResult> future;
+   OverrideVisibilityScoresForTesting({{"my query", 0.99}});
+   service_->Search(nullptr, "my query", {}, 3, /*skip_answering=*/false,
+-                   future.GetRepeatingCallback());
++                   /*url_id_filter=*/{}, future.GetRepeatingCallback());
+   SearchResult result = future.Take();
+ 
+   EXPECT_EQ(result.scored_url_rows.size(), 2u);
+@@ -1146,19 +1154,19 @@ TEST_F(HistoryEmbeddingsServiceTest, CancelPreviousSearches) {
+ 
+   base::test::TestFuture<SearchResult> future1;
+   service_->Search(nullptr, "passage", {}, 3, /*skip_answering=*/true,
+-                   future1.GetRepeatingCallback());
++                   /*url_id_filter=*/{}, future1.GetRepeatingCallback());
+ 
+   base::test::TestFuture<SearchResult> future2;
+   service_->Search(nullptr, "passage", {}, 3, /*skip_answering=*/true,
+-                   future2.GetRepeatingCallback());
++                   /*url_id_filter=*/{}, future2.GetRepeatingCallback());
+ 
+   base::test::TestFuture<SearchResult> future3;
+   service_->Search(nullptr, "passage", {}, 3, /*skip_answering=*/true,
+-                   future3.GetRepeatingCallback());
++                   /*url_id_filter=*/{}, future3.GetRepeatingCallback());
+ 
+   base::test::TestFuture<SearchResult> future4;
+   service_->Search(nullptr, "passage", {}, 3, /*skip_answering=*/true,
+-                   future4.GetRepeatingCallback());
++                   /*url_id_filter=*/{}, future4.GetRepeatingCallback());
+ 
+   // The first query is skipped.
+   SearchResult result1 = future1.Take();

--- a/patches/components-history_embeddings-core-history_embeddings_search.h.patch
+++ b/patches/components-history_embeddings-core-history_embeddings_search.h.patch
@@ -1,0 +1,22 @@
+diff --git a/components/history_embeddings/core/history_embeddings_search.h b/components/history_embeddings/core/history_embeddings_search.h
+index cdee1e215275eadbf9f2c6ddeec6f79ba512b767..85085d0ef9451e9b6dbedd39fa5b5481d66114cf 100644
+--- a/components/history_embeddings/core/history_embeddings_search.h
++++ b/components/history_embeddings/core/history_embeddings_search.h
+@@ -116,6 +116,9 @@ class HistoryEmbeddingsSearch {
+   // completely new search session; if it is non-null and the session_id is set,
+   // the new session_id is set based on the previous to indicate a continuing
+   // search session.
++  // When `url_id_filter` is non-empty, the search is restricted to UrlData
++  // rows whose `url_id` is in the set; storage backends use it to short-circuit
++  // a full-corpus scan when the caller already knows the candidate URLIDs.
+   // Returns a stub result that can be used to detect if a later published
+   // SearchResult instance is related to this search.
+   virtual SearchResult Search(SearchResult* previous_search_result,
+@@ -123,6 +126,7 @@ class HistoryEmbeddingsSearch {
+                               std::optional<base::Time> time_range_start,
+                               size_t count,
+                               bool skip_answering,
++                              std::vector<history::URLID> url_id_filter,
+                               SearchResultCallback callback) = 0;
+ };
+ 

--- a/patches/components-history_embeddings-core-sql_database.cc.patch
+++ b/patches/components-history_embeddings-core-sql_database.cc.patch
@@ -1,0 +1,85 @@
+diff --git a/components/history_embeddings/core/sql_database.cc b/components/history_embeddings/core/sql_database.cc
+index 7d7c68304a49d551078a44ce8e5a09b035cab38b..0c626e5e44484508f92c9b6076344ae5f613d34a 100644
+--- a/components/history_embeddings/core/sql_database.cc
++++ b/components/history_embeddings/core/sql_database.cc
+@@ -430,39 +430,50 @@ constexpr char kSqlSelectPassagesAndEmbeddings[] =
+     "passages.passages_blob, embeddings.embeddings_blob "
+     "FROM passages "
+     "INNER JOIN embeddings ON passages.url_id = embeddings.url_id";
+-constexpr char kSqlSelectPassagesAndEmbeddingsWithinTimeRange[] =
+-    "SELECT passages.url_id, passages.visit_id, passages.visit_time, "
+-    "passages.passages_blob, embeddings.embeddings_blob "
+-    "FROM passages "
+-    "INNER JOIN embeddings ON passages.url_id = embeddings.url_id "
+-    "WHERE passages.visit_time >= ?";
+ 
+ std::unique_ptr<VectorDatabase::UrlDataIterator>
+-SqlDatabase::MakeUrlDataIterator(std::optional<base::Time> time_range_start) {
++SqlDatabase::MakeUrlDataIterator(
++    std::optional<base::Time> time_range_start,
++    const std::vector<history::URLID>& url_id_filter) {
+   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+ 
+   if (!LazyInit()) {
+     return nullptr;
+   }
+ 
+-  DCHECK(db_.IsSQLValid(kSqlSelectPassagesAndEmbeddings));
+-  DCHECK(db_.IsSQLValid(kSqlSelectPassagesAndEmbeddingsWithinTimeRange));
+-
+   struct RowDataIterator : public UrlDataIterator {
+-    explicit RowDataIterator(base::WeakPtr<SqlDatabase> sql_database,
+-                             std::optional<base::Time> time_range_start)
++    RowDataIterator(base::WeakPtr<SqlDatabase> sql_database,
++                    std::optional<base::Time> time_range_start,
++                    const std::vector<history::URLID>& url_id_filter)
+         : sql_database(sql_database), data(0, 0, base::Time()) {
+       CHECK(!sql_database->iteration_statement_);
++
++      // Start with `WHERE TRUE` so every optional clause can be appended as
++      // `" AND <condition>"` without tracking whether it's the first.
++      // `url_id_filter` adds one `?` per id so all matching rows are fetched
++      // in a single statement.
++      std::string sql = kSqlSelectPassagesAndEmbeddings;
++      sql.append(" WHERE TRUE");
+       if (time_range_start.has_value()) {
+-        sql_database->iteration_statement_ = std::make_unique<sql::Statement>(
+-            sql_database->db_.GetCachedStatement(
+-                SQL_FROM_HERE, kSqlSelectPassagesAndEmbeddingsWithinTimeRange));
+-        sql_database->iteration_statement_->BindTime(0,
+-                                                     time_range_start.value());
+-      } else {
+-        sql_database->iteration_statement_ = std::make_unique<sql::Statement>(
+-            sql_database->db_.GetCachedStatement(
+-                SQL_FROM_HERE, kSqlSelectPassagesAndEmbeddings));
++        sql.append(" AND passages.visit_time >= ?");
++      }
++      if (!url_id_filter.empty()) {
++        sql.append(" AND passages.url_id IN (?");
++        for (size_t i = 1; i < url_id_filter.size(); ++i) {
++          sql.append(",?");
++        }
++        sql.append(")");
++      }
++
++      sql_database->iteration_statement_ = std::make_unique<sql::Statement>(
++          sql_database->db_.GetUniqueStatement(sql));
++      int param_index = 0;
++      if (time_range_start.has_value()) {
++        sql_database->iteration_statement_->BindTime(param_index++,
++                                                     *time_range_start);
++      }
++      for (history::URLID id : url_id_filter) {
++        sql_database->iteration_statement_->BindInt64(param_index++, id);
+       }
+     }
+     ~RowDataIterator() override {
+@@ -541,7 +552,7 @@ SqlDatabase::MakeUrlDataIterator(std::optional<base::Time> time_range_start) {
+   };
+ 
+   return std::make_unique<RowDataIterator>(weak_ptr_factory_.GetWeakPtr(),
+-                                           time_range_start);
++                                           time_range_start, url_id_filter);
+ }
+ 
+ bool SqlDatabase::DeleteDataForUrlId(history::URLID url_id) {

--- a/patches/components-history_embeddings-core-sql_database.h.patch
+++ b/patches/components-history_embeddings-core-sql_database.h.patch
@@ -1,0 +1,14 @@
+diff --git a/components/history_embeddings/core/sql_database.h b/components/history_embeddings/core/sql_database.h
+index 0c9e524d6a7cbc903fb6ce4b5195f4608332d7e2..2e7d105ac63d7c2f60758f90841e658f70ea16ba 100644
+--- a/components/history_embeddings/core/sql_database.h
++++ b/components/history_embeddings/core/sql_database.h
+@@ -70,7 +70,8 @@ class SqlDatabase : public VectorDatabase {
+   size_t GetEmbeddingDimensions() const override;
+   bool AddUrlData(UrlData url_data) override;
+   std::unique_ptr<UrlDataIterator> MakeUrlDataIterator(
+-      std::optional<base::Time> time_range_start) override;
++      std::optional<base::Time> time_range_start,
++      const std::vector<history::URLID>& url_id_filter) override;
+ 
+   // These three methods are used to keep the on-disk persistence in sync with
+   // History deletions, either from user action or time-based expiration.

--- a/patches/components-history_embeddings-core-sql_database_unittest.cc.patch
+++ b/patches/components-history_embeddings-core-sql_database_unittest.cc.patch
@@ -1,0 +1,49 @@
+diff --git a/components/history_embeddings/core/sql_database_unittest.cc b/components/history_embeddings/core/sql_database_unittest.cc
+index dde15ad4fe46e647adea936a9c5126cb2460ff6d..eed5a4e13bce9537e8817d00217eda781e6cd8a2 100644
+--- a/components/history_embeddings/core/sql_database_unittest.cc
++++ b/components/history_embeddings/core/sql_database_unittest.cc
+@@ -91,7 +91,7 @@ class HistoryEmbeddingsSqlDatabaseTest : public testing::Test {
+   }
+ 
+   size_t GetEmbeddingCount(SqlDatabase* sql_database) {
+-    auto iterator = sql_database->MakeUrlDataIterator({});
++    auto iterator = sql_database->MakeUrlDataIterator({}, {});
+     EXPECT_TRUE(iterator);
+     size_t count = 0;
+     while (iterator->Next()) {
+@@ -194,7 +194,7 @@ TEST_F(HistoryEmbeddingsSqlDatabaseTest, WriteCloseAndThenReadUrlData) {
+   {
+     // Block scope destructs iterator before database is closed.
+     std::unique_ptr<VectorDatabase::UrlDataIterator> iterator =
+-        sql_database->MakeUrlDataIterator({});
++        sql_database->MakeUrlDataIterator({}, {});
+     EXPECT_TRUE(iterator);
+     for (const UrlData& url_data : url_datas) {
+       const UrlData* read_url_data = iterator->Next();
+@@ -317,7 +317,7 @@ TEST_F(HistoryEmbeddingsSqlDatabaseTest, IteratorMaySafelyOutliveDatabase) {
+   // Without database reset, iteration reads data.
+   {
+     std::unique_ptr<VectorDatabase::UrlDataIterator> iterator =
+-        sql_database->MakeUrlDataIterator({});
++        sql_database->MakeUrlDataIterator({}, {});
+     EXPECT_TRUE(iterator);
+     EXPECT_TRUE(iterator->Next());
+   }
+@@ -325,7 +325,7 @@ TEST_F(HistoryEmbeddingsSqlDatabaseTest, IteratorMaySafelyOutliveDatabase) {
+   // With database reset, iteration gracefully ends.
+   {
+     std::unique_ptr<VectorDatabase::UrlDataIterator> iterator =
+-        sql_database->MakeUrlDataIterator({});
++        sql_database->MakeUrlDataIterator({}, {});
+     EXPECT_TRUE(iterator);
+ 
+     // Reset database while iterator is still in scope.
+@@ -505,7 +505,7 @@ TEST_F(HistoryEmbeddingsSqlDatabaseTest, IterationSkipsAndReportsMismatches) {
+   {
+     // Iterate through stored data once.
+     std::unique_ptr<VectorDatabase::UrlDataIterator> iterator =
+-        sql_database->MakeUrlDataIterator({});
++        sql_database->MakeUrlDataIterator({}, {});
+     EXPECT_TRUE(iterator);
+     while (iterator->Next()) {
+       observed++;

--- a/patches/components-history_embeddings-core-vector_database.cc.patch
+++ b/patches/components-history_embeddings-core-vector_database.cc.patch
@@ -1,0 +1,75 @@
+diff --git a/components/history_embeddings/core/vector_database.cc b/components/history_embeddings/core/vector_database.cc
+index b380c2a1a8af209d7efd3e94e38a7a9b28a1b6d0..ffb3c0d78a5ec3e5267e620fe3e29559dd505830 100644
+--- a/components/history_embeddings/core/vector_database.cc
++++ b/components/history_embeddings/core/vector_database.cc
+@@ -245,7 +245,7 @@ SearchInfo VectorDatabase::FindNearest(
+   }
+ 
+   std::unique_ptr<UrlDataIterator> iterator =
+-      MakeUrlDataIterator(time_range_start);
++      MakeUrlDataIterator(time_range_start, search_params.url_id_filter);
+   if (!iterator) {
+     return {};
+   }
+@@ -378,41 +378,47 @@ bool VectorDatabaseInMemory::AddUrlData(UrlData url_data) {
+ 
+ std::unique_ptr<VectorDatabase::UrlDataIterator>
+ VectorDatabaseInMemory::MakeUrlDataIterator(
+-    std::optional<base::Time> time_range_start) {
++    std::optional<base::Time> time_range_start,
++    const std::vector<history::URLID>& url_id_filter) {
+   struct SimpleIterator : public UrlDataIterator {
+     explicit SimpleIterator(const std::vector<UrlData>& source,
+-                            std::optional<base::Time> time_range_start)
++                            std::optional<base::Time> time_range_start,
++                            std::vector<history::URLID> url_id_filter)
+         : iterator_(source.cbegin()),
+           end_(source.cend()),
+-          time_range_start_(time_range_start) {}
++          time_range_start_(time_range_start),
++          url_id_filter_(std::move(url_id_filter)) {}
+     ~SimpleIterator() override = default;
+ 
+     const UrlData* Next() override {
+-      if (time_range_start_.has_value()) {
+-        while (iterator_ != end_) {
+-          if (iterator_->visit_time >= time_range_start_.value()) {
+-            break;
+-          }
++      while (iterator_ != end_) {
++        if (time_range_start_.has_value() &&
++            iterator_->visit_time < time_range_start_.value()) {
+           iterator_++;
++          continue;
+         }
++        if (!url_id_filter_.empty() &&
++            !std::ranges::contains(url_id_filter_, iterator_->url_id)) {
++          iterator_++;
++          continue;
++        }
++        return &(*iterator_++);
+       }
+-
+-      if (iterator_ == end_) {
+-        return nullptr;
+-      }
+-      return &(*iterator_++);
++      return nullptr;
+     }
+ 
+     std::vector<UrlData>::const_iterator iterator_;
+     std::vector<UrlData>::const_iterator end_;
+     const std::optional<base::Time> time_range_start_;
++    const std::vector<history::URLID> url_id_filter_;
+   };
+ 
+   if (data_.empty()) {
+     return nullptr;
+   }
+ 
+-  return std::make_unique<SimpleIterator>(data_, time_range_start);
++  return std::make_unique<SimpleIterator>(data_, time_range_start,
++                                          url_id_filter);
+ }
+ 
+ std::vector<std::string> SplitQueryToTerms(

--- a/patches/components-history_embeddings-core-vector_database.h.patch
+++ b/patches/components-history_embeddings-core-vector_database.h.patch
@@ -1,0 +1,41 @@
+diff --git a/components/history_embeddings/core/vector_database.h b/components/history_embeddings/core/vector_database.h
+index 5746627f4113bf3edda6f068fcd77576938e212f..8b1fde8193165448ea2d30b8181c9f2c9f11d4df 100644
+--- a/components/history_embeddings/core/vector_database.h
++++ b/components/history_embeddings/core/vector_database.h
+@@ -95,6 +95,12 @@ struct SearchParams {
+ 
+   // If true, answering step will be skipped even if the query is answerable.
+   bool skip_answering = false;
++
++  // If non-empty, restricts the search to UrlData rows whose `url_id` is in
++  // this set. Empty means no restriction (search the full corpus). Storage
++  // backends use this to short-circuit a full scan when the caller already
++  // knows the candidate URLIDs (e.g. open tabs, a bookmarks folder).
++  std::vector<history::URLID> url_id_filter;
+ };
+ 
+ struct SearchInfo {
+@@ -193,9 +199,11 @@ class VectorDatabase {
+   virtual bool AddUrlData(UrlData url_data) = 0;
+ 
+   // Create an iterator that steps through database items.
+-  // Null may be returned if there are none.
++  // Null may be returned if there are none. When `url_id_filter` is non-empty
++  // the iterator yields only rows whose `url_id` is in the set.
+   virtual std::unique_ptr<UrlDataIterator> MakeUrlDataIterator(
+-      std::optional<base::Time> time_range_start) = 0;
++      std::optional<base::Time> time_range_start,
++      const std::vector<history::URLID>& url_id_filter) = 0;
+ 
+   // Searches the database for embeddings near given `query` and returns
+   // information about where they were found and how nearly the query matched.
+@@ -222,7 +230,8 @@ class VectorDatabaseInMemory : public VectorDatabase {
+   size_t GetEmbeddingDimensions() const override;
+   bool AddUrlData(UrlData url_data) override;
+   std::unique_ptr<UrlDataIterator> MakeUrlDataIterator(
+-      std::optional<base::Time> time_range_start) override;
++      std::optional<base::Time> time_range_start,
++      const std::vector<history::URLID>& url_id_filter) override;
+ 
+  private:
+   std::vector<UrlData> data_;

--- a/patches/components-omnibox-browser-history_embeddings_provider.cc.patch
+++ b/patches/components-omnibox-browser-history_embeddings_provider.cc.patch
@@ -1,0 +1,13 @@
+diff --git a/components/omnibox/browser/history_embeddings_provider.cc b/components/omnibox/browser/history_embeddings_provider.cc
+index d1bb7fbb2e2aee320d9017a7538cdff50fe43b8e..ae107cd847b20d1615c90ff0de06f42db252cd1a 100644
+--- a/components/omnibox/browser/history_embeddings_provider.cc
++++ b/components/omnibox/browser/history_embeddings_provider.cc
+@@ -93,7 +93,7 @@ void HistoryEmbeddingsProvider::Start(const AutocompleteInput& input,
+       metrics::OmniboxEventProto_Feature_HISTORY_EMBEDDINGS_FEATURE);
+   search->Search(
+       nullptr, base::UTF16ToUTF8(input_.text()), {}, provider_max_matches_,
+-      /*skip_answering=*/false,
++      /*skip_answering=*/false, /*url_id_filter=*/{},
+       base::BindRepeating(&HistoryEmbeddingsProvider::OnReceivedSearchResult,
+                           weak_factory_.GetWeakPtr()));
+ }

--- a/patches/components-omnibox-browser-history_embeddings_provider_unittest.cc.patch
+++ b/patches/components-omnibox-browser-history_embeddings_provider_unittest.cc.patch
@@ -1,0 +1,66 @@
+diff --git a/components/omnibox/browser/history_embeddings_provider_unittest.cc b/components/omnibox/browser/history_embeddings_provider_unittest.cc
+index 8330f50474d3dbc66b9d7a1c00dbfe3ea795ede9..2ef8f8cf51cba330ad54432c629a706651e9ffa3 100644
+--- a/components/omnibox/browser/history_embeddings_provider_unittest.cc
++++ b/components/omnibox/browser/history_embeddings_provider_unittest.cc
+@@ -117,6 +117,7 @@ class MockHistoryEmbeddingsSearch
+                std::optional<base::Time> time_range_start,
+                size_t count,
+                bool skip_answering,
++               std::vector<history::URLID> url_id_filter,
+                history_embeddings::SearchResultCallback callback),
+               (override));
+ };
+@@ -151,11 +152,12 @@ class HistoryEmbeddingsProviderTest : public testing::Test,
+     // can be ran to simulate `Search()` responding asyncly.
+     ON_CALL(*history_embeddings_search_,
+             Search(testing::_, testing::_, testing::_, testing::_, testing::_,
+-                   testing::_))
++                   testing::_, testing::_))
+         .WillByDefault(
+             [&](history_embeddings::SearchResult* previous_search_result,
+                 std::string query, std::optional<base::Time> time_range_start,
+                 size_t count, bool skip_answering,
++                std::vector<history::URLID> url_id_filter,
+                 history_embeddings::SearchResultCallback callback) {
+               search_callbacks_.push_back(base::BindOnce(
+                   [](history_embeddings::SearchResultCallback callback,
+@@ -207,7 +209,7 @@ TEST_F(HistoryEmbeddingsProviderTest, Start) {
+       .WillOnce(testing::Return(false));
+   EXPECT_CALL(*history_embeddings_search_,
+               Search(testing::_, testing::_, testing::_, testing::_, testing::_,
+-                     testing::_))
++                     testing::_, testing::_))
+       .Times(0);
+   history_embeddings_provider_->Start(long_input, false);
+   EXPECT_FALSE(trigger_service->GetFeatureTriggeredInSession(trigger_feature));
+@@ -229,7 +231,7 @@ TEST_F(HistoryEmbeddingsProviderTest, Start) {
+ 
+   EXPECT_CALL(*history_embeddings_search_,
+               Search(testing::_, testing::_, testing::_, testing::_, testing::_,
+-                     testing::_))
++                     testing::_, testing::_))
+       .Times(0);
+   history_embeddings_provider_->Start(short_input, false);
+   EXPECT_FALSE(trigger_service->GetFeatureTriggeredInSession(trigger_feature));
+@@ -238,16 +240,17 @@ TEST_F(HistoryEmbeddingsProviderTest, Start) {
+   // Sync queries should be blocked.
+   EXPECT_CALL(*history_embeddings_search_,
+               Search(testing::_, testing::_, testing::_, testing::_, testing::_,
+-                     testing::_))
++                     testing::_, testing::_))
+       .Times(0);
+   history_embeddings_provider_->Start(sync_long_input, false);
+   EXPECT_FALSE(trigger_service->GetFeatureTriggeredInSession(trigger_feature));
+   trigger_service->ResetSession();
+ 
+   // Long queries should pass.
+-  EXPECT_CALL(*history_embeddings_search_,
+-              Search(testing::_, "query query query",
+-                     std::optional<base::Time>{}, 3u, false, testing::_))
++  EXPECT_CALL(
++      *history_embeddings_search_,
++      Search(testing::_, "query query query", std::optional<base::Time>{}, 3u,
++             false, testing::_, testing::_))
+       .Times(1);
+   history_embeddings_provider_->Start(long_input, false);
+   EXPECT_TRUE(trigger_service->GetFeatureTriggeredInSession(trigger_feature));


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/55935

Mirrors https://chromium-review.googlesource.com/c/chromium/src/+/7902082
(merged as 95bcdbb98451). Threads a vector<URLID> url_id_filter from
HistoryEmbeddingsSearch::Search through SearchParams into
VectorDatabase::MakeUrlDataIterator. When non-empty, SqlDatabase fetches
only matching rows via 'WHERE passages.url_id IN (?,...)' in a single
statement; VectorDatabaseInMemory honors it inline.

Existing upstream callers (omnibox provider, WebUI handler, AI data
service) pass {} to preserve current behavior. 

Patches drop once the
local chromium baseline includes the merged CL.