### PR TITLE
[VPN 2.0] Move Boringtun dependency to VPN Helper

### DIFF
--- a/browser/sources.gni
+++ b/browser/sources.gni
@@ -558,10 +558,8 @@ if (enable_brave_vpn) {
 }
 
 if (enable_brave_vpn_v2) {
-  brave_chrome_browser_deps += [
-    "//brave/components/brave_vpn/browser/v2:browser",
-    "//brave/third_party/boringtun",
-  ]
+  brave_chrome_browser_deps +=
+      [ "//brave/components/brave_vpn/browser/v2:browser" ]
 }
 
 if (is_android) {

--- a/components/brave_vpn/app/v2/helper/BUILD.gn
+++ b/components/brave_vpn/app/v2/helper/BUILD.gn
@@ -41,6 +41,8 @@ executable("helper") {
     "//brave/components/brave_vpn/app/v2/shared",
   ]
 
+  data_deps = [ "//brave/third_party/boringtun" ]
+
   if (is_win) {
     deps += [
       ":version_resources",
@@ -62,11 +64,19 @@ if (is_mac) {
     sources = [ "main.cc" ]
 
     deps = [
+      ":boringtun_bundle_data",
       ":core",
       "//base",
       "//base:base_static",
       "//brave/components/brave_vpn/app/v2/shared",
     ]
+  }
+
+  # Drops boringtun shared object into the helper's bundle.
+  bundle_data("boringtun_bundle_data") {
+    sources = [ "$root_out_dir/libboringtun.dylib" ]
+    outputs = [ "{{bundle_contents_dir}}/Frameworks/{{source_file_part}}" ]
+    public_deps = [ "//brave/third_party/boringtun" ]
   }
 
   # Drops the assembled app into the browser framework's Helpers directory.


### PR DESCRIPTION
Move boringtun dependency from the browser to the VPN helper, and make sure it's properly bundled with the helper on Mac.

Implements part of https://github.com/brave/brave-browser/issues/54626

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
