### PR TITLE
[NTP] Fixes blank page on NTP due to Brave News ads removal (uplift to 1.92.x)

### DIFF
--- a/components/brave_news/browser/resources/shared/useFeedV2.ts
+++ b/components/brave_news/browser/resources/shared/useFeedV2.ts
@@ -73,6 +73,14 @@ const maybeLoadFeed = (view?: FeedView) => {
 
   const feed: FeedV2 = JSON.parse(data)
 
+  // Remove any cached feed whose items include a type no longer supported
+  // in the FeedItemV2.
+  if (feed.items?.some(item => !item.article && !item.cluster && !item.discover && !item.hero)) {
+    localStorage.removeItem(FEED_KEY)
+    sessionStorage.removeItem(FEED_KEY)
+    return undefined
+  }
+
   // If we loaded the feed from localStorage, and it's too old remove it from
   // storage and return undefined.
   if (isTooOld(feed)) {


### PR DESCRIPTION
Uplift of #36849
Resolves https://github.com/brave/brave-browser/issues/55940

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.