### PR TITLE
[Sidebar V2] Consider panel visibility also for contents's bottom radius

### DIFF
--- a/browser/ui/views/frame/BUILD.gn
+++ b/browser/ui/views/frame/BUILD.gn
@@ -95,6 +95,8 @@ source_set("browser_tests") {
     ":frame",
     ":frame_impl",
     "//base",
+    "//brave/browser/ui/sidebar:sidebar_impl",
+    "//brave/browser/ui/sidebar/buildflags",
     "//brave/browser/ui/views/frame/vertical_tabs",
     "//brave/browser/ui/views/sidebar",
     "//brave/components/brave_origin/buildflags",

--- a/browser/ui/views/frame/brave_browser_view_browsertest.cc
+++ b/browser/ui/views/frame/brave_browser_view_browsertest.cc
@@ -12,6 +12,8 @@
 #include "base/test/scoped_feature_list.h"
 #include "brave/browser/ui/bookmark/bookmark_helper.h"
 #include "brave/browser/ui/browser_commands.h"
+#include "brave/browser/ui/sidebar/buildflags/buildflags.h"
+#include "brave/browser/ui/sidebar/sidebar_service_factory.h"
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
 #include "brave/browser/ui/views/frame/brave_browser_view.h"
 #include "brave/browser/ui/views/frame/brave_contents_view_util.h"
@@ -22,6 +24,7 @@
 #include "brave/common/pref_names.h"
 #include "brave/components/brave_origin/buildflags/buildflags.h"
 #include "brave/components/constants/pref_names.h"
+#include "brave/components/sidebar/browser/sidebar_service.h"
 #include "build/build_config.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser_commands.h"
@@ -46,6 +49,7 @@
 #include "chrome/browser/ui/views/frame/scrim_view.h"
 #include "chrome/browser/ui/views/frame/top_container_view.h"
 #include "chrome/browser/ui/views/infobars/infobar_container_view.h"
+#include "chrome/common/pref_names.h"
 #include "chrome/test/base/in_process_browser_test.h"
 #include "components/prefs/pref_service.h"
 #include "content/public/browser/web_contents.h"
@@ -404,6 +408,78 @@ IN_PROC_BROWSER_TEST_P(BraveBrowserViewWithRoundedCornersTest,
                                           ->GetBackgroundRadii());
   }
 }
+
+// Regression test: In Sidebar V2 the Chromium side panel can be visible while
+// IsSidebarVisible() is false. Verify that the lower corner adjacent to the
+// panel still uses the border radius in that case.
+#if BUILDFLAG(ENABLE_SIDEBAR_V2)
+IN_PROC_BROWSER_TEST_P(
+    BraveBrowserViewWithRoundedCornersTest,
+    RoundedCornersWithSidePanelVisibleButSidebarControlViewHiddenTest) {
+#if BUILDFLAG(IS_MAC)
+  // TODO(https://github.com/brave/brave-browser/issues/55995): Re-enable on
+  // macOS 26.
+  if (base::mac::MacOSMajorVersion() == 26) {
+    GTEST_SKIP() << "Disabled on macOS Tahoe.";
+  }
+#endif
+
+  const auto border_radius = GetRoundedCornersBorderRadius();
+  const auto window_corner_radius =
+      GetRoundedCornersBorderRadiusAtWindowCorner();
+  auto* prefs = browser()->profile()->GetPrefs();
+
+  // Hide the sidebar so IsSidebarVisible() returns false, isolating the
+  // side_panel()->GetVisible() branch of GetRoundedCornersForContentsView().
+  sidebar::SidebarServiceFactory::GetForProfile(browser()->profile())
+      ->SetSidebarShowOption(
+          sidebar::SidebarService::ShowSidebarOption::kShowNever);
+  RunScheduledLayouts();
+
+  // Baseline: no panel, no sidebar -> both lower corners use window radius.
+  EXPECT_FALSE(brave_browser_view()->IsSidebarVisible());
+  if (IsRoundedCornersEnabled()) {
+    ExpectContentsViewRadii(border_radius, border_radius, window_corner_radius,
+                            window_corner_radius);
+  }
+
+  auto* panel_ui = browser()->GetFeatures().side_panel_ui();
+
+  // --- Right-aligned panel (default: kSidePanelHorizontalAlignment = true) ---
+  panel_ui->Toggle();
+  RunScheduledLayouts();
+
+  ASSERT_TRUE(browser_view()->side_panel()->GetVisible());
+  EXPECT_FALSE(brave_browser_view()->IsSidebarVisible());
+
+  if (IsRoundedCornersEnabled()) {
+    // Panel is on the right -> lower-right rounded, lower-left at window edge.
+    ExpectContentsViewRadii(border_radius, border_radius, window_corner_radius,
+                            border_radius);
+  } else {
+    ExpectContentsViewRadii(0, 0, 0, 0);
+  }
+
+  panel_ui->Toggle();
+  RunScheduledLayouts();
+
+  // --- Left-aligned panel (kSidePanelHorizontalAlignment = false) ---
+  prefs->SetBoolean(prefs::kSidePanelHorizontalAlignment, false);
+  panel_ui->Toggle();
+  RunScheduledLayouts();
+
+  ASSERT_TRUE(browser_view()->side_panel()->GetVisible());
+  EXPECT_FALSE(brave_browser_view()->IsSidebarVisible());
+
+  if (IsRoundedCornersEnabled()) {
+    // Panel is on the left -> lower-left rounded, lower-right at window edge.
+    ExpectContentsViewRadii(border_radius, border_radius, border_radius,
+                            window_corner_radius);
+  } else {
+    ExpectContentsViewRadii(0, 0, 0, 0);
+  }
+}
+#endif  // BUILDFLAG(ENABLE_SIDEBAR_V2)
 
 // Test 2: Rounded corners in split tab mode
 IN_PROC_BROWSER_TEST_P(BraveBrowserViewWithRoundedCornersTest,

--- a/browser/ui/views/frame/brave_contents_view_util.cc
+++ b/browser/ui/views/frame/brave_contents_view_util.cc
@@ -116,7 +116,18 @@ gfx::RoundedCornersF BraveContentsViewUtil::GetRoundedCornersForContentsView(
     }
   }
 
-  if (browser_view->IsSidebarVisible()) {
+  // In V2, checking sidebar UI only is not sufficient because panel could be
+  // visible alone. Below works on both(V1 and V2) because side_panel() is null
+  // in V2.
+  // TODO(https://github.com/brave/brave-browser/issues/56248): Rethink the
+  // naming convention for V2. The current names will become inaccurate. For
+  // instance, IsSidebarVisible() works fine in V1 because the container view
+  // includes both the sidebar control UI and the panel. But in V2, the panel is
+  // separated from the container view, so IsSidebarVisible() will no longer
+  // return an accurate value.
+  if (browser_view->IsSidebarVisible() ||
+      (browser_view->side_panel() &&
+       browser_view->side_panel()->GetVisible())) {
     if (browser_window_interface->GetProfile()->GetPrefs()->GetBoolean(
             prefs::kSidePanelHorizontalAlignment)) {
       has_right_side_ui = true;


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves no issue - use umbrella issue (https://github.com/brave/brave-browser/issues/51462)

Don't use window-corner radius to web contents when panel or sidebar UI(control view) are visible.

TEST=RoundedCornersWithSidePanelVisibleButSidebarControlViewHiddenTest

Use non window-corner radius: fixed by this PR
<img width="600" alt="image" src="https://github.com/user-attachments/assets/e7280d8d-f3f2-495b-9723-afa2d8e33410" />

Use window-corner radius: existing behavior
<img width="200" alt="image" src="https://github.com/user-attachments/assets/3bbbc88e-5f91-4815-843c-596440172074" />

Use non window-corner radius: existing behavior
<img width="200" alt="image" src="https://github.com/user-attachments/assets/fe719e9d-6039-4295-a70b-6f904f2d2e57" />

Use non window-corner radius: existing behavior
<img width="600" alt="image" src="https://github.com/user-attachments/assets/37b19e8b-9f4e-4d26-9cfd-d767915f3934" />


<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
