### PR TITLE
[iOS] Add support for token validation in JavaScriptFeatures

### DIFF
--- a/ios/web/js_messaging/BUILD.gn
+++ b/ios/web/js_messaging/BUILD.gn
@@ -5,28 +5,56 @@
 
 import("//ios/web/public/js_messaging/compile_ts.gni")
 import("//ios/web/public/js_messaging/optimize_js.gni")
+import("//ios/web/public/js_messaging/optimize_ts.gni")
 
 source_set("js_messaging") {
   sources = [
     "safe_builtins_javascript_feature.h",
     "safe_builtins_javascript_feature.mm",
   ]
-  deps = [ ":safe_builtins_js" ]
+  deps = [
+    ":message_handler_token",
+    ":safe_builtins_js",
+  ]
   public_deps = [ "//ios/web/public/js_messaging" ]
+}
+
+source_set("message_handler_token") {
+  sources = [
+    "message_handler_token.h",
+    "message_handler_token.mm",
+  ]
+  public_deps = [
+    "//base",
+    "//ios/web/public/js_messaging",
+  ]
 }
 
 source_set("unittests") {
   testonly = true
-  sources = [ "safe_builtins_javascript_test.mm" ]
+  sources = [
+    "message_handler_token_inttest.mm",
+    "safe_builtins_javascript_test.mm",
+  ]
   deps = [
+    ":message_handler_token",
+    ":message_handler_token_test_api",
     ":safe_builtins_js",
     "//base",
     "//base/test:test_support",
+    "//ios/web/public/js_messaging",
     "//ios/web/public/test:javascript_test",
+    "//ios/web/public/test:test_fixture",
     "//ios/web/public/test:util",
+    "//ios/web/public/test/fakes",
     "//testing/gtest",
     "//url",
   ]
+}
+
+compile_ts("util_scripts") {
+  sources = [ "resources/utils.ts" ]
+  deps = [ ":safe_builtins" ]
 }
 
 compile_ts("safe_builtins") {
@@ -41,4 +69,14 @@ optimize_js("safe_builtins_js") {
   output_name = "safe_builtins"
 
   deps = [ ":safe_builtins" ]
+}
+
+optimize_ts("message_handler_token_test_api") {
+  testonly = true
+  sources = [ "resources/message_handler_token_test_api.ts" ]
+  deps = [
+    ":util_scripts",
+    "//ios/web/public/js_messaging:gcrweb",
+    "//ios/web/public/js_messaging:util_scripts",
+  ]
 }

--- a/ios/web/js_messaging/message_handler_token.h
+++ b/ios/web/js_messaging/message_handler_token.h
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_IOS_WEB_JS_MESSAGING_MESSAGE_HANDLER_TOKEN_H_
+#define BRAVE_IOS_WEB_JS_MESSAGING_MESSAGE_HANDLER_TOKEN_H_
+
+#include <optional>
+#include <string>
+
+#include "base/uuid.h"
+#include "ios/web/public/js_messaging/java_script_feature.h"
+
+namespace web {
+
+class ScriptMessage;
+
+// A composable helper that generates a stable, per-instance token for use with
+// JavaScriptFeature subclasses.
+//
+// Hold an instance as a member of a JavaScriptFeature and provide
+// FeatureScripts replacements callback with the GetPlaceholderReplacements call
+// and use `GetValidatedScriptMessageBody` in your JavaScriptMessage's message
+// received override.
+//
+// To send tokenized messages to the JavaScriptFeature from TypeScript, use
+// `sendTokenizedWebKitMessage` or `sendTokenizedWebKitMessageWithReply` from
+// `//brave/ios/js_messaging/resources/utils.js`
+class MessageHandlerToken {
+ public:
+  using PlaceholderReplacements =
+      web::JavaScriptFeature::FeatureScript::PlaceholderReplacements;
+
+  // Returns the message passed in from `sendTokenizedWebKitMessage` if the
+  // token matches or nullptr if the token is missing or invalid
+  std::optional<const base::Value*> GetValidatedScriptMessageBody(
+      const web::ScriptMessage& script_message);
+
+  // Returns the FeatureScript placeholder replacements map that substitutes
+  // the JavaScript-side placeholder (`gCrWebPlaceholderMessageHandlerToken`)
+  PlaceholderReplacements GetPlaceholderReplacements() const;
+
+ private:
+  base::Uuid token_ = base::Uuid::GenerateRandomV4();
+};
+
+}  // namespace web
+
+#endif  // BRAVE_IOS_WEB_JS_MESSAGING_MESSAGE_HANDLER_TOKEN_H_

--- a/ios/web/js_messaging/message_handler_token.mm
+++ b/ios/web/js_messaging/message_handler_token.mm
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/ios/web/js_messaging/message_handler_token.h"
+
+#include <optional>
+
+#include "base/strings/sys_string_conversions.h"
+#include "ios/web/public/js_messaging/script_message.h"
+
+namespace web {
+
+namespace {
+constexpr char kTokenKey[] = "token";
+constexpr char kMessageKey[] = "message";
+}  // namespace
+
+std::optional<const base::Value*>
+MessageHandlerToken::GetValidatedScriptMessageBody(
+    const web::ScriptMessage& script_message) {
+  const base::DictValue* script_dict =
+      script_message.body() ? script_message.body()->GetIfDict() : nullptr;
+  if (!script_dict) {
+    return std::nullopt;
+  }
+
+  const std::string* token = script_dict->FindString(kTokenKey);
+  if (!token || *token != token_.AsLowercaseString()) {
+    return std::nullopt;
+  }
+
+  const base::Value* message = script_dict->Find(kMessageKey);
+  if (!message) {
+    return std::nullopt;
+  }
+
+  return message;
+}
+
+web::JavaScriptFeature::FeatureScript::PlaceholderReplacements
+MessageHandlerToken::GetPlaceholderReplacements() const {
+  return @{
+    @"gCrWebPlaceholderMessageHandlerToken" :
+        base::SysUTF8ToNSString(token_.AsLowercaseString())
+  };
+}
+
+}  // namespace web

--- a/ios/web/js_messaging/message_handler_token_inttest.mm
+++ b/ios/web/js_messaging/message_handler_token_inttest.mm
@@ -1,0 +1,120 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include <memory>
+#include <string>
+
+#include "base/functional/bind.h"
+#include "base/test/ios/wait_util.h"
+#include "brave/ios/web/js_messaging/message_handler_token.h"
+#include "ios/web/public/js_messaging/content_world.h"
+#include "ios/web/public/js_messaging/java_script_feature.h"
+#include "ios/web/public/js_messaging/script_message.h"
+#include "ios/web/public/test/fakes/fake_web_client.h"
+#include "ios/web/public/test/js_test_util.h"
+#include "ios/web/public/test/web_test_with_web_state.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace {
+
+// Test feature that composes a RandomizedMessageHandlerName and records
+// whether it has received a script message so tests can assert against it.
+class TestJavaScriptFeature : public web::JavaScriptFeature {
+ public:
+  TestJavaScriptFeature()
+      : JavaScriptFeature(
+            web::ContentWorld::kPageContentWorld,
+            {FeatureScript::CreateWithFilename(
+                "message_handler_token_test_api",
+                FeatureScript::InjectionTime::kDocumentStart,
+                FeatureScript::TargetFrames::kMainFrame,
+                FeatureScript::ReinjectionBehavior::kInjectOncePerWindow,
+                base::BindRepeating(
+                    &web::MessageHandlerToken::GetPlaceholderReplacements,
+                    base::Unretained(&token_)))}) {}
+  ~TestJavaScriptFeature() override = default;
+
+  std::optional<std::string> GetScriptMessageHandlerName() const override {
+    return "ScriptHandlerName";
+  }
+
+  bool valid_message_received() const { return message_received_; }
+  bool invalid_message_received() const { return invalid_message_received_; }
+
+  void ScriptMessageReceived(web::WebState* web_state,
+                             const web::ScriptMessage& message) override {
+    auto body = token_.GetValidatedScriptMessageBody(message);
+    if (body) {
+      auto* dict = body.value()->GetIfDict();
+      if (!dict) {
+        return;
+      }
+      auto* value = dict->FindString("key");
+      if (value) {
+        message_received_ = *value == "value";
+      }
+    } else {
+      invalid_message_received_ = true;
+    }
+  }
+
+ private:
+  web::MessageHandlerToken token_;
+  bool message_received_ = false;
+  bool invalid_message_received_ = false;
+};
+
+}  // namespace
+
+class MessageHandlerTokenFeatureTest : public web::WebTestWithWebState {
+ protected:
+  MessageHandlerTokenFeatureTest()
+      : web::WebTestWithWebState(std::make_unique<web::FakeWebClient>()) {}
+
+  void SetUp() override {
+    WebTestWithWebState::SetUp();
+
+    feature_ = std::make_unique<TestJavaScriptFeature>();
+    static_cast<web::FakeWebClient*>(GetWebClient())
+        ->SetJavaScriptFeatures({feature_.get()});
+    LoadHtml(@"<html></html>");
+  }
+
+  void TearDown() override {
+    feature_.reset();
+    WebTestWithWebState::TearDown();
+  }
+
+  std::unique_ptr<TestJavaScriptFeature> feature_;
+};
+
+// Tests that the message body received is valid with the correct token
+TEST_F(MessageHandlerTokenFeatureTest, TestValidMessageReceived) {
+  ASSERT_FALSE(feature_->valid_message_received());
+  web::test::ExecuteJavaScriptForFeature(
+      web_state(),
+      @"__gCrWeb.callFunctionInGcrWeb('message_handler_token_tests', "
+      @"'sendTokenizedWebKitMessage', [])",
+      feature_.get());
+  ASSERT_TRUE(base::test::ios::WaitUntilConditionOrTimeout(
+      base::test::ios::kWaitForJSCompletionTimeout, ^bool {
+        return feature_->valid_message_received();
+      }));
+}
+
+// Tests that the message body received that contains no token is invalid and
+// not handled
+TEST_F(MessageHandlerTokenFeatureTest, TestInvalidMessageReceived) {
+  ASSERT_FALSE(feature_->invalid_message_received());
+  web::test::ExecuteJavaScriptForFeature(
+      web_state(),
+      @"__gCrWeb.callFunctionInGcrWeb('message_handler_token_tests', "
+      @"'sendWebKitMessage', [])",
+      feature_.get());
+  ASSERT_TRUE(base::test::ios::WaitUntilConditionOrTimeout(
+      base::test::ios::kWaitForJSCompletionTimeout, ^bool {
+        return feature_->invalid_message_received();
+      }));
+}

--- a/ios/web/js_messaging/resources/message_handler_token_test_api.ts
+++ b/ios/web/js_messaging/resources/message_handler_token_test_api.ts
@@ -1,0 +1,20 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import {CrWebApi, gCrWeb} from '//ios/web/public/js_messaging/resources/gcrweb.js';
+import {sendTokenizedWebKitMessage} from "//brave/ios/web/js_messaging/resources/utils.js";
+import {sendWebKitMessage} from "//ios/web/public/js_messaging/resources/utils.js";
+
+function send() {
+  sendTokenizedWebKitMessage('ScriptHandlerName', {'key': 'value'});
+}
+function sendInvalid() {
+  sendWebKitMessage('ScriptHandlerName', {'key': 'value'});
+}
+
+const testApi = new CrWebApi('message_handler_token_tests');
+testApi.addFunction('sendTokenizedWebKitMessage', send);
+testApi.addFunction('sendWebKitMessage', sendInvalid);
+gCrWeb.registerApi(testApi);

--- a/ios/web/js_messaging/resources/safe_builtins.ts
+++ b/ios/web/js_messaging/resources/safe_builtins.ts
@@ -3,21 +3,46 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
+declare global {
+  interface Window {
+    webkit: any;
+  }
+}
+
 class SafeBuiltins {
   readonly $Object: typeof Object = this.secureCopy(Object);
   readonly $Function: typeof Function = this.secureCopy(Function);
   readonly $Array: typeof Array = this.secureCopy(Array);
   readonly $ = function(value: any): any { return value; }
 
+  // Sends a message to a script message handler in the browser
+  readonly sendWebKitMessage: (handlerName: string, message: object|string) => void;
+
+  // Sends a message to a script message handler in the browser and returns a
+  // Promise that resolves when the browser replies
+  readonly sendWebKitMessageWithReply: (handlerName: string, message: object|string) => Promise<any>;
+
   constructor() {
-    // Freeze all the safe builtins
-    for (const value of [this.$Object, this.$Function, this.$Array, this.$]) {
+    // Setup private refs to capture in safe builtin functions
+    const webkitMessageHandlers = window.webkit.messageHandlers;
+
+    this.sendWebKitMessage = (handlerName, message) => {
+      webkitMessageHandlers[handlerName].postMessage(message);
+    }
+
+    this.sendWebKitMessageWithReply = (handlerName, message) => {
+      return webkitMessageHandlers[handlerName].postMessage(message);
+    }
+
+    // Freeze all the safe builtins and any function we export
+    for (const value of [this.$Object, this.$Function, this.$Array, this.$,
+      this.sendWebKitMessage, this.sendWebKitMessageWithReply]) {
       this.deepFreeze(value);
     }
   }
 
   // Freeze an object and its prototype
-  deepFreeze(value: any) {
+  private deepFreeze(value: any) {
     if (!value) {
       return;
     }

--- a/ios/web/js_messaging/resources/utils.ts
+++ b/ios/web/js_messaging/resources/utils.ts
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { gSafeBuiltins }
+  from "//brave/ios/web/js_messaging/resources/safe_builtins.js";
+
+// A token to be used for validating communication with the browser
+const messageHandlerToken: string = 'gCrWebPlaceholderMessageHandlerToken';
+
+// Posts `message` to the webkit message handler specified by `handlerName` and
+// embeds a token for the browser to validate
+export function sendTokenizedWebKitMessage(
+    handlerName: string, message: object|string) {
+  gSafeBuiltins.sendWebKitMessage(handlerName, {
+    token: messageHandlerToken,
+    message: message
+  });
+}
+
+// Posts `message` to the webkit message handler specified by `handlerName` and
+// embeds a token for the browser to validate and waits for a reply
+export function sendTokenizedWebKitMessageWithReply(
+    handlerName: string, message: object|string): Promise<any> {
+  return gSafeBuiltins.sendWebKitMessageWithReply(handlerName, {
+    token: messageHandlerToken,
+    message: message
+  })
+}


### PR DESCRIPTION
This change adds a helper class `MessageHandlerToken` that can be used in JavaScriptFeature's to support tokenized communication validation. The token is a UUIDv4 which is injected with the script itself via placeholder 
