### PR TITLE
[Android] Show restart prompt on credential-refresh Origin purchase (uplift to 1.91.x)

### DIFF
--- a/android/brave_java_sources.gni
+++ b/android/brave_java_sources.gni
@@ -91,6 +91,7 @@ brave_java_sources = [
   "../../brave/android/java/org/chromium/chrome/browser/brave_news/models/FeedItemsCard.java",
   "../../brave/android/java/org/chromium/chrome/browser/brave_origin/BraveOriginDeepLinkHandler.java",
   "../../brave/android/java/org/chromium/chrome/browser/brave_origin/BraveOriginPlansActivity.java",
+  "../../brave/android/java/org/chromium/chrome/browser/brave_origin/BraveOriginSettingsLauncherHelper.java",
   "../../brave/android/java/org/chromium/chrome/browser/brave_origin/BraveOriginSubscriptionPrefs.java",
   "../../brave/android/java/org/chromium/chrome/browser/brave_stats/BraveStatsBottomSheetDialogFragment.java",
   "../../brave/android/java/org/chromium/chrome/browser/brave_stats/BraveStatsUtil.java",

--- a/android/java/org/chromium/chrome/browser/brave_origin/BraveOriginSettingsLauncherHelper.java
+++ b/android/java/org/chromium/chrome/browser/brave_origin/BraveOriginSettingsLauncherHelper.java
@@ -1,0 +1,35 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.chromium.chrome.browser.brave_origin;
+
+import android.app.Activity;
+import android.os.Bundle;
+
+import org.jni_zero.CalledByNative;
+
+import org.chromium.base.ApplicationStatus;
+import org.chromium.build.annotations.NullMarked;
+import org.chromium.chrome.browser.settings.BraveOriginPreferences;
+import org.chromium.chrome.browser.settings.SettingsNavigationFactory;
+
+/**
+ * Opens the Brave Origin settings screen from native when a purchase is first detected, so the user
+ * can restart to apply the newly enforced policies.
+ */
+@NullMarked
+public class BraveOriginSettingsLauncherHelper {
+    @CalledByNative
+    private static void showOriginSettingsForRestart() {
+        Activity activity = ApplicationStatus.getLastTrackedFocusedActivity();
+        if (activity == null) {
+            return;
+        }
+        Bundle args = new Bundle();
+        args.putBoolean(BraveOriginPreferences.EXTRA_SHOW_RESTART_PROMPT, true);
+        SettingsNavigationFactory.createSettingsNavigation()
+                .startSettings(activity, BraveOriginPreferences.class, args);
+    }
+}

--- a/android/java/org/chromium/chrome/browser/settings/BraveOriginPreferences.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveOriginPreferences.java
@@ -52,6 +52,12 @@ public class BraveOriginPreferences extends BravePreferenceFragment
         implements Preference.OnPreferenceChangeListener {
     private static final String TAG = "BraveOriginPrefs";
 
+    /**
+     * Fragment argument: when true, show the restart snackbar on open (set by native when a
+     * purchase is first detected via credential refresh).
+     */
+    public static final String EXTRA_SHOW_RESTART_PROMPT = "show_restart_prompt";
+
     // Preference keys
     private static final String PREF_REWARDS_SWITCH = "rewards_switch";
     private static final String PREF_PRIVACY_PRESERVING_ANALYTICS_SWITCH =
@@ -75,6 +81,12 @@ public class BraveOriginPreferences extends BravePreferenceFragment
 
     /** Whether we are in the post-purchase "fetching credentials" state. */
     private boolean mIsFetchingCredentials;
+
+    /**
+     * Whether to show the restart snackbar on open. Set when the screen is opened by native after a
+     * credential-refresh purchase, where credentials are already present (no fetching spinner).
+     */
+    private boolean mShowRestartPrompt;
 
     /** References to the fetching/restart containers in the snackbar for toggling visibility. */
     @Nullable private View mFetchingContainer;
@@ -149,6 +161,11 @@ public class BraveOriginPreferences extends BravePreferenceFragment
                     });
         }
 
+        Bundle args = getArguments();
+        if (args != null) {
+            mShowRestartPrompt = args.getBoolean(EXTRA_SHOW_RESTART_PROMPT, false);
+        }
+
         // Check if we are in the post-purchase state (credentials being fetched)
         if (BraveOriginSubscriptionPrefs.isFetchingCredentials(profile)) {
             mIsFetchingCredentials = true;
@@ -177,6 +194,8 @@ public class BraveOriginPreferences extends BravePreferenceFragment
         super.onViewCreated(view, savedInstanceState);
         if (mIsFetchingCredentials) {
             showFetchingSnackbar();
+        } else if (mShowRestartPrompt) {
+            showRestartSnackbar();
         }
     }
 

--- a/android/javatests/org/chromium/chrome/browser/origin/settings/BraveOriginPreferencesTest.java
+++ b/android/javatests/org/chromium/chrome/browser/origin/settings/BraveOriginPreferencesTest.java
@@ -7,8 +7,11 @@ package org.chromium.chrome.browser.origin.settings;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
+import android.os.Bundle;
 import android.os.Looper;
+import android.view.View;
 
 import androidx.test.filters.SmallTest;
 
@@ -18,8 +21,11 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import org.chromium.base.test.util.CriteriaHelper;
 import org.chromium.base.test.util.DoNotBatch;
+import org.chromium.chrome.R;
 import org.chromium.chrome.browser.settings.BraveOriginPreferences;
+import org.chromium.chrome.browser.settings.SettingsActivity;
 import org.chromium.chrome.browser.settings.SettingsActivityTestRule;
 import org.chromium.chrome.test.ChromeJUnit4ClassRunner;
 import org.chromium.components.browser_ui.settings.ChromeSwitchPreference;
@@ -125,6 +131,37 @@ public class BraveOriginPreferencesTest {
         assertFalse(
                 "PREF_WEB_DISCOVERY_PROJECT_SWITCH should be off by default",
                 webDiscoveryProjectSwitch.isChecked());
+    }
+
+    // Test that launching with EXTRA_SHOW_RESTART_PROMPT shows the restart snackbar (the
+    // credential-refresh path, where credentials are already present so there is no spinner).
+    @Test
+    @SmallTest
+    public void testRestartPromptArgShowsRestartSnackbar() {
+        Bundle args = new Bundle();
+        args.putBoolean(BraveOriginPreferences.EXTRA_SHOW_RESTART_PROMPT, true);
+        SettingsActivity activity = mSettingsActivityTestRule.startSettingsActivity(args);
+        mBraveOriginPreferences = mSettingsActivityTestRule.getFragment();
+        Assert.assertNotNull("SettingsActivity failed to launch.", mBraveOriginPreferences);
+
+        // The snackbar is shown asynchronously from onViewCreated; poll for its
+        // "Restart now" action button to appear.
+        CriteriaHelper.pollUiThread(
+                () -> {
+                    View action =
+                            activity.getWindow().getDecorView().findViewById(R.id.snackbar_action);
+                    return action != null && action.getVisibility() == View.VISIBLE;
+                },
+                "Restart snackbar should be shown when EXTRA_SHOW_RESTART_PROMPT is set",
+                5000L,
+                100L);
+
+        // The "fetching credentials" spinner state must not be shown on this path.
+        View fetching =
+                activity.getWindow().getDecorView().findViewById(R.id.snackbar_fetching_container);
+        assertTrue(
+                "Fetching spinner should not be shown",
+                fetching == null || fetching.getVisibility() != View.VISIBLE);
     }
 
     private void startSettings() {

--- a/browser/ui/brave_origin/BUILD.gn
+++ b/browser/ui/brave_origin/BUILD.gn
@@ -16,4 +16,15 @@ source_set("brave_origin") {
   # chrome/browser/ui/chrome_pages.h is provided transitively through the
   # //chrome/browser/ui -> //brave/browser/ui dependency chain. Adding
   # //chrome/browser/ui directly would create a dependency cycle.
+
+  if (is_android) {
+    sources += [
+      "android/brave_origin_settings_launcher_helper.cc",
+      "android/brave_origin_settings_launcher_helper.h",
+    ]
+    deps += [
+      "//brave/browser/ui/brave_origin/android:jni_headers",
+      "//components/prefs",
+    ]
+  }
 }

--- a/browser/ui/brave_origin/android/BUILD.gn
+++ b/browser/ui/brave_origin/android/BUILD.gn
@@ -1,0 +1,11 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import("//build/config/android/rules.gni")
+import("//third_party/jni_zero/jni_zero.gni")
+
+generate_jni("jni_headers") {
+  sources = [ "//brave/android/java/org/chromium/chrome/browser/brave_origin/BraveOriginSettingsLauncherHelper.java" ]
+}

--- a/browser/ui/brave_origin/android/brave_origin_settings_launcher_helper.cc
+++ b/browser/ui/brave_origin/android/brave_origin_settings_launcher_helper.cc
@@ -1,0 +1,43 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/brave_origin/android/brave_origin_settings_launcher_helper.h"
+
+#include "base/android/jni_android.h"
+#include "brave/browser/ui/brave_origin/android/jni_headers/BraveOriginSettingsLauncherHelper_jni.h"
+#include "brave/components/brave_origin/pref_names.h"
+#include "chrome/browser/profiles/profile.h"
+#include "components/prefs/pref_service.h"
+
+namespace brave_origin {
+
+void OpenOriginSettingsForRestart(Profile* profile) {
+  // Android has two post-purchase paths that surface the restart prompt
+  // differently, so they can't share one code path:
+  //
+  //   * Play Store purchase: the SKUs credentials aren't ready yet at purchase
+  //     time. The Java subscription flow (BraveOriginSubscriptionPrefs) opens
+  //     the Origin settings screen showing a spinner ("Disabling features")
+  //     while fetchOrderCredentials runs, then transitions to the restart
+  //     prompt once the credentials arrive.
+  //   * Credential refresh (e.g. linked from account.brave.com): the
+  //     credentials are already present when we detect the purchase, so there
+  //     is nothing to wait for -- we go straight to the restart prompt with no
+  //     spinner.
+  //
+  // A Play purchase's fetchOrderCredentials writes kSkusState, which the shared
+  // C++ service observes and reports as a first purchase here too. Skip it in
+  // that case (identified by a non-empty purchase token) so the Java spinner
+  // flow owns the prompt and the settings screen isn't opened twice.
+  if (!profile->GetPrefs()
+           ->GetString(prefs::kBraveOriginPurchaseTokenAndroid)
+           .empty()) {
+    return;
+  }
+  Java_BraveOriginSettingsLauncherHelper_showOriginSettingsForRestart(
+      base::android::AttachCurrentThread());
+}
+
+}  // namespace brave_origin

--- a/browser/ui/brave_origin/android/brave_origin_settings_launcher_helper.h
+++ b/browser/ui/brave_origin/android/brave_origin_settings_launcher_helper.h
@@ -1,0 +1,20 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_BRAVE_ORIGIN_ANDROID_BRAVE_ORIGIN_SETTINGS_LAUNCHER_HELPER_H_
+#define BRAVE_BROWSER_UI_BRAVE_ORIGIN_ANDROID_BRAVE_ORIGIN_SETTINGS_LAUNCHER_HELPER_H_
+
+class Profile;
+
+namespace brave_origin {
+
+// Opens the Brave Origin settings screen and asks it to surface the restart
+// prompt. Called when a purchase is first detected so the user can restart to
+// apply the newly enforced policies.
+void OpenOriginSettingsForRestart(Profile* profile);
+
+}  // namespace brave_origin
+
+#endif  // BRAVE_BROWSER_UI_BRAVE_ORIGIN_ANDROID_BRAVE_ORIGIN_SETTINGS_LAUNCHER_HELPER_H_

--- a/browser/ui/brave_origin/brave_origin_navigation.cc
+++ b/browser/ui/brave_origin/brave_origin_navigation.cc
@@ -5,12 +5,13 @@
 
 #include "brave/browser/brave_origin/brave_origin_navigation.h"
 
-#include "base/notimplemented.h"
 #include "brave/browser/skus/skus_service_factory.h"
 #include "build/build_config.h"
 #include "chrome/browser/profiles/profile.h"
 
-#if !BUILDFLAG(IS_ANDROID)
+#if BUILDFLAG(IS_ANDROID)
+#include "brave/browser/ui/brave_origin/android/brave_origin_settings_launcher_helper.h"
+#else
 #include "chrome/browser/ui/chrome_pages.h"
 #endif
 
@@ -25,7 +26,7 @@ void BraveOriginNavigationDelegate::OpenOriginSettings() {
 #if !BUILDFLAG(IS_ANDROID)
   chrome::ShowSettingsSubPageForProfile(&*profile_, "origin");
 #else
-  NOTIMPLEMENTED();
+  OpenOriginSettingsForRestart(&*profile_);
 #endif
 }
 


### PR DESCRIPTION
Uplift of #36904
Resolves https://github.com/brave/brave-browser/issues/55991

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.