### PR TITLE
Exempt WebUI and trivial UI from ARCH-062 CUJ test best practice

### DIFF
--- a/docs/best-practices/architecture.md
+++ b/docs/best-practices/architecture.md
@@ -1395,6 +1395,13 @@ etc.). Non-UI components such as tab helpers, services, or background logic
 should be covered by unit tests or browser tests appropriate to the code — a CUJ
 test is not required when there is no user-visible interaction to validate.
 
+**Exception:** This rule targets native (Views) UI that `InteractiveBrowserTest`
+can drive. Don't require a CUJ test for WebUI pages such as `brave://settings`
+or `chrome://history`, where `InteractiveBrowserTest`-style testing is not
+available, nor for trivial UI with no meaningful logic to test (e.g. a toggle
+wired to a pref), nor for changes that follow an existing untested pattern in
+the surrounding code.
+
 ```cpp
 // ✅ CORRECT - CUJ test: validates user-visible behavior end-to-end
 IN_PROC_BROWSER_TEST_F(MyFeatureInteractiveTest, UserCanToggleFeature) {


### PR DESCRIPTION
Adds an exception to best practice [ARCH-062](https://github.com/brave/brave-core/tree/master/docs/best-practices/architecture.md#ARCH-062) (Every UI Feature Needs a CUJ Test) so it no longer flags WebUI pages such as `brave://settings` or `chrome://history`, where `InteractiveBrowserTest`-style CUJ testing isn't available, nor trivial UI with no meaningful logic to test (e.g. a toggle wired to a pref), nor changes that follow an existing untested pattern in the surrounding code.

This mirrors the exception recently added to TI-039 in #36901.

Per discussion in https://github.com/brave/brave-core/pull/36624#discussion_r3343149358