### PR TITLE
[Polkadot] [Wallet] update polkadot coins to show the correct logo

### DIFF
--- a/components/brave_wallet_ui/options/asset-options.ts
+++ b/components/brave_wallet_ui/options/asset-options.ts
@@ -70,6 +70,7 @@ export const getNetworkLogo = (chainId: string, symbol: string): string => {
     case 'ADA':
       return CardanoIcon
     case 'DOT':
+    case 'WND':
       return PolkadotIcon
   }
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Update the Polkadot Westend coins to display the associated Polkadot logo instead of a default icon.

<!-- Add brave-browser issue below that this PR will resolve -->
We need to manually add Westend Asset Hub as a supported testnet to get it properly display as a testnet network.

| Before | After |
| :------ | :------ |
| <img width="686" height="486" alt="image" src="https://github.com/user-attachments/assets/21b2f315-0d22-4e30-a990-a260abb772d7" /> | <img width="691" height="489" alt="image" src="https://github.com/user-attachments/assets/8b736b18-ed7c-4708-8820-d5f11a53dc75" /> |