### PR TITLE
[VPN 2.0] Minor fix in BraveVpnServiceObserver and unit tests

### DIFF
--- a/components/brave_vpn/browser/BUILD.gn
+++ b/components/brave_vpn/browser/BUILD.gn
@@ -85,7 +85,10 @@ source_set("test_support") {
 source_set("unit_tests") {
   testonly = true
 
-  sources = [ "brave_vpn_service_unittest.cc" ]
+  sources = [
+    "brave_vpn_service_observer_unittest.cc",
+    "brave_vpn_service_unittest.cc",
+  ]
 
   if (enable_brave_vpn_v1) {
     sources += [

--- a/components/brave_vpn/browser/brave_vpn_service_observer.cc
+++ b/components/brave_vpn/browser/brave_vpn_service_observer.cc
@@ -21,6 +21,7 @@ void BraveVpnServiceObserver::Observe(BraveVpnService* service) {
     return;
 
   if (service->IsBraveVPNEnabled()) {
+    receiver_.reset();
     mojo::PendingRemote<mojom::ServiceObserver> listener;
     receiver_.Bind(listener.InitWithNewPipeAndPassReceiver());
     service->AddObserver(std::move(listener));

--- a/components/brave_vpn/browser/brave_vpn_service_observer_unittest.cc
+++ b/components/brave_vpn/browser/brave_vpn_service_observer_unittest.cc
@@ -1,0 +1,47 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/browser/brave_vpn_service_observer.h"
+
+#include <memory>
+
+#include "brave/components/brave_vpn/browser/test/fake_brave_vpn_service.h"
+#include "content/public/test/browser_task_environment.h"
+#include "mojo/public/cpp/bindings/remote.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace brave_vpn {
+
+class BraveVpnServiceObserverTest : public testing::Test {
+ public:
+  BraveVpnServiceObserverTest() = default;
+  ~BraveVpnServiceObserverTest() override = default;
+
+ protected:
+  void SetUp() override { service_ = std::make_unique<FakeBraveVpnService>(); }
+
+  FakeBraveVpnService* service() { return service_.get(); }
+
+ private:
+  content::BrowserTaskEnvironment task_environment_;
+  std::unique_ptr<FakeBraveVpnService> service_;
+};
+
+// Calling Observe() twice on the same service should not crash,
+// and the observer should be correctly re-bound after the second call.
+TEST_F(BraveVpnServiceObserverTest, ObserveCalledTwiceDoesNotCrash) {
+  FakeBraveVpnService* service = this->service();
+  BraveVpnServiceObserver observer;
+  EXPECT_NO_FATAL_FAILURE(observer.Observe(service));
+  EXPECT_NO_FATAL_FAILURE(observer.Observe(service));
+}
+
+// Calling Observe() with a null service should be a safe no-op.
+TEST_F(BraveVpnServiceObserverTest, ObserveWithNullServiceDoesNotCrash) {
+  BraveVpnServiceObserver observer;
+  EXPECT_NO_FATAL_FAILURE(observer.Observe(nullptr));
+}
+
+}  // namespace brave_vpn


### PR DESCRIPTION
BraveVPNServiceObserver is an existing observer that works with VPN Architecture 1.0. It can be reused for Architecture 2.0 mostly as-is, with minor changes.

This change adds a minor fix to ensure BraveVpnServiceObserver doesn't crash on multiple Observe() calls, and adds unit tests.

Resolves https://github.com/brave/brave-browser/issues/54599


<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
