### PR TITLE
[Brave News]: Add sync support

### DIFF
--- a/chromium_src/chrome/browser/sync/prefs/chrome_syncable_prefs_database.cc
+++ b/chromium_src/chrome/browser/sync/prefs/chrome_syncable_prefs_database.cc
@@ -47,6 +47,16 @@ enum {
   kProfileContentSettingsPartitionedExceptionsFingerprintingV2 = 300027,
   kProfileContentSettingsPartitionedExceptionsBraveShields = 300028,
   kProfileContentSettingsPartitionedExceptionsBraveSpeedreader = 300029,
+  // Brave News prefs (mirrors
+  // brave/components/brave_news/common/pref_names.h). Synced as part of the
+  // "Settings" (PREFERENCES) sync type.
+  kBraveNewsShouldShowToolbarButton = 300030,
+  kBraveNewsNewTabPageShowToday = 300031,
+  kBraveNewsOptedIn = 300032,
+  kBraveNewsSources = 300033,
+  kBraveNewsChannels = 300034,
+  kBraveNewsDirectFeeds = 300035,
+  kBraveNewsOpenArticlesInNewTab = 300036,
 };
 }  // namespace brave_syncable_prefs_ids
 
@@ -197,6 +207,42 @@ const auto& BraveSyncablePreferences() {
             kProfileContentSettingsPartitionedExceptionsTrackers,
         syncer::PREFERENCES, sync_preferences::PrefSensitivity::kNone,
         sync_preferences::MergeBehavior::kMergeableDict}},
+      // Brave News prefs (mirrors
+      // brave/components/brave_news/common/pref_names.h).
+      {"brave.today.should_show_toolbar_button",
+       {brave_syncable_prefs_ids::kBraveNewsShouldShowToolbarButton,
+        syncer::PREFERENCES, sync_preferences::PrefSensitivity::kNone,
+        sync_preferences::MergeBehavior::kNone}},
+      {"brave.new_tab_page.show_brave_news",
+       {brave_syncable_prefs_ids::kBraveNewsNewTabPageShowToday,
+        syncer::PREFERENCES, sync_preferences::PrefSensitivity::kNone,
+        sync_preferences::MergeBehavior::kNone}},
+      {"brave.today.opted_in",
+       {brave_syncable_prefs_ids::kBraveNewsOptedIn, syncer::PREFERENCES,
+        sync_preferences::PrefSensitivity::kNone,
+        sync_preferences::MergeBehavior::kNone}},
+      // These dicts hold mutable subscription state (toggles and removals), not
+      // just additions. A per-key union merge (kMergeableDict) is additive and
+      // resolves conflicts in favor of the account value, so toggles get
+      // reverted and removals get resurrected at sync association. kNone gives
+      // whole-dict last-writer-wins, so adds, removals and toggles all
+      // propagate.
+      {"brave.today.sources",
+       {brave_syncable_prefs_ids::kBraveNewsSources, syncer::PREFERENCES,
+        sync_preferences::PrefSensitivity::kNone,
+        sync_preferences::MergeBehavior::kNone}},
+      {"brave.news.channels",
+       {brave_syncable_prefs_ids::kBraveNewsChannels, syncer::PREFERENCES,
+        sync_preferences::PrefSensitivity::kNone,
+        sync_preferences::MergeBehavior::kNone}},
+      {"brave.today.userfeeds",
+       {brave_syncable_prefs_ids::kBraveNewsDirectFeeds, syncer::PREFERENCES,
+        sync_preferences::PrefSensitivity::kNone,
+        sync_preferences::MergeBehavior::kNone}},
+      {"brave.news.open-articles-in-new-tab",
+       {brave_syncable_prefs_ids::kBraveNewsOpenArticlesInNewTab,
+        syncer::PREFERENCES, sync_preferences::PrefSensitivity::kNone,
+        sync_preferences::MergeBehavior::kNone}},
   });
   return kBraveSyncablePrefsAllowList;
 }

--- a/components/brave_news/common/BUILD.gn
+++ b/components/brave_news/common/BUILD.gn
@@ -63,6 +63,7 @@ if (enable_brave_news) {
       "//base",
       "//brave/components/l10n/common",
       "//brave/components/p3a_utils",
+      "//components/pref_registry",
       "//components/prefs",
       "//url",
     ]

--- a/components/brave_news/common/DEPS
+++ b/components/brave_news/common/DEPS
@@ -1,5 +1,6 @@
 include_rules = [
   "+components/prefs",
+  "+components/pref_registry",
 ]
 
 specific_include_rules = {

--- a/components/brave_news/common/pref_names.cc
+++ b/components/brave_news/common/pref_names.cc
@@ -8,6 +8,7 @@
 #include "brave/components/brave_news/common/locales_helper.h"
 #include "brave/components/brave_news/common/p3a_pref_names.h"
 #include "brave/components/p3a_utils/feature_usage.h"
+#include "components/pref_registry/pref_registry_syncable.h"
 #include "components/prefs/pref_registry_simple.h"
 #include "components/prefs/pref_service.h"
 
@@ -15,14 +16,25 @@ namespace brave_news {
 namespace prefs {
 
 void RegisterProfilePrefs(PrefRegistrySimple* registry) {
-  registry->RegisterBooleanPref(kShouldShowToolbarButton, true);
-  registry->RegisterBooleanPref(kNewTabPageShowToday,
-                                IsUserInDefaultEnabledLocale());
-  registry->RegisterBooleanPref(kBraveNewsOptedIn, false);
-  registry->RegisterDictionaryPref(kBraveNewsSources);
-  registry->RegisterDictionaryPref(kBraveNewsChannels);
-  registry->RegisterDictionaryPref(kBraveNewsDirectFeeds);
-  registry->RegisterBooleanPref(kBraveNewsOpenArticlesInNewTab, true);
+  // These prefs are synced as part of the "Settings" (PREFERENCES) sync type.
+  registry->RegisterBooleanPref(
+      kShouldShowToolbarButton, true,
+      user_prefs::PrefRegistrySyncable::SYNCABLE_PREF);
+  registry->RegisterBooleanPref(
+      kNewTabPageShowToday, IsUserInDefaultEnabledLocale(),
+      user_prefs::PrefRegistrySyncable::SYNCABLE_PREF);
+  registry->RegisterBooleanPref(
+      kBraveNewsOptedIn, false,
+      user_prefs::PrefRegistrySyncable::SYNCABLE_PREF);
+  registry->RegisterDictionaryPref(
+      kBraveNewsSources, user_prefs::PrefRegistrySyncable::SYNCABLE_PREF);
+  registry->RegisterDictionaryPref(
+      kBraveNewsChannels, user_prefs::PrefRegistrySyncable::SYNCABLE_PREF);
+  registry->RegisterDictionaryPref(
+      kBraveNewsDirectFeeds, user_prefs::PrefRegistrySyncable::SYNCABLE_PREF);
+  registry->RegisterBooleanPref(
+      kBraveNewsOpenArticlesInNewTab, true,
+      user_prefs::PrefRegistrySyncable::SYNCABLE_PREF);
   registry->RegisterBooleanPref(kBraveNewsDisabledByPolicy, false);
 
   brave_news::p3a::prefs::RegisterProfileNewsMetricsPrefs(registry);


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/23054
Closes https://github.com/brave/brave-core/pull/37013
Closes https://github.com/brave/go-sync/pull/429

I had a play around with more complicated sync strategies here but merging gets a lot more complicated unless we add timestamps to individual entires. I think for the most part this should be a pretty massive improvement.

One case where this won't work properly is if you make edits on two different devices, the first edit will win.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
