### PR TITLE
Revert "[toolchain] Disabling unused Mac toolchain downloads (#36760)"

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -56,7 +56,7 @@ hooks = [
     # Download hermetic xcode for goma
     'name': 'download_hermetic_xcode',
     'pattern': '.',
-    'condition': 'checkout_mac',
+    'condition': 'checkout_mac or checkout_ios',
     'action': ['vpython3', 'build/mac/download_hermetic_xcode.py'],
   },
   {


### PR DESCRIPTION
This reverts commit 31ac5c1ba85b2c6b0987379d567a172df8d0a035.

This change had been introduced under the impression we did not make use
of the hermetic toolchain to build the iOS code, but that's not
accurate. This is a partial revert of the change disabling the hermetic
SDK during the iOS checkout.

Bug: https://github.com/brave/brave-browser/issues/55812
