### PR TITLE
[Android][Origin] Resume interrupted credential fetch on startup

### DIFF
--- a/android/java/org/chromium/chrome/browser/app/BraveActivity.java
+++ b/android/java/org/chromium/chrome/browser/app/BraveActivity.java
@@ -1210,14 +1210,19 @@ public abstract class BraveActivity extends ChromeActivity
 
         BraveVpnNativeWorker.getInstance().reloadPurchasedState();
 
-        // Restore Origin purchase from Google Play if the local pref is not set
-        // (e.g. after device change). This ensures prefs are populated before the user
-        // taps the Origin menu.
         Profile profile = mTabModelProfileSupplier.get();
-        if (profile != null
-                && ChromeFeatureList.isEnabled(BraveFeatureList.BRAVE_ORIGIN)
-                && !BraveOriginSubscriptionPrefs.getIsSubscriptionActive(profile)) {
-            BraveOriginSubscriptionPrefs.verifyPurchase(profile);
+        if (profile != null && ChromeFeatureList.isEnabled(BraveFeatureList.BRAVE_ORIGIN)) {
+            if (!BraveOriginSubscriptionPrefs.getIsSubscriptionActive(profile)) {
+                // Restore Origin purchase from Google Play if the local pref is not set
+                // (e.g. after device change). This ensures prefs are populated before the user
+                // taps the Origin menu.
+                BraveOriginSubscriptionPrefs.verifyPurchase(profile);
+            } else {
+                // The subscription is active locally. If a prior session was killed mid-fetch
+                // (order ID never written), restart the credential fetch so the user isn't left
+                // permanently stuck on the "Disabling features" spinner.
+                BraveOriginSubscriptionPrefs.resumeCredentialFetchIfNeeded(profile);
+            }
         }
 
         BraveHelper.maybeMigrateSettings();

--- a/android/java/org/chromium/chrome/browser/brave_origin/BraveOriginSubscriptionPrefs.java
+++ b/android/java/org/chromium/chrome/browser/brave_origin/BraveOriginSubscriptionPrefs.java
@@ -74,6 +74,15 @@ public class BraveOriginSubscriptionPrefs {
     @Nullable private static Callback<Boolean> sCredentialsFetchedCallback;
 
     /**
+     * True while a {@link #createFetchOrder} chain is running. The fetch lives entirely in memory,
+     * so this guards {@link #resumeCredentialFetchIfNeeded} from starting a second, concurrent
+     * fetch when both the startup hook and the settings screen detect the same interrupted state.
+     * Reset in {@link #notifyCredentialsFetched}, which every terminal path of the fetch routes
+     * through.
+     */
+    private static boolean sFetchInProgress;
+
+    /**
      * Registers a one-shot callback that will be invoked on the UI thread when
      * fetchOrderCredentials finishes. Any previously registered callback is replaced.
      *
@@ -108,11 +117,40 @@ public class BraveOriginSubscriptionPrefs {
     }
 
     /**
+     * Resumes an interrupted post-purchase credential fetch left over from a prior session.
+     *
+     * <p>The fetch ({@link #createFetchOrder}) runs entirely in memory: if the browser is killed
+     * before {@link #fetchOrderCredentials} writes the order ID, the prefs stay in the "fetching"
+     * state ({@link #isFetchingCredentials} stays true) but no fetch is running. Nothing else
+     * re-triggers it on the next launch - the Play Store {@link #verifyPurchase} restore is skipped
+     * while the subscription pref is already active - so the Origin settings screen would otherwise
+     * show the "Disabling features" spinner forever. Call this on startup to restart the fetch from
+     * the persisted purchase token. Unlike {@link #verifyPurchase} it issues no Play Store billing
+     * query and never clears local state, so a transient billing outage cannot un-enroll the user.
+     *
+     * @param profile The profile to use for the operation.
+     */
+    public static void resumeCredentialFetchIfNeeded(@Nullable Profile profile) {
+        if (profile == null || sFetchInProgress || !isFetchingCredentials(profile)) {
+            return;
+        }
+        // isFetchingCredentials() already guarantees the purchase token is non-empty.
+        String purchaseToken =
+                UserPrefs.get(profile).getString(BravePref.BRAVE_ORIGIN_PURCHASE_TOKEN_ANDROID);
+        createFetchOrder(profile, purchaseToken);
+        // Mirror verifyPurchase(): open the Origin settings screen so the user sees the spinner
+        // while credentials finish fetching and is then prompted to restart, since the enforced
+        // policies only take effect after a restart.
+        BraveOriginSettingsLauncherHelper.showOriginSettingsForRestart();
+    }
+
+    /**
      * Fires the one-shot credentials-fetched callback, if registered.
      *
      * @param success Whether the credential fetch succeeded.
      */
     private static void notifyCredentialsFetched(boolean success) {
+        sFetchInProgress = false;
         Callback<Boolean> callback = sCredentialsFetchedCallback;
         sCredentialsFetchedCallback = null;
         if (callback != null) {
@@ -290,6 +328,7 @@ public class BraveOriginSubscriptionPrefs {
      * @param purchaseToken The purchase token to use for the operation
      */
     private static void createFetchOrder(Profile profile, String purchaseToken) {
+        sFetchInProgress = true;
         PrefService prefService = UserPrefs.get(profile);
         String packageName = prefService.getString(BravePref.BRAVE_ORIGIN_PACKAGE_NAME_ANDROID);
         String productId = prefService.getString(BravePref.BRAVE_ORIGIN_PRODUCT_ID_ANDROID);


### PR DESCRIPTION
After purchasing Origin, the post-purchase credential fetch (createFetchOrder -> Skus createOrderFromReceipt -> fetchOrderCredentials) runs entirely in memory. If the browser is killed before the order ID is written, the subscription prefs stay in the "fetching" state (subscription_active=true, order_id empty, purchase_token set) but nothing re-runs the fetch: the startup verifyPurchase() restore is skipped while the subscription is active, so opening Settings -> Origin shows the "Disabling features" spinner forever.

Add BraveOriginSubscriptionPrefs.resumeCredentialFetchIfNeeded(), which restarts the fetch from the persisted purchase token when isFetchingCredentials is true and no fetch is already running (guarded by sFetchInProgress). Unlike verifyPurchase it issues no Play Store billing query and never clears local state, so a transient billing outage cannot un-enroll the user. It also opens the Origin settings screen so the user sees the spinner and is then prompted to restart, since the enforced policies only take effect after a restart. Wired into the BraveActivity startup hook's active-subscription branch.

Resolves: https://github.com/brave/brave-browser/issues/56201

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
