### PR TITLE
Added description under New Email Alias autofill suggestion.

### DIFF
--- a/browser/email_aliases/email_aliases_autofill_browsertest.cc
+++ b/browser/email_aliases/email_aliases_autofill_browsertest.cc
@@ -3,6 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include <algorithm>
 #include <string_view>
 #include <vector>
 
@@ -23,14 +24,38 @@
 #include "components/autofill/core/browser/foundations/test_autofill_manager_waiter.h"
 #include "components/autofill/core/browser/suggestions/suggestion.h"
 #include "components/autofill/core/browser/test_utils/autofill_test_utils.h"
+#include "components/grit/brave_components_strings.h"
 #include "content/public/browser/render_frame_host.h"
 #include "content/public/browser/render_widget_host.h"
 #include "content/public/browser/render_widget_host_view.h"
 #include "content/public/browser/web_contents.h"
 #include "content/public/test/browser_test.h"
 #include "content/public/test/browser_test_utils.h"
+#include "ui/base/l10n/l10n_util.h"
 
 namespace email_aliases {
+
+namespace {
+
+void ExpectBraveEmailAliasAddressEntry(const autofill::Suggestion& suggestion) {
+  EXPECT_EQ(suggestion.type, autofill::SuggestionType::kAddressEntry);
+  EXPECT_TRUE(suggestion.brave_new_email_alias_suggestion);
+  EXPECT_EQ(suggestion.main_text.value,
+            l10n_util::GetStringUTF16(IDS_IDC_NEW_EMAIL_ALIAS));
+  ASSERT_EQ(1u, suggestion.labels.size());
+  EXPECT_EQ(suggestion.labels[0][0].value,
+            l10n_util::GetStringUTF16(IDS_IDC_NEW_EMAIL_ALIAS_DESC));
+  EXPECT_EQ(suggestion.icon, autofill::Suggestion::Icon::kEmail);
+}
+
+const autofill::Suggestion* FindBraveEmailAliasSuggestion(
+    const std::vector<autofill::Suggestion>& suggestions) {
+  const auto it = std::ranges::find_if(
+      suggestions, &autofill::Suggestion::brave_new_email_alias_suggestion);
+  return it == suggestions.end() ? nullptr : &*it;
+}
+
+}  // namespace
 
 class TestAutofillClient : public autofill::ChromeAutofillClient {
  public:
@@ -163,31 +188,37 @@ IN_PROC_BROWSER_TEST_P(EmailAliasesAutofillTest, NewEmailAliasSuggestion) {
 
   ASSERT_LE(3u, autofill_client()->suggestions().size());
 
-  // Suggestion from Address settings.
+  // Saved profile suggestion — kAddressEntry without the Brave flag.
   EXPECT_EQ(autofill_client()->suggestions()[0].main_text.value,
             u"johndoe@hades.com");
   EXPECT_EQ(autofill_client()->suggestions()[0].type,
             autofill::SuggestionType::kAddressEntry);
-
-  EXPECT_EQ(autofill_client()->suggestions()[1].type,
-            autofill::SuggestionType::kSeparator);
-
-  // Upstream ManageAddress suggession.
-  EXPECT_EQ(autofill_client()->suggestions()[2].type,
-            autofill::SuggestionType::kManageAddress);
   EXPECT_FALSE(
-      autofill_client()->suggestions()[2].brave_new_email_alias_suggestion);
+      autofill_client()->suggestions()[0].brave_new_email_alias_suggestion);
 
+  const autofill::Suggestion* brave_suggestion =
+      FindBraveEmailAliasSuggestion(autofill_client()->suggestions());
   if (GetParam()) {
     ASSERT_LE(4u, autofill_client()->suggestions().size());
-    // EmailAlias ManageAddress (type reused) suggession.
+    ASSERT_NE(brave_suggestion, nullptr);
+
+    // Brave email alias suggestion — last body row, before footer.
+    ExpectBraveEmailAliasAddressEntry(*brave_suggestion);
+    EXPECT_EQ(brave_suggestion, &autofill_client()->suggestions()[1]);
+
+    EXPECT_EQ(autofill_client()->suggestions()[2].type,
+              autofill::SuggestionType::kSeparator);
     EXPECT_EQ(autofill_client()->suggestions()[3].type,
               autofill::SuggestionType::kManageAddress);
-    EXPECT_TRUE(
-        autofill_client()->suggestions()[3].brave_new_email_alias_suggestion);
   } else {
-    // Feature is disabled.
+    // Feature is disabled — no Brave email alias suggestion.
+    EXPECT_EQ(brave_suggestion, nullptr);
+
     EXPECT_EQ(3u, autofill_client()->suggestions().size());
+    EXPECT_EQ(autofill_client()->suggestions()[1].type,
+              autofill::SuggestionType::kSeparator);
+    EXPECT_EQ(autofill_client()->suggestions()[2].type,
+              autofill::SuggestionType::kManageAddress);
   }
 
   autofill_client()->ResetSuggestions();
@@ -208,13 +239,14 @@ IN_PROC_BROWSER_TEST_P(EmailAliasesAutofillTest,
 
   ASSERT_TRUE(base::test::RunUntil(
       [&]() { return !autofill_client()->suggestions().empty(); }));
+
+  // Brave email alias suggestion as the only entry on signup email field.
   EXPECT_EQ(1u, autofill_client()->suggestions().size());
 
-  // EmailAlias ManageAddress (type reused) suggession.
-  EXPECT_EQ(autofill_client()->suggestions()[0].type,
-            autofill::SuggestionType::kManageAddress);
-  EXPECT_TRUE(
-      autofill_client()->suggestions()[0].brave_new_email_alias_suggestion);
+  const autofill::Suggestion* brave_suggestion =
+      FindBraveEmailAliasSuggestion(autofill_client()->suggestions());
+  ASSERT_NE(brave_suggestion, nullptr);
+  ExpectBraveEmailAliasAddressEntry(*brave_suggestion);
 
   autofill_client()->ResetSuggestions();
 }

--- a/chromium_src/chrome/browser/ui/autofill/chrome_autofill_client.cc
+++ b/chromium_src/chrome/browser/ui/autofill/chrome_autofill_client.cc
@@ -10,7 +10,7 @@
 #include "brave/components/constants/pref_names.h"
 #include "brave/components/email_aliases/buildflags/buildflags.h"
 #include "chrome/browser/profiles/profile.h"
-#include "chrome/browser/ui/autofill/payments/webauthn_dialog_controller_impl.h"
+#include "chrome/browser/ui/autofill/autofill_suggestion_controller_utils.h"
 #include "chrome/browser/ui/browser_window/public/browser_window_features.h"
 #include "chrome/browser/ui/browser_window/public/browser_window_interface.h"
 #include "chrome/browser/ui/page_info/page_info_dialog.h"
@@ -143,12 +143,23 @@ class BraveChromeAutofillClient : public ChromeAutofillClient {
 
       if (contains_email_suggestion || username_field_in_sign_up_form) {
         autofill::Suggestion new_email_alias(
-            autofill::SuggestionType::kManageAddress);
+            autofill::SuggestionType::kAddressEntry);
         new_email_alias.icon = autofill::Suggestion::Icon::kEmail;
         new_email_alias.main_text = autofill::Suggestion::Text(
             l10n_util::GetStringUTF16(IDS_IDC_NEW_EMAIL_ALIAS));
+        new_email_alias.labels.push_back({autofill::Suggestion::Text(
+            l10n_util::GetStringUTF16(IDS_IDC_NEW_EMAIL_ALIAS_DESC))});
         new_email_alias.brave_new_email_alias_suggestion = true;
-        chrome_suggestions.push_back(std::move(new_email_alias));
+
+        size_t insert_index = chrome_suggestions.size();
+        for (size_t i = 0; i < chrome_suggestions.size(); ++i) {
+          if (IsFooterItem(chrome_suggestions, i)) {
+            insert_index = i;
+            break;
+          }
+        }
+        chrome_suggestions.insert(chrome_suggestions.begin() + insert_index,
+                                  std::move(new_email_alias));
       }
     }
   }

--- a/chromium_src/chrome/browser/ui/views/autofill/popup/popup_row_factory_utils.cc
+++ b/chromium_src/chrome/browser/ui/views/autofill/popup/popup_row_factory_utils.cc
@@ -1,0 +1,29 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "chrome/browser/ui/views/chrome_layout_provider.h"
+#include "ui/views/controls/menu/menu_config.h"
+
+constexpr int kNewEmailAliaseSuggestionMaxWidth = 512;
+
+// This macro redefines FormatLabel at the beginning of CreateSubtextViews to
+// allow long descriptions for New Email Alias suggestions to be shown.
+#define GetDistanceMetric(...)                                              \
+  GetDistanceMetric(__VA_ARGS__);                                           \
+  auto FormatLabel_ChromiumImpl = FormatLabel;                              \
+  auto FormatLabel = [&FormatLabel_ChromiumImpl, &suggestion](              \
+                         views::Label& label, const Suggestion::Text& text, \
+                         FillingProduct main_filling_product,               \
+                         int maximum_width_single_line) {                   \
+    if (suggestion.brave_new_email_alias_suggestion) {                      \
+      maximum_width_single_line = kNewEmailAliaseSuggestionMaxWidth;        \
+    }                                                                       \
+    FormatLabel_ChromiumImpl(label, text, main_filling_product,             \
+                             maximum_width_single_line);                    \
+  }
+
+#include <chrome/browser/ui/views/autofill/popup/popup_row_factory_utils.cc>
+
+#undef GetDistanceMetric

--- a/components/resources/commands.grdp
+++ b/components/resources/commands.grdp
@@ -573,6 +573,10 @@
   <message name="IDS_IDC_NEW_EMAIL_ALIAS" desc="Message for context menu that enables the Email Alias generator UI for the page">
     New Email Alias
   </message>
+  <message name="IDS_IDC_NEW_EMAIL_ALIAS_DESC" desc="Desc label for Email Aliases autofill suggestsion">
+    Create a random email that forwards to your inbox.
+  </message>
+
   <message name="IDS_IDC_NEW_TEMPORARY_CONTAINER" desc="Label for the command that opens the current URL in a new local-only temporary container.">
     New temporary container
   </message>


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/56118

With suggestions from a profile.
<img width="661" height="353" alt="image" src="https://github.com/user-attachments/assets/6877a0a5-85bd-4a3c-90ab-ef97ed50b826" />

Standalone:

<img width="869" height="304" alt="image" src="https://github.com/user-attachments/assets/f0820555-33cf-4a39-a5e2-88fc4c65e250" />

