### PR TITLE
Change `manageProfile` screen grid to use 7 columns

### DIFF
--- a/browser/resources/settings/br/settings_manage_profile.ts
+++ b/browser/resources/settings/br/settings_manage_profile.ts
@@ -3,16 +3,54 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import {RegisterStyleOverride} from 'chrome://resources/brave/polymer_overriding.js'
-import {html} from 'chrome://resources/polymer/v3_0/polymer/polymer_bundled.min.js'
+import {
+  RegisterPolymerTemplateModifications,
+  RegisterStyleOverride,
+} from 'chrome://resources/brave/polymer_overriding.js'
+import { html } from 'chrome://resources/polymer/v3_0/polymer/polymer_bundled.min.js'
+
+// Brave avatar assets are organized in 7-color groups per style under
+// `app/theme/default_100_percent/common/avatars`. Chromium's default 6-column
+// picker splits each group across multiple rows. Force the use of 7 columns to
+// keep variants visually aligned.
+const kManageProfilePickerColumns = '7'
 
 RegisterStyleOverride(
   'settings-manage-profile',
   html`
     <style include="settings-shared">
-      .cr-row.manage-profile-section {
-          padding-top: var(--leo-spacing-xl) !important;
+      .content {
+        --cr-section-indent-width: 20px;
       }
-  </style>
-  `
+
+      .cr-row.manage-profile-section {
+        padding-top: var(--leo-spacing-xl) !important;
+      }
+
+      .grid-container {
+        --icon-grid-gap: 22px !important;
+        --icon-size: 66px !important;
+      }
+    </style>
+  `,
 )
+
+RegisterPolymerTemplateModifications({
+  'settings-manage-profile': (templateContent) => {
+    const themeColorPicker = templateContent.querySelector(
+      'cr-theme-color-picker',
+    )
+    if (!themeColorPicker) {
+      throw new Error('[Settings] Missing Manage Profile theme color picker')
+    }
+    themeColorPicker.setAttribute('columns', kManageProfilePickerColumns)
+
+    const profileAvatarSelector = templateContent.querySelector(
+      'cr-profile-avatar-selector',
+    )
+    if (!profileAvatarSelector) {
+      throw new Error('[Settings] Missing Manage Profile avatar selector')
+    }
+    profileAvatarSelector.setAttribute('columns', kManageProfilePickerColumns)
+  },
+})

--- a/browser/ui/webui/settings/BUILD.gn
+++ b/browser/ui/webui/settings/BUILD.gn
@@ -68,7 +68,10 @@ source_set("browser_tests") {
   if (!is_android) {
     testonly = true
 
-    sources = [ "settings_secure_dns_handler_browsertest.cc" ]
+    sources = [
+      "brave_manage_profile_browsertest.cc",
+      "settings_secure_dns_handler_browsertest.cc",
+    ]
 
     deps = [
       "//chrome/browser/ui/",

--- a/browser/ui/webui/settings/brave_manage_profile_browsertest.cc
+++ b/browser/ui/webui/settings/brave_manage_profile_browsertest.cc
@@ -8,6 +8,7 @@
 #if !BUILDFLAG(IS_CHROMEOS)
 
 #include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/tabs/tab_strip_model.h"
 #include "chrome/common/chrome_isolated_world_ids.h"
 #include "chrome/test/base/in_process_browser_test.h"
 #include "chrome/test/base/ui_test_utils.h"
@@ -105,8 +106,6 @@ content::EvalJsResult WaitForManageProfilePickerLayout(
                          ISOLATED_WORLD_ID_BRAVE_INTERNAL);
 }
 
-}  // namespace
-
 class BraveManageProfileBrowserTest : public InProcessBrowserTest {
  public:
   BraveManageProfileBrowserTest() = default;
@@ -127,5 +126,7 @@ IN_PROC_BROWSER_TEST_F(BraveManageProfileBrowserTest,
 
   ASSERT_EQ("ready", WaitForManageProfilePickerLayout(web_contents));
 }
+
+}  // namespace
 
 #endif  // !BUILDFLAG(IS_CHROMEOS)

--- a/browser/ui/webui/settings/brave_manage_profile_browsertest.cc
+++ b/browser/ui/webui/settings/brave_manage_profile_browsertest.cc
@@ -1,0 +1,131 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "build/build_config.h"
+
+#if !BUILDFLAG(IS_CHROMEOS)
+
+#include "chrome/browser/ui/browser.h"
+#include "chrome/common/chrome_isolated_world_ids.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "chrome/test/base/ui_test_utils.h"
+#include "content/public/browser/web_contents.h"
+#include "content/public/test/browser_test.h"
+#include "content/public/test/browser_test_utils.h"
+#include "url/gurl.h"
+
+namespace {
+
+content::EvalJsResult WaitForManageProfilePickerLayout(
+    content::WebContents* web_contents) {
+  constexpr char kScript[] = R"(
+  new Promise((resolve) => {
+    const expectedColumnCount = 7;
+    const timeoutMs = 10000;
+    const startTime = performance.now();
+    let lastStatus = 'Manage Profile picker layout did not run';
+
+    function deepQuery(root, selector) {
+      const direct = root.querySelector(selector);
+      if (direct) {
+        return direct;
+      }
+      for (const element of root.querySelectorAll('*')) {
+        const found =
+            element.shadowRoot && deepQuery(element.shadowRoot, selector);
+        if (found) {
+          return found;
+        }
+      }
+      return null;
+    }
+
+    function renderedColumnCount(pickerSelector) {
+      const page = deepQuery(document, 'settings-manage-profile');
+      const picker = page?.shadowRoot?.querySelector(pickerSelector);
+      const grid = picker?.shadowRoot?.querySelector('cr-grid');
+      const gridElement = grid?.shadowRoot?.querySelector('#grid');
+      if (!gridElement) {
+        return null;
+      }
+
+      const gridTemplateColumns =
+          getComputedStyle(gridElement).gridTemplateColumns.trim();
+      if (!gridTemplateColumns || gridTemplateColumns === 'none') {
+        return null;
+      }
+
+      return gridTemplateColumns.split(/\s+/).length;
+    }
+
+    function checkPickerLayout(pickerSelector) {
+      const actualColumnCount = renderedColumnCount(pickerSelector);
+      if (actualColumnCount === expectedColumnCount) {
+        return 'ready';
+      }
+      if (actualColumnCount === null) {
+        return `${pickerSelector} grid not ready`;
+      }
+
+      return `${pickerSelector} rendered ${actualColumnCount} columns`;
+    }
+
+    function getLayoutStatus() {
+      for (const pickerSelector of [
+        'cr-theme-color-picker',
+        'cr-profile-avatar-selector',
+      ]) {
+        const status = checkPickerLayout(pickerSelector);
+        if (status !== 'ready') {
+          return status;
+        }
+      }
+
+      return 'ready';
+    }
+
+    function maybeFinish() {
+      lastStatus = getLayoutStatus();
+      if (lastStatus === 'ready' ||
+          performance.now() - startTime >= timeoutMs) {
+        resolve(lastStatus);
+        return;
+      }
+      setTimeout(maybeFinish, 50);
+    }
+
+    maybeFinish();
+  })
+)";
+
+  return content::EvalJs(web_contents, kScript,
+                         content::EXECUTE_SCRIPT_DEFAULT_OPTIONS,
+                         ISOLATED_WORLD_ID_BRAVE_INTERNAL);
+}
+
+}  // namespace
+
+class BraveManageProfileBrowserTest : public InProcessBrowserTest {
+ public:
+  BraveManageProfileBrowserTest() = default;
+  ~BraveManageProfileBrowserTest() override = default;
+};
+
+// Verifies Brave renders Manage Profile theme/avatar pickers in seven columns.
+IN_PROC_BROWSER_TEST_F(BraveManageProfileBrowserTest,
+                       ManageProfilePickerUsesSevenColumns) {
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(
+      browser(), GURL("chrome://settings/manageProfile")));
+
+  content::WebContents* web_contents =
+      browser()->tab_strip_model()->GetActiveWebContents();
+  ASSERT_NE(web_contents, nullptr);
+  ASSERT_TRUE(content::WaitForLoadStop(web_contents));
+  EXPECT_EQ(web_contents->GetURL(), GURL("chrome://settings/manageProfile"));
+
+  ASSERT_EQ("ready", WaitForManageProfilePickerLayout(web_contents));
+}
+
+#endif  // !BUILDFLAG(IS_CHROMEOS)


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/56178.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

**Summary**
Updates the `brave://settings/manageProfile` page so Brave's theme color and avatar pickers render in 7 columns instead of Chromium's 6-column layout. This keeps Brave's avatar variants aligned with the 7-color asset grouping in [app/theme/default_100_percent/common/avatars](https://github.com/brave/brave-core/tree/master/app/theme/default_100_percent/common/avatars).

To fit the wider grid, these changes:
* reduce picker item size from `72px` to `66px`
* reduce picker item gap from `25px` to `22px`
* overrides `--cr-section-indent-width` to `20px` for content indentation on the Manage Profile screen
* update both "Pick a theme color" and "Pick an avatar" from 6 to 7 columns, so the two sections are consistent

**Tests**
Adds a browser test that verifies both Manage Profile pickers render with 7 columns.

```
 npm run test brave_browser_tests Debug -- --gtest_filter=BraveManageProfileBrowserTest.ManageProfilePickerUsesSevenColumns --test-launcher-jobs=1
```


Before (recorded on Nightly `1.93.38`):

https://github.com/user-attachments/assets/26295bbb-f039-4b78-9a05-33b143a25097


After:

https://github.com/user-attachments/assets/c6af297d-427d-428f-ac62-560f685bbe13




