### PR TITLE
[ads] Fix crash when round-robin or pacing drains all ads from a priority bucket

### DIFF
--- a/components/brave_ads/core/internal/serving/eligible_ads/pipelines/new_tab_page_ads/eligible_new_tab_page_ads_v2.cc
+++ b/components/brave_ads/core/internal/serving/eligible_ads/pipelines/new_tab_page_ads/eligible_new_tab_page_ads_v2.cc
@@ -272,6 +272,10 @@ void EligibleNewTabPageAdsV2::FilterAndMaybePredictCreativeAdCallback(
 
     PaceCreativeAds(creative_ad_bucket);
 
+    if (creative_ad_bucket.empty()) {
+      continue;
+    }
+
     std::optional<CreativeNewTabPageAdInfo> predicted_creative_ad =
         MaybePredictCreativeAd(creative_ad_bucket, user_model, ad_events);
     if (!predicted_creative_ad) {

--- a/components/brave_ads/core/internal/serving/eligible_ads/pipelines/new_tab_page_ads/eligible_new_tab_page_ads_v2_unittest.cc
+++ b/components/brave_ads/core/internal/serving/eligible_ads/pipelines/new_tab_page_ads/eligible_new_tab_page_ads_v2_unittest.cc
@@ -16,6 +16,7 @@
 #include "brave/components/brave_ads/core/internal/creatives/new_tab_page_ads/new_tab_page_ad_builder.h"
 #include "brave/components/brave_ads/core/internal/creatives/new_tab_page_ads/test/creative_new_tab_page_ad_test_util.h"
 #include "brave/components/brave_ads/core/internal/serving/eligible_ads/eligible_ads_feature.h"
+#include "brave/components/brave_ads/core/internal/serving/eligible_ads/pacing/pacing_random_util.h"
 #include "brave/components/brave_ads/core/internal/serving/eligible_ads/round_robin/creative_ad_round_robin.h"
 #include "brave/components/brave_ads/core/internal/serving/targeting/user_model/user_model_info.h"
 #include "brave/components/brave_ads/core/internal/targeting/behavioral/anti_targeting/resource/anti_targeting_resource.h"
@@ -698,6 +699,36 @@ TEST_F(
     eligible_ads_->GetForUserModel(user_model, test_future.GetCallback());
     EXPECT_THAT(test_future.Take(), ::testing::ElementsAre(creative_ad_1));
   }
+}
+
+TEST_F(BraveAdsEligibleNewTabPageAdsV2Test,
+       FallThroughToLowerPriorityBucketWhenPacingDrainsHigherPriorityBucket) {
+  // Arrange: `creative_ad_1` (priority 1) has a zero pass-through rate so
+  // pacing always removes it, leaving an empty bucket. The pipeline must fall
+  // through to `creative_ad_2` (priority 2).
+  CreativeNewTabPageAdInfo creative_ad_1 =
+      test::BuildCreativeNewTabPageAd(CreativeNewTabPageAdWallpaperType::kImage,
+                                      /*use_random_uuids=*/true);
+  creative_ad_1.priority = 1;
+  creative_ad_1.pass_through_rate = 0.0;
+
+  CreativeNewTabPageAdInfo creative_ad_2 =
+      test::BuildCreativeNewTabPageAd(CreativeNewTabPageAdWallpaperType::kImage,
+                                      /*use_random_uuids=*/true);
+  creative_ad_2.priority = 2;
+  creative_ad_2.pass_through_rate = 1.0;
+
+  test::SaveCreativeNewTabPageAds({creative_ad_1, creative_ad_2});
+
+  const ScopedPacingRandomNumberSetterForTesting scoped_setter(0.5);
+
+  // Act & Assert
+  base::test::TestFuture<CreativeNewTabPageAdList> test_future;
+  eligible_ads_->GetForUserModel(
+      UserModelInfo{IntentUserModelInfo{}, LatentInterestUserModelInfo{},
+                    InterestUserModelInfo{}},
+      test_future.GetCallback());
+  EXPECT_THAT(test_future.Take(), ::testing::ElementsAre(creative_ad_2));
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/serving/eligible_ads/pipelines/notification_ads/eligible_notification_ads_v2.cc
+++ b/components/brave_ads/core/internal/serving/eligible_ads/pipelines/notification_ads/eligible_notification_ads_v2.cc
@@ -171,6 +171,10 @@ void EligibleNotificationAdsV2::FilterAndMaybePredictCreativeAd(
 
     PaceCreativeAds(creative_ad_bucket);
 
+    if (creative_ad_bucket.empty()) {
+      continue;
+    }
+
     std::optional<CreativeNotificationAdInfo> predicted_creative_ad =
         MaybePredictCreativeAd(creative_ad_bucket, user_model, ad_events);
     if (!predicted_creative_ad) {

--- a/components/brave_ads/core/internal/serving/eligible_ads/pipelines/notification_ads/eligible_notification_ads_v2_unittest.cc
+++ b/components/brave_ads/core/internal/serving/eligible_ads/pipelines/notification_ads/eligible_notification_ads_v2_unittest.cc
@@ -17,6 +17,7 @@
 #include "brave/components/brave_ads/core/internal/creatives/notification_ads/notification_ad_builder.h"
 #include "brave/components/brave_ads/core/internal/creatives/notification_ads/test/creative_notification_ad_test_util.h"
 #include "brave/components/brave_ads/core/internal/serving/eligible_ads/eligible_ads_feature.h"
+#include "brave/components/brave_ads/core/internal/serving/eligible_ads/pacing/pacing_random_util.h"
 #include "brave/components/brave_ads/core/internal/serving/eligible_ads/round_robin/creative_ad_round_robin.h"
 #include "brave/components/brave_ads/core/internal/serving/targeting/user_model/user_model_info.h"
 #include "brave/components/brave_ads/core/internal/targeting/behavioral/anti_targeting/resource/anti_targeting_resource.h"
@@ -655,6 +656,34 @@ TEST_F(
     eligible_ads_->GetForUserModel(user_model, test_future.GetCallback());
     EXPECT_THAT(test_future.Take(), ::testing::ElementsAre(creative_ad_1));
   }
+}
+
+TEST_F(BraveAdsEligibleNotificationAdsV2Test,
+       FallThroughToLowerPriorityBucketWhenPacingDrainsHigherPriorityBucket) {
+  // Arrange: `creative_ad_1` (priority 1) has a zero pass-through rate so
+  // pacing always removes it, leaving an empty bucket. The pipeline must fall
+  // through to `creative_ad_2` (priority 2).
+  CreativeNotificationAdInfo creative_ad_1 =
+      test::BuildCreativeNotificationAd(/*use_random_uuids=*/true);
+  creative_ad_1.priority = 1;
+  creative_ad_1.pass_through_rate = 0.0;
+
+  CreativeNotificationAdInfo creative_ad_2 =
+      test::BuildCreativeNotificationAd(/*use_random_uuids=*/true);
+  creative_ad_2.priority = 2;
+  creative_ad_2.pass_through_rate = 1.0;
+
+  database::SaveCreativeNotificationAds({creative_ad_1, creative_ad_2});
+
+  const ScopedPacingRandomNumberSetterForTesting scoped_setter(0.5);
+
+  // Act & Assert
+  base::test::TestFuture<CreativeNotificationAdList> test_future;
+  eligible_ads_->GetForUserModel(
+      UserModelInfo{IntentUserModelInfo{}, LatentInterestUserModelInfo{},
+                    InterestUserModelInfo{}},
+      test_future.GetCallback());
+  EXPECT_THAT(test_future.Take(), ::testing::ElementsAre(creative_ad_2));
 }
 
 }  // namespace brave_ads


### PR DESCRIPTION
Moving round-robin and pacing inside the per-bucket loop (da638da8) introduced a case where either filter could empty a bucket that had ads at bucketing time. MaybePredictCreativeAd CHECKs that its input is non-empty, so calling it on an empty bucket crashes. Add a guard to skip to the next bucket when the filters leave nothing to predict.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/56227

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
