### PR TITLE
[Wallet]: Migrate Asset Details Menu to use Nala Button Menu

### DIFF
--- a/components/brave_wallet_ui/components/desktop/card-headers/asset-details-header.tsx
+++ b/components/brave_wallet_ui/components/desktop/card-headers/asset-details-header.tsx
@@ -36,7 +36,6 @@ import {
 import { querySubscriptionOptions60s } from '../../../common/slices/constants'
 
 // Hooks
-import { useOnClickOutside } from '../../../common/hooks/useOnClickOutside'
 import useExplorer from '../../../common/hooks/explorer'
 
 // Components
@@ -49,7 +48,6 @@ import { ShieldedLabel } from '../../shared/shielded_label/shielded_label'
 import {
   MenuButton,
   MenuButtonIcon,
-  MenuWrapper,
   HorizontalDivider,
 } from './shared-card-headers.style'
 import {
@@ -99,40 +97,9 @@ export const AssetDetailsHeader = (props: Props) => {
     useGetNetworkQuery(selectedAsset ?? skipToken)
   const { data: defaultFiatCurrency } = useGetDefaultFiatCurrencyQuery()
 
-  // state
-  const [showAssetDetailsMenu, setShowAssetDetailsMenu] =
-    React.useState<boolean>(false)
-
-  // refs
-  const assetDetailsMenuRef = React.useRef<HTMLDivElement>(null)
-
-  // hooks
-  useOnClickOutside(
-    assetDetailsMenuRef,
-    () => setShowAssetDetailsMenu(false),
-    showAssetDetailsMenu,
-  )
-
   const openExplorer = useExplorer(selectedAssetsNetwork)
 
   // methods
-  const handleOnClickHideToken = React.useCallback(() => {
-    setShowAssetDetailsMenu(false)
-    onClickHideToken()
-  }, [onClickHideToken])
-
-  const handleOnClickTokenDetails = React.useCallback(() => {
-    setShowAssetDetailsMenu(false)
-    onClickTokenDetails()
-  }, [onClickTokenDetails])
-
-  const handleOnClickEditToken = React.useCallback(() => {
-    if (onClickEditToken) {
-      setShowAssetDetailsMenu(false)
-      onClickEditToken()
-    }
-  }, [onClickEditToken])
-
   const onClickViewOnExplorer = React.useCallback(() => {
     if (selectedAsset) {
       openExplorer('token', selectedAsset.contractAddress)()
@@ -321,30 +288,23 @@ export const AssetDetailsHeader = (props: Props) => {
                   <HorizontalSpace space='16px' />
                 </>
               )}
-              <MenuWrapper ref={assetDetailsMenuRef}>
+              <AssetDetailsMenu
+                assetSymbol={selectedAsset?.symbol ?? ''}
+                onClickHideToken={onClickHideToken}
+                onClickTokenDetails={onClickTokenDetails}
+                onClickViewOnExplorer={onClickViewOnExplorer}
+                onClickEditToken={onClickEditToken}
+              >
                 {isMobileOrPanel ? (
-                  <Button
-                    onClick={() => setShowAssetDetailsMenu((prev) => !prev)}
-                  >
+                  <Button slot='anchor-content'>
                     <ButtonIcon name='more-vertical' />
                   </Button>
                 ) : (
-                  <MenuButton
-                    onClick={() => setShowAssetDetailsMenu((prev) => !prev)}
-                  >
+                  <MenuButton slot='anchor-content'>
                     <MenuButtonIcon name='more-vertical' />
                   </MenuButton>
                 )}
-                {showAssetDetailsMenu && (
-                  <AssetDetailsMenu
-                    assetSymbol={selectedAsset?.symbol ?? ''}
-                    onClickHideToken={handleOnClickHideToken}
-                    onClickTokenDetails={handleOnClickTokenDetails}
-                    onClickViewOnExplorer={onClickViewOnExplorer}
-                    onClickEditToken={handleOnClickEditToken}
-                  />
-                )}
-              </MenuWrapper>
+              </AssetDetailsMenu>
             </>
           )}
       </Row>

--- a/components/brave_wallet_ui/components/desktop/wallet-menus/asset-details-menu.tsx
+++ b/components/brave_wallet_ui/components/desktop/wallet-menus/asset-details-menu.tsx
@@ -4,18 +4,15 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import * as React from 'react'
+import Icon from '@brave/leo/react/icon'
 
 import { getLocale } from '../../../../common/locale'
 
 // Styled Components
-import {
-  StyledWrapper,
-  PopupButton,
-  PopupButtonText,
-  ButtonIcon,
-} from './wellet-menus.style'
+import { ButtonMenu } from './wellet-menus.style'
 
 interface Props {
+  children: React.ReactNode
   assetSymbol: string
   onClickTokenDetails: () => void
   onClickViewOnExplorer: () => void
@@ -25,6 +22,7 @@ interface Props {
 
 export const AssetDetailsMenu = (props: Props) => {
   const {
+    children,
     assetSymbol,
     onClickTokenDetails,
     onClickViewOnExplorer,
@@ -33,36 +31,29 @@ export const AssetDetailsMenu = (props: Props) => {
   } = props
 
   return (
-    <StyledWrapper yPosition={42}>
-      <PopupButton onClick={onClickTokenDetails}>
-        <ButtonIcon name='info-outline' />
-        <PopupButtonText>
-          {getLocale('braveWalletPortfolioTokenDetailsMenuLabel')}
-        </PopupButtonText>
-      </PopupButton>
+    <ButtonMenu placement='bottom-end'>
+      {children}
+      <leo-menu-item onClick={onClickTokenDetails}>
+        <Icon name='info-outline' />
+        {getLocale('braveWalletPortfolioTokenDetailsMenuLabel')}
+      </leo-menu-item>
       {onClickEditToken && (
-        <PopupButton onClick={onClickEditToken}>
-          <ButtonIcon name='edit-pencil' />
-          <PopupButtonText>
-            {getLocale('braveWalletAllowSpendEditButton')}
-          </PopupButtonText>
-        </PopupButton>
+        <leo-menu-item onClick={onClickEditToken}>
+          <Icon name='edit-pencil' />
+          {getLocale('braveWalletAllowSpendEditButton')}
+        </leo-menu-item>
       )}
-      <PopupButton onClick={onClickViewOnExplorer}>
-        <ButtonIcon name='launch' />
-        <PopupButtonText>
-          {getLocale('braveWalletPortfolioViewOnExplorerMenuLabel')}
-        </PopupButtonText>
-      </PopupButton>
-      <PopupButton onClick={onClickHideToken}>
-        <ButtonIcon name='trash' />
-        <PopupButtonText>
-          {getLocale('braveWalletPortfolioHideTokenMenuLabel').replace(
-            '$1',
-            assetSymbol,
-          )}
-        </PopupButtonText>
-      </PopupButton>
-    </StyledWrapper>
+      <leo-menu-item onClick={onClickViewOnExplorer}>
+        <Icon name='launch' />
+        {getLocale('braveWalletPortfolioViewOnExplorerMenuLabel')}
+      </leo-menu-item>
+      <leo-menu-item onClick={onClickHideToken}>
+        <Icon name='trash' />
+        {getLocale('braveWalletPortfolioHideTokenMenuLabel').replace(
+          '$1',
+          assetSymbol,
+        )}
+      </leo-menu-item>
+    </ButtonMenu>
   )
 }


### PR DESCRIPTION
## Description 

Migrates the `Asset Details Menu` to use the Nala `Button Menu` component

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/56240>

Before:

<img width="402" height="661" alt="Screenshot 9" src="https://github.com/user-attachments/assets/8a84038a-d50e-42bd-b9ba-9cb9e6e59921" /> | <img width="338" height="359" alt="Screenshot 10" src="https://github.com/user-attachments/assets/59b7078f-0e3d-4b6d-b813-f6a0bc718d99" />
--|--

After:

<img width="398" height="661" alt="Screenshot 11" src="https://github.com/user-attachments/assets/82523c24-896f-47c5-87f8-a30c7e684920" /> | <img width="316" height="329" alt="Screenshot 12" src="https://github.com/user-attachments/assets/2e5dff6d-c62e-4367-8b9d-108d9174133c" />
--|--


<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

## Test Plan:
1. The `Asset Details Menu` should continue to work as expected.