### PR TITLE
Skip rewards grant .env asserts for Brave Origin builds

### DIFF
--- a/components/brave_rewards/core/buildflags/buildflags.gni
+++ b/components/brave_rewards/core/buildflags/buildflags.gni
@@ -44,8 +44,11 @@ if (is_official_build) {
   }
 
   # These args are currently used by "components/brave_adaptive_captcha" when
-  # rewards is disabled.
-  assert(rewards_grant_dev_endpoint != "")
-  assert(rewards_grant_staging_endpoint != "")
-  assert(rewards_grant_prod_endpoint != "")
+  # rewards is disabled. They are not needed for Brave Origin builds, which
+  # ship with rewards (and adaptive captcha) disabled.
+  if (!is_brave_origin_branded) {
+    assert(rewards_grant_dev_endpoint != "")
+    assert(rewards_grant_staging_endpoint != "")
+    assert(rewards_grant_prod_endpoint != "")
+  }
 }


### PR DESCRIPTION
Brave Origin builds disable rewards (`enable_brave_rewards = !is_brave_origin_branded`), so the `rewards_grant_{dev,staging,prod}_endpoint` values are unused. This gates their `is_official_build` asserts behind `!is_brave_origin_branded` so they are no longer required in `.env` for Origin builds.

Resolves https://github.com/brave/brave-browser/issues/55335