### PR TITLE
[Wallet]: Migrate Accounts Menu to use Nala Button Menu

### DIFF
--- a/components/brave_wallet_ui/components/desktop/card-headers/accounts-header.tsx
+++ b/components/brave_wallet_ui/components/desktop/card-headers/accounts-header.tsx
@@ -18,7 +18,6 @@ import { DefaultPanelHeader } from './default-panel-header'
 import { getLocale } from '../../../../common/locale'
 
 // Hooks
-import { useOnClickOutside } from '../../../common/hooks/useOnClickOutside'
 import { useSafeUISelector } from '../../../common/hooks/use-safe-selector'
 
 import { AccountsMenu } from '../wallet-menus/accounts-menu'
@@ -28,7 +27,6 @@ import {
   HeaderTitle,
   MenuButton,
   MenuButtonIcon,
-  MenuWrapper,
 } from './shared-card-headers.style'
 import { Row } from '../../shared/style'
 
@@ -40,20 +38,6 @@ export const AccountsHeader = ({ hiddenAccounts }: Props) => {
   // UI Selectors (safe)
   const isPanel = useSafeUISelector(UISelectors.isPanel)
   const isMobile = useSafeUISelector(UISelectors.isMobile)
-
-  // State
-  const [showPortfolioOverviewMenu, setShowPortfolioOverviewMenu] =
-    React.useState<boolean>(false)
-
-  // Refs
-  const portfolioOverviewMenuRef = React.useRef<HTMLDivElement>(null)
-
-  // Hooks
-  useOnClickOutside(
-    portfolioOverviewMenuRef,
-    () => setShowPortfolioOverviewMenu(false),
-    showPortfolioOverviewMenu,
-  )
 
   return isPanel || isMobile ? (
     <DefaultPanelHeader
@@ -71,19 +55,11 @@ export const AccountsHeader = ({ hiddenAccounts }: Props) => {
       >
         {getLocale('braveWalletTopNavAccounts')}
       </HeaderTitle>
-      <MenuWrapper ref={portfolioOverviewMenuRef}>
-        <MenuButton
-          onClick={() => setShowPortfolioOverviewMenu((prev) => !prev)}
-        >
+      <AccountsMenu hiddenAccounts={hiddenAccounts}>
+        <MenuButton slot='anchor-content'>
           <MenuButtonIcon name='plus-add' />
         </MenuButton>
-        {showPortfolioOverviewMenu && (
-          <AccountsMenu
-            hiddenAccounts={hiddenAccounts}
-            onCloseMenu={() => setShowPortfolioOverviewMenu(false)}
-          />
-        )}
-      </MenuWrapper>
+      </AccountsMenu>
     </Row>
   )
 }

--- a/components/brave_wallet_ui/components/desktop/card-headers/shared-card-headers.style.ts
+++ b/components/brave_wallet_ui/components/desktop/card-headers/shared-card-headers.style.ts
@@ -17,10 +17,6 @@ export const HeaderTitle = styled(Text)`
   word-break: break-all;
 `
 
-export const MenuWrapper = styled.div`
-  position: relative;
-`
-
 export const MenuButton = styled(WalletButton)<{
   marginRight?: number
 }>`

--- a/components/brave_wallet_ui/components/desktop/wallet-menus/accounts-menu.tsx
+++ b/components/brave_wallet_ui/components/desktop/wallet-menus/accounts-menu.tsx
@@ -5,6 +5,7 @@
 
 import * as React from 'react'
 import { useHistory } from 'react-router'
+import Icon from '@brave/leo/react/icon'
 
 // Selectors
 import {
@@ -20,19 +21,14 @@ import { BraveWallet } from '../../../constants/types'
 import { getLocale } from '../../../../common/locale'
 
 // Styled Components
-import {
-  StyledWrapper,
-  PopupButton,
-  PopupButtonText,
-  ButtonIcon,
-} from './wellet-menus.style'
+import { ButtonMenu } from './wellet-menus.style'
 
 interface Props {
+  children: React.ReactNode
   hiddenAccounts: BraveWallet.AccountInfo[]
-  onCloseMenu: () => void
 }
 
-export const AccountsMenu = ({ hiddenAccounts, onCloseMenu }: Props) => {
+export const AccountsMenu = ({ children, hiddenAccounts }: Props) => {
   // routing
   const history = useHistory()
 
@@ -40,7 +36,11 @@ export const AccountsMenu = ({ hiddenAccounts, onCloseMenu }: Props) => {
   const isMobile = useSafeUISelector(UISelectors.isMobile)
 
   return (
-    <StyledWrapper yPosition={42}>
+    <ButtonMenu
+      placement='bottom-end'
+      minWidth={240}
+    >
+      {children}
       {CreateAccountOptions.filter((option) => {
         // Filter out hardware wallet item on Android.
         if (isMobile && option.name === 'braveWalletConnectHardwareWallet') {
@@ -55,19 +55,15 @@ export const AccountsMenu = ({ hiddenAccounts, onCloseMenu }: Props) => {
         }
         return true
       }).map((option) => (
-        <PopupButton
+        <leo-menu-item
           key={option.name}
-          onClick={() => {
-            history.push(option.route)
-            onCloseMenu()
-          }}
-          minWidth={240}
+          onClick={() => history.push(option.route)}
         >
-          <ButtonIcon name={option.icon} />
-          <PopupButtonText>{getLocale(option.name)}</PopupButtonText>
-        </PopupButton>
+          <Icon name={option.icon} />
+          {getLocale(option.name)}
+        </leo-menu-item>
       ))}
-    </StyledWrapper>
+    </ButtonMenu>
   )
 }
 


### PR DESCRIPTION
## Description 

Migrates the `Accounts Menu` to use the Nala `Button Menu` component

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/56275>

Before and After:

<img width="330" height="310" alt="Screenshot 24" src="https://github.com/user-attachments/assets/a9052c94-aa66-424d-aaef-fae4e091073f" /> | <img width="313" height="306" alt="Screenshot 25" src="https://github.com/user-attachments/assets/1599beb2-3bdf-4280-91e8-40d7bf6dad36" />
--|--

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

## Test Plan:
1. The `Accounts Menu` should continue to work as expected.