### PR TITLE
[toolchain] Use Xcode hermetic toolchain for rust WASM builds

### DIFF
--- a/tools/crates/BUILD.gn
+++ b/tools/crates/BUILD.gn
@@ -5,6 +5,24 @@
 
 import("//brave/tools/crates/build_crate.gni")
 
+# Build-time cargo configuration overlay shared by every `build_crate()`
+# target.  Substituted from cargo-config.toml.template; the output is passed
+# to cargo via --config alongside the in-tree .cargo/config.toml.
+action("cargo_config") {
+  script = "//brave/tools/crates/generate_cargo_config.py"
+  _template = "//brave/tools/crates/cargo-config.toml.template"
+  inputs = [ _template ]
+  outputs = [ cargo_config_overlay_path ]
+  args = [
+    "--template",
+    rebase_path(_template, root_build_dir),
+    "--out",
+    rebase_path(cargo_config_overlay_path, root_build_dir),
+    "--var",
+    "RUST_LLD=" + rebase_path("//third_party/rust-toolchain/bin/rust-lld"),
+  ]
+}
+
 build_crate("cargo-audit") {
 }
 

--- a/tools/crates/build_crate.gni
+++ b/tools/crates/build_crate.gni
@@ -4,6 +4,17 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import("//brave/build/host_os_constants.gni")
+import("//build/config/clang/clang.gni")
+import("//build_overrides/build.gni")
+if (host_os == "mac") {
+  import("//build/config/mac/mac_sdk.gni")
+}
+
+# Path of the generated cargo configuration overlay.  Produced by the
+# `:cargo_config` action in //brave/tools/crates:BUILD.gn and consumed by
+# every `build_crate()` invocation below.  Kept here so both files agree on
+# the location without an extra import.
+cargo_config_overlay_path = "$root_gen_dir/brave/tools/crates/cargo-config.toml"
 
 template("build_crate") {
   if (defined(invoker["crates"])) {
@@ -31,6 +42,10 @@ template("build_crate") {
     assert(current_toolchain == host_toolchain)
 
     forward_variables_from(invoker, [ "deps" ])
+    if (!defined(deps)) {
+      deps = []
+    }
+    deps += [ "//brave/tools/crates:cargo_config" ]
 
     script = "//brave/build/gn_run_rsp.py"
     args = [ "{{response_file_name}}" ]
@@ -41,6 +56,7 @@ template("build_crate") {
       "//brave/tools/crates/.cargo/config.toml",
       "//brave/tools/crates/Cargo.lock",
       "//brave/tools/crates/Cargo.toml",
+      cargo_config_overlay_path,
     ]
 
     outputs = executable_output_paths
@@ -58,6 +74,30 @@ template("build_crate") {
       "PATH=" +
           rebase_path("//third_party/rust-toolchain/bin", root_build_dir) +
           host_path_sep + getenv("PATH"),
+    ]
+
+    # Point cargo at the chromium-bundled clang as the linker driver so rustc
+    # doesn't fall through to the system `/usr/bin/cc` -> `/usr/bin/xcrun`
+    # chain (the hermetic Xcode tarball ships only the SDK, not a compiler;
+    # see build/toolchain/apple/toolchain.gni:160 where the upstream apple
+    # toolchain wires its own `clang`/`clang++` etc. from
+    # `$clang_base_path/bin/`).  Because that clang lives outside any Xcode
+    # layout, it can't auto-detect the SDK, so we also export `SDKROOT`
+    # pointing at the hermetic SDK from build/config/mac/mac_sdk.gni.
+    if (host_os == "mac" && !use_system_xcode) {
+      if (host_cpu == "arm64") {
+        _host_triple_envname = "AARCH64_APPLE_DARWIN"
+      } else {
+        _host_triple_envname = "X86_64_APPLE_DARWIN"
+      }
+      response_file_contents += [
+        "SDKROOT=" + rebase_path(mac_sdk_path),
+        "CARGO_TARGET_${_host_triple_envname}_LINKER=" +
+            rebase_path("$clang_base_path/bin/clang"),
+      ]
+    }
+
+    response_file_contents += [
       rebase_path(cargo_exe),
       "build",
       "--quiet",
@@ -67,6 +107,8 @@ template("build_crate") {
       rebase_path("//brave/tools/crates/Cargo.toml"),
       "--config",
       rebase_path("//brave/tools/crates/.cargo/config.toml"),
+      "--config",
+      rebase_path(cargo_config_overlay_path),
       "--target-dir",
       rebase_path(cargo_target_dir),
       "--frozen",

--- a/tools/crates/cargo-config.toml.template
+++ b/tools/crates/cargo-config.toml.template
@@ -1,0 +1,17 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+# Build-time cargo configuration overlay.  This template is substituted by
+# generate_cargo_config.py and the output is passed to cargo via --config when
+# building build_crate() targets.  It layers on top of the in-tree
+# .cargo/config.toml (which holds the vendor source replacement and release
+# profile settings owned by update.py).
+#
+# Keep this file scoped to entries that need build-time path substitution
+# (typically hermetic-toolchain paths that vary across machines).  Settings
+# expressible statically should stay in .cargo/config.toml.
+
+[target.wasm32-unknown-unknown]
+linker = "$RUST_LLD"

--- a/tools/crates/generate_cargo_config.py
+++ b/tools/crates/generate_cargo_config.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env vpython3
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Substitute placeholders in a cargo config template.
+
+Mirrors the upstream tools/rust/build_rust.py pattern: read a checked-in
+.template file, apply string.Template substitution from --var KEY=VALUE
+arguments, write the result to --out.
+"""
+
+import argparse
+import string
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--template',
+                        required=True,
+                        type=Path,
+                        help='Path to the .template input file.')
+    parser.add_argument('--out',
+                        required=True,
+                        type=Path,
+                        help='Path to write the substituted output to.')
+    parser.add_argument(
+        '--var',
+        action='append',
+        default=[],
+        metavar='KEY=VALUE',
+        help='Substitution applied to $KEY placeholders.  May be repeated.')
+    args = parser.parse_args()
+
+    subs: dict[str, str] = {}
+    for entry in args.var:
+        key, sep, value = entry.partition('=')
+        if not key or not sep:
+            parser.error(f'--var must be KEY=VALUE, got {entry!r}')
+        subs[key] = value
+
+    template = string.Template(args.template.read_text())
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(template.substitute(subs))
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
This has come up recently iwith a report indicating that WASM rust
builds were falling through and attempting to use the installed Xcode
toolchain:

```
= note: cc: error: sh -c '/Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild -sdk macosx -find clang 2> /dev/null' failed with exit code 17664: (null) (errno=Undefined error: 0)
          xcode-select: Failed to locate 'clang', requesting installation of command line developer tools.
```