### PR TITLE
Group Brave-imported-from-Chrome profiles under Brave in Origin import

### DIFF
--- a/components/brave_welcome_ui/state/hooks.ts
+++ b/components/brave_welcome_ui/state/hooks.ts
@@ -6,21 +6,15 @@
 import * as React from 'react'
 import { BrowserProfile, ImportDataBrowserProxyImpl } from '../api/welcome_browser_proxy'
 import { loadTimeData } from '$web-common/loadTimeData'
-import { BrowserType, ViewType } from './component_types'
+import { ViewType } from './component_types'
+import { getBrowserType } from './utils'
 import DataContext from './context'
 
-const browserList = Object.values(BrowserType)
-
 export const getValidBrowserProfiles = (profiles: BrowserProfile[]) => {
-  const getBrowserName = (toFind: string) => {
-    // TODO(tali): Add exact matching for cases like "Chrome" vs "Chrome Canary"
-    return browserList.find(browser => toFind.includes(browser))
-  }
-
   let results = profiles
     .filter((profile) => profile.name !== 'Bookmarks HTML File')
     .map((profile) => {
-      const browserType = getBrowserName(profile.name)
+      const browserType = getBrowserType(profile.name)
       // Introducing a new property here
       return { ...profile, browserType }
     })

--- a/components/brave_welcome_ui/state/utils.test.ts
+++ b/components/brave_welcome_ui/state/utils.test.ts
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { getBrowserType } from './utils'
+import { BrowserType } from './component_types'
+
+describe('getBrowserType', () => {
+  it('classifies a regular Chrome profile as Chrome', () => {
+    expect(getBrowserType('Google Chrome Your Chrome')).toBe(BrowserType.Chrome)
+    expect(getBrowserType('Google Chrome Profile 2')).toBe(BrowserType.Chrome)
+  })
+
+  it('matches the longer Chrome variants before plain Chrome', () => {
+    expect(getBrowserType('Google Chrome Canary Default'))
+      .toBe(BrowserType.Chrome_Canary)
+    expect(getBrowserType('Google Chrome Beta Default'))
+      .toBe(BrowserType.Chrome_Beta)
+    expect(getBrowserType('Google Chrome Dev Default'))
+      .toBe(BrowserType.Chrome_Dev)
+  })
+
+  // https://github.com/brave/brave-browser/issues/56072
+  // A Chrome profile previously imported into Brave keeps the Chrome-derived
+  // name; Brave Origin detects it from the Brave user data folder and prepends
+  // the "Brave" brand. It must be grouped under Brave, not Chrome.
+  it('classifies a Brave profile imported from Chrome as Brave', () => {
+    expect(getBrowserType('Brave Google Chrome Your Chrome'))
+      .toBe(BrowserType.Brave)
+    expect(getBrowserType('Brave Google Chrome Profile 2'))
+      .toBe(BrowserType.Brave)
+  })
+
+  it('classifies a regular Brave profile as Brave', () => {
+    expect(getBrowserType('Brave Default')).toBe(BrowserType.Brave)
+  })
+
+  it('does not match a brand that only appears mid-name', () => {
+    // A user-chosen Chrome profile name that happens to contain "Brave".
+    expect(getBrowserType('Google Chrome Brave stuff')).toBe(BrowserType.Chrome)
+  })
+
+  it('returns undefined for an unknown source', () => {
+    expect(getBrowserType('Bookmarks HTML File')).toBeUndefined()
+  })
+})

--- a/components/brave_welcome_ui/state/utils.ts
+++ b/components/brave_welcome_ui/state/utils.ts
@@ -4,6 +4,24 @@
 // you can obtain one at https://mozilla.org/MPL/2.0/.
 
 import { BrowserProfile } from '../api/welcome_browser_proxy'
+import { BrowserType } from './component_types'
+
+const browserList = Object.values(BrowserType)
+
+// Determines the source browser for a detected profile from its display name.
+// The C++ importer prepends the browser brand to the profile name, so the
+// brand is always at the *start* of the name (e.g. a Chrome profile that was
+// previously imported into Brave is detected by Brave Origin as
+// "Brave Google Chrome Your Chrome"). We must match against the start of the
+// name: a substring match would misclassify that profile as "Google Chrome"
+// because its name still contains the original Chrome profile name, causing it
+// to appear under the Chrome tile instead of the Brave tile.
+// https://github.com/brave/brave-browser/issues/56072
+// Note: BrowserType lists the longer Chrome variants (Canary/Beta/Dev) before
+// plain "Google Chrome", so startsWith also resolves those correctly.
+export const getBrowserType = (profileName: string) => {
+  return browserList.find((browser) => profileName.startsWith(browser))
+}
 
 export const getUniqueBrowserTypes = (browserProfiles: BrowserProfile[]) => {
   const browsersTypes = browserProfiles.map((profile) => profile.browserType)


### PR DESCRIPTION
## Summary

Fixes brave/brave-browser#56072

In **Brave Origin**, selecting **Google Chrome** on the onboarding import screen also listed Chrome profiles that had previously been imported into regular Brave (shown as e.g. `Brave Google Chrome Your Chrome`). They should appear only under the **Brave** tile.

## Root cause

Brave Origin intentionally detects regular Brave's profiles as an import source (the `IS_BRAVE_ORIGIN_BRANDED` block in `chromium_src/.../importer_list.cc`), so a user migrating from Brave to Brave Origin can bring their data over.

The C++ importer builds each profile's display name as `brand + " " + profileName`. A Chrome profile that was imported into regular Brave keeps its Chrome-derived name (`Google Chrome Your Chrome`), so when Brave Origin detects it from the Brave user data folder it becomes `Brave Google Chrome Your Chrome`.

The welcome UI then grouped profiles under a browser tile by **substring-matching** that name against the browser list:

```ts
// hooks.ts (before)
const getBrowserName = (toFind: string) => {
  // TODO(tali): Add exact matching for cases like "Chrome" vs "Chrome Canary"
  return browserList.find(browser => toFind.includes(browser))
}
```

`"Brave Google Chrome Your Chrome".includes("Google Chrome")` is `true`, and `Google Chrome` precedes `Brave` in the list, so the profile was classified as Chrome.

This also explains the reporter's observation that renaming the profile in Brave (to something without "Chrome" in it) made it stop showing under Chrome — the substring no longer matched.

## Fix

The brand is always prepended as a **prefix**, so match the start of the name instead of anywhere in it. Moved the helper to `utils.ts` as `getBrowserType` and added unit tests. This also resolves the pre-existing `TODO(tali)` — `BrowserType` lists the longer Chrome variants (Canary/Beta/Dev) before plain `Google Chrome`, so `startsWith` selects the correct one.

## Test plan

- `npm run test-unit -- components/brave_welcome_ui/state/utils.test.ts`
- Manual (per the issue):
  1. Install regular Brave, import Chrome profiles via onboarding, close Brave.
  2. Install Brave Origin, open onboarding import, select **Google Chrome**.
  3. The profile list shows only the actual Chrome profiles; the Brave-side copies now appear under the **Brave** tile.
