### PR TITLE
Fix iPhone Playlist full screen force not taking effect

### DIFF
--- a/ios/brave-ios/Sources/PlaylistUI/MediaContentView.swift
+++ b/ios/brave-ios/Sources/PlaylistUI/MediaContentView.swift
@@ -58,20 +58,16 @@ struct MediaContentView: View {
         .ignoresSafeArea()
         .allowsHitTesting(false)
     }
-    .onChange(of: isFullScreen) { oldValue, newValue in
+    .onChange(of: isFullScreen) {
       handleFullScreenOrientationChanges(
-        expectedFullScreen: newValue,
-        expectedOrientation: interfaceOrientation,
-        didFullScreenChange: oldValue != newValue,
-        didOrientationChange: false
+        isFullScreenModeChanging: true,
+        isOrientationChanging: false
       )
     }
-    .onChange(of: interfaceOrientation) { oldValue, newValue in
+    .onChange(of: interfaceOrientation) {
       handleFullScreenOrientationChanges(
-        expectedFullScreen: isFullScreen,
-        expectedOrientation: newValue,
-        didFullScreenChange: false,
-        didOrientationChange: oldValue != newValue
+        isFullScreenModeChanging: false,
+        isOrientationChanging: true
       )
     }
     .persistentSystemOverlays(isFullScreen ? .hidden : .automatic)
@@ -80,10 +76,8 @@ struct MediaContentView: View {
   }
 
   private func handleFullScreenOrientationChanges(
-    expectedFullScreen: Bool,
-    expectedOrientation: UIInterfaceOrientation,
-    didFullScreenChange: Bool,
-    didOrientationChange: Bool
+    isFullScreenModeChanging: Bool,
+    isOrientationChanging: Bool
   ) {
     if UIDevice.current.userInterfaceIdiom != .phone {
       // Full screen and orientations don't affect iPads
@@ -100,12 +94,12 @@ struct MediaContentView: View {
 
     let isPortraitVideo = model.isPortraitVideo
 
-    if !didFullScreenChange && !didOrientationChange {
+    if !isFullScreenModeChanging && !isOrientationChanging {
       // Nothing to do
       return
     }
 
-    switch (expectedFullScreen, expectedOrientation.isLandscape) {
+    switch (isFullScreen, interfaceOrientation.isLandscape) {
     case (true, false):
       // When a user taps full screen mode we specifically want to shift into landscape orientation
       // Likewise if the user was in full screen mode already and is no longer in landscape
@@ -113,9 +107,9 @@ struct MediaContentView: View {
       // since potrait video can display fullscreen without being in landscape
       if !isPortraitVideo {
         ignoreFollowingFullScreenOrientationChange = true
-        if didFullScreenChange {
+        if isFullScreenModeChanging {
           requestGeometryUpdate(orientation: .landscapeLeft)
-        } else if didOrientationChange {
+        } else if isOrientationChanging {
           toggleFullScreen(explicitFullScreenMode: false)
         }
       }
@@ -123,9 +117,9 @@ struct MediaContentView: View {
       // When a user is exiting full screen we always want to shift back to portrait orientation.
       // Likewise if the user is shifting into landscape orientation we want to enter full screen mode
       ignoreFollowingFullScreenOrientationChange = true
-      if didFullScreenChange {
+      if isFullScreenModeChanging {
         requestGeometryUpdate(orientation: .portrait)
-      } else if didOrientationChange {
+      } else if isOrientationChanging {
         toggleFullScreen(explicitFullScreenMode: true)
       }
     default:

--- a/ios/brave-ios/Sources/PlaylistUI/MediaContentView.swift
+++ b/ios/brave-ios/Sources/PlaylistUI/MediaContentView.swift
@@ -58,16 +58,20 @@ struct MediaContentView: View {
         .ignoresSafeArea()
         .allowsHitTesting(false)
     }
-    .onChange(of: isFullScreen) { _, newValue in
+    .onChange(of: isFullScreen) { oldValue, newValue in
       handleFullScreenOrientationChanges(
         expectedFullScreen: newValue,
-        expectedOrientation: interfaceOrientation
+        expectedOrientation: interfaceOrientation,
+        didFullScreenChange: oldValue != newValue,
+        didOrientationChange: false
       )
     }
-    .onChange(of: interfaceOrientation) { _, newValue in
+    .onChange(of: interfaceOrientation) { oldValue, newValue in
       handleFullScreenOrientationChanges(
         expectedFullScreen: isFullScreen,
-        expectedOrientation: newValue
+        expectedOrientation: newValue,
+        didFullScreenChange: false,
+        didOrientationChange: oldValue != newValue
       )
     }
     .persistentSystemOverlays(isFullScreen ? .hidden : .automatic)
@@ -77,7 +81,9 @@ struct MediaContentView: View {
 
   private func handleFullScreenOrientationChanges(
     expectedFullScreen: Bool,
-    expectedOrientation: UIInterfaceOrientation
+    expectedOrientation: UIInterfaceOrientation,
+    didFullScreenChange: Bool,
+    didOrientationChange: Bool
   ) {
     if UIDevice.current.userInterfaceIdiom != .phone {
       // Full screen and orientations don't affect iPads
@@ -93,10 +99,8 @@ struct MediaContentView: View {
     }
 
     let isPortraitVideo = model.isPortraitVideo
-    let isFullScreenModeChanging = expectedFullScreen != isFullScreen
-    let isOrientationChanging = expectedOrientation != interfaceOrientation
 
-    if !isFullScreenModeChanging && !isOrientationChanging {
+    if !didFullScreenChange && !didOrientationChange {
       // Nothing to do
       return
     }
@@ -109,9 +113,9 @@ struct MediaContentView: View {
       // since potrait video can display fullscreen without being in landscape
       if !isPortraitVideo {
         ignoreFollowingFullScreenOrientationChange = true
-        if isFullScreenModeChanging {
+        if didFullScreenChange {
           requestGeometryUpdate(orientation: .landscapeLeft)
-        } else {  // isOrientationChanging
+        } else if didOrientationChange {
           toggleFullScreen(explicitFullScreenMode: false)
         }
       }
@@ -119,9 +123,9 @@ struct MediaContentView: View {
       // When a user is exiting full screen we always want to shift back to portrait orientation.
       // Likewise if the user is shifting into landscape orientation we want to enter full screen mode
       ignoreFollowingFullScreenOrientationChange = true
-      if isFullScreenModeChanging {
+      if didFullScreenChange {
         requestGeometryUpdate(orientation: .portrait)
-      } else {  // isOrientationChanging
+      } else if didOrientationChange {
         toggleFullScreen(explicitFullScreenMode: true)
       }
     default:

--- a/ios/brave-ios/Sources/PlaylistUI/PlaylistSplitView.swift
+++ b/ios/brave-ios/Sources/PlaylistUI/PlaylistSplitView.swift
@@ -58,12 +58,7 @@ struct PlaylistSplitView<Sidebar: View, SidebarHeader: View, Content: View, Tool
     //
     // This is not actually an inverse of whether or not the bottom drawer is visible, since
     // on iPhone in landscape, we show neither sidebar or drawer.
-    // iPhone landscape uses a regular horizontal size class but should force fullscreen
-    // (see MediaContentView), not the iPad sidebar layout.
-    if UIDevice.current.userInterfaceIdiom == .pad,
-      horizontalSizeClass == .regular,
-      interfaceOrientation.isLandscape
-    {
+    if horizontalSizeClass == .regular && interfaceOrientation.isLandscape {
       return .sidebar
     }
     // Whether or not the sidebar is rendered inside of a bottom sheet

--- a/ios/brave-ios/Sources/PlaylistUI/PlaylistSplitView.swift
+++ b/ios/brave-ios/Sources/PlaylistUI/PlaylistSplitView.swift
@@ -58,7 +58,12 @@ struct PlaylistSplitView<Sidebar: View, SidebarHeader: View, Content: View, Tool
     //
     // This is not actually an inverse of whether or not the bottom drawer is visible, since
     // on iPhone in landscape, we show neither sidebar or drawer.
-    if horizontalSizeClass == .regular && interfaceOrientation.isLandscape {
+    // iPhone landscape uses a regular horizontal size class but should force fullscreen
+    // (see MediaContentView), not the iPad sidebar layout.
+    if UIDevice.current.userInterfaceIdiom == .pad,
+      horizontalSizeClass == .regular,
+      interfaceOrientation.isLandscape
+    {
       return .sidebar
     }
     // Whether or not the sidebar is rendered inside of a bottom sheet


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/55984

## Summary
On iPhone, rotating to landscape should force fullscreen mode. This was broken because `handleFullScreenOrientationChanges` derived whether `fullscreen` or `orientation` had changed by comparing an expected value against the environment. However, SwiftUI updates environment values before `.onChange` fires, so the comparison was always `false` and `toggleFullScreen` was never called.

The fix uses handler identity instead of value comparison: the `isFullScreen` handler passes `isFullScreenModeChanging: true`; the `interfaceOrientation` handler passes `isOrientationChanging: true`. The switch then reads the already-updated environment values directly.

This also affected Max-style iPhones (Plus/Max), which report `.regular` horizontal size class in landscape. Because `fullscreen` was never triggered, `PlaylistSplitView.sidebarLayoutMode` never hit the `if isFullScreen { return .none } ` early exit and fell through to the sidebar layout path. Once `fullscreen` is triggered correctly, this path is unreachable for iPhones.

iPad behaviour remains unchanged: landscape + regular width still uses the sidebar layout.

## Root cause

The broken comparison logic seems to have been in the to the original playlist UI ([#23425](https://github.com/brave/brave-core/pull/23425)). 

The `onChange` API migration ([#35164](https://github.com/brave/brave-core/pull/35164)) made the timing issue more consistent in 1.90.x.


## Test plan

| Device | Test Case | Expected result |
|--------|----------|-----------------|
| iPhone | Play a YouTube video, add to playlist, open from playlist, rotate to landscape while playing | Player forces fullscreen (no sidebar, toolbar, or windowed controls) |
| iPhone | Rotate back to portrait while in fullscreen | Exits fullscreen and returns to portrait layout |
| iPhone | Tap fullscreen button manually (non-portrait video) | Enters fullscreen and rotates to landscape |
| iPhone | Portrait-only video | Fullscreen toggle works without requiring landscape rotation |
| iPad | Same playlist flow in landscape | Windowed/sidebar layout still shown (unchanged) |
| iPad | Portrait | Bottom sheet sidebar still works |

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
