### PR TITLE
[VPN 2.0] Add LaunchAgent plist for Brave VPN Agent on macOS

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -721,6 +721,10 @@ action("create_dist_zips") {
 if (is_mac) {
   group("brave_app") {
     deps = [ ":brave_app_plist" ]
+
+    if (enable_brave_vpn_v2_bundling) {
+      deps += [ "//brave/components/brave_vpn/app/v2/agent:brave_vpn_agent_launchd_plist_data" ]
+    }
   }
 
   brave_tweak_info_plist("brave_app_plist") {

--- a/components/brave_vpn/app/v2/agent/BUILD.gn
+++ b/components/brave_vpn/app/v2/agent/BUILD.gn
@@ -7,6 +7,7 @@ import("//brave/components/brave_vpn/common/buildflags/buildflags.gni")
 if (is_mac) {
   import("//build/config/mac/rules.gni")
   import("//build/util/branding.gni")
+  import("//build/util/process_version.gni")
 }
 if (is_win) {
   import("//chrome/process_version_rc_template.gni")
@@ -79,5 +80,28 @@ if (is_mac) {
     sources = [ "$root_out_dir/$vpn_agent_product_full_name.app" ]
     outputs = [ "{{bundle_contents_dir}}/Helpers/{{source_file_part}}" ]
     public_deps = [ ":brave_vpn_agent_bundle" ]
+  }
+
+  # Generates the LaunchAgent plist with channel-specific substitutions.
+  process_version("brave_vpn_agent_launchd_plist") {
+    extra_args = [
+      "-e",
+      "VPN_AGENT_BUNDLE_ID=\"$vpn_agent_bundle_id\"",
+      "-e",
+      "VPN_AGENT_NAME=\"$vpn_agent_product_full_name\"",
+      "-e",
+      "FRAMEWORK_NAME=\"$chrome_product_full_name Framework\"",
+    ]
+    process_only = true
+    template_file = "mac/launchd.plist"
+    output = "$target_gen_dir/$vpn_agent_bundle_id.plist"
+  }
+
+  # Drops the LaunchAgent plist into the browser bundle.
+  bundle_data("brave_vpn_agent_launchd_plist_data") {
+    sources = [ "$target_gen_dir/$vpn_agent_bundle_id.plist" ]
+    outputs =
+        [ "{{bundle_contents_dir}}/Library/LaunchAgents/{{source_file_part}}" ]
+    public_deps = [ ":brave_vpn_agent_launchd_plist" ]
   }
 }

--- a/components/brave_vpn/app/v2/agent/mac/launchd.plist
+++ b/components/brave_vpn/app/v2/agent/mac/launchd.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>@VPN_AGENT_BUNDLE_ID@</string>
+  <key>BundleProgram</key>
+  <string>Contents/Frameworks/@FRAMEWORK_NAME@.framework/Helpers/@VPN_AGENT_NAME@.app/Contents/MacOS/@VPN_AGENT_NAME@</string>
+  <key>MachServices</key>
+  <dict>
+    <key>@VPN_AGENT_BUNDLE_ID@</key>
+    <dict>
+      <key>HideUntilCheckIn</key>
+      <true/>
+    </dict>
+  </dict>
+  <key>RunAtLoad</key>
+  <false/>
+  <key>KeepAlive</key>
+  <false/>
+</dict>
+</plist>


### PR DESCRIPTION
Add launchd.plist template and wire it into the browser bundle at `Contents/Library/LaunchAgents/` so `SMAppService.agent(plistName:)` can register the agent. Use process_version with @var@ substitution to support variable replacement in plist keys, which is required for the MachServices endpoint name. The generated plist is placed into the browser's `brave_app` target deps rather than the framework, since SMAppService requires it in the top-level app bundle.

Resolves https://github.com/brave/brave-browser/issues/54619

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
