### PR TITLE
[git-cr] Adding `git cr commit --fixup=drop`

### DIFF
--- a/tools/cr/alias/commit.py
+++ b/tools/cr/alias/commit.py
@@ -16,6 +16,7 @@ Usage
   git cr commit -m "Fix login button alignment"
   git cr commit --tagged WIP -m "Work in progress"
   git cr commit --fixup=reassign:<ref>   # shortcut for `brockit.py reassign`
+  git cr commit --fixup=drop:<ref>       # shortcut for `brockit.py drop`
 
   Custom flags (forwarded to the commit-msg hook via environment variables):
     --tagged    Comma-separated tags            → $tags
@@ -93,14 +94,17 @@ class _LenientArgumentParser(argparse.ArgumentParser):
 
 
 @dataclass(frozen=True)
-class _ReassignShortcut:
-    """The `git cr commit --fixup=reassign:<ref>` shortcut.
+class _MarkChangeShortcut:
+    """The `git cr commit --fixup=<verb>:<ref>` shortcut.
 
-    This is a convenience shortcut for brockit's `reassign` task. It can be used
-    either as:
+    This is a convenience shortcut for brockit's change-marking tasks. Each
+    supported `<verb>` maps to a brockit task that drops an empty marker commit
+    (e.g. `reassign!`/`drop!`) which brockit's `rebase` command later acts on.
+    It can be used either as:
       git cr commit --fixup=reassign:HEAD
+      git cr commit --fixup=drop:HEAD
 
-    or
+    or with the split spelling:
       git cr commit --fixup reassign:HEAD
 
     `from_args` is the entry point: it returns a ready-to-run instance when
@@ -108,25 +112,30 @@ class _ReassignShortcut:
     commit.
     """
 
-    # Value prefix that selects this mode, mirroring git's own `amend:` /
-    # `reword:` fixup modes.
-    _PREFIX: ClassVar[str] = 'reassign:'
+    # Maps each supported `<verb>:` value -- mirroring git's own `amend:` /
+    # `reword:` fixup modes -- to the name of the brockit task that implements
+    # it. The task is resolved lazily in `run` so brockit stays unimported on
+    # the ordinary commit path.
+    _TASKS: ClassVar[dict[str, str]] = {
+        'reassign': 'Reassign',
+        'drop': 'Drop',
+    }
 
-    # The commit reference whose authorship is being reassigned.
+    # The verb selecting the brockit task, e.g. `reassign` or `drop`.
+    verb: str
+    # The commit reference being marked.
     target: str
 
     @staticmethod
-    def from_args(args: list[str]) -> _ReassignShortcut | None:
+    def from_args(args: list[str]) -> _MarkChangeShortcut | None:
         """Build the shortcut from *args*, or return None when it isn't used.
 
-        This function checks for the presence of the reassign shortcut use that
-        we are interested in, and if found, parses out the args provided,
-        strictly looking only for `--fixup` and validating the format used for
-        its value.
+        Parses *args* strictly looking only for `--fixup`, then validates its
+        value. Anything that isn't one of our `<verb>:<ref>` shortcuts -- an
+        ordinary commit, a malformed `--fixup`, or git's own fixup modes
+        (`amend:` / `reword:`) -- silently bails out as None so the caller falls
+        back to the normal commit path.
         """
-        if not any(_ReassignShortcut._PREFIX in arg for arg in args):
-            return None
-
         parser = _LenientArgumentParser(add_help=False)
         parser.add_argument('--fixup')
         try:
@@ -135,21 +144,24 @@ class _ReassignShortcut:
             return None
 
         fixup = parsed.fixup
-        if fixup is None or not fixup.startswith(_ReassignShortcut._PREFIX):
+        if fixup is None or ':' not in fixup:
+            return None
+        verb, target = fixup.split(':', 1)
+        # Leave git's own fixup modes (and anything unrecognised) untouched.
+        if verb not in _MarkChangeShortcut._TASKS:
             return None
         if other_args:
             raise UserValidationError(
-                'git_cr: --fixup=reassign:<ref> cannot be combined with '
+                f'git_cr: --fixup={verb}:<ref> cannot be combined with '
                 f'other arguments; remove: {" ".join(other_args)}')
-        target = fixup[len(_ReassignShortcut._PREFIX):]
         if not target:
             raise UserValidationError(
-                'git_cr: --fixup=reassign: requires a commit reference, '
-                'e.g. --fixup=reassign:HEAD~2')
-        return _ReassignShortcut(target)
+                f'git_cr: --fixup={verb}: requires a commit reference, '
+                f'e.g. --fixup={verb}:HEAD~2')
+        return _MarkChangeShortcut(verb, target)
 
     def run(self) -> int:
-        """Run brockit's `Reassign` task for the captured target.
+        """Run the selected brockit change-marking task for the target.
 
         The commit-msg hook is irrelevant (brockit commits with --no-verify),
         so it is not checked.
@@ -157,11 +169,12 @@ class _ReassignShortcut:
         # Imported lazily: brockit is a heavy module, so we only import it when
         # needed.
         import brockit
+        task = getattr(brockit, _MarkChangeShortcut._TASKS[self.verb])
         try:
-            brockit.Reassign().run(change=self.target)
+            task().run(change=self.target)
         except (brockit.InvalidInputException, brockit.BadOutcomeException,
                 brockit.ActionNeededException):
-            # Handling brockit exceptions as failures to create the reassingment
+            # Handling brockit exceptions as failures to create the marker
             # commit.
             return 1
         return 0
@@ -169,10 +182,10 @@ class _ReassignShortcut:
 
 def cmd_commit(args: list[str]) -> int:
     """Parse commit flags and invoke git commit with injected environment."""
-    # Let's try first to check for the reassignment shortcut being used.
-    reassign = _ReassignShortcut.from_args(args)
-    if reassign is not None:
-        return reassign.run()
+    # Let's try first to check for a change-marking shortcut being used.
+    mark_change = _MarkChangeShortcut.from_args(args)
+    if mark_change is not None:
+        return mark_change.run()
 
     parser = argparse.ArgumentParser(
         prog='git cr commit',

--- a/tools/cr/alias/commit_test.py
+++ b/tools/cr/alias/commit_test.py
@@ -19,7 +19,7 @@ import unittest
 
 import _boot  # noqa: F401
 from cmd_test import (CMD_SCRIPT, _GIT_ENV_OVERRIDES, _Sandbox)
-from alias.commit import _ReassignShortcut
+from alias.commit import _MarkChangeShortcut
 
 # ---------------------------------------------------------------------------
 # Tests: flag pass-through
@@ -283,6 +283,18 @@ class TestReassignFixup(unittest.TestCase):
         self.assertTrue(
             self._sandbox.last_commit_message().startswith('reassign!'))
 
+    def test_drop_verb_creates_drop_commit(self) -> None:
+        """--fixup=drop:HEAD adds an empty drop! commit via brockit drop."""
+        before = self._commit_count()
+        result = self._sandbox.run_gc(['commit', '--fixup=drop:HEAD'])
+        self.assertEqual(result.returncode, 0, msg=f'stderr: {result.stderr}')
+        self.assertEqual(self._commit_count(), before + 1)
+        msg = self._sandbox.last_commit_message()
+        # brockit formats the subject as `drop!<hash>! <original subject>`.
+        self.assertTrue(msg.startswith('drop!'),
+                        msg=f'unexpected message: {msg!r}')
+        self.assertIn('Add file.txt', msg)
+
     def test_empty_ref_is_rejected(self) -> None:
         """--fixup=reassign: with no ref errors out without committing."""
         before = self._commit_count()
@@ -327,40 +339,50 @@ class TestReassignFixup(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
-# Tests: _ReassignShortcut.from_args detection and leniency (unit)
+# Tests: _MarkChangeShortcut.from_args detection and leniency (unit)
 # ---------------------------------------------------------------------------
 
 
-class TestReassignShortcutParsing(unittest.TestCase):
+class TestMarkChangeShortcutParsing(unittest.TestCase):
     """Unit checks for the lenient arg detection in from_args."""
 
     def test_detects_joined_and_split_forms(self) -> None:
         """Both `--fixup=reassign:X` and `--fixup reassign:X` are recognised."""
+        joined = _MarkChangeShortcut.from_args(['--fixup=reassign:HEAD'])
+        self.assertIsNotNone(joined)
+        self.assertEqual(joined.verb, 'reassign')
+        self.assertEqual(joined.target, 'HEAD')
         self.assertIsNotNone(
-            _ReassignShortcut.from_args(['--fixup=reassign:HEAD']))
-        self.assertIsNotNone(
-            _ReassignShortcut.from_args(['--fixup', 'reassign:HEAD']))
+            _MarkChangeShortcut.from_args(['--fixup', 'reassign:HEAD']))
 
-    def test_absent_when_no_reassign_marker(self) -> None:
+    def test_detects_drop_verb(self) -> None:
+        """The `drop:` verb is recognised alongside `reassign:`."""
+        for form in (['--fixup=drop:HEAD'], ['--fixup', 'drop:HEAD']):
+            shortcut = _MarkChangeShortcut.from_args(form)
+            self.assertIsNotNone(shortcut, msg=f'not detected: {form}')
+            self.assertEqual(shortcut.verb, 'drop')
+            self.assertEqual(shortcut.target, 'HEAD')
+
+    def test_absent_when_no_marker(self) -> None:
         """Ordinary commits and git's native fixup modes are not claimed."""
-        self.assertIsNone(_ReassignShortcut.from_args(['--fixup=HEAD']))
-        self.assertIsNone(_ReassignShortcut.from_args(['-m', 'a message']))
+        self.assertIsNone(_MarkChangeShortcut.from_args(['--fixup=HEAD']))
+        self.assertIsNone(_MarkChangeShortcut.from_args(['--fixup=amend:HEAD'
+                                                         ]))
+        self.assertIsNone(_MarkChangeShortcut.from_args(['-m', 'a message']))
 
     def test_marker_outside_fixup_is_not_the_shortcut(self) -> None:
-        """`reassign:` only in a commit message is not the shortcut."""
+        """A verb token only in a commit message is not the shortcut."""
         self.assertIsNone(
-            _ReassignShortcut.from_args(['-m', 'fix reassign: bug']))
+            _MarkChangeShortcut.from_args(['-m', 'fix reassign: bug']))
 
     def test_malformed_fixup_does_not_terminate(self) -> None:
         """A `--fixup` with no value must not exit the process.
 
         A strict ArgumentParser would call sys.exit() here; the lenient parser
-        instead reports "not the shortcut" so the caller falls back to the
-        normal commit path. `reassign:` appears in another token so the cheap
-        pre-check passes and the parse is actually attempted.
+        instead raises, so from_args reports "not the shortcut" and the caller
+        falls back to the normal commit path.
         """
-        self.assertIsNone(
-            _ReassignShortcut.from_args(['reassign:x', '--fixup']))
+        self.assertIsNone(_MarkChangeShortcut.from_args(['--fixup']))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
This is just a shortcut to `brockit drop`, which provides a commit to
serve as a rebase event to drop a target commit.
