### PR TITLE
Localize Brave Origin startup error messages

### DIFF
--- a/browser/ui/webui/brave_origin_startup/BUILD.gn
+++ b/browser/ui/webui/brave_origin_startup/BUILD.gn
@@ -48,6 +48,7 @@ source_set("unit_tests") {
     ":brave_origin_startup",
     "//base/test:test_support",
     "//brave/components/brave_origin:pref_names",
+    "//brave/components/resources:strings_grit",
     "//brave/components/skus/browser:test_support",
     "//components/prefs:test_support",
     "//content/test:test_support",

--- a/browser/ui/webui/brave_origin_startup/brave_origin_startup_handler.cc
+++ b/browser/ui/webui/brave_origin_startup/brave_origin_startup_handler.cc
@@ -13,7 +13,9 @@
 #include "brave/brave_domains/service_domains.h"
 #include "brave/components/brave_origin/pref_names.h"
 #include "brave/components/skus/browser/skus_utils.h"
+#include "components/grit/brave_components_strings.h"
 #include "components/prefs/pref_service.h"
+#include "ui/base/l10n/l10n_util.h"
 
 namespace {
 
@@ -82,7 +84,9 @@ void BraveOriginStartupHandler::VerifyPurchaseId(
     const std::string& purchase_id,
     VerifyPurchaseIdCallback callback) {
   if (!EnsureSkusConnected()) {
-    std::move(callback).Run(false, "Unable to connect to SKU service");
+    std::move(callback).Run(
+        false, l10n_util::GetStringUTF8(
+                   IDS_BRAVE_ORIGIN_STARTUP_ERROR_SKUS_CONNECTION));
     return;
   }
 
@@ -91,7 +95,9 @@ void BraveOriginStartupHandler::VerifyPurchaseId(
   base::TrimWhitespaceASCII(purchase_id, base::TrimPositions::TRIM_ALL,
                             &trimmed_id);
   if (trimmed_id.empty()) {
-    std::move(callback).Run(false, "Purchase ID is empty");
+    std::move(callback).Run(
+        false, l10n_util::GetStringUTF8(
+                   IDS_BRAVE_ORIGIN_STARTUP_ERROR_EMPTY_PURCHASE_ID));
     return;
   }
 
@@ -167,7 +173,9 @@ void BraveOriginStartupHandler::OnRefreshOrder(
   if (result->code != skus::mojom::SkusResultCode::Ok) {
     VLOG(1) << "RefreshOrder failed with code: "
             << static_cast<int>(result->code);
-    std::move(callback).Run(false, "Invalid purchase ID");
+    std::move(callback).Run(
+        false, l10n_util::GetStringUTF8(
+                   IDS_BRAVE_ORIGIN_STARTUP_ERROR_INVALID_PURCHASE_ID));
     return;
   }
 
@@ -183,7 +191,9 @@ void BraveOriginStartupHandler::OnFetchOrderCredentials(
   if (result->code != skus::mojom::SkusResultCode::Ok) {
     VLOG(1) << "FetchOrderCredentials failed with code: "
             << static_cast<int>(result->code);
-    std::move(callback).Run(false, "Failed to fetch credentials");
+    std::move(callback).Run(
+        false, l10n_util::GetStringUTF8(
+                   IDS_BRAVE_ORIGIN_STARTUP_ERROR_FETCH_CREDENTIALS));
     return;
   }
 
@@ -203,5 +213,9 @@ void BraveOriginStartupHandler::OnVerifyCredentialSummary(
     local_state_->SetBoolean(brave_origin::kOriginPurchaseValidated, true);
   }
 
-  std::move(callback).Run(purchased, purchased ? "" : "Purchase not found");
+  std::move(callback).Run(
+      purchased, purchased
+                     ? std::string()
+                     : l10n_util::GetStringUTF8(
+                           IDS_BRAVE_ORIGIN_STARTUP_ERROR_PURCHASE_NOT_FOUND));
 }

--- a/browser/ui/webui/brave_origin_startup/brave_origin_startup_handler_unittest.cc
+++ b/browser/ui/webui/brave_origin_startup/brave_origin_startup_handler_unittest.cc
@@ -14,10 +14,12 @@
 #include "brave/components/brave_origin/pref_names.h"
 #include "brave/components/skus/browser/test/fake_skus_service.h"
 #include "build/build_config.h"
+#include "components/grit/brave_components_strings.h"
 #include "components/prefs/pref_registry_simple.h"
 #include "components/prefs/testing_pref_service.h"
 #include "content/public/test/browser_task_environment.h"
 #include "testing/gtest/include/gtest/gtest.h"
+#include "ui/base/l10n/l10n_util.h"
 
 class BraveOriginStartupHandlerTest : public testing::Test {
  public:
@@ -112,7 +114,8 @@ TEST_F(BraveOriginStartupHandlerTest,
 
   auto [success, error] = future.Get();
   EXPECT_FALSE(success);
-  EXPECT_FALSE(error.empty());
+  EXPECT_EQ(error, l10n_util::GetStringUTF8(
+                       IDS_BRAVE_ORIGIN_STARTUP_ERROR_SKUS_CONNECTION));
 }
 
 TEST_F(BraveOriginStartupHandlerTest, PrefDefaultIsFalse) {
@@ -200,7 +203,8 @@ TEST_F(BraveOriginStartupHandlerTest, VerifyPurchaseIdFailsWithNoCredentials) {
 
   auto [success, error] = future.Get();
   EXPECT_FALSE(success);
-  EXPECT_FALSE(error.empty());
+  EXPECT_EQ(error, l10n_util::GetStringUTF8(
+                       IDS_BRAVE_ORIGIN_STARTUP_ERROR_PURCHASE_NOT_FOUND));
   EXPECT_FALSE(local_state_.GetBoolean(brave_origin::kOriginPurchaseValidated));
 }
 
@@ -213,7 +217,8 @@ TEST_F(BraveOriginStartupHandlerTest,
 
   auto [success, error] = future.Get();
   EXPECT_FALSE(success);
-  EXPECT_EQ(error, "Purchase ID is empty");
+  EXPECT_EQ(error, l10n_util::GetStringUTF8(
+                       IDS_BRAVE_ORIGIN_STARTUP_ERROR_EMPTY_PURCHASE_ID));
 }
 
 TEST_F(BraveOriginStartupHandlerTest,
@@ -225,7 +230,8 @@ TEST_F(BraveOriginStartupHandlerTest,
 
   auto [success, error] = future.Get();
   EXPECT_FALSE(success);
-  EXPECT_EQ(error, "Purchase ID is empty");
+  EXPECT_EQ(error, l10n_util::GetStringUTF8(
+                       IDS_BRAVE_ORIGIN_STARTUP_ERROR_EMPTY_PURCHASE_ID));
 }
 
 #if BUILDFLAG(IS_LINUX)

--- a/components/resources/brave_origin_startup_strings.grdp
+++ b/components/resources/brave_origin_startup_strings.grdp
@@ -59,4 +59,28 @@
   <message name="IDS_BRAVE_ORIGIN_STARTUP_LINUX_FREE_BUTTON" desc="Button label to proceed with Origin for free on Linux" formatter_data="webui=BraveOriginStartup">
     Proceed with Origin for free on Linux
   </message>
+
+  <!-- The IDS_BRAVE_ORIGIN_STARTUP_ERROR_* messages are returned to the UI
+       through the mojo VerifyPurchaseId callback and localized in C++ via
+       l10n_util, so they are intentionally excluded from the WebUI JS bundle
+       (no formatter_data="webui=BraveOriginStartup"). -->
+  <message name="IDS_BRAVE_ORIGIN_STARTUP_ERROR_SKUS_CONNECTION" desc="Error message shown when the browser cannot connect to the purchase service while verifying a Brave Origin purchase ID">
+    Unable to connect to SKU service
+  </message>
+
+  <message name="IDS_BRAVE_ORIGIN_STARTUP_ERROR_EMPTY_PURCHASE_ID" desc="Error message shown when the user submits an empty purchase ID in the Brave Origin restore dialog">
+    Purchase ID is empty
+  </message>
+
+  <message name="IDS_BRAVE_ORIGIN_STARTUP_ERROR_INVALID_PURCHASE_ID" desc="Error message shown when the entered Brave Origin purchase ID is not valid">
+    Invalid purchase ID
+  </message>
+
+  <message name="IDS_BRAVE_ORIGIN_STARTUP_ERROR_FETCH_CREDENTIALS" desc="Error message shown when fetching the credentials for a Brave Origin purchase fails">
+    Failed to fetch credentials
+  </message>
+
+  <message name="IDS_BRAVE_ORIGIN_STARTUP_ERROR_PURCHASE_NOT_FOUND" desc="Error message shown when no Brave Origin purchase is found for the entered purchase ID">
+    Purchase not found
+  </message>
 </grit-part>


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/56237

The error messages shown in the Brave Origin startup/restore dialog were hardcoded English and not translated into other locales. This moves them into the GRDP string resources and returns them via `l10n_util` so they are localized.

Reported in Slack: the "Failed to fetch credentials" message appeared in English in the Japanese locale.

## Test plan
In a non-English locale (e.g. ja), enter an invalid purchase ID in the Brave Origin restore dialog and verify the error message is translated.
