### PR TITLE
[query-filter] Update test only code in query filter component installer

### DIFF
--- a/components/query_filter/browser/query_filter_component_installer.cc
+++ b/components/query_filter/browser/query_filter_component_installer.cc
@@ -23,7 +23,6 @@
 #include "brave/components/query_filter/common/features.h"
 #include "components/component_updater/component_installer.h"
 #include "components/component_updater/component_updater_service.h"
-#include "third_party/abseil-cpp/absl/cleanup/cleanup.h"
 
 namespace {
 inline constexpr char kQueryFilterComponentName[] = "Query Filter";
@@ -46,27 +45,20 @@ std::string ReadQueryFilterFile(const base::FilePath& path) {
   return contents;
 }
 
-void OnQueryFilterFileRead(const base::Version& version,
-                           const std::string& json_data) {
-  absl::Cleanup cleanup_for_test_only = []() {
-    if (g_on_file_loaded_callback_for_testing_) {
-      CHECK_IS_TEST();
-      CHECK(!g_on_file_loaded_callback_for_testing_->is_null());
-      std::move(*g_on_file_loaded_callback_for_testing_).Run();
-    }
-  };
-
+// Returns true iff the current set of rules were updated.
+bool OnQueryFilterFileRead(const std::string& json_data) {
   if (json_data.empty()) {
-    return;
+    return false;
   }
   auto* data = query_filter::QueryFilterData::GetInstance();
   CHECK(data);
 
   if (!data->PopulateDataFromComponent(json_data)) {
     LOG(WARNING) << "Failed to populate data from component";
-    return;
+    return false;
   }
-  data->UpdateVersion(version);
+
+  return true;
 }
 
 }  // namespace
@@ -118,7 +110,21 @@ void QueryFilterComponentInstallerPolicy::ComponentReady(
       base::BindOnce(
           &ReadQueryFilterFile,
           install_dir.AppendASCII(query_filter::kQueryFilterJsonFile)),
-      base::BindOnce(&OnQueryFilterFileRead, version));
+      base::BindOnce(
+          [](base::Version version, const std::string& json_data) {
+            if (OnQueryFilterFileRead(json_data)) {
+              query_filter::QueryFilterData::GetInstance()->UpdateVersion(
+                  version);
+            }
+
+            if (g_on_file_loaded_callback_for_testing_) {
+              CHECK_IS_TEST();
+              CHECK(!g_on_file_loaded_callback_for_testing_->is_null());
+              std::move(*g_on_file_loaded_callback_for_testing_).Run();
+              g_on_file_loaded_callback_for_testing_ = nullptr;
+            }
+          },
+          version));
 }
 
 base::FilePath QueryFilterComponentInstallerPolicy::GetRelativeInstallDir()

--- a/components/query_filter/browser/query_filter_component_installer.cc
+++ b/components/query_filter/browser/query_filter_component_installer.cc
@@ -59,9 +59,7 @@ void OnQueryFilterFileRead(const base::Version& version,
     LOG(WARNING) << "Failed to populate data from component";
     return;
   }
-
   data->UpdateVersion(version);
-  return;
 }
 
 }  // namespace

--- a/components/query_filter/browser/query_filter_component_installer.cc
+++ b/components/query_filter/browser/query_filter_component_installer.cc
@@ -45,20 +45,23 @@ std::string ReadQueryFilterFile(const base::FilePath& path) {
   return contents;
 }
 
-// Returns true iff the current set of rules were updated.
-bool OnQueryFilterFileRead(const std::string& json_data) {
+// Reads the |json_data| and updates the component version iff the current rules
+// were updated.
+void OnQueryFilterFileRead(const base::Version& version,
+                           const std::string& json_data) {
   if (json_data.empty()) {
-    return false;
+    return;
   }
   auto* data = query_filter::QueryFilterData::GetInstance();
   CHECK(data);
 
   if (!data->PopulateDataFromComponent(json_data)) {
     LOG(WARNING) << "Failed to populate data from component";
-    return false;
+    return;
   }
 
-  return true;
+  data->UpdateVersion(version);
+  return;
 }
 
 }  // namespace
@@ -111,11 +114,8 @@ void QueryFilterComponentInstallerPolicy::ComponentReady(
           &ReadQueryFilterFile,
           install_dir.AppendASCII(query_filter::kQueryFilterJsonFile)),
       base::BindOnce(
-          [](base::Version version, const std::string& json_data) {
-            if (OnQueryFilterFileRead(json_data)) {
-              query_filter::QueryFilterData::GetInstance()->UpdateVersion(
-                  version);
-            }
+          [](const base::Version& version, const std::string& json_data) {
+            OnQueryFilterFileRead(version, json_data);
 
             if (g_on_file_loaded_callback_for_testing_) {
               CHECK_IS_TEST();


### PR DESCRIPTION
This change slightly updates the [callback](https://sourcegraph.com/r/github.com/brave/brave-core/-/blob/components/query_filter/browser/query_filter_component_installer.cc?L114) logic after ReadQueryFilterFile is fired. Previously, the result of [ReadQueryFilterFile](https://sourcegraph.com/r/github.com/brave/brave-core@023dc2f6a5f03d105c703f2f2109f27c1719b8d7/-/blob/components/query_filter/browser/query_filter_component_installer.cc?L40) was directly plugged into [OnQueryFilterFileRead](https://sourcegraph.com/r/github.com/brave/brave-core/-/blob/components/query_filter/browser/query_filter_component_installer.cc?L49) which took care of not only the core responsibility (i.e populating the query filter data), but also had some test-only logic hidden away. 

This change modifies the callback to instead calling `OnQueryFilterFileRead directly, it calls a lambda that breaks the previous work of `OnQueryFilterFileRead` into distinct individual parts and simplifying the `OnQueryFilterFileRead` code. 

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/56328

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
