### PR TITLE
[iOS] Hide unavailable features from Shortcut widgets

### DIFF
--- a/ios/brave-ios/App/BraveWidgets/LockScreenShortcutWidget.swift
+++ b/ios/brave-ios/App/BraveWidgets/LockScreenShortcutWidget.swift
@@ -109,6 +109,8 @@ struct LockScreenShortcutView: View {
   }
 }
 
+#if DEBUG
+
 #Preview(
   as: .accessoryCircular,
   widget: {
@@ -128,3 +130,5 @@ struct LockScreenShortcutView: View {
     LockScreenShortcutEntry(date: .now, widgetShortcut: nil)
   }
 )
+
+#endif

--- a/ios/brave-ios/App/BraveWidgets/LockScreenShortcutWidget.swift
+++ b/ios/brave-ios/App/BraveWidgets/LockScreenShortcutWidget.swift
@@ -31,12 +31,20 @@ struct LockScreenShortcutWidget: Widget {
 
 struct LockScreenShortcutEntry: TimelineEntry {
   var date: Date
-  var widgetShortcut: WidgetShortcut
+  var widgetShortcut: WidgetShortcut?
 }
 
 struct LockScreenShortcutProvider: IntentTimelineProvider {
   typealias Intent = LockScreenShortcutConfigurationIntent
   typealias Entry = LockScreenShortcutEntry
+
+  private func shortcut(for configuration: Intent) async -> WidgetShortcut? {
+    let disabledShortcuts = await DisabledShortcutsWidgetData.loadDisabledShortcuts()
+    if disabledShortcuts.contains(configuration.shortcut) {
+      return nil
+    }
+    return configuration.shortcut
+  }
 
   func placeholder(in context: Context) -> Entry {
     .init(date: Date(), widgetShortcut: .bookmarks)
@@ -46,22 +54,28 @@ struct LockScreenShortcutProvider: IntentTimelineProvider {
     in context: Context,
     completion: @escaping (Entry) -> Void
   ) {
-    let entry = LockScreenShortcutEntry(
-      date: Date(),
-      widgetShortcut: configuration.shortcut
-    )
-    completion(entry)
+    Task {
+      let shortcut = await shortcut(for: configuration)
+      let entry = LockScreenShortcutEntry(
+        date: Date(),
+        widgetShortcut: shortcut
+      )
+      completion(entry)
+    }
   }
   func getTimeline(
     for configuration: Intent,
     in context: Context,
     completion: @escaping (Timeline<Entry>) -> Void
   ) {
-    let entry = LockScreenShortcutEntry(
-      date: Date(),
-      widgetShortcut: configuration.shortcut
-    )
-    completion(.init(entries: [entry], policy: .never))
+    Task {
+      let shortcut = await shortcut(for: configuration)
+      let entry = LockScreenShortcutEntry(
+        date: Date(),
+        widgetShortcut: shortcut
+      )
+      completion(.init(entries: [entry], policy: .never))
+    }
   }
 }
 
@@ -72,18 +86,45 @@ struct LockScreenShortcutView: View {
     ZStack {
       AccessoryWidgetBackground()
         .widgetBackground { EmptyView() }
-      entry.widgetShortcut.image
-        .imageScale(.large)
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .font(.system(size: 20))
-        .widgetLabel(entry.widgetShortcut.displayString)
-        .accessibilityLabel(Text(entry.widgetShortcut.displayString))
-        .unredacted()
-        .widgetURL(
-          URL(
-            string: "\(AppURLScheme.appURLScheme)://shortcut?path=\(entry.widgetShortcut.rawValue)"
-          )
-        )
+      Group {
+        if let widgetShortcut = entry.widgetShortcut {
+          widgetShortcut.image
+            .widgetLabel(widgetShortcut.displayString)
+            .accessibilityLabel(Text(widgetShortcut.displayString))
+            .widgetURL(
+              URL(
+                string: "\(AppURLScheme.appURLScheme)://shortcut?path=\(widgetShortcut.rawValue)"
+              )
+            )
+        } else {
+          Image(systemName: "xmark.octagon")
+            .accessibilityLabel(Text(Strings.Widgets.shortcutsEmptyState))
+        }
+      }
+      .imageScale(.large)
+      .frame(maxWidth: .infinity, maxHeight: .infinity)
+      .font(.system(size: 20))
+      .unredacted()
     }
   }
 }
+
+#Preview(
+  as: .accessoryCircular,
+  widget: {
+    LockScreenShortcutWidget()
+  },
+  timeline: {
+    LockScreenShortcutEntry(date: .now, widgetShortcut: .newTab)
+  }
+)
+
+#Preview(
+  as: .accessoryCircular,
+  widget: {
+    LockScreenShortcutWidget()
+  },
+  timeline: {
+    LockScreenShortcutEntry(date: .now, widgetShortcut: nil)
+  }
+)

--- a/ios/brave-ios/App/BraveWidgets/ShortcutsWidget.swift
+++ b/ios/brave-ios/App/BraveWidgets/ShortcutsWidget.swift
@@ -35,21 +35,29 @@ private struct ShortcutEntry: TimelineEntry {
 private struct ShortcutProvider: IntentTimelineProvider {
   typealias Intent = ShortcutsConfigurationIntent
   typealias Entry = ShortcutEntry
+
+  private func shortcuts(for configuration: Intent) async -> [WidgetShortcut] {
+    let disabledShortcuts = await DisabledShortcutsWidgetData.loadDisabledShortcuts()
+    return [
+      configuration.slot1,
+      configuration.slot2,
+      configuration.slot3,
+      configuration.slot4,
+    ].filter { !disabledShortcuts.contains($0) }
+  }
+
   func getSnapshot(
     for configuration: Intent,
     in context: Context,
     completion: @escaping (ShortcutEntry) -> Void
   ) {
-    let entry = ShortcutEntry(
-      date: Date(),
-      shortcutSlots: [
-        configuration.slot1,
-        configuration.slot2,
-        configuration.slot3,
-        configuration.slot4,
-      ]
-    )
-    completion(entry)
+    Task {
+      let entry = ShortcutEntry(
+        date: Date(),
+        shortcutSlots: await shortcuts(for: configuration)
+      )
+      completion(entry)
+    }
   }
 
   func placeholder(in context: Context) -> ShortcutEntry {
@@ -64,16 +72,13 @@ private struct ShortcutProvider: IntentTimelineProvider {
     in context: Context,
     completion: @escaping (Timeline<ShortcutEntry>) -> Void
   ) {
-    let entry = ShortcutEntry(
-      date: Date(),
-      shortcutSlots: [
-        configuration.slot1,
-        configuration.slot2,
-        configuration.slot3,
-        configuration.slot4,
-      ]
-    )
-    completion(.init(entries: [entry], policy: .never))
+    Task {
+      let entry = ShortcutEntry(
+        date: Date(),
+        shortcutSlots: await shortcuts(for: configuration)
+      )
+      completion(.init(entries: [entry], policy: .never))
+    }
   }
 }
 
@@ -223,14 +228,32 @@ private struct ShortcutsView: View {
         )
       }
       HStack(spacing: 8) {
-        ForEach(slots, id: \.self) { shortcut in
-          ShortcutLink(
-            url: "\(AppURLScheme.appURLScheme)://shortcut?path=\(shortcut.rawValue)",
-            text: shortcut.displayString,
-            image: {
-              shortcut.image
+        if slots.isEmpty {
+          Text(Strings.Widgets.shortcutsEmptyState)
+            .padding(8)
+            .foregroundColor(
+              renderingMode == .accented
+                ? Color.white.opacity(0.6) : Color(braveSystemName: .textDisabled)
+            )
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .overlay {
+              ContainerRelativeShape()
+                .stroke(
+                  renderingMode == .accented
+                    ? Color.white.opacity(0.3) : Color(braveSystemName: .dividerStrong),
+                  style: .init(lineWidth: 1, dash: [2, 3], dashPhase: 0)
+                )
             }
-          )
+        } else {
+          ForEach(slots, id: \.self) { shortcut in
+            ShortcutLink(
+              url: "\(AppURLScheme.appURLScheme)://shortcut?path=\(shortcut.rawValue)",
+              text: shortcut.displayString,
+              image: {
+                shortcut.image
+              }
+            )
+          }
         }
       }
       .frame(maxHeight: .infinity)
@@ -242,12 +265,22 @@ private struct ShortcutsView: View {
 
 // MARK: - Previews
 
-@available(iOS 17.0, *)#Preview(
+#Preview(
   as: .systemMedium,
   widget: {
     ShortcutsWidget()
   },
   timeline: {
     ShortcutEntry(date: .now, shortcutSlots: [.newTab, .newPrivateTab, .bookmarks])
+  }
+)
+
+#Preview(
+  as: .systemMedium,
+  widget: {
+    ShortcutsWidget()
+  },
+  timeline: {
+    ShortcutEntry(date: .now, shortcutSlots: [])
   }
 )

--- a/ios/brave-ios/App/BraveWidgets/ShortcutsWidget.swift
+++ b/ios/brave-ios/App/BraveWidgets/ShortcutsWidget.swift
@@ -233,15 +233,15 @@ private struct ShortcutsView: View {
             .padding(8)
             .foregroundColor(
               renderingMode == .accented
-                ? Color.white.opacity(0.6) : Color(braveSystemName: .textDisabled)
+                ? Color.white.opacity(0.7) : Color(braveSystemName: .textDisabled)
             )
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .overlay {
               ContainerRelativeShape()
                 .stroke(
                   renderingMode == .accented
-                    ? Color.white.opacity(0.3) : Color(braveSystemName: .dividerStrong),
-                  style: .init(lineWidth: 1, dash: [2, 3], dashPhase: 0)
+                    ? Color.white.opacity(0.2) : Color(braveSystemName: .dividerSubtle),
+                  style: .init(lineWidth: 1)
                 )
             }
         } else {
@@ -265,6 +265,8 @@ private struct ShortcutsView: View {
 
 // MARK: - Previews
 
+#if DEBUG
+
 #Preview(
   as: .systemMedium,
   widget: {
@@ -284,3 +286,5 @@ private struct ShortcutsView: View {
     ShortcutEntry(date: .now, shortcutSlots: [])
   }
 )
+
+#endif

--- a/ios/brave-ios/App/BraveWidgets/WidgetStrings.swift
+++ b/ios/brave-ios/App/BraveWidgets/WidgetStrings.swift
@@ -40,6 +40,13 @@ extension Strings {
       comment: "Title for shortcuts widget on 'add widget' screen."
     )
 
+    public static let shortcutsEmptyState = NSLocalizedString(
+      "widgets.shortcutsEmptyState",
+      bundle: widgetBundle,
+      value: "No Shortcuts Selected",
+      comment: "A label shown on the widget has no available shortcuts to display."
+    )
+
     public static let shortcutsWidgetDescription = NSLocalizedString(
       "widgets.shortcutsWidgetDescription",
       bundle: widgetBundle,

--- a/ios/brave-ios/App/BraveWidgets/WidgetStrings.swift
+++ b/ios/brave-ios/App/BraveWidgets/WidgetStrings.swift
@@ -43,7 +43,7 @@ extension Strings {
     public static let shortcutsEmptyState = NSLocalizedString(
       "widgets.shortcutsEmptyState",
       bundle: widgetBundle,
-      value: "No Shortcuts Selected",
+      value: "Your shortcuts will appear here",
       comment: "A label shown on the widget has no available shortcuts to display."
     )
 

--- a/ios/brave-ios/Package.swift
+++ b/ios/brave-ios/Package.swift
@@ -389,7 +389,7 @@ var package = Package(
       dependencies: ["FaviconModels"],
       sources: [
         "BraveWidgets.intentdefinition", "LockScreenFavoriteIntentHandler.swift",
-        "FavoritesWidgetData.swift",
+        "FavoritesWidgetData.swift", "DisabledShortcutsWidgetData.swift",
       ],
       plugins: ["IntentBuilderPlugin", "LoggerPlugin"]
     ),

--- a/ios/brave-ios/Sources/Brave/Extensions/WidgetShortcutExtension.swift
+++ b/ios/brave-ios/Sources/Brave/Extensions/WidgetShortcutExtension.swift
@@ -42,6 +42,28 @@ extension WidgetShortcut {
     return options
   }
 
+  /// The set of shortcuts that are currently unavailable and should be hidden from the Shortcuts
+  /// widgets (for example, disabled by a Brave Origin or enterprise policy).
+  static func disabledWidgetShortcuts(
+    prefs: any PrefService,
+    isWalletAvailable: Bool
+  ) -> Set<WidgetShortcut> {
+    var disabled: Set<WidgetShortcut> = []
+    if !prefs.isPlaylistAvailable {
+      disabled.insert(.playlist)
+    }
+    if !prefs.isBraveNewsAvailable {
+      disabled.insert(.braveNews)
+    }
+    if !isWalletAvailable {
+      disabled.insert(.wallet)
+    }
+    if !AIChatUtils.isAIChatEnabled(for: prefs) {
+      disabled.insert(.braveLeo)
+    }
+    return disabled
+  }
+
   var displayString: String {
     switch self {
     case .unknown:

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Widgets.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Widgets.swift
@@ -16,6 +16,19 @@ extension BrowserViewController: NSFetchedResultsControllerDelegate {
     updateWidgetFavoritesData()
   }
 
+  /// Writes the set of shortcuts that are currently unavailable (e.g. disabled
+  /// by a Brave Origin policy) to shared storage so the Shortcuts widgets can
+  /// hide them from both the configuration picker and installed widgets.
+  func updateWidgetShortcutsData() {
+    let disabled = WidgetShortcut.disabledWidgetShortcuts(
+      prefs: profileController.profile.prefs,
+      isWalletAvailable: profileController.braveWalletAPI.isAllowed
+    )
+    Task {
+      await DisabledShortcutsWidgetData.updateDisabledShortcuts(disabled)
+    }
+  }
+
   func updateWidgetFavoritesData() {
     guard let frc = widgetBookmarksFRC else { return }
     try? frc.performFetch()

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -535,6 +535,7 @@ public class BrowserViewController: UIViewController {
     try? widgetBookmarksFRC?.performFetch()
 
     updateWidgetFavoritesData()
+    updateWidgetShortcutsData()
 
     // Eliminate the older usage days
     // Used in App Rating criteria

--- a/ios/brave-ios/Sources/BraveWidgetsModels/DisabledShortcutsWidgetData.swift
+++ b/ios/brave-ios/Sources/BraveWidgetsModels/DisabledShortcutsWidgetData.swift
@@ -1,0 +1,69 @@
+// Copyright 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import Shared
+import WidgetKit
+import os.log
+
+/// Shared storage describing which `WidgetShortcut`s are currently unavailable, for example when
+/// disabled by Brave Origin or enterprise policies.
+public class DisabledShortcutsWidgetData {
+  private static var widgetDataRoot: URL? {
+    FileManager.default.containerURL(
+      forSecurityApplicationGroupIdentifier: AppInfo.sharedContainerIdentifier
+    )?.appendingPathComponent("widget_data")
+  }
+
+  private static var widgetDataPath: URL? {
+    widgetDataRoot?.appendingPathComponent("disabled_shortcuts.json")
+  }
+
+  /// The set of shortcuts that are currently unavailable. An empty set (the
+  /// common case, including a missing file) means every feature is available.
+  public static func loadDisabledShortcuts() async -> Set<WidgetShortcut> {
+    guard let dataPath = widgetDataPath,
+      FileManager.default.fileExists(atPath: dataPath.path)
+    else {
+      return []
+    }
+    do {
+      let jsonData = try Data(contentsOf: dataPath)
+      let rawValues = try JSONDecoder().decode([Int].self, from: jsonData)
+      return Set(
+        rawValues.compactMap(WidgetShortcut.init(rawValue:)).filter { $0 != .unknown }
+      )
+    } catch {
+      Logger.module.error("loadDisabledShortcuts error: \(error.localizedDescription)")
+      return []
+    }
+  }
+
+  /// Writes the set of unavailable shortcuts and reloads the affected widgets.
+  /// When the set is empty the backing file is removed to keep the common case
+  /// clean.
+  public static func updateDisabledShortcuts(_ shortcuts: Set<WidgetShortcut>) async {
+    guard let rootPath = widgetDataRoot, let dataPath = widgetDataPath else { return }
+    do {
+      let rawValues = shortcuts.filter { $0 != .unknown }.map(\.rawValue).sorted()
+      if rawValues.isEmpty {
+        if FileManager.default.fileExists(atPath: dataPath.path) {
+          try FileManager.default.removeItem(at: dataPath)
+        }
+      } else {
+        let widgetData = try JSONEncoder().encode(rawValues)
+        try FileManager.default.createDirectory(
+          atPath: rootPath.path,
+          withIntermediateDirectories: true
+        )
+        try widgetData.write(to: dataPath)
+      }
+      WidgetCenter.shared.reloadTimelines(ofKind: "ShortcutsWidget")
+      WidgetCenter.shared.reloadTimelines(ofKind: "LockScreenShortcutWidget")
+    } catch {
+      Logger.module.error("updateDisabledShortcuts error: \(error.localizedDescription)")
+    }
+  }
+}


### PR DESCRIPTION
This stores features that are unavailable in the group container similar to favourites to adjust how the shortcuts widget is displayed when features are unavailable due to Brave Origin or enterprise policies.

Note: This does not remove the features from the shortcut configuration, only removes them from the rendered widget after selection. The reason for this is we cannot update the overall configuration data of the widget without breaking existing users widgets (they reset back to placeholder state and are no longer editable).

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/48895

### Test
1. Add a shortcut widget with Brave Origin features such a Playlist, Brave News, Wallet or AI Chat to both your home screen and lock screen
2. Enable Brave Origin or policy that would disable this feature, kill & re-launch app
3. On the lock screen widget: Verify the shortcut is replaced with a warning symbol that simply opens the app and not the feature itself
4. On the home screen: Verify the slots that have Origin features are removed
5. Verify if all slots are removed it shows a new label stating that no shortcuts are selected
