### PR TITLE
[brockit] Add `update-rust-wasm-toolchain` command

### DIFF
--- a/tools/cr/brockit.py
+++ b/tools/cr/brockit.py
@@ -210,6 +210,24 @@ running.
 tools/cr/brockit.py gen-rust-toolchain @latest-canary --watch
 ```
 
+### `brockit.py update-rust-wasm-toolchain`
+This command repins the Rust/WASM toolchain objects in
+`tools/cr/toolchains/install_extra_deps.py` to the latest published archives for
+a given Chromium tag's Rust+Clang revision, and commits the change. The tag's
+`tools/rust/update_rust.py` and `tools/clang/scripts/update.py` are read to
+identify the toolchain to pin.
+
+```sh
+tools/cr/brockit.py update-rust-wasm-toolchain --to=150.0.7850.1
+```
+
+The `--to` expects a Chromium referecence, and this includes reference labels
+(e.g. `@latest-tag`, etc).
+
+Pass `--culprit=<hash>` to reference a specific Chromium commit in the commit
+body. If none is provided, `brockit` uses the last Chromium commit that has
+changed the versioning of the rust toolchain.
+
 ### `brockit.py reassign`
 This command is used to change the authorship of a given commit in the branch.
 It generates an empty commit with the message `reassign! {original_subject}`
@@ -236,6 +254,7 @@ authorship.
 from __future__ import annotations
 
 import argparse
+import ast
 from dataclasses import dataclass, field, replace
 from datetime import datetime
 import json
@@ -267,6 +286,7 @@ import repository
 from repository import Repository
 from terminal import (IncendiaryErrorHandler, Task as BaseTask, console,
                       is_verbose, terminal)
+from toolchains import build_rust_toolchain
 import versioning
 from versioning import Version
 from vpython_utils import VPYTHON3_PATH
@@ -2899,6 +2919,228 @@ class GenRustToolchain(Task):
                                     (0, 4)))
 
 
+# Installer whose `EXTRA_DEPS` rust-toolchain entry is repinned by
+# `update-rust-wasm-toolchain` (relative to repository.brave.root).
+INSTALL_EXTRA_DEPS_FILE = Path('tools/cr/toolchains/install_extra_deps.py')
+
+# Chromium-side scripts that pin the Rust/Clang revision the toolchain is built
+# from, and the constants in them that identify it. `update-rust-wasm-toolchain`
+# pickaxes these scripts for the commit that introduced the current values to
+# attribute the toolchain update (the same constants `_check_rust_toolchain`
+# reads).
+RUST_REVISION_FILES = ('tools/rust/update_rust.py',
+                       'tools/clang/scripts/update.py')
+RUST_REVISION_KEYS = ('RUST_REVISION', 'RUST_SUB_REVISION', 'CLANG_REVISION')
+
+
+def _render_py_literal(value: object, indent: int = 0) -> str:
+    """Render a str/bool/dict/list literal as multi-line Python source.
+
+    Matches the layout `install_extra_deps.py` already uses -- 4-space
+    indent steps, single-quoted strings, trailing commas -- so re-rendering
+    `EXTRA_DEPS` round-trips through yapf unchanged.
+    """
+    pad = ' ' * indent
+    child = ' ' * (indent + 4)
+    if isinstance(value, dict):
+        if not value:
+            return '{}'
+        items = ''.join(f'{child}{_render_py_literal(key)}: '
+                        f'{_render_py_literal(val, indent + 4)},\n'
+                        for key, val in value.items())
+        return f'{{\n{items}{pad}}}'
+    if isinstance(value, list):
+        if not value:
+            return '[]'
+        items = ''.join(f'{child}{_render_py_literal(item, indent + 4)},\n'
+                        for item in value)
+        return f'[\n{items}{pad}]'
+    if isinstance(value, bool):
+        return 'True' if value else 'False'
+    if isinstance(value, str):
+        # Single-quoted to match the file. Values here never contain a single
+        # quote or backslash; fall back to repr only defensively.
+        if "'" in value or '\\' in value:
+            return repr(value)
+        return f"'{value}'"
+    return repr(value)
+
+
+class UpdateRustWasmToolchain(Task):
+    """Updates the rust WASM entry in `install_extra_deps.py`.
+
+    This task is used to update the Rust/WASM toolchain pins to be used during
+    checkout of Brave. This is a very simple helper, and all it does is take
+    care to retrieve the details for the latest published Rust/WASM toolchain
+    matching the version currently selected in Chromium, and with that it
+    rewrites the `EXTRA_DEPS` details for the rust-toolchain entry in
+    `install_extra_deps.py`.
+
+    After the file for the deps is updated, the tasks also commits a change with
+    a culprit.
+    """
+
+    def status_message(self):
+        return "Updating Rust/WASM toolchain pins..."
+
+    @staticmethod
+    def _load_extra_deps(source: str) -> tuple[ast.Assign, dict]:
+        """Return the `EXTRA_DEPS = {...}` assignment node and its dict value.
+
+        The value is read with `ast.literal_eval`, so the installer is parsed
+        as data rather than imported (importing it pulls in gclient).
+        """
+        for node in ast.parse(source).body:
+            if (isinstance(node, ast.Assign) and len(node.targets) == 1
+                    and isinstance(node.targets[0], ast.Name)
+                    and node.targets[0].id == 'EXTRA_DEPS'):
+                return node, ast.literal_eval(node.value)
+        raise InvalidInputException(
+            f'No EXTRA_DEPS assignment found in {INSTALL_EXTRA_DEPS_FILE}.')
+
+    @staticmethod
+    def _upstream_stem(text: str) -> str:
+        """Build the upstream toolchain package stem from the revision scripts.
+
+        Matches `package_rust.RUST_TOOLCHAIN_PACKAGE_NAME` minus the `.tar.xz`
+        suffix --
+        `rust-toolchain-<RUST_REVISION>-<RUST_SUB_REVISION>-<CLANG_REVISION>` --
+        built from the scripts' source so brockit needn't import `package_rust`
+        (which pulls in gclient). Value patterns mirror
+        `tools/clang/scripts/upload_revision.py`: quoted strings, bare-integer
+        sub-revision.
+        """
+
+        def read(key: str, value: str) -> str:
+            match = re.search(rf'{key} = {value}', text)
+            if not match:
+                raise InvalidInputException(
+                    f'{key} not found in {", ".join(RUST_REVISION_FILES)}.')
+            return match.group(1)
+
+        quoted, integer = r"'([0-9a-z-]+)'", r'([0-9]+)'
+        return ('rust-toolchain-'
+                f'{read("RUST_REVISION", quoted)}-'
+                f'{read("RUST_SUB_REVISION", integer)}-'
+                f'{read("CLANG_REVISION", quoted)}')
+
+    @staticmethod
+    def _resolve_chromium_culprit(text: str, ref: str) -> str:
+        """Finds the commit that updated the Rust toolchain in Chromium.
+
+        This function determines which commit is reponsible for the current
+        rust toolchain versionin in Chromium, using `ref` as a starting point..
+        """
+
+        def assignment_pattern(name: str) -> str:
+            match = re.search(rf'(?m)^{name} = (.+)$', text)
+            if not match:
+                raise InvalidInputException(
+                    f'Could not read {name} from '
+                    f'{", ".join(RUST_REVISION_FILES)}.')
+            value = match.group(1).split('#', 1)[0].strip()
+            return f'{name} = {re.escape(value)}'
+
+        regex = '|'.join(
+            assignment_pattern(name) for name in RUST_REVISION_KEYS)
+        commit_hash = repository.chromium.run_git('log', '--extended-regexp',
+                                                  '-G', regex, '--pretty=%H',
+                                                  '-1', ref, '--',
+                                                  *RUST_REVISION_FILES)
+        if not commit_hash:
+            raise InvalidInputException(
+                'Could not find a Chromium commit pinning the Rust/Clang '
+                f'revision at {ref}. Pass [bold cyan]--culprit[/] to point '
+                'at it explicitly.')
+        return commit_hash
+
+    @staticmethod
+    def _commit_title(new_entry: dict) -> str:
+        """Build a commit subject naming the exact toolchain build being pinned.
+
+        We build the title to show the new toolchain's relevant details, being
+        the rust version, and the clang revision it was built with. The
+        trailing `sub` is the upstream rust sub revision (RUST_SUB_REVISION),
+        not Brave's respin counter. The result is something like this:
+
+          Rust/WASM toolchain (4c4205163abc-5, llvmorg-23-init-10931-g20b6ec77, sub 5)
+
+        The values in the title are extracted form the tarball's name.
+        """
+        object_name = next(iter(
+            new_entry.values()))['objects'][0]['object_name']
+        name = object_name.removesuffix('.tar.xz')
+        match = re.search(
+            r'rust-toolchain-(?P<rust>[0-9a-f]+)-(?P<sub>\d+)-'
+            r'(?P<clang>llvmorg-.+)-(?P<brave>\d+)$', name)
+        if not match:
+            return f'Rust/WASM toolchain {name}'
+        return (f'Rust/WASM toolchain ({match["rust"][:12]}-{match["sub"]}, '
+                f'{match["clang"]}, sub {match["sub"]})')
+
+    def execute(self, chromium_ref: str, culprit: str | None):
+        status = GitStatus()
+        if status.has_staged_files():
+            raise InvalidInputException(
+                'Staged files detected. Please commit or unstage changes '
+                'before generating a toolchain update:\n%s' %
+                '\n'.join(status.get_all_staged_entries()))
+
+        # Resolve to a concrete Chromium tag (supports the @latest-* labels),
+        # then read both revision scripts at that ref in a single `git show`.
+        version = _fetch_chromium_tag(chromium_ref)
+        ref = str(version)
+        revision_text = repository.chromium.read_file(*RUST_REVISION_FILES,
+                                                      commit=ref)
+        upstream_stem = self._upstream_stem(revision_text)
+
+        terminal.log_task(
+            f'Resolving the published Rust/WASM toolchain for Chromium '
+            f'{version}...')
+        try:
+            new_entry = build_rust_toolchain.rust_toolchain_extra_dep(
+                upstream_stem)
+        except RuntimeError as e:
+            raise BadOutcomeException(str(e)) from e
+
+        for entry in new_entry.values():
+            for obj in entry['objects']:
+                console.log(Padding(f'✔️ {obj["object_name"]}', (0, 4)))
+
+        path = repository.brave.root / INSTALL_EXTRA_DEPS_FILE
+        source = path.read_bytes().decode('utf-8')
+        node, extra_deps = self._load_extra_deps(source)
+
+        # Replace the rust-toolchain entry (in place, preserving key order),
+        # then re-render the whole EXTRA_DEPS assignment.
+        extra_deps.update(new_entry)
+        rendered = f'EXTRA_DEPS = {_render_py_literal(extra_deps)}\n'
+        lines = source.splitlines(keepends=True)
+        new_source = (''.join(lines[:node.lineno - 1]) + rendered +
+                      ''.join(lines[node.end_lineno:]))
+
+        if new_source == source:
+            terminal.log_task(
+                f'{INSTALL_EXTRA_DEPS_FILE} is already up to date; '
+                'nothing to commit.')
+            return
+
+        path.write_text(new_source, encoding='utf-8', newline='')
+
+        commit_hash = culprit or self._resolve_chromium_culprit(
+            revision_text, ref)
+        repository.brave.run_git('add', INSTALL_EXTRA_DEPS_FILE)
+        repository.brave.git_commit(self._commit_title(new_entry),
+                                    env={
+                                        **os.environ,
+                                        'tags': 'toolchain',
+                                        'culprit': commit_hash,
+                                    })
+        terminal.log_task(
+            f'Committed the Rust/WASM toolchain update (culprit {commit_hash}).'
+        )
+
+
 def fetch_chromium_dash_version(channel: str) -> Version:
     """Fetches the highest latest version across all platforms for a channel.
 
@@ -3204,6 +3446,31 @@ def main():
         "pipeline's\nstage and status until all finish. Press Ctrl+C to stop "
         'watching;\nthe builds keep running.')
 
+    update_rust_parser = subparsers.add_parser(
+        'update-rust-wasm-toolchain',
+        parents=[global_parser],
+        formatter_class=argparse.RawTextHelpFormatter,
+        help='Repins the Rust/WASM toolchain objects in '
+        'tools/cr/toolchains/install_extra_deps.py to the latest published '
+        'archives for a Chromium tag\'s Rust+Clang revision, and commits the '
+        'change.')
+    update_rust_parser.add_argument(
+        '--to',
+        required=True,
+        dest='to',
+        help=(
+            'The Chromium version whose Rust+Clang revision to repin against\n'
+            '(e.g. 150.0.7850.1), or one of the @latest-* labels accepted by\n'
+            '`lift --to` (e.g. @latest-canary, @latest-m150,\n'
+            '@latest-for-branch, @latest-tag).'))
+    update_rust_parser.add_argument(
+        '--culprit',
+        default=None,
+        help='Chromium commit hash to reference in the commit body. Defaults '
+        'to the last Chromium commit touching the Rust/Clang revision '
+        '(tools/rust/update_rust.py, tools/clang/scripts/update.py).',
+        dest='culprit')
+
     subparsers.add_parser('reference',
                           help='Detailed documentation for this tool.')
     args = parser.parse_args()
@@ -3271,6 +3538,9 @@ def main():
                 task.run_watching(tag=args.tag)
             else:
                 task.run(tag=args.tag)
+        if args.command == 'update-rust-wasm-toolchain':
+            UpdateRustWasmToolchain().run(chromium_ref=args.to,
+                                          culprit=args.culprit)
         if args.command == 'reference':
             console.print(Markdown(__doc__))
         if args.command == 'show':

--- a/tools/cr/toolchains/build_rust_toolchain.py
+++ b/tools/cr/toolchains/build_rust_toolchain.py
@@ -186,6 +186,37 @@ CHROME_VERSION_FILE = Path('chrome/VERSION')
 TOOLCHAIN_BUCKET_URL = (
     'https://brave-build-deps-public.s3.brave.com/rust-toolchain-aux')
 
+# Every platform a Rust/WASM toolchain is published for, mapped to the gclient
+# host condition `install_extra_deps.py` uses to select the matching
+# archive. Keyed by the prefix `_platform_prefix` emits. Single source of truth
+# for "what platforms exist", consumed by `rust_toolchain_extra_dep`.
+SUPPORTED_PLATFORM_CONDITIONS = {
+    'linux-x64': 'host_os == "linux"',
+    'mac-arm64': 'host_os == "mac" and host_cpu == "arm64"',
+    'mac': 'host_os == "mac" and host_cpu == "x64"',
+    'win': 'host_os == "win"',
+}
+
+# Chromium GCS `host_os` directory for each supported platform prefix. The Brave
+# WASM archive is an *overlay* on top of the upstream Chromium-built Rust
+# toolchain that gclient downloads as a `gcs` dep, so each published object
+# records the upstream archive it sits on top of (`overlayed_on`). This maps our
+# prefix to the directory that archive lives under in the clang bucket,
+# mirroring the `host_os` list in
+# `tools/clang/scripts/sync_deps.py:GetRustObjectNames`.
+PLATFORM_PREFIX_TO_CHROMIUM_HOST_OS = {
+    'linux-x64': 'Linux_x64',
+    'mac-arm64': 'Mac_arm64',
+    'mac': 'Mac',
+    'win': 'Win',
+}
+
+# Install path + dep-level condition of the published Rust/WASM toolchain in
+# `install_extra_deps.py`'s `EXTRA_DEPS`. `rust_toolchain_extra_dep`
+# returns the entry keyed by this path.
+RUST_TOOLCHAIN_DEP_PATH = 'src/third_party/rust-toolchain'
+RUST_TOOLCHAIN_DEP_CONDITION = 'not rust_force_head_revision'
+
 if sys.platform == 'win32':
     # Path to Git's sh.exe on Windows, which is used by
     # `tools/rust/build_rust.py` to build the toolchain on Windows.`
@@ -236,6 +267,95 @@ def _sha256_file(path: Path) -> str:
         for chunk in iter(lambda: f.read(65536), b''):
             digest.update(chunk)
     return digest.hexdigest()
+
+
+def _latest_index_object(index_url: str,
+                         expected_stem: str) -> tuple[str, str]:
+    """Download a platform's YAML index and return its latest archive.
+
+    The index lists builds in chronological order, so the last element is the
+    most recent archive for that platform + revision. Returns
+    `(object_name, sha256sum)`, where `object_name` is the archive's basename.
+
+    `expected_stem` is the `<platform>-<upstream-stem>` the archive name must
+    start with. A mismatch means the index was fetched from the wrong key or is
+    cross-contaminated with another platform's builds, and is treated as a hard
+    error rather than silently trusted.
+    """
+    try:
+        with urllib.request.urlopen(index_url) as response:
+            entries = yaml.safe_load(response) or []
+    except urllib.error.URLError as e:
+        raise RuntimeError(
+            f'Failed to fetch toolchain index {index_url}: {e}') from e
+    if not entries:
+        raise RuntimeError(f'Published toolchain index is empty: {index_url}')
+    latest = entries[-1]
+    if (not isinstance(latest, dict) or 'url' not in latest
+            or 'sha256sum' not in latest):
+        raise RuntimeError(
+            f'Malformed entry in toolchain index {index_url}: expected a '
+            f'mapping with "url" and "sha256sum", got {latest!r}')
+    object_name = latest['url'].rsplit('/', 1)[-1]
+    if not object_name.startswith(f'{expected_stem}-'):
+        raise RuntimeError(
+            f'Toolchain index {index_url} yielded {object_name!r}, which does '
+            f'not start with the expected {expected_stem!r} stem.')
+    return object_name, latest['sha256sum']
+
+
+def rust_toolchain_extra_dep(upstream_stem: str) -> dict[str, dict]:
+    """Assemble the complete `EXTRA_DEPS` entry for the published toolchain.
+
+    This function composes a Python dictionary representing the full
+    `EXTRA_DEPS` value that should be used in `install_extra_deps.py` for
+    the current Chromium checkout.
+
+        {
+          'src/third_party/rust-toolchain': {
+            'bucket': '<bucket>/',
+            'condition': 'not rust_force_head_revision',
+            'objects': [
+              {'object_name': ..., 'sha256sum': ...,
+               'overlayed_on': ..., 'condition': ...},
+              ...
+            ],
+          },
+        }
+
+    This function is used by brockit to patch the value of `EXTRA_DEPS` in
+    `install_extra_deps.py`.
+
+    Args:
+        upstream_stem: The upstream toolchain package stem (i.e.
+            `package_rust.RUST_TOOLCHAIN_PACKAGE_NAME` without the `.tar.xz`
+            suffix).
+
+    Raises:
+        RuntimeError: if any platform's index is missing or empty.
+    """
+    objects = []
+    for platform_prefix, condition in SUPPORTED_PLATFORM_CONDITIONS.items():
+        stem = f'{platform_prefix}-{upstream_stem}'
+        index_url = f'{TOOLCHAIN_BUCKET_URL}/{stem}.yaml'
+        object_name, sha256sum = _latest_index_object(index_url, stem)
+        host_os = PLATFORM_PREFIX_TO_CHROMIUM_HOST_OS[platform_prefix]
+        objects.append({
+            'object_name': object_name,
+            'sha256sum': sha256sum,
+            # Upstream Chromium-built Rust toolchain this archive overlays; see
+            # `sync_deps.GetRustObjectNames` for the matching naming scheme.
+            'overlayed_on': f'{host_os}/{upstream_stem}.tar.xz',
+            'condition': condition,
+        })
+
+    return {
+        RUST_TOOLCHAIN_DEP_PATH: {
+            'bucket': f'{TOOLCHAIN_BUCKET_URL}/',
+            'condition': RUST_TOOLCHAIN_DEP_CONDITION,
+            'objects': objects,
+        }
+    }
 
 
 class ToolchainBuilder:

--- a/tools/cr/update_rust_wasm_toolchain_test.py
+++ b/tools/cr/update_rust_wasm_toolchain_test.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env vpython3
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Tests for `brockit.UpdateRustWasmToolchain` and `_render_py_literal`.
+
+Two layers:
+
+* `RenderLiteralTest` / `LoadExtraDepsTest` cover the pure source-handling --
+  rendering an `EXTRA_DEPS` literal and reading it back out with `ast`.
+
+* `UpdateExecuteTest` drives `execute` end-to-end against a `FakeChromiumRepo`
+  with the commit-msg hook installed (the builder is faked, so no network),
+  validating the file rewrite *and* the `tags=toolchain` / `culprit=<hash>`
+  commit -- the same way `UpdateXcodeToolchainExecuteTest` works.
+"""
+
+from __future__ import annotations
+
+import ast
+import shutil
+import stat
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import brockit
+from test.fake_chromium_repo import FakeChromiumRepo
+
+# Source of the commit-msg hook, symlinked/copied into the fake brave repo so
+# the `tags` / `culprit` env wiring is exercised exactly as in production.
+HOOK_SOURCE: Path = (Path(__file__).resolve().parent / 'alias' /
+                     'commit-msg.py')
+
+# A stand-in for install_extra_deps.py: two EXTRA_DEPS entries (only the
+# rust-toolchain one should change) plus trailing code that must survive.
+SAMPLE_FILE = """\
+# Installer module.
+
+EXTRA_DEPS = {
+    'src/other-dep': {
+        'bucket': 'https://example.invalid/other/',
+        'objects': [
+            {
+                'object_name': 'other.tar.xz',
+                'sha256sum': 'othersha',
+                'condition': 'host_os == "linux"',
+            },
+        ],
+    },
+    'src/third_party/rust-toolchain': {
+        'bucket': 'https://example.invalid/rust-toolchain-aux/',
+        'condition': 'not rust_force_head_revision',
+        'objects': [
+            {
+                'object_name': 'old-linux-1.tar.xz',
+                'sha256sum': 'oldlinuxsha',
+                'condition': 'host_os == "linux"',
+            },
+        ],
+    },
+}
+
+
+def untouched():
+    return 1
+"""
+
+# What the faked builder returns -- a fresh rust-toolchain entry.
+NEW_ENTRY = {
+    'src/third_party/rust-toolchain': {
+        'bucket': 'https://example.invalid/rust-toolchain-aux/',
+        'condition': 'not rust_force_head_revision',
+        'objects': [
+            {
+                'object_name': 'linux-x64-rust-toolchain-2.tar.xz',
+                'sha256sum': 'newlinuxsha',
+                'condition': 'host_os == "linux"',
+            },
+            {
+                'object_name': 'win-rust-toolchain-2.tar.xz',
+                'sha256sum': 'newwinsha',
+                'condition': 'host_os == "win"',
+            },
+        ],
+    },
+}
+
+
+class RenderLiteralTest(unittest.TestCase):
+    """Tests for `brockit._render_py_literal`."""
+
+    def test_round_trips(self):
+        self.assertEqual(
+            ast.literal_eval(brockit._render_py_literal(NEW_ENTRY)), NEW_ENTRY)
+
+    def test_single_quoted_with_embedded_double_quotes(self):
+        rendered = brockit._render_py_literal(
+            {'condition': 'host_os == "mac" and host_cpu == "arm64"'})
+        self.assertIn(
+            "    'condition': 'host_os == \"mac\" and host_cpu == \"arm64\"',",
+            rendered)
+
+    def test_empty_containers(self):
+        self.assertEqual(brockit._render_py_literal({}), '{}')
+        self.assertEqual(brockit._render_py_literal([]), '[]')
+
+
+class CommitTitleTest(unittest.TestCase):
+    """Tests for `UpdateRustWasmToolchain._commit_title`."""
+
+    @staticmethod
+    def _entry(object_name: str) -> dict:
+        """Wrap `object_name` in the minimal `EXTRA_DEPS`-shaped dict the
+        title builder reads its first object from."""
+        return {
+            'src/third_party/rust-toolchain': {
+                'objects': [{
+                    'object_name': object_name
+                }],
+            }
+        }
+
+    def test_title_uses_upstream_rust_sub_revision(self):
+        # Full archive name with an upstream rust sub revision (`2`) that
+        # differs from Brave's respin counter (`1`), so a title that wrongly
+        # rendered the brave sub revision would read `sub 1`.
+        name = ('linux-x64-rust-toolchain-'
+                '4c4205163abcbd08948b3efab796c543ba1ea687-2-'
+                'llvmorg-23-init-10931-g20b6ec66-1.tar.xz')
+        title = brockit.UpdateRustWasmToolchain._commit_title(
+            self._entry(name))
+        self.assertEqual(
+            title, 'Rust/WASM toolchain (4c4205163abc-2, '
+            'llvmorg-23-init-10931-g20b6ec66, sub 2)')
+
+    def test_unparseable_name_falls_back_to_stem(self):
+        title = brockit.UpdateRustWasmToolchain._commit_title(
+            self._entry('linux-x64-rust-toolchain-2.tar.xz'))
+        self.assertEqual(title,
+                         'Rust/WASM toolchain linux-x64-rust-toolchain-2')
+
+
+class LoadExtraDepsTest(unittest.TestCase):
+    """Tests for `UpdateRustWasmToolchain._load_extra_deps`."""
+
+    def test_returns_node_and_value(self):
+        node, value = brockit.UpdateRustWasmToolchain._load_extra_deps(
+            SAMPLE_FILE)
+        self.assertEqual(node.targets[0].id, 'EXTRA_DEPS')
+        self.assertIn('src/third_party/rust-toolchain', value)
+        self.assertIn('src/other-dep', value)
+
+    def test_missing_assignment_raises(self):
+        with self.assertRaises(brockit.InvalidInputException):
+            brockit.UpdateRustWasmToolchain._load_extra_deps('X = 1\n')
+
+
+class UpdateExecuteTest(unittest.TestCase):
+    """End-to-end `execute` against a `FakeChromiumRepo` (builder faked)."""
+
+    INSTALLER = 'tools/cr/toolchains/install_extra_deps.py'
+
+    # The Chromium tag `execute` resolves `--to` against; the revision-bump
+    # commit is tagged with it so the revision scripts can be read at the ref.
+    CHROMIUM_TAG = '150.0.7850.1'
+
+    def setUp(self):
+        self.repo = FakeChromiumRepo()
+        self.repo.setup()
+        self.addCleanup(self.repo.cleanup)
+        self._checkout_cr_branch()
+        self._install_commit_msg_hook()
+        self._seed_installer()
+
+        patcher = patch.object(brockit.build_rust_toolchain,
+                               'rust_toolchain_extra_dep',
+                               return_value=NEW_ENTRY)
+        self.builder = patcher.start()
+        self.addCleanup(patcher.stop)
+
+    # -- fixture helpers ----------------------------------------------------
+
+    def _checkout_cr_branch(self, name: str = 'cr150') -> None:
+        self.repo._run_git_command(['checkout', '-b', name], self.repo.brave)
+
+    def _install_commit_msg_hook(self) -> None:
+        hooks_dir = self.repo.brave / '.git' / 'hooks'
+        hooks_dir.mkdir(exist_ok=True)
+        dest = hooks_dir / 'commit-msg'
+        if dest.exists() or dest.is_symlink():
+            dest.unlink()
+        shutil.copy2(HOOK_SOURCE, dest)
+        dest.chmod(dest.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP
+                   | stat.S_IXOTH)
+
+    def _seed_installer(self, content: str = SAMPLE_FILE) -> None:
+        path = self.repo.brave / self.INSTALLER
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding='utf-8', newline='')
+        self.repo._run_git_command(['add', str(path)], self.repo.brave)
+        self.repo._run_git_command(
+            ['commit', '--no-verify', '-m', 'Seed installer'], self.repo.brave)
+
+    def _seed_rust_revision_bump(self) -> str:
+        """Seed a Chromium commit introducing the Rust/Clang revision constants
+        in both scripts and tag it as `CHROMIUM_TAG`, returning its hash -- the
+        ref `execute` reads the revision constants from, and what the pickaxe in
+        `_resolve_chromium_culprit` should attribute the update to."""
+        self.repo.write_and_stage_file(
+            'tools/rust/update_rust.py',
+            "RUST_REVISION = 'abc123def'\nRUST_SUB_REVISION = 2\n",
+            self.repo.chromium)
+        self.repo.write_and_stage_file(
+            'tools/clang/scripts/update.py',
+            "CLANG_REVISION = 'llvmorg-23-init-10931-g20b6ec66'\n",
+            self.repo.chromium)
+        culprit = self.repo.commit('Roll clang+rust revision',
+                                   self.repo.chromium)
+        self.repo._run_git_command(['tag', self.CHROMIUM_TAG],
+                                   self.repo.chromium)
+        return culprit
+
+    def _installer_text(self) -> str:
+        return (self.repo.brave / self.INSTALLER).read_bytes().decode('utf-8')
+
+    def _brave_head(self) -> str:
+        return self.repo._run_git_command(['rev-parse', 'HEAD'],
+                                          self.repo.brave)
+
+    def _last_brave_message(self) -> str:
+        return self.repo._run_git_command(['log', '-1', '--format=%B'],
+                                          self.repo.brave)
+
+    # -- tests --------------------------------------------------------------
+
+    def test_updates_and_commits_with_auto_culprit(self):
+        culprit = self._seed_rust_revision_bump()
+
+        brockit.UpdateRustWasmToolchain().execute(
+            chromium_ref=self.CHROMIUM_TAG, culprit=None)
+
+        text = self._installer_text()
+        self.assertIn('linux-x64-rust-toolchain-2.tar.xz', text)
+        self.assertIn('win-rust-toolchain-2.tar.xz', text)
+        self.assertNotIn('old-linux-1.tar.xz', text)
+        # The unrelated entry and trailing code survive.
+        self.assertIn("'src/other-dep'", text)
+        self.assertIn('def untouched():', text)
+
+        message = self._last_brave_message()
+        subject = message.splitlines()[0]
+        self.assertIn('[cr150]', subject)
+        self.assertIn('[toolchain]', subject)
+        self.assertIn('Rust/WASM toolchain', subject)
+        # Auto-detected culprit rendered into the body.
+        self.assertIn(
+            f'https://chromium.googlesource.com/chromium/src/+/{culprit}',
+            message)
+        self.assertIn('Roll clang+rust revision', message)
+
+    def test_explicit_culprit_overrides_autodetect(self):
+        # Seed the revision bump (read for the toolchain stem and what
+        # auto-detect would attribute to) then point --culprit at an unrelated
+        # commit, proving the explicit value wins over auto-detection.
+        autodetect = self._seed_rust_revision_bump()
+        self.repo.write_and_stage_file('docs/unrelated.txt', 'noise\n',
+                                       self.repo.chromium)
+        culprit = self.repo.commit('Unrelated chromium change',
+                                   self.repo.chromium)
+
+        brockit.UpdateRustWasmToolchain().execute(
+            chromium_ref=self.CHROMIUM_TAG, culprit=culprit)
+
+        message = self._last_brave_message()
+        self.assertIn(
+            f'https://chromium.googlesource.com/chromium/src/+/{culprit}',
+            message)
+        self.assertIn('Unrelated chromium change', message)
+        # The auto-detected culprit was overridden, not used.
+        self.assertNotIn(autodetect, message)
+
+    def test_idempotent_second_run_does_not_commit(self):
+        self._seed_rust_revision_bump()
+        toolchain = brockit.UpdateRustWasmToolchain()
+
+        toolchain.execute(chromium_ref=self.CHROMIUM_TAG, culprit=None)
+        head_after_first = self._brave_head()
+
+        # The file already holds NEW_ENTRY, so a re-run is a byte-identical
+        # no-op and must not produce a second commit.
+        toolchain.execute(chromium_ref=self.CHROMIUM_TAG, culprit=None)
+        self.assertEqual(self._brave_head(), head_after_first)
+
+    def test_staged_files_block_the_update(self):
+        self.repo.write_and_stage_file('staged.txt', 'wip\n', self.repo.brave)
+        with self.assertRaises(brockit.InvalidInputException):
+            brockit.UpdateRustWasmToolchain().execute(
+                chromium_ref=self.CHROMIUM_TAG, culprit='deadbeef')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR adds a command to `brockit` to be used to update the Rust/WASM
toolchain. This command will take care of determining which version we
should be using, and going ahead and fetching whatever is available in
the bucket, based on the available indexes.

Bug: https://github.com/brave/brave-browser/issues/55812
