### PR TITLE
Set disabled icon for scroll buttons

### DIFF
--- a/browser/ui/views/frame/brave_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/brave_tab_strip_region_view.cc
@@ -29,6 +29,7 @@
 #include "ui/base/l10n/l10n_util.h"
 #include "ui/base/metadata/metadata_header_macros.h"
 #include "ui/base/metadata/metadata_impl_macros.h"
+#include "ui/base/models/image_model.h"
 #include "ui/events/event.h"
 #include "ui/views/animation/ink_drop.h"
 #include "ui/views/controls/button/button.h"
@@ -59,6 +60,7 @@ class BraveTabStripScrollButton : public TabStripControlButton {
   bool IsRepeatingForTesting() const;
 
   // TabStripControlButton:
+  void UpdateIcon() override;
   bool OnMousePressed(const ui::MouseEvent& event) override;
   void OnMouseReleased(const ui::MouseEvent& event) override;
   void OnMouseCaptureLost() override;
@@ -70,6 +72,7 @@ class BraveTabStripScrollButton : public TabStripControlButton {
 
   base::RepeatingClosure scroll_action_;
   views::RepeatController repeater_;
+  raw_ref<const gfx::VectorIcon> icon_;
 };
 
 BraveTabStripScrollButton::BraveTabStripScrollButton(
@@ -83,7 +86,8 @@ BraveTabStripScrollButton::BraveTabStripScrollButton(
                             Edge::kNone),
       scroll_action_(std::move(scroll_action)),
       repeater_(base::BindRepeating(&BraveTabStripScrollButton::OnRepeaterFired,
-                                    base::Unretained(this))) {
+                                    base::Unretained(this))),
+      icon_(icon) {
   button_controller()->set_notify_action(
       views::ButtonController::NotifyAction::kOnPress);
 }
@@ -98,6 +102,19 @@ bool BraveTabStripScrollButton::IsRepeatingForTesting() const {
 
 void BraveTabStripScrollButton::OnRepeaterFired() {
   scroll_action_.Run();
+}
+
+void BraveTabStripScrollButton::UpdateIcon() {
+  TabStripControlButton::UpdateIcon();
+
+  auto* cp = GetColorProvider();
+  CHECK(cp);
+
+  SetImageModel(
+      STATE_DISABLED,
+      ui::ImageModel::FromVectorIcon(
+          icon_.get(),
+          cp->GetColor(kColorNewTabButtonCRForegroundFrameInactive), 16));
 }
 
 bool BraveTabStripScrollButton::OnMousePressed(const ui::MouseEvent& event) {


### PR DESCRIPTION
TabStripControlButton::UpdateIcon() is missing disabled icon. But the scroll buttons are disabled when the tab strip is not scrollable , so the icon should be updated to reflect that.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/56013

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
