### PR TITLE
[Sidebar V2] Fixed panel position when panel and VT are on same side

### DIFF
--- a/browser/ui/sidebar/sidebar_browsertest.cc
+++ b/browser/ui/sidebar/sidebar_browsertest.cc
@@ -26,6 +26,7 @@
 #include "brave/browser/ui/sidebar/sidebar_service_factory.h"
 #include "brave/browser/ui/sidebar/sidebar_utils.h"
 #include "brave/browser/ui/sidebar/sidebar_web_panel_controller.h"
+#include "brave/browser/ui/tabs/brave_tab_prefs.h"
 #include "brave/browser/ui/views/frame/brave_browser_view.h"
 #include "brave/browser/ui/views/frame/brave_contents_view_util.h"
 #include "brave/browser/ui/views/frame/split_view/brave_contents_container_view.h"
@@ -2046,7 +2047,8 @@ using views::ShapeContextTokensOverride::
 // In V2 the upstream side panel is a direct child of browser_view, positioned
 // by CalculateSideBarLayout.  Verify that when the panel is open it sits
 // between the contents container and the sidebar control, NOT outside it.
-// Covers both the default right-side and the explicitly set left-side layouts.
+// Covers: right-side, left-side, and VT+sidebar on the same side (regression
+// for the vtab_width gap bug fixed in ComputeAdjustedPanelBounds).
 IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, SidebarV2PanelPositionTest) {
   auto* browser_view = BrowserView::GetBrowserViewForBrowser(browser());
   auto* panel = browser_view->side_panel();
@@ -2090,6 +2092,44 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, SidebarV2PanelPositionTest) {
       << "sidebar=" << sidebar->bounds().ToString()
       << " panel=" << panel->bounds().ToString();
 
+  EXPECT_EQ(panel->bounds().y(), contents->bounds().y())
+      << "panel y=" << panel->bounds().y()
+      << " contents y=" << contents->bounds().y();
+
+  // --- VT and sidebar on the same left side (VT left by default, sidebar
+  // left). Before the fix, the panel was misplaced by vtab_width, leaving a gap
+  // between the panel and the contents container.
+  prefs->SetBoolean(prefs::kSidePanelHorizontalAlignment, false);
+  brave::ToggleVerticalTabStrip(browser());
+  ASSERT_TRUE(tabs::utils::ShouldShowBraveVerticalTabs(browser()));
+  // VT defaults to left (kVerticalTabsOnRight = false).
+  ASSERT_FALSE(tabs::utils::IsVerticalTabOnRight(browser()));
+  RunScheduledLayouts();
+
+  ASSERT_TRUE(sidebar->sidebar_on_left());
+
+  // Panel sits immediately right of the sidebar control; no gap to contents.
+  //   [VT] [sidebar_control] [panel] [contents]
+  EXPECT_EQ(sidebar->bounds().right(), panel->bounds().x())
+      << "sidebar=" << sidebar->bounds().ToString()
+      << " panel=" << panel->bounds().ToString();
+  EXPECT_EQ(panel->bounds().y(), contents->bounds().y())
+      << "panel y=" << panel->bounds().y()
+      << " contents y=" << contents->bounds().y();
+
+  // --- VT and sidebar on the same right side (VT right, sidebar right).
+  prefs->SetBoolean(prefs::kSidePanelHorizontalAlignment, true);
+  prefs->SetBoolean(brave_tabs::kVerticalTabsOnRight, true);
+  ASSERT_TRUE(tabs::utils::IsVerticalTabOnRight(browser()));
+  RunScheduledLayouts();
+
+  ASSERT_FALSE(sidebar->sidebar_on_left());
+
+  // Panel sits immediately left of the sidebar control; no gap to contents.
+  //   [contents] [panel] [sidebar_control] [VT]
+  EXPECT_EQ(panel->bounds().right(), sidebar->bounds().x())
+      << "panel=" << panel->bounds().ToString()
+      << " sidebar=" << sidebar->bounds().ToString();
   EXPECT_EQ(panel->bounds().y(), contents->bounds().y())
       << "panel y=" << panel->bounds().y()
       << " contents y=" << contents->bounds().y();

--- a/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl.cc
+++ b/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl.cc
@@ -77,24 +77,30 @@ gfx::Rect BraveBrowserViewTabbedLayoutImpl::ComputeSidebarBounds(
 gfx::Rect BraveBrowserViewTabbedLayoutImpl::ComputeAdjustedPanelBounds(
     bool sidebar_leading,
     const gfx::Rect& sidebar_bounds,
-    const gfx::Rect& panel_bounds) {
-  // The upstream layout animates the panel by varying panel.x:
-  //   trailing panel: x = right_edge - visible_width (slides in from high X)
-  //   leading  panel: x = left_edge - (target - visible_width) (from low X)
+    const gfx::Rect& panel_bounds,
+    const gfx::Rect& visual_client_area) {
+  // The upstream layout animates the panel's open/close by sliding panel.x
+  // between the browser edge (hidden) and the target width (shown), keeping the
+  // bounds width fixed. We translate that whole slide by a constant offset so
+  // it plays out against the sidebar's inner edge instead of the browser edge.
   //
-  // Shifting by ±sidebar_width offsets the whole slide range without changing
-  // the animation value, so the panel animates correctly against the sidebar
-  // edge instead of the browser edge. The sidebar and the upstream panel share
-  // the alignment pref, so `sidebar_leading` matches upstream's
-  // `side_panel_leading` and the shift direction agrees with where upstream
-  // placed the panel.
+  // A constant shift preserves the animation — overwriting panel.x outright
+  // would pin the bounds to a fixed rectangle and flatten the slide (the panel
+  // would pop to fully-open and overlap the still-animating contents). The
+  // offset is the gap between the upstream anchor edge (|visual_client_area|,
+  // the same rect upstream used to place |panel_bounds|) and the sidebar's
+  // inner edge. Because |sidebar_bounds| is already inset for any vertical tab
+  // on the same side, the offset is correct in every VT configuration.
+  //
+  // The sidebar and the upstream panel share the alignment pref, so
+  // `sidebar_leading` matches upstream's `side_panel_leading`.
   gfx::Rect result = panel_bounds;
   if (sidebar_leading) {
-    // Sidebar at the leading edge: shift panel toward high X.
-    result.set_x(panel_bounds.x() + sidebar_bounds.width());
+    // Slide anchored to the sidebar's trailing (right) edge.
+    result.Offset(sidebar_bounds.right() - visual_client_area.x(), 0);
   } else {
-    // Sidebar at the trailing edge: shift panel toward low X.
-    result.set_x(panel_bounds.x() - sidebar_bounds.width());
+    // Slide anchored to the sidebar's leading (left) edge.
+    result.Offset(sidebar_bounds.x() - visual_client_area.right(), 0);
   }
   return result;
 }
@@ -468,7 +474,8 @@ void BraveBrowserViewTabbedLayoutImpl::CalculateSideBarLayout(
       return;
     }
     panel_layout->bounds = ComputeAdjustedPanelBounds(
-        sidebar_leading, sidebar_bounds, panel_layout->bounds);
+        sidebar_leading, sidebar_bounds, panel_layout->bounds,
+        params.visual_client_area);
     // The upstream layout offsets the panel -1px above the contents to overlap
     // the toolbar separator. Brave doesn't need that overlap; align the panel's
     // vertical extent with the contents container instead.

--- a/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl.h
+++ b/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl.h
@@ -40,12 +40,17 @@ class BraveBrowserViewTabbedLayoutImpl : public BrowserViewTabbedLayoutImpl {
                                         int y,
                                         int height);
   // Returns the adjusted bounds for an upstream side panel so that it sits
-  // between the contents area and the sidebar control view.  The panel is
-  // shifted inward (toward the centre of the browser) until it is flush with
-  // the inner edge of |sidebar_bounds|.
-  static gfx::Rect ComputeAdjustedPanelBounds(bool sidebar_leading,
-                                              const gfx::Rect& sidebar_bounds,
-                                              const gfx::Rect& panel_bounds);
+  // between the contents area and the sidebar control view.  The upstream panel
+  // animates its open/close slide against the browser edge; this translates the
+  // whole slide by a constant offset so it instead plays out against the inner
+  // edge of |sidebar_bounds|, ending flush with the sidebar at full open.
+  // |visual_client_area| is the upstream anchor rect (the same one used to
+  // compute |panel_bounds|), needed to derive that offset.
+  static gfx::Rect ComputeAdjustedPanelBounds(
+      bool sidebar_leading,
+      const gfx::Rect& sidebar_bounds,
+      const gfx::Rect& panel_bounds,
+      const gfx::Rect& visual_client_area);
 
   views::View* contents_container() { return views().contents_container; }
 

--- a/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl_unittest.cc
+++ b/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl_unittest.cc
@@ -153,67 +153,91 @@ TEST(BraveBrowserViewTabbedLayoutImplSidebarTest,
 
 // ---------------------------------------------------------------------------
 // ComputeAdjustedPanelBounds
+//
+// The function translates the upstream panel by a constant offset so its
+// open/close slide plays out against the sidebar's inner edge. The upstream
+// panel keeps full `target_width` and animates by varying its x via
+// `visible_width` (0 → target); the function adds a constant shift, so it must
+// preserve that x-driven slide and only land flush with the sidebar at full
+// open. The "FullyOpen" cases pin the full-open geometry; the "Animating"
+// cases lock in that a mid-animation panel still slides (is not flattened).
+// `visual_client_area` is the upstream anchor rect, the same one upstream used
+// to place the panel.
 // ---------------------------------------------------------------------------
 
 TEST(BraveBrowserViewTabbedLayoutImplSidebarTest,
-     ComputeAdjustedPanelBoundsSidebarOnRightFullyOpen) {
-  // Browser 1000px wide. Sidebar control: narrow, x=960, width=40.
-  // Panel: upstream placed it at x=700 (= 1000-300), width=300 (fully open).
-  // Expected: shift left by sidebar_width (40) → x=660, right=960=sidebar.x.
+     ComputeAdjustedPanelBoundsSidebarTrailingFullyOpen) {
+  // Client 1000px wide. Trailing (right) sidebar at x=960, w=40 (flush, no VT).
+  // Panel fully open: upstream x = client.right()-target = 1000-300 = 700.
+  // Shift = sidebar.x()-client.right() = 960-1000 = -40 → x = 660, right = 960.
+  gfx::Rect client(0, 0, 1000, 700);
   gfx::Rect sidebar(960, 50, 40, 600);
   gfx::Rect panel(700, 50, 300, 600);
   gfx::Rect adjusted =
       BraveBrowserViewTabbedLayoutImpl::ComputeAdjustedPanelBounds(
-          /*sidebar_leading=*/false, sidebar, panel);
-  EXPECT_EQ(660, adjusted.x());
+          /*sidebar_leading=*/false, sidebar, panel, client);
+  EXPECT_EQ(gfx::Rect(660, 50, 300, 600), adjusted);
   EXPECT_EQ(sidebar.x(), adjusted.right());  // flush with sidebar's left edge
-  EXPECT_EQ(panel.width(), adjusted.width());
-  EXPECT_EQ(panel.y(), adjusted.y());
-  EXPECT_EQ(panel.height(), adjusted.height());
 }
 
 TEST(BraveBrowserViewTabbedLayoutImplSidebarTest,
-     ComputeAdjustedPanelBoundsSidebarOnRightAnimating) {
-  // Same browser/sidebar.  Panel 50% open: visible_width=150, so upstream
-  // places it at x=850 (= 1000-150).  After adjustment: x=810.
-  // The user sees 150px between adjusted.x(810) and sidebar.x(960). ✓
+     ComputeAdjustedPanelBoundsSidebarTrailingAnimating) {
+  // Same client/sidebar. Panel 50% open: visible_width=150, so upstream
+  // x = client.right()-visible = 1000-150 = 850.  Shift = -40 → x = 810.
+  // The slide is preserved: 150px of panel is visible up to the sidebar edge.
+  gfx::Rect client(0, 0, 1000, 700);
   gfx::Rect sidebar(960, 50, 40, 600);
-  gfx::Rect panel(850, 50, 300, 600);  // upstream: right_edge - visible_width
+  gfx::Rect panel(850, 50, 300, 600);
   gfx::Rect adjusted =
       BraveBrowserViewTabbedLayoutImpl::ComputeAdjustedPanelBounds(
-          /*sidebar_leading=*/false, sidebar, panel);
+          /*sidebar_leading=*/false, sidebar, panel, client);
   EXPECT_EQ(810, adjusted.x());
   EXPECT_EQ(150, sidebar.x() - adjusted.x());  // 150px visible to the user
 }
 
 TEST(BraveBrowserViewTabbedLayoutImplSidebarTest,
-     ComputeAdjustedPanelBoundsSidebarOnLeftFullyOpen) {
-  // Browser 1000px wide. Sidebar control: x=0, width=40.
-  // Panel: upstream placed it at x=0 (= visual_client_area.x()), width=300
-  // (fully open). Expected: shift right by sidebar_width (40) →
-  // x=40=sidebar.right.
+     ComputeAdjustedPanelBoundsSidebarAndVtabTrailingFullyOpen) {
+  // The regression case: VT on the right (width 150) pushes the sidebar inward,
+  // so sidebar.x()=810 (= 1000-150-40).  Panel fully open: upstream x=700.
+  // Shift = sidebar.x()-client.right() = 810-1000 = -190 = -(sidebar 40 + VT
+  // 150) → x = 510, right = 810.  A constant ±sidebar_width shift would have
+  // left a 150px gap here.
+  gfx::Rect client(0, 0, 1000, 700);
+  gfx::Rect sidebar(810, 50, 40, 600);
+  gfx::Rect panel(700, 50, 300, 600);
+  gfx::Rect adjusted =
+      BraveBrowserViewTabbedLayoutImpl::ComputeAdjustedPanelBounds(
+          /*sidebar_leading=*/false, sidebar, panel, client);
+  EXPECT_EQ(gfx::Rect(510, 50, 300, 600), adjusted);
+  EXPECT_EQ(sidebar.x(), adjusted.right());  // flush with sidebar's left edge
+}
+
+TEST(BraveBrowserViewTabbedLayoutImplSidebarTest,
+     ComputeAdjustedPanelBoundsSidebarLeadingFullyOpen) {
+  // Client 1000px wide. Leading (left) sidebar at x=0, w=40 (flush, no VT).
+  // Panel fully open: upstream x = client.x()-(target-visible) = 0.
+  // Shift = sidebar.right()-client.x() = 40-0 = 40 → x = 40 = sidebar.right().
+  gfx::Rect client(0, 0, 1000, 700);
   gfx::Rect sidebar(0, 50, 40, 600);
   gfx::Rect panel(0, 50, 300, 600);
   gfx::Rect adjusted =
       BraveBrowserViewTabbedLayoutImpl::ComputeAdjustedPanelBounds(
-          /*sidebar_leading=*/true, sidebar, panel);
-  EXPECT_EQ(40, adjusted.x());
+          /*sidebar_leading=*/true, sidebar, panel, client);
+  EXPECT_EQ(gfx::Rect(40, 50, 300, 600), adjusted);
   EXPECT_EQ(sidebar.right(), adjusted.x());  // flush with sidebar's right edge
-  EXPECT_EQ(panel.width(), adjusted.width());
-  EXPECT_EQ(panel.y(), adjusted.y());
-  EXPECT_EQ(panel.height(), adjusted.height());
 }
 
 TEST(BraveBrowserViewTabbedLayoutImplSidebarTest,
-     ComputeAdjustedPanelBoundsSidebarOnLeftAnimating) {
-  // Panel 50% open: visible_width=150, upstream x = 0-(300-150) = -150.
-  // After adjustment: x = -150+40 = -110.
-  // Visible to user: from sidebar.right(40) to adjusted.right(190) = 150px. ✓
+     ComputeAdjustedPanelBoundsSidebarLeadingAnimating) {
+  // Same client/sidebar. Panel 50% open: visible_width=150, so upstream
+  // x = client.x()-(target-visible) = 0-(300-150) = -150.  Shift = 40 → x=-110.
+  // The slide is preserved: 150px visible from the sidebar edge.
+  gfx::Rect client(0, 0, 1000, 700);
   gfx::Rect sidebar(0, 50, 40, 600);
-  gfx::Rect panel(-150, 50, 300, 600);  // upstream: left_edge-(target-visible)
+  gfx::Rect panel(-150, 50, 300, 600);
   gfx::Rect adjusted =
       BraveBrowserViewTabbedLayoutImpl::ComputeAdjustedPanelBounds(
-          /*sidebar_leading=*/true, sidebar, panel);
+          /*sidebar_leading=*/true, sidebar, panel, client);
   EXPECT_EQ(-110, adjusted.x());
   EXPECT_EQ(150, adjusted.right() - sidebar.right());  // 150px visible to user
 }


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves no issue - use umbrella issue (https://github.com/brave/brave-browser/issues/51462)

Adjusted side panel positioning so the panel sits adjacent to the Brave sidebar control
even when the vertical tab strip (VT) is on the same side, eliminating the previously observed “vtab_width gap”.

TEST=SidebarBrowserTest.SidebarV2PanelPositionTest, BraveBrowserViewTabbedLayoutImplSidebarTest.*

Panel position with this fix:
<img width="1244" height="591" alt="Screenshot from 2026-06-12 13-54-56" src="https://github.com/user-attachments/assets/11246354-8722-4fec-94d1-21d5b67b3355" />

Panel position without this fix: 
<img width="1244" height="591" alt="Screenshot from 2026-06-12 13-56-10" src="https://github.com/user-attachments/assets/36ffe6a6-9e63-41c7-9d0a-b249cf9c80f3" />


<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
