### PR TITLE
[Android][Origin] Reclaim toolbar space when the rewards icon is hidden on tablet

### DIFF
--- a/android/java/org/chromium/chrome/browser/toolbar/top/BraveToolbarLayoutImpl.java
+++ b/android/java/org/chromium/chrome/browser/toolbar/top/BraveToolbarLayoutImpl.java
@@ -697,6 +697,20 @@ public abstract class BraveToolbarLayoutImpl extends ToolbarLayout
         post(mToolbarSnapshotCaptureRunnable);
     }
 
+    /** Updates the rewards layout visibility, keeping the tablet toolbar layout in sync. */
+    private void setRewardsLayoutVisibility(int visibility) {
+        if (mRewardsLayout == null || mRewardsLayout.getVisibility() == visibility) {
+            return;
+        }
+        mRewardsLayout.setVisibility(visibility);
+        // Tablet only: re-request layout on the rewards view so its row re-measures and the
+        // location bar reclaims the freed width, then refresh the toolbar snapshot.
+        if (BraveReflectionUtil.equalTypes(this.getClass(), ToolbarTablet.class)) {
+            post(mRewardsLayout::requestLayout);
+            invalidateToolbarSnapshotOnTablet();
+        }
+    }
+
     private void requestToolbarSnapshotCapture() {
         final ToolbarControlContainer toolbarControlContainer =
                 getRootView().findViewById(R.id.control_container);
@@ -1351,7 +1365,7 @@ public abstract class BraveToolbarLayoutImpl extends ToolbarLayout
 
         if (mRewardsLayout == null) return;
         if (isIncognito()) {
-            mRewardsLayout.setVisibility(View.GONE);
+            setRewardsLayoutVisibility(View.GONE);
             updateShieldsLayoutBackground(true);
         } else if (isNativeLibraryReady()
                 && mBraveRewardsNativeWorker != null
@@ -1361,10 +1375,10 @@ public abstract class BraveToolbarLayoutImpl extends ToolbarLayout
             Profile profile = Profile.fromWebContents(tab.getWebContents());
             boolean isDisabled = BraveRewardsPolicy.isDisabledByPolicy(profile);
             if (!isDisabled) {
-                mRewardsLayout.setVisibility(View.VISIBLE);
+                setRewardsLayoutVisibility(View.VISIBLE);
                 updateShieldsLayoutBackground(false);
             } else {
-                mRewardsLayout.setVisibility(View.GONE);
+                setRewardsLayoutVisibility(View.GONE);
                 updateShieldsLayoutBackground(true);
             }
         }
@@ -1764,7 +1778,7 @@ public abstract class BraveToolbarLayoutImpl extends ToolbarLayout
                         && !BraveRewardsPolicy.isDisabledByPolicy(profile)
                         && mBraveRewardsNativeWorker != null
                         && mBraveRewardsNativeWorker.isSupported();
-        mRewardsLayout.setVisibility(shouldShowRewards ? View.VISIBLE : View.GONE);
+        setRewardsLayoutVisibility(shouldShowRewards ? View.VISIBLE : View.GONE);
         // Update the shields layout background to match the rewards layout visibility.
         updateShieldsLayoutBackground(!shouldShowRewards);
     }
@@ -1808,8 +1822,8 @@ public abstract class BraveToolbarLayoutImpl extends ToolbarLayout
 
         boolean isDisabled = BraveRewardsPolicy.isDisabledByPolicy(profile);
         // Only show if policy allows (not disabled)
-        if (!isDisabled && mRewardsLayout != null) {
-            mRewardsLayout.setVisibility(View.VISIBLE);
+        if (!isDisabled) {
+            setRewardsLayoutVisibility(View.VISIBLE);
         }
         // If policy disables rewards, keep it hidden (default is GONE)
 


### PR DESCRIPTION
On tablet the rewards (BAT) icon lives in the brave_toolbar row, a wrap_content LinearLayout that caches its measured width. When the icon is hidden from onMeasure (e.g. when Brave Origin disables rewards), the implicit requestLayout() from setVisibility() is dropped because the toolbar is already mid-layout, so the row keeps its old width and the weighted location bar never reclaims the freed space, leaving a gap until a device rotation forces a fresh layout.

Route all rewards-slot visibility changes through a helper that, on an actual change on tablet, re-requests layout on the rewards view itself (so its row re-measures) off the measure pass, and refreshes the cached tablet toolbar snapshot.

Resolves: https://github.com/brave/brave-browser/issues/56036

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
