### PR TITLE
[farbling] Add browser tests for blob:// rendered inside iframe

### DIFF
--- a/browser/farbling/brave_blob_screen_farbling_browsertest.cc
+++ b/browser/farbling/brave_blob_screen_farbling_browsertest.cc
@@ -124,8 +124,6 @@ class BraveBlobScreenFarblingBrowserTest
     NavigateToBlobIframe();
   }
 
-  // Like NavigateToBlob but the blob URL is loaded inside an iframe rather
-  // than a new popup window, so the pass/fail title is set on the main frame.
   void NavigateToBlobIframe() {
     ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), blob_test_url_));
     content::ExecuteScriptAsync(Parent(),

--- a/browser/farbling/brave_blob_screen_farbling_browsertest.cc
+++ b/browser/farbling/brave_blob_screen_farbling_browsertest.cc
@@ -6,6 +6,7 @@
 #include <string>
 
 #include "base/path_service.h"
+#include "base/test/run_until.h"
 #include "base/test/scoped_feature_list.h"
 #include "brave/components/brave_shields/core/browser/brave_shields_utils.h"
 #include "brave/components/constants/brave_paths.h"
@@ -128,8 +129,17 @@ class BraveBlobScreenFarblingBrowserTest
     ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), blob_test_url_));
     content::ExecuteScriptAsync(Parent(),
                                 "startBlobScreenFingerprintingIframeTest()");
-    TitleWatcher watcher(Contents(), u"pass");
-    EXPECT_EQ(u"pass", watcher.WaitAndGetTitle());
+
+    // Wait for the blob iframe to finish writing to localStorage.
+    ASSERT_TRUE(base::test::RunUntil([&]() {
+      return content::EvalJs(Parent(),
+                             "localStorage.getItem('blob_done') === 'true'")
+          .ExtractBool();
+    }));
+
+    EXPECT_EQ(true, content::EvalJs(Parent(),
+                                    "storedScreenValuesMatch('parent', 'blob')")
+                        .ExtractBool());
   }
 
  private:

--- a/browser/farbling/brave_blob_screen_farbling_browsertest.cc
+++ b/browser/farbling/brave_blob_screen_farbling_browsertest.cc
@@ -25,8 +25,6 @@ using content::TitleWatcher;
 
 namespace {
 
-constexpr char16_t kPassTitle[] = u"pass";
-constexpr char16_t kFailTitle[] = u"fail";
 constexpr gfx::Rect kTestWindowBounds(100, 100, 400, 400);
 
 }  // namespace
@@ -95,12 +93,10 @@ class BraveBlobScreenFarblingBrowserTest
     SetFingerprintingSetting(/*allow=*/false);
     // TODO(https://github.com/brave/brave-browser/issues/56048): Expect pass
     // once Shields are supported on blob:// URLs.
-    std::u16string expected_title = GetParam() ? kFailTitle : kPassTitle;
-    NavigateToBlob(expected_title);
+    NavigateToBlob(GetParam() ? u"fail" : u"pass");
 
     SetFingerprintingSetting(/*allow=*/true);
-    expected_title = kPassTitle;
-    NavigateToBlob(expected_title);
+    NavigateToBlob(u"pass");
   }
 
   void NavigateToBlob(const std::u16string& expected_title) {
@@ -115,6 +111,27 @@ class BraveBlobScreenFarblingBrowserTest
     TitleWatcher watcher(popup_contents, expected_title);
     EXPECT_EQ(expected_title, watcher.WaitAndGetTitle());
     CloseBrowserSynchronously(popup);
+  }
+
+  // Similar to FarbleScreenBlobURL but renders the blob in an iframe.
+  void FarbleScreenBlobURLIframe() {
+    ui_test_utils::SetAndWaitForBounds(*browser(), kTestWindowBounds);
+
+    SetFingerprintingSetting(/*allow=*/false);
+    NavigateToBlobIframe();
+
+    SetFingerprintingSetting(/*allow=*/true);
+    NavigateToBlobIframe();
+  }
+
+  // Like NavigateToBlob but the blob URL is loaded inside an iframe rather
+  // than a new popup window, so the pass/fail title is set on the main frame.
+  void NavigateToBlobIframe() {
+    ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), blob_test_url_));
+    content::ExecuteScriptAsync(Parent(),
+                                "startBlobScreenFingerprintingIframeTest()");
+    TitleWatcher watcher(Contents(), u"pass");
+    EXPECT_EQ(u"pass", watcher.WaitAndGetTitle());
   }
 
  private:
@@ -134,4 +151,9 @@ INSTANTIATE_TEST_SUITE_P(
 IN_PROC_BROWSER_TEST_P(BraveBlobScreenFarblingBrowserTest,
                        FarbleScreenBlobURL) {
   FarbleScreenBlobURL();
+}
+
+IN_PROC_BROWSER_TEST_P(BraveBlobScreenFarblingBrowserTest,
+                       FarbleScreenBlobURLIframe) {
+  FarbleScreenBlobURLIframe();
 }

--- a/chromium_src/third_party/blink/renderer/core/frame/local_dom_window.cc
+++ b/chromium_src/third_party/blink/renderer/core/frame/local_dom_window.cc
@@ -4,7 +4,6 @@
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #include "third_party/blink/renderer/core/frame/local_dom_window.h"
-
 #include "brave/third_party/blink/renderer/core/farbling/brave_session_cache.h"
 // Include mouse_event.h, pointer_event.h here to avoid re-defining
 // tokens named screenX, screenY:

--- a/chromium_src/third_party/blink/renderer/core/frame/local_dom_window.cc
+++ b/chromium_src/third_party/blink/renderer/core/frame/local_dom_window.cc
@@ -45,21 +45,6 @@ using brave::BlockScreenFingerprinting;
 using brave::FarbleInteger;
 using brave::FarbleKey;
 
-namespace {
-
-// A helper method to return the execution context of the |opener| if |opener|
-// is not null. Otherwise, returns the |current_context|.
-// Sharing the same execution context as the opener helps to ensure the
-// underlying brave session cache is the same, which helps to keep the same
-// farbling seed for both the opener and the openee ensuring they see the same
-// farbled values.
-ExecutionContext* GetContextFromOpenerIfPossible(
-    const DOMWindow* opener,
-    ExecutionContext* current_context) {
-  return opener ? opener->GetExecutionContext() : current_context;
-}
-
-}  // namespace
 const SecurityOrigin* GetEphemeralStorageOrigin(LocalDOMWindow* window) {
   auto* frame = window->GetFrame();
   if (!frame) {
@@ -114,8 +99,7 @@ int LocalDOMWindow::screenY() const {
 void LocalDOMWindow::resizeTo(int width,
                               int height,
                               ExceptionState& exception_state) const {
-  ExecutionContext* context =
-      GetContextFromOpenerIfPossible(opener(), GetExecutionContext());
+  ExecutionContext* context = GetExecutionContext();
   if (BlockScreenFingerprinting(context)) {
     resizeTo_ChromiumImpl(width + outerWidth_ChromiumImpl() - outerWidth(),
                           height + outerHeight_ChromiumImpl() - outerHeight(),
@@ -126,8 +110,7 @@ void LocalDOMWindow::resizeTo(int width,
 }
 
 void LocalDOMWindow::moveTo(int x, int y) const {
-  ExecutionContext* context =
-      GetContextFromOpenerIfPossible(opener(), GetExecutionContext());
+  ExecutionContext* context = GetExecutionContext();
   if (BlockScreenFingerprinting(context)) {
     moveTo_ChromiumImpl(x + screenX_ChromiumImpl() - screenX(),
                         y + screenY_ChromiumImpl() - screenY());

--- a/chromium_src/third_party/blink/renderer/core/frame/local_dom_window.cc
+++ b/chromium_src/third_party/blink/renderer/core/frame/local_dom_window.cc
@@ -4,6 +4,7 @@
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #include "third_party/blink/renderer/core/frame/local_dom_window.h"
+
 #include "brave/third_party/blink/renderer/core/farbling/brave_session_cache.h"
 // Include mouse_event.h, pointer_event.h here to avoid re-defining
 // tokens named screenX, screenY:
@@ -44,6 +45,21 @@ using brave::BlockScreenFingerprinting;
 using brave::FarbleInteger;
 using brave::FarbleKey;
 
+namespace {
+
+// A helper method to return the execution context of the |opener| if |opener|
+// is not null. Otherwise, returns the |current_context|.
+// Sharing the same execution context as the opener helps to ensure the
+// underlying brave session cache is the same, which helps to keep the same
+// farbling seed for both the opener and the openee ensuring they see the same
+// farbled values.
+ExecutionContext* GetContextFromOpenerIfPossible(
+    const DOMWindow* opener,
+    ExecutionContext* current_context) {
+  return opener ? opener->GetExecutionContext() : current_context;
+}
+
+}  // namespace
 const SecurityOrigin* GetEphemeralStorageOrigin(LocalDOMWindow* window) {
   auto* frame = window->GetFrame();
   if (!frame) {
@@ -98,7 +114,8 @@ int LocalDOMWindow::screenY() const {
 void LocalDOMWindow::resizeTo(int width,
                               int height,
                               ExceptionState& exception_state) const {
-  ExecutionContext* context = GetExecutionContext();
+  ExecutionContext* context =
+      GetContextFromOpenerIfPossible(opener(), GetExecutionContext());
   if (BlockScreenFingerprinting(context)) {
     resizeTo_ChromiumImpl(width + outerWidth_ChromiumImpl() - outerWidth(),
                           height + outerHeight_ChromiumImpl() - outerHeight(),
@@ -109,7 +126,8 @@ void LocalDOMWindow::resizeTo(int width,
 }
 
 void LocalDOMWindow::moveTo(int x, int y) const {
-  ExecutionContext* context = GetExecutionContext();
+  ExecutionContext* context =
+      GetContextFromOpenerIfPossible(opener(), GetExecutionContext());
   if (BlockScreenFingerprinting(context)) {
     moveTo_ChromiumImpl(x + screenX_ChromiumImpl() - screenX(),
                         y + screenY_ChromiumImpl() - screenY());

--- a/test/data/blob-fingerprinting.html
+++ b/test/data/blob-fingerprinting.html
@@ -46,9 +46,11 @@
       return Object.keys(left).every((key) => left[key] === right[key]);
     }
 
-    // Opens a pop-up window with a blob:// url which writes to the local storage
-    // the various screen attributes it sees.
+    // Opens a pop-up window with a blob:// url which writes to the local
+    // storage the various screen attributes it sees. The popup sets its own
+    // title to "pass" or "fail".
     window.startBlobScreenFingerprintingTest = function() {
+      document.title = 'Blob fingerprinting test';
       writeScreenValues('parent');
       const html =
 `<!DOCTYPE html>
@@ -72,6 +74,54 @@
       window.open(
           URL.createObjectURL(blob), '_blank',
           `left=${screenX},top=${screenY},width=${outerWidth},height=${outerHeight}`);
+    };
+
+    // Loads a blob:// url in an iframe which writes to the local storage the
+    // various screen attributes it sees. The main frame polls localStorage for
+    // completion and sets its own title to "pass", "fail", or "timeout".
+    window.startBlobScreenFingerprintingIframeTest = function() {
+      document.title = 'Blob fingerprinting test';
+      localStorage.removeItem('blob_done');
+      writeScreenValues('parent');
+      const html =
+`<!DOCTYPE html>
+    <html>
+    <head><meta charset="utf-8"></head>
+    <body>
+    <script>
+        const readScreenValues = ${readScreenValues.toString()};
+        const writeScreenValues = ${writeScreenValues.toString()};
+        writeScreenValues('blob');
+        localStorage.setItem('blob_done', 'true');
+    <\/script>
+    </body>
+</html>`;
+
+      const blob = new Blob([html], {type: 'text/html'});
+      const blobUrl = URL.createObjectURL(blob);
+
+      const iframe = document.createElement('iframe');
+      iframe.src = blobUrl;
+      document.body.appendChild(iframe);
+
+      let attempts = 0;
+      const poller = setInterval(() => {
+        attempts++;
+        if (attempts > 200) {
+          clearInterval(poller);
+          URL.revokeObjectURL(blobUrl);
+          document.title = 'timeout';
+          return;
+        }
+
+        if (localStorage.getItem('blob_done') !== 'true') return;
+
+        clearInterval(poller);
+        URL.revokeObjectURL(blobUrl);
+        document.title = storedScreenValuesMatch('parent', 'blob')
+            ? 'pass'
+            : 'fail';
+      }, 50);
     };
   </script>
 </body>

--- a/test/data/blob-fingerprinting.html
+++ b/test/data/blob-fingerprinting.html
@@ -78,10 +78,10 @@
     };
 
     // Loads a blob:// url in an iframe which writes to the local storage the
-    // various screen attributes it sees. The main frame polls localStorage for
-    // completion and sets its own title to "pass", "fail", or "timeout".
+    // various screen attributes it sees. The C++ test polls localStorage for
+    // completion via EvalJs / base::test::RunUntil(), so no JS-side poller is
+    // needed here.
     window.startBlobScreenFingerprintingIframeTest = function() {
-      document.title = 'Blob fingerprinting test';
       localStorage.clear();
       writeScreenValues('parent');
       const html =
@@ -104,25 +104,8 @@
       const iframe = document.createElement('iframe');
       iframe.src = blobUrl;
       document.body.appendChild(iframe);
-
-      let attempts = 0;
-      const poller = setInterval(() => {
-        attempts++;
-        if (attempts > 200) {
-          clearInterval(poller);
-          URL.revokeObjectURL(blobUrl);
-          document.title = 'timeout';
-          return;
-        }
-
-        if (localStorage.getItem('blob_done') !== 'true') return;
-
-        clearInterval(poller);
-        URL.revokeObjectURL(blobUrl);
-        document.title = storedScreenValuesMatch('parent', 'blob')
-            ? 'pass'
-            : 'fail';
-      }, 50);
+      // Revoking after appendChild is safe: the navigation has already started.
+      URL.revokeObjectURL(blobUrl);
     };
   </script>
 </body>

--- a/test/data/blob-fingerprinting.html
+++ b/test/data/blob-fingerprinting.html
@@ -51,6 +51,7 @@
     // title to "pass" or "fail".
     window.startBlobScreenFingerprintingTest = function() {
       document.title = 'Blob fingerprinting test';
+      localStorage.clear();
       writeScreenValues('parent');
       const html =
 `<!DOCTYPE html>
@@ -81,7 +82,7 @@
     // completion and sets its own title to "pass", "fail", or "timeout".
     window.startBlobScreenFingerprintingIframeTest = function() {
       document.title = 'Blob fingerprinting test';
-      localStorage.removeItem('blob_done');
+      localStorage.clear();
       writeScreenValues('parent');
       const html =
 `<!DOCTYPE html>


### PR DESCRIPTION
This change adds more tests to check the current behaviour of farbling when the blob:// URL is loaded in an iframe. The [expectation](https://sourcegraph.com/r/github.com/brave/brave-core/-/blob/third_party/blink/renderer/core/farbling/brave_session_cache.cc?L58-60) is that iframe receives the same farbling seed as the top frame so they both should see the same values. The test checks that. 

The main change to support farbling on blob:// URLs when opened as a new window is tracked at https://github.com/brave/brave-core/pull/37153

<!-- Add brave-browser issue below that this PR will resolve -->
Related https://github.com/brave/brave-browser/issues/56048 

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
