### PR TITLE
[brave_news] Remove some headers from pcdn requests

### DIFF
--- a/browser/ui/webui/brave_sanitized_image_source.cc
+++ b/browser/ui/webui/brave_sanitized_image_source.cc
@@ -13,16 +13,17 @@
 #include "base/memory/scoped_refptr.h"
 #include "base/strings/strcat.h"
 #include "base/strings/string_split.h"
-#include "base/strings/string_util.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/task/task_traits.h"
 #include "base/task/thread_pool.h"
 #include "brave/brave_domains/service_domains.h"
+#include "brave/components/brave_private_cdn/headers.h"
 #include "brave/components/brave_private_cdn/private_cdn_helper.h"
 #include "chrome/browser/profiles/profile.h"
 #include "content/public/browser/browser_context.h"
 #include "content/public/browser/storage_partition.h"
 #include "net/base/url_util.h"
+#include "net/http/http_request_headers.h"
 #include "net/traffic_annotation/network_traffic_annotation.h"
 #include "services/network/public/cpp/resource_request.h"
 #include "services/network/public/cpp/simple_url_loader.h"
@@ -248,6 +249,17 @@ void BraveSanitizedImageSource::StartImageDownload(
   auto request = std::make_unique<network::ResourceRequest>();
   request->url = request_attributes.image_url;
   request->credentials_mode = network::mojom::CredentialsMode::kOmit;
+
+  // Lazily initialize the pcdn domain
+  if (pcdn_domain_.empty()) {
+    pcdn_domain_ = brave_domains::GetServicesDomain("pcdn");
+  }
+
+  if (request_attributes.image_url.host() == pcdn_domain_) {
+    for (const auto& entry : brave::private_cdn_headers) {
+      request->headers.SetHeader(entry.first, entry.second);
+    }
+  }
   request->headers.SetHeader("Accept",
                              blink::network_utils::ImageAcceptHeader());
 

--- a/browser/ui/webui/brave_sanitized_image_source_unittest.cc
+++ b/browser/ui/webui/brave_sanitized_image_source_unittest.cc
@@ -82,13 +82,14 @@ class BraveSanitizedImageSourceTest : public testing::Test {
 
               const auto user_agent = request.headers.GetHeader(
                   net::HttpRequestHeaders::kUserAgent);
-              ASSERT_TRUE(user_agent.has_value());
-              EXPECT_TRUE(user_agent->empty());
+
+              const bool is_pcdn = url.host() == "pcdn.brave.com";
+
+              ASSERT_EQ(user_agent.has_value(), is_pcdn);
 
               const auto accept_language = request.headers.GetHeader(
                   net::HttpRequestHeaders::kAcceptLanguage);
-              ASSERT_TRUE(accept_language.has_value());
-              EXPECT_TRUE(accept_language->empty());
+              ASSERT_EQ(accept_language.has_value(), is_pcdn);
             });
     test_url_loader_factory_.SetInterceptor(std::move(interceptor));
     test_url_loader_factory_.AddResponse(url.spec(), std::move(data));

--- a/browser/ui/webui/brave_sanitized_image_source_unittest.cc
+++ b/browser/ui/webui/brave_sanitized_image_source_unittest.cc
@@ -21,6 +21,7 @@
 #include "chrome/test/base/testing_profile.h"
 #include "content/public/browser/web_contents.h"
 #include "content/public/test/browser_task_environment.h"
+#include "net/http/http_request_headers.h"
 #include "services/data_decoder/public/cpp/test_support/in_process_data_decoder.h"
 #include "services/network/public/cpp/simple_url_loader.h"
 #include "services/network/public/cpp/weak_wrapper_shared_url_loader_factory.h"
@@ -78,6 +79,16 @@ class BraveSanitizedImageSourceTest : public testing::Test {
               const auto accept_header = request.headers.GetHeader("Accept");
               ASSERT_TRUE(accept_header.has_value());
               EXPECT_NE(accept_header->find("image/webp"), std::string::npos);
+
+              const auto user_agent = request.headers.GetHeader(
+                  net::HttpRequestHeaders::kUserAgent);
+              ASSERT_TRUE(user_agent.has_value());
+              EXPECT_TRUE(user_agent->empty());
+
+              const auto accept_language = request.headers.GetHeader(
+                  net::HttpRequestHeaders::kAcceptLanguage);
+              ASSERT_TRUE(accept_language.has_value());
+              EXPECT_TRUE(accept_language->empty());
             });
     test_url_loader_factory_.SetInterceptor(std::move(interceptor));
     test_url_loader_factory_.AddResponse(url.spec(), std::move(data));

--- a/ios/browser/ui/webui/sanitized_image_source.mm
+++ b/ios/browser/ui/webui/sanitized_image_source.mm
@@ -20,6 +20,7 @@
 #include "base/task/task_traits.h"
 #include "base/task/thread_pool.h"
 #include "brave/brave_domains/service_domains.h"
+#include "brave/components/brave_private_cdn/headers.h"
 #include "brave/components/brave_private_cdn/private_cdn_helper.h"
 #include "components/image_fetcher/ios/ios_image_decoder_impl.h"
 #include "components/signin/public/identity_manager/primary_account_access_token_fetcher.h"
@@ -29,6 +30,7 @@
 #include "ios/chrome/browser/signin/model/identity_manager_factory.h"
 #include "ios/web/public/browser_state.h"
 #include "net/base/url_util.h"
+#include "net/http/http_request_headers.h"
 #include "net/http/http_response_headers.h"
 #include "net/traffic_annotation/network_traffic_annotation.h"
 #include "services/data_decoder/public/cpp/decode_image.h"
@@ -281,6 +283,18 @@ void SanitizedImageSource::StartImageDownload(
   auto request = std::make_unique<network::ResourceRequest>();
   request->url = request_attributes.image_url;
   request->credentials_mode = network::mojom::CredentialsMode::kOmit;
+
+  // Lazily initialize the pcdn domain
+  if (pcdn_domain_.empty()) {
+    pcdn_domain_ = brave_domains::GetServicesDomain("pcdn");
+  }
+
+  if (request_attributes.image_url.host() == pcdn_domain_) {
+    for (const auto& entry : brave::private_cdn_headers) {
+      request->headers.SetHeader(entry.first, entry.second);
+    }
+  }
+
   if (request_attributes.access_token_info) {
     request->headers.SetHeader(
         net::HttpRequestHeaders::kAuthorization,


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/56244


Android [uses](https://github.com/brave/brave-core/blob/2d0b4f875919a6f88c3e8910200a46987aad4096/components/brave_news/browser/brave_news_controller.cc#L486) `private_cdn_request_helper_.DownloadToString` that already does preprocessing.

before/after:
```
                           --> :method: GET
                               :authority: pcdn.brave.com
                               :scheme: https
                               :path: /brave-today/cache/99b4b7f835edaa02c927baa07117e538b2d50c638d83130cb7529650e9f29e8f.jpg.pad
                               accept: image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8
                               braveservicekey: xxxx
                               sec-fetch-site: none
                               sec-fetch-mode: no-cors
                               sec-fetch-dest: empty
                               user-agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36
                               accept-encoding: gzip, deflate, br, zstd
                               accept-language: en-US,en;q=0.9
                               priority: u=4, i

                          --> :method: GET
                              :authority: pcdn.brave.com
                              :scheme: https
                              :path: /brave-today/cover_images/97030f8413d3ab3528870f45ac2a838eab3ef2df5819cd72e960128c9c7ae228.png.pad
                              user-agent: 
                              accept: image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8
                              braveservicekey: xxxx
                              sec-fetch-site: none
                              sec-fetch-mode: no-cors
                              sec-fetch-dest: empty
                              accept-encoding: gzip, deflate, br, zstd
                              accept-language: 
                              priority: u=4, i
```

Also, there is [GetPublisher](https://github.com/brave/brave-core/blob/7c4ebca69daf106d5f6442f4757244d64cf8d2c8/components/brave_rewards/core/engine/endpoint/private_cdn/get_publisher/get_publisher.h#L36) in Rewards that could have the same issue.
If it is, we need another PR to fix it.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
