### PR TITLE
[Android][Origin] Reclaim toolbar space when the rewards icon is hidden on tablet (uplift to 1.91.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/toolbar/top/BraveToolbarLayoutImpl.java
+++ b/android/java/org/chromium/chrome/browser/toolbar/top/BraveToolbarLayoutImpl.java
@@ -710,6 +710,20 @@ public abstract class BraveToolbarLayoutImpl extends ToolbarLayout
         post(mToolbarSnapshotCaptureRunnable);
     }
 
+    /** Updates the rewards layout visibility, keeping the tablet toolbar layout in sync. */
+    private void setRewardsLayoutVisibility(int visibility) {
+        if (mRewardsLayout == null || mRewardsLayout.getVisibility() == visibility) {
+            return;
+        }
+        mRewardsLayout.setVisibility(visibility);
+        // Tablet only: re-request layout on the rewards view so its row re-measures and the
+        // location bar reclaims the freed width, then refresh the toolbar snapshot.
+        if (BraveReflectionUtil.equalTypes(this.getClass(), ToolbarTablet.class)) {
+            post(mRewardsLayout::requestLayout);
+            invalidateToolbarSnapshotOnTablet();
+        }
+    }
+
     private void requestToolbarSnapshotCapture() {
         final ToolbarControlContainer toolbarControlContainer =
                 getRootView().findViewById(R.id.control_container);
@@ -1389,7 +1403,7 @@ public abstract class BraveToolbarLayoutImpl extends ToolbarLayout
 
         if (mRewardsLayout == null) return;
         if (isIncognito()) {
-            mRewardsLayout.setVisibility(View.GONE);
+            setRewardsLayoutVisibility(View.GONE);
             updateShieldsLayoutBackground(true);
         } else if (isNativeLibraryReady()
                 && mBraveRewardsNativeWorker != null
@@ -1399,10 +1413,10 @@ public abstract class BraveToolbarLayoutImpl extends ToolbarLayout
             Profile profile = Profile.fromWebContents(tab.getWebContents());
             boolean isDisabled = BraveRewardsPolicy.isDisabledByPolicy(profile);
             if (!isDisabled) {
-                mRewardsLayout.setVisibility(View.VISIBLE);
+                setRewardsLayoutVisibility(View.VISIBLE);
                 updateShieldsLayoutBackground(false);
             } else {
-                mRewardsLayout.setVisibility(View.GONE);
+                setRewardsLayoutVisibility(View.GONE);
                 updateShieldsLayoutBackground(true);
             }
         }
@@ -1791,7 +1805,7 @@ public abstract class BraveToolbarLayoutImpl extends ToolbarLayout
 
         Tab tab = getToolbarDataProvider().getTab();
         Profile profile = tab != null ? Profile.fromWebContents(tab.getWebContents()) : null;
-        mRewardsLayout.setVisibility(
+        setRewardsLayoutVisibility(
                 width >= DeviceFormFactor.getNonMultiDisplayMinimumTabletWidthPx(getContext())
                                 && !BraveRewardsPolicy.isDisabledByPolicy(profile)
                         ? View.VISIBLE
@@ -1839,8 +1853,8 @@ public abstract class BraveToolbarLayoutImpl extends ToolbarLayout
 
         boolean isDisabled = BraveRewardsPolicy.isDisabledByPolicy(profile);
         // Only show if policy allows (not disabled)
-        if (!isDisabled && mRewardsLayout != null) {
-            mRewardsLayout.setVisibility(View.VISIBLE);
+        if (!isDisabled) {
+            setRewardsLayoutVisibility(View.VISIBLE);
         }
         // If policy disables rewards, keep it hidden (default is GONE)
 


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/36975
Resolves https://github.com/brave/brave-browser/issues/56036