### PR TITLE
[toolchain] Build Rust/WASM with `LZMA_API_STATIC`

### DIFF
--- a/tools/cr/toolchains/build_rust_toolchain.py
+++ b/tools/cr/toolchains/build_rust_toolchain.py
@@ -1100,6 +1100,16 @@ class ToolchainBuilder:
                     'build_rust.py on Windows. Please install Git for Windows '
                     'and ensure its bin/ directory is on PATH.')
 
+        # `bootstrap` tool is cauing a linking warning on apple machines, that
+        # becomes a hard error, because the build binds to the node's Homebrew
+        # `liblzma.dylib` which targets a newer macOS than our deployment
+        # target. For this reason, we force `lzma-sys` to compile and statically
+        # link its bundled liblzma to avoid this warning. Upstream already does
+        # this on Linux, but they have not hit this issue on macOS, as their
+        # nodes don't have homebrew installed.
+        if sys.platform == 'darwin':
+            os.environ['LZMA_API_STATIC'] = '1'
+
         with self._temporary_config_toml_template_edits():
             self._prepare_run_xpy()
             self._run_xpy()


### PR DESCRIPTION
We are running into issues in the intel nodes, but this can also happen
in arm systems, when the local homebrew install has deployed a different
version from the one expected during link.

We are setting this change to get this dependency built and statically
linked. It is of note that upstream already does this on Linux, but they
most likely don't have homebrew installs on their bots, and that's why
they are not hitting this on Mac.

Bug: https://github.com/brave/brave-browser/issues/55812
