### PR TITLE
[iOS] Register missing adblock preferences on iOS

### DIFF
--- a/ios/browser/shared/prefs/browser_prefs_impl.mm
+++ b/ios/browser/shared/prefs/browser_prefs_impl.mm
@@ -129,6 +129,12 @@ void RegisterLocalStatePrefs(PrefRegistrySimple* registry) {
       brave_shields::prefs::kAdBlockCheckedAllDefaultRegions, false);
   registry->RegisterBooleanPref(
       brave_shields::prefs::kAdBlockCheckedDefaultRegion, false);
+  registry->RegisterBooleanPref(brave_shields::prefs::kFBEmbedControlType,
+                                true);
+  registry->RegisterBooleanPref(brave_shields::prefs::kTwitterEmbedControlType,
+                                true);
+  registry->RegisterBooleanPref(brave_shields::prefs::kLinkedInEmbedControlType,
+                                false);
 }
 
 void MigrateObsoleteProfilePrefs(PrefService* prefs) {


### PR DESCRIPTION
- Preferences weren't registered on iOS because we don't use shared desktop/Android `AdBlockService` where these are [registered](https://github.com/brave/brave-core/blob/2d0b4f875919a6f88c3e8910200a46987aad4096/components/brave_shields/content/browser/ad_block_service.cc#L435-L437).
- These 3 preferences are being checked against here: https://github.com/brave/brave-core/pull/36826/changes#diff-e18e45d3daaff716c92c96fb5fe0850c82afbb4dba89dd3cf71760f13b9020d0R364

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

### Testplan

Build & run iOS, verify does not crash due to unregistered preferences