### PR TITLE
[Android][Sync] Suppress warning when enable autofill (uplift to 1.91.x)

### DIFF
--- a/android/javatests/org/chromium/chrome/browser/sync/BraveManageSyncSettingsTest.java
+++ b/android/javatests/org/chromium/chrome/browser/sync/BraveManageSyncSettingsTest.java
@@ -76,6 +76,25 @@ public class BraveManageSyncSettingsTest {
         Assert.assertTrue("Reading list toggle should be visible", prefReadingList.isVisible());
     }
 
+    @Test
+    @SmallTest
+    @Feature({"Sync"})
+    public void syncAddressesWithCustomPassphraseDoesNotShowWarningDialog() {
+        setupMockSyncService();
+        when(mSyncService.isUsingExplicitPassphrase()).thenReturn(true);
+        BraveManageSyncSettings fragment = startManageSyncPreferences();
+
+        ChromeSwitchPreference addressesToggle =
+                fragment.findPreference(ManageSyncSettings.PREF_ACCOUNT_SECTION_ADDRESSES_TOGGLE);
+        Assert.assertNotNull("Addresses toggle should exist", addressesToggle);
+
+        // Upstream shows a warning dialog and returns false when enabling addresses sync
+        // with a custom passphrase. Brave suppresses this dialog and returns true.
+        Assert.assertTrue(
+                "Addresses warning dialog should be suppressed",
+                fragment.onPreferenceChange(addressesToggle, true));
+    }
+
     void syncPasswordsOverridden(Boolean isChromeOS, Boolean handlerShouldBeOverridden) {
         setupMockSyncService();
 

--- a/patches/chrome-android-java-src-org-chromium-chrome-browser-sync-settings-ManageSyncSettings.java.patch
+++ b/patches/chrome-android-java-src-org-chromium-chrome-browser-sync-settings-ManageSyncSettings.java.patch
@@ -1,8 +1,16 @@
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/sync/settings/ManageSyncSettings.java b/chrome/android/java/src/org/chromium/chrome/browser/sync/settings/ManageSyncSettings.java
-index c6328dbceb0af518411fd05aa9c97b4280f161eb..d5d1213d8c1ea29d6b4c8421ec13129a501c6233 100644
+index c6328dbceb0af518411fd05aa9c97b4280f161eb..fba4af36657b466b541c90f855cb1eec5366f934 100644
 --- a/chrome/android/java/src/org/chromium/chrome/browser/sync/settings/ManageSyncSettings.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/sync/settings/ManageSyncSettings.java
-@@ -451,6 +451,7 @@ public class ManageSyncSettings extends ChromeBaseSettingsFragment
+@@ -262,6 +262,7 @@ public class ManageSyncSettings extends ChromeBaseSettingsFragment
+ 
+     @Override
+     public boolean onPreferenceChange(Preference preference, Object newValue) {
++        if (false)  // Suppress the "addresses not encrypted" warning (not applicable to Brave's sync model).
+         if (mSyncService.isUsingExplicitPassphrase()
+                 && preference
+                         .getKey()
+@@ -451,6 +452,7 @@ public class ManageSyncSettings extends ChromeBaseSettingsFragment
       */
      private void updateSyncPreferences() {
          String signedInAccountName =


### PR DESCRIPTION
Uplift of #36876
Resolves https://github.com/brave/brave-browser/issues/55902

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.