### PR TITLE
[screenshot] Add capture engine for visible area and full page

### DIFF
--- a/app/brave_generated_resources.grd
+++ b/app/brave_generated_resources.grd
@@ -517,6 +517,11 @@ Or change later at <ph name="SETTINGS_EXTENIONS_LINK">$2<ex>brave://settings/ext
         Leo AI
       </message>
 
+      <!-- Screenshot feature strings -->
+      <message name="IDS_BRAVE_SCREENSHOT_BUBBLE_TITLE" desc="Title of the screenshot capture bubble and download selection dialog">
+        Capture screenshot
+      </message>
+
       <!-- Extensions page strings -->
       <message name="IDS_EXTENSIONS_BRAVE_ITEM_SOURCE_WEBSTORE" desc="The text to indicate that an extension is from the Web Extensions Store.">
         Web Extensions Store

--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -129,6 +129,7 @@
 #include "brave/browser/ui/darker_theme/features.h"
 #include "brave/browser/ui/focus_mode/focus_mode_features.h"
 #include "brave/browser/ui/page_info/features.h"
+#include "brave/browser/ui/screenshot/features.h"
 #endif
 
 #define EXPAND_FEATURE_ENTRIES(...) __VA_ARGS__,
@@ -828,6 +829,20 @@ constexpr flags_ui::FeatureEntry::Choice kVerticalTabCollapseDelayChoices[] = {
 #define BRAVE_WORKSPACE_FEATURE_ENTRY
 #endif
 
+#if defined(TOOLKIT_VIEWS)
+#define BRAVE_SCREENSHOT_FEATURE_ENTRY                                        \
+  EXPAND_FEATURE_ENTRIES({                                                    \
+      "brave-screenshot",                                                     \
+      "Enable Brave Screenshot",                                              \
+      "Adds a toolbar button for capturing the visible area or full page as " \
+      "a PNG.",                                                               \
+      kOsDesktop,                                                             \
+      FEATURE_VALUE_TYPE(screenshot::features::kBraveScreenshot),             \
+  })
+#else
+#define BRAVE_SCREENSHOT_FEATURE_ENTRY
+#endif
+
 // Keep the last item empty.
 #define LAST_BRAVE_FEATURE_ENTRIES_ITEM
 
@@ -1425,6 +1440,7 @@ constexpr flags_ui::FeatureEntry::Choice kVerticalTabCollapseDelayChoices[] = {
       kOsDesktop | kOsAndroid,                                                 \
       FEATURE_VALUE_TYPE(brave_origin::features::kBraveOrigin),                \
   })                                                                           \
+  BRAVE_SCREENSHOT_FEATURE_ENTRY                                               \
   LAST_BRAVE_FEATURE_ENTRIES_ITEM  // Keep it as the last item.
 namespace flags_ui {
 namespace {

--- a/browser/ai_chat/print_preview_extraction_delegate_impl.cc
+++ b/browser/ai_chat/print_preview_extraction_delegate_impl.cc
@@ -10,15 +10,16 @@
 namespace ai_chat {
 
 PrintPreviewExtractionDelegateImpl::PrintPreviewExtractionDelegateImpl(
+    content::WebContents* web_contents,
     std::unique_ptr<screenshot::PrintPreviewExtractor> extractor)
-    : extractor_(std::move(extractor)) {}
+    : extractor_(std::move(extractor)), web_contents_(web_contents) {}
 
 PrintPreviewExtractionDelegateImpl::~PrintPreviewExtractionDelegateImpl() =
     default;
 
 void PrintPreviewExtractionDelegateImpl::CaptureImages(
     CaptureImagesCallback callback) {
-  extractor_->CaptureImages(std::move(callback));
+  extractor_->CaptureImages(web_contents_, std::move(callback));
 }
 
 }  // namespace ai_chat

--- a/browser/ai_chat/print_preview_extraction_delegate_impl.h
+++ b/browser/ai_chat/print_preview_extraction_delegate_impl.h
@@ -15,6 +15,10 @@
 
 static_assert(BUILDFLAG(ENABLE_PRINT_PREVIEW));
 
+namespace content {
+class WebContents;
+}  // namespace content
+
 namespace ai_chat {
 
 // Adapts the browser-layer PrintPreviewExtractor to the AI Chat
@@ -22,7 +26,8 @@ namespace ai_chat {
 class PrintPreviewExtractionDelegateImpl
     : public AssociatedWebContentsContent::PrintPreviewExtractionDelegate {
  public:
-  explicit PrintPreviewExtractionDelegateImpl(
+  PrintPreviewExtractionDelegateImpl(
+      content::WebContents* web_contents,
       std::unique_ptr<screenshot::PrintPreviewExtractor> extractor);
   ~PrintPreviewExtractionDelegateImpl() override;
 
@@ -36,6 +41,7 @@ class PrintPreviewExtractionDelegateImpl
 
  private:
   std::unique_ptr<screenshot::PrintPreviewExtractor> extractor_;
+  raw_ptr<content::WebContents> web_contents_;
 };
 
 }  // namespace ai_chat

--- a/browser/brave_tab_helpers.cc
+++ b/browser/brave_tab_helpers.cc
@@ -160,8 +160,8 @@ void AttachTabHelpers(content::WebContents* web_contents) {
         web_contents,
 #if BUILDFLAG(ENABLE_PRINT_PREVIEW)
         std::make_unique<ai_chat::PrintPreviewExtractionDelegateImpl>(
+            web_contents,
             screenshot::CreatePrintPreviewExtractor(
-                web_contents,
                 base::BindRepeating(
                     []() -> base::IDMap<printing::mojom::PrintPreviewUI*>& {
                       return printing::PrintPreviewUI::GetPrintPreviewUIIdMap();

--- a/browser/screenshot/print_preview_extractor.cc
+++ b/browser/screenshot/print_preview_extractor.cc
@@ -17,17 +17,16 @@
 
 namespace screenshot {
 
-PrintPreviewExtractor::PrintPreviewExtractor(content::WebContents* web_contents,
-                                             CreateExtractorCallback callback)
-    : create_extractor_callback_(std::move(callback)),
-      web_contents_(web_contents) {}
+PrintPreviewExtractor::PrintPreviewExtractor(CreateExtractorCallback callback)
+    : create_extractor_callback_(std::move(callback)) {}
 
 PrintPreviewExtractor::~PrintPreviewExtractor() = default;
 
-void PrintPreviewExtractor::CaptureImages(CaptureImagesCallback callback) {
+void PrintPreviewExtractor::CaptureImages(content::WebContents* web_contents,
+                                          CaptureImagesCallback callback) {
   // Overwrite any existing extraction in progress, cancelling the operation.
   extractor_ = create_extractor_callback_.Run(
-      web_contents_, screenshot::IsPdf(web_contents_),
+      web_contents, screenshot::IsPdf(web_contents),
       CaptureImagesCallback(base::BindOnce(&PrintPreviewExtractor::OnComplete,
                                            weak_ptr_factory_.GetWeakPtr(),
                                            std::move(callback))));

--- a/browser/screenshot/print_preview_extractor.h
+++ b/browser/screenshot/print_preview_extractor.h
@@ -43,13 +43,13 @@ class PrintPreviewExtractor {
           bool is_pdf,
           CaptureImagesCallback&&)>;
 
-  PrintPreviewExtractor(content::WebContents* web_contents,
-                        CreateExtractorCallback callback);
+  explicit PrintPreviewExtractor(CreateExtractorCallback callback);
   ~PrintPreviewExtractor();
   PrintPreviewExtractor(const PrintPreviewExtractor&) = delete;
   PrintPreviewExtractor& operator=(const PrintPreviewExtractor&) = delete;
 
-  void CaptureImages(CaptureImagesCallback callback);
+  void CaptureImages(content::WebContents* web_contents,
+                     CaptureImagesCallback callback);
 
  private:
   friend class PrintPreviewExtractorTest;
@@ -59,7 +59,6 @@ class PrintPreviewExtractor {
 
   CreateExtractorCallback create_extractor_callback_;
   std::unique_ptr<Extractor> extractor_;
-  raw_ptr<content::WebContents> web_contents_;
 
   base::WeakPtrFactory<PrintPreviewExtractor> weak_ptr_factory_{this};
 };

--- a/browser/screenshot/print_preview_extractor_factory.cc
+++ b/browser/screenshot/print_preview_extractor_factory.cc
@@ -12,32 +12,28 @@
 #include "brave/browser/screenshot/print_preview_extractor.h"
 #include "brave/browser/screenshot/print_preview_extractor_internal.h"
 #include "chrome/browser/profiles/profile.h"
-#include "content/public/browser/web_contents.h"
 
 namespace screenshot {
 
 std::unique_ptr<PrintPreviewExtractor> CreatePrintPreviewExtractor(
-    content::WebContents* web_contents,
     base::RepeatingCallback<base::IDMap<printing::mojom::PrintPreviewUI*>&()>
         id_map_callback,
     base::RepeatingCallback<base::flat_map<int, int>&()>
         request_id_map_callback) {
-  return std::make_unique<PrintPreviewExtractor>(
-      web_contents,
-      base::BindRepeating(
-          [](base::RepeatingCallback<base::IDMap<
-                 printing::mojom::PrintPreviewUI*>&()> id_map_callback,
-             base::RepeatingCallback<base::flat_map<int, int>&()>
-                 request_id_map_callback,
-             content::WebContents* wc, bool is_pdf,
-             PrintPreviewExtractor::CaptureImagesCallback&& callback)
-              -> std::unique_ptr<PrintPreviewExtractor::Extractor> {
-            return std::make_unique<PrintPreviewExtractorInternal>(
-                wc, Profile::FromBrowserContext(wc->GetBrowserContext()),
-                is_pdf, std::move(callback), std::move(id_map_callback),
-                std::move(request_id_map_callback));
-          },
-          std::move(id_map_callback), std::move(request_id_map_callback)));
+  return std::make_unique<PrintPreviewExtractor>(base::BindRepeating(
+      [](base::RepeatingCallback<
+             base::IDMap<printing::mojom::PrintPreviewUI*>&()> id_map_callback,
+         base::RepeatingCallback<base::flat_map<int, int>&()>
+             request_id_map_callback,
+         content::WebContents* wc, bool is_pdf,
+         PrintPreviewExtractor::CaptureImagesCallback&& callback)
+          -> std::unique_ptr<PrintPreviewExtractor::Extractor> {
+        return std::make_unique<PrintPreviewExtractorInternal>(
+            wc, Profile::FromBrowserContext(wc->GetBrowserContext()), is_pdf,
+            std::move(callback), std::move(id_map_callback),
+            std::move(request_id_map_callback));
+      },
+      std::move(id_map_callback), std::move(request_id_map_callback)));
 }
 
 }  // namespace screenshot

--- a/browser/screenshot/print_preview_extractor_factory.h
+++ b/browser/screenshot/print_preview_extractor_factory.h
@@ -15,19 +15,13 @@
 
 static_assert(BUILDFLAG(ENABLE_PRINT_PREVIEW));
 
-namespace content {
-class WebContents;
-}  // namespace content
-
 namespace screenshot {
 
 // Constructs a PrintPreviewExtractor wired up with the default Extractor
 // factory used in production (PrintPreviewExtractorInternal).
 // Deps to callbacks are injected from the caller to avoid circular dependencies
-// between this module and the `chrome/browser/ui/` target. See
-// brave_tab_helpers.cc.
+// between this module and the `chrome/browser/ui/` target.
 std::unique_ptr<PrintPreviewExtractor> CreatePrintPreviewExtractor(
-    content::WebContents* web_contents,
     base::RepeatingCallback<base::IDMap<printing::mojom::PrintPreviewUI*>&()>
         id_map_callback,
     base::RepeatingCallback<base::flat_map<int, int>&()>

--- a/browser/screenshot/print_preview_extractor_unittest.cc
+++ b/browser/screenshot/print_preview_extractor_unittest.cc
@@ -249,7 +249,6 @@ class PrintPreviewExtractorTest : public ChromeRenderViewHostTestHarness {
                       ui::PageTransition::PAGE_TRANSITION_FIRST);
     printing::PrintCompositeClient::CreateForWebContents(web_contents());
     pp_extractor_ = std::make_unique<PrintPreviewExtractor>(
-        web_contents(),
         base::BindRepeating([](content::WebContents* web_contents, bool is_pdf,
                                PrintPreviewExtractor::CaptureImagesCallback&&
                                    callback)
@@ -363,7 +362,7 @@ class PrintPreviewExtractorTest : public ChromeRenderViewHostTestHarness {
     base::test::TestFuture<
         base::expected<std::vector<std::vector<uint8_t>>, std::string>>
         future;
-    pp_extractor_->CaptureImages(future.GetCallback());
+    pp_extractor_->CaptureImages(web_contents(), future.GetCallback());
     auto result = future.Take();
     ASSERT_FALSE(result.has_value());
     EXPECT_EQ(result.error(), "PrintPreviewFailed");
@@ -402,7 +401,7 @@ class PrintPreviewExtractorTest : public ChromeRenderViewHostTestHarness {
     base::test::TestFuture<
         base::expected<std::vector<std::vector<uint8_t>>, std::string>>
         future;
-    pp_extractor_->CaptureImages(future.GetCallback());
+    pp_extractor_->CaptureImages(web_contents(), future.GetCallback());
     auto result = future.Take();
     ASSERT_FALSE(result.has_value());
     EXPECT_EQ(result.error(), expected_error_message);
@@ -499,7 +498,7 @@ TEST_F(PrintPreviewExtractorTest, CaptureImagesWithNonPdf) {
   base::test::TestFuture<
       base::expected<std::vector<std::vector<uint8_t>>, std::string>>
       future;
-  pp_extractor_->CaptureImages(future.GetCallback());
+  pp_extractor_->CaptureImages(web_contents(), future.GetCallback());
   auto result = future.Take();
   ASSERT_FALSE(result.has_value());
   EXPECT_EQ(result.error(), "PrintPreviewFailed");
@@ -584,7 +583,7 @@ TEST_F(PrintPreviewExtractorTest, PrintPreviewData) {
         MockPrintPreviewPrintRenderFrame::ExpectedError::kNone);
 
     base::test::TestFuture<ImageResult> future;
-    pp_extractor_->CaptureImages(future.GetCallback());
+    pp_extractor_->CaptureImages(web_contents(), future.GetCallback());
     RunTestCase(future, test_case.mime_type, test_case.expected_error_msg,
                 test_case.extractor_error,
                 test_case.simulate_partial_composition);

--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -1434,6 +1434,7 @@ source_set("ui") {
 
   if (toolkit_views) {
     deps += [
+      "//brave/browser/ui/screenshot",
       "//components/constrained_window",
       "//ui/events",
       "//ui/views",

--- a/browser/ui/browser_window/internal/BUILD.gn
+++ b/browser/ui/browser_window/internal/BUILD.gn
@@ -22,8 +22,10 @@ source_set("internal") {
     "//brave/components/brave_vpn/common/buildflags",
     "//brave/components/email_aliases/buildflags",
     "//brave/components/playlist/core/common/buildflags",
+    "//chrome/browser/profiles:profile",
     "//chrome/browser/tab_group_sync:factories",
     "//chrome/browser/ui/browser_window",
+    "//printing/buildflags",
   ]
 
   if (enable_playlist) {
@@ -48,10 +50,6 @@ source_set("internal") {
     ]
   }
 
-  deps += [
-    "//chrome/browser/profiles:profile",
-    "//printing/buildflags",
-  ]
   if (enable_print_preview) {
     deps += [ "//brave/browser/screenshot" ]
   }

--- a/browser/ui/browser_window/internal/BUILD.gn
+++ b/browser/ui/browser_window/internal/BUILD.gn
@@ -8,6 +8,7 @@ import("//brave/components/brave_vpn/common/buildflags/buildflags.gni")
 import("//brave/components/email_aliases/buildflags/buildflags.gni")
 import("//brave/components/playlist/core/common/buildflags/buildflags.gni")
 import("//build/config/ui.gni")
+import("//printing/buildflags/buildflags.gni")
 
 source_set("internal") {
   sources = []
@@ -39,11 +40,20 @@ source_set("internal") {
   if (!is_android) {
     deps += [
       "//brave/browser/ui/focus_mode",
+      "//brave/browser/ui/screenshot",
       "//brave/browser/ui/tabs:tab_menu",
       "//brave/browser/ui/tabs:tree_tab_session_manager",
       "//brave/browser/ui/views/page_info",
       "//chrome/browser/ui/tabs:features",
     ]
+  }
+
+  deps += [
+    "//chrome/browser/profiles:profile",
+    "//printing/buildflags",
+  ]
+  if (enable_print_preview) {
+    deps += [ "//brave/browser/screenshot" ]
   }
 
   if (enable_brave_rewards) {

--- a/browser/ui/browser_window/internal/browser_window_features.cc
+++ b/browser/ui/browser_window/internal/browser_window_features.cc
@@ -5,12 +5,15 @@
 
 #include "chrome/browser/ui/browser_window/public/browser_window_features.h"
 
+#include "base/containers/flat_map.h"
 #include "base/feature_list.h"
+#include "base/functional/bind.h"
 #include "base/memory/ptr_util.h"
 #include "base/notreached.h"
 #include "brave/browser/ui/brave_browser_window.h"
 #include "brave/browser/ui/focus_mode/focus_mode_controller.h"
 #include "brave/browser/ui/focus_mode/focus_mode_utils.h"
+#include "brave/browser/ui/screenshot/screenshot_controller.h"
 #include "brave/browser/ui/sidebar/sidebar_controller.h"
 #include "brave/browser/ui/sidebar/sidebar_utils.h"
 #include "brave/browser/ui/tabs/brave_browser_tab_menu_model_delegate.h"
@@ -21,11 +24,14 @@
 #include "brave/components/brave_vpn/common/buildflags/buildflags.h"
 #include "brave/components/email_aliases/buildflags/buildflags.h"
 #include "brave/components/playlist/core/common/buildflags/buildflags.h"
+#include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/tab_group_sync/tab_group_sync_service_factory.h"
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/browser_window/public/browser_window_interface.h"
 #include "chrome/browser/ui/tabs/features.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
+#include "printing/buildflags/buildflags.h"
+#include "ui/gfx/native_ui_types.h"
 
 #if BUILDFLAG(ENABLE_BRAVE_REWARDS)
 #include "brave/browser/brave_rewards/rewards_service_factory.h"
@@ -34,6 +40,11 @@
 
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
 #include "brave/browser/ui/brave_vpn/brave_vpn_controller.h"
+#endif
+
+#if BUILDFLAG(ENABLE_PRINT_PREVIEW)
+#include "brave/browser/screenshot/print_preview_extractor_factory.h"
+#include "chrome/browser/ui/webui/print_preview/print_preview_ui.h"
 #endif
 
 #if !BUILDFLAG(ENABLE_BRAVE_REWARDS)
@@ -145,12 +156,42 @@ void BrowserWindowFeatures::InitPostBrowserViewConstruction(
   brave_vpn_controller_ = std::make_unique<BraveVPNController>(browser_view);
 #endif
 
+#if BUILDFLAG(ENABLE_PRINT_PREVIEW)
+  {
+    auto extractor = screenshot::CreatePrintPreviewExtractor(
+        base::BindRepeating(
+            []() -> base::IDMap<printing::mojom::PrintPreviewUI*>& {
+              return printing::PrintPreviewUI::GetPrintPreviewUIIdMap();
+            }),
+        base::BindRepeating([]() -> base::flat_map<int, int>& {
+          return printing::PrintPreviewUI::GetPrintPreviewUIRequestIdMap();
+        }));
+    screenshot_controller_ = std::make_unique<screenshot::ScreenshotController>(
+        browser_view->GetProfile(),
+        base::BindRepeating(
+            [](BrowserView* bv) -> gfx::NativeWindow {
+              return bv->GetNativeWindow();
+            },
+            browser_view),
+        base::BindRepeating([]() { return base::FilePath(); }),
+        std::move(extractor));
+  }
+#else
+  screenshot_controller_ = std::make_unique<screenshot::ScreenshotController>(
+      browser_view->GetProfile(), base::BindRepeating(
+                                      [](BrowserView* bv) -> gfx::NativeWindow {
+                                        return bv->GetNativeWindow();
+                                      },
+                                      browser_view));
+#endif
+
   BrowserWindowFeatures_ChromiumImpl::InitPostBrowserViewConstruction(
       browser_view);
 }
 
 void BrowserWindowFeatures::TearDownPreBrowserWindowDestruction() {
   BrowserWindowFeatures_ChromiumImpl::TearDownPreBrowserWindowDestruction();
+  screenshot_controller_.reset();
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
   brave_vpn_controller_.reset();
 #endif

--- a/browser/ui/browser_window/internal/browser_window_features.cc
+++ b/browser/ui/browser_window/internal/browser_window_features.cc
@@ -173,7 +173,6 @@ void BrowserWindowFeatures::InitPostBrowserViewConstruction(
               return bv->GetNativeWindow();
             },
             browser_view),
-        base::BindRepeating([]() { return base::FilePath(); }),
         std::move(extractor));
   }
 #else

--- a/browser/ui/browser_window/public/browser_window_features.h
+++ b/browser/ui/browser_window/public/browser_window_features.h
@@ -32,6 +32,10 @@ class EmailAliasesController;
 }  // namespace email_aliases
 #endif
 
+namespace screenshot {
+class ScreenshotController;
+}  // namespace screenshot
+
 // This file doesn't include header file for BrowserWindowFeatures_ChromiumImpl
 // because this file only could be included at the bottom of
 // //chrome/browser/ui/browser_window/public/browser_window_features.h. So we
@@ -88,6 +92,10 @@ class BrowserWindowFeatures : public BrowserWindowFeatures_ChromiumImpl {
     return tree_tab_session_manager_.get();
   }
 
+  screenshot::ScreenshotController* screenshot_controller() {
+    return screenshot_controller_.get();
+  }
+
  private:
   std::unique_ptr<sidebar::SidebarController> sidebar_controller_;
   std::unique_ptr<BraveVPNController> brave_vpn_controller_;
@@ -106,6 +114,7 @@ class BrowserWindowFeatures : public BrowserWindowFeatures_ChromiumImpl {
   std::unique_ptr<BraveNonClientHitTestHelper>
       brave_non_client_hit_test_helper_;
   std::unique_ptr<TreeTabSessionManager> tree_tab_session_manager_;
+  std::unique_ptr<screenshot::ScreenshotController> screenshot_controller_;
 };
 
 #endif  // BRAVE_BROWSER_UI_BROWSER_WINDOW_PUBLIC_BROWSER_WINDOW_FEATURES_H_

--- a/browser/ui/screenshot/BUILD.gn
+++ b/browser/ui/screenshot/BUILD.gn
@@ -1,0 +1,55 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import("//printing/buildflags/buildflags.gni")
+
+source_set("screenshot") {
+  sources = [
+    "features.cc",
+    "features.h",
+    "screenshot_controller.cc",
+    "screenshot_controller.h",
+  ]
+
+  public_deps = [
+    "//printing/buildflags",
+    "//skia",
+    "//ui/gfx",
+    "//ui/shell_dialogs",
+  ]
+
+  deps = [
+    "//base",
+    "//brave/app:brave_generated_resources_grit",
+    "//chrome/app:generated_resources",
+    "//chrome/browser/download",
+    "//components/viz/common",
+    "//content/public/browser",
+    "//ui/base",
+    "//ui/gfx/codec",
+  ]
+
+  if (enable_print_preview) {
+    deps += [ "//brave/browser/screenshot" ]
+  }
+}
+
+source_set("unit_tests") {
+  testonly = true
+  sources = [ "screenshot_controller_unittest.cc" ]
+  deps = [
+    ":screenshot",
+    "//base",
+    "//base/test:test_support",
+    "//chrome/test:test_support",
+    "//content/test:test_support",
+    "//printing/buildflags",
+    "//skia",
+    "//testing/gtest",
+    "//ui/gfx",
+    "//ui/gfx/codec",
+    "//ui/shell_dialogs:test_support",
+  ]
+}

--- a/browser/ui/screenshot/features.cc
+++ b/browser/ui/screenshot/features.cc
@@ -1,0 +1,18 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/browser/ui/screenshot/features.h"
+
+#include "base/feature_list.h"
+
+namespace screenshot::features {
+
+BASE_FEATURE(kBraveScreenshot, base::FEATURE_DISABLED_BY_DEFAULT);
+
+bool IsScreenshotEnabled() {
+  return base::FeatureList::IsEnabled(kBraveScreenshot);
+}
+
+}  // namespace screenshot::features

--- a/browser/ui/screenshot/features.h
+++ b/browser/ui/screenshot/features.h
@@ -1,0 +1,19 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_BROWSER_UI_SCREENSHOT_FEATURES_H_
+#define BRAVE_BROWSER_UI_SCREENSHOT_FEATURES_H_
+
+#include "base/feature.h"
+
+namespace screenshot::features {
+
+BASE_DECLARE_FEATURE(kBraveScreenshot);
+
+bool IsScreenshotEnabled();
+
+}  // namespace screenshot::features
+
+#endif  // BRAVE_BROWSER_UI_SCREENSHOT_FEATURES_H_

--- a/browser/ui/screenshot/screenshot_controller.cc
+++ b/browser/ui/screenshot/screenshot_controller.cc
@@ -236,7 +236,7 @@ void ScreenshotController::OnFullPageChunks(ChunkResult result) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
 
   if (!result.has_value()) {
-    VLOG(1) << "Full page capture failed: " << result.error();
+    DVLOG(1) << "Full page capture failed: " << result.error();
     FinishWithError(Error::kCaptureFailed);
     return;
   }

--- a/browser/ui/screenshot/screenshot_controller.cc
+++ b/browser/ui/screenshot/screenshot_controller.cc
@@ -158,9 +158,10 @@ ScreenshotController::~ScreenshotController() {
 base::expected<void, ScreenshotController::Error>
 ScreenshotController::CanCapture(content::WebContents* web_contents) const {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-  if (busy_) {
+  if (pending_callback_) {
     return base::unexpected(Error::kBusy);
   }
+
   if (!web_contents || !web_contents->GetRenderWidgetHostView()) {
     return base::unexpected(Error::kNoTab);
   }
@@ -178,7 +179,6 @@ void ScreenshotController::CaptureVisibleArea(
   auto* view = web_contents->GetRenderWidgetHostView();
   CHECK(view);
 
-  busy_ = true;
   pending_callback_ = std::move(done);
 
   // CopyFromSurface's callback isn't guaranteed to run on the calling sequence,
@@ -210,7 +210,6 @@ void ScreenshotController::CaptureFullPage(content::WebContents* web_contents,
     return;
   }
 
-  busy_ = true;
   pending_callback_ = std::move(done);
 
   auto on_chunks = base::BindOnce(&ScreenshotController::OnFullPageChunks,
@@ -342,7 +341,8 @@ void ScreenshotController::FinishWithError(Error error) {
 
 void ScreenshotController::Reset() {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-  busy_ = false;
+  CHECK(pending_callback_) << "Reset() called without a pending operation. The "
+                              "callback should be called before Reset()";
   pending_png_.clear();
   if (select_dialog_) {
     select_dialog_->ListenerDestroyed();

--- a/browser/ui/screenshot/screenshot_controller.cc
+++ b/browser/ui/screenshot/screenshot_controller.cc
@@ -1,0 +1,351 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/browser/ui/screenshot/screenshot_controller.h"
+
+#include <algorithm>
+#include <utility>
+
+#include "base/containers/span.h"
+#include "base/files/file_util.h"
+#include "base/functional/bind.h"
+#include "base/logging.h"
+#include "base/task/bind_post_task.h"
+#include "base/task/thread_pool.h"
+#include "base/time/time.h"
+#include "brave/grit/brave_generated_resources.h"
+#include "chrome/browser/download/download_prefs.h"
+#include "components/viz/common/frame_sinks/copy_output_result.h"
+#include "content/public/browser/render_widget_host_view.h"
+#include "content/public/browser/web_contents.h"
+#include "third_party/abseil-cpp/absl/strings/str_format.h"
+#include "third_party/skia/include/core/SkBitmap.h"
+#include "third_party/skia/include/core/SkCanvas.h"
+#include "third_party/skia/include/core/SkColor.h"
+#include "third_party/skia/include/core/SkImage.h"
+#include "third_party/skia/include/core/SkRect.h"
+#include "ui/base/l10n/l10n_util.h"
+#include "ui/gfx/codec/png_codec.h"
+#include "ui/shell_dialogs/select_file_policy.h"
+#include "ui/shell_dialogs/selected_file_info.h"
+
+#if BUILDFLAG(ENABLE_PRINT_PREVIEW)
+#include "brave/browser/screenshot/print_preview_extractor.h"
+#endif
+
+namespace screenshot {
+
+namespace {
+
+#if BUILDFLAG(ENABLE_PRINT_PREVIEW)
+// Cap to avoid OOM on extremely tall stitched pages.
+constexpr int64_t kMaxStitchedBytes = 512LL * 1024 * 1024;
+
+std::optional<std::vector<uint8_t>> StitchAndEncode(
+    std::vector<std::vector<uint8_t>> chunks) {
+  if (chunks.empty()) {
+    return std::nullopt;
+  }
+
+  std::vector<SkBitmap> opaque_chunks;
+  opaque_chunks.reserve(chunks.size());
+  for (const auto& png : chunks) {
+    SkBitmap bmp = gfx::PNGCodec::Decode(png);
+    if (bmp.drawsNothing()) {
+      return std::nullopt;
+    }
+    SkIRect bounds = bmp.bounds();
+    if (bounds.isEmpty()) {
+      continue;
+    }
+    opaque_chunks.push_back(std::move(bmp));
+  }
+  if (opaque_chunks.empty()) {
+    return std::nullopt;
+  }
+
+  int width = 0;
+  int total_height = 0;
+  for (const auto& bitmap : opaque_chunks) {
+    width = std::max(width, bitmap.bounds().width());
+    total_height += bitmap.bounds().height();
+  }
+  if (width <= 0 || total_height <= 0) {
+    return std::nullopt;
+  }
+  if (static_cast<int64_t>(width) * total_height * 4 > kMaxStitchedBytes) {
+    return std::nullopt;
+  }
+
+  SkBitmap out;
+  if (!out.tryAllocN32Pixels(width, total_height)) {
+    return std::nullopt;
+  }
+  SkCanvas canvas(out);
+  canvas.clear(SK_ColorWHITE);
+  int y_offset = 0;
+  for (const auto& bitmap : opaque_chunks) {
+    // Draw only the opaque region of the chunk at (0, y_offset).
+    SkRect src = SkRect::Make(bitmap.bounds());
+    SkRect dst = SkRect::MakeXYWH(0, y_offset, bitmap.bounds().width(),
+                                  bitmap.bounds().height());
+    canvas.drawImageRect(bitmap.asImage(), src, dst, SkSamplingOptions(),
+                         /*paint=*/nullptr,
+                         SkCanvas::kStrict_SrcRectConstraint);
+    y_offset += bitmap.bounds().height();
+  }
+
+  return gfx::PNGCodec::EncodeBGRASkBitmap(out, /*discard_transparency=*/true);
+}
+#endif  // BUILDFLAG(ENABLE_PRINT_PREVIEW)
+
+std::optional<std::vector<uint8_t>> EncodeBitmap(const SkBitmap& bitmap) {
+  if (bitmap.drawsNothing()) {
+    return std::nullopt;
+  }
+  return gfx::PNGCodec::EncodeBGRASkBitmap(bitmap,
+                                           /*discard_transparency=*/true);
+}
+
+bool WritePngFile(const base::FilePath& path, base::span<const uint8_t> bytes) {
+  return base::WriteFile(path, bytes);
+}
+
+base::FilePath BuildDefaultPath(const base::FilePath& download_dir) {
+  base::Time::Exploded now;
+  base::Time::Now().LocalExplode(&now);
+  std::string name = absl::StrFormat(
+      "screenshot-%04d-%02d-%02d-%02d%02d%02d.png", now.year, now.month,
+      now.day_of_month, now.hour, now.minute, now.second);
+  return base::GetUniquePath(download_dir.AppendASCII(name));
+}
+
+}  // namespace
+
+ScreenshotController::ScreenshotController(
+    content::BrowserContext* profile,
+    NativeWindowGetter parent_window_getter,
+    DownloadDirGetter download_dir_getter)
+    : parent_window_getter_(std::move(parent_window_getter)),
+      download_dir_getter_(std::move(download_dir_getter)),
+      profile_(profile) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+}
+
+#if BUILDFLAG(ENABLE_PRINT_PREVIEW)
+ScreenshotController::ScreenshotController(
+    content::BrowserContext* profile,
+    NativeWindowGetter parent_window_getter,
+    DownloadDirGetter download_dir_getter,
+    std::unique_ptr<screenshot::PrintPreviewExtractor> print_preview_extractor)
+    : parent_window_getter_(std::move(parent_window_getter)),
+      download_dir_getter_(std::move(download_dir_getter)),
+      print_preview_extractor_(std::move(print_preview_extractor)),
+      profile_(profile) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+
+  CHECK(print_preview_extractor_);
+}
+#endif
+
+ScreenshotController::~ScreenshotController() {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  if (select_dialog_) {
+    select_dialog_->ListenerDestroyed();
+  }
+}
+
+bool ScreenshotController::CanCapture(
+    content::WebContents* web_contents) const {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  if (busy_ || !web_contents) {
+    return false;
+  }
+  return web_contents->GetRenderWidgetHostView() != nullptr;
+}
+
+void ScreenshotController::CaptureVisibleArea(
+    content::WebContents* web_contents,
+    ResultCallback done) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  if (!CanCapture(web_contents)) {
+    std::move(done).Run(base::unexpected(Error::kNoTab));
+    return;
+  }
+  auto* view = web_contents->GetRenderWidgetHostView();
+  CHECK(view);
+
+  busy_ = true;
+  pending_callback_ = std::move(done);
+
+  // CopyFromSurface's callback isn't guaranteed to run on the calling sequence,
+  // so post back to the UI thread before touching member state.
+  auto on_copied = base::BindPostTaskToCurrentDefault(base::BindOnce(
+      [](base::WeakPtr<ScreenshotController> self,
+         const content::CopyFromSurfaceResult& result) {
+        if (!self) {
+          return;
+        }
+        SkBitmap bitmap;
+        if (result.has_value()) {
+          bitmap = result.value().bitmap;
+        }
+        self->OnVisibleAreaCopied(std::move(bitmap));
+      },
+      weak_factory_.GetWeakPtr()));
+
+  view->CopyFromSurface(gfx::Rect(), gfx::Size(), base::TimeDelta(),
+                        std::move(on_copied));
+}
+
+#if BUILDFLAG(ENABLE_PRINT_PREVIEW)
+void ScreenshotController::CaptureFullPage(content::WebContents* web_contents,
+                                           ResultCallback done) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  if (!CanCapture(web_contents)) {
+    std::move(done).Run(base::unexpected(Error::kNoTab));
+    return;
+  }
+
+  busy_ = true;
+  pending_callback_ = std::move(done);
+
+  auto on_chunks = base::BindOnce(&ScreenshotController::OnFullPageChunks,
+                                  weak_factory_.GetWeakPtr());
+  print_preview_extractor_->CaptureImages(web_contents, std::move(on_chunks));
+}
+#endif  // BUILDFLAG(ENABLE_PRINT_PREVIEW)
+
+void ScreenshotController::OnVisibleAreaCopied(SkBitmap bitmap) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  if (bitmap.drawsNothing()) {
+    FinishWithError(Error::kCaptureFailed);
+    return;
+  }
+  base::ThreadPool::PostTaskAndReplyWithResult(
+      FROM_HERE, {base::TaskPriority::USER_VISIBLE},
+      base::BindOnce(&EncodeBitmap, std::move(bitmap)),
+      base::BindOnce(&ScreenshotController::OnEncoded,
+                     weak_factory_.GetWeakPtr()));
+}
+
+#if BUILDFLAG(ENABLE_PRINT_PREVIEW)
+void ScreenshotController::OnFullPageChunks(ChunkResult result) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+
+  if (!result.has_value()) {
+    VLOG(1) << "Full page capture failed: " << result.error();
+    FinishWithError(Error::kCaptureFailed);
+    return;
+  }
+  base::ThreadPool::PostTaskAndReplyWithResult(
+      FROM_HERE, {base::TaskPriority::USER_VISIBLE},
+      base::BindOnce(&StitchAndEncode, std::move(result.value())),
+      base::BindOnce(&ScreenshotController::OnEncoded,
+                     weak_factory_.GetWeakPtr()));
+}
+#endif  // BUILDFLAG(ENABLE_PRINT_PREVIEW)
+
+void ScreenshotController::OnEncoded(std::optional<std::vector<uint8_t>> png) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  if (!png) {
+    FinishWithError(Error::kEncodeFailed);
+    return;
+  }
+  ShowSaveDialog(std::move(*png));
+}
+
+void ScreenshotController::ShowSaveDialog(std::vector<uint8_t> png) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  pending_png_ = std::move(png);
+  base::FilePath download_dir =
+      download_dir_getter_ ? download_dir_getter_.Run() : base::FilePath();
+  if (download_dir.empty()) {
+    download_dir = DownloadPrefs::FromBrowserContext(profile_)->DownloadPath();
+  }
+  base::ThreadPool::PostTaskAndReplyWithResult(
+      FROM_HERE, {base::MayBlock(), base::TaskPriority::USER_VISIBLE},
+      base::BindOnce(&BuildDefaultPath, download_dir),
+      base::BindOnce(&ScreenshotController::ShowSaveDialogWithPath,
+                     weak_factory_.GetWeakPtr()));
+}
+
+void ScreenshotController::ShowSaveDialogWithPath(base::FilePath default_path) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  if (default_path.empty()) {
+    FinishWithError(Error::kWriteFailed);
+    return;
+  }
+
+  if (select_dialog_) {
+    select_dialog_->ListenerDestroyed();
+  }
+  select_dialog_ = ui::SelectFileDialog::Create(this, nullptr);
+
+  ui::SelectFileDialog::FileTypeInfo file_types;
+  file_types.extensions.push_back({FILE_PATH_LITERAL("png")});
+
+  select_dialog_->SelectFile(
+      ui::SelectFileDialog::SELECT_SAVEAS_FILE,
+      l10n_util::GetStringUTF16(IDS_BRAVE_SCREENSHOT_BUBBLE_TITLE),
+      default_path, &file_types, /*file_type_index=*/1,
+      FILE_PATH_LITERAL("png"), parent_window_getter_.Run(),
+      /*params=*/nullptr);
+}
+
+void ScreenshotController::FileSelected(const ui::SelectedFileInfo& file,
+                                        int /*index*/) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  base::FilePath path = file.file_path;
+  // Move bytes out of member state before posting so a re-entrant call after
+  // Reset() doesn't see them.
+  std::vector<uint8_t> bytes = std::move(pending_png_);
+
+  base::ThreadPool::PostTaskAndReplyWithResult(
+      FROM_HERE, {base::MayBlock(), base::TaskPriority::USER_VISIBLE},
+      base::BindOnce(&WritePngFile, path, std::move(bytes)),
+      base::BindOnce(&ScreenshotController::OnFileWritten,
+                     weak_factory_.GetWeakPtr(), path));
+}
+
+void ScreenshotController::OnFileWritten(base::FilePath path, bool ok) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  ResultCallback cb = std::move(pending_callback_);
+  Reset();
+  if (!cb) {
+    return;
+  }
+  if (ok) {
+    std::move(cb).Run(path);
+  } else {
+    std::move(cb).Run(base::unexpected(Error::kWriteFailed));
+  }
+}
+
+void ScreenshotController::FileSelectionCanceled() {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  FinishWithError(Error::kUserCancelled);
+}
+
+void ScreenshotController::FinishWithError(Error error) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  ResultCallback cb = std::move(pending_callback_);
+  Reset();
+  if (cb) {
+    std::move(cb).Run(base::unexpected(error));
+  }
+}
+
+void ScreenshotController::Reset() {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  busy_ = false;
+  pending_png_.clear();
+  if (select_dialog_) {
+    select_dialog_->ListenerDestroyed();
+    select_dialog_.reset();
+  }
+}
+
+}  // namespace screenshot

--- a/browser/ui/screenshot/screenshot_controller.cc
+++ b/browser/ui/screenshot/screenshot_controller.cc
@@ -348,8 +348,9 @@ void ScreenshotController::FinishWithError(Error error) {
 
 void ScreenshotController::Reset() {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-  CHECK(pending_callback_) << "Reset() called without a pending operation. The "
-                              "callback should be called before Reset()";
+  CHECK(pending_callback_.is_null())
+      << "Reset() called without a pending operation. The "
+         "callback should be called before Reset()";
   pending_png_.clear();
   if (select_dialog_) {
     select_dialog_->ListenerDestroyed();

--- a/browser/ui/screenshot/screenshot_controller.cc
+++ b/browser/ui/screenshot/screenshot_controller.cc
@@ -14,6 +14,7 @@
 #include "base/functional/bind.h"
 #include "base/logging.h"
 #include "base/task/bind_post_task.h"
+#include "base/task/task_traits.h"
 #include "base/task/thread_pool.h"
 #include "base/time/time.h"
 #include "base/types/expected.h"
@@ -225,7 +226,9 @@ void ScreenshotController::OnVisibleAreaCopied(SkBitmap bitmap) {
     return;
   }
   base::ThreadPool::PostTaskAndReplyWithResult(
-      FROM_HERE, {base::TaskPriority::USER_VISIBLE},
+      FROM_HERE,
+      {base::TaskPriority::USER_VISIBLE,
+       base::TaskShutdownBehavior::SKIP_ON_SHUTDOWN},
       base::BindOnce(&EncodeBitmap, std::move(bitmap)),
       base::BindOnce(&ScreenshotController::OnEncoded,
                      weak_factory_.GetWeakPtr()));
@@ -241,7 +244,9 @@ void ScreenshotController::OnFullPageChunks(ChunkResult result) {
     return;
   }
   base::ThreadPool::PostTaskAndReplyWithResult(
-      FROM_HERE, {base::TaskPriority::USER_VISIBLE},
+      FROM_HERE,
+      {base::TaskPriority::USER_VISIBLE,
+       base::TaskShutdownBehavior::SKIP_ON_SHUTDOWN},
       base::BindOnce(&StitchAndEncode, std::move(result.value())),
       base::BindOnce(&ScreenshotController::OnEncoded,
                      weak_factory_.GetWeakPtr()));
@@ -266,7 +271,9 @@ void ScreenshotController::ShowSaveDialog(std::vector<uint8_t> png) {
     download_dir = DownloadPrefs::FromBrowserContext(profile_)->DownloadPath();
   }
   base::ThreadPool::PostTaskAndReplyWithResult(
-      FROM_HERE, {base::MayBlock(), base::TaskPriority::USER_VISIBLE},
+      FROM_HERE,
+      {base::MayBlock(), base::TaskPriority::USER_VISIBLE,
+       base::TaskShutdownBehavior::SKIP_ON_SHUTDOWN},
       base::BindOnce(&BuildDefaultPath, download_dir),
       base::BindOnce(&ScreenshotController::ShowSaveDialogWithPath,
                      weak_factory_.GetWeakPtr()));

--- a/browser/ui/screenshot/screenshot_controller.cc
+++ b/browser/ui/screenshot/screenshot_controller.cc
@@ -16,6 +16,7 @@
 #include "base/task/bind_post_task.h"
 #include "base/task/thread_pool.h"
 #include "base/time/time.h"
+#include "base/types/expected.h"
 #include "brave/grit/brave_generated_resources.h"
 #include "chrome/browser/download/download_prefs.h"
 #include "components/viz/common/frame_sinks/copy_output_result.h"
@@ -154,21 +155,24 @@ ScreenshotController::~ScreenshotController() {
   }
 }
 
-bool ScreenshotController::CanCapture(
-    content::WebContents* web_contents) const {
+base::expected<void, ScreenshotController::Error>
+ScreenshotController::CanCapture(content::WebContents* web_contents) const {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-  if (busy_ || !web_contents) {
-    return false;
+  if (busy_) {
+    return base::unexpected(Error::kBusy);
   }
-  return web_contents->GetRenderWidgetHostView() != nullptr;
+  if (!web_contents || !web_contents->GetRenderWidgetHostView()) {
+    return base::unexpected(Error::kNoTab);
+  }
+  return base::ok();
 }
 
 void ScreenshotController::CaptureVisibleArea(
     content::WebContents* web_contents,
     ResultCallback done) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-  if (!CanCapture(web_contents)) {
-    std::move(done).Run(base::unexpected(Error::kNoTab));
+  if (auto result = CanCapture(web_contents); !result.has_value()) {
+    std::move(done).Run(base::unexpected(result.error()));
     return;
   }
   auto* view = web_contents->GetRenderWidgetHostView();
@@ -201,8 +205,8 @@ void ScreenshotController::CaptureVisibleArea(
 void ScreenshotController::CaptureFullPage(content::WebContents* web_contents,
                                            ResultCallback done) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-  if (!CanCapture(web_contents)) {
-    std::move(done).Run(base::unexpected(Error::kNoTab));
+  if (auto result = CanCapture(web_contents); !result.has_value()) {
+    std::move(done).Run(base::unexpected(result.error()));
     return;
   }
 

--- a/browser/ui/screenshot/screenshot_controller.cc
+++ b/browser/ui/screenshot/screenshot_controller.cc
@@ -9,6 +9,7 @@
 #include <utility>
 
 #include "base/containers/span.h"
+#include "base/files/file.h"
 #include "base/files/file_util.h"
 #include "base/functional/bind.h"
 #include "base/logging.h"
@@ -126,10 +127,8 @@ base::FilePath BuildDefaultPath(const base::FilePath& download_dir) {
 
 ScreenshotController::ScreenshotController(
     content::BrowserContext* profile,
-    NativeWindowGetter parent_window_getter,
-    DownloadDirGetter download_dir_getter)
+    NativeWindowGetter parent_window_getter)
     : parent_window_getter_(std::move(parent_window_getter)),
-      download_dir_getter_(std::move(download_dir_getter)),
       profile_(profile) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
 }
@@ -138,10 +137,8 @@ ScreenshotController::ScreenshotController(
 ScreenshotController::ScreenshotController(
     content::BrowserContext* profile,
     NativeWindowGetter parent_window_getter,
-    DownloadDirGetter download_dir_getter,
     std::unique_ptr<screenshot::PrintPreviewExtractor> print_preview_extractor)
     : parent_window_getter_(std::move(parent_window_getter)),
-      download_dir_getter_(std::move(download_dir_getter)),
       print_preview_extractor_(std::move(print_preview_extractor)),
       profile_(profile) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
@@ -261,7 +258,7 @@ void ScreenshotController::ShowSaveDialog(std::vector<uint8_t> png) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
   pending_png_ = std::move(png);
   base::FilePath download_dir =
-      download_dir_getter_ ? download_dir_getter_.Run() : base::FilePath();
+      download_dir_for_testing_.value_or(base::FilePath());
   if (download_dir.empty()) {
     download_dir = DownloadPrefs::FromBrowserContext(profile_)->DownloadPath();
   }

--- a/browser/ui/screenshot/screenshot_controller.cc
+++ b/browser/ui/screenshot/screenshot_controller.cc
@@ -269,7 +269,8 @@ void ScreenshotController::ShowSaveDialog(std::vector<uint8_t> png) {
                      weak_factory_.GetWeakPtr()));
 }
 
-void ScreenshotController::ShowSaveDialogWithPath(base::FilePath default_path) {
+void ScreenshotController::ShowSaveDialogWithPath(
+    const base::FilePath& default_path) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
   if (default_path.empty()) {
     FinishWithError(Error::kWriteFailed);
@@ -307,7 +308,7 @@ void ScreenshotController::FileSelected(const ui::SelectedFileInfo& file,
                      weak_factory_.GetWeakPtr(), path));
 }
 
-void ScreenshotController::OnFileWritten(base::FilePath path, bool ok) {
+void ScreenshotController::OnFileWritten(const base::FilePath& path, bool ok) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
   ResultCallback cb = std::move(pending_callback_);
   Reset();

--- a/browser/ui/screenshot/screenshot_controller.h
+++ b/browser/ui/screenshot/screenshot_controller.h
@@ -32,7 +32,7 @@ class PrintPreviewExtractor;
 
 // Owned by BrowserWindowFeatures (one per Browser). Orchestrates capture of a
 // screenshot (visible area or full page), encodes the result as PNG, and
-// drives a Save As dialog. Does not expose ai_chat:: types to callers.
+// drives a Save As dialog.
 class ScreenshotController : public ui::SelectFileDialog::Listener {
  public:
   enum class Error {

--- a/browser/ui/screenshot/screenshot_controller.h
+++ b/browser/ui/screenshot/screenshot_controller.h
@@ -75,7 +75,7 @@ class ScreenshotController : public ui::SelectFileDialog::Listener {
   void CaptureFullPage(content::WebContents* web_contents, ResultCallback done);
 #endif  // BUILDFLAG(ENABLE_PRINT_PREVIEW)
 
-  void set_download_dir_for_testing(base::FilePath path) {
+  void set_download_dir_for_testing(const base::FilePath& path) {
     download_dir_for_testing_ = path;
   }
 
@@ -96,9 +96,9 @@ class ScreenshotController : public ui::SelectFileDialog::Listener {
 
   void OnEncoded(std::optional<std::vector<uint8_t>> png);
   void ShowSaveDialog(std::vector<uint8_t> png);
-  void ShowSaveDialogWithPath(base::FilePath default_path);
+  void ShowSaveDialogWithPath(const base::FilePath& default_path);
   // Reply callback for WritePngFile posted from FileSelected().
-  void OnFileWritten(base::FilePath path, bool ok);
+  void OnFileWritten(const base::FilePath& path, bool ok);
   void FinishWithError(Error error);
   void Reset();
 

--- a/browser/ui/screenshot/screenshot_controller.h
+++ b/browser/ui/screenshot/screenshot_controller.h
@@ -46,24 +46,14 @@ class ScreenshotController : public ui::SelectFileDialog::Listener {
       base::OnceCallback<void(base::expected<base::FilePath, Error>)>;
 
   // `parent_window_getter` is invoked just-in-time at Save-As dialog
-  // creation, after the browser window is fully initialized. Constructing the
-  // controller during BraveToolbarView::Init() (when browser->window() is
-  // still null) is intentional.
+  // creation, after the browser window is fully initialized.
   using NativeWindowGetter = base::RepeatingCallback<gfx::NativeWindow()>;
 
-  // Returns the directory used as the default Save As path. If empty, falls
-  // back to DownloadPrefs::FromBrowserContext(profile_)->DownloadPath().
-  // Tests can inject a simpler implementation to avoid the full download
-  // service stack.
-  using DownloadDirGetter = base::RepeatingCallback<base::FilePath()>;
-
   ScreenshotController(content::BrowserContext* profile,
-                       NativeWindowGetter parent_window_getter,
-                       DownloadDirGetter download_dir_getter = {});
+                       NativeWindowGetter parent_window_getter);
 #if BUILDFLAG(ENABLE_PRINT_PREVIEW)
   ScreenshotController(content::BrowserContext* profile,
                        NativeWindowGetter parent_window_getter,
-                       DownloadDirGetter download_dir_getter,
                        std::unique_ptr<screenshot::PrintPreviewExtractor>
                            print_preview_extractor);
 #endif
@@ -84,6 +74,10 @@ class ScreenshotController : public ui::SelectFileDialog::Listener {
 #if BUILDFLAG(ENABLE_PRINT_PREVIEW)
   void CaptureFullPage(content::WebContents* web_contents, ResultCallback done);
 #endif  // BUILDFLAG(ENABLE_PRINT_PREVIEW)
+
+  void set_download_dir_for_testing(base::FilePath path) {
+    download_dir_for_testing_ = path;
+  }
 
   // ui::SelectFileDialog::Listener:
   void FileSelected(const ui::SelectedFileInfo& file, int index) override;
@@ -109,7 +103,6 @@ class ScreenshotController : public ui::SelectFileDialog::Listener {
   void Reset();
 
   NativeWindowGetter parent_window_getter_;
-  DownloadDirGetter download_dir_getter_;
   bool busy_ = false;
 
   // Pending operation state. Set on entry, cleared on Reset().
@@ -119,6 +112,8 @@ class ScreenshotController : public ui::SelectFileDialog::Listener {
 #if BUILDFLAG(ENABLE_PRINT_PREVIEW)
   std::unique_ptr<screenshot::PrintPreviewExtractor> print_preview_extractor_;
 #endif
+
+  std::optional<base::FilePath> download_dir_for_testing_;
 
   raw_ptr<content::BrowserContext> profile_;
 

--- a/browser/ui/screenshot/screenshot_controller.h
+++ b/browser/ui/screenshot/screenshot_controller.h
@@ -37,6 +37,7 @@ class ScreenshotController : public ui::SelectFileDialog::Listener {
  public:
   enum class Error {
     kNoTab,
+    kBusy,
     kCaptureFailed,
     kEncodeFailed,
     kUserCancelled,
@@ -65,7 +66,8 @@ class ScreenshotController : public ui::SelectFileDialog::Listener {
 
   // Returns false if `web_contents` has no live RenderWidgetHostView or a
   // capture is already in flight.
-  bool CanCapture(content::WebContents* web_contents) const;
+  base::expected<void, Error> CanCapture(
+      content::WebContents* web_contents) const;
 
   // Captures the visible viewport area or the full page of `web_contents`,
   // encodes the result as PNG, and drives a Save As dialog.

--- a/browser/ui/screenshot/screenshot_controller.h
+++ b/browser/ui/screenshot/screenshot_controller.h
@@ -62,9 +62,6 @@ class ScreenshotController : public ui::SelectFileDialog::Listener {
   ScreenshotController& operator=(const ScreenshotController&) = delete;
   ~ScreenshotController() override;
 
-  bool busy() const { return busy_; }
-
-  // Returns false if `web_contents` has no live RenderWidgetHostView or a
   // capture is already in flight.
   base::expected<void, Error> CanCapture(
       content::WebContents* web_contents) const;
@@ -105,7 +102,6 @@ class ScreenshotController : public ui::SelectFileDialog::Listener {
   void Reset();
 
   NativeWindowGetter parent_window_getter_;
-  bool busy_ = false;
 
   // Pending operation state. Set on entry, cleared on Reset().
   ResultCallback pending_callback_;

--- a/browser/ui/screenshot/screenshot_controller.h
+++ b/browser/ui/screenshot/screenshot_controller.h
@@ -1,0 +1,133 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_BROWSER_UI_SCREENSHOT_SCREENSHOT_CONTROLLER_H_
+#define BRAVE_BROWSER_UI_SCREENSHOT_SCREENSHOT_CONTROLLER_H_
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "base/files/file_path.h"
+#include "base/functional/callback.h"
+#include "base/memory/raw_ptr.h"
+#include "base/memory/weak_ptr.h"
+#include "base/sequence_checker.h"
+#include "base/types/expected.h"
+#include "printing/buildflags/buildflags.h"
+#include "third_party/skia/include/core/SkBitmap.h"
+#include "ui/gfx/native_ui_types.h"
+#include "ui/shell_dialogs/select_file_dialog.h"
+
+namespace content {
+class BrowserContext;
+class WebContents;
+}  // namespace content
+
+namespace screenshot {
+class PrintPreviewExtractor;
+
+// Owned by BrowserWindowFeatures (one per Browser). Orchestrates capture of a
+// screenshot (visible area or full page), encodes the result as PNG, and
+// drives a Save As dialog. Does not expose ai_chat:: types to callers.
+class ScreenshotController : public ui::SelectFileDialog::Listener {
+ public:
+  enum class Error {
+    kNoTab,
+    kCaptureFailed,
+    kEncodeFailed,
+    kUserCancelled,
+    kWriteFailed,
+  };
+  using ResultCallback =
+      base::OnceCallback<void(base::expected<base::FilePath, Error>)>;
+
+  // `parent_window_getter` is invoked just-in-time at Save-As dialog
+  // creation, after the browser window is fully initialized. Constructing the
+  // controller during BraveToolbarView::Init() (when browser->window() is
+  // still null) is intentional.
+  using NativeWindowGetter = base::RepeatingCallback<gfx::NativeWindow()>;
+
+  // Returns the directory used as the default Save As path. If empty, falls
+  // back to DownloadPrefs::FromBrowserContext(profile_)->DownloadPath().
+  // Tests can inject a simpler implementation to avoid the full download
+  // service stack.
+  using DownloadDirGetter = base::RepeatingCallback<base::FilePath()>;
+
+  ScreenshotController(content::BrowserContext* profile,
+                       NativeWindowGetter parent_window_getter,
+                       DownloadDirGetter download_dir_getter = {});
+#if BUILDFLAG(ENABLE_PRINT_PREVIEW)
+  ScreenshotController(content::BrowserContext* profile,
+                       NativeWindowGetter parent_window_getter,
+                       DownloadDirGetter download_dir_getter,
+                       std::unique_ptr<screenshot::PrintPreviewExtractor>
+                           print_preview_extractor);
+#endif
+  ScreenshotController(const ScreenshotController&) = delete;
+  ScreenshotController& operator=(const ScreenshotController&) = delete;
+  ~ScreenshotController() override;
+
+  bool busy() const { return busy_; }
+
+  // Returns false if `web_contents` has no live RenderWidgetHostView or a
+  // capture is already in flight.
+  bool CanCapture(content::WebContents* web_contents) const;
+
+  // Captures the visible viewport area or the full page of `web_contents`,
+  // encodes the result as PNG, and drives a Save As dialog.
+  void CaptureVisibleArea(content::WebContents* web_contents,
+                          ResultCallback done);
+#if BUILDFLAG(ENABLE_PRINT_PREVIEW)
+  void CaptureFullPage(content::WebContents* web_contents, ResultCallback done);
+#endif  // BUILDFLAG(ENABLE_PRINT_PREVIEW)
+
+  // ui::SelectFileDialog::Listener:
+  void FileSelected(const ui::SelectedFileInfo& file, int index) override;
+  void FileSelectionCanceled() override;
+
+ private:
+  friend class ScreenshotControllerTest;
+
+  using ChunkResult =
+      base::expected<std::vector<std::vector<uint8_t>>, std::string>;
+
+  void OnVisibleAreaCopied(SkBitmap bitmap);
+#if BUILDFLAG(ENABLE_PRINT_PREVIEW)
+  void OnFullPageChunks(ChunkResult result);
+#endif
+
+  void OnEncoded(std::optional<std::vector<uint8_t>> png);
+  void ShowSaveDialog(std::vector<uint8_t> png);
+  void ShowSaveDialogWithPath(base::FilePath default_path);
+  // Reply callback for WritePngFile posted from FileSelected().
+  void OnFileWritten(base::FilePath path, bool ok);
+  void FinishWithError(Error error);
+  void Reset();
+
+  NativeWindowGetter parent_window_getter_;
+  DownloadDirGetter download_dir_getter_;
+  bool busy_ = false;
+
+  // Pending operation state. Set on entry, cleared on Reset().
+  ResultCallback pending_callback_;
+  std::vector<uint8_t> pending_png_;
+
+#if BUILDFLAG(ENABLE_PRINT_PREVIEW)
+  std::unique_ptr<screenshot::PrintPreviewExtractor> print_preview_extractor_;
+#endif
+
+  raw_ptr<content::BrowserContext> profile_;
+
+  scoped_refptr<ui::SelectFileDialog> select_dialog_;
+
+  SEQUENCE_CHECKER(sequence_checker_);
+  base::WeakPtrFactory<ScreenshotController> weak_factory_{this};
+};
+
+}  // namespace screenshot
+
+#endif  // BRAVE_BROWSER_UI_SCREENSHOT_SCREENSHOT_CONTROLLER_H_

--- a/browser/ui/screenshot/screenshot_controller_unittest.cc
+++ b/browser/ui/screenshot/screenshot_controller_unittest.cc
@@ -55,9 +55,8 @@ class ScreenshotControllerTest : public ChromeRenderViewHostTestHarness {
     // DownloadPrefs (which requires a full download-service stack).
     const base::FilePath download_dir = temp_dir_.GetPath();
     controller_ = std::make_unique<ScreenshotController>(
-        profile(), base::BindRepeating([]() { return gfx::NativeWindow(); }),
-        base::BindRepeating([](base::FilePath dir) { return dir; },
-                            download_dir));
+        profile(), base::BindRepeating([]() { return gfx::NativeWindow(); }));
+    controller_->set_download_dir_for_testing(download_dir);
   }
 
   void TearDown() override {

--- a/browser/ui/screenshot/screenshot_controller_unittest.cc
+++ b/browser/ui/screenshot/screenshot_controller_unittest.cc
@@ -69,7 +69,6 @@ class ScreenshotControllerTest : public ChromeRenderViewHostTestHarness {
   // Sets the controller into the same busy state that CaptureVisibleArea()
   // would set before dispatching CopyFromSurface.
   void InjectBitmap(SkBitmap bitmap, ScreenshotController::ResultCallback cb) {
-    controller_->busy_ = true;
     controller_->pending_callback_ = std::move(cb);
     controller_->OnVisibleAreaCopied(std::move(bitmap));
   }
@@ -80,7 +79,6 @@ class ScreenshotControllerTest : public ChromeRenderViewHostTestHarness {
   void InjectChunks(
       base::expected<std::vector<std::vector<uint8_t>>, std::string> chunks,
       ScreenshotController::ResultCallback cb) {
-    controller_->busy_ = true;
     controller_->pending_callback_ = std::move(cb);
     controller_->OnFullPageChunks(std::move(chunks));
   }
@@ -92,6 +90,10 @@ class ScreenshotControllerTest : public ChromeRenderViewHostTestHarness {
   }
 #endif  // BUILDFLAG(ENABLE_PRINT_PREVIEW)
 
+  void SetPendingCallback(ScreenshotController::ResultCallback cb) {
+    controller_->pending_callback_ = std::move(cb);
+  }
+
   base::ScopedTempDir temp_dir_;
   raw_ptr<ui::FakeSelectFileDialog::Factory> dialog_factory_ = nullptr;
   std::unique_ptr<ScreenshotController> controller_;
@@ -102,11 +104,19 @@ class ScreenshotControllerTest : public ChromeRenderViewHostTestHarness {
 // ---------------------------------------------------------------------------
 
 TEST_F(ScreenshotControllerTest, CanCapture_ReturnsFalseForNullWebContents) {
-  EXPECT_FALSE(controller_->CanCapture(nullptr));
+  EXPECT_FALSE(controller_->CanCapture(nullptr).has_value());
 }
 
 TEST_F(ScreenshotControllerTest, CanCapture_ReturnsTrueWhenViewExists) {
-  EXPECT_TRUE(controller_->CanCapture(web_contents()));
+  EXPECT_TRUE(controller_->CanCapture(web_contents()).has_value());
+}
+
+TEST_F(ScreenshotControllerTest, CanCapture_ReturnsBusyWhenPendingCallbackSet) {
+  base::test::TestFuture<Result> pending_callback_future;
+  SetPendingCallback(pending_callback_future.GetCallback());
+
+  auto result = controller_->CanCapture(web_contents());
+  EXPECT_EQ(result, base::unexpected(Error::kBusy));
 }
 
 TEST_F(ScreenshotControllerTest,
@@ -117,9 +127,9 @@ TEST_F(ScreenshotControllerTest,
 }
 
 // Calling CaptureVisibleArea twice before the first completes: the second call
-// should be rejected immediately with kNoTab because the controller is busy.
+// should be rejected immediately with kBusy because the controller is busy.
 TEST_F(ScreenshotControllerTest,
-       CaptureVisibleArea_AlreadyBusy_SecondCallReturnsNoTab) {
+       CaptureVisibleArea_AlreadyBusy_SecondCallReturnsBusy) {
   base::test::TestFuture<Result> future1;
   base::test::TestFuture<Result> future2;
 
@@ -130,7 +140,7 @@ TEST_F(ScreenshotControllerTest,
 
   // Second call sees busy_ == true and rejects immediately.
   controller_->CaptureVisibleArea(web_contents(), future2.GetCallback());
-  EXPECT_EQ(future2.Get(), base::unexpected(Error::kNoTab));
+  EXPECT_EQ(future2.Get(), base::unexpected(Error::kBusy));
 
   // Let the first pipeline drain (kNotImplemented → empty bitmap →
   // kCaptureFailed).
@@ -299,6 +309,9 @@ TEST_F(ScreenshotControllerTest,
   SkBitmap stitched = gfx::PNGCodec::Decode(*png_bytes);
   EXPECT_EQ(stitched.width(), 64);
   EXPECT_EQ(stitched.height(), 80);  // 48 + 32
+  // Verify vertical ordering: chunk 0 (red) is drawn above chunk 1 (green).
+  EXPECT_EQ(stitched.getColor(0, 0), SK_ColorRED);
+  EXPECT_EQ(stitched.getColor(0, 48), SK_ColorGREEN);
 }
 
 #endif  // BUILDFLAG(ENABLE_PRINT_PREVIEW)

--- a/browser/ui/screenshot/screenshot_controller_unittest.cc
+++ b/browser/ui/screenshot/screenshot_controller_unittest.cc
@@ -1,0 +1,307 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/browser/ui/screenshot/screenshot_controller.h"
+
+#include <memory>
+#include <utility>
+
+#include "base/files/file_path.h"
+#include "base/files/file_util.h"
+#include "base/files/scoped_temp_dir.h"
+#include "base/test/test_future.h"
+#include "base/types/expected.h"
+#include "chrome/test/base/chrome_render_view_host_test_harness.h"
+#include "printing/buildflags/buildflags.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "third_party/skia/include/core/SkBitmap.h"
+#include "third_party/skia/include/core/SkCanvas.h"
+#include "third_party/skia/include/core/SkColor.h"
+#include "ui/gfx/codec/png_codec.h"
+#include "ui/gfx/native_ui_types.h"
+#include "ui/shell_dialogs/fake_select_file_dialog.h"
+
+namespace screenshot {
+
+namespace {
+
+SkBitmap MakeSolidBitmap(int width, int height, SkColor color) {
+  SkBitmap bm;
+  bm.allocN32Pixels(width, height);
+  SkCanvas canvas(bm);
+  canvas.drawColor(color);
+  return bm;
+}
+
+}  // namespace
+
+using Error = ScreenshotController::Error;
+using Result = base::expected<base::FilePath, Error>;
+
+class ScreenshotControllerTest : public ChromeRenderViewHostTestHarness {
+ protected:
+  void SetUp() override {
+    ChromeRenderViewHostTestHarness::SetUp();
+
+    ASSERT_TRUE(temp_dir_.CreateUniqueTempDir());
+
+    // Install the fake select-file-dialog factory.  It intercepts every
+    // SelectFileDialog::Create() call for the lifetime of this test.
+    dialog_factory_ = ui::FakeSelectFileDialog::RegisterFactory();
+
+    // Inject a simple download-dir getter so the controller never touches
+    // DownloadPrefs (which requires a full download-service stack).
+    const base::FilePath download_dir = temp_dir_.GetPath();
+    controller_ = std::make_unique<ScreenshotController>(
+        profile(), base::BindRepeating([]() { return gfx::NativeWindow(); }),
+        base::BindRepeating([](base::FilePath dir) { return dir; },
+                            download_dir));
+  }
+
+  void TearDown() override {
+    controller_.reset();
+    ChromeRenderViewHostTestHarness::TearDown();
+  }
+
+  // Drives the pipeline from OnVisibleAreaCopied() onward, bypassing
+  // CopyFromSurface (which returns kNotImplemented in the test environment).
+  // Sets the controller into the same busy state that CaptureVisibleArea()
+  // would set before dispatching CopyFromSurface.
+  void InjectBitmap(SkBitmap bitmap, ScreenshotController::ResultCallback cb) {
+    controller_->busy_ = true;
+    controller_->pending_callback_ = std::move(cb);
+    controller_->OnVisibleAreaCopied(std::move(bitmap));
+  }
+
+#if BUILDFLAG(ENABLE_PRINT_PREVIEW)
+  // Drives the pipeline from OnFullPageChunks() onward, bypassing
+  // CaptureFullPage and the real PrintPreviewExtractor.
+  void InjectChunks(
+      base::expected<std::vector<std::vector<uint8_t>>, std::string> chunks,
+      ScreenshotController::ResultCallback cb) {
+    controller_->busy_ = true;
+    controller_->pending_callback_ = std::move(cb);
+    controller_->OnFullPageChunks(std::move(chunks));
+  }
+
+  static std::vector<uint8_t> EncodeBitmapAsPng(const SkBitmap& bitmap) {
+    auto encoded = gfx::PNGCodec::EncodeBGRASkBitmap(bitmap, false);
+    CHECK(encoded);
+    return *encoded;
+  }
+#endif  // BUILDFLAG(ENABLE_PRINT_PREVIEW)
+
+  base::ScopedTempDir temp_dir_;
+  raw_ptr<ui::FakeSelectFileDialog::Factory> dialog_factory_ = nullptr;
+  std::unique_ptr<ScreenshotController> controller_;
+};
+
+// ---------------------------------------------------------------------------
+// CanCapture / early-reject tests (no bitmap injection needed)
+// ---------------------------------------------------------------------------
+
+TEST_F(ScreenshotControllerTest, CanCapture_ReturnsFalseForNullWebContents) {
+  EXPECT_FALSE(controller_->CanCapture(nullptr));
+}
+
+TEST_F(ScreenshotControllerTest, CanCapture_ReturnsTrueWhenViewExists) {
+  EXPECT_TRUE(controller_->CanCapture(web_contents()));
+}
+
+TEST_F(ScreenshotControllerTest,
+       CaptureVisibleArea_NullWebContents_ReturnsNoTab) {
+  base::test::TestFuture<Result> future;
+  controller_->CaptureVisibleArea(nullptr, future.GetCallback());
+  EXPECT_EQ(future.Get(), base::unexpected(Error::kNoTab));
+}
+
+// Calling CaptureVisibleArea twice before the first completes: the second call
+// should be rejected immediately with kNoTab because the controller is busy.
+TEST_F(ScreenshotControllerTest,
+       CaptureVisibleArea_AlreadyBusy_SecondCallReturnsNoTab) {
+  base::test::TestFuture<Result> future1;
+  base::test::TestFuture<Result> future2;
+
+  // First call starts the async pipeline (CopyFromSurface is a no-op in tests;
+  // its base-class implementation calls back with kNotImplemented immediately,
+  // but the result is posted, not synchronous).
+  controller_->CaptureVisibleArea(web_contents(), future1.GetCallback());
+
+  // Second call sees busy_ == true and rejects immediately.
+  controller_->CaptureVisibleArea(web_contents(), future2.GetCallback());
+  EXPECT_EQ(future2.Get(), base::unexpected(Error::kNoTab));
+
+  // Let the first pipeline drain (kNotImplemented → empty bitmap →
+  // kCaptureFailed).
+  EXPECT_EQ(future1.Get(), base::unexpected(Error::kCaptureFailed));
+}
+
+// When CopyFromSurface fails (the test environment's base-class implementation
+// returns kNotImplemented), the controller should report kCaptureFailed.
+TEST_F(ScreenshotControllerTest,
+       CaptureVisibleArea_CopyFromSurfaceFails_ReturnsCaptureFailed) {
+  base::test::TestFuture<Result> future;
+  controller_->CaptureVisibleArea(web_contents(), future.GetCallback());
+  EXPECT_EQ(future.Get(), base::unexpected(Error::kCaptureFailed));
+}
+
+// ---------------------------------------------------------------------------
+// Pipeline tests — inject a valid bitmap to reach the dialog / write stages
+// ---------------------------------------------------------------------------
+
+TEST_F(ScreenshotControllerTest, Pipeline_EmptyBitmap_ReturnsCaptureFailed) {
+  base::test::TestFuture<Result> future;
+  InjectBitmap(SkBitmap(), future.GetCallback());
+  EXPECT_EQ(future.Get(), base::unexpected(Error::kCaptureFailed));
+}
+
+TEST_F(ScreenshotControllerTest,
+       Pipeline_UserCancelsDialog_ReturnsUserCancelled) {
+  // Signal when the fake dialog is opened so we can cancel it from outside
+  // the callback (avoiding re-entrant dialog destruction).
+  base::test::TestFuture<void> dialog_opened;
+  dialog_factory_->SetOpenCallback(dialog_opened.GetRepeatingCallback());
+
+  base::test::TestFuture<Result> future;
+  InjectBitmap(MakeSolidBitmap(64, 64, SK_ColorBLUE), future.GetCallback());
+
+  // Wait for the encode + path-build background tasks to complete and for
+  // ShowSaveDialogWithPath to open the dialog.
+  ASSERT_TRUE(dialog_opened.Wait());
+
+  ui::FakeSelectFileDialog* dialog = dialog_factory_->GetLastDialog();
+  ASSERT_TRUE(dialog);
+  dialog->CallFileSelectionCanceled();
+
+  EXPECT_EQ(future.Get(), base::unexpected(Error::kUserCancelled));
+}
+
+TEST_F(ScreenshotControllerTest,
+       Pipeline_FileSelected_WritesToDiskAndReturnsPath) {
+  base::test::TestFuture<void> dialog_opened;
+  dialog_factory_->SetOpenCallback(dialog_opened.GetRepeatingCallback());
+
+  base::test::TestFuture<Result> future;
+  InjectBitmap(MakeSolidBitmap(64, 64, SK_ColorGREEN), future.GetCallback());
+
+  ASSERT_TRUE(dialog_opened.Wait());
+
+  ui::FakeSelectFileDialog* dialog = dialog_factory_->GetLastDialog();
+  ASSERT_TRUE(dialog);
+
+  base::FilePath save_path =
+      temp_dir_.GetPath().AppendASCII("test_screenshot.png");
+  ASSERT_TRUE(dialog->CallFileSelected(save_path, "png"));
+
+  Result result = future.Get();
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), save_path);
+  EXPECT_TRUE(base::PathExists(save_path));
+}
+
+TEST_F(ScreenshotControllerTest,
+       Pipeline_WriteToUnwritablePath_ReturnsWriteFailed) {
+  base::test::TestFuture<void> dialog_opened;
+  dialog_factory_->SetOpenCallback(dialog_opened.GetRepeatingCallback());
+
+  base::test::TestFuture<Result> future;
+  InjectBitmap(MakeSolidBitmap(64, 64, SK_ColorRED), future.GetCallback());
+
+  ASSERT_TRUE(dialog_opened.Wait());
+
+  ui::FakeSelectFileDialog* dialog = dialog_factory_->GetLastDialog();
+  ASSERT_TRUE(dialog);
+
+  // Select a path whose parent directory does not exist so WriteFile fails.
+  base::FilePath bad_path = temp_dir_.GetPath()
+                                .AppendASCII("nonexistent_subdir")
+                                .AppendASCII("screenshot.png");
+  ASSERT_TRUE(dialog->CallFileSelected(bad_path, "png"));
+
+  EXPECT_EQ(future.Get(), base::unexpected(Error::kWriteFailed));
+}
+
+#if BUILDFLAG(ENABLE_PRINT_PREVIEW)
+
+// ---------------------------------------------------------------------------
+// Full-page capture pipeline tests (OnFullPageChunks / StitchAndEncode)
+// ---------------------------------------------------------------------------
+
+TEST_F(ScreenshotControllerTest, FullPage_ExtractorError_ReturnsCaptureFailed) {
+  base::test::TestFuture<Result> future;
+  InjectChunks(base::unexpected(std::string("extractor failed")),
+               future.GetCallback());
+  EXPECT_EQ(future.Get(), base::unexpected(Error::kCaptureFailed));
+}
+
+// An empty chunks vector causes StitchAndEncode to return nullopt, which the
+// controller surfaces as kEncodeFailed.
+TEST_F(ScreenshotControllerTest, FullPage_EmptyChunks_ReturnsEncodeFailed) {
+  base::test::TestFuture<Result> future;
+  InjectChunks(std::vector<std::vector<uint8_t>>{}, future.GetCallback());
+  EXPECT_EQ(future.Get(), base::unexpected(Error::kEncodeFailed));
+}
+
+TEST_F(ScreenshotControllerTest, FullPage_SingleChunk_SavesToDisk) {
+  base::test::TestFuture<void> dialog_opened;
+  dialog_factory_->SetOpenCallback(dialog_opened.GetRepeatingCallback());
+
+  std::vector<std::vector<uint8_t>> chunks = {
+      EncodeBitmapAsPng(MakeSolidBitmap(64, 48, SK_ColorBLUE))};
+
+  base::test::TestFuture<Result> future;
+  InjectChunks(std::move(chunks), future.GetCallback());
+
+  ASSERT_TRUE(dialog_opened.Wait());
+  ui::FakeSelectFileDialog* dialog = dialog_factory_->GetLastDialog();
+  ASSERT_TRUE(dialog);
+
+  base::FilePath save_path =
+      temp_dir_.GetPath().AppendASCII("fullpage_single.png");
+  ASSERT_TRUE(dialog->CallFileSelected(save_path, "png"));
+
+  Result result = future.Get();
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), save_path);
+  EXPECT_TRUE(base::PathExists(save_path));
+}
+
+// Two chunks of different heights should be stitched into an image whose width
+// is the maximum chunk width and whose height is the sum of the chunk heights.
+TEST_F(ScreenshotControllerTest,
+       FullPage_MultiChunk_StitchesToCorrectDimensions) {
+  base::test::TestFuture<void> dialog_opened;
+  dialog_factory_->SetOpenCallback(dialog_opened.GetRepeatingCallback());
+
+  // Chunk 0: 64×48, chunk 1: 64×32 → stitched: 64×80.
+  std::vector<std::vector<uint8_t>> chunks = {
+      EncodeBitmapAsPng(MakeSolidBitmap(64, 48, SK_ColorRED)),
+      EncodeBitmapAsPng(MakeSolidBitmap(64, 32, SK_ColorGREEN))};
+
+  base::test::TestFuture<Result> future;
+  InjectChunks(std::move(chunks), future.GetCallback());
+
+  ASSERT_TRUE(dialog_opened.Wait());
+  ui::FakeSelectFileDialog* dialog = dialog_factory_->GetLastDialog();
+  ASSERT_TRUE(dialog);
+
+  base::FilePath save_path =
+      temp_dir_.GetPath().AppendASCII("fullpage_multi.png");
+  ASSERT_TRUE(dialog->CallFileSelected(save_path, "png"));
+
+  Result result = future.Get();
+  ASSERT_TRUE(result.has_value());
+
+  std::optional<std::vector<uint8_t>> png_bytes =
+      base::ReadFileToBytes(save_path);
+  ASSERT_TRUE(png_bytes);
+  SkBitmap stitched = gfx::PNGCodec::Decode(*png_bytes);
+  EXPECT_EQ(stitched.width(), 64);
+  EXPECT_EQ(stitched.height(), 80);  // 48 + 32
+}
+
+#endif  // BUILDFLAG(ENABLE_PRINT_PREVIEW)
+
+}  // namespace screenshot

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -187,6 +187,7 @@ test("brave_unit_tests") {
     "//brave/browser/serp_metrics:unit_tests",
     "//brave/browser/ui:unit_tests",
     "//brave/browser/ui/brave_tooltips",
+    "//brave/browser/ui/screenshot:unit_tests",
     "//brave/browser/ui/startup:unit_tests",
     "//brave/browser/ui/webui:unit_tests",
     "//brave/browser/web_discovery:unit_tests",


### PR DESCRIPTION
Add brave/browser/ui/screenshot/, a View-agnostic capture orchestrator that the toolbar UI (next commit) will drive. Two modes:

Visible area:
  RenderWidgetHostView::CopyFromSurface -> SkBitmap -> PNG (encoded on
  ThreadPool) -> Save As.

Full page: Uses screenshot::PrintPreviewExtractor

Save As default filename is screenshot-YYYY-MM-DD-HHMMSS.png

A `kBraveScreenshot` base::Feature gates the feature; the toolbar wiring comes in the next commit.

<!-- Add brave-browser issue below that this PR will resolve -->
part of https://github.com/brave/brave-browser/issues/56140

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
