### PR TITLE
Add "load after restore" feature to backup results service (uplift to 1.91.x)

### DIFF
--- a/browser/brave_search/backup_results_service_browsertest.cc
+++ b/browser/brave_search/backup_results_service_browsertest.cc
@@ -39,6 +39,10 @@ constexpr char kTestCustomHeaderName[] = "X-Custom-Header";
 constexpr char kTestCustomHeaderValue[] = "test-value";
 constexpr char kTestUAOverride[] = "TestBrowser/1.0";
 
+constexpr char kTestRootPath[] = "/";
+constexpr char kTestRootHtml[] =
+    "<!doctype html><html><body>Root Content</body></html>";
+
 constexpr char kTestInitPath[] = "/test";
 constexpr char kTestInitHtml[] = R"(
 <!doctype html>
@@ -101,6 +105,7 @@ class BackupResultsServiceBrowserTest : public InProcessBrowserTest {
     response->set_content_type("text/html");
 
     auto url = request.GetURL();
+    request_paths_.emplace_back(url.path());
     if (auto* v = base::FindOrNull(request.headers, kTestCustomHeaderName)) {
       last_custom_header_ = *v;
     }
@@ -108,7 +113,9 @@ class BackupResultsServiceBrowserTest : public InProcessBrowserTest {
                                    net::HttpRequestHeaders::kUserAgent)) {
       last_user_agent_ = *v;
     }
-    if (url.path() == kTestInitPath) {
+    if (url.path() == kTestRootPath) {
+      response->set_content(kTestRootHtml);
+    } else if (url.path() == kTestInitPath) {
       response->set_content(redirect_to_invalid_domain_
                                 ? kTestInitInvalidRedirectHtml
                                 : kTestInitHtml);
@@ -142,6 +149,7 @@ class BackupResultsServiceBrowserTest : public InProcessBrowserTest {
 
   std::optional<std::string> last_custom_header_;
   std::optional<std::string> last_user_agent_;
+  std::vector<std::string> request_paths_;
 };
 
 IN_PROC_BROWSER_TEST_F(BackupResultsServiceBrowserTest, BasicRenderAndLoad) {
@@ -161,6 +169,8 @@ IN_PROC_BROWSER_TEST_F(BackupResultsServiceBrowserTest, BasicRenderAndLoad) {
               EXPECT_FALSE(last_custom_header_);
               EXPECT_TRUE(last_user_agent_);
               EXPECT_NE(last_user_agent_, kTestUAOverride);
+              EXPECT_EQ(request_paths_, (std::vector<std::string>{
+                                            kTestInitPath, kTestFinalPath}));
               run_loop.Quit();
             }));
     run_loop.Run();
@@ -168,6 +178,7 @@ IN_PROC_BROWSER_TEST_F(BackupResultsServiceBrowserTest, BasicRenderAndLoad) {
 
   BackupResultsServiceImpl::RecordLastViewSize(g_browser_process->local_state(),
                                                gfx::Size(1280, 720));
+  request_paths_.clear();
 
   {
     base::RunLoop run_loop;
@@ -180,6 +191,8 @@ IN_PROC_BROWSER_TEST_F(BackupResultsServiceBrowserTest, BasicRenderAndLoad) {
                 EXPECT_EQ(kTestFinalHtml, result->html);
                 EXPECT_EQ(net::HTTP_OK, result->final_status_code);
               }
+              EXPECT_EQ(request_paths_, (std::vector<std::string>{
+                                            kTestInitPath, kTestFinalPath}));
               run_loop.Quit();
             }));
     run_loop.Run();
@@ -195,6 +208,7 @@ IN_PROC_BROWSER_TEST_F(BackupResultsServiceBrowserTest, InvalidDomain) {
       base::BindLambdaForTesting(
           [&](std::optional<BackupResultsService::BackupResults> result) {
             EXPECT_FALSE(result.has_value());
+            EXPECT_TRUE(request_paths_.empty());
             run_loop.Quit();
           }));
 
@@ -212,6 +226,8 @@ IN_PROC_BROWSER_TEST_F(BackupResultsServiceBrowserTest, InvalidRedirect) {
       base::BindLambdaForTesting(
           [&](std::optional<BackupResultsService::BackupResults> result) {
             EXPECT_FALSE(result.has_value());
+            EXPECT_EQ(request_paths_,
+                      (std::vector<std::string>{kTestInitPath}));
             run_loop.Quit();
           }));
 
@@ -237,6 +253,8 @@ IN_PROC_BROWSER_TEST_F(BackupResultsServiceBrowserTest, CookieHeader) {
             EXPECT_FALSE(last_custom_header_);
             EXPECT_TRUE(last_user_agent_);
             EXPECT_NE(last_user_agent_, kTestUAOverride);
+            EXPECT_EQ(request_paths_,
+                      (std::vector<std::string>{kTestFinalPath}));
             run_loop.Quit();
           }));
 
@@ -265,6 +283,8 @@ IN_PROC_BROWSER_TEST_F(BackupResultsServiceFullRenderBrowserTest, FullRender) {
               EXPECT_EQ(kTestFinalHtml, result->html);
               EXPECT_EQ(net::HTTP_OK, result->final_status_code);
             }
+            EXPECT_EQ(request_paths_, (std::vector<std::string>{
+                                          kTestInitPath, kTestFinalPath}));
             run_loop.Quit();
           }));
 
@@ -289,6 +309,7 @@ IN_PROC_BROWSER_TEST_F(BackupResultsServiceDisabledBrowserTest,
       base::BindLambdaForTesting(
           [&](std::optional<BackupResultsService::BackupResults> result) {
             EXPECT_FALSE(result.has_value());
+            EXPECT_TRUE(request_paths_.empty());
             run_loop.Quit();
           }));
 
@@ -301,8 +322,9 @@ class BackupResultsServiceFeatureHeadersBrowserTest
   BackupResultsServiceFeatureHeadersBrowserTest() {
     scoped_feature_list_.InitWithFeaturesAndParameters(
         {{features::kBackupResults,
-          {{"headers", absl::StrFormat("{\"%s\":\"%s\"}", kTestCustomHeaderName,
-                                       kTestCustomHeaderValue)}}}},
+          {{features::kBackupResultsHeaders.name,
+            absl::StrFormat("{\"%s\":\"%s\"}", kTestCustomHeaderName,
+                            kTestCustomHeaderValue)}}}},
         {});
   }
 };
@@ -323,6 +345,8 @@ IN_PROC_BROWSER_TEST_F(BackupResultsServiceFeatureHeadersBrowserTest,
             EXPECT_EQ(last_custom_header_, kTestCustomHeaderValue);
             EXPECT_TRUE(last_user_agent_);
             EXPECT_NE(last_user_agent_, kTestUAOverride);
+            EXPECT_EQ(request_paths_,
+                      (std::vector<std::string>{kTestFinalPath}));
             run_loop.Quit();
           }));
 
@@ -342,6 +366,8 @@ IN_PROC_BROWSER_TEST_F(BackupResultsServiceFeatureHeadersBrowserTest,
             EXPECT_EQ(last_custom_header_, kTestCustomHeaderValue);
             EXPECT_TRUE(last_user_agent_);
             EXPECT_NE(last_user_agent_, kTestUAOverride);
+            EXPECT_EQ(request_paths_, (std::vector<std::string>{
+                                          kTestInitPath, kTestFinalPath}));
             run_loop.Quit();
           }));
 
@@ -353,7 +379,9 @@ class BackupResultsServiceUAOverrideBrowserTest
  public:
   BackupResultsServiceUAOverrideBrowserTest() {
     scoped_feature_list_.InitWithFeaturesAndParameters(
-        {{features::kBackupResults, {{"ua_override", kTestUAOverride}}}}, {});
+        {{features::kBackupResults,
+          {{features::kBackupResultsUAOverride.name, kTestUAOverride}}}},
+        {});
   }
 };
 
@@ -367,6 +395,8 @@ IN_PROC_BROWSER_TEST_F(BackupResultsServiceUAOverrideBrowserTest, WebContents) {
           [&](std::optional<BackupResultsService::BackupResults> result) {
             EXPECT_TRUE(result.has_value());
             EXPECT_EQ(last_user_agent_, kTestUAOverride);
+            EXPECT_EQ(request_paths_, (std::vector<std::string>{
+                                          kTestInitPath, kTestFinalPath}));
             run_loop.Quit();
           }));
 
@@ -393,7 +423,8 @@ class BackupResultsServiceUAOverrideWithMetadataBrowserTest
 
     scoped_feature_list_.InitWithFeaturesAndParameters(
         {{features::kBackupResults,
-          {{"ua_override", kTestUAOverride}, {"ua_metadata", encoded}}}},
+          {{features::kBackupResultsUAOverride.name, kTestUAOverride},
+           {features::kBackupResultsUAMetadata.name, encoded}}}},
         {});
   }
 };
@@ -409,6 +440,8 @@ IN_PROC_BROWSER_TEST_F(BackupResultsServiceUAOverrideWithMetadataBrowserTest,
           [&](std::optional<BackupResultsService::BackupResults> result) {
             EXPECT_TRUE(result.has_value());
             EXPECT_EQ(last_user_agent_, kTestUAOverride);
+            EXPECT_EQ(request_paths_, (std::vector<std::string>{
+                                          kTestInitPath, kTestFinalPath}));
             run_loop.Quit();
           }));
 
@@ -420,7 +453,9 @@ class BackupResultsServiceDailyLimitBrowserTest
  public:
   BackupResultsServiceDailyLimitBrowserTest() {
     scoped_feature_list_.InitWithFeaturesAndParameters(
-        {{features::kBackupResults, {{"max_daily_requests", "2"}}}}, {});
+        {{features::kBackupResults,
+          {{features::kBackupResultsMaxDailyRequests.name, "2"}}}},
+        {});
   }
 };
 
@@ -434,16 +469,21 @@ IN_PROC_BROWSER_TEST_F(BackupResultsServiceDailyLimitBrowserTest,
 
   // First two requests should succeed (limit is 2).
   for (int i = 0; i < 2; i++) {
+    request_paths_.clear();
     base::RunLoop run_loop;
     backup_results_service_->FetchBackupResults(
         url, headers,
         base::BindLambdaForTesting(
             [&](std::optional<BackupResultsService::BackupResults> result) {
               EXPECT_TRUE(result.has_value());
+              EXPECT_EQ(request_paths_,
+                        (std::vector<std::string>{kTestFinalPath}));
               run_loop.Quit();
             }));
     run_loop.Run();
   }
+
+  request_paths_.clear();
 
   // Third request should be rejected immediately.
   {
@@ -454,6 +494,7 @@ IN_PROC_BROWSER_TEST_F(BackupResultsServiceDailyLimitBrowserTest,
             [&](std::optional<BackupResultsService::BackupResults> result) {
               EXPECT_FALSE(result.has_value());
               run_loop.Quit();
+              EXPECT_TRUE(request_paths_.empty());
             }));
     run_loop.Run();
   }
@@ -471,6 +512,8 @@ IN_PROC_BROWSER_TEST_F(BackupResultsServiceDailyLimitBrowserTest,
         base::BindLambdaForTesting(
             [&](std::optional<BackupResultsService::BackupResults> result) {
               EXPECT_TRUE(result.has_value());
+              EXPECT_EQ(request_paths_,
+                        (std::vector<std::string>{kTestFinalPath}));
               run_loop.Quit();
             }));
     run_loop.Run();
@@ -485,13 +528,53 @@ IN_PROC_BROWSER_TEST_F(BackupResultsServiceBrowserTest, NoDailyLimitByDefault) {
 
   for (int i = 0; i < 5; i++) {
     base::RunLoop run_loop;
+    request_paths_.clear();
     backup_results_service_->FetchBackupResults(
         url, headers,
         base::BindLambdaForTesting(
             [&](std::optional<BackupResultsService::BackupResults> result) {
               EXPECT_TRUE(result.has_value());
+              EXPECT_EQ(request_paths_,
+                        (std::vector<std::string>{kTestFinalPath}));
               run_loop.Quit();
             }));
+    run_loop.Run();
+  }
+}
+
+class BackupResultsServiceLoadAfterRestoreBrowserTest
+    : public BackupResultsServiceBrowserTest {
+ public:
+  BackupResultsServiceLoadAfterRestoreBrowserTest() {
+    scoped_feature_list_.InitWithFeaturesAndParameters(
+        {{features::kBackupResults,
+          {{features::kBackupResultsLoadAfterRestore.name, "true"}}}},
+        {});
+  }
+};
+
+IN_PROC_BROWSER_TEST_F(BackupResultsServiceLoadAfterRestoreBrowserTest,
+                       LoadAfterRestore) {
+  GURL url = https_server_->GetURL("google.ca", kTestInitPath);
+
+  for (bool low_latency_required : {false, true}) {
+    request_paths_.clear();
+    base::RunLoop run_loop;
+    backup_results_service_->FetchBackupResults(
+        url, std::nullopt,
+        base::BindLambdaForTesting(
+            [&](std::optional<BackupResultsService::BackupResults> result) {
+              EXPECT_TRUE(result.has_value());
+              if (result) {
+                EXPECT_EQ(kTestFinalHtml, result->html);
+                EXPECT_EQ(net::HTTP_OK, result->final_status_code);
+              }
+              EXPECT_EQ(request_paths_,
+                        (std::vector<std::string>{kTestRootPath, kTestInitPath,
+                                                  kTestFinalPath}));
+              run_loop.Quit();
+            }),
+        low_latency_required);
     run_loop.Run();
   }
 }

--- a/browser/brave_search/backup_results_service_impl.cc
+++ b/browser/brave_search/backup_results_service_impl.cc
@@ -84,6 +84,7 @@ constexpr net::NetworkTrafficAnnotationTag kNetworkTrafficAnnotationTag =
 
 constexpr base::ByteCount kMaxResponseSize = base::MiB(5);
 constexpr base::TimeDelta kTimeout = base::Seconds(5);
+constexpr base::TimeDelta kLoadAfterRestoreTimeout = base::Seconds(12);
 
 class BackupResultsWebContentsObserver
     : public content::WebContentsObserver,
@@ -147,7 +148,8 @@ void BackupResultsServiceImpl::RecordLastViewSize(PrefService* local_state,
 void BackupResultsServiceImpl::FetchBackupResults(
     const GURL& url,
     std::optional<net::HttpRequestHeaders> headers,
-    BackupResultsCallback callback) {
+    BackupResultsCallback callback,
+    bool low_latency_required) {
   if (!profile_ || !base::FeatureList::IsEnabled(features::kBackupResults) ||
       UpdateDailyRequestCount()) {
     std::move(callback).Run(std::nullopt);
@@ -204,39 +206,27 @@ void BackupResultsServiceImpl::FetchBackupResults(
 
     SeedNavigationHistory(*web_contents, url);
 
-    if (features::IsBackupResultsFullRenderEnabled()) {
-      BackupResultsWebContentsObserver::CreateForWebContents(
-          web_contents.get(), weak_ptr_factory_.GetWeakPtr());
-    }
+    BackupResultsWebContentsObserver::CreateForWebContents(
+        web_contents.get(), weak_ptr_factory_.GetWeakPtr());
   }
 
-  auto request = pending_requests_.emplace(pending_requests_.end(),
-                                           std::move(web_contents), headers,
-                                           otr_profile, std::move(callback));
+  auto request = pending_requests_.emplace(
+      pending_requests_.end(), std::move(web_contents), headers, otr_profile,
+      low_latency_required, std::move(callback));
 
   if (should_render) {
-    auto load_url_params = content::NavigationController::LoadURLParams(url);
-    load_url_params.transition_type = ui::PAGE_TRANSITION_LINK;
-    // Disallow all downloads
-    for (size_t i = 0;
-         i <= static_cast<size_t>(blink::NavigationDownloadType::kMaxValue);
-         i++) {
-      blink::NavigationDownloadType type =
-          static_cast<blink::NavigationDownloadType>(i);
-      load_url_params.download_policy.SetDisallowed(type);
+    const bool load_after_restore =
+        features::kBackupResultsLoadAfterRestore.Get();
+    request->target_url = url;
+    if (!load_after_restore) {
+      if (!LoadTargetUrl(request)) {
+        return;
+      }
     }
-    auto extra_headers = GetExtraHeaders(request->headers);
-    if (!extra_headers.IsEmpty()) {
-      load_url_params.extra_headers = extra_headers.ToString();
-    }
-    MaybeApplyUserAgentOverride(*request->web_contents, load_url_params);
-    if (!request->web_contents->GetController().LoadURLWithParams(
-            load_url_params)) {
-      CleanupAndDispatchResult(request, std::nullopt);
-      return;
-    }
+    const base::TimeDelta timeout =
+        load_after_restore ? kLoadAfterRestoreTimeout : kTimeout;
     request->timeout_timer.Start(
-        FROM_HERE, kTimeout,
+        FROM_HERE, timeout,
         base::BindOnce(&BackupResultsServiceImpl::CleanupAndDispatchResult,
                        base::Unretained(this), request, std::nullopt));
   } else {
@@ -248,9 +238,11 @@ BackupResultsServiceImpl::PendingRequest::PendingRequest(
     std::unique_ptr<content::WebContents> web_contents,
     std::optional<net::HttpRequestHeaders> headers,
     Profile* otr_profile,
+    bool low_latency_required,
     BackupResultsCallback callback)
     : headers(std::move(headers)),
       callback(std::move(callback)),
+      low_latency_required(low_latency_required),
       web_contents(std::move(web_contents)),
       otr_profile(otr_profile) {}
 
@@ -285,6 +277,10 @@ bool BackupResultsServiceImpl::HandleWebContentsStartRequest(
                features::kBackupResultsFullRenderMaxRequests.Get());
   }
   if (!pending_request->initial_request_started) {
+    if (features::kBackupResultsLoadAfterRestore.Get() &&
+        url != pending_request->target_url) {
+      return true;
+    }
     pending_request->initial_request_started = true;
     return true;
   }
@@ -310,14 +306,37 @@ void BackupResultsServiceImpl::HandleWebContentsDidFinishLoad(
     return;
   }
   pending_request->requests_loaded++;
-  if (pending_request->requests_loaded ==
-      static_cast<size_t>(
-          features::kBackupResultsFullRenderMaxRequests.Get())) {
+
+  if (features::IsBackupResultsFullRenderEnabled() &&
+      pending_request->requests_loaded ==
+          static_cast<size_t>(
+              features::kBackupResultsFullRenderMaxRequests.Get())) {
     content_extraction::GetInnerHtml(
         *pending_request->web_contents->GetPrimaryMainFrame(),
         base::BindOnce(
             &BackupResultsServiceImpl::HandleWebContentsContentExtraction,
             weak_ptr_factory_.GetWeakPtr(), pending_request));
+    return;
+  }
+
+  if (features::kBackupResultsLoadAfterRestore.Get() &&
+      pending_request->web_contents->GetLastCommittedURL() !=
+          pending_request->target_url) {
+    // Root page has loaded; schedule load of the actual target URL after a
+    // randomized delay.
+    const base::TimeDelta delay_min =
+        pending_request->low_latency_required
+            ? features::kBackupResultsLoadAfterRestoreLowDelayMin.Get()
+            : features::kBackupResultsLoadAfterRestoreDelayMin.Get();
+    const base::TimeDelta delay_max =
+        pending_request->low_latency_required
+            ? features::kBackupResultsLoadAfterRestoreLowDelayMax.Get()
+            : features::kBackupResultsLoadAfterRestoreDelayMax.Get();
+    const base::TimeDelta delay = base::RandTimeDelta(delay_min, delay_max);
+    pending_request->load_after_restore_timer.Start(
+        FROM_HERE, delay,
+        base::BindOnce(&BackupResultsServiceImpl::OnLoadAfterRestoreTimer,
+                       base::Unretained(this), pending_request));
   }
 }
 
@@ -401,6 +420,10 @@ void BackupResultsServiceImpl::SeedNavigationHistory(
   entries.push_back(std::move(entry));
   web_contents.GetController().Restore(
       /*selected_navigation=*/0, content::RestoreType::kRestored, &entries);
+
+  if (features::kBackupResultsLoadAfterRestore.Get()) {
+    web_contents.GetController().LoadIfNecessary();
+  }
 }
 
 void BackupResultsServiceImpl::MakeSimpleURLLoaderRequest(
@@ -437,6 +460,39 @@ void BackupResultsServiceImpl::MakeSimpleURLLoaderRequest(
       base::BindOnce(&BackupResultsServiceImpl::HandleURLLoaderResponse,
                      base::Unretained(this), pending_request),
       kMaxResponseSize.InBytes());
+}
+
+void BackupResultsServiceImpl::OnLoadAfterRestoreTimer(
+    PendingRequestList::iterator pending_request) {
+  LoadTargetUrl(pending_request);
+}
+
+bool BackupResultsServiceImpl::LoadTargetUrl(
+    PendingRequestList::iterator pending_request) {
+  if (!pending_request->web_contents) {
+    return false;
+  }
+  auto load_url_params =
+      content::NavigationController::LoadURLParams(pending_request->target_url);
+  load_url_params.transition_type = ui::PAGE_TRANSITION_LINK;
+  for (size_t i = 0;
+       i <= static_cast<size_t>(blink::NavigationDownloadType::kMaxValue);
+       i++) {
+    blink::NavigationDownloadType type =
+        static_cast<blink::NavigationDownloadType>(i);
+    load_url_params.download_policy.SetDisallowed(type);
+  }
+  auto extra_headers = GetExtraHeaders(pending_request->headers);
+  if (!extra_headers.IsEmpty()) {
+    load_url_params.extra_headers = extra_headers.ToString();
+  }
+  MaybeApplyUserAgentOverride(*pending_request->web_contents, load_url_params);
+  if (!pending_request->web_contents->GetController().LoadURLWithParams(
+          load_url_params)) {
+    CleanupAndDispatchResult(pending_request, std::nullopt);
+    return false;
+  }
+  return true;
 }
 
 void BackupResultsServiceImpl::HandleURLLoaderResponse(

--- a/browser/brave_search/backup_results_service_impl.h
+++ b/browser/brave_search/backup_results_service_impl.h
@@ -54,7 +54,8 @@ class BackupResultsServiceImpl : public BackupResultsService,
 
   void FetchBackupResults(const GURL& url,
                           std::optional<net::HttpRequestHeaders> headers,
-                          BackupResultsCallback callback) override;
+                          BackupResultsCallback callback,
+                          bool low_latency_required = false) override;
 
   bool HandleWebContentsStartRequest(const content::WebContents* web_contents,
                                      const GURL& url) override;
@@ -76,13 +77,16 @@ class BackupResultsServiceImpl : public BackupResultsService,
     PendingRequest(std::unique_ptr<content::WebContents> web_contents,
                    std::optional<net::HttpRequestHeaders> headers,
                    Profile* otr_profile,
+                   bool low_latency_required,
                    BackupResultsCallback callback);
     ~PendingRequest();
 
     std::optional<net::HttpRequestHeaders> headers;
     BackupResultsCallback callback;
 
+    bool low_latency_required;
     std::unique_ptr<content::WebContents> web_contents;
+    GURL target_url;
 
     raw_ptr<Profile> otr_profile;
     scoped_refptr<network::SharedURLLoaderFactory> shared_url_loader_factory;
@@ -92,6 +96,7 @@ class BackupResultsServiceImpl : public BackupResultsService,
     size_t requests_loaded = 0;
     int last_response_code = -1;
     base::OneShotTimer timeout_timer;
+    base::OneShotTimer load_after_restore_timer;
   };
   using PendingRequestList = std::list<PendingRequest>;
 
@@ -102,6 +107,8 @@ class BackupResultsServiceImpl : public BackupResultsService,
                                   const GURL& url);
   void HandleURLLoaderResponse(PendingRequestList::iterator pending_request,
                                std::optional<std::string> html);
+  bool LoadTargetUrl(PendingRequestList::iterator pending_request);
+  void OnLoadAfterRestoreTimer(PendingRequestList::iterator pending_request);
 
   void HandleWebContentsContentExtraction(
       PendingRequestList::iterator pending_request,

--- a/components/brave_search/browser/backup_results_service.h
+++ b/components/brave_search/browser/backup_results_service.h
@@ -51,7 +51,8 @@ class BackupResultsService : public KeyedService {
   virtual void FetchBackupResults(
       const GURL& url,
       std::optional<net::HttpRequestHeaders> headers,
-      BackupResultsCallback callback) = 0;
+      BackupResultsCallback callback,
+      bool low_latency_required = false) = 0;
 
   // Called by BackupResultsNavigationThrottle. Returns true if request should
   // continue.

--- a/components/brave_search/browser/brave_search_fallback_host.cc
+++ b/components/brave_search/browser/brave_search_fallback_host.cc
@@ -88,7 +88,8 @@ void BraveSearchFallbackHost::FetchBackupResults(
   backup_results_service_->FetchBackupResults(
       url, headers,
       base::BindOnce(&BraveSearchFallbackHost::OnResultsAvailable,
-                     weak_factory_.GetWeakPtr(), std::move(callback)));
+                     weak_factory_.GetWeakPtr(), std::move(callback)),
+      /*low_latency_required=*/true);
 }
 
 void BraveSearchFallbackHost::OnResultsAvailable(

--- a/components/brave_search/common/features.cc
+++ b/components/brave_search/common/features.cc
@@ -48,4 +48,27 @@ const base::FeatureParam<std::string> kBackupResultsUAMetadata{
 const base::FeatureParam<int> kBackupResultsMaxDailyRequests{
     &kBackupResults, "max_daily_requests", -1};
 
+const base::FeatureParam<bool> kBackupResultsLoadAfterRestore{
+    &kBackupResults, "load_after_restore", false};
+
+const base::FeatureParam<base::TimeDelta>
+    kBackupResultsLoadAfterRestoreDelayMin{&kBackupResults,
+                                           "load_after_restore_delay_min",
+                                           base::Milliseconds(3000)};
+
+const base::FeatureParam<base::TimeDelta>
+    kBackupResultsLoadAfterRestoreDelayMax{&kBackupResults,
+                                           "load_after_restore_delay_max",
+                                           base::Milliseconds(6000)};
+
+const base::FeatureParam<base::TimeDelta>
+    kBackupResultsLoadAfterRestoreLowDelayMin{
+        &kBackupResults, "load_after_restore_low_delay_min",
+        base::Milliseconds(0)};
+
+const base::FeatureParam<base::TimeDelta>
+    kBackupResultsLoadAfterRestoreLowDelayMax{
+        &kBackupResults, "load_after_restore_low_delay_max",
+        base::Milliseconds(1500)};
+
 }  // namespace brave_search::features

--- a/components/brave_search/common/features.h
+++ b/components/brave_search/common/features.h
@@ -8,6 +8,7 @@
 
 #include "base/feature_list.h"
 #include "base/metrics/field_trial_params.h"
+#include "base/time/time.h"
 
 namespace brave_search {
 namespace features {
@@ -44,6 +45,21 @@ extern const base::FeatureParam<std::string> kBackupResultsUAOverride;
 extern const base::FeatureParam<std::string> kBackupResultsUAMetadata;
 // Maximum number of backup results fetches allowed per day. -1 means no limit.
 extern const base::FeatureParam<int> kBackupResultsMaxDailyRequests;
+// If true, seeds navigation history and loads the root URL first, then
+// loads the actual target URL after a randomized delay following
+// the root page's load completion.
+extern const base::FeatureParam<bool> kBackupResultsLoadAfterRestore;
+// Randomized delay range before loading the target URL after root page restore.
+// Used when low_latency_required is false.
+extern const base::FeatureParam<base::TimeDelta>
+    kBackupResultsLoadAfterRestoreDelayMin;
+extern const base::FeatureParam<base::TimeDelta>
+    kBackupResultsLoadAfterRestoreDelayMax;
+// Randomized delay range used when low_latency_required is true.
+extern const base::FeatureParam<base::TimeDelta>
+    kBackupResultsLoadAfterRestoreLowDelayMin;
+extern const base::FeatureParam<base::TimeDelta>
+    kBackupResultsLoadAfterRestoreLowDelayMax;
 
 }  // namespace features
 }  // namespace brave_search

--- a/components/web_discovery/browser/web_discovery_service_unittest.cc
+++ b/components/web_discovery/browser/web_discovery_service_unittest.cc
@@ -30,7 +30,8 @@ class WebDiscoveryServiceTest : public testing::Test {
     // Override virtual methods with empty implementations
     void FetchBackupResults(const GURL& url,
                             std::optional<net::HttpRequestHeaders> headers,
-                            BackupResultsCallback callback) override {}
+                            BackupResultsCallback callback,
+                            bool low_latency_required = false) override {}
 
     bool HandleWebContentsStartRequest(const content::WebContents* web_contents,
                                        const GURL& url) override {


### PR DESCRIPTION
Uplift of #36999
Resolves https://github.com/brave/brave-browser/issues/56100

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.