### PR TITLE
[Android][Sync] Suppress warning when enable autofill

### DIFF
--- a/android/javatests/org/chromium/chrome/browser/sync/BraveManageSyncSettingsTest.java
+++ b/android/javatests/org/chromium/chrome/browser/sync/BraveManageSyncSettingsTest.java
@@ -76,6 +76,25 @@ public class BraveManageSyncSettingsTest {
         Assert.assertTrue("Reading list toggle should be visible", prefReadingList.isVisible());
     }
 
+    @Test
+    @SmallTest
+    @Feature({"Sync"})
+    public void syncAddressesWithCustomPassphraseDoesNotShowWarningDialog() {
+        setupMockSyncService();
+        when(mSyncService.isUsingExplicitPassphrase()).thenReturn(true);
+        BraveManageSyncSettings fragment = startManageSyncPreferences();
+
+        ChromeSwitchPreference addressesToggle =
+                fragment.findPreference(ManageSyncSettings.PREF_ACCOUNT_SECTION_ADDRESSES_TOGGLE);
+        Assert.assertNotNull("Addresses toggle should exist", addressesToggle);
+
+        // Upstream shows a warning dialog and returns false when enabling addresses sync
+        // with a custom passphrase. Brave suppresses this dialog and returns true.
+        Assert.assertTrue(
+                "Addresses warning dialog should be suppressed",
+                fragment.onPreferenceChange(addressesToggle, true));
+    }
+
     void syncPasswordsOverridden(Boolean isChromeOS, Boolean handlerShouldBeOverridden) {
         setupMockSyncService();
 

--- a/patches/chrome-android-java-src-org-chromium-chrome-browser-sync-settings-ManageSyncSettings.java.patch
+++ b/patches/chrome-android-java-src-org-chromium-chrome-browser-sync-settings-ManageSyncSettings.java.patch
@@ -1,8 +1,16 @@
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/sync/settings/ManageSyncSettings.java b/chrome/android/java/src/org/chromium/chrome/browser/sync/settings/ManageSyncSettings.java
-index c6328dbceb0af518411fd05aa9c97b4280f161eb..d5d1213d8c1ea29d6b4c8421ec13129a501c6233 100644
+index c6328dbceb0af518411fd05aa9c97b4280f161eb..fba4af36657b466b541c90f855cb1eec5366f934 100644
 --- a/chrome/android/java/src/org/chromium/chrome/browser/sync/settings/ManageSyncSettings.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/sync/settings/ManageSyncSettings.java
-@@ -451,6 +451,7 @@ public class ManageSyncSettings extends ChromeBaseSettingsFragment
+@@ -262,6 +262,7 @@ public class ManageSyncSettings extends ChromeBaseSettingsFragment
+ 
+     @Override
+     public boolean onPreferenceChange(Preference preference, Object newValue) {
++        if (false)  // Suppress the "addresses not encrypted" warning (not applicable to Brave's sync model).
+         if (mSyncService.isUsingExplicitPassphrase()
+                 && preference
+                         .getKey()
+@@ -451,6 +452,7 @@ public class ManageSyncSettings extends ChromeBaseSettingsFragment
       */
      private void updateSyncPreferences() {
          String signedInAccountName =


### PR DESCRIPTION
This PR suppresses the warning `Save without encryption/Addresses aren't encrypted with your passphrase. This lets you use them in other Brave services.` while enabling Autofill sync type.

Brave uses encrypt all option, verified at `NigoriState::GetEncryptedTypes`

I have chosen simple patch over the plaster because plaster is currently in status `use only in emergency`; bytecode patching would make me to duplicate the part of `onPreferenceChange`
```java
        PostTask.postTask(
                TaskTraits.UI_DEFAULT,
                mCallbackController.makeCancelable(this::updateSyncStateFromSelectedTypes));

```

Must be uplifted to all channels along with `cr149`.

Resolves https://github.com/brave/brave-browser/issues/55902

### Video


https://github.com/user-attachments/assets/ad375f9b-c1c5-4f07-8bca-ef7c4580e99b



<!-- Add brave-browser issue below that this PR will resolve -->


<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
