### PR TITLE
[iOS] Gate Siri Shortcuts feature access on active policies

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Playlist.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Playlist.swift
@@ -299,6 +299,9 @@ extension BrowserViewController: PlaylistScriptHandlerDelegate {
     item: PlaylistInfo?,
     playbackOffset: Double
   ) {
+    if !profileController.profile.prefs.isPlaylistAvailable {
+      return
+    }
     let playlistController = PlaylistCoordinator.shared.getPlaylistController(
       tab: tab,
       profile: profileController.profile,

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+VPN.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+VPN.swift
@@ -33,6 +33,10 @@ extension BrowserViewController {
 
   /// Shows a vpn screen based on vpn state.
   public func presentCorrespondingVPNViewController() {
+    if !profileController.profile.prefs.isBraveVPNAvailable {
+      return
+    }
+
     if BraveVPN.isSkusCredentialSessionExpired {
       let alert = vpnSessionExpiredStateAlert(loginCallback: { [unowned self] _ in
         self.openURLInNewTab(

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/General/ShortcutSettingsViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/General/ShortcutSettingsViewController.swift
@@ -6,6 +6,7 @@
 import BraveShared
 import BraveStrings
 import IntentsUI
+import OrderedCollections
 import SwiftUI
 
 struct ShortcutSettingsView: View {
@@ -26,9 +27,27 @@ struct ShortcutSettingsView: View {
   @State private var shortcutSheet: ShortcutSheet?
   @State private var isOpenSettingsAlertPresented: Bool = false
 
+  var isPlaylistAvailable: Bool
+  var isBraveVPNAvailable: Bool
+  var isBraveNewsAvailable: Bool
+
+  private var activityTypes: [ActivityType] {
+    var types = OrderedSet(ActivityType.allCases)
+    if !isPlaylistAvailable {
+      types.remove(.openPlayList)
+    }
+    if !isBraveVPNAvailable {
+      types.remove(.enableBraveVPN)
+    }
+    if !isBraveNewsAvailable {
+      types.remove(.openBraveNews)
+    }
+    return Array(types)
+  }
+
   var body: some View {
     Form {
-      ForEach(ActivityType.allCases, id: \.identifier) { activityType in
+      ForEach(activityTypes, id: \.identifier) { activityType in
         Section {
           Button {
             Task { @MainActor in
@@ -98,8 +117,18 @@ struct ShortcutSettingsView: View {
 }
 
 class ShortcutSettingsViewController: UIHostingController<ShortcutSettingsView> {
-  init() {
-    super.init(rootView: ShortcutSettingsView())
+  init(
+    isPlaylistAvailable: Bool,
+    isBraveVPNAvailable: Bool,
+    isBraveNewsAvailable: Bool,
+  ) {
+    super.init(
+      rootView: ShortcutSettingsView(
+        isPlaylistAvailable: isPlaylistAvailable,
+        isBraveVPNAvailable: isBraveVPNAvailable,
+        isBraveNewsAvailable: isBraveNewsAvailable
+      )
+    )
   }
 
   @available(*, unavailable)

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/SettingsViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/SettingsViewController.swift
@@ -815,7 +815,11 @@ class SettingsViewController: TableViewController, BraveAccountAuthenticationObs
           text: Strings.Shortcuts.shortcutSettingsTitle,
           selection: { [unowned self] in
             self.navigationController?.pushViewController(
-              ShortcutSettingsViewController(),
+              ShortcutSettingsViewController(
+                isPlaylistAvailable: braveCore.profile.prefs.isPlaylistAvailable,
+                isBraveVPNAvailable: braveCore.profile.prefs.isBraveVPNAvailable,
+                isBraveNewsAvailable: braveCore.profile.prefs.isBraveNewsAvailable
+              ),
               animated: true
             )
           },

--- a/ios/brave-ios/Sources/Brave/Shortcuts/ActivityShortcutManager.swift
+++ b/ios/brave-ios/Sources/Brave/Shortcuts/ActivityShortcutManager.swift
@@ -186,6 +186,9 @@ public class ActivityShortcutManager: NSObject {
     case .clearBrowsingHistory:
       bvc.clearHistoryAndOpenNewTab()
     case .enableBraveVPN:
+      if !bvc.profileController.profile.prefs.isBraveVPNAvailable {
+        return
+      }
       // need to stay in NTP for Brave VPN flow
       openExternalNewTab(bvc.privateBrowsingManager.isPrivateBrowsing, false)
 
@@ -198,6 +201,10 @@ public class ActivityShortcutManager: NSObject {
         }
       }
     case .openBraveNews:
+      if !bvc.profileController.profile.prefs.isBraveNewsAvailable {
+        return
+      }
+
       // Do nothing as browser when browser to PB only and Brave News isn't available on private tabs
       guard !Preferences.Privacy.privateBrowsingOnly.value else {
         return
@@ -229,6 +236,10 @@ public class ActivityShortcutManager: NSObject {
         bvc.present(container, animated: true)
       }
     case .openPlayList:
+      if !bvc.profileController.profile.prefs.isPlaylistAvailable {
+        return
+      }
+
       bvc.popToBVC()
 
       let tab = bvc.tabManager.selectedTab


### PR DESCRIPTION
Removes the options from the Siri Shortcuts settings page and gates any previously added shortcuts

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/56132
