### PR TITLE
[toolchain] Fix `build_rust.py` call on `Windows`

### DIFF
--- a/tools/cr/toolchains/build_rust_toolchain.py
+++ b/tools/cr/toolchains/build_rust_toolchain.py
@@ -677,9 +677,9 @@ class ToolchainBuilder:
                         '--stage',
                         '1',
                         '--set',
-                        f'build.rustc={rustc}',
+                        f'build.rustc={rustc.as_posix()}',
                         '--set',
-                        f'build.cargo={cargo}',
+                        f'build.cargo={cargo.as_posix()}',
                         '--set',
                         'build.local-rebuild=true',
                         cwd=self._tools_rust)


### PR DESCRIPTION
Paths on Windows have a different format, and this is breaking the
script run on the windows bot.

Bug: brave.dev/bug/55812
