### PR TITLE
Use hermetic Clang/macOS SDK in `build_crate` and `rust_to_wasm` on macOS.

### DIFF
--- a/build/rust/rust_host_linker.py
+++ b/build/rust/rust_host_linker.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Host linker wrapper that drives `clang` with the hermetic `ld64.lld`.
+
+Used as `CARGO_TARGET_<host>_LINKER` for cargo builds that cross-compile to
+another target (e.g. wasm-pack's `wasm32-unknown-unknown` build) while still
+building some dependencies (serde, libc, ...) for the macOS host. Without this,
+clang's host link step runs `xcrun -find ld` and reaches into the local Xcode
+installation instead of the hermetic toolchain.
+
+The obvious fix (passing `--ld-path` via rustflags) doesn't work here:
+- `CARGO_TARGET_<host>_RUSTFLAGS` stops applying to build scripts once
+  `--target` is set, so the flag never reaches the host units.
+- `build.rustflags` does reach them, but also applies to
+  `wasm32-unknown-unknown`, where rust-lld rejects `--ld-path` as an unknown
+  argument.
+- Adding `target.wasm32-unknown-unknown.rustflags` to override it makes cargo
+  switch to target-specific rustflags for ALL units, so `build.rustflags` stops
+  reaching the host build scripts again - you can't fix both at once.
+- `-Z host-config`/`-Z target-applies-to-host` separates host vs. target flags
+  cleanly, but it's nightly/unstable.
+
+`CARGO_TARGET_<host>_LINKER` IS applied to host build scripts and is never
+passed to the WASM link, so we put `--ld-path` inside the linker invocation
+instead of a rustflag. (A plain `build_crate` build has no `--target`, so it
+could just set "CARGO_TARGET_..._RUSTFLAGS=-Clink-arg=--ld-path=...";
+this wrapper works for both.)
+"""
+
+import os
+import subprocess
+import sys
+
+
+def main():
+    cc = os.environ.get('CC')
+    if not cc:
+        print('rust_host_linker: $CC is not set', file=sys.stderr)
+        return 1
+    ld_path = os.path.join(os.path.dirname(cc), 'ld64.lld')
+    return subprocess.call([cc, f'--ld-path={ld_path}'] + sys.argv[1:])
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/build/rust/rust_host_toolchain.gni
+++ b/build/rust/rust_host_toolchain.gni
@@ -1,0 +1,44 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+# Hermetic host toolchain for cargo invocations (see `build_crate.gni` and
+# `rust_to_wasm.gni`). On macOS, point cargo's host build scripts and linker at
+# the hermetic Clang/SDK instead of letting cc-rs discover the system Xcode via
+# `xcrun`. `rust_host_inputs` and `rust_host_response_file_contents` are empty on
+# every other host, so callers can append them unconditionally.
+
+rust_host_inputs = []
+rust_host_response_file_contents = []
+
+if (host_os == "mac" && current_toolchain == host_toolchain) {
+  import("//build/config/clang/clang.gni")
+  import("//build/config/mac/mac_sdk.gni")
+
+  _clang_bin = rebase_path("$clang_base_path/bin")
+
+  assert(host_cpu == "arm64" || host_cpu == "x64")
+  if (host_cpu == "arm64") {
+    _rust_host_triple = "AARCH64_APPLE_DARWIN"
+  } else {
+    _rust_host_triple = "X86_64_APPLE_DARWIN"
+  }
+
+  rust_host_inputs += [ "//brave/build/rust/rust_host_linker.py" ]
+  rust_host_response_file_contents += [
+    "AR=$_clang_bin/llvm-ar",
+
+    # Route the host link through a wrapper that drives clang with the hermetic
+    # `ld64.lld`. This is `_LINKER` rather than a rustflag deliberately: when
+    # cargo cross-compiles (e.g. `rust_to_wasm`), only `_LINKER` reaches the host
+    # build scripts without leaking into the target link. See the wrapper's
+    # module docstring for the full rationale.
+    "CARGO_TARGET_${_rust_host_triple}_LINKER=" +
+        rebase_path("//brave/build/rust/rust_host_linker.py"),
+    "CC=$_clang_bin/clang",
+    "CXX=$_clang_bin/clang++",
+    "MACOSX_DEPLOYMENT_TARGET=$mac_deployment_target",
+    "SDKROOT=" + rebase_path(mac_sdk_path),
+  ]
+}

--- a/components/common/rust_to_wasm.gni
+++ b/components/common/rust_to_wasm.gni
@@ -4,6 +4,7 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import("//brave/build/host_os_constants.gni")
+import("//brave/build/rust/rust_host_toolchain.gni")
 
 template("rust_to_wasm") {
   assert(defined(invoker.rust_packages),
@@ -31,6 +32,7 @@ template("rust_to_wasm") {
     if (defined(invoker.inputs)) {
       inputs += invoker.inputs
     }
+    inputs += rust_host_inputs
 
     script = "//brave/build/gn_run_rsp.py"
     args = [ "{{response_file_name}}" ]
@@ -45,8 +47,17 @@ template("rust_to_wasm") {
     # or via `cargo install`, which:
     # - causes a race condition between the processes (that action_foreach forks) for wasm-pack's cache directory (if wasm-pack is run for the first time),
     # - makes our approach less self-contained.
-    response_file_contents = [
-      "PATH=./" + host_path_sep + getenv("PATH"),
+    #
+    # The rust-toolchain `rebase_path` MUST stay absolute - see the note in
+    # `//brave/tools/crates/build_crate.gni` for why a relative entry can
+    # silently fall through to a local rustup proxy.
+    response_file_contents = [ "PATH=./" + host_path_sep +
+                               rebase_path("//third_party/rust-toolchain/bin") +
+                               host_path_sep + getenv("PATH") ]
+
+    response_file_contents += rust_host_response_file_contents
+
+    response_file_contents += [
       rebase_path("$root_build_dir/wasm-pack$host_exe_suffix"),
       "--log-level",
       "warn",

--- a/tools/crates/build_crate.gni
+++ b/tools/crates/build_crate.gni
@@ -4,6 +4,7 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import("//brave/build/host_os_constants.gni")
+import("//brave/build/rust/rust_host_toolchain.gni")
 
 template("build_crate") {
   if (defined(invoker["crates"])) {
@@ -42,6 +43,7 @@ template("build_crate") {
       "//brave/tools/crates/Cargo.lock",
       "//brave/tools/crates/Cargo.toml",
     ]
+    inputs += rust_host_inputs
 
     outputs = executable_output_paths
 
@@ -55,9 +57,18 @@ template("build_crate") {
       "TMPDIR=" + rebase_path(cargo_target_dir),
       "TEMP=" + rebase_path(cargo_target_dir),
       "TMP=" + rebase_path(cargo_target_dir),
-      "PATH=" +
-          rebase_path("//third_party/rust-toolchain/bin", root_build_dir) +
+
+      # This `rebase_path` MUST stay absolute (new_base = ""). A relative
+      # entry like `../../third_party/rust-toolchain/bin` is resolved against the
+      # process's CWD, so it may not resolve correctly and could silently fall
+      # through to a local rustup proxy via `~/.cargo/bin`.
+      "PATH=" + rebase_path("//third_party/rust-toolchain/bin") +
           host_path_sep + getenv("PATH"),
+    ]
+
+    response_file_contents += rust_host_response_file_contents
+
+    response_file_contents += [
       rebase_path(cargo_exe),
       "build",
       "--quiet",


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->

For `build_crate`, this would work just fine:
```
response_file_contents += [
  "AR=$clang_bin/llvm-ar",
  "CARGO_TARGET_${rust_host_triple}_LINKER=$clang_bin/clang",
  "CARGO_TARGET_${rust_host_triple}_RUSTFLAGS=-Clink-arg=--ld-path=$clang_bin/ld64.lld",
  "CC=$clang_bin/clang",
  "CXX=$clang_bin/clang++",
  "MACOSX_DEPLOYMENT_TARGET=$mac_deployment_target",
  "SDKROOT=" + rebase_path(mac_sdk_path),
]
```
as it's a plain `cargo build` (no `--target`).

But since `rust_to_wasm` builds for the `wasm32-unknown-unknown` target via `wasm-pack`'s internal `cargo` call, `cargo`'s rustflags rules change, and none of the rustflags-based approaches work cleanly.

The problem is that `cargo` still builds some host-side dependencies (`serde`, `libc`, etc.) for macOS, and those are linked through `clang`, which uses `xcrun -find ld` to locate the linker and ends up touching the local Xcode installation.

So we need to tell `clang` which linker to use for the host-side link step, so it uses the hermetic `ld64.lld` instead of consulting Xcode, but:
- `CARGO_TARGET_<host>_RUSTFLAGS` — once `--target` is set, `cargo` stops applying the host triple's rustflags to build scripts. So the `--ld-path` never reaches them. (This is exactly why it works in `build_crate` but not here.)
- `build.rustflags`:
```
response_file_contents += [
  "--config",
  "build.rustflags=[\"-Clink-arg=--ld-path=$clang_bin/ld64.lld\"]",
]
```
alone does reach the build scripts, but it also applies to the `wasm32-unknown-unknown` target, and `rust-lld` (the WASM linker) rejects `--ld-path` with unknown argument.
- so I tried `build.rustflags` + `target.wasm32-unknown-unknown.rustflags`:
```
response_file_contents += [
  "--config",
  "build.rustflags=[\"-Clink-arg=--ld-path=$clang_bin/ld64.lld\"]",
  "--config",
  "target.wasm32-unknown-unknown.rustflags=[\"-Cstrip=none\"]",
]
```
The idea was that a non-empty `target.wasm32-unknown-unknown.rustflags` overrides `build.rustflags` for `wasm32-unknown-unknown` and drops the `--ld-path` there. But it turns out the moment you set any `target.<triple>.rustflags`, `cargo` switches to target-specific rustflags for all units, so `build.rustflags` stops reaching the host build scripts too. Net result: WASM link is fixed, but the host link breaks again with the same `xcrun -find ld` failure. You can't have both.
- `-Z host-config`/`-Z target-applies-to-host` does cleanly separate host vs. target flags and solve this, but it's a nightly/unstable `cargo` flag, so I didn't want to depend on it.
- The way out is to stop using rustflags entirely for this. `CARGO_TARGET_<host>_LINKER` is applied to the host build scripts (unlike its `_RUSTFLAGS` sibling), and it's never passed to the WASM link. So instead of injecting `--ld-path` as a flag, I'm pointing the host linker at a small wrapper (`rust_host_linker.py`) that runs `clang --ld-path=<hermetic ld64.lld> "$@"`. The `--ld-path` is now inside the linker invocation — it reaches the host build scripts and never touches `wasm32-unknown-unknown`.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
