### PR TITLE
 [AI Chat] Fix flaky AIChatConversationTaskBrowserTest GenerateAssistantResponse over-saturation

### DIFF
--- a/browser/ai_chat/ai_chat_conversation_task_browsertest.cc
+++ b/browser/ai_chat/ai_chat_conversation_task_browsertest.cc
@@ -431,17 +431,19 @@ IN_PROC_BROWSER_TEST_F(AIChatConversationTaskBrowserTest, TaskStopAction) {
             EngineConsumer::GenerationResultData(nullptr, std::nullopt)));
   }
 
+  // The tool will execute and a response sent - we need to set up the new
+  // expectation *before* pumping the loop below. The real navigate tool
+  // completes asynchronously and can trigger the next assistant response while
+  // we wait for the running state, which would otherwise over-saturate the
+  // previous expectation.
+  auto generate_future = SetupMockGenerateAssistantResponse();
+
   EXPECT_TRUE(base::test::RunUntil([this]() {
     return GetConversationState()->tool_use_task_state ==
            mojom::TaskState::kRunning;
   }));
 
-  // The tool will execute and response sent - we need to set up a new
-  // expectation so the previous one is not triggered.
-  {
-    auto generate_future = SetupMockGenerateAssistantResponse();
-    std::ignore = generate_future->Take();
-  }
+  std::ignore = generate_future->Take();
 }
 
 IN_PROC_BROWSER_TEST_F(AIChatConversationTaskBrowserTest, TaskUI) {
@@ -645,6 +647,15 @@ IN_PROC_BROWSER_TEST_F(AIChatConversationTaskBrowserTest,
         .Run(base::ok(
             EngineConsumer::GenerationResultData(nullptr, std::nullopt)));
   }
+
+  // The first response's WillOnce is now consumed. The real navigate tool
+  // completes asynchronously and triggers a follow-up assistant response that
+  // this test intentionally does not drive (it only verifies UI state while the
+  // task is running). Absorb any such calls so they don't over-saturate the
+  // previous expectation. This must be installed before pumping the loop below.
+  EXPECT_CALL(*mock_engine_, GenerateAssistantResponse)
+      .Times(testing::AnyNumber());
+
   ASSERT_TRUE(base::test::RunUntil([this]() {
     return GetConversationState()->tool_use_task_state ==
            mojom::TaskState::kRunning;


### PR DESCRIPTION
- Fix https://github.com/brave/brave-browser/issues/55912

  Problem:
  - TaskStopAction and NoUpstreamGlicAndActorButtonsContainer intermittently failed with "Mock function called more times than expected" on the GenerateAssistantResponse WillOnce expectation.

  Root cause:
  - Both tests drive the real web_page_navigator tool, which completes asynchronously and fires a follow-up GenerateAssistantResponse for the tool-result round. That call could land on an already-consumed WillOnce expectation when it fired during a RunUntil() pump before the next expectation was installed.

  Fix:
  - TaskStopAction: install the next expectation before the RunUntil(kRunning) pump instead of after it.
  - NoUpstreamGlicAndActorButtonsContainer: add a Times(AnyNumber()) expectation to absorb the follow-up response the test does not drive.
