### PR TITLE
[Sidebar V2] Apply panel shadow

### DIFF
--- a/browser/ui/sidebar/sidebar_browsertest.cc
+++ b/browser/ui/sidebar/sidebar_browsertest.cc
@@ -87,6 +87,7 @@
 #include "ui/events/test/event_generator.h"
 #include "ui/gfx/animation/animation_test_api.h"
 #include "ui/gfx/geometry/point.h"
+#include "ui/gfx/geometry/rounded_corners_f.h"
 #include "ui/views/animation/ink_drop.h"
 #include "ui/views/layout/layout_provider.h"
 #include "ui/views/widget/widget_utils.h"
@@ -337,6 +338,11 @@ class SidebarBrowserTest : public InProcessBrowserTest {
     auto const iter =
         std::ranges::find(items, false, &SidebarItem::open_in_panel);
     return std::distance(items.cbegin(), iter);
+  }
+
+  BraveBrowserView* browser_view() {
+    return BraveBrowserView::From(
+        BrowserView::GetBrowserViewForBrowser(browser()));
   }
 
   // ===== V2-aware helpers =====
@@ -928,11 +934,6 @@ class SidebarBrowserWithWebPanelTest
 
   BraveMultiContentsView* GetBraveMultiContentsView() {
     return browser_view()->GetBraveMultiContentsView();
-  }
-
-  BraveBrowserView* browser_view() {
-    return BraveBrowserView::From(
-        BrowserView::GetBrowserViewForBrowser(browser()));
   }
 
   bool IsWebPanelEnabled() const {
@@ -2659,6 +2660,88 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, SidebarV2ToolbarButtonPinning) {
       << "Toolbar button must be hidden again under kShowAlways";
   EXPECT_FALSE(controller()->sidebar_pinned())
       << "Pinned state must remain false after returning to kShowAlways";
+}
+
+// Exercises the V2 side-panel drop shadow (BraveSidePanelShadowOverlayView):
+//   * it is shown only while the panel is open AND rounded corners are enabled,
+//   * it stacks directly below the panel (so the panel paints over its inner
+//     part),
+//   * it paints into a clipped, non-opaque layer clamped to the browser view,
+//     and
+//   * its shadow shape tracks the panel's visible (inset) rounded area.
+IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, SidebarV2PanelShadow) {
+  auto* panel_ui = browser()->GetFeatures().side_panel_ui();
+  auto* side_panel = browser_view()->side_panel();
+  side_panel->DisableAnimationsForTesting();
+  auto* prefs = browser()->profile()->GetPrefs();
+
+  views::View* overlay =
+      browser_view()->side_panel_shadow_overlay_for_testing();
+  ASSERT_TRUE(overlay) << "Overlay should be created for the V2 sidebar";
+
+  // Hidden while the panel is closed.
+  EXPECT_FALSE(overlay->GetVisible());
+
+  // Open the panel with rounded corners on: the shadow shows.
+  prefs->SetBoolean(kWebViewRoundedCorners, true);
+  panel_ui->Toggle();
+  ASSERT_TRUE(base::test::RunUntil([&]() { return side_panel->GetVisible(); }));
+  RunScheduledLayouts();
+  ASSERT_TRUE(overlay->GetVisible())
+      << "Shadow should show when the panel is open and corners are rounded";
+
+  // It stacks directly below the panel; both are children of the browser view.
+  const auto overlay_index = browser_view()->GetIndexOf(overlay);
+  const auto panel_index = browser_view()->GetIndexOf(side_panel);
+  ASSERT_TRUE(overlay_index.has_value());
+  ASSERT_TRUE(panel_index.has_value());
+  EXPECT_EQ(overlay_index.value() + 1, panel_index.value())
+      << "overlay must be the child directly below the side panel";
+
+  // It paints into a clipped, non-opaque layer clamped to the browser view, so
+  // the blurred shadow never draws outside the window.
+  ASSERT_TRUE(overlay->layer());
+  EXPECT_FALSE(overlay->layer()->fills_bounds_opaquely());
+  EXPECT_TRUE(overlay->layer()->GetMasksToBounds());
+  EXPECT_TRUE(browser_view()->GetLocalBounds().Contains(overlay->bounds()))
+      << "overlay " << overlay->bounds().ToString() << " should fit within "
+      << browser_view()->GetLocalBounds().ToString();
+
+  // The shadow shape (the overlay's sole child view) hugs the panel's *visible*
+  // rounded area: inset by the panel's border insets on the content/outer/
+  // bottom edges, but flush with the panel's top since the header shares the
+  // rounded top. side_panel and the overlay are both children of the browser
+  // view, so convert the shape into that shared coordinate space.
+  ASSERT_EQ(1u, overlay->children().size());
+  gfx::Rect shape_bounds = overlay->children()[0]->bounds();
+  shape_bounds.Offset(overlay->bounds().OffsetFromOrigin());
+  gfx::Insets shape_insets = side_panel->GetInsets();
+  shape_insets.set_top(0);
+  gfx::Rect expected_shape = side_panel->bounds();
+  expected_shape.Inset(shape_insets);
+  EXPECT_EQ(shape_bounds, expected_shape)
+      << "shadow shape " << shape_bounds.ToString()
+      << " should match the panel's visible area " << expected_shape.ToString();
+
+  // Disabling rounded corners hides the shadow even while the panel is open.
+  // This drives the pref callback -> UpdateRoundedCornersUI() ->
+  // UpdateSidebarBorder() -> UpdateShadowVisibility() path.
+  prefs->SetBoolean(kWebViewRoundedCorners, false);
+  RunScheduledLayouts();
+  EXPECT_FALSE(overlay->GetVisible())
+      << "Shadow should hide when rounded corners are disabled";
+
+  // Re-enable corners, then close the panel: the shadow hides again (driven by
+  // the panel-visibility observer).
+  prefs->SetBoolean(kWebViewRoundedCorners, true);
+  RunScheduledLayouts();
+  ASSERT_TRUE(overlay->GetVisible());
+  panel_ui->Toggle();
+  ASSERT_TRUE(
+      base::test::RunUntil([&]() { return !side_panel->GetVisible(); }));
+  RunScheduledLayouts();
+  EXPECT_FALSE(overlay->GetVisible())
+      << "Shadow should hide when the panel is closed";
 }
 
 #endif  // BUILDFLAG(ENABLE_SIDEBAR_V2)

--- a/browser/ui/views/frame/BUILD.gn
+++ b/browser/ui/views/frame/BUILD.gn
@@ -3,6 +3,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import("//brave/browser/ui/sidebar/buildflags/buildflags.gni")
+
 source_set("frame") {
   sources = [
     "brave_contents_view_util.h",
@@ -12,6 +14,13 @@ source_set("frame") {
     "layout/brave_browser_view_tabbed_layout_impl.h",
     "tab_strip_placement_coordinator.h",
   ]
+
+  # The V2 side-panel shadow overlay is only used when upstream's SidePanel is
+  # active (enable_sidebar_v2). The header is consumed by brave_browser_view.cc
+  # under the same buildflag.
+  if (enable_sidebar_v2) {
+    sources += [ "brave_side_panel_shadow_overlay_view.h" ]
+  }
 
   public_deps = [
     "//base",
@@ -45,6 +54,14 @@ source_set("frame_impl") {
     "//components/split_tabs",
     "//components/tabs:public",
   ]
+
+  # See the matching `frame` target comment. brave_browser_view.h and
+  # view_shadow.h come from //brave/browser/ui:ui via its
+  # allow_circular_includes_from allowance for this target.
+  if (enable_sidebar_v2) {
+    sources += [ "brave_side_panel_shadow_overlay_view.cc" ]
+    deps += [ "//chrome/browser/ui/views/side_panel" ]
+  }
 }
 
 source_set("unit_tests") {

--- a/browser/ui/views/frame/brave_browser_view.cc
+++ b/browser/ui/views/frame/brave_browser_view.cc
@@ -120,6 +120,7 @@
 #endif
 
 #if BUILDFLAG(ENABLE_SIDEBAR_V2)
+#include "brave/browser/ui/views/frame/brave_side_panel_shadow_overlay_view.h"
 #include "brave/browser/ui/views/side_panel/brave_side_panel_resize_area.h"
 #endif
 
@@ -369,6 +370,13 @@ BraveBrowserView::BraveBrowserView(Browser* browser) : BrowserView(browser) {
 #if BUILDFLAG(ENABLE_SIDEBAR_V2)
       side_panel_->SetResizeArea(
           std::make_unique<views::BraveSidePanelResizeArea>(side_panel_));
+
+      side_panel_shadow_overlay_ = AddChildView(
+          std::make_unique<BraveSidePanelShadowOverlayView>(*this));
+      // Render the overlay just below `side_panel_` so the panel covers the
+      // inner part of the shadow (a higher child index paints on top).
+      ReorderChildView(side_panel_shadow_overlay_,
+                       GetIndexOf(side_panel_).value());
 #endif
     } else {
       // V1: wrap chromium's side panel inside SidebarContainerView.
@@ -1127,6 +1135,9 @@ void BraveBrowserView::UpdateSidebarBorder() {
     side_panel_->SetRoundedBorderEnabled(
         ShouldUseBraveWebViewRoundedCornersForContents(browser_));
   }
+  if (side_panel_shadow_overlay_) {
+    side_panel_shadow_overlay_->UpdateShadowVisibility();
+  }
 #else
   if (side_panel_) {
     side_panel_->UpdateBorder();
@@ -1137,6 +1148,12 @@ void BraveBrowserView::UpdateSidebarBorder() {
     sidebar_container_view_->UpdateBorder();
   }
 }
+
+#if BUILDFLAG(ENABLE_SIDEBAR_V2)
+views::View* BraveBrowserView::side_panel_shadow_overlay_for_testing() {
+  return side_panel_shadow_overlay_.get();
+}
+#endif
 
 // PWA and omnibox Shields share kShieldsActionIcon; the PWA build uses
 // BraveShieldsToolbarButton with that id.

--- a/browser/ui/views/frame/brave_browser_view.h
+++ b/browser/ui/views/frame/brave_browser_view.h
@@ -17,6 +17,7 @@
 #include "base/memory/weak_ptr.h"
 #include "base/scoped_observation.h"
 #include "brave/browser/ui/commands/accelerator_service.h"
+#include "brave/browser/ui/sidebar/buildflags/buildflags.h"
 #include "brave/browser/ui/tabs/brave_tab_strip_model.h"
 #include "brave/components/brave_vpn/common/buildflags/buildflags.h"
 #include "brave/components/brave_wallet/common/buildflags/buildflags.h"
@@ -65,6 +66,7 @@ class Widget;
 }  // namespace views
 
 class BraveBrowser;
+class BraveSidePanelShadowOverlayView;
 class BraveShieldsToolbarButton;
 class BraveHelpBubbleHostView;
 class BraveMultiContentsView;
@@ -177,6 +179,10 @@ class BraveBrowserView : public BrowserView,
   views::View* top_container_separator_for_testing() const {
     return top_container_separator_;
   }
+
+#if BUILDFLAG(ENABLE_SIDEBAR_V2)
+  views::View* side_panel_shadow_overlay_for_testing();
+#endif
 
 #if BUILDFLAG(ENABLE_EXTENSIONS)
   // Returns the PWA Shields toolbar button, if it exists. Note that this
@@ -306,6 +312,12 @@ class BraveBrowserView : public BrowserView,
   std::unique_ptr<BrowserWindowMouseEventHandler>
       browser_window_mouse_event_handler_;
   std::unique_ptr<ViewShadow> contents_shadow_;
+
+#if BUILDFLAG(ENABLE_SIDEBAR_V2)
+  // Sibling of `side_panel_` that renders the panel's drop shadow without
+  // drawing outside the browser view. Tracks the panel by observing it.
+  raw_ptr<BraveSidePanelShadowOverlayView> side_panel_shadow_overlay_ = nullptr;
+#endif
 
   PrefChangeRegistrar pref_change_registrar_;
   BooleanPrefMember compact_horizontal_tabs_;

--- a/browser/ui/views/frame/brave_side_panel_shadow_overlay_view.cc
+++ b/browser/ui/views/frame/brave_side_panel_shadow_overlay_view.cc
@@ -44,6 +44,10 @@ BraveSidePanelShadowOverlayView::BraveSidePanelShadowOverlayView(
   layer()->SetMasksToBounds(true);
   SetVisible(false);
 
+  auto* panel = browser_view_->side_panel();
+  CHECK(panel);
+  panel_observation_.Observe(panel);
+
   panel_shape_ = AddChildView(std::make_unique<views::View>());
 
   const int radius = views::LayoutProvider::Get()->GetCornerRadiusMetric(
@@ -53,24 +57,9 @@ BraveSidePanelShadowOverlayView::BraveSidePanelShadowOverlayView(
   shadow_->SetVisible(false);
 }
 
-BraveSidePanelShadowOverlayView::~BraveSidePanelShadowOverlayView() {
-  if (observed_panel_) {
-    observed_panel_->RemoveObserver(this);
-    observed_panel_ = nullptr;
-  }
-}
+BraveSidePanelShadowOverlayView::~BraveSidePanelShadowOverlayView() = default;
 
 void BraveSidePanelShadowOverlayView::UpdateShadowVisibility() {
-  SyncToSidePanel();
-}
-
-void BraveSidePanelShadowOverlayView::AddedToWidget() {
-  if (!observed_panel_) {
-    if (auto* panel = browser_view_->side_panel()) {
-      observed_panel_ = panel;
-      observed_panel_->AddObserver(this);
-    }
-  }
   SyncToSidePanel();
 }
 
@@ -88,14 +77,13 @@ void BraveSidePanelShadowOverlayView::OnViewVisibilityChanged(
 
 void BraveSidePanelShadowOverlayView::OnViewIsDeleting(
     views::View* observed_view) {
-  observed_view->RemoveObserver(this);
-  if (observed_view == observed_panel_) {
-    observed_panel_ = nullptr;
-  }
+  auto* panel = panel_observation_.GetSource();
+  CHECK_EQ(panel, observed_view);
+  panel_observation_.Reset();
 }
 
 void BraveSidePanelShadowOverlayView::SyncToSidePanel() {
-  auto* panel = browser_view_->side_panel();
+  auto* panel = panel_observation_.GetSource();
   const bool rounded_corners =
       BraveBrowserView::ShouldUseBraveWebViewRoundedCornersForContents(
           browser_view_->browser());

--- a/browser/ui/views/frame/brave_side_panel_shadow_overlay_view.cc
+++ b/browser/ui/views/frame/brave_side_panel_shadow_overlay_view.cc
@@ -1,0 +1,142 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/views/frame/brave_side_panel_shadow_overlay_view.h"
+
+#include <memory>
+
+#include "brave/browser/ui/views/frame/brave_browser_view.h"
+#include "brave/browser/ui/views/frame/brave_contents_view_util.h"
+#include "brave/browser/ui/views/view_shadow.h"
+#include "chrome/browser/ui/views/frame/browser_view.h"
+#include "chrome/browser/ui/views/side_panel/side_panel.h"
+#include "ui/base/metadata/metadata_impl_macros.h"
+#include "ui/compositor/layer.h"
+#include "ui/gfx/geometry/rect.h"
+#include "ui/gfx/geometry/rounded_corners_f.h"
+#include "ui/views/layout/layout_provider.h"
+#include "ui/views/view.h"
+
+namespace {
+
+// Transparent margin added around the panel so the blurred shadow has room to
+// render before being clipped to the browser view. The visible blur extends
+// roughly `2 * blur_radius` px; a slightly larger margin is harmless because it
+// is clipped away by MasksToBounds.
+constexpr int kShadowMargin = 8;
+
+}  // namespace
+
+BraveSidePanelShadowOverlayView::BraveSidePanelShadowOverlayView(
+    BrowserView& browser_view)
+    : browser_view_(browser_view) {
+  // Purely decorative; never intercept events.
+  SetCanProcessEventsWithinSubtree(false);
+
+  // Paint to a clipped, non-opaque layer. MasksToBounds, combined with clamping
+  // our bounds to the browser view in SyncToSidePanel(), is what guarantees the
+  // shadow is never drawn outside the browser view (e.g. past the window edge
+  // during the slide animation).
+  SetPaintToLayer();
+  layer()->SetFillsBoundsOpaquely(false);
+  layer()->SetMasksToBounds(true);
+  SetVisible(false);
+
+  panel_shape_ = AddChildView(std::make_unique<views::View>());
+
+  const int radius = views::LayoutProvider::Get()->GetCornerRadiusMetric(
+      views::ShapeContextTokensOverride::kRoundedCornersBorderRadius);
+  shadow_ = BraveContentsViewUtil::CreateShadow(panel_shape_,
+                                                gfx::RoundedCornersF(radius));
+  shadow_->SetVisible(false);
+}
+
+BraveSidePanelShadowOverlayView::~BraveSidePanelShadowOverlayView() {
+  if (observed_panel_) {
+    observed_panel_->RemoveObserver(this);
+    observed_panel_ = nullptr;
+  }
+}
+
+void BraveSidePanelShadowOverlayView::UpdateShadowVisibility() {
+  SyncToSidePanel();
+}
+
+void BraveSidePanelShadowOverlayView::AddedToWidget() {
+  if (!observed_panel_) {
+    if (auto* panel = browser_view_->side_panel()) {
+      observed_panel_ = panel;
+      observed_panel_->AddObserver(this);
+    }
+  }
+  SyncToSidePanel();
+}
+
+void BraveSidePanelShadowOverlayView::OnViewBoundsChanged(
+    views::View* /*observed_view*/) {
+  SyncToSidePanel();
+}
+
+void BraveSidePanelShadowOverlayView::OnViewVisibilityChanged(
+    views::View* /*observed_view*/,
+    views::View* /*starting_view*/,
+    bool /*is_visible*/) {
+  SyncToSidePanel();
+}
+
+void BraveSidePanelShadowOverlayView::OnViewIsDeleting(
+    views::View* observed_view) {
+  observed_view->RemoveObserver(this);
+  if (observed_view == observed_panel_) {
+    observed_panel_ = nullptr;
+  }
+}
+
+void BraveSidePanelShadowOverlayView::SyncToSidePanel() {
+  auto* panel = browser_view_->side_panel();
+  const bool rounded_corners =
+      BraveBrowserView::ShouldUseBraveWebViewRoundedCornersForContents(
+          browser_view_->browser());
+
+  if (!panel || !panel->GetVisible() || !rounded_corners) {
+    shadow_->SetVisible(false);
+    SetVisible(false);
+    return;
+  }
+
+  // `panel->bounds()` is in browser-view coordinates; this overlay is also a
+  // child of the browser view, so they share a coordinate space.
+  const gfx::Rect panel_bounds = panel->bounds();
+
+  // Our bounds: the panel plus a margin for the blur, clamped to the browser
+  // view. Clamping + MasksToBounds clips any part of the shadow that would fall
+  // outside the browser view (e.g. on the window edge during the slide).
+  gfx::Rect overlay_bounds = panel_bounds;
+  overlay_bounds.Inset(-kShadowMargin);
+  overlay_bounds.Intersect(browser_view_->GetLocalBounds());
+  SetBoundsRect(overlay_bounds);
+
+  // Position the shadow shape over the panel's *visible* rounded area, in our
+  // local coordinates. SidePanel::UpdateBorder() pads the panel - a bottom and
+  // outer-side margin plus a header-height top inset - so the rounded content
+  // is smaller than panel->bounds(). Shrink the shape by those same insets so
+  // the shadow hugs the visible edges rather than the raw bounds (otherwise the
+  // padded sides look offset/thicker). The top inset is dropped because the
+  // header fills it and shares the panel's rounded top, so the shadow should
+  // still wrap the very top edge.
+  // The blur around the shape may extend past our (clamped) bounds; that
+  // overflow is exactly what MasksToBounds clips so the shadow never leaves the
+  // browser view.
+  gfx::Rect shape_bounds = panel_bounds;
+  shape_bounds.Offset(-overlay_bounds.x(), -overlay_bounds.y());
+  shape_bounds.Inset(panel->GetInsets().set_top(0));
+  panel_shape_->SetBoundsRect(shape_bounds);
+
+  SetVisible(true);
+  shadow_->SetVisible(true);
+}
+
+BEGIN_METADATA(BraveSidePanelShadowOverlayView)
+END_METADATA

--- a/browser/ui/views/frame/brave_side_panel_shadow_overlay_view.h
+++ b/browser/ui/views/frame/brave_side_panel_shadow_overlay_view.h
@@ -1,0 +1,72 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_VIEWS_FRAME_BRAVE_SIDE_PANEL_SHADOW_OVERLAY_VIEW_H_
+#define BRAVE_BROWSER_UI_VIEWS_FRAME_BRAVE_SIDE_PANEL_SHADOW_OVERLAY_VIEW_H_
+
+#include <memory>
+
+#include "base/memory/raw_ptr.h"
+#include "base/memory/raw_ref.h"
+#include "ui/base/metadata/metadata_header_macros.h"
+#include "ui/views/view.h"
+#include "ui/views/view_observer.h"
+
+class BrowserView;
+class ViewShadow;
+
+// Renders a drop shadow around the V2 side panel that is visually identical to
+// the V1 panel shadow (BraveContentsViewUtil::CreateShadow) but never draws
+// outside the browser view.
+//
+// V1 attaches the shadow layer to the side panel's own `kBelow` region, so the
+// shadow rides along with the sliding panel and leaks outside the window during
+// the open/close animation. Instead, this view is a sibling of the side panel
+// in BraveBrowserView. It:
+//   * tracks the panel's bounds by observing it,
+//   * paints the shadow into its own layer that is clipped (MasksToBounds) and
+//     clamped to the browser view, so nothing is ever drawn outside it, and
+//   * is stacked just *below* the panel, so the panel covers the inner part of
+//     the shadow - leaving only the outer glow visible, matching V1.
+class BraveSidePanelShadowOverlayView : public views::View,
+                                        public views::ViewObserver {
+  METADATA_HEADER(BraveSidePanelShadowOverlayView, views::View)
+
+ public:
+  explicit BraveSidePanelShadowOverlayView(BrowserView& browser_view);
+  BraveSidePanelShadowOverlayView(const BraveSidePanelShadowOverlayView&) =
+      delete;
+  BraveSidePanelShadowOverlayView& operator=(
+      const BraveSidePanelShadowOverlayView&) = delete;
+  ~BraveSidePanelShadowOverlayView() override;
+
+  // Call when the rounded-corners preference or panel state may have changed
+  // without a corresponding panel bounds/visibility change.
+  void UpdateShadowVisibility();
+
+ private:
+  // views::View:
+  void AddedToWidget() override;
+
+  // views::ViewObserver:
+  void OnViewBoundsChanged(views::View* observed_view) override;
+  void OnViewVisibilityChanged(views::View* observed_view,
+                               views::View* starting_view,
+                               bool is_visible) override;
+  void OnViewIsDeleting(views::View* observed_view) override;
+
+  // Syncs this view's bounds, child shape and visibility to the side panel's
+  // current bounds, visibility and rounded-corners state.
+  void SyncToSidePanel();
+
+  const raw_ref<BrowserView> browser_view_;
+  raw_ptr<views::View> observed_panel_ = nullptr;
+  // Transparent child sized exactly to the side panel. `shadow_` renders the
+  // drop shadow around its rounded-rect shape.
+  raw_ptr<views::View> panel_shape_ = nullptr;
+  std::unique_ptr<ViewShadow> shadow_;
+};
+
+#endif  // BRAVE_BROWSER_UI_VIEWS_FRAME_BRAVE_SIDE_PANEL_SHADOW_OVERLAY_VIEW_H_

--- a/browser/ui/views/frame/brave_side_panel_shadow_overlay_view.h
+++ b/browser/ui/views/frame/brave_side_panel_shadow_overlay_view.h
@@ -10,6 +10,7 @@
 
 #include "base/memory/raw_ptr.h"
 #include "base/memory/raw_ref.h"
+#include "base/scoped_observation.h"
 #include "ui/base/metadata/metadata_header_macros.h"
 #include "ui/views/view.h"
 #include "ui/views/view_observer.h"
@@ -47,9 +48,6 @@ class BraveSidePanelShadowOverlayView : public views::View,
   void UpdateShadowVisibility();
 
  private:
-  // views::View:
-  void AddedToWidget() override;
-
   // views::ViewObserver:
   void OnViewBoundsChanged(views::View* observed_view) override;
   void OnViewVisibilityChanged(views::View* observed_view,
@@ -62,7 +60,8 @@ class BraveSidePanelShadowOverlayView : public views::View,
   void SyncToSidePanel();
 
   const raw_ref<BrowserView> browser_view_;
-  raw_ptr<views::View> observed_panel_ = nullptr;
+  base::ScopedObservation<views::View, views::ViewObserver> panel_observation_{
+      this};
   // Transparent child sized exactly to the side panel. `shadow_` renders the
   // drop shadow around its rounded-rect shape.
   raw_ptr<views::View> panel_shape_ = nullptr;

--- a/browser/ui/views/side_panel/brave_side_panel_header.cc
+++ b/browser/ui/views/side_panel/brave_side_panel_header.cc
@@ -11,7 +11,9 @@
 #include "base/functional/bind.h"
 #include "brave/ui/color/nala/nala_color_id.h"
 #include "ui/base/metadata/metadata_impl_macros.h"
+#include "ui/compositor/layer.h"
 #include "ui/gfx/geometry/insets.h"
+#include "ui/gfx/geometry/rounded_corners_f.h"
 #include "ui/views/background.h"
 #include "ui/views/controls/button/image_button.h"
 #include "ui/views/controls/label.h"
@@ -32,6 +34,16 @@ constexpr int kSeparatorHorizontalSpacing = 12;
 BraveSidePanelHeader::BraveSidePanelHeader(std::unique_ptr<Delegate> delegate)
     : delegate_(std::move(delegate)) {
   CHECK(delegate_);
+
+  // Paint to a layer so the header composites above the layer-backed side-panel
+  // shadow overlay (BraveSidePanelShadowOverlayView). Without its own layer the
+  // header paints into the browser-view root layer, beneath the overlay, so the
+  // shadow's blur is drawn over the header instead of behind it. The content
+  // web view is already layer-backed for the same reason. FillsBoundsOpaquely
+  // is false because the background has rounded (transparent) top corners.
+  SetPaintToLayer();
+  layer()->SetFillsBoundsOpaquely(false);
+  layer()->SetIsFastRoundedCorner(true);
 
   UpdateHeader();
   SetLayoutManager(std::make_unique<views::FlexLayout>())
@@ -69,8 +81,15 @@ BraveSidePanelHeader::BraveSidePanelHeader(std::unique_ptr<Delegate> delegate)
 BraveSidePanelHeader::~BraveSidePanelHeader() = default;
 
 void BraveSidePanelHeader::UpdateHeader() {
-  SetBackground(views::CreateRoundedRectBackground(
-      nala::kColorPageBackground, delegate_->GetTopRadius(), 0, 0));
+  const int top_radius = delegate_->GetTopRadius();
+  SetBackground(views::CreateRoundedRectBackground(nala::kColorPageBackground,
+                                                   top_radius, 0, 0));
+  // Keep the layer clip in sync with the rounded background so the top corners
+  // match the panel and the shadow shows through them.
+  if (layer()) {
+    layer()->SetRoundedCornerRadius(
+        gfx::RoundedCornersF(top_radius, top_radius, 0, 0));
+  }
 }
 
 void BraveSidePanelHeader::Layout(PassKey) {


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves no issue - use umbrella issue (https://github.com/brave/brave-browser/issues/51462)

Sidebar V2 uses upstream's SidePanel, which doesn't carry Brave's
rounded-corner drop shadow. Add a shadow around the open side panel that
matches the V1 / contents-area shadow (BraveContentsViewUtil::CreateShadow)
without ever drawing outside the browser view.

Instead of attaching the shadow to the panel's own layer (which would slide
with the panel and leak past the window edge during the open/close
animation), add BraveSidePanelShadowOverlayView - a decorative sibling of the
side panel that:

* tracks the panel's bounds and visibility by observing it,
* paints the shadow into its own MasksToBounds layer clamped to the browser view,
   so the blur is never drawn outside the window, and
* is stacked just below the panel, so the panel covers the inner half of the
   blur and only the outer glow shows.

The shadow shape is inset by the panel's border insets so it hugs the visible
rounded panel (smaller than the raw panel bounds) rather than the padded
edges.

BraveSidePanelHeader now paints to its own non-opaque, top-rounded layer so it
composites above the overlay. Without a layer it rendered into the browser-view
root layer beneath the overlay, and the blur was drawn over the header instead
of behind it.

TEST=SidebarBrowserTest.SidebarV2PanelShadow

Shadow around panel when rounded corners is on
<img width="400" alt="image" src="https://github.com/user-attachments/assets/b8d28b20-7b26-4dab-9865-9a6208febc34" />

No shadow when rounded corners is off
<img width="400" alt="image" src="https://github.com/user-attachments/assets/8f348eab-07b0-46b0-8895-61d747ed2654" />

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
