### PR TITLE
[Wallet]: Migrate Actions More Menu to use Nala Button Menu

### DIFF
--- a/components/brave_wallet_ui/components/desktop/views/portfolio/components/buy-send-swap-deposit-nav/buy-send-swap-deposit-nav.style.ts
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/components/buy-send-swap-deposit-nav/buy-send-swap-deposit-nav.style.ts
@@ -6,14 +6,7 @@
 import styled from 'styled-components'
 import * as leo from '@brave/leo/tokens/css/variables'
 import Icon from '@brave/leo/react/icon'
-import { WalletButton, Column } from '../../../../../shared/style'
-
-export const ButtonWrapper = styled(Column)`
-  margin-right: 28px;
-  &:last-child {
-    margin-right: 0px;
-  }
-`
+import { WalletButton } from '../../../../../shared/style'
 
 export const Button = styled(WalletButton)<{
   minWidth?: number
@@ -39,8 +32,4 @@ export const ButtonIcon = styled(Icon)`
   @media (prefers-color-scheme: dark) {
     color: ${leo.color.schemes.onPrimary};
   }
-`
-
-export const MoreMenuWrapper = styled(ButtonWrapper)`
-  position: relative;
 `

--- a/components/brave_wallet_ui/components/desktop/views/portfolio/components/buy-send-swap-deposit-nav/buy-send-swap-deposit-nav.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/components/buy-send-swap-deposit-nav/buy-send-swap-deposit-nav.tsx
@@ -9,9 +9,6 @@ import * as React from 'react'
 import { NavOption } from '../../../../../../constants/types'
 
 // Hooks
-import {
-  useOnClickOutside, //
-} from '../../../../../../common/hooks/useOnClickOutside'
 import { useRoute } from '../../../../../../common/hooks/use_route'
 
 // Options
@@ -31,30 +28,18 @@ import { UISelectors } from '../../../../../../common/selectors'
 
 // Components
 import {
-  PortfolioAccountMenu, //
+  PortfolioActionsMoreMenu, //
 } from '../../../../wallet-menus/portfolio_actions_more_menu'
 
 // Styled Components
-import {
-  Button,
-  ButtonIcon,
-  ButtonWrapper,
-  MoreMenuWrapper,
-} from './buy-send-swap-deposit-nav.style'
-import { Row, Text } from '../../../../../shared/style'
+import { Button, ButtonIcon } from './buy-send-swap-deposit-nav.style'
+import { Row, Column, Text } from '../../../../../shared/style'
 
 export const BuySendSwapDepositNav = () => {
-  // state
-  const [showMoreMenu, setShowMoreMenu] = React.useState<boolean>(false)
-
-  // refs
-  const moreMenuRef = React.useRef<HTMLDivElement>(null)
-
   // selectors
   const isIOS = useSafeUISelector(UISelectors.isIOS)
 
   // hooks
-  useOnClickOutside(moreMenuRef, () => setShowMoreMenu(false), showMoreMenu)
   const { openOrPushRoute } = useRoute()
 
   // methods
@@ -70,9 +55,12 @@ export const BuySendSwapDepositNav = () => {
     : BuySendSwapDepositOptions
 
   return (
-    <Row width='unset'>
+    <Row
+      width='unset'
+      gap='28px'
+    >
       {options.slice(0, 3).map((option) => (
-        <ButtonWrapper key={option.id}>
+        <Column key={option.id}>
           <Button onClick={() => onClick(option)}>
             <ButtonIcon name={option.icon} />
           </Button>
@@ -82,20 +70,21 @@ export const BuySendSwapDepositNav = () => {
           >
             {getLocale(option.name)}
           </Text>
-        </ButtonWrapper>
+        </Column>
       ))}
-      <MoreMenuWrapper ref={moreMenuRef}>
-        <Button onClick={() => setShowMoreMenu(true)}>
-          <ButtonIcon name='more-horizontal' />
-        </Button>
-        <Text
-          textColor='primary'
-          variant='small.semibold'
-        >
-          {getLocale('braveWalletButtonMore')}
-        </Text>
-        {showMoreMenu && <PortfolioAccountMenu onClick={onClick} />}
-      </MoreMenuWrapper>
+      <PortfolioActionsMoreMenu onClick={onClick}>
+        <Column slot='anchor-content'>
+          <Button>
+            <ButtonIcon name='more-horizontal' />
+          </Button>
+          <Text
+            textColor='primary'
+            variant='small.semibold'
+          >
+            {getLocale('braveWalletButtonMore')}
+          </Text>
+        </Column>
+      </PortfolioActionsMoreMenu>
     </Row>
   )
 }

--- a/components/brave_wallet_ui/components/desktop/wallet-menus/portfolio_actions_more_menu.tsx
+++ b/components/brave_wallet_ui/components/desktop/wallet-menus/portfolio_actions_more_menu.tsx
@@ -4,6 +4,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import * as React from 'react'
+import Icon from '@brave/leo/react/icon'
 
 // Types
 import { NavOption } from '../../../constants/types'
@@ -22,36 +23,36 @@ import { useSafeUISelector } from '../../../common/hooks/use-safe-selector'
 import { UISelectors } from '../../../common/selectors'
 
 // Styled Components
-import {
-  StyledWrapper,
-  PopupButton,
-  PopupButtonText,
-  ButtonIcon,
-} from './wellet-menus.style'
+import { ButtonMenu } from './wellet-menus.style'
 
 interface Props {
+  children: React.ReactNode
   onClick: (option: NavOption) => void
 }
 
-export const PortfolioAccountMenu = (props: Props) => {
+export const PortfolioActionsMoreMenu = (props: Props) => {
+  const { onClick, children } = props
+
+  // selectors
   const isIOS = useSafeUISelector(UISelectors.isIOS)
+
+  // computed
   const options = isIOS
     ? BuySendSwapDepositIOSOptions
     : BuySendSwapDepositOptions
 
-  const { onClick } = props
-
   return (
-    <StyledWrapper yPosition={56}>
+    <ButtonMenu placement='bottom-end'>
+      {children}
       {options.slice(3).map((option) => (
-        <PopupButton
+        <leo-menu-item
           key={option.id}
           onClick={() => onClick(option)}
         >
-          <ButtonIcon name={option.icon} />
-          <PopupButtonText>{getLocale(option.name)}</PopupButtonText>
-        </PopupButton>
+          <Icon name={option.icon} />
+          {getLocale(option.name)}
+        </leo-menu-item>
       ))}
-    </StyledWrapper>
+    </ButtonMenu>
   )
 }


### PR DESCRIPTION
## Description 

Migrates the `Actions More Menu` to use the Nala `Button Menu` component

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/56264>

Before and After:

<img width="333" height="231" alt="Screenshot 21" src="https://github.com/user-attachments/assets/80fe535f-6fb5-4fc7-9102-2416e6ebf9ca" /> | <img width="323" height="232" alt="Screenshot 23" src="https://github.com/user-attachments/assets/47d694dd-4358-48ac-9aec-ecc6d8c85585" />
--|--


<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

## Test Plan:
1. The `Actions More Menu` should continue to work as expected.