### PR TITLE
[Sidebar V2] Use window-corner radius when panel is at window edge

### DIFF
--- a/browser/ui/sidebar/sidebar_browsertest.cc
+++ b/browser/ui/sidebar/sidebar_browsertest.cc
@@ -2038,6 +2038,10 @@ INSTANTIATE_TEST_SUITE_P(
     });
 
 #if BUILDFLAG(ENABLE_SIDEBAR_V2)
+using views::ShapeContextTokensOverride::kRoundedCornersBorderRadius;
+using views::ShapeContextTokensOverride::
+    kRoundedCornersBorderRadiusAtWindowCorner;
+
 // In V2 the upstream side panel is a direct child of browser_view, positioned
 // by CalculateSideBarLayout.  Verify that when the panel is open it sits
 // between the contents container and the sidebar control, NOT outside it.
@@ -2187,11 +2191,11 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, SidebarV2BraveHeaderTest) {
 namespace {
 
 // Returns the corners that GetRoundedCorners() inside ContentParentView would
-// compute for the panel's current header and pref state.
+// compute for the panel's current header and browser state.
 gfx::RoundedCornersF ExpectedContentCorners(SidePanel* panel,
-                                            PrefService* prefs) {
+                                            BrowserWindowInterface* browser) {
   return brave::GetPanelContentsRoundedCorners(
-      prefs, panel->GetHeaderView<views::View>() != nullptr);
+      browser, panel->GetHeaderView<views::View>() != nullptr);
 }
 
 // Asserts layer-backed content children carry the expected corner radii.
@@ -2223,8 +2227,8 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest,
   side_panel->DisableAnimationsForTesting();
   prefs->SetBoolean(kWebViewRoundedCorners, true);
 
-  const int r = views::LayoutProvider::Get()->GetDistanceMetric(
-      ChromeDistanceMetric::DISTANCE_SIDE_PANEL_CONTENT_RADIUS);
+  const int r = views::LayoutProvider::Get()->GetCornerRadiusMetric(
+      kRoundedCornersBorderRadius);
   const gfx::RoundedCornersF flat_top(0, 0, r, r);
   const gfx::RoundedCornersF all_round(r);
   const gfx::RoundedCornersF none;
@@ -2243,33 +2247,33 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest,
   panel_ui->Show(SidePanelEntryId::kBookmarks);
   wait_for_entry(SidePanelEntryId::kBookmarks);
   EXPECT_NE(nullptr, side_panel->GetHeaderView<views::View>());
-  EXPECT_EQ(flat_top, ExpectedContentCorners(side_panel, prefs));
+  EXPECT_EQ(flat_top, ExpectedContentCorners(side_panel, browser()));
   ExpectContentChildLayerCorners(side_panel, flat_top);
 
   // CustomizeChrome has no Brave header → all corners must be round.
   panel_ui->Show(SidePanelEntryId::kCustomizeChrome);
   wait_for_entry(SidePanelEntryId::kCustomizeChrome);
   EXPECT_EQ(nullptr, side_panel->GetHeaderView<views::View>());
-  EXPECT_EQ(all_round, ExpectedContentCorners(side_panel, prefs));
+  EXPECT_EQ(all_round, ExpectedContentCorners(side_panel, browser()));
   ExpectContentChildLayerCorners(side_panel, all_round);
 
   // Back to bookmarks → flat top again.
   panel_ui->Show(SidePanelEntryId::kBookmarks);
   wait_for_entry(SidePanelEntryId::kBookmarks);
   EXPECT_NE(nullptr, side_panel->GetHeaderView<views::View>());
-  EXPECT_EQ(flat_top, ExpectedContentCorners(side_panel, prefs));
+  EXPECT_EQ(flat_top, ExpectedContentCorners(side_panel, browser()));
   ExpectContentChildLayerCorners(side_panel, flat_top);
 
   // (b) Pref change while panel is open ---------------------------------
 
   // Pref OFF: no corners regardless of header (UpdateBorder() path).
   prefs->SetBoolean(kWebViewRoundedCorners, false);
-  EXPECT_EQ(none, ExpectedContentCorners(side_panel, prefs));
+  EXPECT_EQ(none, ExpectedContentCorners(side_panel, browser()));
   ExpectContentChildLayerCorners(side_panel, none);
 
   // Pref ON again: flat top (bookmarks has header).
   prefs->SetBoolean(kWebViewRoundedCorners, true);
-  EXPECT_EQ(flat_top, ExpectedContentCorners(side_panel, prefs));
+  EXPECT_EQ(flat_top, ExpectedContentCorners(side_panel, browser()));
   ExpectContentChildLayerCorners(side_panel, flat_top);
 
   // (c) Panel reopened after pref changed while closed ------------------
@@ -2284,8 +2288,108 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest,
   // Reopen — Open() must re-apply corners with the new pref value.
   panel_ui->Show(SidePanelEntryId::kBookmarks);
   wait_for_entry(SidePanelEntryId::kBookmarks);
-  EXPECT_EQ(none, ExpectedContentCorners(side_panel, prefs));
+  EXPECT_EQ(none, ExpectedContentCorners(side_panel, browser()));
   ExpectContentChildLayerCorners(side_panel, none);
+}
+
+// Verifies GetPanelContentsRoundedCorners() across all four conditions
+// introduced by the commit that added sidebar-visibility and alignment logic:
+//   - Pref disabled → always empty.
+//   - Sidebar visible → regular radius (sidebar sits between panel and window).
+//   - Sidebar hidden, panel right → lower-right gets window-corner radius.
+//   - Sidebar hidden, panel left  → lower-left  gets window-corner radius.
+IN_PROC_BROWSER_TEST_F(SidebarBrowserTest,
+                       SidebarV2GetPanelContentsRoundedCorners) {
+  auto* prefs = browser()->profile()->GetPrefs();
+  auto* service = SidebarServiceFactory::GetForProfile(browser()->profile());
+
+  const int r = views::LayoutProvider::Get()->GetCornerRadiusMetric(
+      kRoundedCornersBorderRadius);
+  const int rw = views::LayoutProvider::Get()->GetCornerRadiusMetric(
+      kRoundedCornersBorderRadiusAtWindowCorner);
+
+  // Pref disabled → always empty regardless of sidebar state.
+  prefs->SetBoolean(kWebViewRoundedCorners, false);
+  EXPECT_EQ(gfx::RoundedCornersF(),
+            brave::GetPanelContentsRoundedCorners(browser(), false));
+  EXPECT_EQ(gfx::RoundedCornersF(),
+            brave::GetPanelContentsRoundedCorners(browser(), true));
+
+  // Sidebar visible (kShowAlways from PreRunTestOnMainThread): regular radius.
+  prefs->SetBoolean(kWebViewRoundedCorners, true);
+  ASSERT_TRUE(browser_view()->IsSidebarVisible());
+  EXPECT_EQ(gfx::RoundedCornersF(r),
+            brave::GetPanelContentsRoundedCorners(browser(), false));
+  EXPECT_EQ(gfx::RoundedCornersF(0, 0, r, r),
+            brave::GetPanelContentsRoundedCorners(browser(), true));
+
+  // Sidebar hidden: panel is flush with the window edge.
+  service->SetSidebarShowOption(SidebarService::ShowSidebarOption::kShowNever);
+  ASSERT_TRUE(base::test::RunUntil(
+      [&]() { return !browser_view()->IsSidebarVisible(); }));
+
+  // Panel on right (default): lower-right corner is the window corner.
+  ASSERT_TRUE(prefs->GetBoolean(prefs::kSidePanelHorizontalAlignment));
+  EXPECT_EQ(gfx::RoundedCornersF(r, r, rw, r),
+            brave::GetPanelContentsRoundedCorners(browser(), false));
+  EXPECT_EQ(gfx::RoundedCornersF(0, 0, rw, r),
+            brave::GetPanelContentsRoundedCorners(browser(), true));
+
+  // Panel on left: lower-left corner is the window corner.
+  prefs->SetBoolean(prefs::kSidePanelHorizontalAlignment, false);
+  EXPECT_EQ(gfx::RoundedCornersF(r, r, r, rw),
+            brave::GetPanelContentsRoundedCorners(browser(), false));
+  EXPECT_EQ(gfx::RoundedCornersF(0, 0, r, rw),
+            brave::GetPanelContentsRoundedCorners(browser(), true));
+}
+
+// Verify that toggling the sidebar UI's visibility while a panel is open
+// re-applies the panel's content corners. SidebarContainerView runs a
+// visibility-changed callback (wired to BraveBrowserView::UpdateBorder() on the
+// panel), so the bottom inner corner flips between the regular radius (sidebar
+// visible) and the window-corner radius (sidebar hidden, panel flush with the
+// window edge) without any other trigger. Between assertions only the sidebar
+// visibility changes — pref, header, and alignment stay fixed — so a corner
+// change proves the callback path fired.
+IN_PROC_BROWSER_TEST_F(SidebarBrowserTest,
+                       SidebarV2ContentCornersFollowSidebarVisibility) {
+  auto* panel_ui = browser()->GetFeatures().side_panel_ui();
+  auto* side_panel = browser_view()->side_panel();
+  auto* prefs = browser()->profile()->GetPrefs();
+  auto* service = SidebarServiceFactory::GetForProfile(browser()->profile());
+  side_panel->DisableAnimationsForTesting();
+  prefs->SetBoolean(kWebViewRoundedCorners, true);
+
+  const int r = views::LayoutProvider::Get()->GetCornerRadiusMetric(
+      kRoundedCornersBorderRadius);
+  const int rw = views::LayoutProvider::Get()->GetCornerRadiusMetric(
+      kRoundedCornersBorderRadiusAtWindowCorner);
+
+  // Open a panel with a Brave header (top corners flat). Default right-aligned,
+  // so the lower-right corner is the one affected by sidebar visibility.
+  ASSERT_TRUE(prefs->GetBoolean(prefs::kSidePanelHorizontalAlignment));
+  panel_ui->Show(SidePanelEntryId::kBookmarks);
+  ASSERT_TRUE(base::test::RunUntil([&]() {
+    return panel_ui->IsSidePanelEntryShowing(
+        SidePanelEntry::Key(SidePanelEntryId::kBookmarks));
+  }));
+
+  // Sidebar visible (kShowAlways default): lower-right uses the regular radius.
+  ASSERT_TRUE(browser_view()->IsSidebarVisible());
+  ExpectContentChildLayerCorners(side_panel, gfx::RoundedCornersF(0, 0, r, r));
+
+  // Hide the sidebar UI: the callback must drive UpdateBorder() so the panel's
+  // lower-right corner becomes the window-corner radius.
+  service->SetSidebarShowOption(SidebarService::ShowSidebarOption::kShowNever);
+  ASSERT_TRUE(base::test::RunUntil(
+      [&]() { return !browser_view()->IsSidebarVisible(); }));
+  ExpectContentChildLayerCorners(side_panel, gfx::RoundedCornersF(0, 0, rw, r));
+
+  // Show the sidebar UI again: lower-right returns to the regular radius.
+  service->SetSidebarShowOption(SidebarService::ShowSidebarOption::kShowAlways);
+  ASSERT_TRUE(base::test::RunUntil(
+      [&]() { return browser_view()->IsSidebarVisible(); }));
+  ExpectContentChildLayerCorners(side_panel, gfx::RoundedCornersF(0, 0, r, r));
 }
 
 // Verify that the resize area is positioned correctly for both border states.

--- a/browser/ui/sidebar/sidebar_browsertest.cc
+++ b/browser/ui/sidebar/sidebar_browsertest.cc
@@ -2316,12 +2316,12 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest,
         SidePanelEntry::Key(SidePanelEntryId::kBookmarks));
   }));
 
-  // Asserts both the computed corners and the corners applied to content layers.
+  // Asserts both the computed corners and the corners applied to content
+  // layers.
   auto expect_corners = [&](const gfx::RoundedCornersF& expected,
                             const base::Location& loc = FROM_HERE) {
     SCOPED_TRACE(loc.ToString());
-    EXPECT_EQ(expected,
-              brave::GetPanelContentsRoundedCorners(browser_view()));
+    EXPECT_EQ(expected, brave::GetPanelContentsRoundedCorners(browser_view()));
     ExpectContentChildLayerCorners(side_panel, expected);
   };
 

--- a/browser/ui/sidebar/sidebar_browsertest.cc
+++ b/browser/ui/sidebar/sidebar_browsertest.cc
@@ -2190,14 +2190,6 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, SidebarV2BraveHeaderTest) {
 
 namespace {
 
-// Returns the corners that GetRoundedCorners() inside ContentParentView would
-// compute for the panel's current header and browser state.
-gfx::RoundedCornersF ExpectedContentCorners(SidePanel* panel,
-                                            BrowserWindowInterface* browser) {
-  return brave::GetPanelContentsRoundedCorners(
-      browser, panel->GetHeaderView<views::View>() != nullptr);
-}
-
 // Asserts layer-backed content children carry the expected corner radii.
 // Children without compositor layers (the typical WebView holder path) are
 // silently skipped; their corners can't be observed via public API.
@@ -2247,33 +2239,33 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest,
   panel_ui->Show(SidePanelEntryId::kBookmarks);
   wait_for_entry(SidePanelEntryId::kBookmarks);
   EXPECT_NE(nullptr, side_panel->GetHeaderView<views::View>());
-  EXPECT_EQ(flat_top, ExpectedContentCorners(side_panel, browser()));
+  EXPECT_EQ(flat_top, brave::GetPanelContentsRoundedCorners(browser_view()));
   ExpectContentChildLayerCorners(side_panel, flat_top);
 
   // CustomizeChrome has no Brave header → all corners must be round.
   panel_ui->Show(SidePanelEntryId::kCustomizeChrome);
   wait_for_entry(SidePanelEntryId::kCustomizeChrome);
   EXPECT_EQ(nullptr, side_panel->GetHeaderView<views::View>());
-  EXPECT_EQ(all_round, ExpectedContentCorners(side_panel, browser()));
+  EXPECT_EQ(all_round, brave::GetPanelContentsRoundedCorners(browser_view()));
   ExpectContentChildLayerCorners(side_panel, all_round);
 
   // Back to bookmarks → flat top again.
   panel_ui->Show(SidePanelEntryId::kBookmarks);
   wait_for_entry(SidePanelEntryId::kBookmarks);
   EXPECT_NE(nullptr, side_panel->GetHeaderView<views::View>());
-  EXPECT_EQ(flat_top, ExpectedContentCorners(side_panel, browser()));
+  EXPECT_EQ(flat_top, brave::GetPanelContentsRoundedCorners(browser_view()));
   ExpectContentChildLayerCorners(side_panel, flat_top);
 
   // (b) Pref change while panel is open ---------------------------------
 
   // Pref OFF: no corners regardless of header (UpdateBorder() path).
   prefs->SetBoolean(kWebViewRoundedCorners, false);
-  EXPECT_EQ(none, ExpectedContentCorners(side_panel, browser()));
+  EXPECT_EQ(none, brave::GetPanelContentsRoundedCorners(browser_view()));
   ExpectContentChildLayerCorners(side_panel, none);
 
   // Pref ON again: flat top (bookmarks has header).
   prefs->SetBoolean(kWebViewRoundedCorners, true);
-  EXPECT_EQ(flat_top, ExpectedContentCorners(side_panel, browser()));
+  EXPECT_EQ(flat_top, brave::GetPanelContentsRoundedCorners(browser_view()));
   ExpectContentChildLayerCorners(side_panel, flat_top);
 
   // (c) Panel reopened after pref changed while closed ------------------
@@ -2288,69 +2280,20 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest,
   // Reopen — Open() must re-apply corners with the new pref value.
   panel_ui->Show(SidePanelEntryId::kBookmarks);
   wait_for_entry(SidePanelEntryId::kBookmarks);
-  EXPECT_EQ(none, ExpectedContentCorners(side_panel, browser()));
+  EXPECT_EQ(none, brave::GetPanelContentsRoundedCorners(browser_view()));
   ExpectContentChildLayerCorners(side_panel, none);
-}
-
-// Verifies GetPanelContentsRoundedCorners() across all four conditions
-// introduced by the commit that added sidebar-visibility and alignment logic:
-//   - Pref disabled → always empty.
-//   - Sidebar visible → regular radius (sidebar sits between panel and window).
-//   - Sidebar hidden, panel right → lower-right gets window-corner radius.
-//   - Sidebar hidden, panel left  → lower-left  gets window-corner radius.
-IN_PROC_BROWSER_TEST_F(SidebarBrowserTest,
-                       SidebarV2GetPanelContentsRoundedCorners) {
-  auto* prefs = browser()->profile()->GetPrefs();
-  auto* service = SidebarServiceFactory::GetForProfile(browser()->profile());
-
-  const int r = views::LayoutProvider::Get()->GetCornerRadiusMetric(
-      kRoundedCornersBorderRadius);
-  const int rw = views::LayoutProvider::Get()->GetCornerRadiusMetric(
-      kRoundedCornersBorderRadiusAtWindowCorner);
-
-  // Pref disabled → always empty regardless of sidebar state.
-  prefs->SetBoolean(kWebViewRoundedCorners, false);
-  EXPECT_EQ(gfx::RoundedCornersF(),
-            brave::GetPanelContentsRoundedCorners(browser(), false));
-  EXPECT_EQ(gfx::RoundedCornersF(),
-            brave::GetPanelContentsRoundedCorners(browser(), true));
-
-  // Sidebar visible (kShowAlways from PreRunTestOnMainThread): regular radius.
-  prefs->SetBoolean(kWebViewRoundedCorners, true);
-  ASSERT_TRUE(browser_view()->IsSidebarVisible());
-  EXPECT_EQ(gfx::RoundedCornersF(r),
-            brave::GetPanelContentsRoundedCorners(browser(), false));
-  EXPECT_EQ(gfx::RoundedCornersF(0, 0, r, r),
-            brave::GetPanelContentsRoundedCorners(browser(), true));
-
-  // Sidebar hidden: panel is flush with the window edge.
-  service->SetSidebarShowOption(SidebarService::ShowSidebarOption::kShowNever);
-  ASSERT_TRUE(base::test::RunUntil(
-      [&]() { return !browser_view()->IsSidebarVisible(); }));
-
-  // Panel on right (default): lower-right corner is the window corner.
-  ASSERT_TRUE(prefs->GetBoolean(prefs::kSidePanelHorizontalAlignment));
-  EXPECT_EQ(gfx::RoundedCornersF(r, r, rw, r),
-            brave::GetPanelContentsRoundedCorners(browser(), false));
-  EXPECT_EQ(gfx::RoundedCornersF(0, 0, rw, r),
-            brave::GetPanelContentsRoundedCorners(browser(), true));
-
-  // Panel on left: lower-left corner is the window corner.
-  prefs->SetBoolean(prefs::kSidePanelHorizontalAlignment, false);
-  EXPECT_EQ(gfx::RoundedCornersF(r, r, r, rw),
-            brave::GetPanelContentsRoundedCorners(browser(), false));
-  EXPECT_EQ(gfx::RoundedCornersF(0, 0, r, rw),
-            brave::GetPanelContentsRoundedCorners(browser(), true));
 }
 
 // Verify that toggling the sidebar UI's visibility while a panel is open
 // re-applies the panel's content corners. SidebarContainerView runs a
 // visibility-changed callback (wired to BraveBrowserView::UpdateBorder() on the
-// panel), so the bottom inner corner flips between the regular radius (sidebar
+// panel), so the inner bottom corner flips between the regular radius (sidebar
 // visible) and the window-corner radius (sidebar hidden, panel flush with the
-// window edge) without any other trigger. Between assertions only the sidebar
-// visibility changes — pref, header, and alignment stay fixed — so a corner
-// change proves the callback path fired.
+// window edge) without any other trigger. The inner bottom corner is the
+// lower-right for a right-aligned panel and the lower-left for a left-aligned
+// panel, so the cycle is exercised under both alignments. Each step checks both
+// the helper's computed corners and the corners actually applied to the content
+// child layers.
 IN_PROC_BROWSER_TEST_F(SidebarBrowserTest,
                        SidebarV2ContentCornersFollowSidebarVisibility) {
   auto* panel_ui = browser()->GetFeatures().side_panel_ui();
@@ -2365,31 +2308,61 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest,
   const int rw = views::LayoutProvider::Get()->GetCornerRadiusMetric(
       kRoundedCornersBorderRadiusAtWindowCorner);
 
-  // Open a panel with a Brave header (top corners flat). Default right-aligned,
-  // so the lower-right corner is the one affected by sidebar visibility.
-  ASSERT_TRUE(prefs->GetBoolean(prefs::kSidePanelHorizontalAlignment));
+  // Open a panel with a Brave header, so the top corners are flat and only the
+  // inner bottom corner varies with sidebar visibility.
   panel_ui->Show(SidePanelEntryId::kBookmarks);
   ASSERT_TRUE(base::test::RunUntil([&]() {
     return panel_ui->IsSidePanelEntryShowing(
         SidePanelEntry::Key(SidePanelEntryId::kBookmarks));
   }));
 
-  // Sidebar visible (kShowAlways default): lower-right uses the regular radius.
-  ASSERT_TRUE(browser_view()->IsSidebarVisible());
-  ExpectContentChildLayerCorners(side_panel, gfx::RoundedCornersF(0, 0, r, r));
+  // Asserts both the computed corners and the corners applied to content layers.
+  auto expect_corners = [&](const gfx::RoundedCornersF& expected,
+                            const base::Location& loc = FROM_HERE) {
+    SCOPED_TRACE(loc.ToString());
+    EXPECT_EQ(expected,
+              brave::GetPanelContentsRoundedCorners(browser_view()));
+    ExpectContentChildLayerCorners(side_panel, expected);
+  };
 
-  // Hide the sidebar UI: the callback must drive UpdateBorder() so the panel's
-  // lower-right corner becomes the window-corner radius.
-  service->SetSidebarShowOption(SidebarService::ShowSidebarOption::kShowNever);
-  ASSERT_TRUE(base::test::RunUntil(
-      [&]() { return !browser_view()->IsSidebarVisible(); }));
-  ExpectContentChildLayerCorners(side_panel, gfx::RoundedCornersF(0, 0, rw, r));
+  // Sidebar visible: the inner bottom corner uses the regular radius regardless
+  // of alignment.
+  const gfx::RoundedCornersF visible(0, 0, r, r);
+  struct Case {
+    bool right_aligned;
+    gfx::RoundedCornersF hidden;  // inner bottom corner is the window corner.
+  };
+  const Case cases[] = {
+      {true, gfx::RoundedCornersF(0, 0, rw, r)},   // right → lower-right.
+      {false, gfx::RoundedCornersF(0, 0, r, rw)},  // left  → lower-left.
+  };
 
-  // Show the sidebar UI again: lower-right returns to the regular radius.
-  service->SetSidebarShowOption(SidebarService::ShowSidebarOption::kShowAlways);
-  ASSERT_TRUE(base::test::RunUntil(
-      [&]() { return browser_view()->IsSidebarVisible(); }));
-  ExpectContentChildLayerCorners(side_panel, gfx::RoundedCornersF(0, 0, r, r));
+  for (const auto& c : cases) {
+    SCOPED_TRACE(c.right_aligned ? "right-aligned" : "left-aligned");
+    prefs->SetBoolean(prefs::kSidePanelHorizontalAlignment, c.right_aligned);
+
+    // Sidebar visible (kShowAlways): regular radius.
+    service->SetSidebarShowOption(
+        SidebarService::ShowSidebarOption::kShowAlways);
+    ASSERT_TRUE(base::test::RunUntil(
+        [&]() { return browser_view()->IsSidebarVisible(); }));
+    expect_corners(visible);
+
+    // Hide the sidebar UI: the callback must drive UpdateBorder() so the inner
+    // bottom corner becomes the window-corner radius.
+    service->SetSidebarShowOption(
+        SidebarService::ShowSidebarOption::kShowNever);
+    ASSERT_TRUE(base::test::RunUntil(
+        [&]() { return !browser_view()->IsSidebarVisible(); }));
+    expect_corners(c.hidden);
+
+    // Show the sidebar UI again: back to the regular radius.
+    service->SetSidebarShowOption(
+        SidebarService::ShowSidebarOption::kShowAlways);
+    ASSERT_TRUE(base::test::RunUntil(
+        [&]() { return browser_view()->IsSidebarVisible(); }));
+    expect_corners(visible);
+  }
 }
 
 // Verify that the resize area is positioned correctly for both border states.

--- a/browser/ui/views/frame/brave_browser_view.cc
+++ b/browser/ui/views/frame/brave_browser_view.cc
@@ -368,13 +368,15 @@ BraveBrowserView::BraveBrowserView(Browser* browser) : BrowserView(browser) {
           AddChildView(std::make_unique<SidebarContainerView>(
               browser_, SidePanelCoordinator::From(browser_), nullptr));
 #if BUILDFLAG(ENABLE_SIDEBAR_V2)
-      // Recompute the panel's content corners whenever the sidebar UI shows or
-      // hides, since the bottom corner radius depends on sidebar visibility.
-      // Unretained() is safe: `this` owns `sidebar_container_view_` (added via
-      // AddChildView), so the container cannot outlive the callback target.
-      sidebar_container_view_->SetSidebarVisibilityChangedCallback(
-          base::BindRepeating(&BraveBrowserView::OnSidebarVisibilityChanged,
-                              base::Unretained(this)));
+      // Recompute the panel's content corners whenever the sidebar control view
+      // shows or hides, since the bottom corner radius depends on sidebar
+      // control view visibility. Unretained() is safe: `this` owns
+      // `sidebar_container_view_` (added via AddChildView), so the container
+      // cannot outlive the callback target.
+      sidebar_container_view_->SetSidebarControlViewVisibilityChangedCallback(
+          base::BindRepeating(
+              &BraveBrowserView::OnSidebarControlViewVisibilityChanged,
+              base::Unretained(this)));
 
       side_panel_->SetResizeArea(
           std::make_unique<views::BraveSidePanelResizeArea>(side_panel_));
@@ -1159,9 +1161,9 @@ void BraveBrowserView::UpdateSidebarBorder() {
 }
 
 #if BUILDFLAG(ENABLE_SIDEBAR_V2)
-void BraveBrowserView::OnSidebarVisibilityChanged() {
-  // The panel's content corner radii depend on whether the sidebar UI is
-  // visible (see brave::GetPanelContentsRoundedCorners()), so re-apply the
+void BraveBrowserView::OnSidebarControlViewVisibilityChanged() {
+  // The panel's content corner radii depend on whether the sidebar control view
+  // is visible (see brave::GetPanelContentsRoundedCorners()), so re-apply the
   // border to recompute them.
   if (side_panel_) {
     side_panel_->UpdateBorder();

--- a/browser/ui/views/frame/brave_browser_view.cc
+++ b/browser/ui/views/frame/brave_browser_view.cc
@@ -368,6 +368,14 @@ BraveBrowserView::BraveBrowserView(Browser* browser) : BrowserView(browser) {
           AddChildView(std::make_unique<SidebarContainerView>(
               browser_, SidePanelCoordinator::From(browser_), nullptr));
 #if BUILDFLAG(ENABLE_SIDEBAR_V2)
+      // Recompute the panel's content corners whenever the sidebar UI shows or
+      // hides, since the bottom corner radius depends on sidebar visibility.
+      // Unretained() is safe: `this` owns `sidebar_container_view_` (added via
+      // AddChildView), so the container cannot outlive the callback target.
+      sidebar_container_view_->SetSidebarVisibilityChangedCallback(
+          base::BindRepeating(&BraveBrowserView::OnSidebarVisibilityChanged,
+                              base::Unretained(this)));
+
       side_panel_->SetResizeArea(
           std::make_unique<views::BraveSidePanelResizeArea>(side_panel_));
 
@@ -1134,6 +1142,7 @@ void BraveBrowserView::UpdateSidebarBorder() {
   if (side_panel_) {
     side_panel_->SetRoundedBorderEnabled(
         ShouldUseBraveWebViewRoundedCornersForContents(browser_));
+    side_panel_->UpdateBorder();
   }
   if (side_panel_shadow_overlay_) {
     side_panel_shadow_overlay_->UpdateShadowVisibility();
@@ -1150,6 +1159,15 @@ void BraveBrowserView::UpdateSidebarBorder() {
 }
 
 #if BUILDFLAG(ENABLE_SIDEBAR_V2)
+void BraveBrowserView::OnSidebarVisibilityChanged() {
+  // The panel's content corner radii depend on whether the sidebar UI is
+  // visible (see brave::GetPanelContentsRoundedCorners()), so re-apply the
+  // border to recompute them.
+  if (side_panel_) {
+    side_panel_->UpdateBorder();
+  }
+}
+
 views::View* BraveBrowserView::side_panel_shadow_overlay_for_testing() {
   return side_panel_shadow_overlay_.get();
 }

--- a/browser/ui/views/frame/brave_browser_view.h
+++ b/browser/ui/views/frame/brave_browser_view.h
@@ -170,9 +170,9 @@ class BraveBrowserView : public BrowserView,
 
 #if BUILDFLAG(ENABLE_SIDEBAR_V2)
   // Re-applies the side panel border so the content corner radii track the
-  // sidebar UI's visibility. Wired as SidebarContainerView's visibility-changed
-  // callback.
-  void OnSidebarVisibilityChanged();
+  // sidebar control view's visibility. Wired as SidebarContainerView's
+  // control-view-visibility-changed callback.
+  void OnSidebarControlViewVisibilityChanged();
 #endif
 
   SidebarContainerView* sidebar_container_view() {

--- a/browser/ui/views/frame/brave_browser_view.h
+++ b/browser/ui/views/frame/brave_browser_view.h
@@ -168,6 +168,13 @@ class BraveBrowserView : public BrowserView,
   void UpdateVerticalTabStripBorder();
   void UpdateSidebarBorder();
 
+#if BUILDFLAG(ENABLE_SIDEBAR_V2)
+  // Re-applies the side panel border so the content corner radii track the
+  // sidebar UI's visibility. Wired as SidebarContainerView's visibility-changed
+  // callback.
+  void OnSidebarVisibilityChanged();
+#endif
+
   SidebarContainerView* sidebar_container_view() {
     return sidebar_container_view_;
   }

--- a/browser/ui/views/side_panel/side_panel_utils.cc
+++ b/browser/ui/views/side_panel/side_panel_utils.cc
@@ -5,10 +5,17 @@
 
 #include "brave/browser/ui/views/side_panel/side_panel_utils.h"
 
+#include "brave/browser/ui/views/frame/brave_browser_view.h"
 #include "brave/common/pref_names.h"
+#include "chrome/browser/ui/browser_window/public/browser_window_interface.h"
 #include "chrome/browser/ui/views/chrome_layout_provider.h"
+#include "chrome/common/pref_names.h"
 #include "components/prefs/pref_service.h"
 #include "ui/views/layout/layout_provider.h"
+
+using views::ShapeContextTokensOverride::kRoundedCornersBorderRadius;
+using views::ShapeContextTokensOverride::
+    kRoundedCornersBorderRadiusAtWindowCorner;
 
 namespace brave {
 
@@ -17,25 +24,54 @@ bool ShouldShowSidePanelHeader(SidePanelEntryId id) {
          id == SidePanelEntryId::kBookmarks;
 }
 
-gfx::RoundedCornersF GetPanelContentsRoundedCorners(PrefService* prefs,
-                                                    bool has_header) {
-  // When Brave's rounded corners are off, the panel has no rounded border, so
-  // the content shouldn't be rounded either.
-  if (!prefs->GetBoolean(kWebViewRoundedCorners)) {
+gfx::RoundedCornersF GetPanelContentsRoundedCorners(
+    BrowserWindowInterface* browser_window_interface,
+    bool has_header) {
+  auto* prefs = browser_window_interface->GetProfile()->GetPrefs();
+  auto* browser_view = BraveBrowserView::From(
+      BrowserView::GetBrowserViewForBrowser(browser_window_interface));
+
+  // Can null during the startup.
+  if (!browser_view || !prefs->GetBoolean(kWebViewRoundedCorners)) {
     return gfx::RoundedCornersF();
   }
 
-  gfx::RoundedCornersF radii(views::LayoutProvider::Get()->GetDistanceMetric(
-      ChromeDistanceMetric::DISTANCE_SIDE_PANEL_CONTENT_RADIUS));
+  auto* layout_provider = views::LayoutProvider::Get();
+  gfx::RoundedCornersF rounded_corners(
+      layout_provider->GetCornerRadiusMetric(kRoundedCornersBorderRadius));
 
   // When a Brave header is attached it paints the rounded top, so flatten the
   // content's top corners to avoid double-rounding.
   if (has_header) {
-    radii.set_upper_left(0);
-    radii.set_upper_right(0);
+    rounded_corners.set_upper_left(0);
+    rounded_corners.set_upper_right(0);
   }
 
-  return radii;
+  // When the sidebar is visible it sits between the panel and the window edge,
+  // so the panel's bottom corner is not a window corner — use regular radius.
+  if (browser_view->IsSidebarVisible()) {
+    return rounded_corners;
+  }
+
+  // When the sidebar is hidden the panel touches the window edge directly. The
+  // inner bottom corner (lower-right for a right-aligned panel, lower-left for
+  // a left-aligned panel) is the window corner and must use the larger
+  // window-corner radius.
+  const auto rounded_corners_border_radius_at_window_corner =
+      layout_provider->GetCornerRadiusMetric(
+          kRoundedCornersBorderRadiusAtWindowCorner);
+
+  const bool panel_on_right =
+      prefs->GetBoolean(prefs::kSidePanelHorizontalAlignment);
+  if (panel_on_right) {
+    rounded_corners.set_lower_right(
+        rounded_corners_border_radius_at_window_corner);
+  } else {
+    rounded_corners.set_lower_left(
+        rounded_corners_border_radius_at_window_corner);
+  }
+
+  return rounded_corners;
 }
 
 }  // namespace brave

--- a/browser/ui/views/side_panel/side_panel_utils.cc
+++ b/browser/ui/views/side_panel/side_panel_utils.cc
@@ -7,11 +7,11 @@
 
 #include "brave/browser/ui/views/frame/brave_browser_view.h"
 #include "brave/common/pref_names.h"
-#include "chrome/browser/ui/browser_window/public/browser_window_interface.h"
-#include "chrome/browser/ui/views/chrome_layout_provider.h"
+#include "chrome/browser/ui/views/side_panel/side_panel.h"
 #include "chrome/common/pref_names.h"
 #include "components/prefs/pref_service.h"
 #include "ui/views/layout/layout_provider.h"
+#include "ui/views/view.h"
 
 using views::ShapeContextTokensOverride::kRoundedCornersBorderRadius;
 using views::ShapeContextTokensOverride::
@@ -24,15 +24,16 @@ bool ShouldShowSidePanelHeader(SidePanelEntryId id) {
          id == SidePanelEntryId::kBookmarks;
 }
 
-gfx::RoundedCornersF GetPanelContentsRoundedCorners(
-    BrowserWindowInterface* browser_window_interface,
-    bool has_header) {
-  auto* prefs = browser_window_interface->GetProfile()->GetPrefs();
-  auto* browser_view = BraveBrowserView::From(
-      BrowserView::GetBrowserViewForBrowser(browser_window_interface));
+gfx::RoundedCornersF GetPanelContentsRoundedCorners(BrowserView* browser_view) {
+  auto* brave_browser_view = BraveBrowserView::From(browser_view);
+  CHECK(brave_browser_view);
+  auto* prefs = brave_browser_view->GetProfile()->GetPrefs();
+  const bool has_header =
+      browser_view->side_panel()->GetHeaderView<views::View>() != nullptr;
 
-  // Can null during the startup.
-  if (!browser_view || !prefs->GetBoolean(kWebViewRoundedCorners)) {
+  // When Brave's rounded corners are off, the panel has no rounded border, so
+  // the content shouldn't be rounded either.
+  if (!prefs->GetBoolean(kWebViewRoundedCorners)) {
     return gfx::RoundedCornersF();
   }
 
@@ -49,7 +50,7 @@ gfx::RoundedCornersF GetPanelContentsRoundedCorners(
 
   // When the sidebar is visible it sits between the panel and the window edge,
   // so the panel's bottom corner is not a window corner — use regular radius.
-  if (browser_view->IsSidebarVisible()) {
+  if (brave_browser_view->IsSidebarVisible()) {
     return rounded_corners;
   }
 
@@ -57,7 +58,7 @@ gfx::RoundedCornersF GetPanelContentsRoundedCorners(
   // inner bottom corner (lower-right for a right-aligned panel, lower-left for
   // a left-aligned panel) is the window corner and must use the larger
   // window-corner radius.
-  const auto rounded_corners_border_radius_at_window_corner =
+  const int rounded_corners_border_radius_at_window_corner =
       layout_provider->GetCornerRadiusMetric(
           kRoundedCornersBorderRadiusAtWindowCorner);
 

--- a/browser/ui/views/side_panel/side_panel_utils.h
+++ b/browser/ui/views/side_panel/side_panel_utils.h
@@ -9,19 +9,18 @@
 #include "chrome/browser/ui/side_panel/side_panel_entry_id.h"
 #include "ui/gfx/geometry/rounded_corners_f.h"
 
-class BrowserWindowInterface;
+class BrowserView;
 
 namespace brave {
 
 // Returns the rounded corners for the web content hosted inside the side panel.
-// Returns empty corners when Brave's rounded corners are disabled. When
-// `has_header` is true the Brave header owns the top rounding, so the
-// content's top corners are flattened to avoid double-rounding. The bottom
-// inner corner uses the window-corner radius when the sidebar is hidden (the
-// panel is flush with the window edge) and the regular radius otherwise.
-gfx::RoundedCornersF GetPanelContentsRoundedCorners(
-    BrowserWindowInterface* browser_window_interface,
-    bool has_header);
+// Returns empty corners when Brave's rounded corners are disabled. When the side
+// panel has a Brave header attached it owns the top rounding, so the content's
+// top corners are flattened to avoid double-rounding. The bottom inner corner
+// uses the window-corner radius when the sidebar is hidden (the panel is flush
+// with the window edge) and the regular radius otherwise. The header state and
+// prefs are read from `browser_view` (and its side panel).
+gfx::RoundedCornersF GetPanelContentsRoundedCorners(BrowserView* browser_view);
 
 // Returns true when the entry with `id` should show Brave's custom side panel
 // header view.

--- a/browser/ui/views/side_panel/side_panel_utils.h
+++ b/browser/ui/views/side_panel/side_panel_utils.h
@@ -9,16 +9,19 @@
 #include "chrome/browser/ui/side_panel/side_panel_entry_id.h"
 #include "ui/gfx/geometry/rounded_corners_f.h"
 
-class PrefService;
+class BrowserWindowInterface;
 
 namespace brave {
 
 // Returns the rounded corners for the web content hosted inside the side panel.
 // Returns empty corners when Brave's rounded corners are disabled. When
 // `has_header` is true the Brave header owns the top rounding, so the
-// content's top corners are flattened to avoid double-rounding.
-gfx::RoundedCornersF GetPanelContentsRoundedCorners(PrefService* prefs,
-                                                    bool has_header);
+// content's top corners are flattened to avoid double-rounding. The bottom
+// inner corner uses the window-corner radius when the sidebar is hidden (the
+// panel is flush with the window edge) and the regular radius otherwise.
+gfx::RoundedCornersF GetPanelContentsRoundedCorners(
+    BrowserWindowInterface* browser_window_interface,
+    bool has_header);
 
 // Returns true when the entry with `id` should show Brave's custom side panel
 // header view.

--- a/browser/ui/views/side_panel/side_panel_utils.h
+++ b/browser/ui/views/side_panel/side_panel_utils.h
@@ -14,12 +14,12 @@ class BrowserView;
 namespace brave {
 
 // Returns the rounded corners for the web content hosted inside the side panel.
-// Returns empty corners when Brave's rounded corners are disabled. When the side
-// panel has a Brave header attached it owns the top rounding, so the content's
-// top corners are flattened to avoid double-rounding. The bottom inner corner
-// uses the window-corner radius when the sidebar is hidden (the panel is flush
-// with the window edge) and the regular radius otherwise. The header state and
-// prefs are read from `browser_view` (and its side panel).
+// Returns empty corners when Brave's rounded corners are disabled. When the
+// side panel has a Brave header attached it owns the top rounding, so the
+// content's top corners are flattened to avoid double-rounding. The bottom
+// inner corner uses the window-corner radius when the sidebar is hidden (the
+// panel is flush with the window edge) and the regular radius otherwise. The
+// header state and prefs are read from `browser_view` (and its side panel).
 gfx::RoundedCornersF GetPanelContentsRoundedCorners(BrowserView* browser_view);
 
 // Returns true when the entry with `id` should show Brave's custom side panel

--- a/browser/ui/views/side_panel/side_panel_utils_unittest.cc
+++ b/browser/ui/views/side_panel/side_panel_utils_unittest.cc
@@ -5,67 +5,15 @@
 
 #include "brave/browser/ui/views/side_panel/side_panel_utils.h"
 
-#include <memory>
-
-#include "brave/common/pref_names.h"
-#include "chrome/browser/ui/browser_window/test/mock_browser_window_interface.h"
 #include "chrome/browser/ui/side_panel/side_panel_entry.h"
-#include "chrome/test/base/testing_profile.h"
-#include "chrome/test/views/chrome_views_test_base.h"
-#include "components/prefs/pref_service.h"
-#include "testing/gmock/include/gmock/gmock.h"
 #include "testing/gtest/include/gtest/gtest.h"
-#include "ui/gfx/geometry/rounded_corners_f.h"
-
-using testing::Return;
 
 namespace brave {
 
-class SidePanelUtilsTest : public ChromeViewsTestBase {
- public:
-  void SetUp() override {
-    profile_ = std::make_unique<TestingProfile>();
-    ChromeViewsTestBase::SetUp();
-    ON_CALL(mock_interface_, GetProfile())
-        .WillByDefault(Return(profile_.get()));
-  }
-
-  void TearDown() override {
-    profile_.reset();
-    ChromeViewsTestBase::TearDown();
-  }
-
- protected:
-  PrefService* prefs() { return profile_->GetPrefs(); }
-
-  std::unique_ptr<TestingProfile> profile_;
-  testing::NiceMock<MockBrowserWindowInterface> mock_interface_;
-};
-
-TEST_F(SidePanelUtilsTest, ShouldShowSidePanelHeaderOnlyForBraveEntries) {
+TEST(SidePanelUtilsTest, ShouldShowSidePanelHeaderOnlyForBraveEntries) {
   EXPECT_TRUE(ShouldShowSidePanelHeader(SidePanelEntryId::kReadingList));
   EXPECT_TRUE(ShouldShowSidePanelHeader(SidePanelEntryId::kBookmarks));
   EXPECT_FALSE(ShouldShowSidePanelHeader(SidePanelEntryId::kCustomizeChrome));
-}
-
-// BrowserView::GetBrowserViewForBrowser() returns null in unit-test
-// environments (no real native window). GetPanelContentsRoundedCorners() must
-// return empty corners in that case, matching the null-safety guard for the
-// startup path.
-TEST_F(SidePanelUtilsTest, RoundedCornersEmptyWhenBrowserViewIsNull) {
-  prefs()->SetBoolean(kWebViewRoundedCorners, true);
-  EXPECT_EQ(gfx::RoundedCornersF(),
-            GetPanelContentsRoundedCorners(&mock_interface_, false));
-  EXPECT_EQ(gfx::RoundedCornersF(),
-            GetPanelContentsRoundedCorners(&mock_interface_, true));
-}
-
-TEST_F(SidePanelUtilsTest, RoundedCornersEmptyWhenPrefDisabled) {
-  prefs()->SetBoolean(kWebViewRoundedCorners, false);
-  EXPECT_EQ(gfx::RoundedCornersF(),
-            GetPanelContentsRoundedCorners(&mock_interface_, false));
-  EXPECT_EQ(gfx::RoundedCornersF(),
-            GetPanelContentsRoundedCorners(&mock_interface_, true));
 }
 
 }  // namespace brave

--- a/browser/ui/views/side_panel/side_panel_utils_unittest.cc
+++ b/browser/ui/views/side_panel/side_panel_utils_unittest.cc
@@ -8,14 +8,16 @@
 #include <memory>
 
 #include "brave/common/pref_names.h"
+#include "chrome/browser/ui/browser_window/test/mock_browser_window_interface.h"
 #include "chrome/browser/ui/side_panel/side_panel_entry.h"
-#include "chrome/browser/ui/views/chrome_layout_provider.h"
 #include "chrome/test/base/testing_profile.h"
 #include "chrome/test/views/chrome_views_test_base.h"
 #include "components/prefs/pref_service.h"
+#include "testing/gmock/include/gmock/gmock.h"
 #include "testing/gtest/include/gtest/gtest.h"
 #include "ui/gfx/geometry/rounded_corners_f.h"
-#include "ui/views/layout/layout_provider.h"
+
+using testing::Return;
 
 namespace brave {
 
@@ -24,6 +26,8 @@ class SidePanelUtilsTest : public ChromeViewsTestBase {
   void SetUp() override {
     profile_ = std::make_unique<TestingProfile>();
     ChromeViewsTestBase::SetUp();
+    ON_CALL(mock_interface_, GetProfile())
+        .WillByDefault(Return(profile_.get()));
   }
 
   void TearDown() override {
@@ -34,12 +38,8 @@ class SidePanelUtilsTest : public ChromeViewsTestBase {
  protected:
   PrefService* prefs() { return profile_->GetPrefs(); }
 
-  int ContentRadius() const {
-    return views::LayoutProvider::Get()->GetDistanceMetric(
-        ChromeDistanceMetric::DISTANCE_SIDE_PANEL_CONTENT_RADIUS);
-  }
-
   std::unique_ptr<TestingProfile> profile_;
+  testing::NiceMock<MockBrowserWindowInterface> mock_interface_;
 };
 
 TEST_F(SidePanelUtilsTest, ShouldShowSidePanelHeaderOnlyForBraveEntries) {
@@ -48,25 +48,24 @@ TEST_F(SidePanelUtilsTest, ShouldShowSidePanelHeaderOnlyForBraveEntries) {
   EXPECT_FALSE(ShouldShowSidePanelHeader(SidePanelEntryId::kCustomizeChrome));
 }
 
+// BrowserView::GetBrowserViewForBrowser() returns null in unit-test
+// environments (no real native window). GetPanelContentsRoundedCorners() must
+// return empty corners in that case, matching the null-safety guard for the
+// startup path.
+TEST_F(SidePanelUtilsTest, RoundedCornersEmptyWhenBrowserViewIsNull) {
+  prefs()->SetBoolean(kWebViewRoundedCorners, true);
+  EXPECT_EQ(gfx::RoundedCornersF(),
+            GetPanelContentsRoundedCorners(&mock_interface_, false));
+  EXPECT_EQ(gfx::RoundedCornersF(),
+            GetPanelContentsRoundedCorners(&mock_interface_, true));
+}
+
 TEST_F(SidePanelUtilsTest, RoundedCornersEmptyWhenPrefDisabled) {
   prefs()->SetBoolean(kWebViewRoundedCorners, false);
   EXPECT_EQ(gfx::RoundedCornersF(),
-            GetPanelContentsRoundedCorners(prefs(), false));
+            GetPanelContentsRoundedCorners(&mock_interface_, false));
   EXPECT_EQ(gfx::RoundedCornersF(),
-            GetPanelContentsRoundedCorners(prefs(), true));
-}
-
-TEST_F(SidePanelUtilsTest, RoundedCornersAllCornersWhenNoHeader) {
-  prefs()->SetBoolean(kWebViewRoundedCorners, true);
-  EXPECT_EQ(gfx::RoundedCornersF(ContentRadius()),
-            GetPanelContentsRoundedCorners(prefs(), false));
-}
-
-TEST_F(SidePanelUtilsTest, RoundedCornersFlatTopWhenHasHeader) {
-  prefs()->SetBoolean(kWebViewRoundedCorners, true);
-  const int r = ContentRadius();
-  EXPECT_EQ(gfx::RoundedCornersF(0, 0, r, r),
-            GetPanelContentsRoundedCorners(prefs(), true));
+            GetPanelContentsRoundedCorners(&mock_interface_, true));
 }
 
 }  // namespace brave

--- a/browser/ui/views/sidebar/sidebar_container_view.cc
+++ b/browser/ui/views/sidebar/sidebar_container_view.cc
@@ -203,14 +203,15 @@ bool SidebarContainerView::IsSidebarVisible() const {
   return sidebar_control_view_ && sidebar_control_view_->GetVisible();
 }
 
-void SidebarContainerView::SetSidebarVisibilityChangedCallback(
+void SidebarContainerView::SetSidebarControlViewVisibilityChangedCallback(
     base::RepeatingClosure callback) {
-  sidebar_visibility_changed_callback_ = std::move(callback);
+  sidebar_control_view_visibility_changed_callback_ = std::move(callback);
 }
 
 void SidebarContainerView::ChildVisibilityChanged(views::View* child) {
-  if (child == sidebar_control_view_ && sidebar_visibility_changed_callback_) {
-    sidebar_visibility_changed_callback_.Run();
+  if (child == sidebar_control_view_ &&
+      sidebar_control_view_visibility_changed_callback_) {
+    sidebar_control_view_visibility_changed_callback_.Run();
   }
 }
 

--- a/browser/ui/views/sidebar/sidebar_container_view.cc
+++ b/browser/ui/views/sidebar/sidebar_container_view.cc
@@ -203,6 +203,17 @@ bool SidebarContainerView::IsSidebarVisible() const {
   return sidebar_control_view_ && sidebar_control_view_->GetVisible();
 }
 
+void SidebarContainerView::SetSidebarVisibilityChangedCallback(
+    base::RepeatingClosure callback) {
+  sidebar_visibility_changed_callback_ = std::move(callback);
+}
+
+void SidebarContainerView::ChildVisibilityChanged(views::View* child) {
+  if (child == sidebar_control_view_ && sidebar_visibility_changed_callback_) {
+    sidebar_visibility_changed_callback_.Run();
+  }
+}
+
 void SidebarContainerView::ShowSidebarOnMouseOver(
     const gfx::PointF& point_in_screen) {
   if (IsSidebarVisible()) {

--- a/browser/ui/views/sidebar/sidebar_container_view.h
+++ b/browser/ui/views/sidebar/sidebar_container_view.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <optional>
 
+#include "base/functional/callback.h"
 #include "base/memory/raw_ptr.h"
 #include "base/timer/timer.h"
 #include "brave/browser/ui/sidebar/sidebar.h"
@@ -86,6 +87,11 @@ class SidebarContainerView : public sidebar::Sidebar,
   bool IsFullscreenForCurrentEntry() const;
   void UpdateBorder();
 
+  // Runs `callback` whenever the sidebar control view's visibility changes, so
+  // the side panel can recompute its content corner radii (which depend on
+  // sidebar visibility — see GetPanelContentsRoundedCorners()).
+  void SetSidebarVisibilityChangedCallback(base::RepeatingClosure callback);
+
   void set_operation_from_active_tab_change(bool tab_change) {
     operation_from_active_tab_change_ = tab_change;
   }
@@ -100,6 +106,7 @@ class SidebarContainerView : public sidebar::Sidebar,
   void MenuClosed() override;
 
   // views::View overrides:
+  void ChildVisibilityChanged(views::View* child) override;
   void Layout(PassKey) override;
   gfx::Size CalculatePreferredSize(
       const views::SizeBounds& available_size) const override;
@@ -216,6 +223,7 @@ class SidebarContainerView : public sidebar::Sidebar,
   base::ScopedObservation<sidebar::SidebarModel,
                           sidebar::SidebarModel::Observer>
       sidebar_model_observation_{this};
+  base::RepeatingClosure sidebar_visibility_changed_callback_;
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_SIDEBAR_SIDEBAR_CONTAINER_VIEW_H_

--- a/browser/ui/views/sidebar/sidebar_container_view.h
+++ b/browser/ui/views/sidebar/sidebar_container_view.h
@@ -89,8 +89,9 @@ class SidebarContainerView : public sidebar::Sidebar,
 
   // Runs `callback` whenever the sidebar control view's visibility changes, so
   // the side panel can recompute its content corner radii (which depend on
-  // sidebar visibility — see GetPanelContentsRoundedCorners()).
-  void SetSidebarVisibilityChangedCallback(base::RepeatingClosure callback);
+  // sidebar control view visibility — see GetPanelContentsRoundedCorners()).
+  void SetSidebarControlViewVisibilityChangedCallback(
+      base::RepeatingClosure callback);
 
   void set_operation_from_active_tab_change(bool tab_change) {
     operation_from_active_tab_change_ = tab_change;
@@ -223,7 +224,7 @@ class SidebarContainerView : public sidebar::Sidebar,
   base::ScopedObservation<sidebar::SidebarModel,
                           sidebar::SidebarModel::Observer>
       sidebar_model_observation_{this};
-  base::RepeatingClosure sidebar_visibility_changed_callback_;
+  base::RepeatingClosure sidebar_control_view_visibility_changed_callback_;
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_SIDEBAR_SIDEBAR_CONTAINER_VIEW_H_

--- a/chromium_src/chrome/browser/ui/views/side_panel/side_panel.cc
+++ b/chromium_src/chrome/browser/ui/views/side_panel/side_panel.cc
@@ -32,13 +32,15 @@ namespace {
 // Applies the current rounded-corner values to every direct child of the
 // content parent view. Used when the pref changes or the panel opens with
 // existing content (so OnChildViewAdded never fired with the new values).
-void UpdateContentWrapperChildCorners(views::View* content_parent_view,
-                                      PrefService* prefs,
-                                      bool has_header) {
+void UpdateContentWrapperChildCorners(
+    views::View* content_parent_view,
+    BrowserWindowInterface* browser_window_interface,
+    bool has_header) {
   // ContentParentView hosts multiple content view and shows at once.
   CHECK(content_parent_view->GetUseDefaultFillLayout());
 
-  auto corners = brave::GetPanelContentsRoundedCorners(prefs, has_header);
+  auto corners = brave::GetPanelContentsRoundedCorners(browser_window_interface,
+                                                       has_header);
   for (views::View* child : content_parent_view->children()) {
     // If the child is a WebView or paints to a layer, round its corners.
     if (views::IsViewClass<views::WebView>(child)) {
@@ -91,7 +93,7 @@ void SidePanel::UpdateBorder() {
 
   // Re-apply corners to existing content: the pref or header state changed.
   UpdateContentWrapperChildCorners(GetContentParentView(),
-                                   browser_view_->GetProfile()->GetPrefs(),
+                                   browser_view_->browser(),
                                    GetHeaderView<views::View>());
 
   const int header_top_inset =

--- a/chromium_src/chrome/browser/ui/views/side_panel/side_panel.cc
+++ b/chromium_src/chrome/browser/ui/views/side_panel/side_panel.cc
@@ -32,15 +32,12 @@ namespace {
 // Applies the current rounded-corner values to every direct child of the
 // content parent view. Used when the pref changes or the panel opens with
 // existing content (so OnChildViewAdded never fired with the new values).
-void UpdateContentWrapperChildCorners(
-    views::View* content_parent_view,
-    BrowserWindowInterface* browser_window_interface,
-    bool has_header) {
+void UpdateContentWrapperChildCorners(views::View* content_parent_view,
+                                      BrowserView* browser_view) {
   // ContentParentView hosts multiple content view and shows at once.
   CHECK(content_parent_view->GetUseDefaultFillLayout());
 
-  auto corners = brave::GetPanelContentsRoundedCorners(browser_window_interface,
-                                                       has_header);
+  auto corners = brave::GetPanelContentsRoundedCorners(browser_view);
   for (views::View* child : content_parent_view->children()) {
     // If the child is a WebView or paints to a layer, round its corners.
     if (views::IsViewClass<views::WebView>(child)) {
@@ -92,9 +89,7 @@ void SidePanel::UpdateBorder() {
   UpdateHorizontalAlignment();
 
   // Re-apply corners to existing content: the pref or header state changed.
-  UpdateContentWrapperChildCorners(GetContentParentView(),
-                                   browser_view_->browser(),
-                                   GetHeaderView<views::View>());
+  UpdateContentWrapperChildCorners(GetContentParentView(), browser_view_);
 
   const int header_top_inset =
       header_view_ ? header_view_->GetPreferredSize().height() : 0;

--- a/patches/chrome-browser-ui-views-side_panel-side_panel.cc.patch
+++ b/patches/chrome-browser-ui-views-side_panel-side_panel.cc.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/ui/views/side_panel/side_panel.cc b/chrome/browser/ui/views/side_panel/side_panel.cc
-index ef7fce6750ec533b14fa1e1719406167d9063942..554e6a357ad81e1411d01c4da8b08cb2e065b844 100644
+index ef7fce6750ec533b14fa1e1719406167d9063942..1a0c7e640d2cb9c37f6e864959694f8e36ac1584 100644
 --- a/chrome/browser/ui/views/side_panel/side_panel.cc
 +++ b/chrome/browser/ui/views/side_panel/side_panel.cc
 @@ -223,6 +223,9 @@ class ContentParentView : public views::View, public views::ViewObserver {
@@ -7,7 +7,7 @@ index ef7fce6750ec533b14fa1e1719406167d9063942..554e6a357ad81e1411d01c4da8b08cb2
  
    gfx::RoundedCornersF GetRoundedCorners() {
 +    return brave::GetPanelContentsRoundedCorners(
-+        browser_view_->GetProfile()->GetPrefs(),
++        browser_view_->browser(),
 +        browser_view_->side_panel()->GetHeaderView<views::View>());
      ChromeDistanceMetric corner_radius =
          ChromeDistanceMetric::DISTANCE_SIDE_PANEL_CONTENT_RADIUS;

--- a/patches/chrome-browser-ui-views-side_panel-side_panel.cc.patch
+++ b/patches/chrome-browser-ui-views-side_panel-side_panel.cc.patch
@@ -1,14 +1,12 @@
 diff --git a/chrome/browser/ui/views/side_panel/side_panel.cc b/chrome/browser/ui/views/side_panel/side_panel.cc
-index ef7fce6750ec533b14fa1e1719406167d9063942..1a0c7e640d2cb9c37f6e864959694f8e36ac1584 100644
+index ef7fce6750ec533b14fa1e1719406167d9063942..b787d2f56607050a59dd14aee53863d5dab9f424 100644
 --- a/chrome/browser/ui/views/side_panel/side_panel.cc
 +++ b/chrome/browser/ui/views/side_panel/side_panel.cc
-@@ -223,6 +223,9 @@ class ContentParentView : public views::View, public views::ViewObserver {
+@@ -223,6 +223,7 @@ class ContentParentView : public views::View, public views::ViewObserver {
    }
  
    gfx::RoundedCornersF GetRoundedCorners() {
-+    return brave::GetPanelContentsRoundedCorners(
-+        browser_view_->browser(),
-+        browser_view_->side_panel()->GetHeaderView<views::View>());
++    return brave::GetPanelContentsRoundedCorners(browser_view_);
      ChromeDistanceMetric corner_radius =
          ChromeDistanceMetric::DISTANCE_SIDE_PANEL_CONTENT_RADIUS;
      return GetLayoutProvider()

--- a/rewrite/chrome/browser/ui/views/side_panel/side_panel.cc.yaml
+++ b/rewrite/chrome/browser/ui/views/side_panel/side_panel.cc.yaml
@@ -7,14 +7,17 @@ substitutions:
   - description: |
       Route ContentParentView::GetRoundedCorners() through Brave's corner helper.
 
-      Calls brave::GetPanelContentsRoundedCorners() with the current prefs and
-      whether the side panel has a Brave header attached.  Reading header_view_
-      state (set before AddChildView in PopulateSidePanel) avoids the timing
-      issue where coordinator->GetCurrentEntryId() still returns the previous
-      entry when OnChildViewAdded fires.
+      Calls brave::GetPanelContentsRoundedCorners() with the BrowserWindowInterface
+      and whether the side panel has a Brave header attached. The
+      BrowserWindowInterface gives the helper access to both prefs and the
+      BraveBrowserView so it can adjust the bottom-corner radius based on sidebar
+      visibility and panel alignment. Reading header_view_ state (set before
+      AddChildView in PopulateSidePanel) avoids the timing issue where
+      coordinator->GetCurrentEntryId() still returns the previous entry when
+      OnChildViewAdded fires.
     re_pattern: '(  gfx::RoundedCornersF GetRoundedCorners\(\) \{)'
     replace: |-
       \1
           return brave::GetPanelContentsRoundedCorners(
-              browser_view_->GetProfile()->GetPrefs(),
+              browser_view_->browser(),
               browser_view_->side_panel()->GetHeaderView<views::View>());

--- a/rewrite/chrome/browser/ui/views/side_panel/side_panel.cc.yaml
+++ b/rewrite/chrome/browser/ui/views/side_panel/side_panel.cc.yaml
@@ -7,17 +7,14 @@ substitutions:
   - description: |
       Route ContentParentView::GetRoundedCorners() through Brave's corner helper.
 
-      Calls brave::GetPanelContentsRoundedCorners() with the BrowserWindowInterface
-      and whether the side panel has a Brave header attached. The
-      BrowserWindowInterface gives the helper access to both prefs and the
-      BraveBrowserView so it can adjust the bottom-corner radius based on sidebar
-      visibility and panel alignment. Reading header_view_ state (set before
-      AddChildView in PopulateSidePanel) avoids the timing issue where
+      Passes the BrowserView; the helper reads the prefs and the side panel's
+      header state from it (and downcasts it to BraveBrowserView) to adjust the
+      bottom-corner radius based on sidebar visibility and panel alignment. The
+      helper reads header_view_ directly (set before AddChildView in
+      PopulateSidePanel), avoiding the timing issue where
       coordinator->GetCurrentEntryId() still returns the previous entry when
       OnChildViewAdded fires.
     re_pattern: '(  gfx::RoundedCornersF GetRoundedCorners\(\) \{)'
     replace: |-
       \1
-          return brave::GetPanelContentsRoundedCorners(
-              browser_view_->browser(),
-              browser_view_->side_panel()->GetHeaderView<views::View>());
+          return brave::GetPanelContentsRoundedCorners(browser_view_);


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves no issue - use umbrella issue (https://github.com/brave/brave-browser/issues/51462)

The side panel's content used a single radius on all corners. When the
panel sits flush against the window edge (the sidebar UI is hidden), its
inner bottom corner is a window corner and should use the larger
window-corner radius instead.

GetPanelContentsRoundedCorners() now takes a BrowserWindowInterface so it
can reach both the prefs and the BraveBrowserView. It applies the
window-corner radius to the panel's inner bottom corner (lower-right when
right-aligned, lower-left when left-aligned) only while the sidebar is
hidden, and the regular radius otherwise.
  
Sidebar UI visibility can change at runtime (show-on-mouse-over, pinning),
so SidebarContainerView runs a callback whenever the control view's
visibility changes; BraveBrowserView wires it to SidePanel::UpdateBorder()
to recompute the corners.

TEST=SidebarBrowserTest.SidebarV2GetPanelContentsRoundedCorners,
           SidebarBrowserTest.SidebarV2ContentCornersFollowSidebarVisibility,
           SidePanelUtilsTest.*

https://github.com/user-attachments/assets/dfb9cbe8-1d86-4704-9b02-c01cac0d4fd4

<img width="300" alt="Screenshot 2026-06-08 at 14 33 10" src="https://github.com/user-attachments/assets/36030f68-069d-4e52-8c8e-4f49294f65c5" /> <img width="300" alt="Screenshot 2026-06-08 at 14 34 46" src="https://github.com/user-attachments/assets/8836bcb5-691a-452d-9ec7-6f022b1ec4d2" />


<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
