### PR TITLE
[Android][Origin] Flush pending prefs before restart so settings survive an immediate relaunch (uplift to 1.92.x)

### DIFF
--- a/browser/android/BUILD.gn
+++ b/browser/android/BUILD.gn
@@ -50,6 +50,7 @@ source_set("android_browser_process") {
     "//components/content_settings/core/browser",
     "//components/content_settings/core/browser:cookie_settings",
     "//components/ntp_tiles",
+    "//components/prefs",
     "//components/sync",
     "//components/translate/core/browser",
     "//components/unified_consent",

--- a/browser/android/brave_relaunch_utils.cc
+++ b/browser/android/brave_relaunch_utils.cc
@@ -4,12 +4,34 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "chrome/android/chrome_jni_headers/BraveRelaunchUtils_jni.h"
+#include "chrome/browser/browser_process.h"
 #include "chrome/browser/lifetime/application_lifetime.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/profiles/profile_manager.h"
+#include "components/prefs/pref_service.h"
 
 namespace chrome {
 namespace android {
 
 void JNI_BraveRelaunchUtils_Restart(JNIEnv* env) {
+  // Pref changes are batched and written to disk asynchronously. The Android
+  // restart path finishes activities and then SIGKILLs the browser process
+  // from a sibling process (BrowserRestartActivity) without a graceful prefs
+  // flush, so a setting changed shortly before a restart can be lost if it
+  // hasn't been written out yet. Flush pending pref writes synchronously here,
+  // mirroring BrowserProcessImpl::EndSession() on desktop, so changes survive
+  // the restart.
+  if (auto* local_state = g_browser_process->local_state()) {
+    local_state->CommitPendingWrite();
+  }
+  if (auto* profile_manager = g_browser_process->profile_manager()) {
+    for (Profile* profile : profile_manager->GetLoadedProfiles()) {
+      if (profile->GetPrefs()) {
+        profile->GetPrefs()->CommitPendingWrite();
+      }
+    }
+  }
+
   chrome::AttemptRestart();
 }
 


### PR DESCRIPTION
Uplift of #37046
Resolves https://github.com/brave/brave-browser/issues/56075

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.