### PR TITLE
[Android] Gate Origin Google Play restore on SKU credential status

### DIFF
--- a/android/java/org/chromium/chrome/browser/app/BraveActivity.java
+++ b/android/java/org/chromium/chrome/browser/app/BraveActivity.java
@@ -1210,21 +1210,6 @@ public abstract class BraveActivity extends ChromeActivity
 
         BraveVpnNativeWorker.getInstance().reloadPurchasedState();
 
-        Profile profile = mTabModelProfileSupplier.get();
-        if (profile != null && ChromeFeatureList.isEnabled(BraveFeatureList.BRAVE_ORIGIN)) {
-            if (!BraveOriginSubscriptionPrefs.getIsSubscriptionActive(profile)) {
-                // Restore Origin purchase from Google Play if the local pref is not set
-                // (e.g. after device change). This ensures prefs are populated before the user
-                // taps the Origin menu.
-                BraveOriginSubscriptionPrefs.verifyPurchase(profile);
-            } else {
-                // The subscription is active locally. If a prior session was killed mid-fetch
-                // (order ID never written), restart the credential fetch so the user isn't left
-                // permanently stuck on the "Disabling features" spinner.
-                BraveOriginSubscriptionPrefs.resumeCredentialFetchIfNeeded(profile);
-            }
-        }
-
         BraveHelper.maybeMigrateSettings();
 
         PrefChangeRegistrar mPrefChangeRegistrar = PrefServiceUtil.createFor(getCurrentProfile());
@@ -1377,12 +1362,30 @@ public abstract class BraveActivity extends ChromeActivity
                 && !BraveVpnPolicy.isDisabledByPolicy(mTabModelProfileSupplier.get())) {
             showLinkVpnSubscriptionDialog();
         }
-        if (ChromeFeatureList.isEnabled(BraveFeatureList.BRAVE_ORIGIN)) {
+        Profile profile = mTabModelProfileSupplier.get();
+        if (profile != null && ChromeFeatureList.isEnabled(BraveFeatureList.BRAVE_ORIGIN)) {
+            if (BraveOriginSubscriptionPrefs.getIsSubscriptionActive(profile)) {
+                // The subscription is active locally (Google Play purchase). If a prior session
+                // was killed mid-fetch (order ID never written), restart the credential fetch so
+                // the user isn't left permanently stuck on the "Disabling features" spinner.
+                BraveOriginSubscriptionPrefs.resumeCredentialFetchIfNeeded(profile);
+            }
             // Refresh the cached Skus credential summary so sync "is Origin active" readers
-            // (promo/engagement gates) see up-to-date status. Local-first; only hits the
-            // backend when credentials are past their expiry window.
+            // (promo/engagement gates) see up-to-date status. Local-first; only hits the backend
+            // when credentials are past their expiry window. The fresh result also decides whether
+            // to restore a Google Play purchase: only query Google Play when there is no local
+            // Play purchase AND no Origin SKU credentials, so a subscription purchased on desktop
+            // and linked to this account is never overridden by an unrelated account-wide Play
+            // purchase. Using the fresh result (not the cache) keeps this correct even on the very
+            // first restart right after linking.
             BraveOriginSubscriptionPrefs.requestCredentialSummary(
-                    mTabModelProfileSupplier.get(), null);
+                    profile,
+                    (isActive) -> {
+                        if (!BraveOriginSubscriptionPrefs.getIsSubscriptionActive(profile)
+                                && !isActive) {
+                            BraveOriginSubscriptionPrefs.verifyPurchase(profile);
+                        }
+                    });
         }
         if (isFirstInstall
                 && (OnboardingPrefManager.getInstance().isDormantUsersEngagementEnabled()


### PR DESCRIPTION
On startup BraveActivity queried Google Play to restore an Origin purchase whenever the local Google Play subscription pref was inactive. That pref is Play-only, so it is also inactive for users entitled via a desktop purchase linked to their Brave account (SKU credentials, no Android Play purchase). For those users an unrelated account-wide Google Play Origin purchase could be pulled in and take over the linked entitlement, wiping the order id and re-creating the order.

Gate the Google Play query on the authoritative SKU credential summary instead of the Play-only pref:
- local Play purchase active -> resume an interrupted credential fetch
- no local Play purchase -> only fall back to verifyPurchase() when the credential summary reports no Origin credentials
- entitled via SKU credentials -> do not query Google Play

The decision uses the fresh credential summary result (not the cached value), so it is also correct on the first restart right after linking, when the cache still holds the previous session's value.

Resolves: https://github.com/brave/brave-browser/issues/56334


<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
