### PR TITLE
Update renderers when wallet is disabled by policy at runtime

### DIFF
--- a/browser/profiles/brave_renderer_updater.cc
+++ b/browser/profiles/brave_renderer_updater.cc
@@ -89,6 +89,13 @@ BraveRendererUpdater::BraveRendererUpdater(
       brave_wallet::kDefaultCardanoWallet,
       base::BindRepeating(&BraveRendererUpdater::UpdateAllRenderers,
                           base::Unretained(this)));
+  // The wallet can be disabled at runtime by policy (e.g. via Brave Origin).
+  // When that happens the renderers must stop installing the provider objects
+  // so they don't request interface binders the browser no longer registers.
+  pref_change_registrar_.Add(
+      brave_wallet::kBraveWalletDisabledByPolicy,
+      base::BindRepeating(&BraveRendererUpdater::UpdateAllRenderers,
+                          base::Unretained(this)));
 #endif
   pref_change_registrar_.Add(
       de_amp::kDeAmpPrefEnabled,
@@ -222,6 +229,15 @@ void BraveRendererUpdater::UpdateRenderer(
 #else
   bool has_installed_metamask = false;
 #endif
+
+  // Recompute whether the wallet is allowed for this context on every update.
+  // This can change at runtime (e.g. when the BraveWalletDisabled policy is
+  // toggled via Brave Origin) and the renderers must be told to stop installing
+  // the provider objects. Otherwise a renderer keeps a stale `true` value,
+  // installs `window.ethereum`/`window.solana`/`window.cardano`, and the
+  // browser kills the renderer with a "No binder found" bad message because the
+  // matching interface binder is no longer registered.
+  is_wallet_allowed_for_context_ = brave_wallet::IsAllowedForContext(profile_);
 
   bool should_ignore_brave_wallet_for_eth =
       !is_wallet_created_ || has_installed_metamask;


### PR DESCRIPTION
## Summary

Resolves https://github.com/brave/brave-browser/issues/56183

When the wallet is disabled at runtime by policy (Brave Origin) without restarting the browser, the renderer kept a **stale** cached value for whether the wallet is allowed for the context. It continued to install the `window.ethereum`, `window.solana`, and `window.cardano` provider objects.

This reproduced when you changed things without restarting.

Crashes the renderer with:
```
RESULT_CODE_KILLED_BAD_MESSAGE
No binder found for interface brave_wallet.mojom.CardanoProvider for the frame/document scope
```

All three providers bind identically, so this affects ethereum/solana/cardano alike — the report happened to hit `window.cardano`.

## Test Plan

1. Turn on Wallet and restart the browser.
2. Load a page (e.g. `brianbondy.com`).
3. In the dev console, evaluate `window.cardano` — it is defined.
4. Turn Wallet back off (Brave Origin / Web3 settings).
5. Reload the page.
   - **Before:** the renderer crashes (`RESULT_CODE_KILLED_BAD_MESSAGE`) on the first reload; a second reload recovers.
   - **After:** no crash; `window.cardano` (and `window.ethereum` / `window.solana`) are no longer installed.
