### PR TITLE
[ai-chat][msan] `ConversationHandler::Observer` string use

### DIFF
--- a/components/ai_chat/core/browser/ai_chat_service.cc
+++ b/components/ai_chat/core/browser/ai_chat_service.cc
@@ -998,7 +998,7 @@ void AIChatService::HandleNewEntry(
 }
 
 void AIChatService::OnConversationEntryRemoved(ConversationHandler* handler,
-                                               std::string entry_uuid) {
+                                               const std::string& entry_uuid) {
   // Persist the removal
   if (ai_chat_db_ && !handler->GetIsTemporary()) {
     ai_chat_db_
@@ -1008,7 +1008,7 @@ void AIChatService::OnConversationEntryRemoved(ConversationHandler* handler,
 }
 
 void AIChatService::OnToolUseEventOutput(ConversationHandler* handler,
-                                         std::string_view entry_uuid,
+                                         const std::string& entry_uuid,
                                          size_t event_order,
                                          mojom::ToolUseEventPtr tool_use) {
   // Persist the tool use event

--- a/components/ai_chat/core/browser/ai_chat_service.h
+++ b/components/ai_chat/core/browser/ai_chat_service.h
@@ -110,9 +110,9 @@ class AIChatService : public KeyedService,
       mojom::ConversationTurnPtr& entry,
       std::optional<PageContents> maybe_associated_content) override;
   void OnConversationEntryRemoved(ConversationHandler* handler,
-                                  std::string entry_uuid) override;
+                                  const std::string& entry_uuid) override;
   void OnToolUseEventOutput(ConversationHandler* handler,
-                            std::string_view entry_uuid,
+                            const std::string& entry_uuid,
                             size_t event_order,
                             mojom::ToolUseEventPtr tool_use) override;
   void OnClientConnectionChanged(ConversationHandler* handler) override;

--- a/components/ai_chat/core/browser/conversation_handler.h
+++ b/components/ai_chat/core/browser/conversation_handler.h
@@ -79,33 +79,31 @@ class ConversationHandler : public mojom::ConversationHandler,
 
   class Observer : public base::CheckedObserver {
    public:
-    ~Observer() override {}
-
     // Called when the conversation history changess
     virtual void OnRequestInProgressChanged(ConversationHandler* handler,
-                                            bool in_progress) {}
+                                            bool in_progress) = 0;
     virtual void OnConversationEntryAdded(
         ConversationHandler* handler,
         mojom::ConversationTurnPtr& entry,
-        std::optional<PageContents> associated_content_value) {}
+        std::optional<PageContents> associated_content_value) = 0;
     virtual void OnConversationEntryRemoved(ConversationHandler* handler,
-                                            std::string turn_uuid) {}
+                                            const std::string& turn_uuid) = 0;
 
     virtual void OnToolUseEventOutput(ConversationHandler* handler,
-                                      std::string_view entry_uuid,
+                                      const std::string& entry_uuid,
                                       size_t event_order,
-                                      mojom::ToolUseEventPtr tool_use) {}
+                                      mojom::ToolUseEventPtr tool_use) = 0;
 
     // Called when a mojo client connects or disconnects
-    virtual void OnClientConnectionChanged(ConversationHandler* handler) {}
+    virtual void OnClientConnectionChanged(ConversationHandler* handler) = 0;
     virtual void OnConversationTitleChanged(
         const std::string& conversation_uuid,
-        const std::string& title) {}
+        const std::string& title) = 0;
     virtual void OnConversationTokenInfoChanged(
         const std::string& conversation_uuid,
         uint64_t total_tokens,
-        uint64_t trimmed_tokens) {}
-    virtual void OnAssociatedContentUpdated(ConversationHandler* handler) {}
+        uint64_t trimmed_tokens) = 0;
+    virtual void OnAssociatedContentUpdated(ConversationHandler* handler) = 0;
   };
 
   struct Suggestion {

--- a/components/ai_chat/core/browser/mock_conversation_handler_observer.h
+++ b/components/ai_chat/core/browser/mock_conversation_handler_observer.h
@@ -39,13 +39,13 @@ class MockConversationHandlerObserver : public ConversationHandler::Observer {
 
   MOCK_METHOD(void,
               OnConversationEntryRemoved,
-              (ConversationHandler*, std::string),
+              (ConversationHandler*, const std::string&),
               (override));
 
   MOCK_METHOD(void,
               OnToolUseEventOutput,
               (ConversationHandler*,
-               std::string_view entry_uuid,
+               const std::string& entry_uuid,
                size_t event_order,
                mojom::ToolUseEventPtr tool_use),
               (override));
@@ -63,6 +63,11 @@ class MockConversationHandlerObserver : public ConversationHandler::Observer {
   MOCK_METHOD(void,
               OnConversationTokenInfoChanged,
               (const std::string&, uint64_t, uint64_t),
+              (override));
+
+  MOCK_METHOD(void,
+              OnAssociatedContentUpdated,
+              (ConversationHandler*),
               (override));
 
  private:


### PR DESCRIPTION
This PR changes some of the events in `ConversationHandler::Observer` to
just use `const std::string&` for cases where `std::string` uses cannot
be completely removed form the call flow, so using `std::string_view`
can becomes a source of extra copies, and passing values a `std::string`
reference simplifies things.

Resolves https://github.com/brave/internal/issues/1763
Resolves https://github.com/brave/internal/issues/1765
Resolves https://github.com/brave/internal/issues/1764
Resolves https://github.com/brave/internal/issues/1766
Resolves https://github.com/brave/internal/issues/1767
Resolves https://github.com/brave/internal/issues/1768
