### PR TITLE
[Android] Fix for settings containment after VPN banner remove

### DIFF
--- a/android/java/org/chromium/chrome/browser/settings/BraveMainPreferencesBase.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveMainPreferencesBase.java
@@ -116,7 +116,7 @@ public abstract class BraveMainPreferencesBase extends BravePreferenceFragment
 
     private final HashMap<String, Preference> mRemovedPreferences = new HashMap<>();
     private @Nullable BraveAccountSectionController mAccountController;
-    private @Nullable Preference mVpnCalloutPreference;
+    private @Nullable VpnCalloutPreference mVpnCalloutPreference;
     private boolean mNotificationClicked;
 
     @Override
@@ -319,6 +319,11 @@ public abstract class BraveMainPreferencesBase extends BravePreferenceFragment
                 && !BraveVpnPolicy.isDisabledByPolicy(getProfile())) {
             if (mVpnCalloutPreference == null) {
                 mVpnCalloutPreference = new VpnCalloutPreference(getActivity());
+                // Dismissing the callout removes it from the screen, which changes the position of
+                // the remaining preferences within their containment groups. Notify so the rounded
+                // card styling gets recomputed; otherwise neighbors keep stale corner/margin
+                // styling computed for their old positions.
+                mVpnCalloutPreference.setOnDismissedCallback(this::notifyPreferencesUpdated);
             }
             if (mVpnCalloutPreference != null) {
                 mVpnCalloutPreference.setKey(PREF_BRAVE_VPN_CALLOUT);

--- a/android/java/org/chromium/chrome/browser/vpn/settings/VpnCalloutPreference.java
+++ b/android/java/org/chromium/chrome/browser/vpn/settings/VpnCalloutPreference.java
@@ -18,6 +18,7 @@ import androidx.cardview.widget.CardView;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceViewHolder;
 
+import org.chromium.build.annotations.Nullable;
 import org.chromium.chrome.R;
 import org.chromium.chrome.browser.InternetConnection;
 import org.chromium.chrome.browser.flags.ChromeFeatureList;
@@ -28,9 +29,19 @@ import org.chromium.ui.base.DeviceFormFactor;
 import org.chromium.ui.widget.Toast;
 
 public class VpnCalloutPreference extends Preference {
+    private @Nullable Runnable mOnDismissedCallback;
+
     public VpnCalloutPreference(Context context) {
         super(context);
         setLayoutResource(R.layout.vpn_settings_callout_modal_layout);
+    }
+
+    /**
+     * Sets a callback invoked after the callout removes itself from the preference screen. Lets the
+     * host fragment refresh dependent UI (e.g. containment styling of the remaining preferences).
+     */
+    public void setOnDismissedCallback(@Nullable Runnable callback) {
+        mOnDismissedCallback = callback;
     }
 
     @Override
@@ -59,18 +70,24 @@ public class VpnCalloutPreference extends Preference {
         mainView.setLayoutParams(params);
 
         AppCompatImageView btnClose = (AppCompatImageView) holder.findViewById(R.id.modal_close);
-        btnClose.setOnClickListener(v -> {
-            getPreferenceManager().getPreferenceScreen().removePreference(this);
-            BraveVpnPrefUtils.setCallout(false);
-        });
+        btnClose.setOnClickListener(
+                v -> {
+                    getPreferenceManager().getPreferenceScreen().removePreference(this);
+                    BraveVpnPrefUtils.setCallout(false);
+                    if (mOnDismissedCallback != null) {
+                        mOnDismissedCallback.run();
+                    }
+                });
         Button btnLearnMore = (Button) holder.findViewById(R.id.btn_learn_more);
-        btnLearnMore.setOnClickListener(v -> {
-            if (!InternetConnection.isNetworkAvailable(getContext())) {
-                Toast.makeText(getContext(), R.string.no_internet, Toast.LENGTH_SHORT).show();
-            } else {
-                BraveVpnUtils.openBraveVpnPlansActivity((Activity) getContext());
-                BraveVpnPrefUtils.setCallout(false);
-            }
-        });
+        btnLearnMore.setOnClickListener(
+                v -> {
+                    if (!InternetConnection.isNetworkAvailable(getContext())) {
+                        Toast.makeText(getContext(), R.string.no_internet, Toast.LENGTH_SHORT)
+                                .show();
+                    } else {
+                        BraveVpnUtils.openBraveVpnPlansActivity((Activity) getContext());
+                        BraveVpnPrefUtils.setCallout(false);
+                    }
+                });
     }
 }


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/55945

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
