### PR TITLE
[iOS] Add methods for sending tokenized prompts to the browser

### DIFF
--- a/ios/web/js_messaging/resources/safe_builtins.ts
+++ b/ios/web/js_messaging/resources/safe_builtins.ts
@@ -22,9 +22,16 @@ class SafeBuiltins {
   // Promise that resolves when the browser replies
   readonly sendWebKitMessageWithReply: (handlerName: string, message: object|string) => Promise<any>;
 
+  // Send a message expecting synchronously by using window.prompt and returns
+  // the reply from the browser.
+  readonly sendWebKitMessageSynchronously: (handlerName: string, message: object|string) => any|null;
+
   constructor() {
     // Setup private refs to capture in safe builtin functions
     const webkitMessageHandlers = window.webkit.messageHandlers;
+    const windowPrompt = window.prompt.bind(window);
+    const jsonStringify = JSON.stringify.bind(JSON);
+    const jsonParse = JSON.parse.bind(JSON);
 
     this.sendWebKitMessage = (handlerName, message) => {
       webkitMessageHandlers[handlerName].postMessage(message);
@@ -32,6 +39,21 @@ class SafeBuiltins {
 
     this.sendWebKitMessageWithReply = (handlerName, message) => {
       return webkitMessageHandlers[handlerName].postMessage(message);
+    }
+
+    this.sendWebKitMessageSynchronously = (handlerName, message) => {
+      const response = windowPrompt(jsonStringify({
+        handler: handlerName,
+        message: message
+      }));
+      if (!response) {
+        return null;
+      }
+      try {
+        return jsonParse(response)
+      } catch {
+        return null;
+      }
     }
 
     // Freeze all the safe builtins and any function we export

--- a/ios/web/js_messaging/resources/utils.ts
+++ b/ios/web/js_messaging/resources/utils.ts
@@ -28,3 +28,14 @@ export function sendTokenizedWebKitMessageWithReply(
     message: message
   })
 }
+
+// Posts `message` to the browser via `window.prompt` with an embedded token for
+// validation and waits for the reply synchronously. If the message isnt valid
+// JSON or the response cannot be parsed as JSON then this returns null
+export function sendTokenizedWebKitMessageSynchronously(
+  handlerName: string, message: object|string): any|null {
+  return gSafeBuiltins.sendWebKitMessageSynchronously(handlerName, {
+    token: messageHandlerToken,
+    message: message
+  })
+}


### PR DESCRIPTION
This adds an additional tokenized method `sendWebKitMessageSynchronously` alongside `sendTokenizedWebKitMessage{WithReply}` that uses `window.prompt` from SafeBuiltins.
