### PR TITLE
Hide Rewards keyboard shortcuts in Brave Origin branded builds

### DIFF
--- a/browser/ui/commands/BUILD.gn
+++ b/browser/ui/commands/BUILD.gn
@@ -24,6 +24,7 @@ source_set("unit_tests") {
     "//brave/components/ai_chat/core/common/buildflags",
     "//brave/components/brave_news/common/buildflags",
     "//brave/components/brave_rewards/core",
+    "//brave/components/brave_rewards/core/buildflags",
     "//brave/components/brave_talk/buildflags",
     "//brave/components/brave_vpn/common/buildflags",
     "//brave/components/brave_wallet/common/buildflags",

--- a/browser/ui/commands/accelerator_service.cc
+++ b/browser/ui/commands/accelerator_service.cc
@@ -18,7 +18,7 @@
 #include "brave/app/command_utils.h"
 #include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
 #include "brave/components/brave_news/common/buildflags/buildflags.h"
-#include "brave/components/brave_rewards/core/pref_names.h"
+#include "brave/components/brave_rewards/core/buildflags/buildflags.h"
 #include "brave/components/brave_talk/buildflags/buildflags.h"
 #include "brave/components/brave_vpn/common/buildflags/buildflags.h"
 #include "brave/components/brave_wallet/common/buildflags/buildflags.h"
@@ -42,6 +42,10 @@
 #if BUILDFLAG(ENABLE_AI_CHAT)
 #include "brave/components/ai_chat/core/common/pref_names.h"
 #endif  // BUILDFLAG(ENABLE_AI_CHAT)
+
+#if BUILDFLAG(ENABLE_BRAVE_REWARDS)
+#include "brave/components/brave_rewards/core/pref_names.h"
+#endif
 
 #if BUILDFLAG(ENABLE_BRAVE_TALK)
 #include "brave/components/brave_talk/pref_names.h"
@@ -457,7 +461,11 @@ bool AcceleratorService::IsCommandDisabledByPolicy(int command_id) const {
 #endif
     case IDC_SHOW_BRAVE_REWARDS:
     case IDC_OFFERS_AND_REWARDS_FOR_PAGE:
+#if BUILDFLAG(ENABLE_BRAVE_REWARDS)
       return pref_service_->GetBoolean(brave_rewards::prefs::kDisabledByPolicy);
+#else
+      return true;  // Rewards not compiled in, always disabled
+#endif
     case IDC_TOGGLE_AI_CHAT:
     case IDC_OPEN_FULL_PAGE_CHAT:
 #if BUILDFLAG(ENABLE_AI_CHAT)

--- a/browser/ui/commands/accelerator_service_unittest.cc
+++ b/browser/ui/commands/accelerator_service_unittest.cc
@@ -10,7 +10,7 @@
 #include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
 #include "brave/components/ai_chat/core/common/pref_names.h"
 #include "brave/components/brave_news/common/buildflags/buildflags.h"
-#include "brave/components/brave_rewards/core/pref_names.h"
+#include "brave/components/brave_rewards/core/buildflags/buildflags.h"
 #include "brave/components/brave_talk/buildflags/buildflags.h"
 #include "brave/components/brave_vpn/common/buildflags/buildflags.h"
 #include "brave/components/brave_vpn/common/pref_names.h"
@@ -54,6 +54,10 @@
 
 #if BUILDFLAG(ENABLE_BRAVE_NEWS)
 #include "brave/components/brave_news/common/pref_names.h"
+#endif
+
+#if BUILDFLAG(ENABLE_BRAVE_REWARDS)
+#include "brave/components/brave_rewards/core/pref_names.h"
 #endif
 
 namespace commands {
@@ -361,6 +365,7 @@ TEST_F(AcceleratorServiceUnitTest, PolicyFiltering) {
 #endif
 
   // Test Brave Rewards
+#if BUILDFLAG(ENABLE_BRAVE_REWARDS)
   EXPECT_FALSE(service.IsCommandDisabledByPolicy(IDC_SHOW_BRAVE_REWARDS));
   profile().GetPrefs()->SetBoolean(brave_rewards::prefs::kDisabledByPolicy,
                                    true);
@@ -368,6 +373,10 @@ TEST_F(AcceleratorServiceUnitTest, PolicyFiltering) {
   profile().GetPrefs()->SetBoolean(brave_rewards::prefs::kDisabledByPolicy,
                                    false);
   EXPECT_FALSE(service.IsCommandDisabledByPolicy(IDC_SHOW_BRAVE_REWARDS));
+#else
+  // Rewards not compiled in, should always return true (disabled)
+  EXPECT_TRUE(service.IsCommandDisabledByPolicy(IDC_SHOW_BRAVE_REWARDS));
+#endif
 
 #if BUILDFLAG(ENABLE_AI_CHAT)
   // Test AI Chat (reverse logic - disabled when pref is false)


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/55967

Brave Origin branded builds compile out Brave Rewards (enable_brave_rewards = !is_brave_origin_branded), but the Rewards keyboard shortcuts under brave://settings/system/shortcuts were still searchable/visible because IsCommandDisabledByPolicy only checked the kDisabledByPolicy pref.

This regressed in #36587 (fixes #55558), which stopped registering the BraveRewardsDisabled policy on branded builds. Previously that policy forced kDisabledByPolicy to true, which incidentally hid the shortcuts; once it was no longer registered, the pref stayed false and the shortcuts became visible. Upgraded builds (Rewards disabled via policy) are unaffected.

Gate the Rewards commands on ENABLE_BRAVE_REWARDS so they are always reported as disabled when Rewards is not compiled in, mirroring how AI Chat, Wallet, Talk, etc. are handled (see #36687 for the equivalent Leo/AI Chat fix).