### PR TITLE
[Sidebar V2] Refactoring RTL handling in browser view layout

### DIFF
--- a/browser/ui/sidebar/sidebar_browsertest.cc
+++ b/browser/ui/sidebar/sidebar_browsertest.cc
@@ -1941,8 +1941,9 @@ IN_PROC_BROWSER_TEST_P(SidebarBrowserTestV1AndV2,
 //   - SetMirrored(false) on SidebarContainerView/SidebarControlView prevents
 //     the Views framework from flipping internal layout in RTL.
 //   - SetFlipCanvasOnPaintForRTLUI(false) on buttons prevents icon flipping.
-//   - GetMirroredRect(contents_bounds) in BraveBrowserViewLayout ensures the
-//     contents container is placed correctly next to the sidebar in RTL.
+//   - BraveBrowserViewTabbedLayoutImpl flips the alignment pref into a
+//     leading-edge boolean in stored coordinates (IsSideBarLeading), so the
+//     sidebar renders on the visual side the user chose in RTL.
 IN_PROC_BROWSER_TEST_P(SidebarBrowserTestV1AndV2, SidebarLayoutInRTLTest) {
   auto* browser_view = BrowserView::GetBrowserViewForBrowser(browser());
   auto* sidebar_container = GetSidebarContainerView();
@@ -1957,8 +1958,8 @@ IN_PROC_BROWSER_TEST_P(SidebarBrowserTestV1AndV2, SidebarLayoutInRTLTest) {
   // --- Right-aligned sidebar (default) ---
   ASSERT_FALSE(IsSidebarUIOnLeft());
 
-  // As we set mirrored rect for sidebar and contents during the layout,
-  // Each views' mirrored bounds are what we're seeing in RTL mode.
+  // Mirrored bounds are the visual positions in RTL: the sidebar must stay on
+  // the visual right, matching the user's alignment pref.
   EXPECT_LE(contents_view->GetMirroredBounds().right(),
             sidebar_container->GetMirroredBounds().x());
 
@@ -1987,8 +1988,8 @@ IN_PROC_BROWSER_TEST_P(SidebarBrowserTestV1AndV2, SidebarLayoutInRTLTest) {
   // their bounds are what we're seeing.
   EXPECT_LE(control_view->bounds().right(), GetSidePanel()->bounds().x());
 
-  // As we set mirrored rect for sidebar and contents during the layout,
-  // Each views' mirrored bounds are what we're seeing in RTL mode.
+  // Mirrored bounds are the visual positions in RTL: the sidebar must stay on
+  // the visual left, matching the user's alignment pref.
   EXPECT_LE(sidebar_container->GetMirroredBounds().right(),
             contents_view->GetMirroredBounds().x());
 }

--- a/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl.cc
+++ b/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl.cc
@@ -11,6 +11,7 @@
 
 #include "base/check.h"
 #include "base/check_is_test.h"
+#include "base/i18n/rtl.h"
 #include "brave/browser/ui/views/frame/brave_browser_view.h"
 #include "brave/browser/ui/views/sidebar/sidebar_container_view.h"
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
@@ -62,34 +63,37 @@ void BraveBrowserViewTabbedLayoutImpl::ConfigureTopContainerBackground(
 
 // static
 gfx::Rect BraveBrowserViewTabbedLayoutImpl::ComputeSidebarBounds(
-    bool sidebar_on_left,
+    bool sidebar_leading,
     int sidebar_width,
     int outer_left,
     int outer_right,
     int y,
     int height) {
-  const int x = sidebar_on_left ? outer_left : outer_right - sidebar_width;
+  const int x = sidebar_leading ? outer_left : outer_right - sidebar_width;
   return gfx::Rect(x, y, sidebar_width, height);
 }
 
 // static
 gfx::Rect BraveBrowserViewTabbedLayoutImpl::ComputeAdjustedPanelBounds(
-    bool sidebar_on_left,
+    bool sidebar_leading,
     const gfx::Rect& sidebar_bounds,
     const gfx::Rect& panel_bounds) {
   // The upstream layout animates the panel by varying panel.x:
-  //   right panel: x = right_edge - visible_width  (slides in from the right)
-  //   left  panel: x = left_edge  - (target - visible_width) (from the left)
+  //   trailing panel: x = right_edge - visible_width (slides in from high X)
+  //   leading  panel: x = left_edge - (target - visible_width) (from low X)
   //
   // Shifting by ±sidebar_width offsets the whole slide range without changing
   // the animation value, so the panel animates correctly against the sidebar
-  // edge instead of the browser edge.
+  // edge instead of the browser edge. The sidebar and the upstream panel share
+  // the alignment pref, so `sidebar_leading` matches upstream's
+  // `side_panel_leading` and the shift direction agrees with where upstream
+  // placed the panel.
   gfx::Rect result = panel_bounds;
-  if (sidebar_on_left) {
-    // Sidebar on left: shift panel right by sidebar width.
+  if (sidebar_leading) {
+    // Sidebar at the leading edge: shift panel toward high X.
     result.set_x(panel_bounds.x() + sidebar_bounds.width());
   } else {
-    // Sidebar on right: shift panel left by sidebar width.
+    // Sidebar at the trailing edge: shift panel toward low X.
     result.set_x(panel_bounds.x() - sidebar_bounds.width());
   }
   return result;
@@ -198,29 +202,6 @@ BraveBrowserViewTabbedLayoutImpl::CalculateProposedLayout(
       insets.set_bottom(0);
       infobar_layout->bounds.Inset(insets);
     }
-  }
-
-  // Mirroring all views that affected by vertical tab alignment in RTL mode
-  // as vertical tab/sidebar follow user's setting for their alignment.
-  // Each views' mirrored bounds are what we're seeing in RTL mode.
-  contents_layout->bounds =
-      views().browser_view->GetMirroredRect(contents_layout->bounds);
-  if (auto* bookmark_layout = layout.GetLayoutFor(views().bookmark_bar)) {
-    bookmark_layout->bounds =
-        views().browser_view->GetMirroredRect(bookmark_layout->bounds);
-  }
-  if (auto* infobar_layout = layout.GetLayoutFor(views().infobar_container)) {
-    infobar_layout->bounds =
-        views().browser_view->GetMirroredRect(infobar_layout->bounds);
-  }
-  if (auto* sidebar_layout = layout.GetLayoutFor(views().sidebar_container)) {
-    sidebar_layout->bounds =
-        views().browser_view->GetMirroredRect(sidebar_layout->bounds);
-  }
-  if (auto* vertical_tab_host_layout =
-          layout.GetLayoutFor(views().vertical_tab_strip_host)) {
-    vertical_tab_host_layout->bounds =
-        views().browser_view->GetMirroredRect(vertical_tab_host_layout->bounds);
   }
 
   return layout;
@@ -407,7 +388,7 @@ void BraveBrowserViewTabbedLayoutImpl::CalculateBraveVerticalTabStripLayout(
   const int width =
       views().vertical_tab_strip_host->GetPreferredSize().width() +
       insets.width();
-  if (delegate().IsVerticalTabOnRight()) {
+  if (!IsVerticalTabStripLeading()) {
     vertical_tab_strip_bounds.set_x(vertical_tab_strip_bounds.right() - width);
   }
   vertical_tab_strip_bounds.set_width(width);
@@ -427,15 +408,18 @@ void BraveBrowserViewTabbedLayoutImpl::CalculateSideBarLayout(
 
   gfx::Rect contents_bounds = contents_layout->bounds;
 
-  const bool on_left = views().sidebar_container->sidebar_on_left();
+  const bool sidebar_leading = IsSidebarLeading();
 
   // The sidebar is always the outermost element on its side (only the vertical
   // tab, when on the same side, sits further out).
   //
-  // Desired LTR layout (sidebar right):
+  // All bounds here are in stored coordinates; `leading` is the lowest-X edge
+  // (rendered on the visual right in RTL).
+  //
+  // Desired layout (sidebar trailing):
   //   [vertical_tab] [contents] [panel] [sidebar]
   //   [contents] [panel] [sidebar] [vertical_tab]
-  // Desired LTR layout (sidebar left):
+  // Desired layout (sidebar leading):
   //   [vertical_tab] [sidebar] [panel] [contents]
   //   [sidebar] [panel] [contents] [vertical_tab]
   //
@@ -447,19 +431,20 @@ void BraveBrowserViewTabbedLayoutImpl::CalculateSideBarLayout(
   // in this function is a no-op in V1 and meaningful only in V2.
 
   // Vertical tab is outermost when on the same side as the sidebar.
-  const bool vtab_on_same_side = views().vertical_tab_strip_host &&
-                                 delegate().ShouldShowVerticalTabs() &&
-                                 (on_left != delegate().IsVerticalTabOnRight());
+  const bool vtab_on_same_side =
+      views().vertical_tab_strip_host && delegate().ShouldShowVerticalTabs() &&
+      (sidebar_leading == IsVerticalTabStripLeading());
   const int vtab_width =
       vtab_on_same_side
           ? views().vertical_tab_strip_host->GetPreferredSize().width()
           : 0;
 
-  // Outer available edge in logical (pre-mirroring) coordinates, inset for
-  // any vertical tab on the same side.
+  // Outer available edges, inset for any vertical tab on the same side.
   const gfx::Rect browser_bounds = views().browser_view->GetLocalBounds();
-  const int outer_left = browser_bounds.x() + (on_left ? vtab_width : 0);
-  const int outer_right = browser_bounds.right() - (on_left ? 0 : vtab_width);
+  const int outer_left =
+      browser_bounds.x() + (sidebar_leading ? vtab_width : 0);
+  const int outer_right =
+      browser_bounds.right() - (sidebar_leading ? 0 : vtab_width);
 
   // Sidebar width capped at 80% of the space shared between contents and
   // sidebar (contents_bounds.width()).  In V1 this is the full available width
@@ -467,9 +452,9 @@ void BraveBrowserViewTabbedLayoutImpl::CalculateSideBarLayout(
   // width, but the sidebar control is narrow enough that the cap never fires.
   const int sidebar_width = GetIdealSideBarWidth(contents_bounds.width());
 
-  const gfx::Rect sidebar_bounds =
-      ComputeSidebarBounds(on_left, sidebar_width, outer_left, outer_right,
-                           contents_bounds.y(), contents_bounds.height());
+  const gfx::Rect sidebar_bounds = ComputeSidebarBounds(
+      sidebar_leading, sidebar_width, outer_left, outer_right,
+      contents_bounds.y(), contents_bounds.height());
 
   // Shift upstream side panels (V2 only; no-op in V1 since those panels are
   // inside sidebar_container and are not top-level layout entries) inward so
@@ -482,8 +467,8 @@ void BraveBrowserViewTabbedLayoutImpl::CalculateSideBarLayout(
     if (!panel_layout) {
       return;
     }
-    panel_layout->bounds = ComputeAdjustedPanelBounds(on_left, sidebar_bounds,
-                                                      panel_layout->bounds);
+    panel_layout->bounds = ComputeAdjustedPanelBounds(
+        sidebar_leading, sidebar_bounds, panel_layout->bounds);
     // The upstream layout offsets the panel -1px above the contents to overlap
     // the toolbar separator. Brave doesn't need that overlap; align the panel's
     // vertical extent with the contents container instead.
@@ -493,7 +478,7 @@ void BraveBrowserViewTabbedLayoutImpl::CalculateSideBarLayout(
   adjust_panel(views().side_panel.get());
 
   // Reduce contents bounds by the sidebar width on the sidebar side.
-  if (on_left) {
+  if (sidebar_leading) {
     contents_bounds.Inset(gfx::Insets().set_left(sidebar_width));
   } else {
     contents_bounds.Inset(gfx::Insets().set_right(sidebar_width));
@@ -554,10 +539,10 @@ void BraveBrowserViewTabbedLayoutImpl::InsetContentsContainerBounds(
         delegate().ShouldUseBraveWebViewRoundedCornersForContents()
             ? (tabs::kMarginForVerticalTabContainers / 2)
             : 0;
-    if (delegate().IsVerticalTabOnRight()) {
-      contents_margins.set_right(margin_with_vertical_tab);
-    } else {
+    if (IsVerticalTabStripLeading()) {
       contents_margins.set_left(margin_with_vertical_tab);
+    } else {
+      contents_margins.set_right(margin_with_vertical_tab);
     }
   }
 
@@ -579,9 +564,8 @@ void BraveBrowserViewTabbedLayoutImpl::InsetContentsContainerBounds(
 
   // If sidebar UI is only shown, contents container should have margin
   // based on sidebar's position because sidebar UI itself has padding always.
-  // If sidebar is shown in left-side, contents container doesn't need its
-  // left margin.
-  if (views().sidebar_container->sidebar_on_left()) {
+  // The contents container doesn't need the full margin on the sidebar side.
+  if (IsSidebarLeading()) {
     contents_margins.set_left(contents_margin_for_rounded_corners);
   } else {
     contents_margins.set_right(contents_margin_for_rounded_corners);
@@ -692,17 +676,29 @@ bool BraveBrowserViewTabbedLayoutImpl::ShouldPushBookmarkBarForVerticalTabs()
          delegate().IsBookmarkBarVisible();
 }
 
+bool BraveBrowserViewTabbedLayoutImpl::IsSidebarLeading() const {
+  // In stored coordinates, the leading (lowest-X) edge renders on the visual
+  // left in LTR and the visual right in RTL. Flip the pref in RTL so the
+  // sidebar always appears on the visual side the user chose.
+  return views().sidebar_container->sidebar_on_left() != base::i18n::IsRTL();
+}
+
+bool BraveBrowserViewTabbedLayoutImpl::IsVerticalTabStripLeading() const {
+  // See IsSideBarLeading() for the polarity rationale.
+  return delegate().IsVerticalTabOnRight() == base::i18n::IsRTL();
+}
+
 gfx::Insets
 BraveBrowserViewTabbedLayoutImpl::GetInsetsConsideringVerticalTabHost() const {
   // This method is used only when vertical tab strip host is set
   CHECK(views().vertical_tab_strip_host);
 
   gfx::Insets insets;
-  if (delegate().IsVerticalTabOnRight()) {
-    insets.set_right(
+  if (IsVerticalTabStripLeading()) {
+    insets.set_left(
         views().vertical_tab_strip_host->GetPreferredSize().width());
   } else {
-    insets.set_left(
+    insets.set_right(
         views().vertical_tab_strip_host->GetPreferredSize().width());
   }
 

--- a/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl.h
+++ b/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl.h
@@ -26,10 +26,14 @@ class BraveBrowserViewTabbedLayoutImpl : public BrowserViewTabbedLayoutImpl {
   // Pure geometry helpers used by CalculateSideBarLayout. Exposed as public
   // static so tests can call them directly without special access.
   //
-  // Returns the bounds for the sidebar control view given its side, width,
-  // the outer (browser-edge) limits already inset for any vertical tab on the
-  // same side, and the vertical extents of the contents area.
-  static gfx::Rect ComputeSidebarBounds(bool sidebar_on_left,
+  // All bounds are in stored (pre-paint-mirroring) coordinates, following the
+  // upstream convention: `leading` means the lowest-X edge, which renders on
+  // the visual right in RTL.
+  //
+  // Returns the bounds for the sidebar control view given its leading edge,
+  // width, the outer (browser-edge) limits already inset for any vertical tab
+  // on the same side, and the vertical extents of the contents area.
+  static gfx::Rect ComputeSidebarBounds(bool sidebar_leading,
                                         int sidebar_width,
                                         int outer_left,
                                         int outer_right,
@@ -39,7 +43,7 @@ class BraveBrowserViewTabbedLayoutImpl : public BrowserViewTabbedLayoutImpl {
   // between the contents area and the sidebar control view.  The panel is
   // shifted inward (toward the centre of the browser) until it is flush with
   // the inner edge of |sidebar_bounds|.
-  static gfx::Rect ComputeAdjustedPanelBounds(bool sidebar_on_left,
+  static gfx::Rect ComputeAdjustedPanelBounds(bool sidebar_leading,
                                               const gfx::Rect& sidebar_bounds,
                                               const gfx::Rect& panel_bounds);
 
@@ -83,6 +87,14 @@ class BraveBrowserViewTabbedLayoutImpl : public BrowserViewTabbedLayoutImpl {
   gfx::Insets GetContentsMargins() const;
   bool ShouldPushBookmarkBarForVerticalTabs() const;
   gfx::Insets GetInsetsConsideringVerticalTabHost() const;
+
+  // Whether the sidebar / vertical tab strip occupies the leading (lowest-X)
+  // edge in stored coordinates. As stored bounds are paint-mirrored in RTL,
+  // these flip the user's alignment pref so the visual side always matches
+  // the pref. This is the same conversion upstream does for its side panel
+  // (`side_panel_leading` in BrowserViewTabbedLayoutImpl).
+  bool IsSidebarLeading() const;
+  bool IsVerticalTabStripLeading() const;
 
 #if BUILDFLAG(IS_MAC)
   gfx::Insets AddFrameBorderInsets(const gfx::Insets& insets) const;

--- a/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl_unittest.cc
+++ b/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl_unittest.cc
@@ -103,13 +103,17 @@ class MockBrowserViewLayoutDelegateForMac
 
 // ---------------------------------------------------------------------------
 // ComputeSidebarBounds
+//
+// All bounds are in stored (pre-paint-mirroring) coordinates;
+// `sidebar_leading` selects the lowest-X edge, which renders on the visual
+// left in LTR and the visual right in RTL.
 // ---------------------------------------------------------------------------
 
 TEST(BraveBrowserViewTabbedLayoutImplSidebarTest, ComputeSidebarBoundsOnRight) {
   // Browser width 1000, no vertical tab on the right side.
   // outer_right = 1000 (full right edge).
   gfx::Rect sidebar = BraveBrowserViewTabbedLayoutImpl::ComputeSidebarBounds(
-      /*sidebar_on_left=*/false, /*sidebar_width=*/200,
+      /*sidebar_leading=*/false, /*sidebar_width=*/200,
       /*outer_left=*/0, /*outer_right=*/1000,
       /*y=*/50, /*height=*/600);
   EXPECT_EQ(gfx::Rect(800, 50, 200, 600), sidebar);
@@ -120,7 +124,7 @@ TEST(BraveBrowserViewTabbedLayoutImplSidebarTest,
   // Vertical tab on right, width 200 → outer_right = 1000 - 200 = 800.
   // Sidebar sits between contents and vertical tab.
   gfx::Rect sidebar = BraveBrowserViewTabbedLayoutImpl::ComputeSidebarBounds(
-      /*sidebar_on_left=*/false, /*sidebar_width=*/150,
+      /*sidebar_leading=*/false, /*sidebar_width=*/150,
       /*outer_left=*/0, /*outer_right=*/800,
       /*y=*/50, /*height=*/600);
   EXPECT_EQ(gfx::Rect(650, 50, 150, 600), sidebar);
@@ -130,7 +134,7 @@ TEST(BraveBrowserViewTabbedLayoutImplSidebarTest, ComputeSidebarBoundsOnLeft) {
   // Browser width 1000, no vertical tab on the left side.
   // outer_left = 0 (full left edge).
   gfx::Rect sidebar = BraveBrowserViewTabbedLayoutImpl::ComputeSidebarBounds(
-      /*sidebar_on_left=*/true, /*sidebar_width=*/200,
+      /*sidebar_leading=*/true, /*sidebar_width=*/200,
       /*outer_left=*/0, /*outer_right=*/1000,
       /*y=*/50, /*height=*/600);
   EXPECT_EQ(gfx::Rect(0, 50, 200, 600), sidebar);
@@ -141,7 +145,7 @@ TEST(BraveBrowserViewTabbedLayoutImplSidebarTest,
   // Vertical tab on left, width 200 → outer_left = 200.
   // Sidebar sits between vertical tab and contents.
   gfx::Rect sidebar = BraveBrowserViewTabbedLayoutImpl::ComputeSidebarBounds(
-      /*sidebar_on_left=*/true, /*sidebar_width=*/150,
+      /*sidebar_leading=*/true, /*sidebar_width=*/150,
       /*outer_left=*/200, /*outer_right=*/1000,
       /*y=*/50, /*height=*/600);
   EXPECT_EQ(gfx::Rect(200, 50, 150, 600), sidebar);
@@ -160,7 +164,7 @@ TEST(BraveBrowserViewTabbedLayoutImplSidebarTest,
   gfx::Rect panel(700, 50, 300, 600);
   gfx::Rect adjusted =
       BraveBrowserViewTabbedLayoutImpl::ComputeAdjustedPanelBounds(
-          /*sidebar_on_left=*/false, sidebar, panel);
+          /*sidebar_leading=*/false, sidebar, panel);
   EXPECT_EQ(660, adjusted.x());
   EXPECT_EQ(sidebar.x(), adjusted.right());  // flush with sidebar's left edge
   EXPECT_EQ(panel.width(), adjusted.width());
@@ -177,7 +181,7 @@ TEST(BraveBrowserViewTabbedLayoutImplSidebarTest,
   gfx::Rect panel(850, 50, 300, 600);  // upstream: right_edge - visible_width
   gfx::Rect adjusted =
       BraveBrowserViewTabbedLayoutImpl::ComputeAdjustedPanelBounds(
-          /*sidebar_on_left=*/false, sidebar, panel);
+          /*sidebar_leading=*/false, sidebar, panel);
   EXPECT_EQ(810, adjusted.x());
   EXPECT_EQ(150, sidebar.x() - adjusted.x());  // 150px visible to the user
 }
@@ -192,7 +196,7 @@ TEST(BraveBrowserViewTabbedLayoutImplSidebarTest,
   gfx::Rect panel(0, 50, 300, 600);
   gfx::Rect adjusted =
       BraveBrowserViewTabbedLayoutImpl::ComputeAdjustedPanelBounds(
-          /*sidebar_on_left=*/true, sidebar, panel);
+          /*sidebar_leading=*/true, sidebar, panel);
   EXPECT_EQ(40, adjusted.x());
   EXPECT_EQ(sidebar.right(), adjusted.x());  // flush with sidebar's right edge
   EXPECT_EQ(panel.width(), adjusted.width());
@@ -209,7 +213,7 @@ TEST(BraveBrowserViewTabbedLayoutImplSidebarTest,
   gfx::Rect panel(-150, 50, 300, 600);  // upstream: left_edge-(target-visible)
   gfx::Rect adjusted =
       BraveBrowserViewTabbedLayoutImpl::ComputeAdjustedPanelBounds(
-          /*sidebar_on_left=*/true, sidebar, panel);
+          /*sidebar_leading=*/true, sidebar, panel);
   EXPECT_EQ(-110, adjusted.x());
   EXPECT_EQ(150, adjusted.right() - sidebar.right());  // 150px visible to user
 }

--- a/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_browsertest.cc
+++ b/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_browsertest.cc
@@ -2199,8 +2199,9 @@ IN_PROC_BROWSER_TEST_P(VerticalTabStripHideCompletelyTest,
 
 // Verifies that the vertical tab strip host view and the web contents are
 // positioned correctly in RTL mode for both "tab on left" and "tab on right"
-// user preferences. The layout applies GetMirroredRect() so the user's visual
-// intent is preserved regardless of locale directionality.
+// user preferences. The layout flips the pref into a leading-edge boolean in
+// stored coordinates (IsVerticalTabStripLeading), so the user's visual intent
+// is preserved regardless of locale directionality.
 IN_PROC_BROWSER_TEST_P(VerticalTabStripBrowserTest, VerticalTabLayoutInRTL) {
   ToggleVerticalTabStrip();
   ASSERT_TRUE(tabs::utils::ShouldShowBraveVerticalTabs(browser()));

--- a/browser/ui/views/side_panel/side_panel_utils.cc
+++ b/browser/ui/views/side_panel/side_panel_utils.cc
@@ -7,6 +7,7 @@
 
 #include "brave/browser/ui/views/frame/brave_browser_view.h"
 #include "brave/common/pref_names.h"
+#include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/views/side_panel/side_panel.h"
 #include "chrome/common/pref_names.h"
 #include "components/prefs/pref_service.h"


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves no issue - use umbrella issue (https://github.com/brave/brave-browser/issues/51462)

No behavioral changes.
Refactored RTL handling in browser view layout as current code doesn't work well with sidebar V2.
With leading concept, don't need to do post mirroring.

BraveBrowserViewTabbedLayoutImpl - refactored to upstream's pattern:
- New private helpers `IsSidebarLeading()` and `IsVerticalTabStripLeading()` convert the user's alignment pref into a stored-coordinate (lowest-X) edge boolean once, exactly like upstream's side_panel_leading.
- All pref-side branches in `CalculateSideBarLayout()`, `CalculateBraveVerticalTabStripLayout()`, `InsetContentsContainerBounds()`, and `GetInsetsConsideringVerticalTabHost()` now use those booleans, and the static helpers' first param is renamed to sidebar_leading.
- The fragile 22-line GetMirroredRect() post-mirroring block is deleted

TEST=Covered by existing test cases - SidebarLayoutInRTLTest, SidePanelResizeInRTLTest, VerticalTabLayoutInRTL

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
