### PR TITLE
[farbling] Fix Accept-Language header position

### DIFF
--- a/browser/farbling/brave_navigator_languages_farbling_browsertest.cc
+++ b/browser/farbling/brave_navigator_languages_farbling_browsertest.cc
@@ -4,7 +4,6 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include <map>
-#include <memory>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -13,15 +12,9 @@
 #include "base/path_service.h"
 #include "base/strings/string_split.h"
 #include "base/strings/string_util.h"
-#include "base/test/bind.h"
-#include "base/test/thread_test_helper.h"
-#include "brave/browser/brave_browser_process.h"
-#include "brave/browser/extensions/brave_base_local_data_files_browsertest.h"
-#include "brave/components/brave_component_updater/browser/local_data_files_service.h"
 #include "brave/components/brave_shields/core/browser/brave_shields_utils.h"
 #include "brave/components/brave_shields/core/common/features.h"
 #include "brave/components/constants/brave_paths.h"
-#include "brave/components/constants/pref_names.h"
 #include "chrome/browser/content_settings/host_content_settings_map_factory.h"
 #include "chrome/browser/extensions/extension_browsertest.h"
 #include "chrome/browser/profiles/profile.h"
@@ -30,7 +23,6 @@
 #include "chrome/test/base/ui_test_utils.h"
 #include "components/language/core/browser/pref_names.h"
 #include "components/network_session_configurator/common/network_switches.h"
-#include "components/permissions/permission_request.h"
 #include "components/prefs/pref_service.h"
 #include "components/user_prefs/user_prefs.h"
 #include "content/public/browser/render_frame_host.h"
@@ -163,8 +155,6 @@ class BraveNavigatorLanguagesFarblingBrowserTest : public InProcessBrowserTest {
     prefs->Set(language::prefs::kSelectedLanguages,
                base::Value(accept_languages));
   }
-
-  void HandleHTTPRequest() {}
 
   void MonitorHTTPRequest(const net::test_server::HttpRequest& request) {
     if (request.relative_url.find("/reduce-language/") == std::string::npos) {

--- a/browser/farbling/brave_navigator_languages_farbling_browsertest.cc
+++ b/browser/farbling/brave_navigator_languages_farbling_browsertest.cc
@@ -5,9 +5,15 @@
 
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
+#include <string_view>
+#include <vector>
 
 #include "base/path_service.h"
+#include "base/strings/string_split.h"
+#include "base/strings/string_util.h"
+#include "base/test/bind.h"
 #include "base/test/thread_test_helper.h"
 #include "brave/browser/brave_browser_process.h"
 #include "brave/browser/extensions/brave_base_local_data_files_browsertest.h"
@@ -40,6 +46,30 @@ using content::TitleWatcher;
 
 namespace {
 constexpr char kNavigatorLanguagesScript[] = "navigator.languages.toString()";
+
+// Returns the zero-based index of `header_name` among the request headers in a
+// raw header block (as exposed via
+// `net::test_server::HttpRequest::all_headers`). The block starts with the
+// request line (e.g. "GET / HTTP/1.1"), which is ignored, followed by one
+// header per line. Returns std::nullopt if the header is not present.
+std::optional<size_t> GetHeaderPosition(const std::string& all_headers,
+                                        std::string_view header_name) {
+  std::vector<std::string> lines = base::SplitString(
+      all_headers, "\r\n", base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
+  // Skip the request line at index 0; headers start at index 1.
+  for (size_t i = 1; i < lines.size(); ++i) {
+    size_t colon_pos = lines[i].find(':');
+    if (colon_pos == std::string::npos) {
+      continue;
+    }
+    std::string_view name = base::TrimWhitespaceASCII(
+        std::string_view(lines[i]).substr(0, colon_pos), base::TRIM_ALL);
+    if (base::EqualsCaseInsensitiveASCII(name, header_name)) {
+      return i - 1;
+    }
+  }
+  return std::nullopt;
+}
 }  // namespace
 
 class BraveNavigatorLanguagesFarblingBrowserTest : public InProcessBrowserTest {
@@ -93,6 +123,13 @@ class BraveNavigatorLanguagesFarblingBrowserTest : public InProcessBrowserTest {
   content::ContentMockCertVerifier mock_cert_verifier_;
   net::EmbeddedTestServer https_server_;
 
+  // When true, the request monitor records the position of the Accept-Language
+  // header from the main document request into `accept_language_position_`.
+  bool capture_accept_language_position_ = false;
+  // Position of the Accept-Language header in the most recently observed main
+  // document request (see `capture_accept_language_position_`).
+  std::optional<size_t> accept_language_position_;
+
   HostContentSettingsMap* content_settings() {
     return HostContentSettingsMapFactory::GetForProfile(browser()->profile());
   }
@@ -127,6 +164,8 @@ class BraveNavigatorLanguagesFarblingBrowserTest : public InProcessBrowserTest {
                base::Value(accept_languages));
   }
 
+  void HandleHTTPRequest() {}
+
   void MonitorHTTPRequest(const net::test_server::HttpRequest& request) {
     if (request.relative_url.find("/reduce-language/") == std::string::npos) {
       return;
@@ -143,6 +182,16 @@ class BraveNavigatorLanguagesFarblingBrowserTest : public InProcessBrowserTest {
     size_t port_pos = host.find(':');
     std::string domain =
         (port_pos != std::string::npos) ? host.substr(0, port_pos) : host;
+
+    // Capture the position of the Accept-Language header within the main
+    // document request so the test can assert it does not vary with the
+    // farbling state. See https://github.com/brave/brave-browser/issues/55271.
+    if (capture_accept_language_position_ &&
+        request.relative_url.find("page-with-subresources.html") !=
+            std::string::npos) {
+      accept_language_position_ =
+          GetHeaderPosition(request.all_headers, "accept-language");
+    }
 
     auto expected_it = expected_http_accept_language_by_domain_.find(domain);
     if (expected_it == expected_http_accept_language_by_domain_.end()) {
@@ -336,6 +385,46 @@ IN_PROC_BROWSER_TEST_F(BraveNavigatorLanguagesFarblingBrowserTest,
   ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url_x));
   ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url_y));
   ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url_z));
+}
+
+// Tests that the position of the HTTP Accept-Language header within the request
+// does not change with the farbling level. Otherwise the header's position
+// would leak whether farbling is enabled.
+// See https://github.com/brave/brave-browser/issues/55271.
+IN_PROC_BROWSER_TEST_F(BraveNavigatorLanguagesFarblingBrowserTest,
+                       FarbleHTTPAcceptLanguageHeaderPosition) {
+  capture_accept_language_position_ = true;
+  std::string domain = "b.test";
+  // Each navigation uses a unique query string so the request is not served
+  // from cache. Otherwise repeated navigations to the same URL would trigger a
+  // conditional revalidation that adds cache-related headers (Cache-Control,
+  // If-None-Match) and shifts the Accept-Language position independently of the
+  // farbling state.
+  GURL url_off = https_server_.GetURL(
+      domain, "/reduce-language/page-with-subresources.html?off");
+  GURL url_default = https_server_.GetURL(
+      domain, "/reduce-language/page-with-subresources.html?default");
+  GURL url_max = https_server_.GetURL(
+      domain, "/reduce-language/page-with-subresources.html?max");
+  SetAcceptLanguages("la,es,en");
+
+  // Farbling level: off. This is the baseline position to compare against.
+  AllowFingerprinting(domain);
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url_off));
+  std::optional<size_t> position_when_off = accept_language_position_;
+  ASSERT_TRUE(position_when_off.has_value());
+
+  // Farbling level: default. Accept-Language is farbled but its position must
+  // match the farbling-off position.
+  SetFingerprintingDefault(domain);
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url_default));
+  EXPECT_EQ(accept_language_position_, position_when_off);
+
+  // Farbling level: maximum. Accept-Language is farbled but its position must
+  // match the farbling-off position.
+  BlockFingerprinting(domain);
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url_max));
+  EXPECT_EQ(accept_language_position_, position_when_off);
 }
 
 // Tests results of farbling HTTP Accept-Language header

--- a/browser/farbling/brave_navigator_languages_farbling_browsertest.cc
+++ b/browser/farbling/brave_navigator_languages_farbling_browsertest.cc
@@ -408,13 +408,13 @@ IN_PROC_BROWSER_TEST_F(BraveNavigatorLanguagesFarblingBrowserTest,
   // match the farbling-off position.
   SetFingerprintingDefault(domain);
   ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url_default));
-  EXPECT_EQ(accept_language_position_, position_when_off);
+  EXPECT_EQ(accept_language_position_, position_when_off) << "farbling=default";
 
   // Farbling level: maximum. Accept-Language is farbled but its position must
   // match the farbling-off position.
   BlockFingerprinting(domain);
   ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url_max));
-  EXPECT_EQ(accept_language_position_, position_when_off);
+  EXPECT_EQ(accept_language_position_, position_when_off) << "farbling=max";
 }
 
 // Tests results of farbling HTTP Accept-Language header

--- a/chromium_src/net/url_request/url_request_http_job.cc
+++ b/chromium_src/net/url_request/url_request_http_job.cc
@@ -9,6 +9,7 @@
 
 namespace net {
 
+namespace {
 // The Accept-Language header position is different when farbling is "off" vs
 // when farbling is "on". This class helps to keep the position same to remove
 // farbling detection by sites.
@@ -31,6 +32,7 @@ class BraveAcceptLanguageHttpHeaderReposition {
 
   ~BraveAcceptLanguageHttpHeaderReposition() = default;
 };
+}  // namespace
 }  // namespace net
 
 #define GetSSLUpgradeDecision(host, is_top_level_nav, net_log)                 \

--- a/chromium_src/net/url_request/url_request_http_job.cc
+++ b/chromium_src/net/url_request/url_request_http_job.cc
@@ -9,8 +9,6 @@
 
 namespace net {
 
-namespace brave {
-
 // The Accept-Language header position is different when farbling is "off" vs
 // when farbling is "on". This class helps to keep the position same to remove
 // farbling detection by sites.
@@ -33,7 +31,6 @@ class BraveAcceptLanguageHttpHeaderReposition {
 
   ~BraveAcceptLanguageHttpHeaderReposition() = default;
 };
-}  // namespace brave
 }  // namespace net
 
 #define GetSSLUpgradeDecision(host, is_top_level_nav, net_log)                 \
@@ -45,12 +42,12 @@ class BraveAcceptLanguageHttpHeaderReposition {
 #define AddHSTSHeader(host, value) \
   AddHSTSHeader(request_->isolation_info(), host, value)
 
-#define BRAVE_ACCEPT_LANGUAGE_HTTP_HEADER_REPOSITION \
-  brave::BraveAcceptLanguageHttpHeaderReposition(request_info_.extra_headers);
+#define BRAVE_URL_REQUEST_HTTP_JOB_ADD_EXTRA_HEADERS \
+  BraveAcceptLanguageHttpHeaderReposition(request_info_.extra_headers);
 
 #include <net/url_request/url_request_http_job.cc>
 
-#undef BRAVE_ACCEPT_LANGUAGE_HTTP_HEADER_REPOSITION
+#undef BRAVE_URL_REQUEST_HTTP_JOB_ADD_EXTRA_HEADERS
 #undef AddHSTSHeader
 #undef ShouldSSLErrorsBeFatal
 #undef GetSSLUpgradeDecision

--- a/chromium_src/net/url_request/url_request_http_job.cc
+++ b/chromium_src/net/url_request/url_request_http_job.cc
@@ -7,6 +7,34 @@
 
 #include "net/http/transport_security_state.h"
 
+namespace net {
+
+namespace brave {
+
+// A helper class to defeat fingerprinting by scripts that relies on the
+// position of the Accept-Language header relative to the UA Agent.
+// See https://github.com/brave/brave-browser/issues/55271.
+class BraveAcceptLanguageHttpHeaderReposition {
+ public:
+  explicit BraveAcceptLanguageHttpHeaderReposition(
+      HttpRequestHeaders& headers) {
+    // We try and move the position of the Accept-Language header to the end.
+    auto modified_language_value =
+        headers.GetHeader(HttpRequestHeaders::kAcceptLanguage);
+    if (modified_language_value.has_value()) {
+      // We remove the header first from the underlying std::vector.
+      headers.RemoveHeader(HttpRequestHeaders::kAcceptLanguage);
+      // We now put the header back at the end.
+      headers.SetHeader(HttpRequestHeaders::kAcceptLanguage,
+                        modified_language_value.value());
+    }
+  }
+
+  ~BraveAcceptLanguageHttpHeaderReposition() = default;
+};
+}  // namespace brave
+}  // namespace net
+
 #define GetSSLUpgradeDecision(host, is_top_level_nav, net_log)                 \
   GetSSLUpgradeDecision(request->isolation_info().network_anonymization_key(), \
                         host, is_top_level_nav, net_log)
@@ -16,8 +44,12 @@
 #define AddHSTSHeader(host, value) \
   AddHSTSHeader(request_->isolation_info(), host, value)
 
+#define BRAVE_ACCEPT_LANGUAGE_HTTP_HEADER_REPOSITION \
+  brave::BraveAcceptLanguageHttpHeaderReposition(request_info_.extra_headers);
+
 #include <net/url_request/url_request_http_job.cc>
 
+#undef BRAVE_ACCEPT_LANGUAGE_HTTP_HEADER_REPOSITION
 #undef AddHSTSHeader
 #undef ShouldSSLErrorsBeFatal
 #undef GetSSLUpgradeDecision

--- a/chromium_src/net/url_request/url_request_http_job.cc
+++ b/chromium_src/net/url_request/url_request_http_job.cc
@@ -11,9 +11,10 @@ namespace net {
 
 namespace brave {
 
-// A helper class to defeat fingerprinting by scripts that relies on the
-// position of the Accept-Language header relative to the UA Agent.
-// See https://github.com/brave/brave-browser/issues/55271.
+// The Accept-Language header position is different when farbling is "off" vs
+// when farbling is "on". This class helps to keep the position same to remove
+// farbling detection by sites.
+// See https://github.com/brave/brave-browser/issues/55271 for more details.
 class BraveAcceptLanguageHttpHeaderReposition {
  public:
   explicit BraveAcceptLanguageHttpHeaderReposition(
@@ -22,9 +23,9 @@ class BraveAcceptLanguageHttpHeaderReposition {
     auto modified_language_value =
         headers.GetHeader(HttpRequestHeaders::kAcceptLanguage);
     if (modified_language_value.has_value()) {
-      // We remove the header first from the underlying std::vector.
+      // We remove the header first from the underlying vector.
       headers.RemoveHeader(HttpRequestHeaders::kAcceptLanguage);
-      // We now put the header back at the end.
+      // This will put the header at the end.
       headers.SetHeader(HttpRequestHeaders::kAcceptLanguage,
                         modified_language_value.value());
     }

--- a/patches/net-url_request-url_request_http_job.cc.patch
+++ b/patches/net-url_request-url_request_http_job.cc.patch
@@ -1,0 +1,12 @@
+diff --git a/net/url_request/url_request_http_job.cc b/net/url_request/url_request_http_job.cc
+index 15b796f4c61b325305d4f9115018483fc95f6f70..75cca1f43ffdb920ee07a36c1a059cb1596cc185 100644
+--- a/net/url_request/url_request_http_job.cc
++++ b/net/url_request/url_request_http_job.cc
+@@ -787,6 +787,7 @@ void URLRequestHttpJob::AddExtraHeaders() {
+       request()->context()->enable_brotli(),
+       request()->context()->enable_zstd());
+ 
++  BRAVE_ACCEPT_LANGUAGE_HTTP_HEADER_REPOSITION
+   if (http_user_agent_settings_) {
+     // Only add default Accept-Language if the request didn't have it
+     // specified.

--- a/patches/net-url_request-url_request_http_job.cc.patch
+++ b/patches/net-url_request-url_request_http_job.cc.patch
@@ -6,7 +6,7 @@ index 15b796f4c61b325305d4f9115018483fc95f6f70..75cca1f43ffdb920ee07a36c1a059cb1
        request()->context()->enable_brotli(),
        request()->context()->enable_zstd());
  
-+  BRAVE_ACCEPT_LANGUAGE_HTTP_HEADER_REPOSITION
++  BRAVE_URL_REQUEST_HTTP_JOB_ADD_EXTRA_HEADERS
    if (http_user_agent_settings_) {
      // Only add default Accept-Language if the request didn't have it
      // specified.


### PR DESCRIPTION
Brave farbles the Accept-Language header when the shields are up. Farbling is done such that sites don't get to know whether they received a farble value. However, there are cases where sites are looking into the position of the Accept-Language header to deterministically tell the user is farbling that header. This leads to site flagging the user unfortunately.

This change tries to mitigate it by readjusting the position of the Accept-Language header such that there's no parity in the position when the shields are "on" vs "off". 

**Demo (before fix):** 

https://github.com/user-attachments/assets/128afc25-29bd-49f7-9dd4-ea625e754419

**Demo (after fix):** 

https://github.com/user-attachments/assets/0ce1d400-4388-4346-87d1-2b6be74f29ca

Resolves: https://github.com/brave/brave-browser/issues/55271

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
