### PR TITLE
[Android] Fix sending crash reports to backtrace

### DIFF
--- a/components/minidump_uploader/BUILD.gn
+++ b/components/minidump_uploader/BUILD.gn
@@ -16,5 +16,8 @@ robolectric_library("junit") {
     "//third_party/androidx:androidx_test_runner_java",
     "//third_party/junit",
   ]
-  sources = [ "android/javatests/src/org/chromium/components/minidump_uploader/BraveHttpURLConnectionFactoryImplTest.java" ]
+  sources = [
+    "android/javatests/src/org/chromium/components/minidump_uploader/BraveHttpURLConnectionFactoryImplTest.java",
+    "android/javatests/src/org/chromium/components/minidump_uploader/BraveMinidumpUploaderTest.java",
+  ]
 }

--- a/components/minidump_uploader/BUILD.gn
+++ b/components/minidump_uploader/BUILD.gn
@@ -13,6 +13,7 @@ robolectric_library("junit") {
     "//base:base_junit_test_support",
     "//base/version_info/android:version_constants_java",
     "//components/minidump_uploader:minidump_uploader_java",
+    "//components/minidump_uploader:minidump_uploader_java_test_support",
     "//third_party/androidx:androidx_test_runner_java",
     "//third_party/junit",
   ]

--- a/components/minidump_uploader/android/javatests/src/org/chromium/components/minidump_uploader/BraveMinidumpUploaderTest.java
+++ b/components/minidump_uploader/android/javatests/src/org/chromium/components/minidump_uploader/BraveMinidumpUploaderTest.java
@@ -1,0 +1,26 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.chromium.components.minidump_uploader;
+
+import androidx.test.filters.SmallTest;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.annotation.Config;
+
+import org.chromium.base.test.BaseRobolectricTestRunner;
+
+/** Unittest for {@link MinidumpUploader}. */
+@RunWith(BaseRobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public class BraveMinidumpUploaderTest {
+    @Test
+    @SmallTest
+    public void testStaticCrashUrlStringIsNotEmpty() {
+        Assert.assertEquals("https://cr.brave.com", MinidumpUploader.sCrashUrlString);
+    }
+}

--- a/components/minidump_uploader/android/javatests/src/org/chromium/components/minidump_uploader/BraveMinidumpUploaderTest.java
+++ b/components/minidump_uploader/android/javatests/src/org/chromium/components/minidump_uploader/BraveMinidumpUploaderTest.java
@@ -7,20 +7,82 @@ package org.chromium.components.minidump_uploader;
 
 import androidx.test.filters.SmallTest;
 
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
 
 import org.chromium.base.test.BaseRobolectricTestRunner;
+import org.chromium.components.minidump_uploader.util.HttpURLConnectionFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
 
 /** Unittest for {@link MinidumpUploader}. */
 @RunWith(BaseRobolectricTestRunner.class)
 @Config(manifest = Config.NONE)
 public class BraveMinidumpUploaderTest {
+    @Rule public CrashTestRule mTestRule = new CrashTestRule();
+    private File mUploadTestFile;
+
+    // Returns a fixed HTTP error code, without overriding the URL — used to verify
+    // that upload() reaches the HTTP layer under Brave's real sCrashUrlString value.
+    private static class ErrorCodeHttpURLConnectionFactory implements HttpURLConnectionFactory {
+        private final int mErrorCode;
+
+        ErrorCodeHttpURLConnectionFactory(int errorCode) {
+            mErrorCode = errorCode;
+        }
+
+        @Override
+        public HttpURLConnection createHttpURLConnection(String url) {
+            try {
+                return new TestHttpURLConnection(new URL(url)) {
+                    @Override
+                    public int getResponseCode() {
+                        return mErrorCode;
+                    }
+                };
+            } catch (IOException e) {
+                return null;
+            }
+        }
+    }
+
+    @Before
+    public void setUp() throws IOException {
+        // Do NOT call setCrashUrlStringForTesting — we intentionally exercise the real
+        // Brave-patched value so that a future upstream change that nulls the field (or
+        // adds a new precondition) turns into a red test rather than a silent breakage.
+        mUploadTestFile = new File(mTestRule.getCrashDir(), "crashFile");
+        CrashTestRule.setUpMinidumpFile(mUploadTestFile, MinidumpUploaderTestConstants.BOUNDARY);
+    }
+
+    @After
+    public void tearDown() {
+        mUploadTestFile.delete();
+    }
+
     @Test
     @SmallTest
-    public void testStaticCrashUrlStringIsNotEmpty() {
+    public void testCrashUrlStringIsBraveEndpoint() {
         Assert.assertEquals("https://cr.brave.com", MinidumpUploader.sCrashUrlString);
+    }
+
+    @Test
+    @SmallTest
+    public void testUploadReachesHttpLayer() {
+        // If sCrashUrlString is null/empty, or upstream adds a new gate inside upload(),
+        // this will return isFailure() instead of isUploadError() and the test will fail.
+        MinidumpUploader uploader =
+                new MinidumpUploader(new ErrorCodeHttpURLConnectionFactory(500));
+        MinidumpUploader.Result result = uploader.upload(mUploadTestFile);
+        Assert.assertTrue(result.isUploadError());
+        Assert.assertEquals(500, result.errorCode());
     }
 }

--- a/patches/components-minidump_uploader-android-java-src-org-chromium-components-minidump_uploader-MinidumpUploader.java.patch
+++ b/patches/components-minidump_uploader-android-java-src-org-chromium-components-minidump_uploader-MinidumpUploader.java.patch
@@ -1,0 +1,13 @@
+diff --git a/components/minidump_uploader/android/java/src/org/chromium/components/minidump_uploader/MinidumpUploader.java b/components/minidump_uploader/android/java/src/org/chromium/components/minidump_uploader/MinidumpUploader.java
+index 0a5320818ab90ddef8c0dff54a8183313234e1d9..8f8b82a64a4aea5f1f0d0542668f20c5b408a984 100644
+--- a/components/minidump_uploader/android/java/src/org/chromium/components/minidump_uploader/MinidumpUploader.java
++++ b/components/minidump_uploader/android/java/src/org/chromium/components/minidump_uploader/MinidumpUploader.java
+@@ -30,7 +30,7 @@ import java.util.zip.GZIPOutputStream;
+ @NullMarked
+ public class MinidumpUploader {
+     /* package */ static @Nullable String sCrashUrlString =
+-            BuildConfig.IS_CHROME_BRANDED ? "https://clients2.google.com/cr/report" : null;
++            "https://cr.brave.com";
+ 
+     public static @Nullable String setCrashUrlStringForTesting(@Nullable String url) {
+         @Nullable String oldUrl = sCrashUrlString;


### PR DESCRIPTION
This PR fixes sending crash reports to backtrace.

Chromium change caused the issue is
```
commit e7f4186e062177e0a295dd443e2a5344d25b74b6
Author: Sean Maher <spvm@chromium.org>
Date:   Fri May 1 12:35:46 2026 -0700

    minidump_uploader: remove google URL on non-branded builds
    
    Prevents users accidentally uploading reports to google servers, given
    that there have been cases where third-parties are uploading non-chrome
    crash reports to Google servers.
    
    Bug: 507913898
    Change-Id: I5daecaab677194d0ec320fa21d69bb92f2408472
    Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7800267
    Reviewed-by: Richard Coles <torne@chromium.org>
    Reviewed-by: Peter Wen <wnwen@chromium.org>
    Commit-Queue: Sean Maher <spvm@chromium.org>
    Cr-Commit-Position: refs/heads/main@{#1624006}
```
the lines 
```c++
            if (sCrashUrlString == null || sCrashUrlString.isEmpty()) {
                return Result.failure("Crash upload URL is not configured");
            }
```
caused that the minidumps were not sent.

The PR patches `sCrashUrlString` and adds some test to maximize chances of preventing similar in the future.
We cannot modify static members with bytecode patching. Theoretically it would be possible to subclass `MinidumpUploader` and assign `sCrashUrlString` before calling `super.upload()` - but this seemed excessive for the constant change.

Resolves https://github.com/brave/brave-browser/issues/56226

### Test Plan
1. Open `brave://crashes`
2. If you had a lot unsent crash reports before - some of them must be sent
3. If there no unsent crash reports - open `chrome://inducebrowsercrashforrealz` internal page which produces the crash, name can be copied form `brave://chrome-urls/` - crash should happen
4. Launch browser again, open `brave://crashes`  - the recent crash report should be marked as sent

<!-- Add brave-browser issue below that this PR will resolve -->


<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
