### PR TITLE
[Android] Show restart prompt on credential-refresh Origin purchase

### DIFF
--- a/android/brave_java_sources.gni
+++ b/android/brave_java_sources.gni
@@ -93,6 +93,7 @@ brave_java_sources = [
   "../../brave/android/java/org/chromium/chrome/browser/brave_news/models/FeedItemsCard.java",
   "../../brave/android/java/org/chromium/chrome/browser/brave_origin/BraveOriginDeepLinkHandler.java",
   "../../brave/android/java/org/chromium/chrome/browser/brave_origin/BraveOriginPlansActivity.java",
+  "../../brave/android/java/org/chromium/chrome/browser/brave_origin/BraveOriginSettingsLauncherHelper.java",
   "../../brave/android/java/org/chromium/chrome/browser/brave_origin/BraveOriginSubscriptionPrefs.java",
   "../../brave/android/java/org/chromium/chrome/browser/brave_stats/BraveStatsBottomSheetDialogFragment.java",
   "../../brave/android/java/org/chromium/chrome/browser/brave_stats/BraveStatsUtil.java",

--- a/android/java/org/chromium/chrome/browser/brave_origin/BraveOriginSettingsLauncherHelper.java
+++ b/android/java/org/chromium/chrome/browser/brave_origin/BraveOriginSettingsLauncherHelper.java
@@ -1,0 +1,35 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.chromium.chrome.browser.brave_origin;
+
+import android.app.Activity;
+import android.os.Bundle;
+
+import org.jni_zero.CalledByNative;
+
+import org.chromium.base.ApplicationStatus;
+import org.chromium.build.annotations.NullMarked;
+import org.chromium.chrome.browser.settings.BraveOriginPreferences;
+import org.chromium.chrome.browser.settings.SettingsNavigationFactory;
+
+/**
+ * Opens the Brave Origin settings screen from native when a purchase is first detected, so the user
+ * can restart to apply the newly enforced policies.
+ */
+@NullMarked
+public class BraveOriginSettingsLauncherHelper {
+    @CalledByNative
+    private static void showOriginSettingsForRestart() {
+        Activity activity = ApplicationStatus.getLastTrackedFocusedActivity();
+        if (activity == null) {
+            return;
+        }
+        Bundle args = new Bundle();
+        args.putBoolean(BraveOriginPreferences.EXTRA_SHOW_RESTART_PROMPT, true);
+        SettingsNavigationFactory.createSettingsNavigation()
+                .startSettings(activity, BraveOriginPreferences.class, args);
+    }
+}

--- a/android/java/org/chromium/chrome/browser/settings/BraveOriginPreferences.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveOriginPreferences.java
@@ -52,6 +52,12 @@ public class BraveOriginPreferences extends BravePreferenceFragment
         implements Preference.OnPreferenceChangeListener {
     private static final String TAG = "BraveOriginPrefs";
 
+    /**
+     * Fragment argument: when true, show the restart snackbar on open (set by native when a
+     * purchase is first detected via credential refresh).
+     */
+    public static final String EXTRA_SHOW_RESTART_PROMPT = "show_restart_prompt";
+
     // Preference keys
     private static final String PREF_REWARDS_SWITCH = "rewards_switch";
     private static final String PREF_PRIVACY_PRESERVING_ANALYTICS_SWITCH =
@@ -75,6 +81,12 @@ public class BraveOriginPreferences extends BravePreferenceFragment
 
     /** Whether we are in the post-purchase "fetching credentials" state. */
     private boolean mIsFetchingCredentials;
+
+    /**
+     * Whether to show the restart snackbar on open. Set when the screen is opened by native after a
+     * credential-refresh purchase, where credentials are already present (no fetching spinner).
+     */
+    private boolean mShowRestartPrompt;
 
     /** References to the fetching/restart containers in the snackbar for toggling visibility. */
     @Nullable private View mFetchingContainer;
@@ -149,6 +161,11 @@ public class BraveOriginPreferences extends BravePreferenceFragment
                     });
         }
 
+        Bundle args = getArguments();
+        if (args != null) {
+            mShowRestartPrompt = args.getBoolean(EXTRA_SHOW_RESTART_PROMPT, false);
+        }
+
         // Check if we are in the post-purchase state (credentials being fetched)
         if (BraveOriginSubscriptionPrefs.isFetchingCredentials(profile)) {
             mIsFetchingCredentials = true;
@@ -177,6 +194,8 @@ public class BraveOriginPreferences extends BravePreferenceFragment
         super.onViewCreated(view, savedInstanceState);
         if (mIsFetchingCredentials) {
             showFetchingSnackbar();
+        } else if (mShowRestartPrompt) {
+            showRestartSnackbar();
         }
     }
 

--- a/android/javatests/org/chromium/chrome/browser/origin/settings/BraveOriginPreferencesTest.java
+++ b/android/javatests/org/chromium/chrome/browser/origin/settings/BraveOriginPreferencesTest.java
@@ -7,8 +7,11 @@ package org.chromium.chrome.browser.origin.settings;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
+import android.os.Bundle;
 import android.os.Looper;
+import android.view.View;
 
 import androidx.test.filters.SmallTest;
 
@@ -18,8 +21,11 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import org.chromium.base.test.util.CriteriaHelper;
 import org.chromium.base.test.util.DoNotBatch;
+import org.chromium.chrome.R;
 import org.chromium.chrome.browser.settings.BraveOriginPreferences;
+import org.chromium.chrome.browser.settings.SettingsActivity;
 import org.chromium.chrome.browser.settings.SettingsActivityTestRule;
 import org.chromium.chrome.test.ChromeJUnit4ClassRunner;
 import org.chromium.components.browser_ui.settings.ChromeSwitchPreference;
@@ -125,6 +131,37 @@ public class BraveOriginPreferencesTest {
         assertFalse(
                 "PREF_WEB_DISCOVERY_PROJECT_SWITCH should be off by default",
                 webDiscoveryProjectSwitch.isChecked());
+    }
+
+    // Test that launching with EXTRA_SHOW_RESTART_PROMPT shows the restart snackbar (the
+    // credential-refresh path, where credentials are already present so there is no spinner).
+    @Test
+    @SmallTest
+    public void testRestartPromptArgShowsRestartSnackbar() {
+        Bundle args = new Bundle();
+        args.putBoolean(BraveOriginPreferences.EXTRA_SHOW_RESTART_PROMPT, true);
+        SettingsActivity activity = mSettingsActivityTestRule.startSettingsActivity(args);
+        mBraveOriginPreferences = mSettingsActivityTestRule.getFragment();
+        Assert.assertNotNull("SettingsActivity failed to launch.", mBraveOriginPreferences);
+
+        // The snackbar is shown asynchronously from onViewCreated; poll for its
+        // "Restart now" action button to appear.
+        CriteriaHelper.pollUiThread(
+                () -> {
+                    View action =
+                            activity.getWindow().getDecorView().findViewById(R.id.snackbar_action);
+                    return action != null && action.getVisibility() == View.VISIBLE;
+                },
+                "Restart snackbar should be shown when EXTRA_SHOW_RESTART_PROMPT is set",
+                5000L,
+                100L);
+
+        // The "fetching credentials" spinner state must not be shown on this path.
+        View fetching =
+                activity.getWindow().getDecorView().findViewById(R.id.snackbar_fetching_container);
+        assertTrue(
+                "Fetching spinner should not be shown",
+                fetching == null || fetching.getVisibility() != View.VISIBLE);
     }
 
     private void startSettings() {

--- a/browser/ui/brave_origin/BUILD.gn
+++ b/browser/ui/brave_origin/BUILD.gn
@@ -16,4 +16,15 @@ source_set("brave_origin") {
   # chrome/browser/ui/chrome_pages.h is provided transitively through the
   # //chrome/browser/ui -> //brave/browser/ui dependency chain. Adding
   # //chrome/browser/ui directly would create a dependency cycle.
+
+  if (is_android) {
+    sources += [
+      "android/brave_origin_settings_launcher_helper.cc",
+      "android/brave_origin_settings_launcher_helper.h",
+    ]
+    deps += [
+      "//brave/browser/ui/brave_origin/android:jni_headers",
+      "//components/prefs",
+    ]
+  }
 }

--- a/browser/ui/brave_origin/android/BUILD.gn
+++ b/browser/ui/brave_origin/android/BUILD.gn
@@ -1,0 +1,11 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import("//build/config/android/rules.gni")
+import("//third_party/jni_zero/jni_zero.gni")
+
+generate_jni("jni_headers") {
+  sources = [ "//brave/android/java/org/chromium/chrome/browser/brave_origin/BraveOriginSettingsLauncherHelper.java" ]
+}

--- a/browser/ui/brave_origin/android/brave_origin_settings_launcher_helper.cc
+++ b/browser/ui/brave_origin/android/brave_origin_settings_launcher_helper.cc
@@ -1,0 +1,43 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/brave_origin/android/brave_origin_settings_launcher_helper.h"
+
+#include "base/android/jni_android.h"
+#include "brave/browser/ui/brave_origin/android/jni_headers/BraveOriginSettingsLauncherHelper_jni.h"
+#include "brave/components/brave_origin/pref_names.h"
+#include "chrome/browser/profiles/profile.h"
+#include "components/prefs/pref_service.h"
+
+namespace brave_origin {
+
+void OpenOriginSettingsForRestart(Profile* profile) {
+  // Android has two post-purchase paths that surface the restart prompt
+  // differently, so they can't share one code path:
+  //
+  //   * Play Store purchase: the SKUs credentials aren't ready yet at purchase
+  //     time. The Java subscription flow (BraveOriginSubscriptionPrefs) opens
+  //     the Origin settings screen showing a spinner ("Disabling features")
+  //     while fetchOrderCredentials runs, then transitions to the restart
+  //     prompt once the credentials arrive.
+  //   * Credential refresh (e.g. linked from account.brave.com): the
+  //     credentials are already present when we detect the purchase, so there
+  //     is nothing to wait for -- we go straight to the restart prompt with no
+  //     spinner.
+  //
+  // A Play purchase's fetchOrderCredentials writes kSkusState, which the shared
+  // C++ service observes and reports as a first purchase here too. Skip it in
+  // that case (identified by a non-empty purchase token) so the Java spinner
+  // flow owns the prompt and the settings screen isn't opened twice.
+  if (!profile->GetPrefs()
+           ->GetString(prefs::kBraveOriginPurchaseTokenAndroid)
+           .empty()) {
+    return;
+  }
+  Java_BraveOriginSettingsLauncherHelper_showOriginSettingsForRestart(
+      base::android::AttachCurrentThread());
+}
+
+}  // namespace brave_origin

--- a/browser/ui/brave_origin/android/brave_origin_settings_launcher_helper.h
+++ b/browser/ui/brave_origin/android/brave_origin_settings_launcher_helper.h
@@ -1,0 +1,20 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_BRAVE_ORIGIN_ANDROID_BRAVE_ORIGIN_SETTINGS_LAUNCHER_HELPER_H_
+#define BRAVE_BROWSER_UI_BRAVE_ORIGIN_ANDROID_BRAVE_ORIGIN_SETTINGS_LAUNCHER_HELPER_H_
+
+class Profile;
+
+namespace brave_origin {
+
+// Opens the Brave Origin settings screen and asks it to surface the restart
+// prompt. Called when a purchase is first detected so the user can restart to
+// apply the newly enforced policies.
+void OpenOriginSettingsForRestart(Profile* profile);
+
+}  // namespace brave_origin
+
+#endif  // BRAVE_BROWSER_UI_BRAVE_ORIGIN_ANDROID_BRAVE_ORIGIN_SETTINGS_LAUNCHER_HELPER_H_

--- a/browser/ui/brave_origin/brave_origin_navigation.cc
+++ b/browser/ui/brave_origin/brave_origin_navigation.cc
@@ -5,12 +5,13 @@
 
 #include "brave/browser/brave_origin/brave_origin_navigation.h"
 
-#include "base/notimplemented.h"
 #include "brave/browser/skus/skus_service_factory.h"
 #include "build/build_config.h"
 #include "chrome/browser/profiles/profile.h"
 
-#if !BUILDFLAG(IS_ANDROID)
+#if BUILDFLAG(IS_ANDROID)
+#include "brave/browser/ui/brave_origin/android/brave_origin_settings_launcher_helper.h"
+#else
 #include "chrome/browser/ui/chrome_pages.h"
 #endif
 
@@ -25,7 +26,7 @@ void BraveOriginNavigationDelegate::OpenOriginSettings() {
 #if !BUILDFLAG(IS_ANDROID)
   chrome::ShowSettingsSubPageForProfile(&*profile_, "origin");
 #else
-  NOTIMPLEMENTED();
+  OpenOriginSettingsForRestart(&*profile_);
 #endif
 }
 


### PR DESCRIPTION
When an Origin purchase is first detected via credential refresh (e.g. linked from account.brave.com), open the Origin settings screen and show the existing restart snackbar.

The shared first-purchase trigger in `BraveOriginService::OnCredentialSummary` calls the navigation delegate, whose Android branch was previously a no-op. It now routes through a JNI helper that opens `BraveOriginPreferences` with an explicit show-restart flag, where `onViewCreated` shows the restart snackbar.

Play Store purchases are left to the existing Java subscription flow (which shows the "Disabling features" spinner while credentials are fetched, then transitions to the restart prompt). The helper skips opening when a Play Store purchase token is present so the screen isn't opened twice.

Resolves: https://github.com/brave/brave-browser/issues/55991

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
