### PR TITLE
Uplift Brave Origin fixes to 1.91.x

### DIFF
--- a/browser/profiles/brave_renderer_updater.cc
+++ b/browser/profiles/brave_renderer_updater.cc
@@ -89,6 +89,13 @@ BraveRendererUpdater::BraveRendererUpdater(
       brave_wallet::kDefaultCardanoWallet,
       base::BindRepeating(&BraveRendererUpdater::UpdateAllRenderers,
                           base::Unretained(this)));
+  // The wallet can be disabled at runtime by policy (e.g. via Brave Origin).
+  // When that happens the renderers must stop installing the provider objects
+  // so they don't request interface binders the browser no longer registers.
+  pref_change_registrar_.Add(
+      brave_wallet::kBraveWalletDisabledByPolicy,
+      base::BindRepeating(&BraveRendererUpdater::UpdateAllRenderers,
+                          base::Unretained(this)));
 #endif
   pref_change_registrar_.Add(
       de_amp::kDeAmpPrefEnabled,
@@ -222,6 +229,15 @@ void BraveRendererUpdater::UpdateRenderer(
 #else
   bool has_installed_metamask = false;
 #endif
+
+  // Recompute whether the wallet is allowed for this context on every update.
+  // This can change at runtime (e.g. when the BraveWalletDisabled policy is
+  // toggled via Brave Origin) and the renderers must be told to stop installing
+  // the provider objects. Otherwise a renderer keeps a stale `true` value,
+  // installs `window.ethereum`/`window.solana`/`window.cardano`, and the
+  // browser kills the renderer with a "No binder found" bad message because the
+  // matching interface binder is no longer registered.
+  is_wallet_allowed_for_context_ = brave_wallet::IsAllowedForContext(profile_);
 
   bool should_ignore_brave_wallet_for_eth =
       !is_wallet_created_ || has_installed_metamask;

--- a/browser/ui/webui/brave_settings_ui.cc
+++ b/browser/ui/webui/brave_settings_ui.cc
@@ -263,12 +263,18 @@ void BraveSettingsUI::AddResources(content::WebUIDataSource* html_source,
                           ai_chat::features::IsAIChatHistoryEnabled());
 #endif
 
+#if BUILDFLAG(IS_BRAVE_ORIGIN_BRANDED)
+  // Survey Panelist is tied to Brave Rewards, which is compiled out of Brave
+  // Origin branded builds, so the setting is never available there.
+  html_source->AddBoolean("isSurveyPanelistAllowed", false);
+#else
   html_source->AddBoolean("isSurveyPanelistAllowed",
                           base::FeatureList::IsEnabled(
                               ntp_background_images::features::
                                   kBraveNTPBrandedWallpaperSurveyPanelist) &&
                               !profile->GetPrefs()->GetBoolean(
                                   brave_rewards::prefs::kDisabledByPolicy));
+#endif
 #if BUILDFLAG(ENABLE_PLAYLIST)
   html_source->AddBoolean(
       "isPlaylistFeatureEnabled",

--- a/browser/ui/webui/settings/brave_privacy_handler.cc
+++ b/browser/ui/webui/settings/brave_privacy_handler.cc
@@ -10,6 +10,7 @@
 #include "base/functional/bind.h"
 #include "base/values.h"
 #include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
+#include "brave/components/brave_origin/buildflags/buildflags.h"
 #include "brave/components/brave_shields/core/common/features.h"
 #include "brave/components/constants/pref_names.h"
 #include "brave/components/de_amp/common/features.h"
@@ -133,12 +134,20 @@ void BravePrivacyHandler::AddLoadTimeData(content::WebUIDataSource* data_source,
       ai_chat::IsAIChatEnabled(profile->GetPrefs()) &&
           ai_chat::features::IsOpenAIChatFromBraveSearchEnabled());
 #endif
+#if BUILDFLAG(IS_BRAVE_ORIGIN_BRANDED)
+  // P3A and usage ping (stats reporting) are disabled for Brave Origin branded
+  // builds. Hide their settings unconditionally so they don't briefly appear on
+  // first launch before the disabling policy is applied (brave-browser#56166).
+  data_source->AddBoolean("isStatsReportingEnabledManaged", true);
+  data_source->AddBoolean("isP3AEnabledManaged", true);
+#else
   auto* local_state = g_browser_process->local_state();
   data_source->AddBoolean(
       "isStatsReportingEnabledManaged",
       local_state->IsManagedPreference(kStatsReportingEnabled));
   data_source->AddBoolean("isP3AEnabledManaged",
                           local_state->IsManagedPreference(p3a::kP3AEnabled));
+#endif
 
 #if BUILDFLAG(IS_WIN)
   {


### PR DESCRIPTION
Uplift of #37081
Uplift of #37090
Resolves brave/brave-browser#56123
Resolves brave/brave-browser#56166
Resolves brave/brave-browser#56183

## Included PRs
- #37081 - Hide Survey Panelist, P3A, and usage ping settings for Brave Origin branded builds
- #37090 - Update renderers when wallet is disabled by policy at runtime

Pre-approval checklist:
- [x] You have tested your change on Nightly.
- [ ] This contains text which needs to be translated.
    - [ ] There are more than 7 days before the release.
    - [ ] I've notified folks in #l10n on Slack that translations are needed.
- [x] The PR milestones match the branch they are landing to.


Pre-merge checklist:
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.

Post-merge checklist:
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.