### PR TITLE
[toolchain][brockit] Fixing Xcode toolchain update command

### DIFF
--- a/tools/cr/brockit.py
+++ b/tools/cr/brockit.py
@@ -171,24 +171,28 @@ when running a cr branch, as it is common to have multiple minor daily bumps
 in a branch.
 
 ### `brockit.py update-xcode-toolchain`
-The hermetic toolchain is generated in CI, and at the end of it, a download URL
-is provided for the generated toolchain. The URL is usually printed in the logs
-as:
+The hermetic Xcode toolchain is generated in CI for the macOS SDK that Chromium
+pins in `build/config/mac/mac_sdk.gni`, and published to Brave's download bucket
+alongside a sibling YAML index. This command repins
+`build/mac/download_hermetic_xcode.py` to that published toolchain.
 
-```
-Download URL: https://....tar.gz
-```
-
-To create a commit updating the hermetic toolchain, simply pass this URL to the
-command:
+Pass `--to` with the Chromium reference whose pinned macOS SDK to repin against.
+It accepts a concrete version or the same `@latest-*` labels as `lift --to`:
 
 ```sh
-tools/cr/brockit.py update-xcode-toolchain <URL>
+tools/cr/brockit.py update-xcode-toolchain --to=150.0.7850.1
 ```
 
+`brockit` reads the SDK version/build from `mac_sdk.gni` at that ref, downloads
+the matching toolchain index, and rewrites the archive hash and the SDK
+version/build constants (and the provenance comment) in
+`build/mac/download_hermetic_xcode.py`. It also lifts the
+`MAC_MINIMUM_OS_VERSION` block (the minimum-OS gate and its comment) verbatim
+from Chromium's `build/mac_toolchain.py` at the same ref.
+
 Pass `--culprit=<hash>` to provide a specific culprit for the toolchain update.
-If none is provided, `brockit` will trying to determine the culprit by looking
-for the last commit updating the toolchain in Chromium.
+If none is provided, `brockit` determines the culprit by looking for the last
+commit that pinned the macOS SDK in `mac_sdk.gni` up to the `--to` ref.
 
 ### `brockit.py gen-rust-toolchain`
 This command triggers the Rust/WASM toolchain Jenkins pipelines (one per
@@ -274,6 +278,7 @@ from rich.table import Table
 from rich.text import Text
 import subprocess
 import sys
+import textwrap
 import time
 
 from git_status import GitStatus
@@ -286,7 +291,7 @@ import repository
 from repository import Repository
 from terminal import (IncendiaryErrorHandler, Task as BaseTask, console,
                       is_verbose, terminal)
-from toolchains import build_rust_toolchain
+from toolchains import build_rust_toolchain, build_xcode_toolchain
 import versioning
 from versioning import Version
 from vpython_utils import VPYTHON3_PATH
@@ -315,13 +320,20 @@ GOOGLESOURCE_COMMIT_LINK = f'{versioning.GOOGLESOURCE_LINK}' '/+/{commit}'
 RUST_TOOLCHAIN_URL = 'https://brave-build-deps-public.s3.brave.com/rust-toolchain-aux/linux-x64-rust-toolchain-{revision}.tar.xz'
 
 # Brave-side script that pins the hermetic Xcode toolchain. Its
-# `XCODE_VERSION` / `XCODE_BUILD_VERSION` / `MAC_SDK_*` constants are the only
-# thing `update-xcode-toolchain` edits.
+# `MAC_BINARIES_HASH` (archive SHA-256) and `MAC_SDK_OFFICIAL_VERSION` /
+# `MAC_SDK_OFFICIAL_BUILD_VERSION` constants -- plus the human-readable
+# provenance comment above them and the `MAC_MINIMUM_OS_VERSION` block mirrored
+# from `CHROMIUM_MAC_TOOLCHAIN_PY` -- are what `update-xcode-toolchain` edits.
 HERMETIC_XCODE_SCRIPT = 'build/mac/download_hermetic_xcode.py'
 
 # Chromium-side file pinning the macOS SDK that we cross-reference to find the
 # upstream commit that triggered this toolchain bump.
 CHROMIUM_MAC_SDK_GNI = 'build/config/mac/mac_sdk.gni'
+
+# Chromium-side installer whose `MAC_MINIMUM_OS_VERSION` block (the minimum-OS
+# gate plus its explanatory comment) the hermetic downloader mirrors verbatim,
+# so the OS gate tracks upstream as the toolchain moves.
+CHROMIUM_MAC_TOOLCHAIN_PY = 'build/mac_toolchain.py'
 
 # Google dash link used to check the latest version for a given channel
 CHROMIUMDASH_LATEST_RELEASE = 'https://chromiumdash.appspot.com/fetch_releases?channel={channel}&platform={platform}&num=1'
@@ -413,6 +425,27 @@ def _get_current_branch_upstream_name() -> str | None:
                                         '--symbolic-full-name', '@{upstream}')
     except subprocess.CalledProcessError:
         return None
+
+
+def _ensure_chromium_tags(*refs: Version | str) -> None:
+    """Ensures each Chromium reference resolves locally, fetching any that are
+    missing as tags from Googlesource.
+
+    Tags for freshly released Chromium versions are frequently absent from a
+    local checkout, so any operation that resolves a version to a commit (e.g.
+    the culprit pickaxes, `git show <tag>:<file>`) must fetch the tag first.
+    """
+    missing = [
+        ref for ref in refs
+        if not repository.chromium.is_valid_git_reference(ref)
+    ]
+    if not missing:
+        return
+
+    fetch_args = ['fetch', versioning.GOOGLESOURCE_LINK]
+    for ref in missing:
+        fetch_args += ['tag', ref]
+    repository.chromium.run_git(*fetch_args)
 
 
 def _update_pinslist_timestamp() -> str:
@@ -1549,9 +1582,9 @@ class Upgrade(Versioned):
                 'Contact DevOps to ask for an updated MacOS toolchain node to '
                 'be used to generate a new toolchain, then generate the new '
                 'toolchain in https://ci.brave.com/view/toolchains/. Once the '
-                'new toolchain is generated, call '
-                '`brockit.py update-xcode-toolchain <url>` with the URL in the '
-                '"Download URL:" line printed in CI.')
+                'new toolchain is published, call '
+                '`brockit.py update-xcode-toolchain --to=<chromium-ref>` to '
+                'repin it.')
         return result
 
     def _check_rust_toolchain(self) -> dict | None:
@@ -1632,13 +1665,7 @@ class Upgrade(Versioned):
         """
         # Fetching the tags between the current version and the target to check
         # for certain things that may have changed that require attention
-        if (not repository.chromium.is_valid_git_reference(
-                self.working_version)
-                or not repository.chromium.is_valid_git_reference(
-                    self.target_version)):
-            repository.chromium.run_git('fetch', versioning.GOOGLESOURCE_LINK,
-                                        'tag', self.working_version, 'tag',
-                                        self.target_version)
+        _ensure_chromium_tags(self.working_version, self.target_version)
 
         advisories = [
             check for check in [
@@ -2355,103 +2382,130 @@ class Reassign(Task):
 
 
 class UpdateXcodeToolchain(Task):
-    """Pins `build/mac/download_hermetic_xcode.py` to a freshly built archive.
+    """Pins `build/mac/download_hermetic_xcode.py` to a published toolchain.
 
-    This is a convenience command to update the URL for downloading the hermetic
-    Xcode toolchain.
+    This class produces a Xcode toolchain update commit, anchored on the
+    Chromium tag pointing at the new toolchain.
     """
 
-    # Filename pattern emitted by tools/cr/toolchains/build_xcode_toolchain.py.
-    # The six dash-separated tokens map 1:1 onto the six constants in
-    # `HERMETIC_XCODE_SCRIPT`.
-    _TOOLCHAIN_URL_RE = re.compile(
-        r'xcode-hermetic-toolchain'
-        r'-(?P<xcode_version>[^-/]+)'
-        r'-(?P<xcode_build_version>[^-/]+)'
-        r'-(?P<mac_sdk_official_version>[^-/]+)'
-        r'-(?P<mac_sdk_official_build_version>[^-/]+)'
-        r'-for-upstream'
-        r'-(?P<mac_sdk_upstream_version>[^-/]+)'
-        r'-(?P<mac_sdk_upstream_build_version>[^-/]+)'
-        r'\.tar\.gz')
+    # Matches the provenance comment above the pinned constants in
+    # `HERMETIC_XCODE_SCRIPT` so it can be regenerated from the freshly resolved
+    # toolchain. Spans the opening line and any contiguous comment lines that
+    # follow, stopping at the first non-comment line (the constants).
+    _PROVENANCE_COMMENT_RE = re.compile(
+        r'^# This contains binaries from Xcode\b.*\n(?:#.*\n)*', re.MULTILINE)
+
+    # Matches the `MAC_MINIMUM_OS_VERSION` block -- its leading comment lines
+    # plus the assignment -- in both Chromium's `build/mac_toolchain.py` and the
+    # hermetic downloader. `update-xcode-toolchain` lifts this block from
+    # upstream and drops it into the downloader verbatim. Each block is preceded
+    # by a blank line, so the contiguous comment run never reaches further up.
+    _MIN_OS_VERSION_BLOCK_RE = re.compile(
+        r'(?:^#.*\n)*^MAC_MINIMUM_OS_VERSION = \[[^\]]*\]\n', re.MULTILINE)
 
     def status_message(self):
         return "Updating Apple toolchain..."
 
     @staticmethod
-    def _replace_constant(text: str, name: str, value: str) -> str:
-        """Rewrites a single `<name> = '<value>'` assignment in *text*.
+    def _provenance_comment(sdk_info: build_xcode_toolchain.MacSdkInfo,
+                            index: dict) -> str:
+        """Render the wrapped provenance comment for the resolved toolchain.
 
-        Anchored at line start and matches both single- and double-quoted
-        existing values so it stays robust if the script ever switches quote
-        style.
+        Records, in prose, the Xcode version/build and Metal build the index
+        reports alongside the macOS SDK version/build, so the in-tree
+        downloader keeps documenting exactly what its archive contains now that
+        it no longer carries an `XCODE_VERSION` constant.
         """
-        pattern = re.compile(rf"^({re.escape(name)}\s*=\s*)(['\"])[^'\"]*\2",
-                             re.MULTILINE)
-        new_text, count = pattern.subn(rf"\1'{value}'", text, count=1)
-        if count != 1:
-            raise InvalidInputException(
-                f'Could not find assignment for {name} in '
-                f'{HERMETIC_XCODE_SCRIPT}')
-        return new_text
+        metal_build = index.get('metal_build') or 'unknown'
+        sentence = (
+            f"This contains binaries from Xcode {index['xcode_version']} "
+            f"({index['xcode_build']}) along with the macOS "
+            f"{sdk_info.sdk_version} SDK ({sdk_info.product_build_version}) "
+            f"and the Metal toolchain ({metal_build}).")
+        return textwrap.fill(
+            sentence, width=79, initial_indent='# ',
+            subsequent_indent='# ') + '\n'
 
-    def _rewrite_hermetic_xcode_script(self, tokens: dict[str, str]) -> bool:
-        """Pins the six toolchain constants to the values parsed from the URL.
+    def _rewrite_hermetic_xcode_script(
+            self, sdk_info: build_xcode_toolchain.MacSdkInfo, index: dict,
+            mac_toolchain_py: str) -> bool:
+        """Pins the archive hash and SDK constants, refreshes the provenance
+        comment, and mirrors Chromium's `MAC_MINIMUM_OS_VERSION` block.
 
-        Returns True if the on-disk file actually changed, False when every
-        constant was already set to the requested value (so the caller can
-        skip committing).
+        `mac_toolchain_py` is the upstream `build/mac_toolchain.py` source the
+        minimum-OS block is lifted from.
+
+        Returns True if the on-disk file actually changed, False when it was
+        already pinned to these exact values (so the caller can skip
+        committing).
         """
         script_path = repository.brave.root / HERMETIC_XCODE_SCRIPT
         original = script_path.read_bytes().decode('utf-8')
-        updated = original
-        mapping = (
-            ('XCODE_VERSION', tokens['xcode_version']),
-            ('XCODE_BUILD_VERSION', tokens['xcode_build_version']),
-            ('MAC_SDK_OFFICIAL_VERSION', tokens['mac_sdk_official_version']),
-            ('MAC_SDK_OFFICIAL_BUILD_VERSION',
-             tokens['mac_sdk_official_build_version']),
-            ('MAC_SDK_UPSTREAM_VERSION', tokens['mac_sdk_upstream_version']),
-            ('MAC_SDK_UPSTREAM_BUILD_VERSION',
-             tokens['mac_sdk_upstream_build_version']),
-        )
-        for name, value in mapping:
-            updated = self._replace_constant(updated, name, value)
+        sdk_version = sdk_info.sdk_version
+        build_version = sdk_info.product_build_version
 
-        if updated == original:
+        content = re.sub(r"MAC_BINARIES_HASH = '[^']*'",
+                         f"MAC_BINARIES_HASH = '{index['sha256sum']}'",
+                         original,
+                         count=1)
+        content = re.sub(r"MAC_SDK_OFFICIAL_VERSION = '[^']*'",
+                         f"MAC_SDK_OFFICIAL_VERSION = '{sdk_version}'",
+                         content,
+                         count=1)
+        content = re.sub(r"MAC_SDK_OFFICIAL_BUILD_VERSION = '[^']*'",
+                         f"MAC_SDK_OFFICIAL_BUILD_VERSION = '{build_version}'",
+                         content,
+                         count=1)
+        content = self._PROVENANCE_COMMENT_RE.sub(
+            lambda _: self._provenance_comment(sdk_info, index),
+            content,
+            count=1)
+
+        # Lift the minimum-OS gate (and its comment) verbatim from upstream.
+        upstream_min_os = self._MIN_OS_VERSION_BLOCK_RE.search(
+            mac_toolchain_py)
+        if upstream_min_os is None:
+            raise InvalidInputException(
+                'Could not find the MAC_MINIMUM_OS_VERSION block in '
+                f'{CHROMIUM_MAC_TOOLCHAIN_PY}.')
+        content = self._MIN_OS_VERSION_BLOCK_RE.sub(
+            lambda _: upstream_min_os.group(0), content, count=1)
+
+        if content == original:
             return False
 
-        script_path.write_text(updated, encoding='utf-8', newline='')
+        script_path.write_text(content, encoding='utf-8', newline='')
         return True
 
-    def _resolve_chromium_commit(self, tokens: dict[str, str]) -> str:
-        """Finds the Chromium commit that pinned the upstream macOS SDK.
+    def _resolve_chromium_culprit(self,
+                                  sdk_info: build_xcode_toolchain.MacSdkInfo,
+                                  ref: str) -> str:
+        """Finds the Chromium commit that pinned this macOS SDK.
 
-        We attempt to find the last commit that introduced one of the values
-        indicated as the upstream toolchain numbers.
+        Pickaxes `build/config/mac/mac_sdk.gni` up to `ref` for the commit that
+        last set either the SDK version or its build number, mirroring
+        `UpdateRustWasmToolchain._resolve_chromium_culprit`.
         """
-        version = re.escape(tokens['mac_sdk_upstream_version'])
-        build = re.escape(tokens['mac_sdk_upstream_build_version'])
+        _ensure_chromium_tags(ref)
+        version = re.escape(sdk_info.sdk_version)
+        build = re.escape(sdk_info.product_build_version)
         regex = (f'mac_sdk_official_version = "{version}"'
                  f'|mac_sdk_official_build_version = "{build}"')
         commit_hash = repository.chromium.run_git('log', '--extended-regexp',
                                                   '-G', regex, '--pretty=%H',
-                                                  '-1', '--',
+                                                  '-1', ref, '--',
                                                   CHROMIUM_MAC_SDK_GNI)
         if not commit_hash:
             raise InvalidInputException(
-                f'Could not find a Chromium commit setting '
-                '`mac_sdk_official_version = '
-                f'"{tokens["mac_sdk_upstream_version"]}"` '
-                'or '
+                'Could not find a Chromium commit setting '
+                f'`mac_sdk_official_version = "{sdk_info.sdk_version}"` or '
                 '`mac_sdk_official_build_version = '
-                f'"{tokens["mac_sdk_upstream_build_version"]}"` '
-                f'in {CHROMIUM_MAC_SDK_GNI}. Pass [bold cyan]--culprit[/] to '
-                'point at it explicitly.')
+                f'"{sdk_info.product_build_version}"` in '
+                f'{CHROMIUM_MAC_SDK_GNI} at {ref}. Pass '
+                '[bold cyan]--culprit[/] to point at it explicitly.')
         return commit_hash
 
-    def execute(self, url: str, culprit: str | None):
-        # Regex breaking each part of the url in different groups.
+    def execute(self, chromium_ref: str, culprit: str | None):
         status = GitStatus()
         if status.has_staged_files():
             raise InvalidInputException(
@@ -2459,22 +2513,36 @@ class UpdateXcodeToolchain(Task):
                 'before generating a toolchain update:\n%s' %
                 '\n'.join(status.get_all_staged_entries()))
 
-        match = self._TOOLCHAIN_URL_RE.search(url)
-        if match is None:
-            raise InvalidInputException(
-                f'URL does not match the xcode-hermetic-toolchain pattern: '
-                f'{url}')
-        tokens = match.groupdict()
+        # Resolve to a concrete Chromium tag (supports the @latest-* labels),
+        # make sure the tag is available locally, then read the SDK pin and the
+        # minimum-OS gate from Chromium at that ref.
+        version = _fetch_chromium_tag(chromium_ref)
+        ref = str(version)
+        _ensure_chromium_tags(ref)
+        mac_sdk_gni = repository.chromium.read_file(CHROMIUM_MAC_SDK_GNI,
+                                                    commit=ref)
+        mac_toolchain_py = repository.chromium.read_file(
+            CHROMIUM_MAC_TOOLCHAIN_PY, commit=ref)
+        try:
+            sdk_info = build_xcode_toolchain.MacSdkInfo.from_gni(mac_sdk_gni)
+        except RuntimeError as e:
+            raise BadOutcomeException(str(e)) from e
 
-        if not self._rewrite_hermetic_xcode_script(tokens):
+        try:
+            index = build_xcode_toolchain.fetch_published_index(sdk_info)
+        except RuntimeError as e:
+            raise BadOutcomeException(str(e)) from e
+
+        if not self._rewrite_hermetic_xcode_script(sdk_info, index,
+                                                   mac_toolchain_py):
             raise InvalidInputException(
                 f'{HERMETIC_XCODE_SCRIPT} is already pinned to these values; '
                 'nothing to commit.')
 
-        commit_hash = culprit or self._resolve_chromium_commit(tokens)
+        commit_hash = culprit or self._resolve_chromium_culprit(sdk_info, ref)
 
-        title = (f'Switch to Xcode {tokens["xcode_version"]} '
-                 f'{tokens["xcode_build_version"]}')
+        title = (f'Switch to Xcode {index["xcode_version"]} '
+                 f'{index["xcode_build"]}')
         repository.brave.run_git('add', HERMETIC_XCODE_SCRIPT)
         repository.brave.git_commit(title,
                                     env={
@@ -3031,6 +3099,7 @@ class UpdateRustWasmToolchain(Task):
         This function determines which commit is reponsible for the current
         rust toolchain versionin in Chromium, using `ref` as a starting point..
         """
+        _ensure_chromium_tags(ref)
 
         def assignment_pattern(name: str) -> str:
             match = re.search(rf'(?m)^{name} = (.+)$', text)
@@ -3087,25 +3156,20 @@ class UpdateRustWasmToolchain(Task):
                 '\n'.join(status.get_all_staged_entries()))
 
         # Resolve to a concrete Chromium tag (supports the @latest-* labels),
-        # then read both revision scripts at that ref in a single `git show`.
+        # make sure the tag is available locally, then read both revision
+        # scripts at that ref in a single `git show`.
         version = _fetch_chromium_tag(chromium_ref)
         ref = str(version)
+        _ensure_chromium_tags(ref)
         revision_text = repository.chromium.read_file(*RUST_REVISION_FILES,
                                                       commit=ref)
         upstream_stem = self._upstream_stem(revision_text)
 
-        terminal.log_task(
-            f'Resolving the published Rust/WASM toolchain for Chromium '
-            f'{version}...')
         try:
             new_entry = build_rust_toolchain.rust_toolchain_extra_dep(
                 upstream_stem)
         except RuntimeError as e:
             raise BadOutcomeException(str(e)) from e
-
-        for entry in new_entry.values():
-            for obj in entry['objects']:
-                console.log(Padding(f'✔️ {obj["object_name"]}', (0, 4)))
 
         path = repository.brave.root / INSTALL_EXTRA_DEPS_FILE
         source = path.read_bytes().decode('utf-8')
@@ -3136,9 +3200,6 @@ class UpdateRustWasmToolchain(Task):
                                         'tags': 'toolchain',
                                         'culprit': commit_hash,
                                     })
-        terminal.log_task(
-            f'Committed the Rust/WASM toolchain update (culprit {commit_hash}).'
-        )
 
 
 def fetch_chromium_dash_version(channel: str) -> Version:
@@ -3411,19 +3472,24 @@ def main():
     update_xcode_parser = subparsers.add_parser(
         'update-xcode-toolchain',
         parents=[global_parser],
-        help='Pins build/mac/download_hermetic_xcode.py to a freshly built '
-        'hermetic Xcode toolchain archive.')
+        formatter_class=argparse.RawTextHelpFormatter,
+        help='Pins build/mac/download_hermetic_xcode.py to the published '
+        'hermetic Xcode toolchain for a Chromium tag\'s macOS SDK, and commits '
+        'the change.')
     update_xcode_parser.add_argument(
-        'url',
-        help=
-        'Archive URL emitted by tools/cr/toolchains/build_xcode_toolchain.py '
-        '(filename must follow the xcode-hermetic-toolchain-<...>.tar.gz '
-        'pattern).')
+        '--to',
+        required=True,
+        dest='to',
+        help=(
+            'The Chromium version whose pinned macOS SDK to repin against\n'
+            '(e.g. 150.0.7850.1), or one of the @latest-* labels accepted by\n'
+            '`lift --to` (e.g. @latest-canary, @latest-m150,\n'
+            '@latest-for-branch, @latest-tag).'))
     update_xcode_parser.add_argument(
         '--culprit',
         default=None,
         help='Chromium commit hash to reference in the commit body. Defaults '
-        'to auto-detecting the commit that pinned the upstream macOS SDK in '
+        'to auto-detecting the commit that pinned the macOS SDK in '
         f'{CHROMIUM_MAC_SDK_GNI}.',
         dest='culprit')
 
@@ -3529,7 +3595,8 @@ def main():
         if args.command == 'reassign':
             Reassign().run(change=args.change)
         if args.command == 'update-xcode-toolchain':
-            UpdateXcodeToolchain().run(url=args.url, culprit=args.culprit)
+            UpdateXcodeToolchain().run(chromium_ref=args.to,
+                                       culprit=args.culprit)
         if args.command == 'gen-rust-toolchain':
             task = GenRustToolchain()
             if args.watch:

--- a/tools/cr/toolchains/build_xcode_toolchain.py
+++ b/tools/cr/toolchains/build_xcode_toolchain.py
@@ -124,11 +124,9 @@ from pathlib import Path
 from typing import Any
 
 import yaml
-from rich.console import Console
 from rich.progress import (BarColumn, DownloadColumn, Progress,
                            TaskProgressColumn, TextColumn, TimeRemainingColumn,
                            TransferSpeedColumn)
-from rich.syntax import Syntax
 
 # Gitiles raw-text endpoint for `build/xcode_binaries.yaml` at a given
 # Chromium tag.
@@ -445,6 +443,27 @@ class MacSdkInfo:
     # Product build number for that SDK, e.g. `25F70`.
     product_build_version: str
 
+    @staticmethod
+    def from_gni(mac_sdk_gni_text: str) -> MacSdkInfo:
+        """Parse the macOS SDK pin out of `build/config/mac/mac_sdk.gni`.
+
+        `mac_sdk_gni_text` is the verbatim file contents. gn auto-formats these
+        assignments as `key = "value"`, so a simple regex recovers each value.
+
+        Raises:
+            RuntimeError: if either expected assignment is missing.
+        """
+
+        def gn_value(key: str) -> str:
+            match = re.search(rf'{key} = "([^"]+)"', mac_sdk_gni_text)
+            if not match:
+                raise RuntimeError(f'{key} not found in mac_sdk.gni')
+            return match.group(1)
+
+        return MacSdkInfo(
+            sdk_version=gn_value('mac_sdk_official_version'),
+            product_build_version=gn_value('mac_sdk_official_build_version'))
+
 
 @dataclasses.dataclass(frozen=True)
 class XcodeInfo:
@@ -480,6 +499,46 @@ class XcodeRelease:
     # field, used to verify the download. `None` if the catalog entry lists no
     # checksum, which `_resolve_xcode_release` rejects as unverifiable.
     sha1: str | None
+
+
+def toolchain_archive_name(sdk_info: MacSdkInfo) -> str:
+    """`xcode-hermetic-toolchain-<sdk-version>-<sdk-build>.tar.gz` for an SDK.
+
+    The deployed Xcode always ships the exact SDK pinned in `mac_sdk.gni`, so
+    this pair alone uniquely identifies the toolchain archive.
+    """
+    return (f'xcode-hermetic-toolchain-{sdk_info.sdk_version}'
+            f'-{sdk_info.product_build_version}.tar.gz')
+
+
+def toolchain_index_name(sdk_info: MacSdkInfo) -> str:
+    """The sibling YAML index name sharing the archive's name stem."""
+    return toolchain_archive_name(sdk_info).removesuffix('.tar.gz') + '.yaml'
+
+
+def fetch_published_index(sdk_info: MacSdkInfo) -> dict:
+    """Download and parse the published toolchain index for an SDK pin.
+
+    Resolves the sibling YAML index for `sdk_info` on the public download
+    bucket, parses it, and returns it verbatim -- the mapping `_write_index`
+    published (`url`, `sha256sum`, `xcode_version`, `xcode_build`,
+    `metal_build`, ...). This is the entry point brockit's
+    `update-xcode-toolchain` consumes, mirroring how
+    `build_rust_toolchain.rust_toolchain_extra_dep` serves the Rust toolchain.
+
+    Raises:
+        RuntimeError: if the index cannot be fetched.
+    """
+    index_url = PACKAGE_DOWNLOAD_URL_BASE + toolchain_index_name(sdk_info)
+    logging.debug('Fetching hermetic Xcode toolchain index %s', index_url)
+    try:
+        with urllib.request.urlopen(
+                index_url, timeout=HTTP_FETCH_TIMEOUT_SECS) as response:
+            return yaml.safe_load(response)
+    except urllib.error.URLError as e:
+        raise RuntimeError(
+            f'Failed to fetch hermetic Xcode toolchain index {index_url}: {e}'
+        ) from e
 
 
 class ToolchainBuilder:
@@ -573,11 +632,8 @@ class ToolchainBuilder:
         if self._upstream_mac_sdk_info is None:
             raise RuntimeError(
                 '_load_upstream_mac_sdk_info() must run before _archive_path')
-        return self._out_dir / (
-            'xcode-hermetic-toolchain'
-            f'-{self._upstream_mac_sdk_info.sdk_version}'
-            f'-{self._upstream_mac_sdk_info.product_build_version}'
-            '.tar.gz')
+        return self._out_dir / toolchain_archive_name(
+            self._upstream_mac_sdk_info)
 
     @property
     def _index_path(self) -> Path:
@@ -743,18 +799,8 @@ class ToolchainBuilder:
         from these sources, storing them in their corresponding fields.
         """
         url = MAC_SDK_GNI_URL_TEMPLATE.format(tag=self._chromium_tag)
-        text = _fetch_gitiles_raw(url)
-
-        def gn_value(key: str) -> str:
-            # gn auto-formats assignments as `key = "value"`.
-            match = re.search(rf'{key} = "([^"]+)"', text)
-            if not match:
-                raise RuntimeError(f'{key} not found in {url}')
-            return match.group(1)
-
-        self._upstream_mac_sdk_info = MacSdkInfo(
-            sdk_version=gn_value('mac_sdk_official_version'),
-            product_build_version=gn_value('mac_sdk_official_build_version'))
+        self._upstream_mac_sdk_info = MacSdkInfo.from_gni(
+            _fetch_gitiles_raw(url))
         logging.info('Upstream macOS SDK version: %s (build %s)',
                      self._upstream_mac_sdk_info.sdk_version,
                      self._upstream_mac_sdk_info.product_build_version)
@@ -1103,8 +1149,7 @@ class ToolchainBuilder:
                               encoding='utf-8',
                               newline='')
         logging.info('Wrote toolchain index %s:', index_path)
-        Console().print(Syntax(index_path.read_bytes().decode('utf-8'),
-                               'yaml'))
+        print(index_path.read_bytes().decode('utf-8'))
 
     def run(self, clear: bool = False, force_overwrite: bool = False) -> None:
         """Execute the full inspect-stage-read-pack pipeline.

--- a/tools/cr/update_xcode_toolchain_test.py
+++ b/tools/cr/update_xcode_toolchain_test.py
@@ -5,64 +5,84 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 """Tests for `brockit.UpdateXcodeToolchain`.
 
-The file is split in two layers, matching `rebase_v2_test.py`'s shape:
+The file is split into layers, matching `update_rust_wasm_toolchain_test.py`'s
+shape:
 
-* `ReplaceConstantTest` exercises the pure file-content transform used to
-  rewrite `build/mac/download_hermetic_xcode.py`. No git involved.
+* `ProvenanceCommentTest` exercises the pure provenance-comment transform used
+  to rewrite `build/mac/download_hermetic_xcode.py`. No git or network involved.
 
-* `UpdateXcodeToolchainExecuteTest` drives
-  `UpdateXcodeToolchain.execute` end-to-end against a `FakeChromiumRepo`,
-  with the commit-msg hook installed so the `tags=toolchain` /
-  `culprit=<hash>` env wiring is validated through the same pipeline that
-  ships in production.
+* `UpdateXcodeToolchainExecuteTest` drives `UpdateXcodeToolchain.execute`
+  end-to-end against a `FakeChromiumRepo` (the published-index fetch is faked,
+  so no network), with the commit-msg hook installed so the `tags=toolchain` /
+  `culprit=<hash>` env wiring is validated through the same pipeline that ships
+  in production.
 """
 
 from __future__ import annotations
 
 import shutil
 import stat
-import subprocess
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 import brockit
-import repository
 from test.fake_chromium_repo import FakeChromiumRepo
 
-# Source of the commit-msg hook. The integration tests symlink this into
+# Source of the commit-msg hook. The integration tests copy this into
 # `.git/hooks/commit-msg` so the `tags` / `culprit` env vars are interpreted
 # exactly the way they are in production.
 HOOK_SOURCE: Path = (Path(__file__).resolve().parent / 'alias' /
                      'commit-msg.py')
 
-# A representative archive URL emitted by
-# `tools/cr/toolchains/build_xcode_toolchain.py`. The six dash-separated tokens
-# in the filename are what `UpdateXcodeToolchain.execute` consumes.
-TOOLCHAIN_URL = (
-    'https://example.invalid/xcode-hermetic-toolchain/'
-    'xcode-hermetic-toolchain-26.5-17F42-26.5-25F70-for-upstream-26.5-25F70'
-    '.tar.gz')
+# The Chromium tag `execute` resolves `--to` against; the mac_sdk.gni bump
+# commit is tagged with it so the SDK pin can be read at the ref.
+CHROMIUM_TAG = '150.0.7850.1'
 
-# The starting on-disk content of `build/mac/download_hermetic_xcode.py`
-# before the bump. Kept minimal -- the six constants are the only thing
-# `UpdateXcodeToolchain.execute` rewrites.
+# What the faked `build_xcode_toolchain.fetch_published_index` returns -- the
+# published index for the bumped SDK (26.5 / 25F70). The SDK version/build are
+# carried by the index `url`/name; the fields below are what brockit pins and
+# titles the commit from.
+FAKE_INDEX = {
+    'url': ('https://vhemnu34de4lf5cj6bx2wwshyy0egdxk.lambda-url.us-west-2.'
+            'on.aws/xcode-hermetic-toolchain/'
+            'xcode-hermetic-toolchain-26.5-25F70.tar.gz'),
+    'sha256sum': 'b' * 64,
+    'xcode_version': '26.5',
+    'xcode_build': '17F42',
+    'metal_build': '17E188',
+    'chromium_tag': CHROMIUM_TAG,
+}
+
+# The starting on-disk content of `build/mac/download_hermetic_xcode.py` before
+# the bump. The archive hash, the two SDK constants, the provenance comment, and
+# the `MAC_MINIMUM_OS_VERSION` block are what `UpdateXcodeToolchain.execute`
+# rewrites; everything else must survive untouched.
 HERMETIC_XCODE_SCRIPT_INITIAL = """\
 # Sample header.
 
-XCODE_VERSION = '26.4'
-XCODE_BUILD_VERSION = '17E192'
+MAC_BINARIES_HASH = 'oldhash'
 
+# This contains binaries from Xcode 26.4 (17E202) along with the macOS 26.4 SDK
+# (25E251) and the Metal toolchain (17E150).
 MAC_SDK_OFFICIAL_VERSION = '26.4'
-MAC_SDK_OFFICIAL_BUILD_VERSION = '25E236'
+MAC_SDK_OFFICIAL_BUILD_VERSION = '25E251'
+XCODE_TOOLCHAIN_DOWNLOAD_URL = (
+    'https://example.invalid/xcode-hermetic-toolchain/xcode-hermetic-toolchain-'
+    f'{MAC_SDK_OFFICIAL_VERSION}-{MAC_SDK_OFFICIAL_BUILD_VERSION}.tar.gz')
 
-MAC_SDK_UPSTREAM_VERSION = '26.4'
-MAC_SDK_UPSTREAM_BUILD_VERSION = '25E236'
+# The toolchain will not be downloaded if the minimum OS version is not met. 19
+# is the Darwin major version number for macOS 10.15. Xcode 26.4 17E202 only
+# runs on macOS 26.1 and newer, but some bots are still running older OS
+# versions. macOS 10.15.4, the OS minimum through Xcode 12.4, still seems to
+# work.
+MAC_MINIMUM_OS_VERSION = [19, 4]
 """
 
-# The starting content of `build/config/mac/mac_sdk.gni` on the chromium
-# side, before the upstream switch. The first commit that introduces the
-# matching upstream build number is what `_resolve_chromium_commit`'s
-# pickaxe is supposed to find.
+# The starting content of `build/config/mac/mac_sdk.gni` on the chromium side,
+# before the upstream switch. The first commit that introduces the matching
+# upstream build number is what `_resolve_chromium_culprit`'s pickaxe is
+# supposed to find.
 MAC_SDK_GNI_INITIAL = """\
 mac_sdk_official_version = "26.4"
 mac_sdk_official_build_version = "25E236"
@@ -73,58 +93,62 @@ mac_sdk_official_version = "26.5"
 mac_sdk_official_build_version = "25F70"
 """
 
+# Chromium's `build/mac_toolchain.py` at the bumped ref. Its
+# `MAC_MINIMUM_OS_VERSION` block (a distinct comment and a bumped `[20, 0]`
+# value) is what `execute` lifts verbatim into the downloader. The surrounding
+# lines exist so the extraction regex has to isolate just the block.
+MAC_TOOLCHAIN_PY = """\
+# Upstream header.
+MAC_BINARIES_TAG = 'sometag'
 
-class ReplaceConstantTest(unittest.TestCase):
-    """Tests for `UpdateXcodeToolchain._replace_constant`."""
+# The toolchain will not be downloaded if the minimum OS version is not met. 19
+# is the Darwin major version number for macOS 10.15. Xcode 26.5 17F42 only
+# runs on macOS 26.3 and newer, but some bots are still running older OS
+# versions. macOS 10.15.4, the OS minimum through Xcode 12.4, still seems to
+# work.
+MAC_MINIMUM_OS_VERSION = [20, 0]
 
-    SAMPLE = ("XCODE_VERSION = '26.4'\n"
-              "XCODE_BUILD_VERSION = '17E192'\n"
-              'MAC_SDK_OFFICIAL_VERSION = "26.4"\n')
+OTHER_CONSTANT = 1
+"""
 
-    def test_rewrites_single_quoted_value(self):
-        result = brockit.UpdateXcodeToolchain._replace_constant(
-            self.SAMPLE, 'XCODE_VERSION', '26.5')
-        self.assertIn("XCODE_VERSION = '26.5'", result)
-        # Untouched lines pass through unchanged.
-        self.assertIn("XCODE_BUILD_VERSION = '17E192'", result)
-        self.assertIn('MAC_SDK_OFFICIAL_VERSION = "26.4"', result)
 
-    def test_rewrites_double_quoted_value(self):
-        """Double-quoted assignments are matched and normalised to
-        single-quoted output (matching the script's existing style)."""
-        result = brockit.UpdateXcodeToolchain._replace_constant(
-            self.SAMPLE, 'MAC_SDK_OFFICIAL_VERSION', '26.5')
-        self.assertIn("MAC_SDK_OFFICIAL_VERSION = '26.5'", result)
+class ProvenanceCommentTest(unittest.TestCase):
+    """Tests for `UpdateXcodeToolchain._provenance_comment`."""
 
-    def test_replaces_only_first_occurrence(self):
-        """The pattern is anchored at line start with `count=1`. A bare
-        substring match elsewhere in the file (e.g. a comment that
-        mentions `XCODE_VERSION`) does not get rewritten."""
-        text = ("# XCODE_VERSION = '???' is the constant below.\n"
-                "XCODE_VERSION = '26.4'\n")
-        result = brockit.UpdateXcodeToolchain._replace_constant(
-            text, 'XCODE_VERSION', '26.5')
+    SDK_INFO = brockit.build_xcode_toolchain.MacSdkInfo(
+        sdk_version='26.5', product_build_version='25F70')
+
+    def test_records_xcode_sdk_and_metal(self):
+        comment = brockit.UpdateXcodeToolchain._provenance_comment(
+            self.SDK_INFO, FAKE_INDEX)
+        # Every line is a comment, stays within the column budget, and the
+        # joined prose names each component the archive bundles.
+        lines = comment.splitlines()
+        self.assertTrue(all(line.startswith('# ') for line in lines))
+        self.assertTrue(all(len(line) <= 79 for line in lines))
+        prose = ' '.join(line[2:] for line in lines)
         self.assertEqual(
-            result, "# XCODE_VERSION = '???' is the constant below.\n"
-            "XCODE_VERSION = '26.5'\n")
+            prose, 'This contains binaries from Xcode 26.5 (17F42) along with '
+            'the macOS 26.5 SDK (25F70) and the Metal toolchain (17E188).')
 
-    def test_missing_constant_raises(self):
-        """A constant that doesn't exist in the file at all surfaces as an
-        `InvalidInputException` rather than silently leaving the file
-        unchanged."""
-        with self.assertRaises(brockit.InvalidInputException):
-            brockit.UpdateXcodeToolchain._replace_constant(
-                self.SAMPLE, 'NOT_A_REAL_CONSTANT', '26.5')
+    def test_missing_metal_build_falls_back_to_unknown(self):
+        comment = brockit.UpdateXcodeToolchain._provenance_comment(
+            self.SDK_INFO, {
+                **FAKE_INDEX, 'metal_build': None
+            })
+        self.assertIn('Metal toolchain (unknown)',
+                      comment.replace('\n# ', ' '))
 
 
 class UpdateXcodeToolchainExecuteTest(unittest.TestCase):
     """End-to-end tests for `UpdateXcodeToolchain.execute`.
 
     Each test seeds the fake brave repo with a starting
-    `build/mac/download_hermetic_xcode.py`, optionally seeds the fake
-    chromium repo with a `build/config/mac/mac_sdk.gni` bump, installs the
-    commit-msg hook so the env-var plumbing is exercised end-to-end, and
-    then drives `UpdateXcodeToolchain.execute` directly.
+    `build/mac/download_hermetic_xcode.py`, seeds the fake chromium repo with a
+    `build/config/mac/mac_sdk.gni` bump tagged as `CHROMIUM_TAG`, fakes the
+    published-index fetch, installs the commit-msg hook so the env-var plumbing
+    is exercised end-to-end, and then drives `UpdateXcodeToolchain.execute`
+    directly.
     """
 
     def setUp(self):
@@ -133,6 +157,13 @@ class UpdateXcodeToolchainExecuteTest(unittest.TestCase):
         self.addCleanup(self.repo.cleanup)
         self._checkout_cr_branch()
         self._install_commit_msg_hook()
+        self._seed_hermetic_xcode_script()
+
+        patcher = patch.object(brockit.build_xcode_toolchain,
+                               'fetch_published_index',
+                               return_value=FAKE_INDEX)
+        self.fetch_index = patcher.start()
+        self.addCleanup(patcher.stop)
 
     # -- fixture helpers ----------------------------------------------------
 
@@ -140,20 +171,14 @@ class UpdateXcodeToolchainExecuteTest(unittest.TestCase):
         """Switches the fake brave repo onto a `cr{N}` branch.
 
         The commit-msg hook keys off the current branch name to inject the
-        `[cr{N}]` prefix into the final commit message, so every
-        integration test runs on a branch that matches that pattern.
+        `[cr{N}]` prefix into the final commit message, so every integration
+        test runs on a branch that matches that pattern.
         """
         self.repo._run_git_command(['checkout', '-b', name], self.repo.brave)
 
     def _install_commit_msg_hook(self) -> None:
         """Copies `tools/cr/alias/commit-msg.py` into the fake brave repo's
-        `.git/hooks/commit-msg` and marks it executable.
-
-        Using a copy (rather than a symlink) keeps the fixture
-        self-contained -- the hook keeps working even after the source
-        worktree the test was launched from has been wiped by other test
-        cleanup.
-        """
+        `.git/hooks/commit-msg` and marks it executable."""
         hooks_dir = self.repo.brave / '.git' / 'hooks'
         hooks_dir.mkdir(exist_ok=True)
         dest = hooks_dir / 'commit-msg'
@@ -165,13 +190,9 @@ class UpdateXcodeToolchainExecuteTest(unittest.TestCase):
 
     def _seed_hermetic_xcode_script(
             self, content: str = HERMETIC_XCODE_SCRIPT_INITIAL) -> None:
-        """Writes `build/mac/download_hermetic_xcode.py` into fake brave
-        with the supplied content and commits it.
-
-        Commits via the hook-bypass path (`--no-verify`) so this fixture
-        commit doesn't try to invoke the hook before we've seeded any
-        culprit history.
-        """
+        """Writes `build/mac/download_hermetic_xcode.py` into fake brave with
+        the supplied content and commits it (hook-bypassed via `--no-verify`,
+        since no culprit history is seeded yet)."""
         script_path = self.repo.brave / brockit.HERMETIC_XCODE_SCRIPT
         script_path.parent.mkdir(parents=True, exist_ok=True)
         script_path.write_text(content, encoding='utf-8', newline='')
@@ -181,39 +202,39 @@ class UpdateXcodeToolchainExecuteTest(unittest.TestCase):
             self.repo.brave)
 
     def _seed_mac_sdk_bump(self,
-                           initial: str = MAC_SDK_GNI_INITIAL,
-                           bumped: str | None = MAC_SDK_GNI_BUMPED) -> str:
-        """Lays down `build/config/mac/mac_sdk.gni` on fake chromium with
-        two commits: the initial pin, then the bump.
+                           mac_toolchain_py: str = MAC_TOOLCHAIN_PY) -> str:
+        """Lays down `build/config/mac/mac_sdk.gni` on fake chromium with two
+        commits -- the initial pin then the bump to 26.5/25F70 -- writes
+        `build/mac_toolchain.py` alongside the bump, and tags the bump commit as
+        `CHROMIUM_TAG`.
 
-        Returns the hash of the *bump* commit -- that's what the pickaxe
-        in `_resolve_chromium_commit` is supposed to find. When `bumped`
-        is `None`, only the initial commit is created (used to test the
-        unresolvable-commit failure path).
+        Returns the bump commit hash: the ref `execute` reads the SDK pin and
+        the minimum-OS block from, and what `_resolve_chromium_culprit`'s
+        pickaxe should attribute the update to.
         """
         gni = self.repo.chromium / 'build' / 'config' / 'mac' / 'mac_sdk.gni'
         gni.parent.mkdir(parents=True, exist_ok=True)
-        gni.write_text(initial, encoding='utf-8', newline='')
+        gni.write_text(MAC_SDK_GNI_INITIAL, encoding='utf-8', newline='')
         self.repo._run_git_command(['add', str(gni)], self.repo.chromium)
         self.repo._run_git_command(['commit', '-m', 'mac: initial SDK pin'],
                                    self.repo.chromium)
 
-        if bumped is None:
-            return ''
-
-        gni.write_text(bumped, encoding='utf-8', newline='')
-        self.repo._run_git_command(['add', str(gni)], self.repo.chromium)
-        self.repo._run_git_command(['commit', '-m', 'mac: Switch to SDK 26.5'],
+        gni.write_text(MAC_SDK_GNI_BUMPED, encoding='utf-8', newline='')
+        toolchain = self.repo.chromium / 'build' / 'mac_toolchain.py'
+        toolchain.write_text(mac_toolchain_py, encoding='utf-8', newline='')
+        self.repo._run_git_command(
+            ['add', str(gni), str(toolchain)], self.repo.chromium)
+        culprit = self.repo.commit('mac: Switch to SDK 26.5',
                                    self.repo.chromium)
-        return self.repo._run_git_command(['rev-parse', 'HEAD'],
-                                          self.repo.chromium)
+        self.repo._run_git_command(['tag', CHROMIUM_TAG], self.repo.chromium)
+        return culprit
 
     def _last_brave_commit_message(self) -> str:
         return self.repo._run_git_command(['log', '-1', '--format=%B'],
                                           self.repo.brave)
 
-    def _last_brave_subject(self) -> str:
-        return self.repo._run_git_command(['log', '-1', '--format=%s'],
+    def _brave_head(self) -> str:
+        return self.repo._run_git_command(['rev-parse', 'HEAD'],
                                           self.repo.brave)
 
     def _read_hermetic_xcode_script(self) -> str:
@@ -223,35 +244,51 @@ class UpdateXcodeToolchainExecuteTest(unittest.TestCase):
     # -- tests --------------------------------------------------------------
 
     def test_constants_rewritten_and_committed(self):
-        """Happy path: every constant takes its value from the URL, the
-        edit lands on disk, and the commit-msg hook stamps the final
-        message with `[cr150][toolchain]` plus the chromium culprit
-        body."""
-        self._seed_hermetic_xcode_script()
+        """Happy path: the archive hash and SDK constants take their values
+        from the index/SDK pin, the provenance comment is regenerated, the edit
+        lands on disk, and the commit-msg hook stamps the final message with
+        `[cr150][toolchain]` plus the chromium culprit body."""
         culprit = self._seed_mac_sdk_bump()
 
-        brockit.UpdateXcodeToolchain().execute(url=TOOLCHAIN_URL, culprit=None)
+        brockit.UpdateXcodeToolchain().execute(chromium_ref=CHROMIUM_TAG,
+                                               culprit=None)
 
         script = self._read_hermetic_xcode_script()
-        self.assertIn("XCODE_VERSION = '26.5'", script)
-        self.assertIn("XCODE_BUILD_VERSION = '17F42'", script)
+        self.assertIn(f"MAC_BINARIES_HASH = '{FAKE_INDEX['sha256sum']}'",
+                      script)
         self.assertIn("MAC_SDK_OFFICIAL_VERSION = '26.5'", script)
         self.assertIn("MAC_SDK_OFFICIAL_BUILD_VERSION = '25F70'", script)
-        self.assertIn("MAC_SDK_UPSTREAM_VERSION = '26.5'", script)
-        self.assertIn("MAC_SDK_UPSTREAM_BUILD_VERSION = '25F70'", script)
+        self.assertNotIn("'oldhash'", script)
+        # The provenance comment was regenerated from the resolved toolchain.
+        sdk_info = brockit.build_xcode_toolchain.MacSdkInfo(
+            sdk_version='26.5', product_build_version='25F70')
+        self.assertIn(
+            brockit.UpdateXcodeToolchain._provenance_comment(
+                sdk_info, FAKE_INDEX), script)
+        # The MAC_MINIMUM_OS_VERSION block was lifted verbatim from upstream
+        # (bumped value + its distinct comment), replacing the old block.
+        self.assertIn('MAC_MINIMUM_OS_VERSION = [20, 0]', script)
+        self.assertIn('runs on macOS 26.3 and newer', script)
+        self.assertNotIn('MAC_MINIMUM_OS_VERSION = [19, 4]', script)
+        self.assertNotIn('runs on macOS 26.1 and newer', script)
+        # The unrelated upstream lines were not dragged along with the block.
+        self.assertNotIn('OTHER_CONSTANT', script)
+        self.assertNotIn('MAC_BINARIES_TAG', script)
+
+        # The index was resolved for the SDK read from mac_sdk.gni at the ref.
+        self.assertEqual(self.fetch_index.call_args.args[0], sdk_info)
 
         message = self._last_brave_commit_message()
         # The hook must have stamped both tags. The relative order between
         # `[cr150]` and `[toolchain]` comes from set iteration in
-        # `commit-msg.py`, so just assert both are present in the
-        # subject.
+        # `commit-msg.py`, so just assert both are present in the subject.
         subject = message.splitlines()[0]
         self.assertIn('[cr150]', subject)
         self.assertIn('[toolchain]', subject)
         self.assertIn('Switch to Xcode 26.5 17F42', subject)
 
-        # The culprit body the hook appends includes the link and the
-        # full `git log -1 <hash>` payload from chromium.
+        # The culprit body the hook appends includes the link and the full
+        # `git log -1 <hash>` payload from chromium.
         self.assertIn(
             f'https://chromium.googlesource.com/chromium/src/+/{culprit}',
             message)
@@ -259,90 +296,81 @@ class UpdateXcodeToolchainExecuteTest(unittest.TestCase):
 
     def test_culprit_override_skips_auto_detection(self):
         """An explicit `culprit=<hash>` bypasses the mac_sdk.gni pickaxe
-        entirely. We prove this by passing a hash that the auto-detector
-        would never have produced -- a commit on the chromium master
-        branch that doesn't touch `mac_sdk.gni` at all."""
-        self._seed_hermetic_xcode_script()
-        # Seed an unrelated chromium commit so we have a real hash to
-        # reference.
+        entirely. We prove this by passing a hash that the auto-detector would
+        never have produced -- an unrelated chromium commit -- and asserting
+        the auto-detected bump hash is absent from the message."""
+        autodetect = self._seed_mac_sdk_bump()
         self.repo.write_and_stage_file('docs/unrelated.txt', 'noise\n',
                                        self.repo.chromium)
-        override_hash = self.repo.commit('Unrelated chromium change',
-                                         self.repo.chromium)
-        # Seed mac_sdk.gni only with the initial state; a successful run
-        # here means the auto-detector was never asked.
-        self._seed_mac_sdk_bump(bumped=None)
+        override = self.repo.commit('Unrelated chromium change',
+                                    self.repo.chromium)
 
-        brockit.UpdateXcodeToolchain().execute(url=TOOLCHAIN_URL,
-                                               culprit=override_hash)
+        brockit.UpdateXcodeToolchain().execute(chromium_ref=CHROMIUM_TAG,
+                                               culprit=override)
 
         message = self._last_brave_commit_message()
         self.assertIn(
-            f'https://chromium.googlesource.com/chromium/src/+/{override_hash}',
+            f'https://chromium.googlesource.com/chromium/src/+/{override}',
             message)
         self.assertIn('Unrelated chromium change', message)
+        self.assertNotIn(autodetect, message)
 
-    def test_already_pinned_raises(self):
-        """When `build/mac/download_hermetic_xcode.py` already carries the
-        URL's six tokens, the regex substitutions are all no-ops and the
-        task aborts instead of producing an empty commit."""
-        self._seed_hermetic_xcode_script(
-            content=("XCODE_VERSION = '26.5'\n"
-                     "XCODE_BUILD_VERSION = '17F42'\n"
-                     "MAC_SDK_OFFICIAL_VERSION = '26.5'\n"
-                     "MAC_SDK_OFFICIAL_BUILD_VERSION = '25F70'\n"
-                     "MAC_SDK_UPSTREAM_VERSION = '26.5'\n"
-                     "MAC_SDK_UPSTREAM_BUILD_VERSION = '25F70'\n"))
+    def test_already_pinned_second_run_raises(self):
+        """A second run over an already-pinned file is a byte-identical no-op:
+        nothing is rewritten, the task aborts instead of producing an empty
+        commit, and HEAD is unchanged."""
         self._seed_mac_sdk_bump()
-        head_before = self.repo._run_git_command(['rev-parse', 'HEAD'],
-                                                 self.repo.brave)
+        toolchain = brockit.UpdateXcodeToolchain()
+
+        toolchain.execute(chromium_ref=CHROMIUM_TAG, culprit=None)
+        head_after_first = self._brave_head()
 
         with self.assertRaises(brockit.InvalidInputException):
-            brockit.UpdateXcodeToolchain().execute(url=TOOLCHAIN_URL,
-                                                   culprit=None)
+            toolchain.execute(chromium_ref=CHROMIUM_TAG, culprit=None)
+        self.assertEqual(self._brave_head(), head_after_first)
 
-        # No commit was produced.
-        head_after = self.repo._run_git_command(['rev-parse', 'HEAD'],
-                                                self.repo.brave)
-        self.assertEqual(head_before, head_after)
-
-    def test_bad_url_raises(self):
-        """A URL whose filename doesn't fit the
-        `xcode-hermetic-toolchain-<...>.tar.gz` shape is rejected before
-        any disk state is touched."""
-        self._seed_hermetic_xcode_script()
+    def test_index_fetch_failure_raises(self):
+        """A failure resolving the published index surfaces as a
+        `BadOutcomeException` and produces no commit."""
         self._seed_mac_sdk_bump()
-        original = self._read_hermetic_xcode_script()
+        self.fetch_index.side_effect = RuntimeError('index not found')
+        head_before = self._brave_head()
 
-        with self.assertRaises(brockit.InvalidInputException):
-            brockit.UpdateXcodeToolchain().execute(
-                url='https://example.invalid/some-other-archive.tar.gz',
-                culprit=None)
-
-        self.assertEqual(self._read_hermetic_xcode_script(), original)
-
-    def test_unresolvable_chromium_commit_raises(self):
-        """When `mac_sdk.gni` has never carried the URL's upstream build
-        number, the pickaxe returns nothing and the task points the user
-        at `--culprit` to recover."""
-        self._seed_hermetic_xcode_script()
-        # Seed mac_sdk.gni without ever introducing the URL's build
-        # number, so `git log -S 25F70 -- build/config/mac/mac_sdk.gni`
-        # comes back empty.
-        self._seed_mac_sdk_bump(bumped=None)
-        head_before = self.repo._run_git_command(['rev-parse', 'HEAD'],
-                                                 self.repo.brave)
-
-        with self.assertRaises(brockit.InvalidInputException):
-            brockit.UpdateXcodeToolchain().execute(url=TOOLCHAIN_URL,
+        with self.assertRaises(brockit.BadOutcomeException):
+            brockit.UpdateXcodeToolchain().execute(chromium_ref=CHROMIUM_TAG,
                                                    culprit=None)
+        self.assertEqual(self._brave_head(), head_before)
 
-        # The script edit happens before the chromium lookup, so the
-        # working tree may be dirty. What we care about here is that no
-        # commit slipped through.
-        head_after = self.repo._run_git_command(['rev-parse', 'HEAD'],
-                                                self.repo.brave)
-        self.assertEqual(head_before, head_after)
+    def test_missing_upstream_min_os_block_raises(self):
+        """When Chromium's `build/mac_toolchain.py` carries no
+        `MAC_MINIMUM_OS_VERSION` block, the task aborts (there is nothing to
+        mirror) and produces no commit."""
+        self._seed_mac_sdk_bump(
+            mac_toolchain_py='# upstream with no min-os block\nFOO = 1\n')
+        head_before = self._brave_head()
+
+        with self.assertRaises(brockit.InvalidInputException):
+            brockit.UpdateXcodeToolchain().execute(chromium_ref=CHROMIUM_TAG,
+                                                   culprit=None)
+        self.assertEqual(self._brave_head(), head_before)
+
+    def test_unresolvable_culprit_raises(self):
+        """`_resolve_chromium_culprit` raises when no commit up to the ref set
+        the SDK being pinned, steering the user at `--culprit` to recover."""
+        ref = self._seed_mac_sdk_bump()
+        # An SDK pair that mac_sdk.gni never carried in its history: the
+        # pickaxe comes back empty.
+        phantom = brockit.build_xcode_toolchain.MacSdkInfo(
+            sdk_version='99.9', product_build_version='Z9Z9')
+        with self.assertRaises(brockit.InvalidInputException):
+            brockit.UpdateXcodeToolchain()._resolve_chromium_culprit(
+                phantom, ref)
+
+    def test_staged_files_block_the_update(self):
+        self.repo.write_and_stage_file('staged.txt', 'wip\n', self.repo.brave)
+        with self.assertRaises(brockit.InvalidInputException):
+            brockit.UpdateXcodeToolchain().execute(chromium_ref=CHROMIUM_TAG,
+                                                   culprit='deadbeef')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This change updates the `update-xcode-toolchain` in brockit to work with
the index query we have now. This command will now maintain the several
task checks we have to do when bumping the toolchain.

Bug: https://github.com/brave/brave-browser/issues/55812
