### PR TITLE
[skus] Migrate HttpResponse cxx bridge off CxxVector/CxxString

### DIFF
--- a/components/skus/browser/rs/cxx/src/httpclient.rs
+++ b/components/skus/browser/rs/cxx/src/httpclient.rs
@@ -46,14 +46,13 @@ impl TryFrom<http::Request<Vec<u8>>> for ffi::HttpRequest {
     }
 }
 
-impl From<ffi::HttpResponse<'_>> for Result<http::Response<Vec<u8>>, InternalError> {
-    fn from(resp: ffi::HttpResponse<'_>) -> Self {
+impl From<ffi::HttpResponse> for Result<http::Response<Vec<u8>>, InternalError> {
+    fn from(resp: ffi::HttpResponse) -> Self {
         match resp.result.code {
             ffi::SkusResultCode::Ok => {
                 let mut response = http::Response::builder().status(resp.return_code);
 
                 for header in resp.headers {
-                    let header = header.to_string();
                     // header: value
                     let idx = header
                         .find(':')
@@ -91,7 +90,7 @@ impl From<ffi::HttpResponse<'_>> for Result<http::Response<Vec<u8>>, InternalErr
                 }
 
                 response
-                    .body(resp.body.iter().cloned().collect())
+                    .body(resp.body)
                     .map_err(|e| InternalError::InvalidCall(e.to_string()))
                     .debug_unwrap()
             }

--- a/components/skus/browser/rs/cxx/src/lib.rs
+++ b/components/skus/browser/rs/cxx/src/lib.rs
@@ -164,11 +164,11 @@ mod ffi {
         pub body: Vec<u8>,
     }
     #[derive(Debug)]
-    pub struct HttpResponse<'a> {
+    pub struct HttpResponse {
         pub result: SkusResult,
         pub return_code: u16,
-        pub headers: &'a CxxVector<CxxString>,
-        pub body: &'a CxxVector<u8>,
+        pub headers: Vec<String>,
+        pub body: Vec<u8>,
     }
 
     extern "Rust" {

--- a/components/skus/browser/skus_url_loader_impl.cc
+++ b/components/skus/browser/skus_url_loader_impl.cc
@@ -94,17 +94,23 @@ void SkusUrlLoaderImpl::OnFetchComplete(
 
   // Body might be empty here which is still a success.
   auto body = api_request_result.SerializeBodyToString();
-  std::vector<uint8_t> body_bytes;
-  if (!body.empty()) {
-    body_bytes.assign(body.begin(), body.end());
+  // HttpResponse owns its data (rust::Vec), so deep-copy across the FFI
+  // boundary rather than handing C++ heap allocations to Rust.
+  rust::Vec<uint8_t> body_bytes;
+  body_bytes.reserve(body.size());
+  for (char byte : body) {
+    body_bytes.push_back(static_cast<uint8_t>(byte));
   }
 
-  std::vector<std::string> headers;
+  rust::Vec<rust::String> headers;
   headers.reserve(api_request_result.headers().size());
   for (const auto& header : api_request_result.headers()) {
     std::string new_header_value = header.first + ": " + header.second;
     VLOG(1) << "header[" << new_header_value << "]";
-    headers.push_back(std::move(new_header_value));
+    // Use lossy() rather than the throwing rust::String ctor: server response
+    // headers are not guaranteed to be UTF-8, and the Rust side already
+    // validates header names/values, returning a clean error on bad input.
+    headers.push_back(rust::String::lossy(new_header_value));
   }
 
   skus::SkusResult result = {


### PR DESCRIPTION
## Summary

Part of brave/brave-browser#55722 (auditing/cleaning up `rust::Str`/`rust::String`/`CxxString`/`CxxVector` misuse across the cxx FFI bridges). This is the brave-core SKUs piece.

The `HttpResponse` struct passed across the Rust↔C++ cxx bridge borrowed `&CxxVector<CxxString>` (headers) and `&CxxVector<u8>` (body). Sharing `std::vector`/`std::string` allocations with Rust this way relies on matching allocators across the FFI boundary, which is the pattern flagged in the audit.

This change switches `HttpResponse` to **owned** `Vec<String>`/`Vec<u8>`, matching the sibling `HttpRequest` struct (which already uses owned types), and deep-copies the data on the C++ side into a `rust::Vec` before handing it over.

## Notes

- Header values are constructed with `rust::String::lossy()` rather than the throwing `rust::String(const std::string&)` constructor. Server response header values are not guaranteed to be UTF-8, and Chromium is built with exceptions disabled — the throwing ctor would abort on a non-UTF-8 header. The Rust side already validates header names/values with `HeaderName::try_from`/`HeaderValue::try_from` and returns a clean `InternalError`, so `lossy()` preserves the prior graceful-failure behavior.
- The body is copied byte-for-byte into a `rust::Vec<uint8_t>`, equivalent to the previous `std::vector<uint8_t>` assignment.

## Test plan

- [x] `npm run build -- --target=brave/components/skus/browser:browser`
- [x] `npm run build -- --target=brave/components/skus/browser:unit_tests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)