### PR TITLE
[android] Show the element blocker if enabled for private tabs.

### DIFF
--- a/android/java/org/chromium/chrome/browser/shields/BraveUnifiedPanelHandler.java
+++ b/android/java/org/chromium/chrome/browser/shields/BraveUnifiedPanelHandler.java
@@ -48,6 +48,7 @@ import android.widget.PopupWindow;
 import android.widget.ScrollView;
 import android.widget.TextView;
 
+import androidx.annotation.VisibleForTesting;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.widget.AppCompatImageView;
 import androidx.appcompat.widget.AppCompatRadioButton;
@@ -553,11 +554,8 @@ public class BraveUnifiedPanelHandler {
 
         View blockElementItem = mAdvancedOptionsContent.findViewById(R.id.block_element_item);
         if (blockElementItem != null) {
-            boolean isPrivateWindow = mCurrentTab != null && mCurrentTab.isIncognito();
-            boolean isFeatureEnabled =
-                    ChromeFeatureList.isEnabled(BraveFeatureList.BRAVE_SHIELDS_ELEMENT_PICKER);
 
-            if (!isPrivateWindow && isFeatureEnabled) {
+            if (shouldShowElementBlocker()) {
                 blockElementItem.setVisibility(View.VISIBLE);
                 blockElementItem.setOnClickListener(
                         v -> {
@@ -666,6 +664,25 @@ public class BraveUnifiedPanelHandler {
 
     private void applyToggleState(boolean isOn) {
         mShieldsToggleSwitch.setChecked(isOn);
+    }
+
+    @VisibleForTesting
+    boolean shouldShowElementBlocker() {
+        boolean isPrivateWindow = mCurrentTab != null && mCurrentTab.isIncognito();
+        boolean isEnabledForPrivate = getElementBlockerPrivateModeEnabled();
+        boolean isFeatureEnabled =
+                ChromeFeatureList.isEnabled(BraveFeatureList.BRAVE_SHIELDS_ELEMENT_PICKER);
+        return (!isPrivateWindow || isEnabledForPrivate) && isFeatureEnabled;
+    }
+
+    @VisibleForTesting
+    void setCurrentTabForTesting(@Nullable Tab tab) {
+        mCurrentTab = tab;
+    }
+
+    @VisibleForTesting
+    protected boolean getElementBlockerPrivateModeEnabled() {
+        return BraveShieldsContentSettings.getAllowElementBlockerInPrivateModeEnabledPref();
     }
 
     private void onShieldsToggleChanged(boolean isChecked) {

--- a/android/junit/src/org/chromium/chrome/browser/shields/BraveUnifiedPanelHandlerStatTest.java
+++ b/android/junit/src/org/chromium/chrome/browser/shields/BraveUnifiedPanelHandlerStatTest.java
@@ -6,18 +6,27 @@
 package org.chromium.chrome.browser.shields;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
+import org.chromium.base.BraveFeatureList;
 import org.chromium.base.ContextUtils;
 import org.chromium.base.test.BaseRobolectricTestRunner;
+import org.chromium.base.test.util.Features.DisableFeatures;
+import org.chromium.base.test.util.Features.EnableFeatures;
 import org.chromium.chrome.browser.preferences.website.BraveShieldsContentSettings;
+import org.chromium.chrome.browser.tab.Tab;
 
 import java.util.ArrayList;
 
@@ -32,11 +41,14 @@ public class BraveUnifiedPanelHandlerStatTest {
     private static final int TAB_ID = 42;
     private static final int UNKNOWN_TAB_ID = 999;
 
+    @Mock private Tab mIncognitoTab;
+
     private BraveUnifiedPanelHandler mHandler;
 
     @Before
     public void setUp() {
-        mHandler = new BraveUnifiedPanelHandler(ContextUtils.getApplicationContext());
+        mHandler = spy(new BraveUnifiedPanelHandler(ContextUtils.getApplicationContext()));
+        mHandler.setCurrentTabForTesting(mIncognitoTab);
     }
 
     @Test
@@ -165,6 +177,48 @@ public class BraveUnifiedPanelHandlerStatTest {
         assertEquals(0, mHandler.getTrackersBlockedCount(UNKNOWN_TAB_ID));
         assertEquals(0, mHandler.getTotalBlockedCount(UNKNOWN_TAB_ID));
         assertTrue(mHandler.getBlockedUrls(UNKNOWN_TAB_ID).isEmpty());
+    }
+
+    @Test
+    @EnableFeatures(BraveFeatureList.BRAVE_SHIELDS_ELEMENT_PICKER)
+    public void shouldShowElementBlocker_normalTab_featureEnabled_shown() {
+        when(mIncognitoTab.isIncognito()).thenReturn(false);
+        // Shouldn't matter but set it to false anyway.
+        doReturn(false).when(mHandler).getElementBlockerPrivateModeEnabled();
+        assertTrue(mHandler.shouldShowElementBlocker());
+    }
+
+    @Test
+    @DisableFeatures(BraveFeatureList.BRAVE_SHIELDS_ELEMENT_PICKER)
+    public void shouldShowElementBlocker_normalTab_featureDisabled_shown() {
+        when(mIncognitoTab.isIncognito()).thenReturn(false);
+        // Ditto previous test, but inverse.
+        doReturn(true).when(mHandler).getElementBlockerPrivateModeEnabled();
+        assertFalse(mHandler.shouldShowElementBlocker());
+    }
+
+    @Test
+    @EnableFeatures(BraveFeatureList.BRAVE_SHIELDS_ELEMENT_PICKER)
+    public void shouldShowElementBlocker_privateTab_privatePrefEnabled_shown() {
+        when(mIncognitoTab.isIncognito()).thenReturn(true);
+        doReturn(true).when(mHandler).getElementBlockerPrivateModeEnabled();
+        assertTrue(mHandler.shouldShowElementBlocker());
+    }
+
+    @Test
+    @EnableFeatures(BraveFeatureList.BRAVE_SHIELDS_ELEMENT_PICKER)
+    public void shouldShowElementBlocker_privateTab_privatePrefDisabled_notShown() {
+        when(mIncognitoTab.isIncognito()).thenReturn(true);
+        doReturn(false).when(mHandler).getElementBlockerPrivateModeEnabled();
+        assertFalse(mHandler.shouldShowElementBlocker());
+    }
+
+    @Test
+    @DisableFeatures(BraveFeatureList.BRAVE_SHIELDS_ELEMENT_PICKER)
+    public void shouldShowElementBlocker_privateTab_featureDisabled_notShown() {
+        when(mIncognitoTab.isIncognito()).thenReturn(true);
+        doReturn(true).when(mHandler).getElementBlockerPrivateModeEnabled();
+        assertFalse(mHandler.shouldShowElementBlocker());
     }
 
     @Test


### PR DESCRIPTION
In our new Shields UI, were missing a check for the user-facing option that allows blocking elements in a page when on a private tab. Consequently, the setting had no effect.

This commit adds the check along with tests to verify behaviour.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves brave/brave-browser#56195

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
