### PR TITLE
[toolchain] Experimental index based Rust/WASM install

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -198,9 +198,11 @@ hooks = [
     'action': ['build/mac/cross-compile/build-libdmg-hfsplus.py', 'third_party/libdmg-hfsplus']
   },
   {
-    'name': 'download_rust_toolchain_aux',
+    'name': 'download_rust_wasm_toolchain',
     'pattern': '.',
-    'action': ['python3', 'build/rust/download_rust_toolchain_aux.py']
+    'action': ['vpython3',
+               'tools/cr/toolchains/install_extra_deps.py',
+               'src/third_party/rust-toolchain']
   },
 ]
 


### PR DESCRIPTION
This PR is an experiment using `install_extra_deps.py`, with it being
wired for the rust toolchain.

With this PR we can try to evolve the idea of having our sync downloads
treated as something close to a DEP installs, with a full loop of how we
we go from detecting that the toolchain was updated, to committing an
updated toolchain to `brave-core`.

With this PR we close the loop for the Rust/WASM toolchain, and that
goes in the following order:

```

    +----------------------------+
    | Toolchain updated upstream |
    +--------------+-------------+
                  |
                  v
    +----------------------------+
    |   B🚀 detects the update    |
    +--------------+-------------+
                  |
                  v
    +------------------------------+
    |     `gen-rust-toolchain`     |
    |     kicks out CI jobs        |
    +--------------+---------------+
                  |
                  v  (Triggers)
    +------------------------------+
    | `update-rust-wasm-toolchain` |
    | creates a commit with new tc |
    | details & updates the script |
    +--------------+---------------+
                  |
                  v
    +------------------------------+
    |         Sync calls           |
    |  `install_extra_deps.py`     |
    |     with new values          |
    +--------------+---------------+
                  |
                  v
    +------------------------------+
    |    `install_extra_deps.py`   |
    |   Landmine check executes:   |
    |   Keyed on `overlayed_on`    |
    |    (Blocks/permits sync)     |
    +------------------------------+

```

The next steps now is to make this process more generic and reusable for
other things too.

The question of how ultimately we may handle `EXTRA_DEPS` is still open,
and will be decide once things become clearer. There is a CL waiting for
review:

https://chromium-review.googlesource.com/c/chromium/tools/depot_tools/+/7885188

This CL has had specific owners added only recently, so it is worth to
see if maybe we can get some allowances from `depot_tools` owners before
deciding for a particular method.

Bug: https://github.com/brave/brave-browser/issues/55812
