### PR TITLE
Add metric for opening screen setting switch (uplift to 1.91.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/settings/BackgroundImagesPreferences.java
+++ b/android/java/org/chromium/chrome/browser/settings/BackgroundImagesPreferences.java
@@ -33,6 +33,8 @@ import org.chromium.components.browser_ui.settings.ChromeBasePreference;
 import org.chromium.components.browser_ui.settings.ChromeSwitchPreference;
 import org.chromium.components.browser_ui.settings.SettingsUtils;
 import org.chromium.components.user_prefs.UserPrefs;
+import org.chromium.misc_metrics.mojom.MiscAndroidMetrics;
+import org.chromium.misc_metrics.mojom.OpeningScreenSwitchType;
 
 /** Fragment to keep track of all the display related preferences. */
 @NullMarked
@@ -157,7 +159,10 @@ public class BackgroundImagesPreferences extends BravePreferenceFragment
             } else if (mOpeningScreenPref != null) {
                 int currentValue =
                         ChromeSharedPreferences.getInstance()
-                                .readInt(BravePreferenceKeys.BRAVE_NEW_TAB_PAGE_OPENING_SCREEN, 1);
+                                .readInt(
+                                        BravePreferenceKeys.BRAVE_NEW_TAB_PAGE_OPENING_SCREEN,
+                                        BravePreferenceKeys
+                                                .BRAVE_OPENING_SCREEN_OPTION_NEW_TAB_AFTER_INACTIVITY);
                 mOpeningScreenPref.initialize(currentValue);
                 mOpeningScreenPref.setOnPreferenceChangeListener(this);
             }
@@ -191,9 +196,44 @@ public class BackgroundImagesPreferences extends BravePreferenceFragment
             NtpUtil.setDisplayBraveStats((boolean) newValue);
         } else if (PREF_OPENING_SCREEN.equals(key)) {
             int option = (int) newValue;
+            int previousOption =
+                    ChromeSharedPreferences.getInstance()
+                            .readInt(
+                                    BravePreferenceKeys.BRAVE_NEW_TAB_PAGE_OPENING_SCREEN,
+                                    BravePreferenceKeys
+                                            .BRAVE_OPENING_SCREEN_OPTION_NEW_TAB_AFTER_INACTIVITY);
             ChromeSharedPreferences.getInstance()
                     .writeInt(BravePreferenceKeys.BRAVE_NEW_TAB_PAGE_OPENING_SCREEN, option);
+            recordOpeningScreenSwitch(previousOption, option);
         }
         return true;
+    }
+
+    private void recordOpeningScreenSwitch(int previousOption, int newOption) {
+        try {
+            MiscAndroidMetrics metrics = BraveActivity.getBraveActivity().getMiscAndroidMetrics();
+            if (metrics == null) return;
+
+            boolean previousIsInactivity =
+                    previousOption
+                            == BravePreferenceKeys
+                                    .BRAVE_OPENING_SCREEN_OPTION_NEW_TAB_AFTER_INACTIVITY;
+            boolean newIsInactivity =
+                    newOption
+                            == BravePreferenceKeys
+                                    .BRAVE_OPENING_SCREEN_OPTION_NEW_TAB_AFTER_INACTIVITY;
+
+            int switchType;
+            if (previousIsInactivity && !newIsInactivity) {
+                switchType = OpeningScreenSwitchType.FROM_INACTIVITY;
+            } else if (!previousIsInactivity && newIsInactivity) {
+                switchType = OpeningScreenSwitchType.TO_INACTIVITY;
+            } else {
+                switchType = OpeningScreenSwitchType.OTHER;
+            }
+            metrics.recordOpeningScreenSettingSwitch(switchType);
+        } catch (BraveActivity.BraveActivityNotFoundException e) {
+            Log.e(TAG, "recordOpeningScreenSwitch " + e);
+        }
     }
 }

--- a/browser/misc_metrics/misc_android_metrics.cc
+++ b/browser/misc_metrics/misc_android_metrics.cc
@@ -5,6 +5,7 @@
 
 #include "brave/browser/misc_metrics/misc_android_metrics.h"
 
+#include "base/metrics/histogram_macros.h"
 #include "brave/browser/misc_metrics/process_misc_metrics.h"
 #include "brave/browser/misc_metrics/uptime_monitor_impl.h"
 #include "brave/browser/search_engines/search_engine_tracker.h"
@@ -15,6 +16,13 @@
 #include "brave/components/misc_metrics/quick_search_metrics.h"
 #include "brave/components/misc_metrics/tab_metrics.h"
 #include "url/gurl.h"
+
+namespace {
+
+constexpr char kOpeningScreenSwitchHistogramName[] =
+    "Brave.NTP.OpeningScreenSwitch";
+
+}  // namespace
 
 namespace misc_metrics {
 
@@ -126,6 +134,11 @@ void MiscAndroidMetrics::RecordTopSiteNavigation(bool is_custom) {
     return;
   }
   navigation_source_metrics_->RecordTopSiteNavigation(is_custom);
+}
+
+void MiscAndroidMetrics::RecordOpeningScreenSettingSwitch(
+    mojom::OpeningScreenSwitchType switch_type) {
+  UMA_HISTOGRAM_ENUMERATION(kOpeningScreenSwitchHistogramName, switch_type);
 }
 
 }  // namespace misc_metrics

--- a/browser/misc_metrics/misc_android_metrics.h
+++ b/browser/misc_metrics/misc_android_metrics.h
@@ -56,6 +56,8 @@ class MiscAndroidMetrics : public mojom::MiscAndroidMetrics {
   void RecordOmniboxHistoryNavigation() override;
   void RecordOmniboxBookmarkNavigation() override;
   void RecordTopSiteNavigation(bool is_custom) override;
+  void RecordOpeningScreenSettingSwitch(
+      mojom::OpeningScreenSwitchType switch_type) override;
 
  private:
   raw_ptr<ProcessMiscMetrics> misc_metrics_;

--- a/components/misc_metrics/common/misc_metrics.mojom
+++ b/components/misc_metrics/common/misc_metrics.mojom
@@ -7,6 +7,17 @@ module misc_metrics.mojom;
 
 import "mojo/public/mojom/base/time.mojom";
 
+// The direction of a manual opening screen setting switch, used for
+// Brave.NTP.OpeningScreenSwitch.
+enum OpeningScreenSwitchType {
+  // Switched from "New tab after inactivity" to another setting.
+  kFromInactivity,
+  // Switched from another setting to "New tab after inactivity".
+  kToInactivity,
+  // Switched between two non-inactivity settings.
+  kOther,
+};
+
 // Handler for Android misc metric events from UI.
 interface MiscAndroidMetrics {
   // Records view of Privacy Hub report.
@@ -55,4 +66,7 @@ interface MiscAndroidMetrics {
   // Records a top site tile navigation from the NTP.
   // isCustom is true for pinned/custom-link tiles, false for frequented tiles.
   RecordTopSiteNavigation(bool isCustom);
+
+  // Records a manual switch of the NTP opening screen setting.
+  RecordOpeningScreenSettingSwitch(OpeningScreenSwitchType switchType);
 };

--- a/components/p3a/metric_names.h
+++ b/components/p3a/metric_names.h
@@ -99,6 +99,7 @@ inline constexpr auto kCollectedTypicalHistograms =
     {"Brave.Importer.ImporterSource.2", {}},
     {"Brave.NTP.CustomizeUsageStatus.2", {}},
     {"Brave.NTP.DefaultPage", {}},
+    {"Brave.NTP.OpeningScreenSwitch", MetricConfig{.ephemeral = true}},
     {"Brave.NTP.SponsoredMediaType", {}},
     {"Brave.Omnibox.SearchCount.NonRewards", {}},
     {"Brave.Omnibox.SearchCount.Rewards", {}},


### PR DESCRIPTION
Uplift of #36992
Resolves https://github.com/brave/brave-browser/issues/56099

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.