### PR TITLE
[Android] Prompt restart when an Origin Play Store purchase is auto-restored

### DIFF
--- a/android/java/org/chromium/chrome/browser/brave_origin/BraveOriginSettingsLauncherHelper.java
+++ b/android/java/org/chromium/chrome/browser/brave_origin/BraveOriginSettingsLauncherHelper.java
@@ -16,13 +16,14 @@ import org.chromium.chrome.browser.settings.BraveOriginPreferences;
 import org.chromium.chrome.browser.settings.SettingsNavigationFactory;
 
 /**
- * Opens the Brave Origin settings screen from native when a purchase is first detected, so the user
- * can restart to apply the newly enforced policies.
+ * Opens the Brave Origin settings screen when a purchase is first detected (from native for web
+ * purchases, or from Java when a Play Store purchase is auto-restored), so the user can restart to
+ * apply the newly enforced policies.
  */
 @NullMarked
 public class BraveOriginSettingsLauncherHelper {
     @CalledByNative
-    private static void showOriginSettingsForRestart() {
+    public static void showOriginSettingsForRestart() {
         Activity activity = ApplicationStatus.getLastTrackedFocusedActivity();
         if (activity == null) {
             return;

--- a/android/java/org/chromium/chrome/browser/brave_origin/BraveOriginSubscriptionPrefs.java
+++ b/android/java/org/chromium/chrome/browser/brave_origin/BraveOriginSubscriptionPrefs.java
@@ -145,6 +145,13 @@ public class BraveOriginSubscriptionPrefs {
                         setOriginPackageName(profile);
                         setOriginProductId(profile, activePurchaseModel.getProductId());
                         setOriginPurchaseToken(profile, activePurchaseModel.getPurchaseToken());
+                        // We only reach verifyPurchase() while the subscription pref is inactive
+                        // (see the BraveActivity guard), so a found purchase means a prior Play
+                        // Store purchase is being auto-restored. setOriginPurchaseToken() above
+                        // already started the credential fetch, so open the Origin settings screen:
+                        // it shows the spinner while credentials are fetched and prompts a restart
+                        // once the policies are enforced.
+                        BraveOriginSettingsLauncherHelper.showOriginSettingsForRestart();
                     } else {
                         setOriginProductId(profile, "");
                         setOriginPurchaseToken(profile, "");


### PR DESCRIPTION
On a fresh profile with a prior Play Store Origin purchase, `BraveActivity` auto-restores it at startup via `verifyPurchase()`. This enforces the Origin policies (e.g. disabling Brave Wallet) live in the running session, but unlike the in-settings purchase and the native web-purchase flows it never prompted a restart. The browser then honours the freshly enforced policy per navigation while already-configured renderers do not, which can leave the two out of sync (e.g. the renderer keeps injecting `window.ethereum` and requests a binder the browser no longer registers).

Open the Origin settings screen when a Play Store purchase is auto-restored, reusing the existing fetching-spinner/restart snackbar, so the user restarts and the policies take effect cleanly at boot. The prompt fires only on the auto-restore transition (the subscription pref is inactive when `verifyPurchase` runs); the in-settings first purchase keeps its own snackbar.

Resolves: https://github.com/brave/brave-browser/issues/56078

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
