### PR TITLE
Hide Rewards keyboard shortcuts in Brave Origin branded builds (uplift to 1.92.x)

### DIFF
--- a/browser/ui/commands/BUILD.gn
+++ b/browser/ui/commands/BUILD.gn
@@ -24,6 +24,7 @@ source_set("unit_tests") {
     "//brave/components/ai_chat/core/common/buildflags",
     "//brave/components/brave_news/common/buildflags",
     "//brave/components/brave_rewards/core",
+    "//brave/components/brave_rewards/core/buildflags",
     "//brave/components/brave_talk/buildflags",
     "//brave/components/brave_vpn/common/buildflags",
     "//brave/components/brave_wallet/common/buildflags",

--- a/browser/ui/commands/accelerator_service.cc
+++ b/browser/ui/commands/accelerator_service.cc
@@ -18,7 +18,7 @@
 #include "brave/app/command_utils.h"
 #include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
 #include "brave/components/brave_news/common/buildflags/buildflags.h"
-#include "brave/components/brave_rewards/core/pref_names.h"
+#include "brave/components/brave_rewards/core/buildflags/buildflags.h"
 #include "brave/components/brave_talk/buildflags/buildflags.h"
 #include "brave/components/brave_vpn/common/buildflags/buildflags.h"
 #include "brave/components/brave_wallet/common/buildflags/buildflags.h"
@@ -42,6 +42,10 @@
 #if BUILDFLAG(ENABLE_AI_CHAT)
 #include "brave/components/ai_chat/core/common/pref_names.h"
 #endif  // BUILDFLAG(ENABLE_AI_CHAT)
+
+#if BUILDFLAG(ENABLE_BRAVE_REWARDS)
+#include "brave/components/brave_rewards/core/pref_names.h"
+#endif
 
 #if BUILDFLAG(ENABLE_BRAVE_TALK)
 #include "brave/components/brave_talk/pref_names.h"
@@ -457,7 +461,11 @@ bool AcceleratorService::IsCommandDisabledByPolicy(int command_id) const {
 #endif
     case IDC_SHOW_BRAVE_REWARDS:
     case IDC_OFFERS_AND_REWARDS_FOR_PAGE:
+#if BUILDFLAG(ENABLE_BRAVE_REWARDS)
       return pref_service_->GetBoolean(brave_rewards::prefs::kDisabledByPolicy);
+#else
+      return true;  // Rewards not compiled in, always disabled
+#endif
     case IDC_TOGGLE_AI_CHAT:
     case IDC_OPEN_FULL_PAGE_CHAT:
 #if BUILDFLAG(ENABLE_AI_CHAT)

--- a/browser/ui/commands/accelerator_service_unittest.cc
+++ b/browser/ui/commands/accelerator_service_unittest.cc
@@ -10,7 +10,7 @@
 #include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
 #include "brave/components/ai_chat/core/common/pref_names.h"
 #include "brave/components/brave_news/common/buildflags/buildflags.h"
-#include "brave/components/brave_rewards/core/pref_names.h"
+#include "brave/components/brave_rewards/core/buildflags/buildflags.h"
 #include "brave/components/brave_talk/buildflags/buildflags.h"
 #include "brave/components/brave_vpn/common/buildflags/buildflags.h"
 #include "brave/components/brave_vpn/common/pref_names.h"
@@ -54,6 +54,10 @@
 
 #if BUILDFLAG(ENABLE_BRAVE_NEWS)
 #include "brave/components/brave_news/common/pref_names.h"
+#endif
+
+#if BUILDFLAG(ENABLE_BRAVE_REWARDS)
+#include "brave/components/brave_rewards/core/pref_names.h"
 #endif
 
 namespace commands {
@@ -361,6 +365,7 @@ TEST_F(AcceleratorServiceUnitTest, PolicyFiltering) {
 #endif
 
   // Test Brave Rewards
+#if BUILDFLAG(ENABLE_BRAVE_REWARDS)
   EXPECT_FALSE(service.IsCommandDisabledByPolicy(IDC_SHOW_BRAVE_REWARDS));
   profile().GetPrefs()->SetBoolean(brave_rewards::prefs::kDisabledByPolicy,
                                    true);
@@ -368,6 +373,10 @@ TEST_F(AcceleratorServiceUnitTest, PolicyFiltering) {
   profile().GetPrefs()->SetBoolean(brave_rewards::prefs::kDisabledByPolicy,
                                    false);
   EXPECT_FALSE(service.IsCommandDisabledByPolicy(IDC_SHOW_BRAVE_REWARDS));
+#else
+  // Rewards not compiled in, should always return true (disabled)
+  EXPECT_TRUE(service.IsCommandDisabledByPolicy(IDC_SHOW_BRAVE_REWARDS));
+#endif
 
 #if BUILDFLAG(ENABLE_AI_CHAT)
   // Test AI Chat (reverse logic - disabled when pref is false)


### PR DESCRIPTION
Uplift of #36882
Resolves brave/brave-browser#55967

## Included PRs
- #36882 - Hide Rewards keyboard shortcuts in Brave Origin branded builds

Pre-approval checklist:
- [x] You have tested your change on Nightly.
- [ ] This contains text which needs to be translated.
    - [ ] There are more than 7 days before the release.
    - [ ] I've notified folks in #l10n on Slack that translations are needed.
- [x] The PR milestones match the branch they are landing to.


Pre-merge checklist:
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.

Post-merge checklist:
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.