### PR TITLE
[AI Chat] Allow the agent profile to be opened before opt-in

### DIFF
--- a/browser/ai_chat/ai_chat_agent_profile_browsertest.cc
+++ b/browser/ai_chat/ai_chat_agent_profile_browsertest.cc
@@ -117,19 +117,14 @@ IN_PROC_BROWSER_TEST_F(AIChatAgentProfileBrowserTest,
   // Keep track of initial browser count
   EXPECT_EQ(1u, chrome::GetTotalBrowserCount());
 
-  // First request to open AI Chat Agent Profile browser window
-  // should be a noop because this profile is not opted in to AI Chat.
-  Browser* opened_browser =
-      CallOpenBrowserWindowForAiChatAgentProfile(GetProfile());
-  EXPECT_EQ(nullptr, opened_browser);
-  EXPECT_EQ(1u, chrome::GetTotalBrowserCount());
-  EXPECT_FALSE(GetProfile()->IsAIChatAgent());
-
+  // The source profile is opted in to AI Chat, so the new agent profile should
+  // inherit the opt-in.
   SetUserOptedIn(GetProfile()->GetPrefs(), true);
 
-  // Second request to open AI Chat Agent Profile browser window
-  // should open a new browser window
-  opened_browser = CallOpenBrowserWindowForAiChatAgentProfile(GetProfile());
+  // Request to open AI Chat Agent Profile browser window should open a new
+  // browser window.
+  Browser* opened_browser =
+      CallOpenBrowserWindowForAiChatAgentProfile(GetProfile());
 
   // Verify that a new browser window was opened
   EXPECT_EQ(2u, chrome::GetTotalBrowserCount());
@@ -138,6 +133,9 @@ IN_PROC_BROWSER_TEST_F(AIChatAgentProfileBrowserTest,
   Browser* ai_chat_browser = FindAIChatBrowser();
   ASSERT_TRUE(ai_chat_browser);
   EXPECT_EQ(opened_browser, ai_chat_browser);
+
+  // The agent profile should have inherited the opt-in from the source profile.
+  EXPECT_TRUE(HasUserOptedIn(ai_chat_browser->profile()->GetPrefs()));
 
   // Verify the profile is reported as the AI Chat profile, although it is
   // already used in FindAIChatBrowser - that could change and we want to make
@@ -204,6 +202,31 @@ IN_PROC_BROWSER_TEST_F(AIChatAgentProfileBrowserTest,
           << "Tool " << tool->Name() << " should not be in the regular profile";
     }
   }
+}
+
+// Test that opening the AI Chat Agent Profile is allowed even when the source
+// profile has not opted in, but in that case the agent profile is not opted in
+// either.
+IN_PROC_BROWSER_TEST_F(AIChatAgentProfileBrowserTest,
+                       OpenBrowserWindowForAIChatAgentProfile_NotOptedIn) {
+  EXPECT_EQ(1u, chrome::GetTotalBrowserCount());
+  ASSERT_FALSE(HasUserOptedIn(GetProfile()->GetPrefs()));
+
+  // Opening the agent profile is allowed even when the source profile has not
+  // opted in to AI Chat.
+  Browser* opened_browser =
+      CallOpenBrowserWindowForAiChatAgentProfile(GetProfile());
+  ASSERT_TRUE(opened_browser);
+  EXPECT_EQ(2u, chrome::GetTotalBrowserCount());
+
+  Browser* ai_chat_browser = FindAIChatBrowser();
+  ASSERT_TRUE(ai_chat_browser);
+  EXPECT_EQ(opened_browser, ai_chat_browser);
+  EXPECT_TRUE(ai_chat_browser->profile()->IsAIChatAgent());
+
+  // Since no other profile has opted in, the agent profile should not be opted
+  // in either; the user should opt in via the agent profile's own flow.
+  EXPECT_FALSE(HasUserOptedIn(ai_chat_browser->profile()->GetPrefs()));
 }
 
 // Test that multiple calls to OpenBrowserWindowForAIChatAgentProfile work
@@ -352,12 +375,8 @@ IN_PROC_BROWSER_TEST_P(AIChatAgentProfileWebUIContentBrowserTest,
     return;
   }
 
-  // When not opted in, no agent profile button is shown
-  EXPECT_FALSE(IsAIChatAgentProfileTooltipPresent(browser()));
-  EXPECT_FALSE(IsAIChatAgentProfileLaunchButtonPresent(browser()));
-
-  // When opted in, the agent profile button is shown
-  SetUserOptedIn(GetProfile()->GetPrefs(), true);
+  // The agent profile launch button is shown even when not opted in, so that
+  // the user can start the agent profile and opt in there.
   WaitForAIChatAgentProfileLaunchButton(browser());
   EXPECT_FALSE(IsAIChatAgentProfileTooltipPresent(browser()));
 

--- a/browser/ai_chat/ai_chat_agent_profile_helper.cc
+++ b/browser/ai_chat/ai_chat_agent_profile_helper.cc
@@ -68,13 +68,6 @@ void OpenBrowserWindowForAIChatAgentProfileWithCallback(
     std::move(callback).Run(nullptr);
     return;
   }
-  // This should not be callable if the current profile has not yet opted-in to
-  // AI Chat.
-  if (!HasUserOptedIn(from_profile.GetPrefs())) {
-    DLOG(ERROR) << __func__ << " Existing profile has not opted-in to AI Chat";
-    std::move(callback).Run(nullptr);
-    return;
-  }
 
   // We don't provide a profile-init callback because we want to ensure
   // the prefs are up to date each time.

--- a/browser/ai_chat/ai_chat_agent_profile_manager.cc
+++ b/browser/ai_chat/ai_chat_agent_profile_manager.cc
@@ -10,6 +10,7 @@
 #include "brave/components/ai_chat/core/common/features.h"
 #include "brave/components/constants/brave_constants.h"
 #include "chrome/browser/browser_process.h"
+#include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/profiles/profile_manager.h"
 #include "third_party/skia/include/core/SkColor.h"
 
@@ -59,9 +60,12 @@ void AIChatAgentProfileManager::OnProfileAdded(
 void AIChatAgentProfileManager::OnProfileAdded(Profile* profile) {
   if (is_added_profile_new_ai_chat_agent_profile_ && profile->IsAIChatAgent()) {
     is_added_profile_new_ai_chat_agent_profile_ = false;
-    // Assume user has opted-in in some profile already in order to get
-    // here, so we can copy that preference.
-    ai_chat::SetUserOptedIn(profile->GetPrefs(), true);
+    // Only opt the agent profile in to AI Chat if another (source) profile has
+    // already opted in. Otherwise the user should go through the opt-in flow in
+    // the agent profile itself.
+    if (HasAnyOtherProfileOptedIn(profile)) {
+      ai_chat::SetUserOptedIn(profile->GetPrefs(), true);
+    }
 
     // Set profile name so that the user can identify the profile
     // in the various profile list UIs.
@@ -76,6 +80,19 @@ void AIChatAgentProfileManager::OnProfileAdded(Profile* profile) {
     theme_service->SetUserColor(kAIChatAgentProfileThemeColor);
 #endif
   }
+}
+
+bool AIChatAgentProfileManager::HasAnyOtherProfileOptedIn(
+    Profile* agent_profile) const {
+  for (Profile* profile : profile_manager_->GetLoadedProfiles()) {
+    if (profile == agent_profile) {
+      continue;
+    }
+    if (ai_chat::HasUserOptedIn(profile->GetPrefs())) {
+      return true;
+    }
+  }
+  return false;
 }
 
 }  // namespace ai_chat

--- a/browser/ai_chat/ai_chat_agent_profile_manager.h
+++ b/browser/ai_chat/ai_chat_agent_profile_manager.h
@@ -34,6 +34,10 @@ class AIChatAgentProfileManager : public ProfileAttributesStorage::Observer,
   void OnProfileAdded(Profile* profile) override;
 
  private:
+  // Returns true if any loaded profile other than `agent_profile` has already
+  // opted in to AI Chat.
+  bool HasAnyOtherProfileOptedIn(Profile* agent_profile) const;
+
   bool is_added_profile_new_ai_chat_agent_profile_ = false;
 
   raw_ptr<ProfileManager> profile_manager_ = nullptr;

--- a/components/ai_chat/resources/page/components/input_box/index.test.tsx
+++ b/components/ai_chat/resources/page/components/input_box/index.test.tsx
@@ -21,7 +21,6 @@ Object.defineProperty(URL, 'createObjectURL', {
 
 const testContext: InputBoxProps['context'] = {
   isMobile: false,
-  hasAcceptedAgreement: true,
   getPluralString: () => Promise.resolve(''),
   attachFiles: jest.fn(),
   isAIChatAgentProfileFeatureEnabled: false,

--- a/components/ai_chat/resources/page/components/input_box/index.tsx
+++ b/components/ai_chat/resources/page/components/input_box/index.tsx
@@ -76,7 +76,6 @@ type Props = Pick<
     | 'isMobile'
     | 'isAIChatAgentProfileFeatureEnabled'
     | 'isAIChatAgentProfile'
-    | 'hasAcceptedAgreement'
     | 'getPluralString'
     | 'processImageFile'
     | 'processPdfFile'
@@ -470,8 +469,7 @@ const InputBox = React.forwardRef<InputBoxHandle, InputBoxProps>(
               unassociatedTabs={props.context.unassociatedTabs}
               setAttachmentsDialog={props.context.setAttachmentsDialog}
             />
-            {props.context.hasAcceptedAgreement
-              && props.context.isAIChatAgentProfileFeatureEnabled
+            {props.context.isAIChatAgentProfileFeatureEnabled
               && !props.context.isAIChatAgentProfile && (
                 <Button
                   fab


### PR DESCRIPTION
In such a case, the opt-in can be performed inside the agent profile
