### PR TITLE
Hide Playlist toggle when managed by Brave Origin policy

### DIFF
--- a/browser/resources/settings/brave_content_page/playlist.html
+++ b/browser/resources/settings/brave_content_page/playlist.html
@@ -12,7 +12,8 @@ You can obtain one at https://mozilla.org/MPL/2.0/. -->
   <settings-toggle-button
     class="cr-row first"
     pref="{{prefs.brave.playlist.enabled}}"
-    label="$i18n{bravePlaylistEnablePlaylistLabel}">
+    label="$i18n{bravePlaylistEnablePlaylistLabel}"
+    hidden="[[isPlaylistManaged_(prefs.brave.playlist.enabled)]]">
   </settings-toggle-button>
   <template
     is="dom-if"

--- a/browser/resources/settings/brave_content_page/playlist.ts
+++ b/browser/resources/settings/brave_content_page/playlist.ts
@@ -24,6 +24,12 @@ class SettingsBraveContentPlaylistElement extends BravePlaylistPageBase {
   static get template () {
     return getTemplate()
   }
+
+  private isPlaylistManaged_(
+      pref: chrome.settingsPrivate.PrefObject): boolean {
+    return pref &&
+        pref.enforcement === chrome.settingsPrivate.Enforcement.ENFORCED;
+  }
 }
 
 customElements.define(SettingsBraveContentPlaylistElement.is, SettingsBraveContentPlaylistElement)


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/55925

When the Playlist pref is enforced by Brave Origin it is forced on, so hide the toggle instead of showing a partially-enabled managed control. Matches the recent Tor toggle fix.