### PR TITLE
Skip AI Chat service key .env assert for Brave Origin builds

### DIFF
--- a/components/ai_chat/core/common/buildflags/BUILD.gn
+++ b/components/ai_chat/core/common/buildflags/BUILD.gn
@@ -6,6 +6,7 @@
 # TODO(https://github.com/brave/brave-browser/issues/48186): Move to root of
 # component.
 
+import("//brave/components/brave_origin/buildflags/buildflags.gni")
 import("//build/buildflag_header.gni")
 import("buildflags.gni")
 
@@ -14,7 +15,11 @@ declare_args() {
 }
 
 if (is_official_build) {
-  assert(service_key_aichat != "")
+  # Not needed for Brave Origin builds, which ship with AI Chat disabled
+  # (enable_ai_chat = !is_brave_origin_branded).
+  if (!is_brave_origin_branded) {
+    assert(service_key_aichat != "")
+  }
 }
 
 buildflag_header("buildflags") {


### PR DESCRIPTION
Brave Origin builds disable AI Chat (`enable_ai_chat = !is_brave_origin_branded`), so the `service_key_aichat` value is unused. This gates its `is_official_build` assert behind `!is_brave_origin_branded` so it is no longer required in `.env` for Origin builds.

Follows the same pattern as #36938 (rewards grant endpoints).

Resolves https://github.com/brave/brave-browser/issues/56070