### PR TITLE
[iOS] Stop feeding HistorySearchOptions with begin and end date (uplift to 1.92.x)

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Sync/BraveCore/History/HistoryAPIExtensions.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Sync/BraveCore/History/HistoryAPIExtensions.swift
@@ -28,13 +28,9 @@ extension BraveHistoryAPI {
       return nil
     }
 
-    let current = Date()
     let options = HistorySearchOptions(
       maxCount: 100,
-      hostOnly: false,
-      duplicateHandling: .removeAll,
-      begin: Calendar.current.date(byAdding: .hour, value: -24, to: current),  // last 24 hour
-      end: current
+      duplicateHandling: .removeAll
     )
 
     return search(


### PR DESCRIPTION
Uplift of #36937
Resolves https://github.com/brave/brave-browser/issues/55837

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.