### PR TITLE
[Wallet]: Migrate Address Actions Menu to use Nala Button Menu

### DIFF
--- a/components/brave_wallet_ui/components/desktop/wallet-menus/address_actions_menu.style.ts
+++ b/components/brave_wallet_ui/components/desktop/wallet-menus/address_actions_menu.style.ts
@@ -10,13 +10,6 @@ import {
   layoutPanelWidth, //
 } from '../wallet-page-wrapper/wallet-page-wrapper.style'
 
-export const AddressMenuWrapper = styled.div`
-  flex: 1;
-  position: relative;
-  display: flex;
-  height: 100%;
-`
-
 export const Button = styled.button`
   flex: 1;
   display: flex;

--- a/components/brave_wallet_ui/components/desktop/wallet-menus/address_actions_menu.tsx
+++ b/components/brave_wallet_ui/components/desktop/wallet-menus/address_actions_menu.tsx
@@ -5,6 +5,7 @@
 
 import * as React from 'react'
 import { showAlert } from '@brave/leo/react/alertCenter'
+import Icon from '@brave/leo/react/icon'
 
 // Types
 import { BraveWallet } from '../../../constants/types'
@@ -12,12 +13,6 @@ import { BraveWallet } from '../../../constants/types'
 // Utils
 import { getLocale } from '../../../../common/locale'
 import { copyToClipboard } from '../../../utils/copy-to-clipboard'
-
-// Selectors
-import {
-  useSafeUISelector, //
-} from '../../../common/hooks/use-safe-selector'
-import { UISelectors } from '../../../common/selectors'
 
 // Hooks
 import {
@@ -32,11 +27,10 @@ import {
   ViewOnBlockExplorerModal, //
 } from '../popup-modals/view_on_block_explorer_modal/view_on_block_explorer_modal'
 import { PopupModal } from '../popup-modals'
-import { MenuWrapper } from './menu_wrapper'
 
 // Styled Components
-import { PopupButton, PopupButtonText, ButtonIcon } from './wellet-menus.style'
-import { AddressMenuWrapper, Button } from './address_actions_menu.style'
+import { ButtonMenu } from './wellet-menus.style'
+import { Button } from './address_actions_menu.style'
 import { VerticalDivider, Column } from '../../shared/style'
 
 export interface Props {
@@ -47,22 +41,16 @@ export interface Props {
 export const AddressActionsMenu = (props: Props) => {
   const { account, children } = props
 
-  const isPanel = useSafeUISelector(UISelectors.isPanel)
-  const isMobile = useSafeUISelector(UISelectors.isMobile)
-
   // State
-  const [showMenu, setShowMenu] = React.useState(false)
   const [showDepositModal, setShowDepositModal] = React.useState(false)
   const [showViewOnExplorerModal, setShowViewOnExplorerModal] =
     React.useState(false)
 
   // Refs
-  const menuRef = React.useRef<HTMLDivElement>(null)
   const depositModalRef = React.useRef<HTMLDivElement>(null)
   const viewOnExplorerModalRef = React.useRef<HTMLDivElement>(null)
 
   // Hooks
-  useOnClickOutside(menuRef, () => setShowMenu(false), showMenu)
   useOnClickOutside(
     depositModalRef,
     () => setShowDepositModal(false),
@@ -75,7 +63,6 @@ export const AddressActionsMenu = (props: Props) => {
   )
 
   const handleCopyAddress = () => {
-    setShowMenu(false)
     copyToClipboard(account.address)
     showAlert({
       type: 'success',
@@ -86,44 +73,21 @@ export const AddressActionsMenu = (props: Props) => {
 
   return (
     <>
-      <AddressMenuWrapper ref={menuRef}>
-        <Button onClick={() => setShowMenu((prev) => !prev)}>{children}</Button>
-        {showMenu && (
-          <MenuWrapper
-            yPosition={isPanel || isMobile ? 26 : 46}
-            left={0}
-          >
-            <PopupButton onClick={handleCopyAddress}>
-              <ButtonIcon name='copy' />
-              <PopupButtonText>
-                {getLocale('braveWalletButtonCopy')}
-              </PopupButtonText>
-            </PopupButton>
-            <PopupButton
-              onClick={() => {
-                setShowDepositModal(true)
-                setShowMenu(false)
-              }}
-            >
-              <ButtonIcon name='qr-code-alternative' />
-              <PopupButtonText>
-                {getLocale('braveWalletDepositCryptoButton')}
-              </PopupButtonText>
-            </PopupButton>
-            <PopupButton
-              onClick={() => {
-                setShowViewOnExplorerModal(true)
-                setShowMenu(false)
-              }}
-            >
-              <ButtonIcon name='web3-blockexplorer' />
-              <PopupButtonText>
-                {getLocale('braveWalletPortfolioViewOnExplorerMenuLabel')}
-              </PopupButtonText>
-            </PopupButton>
-          </MenuWrapper>
-        )}
-      </AddressMenuWrapper>
+      <ButtonMenu placement='bottom-start'>
+        <Button slot='anchor-content'>{children}</Button>
+        <leo-menu-item onClick={handleCopyAddress}>
+          <Icon name='copy' />
+          {getLocale('braveWalletButtonCopy')}
+        </leo-menu-item>
+        <leo-menu-item onClick={() => setShowDepositModal(true)}>
+          <Icon name='qr-code-alternative' />
+          {getLocale('braveWalletDepositCryptoButton')}
+        </leo-menu-item>
+        <leo-menu-item onClick={() => setShowViewOnExplorerModal(true)}>
+          <Icon name='web3-blockexplorer' />
+          {getLocale('braveWalletPortfolioViewOnExplorerMenuLabel')}
+        </leo-menu-item>
+      </ButtonMenu>
       {showDepositModal && (
         <PopupModal
           title={getLocale('braveWalletDepositCryptoButton')}


### PR DESCRIPTION
## Description 

Migrates the `Address Actions Menu` to use the Nala `Button Menu` component

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/56245>

Before and After:

<img width="405" height="255" alt="Screenshot 18" src="https://github.com/user-attachments/assets/3a08752c-d1b5-489d-9e10-baf33d4434ce" /> | <img width="416" height="255" alt="Screenshot 19" src="https://github.com/user-attachments/assets/c7f896fa-876c-4774-a9bb-a8189bf77f67" />
--|--

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

## Test Plan:
1. The `Address Actions Menu` should continue to work as expected.