### PR TITLE
[Android] Fix sending crash reports to backtrace (uplift to 1.91.x)

### DIFF
--- a/components/minidump_uploader/BUILD.gn
+++ b/components/minidump_uploader/BUILD.gn
@@ -13,8 +13,12 @@ robolectric_library("junit") {
     "//base:base_junit_test_support",
     "//base/version_info/android:version_constants_java",
     "//components/minidump_uploader:minidump_uploader_java",
+    "//components/minidump_uploader:minidump_uploader_java_test_support",
     "//third_party/androidx:androidx_test_runner_java",
     "//third_party/junit",
   ]
-  sources = [ "android/javatests/src/org/chromium/components/minidump_uploader/BraveHttpURLConnectionFactoryImplTest.java" ]
+  sources = [
+    "android/javatests/src/org/chromium/components/minidump_uploader/BraveHttpURLConnectionFactoryImplTest.java",
+    "android/javatests/src/org/chromium/components/minidump_uploader/BraveMinidumpUploaderTest.java",
+  ]
 }

--- a/components/minidump_uploader/android/javatests/src/org/chromium/components/minidump_uploader/BraveMinidumpUploaderTest.java
+++ b/components/minidump_uploader/android/javatests/src/org/chromium/components/minidump_uploader/BraveMinidumpUploaderTest.java
@@ -1,0 +1,88 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.chromium.components.minidump_uploader;
+
+import androidx.test.filters.SmallTest;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.annotation.Config;
+
+import org.chromium.base.test.BaseRobolectricTestRunner;
+import org.chromium.components.minidump_uploader.util.HttpURLConnectionFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+/** Unittest for {@link MinidumpUploader}. */
+@RunWith(BaseRobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public class BraveMinidumpUploaderTest {
+    @Rule public CrashTestRule mTestRule = new CrashTestRule();
+    private File mUploadTestFile;
+
+    // Returns a fixed HTTP error code, without overriding the URL — used to verify
+    // that upload() reaches the HTTP layer under Brave's real sCrashUrlString value.
+    private static class ErrorCodeHttpURLConnectionFactory implements HttpURLConnectionFactory {
+        private final int mErrorCode;
+
+        ErrorCodeHttpURLConnectionFactory(int errorCode) {
+            mErrorCode = errorCode;
+        }
+
+        @Override
+        public HttpURLConnection createHttpURLConnection(String url) {
+            try {
+                return new TestHttpURLConnection(new URL(url)) {
+                    @Override
+                    public int getResponseCode() {
+                        return mErrorCode;
+                    }
+                };
+            } catch (IOException e) {
+                return null;
+            }
+        }
+    }
+
+    @Before
+    public void setUp() throws IOException {
+        // Do NOT call setCrashUrlStringForTesting — we intentionally exercise the real
+        // Brave-patched value so that a future upstream change that nulls the field (or
+        // adds a new precondition) turns into a red test rather than a silent breakage.
+        mUploadTestFile = new File(mTestRule.getCrashDir(), "crashFile");
+        CrashTestRule.setUpMinidumpFile(mUploadTestFile, MinidumpUploaderTestConstants.BOUNDARY);
+    }
+
+    @After
+    public void tearDown() {
+        mUploadTestFile.delete();
+    }
+
+    @Test
+    @SmallTest
+    public void testCrashUrlStringIsBraveEndpoint() {
+        Assert.assertEquals("https://cr.brave.com", MinidumpUploader.sCrashUrlString);
+    }
+
+    @Test
+    @SmallTest
+    public void testUploadReachesHttpLayer() {
+        // If sCrashUrlString is null/empty, or upstream adds a new gate inside upload(),
+        // this will return isFailure() instead of isUploadError() and the test will fail.
+        MinidumpUploader uploader =
+                new MinidumpUploader(new ErrorCodeHttpURLConnectionFactory(500));
+        MinidumpUploader.Result result = uploader.upload(mUploadTestFile);
+        Assert.assertTrue(result.isUploadError());
+        Assert.assertEquals(500, result.errorCode());
+    }
+}

--- a/patches/components-minidump_uploader-android-java-src-org-chromium-components-minidump_uploader-MinidumpUploader.java.patch
+++ b/patches/components-minidump_uploader-android-java-src-org-chromium-components-minidump_uploader-MinidumpUploader.java.patch
@@ -1,0 +1,13 @@
+diff --git a/components/minidump_uploader/android/java/src/org/chromium/components/minidump_uploader/MinidumpUploader.java b/components/minidump_uploader/android/java/src/org/chromium/components/minidump_uploader/MinidumpUploader.java
+index 0a5320818ab90ddef8c0dff54a8183313234e1d9..8f8b82a64a4aea5f1f0d0542668f20c5b408a984 100644
+--- a/components/minidump_uploader/android/java/src/org/chromium/components/minidump_uploader/MinidumpUploader.java
++++ b/components/minidump_uploader/android/java/src/org/chromium/components/minidump_uploader/MinidumpUploader.java
+@@ -30,7 +30,7 @@ import java.util.zip.GZIPOutputStream;
+ @NullMarked
+ public class MinidumpUploader {
+     /* package */ static @Nullable String sCrashUrlString =
+-            BuildConfig.IS_CHROME_BRANDED ? "https://clients2.google.com/cr/report" : null;
++            "https://cr.brave.com";
+ 
+     public static @Nullable String setCrashUrlStringForTesting(@Nullable String url) {
+         @Nullable String oldUrl = sCrashUrlString;


### PR DESCRIPTION
Uplift of #37123
Resolves https://github.com/brave/brave-browser/issues/56226

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.