### PR TITLE
[Settings] Fix Survey Panelist page back button

### DIFF
--- a/browser/resources/settings/brave_survey_panelist_page/brave_survey_panelist_page.html
+++ b/browser/resources/settings/brave_survey_panelist_page/brave_survey_panelist_page.html
@@ -3,7 +3,7 @@ This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this file,
 You can obtain one at https://mozilla.org/MPL/2.0/. -->
 
-<settings-section
+<settings-subpage
   page-title="$i18n{surveyPanelist}">
 
   <settings-toggle-button
@@ -15,4 +15,4 @@ You can obtain one at https://mozilla.org/MPL/2.0/. -->
     on-sub-label-link-clicked="onSurveyPanelistLearnMoreLinkClick_">
   </settings-toggle-button>
 
-</settings-section>
+</settings-subpage>


### PR DESCRIPTION
Fixes the Settings back button behavior for the Survey Panelist subpage.
The Survey Panelist page now has a back button. It navigates user to previous Settings page successfully.

## Test plan
### Test case 1
1. Launch Brave.
2. Open `brave://settings/privacy`.
3. Navigate to the Data Collection section.
4. Open the Survey Panelist subpage and ensure there is a new back button.
5. Click the back button.
6. Confirm Brave returns to the expected parent Data Collection / Privacy settings view.
7. Open the Survey Panelist subpage again.
8. Use the browser back button.
9. Confirm navigation returns to the expected parent settings view.

Resolves https://github.com/brave/brave-browser/issues/50559