### PR TITLE
[iOS] Add support for handling JavaScript prompts in JavaScriptFeatures

### DIFF
--- a/chromium_src/ios/web/js_messaging/java_script_content_world.h
+++ b/chromium_src/ios/web/js_messaging/java_script_content_world.h
@@ -1,0 +1,29 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_CHROMIUM_SRC_IOS_WEB_JS_MESSAGING_JAVA_SCRIPT_CONTENT_WORLD_H_
+#define BRAVE_CHROMIUM_SRC_IOS_WEB_JS_MESSAGING_JAVA_SCRIPT_CONTENT_WORLD_H_
+
+#include "base/containers/flat_map.h"
+
+// Add a new function `GetFeatureReplyingToPrompts` and map to the
+// `JavaScriptContentWorld` type which will be used to obtain a
+// `JavaScriptFeature` based on the supplied handler name to call into when
+// handling window prompts
+#define AddFeature(...)                                 \
+  AddFeature(__VA_ARGS__);                              \
+  const JavaScriptFeature* GetFeatureReplyingToPrompts( \
+      const std::string& handler_name)
+#define features_                                       \
+  features_;                                            \
+  base::flat_map<std::string, const JavaScriptFeature*> \
+      prompt_replying_features_
+
+#include <ios/web/js_messaging/java_script_content_world.h>  // IWYU pragma: export
+
+#undef features_
+#undef AddFeature
+
+#endif  // BRAVE_CHROMIUM_SRC_IOS_WEB_JS_MESSAGING_JAVA_SCRIPT_CONTENT_WORLD_H_

--- a/chromium_src/ios/web/js_messaging/java_script_content_world.mm
+++ b/chromium_src/ios/web/js_messaging/java_script_content_world.mm
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "ios/web/js_messaging/java_script_content_world.h"
+
+// Add to the map of prompt replying features during the `AddFeature` call.
+// At this point `optional_handler_name` optionality is already checked
+#define script_message_handlers_                                        \
+  if (feature->GetFeatureRepliesToPrompts()) {                          \
+    prompt_replying_features_[optional_handler_name.value()] = feature; \
+  }                                                                     \
+  script_message_handlers_
+
+#include <ios/web/js_messaging/java_script_content_world.mm>
+
+#undef script_message_handlers_
+
+namespace web {
+
+const JavaScriptFeature* JavaScriptContentWorld::GetFeatureReplyingToPrompts(
+    const std::string& handler_name) {
+  auto it = prompt_replying_features_.find(handler_name);
+  if (it == prompt_replying_features_.end()) {
+    return nullptr;
+  }
+  return it->second;
+}
+
+}  // namespace web

--- a/chromium_src/ios/web/js_messaging/java_script_feature.mm
+++ b/chromium_src/ios/web/js_messaging/java_script_feature.mm
@@ -1,0 +1,14 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include <ios/web/js_messaging/java_script_feature.mm>
+
+namespace web {
+
+bool JavaScriptFeature::GetFeatureRepliesToPrompts() const {
+  return false;
+}
+
+}  // namespace web

--- a/chromium_src/ios/web/public/js_messaging/java_script_feature.h
+++ b/chromium_src/ios/web/public/js_messaging/java_script_feature.h
@@ -1,0 +1,26 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_CHROMIUM_SRC_IOS_WEB_PUBLIC_JS_MESSAGING_JAVA_SCRIPT_FEATURE_H_
+#define BRAVE_CHROMIUM_SRC_IOS_WEB_PUBLIC_JS_MESSAGING_JAVA_SCRIPT_FEATURE_H_
+
+// Adding a new function that will allow JavaScriptFeature's to reply to
+// window.prompt communications. Defaults to false. JavaScriptFeature's that
+// return true from this must implement `ScriptMessageReceivedWithReply` and
+// call the completion handler synchronously.
+#define GetFeatureRepliesToMessages    \
+  GetFeatureRepliesToMessages() const; \
+  virtual bool GetFeatureRepliesToPrompts
+// Friending PromptFacade so it can call ScriptMessageReceivedWithReply.
+#define JavaScriptContentWorld \
+  JavaScriptContentWorld;      \
+  friend class PromptFacade
+
+#include <ios/web/public/js_messaging/java_script_feature.h>  // IWYU pragma: export
+
+#undef JavaScriptContentWorld
+#undef GetFeatureRepliesToMessages
+
+#endif  // BRAVE_CHROMIUM_SRC_IOS_WEB_PUBLIC_JS_MESSAGING_JAVA_SCRIPT_FEATURE_H_

--- a/chromium_src/ios/web/web_state/ui/DEPS
+++ b/chromium_src/ios/web/web_state/ui/DEPS
@@ -1,0 +1,3 @@
+include_rules = [
+  "+brave/ios/web/js_messaging/prompt_facade.h"
+]

--- a/chromium_src/ios/web/web_state/ui/crw_web_controller.mm
+++ b/chromium_src/ios/web/web_state/ui/crw_web_controller.mm
@@ -7,20 +7,31 @@
 
 #include <WebKit/WebKit.h>
 
+#include "ios/web/web_state/ui/crw_wk_ui_handler.h"
 #include "net/base/apple/url_conversions.h"
 #include "url/gurl.h"
 
-// Replace the underlying CRWWKNavigationHandler with our subclass
-#define _navigationHandler                                         \
-  _navigationHandler =                                             \
-      [[BraveCRWWKNavigationHandler alloc] initWithDelegate:self]; \
-  if (false) [[maybe_unused]]                                      \
-  auto* _
+// Replace the navigation & UI handlers with Brave subclasses
+#define initWithWebState                                               \
+  initWithWebState:                                                    \
+  (WebStateImpl*)webState {                                            \
+    if ((self = [self initWithWebState_Chromium:webState])) {          \
+      _navigationHandler =                                             \
+          [[BraveCRWWKNavigationHandler alloc] initWithDelegate:self]; \
+      _UIHandler = [[BraveCRWWKUIHandler alloc] init];                 \
+      _UIHandler.delegate = self;                                      \
+    }                                                                  \
+    return self;                                                       \
+  }                                                                    \
+  -(instancetype)initWithWebState_Chromium
+
 // Support for tab sync
 #define webViewNavigationProxy webViewNavigationProxy_ChromiumImpl
+
 #include <ios/web/web_state/ui/crw_web_controller.mm>
+
 #undef webViewNavigationProxy
-#undef _navigationHandler
+#undef initWithWebState
 
 #pragma mark - BackForwardList
 

--- a/chromium_src/ios/web/web_state/ui/crw_web_controller.mm
+++ b/chromium_src/ios/web/web_state/ui/crw_web_controller.mm
@@ -7,23 +7,8 @@
 
 #include <WebKit/WebKit.h>
 
-#include "ios/web/web_state/ui/crw_wk_ui_handler.h"
 #include "net/base/apple/url_conversions.h"
 #include "url/gurl.h"
-
-// Replace the navigation & UI handlers with Brave subclasses
-#define initWithWebState                                               \
-  initWithWebState:                                                    \
-  (WebStateImpl*)webState {                                            \
-    if ((self = [self initWithWebState_Chromium:webState])) {          \
-      _navigationHandler =                                             \
-          [[BraveCRWWKNavigationHandler alloc] initWithDelegate:self]; \
-      _UIHandler = [[BraveCRWWKUIHandler alloc] init];                 \
-      _UIHandler.delegate = self;                                      \
-    }                                                                  \
-    return self;                                                       \
-  }                                                                    \
-  -(instancetype)initWithWebState_Chromium
 
 // Support for tab sync
 #define webViewNavigationProxy webViewNavigationProxy_ChromiumImpl
@@ -31,7 +16,6 @@
 #include <ios/web/web_state/ui/crw_web_controller.mm>
 
 #undef webViewNavigationProxy
-#undef initWithWebState
 
 #pragma mark - BackForwardList
 

--- a/chromium_src/ios/web/web_state/ui/crw_wk_ui_handler.h
+++ b/chromium_src/ios/web/web_state/ui/crw_wk_ui_handler.h
@@ -1,0 +1,16 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_CHROMIUM_SRC_IOS_WEB_WEB_STATE_UI_CRW_WK_UI_HANDLER_H_
+#define BRAVE_CHROMIUM_SRC_IOS_WEB_WEB_STATE_UI_CRW_WK_UI_HANDLER_H_
+
+#include <ios/web/web_state/ui/crw_wk_ui_handler.h>  // IWYU pragma: export
+
+// A CRWWKUIHandler subclass which will override the WKUIDelegate methods to
+// handle JavaScript prompts
+@interface BraveCRWWKUIHandler : CRWWKUIHandler
+@end
+
+#endif  // BRAVE_CHROMIUM_SRC_IOS_WEB_WEB_STATE_UI_CRW_WK_UI_HANDLER_H_

--- a/chromium_src/ios/web/web_state/ui/crw_wk_ui_handler.mm
+++ b/chromium_src/ios/web/web_state/ui/crw_wk_ui_handler.mm
@@ -3,7 +3,17 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
+#include "brave/chromium_src/ios/web/web_state/ui/crw_wk_ui_handler.h"
+
+#include <memory>
+#include <string>
+
+#include "base/strings/sys_string_conversions.h"
+#include "brave/ios/web/js_messaging/prompt_facade.h"
+#include "ios/web/common/url_scheme_util.h"
 #include "ios/web/public/web_client.h"
+#include "net/base/apple/url_conversions.h"
+#include "url/gurl.h"
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wnullability-completeness"
@@ -15,5 +25,49 @@
 #include <ios/web/web_state/ui/crw_wk_ui_handler.mm>
 
 #undef IsAppSpecificURL
+
+@implementation BraveCRWWKUIHandler {
+  std::unique_ptr<web::PromptFacade> _promptFacade;
+}
+
+- (web::PromptFacade*)promptFacade {
+  if (!_promptFacade) {
+    _promptFacade = std::make_unique<web::PromptFacade>(self.webStateImpl);
+  }
+  return _promptFacade.get();
+}
+
+- (void)close {
+  [super close];
+  _promptFacade.reset();
+}
+
+- (void)webView:(WKWebView*)webView
+    runJavaScriptTextInputPanelWithPrompt:(NSString*)prompt
+                              defaultText:(NSString*)defaultText
+                         initiatedByFrame:(WKFrameInfo*)frame
+                        completionHandler:
+                            (void (^)(NSString* result))completionHandler {
+  GURL origin_url(web::GURLOriginWithWKSecurityOrigin(frame.securityOrigin));
+  // For standard web pages we'll see if the window.prompt needs to be handled
+  // by a configured `JavaScriptFeature` to handle immediately without actually
+  // displaying a JS prompt to the user
+  if (web::UrlHasWebScheme(origin_url)) {
+    std::optional<std::string> result =
+        self.promptFacade->HandleJavaScriptPrompt(
+            net::GURLWithNSURL(frame.request.URL), frame.isMainFrame,
+            base::SysNSStringToUTF8(prompt));
+    if (result) {
+      completionHandler(base::SysUTF8ToNSString(*result));
+      return;
+    }
+  }
+  [super webView:webView
+      runJavaScriptTextInputPanelWithPrompt:prompt
+                                defaultText:defaultText
+                           initiatedByFrame:frame
+                          completionHandler:completionHandler];
+}
+@end
 
 #pragma clang diagnostic pop

--- a/chromium_src/ios/web/web_state/ui/crw_wk_ui_handler.mm
+++ b/chromium_src/ios/web/web_state/ui/crw_wk_ui_handler.mm
@@ -55,8 +55,9 @@
   if (web::UrlHasWebScheme(origin_url)) {
     std::optional<std::string> result =
         self.promptFacade->HandleJavaScriptPrompt(
-            net::GURLWithNSURL(frame.request.URL), frame.isMainFrame,
-            base::SysNSStringToUTF8(prompt));
+            net::GURLWithNSURL(frame.request.URL),
+            web::OriginWithWKSecurityOrigin(frame.securityOrigin),
+            frame.isMainFrame, base::SysNSStringToUTF8(prompt));
     if (result) {
       completionHandler(base::SysUTF8ToNSString(*result));
       return;

--- a/ios/web/js_messaging/BUILD.gn
+++ b/ios/web/js_messaging/BUILD.gn
@@ -42,10 +42,32 @@ source_set("randomized_message_handler_name") {
   ]
 }
 
+source_set("prompt_facade") {
+  visibility = [
+    ":unittests",
+    "//ios/web/web_state/ui",
+  ]
+  sources = [
+    "prompt_facade.h",
+    "prompt_facade.mm",
+  ]
+  deps = [
+    "//ios/web/js_messaging",
+    "//ios/web/js_messaging:java_script_content_world_header",
+    "//ios/web/js_messaging:java_script_feature_manager_header",
+    "//ios/web/public",
+    "//ios/web/public/js_messaging",
+    "//url",
+  ]
+  public_deps = [ "//base" ]
+  assert_no_deps = [ "//brave/ios/browser" ]
+}
+
 source_set("unittests") {
   testonly = true
   sources = [
     "message_handler_token_inttest.mm",
+    "prompt_facade_unittest.mm",
     "randomized_message_handler_name_inttest.mm",
     "safe_builtins_javascript_test.mm",
   ]
@@ -53,11 +75,13 @@ source_set("unittests") {
     ":js_messaging",
     ":message_handler_token",
     ":message_handler_token_test_api",
+    ":prompt_facade",
     ":randomized_message_handler_name",
     ":randomized_message_handler_test_api",
     ":safe_builtins_js",
     "//base",
     "//base/test:test_support",
+    "//ios/web/js_messaging:java_script_feature_manager_header",
     "//ios/web/public/js_messaging",
     "//ios/web/public/test:javascript_test",
     "//ios/web/public/test:test_fixture",

--- a/ios/web/js_messaging/DEPS
+++ b/ios/web/js_messaging/DEPS
@@ -1,0 +1,4 @@
+include_rules = [
+  "+ios/web/web_state/ui",
+  "+ios/web/js_messaging",
+]

--- a/ios/web/js_messaging/prompt_facade.h
+++ b/ios/web/js_messaging/prompt_facade.h
@@ -13,6 +13,10 @@
 
 class GURL;
 
+namespace url {
+class Origin;
+}
+
 namespace web {
 
 class WebState;
@@ -31,6 +35,7 @@ class PromptFacade {
   // dispatches the message and returns the JSON-encoded reply, otherwise
   // returns nullptr
   std::optional<std::string> HandleJavaScriptPrompt(GURL request_url,
+                                                    url::Origin security_origin,
                                                     bool is_main_frame,
                                                     const std::string& prompt);
 

--- a/ios/web/js_messaging/prompt_facade.h
+++ b/ios/web/js_messaging/prompt_facade.h
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_IOS_WEB_JS_MESSAGING_PROMPT_FACADE_H_
+#define BRAVE_IOS_WEB_JS_MESSAGING_PROMPT_FACADE_H_
+
+#include <optional>
+#include <string>
+
+#include "base/memory/raw_ptr.h"
+
+class GURL;
+
+namespace web {
+
+class WebState;
+
+// Routes synchronous `window.prompt()` payloads to JavaScriptFeatures that
+// have opted in via `JavaScriptFeature::GetFeatureRepliesToPrompts()`. The
+// prompt body is expected to be a JSON document with `handler` and `message`
+// keys.
+class PromptFacade {
+ public:
+  // Constructs PromptFacade. The calling code must retain ownership of
+  // `web_state`, which cannot be null.
+  explicit PromptFacade(web::WebState* web_state);
+
+  // If `prompt` targets a registered JavaScriptFeature on the bound WebState,
+  // dispatches the message and returns the JSON-encoded reply, otherwise
+  // returns nullptr
+  std::optional<std::string> HandleJavaScriptPrompt(GURL request_url,
+                                                    bool is_main_frame,
+                                                    const std::string& prompt);
+
+ private:
+  raw_ptr<WebState> web_state_;
+};
+
+}  // namespace web
+
+#endif  // BRAVE_IOS_WEB_JS_MESSAGING_PROMPT_FACADE_H_

--- a/ios/web/js_messaging/prompt_facade.mm
+++ b/ios/web/js_messaging/prompt_facade.mm
@@ -1,0 +1,107 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/ios/web/js_messaging/prompt_facade.h"
+
+#include <memory>
+#include <optional>
+#include <string>
+
+#include "base/check.h"
+#include "base/functional/bind.h"
+#include "base/json/json_reader.h"
+#include "base/json/json_writer.h"
+#include "base/values.h"
+#include "ios/web/js_messaging/java_script_content_world.h"
+#include "ios/web/js_messaging/java_script_feature_manager.h"
+#include "ios/web/public/browser_state.h"
+#include "ios/web/public/js_messaging/java_script_feature.h"
+#include "ios/web/public/js_messaging/script_message.h"
+#include "ios/web/public/web_state.h"
+#include "url/gurl.h"
+
+namespace web {
+
+namespace {
+
+// Expected JSON key names when handling prompts from JavaScriptFeatures
+constexpr char kHandlerNameKey[] = "handler";
+constexpr char kMessageKey[] = "message";
+
+// Get the first JavaScriptFeature that replies to prompts with the given
+// handler name. Unfortunately prompts cannot supply their current content world
+// so we must check all of them.
+const JavaScriptFeature* GetFeatureReplyingToPrompts(
+    web::BrowserState* browser_state,
+    const std::string& handler_name) {
+  std::vector<JavaScriptContentWorld*> worlds =
+      JavaScriptFeatureManager::FromBrowserState(browser_state)
+          ->GetAllContentWorlds();
+  for (JavaScriptContentWorld* world : worlds) {
+    if (const JavaScriptFeature* found =
+            world->GetFeatureReplyingToPrompts(handler_name)) {
+      return found;
+    }
+  }
+  return nullptr;
+}
+
+}  // namespace
+
+PromptFacade::PromptFacade(web::WebState* web_state) : web_state_(web_state) {}
+
+std::optional<std::string> PromptFacade::HandleJavaScriptPrompt(
+    GURL request_url,
+    bool is_main_frame,
+    const std::string& prompt) {
+  if (!request_url.is_valid()) {
+    return std::nullopt;
+  }
+
+  std::optional<base::DictValue> dict = base::JSONReader::ReadDict(
+      prompt, base::JSONParserOptions::JSON_PARSE_RFC);
+  if (!dict) {
+    return std::nullopt;
+  }
+
+  const std::string* handler_name = dict->FindString(kHandlerNameKey);
+  const base::Value* message = dict->Find(kMessageKey);
+  if (!handler_name || !message) {
+    return std::nullopt;
+  }
+
+  const JavaScriptFeature* feature =
+      GetFeatureReplyingToPrompts(web_state_->GetBrowserState(), *handler_name);
+  if (!feature) {
+    return std::nullopt;
+  }
+
+  ScriptMessage script_message(std::make_unique<base::Value>(message->Clone()),
+                               /*is_user_interacting=*/false, is_main_frame,
+                               std::move(request_url));
+
+  bool replied = false;
+  std::string reply_json;
+  // Typically upstream binds `ScriptMessageReceivedWithReply` to the mutable
+  // `WeakPtr` of `JavaScriptFeature` which removes the `const`. Since our code
+  // is non-escaping though we don't need to make a `WeakPtr` so must
+  // `const_cast`
+  const_cast<JavaScriptFeature*>(feature)->ScriptMessageReceivedWithReply(
+      web_state_, script_message,
+      base::BindOnce(
+          [](bool* replied, std::string* reply_json, const base::Value* reply,
+             NSString* error) {
+            *replied = true;
+            if (reply) {
+              base::JSONWriter::Write(*reply, reply_json);
+            }
+          },
+          &replied, &reply_json));
+  DCHECK(replied)
+      << "JavaScriptFeature replying to window.prompt must reply synchronously";
+  return reply_json;
+}
+
+}  // namespace web

--- a/ios/web/js_messaging/prompt_facade.mm
+++ b/ios/web/js_messaging/prompt_facade.mm
@@ -21,6 +21,7 @@
 #include "ios/web/public/js_messaging/script_message.h"
 #include "ios/web/public/web_state.h"
 #include "url/gurl.h"
+#include "url/origin.h"
 
 namespace web {
 
@@ -54,6 +55,7 @@ PromptFacade::PromptFacade(web::WebState* web_state) : web_state_(web_state) {}
 
 std::optional<std::string> PromptFacade::HandleJavaScriptPrompt(
     GURL request_url,
+    url::Origin security_origin,
     bool is_main_frame,
     const std::string& prompt) {
   if (!request_url.is_valid()) {
@@ -72,9 +74,15 @@ std::optional<std::string> PromptFacade::HandleJavaScriptPrompt(
     return std::nullopt;
   }
 
-  const JavaScriptFeature* feature =
-      GetFeatureReplyingToPrompts(web_state_->GetBrowserState(), *handler_name);
-  if (!feature) {
+  // Typically upstream binds `ScriptMessageReceivedWithReply` to the mutable
+  // `WeakPtr` of `JavaScriptFeature` which removes the `const`. Since our code
+  // is non-escaping though we don't need to make a `WeakPtr` so must
+  // `const_cast`
+  JavaScriptFeature* feature =
+      const_cast<JavaScriptFeature*>(GetFeatureReplyingToPrompts(
+          web_state_->GetBrowserState(), *handler_name));
+
+  if (!feature || !feature->ShouldHandleMessageFromOrigin(security_origin)) {
     return std::nullopt;
   }
 
@@ -84,11 +92,7 @@ std::optional<std::string> PromptFacade::HandleJavaScriptPrompt(
 
   bool replied = false;
   std::string reply_json;
-  // Typically upstream binds `ScriptMessageReceivedWithReply` to the mutable
-  // `WeakPtr` of `JavaScriptFeature` which removes the `const`. Since our code
-  // is non-escaping though we don't need to make a `WeakPtr` so must
-  // `const_cast`
-  const_cast<JavaScriptFeature*>(feature)->ScriptMessageReceivedWithReply(
+  feature->ScriptMessageReceivedWithReply(
       web_state_, script_message,
       base::BindOnce(
           [](bool* replied, std::string* reply_json, const base::Value* reply,

--- a/ios/web/js_messaging/prompt_facade_unittest.mm
+++ b/ios/web/js_messaging/prompt_facade_unittest.mm
@@ -24,6 +24,7 @@
 #include "ios/web/public/test/web_test.h"
 #include "testing/gtest/include/gtest/gtest.h"
 #include "url/gurl.h"
+#include "url/origin.h"
 
 namespace web {
 
@@ -107,7 +108,8 @@ class PromptFacadeTest : public WebTest {
   }
 
   std::optional<std::string> HandlePrompt(const std::string& prompt) {
-    return handler_->HandleJavaScriptPrompt(GURL("https://example.com/"),
+    GURL url("https://example.com/");
+    return handler_->HandleJavaScriptPrompt(url, url::Origin::Create(url),
                                             /*is_main_frame=*/true, prompt);
   }
 
@@ -158,9 +160,9 @@ TEST_F(PromptFacadeTest, ValidPromptDispatchesToFeature) {
   base::DictValue message;
   message.Set("key", "value");
   std::string prompt = BuildPromptJSON(kHandlerName, std::move(message));
-  std::optional<std::string> result =
-      handler_->HandleJavaScriptPrompt(GURL("https://example.com/foo"),
-                                       /*is_main_frame=*/true, prompt);
+  GURL url("https://example.com/foo");
+  std::optional<std::string> result = handler_->HandleJavaScriptPrompt(
+      url, url::Origin::Create(url), /*is_main_frame=*/true, prompt);
   ASSERT_TRUE(result.has_value());
   EXPECT_EQ("\"hello\"", *result);
 
@@ -185,9 +187,9 @@ TEST_F(PromptFacadeTest, SubFramePropagatedToMessage) {
   feature_->SetReply(std::make_unique<base::Value>("hello"));
 
   std::string prompt = BuildPromptJSON(kHandlerName, base::DictValue());
-  std::optional<std::string> result =
-      handler_->HandleJavaScriptPrompt(GURL("https://example.com/"),
-                                       /*is_main_frame=*/false, prompt);
+  GURL url("https://example.com/");
+  std::optional<std::string> result = handler_->HandleJavaScriptPrompt(
+      url, url::Origin::Create(url), /*is_main_frame=*/false, prompt);
   EXPECT_TRUE(result.has_value());
   ASSERT_NE(nullptr, feature_->last_message());
   EXPECT_FALSE(feature_->last_message()->is_main_frame());

--- a/ios/web/js_messaging/prompt_facade_unittest.mm
+++ b/ios/web/js_messaging/prompt_facade_unittest.mm
@@ -1,0 +1,225 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/ios/web/js_messaging/prompt_facade.h"
+
+#include <Foundation/Foundation.h>
+
+#include <memory>
+#include <optional>
+#include <string>
+
+#include "base/json/json_reader.h"
+#include "base/json/json_writer.h"
+#include "base/memory/raw_ptr.h"
+#include "base/test/gtest_util.h"
+#include "base/values.h"
+#include "ios/web/js_messaging/java_script_feature_manager.h"
+#include "ios/web/public/js_messaging/content_world.h"
+#include "ios/web/public/js_messaging/java_script_feature.h"
+#include "ios/web/public/js_messaging/script_message.h"
+#include "ios/web/public/test/fakes/fake_web_state.h"
+#include "ios/web/public/test/web_test.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "url/gurl.h"
+
+namespace web {
+
+namespace {
+
+constexpr char kHandlerName[] = "TestPromptHandler";
+
+// Test feature that opts in to replying to window.prompt() messages and
+// captures the most recent message it receives so tests can assert against it.
+class TestPromptFeature : public JavaScriptFeature {
+ public:
+  explicit TestPromptFeature(ContentWorld content_world)
+      : JavaScriptFeature(content_world) {}
+  ~TestPromptFeature() override = default;
+
+  std::optional<std::string> GetScriptMessageHandlerName() const override {
+    return std::string(kHandlerName);
+  }
+
+  bool GetFeatureRepliesToPrompts() const override { return true; }
+
+  void ScriptMessageReceivedWithReply(
+      WebState* web_state,
+      const ScriptMessage& message,
+      ScriptMessageReplyCallback callback) override {
+    last_web_state_ = web_state;
+    last_message_ = std::make_unique<ScriptMessage>(message);
+    std::move(callback).Run(reply_value_.get(), /*error=*/nil);
+  }
+
+  void SetReply(std::unique_ptr<base::Value> value) {
+    reply_value_ = std::move(value);
+  }
+
+  WebState* last_web_state() const { return last_web_state_; }
+  const ScriptMessage* last_message() const { return last_message_.get(); }
+
+ private:
+  std::unique_ptr<ScriptMessage> last_message_;
+  std::unique_ptr<base::Value> reply_value_;
+  raw_ptr<WebState> last_web_state_ = nullptr;
+};
+
+std::string BuildPromptJSON(std::optional<std::string> handler,
+                            std::optional<base::DictValue> message) {
+  base::DictValue dict;
+  if (handler) {
+    dict.Set("handler", *handler);
+  }
+  if (message) {
+    dict.Set("message", std::move(*message));
+  }
+  std::string json;
+  base::JSONWriter::Write(dict, &json);
+  return json;
+}
+
+}  // namespace
+
+class PromptFacadeTest : public WebTest {
+ protected:
+  void SetUp() override {
+    WebTest::SetUp();
+
+    feature_ =
+        std::make_unique<TestPromptFeature>(ContentWorld::kPageContentWorld);
+    JavaScriptFeatureManager::FromBrowserState(GetBrowserState())
+        ->ConfigureFeatures({feature_.get()});
+
+    web_state_ = std::make_unique<FakeWebState>();
+    web_state_->SetBrowserState(GetBrowserState());
+
+    handler_ = std::make_unique<web::PromptFacade>(web_state_.get());
+  }
+
+  void TearDown() override {
+    handler_.reset();
+    web_state_.reset();
+    feature_.reset();
+    WebTest::TearDown();
+  }
+
+  std::optional<std::string> HandlePrompt(const std::string& prompt) {
+    return handler_->HandleJavaScriptPrompt(GURL("https://example.com/"),
+                                            /*is_main_frame=*/true, prompt);
+  }
+
+  std::unique_ptr<TestPromptFeature> feature_;
+  std::unique_ptr<FakeWebState> web_state_;
+  std::unique_ptr<PromptFacade> handler_;
+};
+
+// Tests that prompts whose body is not valid JSON are not handled.
+TEST_F(PromptFacadeTest, InvalidJsonReturnsNullopt) {
+  EXPECT_EQ(std::nullopt, HandlePrompt("this is not json"));
+  EXPECT_EQ(nullptr, feature_->last_message());
+}
+
+// Tests that prompts whose body is valid JSON but not an object are not
+// handled.
+TEST_F(PromptFacadeTest, NonObjectJsonReturnsNullopt) {
+  EXPECT_EQ(std::nullopt, HandlePrompt("[1,2,3]"));
+}
+
+// Tests that an object missing the "handler" key is not handled.
+TEST_F(PromptFacadeTest, MissingHandlerReturnsNullopt) {
+  std::string prompt =
+      BuildPromptJSON(/*handler=*/std::nullopt, base::DictValue());
+  EXPECT_EQ(std::nullopt, HandlePrompt(prompt));
+}
+
+// Tests that an object missing the "message" key is not handled.
+TEST_F(PromptFacadeTest, MissingMessageReturnsNullopt) {
+  std::string prompt = BuildPromptJSON(kHandlerName,
+                                       /*message=*/std::nullopt);
+  EXPECT_EQ(std::nullopt, HandlePrompt(prompt));
+}
+
+// Tests that a prompt with a handler name that does not match any registered
+// feature is not handled.
+TEST_F(PromptFacadeTest, UnknownHandlerReturnsNullopt) {
+  std::string prompt = BuildPromptJSON("NonExistentHandler", base::DictValue());
+  EXPECT_EQ(std::nullopt, HandlePrompt(prompt));
+  EXPECT_EQ(nullptr, feature_->last_message());
+}
+
+// Tests that a well-formed prompt is dispatched to the matching feature, and
+// that the feature's synchronous reply is JSON-encoded into `result`.
+TEST_F(PromptFacadeTest, ValidPromptDispatchesToFeature) {
+  feature_->SetReply(std::make_unique<base::Value>("hello"));
+
+  base::DictValue message;
+  message.Set("key", "value");
+  std::string prompt = BuildPromptJSON(kHandlerName, std::move(message));
+  std::optional<std::string> result =
+      handler_->HandleJavaScriptPrompt(GURL("https://example.com/foo"),
+                                       /*is_main_frame=*/true, prompt);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ("\"hello\"", *result);
+
+  ASSERT_NE(nullptr, feature_->last_message());
+  EXPECT_EQ(web_state_.get(), feature_->last_web_state());
+  EXPECT_TRUE(feature_->last_message()->is_main_frame());
+  EXPECT_FALSE(feature_->last_message()->is_user_interacting());
+  ASSERT_TRUE(feature_->last_message()->request_url().has_value());
+  EXPECT_EQ(GURL("https://example.com/foo"),
+            *feature_->last_message()->request_url());
+
+  base::Value* body = feature_->last_message()->body();
+  ASSERT_TRUE(body);
+  ASSERT_TRUE(body->is_dict());
+  const std::string* key_value = body->GetDict().FindString("key");
+  ASSERT_TRUE(key_value);
+  EXPECT_EQ("value", *key_value);
+}
+
+// Tests that `is_main_frame=false` is propagated to the dispatched message.
+TEST_F(PromptFacadeTest, SubFramePropagatedToMessage) {
+  feature_->SetReply(std::make_unique<base::Value>("hello"));
+
+  std::string prompt = BuildPromptJSON(kHandlerName, base::DictValue());
+  std::optional<std::string> result =
+      handler_->HandleJavaScriptPrompt(GURL("https://example.com/"),
+                                       /*is_main_frame=*/false, prompt);
+  EXPECT_TRUE(result.has_value());
+  ASSERT_NE(nullptr, feature_->last_message());
+  EXPECT_FALSE(feature_->last_message()->is_main_frame());
+}
+
+// Tests that when the feature's reply is null (e.g. the feature opted not to
+// produce a value), the result is an empty string.
+TEST_F(PromptFacadeTest, NullReplyProducesEmptyString) {
+  // No `SetReply` call: feature replies with a null base::Value*.
+  std::string prompt = BuildPromptJSON(kHandlerName, base::DictValue());
+  std::optional<std::string> result = HandlePrompt(prompt);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ("", *result);
+}
+
+// Tests that complex reply values are JSON-encoded into `result`.
+TEST_F(PromptFacadeTest, DictReplyIsJsonEncoded) {
+  base::DictValue reply;
+  reply.Set("ok", true);
+  reply.Set("value", 42);
+  feature_->SetReply(std::make_unique<base::Value>(std::move(reply)));
+
+  std::string prompt = BuildPromptJSON(kHandlerName, base::DictValue());
+  std::optional<std::string> result = HandlePrompt(prompt);
+  ASSERT_TRUE(result.has_value());
+
+  std::optional<base::Value> parsed =
+      base::JSONReader::Read(*result, base::JSONParserOptions::JSON_PARSE_RFC);
+  ASSERT_TRUE(parsed);
+  ASSERT_TRUE(parsed->is_dict());
+  EXPECT_EQ(true, parsed->GetDict().FindBool("ok"));
+  EXPECT_EQ(42, parsed->GetDict().FindInt("value"));
+}
+
+}  // namespace web

--- a/ios/web/sources.gni
+++ b/ios/web/sources.gni
@@ -3,6 +3,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
+# Additional deps for the //ios/web/web_state/ui target
+brave_ios_web_web_state_ui_deps =
+    [ "//brave/ios/web/js_messaging:prompt_facade" ]
+
 # This list is added to //ios/web/public/test:test_fixture
 # DO NOT add anything from `//brave/ios/browser` to this list.
 brave_ios_web_test_fixture_visibility = [ "//brave/ios/web/*" ]

--- a/patches/ios-web-web_state-ui-BUILD.gn.patch
+++ b/patches/ios-web-web_state-ui-BUILD.gn.patch
@@ -1,0 +1,12 @@
+diff --git a/ios/web/web_state/ui/BUILD.gn b/ios/web/web_state/ui/BUILD.gn
+index f6f73a7d9d4b2530f49b9a1526a945219d4a5aa9..e54110c3b38d5133ad107abc721d023ef61410a6 100644
+--- a/ios/web/web_state/ui/BUILD.gn
++++ b/ios/web/web_state/ui/BUILD.gn
+@@ -86,6 +86,7 @@ source_set("ui") {
+     "crw_wk_ui_handler.mm",
+     "crw_wk_ui_handler_delegate.h",
+   ]
++  import("//brave/ios/web/sources.gni") deps += brave_ios_web_web_state_ui_deps
+ }
+ 
+ source_set("web_controller_header") {

--- a/patches/ios-web-web_state-ui-crw_web_controller.mm.patch
+++ b/patches/ios-web-web_state-ui-crw_web_controller.mm.patch
@@ -1,0 +1,18 @@
+diff --git a/ios/web/web_state/ui/crw_web_controller.mm b/ios/web/web_state/ui/crw_web_controller.mm
+index 13067f0c8f2d1fba7215fdab050d07e8cbbb8cef..6cad786e94b0daab2042f8adacfb00bcfdf07827 100644
+--- a/ios/web/web_state/ui/crw_web_controller.mm
++++ b/ios/web/web_state/ui/crw_web_controller.mm
+@@ -311,11 +311,11 @@ BOOL ExtractInteractionState(NSData* data, NSData** interactionState) {
+       web::AnnotationsTextManager::CreateForWebState(_webStateImpl);
+     }
+ 
+-    _navigationHandler = [[CRWWKNavigationHandler alloc] initWithDelegate:self];
++    _navigationHandler = [[BraveCRWWKNavigationHandler alloc] initWithDelegate:self];
+ 
+     _jsNavigationHandler = [[CRWJSNavigationHandler alloc] init];
+ 
+-    _UIHandler = [[CRWWKUIHandler alloc] init];
++    _UIHandler = [[BraveCRWWKUIHandler alloc] init];
+     _UIHandler.delegate = self;
+ 
+     _webViewNavigationObserver = [[CRWWebViewNavigationObserver alloc] init];

--- a/rewrite/ios/web/web_state/ui/crw_web_controller.mm.yaml
+++ b/rewrite/ios/web/web_state/ui/crw_web_controller.mm.yaml
@@ -1,0 +1,12 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+substitutions:
+  - description: Replace CRWWKNavigationHandler with BraveCRWWKNavigationHandler
+    pattern: 'CRWWKNavigationHandler alloc'
+    replace: 'BraveCRWWKNavigationHandler alloc'
+  - description: Replace CRWWKUIHandler with BraveCRWWKUIHandler
+    pattern: 'CRWWKUIHandler alloc'
+    replace: 'BraveCRWWKUIHandler alloc'


### PR DESCRIPTION
This adds the chromium_src overrides required to allow `JavaScriptFeature` to handle `window.prompt` the same way it does standard WebKit message handlers by opting into a new function `GetFeatureRepliesToPrompts`.
