### PR TITLE
fix omnibox color override with custom themes

### DIFF
--- a/browser/ui/color/brave_color_mixer.cc
+++ b/browser/ui/color/brave_color_mixer.cc
@@ -746,6 +746,11 @@ void AddBraveOmniboxColorMixer(ui::ColorProvider* provider,
     return;
   }
 
+  // Don't override omnibox colors when user has a custom theme
+  if (key.custom_theme) {
+    return;
+  }
+
   auto& postprocessing_mixer = provider->AddPostprocessingMixer();
   // Location bar
   postprocessing_mixer[kColorLocationBarBackground] = {


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/55952

The Midnight theme's darker mode was overriding omnibox colors even when users had custom themes installed, causing the inactive omnibox to ignore the `omnibox_background` color from the theme manifest.

This PR adds a check to skip the Midnight theme's postprocessing mixer when a custom theme is present, allowing custom theme colors to be respected.

### Before
The inactive omnibox was being set automatically using the frame color, ignoring the custom theme's `omnibox_background` setting.

### After  
Custom theme's `omnibox_background` color is properly applied to both active and inactive omnibox states.