### PR TITLE
[VPN 2.0] Implement crash reporting to VPN apps

### DIFF
--- a/app/BUILD.gn
+++ b/app/BUILD.gn
@@ -122,6 +122,9 @@ source_set("unit_tests") {
   if (!is_android) {
     sources += [ "command_utils_unittest.cc" ]
   }
+  if (enable_brave_vpn_v2) {
+    sources += [ "vpn_apps_branding_unittest.cc" ]
+  }
   deps = [
     "//base",
     "//base/test:test_support",
@@ -214,6 +217,9 @@ source_set("unit_tests") {
   }
   if (is_win) {
     deps += [ "//chrome/browser/startup" ]
+  }
+  if (enable_brave_vpn_v2) {
+    deps += [ "//brave/components/brave_vpn/app/v2/shared" ]
   }
 }
 

--- a/app/DEPS
+++ b/app/DEPS
@@ -99,4 +99,7 @@ specific_include_rules = {
     # code outside of content should not access content/common
     "!content/common",
   ],
+  "vpn_apps_branding_unittest\.cc": [
+    "+brave/components/brave_vpn/app/v2/shared/app_utils.h",
+  ],
 }

--- a/app/vpn_apps_branding_unittest.cc
+++ b/app/vpn_apps_branding_unittest.cc
@@ -1,0 +1,149 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "base/files/file_path.h"
+#include "base/strings/string_util.h"
+#include "brave/components/brave_vpn/app/v2/shared/app_utils.h"
+#include "build/build_config.h"
+#include "chrome/common/chrome_paths_internal.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+#if BUILDFLAG(IS_WIN)
+#include "chrome/install_static/install_details.h"
+#include "chrome/install_static/user_data_dir.h"
+#endif  // BUILDFLAG(IS_WIN)
+
+#if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_LINUX)
+
+namespace {
+base::FilePath GetDefaultUserDataDirectory() {
+  base::FilePath user_data_dir;
+#if BUILDFLAG(IS_WIN)
+  const install_static::InstallConstants kFakeInstallConstants = {
+      sizeof(install_static::InstallConstants), 0, "", L"", L"", L"", L""};
+  std::wstring result, invalid;
+  install_static::GetUserDataDirectoryImpl(L"", kFakeInstallConstants, &result,
+                                           &invalid);
+  user_data_dir = base::FilePath(result);
+#else   // BUILDFLAG(IS_WIN)
+  chrome::GetDefaultUserDataDirectory(&user_data_dir);
+#endif  // BUILDFLAG(IS_WIN)
+  return user_data_dir;
+}
+
+// Returns the index of the last path component whose name starts with
+// |prefix|. Scanning from the end (rather than the front) keeps the
+// search anchored to the product/leaf directory and avoids matching an
+// unrelated leading component that happens to share the prefix.
+// It also transparently skips the trailing "User Data" component that
+// Chrome appends to the user data dir.
+std::optional<size_t> FindLastComponentIndexWithPrefix(
+    const std::vector<base::FilePath::StringType>& components,
+    std::string_view prefix) {
+  for (size_t i = components.size(); i > 0; --i) {
+    if (base::StartsWith(base::FilePath(components[i - 1]).AsUTF8Unsafe(),
+                         prefix, base::CompareCase::SENSITIVE)) {
+      return i - 1;
+    }
+  }
+  return std::nullopt;
+}
+
+// Extracts the "company" segment of a "<...>/<company>/<product>" data
+// directory -- i.e. the directory immediately preceding the component that
+// starts with |product_prefix|. For example, given
+// ".../BraveSoftware/Brave-Browser" and the prefix "Brave-Browser", this
+// returns "BraveSoftware". Returns std::nullopt if no matching product
+// component exists, or if nothing precedes it.
+std::optional<std::string> GetCompanyName(const base::FilePath& path,
+                                          std::string_view product_prefix) {
+  const std::vector<base::FilePath::StringType> components =
+      path.GetComponents();
+  const std::optional<size_t> product_index =
+      FindLastComponentIndexWithPrefix(components, product_prefix);
+  if (!product_index.has_value() || *product_index == 0) {
+    return std::nullopt;
+  }
+  return base::FilePath(components[*product_index - 1]).AsUTF8Unsafe();
+}
+}  // namespace
+
+TEST(VpnAppsBrandingTest, UnprivilegedDataDirMatchesChromeDataDir) {
+  base::FilePath chrome_user_data_dir = GetDefaultUserDataDirectory();
+  ASSERT_FALSE(chrome_user_data_dir.empty());
+
+  const base::FilePath vpn_unprivileged_data_dir =
+      brave_vpn::v2::app_utils::GetUserDataDir("app",
+                                               /*is_privileged_process=*/false);
+  ASSERT_FALSE(vpn_unprivileged_data_dir.empty());
+
+  const auto chrome_components = chrome_user_data_dir.GetComponents();
+  const auto vpn_components = vpn_unprivileged_data_dir.GetComponents();
+
+  // Locate the product directory in each path: the "Brave-*" directory
+  // for the browser and the "app" directory for the VPN. Everything before it
+  // is the shared "<...>/BraveSoftware" prefix we want to compare.
+  const std::string browser_product_name_prefix = "Brave-";
+  const std::optional<size_t> chrome_product_index =
+      FindLastComponentIndexWithPrefix(chrome_components,
+                                       browser_product_name_prefix);
+  ASSERT_TRUE(chrome_product_index.has_value())
+      << "No '" << browser_product_name_prefix << "' directory found in "
+      << chrome_user_data_dir;
+
+  const std::optional<size_t> vpn_app_index =
+      FindLastComponentIndexWithPrefix(vpn_components, "app");
+  ASSERT_TRUE(vpn_app_index.has_value())
+      << "No 'app' directory found in " << vpn_unprivileged_data_dir;
+
+  // The prefixes must be at the same depth and identical component-by-component
+  // (comparing components avoids platform-specific path reconstruction quirks).
+  ASSERT_EQ(*chrome_product_index, *vpn_app_index)
+      << "Data dirs are nested at different depths:\n  " << chrome_user_data_dir
+      << "\n  " << vpn_unprivileged_data_dir;
+  for (size_t i = 0; i < *chrome_product_index; ++i) {
+    EXPECT_EQ(base::FilePath(chrome_components[i]).AsUTF8Unsafe(),
+              base::FilePath(vpn_components[i]).AsUTF8Unsafe())
+        << "Path prefix differs at component " << i
+        << " between Chrome's user data dir (" << chrome_user_data_dir
+        << ") and the VPN data dir (" << vpn_unprivileged_data_dir << ")";
+  }
+}
+
+TEST(VpnAppsBrandingTest, PrivilegedDataDirHasCorrectCompanyName) {
+  base::FilePath chrome_user_data_dir = GetDefaultUserDataDirectory();
+  ASSERT_FALSE(chrome_user_data_dir.empty());
+
+  // Extract the company name from chrome_user_data_dir, e.g. the
+  // "BraveSoftware" part of ".../BraveSoftware/Brave-BrowserBeta".
+  const std::string browser_product_name_prefix = "Brave-";
+  const std::optional<std::string> chrome_company_name =
+      GetCompanyName(chrome_user_data_dir, browser_product_name_prefix);
+  ASSERT_TRUE(chrome_company_name.has_value())
+      << "Could not extract a company name from " << chrome_user_data_dir;
+
+  const base::FilePath vpn_privileged_data_dir =
+      brave_vpn::v2::app_utils::GetUserDataDir("app",
+                                               /*is_privileged_process=*/true);
+  ASSERT_FALSE(vpn_privileged_data_dir.empty());
+
+  // Extract the company name from vpn_privileged_data_dir, e.g. the
+  // "BraveSoftware" part of ".../BraveSoftware/app".
+  const std::optional<std::string> vpn_company_name =
+      GetCompanyName(vpn_privileged_data_dir, "app");
+  ASSERT_TRUE(vpn_company_name.has_value())
+      << "Could not extract a company name from " << vpn_privileged_data_dir;
+
+  // The privileged VPN process must store its data under the same company
+  // directory as the browser.
+  EXPECT_EQ(*chrome_company_name, *vpn_company_name);
+}
+
+#endif  // BUILDFLAG(IS_WIN) || BUILDFLAG(IS_LINUX)

--- a/components/BUILD.gn
+++ b/components/BUILD.gn
@@ -4,6 +4,7 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import("//brave/components/ai_chat/core/common/buildflags/buildflags.gni")
+import("//brave/components/brave_vpn/common/buildflags/buildflags.gni")
 import("//brave/components/brave_wallet/common/buildflags/buildflags.gni")
 import("//brave/components/brave_wayback_machine/buildflags/buildflags.gni")
 import("//brave/components/containers/buildflags/buildflags.gni")
@@ -86,6 +87,10 @@ test("brave_components_unittests") {
       "//brave/components/ai_chat/core/browser/ollama:unit_tests",
       "//brave/components/ai_chat/core/common:unit_tests",
     ]
+  }
+
+  if (enable_brave_vpn_v2) {
+    deps += [ "//brave/components/brave_vpn/app/v2/shared:unit_tests" ]
   }
 
   if (enable_email_aliases) {

--- a/components/brave_vpn/app/v2/agent/BUILD.gn
+++ b/components/brave_vpn/app/v2/agent/BUILD.gn
@@ -41,6 +41,7 @@ executable("agent") {
     "//base",
     "//base:base_static",
     "//brave/components/brave_vpn/app/v2/shared",
+    "//brave/components/brave_vpn/app/v2/shared:crashrpt",
   ]
 
   if (is_mac) {
@@ -77,6 +78,7 @@ if (is_mac) {
       "//base",
       "//base:base_static",
       "//brave/components/brave_vpn/app/v2/shared",
+      "//brave/components/brave_vpn/app/v2/shared:crashrpt",
     ]
 
     ldflags = []

--- a/components/brave_vpn/app/v2/agent/main.cc
+++ b/components/brave_vpn/app/v2/agent/main.cc
@@ -10,12 +10,22 @@
 #include "base/process/memory.h"
 #include "brave/components/brave_vpn/app/v2/agent/agent_app.h"
 #include "brave/components/brave_vpn/app/v2/shared/app_utils.h"
+#include "brave/components/brave_vpn/app/v2/shared/crash_reporter_client.h"
+#include "brave/components/brave_vpn/app/v2/shared/switches.h"
 #include "build/build_config.h"
 
 #if BUILDFLAG(IS_WIN)
 #include "base/win/process_startup_helper.h"
 #include "base/win/windows_types.h"
 #endif
+
+using brave_vpn::v2::AgentApp;
+using brave_vpn::v2::CrashReporterClient;
+
+namespace {
+constexpr char kBraveVpnAgentAppProcessType[] = "brave-vpn-agent-app";
+constexpr char kBraveVpnAgentAppProductName[] = "BraveVpnAgentApp";
+}  // namespace
 
 #if BUILDFLAG(IS_WIN)
 int APIENTRY wWinMain(HINSTANCE, HINSTANCE, wchar_t*, int) {
@@ -37,8 +47,36 @@ int main(int argc, char* argv[]) {
   base::win::SetupCRT(command_line);
 #endif
 
-  brave_vpn::v2::app_utils::InitLogging(command_line);
+  std::string process_type = command_line.GetSwitchValueASCII(
+      brave_vpn::v2::switches::kVpnAppProcessType);
+#if BUILDFLAG(IS_WIN)
+  auto crashpad_handler_status =
+      CrashReporterClient::RunAsCrashpadHandlerIfRequired(
+          process_type, command_line.GetSwitchValuePath(
+                            brave_vpn::v2::switches::kVpnAppUserDataDir));
+  if (crashpad_handler_status.has_value()) {
+    return crashpad_handler_status.value();
+  }
+#endif  // BUILDFLAG(IS_WIN)
 
-  brave_vpn::v2::AgentApp agent_app;
+  brave_vpn::v2::app_utils::InitLogging(command_line);
+#if BUILDFLAG(IS_MAC)
+  brave_vpn::v2::app_utils::ConfigureFrameworkBundlePath();
+#endif
+
+  if (process_type.empty()) {
+    process_type = kBraveVpnAgentAppProcessType;
+  }
+  std::string channel_name = command_line.GetSwitchValueASCII(
+      brave_vpn::v2::switches::kVpnAppChannelName);
+  if (channel_name.empty()) {
+    channel_name = "unknown";
+  }
+  CrashReporterClient::InitializeForProcess(
+      process_type, kBraveVpnAgentAppProductName, channel_name,
+      brave_vpn::v2::app_utils::GetUserDataDir(
+          kBraveVpnAgentAppProductName, /*is_privileged_process=*/false));
+
+  AgentApp agent_app;
   return agent_app.Run();
 }

--- a/components/brave_vpn/app/v2/helper/BUILD.gn
+++ b/components/brave_vpn/app/v2/helper/BUILD.gn
@@ -41,6 +41,7 @@ executable("helper") {
     "//base",
     "//base:base_static",
     "//brave/components/brave_vpn/app/v2/shared",
+    "//brave/components/brave_vpn/app/v2/shared:crashrpt",
   ]
 
   data_deps = [ "//brave/third_party/boringtun" ]
@@ -76,6 +77,7 @@ if (is_mac) {
       "//base",
       "//base:base_static",
       "//brave/components/brave_vpn/app/v2/shared",
+      "//brave/components/brave_vpn/app/v2/shared:crashrpt",
     ]
 
     ldflags = []

--- a/components/brave_vpn/app/v2/helper/main.cc
+++ b/components/brave_vpn/app/v2/helper/main.cc
@@ -10,11 +10,21 @@
 #include "base/process/memory.h"
 #include "brave/components/brave_vpn/app/v2/helper/helper_app.h"
 #include "brave/components/brave_vpn/app/v2/shared/app_utils.h"
+#include "brave/components/brave_vpn/app/v2/shared/crash_reporter_client.h"
+#include "brave/components/brave_vpn/app/v2/shared/switches.h"
 #include "build/build_config.h"
 
 #if BUILDFLAG(IS_WIN)
 #include "base/win/process_startup_helper.h"
 #endif
+
+using brave_vpn::v2::CrashReporterClient;
+using brave_vpn::v2::HelperApp;
+
+namespace {
+constexpr char kBraveVpnHelperAppProcessType[] = "brave-vpn-helper-app";
+constexpr char kBraveVpnHelperAppProductName[] = "BraveVpnHelperApp";
+}  // namespace
 
 int main(int argc, char* argv[]) {
   base::AtExitManager exit_manager;
@@ -28,8 +38,36 @@ int main(int argc, char* argv[]) {
   base::win::SetupCRT(command_line);
 #endif
 
-  brave_vpn::v2::app_utils::InitLogging(command_line);
+  std::string process_type = command_line.GetSwitchValueASCII(
+      brave_vpn::v2::switches::kVpnAppProcessType);
+#if BUILDFLAG(IS_WIN)
+  auto crashpad_handler_status =
+      CrashReporterClient::RunAsCrashpadHandlerIfRequired(
+          process_type, command_line.GetSwitchValuePath(
+                            brave_vpn::v2::switches::kVpnAppUserDataDir));
+  if (crashpad_handler_status.has_value()) {
+    return crashpad_handler_status.value();
+  }
+#endif  // BUILDFLAG(IS_WIN)
 
-  brave_vpn::v2::HelperApp helper_app;
+  brave_vpn::v2::app_utils::InitLogging(command_line);
+#if BUILDFLAG(IS_MAC)
+  brave_vpn::v2::app_utils::ConfigureFrameworkBundlePath();
+#endif
+
+  if (process_type.empty()) {
+    process_type = kBraveVpnHelperAppProcessType;
+  }
+  std::string channel_name = command_line.GetSwitchValueASCII(
+      brave_vpn::v2::switches::kVpnAppChannelName);
+  if (channel_name.empty()) {
+    channel_name = "unknown";
+  }
+  CrashReporterClient::InitializeForProcess(
+      process_type, kBraveVpnHelperAppProductName, channel_name,
+      brave_vpn::v2::app_utils::GetUserDataDir(kBraveVpnHelperAppProductName,
+                                               /*is_privileged_process=*/true));
+
+  HelperApp helper_app;
   return helper_app.Run();
 }

--- a/components/brave_vpn/app/v2/shared/BUILD.gn
+++ b/components/brave_vpn/app/v2/shared/BUILD.gn
@@ -11,7 +11,57 @@ static_library("shared") {
   sources = [
     "app_utils.cc",
     "app_utils.h",
+    "switches.h",
   ]
 
   deps = [ "//base" ]
+
+  if (is_mac) {
+    sources += [ "app_utils_mac.cc" ]
+  }
+}
+
+static_library("crashrpt") {
+  sources = [
+    "crash_reporter_client.cc",
+    "crash_reporter_client.h",
+  ]
+
+  public_deps = [ "//components/crash/core/app" ]
+
+  deps = [
+    ":shared",
+    "//base",
+    "//components/version_info:channel",
+  ]
+
+  if (is_win) {
+    sources += [ "crash_reporter_client_win.cc" ]
+
+    deps += [
+      "//components/crash/core/app:crash_export_thunks",
+      "//components/crash/core/app:run_as_crashpad_handler",
+    ]
+  }
+
+  if (is_posix) {
+    sources += [ "crash_reporter_client_posix.cc" ]
+    data_deps = [ "//components/crash/core/app:chrome_crashpad_handler" ]
+  }
+}
+
+source_set("unit_tests") {
+  testonly = true
+  sources = [
+    "app_utils_unittest.cc",
+    "crash_reporter_client_unittest.cc",
+  ]
+
+  deps = [
+    ":crashrpt",
+    ":shared",
+    "//base",
+    "//base/test:test_support",
+    "//testing/gtest",
+  ]
 }

--- a/components/brave_vpn/app/v2/shared/DEPS
+++ b/components/brave_vpn/app/v2/shared/DEPS
@@ -1,0 +1,4 @@
+include_rules = [
+  "+components/crash/core/app",
+  "+components/version_info",
+]

--- a/components/brave_vpn/app/v2/shared/app_utils.cc
+++ b/components/brave_vpn/app/v2/shared/app_utils.cc
@@ -5,29 +5,64 @@
 
 #include "brave/components/brave_vpn/app/v2/shared/app_utils.h"
 
+#include "base/base_paths.h"
+#include "base/check.h"
+#include "base/environment.h"
 #include "base/logging.h"
 #include "base/logging/logging_settings.h"
+#include "base/path_service.h"
+#include "brave/components/brave_vpn/app/v2/shared/switches.h"
+#include "build/build_config.h"
 
-namespace brave_vpn {
-namespace v2 {
-namespace app_utils {
+#if BUILDFLAG(IS_LINUX)
+#include "base/nix/xdg_util.h"
+#endif
+
+namespace brave_vpn::v2::app_utils {
 namespace {
-inline constexpr char kVpnAppLogFile[] = "log-file";
-}
+inline constexpr base::FilePath::CharType kBraveCompanyName[] =
+    FILE_PATH_LITERAL("BraveSoftware");
+}  // namespace
 
 void InitLogging(const base::CommandLine& command_line) {
   logging::LoggingSettings settings;
   settings.logging_dest =
       logging::LOG_TO_SYSTEM_DEBUG_LOG | logging::LOG_TO_STDERR;
   base::FilePath log_file_path;
-  if (command_line.HasSwitch(kVpnAppLogFile)) {
+  if (command_line.HasSwitch(switches::kVpnAppLogFile)) {
     settings.logging_dest |= logging::LOG_TO_FILE;
-    log_file_path = command_line.GetSwitchValuePath(kVpnAppLogFile);
+    log_file_path = command_line.GetSwitchValuePath(switches::kVpnAppLogFile);
     settings.log_file_path = log_file_path.value().c_str();
   }
   logging::InitLogging(settings);
 }
 
-}  // namespace app_utils
-}  // namespace v2
-}  // namespace brave_vpn
+base::FilePath GetUserDataDir(const std::string& product_name,
+                              bool is_privileged_process) {
+  CHECK(!product_name.empty());
+  base::FilePath result;
+#if BUILDFLAG(IS_WIN)
+  result = base::PathService::CheckedGet(is_privileged_process
+                                             ? base::DIR_COMMON_APP_DATA
+                                             : base::DIR_LOCAL_APP_DATA);
+#elif BUILDFLAG(IS_MAC)
+  result =
+      is_privileged_process
+          ? base::FilePath(FILE_PATH_LITERAL("/Library/Application Support"))
+          : base::PathService::CheckedGet(base::DIR_APP_DATA);
+#elif BUILDFLAG(IS_LINUX)
+  if (is_privileged_process) {
+    result = base::FilePath(FILE_PATH_LITERAL("/var/lib"));
+  } else {
+    auto env = base::Environment::Create();
+    result = base::nix::GetXDGDirectory(
+        env.get(), base::nix::kXdgConfigHomeEnvVar, base::nix::kDotConfigDir);
+  }
+#else
+#error unsupported platform
+#endif
+  return result.Append(kBraveCompanyName)
+      .Append(base::FilePath::FromUTF8Unsafe(product_name));
+}
+
+}  // namespace brave_vpn::v2::app_utils

--- a/components/brave_vpn/app/v2/shared/app_utils.h
+++ b/components/brave_vpn/app/v2/shared/app_utils.h
@@ -6,16 +6,44 @@
 #ifndef BRAVE_COMPONENTS_BRAVE_VPN_APP_V2_SHARED_APP_UTILS_H_
 #define BRAVE_COMPONENTS_BRAVE_VPN_APP_V2_SHARED_APP_UTILS_H_
 
-#include "base/command_line.h"
+#include <string>
 
-namespace brave_vpn {
-namespace v2 {
-namespace app_utils {
+#include "base/command_line.h"
+#include "base/files/file_path.h"
+#include "build/build_config.h"
+
+namespace brave_vpn::v2::app_utils {
 
 void InitLogging(const base::CommandLine& command_line);
 
-}  // namespace app_utils
-}  // namespace v2
-}  // namespace brave_vpn
+// Returns the per-product user data directory, formed by appending the Brave
+// company name and `product_name` to a platform-specific base path.
+// `product_name` must be non-empty, otherwise it will be a CHECK failure.
+//
+// The base path depends on the platform and on `is_privileged_process`. When
+// `is_privileged_process` is true, a machine-wide location is used (Windows:
+// common app data; macOS: /Library/Application Support; Linux: /var/lib).
+// When false, a per-user location is used (Windows: local app data; macOS:
+// per-user app data; Linux: XDG config home).
+base::FilePath GetUserDataDir(const std::string& product_name,
+                              bool is_privileged_process);
+
+#if BUILDFLAG(IS_MAC)
+// Resolves the framework path for a process whose executable lives in
+// `exe_dir`. When `am_i_bundled` is true the agent is nested inside the
+// framework, so the enclosing ".framework" ancestor of `exe_dir` is returned.
+// When false (a bare binary run from the build output dir) the sibling
+// ".framework" directory inside `exe_dir` is returned. Returns an empty path
+// if no framework is found.
+base::FilePath ResolveFrameworkPath(const base::FilePath& exe_dir,
+                                    bool am_i_bundled);
+
+// Points base's framework bundle path at the enclosing/sibling ".framework"
+// so crashpad can locate chrome_crashpad_handler. Must be called before crash
+// reporting is initialized.
+void ConfigureFrameworkBundlePath();
+#endif
+
+}  // namespace brave_vpn::v2::app_utils
 
 #endif  // BRAVE_COMPONENTS_BRAVE_VPN_APP_V2_SHARED_APP_UTILS_H_

--- a/components/brave_vpn/app/v2/shared/app_utils_mac.cc
+++ b/components/brave_vpn/app/v2/shared/app_utils_mac.cc
@@ -1,0 +1,59 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/app/v2/shared/app_utils.h"
+
+#include "base/apple/bundle_locations.h"
+#include "base/apple/foundation_util.h"
+#include "base/files/file_enumerator.h"
+#include "base/logging.h"
+#include "base/path_service.h"
+
+namespace brave_vpn::v2::app_utils {
+namespace {
+inline constexpr base::FilePath::CharType kFrameworkExtension[] =
+    FILE_PATH_LITERAL(".framework");
+}  // namespace
+
+base::FilePath ResolveFrameworkPath(const base::FilePath& exe_dir,
+                                    bool am_i_bundled) {
+  base::FilePath framework_path;
+  if (am_i_bundled) {
+    // Bundled app: the executable is nested inside the framework.
+    base::FilePath path = exe_dir;
+    while (!path.empty() &&
+           path.BaseName().Extension() != kFrameworkExtension) {
+      base::FilePath parent = path.DirName();
+      if (parent == path) {
+        return base::FilePath();
+      }
+      path = parent;
+    }
+    framework_path = path;
+  } else {
+    // Standalone binary: the framework sits beside it.
+    base::FileEnumerator e(exe_dir, /*recursive=*/false,
+                           base::FileEnumerator::DIRECTORIES);
+    for (base::FilePath checked_path = e.Next(); !checked_path.empty();
+         checked_path = e.Next()) {
+      if (checked_path.BaseName().Extension() == kFrameworkExtension) {
+        framework_path = checked_path;
+        break;
+      }
+    }
+  }
+  return framework_path;
+}
+
+void ConfigureFrameworkBundlePath() {
+  base::FilePath framework_path = ResolveFrameworkPath(
+      base::PathService::CheckedGet(base::DIR_EXE), base::apple::AmIBundled());
+  if (!framework_path.empty()) {
+    DVLOG(1) << "Framework detected: " << framework_path;
+    base::apple::SetOverrideFrameworkBundlePath(framework_path);
+  }
+}
+
+}  // namespace brave_vpn::v2::app_utils

--- a/components/brave_vpn/app/v2/shared/app_utils_unittest.cc
+++ b/components/brave_vpn/app/v2/shared/app_utils_unittest.cc
@@ -1,0 +1,93 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/app/v2/shared/app_utils.h"
+
+#include "base/files/file_util.h"
+#include "base/files/scoped_temp_dir.h"
+#include "base/test/gtest_util.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace brave_vpn::v2::app_utils {
+
+// An empty product name is a programming error and must CHECK rather than
+// silently produce a company-root path.
+TEST(AppUtilsDeathTest, EmptyProductNameChecks) {
+  EXPECT_CHECK_DEATH(
+      GetUserDataDir(std::string(), /*is_privileged_process=*/false));
+  EXPECT_CHECK_DEATH(
+      GetUserDataDir(std::string(), /*is_privileged_process=*/true));
+}
+
+// The base directory varies by platform, but the last two path components are
+// always "<company>/<product>".
+TEST(AppUtilsTest, UserDataDirHasCompanyAndProduct) {
+  for (bool is_privileged_process : {false, true}) {
+    const base::FilePath dir = GetUserDataDir("app", is_privileged_process);
+
+    EXPECT_EQ(dir.BaseName().value(), FILE_PATH_LITERAL("app"))
+        << "is_privileged_process=" << is_privileged_process;
+    EXPECT_EQ(dir.DirName().BaseName().value(),
+              FILE_PATH_LITERAL("BraveSoftware"))
+        << "is_privileged_process=" << is_privileged_process;
+  }
+}
+
+// Privileged and unprivileged processes must resolve to different base paths
+// on every platform; a swapped branch would make them collide.
+TEST(AppUtilsTest, PrivilegedDiffersFromUser) {
+  EXPECT_NE(GetUserDataDir("app", /*is_privileged_process=*/false),
+            GetUserDataDir("app", /*is_privileged_process=*/true));
+}
+
+#if BUILDFLAG(IS_MAC)
+// Bundled: walk up to the enclosing ".framework" ancestor.
+TEST(AppUtilsTest, ResolveFrameworkBundledFindsAncestor) {
+  const base::FilePath exe_dir(FILE_PATH_LITERAL(
+      "/Apps/Brave.app/Contents/Frameworks/Brave Framework.framework/"
+      "Versions/1/Helpers/Brave VPN Agent.app/Contents/MacOS"));
+
+  EXPECT_EQ(
+      ResolveFrameworkPath(exe_dir, /*am_i_bundled=*/true),
+      base::FilePath(FILE_PATH_LITERAL(
+          "/Apps/Brave.app/Contents/Frameworks/Brave Framework.framework")));
+}
+
+// Bundled but no ".framework" ancestor: returns empty and (crucially)
+// terminates at the filesystem root instead of looping forever.
+TEST(AppUtilsTest, ResolveFrameworkBundledNoFrameworkReturnsEmpty) {
+  const base::FilePath exe_dir(
+      FILE_PATH_LITERAL("/Apps/Standalone.app/Contents/MacOS"));
+
+  EXPECT_TRUE(ResolveFrameworkPath(exe_dir, /*am_i_bundled=*/true).empty());
+}
+
+// Standalone: find the sibling ".framework", ignoring non-framework
+// directories.
+TEST(AppUtilsTest, ResolveFrameworkStandaloneFindsSibling) {
+  base::ScopedTempDir temp;
+  ASSERT_TRUE(temp.CreateUniqueTempDir());
+
+  const base::FilePath framework =
+      temp.GetPath().Append(FILE_PATH_LITERAL("Brave Framework.framework"));
+  ASSERT_TRUE(base::CreateDirectory(framework));
+  ASSERT_TRUE(base::CreateDirectory(
+      temp.GetPath().Append(FILE_PATH_LITERAL("Resources"))));
+
+  EXPECT_EQ(ResolveFrameworkPath(temp.GetPath(), /*am_i_bundled=*/false),
+            framework);
+}
+
+// Standalone with no framework present: returns empty.
+TEST(AppUtilsTest, ResolveFrameworkStandaloneNoneReturnsEmpty) {
+  base::ScopedTempDir temp;
+  ASSERT_TRUE(temp.CreateUniqueTempDir());
+
+  EXPECT_TRUE(
+      ResolveFrameworkPath(temp.GetPath(), /*am_i_bundled=*/false).empty());
+}
+#endif  // BUILDFLAG(IS_MAC)
+
+}  // namespace brave_vpn::v2::app_utils

--- a/components/brave_vpn/app/v2/shared/crash_reporter_client.cc
+++ b/components/brave_vpn/app/v2/shared/crash_reporter_client.cc
@@ -1,0 +1,97 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/app/v2/shared/crash_reporter_client.h"
+
+#include <utility>
+
+#include "base/debug/leak_annotations.h"
+#include "base/files/file_util.h"
+#include "base/logging.h"
+#include "brave/components/brave_vpn/app/v2/shared/switches.h"
+#include "components/crash/core/app/crash_switches.h"
+#include "components/crash/core/app/crashpad.h"
+
+namespace brave_vpn::v2 {
+
+// static
+void CrashReporterClient::InitializeForProcess(
+    const std::string& process_type,
+    const std::string& product_name,
+    const std::string& channel_name,
+    const base::FilePath& profile_dir) {
+  if (instance_) {
+    return;
+  }
+  instance_ = new CrashReporterClient(product_name, channel_name, profile_dir);
+  ANNOTATE_LEAKING_OBJECT_PTR(instance_);
+
+#if BUILDFLAG(IS_WIN)
+  // Don't set up Crashpad crash reporting in the Crashpad handler itself,
+  // nor in the fallback crash handler for the Crashpad handler process.
+  if (process_type == crash_reporter::switches::kCrashpadHandler) {
+    return;
+  }
+#endif  // BUILDFLAG(IS_WIN)
+
+  crash_reporter::SetCrashReporterClient(instance_);
+
+  DVLOG(1) << "Initializing Crashpad for process type: " << process_type
+           << ", product name: " << instance_->product_name_
+           << ", channel name: " << instance_->channel_name_
+           << ", profile dir: " << instance_->profile_dir_;
+
+  base::File::Error error;
+  if (!base::CreateDirectoryAndGetError(instance_->profile_dir_, &error)) {
+    LOG(ERROR) << "Failed to create profile dir " << instance_->profile_dir_
+               << ": " << base::File::ErrorToString(error);
+  }
+
+#if BUILDFLAG(IS_WIN)
+  crash_reporter::InitializeCrashpadWithEmbeddedHandler(
+      true, process_type, instance_->profile_dir_.AsUTF8Unsafe(),
+      base::FilePath());
+#else   // BUILDFLAG(IS_WIN)
+  crash_reporter::InitializeCrashpad(/*initial_client=*/true, process_type);
+#endif  // BUILDFLAG(IS_WIN)
+}
+
+CrashReporterClient* CrashReporterClient::instance_ = nullptr;
+
+CrashReporterClient::CrashReporterClient(std::string product_name,
+                                         std::string channel_name,
+                                         base::FilePath profile_dir)
+    : product_name_(std::move(product_name)),
+      channel_name_(std::move(channel_name)),
+      profile_dir_(std::move(profile_dir)) {}
+
+CrashReporterClient::~CrashReporterClient() = default;
+
+bool CrashReporterClient::IsRunningUnattended() {
+  // TODO(https://github.com/brave/brave-browser/issues/56405): return true once
+  // we are ready to upload the crash reports.
+  return true;
+}
+
+bool CrashReporterClient::GetCollectStatsConsent() {
+  // TODO(https://github.com/brave/brave-browser/issues/56405): implement this
+  // to return the user's consent for collecting crash stats.
+  return false;
+}
+
+bool CrashReporterClient::GetCollectStatsInSample() {
+  // No sampling throttle, collect for everyone using the VPN.
+  return true;
+}
+
+bool CrashReporterClient::ReportingIsEnforcedByPolicy(
+    bool* /*breakpad_enabled*/) {
+  // TODO(https://github.com/brave/brave-browser/issues/56405): implement this
+  // to return whether configuration management allows loading the crash
+  // reporter.
+  return false;
+}
+
+}  // namespace brave_vpn::v2

--- a/components/brave_vpn/app/v2/shared/crash_reporter_client.h
+++ b/components/brave_vpn/app/v2/shared/crash_reporter_client.h
@@ -1,0 +1,83 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_VPN_APP_V2_SHARED_CRASH_REPORTER_CLIENT_H_
+#define BRAVE_COMPONENTS_BRAVE_VPN_APP_V2_SHARED_CRASH_REPORTER_CLIENT_H_
+
+#include <optional>
+#include <string>
+
+#include "base/files/file_path.h"
+#include "build/build_config.h"
+#include "components/crash/core/app/crash_reporter_client.h"
+
+namespace brave_vpn::v2 {
+
+class CrashReporterClient final : public crash_reporter::CrashReporterClient {
+ public:
+  // Initializes the crash reporter client for the current process. This should
+  // be called early in the process's initialization, before any crash reporting
+  // functionality is used. The parameters are used to configure the crash
+  // reporter with the appropriate product name, channel name, and profile
+  // directory for storing crash reports ("Crashpad" subdirectory of the profile
+  // directory).
+  static void InitializeForProcess(const std::string& process_type,
+                                   const std::string& product_name,
+                                   const std::string& channel_name,
+                                   const base::FilePath& profile_dir);
+
+#if BUILDFLAG(IS_WIN)
+  // On Windows, if the process is a crash handler process, this function will
+  // run the crash handler and return the exit code. If the process is not a
+  // crash handler process, this function will return std::nullopt. This allows
+  // the caller to determine if it should exit immediately after running the
+  // crash handler, or if it should continue with normal initialization.
+  static std::optional<int> RunAsCrashpadHandlerIfRequired(
+      const std::string& process_type,
+      const base::FilePath& user_data_dir);
+#endif
+
+  ~CrashReporterClient() override;
+  CrashReporterClient(const CrashReporterClient&) = delete;
+  CrashReporterClient& operator=(const CrashReporterClient&) = delete;
+
+  // crash_reporter::CrashReporterClient override:
+  bool IsRunningUnattended() override;
+  bool GetCollectStatsConsent() override;
+  bool GetCollectStatsInSample() override;
+  bool ReportingIsEnforcedByPolicy(bool* breakpad_enabled) override;
+#if BUILDFLAG(IS_WIN)
+  bool GetShouldDumpLargerDumps() override;
+  bool GetCrashDumpLocation(std::wstring* crash_dir) override;
+  bool GetCrashMetricsLocation(std::wstring* metrics_dir) override;
+  void GetProductNameAndVersion(const std::wstring& exe_path,
+                                std::wstring* product_name,
+                                std::wstring* version,
+                                std::wstring* special_build,
+                                std::wstring* channel_name) override;
+#else   // BUILDFLAG(IS_WIN)
+  bool GetCrashDumpLocation(base::FilePath* crash_dir) override;
+  bool GetCrashMetricsLocation(base::FilePath* metrics_dir) override;
+#endif  // BUILDFLAG(IS_WIN)
+
+ private:
+  friend class CrashReporterClientTest;
+
+  // No constuction outside of InitializeForProcess, to ensure the singleton
+  // pattern is followed.
+  explicit CrashReporterClient(std::string product_name,
+                               std::string channel_name,
+                               base::FilePath profile_dir);
+
+  static CrashReporterClient* instance_;
+
+  std::string product_name_;
+  std::string channel_name_;
+  base::FilePath profile_dir_;
+};
+
+}  // namespace brave_vpn::v2
+
+#endif  // BRAVE_COMPONENTS_BRAVE_VPN_APP_V2_SHARED_CRASH_REPORTER_CLIENT_H_

--- a/components/brave_vpn/app/v2/shared/crash_reporter_client_posix.cc
+++ b/components/brave_vpn/app/v2/shared/crash_reporter_client_posix.cc
@@ -1,0 +1,28 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/app/v2/shared/crash_reporter_client.h"
+
+#include "base/files/file_path.h"
+
+namespace brave_vpn::v2 {
+
+bool CrashReporterClient::GetCrashDumpLocation(base::FilePath* crash_dir) {
+  if (profile_dir_.empty()) {
+    return false;
+  }
+  *crash_dir = profile_dir_.Append(FILE_PATH_LITERAL("Crashpad"));
+  return true;
+}
+
+bool CrashReporterClient::GetCrashMetricsLocation(base::FilePath* metrics_dir) {
+  if (profile_dir_.empty()) {
+    return false;
+  }
+  *metrics_dir = profile_dir_;
+  return true;
+}
+
+}  // namespace brave_vpn::v2

--- a/components/brave_vpn/app/v2/shared/crash_reporter_client_unittest.cc
+++ b/components/brave_vpn/app/v2/shared/crash_reporter_client_unittest.cc
@@ -1,0 +1,85 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/app/v2/shared/crash_reporter_client.h"
+
+#include <memory>
+
+#include "base/files/file_path.h"
+#include "base/memory/ptr_util.h"
+#include "build/build_config.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace brave_vpn::v2 {
+
+class CrashReporterClientTest : public testing::Test {
+ protected:
+  std::unique_ptr<CrashReporterClient> MakeClient(
+      const base::FilePath& profile_dir) {
+    return base::WrapUnique(
+        new CrashReporterClient("app", "unknown", profile_dir));
+  }
+};
+
+TEST_F(CrashReporterClientTest, CrashDumpLocationAppendsCrashpad) {
+  const base::FilePath profile_dir(FILE_PATH_LITERAL("test_profile"));
+  auto client = MakeClient(profile_dir);
+
+#if BUILDFLAG(IS_WIN)
+  std::wstring dir;
+  EXPECT_TRUE(client->GetCrashDumpLocation(&dir));
+  EXPECT_EQ(dir, profile_dir.Append(L"Crashpad").value());
+#else
+  base::FilePath dir;
+  EXPECT_TRUE(client->GetCrashDumpLocation(&dir));
+  EXPECT_EQ(dir, profile_dir.Append(FILE_PATH_LITERAL("Crashpad")));
+#endif
+}
+
+TEST_F(CrashReporterClientTest, CrashMetricsLocationIsProfileDir) {
+  const base::FilePath profile_dir(FILE_PATH_LITERAL("test_profile"));
+  auto client = MakeClient(profile_dir);
+
+#if BUILDFLAG(IS_WIN)
+  std::wstring dir;
+  EXPECT_TRUE(client->GetCrashMetricsLocation(&dir));
+  EXPECT_EQ(dir, profile_dir.value());
+#else
+  base::FilePath dir;
+  EXPECT_TRUE(client->GetCrashMetricsLocation(&dir));
+  EXPECT_EQ(dir, profile_dir);
+#endif
+}
+
+// Regression guard: with an empty profile dir both accessors must return false
+// (and not write a bogus relative path into the out-param).
+TEST_F(CrashReporterClientTest, EmptyProfileDirReturnsFalse) {
+  auto client = MakeClient(base::FilePath());
+
+#if BUILDFLAG(IS_WIN)
+  std::wstring dump;
+  std::wstring metrics;
+#else
+  base::FilePath dump;
+  base::FilePath metrics;
+#endif
+  EXPECT_FALSE(client->GetCrashDumpLocation(&dump));
+  EXPECT_FALSE(client->GetCrashMetricsLocation(&metrics));
+}
+
+// For now, the client never uploads crash reports. If later we change the
+// contract, the test must be updated accordingly.
+TEST_F(CrashReporterClientTest, NeverUploads) {
+  auto client = MakeClient(base::FilePath(FILE_PATH_LITERAL("test_profile")));
+
+  EXPECT_TRUE(client->IsRunningUnattended());
+#if !BUILDFLAG(IS_WIN)
+  // On Windows consent is delegated to install_static, which needs product
+  // details initialized; on POSIX "no consent" is pinned unconditionally.
+  EXPECT_FALSE(client->GetCollectStatsConsent());
+#endif
+}
+
+}  // namespace brave_vpn::v2

--- a/components/brave_vpn/app/v2/shared/crash_reporter_client_win.cc
+++ b/components/brave_vpn/app/v2/shared/crash_reporter_client_win.cc
@@ -1,0 +1,80 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/app/v2/shared/crash_reporter_client.h"
+
+#include <memory>
+
+#include "base/command_line.h"
+#include "base/file_version_info.h"
+#include "base/files/file_path.h"
+#include "base/strings/string_util.h"
+#include "base/strings/utf_string_conversions.h"
+#include "brave/components/brave_vpn/app/v2/shared/switches.h"
+#include "components/crash/core/app/crash_switches.h"
+#include "components/crash/core/app/crashpad.h"
+#include "components/crash/core/app/fallback_crash_handling_win.h"
+#include "components/crash/core/app/run_as_crashpad_handler_win.h"
+#include "components/version_info/channel.h"
+
+namespace brave_vpn::v2 {
+
+// static
+std::optional<int> CrashReporterClient::RunAsCrashpadHandlerIfRequired(
+    const std::string& process_type,
+    const base::FilePath& user_data_dir) {
+  if (process_type == crash_reporter::switches::kCrashpadHandler) {
+    const auto& command_line = *base::CommandLine::ForCurrentProcess();
+    crash_reporter::SetupFallbackCrashHandling(command_line);
+    return crash_reporter::RunAsCrashpadHandler(command_line, user_data_dir,
+                                                switches::kVpnAppProcessType,
+                                                switches::kVpnAppUserDataDir);
+  }
+  return std::nullopt;
+}
+
+bool CrashReporterClient::GetShouldDumpLargerDumps() {
+  // Use large dumps for all but the stable/unknown channel.
+  return channel_name_ !=
+             version_info::GetChannelString(version_info::Channel::STABLE) &&
+         channel_name_ !=
+             version_info::GetChannelString(version_info::Channel::UNKNOWN);
+}
+
+bool CrashReporterClient::GetCrashDumpLocation(std::wstring* crash_dir) {
+  if (profile_dir_.empty()) {
+    return false;
+  }
+  *crash_dir = profile_dir_.Append(L"Crashpad").value();
+  return true;
+}
+
+bool CrashReporterClient::GetCrashMetricsLocation(std::wstring* metrics_dir) {
+  if (profile_dir_.empty()) {
+    return false;
+  }
+  *metrics_dir = profile_dir_.value();
+  return true;
+}
+
+void CrashReporterClient::GetProductNameAndVersion(const std::wstring& exe_path,
+                                                   std::wstring* product_name,
+                                                   std::wstring* version,
+                                                   std::wstring* special_build,
+                                                   std::wstring* channel_name) {
+  *product_name = base::UTF8ToWide(product_name_);
+  std::unique_ptr<FileVersionInfo> version_info(
+      FileVersionInfo::CreateFileVersionInfo(base::FilePath(exe_path)));
+  if (version_info) {
+    *version = base::AsWString(version_info->product_version());
+    *special_build = base::AsWString(version_info->special_build());
+  } else {
+    *version = L"0.0.0.0-devel";
+    *special_build = std::wstring();
+  }
+  *channel_name = base::UTF8ToWide(channel_name_);
+}
+
+}  // namespace brave_vpn::v2

--- a/components/brave_vpn/app/v2/shared/switches.h
+++ b/components/brave_vpn/app/v2/shared/switches.h
@@ -1,0 +1,18 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_VPN_APP_V2_SHARED_SWITCHES_H_
+#define BRAVE_COMPONENTS_BRAVE_VPN_APP_V2_SHARED_SWITCHES_H_
+
+namespace brave_vpn::v2::switches {
+
+inline constexpr char kVpnAppLogFile[] = "log-file";
+inline constexpr char kVpnAppProcessType[] = "type";
+inline constexpr char kVpnAppUserDataDir[] = "user-data-dir";
+inline constexpr char kVpnAppChannelName[] = "channel-name";
+
+}  // namespace brave_vpn::v2::switches
+
+#endif  // BRAVE_COMPONENTS_BRAVE_VPN_APP_V2_SHARED_SWITCHES_H_


### PR DESCRIPTION
The change implements Chromium crash reporting for Agent and Helper apps, similar to what we currently have for Wireguard service on Windows, but cross-platform. For now, no crash uploading will happen - local reporting only. Code is shared between the apps, not duplicated.

Implements part of https://github.com/brave/brave-browser/issues/55909

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
