### PR TITLE
Hide Survey Panelist, P3A, and usage ping settings for Brave Origin branded builds

### DIFF
--- a/browser/ui/webui/brave_settings_ui.cc
+++ b/browser/ui/webui/brave_settings_ui.cc
@@ -264,12 +264,18 @@ void BraveSettingsUI::AddResources(content::WebUIDataSource* html_source,
                           ai_chat::features::IsAIChatHistoryEnabled());
 #endif
 
+#if BUILDFLAG(IS_BRAVE_ORIGIN_BRANDED)
+  // Survey Panelist is tied to Brave Rewards, which is compiled out of Brave
+  // Origin branded builds, so the setting is never available there.
+  html_source->AddBoolean("isSurveyPanelistAllowed", false);
+#else
   html_source->AddBoolean("isSurveyPanelistAllowed",
                           base::FeatureList::IsEnabled(
                               ntp_background_images::features::
                                   kBraveNTPBrandedWallpaperSurveyPanelist) &&
                               !profile->GetPrefs()->GetBoolean(
                                   brave_rewards::prefs::kDisabledByPolicy));
+#endif
 #if BUILDFLAG(ENABLE_PLAYLIST)
   html_source->AddBoolean(
       "isPlaylistFeatureEnabled",

--- a/browser/ui/webui/settings/brave_privacy_handler.cc
+++ b/browser/ui/webui/settings/brave_privacy_handler.cc
@@ -10,6 +10,7 @@
 #include "base/functional/bind.h"
 #include "base/values.h"
 #include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
+#include "brave/components/brave_origin/buildflags/buildflags.h"
 #include "brave/components/brave_shields/core/common/features.h"
 #include "brave/components/constants/pref_names.h"
 #include "brave/components/de_amp/common/features.h"
@@ -133,12 +134,20 @@ void BravePrivacyHandler::AddLoadTimeData(content::WebUIDataSource* data_source,
       ai_chat::IsAIChatEnabled(profile->GetPrefs()) &&
           ai_chat::features::IsOpenAIChatFromBraveSearchEnabled());
 #endif
+#if BUILDFLAG(IS_BRAVE_ORIGIN_BRANDED)
+  // P3A and usage ping (stats reporting) are disabled for Brave Origin branded
+  // builds. Hide their settings unconditionally so they don't briefly appear on
+  // first launch before the disabling policy is applied (brave-browser#56166).
+  data_source->AddBoolean("isStatsReportingEnabledManaged", true);
+  data_source->AddBoolean("isP3AEnabledManaged", true);
+#else
   auto* local_state = g_browser_process->local_state();
   data_source->AddBoolean(
       "isStatsReportingEnabledManaged",
       local_state->IsManagedPreference(kStatsReportingEnabled));
   data_source->AddBoolean("isP3AEnabledManaged",
                           local_state->IsManagedPreference(p3a::kP3AEnabled));
+#endif
 
 #if BUILDFLAG(IS_WIN)
   {


### PR DESCRIPTION
Hides several Data Collection settings in brave://settings/privacy that should not be available in Brave Origin branded/standalone builds.

Remaining Data Collection settings pane looks like this:
<img width="780" height="320" alt="Screenshot 2026-06-08 at 4 28 06 PM" src="https://github.com/user-attachments/assets/eeff9380-bd9e-4293-87ec-107e20db901d" />


Survey Panelist (#56123): the previous fix relied on the BraveRewardsDisabled policy setting kDisabledByPolicy, but that policy is now compiled out for Brave Origin branded builds (which disable Brave Rewards), so the check no longer applied. This gates isSurveyPanelistAllowed on IS_BRAVE_ORIGIN_BRANDED directly.

P3A and usage ping (#56166): these defaulted off for branded builds but their settings were only hidden once the disabling policy became managed, which happens after the first restart, so they briefly appeared on first launch. This forces isP3AEnabledManaged and isStatsReportingEnabledManaged to true for branded builds so the toggles are always hidden.

Resolves https://github.com/brave/brave-browser/issues/56123
Resolves https://github.com/brave/brave-browser/issues/56166