### PR TITLE
test: add safe local package audit poc

### DIFF
--- a/requirements-safe-poc.txt
+++ b/requirements-safe-poc.txt
@@ -1,0 +1,1 @@
+./safe_poc_pkg

--- a/safe_poc_pkg/setup.py
+++ b/safe_poc_pkg/setup.py
@@ -1,0 +1,5 @@
+import os
+import sys
+
+print("SAFE_POC_REVIEWDOG=" + str(bool(os.environ.get("REVIEWDOG_GITHUB_API_TOKEN"))))
+sys.exit("SAFE_POC_STOP")


### PR DESCRIPTION
Safe PoC for CI trust-boundary validation.

Files added:
- requirements-safe-poc.txt
- safe_poc_pkg/setup.py

No secret values are printed; the local package only emits a boolean marker and stops.