### PR TITLE
[VPN 2.0] Add GetLastConnectionError API to BraveVpnService

### DIFF
--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -993,7 +993,6 @@ source_set("ui") {
     ]
   }
   if (enable_brave_vpn_v1) {
-    deps += [ "//brave/components/brave_vpn/browser/connection:api" ]
     if (is_win) {
       deps += [
         "//brave/components/brave_vpn/common/win",

--- a/browser/ui/webui/skus_internals_ui.cc
+++ b/browser/ui/webui/skus_internals_ui.cc
@@ -42,10 +42,6 @@
 #include "brave/components/brave_vpn/common/pref_names.h"
 #endif
 
-#if BUILDFLAG(ENABLE_BRAVE_VPN_V1)
-#include "brave/components/brave_vpn/browser/connection/brave_vpn_connection_manager.h"
-#endif
-
 namespace {
 
 void SaveSkusStateToFile(const base::FilePath& path,
@@ -231,10 +227,12 @@ void SkusInternalsUI::FileSelectionCanceled() {
 
 std::string SkusInternalsUI::GetLastVPNConnectionError() const {
   std::string error;
-#if BUILDFLAG(ENABLE_BRAVE_VPN_V1)
-  auto* manager = g_brave_browser_process->brave_vpn_connection_manager();
-  CHECK(manager);
-  error = manager->GetLastConnectionError();
+#if BUILDFLAG(ENABLE_BRAVE_VPN) && !BUILDFLAG(IS_ANDROID)
+  auto* profile = Profile::FromWebUI(web_ui());
+  if (auto* service =
+          brave_vpn::BraveVpnServiceFactory::GetForProfile(profile)) {
+    error = service->GetLastConnectionError();
+  }
 #endif
   return error;
 }

--- a/components/brave_vpn/browser/brave_vpn_service.h
+++ b/components/brave_vpn/browser/brave_vpn_service.h
@@ -63,6 +63,7 @@ class BraveVpnService : public mojom::ServiceHandler, public KeyedService {
   virtual bool IsConnected() const = 0;
   virtual void ToggleConnection() = 0;
   virtual mojom::ConnectionState GetConnectionState() const = 0;
+  virtual std::string GetLastConnectionError() const = 0;
   virtual void RecordWidgetUsageMetrics(bool new_usage) = 0;
 #else   //  !BUILDFLAG(IS_ANDROID)
   // Public interface for Android native worker.

--- a/components/brave_vpn/browser/brave_vpn_service_impl.cc
+++ b/components/brave_vpn/browser/brave_vpn_service_impl.cc
@@ -122,6 +122,11 @@ std::string BraveVpnServiceImpl::GetCurrentEnvironment() const {
 }
 
 #if !BUILDFLAG(IS_ANDROID)
+std::string BraveVpnServiceImpl::GetLastConnectionError() const {
+  CHECK(connection_manager_);
+  return connection_manager_->GetLastConnectionError();
+}
+
 void BraveVpnServiceImpl::RecordWidgetUsageMetrics(bool new_usage) {
   brave_vpn_metrics_.RecordWidgetUsage(new_usage);
 }

--- a/components/brave_vpn/browser/brave_vpn_service_impl.h
+++ b/components/brave_vpn/browser/brave_vpn_service_impl.h
@@ -77,6 +77,7 @@ class BraveVpnServiceImpl : public BraveVpnService,
   bool IsConnected() const override;
   void ToggleConnection() override;
   mojom::ConnectionState GetConnectionState() const override;
+  std::string GetLastConnectionError() const override;
   void RecordWidgetUsageMetrics(bool new_usage) override;
 #endif  // !BUILDFLAG(IS_ANDROID)
 

--- a/components/brave_vpn/browser/brave_vpn_service_unittest.cc
+++ b/components/brave_vpn/browser/brave_vpn_service_unittest.cc
@@ -45,6 +45,7 @@ class TestBraveVpnService : public BraveVpnService {
   mojom::ConnectionState GetConnectionState() const override {
     return mojom::ConnectionState::DISCONNECTED;
   }
+  std::string GetLastConnectionError() const override { return {}; }
   void RecordWidgetUsageMetrics(bool new_usage) override {}
 #else
   void GetTimezonesForRegions(ResponseCallback callback) override {}

--- a/components/brave_vpn/browser/v2/brave_vpn_service_impl.h
+++ b/components/brave_vpn/browser/v2/brave_vpn_service_impl.h
@@ -37,6 +37,7 @@ class BraveVpnServiceImpl : public BraveVpnService {
   bool IsConnected() const override;
   void ToggleConnection() override;
   mojom::ConnectionState GetConnectionState() const override;
+  std::string GetLastConnectionError() const override;
   void RecordWidgetUsageMetrics(bool new_usage) override;
 
   // mojom::ServiceHandler overrides:

--- a/components/brave_vpn/browser/v2/brave_vpn_service_impl_desktop.cc
+++ b/components/brave_vpn/browser/v2/brave_vpn_service_impl_desktop.cc
@@ -26,6 +26,11 @@ mojom::ConnectionState BraveVpnServiceImpl::GetConnectionState() const {
   return connection_state_;
 }
 
+std::string BraveVpnServiceImpl::GetLastConnectionError() const {
+  NOTIMPLEMENTED();
+  return std::string();
+}
+
 void BraveVpnServiceImpl::RecordWidgetUsageMetrics(bool new_usage) {
   NOTIMPLEMENTED();
 }


### PR DESCRIPTION
Currently, SkusInternalsUI uses a call to the VPN connection manager to get a last VPN error. This is relevant only to Architecture 1.0, since in Architecture 2.0 there is no connection manager in the browser. Hence we need to implement an implementation-agnotic API in the BraveVpnService, to access the last VPN connection error in SkusInternalsUI. This change introduces this new API.

Resolves https://github.com/brave/brave-browser/issues/55762

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
