### PR TITLE
[farbling] Fix webgpu tests and scrubbing issue

### DIFF
--- a/browser/farbling/BUILD.gn
+++ b/browser/farbling/BUILD.gn
@@ -56,6 +56,7 @@ if (!is_android) {
       "//components/prefs",
       "//content/public/browser",
       "//content/test:test_support",
+      "//gpu/config",
       "//ui/color:test_support",
       "//ui/native_theme:test_support",
     ]

--- a/browser/farbling/brave_webgpu_farbling_browsertest.cc
+++ b/browser/farbling/brave_webgpu_farbling_browsertest.cc
@@ -9,6 +9,7 @@
 #include "brave/components/brave_shields/core/common/features.h"
 #include "brave/components/constants/brave_paths.h"
 #include "brave/components/webcompat/core/common/features.h"
+#include "build/build_config.h"
 #include "chrome/browser/content_settings/host_content_settings_map_factory.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser.h"
@@ -162,10 +163,18 @@ INSTANTIATE_TEST_SUITE_P(
                         : "WebGLBalancedFingerprintingProtection_Disabled";
     });
 
+// Windows x64 doesn't have the WebGPU adapter support.
+#if BUILDFLAG(IS_WIN) && defined(ARCH_CPU_X86_64)
+#define NON_WIN_X64_TEST(test) DISABLED_##test
+#else
+#define NON_WIN_X64_TEST(test) test
+#endif
+
 // Tests that navigator.gpu.requestAdapter() → adapter.info fields (vendor,
 // architecture, device) are emptied under BALANCED (feature on) and MAXIMUM
 // farbling, and are returned as-is under OFF and BALANCED (feature off).
-IN_PROC_BROWSER_TEST_P(BraveWebGPUAdapterInfoTest, FarbleAdapterInfo) {
+IN_PROC_BROWSER_TEST_P(BraveWebGPUAdapterInfoTest,
+                       NON_WIN_X64_TEST(FarbleAdapterInfo)) {
   const std::string domain = "a.com";
   const GURL url = https_server_.GetURL(domain, "/adapter-info.html");
 
@@ -202,7 +211,8 @@ IN_PROC_BROWSER_TEST_P(BraveWebGPUAdapterInfoTest, FarbleAdapterInfo) {
 // (vendor, architecture, device) are emptied under BALANCED (feature on) and
 // MAXIMUM farbling, and are returned as-is under OFF and BALANCED (feature
 // off).
-IN_PROC_BROWSER_TEST_P(BraveWebGPUAdapterInfoTest, FarbleDeviceAdapterInfo) {
+IN_PROC_BROWSER_TEST_P(BraveWebGPUAdapterInfoTest,
+                       NON_WIN_X64_TEST(FarbleDeviceAdapterInfo)) {
   const std::string domain = "a.com";
   const GURL url = https_server_.GetURL(domain, "/device-adapter-info.html");
 
@@ -238,7 +248,7 @@ IN_PROC_BROWSER_TEST_P(BraveWebGPUAdapterInfoTest, FarbleDeviceAdapterInfo) {
 // Tests that adapter.info fields (vendor, architecture, device) are NOT
 // scrubbed under MAXIMUM farbling when WebGPU developer features are enabled.
 IN_PROC_BROWSER_TEST_F(BraveWebGPUDeveloperFeaturesTest,
-                       AdapterInfoNotScrubbed) {
+                       NON_WIN_X64_TEST(AdapterInfoNotScrubbed)) {
   const std::string domain = "a.com";
   const GURL url = https_server_.GetURL(domain, "/adapter-info.html");
 
@@ -263,7 +273,7 @@ IN_PROC_BROWSER_TEST_F(BraveWebGPUDeveloperFeaturesTest,
 // Tests that device.adapterInfo fields (vendor, architecture, device) are NOT
 // scrubbed under MAXIMUM farbling when WebGPU developer features are enabled.
 IN_PROC_BROWSER_TEST_F(BraveWebGPUDeveloperFeaturesTest,
-                       DeviceAdapterInfoNotScrubbed) {
+                       NON_WIN_X64_TEST(DeviceAdapterInfoNotScrubbed)) {
   const std::string domain = "a.com";
   const GURL url = https_server_.GetURL(domain, "/device-adapter-info.html");
 

--- a/browser/farbling/brave_webgpu_farbling_browsertest.cc
+++ b/browser/farbling/brave_webgpu_farbling_browsertest.cc
@@ -175,10 +175,6 @@ IN_PROC_BROWSER_TEST_P(BraveWebGPUAdapterInfoTest, FarbleAdapterInfo) {
   const std::string actual_off =
       EvalJs(contents(), kGPUAdapterInfoScript).ExtractString();
 
-  if (actual_off == "no-gpu" || actual_off == "no-adapter") {
-    GTEST_SKIP() << "WebGPU adapter not available in this environment";
-  }
-
   // Farbling level: maximum (BlockFingerprinting → BraveFarblingLevel::MAXIMUM)
   // All three adapter info fields must be empty regardless of the feature flag.
   BlockFingerprinting(domain);
@@ -216,11 +212,6 @@ IN_PROC_BROWSER_TEST_P(BraveWebGPUAdapterInfoTest, FarbleDeviceAdapterInfo) {
   const std::string actual_off =
       EvalJs(contents(), kGPUAdapterInfoScript).ExtractString();
 
-  if (actual_off == "no-gpu" || actual_off == "no-adapter" ||
-      actual_off == "no-device") {
-    GTEST_SKIP() << "WebGPU device not available in this environment";
-  }
-
   // Farbling level: maximum (BlockFingerprinting → BraveFarblingLevel::MAXIMUM)
   // All three adapter info fields must be empty regardless of the feature flag.
   BlockFingerprinting(domain);
@@ -257,9 +248,6 @@ IN_PROC_BROWSER_TEST_F(BraveWebGPUDeveloperFeaturesTest,
   const std::string actual_off =
       EvalJs(contents(), kGPUAdapterInfoScript).ExtractString();
 
-  if (actual_off == "no-gpu" || actual_off == "no-adapter") {
-    GTEST_SKIP() << "WebGPU adapter not available in this environment";
-  }
   // Developer features expose real values, so the baseline must not be empty.
   ASSERT_NE(actual_off, kEmptyAdapterInfo);
 
@@ -285,10 +273,6 @@ IN_PROC_BROWSER_TEST_F(BraveWebGPUDeveloperFeaturesTest,
   const std::string actual_off =
       EvalJs(contents(), kGPUAdapterInfoScript).ExtractString();
 
-  if (actual_off == "no-gpu" || actual_off == "no-adapter" ||
-      actual_off == "no-device") {
-    GTEST_SKIP() << "WebGPU device not available in this environment";
-  }
   // Developer features expose real values, so the baseline must not be empty.
   ASSERT_NE(actual_off, kEmptyAdapterInfo);
 

--- a/browser/farbling/brave_webgpu_farbling_browsertest.cc
+++ b/browser/farbling/brave_webgpu_farbling_browsertest.cc
@@ -17,6 +17,8 @@
 #include "components/content_settings/core/browser/host_content_settings_map.h"
 #include "content/public/test/browser_test.h"
 #include "content/public/test/browser_test_utils.h"
+#include "content/public/test/content_mock_cert_verifier.h"
+#include "gpu/config/gpu_switches.h"
 #include "net/dns/mock_host_resolver.h"
 #include "net/test/embedded_test_server/embedded_test_server.h"
 #include "third_party/blink/public/common/features.h"
@@ -40,7 +42,13 @@ constexpr char kEmptyAdapterInfo[] = ",,";
 
 class BraveWebGPUFarblingBrowserTest : public InProcessBrowserTest {
  public:
-  BraveWebGPUFarblingBrowserTest() {
+  // WebGPU's navigator.gpu is gated behind [SecureContext], so the test pages
+  // must be served from a secure origin. Use an HTTPS server backed by a mock
+  // cert verifier (which accepts the test cert for any hostname) so the
+  // existing per-domain Shields fingerprinting controls keep working.
+  // See navigator_gpu.idl in the upstream.
+  BraveWebGPUFarblingBrowserTest()
+      : https_server_(net::test_server::EmbeddedTestServer::TYPE_HTTPS) {
     scoped_feature_list_.InitWithFeatures(
         {
             brave_shields::features::kBraveShowStrictFingerprintingMode,
@@ -52,15 +60,34 @@ class BraveWebGPUFarblingBrowserTest : public InProcessBrowserTest {
   void SetUpOnMainThread() override {
     InProcessBrowserTest::SetUpOnMainThread();
 
+    mock_cert_verifier_.mock_cert_verifier()->set_default_result(net::OK);
     host_resolver()->AddRule("*", "127.0.0.1");
-    content::SetupCrossSiteRedirector(embedded_test_server());
+    content::SetupCrossSiteRedirector(&https_server_);
 
     base::FilePath test_data_dir =
         base::PathService::CheckedGet(brave::DIR_TEST_DATA);
     test_data_dir = test_data_dir.AppendASCII(kEmbeddedTestServerDirectory);
-    embedded_test_server()->ServeFilesFromDirectory(test_data_dir);
+    https_server_.ServeFilesFromDirectory(test_data_dir);
 
-    ASSERT_TRUE(embedded_test_server()->Start());
+    ASSERT_TRUE(https_server_.Start());
+  }
+
+  void SetUpCommandLine(base::CommandLine* command_line) override {
+    InProcessBrowserTest::SetUpCommandLine(command_line);
+    mock_cert_verifier_.SetUpCommandLine(command_line);
+    // Exposes navigator.gpu / a real adapter on platforms where WebGPU isn't
+    // enabled by default (e.g. Linux CI).
+    command_line->AppendSwitch(switches::kEnableUnsafeWebGPU);
+  }
+
+  void SetUpInProcessBrowserTestFixture() override {
+    InProcessBrowserTest::SetUpInProcessBrowserTestFixture();
+    mock_cert_verifier_.SetUpInProcessBrowserTestFixture();
+  }
+
+  void TearDownInProcessBrowserTestFixture() override {
+    InProcessBrowserTest::TearDownInProcessBrowserTestFixture();
+    mock_cert_verifier_.TearDownInProcessBrowserTestFixture();
   }
 
   HostContentSettingsMap* content_settings() {
@@ -70,19 +97,19 @@ class BraveWebGPUFarblingBrowserTest : public InProcessBrowserTest {
   void AllowFingerprinting(const std::string& domain) {
     brave_shields::SetFingerprintingControlType(
         content_settings(), ControlType::ALLOW,
-        embedded_test_server()->GetURL(domain, "/"));
+        https_server_.GetURL(domain, "/"));
   }
 
   void BlockFingerprinting(const std::string& domain) {
     brave_shields::SetFingerprintingControlType(
         content_settings(), ControlType::BLOCK,
-        embedded_test_server()->GetURL(domain, "/"));
+        https_server_.GetURL(domain, "/"));
   }
 
   void SetFingerprintingDefault(const std::string& domain) {
     brave_shields::SetFingerprintingControlType(
         content_settings(), ControlType::DEFAULT,
-        embedded_test_server()->GetURL(domain, "/"));
+        https_server_.GetURL(domain, "/"));
   }
 
   content::WebContents* contents() {
@@ -90,7 +117,21 @@ class BraveWebGPUFarblingBrowserTest : public InProcessBrowserTest {
   }
 
  protected:
+  net::EmbeddedTestServer https_server_;
+  content::ContentMockCertVerifier mock_cert_verifier_;
   base::test::ScopedFeatureList scoped_feature_list_;
+};
+
+// Test no scrubbing fixture.
+class BraveWebGPUDeveloperFeaturesTest : public BraveWebGPUFarblingBrowserTest {
+ public:
+  void SetUpCommandLine(base::CommandLine* command_line) override {
+    BraveWebGPUFarblingBrowserTest::SetUpCommandLine(command_line);
+    // When --enable-webgpu-developer-features is set,
+    // GPUAdapter::CreateAdapterInfoForAdapter() returns the full, real adapter
+    // info and the farbling scrubbing is intentionally bypassed.
+    command_line->AppendSwitch(switches::kEnableWebGPUDeveloperFeatures);
+  }
 };
 
 // Parameterized over whether kWebGLBalancedFingerprintingProtection is enabled,
@@ -126,7 +167,7 @@ INSTANTIATE_TEST_SUITE_P(
 // farbling, and are returned as-is under OFF and BALANCED (feature off).
 IN_PROC_BROWSER_TEST_P(BraveWebGPUAdapterInfoTest, FarbleAdapterInfo) {
   const std::string domain = "a.com";
-  const GURL url = embedded_test_server()->GetURL(domain, "/adapter-info.html");
+  const GURL url = https_server_.GetURL(domain, "/adapter-info.html");
 
   // Farbling level: off — collect the real adapter info as a baseline.
   AllowFingerprinting(domain);
@@ -167,8 +208,7 @@ IN_PROC_BROWSER_TEST_P(BraveWebGPUAdapterInfoTest, FarbleAdapterInfo) {
 // off).
 IN_PROC_BROWSER_TEST_P(BraveWebGPUAdapterInfoTest, FarbleDeviceAdapterInfo) {
   const std::string domain = "a.com";
-  const GURL url =
-      embedded_test_server()->GetURL(domain, "/device-adapter-info.html");
+  const GURL url = https_server_.GetURL(domain, "/device-adapter-info.html");
 
   // Farbling level: off — collect the real adapter info as a baseline.
   AllowFingerprinting(domain);
@@ -202,4 +242,61 @@ IN_PROC_BROWSER_TEST_P(BraveWebGPUAdapterInfoTest, FarbleDeviceAdapterInfo) {
     // kWebGLBalancedFingerprintingProtection disabled: fields must be real.
     EXPECT_EQ(actual_balanced, actual_off);
   }
+}
+
+// Tests that adapter.info fields (vendor, architecture, device) are NOT
+// scrubbed under MAXIMUM farbling when WebGPU developer features are enabled.
+IN_PROC_BROWSER_TEST_F(BraveWebGPUDeveloperFeaturesTest,
+                       AdapterInfoNotScrubbed) {
+  const std::string domain = "a.com";
+  const GURL url = https_server_.GetURL(domain, "/adapter-info.html");
+
+  // Farbling level: off — collect the real adapter info as a baseline.
+  AllowFingerprinting(domain);
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
+  const std::string actual_off =
+      EvalJs(contents(), kGPUAdapterInfoScript).ExtractString();
+
+  if (actual_off == "no-gpu" || actual_off == "no-adapter") {
+    GTEST_SKIP() << "WebGPU adapter not available in this environment";
+  }
+  // Developer features expose real values, so the baseline must not be empty.
+  ASSERT_NE(actual_off, kEmptyAdapterInfo);
+
+  // Farbling level: maximum (BlockFingerprinting →
+  // BraveFarblingLevel::MAXIMUM). Developer features bypass scrubbing, so the
+  // info must match the baseline.
+  BlockFingerprinting(domain);
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
+  EXPECT_EQ(EvalJs(contents(), kGPUAdapterInfoScript).ExtractString(),
+            actual_off);
+}
+
+// Tests that device.adapterInfo fields (vendor, architecture, device) are NOT
+// scrubbed under MAXIMUM farbling when WebGPU developer features are enabled.
+IN_PROC_BROWSER_TEST_F(BraveWebGPUDeveloperFeaturesTest,
+                       DeviceAdapterInfoNotScrubbed) {
+  const std::string domain = "a.com";
+  const GURL url = https_server_.GetURL(domain, "/device-adapter-info.html");
+
+  // Farbling level: off — collect the real adapter info as a baseline.
+  AllowFingerprinting(domain);
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
+  const std::string actual_off =
+      EvalJs(contents(), kGPUAdapterInfoScript).ExtractString();
+
+  if (actual_off == "no-gpu" || actual_off == "no-adapter" ||
+      actual_off == "no-device") {
+    GTEST_SKIP() << "WebGPU device not available in this environment";
+  }
+  // Developer features expose real values, so the baseline must not be empty.
+  ASSERT_NE(actual_off, kEmptyAdapterInfo);
+
+  // Farbling level: maximum (BlockFingerprinting →
+  // BraveFarblingLevel::MAXIMUM). Developer features bypass scrubbing, so the
+  // info must match the baseline.
+  BlockFingerprinting(domain);
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
+  EXPECT_EQ(EvalJs(contents(), kGPUAdapterInfoScript).ExtractString(),
+            actual_off);
 }

--- a/chromium_src/third_party/blink/renderer/modules/webgpu/gpu_adapter.cc
+++ b/chromium_src/third_party/blink/renderer/modules/webgpu/gpu_adapter.cc
@@ -56,9 +56,9 @@ class BraveScrubWebGpuAdapterInfo {
 
 }  // namespace blink
 
-#define BRAVE_SCRUB_WEBGPU_ADAPTER_INFO                             \
-  BraveScrubWebGpuAdapterInfo(gpu_->GetExecutionContext(), vendor_, \
-                              architecture_, device_);
+#define BRAVE_SCRUB_WEBGPU_ADAPTER_INFO                                \
+  BraveScrubWebGpuAdapterInfo scrub_guard(gpu_->GetExecutionContext(), \
+                                          vendor_, architecture_, device_);
 
 #include <third_party/blink/renderer/modules/webgpu/gpu_adapter.cc>
 


### PR DESCRIPTION
Currently the [BraveScrubWebGpuAdapterInfo](https://sourcegraph.com/r/github.com/brave/brave-core/-/blob/chromium_src/third_party/blink/renderer/modules/webgpu/gpu_adapter.cc?L60) instance in [gpu_adapter.cc](https://sourcegraph.com/r/github.com/brave/brave-core/-/blob/chromium_src/third_party/blink/renderer/modules/webgpu/gpu_adapter.cc?L60) is a temporary object that gets destroyed immediately after the semi-colon. This object was originally intended to be preserved until the end of the [method scope](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/modules/webgpu/gpu_adapter.cc;l=125?q=gpu_adapter.cc) where it's defined, and, because of the early destruction the scrubbing didn't occur. 

This bug was also not also flagged by the corresponding [brave_webgpu_farbling_browsertests](https://sourcegraph.com/r/github.com/brave/brave-core/-/blob/browser/farbling/brave_webgpu_farbling_browsertest.cc) either. The tests were shown as passed but they were actually [skipped](https://sourcegraph.com/r/github.com/brave/brave-core/-/blob/browser/farbling/brave_webgpu_farbling_browsertest.cc?L179-181) because of not having a valid instance of `navigator.gpu`. The GTEST_SKIP() should have ideally printed out the SKIPPED with the skipped message, but due to the fact that our tests are piped through `npm run test` it added extra constraints on the output shown to the user. So, both "SKIPPED" and the message were omitted. 

This change also fixes the webgpu browser tests which skipped the tests. The fix was to serving the test page from a secured context, as it was required to access the `navigator.gpu` instance. This constraint is set in [navigator_gpu.idl](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/modules/webgpu/navigator_gpu.idl;l=10?q=navigator_gpu.idl) SECURE_CONTEXT constraint. Along with the secure context, the tests also had to add the command line switch [kEnableUnsafeWebGPU](https://source.chromium.org/chromium/chromium/src/+/main:gpu/config/gpu_switches.cc;l=52). 

This change also adds another test to ensure we don't scrub when the [kEnableWebGPUDeveloperFeatures](https://source.chromium.org/chromium/chromium/src/+/main:gpu/config/gpu_switches.cc;l=56-59) switch was enabled. 

<!-- Add brave-browser issue below that this PR will resolve -->
Related https://github.com/brave/brave-browser/issues/55677 

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
