### PR TITLE
[Wallet] Fix renderer crash

### DIFF
--- a/components/brave_wallet/renderer/js_ethereum_provider.h
+++ b/components/brave_wallet/renderer/js_ethereum_provider.h
@@ -52,8 +52,8 @@ class JSEthereumProvider final : public gin::Wrappable<JSEthereumProvider>,
                     base::Value result) override;
 
  private:
-  class MetaMask final : public content::RenderFrameObserver,
-                         public gin::Wrappable<MetaMask> {
+  class MetaMask final : public gin::Wrappable<MetaMask>,
+                         public content::RenderFrameObserver {
    public:
     static constexpr gin::WrapperInfo kWrapperInfo = {{gin::kEmbedderNativeGin},
                                                       gin::kMetaMask};


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/56323

Reorder base classes of MetaMask(gin::Wrappable<MetaMask> must be first) so GC works correctly.


```
[ 00 ] std::__Cr::vector<base::internal::UncheckedObserverAdapter<(partition_alloc::internal::RawPtrTraits)0, false>, std::__Cr::allocator<base::internal::UncheckedObserverAdapter<(partition_alloc::internal::RawPtrTraits)0, false>>>::begin() ( vector.h:348 )
[ 01 ] auto std::__Cr::ranges::__begin::__fn::operator()<std::__Cr::vector<base::internal::UncheckedObserverAdapter<(partition_alloc::internal::RawPtrTraits)0, false>, std::__Cr::allocator<base::internal::UncheckedObserverAdapter<(partition_alloc::internal::RawPtrTraits)0, false>>>&>(T&&) const ( access.h:75 )
[ 02 ] std::__Cr::_IfImpl<borrowed_range<T>>::_Select<decltype(std::__Cr::ranges::__cpo::begin(std::declval<T&>())), std::__Cr::ranges::dangling> std::__Cr::ranges::__find_if::operator()<std::__Cr::vector<base::internal::UncheckedObserverAdapter<(partition_alloc::internal::RawPtrTraits)0, false>, std::__Cr::allocator<base::internal::UncheckedObserverAdapter<(partition_alloc::internal::RawPtrTraits)0, false>>>&, std::__Cr::identity, base::ObserverList<content::RenderFrameObserver, false, (base::ObserverListReentrancyPolicy)2, base::internal::UncheckedObserverAdapter<(partition_alloc::internal::RawPtrTraits)0, false>>::RemoveObserver(content::RenderFrameObserver const*)::'lambda'(T const&)>(T&&, base::ObserverList<content::RenderFrameObserver, false, (base::ObserverListReentrancyPolicy)2, base::internal::UncheckedObserverAdapter<(partition_alloc::internal::RawPtrTraits)0, false>>::RemoveObserver(content::RenderFrameObserver const*)::'lambda'(T const&), T0) const ( ranges_find_if.h:49 )
[ 03 ] base::ObserverList<content::RenderFrameObserver, false, (base::ObserverListReentrancyPolicy)2, base::internal::UncheckedObserverAdapter<(partition_alloc::internal::RawPtrTraits)0, false>>::RemoveObserver(content::RenderFrameObserver const*) ( observer_list.h:385 )
[ 04 ] content::RenderFrameObserver::Dispose() ( render_frame_observer.cc:29 )
[ 05 ] brave_wallet::JSEthereumProvider::MetaMask::Cleanup() ( js_ethereum_provider.cc:284 )
[ 06 ] brave_wallet::JSEthereumProvider::MetaMask::OnDestruct() ( js_ethereum_provider.cc:288 )
[ 07 ] cppgc::internal::(anonymous namespace)::InlinedFinalizationBuilder<cppgc::internal::(anonymous namespace)::RegularFreeHandler>::ResultType cppgc::internal::(anonymous namespace)::SweepNormalPage<cppgc::internal::(anonymous namespace)::InlinedFinalizationBuilder<cppgc::internal::(anonymous namespace)::RegularFreeHandler>>(cppgc::internal::NormalPage*, v8::PageAllocator&, cppgc::internal::StickyBits) ( heap-object-header.cc:37 )
[ 08 ] cppgc::internal::(anonymous namespace)::MutatorThreadSweeper::VisitNormalPage(cppgc::internal::NormalPage&) ( sweeper.cc:721 )
[ 09 ] cppgc::internal::HeapVisitor<cppgc::internal::(anonymous namespace)::MutatorThreadSweeper>::VisitNormalPageImpl(cppgc::internal::NormalPage&) ( heap-visitor.h:75 )
[ 10 ] cppgc::internal::HeapVisitor<cppgc::internal::(anonymous namespace)::MutatorThreadSweeper>::Traverse(cppgc::internal::BasePage&) ( heap-visitor.h:47 )
[ 11 ] cppgc::internal::(anonymous namespace)::InlinedFinalizationBuilder<cppgc::internal::(anonymous namespace)::RegularFreeHandler>::ResultType cppgc::internal::(anonymous namespace)::SweepNormalPage<cppgc::internal::(anonymous namespace)::InlinedFinalizationBuilder<cppgc::internal::(anonymous namespace)::RegularFreeHandler>>(cppgc::internal::NormalPage*, v8::PageAllocator&, cppgc::internal::StickyBits) ( heap-object-header.cc:37 )
[ 12 ] cppgc::internal::(anonymous namespace)::MutatorThreadSweeper::VisitNormalPage(cppgc::internal::NormalPage&) ( sweeper.cc:721 )
[ 13 ] cppgc::internal::HeapVisitor<cppgc::internal::(anonymous namespace)::MutatorThreadSweeper>::VisitNormalPageImpl(cppgc::internal::NormalPage&) ( heap-visitor.h:75 )
[ 14 ] cppgc::internal::HeapVisitor<cppgc::internal::(anonymous namespace)::MutatorThreadSweeper>::Traverse(cppgc::internal::BasePage&) ( heap-visitor.h:47 )
[ 15 ] cppgc::internal::(anonymous namespace)::MutatorThreadSweeper::SweepPage(cppgc::internal::BasePage&) ( sweeper.cc:653 )
[ 16 ] cppgc::internal::(anonymous namespace)::MutatorThreadSweeper::Sweep(cppgc::internal::(anonymous namespace)::SweepingState&) ( sweeper.cc:649 )
[ 17 ] cppgc::internal::(anonymous namespace)::MutatorThreadSweeper::Sweep(std::__Cr::vector<cppgc::internal::(anonymous namespace)::SweepingState, std::__Cr::allocator<cppgc::internal::(anonymous namespace)::SweepingState>>&) ( sweeper.cc:643 )
[ 18 ] cppgc::internal::Sweeper::SweeperImpl::Finish() ( sweeper.cc:1310 )
[ 19 ] cppgc::internal::Sweeper::SweeperImpl::FinishIfRunning() ( sweeper.cc:1236 )
[ 20 ] cppgc::internal::Sweeper::FinishIfRunning() ( sweeper.cc:1665 )
[ 21 ] v8::internal::CppHeap::FinishSweepingIfRunning() ( cpp-heap.cc:1264 )
[ 22 ] v8::internal::Heap::EnsureSweepingCompleted(v8::internal::Heap::SweepingForcedFinalizationMode, v8::internal::CompleteSweepingReason) ( heap.cc:7642 )
[ 23 ] v8::internal::Heap::CompleteSweepingFull(v8::internal::CompleteSweepingReason) ( heap.cc:1925 )
[ 24 ] v8::internal::Heap::StartIncrementalMarking(v8::base::Flags<v8::internal::GCFlag, unsigned char, unsigned char>, v8::internal::GarbageCollectionReason, v8::GCCallbackFlags, v8::internal::GarbageCollector, char const*) ( heap.cc:1860 )
[ 25 ] v8::internal::CppHeap::ReportBufferedAllocationSizeIfPossible() ( cpp-heap.cc:1093 )
...
```

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
