### PR TITLE
[iOS] [Origin] Don't initialize ads service when Rewards is unavailable (uplift to 1.92.x)

### DIFF
--- a/ios/browser/brave_ads/ads_service_impl_ios.h
+++ b/ios/browser/brave_ads/ads_service_impl_ios.h
@@ -146,6 +146,7 @@ class AdsServiceImplIOS : public AdsService {
   // KeyedService:
   void Shutdown() override;
 
+  bool CanStartBatAdsService() const;
   void InitializeAds(ResultCallback callback);
   void InitializeAdsCallback(ResultCallback callback, bool success);
 

--- a/ios/browser/brave_ads/ads_service_impl_ios.mm
+++ b/ios/browser/brave_ads/ads_service_impl_ios.mm
@@ -27,6 +27,7 @@
 #include "brave/components/brave_ads/core/public/ads_client/ads_client.h"
 #include "brave/components/brave_ads/core/public/ads_constants.h"
 #include "brave/components/brave_ads/core/public/command_line_switches/command_line_switches_util.h"
+#include "brave/components/brave_rewards/core/rewards_util.h"
 #include "components/prefs/pref_service.h"
 #include "sql/database.h"
 #include "ui/base/page_transition_types.h"
@@ -60,6 +61,12 @@ bool AdsServiceImplIOS::IsIneligibleToStart() const {
   return false;
 }
 
+bool AdsServiceImplIOS::CanStartBatAdsService() const {
+  // Never start if Rewards is disabled by policy, feature flag, or
+  // unsupported region, regardless of which ad unit the user has opted into.
+  return brave_rewards::IsSupported(&*prefs_);
+}
+
 bool AdsServiceImplIOS::IsInitialized() const {
   return !!ads_;
 }
@@ -71,7 +78,7 @@ void AdsServiceImplIOS::InitializeAds(
     mojom::BuildChannelInfoPtr mojom_build_channel,
     mojom::WalletInfoPtr mojom_wallet,
     ResultCallback callback) {
-  if (IsInitialized()) {
+  if (IsInitialized() || !CanStartBatAdsService()) {
     return std::move(callback).Run(/*success=*/false);
   }
 


### PR DESCRIPTION
Uplift of #36985
Resolves https://github.com/brave/brave-browser/issues/56060

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.