### PR TITLE
[Android] Prompt restart when an Origin Play Store purchase is auto-restored (uplift to 1.91.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/brave_origin/BraveOriginSettingsLauncherHelper.java
+++ b/android/java/org/chromium/chrome/browser/brave_origin/BraveOriginSettingsLauncherHelper.java
@@ -16,13 +16,14 @@ import org.chromium.chrome.browser.settings.BraveOriginPreferences;
 import org.chromium.chrome.browser.settings.SettingsNavigationFactory;
 
 /**
- * Opens the Brave Origin settings screen from native when a purchase is first detected, so the user
- * can restart to apply the newly enforced policies.
+ * Opens the Brave Origin settings screen when a purchase is first detected (from native for web
+ * purchases, or from Java when a Play Store purchase is auto-restored), so the user can restart to
+ * apply the newly enforced policies.
  */
 @NullMarked
 public class BraveOriginSettingsLauncherHelper {
     @CalledByNative
-    private static void showOriginSettingsForRestart() {
+    public static void showOriginSettingsForRestart() {
         Activity activity = ApplicationStatus.getLastTrackedFocusedActivity();
         if (activity == null) {
             return;

--- a/android/java/org/chromium/chrome/browser/brave_origin/BraveOriginSubscriptionPrefs.java
+++ b/android/java/org/chromium/chrome/browser/brave_origin/BraveOriginSubscriptionPrefs.java
@@ -145,6 +145,13 @@ public class BraveOriginSubscriptionPrefs {
                         setOriginPackageName(profile);
                         setOriginProductId(profile, activePurchaseModel.getProductId());
                         setOriginPurchaseToken(profile, activePurchaseModel.getPurchaseToken());
+                        // We only reach verifyPurchase() while the subscription pref is inactive
+                        // (see the BraveActivity guard), so a found purchase means a prior Play
+                        // Store purchase is being auto-restored. setOriginPurchaseToken() above
+                        // already started the credential fetch, so open the Origin settings screen:
+                        // it shows the spinner while credentials are fetched and prompts a restart
+                        // once the policies are enforced.
+                        BraveOriginSettingsLauncherHelper.showOriginSettingsForRestart();
                     } else {
                         setOriginProductId(profile, "");
                         setOriginPurchaseToken(profile, "");


### PR DESCRIPTION
Uplift of #37036
Resolves https://github.com/brave/brave-browser/issues/56078

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.