### PR TITLE
[brockit] Adding `drop!` command for B🚀

### DIFF
--- a/tools/cr/brockit.py
+++ b/tools/cr/brockit.py
@@ -253,6 +253,15 @@ squashed commit message by removing the `reassign! ` line and preserving the
 original commit's subject and body. Because the original commit is squashed into
 the reassignment commit, the resulting commit adopts the reassignment commit's
 authorship.
+
+### `brockit.py drop`
+This is the counterpart to `reassign`. It generates an empty commit with the
+message `drop! {original_subject}`, marking the referenced change to be dropped
+by `brockit.py rebase`.
+
+```sh
+tools/cr/brockit.py drop <commit_hash>
+```
 """
 
 from __future__ import annotations
@@ -285,7 +294,7 @@ from patchfile import Patchfile
 import plaster
 from plaster import PlasterFile, PlasterFileNeedsRegen
 import rebase_v2
-from rebase_v2 import REASSIGN_COMMIT_MSG_PREFIX
+from rebase_v2 import DROP_COMMIT_MSG_PREFIX, REASSIGN_COMMIT_MSG_PREFIX
 import repository
 from repository import Repository
 from terminal import (IncendiaryErrorHandler, Task as BaseTask, console,
@@ -2101,7 +2110,7 @@ class Rebase(Task):
         # line starting with `pick ` that matches the commit message, then
         # moving the reassign commit above it, and changing the pick line under
         # it to a `squash` line.
-        # Orphaned `reassing!` commits get intentionally silently dropped at
+        # Orphaned `reassign!` commits get intentionally silently dropped at
         # this point.
         for reassign_line in reassign:
             command, comment = [
@@ -2110,7 +2119,7 @@ class Rebase(Task):
 
             # The format of the commit reassign commit will always be:
             #
-            # reassign!ae3724d6603! [brockit] Authorship reassingment
+            # reassign!ae3724d6603! [brockit] Authorship reassignment
             #
             # The first part can be ignored. The hash is the second part, and
             # the remainder is the commit message.
@@ -2314,48 +2323,69 @@ class Rebase(Task):
             raise InvalidInputException('Rebase failed.') from e
 
 
-class Reassign(Task):
-    """Creates a reassignment commit for a given change in the branch.
+class _MarkChangeTask(Task):
+    """Base for tasks that mark a change with an empty `<prefix><hash>!` commit.
 
-    This task is used for cases where the authorship of a given change should be
-    reassigned to a different author. This class is responsible for creating an
-    empty commit whose author is the person calling this command. This commit is
-    similar to a `fixup!` commit, being called `reassign!`, followed by the
-    short hash for the change being reassigned. This change is then picked up
-    by the brockit's `rebase` command, and squashed as the base commit for the
-    original change, resulting in a change of authorship.
+    This class creates an empty commit with a subcommand that is understood by
+    brockit's `rebase` command to mark a change in the branch.
     """
 
+    # Abstract base: instantiated only through its concrete subclasses.
+    # pylint: disable=abstract-method
+
+    def __init__(self, prefix: str):
+        # The `<prefix>` placed before the target hash (e.g. `reassign!`).
+        self._prefix = prefix
+
     def status_message(self):
-        return "Creating reassignment commit..."
+        # Derive the action word from the prefix, e.g. `drop!` → "drop".
+        return f"Creating {self._prefix.rstrip('!')} commit..."
 
     def execute(self, change: str):
-        """Creates the reassignment commit.
-
-    This function creates an empty commit with the message
-    `reassign! {change}`, and the author being the user calling this
-    command.
+        """Creates the empty `<prefix><hash>! <subject>` commit.
 
     Args:
         change:
-            The change for which the authorship should be reassigned. This is
-            any valid git reference that resolves to a single commit.
+            The change to mark. This is any valid git reference that resolves
+            to a single commit.
         """
-
         status = GitStatus()
         if status.has_staged_files():
             raise InvalidInputException(
                 'Staged files detected. Please commit or unstage changes '
-                'before reassigning:\n%s' %
+                'before marking the change:\n%s' %
                 '\n'.join(status.get_all_staged_entries()))
 
         commit, message = repository.brave.run_git('log', '-1', change, '-s',
                                                    '--format=%h %s').split(
                                                        ' ', 1)
-        repository.brave.git_commit(
-            f"{REASSIGN_COMMIT_MSG_PREFIX}{commit}! {message}",
-            allows_empty=True,
-            no_verify=True)
+        repository.brave.git_commit(f"{self._prefix}{commit}! {message}",
+                                    allows_empty=True,
+                                    no_verify=True)
+
+
+class Reassign(_MarkChangeTask):
+    """Creates a reassignment commit for a given change in the branch.
+
+    This task is used for cases where the authorship of a given change should be
+    reassigned to a different author. The empty `reassign!` commit it creates is
+    picked up by brockit's `rebase` command and squashed as the base commit for
+    the original change, resulting in a change of authorship.
+    """
+
+    def __init__(self):
+        super().__init__(REASSIGN_COMMIT_MSG_PREFIX)
+
+
+class Drop(_MarkChangeTask):
+    """Creates a drop commit for a given change in the branch.
+
+    This task is used to create a `drop!` commit, which gets picked up by the
+    rebase engine, and causes the target change to be dropped during rebase.
+    """
+
+    def __init__(self):
+        super().__init__(DROP_COMMIT_MSG_PREFIX)
 
 
 class UpdateXcodeToolchain(Task):
@@ -3412,6 +3442,14 @@ def main():
         'change',
         help='The commit reference to reassign (hash, HEAD~N, etc.).')
 
+    drop_parser = subparsers.add_parser(
+        'drop',
+        parents=[global_parser],
+        help=(f'Creates a {DROP_COMMIT_MSG_PREFIX} commit marking a given '
+              'change to be dropped during rebase.'))
+    drop_parser.add_argument(
+        'change', help='The commit reference to drop (hash, HEAD~N, etc.).')
+
     update_xcode_parser = subparsers.add_parser(
         'update-xcode-toolchain',
         parents=[global_parser],
@@ -3532,6 +3570,8 @@ def main():
             GitHubIssue(resolve_version_with_from_ref_arg()).run()
         if args.command == 'reassign':
             Reassign().run(change=args.change)
+        if args.command == 'drop':
+            Drop().run(change=args.change)
         if args.command == 'update-xcode-toolchain':
             UpdateXcodeToolchain().run(url=args.url, culprit=args.culprit)
         if args.command == 'gen-rust-toolchain':

--- a/tools/cr/brockit_test.py
+++ b/tools/cr/brockit_test.py
@@ -711,5 +711,52 @@ class BrockitTest(unittest.TestCase):
         self.assertNotIn('not_l10n.txt', committed_files)
 
 
+class MarkChangeTaskTest(unittest.TestCase):
+    """Tests for the `reassign` and `drop` change-marking commands."""
+
+    def setUp(self):
+        self.fake_chromium_src = FakeChromiumRepo()
+        self.fake_chromium_src.setup()
+        self.addCleanup(self.fake_chromium_src.cleanup)
+        self.brave = self.fake_chromium_src.brave
+
+    def _git(self, *args: str) -> str:
+        return self.fake_chromium_src._run_git_command(list(args), self.brave)
+
+    def _make_target(self, subject: str) -> str:
+        """Commits a change with `subject` and returns its `%h` short hash."""
+        self.fake_chromium_src.write_and_stage_file('foo.txt', 'content',
+                                                    self.brave)
+        self.fake_chromium_src.commit(subject, self.brave)
+        return self._git('log', '-1', '--format=%h')
+
+    def _assert_marks_change(self, task, prefix: str) -> None:
+        """Runs `task` over a fresh target and asserts it produced an empty
+        `<prefix><hash>! <subject>` commit on top."""
+        short_hash = self._make_target('A change to mark')
+
+        task.execute(change='HEAD')
+
+        self.assertEqual(self._git('log', '-1', '--format=%s'),
+                         f'{prefix}{short_hash}! A change to mark')
+        # The marking commit must be empty: no diff against its parent.
+        self.assertEqual(self._git('diff', '--name-only', 'HEAD~1', 'HEAD'),
+                         '')
+
+    def test_reassign_creates_empty_reassign_commit(self):
+        self._assert_marks_change(brockit.Reassign(), 'reassign!')
+
+    def test_drop_creates_empty_drop_commit(self):
+        self._assert_marks_change(brockit.Drop(), 'drop!')
+
+    def test_drop_rejects_staged_files(self):
+        """Marking refuses to run while there are staged changes."""
+        self._make_target('A change to mark')
+        self.fake_chromium_src.write_and_stage_file('staged.txt', 'wip',
+                                                    self.brave)
+        with self.assertRaises(brockit.InvalidInputException):
+            brockit.Drop().execute(change='HEAD')
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tools/cr/rebase_v2.py
+++ b/tools/cr/rebase_v2.py
@@ -12,7 +12,7 @@ file-in / file-out transforms that brockit hooks into git via the
 * `rewrite_plan(todo_file, …)` -- reorders the rebase TODO produced by
   `GIT_SEQUENCE_EDITOR`. Pinned commits get grouped to the top, recyclable
   commits get optionally evicted, reassign commits get placed next to
-  their target.
+  their target, and drop commits remove themselves along with their target.
 * `MessageWriter.parse(todo_file)` + `rewrite_with_last_message()` --
   composes the squash commit message produced by `GIT_EDITOR`, picking
   whichever surviving message corresponds to the kind of squash being
@@ -50,6 +50,9 @@ Commit categories formalised here (see `EntryType`):
 * REASSIGNMENT -- `reassign!<hash>!` commits authored by
   `brockit reassign`. Repositioned next to their target when
   `pinned_squashed=True`.
+* DROP -- `drop!<hash>!` commits authored by `brockit drop`. Both the
+  marker and its target are removed from the plan when
+  `pinned_squashed=True`.
 * DEFAULT -- everything else.
 """
 
@@ -65,8 +68,10 @@ from pathlib import Path
 
 from terminal import terminal
 
-# Brockit-specific prefix for commit messages, similar to `fixup!`.
+# Brockit-specific prefixes for commit messages, similar to `fixup!`. Each
+# marks an empty `<prefix><hash>!` commit that `brockit rebase` acts on.
 REASSIGN_COMMIT_MSG_PREFIX = 'reassign!'
+DROP_COMMIT_MSG_PREFIX = 'drop!'
 
 # Strips one or more leading bracketed tags whose first token starts with
 # `cr` followed by digits -- e.g. `[cr149] `, `[cr149][ios] `. Leaves
@@ -180,6 +185,8 @@ def get_entry_type_for_subject(subject: str) -> 'EntryType':
     into one of the four `EntryType` variants."""
     if subject.startswith(REASSIGN_COMMIT_MSG_PREFIX):
         return EntryType.REASSIGNMENT
+    if subject.startswith(DROP_COMMIT_MSG_PREFIX):
+        return EntryType.DROP
     if get_pinned_group_for_subject(subject) is not None:
         return EntryType.PINNED
     if is_recyclable(subject):
@@ -250,6 +257,8 @@ class EntryType(enum.Enum):
     * `RECYCLABLE`   -- subject matches one of `RECYCLABLE_PATTERNS`.
     * `REASSIGNMENT` -- subject (or autosquash subcommand) starts with
                         `reassign!`.
+    * `DROP`         -- subject (or autosquash subcommand) starts with
+                        `drop!`.
     * `DEFAULT`      -- none of the above; produced only by `EntryLine`.
                         `MessageWriter.parse` never returns this value
                         -- it raises `EditorRecoverableFailure` instead.
@@ -257,6 +266,7 @@ class EntryType(enum.Enum):
     PINNED = 'pinned'
     RECYCLABLE = 'recyclable'
     REASSIGNMENT = 'reassignment'
+    DROP = 'drop'
     DEFAULT = 'default'
 
 
@@ -325,6 +335,8 @@ class EntryLine:
         self._entry_type: EntryType = EntryType.DEFAULT
         if self._subcommand and self._subcommand[0] == 'reassign':
             self._entry_type = EntryType.REASSIGNMENT
+        elif self._subcommand and self._subcommand[0] == 'drop':
+            self._entry_type = EntryType.DROP
         elif is_recyclable(self._message):
             self._entry_type = EntryType.RECYCLABLE
         else:
@@ -376,6 +388,10 @@ class EntryLine:
         return self._entry_type is EntryType.REASSIGNMENT
 
     @property
+    def is_drop(self) -> bool:
+        return self._entry_type is EntryType.DROP
+
+    @property
     def reassign_target_hash(self) -> str | None:
         """The target hash carried in the `reassign!<hash>!` prefix --
         or `None` if the prefix has no hash. Raises
@@ -385,9 +401,17 @@ class EntryLine:
             raise NotImplementedError(
                 'reassign_target_hash is only defined for reassignment '
                 'commits')
-        if self._subcommand and len(self._subcommand) >= 2:
-            return self._subcommand[1]
-        return None
+        return self._subcommand_target_hash()
+
+    @property
+    def drop_target_hash(self) -> str | None:
+        """The target hash carried in the `drop!<hash>!` prefix -- or
+        `None` if the prefix has no hash. Raises `NotImplementedError`
+        on a non-drop commit (callers should gate on `is_drop` first)."""
+        if not self.is_drop:
+            raise NotImplementedError(
+                'drop_target_hash is only defined for drop commits')
+        return self._subcommand_target_hash()
 
     # ----- the one mutable property -----------------------------------------
 
@@ -454,6 +478,14 @@ class EntryLine:
 
     # ----- private helpers --------------------------------------------------
 
+    def _subcommand_target_hash(self) -> str | None:
+        """Returns the hash token of a `<marker>!<hash>!` subcommand prefix
+        (e.g. the `<hash>` in `reassign!<hash>!` / `drop!<hash>!`), or `None`
+        when the marker carries no hash."""
+        if self._subcommand and len(self._subcommand) >= 2:
+            return self._subcommand[1]
+        return None
+
     def _refresh_out(self) -> None:
         """Regenerates `_out` from the current field values in the
         canonical `<command> <hash> # [<sub1>!<sub2>! ]<message>[ # <note>]`
@@ -485,7 +517,8 @@ def rewrite_plan(*,
             commit in each group stays `pick`; subsequent ones become
             `squash`. Reassign commits are repositioned to sit
             immediately above their target (with the target rewritten
-            to `squash`). Defaults to `False`.
+            to `squash`). Drop commits remove themselves together with
+            their target. Defaults to `False`.
         discard_recyclable: When `True`, drop recyclable commits from
             the plan entirely. Defaults to `False`.
 
@@ -502,37 +535,40 @@ def rewrite_plan(*,
     pinned_groups = {group: [] for group, _ in PINNED_GROUPS}
     all_others = []
 
-    def add_reassign_before_target(reassign: EntryLine) -> None:
-        """Looks for `reassign`'s target in `all_others` and, if found,
-        inserts `reassign` immediately above it while rewriting the
-        target to `squash`. Reassignment targets are required to be
-        regular commits -- pinned and recyclable commits aren't
-        supported, so a reassign whose target is pinned (or got dropped
-        as recyclable) ends up orphaned and silently discarded."""
+    def find_marker_target(
+            marker: EntryLine,
+            target_hash: str | None) -> tuple[EntryLine | None, int | None]:
+        """Locates a `reassign!`/`drop!` marker's target among the entries
+        seen so far (`all_others`), returning it with its index, or
+        `(None, None)` when the marker is orphaned.
 
-        def find_target(predicate) -> tuple[EntryLine | None, int | None]:
-            """Walks `all_others` in reverse order and returns the first
-            entry that satisfies `predicate`, paired with its index. The
-            reverse walk is a small optimisation: a reassign's target is
-            usually the immediately-preceding entry_line, so the typical hit
-            is on the first iteration. Returns `(None, None)` when no
-            entry matches."""
+        The lookup is by `target_hash` first, then falls back to matching the
+        commit subject. `all_others` is walked in reverse -- a marker's target
+        is usually the immediately-preceding entry, so the typical hit is on
+        the first iteration. Pinned and recyclable targets aren't in
+        `all_others`, so a marker pointing at one ends up orphaned."""
+
+        def find(predicate) -> tuple[EntryLine | None, int | None]:
             return next(((c, i) for c, i in zip(
                 reversed(all_others), range(len(all_others) - 1, -1, -1))
                          if predicate(c)), (None, None))
 
-        target, target_idx = None, None
-        if reassign.reassign_target_hash is not None:
-            target, target_idx = find_target(
-                lambda c: c.hash == reassign.reassign_target_hash)
-
+        target, target_idx = (None, None)
+        if target_hash is not None:
+            target, target_idx = find(lambda c: c.hash == target_hash)
         if target is None:
             # Fallback search by commit message. This is allowed.
-            target, target_idx = find_target(
-                lambda c: c.message == reassign.message)
+            target, target_idx = find(lambda c: c.message == marker.message)
+        return target, target_idx
 
+    def add_reassign_before_target(reassign: EntryLine) -> None:
+        """Inserts `reassign` immediately above its target while rewriting the
+        target to `squash`, so the target's content is absorbed into the
+        (empty) reassign commit and adopts its authorship. An orphaned
+        reassign is silently discarded."""
+        target, target_idx = find_marker_target(reassign,
+                                                reassign.reassign_target_hash)
         if target is None:
-            # Reassignment is orphaned -- drop it and do nothing.
             logging.warning('Dropping orphaned reassignment: %s',
                             reassign.out.strip())
             return
@@ -543,6 +579,17 @@ def rewrite_plan(*,
         # `out` in sync automatically.
         target.command = 'squash'
         all_others.insert(target_idx, reassign)
+
+    def drop_with_target(drop: EntryLine) -> None:
+        """Removes the `drop` marker's target from the plan. The marker itself
+        is dropped by the caller -- it's never appended to `all_others`. An
+        orphaned drop is silently discarded, leaving the plan untouched."""
+        target, target_idx = find_marker_target(drop, drop.drop_target_hash)
+        if target is None:
+            logging.warning('Dropping orphaned drop: %s', drop.out.strip())
+            return
+
+        del all_others[target_idx]
 
     for line in todo_file.read_bytes().decode('utf-8').splitlines():
         entry_line = EntryLine.parse(line)
@@ -557,6 +604,9 @@ def rewrite_plan(*,
         if pinned_squashed:
             if entry_line.is_reassignment:
                 add_reassign_before_target(entry_line)
+                continue
+            if entry_line.is_drop:
+                drop_with_target(entry_line)
                 continue
             if entry_line.pinned_group is not None:
                 # First commit in the group becomes `pick`; subsequent

--- a/tools/cr/rebase_v2_test.py
+++ b/tools/cr/rebase_v2_test.py
@@ -148,6 +148,28 @@ class EntryLineParseTest(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             _ = regular.reassign_target_hash
 
+    def test_drop_classification_and_target_hash(self):
+        """`drop!<hash>!` commits classify as DROP, expose `is_drop`, and
+        carry their target hash in `drop_target_hash` -- mirroring the
+        reassign equivalents."""
+        EntryType = rebase_v2.EntryType
+
+        drop = rebase_v2.EntryLine.parse(
+            'pick zzz # drop!bbb! [cr148] Feature B\n')
+        self.assertIs(drop.entry_type, EntryType.DROP)
+        self.assertTrue(drop.is_drop)
+        self.assertFalse(drop.is_reassignment)
+        self.assertEqual(drop.drop_target_hash, 'bbb')
+
+        no_hash = rebase_v2.EntryLine.parse(
+            'pick zzz # drop! [cr148] Feature B\n')
+        self.assertTrue(no_hash.is_drop)
+        self.assertIsNone(no_hash.drop_target_hash)
+
+        regular = rebase_v2.EntryLine.parse('pick aaa # [cr148] Feature A\n')
+        with self.assertRaises(NotImplementedError):
+            _ = regular.drop_target_hash
+
     def test_fixup_of_pinned_classified_as_pinned(self):
         """A `fixup -C` whose `amend!` subject is pinned still ends up
         `entry_type=PINNED` with the right `pinned_group`. The
@@ -628,6 +650,67 @@ class RewritePlanTest(unittest.TestCase):
             path.read_text(), 'pick aaa # [cr148] Feature A\n'
             'pick zzz # reassign!xxx! [cr148] Feature B # empty\n'
             'squash bbb # [cr148] Feature B\n')
+
+    # ----- pinned_squashed=True, drop! markers ------------------------------
+
+    def test_squashed_drop_removes_target_and_marker(self):
+        """A `drop!<hash>!` removes both its target (matched by hash) and
+        itself from the plan."""
+        path = self._todo('pick aaa # [cr148] Feature A\n'
+                          'pick bbb # [cr148] Feature B\n'
+                          'pick zzz # drop!bbb! [cr148] Feature B\n')
+
+        rebase_v2.rewrite_plan(todo_file=path, pinned_squashed=True)
+
+        self.assertEqual(path.read_text(), 'pick aaa # [cr148] Feature A\n')
+
+    def test_squashed_drop_falls_back_to_message_match(self):
+        """A non-matching hash falls back to dropping the commit whose
+        subject matches the drop's message."""
+        path = self._todo('pick aaa # [cr148] Feature A\n'
+                          'pick bbb # [cr148] Feature B\n'
+                          'pick zzz # drop!xxx! [cr148] Feature B\n')
+
+        rebase_v2.rewrite_plan(todo_file=path, pinned_squashed=True)
+
+        self.assertEqual(path.read_text(), 'pick aaa # [cr148] Feature A\n')
+
+    def test_squashed_orphan_drop_left_untouched(self):
+        """A drop whose hash and subject both miss is silently discarded
+        (its marker line is removed), leaving the rest of the plan alone."""
+        path = self._todo(
+            'pick aaa # [cr148] Feature A\n'
+            'pick zzz # drop!xxx! [cr148] Completely unrelated subject\n')
+
+        rebase_v2.rewrite_plan(todo_file=path, pinned_squashed=True)
+
+        self.assertEqual(path.read_text(), 'pick aaa # [cr148] Feature A\n')
+
+    def test_squashed_drop_with_empty_suffix(self):
+        """The ` # empty` suffix on a drop is stripped before the
+        message-based lookup, just like reassign."""
+        path = self._todo('pick aaa # [cr148] Feature A\n'
+                          'pick bbb # [cr148] Feature B\n'
+                          'pick zzz # drop!xxx! [cr148] Feature B # empty\n')
+
+        rebase_v2.rewrite_plan(todo_file=path, pinned_squashed=True)
+
+        self.assertEqual(path.read_text(), 'pick aaa # [cr148] Feature A\n')
+
+    def test_squashed_drop_not_processed_without_pinned_squashed(self):
+        """Like reassign, drop markers are only acted on under
+        `pinned_squashed`. With only `discard_recyclable`, the marker and its
+        target are left in place."""
+        path = self._todo('pick aaa # [cr148] Feature A\n'
+                          'pick bbb # [cr148] Feature B\n'
+                          'pick zzz # drop!bbb! [cr148] Feature B\n')
+
+        rebase_v2.rewrite_plan(todo_file=path, discard_recyclable=True)
+
+        self.assertEqual(
+            path.read_text(), 'pick aaa # [cr148] Feature A\n'
+            'pick bbb # [cr148] Feature B\n'
+            'pick zzz # drop!bbb! [cr148] Feature B\n')
 
     # ----- pinned_squashed=True, discard_recyclable=True --------------------
 


### PR DESCRIPTION
This command is a sibling to `reassign!`, in the sense that it also
creates a commit with a subcommand tag to guide a rebase event. In this
case though, the `drop!` indicates that a target commit is supposed to
be dropped during rebase.

Similar to `ressign!` handling, this type of pin can only be processed
with `--squash-minor-bumps`, and the target commit cannot be another
pinned commit.

This change is being implemented for rebase v2 only.

Bug: https://github.com/brave/brave-browser/issues/56150
