### PR TITLE
[git-cr] Adding `git cr commit --fixup=reassign:hash`

### DIFF
--- a/tools/cr/alias/README.md
+++ b/tools/cr/alias/README.md
@@ -37,6 +37,21 @@ git cr commit --culprit abc123,def456 -m "Adjust to upstream API change"
 [commit-msg hook behaviour](#commit-msg-hook-behaviour) section below for more
 details.
 
+#### `--fixup=reassign:<ref>`
+
+Git understands `--fixup=<ref>`, `--fixup=amend:<ref>`, and
+`--fixup=reword:<ref>`. `git cr commit` extends this family with a brave-core
+`reassign:` mode, which is a shortcut for `brockit.py reassign <ref>`:
+
+```sh
+git cr commit --fixup=reassign:HEAD~2
+```
+
+This creates the empty `reassign!<hash>!` commit that `brockit rebase` later
+squashes onto its target to swap authorship. Because brockit owns the resulting
+commit, this mode must stand alone — combining it with any other argument is an
+error.
+
 ### `git cr mv`
 
 Move a file or directory inside `brave-core` and repair every artefact that

--- a/tools/cr/alias/commit.py
+++ b/tools/cr/alias/commit.py
@@ -15,6 +15,7 @@ Usage
 
   git cr commit -m "Fix login button alignment"
   git cr commit --tagged WIP -m "Work in progress"
+  git cr commit --fixup=reassign:<ref>   # shortcut for `brockit.py reassign`
 
   Custom flags (forwarded to the commit-msg hook via environment variables):
     --tagged    Comma-separated tags            → $tags
@@ -31,6 +32,8 @@ import os
 import platform
 import stat
 import subprocess
+from dataclasses import dataclass
+from typing import ClassVar, NoReturn
 
 import _boot  # noqa: F401
 from alias.base import (HOOK_DEST, WINDOWS_SHIM, UserValidationError,
@@ -78,8 +81,99 @@ def _run_commit(
                           env=env).returncode
 
 
+class _LenientArgumentParser(argparse.ArgumentParser):
+    """An `ArgumentParser` that raises instead of terminating on error.
+
+    This class is useful when parsing shortcuts, as we just bail out when the
+    arguments don't match.
+    """
+
+    def error(self, message: str) -> NoReturn:
+        raise ValueError(message)
+
+
+@dataclass(frozen=True)
+class _ReassignShortcut:
+    """The `git cr commit --fixup=reassign:<ref>` shortcut.
+
+    This is a convenience shortcut for brockit's `reassign` task. It can be used
+    either as:
+      git cr commit --fixup=reassign:HEAD
+
+    or
+      git cr commit --fixup reassign:HEAD
+
+    `from_args` is the entry point: it returns a ready-to-run instance when
+    the shortcut is present and valid, or None when the args are an ordinary
+    commit.
+    """
+
+    # Value prefix that selects this mode, mirroring git's own `amend:` /
+    # `reword:` fixup modes.
+    _PREFIX: ClassVar[str] = 'reassign:'
+
+    # The commit reference whose authorship is being reassigned.
+    target: str
+
+    @staticmethod
+    def from_args(args: list[str]) -> _ReassignShortcut | None:
+        """Build the shortcut from *args*, or return None when it isn't used.
+
+        This function checks for the presence of the reassign shortcut use that
+        we are interested in, and if found, parses out the args provided,
+        strictly looking only for `--fixup` and validating the format used for
+        its value.
+        """
+        if not any(_ReassignShortcut._PREFIX in arg for arg in args):
+            return None
+
+        parser = _LenientArgumentParser(add_help=False)
+        parser.add_argument('--fixup')
+        try:
+            parsed, other_args = parser.parse_known_args(args)
+        except ValueError:
+            return None
+
+        fixup = parsed.fixup
+        if fixup is None or not fixup.startswith(_ReassignShortcut._PREFIX):
+            return None
+        if other_args:
+            raise UserValidationError(
+                'git_cr: --fixup=reassign:<ref> cannot be combined with '
+                f'other arguments; remove: {" ".join(other_args)}')
+        target = fixup[len(_ReassignShortcut._PREFIX):]
+        if not target:
+            raise UserValidationError(
+                'git_cr: --fixup=reassign: requires a commit reference, '
+                'e.g. --fixup=reassign:HEAD~2')
+        return _ReassignShortcut(target)
+
+    def run(self) -> int:
+        """Run brockit's `Reassign` task for the captured target.
+
+        The commit-msg hook is irrelevant (brockit commits with --no-verify),
+        so it is not checked.
+        """
+        # Imported lazily: brockit is a heavy module, so we only import it when
+        # needed.
+        import brockit
+        try:
+            brockit.Reassign().run(change=self.target)
+        except (brockit.InvalidInputException, brockit.BadOutcomeException,
+                brockit.ActionNeededException):
+            # Handling brockit exceptions as failures to create the reassingment
+            # commit.
+            return 1
+        return 0
+
+
 def cmd_commit(args: list[str]) -> int:
     """Parse commit flags and invoke git commit with injected environment."""
+    # Let's try first to check for the reassignment shortcut being used.
+    reassign = _ReassignShortcut.from_args(args)
+    if reassign is not None:
+        return reassign.run()
+
     parser = argparse.ArgumentParser(
         prog='git cr commit',
         description='git commit wrapper with brave-core hook flags',

--- a/tools/cr/alias/commit_test.py
+++ b/tools/cr/alias/commit_test.py
@@ -19,6 +19,7 @@ import unittest
 
 import _boot  # noqa: F401
 from cmd_test import (CMD_SCRIPT, _GIT_ENV_OVERRIDES, _Sandbox)
+from alias.commit import _ReassignShortcut
 
 # ---------------------------------------------------------------------------
 # Tests: flag pass-through
@@ -228,6 +229,138 @@ class TestCommitSanityCheck(unittest.TestCase):
         result = self._sandbox.run_gc(['commit', '-m', 'should fail'])
         self.assertNotEqual(result.returncode, 0)
         self.assertIn('install-hook', result.stderr)
+
+
+# ---------------------------------------------------------------------------
+# Tests: --fixup=reassign: shortcut (delegates to brockit reassign)
+# ---------------------------------------------------------------------------
+
+
+class TestReassignFixup(unittest.TestCase):
+    """git cr commit --fixup=reassign:<ref> delegates to brockit reassign."""
+
+    def setUp(self) -> None:
+        self._sandbox = _Sandbox()
+        self._sandbox.__enter__()
+
+    def tearDown(self) -> None:
+        self._sandbox.__exit__(None, None, None)
+
+    def _commit_count(self) -> int:
+        return int(
+            subprocess.check_output(
+                ['git', 'rev-list', '--count', 'HEAD'],
+                cwd=self._sandbox.root,
+                text=True,
+                env={
+                    **os.environ,
+                    **_GIT_ENV_OVERRIDES
+                },
+            ).strip())
+
+    def test_joined_form_creates_reassign_commit(self) -> None:
+        """--fixup=reassign:HEAD adds an empty reassign! commit on top.
+
+        No hook is installed: the shortcut must work without it because
+        brockit commits with --no-verify.
+        """
+        before = self._commit_count()
+        result = self._sandbox.run_gc(['commit', '--fixup=reassign:HEAD'])
+        self.assertEqual(result.returncode, 0, msg=f'stderr: {result.stderr}')
+        self.assertEqual(self._commit_count(), before + 1)
+        msg = self._sandbox.last_commit_message()
+        # brockit formats the subject as `reassign!<hash>! <original subject>`.
+        self.assertTrue(msg.startswith('reassign!'),
+                        msg=f'unexpected message: {msg!r}')
+        self.assertIn('Add file.txt', msg)
+
+    def test_split_form_creates_reassign_commit(self) -> None:
+        """The split spelling `--fixup reassign:HEAD` is handled too."""
+        before = self._commit_count()
+        result = self._sandbox.run_gc(['commit', '--fixup', 'reassign:HEAD'])
+        self.assertEqual(result.returncode, 0, msg=f'stderr: {result.stderr}')
+        self.assertEqual(self._commit_count(), before + 1)
+        self.assertTrue(
+            self._sandbox.last_commit_message().startswith('reassign!'))
+
+    def test_empty_ref_is_rejected(self) -> None:
+        """--fixup=reassign: with no ref errors out without committing."""
+        before = self._commit_count()
+        result = self._sandbox.run_gc(['commit', '--fixup=reassign:'])
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn('reassign', result.stderr)
+        self.assertEqual(self._commit_count(), before)
+
+    def test_extra_passthrough_arg_is_rejected(self) -> None:
+        """Mixing the shortcut with a git arg (e.g. -m) errors, no commit."""
+        before = self._commit_count()
+        result = self._sandbox.run_gc(
+            ['commit', '--fixup=reassign:HEAD', '-m', 'nope'])
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn('cannot be combined', result.stderr)
+        self.assertEqual(self._commit_count(), before)
+
+    def test_extra_wrapper_flag_is_rejected(self) -> None:
+        """Mixing the shortcut with a wrapper flag (--tagged) errors too."""
+        before = self._commit_count()
+        result = self._sandbox.run_gc(
+            ['commit', '--tagged', 'WIP', '--fixup=reassign:HEAD'])
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn('cannot be combined', result.stderr)
+        self.assertIn('--tagged', result.stderr)
+        self.assertEqual(self._commit_count(), before)
+
+    def test_native_fixup_still_passes_through_to_git(self) -> None:
+        """A plain `--fixup=<ref>` is not intercepted and reaches git.
+
+        git produces a `fixup! Add file.txt` commit, proving the wrapper only
+        claims the `reassign:` mode and leaves git's own modes alone.
+        """
+        self._sandbox.install_hook()
+        self._sandbox.stage_change('fixup body\n')
+        result = self._sandbox.run_gc(
+            ['commit', '--fixup=HEAD', '--no-verify'])
+        self.assertEqual(result.returncode, 0, msg=f'stderr: {result.stderr}')
+        msg = self._sandbox.last_commit_message()
+        self.assertTrue(msg.startswith('fixup!'),
+                        msg=f'unexpected message: {msg!r}')
+
+
+# ---------------------------------------------------------------------------
+# Tests: _ReassignShortcut.from_args detection and leniency (unit)
+# ---------------------------------------------------------------------------
+
+
+class TestReassignShortcutParsing(unittest.TestCase):
+    """Unit checks for the lenient arg detection in from_args."""
+
+    def test_detects_joined_and_split_forms(self) -> None:
+        """Both `--fixup=reassign:X` and `--fixup reassign:X` are recognised."""
+        self.assertIsNotNone(
+            _ReassignShortcut.from_args(['--fixup=reassign:HEAD']))
+        self.assertIsNotNone(
+            _ReassignShortcut.from_args(['--fixup', 'reassign:HEAD']))
+
+    def test_absent_when_no_reassign_marker(self) -> None:
+        """Ordinary commits and git's native fixup modes are not claimed."""
+        self.assertIsNone(_ReassignShortcut.from_args(['--fixup=HEAD']))
+        self.assertIsNone(_ReassignShortcut.from_args(['-m', 'a message']))
+
+    def test_marker_outside_fixup_is_not_the_shortcut(self) -> None:
+        """`reassign:` only in a commit message is not the shortcut."""
+        self.assertIsNone(
+            _ReassignShortcut.from_args(['-m', 'fix reassign: bug']))
+
+    def test_malformed_fixup_does_not_terminate(self) -> None:
+        """A `--fixup` with no value must not exit the process.
+
+        A strict ArgumentParser would call sys.exit() here; the lenient parser
+        instead reports "not the shortcut" so the caller falls back to the
+        normal commit path. `reassign:` appears in another token so the cheap
+        pre-check passes and the parse is actually attempted.
+        """
+        self.assertIsNone(
+            _ReassignShortcut.from_args(['reassign:x', '--fixup']))
 
 
 # ---------------------------------------------------------------------------

--- a/tools/cr/brockit.py
+++ b/tools/cr/brockit.py
@@ -237,6 +237,10 @@ where the author is the person running the command.
 tools/cr/brockit.py reassign <commit_hash>
 ```
 
+As a shortcut, `git cr commit --fixup=reassign:<commit_hash>` runs this exact
+command. This mirrors git's native `--fixup=amend:` / `--fixup=reword:` modes,
+adding a brave-core `reassign:` mode to the same family.
+
 This commit acts similarly to a `fixup!` commit but works in tandem with
 `brockit.py rebase`. When `brockit.py rebase` is run, the rebase process detects
 the `reassign! ` commit. It moves this commit directly above the original target


### PR DESCRIPTION
This is just a shortcut for `brockit.py reassign <hash>`.
