### PR TITLE
[Wallet]: Update Bug Icon and CTA Button

### DIFF
--- a/components/brave_wallet_ui/components/desktop/wallet-page-wrapper/wallet-page-wrapper.tsx
+++ b/components/brave_wallet_ui/components/desktop/wallet-page-wrapper/wallet-page-wrapper.tsx
@@ -170,6 +170,7 @@ export const WalletPageWrapper = (props: Props) => {
             <CTAButton
               buttonText={getLocale('braveWalletReportAnIssueButtonText')}
               url='https://community.brave.app/tags/c/wallet/131/bug'
+              iconName='bug'
             />
           </FeatureRequestButtonWrapper>
         )}

--- a/components/brave_wallet_ui/components/shared/cta_button/cta_button.style.ts
+++ b/components/brave_wallet_ui/components/shared/cta_button/cta_button.style.ts
@@ -4,42 +4,13 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import styled from 'styled-components'
-import * as leo from '@brave/leo/tokens/css/variables'
-
-// Assets
-import IdeaIcon from '../../../assets/svg-icons/idea.svg'
 
 // Shared Styles
-import { Text, WalletButton } from '../style'
+import { Row } from '../style'
 
-export const Button = styled(WalletButton)`
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  align-items: center;
-  padding: 8px 14px;
+export const ButtonWrapper = styled(Row)`
   position: fixed;
   bottom: 32px;
   right: 32px;
-  background-color: ${leo.color.blurple[50]};
-  border: none;
-  outline: none;
-  border-radius: 40px;
-  cursor: pointer;
   z-index: 10;
-`
-
-export const ButtonText = styled(Text)`
-  color: ${leo.color.white};
-`
-
-export const IdeaButtonIcon = styled.span`
-  width: 24px;
-  height: 24px;
-  background-color: ${leo.color.white};
-  -webkit-mask-image: url(${IdeaIcon});
-  mask-image: url(${IdeaIcon});
-  mask-size: cover;
-  margin-right: 8px;
-  rotate: 180deg;
 `

--- a/components/brave_wallet_ui/components/shared/cta_button/cta_button.tsx
+++ b/components/brave_wallet_ui/components/shared/cta_button/cta_button.tsx
@@ -4,27 +4,37 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import * as React from 'react'
+import Button from '@brave/leo/react/button'
+import Icon from '@brave/leo/react/icon'
 
 // Utils
 import { openTab } from '../../../utils/routes-utils'
 
 // Styled Components
-import { Button, ButtonText, IdeaButtonIcon } from './cta_button.style'
+import { ButtonWrapper } from './cta_button.style'
 
 interface Props {
   buttonText: string
   url: string
+  iconName?: string
 }
 
-export const CTAButton = ({ buttonText, url }: Props) => {
+export const CTAButton = ({ buttonText, url, iconName }: Props) => {
   const onClick = React.useCallback(() => {
     openTab(url)
   }, [url])
 
   return (
-    <Button onClick={onClick}>
-      <IdeaButtonIcon />
-      <ButtonText variant='default.semibold'>{buttonText}</ButtonText>
-    </Button>
+    <ButtonWrapper width='unset'>
+      <Button onClick={onClick}>
+        {iconName && (
+          <Icon
+            slot='icon-before'
+            name={iconName}
+          />
+        )}
+        {buttonText}
+      </Button>
+    </ButtonWrapper>
   )
 }

--- a/ui/webui/resources/BUILD.gn
+++ b/ui/webui/resources/BUILD.gn
@@ -184,6 +184,7 @@ leo_icons_sources = [
   "browser-home.svg",
   "browser-ntp-widget.svg",
   "btc-color.svg",
+  "bug.svg",
   "calendar-check.svg",
   "camera.svg",
   "caps-lock.svg",


### PR DESCRIPTION
## Description 

- Now uses our Nala `Bug` icon for the `Report an issue` button
- Updates the `Report an issue` button to use our Nala `Button` component

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/55977>

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

Before:

<img width="236" height="109" alt="Screenshot 58" src="https://github.com/user-attachments/assets/f1284cbf-3453-4d0a-82d6-987ff3c96e06" />

After:

<img width="217" height="103" alt="Screenshot 57" src="https://github.com/user-attachments/assets/e846aef1-e0f9-403c-9c43-db6ab3e2fd14" />
