### PR TITLE
[ads] Change round robin NTT serving to respect campaigns priority

### DIFF
--- a/components/brave_ads/core/internal/serving/eligible_ads/pipelines/new_tab_page_ads/eligible_new_tab_page_ads_v2.cc
+++ b/components/brave_ads/core/internal/serving/eligible_ads/pipelines/new_tab_page_ads/eligible_new_tab_page_ads_v2.cc
@@ -256,26 +256,24 @@ void EligibleNewTabPageAdsV2::FilterAndMaybePredictCreativeAdCallback(
                                              site_history);
   ApplyExclusionRules(creative_ads, last_served_ad_, &exclusion_rules);
 
-  // Round-robin must run after exclusion rules but before pacing. Exclusion
-  // rules determine which ads are actually eligible, so rotation must operate
-  // on that filtered set. Pacing is a rate limiter rather than an eligibility
-  // filter, so it should not influence which ads the rotation considers
-  // unserved. Running round-robin before pacing ensures rotation resets are
-  // driven by which ads have actually been served rather than pacing
-  // suppression.
-  creative_ad_round_robin_->Filter(creative_ads);
-
-  PaceCreativeAds(creative_ads);
-
-  const PrioritizedCreativeAdBuckets<CreativeNewTabPageAdList> buckets =
+  PrioritizedCreativeAdBuckets<CreativeNewTabPageAdList> creative_ad_buckets =
       SortCreativeAdsIntoBucketsByPriority(creative_ads);
-  LogNumberOfCreativeAdsPerBucket(buckets);
+  LogNumberOfCreativeAdsPerBucket(creative_ad_buckets);
 
   // For each bucket of prioritized ads attempt to predict the most suitable ad
-  // for the user in priority order.
-  for (const auto& [priority, prioritized_creative_ads] : buckets) {
+  // for the user in priority order. Round-robin is applied per bucket after
+  // exclusion rules but before pacing so that lower-priority campaigns are
+  // never served while higher-priority campaigns still have eligible ads.
+  for (auto& [priority, creative_ad_bucket] : creative_ad_buckets) {
+    // Round-robin after exclusion rules ensures rotation operates on the
+    // actually-eligible set. Running it before pacing ensures rotation resets
+    // are driven by which ads have been served rather than pacing suppression.
+    creative_ad_round_robin_->Filter(creative_ad_bucket);
+
+    PaceCreativeAds(creative_ad_bucket);
+
     std::optional<CreativeNewTabPageAdInfo> predicted_creative_ad =
-        MaybePredictCreativeAd(prioritized_creative_ads, user_model, ad_events);
+        MaybePredictCreativeAd(creative_ad_bucket, user_model, ad_events);
     if (!predicted_creative_ad) {
       // Could not predict an ad for this bucket, so continue to the next
       // bucket.

--- a/components/brave_ads/core/internal/serving/eligible_ads/pipelines/new_tab_page_ads/eligible_new_tab_page_ads_v2_unittest.cc
+++ b/components/brave_ads/core/internal/serving/eligible_ads/pipelines/new_tab_page_ads/eligible_new_tab_page_ads_v2_unittest.cc
@@ -13,12 +13,15 @@
 #include "brave/components/brave_ads/core/internal/common/test/test_base.h"
 #include "brave/components/brave_ads/core/internal/common/test/time_test_util.h"
 #include "brave/components/brave_ads/core/internal/creatives/new_tab_page_ads/creative_new_tab_page_ad_info.h"
+#include "brave/components/brave_ads/core/internal/creatives/new_tab_page_ads/new_tab_page_ad_builder.h"
 #include "brave/components/brave_ads/core/internal/creatives/new_tab_page_ads/test/creative_new_tab_page_ad_test_util.h"
 #include "brave/components/brave_ads/core/internal/serving/eligible_ads/eligible_ads_feature.h"
 #include "brave/components/brave_ads/core/internal/serving/eligible_ads/round_robin/creative_ad_round_robin.h"
 #include "brave/components/brave_ads/core/internal/serving/targeting/user_model/user_model_info.h"
 #include "brave/components/brave_ads/core/internal/targeting/behavioral/anti_targeting/resource/anti_targeting_resource.h"
 #include "brave/components/brave_ads/core/internal/targeting/geographical/subdivision/subdivision_targeting.h"
+#include "brave/components/brave_ads/core/internal/user_engagement/ad_events/test/ad_event_test_util.h"
+#include "brave/components/brave_ads/core/mojom/brave_ads.mojom.h"
 
 // npm run test -- brave_unit_tests --filter=BraveAds*
 
@@ -217,16 +220,16 @@ TEST_F(BraveAdsEligibleNewTabPageAdsV2Test,
 
 TEST_F(BraveAdsEligibleNewTabPageAdsV2Test, ZeroPriorityAdIsNeverServed) {
   // Arrange: `creative_ad_1` has priority 0 and must be excluded by the
-  // bucketing step; `creative_ad_2` has the default priority 2 and should be
-  // served.
+  // bucketing step; `creative_ad_2` has priority 1 and should be served.
   CreativeNewTabPageAdInfo creative_ad_1 =
       test::BuildCreativeNewTabPageAd(CreativeNewTabPageAdWallpaperType::kImage,
                                       /*use_random_uuids=*/true);
   creative_ad_1.priority = 0;
 
-  const CreativeNewTabPageAdInfo creative_ad_2 =
+  CreativeNewTabPageAdInfo creative_ad_2 =
       test::BuildCreativeNewTabPageAd(CreativeNewTabPageAdWallpaperType::kImage,
                                       /*use_random_uuids=*/true);
+  creative_ad_2.priority = 1;
 
   test::SaveCreativeNewTabPageAds({creative_ad_1, creative_ad_2});
 
@@ -237,6 +240,31 @@ TEST_F(BraveAdsEligibleNewTabPageAdsV2Test, ZeroPriorityAdIsNeverServed) {
                     InterestUserModelInfo{SegmentList{"untargeted"}}},
       test_future.GetCallback());
   EXPECT_THAT(test_future.Take(), ::testing::ElementsAre(creative_ad_2));
+}
+
+TEST_F(
+    BraveAdsEligibleNewTabPageAdsV2Test,
+    HigherPriorityAdIsServedBeforeLowerPriorityAdWithNonSequentialPriorities) {
+  // Arrange: `creative_ad_1` has priority 1 and `creative_ad_2` has priority 5.
+  CreativeNewTabPageAdInfo creative_ad_1 =
+      test::BuildCreativeNewTabPageAd(CreativeNewTabPageAdWallpaperType::kImage,
+                                      /*use_random_uuids=*/true);
+  creative_ad_1.priority = 1;
+
+  CreativeNewTabPageAdInfo creative_ad_2 =
+      test::BuildCreativeNewTabPageAd(CreativeNewTabPageAdWallpaperType::kImage,
+                                      /*use_random_uuids=*/true);
+  creative_ad_2.priority = 5;
+
+  test::SaveCreativeNewTabPageAds({creative_ad_1, creative_ad_2});
+
+  // Act & Assert
+  base::test::TestFuture<CreativeNewTabPageAdList> test_future;
+  eligible_ads_->GetForUserModel(
+      UserModelInfo{IntentUserModelInfo{}, LatentInterestUserModelInfo{},
+                    InterestUserModelInfo{SegmentList{"untargeted"}}},
+      test_future.GetCallback());
+  EXPECT_THAT(test_future.Take(), ::testing::ElementsAre(creative_ad_1));
 }
 
 TEST_F(BraveAdsEligibleNewTabPageAdsV2Test,
@@ -265,11 +293,11 @@ TEST_F(BraveAdsEligibleNewTabPageAdsV2Test,
 }
 
 TEST_F(BraveAdsEligibleNewTabPageAdsV2Test,
-       RoundRobinServesLowerPriorityAdAfterHigherPriorityAdHasBeenShown) {
+       HigherPriorityAdContinuesToServeAfterRoundRobinReset) {
   // Arrange: `creative_ad_1` has priority 1 and `creative_ad_2` has priority 2.
-  // After `creative_ad_1` is served, round-robin excludes it so the
-  // higher-priority bucket is empty and the pipeline falls through to the
-  // lower-priority bucket.
+  // After the only priority 1 ad is served, its per-bucket rotation resets
+  // so it remains eligible. The lower-priority `creative_ad_2` must never be
+  // served as long as the higher-priority bucket has an eligible ad.
   CreativeNewTabPageAdInfo creative_ad_1 =
       test::BuildCreativeNewTabPageAd(CreativeNewTabPageAdWallpaperType::kImage,
                                       /*use_random_uuids=*/true);
@@ -294,18 +322,21 @@ TEST_F(BraveAdsEligibleNewTabPageAdsV2Test,
     SimulateServeAd(creative_ad_1);
   }
 
-  // Assert: round-robin excludes the already-seen `creative_ad_1`, leaving
-  // only the lower-priority `creative_ad_2`.
+  // Assert: the priority 1 bucket rotation resets (it is the only ad), so
+  // `creative_ad_1` serves again rather than falling through to
+  // `creative_ad_2`.
   {
     base::test::TestFuture<CreativeNewTabPageAdList> test_future;
     eligible_ads_->GetForUserModel(user_model, test_future.GetCallback());
-    EXPECT_THAT(test_future.Take(), ::testing::ElementsAre(creative_ad_2));
+    EXPECT_THAT(test_future.Take(), ::testing::ElementsAre(creative_ad_1));
   }
 }
 
 TEST_F(BraveAdsEligibleNewTabPageAdsV2Test,
-       RoundRobinServesHigherPriorityAdAgainAfterAllAdsHaveBeenShown) {
-  // Arrange: `creative_ad_1` has priority 1 and `creative_ad_2` has priority 2.
+       RoundRobinResetsWithinPriorityBucketAfterAllAdsHaveBeenShown) {
+  // Arrange: `creative_ad_1` and `creative_ad_2` share a priority 1;
+  // `creative_ad_3` has a priority 2 and must never be served while the
+  // priority 1 bucket has eligible ads.
   CreativeNewTabPageAdInfo creative_ad_1 =
       test::BuildCreativeNewTabPageAd(CreativeNewTabPageAdWallpaperType::kImage,
                                       /*use_random_uuids=*/true);
@@ -314,37 +345,42 @@ TEST_F(BraveAdsEligibleNewTabPageAdsV2Test,
   CreativeNewTabPageAdInfo creative_ad_2 =
       test::BuildCreativeNewTabPageAd(CreativeNewTabPageAdWallpaperType::kImage,
                                       /*use_random_uuids=*/true);
-  creative_ad_2.priority = 2;
+  creative_ad_2.priority = 1;
 
-  test::SaveCreativeNewTabPageAds({creative_ad_1, creative_ad_2});
+  CreativeNewTabPageAdInfo creative_ad_3 =
+      test::BuildCreativeNewTabPageAd(CreativeNewTabPageAdWallpaperType::kImage,
+                                      /*use_random_uuids=*/true);
+  creative_ad_3.priority = 2;
+
+  test::SaveCreativeNewTabPageAds(
+      {creative_ad_1, creative_ad_2, creative_ad_3});
 
   const UserModelInfo user_model{
       IntentUserModelInfo{}, LatentInterestUserModelInfo{},
       InterestUserModelInfo{SegmentList{"untargeted"}}};
 
-  // Act: serve each ad once so that all ads have been seen.
-  {
-    base::test::TestFuture<CreativeNewTabPageAdList> test_future;
-    eligible_ads_->GetForUserModel(user_model, test_future.GetCallback());
-    EXPECT_THAT(test_future.Take(), ::testing::ElementsAre(creative_ad_1));
-    SimulateServeAd(creative_ad_1);
-  }
+  // Act: serve each priority 1 ad once.
+  base::test::TestFuture<CreativeNewTabPageAdList> test_future_1;
+  eligible_ads_->GetForUserModel(user_model, test_future_1.GetCallback());
+  const CreativeNewTabPageAdList first_served_creative_ads =
+      test_future_1.Take();
+  EXPECT_THAT(first_served_creative_ads, ::testing::SizeIs(1));
+  SimulateServeAd(first_served_creative_ads);
 
-  {
-    base::test::TestFuture<CreativeNewTabPageAdList> test_future;
-    eligible_ads_->GetForUserModel(user_model, test_future.GetCallback());
-    EXPECT_THAT(test_future.Take(), ::testing::ElementsAre(creative_ad_2));
-    SimulateServeAd(creative_ad_2);
-  }
+  base::test::TestFuture<CreativeNewTabPageAdList> test_future_2;
+  eligible_ads_->GetForUserModel(user_model, test_future_2.GetCallback());
+  const CreativeNewTabPageAdList second_served_creative_ads =
+      test_future_2.Take();
+  EXPECT_THAT(second_served_creative_ads, ::testing::SizeIs(1));
+  ASSERT_NE(first_served_creative_ads, second_served_creative_ads);
+  SimulateServeAd(second_served_creative_ads);
 
-  // Assert: all ads have been seen so the rotation resets. `creative_ad_1` is
-  // served again because `creative_ad_2` is excluded as the most recently
-  // served ad.
-  {
-    base::test::TestFuture<CreativeNewTabPageAdList> test_future;
-    eligible_ads_->GetForUserModel(user_model, test_future.GetCallback());
-    EXPECT_THAT(test_future.Take(), ::testing::ElementsAre(creative_ad_1));
-  }
+  // Assert: all priority 1 ads have been seen so the bucket resets.
+  // `second_served_creative_ads` is excluded; `first_served_creative_ads` comes
+  // back. The lower-priority `creative_ad_3` is never reached.
+  base::test::TestFuture<CreativeNewTabPageAdList> test_future_3;
+  eligible_ads_->GetForUserModel(user_model, test_future_3.GetCallback());
+  EXPECT_EQ(test_future_3.Take(), first_served_creative_ads);
 }
 
 TEST_F(BraveAdsEligibleNewTabPageAdsV2Test,
@@ -388,6 +424,279 @@ TEST_F(BraveAdsEligibleNewTabPageAdsV2Test,
     base::test::TestFuture<CreativeNewTabPageAdList> test_future;
     eligible_ads_->GetForUserModel(user_model, test_future.GetCallback());
     EXPECT_THAT(test_future.Take(), ::testing::ElementsAre(creative_ad_3));
+  }
+}
+
+TEST_F(BraveAdsEligibleNewTabPageAdsV2Test,
+       LowerPriorityAdIsServedWhenHigherPriorityAdHitsItsFrequencyCap) {
+  // Arrange: `creative_ad_1` has priority 1 with a frequency cap of 1;
+  // `creative_ad_2` has priority 2. Once `creative_ad_1` has been served once
+  // today its frequency cap is exhausted and the pipeline must fall through to
+  // `creative_ad_2`.
+  CreativeNewTabPageAdInfo creative_ad_1 =
+      test::BuildCreativeNewTabPageAd(CreativeNewTabPageAdWallpaperType::kImage,
+                                      /*use_random_uuids=*/true);
+  creative_ad_1.priority = 1;
+  creative_ad_1.per_day = 1;
+
+  CreativeNewTabPageAdInfo creative_ad_2 =
+      test::BuildCreativeNewTabPageAd(CreativeNewTabPageAdWallpaperType::kImage,
+                                      /*use_random_uuids=*/true);
+  creative_ad_2.priority = 2;
+
+  test::SaveCreativeNewTabPageAds({creative_ad_1, creative_ad_2});
+
+  test::RecordAdEvents(BuildNewTabPageAd(creative_ad_1),
+                       mojom::ConfirmationType::kServedImpression,
+                       /*count=*/1);
+
+  // Act & Assert: `creative_ad_1` has exhausted its frequency cap so the
+  // pipeline falls through to the lower-priority `creative_ad_2`.
+  base::test::TestFuture<CreativeNewTabPageAdList> test_future;
+  eligible_ads_->GetForUserModel(
+      UserModelInfo{IntentUserModelInfo{}, LatentInterestUserModelInfo{},
+                    InterestUserModelInfo{SegmentList{"untargeted"}}},
+      test_future.GetCallback());
+  EXPECT_THAT(test_future.Take(), ::testing::ElementsAre(creative_ad_2));
+}
+
+TEST_F(BraveAdsEligibleNewTabPageAdsV2Test,
+       LowerPriorityAdIsServedWhenAllHigherPriorityAdsHitTheirFrequencyCaps) {
+  // Arrange
+  CreativeNewTabPageAdInfo creative_ad_1 =
+      test::BuildCreativeNewTabPageAd(CreativeNewTabPageAdWallpaperType::kImage,
+                                      /*use_random_uuids=*/true);
+  creative_ad_1.priority = 1;
+  creative_ad_1.per_day = 1;
+
+  CreativeNewTabPageAdInfo creative_ad_2 =
+      test::BuildCreativeNewTabPageAd(CreativeNewTabPageAdWallpaperType::kImage,
+                                      /*use_random_uuids=*/true);
+  creative_ad_2.priority = 1;
+  creative_ad_2.per_day = 1;
+
+  CreativeNewTabPageAdInfo creative_ad_3 =
+      test::BuildCreativeNewTabPageAd(CreativeNewTabPageAdWallpaperType::kImage,
+                                      /*use_random_uuids=*/true);
+  creative_ad_3.priority = 2;
+
+  test::SaveCreativeNewTabPageAds(
+      {creative_ad_1, creative_ad_2, creative_ad_3});
+
+  test::RecordAdEvents(BuildNewTabPageAd(creative_ad_1),
+                       mojom::ConfirmationType::kServedImpression,
+                       /*count=*/1);
+  test::RecordAdEvents(BuildNewTabPageAd(creative_ad_2),
+                       mojom::ConfirmationType::kServedImpression,
+                       /*count=*/1);
+
+  // Act & Assert: all priority 1 ads are frequency-capped so the pipeline
+  // falls through to `creative_ad_3`.
+  base::test::TestFuture<CreativeNewTabPageAdList> test_future;
+  eligible_ads_->GetForUserModel(
+      UserModelInfo{IntentUserModelInfo{}, LatentInterestUserModelInfo{},
+                    InterestUserModelInfo{SegmentList{"untargeted"}}},
+      test_future.GetCallback());
+  EXPECT_THAT(test_future.Take(), ::testing::ElementsAre(creative_ad_3));
+}
+
+TEST_F(BraveAdsEligibleNewTabPageAdsV2Test,
+       EachLowerPriorityAdIsServedWhenHigherPriorityAdsAreFrequencyCapped) {
+  // Arrange: `creative_ad_1` has priority 1, `creative_ad_2` has priority 2,
+  // and `creative_ad_3` has priority 3. Each higher-priority ad has a frequency
+  // cap of 1 so the pipeline cascades through each bucket in order.
+  CreativeNewTabPageAdInfo creative_ad_1 =
+      test::BuildCreativeNewTabPageAd(CreativeNewTabPageAdWallpaperType::kImage,
+                                      /*use_random_uuids=*/true);
+  creative_ad_1.priority = 1;
+  creative_ad_1.per_day = 1;
+
+  CreativeNewTabPageAdInfo creative_ad_2 =
+      test::BuildCreativeNewTabPageAd(CreativeNewTabPageAdWallpaperType::kImage,
+                                      /*use_random_uuids=*/true);
+  creative_ad_2.priority = 2;
+  creative_ad_2.per_day = 1;
+
+  CreativeNewTabPageAdInfo creative_ad_3 =
+      test::BuildCreativeNewTabPageAd(CreativeNewTabPageAdWallpaperType::kImage,
+                                      /*use_random_uuids=*/true);
+  creative_ad_3.priority = 3;
+
+  test::SaveCreativeNewTabPageAds(
+      {creative_ad_1, creative_ad_2, creative_ad_3});
+
+  const UserModelInfo user_model{
+      IntentUserModelInfo{}, LatentInterestUserModelInfo{},
+      InterestUserModelInfo{SegmentList{"untargeted"}}};
+
+  // Act & Assert: priority 1 ad is served first.
+  {
+    base::test::TestFuture<CreativeNewTabPageAdList> test_future;
+    eligible_ads_->GetForUserModel(user_model, test_future.GetCallback());
+    EXPECT_THAT(test_future.Take(), ::testing::ElementsAre(creative_ad_1));
+  }
+
+  test::RecordAdEvents(BuildNewTabPageAd(creative_ad_1),
+                       mojom::ConfirmationType::kServedImpression,
+                       /*count=*/1);
+
+  // Priority 1 is capped; priority 2 ad is served next.
+  {
+    base::test::TestFuture<CreativeNewTabPageAdList> test_future;
+    eligible_ads_->GetForUserModel(user_model, test_future.GetCallback());
+    EXPECT_THAT(test_future.Take(), ::testing::ElementsAre(creative_ad_2));
+  }
+
+  test::RecordAdEvents(BuildNewTabPageAd(creative_ad_2),
+                       mojom::ConfirmationType::kServedImpression,
+                       /*count=*/1);
+
+  // Both priority 1 and 2 are capped; priority 3 ad is served last.
+  {
+    base::test::TestFuture<CreativeNewTabPageAdList> test_future;
+    eligible_ads_->GetForUserModel(user_model, test_future.GetCallback());
+    EXPECT_THAT(test_future.Take(), ::testing::ElementsAre(creative_ad_3));
+  }
+}
+
+TEST_F(BraveAdsEligibleNewTabPageAdsV2Test,
+       UncappedHigherPriorityAdServesWhenOtherHigherPriorityAdsAreCapped) {
+  // Arrange: `creative_ad_1` is frequency-capped; `creative_ad_2` shares
+  // priority 1 but is not capped. The pipeline must serve `creative_ad_2`
+  // rather than falling through to `creative_ad_3` (priority 2).
+  CreativeNewTabPageAdInfo creative_ad_1 =
+      test::BuildCreativeNewTabPageAd(CreativeNewTabPageAdWallpaperType::kImage,
+                                      /*use_random_uuids=*/true);
+  creative_ad_1.priority = 1;
+  creative_ad_1.per_day = 1;
+
+  CreativeNewTabPageAdInfo creative_ad_2 =
+      test::BuildCreativeNewTabPageAd(CreativeNewTabPageAdWallpaperType::kImage,
+                                      /*use_random_uuids=*/true);
+  creative_ad_2.priority = 1;
+
+  CreativeNewTabPageAdInfo creative_ad_3 =
+      test::BuildCreativeNewTabPageAd(CreativeNewTabPageAdWallpaperType::kImage,
+                                      /*use_random_uuids=*/true);
+  creative_ad_3.priority = 2;
+
+  test::SaveCreativeNewTabPageAds(
+      {creative_ad_1, creative_ad_2, creative_ad_3});
+
+  test::RecordAdEvents(BuildNewTabPageAd(creative_ad_1),
+                       mojom::ConfirmationType::kServedImpression,
+                       /*count=*/1);
+
+  // Act & Assert: `creative_ad_2` is eligible in the priority 1 bucket so
+  // the pipeline serves it rather than falling through to `creative_ad_3`.
+  base::test::TestFuture<CreativeNewTabPageAdList> test_future;
+  eligible_ads_->GetForUserModel(
+      UserModelInfo{IntentUserModelInfo{}, LatentInterestUserModelInfo{},
+                    InterestUserModelInfo{SegmentList{"untargeted"}}},
+      test_future.GetCallback());
+  EXPECT_THAT(test_future.Take(), ::testing::ElementsAre(creative_ad_2));
+}
+
+TEST_F(BraveAdsEligibleNewTabPageAdsV2Test,
+       HigherPriorityAdResumesServingAfterFrequencyCapResets) {
+  // Arrange: `creative_ad_1` (priority 1) exhausts its frequency cap so the
+  // pipeline falls through to `creative_ad_2` (priority 2). After a day the
+  // cap resets and `creative_ad_1` must be served again.
+  CreativeNewTabPageAdInfo creative_ad_1 =
+      test::BuildCreativeNewTabPageAd(CreativeNewTabPageAdWallpaperType::kImage,
+                                      /*use_random_uuids=*/true);
+  creative_ad_1.priority = 1;
+  creative_ad_1.per_day = 1;
+
+  CreativeNewTabPageAdInfo creative_ad_2 =
+      test::BuildCreativeNewTabPageAd(CreativeNewTabPageAdWallpaperType::kImage,
+                                      /*use_random_uuids=*/true);
+  creative_ad_2.priority = 2;
+
+  test::SaveCreativeNewTabPageAds({creative_ad_1, creative_ad_2});
+
+  test::RecordAdEvents(BuildNewTabPageAd(creative_ad_1),
+                       mojom::ConfirmationType::kServedImpression,
+                       /*count=*/1);
+
+  const UserModelInfo user_model{
+      IntentUserModelInfo{}, LatentInterestUserModelInfo{},
+      InterestUserModelInfo{SegmentList{"untargeted"}}};
+
+  // Confirm the cap is active and `creative_ad_2` is served as fallback.
+  {
+    base::test::TestFuture<CreativeNewTabPageAdList> test_future;
+    eligible_ads_->GetForUserModel(user_model, test_future.GetCallback());
+    EXPECT_THAT(test_future.Take(), ::testing::ElementsAre(creative_ad_2));
+  }
+
+  // Advance past the one-day frequency cap window.
+  AdvanceClockBy(base::Days(1));
+
+  // Assert: `creative_ad_1`'s cap has reset so the pipeline serves it again
+  // ahead of the lower-priority `creative_ad_2`.
+  {
+    base::test::TestFuture<CreativeNewTabPageAdList> test_future;
+    eligible_ads_->GetForUserModel(user_model, test_future.GetCallback());
+    EXPECT_THAT(test_future.Take(), ::testing::ElementsAre(creative_ad_1));
+  }
+}
+
+TEST_F(
+    BraveAdsEligibleNewTabPageAdsV2Test,
+    HigherPriorityBucketTakesPrecedenceImmediatelyAfterCapResetsWhileServingLowerPriority) {
+  // Arrange: `creative_ad_1` (priority 1) is frequency-capped so the pipeline
+  // falls through to the priority 2 bucket which has two ads mid-rotation.
+  // When the priority 1 cap resets, the next serve must jump back to
+  // `creative_ad_1` rather than continuing the lower-priority rotation.
+  CreativeNewTabPageAdInfo creative_ad_1 =
+      test::BuildCreativeNewTabPageAd(CreativeNewTabPageAdWallpaperType::kImage,
+                                      /*use_random_uuids=*/true);
+  creative_ad_1.priority = 1;
+  creative_ad_1.per_day = 1;
+
+  CreativeNewTabPageAdInfo creative_ad_2 =
+      test::BuildCreativeNewTabPageAd(CreativeNewTabPageAdWallpaperType::kImage,
+                                      /*use_random_uuids=*/true);
+  creative_ad_2.priority = 2;
+
+  CreativeNewTabPageAdInfo creative_ad_3 =
+      test::BuildCreativeNewTabPageAd(CreativeNewTabPageAdWallpaperType::kImage,
+                                      /*use_random_uuids=*/true);
+  creative_ad_3.priority = 2;
+
+  test::SaveCreativeNewTabPageAds(
+      {creative_ad_1, creative_ad_2, creative_ad_3});
+
+  test::RecordAdEvents(BuildNewTabPageAd(creative_ad_1),
+                       mojom::ConfirmationType::kServedImpression,
+                       /*count=*/1);
+
+  const UserModelInfo user_model{
+      IntentUserModelInfo{}, LatentInterestUserModelInfo{},
+      InterestUserModelInfo{SegmentList{"untargeted"}}};
+
+  // Serve from the lower-priority bucket while `creative_ad_1` is capped.
+  {
+    base::test::TestFuture<CreativeNewTabPageAdList> test_future;
+    eligible_ads_->GetForUserModel(user_model, test_future.GetCallback());
+    const CreativeNewTabPageAdList lower_priority_served_creative_ads =
+        test_future.Take();
+    EXPECT_THAT(lower_priority_served_creative_ads, ::testing::SizeIs(1));
+    SimulateServeAd(lower_priority_served_creative_ads);
+  }
+
+  // Advance past the one-day frequency cap window so `creative_ad_1` is
+  // eligible again.
+  AdvanceClockBy(base::Days(1));
+
+  // Assert: the priority 1 bucket has an eligible ad again so
+  // `creative_ad_1` is served immediately, even though the priority 2
+  // rotation is mid-cycle.
+  {
+    base::test::TestFuture<CreativeNewTabPageAdList> test_future;
+    eligible_ads_->GetForUserModel(user_model, test_future.GetCallback());
+    EXPECT_THAT(test_future.Take(), ::testing::ElementsAre(creative_ad_1));
   }
 }
 

--- a/components/brave_ads/core/internal/serving/eligible_ads/pipelines/notification_ads/eligible_notification_ads_v2.cc
+++ b/components/brave_ads/core/internal/serving/eligible_ads/pipelines/notification_ads/eligible_notification_ads_v2.cc
@@ -155,26 +155,24 @@ void EligibleNotificationAdsV2::FilterAndMaybePredictCreativeAd(
       site_history);
   ApplyExclusionRules(creative_ads, last_served_ad_, &exclusion_rules);
 
-  // Round-robin must run after exclusion rules but before pacing. Exclusion
-  // rules determine which ads are actually eligible, so rotation must operate
-  // on that filtered set. Pacing is a rate limiter rather than an eligibility
-  // filter, so it should not influence which ads the rotation considers
-  // unserved. Running round-robin before pacing ensures rotation resets are
-  // driven by which ads have actually been served rather than pacing
-  // suppression.
-  creative_ad_round_robin_->Filter(creative_ads);
-
-  PaceCreativeAds(creative_ads);
-
-  const PrioritizedCreativeAdBuckets<CreativeNotificationAdList> buckets =
+  PrioritizedCreativeAdBuckets<CreativeNotificationAdList> creative_ad_buckets =
       SortCreativeAdsIntoBucketsByPriority(creative_ads);
-  LogNumberOfCreativeAdsPerBucket(buckets);
+  LogNumberOfCreativeAdsPerBucket(creative_ad_buckets);
 
   // For each bucket of prioritized ads attempt to predict the most suitable ad
-  // for the user in priority order.
-  for (const auto& [priority, prioritized_creative_ads] : buckets) {
+  // for the user in priority order. Round-robin is applied per bucket after
+  // exclusion rules but before pacing so that lower-priority campaigns are
+  // never served while higher-priority campaigns still have eligible ads.
+  for (auto& [priority, creative_ad_bucket] : creative_ad_buckets) {
+    // Round-robin after exclusion rules ensures rotation operates on the
+    // actually-eligible set. Running it before pacing ensures rotation resets
+    // are driven by which ads have been served rather than pacing suppression.
+    creative_ad_round_robin_->Filter(creative_ad_bucket);
+
+    PaceCreativeAds(creative_ad_bucket);
+
     std::optional<CreativeNotificationAdInfo> predicted_creative_ad =
-        MaybePredictCreativeAd(prioritized_creative_ads, user_model, ad_events);
+        MaybePredictCreativeAd(creative_ad_bucket, user_model, ad_events);
     if (!predicted_creative_ad) {
       // Could not predict an ad for this bucket, so continue to the next
       // bucket.

--- a/components/brave_ads/core/internal/serving/eligible_ads/pipelines/notification_ads/eligible_notification_ads_v2_unittest.cc
+++ b/components/brave_ads/core/internal/serving/eligible_ads/pipelines/notification_ads/eligible_notification_ads_v2_unittest.cc
@@ -14,12 +14,15 @@
 #include "brave/components/brave_ads/core/internal/common/test/time_test_util.h"
 #include "brave/components/brave_ads/core/internal/creatives/notification_ads/creative_notification_ad_info.h"
 #include "brave/components/brave_ads/core/internal/creatives/notification_ads/creative_notification_ads_database_util.h"
+#include "brave/components/brave_ads/core/internal/creatives/notification_ads/notification_ad_builder.h"
 #include "brave/components/brave_ads/core/internal/creatives/notification_ads/test/creative_notification_ad_test_util.h"
 #include "brave/components/brave_ads/core/internal/serving/eligible_ads/eligible_ads_feature.h"
 #include "brave/components/brave_ads/core/internal/serving/eligible_ads/round_robin/creative_ad_round_robin.h"
 #include "brave/components/brave_ads/core/internal/serving/targeting/user_model/user_model_info.h"
 #include "brave/components/brave_ads/core/internal/targeting/behavioral/anti_targeting/resource/anti_targeting_resource.h"
 #include "brave/components/brave_ads/core/internal/targeting/geographical/subdivision/subdivision_targeting.h"
+#include "brave/components/brave_ads/core/internal/user_engagement/ad_events/test/ad_event_test_util.h"
+#include "brave/components/brave_ads/core/mojom/brave_ads.mojom.h"
 
 // npm run test -- brave_unit_tests --filter=BraveAds*
 
@@ -179,35 +182,38 @@ TEST_F(BraveAdsEligibleNotificationAdsV2Test,
   // Act
   base::test::TestFuture<CreativeNotificationAdList> test_future_1;
   eligible_ads_->GetForUserModel(user_model, test_future_1.GetCallback());
-  const CreativeNotificationAdList creative_ads_1 = test_future_1.Take();
-  EXPECT_THAT(creative_ads_1, ::testing::SizeIs(1));
-  SimulateServeAd(creative_ads_1);
+  const CreativeNotificationAdList first_served_creative_ads =
+      test_future_1.Take();
+  EXPECT_THAT(first_served_creative_ads, ::testing::SizeIs(1));
+  SimulateServeAd(first_served_creative_ads);
 
   base::test::TestFuture<CreativeNotificationAdList> test_future_2;
   eligible_ads_->GetForUserModel(user_model, test_future_2.GetCallback());
-  const CreativeNotificationAdList creative_ads_2 = test_future_2.Take();
-  EXPECT_THAT(creative_ads_2, ::testing::SizeIs(1));
-  SimulateServeAd(creative_ads_2);
+  const CreativeNotificationAdList second_served_creative_ads =
+      test_future_2.Take();
+  EXPECT_THAT(second_served_creative_ads, ::testing::SizeIs(1));
+  SimulateServeAd(second_served_creative_ads);
 
-  ASSERT_NE(creative_ads_1, creative_ads_2);
+  ASSERT_NE(first_served_creative_ads, second_served_creative_ads);
 
-  // Assert: `creative_ads_1` is served again because `creative_ads_2` was
-  // served last and is not served immediately after all ads have been seen.
+  // Assert: `first_served_creative_ads` is served again because
+  // `second_served_creative_ads` was served last and is not served immediately
+  // after all ads have been seen.
   base::test::TestFuture<CreativeNotificationAdList> test_future_3;
   eligible_ads_->GetForUserModel(user_model, test_future_3.GetCallback());
-  EXPECT_EQ(test_future_3.Take(), creative_ads_1);
+  EXPECT_EQ(test_future_3.Take(), first_served_creative_ads);
 }
 
 TEST_F(BraveAdsEligibleNotificationAdsV2Test, ZeroPriorityAdIsNeverServed) {
   // Arrange: `creative_ad_1` has priority 0 and must be excluded by the
-  // bucketing step; `creative_ad_2` has the default priority 2 and should be
-  // served.
+  // bucketing step; `creative_ad_2` has priority 1 and should be served.
   CreativeNotificationAdInfo creative_ad_1 =
       test::BuildCreativeNotificationAd(/*use_random_uuids=*/true);
   creative_ad_1.priority = 0;
 
-  const CreativeNotificationAdInfo creative_ad_2 =
+  CreativeNotificationAdInfo creative_ad_2 =
       test::BuildCreativeNotificationAd(/*use_random_uuids=*/true);
+  creative_ad_2.priority = 1;
 
   database::SaveCreativeNotificationAds({creative_ad_1, creative_ad_2});
 
@@ -218,6 +224,29 @@ TEST_F(BraveAdsEligibleNotificationAdsV2Test, ZeroPriorityAdIsNeverServed) {
                     InterestUserModelInfo{SegmentList{"untargeted"}}},
       test_future.GetCallback());
   EXPECT_THAT(test_future.Take(), ::testing::ElementsAre(creative_ad_2));
+}
+
+TEST_F(
+    BraveAdsEligibleNotificationAdsV2Test,
+    HigherPriorityAdIsServedBeforeLowerPriorityAdWithNonSequentialPriorities) {
+  // Arrange: `creative_ad_1` has priority 1 and `creative_ad_2` has priority 5.
+  CreativeNotificationAdInfo creative_ad_1 =
+      test::BuildCreativeNotificationAd(/*use_random_uuids=*/true);
+  creative_ad_1.priority = 1;
+
+  CreativeNotificationAdInfo creative_ad_2 =
+      test::BuildCreativeNotificationAd(/*use_random_uuids=*/true);
+  creative_ad_2.priority = 5;
+
+  database::SaveCreativeNotificationAds({creative_ad_1, creative_ad_2});
+
+  // Act & Assert
+  base::test::TestFuture<CreativeNotificationAdList> test_future;
+  eligible_ads_->GetForUserModel(
+      UserModelInfo{IntentUserModelInfo{}, LatentInterestUserModelInfo{},
+                    InterestUserModelInfo{SegmentList{"untargeted"}}},
+      test_future.GetCallback());
+  EXPECT_THAT(test_future.Take(), ::testing::ElementsAre(creative_ad_1));
 }
 
 TEST_F(BraveAdsEligibleNotificationAdsV2Test,
@@ -244,11 +273,11 @@ TEST_F(BraveAdsEligibleNotificationAdsV2Test,
 }
 
 TEST_F(BraveAdsEligibleNotificationAdsV2Test,
-       RoundRobinServesLowerPriorityAdAfterHigherPriorityAdHasBeenShown) {
+       HigherPriorityAdContinuesToServeAfterRoundRobinReset) {
   // Arrange: `creative_ad_1` has priority 1 and `creative_ad_2` has priority 2.
-  // After `creative_ad_1` is served, round-robin excludes it so the
-  // higher-priority bucket is empty and the pipeline falls through to the
-  // lower-priority bucket.
+  // After the only priority 1 ad is served, its per-bucket rotation resets
+  // so it remains eligible. The lower-priority `creative_ad_2` must never be
+  // served as long as the higher-priority bucket has an eligible ad.
   CreativeNotificationAdInfo creative_ad_1 =
       test::BuildCreativeNotificationAd(/*use_random_uuids=*/true);
   creative_ad_1.priority = 1;
@@ -271,55 +300,62 @@ TEST_F(BraveAdsEligibleNotificationAdsV2Test,
     SimulateServeAd(creative_ad_1);
   }
 
-  // Assert: round-robin excludes the already-seen `creative_ad_1`, leaving
-  // only the lower-priority `creative_ad_2`.
+  // Assert: the priority 1 bucket rotation resets (it is the only ad), so
+  // `creative_ad_1` serves again rather than falling through to
+  // `creative_ad_2`.
   {
     base::test::TestFuture<CreativeNotificationAdList> test_future;
     eligible_ads_->GetForUserModel(user_model, test_future.GetCallback());
-    EXPECT_THAT(test_future.Take(), ::testing::ElementsAre(creative_ad_2));
+    EXPECT_THAT(test_future.Take(), ::testing::ElementsAre(creative_ad_1));
   }
 }
 
 TEST_F(BraveAdsEligibleNotificationAdsV2Test,
-       RoundRobinServesHigherPriorityAdAgainAfterAllAdsHaveBeenShown) {
-  // Arrange: `creative_ad_1` has priority 1 and `creative_ad_2` has priority 2.
+       RoundRobinResetsWithinPriorityBucketAfterAllAdsHaveBeenShown) {
+  // Arrange: `creative_ad_1` and `creative_ad_2` share a priority 1;
+  // `creative_ad_3` has a priority 2 and must never be served while the
+  // priority 1 bucket has eligible ads.
   CreativeNotificationAdInfo creative_ad_1 =
       test::BuildCreativeNotificationAd(/*use_random_uuids=*/true);
   creative_ad_1.priority = 1;
 
   CreativeNotificationAdInfo creative_ad_2 =
       test::BuildCreativeNotificationAd(/*use_random_uuids=*/true);
-  creative_ad_2.priority = 2;
+  creative_ad_2.priority = 1;
 
-  database::SaveCreativeNotificationAds({creative_ad_1, creative_ad_2});
+  CreativeNotificationAdInfo creative_ad_3 =
+      test::BuildCreativeNotificationAd(/*use_random_uuids=*/true);
+  creative_ad_3.priority = 2;
+
+  database::SaveCreativeNotificationAds(
+      {creative_ad_1, creative_ad_2, creative_ad_3});
 
   const UserModelInfo user_model{
       IntentUserModelInfo{}, LatentInterestUserModelInfo{},
       InterestUserModelInfo{SegmentList{"untargeted"}}};
 
-  // Act: serve each ad once so that all ads have been seen.
-  {
-    base::test::TestFuture<CreativeNotificationAdList> test_future;
-    eligible_ads_->GetForUserModel(user_model, test_future.GetCallback());
-    EXPECT_THAT(test_future.Take(), ::testing::ElementsAre(creative_ad_1));
-    SimulateServeAd(creative_ad_1);
-  }
+  // Act: serve each priority 1 ad once.
+  base::test::TestFuture<CreativeNotificationAdList> test_future_1;
+  eligible_ads_->GetForUserModel(user_model, test_future_1.GetCallback());
+  const CreativeNotificationAdList first_served_creative_ads =
+      test_future_1.Take();
+  EXPECT_THAT(first_served_creative_ads, ::testing::SizeIs(1));
+  SimulateServeAd(first_served_creative_ads);
 
-  {
-    base::test::TestFuture<CreativeNotificationAdList> test_future;
-    eligible_ads_->GetForUserModel(user_model, test_future.GetCallback());
-    EXPECT_THAT(test_future.Take(), ::testing::ElementsAre(creative_ad_2));
-    SimulateServeAd(creative_ad_2);
-  }
+  base::test::TestFuture<CreativeNotificationAdList> test_future_2;
+  eligible_ads_->GetForUserModel(user_model, test_future_2.GetCallback());
+  const CreativeNotificationAdList second_served_creative_ads =
+      test_future_2.Take();
+  EXPECT_THAT(second_served_creative_ads, ::testing::SizeIs(1));
+  ASSERT_NE(first_served_creative_ads, second_served_creative_ads);
+  SimulateServeAd(second_served_creative_ads);
 
-  // Assert: all ads have been seen so the rotation resets. `creative_ad_1` is
-  // served again because `creative_ad_2` is excluded as the most recently
-  // served ad.
-  {
-    base::test::TestFuture<CreativeNotificationAdList> test_future;
-    eligible_ads_->GetForUserModel(user_model, test_future.GetCallback());
-    EXPECT_THAT(test_future.Take(), ::testing::ElementsAre(creative_ad_1));
-  }
+  // Assert: all priority 1 ads have been seen so the bucket resets.
+  // The second-served ad is excluded; the first-served ad comes back.
+  // The lower-priority `creative_ad_3` is never reached.
+  base::test::TestFuture<CreativeNotificationAdList> test_future_3;
+  eligible_ads_->GetForUserModel(user_model, test_future_3.GetCallback());
+  EXPECT_EQ(test_future_3.Take(), first_served_creative_ads);
 }
 
 TEST_F(BraveAdsEligibleNotificationAdsV2Test,
@@ -360,6 +396,264 @@ TEST_F(BraveAdsEligibleNotificationAdsV2Test,
     base::test::TestFuture<CreativeNotificationAdList> test_future;
     eligible_ads_->GetForUserModel(user_model, test_future.GetCallback());
     EXPECT_THAT(test_future.Take(), ::testing::ElementsAre(creative_ad_3));
+  }
+}
+
+TEST_F(BraveAdsEligibleNotificationAdsV2Test,
+       LowerPriorityAdIsServedWhenHigherPriorityAdHitsItsFrequencyCap) {
+  // Arrange: `creative_ad_1` has priority 1 with a frequency cap of 1;
+  // `creative_ad_2` has priority 2. Once `creative_ad_1` has been served once
+  // today its frequency cap is exhausted and the pipeline must fall through to
+  // `creative_ad_2`.
+  CreativeNotificationAdInfo creative_ad_1 =
+      test::BuildCreativeNotificationAd(/*use_random_uuids=*/true);
+  creative_ad_1.priority = 1;
+  creative_ad_1.per_day = 1;
+
+  CreativeNotificationAdInfo creative_ad_2 =
+      test::BuildCreativeNotificationAd(/*use_random_uuids=*/true);
+  creative_ad_2.priority = 2;
+
+  database::SaveCreativeNotificationAds({creative_ad_1, creative_ad_2});
+
+  test::RecordAdEvents(BuildNotificationAd(creative_ad_1),
+                       mojom::ConfirmationType::kServedImpression,
+                       /*count=*/1);
+
+  // Act & Assert: `creative_ad_1` has exhausted its frequency cap so the
+  // pipeline falls through to the lower-priority `creative_ad_2`.
+  base::test::TestFuture<CreativeNotificationAdList> test_future;
+  eligible_ads_->GetForUserModel(
+      UserModelInfo{IntentUserModelInfo{}, LatentInterestUserModelInfo{},
+                    InterestUserModelInfo{SegmentList{"untargeted"}}},
+      test_future.GetCallback());
+  EXPECT_THAT(test_future.Take(), ::testing::ElementsAre(creative_ad_2));
+}
+
+TEST_F(BraveAdsEligibleNotificationAdsV2Test,
+       LowerPriorityAdIsServedWhenAllHigherPriorityAdsHitTheirFrequencyCaps) {
+  // Arrange: both priority 1 ads have exhausted their frequency caps;
+  // `creative_ad_3` has priority 2 and must be served as a fallback.
+  CreativeNotificationAdInfo creative_ad_1 =
+      test::BuildCreativeNotificationAd(/*use_random_uuids=*/true);
+  creative_ad_1.priority = 1;
+  creative_ad_1.per_day = 1;
+
+  CreativeNotificationAdInfo creative_ad_2 =
+      test::BuildCreativeNotificationAd(/*use_random_uuids=*/true);
+  creative_ad_2.priority = 1;
+  creative_ad_2.per_day = 1;
+
+  CreativeNotificationAdInfo creative_ad_3 =
+      test::BuildCreativeNotificationAd(/*use_random_uuids=*/true);
+  creative_ad_3.priority = 2;
+
+  database::SaveCreativeNotificationAds(
+      {creative_ad_1, creative_ad_2, creative_ad_3});
+
+  test::RecordAdEvents(BuildNotificationAd(creative_ad_1),
+                       mojom::ConfirmationType::kServedImpression,
+                       /*count=*/1);
+  test::RecordAdEvents(BuildNotificationAd(creative_ad_2),
+                       mojom::ConfirmationType::kServedImpression,
+                       /*count=*/1);
+
+  // Act & Assert: all priority 1 ads are frequency-capped so the pipeline
+  // falls through to `creative_ad_3`.
+  base::test::TestFuture<CreativeNotificationAdList> test_future;
+  eligible_ads_->GetForUserModel(
+      UserModelInfo{IntentUserModelInfo{}, LatentInterestUserModelInfo{},
+                    InterestUserModelInfo{SegmentList{"untargeted"}}},
+      test_future.GetCallback());
+  EXPECT_THAT(test_future.Take(), ::testing::ElementsAre(creative_ad_3));
+}
+
+TEST_F(BraveAdsEligibleNotificationAdsV2Test,
+       EachLowerPriorityAdIsServedWhenHigherPriorityAdsAreFrequencyCapped) {
+  // Arrange: `creative_ad_1` has priority 1, `creative_ad_2` has priority 2,
+  // and `creative_ad_3` has priority 3. Each higher-priority ad has a frequency
+  // cap of 1 so the pipeline cascades through each bucket in order.
+  CreativeNotificationAdInfo creative_ad_1 =
+      test::BuildCreativeNotificationAd(/*use_random_uuids=*/true);
+  creative_ad_1.priority = 1;
+  creative_ad_1.per_day = 1;
+
+  CreativeNotificationAdInfo creative_ad_2 =
+      test::BuildCreativeNotificationAd(/*use_random_uuids=*/true);
+  creative_ad_2.priority = 2;
+  creative_ad_2.per_day = 1;
+
+  CreativeNotificationAdInfo creative_ad_3 =
+      test::BuildCreativeNotificationAd(/*use_random_uuids=*/true);
+  creative_ad_3.priority = 3;
+
+  database::SaveCreativeNotificationAds(
+      {creative_ad_1, creative_ad_2, creative_ad_3});
+
+  const UserModelInfo user_model{
+      IntentUserModelInfo{}, LatentInterestUserModelInfo{},
+      InterestUserModelInfo{SegmentList{"untargeted"}}};
+
+  // Act & Assert: priority 1 ad is served first.
+  {
+    base::test::TestFuture<CreativeNotificationAdList> test_future;
+    eligible_ads_->GetForUserModel(user_model, test_future.GetCallback());
+    EXPECT_THAT(test_future.Take(), ::testing::ElementsAre(creative_ad_1));
+  }
+
+  test::RecordAdEvents(BuildNotificationAd(creative_ad_1),
+                       mojom::ConfirmationType::kServedImpression,
+                       /*count=*/1);
+
+  // Priority 1 is capped; priority 2 ad is served next.
+  {
+    base::test::TestFuture<CreativeNotificationAdList> test_future;
+    eligible_ads_->GetForUserModel(user_model, test_future.GetCallback());
+    EXPECT_THAT(test_future.Take(), ::testing::ElementsAre(creative_ad_2));
+  }
+
+  test::RecordAdEvents(BuildNotificationAd(creative_ad_2),
+                       mojom::ConfirmationType::kServedImpression,
+                       /*count=*/1);
+
+  // Both priority 1 and 2 are capped; priority 3 ad is served last.
+  {
+    base::test::TestFuture<CreativeNotificationAdList> test_future;
+    eligible_ads_->GetForUserModel(user_model, test_future.GetCallback());
+    EXPECT_THAT(test_future.Take(), ::testing::ElementsAre(creative_ad_3));
+  }
+}
+
+TEST_F(BraveAdsEligibleNotificationAdsV2Test,
+       UncappedHigherPriorityAdServesWhenOtherHigherPriorityAdsAreCapped) {
+  // Arrange: `creative_ad_1` is frequency-capped; `creative_ad_2` shares
+  // priority 1 but is not capped. The pipeline must serve `creative_ad_2`
+  // rather than falling through to `creative_ad_3` (priority 2).
+  CreativeNotificationAdInfo creative_ad_1 =
+      test::BuildCreativeNotificationAd(/*use_random_uuids=*/true);
+  creative_ad_1.priority = 1;
+  creative_ad_1.per_day = 1;
+
+  CreativeNotificationAdInfo creative_ad_2 =
+      test::BuildCreativeNotificationAd(/*use_random_uuids=*/true);
+  creative_ad_2.priority = 1;
+
+  CreativeNotificationAdInfo creative_ad_3 =
+      test::BuildCreativeNotificationAd(/*use_random_uuids=*/true);
+  creative_ad_3.priority = 2;
+
+  database::SaveCreativeNotificationAds(
+      {creative_ad_1, creative_ad_2, creative_ad_3});
+
+  test::RecordAdEvents(BuildNotificationAd(creative_ad_1),
+                       mojom::ConfirmationType::kServedImpression,
+                       /*count=*/1);
+
+  // Act & Assert: `creative_ad_2` is eligible in the priority 1 bucket so
+  // the pipeline serves it rather than falling through to `creative_ad_3`.
+  base::test::TestFuture<CreativeNotificationAdList> test_future;
+  eligible_ads_->GetForUserModel(
+      UserModelInfo{IntentUserModelInfo{}, LatentInterestUserModelInfo{},
+                    InterestUserModelInfo{SegmentList{"untargeted"}}},
+      test_future.GetCallback());
+  EXPECT_THAT(test_future.Take(), ::testing::ElementsAre(creative_ad_2));
+}
+
+TEST_F(BraveAdsEligibleNotificationAdsV2Test,
+       HigherPriorityAdResumesServingAfterFrequencyCapResets) {
+  // Arrange: `creative_ad_1` (priority 1) exhausts its frequency cap so the
+  // pipeline falls through to `creative_ad_2` (priority 2). After a day the
+  // cap resets and `creative_ad_1` must be served again.
+  CreativeNotificationAdInfo creative_ad_1 =
+      test::BuildCreativeNotificationAd(/*use_random_uuids=*/true);
+  creative_ad_1.priority = 1;
+  creative_ad_1.per_day = 1;
+
+  CreativeNotificationAdInfo creative_ad_2 =
+      test::BuildCreativeNotificationAd(/*use_random_uuids=*/true);
+  creative_ad_2.priority = 2;
+
+  database::SaveCreativeNotificationAds({creative_ad_1, creative_ad_2});
+
+  test::RecordAdEvents(BuildNotificationAd(creative_ad_1),
+                       mojom::ConfirmationType::kServedImpression,
+                       /*count=*/1);
+
+  const UserModelInfo user_model{
+      IntentUserModelInfo{}, LatentInterestUserModelInfo{},
+      InterestUserModelInfo{SegmentList{"untargeted"}}};
+
+  // Confirm the cap is active and `creative_ad_2` is served as fallback.
+  {
+    base::test::TestFuture<CreativeNotificationAdList> test_future;
+    eligible_ads_->GetForUserModel(user_model, test_future.GetCallback());
+    EXPECT_THAT(test_future.Take(), ::testing::ElementsAre(creative_ad_2));
+  }
+
+  // Advance past the one-day frequency cap window.
+  AdvanceClockBy(base::Days(1));
+
+  // Assert: `creative_ad_1`'s cap has reset so the pipeline serves it again
+  // ahead of the lower-priority `creative_ad_2`.
+  {
+    base::test::TestFuture<CreativeNotificationAdList> test_future;
+    eligible_ads_->GetForUserModel(user_model, test_future.GetCallback());
+    EXPECT_THAT(test_future.Take(), ::testing::ElementsAre(creative_ad_1));
+  }
+}
+
+TEST_F(
+    BraveAdsEligibleNotificationAdsV2Test,
+    HigherPriorityBucketTakesPrecedenceImmediatelyAfterCapResetsWhileServingLowerPriority) {
+  // Arrange: `creative_ad_1` (priority 1) is frequency-capped so the pipeline
+  // falls through to the priority 2 bucket which has two ads mid-rotation.
+  // When the priority 1 cap resets, the next serve must jump back to
+  // `creative_ad_1` rather than continuing the lower-priority rotation.
+  CreativeNotificationAdInfo creative_ad_1 =
+      test::BuildCreativeNotificationAd(/*use_random_uuids=*/true);
+  creative_ad_1.priority = 1;
+  creative_ad_1.per_day = 1;
+
+  CreativeNotificationAdInfo creative_ad_2 =
+      test::BuildCreativeNotificationAd(/*use_random_uuids=*/true);
+  creative_ad_2.priority = 2;
+
+  CreativeNotificationAdInfo creative_ad_3 =
+      test::BuildCreativeNotificationAd(/*use_random_uuids=*/true);
+  creative_ad_3.priority = 2;
+
+  database::SaveCreativeNotificationAds(
+      {creative_ad_1, creative_ad_2, creative_ad_3});
+
+  test::RecordAdEvents(BuildNotificationAd(creative_ad_1),
+                       mojom::ConfirmationType::kServedImpression,
+                       /*count=*/1);
+
+  const UserModelInfo user_model{
+      IntentUserModelInfo{}, LatentInterestUserModelInfo{},
+      InterestUserModelInfo{SegmentList{"untargeted"}}};
+
+  // Serve from the lower-priority bucket while `creative_ad_1` is capped.
+  {
+    base::test::TestFuture<CreativeNotificationAdList> test_future;
+    eligible_ads_->GetForUserModel(user_model, test_future.GetCallback());
+    const CreativeNotificationAdList lower_priority_served_creative_ads =
+        test_future.Take();
+    EXPECT_THAT(lower_priority_served_creative_ads, ::testing::SizeIs(1));
+    SimulateServeAd(lower_priority_served_creative_ads);
+  }
+
+  // Advance past the one-day frequency cap window so `creative_ad_1` is
+  // eligible again.
+  AdvanceClockBy(base::Days(1));
+
+  // Assert: the priority 1 bucket has an eligible ad again so
+  // `creative_ad_1` is served immediately, even though the priority 2
+  // rotation is mid-cycle.
+  {
+    base::test::TestFuture<CreativeNotificationAdList> test_future;
+    eligible_ads_->GetForUserModel(user_model, test_future.GetCallback());
+    EXPECT_THAT(test_future.Take(), ::testing::ElementsAre(creative_ad_1));
   }
 }
 

--- a/components/brave_ads/core/internal/serving/eligible_ads/round_robin/creative_ad_round_robin_unittest.cc
+++ b/components/brave_ads/core/internal/serving/eligible_ads/round_robin/creative_ad_round_robin_unittest.cc
@@ -215,4 +215,76 @@ TEST_F(BraveAdsCreativeAdRoundRobinTest,
   EXPECT_THAT(creative_ads, testing::ElementsAre(creative_ad_1, creative_ad_2));
 }
 
+TEST_F(BraveAdsCreativeAdRoundRobinTest,
+       ShouldNotFilterAdsWhenRoundRobinIsDisabled) {
+  // Arrange
+  scoped_feature_list_.Reset();
+  scoped_feature_list_.InitAndEnableFeatureWithParameters(
+      kEligibleAdFeature, {{"should_round_robin", "false"}});
+
+  const CreativeNewTabPageAdInfo creative_ad_1 =
+      test::BuildCreativeNewTabPageAd(CreativeNewTabPageAdWallpaperType::kImage,
+                                      /*use_random_uuids=*/true);
+  creative_ad_round_robin_.MarkAsServed(creative_ad_1);
+
+  const CreativeNewTabPageAdInfo creative_ad_2 =
+      test::BuildCreativeNewTabPageAd(CreativeNewTabPageAdWallpaperType::kImage,
+                                      /*use_random_uuids=*/true);
+
+  CreativeNewTabPageAdList creative_ads = {creative_ad_1, creative_ad_2};
+
+  // Act
+  creative_ad_round_robin_.Filter(creative_ads);
+
+  // Assert
+  EXPECT_THAT(creative_ads, testing::ElementsAre(creative_ad_1, creative_ad_2));
+}
+
+TEST_F(BraveAdsCreativeAdRoundRobinTest,
+       ShouldExcludeLastServedAdAfterBucketReset) {
+  // Arrange
+  CreativeNewTabPageAdInfo creative_ad_1 =
+      test::BuildCreativeNewTabPageAd(CreativeNewTabPageAdWallpaperType::kImage,
+                                      /*use_random_uuids=*/true);
+  creative_ad_1.priority = 1;
+  creative_ad_round_robin_.MarkAsServed(creative_ad_1);
+
+  CreativeNewTabPageAdInfo creative_ad_2 =
+      test::BuildCreativeNewTabPageAd(CreativeNewTabPageAdWallpaperType::kImage,
+                                      /*use_random_uuids=*/true);
+  creative_ad_2.priority = 1;
+  creative_ad_round_robin_.MarkAsServed(creative_ad_2);
+
+  CreativeNewTabPageAdList creative_ads = {creative_ad_1, creative_ad_2};
+
+  // Act
+  creative_ad_round_robin_.Filter(creative_ads);
+
+  // Assert
+  EXPECT_THAT(creative_ads, testing::ElementsAre(creative_ad_1));
+}
+
+TEST_F(BraveAdsCreativeAdRoundRobinTest,
+       ShouldKeepUnservedAdEligibleWhenOtherAdHasBeenServed) {
+  // Arrange
+  CreativeNewTabPageAdInfo creative_ad_1 =
+      test::BuildCreativeNewTabPageAd(CreativeNewTabPageAdWallpaperType::kImage,
+                                      /*use_random_uuids=*/true);
+  creative_ad_1.priority = 1;
+  creative_ad_round_robin_.MarkAsServed(creative_ad_1);
+
+  CreativeNewTabPageAdInfo creative_ad_2 =
+      test::BuildCreativeNewTabPageAd(CreativeNewTabPageAdWallpaperType::kImage,
+                                      /*use_random_uuids=*/true);
+  creative_ad_2.priority = 1;
+
+  CreativeNewTabPageAdList creative_ads = {creative_ad_1, creative_ad_2};
+
+  // Act
+  creative_ad_round_robin_.Filter(creative_ads);
+
+  // Assert
+  EXPECT_THAT(creative_ads, testing::ElementsAre(creative_ad_2));
+}
+
 }  // namespace brave_ads


### PR DESCRIPTION
Previously, round-robin filtering ran once across all ads before priority
bucketing, so a campaign that had exhausted its rotation could suppress
higher-priority campaigns from being served. This change moves the
round-robin filter inside the per-bucket loop so each priority bucket
rotates independently, preserving intended campaign priority ordering.

Pacing is also applied per bucket, after round-robin. If all ads in a
bucket are suppressed by pacing, the pipeline falls through to the next
priority bucket so lower-priority campaigns continue to backfill paced
out slots. Whether this is the intended behavior for pass through rate
is a separate open question.

- Priority
  - Higher priority ad always shows before lower priority
  - Once a high priority ad has rotated through, it resets and keeps serving rather than giving way to lower priority

- Pacing
  - If a high priority ad is suppressed by pacing, a lower priority ad fills the slot
  - If a high priority ad is never suppressed, lower priority ads never show

- Frequency caps
  - When a high priority ad reaches its cap, the next priority level serves instead
  - When all ads at a priority level have reached their cap, the pipeline works down through each level in order
  - If one ad at a priority level has reached its cap but another has not, the uncapped ad serves with no fallthrough

- Rotation
  - Each priority level rotates independently
  - When a cap resets for a high priority ad, it takes back the slot rather than letting lower priority continue

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/55448

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
