### PR TITLE
[VPN 2.0] Create stub Helper application

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -150,7 +150,10 @@ group("all") {
 
 if (enable_brave_vpn_v2) {
   group("brave_vpn_data_deps") {
-    data_deps = [ "//brave/components/brave_vpn/app/v2/agent" ]
+    data_deps = [
+      "//brave/components/brave_vpn/app/v2/agent",
+      "//brave/components/brave_vpn/app/v2/helper",
+    ]
   }
 }
 
@@ -332,6 +335,7 @@ if (is_mac) {
     group("vpn_apps_bundle_data") {
       deps = [
         "//brave/components/brave_vpn/app/v2/agent:brave_vpn_agent_bundle_data",
+        "//brave/components/brave_vpn/app/v2/helper:brave_vpn_helper_bundle_data",
       ]
     }
   }

--- a/components/brave_vpn/app/v2/agent/BUILD.gn
+++ b/components/brave_vpn/app/v2/agent/BUILD.gn
@@ -39,6 +39,7 @@ executable("agent") {
     ":core",
     "//base",
     "//base:base_static",
+    "//brave/components/brave_vpn/app/v2/shared",
   ]
 
   if (is_mac) {
@@ -72,6 +73,7 @@ if (is_mac) {
       ":core",
       "//base",
       "//base:base_static",
+      "//brave/components/brave_vpn/app/v2/shared",
     ]
   }
 

--- a/components/brave_vpn/app/v2/helper/BUILD.gn
+++ b/components/brave_vpn/app/v2/helper/BUILD.gn
@@ -1,0 +1,78 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import("//brave/components/brave_vpn/common/buildflags/buildflags.gni")
+if (is_mac) {
+  import("//build/config/mac/rules.gni")
+  import("//build/util/branding.gni")
+}
+if (is_win) {
+  import("//chrome/process_version_rc_template.gni")
+}
+
+assert(enable_brave_vpn_v2)
+
+source_set("core") {
+  sources = [
+    "helper_app.cc",
+    "helper_app.h",
+  ]
+
+  public_deps = [ "//base" ]
+}
+
+if (is_win) {
+  process_version_rc_template("version_resources") {
+    sources = [ "win/helper.ver" ]
+    output = "$target_gen_dir/brave_vpn_helper_app.rc"
+  }
+}
+
+executable("helper") {
+  output_name = "brave_vpn_helper_app"
+
+  sources = [ "main.cc" ]
+  deps = [
+    ":core",
+    "//base",
+    "//base:base_static",
+    "//brave/components/brave_vpn/app/v2/shared",
+  ]
+
+  if (is_win) {
+    deps += [
+      ":version_resources",
+      "//build/win:default_exe_manifest",
+    ]
+  }
+}
+
+if (is_mac) {
+  vpn_helper_product_full_name = "$chrome_product_full_name VPN Helper"
+  vpn_helper_bundle_id = "$chrome_mac_bundle_id.vpn.helper"
+
+  # Assembles the helper executable and Info.plist into an app bundle.
+  mac_app_bundle("brave_vpn_helper_bundle") {
+    info_plist = "mac/Info.plist"
+    output_name = vpn_helper_product_full_name
+    extra_substitutions = [ "MAC_BUNDLE_IDENTIFIER=$vpn_helper_bundle_id" ]
+
+    sources = [ "main.cc" ]
+
+    deps = [
+      ":core",
+      "//base",
+      "//base:base_static",
+      "//brave/components/brave_vpn/app/v2/shared",
+    ]
+  }
+
+  # Drops the assembled app into the browser framework's Helpers directory.
+  bundle_data("brave_vpn_helper_bundle_data") {
+    sources = [ "$root_out_dir/$vpn_helper_product_full_name.app" ]
+    outputs = [ "{{bundle_contents_dir}}/Helpers/{{source_file_part}}" ]
+    public_deps = [ ":brave_vpn_helper_bundle" ]
+  }
+}

--- a/components/brave_vpn/app/v2/helper/helper_app.cc
+++ b/components/brave_vpn/app/v2/helper/helper_app.cc
@@ -1,0 +1,23 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/app/v2/helper/helper_app.h"
+
+#include "base/logging.h"
+
+namespace brave_vpn {
+namespace v2 {
+
+HelperApp::HelperApp() = default;
+
+HelperApp::~HelperApp() = default;
+
+int HelperApp::Run() {
+  VLOG(1) << "Hello from the Brave VPN Helper!";
+  return 0;
+}
+
+}  // namespace v2
+}  // namespace brave_vpn

--- a/components/brave_vpn/app/v2/helper/helper_app.h
+++ b/components/brave_vpn/app/v2/helper/helper_app.h
@@ -1,0 +1,32 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_VPN_APP_V2_HELPER_HELPER_APP_H_
+#define BRAVE_COMPONENTS_BRAVE_VPN_APP_V2_HELPER_HELPER_APP_H_
+
+namespace brave_vpn {
+namespace v2 {
+
+// The HelperApp class encapsulates the main application logic for the
+// privileged Brave VPN helper process. It provides a stub method for running
+// the main event loop.
+
+class HelperApp final {
+ public:
+  HelperApp();
+  ~HelperApp();
+
+  HelperApp(const HelperApp&) = delete;
+  HelperApp& operator=(const HelperApp&) = delete;
+
+  // Runs the main event loop of the application. The return value is the exit
+  // code of the application.
+  int Run();
+};
+
+}  // namespace v2
+}  // namespace brave_vpn
+
+#endif  // BRAVE_COMPONENTS_BRAVE_VPN_APP_V2_HELPER_HELPER_APP_H_

--- a/components/brave_vpn/app/v2/helper/mac/Info.plist
+++ b/components/brave_vpn/app/v2/helper/mac/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleIdentifier</key>
+  <string>${MAC_BUNDLE_IDENTIFIER}</string>
+  <key>CFBundleDisplayName</key>
+  <string>${PRODUCT_NAME}</string>
+  <key>CFBundleExecutable</key>
+  <string>${EXECUTABLE_NAME}</string>
+  <key>CFBundleName</key>
+  <string>${PRODUCT_NAME}</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleVersion</key>
+  <string>1.0</string>
+  <key>LSMinimumSystemVersion</key>
+  <string>${MACOSX_DEPLOYMENT_TARGET}</string>
+</dict>
+</plist>

--- a/components/brave_vpn/app/v2/helper/main.cc
+++ b/components/brave_vpn/app/v2/helper/main.cc
@@ -8,7 +8,7 @@
 #include "base/logging.h"
 #include "base/logging/logging_settings.h"
 #include "base/process/memory.h"
-#include "brave/components/brave_vpn/app/v2/agent/agent_app.h"
+#include "brave/components/brave_vpn/app/v2/helper/helper_app.h"
 #include "brave/components/brave_vpn/app/v2/shared/app_utils.h"
 #include "build/build_config.h"
 
@@ -34,6 +34,6 @@ int main(int argc, char* argv[]) {
 
   brave_vpn::v2::app_utils::InitLogging(command_line);
 
-  brave_vpn::v2::AgentApp agent_app;
-  return agent_app.Run();
+  brave_vpn::v2::HelperApp helper_app;
+  return helper_app.Run();
 }

--- a/components/brave_vpn/app/v2/helper/win/helper.ver
+++ b/components/brave_vpn/app/v2/helper/win/helper.ver
@@ -1,0 +1,3 @@
+INTERNAL_NAME=brave_vpn_helper_app
+ORIGINAL_FILENAME=brave_vpn_helper_app.exe
+PRODUCT_FULLNAME=Brave Browser VPN Helper

--- a/components/brave_vpn/app/v2/shared/BUILD.gn
+++ b/components/brave_vpn/app/v2/shared/BUILD.gn
@@ -1,0 +1,17 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import("//brave/components/brave_vpn/common/buildflags/buildflags.gni")
+
+assert(enable_brave_vpn_v2)
+
+static_library("shared") {
+  sources = [
+    "app_utils.cc",
+    "app_utils.h",
+  ]
+
+  deps = [ "//base" ]
+}

--- a/components/brave_vpn/app/v2/shared/app_utils.cc
+++ b/components/brave_vpn/app/v2/shared/app_utils.cc
@@ -1,0 +1,33 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/app/v2/shared/app_utils.h"
+
+#include "base/logging.h"
+#include "base/logging/logging_settings.h"
+
+namespace brave_vpn {
+namespace v2 {
+namespace app_utils {
+namespace {
+inline constexpr char kVpnAppLogFile[] = "log-file";
+}
+
+void InitLogging(const base::CommandLine& command_line) {
+  logging::LoggingSettings settings;
+  settings.logging_dest =
+      logging::LOG_TO_SYSTEM_DEBUG_LOG | logging::LOG_TO_STDERR;
+  base::FilePath log_file_path;
+  if (command_line.HasSwitch(kVpnAppLogFile)) {
+    settings.logging_dest |= logging::LOG_TO_FILE;
+    log_file_path = command_line.GetSwitchValuePath(kVpnAppLogFile);
+    settings.log_file_path = log_file_path.value().c_str();
+  }
+  logging::InitLogging(settings);
+}
+
+}  // namespace app_utils
+}  // namespace v2
+}  // namespace brave_vpn

--- a/components/brave_vpn/app/v2/shared/app_utils.h
+++ b/components/brave_vpn/app/v2/shared/app_utils.h
@@ -1,0 +1,21 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_VPN_APP_V2_SHARED_APP_UTILS_H_
+#define BRAVE_COMPONENTS_BRAVE_VPN_APP_V2_SHARED_APP_UTILS_H_
+
+#include "base/command_line.h"
+
+namespace brave_vpn {
+namespace v2 {
+namespace app_utils {
+
+void InitLogging(const base::CommandLine& command_line);
+
+}  // namespace app_utils
+}  // namespace v2
+}  // namespace brave_vpn
+
+#endif  // BRAVE_COMPONENTS_BRAVE_VPN_APP_V2_SHARED_APP_UTILS_H_


### PR DESCRIPTION
Create a stub VPN helper application that can run independently of the browser, in privileged mode. It is supposed to run as a daemon (no UI), and load some external libraries, such as Boringtun shared library. Hence on Mac, the helper is also packed into an app bundle. This also follows the existing Chromium way of bundling helpers on Mac. Code that is shared with an agent app, is extracted from the agent, and placed into a shared directory.

Implements part of https://github.com/brave/brave-browser/issues/54626

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
