### PR TITLE
[Android] Fix home-screen PWA/shortcut icons disappearing after reboot

### DIFF
--- a/android/brave_java_sources.gni
+++ b/android/brave_java_sources.gni
@@ -36,6 +36,7 @@ brave_java_sources = [
   "../../brave/android/java/org/chromium/chrome/browser/BraveLandscapeHelper.java",
   "../../brave/android/java/org/chromium/chrome/browser/BraveLaunchIntentDispatcher.java",
   "../../brave/android/java/org/chromium/chrome/browser/BraveLocalState.java",
+  "../../brave/android/java/org/chromium/chrome/browser/BravePwaShortcutIconHelper.java",
   "../../brave/android/java/org/chromium/chrome/browser/BraveRelaunchUtils.java",
   "../../brave/android/java/org/chromium/chrome/browser/BraveRewardsBalance.java",
   "../../brave/android/java/org/chromium/chrome/browser/BraveRewardsExternalWallet.java",

--- a/android/java/org/chromium/chrome/browser/BravePwaShortcutIconHelper.java
+++ b/android/java/org/chromium/chrome/browser/BravePwaShortcutIconHelper.java
@@ -1,0 +1,74 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.chromium.chrome.browser;
+
+import android.graphics.Bitmap;
+
+import androidx.annotation.VisibleForTesting;
+
+import org.chromium.build.annotations.NullMarked;
+import org.chromium.build.annotations.Nullable;
+import org.chromium.chrome.browser.browserservices.intents.BitmapHelper;
+
+/**
+ * Helper that bounds the size of a PWA icon before it is base64-encoded into a pinned-shortcut
+ * Intent.
+ *
+ * <p>On Android 12+ the system ShortcutService persists pinned shortcuts as Binary XML, where every
+ * string is capped at 65535 bytes. A high-resolution icon's base64 string overflows that cap, the
+ * whole package XML write fails atomically, and ALL of Brave's pinned shortcuts get dropped on the
+ * next reboot. Chrome avoids this by minting WebAPKs (icons live in APK drawables), a Google-only
+ * backend Brave cannot use, so Brave falls back to the legacy webapp-shortcut path that carries the
+ * icon in the Intent.
+ *
+ * <p>Downscaling here keeps the encoded icon under the limit. Only the in-Intent copy shrinks; the
+ * home-screen glyph is a separate full-resolution Bitmap and is unaffected. The MAC stays
+ * consistent because it is computed over this same encoded string.
+ */
+@NullMarked
+public class BravePwaShortcutIconHelper {
+    // Keep the encoded icon comfortably below the 65535-byte Binary XML string
+    // limit to leave headroom for the rest of the shortcut's persisted strings.
+    @VisibleForTesting static final int MAX_ENCODED_ICON_CHARS = 60000;
+
+    // Floor so the in-app icon stays recognizable even for pathological inputs.
+    @VisibleForTesting static final int MIN_ICON_SIZE_PX = 48;
+
+    // Bound on shrink iterations; convergence is fast but guard against edge
+    // cases (e.g. incompressible noise) where a single pass is not enough.
+    private static final int MAX_ATTEMPTS = 10;
+
+    /**
+     * Encodes {@code bitmap} as a base64 PNG string like {@link
+     * BitmapHelper#encodeBitmapAsString(Bitmap)}, downscaling first if needed so the result fits
+     * within the ShortcutService Binary XML string limit.
+     *
+     * @param bitmap The icon to encode, may be null.
+     * @return the base64-encoded (and possibly downscaled) icon string.
+     */
+    public static String encodeDownscaledBitmapAsString(@Nullable Bitmap bitmap) {
+        if (bitmap == null) return "";
+
+        String encoded = BitmapHelper.encodeBitmapAsString(bitmap);
+        int width = bitmap.getWidth();
+        int height = bitmap.getHeight();
+        for (int attempt = 0;
+                attempt < MAX_ATTEMPTS
+                        && encoded.length() > MAX_ENCODED_ICON_CHARS
+                        && width > MIN_ICON_SIZE_PX
+                        && height > MIN_ICON_SIZE_PX;
+                attempt++) {
+            // Scale proportionally to the overage (base64 length tracks pixel
+            // count) so we converge in a couple of passes, then re-encode.
+            double ratio = Math.sqrt((double) MAX_ENCODED_ICON_CHARS / encoded.length());
+            width = Math.max(MIN_ICON_SIZE_PX, (int) (width * ratio));
+            height = Math.max(MIN_ICON_SIZE_PX, (int) (height * ratio));
+            Bitmap scaled = Bitmap.createScaledBitmap(bitmap, width, height, true);
+            encoded = BitmapHelper.encodeBitmapAsString(scaled);
+        }
+        return encoded;
+    }
+}

--- a/android/junit/BUILD.gn
+++ b/android/junit/BUILD.gn
@@ -107,8 +107,10 @@ if (is_android) {
   }
 
   robolectric_library("brave_junit_tests_org.chromium.chrome.browser") {
-    sources =
-        [ "src/org/chromium/chrome/browser/BraveIntentHandlerUnitTest.java" ]
+    sources = [
+      "src/org/chromium/chrome/browser/BraveIntentHandlerUnitTest.java",
+      "src/org/chromium/chrome/browser/BravePwaShortcutIconHelperTest.java",
+    ]
 
     deps = [ "//chrome/android/junit:chrome_junit_tests_helper" ]
   }

--- a/android/junit/src/org/chromium/chrome/browser/BravePwaShortcutIconHelperTest.java
+++ b/android/junit/src/org/chromium/chrome/browser/BravePwaShortcutIconHelperTest.java
@@ -1,0 +1,169 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.chromium.chrome.browser;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import android.graphics.Bitmap;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.annotation.Config;
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+import org.robolectric.shadow.api.Shadow;
+
+import org.chromium.base.test.BaseRobolectricTestRunner;
+import org.chromium.chrome.browser.browserservices.intents.BitmapHelper;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * Unit tests for {@link BravePwaShortcutIconHelper#encodeDownscaledBitmapAsString}.
+ *
+ * <p>Robolectric's default Bitmap shadow does not produce a compressed stream whose size tracks
+ * pixel count, so the downscale loop would never engage. These tests install {@link
+ * ShadowSizedBitmap}, which models compressed output as a fixed number of bytes per pixel — the
+ * real-world relationship the helper relies on — making the behaviour deterministic.
+ */
+@RunWith(BaseRobolectricTestRunner.class)
+@Config(shadows = {BravePwaShortcutIconHelperTest.ShadowSizedBitmap.class})
+public class BravePwaShortcutIconHelperTest {
+    // The helper's own contract: it caps the encoded icon at MAX_ENCODED_ICON_CHARS
+    // (which sits below the 65535-byte ShortcutService Binary-XML limit) and never
+    // shrinks an icon below MIN_ICON_SIZE_PX.
+    private static final int MAX_ENCODED_ICON_CHARS =
+            BravePwaShortcutIconHelper.MAX_ENCODED_ICON_CHARS;
+    private static final int MIN_ICON_SIZE_PX = BravePwaShortcutIconHelper.MIN_ICON_SIZE_PX;
+
+    @Before
+    public void setUp() {
+        ShadowSizedBitmap.reset();
+    }
+
+    @Test
+    public void testNullBitmapReturnsEmptyString() {
+        assertEquals("", BravePwaShortcutIconHelper.encodeDownscaledBitmapAsString(null));
+    }
+
+    @Test
+    public void testSmallIconPassesThroughUnchanged() {
+        // A 96x96 icon encodes well under the limit, so it must not be scaled and
+        // must match the plain encoding byte-for-byte.
+        Bitmap icon = Bitmap.createBitmap(96, 96, Bitmap.Config.ARGB_8888);
+        String result = BravePwaShortcutIconHelper.encodeDownscaledBitmapAsString(icon);
+
+        assertEquals(BitmapHelper.encodeBitmapAsString(icon), result);
+        assertEquals("no downscale should occur", 0, ShadowSizedBitmap.sScaleCalls);
+    }
+
+    @Test
+    public void testOversizedIconIsDownscaledUnderLimit() {
+        // A 512x512 icon at 1 byte/pixel encodes far over the limit; the helper
+        // must shrink it until the encoded string fits, without dropping below
+        // the floor.
+        Bitmap icon = Bitmap.createBitmap(512, 512, Bitmap.Config.ARGB_8888);
+        String before = BitmapHelper.encodeBitmapAsString(icon);
+        assertTrue(
+                "precondition: input must exceed the cap",
+                before.length() > MAX_ENCODED_ICON_CHARS);
+
+        String result = BravePwaShortcutIconHelper.encodeDownscaledBitmapAsString(icon);
+
+        assertTrue(
+                "encoded icon must fit under the cap", result.length() <= MAX_ENCODED_ICON_CHARS);
+        assertTrue("downscale must have happened", ShadowSizedBitmap.sScaleCalls > 0);
+        assertTrue(
+                "output must stay at/above the floor",
+                ShadowSizedBitmap.sLastWidth >= MIN_ICON_SIZE_PX);
+        assertTrue("output must be smaller than the input", ShadowSizedBitmap.sLastWidth < 512);
+        assertNotEquals(before, result);
+    }
+
+    @Test
+    public void testPathologicalIconClampsToFloorAndTerminates() {
+        // 30 bytes/pixel keeps even a 48x48 icon over the limit, forcing the
+        // helper down to the floor. It must stop there (not loop forever) and
+        // never produce a sub-floor icon.
+        ShadowSizedBitmap.sBytesPerPixel = 30;
+        Bitmap icon = Bitmap.createBitmap(256, 256, Bitmap.Config.ARGB_8888);
+
+        String result = BravePwaShortcutIconHelper.encodeDownscaledBitmapAsString(icon);
+
+        assertTrue("must not return empty for a valid bitmap", result.length() > 0);
+        assertEquals(
+                "must clamp to the floor width", MIN_ICON_SIZE_PX, ShadowSizedBitmap.sLastWidth);
+        assertEquals(
+                "must clamp to the floor height", MIN_ICON_SIZE_PX, ShadowSizedBitmap.sLastHeight);
+    }
+
+    /**
+     * Bitmap shadow whose compressed size is {@code width * height * sBytesPerPixel} bytes, so the
+     * encoded length tracks pixel count the way an incompressible (e.g. random-noise) PNG icon does
+     * in practice. Also records the most recently created bitmap's dimensions and the number of
+     * scale operations so tests can assert on the loop's behaviour.
+     */
+    @Implements(Bitmap.class)
+    public static class ShadowSizedBitmap {
+        public static int sBytesPerPixel;
+        public static int sLastWidth;
+        public static int sLastHeight;
+        public static int sScaleCalls;
+
+        private int mWidth;
+        private int mHeight;
+
+        public static void reset() {
+            sBytesPerPixel = 1;
+            sLastWidth = 0;
+            sLastHeight = 0;
+            sScaleCalls = 0;
+        }
+
+        @Implementation
+        protected static Bitmap createBitmap(int width, int height, Bitmap.Config config) {
+            Bitmap bitmap = Shadow.newInstanceOf(Bitmap.class);
+            ShadowSizedBitmap shadow = Shadow.extract(bitmap);
+            shadow.mWidth = width;
+            shadow.mHeight = height;
+            sLastWidth = width;
+            sLastHeight = height;
+            return bitmap;
+        }
+
+        @Implementation
+        protected static Bitmap createScaledBitmap(
+                Bitmap src, int dstWidth, int dstHeight, boolean filter) {
+            sScaleCalls++;
+            return createBitmap(dstWidth, dstHeight, Bitmap.Config.ARGB_8888);
+        }
+
+        @Implementation
+        protected int getWidth() {
+            return mWidth;
+        }
+
+        @Implementation
+        protected int getHeight() {
+            return mHeight;
+        }
+
+        @Implementation
+        protected boolean compress(Bitmap.CompressFormat format, int quality, OutputStream stream) {
+            int byteCount = mWidth * mHeight * sBytesPerPixel;
+            try {
+                stream.write(new byte[byteCount]);
+            } catch (IOException e) {
+                return false;
+            }
+            return true;
+        }
+    }
+}

--- a/patches/chrome-android-java-src-org-chromium-chrome-browser-ShortcutHelper.java.patch
+++ b/patches/chrome-android-java-src-org-chromium-chrome-browser-ShortcutHelper.java.patch
@@ -1,0 +1,13 @@
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/ShortcutHelper.java b/chrome/android/java/src/org/chromium/chrome/browser/ShortcutHelper.java
+index 55b6365710f09f7c9e74fc0e511191c81e210650..4860b943cbef438847832977346e105889cf623f 100644
+--- a/chrome/android/java/src/org/chromium/chrome/browser/ShortcutHelper.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/ShortcutHelper.java
+@@ -110,7 +110,7 @@ public class ShortcutHelper {
+                 // Encoding {@link icon} as a string and computing the mac are expensive.
+ 
+                 // Encode the icon as a base64 string (Launcher drops Bitmaps in the Intent).
+-                String encodedIcon = BitmapHelper.encodeBitmapAsString(icon);
++                String encodedIcon = BravePwaShortcutIconHelper.encodeDownscaledBitmapAsString(icon);
+ 
+                 // TODO(http://crbug.com/40097069): Use action which does not require mac on O+
+                 Intent shortcutIntent =


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/52423

## 🐛 Problem
On Android, icons added via **"Add to Home screen"** — both installed **PWAs** and plain **shortcuts** — **vanish after a reboot**. They appear fine, then disappear on restart. Reproduced across several brands/launchers (Oppo, Xiaomi, Pixel…), on stock **and** third-party launchers (Nova). **Chrome on the same device is unaffected.**

## 🔍 Root cause
Brave doesn't mint WebAPKs, so "Add to Home screen" always pins a shortcut via `ShortcutManager`. Android persists the shortcut's launch `Intent` extras as **Android Binary XML**, where each serialized string is capped at **65535 bytes** (modified UTF-8). The icon is stored as a base64 string in `WebappConstants.EXTRA_ICON`; a high-res icon overflows that cap, so `ShortcutService` fails to write the package file and **drops every Brave shortcut** on the next reboot:

```
ShortcutService: Failed to write to file .../com.brave.browser.xml
java.io.IOException: Modified UTF-8 length too large: -83039
  PersistableBundle.saveToXml → ShortcutService.writeTagExtra → ShortcutPackage.saveShortcut
```

The icon shows briefly because `requestPinShortcut()` adds it to the launcher's in-memory list first; the on-disk write fails, so it's gone after reboot. As the file is **per-package**, one oversized PWA icon also takes down co-existing plain shortcuts (→ both disappear). Chrome avoids this by installing real WebAPKs, which never go through `ShortcutService`.

## 🛠️ Fix
Route the pinned-shortcut icon through a new `BravePwaShortcutIconHelper` that **calls the upstream `BitmapHelper.encodeBitmapAsString()`** and **downscales the bitmap only when its base64 would otherwise exceed the limit** (floored at 48px). Only the in-Intent copy shrinks — the home-screen glyph is a separate full-res `Bitmap` and is unaffected, and the MAC stays consistent (computed over the same encoded string). Applied via a direct patch to `ShortcutHelper.java`, with unit tests covering the helper.

## ✅ Testing
Built locally (`arm64`, Debug) and **tested on a physical Oppo Reno 13 Pro (Android 16)**:
- Added a **PWA** ("Install") **and** a **plain shortcut** ("Add to Home screen") → **rebooted** → **both survive** ✅
- Before this change, both **vanished** after reboot.
- Same result on the **Oppo stock launcher** and **Nova Launcher**.

(@SergeyZhukovsky also reproduced the failure on a Pixel with a large icon 🙏)

## 📝 Notes
- Minimal: no behavior change unless the encoded icon would exceed the limit.
- A floor on the downscale keeps the splash/stored icon reasonable.
- Happy to adjust the implementation as needed before merge.