### PR TITLE
[Android] Fix for settings containment after VPN banner remove (uplift to 1.92.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/settings/BraveMainPreferencesBase.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveMainPreferencesBase.java
@@ -116,7 +116,7 @@ public abstract class BraveMainPreferencesBase extends BravePreferenceFragment
 
     private final HashMap<String, Preference> mRemovedPreferences = new HashMap<>();
     private @Nullable BraveAccountSectionController mAccountController;
-    private @Nullable Preference mVpnCalloutPreference;
+    private @Nullable VpnCalloutPreference mVpnCalloutPreference;
     private boolean mNotificationClicked;
 
     @Override
@@ -319,6 +319,11 @@ public abstract class BraveMainPreferencesBase extends BravePreferenceFragment
                 && !BraveVpnPolicy.isDisabledByPolicy(getProfile())) {
             if (mVpnCalloutPreference == null) {
                 mVpnCalloutPreference = new VpnCalloutPreference(getActivity());
+                // Dismissing the callout removes it from the screen, which changes the position of
+                // the remaining preferences within their containment groups. Notify so the rounded
+                // card styling gets recomputed; otherwise neighbors keep stale corner/margin
+                // styling computed for their old positions.
+                mVpnCalloutPreference.setOnDismissedCallback(this::notifyPreferencesUpdated);
             }
             if (mVpnCalloutPreference != null) {
                 mVpnCalloutPreference.setKey(PREF_BRAVE_VPN_CALLOUT);

--- a/android/java/org/chromium/chrome/browser/vpn/settings/VpnCalloutPreference.java
+++ b/android/java/org/chromium/chrome/browser/vpn/settings/VpnCalloutPreference.java
@@ -18,6 +18,7 @@ import androidx.cardview.widget.CardView;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceViewHolder;
 
+import org.chromium.build.annotations.Nullable;
 import org.chromium.chrome.R;
 import org.chromium.chrome.browser.InternetConnection;
 import org.chromium.chrome.browser.flags.ChromeFeatureList;
@@ -28,9 +29,19 @@ import org.chromium.ui.base.DeviceFormFactor;
 import org.chromium.ui.widget.Toast;
 
 public class VpnCalloutPreference extends Preference {
+    private @Nullable Runnable mOnDismissedCallback;
+
     public VpnCalloutPreference(Context context) {
         super(context);
         setLayoutResource(R.layout.vpn_settings_callout_modal_layout);
+    }
+
+    /**
+     * Sets a callback invoked after the callout removes itself from the preference screen. Lets the
+     * host fragment refresh dependent UI (e.g. containment styling of the remaining preferences).
+     */
+    public void setOnDismissedCallback(@Nullable Runnable callback) {
+        mOnDismissedCallback = callback;
     }
 
     @Override
@@ -59,18 +70,24 @@ public class VpnCalloutPreference extends Preference {
         mainView.setLayoutParams(params);
 
         AppCompatImageView btnClose = (AppCompatImageView) holder.findViewById(R.id.modal_close);
-        btnClose.setOnClickListener(v -> {
-            getPreferenceManager().getPreferenceScreen().removePreference(this);
-            BraveVpnPrefUtils.setCallout(false);
-        });
+        btnClose.setOnClickListener(
+                v -> {
+                    getPreferenceManager().getPreferenceScreen().removePreference(this);
+                    BraveVpnPrefUtils.setCallout(false);
+                    if (mOnDismissedCallback != null) {
+                        mOnDismissedCallback.run();
+                    }
+                });
         Button btnLearnMore = (Button) holder.findViewById(R.id.btn_learn_more);
-        btnLearnMore.setOnClickListener(v -> {
-            if (!InternetConnection.isNetworkAvailable(getContext())) {
-                Toast.makeText(getContext(), R.string.no_internet, Toast.LENGTH_SHORT).show();
-            } else {
-                BraveVpnUtils.openBraveVpnPlansActivity((Activity) getContext());
-                BraveVpnPrefUtils.setCallout(false);
-            }
-        });
+        btnLearnMore.setOnClickListener(
+                v -> {
+                    if (!InternetConnection.isNetworkAvailable(getContext())) {
+                        Toast.makeText(getContext(), R.string.no_internet, Toast.LENGTH_SHORT)
+                                .show();
+                    } else {
+                        BraveVpnUtils.openBraveVpnPlansActivity((Activity) getContext());
+                        BraveVpnPrefUtils.setCallout(false);
+                    }
+                });
     }
 }


### PR DESCRIPTION
Uplift of #36878
Resolves https://github.com/brave/brave-browser/issues/55945

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.