### PR TITLE
Exclude orphaned containers from GetUsedContainerIds during cleanup

### DIFF
--- a/browser/containers/containers_browsertest.cc
+++ b/browser/containers/containers_browsertest.cc
@@ -1978,7 +1978,7 @@ IN_PROC_BROWSER_TEST_F(ContainersBrowserTest, MixedTabsPersistence) {
 }
 
 IN_PROC_BROWSER_TEST_F(ContainersBrowserTest,
-                       DISABLED_PRE_RemovedContainerCleanupAfterRestore) {
+                       PRE_RemovedContainerCleanupAfterRestore) {
   const GURL url("https://a.test/simple.html");
   std::vector<containers::mojom::ContainerPtr> synced;
   auto container = containers::mojom::Container::New(
@@ -2019,7 +2019,7 @@ IN_PROC_BROWSER_TEST_F(ContainersBrowserTest,
 }
 
 IN_PROC_BROWSER_TEST_F(ContainersBrowserTest,
-                       DISABLED_RemovedContainerCleanupAfterRestore) {
+                       RemovedContainerCleanupAfterRestore) {
   const GURL url("https://a.test/simple.html");
   auto container = containers::mojom::Container::New(
       kTestContainerId, "Shopping", containers::mojom::Icon::kShopping,

--- a/components/containers/core/browser/containers_service.cc
+++ b/components/containers/core/browser/containers_service.cc
@@ -7,6 +7,7 @@
 
 #include <utility>
 #include <variant>
+#include <vector>
 
 #include "base/check.h"
 #include "base/check_deref.h"
@@ -106,8 +107,20 @@ std::vector<mojom::ContainerPtr> ContainersService::GetContainers() const {
 }
 
 std::vector<std::string> ContainersService::GetUsedContainerIds() const {
-  return base::ToVector(GetLocallyUsedContainersFromPrefs(*prefs_),
-                        [](const auto& c) { return c->id; });
+  if (orphaned_cleanup_state_ ==
+      OrphanedContainersCleanupState::kDiscoveringOrphans) {
+    return {};
+  }
+
+  auto used_ids = base::ToVector(GetLocallyUsedContainersFromPrefs(*prefs_),
+                                 [](const auto& c) { return c->id; });
+  if (orphaned_cleanup_state_ ==
+      OrphanedContainersCleanupState::kRemovingOrphans) {
+    std::erase_if(used_ids, [&](const std::string& id) {
+      return orphaned_containers_pending_removal_.contains(id);
+    });
+  }
+  return used_ids;
 }
 
 bool ContainersService::ShouldShowContainerControls() const {
@@ -159,6 +172,10 @@ ContainersService::GetContainerIdFromContainerSpecifier(
 }
 
 void ContainersService::ScheduleOrphanedContainersCleanup() {
+  if (orphaned_cleanup_state_ != OrphanedContainersCleanupState::kIdle) {
+    return;
+  }
+
   bool should_cleanup = false;
 
   // Check if any locally used container is not referenced by the synced
@@ -179,6 +196,8 @@ void ContainersService::ScheduleOrphanedContainersCleanup() {
   // If any locally used container is not referenced by the synced containers
   // list, schedule the cleanup.
   if (should_cleanup) {
+    orphaned_cleanup_state_ =
+        OrphanedContainersCleanupState::kDiscoveringOrphans;
     delegate_->GetReferencedContainerIds(
         base::BindOnce(&ContainersService::OnReferencedContainerIdsReady,
                        weak_factory_.GetWeakPtr()));
@@ -197,14 +216,26 @@ void ContainersService::OnReferencedContainerIdsReady(
       continue;
     }
 
+    orphaned_containers_pending_removal_.insert(id);
     delegate_->DeleteContainerStorage(
         id, base::BindOnce(&ContainersService::OnContainerStorageDeleted,
                            weak_factory_.GetWeakPtr(), id));
+  }
+
+  if (orphaned_containers_pending_removal_.empty()) {
+    orphaned_cleanup_state_ = OrphanedContainersCleanupState::kIdle;
+  } else {
+    orphaned_cleanup_state_ = OrphanedContainersCleanupState::kRemovingOrphans;
   }
 }
 
 void ContainersService::OnContainerStorageDeleted(const std::string& id,
                                                   bool success) {
+  orphaned_containers_pending_removal_.erase(id);
+  if (orphaned_containers_pending_removal_.empty()) {
+    orphaned_cleanup_state_ = OrphanedContainersCleanupState::kIdle;
+  }
+
   if (!success) {
     LOG(WARNING) << "Failed to delete container storage for " << id
                  << " will retry on next launch";

--- a/components/containers/core/browser/containers_service.h
+++ b/components/containers/core/browser/containers_service.h
@@ -77,7 +77,8 @@ class ContainersService : public KeyedService {
   // Returns the list of user-editable containers.
   std::vector<mojom::ContainerPtr> GetContainers() const;
 
-  // Returns ids of containers that have been used in this profile.
+  // Returns ids of containers that have been used in this profile. Empty while
+  // orphaned-container cleanup is discovering candidates.
   std::vector<std::string> GetUsedContainerIds() const;
 
   // Whether the Containers controls (menus, management UI) should be shown.
@@ -108,10 +109,19 @@ class ContainersService : public KeyedService {
   // Called when the storage for the container with the given id is deleted.
   void OnContainerStorageDeleted(const std::string& id, bool success);
 
+  enum class OrphanedContainersCleanupState {
+    kIdle,
+    kDiscoveringOrphans,
+    kRemovingOrphans,
+  };
+
   raw_ref<PrefService> prefs_;
   std::unique_ptr<Delegate> delegate_;
   PrefChangeRegistrar pref_change_registrar_;
   base::ObserverList<ContainersServiceObserver> observers_;
+  OrphanedContainersCleanupState orphaned_cleanup_state_ =
+      OrphanedContainersCleanupState::kIdle;
+  base::flat_set<std::string> orphaned_containers_pending_removal_;
   base::WeakPtrFactory<ContainersService> weak_factory_{this};
 };
 

--- a/components/containers/core/browser/containers_service_unittest.cc
+++ b/components/containers/core/browser/containers_service_unittest.cc
@@ -203,6 +203,59 @@ TEST_F(ContainersServiceTest, GetUsedContainerIds) {
   EXPECT_THAT(service_->GetUsedContainerIds(), testing::ElementsAre("used-id"));
 }
 
+TEST_F(ContainersServiceTest, GetUsedContainerIds_EmptyWhileDiscovering) {
+  SetContainersToPrefs({}, prefs_);
+  service_->MarkContainerUsed("orphan-id");
+
+  delegate_->set_defer_referenced_container_ids_callback(true);
+  service_->ScheduleOrphanedContainersCleanupForTesting();
+
+  EXPECT_TRUE(GetLocallyUsedContainerFromPrefs(prefs_, "orphan-id"));
+  EXPECT_TRUE(service_->GetUsedContainerIds().empty());
+}
+
+TEST_F(ContainersServiceTest,
+       GetUsedContainerIds_ExcludesOrphansWhileRemoving) {
+  SetContainersToPrefs({}, prefs_);
+  service_->MarkContainerUsed("orphan-id");
+  service_->MarkContainerUsed("retained-id");
+
+  delegate_->SetReferencedContainersIds({"retained-id"});
+  delegate_->set_defer_referenced_container_ids_callback(true);
+  delegate_->set_defer_delete_container_storage_callback(true);
+  service_->ScheduleOrphanedContainersCleanupForTesting();
+
+  delegate_->RunDeferredReferencedContainerIdsCallback();
+
+  EXPECT_TRUE(GetLocallyUsedContainerFromPrefs(prefs_, "orphan-id"));
+  EXPECT_TRUE(GetLocallyUsedContainerFromPrefs(prefs_, "retained-id"));
+  EXPECT_THAT(service_->GetUsedContainerIds(),
+              testing::ElementsAre("retained-id"));
+}
+
+TEST_F(ContainersServiceTest, GetUsedContainerIds_IncludesFailedDelete) {
+  SetContainersToPrefs({}, prefs_);
+  service_->MarkContainerUsed("orphan-id");
+
+  delegate_->SetReferencedContainersIds({});
+  delegate_->set_delete_result(false);
+  service_->ScheduleOrphanedContainersCleanupForTesting();
+
+  EXPECT_THAT(service_->GetUsedContainerIds(),
+              testing::ElementsAre("orphan-id"));
+}
+
+TEST_F(ContainersServiceTest, GetUsedContainerIds_BackToIdleAfterRemoval) {
+  SetContainersToPrefs({}, prefs_);
+  service_->MarkContainerUsed("orphan-id");
+
+  delegate_->SetReferencedContainersIds({});
+  service_->ScheduleOrphanedContainersCleanupForTesting();
+
+  EXPECT_TRUE(service_->GetUsedContainerIds().empty());
+  EXPECT_FALSE(GetLocallyUsedContainerFromPrefs(prefs_, "orphan-id"));
+}
+
 TEST_F(ContainersServiceTest,
        MarkContainerUsed_DoesNotUpsertWhenAlreadyInUsedPrefs) {
   auto container = MakeContainer("used-id", "Local");

--- a/components/containers/core/browser/containers_test_utils.cc
+++ b/components/containers/core/browser/containers_test_utils.cc
@@ -15,12 +15,21 @@ namespace containers {
 MockContainersServiceDelegate::MockContainersServiceDelegate() {
   ON_CALL(*this, GetReferencedContainerIds(testing::_))
       .WillByDefault([this](OnReferencedContainerIdsReadyCallback callback) {
+        if (defer_referenced_container_ids_callback_) {
+          deferred_referenced_container_ids_callback_ = std::move(callback);
+          return;
+        }
         std::move(callback).Run(referenced_container_ids_);
       });
   ON_CALL(*this, DeleteContainerStorage(testing::_, testing::_))
       .WillByDefault([this](const std::string& id,
                             DeleteContainerStorageCallback callback) {
         delete_requests_.push_back(id);
+        if (defer_delete_container_storage_callback_) {
+          deferred_delete_container_storage_callbacks_[id] =
+              std::move(callback);
+          return;
+        }
         std::move(callback).Run(delete_result_);
       });
 }

--- a/components/containers/core/browser/containers_test_utils.h
+++ b/components/containers/core/browser/containers_test_utils.h
@@ -10,6 +10,8 @@
 #include <utility>
 #include <vector>
 
+#include "base/check.h"
+#include "base/containers/flat_map.h"
 #include "base/containers/flat_set.h"
 #include "brave/components/containers/core/browser/containers_service.h"
 #include "brave/components/containers/core/mojom/containers.mojom.h"
@@ -37,6 +39,29 @@ class MockContainersServiceDelegate : public ContainersService::Delegate {
   }
 
   void set_delete_result(bool delete_result) { delete_result_ = delete_result; }
+
+  void set_defer_referenced_container_ids_callback(bool defer) {
+    defer_referenced_container_ids_callback_ = defer;
+  }
+
+  void set_defer_delete_container_storage_callback(bool defer) {
+    defer_delete_container_storage_callback_ = defer;
+  }
+
+  void RunDeferredReferencedContainerIdsCallback() {
+    CHECK(deferred_referenced_container_ids_callback_);
+    std::move(deferred_referenced_container_ids_callback_)
+        .Run(referenced_container_ids_);
+    deferred_referenced_container_ids_callback_.Reset();
+  }
+
+  void RunDeferredDeleteContainerStorageCallback(const std::string& id) {
+    CHECK(deferred_delete_container_storage_callbacks_.contains(id));
+    std::move(deferred_delete_container_storage_callbacks_[id])
+        .Run(delete_result_);
+    deferred_delete_container_storage_callbacks_.erase(id);
+  }
+
   const std::vector<std::string>& delete_requests() const {
     return delete_requests_;
   }
@@ -44,6 +69,12 @@ class MockContainersServiceDelegate : public ContainersService::Delegate {
  private:
   base::flat_set<std::string> referenced_container_ids_;
   bool delete_result_ = true;
+  bool defer_referenced_container_ids_callback_ = false;
+  bool defer_delete_container_storage_callback_ = false;
+  OnReferencedContainerIdsReadyCallback
+      deferred_referenced_container_ids_callback_;
+  base::flat_map<std::string, DeleteContainerStorageCallback>
+      deferred_delete_container_storage_callbacks_;
   std::vector<std::string> delete_requests_;
 };
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
GetUsedContainerIds() could return container ids that orphaned-container cleanup was about to delete or was actively removing. Browsing data removal uses this list to enumerate container storage partitions,  could race with cleanup.

Track orphaned-container cleanup state in ContainersService:
- return an empty list while referenced container ids are being resolved
- exclude ids pending storage deletion once orphans are known

Resolves https://github.com/brave/brave-browser/issues/56319

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - instruct CI to not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting for your code changes
* CI/enable-test-only-affected - instruct CI to only run tests affected by your change
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run smoke performance tests
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/run-teamcity - run TeamCity
* CI/skip-teamcity - skip TeamCity
* CI/skip - do not run CI builds (except noplatform)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
