### PR TITLE
[toolchain] `EphemeralXcode` for all Xcode install code

### DIFF
--- a/tools/cr/toolchains/build_xcode_toolchain.py
+++ b/tools/cr/toolchains/build_xcode_toolchain.py
@@ -117,9 +117,12 @@ import shutil
 import subprocess
 import sys
 import tarfile
+import tempfile
 import time
 import urllib.error
 import urllib.request
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
@@ -496,9 +499,8 @@ class XcodeRelease:
     xip_filename: str
 
     # Expected SHA-1 of the `.xip`, from the xcodereleases `checksums.sha1`
-    # field, used to verify the download. `None` if the catalog entry lists no
-    # checksum, which `_resolve_xcode_release` rejects as unverifiable.
-    sha1: str | None
+    # field, used to verify the download.
+    sha1: str
 
 
 def toolchain_archive_name(sdk_info: MacSdkInfo) -> str:
@@ -541,20 +543,351 @@ def fetch_published_index(sdk_info: MacSdkInfo) -> dict:
         ) from e
 
 
+class EphemeralXcode:
+    """Deploys and selects the Xcode that ships a target macOS SDK.
+
+    This class takes care of resolving the exact Xcode release that bundles the
+    requested SDK. Installs are done under `/Applications/xcode_<build>.app`,
+    with the build number being used as a key. If an exising install is already
+    found in place, we just select the pre-existing install.
+    """
+
+    def __init__(self):
+        """Initialize an unresolved manager; call `deploy()` to populate it."""
+        # Path to the active local Xcode.app, populated by `_locate_app()`
+        # from `xcode-select -p`.
+        self._app: Path | None = None
+
+        # The Xcode release resolved from `xcodereleases.com` for the requested
+        # macOS SDK build, populated by `_resolve_release()` and deployed by
+        # `_install()`.
+        self._release: XcodeRelease | None = None
+
+    @property
+    def app(self) -> Path:
+        """The active `Xcode.app` resolved by the last `deploy()`."""
+        if self._app is None:
+            raise RuntimeError('deploy() must run before accessing app')
+        return self._app
+
+    @property
+    def release(self) -> XcodeRelease:
+        """The Xcode release resolved by the last `deploy()`."""
+        if self._release is None:
+            raise RuntimeError('deploy() must run before accessing release')
+        return self._release
+
+    @contextmanager
+    def deploy(self, mac_sdk_info: MacSdkInfo) -> Iterator[EphemeralXcode]:
+        """Resolve, install, and select the Xcode for an SDK pin, then reset.
+
+        A context manager. Resolves the released Xcode that ships
+        `mac_sdk_info`, deploys it, selects it as the active Xcode and verifies
+        the active Xcode/SDK versions match, then yields with `release` and
+        `app` populated and the resolved Xcode active (so `xcodebuild`/`xcrun`
+        resolve against it). At the end, the context always reverts back to
+        `sudo xcode-select --reset`.
+
+        Args:
+            mac_sdk_info: The macOS SDK version/build the deployed Xcode must
+                ship (typically Chromium's `mac_sdk.gni` pin).
+
+        Yields:
+            This `EphemeralXcode`, with `app`/`release` populated.
+        """
+        self._resolve_release(mac_sdk_info)
+        app_path = self._install()
+        with self._select(app_path):
+            self._locate_app()
+            self._verify_versions(mac_sdk_info)
+            yield self
+
+    def _resolve_release(self, mac_sdk_info: MacSdkInfo) -> None:
+        """Map a macOS SDK build to a released Xcode `.xip`.
+
+        Queries `xcodereleases.com` and looks for the *released*  Xcode entries
+        whose bundled macOS SDK build matches `mac_sdk_info`'s build. Results
+        are also filtered down to the released Universal archive, which is what
+        we use in our infra. Stores the result on `self._release`.
+        """
+        target_build = mac_sdk_info.product_build_version
+        data = _fetch_xcode_releases()
+
+        candidates: list[XcodeRelease] = []
+        for entry in data:
+            # The catalog lists other products (Swift Playgrounds, Command Line
+            # Tools, ...) alongside Xcode; we only care about Xcode entries.
+            if entry.get('name') != 'Xcode':
+                continue
+            version = entry['version']
+            # Only final releases: the `release` object carries a truthy
+            # `release` key. Betas (`{'beta': N}`), release candidates
+            # (`{'rc': N}`), GM seeds, etc. all lack it and are skipped.
+            if not (version.get('release') or {}).get('release'):
+                continue
+            macos_sdks = entry['sdks']['macOS']
+            if not any(sdk.get('build') == target_build for sdk in macos_sdks):
+                continue
+            url = ((entry.get('links') or {}).get('download') or {}).get('url')
+            if not url:
+                continue
+            candidates.append(
+                XcodeRelease(version=version.get('number'),
+                             build=version.get('build'),
+                             download_url=url,
+                             xip_filename=url.rsplit('/', 1)[-1],
+                             sha1=entry['checksums']['sha1']))
+
+        # Brave mirrors the Universal package. That's the default. Only if no
+        # Universal archive is listed do we consider the remaining
+        # (e.g. arm64-only) candidates.
+        universal = [c for c in candidates if 'Universal' in c.xip_filename]
+        chosen = universal or candidates
+        if not chosen:
+            raise RuntimeError(
+                f'No released Xcode on {XCODE_RELEASES_API_URL} bundles macOS '
+                f'SDK build {target_build}')
+        if len(chosen) > 1:
+            names = ', '.join(c.xip_filename for c in chosen)
+            raise RuntimeError(
+                'Ambiguous Xcode release: multiple released archives bundle '
+                f'macOS SDK build {target_build}: {names}')
+        self._release = chosen[0]
+        logging.info('Resolved Xcode %s (build %s) -> %s (sha1 %s)',
+                     self._release.version, self._release.build,
+                     self._release.xip_filename, self._release.sha1)
+
+    def _install(self) -> Path:
+        """Ensure the resolved Xcode is expanded on disk, installing if needed.
+
+        Reuses an Xcode previously expanded on this node, keyed by build number,
+        under `XCODE_APPS_DIR` as `xcode_<build>.app`. If it is not already
+        present, the `.xip` is downloaded and expanded into place. Returns the
+        path to the expanded `Xcode.app`.
+        """
+        assert self._release is not None
+        app_name = f'xcode_{self._release.build.lower()}.app'
+        app_path = XCODE_APPS_DIR / app_name
+        if app_path.exists():
+            logging.info('Reusing Xcode already expanded at %s', app_path)
+        else:
+            self._download_and_expand(app_path)
+        return app_path
+
+    def _download_and_expand(self, app_path: Path) -> None:
+        """Download the resolved `.xip` and expand it to *app_path*.
+
+        Fetches the archive into an auto-cleaned temp dir, verifies it against
+        its expected SHA-1 provided by `xcodereleases.com`, then expands the
+        `xip` archive, and finally the resulting `Xcode.app` is moved into
+        `app_path`. The expansion happens on the same volume as `app_path` so
+        the final move is an instantaneous rename rather than a multi-gigabyte
+        copy.
+        """
+        assert self._release is not None
+
+        # Expand into a sibling of the destination (same volume) so the final
+        # `Xcode.app` -> `xcode_<build>.app` move is a rename, not a copy.
+        expand_dir = app_path.with_name(f'.{app_path.stem}.expand')
+        if expand_dir.exists():
+            shutil.rmtree(expand_dir)
+        expand_dir.mkdir(parents=True)
+        try:
+            # The multi-gigabyte `.xip` is only read during expansion, so it
+            # lives in a temp dir that cleans itself up rather than lingering in
+            # any output tree.
+            with tempfile.TemporaryDirectory(prefix='xcode-xip-') as tmp_dir:
+                xip_path = Path(tmp_dir) / self._release.xip_filename
+                self._download_xip(xip_path)
+                # `unxip` and `xip --expand` both write `Xcode.app` into the
+                # current directory and take no output-path flag, hence the
+                # dedicated `cwd`. `unxip` is dramatically faster, but is not
+                # installed by default, so prefer it when present and fall back
+                # to Apple's `xip` otherwise.
+                if shutil.which('unxip'):
+                    _check_call('unxip', str(xip_path), cwd=expand_dir)
+                else:
+                    logging.warning(
+                        '`unxip` not found on PATH; falling back to the slower '
+                        '`xip --expand`. Installing `unxip` (`brew install '
+                        'unxip`) is strongly preferred for much faster Xcode '
+                        'expansion.')
+                    _check_call('xip',
+                                '--expand',
+                                str(xip_path),
+                                cwd=expand_dir)
+            expanded_app = expand_dir / 'Xcode.app'
+            if not expanded_app.exists():
+                raise RuntimeError(
+                    f'xip did not produce Xcode.app under {expand_dir}')
+            logging.info('Installing expanded Xcode to %s', app_path)
+            shutil.move(expanded_app, app_path)
+        finally:
+            shutil.rmtree(expand_dir, ignore_errors=True)
+
+    def _download_xip(self, dest: Path) -> None:
+        """Download the resolved, SHA-1-verified `.xip` into *dest*.
+
+        Tries the published filename first, then a variant with the `_Universal`
+        segment stripped (DevOps sometimes strips that portion from the name).
+        Each download is checked against the `checksums.sha1` value
+        xcodereleases.com reports for the release. An unverifiable archive is
+        never left on disk.
+        """
+        assert self._release is not None
+        expected_sha1 = self._release.sha1
+        filename = self._release.xip_filename
+        urls = [XCODE_ARCHIVE_BUCKET_URL + filename]
+        stripped = filename.replace('_Universal', '')
+        if stripped != filename:
+            urls.append(XCODE_ARCHIVE_BUCKET_URL + stripped)
+
+        last_error: Exception | None = None
+        for url in urls:
+            try:
+                logging.info('Downloading Xcode archive %s', url)
+                _download_to_file(url, dest)
+            except urllib.error.URLError as e:
+                logging.warning('Download failed for %s: %s', url, e)
+                last_error = e
+                continue
+            logging.info('Verifying SHA-1 of %s', dest)
+            actual_sha1 = _sha1_of_file(dest)
+            if actual_sha1 != expected_sha1:
+                logging.warning('SHA-1 mismatch for %s: expected %s, got %s',
+                                url, expected_sha1, actual_sha1)
+                dest.unlink(missing_ok=True)
+                last_error = RuntimeError(
+                    f'SHA-1 mismatch for {url}: expected {expected_sha1}, '
+                    f'got {actual_sha1}')
+                continue
+            logging.info('Verified SHA-1 %s of %s', actual_sha1, dest)
+            return
+        raise RuntimeError(
+            f'Could not download a verified Xcode archive. Tried {urls}'
+        ) from last_error
+
+    @contextmanager
+    def _select(self, app_path: Path) -> Iterator[None]:
+        """Make *app_path* the active Xcode for the duration of the context.
+
+        Switches the developer dir with `sudo xcode-select -s`, and runs
+        `xcodebuild -runFirstLaunch` so the freshly expanded Xcode finishes its
+        one-time setup. On exit always reverts back to the default installation
+        with `sudo xcode-select --reset`, so the machine is never left pointing
+        at this ephemeral Xcode.
+        """
+        _check_call('sudo', '/usr/bin/xcode-select', '-s', str(app_path))
+        _check_call('sudo', '/usr/bin/xcodebuild', '-license', 'accept')
+        _check_call('sudo', '/usr/bin/xcodebuild', '-runFirstLaunch')
+
+        # This is to avoid issues caused by mixed usage of different Xcode
+        # versions on one machine.
+        _check_call('xcrun', 'simctl', 'list')
+        try:
+            yield
+        finally:
+            _check_call('sudo', '/usr/bin/xcode-select', '--reset')
+
+    def _locate_app(self) -> None:
+        """Resolve the local Xcode.app from the system developer dir.
+
+        `xcode-select -p` prints the active developer directory, typically
+        `/Applications/Xcode.app/Contents/Developer`. Walk two parents up
+        to recover the .app bundle itself, then sanity-check the `.app`
+        suffix so a misconfigured xcode-select (pointing at e.g.
+        CommandLineTools) fails loud and early rather than producing a
+        useless archive.
+        """
+        developer_dir = _check_call('xcode-select', '-p',
+                                    capture_stdout=True).strip()
+        app = Path(developer_dir).parent.parent
+        if app.suffix != '.app':
+            raise RuntimeError(
+                f'xcode-select -p returned {developer_dir!r}; expected a '
+                f'path inside an Xcode.app bundle (derived app={app}).')
+        self._app = app
+        logging.info('Detected Xcode at %s', self._app)
+
+    def _verify_versions(self, mac_sdk_info: MacSdkInfo) -> None:
+        """Probe `xcodebuild` and confirm the active Xcode and SDK match.
+
+        Runs `xcodebuild -version -sdk macosx`, whose output carries both the
+        Xcode-level lines (`Xcode <ver>` / `Build version <build>`) and the SDK-
+        level lines (`SDKVersion:` / `ProductBuildVersion:`). All four values
+        are load-bearing: the Xcode build is checked against the resolved
+        release and the SDK pair against `mac_sdk_info`, so a wrong active
+        Xcode/SDK fails the build. Missing any one of them is a hard failure
+        rather than a silent fallback.
+        """
+        output = _check_call('xcodebuild',
+                             '-version',
+                             '-sdk',
+                             'macosx',
+                             capture_stdout=True)
+        sdk_version = re.search(r'^SDKVersion: (.+)$', output, re.MULTILINE)
+        sdk_build = re.search(r'^ProductBuildVersion: (.+)$', output,
+                              re.MULTILINE)
+
+        output = _check_call('xcodebuild', '-version', capture_stdout=True)
+        xcode_version = re.search(r'^Xcode (.+)$', output, re.MULTILINE)
+        xcode_build = re.search(r'^Build version (.+)$', output, re.MULTILINE)
+
+        if not (xcode_version and xcode_build and sdk_version and sdk_build):
+            raise RuntimeError(
+                'xcodebuild did not report all of Xcode / Build version / '
+                f'SDKVersion / ProductBuildVersion; raw output:\n{output}')
+        local_xcode_info = XcodeInfo(version=xcode_version.group(1).strip(),
+                                     build=xcode_build.group(1).strip())
+        local_mac_sdk_info = MacSdkInfo(
+            sdk_version=sdk_version.group(1).strip(),
+            product_build_version=sdk_build.group(1).strip())
+
+        # `deploy()` resolves the release before probing, so it must be set.
+        assert self._release is not None
+
+        # `_select()` should have made the Xcode we resolved active. If the
+        # selected Xcode build doesn't match the one we are expected to be
+        # using to build the SDK, we must fail the run.
+        if local_xcode_info.build != self._release.build:
+            raise RuntimeError(
+                f'Active Xcode build {local_xcode_info.build} does not '
+                f'match the resolved build {self._release.build}; '
+                'xcode-select may be pointing at the wrong Xcode.')
+
+        # The deployed Xcode must ship the exact macOS SDK Chromium, otherwise
+        # the build would be using an incorrect SDK.
+        if local_mac_sdk_info != mac_sdk_info:
+            raise RuntimeError(
+                'Active macOS SDK '
+                f'{local_mac_sdk_info.sdk_version} '
+                f'(build {local_mac_sdk_info.product_build_version}) '
+                'does not match the upstream-pinned '
+                f'{mac_sdk_info.sdk_version} '
+                f'(build {mac_sdk_info.product_build_version}).')
+
+        logging.info('Local Xcode: %s (build %s)', local_xcode_info.version,
+                     local_xcode_info.build)
+        logging.info('Local macOS SDK: %s (build %s)',
+                     local_mac_sdk_info.sdk_version,
+                     local_mac_sdk_info.product_build_version)
+
+
 class ToolchainBuilder:
     """A builder for the XCode hermetic toolchain archive.
 
     This builder does a few things:
 
     1. **Versioning** The builder reads the macOS SDK build Chromium pins for
-       the given tag, resolves it to a released Xcode via `xcodereleases.com`
-       (`_resolve_xcode_release`), deploys and selects that Xcode
-       (`_install_xcode`, reusing or downloading + expanding its `.xip`), then
+       the given tag, then hands that SDK pin to `EphemeralXcode.deploy`, which
+       resolves it to a released Xcode via `xcodereleases.com`, deploys and
+       selects that Xcode (reusing or downloading + expanding its `.xip`), and
        reads back the active Xcode/SDK versions to confirm they match. The
        output archive is named solely after the upstream SDK pair, which alone
        identifies it because the deployed Xcode always ships that exact SDK.
     2. **Stage** (`_stage_xcode` + `_add_metal_toolchain`): Clones the
-       detected Xcode.app into `self._staged_xcode` using BSD `cp -ac`
+       deployed Xcode.app (`self._xcode.app`) into `self._staged_xcode` using
+       BSD `cp -ac`
        (APFS clonefile), then downloads the on-demand Metal toolchain
        via `xcodebuild -downloadComponent metalToolchain` and rsyncs its
        artifacts into the staged `XcodeDefault.xctoolchain`.
@@ -589,9 +922,10 @@ class ToolchainBuilder:
         # Absolute path of the directory the output archive is written into.
         self._out_dir: Path = out_dir.expanduser().resolve()
 
-        # Path to the local Xcode.app, populated by `_locate_xcode_app()`
-        # from `xcode-select -p`.
-        self._xcode_app: Path | None = None
+        # Resolves, deploys, and selects the Xcode that ships the upstream SDK,
+        # exposing the deployed `Xcode.app` and the resolved release. Driven by
+        # `run()` via `EphemeralXcode.deploy()`.
+        self._xcode: EphemeralXcode = EphemeralXcode()
 
         # Transient working tree where Xcode is cloned and augmented with
         # the Metal toolchain before `_build_archive` packs it. Created
@@ -603,11 +937,6 @@ class ToolchainBuilder:
         # sole identifier encoded in the archive name, which lets brockit check
         # for the toolchain's existence from the SDK bump alone.
         self._upstream_mac_sdk_info: MacSdkInfo | None = None
-
-        # The Xcode release resolved from `xcodereleases.com` for the upstream
-        # macOS SDK build, populated by `_resolve_xcode_release()` and deployed
-        # by `_install_xcode()`.
-        self._xcode_release: XcodeRelease | None = None
 
         # Metal toolchain build number (e.g. `17E188`), populated by
         # `_add_metal_toolchain()` and recorded in the index. `None` if it
@@ -646,26 +975,6 @@ class ToolchainBuilder:
         stem = archive.name.removesuffix('.tar.gz')
         return archive.with_name(f'{stem}.yaml')
 
-    def _locate_xcode_app(self) -> None:
-        """Resolve the local Xcode.app from the system developer dir.
-
-        `xcode-select -p` prints the active developer directory, typically
-        `/Applications/Xcode.app/Contents/Developer`. Walk two parents up
-        to recover the .app bundle itself, then sanity-check the `.app`
-        suffix so a misconfigured xcode-select (pointing at e.g.
-        CommandLineTools) fails loud and early rather than producing a
-        useless archive.
-        """
-        developer_dir = _check_call('xcode-select', '-p',
-                                    capture_stdout=True).strip()
-        app = Path(developer_dir).parent.parent
-        if app.suffix != '.app':
-            raise RuntimeError(
-                f'xcode-select -p returned {developer_dir!r}; expected a '
-                f'path inside an Xcode.app bundle (derived app={app}).')
-        self._xcode_app = app
-        logging.info('Detected Xcode at %s', self._xcode_app)
-
     def _stage_xcode(self) -> None:
         """Clone the detected Xcode.app into `self._staged_xcode`.
 
@@ -677,12 +986,11 @@ class ToolchainBuilder:
         matching the layout `_pack` and Chromium's `xcode_binaries.yaml`
         expect.
         """
-        assert self._xcode_app is not None
         if self._staged_xcode.exists():
             logging.info('Removing existing stage at %s', self._staged_xcode)
             shutil.rmtree(self._staged_xcode)
         self._staged_xcode.mkdir(parents=True)
-        _check_call('cp', '-ac', f'{self._xcode_app}/',
+        _check_call('cp', '-ac', f'{self._xcode.app}/',
                     str(self._staged_xcode))
 
     def _add_metal_toolchain(self) -> None:
@@ -725,72 +1033,6 @@ class ToolchainBuilder:
                     f'{metal_dir}/usr/bin/metal',
                     f'{metal_dir}/usr/bin/metallib', f'{dest}/bin/')
 
-    def _load_local_versions(self) -> None:
-        """Probe `xcodebuild` for the active Xcode and macOS SDK versions.
-
-        Runs `xcodebuild -version -sdk macosx`, whose output carries both the
-        Xcode-level lines (`Xcode <ver>` / `Build version <build>`) and the SDK-
-        level lines (`SDKVersion:` / `ProductBuildVersion:`). All four values
-        are load-bearing: the Xcode build is checked against the resolved
-        release and the SDK pair against `self._upstream_mac_sdk_info`, so a
-        wrong active Xcode/SDK fails the build. Missing any one of them is a
-        hard failure rather than a silent fallback.
-        """
-        output = _check_call('xcodebuild',
-                             '-version',
-                             '-sdk',
-                             'macosx',
-                             capture_stdout=True)
-        sdk_version = re.search(r'^SDKVersion: (.+)$', output, re.MULTILINE)
-        sdk_build = re.search(r'^ProductBuildVersion: (.+)$', output,
-                              re.MULTILINE)
-
-        output = _check_call('xcodebuild', '-version', capture_stdout=True)
-        xcode_version = re.search(r'^Xcode (.+)$', output, re.MULTILINE)
-        xcode_build = re.search(r'^Build version (.+)$', output, re.MULTILINE)
-
-        if not (xcode_version and xcode_build and sdk_version and sdk_build):
-            raise RuntimeError(
-                'xcodebuild did not report all of Xcode / Build version / '
-                f'SDKVersion / ProductBuildVersion; raw output:\n{output}')
-        local_xcode_info = XcodeInfo(version=xcode_version.group(1).strip(),
-                                     build=xcode_build.group(1).strip())
-        local_mac_sdk_info = MacSdkInfo(
-            sdk_version=sdk_version.group(1).strip(),
-            product_build_version=sdk_build.group(1).strip())
-
-        # Invariants by this point: `run()` resolves the upstream SDK and the
-        # Xcode release before deploying/probing, so both must be populated.
-        assert self._xcode_release is not None
-        assert self._upstream_mac_sdk_info is not None
-
-        # `_install_xcode()` should have selected the Xcode we resolved. If the
-        # selected Xcode build doesn't match the one we are expected to be
-        # using to build the SDK, we must fail the run.
-        if local_xcode_info.build != self._xcode_release.build:
-            raise RuntimeError(
-                f'Active Xcode build {local_xcode_info.build} does not '
-                f'match the resolved build {self._xcode_release.build}; '
-                'xcode-select may be pointing at the wrong Xcode.')
-
-        # The deployed Xcode must ship the exact macOS SDK Chromium, otherwise
-        # the build would be using an incorrect SDK.
-        if local_mac_sdk_info != self._upstream_mac_sdk_info:
-            raise RuntimeError(
-                'Active macOS SDK '
-                f'{local_mac_sdk_info.sdk_version} '
-                f'(build {local_mac_sdk_info.product_build_version}) '
-                'does not match the upstream-pinned '
-                f'{self._upstream_mac_sdk_info.sdk_version} '
-                f'(build {self._upstream_mac_sdk_info.product_build_version}).'
-            )
-
-        logging.info('Local Xcode: %s (build %s)', local_xcode_info.version,
-                     local_xcode_info.build)
-        logging.info('Local macOS SDK: %s (build %s)',
-                     local_mac_sdk_info.sdk_version,
-                     local_mac_sdk_info.product_build_version)
-
     def _load_upstream_mac_sdk_info(self) -> None:
         """Fetch the macOS SDK used in the Chromium tag provided.
 
@@ -804,187 +1046,6 @@ class ToolchainBuilder:
         logging.info('Upstream macOS SDK version: %s (build %s)',
                      self._upstream_mac_sdk_info.sdk_version,
                      self._upstream_mac_sdk_info.product_build_version)
-
-    def _resolve_xcode_release(self) -> None:
-        """Map the upstream macOS SDK build to a released Xcode `.xip`.
-
-        Queries `xcodereleases.com` and looks for the *released* (not beta, not
-        RC) Xcode whose bundled macOS SDK build matches the upstream SDK build.
-        A single SDK build is shared by several catalog entries (the Universal
-        package, the Apple-silicon-only package, and the matching release
-        candidates), so the result is filtered down to the released Universal
-        archive, which is what we use in our infra. Stores the result on
-        `self._xcode_release`.
-        """
-        assert self._upstream_mac_sdk_info is not None
-        target_build = self._upstream_mac_sdk_info.product_build_version
-        data = _fetch_xcode_releases()
-
-        candidates: list[XcodeRelease] = []
-        for entry in data:
-            version = entry.get('version') or {}
-            # Only final releases: the `release` object carries a truthy
-            # `release` key. Betas (`{'beta': N}`), release candidates
-            # (`{'rc': N}`), GM seeds, etc. all lack it and are skipped.
-            if not (version.get('release') or {}).get('release'):
-                continue
-            macos_sdks = (entry.get('sdks') or {}).get('macOS') or []
-            if not any(sdk.get('build') == target_build for sdk in macos_sdks):
-                continue
-            url = ((entry.get('links') or {}).get('download') or {}).get('url')
-            if not url:
-                continue
-            candidates.append(
-                XcodeRelease(version=version.get('number'),
-                             build=version.get('build'),
-                             download_url=url,
-                             xip_filename=url.rsplit('/', 1)[-1],
-                             sha1=(entry.get('checksums') or {}).get('sha1')))
-
-        # Brave mirrors the Universal package. That's the default. Only if no
-        # Universal archive is listed do we consider the remaining
-        # (e.g. arm64-only) candidates.
-        universal = [c for c in candidates if 'Universal' in c.xip_filename]
-        chosen = universal or candidates
-        if not chosen:
-            raise RuntimeError(
-                f'No released Xcode on {XCODE_RELEASES_API_URL} bundles macOS '
-                f'SDK build {target_build}')
-        if len(chosen) > 1:
-            names = ', '.join(c.xip_filename for c in chosen)
-            raise RuntimeError(
-                'Ambiguous Xcode release: multiple released archives bundle '
-                f'macOS SDK build {target_build}: {names}')
-        self._xcode_release = chosen[0]
-        if not self._xcode_release.sha1:
-            raise RuntimeError(
-                f'{XCODE_RELEASES_API_URL} lists no SHA-1 checksum for '
-                f'{self._xcode_release.xip_filename}; refusing to install an '
-                'unverifiable Xcode archive.')
-        logging.info('Resolved Xcode %s (build %s) -> %s (sha1 %s)',
-                     self._xcode_release.version, self._xcode_release.build,
-                     self._xcode_release.xip_filename,
-                     self._xcode_release.sha1)
-
-    def _install_xcode(self) -> None:
-        """Deploy and select the resolved Xcode, installing if needed.
-
-        Reuses an Xcode previously expanded on this node, keyed by build number,
-        under `XCODE_APPS_DIR` as `xcode_<build>.app`. If it is not already
-        present, the `.xip` is downloadedand expanded into place. Either way the
-        chosen Xcode is then made active via `xcode-select`.
-        """
-        assert self._xcode_release is not None
-        app_name = f'xcode_{self._xcode_release.build.lower()}.app'
-        app_path = XCODE_APPS_DIR / app_name
-        if app_path.exists():
-            logging.info('Reusing Xcode already expanded at %s', app_path)
-        else:
-            self._download_and_expand_xcode(app_path)
-        self._select_xcode(app_path)
-
-    def _download_and_expand_xcode(self, app_path: Path) -> None:
-        """Download the resolved `.xip` and expand it to *app_path*.
-
-        Fetches the archive into `--out-dir`, verifies it against its expected
-        SHA-1 provided by `xcodereleases.com`, then expands the `xip` archive,
-        and finally the resulting `Xcode.app` is moved into `app_path`. The
-        expansion happens on the same volume as `app_path` so the final move is
-        an instantaneous rename rather than a multi-gigabyte copy.
-        """
-        assert self._xcode_release is not None
-        self._out_dir.mkdir(parents=True, exist_ok=True)
-        xip_path = self._out_dir / self._xcode_release.xip_filename
-        self._download_xip(xip_path)
-
-        # Expand into a sibling of the destination (same volume) so the final
-        # `Xcode.app` -> `xcode_<build>.app` move is a rename, not a copy.
-        expand_dir = app_path.with_name(f'.{app_path.stem}.expand')
-        if expand_dir.exists():
-            shutil.rmtree(expand_dir)
-        expand_dir.mkdir(parents=True)
-        try:
-            # `unxip` and `xip --expand` both write `Xcode.app` into the current
-            # directory and take no output-path flag, hence the dedicated `cwd`.
-            # `unxip` is dramatically faster, but is not installed by default,
-            # so prefer it when present and fall back to Apple's `xip`
-            # otherwise.
-            if shutil.which('unxip'):
-                _check_call('unxip', str(xip_path), cwd=expand_dir)
-            else:
-                logging.warning(
-                    '`unxip` not found on PATH; falling back to the slower '
-                    '`xip --expand`. Installing `unxip` (`brew install unxip`) '
-                    'is strongly preferred for much faster Xcode expansion.')
-                _check_call('xip', '--expand', str(xip_path), cwd=expand_dir)
-            expanded_app = expand_dir / 'Xcode.app'
-            if not expanded_app.exists():
-                raise RuntimeError(
-                    f'xip did not produce Xcode.app under {expand_dir}')
-            logging.info('Installing expanded Xcode to %s', app_path)
-            shutil.move(expanded_app, app_path)
-        finally:
-            shutil.rmtree(expand_dir, ignore_errors=True)
-            xip_path.unlink(missing_ok=True)
-
-    def _download_xip(self, dest: Path) -> None:
-        """Download the resolved, SHA-1-verified `.xip` into *dest*.
-
-        Tries the published filename first, then a variant with the `_Universal`
-        segment stripped (DevOps sometimes strips that portion from the name).
-        Each download is checked against the `checksums.sha1` value
-        xcodereleases.com reports for the release. An unverifiable archive is
-        never left on disk.
-        """
-        assert self._xcode_release is not None
-        # `expected_sha1` is guaranteed non-None by `_resolve_xcode_release`.
-        expected_sha1 = self._xcode_release.sha1
-        assert expected_sha1 is not None
-        filename = self._xcode_release.xip_filename
-        urls = [XCODE_ARCHIVE_BUCKET_URL + filename]
-        stripped = filename.replace('_Universal', '')
-        if stripped != filename:
-            urls.append(XCODE_ARCHIVE_BUCKET_URL + stripped)
-
-        last_error: Exception | None = None
-        for url in urls:
-            try:
-                logging.info('Downloading Xcode archive %s', url)
-                _download_to_file(url, dest)
-            except urllib.error.URLError as e:
-                logging.warning('Download failed for %s: %s', url, e)
-                last_error = e
-                continue
-            logging.info('Verifying SHA-1 of %s', dest)
-            actual_sha1 = _sha1_of_file(dest)
-            if actual_sha1 != expected_sha1:
-                logging.warning('SHA-1 mismatch for %s: expected %s, got %s',
-                                url, expected_sha1, actual_sha1)
-                dest.unlink(missing_ok=True)
-                last_error = RuntimeError(
-                    f'SHA-1 mismatch for {url}: expected {expected_sha1}, '
-                    f'got {actual_sha1}')
-                continue
-            logging.info('Verified SHA-1 %s of %s', actual_sha1, dest)
-            return
-        raise RuntimeError(
-            f'Could not download a verified Xcode archive. Tried {urls}'
-        ) from last_error
-
-    def _select_xcode(self, app_path: Path) -> None:
-        """Make *app_path* the active Xcode via `xcode-select`.
-
-        Switches the developer dir with `sudo xcode-select -s`, and runs
-        `xcodebuild -runFirstLaunch` so the freshly expanded Xcode finishes its
-        one-time setup.
-        """
-        _check_call('sudo', '/usr/bin/xcode-select', '-s', str(app_path))
-        _check_call('sudo', '/usr/bin/xcodebuild', '-license', 'accept')
-        _check_call('sudo', '/usr/bin/xcodebuild', '-runFirstLaunch')
-
-        # This is to avoid issues caused by mixed usage of different Xcode
-        # versions on one machine.
-        _check_call('xcrun', 'simctl', 'list')
 
     def _fetch_pkg_def(self) -> str:
         """Fetch `xcode_binaries.yaml` from gitiles."""
@@ -1123,17 +1184,17 @@ class ToolchainBuilder:
 
         After writing, the index file is read back and printed in the console.
         """
-        assert self._xcode_release is not None
+        xcode_release = self._xcode.release
         archive_path = self._archive_path
         index_path = self._index_path
 
         index = {
             'url': PACKAGE_DOWNLOAD_URL_BASE + archive_path.name,
             'sha256sum': _sha256_of_file(archive_path),
-            'xcode_xip_source_url': self._xcode_release.download_url,
-            'xcode_xip_sha1sum': self._xcode_release.sha1,
-            'xcode_version': self._xcode_release.version,
-            'xcode_build': self._xcode_release.build,
+            'xcode_xip_source_url': xcode_release.download_url,
+            'xcode_xip_sha1sum': xcode_release.sha1,
+            'xcode_version': xcode_release.version,
+            'xcode_build': xcode_release.build,
             'metal_build': self._metal_build,
             'chromium_tag': self._chromium_tag,
         }
@@ -1171,9 +1232,9 @@ class ToolchainBuilder:
                 present under `self._staged_xcode`.
             RuntimeError: If Chromium's `mac_sdk.gni` is missing either of the
                 expected assignments, if no released Universal Xcode bundles
-                the upstream SDK build (or more than one does), if the resolved
-                release lists no SHA-1 checksum, if no Xcode `.xip` can be
-                downloaded and SHA-1-verified, if `xip` does not expand an
+                the upstream SDK build (or more than one does), if no Xcode
+                `.xip` can be downloaded and SHA-1-verified, if `xip` does not
+                expand an
                 `Xcode.app`, if the selected Xcode build does not match the
                 resolved one, if `xcode-select` does not point at an
                 Xcode.app, if `xcodebuild` does not report all of Xcode /
@@ -1194,15 +1255,15 @@ class ToolchainBuilder:
         self._load_upstream_mac_sdk_info()
         if not force_overwrite:
             self._precheck_publishable()
-        self._resolve_xcode_release()
-        self._install_xcode()
-        self._locate_xcode_app()
-        self._load_local_versions()
-        self._stage_xcode()
-        self._add_metal_toolchain()
-        self._read_entries()
-        output = self._archive_path
-        self._build_archive()
+        assert self._upstream_mac_sdk_info is not None
+        # The deployed Xcode is the active one only inside this block; on exit
+        # `deploy()` always reverts the selection with `xcode-select --reset`.
+        with self._xcode.deploy(self._upstream_mac_sdk_info):
+            self._stage_xcode()
+            self._add_metal_toolchain()
+            self._read_entries()
+            output = self._archive_path
+            self._build_archive()
         logging.info('Wrote %s (%d bytes)', output, output.stat().st_size)
         logging.info('Removing staged Xcode at %s', self._staged_xcode)
         shutil.rmtree(self._staged_xcode)


### PR DESCRIPTION
This PR separates the Xcode management code from the `ToolchainBuilder`
code, in order to make it a bit more reusable.

Bug: https://github.com/brave/brave-browser/issues/55812
