### PR TITLE
[Wallet] Fix renderer crash after accessing ethereum._metamask

### DIFF
--- a/components/brave_wallet/renderer/js_ethereum_provider.cc
+++ b/components/brave_wallet/renderer/js_ethereum_provider.cc
@@ -278,7 +278,28 @@ JSEthereumProvider::MetaMask::MetaMask(content::RenderFrame* render_frame)
     : RenderFrameObserver(render_frame) {}
 JSEthereumProvider::MetaMask::~MetaMask() = default;
 
-void JSEthereumProvider::MetaMask::OnDestruct() {}
+void JSEthereumProvider::MetaMask::Cleanup() {
+  // No longer need that object. Reset mojo connection, clean bound v8
+  // references, stop tracking the render frame.
+
+  ethereum_provider_.reset();
+  weak_ptr_factory_.InvalidateWeakPtrs();
+  Dispose();
+}
+
+void JSEthereumProvider::MetaMask::OnDestruct() {
+  Cleanup();
+}
+
+void JSEthereumProvider::MetaMask::WillReleaseScriptContext(
+    v8::Local<v8::Context>,
+    int32_t world_id) {
+  if (world_id != content::ISOLATED_WORLD_ID_GLOBAL) {
+    return;
+  }
+
+  Cleanup();
+}
 
 gin::ObjectTemplateBuilder
 JSEthereumProvider::MetaMask::GetObjectTemplateBuilder(v8::Isolate* isolate) {
@@ -311,10 +332,10 @@ v8::Local<v8::Promise> JSEthereumProvider::MetaMask::IsUnlocked(
       v8::Global<v8::Context>(isolate, isolate->GetCurrentContext()));
   auto promise_resolver(
       v8::Global<v8::Promise::Resolver>(isolate, resolver.ToLocalChecked()));
-  auto context(v8::Global<v8::Context>(isolate, isolate->GetCurrentContext()));
-  ethereum_provider_->IsLocked(base::BindOnce(
-      &JSEthereumProvider::MetaMask::OnIsUnlocked, base::Unretained(this),
-      std::move(global_context), std::move(promise_resolver), isolate));
+  ethereum_provider_->IsLocked(
+      base::BindOnce(&JSEthereumProvider::MetaMask::OnIsUnlocked,
+                     weak_ptr_factory_.GetWeakPtr(), std::move(global_context),
+                     std::move(promise_resolver), isolate));
 
   return resolver.ToLocalChecked()->GetPromise();
 }

--- a/components/brave_wallet/renderer/js_ethereum_provider.h
+++ b/components/brave_wallet/renderer/js_ethereum_provider.h
@@ -63,9 +63,6 @@ class JSEthereumProvider final : public gin::Wrappable<JSEthereumProvider>,
     MetaMask(const MetaMask&) = delete;
     MetaMask& operator=(const MetaMask&) = delete;
 
-    // content::RenderFrameObserver:
-    void OnDestruct() override;
-
     // gin::WrappableBase
     gin::ObjectTemplateBuilder GetObjectTemplateBuilder(
         v8::Isolate* isolate) override;
@@ -73,11 +70,19 @@ class JSEthereumProvider final : public gin::Wrappable<JSEthereumProvider>,
     v8::Local<v8::Promise> IsUnlocked(v8::Isolate* isolate);
 
    private:
+    void Cleanup();
+
+    // content::RenderFrameObserver:
+    void OnDestruct() override;
+    void WillReleaseScriptContext(v8::Local<v8::Context> context,
+                                  int32_t world_id) override;
+
     void OnIsUnlocked(v8::Global<v8::Context> global_context,
                       v8::Global<v8::Promise::Resolver> promise_resolver,
                       v8::Isolate* isolate,
                       bool locked);
     mojo::Remote<mojom::EthereumProvider> ethereum_provider_;
+    base::WeakPtrFactory<MetaMask> weak_ptr_factory_{this};
   };
 
   void Cleanup();


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/56081

This MM fix was incomplete https://github.com/brave/brave-core/pull/36564
Applied the same lifetime fix as for JS Providers https://github.com/brave/brave-core/pull/36816

### Test plan
- Open https://swap.cow.fi/#/1/swap/WETH/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48
- Quickly click Cow Swap logo in the corner for some times(navigates to https://swap.cow.fi/ and back to first link). Renderer should not crash. 

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
