### PR TITLE
[Android][Origin] Flush pending prefs before restart so settings survive an immediate relaunch

### DIFF
--- a/browser/android/BUILD.gn
+++ b/browser/android/BUILD.gn
@@ -50,6 +50,7 @@ source_set("android_browser_process") {
     "//components/content_settings/core/browser",
     "//components/content_settings/core/browser:cookie_settings",
     "//components/ntp_tiles",
+    "//components/prefs",
     "//components/sync",
     "//components/translate/core/browser",
     "//components/unified_consent",

--- a/browser/android/brave_relaunch_utils.cc
+++ b/browser/android/brave_relaunch_utils.cc
@@ -4,12 +4,34 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "chrome/android/chrome_jni_headers/BraveRelaunchUtils_jni.h"
+#include "chrome/browser/browser_process.h"
 #include "chrome/browser/lifetime/application_lifetime.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/profiles/profile_manager.h"
+#include "components/prefs/pref_service.h"
 
 namespace chrome {
 namespace android {
 
 void JNI_BraveRelaunchUtils_Restart(JNIEnv* env) {
+  // Pref changes are batched and written to disk asynchronously. The Android
+  // restart path finishes activities and then SIGKILLs the browser process
+  // from a sibling process (BrowserRestartActivity) without a graceful prefs
+  // flush, so a setting changed shortly before a restart can be lost if it
+  // hasn't been written out yet. Flush pending pref writes synchronously here,
+  // mirroring BrowserProcessImpl::EndSession() on desktop, so changes survive
+  // the restart.
+  if (auto* local_state = g_browser_process->local_state()) {
+    local_state->CommitPendingWrite();
+  }
+  if (auto* profile_manager = g_browser_process->profile_manager()) {
+    for (Profile* profile : profile_manager->GetLoadedProfiles()) {
+      if (profile->GetPrefs()) {
+        profile->GetPrefs()->CommitPendingWrite();
+      }
+    }
+  }
+
   chrome::AttemptRestart();
 }
 


### PR DESCRIPTION
Changing a setting and immediately restarting (e.g. "Restart now" on the Brave Origin screen) could discard the change; waiting a few seconds avoided it.

Pref writes are batched behind a timer and flushed to disk later. The Android restart path SIGKILLs the browser process from a sibling process (`BrowserRestartActivity`) with no graceful shutdown, so pending prefs are never flushed. Whether a change survived depended on an unrelated write happening to flush the store first, hence the intermittent, single-device reports.

Flush local_state and each loaded profile's prefs via `CommitPendingWrite()` before `AttemptRestart()`. It is async-to-disk, a no-op when nothing is pending, and the write is atomic.

Resolves: https://github.com/brave/brave-browser/issues/56075


<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
