### PR TITLE
Fix upstream windows build flake by ignoring .rsp in reorder-imports.

### DIFF
--- a/chromium_src/build/win/reorder-imports.py
+++ b/chromium_src/build/win/reorder-imports.py
@@ -8,7 +8,7 @@ import glob
 import override_utils
 
 
-@override_utils.override_function(glob, name='iglob')
+@override_utils.override_function(glob)
 def iglob(original_function, *args, **kwargs):
     for fname in original_function(*args, **kwargs):
         # The .rsp (response file) can still be present while this action runs,

--- a/chromium_src/build/win/reorder-imports.py
+++ b/chromium_src/build/win/reorder-imports.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import glob
+
+import override_utils
+
+
+@override_utils.override_function(glob, name='iglob')
+def iglob(original_function, *args, **kwargs):
+    for fname in original_function(*args, **kwargs):
+        # The .rsp (response file) can still be present while this action runs,
+        # make sure to skip it as it's not a valid input file.
+        if fname.endswith('.rsp'):
+            continue
+        yield fname

--- a/patches/build-win-reorder-imports.py.patch
+++ b/patches/build-win-reorder-imports.py.patch
@@ -1,0 +1,11 @@
+diff --git a/build/win/reorder-imports.py b/build/win/reorder-imports.py
+index 88851609d4be06eea3365bcef1191b4d285560f8..d78ce61726e700178982f031343759b2b8df682e 100755
+--- a/build/win/reorder-imports.py
++++ b/build/win/reorder-imports.py
+@@ -93,5 +93,6 @@ def main(argv):
+     parser.error('Please provide and input and output directory')
+   return reorder_imports(opts.input, opts.output, opts.arch)
+ 
++from brave_chromium_utils import inline_chromium_src_override; inline_chromium_src_override(globals(), locals())
+ if __name__ == "__main__":
+   sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves
```
21:31:46    File "D:\ws\x64-nightly\src\brave\vendor\depot_tools\bootstrap-2@3_11_8_chromium_35_bin\python3\bin\Lib\shutil.py", line 256, in copyfile
21:31:46      with open(src, 'rb') as fsrc:
21:31:46           ^^^^^^^^^^^^^^^
21:31:46  PermissionError: [Errno 13] Permission denied: 'initialexe\\chrome.exe.rsp'
```

The correct GN dep is there, so it's not a dependency issue, but a file removal issue.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
