### PR TITLE
[Polkadot] [Wallet] update suggested Polkadot account names to be accurate

### DIFF
--- a/components/brave_wallet_ui/components/desktop/popup-modals/add-account-modal/create-account-modal.tsx
+++ b/components/brave_wallet_ui/components/desktop/popup-modals/add-account-modal/create-account-modal.tsx
@@ -12,7 +12,10 @@ import { showAlert } from '@brave/leo/react/alertCenter'
 
 // utils
 import { getLocale } from '$web-common/locale'
-import { keyringIdForNewAccount } from '../../../../utils/account-utils'
+import {
+  getAccountsForNetwork,
+  keyringIdForNewAccount,
+} from '../../../../utils/account-utils'
 
 // options
 import { CreateAccountOptions } from '../../../../options/create-account-options'
@@ -113,10 +116,22 @@ export const CreateAccountModal = () => {
 
   const suggestedAccountName = React.useMemo(() => {
     const allAccounts = [...accounts, ...hiddenAccounts]
-    const accountTypeLength =
-      allAccounts.filter(
-        (account) => account.accountId.coin === selectedAccountType?.coin,
-      ).length + 1
+    // Polkadot accounts are scoped by keyring (mainnet vs testnet), not coin,
+    // so defer to getAccountsForNetwork for keyring-aware counting.
+    const matchingAccounts =
+      selectedAccountType?.coin === BraveWallet.CoinType.DOT
+      && selectedAccountType.fixedNetwork
+        ? getAccountsForNetwork(
+            {
+              coin: selectedAccountType.coin,
+              chainId: selectedAccountType.fixedNetwork,
+            },
+            allAccounts,
+          )
+        : allAccounts.filter(
+            (account) => account.accountId.coin === selectedAccountType?.coin,
+          )
+    const accountTypeLength = matchingAccounts.length + 1
     return `${
       selectedAccountType?.name //
     } ${getLocale('braveWalletSubviewAccount')} ${

--- a/components/brave_wallet_ui/constants/types.ts
+++ b/components/brave_wallet_ui/constants/types.ts
@@ -709,6 +709,11 @@ export const ZCashTestnetKeyringIds = [BraveWallet.KeyringId.kZCashTestnet]
 
 export const CardanoTestnetKeyringIds = [BraveWallet.KeyringId.kCardanoTestnet]
 
+export const PolkadotMainnetKeyringIds = [
+  BraveWallet.KeyringId.kPolkadotMainnet,
+  BraveWallet.KeyringId.kPolkadotImport,
+]
+
 export const PolkadotTestnetKeyringIds = [
   BraveWallet.KeyringId.kPolkadotTestnet,
   BraveWallet.KeyringId.kPolkadotImportTestnet,

--- a/components/brave_wallet_ui/utils/account-utils.ts
+++ b/components/brave_wallet_ui/utils/account-utils.ts
@@ -13,7 +13,9 @@ import {
   BitcoinTestnetKeyringIds,
   ZCashTestnetKeyringIds,
   CardanoTestnetKeyringIds,
+  PolkadotMainnetKeyringIds,
   PolkadotTestnetKeyringIds,
+  SupportedTestNetworks,
 } from '../constants/types'
 
 // constants
@@ -291,6 +293,17 @@ export const getAccountsForNetwork = (
     return accounts.filter(
       (account) =>
         account.accountId.keyringId === BraveWallet.KeyringId.kFilecoinTestnet,
+    )
+  }
+  // Polkadot accounts are portable across every parachain and the relay chain,
+  // so an account belongs to a network purely by its keyring (mainnet vs
+  // testnet) rather than by chainId.
+  if (network.coin === BraveWallet.CoinType.DOT) {
+    const polkadotKeyringIds = SupportedTestNetworks.includes(network.chainId)
+      ? PolkadotTestnetKeyringIds
+      : PolkadotMainnetKeyringIds
+    return accounts.filter((account) =>
+      polkadotKeyringIds.includes(account.accountId.keyringId),
     )
   }
   return accounts.filter((account) => account.accountId.coin === network.coin)

--- a/components/brave_wallet_ui/utils/address-utils.ts
+++ b/components/brave_wallet_ui/utils/address-utils.ts
@@ -5,6 +5,7 @@
 
 // utils
 import { getLocale } from '../../common/locale'
+import { getAccountsForNetwork } from './account-utils'
 
 // types
 import { BraveWallet, SupportedTestNetworks } from '../constants/types'
@@ -70,9 +71,13 @@ export const suggestNewAccountName = (
   accounts: BraveWallet.AccountInfo[],
   network: Pick<BraveWallet.NetworkInfo, 'coin' | 'symbolName' | 'chainId'>,
 ) => {
-  const accountTypeLength =
-    accounts.filter((account) => account.accountId.coin === network.coin).length
-    + 1
+  // Polkadot accounts are scoped by keyring (mainnet vs testnet), not coin, so
+  // defer to getAccountsForNetwork for keyring-aware counting.
+  const matchingAccounts =
+    network.coin === BraveWallet.CoinType.DOT
+      ? getAccountsForNetwork(network, accounts)
+      : accounts.filter((account) => account.accountId.coin === network.coin)
+  const accountTypeLength = matchingAccounts.length + 1
   return `${network.symbolName} ${getLocale(
     SupportedTestNetworks.includes(network.chainId)
       ? 'braveWalletTestNetworkAccount'


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Right now when a user attempts to create a Polkadot account the suggested name will present an account index that totals _all_ Polkadot accounts. 

In reality, users either create a testnet or mainnet Polkadot account and the UI needs to reflect this accordingly as internally, we only have one coin type that represents Polkadot: DOT. 

It would be unsustainable to introduce a new coin type for each parachain so we simply update the account counting logic at each call-site.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
